### PR TITLE
Admin list pagination and search

### DIFF
--- a/ayunis-core-backend/package-lock.json
+++ b/ayunis-core-backend/package-lock.json
@@ -372,7 +372,6 @@
       "version": "7.26.10",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.26.2",
@@ -2635,7 +2634,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.13.tgz",
       "integrity": "sha512-AvvthqfqrAhNH9dnfmrfKzX5upOdjUVJYFqNSlkmGf64gRaTzlPwz99IHYnVs28qYAybvAlBV+H7pn0saFY4Ig==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -2951,7 +2949,6 @@
     "node_modules/@nestjs-cls/transactional": {
       "version": "3.1.0",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -3094,7 +3091,6 @@
     "node_modules/@nestjs/common": {
       "version": "11.0.20",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "file-type": "20.4.1",
         "iterare": "1.2.1",
@@ -3138,7 +3134,6 @@
       "version": "11.0.20",
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@nuxt/opencollective": "0.4.1",
         "fast-safe-stringify": "2.1.1",
@@ -3234,7 +3229,6 @@
     "node_modules/@nestjs/platform-express": {
       "version": "11.0.20",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cors": "2.8.5",
         "express": "5.1.0",
@@ -3441,7 +3435,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -3463,7 +3456,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.2.0.tgz",
       "integrity": "sha512-qRkLWiUEZNAmYapZ7KGS5C4OmBLcP/H2foXeOEaowYCR0wi89fHejrfYfbuLVCMLp/dWZXKvQusdbUEZjERfwQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
       },
@@ -3476,7 +3468,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.2.0.tgz",
       "integrity": "sha512-FuabnnUm8LflnieVxs6eP7Z383hgQU4W1e3KJS6aOG3RxWxcHyBxH8fDMHNgu/gFx/M2jvTOW/4/PHhLz6bjWw==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
@@ -3492,7 +3483,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.208.0.tgz",
       "integrity": "sha512-Eju0L4qWcQS+oXxi6pgh7zvE2byogAkcsVv0OjHF/97iOz1N/aKE6etSGowYkie+YA1uo6DNwdSxaaNnLvcRlA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/api-logs": "0.208.0",
         "import-in-the-middle": "^2.0.0",
@@ -3896,7 +3886,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.2.0.tgz",
       "integrity": "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.2.0",
         "@opentelemetry/semantic-conventions": "^1.29.0"
@@ -3913,7 +3902,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.2.0.tgz",
       "integrity": "sha512-xWQgL0Bmctsalg6PaXExmzdedSp3gyKV8mQBwK/j9VGdCDu2fmXIb2gAehBKbkXCpJ4HPkgv3QfoJWRT4dHWbw==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.2.0",
         "@opentelemetry/resources": "2.2.0",
@@ -3931,7 +3919,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.38.0.tgz",
       "integrity": "sha512-kocjix+/sSggfJhwXqClZ3i9Y/MI0fp7b+g7kCRm6psy2dsf8uApTRclwG18h8Avm7C9+fnt+O36PspJ/OzoWg==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=14"
       }
@@ -4725,7 +4712,6 @@
       "version": "0.6.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@swc/counter": "^0.1.3",
         "@xhmikosr/bin-wrapper": "^13.0.5",
@@ -4790,7 +4776,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@swc/counter": "^0.1.3",
         "@swc/types": "^0.1.21"
@@ -5134,7 +5119,6 @@
       "version": "9.6.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -5160,7 +5144,6 @@
       "version": "5.0.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^5.0.0",
@@ -5316,7 +5299,6 @@
     "node_modules/@types/node": {
       "version": "22.15.3",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -5449,6 +5431,7 @@
       "resolved": "https://registry.npmjs.org/@types/through/-/through-0.0.33.tgz",
       "integrity": "sha512-HsJ+z3QuETzP3cswwtzt2vEIiHBk/dCcHGhbmG5X3ecnwFD/lPrMpliGXxSCg03L9AhrdwA4Oz/qfspkDW+xGQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -5516,7 +5499,6 @@
       "version": "8.30.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.30.1",
         "@typescript-eslint/types": "8.30.1",
@@ -6409,7 +6391,6 @@
     "node_modules/acorn": {
       "version": "8.15.0",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6490,7 +6471,6 @@
     "node_modules/ajv": {
       "version": "8.17.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -7122,7 +7102,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -7420,7 +7399,6 @@
       "version": "4.0.3",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "readdirp": "^4.0.1"
       },
@@ -7466,13 +7444,11 @@
     },
     "node_modules/class-transformer": {
       "version": "0.5.1",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/class-validator": {
       "version": "0.14.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/validator": "^13.11.8",
         "libphonenumber-js": "^1.10.53",
@@ -8677,7 +8653,6 @@
       "version": "9.33.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -8737,7 +8712,6 @@
       "version": "10.1.2",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -8991,7 +8965,6 @@
     "node_modules/express": {
       "version": "5.1.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.0",
@@ -10852,7 +10825,6 @@
       "version": "29.7.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -11591,7 +11563,6 @@
       "version": "1.4.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 10.16.0"
       }
@@ -13105,7 +13076,6 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
       "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16"
       }
@@ -13124,7 +13094,6 @@
     "node_modules/nestjs-cls": {
       "version": "6.0.1",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -13842,7 +13811,6 @@
     "node_modules/passport": {
       "version": "0.7.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "passport-strategy": "1.x.x",
         "pause": "0.0.1",
@@ -13987,7 +13955,6 @@
     "node_modules/pg": {
       "version": "8.16.3",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.9.1",
         "pg-pool": "^3.10.1",
@@ -14222,7 +14189,6 @@
     "node_modules/prettier": {
       "version": "3.6.2",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -14477,8 +14443,7 @@
     },
     "node_modules/reflect-metadata": {
       "version": "0.2.2",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
@@ -14747,7 +14712,6 @@
     "node_modules/rxjs": {
       "version": "7.8.2",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -14864,7 +14828,6 @@
       "version": "6.12.6",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -16185,7 +16148,6 @@
       "version": "10.9.2",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -16456,7 +16418,6 @@
       "resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.3.28.tgz",
       "integrity": "sha512-6GH7wXhtfq2D33ZuRXYwIsl/qM5685WZcODZb7noOOcRMteM9KF2x2ap3H0EBjnSV0VO4gNAfJT5Ukp0PkOlvg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@sqltools/formatter": "^1.2.5",
         "ansis": "^4.2.0",
@@ -16658,7 +16619,6 @@
       "version": "5.8.3",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -17091,7 +17051,6 @@
       "integrity": "sha512-HU1JOuV1OavsZ+mfigY0j8d1TgQgbZ6M+J75zDkpEAwYeXjWSqrGJtgnPblJjd/mAyTNQ7ygw0MiKOn6etz8yw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -17367,7 +17326,6 @@
     "node_modules/winston": {
       "version": "3.17.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@colors/colors": "^1.6.0",
         "@dabh/diagnostics": "^2.0.2",
@@ -17712,7 +17670,6 @@
     "node_modules/zod": {
       "version": "3.24.3",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/ayunis-core-backend/src/domain/models/application/use-cases/delete-permitted-model/delete-permitted-model.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/delete-permitted-model/delete-permitted-model.use-case.ts
@@ -179,17 +179,18 @@ export class DeletePermittedModelUseCase {
     orgId: UUID,
     model: PermittedEmbeddingModel,
   ): Promise<void> {
-    const users = await this.findUsersByOrgIdUseCase.execute(
-      new FindUsersByOrgIdQuery(orgId),
+    const paginatedUsers = await this.findUsersByOrgIdUseCase.execute(
+      new FindUsersByOrgIdQuery({ orgId }),
     );
 
-    for (const user of users) {
-      const threads = await this.findAllThreadsUseCase.execute(
-        new FindAllThreadsQuery(user.id, {
-          withSources: true,
+    for (const user of paginatedUsers.data) {
+      const paginatedThreads = await this.findAllThreadsUseCase.execute(
+        new FindAllThreadsQuery({
+          userId: user.id,
+          options: { withSources: true },
         }),
       );
-      for (const thread of threads) {
+      for (const thread of paginatedThreads.data) {
         if (thread.sourceAssignments && thread.sourceAssignments.length > 0) {
           for (const sourceAssignment of thread.sourceAssignments) {
             await this.deleteSourceUseCase.execute(

--- a/ayunis-core-backend/src/domain/threads/application/ports/threads.repository.ts
+++ b/ayunis-core-backend/src/domain/threads/application/ports/threads.repository.ts
@@ -1,6 +1,7 @@
 import { SourceAssignment } from '../../domain/thread-source-assignment.entity';
 import { Thread } from '../../domain/thread.entity';
 import { UUID } from 'crypto';
+import { Paginated } from 'src/common/pagination';
 
 export interface ThreadsFindAllOptions {
   withSources?: boolean;
@@ -13,6 +14,11 @@ export interface ThreadsFindAllFilters {
   agentId?: string;
 }
 
+export interface ThreadsFindAllPaginationOptions {
+  limit?: number;
+  offset?: number;
+}
+
 export abstract class ThreadsRepository {
   abstract create(thread: Thread): Promise<Thread>;
   abstract findOne(id: UUID, userId: UUID): Promise<Thread | null>;
@@ -21,6 +27,12 @@ export abstract class ThreadsRepository {
     options?: ThreadsFindAllOptions,
     filters?: ThreadsFindAllFilters,
   ): Promise<Thread[]>;
+  abstract findAllPaginated(
+    userId: UUID,
+    options?: ThreadsFindAllOptions,
+    filters?: ThreadsFindAllFilters,
+    pagination?: ThreadsFindAllPaginationOptions,
+  ): Promise<Paginated<Thread>>;
   abstract findAllByModel(
     modelId: UUID,
     options?: ThreadsFindAllOptions,

--- a/ayunis-core-backend/src/domain/threads/application/use-cases/find-all-threads/find-all-threads.query.ts
+++ b/ayunis-core-backend/src/domain/threads/application/use-cases/find-all-threads/find-all-threads.query.ts
@@ -1,17 +1,39 @@
 import { UUID } from 'crypto';
 
 export class FindAllThreadsQuery {
-  constructor(
-    public readonly userId: UUID,
-    public readonly options?: {
+  public readonly userId: UUID;
+  public readonly options?: {
+    withSources?: boolean;
+    withMessages?: boolean;
+    withAgent?: boolean;
+    withModel?: boolean;
+  };
+  public readonly filters?: {
+    search?: string;
+    agentId?: string;
+  };
+  public readonly limit: number;
+  public readonly offset: number;
+
+  constructor(params: {
+    userId: UUID;
+    options?: {
       withSources?: boolean;
       withMessages?: boolean;
       withAgent?: boolean;
       withModel?: boolean;
-    },
-    public readonly filters?: {
+    };
+    filters?: {
       search?: string;
       agentId?: string;
-    },
-  ) {}
+    };
+    limit?: number;
+    offset?: number;
+  }) {
+    this.userId = params.userId;
+    this.options = params.options;
+    this.filters = params.filters;
+    this.limit = params.limit ?? 25;
+    this.offset = params.offset ?? 0;
+  }
 }

--- a/ayunis-core-backend/src/domain/threads/application/use-cases/find-all-threads/find-all-threads.use-case.ts
+++ b/ayunis-core-backend/src/domain/threads/application/use-cases/find-all-threads/find-all-threads.use-case.ts
@@ -2,6 +2,7 @@ import { Injectable, Logger } from '@nestjs/common';
 import { Thread } from '../../../domain/thread.entity';
 import { ThreadsRepository } from '../../ports/threads.repository';
 import { FindAllThreadsQuery } from './find-all-threads.query';
+import { Paginated } from 'src/common/pagination';
 
 @Injectable()
 export class FindAllThreadsUseCase {
@@ -9,16 +10,22 @@ export class FindAllThreadsUseCase {
 
   constructor(private readonly threadsRepository: ThreadsRepository) {}
 
-  async execute(query: FindAllThreadsQuery): Promise<Thread[]> {
+  async execute(query: FindAllThreadsQuery): Promise<Paginated<Thread>> {
     this.logger.log('findAll', {
       userId: query.userId,
       filters: query.filters,
+      limit: query.limit,
+      offset: query.offset,
     });
     try {
-      return await this.threadsRepository.findAll(
+      return await this.threadsRepository.findAllPaginated(
         query.userId,
         query.options,
         query.filters,
+        {
+          limit: query.limit,
+          offset: query.offset,
+        },
       );
     } catch (error) {
       this.logger.error('Failed to find all threads', {

--- a/ayunis-core-backend/src/domain/threads/infrastructure/persistence/local/local-threads.repository.ts
+++ b/ayunis-core-backend/src/domain/threads/infrastructure/persistence/local/local-threads.repository.ts
@@ -2,6 +2,7 @@ import { Thread } from 'src/domain/threads/domain/thread.entity';
 import {
   ThreadsFindAllFilters,
   ThreadsFindAllOptions,
+  ThreadsFindAllPaginationOptions,
   ThreadsRepository,
 } from 'src/domain/threads/application/ports/threads.repository';
 import { Logger, Injectable } from '@nestjs/common';
@@ -14,6 +15,7 @@ import { ThreadNotFoundError } from 'src/domain/threads/application/threads.erro
 import { SourceAssignment } from 'src/domain/threads/domain/thread-source-assignment.entity';
 import { ThreadSourceAssignmentMapper } from './mappers/thread-source-assignment.mapper';
 import { ThreadSourceAssignmentRecord } from './schema/thread-source-assignment.record';
+import { Paginated } from 'src/common/pagination';
 
 @Injectable()
 export class LocalThreadsRepository extends ThreadsRepository {
@@ -121,6 +123,70 @@ export class LocalThreadsRepository extends ThreadsRepository {
 
     const threadEntities = await queryBuilder.getMany();
     return threadEntities.map((entity) => this.threadMapper.toDomain(entity));
+  }
+
+  async findAllPaginated(
+    userId: UUID,
+    options?: ThreadsFindAllOptions,
+    filters?: ThreadsFindAllFilters,
+    pagination?: ThreadsFindAllPaginationOptions,
+  ): Promise<Paginated<Thread>> {
+    this.logger.log('findAllPaginated', { userId, filters, pagination });
+
+    const limit = pagination?.limit ?? 25;
+    const offset = pagination?.offset ?? 0;
+
+    const queryBuilder = this.threadRepository
+      .createQueryBuilder('thread')
+      .where('thread.userId = :userId', { userId });
+
+    if (filters?.search) {
+      queryBuilder.andWhere('thread.title ILIKE :search', {
+        search: `%${filters.search}%`,
+      });
+    }
+
+    if (filters?.agentId) {
+      queryBuilder.andWhere('thread.agentId = :agentId', {
+        agentId: filters.agentId,
+      });
+    }
+
+    // Add relations based on options
+    if (options?.withMessages) {
+      queryBuilder.leftJoinAndSelect('thread.messages', 'messages');
+    }
+    if (options?.withSources) {
+      queryBuilder.leftJoinAndSelect(
+        'thread.sourceAssignments',
+        'sourceAssignments',
+      );
+      queryBuilder.leftJoinAndSelect('sourceAssignments.source', 'source');
+    }
+    if (options?.withModel) {
+      queryBuilder.leftJoinAndSelect('thread.model', 'model');
+    }
+
+    // Order by most recent first
+    queryBuilder.orderBy('thread.updatedAt', 'DESC');
+
+    // Apply pagination
+    queryBuilder.skip(offset).take(limit);
+
+    const [threadEntities, total] = await queryBuilder.getManyAndCount();
+
+    this.logger.debug('Found threads (paginated)', {
+      userId,
+      count: threadEntities.length,
+      total,
+    });
+
+    return new Paginated({
+      data: threadEntities.map((entity) => this.threadMapper.toDomain(entity)),
+      limit,
+      offset,
+      total,
+    });
   }
 
   async findAllByModel(

--- a/ayunis-core-backend/src/domain/threads/presenters/http/dto/get-threads-response-item.dto.ts
+++ b/ayunis-core-backend/src/domain/threads/presenters/http/dto/get-threads-response-item.dto.ts
@@ -13,6 +13,7 @@ import {
   ToolResultMessageContentResponseDto,
 } from './get-thread-response.dto/message-response.dto';
 import { ModelResponseDto } from './get-thread-response.dto/model-response-dto';
+import { PaginationDto } from 'src/common/pagination';
 
 @ApiExtraModels(
   UserMessageResponseDto,
@@ -55,4 +56,18 @@ export class GetThreadsResponseDtoItem {
     example: false,
   })
   isAnonymous: boolean;
+}
+
+export class ThreadsListResponseDto {
+  @ApiProperty({
+    description: 'List of threads',
+    type: [GetThreadsResponseDtoItem],
+  })
+  threads: GetThreadsResponseDtoItem[];
+
+  @ApiProperty({
+    description: 'Pagination metadata',
+    type: PaginationDto,
+  })
+  pagination: PaginationDto;
 }

--- a/ayunis-core-backend/src/domain/threads/presenters/http/mappers/get-threads.mapper.ts
+++ b/ayunis-core-backend/src/domain/threads/presenters/http/mappers/get-threads.mapper.ts
@@ -1,6 +1,10 @@
 import { Injectable } from '@nestjs/common';
 import { Thread } from '../../../domain/thread.entity';
-import { GetThreadsResponseDtoItem } from '../dto/get-threads-response-item.dto';
+import {
+  GetThreadsResponseDtoItem,
+  ThreadsListResponseDto,
+} from '../dto/get-threads-response-item.dto';
+import { Paginated } from 'src/common/pagination';
 
 @Injectable()
 export class GetThreadsDtoMapper {
@@ -16,5 +20,16 @@ export class GetThreadsDtoMapper {
 
   toDtoArray(threads: Thread[]): GetThreadsResponseDtoItem[] {
     return threads.map((thread) => this.toDto(thread));
+  }
+
+  toListDto(paginatedThreads: Paginated<Thread>): ThreadsListResponseDto {
+    return {
+      threads: paginatedThreads.data.map((thread) => this.toDto(thread)),
+      pagination: {
+        limit: paginatedThreads.limit,
+        offset: paginatedThreads.offset,
+        total: paginatedThreads.total,
+      },
+    };
   }
 }

--- a/ayunis-core-backend/src/iam/invites/application/ports/invites.repository.ts
+++ b/ayunis-core-backend/src/iam/invites/application/ports/invites.repository.ts
@@ -1,12 +1,23 @@
 import { Injectable } from '@nestjs/common';
 import { UUID } from 'crypto';
 import { Invite } from '../../domain/invite.entity';
+import { Paginated } from 'src/common/pagination';
+
+export interface FindByOrgIdOptions {
+  search?: string;
+  limit?: number;
+  offset?: number;
+}
 
 @Injectable()
 export abstract class InvitesRepository {
   abstract create(invite: Invite): Promise<void>;
   abstract findOne(id: UUID): Promise<Invite | null>;
   abstract findByOrgId(orgId: UUID): Promise<Invite[]>;
+  abstract findByOrgIdPaginated(
+    orgId: UUID,
+    options?: FindByOrgIdOptions,
+  ): Promise<Paginated<Invite>>;
   abstract findOneByEmail(email: string): Promise<Invite | null>;
   abstract accept(id: UUID): Promise<void>;
   abstract delete(id: UUID): Promise<void>;

--- a/ayunis-core-backend/src/iam/invites/application/use-cases/get-invites-by-org/get-invites-by-org.query.ts
+++ b/ayunis-core-backend/src/iam/invites/application/use-cases/get-invites-by-org/get-invites-by-org.query.ts
@@ -4,14 +4,23 @@ export class GetInvitesByOrgQuery {
   public readonly orgId: UUID;
   public readonly requestingUserId: UUID;
   public readonly onlyOpen: boolean;
+  public readonly search?: string;
+  public readonly limit: number;
+  public readonly offset: number;
 
   constructor(params: {
     orgId: UUID;
     requestingUserId: UUID;
     onlyOpen?: boolean;
+    search?: string;
+    limit?: number;
+    offset?: number;
   }) {
     this.orgId = params.orgId;
     this.requestingUserId = params.requestingUserId;
     this.onlyOpen = params.onlyOpen ?? false;
+    this.search = params.search;
+    this.limit = params.limit ?? 25;
+    this.offset = params.offset ?? 0;
   }
 }

--- a/ayunis-core-backend/src/iam/invites/application/use-cases/get-invites-by-org/get-invites-by-org.use-case.ts
+++ b/ayunis-core-backend/src/iam/invites/application/use-cases/get-invites-by-org/get-invites-by-org.use-case.ts
@@ -7,6 +7,7 @@ import { ApplicationError } from 'src/common/errors/base.error';
 import { ContextService } from 'src/common/context/services/context.service';
 import { UserRole } from 'src/iam/users/domain/value-objects/role.object';
 import { SystemRole } from 'src/iam/users/domain/value-objects/system-role.enum';
+import { Paginated } from 'src/common/pagination';
 
 @Injectable()
 export class GetInvitesByOrgUseCase {
@@ -17,11 +18,14 @@ export class GetInvitesByOrgUseCase {
     private readonly contextService: ContextService,
   ) {}
 
-  async execute(query: GetInvitesByOrgQuery): Promise<Invite[]> {
+  async execute(query: GetInvitesByOrgQuery): Promise<Paginated<Invite>> {
     try {
       this.logger.log('execute', {
         orgId: query.orgId,
         requestingUserId: query.requestingUserId,
+        search: query.search,
+        limit: query.limit,
+        offset: query.offset,
       });
 
       const orgId = this.contextService.get('orgId');
@@ -33,20 +37,34 @@ export class GetInvitesByOrgUseCase {
         throw new UnauthorizedInviteAccessError();
       }
 
-      let invites = await this.invitesRepository.findByOrgId(query.orgId);
+      const paginatedInvites =
+        await this.invitesRepository.findByOrgIdPaginated(query.orgId, {
+          search: query.search,
+          limit: query.limit,
+          offset: query.offset,
+        });
+
+      // Filter only open invites if requested
       if (query.onlyOpen) {
-        invites = invites.filter(
+        const filteredData = paginatedInvites.data.filter(
           (invite) =>
             invite.acceptedAt === null || invite.acceptedAt === undefined,
         );
+        return new Paginated({
+          data: filteredData,
+          limit: paginatedInvites.limit,
+          offset: paginatedInvites.offset,
+          total: filteredData.length,
+        });
       }
 
       this.logger.debug('Found invites', {
         orgId: query.orgId,
-        count: invites.length,
+        count: paginatedInvites.data.length,
+        total: paginatedInvites.total,
       });
 
-      return invites;
+      return paginatedInvites;
     } catch (error) {
       if (error instanceof ApplicationError) {
         throw error;

--- a/ayunis-core-backend/src/iam/invites/presenters/http/dtos/get-invites-query-params.dto.ts
+++ b/ayunis-core-backend/src/iam/invites/presenters/http/dtos/get-invites-query-params.dto.ts
@@ -1,20 +1,18 @@
 import { ApiPropertyOptional } from '@nestjs/swagger';
-import { IsOptional, IsString, IsUUID, IsInt, Min, Max } from 'class-validator';
+import { IsOptional, IsString, IsInt, Min, Max } from 'class-validator';
 import { Type } from 'class-transformer';
 
-export class FindAllThreadsQueryParamsDto {
-  @ApiPropertyOptional({ description: 'Search threads by title' })
+export class GetInvitesQueryParamsDto {
+  @ApiPropertyOptional({
+    description: 'Search invites by email',
+    example: 'user@example.com',
+  })
   @IsOptional()
   @IsString()
   search?: string;
 
-  @ApiPropertyOptional({ description: 'Filter threads by agent ID' })
-  @IsOptional()
-  @IsUUID()
-  agentId?: string;
-
   @ApiPropertyOptional({
-    description: 'Maximum number of threads to return',
+    description: 'Maximum number of invites to return',
     example: 25,
     default: 25,
     minimum: 1,
@@ -28,7 +26,7 @@ export class FindAllThreadsQueryParamsDto {
   limit?: number;
 
   @ApiPropertyOptional({
-    description: 'Number of threads to skip before collecting results',
+    description: 'Number of invites to skip before collecting results',
     example: 0,
     default: 0,
     minimum: 0,

--- a/ayunis-core-backend/src/iam/invites/presenters/http/dtos/invite-response.dto.ts
+++ b/ayunis-core-backend/src/iam/invites/presenters/http/dtos/invite-response.dto.ts
@@ -1,6 +1,7 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { UUID } from 'crypto';
 import { UserRole } from '../../../../users/domain/value-objects/role.object';
+import { PaginationDto } from 'src/common/pagination';
 
 export enum InviteStatus {
   PENDING = 'pending',
@@ -84,4 +85,18 @@ export class AcceptInviteResponseDto {
     format: 'uuid',
   })
   orgId: string;
+}
+
+export class InvitesListResponseDto {
+  @ApiProperty({
+    description: 'List of invites',
+    type: [InviteResponseDto],
+  })
+  invites: InviteResponseDto[];
+
+  @ApiProperty({
+    description: 'Pagination metadata',
+    type: PaginationDto,
+  })
+  pagination: PaginationDto;
 }

--- a/ayunis-core-backend/src/iam/invites/presenters/http/mappers/invite-response.mapper.ts
+++ b/ayunis-core-backend/src/iam/invites/presenters/http/mappers/invite-response.mapper.ts
@@ -5,8 +5,10 @@ import {
   InviteStatus,
   InviteDetailResponseDto,
   AcceptInviteResponseDto,
+  InvitesListResponseDto,
 } from '../dtos/invite-response.dto';
 import { InviteWithOrgDetails } from '../../../application/use-cases/get-invite-by-token/get-invite-by-token.use-case';
+import { Paginated } from 'src/common/pagination';
 
 @Injectable()
 export class InviteResponseMapper {
@@ -26,6 +28,17 @@ export class InviteResponseMapper {
 
   toDtoArray(invites: Invite[]): InviteResponseDto[] {
     return invites.map((invite) => this.toDto(invite));
+  }
+
+  toListDto(paginatedInvites: Paginated<Invite>): InvitesListResponseDto {
+    return {
+      invites: paginatedInvites.data.map((invite) => this.toDto(invite)),
+      pagination: {
+        limit: paginatedInvites.limit,
+        offset: paginatedInvites.offset,
+        total: paginatedInvites.total,
+      },
+    };
   }
 
   toDetailDto(inviteWithOrg: InviteWithOrgDetails): InviteDetailResponseDto {

--- a/ayunis-core-backend/src/iam/orgs/application/ports/orgs.repository.ts
+++ b/ayunis-core-backend/src/iam/orgs/application/ports/orgs.repository.ts
@@ -1,11 +1,21 @@
 import { Org } from 'src/iam/orgs/domain/org.entity';
 import { UUID } from 'crypto';
+import { Paginated } from 'src/common/pagination';
+
+export interface FindAllForSuperAdminOptions {
+  search?: string;
+  limit?: number;
+  offset?: number;
+}
 
 export abstract class OrgsRepository {
   abstract findById(id: UUID): Promise<Org>;
   abstract findByUserId(userId: UUID): Promise<Org>;
   abstract findAllIds(): Promise<UUID[]>;
   abstract findAllForSuperAdmin(): Promise<Org[]>;
+  abstract findAllForSuperAdminPaginated(
+    options?: FindAllForSuperAdminOptions,
+  ): Promise<Paginated<Org>>;
   abstract create(org: Org): Promise<Org>;
   abstract update(org: Org): Promise<Org>;
   abstract delete(id: UUID): Promise<void>;

--- a/ayunis-core-backend/src/iam/orgs/application/use-cases/super-admin-get-all-orgs/super-admin-get-all-orgs.query.ts
+++ b/ayunis-core-backend/src/iam/orgs/application/use-cases/super-admin-get-all-orgs/super-admin-get-all-orgs.query.ts
@@ -1,0 +1,11 @@
+export class SuperAdminGetAllOrgsQuery {
+  public readonly search?: string;
+  public readonly limit: number;
+  public readonly offset: number;
+
+  constructor(params?: { search?: string; limit?: number; offset?: number }) {
+    this.search = params?.search;
+    this.limit = params?.limit ?? 25;
+    this.offset = params?.offset ?? 0;
+  }
+}

--- a/ayunis-core-backend/src/iam/orgs/application/use-cases/super-admin-get-all-orgs/super-admin-get-all-orgs.use-case.ts
+++ b/ayunis-core-backend/src/iam/orgs/application/use-cases/super-admin-get-all-orgs/super-admin-get-all-orgs.use-case.ts
@@ -4,6 +4,8 @@ import { OrgsRepository } from '../../ports/orgs.repository';
 import { ContextService } from 'src/common/context/services/context.service';
 import { SystemRole } from 'src/iam/users/domain/value-objects/system-role.enum';
 import { OrgUnauthorizedError } from '../../orgs.errors';
+import { SuperAdminGetAllOrgsQuery } from './super-admin-get-all-orgs.query';
+import { Paginated } from 'src/common/pagination';
 
 @Injectable()
 export class SuperAdminGetAllOrgsUseCase {
@@ -14,8 +16,12 @@ export class SuperAdminGetAllOrgsUseCase {
     private readonly contextService: ContextService,
   ) {}
 
-  async execute(): Promise<Org[]> {
-    this.logger.log('superAdminGetAllOrgs', {});
+  async execute(query: SuperAdminGetAllOrgsQuery): Promise<Paginated<Org>> {
+    this.logger.log('superAdminGetAllOrgs', {
+      search: query.search,
+      limit: query.limit,
+      offset: query.offset,
+    });
 
     const systemRole = this.contextService.get('systemRole');
     if (systemRole !== SystemRole.SUPER_ADMIN) {
@@ -25,6 +31,10 @@ export class SuperAdminGetAllOrgsUseCase {
       throw new OrgUnauthorizedError('Super admin privileges required');
     }
 
-    return this.orgsRepository.findAllForSuperAdmin();
+    return this.orgsRepository.findAllForSuperAdminPaginated({
+      search: query.search,
+      limit: query.limit,
+      offset: query.offset,
+    });
   }
 }

--- a/ayunis-core-backend/src/iam/orgs/presenters/http/dtos/get-orgs-query-params.dto.ts
+++ b/ayunis-core-backend/src/iam/orgs/presenters/http/dtos/get-orgs-query-params.dto.ts
@@ -1,20 +1,18 @@
 import { ApiPropertyOptional } from '@nestjs/swagger';
-import { IsOptional, IsString, IsUUID, IsInt, Min, Max } from 'class-validator';
+import { IsOptional, IsString, IsInt, Min, Max } from 'class-validator';
 import { Type } from 'class-transformer';
 
-export class FindAllThreadsQueryParamsDto {
-  @ApiPropertyOptional({ description: 'Search threads by title' })
+export class GetOrgsQueryParamsDto {
+  @ApiPropertyOptional({
+    description: 'Search organizations by name',
+    example: 'Acme',
+  })
   @IsOptional()
   @IsString()
   search?: string;
 
-  @ApiPropertyOptional({ description: 'Filter threads by agent ID' })
-  @IsOptional()
-  @IsUUID()
-  agentId?: string;
-
   @ApiPropertyOptional({
-    description: 'Maximum number of threads to return',
+    description: 'Maximum number of organizations to return',
     example: 25,
     default: 25,
     minimum: 1,
@@ -28,7 +26,7 @@ export class FindAllThreadsQueryParamsDto {
   limit?: number;
 
   @ApiPropertyOptional({
-    description: 'Number of threads to skip before collecting results',
+    description: 'Number of organizations to skip before collecting results',
     example: 0,
     default: 0,
     minimum: 0,

--- a/ayunis-core-backend/src/iam/orgs/presenters/http/dtos/super-admin-org-response.dto.ts
+++ b/ayunis-core-backend/src/iam/orgs/presenters/http/dtos/super-admin-org-response.dto.ts
@@ -1,5 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { UUID } from 'crypto';
+import { PaginationDto } from 'src/common/pagination';
 
 export class SuperAdminOrgResponseDto {
   @ApiProperty({
@@ -29,4 +30,10 @@ export class SuperAdminOrgListResponseDto {
     type: [SuperAdminOrgResponseDto],
   })
   orgs: SuperAdminOrgResponseDto[];
+
+  @ApiProperty({
+    description: 'Pagination metadata',
+    type: PaginationDto,
+  })
+  pagination: PaginationDto;
 }

--- a/ayunis-core-backend/src/iam/orgs/presenters/http/mappers/super-admin-org-response-dto.mapper.ts
+++ b/ayunis-core-backend/src/iam/orgs/presenters/http/mappers/super-admin-org-response-dto.mapper.ts
@@ -4,6 +4,7 @@ import {
   SuperAdminOrgListResponseDto,
   SuperAdminOrgResponseDto,
 } from '../dtos/super-admin-org-response.dto';
+import { Paginated } from 'src/common/pagination';
 
 @Injectable()
 export class SuperAdminOrgResponseDtoMapper {
@@ -15,9 +16,14 @@ export class SuperAdminOrgResponseDtoMapper {
     };
   }
 
-  toListDto(orgs: Org[]): SuperAdminOrgListResponseDto {
+  toListDto(paginatedOrgs: Paginated<Org>): SuperAdminOrgListResponseDto {
     return {
-      orgs: orgs.map((org) => this.toDto(org)),
+      orgs: paginatedOrgs.data.map((org) => this.toDto(org)),
+      pagination: {
+        limit: paginatedOrgs.limit,
+        offset: paginatedOrgs.offset,
+        total: paginatedOrgs.total,
+      },
     };
   }
 }

--- a/ayunis-core-backend/src/iam/orgs/presenters/http/super-admin-orgs.controller.ts
+++ b/ayunis-core-backend/src/iam/orgs/presenters/http/super-admin-orgs.controller.ts
@@ -7,6 +7,7 @@ import {
   Logger,
   Param,
   Post,
+  Query,
 } from '@nestjs/common';
 import {
   ApiBadRequestResponse,
@@ -20,11 +21,13 @@ import {
   ApiTags,
 } from '@nestjs/swagger';
 import { SuperAdminGetAllOrgsUseCase } from '../../application/use-cases/super-admin-get-all-orgs/super-admin-get-all-orgs.use-case';
+import { SuperAdminGetAllOrgsQuery } from '../../application/use-cases/super-admin-get-all-orgs/super-admin-get-all-orgs.query';
 import { SuperAdminOrgResponseDtoMapper } from './mappers/super-admin-org-response-dto.mapper';
 import {
   SuperAdminOrgListResponseDto,
   SuperAdminOrgResponseDto,
 } from './dtos/super-admin-org-response.dto';
+import { GetOrgsQueryParamsDto } from './dtos/get-orgs-query-params.dto';
 import { UUID } from 'crypto';
 import { FindOrgByIdQuery } from '../../application/use-cases/find-org-by-id/find-org-by-id.query';
 import { FindOrgByIdUseCase } from '../../application/use-cases/find-org-by-id/find-org-by-id.use-case';
@@ -93,6 +96,12 @@ export class SuperAdminOrgsController {
     description: 'The requester is not a super admin.',
   })
   @ApiQuery({
+    name: 'search',
+    required: false,
+    type: String,
+    description: 'Search organizations by name.',
+  })
+  @ApiQuery({
     name: 'limit',
     required: false,
     type: Number,
@@ -106,10 +115,18 @@ export class SuperAdminOrgsController {
     description: 'Number of organizations to skip before collecting results.',
     example: 0,
   })
-  async getAllOrgs(): Promise<SuperAdminOrgListResponseDto> {
-    const orgs = await this.superAdminGetAllOrgsUseCase.execute();
+  async getAllOrgs(
+    @Query() queryParams: GetOrgsQueryParamsDto,
+  ): Promise<SuperAdminOrgListResponseDto> {
+    const paginatedOrgs = await this.superAdminGetAllOrgsUseCase.execute(
+      new SuperAdminGetAllOrgsQuery({
+        search: queryParams.search,
+        limit: queryParams.limit,
+        offset: queryParams.offset,
+      }),
+    );
 
-    return this.superAdminOrgResponseDtoMapper.toListDto(orgs);
+    return this.superAdminOrgResponseDtoMapper.toListDto(paginatedOrgs);
   }
 
   @Get(':id')

--- a/ayunis-core-backend/src/iam/subscriptions/application/use-cases/create-subscription/create-subscription.use-case.ts
+++ b/ayunis-core-backend/src/iam/subscriptions/application/use-cases/create-subscription/create-subscription.use-case.ts
@@ -79,7 +79,7 @@ export class CreateSubscriptionUseCase {
         );
       }
 
-      const [invites, users] = await Promise.all([
+      const [paginatedInvites, paginatedUsers] = await Promise.all([
         this.getInvitesByOrgUseCase.execute(
           new GetInvitesByOrgQuery({
             orgId: command.orgId,
@@ -88,17 +88,20 @@ export class CreateSubscriptionUseCase {
           }),
         ),
         this.findUsersByOrgIdUseCase.execute(
-          new FindUsersByOrgIdQuery(command.orgId),
+          new FindUsersByOrgIdQuery({ orgId: command.orgId }),
         ),
       ]);
-      if (invites.length + users.length > command.noOfSeats) {
+      const invitesCount =
+        paginatedInvites.total ?? paginatedInvites.data.length;
+      const usersCount = paginatedUsers.total ?? paginatedUsers.data.length;
+      if (invitesCount + usersCount > command.noOfSeats) {
         this.logger.warn('Too many used seats', {
           orgId: command.orgId,
-          openInvites: invites.length,
+          openInvites: invitesCount,
         });
         throw new TooManyUsedSeatsError({
           orgId: command.orgId,
-          openInvites: invites.length,
+          openInvites: invitesCount,
         });
       }
 

--- a/ayunis-core-backend/src/iam/subscriptions/application/use-cases/update-seats/update-seats.use-case.ts
+++ b/ayunis-core-backend/src/iam/subscriptions/application/use-cases/update-seats/update-seats.use-case.ts
@@ -79,24 +79,27 @@ export class UpdateSeatsUseCase {
       }
       const subscription = result.subscription;
 
-      const users = await this.findUsersByOrgIdUseCase.execute(
-        new FindUsersByOrgIdQuery(command.orgId),
+      const paginatedUsers = await this.findUsersByOrgIdUseCase.execute(
+        new FindUsersByOrgIdQuery({ orgId: command.orgId }),
       );
-      const openInvites = await this.getInvitesByOrgUseCase.execute(
+      const paginatedOpenInvites = await this.getInvitesByOrgUseCase.execute(
         new GetInvitesByOrgQuery({
           orgId: command.orgId,
           requestingUserId: command.requestingUserId,
           onlyOpen: true,
         }),
       );
-      if (command.noOfSeats < users.length + openInvites.length) {
+      const usersCount = paginatedUsers.total ?? paginatedUsers.data.length;
+      const openInvitesCount =
+        paginatedOpenInvites.total ?? paginatedOpenInvites.data.length;
+      if (command.noOfSeats < usersCount + openInvitesCount) {
         this.logger.warn('Too many used seats', {
           orgId: command.orgId,
-          openInvites: openInvites,
+          openInvites: openInvitesCount,
         });
         throw new TooManyUsedSeatsError({
           orgId: command.orgId,
-          openInvites: openInvites.length,
+          openInvites: openInvitesCount,
         });
       }
 

--- a/ayunis-core-backend/src/iam/users/application/ports/users.repository.ts
+++ b/ayunis-core-backend/src/iam/users/application/ports/users.repository.ts
@@ -1,10 +1,21 @@
 import { User } from '../../domain/user.entity';
 import { UUID } from 'crypto';
+import { Paginated } from 'src/common/pagination';
+
+export interface FindManyByOrgIdOptions {
+  search?: string;
+  limit?: number;
+  offset?: number;
+}
 
 export abstract class UsersRepository {
   abstract findOneById(id: UUID): Promise<User | null>;
   abstract findOneByEmail(email: string): Promise<User | null>;
   abstract findManyByOrgId(orgId: UUID): Promise<User[]>;
+  abstract findManyByOrgIdPaginated(
+    orgId: UUID,
+    options?: FindManyByOrgIdOptions,
+  ): Promise<Paginated<User>>;
   abstract create(user: User): Promise<User>;
   abstract update(user: User): Promise<User>;
   abstract delete(id: UUID): Promise<void>;

--- a/ayunis-core-backend/src/iam/users/application/use-cases/find-users-by-org-id/find-users-by-org-id.query.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/find-users-by-org-id/find-users-by-org-id.query.ts
@@ -1,5 +1,20 @@
 import { UUID } from 'crypto';
 
 export class FindUsersByOrgIdQuery {
-  constructor(public readonly orgId: UUID) {}
+  public readonly orgId: UUID;
+  public readonly search?: string;
+  public readonly limit: number;
+  public readonly offset: number;
+
+  constructor(params: {
+    orgId: UUID;
+    search?: string;
+    limit?: number;
+    offset?: number;
+  }) {
+    this.orgId = params.orgId;
+    this.search = params.search;
+    this.limit = params.limit ?? 25;
+    this.offset = params.offset ?? 0;
+  }
 }

--- a/ayunis-core-backend/src/iam/users/application/use-cases/find-users-by-org-id/find-users-by-org-id.use-case.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/find-users-by-org-id/find-users-by-org-id.use-case.ts
@@ -6,6 +6,7 @@ import { UserRole } from 'src/iam/users/domain/value-objects/role.object';
 import { SystemRole } from 'src/iam/users/domain/value-objects/system-role.enum';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
 import { ContextService } from 'src/common/context/services/context.service';
+import { Paginated } from 'src/common/pagination';
 
 @Injectable()
 export class FindUsersByOrgIdUseCase {
@@ -16,8 +17,13 @@ export class FindUsersByOrgIdUseCase {
     private readonly contextService: ContextService,
   ) {}
 
-  async execute(query: FindUsersByOrgIdQuery): Promise<User[]> {
-    this.logger.log('findManyByOrgId', { orgId: query.orgId });
+  async execute(query: FindUsersByOrgIdQuery): Promise<Paginated<User>> {
+    this.logger.log('findManyByOrgId', {
+      orgId: query.orgId,
+      search: query.search,
+      limit: query.limit,
+      offset: query.offset,
+    });
     const systemRole = this.contextService.get('systemRole');
     const orgRole = this.contextService.get('role');
     if (
@@ -25,6 +31,10 @@ export class FindUsersByOrgIdUseCase {
     ) {
       throw new UnauthorizedAccessError({ orgId: query.orgId });
     }
-    return this.usersRepository.findManyByOrgId(query.orgId);
+    return this.usersRepository.findManyByOrgIdPaginated(query.orgId, {
+      search: query.search,
+      limit: query.limit,
+      offset: query.offset,
+    });
   }
 }

--- a/ayunis-core-backend/src/iam/users/presenters/http/dtos/get-users-query-params.dto.ts
+++ b/ayunis-core-backend/src/iam/users/presenters/http/dtos/get-users-query-params.dto.ts
@@ -1,20 +1,18 @@
 import { ApiPropertyOptional } from '@nestjs/swagger';
-import { IsOptional, IsString, IsUUID, IsInt, Min, Max } from 'class-validator';
+import { IsOptional, IsString, IsInt, Min, Max } from 'class-validator';
 import { Type } from 'class-transformer';
 
-export class FindAllThreadsQueryParamsDto {
-  @ApiPropertyOptional({ description: 'Search threads by title' })
+export class GetUsersQueryParamsDto {
+  @ApiPropertyOptional({
+    description: 'Search users by name or email',
+    example: 'john',
+  })
   @IsOptional()
   @IsString()
   search?: string;
 
-  @ApiPropertyOptional({ description: 'Filter threads by agent ID' })
-  @IsOptional()
-  @IsUUID()
-  agentId?: string;
-
   @ApiPropertyOptional({
-    description: 'Maximum number of threads to return',
+    description: 'Maximum number of users to return',
     example: 25,
     default: 25,
     minimum: 1,
@@ -28,7 +26,7 @@ export class FindAllThreadsQueryParamsDto {
   limit?: number;
 
   @ApiPropertyOptional({
-    description: 'Number of threads to skip before collecting results',
+    description: 'Number of users to skip before collecting results',
     example: 0,
     default: 0,
     minimum: 0,

--- a/ayunis-core-backend/src/iam/users/presenters/http/dtos/user-response.dto.ts
+++ b/ayunis-core-backend/src/iam/users/presenters/http/dtos/user-response.dto.ts
@@ -1,6 +1,7 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { UserRole } from '../../../domain/value-objects/role.object';
 import { UUID } from 'crypto';
+import { PaginationDto } from 'src/common/pagination';
 
 export class UserResponseDto {
   @ApiProperty({
@@ -50,4 +51,10 @@ export class UsersListResponseDto {
     type: [UserResponseDto],
   })
   users: UserResponseDto[];
+
+  @ApiProperty({
+    description: 'Pagination metadata',
+    type: PaginationDto,
+  })
+  pagination: PaginationDto;
 }

--- a/ayunis-core-backend/src/iam/users/presenters/http/mappers/user-response-dto.mapper.ts
+++ b/ayunis-core-backend/src/iam/users/presenters/http/mappers/user-response-dto.mapper.ts
@@ -4,6 +4,7 @@ import {
   UsersListResponseDto,
 } from '../dtos/user-response.dto';
 import { User } from '../../../domain/user.entity';
+import { Paginated } from 'src/common/pagination';
 
 @Injectable()
 export class UserResponseDtoMapper {
@@ -18,9 +19,14 @@ export class UserResponseDtoMapper {
     };
   }
 
-  toListDto(users: User[]): UsersListResponseDto {
+  toListDto(paginatedUsers: Paginated<User>): UsersListResponseDto {
     return {
-      users: users.map((user) => this.toDto(user)),
+      users: paginatedUsers.data.map((user) => this.toDto(user)),
+      pagination: {
+        limit: paginatedUsers.limit,
+        offset: paginatedUsers.offset,
+        total: paginatedUsers.total,
+      },
     };
   }
 }


### PR DESCRIPTION
Add pagination to the user settings for admins (invites and users), the chat list, and the organization list for superadmins, utilizing the common pagination DTO. Also, add search functionality to the superadmin organization list.

---
<a href="https://cursor.com/background-agent?bcId=bc-085f1c46-a322-49d8-9b48-4ecf179af0d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-085f1c46-a322-49d8-9b48-4ecf179af0d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds paginated, searchable list endpoints for threads, org invites, org users (incl. super-admin views), and super-admin orgs, updating repos/use-cases to return `Paginated<T>` with Swagger DTOs.
> 
> - **API/Endpoints**
>   - Threads: `GET /threads` now supports `limit`, `offset`, `search`, `agentId` and returns `ThreadsListResponseDto`.
>   - Invites: `GET /invites` adds `search`, pagination; returns `InvitesListResponseDto`.
>   - Users:
>     - Org users: `GET /users` adds `search`, pagination; returns `UsersListResponseDto`.
>     - Super-admin: `GET /super-admin/users/:orgId` adds `search`, pagination.
>   - Super-admin Orgs: `GET /super-admin/orgs` adds `search`, pagination; returns `SuperAdminOrgListResponseDto`.
> - **Repositories/Use Cases**
>   - Introduce/implement `findAll*Paginated` methods returning `Paginated<T>` for threads, invites, users, orgs.
>   - Update queries/use-cases (e.g., `FindAllThreads`, `GetInvitesByOrg`, `FindUsersByOrgId`, super-admin orgs) to accept `limit/offset/search` and return paginated results.
>   - Mappers/DTOs updated to include `pagination` metadata.
> - **Related logic updates**
>   - Subscription seat checks and permitted-model deletion now use paginated user/invite/thread results and totals.
> - **Tests**
>   - Adjust unit tests to expect `Paginated<T>` responses and pagination fields.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d4433854644baa721a38968788aca9cdc433eefa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->