### PR TITLE
fix: force additionalProperties false for openai AYC-000

### DIFF
--- a/ayunis-core-backend/src/domain/models/infrastructure/inference/base-openai-chat.inference.ts
+++ b/ayunis-core-backend/src/domain/models/infrastructure/inference/base-openai-chat.inference.ts
@@ -17,6 +17,7 @@ import retryWithBackoff from 'src/common/util/retryWithBackoff';
 import { InferenceFailedError } from '../../application/models.errors';
 import { MessageRole } from 'src/domain/messages/domain/value-objects/message-role.object';
 import { ThinkingContentParser } from 'src/common/util/thinking-content-parser';
+import { normalizeSchemaForOpenAI } from '../util/normalize-schema-for-openai';
 
 @Injectable()
 export abstract class BaseOpenAIChatInferenceHandler extends InferenceHandler {
@@ -77,7 +78,9 @@ export abstract class BaseOpenAIChatInferenceHandler extends InferenceHandler {
       function: {
         name: tool.name,
         description: tool.description,
-        parameters: tool.parameters as FunctionParameters | undefined,
+        parameters: normalizeSchemaForOpenAI(
+          tool.parameters as Record<string, unknown> | undefined,
+        ) as FunctionParameters | undefined,
       },
     };
   };

--- a/ayunis-core-backend/src/domain/models/infrastructure/stream-inference/base-openai-chat.stream-inference.ts
+++ b/ayunis-core-backend/src/domain/models/infrastructure/stream-inference/base-openai-chat.stream-inference.ts
@@ -18,6 +18,7 @@ import { ThinkingMessageContent } from 'src/domain/messages/domain/message-conte
 import { Tool } from 'src/domain/tools/domain/tool.entity';
 import { MessageRole } from 'src/domain/messages/domain/value-objects/message-role.object';
 import { ThinkingContentParser } from 'src/common/util/thinking-content-parser';
+import { normalizeSchemaForOpenAI } from '../util/normalize-schema-for-openai';
 
 @Injectable()
 export class BaseOpenAIChatStreamInferenceHandler
@@ -101,7 +102,9 @@ export class BaseOpenAIChatStreamInferenceHandler
       function: {
         name: tool.name,
         description: tool.description,
-        parameters: tool.parameters as FunctionParameters | undefined,
+        parameters: normalizeSchemaForOpenAI(
+          tool.parameters as Record<string, unknown> | undefined,
+        ) as FunctionParameters | undefined,
       },
     };
   };

