### PR TITLE
feat: trim context to 80k, show warning on long chats AYC-68

### DIFF
--- a/ayunis-core-backend/package-lock.json
+++ b/ayunis-core-backend/package-lock.json
@@ -54,6 +54,7 @@
         "pg": "^8.16.3",
         "reflect-metadata": "^0.2.2",
         "rxjs": "^7.8.1",
+        "tiktoken": "^1.0.22",
         "typeorm": "^0.3.25",
         "uuid": "^11.1.0",
         "winston": "^3.17.0",
@@ -19620,6 +19621,12 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/tiktoken": {
+      "version": "1.0.22",
+      "resolved": "https://registry.npmjs.org/tiktoken/-/tiktoken-1.0.22.tgz",
+      "integrity": "sha512-PKvy1rVF1RibfF3JlXBSP0Jrcw2uq3yXdgcEXtKTYn3QJ/cBRBHDnrJ5jHky+MENZ6DIPwNUGWpkVx+7joCpNA==",
+      "license": "MIT"
     },
     "node_modules/tmpl": {
       "version": "1.0.5",

--- a/ayunis-core-backend/package.json
+++ b/ayunis-core-backend/package.json
@@ -87,6 +87,7 @@
     "pg": "^8.16.3",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",
+    "tiktoken": "^1.0.22",
     "typeorm": "^0.3.25",
     "uuid": "^11.1.0",
     "winston": "^3.17.0",

--- a/ayunis-core-backend/src/common/token-counter/application/ports/token-counter.handler.port.ts
+++ b/ayunis-core-backend/src/common/token-counter/application/ports/token-counter.handler.port.ts
@@ -1,0 +1,10 @@
+export enum TokenCounterType {
+  TIKTOKEN = 'tiktoken',
+  SIMPLE = 'simple',
+}
+
+export abstract class TokenCounterHandler {
+  abstract readonly type: TokenCounterType;
+  abstract isAvailable(): boolean;
+  abstract countTokens(text: string): number;
+}

--- a/ayunis-core-backend/src/common/token-counter/application/token-counter.errors.ts
+++ b/ayunis-core-backend/src/common/token-counter/application/token-counter.errors.ts
@@ -1,0 +1,51 @@
+import { ApplicationError, ErrorMetadata } from '../../errors/base.error';
+import { TokenCounterType } from './ports/token-counter.handler.port';
+
+export enum TokenCounterErrorCode {
+  HANDLER_NOT_FOUND = 'TOKEN_COUNTER_HANDLER_NOT_FOUND',
+  HANDLER_NOT_AVAILABLE = 'TOKEN_COUNTER_HANDLER_NOT_AVAILABLE',
+  COUNTING_FAILED = 'TOKEN_COUNTING_FAILED',
+}
+
+export class TokenCounterError extends ApplicationError {
+  constructor(
+    message: string,
+    code: TokenCounterErrorCode,
+    status: number,
+    metadata?: ErrorMetadata,
+  ) {
+    super(message, code, status, metadata);
+    this.name = 'TokenCounterError';
+  }
+}
+
+export class TokenCounterHandlerNotFoundError extends TokenCounterError {
+  constructor(type: TokenCounterType, metadata?: ErrorMetadata) {
+    super(
+      `Token counter handler not found: ${type}`,
+      TokenCounterErrorCode.HANDLER_NOT_FOUND,
+      404,
+      { type, ...metadata },
+    );
+    this.name = 'TokenCounterHandlerNotFoundError';
+  }
+}
+
+export class TokenCounterHandlerNotAvailableError extends TokenCounterError {
+  constructor(type: TokenCounterType, metadata?: ErrorMetadata) {
+    super(
+      `Token counter handler is not available: ${type}`,
+      TokenCounterErrorCode.HANDLER_NOT_AVAILABLE,
+      503,
+      { type, ...metadata },
+    );
+    this.name = 'TokenCounterHandlerNotAvailableError';
+  }
+}
+
+export class TokenCountingFailedError extends TokenCounterError {
+  constructor(message: string, metadata?: ErrorMetadata) {
+    super(message, TokenCounterErrorCode.COUNTING_FAILED, 500, metadata);
+    this.name = 'TokenCountingFailedError';
+  }
+}

--- a/ayunis-core-backend/src/common/token-counter/application/token-counter.registry.ts
+++ b/ayunis-core-backend/src/common/token-counter/application/token-counter.registry.ts
@@ -1,0 +1,59 @@
+import { Injectable, Logger } from '@nestjs/common';
+import {
+  TokenCounterHandler,
+  TokenCounterType,
+} from './ports/token-counter.handler.port';
+import {
+  TokenCounterHandlerNotFoundError,
+  TokenCounterHandlerNotAvailableError,
+} from './token-counter.errors';
+
+@Injectable()
+export class TokenCounterRegistry {
+  private readonly logger = new Logger(TokenCounterRegistry.name);
+  private readonly handlers = new Map<TokenCounterType, TokenCounterHandler>();
+
+  registerHandler(handler: TokenCounterHandler): void {
+    this.handlers.set(handler.type, handler);
+  }
+
+  getHandler(type: TokenCounterType): TokenCounterHandler {
+    this.logger.debug('getHandler', { type });
+    const handler = this.handlers.get(type);
+
+    if (!handler) {
+      throw new TokenCounterHandlerNotFoundError(type);
+    }
+
+    if (!handler.isAvailable()) {
+      throw new TokenCounterHandlerNotAvailableError(type);
+    }
+
+    return handler;
+  }
+
+  getDefaultHandler(): TokenCounterHandler {
+    this.logger.debug('getDefaultHandler');
+
+    // Prefer tiktoken if available
+    const tiktokenHandler = this.handlers.get(TokenCounterType.TIKTOKEN);
+    if (tiktokenHandler?.isAvailable()) {
+      return tiktokenHandler;
+    }
+
+    // Fallback to simple handler
+    const simpleHandler = this.handlers.get(TokenCounterType.SIMPLE);
+    if (simpleHandler?.isAvailable()) {
+      return simpleHandler;
+    }
+
+    throw new TokenCounterHandlerNotFoundError(TokenCounterType.TIKTOKEN);
+  }
+
+  getAvailableTypes(): TokenCounterType[] {
+    this.logger.debug('getAvailableTypes');
+    return Array.from(this.handlers.entries())
+      .filter(([, handler]) => handler.isAvailable())
+      .map(([type]) => type);
+  }
+}

--- a/ayunis-core-backend/src/common/token-counter/application/use-cases/count-tokens/count-tokens.command.ts
+++ b/ayunis-core-backend/src/common/token-counter/application/use-cases/count-tokens/count-tokens.command.ts
@@ -1,0 +1,8 @@
+import { TokenCounterType } from '../../ports/token-counter.handler.port';
+
+export class CountTokensCommand {
+  constructor(
+    public readonly text: string,
+    public readonly counterType?: TokenCounterType,
+  ) {}
+}

--- a/ayunis-core-backend/src/common/token-counter/application/use-cases/count-tokens/count-tokens.use-case.ts
+++ b/ayunis-core-backend/src/common/token-counter/application/use-cases/count-tokens/count-tokens.use-case.ts
@@ -1,0 +1,20 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { TokenCounterRegistry } from '../../token-counter.registry';
+import { CountTokensCommand } from './count-tokens.command';
+
+@Injectable()
+export class CountTokensUseCase {
+  private readonly logger = new Logger(CountTokensUseCase.name);
+
+  constructor(private readonly registry: TokenCounterRegistry) {}
+
+  execute(command: CountTokensCommand): number {
+    this.logger.debug('execute', { textLength: command.text.length });
+
+    const handler = command.counterType
+      ? this.registry.getHandler(command.counterType)
+      : this.registry.getDefaultHandler();
+
+    return handler.countTokens(command.text);
+  }
+}

--- a/ayunis-core-backend/src/common/token-counter/infrastructure/handlers/simple.handler.ts
+++ b/ayunis-core-backend/src/common/token-counter/infrastructure/handlers/simple.handler.ts
@@ -1,0 +1,19 @@
+import { Injectable } from '@nestjs/common';
+import {
+  TokenCounterHandler,
+  TokenCounterType,
+} from '../../application/ports/token-counter.handler.port';
+
+@Injectable()
+export class SimpleHandler extends TokenCounterHandler {
+  readonly type = TokenCounterType.SIMPLE;
+
+  isAvailable(): boolean {
+    return true;
+  }
+
+  countTokens(text: string): number {
+    // Rough estimation: ~4 characters per token on average
+    return Math.ceil(text.length / 4);
+  }
+}

--- a/ayunis-core-backend/src/common/token-counter/infrastructure/handlers/tiktoken.handler.ts
+++ b/ayunis-core-backend/src/common/token-counter/infrastructure/handlers/tiktoken.handler.ts
@@ -1,0 +1,41 @@
+import { Injectable, Logger, OnModuleDestroy } from '@nestjs/common';
+import { Tiktoken, encoding_for_model } from 'tiktoken';
+import {
+  TokenCounterHandler,
+  TokenCounterType,
+} from '../../application/ports/token-counter.handler.port';
+
+@Injectable()
+export class TiktokenHandler
+  extends TokenCounterHandler
+  implements OnModuleDestroy
+{
+  private readonly logger = new Logger(TiktokenHandler.name);
+  readonly type = TokenCounterType.TIKTOKEN;
+  private encoder: Tiktoken | null = null;
+
+  isAvailable(): boolean {
+    return true;
+  }
+
+  countTokens(text: string): number {
+    const encoder = this.getEncoder();
+    const tokens = encoder.encode(text);
+    return tokens.length;
+  }
+
+  private getEncoder(): Tiktoken {
+    if (!this.encoder) {
+      this.logger.debug('initializing tiktoken encoder (cl100k_base)');
+      this.encoder = encoding_for_model('gpt-4');
+    }
+    return this.encoder;
+  }
+
+  onModuleDestroy() {
+    if (this.encoder) {
+      this.encoder.free();
+      this.encoder = null;
+    }
+  }
+}

--- a/ayunis-core-backend/src/common/token-counter/infrastructure/handlers/tiktoken.handler.ts
+++ b/ayunis-core-backend/src/common/token-counter/infrastructure/handlers/tiktoken.handler.ts
@@ -1,5 +1,5 @@
 import { Injectable, Logger, OnModuleDestroy } from '@nestjs/common';
-import { Tiktoken, encoding_for_model } from 'tiktoken';
+import { Tiktoken, get_encoding } from 'tiktoken';
 import {
   TokenCounterHandler,
   TokenCounterType,
@@ -27,7 +27,7 @@ export class TiktokenHandler
   private getEncoder(): Tiktoken {
     if (!this.encoder) {
       this.logger.debug('initializing tiktoken encoder (cl100k_base)');
-      this.encoder = encoding_for_model('gpt-4');
+      this.encoder = get_encoding('cl100k_base');
     }
     return this.encoder;
   }

--- a/ayunis-core-backend/src/common/token-counter/token-counter.module.ts
+++ b/ayunis-core-backend/src/common/token-counter/token-counter.module.ts
@@ -1,0 +1,28 @@
+import { Module } from '@nestjs/common';
+import { TokenCounterRegistry } from './application/token-counter.registry';
+import { CountTokensUseCase } from './application/use-cases/count-tokens/count-tokens.use-case';
+import { TiktokenHandler } from './infrastructure/handlers/tiktoken.handler';
+import { SimpleHandler } from './infrastructure/handlers/simple.handler';
+
+@Module({
+  providers: [
+    {
+      provide: TokenCounterRegistry,
+      useFactory: (
+        tiktokenHandler: TiktokenHandler,
+        simpleHandler: SimpleHandler,
+      ) => {
+        const registry = new TokenCounterRegistry();
+        registry.registerHandler(tiktokenHandler);
+        registry.registerHandler(simpleHandler);
+        return registry;
+      },
+      inject: [TiktokenHandler, SimpleHandler],
+    },
+    CountTokensUseCase,
+    TiktokenHandler,
+    SimpleHandler,
+  ],
+  exports: [TokenCounterRegistry, CountTokensUseCase],
+})
+export class TokenCounterModule {}

--- a/ayunis-core-backend/src/domain/messages/application/use-cases/count-messages-tokens/count-messages-tokens.command.ts
+++ b/ayunis-core-backend/src/domain/messages/application/use-cases/count-messages-tokens/count-messages-tokens.command.ts
@@ -1,0 +1,9 @@
+import { TokenCounterType } from 'src/common/token-counter/application/ports/token-counter.handler.port';
+import { Message } from '../../../domain/message.entity';
+
+export class CountMessagesTokensCommand {
+  constructor(
+    public readonly messages: Message[],
+    public readonly counterType?: TokenCounterType,
+  ) {}
+}

--- a/ayunis-core-backend/src/domain/messages/application/use-cases/count-messages-tokens/count-messages-tokens.use-case.ts
+++ b/ayunis-core-backend/src/domain/messages/application/use-cases/count-messages-tokens/count-messages-tokens.use-case.ts
@@ -1,0 +1,30 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { CountTokensUseCase } from 'src/common/token-counter/application/use-cases/count-tokens/count-tokens.use-case';
+import { CountTokensCommand } from 'src/common/token-counter/application/use-cases/count-tokens/count-tokens.command';
+import { CountMessagesTokensCommand } from './count-messages-tokens.command';
+import { extractTextFromContent } from '../../utils/message-text-extractor.util';
+
+@Injectable()
+export class CountMessagesTokensUseCase {
+  private readonly logger = new Logger(CountMessagesTokensUseCase.name);
+
+  constructor(private readonly countTokensUseCase: CountTokensUseCase) {}
+
+  execute(command: CountMessagesTokensCommand): number {
+    this.logger.log('execute', { messageCount: command.messages.length });
+
+    const allText = command.messages
+      .flatMap((message) => message.content)
+      .map((content) => extractTextFromContent(content))
+      .filter((text) => text.length > 0)
+      .join('\n');
+
+    if (allText.length === 0) {
+      return 0;
+    }
+
+    return this.countTokensUseCase.execute(
+      new CountTokensCommand(allText, command.counterType),
+    );
+  }
+}

--- a/ayunis-core-backend/src/domain/messages/application/use-cases/count-messages-tokens/index.ts
+++ b/ayunis-core-backend/src/domain/messages/application/use-cases/count-messages-tokens/index.ts
@@ -1,0 +1,2 @@
+export { CountMessagesTokensCommand } from './count-messages-tokens.command';
+export { CountMessagesTokensUseCase } from './count-messages-tokens.use-case';

--- a/ayunis-core-backend/src/domain/messages/application/use-cases/trim-messages-for-context/index.ts
+++ b/ayunis-core-backend/src/domain/messages/application/use-cases/trim-messages-for-context/index.ts
@@ -1,0 +1,2 @@
+export { TrimMessagesForContextCommand } from './trim-messages-for-context.command';
+export { TrimMessagesForContextUseCase } from './trim-messages-for-context.use-case';

--- a/ayunis-core-backend/src/domain/messages/application/use-cases/trim-messages-for-context/trim-messages-for-context.command.ts
+++ b/ayunis-core-backend/src/domain/messages/application/use-cases/trim-messages-for-context/trim-messages-for-context.command.ts
@@ -1,0 +1,10 @@
+import { TokenCounterType } from 'src/common/token-counter/application/ports/token-counter.handler.port';
+import { Message } from '../../../domain/message.entity';
+
+export class TrimMessagesForContextCommand {
+  constructor(
+    public readonly messages: Message[],
+    public readonly maxTokens: number,
+    public readonly counterType?: TokenCounterType,
+  ) {}
+}

--- a/ayunis-core-backend/src/domain/messages/application/use-cases/trim-messages-for-context/trim-messages-for-context.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/messages/application/use-cases/trim-messages-for-context/trim-messages-for-context.use-case.spec.ts
@@ -1,0 +1,294 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { randomUUID, UUID } from 'crypto';
+import { TrimMessagesForContextUseCase } from './trim-messages-for-context.use-case';
+import { TrimMessagesForContextCommand } from './trim-messages-for-context.command';
+import { CountTokensUseCase } from 'src/common/token-counter/application/use-cases/count-tokens/count-tokens.use-case';
+import { UserMessage } from '../../../domain/messages/user-message.entity';
+import { AssistantMessage } from '../../../domain/messages/assistant-message.entity';
+import { TextMessageContent } from '../../../domain/message-contents/text-message-content.entity';
+import { Message } from '../../../domain/message.entity';
+
+describe('TrimMessagesForContextUseCase', () => {
+  let useCase: TrimMessagesForContextUseCase;
+  let mockCountTokensUseCase: jest.Mocked<CountTokensUseCase>;
+
+  const threadId = randomUUID();
+
+  const createUserMessage = (
+    text: string,
+    createdAt: Date,
+    id?: UUID,
+  ): UserMessage => {
+    return new UserMessage({
+      id,
+      threadId,
+      createdAt,
+      content: [new TextMessageContent(text)],
+    });
+  };
+
+  const createAssistantMessage = (
+    text: string,
+    createdAt: Date,
+    id?: UUID,
+  ): AssistantMessage => {
+    return new AssistantMessage({
+      id,
+      threadId,
+      createdAt,
+      content: [new TextMessageContent(text)],
+    });
+  };
+
+  beforeEach(async () => {
+    mockCountTokensUseCase = {
+      execute: jest.fn(),
+    } as unknown as jest.Mocked<CountTokensUseCase>;
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        TrimMessagesForContextUseCase,
+        { provide: CountTokensUseCase, useValue: mockCountTokensUseCase },
+      ],
+    }).compile();
+
+    useCase = module.get<TrimMessagesForContextUseCase>(
+      TrimMessagesForContextUseCase,
+    );
+  });
+
+  it('should be defined', () => {
+    expect(useCase).toBeDefined();
+  });
+
+  describe('execute', () => {
+    it('should return empty array for empty messages', () => {
+      const command = new TrimMessagesForContextCommand([], 1000);
+
+      const result = useCase.execute(command);
+
+      expect(result).toEqual([]);
+      expect(mockCountTokensUseCase.execute).not.toHaveBeenCalled();
+    });
+
+    it('should return all messages when total tokens fit within limit', () => {
+      const messages: Message[] = [
+        createUserMessage('Hello', new Date('2024-01-01T10:00:00Z')),
+        createAssistantMessage('Hi there', new Date('2024-01-01T10:01:00Z')),
+        createUserMessage('How are you?', new Date('2024-01-01T10:02:00Z')),
+      ];
+
+      // Each message counts as 10 tokens
+      mockCountTokensUseCase.execute.mockReturnValue(10);
+
+      const command = new TrimMessagesForContextCommand(messages, 100);
+      const result = useCase.execute(command);
+
+      expect(result).toHaveLength(3);
+      expect(result[0].role).toBe('user');
+    });
+
+    it('should trim messages from the beginning when exceeding token limit', () => {
+      const messages: Message[] = [
+        createUserMessage('First user', new Date('2024-01-01T10:00:00Z')),
+        createAssistantMessage('First reply', new Date('2024-01-01T10:01:00Z')),
+        createUserMessage('Second user', new Date('2024-01-01T10:02:00Z')),
+        createAssistantMessage(
+          'Second reply',
+          new Date('2024-01-01T10:03:00Z'),
+        ),
+      ];
+
+      // Each message counts as 30 tokens, limit is 100
+      // Can fit 3 messages (90 tokens), but need to ensure first is user
+      mockCountTokensUseCase.execute.mockReturnValue(30);
+
+      const command = new TrimMessagesForContextCommand(messages, 100);
+      const result = useCase.execute(command);
+
+      // Should keep last 3 messages: assistant, user, assistant
+      // But first must be user, so should skip assistant and keep: user, assistant
+      expect(result).toHaveLength(2);
+      expect(result[0].role).toBe('user');
+    });
+
+    it('should ensure first message is a user message by skipping non-user messages', () => {
+      const messages: Message[] = [
+        createAssistantMessage(
+          'Orphan assistant',
+          new Date('2024-01-01T10:00:00Z'),
+        ),
+        createUserMessage('User message', new Date('2024-01-01T10:01:00Z')),
+        createAssistantMessage('Reply', new Date('2024-01-01T10:02:00Z')),
+      ];
+
+      mockCountTokensUseCase.execute.mockReturnValue(10);
+
+      const command = new TrimMessagesForContextCommand(messages, 100);
+      const result = useCase.execute(command);
+
+      // All fit, but first is assistant, should skip to first user
+      expect(result).toHaveLength(2);
+      expect(result[0].role).toBe('user');
+      expect(result[1].role).toBe('assistant');
+    });
+
+    it('should return empty array when no user messages exist in selection', () => {
+      const messages: Message[] = [
+        createAssistantMessage('First', new Date('2024-01-01T10:00:00Z')),
+        createAssistantMessage('Second', new Date('2024-01-01T10:01:00Z')),
+      ];
+
+      mockCountTokensUseCase.execute.mockReturnValue(10);
+
+      const command = new TrimMessagesForContextCommand(messages, 100);
+      const result = useCase.execute(command);
+
+      expect(result).toEqual([]);
+    });
+
+    it('should sort messages by creation date before processing', () => {
+      // Messages provided out of order
+      const messages: Message[] = [
+        createUserMessage('Third', new Date('2024-01-01T10:02:00Z')),
+        createUserMessage('First', new Date('2024-01-01T10:00:00Z')),
+        createAssistantMessage('Second', new Date('2024-01-01T10:01:00Z')),
+      ];
+
+      mockCountTokensUseCase.execute.mockReturnValue(10);
+
+      const command = new TrimMessagesForContextCommand(messages, 100);
+      const result = useCase.execute(command);
+
+      expect(result).toHaveLength(3);
+      // Should be sorted: First (user), Second (assistant), Third (user)
+      expect(result[0].createdAt).toEqual(new Date('2024-01-01T10:00:00Z'));
+      expect(result[1].createdAt).toEqual(new Date('2024-01-01T10:01:00Z'));
+      expect(result[2].createdAt).toEqual(new Date('2024-01-01T10:02:00Z'));
+    });
+
+    it('should handle single user message', () => {
+      const messages: Message[] = [
+        createUserMessage('Only message', new Date('2024-01-01T10:00:00Z')),
+      ];
+
+      mockCountTokensUseCase.execute.mockReturnValue(10);
+
+      const command = new TrimMessagesForContextCommand(messages, 100);
+      const result = useCase.execute(command);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].role).toBe('user');
+    });
+
+    it('should return empty when single user message exceeds limit', () => {
+      const messages: Message[] = [
+        createUserMessage('Large message', new Date('2024-01-01T10:00:00Z')),
+      ];
+
+      mockCountTokensUseCase.execute.mockReturnValue(200);
+
+      const command = new TrimMessagesForContextCommand(messages, 100);
+      const result = useCase.execute(command);
+
+      // Cannot fit any messages
+      expect(result).toEqual([]);
+    });
+
+    it('should keep most recent messages when trimming', () => {
+      const oldUserMsg = createUserMessage(
+        'Old user',
+        new Date('2024-01-01T10:00:00Z'),
+      );
+      const oldAssistantMsg = createAssistantMessage(
+        'Old assistant',
+        new Date('2024-01-01T10:01:00Z'),
+      );
+      const newUserMsg = createUserMessage(
+        'New user',
+        new Date('2024-01-01T10:02:00Z'),
+      );
+      const newAssistantMsg = createAssistantMessage(
+        'New assistant',
+        new Date('2024-01-01T10:03:00Z'),
+      );
+
+      const messages: Message[] = [
+        oldUserMsg,
+        oldAssistantMsg,
+        newUserMsg,
+        newAssistantMsg,
+      ];
+
+      // Each message is 40 tokens, limit is 100 (can fit 2)
+      mockCountTokensUseCase.execute.mockReturnValue(40);
+
+      const command = new TrimMessagesForContextCommand(messages, 100);
+      const result = useCase.execute(command);
+
+      // Should keep the 2 most recent: newUserMsg, newAssistantMsg
+      expect(result).toHaveLength(2);
+      expect(result[0].id).toBe(newUserMsg.id);
+      expect(result[1].id).toBe(newAssistantMsg.id);
+    });
+
+    it('should handle messages with empty content (0 tokens)', () => {
+      const emptyUserMsg = new UserMessage({
+        threadId,
+        createdAt: new Date('2024-01-01T10:00:00Z'),
+        content: [],
+      });
+      const normalUserMsg = createUserMessage(
+        'Normal',
+        new Date('2024-01-01T10:01:00Z'),
+      );
+
+      const messages: Message[] = [emptyUserMsg, normalUserMsg];
+
+      mockCountTokensUseCase.execute.mockReturnValue(10);
+
+      const command = new TrimMessagesForContextCommand(messages, 100);
+      const result = useCase.execute(command);
+
+      expect(result).toHaveLength(2);
+    });
+
+    it('should not mutate the original messages array', () => {
+      const messages: Message[] = [
+        createUserMessage('Third', new Date('2024-01-01T10:02:00Z')),
+        createUserMessage('First', new Date('2024-01-01T10:00:00Z')),
+      ];
+
+      const originalOrder = [...messages];
+      mockCountTokensUseCase.execute.mockReturnValue(10);
+
+      const command = new TrimMessagesForContextCommand(messages, 100);
+      useCase.execute(command);
+
+      // Original array should not be modified
+      expect(messages[0].createdAt).toEqual(originalOrder[0].createdAt);
+      expect(messages[1].createdAt).toEqual(originalOrder[1].createdAt);
+    });
+
+    it('should pass counterType to token counting', () => {
+      const messages: Message[] = [
+        createUserMessage('Test', new Date('2024-01-01T10:00:00Z')),
+      ];
+
+      mockCountTokensUseCase.execute.mockReturnValue(10);
+
+      const command = new TrimMessagesForContextCommand(
+        messages,
+        100,
+        'tiktoken' as any,
+      );
+      useCase.execute(command);
+
+      expect(mockCountTokensUseCase.execute).toHaveBeenCalledWith(
+        expect.objectContaining({
+          counterType: 'tiktoken',
+        }),
+      );
+    });
+  });
+});

