### PR TITLE
Upload disabled hint

### DIFF
--- a/ayunis-core-frontend/src/widgets/chat-input/ui/PlusButton.tsx
+++ b/ayunis-core-frontend/src/widgets/chat-input/ui/PlusButton.tsx
@@ -21,6 +21,7 @@ import { usePrompts } from '../api/usePrompts';
 import { useTranslation } from 'react-i18next';
 import { showError } from '@/shared/lib/toast';
 import { useNavigate } from '@tanstack/react-router';
+import TooltipIf from '@/widgets/tooltip-if/ui/TooltipIf';
 interface PlusButtonProps {
   onFileUpload: (file: File) => void;
   onImageSelect?: (files: FileList | null) => void;
@@ -99,13 +100,18 @@ export default function PlusButton({
         </DropdownMenuTrigger>
         <DropdownMenuContent align="start">
           <DropdownMenuGroup>
-            <DropdownMenuItem
-              onClick={() => documentInputRef.current?.click()}
-              disabled={isLoading || isFileSourceDisabled}
+            <TooltipIf
+              condition={isFileSourceDisabled || false}
+              tooltip={t('chatInput.fileSourceDisabled')}
             >
-              <FileText className="h-4 w-4" />
-              <span>{t('chatInput.uploadDocument')}</span>
-            </DropdownMenuItem>
+              <DropdownMenuItem
+                onClick={() => documentInputRef.current?.click()}
+                disabled={isLoading || isFileSourceDisabled}
+              >
+                <FileText className="h-4 w-4" />
+                <span>{t('chatInput.uploadDocument')}</span>
+              </DropdownMenuItem>
+            </TooltipIf>
             <DropdownMenuItem
               onClick={() => imageInputRef.current?.click()}
               disabled={isLoading || isImageUploadDisabled}


### PR DESCRIPTION
Add a conditional tooltip to the document upload menu item to explain why it's disabled when no embedding model is enabled.

---
[Slack Thread](https://locaboo.slack.com/archives/C0375HX2C4S/p1768292644450379?thread_ts=1768292644.450379&cid=C0375HX2C4S)

<a href="https://cursor.com/background-agent?bcId=bc-70dca77f-26d0-468f-b034-15aeb64caff3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-70dca77f-26d0-468f-b034-15aeb64caff3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a disabled-state hint for the document upload action in the chat input menu.
> 
> - Wraps `uploadDocument` `DropdownMenuItem` with `TooltipIf` to display `t('chatInput.fileSourceDisabled')` when `isFileSourceDisabled` is true
> - Imports `TooltipIf` and preserves existing loading/disabled behavior for document and image uploads
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6dae4725a48cd69d603979dbe712c94cf917ea21. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->