### PR TITLE
feat: add chat search AYC-60

### DIFF
--- a/ayunis-core-backend/src/domain/threads/application/ports/threads.repository.ts
+++ b/ayunis-core-backend/src/domain/threads/application/ports/threads.repository.ts
@@ -8,12 +8,18 @@ export interface ThreadsFindAllOptions {
   withModel?: boolean;
 }
 
+export interface ThreadsFindAllFilters {
+  search?: string;
+  agentId?: string;
+}
+
 export abstract class ThreadsRepository {
   abstract create(thread: Thread): Promise<Thread>;
   abstract findOne(id: UUID, userId: UUID): Promise<Thread | null>;
   abstract findAll(
     userId: UUID,
     options?: ThreadsFindAllOptions,
+    filters?: ThreadsFindAllFilters,
   ): Promise<Thread[]>;
   abstract findAllByModel(
     modelId: UUID,

--- a/ayunis-core-backend/src/domain/threads/application/use-cases/find-all-threads/find-all-threads.query.ts
+++ b/ayunis-core-backend/src/domain/threads/application/use-cases/find-all-threads/find-all-threads.query.ts
@@ -9,5 +9,9 @@ export class FindAllThreadsQuery {
       withAgent?: boolean;
       withModel?: boolean;
     },
+    public readonly filters?: {
+      search?: string;
+      agentId?: string;
+    },
   ) {}
 }

--- a/ayunis-core-backend/src/domain/threads/application/use-cases/find-all-threads/find-all-threads.use-case.ts
+++ b/ayunis-core-backend/src/domain/threads/application/use-cases/find-all-threads/find-all-threads.use-case.ts
@@ -10,9 +10,16 @@ export class FindAllThreadsUseCase {
   constructor(private readonly threadsRepository: ThreadsRepository) {}
 
   async execute(query: FindAllThreadsQuery): Promise<Thread[]> {
-    this.logger.log('findAll', { userId: query.userId });
+    this.logger.log('findAll', {
+      userId: query.userId,
+      filters: query.filters,
+    });
     try {
-      return await this.threadsRepository.findAll(query.userId, query.options);
+      return await this.threadsRepository.findAll(
+        query.userId,
+        query.options,
+        query.filters,
+      );
     } catch (error) {
       this.logger.error('Failed to find all threads', {
         userId: query.userId,

--- a/ayunis-core-backend/src/domain/threads/presenters/http/dto/find-all-threads-query-params.dto.ts
+++ b/ayunis-core-backend/src/domain/threads/presenters/http/dto/find-all-threads-query-params.dto.ts
@@ -1,0 +1,14 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsOptional, IsString, IsUUID } from 'class-validator';
+
+export class FindAllThreadsQueryParamsDto {
+  @ApiPropertyOptional({ description: 'Search threads by title' })
+  @IsOptional()
+  @IsString()
+  search?: string;
+
+  @ApiPropertyOptional({ description: 'Filter threads by agent ID' })
+  @IsOptional()
+  @IsUUID()
+  agentId?: string;
+}

--- a/ayunis-core-frontend/src/app/routeTree.gen.ts
+++ b/ayunis-core-frontend/src/app/routeTree.gen.ts
@@ -10,415 +10,430 @@
 
 // Import Routes
 
-import { Route as rootRoute } from "./routes/__root";
-import { Route as AuthenticatedImport } from "./routes/_authenticated";
-import { Route as IndexImport } from "./routes/index";
-import { Route as onboardingRegisterImport } from "./routes/(onboarding)/register";
-import { Route as onboardingLoginImport } from "./routes/(onboarding)/login";
-import { Route as onboardingEmailConfirmImport } from "./routes/(onboarding)/email-confirm";
-import { Route as onboardingConfirmEmailImport } from "./routes/(onboarding)/confirm-email";
-import { Route as onboardingAcceptInviteImport } from "./routes/(onboarding)/accept-invite";
-import { Route as AuthenticatedSuperAdminSettingsIndexImport } from "./routes/_authenticated/super-admin-settings.index";
-import { Route as AuthenticatedSettingsIndexImport } from "./routes/_authenticated/settings.index";
-import { Route as AuthenticatedPromptsIndexImport } from "./routes/_authenticated/prompts.index";
-import { Route as AuthenticatedChatIndexImport } from "./routes/_authenticated/chat.index";
-import { Route as AuthenticatedAgentsIndexImport } from "./routes/_authenticated/agents.index";
-import { Route as AuthenticatedAdminSettingsIndexImport } from "./routes/_authenticated/admin-settings.index";
-import { Route as AuthenticatedSettingsGeneralImport } from "./routes/_authenticated/settings.general";
-import { Route as AuthenticatedSettingsAccountImport } from "./routes/_authenticated/settings.account";
-import { Route as AuthenticatedChatsThreadIdImport } from "./routes/_authenticated/chats.$threadId";
-import { Route as AuthenticatedAgentsIdImport } from "./routes/_authenticated/agents.$id";
-import { Route as AuthenticatedAdminSettingsUsersImport } from "./routes/_authenticated/admin-settings.users";
-import { Route as AuthenticatedAdminSettingsModelsImport } from "./routes/_authenticated/admin-settings.models";
-import { Route as AuthenticatedAdminSettingsIntegrationsImport } from "./routes/_authenticated/admin-settings.integrations";
-import { Route as AuthenticatedAdminSettingsBillingImport } from "./routes/_authenticated/admin-settings.billing";
-import { Route as onboardingPasswordResetImport } from "./routes/(onboarding)/password.reset";
-import { Route as onboardingPasswordForgotImport } from "./routes/(onboarding)/password.forgot";
-import { Route as AuthenticatedSuperAdminSettingsOrgsIndexImport } from "./routes/_authenticated/super-admin-settings.orgs.index";
-import { Route as AuthenticatedSuperAdminSettingsModelsCatalogIndexImport } from "./routes/_authenticated/super-admin-settings.models-catalog.index";
-import { Route as AuthenticatedSuperAdminSettingsOrgsIdImport } from "./routes/_authenticated/super-admin-settings.orgs.$id";
+import { Route as rootRoute } from './routes/__root'
+import { Route as AuthenticatedImport } from './routes/_authenticated'
+import { Route as IndexImport } from './routes/index'
+import { Route as onboardingRegisterImport } from './routes/(onboarding)/register'
+import { Route as onboardingLoginImport } from './routes/(onboarding)/login'
+import { Route as onboardingEmailConfirmImport } from './routes/(onboarding)/email-confirm'
+import { Route as onboardingConfirmEmailImport } from './routes/(onboarding)/confirm-email'
+import { Route as onboardingAcceptInviteImport } from './routes/(onboarding)/accept-invite'
+import { Route as AuthenticatedSuperAdminSettingsIndexImport } from './routes/_authenticated/super-admin-settings.index'
+import { Route as AuthenticatedSettingsIndexImport } from './routes/_authenticated/settings.index'
+import { Route as AuthenticatedPromptsIndexImport } from './routes/_authenticated/prompts.index'
+import { Route as AuthenticatedChatsIndexImport } from './routes/_authenticated/chats.index'
+import { Route as AuthenticatedChatIndexImport } from './routes/_authenticated/chat.index'
+import { Route as AuthenticatedAgentsIndexImport } from './routes/_authenticated/agents.index'
+import { Route as AuthenticatedAdminSettingsIndexImport } from './routes/_authenticated/admin-settings.index'
+import { Route as AuthenticatedSettingsGeneralImport } from './routes/_authenticated/settings.general'
+import { Route as AuthenticatedSettingsAccountImport } from './routes/_authenticated/settings.account'
+import { Route as AuthenticatedChatsThreadIdImport } from './routes/_authenticated/chats.$threadId'
+import { Route as AuthenticatedAgentsIdImport } from './routes/_authenticated/agents.$id'
+import { Route as AuthenticatedAdminSettingsUsersImport } from './routes/_authenticated/admin-settings.users'
+import { Route as AuthenticatedAdminSettingsModelsImport } from './routes/_authenticated/admin-settings.models'
+import { Route as AuthenticatedAdminSettingsIntegrationsImport } from './routes/_authenticated/admin-settings.integrations'
+import { Route as AuthenticatedAdminSettingsBillingImport } from './routes/_authenticated/admin-settings.billing'
+import { Route as onboardingPasswordResetImport } from './routes/(onboarding)/password.reset'
+import { Route as onboardingPasswordForgotImport } from './routes/(onboarding)/password.forgot'
+import { Route as AuthenticatedSuperAdminSettingsOrgsIndexImport } from './routes/_authenticated/super-admin-settings.orgs.index'
+import { Route as AuthenticatedSuperAdminSettingsModelsCatalogIndexImport } from './routes/_authenticated/super-admin-settings.models-catalog.index'
+import { Route as AuthenticatedSuperAdminSettingsOrgsIdImport } from './routes/_authenticated/super-admin-settings.orgs.$id'
 
 // Create/Update Routes
 
 const AuthenticatedRoute = AuthenticatedImport.update({
-  id: "/_authenticated",
+  id: '/_authenticated',
   getParentRoute: () => rootRoute,
-} as any);
+} as any)
 
 const IndexRoute = IndexImport.update({
-  id: "/",
-  path: "/",
+  id: '/',
+  path: '/',
   getParentRoute: () => rootRoute,
-} as any);
+} as any)
 
 const onboardingRegisterRoute = onboardingRegisterImport.update({
-  id: "/(onboarding)/register",
-  path: "/register",
+  id: '/(onboarding)/register',
+  path: '/register',
   getParentRoute: () => rootRoute,
-} as any);
+} as any)
 
 const onboardingLoginRoute = onboardingLoginImport.update({
-  id: "/(onboarding)/login",
-  path: "/login",
+  id: '/(onboarding)/login',
+  path: '/login',
   getParentRoute: () => rootRoute,
-} as any);
+} as any)
 
 const onboardingEmailConfirmRoute = onboardingEmailConfirmImport.update({
-  id: "/(onboarding)/email-confirm",
-  path: "/email-confirm",
+  id: '/(onboarding)/email-confirm',
+  path: '/email-confirm',
   getParentRoute: () => rootRoute,
-} as any);
+} as any)
 
 const onboardingConfirmEmailRoute = onboardingConfirmEmailImport.update({
-  id: "/(onboarding)/confirm-email",
-  path: "/confirm-email",
+  id: '/(onboarding)/confirm-email',
+  path: '/confirm-email',
   getParentRoute: () => rootRoute,
-} as any);
+} as any)
 
 const onboardingAcceptInviteRoute = onboardingAcceptInviteImport.update({
-  id: "/(onboarding)/accept-invite",
-  path: "/accept-invite",
+  id: '/(onboarding)/accept-invite',
+  path: '/accept-invite',
   getParentRoute: () => rootRoute,
-} as any);
+} as any)
 
 const AuthenticatedSuperAdminSettingsIndexRoute =
   AuthenticatedSuperAdminSettingsIndexImport.update({
-    id: "/super-admin-settings/",
-    path: "/super-admin-settings/",
+    id: '/super-admin-settings/',
+    path: '/super-admin-settings/',
     getParentRoute: () => AuthenticatedRoute,
-  } as any);
+  } as any)
 
 const AuthenticatedSettingsIndexRoute = AuthenticatedSettingsIndexImport.update(
   {
-    id: "/settings/",
-    path: "/settings/",
+    id: '/settings/',
+    path: '/settings/',
     getParentRoute: () => AuthenticatedRoute,
   } as any,
-);
+)
 
 const AuthenticatedPromptsIndexRoute = AuthenticatedPromptsIndexImport.update({
-  id: "/prompts/",
-  path: "/prompts/",
+  id: '/prompts/',
+  path: '/prompts/',
   getParentRoute: () => AuthenticatedRoute,
-} as any);
+} as any)
+
+const AuthenticatedChatsIndexRoute = AuthenticatedChatsIndexImport.update({
+  id: '/chats/',
+  path: '/chats/',
+  getParentRoute: () => AuthenticatedRoute,
+} as any)
 
 const AuthenticatedChatIndexRoute = AuthenticatedChatIndexImport.update({
-  id: "/chat/",
-  path: "/chat/",
+  id: '/chat/',
+  path: '/chat/',
   getParentRoute: () => AuthenticatedRoute,
-} as any);
+} as any)
 
 const AuthenticatedAgentsIndexRoute = AuthenticatedAgentsIndexImport.update({
-  id: "/agents/",
-  path: "/agents/",
+  id: '/agents/',
+  path: '/agents/',
   getParentRoute: () => AuthenticatedRoute,
-} as any);
+} as any)
 
 const AuthenticatedAdminSettingsIndexRoute =
   AuthenticatedAdminSettingsIndexImport.update({
-    id: "/admin-settings/",
-    path: "/admin-settings/",
+    id: '/admin-settings/',
+    path: '/admin-settings/',
     getParentRoute: () => AuthenticatedRoute,
-  } as any);
+  } as any)
 
 const AuthenticatedSettingsGeneralRoute =
   AuthenticatedSettingsGeneralImport.update({
-    id: "/settings/general",
-    path: "/settings/general",
+    id: '/settings/general',
+    path: '/settings/general',
     getParentRoute: () => AuthenticatedRoute,
-  } as any);
+  } as any)
 
 const AuthenticatedSettingsAccountRoute =
   AuthenticatedSettingsAccountImport.update({
-    id: "/settings/account",
-    path: "/settings/account",
+    id: '/settings/account',
+    path: '/settings/account',
     getParentRoute: () => AuthenticatedRoute,
-  } as any);
+  } as any)
 
 const AuthenticatedChatsThreadIdRoute = AuthenticatedChatsThreadIdImport.update(
   {
-    id: "/chats/$threadId",
-    path: "/chats/$threadId",
+    id: '/chats/$threadId',
+    path: '/chats/$threadId',
     getParentRoute: () => AuthenticatedRoute,
   } as any,
-);
+)
 
 const AuthenticatedAgentsIdRoute = AuthenticatedAgentsIdImport.update({
-  id: "/agents/$id",
-  path: "/agents/$id",
+  id: '/agents/$id',
+  path: '/agents/$id',
   getParentRoute: () => AuthenticatedRoute,
-} as any);
+} as any)
 
 const AuthenticatedAdminSettingsUsersRoute =
   AuthenticatedAdminSettingsUsersImport.update({
-    id: "/admin-settings/users",
-    path: "/admin-settings/users",
+    id: '/admin-settings/users',
+    path: '/admin-settings/users',
     getParentRoute: () => AuthenticatedRoute,
-  } as any);
+  } as any)
 
 const AuthenticatedAdminSettingsModelsRoute =
   AuthenticatedAdminSettingsModelsImport.update({
-    id: "/admin-settings/models",
-    path: "/admin-settings/models",
+    id: '/admin-settings/models',
+    path: '/admin-settings/models',
     getParentRoute: () => AuthenticatedRoute,
-  } as any);
+  } as any)
 
 const AuthenticatedAdminSettingsIntegrationsRoute =
   AuthenticatedAdminSettingsIntegrationsImport.update({
-    id: "/admin-settings/integrations",
-    path: "/admin-settings/integrations",
+    id: '/admin-settings/integrations',
+    path: '/admin-settings/integrations',
     getParentRoute: () => AuthenticatedRoute,
-  } as any);
+  } as any)
 
 const AuthenticatedAdminSettingsBillingRoute =
   AuthenticatedAdminSettingsBillingImport.update({
-    id: "/admin-settings/billing",
-    path: "/admin-settings/billing",
+    id: '/admin-settings/billing',
+    path: '/admin-settings/billing',
     getParentRoute: () => AuthenticatedRoute,
-  } as any);
+  } as any)
 
 const onboardingPasswordResetRoute = onboardingPasswordResetImport.update({
-  id: "/(onboarding)/password/reset",
-  path: "/password/reset",
+  id: '/(onboarding)/password/reset',
+  path: '/password/reset',
   getParentRoute: () => rootRoute,
-} as any);
+} as any)
 
 const onboardingPasswordForgotRoute = onboardingPasswordForgotImport.update({
-  id: "/(onboarding)/password/forgot",
-  path: "/password/forgot",
+  id: '/(onboarding)/password/forgot',
+  path: '/password/forgot',
   getParentRoute: () => rootRoute,
-} as any);
+} as any)
 
 const AuthenticatedSuperAdminSettingsOrgsIndexRoute =
   AuthenticatedSuperAdminSettingsOrgsIndexImport.update({
-    id: "/super-admin-settings/orgs/",
-    path: "/super-admin-settings/orgs/",
+    id: '/super-admin-settings/orgs/',
+    path: '/super-admin-settings/orgs/',
     getParentRoute: () => AuthenticatedRoute,
-  } as any);
+  } as any)
 
 const AuthenticatedSuperAdminSettingsModelsCatalogIndexRoute =
   AuthenticatedSuperAdminSettingsModelsCatalogIndexImport.update({
-    id: "/super-admin-settings/models-catalog/",
-    path: "/super-admin-settings/models-catalog/",
+    id: '/super-admin-settings/models-catalog/',
+    path: '/super-admin-settings/models-catalog/',
     getParentRoute: () => AuthenticatedRoute,
-  } as any);
+  } as any)
 
 const AuthenticatedSuperAdminSettingsOrgsIdRoute =
   AuthenticatedSuperAdminSettingsOrgsIdImport.update({
-    id: "/super-admin-settings/orgs/$id",
-    path: "/super-admin-settings/orgs/$id",
+    id: '/super-admin-settings/orgs/$id',
+    path: '/super-admin-settings/orgs/$id',
     getParentRoute: () => AuthenticatedRoute,
-  } as any);
+  } as any)
 
 // Populate the FileRoutesByPath interface
 
