### PR TITLE
feat: archive models AYC-65

### DIFF
--- a/ayunis-core-backend/src/domain/models/application/ports/permitted-models.repository.ts
+++ b/ayunis-core-backend/src/domain/models/application/ports/permitted-models.repository.ts
@@ -41,4 +41,8 @@ export abstract class PermittedModelsRepository {
     orgId: UUID;
   }): Promise<PermittedLanguageModel>;
   abstract update(permittedModel: PermittedModel): Promise<PermittedModel>;
+  abstract findAllByCatalogModelId(
+    catalogModelId: UUID,
+  ): Promise<PermittedModel[]>;
+  abstract unsetDefaultsByCatalogModelId(catalogModelId: UUID): Promise<void>;
 }

--- a/ayunis-core-backend/src/domain/models/application/ports/user-default-models.repository.ts
+++ b/ayunis-core-backend/src/domain/models/application/ports/user-default-models.repository.ts
@@ -20,4 +20,5 @@ export abstract class UserDefaultModelsRepository {
     userId: UUID,
   ): Promise<void>;
   abstract deleteByModelId(modelId: UUID): Promise<void>;
+  abstract deleteByPermittedModelIds(permittedModelIds: UUID[]): Promise<void>;
 }

--- a/ayunis-core-backend/src/domain/models/application/use-cases/clear-defaults-by-catalog-model-id/clear-defaults-by-catalog-model-id.command.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/clear-defaults-by-catalog-model-id/clear-defaults-by-catalog-model-id.command.ts
@@ -1,0 +1,5 @@
+import { UUID } from 'crypto';
+
+export class ClearDefaultsByCatalogModelIdCommand {
+  constructor(public readonly catalogModelId: UUID) {}
+}