--- a/ayunis-core-backend/src/domain/messages/application/use-cases/trim-messages-for-context/trim-messages-for-context.use-case.ts
+++ b/ayunis-core-backend/src/domain/messages/application/use-cases/trim-messages-for-context/trim-messages-for-context.use-case.ts
@@ -1,0 +1,104 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { CountTokensUseCase } from 'src/common/token-counter/application/use-cases/count-tokens/count-tokens.use-case';
+import { CountTokensCommand } from 'src/common/token-counter/application/use-cases/count-tokens/count-tokens.command';
+import { TokenCounterType } from 'src/common/token-counter/application/ports/token-counter.handler.port';
+import { Message } from '../../../domain/message.entity';
+import { MessageRole } from '../../../domain/value-objects/message-role.object';
+import { TrimMessagesForContextCommand } from './trim-messages-for-context.command';
+import { extractTextFromMessage } from '../../utils/message-text-extractor.util';
+
+@Injectable()
+export class TrimMessagesForContextUseCase {
+  private readonly logger = new Logger(TrimMessagesForContextUseCase.name);
+
+  constructor(private readonly countTokensUseCase: CountTokensUseCase) {}
+
+  execute(command: TrimMessagesForContextCommand): Message[] {
+    this.logger.log('execute', {
+      messageCount: command.messages.length,
+      maxTokens: command.maxTokens,
+    });
+
+    if (command.messages.length === 0) {
+      return [];
+    }
+
+    // Sort messages by creation date (oldest first)
+    const sortedMessages = [...command.messages].sort(
+      (a, b) => a.createdAt.getTime() - b.createdAt.getTime(),
+    );
+
+    // Calculate tokens for each message
+    const messagesWithTokens = sortedMessages.map((message) => ({
+      message,
+      tokens: this.countTokensForMessage(message, command.counterType),
+    }));
+
+    // Start from the end and work backwards, accumulating messages
+    const selectedMessages: Message[] = [];
+    let totalTokens = 0;
+
+    for (let i = messagesWithTokens.length - 1; i >= 0; i--) {
+      const { message, tokens } = messagesWithTokens[i];
+
+      if (totalTokens + tokens <= command.maxTokens) {
+        selectedMessages.unshift(message);
+        totalTokens += tokens;
+      } else {
+        // Stop when we can't fit more messages
+        break;
+      }
+    }
+
+    // Ensure the first message is a user message
+    const trimmedMessages = this.ensureFirstMessageIsUser(selectedMessages);
+
+    this.logger.log('execute completed', {
+      originalCount: command.messages.length,
+      selectedCount: trimmedMessages.length,
+      totalTokens,
+    });
+
+    return trimmedMessages;
+  }
+
+  private countTokensForMessage(
+    message: Message,
+    counterType?: TokenCounterType,
+  ): number {
+    const text = extractTextFromMessage(message.content);
+
+    if (text.length === 0) {
+      return 0;
+    }
+
+    return this.countTokensUseCase.execute(
+      new CountTokensCommand(text, counterType),
+    );
+  }
+
+  private ensureFirstMessageIsUser(messages: Message[]): Message[] {
+    if (messages.length === 0) {
+      return [];
+    }
+
+    // Find the index of the first user message
+    const firstUserIndex = messages.findIndex(
+      (m) => m.role === MessageRole.USER,
+    );
+
+    if (firstUserIndex === -1) {
+      // No user message found, return empty array
+      this.logger.warn('No user message found in selected messages');
+      return [];
+    }
+
+    if (firstUserIndex === 0) {
+      // First message is already a user message
+      return messages;
+    }
+
+    // Skip messages before the first user message
+    return messages.slice(firstUserIndex);
+  }
+}