-declare module "@tanstack/react-router" {
+declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
-    "/": {
-      id: "/";
-      path: "/";
-      fullPath: "/";
-      preLoaderRoute: typeof IndexImport;
-      parentRoute: typeof rootRoute;
-    };
-    "/_authenticated": {
-      id: "/_authenticated";
-      path: "";
-      fullPath: "";
-      preLoaderRoute: typeof AuthenticatedImport;
-      parentRoute: typeof rootRoute;
-    };
-    "/(onboarding)/accept-invite": {
-      id: "/(onboarding)/accept-invite";
-      path: "/accept-invite";
-      fullPath: "/accept-invite";
-      preLoaderRoute: typeof onboardingAcceptInviteImport;
-      parentRoute: typeof rootRoute;
-    };
-    "/(onboarding)/confirm-email": {
-      id: "/(onboarding)/confirm-email";
-      path: "/confirm-email";
-      fullPath: "/confirm-email";
-      preLoaderRoute: typeof onboardingConfirmEmailImport;
-      parentRoute: typeof rootRoute;
-    };
-    "/(onboarding)/email-confirm": {
-      id: "/(onboarding)/email-confirm";
-      path: "/email-confirm";
-      fullPath: "/email-confirm";
-      preLoaderRoute: typeof onboardingEmailConfirmImport;
-      parentRoute: typeof rootRoute;
-    };
-    "/(onboarding)/login": {
-      id: "/(onboarding)/login";
-      path: "/login";
-      fullPath: "/login";
-      preLoaderRoute: typeof onboardingLoginImport;
-      parentRoute: typeof rootRoute;
-    };
-    "/(onboarding)/register": {
-      id: "/(onboarding)/register";
-      path: "/register";
-      fullPath: "/register";
-      preLoaderRoute: typeof onboardingRegisterImport;
-      parentRoute: typeof rootRoute;
-    };
-    "/(onboarding)/password/forgot": {
-      id: "/(onboarding)/password/forgot";
-      path: "/password/forgot";
-      fullPath: "/password/forgot";
-      preLoaderRoute: typeof onboardingPasswordForgotImport;
-      parentRoute: typeof rootRoute;
-    };
-    "/(onboarding)/password/reset": {
-      id: "/(onboarding)/password/reset";
-      path: "/password/reset";
-      fullPath: "/password/reset";
-      preLoaderRoute: typeof onboardingPasswordResetImport;
-      parentRoute: typeof rootRoute;
-    };
-    "/_authenticated/admin-settings/billing": {
-      id: "/_authenticated/admin-settings/billing";
-      path: "/admin-settings/billing";
-      fullPath: "/admin-settings/billing";
-      preLoaderRoute: typeof AuthenticatedAdminSettingsBillingImport;
-      parentRoute: typeof AuthenticatedImport;
-    };
-    "/_authenticated/admin-settings/integrations": {
-      id: "/_authenticated/admin-settings/integrations";
-      path: "/admin-settings/integrations";
-      fullPath: "/admin-settings/integrations";
-      preLoaderRoute: typeof AuthenticatedAdminSettingsIntegrationsImport;
-      parentRoute: typeof AuthenticatedImport;
-    };
-    "/_authenticated/admin-settings/models": {
-      id: "/_authenticated/admin-settings/models";
-      path: "/admin-settings/models";
-      fullPath: "/admin-settings/models";
-      preLoaderRoute: typeof AuthenticatedAdminSettingsModelsImport;
-      parentRoute: typeof AuthenticatedImport;
-    };
-    "/_authenticated/admin-settings/users": {
-      id: "/_authenticated/admin-settings/users";
-      path: "/admin-settings/users";
-      fullPath: "/admin-settings/users";
-      preLoaderRoute: typeof AuthenticatedAdminSettingsUsersImport;
-      parentRoute: typeof AuthenticatedImport;
-    };
-    "/_authenticated/agents/$id": {
-      id: "/_authenticated/agents/$id";
-      path: "/agents/$id";
-      fullPath: "/agents/$id";
-      preLoaderRoute: typeof AuthenticatedAgentsIdImport;
-      parentRoute: typeof AuthenticatedImport;
-    };
-    "/_authenticated/chats/$threadId": {
-      id: "/_authenticated/chats/$threadId";
-      path: "/chats/$threadId";
-      fullPath: "/chats/$threadId";
-      preLoaderRoute: typeof AuthenticatedChatsThreadIdImport;
-      parentRoute: typeof AuthenticatedImport;
-    };
-    "/_authenticated/settings/account": {
-      id: "/_authenticated/settings/account";
-      path: "/settings/account";
-      fullPath: "/settings/account";
-      preLoaderRoute: typeof AuthenticatedSettingsAccountImport;
-      parentRoute: typeof AuthenticatedImport;
-    };
-    "/_authenticated/settings/general": {
-      id: "/_authenticated/settings/general";
-      path: "/settings/general";
-      fullPath: "/settings/general";
-      preLoaderRoute: typeof AuthenticatedSettingsGeneralImport;
-      parentRoute: typeof AuthenticatedImport;
-    };
-    "/_authenticated/admin-settings/": {
-      id: "/_authenticated/admin-settings/";
-      path: "/admin-settings";
-      fullPath: "/admin-settings";
-      preLoaderRoute: typeof AuthenticatedAdminSettingsIndexImport;
-      parentRoute: typeof AuthenticatedImport;
-    };
-    "/_authenticated/agents/": {
-      id: "/_authenticated/agents/";
-      path: "/agents";
-      fullPath: "/agents";
-      preLoaderRoute: typeof AuthenticatedAgentsIndexImport;
-      parentRoute: typeof AuthenticatedImport;
-    };
-    "/_authenticated/chat/": {
-      id: "/_authenticated/chat/";
-      path: "/chat";
-      fullPath: "/chat";
-      preLoaderRoute: typeof AuthenticatedChatIndexImport;
-      parentRoute: typeof AuthenticatedImport;
-    };
-    "/_authenticated/prompts/": {
-      id: "/_authenticated/prompts/";
-      path: "/prompts";
-      fullPath: "/prompts";
-      preLoaderRoute: typeof AuthenticatedPromptsIndexImport;
-      parentRoute: typeof AuthenticatedImport;
-    };
-    "/_authenticated/settings/": {
-      id: "/_authenticated/settings/";
-      path: "/settings";
-      fullPath: "/settings";
-      preLoaderRoute: typeof AuthenticatedSettingsIndexImport;
-      parentRoute: typeof AuthenticatedImport;
-    };
-    "/_authenticated/super-admin-settings/": {
-      id: "/_authenticated/super-admin-settings/";
-      path: "/super-admin-settings";
-      fullPath: "/super-admin-settings";
-      preLoaderRoute: typeof AuthenticatedSuperAdminSettingsIndexImport;
-      parentRoute: typeof AuthenticatedImport;
-    };
-    "/_authenticated/super-admin-settings/orgs/$id": {
-      id: "/_authenticated/super-admin-settings/orgs/$id";
-      path: "/super-admin-settings/orgs/$id";
-      fullPath: "/super-admin-settings/orgs/$id";
-      preLoaderRoute: typeof AuthenticatedSuperAdminSettingsOrgsIdImport;
-      parentRoute: typeof AuthenticatedImport;
-    };
-    "/_authenticated/super-admin-settings/models-catalog/": {
-      id: "/_authenticated/super-admin-settings/models-catalog/";
-      path: "/super-admin-settings/models-catalog";
-      fullPath: "/super-admin-settings/models-catalog";
-      preLoaderRoute: typeof AuthenticatedSuperAdminSettingsModelsCatalogIndexImport;
-      parentRoute: typeof AuthenticatedImport;
-    };
-    "/_authenticated/super-admin-settings/orgs/": {
-      id: "/_authenticated/super-admin-settings/orgs/";
-      path: "/super-admin-settings/orgs";
-      fullPath: "/super-admin-settings/orgs";
-      preLoaderRoute: typeof AuthenticatedSuperAdminSettingsOrgsIndexImport;
-      parentRoute: typeof AuthenticatedImport;
-    };
+    '/': {
+      id: '/'
+      path: '/'
+      fullPath: '/'
+      preLoaderRoute: typeof IndexImport
+      parentRoute: typeof rootRoute
+    }
+    '/_authenticated': {
+      id: '/_authenticated'
+      path: ''
+      fullPath: ''
+      preLoaderRoute: typeof AuthenticatedImport
+      parentRoute: typeof rootRoute
+    }
+    '/(onboarding)/accept-invite': {
+      id: '/(onboarding)/accept-invite'
+      path: '/accept-invite'
+      fullPath: '/accept-invite'
+      preLoaderRoute: typeof onboardingAcceptInviteImport
+      parentRoute: typeof rootRoute
+    }
+    '/(onboarding)/confirm-email': {
+      id: '/(onboarding)/confirm-email'
+      path: '/confirm-email'
+      fullPath: '/confirm-email'
+      preLoaderRoute: typeof onboardingConfirmEmailImport
+      parentRoute: typeof rootRoute
+    }
+    '/(onboarding)/email-confirm': {
+      id: '/(onboarding)/email-confirm'
+      path: '/email-confirm'
+      fullPath: '/email-confirm'
+      preLoaderRoute: typeof onboardingEmailConfirmImport
+      parentRoute: typeof rootRoute
+    }
+    '/(onboarding)/login': {
+      id: '/(onboarding)/login'
+      path: '/login'
+      fullPath: '/login'
+      preLoaderRoute: typeof onboardingLoginImport
+      parentRoute: typeof rootRoute
+    }
+    '/(onboarding)/register': {
+      id: '/(onboarding)/register'
+      path: '/register'
+      fullPath: '/register'
+      preLoaderRoute: typeof onboardingRegisterImport
+      parentRoute: typeof rootRoute
+    }
+    '/(onboarding)/password/forgot': {
+      id: '/(onboarding)/password/forgot'
+      path: '/password/forgot'
+      fullPath: '/password/forgot'
+      preLoaderRoute: typeof onboardingPasswordForgotImport
+      parentRoute: typeof rootRoute
+    }
+    '/(onboarding)/password/reset': {
+      id: '/(onboarding)/password/reset'
+      path: '/password/reset'
+      fullPath: '/password/reset'
+      preLoaderRoute: typeof onboardingPasswordResetImport
+      parentRoute: typeof rootRoute
+    }
+    '/_authenticated/admin-settings/billing': {
+      id: '/_authenticated/admin-settings/billing'
+      path: '/admin-settings/billing'
+      fullPath: '/admin-settings/billing'
+      preLoaderRoute: typeof AuthenticatedAdminSettingsBillingImport
+      parentRoute: typeof AuthenticatedImport
+    }
+    '/_authenticated/admin-settings/integrations': {
+      id: '/_authenticated/admin-settings/integrations'
+      path: '/admin-settings/integrations'
+      fullPath: '/admin-settings/integrations'
+      preLoaderRoute: typeof AuthenticatedAdminSettingsIntegrationsImport
+      parentRoute: typeof AuthenticatedImport
+    }
+    '/_authenticated/admin-settings/models': {
+      id: '/_authenticated/admin-settings/models'
+      path: '/admin-settings/models'
+      fullPath: '/admin-settings/models'
+      preLoaderRoute: typeof AuthenticatedAdminSettingsModelsImport
+      parentRoute: typeof AuthenticatedImport
+    }
+    '/_authenticated/admin-settings/users': {
+      id: '/_authenticated/admin-settings/users'
+      path: '/admin-settings/users'
+      fullPath: '/admin-settings/users'
+      preLoaderRoute: typeof AuthenticatedAdminSettingsUsersImport
+      parentRoute: typeof AuthenticatedImport
+    }
+    '/_authenticated/agents/$id': {
+      id: '/_authenticated/agents/$id'
+      path: '/agents/$id'
+      fullPath: '/agents/$id'
+      preLoaderRoute: typeof AuthenticatedAgentsIdImport
+      parentRoute: typeof AuthenticatedImport
+    }
+    '/_authenticated/chats/$threadId': {
+      id: '/_authenticated/chats/$threadId'
+      path: '/chats/$threadId'
+      fullPath: '/chats/$threadId'
+      preLoaderRoute: typeof AuthenticatedChatsThreadIdImport
+      parentRoute: typeof AuthenticatedImport
+    }
+    '/_authenticated/settings/account': {
+      id: '/_authenticated/settings/account'
+      path: '/settings/account'
+      fullPath: '/settings/account'
+      preLoaderRoute: typeof AuthenticatedSettingsAccountImport
+      parentRoute: typeof AuthenticatedImport
+    }
+    '/_authenticated/settings/general': {
+      id: '/_authenticated/settings/general'
+      path: '/settings/general'
+      fullPath: '/settings/general'
+      preLoaderRoute: typeof AuthenticatedSettingsGeneralImport
+      parentRoute: typeof AuthenticatedImport
+    }
+    '/_authenticated/admin-settings/': {
+      id: '/_authenticated/admin-settings/'
+      path: '/admin-settings'
+      fullPath: '/admin-settings'
+      preLoaderRoute: typeof AuthenticatedAdminSettingsIndexImport
+      parentRoute: typeof AuthenticatedImport
+    }
+    '/_authenticated/agents/': {
+      id: '/_authenticated/agents/'
+      path: '/agents'
+      fullPath: '/agents'
+      preLoaderRoute: typeof AuthenticatedAgentsIndexImport
+      parentRoute: typeof AuthenticatedImport
+    }
+    '/_authenticated/chat/': {
+      id: '/_authenticated/chat/'
+      path: '/chat'
+      fullPath: '/chat'
+      preLoaderRoute: typeof AuthenticatedChatIndexImport
+      parentRoute: typeof AuthenticatedImport
+    }
+    '/_authenticated/chats/': {
+      id: '/_authenticated/chats/'
+      path: '/chats'
+      fullPath: '/chats'
+      preLoaderRoute: typeof AuthenticatedChatsIndexImport
+      parentRoute: typeof AuthenticatedImport
+    }
+    '/_authenticated/prompts/': {
+      id: '/_authenticated/prompts/'
+      path: '/prompts'
+      fullPath: '/prompts'
+      preLoaderRoute: typeof AuthenticatedPromptsIndexImport
+      parentRoute: typeof AuthenticatedImport
+    }
+    '/_authenticated/settings/': {
+      id: '/_authenticated/settings/'
+      path: '/settings'
+      fullPath: '/settings'
+      preLoaderRoute: typeof AuthenticatedSettingsIndexImport
+      parentRoute: typeof AuthenticatedImport
+    }
+    '/_authenticated/super-admin-settings/': {
+      id: '/_authenticated/super-admin-settings/'
+      path: '/super-admin-settings'
+      fullPath: '/super-admin-settings'
+      preLoaderRoute: typeof AuthenticatedSuperAdminSettingsIndexImport
+      parentRoute: typeof AuthenticatedImport
+    }
+    '/_authenticated/super-admin-settings/orgs/$id': {
+      id: '/_authenticated/super-admin-settings/orgs/$id'
+      path: '/super-admin-settings/orgs/$id'
+      fullPath: '/super-admin-settings/orgs/$id'
+      preLoaderRoute: typeof AuthenticatedSuperAdminSettingsOrgsIdImport
+      parentRoute: typeof AuthenticatedImport
+    }
+    '/_authenticated/super-admin-settings/models-catalog/': {
+      id: '/_authenticated/super-admin-settings/models-catalog/'
+      path: '/super-admin-settings/models-catalog'
+      fullPath: '/super-admin-settings/models-catalog'
+      preLoaderRoute: typeof AuthenticatedSuperAdminSettingsModelsCatalogIndexImport
+      parentRoute: typeof AuthenticatedImport
+    }
+    '/_authenticated/super-admin-settings/orgs/': {
+      id: '/_authenticated/super-admin-settings/orgs/'
+      path: '/super-admin-settings/orgs'
+      fullPath: '/super-admin-settings/orgs'
+      preLoaderRoute: typeof AuthenticatedSuperAdminSettingsOrgsIndexImport
+      parentRoute: typeof AuthenticatedImport
+    }
   }
 }
 
 // Create and export the route tree
 
 interface AuthenticatedRouteChildren {
-  AuthenticatedAdminSettingsBillingRoute: typeof AuthenticatedAdminSettingsBillingRoute;
-  AuthenticatedAdminSettingsIntegrationsRoute: typeof AuthenticatedAdminSettingsIntegrationsRoute;
-  AuthenticatedAdminSettingsModelsRoute: typeof AuthenticatedAdminSettingsModelsRoute;
-  AuthenticatedAdminSettingsUsersRoute: typeof AuthenticatedAdminSettingsUsersRoute;
-  AuthenticatedAgentsIdRoute: typeof AuthenticatedAgentsIdRoute;
-  AuthenticatedChatsThreadIdRoute: typeof AuthenticatedChatsThreadIdRoute;
-  AuthenticatedSettingsAccountRoute: typeof AuthenticatedSettingsAccountRoute;
-  AuthenticatedSettingsGeneralRoute: typeof AuthenticatedSettingsGeneralRoute;
-  AuthenticatedAdminSettingsIndexRoute: typeof AuthenticatedAdminSettingsIndexRoute;
-  AuthenticatedAgentsIndexRoute: typeof AuthenticatedAgentsIndexRoute;
-  AuthenticatedChatIndexRoute: typeof AuthenticatedChatIndexRoute;
-  AuthenticatedPromptsIndexRoute: typeof AuthenticatedPromptsIndexRoute;
-  AuthenticatedSettingsIndexRoute: typeof AuthenticatedSettingsIndexRoute;
-  AuthenticatedSuperAdminSettingsIndexRoute: typeof AuthenticatedSuperAdminSettingsIndexRoute;
-  AuthenticatedSuperAdminSettingsOrgsIdRoute: typeof AuthenticatedSuperAdminSettingsOrgsIdRoute;
-  AuthenticatedSuperAdminSettingsModelsCatalogIndexRoute: typeof AuthenticatedSuperAdminSettingsModelsCatalogIndexRoute;
-  AuthenticatedSuperAdminSettingsOrgsIndexRoute: typeof AuthenticatedSuperAdminSettingsOrgsIndexRoute;
+  AuthenticatedAdminSettingsBillingRoute: typeof AuthenticatedAdminSettingsBillingRoute
+  AuthenticatedAdminSettingsIntegrationsRoute: typeof AuthenticatedAdminSettingsIntegrationsRoute
+  AuthenticatedAdminSettingsModelsRoute: typeof AuthenticatedAdminSettingsModelsRoute
+  AuthenticatedAdminSettingsUsersRoute: typeof AuthenticatedAdminSettingsUsersRoute
+  AuthenticatedAgentsIdRoute: typeof AuthenticatedAgentsIdRoute
+  AuthenticatedChatsThreadIdRoute: typeof AuthenticatedChatsThreadIdRoute
+  AuthenticatedSettingsAccountRoute: typeof AuthenticatedSettingsAccountRoute
+  AuthenticatedSettingsGeneralRoute: typeof AuthenticatedSettingsGeneralRoute
+  AuthenticatedAdminSettingsIndexRoute: typeof AuthenticatedAdminSettingsIndexRoute
+  AuthenticatedAgentsIndexRoute: typeof AuthenticatedAgentsIndexRoute
+  AuthenticatedChatIndexRoute: typeof AuthenticatedChatIndexRoute
+  AuthenticatedChatsIndexRoute: typeof AuthenticatedChatsIndexRoute
+  AuthenticatedPromptsIndexRoute: typeof AuthenticatedPromptsIndexRoute
+  AuthenticatedSettingsIndexRoute: typeof AuthenticatedSettingsIndexRoute
+  AuthenticatedSuperAdminSettingsIndexRoute: typeof AuthenticatedSuperAdminSettingsIndexRoute
+  AuthenticatedSuperAdminSettingsOrgsIdRoute: typeof AuthenticatedSuperAdminSettingsOrgsIdRoute
+  AuthenticatedSuperAdminSettingsModelsCatalogIndexRoute: typeof AuthenticatedSuperAdminSettingsModelsCatalogIndexRoute
+  AuthenticatedSuperAdminSettingsOrgsIndexRoute: typeof AuthenticatedSuperAdminSettingsOrgsIndexRoute
 }
 
 const AuthenticatedRouteChildren: AuthenticatedRouteChildren = {
@@ -435,6 +450,7 @@ const AuthenticatedRouteChildren: AuthenticatedRouteChildren = {
   AuthenticatedAdminSettingsIndexRoute: AuthenticatedAdminSettingsIndexRoute,
   AuthenticatedAgentsIndexRoute: AuthenticatedAgentsIndexRoute,
   AuthenticatedChatIndexRoute: AuthenticatedChatIndexRoute,
+  AuthenticatedChatsIndexRoute: AuthenticatedChatsIndexRoute,
   AuthenticatedPromptsIndexRoute: AuthenticatedPromptsIndexRoute,
   AuthenticatedSettingsIndexRoute: AuthenticatedSettingsIndexRoute,
   AuthenticatedSuperAdminSettingsIndexRoute:
@@ -445,198 +461,204 @@ const AuthenticatedRouteChildren: AuthenticatedRouteChildren = {
     AuthenticatedSuperAdminSettingsModelsCatalogIndexRoute,
   AuthenticatedSuperAdminSettingsOrgsIndexRoute:
     AuthenticatedSuperAdminSettingsOrgsIndexRoute,
-};
+}
 
 const AuthenticatedRouteWithChildren = AuthenticatedRoute._addFileChildren(
   AuthenticatedRouteChildren,
-);
+)
 
 export interface FileRoutesByFullPath {
-  "/": typeof IndexRoute;
-  "": typeof AuthenticatedRouteWithChildren;
-  "/accept-invite": typeof onboardingAcceptInviteRoute;
-  "/confirm-email": typeof onboardingConfirmEmailRoute;
-  "/email-confirm": typeof onboardingEmailConfirmRoute;
-  "/login": typeof onboardingLoginRoute;
-  "/register": typeof onboardingRegisterRoute;
-  "/password/forgot": typeof onboardingPasswordForgotRoute;
-  "/password/reset": typeof onboardingPasswordResetRoute;
-  "/admin-settings/billing": typeof AuthenticatedAdminSettingsBillingRoute;
-  "/admin-settings/integrations": typeof AuthenticatedAdminSettingsIntegrationsRoute;
-  "/admin-settings/models": typeof AuthenticatedAdminSettingsModelsRoute;
-  "/admin-settings/users": typeof AuthenticatedAdminSettingsUsersRoute;
-  "/agents/$id": typeof AuthenticatedAgentsIdRoute;
-  "/chats/$threadId": typeof AuthenticatedChatsThreadIdRoute;
-  "/settings/account": typeof AuthenticatedSettingsAccountRoute;
-  "/settings/general": typeof AuthenticatedSettingsGeneralRoute;
-  "/admin-settings": typeof AuthenticatedAdminSettingsIndexRoute;
-  "/agents": typeof AuthenticatedAgentsIndexRoute;
-  "/chat": typeof AuthenticatedChatIndexRoute;
-  "/prompts": typeof AuthenticatedPromptsIndexRoute;
-  "/settings": typeof AuthenticatedSettingsIndexRoute;
-  "/super-admin-settings": typeof AuthenticatedSuperAdminSettingsIndexRoute;
-  "/super-admin-settings/orgs/$id": typeof AuthenticatedSuperAdminSettingsOrgsIdRoute;
-  "/super-admin-settings/models-catalog": typeof AuthenticatedSuperAdminSettingsModelsCatalogIndexRoute;
-  "/super-admin-settings/orgs": typeof AuthenticatedSuperAdminSettingsOrgsIndexRoute;
+  '/': typeof IndexRoute
+  '': typeof AuthenticatedRouteWithChildren
+  '/accept-invite': typeof onboardingAcceptInviteRoute
+  '/confirm-email': typeof onboardingConfirmEmailRoute
+  '/email-confirm': typeof onboardingEmailConfirmRoute
+  '/login': typeof onboardingLoginRoute
+  '/register': typeof onboardingRegisterRoute
+  '/password/forgot': typeof onboardingPasswordForgotRoute
+  '/password/reset': typeof onboardingPasswordResetRoute
+  '/admin-settings/billing': typeof AuthenticatedAdminSettingsBillingRoute
+  '/admin-settings/integrations': typeof AuthenticatedAdminSettingsIntegrationsRoute
+  '/admin-settings/models': typeof AuthenticatedAdminSettingsModelsRoute
+  '/admin-settings/users': typeof AuthenticatedAdminSettingsUsersRoute
+  '/agents/$id': typeof AuthenticatedAgentsIdRoute
+  '/chats/$threadId': typeof AuthenticatedChatsThreadIdRoute
+  '/settings/account': typeof AuthenticatedSettingsAccountRoute
+  '/settings/general': typeof AuthenticatedSettingsGeneralRoute
+  '/admin-settings': typeof AuthenticatedAdminSettingsIndexRoute
+  '/agents': typeof AuthenticatedAgentsIndexRoute
+  '/chat': typeof AuthenticatedChatIndexRoute
+  '/chats': typeof AuthenticatedChatsIndexRoute
+  '/prompts': typeof AuthenticatedPromptsIndexRoute
+  '/settings': typeof AuthenticatedSettingsIndexRoute
+  '/super-admin-settings': typeof AuthenticatedSuperAdminSettingsIndexRoute
+  '/super-admin-settings/orgs/$id': typeof AuthenticatedSuperAdminSettingsOrgsIdRoute
+  '/super-admin-settings/models-catalog': typeof AuthenticatedSuperAdminSettingsModelsCatalogIndexRoute
+  '/super-admin-settings/orgs': typeof AuthenticatedSuperAdminSettingsOrgsIndexRoute
 }
 
 export interface FileRoutesByTo {
-  "/": typeof IndexRoute;
-  "": typeof AuthenticatedRouteWithChildren;
-  "/accept-invite": typeof onboardingAcceptInviteRoute;
-  "/confirm-email": typeof onboardingConfirmEmailRoute;
-  "/email-confirm": typeof onboardingEmailConfirmRoute;
-  "/login": typeof onboardingLoginRoute;
-  "/register": typeof onboardingRegisterRoute;
-  "/password/forgot": typeof onboardingPasswordForgotRoute;
-  "/password/reset": typeof onboardingPasswordResetRoute;
-  "/admin-settings/billing": typeof AuthenticatedAdminSettingsBillingRoute;
-  "/admin-settings/integrations": typeof AuthenticatedAdminSettingsIntegrationsRoute;
-  "/admin-settings/models": typeof AuthenticatedAdminSettingsModelsRoute;
-  "/admin-settings/users": typeof AuthenticatedAdminSettingsUsersRoute;
-  "/agents/$id": typeof AuthenticatedAgentsIdRoute;
-  "/chats/$threadId": typeof AuthenticatedChatsThreadIdRoute;
-  "/settings/account": typeof AuthenticatedSettingsAccountRoute;
-  "/settings/general": typeof AuthenticatedSettingsGeneralRoute;
-  "/admin-settings": typeof AuthenticatedAdminSettingsIndexRoute;
-  "/agents": typeof AuthenticatedAgentsIndexRoute;
-  "/chat": typeof AuthenticatedChatIndexRoute;
-  "/prompts": typeof AuthenticatedPromptsIndexRoute;
-  "/settings": typeof AuthenticatedSettingsIndexRoute;
-  "/super-admin-settings": typeof AuthenticatedSuperAdminSettingsIndexRoute;
-  "/super-admin-settings/orgs/$id": typeof AuthenticatedSuperAdminSettingsOrgsIdRoute;
-  "/super-admin-settings/models-catalog": typeof AuthenticatedSuperAdminSettingsModelsCatalogIndexRoute;
-  "/super-admin-settings/orgs": typeof AuthenticatedSuperAdminSettingsOrgsIndexRoute;
+  '/': typeof IndexRoute
+  '': typeof AuthenticatedRouteWithChildren
+  '/accept-invite': typeof onboardingAcceptInviteRoute
+  '/confirm-email': typeof onboardingConfirmEmailRoute
+  '/email-confirm': typeof onboardingEmailConfirmRoute
+  '/login': typeof onboardingLoginRoute
+  '/register': typeof onboardingRegisterRoute
+  '/password/forgot': typeof onboardingPasswordForgotRoute
+  '/password/reset': typeof onboardingPasswordResetRoute
+  '/admin-settings/billing': typeof AuthenticatedAdminSettingsBillingRoute
+  '/admin-settings/integrations': typeof AuthenticatedAdminSettingsIntegrationsRoute
+  '/admin-settings/models': typeof AuthenticatedAdminSettingsModelsRoute
+  '/admin-settings/users': typeof AuthenticatedAdminSettingsUsersRoute
+  '/agents/$id': typeof AuthenticatedAgentsIdRoute
+  '/chats/$threadId': typeof AuthenticatedChatsThreadIdRoute
+  '/settings/account': typeof AuthenticatedSettingsAccountRoute
+  '/settings/general': typeof AuthenticatedSettingsGeneralRoute
+  '/admin-settings': typeof AuthenticatedAdminSettingsIndexRoute
+  '/agents': typeof AuthenticatedAgentsIndexRoute
+  '/chat': typeof AuthenticatedChatIndexRoute
+  '/chats': typeof AuthenticatedChatsIndexRoute
+  '/prompts': typeof AuthenticatedPromptsIndexRoute
+  '/settings': typeof AuthenticatedSettingsIndexRoute
+  '/super-admin-settings': typeof AuthenticatedSuperAdminSettingsIndexRoute
+  '/super-admin-settings/orgs/$id': typeof AuthenticatedSuperAdminSettingsOrgsIdRoute
+  '/super-admin-settings/models-catalog': typeof AuthenticatedSuperAdminSettingsModelsCatalogIndexRoute
+  '/super-admin-settings/orgs': typeof AuthenticatedSuperAdminSettingsOrgsIndexRoute
 }
 
 export interface FileRoutesById {
-  __root__: typeof rootRoute;
-  "/": typeof IndexRoute;
-  "/_authenticated": typeof AuthenticatedRouteWithChildren;
-  "/(onboarding)/accept-invite": typeof onboardingAcceptInviteRoute;
-  "/(onboarding)/confirm-email": typeof onboardingConfirmEmailRoute;
-  "/(onboarding)/email-confirm": typeof onboardingEmailConfirmRoute;
-  "/(onboarding)/login": typeof onboardingLoginRoute;
-  "/(onboarding)/register": typeof onboardingRegisterRoute;
-  "/(onboarding)/password/forgot": typeof onboardingPasswordForgotRoute;
-  "/(onboarding)/password/reset": typeof onboardingPasswordResetRoute;
-  "/_authenticated/admin-settings/billing": typeof AuthenticatedAdminSettingsBillingRoute;
-  "/_authenticated/admin-settings/integrations": typeof AuthenticatedAdminSettingsIntegrationsRoute;
-  "/_authenticated/admin-settings/models": typeof AuthenticatedAdminSettingsModelsRoute;
-  "/_authenticated/admin-settings/users": typeof AuthenticatedAdminSettingsUsersRoute;
-  "/_authenticated/agents/$id": typeof AuthenticatedAgentsIdRoute;
-  "/_authenticated/chats/$threadId": typeof AuthenticatedChatsThreadIdRoute;
-  "/_authenticated/settings/account": typeof AuthenticatedSettingsAccountRoute;
-  "/_authenticated/settings/general": typeof AuthenticatedSettingsGeneralRoute;
-  "/_authenticated/admin-settings/": typeof AuthenticatedAdminSettingsIndexRoute;
-  "/_authenticated/agents/": typeof AuthenticatedAgentsIndexRoute;
-  "/_authenticated/chat/": typeof AuthenticatedChatIndexRoute;
-  "/_authenticated/prompts/": typeof AuthenticatedPromptsIndexRoute;
-  "/_authenticated/settings/": typeof AuthenticatedSettingsIndexRoute;
-  "/_authenticated/super-admin-settings/": typeof AuthenticatedSuperAdminSettingsIndexRoute;
-  "/_authenticated/super-admin-settings/orgs/$id": typeof AuthenticatedSuperAdminSettingsOrgsIdRoute;
-  "/_authenticated/super-admin-settings/models-catalog/": typeof AuthenticatedSuperAdminSettingsModelsCatalogIndexRoute;
-  "/_authenticated/super-admin-settings/orgs/": typeof AuthenticatedSuperAdminSettingsOrgsIndexRoute;
+  __root__: typeof rootRoute
+  '/': typeof IndexRoute
+  '/_authenticated': typeof AuthenticatedRouteWithChildren
+  '/(onboarding)/accept-invite': typeof onboardingAcceptInviteRoute
+  '/(onboarding)/confirm-email': typeof onboardingConfirmEmailRoute
+  '/(onboarding)/email-confirm': typeof onboardingEmailConfirmRoute
+  '/(onboarding)/login': typeof onboardingLoginRoute
+  '/(onboarding)/register': typeof onboardingRegisterRoute
+  '/(onboarding)/password/forgot': typeof onboardingPasswordForgotRoute
+  '/(onboarding)/password/reset': typeof onboardingPasswordResetRoute
+  '/_authenticated/admin-settings/billing': typeof AuthenticatedAdminSettingsBillingRoute
+  '/_authenticated/admin-settings/integrations': typeof AuthenticatedAdminSettingsIntegrationsRoute
+  '/_authenticated/admin-settings/models': typeof AuthenticatedAdminSettingsModelsRoute
+  '/_authenticated/admin-settings/users': typeof AuthenticatedAdminSettingsUsersRoute
+  '/_authenticated/agents/$id': typeof AuthenticatedAgentsIdRoute
+  '/_authenticated/chats/$threadId': typeof AuthenticatedChatsThreadIdRoute
+  '/_authenticated/settings/account': typeof AuthenticatedSettingsAccountRoute
+  '/_authenticated/settings/general': typeof AuthenticatedSettingsGeneralRoute
+  '/_authenticated/admin-settings/': typeof AuthenticatedAdminSettingsIndexRoute
+  '/_authenticated/agents/': typeof AuthenticatedAgentsIndexRoute
+  '/_authenticated/chat/': typeof AuthenticatedChatIndexRoute
+  '/_authenticated/chats/': typeof AuthenticatedChatsIndexRoute
+  '/_authenticated/prompts/': typeof AuthenticatedPromptsIndexRoute
+  '/_authenticated/settings/': typeof AuthenticatedSettingsIndexRoute
+  '/_authenticated/super-admin-settings/': typeof AuthenticatedSuperAdminSettingsIndexRoute
+  '/_authenticated/super-admin-settings/orgs/$id': typeof AuthenticatedSuperAdminSettingsOrgsIdRoute
+  '/_authenticated/super-admin-settings/models-catalog/': typeof AuthenticatedSuperAdminSettingsModelsCatalogIndexRoute
+  '/_authenticated/super-admin-settings/orgs/': typeof AuthenticatedSuperAdminSettingsOrgsIndexRoute
 }
 
 export interface FileRouteTypes {
-  fileRoutesByFullPath: FileRoutesByFullPath;
+  fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
-    | "/"
-    | ""
-    | "/accept-invite"
-    | "/confirm-email"
-    | "/email-confirm"
-    | "/login"
-    | "/register"
-    | "/password/forgot"
-    | "/password/reset"
-    | "/admin-settings/billing"
-    | "/admin-settings/integrations"
-    | "/admin-settings/models"
-    | "/admin-settings/users"
-    | "/agents/$id"
-    | "/chats/$threadId"
-    | "/settings/account"
-    | "/settings/general"
-    | "/admin-settings"
-    | "/agents"
-    | "/chat"
-    | "/prompts"
-    | "/settings"
-    | "/super-admin-settings"
-    | "/super-admin-settings/orgs/$id"
-    | "/super-admin-settings/models-catalog"
-    | "/super-admin-settings/orgs";
-  fileRoutesByTo: FileRoutesByTo;
+    | '/'
+    | ''
+    | '/accept-invite'
+    | '/confirm-email'
+    | '/email-confirm'
+    | '/login'
+    | '/register'
+    | '/password/forgot'
+    | '/password/reset'
+    | '/admin-settings/billing'
+    | '/admin-settings/integrations'
+    | '/admin-settings/models'
+    | '/admin-settings/users'
+    | '/agents/$id'
+    | '/chats/$threadId'
+    | '/settings/account'
+    | '/settings/general'
+    | '/admin-settings'
+    | '/agents'
+    | '/chat'
+    | '/chats'
+    | '/prompts'
+    | '/settings'
+    | '/super-admin-settings'
+    | '/super-admin-settings/orgs/$id'
+    | '/super-admin-settings/models-catalog'
+    | '/super-admin-settings/orgs'
+  fileRoutesByTo: FileRoutesByTo
   to:
-    | "/"
-    | ""
-    | "/accept-invite"
-    | "/confirm-email"
-    | "/email-confirm"
-    | "/login"
-    | "/register"
-    | "/password/forgot"
-    | "/password/reset"
-    | "/admin-settings/billing"
-    | "/admin-settings/integrations"
-    | "/admin-settings/models"
-    | "/admin-settings/users"
-    | "/agents/$id"
-    | "/chats/$threadId"
-    | "/settings/account"
-    | "/settings/general"
-    | "/admin-settings"
-    | "/agents"
-    | "/chat"
-    | "/prompts"
-    | "/settings"
-    | "/super-admin-settings"
-    | "/super-admin-settings/orgs/$id"
-    | "/super-admin-settings/models-catalog"
-    | "/super-admin-settings/orgs";
+    | '/'
+    | ''
+    | '/accept-invite'
+    | '/confirm-email'
+    | '/email-confirm'
+    | '/login'
+    | '/register'
+    | '/password/forgot'
+    | '/password/reset'
+    | '/admin-settings/billing'
+    | '/admin-settings/integrations'
+    | '/admin-settings/models'
+    | '/admin-settings/users'
+    | '/agents/$id'
+    | '/chats/$threadId'
+    | '/settings/account'
+    | '/settings/general'
+    | '/admin-settings'
+    | '/agents'
+    | '/chat'
+    | '/chats'
+    | '/prompts'
+    | '/settings'
+    | '/super-admin-settings'
+    | '/super-admin-settings/orgs/$id'
+    | '/super-admin-settings/models-catalog'
+    | '/super-admin-settings/orgs'
   id:
-    | "__root__"
-    | "/"
-    | "/_authenticated"
-    | "/(onboarding)/accept-invite"
-    | "/(onboarding)/confirm-email"
-    | "/(onboarding)/email-confirm"
-    | "/(onboarding)/login"
-    | "/(onboarding)/register"
-    | "/(onboarding)/password/forgot"
-    | "/(onboarding)/password/reset"
-    | "/_authenticated/admin-settings/billing"
-    | "/_authenticated/admin-settings/integrations"
-    | "/_authenticated/admin-settings/models"
-    | "/_authenticated/admin-settings/users"
-    | "/_authenticated/agents/$id"
-    | "/_authenticated/chats/$threadId"
-    | "/_authenticated/settings/account"
-    | "/_authenticated/settings/general"
-    | "/_authenticated/admin-settings/"
-    | "/_authenticated/agents/"
-    | "/_authenticated/chat/"
-    | "/_authenticated/prompts/"
-    | "/_authenticated/settings/"
-    | "/_authenticated/super-admin-settings/"
-    | "/_authenticated/super-admin-settings/orgs/$id"
-    | "/_authenticated/super-admin-settings/models-catalog/"
-    | "/_authenticated/super-admin-settings/orgs/";
-  fileRoutesById: FileRoutesById;
+    | '__root__'
+    | '/'
+    | '/_authenticated'
+    | '/(onboarding)/accept-invite'
+    | '/(onboarding)/confirm-email'
+    | '/(onboarding)/email-confirm'
+    | '/(onboarding)/login'
+    | '/(onboarding)/register'
+    | '/(onboarding)/password/forgot'
+    | '/(onboarding)/password/reset'
+    | '/_authenticated/admin-settings/billing'
+    | '/_authenticated/admin-settings/integrations'
+    | '/_authenticated/admin-settings/models'
+    | '/_authenticated/admin-settings/users'
+    | '/_authenticated/agents/$id'
+    | '/_authenticated/chats/$threadId'
+    | '/_authenticated/settings/account'
+    | '/_authenticated/settings/general'
+    | '/_authenticated/admin-settings/'
+    | '/_authenticated/agents/'
+    | '/_authenticated/chat/'
+    | '/_authenticated/chats/'
+    | '/_authenticated/prompts/'
+    | '/_authenticated/settings/'
+    | '/_authenticated/super-admin-settings/'
+    | '/_authenticated/super-admin-settings/orgs/$id'
+    | '/_authenticated/super-admin-settings/models-catalog/'
+    | '/_authenticated/super-admin-settings/orgs/'
+  fileRoutesById: FileRoutesById
 }
 
 export interface RootRouteChildren {
-  IndexRoute: typeof IndexRoute;
-  AuthenticatedRoute: typeof AuthenticatedRouteWithChildren;
-  onboardingAcceptInviteRoute: typeof onboardingAcceptInviteRoute;
-  onboardingConfirmEmailRoute: typeof onboardingConfirmEmailRoute;
-  onboardingEmailConfirmRoute: typeof onboardingEmailConfirmRoute;
-  onboardingLoginRoute: typeof onboardingLoginRoute;
-  onboardingRegisterRoute: typeof onboardingRegisterRoute;
-  onboardingPasswordForgotRoute: typeof onboardingPasswordForgotRoute;
-  onboardingPasswordResetRoute: typeof onboardingPasswordResetRoute;
+  IndexRoute: typeof IndexRoute
+  AuthenticatedRoute: typeof AuthenticatedRouteWithChildren
+  onboardingAcceptInviteRoute: typeof onboardingAcceptInviteRoute
+  onboardingConfirmEmailRoute: typeof onboardingConfirmEmailRoute
+  onboardingEmailConfirmRoute: typeof onboardingEmailConfirmRoute
+  onboardingLoginRoute: typeof onboardingLoginRoute
+  onboardingRegisterRoute: typeof onboardingRegisterRoute
+  onboardingPasswordForgotRoute: typeof onboardingPasswordForgotRoute
+  onboardingPasswordResetRoute: typeof onboardingPasswordResetRoute
 }
 
 const rootRouteChildren: RootRouteChildren = {
@@ -649,11 +671,11 @@ const rootRouteChildren: RootRouteChildren = {
   onboardingRegisterRoute: onboardingRegisterRoute,
   onboardingPasswordForgotRoute: onboardingPasswordForgotRoute,
   onboardingPasswordResetRoute: onboardingPasswordResetRoute,
-};
+}
 
 export const routeTree = rootRoute
   ._addFileChildren(rootRouteChildren)
