### PR TITLE
Agent creation default model

### DIFF
--- a/ayunis-core-frontend/src/pages/agents/ui/CreateAgentDialog.tsx
+++ b/ayunis-core-frontend/src/pages/agents/ui/CreateAgentDialog.tsx
@@ -25,12 +25,13 @@ import {
 import { Input } from '@/shared/ui/shadcn/input';
 import { Textarea } from '@/shared/ui/shadcn/textarea';
 import { Button } from '@/shared/ui/shadcn/button';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { Plus } from 'lucide-react';
 import { type CreateAgentData, useCreateAgent } from '../api/useCreateAgent';
 import { useTranslation } from 'react-i18next';
 import { usePermittedModels } from '@/features/usePermittedModels';
 import { ToolAssignmentDtoType } from '@/shared/api/generated/ayunisCoreAPI.schemas';
+import { useModelsControllerGetEffectiveDefaultModel } from '@/shared/api/generated/ayunisCoreAPI';
 
 interface CreateAgentDialogProps {
   buttonText?: string;
@@ -55,6 +56,16 @@ export default function CreateAgentDialog({
     resetForm,
     isLoading,
   } = useCreateAgent();
+
+  // Fetch the user's effective default model
+  const { data: defaultModelData } = useModelsControllerGetEffectiveDefaultModel();
+
+  // Pre-select the default model when the dialog opens
+  useEffect(() => {
+    if (isOpen && defaultModelData?.permittedLanguageModel?.id) {
+      form.setValue('modelId', defaultModelData.permittedLanguageModel.id);
+    }
+  }, [isOpen, defaultModelData, form]);
 
   const handleSubmit = (data: CreateAgentData) => {
     const toolAssignments = internetSearchEnabled

--- a/ayunis-core-frontend/src/pages/agents/ui/CreateAgentDialog.tsx
+++ b/ayunis-core-frontend/src/pages/agents/ui/CreateAgentDialog.tsx
@@ -130,7 +130,7 @@ export default function CreateAgentDialog({
                     <FormLabel>{t('createDialog.form.modelLabel')}</FormLabel>
                     <Select
                       onValueChange={field.onChange}
-                      defaultValue={field.value}
+                      value={field.value}
                     >
                       <FormControl>
                         <SelectTrigger className="w-full">


### PR DESCRIPTION
Pre-select the user's effective default model in the agent creation form to improve user experience.

---
[Slack Thread](https://locaboo.slack.com/archives/C0375HX2C4S/p1765963975151289?thread_ts=1765963975.151289&cid=C0375HX2C4S)

<a href="https://cursor.com/background-agent?bcId=bc-c9c83e15-216b-49aa-950f-24dca6aceac0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c9c83e15-216b-49aa-950f-24dca6aceac0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Preselects the user's effective default model when opening the Create Agent dialog and switches the model select to a controlled value.
> 
> - **Frontend**
>   - **CreateAgentDialog (`CreateAgentDialog.tsx`)**
>     - Fetches effective default model via `useModelsControllerGetEffectiveDefaultModel` and pre-selects it on dialog open.
>     - Converts model select from `defaultValue` to controlled `value`.
>     - Adds `useEffect` to set `form.modelId` when the dialog opens.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9c99878a63da2d1f846ccbb8749dbbd6a3857161. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->