### PR TITLE
fix: Fix confirm modal closing

### DIFF
--- a/ayunis-core-frontend/src/widgets/confirmation-modal/ui/ConfirmationModal.tsx
+++ b/ayunis-core-frontend/src/widgets/confirmation-modal/ui/ConfirmationModal.tsx
@@ -14,8 +14,8 @@ export default function ConfirmationModal() {
   const { isOpen, options, hideConfirmation } = useConfirmationContext();
   const [isLoading, setIsLoading] = useState(false);
 
-  if (!options) return null;
   const handleConfirm = async () => {
+    if (!options) return;
     try {
       setIsLoading(true);
       await options.onConfirm();
@@ -31,27 +31,33 @@ export default function ConfirmationModal() {
     hideConfirmation();
   };
 
-  const isDangerous = options.variant === 'destructive';
+  const isDangerous = options?.variant === 'destructive';
+
+  // Important: Dialog must always be rendered (not conditionally returned) so it receives
+  // the open={false} transition. Without this, Radix UI won't clean up its Portal and
+  // overlay, leaving an invisible layer that blocks all pointer events.
   return (
     <Dialog open={isOpen} onOpenChange={(open) => !open && handleCancel()}>
-      <DialogContent className="sm:max-w-[425px]">
-        <DialogHeader>
-          <DialogTitle>{options.title}</DialogTitle>
-          <DialogDescription>{options.description}</DialogDescription>
-        </DialogHeader>
-        <DialogFooter>
-          <Button variant="outline" onClick={handleCancel} disabled={isLoading}>
-            {options.cancelText || 'Cancel'}
-          </Button>
-          <Button
-            variant={isDangerous ? 'destructive' : 'default'}
-            onClick={() => void handleConfirm()}
-            disabled={isLoading}
-          >
-            {isLoading ? 'Loading...' : options.confirmText || 'Confirm'}
-          </Button>
-        </DialogFooter>
-      </DialogContent>
+      {options && (
+        <DialogContent className="sm:max-w-[425px]">
+          <DialogHeader>
+            <DialogTitle>{options.title}</DialogTitle>
+            <DialogDescription>{options.description}</DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={handleCancel} disabled={isLoading}>
+              {options.cancelText || 'Cancel'}
+            </Button>
+            <Button
+              variant={isDangerous ? 'destructive' : 'default'}
+              onClick={() => void handleConfirm()}
+              disabled={isLoading}
+            >
+              {isLoading ? 'Loading...' : options.confirmText || 'Confirm'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      )}
     </Dialog>
   );
 }

--- a/ayunis-core-frontend/src/widgets/confirmation-modal/ui/ConfirmationModal.tsx
+++ b/ayunis-core-frontend/src/widgets/confirmation-modal/ui/ConfirmationModal.tsx
@@ -45,7 +45,11 @@ export default function ConfirmationModal() {
             <DialogDescription>{options.description}</DialogDescription>
           </DialogHeader>
           <DialogFooter>
-            <Button variant="outline" onClick={handleCancel} disabled={isLoading}>
+            <Button
+              variant="outline"
+              onClick={handleCancel}
+              disabled={isLoading}
+            >
               {options.cancelText || 'Cancel'}
             </Button>
             <Button


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Always keep the Dialog mounted and guard for missing options to fix modal closing and overlay cleanup.
> 
> - **Confirmation Modal (`widgets/confirmation-modal/ui/ConfirmationModal.tsx`)**:
>   - Always render `Dialog`; conditionally render `DialogContent` when `options` exists to ensure Radix portal/overlay cleanup.
>   - Add null-safety: early-return in `handleConfirm` if no `options`; use `options?.variant` for `isDangerous`.
>   - Maintain loading/disabled states on action buttons.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 084dca104639cfca8d07e94aaf5bd90e3334a872. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->