-  ._addFileTypes<FileRouteTypes>();
+  ._addFileTypes<FileRouteTypes>()
 
 /* ROUTE_MANIFEST_START
 {
@@ -689,6 +711,7 @@ export const routeTree = rootRoute
         "/_authenticated/admin-settings/",
         "/_authenticated/agents/",
         "/_authenticated/chat/",
+        "/_authenticated/chats/",
         "/_authenticated/prompts/",
         "/_authenticated/settings/",
         "/_authenticated/super-admin-settings/",
@@ -760,6 +783,10 @@ export const routeTree = rootRoute
     },
     "/_authenticated/chat/": {
       "filePath": "_authenticated/chat.index.tsx",
+      "parent": "/_authenticated"
+    },
+    "/_authenticated/chats/": {
+      "filePath": "_authenticated/chats.index.tsx",
       "parent": "/_authenticated"
     },
     "/_authenticated/prompts/": {

--- a/ayunis-core-frontend/src/app/routes/_authenticated/chats.index.tsx
+++ b/ayunis-core-frontend/src/app/routes/_authenticated/chats.index.tsx
@@ -1,0 +1,47 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { z } from 'zod';
+import { ChatsPage } from '@/pages/chats';
+import {
+  threadsControllerFindAll,
+  getThreadsControllerFindAllQueryKey,
+  agentsControllerFindAll,
+  getAgentsControllerFindAllQueryKey,
+} from '@/shared/api/generated/ayunisCoreAPI';
+
+const searchSchema = z.object({
+  search: z.string().optional(),
+  agentId: z.string().optional(),
+});
+
+export const Route = createFileRoute('/_authenticated/chats/')({
+  validateSearch: searchSchema,
+  loaderDeps: ({ search }) => search,
+  loader: async ({ deps: { search, agentId }, context: { queryClient } }) => {
+    const [chats, agents] = await Promise.all([
+      queryClient.fetchQuery({
+        queryKey: getThreadsControllerFindAllQueryKey({ search, agentId }),
+        queryFn: () => threadsControllerFindAll({ search, agentId }),
+      }),
+      queryClient.fetchQuery({
+        queryKey: getAgentsControllerFindAllQueryKey(),
+        queryFn: () => agentsControllerFindAll(),
+      }),
+    ]);
+    return { chats, agents, search, agentId };
+  },
+  component: RouteComponent,
+});
+
+function RouteComponent() {
+  const { chats, agents, search, agentId } = Route.useLoaderData();
+  const hasFilters = Boolean(search || agentId);
+  return (
+    <ChatsPage
+      chats={chats}
+      agents={agents}
+      search={search}
+      agentId={agentId}
+      hasFilters={hasFilters}
+    />
+  );
+}

--- a/ayunis-core-frontend/src/i18n.ts
+++ b/ayunis-core-frontend/src/i18n.ts
@@ -25,8 +25,8 @@ import enSuperAdminSettingsOrg from './shared/locales/en/super-admin-settings-or
 import deSuperAdminSettingsOrg from './shared/locales/de/super-admin-settings-org.json';
 import enSettings from './shared/locales/en/settings.json';
 import deSettings from './shared/locales/de/settings.json';
-import enChats from './shared/locales/en/chats.json';
-import deChats from './shared/locales/de/chats.json';
+import enChat from './shared/locales/en/chat.json';
+import deChat from './shared/locales/de/chat.json';
 import enPrompts from './shared/locales/en/prompts.json';
 import dePrompts from './shared/locales/de/prompts.json';
 import enAgents from './shared/locales/en/agents.json';
@@ -35,6 +35,8 @@ import enAgent from './shared/locales/en/agent.json';
 import deAgent from './shared/locales/de/agent.json';
 import enQuickActions from './shared/locales/en/quickActions.json';
 import deQuickActions from './shared/locales/de/quickActions.json';
+import enChats from './shared/locales/en/chats.json';
+import deChats from './shared/locales/de/chats.json';
 
 const resources = {
   en: {
@@ -49,6 +51,7 @@ const resources = {
     'super-admin-settings-orgs': enSuperAdminSettingsOrgs,
     'super-admin-settings-org': enSuperAdminSettingsOrg,
     settings: enSettings,
+    chat: enChat,
     chats: enChats,
     prompts: enPrompts,
     agents: enAgents,
@@ -67,6 +70,7 @@ const resources = {
     'super-admin-settings-orgs': deSuperAdminSettingsOrgs,
     'super-admin-settings-org': deSuperAdminSettingsOrg,
     settings: deSettings,
+    chat: deChat,
     chats: deChats,
     prompts: dePrompts,
     agents: deAgents,

--- a/ayunis-core-frontend/src/pages/chat/api/useGenerateIcs.ts
+++ b/ayunis-core-frontend/src/pages/chat/api/useGenerateIcs.ts
@@ -74,7 +74,7 @@ function validate(input: CalendarEventInput): void {
 }
 
 export function useGenerateIcs() {
-  const { t } = useTranslation('chats');
+  const { t } = useTranslation('chat');
 
   const generate = useCallback(
     (data: CalendarEventInput): string => {

--- a/ayunis-core-frontend/src/pages/chat/api/useMessageSend.ts
+++ b/ayunis-core-frontend/src/pages/chat/api/useMessageSend.ts
@@ -50,7 +50,7 @@ interface SendMessagePayload {
 }
 
 export function useMessageSend(params: UseMessageSendParams) {
-  const { t } = useTranslation('chats');
+  const { t } = useTranslation('chat');
   const queryClient = useQueryClient();
   const abortControllerRef = useRef<AbortController | null>(null);
   const isLoadingRef = useRef(false);

--- a/ayunis-core-frontend/src/pages/chat/ui/ChatMessage.tsx
+++ b/ayunis-core-frontend/src/pages/chat/ui/ChatMessage.tsx
@@ -61,7 +61,7 @@ export default function ChatMessage({
         <div className="flex items-center gap-2">
           <Loader2 className="h-4 w-4 animate-spin" />
           <span className="text-sm text-muted-foreground">
-            {t('chat.aiThinking')}
+            {t('chat.thinking')}
           </span>
         </div>
       </div>

--- a/ayunis-core-frontend/src/pages/chat/ui/ChatMessage.tsx
+++ b/ayunis-core-frontend/src/pages/chat/ui/ChatMessage.tsx
@@ -47,7 +47,7 @@ export default function ChatMessage({
   isLoading = false,
   isStreaming = false,
 }: ChatMessageProps) {
-  const { t } = useTranslation('chats');
+  const { t } = useTranslation('chat');
   const { theme } = useTheme();
   // Show loading indicator when isLoading is true and no message
   if (isLoading && !message) {

--- a/ayunis-core-frontend/src/pages/chat/ui/ChatPage.tsx
+++ b/ayunis-core-frontend/src/pages/chat/ui/ChatPage.tsx
@@ -57,7 +57,7 @@ export default function ChatPage({
   thread: initialThread,
   isEmbeddingModelEnabled,
 }: ChatPageProps) {
-  const { t } = useTranslation('chats');
+  const { t } = useTranslation('chat');
   const { confirm } = useConfirmation();
   const navigate = useNavigate();
   const { agents } = useAgents();

--- a/ayunis-core-frontend/src/pages/chat/ui/chat-widgets/CreateCalendarEventWidget.tsx
+++ b/ayunis-core-frontend/src/pages/chat/ui/chat-widgets/CreateCalendarEventWidget.tsx
@@ -33,7 +33,7 @@ export default function CreateCalendarEventWidget({
   content: ToolUseMessageContent;
   isStreaming?: boolean;
 }) {
-  const { t } = useTranslation('chats');
+  const { t } = useTranslation('chat');
   const { generate } = useGenerateIcs();
 
   const params = (content.params || {}) as Partial<CalendarEventInput>;

--- a/ayunis-core-frontend/src/pages/chat/ui/chat-widgets/ExecutableToolWidget.tsx
+++ b/ayunis-core-frontend/src/pages/chat/ui/chat-widgets/ExecutableToolWidget.tsx
@@ -35,7 +35,7 @@ export default function ExecutableToolWidget({
   content: ToolUseMessageContent;
   isStreaming?: boolean;
 }) {
-  const { t } = useTranslation('chats');
+  const { t } = useTranslation('chat');
   const [open, setOpen] = useState(false);
 
   // Check if params are empty or incomplete (streaming in progress)

--- a/ayunis-core-frontend/src/pages/chat/ui/chat-widgets/SendEmailWidget.tsx
+++ b/ayunis-core-frontend/src/pages/chat/ui/chat-widgets/SendEmailWidget.tsx
@@ -15,7 +15,7 @@ export default function SendEmailWidget({
   content: ToolUseMessageContent;
   isStreaming?: boolean;
 }) {
-  const { t } = useTranslation('chats');
+  const { t } = useTranslation('chat');
   const params = (content.params || {}) as {
     subject?: string;
     body?: string;

--- a/ayunis-core-frontend/src/pages/chat/ui/chat-widgets/ThinkingBlockWidget.tsx
+++ b/ayunis-core-frontend/src/pages/chat/ui/chat-widgets/ThinkingBlockWidget.tsx
@@ -13,7 +13,7 @@ export default function ThinkingBlockWidget({
   content,
   open: initialOpen,
 }: ThinkingBlockWidgetProps) {
-  const { t } = useTranslation('chats');
+  const { t } = useTranslation('chat');
   const [open, setOpen] = useState(initialOpen);
 
   useEffect(() => {

--- a/ayunis-core-frontend/src/pages/chats/api/useChatsSearch.ts
+++ b/ayunis-core-frontend/src/pages/chats/api/useChatsSearch.ts
@@ -1,0 +1,41 @@
+import { useQueryClient } from '@tanstack/react-query';
+import { useRouter } from '@tanstack/react-router';
+import { toast } from 'sonner';
+import {
+  useThreadsControllerDelete,
+  getThreadsControllerFindAllQueryKey,
+} from '@/shared/api/generated/ayunisCoreAPI';
+import { useTranslation } from 'react-i18next';
+
+export function useDeleteChat(onSuccess?: () => void) {
+  const { t } = useTranslation('chats');
+  const queryClient = useQueryClient();
+  const router = useRouter();
+
+  const mutation = useThreadsControllerDelete({
+    mutation: {
+      onSuccess: () => {
+        toast.success(t('delete.success'));
+        onSuccess?.();
+      },
+      onError: () => {
+        toast.error(t('delete.error'));
+      },
+      onSettled: () => {
+        void queryClient.invalidateQueries({
+          queryKey: getThreadsControllerFindAllQueryKey(),
+        });
+        void router.invalidate();
+      },
+    },
+  });
+
+  function deleteChat(chatId: string) {
+    mutation.mutate({ id: chatId });
+  }
+
+  return {
+    deleteChat,
+    isDeleting: mutation.isPending,
+  };
+}

--- a/ayunis-core-frontend/src/pages/chats/index.ts
+++ b/ayunis-core-frontend/src/pages/chats/index.ts
@@ -1,0 +1,1 @@
+export { default as ChatsPage } from './ui/ChatsPage';

--- a/ayunis-core-frontend/src/pages/chats/model/types.ts
+++ b/ayunis-core-frontend/src/pages/chats/model/types.ts
@@ -1,0 +1,2 @@
+export type { GetThreadsResponseDtoItem as ChatListItem } from '@/shared/api/generated/ayunisCoreAPI.schemas';
+export type { AgentResponseDto as Agent } from '@/shared/api/generated/ayunisCoreAPI.schemas';

--- a/ayunis-core-frontend/src/pages/chats/ui/ChatCard.tsx
+++ b/ayunis-core-frontend/src/pages/chats/ui/ChatCard.tsx
@@ -1,0 +1,82 @@
+import { Button } from '@/shared/ui/shadcn/button';
+import { Badge } from '@/shared/ui/shadcn/badge';
+import { Trash2 } from 'lucide-react';
+import { useConfirmation } from '@/widgets/confirmation-modal';
+import { useTranslation } from 'react-i18next';
+import type { ChatListItem } from '../model/types';
+import { useRouter } from '@tanstack/react-router';
+import {
+  Item,
+  ItemActions,
+  ItemContent,
+  ItemDescription,
+  ItemTitle,
+} from '@/shared/ui/shadcn/item';
+import { useDeleteChat } from '../api/useChatsSearch';
+
+interface ChatCardProps {
+  chat: ChatListItem;
+}
+
+export default function ChatCard({ chat }: ChatCardProps) {
+  const { t } = useTranslation('chats');
+  const { deleteChat, isDeleting } = useDeleteChat();
+  const { confirm } = useConfirmation();
+  const router = useRouter();
+
+  const title = chat.title || t('card.untitled');
+  const createdDate = new Date(chat.createdAt).toLocaleDateString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  });
+
+  function handleDelete(e: React.MouseEvent) {
+    e.stopPropagation();
+    confirm({
+      title: t('card.confirmDelete.title'),
+      description: t('card.confirmDelete.description', { title }),
+      confirmText: t('card.confirmDelete.confirmText'),
+      cancelText: t('card.confirmDelete.cancelText'),
+      variant: 'destructive',
+      onConfirm: () => {
+        deleteChat(chat.id);
+      },
+    });
+  }
+
+  return (
+    <Item
+      variant="outline"
+      className="cursor-pointer"
+      onClick={() =>
+        void router.navigate({
+          to: '/chats/$threadId',
+          params: { threadId: chat.id },
+        })
+      }
+    >
+      <ItemContent>
+        <ItemTitle>
+          <span>{title}</span>
+          {chat.isAnonymous && (
+            <Badge variant="outline" className="ml-2 text-xs">
+              {t('card.anonymous')}
+            </Badge>
+          )}
+        </ItemTitle>
+        <ItemDescription>{createdDate}</ItemDescription>
+      </ItemContent>
+      <ItemActions>
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={handleDelete}
+          disabled={isDeleting}
+        >
+          <Trash2 className="h-4 w-4" />
+        </Button>
+      </ItemActions>
+    </Item>
+  );
+}

--- a/ayunis-core-frontend/src/pages/chats/ui/ChatsEmptyState.tsx
+++ b/ayunis-core-frontend/src/pages/chats/ui/ChatsEmptyState.tsx
@@ -1,0 +1,37 @@
+import { useTranslation } from 'react-i18next';
+import { EmptyState } from '@/widgets/empty-state';
+import { Button } from '@/shared/ui/shadcn/button';
+import { Link } from '@tanstack/react-router';
+import { MessageCircle } from 'lucide-react';
+
+interface ChatsEmptyStateProps {
+  hasFilters: boolean;
+}
+
+export default function ChatsEmptyState({ hasFilters }: ChatsEmptyStateProps) {
+  const { t } = useTranslation('chats');
+
+  if (hasFilters) {
+    return (
+      <EmptyState
+        title={t('emptyState.noResultsTitle')}
+        description={t('emptyState.noResultsDescription')}
+      />
+    );
+  }
+
+  return (
+    <EmptyState
+      title={t('emptyState.title')}
+      description={t('emptyState.description')}
+      action={
+        <Button asChild>
+          <Link to="/chat">
+            <MessageCircle className="mr-2 h-4 w-4" />
+            {t('emptyState.startChat')}
+          </Link>
+        </Button>
+      }
+    />
+  );
+}

--- a/ayunis-core-frontend/src/pages/chats/ui/ChatsFilters.tsx
+++ b/ayunis-core-frontend/src/pages/chats/ui/ChatsFilters.tsx
@@ -1,0 +1,92 @@
+import { Input } from '@/shared/ui/shadcn/input';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/shared/ui/shadcn/select';
+import { useNavigate } from '@tanstack/react-router';
+import { Search } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { useState, useEffect } from 'react';
+import type { Agent } from '../model/types';
+
+interface ChatsFiltersProps {
+  agents: Agent[];
+  search?: string;
+  agentId?: string;
+}
+
+export default function ChatsFilters({
+  agents,
+  search,
+  agentId,
+}: ChatsFiltersProps) {
+  const { t } = useTranslation('chats');
+  const navigate = useNavigate();
+  const [searchValue, setSearchValue] = useState(search ?? '');
+
+  // Sync search value with URL params
+  useEffect(() => {
+    const updateValue = () => {
+      setSearchValue(search ?? '');
+    };
+    updateValue();
+  }, [search]);
+
+  // Debounced search update
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      if (searchValue !== (search ?? '')) {
+        void navigate({
+          to: '/chats',
+          search: (prev: { search?: string; agentId?: string }) => ({
+            ...prev,
+            search: searchValue || undefined,
+          }),
+        });
+      }
+    }, 300);
+
+    return () => clearTimeout(timer);
+  }, [searchValue, search, navigate]);
+
+  const handleAgentChange = (value: string) => {
+    void navigate({
+      to: '/chats',
+      search: (prev: { search?: string; agentId?: string }) => ({
+        ...prev,
+        agentId: value === 'all' ? undefined : value,
+      }),
+    });
+  };
+
+  return (
+    <div className="flex gap-4 mb-6">
+      <div className="relative flex-1 max-w-md">
+        <Search className="absolute left-3 top-1/2 -translate-y-1/2 size-4 text-muted-foreground" />
+        <Input
+          type="text"
+          placeholder={t('filters.searchPlaceholder')}
+          value={searchValue}
+          onChange={(e) => setSearchValue(e.target.value)}
+          className="pl-10"
+        />
+      </div>
+      <Select value={agentId ?? 'all'} onValueChange={handleAgentChange}>
+        <SelectTrigger className="w-[200px]">
+          <SelectValue placeholder={t('filters.agentFilterLabel')} />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="all">{t('filters.agentFilterAll')}</SelectItem>
+          {agents.map((agent) => (
+            <SelectItem key={agent.id} value={agent.id}>
+              {agent.name}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  );
+}

--- a/ayunis-core-frontend/src/pages/chats/ui/ChatsPage.tsx
+++ b/ayunis-core-frontend/src/pages/chats/ui/ChatsPage.tsx
@@ -1,0 +1,66 @@
+import AppLayout from '@/layouts/app-layout';
+import ContentAreaLayout from '@/layouts/content-area-layout/ui/ContentAreaLayout';
+import ContentAreaHeader from '@/widgets/content-area-header/ui/ContentAreaHeader';
+import ChatsFilters from './ChatsFilters';
+import ChatCard from './ChatCard';
+import ChatsEmptyState from './ChatsEmptyState';
+import FullScreenMessageLayout from '@/layouts/full-screen-message-layout/ui/FullScreenMessageLayout';
+import { useTranslation } from 'react-i18next';
+import type { ChatListItem, Agent } from '../model/types';
+
+interface ChatsPageProps {
+  chats: ChatListItem[];
+  agents: Agent[];
+  search?: string;
+  agentId?: string;
+  hasFilters: boolean;
+}
+
+export default function ChatsPage({
+  chats,
+  agents,
+  search,
+  agentId,
+  hasFilters,
+}: ChatsPageProps) {
+  const { t } = useTranslation('chats');
+
+  // Sort chats by creation date (newest first)
+  const sortedChats = [...chats].sort(
+    (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+  );
+
+  if (chats.length === 0 && !hasFilters) {
+    return (
+      <AppLayout>
+        <FullScreenMessageLayout
+          header={<ContentAreaHeader title={t('page.title')} />}
+        >
+          <ChatsEmptyState hasFilters={false} />
+        </FullScreenMessageLayout>
+      </AppLayout>
+    );
+  }
+
+  return (
+    <AppLayout>
+      <ContentAreaLayout
+        contentHeader={<ContentAreaHeader title={t('page.title')} />}
+        contentArea={
+          <>
+            <ChatsFilters agents={agents} search={search} agentId={agentId} />
+            {chats.length === 0 ? (
+              <ChatsEmptyState hasFilters={hasFilters} />
+            ) : (
+              <div className="space-y-3">
+                {sortedChats.map((chat) => (
+                  <ChatCard key={chat.id} chat={chat} />
+                ))}
+              </div>
+            )}
+          </>
+        }
+      />
+    </AppLayout>
+  );
+}

--- a/ayunis-core-frontend/src/pages/new-chat/ui/NewChatPage.tsx
+++ b/ayunis-core-frontend/src/pages/new-chat/ui/NewChatPage.tsx
@@ -28,7 +28,7 @@ export default function NewChatPage({
   isEmbeddingModelEnabled,
   agents,
 }: NewChatPageProps) {
-  const { t } = useTranslation('chats');
+  const { t } = useTranslation('chat');
   const { initiateChat } = useInitiateChat();
   const { models } = usePermittedModels();
   const chatInputRef = useRef<ChatInputRef>(null);

--- a/ayunis-core-frontend/src/pages/new-chat/ui/NewChatPageNoModelError.tsx
+++ b/ayunis-core-frontend/src/pages/new-chat/ui/NewChatPageNoModelError.tsx
@@ -12,7 +12,7 @@ import { useTranslation } from 'react-i18next';
 import ContentAreaHeader from '@/widgets/content-area-header/ui/ContentAreaHeader';
 
 export default function NewChatPageNoModelError() {
-  const { t } = useTranslation('chats');
+  const { t } = useTranslation('chat');
 
   return (
     <NewChatPageLayout header={<ContentAreaHeader title="New Chat" />}>

--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
@@ -1401,6 +1401,8 @@ export type FileSourceResponseDtoFileType = typeof FileSourceResponseDtoFileType
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const FileSourceResponseDtoFileType = {
   pdf: 'pdf',
+  docx: 'docx',
+  pptx: 'pptx',
 } as const;
 
 export interface FileSourceResponseDto {
@@ -2406,6 +2408,17 @@ export type UserControllerValidateResetToken200 = {
 export type StorageControllerUploadFileBody = {
   /** The file to upload */
   file: Blob;