--- a/ayunis-core-backend/src/domain/models/application/use-cases/clear-defaults-by-catalog-model-id/clear-defaults-by-catalog-model-id.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/clear-defaults-by-catalog-model-id/clear-defaults-by-catalog-model-id.use-case.spec.ts
@@ -1,0 +1,337 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { Logger } from '@nestjs/common';
+import { ClearDefaultsByCatalogModelIdUseCase } from './clear-defaults-by-catalog-model-id.use-case';
+import { ClearDefaultsByCatalogModelIdCommand } from './clear-defaults-by-catalog-model-id.command';
+import { PermittedModelsRepository } from '../../ports/permitted-models.repository';
+import { UserDefaultModelsRepository } from '../../ports/user-default-models.repository';
+import { PermittedModel } from 'src/domain/models/domain/permitted-model.entity';
+import { LanguageModel } from 'src/domain/models/domain/models/language.model';
+import { ModelProvider } from 'src/domain/models/domain/value-objects/model-provider.enum';
+import { UUID } from 'crypto';
+
+describe('ClearDefaultsByCatalogModelIdUseCase', () => {
+  let useCase: ClearDefaultsByCatalogModelIdUseCase;
+  let permittedModelsRepository: jest.Mocked<PermittedModelsRepository>;
+  let userDefaultModelsRepository: jest.Mocked<UserDefaultModelsRepository>;
+
+  const mockCatalogModelId = '123e4567-e89b-12d3-a456-426614174001' as UUID;
+  const mockOrgId1 = '123e4567-e89b-12d3-a456-426614174100' as UUID;
+  const mockOrgId2 = '123e4567-e89b-12d3-a456-426614174101' as UUID;
+  const mockPermittedModelId1 = '123e4567-e89b-12d3-a456-426614174200' as UUID;
+  const mockPermittedModelId2 = '123e4567-e89b-12d3-a456-426614174201' as UUID;
+
+  beforeEach(async () => {
+    const mockPermittedModelsRepository = {
+      findAllByCatalogModelId: jest.fn(),
+      unsetDefaultsByCatalogModelId: jest.fn(),
+      findAll: jest.fn(),
+      findOrgDefaultLanguage: jest.fn(),
+      findOne: jest.fn(),
+      findOneLanguage: jest.fn(),
+      findOneEmbedding: jest.fn(),
+      findManyLanguage: jest.fn(),
+      create: jest.fn(),
+      delete: jest.fn(),
+      setAsDefault: jest.fn(),
+      update: jest.fn(),
+    };
+
+    const mockUserDefaultModelsRepository = {
+      deleteByPermittedModelIds: jest.fn(),
+      findByUserId: jest.fn(),
+      create: jest.fn(),
+      update: jest.fn(),
+      setAsDefault: jest.fn(),
+      delete: jest.fn(),
+      deleteByModelId: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ClearDefaultsByCatalogModelIdUseCase,
+        {
+          provide: PermittedModelsRepository,
+          useValue: mockPermittedModelsRepository,
+        },
+        {
+          provide: UserDefaultModelsRepository,
+          useValue: mockUserDefaultModelsRepository,
+        },
+      ],
+    }).compile();
+
+    useCase = module.get<ClearDefaultsByCatalogModelIdUseCase>(
+      ClearDefaultsByCatalogModelIdUseCase,
+    );
+    permittedModelsRepository = module.get(PermittedModelsRepository);
+    userDefaultModelsRepository = module.get(UserDefaultModelsRepository);
+
+    // Mock logger
+    jest.spyOn(Logger.prototype, 'log').mockImplementation();
+    jest.spyOn(Logger.prototype, 'debug').mockImplementation();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const createMockLanguageModel = (id: UUID): LanguageModel => {
+    return new LanguageModel({
+      id,
+      name: 'gpt-4',
+      displayName: 'GPT-4',
+      provider: ModelProvider.OPENAI,
+      canStream: true,
+      isReasoning: false,
+      isArchived: false,
+      canUseTools: true,
+      canVision: false,
+    });
+  };
+
+  const createMockPermittedModel = (
+    id: UUID,
+    orgId: UUID,
+    model: LanguageModel,
+    isDefault = false,
+  ): PermittedModel => {
+    return new PermittedModel({
+      id,
+      model,
+      orgId,
+      isDefault,
+    });
+  };
+
+  describe('execute', () => {
+    it('should find permitted models by catalog model ID', async () => {
+      // Arrange
+      const command = new ClearDefaultsByCatalogModelIdCommand(
+        mockCatalogModelId,
+      );
+      const mockModel = createMockLanguageModel(mockCatalogModelId);
+      const mockPermittedModels = [
+        createMockPermittedModel(
+          mockPermittedModelId1,
+          mockOrgId1,
+          mockModel,
+          true,
+        ),
+        createMockPermittedModel(
+          mockPermittedModelId2,
+          mockOrgId2,
+          mockModel,
+          true,
+        ),
+      ];
+
+      permittedModelsRepository.findAllByCatalogModelId.mockResolvedValue(
+        mockPermittedModels,
+      );
+      userDefaultModelsRepository.deleteByPermittedModelIds.mockResolvedValue();
+      permittedModelsRepository.unsetDefaultsByCatalogModelId.mockResolvedValue();
+
+      // Act
+      await useCase.execute(command);
+
+      // Assert
+      expect(
+        permittedModelsRepository.findAllByCatalogModelId,
+      ).toHaveBeenCalledWith(mockCatalogModelId);
+    });
+
+    it('should delete user defaults for all permitted models referencing the catalog model', async () => {
+      // Arrange
+      const command = new ClearDefaultsByCatalogModelIdCommand(
+        mockCatalogModelId,
+      );
+      const mockModel = createMockLanguageModel(mockCatalogModelId);
+      const mockPermittedModels = [
+        createMockPermittedModel(
+          mockPermittedModelId1,
+          mockOrgId1,
+          mockModel,
+          true,
+        ),
+        createMockPermittedModel(
+          mockPermittedModelId2,
+          mockOrgId2,
+          mockModel,
+          false,
+        ),
+      ];
+
+      permittedModelsRepository.findAllByCatalogModelId.mockResolvedValue(
+        mockPermittedModels,
+      );
+      userDefaultModelsRepository.deleteByPermittedModelIds.mockResolvedValue();
+      permittedModelsRepository.unsetDefaultsByCatalogModelId.mockResolvedValue();
+
+      // Act
+      await useCase.execute(command);
+
+      // Assert
+      expect(
+        userDefaultModelsRepository.deleteByPermittedModelIds,
+      ).toHaveBeenCalledWith([mockPermittedModelId1, mockPermittedModelId2]);
+    });
+
+    it('should unset org defaults for all permitted models using the catalog model', async () => {
+      // Arrange
+      const command = new ClearDefaultsByCatalogModelIdCommand(
+        mockCatalogModelId,
+      );
+      const mockModel = createMockLanguageModel(mockCatalogModelId);
+      const mockPermittedModels = [
+        createMockPermittedModel(
+          mockPermittedModelId1,
+          mockOrgId1,
+          mockModel,
+          true,
+        ),
+      ];
+
+      permittedModelsRepository.findAllByCatalogModelId.mockResolvedValue(
+        mockPermittedModels,
+      );
+      userDefaultModelsRepository.deleteByPermittedModelIds.mockResolvedValue();
+      permittedModelsRepository.unsetDefaultsByCatalogModelId.mockResolvedValue();
+
+      // Act
+      await useCase.execute(command);
+
+      // Assert
+      expect(
+        permittedModelsRepository.unsetDefaultsByCatalogModelId,
+      ).toHaveBeenCalledWith(mockCatalogModelId);
+    });
+
+    it('should be a no-op when no permitted models exist for the catalog model', async () => {
+      // Arrange
+      const command = new ClearDefaultsByCatalogModelIdCommand(
+        mockCatalogModelId,
+      );
+
+      permittedModelsRepository.findAllByCatalogModelId.mockResolvedValue([]);
+
+      const debugSpy = jest.spyOn(Logger.prototype, 'debug');
+
+      // Act
+      await useCase.execute(command);
+
+      // Assert
+      expect(
+        permittedModelsRepository.findAllByCatalogModelId,
+      ).toHaveBeenCalledWith(mockCatalogModelId);
+      expect(
+        userDefaultModelsRepository.deleteByPermittedModelIds,
+      ).not.toHaveBeenCalled();
+      expect(
+        permittedModelsRepository.unsetDefaultsByCatalogModelId,
+      ).not.toHaveBeenCalled();
+      expect(debugSpy).toHaveBeenCalledWith(
+        'No permitted models found for catalog model',
+        { catalogModelId: mockCatalogModelId },
+      );
+    });
+
+    it('should execute operations in correct order: find, delete user defaults, then unset org defaults', async () => {
+      // Arrange
+      const command = new ClearDefaultsByCatalogModelIdCommand(
+        mockCatalogModelId,
+      );
+      const mockModel = createMockLanguageModel(mockCatalogModelId);
+      const mockPermittedModels = [
+        createMockPermittedModel(
+          mockPermittedModelId1,
+          mockOrgId1,
+          mockModel,
+          true,
+        ),
+      ];
+
+      const callOrder: string[] = [];
+
+      permittedModelsRepository.findAllByCatalogModelId.mockImplementation(
+        async () => {
+          callOrder.push('findAllByCatalogModelId');
+          return mockPermittedModels;
+        },
+      );
+      userDefaultModelsRepository.deleteByPermittedModelIds.mockImplementation(
+        async () => {
+          callOrder.push('deleteByPermittedModelIds');
+        },
+      );
+      permittedModelsRepository.unsetDefaultsByCatalogModelId.mockImplementation(
+        async () => {
+          callOrder.push('unsetDefaultsByCatalogModelId');
+        },
+      );
+
+      // Act
+      await useCase.execute(command);
+
+      // Assert
+      expect(callOrder).toEqual([
+        'findAllByCatalogModelId',
+        'deleteByPermittedModelIds',
+        'unsetDefaultsByCatalogModelId',
+      ]);
+    });
+
+    it('should log appropriate messages during execution', async () => {
+      // Arrange
+      const command = new ClearDefaultsByCatalogModelIdCommand(
+        mockCatalogModelId,
+      );
+      const mockModel = createMockLanguageModel(mockCatalogModelId);
+      const mockPermittedModels = [
+        createMockPermittedModel(
+          mockPermittedModelId1,
+          mockOrgId1,
+          mockModel,
+          true,
+        ),
+        createMockPermittedModel(
+          mockPermittedModelId2,
+          mockOrgId2,
+          mockModel,
+          false,
+        ),
+      ];
+
+      permittedModelsRepository.findAllByCatalogModelId.mockResolvedValue(
+        mockPermittedModels,
+      );
+      userDefaultModelsRepository.deleteByPermittedModelIds.mockResolvedValue();
+      permittedModelsRepository.unsetDefaultsByCatalogModelId.mockResolvedValue();
+
+      const logSpy = jest.spyOn(Logger.prototype, 'log');
+      const debugSpy = jest.spyOn(Logger.prototype, 'debug');
+
+      // Act
+      await useCase.execute(command);
+
+      // Assert
+      expect(logSpy).toHaveBeenCalledWith(
+        'Clearing defaults for archived catalog model',
+        { catalogModelId: mockCatalogModelId },
+      );
+      expect(debugSpy).toHaveBeenCalledWith(
+        'Found permitted models to clear defaults',
+        {
+          catalogModelId: mockCatalogModelId,
+          permittedModelCount: 2,
+        },
+      );
+      expect(logSpy).toHaveBeenCalledWith(
+        'Successfully cleared all defaults for archived catalog model',
+        {
+          catalogModelId: mockCatalogModelId,
+          affectedPermittedModels: 2,
+        },
+      );
+    });
+  });
+});