--- a/ayunis-core-backend/src/domain/messages/application/utils/message-text-extractor.util.ts
+++ b/ayunis-core-backend/src/domain/messages/application/utils/message-text-extractor.util.ts
@@ -1,0 +1,49 @@
+import { MessageContent } from '../../domain/message-content.entity';
+import { MessageContentType } from '../../domain/value-objects/message-content-type.object';
+import { TextMessageContent } from '../../domain/message-contents/text-message-content.entity';
+import { ThinkingMessageContent } from '../../domain/message-contents/thinking-message-content.entity';
+import { ToolUseMessageContent } from '../../domain/message-contents/tool-use.message-content.entity';
+import { ToolResultMessageContent } from '../../domain/message-contents/tool-result.message-content.entity';
+
+/**
+ * Extracts text content from a message content entity for token counting purposes.
+ * Returns empty string for content types that don't have meaningful text (e.g., images).
+ */
+export function extractTextFromContent(content: MessageContent): string {
+  const typedContent = content as { type: MessageContentType };
+
+  switch (typedContent.type) {
+    case MessageContentType.TEXT:
+      return (content as TextMessageContent).text;
+
+    case MessageContentType.THINKING:
+      return (content as ThinkingMessageContent).thinking;
+
+    case MessageContentType.TOOL_USE: {
+      const toolUse = content as ToolUseMessageContent;
+      return `${toolUse.id} ${toolUse.name} ${JSON.stringify(toolUse.params)}`;
+    }
+
+    case MessageContentType.TOOL_RESULT: {
+      const toolResult = content as ToolResultMessageContent;
+      return `${toolResult.toolId} ${toolResult.toolName} ${toolResult.result}`;
+    }
+
+    case MessageContentType.IMAGE:
+      // Images have fixed token cost based on dimensions, not text-based
+      return '';
+
+    default:
+      return '';
+  }
+}
+
+/**
+ * Extracts all text from a message's content array and joins it.
+ */
+export function extractTextFromMessage(content: MessageContent[]): string {
+  return content
+    .map((c) => extractTextFromContent(c))
+    .filter((text) => text.length > 0)
+    .join('\n');
+}