+};
+
+export type ThreadsControllerFindAllParams = {
+/**
+ * Search threads by title
+ */
+search?: string;
+/**
+ * Filter threads by agent ID
+ */
+agentId?: string;
 };
 
 export type ThreadsControllerGetThreadSources200Item = FileSourceResponseDto | UrlSourceResponseDto | CSVDataSourceResponseDto;

--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.ts
@@ -98,6 +98,7 @@ import type {
   SuperAdminTrialResponseDto,
   SuperAdminTrialResponseDtoNullable,
   ThreadsControllerAddFileSourceBody,
+  ThreadsControllerFindAllParams,
   ThreadsControllerGetThreadSources200Item,
   UpdateAgentDto,
   UpdateBillingInfoDto,
@@ -5891,33 +5892,34 @@ export const useThreadsControllerCreate = <TError = void,
  * @summary Get all threads for the current user
  */
 export const threadsControllerFindAll = (
-    
+    params?: ThreadsControllerFindAllParams,
  signal?: AbortSignal
 ) => {
       
       
       return customAxiosInstance<GetThreadsResponseDtoItem[]>(
-      {url: `/threads`, method: 'GET', signal
+      {url: `/threads`, method: 'GET',
+        params, signal
     },
       );
     }
   
 
-export const getThreadsControllerFindAllQueryKey = () => {
-    return [`/threads`] as const;
+export const getThreadsControllerFindAllQueryKey = (params?: ThreadsControllerFindAllParams,) => {
+    return [`/threads`, ...(params ? [params]: [])] as const;
     }
 
     
-export const getThreadsControllerFindAllQueryOptions = <TData = Awaited<ReturnType<typeof threadsControllerFindAll>>, TError = void>( options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof threadsControllerFindAll>>, TError, TData>>, }
+export const getThreadsControllerFindAllQueryOptions = <TData = Awaited<ReturnType<typeof threadsControllerFindAll>>, TError = void>(params?: ThreadsControllerFindAllParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof threadsControllerFindAll>>, TError, TData>>, }
 ) => {
 
 const {query: queryOptions} = options ?? {};
 
-  const queryKey =  queryOptions?.queryKey ?? getThreadsControllerFindAllQueryKey();
+  const queryKey =  queryOptions?.queryKey ?? getThreadsControllerFindAllQueryKey(params);
 
   
 
-    const queryFn: QueryFunction<Awaited<ReturnType<typeof threadsControllerFindAll>>> = ({ signal }) => threadsControllerFindAll(signal);
+    const queryFn: QueryFunction<Awaited<ReturnType<typeof threadsControllerFindAll>>> = ({ signal }) => threadsControllerFindAll(params, signal);
 
       
 
@@ -5931,7 +5933,7 @@ export type ThreadsControllerFindAllQueryError = void
 
 
 export function useThreadsControllerFindAll<TData = Awaited<ReturnType<typeof threadsControllerFindAll>>, TError = void>(
-  options: { query:Partial<UseQueryOptions<Awaited<ReturnType<typeof threadsControllerFindAll>>, TError, TData>> & Pick<
+ params: undefined |  ThreadsControllerFindAllParams, options: { query:Partial<UseQueryOptions<Awaited<ReturnType<typeof threadsControllerFindAll>>, TError, TData>> & Pick<
         DefinedInitialDataOptions<
           Awaited<ReturnType<typeof threadsControllerFindAll>>,
           TError,
@@ -5941,7 +5943,7 @@ export function useThreadsControllerFindAll<TData = Awaited<ReturnType<typeof th
  , queryClient?: QueryClient
   ):  DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
 export function useThreadsControllerFindAll<TData = Awaited<ReturnType<typeof threadsControllerFindAll>>, TError = void>(
-  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof threadsControllerFindAll>>, TError, TData>> & Pick<
+ params?: ThreadsControllerFindAllParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof threadsControllerFindAll>>, TError, TData>> & Pick<
         UndefinedInitialDataOptions<
           Awaited<ReturnType<typeof threadsControllerFindAll>>,
           TError,
@@ -5951,7 +5953,7 @@ export function useThreadsControllerFindAll<TData = Awaited<ReturnType<typeof th
  , queryClient?: QueryClient
   ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
 export function useThreadsControllerFindAll<TData = Awaited<ReturnType<typeof threadsControllerFindAll>>, TError = void>(
-  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof threadsControllerFindAll>>, TError, TData>>, }
+ params?: ThreadsControllerFindAllParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof threadsControllerFindAll>>, TError, TData>>, }
  , queryClient?: QueryClient
   ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
 /**
@@ -5959,11 +5961,11 @@ export function useThreadsControllerFindAll<TData = Awaited<ReturnType<typeof th
  */
 
 export function useThreadsControllerFindAll<TData = Awaited<ReturnType<typeof threadsControllerFindAll>>, TError = void>(
-  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof threadsControllerFindAll>>, TError, TData>>, }
+ params?: ThreadsControllerFindAllParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof threadsControllerFindAll>>, TError, TData>>, }
  , queryClient?: QueryClient 
  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
 
-  const queryOptions = getThreadsControllerFindAllQueryOptions(options)
+  const queryOptions = getThreadsControllerFindAllQueryOptions(params,options)
 
   const query = useQuery(queryOptions , queryClient) as  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
 

--- a/ayunis-core-frontend/src/shared/api/openapi-schema.json
+++ b/ayunis-core-frontend/src/shared/api/openapi-schema.json
@@ -18,9 +18,7 @@
           }
         },
         "summary": "Check if the deployment is running in a cloud environment",
-        "tags": [
-          "app"
-        ]
+        "tags": ["app"]
       }
     },
     "/health": {
@@ -33,9 +31,7 @@
           }
         },
         "summary": "Check if the deployment is healthy",
-        "tags": [
-          "app"
-        ]
+        "tags": ["app"]
       }
     },
     "/models/available": {
@@ -61,9 +57,7 @@
           }
         },
         "summary": "Get all available models",
-        "tags": [
-          "models"
-        ]
+        "tags": ["models"]
       }
     },
     "/models/permitted": {
@@ -92,9 +86,7 @@
           }
         },
         "summary": "Create a permitted model",
-        "tags": [
-          "models"
-        ]
+        "tags": ["models"]
       }
     },
     "/models/permitted/{id}": {
@@ -119,9 +111,7 @@
           }
         },
         "summary": "Delete a permitted model",
-        "tags": [
-          "models"
-        ]
+        "tags": ["models"]
       },
       "patch": {
         "operationId": "ModelsController_updatePermittedModel",
@@ -164,9 +154,7 @@
           }
         },
         "summary": "Update a permitted model",
-        "tags": [
-          "models"
-        ]
+        "tags": ["models"]
       }
     },
     "/models/permitted/language-models": {
@@ -192,9 +180,7 @@
           }
         },
         "summary": "Get all permitted language models",
-        "tags": [
-          "models"
-        ]
+        "tags": ["models"]
       }
     },
     "/models/default": {
@@ -218,9 +204,7 @@
           }
         },
         "summary": "Get the effective default model for the user",
-        "tags": [
-          "models"
-        ]
+        "tags": ["models"]
       }
     },
     "/models/org/default": {
@@ -244,9 +228,7 @@
           }
         },
         "summary": "Get the organization default model",
-        "tags": [
-          "models"
-        ]
+        "tags": ["models"]
       },
       "put": {
         "description": "Sets the specified permitted model as the organization default. If a default already exists, it will be updated to the new model.",
@@ -281,9 +263,7 @@
           }
         },
         "summary": "Set or update the organization default model",
-        "tags": [
-          "models"
-        ]
+        "tags": ["models"]
       }
     },
     "/models/user/default": {
@@ -307,9 +287,7 @@
           }
         },
         "summary": "Get the user-specific default model",
-        "tags": [
-          "models"
-        ]
+        "tags": ["models"]
       },
       "put": {
         "description": "Sets the specified permitted model as the user default. If a default already exists, it will be updated to the new model.",
@@ -344,9 +322,7 @@
           }
         },
         "summary": "Set or update the user default model",
-        "tags": [
-          "models"
-        ]
+        "tags": ["models"]
       },
       "delete": {
         "operationId": "ModelsController_deleteUserDefaultModel",
@@ -360,9 +336,7 @@
           }
         },
         "summary": "Delete the user default model",
-        "tags": [
-          "models"
-        ]
+        "tags": ["models"]
       }
     },
     "/models/provider/{provider}": {
@@ -398,9 +372,7 @@
           }
         },
         "summary": "Get model provider information",
