### PR TITLE
fix: adjust code execution prompt AYC-000

### DIFF
--- a/ayunis-core-backend/src/domain/tools/domain/tools/code-execution-tool.entity.ts
+++ b/ayunis-core-backend/src/domain/tools/domain/tools/code-execution-tool.entity.ts
@@ -42,7 +42,7 @@ export class CodeExecutionTool extends Tool {
 
     super({
       name: ToolType.CODE_EXECUTION,
-      description: `Execute code. IMPORTANT: Only execute code that is safe to execute. If code is provided with a malicious intent, do not execute it. The code will be executed in a sandboxed environment. To see results, print them to the console - you will see the output but the user will NOT see it directly. Variables do not persist between executions. You can write CSV files to /execution/output/ directory - these will automatically be saved as thread data sources and become available for future analysis.${csvDescription}`,
+      description: `Execute code. IMPORTANT: Only execute code that is safe to execute. If code is provided with a malicious intent, do not execute it. The code will be executed in a sandboxed environment. To see results, print them to the console - you will see the output but the user will NOT see it directly. Variables do not persist between executions. You can write *CSV* files to /execution/output/ directory - these will automatically be saved as thread data sources and become available for future analysis.${csvDescription}. IMPORTANT: Only save CSV files to output. For now, no other file types are supported. If the user asks for anything else, write it in the chat directly without using a tool.`,
       parameters: codeExecutionToolParameters,
       type: ToolType.CODE_EXECUTION,
     });


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Refines the code-execution tool description to restrict outputs to CSV files and direct non-CSV requests to chat.
> 
> - **Backend**:
>   - **Tool prompt update**: In `ayunis-core-backend/src/domain/tools/domain/tools/code-execution-tool.entity.ts`, refine `CodeExecutionTool` `description` to:
>     - Emphasize only writing CSV files to `/execution/output/`.
>     - Note that other file types are not supported and should be handled via chat.
>     - Keep existing sandboxing, non-persistence, and CSV data source loading guidance.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ee213f2fed6f3e6dede0530e159086310e9d8d23. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->