### PR TITLE
Dynamic time-based chat header

### DIFF
--- a/ayunis-core-frontend/package-lock.json
+++ b/ayunis-core-frontend/package-lock.json
@@ -154,7 +154,6 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -247,7 +246,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.27.4.tgz",
       "integrity": "sha512-bXYxrXFubeYdvB0NhD/NBB3Qi6aZeV20GOWVI47t2dkecCEoneR4NPVcb7abpXDEvejgrUfFtG6vG/zxAKmg+g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -612,7 +610,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -636,7 +633,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3692,7 +3688,6 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -3807,7 +3802,6 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -3948,7 +3942,6 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -4375,7 +4368,6 @@
       "resolved": "https://registry.npmjs.org/@tanstack/react-router/-/react-router-1.120.15.tgz",
       "integrity": "sha512-apzBmXh4pHwqUGU3kD8y2FJMi7rVoUbRxh5oV7v8kEb6Aq5Xpdo+OcpThw8h/M2zv7v4Ef8IoY6WFCKKu3HBjQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@tanstack/history": "1.115.0",
         "@tanstack/react-store": "^0.7.0",
@@ -4441,7 +4433,6 @@
       "resolved": "https://registry.npmjs.org/@tanstack/router-core/-/router-core-1.120.15.tgz",
       "integrity": "sha512-soLj+mEuvSxAVFK/3b85IowkkvmSuQL6J0RSIyKJFGFgy0CmUzpcBGEO99+JNWvvvzHgIoY4F4KtLIN+rvFSFA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@tanstack/history": "1.115.0",
         "@tanstack/store": "^0.7.0",
@@ -4614,7 +4605,6 @@
       "integrity": "sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -4875,7 +4865,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.6.tgz",
       "integrity": "sha512-JeG0rEWak0N6Itr6QUx+X60uQmN+5t3j9r/OVDtWzFXKaj6kD1BwJzOksD0FF6iWxZlbE1kB0q9vtnU2ekqa1Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -4886,7 +4875,6 @@
       "integrity": "sha512-4hOiT/dwO8Ko0gV1m/TJZYk3y0KBnY9vzDh7W+DH17b2HFSOGgdj33dhihPeuy3l0q23+4e+hoXHV6hCC4dCXw==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.0.0"
       }
@@ -4959,7 +4947,6 @@
       "integrity": "sha512-tK3GPFWbirvNgsNKto+UmB/cRtn6TZfyw0D6IKrW55n6Vbs7KJoZtI//kpTKzE/DUmmnAFD8/Ca46s7Obs92/w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.46.4",
         "@typescript-eslint/types": "8.46.4",
@@ -5331,7 +5318,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5798,7 +5784,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001718",
         "electron-to-chromium": "^1.5.160",
@@ -6178,8 +6163,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/d3-array": {
       "version": "3.2.4",
@@ -6935,7 +6919,6 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6996,7 +6979,6 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -8212,7 +8194,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.27.1"
       },
@@ -8877,7 +8858,6 @@
       "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",
@@ -8918,7 +8898,6 @@
       "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 10.16.0"
       }
@@ -11281,7 +11260,6 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
       "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -11421,7 +11399,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
       "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -11452,7 +11429,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
       "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.26.0"
       },
@@ -11465,7 +11441,6 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.58.1.tgz",
       "integrity": "sha512-Lml/KZYEEFfPhUVgE0RdCVpnC4yhW+PndRhbiTtdvSlQTL8IfVR+iQkBjLIvmmc6+GGoVeM11z37ktKFPAb0FA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -12207,7 +12182,6 @@
       "resolved": "https://registry.npmjs.org/seroval/-/seroval-1.3.2.tgz",
       "integrity": "sha512-RbcPH1n5cfwKrru7v7+zrZvjLurgHhGyso3HTyGtRivGWgYjbOmGuivCQaORNELjNONoK35nj28EoWul9sb1zQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -12474,7 +12448,6 @@
       "resolved": "https://registry.npmjs.org/solid-js/-/solid-js-1.9.7.tgz",
       "integrity": "sha512-/saTKi8iWEM233n5OSi1YHCCuh66ZIQ7aK2hsToPe4tqGm7qAejU1SwNuTPivbWAYq7SjuHVVYxxuZQNRbICiw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.1.0",
         "seroval": "~1.3.0",
