### PR TITLE
Handle missing subscription in invite creation

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -50,8 +50,8 @@ RUN npm ci --only=production && npm rebuild bcrypt --build-from-source
 # Copy built backend from builder stage
 COPY --from=backend-builder /app/dist ./dist
 
-# Copy frontend files from builder stage
-COPY --from=backend-builder /app/frontend ./frontend
+# Copy frontend files from builder stage into dist/frontend
+COPY --from=backend-builder /app/frontend ./dist/frontend
 
 # Create uploads directory
 RUN mkdir -p uploads

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -68,4 +68,4 @@ HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
   CMD node -e "require('http').get('http://localhost:3000/health', (res) => { process.exit(res.statusCode === 200 ? 0 : 1) })" || exit 1
 
 # Start the application
-CMD ["node", "dist/main.js"] 
+CMD ["node", "dist/src/main.js"] 

--- a/ayunis-core-backend/package.json
+++ b/ayunis-core-backend/package.json
@@ -11,7 +11,7 @@
     "start": "nest start",
     "start:dev": "nest start --watch",
     "start:debug": "nest start --debug --watch",
-    "start:prod": "node dist/main",
+    "start:prod": "node dist/src/main",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
     "test": "jest",
     "test:watch": "jest --watch",
@@ -36,7 +36,7 @@
     "bundle-frontend": "bash scripts/bundle-frontend.sh",
     "generate:client": "orval --config ./orval.config.ts",
     "cli:ts": "ts-node -r tsconfig-paths/register -r dotenv/config src/cli/main.ts",
-    "cli": "node dist/cli/main.js",
+    "cli": "node dist/src/cli/main.js",
     "seed:ts": "npm run cli:ts -- seed:minimal",
     "seed": "npm run cli -- seed:minimal"
   },

--- a/ayunis-core-backend/src/iam/invites/application/use-cases/create-invite/create-invite.use-case.ts
+++ b/ayunis-core-backend/src/iam/invites/application/use-cases/create-invite/create-invite.use-case.ts
@@ -67,7 +67,7 @@ export class CreateInviteUseCase {
       if (isCloud) {
         let subscription: Awaited<
           ReturnType<GetActiveSubscriptionUseCase['execute']>
-        > = null;
+        > | null = null;
 
         try {
           subscription = await this.getActiveSubscriptionUseCase.execute(

--- a/ayunis-core-backend/src/iam/subscriptions/application/use-cases/get-active-subscription/get-active-subscription.use-case.ts
+++ b/ayunis-core-backend/src/iam/subscriptions/application/use-cases/get-active-subscription/get-active-subscription.use-case.ts
@@ -34,7 +34,7 @@ export class GetActiveSubscriptionUseCase {
     subscription: Subscription;
     availableSeats: number;
     nextRenewalDate: Date;
-  } | null> {
+  }> {
     this.logger.log('Getting subscription', {
       orgId: query.orgId,
       requestingUserId: query.requestingUserId,

--- a/ayunis-core-e2e-ui-tests/cypress/pages/components/models-dropdown.component.ts
+++ b/ayunis-core-e2e-ui-tests/cypress/pages/components/models-dropdown.component.ts
@@ -1,10 +1,10 @@
 import { BaseComponent } from '@pages/components/base.component';
 
 class ModelsDropdown extends BaseComponent {
-	rootLocator = `div[data-slot="select-group"]`;
+	rootLocator = `div[data-slot="select-content"]`;
 
 	get options() {
-		return cy.get(`${this.rootLocator} div[role="option"]`);
+		return cy.get(`${this.rootLocator} div[data-slot="select-item"]`);
 	}
 }
 


### PR DESCRIPTION
This pull request contains changes generated by a Cursor Cloud Agent

<a href="https://cursor.com/background-agent?bcId=bc-4704481e-92b9-4785-b5cd-9be7a64a4951"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4704481e-92b9-4785-b5cd-9be7a64a4951"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Allow invite creation without an active subscription, update subscription use-case contract, align build/runtime paths to `dist/src`, and fix e2e dropdown selectors.
> 
> - **Backend**:
>   - **Invites**: `CreateInviteUseCase` now proceeds when `SubscriptionNotFoundError` is thrown (catches error), with corresponding unit test added.
>   - **Subscriptions**: `GetActiveSubscriptionUseCase.execute` no longer returns `null`; it throws `SubscriptionNotFoundError` and updates the return type accordingly.
>   - **Build/Runtime Paths**: Adjusted paths to built artifacts:
>     - `package.json` `start:prod` and `cli` now run `node dist/src/...`.
>     - `Dockerfile.test` copies frontend to `dist/frontend` and starts app with `dist/src/main.js`.
> - **E2E/UI Tests**:
>   - Updated model dropdown selectors in `cypress/pages/components/models-dropdown.component.ts` to new `data-slot` attributes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5af5720298df74c1bec52389e935e96655f44f02. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->