### PR TITLE
Password visibility toggle

### DIFF
--- a/ayunis-core-frontend/src/pages/admin-settings/integrations-settings/ui/create-custom-dialog.tsx
+++ b/ayunis-core-frontend/src/pages/admin-settings/integrations-settings/ui/create-custom-dialog.tsx
@@ -26,6 +26,7 @@ import {
   SelectValue,
 } from '@/shared/ui/shadcn/select';
 import { Input } from '@/shared/ui/shadcn/input';
+import { PasswordInput } from '@/shared/ui/shadcn/password-input';
 import { Button } from '@/shared/ui/shadcn/button';
 import type { CreateCustomIntegrationFormData } from '../model/types';
 import { useCreateCustomIntegration } from '../api/useCreateCustomIntegration';
@@ -267,8 +268,7 @@ export function CreateCustomDialog({
                         {t('integrations.createCustomDialog.credentials')}
                       </FormLabel>
                       <FormControl>
-                        <Input
-                          type="password"
+                        <PasswordInput
                           placeholder={t(
                             'integrations.createCustomDialog.credentialsPlaceholder',
                           )}
@@ -298,8 +298,7 @@ export function CreateCustomDialog({
                       {t('integrations.createCustomDialog.credentials')}
                     </FormLabel>
                     <FormControl>
-                      <Input
-                        type="password"
+                      <PasswordInput
                         placeholder={t(
                           'integrations.createCustomDialog.credentialsPlaceholder',
                         )}

--- a/ayunis-core-frontend/src/pages/admin-settings/integrations-settings/ui/edit-integration-dialog.tsx
+++ b/ayunis-core-frontend/src/pages/admin-settings/integrations-settings/ui/edit-integration-dialog.tsx
@@ -18,6 +18,7 @@ import {
   FormMessage,
 } from '@/shared/ui/shadcn/form';
 import { Input } from '@/shared/ui/shadcn/input';
+import { PasswordInput } from '@/shared/ui/shadcn/password-input';
 import { Button } from '@/shared/ui/shadcn/button';
 import type { McpIntegration, UpdateIntegrationFormData } from '../model/types';
 import { useUpdateIntegration } from '../api/useUpdateIntegration';
@@ -165,8 +166,7 @@ export function EditIntegrationDialog({
                           {t('integrations.editDialog.credentials')}
                         </FormLabel>
                         <FormControl>
-                          <Input
-                            type="password"
+                          <PasswordInput
                             placeholder={t(
                               'integrations.editDialog.credentialsPlaceholder',
                             )}
@@ -194,8 +194,7 @@ export function EditIntegrationDialog({
                         {t('integrations.editDialog.credentials')}
                       </FormLabel>
                       <FormControl>
-                        <Input
-                          type="password"
+                        <PasswordInput
                           placeholder={t(
                             'integrations.editDialog.credentialsPlaceholder',
                           )}

--- a/ayunis-core-frontend/src/pages/auth/invite-accept/ui/InviteAcceptPage.tsx
+++ b/ayunis-core-frontend/src/pages/auth/invite-accept/ui/InviteAcceptPage.tsx
@@ -8,6 +8,7 @@ import {
   FormMessage,
 } from '@/shared/ui/shadcn/form';
 import { Input } from '@/shared/ui/shadcn/input';
+import { PasswordInput } from '@/shared/ui/shadcn/password-input';
 import OnboardingLayout from '@/layouts/onboarding-layout';
 import type { Invite } from '../model/openapi';
 import { useInviteAccept } from '../api';
@@ -82,9 +83,8 @@ export default function InviteAcceptPage({
               <FormItem>
                 <FormLabel>{t('inviteAccept.password')}</FormLabel>
                 <FormControl>
-                  <Input
+                  <PasswordInput
                     placeholder={t('inviteAccept.passwordPlaceholder')}
-                    type="password"
                     {...field}
                   />
                 </FormControl>

--- a/ayunis-core-frontend/src/pages/auth/login/ui/LoginPage.tsx
+++ b/ayunis-core-frontend/src/pages/auth/login/ui/LoginPage.tsx
@@ -9,6 +9,7 @@ import {
   FormMessage,
 } from '@/shared/ui/shadcn/form';
 import { Input } from '@/shared/ui/shadcn/input';
+import { PasswordInput } from '@/shared/ui/shadcn/password-input';
 import OnboardingLayout from '@/layouts/onboarding-layout';
 import { useLogin } from '../api/useLogin';
 import { useTranslation } from 'react-i18next';
@@ -80,9 +81,8 @@ export function LoginPage({
               <FormItem>
                 <FormLabel>{t('login.password')}</FormLabel>
                 <FormControl>
-                  <Input
+                  <PasswordInput
                     placeholder={t('login.passwordPlaceholder')}
-                    type="password"
                     data-testid="password"
                     {...field}
                   />

--- a/ayunis-core-frontend/src/pages/auth/register/ui/RegisterPage.tsx
+++ b/ayunis-core-frontend/src/pages/auth/register/ui/RegisterPage.tsx
@@ -8,6 +8,7 @@ import {
   FormMessage,
 } from '@/shared/ui/shadcn/form';
 import { Input } from '@/shared/ui/shadcn/input';
+import { PasswordInput } from '@/shared/ui/shadcn/password-input';
 import OnboardingLayout from '@/layouts/onboarding-layout';
 import { useRegister } from '../api';
 import { useTranslation, Trans } from 'react-i18next';
@@ -155,10 +156,9 @@ export function RegisterPage({
               <FormItem>
                 <FormLabel>{t('register.password')}</FormLabel>
                 <FormControl>
-                  <Input
+                  <PasswordInput
                     required
                     placeholder={t('register.passwordPlaceholder')}
-                    type="password"
                     {...field}
                   />
                 </FormControl>

--- a/ayunis-core-frontend/src/pages/auth/reset-password/ui/ResetPasswordPage.tsx
+++ b/ayunis-core-frontend/src/pages/auth/reset-password/ui/ResetPasswordPage.tsx
@@ -7,7 +7,7 @@ import {
   FormLabel,
   FormMessage,
 } from '@/shared/ui/shadcn/form';
-import { Input } from '@/shared/ui/shadcn/input';
+import { PasswordInput } from '@/shared/ui/shadcn/password-input';
 import OnboardingLayout from '@/layouts/onboarding-layout';
 import { useResetPassword } from '../api/useResetPassword';
 import { useTranslation } from 'react-i18next';
@@ -47,9 +47,8 @@ export function ResetPasswordPage({ token }: { token: string }) {
               <FormItem>
                 <FormLabel>{t('resetPassword.newPassword')}</FormLabel>
                 <FormControl>
-                  <Input
+                  <PasswordInput
                     placeholder={t('resetPassword.newPasswordPlaceholder')}
-                    type="password"
                     {...field}
                   />
                 </FormControl>
@@ -64,9 +63,8 @@ export function ResetPasswordPage({ token }: { token: string }) {
               <FormItem>
                 <FormLabel>{t('resetPassword.confirmPassword')}</FormLabel>
                 <FormControl>
-                  <Input
+                  <PasswordInput
                     placeholder={t('resetPassword.confirmPasswordPlaceholder')}
-                    type="password"
                     {...field}
                   />
                 </FormControl>

--- a/ayunis-core-frontend/src/pages/settings/account-settings/ui/PasswordSettingsPage.tsx
+++ b/ayunis-core-frontend/src/pages/settings/account-settings/ui/PasswordSettingsPage.tsx
@@ -4,7 +4,7 @@ import {
   CardHeader,
   CardTitle,
 } from '@/shared/ui/shadcn/card';
-import { Input } from '@/shared/ui/shadcn/input';
+import { PasswordInput } from '@/shared/ui/shadcn/password-input';
 import { Button } from '@/shared/ui/shadcn/button';
 import { Separator } from '@/shared/ui/shadcn/separator';
 import { useTranslation } from 'react-i18next';
@@ -42,9 +42,8 @@ export default function PasswordSettingsPage() {
                 <FormItem>
                   <FormLabel>{t('account.currentPassword')}</FormLabel>
                   <FormControl>
-                    <Input
+                    <PasswordInput
                       {...field}
-                      type="password"
                       placeholder={t('account.currentPasswordPlaceholder')}
                     />
                   </FormControl>
@@ -62,9 +61,8 @@ export default function PasswordSettingsPage() {
                 <FormItem>
                   <FormLabel>{t('account.newPassword')}</FormLabel>
                   <FormControl>
-                    <Input
+                    <PasswordInput
                       {...field}
-                      type="password"
                       placeholder={t('account.newPasswordPlaceholder')}
                     />
                   </FormControl>
@@ -83,9 +81,8 @@ export default function PasswordSettingsPage() {
                 <FormItem>
                   <FormLabel>{t('account.confirmPassword')}</FormLabel>
                   <FormControl>
-                    <Input
+                    <PasswordInput
                       {...field}
-                      type="password"
                       placeholder={t('account.confirmPasswordPlaceholder')}
                     />
                   </FormControl>

--- a/ayunis-core-frontend/src/shared/ui/shadcn/password-input.tsx
+++ b/ayunis-core-frontend/src/shared/ui/shadcn/password-input.tsx
@@ -1,0 +1,41 @@
+import * as React from 'react';
+import { Eye, EyeOff } from 'lucide-react';
+import { Input } from './input';
+import { cn } from '@/shared/lib/shadcn/utils';
+
+interface PasswordInputProps extends React.ComponentProps<'input'> {
+  className?: string;
+}
+
+const PasswordInput = React.forwardRef<HTMLInputElement, PasswordInputProps>(
+  ({ className, ...props }, ref) => {
+    const [showPassword, setShowPassword] = React.useState(false);
+
+    return (
+      <div className="relative">
+        <Input
+          type={showPassword ? 'text' : 'password'}
+          className={cn('pr-10', className)}
+          ref={ref}
+          {...props}
+        />
+        <button
+          type="button"
+          onClick={() => setShowPassword(!showPassword)}
+          className="absolute right-0 top-0 h-full px-3 py-2 hover:bg-transparent"
+          aria-label={showPassword ? 'Hide password' : 'Show password'}
+        >
+          {showPassword ? (
+            <EyeOff className="h-4 w-4 text-muted-foreground" />
+          ) : (
+            <Eye className="h-4 w-4 text-muted-foreground" />
+          )}
+        </button>
+      </div>
+    );
+  },
+);
+
+PasswordInput.displayName = 'PasswordInput';
+
+export { PasswordInput };

--- a/ayunis-core-frontend/src/shared/ui/shadcn/password-input.tsx
+++ b/ayunis-core-frontend/src/shared/ui/shadcn/password-input.tsx
@@ -8,22 +8,24 @@ interface PasswordInputProps extends React.ComponentProps<'input'> {
 }
 
 const PasswordInput = React.forwardRef<HTMLInputElement, PasswordInputProps>(
-  ({ className, ...props }, ref) => {
+  ({ className, disabled, ...props }, ref) => {
     const [showPassword, setShowPassword] = React.useState(false);
 
     return (
       <div className="relative">
         <Input
+          {...props}
           type={showPassword ? 'text' : 'password'}
           className={cn('pr-10', className)}
+          disabled={disabled}
           ref={ref}
-          {...props}
         />
         <button
           type="button"
           onClick={() => setShowPassword(!showPassword)}
           className="absolute right-0 top-0 h-full px-3 py-2 hover:bg-transparent"
           aria-label={showPassword ? 'Hide password' : 'Show password'}
+          disabled={disabled}
         >
           {showPassword ? (
             <EyeOff className="h-4 w-4 text-muted-foreground" />


### PR DESCRIPTION
Add password visibility toggle buttons to all password input fields to improve user experience.

---
[Slack Thread](https://locaboo.slack.com/archives/C0375HX2C4S/p1768376886382459?thread_ts=1768376886.382459&cid=C0375HX2C4S)

<a href="https://cursor.com/background-agent?bcId=bc-beba9c7e-df78-451c-bf27-79c07467d612"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-beba9c7e-df78-451c-bf27-79c07467d612"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a reusable password field with visibility toggle and applies it app-wide where passwords/credentials are entered.
> 
> - New `shared/ui/shadcn/password-input.tsx`: `PasswordInput` wraps `Input` with show/hide toggle (Eye/EyeOff), forwards ref, supports disabled, and adds right-padding
> - Replaces plain `Input type="password"` with `PasswordInput` in: login, register, invite accept, reset password, account password settings, and admin integrations (create/edit) dialogs for credentials
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7caf9294f1b22a0b46327b07e1f700c2dd7c06fc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->