@@ -12830,8 +12803,7 @@
       "version": "4.1.8",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.8.tgz",
       "integrity": "sha512-kjeW8gjdxasbmFKpVGrGd5T4i40mV5J2Rasw48QARfYeQ8YS9x02ON9SFWax3Qf616rt4Cp3nVNIj6Hd1mP3og==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/tailwindcss-animate": {
       "version": "1.0.7",
@@ -12881,8 +12853,7 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/tiny-warning": {
       "version": "1.0.3",
@@ -12939,7 +12910,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
       "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -13211,7 +13181,6 @@
       "integrity": "sha512-5PzUddaA9FbaarUzIsEc4wNXCiO4Ot3bJNeMF2qKpYlTmM9TTaSHQ7162w756ERCkXER/+o2purRG6YOAv6EMA==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@gerrit0/mini-shiki": "^3.2.2",
         "lunr": "^2.3.9",
@@ -13249,7 +13218,6 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -13663,7 +13631,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.5.tgz",
       "integrity": "sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -13775,7 +13742,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
       "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -14225,7 +14191,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.55.tgz",
       "integrity": "sha512-219huNnkSLQnLsQ3uaRjXsxMrVm5C9W3OOpEVt2k5tvMKuA8nBSu38e0B//a+he9Iq2dvmk2VyYVlHqiHa4YBA==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/ayunis-core-frontend/src/pages/new-chat/model/useTimeBasedGreeting.ts
+++ b/ayunis-core-frontend/src/pages/new-chat/model/useTimeBasedGreeting.ts
@@ -47,6 +47,26 @@ const greetings: Record<string, Greeting[]> = {
       de: 'Selbst der Kopierer schläft noch. Was kann ich tun?',
       en: 'Even the copier is still sleeping. How can I help?',
     },
+    {
+      de: 'Um diese Zeit? Sie meinen es ernst mit der Verwaltung.',
+      en: 'At this hour? You take administration seriously.',
+    },
+    {
+      de: 'Die Jalousien sind noch unten. Der Service ist oben.',
+      en: 'The blinds are still down. The service is up.',
+    },
+    {
+      de: 'Bevor die ersten Stempel fallen – was steht an?',
+      en: 'Before the first stamps drop – what can I do?',
+    },
+    {
+      de: 'Der Drucker heizt vor. Ich bin schon warm.',
+      en: "The printer is warming up. I'm already warm.",
+    },
+    {
+      de: 'Ganz früh dran. Die Formulare warten schon.',
+      en: 'Very early. The forms are already waiting.',
+    },
   ],
 
   // 8–10 Uhr (Klassischer Dienstbeginn / Classic Office Start)
@@ -86,6 +106,26 @@ const greetings: Record<string, Greeting[]> = {
     {
       de: 'Zimmer 101 ist besetzt. Zimmer KI ist frei.',
       en: 'Room 101 is occupied. Room AI is available.',
+    },
+    {
+      de: 'Erster Kaffee, erste Anfrage. Passt.',
+      en: 'First coffee, first request. Perfect.',
+    },
+    {
+      de: 'Die Unterschriftenmappe liegt bereit. Was soll rein?',
+      en: "The signature folder is ready. What's going in?",
+    },
+    {
+      de: 'Frisch gestempelt und bereit für Ihre Fragen.',
+      en: 'Freshly stamped and ready for your questions.',
+    },
+    {
+      de: 'Der Postbote war noch nicht da. Ich schon.',
+      en: "The mailman hasn't arrived yet. I have.",
+    },
+    {
+      de: 'Morgens um acht macht die Behörde auf. Und ich mit.',
+      en: 'The office opens at eight. And so do I.',
     },
   ],
 
@@ -127,6 +167,26 @@ const greetings: Record<string, Greeting[]> = {
       de: 'Alle Schalter besetzt. Dieser hier ist immer frei.',
       en: 'All counters occupied. This one is always free.',
     },
+    {
+      de: 'Volle Auslastung im Amt. Null Wartezeit hier.',
+      en: 'Full capacity at the office. Zero wait time here.',
+    },
+    {
+      de: 'Der Kopierer qualmt. Ich nicht.',
+      en: "The copier is smoking. I'm not.",
+    },
+    {
+      de: 'Telefone klingeln überall. Hier ist es ruhig.',
+      en: "Phones ringing everywhere. It's quiet here.",
+    },
+    {
+      de: 'Peak Performance in der Verwaltung. Fragen Sie los.',
+      en: 'Peak performance in administration. Ask away.',
+    },
+    {
+      de: 'Die Stempel sind heiß gelaufen. Meiner nicht.',
+      en: "The stamps are overheating. Mine isn't.",
+    },
   ],
 
   // 12–13 Uhr (Mittagspause / Lunch Break)