-        "tags": [
-          "models"
-        ]
+        "tags": ["models"]
       }
     },
     "/models/providers/permitted": {
@@ -439,9 +411,7 @@
           }
         },
         "summary": "Create a permitted provider (Admin only)",
-        "tags": [
-          "models"
-        ]
+        "tags": ["models"]
       },
       "get": {
         "operationId": "ModelsController_getAllPermittedProviders",
@@ -465,9 +435,7 @@
           }
         },
         "summary": "Get all permitted providers",
-        "tags": [
-          "models"
-        ]
+        "tags": ["models"]
       },
       "delete": {
         "operationId": "ModelsController_deletePermittedProvider",
@@ -500,9 +468,7 @@
           }
         },
         "summary": "Delete a permitted provider (Admin only)",
-        "tags": [
-          "models"
-        ]
+        "tags": ["models"]
       }
     },
     "/models/providers/all-with-permitted-status": {
@@ -532,9 +498,7 @@
           }
         },
         "summary": "Get all model provider infos with permitted status (Admin only)",
-        "tags": [
-          "models"
-        ]
+        "tags": ["models"]
       }
     },
     "/models/embedding/enabled": {
@@ -557,9 +521,7 @@
           }
         },
         "summary": "Check if an embedding model is enabled for this org",
-        "tags": [
-          "models"
-        ]
+        "tags": ["models"]
       }
     },
     "/super-admin/models/{orgId}/available": {
@@ -601,9 +563,7 @@
           }
         },
         "summary": "Get all available models",
-        "tags": [
-          "Super Admin Models"
-        ]
+        "tags": ["Super Admin Models"]
       }
     },
     "/super-admin/models/{orgId}/default-model": {
@@ -658,9 +618,7 @@
           }
         },
         "summary": "Set or update the organization default model",
-        "tags": [
-          "Super Admin Models"
-        ]
+        "tags": ["Super Admin Models"]
       }
     },
     "/super-admin/models/catalog/{id}": {
@@ -695,9 +653,7 @@
           }
         },
         "summary": "Delete a model from the catalog",
-        "tags": [
-          "Super Admin Models"
-        ]
+        "tags": ["Super Admin Models"]
       },
       "get": {
         "description": "Retrieve a specific model from the master catalog by its ID. This endpoint is only accessible to super admins.",
@@ -744,9 +700,7 @@
           }
         },
         "summary": "Get a model by ID from the catalog",
-        "tags": [
-          "Super Admin Models"
-        ]
+        "tags": ["Super Admin Models"]
       }
     },
     "/super-admin/models/{orgId}/permitted-models": {
@@ -795,9 +749,7 @@
           }
         },
         "summary": "Get all permitted models for a specific organization",
-        "tags": [
-          "Super Admin Models"
-        ]
+        "tags": ["Super Admin Models"]
       },
       "post": {
         "description": "Create a new permitted model for the specified organization. This endpoint is only accessible to super admins.",
@@ -843,9 +795,7 @@
           }
         },
         "summary": "Create a permitted model for a specific organization",
-        "tags": [
-          "Super Admin Models"
-        ]
+        "tags": ["Super Admin Models"]
       }
     },
     "/super-admin/models/{orgId}/permitted-models/{id}": {
@@ -894,9 +844,7 @@
           }
         },
         "summary": "Delete a permitted model for a specific organization",
-        "tags": [
-          "Super Admin Models"
-        ]
+        "tags": ["Super Admin Models"]
       },
       "patch": {
         "description": "Update the settings of a permitted model for the specified organization. This endpoint is only accessible to super admins.",
@@ -967,9 +915,7 @@
           }
         },
         "summary": "Update a permitted model for a specific organization",
-        "tags": [
-          "Super Admin Models"
-        ]
+        "tags": ["Super Admin Models"]
       }
     },
     "/super-admin/models/{orgId}/permitted-providers": {
@@ -1011,9 +957,7 @@
           }
         },
         "summary": "Get all permitted providers for a specific organization",
-        "tags": [
-          "Super Admin Models"
-        ]
+        "tags": ["Super Admin Models"]
       },
       "post": {
         "description": "Create a new permitted provider for the specified organization. This endpoint is only accessible to super admins.",
@@ -1056,9 +1000,7 @@
           }
         },
         "summary": "Create a permitted provider for a specific organization",
-        "tags": [
-          "Super Admin Models"
-        ]
+        "tags": ["Super Admin Models"]
       },
       "delete": {
         "description": "Delete a permitted provider for the specified organization. This endpoint is only accessible to super admin.",
@@ -1104,9 +1046,7 @@
           }
         },
         "summary": "Delete a permitted provider for a specific organization",
-        "tags": [
-          "Super Admin Models"
-        ]
+        "tags": ["Super Admin Models"]
       }
     },
     "/super-admin/models/{orgId}/providers/all-with-permitted-status": {
@@ -1148,9 +1088,7 @@
           }
         },
         "summary": "Get all model provider infos with permitted status for a specific organization",
-        "tags": [
-          "Super Admin Models"
-        ]
+        "tags": ["Super Admin Models"]
       }
     },
     "/super-admin/models/catalog": {
@@ -1187,9 +1125,7 @@
           }
         },
         "summary": "Get all models in the catalog",
-        "tags": [
-          "Super Admin Models"
-        ]
+        "tags": ["Super Admin Models"]
       }
     },
     "/super-admin/models/catalog/language": {
@@ -1232,9 +1168,7 @@
           }
         },
         "summary": "Create a new language model in the catalog",
-        "tags": [
-          "Super Admin Models"
-        ]
+        "tags": ["Super Admin Models"]
       }
     },
     "/super-admin/models/catalog/language/{id}": {
@@ -1289,9 +1223,7 @@
           }
         },
         "summary": "Update a language model in the catalog",
-        "tags": [
-          "Super Admin Models"
-        ]
+        "tags": ["Super Admin Models"]
       }
     },
     "/super-admin/models/catalog/embedding": {
@@ -1334,9 +1266,7 @@
           }
         },
         "summary": "Create a new embedding model in the catalog",
-        "tags": [
-          "Super Admin Models"
-        ]
+        "tags": ["Super Admin Models"]
       }
     },
     "/super-admin/models/catalog/embedding/{id}": {
@@ -1391,9 +1321,7 @@
           }
         },
         "summary": "Update an embedding model in the catalog",
-        "tags": [
-          "Super Admin Models"
-        ]
+        "tags": ["Super Admin Models"]
       }
     },
     "/super-admin/orgs": {
@@ -1431,9 +1359,7 @@
           }
         },
         "summary": "Create a new organization",
-        "tags": [
-          "Super Admin Orgs"
-        ]
+        "tags": ["Super Admin Orgs"]
       },
       "get": {
         "description": "Retrieve every organization in the system. Only accessible to users with the super admin system role.",
@@ -1476,9 +1402,7 @@
           }
         },
         "summary": "List all organizations",
-        "tags": [
-          "Super Admin Orgs"
-        ]
+        "tags": ["Super Admin Orgs"]
       }
     },
     "/super-admin/orgs/{id}": {
@@ -1512,9 +1436,7 @@
           }
         },
         "summary": "Get an organization by ID",
-        "tags": [
-          "Super Admin Orgs"
-        ]
+        "tags": ["Super Admin Orgs"]
       }
     },
     "/users": {
@@ -1541,9 +1463,7 @@
           }
         },
         "summary": "Get users in current organization",
-        "tags": [
-          "Users"
-        ]
+        "tags": ["Users"]
       }
     },
     "/users/{id}/role": {
@@ -1599,9 +1519,7 @@
           }
         },
         "summary": "Update user role",
-        "tags": [
-          "Users"
-        ]
+        "tags": ["Users"]
       }
     },
     "/users/name": {
@@ -1645,9 +1563,7 @@
           }
         },
         "summary": "Update user name",
-        "tags": [
-          "Users"
-        ]
+        "tags": ["Users"]
       }
     },
     "/users/password": {
@@ -1681,9 +1597,7 @@
           }
         },
         "summary": "Update user password",
-        "tags": [
-          "Users"
-        ]
+        "tags": ["Users"]
       }
     },
     "/users/confirm-email": {
@@ -1717,9 +1631,7 @@
           }
         },
         "summary": "Confirm user email",
-        "tags": [
-          "Users"
-        ]
+        "tags": ["Users"]
       }
     },
     "/users/resend-confirmation": {
@@ -1750,9 +1662,7 @@
           }
         },
         "summary": "Resend email confirmation",
-        "tags": [
-          "Users"
-        ]
+        "tags": ["Users"]
       }
     },
     "/users/{id}": {
@@ -1787,9 +1697,7 @@
           }
         },
         "summary": "Delete a user",
-        "tags": [
-          "Users"
-        ]
+        "tags": ["Users"]
       }
     },
     "/users/{id}/trigger-password-reset": {
@@ -1820,9 +1728,7 @@
           }
         },
         "summary": "Trigger password reset for a user",
-        "tags": [
-          "Users"
-        ]
+        "tags": ["Users"]
       }
     },
     "/users/forgot-password": {
@@ -1853,9 +1759,7 @@
           }
         },
         "summary": "Trigger password reset",
-        "tags": [
-          "Users"
-        ]
+        "tags": ["Users"]
       }
     },
     "/users/reset-password": {
@@ -1889,9 +1793,7 @@
           }
         },
         "summary": "Reset password with token",
-        "tags": [
-          "Users"
-        ]
+        "tags": ["Users"]
       }
     },
     "/users/validate-reset-token": {
@@ -1935,9 +1837,7 @@
           }
         },
         "summary": "Validate password reset token",
-        "tags": [
-          "Users"
-        ]
+        "tags": ["Users"]
       }
     },
     "/super-admin/users/{orgId}": {
@@ -1979,9 +1879,7 @@
           }
         },
         "summary": "Get users by organization ID",
-        "tags": [
-          "Super Admin Users"
-        ]
+        "tags": ["Super Admin Users"]
       }
     },
     "/super-admin/users/{userId}": {
@@ -2016,9 +1914,7 @@
           }
         },
         "summary": "Delete a user",
-        "tags": [
-          "Super Admin Users"
-        ]
+        "tags": ["Super Admin Users"]
       }
     },
     "/super-admin/users/{userId}/trigger-password-reset": {
@@ -2053,9 +1949,7 @@
           }
         },
         "summary": "Trigger password reset for a user",
-        "tags": [
-          "Super Admin Users"
-        ]
+        "tags": ["Super Admin Users"]
       }
     },
     "/super-admin/users/{orgId}/create": {
@@ -2111,9 +2005,7 @@
           }
         },
         "summary": "Create a new user in an organization",
-        "tags": [
-          "Super Admin Users"
-        ]
+        "tags": ["Super Admin Users"]
       }
     },
     "/invites": {
@@ -2150,9 +2042,7 @@
           }
         },
         "summary": "Create a new invite",
-        "tags": [
-          "invites"
-        ]
+        "tags": ["invites"]
       },
       "get": {
         "description": "Retrieve all invites for the organization with calculated status and sent date",
@@ -2177,9 +2067,7 @@
           }
         },
         "summary": "Get all invites for current user's organization",
-        "tags": [
-          "invites"
-        ]
+        "tags": ["invites"]
       }
     },
     "/invites/{token}": {
@@ -2217,9 +2105,7 @@
           }
         },
         "summary": "Get a single invite by token",
-        "tags": [
-          "invites"
-        ]
+        "tags": ["invites"]
       }
     },
     "/invites/accept": {
@@ -2259,9 +2145,7 @@
           }
         },
         "summary": "Accept an invite",
-        "tags": [
-          "invites"
-        ]
+        "tags": ["invites"]
       }
     },
     "/invites/{id}": {
@@ -2295,9 +2179,7 @@
           }
         },
         "summary": "Delete an invite",
-        "tags": [
-          "invites"
-        ]
+        "tags": ["invites"]
       }
     },
     "/subscriptions": {
@@ -2326,9 +2208,7 @@
           }
         },
         "summary": "Get subscription details for the current organization",
-        "tags": [
-          "subscriptions"
-        ]
+        "tags": ["subscriptions"]
       },
       "post": {
         "operationId": "SubscriptionsController_createSubscription",
@@ -2368,9 +2248,7 @@
           }
         },
         "summary": "Create a new subscription for the current organization",
-        "tags": [
-          "subscriptions"
-        ]
+        "tags": ["subscriptions"]
       },
       "delete": {
         "operationId": "SubscriptionsController_cancelSubscription",
@@ -2393,9 +2271,7 @@
           }
         },
         "summary": "Cancel the subscription for the current organization",
-        "tags": [
-          "subscriptions"
-        ]
+        "tags": ["subscriptions"]
       }
     },
     "/subscriptions/active": {
@@ -2418,9 +2294,7 @@
           }
         },
         "summary": "Check if the current organization has an active subscription",
-        "tags": [
-          "subscriptions"
-        ]
+        "tags": ["subscriptions"]
       }
     },
     "/subscriptions/price": {
@@ -2446,9 +2320,7 @@
           }
         },
         "summary": "Get the current price per seat monthly",
-        "tags": [
-          "subscriptions"
-        ]
+        "tags": ["subscriptions"]
       }
     },
     "/subscriptions/seats": {
@@ -2480,9 +2352,7 @@
           }
         },
         "summary": "Update the number of seats for the current organization",
-        "tags": [
-          "subscriptions"
-        ]
+        "tags": ["subscriptions"]
       }
     },
     "/subscriptions/billing-info": {
@@ -2517,9 +2387,7 @@
           }
         },
         "summary": "Update the billing information for the current organization",
-        "tags": [
-          "subscriptions"
-        ]
+        "tags": ["subscriptions"]
       }
     },
     "/subscriptions/uncancel": {
@@ -2544,9 +2412,7 @@
           }
         },
         "summary": "Uncancel the subscription for the current organization",
-        "tags": [
-          "subscriptions"
-        ]
+        "tags": ["subscriptions"]
       }
     },
     "/super-admin/subscriptions/{orgId}": {
@@ -2585,9 +2451,7 @@
           }
         },
         "summary": "Get subscription details for a specific organization",
-        "tags": [
-          "Super Admin Subscriptions"
-        ]
+        "tags": ["Super Admin Subscriptions"]
       },
       "post": {
         "description": "Create a new subscription for the specified organization. This endpoint is only accessible to super admins.",
@@ -2640,9 +2504,7 @@
           }
         },
         "summary": "Create a new subscription for a specific organization",
-        "tags": [
-          "Super Admin Subscriptions"
-        ]
+        "tags": ["Super Admin Subscriptions"]
       },
       "delete": {
         "description": "Cancel the subscription for the specified organization. This endpoint is only accessible to super admins.",
@@ -2678,9 +2540,7 @@
           }
         },
         "summary": "Cancel the subscription for a specific organization",
-        "tags": [
-          "Super Admin Subscriptions"
-        ]
+        "tags": ["Super Admin Subscriptions"]
       }
     },
     "/super-admin/subscriptions/{orgId}/seats": {
@@ -2728,9 +2588,7 @@
           }
         },
         "summary": "Update the number of seats for a specific organization",
-        "tags": [
-          "Super Admin Subscriptions"
-        ]
+        "tags": ["Super Admin Subscriptions"]
       }
     },
     "/super-admin/subscriptions/{orgId}/billing-info": {
@@ -2778,9 +2636,7 @@
           }
         },
         "summary": "Update the billing information for a specific organization",
-        "tags": [
-          "Super Admin Subscriptions"
-        ]
+        "tags": ["Super Admin Subscriptions"]
       }
     },
     "/super-admin/subscriptions/{orgId}/uncancel": {
@@ -2818,9 +2674,7 @@
           }
         },
         "summary": "Uncancel the subscription for a specific organization",
-        "tags": [
-          "Super Admin Subscriptions"
-        ]
+        "tags": ["Super Admin Subscriptions"]
       }
     },
     "/storage/upload": {
@@ -2834,9 +2688,7 @@
             "multipart/form-data": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "file"
-                ],
+                "required": ["file"],
                 "properties": {
                   "file": {
                     "type": "string",
@@ -2864,9 +2716,7 @@
           }
         },
         "summary": "Upload a file to object storage",
-        "tags": [
-          "storage"
-        ]
+        "tags": ["storage"]
       }
     },
     "/storage/{objectName}": {
@@ -2888,9 +2738,7 @@
             "description": ""
           }
         },
-        "tags": [
-          "storage"
-        ]
+        "tags": ["storage"]
       },
       "delete": {
         "operationId": "StorageController_deleteFile",
@@ -2910,9 +2758,7 @@
             "description": ""
           }
         },
-        "tags": [
-          "storage"
-        ]
+        "tags": ["storage"]
       }
     },
     "/storage/url/{objectName}": {
@@ -2934,9 +2780,7 @@
             "description": ""
           }
         },
-        "tags": [
-          "storage"
-        ]
+        "tags": ["storage"]
       }
     },
     "/threads": {
@@ -2972,13 +2816,30 @@
           }
         },
         "summary": "Create a new thread",
-        "tags": [
-          "threads"
-        ]
+        "tags": ["threads"]
       },
       "get": {
         "operationId": "ThreadsController_findAll",
-        "parameters": [],
+        "parameters": [
+          {
+            "name": "search",
+            "required": false,
+            "in": "query",
+            "description": "Search threads by title",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "agentId",
+            "required": false,
+            "in": "query",
+            "description": "Filter threads by agent ID",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "Returns all threads for the current user",
@@ -2998,9 +2859,7 @@
           }
         },
         "summary": "Get all threads for the current user",
-        "tags": [
-          "threads"
-        ]
+        "tags": ["threads"]
       }
     },
     "/threads/{id}": {
@@ -3037,9 +2896,7 @@
           }
         },
         "summary": "Get a thread by ID",
-        "tags": [
-          "threads"
-        ]
+        "tags": ["threads"]
       },
       "delete": {
         "operationId": "ThreadsController_delete",
@@ -3067,9 +2924,7 @@
           }
         },
         "summary": "Delete a thread",
-        "tags": [
-          "threads"
-        ]
+        "tags": ["threads"]
       }
     },
     "/threads/{id}/sources": {
@@ -3119,9 +2974,7 @@
           }
         },
         "summary": "Get all sources for a thread",
-        "tags": [
-          "threads"
-        ]
+        "tags": ["threads"]
       }
     },
     "/threads/{id}/sources/file": {
@@ -3160,9 +3013,7 @@
                     "description": "A description of the file source"
                   }
                 },
-                "required": [
-                  "file"
-                ]
+                "required": ["file"]
               }
             }
           }
@@ -3173,9 +3024,7 @@
           }
         },
         "summary": "Add a file source to a thread",
-        "tags": [
-          "threads"
-        ]
+        "tags": ["threads"]
       }
     },
     "/threads/{id}/sources/{sourceId}": {
@@ -3212,9 +3061,7 @@
           }
         },
         "summary": "Remove a source from a thread",
-        "tags": [
-          "threads"
-        ]
+        "tags": ["threads"]
       }
     },
     "/threads/{id}/sources/{sourceId}/download": {
@@ -3262,9 +3109,7 @@
           }
         },
         "summary": "Download a data source as CSV",
-        "tags": [
-          "threads"
-        ]
+        "tags": ["threads"]
       }
     },
     "/agents": {
@@ -3300,9 +3145,7 @@
           }
         },
         "summary": "Create a new agent",
-        "tags": [
-          "agents"
-        ]
+        "tags": ["agents"]
       },
       "get": {
         "operationId": "AgentsController_findAll",
@@ -3326,9 +3169,7 @@
           }
         },
         "summary": "Get all agents for the current user",
-        "tags": [
-          "agents"
-        ]
+        "tags": ["agents"]
       }
     },
     "/agents/{id}": {
@@ -3365,9 +3206,7 @@
           }
         },
         "summary": "Get an agent by ID",
-        "tags": [
-          "agents"
-        ]
+        "tags": ["agents"]
       },
       "put": {
         "operationId": "AgentsController_update",
@@ -3415,9 +3254,7 @@
           }
         },
         "summary": "Update an agent",
-        "tags": [
-          "agents"
-        ]
+        "tags": ["agents"]
       },
       "delete": {
         "operationId": "AgentsController_delete",
@@ -3445,9 +3282,7 @@
           }
         },
         "summary": "Delete an agent",
-        "tags": [
-          "agents"
-        ]
+        "tags": ["agents"]
       }
     },
     "/agents/{id}/sources": {
@@ -3487,9 +3322,7 @@
           }
         },
         "summary": "Get all sources for an agent",
-        "tags": [
-          "agents"
-        ]
+        "tags": ["agents"]
       }
     },
     "/agents/{id}/sources/file": {
@@ -3520,9 +3353,7 @@
                     "description": "The file to upload"
                   }
                 },
-                "required": [
-                  "file"
-                ]
+                "required": ["file"]
               }
             }
           }
@@ -3532,7 +3363,7 @@
             "description": "The file source has been successfully added to the agent"
           },
           "400": {
-            "description": "Invalid file"
+            "description": "Invalid or unsupported file type. Supported types: PDF, DOCX, PPTX, CSV, XLSX, XLS"
           },
           "404": {
             "description": "Agent not found"
@@ -3542,9 +3373,7 @@
           }
         },
         "summary": "Add a file source to an agent",
-        "tags": [
-          "agents"
-        ]
+        "tags": ["agents"]
       }
     },
     "/agents/{id}/sources/{sourceAssignmentId}": {
@@ -3581,9 +3410,7 @@
           }
         },
         "summary": "Remove a source from an agent",
-        "tags": [
-          "agents"
-        ]
+        "tags": ["agents"]
       }
     },
     "/agents/{agentId}/mcp-integrations/{integrationId}": {
@@ -3636,9 +3463,7 @@
           }
         },
         "summary": "Assign MCP integration to agent",
-        "tags": [
-          "agents"
-        ]
+        "tags": ["agents"]
       },
       "delete": {
         "operationId": "AgentsController_unassignMcpIntegration",
@@ -3680,9 +3505,7 @@
           }
         },
         "summary": "Unassign MCP integration from agent",
-        "tags": [
-          "agents"
-        ]
+        "tags": ["agents"]
       }
     },
     "/agents/{agentId}/mcp-integrations": {
@@ -3719,9 +3542,7 @@
           }
         },
         "summary": "List MCP integrations assigned to agent",
-        "tags": [
-          "agents"
-        ]
+        "tags": ["agents"]
       }
     },
     "/shares": {
@@ -3764,9 +3585,7 @@
           }
         },
         "summary": "Create a share for an agent",
