### PR TITLE
feat: add product knowledge AYC-52

### DIFF
--- a/ayunis-core-backend/src/domain/runs/application/use-cases/execute-run/execute-run.use-case.ts
+++ b/ayunis-core-backend/src/domain/runs/application/use-cases/execute-run/execute-run.use-case.ts
@@ -277,6 +277,15 @@ export class ExecuteRunUseCase {
       ),
     );
 
+    // Product knowledge tool is always available
+    tools.push(
+      await this.assembleToolsUseCase.execute(
+        new AssembleToolCommand({
+          type: ToolType.PRODUCT_KNOWLEDGE,
+        }),
+      ),
+    );
+
     // Internet search tool is always available
     if (
       isCloudHosted ||

--- a/ayunis-core-backend/src/domain/tools/application/handlers/product-knowledge-tool.handler.ts
+++ b/ayunis-core-backend/src/domain/tools/application/handlers/product-knowledge-tool.handler.ts
@@ -1,0 +1,53 @@
+import { Injectable, Logger } from '@nestjs/common';
+import {
+  ToolExecutionContext,
+  ToolExecutionHandler,
+} from '../ports/execution.handler';
+import {
+  ProductKnowledgeTool,
+  ProductKnowledgeTopic,
+} from '../../domain/tools/product-knowledge-tool.entity';
+import { ProductKnowledgePort } from '../ports/product-knowledge.port';
+import { ToolExecutionFailedError } from '../tools.errors';
+
+@Injectable()
+export class ProductKnowledgeToolHandler extends ToolExecutionHandler {
+  private readonly logger = new Logger(ProductKnowledgeToolHandler.name);
+
+  constructor(private readonly productKnowledgePort: ProductKnowledgePort) {
+    super();
+  }
+
+  async execute(params: {
+    tool: ProductKnowledgeTool;
+    input: Record<string, unknown>;
+    context: ToolExecutionContext;
+  }): Promise<string> {
+    const { tool, input } = params;
+
+    try {
+      tool.validateParams(input);
+    } catch (error) {
+      throw new ToolExecutionFailedError({
+        toolName: tool.name,
+        message: `Invalid input: ${error instanceof Error ? error.message : 'Unknown error'}`,
+        exposeToLLM: true,
+      });
+    }
+
+    const topic = input.topic as ProductKnowledgeTopic;
+    this.logger.log('Retrieving product knowledge', { topic });
+
+    try {
+      const content = this.productKnowledgePort.getContent(topic);
+      return await Promise.resolve(content);
+    } catch (error) {
+      this.logger.error('Failed to retrieve product knowledge', error);
+      throw new ToolExecutionFailedError({
+        toolName: tool.name,
+        message: `Failed to retrieve documentation for topic: ${topic}`,
+        exposeToLLM: true,
+      });
+    }
+  }
+}

--- a/ayunis-core-backend/src/domain/tools/application/ports/product-knowledge.port.ts
+++ b/ayunis-core-backend/src/domain/tools/application/ports/product-knowledge.port.ts
@@ -1,0 +1,5 @@
+import { ProductKnowledgeTopic } from 'src/domain/tools/domain/tools/product-knowledge-tool.entity';
+
+export abstract class ProductKnowledgePort {
+  abstract getContent(topic: ProductKnowledgeTopic): string;
+}

--- a/ayunis-core-backend/src/domain/tools/application/tool-handler.registry.ts
+++ b/ayunis-core-backend/src/domain/tools/application/tool-handler.registry.ts
@@ -16,6 +16,8 @@ import { McpIntegrationToolHandler } from './handlers/mcp-integration-tool.handl
 import { McpIntegrationResourceHandler } from './handlers/mcp-integration-resource.handler';
 import { McpIntegrationTool } from '../domain/tools/mcp-integration-tool.entity';
 import { McpIntegrationResource } from '../domain/tools/mcp-integration-resource.entity';
+import { ProductKnowledgeToolHandler } from './handlers/product-knowledge-tool.handler';
+import { ProductKnowledgeTool } from '../domain/tools/product-knowledge-tool.entity';
 
 @Injectable()
 export class ToolHandlerRegistry {
@@ -29,6 +31,7 @@ export class ToolHandlerRegistry {
     private readonly codeExecutionToolHandler: CodeExecutionToolHandler,
     private readonly mcpIntegrationToolHandler: McpIntegrationToolHandler,
     private readonly mcpIntegrationResourceHandler: McpIntegrationResourceHandler,
+    private readonly productKnowledgeToolHandler: ProductKnowledgeToolHandler,
   ) {}
 
   getHandler(tool: Tool): ToolExecutionHandler {
@@ -53,6 +56,9 @@ export class ToolHandlerRegistry {
     }
     if (tool instanceof McpIntegrationResource) {
       return this.mcpIntegrationResourceHandler;
+    }
+    if (tool instanceof ProductKnowledgeTool) {
+      return this.productKnowledgeToolHandler;
     }
     throw new ToolHandlerNotFoundError({
       toolType: tool.name,

--- a/ayunis-core-backend/src/domain/tools/application/tool.factory.spec.ts
+++ b/ayunis-core-backend/src/domain/tools/application/tool.factory.spec.ts
@@ -89,8 +89,9 @@ describe('ToolFactory', () => {
       expect(types).toContain(ToolType.BAR_CHART);
       expect(types).toContain(ToolType.LINE_CHART);
       expect(types).toContain(ToolType.PIE_CHART);
+      expect(types).toContain(ToolType.PRODUCT_KNOWLEDGE);
 
-      expect(types.length).toBe(13);
+      expect(types.length).toBe(14);
     });
   });
 });

--- a/ayunis-core-backend/src/domain/tools/application/tool.factory.ts
+++ b/ayunis-core-backend/src/domain/tools/application/tool.factory.ts
@@ -22,6 +22,7 @@ import { BarChartTool } from '../domain/tools/bar-chart-tool.entity';
 import { LineChartTool } from '../domain/tools/line-chart-tool.entity';
 import { PieChartTool } from '../domain/tools/pie-chart-tool.entity';
 import { DataSource } from 'src/domain/sources/domain/sources/data-source.entity';
+import { ProductKnowledgeTool } from '../domain/tools/product-knowledge-tool.entity';
 
 @Injectable()
 export class ToolFactory {
@@ -85,6 +86,8 @@ export class ToolFactory {
             contextType: params.context?.constructor.name || 'null',
           },
         });