@@ -166,6 +226,26 @@ const greetings: Record<string, Greeting[]> = {
     {
       de: 'Die Kollegen sind beim Mensa-Schnitzel. Ich bin hier.',
       en: "The colleagues are at the cafeteria schnitzel. I'm here.",
+    },
+    {
+      de: 'Mittagstisch nebenan. Servicetisch hier.',
+      en: 'Lunch table next door. Service table here.',
+    },
+    {
+      de: 'Die Kaffeekanne ist leer. Mein Wissen nicht.',
+      en: 'The coffee pot is empty. My knowledge is not.',
+    },
+    {
+      de: 'Alle beim Essen. Ich bei der Arbeit.',
+      en: "Everyone's eating. I'm working.",
+    },
+    {
+      de: 'Brotzeit für die Belegschaft. Beratung für Sie.',
+      en: 'Lunch for the staff. Consultation for you.',
+    },
+    {
+      de: 'Der Pausenraum ist voll. Der Chat ist bereit.',
+      en: 'The break room is full. The chat is ready.',
     },
   ],
 
@@ -207,6 +287,26 @@ const greetings: Record<string, Greeting[]> = {
       de: 'Espresso-Zeit für Menschen. Antwort-Zeit für mich.',
       en: 'Espresso time for humans. Answer time for me.',
     },
+    {
+      de: 'Müde Augen am Bildschirm? Meine sind hellwach.',
+      en: 'Tired eyes on the screen? Mine are wide awake.',
+    },
+    {
+      de: 'Die Tastatur klappert langsamer. Meine nicht.',
+      en: "The keyboards are clicking slower. Mine isn't.",
+    },
+    {
+      de: 'Siesta-Stimmung im Großraumbüro. Hier herrscht Betrieb.',
+      en: "Siesta mood in the open office. It's busy here.",
+    },
+    {
+      de: 'Der Nachmittagskaffee dampft. Ich dampfe vor Tatendrang.',
+      en: "The afternoon coffee is steaming. I'm steaming with enthusiasm.",
+    },
+    {
+      de: 'Energietief? Nicht bei mir.',
+      en: 'Energy low? Not with me.',
+    },
   ],
 
   // 15–17 Uhr (Nachmittagsschicht / Afternoon Shift)
@@ -246,6 +346,26 @@ const greetings: Record<string, Greeting[]> = {
     {
       de: 'Der Parkplatz leert sich. Der Service bleibt.',
       en: 'The parking lot is emptying. The service stays.',
+    },
+    {
+      de: 'Bald ist Feierabend. Noch Zeit für eine Frage?',
+      en: 'Closing time soon. Time for one more question?',
+    },
+    {
+      de: 'Die Akten werden zugeklappt. Mein Ohr bleibt offen.',
+      en: 'The files are being closed. My ear stays open.',
+    },
+    {
+      de: 'Countdown zum Dienstschluss. Bei mir läuft keine Uhr.',
+      en: "Countdown to closing. There's no clock running for me.",
+    },
+    {
+      de: 'Die letzten Unterschriften des Tages. Und Ihre Frage?',
+      en: 'The last signatures of the day. And your question?',
+    },
+    {
+      de: 'Kurz vor Torschluss. Aber die Tür steht offen.',
+      en: 'Just before closing. But the door is open.',
     },
   ],
 
@@ -287,6 +407,26 @@ const greetings: Record<string, Greeting[]> = {
       de: 'Abendsprechstunde ohne Termin. Was führt Sie her?',
       en: 'Evening consultation without appointment. What brings you here?',
     },
+    {
+      de: 'Überstunden für Menschen. Normalzeit für mich.',
+      en: 'Overtime for humans. Regular time for me.',
+    },
+    {
+      de: 'Das Bürolicht ist aus. Der Bildschirm leuchtet noch.',
+      en: 'The office light is off. The screen is still glowing.',
+    },
+    {
+      de: 'Nach 17 Uhr? Kein Problem, ich habe Gleitzeit.',
+      en: 'After 5 PM? No problem, I have flexible hours.',
+    },
+    {
+      de: 'Die Reinigungskraft kommt. Der Service geht nicht.',
+      en: "The cleaner is coming. The service isn't leaving.",
+    },
+    {
+      de: 'Feierabendbier für andere. Feierabend-Service für Sie.',
+      en: 'After-work beer for others. After-work service for you.',
+    },
   ],
 
   // 21–6 Uhr (Nachtschicht / Night Shift)