--- a/ayunis-core-backend/src/domain/messages/messages.module.ts
+++ b/ayunis-core-backend/src/domain/messages/messages.module.ts
@@ -3,6 +3,7 @@ import { MESSAGES_REPOSITORY } from './application/ports/messages.repository';
 import { LocalMessagesRepository } from './infrastructure/persistence/local/local-messages.repository';
 import { LocalMessagesRepositoryModule } from './infrastructure/persistence/local/local-messages-repository.module';
 import { StorageModule } from '../storage/storage.module';
+import { TokenCounterModule } from 'src/common/token-counter/token-counter.module';
 
 // Use Cases
 import { CreateUserMessageUseCase } from './application/use-cases/create-user-message/create-user-message.use-case';
@@ -12,6 +13,8 @@ import { SaveAssistantMessageUseCase } from './application/use-cases/save-assist
 import { CreateToolResultMessageUseCase } from './application/use-cases/create-tool-result-message/create-tool-result-message.use-case';
 import { DeleteMessageUseCase } from './application/use-cases/delete-message/delete-message.use-case';
 import { CleanupOrphanedImagesUseCase } from './application/use-cases/cleanup-orphaned-images/cleanup-orphaned-images.use-case';
+import { CountMessagesTokensUseCase } from './application/use-cases/count-messages-tokens/count-messages-tokens.use-case';
+import { TrimMessagesForContextUseCase } from './application/use-cases/trim-messages-for-context/trim-messages-for-context.use-case';
 
 // Services
 import { ImageContentService } from './application/services/image-content.service';