-        "tags": [
-          "shares"
-        ]
+        "tags": ["shares"]
       },
       "get": {
         "operationId": "SharesController_getShares",
@@ -3787,10 +3606,7 @@
             "in": "query",
             "description": "Type of the entity",
             "schema": {
-              "enum": [
-                "agent",
-                "prompt"
-              ],
+              "enum": ["agent", "prompt"],
               "type": "string"
             }
           }
@@ -3820,9 +3636,7 @@
           }
         },
         "summary": "Get shares for an entity",
-        "tags": [
-          "shares"
-        ]
+        "tags": ["shares"]
       }
     },
     "/shares/{id}": {
@@ -3855,9 +3669,7 @@
           }
         },
         "summary": "Delete a share",
-        "tags": [
-          "shares"
-        ]
+        "tags": ["shares"]
       }
     },
     "/mcp-integrations/predefined": {
@@ -3893,9 +3705,7 @@
           }
         },
         "summary": "Create a new predefined MCP integration",
-        "tags": [
-          "mcp-integrations"
-        ]
+        "tags": ["mcp-integrations"]
       }
     },
     "/mcp-integrations/custom": {
@@ -3928,9 +3738,7 @@
           }
         },
         "summary": "Create a new custom MCP integration",
-        "tags": [
-          "mcp-integrations"
-        ]
+        "tags": ["mcp-integrations"]
       }
     },
     "/mcp-integrations": {
@@ -3953,9 +3761,7 @@
           }
         },
         "summary": "List all MCP integrations for organization",
-        "tags": [
-          "mcp-integrations"
-        ]
+        "tags": ["mcp-integrations"]
       }
     },
     "/mcp-integrations/predefined/available": {
@@ -3978,9 +3784,7 @@
           }
         },
         "summary": "List available predefined MCP integration configurations",
-        "tags": [
-          "mcp-integrations"
-        ]
+        "tags": ["mcp-integrations"]
       }
     },
     "/mcp-integrations/available": {
@@ -4003,9 +3807,7 @@
           }
         },
         "summary": "List all available (enabled) MCP integrations for organization",
-        "tags": [
-          "mcp-integrations"
-        ]
+        "tags": ["mcp-integrations"]
       }
     },
     "/mcp-integrations/{id}": {
@@ -4038,9 +3840,7 @@
           }
         },
         "summary": "Get MCP integration by ID",
-        "tags": [
-          "mcp-integrations"
-        ]
+        "tags": ["mcp-integrations"]
       },
       "patch": {
         "operationId": "McpIntegrationsController_update",
@@ -4084,9 +3884,7 @@
           }
         },
         "summary": "Update MCP integration",
-        "tags": [
-          "mcp-integrations"
-        ]
+        "tags": ["mcp-integrations"]
       },
       "delete": {
         "operationId": "McpIntegrationsController_delete",
@@ -4110,9 +3908,7 @@
           }
         },
         "summary": "Delete MCP integration",
-        "tags": [
-          "mcp-integrations"
-        ]
+        "tags": ["mcp-integrations"]
       }
     },
     "/mcp-integrations/{id}/enable": {
@@ -4145,9 +3941,7 @@
           }
         },
         "summary": "Enable MCP integration",
-        "tags": [
-          "mcp-integrations"
-        ]
+        "tags": ["mcp-integrations"]
       }
     },
     "/mcp-integrations/{id}/disable": {
@@ -4180,9 +3974,7 @@
           }
         },
         "summary": "Disable MCP integration",
-        "tags": [
-          "mcp-integrations"
-        ]
+        "tags": ["mcp-integrations"]
       }
     },
     "/mcp-integrations/{id}/validate": {
@@ -4215,9 +4007,7 @@
           }
         },
         "summary": "Validate MCP integration connection",
-        "tags": [
-          "mcp-integrations"
-        ]
+        "tags": ["mcp-integrations"]
       }
     },
     "/retrievers/url": {
@@ -4240,9 +4030,7 @@
           }
         },
         "summary": "Retrieve content from a URL",
-        "tags": [
-          "retrievers"
-        ]
+        "tags": ["retrievers"]
       }
     },
     "/runs/send-message": {
@@ -4256,9 +4044,7 @@
             "multipart/form-data": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "threadId"
-                ],
+                "required": ["threadId"],
                 "properties": {
                   "threadId": {
                     "type": "string",
@@ -4412,9 +4198,7 @@
           }
         },
         "summary": "Send a message with optional images and receive streaming response",
-        "tags": [
-          "runs"
-        ]
+        "tags": ["runs"]
       }
     },
     "/super-admin/trials": {
@@ -4452,9 +4236,7 @@
           }
         },
         "summary": "Create a new trial",
-        "tags": [
-          "Super Admin Trials"
-        ]
+        "tags": ["Super Admin Trials"]
       }
     },
     "/super-admin/trials/{orgId}": {
@@ -4491,9 +4273,7 @@
           }
         },
         "summary": "Get a trial by organization ID",
-        "tags": [
-          "Super Admin Trials"
-        ]
+        "tags": ["Super Admin Trials"]
       },
       "put": {
         "description": "Update a trial for an organization. Can update maxMessages and/or messagesSent. Only accessible to users with the super admin system role.",
@@ -4539,9 +4319,7 @@
           }
         },
         "summary": "Update a trial",
-        "tags": [
-          "Super Admin Trials"
-        ]
+        "tags": ["Super Admin Trials"]
       }
     },
     "/prompts": {
@@ -4577,9 +4355,7 @@
           }
         },
         "summary": "Create a new prompt",
-        "tags": [
-          "prompts"
-        ]
+        "tags": ["prompts"]
       },
       "get": {
         "operationId": "PromptsController_findAll",
@@ -4603,9 +4379,7 @@
           }
         },
         "summary": "Get all prompts for the current user",
-        "tags": [
-          "prompts"
-        ]
+        "tags": ["prompts"]
       }
     },
     "/prompts/{id}": {
@@ -4642,9 +4416,7 @@
           }
         },
         "summary": "Get a prompt by ID",
-        "tags": [
-          "prompts"
-        ]
+        "tags": ["prompts"]
       },
       "put": {
         "operationId": "PromptsController_update",
@@ -4692,9 +4464,7 @@
           }
         },
         "summary": "Update a prompt",
-        "tags": [
-          "prompts"
-        ]
+        "tags": ["prompts"]
       },
       "delete": {
         "operationId": "PromptsController_delete",
@@ -4722,9 +4492,7 @@
           }
         },
         "summary": "Delete a prompt",
-        "tags": [
-          "prompts"
-        ]
+        "tags": ["prompts"]
       }
     },
     "/auth/login": {
@@ -4776,9 +4544,7 @@
           }
         },
         "summary": "User login",
-        "tags": [
-          "Authentication"
-        ]
+        "tags": ["Authentication"]
       }
     },
     "/auth/register": {
@@ -4830,9 +4596,7 @@
           }
         },
         "summary": "User registration",
-        "tags": [
-          "Authentication"
-        ]
+        "tags": ["Authentication"]
       }
     },
     "/auth/refresh": {
@@ -4878,9 +4642,7 @@
           }
         ],
         "summary": "Refresh authentication tokens",
-        "tags": [
-          "Authentication"
-        ]
+        "tags": ["Authentication"]
       }
     },
     "/auth/me": {
@@ -4921,9 +4683,7 @@
           }
         },
         "summary": "Get current user information",
-        "tags": [
-          "Authentication"
-        ]
+        "tags": ["Authentication"]
       }
     },
     "/auth/logout": {
@@ -4944,9 +4704,7 @@
           }
         },
         "summary": "User logout",
-        "tags": [
-          "Authentication"
-        ]
+        "tags": ["Authentication"]
       }
     },
     "/admin/models": {
@@ -4958,9 +4716,7 @@
             "description": ""
           }
         },
-        "tags": [
-          "Admin"
-        ]
+        "tags": ["Admin"]
       }
     },
     "/admin/model": {
@@ -4981,9 +4737,7 @@
             "description": ""
           }
         },
-        "tags": [
-          "Admin"
-        ]
+        "tags": ["Admin"]
       }
     },
     "/admin/language-models": {
@@ -5005,9 +4759,7 @@
             "description": ""
           }
         },
-        "tags": [
-          "Admin"
-        ]
+        "tags": ["Admin"]
       }
     },
     "/admin/embedding-models": {
@@ -5029,9 +4781,7 @@
             "description": ""
           }
         },
-        "tags": [
-          "Admin"
-        ]
+        "tags": ["Admin"]
       }
     },
     "/admin/language-models/{id}": {
@@ -5062,9 +4812,7 @@
             "description": ""
           }
         },
-        "tags": [
-          "Admin"
-        ]
+        "tags": ["Admin"]
       }
     },
     "/admin/embedding-models/{id}": {
@@ -5095,9 +4843,7 @@
             "description": ""
           }
         },
-        "tags": [
-          "Admin"
-        ]
+        "tags": ["Admin"]
       }
     },
     "/admin/models/{id}": {
@@ -5118,9 +4864,7 @@
             "description": ""
           }
         },
-        "tags": [
-          "Admin"
-        ]
+        "tags": ["Admin"]
       }
     }
   },
@@ -5153,10 +4897,7 @@
             "example": false
           }
         },
-        "required": [
-          "isCloud",
-          "isRegistrationDisabled"
-        ]
+        "required": ["isCloud", "isRegistrationDisabled"]
       },
       "ModelWithConfigResponseDto": {
         "type": "object",
@@ -5256,9 +4997,7 @@
             "default": false
           }
         },
-        "required": [
-          "modelId"
-        ]
+        "required": ["modelId"]
       },
       "UpdatePermittedModelDto": {
         "type": "object",
@@ -5269,9 +5008,7 @@
             "example": true
           }
         },
-        "required": [
-          "anonymousOnly"
-        ]
+        "required": ["anonymousOnly"]
       },
       "PermittedLanguageModelResponseDto": {
         "type": "object",
@@ -5303,9 +5040,7 @@
           },
           "type": {
             "type": "string",
-            "enum": [
-              "language"
-            ],
+            "enum": ["language"],
             "description": "The type of the model (always language)"
           },
           "isArchived": {
@@ -5355,9 +5090,7 @@
             ]
           }
         },
-        "required": [
-          "permittedLanguageModel"
-        ]
+        "required": ["permittedLanguageModel"]
       },
       "SetUserDefaultModelDto": {
         "type": "object",
@@ -5368,9 +5101,7 @@
             "example": "123e4567-e89b-12d3-a456-426614174000"
           }
         },
-        "required": [
-          "permittedModelId"
-        ]
+        "required": ["permittedModelId"]
       },
       "SetOrgDefaultModelDto": {
         "type": "object",
@@ -5381,9 +5112,7 @@
             "example": "123e4567-e89b-12d3-a456-426614174000"
           }
         },
-        "required": [
-          "permittedModelId"
-        ]
+        "required": ["permittedModelId"]
       },
       "ModelProviderInfoResponseDto": {
         "type": "object",
@@ -5409,22 +5138,12 @@
           },
           "hostedIn": {
             "type": "string",
-            "enum": [
-              "DE",
-              "EU",
-              "US",
-              "SELF_HOSTED",
-              "AYUNIS"
-            ],
+            "enum": ["DE", "EU", "US", "SELF_HOSTED", "AYUNIS"],
             "description": "The location where the provider hosts their services",
             "example": "US"
           }
         },
-        "required": [
-          "provider",
-          "displayName",
-          "hostedIn"
-        ]
+        "required": ["provider", "displayName", "hostedIn"]
       },
       "CreatePermittedProviderDto": {
         "type": "object",
@@ -5444,9 +5163,7 @@
             "example": "openai"
           }
         },
-        "required": [
-          "provider"
-        ]
+        "required": ["provider"]
       },
       "PermittedProviderResponseDto": {
         "type": "object",
@@ -5472,22 +5189,12 @@
           },
           "hostedIn": {
             "type": "string",
-            "enum": [
-              "DE",
-              "EU",
-              "US",
-              "SELF_HOSTED",
-              "AYUNIS"
-            ],
+            "enum": ["DE", "EU", "US", "SELF_HOSTED", "AYUNIS"],
             "description": "The location where the provider hosts their services",
             "example": "US"
           }
         },
-        "required": [
-          "provider",
-          "displayName",
-          "hostedIn"
-        ]
+        "required": ["provider", "displayName", "hostedIn"]
       },
       "DeletePermittedProviderDto": {
         "type": "object",
@@ -5507,9 +5214,7 @@
             "example": "openai"
           }
         },
-        "required": [
-          "provider"
-        ]
+        "required": ["provider"]
       },
       "ModelProviderWithPermittedStatusResponseDto": {
         "type": "object",
@@ -5535,13 +5240,7 @@
           },
           "hostedIn": {
             "type": "string",
-            "enum": [
-              "DE",
-              "EU",
-              "US",
-              "SELF_HOSTED",
-              "AYUNIS"
-            ],
+            "enum": ["DE", "EU", "US", "SELF_HOSTED", "AYUNIS"],
             "description": "The location where the provider hosts their services",
             "example": "DE"
           },
@@ -5551,12 +5250,7 @@
             "example": true
           }
         },
-        "required": [
-          "provider",
-          "displayName",
-          "hostedIn",
-          "isPermitted"
-        ]
+        "required": ["provider", "displayName", "hostedIn", "isPermitted"]
       },
       "EmbeddingModelEnabledResponseDto": {
         "type": "object",
@@ -5567,9 +5261,7 @@
             "example": true
           }
         },
-        "required": [
-          "isEmbeddingModelEnabled"
-        ]
+        "required": ["isEmbeddingModelEnabled"]
       },
       "PermittedEmbeddingModelResponseDto": {
         "type": "object",
@@ -5601,9 +5293,7 @@
           },
           "type": {
             "type": "string",
-            "enum": [
-              "embedding"
-            ],
+            "enum": ["embedding"],
             "description": "The type of the model (always embedding)"
           },
           "isArchived": {
@@ -5784,11 +5474,7 @@
           "dimensions": {
             "type": "number",
             "description": "The dimensions of the embedding",
-            "enum": [
-              1024,
-              1536,
-              2560
-            ],
+            "enum": [1024, 1536, 2560],
             "example": 1536
           },
           "isArchived": {
@@ -5835,11 +5521,7 @@
           "dimensions": {
             "type": "number",
             "description": "The dimensions of the embedding",
-            "enum": [
-              1024,
-              1536,
-              2560
-            ],
+            "enum": [1024, 1536, 2560],
             "example": 1536
           },
           "isArchived": {
@@ -5891,9 +5573,7 @@
           },
           "type": {
             "type": "string",
-            "enum": [
-              "language"
-            ],
+            "enum": ["language"],
             "description": "The type of the model (always language)"
           },
           "isArchived": {
@@ -5982,9 +5662,7 @@
           },
           "type": {
             "type": "string",
-            "enum": [
-              "embedding"
-            ],
+            "enum": ["embedding"],
             "description": "The type of the model (always embedding)"
           },
           "isArchived": {
@@ -6037,9 +5715,7 @@
             "example": "Acme Corporation"
           }
         },
-        "required": [
-          "name"
-        ]
+        "required": ["name"]
       },
       "SuperAdminOrgResponseDto": {
         "type": "object",
@@ -6062,11 +5738,7 @@
             "example": "2024-01-15T10:30:00Z"
           }
         },
-        "required": [
-          "id",
-          "name",
-          "createdAt"
-        ]
+        "required": ["id", "name", "createdAt"]
       },
       "SuperAdminOrgListResponseDto": {
         "type": "object",
@@ -6079,9 +5751,7 @@
             }
           }
         },
-        "required": [
-          "orgs"
-        ]
+        "required": ["orgs"]
       },
       "UserResponseDto": {
         "type": "object",
@@ -6105,10 +5775,7 @@
           "role": {
             "type": "string",
             "description": "User role",
-            "enum": [
-              "admin",
-              "user"
-            ],
+            "enum": ["admin", "user"],
             "example": "user"
           },
           "orgId": {
@@ -6124,14 +5791,7 @@
             "example": "2024-01-15T10:30:00Z"
           }
         },
-        "required": [
-          "id",
-          "name",
-          "email",
-          "role",
-          "orgId",
-          "createdAt"
-        ]
+        "required": ["id", "name", "email", "role", "orgId", "createdAt"]
       },
       "UsersListResponseDto": {
         "type": "object",
@@ -6144,9 +5804,7 @@
             }
           }
         },
-        "required": [
-          "users"
-        ]
+        "required": ["users"]
       },
       "UpdateUserRoleDto": {
         "type": "object",
@@ -6154,16 +5812,11 @@
           "role": {
             "type": "string",
             "description": "New role for the user",
-            "enum": [
-              "admin",
-              "user"
-            ],
+            "enum": ["admin", "user"],
             "example": "admin"
           }
         },
-        "required": [
-          "role"
-        ]
+        "required": ["role"]
       },
       "UpdateUserNameDto": {
         "type": "object",
@@ -6176,9 +5829,7 @@
             "maxLength": 100
           }
         },
-        "required": [
-          "name"
-        ]
+        "required": ["name"]
       },
       "UpdatePasswordDto": {
         "type": "object",
@@ -6217,9 +5868,7 @@
             "example": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
           }
         },
-        "required": [
-          "token"
-        ]
+        "required": ["token"]
       },
       "ResendEmailConfirmationDto": {
         "type": "object",
@@ -6231,9 +5880,7 @@
             "format": "email"
           }
         },
-        "required": [
-          "email"
-        ]
+        "required": ["email"]
       },
       "ForgotPasswordDto": {
         "type": "object",
@@ -6244,9 +5891,7 @@
             "example": "user@example.com"
           }
         },
-        "required": [
-          "email"
-        ]
+        "required": ["email"]
       },
       "ResetPasswordDto": {
         "type": "object",
@@ -6269,11 +5914,7 @@
             "minLength": 8
           }
         },
-        "required": [
-          "resetToken",
-          "newPassword",
-          "newPasswordConfirmation"
-        ]
+        "required": ["resetToken", "newPassword", "newPasswordConfirmation"]
       },
       "CreateUserDto": {
         "type": "object",
@@ -6291,10 +5932,7 @@
           "role": {
             "type": "string",
             "description": "Role for the user",
-            "enum": [
-              "admin",
-              "user"
-            ],
+            "enum": ["admin", "user"],
             "example": "user"
           },
           "sendPasswordResetEmail": {
@@ -6303,12 +5941,7 @@
             "example": true
           }
         },
-        "required": [
-          "email",
-          "name",
-          "role",
-          "sendPasswordResetEmail"
-        ]
+        "required": ["email", "name", "role", "sendPasswordResetEmail"]
       },
       "CreateInviteDto": {
         "type": "object",
@@ -6321,17 +5954,11 @@
           "role": {
             "type": "string",
             "description": "Role to assign to the invited user",
-            "enum": [
-              "admin",
-              "user"
-            ],
+            "enum": ["admin", "user"],
             "example": "user"
           }
         },
-        "required": [
-          "email",
-          "role"
-        ]
+        "required": ["email", "role"]
       },
       "CreateInviteResponseDto": {
         "type": "object",
@@ -6343,9 +5970,7 @@
             "nullable": true
           }
         },
-        "required": [
-          "url"
-        ]
+        "required": ["url"]
       },
       "InviteResponseDto": {
         "type": "object",
@@ -6364,20 +5989,13 @@
           "role": {
             "type": "string",
             "description": "Role assigned to the invited user",
-            "enum": [
-              "admin",
-              "user"
-            ],
+            "enum": ["admin", "user"],
             "example": "user"
           },
           "status": {
             "type": "string",
             "description": "Current status of the invite",
-            "enum": [
-              "pending",
-              "accepted",
-              "expired"
-            ],
+            "enum": ["pending", "accepted", "expired"],
             "example": "pending"
           },
           "sentDate": {
@@ -6399,14 +6017,7 @@
             "example": "2023-12-02T15:30:00Z"
           }
         },
-        "required": [
-          "id",
-          "email",
-          "role",
-          "status",
-          "sentDate",
-          "expiresAt"
-        ]
+        "required": ["id", "email", "role", "status", "sentDate", "expiresAt"]
       },
       "InviteDetailResponseDto": {
         "type": "object",
@@ -6425,20 +6036,13 @@
           "role": {
             "type": "string",
             "description": "Role assigned to the invited user",
-            "enum": [
-              "admin",
-              "user"
-            ],
+            "enum": ["admin", "user"],
             "example": "user"
           },
           "status": {
             "type": "string",
             "description": "Current status of the invite",
-            "enum": [
-              "pending",
-              "accepted",
-              "expired"
-            ],
+            "enum": ["pending", "accepted", "expired"],
             "example": "pending"
           },
           "sentDate": {
@@ -6527,11 +6131,7 @@
             "format": "uuid"
           }
         },
-        "required": [
-          "inviteId",
-          "email",
-          "orgId"
-        ]
+        "required": ["inviteId", "email", "orgId"]
       },
       "SubscriptionBillingInfoResponseDto": {
         "type": "object",
@@ -6626,10 +6226,7 @@
           "renewalCycle": {
             "type": "string",
             "description": "Renewal cycle of the subscription",
-            "enum": [
-              "monthly",
-              "yearly"
-            ],
+            "enum": ["monthly", "yearly"],
             "example": "monthly"
           },
           "renewalCycleAnchor": {
@@ -6754,9 +6351,7 @@
             "example": true
           }
         },
-        "required": [
-          "hasActiveSubscription"
-        ]
+        "required": ["hasActiveSubscription"]
       },
       "UpdateBillingInfoDto": {
         "type": "object",
@@ -6815,9 +6410,7 @@
             "example": 29.99
           }
         },
-        "required": [
-          "pricePerSeatMonthly"
-        ]
+        "required": ["pricePerSeatMonthly"]
       },
       "UpdateSeatsDto": {
         "type": "object",
@@ -6853,11 +6446,7 @@
             "example": "2024-01-01T00:00:00.000Z"
           }
         },
-        "required": [
-          "objectName",
-          "size",
-          "etag"
-        ]
+        "required": ["objectName", "size", "etag"]
       },
       "CreateThreadDto": {
         "type": "object",
@@ -6904,9 +6493,7 @@
             "type": "string",
             "description": "Role of the message sender",
             "example": "user",
-            "enum": [
-              "user"
-            ]
+            "enum": ["user"]
           },
           "content": {
             "type": "array",
@@ -6923,13 +6510,7 @@
             }
           }
         },
-        "required": [
-          "id",
-          "threadId",
-          "createdAt",
-          "role",
-          "content"
-        ]
+        "required": ["id", "threadId", "createdAt", "role", "content"]
       },
       "SystemMessageResponseDto": {
         "type": "object",
@@ -6953,9 +6534,7 @@
             "type": "string",
             "description": "Role of the message sender",
             "example": "system",
-            "enum": [
-              "system"
-            ]
+            "enum": ["system"]
           },
           "content": {
             "type": "array",
@@ -6965,13 +6544,7 @@
             }
           }
         },
