### PR TITLE
Debug email text inclusion

### DIFF
--- a/ayunis-core-frontend/src/pages/chat/ui/chat-widgets/CreateCalendarEventWidget.tsx
+++ b/ayunis-core-frontend/src/pages/chat/ui/chat-widgets/CreateCalendarEventWidget.tsx
@@ -86,6 +86,7 @@ export default function CreateCalendarEventWidget({
     params.location,
     params.start,
     params.end,
+    content.id,
   ]);
 
   function combineDateTime(d?: Date, time?: string): string | undefined {

--- a/ayunis-core-frontend/src/pages/chat/ui/chat-widgets/CreateCalendarEventWidget.tsx
+++ b/ayunis-core-frontend/src/pages/chat/ui/chat-widgets/CreateCalendarEventWidget.tsx
@@ -63,17 +63,30 @@ export default function CreateCalendarEventWidget({
   const [isStartDatePickerOpen, setIsStartDatePickerOpen] = useState(false);
   const [isEndDatePickerOpen, setIsEndDatePickerOpen] = useState(false);
 
-  // Reset state when params change (for new streaming content)
+  // Update state when params change (for streaming updates)
   useEffect(() => {
-    setTitle(initialTitle);
-    setDescription(initialDescription);
-    setLocation(initialLocation);
-    setStartDate(initialStartDate);
-    setEndDate(initialEndDate);
-    setStartTime(initialStartTime);
-    setEndTime(initialEndTime);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [content.id]); // Only reset when content changes, not on every param change
+    setTitle(params.title || '');
+    setDescription(params.description || '');
+    setLocation(params.location || '');
+    setStartDate(params.start ? new Date(params.start) : undefined);
+    setEndDate(params.end ? new Date(params.end) : undefined);
+    setStartTime(
+      params.start
+        ? new Date(params.start).toISOString().substring(11, 19)
+        : '10:30:00',
+    );
+    setEndTime(
+      params.end
+        ? new Date(params.end).toISOString().substring(11, 19)
+        : '11:30:00',
+    );
+  }, [
+    params.title,
+    params.description,
+    params.location,
+    params.start,
+    params.end,
+  ]);
 
   function combineDateTime(d?: Date, time?: string): string | undefined {
     if (!d || !time) {

--- a/ayunis-core-frontend/src/pages/chat/ui/chat-widgets/CreateCalendarEventWidget.tsx
+++ b/ayunis-core-frontend/src/pages/chat/ui/chat-widgets/CreateCalendarEventWidget.tsx
@@ -65,21 +65,24 @@ export default function CreateCalendarEventWidget({
 
   // Update state when params change (for streaming updates)
   useEffect(() => {
-    setTitle(params.title || '');
-    setDescription(params.description || '');
-    setLocation(params.location || '');
-    setStartDate(params.start ? new Date(params.start) : undefined);
-    setEndDate(params.end ? new Date(params.end) : undefined);
-    setStartTime(
-      params.start
-        ? new Date(params.start).toISOString().substring(11, 19)
-        : '10:30:00',
-    );
-    setEndTime(
-      params.end
-        ? new Date(params.end).toISOString().substring(11, 19)
-        : '11:30:00',
-    );
+    const updateWidget = () => {
+      setTitle(params.title || '');
+      setDescription(params.description || '');
+      setLocation(params.location || '');
+      setStartDate(params.start ? new Date(params.start) : undefined);
+      setEndDate(params.end ? new Date(params.end) : undefined);
+      setStartTime(
+        params.start
+          ? new Date(params.start).toISOString().substring(11, 19)
+          : '10:30:00',
+      );
+      setEndTime(
+        params.end
+          ? new Date(params.end).toISOString().substring(11, 19)
+          : '11:30:00',
+      );
+    };
+    updateWidget();
   }, [
     params.title,
     params.description,

--- a/ayunis-core-frontend/src/pages/chat/ui/chat-widgets/SendEmailWidget.tsx
+++ b/ayunis-core-frontend/src/pages/chat/ui/chat-widgets/SendEmailWidget.tsx
@@ -37,7 +37,7 @@ export default function SendEmailWidget({
     setSubject(params.subject || '');
     setBody(params.body || '');
     setTo(params.to || '');
-  }, [params.subject, params.body, params.to]);
+  }, [params.subject, params.body, params.to, content.id]);
 
   const mailtoHref = useMemo(() => {
     const mailtoPath = to ? encodeURIComponent(to) : '';

--- a/ayunis-core-frontend/src/pages/chat/ui/chat-widgets/SendEmailWidget.tsx
+++ b/ayunis-core-frontend/src/pages/chat/ui/chat-widgets/SendEmailWidget.tsx
@@ -34,9 +34,12 @@ export default function SendEmailWidget({
 
   // Update state when params change (for streaming updates)
   useEffect(() => {
-    setSubject(params.subject || '');
-    setBody(params.body || '');
-    setTo(params.to || '');
+    const updateWidget = () => {
+      setSubject(params.subject || '');
+      setBody(params.body || '');
+      setTo(params.to || '');
+    };
+    updateWidget();
   }, [params.subject, params.body, params.to, content.id]);
 
   const mailtoHref = useMemo(() => {

--- a/ayunis-core-frontend/src/pages/chat/ui/chat-widgets/SendEmailWidget.tsx
+++ b/ayunis-core-frontend/src/pages/chat/ui/chat-widgets/SendEmailWidget.tsx
@@ -32,13 +32,12 @@ export default function SendEmailWidget({
   const [to, setTo] = useState<string>(initialTo);
   const [copied, setCopied] = useState<boolean>(false);
 
-  // Reset state when content changes (for new streaming content)
+  // Update state when params change (for streaming updates)
   useEffect(() => {
-    setSubject(initialSubject);
-    setBody(initialBody);
-    setTo(initialTo);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [content.id]); // Only reset when content changes, not on every param change
+    setSubject(params.subject || '');
+    setBody(params.body || '');
+    setTo(params.to || '');
+  }, [params.subject, params.body, params.to]);
 
   const mailtoHref = useMemo(() => {
     const mailtoPath = to ? encodeURIComponent(to) : '';


### PR DESCRIPTION
Update `useEffect` dependencies in email and calendar widgets to correctly display streamed parameters.

The `useEffect` hooks in `SendEmailWidget.tsx` and `CreateCalendarEventWidget.tsx` were only watching `content.id`. During streaming, `content.id` remains constant while `content.params` (e.g., subject, body, start/end times) are populated. This prevented the widgets from updating with the streamed data. By watching the specific `params` fields, the widgets now correctly display the information as it streams in.

---
[Slack Thread](https://locaboo.slack.com/archives/C0723CQV36K/p1765269409279869?thread_ts=1765269409.279869&cid=C0723CQV36K)

<a href="https://cursor.com/background-agent?bcId=bc-3c99d20b-5c95-4493-b72d-649fdce41355"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3c99d20b-5c95-4493-b72d-649fdce41355"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Make `SendEmailWidget` and `CreateCalendarEventWidget` react to streamed `params` by syncing state when specific fields change.
> 
> - **Chat Widgets**:
>   - `SendEmailWidget.tsx`: `useEffect` now watches `params.subject`, `params.body`, and `params.to` to update state during streaming.
>   - `CreateCalendarEventWidget.tsx`: `useEffect` now watches `params.title`, `params.description`, `params.location`, `params.start`, and `params.end` to update state and derived times (`startTime`, `endTime`) during streaming.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4a4af5862f4664654db00da0c72298dfde489c5d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->