### PR TITLE
feat: implement drag and drop for file upload AYC-000

### DIFF
--- a/ayunis-core-frontend/src/shared/locales/de/common.json
+++ b/ayunis-core-frontend/src/shared/locales/de/common.json
@@ -76,7 +76,9 @@
       "send_email": "E-Mails vorbereiten",
       "cannot_disable": "Diese Funktion kann nicht deaktiviert werden."
     },
-    "fileSourceDisabled": "Um Dokumente hochzuladen, muss ein Embedding-Modell aktiviert sein."
+    "fileSourceDisabled": "Um Dokumente hochzuladen, muss ein Embedding-Modell aktiviert sein.",
+    "dropFilesHint": "Dateien hier ablegen",
+    "invalidDroppedFileType": "Einige Dateien wurden übersprungen, da sie nicht unterstützt werden."
   },
   "common": {
     "loading": "Laden...",

--- a/ayunis-core-frontend/src/shared/locales/en/common.json
+++ b/ayunis-core-frontend/src/shared/locales/en/common.json
@@ -76,7 +76,9 @@
       "send_email": "Prepare Emails",
       "cannot_disable": "This function cannot be disabled."
     },
-    "fileSourceDisabled": "To upload documents, an embedding model must be enabled."
+    "fileSourceDisabled": "To upload documents, an embedding model must be enabled.",
+    "dropFilesHint": "Drop files here",
+    "invalidDroppedFileType": "Some files were skipped because they are not supported."
   },
   "common": {
     "loading": "Loading...",

--- a/ayunis-core-frontend/src/widgets/chat-input/hooks/index.ts
+++ b/ayunis-core-frontend/src/widgets/chat-input/hooks/index.ts
@@ -1,2 +1,3 @@
 export { usePendingImages, type PendingImage } from './usePendingImages';
 export { useImagePaste } from './useImagePaste';
+export { useFileDrop } from './useFileDrop';

--- a/ayunis-core-frontend/src/widgets/chat-input/hooks/useFileDrop.ts
+++ b/ayunis-core-frontend/src/widgets/chat-input/hooks/useFileDrop.ts
@@ -1,0 +1,110 @@
+import { useCallback, useEffect, useState, type RefObject } from 'react';
+import { separateFilesByType } from '../utils/fileHandlers';
+
+interface UseFileDropOptions {
+  containerRef: RefObject<HTMLElement | null>;
+  onDocumentDrop: (file: File) => void;
+  onImagesDrop: (files: File[]) => void;
+  isDocumentUploadEnabled: boolean;
+  isImageUploadEnabled: boolean;
+  acceptedDocumentExtensions: string[];
+}
+
+interface UseFileDropResult {
+  isDragging: boolean;
+}
+
+export function useFileDrop({
+  containerRef,
+  onDocumentDrop,
+  onImagesDrop,
+  isDocumentUploadEnabled,
+  isImageUploadEnabled,
+  acceptedDocumentExtensions,
+}: UseFileDropOptions): UseFileDropResult {
+  const [isDragging, setIsDragging] = useState(false);
+  const [, setDragCounter] = useState(0);
+
+  const isValidDocumentFile = useCallback(
+    (file: File): boolean => {
+      const extension = '.' + file.name.split('.').pop()?.toLowerCase();
+      return acceptedDocumentExtensions.includes(extension);
+    },
+    [acceptedDocumentExtensions],
+  );
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const handleDragEnter = (e: DragEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+      setDragCounter((prev) => prev + 1);
+      setIsDragging(true);
+    };
+
+    const handleDragLeave = (e: DragEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+      setDragCounter((prev) => {
+        const newCount = prev - 1;
+        if (newCount === 0) {
+          setIsDragging(false);
+        }
+        return newCount;
+      });
+    };
+
+    const handleDragOver = (e: DragEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+    };
+
+    const handleDrop = (e: DragEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+      setIsDragging(false);
+      setDragCounter(0);
+
+      const files = e.dataTransfer?.files;
+      if (!files || files.length === 0) return;
+
+      const { images, regularFiles } = separateFilesByType(files);
+
+      // Handle images
+      if (isImageUploadEnabled && images.length > 0) {
+        onImagesDrop(images);
+      }
+
+      // Handle documents (only first one, as per existing behavior)
+      if (isDocumentUploadEnabled && regularFiles.length > 0) {
+        const validDocuments = regularFiles.filter(isValidDocumentFile);
+        if (validDocuments.length > 0) {
+          onDocumentDrop(validDocuments[0]);
+        }
+      }
+    };
+
+    container.addEventListener('dragenter', handleDragEnter);
+    container.addEventListener('dragleave', handleDragLeave);
+    container.addEventListener('dragover', handleDragOver);
+    container.addEventListener('drop', handleDrop);
+
+    return () => {
+      container.removeEventListener('dragenter', handleDragEnter);
+      container.removeEventListener('dragleave', handleDragLeave);
+      container.removeEventListener('dragover', handleDragOver);
+      container.removeEventListener('drop', handleDrop);
+    };
+  }, [
+    containerRef,
+    onDocumentDrop,
+    onImagesDrop,
+    isDocumentUploadEnabled,
+    isImageUploadEnabled,
+    isValidDocumentFile,
+  ]);
+
+  return { isDragging };
+}

--- a/ayunis-core-frontend/src/widgets/chat-input/hooks/useFileDrop.ts
+++ b/ayunis-core-frontend/src/widgets/chat-input/hooks/useFileDrop.ts
@@ -1,4 +1,6 @@
 import { useCallback, useEffect, useState, type RefObject } from 'react';