--- a/ayunis-core-backend/src/domain/models/application/use-cases/clear-defaults-by-catalog-model-id/clear-defaults-by-catalog-model-id.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/clear-defaults-by-catalog-model-id/clear-defaults-by-catalog-model-id.use-case.ts
@@ -1,0 +1,60 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ClearDefaultsByCatalogModelIdCommand } from './clear-defaults-by-catalog-model-id.command';
+import { PermittedModelsRepository } from '../../ports/permitted-models.repository';
+import { UserDefaultModelsRepository } from '../../ports/user-default-models.repository';
+
+@Injectable()
+export class ClearDefaultsByCatalogModelIdUseCase {
+  private readonly logger = new Logger(
+    ClearDefaultsByCatalogModelIdUseCase.name,
+  );
+
+  constructor(
+    private readonly permittedModelsRepository: PermittedModelsRepository,
+    private readonly userDefaultModelsRepository: UserDefaultModelsRepository,
+  ) {}
+
+  async execute(command: ClearDefaultsByCatalogModelIdCommand): Promise<void> {
+    this.logger.log('Clearing defaults for archived catalog model', {
+      catalogModelId: command.catalogModelId,
+    });
+
+    // 1. Find all permitted models that reference this catalog model
+    const permittedModels =
+      await this.permittedModelsRepository.findAllByCatalogModelId(
+        command.catalogModelId,
+      );
+
+    if (permittedModels.length === 0) {
+      this.logger.debug('No permitted models found for catalog model', {
+        catalogModelId: command.catalogModelId,
+      });
+      return;
+    }
+
+    const permittedModelIds = permittedModels.map((pm) => pm.id);
+
+    this.logger.debug('Found permitted models to clear defaults', {
+      catalogModelId: command.catalogModelId,
+      permittedModelCount: permittedModelIds.length,
+    });
+
+    // 2. Delete all user default models that reference these permitted models
+    await this.userDefaultModelsRepository.deleteByPermittedModelIds(
+      permittedModelIds,
+    );
+
+    // 3. Unset isDefault flag on all permitted models using this catalog model
+    await this.permittedModelsRepository.unsetDefaultsByCatalogModelId(
+      command.catalogModelId,
+    );
+
+    this.logger.log(
+      'Successfully cleared all defaults for archived catalog model',
+      {
+        catalogModelId: command.catalogModelId,
+        affectedPermittedModels: permittedModelIds.length,
+      },
+    );
+  }
+}