@@ -20,7 +23,11 @@ import { ImageContentService } from './application/services/image-content.servic
 import { OrphanedImagesCleanupTask } from './infrastructure/tasks/orphaned-images-cleanup.task';
 
 @Module({
-  imports: [LocalMessagesRepositoryModule, forwardRef(() => StorageModule)],
+  imports: [
+    LocalMessagesRepositoryModule,
+    forwardRef(() => StorageModule),
+    TokenCounterModule,
+  ],
   providers: [
     {
       provide: MESSAGES_REPOSITORY,
@@ -34,6 +41,8 @@ import { OrphanedImagesCleanupTask } from './infrastructure/tasks/orphaned-image
     CreateToolResultMessageUseCase,
     DeleteMessageUseCase,
     CleanupOrphanedImagesUseCase,
+    CountMessagesTokensUseCase,
+    TrimMessagesForContextUseCase,
     // Services
     ImageContentService,
     // Tasks
@@ -49,6 +58,8 @@ import { OrphanedImagesCleanupTask } from './infrastructure/tasks/orphaned-image
     CreateToolResultMessageUseCase,
     DeleteMessageUseCase,
     CleanupOrphanedImagesUseCase,
+    CountMessagesTokensUseCase,
+    TrimMessagesForContextUseCase,
     // Services
     ImageContentService,
   ],

--- a/ayunis-core-backend/src/domain/runs/application/use-cases/execute-run-and-set-title/execute-run-and-set-title.use-case.ts
+++ b/ayunis-core-backend/src/domain/runs/application/use-cases/execute-run-and-set-title/execute-run-and-set-title.use-case.ts
@@ -52,7 +52,7 @@ export class ExecuteRunAndSetTitleUseCase {
       };
       yield streamingStartResponse;
 
-      const thread = await this.findThreadUseCase.execute(
+      const { thread } = await this.findThreadUseCase.execute(
         new FindThreadQuery(command.threadId),
       );
 

--- a/ayunis-core-backend/src/domain/threads/application/use-cases/get-thread-sources/get-thread-sources.use-case.ts
+++ b/ayunis-core-backend/src/domain/threads/application/use-cases/get-thread-sources/get-thread-sources.use-case.ts
@@ -18,7 +18,7 @@ export class GetThreadSourcesUseCase {
     });
 
     try {
-      const thread = await this.findThreadUseCase.execute(
+      const { thread } = await this.findThreadUseCase.execute(
         new FindThreadQuery(query.threadId),
       );
       return (

--- a/ayunis-core-backend/src/domain/threads/presenters/http/dto/get-thread-response.dto/index.ts
+++ b/ayunis-core-backend/src/domain/threads/presenters/http/dto/get-thread-response.dto/index.ts
@@ -111,4 +111,11 @@ export class GetThreadResponseDto {
     example: false,
   })
   isAnonymous: boolean;
+
+  @ApiProperty({
+    description:
+      'Whether the thread has exceeded the token threshold for optimal performance',
+    example: false,
+  })
+  isLongChat: boolean;
 }

--- a/ayunis-core-backend/src/domain/threads/presenters/http/mappers/get-thread.mapper.ts
+++ b/ayunis-core-backend/src/domain/threads/presenters/http/mappers/get-thread.mapper.ts
@@ -3,6 +3,7 @@ import { Thread } from '../../../domain/thread.entity';
 import { GetThreadResponseDto } from '../dto/get-thread-response.dto';
 import { MessageDtoMapper } from './message.mapper';
 import { SourceDtoMapper } from './source.mapper';
+import { FindThreadResult } from '../../../application/use-cases/find-thread/find-thread.use-case';
 
 @Injectable()
 export class GetThreadDtoMapper {
@@ -11,7 +12,8 @@ export class GetThreadDtoMapper {
     private readonly sourceDtoMapper: SourceDtoMapper,
   ) {}
 
-  toDto(thread: Thread): GetThreadResponseDto {
+  toDto(result: FindThreadResult): GetThreadResponseDto {
+    const { thread, isLongChat } = result;
     return {
       id: thread.id,
       userId: thread.userId,
@@ -26,10 +28,11 @@ export class GetThreadDtoMapper {
       createdAt: thread.createdAt.toISOString(),
       updatedAt: thread.updatedAt.toISOString(),
       isAnonymous: thread.isAnonymous,
+      isLongChat,
     };
   }
 
   toDtoArray(threads: Thread[]): GetThreadResponseDto[] {
-    return threads.map((thread) => this.toDto(thread));
+    return threads.map((thread) => this.toDto({ thread, isLongChat: false }));
   }
 }

--- a/ayunis-core-backend/src/domain/threads/presenters/http/threads.controller.ts
+++ b/ayunis-core-backend/src/domain/threads/presenters/http/threads.controller.ts
@@ -138,7 +138,8 @@ export class ThreadsController {
         isAnonymous: createThreadDto.isAnonymous,
       }),
     );
-    return this.getThreadDtoMapper.toDto(thread);
+    // New threads are never long chats
+    return this.getThreadDtoMapper.toDto({ thread, isLongChat: false });
   }
 
   @Get()
@@ -215,10 +216,10 @@ export class ThreadsController {
     @Param('id', ParseUUIDPipe) id: UUID,
   ): Promise<GetThreadResponseDto> {
     this.logger.log('findOne', { id });
-    const thread = await this.findThreadUseCase.execute(
+    const result = await this.findThreadUseCase.execute(
       new FindThreadQuery(id),
     );
-    return this.getThreadDtoMapper.toDto(thread);
+    return this.getThreadDtoMapper.toDto(result);
   }
 
   @Delete(':id')
@@ -456,7 +457,7 @@ export class ThreadsController {
       }
 
       // Add all sources to the thread
-      const thread = await this.findThreadUseCase.execute(
+      const { thread } = await this.findThreadUseCase.execute(
         new FindThreadQuery(threadId),
       );
 
@@ -504,7 +505,7 @@ export class ThreadsController {
     this.logger.log('removeSource', { threadId, sourceId });
 
     // First get the thread
-    const thread = await this.findThreadUseCase.execute(
+    const { thread } = await this.findThreadUseCase.execute(
       new FindThreadQuery(threadId),
     );
 

--- a/ayunis-core-backend/src/domain/threads/threads.module.ts
+++ b/ayunis-core-backend/src/domain/threads/threads.module.ts
@@ -27,6 +27,7 @@ import { ReplaceAgentWithDefaultModelUseCase } from './application/use-cases/rep
 import { FindAllThreadsByOrgWithSourcesUseCase } from './application/use-cases/find-all-threads-by-org-with-sources/find-all-threads-by-org-with-sources.use-case';
 import { AgentsModule } from '../agents/agents.module';
 import { StorageModule } from '../storage/storage.module';
+import { MessagesModule } from '../messages/messages.module';
 
 @Module({
   imports: [
@@ -34,6 +35,7 @@ import { StorageModule } from '../storage/storage.module';
     SourcesModule,
     forwardRef(() => ModelsModule),
     forwardRef(() => AgentsModule),
+    MessagesModule,
     OrgsModule,
     StorageModule,
   ],

--- a/ayunis-core-backend/src/domain/threads/threads.module.ts
+++ b/ayunis-core-backend/src/domain/threads/threads.module.ts
@@ -4,7 +4,6 @@ import { ThreadsRepository } from './application/ports/threads.repository';
 import { LocalThreadsRepositoryModule } from './infrastructure/persistence/local/local-threads-repository.module';
 import { SourcesModule } from '../sources/sources.module';
 import { ModelsModule } from '../models/models.module';
-import { MessagesModule } from '../messages/messages.module';
 import { SourceDtoMapper } from './presenters/http/mappers/source.mapper';
 import { GetThreadDtoMapper } from './presenters/http/mappers/get-thread.mapper';
 import { MessageDtoMapper } from './presenters/http/mappers/message.mapper';
@@ -35,7 +34,6 @@ import { StorageModule } from '../storage/storage.module';
     SourcesModule,
     forwardRef(() => ModelsModule),
     forwardRef(() => AgentsModule),
-    MessagesModule,
     OrgsModule,
     StorageModule,
   ],

--- a/ayunis-core-backend/src/domain/tools/application/handlers/code-execution-tool.handler.ts
+++ b/ayunis-core-backend/src/domain/tools/application/handlers/code-execution-tool.handler.ts
@@ -99,7 +99,7 @@ export class CodeExecutionToolHandler extends ToolExecutionHandler {
         Object.keys(response.output_files).length > 0
       ) {
         try {
-          const thread = await this.findThreadUseCase.execute(
+          const { thread } = await this.findThreadUseCase.execute(
             new FindThreadQuery(context.threadId),
           );
 

--- a/ayunis-core-backend/src/domain/tools/application/handlers/mcp-integration-resource.handler.ts
+++ b/ayunis-core-backend/src/domain/tools/application/handlers/mcp-integration-resource.handler.ts
@@ -45,7 +45,7 @@ export class McpIntegrationResourceHandler implements ToolExecutionHandler {
           ),
         );
       const threadId = context.threadId;
-      const thread = await this.findThreadUseCase.execute(
+      const { thread } = await this.findThreadUseCase.execute(
         new FindThreadQuery(threadId),
       );
       if (mimeType === 'text/csv') {

--- a/ayunis-core-frontend/src/pages/chat/ui/ChatPage.tsx
+++ b/ayunis-core-frontend/src/pages/chat/ui/ChatPage.tsx
@@ -469,7 +469,7 @@ export default function ChatPage({
   );
 
   // Long chat warning banner
-  const longChatWarning = !thread.isLongChat && <LongChatWarning />;
+  const longChatWarning = thread.isLongChat && <LongChatWarning />;
 
   // Chat Input
   // Agent, model, and anonymous mode controls are always disabled on ChatPage

--- a/ayunis-core-frontend/src/pages/chat/ui/ChatPage.tsx
+++ b/ayunis-core-frontend/src/pages/chat/ui/ChatPage.tsx
@@ -6,6 +6,7 @@ import { useChatContext } from '@/shared/contexts/chat/useChatContext';
 import { useMessageSend } from '../api/useMessageSend';
 import ContentAreaHeader from '@/widgets/content-area-header/ui/ContentAreaHeader';
 import { MoreVertical, ShieldCheck, Trash2, Pencil } from 'lucide-react';
+import LongChatWarning from './LongChatWarning';
 import type { Thread, Message } from '../model/openapi';
 import { showError } from '@/shared/lib/toast';
 import config from '@/shared/config';
@@ -467,35 +468,41 @@ export default function ChatPage({
     </div>
   );
 
+  // Long chat warning banner
+  const longChatWarning = !thread.isLongChat && <LongChatWarning />;
+
   // Chat Input
   // Agent, model, and anonymous mode controls are always disabled on ChatPage
   // because the thread already has messages (ChatPage is only shown after first message)
   const chatInput = (
-    <ChatInput
-      ref={chatInputRef}
-      modelId={
-        // If the thread has an agent, use the agent's model
-        thread.agentId ? selectedAgent?.model.id : thread.permittedModelId
-      }
-      isModelChangeDisabled={true}
-      isAgentChangeDisabled={true}
-      isAnonymousChangeDisabled={true}
-      agentId={thread.agentId}
-      sources={thread.sources}
-      isAnonymous={thread.isAnonymous}
-      isStreaming={isStreaming}
-      isCreatingFileSource={isTotallyCreatingFileSource}
-      onModelChange={() => {}}
-      onAgentChange={() => {}}
-      onAgentRemove={() => {}}
-      onFileUpload={handleFileUpload}
-      onRemoveSource={deleteFileSource}
-      onDownloadSource={(sourceId) => void handleDownloadSource(sourceId)}
-      onSend={(m, imageFiles) => void handleSend(m, imageFiles)}
-      onSendCancelled={handleSendCancelled}
-      isEmbeddingModelEnabled={isEmbeddingModelEnabled}
-      isVisionEnabled={isVisionEnabled}
-    />
+    <>
+      {longChatWarning}
+      <ChatInput
+        ref={chatInputRef}
+        modelId={
+          // If the thread has an agent, use the agent's model
+          thread.agentId ? selectedAgent?.model.id : thread.permittedModelId
+        }
+        isModelChangeDisabled={true}
+        isAgentChangeDisabled={true}
+        isAnonymousChangeDisabled={true}
+        agentId={thread.agentId}
+        sources={thread.sources}
+        isAnonymous={thread.isAnonymous}
+        isStreaming={isStreaming}
+        isCreatingFileSource={isTotallyCreatingFileSource}
+        onModelChange={() => {}}
+        onAgentChange={() => {}}
+        onAgentRemove={() => {}}
+        onFileUpload={handleFileUpload}
+        onRemoveSource={deleteFileSource}
+        onDownloadSource={(sourceId) => void handleDownloadSource(sourceId)}
+        onSend={(m, imageFiles) => void handleSend(m, imageFiles)}
+        onSendCancelled={handleSendCancelled}
+        isEmbeddingModelEnabled={isEmbeddingModelEnabled}
+        isVisionEnabled={isVisionEnabled}
+      />
+    </>
   );
 
   return (

--- a/ayunis-core-frontend/src/pages/chat/ui/LongChatWarning.tsx
+++ b/ayunis-core-frontend/src/pages/chat/ui/LongChatWarning.tsx
@@ -1,0 +1,46 @@
+import { AlertTriangle } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { useNavigate } from '@tanstack/react-router';
+import { Button } from '@/shared/ui/shadcn/button';
+import {
+  Item,
+  ItemMedia,
+  ItemContent,
+  ItemTitle,
+  ItemDescription,
+  ItemActions,
+} from '@/shared/ui/shadcn/item';
+
+export default function LongChatWarning() {
+  const { t } = useTranslation('chat');
+  const navigate = useNavigate();
+
+  function handleNewChat() {
+    void navigate({ to: '/chat' });
+  }
+
+  return (
+    <Item
+      variant="muted"
+      size="sm"
+      className="mx-4 mb-2 border-yellow-200 bg-yellow-50 dark:border-yellow-900 dark:bg-yellow-950"
+    >
+      <ItemMedia>
+        <AlertTriangle className="h-4 w-4 text-yellow-700 dark:text-yellow-400" />
+      </ItemMedia>
+      <ItemContent>
+        <ItemTitle className="text-yellow-700 dark:text-yellow-400">
+          {t('chat.longChatWarningTitle')}
+        </ItemTitle>
+        <ItemDescription className="text-yellow-700 dark:text-yellow-400">
+          {t('chat.longChatWarningDescription')}
+        </ItemDescription>
+      </ItemContent>
+      <ItemActions>
+        <Button variant="outline" size="sm" onClick={handleNewChat}>
+          {t('newChat.newChat')}
+        </Button>
+      </ItemActions>
+    </Item>
+  );
+}

--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
@@ -1575,6 +1575,8 @@ export interface GetThreadResponseDto {
   updatedAt: string;
   /** Whether the thread is in anonymous mode (PII redaction enabled) */
   isAnonymous: boolean;
+  /** Whether the thread has exceeded the token threshold for optimal performance */
+  isLongChat: boolean;
 }
 
 export interface GetThreadsResponseDtoItem {

--- a/ayunis-core-frontend/src/shared/api/openapi-schema.json
+++ b/ayunis-core-frontend/src/shared/api/openapi-schema.json
@@ -7490,6 +7490,11 @@
             "type": "boolean",
             "description": "Whether the thread is in anonymous mode (PII redaction enabled)",
             "example": false
+          },
+          "isLongChat": {
+            "type": "boolean",
+            "description": "Whether the thread has exceeded the token threshold for optimal performance",
+            "example": false
           }
         },
         "required": [
@@ -7501,7 +7506,8 @@
           "sources",
           "createdAt",
           "updatedAt",
-          "isAnonymous"
+          "isAnonymous",
+          "isLongChat"
         ]
       },
       "GetThreadsResponseDtoItem": {

--- a/ayunis-core-frontend/src/shared/locales/de/chat.json
+++ b/ayunis-core-frontend/src/shared/locales/de/chat.json
@@ -58,7 +58,7 @@
     "charts": {
       "emptyState": "Keine Diagrammdaten verfügbar"
     },
-    "longChatWarningTitle": "Lange Konversation",
+    "longChatWarningTitle": "Konversation zu lang",
     "longChatWarningDescription": "Für bessere Ergebnisse sollten Sie einen neuen Chat starten."
   },
   "newChat": {

--- a/ayunis-core-frontend/src/shared/locales/de/chat.json
+++ b/ayunis-core-frontend/src/shared/locales/de/chat.json
@@ -57,7 +57,9 @@
     },
     "charts": {
       "emptyState": "Keine Diagrammdaten verfügbar"
-    }
+    },
+    "longChatWarningTitle": "Lange Konversation",
+    "longChatWarningDescription": "Für bessere Ergebnisse sollten Sie einen neuen Chat starten."
   },
   "newChat": {
     "newChat": "Neuer Chat",

--- a/ayunis-core-frontend/src/shared/locales/en/chat.json
+++ b/ayunis-core-frontend/src/shared/locales/en/chat.json
@@ -58,7 +58,7 @@
     "charts": {
       "emptyState": "No chart data available"
     },
-    "longChatWarningTitle": "Long conversation",
+    "longChatWarningTitle": "Conversation too long",
     "longChatWarningDescription": "For better results, consider starting a new chat."
   },
   "newChat": {

--- a/ayunis-core-frontend/src/shared/locales/en/chat.json
+++ b/ayunis-core-frontend/src/shared/locales/en/chat.json
@@ -57,7 +57,9 @@
     },
     "charts": {
       "emptyState": "No chart data available"
-    }
+    },
+    "longChatWarningTitle": "Long conversation",
+    "longChatWarningDescription": "For better results, consider starting a new chat."
   },
   "newChat": {
     "newChat": "New Chat",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Implements token-aware context management and long-chat signalling across backend and frontend.
> 
> - Add token counting subsystem with `tiktoken` and a simple estimator (`TokenCounterModule`, handlers, registry, errors); expose `CountTokensUseCase`
> - New `TrimMessagesForContextUseCase` to keep most-recent messages within `MAX_CONTEXT_TOKENS` (80k); integrated into `ExecuteRunUseCase` before inference (streaming and non-streaming)
> - Compute thread token count in `FindThreadUseCase` and return `{ thread, isLongChat }` (threshold 50k); update DTO (`GetThreadResponseDto.isLongChat`), mapper, controller, and OpenAPI/types
> - Frontend: render `LongChatWarning` banner when `thread.isLongChat` is true and include it above `ChatInput`; add i18n strings (en/de)
> - Wire modules: `MessagesModule` imports `TokenCounterModule`; `ThreadsModule` depends on `MessagesModule`; update callers to destructure `{ thread }` from `FindThreadUseCase`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e41ef1868f3a1e02a303174727d0643467e74879. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->