@@ -326,6 +466,30 @@ const greetings: Record<string, Greeting[]> = {
     {
       de: 'Auch Nachteulen verdienen Verwaltung.',
       en: 'Even night owls deserve administration.',
+    },
+    {
+      de: 'Schlaflos in der Behörde? Ich auch – freiwillig.',
+      en: "Sleepless at the office? Me too – voluntarily.",
+    },
+    {
+      de: 'Die Sterne leuchten. Mein Service auch.',
+      en: 'The stars are shining. So is my service.',
+    },
+    {
+      de: 'Mitternachtsbürokratie. Ganz ohne Papierkram.',
+      en: 'Midnight bureaucracy. Without any paperwork.',
+    },
+    {
+      de: 'Wenn die Stadt schläft, wacht der Chatbot.',
+      en: 'When the city sleeps, the chatbot watches.',
+    },
+    {
+      de: 'Zu später Stunde noch Fragen? Immer gerne.',
+      en: 'Questions at this late hour? Always welcome.',
+    },
+    {
+      de: 'Die Nachtschicht hat begonnen. Was kann ich tun?',
+      en: 'The night shift has begun. What can I do?',
     },
   ],
 };

--- a/ayunis-core-frontend/src/pages/new-chat/model/useTimeBasedGreeting.ts
+++ b/ayunis-core-frontend/src/pages/new-chat/model/useTimeBasedGreeting.ts
@@ -1,0 +1,239 @@
+import { useMemo } from 'react';
+
+interface Greeting {
+  de: string;
+  en: string;
+}
+
+// Time-based greetings with German bureaucratic humor
+// Each time period has a set of greetings to randomly choose from
+
+const greetings: Record<string, Greeting[]> = {
+  // 6–8 Uhr (Die Frühaufsteher / Early Birds)
+  earlyMorning: [
+    {
+      de: 'Noch vor dem ersten Bürger am Schalter – Respekt!',
+      en: 'Before the first citizen at the counter – respect!',
+    },
+    {
+      de: 'Die Akten sind noch kalt. Was brennt bei Ihnen?',
+      en: "The files are still cold. What's burning for you?",
+    },
+    {
+      de: 'Frühdienst. Der Kaffee zieht noch.',
+      en: "Early shift. The coffee's still brewing.",
+    },
+    {
+      de: 'Vor Dienstbeginn schon produktiv? Vorbildlich.',
+      en: 'Productive before office hours? Exemplary.',
+    },
+    {
+      de: 'Das Faxgerät wärmt sich gerade auf.',
+      en: 'The fax machine is just warming up.',
+    },
+  ],
+
+  // 8–10 Uhr (Klassischer Dienstbeginn / Classic Office Start)
+  morningStart: [
+    {
+      de: 'Die Behörde ist geöffnet. Bitte ziehen Sie eine Nummer... oder fragen Sie einfach.',
+      en: 'The office is open. Please take a number... or just ask.',
+    },
+    {
+      de: 'Pünktlich wie ein Beamter. Was liegt an?',
+      en: "Punctual as a civil servant. What's on the agenda?",
+    },
+    {
+      de: 'Der Amtsschimmel ist gesattelt.',
+      en: 'The bureaucratic horse is saddled.',
+    },
+    {
+      de: 'Dienstbeginn. Ihr Anliegen, bitte.',
+      en: 'Office hours begin. Your request, please.',
+    },
+    {
+      de: 'Die Posteingänge sind sortiert – jetzt Sie.',
+      en: "The inboxes are sorted – now it's your turn.",
+    },
+  ],
+
+  // 10–12 Uhr (Hochbetrieb / Peak Hours)
+  lateMorning: [
+    {
+      de: 'Kernarbeitszeit. Alle Sachbearbeiter im Einsatz.',
+      en: 'Core working hours. All clerks on duty.',
+    },
+    {
+      de: 'Stoßzeit am Schalter – gut, dass Sie digital hier sind.',
+      en: "Rush hour at the counter – good thing you're here digitally.",
+    },
+    {
+      de: 'Zwischen Bauantrag und Bürgeranfrage: Was kann ich tun?',
+      en: 'Between building permits and citizen inquiries: How can I help?',
+    },
+    {
+      de: 'Die Warteschlange wäre jetzt lang. Hier nicht.',
+      en: "The queue would be long now. Not here.",
+    },
+    {
+      de: 'Mitten im Tagesgeschäft. Schießen Sie los.',
+      en: 'In the middle of daily business. Fire away.',
+    },
+  ],
+
+  // 12–13 Uhr (Mittagspause / Lunch Break)
+  lunchBreak: [
+    {
+      de: 'Das Amt ist in der Mittagspause. Ich nicht.',
+      en: "The office is on lunch break. I'm not.",
+    },
+    {
+      de: 'Zwischen 12 und 13 Uhr geschlossen – außer hier.',
+      en: 'Closed between 12 and 1 – except here.',
+    },
+    {
+      de: 'Die Kantine ist voll. Der Chat ist leer. Perfektes Timing.',
+      en: 'The cafeteria is full. The chat is empty. Perfect timing.',
+    },
+    {
+      de: 'Mittagspause? Für mich ein Fremdwort.',
+      en: "Lunch break? A foreign concept to me.",
+    },
+    {
+      de: 'Der Schalter wäre jetzt zu. Fragen Sie trotzdem.',
+      en: 'The counter would be closed now. Ask anyway.',
+    },
+  ],
+
+  // 13–15 Uhr (Suppenkoma / Food Coma)
+  earlyAfternoon: [
+    {
+      de: 'Das Schnitzel wirkt. Ich bin trotzdem wach.',
+      en: "The schnitzel is kicking in. I'm still awake though.",
+    },
+    {
+      de: 'Nachmittagstief in der Amtsstube – gut, dass ich keins habe.',
+      en: "Afternoon slump in the office – good thing I don't have one.",
+    },
+    {
+      de: 'Die Kollegen verdauen. Ich arbeite.',
+      en: "The colleagues are digesting. I'm working.",
+    },
+    {
+      de: 'Schwere Augenlider am Schreibtisch? Hier nicht.',
+      en: 'Heavy eyelids at the desk? Not here.',
+    },
+    {
+      de: 'Post-Kantine-Produktivität. Wie kann ich helfen?',
+      en: 'Post-cafeteria productivity. How can I help?',
+    },
+  ],
+
+  // 15–17 Uhr (Nachmittagsschicht / Afternoon Shift)
+  lateAfternoon: [
+    {
+      de: 'Die Sprechstunde neigt sich dem Ende zu – fragen Sie schnell.',
+      en: "Office hours are coming to an end – ask quickly.",
+    },
+    {
+      de: 'Noch im Dienst. Was kann ich klären?',
+      en: 'Still on duty. What can I clarify?',
+    },
+    {
+      de: 'Letzte Runde vor Feierabend. Was brauchen Sie?',
+      en: 'Last round before closing time. What do you need?',
+    },
+    {
+      de: 'Die Ausgangskörbe füllen sich. Und Ihr Anliegen?',
+      en: 'The outboxes are filling up. And your request?',
+    },
+    {
+      de: 'Endspurt. Welcher Vorgang soll noch raus?',
+      en: 'Final sprint. Which case should still go out?',
+    },
+  ],
+
+  // 17–21 Uhr (Nach Dienstschluss / After Hours)
+  evening: [
+    {
+      de: 'Das Rathaus ist zu. Ich nicht.',
+      en: "City hall is closed. I'm not.",
+    },
+    {
+      de: 'Feierabend für Menschen, Bereitschaft für mich.',
+      en: 'Closing time for humans, standby for me.',
+    },
+    {
+      de: 'Öffnungszeiten? Kenne ich nicht.',
+      en: "Opening hours? I don't know them.",
+    },
+    {
+      de: 'Die Lichter im Amt sind aus – hier brennt noch eins.',
+      en: "The lights in the office are off – one's still on here.",
+    },
+    {
+      de: 'Außerhalb der Geschäftszeiten, aber voll funktionsfähig.',
+      en: 'Outside business hours, but fully operational.',
+    },
+  ],
+
+  // 21–6 Uhr (Nachtschicht / Night Shift)
+  night: [
+    {
+      de: 'Nachtbereitschaft. Was führt Sie her?',
+      en: 'Night duty. What brings you here?',
+    },
+    {
+      de: 'Während das Amt schläft: Wie kann ich helfen?',
+      en: 'While the office sleeps: How can I help?',
+    },
+    {
+      de: '24-Stunden-Verwaltung. Ohne Wartemarke.',
+      en: '24-hour administration. No waiting ticket needed.',
+    },
+    {
+      de: 'Die Akten ruhen. Ich nicht.',
+      en: "The files are resting. I'm not.",
+    },
+    {
+      de: 'Nächtlicher Behördengang – ganz ohne kalte Flure.',
+      en: 'Nightly visit to the authorities – without the cold hallways.',
+    },
+  ],
+};
+
+function getTimePeriod(hour: number): keyof typeof greetings {
+  if (hour >= 6 && hour < 8) return 'earlyMorning';
+  if (hour >= 8 && hour < 10) return 'morningStart';
+  if (hour >= 10 && hour < 12) return 'lateMorning';
+  if (hour >= 12 && hour < 13) return 'lunchBreak';
+  if (hour >= 13 && hour < 15) return 'earlyAfternoon';
+  if (hour >= 15 && hour < 17) return 'lateAfternoon';
+  if (hour >= 17 && hour < 21) return 'evening';
+  // 21-6 is night (including 0-5)
+  return 'night';
+}
+
+function getRandomGreeting(period: keyof typeof greetings): Greeting {
+  const periodGreetings = greetings[period];
+  const randomIndex = Math.floor(Math.random() * periodGreetings.length);
+  return periodGreetings[randomIndex];
+}
+
+/**
+ * Returns a time-based greeting with German bureaucratic humor.
+ * The greeting changes based on the current time of day and is randomly
+ * selected from a list of greetings for that time period.
+ *
+ * The greeting is memoized and only recalculated when the component mounts
+ * (not on every render), so it stays consistent during the session.
+ */
+export function useTimeBasedGreeting(): Greeting {
+  const greeting = useMemo(() => {
+    const hour = new Date().getHours();
+    const period = getTimePeriod(hour);
+    return getRandomGreeting(period);
+  }, []);
+
+  return greeting;
+}

