### PR TITLE
feat: fair use policy AYC-69

### DIFF
--- a/ayunis-core-backend/src/db/migrations/1768399888552-AddUsageQuotas.ts
+++ b/ayunis-core-backend/src/db/migrations/1768399888552-AddUsageQuotas.ts
@@ -1,20 +1,31 @@
-import { MigrationInterface, QueryRunner } from "typeorm";
+import { MigrationInterface, QueryRunner } from 'typeorm';
 
 export class AddUsageQuotas1768399888552 implements MigrationInterface {
-    name = 'AddUsageQuotas1768399888552'
+  name = 'AddUsageQuotas1768399888552';
 
-    public async up(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.query(`CREATE TYPE "public"."usage_quotas_quotatype_enum" AS ENUM('FAIR_USE_MESSAGES')`);
-        await queryRunner.query(`CREATE TABLE "usage_quotas" ("id" character varying NOT NULL, "createdAt" TIMESTAMP NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP NOT NULL DEFAULT now(), "userId" character varying NOT NULL, "quotaType" "public"."usage_quotas_quotatype_enum" NOT NULL, "count" integer NOT NULL DEFAULT '0', "windowStartAt" TIMESTAMP NOT NULL, "windowDurationMs" bigint NOT NULL, CONSTRAINT "UQ_394fe814ce4a600f6a083111998" UNIQUE ("userId", "quotaType"), CONSTRAINT "PK_6f12bb43b7afd110c544d3549c4" PRIMARY KEY ("id"))`);
-        await queryRunner.query(`CREATE INDEX "IDX_394fe814ce4a600f6a08311199" ON "usage_quotas" ("userId", "quotaType") `);
-        await queryRunner.query(`ALTER TABLE "usage_quotas" ADD CONSTRAINT "FK_37d7c2fab0e43097c7035472533" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE NO ACTION`);
-    }
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TYPE "public"."usage_quotas_quotatype_enum" AS ENUM('FAIR_USE_MESSAGES')`,
+    );
+    await queryRunner.query(
+      `CREATE TABLE "usage_quotas" ("id" character varying NOT NULL, "createdAt" TIMESTAMP NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP NOT NULL DEFAULT now(), "userId" character varying NOT NULL, "quotaType" "public"."usage_quotas_quotatype_enum" NOT NULL, "count" integer NOT NULL DEFAULT '0', "windowStartAt" TIMESTAMP NOT NULL, "windowDurationMs" bigint NOT NULL, CONSTRAINT "UQ_394fe814ce4a600f6a083111998" UNIQUE ("userId", "quotaType"), CONSTRAINT "PK_6f12bb43b7afd110c544d3549c4" PRIMARY KEY ("id"))`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_394fe814ce4a600f6a08311199" ON "usage_quotas" ("userId", "quotaType") `,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "usage_quotas" ADD CONSTRAINT "FK_37d7c2fab0e43097c7035472533" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+  }
 
-    public async down(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.query(`ALTER TABLE "usage_quotas" DROP CONSTRAINT "FK_37d7c2fab0e43097c7035472533"`);
-        await queryRunner.query(`DROP INDEX "public"."IDX_394fe814ce4a600f6a08311199"`);
-        await queryRunner.query(`DROP TABLE "usage_quotas"`);
-        await queryRunner.query(`DROP TYPE "public"."usage_quotas_quotatype_enum"`);
-    }
-
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "usage_quotas" DROP CONSTRAINT "FK_37d7c2fab0e43097c7035472533"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_394fe814ce4a600f6a08311199"`,
+    );
+    await queryRunner.query(`DROP TABLE "usage_quotas"`);
+    await queryRunner.query(`DROP TYPE "public"."usage_quotas_quotatype_enum"`);
+  }
 }

