### PR TITLE
fix: fix cleanup and add announcable org id as env variable AYC-000

### DIFF
--- a/ayunis-core-frontend/.env.example
+++ b/ayunis-core-frontend/.env.example
@@ -5,5 +5,5 @@ VITE_API_BASE_URL=http://localhost:3000/api
 # Sentry error tracking (optional, production only)
 VITE_SENTRY_DSN=
 
-# Release notes widget (disabled by default)
-VITE_RELEASE_NOTES_ENABLED=false
+# Announcable release notes widget (disabled if empty)
+VITE_ANNOUNCABLE_ORG_ID=

--- a/ayunis-core-frontend/src/features/useReleaseNotes.ts
+++ b/ayunis-core-frontend/src/features/useReleaseNotes.ts
@@ -12,26 +12,38 @@ declare global {
   }
 }
 
+// Module-level flag to track if script has been loaded (persists across component remounts)
+let announcableLoaded = false;
+
 /**
  * Hook to initialize the release notes widget.
  * Must be called in a component that renders AFTER the #updates-button element exists.
  */
 export function useReleaseNotes(): void {
   useEffect(() => {
-    if (!config.features.releaseNotes) {
+    const orgId = config.features.announcableOrgId;
+
+    // Don't initialize if feature is disabled (no org ID configured)
+    if (!orgId) {
+      return;
+    }
+
+    // Prevent duplicate script injection (survives HMR and React Strict Mode)
+    if (announcableLoaded) {
       return;
     }
 
     const scriptId = 'announcable-widget-script';
 
-    // Prevent duplicate script injection
+    // Also check DOM as a fallback (e.g., if module was reloaded but script persists)
     if (document.getElementById(scriptId)) {
+      announcableLoaded = true;
       return;
     }
 
     // Initialize the widget configuration
     window.announcable_init = {
-      org_id: 'bbcb0cc9-f4b8-4e54-a2a7-bfcac8b98154',
+      org_id: orgId,
       anchor_query_selector: '#updates-button',
     };
 
@@ -43,14 +55,10 @@ export function useReleaseNotes(): void {
     script.async = true;
     document.body.appendChild(script);
 
-    // Cleanup on unmount
-    return () => {
-      const existingScript = document.getElementById(scriptId);
-      if (existingScript && existingScript.parentNode) {
-        existingScript.parentNode.removeChild(existingScript);
-      }
-      // Clean up the global config
-      delete window.announcable_init;
-    };
+    // Mark as loaded - do NOT remove on cleanup since custom elements can't be unregistered
+    announcableLoaded = true;
+
+    // No cleanup needed - the widget registers custom elements that persist
+    // and cannot be unregistered from CustomElementRegistry
   }, []);
 }

--- a/ayunis-core-frontend/src/shared/config/index.ts
+++ b/ayunis-core-frontend/src/shared/config/index.ts
@@ -15,7 +15,9 @@ const config = {
   },
   features: {
     devtools: import.meta.env.MODE !== 'production',
-    releaseNotes: import.meta.env.VITE_RELEASE_NOTES_ENABLED === 'true',
+    announcableOrgId: import.meta.env.VITE_ANNOUNCABLE_ORG_ID as
+      | string
+      | undefined,
   },
   analytics: {
     gtmContainerId: import.meta.env.VITE_GTM_CONTAINER_ID as string | undefined,

--- a/ayunis-core-frontend/src/widgets/app-sidebar/ui/AppSidebar.tsx
+++ b/ayunis-core-frontend/src/widgets/app-sidebar/ui/AppSidebar.tsx
@@ -122,7 +122,7 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
 
       <SidebarFooter>
         <SidebarMenu>
-          {config.features.releaseNotes && (
+          {config.features.announcableOrgId && (
             <SidebarMenuItem>
               <SidebarMenuButton id="updates-button">
                 <Megaphone />


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Switches release-notes integration to be driven by an Announcable org ID and hardens widget initialization.
> 
> - Replaces `features.releaseNotes` with `features.announcableOrgId`; adds `VITE_ANNOUNCABLE_ORG_ID` in `.env.example` and config
> - Updates `useReleaseNotes` to use the org ID, avoid duplicate script injection via a module-level flag and DOM check, and remove cleanup since custom elements persist
> - Sidebar now shows the "Updates" button only when `announcableOrgId` is configured
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 089ed86d5e809b78e197e4c8d842d4a890f1c4b4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->