### PR TITLE
Set title formatting cleanup

### DIFF
--- a/ayunis-core-backend/src/domain/threads/application/use-cases/generate-and-set-thread-title/generate-and-set-thread-title.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/threads/application/use-cases/generate-and-set-thread-title/generate-and-set-thread-title.use-case.spec.ts
@@ -1,0 +1,118 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { GenerateAndSetThreadTitleUseCase } from './generate-and-set-thread-title.use-case';
+import { UpdateThreadTitleUseCase } from '../update-thread-title/update-thread-title.use-case';
+import { GetInferenceUseCase } from 'src/domain/models/application/use-cases/get-inference/get-inference.use-case';
+
+describe('GenerateAndSetThreadTitleUseCase - Markdown Stripping', () => {
+  let useCase: GenerateAndSetThreadTitleUseCase;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        GenerateAndSetThreadTitleUseCase,
+        {
+          provide: UpdateThreadTitleUseCase,
+          useValue: {},
+        },
+        {
+          provide: GetInferenceUseCase,
+          useValue: {},
+        },
+      ],
+    }).compile();
+
+    useCase = module.get<GenerateAndSetThreadTitleUseCase>(
+      GenerateAndSetThreadTitleUseCase,
+    );
+  });
+
+  describe('stripMarkdownFormatting', () => {
+    it('should strip bold formatting with **', () => {
+      const input = '**Turnhalle mieten – Sportverein**';
+      const expected = 'Turnhalle mieten – Sportverein';
+      // @ts-expect-error - accessing private method for testing
+      const result = useCase.stripMarkdownFormatting(input);
+      expect(result).toBe(expected);
+    });
+
+    it('should strip bold formatting with __', () => {
+      const input = '__KI-Unterstützung für Verwaltung__';
+      const expected = 'KI-Unterstützung für Verwaltung';
+      // @ts-expect-error - accessing private method for testing
+      const result = useCase.stripMarkdownFormatting(input);
+      expect(result).toBe(expected);
+    });
+
+    it('should strip italic formatting with *', () => {
+      const input = '*Important Title*';
+      const expected = 'Important Title';
+      // @ts-expect-error - accessing private method for testing
+      const result = useCase.stripMarkdownFormatting(input);
+      expect(result).toBe(expected);
+    });
+
+    it('should strip quotes', () => {
+      const input = '**"Turnhalle mieten – Sportverein"**';
+      const expected = 'Turnhalle mieten – Sportverein';
+      // @ts-expect-error - accessing private method for testing
+      const result = useCase.stripMarkdownFormatting(input);
+      expect(result).toBe(expected);
+    });
+
+    it('should strip inline code', () => {
+      const input = '`Code Title` with text';
+      const expected = 'Code Title with text';
+      // @ts-expect-error - accessing private method for testing
+      const result = useCase.stripMarkdownFormatting(input);
+      expect(result).toBe(expected);
+    });
+
+    it('should strip strikethrough', () => {
+      const input = '~~Old Title~~ New Title';
+      const expected = 'Old Title New Title';
+      // @ts-expect-error - accessing private method for testing
+      const result = useCase.stripMarkdownFormatting(input);
+      expect(result).toBe(expected);
+    });
+
+    it('should strip headers', () => {
+      const input = '## Title Header';
+      const expected = 'Title Header';
+      // @ts-expect-error - accessing private method for testing
+      const result = useCase.stripMarkdownFormatting(input);
+      expect(result).toBe(expected);
+    });
+
+    it('should strip links and keep text', () => {
+      const input = '[Title Link](https://example.com)';
+      const expected = 'Title Link';
+      // @ts-expect-error - accessing private method for testing
+      const result = useCase.stripMarkdownFormatting(input);
+      expect(result).toBe(expected);
+    });
+
+    it('should handle multiple markdown formats', () => {
+      const input = '**"Important"** *Title* with `code`';
+      const expected = 'Important Title with code';
+      // @ts-expect-error - accessing private method for testing
+      const result = useCase.stripMarkdownFormatting(input);
+      expect(result).toBe(expected);
+    });
+
+    it('should clean up extra whitespace', () => {
+      const input = '**Title**   with    extra     spaces';
+      const expected = 'Title with extra spaces';
+      // @ts-expect-error - accessing private method for testing
+      const result = useCase.stripMarkdownFormatting(input);
+      expect(result).toBe(expected);
+    });
+
+    it('should return empty string for input with only markdown', () => {
+      const input = '**""**';
+      const expected = '';
+      // @ts-expect-error - accessing private method for testing
+      const result = useCase.stripMarkdownFormatting(input);
+      expect(result).toBe(expected);
+    });
+  });
+});

