### PR TITLE
Assistant message copy button

### DIFF
--- a/ayunis-core-frontend/src/pages/chat/ui/ChatMessage.tsx
+++ b/ayunis-core-frontend/src/pages/chat/ui/ChatMessage.tsx
@@ -5,6 +5,11 @@ import { Dialog, DialogContent, DialogTitle } from '@/shared/ui/shadcn/dialog';
 import { Bot, Loader2, Copy, Check } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { Button } from '@/shared/ui/shadcn/button';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/shared/ui/shadcn/tooltip';
 import type {
   Message,
   AssistantMessageContent,
@@ -44,11 +49,12 @@ interface ChatMessageProps {
 
 function CopyMessageButton({ message }: { message: Message }) {
   const [copied, setCopied] = useState(false);
+  const { t } = useTranslation('chat');
 
   const extractTextContent = (message: Message): string => {
     if (message.role !== 'assistant') return '';
     if (!message.content || message.content.length === 0) return '';
-    
+
     return message.content
       .filter((content) => content.type === 'text')
       .map((content) => (content as TextMessageContent).text)
@@ -72,19 +78,24 @@ function CopyMessageButton({ message }: { message: Message }) {
   if (!textContent) return null;
 
   return (
-    <Button
-      variant="ghost"
-      size="icon"
-      className="h-7 w-7 mt-1"
-      onClick={handleCopy}
-      aria-label="Copy message"
-    >
-      {copied ? (
-        <Check className="h-3.5 w-3.5" />
-      ) : (
-        <Copy className="h-3.5 w-3.5" />
-      )}
-    </Button>
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-7 w-7 mt-1"
+          onClick={() => void handleCopy()}
+          aria-label={t('chat.copyToClipboard')}
+        >
+          {copied ? (
+            <Check className="h-3.5 w-3.5" />
+          ) : (
+            <Copy className="h-3.5 w-3.5" />
+          )}
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent>{t('chat.copyToClipboard')}</TooltipContent>
+    </Tooltip>
   );
 }
 

--- a/ayunis-core-frontend/src/pages/chat/ui/ChatMessage.tsx
+++ b/ayunis-core-frontend/src/pages/chat/ui/ChatMessage.tsx
@@ -2,8 +2,9 @@ import { useState } from 'react';
 import { Card, CardContent } from '@/shared/ui/shadcn/card';
 import { Avatar, AvatarFallback } from '@/shared/ui/shadcn/avatar';
 import { Dialog, DialogContent, DialogTitle } from '@/shared/ui/shadcn/dialog';
-import { Bot, Loader2 } from 'lucide-react';
+import { Bot, Loader2, Copy, Check } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
+import { Button } from '@/shared/ui/shadcn/button';
 import type {
   Message,
   AssistantMessageContent,
@@ -39,6 +40,51 @@ interface ChatMessageProps {
   isLoading?: boolean;
   hideAvatar?: boolean;
   isStreaming?: boolean;
+}
+
+function CopyMessageButton({ message }: { message: Message }) {
+  const [copied, setCopied] = useState(false);
+
+  const extractTextContent = (message: Message): string => {
+    if (message.role !== 'assistant') return '';
+    
+    return message.content
+      .filter((content) => content.type === 'text')
+      .map((content) => (content as TextMessageContent).text)
+      .join('\n\n');
+  };
+
+  const handleCopy = async () => {
+    const textContent = extractTextContent(message);
+    if (!textContent) return;
+
+    try {
+      await navigator.clipboard.writeText(textContent);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch (error) {
+      console.error('Failed to copy message:', error);
+    }
+  };
+
+  const textContent = extractTextContent(message);
+  if (!textContent) return null;
+
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      className="h-7 w-7 mt-1"
+      onClick={handleCopy}
+      aria-label="Copy message"
+    >
+      {copied ? (
+        <Check className="h-3.5 w-3.5" />
+      ) : (
+        <Copy className="h-3.5 w-3.5" />
+      )}
+    </Button>
+  );
 }
 
 export default function ChatMessage({
@@ -115,6 +161,7 @@ export default function ChatMessage({
           >
             {renderMessageContent(message, isStreaming)}
           </div>
+          <CopyMessageButton message={message} />
         </div>
       </div>
     );

--- a/ayunis-core-frontend/src/pages/chat/ui/ChatMessage.tsx
+++ b/ayunis-core-frontend/src/pages/chat/ui/ChatMessage.tsx
@@ -47,6 +47,7 @@ function CopyMessageButton({ message }: { message: Message }) {
 
   const extractTextContent = (message: Message): string => {
     if (message.role !== 'assistant') return '';
+    if (!message.content || message.content.length === 0) return '';
     
     return message.content
       .filter((content) => content.type === 'text')

--- a/ayunis-core-frontend/src/shared/locales/de/chat.json
+++ b/ayunis-core-frontend/src/shared/locales/de/chat.json
@@ -22,6 +22,7 @@
     "errorUpdateAgent": "Agent konnte nicht aktualisiert werden",
     "errorRemoveAgent": "Agent konnte nicht entfernt werden",
     "thinking": "Nachdenken",
+    "copyToClipboard": "In die Zwischenablage kopieren",
     "tools": {
       "internet_search": "Im Internet suchen",
       "website_content": "Website abfragen",

--- a/ayunis-core-frontend/src/shared/locales/en/chat.json
+++ b/ayunis-core-frontend/src/shared/locales/en/chat.json
@@ -22,6 +22,7 @@
     "errorUpdateAgent": "Agent could not be updated",
     "errorRemoveAgent": "Agent could not be removed",
     "thinking": "Thinking",
+    "copyToClipboard": "Copy to clipboard",
     "tools": {
       "internet_search": "Search the internet",
       "website_content": "Query website",


### PR DESCRIPTION
Add a copy button below each assistant message to allow users to copy the visible markdown-formatted text to their clipboard, with a visual confirmation.

---
[Slack Thread](https://locaboo.slack.com/archives/C0375HX2C4S/p1765964137335699?thread_ts=1765964137.335699&cid=C0375HX2C4S)

<a href="https://cursor.com/background-agent?bcId=bc-5f3a6613-c4a2-4b3b-aefe-15bd80d2e59a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5f3a6613-c4a2-4b3b-aefe-15bd80d2e59a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a copy button under assistant messages to copy text content with tooltip and visual confirmation, plus i18n strings.
> 
> - **Frontend (Chat UI)**:
>   - Add `CopyMessageButton` in `pages/chat/ui/ChatMessage.tsx` to copy assistant text content via clipboard API with tooltip and `Copy`/`Check` icon feedback.
>   - Render the button under assistant messages; integrate `Button`, `Tooltip` components and new icons.
> - **i18n**:
>   - Add `chat.copyToClipboard` to `shared/locales/en/chat.json` and `shared/locales/de/chat.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a75d745ec7934e3abc8f4cf939fd11306b2e120e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->