--- a/ayunis-core-frontend/src/pages/new-chat/model/useTimeBasedGreeting.ts
+++ b/ayunis-core-frontend/src/pages/new-chat/model/useTimeBasedGreeting.ts
@@ -1,4 +1,5 @@
 import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
 
 interface Greeting {
   de: string;
@@ -517,15 +518,21 @@ function getRandomGreeting(period: keyof typeof greetings): Greeting {
  * The greeting changes based on the current time of day and is randomly
  * selected from a list of greetings for that time period.
  *
+ * The greeting is returned in the user's current language (German or English).
+ *
  * The greeting is memoized and only recalculated when the component mounts
  * (not on every render), so it stays consistent during the session.
  */
-export function useTimeBasedGreeting(): Greeting {
+export function useTimeBasedGreeting(): string {
+  const { i18n } = useTranslation();
+
   const greeting = useMemo(() => {
     const hour = new Date().getHours();
     const period = getTimePeriod(hour);
     return getRandomGreeting(period);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  return greeting;
+  // Return greeting in user's language (default to German if not English)
+  return i18n.language === 'en' ? greeting.en : greeting.de;
 }

--- a/ayunis-core-frontend/src/pages/new-chat/model/useTimeBasedGreeting.ts
+++ b/ayunis-core-frontend/src/pages/new-chat/model/useTimeBasedGreeting.ts
@@ -31,6 +31,22 @@ const greetings: Record<string, Greeting[]> = {
       de: 'Das Faxgerät wärmt sich gerade auf.',
       en: 'The fax machine is just warming up.',
     },
+    {
+      de: 'Der frühe Bürger fängt den Sachbearbeiter.',
+      en: 'The early citizen catches the clerk.',
+    },
+    {
+      de: 'Die Flure sind noch leer. Beste Zeit für Behördengänge.',
+      en: 'The hallways are still empty. Best time for official business.',
+    },
+    {
+      de: 'Morgenstund hat Aktenband im Mund.',
+      en: 'The early bird gets the paperwork done.',
+    },
+    {
+      de: 'Selbst der Kopierer schläft noch. Was kann ich tun?',
+      en: 'Even the copier is still sleeping. How can I help?',
+    },
   ],
 
   // 8–10 Uhr (Klassischer Dienstbeginn / Classic Office Start)
@@ -54,6 +70,22 @@ const greetings: Record<string, Greeting[]> = {
     {
       de: 'Die Posteingänge sind sortiert – jetzt Sie.',
       en: "The inboxes are sorted – now it's your turn.",
+    },
+    {
+      de: 'Die Stempeluhr hat geklingelt. Wie kann ich helfen?',
+      en: 'The time clock has rung. How can I help?',
+    },
+    {
+      de: 'Guten Morgen. Ihr Anliegen in dreifacher Ausfertigung, bitte.',
+      en: 'Good morning. Your request in triplicate, please.',
+    },
+    {
+      de: 'Die Wartemarken sind frisch gedruckt. Sie brauchen keine.',
+      en: "The queue tickets are freshly printed. You don't need one.",
+    },
+    {
+      de: 'Zimmer 101 ist besetzt. Zimmer KI ist frei.',
+      en: 'Room 101 is occupied. Room AI is available.',
     },
   ],
 
@@ -79,6 +111,22 @@ const greetings: Record<string, Greeting[]> = {
       de: 'Mitten im Tagesgeschäft. Schießen Sie los.',
       en: 'In the middle of daily business. Fire away.',
     },
+    {
+      de: 'Hochbetrieb im Bürgerbüro. Hier herrscht Ruhe.',
+      en: "Rush hour at the citizen's office. It's quiet here.",
+    },
+    {
+      de: 'Die Formulare stapeln sich. Ihre Frage passt noch drauf.',
+      en: 'The forms are piling up. Your question still fits.',
+    },
+    {
+      de: 'Aktenzeichen XY ungelöst? Nicht mit mir.',
+      en: 'Case file XY unsolved? Not with me.',
+    },
+    {
+      de: 'Alle Schalter besetzt. Dieser hier ist immer frei.',
+      en: 'All counters occupied. This one is always free.',
+    },
   ],
 
   // 12–13 Uhr (Mittagspause / Lunch Break)
@@ -102,6 +150,22 @@ const greetings: Record<string, Greeting[]> = {
     {
       de: 'Der Schalter wäre jetzt zu. Fragen Sie trotzdem.',
       en: 'The counter would be closed now. Ask anyway.',
+    },
+    {
+      de: 'Currywurst-Pause für die anderen. Service für Sie.',
+      en: 'Currywurst break for the others. Service for you.',
+    },
+    {
+      de: 'Die Mikrowelle piept nebenan. Ich bin einsatzbereit.',
+      en: "The microwave is beeping next door. I'm ready for action.",
+    },
+    {
+      de: 'Geschlossen wegen Mittag? Nicht dieser Schalter.',
+      en: 'Closed for lunch? Not this counter.',
+    },
+    {
+      de: 'Die Kollegen sind beim Mensa-Schnitzel. Ich bin hier.',
+      en: "The colleagues are at the cafeteria schnitzel. I'm here.",
     },
   ],
 
@@ -127,6 +191,22 @@ const greetings: Record<string, Greeting[]> = {
       de: 'Post-Kantine-Produktivität. Wie kann ich helfen?',
       en: 'Post-cafeteria productivity. How can I help?',
     },
+    {
+      de: 'Verdauungsspaziergang? Ich bleibe am Platz.',
+      en: "Digestive walk? I'm staying at my desk.",
+    },
+    {
+      de: 'Die Kaffeemaschine läuft auf Hochtouren. Ich auch.',
+      en: "The coffee machine is running at full speed. So am I.",
+    },
+    {
+      de: 'Mittagsloch im Amt. Hier ist alles dicht.',
+      en: 'Afternoon slump in the office. Everything is tight here.',
+    },
+    {
+      de: 'Espresso-Zeit für Menschen. Antwort-Zeit für mich.',
+      en: 'Espresso time for humans. Answer time for me.',
+    },
   ],
 
   // 15–17 Uhr (Nachmittagsschicht / Afternoon Shift)
@@ -150,6 +230,22 @@ const greetings: Record<string, Greeting[]> = {
     {
       de: 'Endspurt. Welcher Vorgang soll noch raus?',
       en: 'Final sprint. Which case should still go out?',
+    },
+    {
+      de: 'Gleich ist Schichtwechsel. Ich bleibe.',
+      en: "Shift change coming up. I'm staying.",
+    },
+    {
+      de: 'Die Uhr tickt Richtung Feierabend. Meine nicht.',
+      en: "The clock is ticking towards closing time. Mine isn't.",
+    },
+    {
+      de: 'Noch schnell vor Büroschluss? Kein Problem.',
+      en: 'Quick question before closing? No problem.',
+    },
+    {
+      de: 'Der Parkplatz leert sich. Der Service bleibt.',
+      en: 'The parking lot is emptying. The service stays.',
     },
   ],
 
@@ -175,6 +271,22 @@ const greetings: Record<string, Greeting[]> = {
       de: 'Außerhalb der Geschäftszeiten, aber voll funktionsfähig.',
       en: 'Outside business hours, but fully operational.',
     },
+    {
+      de: 'Der Pförtner ist weg. Ich empfange Sie trotzdem.',
+      en: "The doorman is gone. I'll receive you anyway.",
+    },
+    {
+      de: 'Behördenschluss war um 17 Uhr. Hier nicht.',
+      en: 'Office closed at 5 PM. Not here.',
+    },
+    {
+      de: 'Die Aktenschränke sind verschlossen. Mein Wissen nicht.',
+      en: 'The filing cabinets are locked. My knowledge is not.',
+    },
+    {
+      de: 'Abendsprechstunde ohne Termin. Was führt Sie her?',
+      en: 'Evening consultation without appointment. What brings you here?',
+    },
   ],
 
   // 21–6 Uhr (Nachtschicht / Night Shift)
@@ -198,6 +310,22 @@ const greetings: Record<string, Greeting[]> = {
     {
       de: 'Nächtlicher Behördengang – ganz ohne kalte Flure.',
       en: 'Nightly visit to the authorities – without the cold hallways.',
+    },
+    {
+      de: 'Der Nachtwächter macht Runde. Ich mache Service.',
+      en: 'The night watchman is making rounds. I provide service.',
+    },
+    {
+      de: 'Stille im Amt. Laut in meinem Prozessor.',
+      en: 'Silence in the office. Busy in my processor.',
+    },
+    {
+      de: 'Nachtschicht ohne Schichtdienst. Was darf es sein?',
+      en: 'Night shift without shift work. What can I do for you?',
+    },
+    {
+      de: 'Auch Nachteulen verdienen Verwaltung.',
+      en: 'Even night owls deserve administration.',
     },
   ],
 };

