### PR TITLE
Agents list tabs

### DIFF
--- a/ayunis-core-frontend/src/shared/locales/de/agents.json
+++ b/ayunis-core-frontend/src/shared/locales/de/agents.json
@@ -2,9 +2,21 @@
   "page": {
     "title": "Meine Agenten"
   },
+  "tabs": {
+    "personal": "Persönliche Agenten",
+    "shared": "Geteilte Agenten"
+  },
   "emptyState": {
     "title": "Noch keine Agenten",
-    "description": "Beginnen Sie mit der Erstellung Ihres ersten KI-Agenten. Agenten helfen Ihnen dabei, spezialisierte KI-Assistenten für bestimmte Aufgaben und Arbeitsabläufe zu erstellen."
+    "description": "Beginnen Sie mit der Erstellung Ihres ersten KI-Agenten. Agenten helfen Ihnen dabei, spezialisierte KI-Assistenten für bestimmte Aufgaben und Arbeitsabläufe zu erstellen.",
+    "personal": {
+      "title": "Noch keine persönlichen Agenten",
+      "description": "Erstellen Sie Ihren ersten KI-Agenten. Agenten helfen Ihnen dabei, spezialisierte KI-Assistenten für bestimmte Aufgaben und Arbeitsabläufe zu erstellen."
+    },
+    "shared": {
+      "title": "Noch keine geteilten Agenten",
+      "description": "Agenten, die von anderen Mitgliedern Ihrer Organisation mit Ihnen geteilt wurden, werden hier angezeigt."
+    }
   },
   "badge": {
     "shared": "Geteilt"

--- a/ayunis-core-frontend/src/shared/locales/en/agents.json
+++ b/ayunis-core-frontend/src/shared/locales/en/agents.json
@@ -2,9 +2,21 @@
   "page": {
     "title": "My Agents"
   },
+  "tabs": {
+    "personal": "Personal Agents",
+    "shared": "Shared Agents"
+  },
   "emptyState": {
     "title": "No agents yet",
-    "description": "Get started by creating your first AI agent. Agents help you set up specialized AI assistants for specific tasks and workflows."
+    "description": "Get started by creating your first AI agent. Agents help you set up specialized AI assistants for specific tasks and workflows.",
+    "personal": {
+      "title": "No personal agents yet",
+      "description": "Create your first AI agent. Agents help you set up specialized AI assistants for specific tasks and workflows."
+    },
+    "shared": {
+      "title": "No shared agents yet",
+      "description": "Agents shared with you by other members of your organization will appear here."
+    }
   },
   "badge": {
     "shared": "Shared"

--- a/ayunis-core-frontend/src/widgets/empty-state/ui/EmptyState.tsx
+++ b/ayunis-core-frontend/src/widgets/empty-state/ui/EmptyState.tsx
@@ -12,7 +12,7 @@ export default function EmptyState({
   action,
 }: EmptyStateProps) {
   return (
-    <div className="flex flex-col items-center justify-center py-16 px-4 text-center max-w-md">
+    <div className="flex flex-col items-center justify-center py-16 px-4 text-center max-w-md mx-auto">
       <h3 className="text-lg font-semibold mb-2">{title}</h3>
       <p className="mb-6 text-muted-foreground">{description}</p>
       {action}


### PR DESCRIPTION
Divide the `/agents` page into "Personal Agents" and "Shared Agents" tabs to improve organization and user experience.

---
<a href="https://cursor.com/background-agent?bcId=bc-5487e7e5-9a55-4cb6-a918-55ebf031cf46"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5487e7e5-9a55-4cb6-a918-55ebf031cf46"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a tabbed layout on `AgentsPage` to separate personal and shared agents, improving organization.
> 
> - Uses `Tabs` to show `personal` and `shared` lists (alphabetically), with a full-screen empty state when there are no agents at all
> - Adds per-tab empty states via `EmptyState`; personal tab includes a create action
> - Updates i18n (`en`, `de`) with `tabs.*` and `emptyState.personal/shared.*` strings
> - Minor UI tweak: center `EmptyState` container (`mx-auto`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b3fd0997a54494a526685be6ce2e9a158f01e17e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->