+import { useTranslation } from 'react-i18next';
+import { toast } from 'sonner';
 import { separateFilesByType } from '../utils/fileHandlers';
 
 interface UseFileDropOptions {
@@ -22,6 +24,7 @@ export function useFileDrop({
   isImageUploadEnabled,
   acceptedDocumentExtensions,
 }: UseFileDropOptions): UseFileDropResult {
+  const { t } = useTranslation();
   const [isDragging, setIsDragging] = useState(false);
   const [, setDragCounter] = useState(0);
 
@@ -71,6 +74,7 @@ export function useFileDrop({
       if (!files || files.length === 0) return;
 
       const { images, regularFiles } = separateFilesByType(files);
+      let hasSkippedFiles = false;
 
       // Handle images
       if (isImageUploadEnabled && images.length > 0) {
@@ -83,6 +87,18 @@ export function useFileDrop({
         if (validDocuments.length > 0) {
           onDocumentDrop(validDocuments[0]);
         }
+        // Check if any documents were skipped due to invalid file type
+        if (validDocuments.length < regularFiles.length) {
+          hasSkippedFiles = true;
+        }
+      } else if (!isDocumentUploadEnabled && regularFiles.length > 0) {
+        // If document upload is disabled but documents were dropped
+        hasSkippedFiles = true;
+      }
+
+      // Show toast if any files were skipped
+      if (hasSkippedFiles) {
+        toast.error(t('chatInput.invalidDroppedFileType'));
       }
     };
 
@@ -104,6 +120,7 @@ export function useFileDrop({
     isDocumentUploadEnabled,
     isImageUploadEnabled,
     isValidDocumentFile,
+    t,
   ]);
 
   return { isDragging };

--- a/ayunis-core-frontend/src/widgets/chat-input/hooks/useFileDrop.ts
+++ b/ayunis-core-frontend/src/widgets/chat-input/hooks/useFileDrop.ts
@@ -24,7 +24,7 @@ export function useFileDrop({
   isImageUploadEnabled,
   acceptedDocumentExtensions,
 }: UseFileDropOptions): UseFileDropResult {
-  const { t } = useTranslation();
+  const { t } = useTranslation('common');
   const [isDragging, setIsDragging] = useState(false);
   const [, setDragCounter] = useState(0);
 
@@ -79,6 +79,9 @@ export function useFileDrop({
       // Handle images
       if (isImageUploadEnabled && images.length > 0) {
         onImagesDrop(images);
+      } else if (!isImageUploadEnabled && images.length > 0) {
+        // If image upload is disabled but images were dropped
+        hasSkippedFiles = true;
       }
 
       // Handle documents (only first one, as per existing behavior)

--- a/ayunis-core-frontend/src/widgets/chat-input/ui/ChatInput.tsx
+++ b/ayunis-core-frontend/src/widgets/chat-input/ui/ChatInput.tsx
@@ -27,7 +27,9 @@ import {
   MAX_IMAGES,
 } from '../hooks/usePendingImages';
 import { useImagePaste } from '../hooks/useImagePaste';
+import { useFileDrop } from '../hooks/useFileDrop';
 import { PendingImageThumbnail } from './PendingImageThumbnail';
+import { cn } from '@/shared/lib/shadcn/utils';
 import { SourcesList } from './SourcesList';
 import { showError } from '@/shared/lib/toast';
 
@@ -124,6 +126,27 @@ const ChatInput = forwardRef<ChatInputRef, ChatInputProps>(
       onImagesPasted: handleImagesPasted,
     });
 
+    const { isDragging } = useFileDrop({
+      containerRef,
+      onDocumentDrop: onFileUpload,
+      onImagesDrop: (files) => {
+        const result = addImages(files);
+        if (result.limitExceeded) {
+          showError(t('chatInput.imageLimitExceeded', { max: MAX_IMAGES }));
+        }
+      },
+      isDocumentUploadEnabled: isEmbeddingModelEnabled && !isCreatingFileSource,
+      isImageUploadEnabled: isVisionEnabled,
+      acceptedDocumentExtensions: [
+        '.pdf',
+        '.csv',
+        '.xlsx',
+        '.xls',
+        '.docx',
+        '.pptx',
+      ],
+    });
+
     useImperativeHandle(ref, () => ({
       setMessage,
       sendMessage: (text: string) => {
@@ -218,7 +241,12 @@ const ChatInput = forwardRef<ChatInputRef, ChatInputProps>(
         className="w-full space-y-2"
         data-testid="chat-input"
       >
-        <Card className="py-4">
+        <Card
+          className={cn(
+            'py-4',
+            isDragging && 'border-2 border-dashed border-primary bg-primary/5',
+          )}
+        >
           <CardContent className="px-4">
             <div className="flex flex-col gap-4">
               <SourcesList


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces drag-and-drop file handling and UI feedback in the chat input.
> 
> - New `useFileDrop` hook to separate images vs documents, validate accepted document extensions, and surface skipped-file toasts using `chatInput.invalidDroppedFileType`
> - Integrated into `ChatInput` with drop-state styling via `cn` (dashed primary border/background), and image-limit handling reused
> - Exported `useFileDrop` from hooks index
> - Added i18n strings for `chatInput.dropFilesHint` and `chatInput.invalidDroppedFileType` in `en/de`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fe842fd819519133dc2c2bbd949eafc05b83fd2d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->