### PR TITLE
Chats page search focus

### DIFF
--- a/ayunis-core-frontend/src/pages/chats/ui/ChatsFilters.tsx
+++ b/ayunis-core-frontend/src/pages/chats/ui/ChatsFilters.tsx
@@ -9,7 +9,7 @@ import {
 import { useNavigate } from '@tanstack/react-router';
 import { Search } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import type { Agent } from '../model/types';
 
 interface ChatsFiltersProps {
@@ -26,6 +26,12 @@ export default function ChatsFilters({
   const { t } = useTranslation('chats');
   const navigate = useNavigate();
   const [searchValue, setSearchValue] = useState(search ?? '');
+  const searchInputRef = useRef<HTMLInputElement>(null);
+
+  // Auto-focus search input on mount
+  useEffect(() => {
+    searchInputRef.current?.focus();
+  }, []);
 
   // Sync search value with URL params
   useEffect(() => {
@@ -67,6 +73,7 @@ export default function ChatsFilters({
       <div className="relative flex-1 max-w-md">
         <Search className="absolute left-3 top-1/2 -translate-y-1/2 size-4 text-muted-foreground" />
         <Input
+          ref={searchInputRef}
           type="text"
           placeholder={t('filters.searchPlaceholder')}
           value={searchValue}


### PR DESCRIPTION
Implement auto-focus on the search input field in the `/chats` page to improve user experience.

---
[Slack Thread](https://locaboo.slack.com/archives/C0375HX2C4S/p1765960827331999?thread_ts=1765960827.331999&cid=C0375HX2C4S)

<a href="https://cursor.com/background-agent?bcId=bc-b0bfd3d9-be8f-4a81-b374-46d558b3250a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b0bfd3d9-be8f-4a81-b374-46d558b3250a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Auto-focuses the chats search input on mount for quicker searching.
> 
> - **UI/UX**:
>   - Auto-focus the search input in `src/pages/chats/ui/ChatsFilters.tsx` using `useRef` and a mount `useEffect`.
>   - Wire the `Input` with a `ref` to enable focusing on render.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ea7de45c161a5c7c8c009312b6e42e13233be616. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->