### PR TITLE
refactor: remove unused Label import in PasswordSettingsPage

### DIFF
--- a/ayunis-core-frontend/src/pages/settings/account-settings/ui/PasswordSettingsPage.tsx
+++ b/ayunis-core-frontend/src/pages/settings/account-settings/ui/PasswordSettingsPage.tsx
@@ -5,7 +5,6 @@ import {
   CardTitle,
 } from "@/shared/ui/shadcn/card";
 import { Input } from "@/shared/ui/shadcn/input";
-import { Label } from "@/shared/ui/shadcn/label";
 import { Button } from "@/shared/ui/shadcn/button";
 import { Separator } from "@/shared/ui/shadcn/separator";
 import { useTranslation } from "react-i18next";


### PR DESCRIPTION
Removed the unused import to prevent the Linting error