--- a/ayunis-core-backend/src/domain/models/application/use-cases/update-embedding-model/update-embedding-model.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/update-embedding-model/update-embedding-model.use-case.ts
@@ -6,9 +6,18 @@ import {
   UnexpectedModelError,
 } from '../../models.errors';
 import { ApplicationError } from 'src/common/errors/base.error';
+import { Injectable, Logger } from '@nestjs/common';
+import { ClearDefaultsByCatalogModelIdUseCase } from '../clear-defaults-by-catalog-model-id/clear-defaults-by-catalog-model-id.use-case';
+import { ClearDefaultsByCatalogModelIdCommand } from '../clear-defaults-by-catalog-model-id/clear-defaults-by-catalog-model-id.command';
 
+@Injectable()
 export class UpdateEmbeddingModelUseCase {
-  constructor(private readonly modelsRepository: ModelsRepository) {}
+  private readonly logger = new Logger(UpdateEmbeddingModelUseCase.name);
+
+  constructor(
+    private readonly modelsRepository: ModelsRepository,
+    private readonly clearDefaultsUseCase: ClearDefaultsByCatalogModelIdUseCase,
+  ) {}
 
   async execute(command: UpdateEmbeddingModelCommand): Promise<EmbeddingModel> {
     try {
@@ -19,6 +28,9 @@ export class UpdateEmbeddingModelUseCase {
       if (!existingModel) {
         throw new ModelNotFoundByIdError(command.id);
       }
+
+      // Check if model is being archived (isArchived: false -> true)
+      const isBeingArchived = !existingModel.isArchived && command.isArchived;
 
       const model = new EmbeddingModel({
         id: command.id,
@@ -32,6 +44,17 @@ export class UpdateEmbeddingModelUseCase {
         currency: command.currency,
       });
       await this.modelsRepository.save(model);
+
+      // Clear defaults if model is being archived (for consistency, though embedding models typically don't have defaults)
+      if (isBeingArchived) {
+        this.logger.log('Model is being archived, clearing defaults', {
+          modelId: command.id,
+        });
+        await this.clearDefaultsUseCase.execute(
+          new ClearDefaultsByCatalogModelIdCommand(command.id),
+        );
+      }
+
       return model;
     } catch (error) {
       if (error instanceof ApplicationError) {

--- a/ayunis-core-backend/src/domain/models/application/use-cases/update-language-model/update-language-model.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/update-language-model/update-language-model.use-case.spec.ts
@@ -1,0 +1,253 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { Logger } from '@nestjs/common';
+import { UpdateLanguageModelUseCase } from './update-language-model.use-case';
+import { UpdateLanguageModelCommand } from './update-language-model.command';
+import { ModelsRepository } from '../../ports/models.repository';
+import { ClearDefaultsByCatalogModelIdUseCase } from '../clear-defaults-by-catalog-model-id/clear-defaults-by-catalog-model-id.use-case';
+import { LanguageModel } from 'src/domain/models/domain/models/language.model';
+import { ModelProvider } from 'src/domain/models/domain/value-objects/model-provider.enum';
+import { ModelNotFoundByIdError } from '../../models.errors';
+import { UUID } from 'crypto';
+
+describe('UpdateLanguageModelUseCase', () => {
+  let useCase: UpdateLanguageModelUseCase;
+  let modelsRepository: jest.Mocked<ModelsRepository>;
+  let clearDefaultsUseCase: jest.Mocked<ClearDefaultsByCatalogModelIdUseCase>;
+
+  const mockModelId = '123e4567-e89b-12d3-a456-426614174001' as UUID;
+
+  beforeEach(async () => {
+    const mockModelsRepository = {
+      findOne: jest.fn(),
+      save: jest.fn(),
+      findAll: jest.fn(),
+      findOneLanguage: jest.fn(),
+      findOneEmbedding: jest.fn(),
+      delete: jest.fn(),
+    };
+
+    const mockClearDefaultsUseCase = {
+      execute: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        UpdateLanguageModelUseCase,
+        { provide: ModelsRepository, useValue: mockModelsRepository },
+        {
+          provide: ClearDefaultsByCatalogModelIdUseCase,
+          useValue: mockClearDefaultsUseCase,
+        },
+      ],
+    }).compile();
+
+    useCase = module.get<UpdateLanguageModelUseCase>(UpdateLanguageModelUseCase);
+    modelsRepository = module.get(ModelsRepository);
+    clearDefaultsUseCase = module.get(ClearDefaultsByCatalogModelIdUseCase);
+
+    // Mock logger
+    jest.spyOn(Logger.prototype, 'log').mockImplementation();
+    jest.spyOn(Logger.prototype, 'debug').mockImplementation();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const createMockLanguageModel = (
+    id: UUID,
+    isArchived: boolean,
+  ): LanguageModel => {
+    return new LanguageModel({
+      id,
+      name: 'gpt-4',
+      displayName: 'GPT-4',
+      provider: ModelProvider.OPENAI,
+      canStream: true,
+      isReasoning: false,
+      isArchived,
+      canUseTools: true,
+      canVision: false,
+    });
+  };
+
+  const createUpdateCommand = (
+    id: UUID,
+    isArchived: boolean,
+  ): UpdateLanguageModelCommand => {
+    return new UpdateLanguageModelCommand({
+      id,
+      name: 'gpt-4',
+      displayName: 'GPT-4',
+      provider: ModelProvider.OPENAI,
+      canStream: true,
+      isReasoning: false,
+      isArchived,
+      canUseTools: true,
+      canVision: false,
+    });
+  };
+
+  describe('execute', () => {
+    it('should call clearDefaultsUseCase when isArchived changes from false to true', async () => {
+      // Arrange
+      const existingModel = createMockLanguageModel(mockModelId, false);
+      const command = createUpdateCommand(mockModelId, true);
+
+      modelsRepository.findOne.mockResolvedValue(existingModel);
+      modelsRepository.save.mockResolvedValue();
+      clearDefaultsUseCase.execute.mockResolvedValue();
+
+      // Act
+      await useCase.execute(command);
+
+      // Assert
+      expect(clearDefaultsUseCase.execute).toHaveBeenCalledTimes(1);
+      expect(clearDefaultsUseCase.execute).toHaveBeenCalledWith(
+        expect.objectContaining({
+          catalogModelId: mockModelId,
+        }),
+      );
+    });
+
+    it('should NOT call clearDefaultsUseCase when model was already archived', async () => {
+      // Arrange
+      const existingModel = createMockLanguageModel(mockModelId, true);
+      const command = createUpdateCommand(mockModelId, true);
+
+      modelsRepository.findOne.mockResolvedValue(existingModel);
+      modelsRepository.save.mockResolvedValue();
+
+      // Act
+      await useCase.execute(command);
+
+      // Assert
+      expect(clearDefaultsUseCase.execute).not.toHaveBeenCalled();
+    });
+
+    it('should NOT call clearDefaultsUseCase when unarchiving (true -> false)', async () => {
+      // Arrange
+      const existingModel = createMockLanguageModel(mockModelId, true);
+      const command = createUpdateCommand(mockModelId, false);
+
+      modelsRepository.findOne.mockResolvedValue(existingModel);
+      modelsRepository.save.mockResolvedValue();
+
+      // Act
+      await useCase.execute(command);
+
+      // Assert
+      expect(clearDefaultsUseCase.execute).not.toHaveBeenCalled();
+    });
+
+    it('should NOT call clearDefaultsUseCase when isArchived remains false', async () => {
+      // Arrange
+      const existingModel = createMockLanguageModel(mockModelId, false);
+      const command = createUpdateCommand(mockModelId, false);
+
+      modelsRepository.findOne.mockResolvedValue(existingModel);
+      modelsRepository.save.mockResolvedValue();
+
+      // Act
+      await useCase.execute(command);
+
+      // Assert
+      expect(clearDefaultsUseCase.execute).not.toHaveBeenCalled();
+    });
+
+    it('should save the model before clearing defaults', async () => {
+      // Arrange
+      const existingModel = createMockLanguageModel(mockModelId, false);
+      const command = createUpdateCommand(mockModelId, true);
+
+      const callOrder: string[] = [];
+
+      modelsRepository.findOne.mockResolvedValue(existingModel);
+      modelsRepository.save.mockImplementation(async () => {
+        callOrder.push('save');
+      });
+      clearDefaultsUseCase.execute.mockImplementation(async () => {
+        callOrder.push('clearDefaults');
+      });
+
+      // Act
+      await useCase.execute(command);
+
+      // Assert
+      expect(callOrder).toEqual(['save', 'clearDefaults']);
+    });
+
+    it('should throw ModelNotFoundByIdError when model does not exist', async () => {
+      // Arrange
+      const command = createUpdateCommand(mockModelId, true);
+
+      modelsRepository.findOne.mockResolvedValue(undefined);
+
+      // Act & Assert
+      await expect(useCase.execute(command)).rejects.toThrow(
+        ModelNotFoundByIdError,
+      );
+      expect(modelsRepository.save).not.toHaveBeenCalled();
+      expect(clearDefaultsUseCase.execute).not.toHaveBeenCalled();
+    });
+
+    it('should return the updated model', async () => {
+      // Arrange
+      const existingModel = createMockLanguageModel(mockModelId, false);
+      const command = createUpdateCommand(mockModelId, true);
+
+      modelsRepository.findOne.mockResolvedValue(existingModel);
+      modelsRepository.save.mockResolvedValue();
+      clearDefaultsUseCase.execute.mockResolvedValue();
+
+      // Act
+      const result = await useCase.execute(command);
+
+      // Assert
+      expect(result).toBeInstanceOf(LanguageModel);
+      expect(result.id).toBe(mockModelId);
+      expect(result.isArchived).toBe(true);
+    });
+
+    it('should log when model is being archived', async () => {
+      // Arrange
+      const existingModel = createMockLanguageModel(mockModelId, false);
+      const command = createUpdateCommand(mockModelId, true);
+
+      modelsRepository.findOne.mockResolvedValue(existingModel);
+      modelsRepository.save.mockResolvedValue();
+      clearDefaultsUseCase.execute.mockResolvedValue();
+
+      const logSpy = jest.spyOn(Logger.prototype, 'log');
+
+      // Act
+      await useCase.execute(command);
+
+      // Assert
+      expect(logSpy).toHaveBeenCalledWith(
+        'Model is being archived, clearing defaults',
+        { modelId: mockModelId },
+      );
+    });
+
+    it('should not log archival message when model is not being archived', async () => {
+      // Arrange
+      const existingModel = createMockLanguageModel(mockModelId, false);
+      const command = createUpdateCommand(mockModelId, false);
+
+      modelsRepository.findOne.mockResolvedValue(existingModel);
+      modelsRepository.save.mockResolvedValue();
+
+      const logSpy = jest.spyOn(Logger.prototype, 'log');
+
+      // Act
+      await useCase.execute(command);
+
+      // Assert
+      expect(logSpy).not.toHaveBeenCalledWith(
+        'Model is being archived, clearing defaults',
+        expect.anything(),
+      );
+    });
+  });
+});

--- a/ayunis-core-backend/src/domain/models/infrastructure/persistence/local-permitted-models/local-permitted-models.repository.ts
+++ b/ayunis-core-backend/src/domain/models/infrastructure/persistence/local-permitted-models/local-permitted-models.repository.ts
@@ -63,6 +63,7 @@ export class LocalPermittedModelsRepository extends PermittedModelsRepository {
       where: {
         orgId,
         isDefault: true,
+        model: { isArchived: false },
       },
       relations: {
         model: true,
@@ -123,7 +124,10 @@ export class LocalPermittedModelsRepository extends PermittedModelsRepository {
   async findOneEmbedding(orgId: UUID): Promise<PermittedEmbeddingModel | null> {
     this.logger.debug('findOneEmbedding', { orgId });
     const permittedModels = await this.permittedModelRepository.find({
-      where: { orgId },
+      where: {
+        orgId,
+        model: { isArchived: false },
+      },
       relations: {
         model: true,
       },
@@ -151,7 +155,10 @@ export class LocalPermittedModelsRepository extends PermittedModelsRepository {
 
   async findManyLanguage(orgId: UUID): Promise<PermittedLanguageModel[]> {
     const permittedModels = await this.permittedModelRepository.find({
-      where: { orgId },
+      where: {
+        orgId,
+        model: { isArchived: false },
+      },
       relations: {
         model: true,
       },

--- a/ayunis-core-backend/src/domain/models/infrastructure/persistence/local-permitted-models/local-permitted-models.repository.ts
+++ b/ayunis-core-backend/src/domain/models/infrastructure/persistence/local-permitted-models/local-permitted-models.repository.ts
@@ -301,4 +301,36 @@ export class LocalPermittedModelsRepository extends PermittedModelsRepository {
 
     return this.permittedModelMapper.toDomain(updatedModel);
   }
+
+  async findAllByCatalogModelId(
+    catalogModelId: UUID,
+  ): Promise<PermittedModel[]> {
+    this.logger.log('findAllByCatalogModelId', { catalogModelId });
+
+    const permittedModels = await this.permittedModelRepository.find({
+      where: { modelId: catalogModelId },
+      relations: { model: true },
+    });
+
+    this.logger.debug('Found permitted models by catalog model id', {
+      catalogModelId,
+      count: permittedModels.length,
+    });
+
+    return permittedModels.map((pm) => this.permittedModelMapper.toDomain(pm));
+  }
+
+  async unsetDefaultsByCatalogModelId(catalogModelId: UUID): Promise<void> {
+    this.logger.log('unsetDefaultsByCatalogModelId', { catalogModelId });
+
+    const result = await this.permittedModelRepository.update(
+      { modelId: catalogModelId, isDefault: true },
+      { isDefault: false },
+    );
+
+    this.logger.debug('Unset defaults for catalog model', {
+      catalogModelId,
+      affected: result.affected,
+    });
+  }
 }

--- a/ayunis-core-backend/src/domain/models/infrastructure/persistence/local-user-default-models/local-user-default-models.repository.ts
+++ b/ayunis-core-backend/src/domain/models/infrastructure/persistence/local-user-default-models/local-user-default-models.repository.ts
@@ -1,6 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { In, Repository } from 'typeorm';
 import { UUID } from 'crypto';
 import { UserDefaultModelsRepository } from '../../../application/ports/user-default-models.repository';
 import { PermittedLanguageModel } from '../../../domain/permitted-model.entity';
@@ -173,6 +173,26 @@ export class LocalUserDefaultModelsRepository extends UserDefaultModelsRepositor
     this.logger.debug('Deleted user default models by model id', {
       modelId,
       affected: result.affected,
+    });
+  }
+
+  async deleteByPermittedModelIds(permittedModelIds: UUID[]): Promise<void> {
+    if (permittedModelIds.length === 0) {
+      this.logger.debug('deleteByPermittedModelIds called with empty array');
+      return;
+    }
+
+    this.logger.log('deleteByPermittedModelIds', {
+      count: permittedModelIds.length,
+    });
+
+    const result = await this.userDefaultModelRepository.delete({
+      model: { id: In(permittedModelIds) },
+    });
+
+    this.logger.debug('Deleted user default models by permitted model ids', {
+      affected: result.affected,
+      permittedModelIds,
     });
   }
 }

--- a/ayunis-core-backend/src/domain/models/models.module.ts
+++ b/ayunis-core-backend/src/domain/models/models.module.ts
@@ -50,6 +50,7 @@ import { ModelProviderInfoResponseDtoMapper } from './presenters/http/mappers/mo
 import { ThreadsModule } from '../threads/threads.module';
 import { AgentsModule } from '../agents/agents.module';
 import { DeleteUserDefaultModelsByModelIdUseCase } from './application/use-cases/delete-user-default-models-by-model-id/delete-user-default-models-by-model-id.use-case';
+import { ClearDefaultsByCatalogModelIdUseCase } from './application/use-cases/clear-defaults-by-catalog-model-id/clear-defaults-by-catalog-model-id.use-case';
 import { OrgsModule } from 'src/iam/orgs/orgs.module';
 import { LocalOllamaInferenceHandler } from './infrastructure/inference/local-ollama.inference';
 import { LocalOllamaStreamInferenceHandler } from './infrastructure/stream-inference/local-ollama.stream-inference';
@@ -214,6 +215,8 @@ import { MessagesModule } from '../messages/messages.module';
     GetOrgDefaultModelUseCase,
     // Org Default Model Use Cases
     ManageOrgDefaultModelUseCase,
+    // Catalog Model Archival Use Cases
+    ClearDefaultsByCatalogModelIdUseCase,
     // Model Management Use Cases
     CreateLanguageModelUseCase,
     CreateEmbeddingModelUseCase,

--- a/ayunis-core-frontend/src/pages/super-admin-settings/models-catalog/ui/ModelsCatalogList.tsx
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/models-catalog/ui/ModelsCatalogList.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next';
 import {
   Card,
   CardContent,
@@ -22,6 +23,7 @@ interface ModelsCatalogListProps {
     model: SuperAdminModelsControllerGetAllCatalogModels200Item,
   ) => void;
   isDeleting: boolean;
+  isArchivedView?: boolean;
 }
 
 function isLanguageModel(
@@ -42,9 +44,23 @@ export default function ModelsCatalogList({
   onEditEmbeddingModel,
   onDeleteModel,
   isDeleting,
+  isArchivedView = false,
 }: ModelsCatalogListProps) {
+  const { t } = useTranslation('super-admin-settings-org');
   const languageModels = models.filter(isLanguageModel);
   const embeddingModels = models.filter(isEmbeddingModel);
+
+  // Show a combined empty state for archived view when there are no archived models at all
+  if (isArchivedView && models.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center space-y-2 py-16 text-center">
+        <h3 className="text-lg font-semibold">{t('models.emptyArchived')}</h3>
+        <p className="text-sm text-muted-foreground max-w-sm">
+          {t('models.emptyArchivedDescription')}
+        </p>
+      </div>
+    );
+  }
 
   return (
     <div className="space-y-6">
@@ -61,7 +77,9 @@ export default function ModelsCatalogList({
             <div className="flex flex-col items-center justify-center space-y-2 py-10 text-center">
               <h3 className="text-lg font-semibold">No language models</h3>
               <p className="text-sm text-muted-foreground max-w-sm">
-                No language models have been added to the catalog yet.
+                {isArchivedView
+                  ? 'No language models have been archived.'
+                  : 'No language models have been added to the catalog yet.'}
               </p>
             </div>
           ) : (
@@ -95,7 +113,9 @@ export default function ModelsCatalogList({
             <div className="flex flex-col items-center justify-center space-y-2 py-10 text-center">
               <h3 className="text-lg font-semibold">No embedding models</h3>
               <p className="text-sm text-muted-foreground max-w-sm">
-                No embedding models have been added to the catalog yet.
+                {isArchivedView
+                  ? 'No embedding models have been archived.'
+                  : 'No embedding models have been added to the catalog yet.'}
               </p>
             </div>
           ) : (

--- a/ayunis-core-frontend/src/pages/super-admin-settings/models-catalog/ui/ModelsCatalogTabs.tsx
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/models-catalog/ui/ModelsCatalogTabs.tsx
@@ -1,0 +1,49 @@
+import { useState, type ReactNode } from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+} from '@/shared/ui/shadcn/tabs';
+
+interface ModelsCatalogTabsProps {
+  activeCount: number;
+  archivedCount: number;
+  renderActiveContent: () => ReactNode;
+  renderArchivedContent: () => ReactNode;
+}
+
+export function ModelsCatalogTabs({
+  activeCount,
+  archivedCount,
+  renderActiveContent,
+  renderArchivedContent,
+}: ModelsCatalogTabsProps) {
+  const { t } = useTranslation('super-admin-settings-org');
+  const [activeTab, setActiveTab] = useState<'active' | 'archived'>('active');
+
+  return (
+    <Tabs
+      value={activeTab}
+      onValueChange={(v) => setActiveTab(v as 'active' | 'archived')}
+    >
+      <TabsList>
+        <TabsTrigger value="active">
+          {t('models.tabs.active')} ({activeCount})
+        </TabsTrigger>
+        <TabsTrigger value="archived">
+          {t('models.tabs.archived')} ({archivedCount})
+        </TabsTrigger>
+      </TabsList>
+
+      <TabsContent value="active" className="mt-4">
+        {renderActiveContent()}
+      </TabsContent>
+
+      <TabsContent value="archived" className="mt-4">
+        {renderArchivedContent()}
+      </TabsContent>
+    </Tabs>
+  );
+}

--- a/ayunis-core-frontend/src/pages/super-admin-settings/models-catalog/ui/Page.tsx
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/models-catalog/ui/Page.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import SuperAdminSettingsLayout from '../../super-admin-settings-layout';
 import ModelsCatalogList from './ModelsCatalogList';
+import { ModelsCatalogTabs } from './ModelsCatalogTabs';
 import { CreateLanguageModelDialog } from './CreateLanguageModelDialog';
 import { EditLanguageModelDialog } from './EditLanguageModelDialog';
 import { CreateEmbeddingModelDialog } from './CreateEmbeddingModelDialog';
@@ -35,6 +36,9 @@ export default function ModelsCatalogPage({
     useState<EmbeddingModelResponseDto | null>(null);
   const { deleteModel, isDeleting } = useDeleteModel();
   const { confirm } = useConfirmation();
+
+  const activeModels = models.filter((m) => !m.isArchived);
+  const archivedModels = models.filter((m) => m.isArchived);
 
   function handleDeleteModel(
     model: SuperAdminModelsControllerGetAllCatalogModels200Item,
@@ -71,15 +75,29 @@ export default function ModelsCatalogPage({
         </DropdownMenu>
       }
     >
-      <div className="space-y-4">
-        <ModelsCatalogList
-          models={models}
-          onEditLanguageModel={setEditLanguageModel}
-          onEditEmbeddingModel={setEditEmbeddingModel}
-          onDeleteModel={handleDeleteModel}
-          isDeleting={isDeleting}
-        />
-      </div>
+      <ModelsCatalogTabs
+        activeCount={activeModels.length}
+        archivedCount={archivedModels.length}
+        renderActiveContent={() => (
+          <ModelsCatalogList
+            models={activeModels}
+            onEditLanguageModel={setEditLanguageModel}
+            onEditEmbeddingModel={setEditEmbeddingModel}
+            onDeleteModel={handleDeleteModel}
+            isDeleting={isDeleting}
+          />
+        )}
+        renderArchivedContent={() => (
+          <ModelsCatalogList
+            models={archivedModels}
+            onEditLanguageModel={setEditLanguageModel}
+            onEditEmbeddingModel={setEditEmbeddingModel}
+            onDeleteModel={handleDeleteModel}
+            isDeleting={isDeleting}
+            isArchivedView
+          />
+        )}
+      />
 
       {/* Dialogs */}
       <CreateLanguageModelDialog

--- a/ayunis-core-frontend/src/shared/locales/de/super-admin-settings-org.json
+++ b/ayunis-core-frontend/src/shared/locales/de/super-admin-settings-org.json
@@ -224,6 +224,12 @@
     "deleteSuccess": "Modell erfolgreich gelöscht",
     "deleteError": "Modell konnte nicht gelöscht werden. Bitte versuchen Sie es erneut.",
     "alreadyExists": "Ein Modell mit dieser Kennung existiert bereits.",
-    "notFound": "Modell nicht gefunden. Es wurde möglicherweise gelöscht."
+    "notFound": "Modell nicht gefunden. Es wurde möglicherweise gelöscht.",
+    "tabs": {
+      "active": "Aktiv",
+      "archived": "Archiviert"
+    },
+    "emptyArchived": "Keine archivierten Modelle",
+    "emptyArchivedDescription": "Archivierte Modelle werden hier angezeigt."
   }
 }

--- a/ayunis-core-frontend/src/shared/locales/en/super-admin-settings-org.json
+++ b/ayunis-core-frontend/src/shared/locales/en/super-admin-settings-org.json
@@ -224,6 +224,12 @@
     "deleteSuccess": "Model deleted successfully",
     "deleteError": "Failed to delete model. Please try again.",
     "alreadyExists": "A model with this identifier already exists.",
-    "notFound": "Model not found. It may have been deleted."
+    "notFound": "Model not found. It may have been deleted.",
+    "tabs": {
+      "active": "Active",
+      "archived": "Archived"
+    },
+    "emptyArchived": "No archived models",
+    "emptyArchivedDescription": "Models you archive will appear here."
   }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Implements model archival handling and improves catalog UI visibility.
> 
> - **Backend (archival flow):** New `ClearDefaultsByCatalogModelIdUseCase` (+ command, tests) removes user defaults and unsets org defaults for all `PermittedModel`s referencing an archived catalog model
> - **Repository extensions:** `PermittedModelsRepository` adds `findAllByCatalogModelId` and `unsetDefaultsByCatalogModelId`; `UserDefaultModelsRepository` adds `deleteByPermittedModelIds`; concrete local repos implement these and filter out archived models in `findOrgDefaultLanguage`, `findOneEmbedding`, and `findManyLanguage`
> - **Update use cases:** `UpdateLanguageModelUseCase` and `UpdateEmbeddingModelUseCase` now detect `isArchived` transitions (false→true) and invoke the clear-defaults use case; adds logging and tests (language)
> - **Wiring:** Registers the new use case in `models.module`
> - **Frontend (UI):** Adds `ModelsCatalogTabs` with Active/Archived counts; updates `Page` to split lists; updates `ModelsCatalogList` for archived empty states; adds i18n strings (en/de)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6284567b846c09f27da2048a8b19ec702459dfbb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->