### PR TITLE
refactor(ui): use ayunis registry for shadcn components. TASK: LOC-11…

### DIFF
--- a/ayunis-core-frontend/.env.example
+++ b/ayunis-core-frontend/.env.example
@@ -7,3 +7,4 @@ VITE_SENTRY_DSN=
 
 # Announcable release notes widget (disabled if empty)
 VITE_ANNOUNCABLE_ORG_ID=
+AYUNIS_REGISTRY_TOKEN=

--- a/ayunis-core-frontend/README.md
+++ b/ayunis-core-frontend/README.md
@@ -39,6 +39,31 @@ Add components using the latest version of [Shadcn](https://ui.shadcn.com/).
 pnpx shadcn@latest add button
 ```
 
+### Ayunis Private Registry
+
+This project uses a custom Ayunis registry for shared shadcn components. The registry is configured in `components.json`:
+
+```json
+{
+  "registries": {
+    "@ayunis": {
+      "url": "https://registry.ayunis.de/r/{name}.json",
+      "headers": {
+        "Authorization": "Bearer ${AYUNIS_REGISTRY_TOKEN}"
+      }
+    }
+  }
+}
+```
+
+To add components from the Ayunis registry:
+
+```bash
+pnpx shadcn@latest add @ayunis/component-name
+```
+
+**Note:** You need to set the `AYUNIS_REGISTRY_TOKEN` environment variable and have the registry server running on port 1998.
+
 
 
 ## Routing

--- a/ayunis-core-frontend/components.json
+++ b/ayunis-core-frontend/components.json
@@ -3,9 +3,17 @@
   "style": "new-york",
   "rsc": false,
   "tsx": true,
+  "registries": {
+    "@ayunis": {
+      "url": "https://registry.ayunis.de/r/{name}.json",
+      "headers": {
+        "Authorization": "Bearer ${AYUNIS_REGISTRY_TOKEN}"
+      }
+    }
+  },
   "tailwind": {
     "config": "",
-    "css": "src/styles.css",
+    "css": "src/styles/main.css",
     "baseColor": "zinc",
     "cssVariables": true,
     "prefix": ""

--- a/ayunis-core-frontend/src/main.tsx
+++ b/ayunis-core-frontend/src/main.tsx
@@ -14,7 +14,7 @@ import { ErrorBoundary } from '@/shared/ui/error-boundary';
 // Import the generated route tree
 import { routeTree } from './app/routeTree.gen.ts';
 
-import './styles.css';
+import './styles/main.css';
 import './i18n.ts';
 import reportWebVitals from './reportWebVitals.ts';
 

--- a/ayunis-core-frontend/src/shared/ui/shadcn/accordion.tsx
+++ b/ayunis-core-frontend/src/shared/ui/shadcn/accordion.tsx
@@ -6,14 +6,14 @@ import { cn } from '@/shared/lib/shadcn/utils';
 
 function Accordion({
   ...props
-}: React.ComponentProps<typeof AccordionPrimitive.Root>) {
+}: React.ComponentProps<typeof AccordionPrimitive.Root>): React.ReactElement {
   return <AccordionPrimitive.Root data-slot="accordion" {...props} />;
 }
 
 function AccordionItem({
   className,
   ...props
-}: React.ComponentProps<typeof AccordionPrimitive.Item>) {
+}: React.ComponentProps<typeof AccordionPrimitive.Item>): React.ReactElement {
   return (
     <AccordionPrimitive.Item
       data-slot="accordion-item"
@@ -27,7 +27,9 @@ function AccordionTrigger({
   className,
   children,
   ...props
-}: React.ComponentProps<typeof AccordionPrimitive.Trigger>) {
+}: React.ComponentProps<
+  typeof AccordionPrimitive.Trigger
+>): React.ReactElement {
   return (
     <AccordionPrimitive.Header className="flex">
       <AccordionPrimitive.Trigger
@@ -49,7 +51,9 @@ function AccordionContent({
   className,
   children,
   ...props
-}: React.ComponentProps<typeof AccordionPrimitive.Content>) {
+}: React.ComponentProps<
+  typeof AccordionPrimitive.Content
+>): React.ReactElement {
   return (
     <AccordionPrimitive.Content
       data-slot="accordion-content"

--- a/ayunis-core-frontend/src/shared/ui/shadcn/alert-dialog.tsx
+++ b/ayunis-core-frontend/src/shared/ui/shadcn/alert-dialog.tsx
@@ -6,13 +6,15 @@ import { buttonVariants } from '@/shared/ui/shadcn/button';
 
 function AlertDialog({
   ...props
-}: React.ComponentProps<typeof AlertDialogPrimitive.Root>) {
+}: React.ComponentProps<typeof AlertDialogPrimitive.Root>): React.ReactElement {
   return <AlertDialogPrimitive.Root data-slot="alert-dialog" {...props} />;
 }
 
 function AlertDialogTrigger({
   ...props
-}: React.ComponentProps<typeof AlertDialogPrimitive.Trigger>) {
+}: React.ComponentProps<
+  typeof AlertDialogPrimitive.Trigger
+>): React.ReactElement {
   return (
     <AlertDialogPrimitive.Trigger data-slot="alert-dialog-trigger" {...props} />
   );
@@ -20,7 +22,9 @@ function AlertDialogTrigger({
 
 function AlertDialogPortal({
   ...props
-}: React.ComponentProps<typeof AlertDialogPrimitive.Portal>) {
+}: React.ComponentProps<
+  typeof AlertDialogPrimitive.Portal
+>): React.ReactElement {
   return (
     <AlertDialogPrimitive.Portal data-slot="alert-dialog-portal" {...props} />
   );
@@ -29,7 +33,9 @@ function AlertDialogPortal({
 function AlertDialogOverlay({
   className,
   ...props
-}: React.ComponentProps<typeof AlertDialogPrimitive.Overlay>) {
+}: React.ComponentProps<
+  typeof AlertDialogPrimitive.Overlay
+>): React.ReactElement {
   return (
     <AlertDialogPrimitive.Overlay
       data-slot="alert-dialog-overlay"
@@ -45,7 +51,9 @@ function AlertDialogOverlay({
 function AlertDialogContent({
   className,
   ...props
-}: React.ComponentProps<typeof AlertDialogPrimitive.Content>) {
+}: React.ComponentProps<
+  typeof AlertDialogPrimitive.Content
+>): React.ReactElement {
   return (
     <AlertDialogPortal>
       <AlertDialogOverlay />
@@ -64,7 +72,7 @@ function AlertDialogContent({
 function AlertDialogHeader({
   className,
   ...props
-}: React.ComponentProps<'div'>) {
+}: React.ComponentProps<'div'>): React.ReactElement {
   return (
     <div
       data-slot="alert-dialog-header"
@@ -77,7 +85,7 @@ function AlertDialogHeader({
 function AlertDialogFooter({
   className,
   ...props
-}: React.ComponentProps<'div'>) {
+}: React.ComponentProps<'div'>): React.ReactElement {
   return (
     <div
       data-slot="alert-dialog-footer"
@@ -93,7 +101,9 @@ function AlertDialogFooter({
 function AlertDialogTitle({
   className,
   ...props
-}: React.ComponentProps<typeof AlertDialogPrimitive.Title>) {
+}: React.ComponentProps<
+  typeof AlertDialogPrimitive.Title
+>): React.ReactElement {
   return (
     <AlertDialogPrimitive.Title
       data-slot="alert-dialog-title"
@@ -106,7 +116,9 @@ function AlertDialogTitle({
 function AlertDialogDescription({
   className,
   ...props
-}: React.ComponentProps<typeof AlertDialogPrimitive.Description>) {
+}: React.ComponentProps<
+  typeof AlertDialogPrimitive.Description
+>): React.ReactElement {
   return (
     <AlertDialogPrimitive.Description
       data-slot="alert-dialog-description"
@@ -119,7 +131,9 @@ function AlertDialogDescription({
 function AlertDialogAction({
   className,
   ...props
-}: React.ComponentProps<typeof AlertDialogPrimitive.Action>) {
+}: React.ComponentProps<
+  typeof AlertDialogPrimitive.Action
+>): React.ReactElement {
   return (
     <AlertDialogPrimitive.Action
       className={cn(buttonVariants(), className)}
@@ -131,7 +145,9 @@ function AlertDialogAction({
 function AlertDialogCancel({
   className,
   ...props
-}: React.ComponentProps<typeof AlertDialogPrimitive.Cancel>) {
+}: React.ComponentProps<
+  typeof AlertDialogPrimitive.Cancel
+>): React.ReactElement {
   return (
     <AlertDialogPrimitive.Cancel
       className={cn(buttonVariants({ variant: 'outline' }), className)}

--- a/ayunis-core-frontend/src/shared/ui/shadcn/avatar.tsx
+++ b/ayunis-core-frontend/src/shared/ui/shadcn/avatar.tsx
@@ -6,7 +6,7 @@ import { cn } from '@/shared/lib/shadcn/utils';
 function Avatar({
   className,
   ...props
-}: React.ComponentProps<typeof AvatarPrimitive.Root>) {
+}: React.ComponentProps<typeof AvatarPrimitive.Root>): React.ReactElement {
   return (
     <AvatarPrimitive.Root
       data-slot="avatar"
@@ -22,7 +22,7 @@ function Avatar({
 function AvatarImage({
   className,
   ...props
-}: React.ComponentProps<typeof AvatarPrimitive.Image>) {
+}: React.ComponentProps<typeof AvatarPrimitive.Image>): React.ReactElement {
   return (
     <AvatarPrimitive.Image
       data-slot="avatar-image"
@@ -35,7 +35,7 @@ function AvatarImage({
 function AvatarFallback({
   className,
   ...props
-}: React.ComponentProps<typeof AvatarPrimitive.Fallback>) {
+}: React.ComponentProps<typeof AvatarPrimitive.Fallback>): React.ReactElement {
   return (
     <AvatarPrimitive.Fallback
       data-slot="avatar-fallback"

--- a/ayunis-core-frontend/src/shared/ui/shadcn/badge.tsx
+++ b/ayunis-core-frontend/src/shared/ui/shadcn/badge.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-refresh/only-export-components */
 import * as React from 'react';
 import { Slot } from '@radix-ui/react-slot';
 import { cva, type VariantProps } from 'class-variance-authority';
@@ -5,7 +6,7 @@ import { cva, type VariantProps } from 'class-variance-authority';
 import { cn } from '@/shared/lib/shadcn/utils';
 
 const badgeVariants = cva(
-  'inline-flex items-center justify-center rounded-md border px-2 py-0.5 text-xs font-medium w-fit whitespace-nowrap shrink-0 [&>svg]:size-3 gap-1 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive transition-[color,box-shadow] overflow-hidden',
+  'inline-flex items-center justify-center rounded-full border px-2 py-0.5 text-xs font-medium w-fit whitespace-nowrap shrink-0 [&>svg]:size-3 gap-1 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive transition-[color,box-shadow] overflow-hidden',
   {
     variants: {
       variant: {
@@ -25,25 +26,24 @@ const badgeVariants = cva(
   },
 );
 
-type BadgeProps = React.ComponentProps<'span'> &
-  VariantProps<typeof badgeVariants> & { asChild?: boolean };
+function Badge({
+  className,
+  variant,
+  asChild = false,
+  ...props
+}: React.ComponentProps<'span'> &
+  VariantProps<typeof badgeVariants> & {
+    asChild?: boolean;
+  }): React.ReactElement {
+  const Comp = asChild ? Slot : 'span';
 
-const Badge = React.forwardRef<HTMLSpanElement, BadgeProps>(
-  ({ className, variant, asChild = false, ...props }, ref) => {
-    const Comp = asChild ? Slot : 'span';
+  return (
+    <Comp
+      data-slot="badge"
+      className={cn(badgeVariants({ variant }), className)}
+      {...props}
+    />
+  );
+}
 
-    return (
-      <Comp
-        ref={ref}
-        data-slot="badge"
-        className={cn(badgeVariants({ variant }), className)}
-        {...props}
-      />
-    );
-  },
-);
-
-Badge.displayName = 'Badge';
-
-// eslint-disable-next-line react-refresh/only-export-components
 export { Badge, badgeVariants };

--- a/ayunis-core-frontend/src/shared/ui/shadcn/breadcrumb.tsx
+++ b/ayunis-core-frontend/src/shared/ui/shadcn/breadcrumb.tsx
@@ -4,11 +4,16 @@ import { ChevronRight, MoreHorizontal } from 'lucide-react';
 
 import { cn } from '@/shared/lib/shadcn/utils';
 
-function Breadcrumb({ ...props }: React.ComponentProps<'nav'>) {
+function Breadcrumb({
+  ...props
+}: React.ComponentProps<'nav'>): React.ReactElement {
   return <nav aria-label="breadcrumb" data-slot="breadcrumb" {...props} />;
 }
 
-function BreadcrumbList({ className, ...props }: React.ComponentProps<'ol'>) {
+function BreadcrumbList({
+  className,
+  ...props
+}: React.ComponentProps<'ol'>): React.ReactElement {
   return (
     <ol
       data-slot="breadcrumb-list"
@@ -21,7 +26,10 @@ function BreadcrumbList({ className, ...props }: React.ComponentProps<'ol'>) {
   );
 }
 
-function BreadcrumbItem({ className, ...props }: React.ComponentProps<'li'>) {
+function BreadcrumbItem({
+  className,
+  ...props
+}: React.ComponentProps<'li'>): React.ReactElement {
   return (
     <li
       data-slot="breadcrumb-item"
@@ -37,7 +45,7 @@ function BreadcrumbLink({
   ...props
 }: React.ComponentProps<'a'> & {
   asChild?: boolean;
-}) {
+}): React.ReactElement {
   const Comp = asChild ? Slot : 'a';
 
   return (
@@ -49,7 +57,10 @@ function BreadcrumbLink({
   );
 }
 
-function BreadcrumbPage({ className, ...props }: React.ComponentProps<'span'>) {
+function BreadcrumbPage({
+  className,
+  ...props
+}: React.ComponentProps<'span'>): React.ReactElement {
   return (
     <span
       data-slot="breadcrumb-page"
@@ -66,7 +77,7 @@ function BreadcrumbSeparator({
   children,
   className,
   ...props
-}: React.ComponentProps<'li'>) {
+}: React.ComponentProps<'li'>): React.ReactElement {
   return (
     <li
       data-slot="breadcrumb-separator"
@@ -83,7 +94,7 @@ function BreadcrumbSeparator({
 function BreadcrumbEllipsis({
   className,
   ...props
-}: React.ComponentProps<'span'>) {
+}: React.ComponentProps<'span'>): React.ReactElement {
   return (
     <span
       data-slot="breadcrumb-ellipsis"

--- a/ayunis-core-frontend/src/shared/ui/shadcn/button.tsx
+++ b/ayunis-core-frontend/src/shared/ui/shadcn/button.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-refresh/only-export-components */
 import * as React from 'react';
 import { Slot } from '@radix-ui/react-slot';
 import { cva, type VariantProps } from 'class-variance-authority';
@@ -9,14 +10,13 @@ const buttonVariants = cva(
   {
     variants: {
       variant: {
-        default:
-          'bg-primary text-primary-foreground shadow-xs hover:bg-primary/90',
+        default: 'bg-primary text-primary-foreground hover:bg-primary/90',
         destructive:
-          'bg-destructive text-white shadow-xs hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60',
+          'bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60',
         outline:
           'border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50',
         secondary:
-          'bg-secondary text-secondary-foreground shadow-xs hover:bg-secondary/80',
+          'bg-secondary text-secondary-foreground hover:bg-secondary/80',
         ghost:
           'hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50',
         link: 'text-primary underline-offset-4 hover:underline',
@@ -26,6 +26,8 @@ const buttonVariants = cva(
         sm: 'h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5',
         lg: 'h-10 rounded-md px-6 has-[>svg]:px-4',
         icon: 'size-9',
+        'icon-sm': 'size-8',
+        'icon-lg': 'size-10',
       },
     },
     defaultVariants: {
@@ -35,27 +37,27 @@ const buttonVariants = cva(
   },
 );
 
-type ButtonProps = React.ComponentProps<'button'> &
+function Button({
+  className,
+  variant = 'default',
+  size = 'default',
+  asChild = false,
+  ...props
+}: React.ComponentProps<'button'> &
   VariantProps<typeof buttonVariants> & {
     asChild?: boolean;
-  };
+  }): React.ReactElement {
+  const Comp = asChild ? Slot : 'button';
 
-const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ className, variant, size, asChild = false, ...props }, ref) => {
-    const Comp = asChild ? Slot : 'button';
+  return (
+    <Comp
+      data-slot="button"
+      data-variant={variant}
+      data-size={size}
+      className={cn(buttonVariants({ variant, size, className }))}
+      {...props}
+    />
+  );
+}
 
-    return (
-      <Comp
-        ref={ref}
-        data-slot="button"
-        className={cn(buttonVariants({ variant, size, className }))}
-        {...props}
-      />
-    );
-  },
-);
-
-Button.displayName = 'Button';
-
-// eslint-disable-next-line react-refresh/only-export-components
 export { Button, buttonVariants };

--- a/ayunis-core-frontend/src/shared/ui/shadcn/calendar.tsx
+++ b/ayunis-core-frontend/src/shared/ui/shadcn/calendar.tsx
@@ -4,7 +4,11 @@ import {
   ChevronLeftIcon,
   ChevronRightIcon,
 } from 'lucide-react';
-import { DayButton, DayPicker, getDefaultClassNames } from 'react-day-picker';
+import {
+  DayPicker,
+  getDefaultClassNames,
+  type DayButton,
+} from 'react-day-picker';
 
 import { cn } from '@/shared/lib/shadcn/utils';
 import { Button, buttonVariants } from '@/shared/ui/shadcn/button';
@@ -20,7 +24,7 @@ function Calendar({
   ...props
 }: React.ComponentProps<typeof DayPicker> & {
   buttonVariant?: React.ComponentProps<typeof Button>['variant'];
-}) {
+}): React.ReactElement {
   const defaultClassNames = getDefaultClassNames();
 
   return (
@@ -98,7 +102,10 @@ function Calendar({
           defaultClassNames.week_number,
         ),
         day: cn(
-          'relative w-full h-full p-0 text-center [&:first-child[data-selected=true]_button]:rounded-l-md [&:last-child[data-selected=true]_button]:rounded-r-md group/day aspect-square select-none',
+          'relative w-full h-full p-0 text-center [&:last-child[data-selected=true]_button]:rounded-r-md group/day aspect-square select-none',
+          props.showWeekNumber
+            ? '[&:nth-child(2)[data-selected=true]_button]:rounded-l-md'
+            : '[&:first-child[data-selected=true]_button]:rounded-l-md',
           defaultClassNames.day,
         ),
         range_start: cn(
@@ -175,7 +182,7 @@ function CalendarDayButton({
   day,
   modifiers,
   ...props
-}: React.ComponentProps<typeof DayButton>) {
+}: React.ComponentProps<typeof DayButton>): React.ReactElement {
   const defaultClassNames = getDefaultClassNames();
 
   const ref = React.useRef<HTMLButtonElement>(null);

--- a/ayunis-core-frontend/src/shared/ui/shadcn/card.tsx
+++ b/ayunis-core-frontend/src/shared/ui/shadcn/card.tsx
@@ -2,12 +2,15 @@ import * as React from 'react';
 
 import { cn } from '@/shared/lib/shadcn/utils';
 
-function Card({ className, ...props }: React.ComponentProps<'div'>) {
+function Card({
+  className,
+  ...props
+}: React.ComponentProps<'div'>): React.ReactElement {
   return (
     <div
       data-slot="card"
       className={cn(
-        'bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6',
+        'bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-sm',
         className,
       )}
       {...props}
@@ -15,12 +18,15 @@ function Card({ className, ...props }: React.ComponentProps<'div'>) {
   );
 }
 
-function CardHeader({ className, ...props }: React.ComponentProps<'div'>) {
+function CardHeader({
+  className,
+  ...props
+}: React.ComponentProps<'div'>): React.ReactElement {
   return (
     <div
       data-slot="card-header"
       className={cn(
-        '@container/card-header grid auto-rows-min grid-rows-[auto_auto] items-start gap-1.5 px-6 has-data-[slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-6',
+        '@container/card-header grid auto-rows-min grid-rows-[auto_auto] items-start gap-2 px-6 has-data-[slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-6',
         className,
       )}
       {...props}
@@ -28,7 +34,10 @@ function CardHeader({ className, ...props }: React.ComponentProps<'div'>) {
   );
 }
 
-function CardTitle({ className, ...props }: React.ComponentProps<'div'>) {
+function CardTitle({
+  className,
+  ...props
+}: React.ComponentProps<'div'>): React.ReactElement {
   return (
     <div
       data-slot="card-title"
@@ -38,7 +47,10 @@ function CardTitle({ className, ...props }: React.ComponentProps<'div'>) {
   );
 }
 
-function CardDescription({ className, ...props }: React.ComponentProps<'div'>) {
+function CardDescription({
+  className,
+  ...props
+}: React.ComponentProps<'div'>): React.ReactElement {
   return (
     <div
       data-slot="card-description"
@@ -48,7 +60,10 @@ function CardDescription({ className, ...props }: React.ComponentProps<'div'>) {
   );
 }
 
-function CardAction({ className, ...props }: React.ComponentProps<'div'>) {
+function CardAction({
+  className,
+  ...props
+}: React.ComponentProps<'div'>): React.ReactElement {
   return (
     <div
       data-slot="card-action"
@@ -61,7 +76,10 @@ function CardAction({ className, ...props }: React.ComponentProps<'div'>) {
   );
 }
 
-function CardContent({ className, ...props }: React.ComponentProps<'div'>) {
+function CardContent({
+  className,
+  ...props
+}: React.ComponentProps<'div'>): React.ReactElement {
   return (
     <div
       data-slot="card-content"
@@ -71,7 +89,10 @@ function CardContent({ className, ...props }: React.ComponentProps<'div'>) {
   );
 }
 
-function CardFooter({ className, ...props }: React.ComponentProps<'div'>) {
+function CardFooter({
+  className,
+  ...props
+}: React.ComponentProps<'div'>): React.ReactElement {
   return (
     <div
       data-slot="card-footer"

--- a/ayunis-core-frontend/src/shared/ui/shadcn/chart.tsx
+++ b/ayunis-core-frontend/src/shared/ui/shadcn/chart.tsx
@@ -291,7 +291,8 @@ function ChartLegendContent({
       {payload
         .filter((item) => item.type !== 'none')
         .map((item) => {
-          const key = `${nameKey || String(item.dataKey) || 'value'}`;
+          const dataKey = nameKey || item.dataKey || 'value';
+          const key = String(dataKey);
           const itemConfig = getPayloadConfigFromPayload(config, item, key);
 
           return (

--- a/ayunis-core-frontend/src/shared/ui/shadcn/chart.tsx
+++ b/ayunis-core-frontend/src/shared/ui/shadcn/chart.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-argument, @typescript-eslint/restrict-template-expressions */
 import * as React from 'react';
 import * as RechartsPrimitive from 'recharts';
 
@@ -22,7 +23,7 @@ type ChartContextProps = {
 
 const ChartContext = React.createContext<ChartContextProps | null>(null);
 
-function useChart() {
+function useChart(): ChartContextProps {
   const context = React.useContext(ChartContext);
 
   if (!context) {
@@ -43,7 +44,7 @@ function ChartContainer({
   children: React.ComponentProps<
     typeof RechartsPrimitive.ResponsiveContainer
   >['children'];
-}) {
+}): React.ReactElement {
   const uniqueId = React.useId();
   const chartId = `chart-${id || uniqueId.replace(/:/g, '')}`;
 
@@ -123,7 +124,7 @@ function ChartTooltipContent({
     indicator?: 'line' | 'dot' | 'dashed';
     nameKey?: string;
     labelKey?: string;
-  }) {
+  }): React.ReactElement | null {
   const { config } = useChart();
 
   const tooltipLabel = React.useMemo(() => {
@@ -182,8 +183,7 @@ function ChartTooltipContent({
           .map((item, index) => {
             const key = `${nameKey || item.name || item.dataKey || 'value'}`;
             const itemConfig = getPayloadConfigFromPayload(config, item, key);
-            const itemPayload = item.payload as { fill?: string } | undefined;
-            const indicatorColor = color || itemPayload?.fill || item.color;
+            const indicatorColor = color || item.payload.fill || item.color;
 
             return (
               <div
@@ -194,13 +194,7 @@ function ChartTooltipContent({
                 )}
               >
                 {formatter && item?.value !== undefined && item.name ? (
-                  formatter(
-                    item.value,
-                    item.name,
-                    item as never,
-                    index,
-                    item.payload as never,
-                  )
+                  formatter(item.value, item.name, item, index, item.payload)
                 ) : (
                   <>
                     {itemConfig?.icon ? (
@@ -235,7 +229,7 @@ function ChartTooltipContent({
                     >
                       <div className="grid gap-1.5">
                         {nestLabel ? tooltipLabel : null}
-                        <span className="text-muted-foreground mr-4">
+                        <span className="text-muted-foreground">
                           {itemConfig?.label || item.name}
                         </span>
                       </div>
@@ -267,7 +261,7 @@ function ChartLegendContent({
   Pick<RechartsPrimitive.LegendProps, 'payload' | 'verticalAlign'> & {
     hideIcon?: boolean;
     nameKey?: string;
-  }) {
+  }): React.ReactElement | null {
   const { config } = useChart();
 
   if (!payload?.length) {
@@ -285,13 +279,12 @@ function ChartLegendContent({
       {payload
         .filter((item) => item.type !== 'none')
         .map((item) => {
-          const dataKey = nameKey || item.dataKey || 'value';
-          const key = String(dataKey);
+          const key = `${nameKey || item.dataKey || 'value'}`;
           const itemConfig = getPayloadConfigFromPayload(config, item, key);
 
           return (
             <div
-              key={String(item.value)}
+              key={item.value}
               className={cn(
                 '[&>svg]:text-muted-foreground flex items-center gap-1.5 [&>svg]:h-3 [&>svg]:w-3',
               )}
@@ -319,7 +312,7 @@ function getPayloadConfigFromPayload(
   config: ChartConfig,
   payload: unknown,
   key: string,
-) {
+): ChartConfig[string] | undefined {
   if (typeof payload !== 'object' || payload === null) {
     return undefined;
   }

--- a/ayunis-core-frontend/src/shared/ui/shadcn/chart.tsx
+++ b/ayunis-core-frontend/src/shared/ui/shadcn/chart.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-argument, @typescript-eslint/restrict-template-expressions */
 import * as React from 'react';
 import * as RechartsPrimitive from 'recharts';
 
@@ -68,7 +67,13 @@ function ChartContainer({
   );
 }
 
-const ChartStyle = ({ id, config }: { id: string; config: ChartConfig }) => {
+const ChartStyle = ({
+  id,
+  config,
+}: {
+  id: string;
+  config: ChartConfig;
+}): React.ReactElement | null => {
   const colorConfig = Object.entries(config).filter(
     ([, config]) => config.theme || config.color,
   );
@@ -183,7 +188,8 @@ function ChartTooltipContent({
           .map((item, index) => {
             const key = `${nameKey || item.name || item.dataKey || 'value'}`;
             const itemConfig = getPayloadConfigFromPayload(config, item, key);
-            const indicatorColor = color || item.payload.fill || item.color;
+            const itemPayload = item.payload as { fill?: string } | undefined;
+            const indicatorColor = color || itemPayload?.fill || item.color;
 
             return (
               <div
@@ -194,7 +200,13 @@ function ChartTooltipContent({
                 )}
               >
                 {formatter && item?.value !== undefined && item.name ? (
-                  formatter(item.value, item.name, item, index, item.payload)
+                  formatter(
+                    item.value,
+                    item.name,
+                    item,
+                    index,
+                    item.payload as never,
+                  )
                 ) : (
                   <>
                     {itemConfig?.icon ? (
@@ -279,12 +291,12 @@ function ChartLegendContent({
       {payload
         .filter((item) => item.type !== 'none')
         .map((item) => {
-          const key = `${nameKey || item.dataKey || 'value'}`;
+          const key = `${nameKey || String(item.dataKey) || 'value'}`;
           const itemConfig = getPayloadConfigFromPayload(config, item, key);
 
           return (
             <div
-              key={item.value}
+              key={String(item.value)}
               className={cn(
                 '[&>svg]:text-muted-foreground flex items-center gap-1.5 [&>svg]:h-3 [&>svg]:w-3',
               )}

--- a/ayunis-core-frontend/src/shared/ui/shadcn/checkbox.tsx
+++ b/ayunis-core-frontend/src/shared/ui/shadcn/checkbox.tsx
@@ -7,7 +7,7 @@ import { cn } from '@/shared/lib/shadcn/utils';
 function Checkbox({
   className,
   ...props
-}: React.ComponentProps<typeof CheckboxPrimitive.Root>) {
+}: React.ComponentProps<typeof CheckboxPrimitive.Root>): React.ReactElement {
   return (
     <CheckboxPrimitive.Root
       data-slot="checkbox"
@@ -19,7 +19,7 @@ function Checkbox({
     >
       <CheckboxPrimitive.Indicator
         data-slot="checkbox-indicator"
-        className="flex items-center justify-center text-current transition-none"
+        className="grid place-content-center text-current transition-none"
       >
         <CheckIcon className="size-3.5" />
       </CheckboxPrimitive.Indicator>

--- a/ayunis-core-frontend/src/shared/ui/shadcn/collapsible.tsx
+++ b/ayunis-core-frontend/src/shared/ui/shadcn/collapsible.tsx
@@ -2,13 +2,15 @@ import * as CollapsiblePrimitive from '@radix-ui/react-collapsible';
 
 function Collapsible({
   ...props
-}: React.ComponentProps<typeof CollapsiblePrimitive.Root>) {
+}: React.ComponentProps<typeof CollapsiblePrimitive.Root>): React.ReactElement {
   return <CollapsiblePrimitive.Root data-slot="collapsible" {...props} />;
 }
 
 function CollapsibleTrigger({
   ...props
-}: React.ComponentProps<typeof CollapsiblePrimitive.CollapsibleTrigger>) {
+}: React.ComponentProps<
+  typeof CollapsiblePrimitive.CollapsibleTrigger
+>): React.ReactElement {
   return (
     <CollapsiblePrimitive.CollapsibleTrigger
       data-slot="collapsible-trigger"
@@ -19,7 +21,9 @@ function CollapsibleTrigger({
 
 function CollapsibleContent({
   ...props
-}: React.ComponentProps<typeof CollapsiblePrimitive.CollapsibleContent>) {
+}: React.ComponentProps<
+  typeof CollapsiblePrimitive.CollapsibleContent
+>): React.ReactElement {
   return (
     <CollapsiblePrimitive.CollapsibleContent
       data-slot="collapsible-content"

--- a/ayunis-core-frontend/src/shared/ui/shadcn/dialog.tsx
+++ b/ayunis-core-frontend/src/shared/ui/shadcn/dialog.tsx
@@ -17,7 +17,7 @@ function Dialog({
   children,
   open,
   ...props
-}: React.ComponentProps<typeof DialogPrimitive.Root>) {
+}: React.ComponentProps<typeof DialogPrimitive.Root>): React.ReactElement {
   const wasOpenRef = React.useRef(open);
   const cleanupTimeoutsRef = React.useRef<ReturnType<typeof setTimeout>[]>([]);
 
@@ -56,26 +56,26 @@ function Dialog({
 
 function DialogTrigger({
   ...props
-}: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
+}: React.ComponentProps<typeof DialogPrimitive.Trigger>): React.ReactElement {
   return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />;
 }
 
 function DialogPortal({
   ...props
-}: React.ComponentProps<typeof DialogPrimitive.Portal>) {
+}: React.ComponentProps<typeof DialogPrimitive.Portal>): React.ReactElement {
   return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />;
 }
 
 function DialogClose({
   ...props
-}: React.ComponentProps<typeof DialogPrimitive.Close>) {
+}: React.ComponentProps<typeof DialogPrimitive.Close>): React.ReactElement {
   return <DialogPrimitive.Close data-slot="dialog-close" {...props} />;
 }
 
 function DialogOverlay({
   className,
   ...props
-}: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
+}: React.ComponentProps<typeof DialogPrimitive.Overlay>): React.ReactElement {
   return (
     <DialogPrimitive.Overlay
       data-slot="dialog-overlay"
@@ -95,14 +95,14 @@ function DialogContent({
   ...props
 }: React.ComponentProps<typeof DialogPrimitive.Content> & {
   showCloseButton?: boolean;
-}) {
+}): React.ReactElement {
   return (
     <DialogPortal data-slot="dialog-portal">
       <DialogOverlay />
       <DialogPrimitive.Content
         data-slot="dialog-content"
         className={cn(
-          'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg',
+          'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 outline-none sm:max-w-lg',
           className,
         )}
         {...props}
@@ -122,7 +122,10 @@ function DialogContent({
   );
 }
 
-function DialogHeader({ className, ...props }: React.ComponentProps<'div'>) {
+function DialogHeader({
+  className,
+  ...props
+}: React.ComponentProps<'div'>): React.ReactElement {
   return (
     <div
       data-slot="dialog-header"
@@ -132,7 +135,10 @@ function DialogHeader({ className, ...props }: React.ComponentProps<'div'>) {
   );
 }
 
-function DialogFooter({ className, ...props }: React.ComponentProps<'div'>) {
+function DialogFooter({
+  className,
+  ...props
+}: React.ComponentProps<'div'>): React.ReactElement {
   return (
     <div
       data-slot="dialog-footer"
@@ -148,7 +154,7 @@ function DialogFooter({ className, ...props }: React.ComponentProps<'div'>) {
 function DialogTitle({
   className,
   ...props
-}: React.ComponentProps<typeof DialogPrimitive.Title>) {
+}: React.ComponentProps<typeof DialogPrimitive.Title>): React.ReactElement {
   return (
     <DialogPrimitive.Title
       data-slot="dialog-title"
@@ -161,7 +167,9 @@ function DialogTitle({
 function DialogDescription({
   className,
   ...props
-}: React.ComponentProps<typeof DialogPrimitive.Description>) {
+}: React.ComponentProps<
+  typeof DialogPrimitive.Description
+>): React.ReactElement {
   return (
     <DialogPrimitive.Description
       data-slot="dialog-description"

--- a/ayunis-core-frontend/src/shared/ui/shadcn/dropdown-menu.tsx
+++ b/ayunis-core-frontend/src/shared/ui/shadcn/dropdown-menu.tsx
@@ -6,13 +6,17 @@ import { cn } from '@/shared/lib/shadcn/utils';
 
 function DropdownMenu({
   ...props
-}: React.ComponentProps<typeof DropdownMenuPrimitive.Root>) {
+}: React.ComponentProps<
+  typeof DropdownMenuPrimitive.Root
+>): React.ReactElement {
   return <DropdownMenuPrimitive.Root data-slot="dropdown-menu" {...props} />;
 }
 
 function DropdownMenuPortal({
   ...props
-}: React.ComponentProps<typeof DropdownMenuPrimitive.Portal>) {
+}: React.ComponentProps<
+  typeof DropdownMenuPrimitive.Portal
+>): React.ReactElement {
   return (
     <DropdownMenuPrimitive.Portal data-slot="dropdown-menu-portal" {...props} />
   );
@@ -20,7 +24,9 @@ function DropdownMenuPortal({
 
 function DropdownMenuTrigger({
   ...props
-}: React.ComponentProps<typeof DropdownMenuPrimitive.Trigger>) {
+}: React.ComponentProps<
+  typeof DropdownMenuPrimitive.Trigger
+>): React.ReactElement {
   return (
     <DropdownMenuPrimitive.Trigger
       data-slot="dropdown-menu-trigger"
@@ -33,7 +39,9 @@ function DropdownMenuContent({
   className,
   sideOffset = 4,
   ...props
-}: React.ComponentProps<typeof DropdownMenuPrimitive.Content>) {
+}: React.ComponentProps<
+  typeof DropdownMenuPrimitive.Content
+>): React.ReactElement {
   return (
     <DropdownMenuPrimitive.Portal>
       <DropdownMenuPrimitive.Content
@@ -51,7 +59,9 @@ function DropdownMenuContent({
 
 function DropdownMenuGroup({
   ...props
-}: React.ComponentProps<typeof DropdownMenuPrimitive.Group>) {
+}: React.ComponentProps<
+  typeof DropdownMenuPrimitive.Group
+>): React.ReactElement {
   return (
     <DropdownMenuPrimitive.Group data-slot="dropdown-menu-group" {...props} />
   );
@@ -65,7 +75,7 @@ function DropdownMenuItem({
 }: React.ComponentProps<typeof DropdownMenuPrimitive.Item> & {
   inset?: boolean;
   variant?: 'default' | 'destructive';
-}) {
+}): React.ReactElement {
   return (
     <DropdownMenuPrimitive.Item
       data-slot="dropdown-menu-item"
@@ -85,7 +95,9 @@ function DropdownMenuCheckboxItem({
   children,
   checked,
   ...props
-}: React.ComponentProps<typeof DropdownMenuPrimitive.CheckboxItem>) {
+}: React.ComponentProps<
+  typeof DropdownMenuPrimitive.CheckboxItem
+>): React.ReactElement {
   return (
     <DropdownMenuPrimitive.CheckboxItem
       data-slot="dropdown-menu-checkbox-item"
@@ -108,7 +120,9 @@ function DropdownMenuCheckboxItem({
 
 function DropdownMenuRadioGroup({
   ...props
-}: React.ComponentProps<typeof DropdownMenuPrimitive.RadioGroup>) {
+}: React.ComponentProps<
+  typeof DropdownMenuPrimitive.RadioGroup
+>): React.ReactElement {
   return (
     <DropdownMenuPrimitive.RadioGroup
       data-slot="dropdown-menu-radio-group"
@@ -121,7 +135,9 @@ function DropdownMenuRadioItem({
   className,
   children,
   ...props
-}: React.ComponentProps<typeof DropdownMenuPrimitive.RadioItem>) {
+}: React.ComponentProps<
+  typeof DropdownMenuPrimitive.RadioItem
+>): React.ReactElement {
   return (
     <DropdownMenuPrimitive.RadioItem
       data-slot="dropdown-menu-radio-item"
@@ -147,7 +163,7 @@ function DropdownMenuLabel({
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.Label> & {
   inset?: boolean;
-}) {
+}): React.ReactElement {
   return (
     <DropdownMenuPrimitive.Label
       data-slot="dropdown-menu-label"
@@ -164,7 +180,9 @@ function DropdownMenuLabel({
 function DropdownMenuSeparator({
   className,
   ...props
-}: React.ComponentProps<typeof DropdownMenuPrimitive.Separator>) {
+}: React.ComponentProps<
+  typeof DropdownMenuPrimitive.Separator
+>): React.ReactElement {
   return (
     <DropdownMenuPrimitive.Separator
       data-slot="dropdown-menu-separator"
@@ -177,7 +195,7 @@ function DropdownMenuSeparator({
 function DropdownMenuShortcut({
   className,
   ...props
-}: React.ComponentProps<'span'>) {
+}: React.ComponentProps<'span'>): React.ReactElement {
   return (
     <span
       data-slot="dropdown-menu-shortcut"
@@ -192,7 +210,7 @@ function DropdownMenuShortcut({
 
 function DropdownMenuSub({
   ...props
-}: React.ComponentProps<typeof DropdownMenuPrimitive.Sub>) {
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Sub>): React.ReactElement {
   return <DropdownMenuPrimitive.Sub data-slot="dropdown-menu-sub" {...props} />;
 }
 
@@ -203,13 +221,13 @@ function DropdownMenuSubTrigger({
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.SubTrigger> & {
   inset?: boolean;
-}) {
+}): React.ReactElement {
   return (
     <DropdownMenuPrimitive.SubTrigger
       data-slot="dropdown-menu-sub-trigger"
       data-inset={inset}
       className={cn(
-        'focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground flex cursor-default items-center rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[inset]:pl-8',
+        "focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className,
       )}
       {...props}
@@ -223,7 +241,9 @@ function DropdownMenuSubTrigger({
 function DropdownMenuSubContent({
   className,
   ...props
-}: React.ComponentProps<typeof DropdownMenuPrimitive.SubContent>) {
+}: React.ComponentProps<
+  typeof DropdownMenuPrimitive.SubContent
+>): React.ReactElement {
   return (
     <DropdownMenuPrimitive.SubContent
       data-slot="dropdown-menu-sub-content"

--- a/ayunis-core-frontend/src/shared/ui/shadcn/empty.tsx
+++ b/ayunis-core-frontend/src/shared/ui/shadcn/empty.tsx
@@ -2,7 +2,10 @@ import { cva, type VariantProps } from 'class-variance-authority';
 
 import { cn } from '@/shared/lib/shadcn/utils';
 
-function Empty({ className, ...props }: React.ComponentProps<'div'>) {
+function Empty({
+  className,
+  ...props
+}: React.ComponentProps<'div'>): React.ReactElement {
   return (
     <div
       data-slot="empty"
@@ -15,7 +18,10 @@ function Empty({ className, ...props }: React.ComponentProps<'div'>) {
   );
 }
 
-function EmptyHeader({ className, ...props }: React.ComponentProps<'div'>) {
+function EmptyHeader({
+  className,
+  ...props
+}: React.ComponentProps<'div'>): React.ReactElement {
   return (
     <div
       data-slot="empty-header"
@@ -47,7 +53,8 @@ function EmptyMedia({
   className,
   variant = 'default',
   ...props
-}: React.ComponentProps<'div'> & VariantProps<typeof emptyMediaVariants>) {
+}: React.ComponentProps<'div'> &
+  VariantProps<typeof emptyMediaVariants>): React.ReactElement {
   return (
     <div
       data-slot="empty-icon"
@@ -58,7 +65,10 @@ function EmptyMedia({
   );
 }
 
-function EmptyTitle({ className, ...props }: React.ComponentProps<'div'>) {
+function EmptyTitle({
+  className,
+  ...props
+}: React.ComponentProps<'div'>): React.ReactElement {
   return (
     <div
       data-slot="empty-title"
@@ -68,7 +78,10 @@ function EmptyTitle({ className, ...props }: React.ComponentProps<'div'>) {
   );
 }
 
-function EmptyDescription({ className, ...props }: React.ComponentProps<'p'>) {
+function EmptyDescription({
+  className,
+  ...props
+}: React.ComponentProps<'p'>): React.ReactElement {
   return (
     <div
       data-slot="empty-description"
@@ -81,7 +94,10 @@ function EmptyDescription({ className, ...props }: React.ComponentProps<'p'>) {
   );
 }
 
-function EmptyContent({ className, ...props }: React.ComponentProps<'div'>) {
+function EmptyContent({
+  className,
+  ...props
+}: React.ComponentProps<'div'>): React.ReactElement {
   return (
     <div
       data-slot="empty-content"

--- a/ayunis-core-frontend/src/shared/ui/shadcn/form.tsx
+++ b/ayunis-core-frontend/src/shared/ui/shadcn/form.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import * as LabelPrimitive from '@radix-ui/react-label';
+import type * as LabelPrimitive from '@radix-ui/react-label';
 import { Slot } from '@radix-ui/react-slot';
 import {
   Controller,
@@ -32,7 +32,7 @@ const FormField = <
   TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
 >({
   ...props
-}: ControllerProps<TFieldValues, TName>) => {
+}: ControllerProps<TFieldValues, TName>): React.ReactElement => {
   return (
     <FormFieldContext.Provider value={{ name: props.name }}>
       <Controller {...props} />
@@ -40,7 +40,17 @@ const FormField = <
   );
 };
 
-function useFormField() {
+const useFormField = (): {
+  id: string;
+  name: string;
+  formItemId: string;
+  formDescriptionId: string;
+  formMessageId: string;
+  invalid: boolean;
+  isDirty: boolean;
+  isTouched: boolean;
+  error?: { message?: string };
+} => {
   const fieldContext = React.useContext(FormFieldContext);
   const itemContext = React.useContext(FormItemContext);
   const { getFieldState } = useFormContext();
@@ -61,7 +71,7 @@ function useFormField() {
     formMessageId: `${id}-form-item-message`,
     ...fieldState,
   };
-}
+};
 
 type FormItemContextValue = {
   id: string;
@@ -71,7 +81,10 @@ const FormItemContext = React.createContext<FormItemContextValue>(
   {} as FormItemContextValue,
 );
 
-function FormItem({ className, ...props }: React.ComponentProps<'div'>) {
+function FormItem({
+  className,
+  ...props
+}: React.ComponentProps<'div'>): React.ReactElement {
   const id = React.useId();
 
   return (
@@ -88,7 +101,7 @@ function FormItem({ className, ...props }: React.ComponentProps<'div'>) {
 function FormLabel({
   className,
   ...props
-}: React.ComponentProps<typeof LabelPrimitive.Root>) {
+}: React.ComponentProps<typeof LabelPrimitive.Root>): React.ReactElement {
   const { error, formItemId } = useFormField();
 
   return (
@@ -102,7 +115,9 @@ function FormLabel({
   );
 }
 
-function FormControl({ ...props }: React.ComponentProps<typeof Slot>) {
+function FormControl({
+  ...props
+}: React.ComponentProps<typeof Slot>): React.ReactElement {
   const { error, formItemId, formDescriptionId, formMessageId } =
     useFormField();
 
@@ -121,7 +136,10 @@ function FormControl({ ...props }: React.ComponentProps<typeof Slot>) {
   );
 }
 
-function FormDescription({ className, ...props }: React.ComponentProps<'p'>) {
+function FormDescription({
+  className,
+  ...props
+}: React.ComponentProps<'p'>): React.ReactElement {
   const { formDescriptionId } = useFormField();
 
   return (
@@ -134,7 +152,10 @@ function FormDescription({ className, ...props }: React.ComponentProps<'p'>) {
   );
 }
 
-function FormMessage({ className, ...props }: React.ComponentProps<'p'>) {
+function FormMessage({
+  className,
+  ...props
+}: React.ComponentProps<'p'>): React.ReactElement | null {
   const { error, formMessageId } = useFormField();
   const body = error ? String(error?.message ?? '') : props.children;
 

--- a/ayunis-core-frontend/src/shared/ui/shadcn/input.tsx
+++ b/ayunis-core-frontend/src/shared/ui/shadcn/input.tsx
@@ -2,13 +2,17 @@ import * as React from 'react';
 
 import { cn } from '@/shared/lib/shadcn/utils';
 
-function Input({ className, type, ...props }: React.ComponentProps<'input'>) {
+function Input({
+  className,
+  type,
+  ...props
+}: React.ComponentProps<'input'>): React.ReactElement {
   return (
     <input
       type={type}
       data-slot="input"
       className={cn(
-        'file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
+        'file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
         'focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]',
         'aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive',
         className,

--- a/ayunis-core-frontend/src/shared/ui/shadcn/item.tsx
+++ b/ayunis-core-frontend/src/shared/ui/shadcn/item.tsx
@@ -5,7 +5,10 @@ import { cva, type VariantProps } from 'class-variance-authority';
 import { cn } from '@/shared/lib/shadcn/utils';
 import { Separator } from '@/shared/ui/shadcn/separator';
 
-function ItemGroup({ className, ...props }: React.ComponentProps<'div'>) {
+function ItemGroup({
+  className,
+  ...props
+}: React.ComponentProps<'div'>): React.ReactElement {
   return (
     <div
       role="list"
@@ -19,7 +22,7 @@ function ItemGroup({ className, ...props }: React.ComponentProps<'div'>) {
 function ItemSeparator({
   className,
   ...props
-}: React.ComponentProps<typeof Separator>) {
+}: React.ComponentProps<typeof Separator>): React.ReactElement {
   return (
     <Separator
       data-slot="item-separator"
@@ -58,7 +61,9 @@ function Item({
   asChild = false,
   ...props
 }: React.ComponentProps<'div'> &
-  VariantProps<typeof itemVariants> & { asChild?: boolean }) {
+  VariantProps<typeof itemVariants> & {
+    asChild?: boolean;
+  }): React.ReactElement {
   const Comp = asChild ? Slot : 'div';
   return (
     <Comp
@@ -92,7 +97,8 @@ function ItemMedia({
   className,
   variant = 'default',
   ...props
-}: React.ComponentProps<'div'> & VariantProps<typeof itemMediaVariants>) {
+}: React.ComponentProps<'div'> &
+  VariantProps<typeof itemMediaVariants>): React.ReactElement {
   return (
     <div
       data-slot="item-media"
@@ -103,7 +109,10 @@ function ItemMedia({
   );
 }
 
-function ItemContent({ className, ...props }: React.ComponentProps<'div'>) {
+function ItemContent({
+  className,
+  ...props
+}: React.ComponentProps<'div'>): React.ReactElement {
   return (
     <div
       data-slot="item-content"
@@ -116,7 +125,10 @@ function ItemContent({ className, ...props }: React.ComponentProps<'div'>) {
   );
 }
 
-function ItemTitle({ className, ...props }: React.ComponentProps<'div'>) {
+function ItemTitle({
+  className,
+  ...props
+}: React.ComponentProps<'div'>): React.ReactElement {
   return (
     <div
       data-slot="item-title"
@@ -129,7 +141,10 @@ function ItemTitle({ className, ...props }: React.ComponentProps<'div'>) {
   );
 }
 
-function ItemDescription({ className, ...props }: React.ComponentProps<'p'>) {
+function ItemDescription({
+  className,
+  ...props
+}: React.ComponentProps<'p'>): React.ReactElement {
   return (
     <p
       data-slot="item-description"
@@ -143,7 +158,10 @@ function ItemDescription({ className, ...props }: React.ComponentProps<'p'>) {
   );
 }
 
-function ItemActions({ className, ...props }: React.ComponentProps<'div'>) {
+function ItemActions({
+  className,
+  ...props
+}: React.ComponentProps<'div'>): React.ReactElement {
   return (
     <div
       data-slot="item-actions"
@@ -153,7 +171,10 @@ function ItemActions({ className, ...props }: React.ComponentProps<'div'>) {
   );
 }
 
-function ItemHeader({ className, ...props }: React.ComponentProps<'div'>) {
+function ItemHeader({
+  className,
+  ...props
+}: React.ComponentProps<'div'>): React.ReactElement {
   return (
     <div
       data-slot="item-header"
@@ -166,7 +187,10 @@ function ItemHeader({ className, ...props }: React.ComponentProps<'div'>) {
   );
 }
 
-function ItemFooter({ className, ...props }: React.ComponentProps<'div'>) {
+function ItemFooter({
+  className,
+  ...props
+}: React.ComponentProps<'div'>): React.ReactElement {
   return (
     <div
       data-slot="item-footer"

--- a/ayunis-core-frontend/src/shared/ui/shadcn/label.tsx
+++ b/ayunis-core-frontend/src/shared/ui/shadcn/label.tsx
@@ -6,7 +6,7 @@ import { cn } from '@/shared/lib/shadcn/utils';
 function Label({
   className,
   ...props
-}: React.ComponentProps<typeof LabelPrimitive.Root>) {
+}: React.ComponentProps<typeof LabelPrimitive.Root>): React.ReactElement {
   return (
     <LabelPrimitive.Root
       data-slot="label"

--- a/ayunis-core-frontend/src/shared/ui/shadcn/pagination.tsx
+++ b/ayunis-core-frontend/src/shared/ui/shadcn/pagination.tsx
@@ -6,9 +6,12 @@ import {
 } from 'lucide-react';
 
 import { cn } from '@/shared/lib/shadcn/utils';
-import { Button, buttonVariants } from '@/shared/ui/shadcn/button';
+import { buttonVariants, type Button } from '@/shared/ui/shadcn/button';
 
-function Pagination({ className, ...props }: React.ComponentProps<'nav'>) {
+function Pagination({
+  className,
+  ...props
+}: React.ComponentProps<'nav'>): React.ReactElement {
   return (
     <nav
       role="navigation"
@@ -23,7 +26,7 @@ function Pagination({ className, ...props }: React.ComponentProps<'nav'>) {
 function PaginationContent({
   className,
   ...props
-}: React.ComponentProps<'ul'>) {
+}: React.ComponentProps<'ul'>): React.ReactElement {
   return (
     <ul
       data-slot="pagination-content"
@@ -33,7 +36,9 @@ function PaginationContent({
   );
 }
 
-function PaginationItem({ ...props }: React.ComponentProps<'li'>) {
+function PaginationItem({
+  ...props
+}: React.ComponentProps<'li'>): React.ReactElement {
   return <li data-slot="pagination-item" {...props} />;
 }
 
@@ -47,7 +52,7 @@ function PaginationLink({
   isActive,
   size = 'icon',
   ...props
-}: PaginationLinkProps) {
+}: PaginationLinkProps): React.ReactElement {
   return (
     <a
       aria-current={isActive ? 'page' : undefined}
@@ -65,46 +70,63 @@ function PaginationLink({
   );
 }
 
+type PaginationPreviousProps = React.ComponentProps<typeof PaginationLink> & {
+  label?: string;
+  ariaLabel?: string;
+};
+
 function PaginationPrevious({
   className,
-  label,
+  label = 'Previous',
+  ariaLabel = 'Go to previous page',
   ...props
-}: React.ComponentProps<typeof PaginationLink> & { label?: string }) {
+}: PaginationPreviousProps): React.ReactElement {
   return (
     <PaginationLink
-      aria-label="Go to previous page"
+      aria-label={ariaLabel}
       size="default"
       className={cn('gap-1 px-2.5 sm:pl-2.5', className)}
       {...props}
     >
       <ChevronLeftIcon />
-      <span className="hidden sm:block">{label ?? 'Previous'}</span>
+      <span className="hidden sm:block">{label}</span>
     </PaginationLink>
   );
 }
 
+type PaginationNextProps = React.ComponentProps<typeof PaginationLink> & {
+  label?: string;
+  ariaLabel?: string;
+};
+
 function PaginationNext({
   className,
-  label,
+  label = 'Next',
+  ariaLabel = 'Go to next page',
   ...props
-}: React.ComponentProps<typeof PaginationLink> & { label?: string }) {
+}: PaginationNextProps): React.ReactElement {
   return (
     <PaginationLink
-      aria-label="Go to next page"
+      aria-label={ariaLabel}
       size="default"
       className={cn('gap-1 px-2.5 sm:pr-2.5', className)}
       {...props}
     >
-      <span className="hidden sm:block">{label ?? 'Next'}</span>
+      <span className="hidden sm:block">{label}</span>
       <ChevronRightIcon />
     </PaginationLink>
   );
 }
 
+type PaginationEllipsisProps = React.ComponentProps<'span'> & {
+  srLabel?: string;
+};
+
 function PaginationEllipsis({
   className,
+  srLabel = 'More pages',
   ...props
-}: React.ComponentProps<'span'>) {
+}: PaginationEllipsisProps): React.ReactElement {
   return (
     <span
       aria-hidden
@@ -113,7 +135,7 @@ function PaginationEllipsis({
       {...props}
     >
       <MoreHorizontalIcon className="size-4" />
-      <span className="sr-only">More pages</span>
+      <span className="sr-only">{srLabel}</span>
     </span>
   );
 }
@@ -126,4 +148,11 @@ export {
   PaginationPrevious,
   PaginationNext,
   PaginationEllipsis,
+};
+
+export type {
+  PaginationLinkProps,
+  PaginationPreviousProps,
+  PaginationNextProps,
+  PaginationEllipsisProps,
 };

--- a/ayunis-core-frontend/src/shared/ui/shadcn/popover.tsx
+++ b/ayunis-core-frontend/src/shared/ui/shadcn/popover.tsx
@@ -5,13 +5,13 @@ import { cn } from '@/shared/lib/shadcn/utils';
 
 function Popover({
   ...props
-}: React.ComponentProps<typeof PopoverPrimitive.Root>) {
+}: React.ComponentProps<typeof PopoverPrimitive.Root>): React.ReactElement {
   return <PopoverPrimitive.Root data-slot="popover" {...props} />;
 }
 
 function PopoverTrigger({
   ...props
-}: React.ComponentProps<typeof PopoverPrimitive.Trigger>) {
+}: React.ComponentProps<typeof PopoverPrimitive.Trigger>): React.ReactElement {
   return <PopoverPrimitive.Trigger data-slot="popover-trigger" {...props} />;
 }
 
@@ -20,7 +20,7 @@ function PopoverContent({
   align = 'center',
   sideOffset = 4,
   ...props
-}: React.ComponentProps<typeof PopoverPrimitive.Content>) {
+}: React.ComponentProps<typeof PopoverPrimitive.Content>): React.ReactElement {
   return (
     <PopoverPrimitive.Portal>
       <PopoverPrimitive.Content
@@ -39,7 +39,7 @@ function PopoverContent({
 
 function PopoverAnchor({
   ...props
-}: React.ComponentProps<typeof PopoverPrimitive.Anchor>) {
+}: React.ComponentProps<typeof PopoverPrimitive.Anchor>): React.ReactElement {
   return <PopoverPrimitive.Anchor data-slot="popover-anchor" {...props} />;
 }
 

--- a/ayunis-core-frontend/src/shared/ui/shadcn/scroll-area.tsx
+++ b/ayunis-core-frontend/src/shared/ui/shadcn/scroll-area.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import * as React from 'react';
 import * as ScrollAreaPrimitive from '@radix-ui/react-scroll-area';
 
@@ -9,7 +7,7 @@ function ScrollArea({
   className,
   children,
   ...props
-}: React.ComponentProps<typeof ScrollAreaPrimitive.Root>) {
+}: React.ComponentProps<typeof ScrollAreaPrimitive.Root>): React.ReactElement {
   return (
     <ScrollAreaPrimitive.Root
       data-slot="scroll-area"
@@ -32,7 +30,9 @@ function ScrollBar({
   className,
   orientation = 'vertical',
   ...props
-}: React.ComponentProps<typeof ScrollAreaPrimitive.ScrollAreaScrollbar>) {
+}: React.ComponentProps<
+  typeof ScrollAreaPrimitive.ScrollAreaScrollbar
+>): React.ReactElement {
   return (
     <ScrollAreaPrimitive.ScrollAreaScrollbar
       data-slot="scroll-area-scrollbar"

--- a/ayunis-core-frontend/src/shared/ui/shadcn/select.tsx
+++ b/ayunis-core-frontend/src/shared/ui/shadcn/select.tsx
@@ -6,19 +6,19 @@ import { cn } from '@/shared/lib/shadcn/utils';
 
 function Select({
   ...props
-}: React.ComponentProps<typeof SelectPrimitive.Root>) {
+}: React.ComponentProps<typeof SelectPrimitive.Root>): React.ReactElement {
   return <SelectPrimitive.Root data-slot="select" {...props} />;
 }
 
 function SelectGroup({
   ...props
-}: React.ComponentProps<typeof SelectPrimitive.Group>) {
+}: React.ComponentProps<typeof SelectPrimitive.Group>): React.ReactElement {
   return <SelectPrimitive.Group data-slot="select-group" {...props} />;
 }
 
 function SelectValue({
   ...props
-}: React.ComponentProps<typeof SelectPrimitive.Value>) {
+}: React.ComponentProps<typeof SelectPrimitive.Value>): React.ReactElement {
   return <SelectPrimitive.Value data-slot="select-value" {...props} />;
 }
 
@@ -29,7 +29,7 @@ function SelectTrigger({
   ...props
 }: React.ComponentProps<typeof SelectPrimitive.Trigger> & {
   size?: 'sm' | 'default';
-}) {
+}): React.ReactElement {
   return (
     <SelectPrimitive.Trigger
       data-slot="select-trigger"
@@ -38,7 +38,6 @@ function SelectTrigger({
         "border-input data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 dark:hover:bg-input/50 flex w-fit items-center justify-between gap-2 rounded-md border bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className,
       )}
-      data-testid="select-trigger"
       {...props}
     >
       {children}
@@ -52,9 +51,10 @@ function SelectTrigger({
 function SelectContent({
   className,
   children,
-  position = 'popper',
+  position = 'item-aligned',
+  align = 'center',
   ...props
-}: React.ComponentProps<typeof SelectPrimitive.Content>) {
+}: React.ComponentProps<typeof SelectPrimitive.Content>): React.ReactElement {
   return (
     <SelectPrimitive.Portal>
       <SelectPrimitive.Content
@@ -66,6 +66,7 @@ function SelectContent({
           className,
         )}
         position={position}
+        align={align}
         {...props}
       >
         <SelectScrollUpButton />
@@ -87,7 +88,7 @@ function SelectContent({
 function SelectLabel({
   className,
   ...props
-}: React.ComponentProps<typeof SelectPrimitive.Label>) {
+}: React.ComponentProps<typeof SelectPrimitive.Label>): React.ReactElement {
   return (
     <SelectPrimitive.Label
       data-slot="select-label"
@@ -101,7 +102,7 @@ function SelectItem({
   className,
   children,
   ...props
-}: React.ComponentProps<typeof SelectPrimitive.Item>) {
+}: React.ComponentProps<typeof SelectPrimitive.Item>): React.ReactElement {
   return (
     <SelectPrimitive.Item
       data-slot="select-item"
@@ -111,7 +112,10 @@ function SelectItem({
       )}
       {...props}
     >
-      <span className="absolute right-2 flex size-3.5 items-center justify-center">
+      <span
+        data-slot="select-item-indicator"
+        className="absolute right-2 flex size-3.5 items-center justify-center"
+      >
         <SelectPrimitive.ItemIndicator>
           <CheckIcon className="size-4" />
         </SelectPrimitive.ItemIndicator>
@@ -124,7 +128,7 @@ function SelectItem({
 function SelectSeparator({
   className,
   ...props
-}: React.ComponentProps<typeof SelectPrimitive.Separator>) {
+}: React.ComponentProps<typeof SelectPrimitive.Separator>): React.ReactElement {
   return (
     <SelectPrimitive.Separator
       data-slot="select-separator"
@@ -137,7 +141,9 @@ function SelectSeparator({
 function SelectScrollUpButton({
   className,
   ...props
-}: React.ComponentProps<typeof SelectPrimitive.ScrollUpButton>) {
+}: React.ComponentProps<
+  typeof SelectPrimitive.ScrollUpButton
+>): React.ReactElement {
   return (
     <SelectPrimitive.ScrollUpButton
       data-slot="select-scroll-up-button"
@@ -155,7 +161,9 @@ function SelectScrollUpButton({
 function SelectScrollDownButton({
   className,
   ...props
-}: React.ComponentProps<typeof SelectPrimitive.ScrollDownButton>) {
+}: React.ComponentProps<
+  typeof SelectPrimitive.ScrollDownButton
+>): React.ReactElement {
   return (
     <SelectPrimitive.ScrollDownButton
       data-slot="select-scroll-down-button"

--- a/ayunis-core-frontend/src/shared/ui/shadcn/separator.tsx
+++ b/ayunis-core-frontend/src/shared/ui/shadcn/separator.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import * as React from 'react';
 import * as SeparatorPrimitive from '@radix-ui/react-separator';
 
@@ -10,7 +8,7 @@ function Separator({
   orientation = 'horizontal',
   decorative = true,
   ...props
-}: React.ComponentProps<typeof SeparatorPrimitive.Root>) {
+}: React.ComponentProps<typeof SeparatorPrimitive.Root>): React.ReactElement {
   return (
     <SeparatorPrimitive.Root
       data-slot="separator"

--- a/ayunis-core-frontend/src/shared/ui/shadcn/sheet.tsx
+++ b/ayunis-core-frontend/src/shared/ui/shadcn/sheet.tsx
@@ -4,32 +4,34 @@ import { XIcon } from 'lucide-react';
 
 import { cn } from '@/shared/lib/shadcn/utils';
 
-function Sheet({ ...props }: React.ComponentProps<typeof SheetPrimitive.Root>) {
+function Sheet({
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Root>): React.ReactElement {
   return <SheetPrimitive.Root data-slot="sheet" {...props} />;
 }
 
 function SheetTrigger({
   ...props
-}: React.ComponentProps<typeof SheetPrimitive.Trigger>) {
+}: React.ComponentProps<typeof SheetPrimitive.Trigger>): React.ReactElement {
   return <SheetPrimitive.Trigger data-slot="sheet-trigger" {...props} />;
 }
 
 function SheetClose({
   ...props
-}: React.ComponentProps<typeof SheetPrimitive.Close>) {
+}: React.ComponentProps<typeof SheetPrimitive.Close>): React.ReactElement {
   return <SheetPrimitive.Close data-slot="sheet-close" {...props} />;
 }
 
 function SheetPortal({
   ...props
-}: React.ComponentProps<typeof SheetPrimitive.Portal>) {
+}: React.ComponentProps<typeof SheetPrimitive.Portal>): React.ReactElement {
   return <SheetPrimitive.Portal data-slot="sheet-portal" {...props} />;
 }
 
 function SheetOverlay({
   className,
   ...props
-}: React.ComponentProps<typeof SheetPrimitive.Overlay>) {
+}: React.ComponentProps<typeof SheetPrimitive.Overlay>): React.ReactElement {
   return (
     <SheetPrimitive.Overlay
       data-slot="sheet-overlay"
@@ -49,7 +51,7 @@ function SheetContent({
   ...props
 }: React.ComponentProps<typeof SheetPrimitive.Content> & {
   side?: 'top' | 'right' | 'bottom' | 'left';
-}) {
+}): React.ReactElement {
   return (
     <SheetPortal>
       <SheetOverlay />
@@ -79,7 +81,10 @@ function SheetContent({
   );
 }
 
-function SheetHeader({ className, ...props }: React.ComponentProps<'div'>) {
+function SheetHeader({
+  className,
+  ...props
+}: React.ComponentProps<'div'>): React.ReactElement {
   return (
     <div
       data-slot="sheet-header"
@@ -89,7 +94,10 @@ function SheetHeader({ className, ...props }: React.ComponentProps<'div'>) {
   );
 }
 
-function SheetFooter({ className, ...props }: React.ComponentProps<'div'>) {
+function SheetFooter({
+  className,
+  ...props
+}: React.ComponentProps<'div'>): React.ReactElement {
   return (
     <div
       data-slot="sheet-footer"
@@ -102,7 +110,7 @@ function SheetFooter({ className, ...props }: React.ComponentProps<'div'>) {
 function SheetTitle({
   className,
   ...props
-}: React.ComponentProps<typeof SheetPrimitive.Title>) {
+}: React.ComponentProps<typeof SheetPrimitive.Title>): React.ReactElement {
   return (
     <SheetPrimitive.Title
       data-slot="sheet-title"
@@ -115,7 +123,9 @@ function SheetTitle({
 function SheetDescription({
   className,
   ...props
-}: React.ComponentProps<typeof SheetPrimitive.Description>) {
+}: React.ComponentProps<
+  typeof SheetPrimitive.Description
+>): React.ReactElement {
   return (
     <SheetPrimitive.Description
       data-slot="sheet-description"

--- a/ayunis-core-frontend/src/shared/ui/shadcn/sidebar.tsx
+++ b/ayunis-core-frontend/src/shared/ui/shadcn/sidebar.tsx
@@ -1,3 +1,4 @@
+// This file modified, need to be pulled from ayunis registry.
 import * as React from 'react';
 import { Slot } from '@radix-ui/react-slot';
 import { cva, type VariantProps } from 'class-variance-authority';

--- a/ayunis-core-frontend/src/shared/ui/shadcn/skeleton.tsx
+++ b/ayunis-core-frontend/src/shared/ui/shadcn/skeleton.tsx
@@ -1,6 +1,9 @@
 import { cn } from '@/shared/lib/shadcn/utils';
 
-function Skeleton({ className, ...props }: React.ComponentProps<'div'>) {
+function Skeleton({
+  className,
+  ...props
+}: React.ComponentProps<'div'>): React.ReactElement {
   return (
     <div
       data-slot="skeleton"

--- a/ayunis-core-frontend/src/shared/ui/shadcn/slider.tsx
+++ b/ayunis-core-frontend/src/shared/ui/shadcn/slider.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import * as React from 'react';
 import * as SliderPrimitive from '@radix-ui/react-slider';
 
@@ -12,7 +10,7 @@ function Slider({
   min = 0,
   max = 100,
   ...props
-}: React.ComponentProps<typeof SliderPrimitive.Root>) {
+}: React.ComponentProps<typeof SliderPrimitive.Root>): React.ReactElement {
   const _values = React.useMemo(
     () =>
       Array.isArray(value)
@@ -53,7 +51,7 @@ function Slider({
         <SliderPrimitive.Thumb
           data-slot="slider-thumb"
           key={index}
-          className="border-primary bg-background ring-ring/50 block size-4 shrink-0 rounded-full border shadow-sm transition-[color,box-shadow] hover:ring-4 focus-visible:ring-4 focus-visible:outline-hidden disabled:pointer-events-none disabled:opacity-50"
+          className="border-primary ring-ring/50 block size-4 shrink-0 rounded-full border bg-white shadow-sm transition-[color,box-shadow] hover:ring-4 focus-visible:ring-4 focus-visible:outline-hidden disabled:pointer-events-none disabled:opacity-50"
         />
       ))}
     </SliderPrimitive.Root>

--- a/ayunis-core-frontend/src/shared/ui/shadcn/slider.tsx
+++ b/ayunis-core-frontend/src/shared/ui/shadcn/slider.tsx
@@ -51,7 +51,7 @@ function Slider({
         <SliderPrimitive.Thumb
           data-slot="slider-thumb"
           key={index}
-          className="border-primary ring-ring/50 block size-4 shrink-0 rounded-full border bg-white shadow-sm transition-[color,box-shadow] hover:ring-4 focus-visible:ring-4 focus-visible:outline-hidden disabled:pointer-events-none disabled:opacity-50"
+          className="border-primary bg-background ring-ring/50 block size-4 shrink-0 rounded-full border shadow-sm transition-[color,box-shadow] hover:ring-4 focus-visible:ring-4 focus-visible:outline-hidden disabled:pointer-events-none disabled:opacity-50"
         />
       ))}
     </SliderPrimitive.Root>

--- a/ayunis-core-frontend/src/shared/ui/shadcn/switch.tsx
+++ b/ayunis-core-frontend/src/shared/ui/shadcn/switch.tsx
@@ -6,7 +6,7 @@ import { cn } from '@/shared/lib/shadcn/utils';
 function Switch({
   className,
   ...props
-}: React.ComponentProps<typeof SwitchPrimitive.Root>) {
+}: React.ComponentProps<typeof SwitchPrimitive.Root>): React.ReactElement {
   return (
     <SwitchPrimitive.Root
       data-slot="switch"

--- a/ayunis-core-frontend/src/shared/ui/shadcn/table.tsx
+++ b/ayunis-core-frontend/src/shared/ui/shadcn/table.tsx
@@ -2,7 +2,10 @@ import * as React from 'react';
 
 import { cn } from '@/shared/lib/shadcn/utils';
 
-function Table({ className, ...props }: React.ComponentProps<'table'>) {
+function Table({
+  className,
+  ...props
+}: React.ComponentProps<'table'>): React.ReactElement {
   return (
     <div
       data-slot="table-container"
@@ -17,7 +20,10 @@ function Table({ className, ...props }: React.ComponentProps<'table'>) {
   );
 }
 
-function TableHeader({ className, ...props }: React.ComponentProps<'thead'>) {
+function TableHeader({
+  className,
+  ...props
+}: React.ComponentProps<'thead'>): React.ReactElement {
   return (
     <thead
       data-slot="table-header"
@@ -27,7 +33,10 @@ function TableHeader({ className, ...props }: React.ComponentProps<'thead'>) {
   );
 }
 
-function TableBody({ className, ...props }: React.ComponentProps<'tbody'>) {
+function TableBody({
+  className,
+  ...props
+}: React.ComponentProps<'tbody'>): React.ReactElement {
   return (
     <tbody
       data-slot="table-body"
@@ -37,7 +46,10 @@ function TableBody({ className, ...props }: React.ComponentProps<'tbody'>) {
   );
 }
 
-function TableFooter({ className, ...props }: React.ComponentProps<'tfoot'>) {
+function TableFooter({
+  className,
+  ...props
+}: React.ComponentProps<'tfoot'>): React.ReactElement {
   return (
     <tfoot
       data-slot="table-footer"
@@ -50,7 +62,10 @@ function TableFooter({ className, ...props }: React.ComponentProps<'tfoot'>) {
   );
 }
 
-function TableRow({ className, ...props }: React.ComponentProps<'tr'>) {
+function TableRow({
+  className,
+  ...props
+}: React.ComponentProps<'tr'>): React.ReactElement {
   return (
     <tr
       data-slot="table-row"
@@ -63,7 +78,10 @@ function TableRow({ className, ...props }: React.ComponentProps<'tr'>) {
   );
 }
 
-function TableHead({ className, ...props }: React.ComponentProps<'th'>) {
+function TableHead({
+  className,
+  ...props
+}: React.ComponentProps<'th'>): React.ReactElement {
   return (
     <th
       data-slot="table-head"
@@ -76,7 +94,10 @@ function TableHead({ className, ...props }: React.ComponentProps<'th'>) {
   );
 }
 
-function TableCell({ className, ...props }: React.ComponentProps<'td'>) {
+function TableCell({
+  className,
+  ...props
+}: React.ComponentProps<'td'>): React.ReactElement {
   return (
     <td
       data-slot="table-cell"
@@ -92,7 +113,7 @@ function TableCell({ className, ...props }: React.ComponentProps<'td'>) {
 function TableCaption({
   className,
   ...props
-}: React.ComponentProps<'caption'>) {
+}: React.ComponentProps<'caption'>): React.ReactElement {
   return (
     <caption
       data-slot="table-caption"

--- a/ayunis-core-frontend/src/shared/ui/shadcn/tabs.tsx
+++ b/ayunis-core-frontend/src/shared/ui/shadcn/tabs.tsx
@@ -6,7 +6,7 @@ import { cn } from '@/shared/lib/shadcn/utils';
 function Tabs({
   className,
   ...props
-}: React.ComponentProps<typeof TabsPrimitive.Root>) {
+}: React.ComponentProps<typeof TabsPrimitive.Root>): React.ReactElement {
   return (
     <TabsPrimitive.Root
       data-slot="tabs"
@@ -19,7 +19,7 @@ function Tabs({
 function TabsList({
   className,
   ...props
-}: React.ComponentProps<typeof TabsPrimitive.List>) {
+}: React.ComponentProps<typeof TabsPrimitive.List>): React.ReactElement {
   return (
     <TabsPrimitive.List
       data-slot="tabs-list"
@@ -35,7 +35,7 @@ function TabsList({
 function TabsTrigger({
   className,
   ...props
-}: React.ComponentProps<typeof TabsPrimitive.Trigger>) {
+}: React.ComponentProps<typeof TabsPrimitive.Trigger>): React.ReactElement {
   return (
     <TabsPrimitive.Trigger
       data-slot="tabs-trigger"
@@ -51,7 +51,7 @@ function TabsTrigger({
 function TabsContent({
   className,
   ...props
-}: React.ComponentProps<typeof TabsPrimitive.Content>) {
+}: React.ComponentProps<typeof TabsPrimitive.Content>): React.ReactElement {
   return (
     <TabsPrimitive.Content
       data-slot="tabs-content"

--- a/ayunis-core-frontend/src/shared/ui/shadcn/textarea.tsx
+++ b/ayunis-core-frontend/src/shared/ui/shadcn/textarea.tsx
@@ -2,7 +2,10 @@ import * as React from 'react';
 
 import { cn } from '@/shared/lib/shadcn/utils';
 
-function Textarea({ className, ...props }: React.ComponentProps<'textarea'>) {
+function Textarea({
+  className,
+  ...props
+}: React.ComponentProps<'textarea'>): React.ReactElement {
   return (
     <textarea
       data-slot="textarea"

--- a/ayunis-core-frontend/src/shared/ui/shadcn/tooltip.tsx
+++ b/ayunis-core-frontend/src/shared/ui/shadcn/tooltip.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import * as React from 'react';
 import * as TooltipPrimitive from '@radix-ui/react-tooltip';
 
@@ -8,7 +6,7 @@ import { cn } from '@/shared/lib/shadcn/utils';
 function TooltipProvider({
   delayDuration = 0,
   ...props
-}: React.ComponentProps<typeof TooltipPrimitive.Provider>) {
+}: React.ComponentProps<typeof TooltipPrimitive.Provider>): React.ReactElement {
   return (
     <TooltipPrimitive.Provider
       data-slot="tooltip-provider"
@@ -20,7 +18,7 @@ function TooltipProvider({
 
 function Tooltip({
   ...props
-}: React.ComponentProps<typeof TooltipPrimitive.Root>) {
+}: React.ComponentProps<typeof TooltipPrimitive.Root>): React.ReactElement {
   return (
     <TooltipProvider>
       <TooltipPrimitive.Root data-slot="tooltip" {...props} />
@@ -30,7 +28,7 @@ function Tooltip({
 
 function TooltipTrigger({
   ...props
-}: React.ComponentProps<typeof TooltipPrimitive.Trigger>) {
+}: React.ComponentProps<typeof TooltipPrimitive.Trigger>): React.ReactElement {
   return <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {...props} />;
 }
 
@@ -39,20 +37,20 @@ function TooltipContent({
   sideOffset = 0,
   children,
   ...props
-}: React.ComponentProps<typeof TooltipPrimitive.Content>) {
+}: React.ComponentProps<typeof TooltipPrimitive.Content>): React.ReactElement {
   return (
     <TooltipPrimitive.Portal>
       <TooltipPrimitive.Content
         data-slot="tooltip-content"
         sideOffset={sideOffset}
         className={cn(
-          'bg-primary text-primary-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-fit origin-(--radix-tooltip-content-transform-origin) rounded-md px-3 py-1.5 text-xs text-balance',
+          'bg-foreground text-background animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-fit origin-(--radix-tooltip-content-transform-origin) rounded-md px-3 py-1.5 text-xs text-balance',
           className,
         )}
         {...props}
       >
         {children}
-        <TooltipPrimitive.Arrow className="bg-primary fill-primary z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px]" />
+        <TooltipPrimitive.Arrow className="bg-foreground fill-foreground z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px]" />
       </TooltipPrimitive.Content>
     </TooltipPrimitive.Portal>
   );

--- a/ayunis-core-frontend/src/styles/AGENTS.md
+++ b/ayunis-core-frontend/src/styles/AGENTS.md
@@ -1,0 +1,57 @@
+# Styles Directory
+
+## CSS Architecture
+
+This directory contains the theme-based CSS architecture:
+
+```
+styles/
+├── AGENTS.md             # This file
+├── main.css              # Main stylesheet - imports theme and app-specific styles
+└── themes/
+    └── core.css          # Core theme from private shadcn registry
+```
+
+### ⚠️ CRITICAL: Do Not Modify `themes/core.css`
+
+**The file `themes/core.css` is sourced from our private shadcn registry and must NEVER be modified directly.**
+
+This file contains:
+
+- CSS custom properties (`:root` and `.dark` variables)
+- Color tokens (background, foreground, primary, secondary, etc.)
+- Radius tokens
+- Sidebar theme variables
+- Tailwind theme inline configuration (`@theme inline`)
+- Base layer styles (`@layer base`)
+
+Any modifications to this file will be overwritten when syncing with the registry and may cause inconsistencies across the design system.
+
+### Where to Add Custom Styles
+
+- **Application-specific styles**: Add to `main.css`
+- **Component-specific styles**: Use Tailwind utility classes directly in components
+- **Theme overrides**: If you need to override theme values for a specific component, use CSS custom properties scoping or Tailwind's utility classes
+
+### main.css Structure
+
+The `main.css` file should:
+
+1. Import Tailwind CSS
+2. Import the theme from `./themes/core.css`
+3. Import any plugins (e.g., `tailwindcss-animate`)
+4. Define custom variants
+5. Contain app-specific global styles (e.g., prose styles for markdown)
+
+Example structure:
+
+```css
+@import 'tailwindcss';
+@import './themes/core.css';
+
+@plugin "tailwindcss-animate";
+
+@custom-variant dark (&:is(.dark *));
+
+/* App-specific styles below */
+```

--- a/ayunis-core-frontend/src/styles/main.css
+++ b/ayunis-core-frontend/src/styles/main.css
@@ -1,0 +1,230 @@
+@import 'tailwindcss';
+@import './themes/core.css';
+
+@plugin "tailwindcss-animate";
+
+@custom-variant dark (&:is(.dark *));
+
+html,
+body {
+  @apply m-0 h-full overflow-hidden;
+  font-family:
+    -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu',
+    'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+#app {
+  @apply h-full overflow-hidden;
+}
+
+code {
+  font-family:
+    source-code-pro, Menlo, Monaco, Consolas, 'Courier New', monospace;
+}
+
+/* Custom prose styles for markdown */
+.prose {
+  color: hsl(var(--foreground));
+  max-width: none;
+}
+
+.prose h1 {
+  color: hsl(var(--foreground));
+  font-weight: 800;
+  font-size: 2.25rem;
+  margin-top: 0;
+  margin-bottom: 0.8888889rem;
+  line-height: 1.1111111;
+}
+
+.prose h2 {
+  color: hsl(var(--foreground));
+  font-weight: 700;
+  font-size: 1.5rem;
+  margin-top: 2rem;
+  margin-bottom: 1rem;
+  line-height: 1.3333333;
+}
+
+.prose h3 {
+  color: hsl(var(--foreground));
+  font-weight: 600;
+  font-size: 1.25rem;
+  margin-top: 1.6rem;
+  margin-bottom: 0.6rem;
+  line-height: 1.6;
+}
+
+.prose h4,
+.prose h5,
+.prose h6 {
+  color: hsl(var(--foreground));
+  font-weight: 600;
+  margin-top: 1.5rem;
+  margin-bottom: 0.5rem;
+  line-height: 1.625;
+}
+
+.prose p {
+  margin-top: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.prose hr {
+  border-color: hsl(var(--border));
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+}
+
+.prose strong {
+  color: hsl(var(--foreground));
+  font-weight: 600;
+}
+
+.prose ol {
+  counter-reset: list-counter;
+  padding-left: 1.625rem;
+}
+
+.prose ol > li {
+  position: relative;
+  counter-increment: list-counter;
+  padding-left: 0.375rem;
+}
+
+.prose ol > li::before {
+  content: counter(list-counter) '.';
+  position: absolute;
+  font-weight: 400;
+  color: hsl(var(--muted-foreground));
+  left: -1.625rem;
+}
+
+.prose ul {
+  padding-left: 1.625rem;
+}
+
+.prose ul > li {
+  position: relative;
+  padding-left: 0.375rem;
+}
+
+.prose ul > li::before {
+  content: '•';
+  position: absolute;
+  color: hsl(var(--muted-foreground));
+  font-weight: bold;
+  left: -1rem;
+}
+
+.prose li {
+  margin-top: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.prose blockquote {
+  font-weight: 500;
+  font-style: italic;
+  color: hsl(var(--foreground));
+  border-left-width: 0.25rem;
+  border-left-color: hsl(var(--border));
+  quotes: '\201C' '\201D' '\2018' '\2019';
+  margin-top: 1.6rem;
+  margin-bottom: 1.6rem;
+  padding-left: 1rem;
+}
+
+.prose code {
+  color: hsl(var(--foreground));
+  font-weight: 600;
+  font-size: 0.875rem;
+  background-color: hsl(var(--muted));
+  padding: 0.2rem 0.4rem;
+  border-radius: 0.25rem;
+}
+
+.prose pre {
+  color: hsl(var(--foreground));
+  background-color: hsl(var(--muted));
+  overflow-x: auto;
+  font-weight: 400;
+  font-size: 0.875rem;
+  line-height: 1.7142857;
+  margin-top: 1.7142857rem;
+  margin-bottom: 1.7142857rem;
+  border-radius: 0.375rem;
+  padding: 0.8571429rem 1.1428571rem;
+}
+
+.prose pre code {
+  background-color: transparent;
+  border-width: 0;
+  border-radius: 0;
+  padding: 0;
+  font-weight: inherit;
+  color: inherit;
+  font-size: inherit;
+  font-family: inherit;
+  line-height: inherit;
+}
+
+.prose a {
+  color: hsl(var(--primary));
+  text-decoration: underline;
+  font-weight: 500;
+}
+
+.prose a:hover {
+  color: hsl(var(--primary));
+  opacity: 0.8;
+}
+
+.prose table {
+  width: 100%;
+  table-layout: auto;
+  text-align: left;
+  margin-top: 2rem;
+  margin-bottom: 2rem;
+  font-size: 0.875rem;
+  line-height: 1.7142857;
+}
+
+.prose thead {
+  border-bottom-width: 1px;
+  border-bottom-color: hsl(var(--border));
+}
+
+.prose thead th {
+  color: hsl(var(--foreground));
+  font-weight: 600;
+  vertical-align: bottom;
+  padding-right: 0.5714286rem;
+  padding-bottom: 0.5714286rem;
+  padding-left: 0.5714286rem;
+}
+
+.prose tbody tr {
+  border-bottom-width: 1px;
+  border-bottom-color: hsl(var(--border));
+}
+
+.prose tbody td {
+  vertical-align: baseline;
+  padding: 0.5714286rem;
+}
+
+.dark .prose {
+  color: hsl(var(--foreground));
+}
+
+.dark .prose h1,
+.dark .prose h2,
+.dark .prose h3,
+.dark .prose h4,
+.dark .prose h5,
+.dark .prose h6,
+.dark .prose strong {
+  color: hsl(var(--foreground));
+}

--- a/ayunis-core-frontend/src/styles/themes/core.css
+++ b/ayunis-core-frontend/src/styles/themes/core.css
@@ -1,0 +1,121 @@
+:root,
+.theme-core {
+  --background: oklch(1 0 0);
+  --foreground: oklch(0.141 0.005 285.823);
+  --card: oklch(1 0 0);
+  --card-foreground: oklch(0.141 0.005 285.823);
+  --popover: oklch(1 0 0);
+  --popover-foreground: oklch(0.141 0.005 285.823);
+  --primary: oklch(0.21 0.006 285.885);
+  --primary-foreground: oklch(0.985 0 0);
+  --secondary: oklch(0.967 0.001 286.375);
+  --secondary-foreground: oklch(0.21 0.006 285.885);
+  --muted: oklch(0.967 0.001 286.375);
+  --muted-foreground: oklch(0.552 0.016 285.938);
+  --accent: oklch(0.967 0.001 286.375);
+  --accent-foreground: oklch(0.21 0.006 285.885);
+  --brand: #8178c3;
+  --destructive: oklch(0.577 0.245 27.325);
+  --destructive-foreground: oklch(0.577 0.245 27.325);
+  --border: oklch(0.92 0.004 286.32);
+  --input: oklch(0.92 0.004 286.32);
+  --ring: oklch(0.871 0.006 286.286);
+  --chart-1: oklch(0.646 0.222 41.116);
+  --chart-2: oklch(0.6 0.118 184.704);
+  --chart-3: oklch(0.398 0.07 227.392);
+  --chart-4: oklch(0.828 0.189 84.429);
+  --chart-5: oklch(0.769 0.188 70.08);
+  --radius: 0.625rem;
+  --sidebar: oklch(0.985 0 0);
+  --sidebar-foreground: oklch(0.141 0.005 285.823);
+  --sidebar-primary: oklch(0.21 0.006 285.885);
+  --sidebar-primary-foreground: oklch(0.985 0 0);
+  --sidebar-accent: oklch(0.967 0.001 286.375);
+  --sidebar-accent-foreground: oklch(0.21 0.006 285.885);
+  --sidebar-border: oklch(0.92 0.004 286.32);
+  --sidebar-ring: oklch(0.871 0.006 286.286);
+}
+
+.theme-core.dark,
+.dark {
+  --background: oklch(0.141 0.005 285.823);
+  --foreground: oklch(0.985 0 0);
+  --card: oklch(0.141 0.005 285.823);
+  --card-foreground: oklch(0.985 0 0);
+  --popover: oklch(0.141 0.005 285.823);
+  --popover-foreground: oklch(0.985 0 0);
+  --primary: oklch(0.985 0 0);
+  --primary-foreground: oklch(0.21 0.006 285.885);
+  --secondary: oklch(0.274 0.006 286.033);
+  --secondary-foreground: oklch(0.985 0 0);
+  --muted: oklch(0.274 0.006 286.033);
+  --muted-foreground: oklch(0.705 0.015 286.067);
+  --accent: oklch(0.274 0.006 286.033);
+  --accent-foreground: oklch(0.985 0 0);
+  --destructive: oklch(0.396 0.141 25.723);
+  --destructive-foreground: oklch(0.637 0.237 25.331);
+  --border: oklch(0.274 0.006 286.033);
+  --input: oklch(0.274 0.006 286.033);
+  --ring: oklch(0.442 0.017 285.786);
+  --chart-1: oklch(0.488 0.243 264.376);
+  --chart-2: oklch(0.696 0.17 162.48);
+  --chart-3: oklch(0.769 0.188 70.08);
+  --chart-4: oklch(0.627 0.265 303.9);
+  --chart-5: oklch(0.645 0.246 16.439);
+  --sidebar: oklch(0.21 0.006 285.885);
+  --sidebar-foreground: oklch(0.985 0 0);
+  --sidebar-primary: oklch(0.488 0.243 264.376);
+  --sidebar-primary-foreground: oklch(0.985 0 0);
+  --sidebar-accent: oklch(0.274 0.006 286.033);
+  --sidebar-accent-foreground: oklch(0.985 0 0);
+  --sidebar-border: oklch(0.274 0.006 286.033);
+  --sidebar-ring: oklch(0.442 0.017 285.786);
+}
+
+@theme inline {
+  --color-background: var(--background);
+  --color-foreground: var(--foreground);
+  --color-card: var(--card);
+  --color-card-foreground: var(--card-foreground);
+  --color-popover: var(--popover);
+  --color-popover-foreground: var(--popover-foreground);
+  --color-primary: var(--primary);
+  --color-primary-foreground: var(--primary-foreground);
+  --color-secondary: var(--secondary);
+  --color-secondary-foreground: var(--secondary-foreground);
+  --color-muted: var(--muted);
+  --color-muted-foreground: var(--muted-foreground);
+  --color-accent: var(--accent);
+  --color-accent-foreground: var(--accent-foreground);
+  --color-destructive: var(--destructive);
+  --color-destructive-foreground: var(--destructive-foreground);
+  --color-border: var(--border);
+  --color-input: var(--input);
+  --color-ring: var(--ring);
+  --color-chart-1: var(--chart-1);
+  --color-chart-2: var(--chart-2);
+  --color-chart-3: var(--chart-3);
+  --color-chart-4: var(--chart-4);
+  --color-chart-5: var(--chart-5);
+  --radius-sm: calc(var(--radius) - 4px);
+  --radius-md: calc(var(--radius) - 2px);
+  --radius-lg: var(--radius);
+  --radius-xl: calc(var(--radius) + 4px);
+  --color-sidebar: var(--sidebar);
+  --color-sidebar-foreground: var(--sidebar-foreground);
+  --color-sidebar-primary: var(--sidebar-primary);
+  --color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
+  --color-sidebar-accent: var(--sidebar-accent);
+  --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
+  --color-sidebar-border: var(--sidebar-border);
+  --color-sidebar-ring: var(--sidebar-ring);
+}
+
+@layer base {
+  * {
+    @apply border-border outline-ring/50;
+  }
+  body {
+    @apply bg-background text-foreground;
+  }
+}


### PR DESCRIPTION
…061 AYC-

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces Ayunis registry-driven shadcn setup and a new theme-based styling system.
> 
> - Configures custom shadcn registry in `components.json` and documents usage in `README.md`; adds `AYUNIS_REGISTRY_TOKEN` to `.env.example`
> - Replaces global stylesheet with theme architecture: adds `src/styles/main.css`, `src/styles/themes/core.css`, and `src/styles/AGENTS.md`; updates imports (e.g., `src/main.tsx`) and shadcn config to use `src/styles/main.css`
> - Refactors shadcn UI components (accordion, button, select, dialog, dropdown, calendar, table, etc.): standardizes return types, classnames/variants, accessibility data-attrs, and minor visual tweaks; includes dialog pointer-events cleanup fix and small behavior/style adjustments in calendar/pagination/select/tooltip
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ec88a89c31f0d123ee5510f8d3103a6a3fb6ed4f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->