### PR TITLE
fix: fix invite flow

### DIFF
--- a/ayunis-core-backend/src/iam/invites/application/use-cases/create-invite/create-invite.use-case.ts
+++ b/ayunis-core-backend/src/iam/invites/application/use-cases/create-invite/create-invite.use-case.ts
@@ -12,6 +12,7 @@ import {
   EmailNotAvailableError,
   InvalidSeatsError,
   UnexpectedInviteError,
+  UserAlreadyExistsError,
 } from '../../invites.errors';
 import { SendInvitationEmailUseCase } from '../send-invitation-email/send-invitation-email.use-case';
 import { ApplicationError } from 'src/common/errors/base.error';
@@ -57,6 +58,9 @@ export class CreateInviteUseCase {
         new FindUserByEmailQuery(command.email),
       );
       if (existingUser) {
+        if (existingUser.orgId === command.orgId) {
+          throw new UserAlreadyExistsError();
+        }
         throw new EmailNotAvailableError();
       }
 

--- a/ayunis-core-frontend/src/pages/admin-settings/users-settings/api/useInviteCreate.ts
+++ b/ayunis-core-frontend/src/pages/admin-settings/users-settings/api/useInviteCreate.ts
@@ -27,6 +27,9 @@ export function useInviteCreate(
         try {
           const { code } = extractErrorData(error);
           switch (code) {
+            case 'USER_ALREADY_EXISTS':
+              showError(t('inviteCreate.userAlreadyExists'));
+              break;
             case 'EMAIL_NOT_AVAILABLE':
               showError(t('inviteCreate.emailNotAvailable'));
               break;

--- a/ayunis-core-frontend/src/pages/admin-settings/users-settings/api/useInviteDelete.ts
+++ b/ayunis-core-frontend/src/pages/admin-settings/users-settings/api/useInviteDelete.ts
@@ -3,7 +3,7 @@ import {
   getSubscriptionsControllerGetSubscriptionQueryKey,
   useInvitesControllerDeleteInvite,
 } from '@/shared/api/generated/ayunisCoreAPI';
-import type { Invite } from '../model/openapi';
+import type { PaginatedInvitesListResponseDto } from '@/shared/api/generated/ayunisCoreAPI.schemas';
 import { useQueryClient } from '@tanstack/react-query';
 import { showError } from '@/shared/lib/toast';
 import { useRouter } from '@tanstack/react-router';
@@ -26,8 +26,12 @@ export function useInviteDelete() {
 
         queryClient.setQueryData(
           getInvitesControllerGetInvitesQueryKey(),
-          (old: Invite[]) => {
-            return old.filter((invite: Invite) => invite.id !== id);
+          (old: PaginatedInvitesListResponseDto | undefined) => {
+            if (!old) return old;
+            return {
+              ...old,
+              data: old.data.filter((invite) => invite.id !== id),
+            };
           },
         );
         return { previousData };

--- a/ayunis-core-frontend/src/shared/locales/de/admin-settings-users.json
+++ b/ayunis-core-frontend/src/shared/locales/de/admin-settings-users.json
@@ -86,6 +86,7 @@
     "success": "Einladung erfolgreich erstellt",
     "error": "Fehler beim Erstellen der Einladung. Bitte versuchen Sie es erneut.",
     "emailNotAvailable": "Einladung nicht möglich.",
+    "userAlreadyExists": "Diese E-Mail-Adresse ist bereits als Benutzer in Ihrer Organisation registriert.",
     "emailProviderBlacklisted": "E-Mail-Adresse von diesem Provider ist nicht erlaubt. Bitte verwenden Sie Ihr Firmen E-Mail-Adresse."
   },
   "inviteDelete": {

--- a/ayunis-core-frontend/src/shared/locales/en/admin-settings-users.json
+++ b/ayunis-core-frontend/src/shared/locales/en/admin-settings-users.json
@@ -85,6 +85,7 @@
     "success": "Invite created successfully!",
     "error": "Failed to create invite. Please try again.",
     "emailNotAvailable": "Invite not possible.",
+    "userAlreadyExists": "This email address is already registered as a user in your organization.",
     "emailProviderBlacklisted": "Email address from this provider is not allowed. Please use your company email address."
   },
   "inviteDelete": {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> - **Backend (invite creation):** When an email already belongs to a user in the same org, throw `UserAlreadyExistsError`; otherwise continue to throw `EmailNotAvailableError` in `create-invite.use-case.ts`.
> - **Frontend (create invite):** Handle `USER_ALREADY_EXISTS` error code in `useInviteCreate` with specific toast using new `inviteCreate.userAlreadyExists` i18n key.
> - **Frontend (delete invite):** Update `useInviteDelete` optimistic cache to work with `PaginatedInvitesListResponseDto` (filter within `data`), and adjust types/imports accordingly.
> - **i18n:** Add `inviteCreate.userAlreadyExists` translations (en/de).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 894db5f1ec4da5c095ca1c18261288f107d1b184. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->