--- a/ayunis-core-backend/src/domain/threads/application/use-cases/generate-and-set-thread-title/generate-and-set-thread-title.use-case.ts
+++ b/ayunis-core-backend/src/domain/threads/application/use-cases/generate-and-set-thread-title/generate-and-set-thread-title.use-case.ts
@@ -66,9 +66,13 @@ export class GenerateAndSetThreadTitleUseCase {
       }
 
       // Remove extra spaces and <think>...</think> blocks
-      const title = firstContent.text
+      let title = firstContent.text
         .replace(/<think(ing)?>([\s\S]*?)<\/think(ing)?>/g, '')
         .trim();
+
+      // Strip markdown formatting
+      title = this.stripMarkdownFormatting(title);
+
       if (!title) {
         throw new EmptyTitleResponseError(command.thread.id);
       }
@@ -99,5 +103,34 @@ export class GenerateAndSetThreadTitleUseCase {
       // Don't throw error - just log it
       return null;
     }
+  }
+
+  /**
+   * Strips markdown formatting from text
+   * Removes: bold, italic, code, strikethrough, headers, links, and quotes
+   */
+  private stripMarkdownFormatting(text: string): string {
+    return (
+      text
+        // Remove bold: **text** or __text__
+        .replace(/\*\*(.+?)\*\*/g, '$1')
+        .replace(/__(.+?)__/g, '$1')
+        // Remove italic: *text* or _text_ (but not within words)
+        .replace(/\*(.+?)\*/g, '$1')
+        .replace(/(?<!\w)_(.+?)_(?!\w)/g, '$1')
+        // Remove strikethrough: ~~text~~
+        .replace(/~~(.+?)~~/g, '$1')
+        // Remove inline code: `text`
+        .replace(/`(.+?)`/g, '$1')
+        // Remove headers: # text
+        .replace(/^#{1,6}\s+/gm, '')
+        // Remove links: [text](url) -> text
+        .replace(/\[(.+?)\]\(.+?\)/g, '$1')
+        // Remove quotes
+        .replace(/["""]/g, '')
+        // Clean up any extra whitespace
+        .replace(/\s+/g, ' ')
+        .trim()
+    );
   }
 }


### PR DESCRIPTION
Strip markdown formatting from generated thread titles to improve readability.

The previous title generation only removed `<think>` tags, leading to markdown formatting (e.g., `**"Turnhalle mieten – Sportverein"**`) appearing directly in chat titles. This change ensures titles are displayed as clean, plain text.

---
[Slack Thread](https://locaboo.slack.com/archives/C0375HX2C4S/p1765958582827929?thread_ts=1765958582.827929&cid=C0375HX2C4S)

<a href="https://cursor.com/background-agent?bcId=bc-89ed6ea8-629d-4590-a9c9-ca11cc7f02ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-89ed6ea8-629d-4590-a9c9-ca11cc7f02ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Strip markdown from generated thread titles and add unit tests covering formatting cases.
> 
> - **Backend**:
>   - In `generate-and-set-thread-title.use-case.ts`, sanitize generated titles by stripping markdown via `stripMarkdownFormatting` (bold, italics, strikethrough, code, headers, links, quotes) and whitespace cleanup, after removing `<think>` blocks.
> - **Tests**:
>   - Add `generate-and-set-thread-title.use-case.spec.ts` with unit tests for `stripMarkdownFormatting` across multiple cases (bold `**`/`__`, italics `*`/`_`, quotes, inline code, strikethrough, headers, links, combined formats, whitespace, empty output).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5e79b428db61535d3fd1854ef62c917276cd82a7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->