### PR TITLE
Default model deletion error

### DIFF
--- a/ayunis-core-backend/src/domain/models/application/models.errors.ts
+++ b/ayunis-core-backend/src/domain/models/application/models.errors.ts
@@ -23,6 +23,8 @@ export enum ModelErrorCode {
   INFERENCE_TIMEOUT = 'INFERENCE_TIMEOUT',
   MODEL_RATE_LIMIT_EXCEEDED = 'MODEL_RATE_LIMIT_EXCEEDED',
   MODEL_DELETION_FAILED = 'MODEL_DELETION_FAILED',
+  CANNOT_DELETE_DEFAULT_MODEL = 'CANNOT_DELETE_DEFAULT_MODEL',
+  CANNOT_DELETE_LAST_MODEL = 'CANNOT_DELETE_LAST_MODEL',
   MODEL_ALREADY_EXISTS = 'MODEL_ALREADY_EXISTS',
   MODEL_UPDATE_FAILED = 'MODEL_UPDATE_FAILED',
   MODEL_CREATION_FAILED = 'MODEL_CREATION_FAILED',
@@ -141,6 +143,30 @@ export class PermittedModelDeletionFailedError extends ModelError {
       `Permitted model deletion failed: ${reason}`,
       ModelErrorCode.MODEL_DELETION_FAILED,
       500,
+      metadata,
+    );
+  }
+}
+
+/** Error thrown when trying to delete the default model */
+export class CannotDeleteDefaultModelError extends ModelError {
+  constructor(modelId?: string, metadata?: ErrorMetadata) {
+    super(
+      `Cannot delete the default model. Please set another model as default first.`,
+      ModelErrorCode.CANNOT_DELETE_DEFAULT_MODEL,
+      400,
+      { ...metadata, modelId },
+    );
+  }
+}
+
+/** Error thrown when trying to delete the last permitted language model */
+export class CannotDeleteLastModelError extends ModelError {
+  constructor(metadata?: ErrorMetadata) {
+    super(
+      `Cannot delete the last permitted language model in an organization.`,
+      ModelErrorCode.CANNOT_DELETE_LAST_MODEL,
+      400,
       metadata,
     );
   }

--- a/ayunis-core-backend/src/domain/models/application/use-cases/delete-permitted-model/delete-permitted-model.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/delete-permitted-model/delete-permitted-model.use-case.ts
@@ -3,6 +3,8 @@ import { DeletePermittedModelCommand } from './delete-permitted-model.command';
 import { PermittedModelsRepository } from '../../ports/permitted-models.repository';
 import {
   PermittedModelDeletionFailedError,
+  CannotDeleteDefaultModelError,
+  CannotDeleteLastModelError,
   UnexpectedModelError,
 } from '../../models.errors';
 import { ReplaceModelWithUserDefaultUseCase } from 'src/domain/threads/application/use-cases/replace-model-with-user-default/replace-model-with-user-default.use-case';
@@ -110,9 +112,7 @@ export class DeletePermittedModelUseCase {
       )
     ).filter((m) => m instanceof PermittedLanguageModel);
     if (permittedModels.length === 1 && permittedModels[0].id === model.id) {
-      throw new PermittedModelDeletionFailedError(
-        'Cannot delete the last permitted language model in an organization',
-      );
+      throw new CannotDeleteLastModelError();
     }
 
     // Check if the model is the default model in the organization