--- a/ayunis-core-backend/src/db/migrations/1768399888552-AddUsageQuotas.ts
+++ b/ayunis-core-backend/src/db/migrations/1768399888552-AddUsageQuotas.ts
@@ -1,0 +1,20 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddUsageQuotas1768399888552 implements MigrationInterface {
+    name = 'AddUsageQuotas1768399888552'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`CREATE TYPE "public"."usage_quotas_quotatype_enum" AS ENUM('FAIR_USE_MESSAGES')`);
+        await queryRunner.query(`CREATE TABLE "usage_quotas" ("id" character varying NOT NULL, "createdAt" TIMESTAMP NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP NOT NULL DEFAULT now(), "userId" character varying NOT NULL, "quotaType" "public"."usage_quotas_quotatype_enum" NOT NULL, "count" integer NOT NULL DEFAULT '0', "windowStartAt" TIMESTAMP NOT NULL, "windowDurationMs" bigint NOT NULL, CONSTRAINT "UQ_394fe814ce4a600f6a083111998" UNIQUE ("userId", "quotaType"), CONSTRAINT "PK_6f12bb43b7afd110c544d3549c4" PRIMARY KEY ("id"))`);
+        await queryRunner.query(`CREATE INDEX "IDX_394fe814ce4a600f6a08311199" ON "usage_quotas" ("userId", "quotaType") `);
+        await queryRunner.query(`ALTER TABLE "usage_quotas" ADD CONSTRAINT "FK_37d7c2fab0e43097c7035472533" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE NO ACTION`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "usage_quotas" DROP CONSTRAINT "FK_37d7c2fab0e43097c7035472533"`);
+        await queryRunner.query(`DROP INDEX "public"."IDX_394fe814ce4a600f6a08311199"`);
+        await queryRunner.query(`DROP TABLE "usage_quotas"`);
+        await queryRunner.query(`DROP TYPE "public"."usage_quotas_quotatype_enum"`);
+    }
+
+}

--- a/ayunis-core-backend/src/domain/runs/application/use-cases/execute-run-and-set-title/execute-run-and-set-title.use-case.ts
+++ b/ayunis-core-backend/src/domain/runs/application/use-cases/execute-run-and-set-title/execute-run-and-set-title.use-case.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger, UnauthorizedException } from '@nestjs/common';
 import { ExecuteRunAndSetTitleCommand } from './execute-run-and-set-title.command';
 import { ExecuteRunUseCase } from '../execute-run/execute-run.use-case';
 import { ExecuteRunCommand } from '../execute-run/execute-run.command';
@@ -26,6 +26,10 @@ import { Agent } from 'src/domain/agents/domain/agent.entity';
 import { AnonymizeTextUseCase } from 'src/common/anonymization/application/use-cases/anonymize-text/anonymize-text.use-case';
 import { AnonymizeTextCommand } from 'src/common/anonymization/application/use-cases/anonymize-text/anonymize-text.command';
 import { ApplicationError } from 'src/common/errors/base.error';
+import { ContextService } from 'src/common/context/services/context.service';
+import { CheckQuotaUseCase } from 'src/iam/quotas/application/use-cases/check-quota/check-quota.use-case';
+import { CheckQuotaQuery } from 'src/iam/quotas/application/use-cases/check-quota/check-quota.query';
+import { QuotaType } from 'src/iam/quotas/domain/quota-type.enum';
 
 @Injectable()
 export class ExecuteRunAndSetTitleUseCase {
@@ -38,12 +42,23 @@ export class ExecuteRunAndSetTitleUseCase {
     private readonly generateAndSetThreadTitleUseCase: GenerateAndSetThreadTitleUseCase,
     private readonly messageDtoMapper: MessageDtoMapper,
     private readonly anonymizeTextUseCase: AnonymizeTextUseCase,
+    private readonly contextService: ContextService,
+    private readonly checkQuotaUseCase: CheckQuotaUseCase,
   ) {}
 
   async *execute(
     command: ExecuteRunAndSetTitleCommand,
   ): AsyncGenerator<RunResponse> {
     try {
+      // Fair use quota check - throws QuotaExceededError if limit exceeded
+      const userId = this.contextService.get('userId');
+      if (!userId) {
+        throw new UnauthorizedException('User not authenticated');
+      }
+      await this.checkQuotaUseCase.execute(
+        new CheckQuotaQuery(userId, QuotaType.FAIR_USE_MESSAGES),
+      );
+
       const streamingStartResponse: RunSessionResponseDto = {
         type: 'session',
         streaming: true,

--- a/ayunis-core-backend/src/domain/runs/application/use-cases/execute-run-and-set-title/execute-run-and-set-title.use-case.ts
+++ b/ayunis-core-backend/src/domain/runs/application/use-cases/execute-run-and-set-title/execute-run-and-set-title.use-case.ts
@@ -121,6 +121,8 @@ export class ExecuteRunAndSetTitleUseCase {
         details: {
           error: error instanceof Error ? error.toString() : 'Unknown error',
           stack: error instanceof Error ? error.stack : 'Unknown error',
+          // Include metadata from ApplicationError (e.g., retryAfterSeconds for quota errors)
+          ...(error instanceof ApplicationError && error.metadata),
         },
       };
 

--- a/ayunis-core-backend/src/domain/runs/runs.module.ts
+++ b/ayunis-core-backend/src/domain/runs/runs.module.ts
@@ -13,6 +13,7 @@ import { McpModule } from 'src/domain/mcp/mcp.module';
 import { SourcesModule } from 'src/domain/sources/sources.module';
 import { AnonymizationModule } from 'src/common/anonymization/anonymization.module';
 import { UsageModule } from 'src/domain/usage/usage.module';
+import { QuotasModule } from 'src/iam/quotas/quotas.module';
 
 @Module({
   imports: [
@@ -27,6 +28,7 @@ import { UsageModule } from 'src/domain/usage/usage.module';
     SourcesModule,
     AnonymizationModule,
     UsageModule,
+    QuotasModule,
   ],
   controllers: [RunsController],
   providers: [ExecuteRunUseCase, ExecuteRunAndSetTitleUseCase],

--- a/ayunis-core-backend/src/iam/iam.module.ts
+++ b/ayunis-core-backend/src/iam/iam.module.ts
@@ -13,6 +13,7 @@ import { AuthorizationModule } from './authorization/authorization.module';
 import { SubscriptionsModule } from './subscriptions/subscriptions.module';
 import { TrialsModule } from './trials/trials.module';
 import { LegalAcceptancesModule } from './legal-acceptances/legal-acceptances.module';
+import { QuotasModule } from './quotas/quotas.module';
 
 @Module({})
 export class IamModule {
@@ -32,6 +33,7 @@ export class IamModule {
         SubscriptionsModule,
         TrialsModule,
         LegalAcceptancesModule,
+        QuotasModule,
       ],
       exports: [
         AuthenticationModule,
@@ -43,6 +45,7 @@ export class IamModule {
         SubscriptionsModule,
         TrialsModule,
         LegalAcceptancesModule,
+        QuotasModule,
       ],
     };
   }

--- a/ayunis-core-backend/src/iam/quotas/application/ports/usage-quota.repository.port.ts
+++ b/ayunis-core-backend/src/iam/quotas/application/ports/usage-quota.repository.port.ts
@@ -1,0 +1,16 @@
+import { UUID } from 'crypto';
+import { UsageQuota } from '../../domain/usage-quota.entity';
+import { QuotaType } from '../../domain/quota-type.enum';
+
+export abstract class UsageQuotaRepositoryPort {
+  /**
+   * Atomically increment the quota counter and return the updated quota.
+   * If no quota exists, creates one with count=1.
+   * If the window has expired, resets it and sets count=1.
+   */
+  abstract incrementAndGet(
+    userId: UUID,
+    quotaType: QuotaType,
+    windowDurationMs: number,
+  ): Promise<UsageQuota>;
+}

--- a/ayunis-core-backend/src/iam/quotas/application/ports/usage-quota.repository.port.ts
+++ b/ayunis-core-backend/src/iam/quotas/application/ports/usage-quota.repository.port.ts
@@ -2,15 +2,35 @@ import { UUID } from 'crypto';
 import { UsageQuota } from '../../domain/usage-quota.entity';
 import { QuotaType } from '../../domain/quota-type.enum';
 
+export interface CheckAndIncrementResult {
+  quota: UsageQuota;
+  exceeded: boolean;
+}
+
 export abstract class UsageQuotaRepositoryPort {
   /**
    * Atomically increment the quota counter and return the updated quota.
    * If no quota exists, creates one with count=1.
    * If the window has expired, resets it and sets count=1.
+   * @deprecated Use checkAndIncrement instead to avoid counter inflation on rejected requests
    */
   abstract incrementAndGet(
     userId: UUID,
     quotaType: QuotaType,
     windowDurationMs: number,
   ): Promise<UsageQuota>;
+
+  /**
+   * Atomically check quota limit and increment if under limit.
+   * - If no quota exists, creates one with count=1 (uses upsert to handle race conditions)
+   * - If the window has expired, resets it and sets count=1
+   * - If count >= limit, returns { exceeded: true } WITHOUT incrementing
+   * - If count < limit, increments and returns { exceeded: false }
+   */
+  abstract checkAndIncrement(
+    userId: UUID,
+    quotaType: QuotaType,
+    windowDurationMs: number,
+    limit: number,
+  ): Promise<CheckAndIncrementResult>;
 }

--- a/ayunis-core-backend/src/iam/quotas/application/quotas.errors.ts
+++ b/ayunis-core-backend/src/iam/quotas/application/quotas.errors.ts
@@ -1,0 +1,47 @@
+import {
+  ApplicationError,
+  ErrorMetadata,
+} from '../../../common/errors/base.error';
+import { HttpException, HttpStatus } from '@nestjs/common';
+
+export enum QuotaErrorCode {
+  QUOTA_EXCEEDED = 'QUOTA_EXCEEDED',
+}
+
+export abstract class QuotaError extends ApplicationError {
+  constructor(
+    message: string,
+    code: QuotaErrorCode,
+    statusCode: number = 429,
+    metadata?: ErrorMetadata,
+  ) {
+    super(message, code, statusCode, metadata);
+  }
+
+  toHttpException() {
+    return new HttpException(
+      {
+        code: this.code,
+        message: this.message,
+        ...(this.metadata && { metadata: this.metadata }),
+      },
+      this.statusCode,
+    );
+  }
+}
+
+export class QuotaExceededError extends QuotaError {
+  constructor(
+    quotaType: string,
+    limit: number,
+    retryAfterSeconds: number,
+    metadata?: ErrorMetadata,
+  ) {
+    super(
+      `Fair use limit exceeded. Maximum ${limit} messages per 3 hours. Try again in ${Math.ceil(retryAfterSeconds / 60)} minutes.`,
+      QuotaErrorCode.QUOTA_EXCEEDED,
+      HttpStatus.TOO_MANY_REQUESTS,
+      { quotaType, limit, retryAfterSeconds, ...metadata },
+    );
+  }
+}

--- a/ayunis-core-backend/src/iam/quotas/application/services/quota-limit-resolver.service.ts
+++ b/ayunis-core-backend/src/iam/quotas/application/services/quota-limit-resolver.service.ts
@@ -1,0 +1,20 @@
+import { Injectable } from '@nestjs/common';
+import { UUID } from 'crypto';
+import { QuotaType } from '../../domain/quota-type.enum';
+
+export interface QuotaLimitConfig {
+  limit: number;
+  windowMs: number;
+}
+
+@Injectable()
+export class QuotaLimitResolverService {
+  resolve(_userId: UUID, quotaType: QuotaType): QuotaLimitConfig {
+    switch (quotaType) {
+      case QuotaType.FAIR_USE_MESSAGES:
+        return { limit: 200, windowMs: 3 * 60 * 60 * 1000 }; // 3 hours
+      default:
+        return { limit: 100, windowMs: 60 * 60 * 1000 }; // 1 hour
+    }
+  }
+}

--- a/ayunis-core-backend/src/iam/quotas/application/use-cases/check-quota/check-quota.query.ts
+++ b/ayunis-core-backend/src/iam/quotas/application/use-cases/check-quota/check-quota.query.ts
@@ -1,0 +1,9 @@
+import { UUID } from 'crypto';
+import { QuotaType } from '../../../domain/quota-type.enum';
+
+export class CheckQuotaQuery {
+  constructor(
+    public readonly userId: UUID,
+    public readonly quotaType: QuotaType,
+  ) {}
+}

--- a/ayunis-core-backend/src/iam/quotas/application/use-cases/check-quota/check-quota.use-case.ts
+++ b/ayunis-core-backend/src/iam/quotas/application/use-cases/check-quota/check-quota.use-case.ts
@@ -1,0 +1,58 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { UsageQuotaRepositoryPort } from '../../ports/usage-quota.repository.port';
+import { QuotaLimitResolverService } from '../../services/quota-limit-resolver.service';
+import { CheckQuotaQuery } from './check-quota.query';
+import { QuotaExceededError } from '../../quotas.errors';
+
+@Injectable()
+export class CheckQuotaUseCase {
+  private readonly logger = new Logger(CheckQuotaUseCase.name);
+
+  constructor(
+    private readonly usageQuotaRepository: UsageQuotaRepositoryPort,
+    private readonly limitResolver: QuotaLimitResolverService,
+  ) {}
+
+  async execute(query: CheckQuotaQuery): Promise<void> {
+    const { limit, windowMs } = this.limitResolver.resolve(
+      query.userId,
+      query.quotaType,
+    );
+
+    this.logger.debug('Checking quota', {
+      userId: query.userId,
+      quotaType: query.quotaType,
+      limit,
+    });
+
+    const quota = await this.usageQuotaRepository.incrementAndGet(
+      query.userId,
+      query.quotaType,
+      windowMs,
+    );
+
+    if (quota.count > limit) {
+      const retryAfterSeconds = Math.ceil(quota.getRemainingTime() / 1000);
+
+      this.logger.warn('Quota exceeded', {
+        userId: query.userId,
+        quotaType: query.quotaType,
+        count: quota.count,
+        limit,
+        retryAfterSeconds,
+      });
+
+      throw new QuotaExceededError(query.quotaType, limit, retryAfterSeconds, {
+        currentCount: quota.count,
+      });
+    }
+
+    this.logger.debug('Quota check passed', {
+      userId: query.userId,
+      quotaType: query.quotaType,
+      count: quota.count,
+      limit,
+      remaining: limit - quota.count,
+    });
+  }
+}

--- a/ayunis-core-backend/src/iam/quotas/domain/quota-type.enum.ts
+++ b/ayunis-core-backend/src/iam/quotas/domain/quota-type.enum.ts
@@ -1,0 +1,3 @@
+export enum QuotaType {
+  FAIR_USE_MESSAGES = 'FAIR_USE_MESSAGES',
+}

--- a/ayunis-core-backend/src/iam/quotas/domain/usage-quota.entity.ts
+++ b/ayunis-core-backend/src/iam/quotas/domain/usage-quota.entity.ts
@@ -1,0 +1,60 @@
+import { randomUUID, UUID } from 'crypto';
+import { QuotaType } from './quota-type.enum';
+
+export interface UsageQuotaParams {
+  id?: UUID;
+  userId: UUID;
+  quotaType: QuotaType;
+  count?: number;
+  windowStartAt?: Date;
+  windowDurationMs: number;
+  createdAt?: Date;
+  updatedAt?: Date;
+}
+
+export class UsageQuota {
+  public readonly id: UUID;
+  public readonly userId: UUID;
+  public readonly quotaType: QuotaType;
+  public count: number;
+  public windowStartAt: Date;
+  public readonly windowDurationMs: number;
+  public readonly createdAt: Date;
+  public updatedAt: Date;
+
+  constructor(params: UsageQuotaParams) {
+    this.id = params.id ?? randomUUID();
+    this.userId = params.userId;
+    this.quotaType = params.quotaType;
+    this.count = params.count ?? 0;
+    this.windowStartAt = params.windowStartAt ?? new Date();
+    this.windowDurationMs = params.windowDurationMs;
+    this.createdAt = params.createdAt ?? new Date();
+    this.updatedAt = params.updatedAt ?? new Date();
+  }
+
+  isWindowExpired(): boolean {
+    const windowEndAt = new Date(
+      this.windowStartAt.getTime() + this.windowDurationMs,
+    );
+    return new Date() > windowEndAt;
+  }
+
+  resetWindow(): void {
+    this.windowStartAt = new Date();
+    this.count = 0;
+    this.updatedAt = new Date();
+  }
+
+  increment(): void {
+    this.count++;
+    this.updatedAt = new Date();
+  }
+
+  getRemainingTime(): number {
+    const windowEndAt = new Date(
+      this.windowStartAt.getTime() + this.windowDurationMs,
+    );
+    return Math.max(0, windowEndAt.getTime() - Date.now());
+  }
+}

--- a/ayunis-core-backend/src/iam/quotas/infrastructure/persistence/postgres/mappers/usage-quota.mapper.ts
+++ b/ayunis-core-backend/src/iam/quotas/infrastructure/persistence/postgres/mappers/usage-quota.mapper.ts
@@ -1,0 +1,30 @@
+import { UsageQuota } from '../../../../domain/usage-quota.entity';
+import { UsageQuotaRecord } from '../schema/usage-quota.record';
+
+export class UsageQuotaMapper {
+  static toDomain(record: UsageQuotaRecord): UsageQuota {
+    return new UsageQuota({
+      id: record.id,
+      userId: record.userId,
+      quotaType: record.quotaType,
+      count: record.count,
+      windowStartAt: record.windowStartAt,
+      windowDurationMs: Number(record.windowDurationMs),
+      createdAt: record.createdAt,
+      updatedAt: record.updatedAt,
+    });
+  }
+
+  static toRecord(entity: UsageQuota): UsageQuotaRecord {
+    const record = new UsageQuotaRecord();
+    record.id = entity.id;
+    record.userId = entity.userId;
+    record.quotaType = entity.quotaType;
+    record.count = entity.count;
+    record.windowStartAt = entity.windowStartAt;
+    record.windowDurationMs = String(entity.windowDurationMs);
+    record.createdAt = entity.createdAt;
+    record.updatedAt = entity.updatedAt;
+    return record;
+  }
+}

--- a/ayunis-core-backend/src/iam/quotas/infrastructure/persistence/postgres/schema/usage-quota.record.ts
+++ b/ayunis-core-backend/src/iam/quotas/infrastructure/persistence/postgres/schema/usage-quota.record.ts
@@ -1,0 +1,28 @@
+import { Entity, Column, Index, ManyToOne, Unique } from 'typeorm';
+import { BaseRecord } from '../../../../../../common/db/base-record';
+import { UserRecord } from '../../../../../users/infrastructure/repositories/local/schema/user.record';
+import { QuotaType } from '../../../../domain/quota-type.enum';
+import { UUID } from 'crypto';
+
+@Entity('usage_quotas')
+@Index(['userId', 'quotaType'])
+@Unique(['userId', 'quotaType'])
+export class UsageQuotaRecord extends BaseRecord {
+  @Column('uuid')
+  userId: UUID;
+
+  @ManyToOne(() => UserRecord, { onDelete: 'CASCADE' })
+  user: UserRecord;
+
+  @Column({ type: 'enum', enum: QuotaType })
+  quotaType: QuotaType;
+
+  @Column('integer', { default: 0 })
+  count: number;
+
+  @Column('timestamp')
+  windowStartAt: Date;
+
+  @Column('bigint')
+  windowDurationMs: string;
+}

--- a/ayunis-core-backend/src/iam/quotas/infrastructure/persistence/postgres/usage-quota.repository.ts
+++ b/ayunis-core-backend/src/iam/quotas/infrastructure/persistence/postgres/usage-quota.repository.ts
@@ -1,0 +1,74 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, DataSource } from 'typeorm';
+import { UUID } from 'crypto';
+import { UsageQuotaRepositoryPort } from '../../../application/ports/usage-quota.repository.port';
+import { UsageQuota } from '../../../domain/usage-quota.entity';
+import { QuotaType } from '../../../domain/quota-type.enum';
+import { UsageQuotaRecord } from './schema/usage-quota.record';
+import { UsageQuotaMapper } from './mappers/usage-quota.mapper';
+
+@Injectable()
+export class UsageQuotaRepository extends UsageQuotaRepositoryPort {
+  constructor(
+    @InjectRepository(UsageQuotaRecord)
+    private readonly repository: Repository<UsageQuotaRecord>,
+    private readonly dataSource: DataSource,
+  ) {
+    super();
+  }
+
+  async incrementAndGet(
+    userId: UUID,
+    quotaType: QuotaType,
+    windowDurationMs: number,
+  ): Promise<UsageQuota> {
+    return await this.dataSource.transaction(async (manager) => {
+      const repo = manager.getRepository(UsageQuotaRecord);
+
+      // Use SELECT FOR UPDATE to lock the row
+      let record = await repo
+        .createQueryBuilder('quota')
+        .setLock('pessimistic_write')
+        .where('quota.userId = :userId', { userId })
+        .andWhere('quota.quotaType = :quotaType', { quotaType })
+        .getOne();
+
+      const now = new Date();
+
+      if (!record) {
+        // Create new quota record
+        const newQuota = new UsageQuota({
+          userId,
+          quotaType,
+          count: 1,
+          windowStartAt: now,
+          windowDurationMs,
+        });
+        record = UsageQuotaMapper.toRecord(newQuota);
+        await repo.save(record);
+        return newQuota;
+      }
+
+      // Check if window has expired
+      const windowEndAt = new Date(
+        record.windowStartAt.getTime() + Number(record.windowDurationMs),
+      );
+
+      if (now > windowEndAt) {
+        // Reset window
+        record.windowStartAt = now;
+        record.count = 1;
+        record.windowDurationMs = String(windowDurationMs);
+      } else {
+        // Increment counter
+        record.count++;
+      }
+
+      record.updatedAt = now;
+      await repo.save(record);
+
+      return UsageQuotaMapper.toDomain(record);
+    });
+  }
+}

--- a/ayunis-core-backend/src/iam/quotas/quotas.module.ts
+++ b/ayunis-core-backend/src/iam/quotas/quotas.module.ts
@@ -1,0 +1,21 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { UsageQuotaRecord } from './infrastructure/persistence/postgres/schema/usage-quota.record';
+import { UsageQuotaRepositoryPort } from './application/ports/usage-quota.repository.port';
+import { UsageQuotaRepository } from './infrastructure/persistence/postgres/usage-quota.repository';
+import { QuotaLimitResolverService } from './application/services/quota-limit-resolver.service';
+import { CheckQuotaUseCase } from './application/use-cases/check-quota/check-quota.use-case';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([UsageQuotaRecord])],
+  providers: [
+    {
+      provide: UsageQuotaRepositoryPort,
+      useClass: UsageQuotaRepository,
+    },
+    QuotaLimitResolverService,
+    CheckQuotaUseCase,
+  ],
+  exports: [CheckQuotaUseCase],
+})
+export class QuotasModule {}

--- a/ayunis-core-frontend/src/pages/chat/api/useMessageSend.ts
+++ b/ayunis-core-frontend/src/pages/chat/api/useMessageSend.ts
@@ -196,7 +196,18 @@ export function useMessageSend(params: UseMessageSendParams) {
           }
 
           // Handle specific error status codes
-          if (error.message.includes('403')) {
+          if (error.message.includes('429')) {
+            // Try to extract retry time from error response
+            const retryMatch = error.message.match(/retryAfterSeconds[":]+(\d+)/);
+            const retryMinutes = retryMatch
+              ? Math.ceil(parseInt(retryMatch[1], 10) / 60)
+              : null;
+            showError(
+              retryMinutes
+                ? t('chat.errorQuotaExceededWithTime', { minutes: retryMinutes })
+                : t('chat.errorQuotaExceeded'),
+            );
+          } else if (error.message.includes('403')) {
             showError(t('chat.upgradeToProError'));
           } else {
             params.onError?.(error);

--- a/ayunis-core-frontend/src/pages/chat/api/useMessageSend.ts
+++ b/ayunis-core-frontend/src/pages/chat/api/useMessageSend.ts
@@ -198,13 +198,17 @@ export function useMessageSend(params: UseMessageSendParams) {
           // Handle specific error status codes
           if (error.message.includes('429')) {
             // Try to extract retry time from error response
-            const retryMatch = error.message.match(/retryAfterSeconds[":]+(\d+)/);
+            const retryMatch = error.message.match(
+              /retryAfterSeconds[":]+(\d+)/,
+            );
             const retryMinutes = retryMatch
               ? Math.ceil(parseInt(retryMatch[1], 10) / 60)
               : null;
             showError(
               retryMinutes
-                ? t('chat.errorQuotaExceededWithTime', { minutes: retryMinutes })
+                ? t('chat.errorQuotaExceededWithTime', {
+                    minutes: retryMinutes,
+                  })
                 : t('chat.errorQuotaExceeded'),
             );
           } else if (error.message.includes('403')) {

--- a/ayunis-core-frontend/src/pages/chat/ui/ChatPage.tsx
+++ b/ayunis-core-frontend/src/pages/chat/ui/ChatPage.tsx
@@ -167,6 +167,17 @@ export default function ChatPage({
         case 'RUN_TOOL_NOT_FOUND':
           showError(t('chat.errorToolNotFound'));
           break;
+        case 'QUOTA_EXCEEDED': {
+          const retryMinutes = error.details?.retryAfterSeconds
+            ? Math.ceil(Number(error.details.retryAfterSeconds) / 60)
+            : null;
+          showError(
+            retryMinutes
+              ? t('chat.errorQuotaExceededWithTime', { minutes: retryMinutes })
+              : t('chat.errorQuotaExceeded'),
+          );
+          break;
+        }
         default:
           showError(t('chat.errorUnexpected'));
       }

--- a/ayunis-core-frontend/src/shared/locales/de/chat.json
+++ b/ayunis-core-frontend/src/shared/locales/de/chat.json
@@ -18,6 +18,8 @@
     "errorMaxIterationsReached": "Maximale Anzahl an Iterationen erreicht",
     "errorToolNotFound": "Tool nicht gefunden",
     "errorSendMessage": "Nachricht konnte nicht gesendet werden. Bitte aktualisieren Sie die Seite und versuchen Sie es erneut.",
+    "errorQuotaExceeded": "Sie haben das Nachrichtenlimit erreicht. Bitte versuchen Sie es später erneut.",
+    "errorQuotaExceededWithTime": "Sie haben das Nachrichtenlimit erreicht. Bitte versuchen Sie es in {{minutes}} Minuten erneut.",
     "errorDownloadSource": "Quelle konnte nicht heruntergeladen werden. Bitte versuchen Sie es erneut.",
     "errorUpdateModel": "Modell konnte nicht aktualisiert werden",
     "errorUpdateAgent": "Agent konnte nicht aktualisiert werden",

--- a/ayunis-core-frontend/src/shared/locales/en/chat.json
+++ b/ayunis-core-frontend/src/shared/locales/en/chat.json
@@ -18,6 +18,8 @@
     "errorMaxIterationsReached": "Maximal number of iterations reached",
     "errorToolNotFound": "Tool not found",
     "errorSendMessage": "Message could not be sent. Please refresh the page and try again.",
+    "errorQuotaExceeded": "You have reached the message limit. Please try again later.",
+    "errorQuotaExceededWithTime": "You have reached the message limit. Please try again in {{minutes}} minutes.",
     "errorDownloadSource": "Failed to download source. Please try again.",
     "errorUpdateModel": "Model could not be updated",
     "errorUpdateAgent": "Agent could not be updated",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Implements fair-use enforcement and user-facing error handling.
> 
> - Backend: New quotas domain (entity, enum), repository with atomic `checkAndIncrement`, error types (`QuotaExceededError` 429 with metadata), limit resolver (200 msgs/3h), and migration creating `usage_quotas` table/index+FK
> - Execution flow: `ExecuteRunAndSetTitleUseCase` now requires authenticated user via `ContextService` and calls `CheckQuotaUseCase`; emits error responses including metadata (e.g., `retryAfterSeconds`)
> - Wiring: Adds `QuotasModule` to `RunsModule` and `IamModule`
> - Frontend: `useMessageSend` and `ChatPage` handle HTTP 429 and `QUOTA_EXCEEDED` codes, extracting `retryAfterSeconds` to display localized messages; updates i18n (en/de)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ba8ef79623d5782e9415d1d80e118be909708bd9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->