+      case ToolType.PRODUCT_KNOWLEDGE:
+        return new ProductKnowledgeTool();
       default:
         throw new ToolInvalidTypeError({
           toolType: params.type,

--- a/ayunis-core-backend/src/domain/tools/domain/tools/product-knowledge-tool.entity.ts
+++ b/ayunis-core-backend/src/domain/tools/domain/tools/product-knowledge-tool.entity.ts
@@ -1,0 +1,58 @@
+import { FromSchema, JSONSchema } from 'json-schema-to-ts';
+import { ToolType } from '../value-objects/tool-type.enum';
+import Ajv from 'ajv';
+import { Tool } from '../tool.entity';
+
+export enum ProductKnowledgeTopic {
+  GETTING_STARTED = 'getting_started',
+  AGENTS = 'agents',
+  TOOLS = 'tools',
+  PROMPTS = 'prompts',
+  SOURCES = 'sources',
+  MODELS = 'models',
+}
+
+const productKnowledgeToolParameters = {
+  type: 'object' as const,
+  properties: {
+    topic: {
+      type: 'string' as const,
+      enum: Object.values(ProductKnowledgeTopic),
+      description: 'The documentation topic to retrieve',
+    },
+  },
+  required: ['topic'],
+  additionalProperties: false,
+} as const satisfies JSONSchema;
+
+type ProductKnowledgeToolParameters = FromSchema<
+  typeof productKnowledgeToolParameters
+>;
+
+export class ProductKnowledgeTool extends Tool {
+  constructor() {
+    super({
+      name: ToolType.PRODUCT_KNOWLEDGE,
+      description:
+        'Retrieve product documentation and help content about Ayunis features. ' +
+        'Use this tool to answer questions about how to use agents, tools, prompts, sources, and models. ' +
+        'Available topics: getting_started, agents, tools, prompts, sources, models.',
+      parameters: productKnowledgeToolParameters,
+      type: ToolType.PRODUCT_KNOWLEDGE,
+    });
+  }
+
+  validateParams(params: Record<string, any>): ProductKnowledgeToolParameters {
+    const ajv = new Ajv();
+    const validate = ajv.compile(this.parameters);
+    const valid = validate(params);
+    if (!valid) {
+      throw new Error(JSON.stringify(validate.errors));
+    }
+    return params as ProductKnowledgeToolParameters;
+  }
+
+  get returnsPii(): boolean {
+    return false;
+  }
+}

--- a/ayunis-core-backend/src/domain/tools/domain/value-objects/tool-type.enum.ts
+++ b/ayunis-core-backend/src/domain/tools/domain/value-objects/tool-type.enum.ts
@@ -13,4 +13,5 @@ export enum ToolType {
   MCP_TOOL = 'mcp_tool',
   MCP_RESOURCE = 'mcp_resource',
   MCP_PROMPT = 'mcp_prompt',
+  PRODUCT_KNOWLEDGE = 'product_knowledge',
 }

--- a/ayunis-core-backend/src/domain/tools/infrastructure/product-knowledge/content/agents.content.ts
+++ b/ayunis-core-backend/src/domain/tools/infrastructure/product-knowledge/content/agents.content.ts
@@ -1,0 +1,45 @@
+export const agentsContent = `
+# Agents
+
+Agents are customizable AI assistants that you can use for your reocurring tasks and workflows.
+
+## What is an Agent?
+
+An Agent is a configured AI assistant with:
+- **Custom instructions**: Define how the agent should behave and respond
+- **Model selection**: Choose which LLM model powers the agent
+- **Knowledge base**: Provide the agent with knowledge from your documents
+- **Integrations**: Connect the agent to external services
+
+## Differences between Agents and Prompts
+
+- Agents encapsulate a complete use case, while prompts are reusable text templates.
+- Agents are more powerful than prompts, as they can use the knowledge base and integrations to answer your questions.
+- Use agents for end to end use cases, while prompts are best for referencing specific text snippets.
+
+## Creating an Agent
+
+1. Navigate to **Agents** in the sidebar
+2. Click **Create Agent**
+3. Fill in the agent details:
+   - **Name**: A descriptive name for the agent
+   - **Instructions**: System prompt that defines the agent's behavior
+   - **Model**: Select the AI model to use
+4. Optionally upload documents to the knowledge base
+5. Optionally enable integrations
+6. Click **Save**
+
+## Using an Agent
+
+1. Start a new conversation
+2. Select your agent from the agent dropdown (robot icon)
+3. The agent will follow its configured instructions, using the knowledge base and integrations to answer your questions
+
+## Best Practices
+
+- Write clear, specific instructions for consistent behavior
+- Assign only the tools the agent needs
+- Test your agent before sharing with others
+- Use sources to give agents domain-specific knowledge
+- Enable integrations to extend agent capabilities
+`;

--- a/ayunis-core-backend/src/domain/tools/infrastructure/product-knowledge/content/getting-started.content.ts
+++ b/ayunis-core-backend/src/domain/tools/infrastructure/product-knowledge/content/getting-started.content.ts
@@ -1,0 +1,26 @@
+export const gettingStartedContent = `
+# Getting Started with Ayunis Core
+
+## What is Ayunis Core?
+
+Ayunis Core is an open-source AI gateway for public administrations that enables intelligent conversations with customizable agents.
+
+## Quick Start
+
+1. **Create a conversation**: Click "New Chat" to start a new conversation
+2. **Start chatting**: Type your message and press Enter
+
+## Key Features
+
+- **Multiple LLM Providers**: Choose among the best available AI models
+- **Agent Builder**: Create personalized AI assistants tailored to your use cases
+- **Prompt Library**: Save and reuse prompts across conversations
+- **Document understanding**: Enhance context with your own documents (Sources)
+- **Tool Integration**: Extend AI capabilities with custom tools and integrations
+
+## Next Steps
+
+- Try out a few **Models** to see which one works best for you
+- Learn about **Agents** to create custom AI assistants
+- Check out **Prompts** to save reusable prompt templates
+`;

--- a/ayunis-core-backend/src/domain/tools/infrastructure/product-knowledge/content/index.ts
+++ b/ayunis-core-backend/src/domain/tools/infrastructure/product-knowledge/content/index.ts
@@ -1,0 +1,6 @@
+export { gettingStartedContent } from './getting-started.content';
+export { agentsContent } from './agents.content';
+export { toolsContent } from './tools.content';
+export { promptsContent } from './prompts.content';
+export { sourcesContent } from './sources.content';
+export { modelsContent } from './models.content';

--- a/ayunis-core-backend/src/domain/tools/infrastructure/product-knowledge/content/models.content.ts
+++ b/ayunis-core-backend/src/domain/tools/infrastructure/product-knowledge/content/models.content.ts
@@ -1,0 +1,38 @@
+export const modelsContent = `
+# Models
+
+Models are the AI language models that power conversations and agents.
+
+## Supported Models
+
+Ayunis Core supports multiple LLM models from different providers:
+
+- **Open Telekom Cloud**: Open Source Models (e.g. GPT-OSS or Qwen 3) or commercial models (e.g. GPT-5, Claude 4.5 Sonnet)
+- **Mistral**: Mistral AI models (e.g. Mistral-7B-Instruct, Mistral-7B-Chat)
+- **OpenAI** or **Anthropic**: For direct integration with their APIs
+
+## Model Configuration
+
+Administrators can configure which models are available:
+
+1. Navigate to **Admin Settings > Models**
+2. Enable specific models for your organization
+3. Optionally enable privacy mode to anonymize model input before sending it to the model
+
+## Choosing a Model
+
+When creating an agent or starting a conversation:
+
+1. Select from available models in the dropdown
+2. Consider the trade-offs:
+   - **Capability**: More advanced models handle complex tasks better (e.g. reasoning, tool use)
+   - **Speed**: Smaller models respond faster
+   - **Privacy**: A flag next to the model name indicates where the model is hosted
+
+## Embedding Models
+
+For Sources (RAG), separate embedding models are used:
+- These convert text to semantic vectors
+- Configure in **Admin Settings > Models** 
+- IMPORTANT:At least one embedding model must be enabled in order to enable document analysis features
+`;

--- a/ayunis-core-backend/src/domain/tools/infrastructure/product-knowledge/content/prompts.content.ts
+++ b/ayunis-core-backend/src/domain/tools/infrastructure/product-knowledge/content/prompts.content.ts
@@ -1,0 +1,48 @@
+export const promptsContent = `
+# Prompts
+
+Prompts are reusable text templates that you can quickly insert into conversations.
+
+## What are Prompts?
+
+Prompts allow you to:
+- Save frequently used instructions
+- Create templates with consistent formatting
+- Quickly apply complex prompts without retyping
+
+## Differences between Prompts and Agents
+
+- Prompts are reusable text templates, while agents are customizable AI assistants.
+- Prompts are less powerful than agents, as they cannot use the knowledge base and integrations to answer your questions.
+- Use prompts for referencing specific text snippets, while agents are best for end to end use cases.
+
+## Creating a Prompt
+
+1. Navigate to **Prompts** in the sidebar
+2. Click **Create Prompt**
+3. Fill in the details:
+   - **Title**: A short, descriptive name
+   - **Content**: The prompt text
+4. Click **Save**
+
+## Using a Prompt
+
+1. In a conversation, click the **Prompts** button
+2. Select a prompt from your library
+3. The prompt content is inserted into your message
+4. You can edit the inserted text before sending
+
+## Organizing Prompts
+
+- Use clear, descriptive titles
+- Group related prompts with consistent naming
+- Keep prompts focused on a single purpose
+- Update prompts as your needs evolve
+
+## Tips for Effective Prompts
+
+- Be specific about what you want
+- Include context when necessary
+- Use formatting (markdown) for complex prompts
+- Test prompts and refine based on results
+`;

--- a/ayunis-core-backend/src/domain/tools/infrastructure/product-knowledge/content/sources.content.ts
+++ b/ayunis-core-backend/src/domain/tools/infrastructure/product-knowledge/content/sources.content.ts
@@ -1,0 +1,32 @@
+export const sourcesContent = `
+# Sources / Document Analysis
+
+Sources provide AI agents with knowledge from your documents, enabling document analysis.
+
+## What are Sources?
+
+Sources are documents that:
+- Get processed and indexed for semantic search
+- Provide context to AI conversations
+- Enable agents to answer questions about your specific content
+
+## Supported File Types
+
+- **PDF**: Documents, reports, manuals
+- **CSV**: Tabular data for analysis
+
+## Adding Sources
+
+1. Navigate to **Sources** in the sidebar
+2. Click **Upload Document**
+3. Select your file
+4. Wait for processing to complete
+
+
+## Using Sources with Agents
+
+1. Go to **Agents** in the sidebar
+2. Select an agent
+3. In the **Knowledge Base** section, upload your documents
+4. The agent will now use those documents when answering questions
+`;

--- a/ayunis-core-backend/src/domain/tools/infrastructure/product-knowledge/content/tools.content.ts
+++ b/ayunis-core-backend/src/domain/tools/infrastructure/product-knowledge/content/tools.content.ts
@@ -1,0 +1,21 @@
+export const toolsContent = `
+# Tools
+
+Tools extend AI capabilities by allowing agents to perform actions beyond text generation.
+
+## Available Tool Types
+
+### Always Available Tools
+These tools are automatically available in all conversations:
+- **Internet Search**: Search the web for up-to-date information
+- **Website Content**: Fetch and read content from URLs
+- **Code Execution**: Execute Python code with data analysis capabilities
+- **Charts**: Generate bar charts, line charts, and pie charts
+- **Product Knowledge**: Search the product knowledge base for information about Ayunis Core
+
+## How Tools Work
+
+1. The AI decides when to use a tool based on the conversation
+2. The tool executes and returns results
+3. The AI incorporates the results into its response
+`;

--- a/ayunis-core-backend/src/domain/tools/infrastructure/product-knowledge/product-knowledge.adapter.ts
+++ b/ayunis-core-backend/src/domain/tools/infrastructure/product-knowledge/product-knowledge.adapter.ts
@@ -1,0 +1,33 @@
+import { Injectable } from '@nestjs/common';
+import { ProductKnowledgePort } from 'src/domain/tools/application/ports/product-knowledge.port';
+import { ProductKnowledgeTopic } from 'src/domain/tools/domain/tools/product-knowledge-tool.entity';
+import {
+  gettingStartedContent,
+  agentsContent,
+  toolsContent,
+  promptsContent,
+  sourcesContent,
+  modelsContent,
+} from './content';
+
+@Injectable()
+export class ProductKnowledgeAdapter extends ProductKnowledgePort {
+  getContent(topic: ProductKnowledgeTopic): string {
+    switch (topic) {
+      case ProductKnowledgeTopic.GETTING_STARTED:
+        return gettingStartedContent;
+      case ProductKnowledgeTopic.AGENTS:
+        return agentsContent;
+      case ProductKnowledgeTopic.TOOLS:
+        return toolsContent;
+      case ProductKnowledgeTopic.PROMPTS:
+        return promptsContent;
+      case ProductKnowledgeTopic.SOURCES:
+        return sourcesContent;
+      case ProductKnowledgeTopic.MODELS:
+        return modelsContent;
+      default:
+        throw new Error(`Unknown product knowledge topic: ${topic as string}`);
+    }
+  }
+}

--- a/ayunis-core-backend/src/domain/tools/tools.module.ts
+++ b/ayunis-core-backend/src/domain/tools/tools.module.ts
@@ -19,6 +19,9 @@ import { ThreadsModule } from '../threads/threads.module';
 import { McpModule } from '../mcp/mcp.module';
 import { McpIntegrationToolHandler } from './application/handlers/mcp-integration-tool.handler';
 import { McpIntegrationResourceHandler } from './application/handlers/mcp-integration-resource.handler';
+import { ProductKnowledgeToolHandler } from './application/handlers/product-knowledge-tool.handler';
+import { ProductKnowledgePort } from './application/ports/product-knowledge.port';
+import { ProductKnowledgeAdapter } from './infrastructure/product-knowledge/product-knowledge.adapter';
 
 @Module({
   imports: [
@@ -42,6 +45,11 @@ import { McpIntegrationResourceHandler } from './application/handlers/mcp-integr
     CodeExecutionToolHandler,
     McpIntegrationToolHandler,
     McpIntegrationResourceHandler,
+    ProductKnowledgeToolHandler,
+    {
+      provide: ProductKnowledgePort,
+      useClass: ProductKnowledgeAdapter,
+    },
     // Repositories and factories
     {
       provide: ToolConfigRepository,

--- a/ayunis-core-frontend/src/pages/new-chat/model/quickActionsData.ts
+++ b/ayunis-core-frontend/src/pages/new-chat/model/quickActionsData.ts
@@ -1,4 +1,4 @@
-import { Pencil, Search, FileText, Eye, type LucideIcon } from 'lucide-react';
+import { Pencil, Search, FileText, Eye, HelpCircle, type LucideIcon } from 'lucide-react';
 
 export interface QuickActionPrompt {
   labelKey: string;
@@ -102,6 +102,37 @@ export const QUICK_ACTIONS: QuickActionCategory[] = [
       {
         labelKey: 'prompts.analyze.strengthsWeaknesses',
         contentKey: 'prompts.analyze.strengthsWeaknessesContent',
+      },
+    ],
+  },
+  {
+    id: 'help',
+    labelKey: 'categories.help',
+    icon: HelpCircle,
+    prompts: [
+      {
+        labelKey: 'prompts.help.gettingStarted',
+        contentKey: 'prompts.help.gettingStartedContent',
+      },
+      {
+        labelKey: 'prompts.help.createAgent',
+        contentKey: 'prompts.help.createAgentContent',
+      },
+      {
+        labelKey: 'prompts.help.availableTools',
+        contentKey: 'prompts.help.availableToolsContent',
+      },
+      {
+        labelKey: 'prompts.help.uploadSources',
+        contentKey: 'prompts.help.uploadSourcesContent',
+      },
+      {
+        labelKey: 'prompts.help.savePrompts',
+        contentKey: 'prompts.help.savePromptsContent',
+      },
+      {
+        labelKey: 'prompts.help.chooseModel',
+        contentKey: 'prompts.help.chooseModelContent',
       },
     ],
   },

--- a/ayunis-core-frontend/src/shared/locales/de/quickActions.json
+++ b/ayunis-core-frontend/src/shared/locales/de/quickActions.json
@@ -3,7 +3,8 @@
     "writing": "Schreiben",
     "research": "Recherche",
     "summarize": "Zusammenfassen",
-    "analyze": "Analysieren"
+    "analyze": "Analysieren",
+    "help": "Hilfe"
   },
   "prompts": {
     "writing": {
@@ -45,6 +46,20 @@
       "evaluateProposalContent": "Könntest du einen Vorschlag für mich bewerten? Falls du weitere Informationen von mir brauchst, stelle mir direkt 1-2 wichtige Fragen. Eine Darstellung mit Pro und Contra wäre hilfreich.",
       "strengthsWeaknesses": "Stärken und Schwächen",
       "strengthsWeaknessesContent": "Könntest du die Stärken und Schwächen von etwas analysieren? Falls du weitere Informationen von mir brauchst, stelle mir direkt 1-2 wichtige Fragen. Eine tabellarische oder strukturierte Gegenüberstellung wäre ideal."
+    },
+    "help": {
+      "gettingStarted": "Wie fange ich mit Ayunis an?",
+      "gettingStartedContent": "Wie fange ich mit Ayunis an? Bitte nutze das Produktwissen-Tool, um mir einen kurzen Überblick über die wichtigsten Funktionen und wie ich sie nutzen kann zu geben.",
+      "createAgent": "Wie erstelle ich einen KI-Agenten?",
+      "createAgentContent": "Wie erstelle ich einen KI-Agenten? Bitte nutze das Produktwissen-Tool, um mir die Schritte und Konfigurationsmöglichkeiten zu erklären.",
+      "availableTools": "Welche Tools können meine Agenten nutzen?",
+      "availableToolsContent": "Welche Tools stehen meinen KI-Agenten zur Verfügung? Bitte nutze das Produktwissen-Tool, um mir zu erklären, was jedes Tool macht und wann ich es einsetzen sollte.",
+      "uploadSources": "Wie füge ich Quellen für RAG hinzu?",
+      "uploadSourcesContent": "Wie lade ich Dokumente hoch und füge Quellen für meine Agenten hinzu? Bitte nutze das Produktwissen-Tool, um mir zu erklären, welche Dateiformate unterstützt werden.",
+      "savePrompts": "Wie speichere und nutze ich Prompts wieder?",
+      "savePromptsContent": "Wie erstelle und speichere ich Prompt-Vorlagen zur Wiederverwendung? Bitte nutze das Produktwissen-Tool, um mir zu erklären, wie die Prompt-Bibliothek funktioniert.",
+      "chooseModel": "Welches KI-Modell soll ich verwenden?",
+      "chooseModelContent": "Welches KI-Modell soll ich wählen? Bitte nutze das Produktwissen-Tool, um mir die verschiedenen Anbieter und Modelle zu erklären und wofür sie am besten geeignet sind."
     }
   }
 }

--- a/ayunis-core-frontend/src/shared/locales/en/quickActions.json
+++ b/ayunis-core-frontend/src/shared/locales/en/quickActions.json
@@ -3,7 +3,8 @@
     "writing": "Write",
     "research": "Research",
     "summarize": "Summarize",
-    "analyze": "Analyze"
+    "analyze": "Analyze",
+    "help": "Help"
   },
   "prompts": {
     "writing": {
@@ -45,6 +46,20 @@
       "evaluateProposalContent": "Could you evaluate a proposal for me? If you need more information from me, please ask 1-2 key questions directly. A presentation with pros and cons would be helpful.",
       "strengthsWeaknesses": "Strengths and weaknesses",
       "strengthsWeaknessesContent": "Could you analyze the strengths and weaknesses of something? If you need more information from me, please ask 1-2 key questions directly. A tabular or structured comparison would be ideal."
+    },
+    "help": {
+      "gettingStarted": "How do I get started with Ayunis?",
+      "gettingStartedContent": "How do I get started with Ayunis? Please use the product knowledge tool to give me a quick overview of the key features and how to use them.",
+      "createAgent": "How do I create an AI agent?",
+      "createAgentContent": "How do I create an AI agent? Please use the product knowledge tool to explain the steps and what options I have for configuring it.",
+      "availableTools": "What tools can my agents use?",
+      "availableToolsContent": "What tools are available for my AI agents? Please use the product knowledge tool to explain what each tool does and when to use it.",
+      "uploadSources": "How do I add sources for RAG?",
+      "uploadSourcesContent": "How do I upload documents and add sources for my agents to use? Please use the product knowledge tool to explain what file types are supported.",
+      "savePrompts": "How do I save and reuse prompts?",
+      "savePromptsContent": "How do I create and save prompt templates for reuse? Please use the product knowledge tool to explain how the prompt library works.",
+      "chooseModel": "Which AI model should I use?",
+      "chooseModelContent": "Which AI model should I choose? Please use the product knowledge tool to explain the different providers and models available and what they're best for."
     }
   }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces an always-available Product Knowledge tool with backend handler/content and adds a Help quick-actions category with localized prompts.
> 
> - **Backend**:
>   - **New tool**: Add `PRODUCT_KNOWLEDGE` tool (`ProductKnowledgeTool`) with schema validation and non-PII return.
>   - **Execution**: Implement `ProductKnowledgeToolHandler` using `ProductKnowledgePort` with `ProductKnowledgeAdapter` and static docs for topics (`getting_started`, `agents`, `tools`, `prompts`, `sources`, `models`).
>   - **Wiring**: Register handler in `ToolHandlerRegistry`, bind port in `ToolsModule`, expose in `ToolFactory` (+tests), and extend `ToolType` enum.
>   - **Availability**: Include `PRODUCT_KNOWLEDGE` in always-available tools during run execution.
> - **Frontend**:
>   - **Quick Actions**: Add `help` category (icon `HelpCircle`) with prompts for getting started, agents, tools, sources, prompts, and model selection.
>   - **i18n**: Add corresponding English and German strings.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 528f24bf86d75e7422f2b708fd0157f62c3672c2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->