### PR TITLE
ChatInput add prompt alignment

### DIFF
--- a/ayunis-core-frontend/src/widgets/chat-input/ui/PlusButton.tsx
+++ b/ayunis-core-frontend/src/widgets/chat-input/ui/PlusButton.tsx
@@ -123,13 +123,13 @@ export default function PlusButton({
           <DropdownMenuGroup>
             <DropdownMenuSub>
               <DropdownMenuSubTrigger>
-                <BookOpen className="h-4 w-4 mr-2 text-muted-foreground" />
+                <BookOpen className="h-4 w-4" />
                 {t('chatInput.addPrompt')}
               </DropdownMenuSubTrigger>
               <DropdownMenuSubContent>
                 {isLoadingPrompts ? (
                   <DropdownMenuItem disabled>
-                    <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                    <Loader2 className="h-4 w-4 animate-spin" />
                     {t('common.loading')}
                   </DropdownMenuItem>
                 ) : promptsError ? (


### PR DESCRIPTION
Fixes alignment of "Add Prompt" item in ChatInput Plus Button.

The `DropdownMenuSubTrigger` and `DropdownMenuItem` components already provide `gap-2` for spacing and handle icon coloring. Manually adding `mr-2` and `text-muted-foreground` to icons caused double spacing and inconsistent styling.

---
<a href="https://cursor.com/background-agent?bcId=bc-8c0f5f6b-3cb2-4bc2-a975-374107482aee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8c0f5f6b-3cb2-4bc2-a975-374107482aee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Standardizes icon spacing/color in the ChatInput Plus Button.
> 
> - In `PlusButton.tsx`, removes `mr-2` and `text-muted-foreground` from `BookOpen` and `Loader2` within `DropdownMenuSubTrigger` and loading `DropdownMenuItem`
> - Relies on dropdown components’ built-in `gap` and styling for consistent alignment
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 62ea783d6f732c510fd9a2e8ee2079e48def6df1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->