--- a/ayunis-core-frontend/src/pages/new-chat/ui/NewChatPage.tsx
+++ b/ayunis-core-frontend/src/pages/new-chat/ui/NewChatPage.tsx
@@ -10,6 +10,7 @@ import { generateUUID } from '@/shared/lib/uuid';
 import type { AgentResponseDto } from '@/shared/api';
 import { SourceResponseDtoType } from '@/shared/api/generated/ayunisCoreAPI.schemas';
 import { usePermittedModels } from '@/features/usePermittedModels';
+import { useTimeBasedGreeting } from '../model/useTimeBasedGreeting';
 
 interface NewChatPageProps {
   prefilledPrompt?: string;
@@ -30,6 +31,7 @@ export default function NewChatPage({
   const { initiateChat } = useInitiateChat();
   const { models } = usePermittedModels();
   const chatInputRef = useRef<ChatInputRef>(null);
+  const greeting = useTimeBasedGreeting();
   const [modelId, setModelId] = useState(selectedModelId);
   const [agentId, setAgentId] = useState(selectedAgentId);
   const [isAnonymous, setIsAnonymous] = useState(false);
@@ -97,7 +99,8 @@ export default function NewChatPage({
       header={<ContentAreaHeader title={t('newChat.newChat')} />}
     >
       <div className="text-center">
-        <h1 className="text-2xl font-bold">{t('newChat.title')}</h1>
+        <h1 className="text-2xl font-bold">{greeting.de}</h1>
+        <p className="text-sm text-muted-foreground mt-1">{greeting.en}</p>
       </div>
       <div className="w-full flex flex-col gap-4 mt-2">
         <ChatInput

--- a/ayunis-core-frontend/src/pages/new-chat/ui/NewChatPage.tsx
+++ b/ayunis-core-frontend/src/pages/new-chat/ui/NewChatPage.tsx
@@ -99,8 +99,7 @@ export default function NewChatPage({
       header={<ContentAreaHeader title={t('newChat.newChat')} />}
     >
       <div className="text-center">
-        <h1 className="text-2xl font-bold">{greeting.de}</h1>
-        <p className="text-sm text-muted-foreground mt-1">{greeting.en}</p>
+        <h1 className="text-2xl font-bold">{greeting}</h1>
       </div>
       <div className="w-full flex flex-col gap-4 mt-2">
         <ChatInput


### PR DESCRIPTION
Add a time-dependent, randomly selected greeting to the new chat page header to enhance user engagement.

---
<a href="https://cursor.com/background-agent?bcId=bc-ed7ea3ed-01fc-42d3-b3df-2e410f44970e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ed7ea3ed-01fc-42d3-b3df-2e410f44970e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces the static New Chat title with a time-dependent, randomly selected, German/English greeting via a new hook.
> 
> - **New Chat UX**:
>   - **Time-based greeting**: Introduces `useTimeBasedGreeting` (`src/pages/new-chat/model/useTimeBasedGreeting.ts`) providing memoized, time-of-day, randomly selected greetings in German/English.
>   - **Header update**: `NewChatPage.tsx` now displays the dynamic greeting in the header (`<h1>`) instead of `t('newChat.title')`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d46bb8aec0285cad4a2b979002d781841b401beb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->