### PR TITLE
feat: adjust system prompt & add file get tool

### DIFF
--- a/ayunis-core-backend/src/app/app.module.ts
+++ b/ayunis-core-backend/src/app/app.module.ts
@@ -41,6 +41,7 @@ import { ServeStaticModule } from '@nestjs/serve-static';
 import { join } from 'path';
 import internetSearchConfig from 'src/config/internet-search.config';
 import { mcpConfig } from '../config/mcp.config';
+import toolsConfig from '../config/tools.config';
 import { IsCloudUseCase } from './application/use-cases/is-cloud/is-cloud.use-case';
 import { IsRegistrationDisabledUseCase } from './application/use-cases/is-registration-disabled/is-registration-disabled.use-case';
 import { ClsModule } from 'nestjs-cls';
@@ -67,6 +68,7 @@ import { SentryModule } from '@sentry/nestjs/setup';
         emailsConfig,
         internetSearchConfig,
         mcpConfig,
+        toolsConfig,
       ],
     }),
     ClsModule.forRoot({

--- a/ayunis-core-backend/src/config/tools.config.ts
+++ b/ayunis-core-backend/src/config/tools.config.ts
@@ -1,0 +1,18 @@
+import { registerAs } from '@nestjs/config';
+
+export interface ToolsConfig {
+  sourceGetText: {
+    maxLines: number;
+    maxChars: number;
+  };
+}
+
+export default registerAs(
+  'tools',
+  (): ToolsConfig => ({
+    sourceGetText: {
+      maxLines: parseInt(process.env.SOURCE_GET_TEXT_MAX_LINES || '200', 10),
+      maxChars: parseInt(process.env.SOURCE_GET_TEXT_MAX_CHARS || '5000', 10),
+    },
+  }),
+);

--- a/ayunis-core-backend/src/config/tools.config.ts
+++ b/ayunis-core-backend/src/config/tools.config.ts
@@ -7,12 +7,23 @@ export interface ToolsConfig {
   };
 }
 
+const parseIntWithDefault = (
+  value: string | undefined,
+  defaultValue: number,
+): number => {
+  const parsed = parseInt(value || String(defaultValue), 10);
+  return Number.isNaN(parsed) ? defaultValue : parsed;
+};
+
 export default registerAs(
   'tools',
   (): ToolsConfig => ({
     sourceGetText: {
-      maxLines: parseInt(process.env.SOURCE_GET_TEXT_MAX_LINES || '200', 10),
-      maxChars: parseInt(process.env.SOURCE_GET_TEXT_MAX_CHARS || '5000', 10),
+      maxLines: parseIntWithDefault(process.env.SOURCE_GET_TEXT_MAX_LINES, 200),
+      maxChars: parseIntWithDefault(
+        process.env.SOURCE_GET_TEXT_MAX_CHARS,
+        5000,
+      ),
     },
   }),
 );

--- a/ayunis-core-backend/src/domain/rag/splitters/infrastructure/handlers/recursive.splitter.spec.ts
+++ b/ayunis-core-backend/src/domain/rag/splitters/infrastructure/handlers/recursive.splitter.spec.ts
@@ -1,0 +1,288 @@
+import { RecursiveSplitterHandler } from './recursive.splitter';
+import { SplitterInput } from '../../application/ports/splitter.handler';
+
+describe('RecursiveSplitterHandler', () => {
+  let handler: RecursiveSplitterHandler;
+
+  beforeEach(() => {
+    handler = new RecursiveSplitterHandler();
+  });
+
+  it('should be defined', () => {
+    expect(handler).toBeDefined();
+  });
+
+  it('should always be available', () => {
+    expect(handler.isAvailable()).toBe(true);
+  });
+
+  describe('line number tracking', () => {
+    it('should add line numbers to a single chunk (text smaller than chunk size)', () => {
+      const input: SplitterInput = {
+        text: 'Line 1\nLine 2\nLine 3',
+        metadata: { chunkSize: 1000, chunkOverlap: 100 },
+      };
+
+      const result = handler.processText(input);
+
+      expect(result.chunks).toHaveLength(1);
+      expect(result.chunks[0].metadata).toMatchObject({
+        index: 0,
+        startLine: 1,
+        endLine: 3,
+        startCharOffset: 0,
+        endCharOffset: 20,
+      });
+    });
+
+    it('should calculate correct line numbers for multi-chunk text', () => {
+      // Create text that will be split into multiple chunks
+      const lines = [
+        'Line 1: First line of content',
+        'Line 2: Second line of content',
+        'Line 3: Third line of content',
+        'Line 4: Fourth line of content',
+        'Line 5: Fifth line of content',
+        'Line 6: Sixth line of content',
+        'Line 7: Seventh line of content',
+        'Line 8: Eighth line of content',
+      ];
+      const text = lines.join('\n');
+
+      const input: SplitterInput = {
+        text,
+        metadata: { chunkSize: 100, chunkOverlap: 20 },
+      };
+
+      const result = handler.processText(input);
+
+      // Should have multiple chunks
+      expect(result.chunks.length).toBeGreaterThan(1);
+
+      // First chunk should start at line 1
+      expect(result.chunks[0].metadata.startLine).toBe(1);
+
+      // Each chunk should have valid line numbers
+      result.chunks.forEach((chunk) => {
+        expect(chunk.metadata.startLine).toBeGreaterThanOrEqual(1);
+        expect(chunk.metadata.endLine).toBeGreaterThanOrEqual(
+          chunk.metadata.startLine as number,
+        );
+        expect(chunk.metadata.startCharOffset).toBeDefined();
+        expect(chunk.metadata.endCharOffset).toBeDefined();
+      });
+
+      // Last chunk should end at or near the last line
+      const lastChunk = result.chunks[result.chunks.length - 1];
+      expect(lastChunk.metadata.endLine).toBe(lines.length);
+    });
+
+    it('should handle single line text', () => {
+      const input: SplitterInput = {
+        text: 'This is a single line without any newlines',
+        metadata: { chunkSize: 1000, chunkOverlap: 100 },
+      };
+
+      const result = handler.processText(input);
+
+      expect(result.chunks).toHaveLength(1);
+      expect(result.chunks[0].metadata.startLine).toBe(1);
+      expect(result.chunks[0].metadata.endLine).toBe(1);
+    });
+
+    it('should handle text with consecutive newlines (empty lines)', () => {
+      const input: SplitterInput = {
+        text: 'Line 1\n\nLine 3\n\n\nLine 6',
+        metadata: { chunkSize: 1000, chunkOverlap: 100 },
+      };
+
+      const result = handler.processText(input);
+
+      expect(result.chunks).toHaveLength(1);
+      expect(result.chunks[0].metadata.startLine).toBe(1);
+      expect(result.chunks[0].metadata.endLine).toBe(6);
+    });
+
+    it('should handle empty text', () => {
+      const input: SplitterInput = {
+        text: '',
+        metadata: { chunkSize: 100, chunkOverlap: 20 },
+      };
+
+      const result = handler.processText(input);
+
+      expect(result.chunks).toHaveLength(0);
+    });
+
+    it('should handle whitespace-only text', () => {
+      const input: SplitterInput = {
+        text: '   \n   \n   ',
+        metadata: { chunkSize: 1000, chunkOverlap: 100 },
+      };
+
+      const result = handler.processText(input);
+
+      // Whitespace-only chunks are trimmed and filtered out
+      expect(result.chunks).toHaveLength(0);
+    });
+
+    it('should preserve chunk index in metadata', () => {
+      const lines = Array.from(
+        { length: 20 },
+        (_, i) => `Line ${i + 1}: Some content here`,
+      );
+      const text = lines.join('\n');
+
+      const input: SplitterInput = {
+        text,
+        metadata: { chunkSize: 100, chunkOverlap: 20 },
+      };
+
+      const result = handler.processText(input);
+
+      // Verify each chunk has sequential index
+      result.chunks.forEach((chunk, i) => {
+        expect(chunk.metadata.index).toBe(i);
+      });
+    });
+
+    it('should calculate character offsets correctly', () => {
+      const input: SplitterInput = {
+        text: 'AAAA\nBBBB\nCCCC',
+        metadata: { chunkSize: 1000, chunkOverlap: 100 },
+      };
+
+      const result = handler.processText(input);
+
+      expect(result.chunks).toHaveLength(1);
+      expect(result.chunks[0].metadata.startCharOffset).toBe(0);
+      expect(result.chunks[0].metadata.endCharOffset).toBe(14); // Length of "AAAA\nBBBB\nCCCC"
+    });
+
+    it('should handle text ending with newline', () => {
+      const input: SplitterInput = {
+        text: 'Line 1\nLine 2\n',
+        metadata: { chunkSize: 1000, chunkOverlap: 100 },
+      };
+
+      const result = handler.processText(input);
+
+      expect(result.chunks).toHaveLength(1);
+      // The chunk includes the trailing newline but ends at the newline character
+      // which is still considered part of line 2
+      expect(result.chunks[0].metadata.startLine).toBe(1);
+      expect(result.chunks[0].metadata.endLine).toBe(2);
+    });
+
+    it('should handle overlapping chunks with correct line numbers', () => {
+      // Create content that will definitely overlap
+      const paragraph1 = 'First paragraph with enough content to fill a chunk.';
+      const paragraph2 =
+        'Second paragraph with additional content for overlap testing.';
+      const paragraph3 =
+        'Third paragraph to ensure multiple chunks are created.';
+      const text = `${paragraph1}\n\n${paragraph2}\n\n${paragraph3}`;
+
+      const input: SplitterInput = {
+        text,
+        metadata: { chunkSize: 80, chunkOverlap: 20 },
+      };
+
+      const result = handler.processText(input);
+
+      // With overlap, chunks may share content but line numbers should still be accurate
+      expect(result.chunks.length).toBeGreaterThan(1);
+
+      // Each chunk's start should be at or after the previous chunk's start
+      for (let i = 1; i < result.chunks.length; i++) {
+        const prevStart = result.chunks[i - 1].metadata
+          .startCharOffset as number;
+        const currStart = result.chunks[i].metadata.startCharOffset as number;
+        expect(currStart).toBeGreaterThan(prevStart);
+      }
+    });
+
+    it('should find line numbers even when overlap creates non-contiguous chunks', () => {
+      // This tests the scenario where overlap text + content creates a string
+      // that doesn't exist contiguously in the original
+      const lines = [
+        'Line 1: AAAAAAAAAA BBBBBBBBBB CCCCCCCCCC',
+        'Line 2: DDDDDDDDDD EEEEEEEEEE FFFFFFFFFF',
+        'Line 3: GGGGGGGGGG HHHHHHHHHH IIIIIIIIII',
+        'Line 4: JJJJJJJJJJ KKKKKKKKKK LLLLLLLLLL',
+      ];
+      const text = lines.join('\n');
+
+      const input: SplitterInput = {
+        text,
+        // Small chunk size to force multiple chunks with overlap
+        metadata: { chunkSize: 50, chunkOverlap: 15 },
+      };
+
+      const result = handler.processText(input);
+
+      // All chunks should have line numbers (not null)
+      for (const chunk of result.chunks) {
+        expect(chunk.metadata.startLine).toBeDefined();
+        expect(chunk.metadata.startLine).not.toBeNull();
+        expect(chunk.metadata.endLine).toBeDefined();
+        expect(chunk.metadata.endLine).not.toBeNull();
+        expect(chunk.metadata.startLine).toBeGreaterThanOrEqual(1);
+        expect(chunk.metadata.endLine).toBeLessThanOrEqual(lines.length);
+      }
+    });
+  });
+
+  describe('processText metadata', () => {
+    it('should include provider name in result metadata', () => {
+      const input: SplitterInput = {
+        text: 'Test content',
+        metadata: { chunkSize: 100, chunkOverlap: 20 },
+      };
+
+      const result = handler.processText(input);
+
+      expect(result.metadata.provider).toBe('recursive');
+    });
+
+    it('should include chunk configuration in result metadata', () => {
+      const input: SplitterInput = {
+        text: 'Test content',
+        metadata: { chunkSize: 150, chunkOverlap: 30 },
+      };
+
+      const result = handler.processText(input);
+
+      expect(result.metadata.chunkSize).toBe(150);
+      expect(result.metadata.chunkOverlap).toBe(30);
+    });
+
+    it('should use default chunk size when not provided', () => {
+      const input: SplitterInput = {
+        text: 'Test content',
+      };
+
+      const result = handler.processText(input);
+
+      expect(result.metadata.chunkSize).toBe(1000); // Default chunk size
+      expect(result.metadata.chunkOverlap).toBe(200); // Default overlap
+    });
+
+    it('should report correct total chunks count', () => {
+      const lines = Array.from(
+        { length: 50 },
+        (_, i) => `Line ${i + 1}: Content`,
+      );
+      const text = lines.join('\n');
+
+      const input: SplitterInput = {
+        text,
+        metadata: { chunkSize: 100, chunkOverlap: 20 },
+      };
+
+      const result = handler.processText(input);
+
+      expect(result.metadata.totalChunks).toBe(result.chunks.length);
+    });
+  });
+});

--- a/ayunis-core-backend/src/domain/rag/splitters/infrastructure/handlers/recursive.splitter.ts
+++ b/ayunis-core-backend/src/domain/rag/splitters/infrastructure/handlers/recursive.splitter.ts
@@ -353,10 +353,13 @@ export class RecursiveSplitterHandler extends SplitterHandler {
       const middleOffset = originalText.indexOf(middlePortion, searchStart);
 
       if (middleOffset !== -1) {
-        // Found middle portion - adjust offsets
+        // Found middle portion - adjust offsets with bounds checking
         return {
-          startCharOffset: middleOffset - middleStart,
-          endCharOffset: middleOffset - middleStart + chunkText.length,
+          startCharOffset: Math.max(0, middleOffset - middleStart),
+          endCharOffset: Math.min(
+            originalText.length,
+            middleOffset - middleStart + chunkText.length,
+          ),
         };
       }
 

--- a/ayunis-core-backend/src/domain/runs/application/services/system-prompt-builder.service.ts
+++ b/ayunis-core-backend/src/domain/runs/application/services/system-prompt-builder.service.ts
@@ -1,0 +1,180 @@
+import { Injectable } from '@nestjs/common';
+import { Tool } from 'src/domain/tools/domain/tool.entity';
+import { Agent } from 'src/domain/agents/domain/agent.entity';
+
+export interface SystemPromptBuildParams {
+  agent?: Agent;
+  tools: Tool[];
+  currentTime: Date;
+}
+
+@Injectable()
+export class SystemPromptBuilderService {
+  build(params: SystemPromptBuildParams): string {
+    const { agent, tools, currentTime } = params;
+
+    const toolSpecificSections = this.buildToolSpecificSections(tools);
+
+    const prompt = `You are an AI assistant powered by Ayunis Core, an open-source AI gateway platform designed for public administrations.
+
+<application_details>
+Ayunis Core is an AI platform that enables intelligent conversations with customizable AI agents, advanced prompt management, and extensible tool integration. It is built for public sector organizations that need sovereign AI solutions with full control over data, models, and integrations.
+
+You are running as an agent within Ayunis Core. Users have configured you with specific instructions, assigned tools, and optionally connected data sources. Your capabilities depend on what has been enabled for this agent.
+</application_details>
+
+<context>
+Current time: ${currentTime.toISOString()}
+</context>
+
+<behavior_instructions>
+
+<core_principles>
+You are a helpful assistant focused on serving users in public administration contexts. Your responses should be:
+
+- **Accurate and factual** — Public administration work requires precision
+- **Professional** — You may be used in official contexts
+- **Respectful of data privacy** — Public sector data is sensitive
+- **Clear and accessible** — Your users may have varying technical backgrounds
+</core_principles>
+
+<tone_and_formatting>
+Keep responses natural and conversational unless the context calls for formal documentation.
+
+Avoid over-formatting. Use lists, headers, and bullet points only when they genuinely improve clarity — not as a default structure. In casual conversation, respond in sentences and paragraphs.
+
+If creating documents or reports, match the formality expected in public administration contexts. German users may expect formal language ("Sie" form).
+
+Do not use emojis unless the user does so first or explicitly requests them.
+</tone_and_formatting>
+
+<language_handling>
+Ayunis Core supports German and English. Respond in the language the user writes in unless they request otherwise.
+
+For German responses:
+
+- Use formal address ("Sie") by default in professional contexts
+- Use correct German punctuation and formatting conventions
+- Be aware of German administrative terminology where relevant
+</language_handling>
+
+<knowledge_boundaries>
+Be honest about what you know and don't know. If asked about information that requires current data you don't have access to, say so clearly.
+
+When tools are available (such as source queries or web access), use them to provide accurate, up-to-date information rather than relying on training data alone.
+</knowledge_boundaries>
+
+</behavior_instructions>
+
+<tool_usage>
+
+<available_tools>
+Your capabilities depend on which tools have been assigned to this agent. Use tools when they help answer the user's question or complete their task. Don't use tools unnecessarily.
+</available_tools>
+
+<tool_guidelines>
+When using tools:
+
+1. **Explain what you're doing** — Let the user know when you're querying data, making requests, or executing code
+2. **Handle errors gracefully** — If a tool fails, explain what happened and suggest alternatives
+3. **Respect rate limits and resources** — Don't make excessive requests
+4. **Verify before actions** — For consequential actions (sending emails, creating events), confirm with the user first
+</tool_guidelines>
+
+${toolSpecificSections}
+
+</tool_usage>
+
+<data_handling>
+
+<privacy_principles>
+Public administration data is sensitive. When handling user data or documents:
+
+- Do not share or reference data from one user's conversation in another's
+- Be cautious about what information you include in tool calls to external services
+- If asked to process personal data, ensure you understand the purpose and have appropriate context
+</privacy_principles>
+
+<document_processing>
+When working with uploaded documents:
+
+- Analyze content faithfully without adding information that isn't there
+- Preserve the structure and meaning when summarizing
+- Note if documents appear incomplete or corrupted
+- Do not fabricate content to fill gaps
+</document_processing>
+
+</data_handling>
+
+<multi_tenant_context>
+Ayunis Core is multi-tenant. You operate within the context of a specific organization. Your knowledge of other organizations, users, or data outside your current context is intentionally limited.
+
+If users ask about platform-wide information you don't have access to, explain that your context is scoped to their organization.
+</multi_tenant_context>
+
+<response_guidelines>
+
+<clarity>
+Structure responses for clarity:
+
+- Lead with the most important information
+- Use formatting to aid comprehension when dealing with complex information
+- Keep responses appropriately sized — comprehensive for complex questions, concise for simple ones
+</clarity>
+
+<citations>
+When your response draws on specific sources (uploaded documents, web pages, tool results):
+
+- Reference where information came from
+- If citing documents, mention the document name or relevant section
+- This helps users verify information and understand your sources
+</citations>
+
+<uncertainty>
+Express appropriate uncertainty:
+
+- If you're not sure about something, say so
+- Distinguish between information from sources vs. general knowledge
+- Don't present speculation as fact
+</uncertainty>
+
+</response_guidelines>
+
+<platform_information>
+If users ask about Ayunis Core itself:
+
+Ayunis Core is an open-source AI gateway platform. Key features include:
+
+- Multi-LLM support (various AI model providers)
+- Customizable agents with specific instructions and tools
+- Document processing and semantic search (RAG)
+- Tool integrations for external services
+- Multi-tenant organization management
+
+For technical questions about the platform, configuration, or deployment, users should consult the platform administrator or documentation.
+</platform_information>
+
+${agent?.instructions ? this.buildAgentInstructionsSection(agent.instructions) : ''}
+
+You are now ready to assist the user.`;
+
+    return prompt.trim();
+  }
+
+  private buildToolSpecificSections(tools: Tool[]): string {
+    const toolSections = tools
+      .filter((tool) => tool.descriptionLong)
+      .map((tool) => tool.descriptionLong)
+      .join('\n\n');
+
+    return toolSections;
+  }
+
+  private buildAgentInstructionsSection(instructions: string): string {
+    return `
+<agent_instructions>
+${instructions}
+</agent_instructions>
+`;
+  }
+}

--- a/ayunis-core-backend/src/domain/runs/application/services/system-prompt-builder.service.ts
+++ b/ayunis-core-backend/src/domain/runs/application/services/system-prompt-builder.service.ts
@@ -177,7 +177,7 @@ You are now ready to assist the user.`;
   private buildToolSpecificSections(tools: Tool[]): string {
     const toolSections = tools
       .filter((tool) => tool.descriptionLong)
-      .map((tool) => tool.descriptionLong)
+      .map((tool) => `<${tool.name}>\n${tool.descriptionLong}\n</${tool.name}>`)
       .join('\n\n');
 
     return toolSections;

--- a/ayunis-core-backend/src/domain/runs/application/use-cases/execute-run/execute-run.use-case.ts
+++ b/ayunis-core-backend/src/domain/runs/application/use-cases/execute-run/execute-run.use-case.ts
@@ -142,10 +142,18 @@ export class ExecuteRunUseCase {
       const tools = model.model.canUseTools
         ? await this.assembleTools(thread, agent)
         : [];
+
+      // Collect all sources from thread and agent for the system prompt
+      const allSources = [
+        ...(thread.sourceAssignments?.map((a) => a.source) ?? []),
+        ...(agent?.sourceAssignments?.map((a) => a.source) ?? []),
+      ];
+
       const instructions = this.systemPromptBuilderService.build({
         agent,
         tools,
         currentTime: new Date(),
+        sources: allSources,
       });
 
       const trace = langfuse.trace({

--- a/ayunis-core-backend/src/domain/runs/application/use-cases/execute-run/execute-run.use-case.ts
+++ b/ayunis-core-backend/src/domain/runs/application/use-cases/execute-run/execute-run.use-case.ts
@@ -144,16 +144,21 @@ export class ExecuteRunUseCase {
         : [];
 
       // Collect all sources from thread and agent for the system prompt
+      // Filter to only TextSources since DataSources (e.g., CSV) can only be used
+      // with code_execution tool, not source_query or source_get_text
       const allSources = [
         ...(thread.sourceAssignments?.map((a) => a.source) ?? []),
         ...(agent?.sourceAssignments?.map((a) => a.source) ?? []),
       ];
+      const textSources = allSources.filter(
+        (s): s is TextSource => s instanceof TextSource,
+      );
 
       const instructions = this.systemPromptBuilderService.build({
         agent,
         tools,
         currentTime: new Date(),
-        sources: allSources,
+        sources: textSources,
       });
 
       const trace = langfuse.trace({

--- a/ayunis-core-backend/src/domain/runs/runs.module.ts
+++ b/ayunis-core-backend/src/domain/runs/runs.module.ts
@@ -7,6 +7,7 @@ import { RunsController } from './presenters/http/runs.controller';
 import { AgentsModule } from 'src/domain/agents/agents.module';
 import { ExecuteRunUseCase } from './application/use-cases/execute-run/execute-run.use-case';
 import { ExecuteRunAndSetTitleUseCase } from './application/use-cases/execute-run-and-set-title/execute-run-and-set-title.use-case';
+import { SystemPromptBuilderService } from './application/services/system-prompt-builder.service';
 import { SubscriptionsModule } from 'src/iam/subscriptions/subscriptions.module';
 import { TrialsModule } from 'src/iam/trials/trials.module';
 import { McpModule } from 'src/domain/mcp/mcp.module';
@@ -29,7 +30,11 @@ import { UsageModule } from 'src/domain/usage/usage.module';
     UsageModule,
   ],
   controllers: [RunsController],
-  providers: [ExecuteRunUseCase, ExecuteRunAndSetTitleUseCase],
+  providers: [
+    ExecuteRunUseCase,
+    ExecuteRunAndSetTitleUseCase,
+    SystemPromptBuilderService,
+  ],
   exports: [ExecuteRunUseCase, ExecuteRunAndSetTitleUseCase],
 })
 export class RunsModule {}

--- a/ayunis-core-backend/src/domain/sources/application/use-cases/create-text-source/create-text-source.use-case.ts
+++ b/ayunis-core-backend/src/domain/sources/application/use-cases/create-text-source/create-text-source.use-case.ts
@@ -160,9 +160,13 @@ export class CreateTextSourceUseCase {
 
     for (const contentBlock of contentBlocks.chunks) {
       // Create source content for each content block
+      // Merge source metadata (fileName, URL) with splitter metadata (index, line numbers)
       const chunk = new TextSourceContentChunk({
         content: contentBlock.text,
-        meta,
+        meta: {
+          ...meta,
+          ...contentBlock.metadata,
+        },
       });
 
       sourceContentChunks.push(chunk);

--- a/ayunis-core-backend/src/domain/tools/application/handlers/source-get-text-tool.handler.ts
+++ b/ayunis-core-backend/src/domain/tools/application/handlers/source-get-text-tool.handler.ts
@@ -1,0 +1,164 @@
+import { Inject, Injectable, Logger } from '@nestjs/common';
+import { ConfigType } from '@nestjs/config';
+import { SourceGetTextTool } from '../../domain/tools/source-get-text-tool.entity';
+import { UUID } from 'crypto';
+import { ToolExecutionFailedError } from '../tools.errors';
+import { GetTextSourceByIdUseCase } from 'src/domain/sources/application/use-cases/get-text-source-by-id/get-text-source-by-id.use-case';
+import { GetTextSourceByIdQuery } from 'src/domain/sources/application/use-cases/get-text-source-by-id/get-text-source-by-id.query';
+import {
+  ToolExecutionContext,
+  ToolExecutionHandler,
+} from '../ports/execution.handler';
+import { TextSource } from 'src/domain/sources/domain/sources/text-source.entity';
+import toolsConfig from 'src/config/tools.config';
+
+interface SourceGetTextResult {
+  sourceId: string;
+  sourceName: string;
+  totalLines: number;
+  requestedStartLine: number;
+  requestedEndLine: number;
+  actualStartLine: number;
+  actualEndLine: number;
+  text: string;
+}
+
+@Injectable()
+export class SourceGetTextToolHandler extends ToolExecutionHandler {
+  private readonly logger = new Logger(SourceGetTextToolHandler.name);
+
+  constructor(
+    private readonly getSourceByIdUseCase: GetTextSourceByIdUseCase,
+    @Inject(toolsConfig.KEY)
+    private readonly config: ConfigType<typeof toolsConfig>,
+  ) {
+    super();
+  }
+
+  async execute(params: {
+    tool: SourceGetTextTool;
+    input: Record<string, unknown>;
+    context: ToolExecutionContext;
+  }): Promise<string> {
+    const { tool, input } = params;
+    this.logger.log('execute', { tool: tool.name, input });
+
+    try {
+      const validatedInput = tool.validateParams(input);
+      const { sourceId, startLine = 1, endLine = -1 } = validatedInput;
+      const { maxLines, maxChars } = this.config.sourceGetText;
+
+      // Get the source
+      const source = await this.getSourceByIdUseCase.execute(
+        new GetTextSourceByIdQuery(sourceId as UUID),
+      );
+
+      if (!source) {
+        throw new ToolExecutionFailedError({
+          toolName: tool.name,
+          message: `Source with ID "${sourceId}" not found`,
+          exposeToLLM: true,
+        });
+      }
+
+      // Ensure it's a TextSource
+      if (!(source instanceof TextSource)) {
+        throw new ToolExecutionFailedError({
+          toolName: tool.name,
+          message: `Source "${source.name}" is not a text source and cannot be read with this tool`,
+          exposeToLLM: true,
+        });
+      }
+
+      const text = source.text || '';
+      const lines = text.split('\n');
+      const totalLines = lines.length;
+
+      // Handle empty text
+      if (totalLines === 0 || (totalLines === 1 && lines[0] === '')) {
+        const result: SourceGetTextResult = {
+          sourceId: source.id,
+          sourceName: source.name,
+          totalLines: 0,
+          requestedStartLine: startLine,
+          requestedEndLine: endLine,
+          actualStartLine: 0,
+          actualEndLine: 0,
+          text: '',
+        };
+        return JSON.stringify(result);
+      }
+
+      // Validate and clamp line numbers
+      const effectiveStartLine = Math.max(1, Math.min(startLine, totalLines));
+      const effectiveEndLine =
+        endLine === -1
+          ? totalLines
+          : Math.max(effectiveStartLine, Math.min(endLine, totalLines));
+
+      // Check if start > end (after clamping)
+      if (startLine > effectiveEndLine && startLine !== 1) {
+        throw new ToolExecutionFailedError({
+          toolName: tool.name,
+          message: `Invalid line range: startLine (${startLine}) is greater than the file's total lines (${totalLines}). The file has ${totalLines} lines.`,
+          exposeToLLM: true,
+        });
+      }
+
+      // Calculate requested line count
+      const requestedLineCount = effectiveEndLine - effectiveStartLine + 1;
+
+      // Check line limit
+      if (requestedLineCount > maxLines) {
+        throw new ToolExecutionFailedError({
+          toolName: tool.name,
+          message: `Requested range (${requestedLineCount} lines) exceeds maximum of ${maxLines} lines. Please use a smaller range. Suggestion: try lines ${effectiveStartLine} to ${effectiveStartLine + maxLines - 1}.`,
+          exposeToLLM: true,
+        });
+      }
+
+      // Extract the requested lines (convert to 0-indexed)
+      const extractedLines = lines.slice(
+        effectiveStartLine - 1,
+        effectiveEndLine,
+      );
+      const extractedText = extractedLines.join('\n');
+
+      // Check character limit
+      if (extractedText.length > maxChars) {
+        // Calculate approximately how many lines we can include
+        const avgLineLength = extractedText.length / requestedLineCount;
+        const suggestedLines = Math.floor(maxChars / avgLineLength);
+
+        throw new ToolExecutionFailedError({
+          toolName: tool.name,
+          message: `Requested text (${extractedText.length} characters) exceeds maximum of ${maxChars} characters. The lines in this range are lengthy. Suggestion: try reading ~${suggestedLines} lines at a time, e.g., lines ${effectiveStartLine} to ${effectiveStartLine + suggestedLines - 1}.`,
+          exposeToLLM: true,
+        });
+      }
+
+      const result: SourceGetTextResult = {
+        sourceId: source.id,
+        sourceName: source.name,
+        totalLines,
+        requestedStartLine: startLine,
+        requestedEndLine: endLine,
+        actualStartLine: effectiveStartLine,
+        actualEndLine: effectiveEndLine,
+        text: extractedText,
+      };
+
+      return JSON.stringify(result);
+    } catch (error) {
+      if (error instanceof ToolExecutionFailedError) {
+        throw error;
+      }
+      this.logger.error('execute', error);
+      throw new ToolExecutionFailedError({
+        toolName: tool.name,
+        message: error instanceof Error ? error.message : 'Unknown error',
+        exposeToLLM: false,
+      });
+    }
+  }
+}

