### PR TITLE
ci: add slack notification after prod deploy AYC-000

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,6 +15,8 @@ jobs:
     outputs:
       releases_created: ${{ steps.release.outputs.releases_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
+      body: ${{ steps.release.outputs.body }}
+      html_url: ${{ steps.release.outputs.html_url }}
     steps:
       - uses: googleapis/release-please-action@v4
         id: release
@@ -78,3 +80,47 @@ jobs:
             docker compose up -d --build
             sleep 60
             docker compose ps
+
+  notify-slack:
+    name: Notify Slack
+    runs-on: ubuntu-latest
+    needs: [release-please, deploy-internal, deploy-production]
+    if: ${{ needs.release-please.outputs.releases_created == 'true' }}
+    steps:
+      - name: Post to Slack
+        uses: slackapi/slack-github-action@v2.0.0
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "header",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "🎉 Ayunis Core ${{ needs.release-please.outputs.tag_name }} deployed"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "${{ needs.release-please.outputs.body }}"
+                  }
+                },
+                {
+                  "type": "actions",
+                  "elements": [
+                    {
+                      "type": "button",
+                      "text": {
+                        "type": "plain_text",
+                        "text": "View Release"
+                      },
+                      "url": "${{ needs.release-please.outputs.html_url }}"
+                    }
+                  ]
+                }
+              ]
+            }

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -88,39 +88,50 @@ jobs:
     if: ${{ needs.release-please.outputs.releases_created == 'true' }}
     steps:
       - name: Post to Slack
-        uses: slackapi/slack-github-action@v2.0.0
-        with:
-          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
-          webhook-type: incoming-webhook
-          payload: |
-            {
-              "blocks": [
+        env:
+          TAG_NAME: ${{ needs.release-please.outputs.tag_name }}
+          BODY: ${{ needs.release-please.outputs.body }}
+          HTML_URL: ${{ needs.release-please.outputs.html_url }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        run: |
+          # Build JSON payload using jq (properly escapes all special characters)
+          PAYLOAD=$(jq -n \
+            --arg tag "$TAG_NAME" \
+            --arg body "$BODY" \
+            --arg url "$HTML_URL" \
+            '{
+              blocks: [
                 {
-                  "type": "header",
-                  "text": {
-                    "type": "plain_text",
-                    "text": "🎉 Ayunis Core ${{ needs.release-please.outputs.tag_name }} deployed"
+                  type: "header",
+                  text: {
+                    type: "plain_text",
+                    text: "🎉 Ayunis Core \($tag) deployed"
                   }
                 },
                 {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "${{ needs.release-please.outputs.body }}"
+                  type: "section",
+                  text: {
+                    type: "mrkdwn",
+                    text: $body
                   }
                 },
                 {
-                  "type": "actions",
-                  "elements": [
+                  type: "actions",
+                  elements: [
                     {
-                      "type": "button",
-                      "text": {
-                        "type": "plain_text",
-                        "text": "View Release"
+                      type: "button",
+                      text: {
+                        type: "plain_text",
+                        text: "View Release"
                       },
-                      "url": "${{ needs.release-please.outputs.html_url }}"
+                      url: $url
                     }
                   ]
                 }
               ]
-            }
+            }')
+
+          curl -sfS -X POST \
+            -H 'Content-Type: application/json' \
+            -d "$PAYLOAD" \
+            "$SLACK_WEBHOOK_URL"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Sends a Slack notification after a successful release deploy.
> 
> - Adds `notify-slack` job triggered after `release-please`, `deploy-internal`, and `deploy-production`, gated on `releases_created`
> - Exposes `body` and `html_url` outputs from `release-please` for use in Slack payload
> - Posts a Slack Blocks message (header with tag, release notes body, and a "View Release" button linking to the release URL) via `SLACK_WEBHOOK_URL`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit feef1746b9c5c2262849e64dd99773c0b1fbf449. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->