### PR TITLE
fix: Fix confirmation modals AYC-000

### DIFF
--- a/ayunis-core-frontend/src/pages/admin-settings/integrations-settings/ui/delete-confirmation-dialog.tsx
+++ b/ayunis-core-frontend/src/pages/admin-settings/integrations-settings/ui/delete-confirmation-dialog.tsx
@@ -27,42 +27,47 @@ export function DeleteConfirmationDialog({
     onOpenChange(false);
   });
 
-  if (!integration) return null;
-
   const handleConfirm = () => {
-    deleteIntegration(integration.id);
+    if (integration) {
+      deleteIntegration(integration.id);
+    }
   };
 
+  // Important: Dialog must always be rendered (not conditionally returned) so it receives
+  // the open={false} transition. Without this, Radix UI won't clean up its Portal and
+  // overlay, leaving an invisible layer that blocks all pointer events.
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent>
-        <DialogHeader>
-          <DialogTitle>{t('integrations.deleteDialog.title')}</DialogTitle>
-          <DialogDescription>
-            {t('integrations.deleteDialog.description', {
-              name: integration.name,
-            })}
-          </DialogDescription>
-        </DialogHeader>
-        <DialogFooter>
-          <Button
-            variant="outline"
-            onClick={() => onOpenChange(false)}
-            disabled={isDeleting}
-          >
-            {t('integrations.deleteDialog.cancel')}
-          </Button>
-          <Button
-            variant="destructive"
-            onClick={handleConfirm}
-            disabled={isDeleting}
-          >
-            {isDeleting
-              ? t('integrations.deleteDialog.deleting')
-              : t('integrations.deleteDialog.delete')}
-          </Button>
-        </DialogFooter>
-      </DialogContent>
+      {integration && (
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{t('integrations.deleteDialog.title')}</DialogTitle>
+            <DialogDescription>
+              {t('integrations.deleteDialog.description', {
+                name: integration.name,
+              })}
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+              disabled={isDeleting}
+            >
+              {t('integrations.deleteDialog.cancel')}
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={handleConfirm}
+              disabled={isDeleting}
+            >
+              {isDeleting
+                ? t('integrations.deleteDialog.deleting')
+                : t('integrations.deleteDialog.delete')}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      )}
     </Dialog>
   );
 }

