### PR TITLE
Thread sorting after pagination

### DIFF
--- a/ayunis-core-backend/src/domain/threads/infrastructure/persistence/local/local-threads.repository.ts
+++ b/ayunis-core-backend/src/domain/threads/infrastructure/persistence/local/local-threads.repository.ts
@@ -130,8 +130,8 @@ export class LocalThreadsRepository extends ThreadsRepository {
       queryBuilder.leftJoinAndSelect('thread.model', 'model');
     }
 
-    // Order by most recent first
-    queryBuilder.orderBy('thread.updatedAt', 'DESC');
+    // Order by most recent first (by creation time)
+    queryBuilder.orderBy('thread.createdAt', 'DESC');
 
     // Apply messages ordering if needed
     if (options?.withMessages) {

--- a/ayunis-core-frontend/src/widgets/app-sidebar/ui/ChatsSidebarGroup.tsx
+++ b/ayunis-core-frontend/src/widgets/app-sidebar/ui/ChatsSidebarGroup.tsx
@@ -217,9 +217,7 @@ export function ChatsSidebarGroup() {
           <CollapsibleContent>
             <SidebarGroupContent>
               <SidebarMenu>
-                {threads
-                  .sort((a, b) => (a.createdAt > b.createdAt ? -1 : 1))
-                  .map((thread) => (
+                {threads.map((thread) => (
                     <SidebarMenuItem key={thread.id} data-testid="chat">
                       <SidebarMenuButton asChild>
                         <Link


### PR DESCRIPTION
Fix thread sorting to use `createdAt` instead of `updatedAt` to display newest threads first.

After pagination was introduced, threads were incorrectly sorted by `updatedAt`, causing them to appear out of order based on their last update time rather than their creation time. This change ensures threads are consistently sorted by creation time descending.

---
<a href="https://cursor.com/background-agent?bcId=bc-2b4f63b4-791d-4f1b-a14e-1b94b5c06ed7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2b4f63b4-791d-4f1b-a14e-1b94b5c06ed7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures newest threads appear first consistently with pagination by relying on server-side ordering.
> 
> - Backend: `LocalThreadsRepository.findAll` now orders by `thread.createdAt DESC` (was `updatedAt DESC`); message order remains `messages.createdAt ASC` when included
> - Frontend: `ChatsSidebarGroup` removes client-side `.sort(...)` and maps `threads` as provided by the API
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eec2095c2f9da4507e4962e7b36459d2cce9ca3a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->