### PR TITLE
fix: fix cascading on delete AYC-000

### DIFF
--- a/ayunis-core-backend/src/db/migrations/1765371231202-FixCascadeDeleteRelations.ts
+++ b/ayunis-core-backend/src/db/migrations/1765371231202-FixCascadeDeleteRelations.ts
@@ -1,0 +1,97 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class FixCascadeDeleteRelations1765371231202
+  implements MigrationInterface
+{
+  name = 'FixCascadeDeleteRelations1765371231202';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "users" DROP CONSTRAINT "FK_1890588e47e133fd85670f187d6"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "tool_config_record" DROP CONSTRAINT "FK_6d332070521471c40d83557db85"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "agents" DROP CONSTRAINT "FK_ef998451a458221d3c409b37923"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "trials" DROP CONSTRAINT "FK_21266e62a69dbcfa54790ce00e7"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "subscriptions" DROP CONSTRAINT "FK_16519322477ef8b09d68ce04889"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "threads" DROP CONSTRAINT "FK_16a4760316ad946a5b114b27d12"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "threads" DROP CONSTRAINT "FK_d6f207f7897d73a658b3b7147eb"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "users" ADD CONSTRAINT "FK_1890588e47e133fd85670f187d6" FOREIGN KEY ("orgId") REFERENCES "orgs"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "tool_config_record" ADD CONSTRAINT "FK_6d332070521471c40d83557db85" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "agents" ADD CONSTRAINT "FK_ef998451a458221d3c409b37923" FOREIGN KEY ("modelId") REFERENCES "permitted_models"("id") ON DELETE RESTRICT ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "trials" ADD CONSTRAINT "FK_21266e62a69dbcfa54790ce00e7" FOREIGN KEY ("orgId") REFERENCES "orgs"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "subscriptions" ADD CONSTRAINT "FK_16519322477ef8b09d68ce04889" FOREIGN KEY ("orgId") REFERENCES "orgs"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "threads" ADD CONSTRAINT "FK_16a4760316ad946a5b114b27d12" FOREIGN KEY ("modelId") REFERENCES "permitted_models"("id") ON DELETE SET NULL ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "threads" ADD CONSTRAINT "FK_d6f207f7897d73a658b3b7147eb" FOREIGN KEY ("agentId") REFERENCES "agents"("id") ON DELETE SET NULL ON UPDATE NO ACTION`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "threads" DROP CONSTRAINT "FK_d6f207f7897d73a658b3b7147eb"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "threads" DROP CONSTRAINT "FK_16a4760316ad946a5b114b27d12"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "subscriptions" DROP CONSTRAINT "FK_16519322477ef8b09d68ce04889"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "trials" DROP CONSTRAINT "FK_21266e62a69dbcfa54790ce00e7"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "agents" DROP CONSTRAINT "FK_ef998451a458221d3c409b37923"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "tool_config_record" DROP CONSTRAINT "FK_6d332070521471c40d83557db85"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "users" DROP CONSTRAINT "FK_1890588e47e133fd85670f187d6"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "threads" ADD CONSTRAINT "FK_d6f207f7897d73a658b3b7147eb" FOREIGN KEY ("agentId") REFERENCES "agents"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "threads" ADD CONSTRAINT "FK_16a4760316ad946a5b114b27d12" FOREIGN KEY ("modelId") REFERENCES "permitted_models"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "subscriptions" ADD CONSTRAINT "FK_16519322477ef8b09d68ce04889" FOREIGN KEY ("orgId") REFERENCES "orgs"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "trials" ADD CONSTRAINT "FK_21266e62a69dbcfa54790ce00e7" FOREIGN KEY ("orgId") REFERENCES "orgs"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "agents" ADD CONSTRAINT "FK_ef998451a458221d3c409b37923" FOREIGN KEY ("modelId") REFERENCES "permitted_models"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "tool_config_record" ADD CONSTRAINT "FK_6d332070521471c40d83557db85" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "users" ADD CONSTRAINT "FK_1890588e47e133fd85670f187d6" FOREIGN KEY ("orgId") REFERENCES "orgs"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+  }
+}

--- a/ayunis-core-backend/src/domain/agents/infrastructure/persistence/local/schema/agent-source-assignment.record.ts
+++ b/ayunis-core-backend/src/domain/agents/infrastructure/persistence/local/schema/agent-source-assignment.record.ts
@@ -20,7 +20,6 @@ export class AgentSourceAssignmentRecord extends BaseRecord {
 
   @ManyToOne(() => SourceRecord, {
     onDelete: 'CASCADE',
-    cascade: true,
     eager: true,
   })
   @JoinColumn({ name: 'sourceId' })

--- a/ayunis-core-backend/src/domain/agents/infrastructure/persistence/local/schema/agent.record.ts
+++ b/ayunis-core-backend/src/domain/agents/infrastructure/persistence/local/schema/agent.record.ts
@@ -25,7 +25,11 @@ export class AgentRecord extends BaseRecord {
   @Column({ nullable: false })
   modelId: UUID;
 
-  @ManyToOne(() => PermittedModelRecord, { nullable: false, eager: true })
+  @ManyToOne(() => PermittedModelRecord, {
+    nullable: false,
+    eager: true,
+    onDelete: 'RESTRICT',
+  })
   model: PermittedModelRecord;
 
   @Column({ nullable: false })

--- a/ayunis-core-backend/src/domain/runs/application/use-cases/execute-run-and-set-title/execute-run-and-set-title.use-case.ts
+++ b/ayunis-core-backend/src/domain/runs/application/use-cases/execute-run-and-set-title/execute-run-and-set-title.use-case.ts
@@ -25,6 +25,7 @@ import { FindOneAgentQuery } from 'src/domain/agents/application/use-cases/find-
 import { Agent } from 'src/domain/agents/domain/agent.entity';
 import { AnonymizeTextUseCase } from 'src/common/anonymization/application/use-cases/anonymize-text/anonymize-text.use-case';
 import { AnonymizeTextCommand } from 'src/common/anonymization/application/use-cases/anonymize-text/anonymize-text.command';
+import { ApplicationError } from 'src/common/errors/base.error';
 
 @Injectable()
 export class ExecuteRunAndSetTitleUseCase {
@@ -88,6 +89,10 @@ export class ExecuteRunAndSetTitleUseCase {
     } catch (error) {
       this.logger.error('Error in executeRunAndSetTitle', error);
 
+      // Preserve error code from domain errors (e.g., RUN_NO_MODEL_FOUND)
+      const errorCode =
+        error instanceof ApplicationError ? error.code : 'EXECUTION_ERROR';
+
       // Yield error response
       const errorResponse: RunErrorResponseDto = {
         type: 'error',
@@ -97,7 +102,7 @@ export class ExecuteRunAndSetTitleUseCase {
             : 'An error occurred while executing the run',
         threadId: command.threadId,
         timestamp: new Date().toISOString(),
-        code: 'EXECUTION_ERROR',
+        code: errorCode,
         details: {
           error: error instanceof Error ? error.toString() : 'Unknown error',
           stack: error instanceof Error ? error.stack : 'Unknown error',

--- a/ayunis-core-backend/src/domain/threads/infrastructure/persistence/local/schema/thread-source-assignment.record.ts
+++ b/ayunis-core-backend/src/domain/threads/infrastructure/persistence/local/schema/thread-source-assignment.record.ts
@@ -20,7 +20,6 @@ export class ThreadSourceAssignmentRecord extends BaseRecord {
 
   @ManyToOne(() => SourceRecord, {
     onDelete: 'CASCADE',
-    cascade: true,
     eager: true,
   })
   @JoinColumn({ name: 'sourceId' })

--- a/ayunis-core-backend/src/domain/threads/infrastructure/persistence/local/schema/thread.record.ts
+++ b/ayunis-core-backend/src/domain/threads/infrastructure/persistence/local/schema/thread.record.ts
@@ -16,14 +16,14 @@ export class ThreadRecord extends BaseRecord {
   @Index()
   modelId?: UUID;
 
-  @ManyToOne(() => PermittedModelRecord)
+  @ManyToOne(() => PermittedModelRecord, { onDelete: 'SET NULL' })
   model?: PermittedModelRecord;
 
   @Column({ nullable: true })
   @Index()
   agentId?: UUID;
 
-  @ManyToOne(() => AgentRecord)
+  @ManyToOne(() => AgentRecord, { onDelete: 'SET NULL' })
   agent?: AgentRecord;
 
   @Column({ nullable: true })

--- a/ayunis-core-backend/src/domain/tools/infrastructure/persistence/local/schema/tool-config.record.ts
+++ b/ayunis-core-backend/src/domain/tools/infrastructure/persistence/local/schema/tool-config.record.ts
@@ -9,7 +9,7 @@ export abstract class ToolConfigRecord extends BaseRecord {
   @Column()
   displayName: string;
 
-  @ManyToOne(() => UserRecord)
+  @ManyToOne(() => UserRecord, { onDelete: 'CASCADE' })
   user: UserRecord;
 
   @Column()

--- a/ayunis-core-backend/src/iam/orgs/infrastructure/repositories/local/schema/org.record.ts
+++ b/ayunis-core-backend/src/iam/orgs/infrastructure/repositories/local/schema/org.record.ts
@@ -9,7 +9,6 @@ export class OrgRecord extends BaseRecord {
 
   @OneToMany(() => UserRecord, (user) => user.org, {
     cascade: true,
-    onDelete: 'CASCADE',
     nullable: false,
   })
   users: UserRecord[];

--- a/ayunis-core-backend/src/iam/subscriptions/infrastructure/persistence/local/schema/subscription.record.ts
+++ b/ayunis-core-backend/src/iam/subscriptions/infrastructure/persistence/local/schema/subscription.record.ts
@@ -10,7 +10,7 @@ export class SubscriptionRecord extends BaseRecord {
   @Column({ type: 'timestamp', nullable: true })
   cancelledAt: Date | null;
 
-  @ManyToOne(() => OrgRecord)
+  @ManyToOne(() => OrgRecord, { onDelete: 'CASCADE' })
   org: OrgRecord;
 
   @Column()

--- a/ayunis-core-backend/src/iam/trials/infrastructure/persistence/local/schema/trial.record.ts
+++ b/ayunis-core-backend/src/iam/trials/infrastructure/persistence/local/schema/trial.record.ts
@@ -5,7 +5,7 @@ import { Entity, Column, Index, ManyToOne } from 'typeorm';
 
 @Entity({ name: 'trials' })
 export class TrialRecord extends BaseRecord {
-  @ManyToOne(() => OrgRecord)
+  @ManyToOne(() => OrgRecord, { onDelete: 'CASCADE' })
   org: OrgRecord;
 
   @Column()

--- a/ayunis-core-backend/src/iam/users/infrastructure/repositories/local/schema/user.record.ts
+++ b/ayunis-core-backend/src/iam/users/infrastructure/repositories/local/schema/user.record.ts
@@ -31,7 +31,10 @@ export class UserRecord extends BaseRecord {
   @Column()
   orgId: UUID;
 
-  @ManyToOne(() => OrgRecord, (org) => org.id, { nullable: false })
+  @ManyToOne(() => OrgRecord, (org) => org.id, {
+    nullable: false,
+    onDelete: 'CASCADE',
+  })
   org: OrgRecord;
 
   @Column({ default: false })


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adjusts FK onDelete policies (cascade/set null/restrict) across users/orgs, tools, trials, subscriptions, threads, and agents, and propagates domain error codes in run streaming responses.
> 
> - **Database / Migrations**
>   - Add migration `src/db/migrations/1765371231202-FixCascadeDeleteRelations.ts` to update FK delete behaviors:
>     - `users.orgId` → `CASCADE`; `tool_config_record.userId` → `CASCADE`.
>     - `agents.modelId` → `RESTRICT`.
>     - `trials.orgId`, `subscriptions.orgId` → `CASCADE`.
>     - `threads.modelId`, `threads.agentId` → `SET NULL`.
> - **Persistence Schema Updates**
>   - Align entities with new FK behaviors:
>     - `AgentRecord.model` → `onDelete: 'RESTRICT'`.
>     - `ThreadRecord.model` and `ThreadRecord.agent` → `onDelete: 'SET NULL'`.
>     - `ToolConfigRecord.user`, `UserRecord.org`, `TrialRecord.org`, `SubscriptionRecord.org` → `onDelete: 'CASCADE'`.
>     - Remove `cascade: true` from `SourceRecord` relations in `AgentSourceAssignmentRecord` and `ThreadSourceAssignmentRecord`.
>     - Remove `onDelete` from `OrgRecord.users` (OneToMany).
> - **Runs / Error Handling**
>   - Preserve domain `ApplicationError.code` in error responses for `ExecuteRunAndSetTitleUseCase` and `RunsController.executeRunAndStream` (fallback to `EXECUTION_ERROR`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 806ac333464dd5581f5ded30b1a961107255844f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->