--- a/ayunis-core-backend/src/domain/tools/application/handlers/source-query-tool.handler.spec.ts
+++ b/ayunis-core-backend/src/domain/tools/application/handlers/source-query-tool.handler.spec.ts
@@ -1,0 +1,310 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { SourceQueryToolHandler } from './source-query-tool.handler';
+import { GetTextSourceByIdUseCase } from 'src/domain/sources/application/use-cases/get-text-source-by-id/get-text-source-by-id.use-case';
+import { QueryTextSourceUseCase } from 'src/domain/sources/application/use-cases/query-text-source/query-text-source.use-case';
+import { SourceQueryTool } from '../../domain/tools/source-query-tool.entity';
+import { TextSourceContentChunk } from 'src/domain/sources/domain/source-content-chunk.entity';
+import { randomUUID } from 'crypto';
+import { ToolExecutionFailedError } from '../tools.errors';
+import { FileSource } from 'src/domain/sources/domain/sources/text-source.entity';
+import { FileType, TextType } from 'src/domain/sources/domain/source-type.enum';
+
+// Helper to create a mock tool with validation bypass
+function createMockTool(sourceId: string) {
+  return {
+    name: 'source_query',
+    validateParams: jest.fn().mockReturnValue({
+      sourceId,
+      query: 'test query',
+    }),
+  } as unknown as SourceQueryTool;
+}
+
+describe('SourceQueryToolHandler', () => {
+  let handler: SourceQueryToolHandler;
+  let mockGetSourceByIdUseCase: jest.Mocked<GetTextSourceByIdUseCase>;
+  let mockQueryTextSourceUseCase: jest.Mocked<QueryTextSourceUseCase>;
+
+  const mockSourceId = randomUUID();
+  const mockOrgId = randomUUID();
+  const mockThreadId = randomUUID();
+
+  beforeEach(async () => {
+    mockGetSourceByIdUseCase = {
+      execute: jest.fn(),
+    } as unknown as jest.Mocked<GetTextSourceByIdUseCase>;
+
+    mockQueryTextSourceUseCase = {
+      execute: jest.fn(),
+    } as unknown as jest.Mocked<QueryTextSourceUseCase>;
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        SourceQueryToolHandler,
+        {
+          provide: GetTextSourceByIdUseCase,
+          useValue: mockGetSourceByIdUseCase,
+        },
+        {
+          provide: QueryTextSourceUseCase,
+          useValue: mockQueryTextSourceUseCase,
+        },
+      ],
+    }).compile();
+
+    handler = module.get<SourceQueryToolHandler>(SourceQueryToolHandler);
+  });
+
+  it('should be defined', () => {
+    expect(handler).toBeDefined();
+  });
+
+  describe('execute with line number metadata', () => {
+    it('should include line numbers in response when metadata is present', async () => {
+      const mockSource = new FileSource({
+        id: mockSourceId,
+        name: 'test-file.pdf',
+        text: 'Test content',
+        contentChunks: [],
+        type: TextType.FILE,
+        fileType: FileType.PDF,
+      });
+
+      const mockChunks: TextSourceContentChunk[] = [
+        new TextSourceContentChunk({
+          content: 'First chunk content',
+          meta: {
+            fileName: 'test-file.pdf',
+            index: 0,
+            startLine: 1,
+            endLine: 10,
+            startCharOffset: 0,
+            endCharOffset: 100,
+          },
+        }),
+        new TextSourceContentChunk({
+          content: 'Second chunk content',
+          meta: {
+            fileName: 'test-file.pdf',
+            index: 1,
+            startLine: 8,
+            endLine: 20,
+            startCharOffset: 80,
+            endCharOffset: 200,
+          },
+        }),
+      ];
+
+      mockGetSourceByIdUseCase.execute.mockResolvedValue(mockSource);
+      mockQueryTextSourceUseCase.execute.mockResolvedValue(mockChunks);
+
+      const tool = createMockTool(mockSourceId);
+      const result = await handler.execute({
+        tool,
+        input: {
+          sourceId: mockSourceId,
+          query: 'test query',
+        },
+        context: { orgId: mockOrgId, threadId: mockThreadId },
+      });
+
+      const parsedResult = JSON.parse(result);
+
+      expect(parsedResult).toHaveLength(2);
+      expect(parsedResult[0]).toEqual({
+        content: 'First chunk content',
+        startLine: 1,
+        endLine: 10,
+        fileName: 'test-file.pdf',
+        url: null,
+      });
+      expect(parsedResult[1]).toEqual({
+        content: 'Second chunk content',
+        startLine: 8,
+        endLine: 20,
+        fileName: 'test-file.pdf',
+        url: null,
+      });
+    });
+
+    it('should include URL in response for URL sources', async () => {
+      const mockSource = new FileSource({
+        id: mockSourceId,
+        name: 'Example Website',
+        text: 'Test content',
+        contentChunks: [],
+        type: TextType.FILE,
+        fileType: FileType.PDF,
+      });
+
+      const mockChunks: TextSourceContentChunk[] = [
+        new TextSourceContentChunk({
+          content: 'Web page content',
+          meta: {
+            url: 'https://example.com/page',
+            index: 0,
+            startLine: 1,
+            endLine: 50,
+          },
+        }),
+      ];
+
+      mockGetSourceByIdUseCase.execute.mockResolvedValue(mockSource);
+      mockQueryTextSourceUseCase.execute.mockResolvedValue(mockChunks);
+
+      const tool = createMockTool(mockSourceId);
+      const result = await handler.execute({
+        tool,
+        input: {
+          sourceId: mockSourceId,
+          query: 'test query',
+        },
+        context: { orgId: mockOrgId, threadId: mockThreadId },
+      });
+
+      const parsedResult = JSON.parse(result);
+
+      expect(parsedResult[0]).toEqual({
+        content: 'Web page content',
+        startLine: 1,
+        endLine: 50,
+        fileName: null,
+        url: 'https://example.com/page',
+      });
+    });
+
+    it('should return null for line numbers when metadata is missing (graceful degradation)', async () => {
+      const mockSource = new FileSource({
+        id: mockSourceId,
+        name: 'old-file.pdf',
+        text: 'Test content',
+        contentChunks: [],
+        type: TextType.FILE,
+        fileType: FileType.PDF,
+      });
+
+      // Simulate old indexed content without line number metadata
+      const mockChunks: TextSourceContentChunk[] = [
+        new TextSourceContentChunk({
+          content: 'Legacy chunk without line numbers',
+          meta: {
+            fileName: 'old-file.pdf',
+          },
+        }),
+      ];
+
+      mockGetSourceByIdUseCase.execute.mockResolvedValue(mockSource);
+      mockQueryTextSourceUseCase.execute.mockResolvedValue(mockChunks);
+
+      const tool = createMockTool(mockSourceId);
+      const result = await handler.execute({
+        tool,
+        input: {
+          sourceId: mockSourceId,
+          query: 'test query',
+        },
+        context: { orgId: mockOrgId, threadId: mockThreadId },
+      });
+
+      const parsedResult = JSON.parse(result);
+
+      expect(parsedResult[0]).toEqual({
+        content: 'Legacy chunk without line numbers',
+        startLine: null,
+        endLine: null,
+        fileName: 'old-file.pdf',
+        url: null,
+      });
+    });
+
+    it('should return null for all metadata when chunk has empty meta', async () => {
+      const mockSource = new FileSource({
+        id: mockSourceId,
+        name: 'test.pdf',
+        text: 'Test content',
+        contentChunks: [],
+        type: TextType.FILE,
+        fileType: FileType.PDF,
+      });
+
+      const mockChunks: TextSourceContentChunk[] = [
+        new TextSourceContentChunk({
+          content: 'Chunk with empty metadata',
+          meta: {},
+        }),
+      ];
+
+      mockGetSourceByIdUseCase.execute.mockResolvedValue(mockSource);
+      mockQueryTextSourceUseCase.execute.mockResolvedValue(mockChunks);
+
+      const tool = createMockTool(mockSourceId);
+      const result = await handler.execute({
+        tool,
+        input: {
+          sourceId: mockSourceId,
+          query: 'test query',
+        },
+        context: { orgId: mockOrgId, threadId: mockThreadId },
+      });
+
+      const parsedResult = JSON.parse(result);
+
+      expect(parsedResult[0]).toEqual({
+        content: 'Chunk with empty metadata',
+        startLine: null,
+        endLine: null,
+        fileName: null,
+        url: null,
+      });
+    });
+
+    it('should return empty array when no chunks match', async () => {
+      const mockSource = new FileSource({
+        id: mockSourceId,
+        name: 'test.pdf',
+        text: 'Test content',
+        contentChunks: [],
+        type: TextType.FILE,
+        fileType: FileType.PDF,
+      });
+
+      mockGetSourceByIdUseCase.execute.mockResolvedValue(mockSource);
+      mockQueryTextSourceUseCase.execute.mockResolvedValue([]);
+
+      const tool = createMockTool(mockSourceId);
+      const result = await handler.execute({
+        tool,
+        input: {
+          sourceId: mockSourceId,
+          query: 'test query',
+        },
+        context: { orgId: mockOrgId, threadId: mockThreadId },
+      });
+
+      const parsedResult = JSON.parse(result);
+
+      expect(parsedResult).toEqual([]);
+    });
+  });
+
+  describe('error handling', () => {
+    it('should throw ToolExecutionFailedError when source is not found', async () => {
+      mockGetSourceByIdUseCase.execute.mockResolvedValue(
+        null as unknown as ReturnType<typeof mockGetSourceByIdUseCase.execute>,
+      );
+
+      const tool = createMockTool(mockSourceId);
+
+      await expect(
+        handler.execute({
+          tool,
+          input: {
+            sourceId: mockSourceId,
+            query: 'test query',
+          },
+          context: { orgId: mockOrgId, threadId: mockThreadId },
+        }),
+      ).rejects.toThrow(ToolExecutionFailedError);
+    });
+  });
+});