@@ -123,10 +123,7 @@ export class DeletePermittedModelUseCase {
       });
     }
     if (modelToDelete.isDefault) {
-      throw new PermittedModelDeletionFailedError(
-        'Cannot delete the default model in an organization',
-        { modelId: model.id },
-      );
+      throw new CannotDeleteDefaultModelError(model.id);
     }
     this.logger.debug(
       'Deleting user default models that reference this model',

--- a/ayunis-core-frontend/src/pages/admin-settings/model-settings/api/useDeletePermittedModel.ts
+++ b/ayunis-core-frontend/src/pages/admin-settings/model-settings/api/useDeletePermittedModel.ts
@@ -7,6 +7,7 @@ import {
   getAgentsControllerFindAllQueryKey,
   getThreadsControllerFindAllQueryKey,
 } from '@/shared/api';
+import extractErrorData from '@/shared/api/extract-error-data';
 import { useConfirmation } from '@/widgets/confirmation-modal';
 import { useQueryClient } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
@@ -55,7 +56,21 @@ export function useDeletePermittedModel() {
       },
       onError: (error, _, context) => {
         console.error('Error deleting permitted model', error);
-        showError(t('models.deletePermittedModel.error'));
+        try {
+          const { code } = extractErrorData(error);
+          switch (code) {
+            case 'CANNOT_DELETE_DEFAULT_MODEL':
+              showError(t('models.deletePermittedModel.errorDefaultModel'));
+              break;
+            case 'CANNOT_DELETE_LAST_MODEL':
+              showError(t('models.deletePermittedModel.errorLastModel'));
+              break;
+            default:
+              showError(t('models.deletePermittedModel.error'));
+          }
+        } catch {
+          showError(t('models.deletePermittedModel.error'));
+        }
         if (context?.previousData && context?.queryKey) {
           queryClient.setQueryData(context.queryKey, context.previousData);
         }

--- a/ayunis-core-frontend/src/pages/super-admin-settings/org/api/useSuperAdminDeletePermittedModel.ts
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/org/api/useSuperAdminDeletePermittedModel.ts
@@ -3,6 +3,7 @@ import {
   type ModelWithConfigResponseDto,
   getSuperAdminModelsControllerGetAvailableModelsQueryKey,
 } from '@/shared/api';
+import extractErrorData from '@/shared/api/extract-error-data';
 import { useConfirmation } from '@/widgets/confirmation-modal';
 import { useQueryClient } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
@@ -66,7 +67,21 @@ export function useSuperAdminDeletePermittedModel(orgId: string) {
         },
         onError: (error, _, context) => {
           console.error('Error deleting permitted model', error);
-          showError(t('models.deletePermittedModel.error'));
+          try {
+            const { code } = extractErrorData(error);
+            switch (code) {
+              case 'CANNOT_DELETE_DEFAULT_MODEL':
+                showError(t('models.deletePermittedModel.errorDefaultModel'));
+                break;
+              case 'CANNOT_DELETE_LAST_MODEL':
+                showError(t('models.deletePermittedModel.errorLastModel'));
+                break;
+              default:
+                showError(t('models.deletePermittedModel.error'));
+            }
+          } catch {
+            showError(t('models.deletePermittedModel.error'));
+          }
 
           if (context?.previousData && context?.queryKey) {
             queryClient.setQueryData(context.queryKey, context.previousData);

--- a/ayunis-core-frontend/src/shared/locales/de/admin-settings-models.json
+++ b/ayunis-core-frontend/src/shared/locales/de/admin-settings-models.json
@@ -31,7 +31,9 @@
       "description": "Sind Sie sicher, dass Sie dieses Modell löschen möchten? Wenn Sie ein Embedding-Modell löschen, werden alle Quellen, die mit diesem Modell verknüpft sind, ebenfalls gelöscht. Wenn Sie ein Sprachmodell löschen, fallen alle Threads, die mit diesem Modell verknüpft sind, auf ein anderes Modell zurück.",
       "confirmText": "Löschen",
       "cancelText": "Abbrechen",
-      "error": "Modellzugriff konnte nicht entfernt werden. Bitte versuchen Sie es erneut."
+      "error": "Modellzugriff konnte nicht entfernt werden. Bitte versuchen Sie es erneut.",
+      "errorDefaultModel": "Das Standardmodell kann nicht gelöscht werden. Bitte legen Sie zuerst ein anderes Modell als Standard fest.",
+      "errorLastModel": "Das letzte freigeschaltete Sprachmodell in Ihrer Organisation kann nicht gelöscht werden."
     },
     "createPermittedModel": {
       "multipleEmbeddingModelsNotAllowed": "Es kann nur ein Embedding-Modell pro Organisation erstellt werden.",

--- a/ayunis-core-frontend/src/shared/locales/en/admin-settings-models.json
+++ b/ayunis-core-frontend/src/shared/locales/en/admin-settings-models.json
@@ -31,7 +31,9 @@
       "description": "Are you sure you want to delete this permitted model? If you delete an embedding model, all sources associated with it will be deleted. If you delete a language model, all threads associated with it will fall back to another model.",
       "confirmText": "Delete",
       "cancelText": "Cancel",
-      "error": "Failed to remove model access. Please try again."
+      "error": "Failed to remove model access. Please try again.",
+      "errorDefaultModel": "Cannot delete the default model. Please set another model as default first.",
+      "errorLastModel": "Cannot delete the last permitted language model in your organization."
     },
     "createPermittedModel": {
       "multipleEmbeddingModelsNotAllowed": "Only one embedding model can be created per organization.",


### PR DESCRIPTION
Show a meaningful frontend error when attempting to delete the default or last permitted model.

Previously, attempting to delete the default model or the last permitted model in an organization resulted in a generic error message. This PR introduces specific error codes in the backend and corresponding localized messages in the frontend to provide clear guidance to the user.

---
<a href="https://cursor.com/background-agent?bcId=bc-83c75b2a-4c76-4e92-909b-4ca83bd11d04"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-83c75b2a-4c76-4e92-909b-4ca83bd11d04"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces precise error handling for prohibited deletions and aligns frontend messaging.
> 
> - Backend: add `CANNOT_DELETE_DEFAULT_MODEL` and `CANNOT_DELETE_LAST_MODEL` to `ModelErrorCode`; implement `CannotDeleteDefaultModelError` and `CannotDeleteLastModelError`; update `delete-permitted-model.use-case` to throw these when deleting a default or the last language model
> - Frontend (admin and super-admin): handle these error codes in `useDeletePermittedModel` and `useSuperAdminDeletePermittedModel` via `extractErrorData`, showing specific toasts
> - i18n: add new localized strings for these errors in `en` and `de` admin settings models locale files
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4f0d497a84a7c88f2b183273af891407934091eb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->