--- a/ayunis-core-frontend/src/pages/admin-settings/integrations-settings/ui/edit-integration-dialog.tsx
+++ b/ayunis-core-frontend/src/pages/admin-settings/integrations-settings/ui/edit-integration-dialog.tsx
@@ -94,64 +94,97 @@ export function EditIntegrationDialog({
     onOpenChange(newOpen);
   };
 
-  if (!integration) return null;
+  const authMethod = integration?.authMethod ?? 'NO_AUTH';
 
-  const authMethod = integration.authMethod ?? 'NO_AUTH';
-
+  // Important: Dialog must always be rendered (not conditionally returned) so it receives
+  // the open={false} transition. Without this, Radix UI won't clean up its Portal and
+  // overlay, leaving an invisible layer that blocks all pointer events.
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
-      <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-[525px]">
-        <DialogHeader>
-          <DialogTitle>{t('integrations.editDialog.title')}</DialogTitle>
-        </DialogHeader>
-        <Form {...form}>
-          <form
-            onSubmit={(e) => void form.handleSubmit(handleSubmit)(e)}
-            className="space-y-4"
-          >
-            <FormField
-              control={form.control}
-              name="name"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>{t('integrations.editDialog.name')}</FormLabel>
-                  <FormControl>
-                    <Input
-                      placeholder={t('integrations.editDialog.namePlaceholder')}
-                      {...field}
-                      disabled={isUpdating}
-                    />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
+      {integration && (
+        <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-[525px]">
+          <DialogHeader>
+            <DialogTitle>{t('integrations.editDialog.title')}</DialogTitle>
+          </DialogHeader>
+          <Form {...form}>
+            <form
+              onSubmit={(e) => void form.handleSubmit(handleSubmit)(e)}
+              className="space-y-4"
+            >
+              <FormField
+                control={form.control}
+                name="name"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>{t('integrations.editDialog.name')}</FormLabel>
+                    <FormControl>
+                      <Input
+                        placeholder={t(
+                          'integrations.editDialog.namePlaceholder',
+                        )}
+                        {...field}
+                        disabled={isUpdating}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              {authMethod === 'CUSTOM_HEADER' && (
+                <>
+                  <FormField
+                    control={form.control}
+                    name="authHeaderName"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>
+                          {t('integrations.editDialog.headerName')}
+                        </FormLabel>
+                        <FormControl>
+                          <Input
+                            placeholder={
+                              integration.authHeaderName ||
+                              t('integrations.editDialog.headerNamePlaceholder')
+                            }
+                            {...field}
+                            disabled={isUpdating}
+                          />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+
+                  <FormField
+                    control={form.control}
+                    name="credentials"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>
+                          {t('integrations.editDialog.credentials')}
+                        </FormLabel>
+                        <FormControl>
+                          <Input
+                            type="password"
+                            placeholder={t(
+                              'integrations.editDialog.credentialsPlaceholder',
+                            )}
+                            {...field}
+                            disabled={isUpdating}
+                          />
+                        </FormControl>
+                        <FormDescription>
+                          {t('integrations.editDialog.credentialsDescription')}
+                        </FormDescription>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                </>
               )}
-            />
 
-            {authMethod === 'CUSTOM_HEADER' && (
-              <>
-                <FormField
-                  control={form.control}
-                  name="authHeaderName"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>
-                        {t('integrations.editDialog.headerName')}
-                      </FormLabel>
-                      <FormControl>
-                        <Input
-                          placeholder={
-                            integration.authHeaderName ||
-                            t('integrations.editDialog.headerNamePlaceholder')
-                          }
-                          {...field}
-                          disabled={isUpdating}
-                        />
-                      </FormControl>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-
+              {authMethod === 'BEARER_TOKEN' && (
                 <FormField
                   control={form.control}
                   name="credentials"
@@ -170,65 +203,37 @@ export function EditIntegrationDialog({
                           disabled={isUpdating}
                         />
                       </FormControl>
-                      <FormDescription>
-                        {t('integrations.editDialog.credentialsDescription')}
-                      </FormDescription>
                       <FormMessage />
                     </FormItem>
                   )}
                 />
-              </>
-            )}
+              )}
 
-            {authMethod === 'BEARER_TOKEN' && (
-              <FormField
-                control={form.control}
-                name="credentials"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>
-                      {t('integrations.editDialog.credentials')}
-                    </FormLabel>
-                    <FormControl>
-                      <Input
-                        type="password"
-                        placeholder={t(
-                          'integrations.editDialog.credentialsPlaceholder',
-                        )}
-                        {...field}
-                        disabled={isUpdating}
-                      />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-            )}
+              {authMethod === 'NO_AUTH' && (
+                <FormDescription>
+                  {t('integrations.editDialog.noCredentialsMessage')}
+                </FormDescription>
+              )}
 
-            {authMethod === 'NO_AUTH' && (
-              <FormDescription>
-                {t('integrations.editDialog.noCredentialsMessage')}
-              </FormDescription>
-            )}
-
-            <DialogFooter>
-              <Button
-                type="button"
-                variant="outline"
-                onClick={() => handleOpenChange(false)}
-                disabled={isUpdating}
-              >
-                {t('integrations.editDialog.cancel')}
-              </Button>
-              <Button type="submit" disabled={isUpdating}>
-                {isUpdating
-                  ? t('integrations.editDialog.updating')
-                  : t('integrations.editDialog.update')}
-              </Button>
-            </DialogFooter>
-          </form>
-        </Form>
-      </DialogContent>
+              <DialogFooter>
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => handleOpenChange(false)}
+                  disabled={isUpdating}
+                >
+                  {t('integrations.editDialog.cancel')}
+                </Button>
+                <Button type="submit" disabled={isUpdating}>
+                  {isUpdating
+                    ? t('integrations.editDialog.updating')
+                    : t('integrations.editDialog.update')}
+                </Button>
+              </DialogFooter>
+            </form>
+          </Form>
+        </DialogContent>
+      )}
     </Dialog>
   );
 }