--- a/ayunis-core-backend/src/domain/tools/application/handlers/source-query-tool.handler.ts
+++ b/ayunis-core-backend/src/domain/tools/application/handlers/source-query-tool.handler.ts
@@ -67,6 +67,10 @@ export class SourceQueryToolHandler extends ToolExecutionHandler {
       const result = matchedChunks.map((chunk) => {
         return {
           content: chunk.content,
+          startLine: (chunk.meta?.startLine as number | undefined) ?? null,
+          endLine: (chunk.meta?.endLine as number | undefined) ?? null,
+          fileName: (chunk.meta?.fileName as string | undefined) ?? null,
+          url: (chunk.meta?.url as string | undefined) ?? null,
         };
       });
 

--- a/ayunis-core-backend/src/domain/tools/application/tool-handler.registry.ts
+++ b/ayunis-core-backend/src/domain/tools/application/tool-handler.registry.ts
@@ -4,8 +4,10 @@ import { ToolExecutionHandler } from './ports/execution.handler';
 import { ToolHandlerNotFoundError } from './tools.errors';
 import { HttpToolHandler } from './handlers/http-tool.handler';
 import { SourceQueryToolHandler } from './handlers/source-query-tool.handler';
+import { SourceGetTextToolHandler } from './handlers/source-get-text-tool.handler';
 import { HttpTool } from '../domain/tools/http-tool.entity';
 import { SourceQueryTool } from '../domain/tools/source-query-tool.entity';
+import { SourceGetTextTool } from '../domain/tools/source-get-text-tool.entity';
 import { InternetSearchToolHandler } from './handlers/internet-search-tool.handler';
 import { InternetSearchTool } from '../domain/tools/internet-search-tool.entity';
 import { WebsiteContentToolHandler } from './handlers/website-content-tool.handler';
@@ -26,6 +28,7 @@ export class ToolHandlerRegistry {
   constructor(
     private readonly httpToolHandler: HttpToolHandler,
     private readonly sourceQueryToolHandler: SourceQueryToolHandler,
+    private readonly sourceGetTextToolHandler: SourceGetTextToolHandler,
     private readonly internetSearchToolHandler: InternetSearchToolHandler,
     private readonly websiteContentToolHandler: WebsiteContentToolHandler,
     private readonly codeExecutionToolHandler: CodeExecutionToolHandler,
@@ -41,6 +44,9 @@ export class ToolHandlerRegistry {
     }
     if (tool instanceof SourceQueryTool) {
       return this.sourceQueryToolHandler;
+    }
+    if (tool instanceof SourceGetTextTool) {
+      return this.sourceGetTextToolHandler;
     }
     if (tool instanceof InternetSearchTool) {
       return this.internetSearchToolHandler;

--- a/ayunis-core-backend/src/domain/tools/application/tool.factory.spec.ts
+++ b/ayunis-core-backend/src/domain/tools/application/tool.factory.spec.ts
@@ -78,6 +78,7 @@ describe('ToolFactory', () => {
 
       expect(types).toContain(ToolType.HTTP);
       expect(types).toContain(ToolType.SOURCE_QUERY);
+      expect(types).toContain(ToolType.SOURCE_GET_TEXT);
       expect(types).toContain(ToolType.INTERNET_SEARCH);
       expect(types).toContain(ToolType.WEBSITE_CONTENT);
       expect(types).toContain(ToolType.SEND_EMAIL);
@@ -91,7 +92,7 @@ describe('ToolFactory', () => {
       expect(types).toContain(ToolType.PIE_CHART);
       expect(types).toContain(ToolType.PRODUCT_KNOWLEDGE);
 
-      expect(types.length).toBe(14);
+      expect(types.length).toBe(15);
     });
   });
 });

--- a/ayunis-core-backend/src/domain/tools/application/tool.factory.ts
+++ b/ayunis-core-backend/src/domain/tools/application/tool.factory.ts
@@ -9,6 +9,7 @@ import {
 import { InternetSearchTool } from '../domain/tools/internet-search-tool.entity';
 import { WebsiteContentTool } from '../domain/tools/website-content-tool.entity';
 import { SourceQueryTool } from '../domain/tools/source-query-tool.entity';
+import { SourceGetTextTool } from '../domain/tools/source-get-text-tool.entity';
 import {
   ToolInvalidConfigError,
   ToolInvalidContextError,
@@ -53,6 +54,20 @@ export class ToolFactory {
           params.context.every((source: unknown) => source instanceof Source)
         ) {
           return new SourceQueryTool(params.context);
+        }
+        throw new ToolInvalidContextError({
+          toolType: params.type,
+          metadata: {
+            contextType: params.context?.constructor.name || 'null',
+          },
+        });
+      case ToolType.SOURCE_GET_TEXT:
+        if (
+          params.context &&
+          params.context instanceof Array &&
+          params.context.every((source: unknown) => source instanceof Source)
+        ) {
+          return new SourceGetTextTool(params.context);
         }
         throw new ToolInvalidContextError({
           toolType: params.type,

--- a/ayunis-core-backend/src/domain/tools/domain/configurable-tool.entity.ts
+++ b/ayunis-core-backend/src/domain/tools/domain/configurable-tool.entity.ts
@@ -9,10 +9,12 @@ export abstract class ConfigurableTool<T extends ToolConfig> extends Tool {
     config: T;
     parameters: JSONSchema;
     description: string;
+    descriptionLong?: string;
   }) {
     super({
       name: generateToolName(params.config),
       description: params.description,
+      descriptionLong: params.descriptionLong,
       parameters: params.parameters,
       type: params.config.type,
     });

--- a/ayunis-core-backend/src/domain/tools/domain/displayable-tool.entity.ts
+++ b/ayunis-core-backend/src/domain/tools/domain/displayable-tool.entity.ts
@@ -8,6 +8,7 @@ export abstract class DisplayableTool extends Tool {
   constructor(params: {
     name: string;
     description: string;
+    descriptionLong?: string;
     parameters: JSONSchema;
     type: ToolType;
   }) {

--- a/ayunis-core-backend/src/domain/tools/domain/tool.entity.ts
+++ b/ayunis-core-backend/src/domain/tools/domain/tool.entity.ts
@@ -4,17 +4,25 @@ import { ToolType } from './value-objects/tool-type.enum';
 export abstract class Tool {
   name: string;
   description: string;
+  /**
+   * Extended description with detailed usage instructions for the system prompt.
+   * This is NOT sent to the LLM tool schema - it's only used in the system prompt
+   * to provide guidance on when and how to use the tool.
+   */
+  descriptionLong?: string;
   parameters: JSONSchema;
   type: ToolType;
 
   constructor(params: {
     name: string;
     description: string;
+    descriptionLong?: string;
     parameters: JSONSchema;
     type: ToolType;
   }) {
     this.name = params.name;
     this.description = params.description;
+    this.descriptionLong = params.descriptionLong;
     this.parameters = params.parameters;
     this.type = params.type;
   }

--- a/ayunis-core-backend/src/domain/tools/domain/tools/bar-chart-tool.entity.ts
+++ b/ayunis-core-backend/src/domain/tools/domain/tools/bar-chart-tool.entity.ts
@@ -56,7 +56,7 @@ export class BarChartTool extends DisplayableTool {
     super({
       name: ToolType.BAR_CHART,
       description:
-        'Display a bar chart with the given data. Use this tool if the user asks for a statistical insight which is best explained with a bar chart and offer any additional textual explanation through the "insight" property. If necessary process data specifically to show the chart. If possible, offer insights alongside the chart even if the user didn\'t ask for them.',
+        'Display a bar chart. Best for comparing quantities across categories.',
       parameters: barChartToolParameters,
       type: ToolType.BAR_CHART,
     });

--- a/ayunis-core-backend/src/domain/tools/domain/tools/code-execution-tool.entity.ts
+++ b/ayunis-core-backend/src/domain/tools/domain/tools/code-execution-tool.entity.ts
@@ -40,9 +40,22 @@ export class CodeExecutionTool extends Tool {
         ? ` Available CSV data sources: ${csvSources.map((s) => `${s.name} (ID: ${s.id})`).join(', ')}. When you specify a dataSourceId, the CSV file will be available at /execution/files/{uuid}.csv - you can load it with pandas.read_csv('/execution/files/{uuid}.csv').`
         : '';
 
+    const csvLongDescription =
+      csvSources.length > 0
+        ? `\nAvailable CSV data sources:\n${csvSources.map((s) => `- ${s.name} (ID: ${s.id})`).join('\n')}\n\nWhen using dataSourceIds, CSV files are available at /execution/files/{uuid}.csv\nLoad with: pandas.read_csv('/execution/files/{uuid}.csv')`
+        : '';
+
     super({
       name: ToolType.CODE_EXECUTION,
-      description: `Execute code. IMPORTANT: Only execute code that is safe to execute. If code is provided with a malicious intent, do not execute it. The code will be executed in a sandboxed environment. To see results, print them to the console - you will see the output but the user will NOT see it directly. Variables do not persist between executions. You can write *CSV* files to /execution/output/ directory - these will automatically be saved as thread data sources and become available for future analysis.${csvDescription}. IMPORTANT: Only save CSV files to output. For now, no other file types are supported. If the user asks for anything else, write it in the chat directly without using a tool.`,
+      description: `Execute Python code in a sandboxed environment. Print results to see output. Variables don't persist between executions.${csvDescription}`,
+      descriptionLong: `
+<code_execution>
+Output visibility: You see printed output, but the user does NOT see it directly - you must relay results in your response.
+
+Output files: Write CSV files to /execution/output/ to save as thread data sources. Only CSV is supported - for other formats, include content in your response instead.
+${csvLongDescription}
+</code_execution>
+      `.trim(),
       parameters: codeExecutionToolParameters,
       type: ToolType.CODE_EXECUTION,
     });

--- a/ayunis-core-backend/src/domain/tools/domain/tools/code-execution-tool.entity.ts
+++ b/ayunis-core-backend/src/domain/tools/domain/tools/code-execution-tool.entity.ts
@@ -48,14 +48,11 @@ export class CodeExecutionTool extends Tool {
     super({
       name: ToolType.CODE_EXECUTION,
       description: `Execute Python code in a sandboxed environment. Print results to see output. Variables don't persist between executions.${csvDescription}`,
-      descriptionLong: `
-<code_execution>
-Output visibility: You see printed output, but the user does NOT see it directly - you must relay results in your response.
+      descriptionLong:
+        `Output visibility: You see printed output, but the user does NOT see it directly - you must relay results in your response.
 
 Output files: Write CSV files to /execution/output/ to save as thread data sources. Only CSV is supported - for other formats, include content in your response instead.
-${csvLongDescription}
-</code_execution>
-      `.trim(),
+${csvLongDescription}`.trim(),
       parameters: codeExecutionToolParameters,
       type: ToolType.CODE_EXECUTION,
     });

--- a/ayunis-core-backend/src/domain/tools/domain/tools/create-calendar-event-tool.entity.ts
+++ b/ayunis-core-backend/src/domain/tools/domain/tools/create-calendar-event-tool.entity.ts
@@ -40,7 +40,7 @@ export class CreateCalendarEventTool extends DisplayableTool {
     super({
       name: ToolType.CREATE_CALENDAR_EVENT,
       description:
-        'Display a widget for the user to create a calendar event and open a calendar link.',
+        'Display a calendar event creation widget. The user reviews and adds to their calendar.',
       parameters: createCalendarEventParameters,
       type: ToolType.CREATE_CALENDAR_EVENT,
     });

--- a/ayunis-core-backend/src/domain/tools/domain/tools/internet-search-tool.entity.ts
+++ b/ayunis-core-backend/src/domain/tools/domain/tools/internet-search-tool.entity.ts
@@ -21,11 +21,8 @@ export class InternetSearchTool extends Tool {
     super({
       name: ToolType.INTERNET_SEARCH,
       description: 'Search the internet for current information.',
-      descriptionLong: `
-<internet_search>
-Use for information that may have changed since your knowledge cutoff. Don't assume the current date when user asks for "latest" - search to find out.
-</internet_search>
-      `.trim(),
+      descriptionLong:
+        'Use for information that may have changed since your knowledge cutoff. Don\'t assume the current date when user asks for "latest" - search to find out.',
       parameters: internetSearchToolParameters,
       type: ToolType.INTERNET_SEARCH,
     });

--- a/ayunis-core-backend/src/domain/tools/domain/tools/internet-search-tool.entity.ts
+++ b/ayunis-core-backend/src/domain/tools/domain/tools/internet-search-tool.entity.ts
@@ -20,8 +20,12 @@ export class InternetSearchTool extends Tool {
   constructor() {
     super({
       name: ToolType.INTERNET_SEARCH,
-      description:
-        'Search the internet for up to date information. Do not assume the current date if the user asks for "latest" information.',
+      description: 'Search the internet for current information.',
+      descriptionLong: `
+<internet_search>
+Use for information that may have changed since your knowledge cutoff. Don't assume the current date when user asks for "latest" - search to find out.
+</internet_search>
+      `.trim(),
       parameters: internetSearchToolParameters,
       type: ToolType.INTERNET_SEARCH,
     });

--- a/ayunis-core-backend/src/domain/tools/domain/tools/line-chart-tool.entity.ts
+++ b/ayunis-core-backend/src/domain/tools/domain/tools/line-chart-tool.entity.ts
@@ -56,7 +56,7 @@ export class LineChartTool extends DisplayableTool {
     super({
       name: ToolType.LINE_CHART,
       description:
-        'Display a line chart with the given data. Use this tool if the user asks for a statistical insight which is best explained with a line chart and offer any additional textual explanation through the "insight" property. If necessary process data specifically to show the chart. If possible, offer insights alongside the chart even if the user didn\'t ask for them. If you are showing time series data, make sure it is ordered by date.',
+        'Display a line chart. Best for showing trends over time. Ensure time series data is ordered chronologically.',
       parameters: lineChartToolParameters,
       type: ToolType.LINE_CHART,
     });

--- a/ayunis-core-backend/src/domain/tools/domain/tools/pie-chart-tool.entity.ts
+++ b/ayunis-core-backend/src/domain/tools/domain/tools/pie-chart-tool.entity.ts
@@ -45,7 +45,7 @@ export class PieChartTool extends DisplayableTool {
     super({
       name: ToolType.PIE_CHART,
       description:
-        'Display a pie chart with the given data. Use this tool if the user asks for a statistical insight which is best explained with a pie chart and offer any additional textual explanation through the "insight" property. If necessary process data specifically to show the chart. If possible, offer insights alongside the chart even if the user didn\'t ask for them.',
+        'Display a pie chart. Best for showing proportions of a whole.',
       parameters: pieChartToolParameters,
       type: ToolType.PIE_CHART,
     });

--- a/ayunis-core-backend/src/domain/tools/domain/tools/product-knowledge-tool.entity.ts
+++ b/ayunis-core-backend/src/domain/tools/domain/tools/product-knowledge-tool.entity.ts
@@ -34,9 +34,7 @@ export class ProductKnowledgeTool extends Tool {
     super({
       name: ToolType.PRODUCT_KNOWLEDGE,
       description:
-        'Retrieve product documentation and help content about Ayunis features. ' +
-        'Use this tool to answer questions about how to use agents, tools, prompts, sources, and models. ' +
-        'Available topics: getting_started, agents, tools, prompts, sources, models.',
+        'Retrieve Ayunis documentation. Topics: getting_started, agents, tools, prompts, sources, models.',
       parameters: productKnowledgeToolParameters,
       type: ToolType.PRODUCT_KNOWLEDGE,
     });

--- a/ayunis-core-backend/src/domain/tools/domain/tools/send-email-tool.entity.ts
+++ b/ayunis-core-backend/src/domain/tools/domain/tools/send-email-tool.entity.ts
@@ -31,7 +31,7 @@ export class SendEmailTool extends DisplayableTool {
     super({
       name: ToolType.SEND_EMAIL,
       description:
-        'Display a widget for the user to send an email. The widget will be displayed in the chat interface.',
+        'Display an email composition widget. The user reviews and controls the final send action.',
       parameters: sendEmailToolParameters,
       type: ToolType.SEND_EMAIL,
     });

--- a/ayunis-core-backend/src/domain/tools/domain/tools/source-get-text-tool.entity.ts
+++ b/ayunis-core-backend/src/domain/tools/domain/tools/source-get-text-tool.entity.ts
@@ -1,0 +1,69 @@
+import { JSONSchema } from 'json-schema-to-ts';
+import Ajv from 'ajv';
+import { ToolType } from '../value-objects/tool-type.enum';
+import { Source } from 'src/domain/sources/domain/source.entity';
+import { Tool } from '../tool.entity';
+
+interface SourceGetTextToolParameters {
+  sourceId: string;
+  startLine?: number;
+  endLine?: number;
+}
+
+function sourceGetTextToolParameters(sources: Source[]): JSONSchema {
+  return {
+    type: 'object' as const,
+    properties: {
+      sourceId: {
+        type: 'string' as const,
+        description: 'The ID of the file to read',
+        enum: sources.map((source) => source.id),
+      },
+      startLine: {
+        type: 'integer' as const,
+        description: 'Starting line number (1-indexed). Defaults to 1.',
+        minimum: 1,
+        default: 1,
+      },
+      endLine: {
+        type: 'integer' as const,
+        description:
+          'Ending line number (inclusive). Use -1 to read until end of file. Defaults to -1.',
+        default: -1,
+      },
+    } as const,
+    required: ['sourceId'],
+    additionalProperties: false,
+  } as const satisfies JSONSchema;
+}
+
+export class SourceGetTextTool extends Tool {
+  constructor(sources: Source[]) {
+    super({
+      name: ToolType.SOURCE_GET_TEXT,
+      description:
+        'Read exact text content from a file by line range. Use this to read specific sections of a file.',
+      descriptionLong: `Read exact text content from a file. Unlike source_query (semantic search), this returns the raw text content.
+
+Use source_get_text when you need to read specific line ranges from a file, get exact content without semantic interpretation, or progressively read through a large file.
+
+Start with smaller ranges (50-100 lines) to avoid hitting size limits. The response includes total line count to help navigate large files.`,
+      parameters: sourceGetTextToolParameters(sources),
+      type: ToolType.SOURCE_GET_TEXT,
+    });
+  }
+
+  validateParams(params: Record<string, unknown>): SourceGetTextToolParameters {
+    const ajv = new Ajv();
+    const validate = ajv.compile(this.parameters);
+    const valid = validate(params);
+    if (!valid) {
+      throw new Error(JSON.stringify(validate.errors));
+    }
+    return params as unknown as SourceGetTextToolParameters;
+  }
+
+  get returnsPii(): boolean {
+    return true;
+  }
+}

--- a/ayunis-core-backend/src/domain/tools/domain/tools/source-get-text-tool.entity.ts
+++ b/ayunis-core-backend/src/domain/tools/domain/tools/source-get-text-tool.entity.ts
@@ -43,11 +43,7 @@ export class SourceGetTextTool extends Tool {
       name: ToolType.SOURCE_GET_TEXT,
       description:
         'Read exact text content from a file by line range. Use this to read specific sections of a file.',
-      descriptionLong: `Read exact text content from a file. Unlike source_query (semantic search), this returns the raw text content.
-
-Use source_get_text when you need to read specific line ranges from a file, get exact content without semantic interpretation, or progressively read through a large file.
-
-Start with smaller ranges (50-100 lines) to avoid hitting size limits. The response includes total line count to help navigate large files.`,
+      descriptionLong: `Read exact text content from a file by line range. Recommended workflow: First use source_query to find relevant snippets - results include startLine and endLine metadata. Then use source_get_text with those line numbers to retrieve additional context around the matched sections. Start with smaller ranges (50-100 lines) to avoid hitting size limits. The response includes total line count to help navigate large files.`,
       parameters: sourceGetTextToolParameters(sources),
       type: ToolType.SOURCE_GET_TEXT,
     });

--- a/ayunis-core-backend/src/domain/tools/domain/tools/source-query-tool.entity.ts
+++ b/ayunis-core-backend/src/domain/tools/domain/tools/source-query-tool.entity.ts
@@ -34,8 +34,7 @@ export class SourceQueryTool extends Tool {
       name: ToolType.SOURCE_QUERY,
       description:
         'Query a file through semantic search. Use the file ID to select which file to search.',
-      descriptionLong:
-        "Query files BEFORE answering questions about attached documents. If files don't contain the answer, say so rather than guessing from general knowledge.",
+      descriptionLong: `Query files BEFORE answering questions about attached documents. If files don't contain the answer, say so rather than guessing from general knowledge. Results may include startLine and endLine metadata for each matched snippet. Use these line numbers with source_get_text to retrieve additional context around relevant sections if necessary.`,
       parameters: sourceQueryToolParameters(sources),
       type: ToolType.SOURCE_QUERY,
     });

--- a/ayunis-core-backend/src/domain/tools/domain/tools/source-query-tool.entity.ts
+++ b/ayunis-core-backend/src/domain/tools/domain/tools/source-query-tool.entity.ts
@@ -37,6 +37,11 @@ export class SourceQueryTool extends Tool {
         sources
           .map((source) => `- ID: ${source.id}, Name: ${source.name}`)
           .join('\n'),
+      descriptionLong: `
+<source_query>
+Query sources BEFORE answering questions about attached documents. If sources don't contain the answer, say so rather than guessing from general knowledge.
+</source_query>
+      `.trim(),
       parameters: sourceQueryToolParameters(sources),
       type: ToolType.SOURCE_QUERY,
     });

--- a/ayunis-core-backend/src/domain/tools/domain/tools/source-query-tool.entity.ts
+++ b/ayunis-core-backend/src/domain/tools/domain/tools/source-query-tool.entity.ts
@@ -34,11 +34,8 @@ export class SourceQueryTool extends Tool {
       name: ToolType.SOURCE_QUERY,
       description:
         'Query a file through semantic search. Use the file ID to select which file to search.',
-      descriptionLong: `
-<source_query>
-Query files BEFORE answering questions about attached documents. If files don't contain the answer, say so rather than guessing from general knowledge.
-</source_query>
-      `.trim(),
+      descriptionLong:
+        "Query files BEFORE answering questions about attached documents. If files don't contain the answer, say so rather than guessing from general knowledge.",
       parameters: sourceQueryToolParameters(sources),
       type: ToolType.SOURCE_QUERY,
     });

--- a/ayunis-core-backend/src/domain/tools/domain/tools/source-query-tool.entity.ts
+++ b/ayunis-core-backend/src/domain/tools/domain/tools/source-query-tool.entity.ts
@@ -15,12 +15,12 @@ function sourceQueryToolParameters(sources: Source[]): JSONSchema {
     properties: {
       sourceId: {
         type: 'string' as const,
-        description: 'The ID of the source to query',
+        description: 'The ID of the file to search',
         enum: sources.map((source) => source.id),
       },
       query: {
         type: 'string' as const,
-        description: 'The query to execute',
+        description: 'The semantic search query to find relevant content',
       },
     } as const,
     required: ['sourceId', 'query'],
@@ -33,13 +33,10 @@ export class SourceQueryTool extends Tool {
     super({
       name: ToolType.SOURCE_QUERY,
       description:
-        'Query a source through semantic search. Use the ID to select the source. Here are the available sources: \n' +
-        sources
-          .map((source) => `- ID: ${source.id}, Name: ${source.name}`)
-          .join('\n'),
+        'Query a file through semantic search. Use the file ID to select which file to search.',
       descriptionLong: `
 <source_query>
-Query sources BEFORE answering questions about attached documents. If sources don't contain the answer, say so rather than guessing from general knowledge.
+Query files BEFORE answering questions about attached documents. If files don't contain the answer, say so rather than guessing from general knowledge.
 </source_query>
       `.trim(),
       parameters: sourceQueryToolParameters(sources),

--- a/ayunis-core-backend/src/domain/tools/domain/tools/website-content-tool.entity.ts
+++ b/ayunis-core-backend/src/domain/tools/domain/tools/website-content-tool.entity.ts
@@ -20,7 +20,7 @@ export class WebsiteContentTool extends Tool {
   constructor() {
     super({
       name: ToolType.WEBSITE_CONTENT,
-      description: 'Get the content of a website through a URL',
+      description: 'Fetch content from a specific URL.',
       parameters: websiteContentToolParameters,
       type: ToolType.WEBSITE_CONTENT,
     });

--- a/ayunis-core-backend/src/domain/tools/domain/value-objects/tool-type.enum.ts
+++ b/ayunis-core-backend/src/domain/tools/domain/value-objects/tool-type.enum.ts
@@ -2,6 +2,7 @@
 export enum ToolType {
   HTTP = 'http',
   SOURCE_QUERY = 'source_query',
+  SOURCE_GET_TEXT = 'source_get_text',
   INTERNET_SEARCH = 'internet_search',
   WEBSITE_CONTENT = 'website_content',
   SEND_EMAIL = 'send_email',

--- a/ayunis-core-backend/src/domain/tools/tools.module.ts
+++ b/ayunis-core-backend/src/domain/tools/tools.module.ts
@@ -2,6 +2,7 @@ import { forwardRef, Module } from '@nestjs/common';
 import { ToolHandlerRegistry } from './application/tool-handler.registry';
 import { HttpToolHandler } from './application/handlers/http-tool.handler';
 import { SourceQueryToolHandler } from './application/handlers/source-query-tool.handler';
+import { SourceGetTextToolHandler } from './application/handlers/source-get-text-tool.handler';
 import { ToolConfigRepository } from './application/ports/tool-config.repository';
 import { LocalToolConfigRepository } from './infrastructure/persistence/local/local-tool-config.repository';
 import { ToolFactory } from './application/tool.factory';
@@ -40,6 +41,7 @@ import { ProductKnowledgeAdapter } from './infrastructure/product-knowledge/prod
     ToolHandlerRegistry,
     HttpToolHandler,
     SourceQueryToolHandler,
+    SourceGetTextToolHandler,
     InternetSearchToolHandler,
     WebsiteContentToolHandler,
     CodeExecutionToolHandler,

--- a/ayunis-core-frontend/src/shared/locales/de/chat.json
+++ b/ayunis-core-frontend/src/shared/locales/de/chat.json
@@ -27,7 +27,8 @@
     "tools": {
       "internet_search": "Im Internet suchen",
       "website_content": "Website abfragen",
-      "source_query": "Quelle durchsuchen",
+      "source_query": "Datei durchsuchen",
+      "source_get_text": "Datei durchsuchen",
       "code_execution": "Berechnung ausführen",
       "send_email": {
         "subject": "Betreff",

--- a/ayunis-core-frontend/src/shared/locales/en/chat.json
+++ b/ayunis-core-frontend/src/shared/locales/en/chat.json
@@ -27,7 +27,8 @@
     "tools": {
       "internet_search": "Search the internet",
       "website_content": "Query website",
-      "source_query": "Query source",
+      "source_query": "Query file",
+      "source_get_text": "Query file",
       "code_execution": "Calculate",
       "send_email": {
         "subject": "Subject",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces a file text retrieval tool, a richer system prompt, and line-number-aware RAG splitting/querying.
> 
> - **New tool:** Adds `source_get_text` (entity, handler, factory, registry, module wiring) with configurable limits via `tools.config` (max lines/chars)
> - **System prompt:** New `SystemPromptBuilderService` used in runs; injects current time, tool-specific long descriptions, and available files into instructions
> - **RAG splitting:** `recursive.splitter` now annotates chunks with `startLine/endLine` and char offsets; comprehensive tests added; `create-text-source` persists splitter metadata in chunk `meta`
> - **Source querying:** `source_query` handler now returns `startLine/endLine`, `fileName`, `url` when available; improved error messaging
> - **Tooling UX:** Tool descriptions refined and `descriptionLong` support added across tools; assemble logic exposes both `source_query` and `source_get_text` for text sources
> - **Frontend i18n:** Rename "Query source" → "Query file" and add label for `source_get_text` (EN/DE)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e3e066825b463439444d5105772e6e4ba9459317. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->