--- a/ayunis-core-backend/src/domain/models/infrastructure/util/normalize-schema-for-openai.spec.ts
+++ b/ayunis-core-backend/src/domain/models/infrastructure/util/normalize-schema-for-openai.spec.ts
@@ -1,0 +1,274 @@
+import { normalizeSchemaForOpenAI } from './normalize-schema-for-openai';
+
+describe('normalizeSchemaForOpenAI', () => {
+  describe('basic cases', () => {
+    it('should return undefined for undefined input', () => {
+      expect(normalizeSchemaForOpenAI(undefined)).toBeUndefined();
+    });
+
+    it('should add additionalProperties: false to object type schema', () => {
+      const schema = {
+        type: 'object',
+        properties: {
+          name: { type: 'string' },
+        },
+      };
+
+      const result = normalizeSchemaForOpenAI(schema);
+
+      expect(result).toEqual({
+        type: 'object',
+        properties: {
+          name: { type: 'string' },
+        },
+        additionalProperties: false,
+      });
+    });
+
+    it('should not overwrite existing additionalProperties', () => {
+      const schema = {
+        type: 'object',
+        properties: {
+          name: { type: 'string' },
+        },
+        additionalProperties: true,
+      };
+
+      const result = normalizeSchemaForOpenAI(schema);
+
+      expect(result).toEqual({
+        type: 'object',
+        properties: {
+          name: { type: 'string' },
+        },
+        additionalProperties: true,
+      });
+    });
+
+    it('should not modify non-object type schemas', () => {
+      const schema = {
+        type: 'string',
+      };
+
+      const result = normalizeSchemaForOpenAI(schema);
+
+      expect(result).toEqual({
+        type: 'string',
+      });
+    });
+  });
+
+  describe('nested object schemas', () => {
+    it('should recursively normalize nested object properties', () => {
+      const schema = {
+        type: 'object',
+        properties: {
+          user: {
+            type: 'object',
+            properties: {
+              name: { type: 'string' },
+              address: {
+                type: 'object',
+                properties: {
+                  city: { type: 'string' },
+                },
+              },
+            },
+          },
+        },
+      };
+
+      const result = normalizeSchemaForOpenAI(schema);
+
+      expect(result).toEqual({
+        type: 'object',
+        additionalProperties: false,
+        properties: {
+          user: {
+            type: 'object',
+            additionalProperties: false,
+            properties: {
+              name: { type: 'string' },
+              address: {
+                type: 'object',
+                additionalProperties: false,
+                properties: {
+                  city: { type: 'string' },
+                },
+              },
+            },
+          },
+        },
+      });
+    });
+  });
+
+  describe('array schemas', () => {
+    it('should normalize object items in arrays', () => {
+      const schema = {
+        type: 'object',
+        properties: {
+          users: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                name: { type: 'string' },
+              },
+            },
+          },
+        },
+      };
+
+      const result = normalizeSchemaForOpenAI(schema);
+
+      expect(result).toEqual({
+        type: 'object',
+        additionalProperties: false,
+        properties: {
+          users: {
+            type: 'array',
+            items: {
+              type: 'object',
+              additionalProperties: false,
+              properties: {
+                name: { type: 'string' },
+              },
+            },
+          },
+        },
+      });
+    });
+
+    it('should not modify primitive array items', () => {
+      const schema = {
+        type: 'object',
+        properties: {
+          tags: {
+            type: 'array',
+            items: {
+              type: 'string',
+            },
+          },
+        },
+      };
+
+      const result = normalizeSchemaForOpenAI(schema);
+
+      expect(result).toEqual({
+        type: 'object',
+        additionalProperties: false,
+        properties: {
+          tags: {
+            type: 'array',
+            items: {
+              type: 'string',
+            },
+          },
+        },
+      });
+    });
+  });
+
+  describe('real-world MCP tool schema', () => {
+    it('should normalize a typical MCP tool schema (like search_legal_texts)', () => {
+      // This simulates the schema structure that caused the original error
+      const schema = {
+        type: 'object',
+        properties: {
+          query: {
+            type: 'string',
+            description: 'The search query',
+          },
+          filters: {
+            type: 'object',
+            properties: {
+              dateFrom: { type: 'string' },
+              dateTo: { type: 'string' },
+            },
+          },
+          limit: {
+            type: 'integer',
+            description: 'Maximum number of results',
+          },
+        },
+        required: ['query'],
+      };
+
+      const result = normalizeSchemaForOpenAI(schema);
+
+      expect(result).toEqual({
+        type: 'object',
+        additionalProperties: false,
+        properties: {
+          query: {
+            type: 'string',
+            description: 'The search query',
+          },
+          filters: {
+            type: 'object',
+            additionalProperties: false,
+            properties: {
+              dateFrom: { type: 'string' },
+              dateTo: { type: 'string' },
+            },
+          },
+          limit: {
+            type: 'integer',
+            description: 'Maximum number of results',
+          },
+        },
+        required: ['query'],
+      });
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should handle schema without properties', () => {
+      const schema = {
+        type: 'object',
+      };
+
+      const result = normalizeSchemaForOpenAI(schema);
+
+      expect(result).toEqual({
+        type: 'object',
+        additionalProperties: false,
+      });
+    });
+
+    it('should handle empty properties object', () => {
+      const schema = {
+        type: 'object',
+        properties: {},
+      };
+
+      const result = normalizeSchemaForOpenAI(schema);
+
+      expect(result).toEqual({
+        type: 'object',
+        properties: {},
+        additionalProperties: false,
+      });
+    });
+
+    it('should not mutate the original schema', () => {
+      const schema = {
+        type: 'object',
+        properties: {
+          name: { type: 'string' },
+        },
+      };
+
+      normalizeSchemaForOpenAI(schema);
+
+      expect(schema).toEqual({
+        type: 'object',
+        properties: {
+          name: { type: 'string' },
+        },
+      });
+      expect(schema).not.toHaveProperty('additionalProperties');
+    });
+  });
+});

--- a/ayunis-core-backend/src/domain/models/infrastructure/util/normalize-schema-for-openai.ts
+++ b/ayunis-core-backend/src/domain/models/infrastructure/util/normalize-schema-for-openai.ts
@@ -1,0 +1,42 @@
+/**
+ * Recursively adds `additionalProperties: false` to all object types in a JSON schema.
+ * OpenAI's strict mode requires this property to be set on all object schemas.
+ *
+ * @param schema - The JSON schema to normalize
+ * @returns The normalized schema with `additionalProperties: false` added to all object types
+ */
+export function normalizeSchemaForOpenAI(
+  schema: Record<string, unknown> | undefined,
+): Record<string, unknown> | undefined {
+  if (!schema) return undefined;
+
+  const normalized = { ...schema };
+
+  // Add additionalProperties: false to object types if not already present
+  if (normalized.type === 'object' && !('additionalProperties' in normalized)) {
+    normalized.additionalProperties = false;
+  }
+
+  // Recursively process properties
+  if (normalized.properties && typeof normalized.properties === 'object') {
+    const props = normalized.properties as Record<
+      string,
+      Record<string, unknown>
+    >;
+    normalized.properties = Object.fromEntries(
+      Object.entries(props).map(([key, value]) => [
+        key,
+        normalizeSchemaForOpenAI(value),
+      ]),
+    );
+  }
+
+  // Handle array items
+  if (normalized.items && typeof normalized.items === 'object') {
+    normalized.items = normalizeSchemaForOpenAI(
+      normalized.items as Record<string, unknown>,
+    );
+  }
+
+  return normalized;
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Ensure tool parameter JSON schemas include additionalProperties: false recursively for OpenAI strict mode and apply during chat and stream tool conversions, with tests added.
> 
> - **Inference (OpenAI Chat/Stream)**:
>   - Apply `normalizeSchemaForOpenAI` when converting tool `parameters` in `inference/base-openai-chat.inference.ts` and `stream-inference/base-openai-chat.stream-inference.ts`.
> - **Utilities**:
>   - Add `util/normalize-schema-for-openai.ts` to recursively set `additionalProperties: false` on all object schemas (including nested objects and array items).
>   - Add comprehensive tests in `util/normalize-schema-for-openai.spec.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4aea2cd5b7c42662d6896aa160954c284376506e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->