### PR TITLE
Chat history search hover

### DIFF
--- a/ayunis-core-frontend/src/layouts/content-area-layout/ui/ContentAreaLayout.tsx
+++ b/ayunis-core-frontend/src/layouts/content-area-layout/ui/ContentAreaLayout.tsx
@@ -23,7 +23,10 @@ export const ContentAreaLayout: React.FC<ContentAreaLayoutProps> = ({
 
       {/* Content Area - takes up remaining space with scrollable content */}
       <div className="flex-1 overflow-hidden  w-full max-w-[800px] mx-auto">
-        <ScrollArea className="h-full">{contentArea}</ScrollArea>
+        <ScrollArea className="h-full">
+          {/* Padding ensures focus rings and hover effects aren't clipped by overflow-hidden */}
+          <div className="px-1">{contentArea}</div>
+        </ScrollArea>
       </div>
     </div>
   );


### PR DESCRIPTION
Fixes clipped hover/focus state of the search input by adding padding to the `ScrollArea` content.

---
[Slack Thread](https://locaboo.slack.com/archives/C0375HX2C4S/p1768208504695119?thread_ts=1768208504.695119&cid=C0375HX2C4S)

<a href="https://cursor.com/background-agent?bcId=bc-fd2efa2b-4f45-492c-b974-71e55f95dfd7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-fd2efa2b-4f45-492c-b974-71e55f95dfd7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

