### PR TITLE
Thread rename modal focus

### DIFF
--- a/ayunis-core-frontend/src/widgets/rename-thread-dialog/ui/RenameThreadDialog.tsx
+++ b/ayunis-core-frontend/src/widgets/rename-thread-dialog/ui/RenameThreadDialog.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import {
   Dialog,
   DialogContent,
@@ -32,6 +32,7 @@ export function RenameThreadDialog({
   const { t } = useTranslation('common');
   const [title, setTitle] = useState(currentTitle || '');
   const [error, setError] = useState<string | null>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
 
   const { rename, isRenaming } = useRenameThread({
     onSuccess: () => {
@@ -84,9 +85,15 @@ export function RenameThreadDialog({
     }
   };
 
+  const handleOpenAutoFocus = (event: Event) => {
+    event.preventDefault();
+    inputRef.current?.focus();
+    inputRef.current?.select();
+  };
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-[425px]">
+      <DialogContent className="sm:max-w-[425px]" onOpenAutoFocus={handleOpenAutoFocus}>
         <form onSubmit={handleSubmit}>
           <DialogHeader>
             <DialogTitle>{t('sidebar.renameThreadTitle')}</DialogTitle>
@@ -98,11 +105,11 @@ export function RenameThreadDialog({
             <div className="grid gap-2">
               <Label htmlFor="title">{t('sidebar.renameThreadLabel')}</Label>
               <Input
+                ref={inputRef}
                 id="title"
                 value={title}
                 onChange={handleTitleChange}
                 placeholder={t('sidebar.renameThreadPlaceholder')}
-                autoFocus
                 maxLength={MAX_TITLE_LENGTH + 1}
                 aria-invalid={!!error}
               />


### PR DESCRIPTION
Auto-focus the input field and select its text in the thread rename modal to improve user experience.

The existing `autoFocus` attribute was unreliable due to Radix UI's focus management. This PR implements a more robust solution using a ref and the `onOpenAutoFocus` callback of `DialogContent` to ensure the input is focused and its content selected when the modal opens.

---
<a href="https://cursor.com/background-agent?bcId=bc-45a5a710-d273-4f0c-8f67-f709797ea5dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-45a5a710-d273-4f0c-8f67-f709797ea5dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves focus behavior in the rename-thread dialog.
> 
> - Adds `inputRef` and `handleOpenAutoFocus` to `RenameThreadDialog` to focus and select the input when the dialog opens
> - Wires `onOpenAutoFocus` on `DialogContent` and attaches `ref` to `Input`; removes unreliable `autoFocus` attribute
> - No behavior changes beyond reliable focus/selection; validation and submit logic remain unchanged
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a64622e4f64c7c368784535f0babb2cd3128fa68. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->