### PR TITLE
Check emoji preservation in chat input

### DIFF
--- a/ayunis-core-frontend/src/widgets/chat-input/ui/ChatInput.tsx
+++ b/ayunis-core-frontend/src/widgets/chat-input/ui/ChatInput.tsx
@@ -183,6 +183,37 @@ const ChatInput = forwardRef<ChatInputRef, ChatInputProps>(
     const canSend =
       (message.trim() || pendingImages.length > 0) && (modelId || agentId);
 
+    function handlePaste(e: React.ClipboardEvent<HTMLTextAreaElement>) {
+      // Ensure emojis are preserved when pasting
+      // Get the pasted text from clipboard
+      const pastedText = e.clipboardData.getData('text/plain');
+      
+      // If there's no text or it's empty, let default behavior handle it
+      if (!pastedText) return;
+
+      // Prevent default to handle paste manually
+      e.preventDefault();
+
+      const target = e.currentTarget;
+      const start = target.selectionStart ?? 0;
+      const end = target.selectionEnd ?? 0;
+
+      // Insert the pasted text at cursor position, preserving emojis
+      const newValue = 
+        message.substring(0, start) + 
+        pastedText + 
+        message.substring(end);
+
+      setMessage(newValue);
+
+      // Set cursor position after pasted content
+      // Need to wait for React to update
+      setTimeout(() => {
+        const newCursorPos = start + pastedText.length;
+        target.setSelectionRange(newCursorPos, newCursorPos);
+      }, 0);
+    }
+
     return (
       <div
         ref={containerRef}
@@ -215,6 +246,7 @@ const ChatInput = forwardRef<ChatInputRef, ChatInputProps>(
                 value={message}
                 autoFocus
                 onChange={(e) => setMessage(e.target.value)}
+                onPaste={handlePaste}
                 onFocus={() => setIsFocused(true)}
                 onBlur={() => setIsFocused(false)}
                 placeholder={t('chatInput.placeholder')}


### PR DESCRIPTION
Add a custom `onPaste` handler to the `ChatInput` component to ensure emojis are preserved when users paste text.

---
[Slack Thread](https://locaboo.slack.com/archives/C0375HX2C4S/p1764924381434019?thread_ts=1764924381.434019&cid=C0375HX2C4S)

<a href="https://cursor.com/background-agent?bcId=bc-2bf7f6f9-4ac7-4cec-8a88-adbdf1642ee4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2bf7f6f9-4ac7-4cec-8a88-adbdf1642ee4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a custom onPaste handler to ChatInput’s textarea to insert pasted text while preserving emojis and cursor position.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 33aeb1f5c2891e604e2d110d184dcb44967c18aa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->