### PR TITLE
feat: add chat input help

### DIFF
--- a/ayunis-core-frontend/src/i18n.ts
+++ b/ayunis-core-frontend/src/i18n.ts
@@ -33,6 +33,8 @@ import enAgents from './shared/locales/en/agents.json';
 import deAgents from './shared/locales/de/agents.json';
 import enAgent from './shared/locales/en/agent.json';
 import deAgent from './shared/locales/de/agent.json';
+import enQuickActions from './shared/locales/en/quickActions.json';
+import deQuickActions from './shared/locales/de/quickActions.json';
 
 const resources = {
   en: {
@@ -51,6 +53,7 @@ const resources = {
     prompts: enPrompts,
     agents: enAgents,
     agent: enAgent,
+    quickActions: enQuickActions,
   },
   de: {
     auth: deAuth,
@@ -68,6 +71,7 @@ const resources = {
     prompts: dePrompts,
     agents: deAgents,
     agent: deAgent,
+    quickActions: deQuickActions,
   },
 };
 

--- a/ayunis-core-frontend/src/pages/new-chat/model/quickActionsData.ts
+++ b/ayunis-core-frontend/src/pages/new-chat/model/quickActionsData.ts
@@ -2,7 +2,7 @@ import { Pencil, Search, FileText, Eye, type LucideIcon } from 'lucide-react';
 
 export interface QuickActionPrompt {
   labelKey: string;
-  content: string;
+  contentKey: string;
 }
 
 export interface QuickActionCategory {
@@ -20,23 +20,19 @@ export const QUICK_ACTIONS: QuickActionCategory[] = [
     prompts: [
       {
         labelKey: 'prompts.writing.draftDocument',
-        content:
-          'Könntest du mir helfen, ein offizielles Schreiben zu verfassen? Falls du weitere Informationen von mir brauchst, stelle mir direkt 1-2 wichtige Fragen. Wenn du meinst, dass ich Dokumente hochladen sollte, die dir bei der Aufgabe helfen würden, lass es mich wissen.',
+        contentKey: 'prompts.writing.draftDocumentContent',
       },
       {
         labelKey: 'prompts.writing.createDraft',
-        content:
-          'Ich brauche einen Entwurf für ein Dokument. Falls du weitere Informationen von mir brauchst, stelle mir direkt 1-2 wichtige Fragen. Bitte führe die Aufgabe so bald wie möglich aus.',
+        contentKey: 'prompts.writing.createDraftContent',
       },
       {
         labelKey: 'prompts.writing.formulateResponse',
-        content:
-          'Könntest du mir helfen, eine Antwort zu formulieren? Falls du weitere Informationen von mir brauchst, stelle mir direkt 1-2 wichtige Fragen. Wenn du meinst, dass ich Dokumente hochladen sollte (z.B. die ursprüngliche Nachricht), lass es mich wissen.',
+        contentKey: 'prompts.writing.formulateResponseContent',
       },
       {
         labelKey: 'prompts.writing.writeText',
-        content:
-          'Ich möchte einen Text schreiben. Falls du weitere Informationen von mir brauchst (Thema, Zielgruppe, Länge), stelle mir direkt 1-2 wichtige Fragen. Bitte führe die Aufgabe so bald wie möglich aus.',
+        contentKey: 'prompts.writing.writeTextContent',
       },
     ],
   },
@@ -47,23 +43,19 @@ export const QUICK_ACTIONS: QuickActionCategory[] = [
     prompts: [
       {
         labelKey: 'prompts.research.explainBasics',
-        content:
-          'Könntest du mir die Grundlagen zu einem Thema erklären? Falls du weitere Informationen von mir brauchst, stelle mir direkt 1-2 wichtige Fragen. Eine visuelle oder strukturierte Darstellung wäre toll, falls es sinnvoll ist.',
+        contentKey: 'prompts.research.explainBasicsContent',
       },
       {
         labelKey: 'prompts.research.whatToConsider',
-        content:
-          'Ich möchte wissen, was ich bei einem bestimmten Thema beachten muss. Falls du weitere Informationen von mir brauchst, stelle mir direkt 1-2 wichtige Fragen. Überlege bei der Erstellung einer Darstellung, welche Art (Checkliste, Übersicht usw.) für diese Aufgabe am hilfreichsten sein könnte.',
+        contentKey: 'prompts.research.whatToConsiderContent',
       },
       {
         labelKey: 'prompts.research.findInformation',
-        content:
-          'Ich suche Informationen zu einem bestimmten Thema. Falls du weitere Informationen von mir brauchst, stelle mir direkt 1-2 wichtige Fragen. Bitte führe die Aufgabe so bald wie möglich aus.',
+        contentKey: 'prompts.research.findInformationContent',
       },
       {
         labelKey: 'prompts.research.helpFind',
-        content:
-          'Könntest du mir helfen, Informationen zu finden? Falls du weitere Informationen von mir brauchst, stelle mir direkt 1-2 wichtige Fragen. Eine strukturierte Zusammenfassung wäre toll, falls es sinnvoll ist.',
+        contentKey: 'prompts.research.helpFindContent',
       },
     ],
   },
@@ -74,23 +66,19 @@ export const QUICK_ACTIONS: QuickActionCategory[] = [
     prompts: [
       {
         labelKey: 'prompts.summarize.summarizeText',
-        content:
-          'Könntest du einen Text für mich zusammenfassen? Wenn du meinst, dass ich Dokumente hochladen sollte, die dir bei der Aufgabe helfen würden, lass es mich wissen. Eine strukturierte Zusammenfassung mit Kernpunkten wäre ideal.',
+        contentKey: 'prompts.summarize.summarizeTextContent',
       },
       {
         labelKey: 'prompts.summarize.extractKeyPoints',
-        content:
-          'Könntest du die wichtigsten Punkte aus einem Text extrahieren? Wenn du meinst, dass ich Dokumente hochladen sollte, lass es mich wissen. Eine Aufzählung der Kernaussagen wäre ideal.',
+        contentKey: 'prompts.summarize.extractKeyPointsContent',
       },
       {
         labelKey: 'prompts.summarize.createOverview',
-        content:
-          'Ich brauche eine Kurzübersicht zu einem Thema oder Dokument. Falls du weitere Informationen von mir brauchst, stelle mir direkt 1-2 wichtige Fragen. Überlege, welche Darstellungsform (Tabelle, Liste, Absätze) am hilfreichsten wäre.',
+        contentKey: 'prompts.summarize.createOverviewContent',
       },
       {
         labelKey: 'prompts.summarize.coreStatements',
-        content:
-          'Könntest du die Kernaussagen eines Textes herausarbeiten? Wenn du meinst, dass ich Dokumente hochladen sollte, lass es mich wissen. Eine klare, strukturierte Aufbereitung wäre toll.',
+        contentKey: 'prompts.summarize.coreStatementsContent',
       },
     ],
   },
@@ -101,23 +89,19 @@ export const QUICK_ACTIONS: QuickActionCategory[] = [
     prompts: [
       {
         labelKey: 'prompts.analyze.checkText',
-        content:
-          'Könntest du einen Text für mich prüfen? Falls du weitere Informationen von mir brauchst (z.B. worauf ich besonders achten sollte), stelle mir direkt 1-2 wichtige Fragen. Wenn du meinst, dass ich Dokumente hochladen sollte, lass es mich wissen.',
+        contentKey: 'prompts.analyze.checkTextContent',
       },
       {
         labelKey: 'prompts.analyze.analyzeDocument',
-        content:
-          'Könntest du ein Dokument für mich analysieren? Wenn du meinst, dass ich Dokumente hochladen sollte, lass es mich wissen. Eine strukturierte Analyse mit den wichtigsten Erkenntnissen wäre ideal.',
+        contentKey: 'prompts.analyze.analyzeDocumentContent',
       },
       {
         labelKey: 'prompts.analyze.evaluateProposal',
-        content:
-          'Könntest du einen Vorschlag für mich bewerten? Falls du weitere Informationen von mir brauchst, stelle mir direkt 1-2 wichtige Fragen. Eine Darstellung mit Pro und Contra wäre hilfreich.',
+        contentKey: 'prompts.analyze.evaluateProposalContent',
       },
       {
         labelKey: 'prompts.analyze.strengthsWeaknesses',
-        content:
-          'Könntest du die Stärken und Schwächen von etwas analysieren? Falls du weitere Informationen von mir brauchst, stelle mir direkt 1-2 wichtige Fragen. Eine tabellarische oder strukturierte Gegenüberstellung wäre ideal.',
+        contentKey: 'prompts.analyze.strengthsWeaknessesContent',
       },
     ],
   },

--- a/ayunis-core-frontend/src/pages/new-chat/model/quickActionsData.ts
+++ b/ayunis-core-frontend/src/pages/new-chat/model/quickActionsData.ts
@@ -1,0 +1,108 @@
+import { Pencil, Search, FileText, Eye, type LucideIcon } from 'lucide-react';
+
+export interface QuickActionPrompt {
+  labelKey: string;
+  content: string;
+}
+
+export interface QuickActionCategory {
+  id: string;
+  labelKey: string;
+  icon: LucideIcon;
+  prompts: QuickActionPrompt[];
+}
+
+export const QUICK_ACTIONS: QuickActionCategory[] = [
+  {
+    id: 'writing',
+    labelKey: 'categories.writing',
+    icon: Pencil,
+    prompts: [
+      {
+        labelKey: 'prompts.writing.draftDocument',
+        content: 'Hilf mir, ein offizielles Schreiben zu verfassen',
+      },
+      {
+        labelKey: 'prompts.writing.createDraft',
+        content: 'Erstelle einen Entwurf für...',
+      },
+      {
+        labelKey: 'prompts.writing.formulateResponse',
+        content: 'Formuliere eine Antwort auf...',
+      },
+      {
+        labelKey: 'prompts.writing.writeText',
+        content: 'Schreibe einen Text über...',
+      },
+    ],
+  },
+  {
+    id: 'research',
+    labelKey: 'categories.research',
+    icon: Search,
+    prompts: [
+      {
+        labelKey: 'prompts.research.explainBasics',
+        content: 'Erkläre mir die Grundlagen zu...',
+      },
+      {
+        labelKey: 'prompts.research.whatToConsider',
+        content: 'Was muss ich beachten bei...?',
+      },
+      {
+        labelKey: 'prompts.research.findInformation',
+        content: 'Welche Informationen gibt es zu...?',
+      },
+      {
+        labelKey: 'prompts.research.helpFind',
+        content: 'Hilf mir, Informationen zu finden über...',
+      },
+    ],
+  },
+  {
+    id: 'summarize',
+    labelKey: 'categories.summarize',
+    icon: FileText,
+    prompts: [
+      {
+        labelKey: 'prompts.summarize.summarizeText',
+        content: 'Fasse den folgenden Text zusammen',
+      },
+      {
+        labelKey: 'prompts.summarize.extractKeyPoints',
+        content: 'Extrahiere die wichtigsten Punkte',
+      },
+      {
+        labelKey: 'prompts.summarize.createOverview',
+        content: 'Erstelle eine Kurzübersicht',
+      },
+      {
+        labelKey: 'prompts.summarize.coreStatements',
+        content: 'Was sind die Kernaussagen?',
+      },
+    ],
+  },
+  {
+    id: 'analyze',
+    labelKey: 'categories.analyze',
+    icon: Eye,
+    prompts: [
+      {
+        labelKey: 'prompts.analyze.checkText',
+        content: 'Prüfe den folgenden Text',
+      },
+      {
+        labelKey: 'prompts.analyze.analyzeDocument',
+        content: 'Analysiere dieses Dokument',
+      },
+      {
+        labelKey: 'prompts.analyze.evaluateProposal',
+        content: 'Bewerte den folgenden Vorschlag',
+      },
+      {
+        labelKey: 'prompts.analyze.strengthsWeaknesses',
+        content: 'Welche Stärken und Schwächen siehst du?',
+      },
+    ],
+  },
+];

--- a/ayunis-core-frontend/src/pages/new-chat/model/quickActionsData.ts
+++ b/ayunis-core-frontend/src/pages/new-chat/model/quickActionsData.ts
@@ -20,19 +20,23 @@ export const QUICK_ACTIONS: QuickActionCategory[] = [
     prompts: [
       {
         labelKey: 'prompts.writing.draftDocument',
-        content: 'Hilf mir, ein offizielles Schreiben zu verfassen',
+        content:
+          'Könntest du mir helfen, ein offizielles Schreiben zu verfassen? Falls du weitere Informationen von mir brauchst, stelle mir direkt 1-2 wichtige Fragen. Wenn du meinst, dass ich Dokumente hochladen sollte, die dir bei der Aufgabe helfen würden, lass es mich wissen.',
       },
       {
         labelKey: 'prompts.writing.createDraft',
-        content: 'Erstelle einen Entwurf für...',
+        content:
+          'Ich brauche einen Entwurf für ein Dokument. Falls du weitere Informationen von mir brauchst, stelle mir direkt 1-2 wichtige Fragen. Bitte führe die Aufgabe so bald wie möglich aus.',
       },
       {
         labelKey: 'prompts.writing.formulateResponse',
-        content: 'Formuliere eine Antwort auf...',
+        content:
+          'Könntest du mir helfen, eine Antwort zu formulieren? Falls du weitere Informationen von mir brauchst, stelle mir direkt 1-2 wichtige Fragen. Wenn du meinst, dass ich Dokumente hochladen sollte (z.B. die ursprüngliche Nachricht), lass es mich wissen.',
       },
       {
         labelKey: 'prompts.writing.writeText',
-        content: 'Schreibe einen Text über...',
+        content:
+          'Ich möchte einen Text schreiben. Falls du weitere Informationen von mir brauchst (Thema, Zielgruppe, Länge), stelle mir direkt 1-2 wichtige Fragen. Bitte führe die Aufgabe so bald wie möglich aus.',
       },
     ],
   },
@@ -43,19 +47,23 @@ export const QUICK_ACTIONS: QuickActionCategory[] = [
     prompts: [
       {
         labelKey: 'prompts.research.explainBasics',
-        content: 'Erkläre mir die Grundlagen zu...',
+        content:
+          'Könntest du mir die Grundlagen zu einem Thema erklären? Falls du weitere Informationen von mir brauchst, stelle mir direkt 1-2 wichtige Fragen. Eine visuelle oder strukturierte Darstellung wäre toll, falls es sinnvoll ist.',
       },
       {
         labelKey: 'prompts.research.whatToConsider',
-        content: 'Was muss ich beachten bei...?',
+        content:
+          'Ich möchte wissen, was ich bei einem bestimmten Thema beachten muss. Falls du weitere Informationen von mir brauchst, stelle mir direkt 1-2 wichtige Fragen. Überlege bei der Erstellung einer Darstellung, welche Art (Checkliste, Übersicht usw.) für diese Aufgabe am hilfreichsten sein könnte.',
       },
       {
         labelKey: 'prompts.research.findInformation',
-        content: 'Welche Informationen gibt es zu...?',
+        content:
+          'Ich suche Informationen zu einem bestimmten Thema. Falls du weitere Informationen von mir brauchst, stelle mir direkt 1-2 wichtige Fragen. Bitte führe die Aufgabe so bald wie möglich aus.',
       },
       {
         labelKey: 'prompts.research.helpFind',
-        content: 'Hilf mir, Informationen zu finden über...',
+        content:
+          'Könntest du mir helfen, Informationen zu finden? Falls du weitere Informationen von mir brauchst, stelle mir direkt 1-2 wichtige Fragen. Eine strukturierte Zusammenfassung wäre toll, falls es sinnvoll ist.',
       },
     ],
   },
@@ -66,19 +74,23 @@ export const QUICK_ACTIONS: QuickActionCategory[] = [
     prompts: [
       {
         labelKey: 'prompts.summarize.summarizeText',
-        content: 'Fasse den folgenden Text zusammen',
+        content:
+          'Könntest du einen Text für mich zusammenfassen? Wenn du meinst, dass ich Dokumente hochladen sollte, die dir bei der Aufgabe helfen würden, lass es mich wissen. Eine strukturierte Zusammenfassung mit Kernpunkten wäre ideal.',
       },
       {
         labelKey: 'prompts.summarize.extractKeyPoints',
-        content: 'Extrahiere die wichtigsten Punkte',
+        content:
+          'Könntest du die wichtigsten Punkte aus einem Text extrahieren? Wenn du meinst, dass ich Dokumente hochladen sollte, lass es mich wissen. Eine Aufzählung der Kernaussagen wäre ideal.',
       },
       {
         labelKey: 'prompts.summarize.createOverview',
-        content: 'Erstelle eine Kurzübersicht',
+        content:
+          'Ich brauche eine Kurzübersicht zu einem Thema oder Dokument. Falls du weitere Informationen von mir brauchst, stelle mir direkt 1-2 wichtige Fragen. Überlege, welche Darstellungsform (Tabelle, Liste, Absätze) am hilfreichsten wäre.',
       },
       {
         labelKey: 'prompts.summarize.coreStatements',
-        content: 'Was sind die Kernaussagen?',
+        content:
+          'Könntest du die Kernaussagen eines Textes herausarbeiten? Wenn du meinst, dass ich Dokumente hochladen sollte, lass es mich wissen. Eine klare, strukturierte Aufbereitung wäre toll.',
       },
     ],
   },
@@ -89,19 +101,23 @@ export const QUICK_ACTIONS: QuickActionCategory[] = [
     prompts: [
       {
         labelKey: 'prompts.analyze.checkText',
-        content: 'Prüfe den folgenden Text',
+        content:
+          'Könntest du einen Text für mich prüfen? Falls du weitere Informationen von mir brauchst (z.B. worauf ich besonders achten sollte), stelle mir direkt 1-2 wichtige Fragen. Wenn du meinst, dass ich Dokumente hochladen sollte, lass es mich wissen.',
       },
       {
         labelKey: 'prompts.analyze.analyzeDocument',
-        content: 'Analysiere dieses Dokument',
+        content:
+          'Könntest du ein Dokument für mich analysieren? Wenn du meinst, dass ich Dokumente hochladen sollte, lass es mich wissen. Eine strukturierte Analyse mit den wichtigsten Erkenntnissen wäre ideal.',
       },
       {
         labelKey: 'prompts.analyze.evaluateProposal',
-        content: 'Bewerte den folgenden Vorschlag',
+        content:
+          'Könntest du einen Vorschlag für mich bewerten? Falls du weitere Informationen von mir brauchst, stelle mir direkt 1-2 wichtige Fragen. Eine Darstellung mit Pro und Contra wäre hilfreich.',
       },
       {
         labelKey: 'prompts.analyze.strengthsWeaknesses',
-        content: 'Welche Stärken und Schwächen siehst du?',
+        content:
+          'Könntest du die Stärken und Schwächen von etwas analysieren? Falls du weitere Informationen von mir brauchst, stelle mir direkt 1-2 wichtige Fragen. Eine tabellarische oder strukturierte Gegenüberstellung wäre ideal.',
       },
     ],
   },

--- a/ayunis-core-frontend/src/pages/new-chat/ui/NewChatPage.tsx
+++ b/ayunis-core-frontend/src/pages/new-chat/ui/NewChatPage.tsx
@@ -124,7 +124,7 @@ export default function NewChatPage({
           isAnonymousEnforced={isAnonymousEnforced}
         />
         <QuickActions
-          onPromptSelect={(text) => chatInputRef.current?.setMessage(text)}
+          onPromptSelect={(text) => chatInputRef.current?.sendMessage(text)}
         />
       </div>
     </NewChatPageLayout>

--- a/ayunis-core-frontend/src/pages/new-chat/ui/NewChatPage.tsx
+++ b/ayunis-core-frontend/src/pages/new-chat/ui/NewChatPage.tsx
@@ -1,8 +1,9 @@
 import NewChatPageLayout from './NewChatPageLayout';
-import ChatInput from '@/widgets/chat-input';
+import ChatInput, { type ChatInputRef } from '@/widgets/chat-input';
 import { useInitiateChat } from '../api/useInitiateChat';
-import { useState } from 'react';
+import { useState, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
+import { QuickActions } from './QuickActions';
 import ContentAreaHeader from '@/widgets/content-area-header/ui/ContentAreaHeader';
 import { showError } from '@/shared/lib/toast';
 import { generateUUID } from '@/shared/lib/uuid';
@@ -28,6 +29,7 @@ export default function NewChatPage({
   const { t } = useTranslation('chats');
   const { initiateChat } = useInitiateChat();
   const { models } = usePermittedModels();
+  const chatInputRef = useRef<ChatInputRef>(null);
   const [modelId, setModelId] = useState(selectedModelId);
   const [agentId, setAgentId] = useState(selectedAgentId);
   const [isAnonymous, setIsAnonymous] = useState(false);
@@ -99,6 +101,7 @@ export default function NewChatPage({
       </div>
       <div className="w-full flex flex-col gap-4 mt-2">
         <ChatInput
+          ref={chatInputRef}
           // If an agent is selected, use the agent's model,
           // but disable the model selection
           // to only show the model that the agent uses
@@ -119,6 +122,9 @@ export default function NewChatPage({
           isAnonymous={isAnonymous}
           onAnonymousChange={setIsAnonymous}
           isAnonymousEnforced={isAnonymousEnforced}
+        />
+        <QuickActions
+          onPromptSelect={(text) => chatInputRef.current?.setMessage(text)}
         />
       </div>
     </NewChatPageLayout>

--- a/ayunis-core-frontend/src/pages/new-chat/ui/QuickActionPanel.tsx
+++ b/ayunis-core-frontend/src/pages/new-chat/ui/QuickActionPanel.tsx
@@ -1,0 +1,70 @@
+import { ChevronRight, X } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { Button } from '@/shared/ui/shadcn/button';
+import {
+  Card,
+  CardAction,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from '@/shared/ui/shadcn/card';
+import { Separator } from '@/shared/ui/shadcn/separator';
+import type {
+  QuickActionCategory,
+  QuickActionPrompt,
+} from '../model/quickActionsData';
+import { Item, ItemActions, ItemContent } from '@/shared/ui/shadcn/item';
+
+interface QuickActionPanelProps {
+  category: QuickActionCategory;
+  onSelect: (prompt: QuickActionPrompt) => void;
+  onClose: () => void;
+}
+
+export function QuickActionPanel({
+  category,
+  onSelect,
+  onClose,
+}: QuickActionPanelProps) {
+  const { t } = useTranslation('quickActions');
+  const Icon = category.icon;
+
+  return (
+    <Card className="gap-2 pb-0">
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Icon className="h-4 w-4" />
+          <span>{t(category.labelKey)}</span>
+        </CardTitle>
+        <CardAction>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-6 w-6"
+            onClick={onClose}
+          >
+            <X className="h-4 w-4" />
+          </Button>
+        </CardAction>
+      </CardHeader>
+      <CardContent className="p-0">
+        <ul>
+          {category.prompts.map((prompt, index) => (
+            <li key={prompt.labelKey}>
+              <Item
+                className="px-6 hover:bg-accent/50 cursor-pointer"
+                onClick={() => onSelect(prompt)}
+              >
+                <ItemContent>{t(prompt.labelKey)}</ItemContent>
+                <ItemActions>
+                  <ChevronRight className="h-4 w-4" />
+                </ItemActions>
+              </Item>
+              {index < category.prompts.length - 1 && <Separator />}
+            </li>
+          ))}
+        </ul>
+      </CardContent>
+    </Card>
+  );
+}

--- a/ayunis-core-frontend/src/pages/new-chat/ui/QuickActions.tsx
+++ b/ayunis-core-frontend/src/pages/new-chat/ui/QuickActions.tsx
@@ -1,0 +1,63 @@
+import { useState, useRef, useLayoutEffect } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Button } from '@/shared/ui/shadcn/button';
+import { QUICK_ACTIONS } from '../model/quickActionsData';
+import { QuickActionPanel } from './QuickActionPanel';
+
+interface QuickActionsProps {
+  onPromptSelect: (text: string) => void;
+}
+
+export function QuickActions({ onPromptSelect }: QuickActionsProps) {
+  const [activeCategory, setActiveCategory] = useState<string | null>(null);
+  const [height, setHeight] = useState<number | undefined>(undefined);
+  const contentRef = useRef<HTMLDivElement>(null);
+  const { t } = useTranslation('quickActions');
+
+  const category = activeCategory
+    ? QUICK_ACTIONS.find((c) => c.id === activeCategory)
+    : null;
+
+  useLayoutEffect(() => {
+    if (contentRef.current) {
+      setHeight(contentRef.current.scrollHeight);
+    }
+  }, [activeCategory]);
+
+  return (
+    <div
+      className="overflow-hidden transition-[height] duration-300 ease-out"
+      style={{ height: height !== undefined ? `${height}px` : 'auto' }}
+    >
+      <div ref={contentRef}>
+        {category ? (
+          <QuickActionPanel
+            category={category}
+            onSelect={(prompt) => {
+              onPromptSelect(prompt.content);
+              setActiveCategory(null);
+            }}
+            onClose={() => setActiveCategory(null)}
+          />
+        ) : (
+          <div className="flex justify-center gap-2 flex-wrap">
+            {QUICK_ACTIONS.map((cat) => {
+              const Icon = cat.icon;
+              return (
+                <Button
+                  key={cat.id}
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setActiveCategory(cat.id)}
+                >
+                  <Icon />
+                  {t(cat.labelKey)}
+                </Button>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/ayunis-core-frontend/src/pages/new-chat/ui/QuickActions.tsx
+++ b/ayunis-core-frontend/src/pages/new-chat/ui/QuickActions.tsx
@@ -34,7 +34,7 @@ export function QuickActions({ onPromptSelect }: QuickActionsProps) {
           <QuickActionPanel
             category={category}
             onSelect={(prompt) => {
-              onPromptSelect(prompt.content);
+              onPromptSelect(t(prompt.contentKey));
               setActiveCategory(null);
             }}
             onClose={() => setActiveCategory(null)}

--- a/ayunis-core-frontend/src/shared/locales/de/quickActions.json
+++ b/ayunis-core-frontend/src/shared/locales/de/quickActions.json
@@ -8,27 +8,43 @@
   "prompts": {
     "writing": {
       "draftDocument": "Offizielles Schreiben verfassen",
+      "draftDocumentContent": "Könntest du mir helfen, ein offizielles Schreiben zu verfassen? Falls du weitere Informationen von mir brauchst, stelle mir direkt 1-2 wichtige Fragen. Wenn du meinst, dass ich Dokumente hochladen sollte, die dir bei der Aufgabe helfen würden, lass es mich wissen.",
       "createDraft": "Entwurf erstellen",
+      "createDraftContent": "Ich brauche einen Entwurf für ein Dokument. Falls du weitere Informationen von mir brauchst, stelle mir direkt 1-2 wichtige Fragen. Bitte führe die Aufgabe so bald wie möglich aus.",
       "formulateResponse": "Antwort formulieren",
-      "writeText": "Text schreiben"
+      "formulateResponseContent": "Könntest du mir helfen, eine Antwort zu formulieren? Falls du weitere Informationen von mir brauchst, stelle mir direkt 1-2 wichtige Fragen. Wenn du meinst, dass ich Dokumente hochladen sollte (z.B. die ursprüngliche Nachricht), lass es mich wissen.",
+      "writeText": "Text schreiben",
+      "writeTextContent": "Ich möchte einen Text schreiben. Falls du weitere Informationen von mir brauchst (Thema, Zielgruppe, Länge), stelle mir direkt 1-2 wichtige Fragen. Bitte führe die Aufgabe so bald wie möglich aus."
     },
     "research": {
       "explainBasics": "Grundlagen erklären",
+      "explainBasicsContent": "Könntest du mir die Grundlagen zu einem Thema erklären? Falls du weitere Informationen von mir brauchst, stelle mir direkt 1-2 wichtige Fragen. Eine visuelle oder strukturierte Darstellung wäre toll, falls es sinnvoll ist.",
       "whatToConsider": "Was muss ich beachten?",
+      "whatToConsiderContent": "Ich möchte wissen, was ich bei einem bestimmten Thema beachten muss. Falls du weitere Informationen von mir brauchst, stelle mir direkt 1-2 wichtige Fragen. Überlege bei der Erstellung einer Darstellung, welche Art (Checkliste, Übersicht usw.) für diese Aufgabe am hilfreichsten sein könnte.",
       "findInformation": "Informationen finden",
-      "helpFind": "Bei der Suche helfen"
+      "findInformationContent": "Ich suche Informationen zu einem bestimmten Thema. Falls du weitere Informationen von mir brauchst, stelle mir direkt 1-2 wichtige Fragen. Bitte führe die Aufgabe so bald wie möglich aus.",
+      "helpFind": "Bei der Suche helfen",
+      "helpFindContent": "Könntest du mir helfen, Informationen zu finden? Falls du weitere Informationen von mir brauchst, stelle mir direkt 1-2 wichtige Fragen. Eine strukturierte Zusammenfassung wäre toll, falls es sinnvoll ist."
     },
     "summarize": {
       "summarizeText": "Text zusammenfassen",
+      "summarizeTextContent": "Könntest du einen Text für mich zusammenfassen? Wenn du meinst, dass ich Dokumente hochladen sollte, die dir bei der Aufgabe helfen würden, lass es mich wissen. Eine strukturierte Zusammenfassung mit Kernpunkten wäre ideal.",
       "extractKeyPoints": "Wichtigste Punkte extrahieren",
+      "extractKeyPointsContent": "Könntest du die wichtigsten Punkte aus einem Text extrahieren? Wenn du meinst, dass ich Dokumente hochladen sollte, lass es mich wissen. Eine Aufzählung der Kernaussagen wäre ideal.",
       "createOverview": "Kurzübersicht erstellen",
-      "coreStatements": "Kernaussagen identifizieren"
+      "createOverviewContent": "Ich brauche eine Kurzübersicht zu einem Thema oder Dokument. Falls du weitere Informationen von mir brauchst, stelle mir direkt 1-2 wichtige Fragen. Überlege, welche Darstellungsform (Tabelle, Liste, Absätze) am hilfreichsten wäre.",
+      "coreStatements": "Kernaussagen identifizieren",
+      "coreStatementsContent": "Könntest du die Kernaussagen eines Textes herausarbeiten? Wenn du meinst, dass ich Dokumente hochladen sollte, lass es mich wissen. Eine klare, strukturierte Aufbereitung wäre toll."
     },
     "analyze": {
       "checkText": "Text prüfen",
+      "checkTextContent": "Könntest du einen Text für mich prüfen? Falls du weitere Informationen von mir brauchst (z.B. worauf ich besonders achten sollte), stelle mir direkt 1-2 wichtige Fragen. Wenn du meinst, dass ich Dokumente hochladen sollte, lass es mich wissen.",
       "analyzeDocument": "Dokument analysieren",
+      "analyzeDocumentContent": "Könntest du ein Dokument für mich analysieren? Wenn du meinst, dass ich Dokumente hochladen sollte, lass es mich wissen. Eine strukturierte Analyse mit den wichtigsten Erkenntnissen wäre ideal.",
       "evaluateProposal": "Vorschlag bewerten",
-      "strengthsWeaknesses": "Stärken und Schwächen"
+      "evaluateProposalContent": "Könntest du einen Vorschlag für mich bewerten? Falls du weitere Informationen von mir brauchst, stelle mir direkt 1-2 wichtige Fragen. Eine Darstellung mit Pro und Contra wäre hilfreich.",
+      "strengthsWeaknesses": "Stärken und Schwächen",
+      "strengthsWeaknessesContent": "Könntest du die Stärken und Schwächen von etwas analysieren? Falls du weitere Informationen von mir brauchst, stelle mir direkt 1-2 wichtige Fragen. Eine tabellarische oder strukturierte Gegenüberstellung wäre ideal."
     }
   }
 }

--- a/ayunis-core-frontend/src/shared/locales/de/quickActions.json
+++ b/ayunis-core-frontend/src/shared/locales/de/quickActions.json
@@ -1,0 +1,34 @@
+{
+  "categories": {
+    "writing": "Schreiben",
+    "research": "Recherche",
+    "summarize": "Zusammenfassen",
+    "analyze": "Analysieren"
+  },
+  "prompts": {
+    "writing": {
+      "draftDocument": "Offizielles Schreiben verfassen",
+      "createDraft": "Entwurf erstellen",
+      "formulateResponse": "Antwort formulieren",
+      "writeText": "Text schreiben"
+    },
+    "research": {
+      "explainBasics": "Grundlagen erklären",
+      "whatToConsider": "Was muss ich beachten?",
+      "findInformation": "Informationen finden",
+      "helpFind": "Bei der Suche helfen"
+    },
+    "summarize": {
+      "summarizeText": "Text zusammenfassen",
+      "extractKeyPoints": "Wichtigste Punkte extrahieren",
+      "createOverview": "Kurzübersicht erstellen",
+      "coreStatements": "Kernaussagen identifizieren"
+    },
+    "analyze": {
+      "checkText": "Text prüfen",
+      "analyzeDocument": "Dokument analysieren",
+      "evaluateProposal": "Vorschlag bewerten",
+      "strengthsWeaknesses": "Stärken und Schwächen"
+    }
+  }
+}

--- a/ayunis-core-frontend/src/shared/locales/en/quickActions.json
+++ b/ayunis-core-frontend/src/shared/locales/en/quickActions.json
@@ -8,27 +8,43 @@
   "prompts": {
     "writing": {
       "draftDocument": "Draft official document",
+      "draftDocumentContent": "Could you help me draft an official document? If you need more information from me, please ask 1-2 key questions directly. If you think I should upload documents that would help with the task, let me know.",
       "createDraft": "Create a draft",
+      "createDraftContent": "I need a draft for a document. If you need more information from me, please ask 1-2 key questions directly. Please carry out the task as soon as possible.",
       "formulateResponse": "Formulate a response",
-      "writeText": "Write text"
+      "formulateResponseContent": "Could you help me formulate a response? If you need more information from me, please ask 1-2 key questions directly. If you think I should upload documents (e.g., the original message), let me know.",
+      "writeText": "Write text",
+      "writeTextContent": "I would like to write a text. If you need more information from me (topic, target audience, length), please ask 1-2 key questions directly. Please carry out the task as soon as possible."
     },
     "research": {
       "explainBasics": "Explain the basics",
+      "explainBasicsContent": "Could you explain the basics of a topic to me? If you need more information from me, please ask 1-2 key questions directly. A visual or structured representation would be great if it makes sense.",
       "whatToConsider": "What should I consider?",
+      "whatToConsiderContent": "I would like to know what I need to consider for a specific topic. If you need more information from me, please ask 1-2 key questions directly. When creating a representation, consider which type (checklist, overview, etc.) would be most helpful for this task.",
       "findInformation": "Find information",
-      "helpFind": "Help me find"
+      "findInformationContent": "I am looking for information on a specific topic. If you need more information from me, please ask 1-2 key questions directly. Please carry out the task as soon as possible.",
+      "helpFind": "Help me find",
+      "helpFindContent": "Could you help me find information? If you need more information from me, please ask 1-2 key questions directly. A structured summary would be great if it makes sense."
     },
     "summarize": {
       "summarizeText": "Summarize text",
+      "summarizeTextContent": "Could you summarize a text for me? If you think I should upload documents that would help with the task, let me know. A structured summary with key points would be ideal.",
       "extractKeyPoints": "Extract key points",
+      "extractKeyPointsContent": "Could you extract the key points from a text? If you think I should upload documents, let me know. A list of core statements would be ideal.",
       "createOverview": "Create overview",
-      "coreStatements": "Identify core statements"
+      "createOverviewContent": "I need a brief overview of a topic or document. If you need more information from me, please ask 1-2 key questions directly. Consider which presentation format (table, list, paragraphs) would be most helpful.",
+      "coreStatements": "Identify core statements",
+      "coreStatementsContent": "Could you extract the core statements from a text? If you think I should upload documents, let me know. A clear, structured presentation would be great."
     },
     "analyze": {
       "checkText": "Check text",
+      "checkTextContent": "Could you check a text for me? If you need more information from me (e.g., what I should pay particular attention to), please ask 1-2 key questions directly. If you think I should upload documents, let me know.",
       "analyzeDocument": "Analyze document",
+      "analyzeDocumentContent": "Could you analyze a document for me? If you think I should upload documents, let me know. A structured analysis with the key findings would be ideal.",
       "evaluateProposal": "Evaluate proposal",
-      "strengthsWeaknesses": "Strengths and weaknesses"
+      "evaluateProposalContent": "Could you evaluate a proposal for me? If you need more information from me, please ask 1-2 key questions directly. A presentation with pros and cons would be helpful.",
+      "strengthsWeaknesses": "Strengths and weaknesses",
+      "strengthsWeaknessesContent": "Could you analyze the strengths and weaknesses of something? If you need more information from me, please ask 1-2 key questions directly. A tabular or structured comparison would be ideal."
     }
   }
 }

--- a/ayunis-core-frontend/src/shared/locales/en/quickActions.json
+++ b/ayunis-core-frontend/src/shared/locales/en/quickActions.json
@@ -1,0 +1,34 @@
+{
+  "categories": {
+    "writing": "Write",
+    "research": "Research",
+    "summarize": "Summarize",
+    "analyze": "Analyze"
+  },
+  "prompts": {
+    "writing": {
+      "draftDocument": "Draft official document",
+      "createDraft": "Create a draft",
+      "formulateResponse": "Formulate a response",
+      "writeText": "Write text"
+    },
+    "research": {
+      "explainBasics": "Explain the basics",
+      "whatToConsider": "What should I consider?",
+      "findInformation": "Find information",
+      "helpFind": "Help me find"
+    },
+    "summarize": {
+      "summarizeText": "Summarize text",
+      "extractKeyPoints": "Extract key points",
+      "createOverview": "Create overview",
+      "coreStatements": "Identify core statements"
+    },
+    "analyze": {
+      "checkText": "Check text",
+      "analyzeDocument": "Analyze document",
+      "evaluateProposal": "Evaluate proposal",
+      "strengthsWeaknesses": "Strengths and weaknesses"
+    }
+  }
+}

--- a/ayunis-core-frontend/src/widgets/chat-input/index.ts
+++ b/ayunis-core-frontend/src/widgets/chat-input/index.ts
@@ -1,3 +1,4 @@
 import ChatInput from './ui/ChatInput';
 
+export type { ChatInputRef } from './ui/ChatInput';
 export default ChatInput;

--- a/ayunis-core-frontend/src/widgets/chat-input/ui/ChatInput.tsx
+++ b/ayunis-core-frontend/src/widgets/chat-input/ui/ChatInput.tsx
@@ -57,6 +57,7 @@ interface ChatInputProps {
 
 export interface ChatInputRef {
   setMessage: (message: string) => void;
+  sendMessage: (message: string) => void;
 }
 
 const ChatInput = forwardRef<ChatInputRef, ChatInputProps>(
@@ -93,6 +94,10 @@ const ChatInput = forwardRef<ChatInputRef, ChatInputProps>(
 
     useImperativeHandle(ref, () => ({
       setMessage,
+      sendMessage: (text: string) => {
+        if (!text.trim() || !(modelId || agentId)) return;
+        onSend(text);
+      },
     }));
 
     function handleSend() {

--- a/ayunis-core-frontend/src/widgets/chat-input/ui/ChatInput.tsx
+++ b/ayunis-core-frontend/src/widgets/chat-input/ui/ChatInput.tsx
@@ -97,6 +97,7 @@ const ChatInput = forwardRef<ChatInputRef, ChatInputProps>(
       sendMessage: (text: string) => {
         if (!text.trim() || !(modelId || agentId)) return;
         onSend(text);
+        setMessage(''); // Clear message after sending
       },
     }));
 

--- a/ayunis-core-frontend/src/widgets/chat-input/ui/ChatInput.tsx
+++ b/ayunis-core-frontend/src/widgets/chat-input/ui/ChatInput.tsx
@@ -97,7 +97,6 @@ const ChatInput = forwardRef<ChatInputRef, ChatInputProps>(
       sendMessage: (text: string) => {
         if (!text.trim() || !(modelId || agentId)) return;
         onSend(text);
-        setMessage(''); // Clear message after sending
       },
     }));
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a localized Quick Actions panel to New Chat and enables sending selected prompts via a new ChatInput ref method.
> 
> - **New Chat UX**:
>   - **Quick Actions**: Add `QuickActions` and `QuickActionPanel` components with categorized prompts (`writing`, `research`, `summarize`, `analyze`) in `src/pages/new-chat/ui/` using data from `model/quickActionsData.ts`.
>   - **Integration**: `NewChatPage.tsx` wires `QuickActions` to `ChatInput` via `ref` and new `sendMessage` method to immediately send selected prompts.
> - **ChatInput API**:
>   - Expose `ChatInputRef` and new `sendMessage(message)` method; update `index.ts` to export the type.
> - **i18n**:
>   - Add `quickActions.json` translations (EN/DE) and register `quickActions` namespace in `i18n.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e1c26f346ed9794679ff39d28c8e2a914f0771df. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->