### PR TITLE
Add agent sources for file uploads

### DIFF
--- a/ayunis-core-backend/src/db/migrations/1756000000000-AddAgentSourceAssignments.ts
+++ b/ayunis-core-backend/src/db/migrations/1756000000000-AddAgentSourceAssignments.ts
@@ -1,0 +1,36 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddAgentSourceAssignments1756000000000 implements MigrationInterface {
+  name = 'AddAgentSourceAssignments1756000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE "agent_source_assignments" (
+        "id" uuid NOT NULL DEFAULT uuid_generate_v4(),
+        "createdAt" TIMESTAMP NOT NULL DEFAULT now(),
+        "updatedAt" TIMESTAMP NOT NULL DEFAULT now(),
+        "agentId" uuid NOT NULL,
+        "sourceId" uuid NOT NULL,
+        CONSTRAINT "PK_agent_source_assignments" PRIMARY KEY ("id")
+      )
+    `);
+
+    await queryRunner.query(`
+      ALTER TABLE "agent_source_assignments" 
+      ADD CONSTRAINT "FK_agent_source_assignments_agent" 
+      FOREIGN KEY ("agentId") REFERENCES "agents"("id") ON DELETE CASCADE ON UPDATE NO ACTION
+    `);
+
+    await queryRunner.query(`
+      ALTER TABLE "agent_source_assignments" 
+      ADD CONSTRAINT "FK_agent_source_assignments_source" 
+      FOREIGN KEY ("sourceId") REFERENCES "sources"("id") ON DELETE CASCADE ON UPDATE NO ACTION
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "agent_source_assignments" DROP CONSTRAINT "FK_agent_source_assignments_source"`);
+    await queryRunner.query(`ALTER TABLE "agent_source_assignments" DROP CONSTRAINT "FK_agent_source_assignments_agent"`);
+    await queryRunner.query(`DROP TABLE "agent_source_assignments"`);
+  }
+}

--- a/ayunis-core-backend/src/domain/agents/agents.module.ts
+++ b/ayunis-core-backend/src/domain/agents/agents.module.ts
@@ -1,11 +1,13 @@
 import { forwardRef, Module } from '@nestjs/common';
 import { ModelsModule } from 'src/domain/models/models.module';
 import { ToolsModule } from 'src/domain/tools/tools.module';
+import { SourcesModule } from 'src/domain/sources/sources.module';
 import { LocalAgentsRepositoryModule } from './infrastructure/persistence/local/local-agent-repository.module';
 import { LocalAgentRepository } from './infrastructure/persistence/local/local-agent.repository';
 import { AgentRepository } from './application/ports/agent.repository';
 import { AgentRecord } from './infrastructure/persistence/local/schema/agent.record';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { CommonModule } from 'src/common/common.module';
 
 // Use Cases
 import { CreateAgentUseCase } from './application/use-cases/create-agent/create-agent.use-case';
@@ -15,11 +17,15 @@ import { FindAllAgentsByOwnerUseCase } from './application/use-cases/find-all-ag
 import { DeleteAgentUseCase } from './application/use-cases/delete-agent/delete-agent.use-case';
 import { UpdateAgentUseCase } from './application/use-cases/update-agent/update-agent.use-case';
 import { ReplaceModelWithUserDefaultUseCase } from './application/use-cases/replace-model-with-user-default/replace-model-with-user-default.use-case';
+import { AddSourceToAgentUseCase } from './application/use-cases/add-source-to-agent/add-source-to-agent.use-case';
+import { RemoveSourceFromAgentUseCase } from './application/use-cases/remove-source-from-agent/remove-source-from-agent.use-case';
+import { GetAgentSourcesUseCase } from './application/use-cases/get-agent-sources/get-agent-sources.use-case';
 
 // Presenters
 import { AgentsController } from './presenters/http/agents.controller';
 import { AgentDtoMapper } from './presenters/http/mappers/agent.mapper';
 import { ThreadsModule } from '../threads/threads.module';
+import { SourceDtoMapper } from '../threads/presenters/http/mappers/source.mapper';
 
 @Module({
   imports: [
@@ -27,7 +33,9 @@ import { ThreadsModule } from '../threads/threads.module';
     LocalAgentsRepositoryModule,
     forwardRef(() => ModelsModule),
     forwardRef(() => ThreadsModule),
+    SourcesModule,
     ToolsModule,
+    CommonModule,
   ],
   providers: [
     {
@@ -42,8 +50,12 @@ import { ThreadsModule } from '../threads/threads.module';
     UpdateAgentUseCase,
     DeleteAgentUseCase,
     ReplaceModelWithUserDefaultUseCase,
+    AddSourceToAgentUseCase,
+    RemoveSourceFromAgentUseCase,
+    GetAgentSourcesUseCase,
     // Presenters
     AgentDtoMapper,
+    SourceDtoMapper,
   ],
   controllers: [AgentsController],
   exports: [

--- a/ayunis-core-backend/src/domain/agents/application/agents.errors.ts
+++ b/ayunis-core-backend/src/domain/agents/application/agents.errors.ts
@@ -16,6 +16,7 @@ export enum AgentErrorCode {
   AGENT_INVALID_INPUT = 'AGENT_INVALID_INPUT',
   AGENT_EXECUTION_FAILED = 'AGENT_EXECUTION_FAILED',
   AGENT_TOOL_ASSIGNMENT_NOT_FOUND = 'AGENT_TOOL_ASSIGNMENT_NOT_FOUND',
+  AGENT_SOURCE_NOT_FOUND = 'AGENT_SOURCE_NOT_FOUND',
 }
 
 /**
@@ -108,6 +109,20 @@ export class AgentToolAssignmentNotFoundError extends AgentError {
     super(
       `Agent tool assignment with ID ${toolAssignmentId} not found`,
       AgentErrorCode.AGENT_TOOL_ASSIGNMENT_NOT_FOUND,
+      404,
+      metadata,
+    );
+  }
+}
+
+/**
+ * Error thrown when an agent source assignment is not found
+ */
+export class AgentSourceNotFoundError extends AgentError {
+  constructor(sourceId: string, agentId: string, metadata?: ErrorMetadata) {
+    super(
+      `Source with ID ${sourceId} not found in agent ${agentId}`,
+      AgentErrorCode.AGENT_SOURCE_NOT_FOUND,
       404,
       metadata,
     );

--- a/ayunis-core-backend/src/domain/agents/application/use-cases/add-source-to-agent/add-source-to-agent.command.ts
+++ b/ayunis-core-backend/src/domain/agents/application/use-cases/add-source-to-agent/add-source-to-agent.command.ts
@@ -1,0 +1,9 @@
+import { Agent } from '../../../domain/agent.entity';
+import { Source } from '../../../../sources/domain/source.entity';
+
+export class AddSourceToAgentCommand {
+  constructor(
+    public readonly agent: Agent,
+    public readonly source: Source,
+  ) {}
+}

--- a/ayunis-core-backend/src/domain/agents/application/use-cases/add-source-to-agent/add-source-to-agent.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/agents/application/use-cases/add-source-to-agent/add-source-to-agent.use-case.spec.ts
@@ -1,0 +1,356 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { Logger } from '@nestjs/common';
+import { AddSourceToAgentUseCase } from './add-source-to-agent.use-case';
+import { AddSourceToAgentCommand } from './add-source-to-agent.command';
+import { AgentRepository } from '../../ports/agent.repository';
+import { Agent } from '../../../domain/agent.entity';
+import { AgentSourceAssignment } from '../../../domain/agent-source-assignment.entity';
+import { FileSource } from '../../../../sources/domain/sources/file-source.entity';
+import { PermittedLanguageModel } from 'src/domain/models/domain/permitted-model.entity';
+import { LanguageModel } from 'src/domain/models/domain/models/language.model';
+import { ModelProvider } from 'src/domain/models/domain/value-objects/model-provider.enum';
+
+describe('AddSourceToAgentUseCase', () => {
+  let useCase: AddSourceToAgentUseCase;
+  let agentRepository: jest.Mocked<AgentRepository>;
+
+  const mockUserId = '123e4567-e89b-12d3-a456-426614174000' as any;
+  const mockOrgId = '123e4567-e89b-12d3-a456-426614174001' as any;
+  const mockAgentId = '123e4567-e89b-12d3-a456-426614174002' as any;
+  const mockSourceId = '123e4567-e89b-12d3-a456-426614174003' as any;
+  const mockModelId = '123e4567-e89b-12d3-a456-426614174004' as any;
+
+  beforeEach(async () => {
+    const mockAgentRepository = {
+      create: jest.fn(),
+      findOne: jest.fn(),
+      findMany: jest.fn(),
+      findAllByOwner: jest.fn(),
+      findAllByModel: jest.fn(),
+      update: jest.fn(),
+      updateModel: jest.fn(),
+      delete: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AddSourceToAgentUseCase,
+        { provide: AgentRepository, useValue: mockAgentRepository },
+      ],
+    }).compile();
+
+    useCase = module.get<AddSourceToAgentUseCase>(AddSourceToAgentUseCase);
+    agentRepository = module.get(AgentRepository);
+
+    // Mock logger
+    jest.spyOn(Logger.prototype, 'log').mockImplementation();
+    jest.spyOn(Logger.prototype, 'debug').mockImplementation();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('execute', () => {
+    it('should add source to agent successfully', async () => {
+      // Arrange
+      const mockModel = new PermittedLanguageModel({
+        id: mockModelId,
+        orgId: mockOrgId,
+        model: new LanguageModel({
+          name: 'gpt-4',
+          displayName: 'GPT-4',
+          provider: ModelProvider.OPENAI,
+          canStream: true,
+          isReasoning: false,
+          isArchived: false,
+        }),
+      });
+
+      const mockSource = new FileSource({
+        fileType: 'application/pdf',
+        fileSize: 1024,
+        fileName: 'test-document.pdf',
+        text: 'Test document content',
+        content: [],
+      });
+      mockSource.id = mockSourceId;
+
+      const originalAgent = new Agent({
+        id: mockAgentId,
+        name: 'Test Agent',
+        instructions: 'Test instructions',
+        model: mockModel,
+        toolAssignments: [],
+        sourceAssignments: [],
+        userId: mockUserId,
+      });
+
+      const updatedAgent = new Agent({
+        id: mockAgentId,
+        name: 'Test Agent',
+        instructions: 'Test instructions',
+        model: mockModel,
+        toolAssignments: [],
+        sourceAssignments: [new AgentSourceAssignment({ source: mockSource })],
+        userId: mockUserId,
+      });
+
+      const command = new AddSourceToAgentCommand(originalAgent, mockSource);
+
+      agentRepository.update.mockResolvedValue(updatedAgent);
+
+      // Act
+      const result = await useCase.execute(command);
+
+      // Assert
+      expect(agentRepository.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: mockAgentId,
+          name: 'Test Agent',
+          instructions: 'Test instructions',
+          sourceAssignments: expect.arrayContaining([
+            expect.objectContaining({
+              source: mockSource,
+            }),
+          ]),
+        }),
+      );
+      expect(result).toBe(updatedAgent);
+      expect(result.sourceAssignments).toHaveLength(1);
+      expect(result.sourceAssignments[0].source).toBe(mockSource);
+    });
+
+    it('should add source to agent that already has sources', async () => {
+      // Arrange
+      const mockModel = new PermittedLanguageModel({
+        id: mockModelId,
+        orgId: mockOrgId,
+        model: new LanguageModel({
+          name: 'gpt-4',
+          displayName: 'GPT-4',
+          provider: ModelProvider.OPENAI,
+          canStream: true,
+          isReasoning: false,
+          isArchived: false,
+        }),
+      });
+
+      const existingSource = new FileSource({
+        fileType: 'text/plain',
+        fileSize: 512,
+        fileName: 'existing-document.txt',
+        text: 'Existing document content',
+        content: [],
+      });
+      existingSource.id = '123e4567-e89b-12d3-a456-426614174005' as any;
+
+      const newSource = new FileSource({
+        fileType: 'application/pdf',
+        fileSize: 1024,
+        fileName: 'new-document.pdf',
+        text: 'New document content',
+        content: [],
+      });
+      newSource.id = mockSourceId;
+
+      const originalAgent = new Agent({
+        id: mockAgentId,
+        name: 'Test Agent',
+        instructions: 'Test instructions',
+        model: mockModel,
+        toolAssignments: [],
+        sourceAssignments: [new AgentSourceAssignment({ source: existingSource })],
+        userId: mockUserId,
+      });
+
+      const updatedAgent = new Agent({
+        id: mockAgentId,
+        name: 'Test Agent',
+        instructions: 'Test instructions',
+        model: mockModel,
+        toolAssignments: [],
+        sourceAssignments: [
+          new AgentSourceAssignment({ source: existingSource }),
+          new AgentSourceAssignment({ source: newSource }),
+        ],
+        userId: mockUserId,
+      });
+
+      const command = new AddSourceToAgentCommand(originalAgent, newSource);
+
+      agentRepository.update.mockResolvedValue(updatedAgent);
+
+      // Act
+      const result = await useCase.execute(command);
+
+      // Assert
+      expect(agentRepository.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sourceAssignments: expect.arrayContaining([
+            expect.objectContaining({ source: existingSource }),
+            expect.objectContaining({ source: newSource }),
+          ]),
+        }),
+      );
+      expect(result.sourceAssignments).toHaveLength(2);
+    });
+
+    it('should log the operation', async () => {
+      // Arrange
+      const mockModel = new PermittedLanguageModel({
+        id: mockModelId,
+        orgId: mockOrgId,
+        model: new LanguageModel({
+          name: 'gpt-4',
+          displayName: 'GPT-4',
+          provider: ModelProvider.OPENAI,
+          canStream: true,
+          isReasoning: false,
+          isArchived: false,
+        }),
+      });
+
+      const mockSource = new FileSource({
+        fileType: 'application/pdf',
+        fileSize: 1024,
+        fileName: 'test-document.pdf',
+        text: 'Test document content',
+        content: [],
+      });
+      mockSource.id = mockSourceId;
+
+      const originalAgent = new Agent({
+        id: mockAgentId,
+        name: 'Test Agent',
+        instructions: 'Test instructions',
+        model: mockModel,
+        toolAssignments: [],
+        sourceAssignments: [],
+        userId: mockUserId,
+      });
+
+      const updatedAgent = new Agent({
+        ...originalAgent,
+        sourceAssignments: [new AgentSourceAssignment({ source: mockSource })],
+      });
+
+      const command = new AddSourceToAgentCommand(originalAgent, mockSource);
+
+      agentRepository.update.mockResolvedValue(updatedAgent);
+
+      const logSpy = jest.spyOn(Logger.prototype, 'log');
+      const debugSpy = jest.spyOn(Logger.prototype, 'debug');
+
+      // Act
+      await useCase.execute(command);
+
+      // Assert
+      expect(logSpy).toHaveBeenCalledWith('execute', {
+        agentId: mockAgentId,
+        sourceId: mockSourceId,
+      });
+      expect(debugSpy).toHaveBeenCalledWith('Source added to agent successfully', {
+        agentId: mockAgentId,
+        sourceId: mockSourceId,
+      });
+    });
+
+    it('should handle repository errors', async () => {
+      // Arrange
+      const mockModel = new PermittedLanguageModel({
+        id: mockModelId,
+        orgId: mockOrgId,
+        model: new LanguageModel({
+          name: 'gpt-4',
+          displayName: 'GPT-4',
+          provider: ModelProvider.OPENAI,
+          canStream: true,
+          isReasoning: false,
+          isArchived: false,
+        }),
+      });
+
+      const mockSource = new FileSource({
+        fileType: 'application/pdf',
+        fileSize: 1024,
+        fileName: 'test-document.pdf',
+        text: 'Test document content',
+        content: [],
+      });
+      mockSource.id = mockSourceId;
+
+      const originalAgent = new Agent({
+        id: mockAgentId,
+        name: 'Test Agent',
+        instructions: 'Test instructions',
+        model: mockModel,
+        toolAssignments: [],
+        sourceAssignments: [],
+        userId: mockUserId,
+      });
+
+      const command = new AddSourceToAgentCommand(originalAgent, mockSource);
+
+      const repositoryError = new Error('Database connection failed');
+      agentRepository.update.mockRejectedValue(repositoryError);
+
+      // Act & Assert
+      await expect(useCase.execute(command)).rejects.toThrow(
+        'Database connection failed',
+      );
+
+      expect(agentRepository.update).toHaveBeenCalled();
+    });
+
+    it('should create new source assignment with unique ID', async () => {
+      // Arrange
+      const mockModel = new PermittedLanguageModel({
+        id: mockModelId,
+        orgId: mockOrgId,
+        model: new LanguageModel({
+          name: 'gpt-4',
+          displayName: 'GPT-4',
+          provider: ModelProvider.OPENAI,
+          canStream: true,
+          isReasoning: false,
+          isArchived: false,
+        }),
+      });
+
+      const mockSource = new FileSource({
+        fileType: 'application/pdf',
+        fileSize: 1024,
+        fileName: 'test-document.pdf',
+        text: 'Test document content',
+        content: [],
+      });
+      mockSource.id = mockSourceId;
+
+      const originalAgent = new Agent({
+        id: mockAgentId,
+        name: 'Test Agent',
+        instructions: 'Test instructions',
+        model: mockModel,
+        toolAssignments: [],
+        sourceAssignments: [],
+        userId: mockUserId,
+      });
+
+      const command = new AddSourceToAgentCommand(originalAgent, mockSource);
+
+      agentRepository.update.mockImplementation((agent) => Promise.resolve(agent));
+
+      // Act
+      await useCase.execute(command);
+
+      // Assert
+      const updatedAgentCall = agentRepository.update.mock.calls[0][0];
+      expect(updatedAgentCall.sourceAssignments).toHaveLength(1);
+      expect(updatedAgentCall.sourceAssignments[0].id).toBeDefined();
+      expect(updatedAgentCall.sourceAssignments[0].source).toBe(mockSource);
+      expect(updatedAgentCall.sourceAssignments[0].createdAt).toBeInstanceOf(Date);
+      expect(updatedAgentCall.sourceAssignments[0].updatedAt).toBeInstanceOf(Date);
+    });
+  });
+});

--- a/ayunis-core-backend/src/domain/agents/application/use-cases/add-source-to-agent/add-source-to-agent.use-case.ts
+++ b/ayunis-core-backend/src/domain/agents/application/use-cases/add-source-to-agent/add-source-to-agent.use-case.ts
@@ -1,0 +1,40 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { AddSourceToAgentCommand } from './add-source-to-agent.command';
+import { AgentRepository } from '../../ports/agent.repository';
+import { Agent } from '../../../domain/agent.entity';
+import { AgentSourceAssignment } from '../../../domain/agent-source-assignment.entity';
+
+@Injectable()
+export class AddSourceToAgentUseCase {
+  private readonly logger = new Logger(AddSourceToAgentUseCase.name);
+
+  constructor(private readonly agentRepository: AgentRepository) {}
+
+  async execute(command: AddSourceToAgentCommand): Promise<Agent> {
+    this.logger.log('execute', {
+      agentId: command.agent.id,
+      sourceId: command.source.id,
+    });
+
+    // Create new source assignment
+    const sourceAssignment = new AgentSourceAssignment({
+      source: command.source,
+    });
+
+    // Create updated agent with new source assignment
+    const updatedAgent = new Agent({
+      ...command.agent,
+      sourceAssignments: [...command.agent.sourceAssignments, sourceAssignment],
+    });
+
+    // Save the updated agent
+    const savedAgent = await this.agentRepository.update(updatedAgent);
+
+    this.logger.debug('Source added to agent successfully', {
+      agentId: savedAgent.id,
+      sourceId: command.source.id,
+    });
+
+    return savedAgent;
+  }
+}

--- a/ayunis-core-backend/src/domain/agents/application/use-cases/get-agent-sources/get-agent-sources.query.ts
+++ b/ayunis-core-backend/src/domain/agents/application/use-cases/get-agent-sources/get-agent-sources.query.ts
@@ -1,0 +1,5 @@
+import { UUID } from 'crypto';
+
+export class GetAgentSourcesQuery {
+  constructor(public readonly agentId: UUID) {}
+}

--- a/ayunis-core-backend/src/domain/agents/application/use-cases/get-agent-sources/get-agent-sources.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/agents/application/use-cases/get-agent-sources/get-agent-sources.use-case.spec.ts
@@ -1,0 +1,408 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { Logger } from '@nestjs/common';
+import { GetAgentSourcesUseCase } from './get-agent-sources.use-case';
+import { GetAgentSourcesQuery } from './get-agent-sources.query';
+import { AgentRepository } from '../../ports/agent.repository';
+import { Agent } from '../../../domain/agent.entity';
+import { AgentSourceAssignment } from '../../../domain/agent-source-assignment.entity';
+import { FileSource } from '../../../../sources/domain/sources/file-source.entity';
+import { PermittedLanguageModel } from 'src/domain/models/domain/permitted-model.entity';
+import { LanguageModel } from 'src/domain/models/domain/models/language.model';
+import { ModelProvider } from 'src/domain/models/domain/value-objects/model-provider.enum';
+import { AgentNotFoundError } from '../../agents.errors';
+import { ContextService } from 'src/common/context/services/context.service';
+
+describe('GetAgentSourcesUseCase', () => {
+  let useCase: GetAgentSourcesUseCase;
+  let agentRepository: jest.Mocked<AgentRepository>;
+  let contextService: jest.Mocked<ContextService>;
+
+  const mockUserId = '123e4567-e89b-12d3-a456-426614174000' as any;
+  const mockOrgId = '123e4567-e89b-12d3-a456-426614174001' as any;
+  const mockAgentId = '123e4567-e89b-12d3-a456-426614174002' as any;
+  const mockSourceId1 = '123e4567-e89b-12d3-a456-426614174003' as any;
+  const mockSourceId2 = '123e4567-e89b-12d3-a456-426614174004' as any;
+  const mockModelId = '123e4567-e89b-12d3-a456-426614174005' as any;
+
+  beforeEach(async () => {
+    const mockAgentRepository = {
+      create: jest.fn(),
+      findOne: jest.fn(),
+      findMany: jest.fn(),
+      findAllByOwner: jest.fn(),
+      findAllByModel: jest.fn(),
+      update: jest.fn(),
+      updateModel: jest.fn(),
+      delete: jest.fn(),
+    };
+
+    const mockContextService = {
+      get: jest.fn((key: string) => {
+        if (key === 'userId') return mockUserId;
+        if (key === 'orgId') return mockOrgId;
+        return undefined;
+      }),
+    } as unknown as jest.Mocked<ContextService>;
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        GetAgentSourcesUseCase,
+        { provide: AgentRepository, useValue: mockAgentRepository },
+        { provide: ContextService, useValue: mockContextService },
+      ],
+    }).compile();
+
+    useCase = module.get<GetAgentSourcesUseCase>(GetAgentSourcesUseCase);
+    agentRepository = module.get(AgentRepository);
+    contextService = module.get(ContextService);
+
+    // Mock logger
+    jest.spyOn(Logger.prototype, 'log').mockImplementation();
+    jest.spyOn(Logger.prototype, 'debug').mockImplementation();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('execute', () => {
+    it('should return agent sources successfully', async () => {
+      // Arrange
+      const mockModel = new PermittedLanguageModel({
+        id: mockModelId,
+        orgId: mockOrgId,
+        model: new LanguageModel({
+          name: 'gpt-4',
+          displayName: 'GPT-4',
+          provider: ModelProvider.OPENAI,
+          canStream: true,
+          isReasoning: false,
+          isArchived: false,
+        }),
+      });
+
+      const mockSource1 = new FileSource({
+        fileType: 'application/pdf',
+        fileSize: 1024,
+        fileName: 'document1.pdf',
+        text: 'Document 1 content',
+        content: [],
+      });
+      mockSource1.id = mockSourceId1;
+
+      const mockSource2 = new FileSource({
+        fileType: 'text/plain',
+        fileSize: 512,
+        fileName: 'document2.txt',
+        text: 'Document 2 content',
+        content: [],
+      });
+      mockSource2.id = mockSourceId2;
+
+      const mockAgent = new Agent({
+        id: mockAgentId,
+        name: 'Test Agent',
+        instructions: 'Test instructions',
+        model: mockModel,
+        toolAssignments: [],
+        sourceAssignments: [
+          new AgentSourceAssignment({ source: mockSource1 }),
+          new AgentSourceAssignment({ source: mockSource2 }),
+        ],
+        userId: mockUserId,
+      });
+
+      const query = new GetAgentSourcesQuery(mockAgentId);
+
+      agentRepository.findOne.mockResolvedValue(mockAgent);
+
+      // Act
+      const result = await useCase.execute(query);
+
+      // Assert
+      expect(agentRepository.findOne).toHaveBeenCalledWith(mockAgentId, mockUserId);
+      expect(result).toHaveLength(2);
+      expect(result[0]).toBe(mockSource1);
+      expect(result[1]).toBe(mockSource2);
+    });
+
+    it('should return empty array for agent with no sources', async () => {
+      // Arrange
+      const mockModel = new PermittedLanguageModel({
+        id: mockModelId,
+        orgId: mockOrgId,
+        model: new LanguageModel({
+          name: 'gpt-4',
+          displayName: 'GPT-4',
+          provider: ModelProvider.OPENAI,
+          canStream: true,
+          isReasoning: false,
+          isArchived: false,
+        }),
+      });
+
+      const mockAgent = new Agent({
+        id: mockAgentId,
+        name: 'Test Agent',
+        instructions: 'Test instructions',
+        model: mockModel,
+        toolAssignments: [],
+        sourceAssignments: [],
+        userId: mockUserId,
+      });
+
+      const query = new GetAgentSourcesQuery(mockAgentId);
+
+      agentRepository.findOne.mockResolvedValue(mockAgent);
+
+      // Act
+      const result = await useCase.execute(query);
+
+      // Assert
+      expect(agentRepository.findOne).toHaveBeenCalledWith(mockAgentId, mockUserId);
+      expect(result).toHaveLength(0);
+      expect(result).toEqual([]);
+    });
+
+    it('should throw AgentNotFoundError when agent does not exist', async () => {
+      // Arrange
+      const query = new GetAgentSourcesQuery(mockAgentId);
+
+      agentRepository.findOne.mockResolvedValue(null);
+
+      // Act & Assert
+      await expect(useCase.execute(query)).rejects.toThrow(AgentNotFoundError);
+      await expect(useCase.execute(query)).rejects.toThrow(
+        `Agent with ID ${mockAgentId} not found`,
+      );
+
+      expect(agentRepository.findOne).toHaveBeenCalledWith(mockAgentId, mockUserId);
+    });
+
+    it('should return single source for agent with one source', async () => {
+      // Arrange
+      const mockModel = new PermittedLanguageModel({
+        id: mockModelId,
+        orgId: mockOrgId,
+        model: new LanguageModel({
+          name: 'gpt-4',
+          displayName: 'GPT-4',
+          provider: ModelProvider.OPENAI,
+          canStream: true,
+          isReasoning: false,
+          isArchived: false,
+        }),
+      });
+
+      const mockSource = new FileSource({
+        fileType: 'application/pdf',
+        fileSize: 1024,
+        fileName: 'single-document.pdf',
+        text: 'Single document content',
+        content: [],
+      });
+      mockSource.id = mockSourceId1;
+
+      const mockAgent = new Agent({
+        id: mockAgentId,
+        name: 'Test Agent',
+        instructions: 'Test instructions',
+        model: mockModel,
+        toolAssignments: [],
+        sourceAssignments: [new AgentSourceAssignment({ source: mockSource })],
+        userId: mockUserId,
+      });
+
+      const query = new GetAgentSourcesQuery(mockAgentId);
+
+      agentRepository.findOne.mockResolvedValue(mockAgent);
+
+      // Act
+      const result = await useCase.execute(query);
+
+      // Assert
+      expect(result).toHaveLength(1);
+      expect(result[0]).toBe(mockSource);
+      expect(result[0].id).toBe(mockSourceId1);
+      expect(result[0].name).toBe('single-document.pdf');
+    });
+
+    it('should log the operation', async () => {
+      // Arrange
+      const mockModel = new PermittedLanguageModel({
+        id: mockModelId,
+        orgId: mockOrgId,
+        model: new LanguageModel({
+          name: 'gpt-4',
+          displayName: 'GPT-4',
+          provider: ModelProvider.OPENAI,
+          canStream: true,
+          isReasoning: false,
+          isArchived: false,
+        }),
+      });
+
+      const mockAgent = new Agent({
+        id: mockAgentId,
+        name: 'Test Agent',
+        instructions: 'Test instructions',
+        model: mockModel,
+        toolAssignments: [],
+        sourceAssignments: [],
+        userId: mockUserId,
+      });
+
+      const query = new GetAgentSourcesQuery(mockAgentId);
+
+      agentRepository.findOne.mockResolvedValue(mockAgent);
+
+      const logSpy = jest.spyOn(Logger.prototype, 'log');
+      const debugSpy = jest.spyOn(Logger.prototype, 'debug');
+
+      // Act
+      await useCase.execute(query);
+
+      // Assert
+      expect(logSpy).toHaveBeenCalledWith('execute', {
+        agentId: mockAgentId,
+      });
+      expect(debugSpy).toHaveBeenCalledWith('Retrieved agent sources successfully', {
+        agentId: mockAgentId,
+        sourceCount: 0,
+      });
+    });
+
+    it('should handle repository errors', async () => {
+      // Arrange
+      const query = new GetAgentSourcesQuery(mockAgentId);
+
+      const repositoryError = new Error('Database connection failed');
+      agentRepository.findOne.mockRejectedValue(repositoryError);
+
+      // Act & Assert
+      await expect(useCase.execute(query)).rejects.toThrow(
+        'Database connection failed',
+      );
+
+      expect(agentRepository.findOne).toHaveBeenCalledWith(mockAgentId, mockUserId);
+    });
+
+    it('should preserve source order from agent source assignments', async () => {
+      // Arrange
+      const mockModel = new PermittedLanguageModel({
+        id: mockModelId,
+        orgId: mockOrgId,
+        model: new LanguageModel({
+          name: 'gpt-4',
+          displayName: 'GPT-4',
+          provider: ModelProvider.OPENAI,
+          canStream: true,
+          isReasoning: false,
+          isArchived: false,
+        }),
+      });
+
+      const firstSource = new FileSource({
+        fileType: 'application/pdf',
+        fileSize: 1024,
+        fileName: 'first-document.pdf',
+        text: 'First document content',
+        content: [],
+      });
+      firstSource.id = mockSourceId1;
+
+      const secondSource = new FileSource({
+        fileType: 'text/plain',
+        fileSize: 512,
+        fileName: 'second-document.txt',
+        text: 'Second document content',
+        content: [],
+      });
+      secondSource.id = mockSourceId2;
+
+      const mockAgent = new Agent({
+        id: mockAgentId,
+        name: 'Test Agent',
+        instructions: 'Test instructions',
+        model: mockModel,
+        toolAssignments: [],
+        sourceAssignments: [
+          new AgentSourceAssignment({ source: firstSource }),
+          new AgentSourceAssignment({ source: secondSource }),
+        ],
+        userId: mockUserId,
+      });
+
+      const query = new GetAgentSourcesQuery(mockAgentId);
+
+      agentRepository.findOne.mockResolvedValue(mockAgent);
+
+      // Act
+      const result = await useCase.execute(query);
+
+      // Assert
+      expect(result).toHaveLength(2);
+      expect(result[0].name).toBe('first-document.pdf');
+      expect(result[1].name).toBe('second-document.txt');
+    });
+
+    it('should handle different source types', async () => {
+      // Arrange
+      const mockModel = new PermittedLanguageModel({
+        id: mockModelId,
+        orgId: mockOrgId,
+        model: new LanguageModel({
+          name: 'gpt-4',
+          displayName: 'GPT-4',
+          provider: ModelProvider.OPENAI,
+          canStream: true,
+          isReasoning: false,
+          isArchived: false,
+        }),
+      });
+
+      const pdfSource = new FileSource({
+        fileType: 'application/pdf',
+        fileSize: 2048,
+        fileName: 'document.pdf',
+        text: 'PDF document content',
+        content: [],
+      });
+      pdfSource.id = mockSourceId1;
+
+      const textSource = new FileSource({
+        fileType: 'text/plain',
+        fileSize: 1024,
+        fileName: 'document.txt',
+        text: 'Text document content',
+        content: [],
+      });
+      textSource.id = mockSourceId2;
+
+      const mockAgent = new Agent({
+        id: mockAgentId,
+        name: 'Test Agent',
+        instructions: 'Test instructions',
+        model: mockModel,
+        toolAssignments: [],
+        sourceAssignments: [
+          new AgentSourceAssignment({ source: pdfSource }),
+          new AgentSourceAssignment({ source: textSource }),
+        ],
+        userId: mockUserId,
+      });
+
+      const query = new GetAgentSourcesQuery(mockAgentId);
+
+      agentRepository.findOne.mockResolvedValue(mockAgent);
+
+      // Act
+      const result = await useCase.execute(query);
+
+      // Assert
+      expect(result).toHaveLength(2);
+      expect((result[0] as FileSource).fileType).toBe('application/pdf');
+      expect((result[1] as FileSource).fileType).toBe('text/plain');
+    });
+  });
+});

--- a/ayunis-core-backend/src/domain/agents/application/use-cases/get-agent-sources/get-agent-sources.use-case.ts
+++ b/ayunis-core-backend/src/domain/agents/application/use-cases/get-agent-sources/get-agent-sources.use-case.ts
@@ -1,0 +1,39 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { GetAgentSourcesQuery } from './get-agent-sources.query';
+import { AgentRepository } from '../../ports/agent.repository';
+import { Source } from '../../../../sources/domain/source.entity';
+import { AgentNotFoundError } from '../../agents.errors';
+import { ContextService } from 'src/common/context/services/context.service';
+
+@Injectable()
+export class GetAgentSourcesUseCase {
+  private readonly logger = new Logger(GetAgentSourcesUseCase.name);
+
+  constructor(
+    private readonly agentRepository: AgentRepository,
+    private readonly contextService: ContextService,
+  ) {}
+
+  async execute(query: GetAgentSourcesQuery): Promise<Source[]> {
+    this.logger.log('execute', { agentId: query.agentId });
+
+    const userId = this.contextService.get('userId');
+    if (!userId) {
+      throw new Error('User not authenticated');
+    }
+
+    const agent = await this.agentRepository.findOne(query.agentId, userId);
+    if (!agent) {
+      throw new AgentNotFoundError(query.agentId);
+    }
+
+    const sources = agent.sourceAssignments.map((assignment) => assignment.source);
+
+    this.logger.debug('Agent sources retrieved', {
+      agentId: query.agentId,
+      sourceCount: sources.length,
+    });
+
+    return sources;
+  }
+}

--- a/ayunis-core-backend/src/domain/agents/application/use-cases/get-agent-sources/get-agent-sources.use-case.ts
+++ b/ayunis-core-backend/src/domain/agents/application/use-cases/get-agent-sources/get-agent-sources.use-case.ts
@@ -29,7 +29,7 @@ export class GetAgentSourcesUseCase {
 
     const sources = agent.sourceAssignments.map((assignment) => assignment.source);
 
-    this.logger.debug('Agent sources retrieved', {
+    this.logger.debug('Retrieved agent sources successfully', {
       agentId: query.agentId,
       sourceCount: sources.length,
     });

--- a/ayunis-core-backend/src/domain/agents/application/use-cases/remove-source-from-agent/remove-source-from-agent.command.ts
+++ b/ayunis-core-backend/src/domain/agents/application/use-cases/remove-source-from-agent/remove-source-from-agent.command.ts
@@ -1,0 +1,9 @@
+import { UUID } from 'crypto';
+import { Agent } from '../../../domain/agent.entity';
+
+export class RemoveSourceFromAgentCommand {
+  constructor(
+    public readonly agent: Agent,
+    public readonly sourceId: UUID,
+  ) {}
+}

--- a/ayunis-core-backend/src/domain/agents/application/use-cases/remove-source-from-agent/remove-source-from-agent.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/agents/application/use-cases/remove-source-from-agent/remove-source-from-agent.use-case.spec.ts
@@ -1,0 +1,384 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { Logger } from '@nestjs/common';
+import { RemoveSourceFromAgentUseCase } from './remove-source-from-agent.use-case';
+import { RemoveSourceFromAgentCommand } from './remove-source-from-agent.command';
+import { AgentRepository } from '../../ports/agent.repository';
+import { Agent } from '../../../domain/agent.entity';
+import { AgentSourceAssignment } from '../../../domain/agent-source-assignment.entity';
+import { FileSource } from '../../../../sources/domain/sources/file-source.entity';
+import { PermittedLanguageModel } from 'src/domain/models/domain/permitted-model.entity';
+import { LanguageModel } from 'src/domain/models/domain/models/language.model';
+import { ModelProvider } from 'src/domain/models/domain/value-objects/model-provider.enum';
+import { AgentSourceNotFoundError } from '../../agents.errors';
+
+describe('RemoveSourceFromAgentUseCase', () => {
+  let useCase: RemoveSourceFromAgentUseCase;
+  let agentRepository: jest.Mocked<AgentRepository>;
+
+  const mockUserId = '123e4567-e89b-12d3-a456-426614174000' as any;
+  const mockOrgId = '123e4567-e89b-12d3-a456-426614174001' as any;
+  const mockAgentId = '123e4567-e89b-12d3-a456-426614174002' as any;
+  const mockSourceId = '123e4567-e89b-12d3-a456-426614174003' as any;
+  const mockModelId = '123e4567-e89b-12d3-a456-426614174004' as any;
+
+  beforeEach(async () => {
+    const mockAgentRepository = {
+      create: jest.fn(),
+      findOne: jest.fn(),
+      findMany: jest.fn(),
+      findAllByOwner: jest.fn(),
+      findAllByModel: jest.fn(),
+      update: jest.fn(),
+      updateModel: jest.fn(),
+      delete: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        RemoveSourceFromAgentUseCase,
+        { provide: AgentRepository, useValue: mockAgentRepository },
+      ],
+    }).compile();
+
+    useCase = module.get<RemoveSourceFromAgentUseCase>(RemoveSourceFromAgentUseCase);
+    agentRepository = module.get(AgentRepository);
+
+    // Mock logger
+    jest.spyOn(Logger.prototype, 'log').mockImplementation();
+    jest.spyOn(Logger.prototype, 'debug').mockImplementation();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('execute', () => {
+    it('should remove source from agent successfully', async () => {
+      // Arrange
+      const mockModel = new PermittedLanguageModel({
+        id: mockModelId,
+        orgId: mockOrgId,
+        model: new LanguageModel({
+          name: 'gpt-4',
+          displayName: 'GPT-4',
+          provider: ModelProvider.OPENAI,
+          canStream: true,
+          isReasoning: false,
+          isArchived: false,
+        }),
+      });
+
+      const mockSource = new FileSource({
+        fileType: 'application/pdf',
+        fileSize: 1024,
+        fileName: 'test-document.pdf',
+        text: 'Test document content',
+        content: [],
+      });
+      mockSource.id = mockSourceId;
+
+      const originalAgent = new Agent({
+        id: mockAgentId,
+        name: 'Test Agent',
+        instructions: 'Test instructions',
+        model: mockModel,
+        toolAssignments: [],
+        sourceAssignments: [new AgentSourceAssignment({ source: mockSource })],
+        userId: mockUserId,
+      });
+
+      const updatedAgent = new Agent({
+        id: mockAgentId,
+        name: 'Test Agent',
+        instructions: 'Test instructions',
+        model: mockModel,
+        toolAssignments: [],
+        sourceAssignments: [],
+        userId: mockUserId,
+      });
+
+      const command = new RemoveSourceFromAgentCommand(originalAgent, mockSourceId);
+
+      agentRepository.update.mockResolvedValue(updatedAgent);
+
+      // Act
+      const result = await useCase.execute(command);
+
+      // Assert
+      expect(agentRepository.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: mockAgentId,
+          name: 'Test Agent',
+          instructions: 'Test instructions',
+          sourceAssignments: [],
+        }),
+      );
+      expect(result).toBe(updatedAgent);
+      expect(result.sourceAssignments).toHaveLength(0);
+    });
+
+    it('should remove specific source from agent with multiple sources', async () => {
+      // Arrange
+      const mockModel = new PermittedLanguageModel({
+        id: mockModelId,
+        orgId: mockOrgId,
+        model: new LanguageModel({
+          name: 'gpt-4',
+          displayName: 'GPT-4',
+          provider: ModelProvider.OPENAI,
+          canStream: true,
+          isReasoning: false,
+          isArchived: false,
+        }),
+      });
+
+      const sourceToRemove = new FileSource({
+        fileType: 'application/pdf',
+        fileSize: 1024,
+        fileName: 'document-to-remove.pdf',
+        text: 'Document to remove content',
+        content: [],
+      });
+      sourceToRemove.id = mockSourceId;
+
+      const sourceToKeep = new FileSource({
+        fileType: 'text/plain',
+        fileSize: 512,
+        fileName: 'document-to-keep.txt',
+        text: 'Document to keep content',
+        content: [],
+      });
+      sourceToKeep.id = '123e4567-e89b-12d3-a456-426614174005' as any;
+
+      const originalAgent = new Agent({
+        id: mockAgentId,
+        name: 'Test Agent',
+        instructions: 'Test instructions',
+        model: mockModel,
+        toolAssignments: [],
+        sourceAssignments: [
+          new AgentSourceAssignment({ source: sourceToRemove }),
+          new AgentSourceAssignment({ source: sourceToKeep }),
+        ],
+        userId: mockUserId,
+      });
+
+      const updatedAgent = new Agent({
+        id: mockAgentId,
+        name: 'Test Agent',
+        instructions: 'Test instructions',
+        model: mockModel,
+        toolAssignments: [],
+        sourceAssignments: [new AgentSourceAssignment({ source: sourceToKeep })],
+        userId: mockUserId,
+      });
+
+      const command = new RemoveSourceFromAgentCommand(originalAgent, mockSourceId);
+
+      agentRepository.update.mockResolvedValue(updatedAgent);
+
+      // Act
+      const result = await useCase.execute(command);
+
+      // Assert
+      expect(agentRepository.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sourceAssignments: expect.arrayContaining([
+            expect.objectContaining({ source: sourceToKeep }),
+          ]),
+        }),
+      );
+      expect(result.sourceAssignments).toHaveLength(1);
+      expect(result.sourceAssignments[0].source.id).toBe(sourceToKeep.id);
+    });
+
+    it('should throw AgentSourceNotFoundError when removing non-existent source', async () => {
+      // Arrange
+      const mockModel = new PermittedLanguageModel({
+        id: mockModelId,
+        orgId: mockOrgId,
+        model: new LanguageModel({
+          name: 'gpt-4',
+          displayName: 'GPT-4',
+          provider: ModelProvider.OPENAI,
+          canStream: true,
+          isReasoning: false,
+          isArchived: false,
+        }),
+      });
+
+      const existingSource = new FileSource({
+        fileType: 'text/plain',
+        fileSize: 512,
+        fileName: 'existing-document.txt',
+        text: 'Existing document content',
+        content: [],
+      });
+      existingSource.id = '123e4567-e89b-12d3-a456-426614174005' as any;
+
+      const originalAgent = new Agent({
+        id: mockAgentId,
+        name: 'Test Agent',
+        instructions: 'Test instructions',
+        model: mockModel,
+        toolAssignments: [],
+        sourceAssignments: [new AgentSourceAssignment({ source: existingSource })],
+        userId: mockUserId,
+      });
+
+      const nonExistentSourceId = '123e4567-e89b-12d3-a456-426614174999' as any;
+      const command = new RemoveSourceFromAgentCommand(originalAgent, nonExistentSourceId);
+
+      // Act & Assert
+      await expect(useCase.execute(command)).rejects.toThrow(AgentSourceNotFoundError);
+      await expect(useCase.execute(command)).rejects.toThrow(
+        `Source with ID ${nonExistentSourceId} not found in agent ${mockAgentId}`,
+      );
+
+      expect(agentRepository.update).not.toHaveBeenCalled();
+    });
+
+    it('should throw AgentSourceNotFoundError when agent has no sources', async () => {
+      // Arrange
+      const mockModel = new PermittedLanguageModel({
+        id: mockModelId,
+        orgId: mockOrgId,
+        model: new LanguageModel({
+          name: 'gpt-4',
+          displayName: 'GPT-4',
+          provider: ModelProvider.OPENAI,
+          canStream: true,
+          isReasoning: false,
+          isArchived: false,
+        }),
+      });
+
+      const originalAgent = new Agent({
+        id: mockAgentId,
+        name: 'Test Agent',
+        instructions: 'Test instructions',
+        model: mockModel,
+        toolAssignments: [],
+        sourceAssignments: [],
+        userId: mockUserId,
+      });
+
+      const command = new RemoveSourceFromAgentCommand(originalAgent, mockSourceId);
+
+      // Act & Assert
+      await expect(useCase.execute(command)).rejects.toThrow(AgentSourceNotFoundError);
+      await expect(useCase.execute(command)).rejects.toThrow(
+        `Source with ID ${mockSourceId} not found in agent ${mockAgentId}`,
+      );
+
+      expect(agentRepository.update).not.toHaveBeenCalled();
+    });
+
+    it('should log the operation', async () => {
+      // Arrange
+      const mockModel = new PermittedLanguageModel({
+        id: mockModelId,
+        orgId: mockOrgId,
+        model: new LanguageModel({
+          name: 'gpt-4',
+          displayName: 'GPT-4',
+          provider: ModelProvider.OPENAI,
+          canStream: true,
+          isReasoning: false,
+          isArchived: false,
+        }),
+      });
+
+      const mockSource = new FileSource({
+        fileType: 'application/pdf',
+        fileSize: 1024,
+        fileName: 'test-document.pdf',
+        text: 'Test document content',
+        content: [],
+      });
+      mockSource.id = mockSourceId;
+
+      const originalAgent = new Agent({
+        id: mockAgentId,
+        name: 'Test Agent',
+        instructions: 'Test instructions',
+        model: mockModel,
+        toolAssignments: [],
+        sourceAssignments: [new AgentSourceAssignment({ source: mockSource })],
+        userId: mockUserId,
+      });
+
+      const updatedAgent = new Agent({
+        ...originalAgent,
+        sourceAssignments: [],
+      });
+
+      const command = new RemoveSourceFromAgentCommand(originalAgent, mockSourceId);
+
+      agentRepository.update.mockResolvedValue(updatedAgent);
+
+      const logSpy = jest.spyOn(Logger.prototype, 'log');
+      const debugSpy = jest.spyOn(Logger.prototype, 'debug');
+
+      // Act
+      await useCase.execute(command);
+
+      // Assert
+      expect(logSpy).toHaveBeenCalledWith('execute', {
+        agentId: mockAgentId,
+        sourceId: mockSourceId,
+      });
+      expect(debugSpy).toHaveBeenCalledWith('Source removed from agent successfully', {
+        agentId: mockAgentId,
+        sourceId: mockSourceId,
+      });
+    });
+
+    it('should handle repository errors', async () => {
+      // Arrange
+      const mockModel = new PermittedLanguageModel({
+        id: mockModelId,
+        orgId: mockOrgId,
+        model: new LanguageModel({
+          name: 'gpt-4',
+          displayName: 'GPT-4',
+          provider: ModelProvider.OPENAI,
+          canStream: true,
+          isReasoning: false,
+          isArchived: false,
+        }),
+      });
+
+      const mockSource = new FileSource({
+        fileType: 'application/pdf',
+        fileSize: 1024,
+        fileName: 'test-document.pdf',
+        text: 'Test document content',
+        content: [],
+      });
+      mockSource.id = mockSourceId;
+
+      const originalAgent = new Agent({
+        id: mockAgentId,
+        name: 'Test Agent',
+        instructions: 'Test instructions',
+        model: mockModel,
+        toolAssignments: [],
+        sourceAssignments: [new AgentSourceAssignment({ source: mockSource })],
+        userId: mockUserId,
+      });
+
+      const command = new RemoveSourceFromAgentCommand(originalAgent, mockSourceId);
+
+      const repositoryError = new Error('Database connection failed');
+      agentRepository.update.mockRejectedValue(repositoryError);
+
+      // Act & Assert
+      await expect(useCase.execute(command)).rejects.toThrow(
+        'Database connection failed',
+      );
+
+      expect(agentRepository.update).toHaveBeenCalled();
+    });
+  });
+});

--- a/ayunis-core-backend/src/domain/agents/application/use-cases/remove-source-from-agent/remove-source-from-agent.use-case.ts
+++ b/ayunis-core-backend/src/domain/agents/application/use-cases/remove-source-from-agent/remove-source-from-agent.use-case.ts
@@ -2,6 +2,7 @@ import { Injectable, Logger } from '@nestjs/common';
 import { RemoveSourceFromAgentCommand } from './remove-source-from-agent.command';
 import { AgentRepository } from '../../ports/agent.repository';
 import { Agent } from '../../../domain/agent.entity';
+import { AgentSourceNotFoundError } from '../../agents.errors';
 
 @Injectable()
 export class RemoveSourceFromAgentUseCase {
@@ -14,6 +15,15 @@ export class RemoveSourceFromAgentUseCase {
       agentId: command.agent.id,
       sourceId: command.sourceId,
     });
+
+    // Check if the source assignment exists
+    const existingAssignment = command.agent.sourceAssignments.find(
+      (assignment) => assignment.source.id === command.sourceId,
+    );
+
+    if (!existingAssignment) {
+      throw new AgentSourceNotFoundError(command.sourceId, command.agent.id);
+    }
 
     // Filter out the source assignment to remove
     const updatedSourceAssignments = command.agent.sourceAssignments.filter(

--- a/ayunis-core-backend/src/domain/agents/application/use-cases/remove-source-from-agent/remove-source-from-agent.use-case.ts
+++ b/ayunis-core-backend/src/domain/agents/application/use-cases/remove-source-from-agent/remove-source-from-agent.use-case.ts
@@ -1,0 +1,39 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { RemoveSourceFromAgentCommand } from './remove-source-from-agent.command';
+import { AgentRepository } from '../../ports/agent.repository';
+import { Agent } from '../../../domain/agent.entity';
+
+@Injectable()
+export class RemoveSourceFromAgentUseCase {
+  private readonly logger = new Logger(RemoveSourceFromAgentUseCase.name);
+
+  constructor(private readonly agentRepository: AgentRepository) {}
+
+  async execute(command: RemoveSourceFromAgentCommand): Promise<Agent> {
+    this.logger.log('execute', {
+      agentId: command.agent.id,
+      sourceId: command.sourceId,
+    });
+
+    // Filter out the source assignment to remove
+    const updatedSourceAssignments = command.agent.sourceAssignments.filter(
+      (assignment) => assignment.source.id !== command.sourceId,
+    );
+
+    // Create updated agent without the source assignment
+    const updatedAgent = new Agent({
+      ...command.agent,
+      sourceAssignments: updatedSourceAssignments,
+    });
+
+    // Save the updated agent
+    const savedAgent = await this.agentRepository.update(updatedAgent);
+
+    this.logger.debug('Source removed from agent successfully', {
+      agentId: savedAgent.id,
+      sourceId: command.sourceId,
+    });
+
+    return savedAgent;
+  }
+}

--- a/ayunis-core-backend/src/domain/agents/domain/agent-source-assignment.entity.ts
+++ b/ayunis-core-backend/src/domain/agents/domain/agent-source-assignment.entity.ts
@@ -1,0 +1,21 @@
+import { UUID, randomUUID } from 'crypto';
+import { Source } from 'src/domain/sources/domain/source.entity';
+
+export class AgentSourceAssignment {
+  public readonly id: UUID;
+  public readonly source: Source;
+  public readonly createdAt: Date;
+  public readonly updatedAt: Date;
+
+  constructor(params: {
+    id?: UUID;
+    source: Source;
+    createdAt?: Date;
+    updatedAt?: Date;
+  }) {
+    this.id = params.id ?? randomUUID();
+    this.source = params.source;
+    this.createdAt = params.createdAt ?? new Date();
+    this.updatedAt = params.updatedAt ?? new Date();
+  }
+}

--- a/ayunis-core-backend/src/domain/agents/domain/agent.entity.ts
+++ b/ayunis-core-backend/src/domain/agents/domain/agent.entity.ts
@@ -2,6 +2,7 @@ import { randomUUID, UUID } from 'crypto';
 import { PermittedLanguageModel } from 'src/domain/models/domain/permitted-model.entity';
 import { Tool } from 'src/domain/tools/domain/tool.entity';
 import { AgentToolAssignment } from './agent-tool-assignment.entity';
+import { AgentSourceAssignment } from './agent-source-assignment.entity';
 
 export class Agent {
   public readonly id: UUID;
@@ -9,6 +10,7 @@ export class Agent {
   public readonly instructions: string;
   public readonly model: PermittedLanguageModel;
   public readonly toolAssignments: Array<AgentToolAssignment>;
+  public readonly sourceAssignments: Array<AgentSourceAssignment>;
   public readonly createdAt: Date;
   public readonly updatedAt: Date;
   public readonly userId: UUID;
@@ -19,6 +21,7 @@ export class Agent {
     instructions: string;
     model: PermittedLanguageModel;
     toolAssignments?: Array<AgentToolAssignment>;
+    sourceAssignments?: Array<AgentSourceAssignment>;
     userId: UUID;
     createdAt?: Date;
     updatedAt?: Date;
@@ -28,6 +31,7 @@ export class Agent {
     this.instructions = params.instructions;
     this.model = params.model;
     this.toolAssignments = params.toolAssignments ?? [];
+    this.sourceAssignments = params.sourceAssignments ?? [];
     this.userId = params.userId;
     this.createdAt = params.createdAt ?? new Date();
     this.updatedAt = params.updatedAt ?? new Date();

--- a/ayunis-core-backend/src/domain/agents/infrastructure/persistence/local/local-agent-repository.module.ts
+++ b/ayunis-core-backend/src/domain/agents/infrastructure/persistence/local/local-agent-repository.module.ts
@@ -2,20 +2,24 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { LocalAgentRepository } from './local-agent.repository';
 import { AgentRecord } from './schema/agent.record';
+import { AgentSourceAssignmentRecord } from './schema/agent-source-assignment.record';
 import { AgentMapper } from './mappers/agent.mapper';
+import { AgentSourceAssignmentMapper } from './mappers/agent-source-assignment.mapper';
 import { LocalPermittedModelsRepositoryModule } from 'src/domain/models/infrastructure/persistence/local-permitted-models/local-permitted-models-repository.module';
 import { LocalToolConfigRepositoryModule } from 'src/domain/tools/infrastructure/persistence/local/local-tool-config-repository.module';
+import { LocalSourcesRepositoryModule } from 'src/domain/sources/infrastructure/persistence/local/local-sources-repository.module';
 import { AgentToolMapper } from './mappers/agent-tool.mapper';
 import { ToolsModule } from 'src/domain/tools/tools.module';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([AgentRecord]),
+    TypeOrmModule.forFeature([AgentRecord, AgentSourceAssignmentRecord]),
     LocalPermittedModelsRepositoryModule,
     LocalToolConfigRepositoryModule,
+    LocalSourcesRepositoryModule,
     ToolsModule,
   ],
-  providers: [AgentMapper, LocalAgentRepository, AgentToolMapper],
+  providers: [AgentMapper, LocalAgentRepository, AgentToolMapper, AgentSourceAssignmentMapper],
   exports: [LocalAgentRepository, AgentMapper],
 })
 export class LocalAgentsRepositoryModule {}

--- a/ayunis-core-backend/src/domain/agents/infrastructure/persistence/local/mappers/agent-source-assignment.mapper.ts
+++ b/ayunis-core-backend/src/domain/agents/infrastructure/persistence/local/mappers/agent-source-assignment.mapper.ts
@@ -1,0 +1,31 @@
+import { Injectable } from '@nestjs/common';
+import { AgentSourceAssignment } from '../../../domain/agent-source-assignment.entity';
+import { AgentSourceAssignmentRecord } from '../schema/agent-source-assignment.record';
+import { SourceMapper } from '../../../../sources/infrastructure/persistence/local/mappers/source.mapper';
+
+@Injectable()
+export class AgentSourceAssignmentMapper {
+  constructor(private readonly sourceMapper: SourceMapper) {}
+
+  toDomain(record: AgentSourceAssignmentRecord): AgentSourceAssignment {
+    return new AgentSourceAssignment({
+      id: record.id,
+      source: this.sourceMapper.toDomain(record.source),
+      createdAt: record.createdAt,
+      updatedAt: record.updatedAt,
+    });
+  }
+
+  toRecord(
+    domain: AgentSourceAssignment,
+    agentId: string,
+  ): AgentSourceAssignmentRecord {
+    const record = new AgentSourceAssignmentRecord();
+    record.id = domain.id;
+    record.agentId = agentId as any;
+    record.sourceId = domain.source.id as any;
+    record.createdAt = domain.createdAt;
+    record.updatedAt = domain.updatedAt;
+    return record;
+  }
+}

--- a/ayunis-core-backend/src/domain/agents/infrastructure/persistence/local/mappers/agent.mapper.ts
+++ b/ayunis-core-backend/src/domain/agents/infrastructure/persistence/local/mappers/agent.mapper.ts
@@ -3,6 +3,7 @@ import { AgentRecord } from '../schema/agent.record';
 import { Injectable, Logger } from '@nestjs/common';
 import { PermittedModelMapper } from 'src/domain/models/infrastructure/persistence/local-permitted-models/mappers/permitted-model.mapper';
 import { AgentToolMapper } from './agent-tool.mapper';
+import { AgentSourceAssignmentMapper } from './agent-source-assignment.mapper';
 import { PermittedLanguageModel } from 'src/domain/models/domain/permitted-model.entity';
 
 @Injectable()
@@ -11,6 +12,7 @@ export class AgentMapper {
   constructor(
     private readonly permittedModelMapper: PermittedModelMapper,
     private readonly agentToolMapper: AgentToolMapper,
+    private readonly agentSourceAssignmentMapper: AgentSourceAssignmentMapper,
   ) {}
 
   toDomain(record: AgentRecord): Agent {
@@ -24,6 +26,9 @@ export class AgentMapper {
       ) as PermittedLanguageModel,
       toolAssignments: record.agentTools?.map((toolRecord) =>
         this.agentToolMapper.toDomain(toolRecord),
+      ),
+      sourceAssignments: record.agentSources?.map((sourceRecord) =>
+        this.agentSourceAssignmentMapper.toDomain(sourceRecord),
       ),
       userId: record.userId,
       createdAt: record.createdAt,
@@ -41,6 +46,9 @@ export class AgentMapper {
     entity.userId = domain.userId;
     entity.agentTools = domain.toolAssignments.map((toolAssignment) =>
       this.agentToolMapper.toRecord(toolAssignment, domain.id),
+    );
+    entity.agentSources = domain.sourceAssignments.map((sourceAssignment) =>
+      this.agentSourceAssignmentMapper.toRecord(sourceAssignment, domain.id),
     );
     return entity;
   }

--- a/ayunis-core-backend/src/domain/agents/infrastructure/persistence/local/schema/agent-source-assignment.record.ts
+++ b/ayunis-core-backend/src/domain/agents/infrastructure/persistence/local/schema/agent-source-assignment.record.ts
@@ -1,0 +1,20 @@
+import { Column, Entity, ManyToOne } from 'typeorm';
+import { BaseRecord } from '../../../../../../common/db/base-record';
+import { UUID } from 'crypto';
+import { AgentRecord } from './agent.record';
+import { SourceRecord } from '../../../../../sources/infrastructure/persistence/local/schema/source.record';
+
+@Entity({ name: 'agent_source_assignments' })
+export class AgentSourceAssignmentRecord extends BaseRecord {
+  @Column({ nullable: false })
+  agentId: UUID;
+
+  @ManyToOne(() => AgentRecord, { nullable: false, onDelete: 'CASCADE' })
+  agent: AgentRecord;
+
+  @Column({ nullable: false })
+  sourceId: UUID;
+
+  @ManyToOne(() => SourceRecord, { nullable: false, eager: true })
+  source: SourceRecord;
+}

--- a/ayunis-core-backend/src/domain/agents/infrastructure/persistence/local/schema/agent.record.ts
+++ b/ayunis-core-backend/src/domain/agents/infrastructure/persistence/local/schema/agent.record.ts
@@ -2,6 +2,7 @@ import { Column, Entity, ManyToOne, OneToMany } from 'typeorm';
 import { BaseRecord } from '../../../../../../common/db/base-record';
 import { UUID } from 'crypto';
 import { AgentToolAssignmentRecord } from './agent-tool.record';
+import { AgentSourceAssignmentRecord } from './agent-source-assignment.record';
 import { PermittedModelRecord } from '../../../../../models/infrastructure/persistence/local-permitted-models/schema/permitted-model.record';
 import { UserRecord } from '../../../../../../iam/users/infrastructure/repositories/local/schema/user.record';
 import { User } from '../../../../../../iam/users/domain/user.entity';
@@ -30,4 +31,9 @@ export class AgentRecord extends BaseRecord {
     cascade: true,
   })
   agentTools?: AgentToolAssignmentRecord[];
+
+  @OneToMany(() => AgentSourceAssignmentRecord, (agentSource) => agentSource.agent, {
+    cascade: true,
+  })
+  agentSources?: AgentSourceAssignmentRecord[];
 }

--- a/ayunis-core-backend/src/domain/agents/presenters/http/dto/agent-response.dto.ts
+++ b/ayunis-core-backend/src/domain/agents/presenters/http/dto/agent-response.dto.ts
@@ -1,6 +1,7 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { UUID } from 'crypto';
 import { ToolType } from 'src/domain/tools/domain/value-objects/tool-type.enum';
+import { SourceResponseDto } from '../../../threads/presenters/http/dto/get-thread-response.dto/source-response.dto';
 
 export class ModelResponseDto {
   @ApiProperty({
@@ -100,4 +101,10 @@ export class AgentResponseDto {
     type: [ToolResponseDto],
   })
   tools: ToolResponseDto[];
+
+  @ApiProperty({
+    description: 'The sources assigned to this agent',
+    type: [SourceResponseDto],
+  })
+  sources: SourceResponseDto[];
 }

--- a/ayunis-core-backend/src/domain/agents/presenters/http/mappers/agent.mapper.ts
+++ b/ayunis-core-backend/src/domain/agents/presenters/http/mappers/agent.mapper.ts
@@ -1,9 +1,12 @@
 import { Injectable } from '@nestjs/common';
 import { Agent } from '../../../domain/agent.entity';
 import { AgentResponseDto } from '../dto/agent-response.dto';
+import { SourceDtoMapper } from '../../../threads/presenters/http/mappers/source.mapper';
 
 @Injectable()
 export class AgentDtoMapper {
+  constructor(private readonly sourceDtoMapper: SourceDtoMapper) {}
+
   toDto(agent: Agent): AgentResponseDto {
     return {
       id: agent.id,
@@ -22,6 +25,9 @@ export class AgentDtoMapper {
         type: tool.type,
         configId: undefined, // Simplified for now
       })),
+      sources: agent.sourceAssignments.map((assignment) =>
+        this.sourceDtoMapper.toDto(assignment.source, agent.id),
+      ),
     };
   }
 

--- a/ayunis-core-backend/src/domain/runs/application/use-cases/execute-run/execute-run.use-case.ts
+++ b/ayunis-core-backend/src/domain/runs/application/use-cases/execute-run/execute-run.use-case.ts
@@ -170,15 +170,30 @@ export class ExecuteRunUseCase {
       );
     }
 
-    // Source query tool is available if there are sources in the thread
+    // Collect all sources from thread and agent
+    const allSources = [];
+    
+    // Add thread sources
     if (thread.sourceAssignments && thread.sourceAssignments.length > 0) {
+      allSources.push(
+        ...thread.sourceAssignments.map((assignment) => assignment.source),
+      );
+    }
+    
+    // Add agent sources
+    if (thread.agent && thread.agent.sourceAssignments && thread.agent.sourceAssignments.length > 0) {
+      allSources.push(
+        ...thread.agent.sourceAssignments.map((assignment) => assignment.source),
+      );
+    }
+
+    // Source query tool is available if there are any sources (from thread or agent)
+    if (allSources.length > 0) {
       tools.push(
         await this.assembleToolsUseCase.execute(
           new AssembleToolCommand({
             type: ToolType.SOURCE_QUERY,
-            context: thread.sourceAssignments.map(
-              (assignment) => assignment.source,
-            ),
+            context: allSources,
           }),
         ),
       );

--- a/ayunis-core-frontend/src/app/routeTree.gen.ts
+++ b/ayunis-core-frontend/src/app/routeTree.gen.ts
@@ -26,6 +26,7 @@ import { Route as AuthenticatedAdminSettingsIndexImport } from './routes/_authen
 import { Route as AuthenticatedSettingsGeneralImport } from './routes/_authenticated/settings.general'
 import { Route as AuthenticatedSettingsAccountImport } from './routes/_authenticated/settings.account'
 import { Route as AuthenticatedChatsThreadIdImport } from './routes/_authenticated/chats.$threadId'
+import { Route as AuthenticatedAgentsAgentIdImport } from './routes/_authenticated/agents.$agentId'
 import { Route as AuthenticatedAdminSettingsUsersImport } from './routes/_authenticated/admin-settings.users'
 import { Route as AuthenticatedAdminSettingsModelsImport } from './routes/_authenticated/admin-settings.models'
 import { Route as AuthenticatedAdminSettingsBillingImport } from './routes/_authenticated/admin-settings.billing'
@@ -126,6 +127,14 @@ const AuthenticatedChatsThreadIdRoute = AuthenticatedChatsThreadIdImport.update(
   {
     id: '/chats/$threadId',
     path: '/chats/$threadId',
+    getParentRoute: () => AuthenticatedRoute,
+  } as any,
+)
+
+const AuthenticatedAgentsAgentIdRoute = AuthenticatedAgentsAgentIdImport.update(
+  {
+    id: '/agents/$agentId',
+    path: '/agents/$agentId',
     getParentRoute: () => AuthenticatedRoute,
   } as any,
 )
@@ -251,6 +260,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedAdminSettingsUsersImport
       parentRoute: typeof AuthenticatedImport
     }
+    '/_authenticated/agents/$agentId': {
+      id: '/_authenticated/agents/$agentId'
+      path: '/agents/$agentId'
+      fullPath: '/agents/$agentId'
+      preLoaderRoute: typeof AuthenticatedAgentsAgentIdImport
+      parentRoute: typeof AuthenticatedImport
+    }
     '/_authenticated/chats/$threadId': {
       id: '/_authenticated/chats/$threadId'
       path: '/chats/$threadId'
@@ -316,6 +332,7 @@ interface AuthenticatedRouteChildren {
   AuthenticatedAdminSettingsBillingRoute: typeof AuthenticatedAdminSettingsBillingRoute
   AuthenticatedAdminSettingsModelsRoute: typeof AuthenticatedAdminSettingsModelsRoute
   AuthenticatedAdminSettingsUsersRoute: typeof AuthenticatedAdminSettingsUsersRoute
+  AuthenticatedAgentsAgentIdRoute: typeof AuthenticatedAgentsAgentIdRoute
   AuthenticatedChatsThreadIdRoute: typeof AuthenticatedChatsThreadIdRoute
   AuthenticatedSettingsAccountRoute: typeof AuthenticatedSettingsAccountRoute
   AuthenticatedSettingsGeneralRoute: typeof AuthenticatedSettingsGeneralRoute
@@ -331,6 +348,7 @@ const AuthenticatedRouteChildren: AuthenticatedRouteChildren = {
     AuthenticatedAdminSettingsBillingRoute,
   AuthenticatedAdminSettingsModelsRoute: AuthenticatedAdminSettingsModelsRoute,
   AuthenticatedAdminSettingsUsersRoute: AuthenticatedAdminSettingsUsersRoute,
+  AuthenticatedAgentsAgentIdRoute: AuthenticatedAgentsAgentIdRoute,
   AuthenticatedChatsThreadIdRoute: AuthenticatedChatsThreadIdRoute,
   AuthenticatedSettingsAccountRoute: AuthenticatedSettingsAccountRoute,
   AuthenticatedSettingsGeneralRoute: AuthenticatedSettingsGeneralRoute,
@@ -358,6 +376,7 @@ export interface FileRoutesByFullPath {
   '/admin-settings/billing': typeof AuthenticatedAdminSettingsBillingRoute
   '/admin-settings/models': typeof AuthenticatedAdminSettingsModelsRoute
   '/admin-settings/users': typeof AuthenticatedAdminSettingsUsersRoute
+  '/agents/$agentId': typeof AuthenticatedAgentsAgentIdRoute
   '/chats/$threadId': typeof AuthenticatedChatsThreadIdRoute
   '/settings/account': typeof AuthenticatedSettingsAccountRoute
   '/settings/general': typeof AuthenticatedSettingsGeneralRoute
@@ -381,6 +400,7 @@ export interface FileRoutesByTo {
   '/admin-settings/billing': typeof AuthenticatedAdminSettingsBillingRoute
   '/admin-settings/models': typeof AuthenticatedAdminSettingsModelsRoute
   '/admin-settings/users': typeof AuthenticatedAdminSettingsUsersRoute
+  '/agents/$agentId': typeof AuthenticatedAgentsAgentIdRoute
   '/chats/$threadId': typeof AuthenticatedChatsThreadIdRoute
   '/settings/account': typeof AuthenticatedSettingsAccountRoute
   '/settings/general': typeof AuthenticatedSettingsGeneralRoute
@@ -405,6 +425,7 @@ export interface FileRoutesById {
   '/_authenticated/admin-settings/billing': typeof AuthenticatedAdminSettingsBillingRoute
   '/_authenticated/admin-settings/models': typeof AuthenticatedAdminSettingsModelsRoute
   '/_authenticated/admin-settings/users': typeof AuthenticatedAdminSettingsUsersRoute
+  '/_authenticated/agents/$agentId': typeof AuthenticatedAgentsAgentIdRoute
   '/_authenticated/chats/$threadId': typeof AuthenticatedChatsThreadIdRoute
   '/_authenticated/settings/account': typeof AuthenticatedSettingsAccountRoute
   '/_authenticated/settings/general': typeof AuthenticatedSettingsGeneralRoute
@@ -430,6 +451,7 @@ export interface FileRouteTypes {
     | '/admin-settings/billing'
     | '/admin-settings/models'
     | '/admin-settings/users'
+    | '/agents/$agentId'
     | '/chats/$threadId'
     | '/settings/account'
     | '/settings/general'
@@ -452,6 +474,7 @@ export interface FileRouteTypes {
     | '/admin-settings/billing'
     | '/admin-settings/models'
     | '/admin-settings/users'
+    | '/agents/$agentId'
     | '/chats/$threadId'
     | '/settings/account'
     | '/settings/general'
@@ -474,6 +497,7 @@ export interface FileRouteTypes {
     | '/_authenticated/admin-settings/billing'
     | '/_authenticated/admin-settings/models'
     | '/_authenticated/admin-settings/users'
+    | '/_authenticated/agents/$agentId'
     | '/_authenticated/chats/$threadId'
     | '/_authenticated/settings/account'
     | '/_authenticated/settings/general'
@@ -539,6 +563,7 @@ export const routeTree = rootRoute
         "/_authenticated/admin-settings/billing",
         "/_authenticated/admin-settings/models",
         "/_authenticated/admin-settings/users",
+        "/_authenticated/agents/$agentId",
         "/_authenticated/chats/$threadId",
         "/_authenticated/settings/account",
         "/_authenticated/settings/general",
@@ -580,6 +605,10 @@ export const routeTree = rootRoute
     },
     "/_authenticated/admin-settings/users": {
       "filePath": "_authenticated/admin-settings.users.tsx",
+      "parent": "/_authenticated"
+    },
+    "/_authenticated/agents/$agentId": {
+      "filePath": "_authenticated/agents.$agentId.tsx",
       "parent": "/_authenticated"
     },
     "/_authenticated/chats/$threadId": {

--- a/ayunis-core-frontend/src/app/routes/_authenticated/agents.$agentId.tsx
+++ b/ayunis-core-frontend/src/app/routes/_authenticated/agents.$agentId.tsx
@@ -1,0 +1,32 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { queryOptions, useQuery } from "@tanstack/react-query";
+import { AgentDetailPage } from "@/pages/agents";
+import {
+  agentsControllerFindOne,
+  getAgentsControllerFindOneQueryKey,
+} from "@/shared/api/generated/ayunisCoreAPI";
+
+const agentDetailQueryOptions = (agentId: string) =>
+  queryOptions({
+    queryKey: getAgentsControllerFindOneQueryKey(agentId),
+    queryFn: () => agentsControllerFindOne(agentId),
+  });
+
+export const Route = createFileRoute("/_authenticated/agents/$agentId")({
+  component: RouteComponent,
+  loader: async ({ context: { queryClient }, params: { agentId } }) => {
+    const agent = await queryClient.fetchQuery(agentDetailQueryOptions(agentId));
+    return agent;
+  },
+});
+
+function RouteComponent() {
+  const { agentId } = Route.useParams();
+  const { data: agent } = useQuery(agentDetailQueryOptions(agentId));
+  
+  if (!agent) {
+    return <div>Agent not found</div>;
+  }
+
+  return <AgentDetailPage agent={agent} />;
+}

--- a/ayunis-core-frontend/src/pages/agents/api/useAddAgentSource.ts
+++ b/ayunis-core-frontend/src/pages/agents/api/useAddAgentSource.ts
@@ -1,0 +1,26 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { agentsControllerAddFileSource, getAgentsControllerGetAgentSourcesQueryKey } from "@/shared/api/generated/ayunisCoreAPI";
+import type { AgentsControllerAddFileSourceBody } from "@/shared/api/generated/ayunisCoreAPI.schemas";
+import { toast } from "sonner";
+import { useTranslation } from "react-i18next";
+
+export function useAddAgentSource() {
+  const { t } = useTranslation("agents");
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ id, data }: { id: string; data: AgentsControllerAddFileSourceBody }) => 
+      agentsControllerAddFileSource(id, data),
+    onSuccess: (_, variables) => {
+      toast.success(t("sources.addSuccess"));
+      // Invalidate agent sources query
+      queryClient.invalidateQueries({
+        queryKey: getAgentsControllerGetAgentSourcesQueryKey(variables.id),
+      });
+    },
+    onError: (error) => {
+      console.error("Failed to add source to agent:", error);
+      toast.error(t("sources.addError"));
+    },
+  });
+}

--- a/ayunis-core-frontend/src/pages/agents/api/useAgentSources.ts
+++ b/ayunis-core-frontend/src/pages/agents/api/useAgentSources.ts
@@ -1,0 +1,9 @@
+import { useAgentsControllerGetAgentSources } from "@/shared/api/generated/ayunisCoreAPI";
+
+export function useAgentSources(agentId: string) {
+  return useAgentsControllerGetAgentSources(agentId, {
+    query: {
+      enabled: !!agentId,
+    },
+  });
+}

--- a/ayunis-core-frontend/src/pages/agents/api/useRemoveAgentSource.ts
+++ b/ayunis-core-frontend/src/pages/agents/api/useRemoveAgentSource.ts
@@ -1,0 +1,25 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { agentsControllerRemoveSource, getAgentsControllerGetAgentSourcesQueryKey } from "@/shared/api/generated/ayunisCoreAPI";
+import { toast } from "sonner";
+import { useTranslation } from "react-i18next";
+
+export function useRemoveAgentSource() {
+  const { t } = useTranslation("agents");
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ id, sourceId }: { id: string; sourceId: string }) => 
+      agentsControllerRemoveSource(id, sourceId),
+    onSuccess: (_, variables) => {
+      toast.success(t("sources.removeSuccess"));
+      // Invalidate agent sources query
+      queryClient.invalidateQueries({
+        queryKey: getAgentsControllerGetAgentSourcesQueryKey(variables.id),
+      });
+    },
+    onError: (error) => {
+      console.error("Failed to remove source from agent:", error);
+      toast.error(t("sources.removeError"));
+    },
+  });
+}

--- a/ayunis-core-frontend/src/pages/agents/index.ts
+++ b/ayunis-core-frontend/src/pages/agents/index.ts
@@ -1,1 +1,2 @@
 export { default as AgentsPage } from "./ui/AgentsPage";
+export { default as AgentDetailPage } from "./ui/AgentDetailPage";

--- a/ayunis-core-frontend/src/pages/agents/ui/AddAgentSourceDialog.tsx
+++ b/ayunis-core-frontend/src/pages/agents/ui/AddAgentSourceDialog.tsx
@@ -1,0 +1,180 @@
+import { useState, useRef } from "react";
+import { Button } from "@/shared/ui/shadcn/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/shared/ui/shadcn/dialog";
+import { Input } from "@/shared/ui/shadcn/input";
+import { Label } from "@/shared/ui/shadcn/label";
+import { Upload, Plus } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { useAddAgentSource } from "../api/useAddAgentSource";
+
+interface AddAgentSourceDialogProps {
+  agentId: string;
+  trigger?: React.ReactNode;
+}
+
+export default function AddAgentSourceDialog({ agentId, trigger }: AddAgentSourceDialogProps) {
+  const { t } = useTranslation("agents");
+  const [open, setOpen] = useState(false);
+  const [selectedFile, setSelectedFile] = useState<File | null>(null);
+  const [dragActive, setDragActive] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const addSource = useAddAgentSource();
+
+  const handleDrag = (e: React.DragEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    if (e.type === "dragenter" || e.type === "dragover") {
+      setDragActive(true);
+    } else if (e.type === "dragleave") {
+      setDragActive(false);
+    }
+  };
+
+  const handleDrop = (e: React.DragEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setDragActive(false);
+    
+    const files = e.dataTransfer.files;
+    if (files && files[0]) {
+      setSelectedFile(files[0]);
+    }
+  };
+
+  const handleFileSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const files = e.target.files;
+    if (files && files[0]) {
+      setSelectedFile(files[0]);
+    }
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!selectedFile) return;
+
+    try {
+      await addSource.mutateAsync({
+        id: agentId,
+        data: {
+          file: selectedFile,
+          name: selectedFile.name,
+        },
+      });
+      setOpen(false);
+      setSelectedFile(null);
+      if (fileInputRef.current) {
+        fileInputRef.current.value = "";
+      }
+    } catch (error) {
+      // Error is handled in the mutation
+    }
+  };
+
+  const handleOpenChange = (newOpen: boolean) => {
+    setOpen(newOpen);
+    if (!newOpen) {
+      setSelectedFile(null);
+      if (fileInputRef.current) {
+        fileInputRef.current.value = "";
+      }
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogTrigger asChild>
+        {trigger || (
+          <Button>
+            <Plus className="h-4 w-4 mr-2" />
+            {t("sources.add")}
+          </Button>
+        )}
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>{t("sources.addDialog.title")}</DialogTitle>
+          <DialogDescription>
+            {t("sources.addDialog.description")}
+          </DialogDescription>
+        </DialogHeader>
+        <form onSubmit={handleSubmit}>
+          <div className="space-y-4">
+            <div
+              className={`border-2 border-dashed rounded-lg p-6 text-center transition-colors ${
+                dragActive
+                  ? "border-primary bg-primary/5"
+                  : "border-muted-foreground/25 hover:border-muted-foreground/50"
+              }`}
+              onDragEnter={handleDrag}
+              onDragLeave={handleDrag}
+              onDragOver={handleDrag}
+              onDrop={handleDrop}
+            >
+              <Upload className="h-10 w-10 mx-auto mb-4 text-muted-foreground" />
+              <div className="space-y-2">
+                <p className="text-sm font-medium">
+                  {selectedFile ? selectedFile.name : t("sources.addDialog.dropzone.title")}
+                </p>
+                <p className="text-xs text-muted-foreground">
+                  {t("sources.addDialog.dropzone.subtitle")}
+                </p>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={() => fileInputRef.current?.click()}
+                >
+                  {t("sources.addDialog.selectFile")}
+                </Button>
+              </div>
+            </div>
+            
+            <Input
+              ref={fileInputRef}
+              type="file"
+              onChange={handleFileSelect}
+              className="hidden"
+              accept=".pdf,.doc,.docx,.txt,.md,.csv,.json,.xml"
+            />
+
+            {selectedFile && (
+              <div className="space-y-2">
+                <Label htmlFor="fileName">{t("sources.addDialog.fileName")}</Label>
+                <Input
+                  id="fileName"
+                  value={selectedFile.name}
+                  readOnly
+                  className="bg-muted"
+                />
+              </div>
+            )}
+          </div>
+
+          <DialogFooter className="mt-6">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => handleOpenChange(false)}
+            >
+              {t("common.cancel")}
+            </Button>
+            <Button
+              type="submit"
+              disabled={!selectedFile || addSource.isPending}
+            >
+              {addSource.isPending ? t("common.uploading") : t("sources.addDialog.upload")}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/ayunis-core-frontend/src/pages/agents/ui/AgentCard.tsx
+++ b/ayunis-core-frontend/src/pages/agents/ui/AgentCard.tsx
@@ -7,7 +7,7 @@ import {
   CardFooter,
 } from "@/shared/ui/shadcn/card";
 import { Button } from "@/shared/ui/shadcn/button";
-import { Edit, MessageCircle, Trash2 } from "lucide-react";
+import { Edit, MessageCircle, Trash2, Settings } from "lucide-react";
 import EditAgentDialog from "./EditAgentDialog";
 import { useDeleteAgent } from "../api/useDeleteAgent";
 import { useConfirmation } from "@/widgets/confirmation-modal";
@@ -44,6 +44,11 @@ export default function AgentCard({ agent }: AgentCardProps) {
         <CardTitle className="text-lg">{agent.name}</CardTitle>
         <CardAction>
           <div className="flex items-center gap-2">
+            <Link to="/agents/$agentId" params={{ agentId: agent.id }}>
+              <Button variant="ghost" size="icon" title="View Details">
+                <Settings className="h-4 w-4" />
+              </Button>
+            </Link>
             <Link to="/chat" search={{ agentId: agent.id }}>
               <Button variant="ghost">
                 <MessageCircle className="h-4 w-4" />{" "}
@@ -72,14 +77,21 @@ export default function AgentCard({ agent }: AgentCardProps) {
       <CardContent>
         <p className="line-clamp-2">{agent.instructions}</p>
       </CardContent>
-      {agent.tools.length > 0 && (
+      {(agent.tools.length > 0 || agent.sources.length > 0) && (
         <CardFooter>
           <div className="flex flex-col gap-2">
-            {agent.tools.map((tool) => (
-              <Badge key={tool.type} variant="outline">
-                {tool.type}
-              </Badge>
-            ))}
+            <div className="flex flex-wrap gap-2">
+              {agent.tools.map((tool) => (
+                <Badge key={tool.type} variant="outline">
+                  {tool.type}
+                </Badge>
+              ))}
+              {agent.sources.length > 0 && (
+                <Badge variant="secondary">
+                  {agent.sources.length} {agent.sources.length === 1 ? 'source' : 'sources'}
+                </Badge>
+              )}
+            </div>
           </div>
         </CardFooter>
       )}

--- a/ayunis-core-frontend/src/pages/agents/ui/AgentDetailPage.tsx
+++ b/ayunis-core-frontend/src/pages/agents/ui/AgentDetailPage.tsx
@@ -1,0 +1,112 @@
+import AppLayout from "@/layouts/app-layout";
+import ContentAreaLayout from "@/layouts/content-area-layout/ui/ContentAreaLayout";
+import ContentAreaHeader from "@/widgets/content-area-header/ui/ContentAreaHeader";
+import { Button } from "@/shared/ui/shadcn/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/shared/ui/shadcn/card";
+import { Badge } from "@/shared/ui/shadcn/badge";
+import { ArrowLeft, Edit, MessageCircle, Settings } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { Link } from "@tanstack/react-router";
+import type { Agent } from "../model/openapi";
+import EditAgentDialog from "./EditAgentDialog";
+import AgentSourcesSection from "./AgentSourcesSection";
+
+interface AgentDetailPageProps {
+  agent: Agent;
+}
+
+export default function AgentDetailPage({ agent }: AgentDetailPageProps) {
+  const { t } = useTranslation("agents");
+
+  return (
+    <AppLayout>
+      <ContentAreaLayout
+        contentHeader={
+          <ContentAreaHeader
+            title={
+              <div className="flex items-center gap-3">
+                <Link to="/agents">
+                  <Button variant="ghost" size="icon">
+                    <ArrowLeft className="h-4 w-4" />
+                  </Button>
+                </Link>
+                <div>
+                  <h1 className="text-2xl font-bold">{agent.name}</h1>
+                  <p className="text-sm text-muted-foreground">Agent Details</p>
+                </div>
+              </div>
+            }
+            action={
+              <div className="flex items-center gap-2">
+                <Link to="/chat" search={{ agentId: agent.id }}>
+                  <Button>
+                    <MessageCircle className="h-4 w-4 mr-2" />
+                    {t("card.startChatButton")}
+                  </Button>
+                </Link>
+                <EditAgentDialog
+                  selectedAgent={agent}
+                  trigger={
+                    <Button variant="outline">
+                      <Edit className="h-4 w-4 mr-2" />
+                      Edit
+                    </Button>
+                  }
+                />
+              </div>
+            }
+          />
+        }
+        contentArea={
+          <div className="space-y-6">
+            {/* Agent Overview */}
+            <Card>
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2">
+                  <Settings className="h-5 w-5" />
+                  Overview
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <div>
+                  <h3 className="font-medium mb-2">Instructions</h3>
+                  <p className="text-sm text-muted-foreground leading-relaxed">
+                    {agent.instructions}
+                  </p>
+                </div>
+                
+                <div>
+                  <h3 className="font-medium mb-2">Model</h3>
+                  <Badge variant="outline">
+                    {agent.model.displayName} ({agent.model.provider})
+                  </Badge>
+                </div>
+
+                {agent.tools.length > 0 && (
+                  <div>
+                    <h3 className="font-medium mb-2">Tools</h3>
+                    <div className="flex flex-wrap gap-2">
+                      {agent.tools.map((tool) => (
+                        <Badge key={tool.type} variant="secondary">
+                          {tool.type}
+                        </Badge>
+                      ))}
+                    </div>
+                  </div>
+                )}
+
+                <div className="text-xs text-muted-foreground pt-2 border-t">
+                  <p>Created: {new Date(agent.createdAt).toLocaleDateString()}</p>
+                  <p>Updated: {new Date(agent.updatedAt).toLocaleDateString()}</p>
+                </div>
+              </CardContent>
+            </Card>
+
+            {/* Agent Sources */}
+            <AgentSourcesSection agentId={agent.id} />
+          </div>
+        }
+      />
+    </AppLayout>
+  );
+}

--- a/ayunis-core-frontend/src/pages/agents/ui/AgentSourcesList.tsx
+++ b/ayunis-core-frontend/src/pages/agents/ui/AgentSourcesList.tsx
@@ -1,0 +1,74 @@
+import { Badge } from "@/shared/ui/shadcn/badge";
+import { Button } from "@/shared/ui/shadcn/button";
+import { Trash2, FileText } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { useConfirmation } from "@/widgets/confirmation-modal";
+import { useRemoveAgentSource } from "../api/useRemoveAgentSource";
+import type { SourceResponseDto } from "@/shared/api/generated/ayunisCoreAPI.schemas";
+
+interface AgentSourcesListProps {
+  agentId: string;
+  sources: SourceResponseDto[];
+}
+
+export default function AgentSourcesList({ agentId, sources }: AgentSourcesListProps) {
+  const { t } = useTranslation("agents");
+  const { confirm } = useConfirmation();
+  const removeSource = useRemoveAgentSource();
+
+  const handleRemoveSource = (source: SourceResponseDto) => {
+    confirm({
+      title: t("sources.confirmRemove.title"),
+      description: t("sources.confirmRemove.description", { name: source.name }),
+      confirmText: t("sources.confirmRemove.confirmText"),
+      cancelText: t("sources.confirmRemove.cancelText"),
+      variant: "destructive",
+      onConfirm: () => {
+        removeSource.mutate({ id: agentId, sourceId: source.id });
+      },
+    });
+  };
+
+  if (sources.length === 0) {
+    return (
+      <div className="text-center py-8 text-muted-foreground">
+        <FileText className="h-12 w-12 mx-auto mb-4 opacity-50" />
+        <p>{t("sources.empty")}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {sources.map((source) => (
+        <div
+          key={source.id}
+          className="flex items-center justify-between p-3 border rounded-lg hover:bg-muted/50"
+        >
+          <div className="flex items-center gap-3 flex-1 min-w-0">
+            <FileText className="h-5 w-5 text-muted-foreground flex-shrink-0" />
+            <div className="flex-1 min-w-0">
+              <p className="font-medium truncate">{source.name}</p>
+              <div className="flex items-center gap-2 mt-1">
+                <Badge variant="secondary" className="text-xs">
+                  {source.type}
+                </Badge>
+              </div>
+            </div>
+          </div>
+          <div className="flex items-center gap-2">
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={() => handleRemoveSource(source)}
+              disabled={removeSource.isPending}
+              title={t("sources.remove")}
+            >
+              <Trash2 className="h-4 w-4" />
+            </Button>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/ayunis-core-frontend/src/pages/agents/ui/AgentSourcesSection.tsx
+++ b/ayunis-core-frontend/src/pages/agents/ui/AgentSourcesSection.tsx
@@ -1,0 +1,69 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/shared/ui/shadcn/card";
+import { Skeleton } from "@/shared/ui/shadcn/skeleton";
+import { FileText } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { useAgentSources } from "../api/useAgentSources";
+import AgentSourcesList from "./AgentSourcesList";
+import AddAgentSourceDialog from "./AddAgentSourceDialog";
+
+interface AgentSourcesSectionProps {
+  agentId: string;
+}
+
+export default function AgentSourcesSection({ agentId }: AgentSourcesSectionProps) {
+  const { t } = useTranslation("agents");
+  const { data: sources, isLoading, error } = useAgentSources(agentId);
+
+  if (error) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <FileText className="h-5 w-5" />
+            {t("sources.title")}
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="text-center py-8 text-destructive">
+            <p>{t("sources.loadError")}</p>
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-4">
+        <CardTitle className="flex items-center gap-2">
+          <FileText className="h-5 w-5" />
+          {t("sources.title")}
+          {sources && sources.length > 0 && (
+            <span className="text-sm font-normal text-muted-foreground">
+              ({sources.length})
+            </span>
+          )}
+        </CardTitle>
+        <AddAgentSourceDialog agentId={agentId} />
+      </CardHeader>
+      <CardContent>
+        {isLoading ? (
+          <div className="space-y-3">
+            {[...Array(3)].map((_, i) => (
+              <div key={i} className="flex items-center gap-3 p-3">
+                <Skeleton className="h-5 w-5" />
+                <div className="flex-1">
+                  <Skeleton className="h-4 w-32 mb-2" />
+                  <Skeleton className="h-3 w-16" />
+                </div>
+                <Skeleton className="h-8 w-8" />
+              </div>
+            ))}
+          </div>
+        ) : (
+          <AgentSourcesList agentId={agentId} sources={sources || []} />
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
@@ -748,6 +748,8 @@ export interface AgentResponseDto {
   model: ModelResponseDto;
   /** The tools assigned to this agent */
   tools: ToolResponseDto[];
+  /** The sources assigned to this agent */
+  sources: SourceResponseDto[];
 }
 
 export interface UpdateAgentDto {
@@ -1275,6 +1277,15 @@ export interface UpdateLanguageModelDto { [key: string]: unknown }
 export interface UpdateEmbeddingModelDto { [key: string]: unknown }
 
 export type ThreadsControllerAddFileSourceBody = {
+  /** The file to upload */
+  file: Blob;
+  /** The display name for the file source */
+  name?: string;
+  /** A description of the file source */
+  description?: string;
+};
+
+export type AgentsControllerAddFileSourceBody = {
   /** The file to upload */
   file: Blob;
   /** The display name for the file source */

--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.ts
@@ -30,6 +30,7 @@ import type {
   ActiveSubscriptionResponseDto,
   AdminControllerGetModelParams,
   AgentResponseDto,
+  AgentsControllerAddFileSourceBody,
   ConfirmEmailDto,
   CreateAgentDto,
   CreateEmbeddingModelDto,
@@ -3059,6 +3060,231 @@ export const useAgentsControllerDelete = <TError = void,
       > => {
 
       const mutationOptions = getAgentsControllerDeleteMutationOptions(options);
+
+      return useMutation(mutationOptions , queryClient);
+    }
+    
+/**
+ * @summary Get all sources for an agent
+ */
+export const agentsControllerGetAgentSources = (
+    id: string,
+ signal?: AbortSignal
+) => {
+      
+      
+      return customAxiosInstance<SourceResponseDto[]>(
+      {url: `/agents/${id}/sources`, method: 'GET', signal
+    },
+      );
+    }
+  
+
+export const getAgentsControllerGetAgentSourcesQueryKey = (id: string,) => {
+    return [`/agents/${id}/sources`] as const;
+    }
+
+    
+export const getAgentsControllerGetAgentSourcesQueryOptions = <TData = Awaited<ReturnType<typeof agentsControllerGetAgentSources>>, TError = void>(id: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof agentsControllerGetAgentSources>>, TError, TData>>, }
+) => {
+
+const {query: queryOptions} = options ?? {};
+
+  const queryKey =  queryOptions?.queryKey ?? getAgentsControllerGetAgentSourcesQueryKey(id);
+
+  
+
+    const queryFn: QueryFunction<Awaited<ReturnType<typeof agentsControllerGetAgentSources>>> = ({ signal }) => agentsControllerGetAgentSources(id, signal);
+
+      
+
+      
+
+   return  { queryKey, queryFn, enabled: !!(id), ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof agentsControllerGetAgentSources>>, TError, TData> & { queryKey: DataTag<QueryKey, TData, TError> }
+}
+
+export type AgentsControllerGetAgentSourcesQueryResult = NonNullable<Awaited<ReturnType<typeof agentsControllerGetAgentSources>>>
+export type AgentsControllerGetAgentSourcesQueryError = void
+
+
+export function useAgentsControllerGetAgentSources<TData = Awaited<ReturnType<typeof agentsControllerGetAgentSources>>, TError = void>(
+ id: string, options: { query:Partial<UseQueryOptions<Awaited<ReturnType<typeof agentsControllerGetAgentSources>>, TError, TData>> & Pick<
+        DefinedInitialDataOptions<
+          Awaited<ReturnType<typeof agentsControllerGetAgentSources>>,
+          TError,
+          Awaited<ReturnType<typeof agentsControllerGetAgentSources>>
+        > , 'initialData'
+      >, }
+ , queryClient?: QueryClient
+  ):  DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useAgentsControllerGetAgentSources<TData = Awaited<ReturnType<typeof agentsControllerGetAgentSources>>, TError = void>(
+ id: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof agentsControllerGetAgentSources>>, TError, TData>> & Pick<
+        UndefinedInitialDataOptions<
+          Awaited<ReturnType<typeof agentsControllerGetAgentSources>>,
+          TError,
+          Awaited<ReturnType<typeof agentsControllerGetAgentSources>>
+        > , 'initialData'
+      >, }
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useAgentsControllerGetAgentSources<TData = Awaited<ReturnType<typeof agentsControllerGetAgentSources>>, TError = void>(
+ id: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof agentsControllerGetAgentSources>>, TError, TData>>, }
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+/**
+ * @summary Get all sources for an agent
+ */
+
+export function useAgentsControllerGetAgentSources<TData = Awaited<ReturnType<typeof agentsControllerGetAgentSources>>, TError = void>(
+ id: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof agentsControllerGetAgentSources>>, TError, TData>>, }
+ , queryClient?: QueryClient 
+ ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
+
+  const queryOptions = getAgentsControllerGetAgentSourcesQueryOptions(id,options)
+
+  const query = useQuery(queryOptions , queryClient) as  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+
+  query.queryKey = queryOptions.queryKey ;
+
+  return query;
+}
+
+
+
+
+/**
+ * @summary Add a file source to an agent
+ */
+export const agentsControllerAddFileSource = (
+    id: string,
+    agentsControllerAddFileSourceBody: AgentsControllerAddFileSourceBody,
+ signal?: AbortSignal
+) => {
+      
+      const formData = new FormData();
+formData.append(`file`, agentsControllerAddFileSourceBody.file)
+if(agentsControllerAddFileSourceBody.name !== undefined) {
+ formData.append(`name`, agentsControllerAddFileSourceBody.name)
+ }
+if(agentsControllerAddFileSourceBody.description !== undefined) {
+ formData.append(`description`, agentsControllerAddFileSourceBody.description)
+ }
+
+      return customAxiosInstance<void>(
+      {url: `/agents/${id}/sources/file`, method: 'POST',
+      headers: {'Content-Type': 'multipart/form-data', },
+       data: formData, signal
+    },
+      );
+    }
+  
+
+
+export const getAgentsControllerAddFileSourceMutationOptions = <TError = unknown,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof agentsControllerAddFileSource>>, TError,{id: string;data: AgentsControllerAddFileSourceBody}, TContext>, }
+): UseMutationOptions<Awaited<ReturnType<typeof agentsControllerAddFileSource>>, TError,{id: string;data: AgentsControllerAddFileSourceBody}, TContext> => {
+
+const mutationKey = ['agentsControllerAddFileSource'];
+const {mutation: mutationOptions} = options ?
+      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
+      options
+      : {...options, mutation: {...options.mutation, mutationKey}}
+      : {mutation: { mutationKey, }};
+
+      
+
+
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof agentsControllerAddFileSource>>, {id: string;data: AgentsControllerAddFileSourceBody}> = (props) => {
+          const {id,data} = props ?? {};
+
+          return  agentsControllerAddFileSource(id,data,)
+        }
+
+        
+
+
+  return  { mutationFn, ...mutationOptions }}
+
+    export type AgentsControllerAddFileSourceMutationResult = NonNullable<Awaited<ReturnType<typeof agentsControllerAddFileSource>>>
+    export type AgentsControllerAddFileSourceMutationBody = AgentsControllerAddFileSourceBody
+    export type AgentsControllerAddFileSourceMutationError = unknown
+
+    /**
+ * @summary Add a file source to an agent
+ */
+export const useAgentsControllerAddFileSource = <TError = unknown,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof agentsControllerAddFileSource>>, TError,{id: string;data: AgentsControllerAddFileSourceBody}, TContext>, }
+ , queryClient?: QueryClient): UseMutationResult<
+        Awaited<ReturnType<typeof agentsControllerAddFileSource>>,
+        TError,
+        {id: string;data: AgentsControllerAddFileSourceBody},
+        TContext
+      > => {
+
+      const mutationOptions = getAgentsControllerAddFileSourceMutationOptions(options);
+
+      return useMutation(mutationOptions , queryClient);
+    }
+    
+/**
+ * @summary Remove a source from an agent
+ */
+export const agentsControllerRemoveSource = (
+    id: string,
+    sourceId: string,
+ ) => {
+      
+      
+      return customAxiosInstance<void>(
+      {url: `/agents/${id}/sources/${sourceId}`, method: 'DELETE'
+    },
+      );
+    }
+  
+
+
+export const getAgentsControllerRemoveSourceMutationOptions = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof agentsControllerRemoveSource>>, TError,{id: string;sourceId: string}, TContext>, }
+): UseMutationOptions<Awaited<ReturnType<typeof agentsControllerRemoveSource>>, TError,{id: string;sourceId: string}, TContext> => {
+
+const mutationKey = ['agentsControllerRemoveSource'];
+const {mutation: mutationOptions} = options ?
+      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
+      options
+      : {...options, mutation: {...options.mutation, mutationKey}}
+      : {mutation: { mutationKey, }};
+
+      
+
+
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof agentsControllerRemoveSource>>, {id: string;sourceId: string}> = (props) => {
+          const {id,sourceId} = props ?? {};
+
+          return  agentsControllerRemoveSource(id,sourceId,)
+        }
+
+        
+
+
+  return  { mutationFn, ...mutationOptions }}
+
+    export type AgentsControllerRemoveSourceMutationResult = NonNullable<Awaited<ReturnType<typeof agentsControllerRemoveSource>>>
+    
+    export type AgentsControllerRemoveSourceMutationError = void
+
+    /**
+ * @summary Remove a source from an agent
+ */
+export const useAgentsControllerRemoveSource = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof agentsControllerRemoveSource>>, TError,{id: string;sourceId: string}, TContext>, }
+ , queryClient?: QueryClient): UseMutationResult<
+        Awaited<ReturnType<typeof agentsControllerRemoveSource>>,
+        TError,
+        {id: string;sourceId: string},
+        TContext
+      > => {
+
+      const mutationOptions = getAgentsControllerRemoveSourceMutationOptions(options);
 
       return useMutation(mutationOptions , queryClient);
     }

--- a/ayunis-core-frontend/src/shared/api/openapi-schema.json.backup
+++ b/ayunis-core-frontend/src/shared/api/openapi-schema.json.backup
@@ -1394,139 +1394,6 @@
         ]
       }
     },
-    "/agents/{id}/sources": {
-      "get": {
-        "operationId": "AgentsController_getAgentSources",
-        "parameters": [
-          {
-            "name": "id",
-            "required": true,
-            "in": "path",
-            "description": "The UUID of the agent",
-            "schema": {
-              "format": "uuid",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Returns all sources for the agent",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/SourceResponseDto"
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Agent not found"
-          },
-          "500": {
-            "description": "Internal server error"
-          }
-        },
-        "summary": "Get all sources for an agent",
-        "tags": [
-          "agents"
-        ]
-      }
-    },
-    "/agents/{id}/sources/file": {
-      "post": {
-        "operationId": "AgentsController_addFileSource",
-        "parameters": [
-          {
-            "name": "id",
-            "required": true,
-            "in": "path",
-            "description": "The UUID of the agent",
-            "schema": {
-              "format": "uuid",
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "multipart/form-data": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "file": {
-                    "type": "string",
-                    "format": "binary",
-                    "description": "The file to upload"
-                  },
-                  "name": {
-                    "type": "string",
-                    "description": "The display name for the file source"
-                  },
-                  "description": {
-                    "type": "string",
-                    "description": "A description of the file source"
-                  }
-                },
-                "required": ["file"]
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "The file source has been successfully added to the agent"
-          }
-        },
-        "summary": "Add a file source to an agent",
-        "tags": [
-          "agents"
-        ]
-      }
-    },
-    "/agents/{id}/sources/{sourceId}": {
-      "delete": {
-        "operationId": "AgentsController_removeSource",
-        "parameters": [
-          {
-            "name": "id",
-            "required": true,
-            "in": "path",
-            "description": "The UUID of the agent",
-            "schema": {
-              "format": "uuid",
-              "type": "string"
-            }
-          },
-          {
-            "name": "sourceId",
-            "required": true,
-            "in": "path",
-            "description": "The UUID of the source to remove",
-            "schema": {
-              "format": "uuid",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "The source has been successfully removed from the agent"
-          },
-          "404": {
-            "description": "Agent or source not found"
-          }
-        },
-        "summary": "Remove a source from an agent",
-        "tags": [
-          "agents"
-        ]
-      }
-    },
     "/retrievers/url": {
       "post": {
         "operationId": "UrlRetrieverController_retrieveUrl",
@@ -4045,13 +3912,6 @@
             "items": {
               "$ref": "#/components/schemas/ToolResponseDto"
             }
-          },
-          "sources": {
-            "description": "The sources assigned to this agent",
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/SourceResponseDto"
-            }
           }
         },
         "required": [
@@ -4062,8 +3922,7 @@
           "createdAt",
           "updatedAt",
           "model",
-          "tools",
-          "sources"
+          "tools"
         ]
       },
       "UpdateAgentDto": {

--- a/ayunis-core-frontend/src/shared/locales/en/agents.json
+++ b/ayunis-core-frontend/src/shared/locales/en/agents.json
@@ -84,5 +84,34 @@
   "delete": {
     "success": "Agent deleted successfully!",
     "error": "Failed to delete agent. Please try again."
+  },
+  "sources": {
+    "title": "Knowledge Sources",
+    "add": "Add Source",
+    "empty": "No sources added yet. Upload files to give your agent access to specific knowledge.",
+    "remove": "Remove source",
+    "openExternal": "Open external link",
+    "loadError": "Failed to load sources. Please try again.",
+    "addSuccess": "Source added successfully!",
+    "addError": "Failed to add source. Please try again.",
+    "removeSuccess": "Source removed successfully!",
+    "removeError": "Failed to remove source. Please try again.",
+    "confirmRemove": {
+      "title": "Remove Source",
+      "description": "Are you sure you want to remove \"{{name}}\"? This action cannot be undone.",
+      "confirmText": "Remove",
+      "cancelText": "Cancel"
+    },
+    "addDialog": {
+      "title": "Add Knowledge Source",
+      "description": "Upload a file to give your agent access to specific knowledge and information.",
+      "fileName": "File Name",
+      "selectFile": "Select File",
+      "upload": "Upload",
+      "dropzone": {
+        "title": "Drop your file here, or click to select",
+        "subtitle": "Supports PDF, DOC, TXT, MD, CSV, JSON, XML files"
+      }
+    }
   }
 }

--- a/ayunis-core-frontend/src/shared/locales/en/common.json
+++ b/ayunis-core-frontend/src/shared/locales/en/common.json
@@ -33,6 +33,8 @@
     "noEmbeddingModelEnabled": "To upload documents, an embedding model must be enabled."
   },
   "common": {
-    "loading": "Loading..."
+    "loading": "Loading...",
+    "cancel": "Cancel",
+    "uploading": "Uploading..."
   }
 }


### PR DESCRIPTION
Implement agent sources to allow users to upload files directly to agents, making them automatically available via the `SOURCE_QUERY` tool in all agent-led conversations.

---
[Slack Thread](https://locaboo.slack.com/archives/C09BRN24D99/p1756126809797399?thread_ts=1756126809.797399&cid=C09BRN24D99)

<a href="https://cursor.com/background-agent?bcId=bc-be0f2a7b-fa89-4111-bd55-66bd6109e1b7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-be0f2a7b-fa89-4111-bd55-66bd6109e1b7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