-        "required": [
-          "id",
-          "threadId",
-          "createdAt",
-          "role",
-          "content"
-        ]
+        "required": ["id", "threadId", "createdAt", "role", "content"]
       },
       "AssistantMessageResponseDto": {
         "type": "object",
@@ -6995,9 +6568,7 @@
             "type": "string",
             "description": "Role of the message sender",
             "example": "assistant",
-            "enum": [
-              "assistant"
-            ]
+            "enum": ["assistant"]
           },
           "content": {
             "type": "array",
@@ -7017,13 +6588,7 @@
             }
           }
         },
-        "required": [
-          "id",
-          "threadId",
-          "createdAt",
-          "role",
-          "content"
-        ]
+        "required": ["id", "threadId", "createdAt", "role", "content"]
       },
       "ToolResultMessageResponseDto": {
         "type": "object",
@@ -7047,9 +6612,7 @@
             "type": "string",
             "description": "Role of the message sender",
             "example": "tool",
-            "enum": [
-              "tool"
-            ]
+            "enum": ["tool"]
           },
           "content": {
             "type": "array",
@@ -7059,13 +6622,7 @@
             }
           }
         },
-        "required": [
-          "id",
-          "threadId",
-          "createdAt",
-          "role",
-          "content"
-        ]
+        "required": ["id", "threadId", "createdAt", "role", "content"]
       },
       "TextMessageContentResponseDto": {
         "type": "object",
@@ -7074,13 +6631,7 @@
             "type": "string",
             "description": "Type of the message content",
             "example": "text",
-            "enum": [
-              "text",
-              "tool_use",
-              "tool_result",
-              "thinking",
-              "image"
-            ]
+            "enum": ["text", "tool_use", "tool_result", "thinking", "image"]
           },
           "text": {
             "type": "string",
@@ -7088,10 +6639,7 @@
             "example": "Hello, how can I help you today?"
           }
         },
-        "required": [
-          "type",
-          "text"
-        ]
+        "required": ["type", "text"]
       },
       "ToolUseMessageContentResponseDto": {
         "type": "object",
@@ -7100,13 +6648,7 @@
             "type": "string",
             "description": "Type of the message content",
             "example": "text",
-            "enum": [
-              "text",
-              "tool_use",
-              "tool_result",
-              "thinking",
-              "image"
-            ]
+            "enum": ["text", "tool_use", "tool_result", "thinking", "image"]
           },
           "id": {
             "type": "string",
@@ -7127,12 +6669,7 @@
             }
           }
         },
-        "required": [
-          "type",
-          "id",
-          "name",
-          "params"
-        ]
+        "required": ["type", "id", "name", "params"]
       },
       "ToolResultMessageContentResponseDto": {
         "type": "object",
@@ -7141,13 +6678,7 @@
             "type": "string",
             "description": "Type of the message content",
             "example": "text",
-            "enum": [
-              "text",
-              "tool_use",
-              "tool_result",
-              "thinking",
-              "image"
-            ]
+            "enum": ["text", "tool_use", "tool_result", "thinking", "image"]
           },
           "toolId": {
             "type": "string",
@@ -7165,12 +6696,7 @@
             "example": "The current temperature in New York is 22°C with partly cloudy skies."
           }
         },
-        "required": [
-          "type",
-          "toolId",
-          "toolName",
-          "result"
-        ]
+        "required": ["type", "toolId", "toolName", "result"]
       },
       "ThinkingMessageContentResponseDto": {
         "type": "object",
@@ -7179,13 +6705,7 @@
             "type": "string",
             "description": "Type of the message content",
             "example": "text",
-            "enum": [
-              "text",
-              "tool_use",
-              "tool_result",
-              "thinking",
-              "image"
-            ]
+            "enum": ["text", "tool_use", "tool_result", "thinking", "image"]
           },
           "thinking": {
             "type": "string",
@@ -7193,10 +6713,7 @@
             "example": "I am thinking about the best way to help you."
           }
         },
-        "required": [
-          "type",
-          "thinking"
-        ]
+        "required": ["type", "thinking"]
       },
       "ImageMessageContentResponseDto": {
         "type": "object",
@@ -7205,13 +6722,7 @@
             "type": "string",
             "description": "Type of the message content",
             "example": "text",
-            "enum": [
-              "text",
-              "tool_use",
-              "tool_result",
-              "thinking",
-              "image"
-            ]
+            "enum": ["text", "tool_use", "tool_result", "thinking", "image"]
           },
           "imageUrl": {
             "type": "string",
@@ -7224,10 +6735,7 @@
             "example": "Screenshot of the reported issue"
           }
         },
-        "required": [
-          "type",
-          "imageUrl"
-        ]
+        "required": ["type", "imageUrl"]
       },
       "ModelResponseDto": {
         "type": "object",
@@ -7291,19 +6799,12 @@
           "type": {
             "type": "string",
             "description": "Type of source",
-            "enum": [
-              "text",
-              "data"
-            ]
+            "enum": ["text", "data"]
           },
           "createdBy": {
             "type": "string",
             "description": "Creator of the source",
-            "enum": [
-              "user",
-              "llm",
-              "system"
-            ]
+            "enum": ["user", "llm", "system"]
           },
           "createdAt": {
             "type": "string",
@@ -7342,19 +6843,12 @@
           "type": {
             "type": "string",
             "description": "Type of source",
-            "enum": [
-              "text",
-              "data"
-            ]
+            "enum": ["text", "data"]
           },
           "createdBy": {
             "type": "string",
             "description": "Creator of the source",
-            "enum": [
-              "user",
-              "llm",
-              "system"
-            ]
+            "enum": ["user", "llm", "system"]
           },
           "createdAt": {
             "type": "string",
@@ -7367,17 +6861,12 @@
           "textType": {
             "type": "string",
             "description": "Type of text",
-            "enum": [
-              "file",
-              "web"
-            ]
+            "enum": ["file", "web"]
           },
           "fileType": {
             "type": "string",
             "description": "Type of file",
-            "enum": [
-              "pdf"
-            ]
+            "enum": ["pdf", "docx", "pptx"]
           }
         },
         "required": [
@@ -7410,19 +6899,12 @@
           "type": {
             "type": "string",
             "description": "Type of source",
-            "enum": [
-              "text",
-              "data"
-            ]
+            "enum": ["text", "data"]
           },
           "createdBy": {
             "type": "string",
             "description": "Creator of the source",
-            "enum": [
-              "user",
-              "llm",
-              "system"
-            ]
+            "enum": ["user", "llm", "system"]
           },
           "createdAt": {
             "type": "string",
@@ -7435,10 +6917,7 @@
           "textType": {
             "type": "string",
             "description": "Type of text",
-            "enum": [
-              "file",
-              "web"
-            ]
+            "enum": ["file", "web"]
           },
           "url": {
             "type": "string",
@@ -7475,19 +6954,12 @@
           "type": {
             "type": "string",
             "description": "Type of source",
-            "enum": [
-              "text",
-              "data"
-            ]
+            "enum": ["text", "data"]
           },
           "createdBy": {
             "type": "string",
             "description": "Creator of the source",
-            "enum": [
-              "user",
-              "llm",
-              "system"
-            ]
+            "enum": ["user", "llm", "system"]
           },
           "createdAt": {
             "type": "string",
@@ -7500,9 +6972,7 @@
           "dataType": {
             "type": "string",
             "description": "Type of data",
-            "enum": [
-              "csv"
-            ]
+            "enum": ["csv"]
           },
           "data": {
             "type": "object",
@@ -7653,12 +7123,7 @@
             "example": false
           }
         },
-        "required": [
-          "id",
-          "createdAt",
-          "updatedAt",
-          "isAnonymous"
-        ]
+        "required": ["id", "createdAt", "updatedAt", "isAnonymous"]
       },
       "ToolAssignmentDto": {
         "type": "object",
@@ -7691,9 +7156,7 @@
             "format": "uuid"
           }
         },
-        "required": [
-          "type"
-        ]
+        "required": ["type"]
       },
       "CreateAgentDto": {
         "type": "object",
@@ -7724,12 +7187,7 @@
             }
           }
         },
-        "required": [
-          "name",
-          "instructions",
-          "modelId",
-          "toolAssignments"
-        ]
+        "required": ["name", "instructions", "modelId", "toolAssignments"]
       },
       "ToolResponseDto": {
         "type": "object",
@@ -7756,9 +7214,7 @@
             ]
           }
         },
-        "required": [
-          "type"
-        ]
+        "required": ["type"]
       },
       "AgentSourceResponseDto": {
         "type": "object",
@@ -7784,18 +7240,10 @@
             "type": "string",
             "description": "The type of source",
             "example": "file",
-            "enum": [
-              "file",
-              "url"
-            ]
+            "enum": ["file", "url"]
           }
         },
-        "required": [
-          "id",
-          "sourceId",
-          "name",
-          "type"
-        ]
+        "required": ["id", "sourceId", "name", "type"]
       },
       "AgentResponseDto": {
         "type": "object",
@@ -7909,11 +7357,7 @@
             "format": "uuid"
           }
         },
-        "required": [
-          "name",
-          "instructions",
-          "modelId"
-        ]
+        "required": ["name", "instructions", "modelId"]
       },
       "McpIntegrationResponseDto": {
         "type": "object",
@@ -7931,10 +7375,7 @@
           "type": {
             "type": "string",
             "description": "Type of integration",
-            "enum": [
-              "predefined",
-              "custom"
-            ],
+            "enum": ["predefined", "custom"],
             "example": "predefined"
           },
           "slug": {
@@ -7960,12 +7401,7 @@
           "authMethod": {
             "type": "string",
             "description": "Authentication method used",
-            "enum": [
-              "NO_AUTH",
-              "BEARER_TOKEN",
-              "CUSTOM_HEADER",
-              "OAUTH"
-            ],
+            "enum": ["NO_AUTH", "BEARER_TOKEN", "CUSTOM_HEADER", "OAUTH"],
             "example": "BEARER_TOKEN"
           },
           "authHeaderName": {
@@ -7981,12 +7417,7 @@
           "connectionStatus": {
             "type": "string",
             "description": "Connection status of the integration",
-            "enum": [
-              "connected",
-              "disconnected",
-              "error",
-              "unknown"
-            ],
+            "enum": ["connected", "disconnected", "error", "unknown"],
             "example": "connected"
           },
           "lastConnectionError": {
@@ -8036,10 +7467,7 @@
           "entityType": {
             "type": "string",
             "description": "Type of entity being shared",
-            "enum": [
-              "agent",
-              "prompt"
-            ]
+            "enum": ["agent", "prompt"]
           },
           "agentId": {
             "type": "string",
@@ -8047,10 +7475,7 @@
             "format": "uuid"
           }
         },
-        "required": [
-          "entityType",
-          "agentId"
-        ]
+        "required": ["entityType", "agentId"]
       },
       "ShareResponseDto": {
         "type": "object",
@@ -8063,10 +7488,7 @@
           "entityType": {
             "type": "string",
             "description": "Type of entity being shared",
-            "enum": [
-              "agent",
-              "prompt"
-            ]
+            "enum": ["agent", "prompt"]
           },
           "entityId": {
             "type": "string",
@@ -8076,10 +7498,7 @@
           "scopeType": {
             "type": "string",
             "description": "Type of share scope (organization or user)",
-            "enum": [
-              "org",
-              "user"
-            ]
+            "enum": ["org", "user"]
           },
           "ownerId": {
             "type": "string",
@@ -8113,11 +7532,7 @@
           "name": {
             "type": "string",
             "description": "The name/type of the credential field",
-            "enum": [
-              "token",
-              "clientId",
-              "clientSecret"
-            ],
+            "enum": ["token", "clientId", "clientSecret"],
             "example": "token"
           },
           "value": {
@@ -8126,10 +7541,7 @@
             "example": "sk_test_123abc"
           }
         },
-        "required": [
-          "name",
-          "value"
-        ]
+        "required": ["name", "value"]
       },
       "CreatePredefinedIntegrationDto": {
         "type": "object",
@@ -8138,11 +7550,7 @@
             "type": "string",
             "description": "The predefined integration slug",
             "example": "TEST",
-            "enum": [
-              "TEST",
-              "LOCABOO",
-              "LEGAL_CODES"
-            ]
+            "enum": ["TEST", "LOCABOO", "LEGAL_CODES"]
           },
           "configValues": {
             "description": "List of config values for credential fields",
@@ -8164,10 +7572,7 @@
             "default": true
           }
         },
-        "required": [
-          "slug",
-          "configValues"
-        ]
+        "required": ["slug", "configValues"]
       },
       "CreateCustomIntegrationDto": {
         "type": "object",
@@ -8187,12 +7592,7 @@
           "authMethod": {
             "type": "string",
             "description": "Authentication method for the MCP server",
-            "enum": [
-              "NO_AUTH",
-              "BEARER_TOKEN",
-              "CUSTOM_HEADER",
-              "OAUTH"
-            ],
+            "enum": ["NO_AUTH", "BEARER_TOKEN", "CUSTOM_HEADER", "OAUTH"],
             "example": "CUSTOM_HEADER",
             "nullable": true
           },
@@ -8213,10 +7613,7 @@
             "default": true
           }
         },
-        "required": [
-          "name",
-          "serverUrl"
-        ]
+        "required": ["name", "serverUrl"]
       },
       "CredentialFieldDto": {
         "type": "object",
@@ -8229,11 +7626,7 @@
           "type": {
             "type": "string",
             "description": "Input type (text or password)",
-            "enum": [
-              "token",
-              "clientId",
-              "clientSecret"
-            ],
+            "enum": ["token", "clientId", "clientSecret"],
             "example": "token"
           },
           "required": {
@@ -8247,11 +7640,7 @@
             "example": "Your Locaboo 3 API token will be used to authenticate with Locaboo 4"
           }
         },
-        "required": [
-          "label",
-          "type",
-          "required"
-        ]
+        "required": ["label", "type", "required"]
       },
       "PredefinedConfigResponseDto": {
         "type": "object",
@@ -8274,12 +7663,7 @@
           "authType": {
             "type": "string",
             "description": "Authentication method for this integration",
-            "enum": [
-              "NO_AUTH",
-              "BEARER_TOKEN",
-              "API_KEY",
-              "OAUTH"
-            ],
+            "enum": ["NO_AUTH", "BEARER_TOKEN", "API_KEY", "OAUTH"],
             "example": "BEARER_TOKEN"
           },
           "authHeaderName": {
@@ -8295,12 +7679,7 @@
             }
           }
         },
-        "required": [
-          "slug",
-          "displayName",
-          "description",
-          "authType"
-        ]
+        "required": ["slug", "displayName", "description", "authType"]
       },
       "UpdateMcpIntegrationDto": {
         "type": "object",
@@ -8352,10 +7731,7 @@
             "example": "Connection timeout"
           }
         },
-        "required": [
-          "valid",
-          "capabilities"
-        ]
+        "required": ["valid", "capabilities"]
       },
       "RetrieveUrlDto": {
         "type": "object",
@@ -8366,9 +7742,7 @@
             "example": "https://example.com/article"
           }
         },
-        "required": [
-          "url"
-        ]
+        "required": ["url"]
       },
       "MessageContentResponseDto": {
         "type": "object",
@@ -8377,18 +7751,10 @@
             "type": "string",
             "description": "Type of the message content",
             "example": "text",
-            "enum": [
-              "text",
-              "tool_use",
-              "tool_result",
-              "thinking",
-              "image"
-            ]
+            "enum": ["text", "tool_use", "tool_result", "thinking", "image"]
           }
         },
-        "required": [
-          "type"
-        ]
+        "required": ["type"]
       },
       "RunSessionResponseDto": {
         "type": "object",
@@ -8397,9 +7763,7 @@
             "type": "string",
             "description": "Response type identifier",
             "example": "session",
-            "enum": [
-              "session"
-            ]
+            "enum": ["session"]
           },
           "success": {
             "type": "boolean",
@@ -8422,11 +7786,7 @@
             "example": "2024-01-01T12:00:00.000Z"
           }
         },
-        "required": [
-          "type",
-          "threadId",
-          "timestamp"
-        ]
+        "required": ["type", "threadId", "timestamp"]
       },
       "RunMessageResponseDto": {
         "type": "object",
@@ -8435,9 +7795,7 @@
             "type": "string",
             "description": "Response type identifier",
             "example": "message",
-            "enum": [
-              "message"
-            ]
+            "enum": ["message"]
           },
           "message": {
             "description": "The message data",
@@ -8467,12 +7825,7 @@
             "example": "2024-01-01T12:00:00.000Z"
           }
         },
-        "required": [
-          "type",
-          "message",
-          "threadId",
-          "timestamp"
-        ]
+        "required": ["type", "message", "threadId", "timestamp"]
       },
       "RunErrorResponseDto": {
         "type": "object",
@@ -8481,9 +7834,7 @@
             "type": "string",
             "description": "Response type identifier",
             "example": "error",
-            "enum": [
-              "error"
-            ]
+            "enum": ["error"]
           },
           "message": {
             "type": "string",
@@ -8513,12 +7864,7 @@
             }
           }
         },
-        "required": [
-          "type",
-          "message",
-          "threadId",
-          "timestamp"
-        ]
+        "required": ["type", "message", "threadId", "timestamp"]
       },
       "RunThreadResponseDto": {
         "type": "object",
@@ -8527,9 +7873,7 @@
             "type": "string",
             "description": "Response type identifier",
             "example": "thread",
-            "enum": [
-              "thread"
-            ]
+            "enum": ["thread"]
           },
           "threadId": {
             "type": "string",
@@ -8540,9 +7884,7 @@
             "type": "string",
             "description": "Type of thread update",
             "example": "title_updated",
-            "enum": [
-              "title_updated"
-            ]
+            "enum": ["title_updated"]
           },
           "title": {
             "type": "string",
@@ -8555,13 +7897,7 @@
             "example": "2024-01-01T12:00:00.000Z"
           }
         },
-        "required": [
-          "type",
-          "threadId",
-          "updateType",
-          "title",
-          "timestamp"
-        ]
+        "required": ["type", "threadId", "updateType", "title", "timestamp"]
       },
       "TextInput": {
         "type": "object",
@@ -8569,9 +7905,7 @@
           "type": {
             "type": "string",
             "description": "The type of input",
-            "enum": [
-              "text"
-            ],
+            "enum": ["text"],
             "example": "text"
           },
           "text": {
@@ -8580,10 +7914,7 @@
             "example": "What is the weather forecast for New York tomorrow?"
           }
         },
-        "required": [
-          "type",
-          "text"
-        ]
+        "required": ["type", "text"]
       },
       "ToolResultInput": {
         "type": "object",
@@ -8591,9 +7922,7 @@
           "type": {
             "type": "string",
             "description": "The type of input",
-            "enum": [
-              "tool_result"
-            ],
+            "enum": ["tool_result"],
             "example": "tool_result"
           },
           "toolId": {
@@ -8612,12 +7941,7 @@
             "example": "{\"location\":\"New York\",\"forecast\":\"Partly cloudy with a high of 75°F and a low of 60°F\",\"precipitation\":\"20%\"}"
           }
         },
-        "required": [
-          "type",
-          "toolId",
-          "toolName",
-          "result"
-        ]
+        "required": ["type", "toolId", "toolName", "result"]
       },
       "SendMessageDto": {
         "type": "object",
@@ -8659,9 +7983,7 @@
             "default": true
           }
         },
-        "required": [
-          "threadId"
-        ]
+        "required": ["threadId"]
       },
       "SuperAdminTrialResponseDto": {
         "type": "object",
@@ -8741,10 +8063,7 @@
             "minimum": 1
           }
         },
-        "required": [
-          "orgId",
-          "maxMessages"
-        ]
+        "required": ["orgId", "maxMessages"]
       },
       "UpdateTrialRequestDto": {
         "type": "object",
@@ -8779,10 +8098,7 @@
             "example": "You are a helpful assistant that helps with project planning. Please provide detailed step-by-step guidance for managing projects effectively."
           }
         },
-        "required": [
-          "title",
-          "content"
-        ]
+        "required": ["title", "content"]
       },
       "PromptResponseDto": {
         "type": "object",
@@ -8847,10 +8163,7 @@
             "example": "You are an expert project planning assistant. Provide comprehensive guidance for project management, including risk assessment and timeline optimization."
           }
         },
-        "required": [
-          "title",
-          "content"
-        ]
+        "required": ["title", "content"]
       },
       "LoginDto": {
         "type": "object",
@@ -8866,10 +8179,7 @@
             "example": "password123"
           }
         },
-        "required": [
-          "email",
-          "password"
-        ]
+        "required": ["email", "password"]
       },
       "SuccessResponseDto": {
         "type": "object",
@@ -8880,9 +8190,7 @@
             "example": true
           }
         },
-        "required": [
-          "success"
-        ]
+        "required": ["success"]
       },
       "ErrorResponseDto": {
         "type": "object",
@@ -8893,9 +8201,7 @@
             "example": "Authentication failed"
           }
         },
-        "required": [
-          "message"
-        ]
+        "required": ["message"]
       },
       "RegisterDto": {
         "type": "object",
@@ -8945,19 +8251,13 @@
           "role": {
             "type": "string",
             "description": "User role",
-            "enum": [
-              "admin",
-              "user"
-            ],
+            "enum": ["admin", "user"],
             "example": "user"
           },
           "systemRole": {
             "type": "string",
             "description": "User system role",
-            "enum": [
-              "customer",
-              "super_admin"
-            ],
+            "enum": ["customer", "super_admin"],
             "example": "super_admin"
           },
           "name": {
@@ -8966,12 +8266,7 @@
             "example": "John Doe"
           }
         },