--- a/ayunis-core-frontend/src/pages/admin-settings/users-settings/ui/InviteUserDialog.tsx
+++ b/ayunis-core-frontend/src/pages/admin-settings/users-settings/ui/InviteUserDialog.tsx
@@ -45,14 +45,6 @@ export default function InviteUserDialog() {
   const [inviteUrl, setInviteUrl] = useState<string | null>(null);
   const [isUrlCopied, setIsUrlCopied] = useState(false);
 
-  const { createInvite, isLoading: isCreatingInvite } = useInviteCreate(
-    (response: CreateInviteResponseDto) => {
-      if (response.url) {
-        setInviteUrl(response.url);
-      }
-    },
-  );
-
   const form = useForm<InviteFormData>({
     defaultValues: {
       email: '',
@@ -60,23 +52,29 @@ export default function InviteUserDialog() {
     },
   });
 
-  function onSubmit(data: InviteFormData) {
-    createInvite(data);
-    // Don't close dialog immediately if URL might be returned
-    if (!inviteUrl) {
-      // Reset form but keep dialog open to potentially show URL
-      form.reset();
-    }
-  }
-
-  function handleCancel() {
+  function handleClose() {
     setIsOpen(false);
     form.reset();
     setInviteUrl(null);
     setIsUrlCopied(false);
   }
 
-  function handleClose() {
+  const { createInvite, isLoading: isCreatingInvite } = useInviteCreate(
+    (response: CreateInviteResponseDto) => {
+      if (response.url) {
+        setInviteUrl(response.url);
+      } else {
+        // Email was sent successfully, close the dialog
+        handleClose();
+      }
+    },
+  );
+
+  function onSubmit(data: InviteFormData) {
+    createInvite(data);
+  }
+
+  function handleCancel() {
     setIsOpen(false);
     form.reset();
     setInviteUrl(null);

--- a/ayunis-core-frontend/src/pages/super-admin-settings/models-catalog/ui/EditEmbeddingModelDialog.tsx
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/models-catalog/ui/EditEmbeddingModelDialog.tsx
@@ -116,150 +116,156 @@ export function EditEmbeddingModelDialog({
     onOpenChange(newOpen);
   };
 
-  if (!model) return null;
-
+  // Important: Dialog must always be rendered (not conditionally returned) so it receives
+  // the open={false} transition. Without this, Radix UI won't clean up its Portal and
+  // overlay, leaving an invisible layer that blocks all pointer events.
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
-      <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-[525px]">
-        <DialogHeader>
-          <DialogTitle>Edit Embedding Model</DialogTitle>
-        </DialogHeader>
-        <Form {...form}>
-          <form
-            onSubmit={(e) => void form.handleSubmit(handleSubmit)(e)}
-            className="space-y-4"
-          >
-            <FormField
-              control={form.control}
-              name="name"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Name</FormLabel>
-                  <FormControl>
-                    <Input
-                      {...field}
-                      placeholder="e.g., text-embedding-3-small"
-                      disabled={isUpdating}
-                      required
-                    />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-
-            <FormField
-              control={form.control}
-              name="provider"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Provider</FormLabel>
-                  <Select
-                    onValueChange={field.onChange}
-                    value={field.value}
-                    disabled={isUpdating}
-                  >
+      {model && (
+        <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-[525px]">
+          <DialogHeader>
+            <DialogTitle>Edit Embedding Model</DialogTitle>
+          </DialogHeader>
+          <Form {...form}>
+            <form
+              onSubmit={(e) => void form.handleSubmit(handleSubmit)(e)}
+              className="space-y-4"
+            >
+              <FormField
+                control={form.control}
+                name="name"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Name</FormLabel>
                     <FormControl>
-                      <SelectTrigger>
-                        <SelectValue placeholder="Select a provider" />
-                      </SelectTrigger>
+                      <Input
+                        {...field}
+                        placeholder="e.g., text-embedding-3-small"
+                        disabled={isUpdating}
+                        required
+                      />
                     </FormControl>
-                    <SelectContent>
-                      {PROVIDERS.map((provider) => (
-                        <SelectItem key={provider.value} value={provider.value}>
-                          {provider.label}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
 
-            <FormField
-              control={form.control}
-              name="displayName"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Display Name</FormLabel>
-                  <FormControl>
-                    <Input
-                      {...field}
-                      placeholder="e.g., Text Embedding 3 Small"
+              <FormField
+                control={form.control}
+                name="provider"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Provider</FormLabel>
+                    <Select
+                      onValueChange={field.onChange}
+                      value={field.value}
                       disabled={isUpdating}
-                      required
-                    />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
+                    >
+                      <FormControl>
+                        <SelectTrigger>
+                          <SelectValue placeholder="Select a provider" />
+                        </SelectTrigger>
+                      </FormControl>
+                      <SelectContent>
+                        {PROVIDERS.map((provider) => (
+                          <SelectItem
+                            key={provider.value}
+                            value={provider.value}
+                          >
+                            {provider.label}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
 
-            <FormField
-              control={form.control}
-              name="dimensions"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Dimensions</FormLabel>
-                  <Select
-                    onValueChange={(value) => field.onChange(Number(value))}
-                    value={String(field.value)}
-                    disabled={isUpdating}
-                  >
+              <FormField
+                control={form.control}
+                name="displayName"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Display Name</FormLabel>
                     <FormControl>
-                      <SelectTrigger>
-                        <SelectValue placeholder="Select dimensions" />
-                      </SelectTrigger>
+                      <Input
+                        {...field}
+                        placeholder="e.g., Text Embedding 3 Small"
+                        disabled={isUpdating}
+                        required
+                      />
                     </FormControl>
-                    <SelectContent>
-                      {DIMENSIONS.map((dim) => (
-                        <SelectItem key={dim.value} value={String(dim.value)}>
-                          {dim.label}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
 
-            <FormField
-              control={form.control}
-              name="isArchived"
-              render={({ field }) => (
-                <FormItem className="flex flex-row items-start space-x-3 space-y-0">
-                  <FormControl>
-                    <Checkbox
-                      checked={field.value}
-                      onCheckedChange={field.onChange}
+              <FormField
+                control={form.control}
+                name="dimensions"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Dimensions</FormLabel>
+                    <Select
+                      onValueChange={(value) => field.onChange(Number(value))}
+                      value={String(field.value)}
                       disabled={isUpdating}
-                    />
-                  </FormControl>
-                  <div className="space-y-1 leading-none">
-                    <FormLabel>Archived</FormLabel>
-                  </div>
-                </FormItem>
-              )}
-            />
+                    >
+                      <FormControl>
+                        <SelectTrigger>
+                          <SelectValue placeholder="Select dimensions" />
+                        </SelectTrigger>
+                      </FormControl>
+                      <SelectContent>
+                        {DIMENSIONS.map((dim) => (
+                          <SelectItem key={dim.value} value={String(dim.value)}>
+                            {dim.label}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
 
-            <DialogFooter>
-              <Button
-                type="button"
-                variant="outline"
-                onClick={() => handleOpenChange(false)}
-                disabled={isUpdating}
-              >
-                Cancel
-              </Button>
-              <Button type="submit" disabled={isUpdating}>
-                {isUpdating ? 'Updating...' : 'Update'}
-              </Button>
-            </DialogFooter>
-          </form>
-        </Form>
-      </DialogContent>
+              <FormField
+                control={form.control}
+                name="isArchived"
+                render={({ field }) => (
+                  <FormItem className="flex flex-row items-start space-x-3 space-y-0">
+                    <FormControl>
+                      <Checkbox
+                        checked={field.value}
+                        onCheckedChange={field.onChange}
+                        disabled={isUpdating}
+                      />
+                    </FormControl>
+                    <div className="space-y-1 leading-none">
+                      <FormLabel>Archived</FormLabel>
+                    </div>
+                  </FormItem>
+                )}
+              />
+
+              <DialogFooter>
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => handleOpenChange(false)}
+                  disabled={isUpdating}
+                >
+                  Cancel
+                </Button>
+                <Button type="submit" disabled={isUpdating}>
+                  {isUpdating ? 'Updating...' : 'Update'}
+                </Button>
+              </DialogFooter>
+            </form>
+          </Form>
+        </DialogContent>
+      )}
     </Dialog>
   );
 }

--- a/ayunis-core-frontend/src/pages/super-admin-settings/models-catalog/ui/EditLanguageModelDialog.tsx
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/models-catalog/ui/EditLanguageModelDialog.tsx
@@ -97,197 +97,203 @@ export function EditLanguageModelDialog({
     onOpenChange(newOpen);
   };
 
-  if (!model) return null;
-
+  // Important: Dialog must always be rendered (not conditionally returned) so it receives
+  // the open={false} transition. Without this, Radix UI won't clean up its Portal and
+  // overlay, leaving an invisible layer that blocks all pointer events.
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
-      <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-[525px]">
-        <DialogHeader>
-          <DialogTitle>Edit Language Model</DialogTitle>
-        </DialogHeader>
-        <Form {...form}>
-          <form
-            onSubmit={(e) => void form.handleSubmit(handleSubmit)(e)}
-            className="space-y-4"
-          >
-            <FormField
-              control={form.control}
-              name="name"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Name</FormLabel>
-                  <FormControl>
-                    <Input
-                      {...field}
-                      placeholder="e.g., gpt-4"
-                      disabled={isUpdating}
-                      required
-                    />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-
-            <FormField
-              control={form.control}
-              name="provider"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Provider</FormLabel>
-                  <Select
-                    onValueChange={field.onChange}
-                    value={field.value}
-                    disabled={isUpdating}
-                  >
+      {model && (
+        <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-[525px]">
+          <DialogHeader>
+            <DialogTitle>Edit Language Model</DialogTitle>
+          </DialogHeader>
+          <Form {...form}>
+            <form
+              onSubmit={(e) => void form.handleSubmit(handleSubmit)(e)}
+              className="space-y-4"
+            >
+              <FormField
+                control={form.control}
+                name="name"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Name</FormLabel>
                     <FormControl>
-                      <SelectTrigger>
-                        <SelectValue placeholder="Select a provider" />
-                      </SelectTrigger>
+                      <Input
+                        {...field}
+                        placeholder="e.g., gpt-4"
+                        disabled={isUpdating}
+                        required
+                      />
                     </FormControl>
-                    <SelectContent>
-                      {PROVIDERS.map((provider) => (
-                        <SelectItem key={provider.value} value={provider.value}>
-                          {provider.label}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
 
-            <FormField
-              control={form.control}
-              name="displayName"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Display Name</FormLabel>
-                  <FormControl>
-                    <Input
-                      {...field}
-                      placeholder="e.g., GPT-4"
+              <FormField
+                control={form.control}
+                name="provider"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Provider</FormLabel>
+                    <Select
+                      onValueChange={field.onChange}
+                      value={field.value}
                       disabled={isUpdating}
-                      required
-                    />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
+                    >
+                      <FormControl>
+                        <SelectTrigger>
+                          <SelectValue placeholder="Select a provider" />
+                        </SelectTrigger>
+                      </FormControl>
+                      <SelectContent>
+                        {PROVIDERS.map((provider) => (
+                          <SelectItem
+                            key={provider.value}
+                            value={provider.value}
+                          >
+                            {provider.label}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
 
-            <FormField
-              control={form.control}
-              name="canStream"
-              render={({ field }) => (
-                <FormItem className="flex flex-row items-start space-x-3 space-y-0">
-                  <FormControl>
-                    <Checkbox
-                      checked={field.value}
-                      onCheckedChange={field.onChange}
-                      disabled={isUpdating}
-                    />
-                  </FormControl>
-                  <div className="space-y-1 leading-none">
-                    <FormLabel>Supports Streaming</FormLabel>
-                  </div>
-                </FormItem>
-              )}
-            />
+              <FormField
+                control={form.control}
+                name="displayName"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Display Name</FormLabel>
+                    <FormControl>
+                      <Input
+                        {...field}
+                        placeholder="e.g., GPT-4"
+                        disabled={isUpdating}
+                        required
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
 
-            <FormField
-              control={form.control}
-              name="canUseTools"
-              render={({ field }) => (
-                <FormItem className="flex flex-row items-start space-x-3 space-y-0">
-                  <FormControl>
-                    <Checkbox
-                      checked={field.value}
-                      onCheckedChange={field.onChange}
-                      disabled={isUpdating}
-                    />
-                  </FormControl>
-                  <div className="space-y-1 leading-none">
-                    <FormLabel>Supports Tool Use</FormLabel>
-                  </div>
-                </FormItem>
-              )}
-            />
+              <FormField
+                control={form.control}
+                name="canStream"
+                render={({ field }) => (
+                  <FormItem className="flex flex-row items-start space-x-3 space-y-0">
+                    <FormControl>
+                      <Checkbox
+                        checked={field.value}
+                        onCheckedChange={field.onChange}
+                        disabled={isUpdating}
+                      />
+                    </FormControl>
+                    <div className="space-y-1 leading-none">
+                      <FormLabel>Supports Streaming</FormLabel>
+                    </div>
+                  </FormItem>
+                )}
+              />
 
-            <FormField
-              control={form.control}
-              name="canVision"
-              render={({ field }) => (
-                <FormItem className="flex flex-row items-start space-x-3 space-y-0">
-                  <FormControl>
-                    <Checkbox
-                      checked={field.value}
-                      onCheckedChange={field.onChange}
-                      disabled={isUpdating}
-                    />
-                  </FormControl>
-                  <div className="space-y-1 leading-none">
-                    <FormLabel>Supports Vision</FormLabel>
-                  </div>
-                </FormItem>
-              )}
-            />
+              <FormField
+                control={form.control}
+                name="canUseTools"
+                render={({ field }) => (
+                  <FormItem className="flex flex-row items-start space-x-3 space-y-0">
+                    <FormControl>
+                      <Checkbox
+                        checked={field.value}
+                        onCheckedChange={field.onChange}
+                        disabled={isUpdating}
+                      />
+                    </FormControl>
+                    <div className="space-y-1 leading-none">
+                      <FormLabel>Supports Tool Use</FormLabel>
+                    </div>
+                  </FormItem>
+                )}
+              />
 
-            <FormField
-              control={form.control}
-              name="isReasoning"
-              render={({ field }) => (
-                <FormItem className="flex flex-row items-start space-x-3 space-y-0">
-                  <FormControl>
-                    <Checkbox
-                      checked={field.value}
-                      onCheckedChange={field.onChange}
-                      disabled={isUpdating}
-                    />
-                  </FormControl>
-                  <div className="space-y-1 leading-none">
-                    <FormLabel>Has Reasoning Capabilities</FormLabel>
-                  </div>
-                </FormItem>
-              )}
-            />
+              <FormField
+                control={form.control}
+                name="canVision"
+                render={({ field }) => (
+                  <FormItem className="flex flex-row items-start space-x-3 space-y-0">
+                    <FormControl>
+                      <Checkbox
+                        checked={field.value}
+                        onCheckedChange={field.onChange}
+                        disabled={isUpdating}
+                      />
+                    </FormControl>
+                    <div className="space-y-1 leading-none">
+                      <FormLabel>Supports Vision</FormLabel>
+                    </div>
+                  </FormItem>
+                )}
+              />
 
-            <FormField
-              control={form.control}
-              name="isArchived"
-              render={({ field }) => (
-                <FormItem className="flex flex-row items-start space-x-3 space-y-0">
-                  <FormControl>
-                    <Checkbox
-                      checked={field.value}
-                      onCheckedChange={field.onChange}
-                      disabled={isUpdating}
-                    />
-                  </FormControl>
-                  <div className="space-y-1 leading-none">
-                    <FormLabel>Archived</FormLabel>
-                  </div>
-                </FormItem>
-              )}
-            />
+              <FormField
+                control={form.control}
+                name="isReasoning"
+                render={({ field }) => (
+                  <FormItem className="flex flex-row items-start space-x-3 space-y-0">
+                    <FormControl>
+                      <Checkbox
+                        checked={field.value}
+                        onCheckedChange={field.onChange}
+                        disabled={isUpdating}
+                      />
+                    </FormControl>
+                    <div className="space-y-1 leading-none">
+                      <FormLabel>Has Reasoning Capabilities</FormLabel>
+                    </div>
+                  </FormItem>
+                )}
+              />
 
-            <DialogFooter>
-              <Button
-                type="button"
-                variant="outline"
-                onClick={() => handleOpenChange(false)}
-                disabled={isUpdating}
-              >
-                Cancel
-              </Button>
-              <Button type="submit" disabled={isUpdating}>
-                {isUpdating ? 'Updating...' : 'Update'}
-              </Button>
-            </DialogFooter>
-          </form>
-        </Form>
-      </DialogContent>
+              <FormField
+                control={form.control}
+                name="isArchived"
+                render={({ field }) => (
+                  <FormItem className="flex flex-row items-start space-x-3 space-y-0">
+                    <FormControl>
+                      <Checkbox
+                        checked={field.value}
+                        onCheckedChange={field.onChange}
+                        disabled={isUpdating}
+                      />
+                    </FormControl>
+                    <div className="space-y-1 leading-none">
+                      <FormLabel>Archived</FormLabel>
+                    </div>
+                  </FormItem>
+                )}
+              />
+
+              <DialogFooter>
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => handleOpenChange(false)}
+                  disabled={isUpdating}
+                >
+                  Cancel
+                </Button>
+                <Button type="submit" disabled={isUpdating}>
+                  {isUpdating ? 'Updating...' : 'Update'}
+                </Button>
+              </DialogFooter>
+            </form>
+          </Form>
+        </DialogContent>
+      )}
     </Dialog>
   );
 }

--- a/ayunis-core-frontend/src/widgets/confirmation-modal/model/ConfirmationProvider.tsx
+++ b/ayunis-core-frontend/src/widgets/confirmation-modal/model/ConfirmationProvider.tsx
@@ -18,7 +18,17 @@ export function ConfirmationProvider({ children }: ConfirmationProviderProps) {
 
   function hideConfirmation() {
     setIsOpen(false);
-    setOptions(null);
+
+    // Force cleanup of Radix's pointer-events on body
+    // Radix Dialog has a bug where it doesn't always remove this
+    const cleanup = () => {
+      document.body.style.pointerEvents = '';
+    };
+
+    // Run cleanup after delays to catch when Radix adds it
+    setTimeout(cleanup, 0);
+    setTimeout(cleanup, 100);
+    setTimeout(cleanup, 300);
   }
 
   return (

--- a/ayunis-core-frontend/src/widgets/confirmation-modal/model/ConfirmationProvider.tsx
+++ b/ayunis-core-frontend/src/widgets/confirmation-modal/model/ConfirmationProvider.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useRef } from 'react';
 import type { ReactNode } from 'react';
 import type { ConfirmationOptions } from './types';
 import { ConfirmationContext } from './useConfirmationContext';
@@ -10,8 +10,16 @@ interface ConfirmationProviderProps {
 export function ConfirmationProvider({ children }: ConfirmationProviderProps) {
   const [isOpen, setIsOpen] = useState(false);
   const [options, setOptions] = useState<ConfirmationOptions | null>(null);
+  const cleanupTimeoutsRef = useRef<NodeJS.Timeout[]>([]);
+
+  function cancelPendingCleanups() {
+    cleanupTimeoutsRef.current.forEach(clearTimeout);
+    cleanupTimeoutsRef.current = [];
+  }
 
   function showConfirmation(confirmationOptions: ConfirmationOptions) {
+    // Cancel any pending cleanups from a previous modal
+    cancelPendingCleanups();
     setOptions(confirmationOptions);
     setIsOpen(true);
   }
@@ -19,16 +27,25 @@ export function ConfirmationProvider({ children }: ConfirmationProviderProps) {
   function hideConfirmation() {
     setIsOpen(false);
 
+    // Cancel any existing cleanup timeouts before scheduling new ones
+    cancelPendingCleanups();
+
     // Force cleanup of Radix's pointer-events on body
     // Radix Dialog has a bug where it doesn't always remove this
     const cleanup = () => {
-      document.body.style.pointerEvents = '';
+      // Only cleanup if no dialog is currently open
+      if (!document.querySelector('[data-radix-dialog-content]')) {
+        document.body.style.pointerEvents = '';
+      }
     };
 
     // Run cleanup after delays to catch when Radix adds it
-    setTimeout(cleanup, 0);
-    setTimeout(cleanup, 100);
-    setTimeout(cleanup, 300);
+    // Store timeout IDs so they can be cancelled if needed
+    cleanupTimeoutsRef.current = [
+      setTimeout(cleanup, 0),
+      setTimeout(cleanup, 100),
+      setTimeout(cleanup, 300),
+    ];
   }
 
   return (

--- a/ayunis-core-frontend/src/widgets/confirmation-modal/ui/ConfirmationModal.tsx
+++ b/ayunis-core-frontend/src/widgets/confirmation-modal/ui/ConfirmationModal.tsx
@@ -33,9 +33,11 @@ export default function ConfirmationModal() {
 
   const isDangerous = options?.variant === 'destructive';
 
-  // Important: Dialog must always be rendered (not conditionally returned) so it receives
-  // the open={false} transition. Without this, Radix UI won't clean up its Portal and
-  // overlay, leaving an invisible layer that blocks all pointer events.
+  // CRITICAL: DialogContent must stay rendered during the close transition.
+  // Radix adds pointer-events:none to <body> when Dialog opens, and removes it on close.
+  // If DialogContent unmounts before Radix completes cleanup (e.g., if options is cleared
+  // immediately), pointer-events:none stays on body permanently, blocking all interactions.
+  // This is why hideConfirmation() only sets isOpen=false but keeps options populated.
   return (
     <Dialog open={isOpen} onOpenChange={(open) => !open && handleCancel()}>
       {options && (


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Ensure dialogs remain mounted during close transitions and add body cleanup to avoid stuck overlays; refine null-safety and invite flow behavior.
> 
> - **Core widgets**:
>   - `widgets/confirmation-modal`: Keep `DialogContent` rendered until close completes and add timed cleanups in `ConfirmationProvider` to clear `body` pointer-events; avoid clearing options on close.
> - **Admin Settings**:
>   - `integrations-settings`: Remove early returns; always render `Dialog`, conditionally render `DialogContent` when `integration` exists; null-safe delete; make `authMethod` nullable-safe.
>   - `users-settings/InviteUserDialog`: Refactor open/close flow; close dialog when email-only invite succeeds; keep open and show URL when provided; simplify submit/cancel handlers.
> - **Super Admin Settings**:
>   - `models-catalog` edit dialogs: Always mount `Dialog` and conditionally render content on model presence; keep form reset logic; no-op when model missing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 14fac762592a5cd7aab51b52e2a4c13ea6677528. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->