-        "required": [
-          "email",
-          "role",
-          "systemRole",
-          "name"
-        ]
+        "required": ["email", "role", "systemRole", "name"]
       },
       "CreateLanguageModelDto": {
         "type": "object",

--- a/ayunis-core-frontend/src/shared/locales/de/chat.json
+++ b/ayunis-core-frontend/src/shared/locales/de/chat.json
@@ -1,0 +1,68 @@
+{
+  "chat": {
+    "untitled": "Ohne Titel",
+    "anonymousMode": "Anonym",
+    "anonymousModeTooltip": "Dieser Chat ist im anonymen Modus. Personenbezogene Daten werden automatisch entfernt.",
+    "deleteThread": "Thread löschen",
+    "deleteThreadTitle": "Thread löschen",
+    "deleteThreadDescription": "Sind Sie sicher, dass Sie diesen Thread löschen möchten? Diese Aktion kann nicht rückgängig gemacht werden.",
+    "deleteText": "Löschen",
+    "cancelText": "Abbrechen",
+    "errorDeleteThread": "Thread konnte nicht gelöscht werden",
+    "unknownMessageType": "Unbekannter Nachrichtentyp",
+    "upgradeToProError": "Sie müssen ein Pro-Abonnement haben, um diese Funktion zu verwenden.",
+    "errorExecutionError": "Fehler beim Abruf der Antwort",
+    "errorUnexpected": "Ein unerwarteter Fehler ist aufgetreten",
+    "errorNoModelFound": "Kein Modell gefunden",
+    "errorMaxIterationsReached": "Maximale Anzahl an Iterationen erreicht",
+    "errorToolNotFound": "Tool nicht gefunden",
+    "errorSendMessage": "Nachricht konnte nicht gesendet werden. Bitte aktualisieren Sie die Seite und versuchen Sie es erneut.",
+    "errorDownloadSource": "Quelle konnte nicht heruntergeladen werden. Bitte versuchen Sie es erneut.",
+    "errorUpdateModel": "Modell konnte nicht aktualisiert werden",
+    "errorUpdateAgent": "Agent konnte nicht aktualisiert werden",
+    "errorRemoveAgent": "Agent konnte nicht entfernt werden",
+    "thinking": "Nachdenken",
+    "tools": {
+      "internet_search": "Im Internet suchen",
+      "website_content": "Website abfragen",
+      "source_query": "Quelle durchsuchen",
+      "code_execution": "Berechnung ausführen",
+      "send_email": {
+        "subject": "Betreff",
+        "body": "Nachricht",
+        "to": "Empfänger",
+        "toPlaceholder": "E-Mail-Adresse eingeben",
+        "subjectPlaceholder": "Betreff eingeben",
+        "bodyPlaceholder": "Nachricht eingeben",
+        "open": "In E-Mail App öffnen",
+        "copyBody": "Text kopieren",
+        "copied": "Kopiert"
+      },
+      "create_calendar_event": {
+        "title": "Titel",
+        "titlePlaceholder": "Ereignistitel",
+        "description": "Beschreibung",
+        "descriptionPlaceholder": "Ereignisbeschreibung",
+        "location": "Ort",
+        "locationPlaceholder": "Wo findet es statt?",
+        "start": "Beginn",
+        "end": "Ende",
+        "open": "In Google Kalender öffnen",
+        "downloadIcs": "Kalendereintrag herunterladen (.ics)",
+        "invalidRange": "Ende muss nach dem Beginn liegen",
+        "selectDate": "Datum wählen"
+      }
+    },
+    "charts": {
+      "emptyState": "Keine Diagrammdaten verfügbar"
+    }
+  },
+  "newChat": {
+    "newChat": "Neuer Chat",
+    "title": "Wie kann ich Ihnen helfen?",
+    "noModelTitle": "Herzlich Willkommen",
+    "noModelDescription": "Bevor es losgehen kann, benötigen wir mindestens ein freigeschaltetes Modell. Bitte wenden Sie sich an Ihren Administrator und bitten Sie ihn, mindestens ein Modell zu aktivieren. Wenn Sie Administrator sind, können Sie ein Modell in den Einstellungen konfigurieren.",
+    "configureModel": "Modell konfigurieren",
+    "upgradeToProError": "Sie müssen ein Pro-Abonnement haben, um diese Funktion zu verwenden."
+  }
+}

--- a/ayunis-core-frontend/src/shared/locales/de/chats.json
+++ b/ayunis-core-frontend/src/shared/locales/de/chats.json
@@ -1,68 +1,32 @@
 {
-  "chat": {
+  "page": {
+    "title": "Chat-Verlauf"
+  },
+  "filters": {
+    "searchPlaceholder": "Chats durchsuchen...",
+    "agentFilterLabel": "Nach Agent filtern",
+    "agentFilterAll": "Alle Agenten",
+    "noAgent": "Kein Agent"
+  },
+  "emptyState": {
+    "title": "Noch keine Chats",
+    "description": "Starten Sie einen neuen Chat, um ihn hier zu sehen.",
+    "noResultsTitle": "Keine passenden Chats",
+    "noResultsDescription": "Versuchen Sie, Ihre Suche oder Filter anzupassen.",
+    "startChat": "Neuen Chat starten"
+  },
+  "card": {
     "untitled": "Ohne Titel",
-    "anonymousMode": "Anonym",
-    "anonymousModeTooltip": "Dieser Chat ist im anonymen Modus. Personenbezogene Daten werden automatisch entfernt.",
-    "deleteThread": "Thread löschen",
-    "deleteThreadTitle": "Thread löschen",
-    "deleteThreadDescription": "Sind Sie sicher, dass Sie diesen Thread löschen möchten? Diese Aktion kann nicht rückgängig gemacht werden.",
-    "deleteText": "Löschen",
-    "cancelText": "Abbrechen",
-    "errorDeleteThread": "Thread konnte nicht gelöscht werden",
-    "unknownMessageType": "Unbekannter Nachrichtentyp",
-    "upgradeToProError": "Sie müssen ein Pro-Abonnement haben, um diese Funktion zu verwenden.",
-    "errorExecutionError": "Fehler beim Abruf der Antwort",
-    "errorUnexpected": "Ein unerwarteter Fehler ist aufgetreten",
-    "errorNoModelFound": "Kein Modell gefunden",
-    "errorMaxIterationsReached": "Maximale Anzahl an Iterationen erreicht",
-    "errorToolNotFound": "Tool nicht gefunden",
-    "errorSendMessage": "Nachricht konnte nicht gesendet werden. Bitte aktualisieren Sie die Seite und versuchen Sie es erneut.",
-    "errorDownloadSource": "Quelle konnte nicht heruntergeladen werden. Bitte versuchen Sie es erneut.",
-    "errorUpdateModel": "Modell konnte nicht aktualisiert werden",
-    "errorUpdateAgent": "Agent konnte nicht aktualisiert werden",
-    "errorRemoveAgent": "Agent konnte nicht entfernt werden",
-    "thinking": "Nachdenken",
-    "tools": {
-      "internet_search": "Im Internet suchen",
-      "website_content": "Website abfragen",
-      "source_query": "Quelle durchsuchen",
-      "code_execution": "Berechnung ausführen",
-      "send_email": {
-        "subject": "Betreff",
-        "body": "Nachricht",
-        "to": "Empfänger",
-        "toPlaceholder": "E-Mail-Adresse eingeben",
-        "subjectPlaceholder": "Betreff eingeben",
-        "bodyPlaceholder": "Nachricht eingeben",
-        "open": "In E-Mail App öffnen",
-        "copyBody": "Text kopieren",
-        "copied": "Kopiert"
-      },
-      "create_calendar_event": {
-        "title": "Titel",
-        "titlePlaceholder": "Ereignistitel",
-        "description": "Beschreibung",
-        "descriptionPlaceholder": "Ereignisbeschreibung",
-        "location": "Ort",
-        "locationPlaceholder": "Wo findet es statt?",
-        "start": "Beginn",
-        "end": "Ende",
-        "open": "In Google Kalender öffnen",
-        "downloadIcs": "Kalendereintrag herunterladen (.ics)",
-        "invalidRange": "Ende muss nach dem Beginn liegen",
-        "selectDate": "Datum wählen"
-      }
-    },
-    "charts": {
-      "emptyState": "Keine Diagrammdaten verfügbar"
+    "anonymous": "Anonym",
+    "confirmDelete": {
+      "title": "Chat löschen",
+      "description": "Sind Sie sicher, dass Sie \"{{title}}\" löschen möchten? Diese Aktion kann nicht rückgängig gemacht werden.",
+      "confirmText": "Löschen",
+      "cancelText": "Abbrechen"
     }
   },
-  "newChat": {
-    "newChat": "Neuer Chat",
-    "title": "Wie kann ich Ihnen helfen?",
-    "noModelTitle": "Herzlich Willkommen",
-    "noModelDescription": "Bevor es losgehen kann, benötigen wir mindestens ein freigeschaltetes Modell. Bitte wenden Sie sich an Ihren Administrator und bitten Sie ihn, mindestens ein Modell zu aktivieren. Wenn Sie Administrator sind, können Sie ein Modell in den Einstellungen konfigurieren.",
-    "configureModel": "Modell konfigurieren",
-    "upgradeToProError": "Sie müssen ein Pro-Abonnement haben, um diese Funktion zu verwenden."
+  "delete": {
+    "success": "Chat erfolgreich gelöscht!",
+    "error": "Chat konnte nicht gelöscht werden. Bitte versuchen Sie es erneut."
   }
 }

--- a/ayunis-core-frontend/src/shared/locales/en/chat.json
+++ b/ayunis-core-frontend/src/shared/locales/en/chat.json
@@ -1,0 +1,68 @@
+{
+  "chat": {
+    "untitled": "Untitled",
+    "anonymousMode": "Anonymous",
+    "anonymousModeTooltip": "This chat is in anonymous mode. Personal data is automatically redacted.",
+    "deleteThread": "Delete thread",
+    "deleteThreadTitle": "Delete Thread",
+    "deleteThreadDescription": "Are you sure you want to delete this thread? This action cannot be undone.",
+    "deleteText": "Delete",
+    "cancelText": "Cancel",
+    "errorDeleteThread": "Failed to delete thread",
+    "unknownMessageType": "Unknown message type",
+    "upgradeToProError": "You need to upgrade to a paid plan to use this feature.",
+    "errorExecutionError": "Error fetching response",
+    "errorUnexpected": "An unexpected error occurred",
+    "errorNoModelFound": "No model found",
+    "errorMaxIterationsReached": "Maximal number of iterations reached",
+    "errorToolNotFound": "Tool not found",
+    "errorSendMessage": "Message could not be sent. Please refresh the page and try again.",
+    "errorDownloadSource": "Failed to download source. Please try again.",
+    "errorUpdateModel": "Model could not be updated",
+    "errorUpdateAgent": "Agent could not be updated",
+    "errorRemoveAgent": "Agent could not be removed",
+    "thinking": "Thinking",
+    "tools": {
+      "internet_search": "Search the internet",
+      "website_content": "Query website",
+      "source_query": "Query source",
+      "code_execution": "Calculate",
+      "send_email": {
+        "subject": "Subject",
+        "body": "Body",
+        "to": "To",
+        "toPlaceholder": "Enter email address",
+        "subjectPlaceholder": "Enter email subject",
+        "bodyPlaceholder": "Write your email body",
+        "open": "Open in email app",
+        "copyBody": "Copy body",
+        "copied": "Copied"
+      },
+      "create_calendar_event": {
+        "title": "Title",
+        "titlePlaceholder": "Event title",
+        "description": "Description",
+        "descriptionPlaceholder": "Event description",
+        "location": "Location",
+        "locationPlaceholder": "Where is it?",
+        "start": "Start",
+        "end": "End",
+        "open": "Open in Google Calendar",
+        "downloadIcs": "Download .ics",
+        "invalidRange": "End must be after start",
+        "selectDate": "Select date"
+      }
+    },
+    "charts": {
+      "emptyState": "No chart data available"
+    }
+  },
+  "newChat": {
+    "newChat": "New Chat",
+    "title": "How can I help you?",
+    "noModelTitle": "Welcome",
+    "noModelDescription": "Before we can start, we need at least one enabled model. Please contact your administrator and ask them to enable at least one model. If you are an administrator, you can configure a model in the settings.",
+    "configureModel": "Configure Model",
+    "upgradeToProError": "You need to upgrade to a paid plan to use this feature."
+  }
+}

--- a/ayunis-core-frontend/src/shared/locales/en/chats.json
+++ b/ayunis-core-frontend/src/shared/locales/en/chats.json
@@ -1,68 +1,32 @@
 {
-  "chat": {
+  "page": {
+    "title": "Chat History"
+  },
+  "filters": {
+    "searchPlaceholder": "Search chats...",
+    "agentFilterLabel": "Filter by Agent",
+    "agentFilterAll": "All Agents",
+    "noAgent": "No Agent"
+  },
+  "emptyState": {
+    "title": "No chats yet",
+    "description": "Start a new chat to see it here.",
+    "noResultsTitle": "No matching chats",
+    "noResultsDescription": "Try adjusting your search or filter.",
+    "startChat": "Start New Chat"
+  },
+  "card": {
     "untitled": "Untitled",
-    "anonymousMode": "Anonymous",
-    "anonymousModeTooltip": "This chat is in anonymous mode. Personal data is automatically redacted.",
-    "deleteThread": "Delete thread",
-    "deleteThreadTitle": "Delete Thread",
-    "deleteThreadDescription": "Are you sure you want to delete this thread? This action cannot be undone.",
-    "deleteText": "Delete",
-    "cancelText": "Cancel",
-    "errorDeleteThread": "Failed to delete thread",
-    "unknownMessageType": "Unknown message type",
-    "upgradeToProError": "You need to upgrade to a paid plan to use this feature.",
-    "errorExecutionError": "Error fetching response",
-    "errorUnexpected": "An unexpected error occurred",
-    "errorNoModelFound": "No model found",
-    "errorMaxIterationsReached": "Maximal number of iterations reached",
-    "errorToolNotFound": "Tool not found",
-    "errorSendMessage": "Message could not be sent. Please refresh the page and try again.",
-    "errorDownloadSource": "Failed to download source. Please try again.",
-    "errorUpdateModel": "Model could not be updated",
-    "errorUpdateAgent": "Agent could not be updated",
-    "errorRemoveAgent": "Agent could not be removed",
-    "thinking": "Thinking",
-    "tools": {
-      "internet_search": "Search the internet",
-      "website_content": "Query website",
-      "source_query": "Query source",
-      "code_execution": "Calculate",
-      "send_email": {
-        "subject": "Subject",
-        "body": "Body",
-        "to": "To",
-        "toPlaceholder": "Enter email address",
-        "subjectPlaceholder": "Enter email subject",
-        "bodyPlaceholder": "Write your email body",
-        "open": "Open in email app",
-        "copyBody": "Copy body",
-        "copied": "Copied"
-      },
-      "create_calendar_event": {
-        "title": "Title",
-        "titlePlaceholder": "Event title",
-        "description": "Description",
-        "descriptionPlaceholder": "Event description",
-        "location": "Location",
-        "locationPlaceholder": "Where is it?",
-        "start": "Start",
-        "end": "End",
-        "open": "Open in Google Calendar",
-        "downloadIcs": "Download .ics",
-        "invalidRange": "End must be after start",
-        "selectDate": "Select date"
-      }
-    },
-    "charts": {
-      "emptyState": "No chart data available"
+    "anonymous": "Anonymous",
+    "confirmDelete": {
+      "title": "Delete Chat",
+      "description": "Are you sure you want to delete \"{{title}}\"? This action cannot be undone.",
+      "confirmText": "Delete",
+      "cancelText": "Cancel"
     }
   },
-  "newChat": {
-    "newChat": "New Chat",
-    "title": "How can I help you?",
-    "noModelTitle": "Welcome",
-    "noModelDescription": "Before we can start, we need at least one enabled model. Please contact your administrator and ask them to enable at least one model. If you are an administrator, you can configure a model in the settings.",
-    "configureModel": "Configure Model",
-    "upgradeToProError": "You need to upgrade to a paid plan to use this feature."
+  "delete": {
+    "success": "Chat deleted successfully!",
+    "error": "Failed to delete chat. Please try again."
   }
 }

--- a/ayunis-core-frontend/src/widgets/app-sidebar/api/useThreads.ts
+++ b/ayunis-core-frontend/src/widgets/app-sidebar/api/useThreads.ts
@@ -16,7 +16,7 @@ export function useThreads() {
     isLoading,
     error,
     refetch,
-  } = useThreadsControllerFindAll({
+  } = useThreadsControllerFindAll(undefined, {
     query: {
       queryKey: getThreadsControllerFindAllQueryKey(),
     },

--- a/ayunis-core-frontend/src/widgets/app-sidebar/ui/ChatsSidebarGroup.tsx
+++ b/ayunis-core-frontend/src/widgets/app-sidebar/ui/ChatsSidebarGroup.tsx
@@ -5,6 +5,7 @@ import {
   AlertCircle,
   Trash,
   ChevronDown,
+  Search,
 } from 'lucide-react';
 import { Link, useParams, useNavigate } from '@tanstack/react-router';
 
@@ -76,9 +77,16 @@ export function ChatsSidebarGroup() {
       <Collapsible defaultOpen className="group/collapsible">
         <SidebarGroup>
           <SidebarGroupLabel asChild>
-            <CollapsibleTrigger>
-              {t('sidebar.chats')}{' '}
-              <ChevronDown className="ml-auto transition-transform group-data-[state=open]/collapsible:rotate-180" />
+            <CollapsibleTrigger className="flex items-center w-full">
+              {t('sidebar.chats')}
+              <Link
+                to="/chats"
+                className="ml-auto mr-1 p-1 hover:bg-accent rounded"
+                onClick={(e) => e.stopPropagation()}
+              >
+                <Search className="size-4" />
+              </Link>
+              <ChevronDown className="transition-transform group-data-[state=open]/collapsible:rotate-180" />
             </CollapsibleTrigger>
           </SidebarGroupLabel>
           <CollapsibleContent>
@@ -103,9 +111,16 @@ export function ChatsSidebarGroup() {
       <Collapsible defaultOpen className="group/collapsible">
         <SidebarGroup>
           <SidebarGroupLabel asChild>
-            <CollapsibleTrigger>
-              {t('sidebar.chats')}{' '}
-              <ChevronDown className="ml-auto transition-transform group-data-[state=open]/collapsible:rotate-180" />
+            <CollapsibleTrigger className="flex items-center w-full">
+              {t('sidebar.chats')}
+              <Link
+                to="/chats"
+                className="ml-auto mr-1 p-1 hover:bg-accent rounded"
+                onClick={(e) => e.stopPropagation()}
+              >
+                <Search className="size-4" />
+              </Link>
+              <ChevronDown className="transition-transform group-data-[state=open]/collapsible:rotate-180" />
             </CollapsibleTrigger>
           </SidebarGroupLabel>
           <CollapsibleContent>
@@ -130,9 +145,16 @@ export function ChatsSidebarGroup() {
       <Collapsible defaultOpen className="group/collapsible">
         <SidebarGroup>
           <SidebarGroupLabel asChild>
-            <CollapsibleTrigger>
-              {t('sidebar.chats')}{' '}
-              <ChevronDown className="ml-auto transition-transform group-data-[state=open]/collapsible:rotate-180" />
+            <CollapsibleTrigger className="flex items-center w-full">
+              {t('sidebar.chats')}
+              <Link
+                to="/chats"
+                className="ml-auto mr-1 p-1 hover:bg-accent rounded"
+                onClick={(e) => e.stopPropagation()}
+              >
+                <Search className="size-4" />
+              </Link>
+              <ChevronDown className="transition-transform group-data-[state=open]/collapsible:rotate-180" />
             </CollapsibleTrigger>
           </SidebarGroupLabel>
           <CollapsibleContent>
@@ -164,9 +186,16 @@ export function ChatsSidebarGroup() {
     <Collapsible defaultOpen className="group/collapsible">
       <SidebarGroup>
         <SidebarGroupLabel asChild>
-          <CollapsibleTrigger>
-            {t('sidebar.chats')}{' '}
-            <ChevronDown className="ml-auto transition-transform group-data-[state=open]/collapsible:rotate-180" />
+          <CollapsibleTrigger className="flex items-center w-full">
+            {t('sidebar.chats')}
+            <Link
+              to="/chats"
+              className="ml-auto mr-1 p-1 hover:bg-accent rounded"
+              onClick={(e) => e.stopPropagation()}
+            >
+              <Search className="size-4" />
+            </Link>
+            <ChevronDown className="transition-transform group-data-[state=open]/collapsible:rotate-180" />
           </CollapsibleTrigger>
         </SidebarGroupLabel>
         <CollapsibleContent>

--- a/ayunis-core-frontend/src/widgets/charts/ui/ChartEmptyState.tsx
+++ b/ayunis-core-frontend/src/widgets/charts/ui/ChartEmptyState.tsx
@@ -2,7 +2,7 @@
 import { useTranslation } from 'react-i18next';
 
 export function ChartEmptyState() {
-  const { t } = useTranslation('chats');
+  const { t } = useTranslation('chat');
 
   return (
     <div className="my-2 w-full p-4 text-sm text-muted-foreground">

--- a/ayunis-core-frontend/src/widgets/confirmation-modal/model/ConfirmationProvider.tsx
+++ b/ayunis-core-frontend/src/widgets/confirmation-modal/model/ConfirmationProvider.tsx
@@ -10,7 +10,7 @@ interface ConfirmationProviderProps {
 export function ConfirmationProvider({ children }: ConfirmationProviderProps) {
   const [isOpen, setIsOpen] = useState(false);
   const [options, setOptions] = useState<ConfirmationOptions | null>(null);
-  const cleanupTimeoutsRef = useRef<NodeJS.Timeout[]>([]);
+  const cleanupTimeoutsRef = useRef<ReturnType<typeof setTimeout>[]>([]);
 
   function cancelPendingCleanups() {
     cleanupTimeoutsRef.current.forEach(clearTimeout);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a new /chats page with search and agent filters, backed by updated Threads API supporting query filters, plus client, sidebar, and i18n updates.
> 
> - **Backend (Threads API)**:
>   - Add optional query filters `search` and `agentId` to `ThreadsRepository.findAll`, `FindAllThreadsQuery`, and use-case; implement filtered query (ILIKE title, `agentId`) with conditional relation joins in local repo.
>   - HTTP: accept `search`/`agentId` query params via `FindAllThreadsQueryParamsDto`; wire into `GET /threads`; extend Swagger docs.
> - **Frontend**:
>   - New chats list route `/chats` with loader (fetch threads+agents), UI (`ChatsPage`, `ChatsFilters`, `ChatCard`), and deletion flow (`useDeleteChat`).
>   - Sidebar: add quick link to `/chats`; adapt `useThreads` to new API signature.
>   - i18n: introduce `chat` namespace (migrate chat components); add/update `en/de` locales; adjust keys in chat-related components and widgets.
>   - Minor: chart empty state translation key; confirmation provider typing fix.
> - **Client/OpenAPI**:
>   - Generated client: `threadsControllerFindAll` now accepts params and query keys include filters.
>   - OpenAPI/spec tweaks including additional file types (`docx`, `pptx`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d75677810bb9ad514e3810d9b42a79ea03356890. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->