### PR TITLE
feat: filter orgs by active subscription as super admin

### DIFF
--- a/ayunis-core-backend/src/iam/orgs/application/ports/orgs.repository.ts
+++ b/ayunis-core-backend/src/iam/orgs/application/ports/orgs.repository.ts
@@ -9,6 +9,7 @@ export interface OrgsPagination {
 
 export interface OrgsFilters {
   search?: string;
+  hasActiveSubscription?: boolean;
 }
 
 export abstract class OrgsRepository {

--- a/ayunis-core-backend/src/iam/orgs/application/use-cases/super-admin-get-all-orgs/super-admin-get-all-orgs.query.ts
+++ b/ayunis-core-backend/src/iam/orgs/application/use-cases/super-admin-get-all-orgs/super-admin-get-all-orgs.query.ts
@@ -7,11 +7,13 @@ const DEFAULT_LIMIT = 50;
 
 export interface SuperAdminGetAllOrgsQueryParams {
   search?: string;
+  hasActiveSubscription?: boolean;
   pagination?: Partial<PaginatedQueryParams>;
 }
 
 export class SuperAdminGetAllOrgsQuery extends PaginatedQuery {
   public readonly search?: string;
+  public readonly hasActiveSubscription?: boolean;
 
   constructor(params?: SuperAdminGetAllOrgsQueryParams) {
     super({
@@ -19,5 +21,6 @@ export class SuperAdminGetAllOrgsQuery extends PaginatedQuery {
       offset: params?.pagination?.offset ?? 0,
     });
     this.search = params?.search;
+    this.hasActiveSubscription = params?.hasActiveSubscription;
   }
 }

--- a/ayunis-core-backend/src/iam/orgs/application/use-cases/super-admin-get-all-orgs/super-admin-get-all-orgs.use-case.ts
+++ b/ayunis-core-backend/src/iam/orgs/application/use-cases/super-admin-get-all-orgs/super-admin-get-all-orgs.use-case.ts
@@ -21,6 +21,7 @@ export class SuperAdminGetAllOrgsUseCase {
       limit: query.limit,
       offset: query.offset,
       search: query.search,
+      hasActiveSubscription: query.hasActiveSubscription,
     });
 
     const systemRole = this.contextService.get('systemRole');
@@ -38,6 +39,7 @@ export class SuperAdminGetAllOrgsUseCase {
       },
       {
         search: query.search,
+        hasActiveSubscription: query.hasActiveSubscription,
       },
     );
   }

--- a/ayunis-core-backend/src/iam/orgs/presenters/http/dtos/super-admin-get-all-orgs-query-params.dto.ts
+++ b/ayunis-core-backend/src/iam/orgs/presenters/http/dtos/super-admin-get-all-orgs-query-params.dto.ts
@@ -1,6 +1,6 @@
 import { ApiPropertyOptional } from '@nestjs/swagger';
-import { Type } from 'class-transformer';
-import { IsInt, IsOptional, IsString, Min } from 'class-validator';
+import { Transform, Type } from 'class-transformer';
+import { IsBoolean, IsInt, IsOptional, IsString, Min } from 'class-validator';
 
 export class SuperAdminGetAllOrgsQueryParamsDto {
   @ApiPropertyOptional({
@@ -10,6 +10,19 @@ export class SuperAdminGetAllOrgsQueryParamsDto {
   @IsOptional()
   @IsString()
   search?: string;
+
+  @ApiPropertyOptional({
+    description: 'Filter organizations by active subscription status',
+    example: true,
+  })
+  @IsOptional()
+  @IsBoolean()
+  @Transform(({ value }) => {
+    if (value === 'true' || value === true) return true;
+    if (value === 'false' || value === false) return false;
+    return undefined;
+  })
+  hasActiveSubscription?: boolean;
 
   @ApiPropertyOptional({
     description: 'Maximum number of organizations to return',

--- a/ayunis-core-backend/src/iam/orgs/presenters/http/super-admin-orgs.controller.ts
+++ b/ayunis-core-backend/src/iam/orgs/presenters/http/super-admin-orgs.controller.ts
@@ -103,6 +103,14 @@ export class SuperAdminOrgsController {
     example: 'Acme',
   })
   @ApiQuery({
+    name: 'hasActiveSubscription',
+    required: false,
+    type: Boolean,
+    description:
+      'Filter organizations by active subscription status. Set to true to show only orgs with active subscriptions, false to show only orgs without.',
+    example: true,
+  })
+  @ApiQuery({
     name: 'limit',
     required: false,
     type: Number,
@@ -122,6 +130,7 @@ export class SuperAdminOrgsController {
     const orgs = await this.superAdminGetAllOrgsUseCase.execute(
       new SuperAdminGetAllOrgsQuery({
         search: queryParams.search,
+        hasActiveSubscription: queryParams.hasActiveSubscription,
         pagination: {
           limit: queryParams.limit,
           offset: queryParams.offset,

--- a/ayunis-core-frontend/src/app/routes/_authenticated/super-admin-settings.orgs.index.tsx
+++ b/ayunis-core-frontend/src/app/routes/_authenticated/super-admin-settings.orgs.index.tsx
@@ -11,6 +11,10 @@ const ORGS_PER_PAGE = 25;
 const searchSchema = z.object({
   search: z.string().optional(),
   page: z.number().min(1).optional().catch(1),
+  hasActiveSubscription: z
+    .enum(['all', 'true', 'false'])
+    .optional()
+    .catch('all'),
 });
 
 export const Route = createFileRoute(
@@ -19,35 +23,49 @@ export const Route = createFileRoute(
   validateSearch: searchSchema,
   loaderDeps: ({ search }) => search,
   component: RouteComponent,
-  loader: async ({ deps: { search, page = 1 }, context: { queryClient } }) => {
+  loader: async ({
+    deps: { search, page = 1, hasActiveSubscription },
+    context: { queryClient },
+  }) => {
     const offset = (page - 1) * ORGS_PER_PAGE;
+    // Convert filter value to API parameter
+    const subscriptionFilter =
+      hasActiveSubscription === 'true'
+        ? true
+        : hasActiveSubscription === 'false'
+          ? false
+          : undefined;
     const response = await queryClient.fetchQuery({
       queryKey: getSuperAdminOrgsControllerGetAllOrgsQueryKey({
         search,
+        hasActiveSubscription: subscriptionFilter,
         limit: ORGS_PER_PAGE,
         offset,
       }),
       queryFn: () =>
         superAdminOrgsControllerGetAllOrgs({
           search,
+          hasActiveSubscription: subscriptionFilter,
           limit: ORGS_PER_PAGE,
           offset,
         }),
     });
     const orgs = response?.data ?? [];
     const pagination = response?.pagination;
-    return { orgs, pagination, search, page };
+    return { orgs, pagination, search, page, hasActiveSubscription };
   },
 });
 
 function RouteComponent() {
-  const { orgs, pagination, search, page } = Route.useLoaderData();
+  const { orgs, pagination, search, page, hasActiveSubscription } =
+    Route.useLoaderData();
   return (
     <SuperAdminOrgsPage
       orgs={orgs}
       pagination={pagination}
       search={search}
       currentPage={page ?? 1}
+      hasActiveSubscription={hasActiveSubscription}
     />
   );
 }

--- a/ayunis-core-frontend/src/pages/super-admin-settings/orgs/ui/OrgsPagination.tsx
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/orgs/ui/OrgsPagination.tsx
@@ -14,12 +14,14 @@ interface OrgsPaginationProps {
   currentPage: number;
   totalPages: number;
   search?: string;
+  hasActiveSubscription?: 'all' | 'true' | 'false';
 }
 
 export default function OrgsPagination({
   currentPage,
   totalPages,
   search,
+  hasActiveSubscription,
 }: OrgsPaginationProps) {
   const { t } = useTranslation('common');
 
@@ -56,6 +58,8 @@ export default function OrgsPagination({
 
   const searchParams = {
     ...(search && { search }),
+    ...(hasActiveSubscription &&
+      hasActiveSubscription !== 'all' && { hasActiveSubscription }),
   };
 
   const isFirstPage = currentPage === 1;

--- a/ayunis-core-frontend/src/pages/super-admin-settings/orgs/ui/OrgsSearch.tsx
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/orgs/ui/OrgsSearch.tsx
@@ -33,7 +33,13 @@ export default function OrgsSearch({ search }: OrgsSearchProps) {
       if (searchValue !== (search ?? '')) {
         void navigate({
           to: '/super-admin-settings/orgs',
-          search: (prev: { search?: string; page?: number }) => ({
+          search: (
+            prev: {
+              search?: string;
+              page?: number;
+              hasActiveSubscription?: string;
+            },
+          ) => ({
             ...prev,
             search: searchValue || undefined,
             page: undefined, // Reset to page 1 when search changes

--- a/ayunis-core-frontend/src/pages/super-admin-settings/orgs/ui/OrgsSubscriptionFilter.tsx
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/orgs/ui/OrgsSubscriptionFilter.tsx
@@ -1,0 +1,49 @@
+import { useNavigate } from '@tanstack/react-router';
+import { useTranslation } from 'react-i18next';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/shared/ui/shadcn/select';
+
+interface OrgsSubscriptionFilterProps {
+  hasActiveSubscription?: 'all' | 'true' | 'false';
+  search?: string;
+}
+
+export default function OrgsSubscriptionFilter({
+  hasActiveSubscription = 'all',
+  search,
+}: OrgsSubscriptionFilterProps) {
+  const { t } = useTranslation('super-admin-settings-orgs');
+  const navigate = useNavigate();
+
+  const handleFilterChange = (value: string) => {
+    void navigate({
+      to: '/super-admin-settings/orgs',
+      search: {
+        search: search || undefined,
+        hasActiveSubscription:
+          value === 'all' ? undefined : (value as 'true' | 'false'),
+        page: undefined, // Reset to page 1 when filter changes
+      },
+    });
+  };
+
+  return (
+    <Select value={hasActiveSubscription} onValueChange={handleFilterChange}>
+      <SelectTrigger className="w-[200px]">
+        <SelectValue placeholder={t('filter.subscription.placeholder')} />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectItem value="all">{t('filter.subscription.all')}</SelectItem>
+        <SelectItem value="true">{t('filter.subscription.active')}</SelectItem>
+        <SelectItem value="false">
+          {t('filter.subscription.inactive')}
+        </SelectItem>
+      </SelectContent>
+    </Select>
+  );
+}

--- a/ayunis-core-frontend/src/pages/super-admin-settings/orgs/ui/OrgsTable.tsx
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/orgs/ui/OrgsTable.tsx
@@ -22,9 +22,14 @@ import type { ReactNode } from 'react';
 interface OrgsTableProps {
   orgs: SuperAdminOrgResponseDto[];
   searchSlot?: ReactNode;
+  filterSlot?: ReactNode;
 }
 
-export default function OrgsTable({ orgs, searchSlot }: OrgsTableProps) {
+export default function OrgsTable({
+  orgs,
+  searchSlot,
+  filterSlot,
+}: OrgsTableProps) {
   const { t } = useTranslation('super-admin-settings-orgs');
   const router = useRouter();
 
@@ -35,7 +40,12 @@ export default function OrgsTable({ orgs, searchSlot }: OrgsTableProps) {
         <CardDescription>{t('header.description')}</CardDescription>
       </CardHeader>
       <CardContent>
-        {searchSlot && <div className="mb-4">{searchSlot}</div>}
+        {(searchSlot || filterSlot) && (
+          <div className="mb-4 flex flex-col gap-4 sm:flex-row sm:items-center">
+            {searchSlot}
+            {filterSlot}
+          </div>
+        )}
         {orgs.length === 0 ? (
           <div className="flex flex-col items-center justify-center space-y-2 py-10 text-center">
             <h3 className="text-lg font-semibold">{t('empty.title')}</h3>

--- a/ayunis-core-frontend/src/pages/super-admin-settings/orgs/ui/Page.tsx
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/orgs/ui/Page.tsx
@@ -3,6 +3,7 @@ import CreateOrgDialog from './CreateOrgDialog';
 import OrgsTable from './OrgsTable';
 import OrgsPagination from './OrgsPagination';
 import OrgsSearch from './OrgsSearch';
+import OrgsSubscriptionFilter from './OrgsSubscriptionFilter';
 import type { SuperAdminOrgResponseDto, PaginationDto } from '@/shared/api';
 
 interface SuperAdminOrgsPageProps {
@@ -10,6 +11,7 @@ interface SuperAdminOrgsPageProps {
   pagination?: PaginationDto;
   search?: string;
   currentPage: number;
+  hasActiveSubscription?: 'all' | 'true' | 'false';
 }
 
 export default function SuperAdminOrgsPage({
@@ -17,6 +19,7 @@ export default function SuperAdminOrgsPage({
   pagination,
   search,
   currentPage,
+  hasActiveSubscription,
 }: SuperAdminOrgsPageProps) {
   const total = pagination?.total ?? 0;
   const limit = pagination?.limit ?? 25;
@@ -25,11 +28,21 @@ export default function SuperAdminOrgsPage({
   return (
     <SuperAdminSettingsLayout action={<CreateOrgDialog />}>
       <div className="space-y-4">
-        <OrgsTable orgs={orgs} searchSlot={<OrgsSearch search={search} />} />
+        <OrgsTable
+          orgs={orgs}
+          searchSlot={<OrgsSearch search={search} />}
+          filterSlot={
+            <OrgsSubscriptionFilter
+              hasActiveSubscription={hasActiveSubscription}
+              search={search}
+            />
+          }
+        />
         <OrgsPagination
           currentPage={currentPage}
           totalPages={totalPages}
           search={search}
+          hasActiveSubscription={hasActiveSubscription}
         />
       </div>
     </SuperAdminSettingsLayout>

--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
@@ -2562,6 +2562,10 @@ export type SuperAdminOrgsControllerGetAllOrgsParams = {
  */
 search?: string;
 /**
+ * Filter organizations by active subscription status.
+ */
+hasActiveSubscription?: boolean;
+/**
  * Maximum number of organizations to return (default: 50).
  */
 limit?: number;

--- a/ayunis-core-frontend/src/shared/locales/de/super-admin-settings-orgs.json
+++ b/ayunis-core-frontend/src/shared/locales/de/super-admin-settings-orgs.json
@@ -43,5 +43,13 @@
   },
   "search": {
     "placeholder": "Organisationen suchen..."
+  },
+  "filter": {
+    "subscription": {
+      "placeholder": "Abonnementstatus",
+      "all": "Alle Organisationen",
+      "active": "Mit aktivem Abonnement",
+      "inactive": "Ohne Abonnement"
+    }
   }
 }

--- a/ayunis-core-frontend/src/shared/locales/en/super-admin-settings-orgs.json
+++ b/ayunis-core-frontend/src/shared/locales/en/super-admin-settings-orgs.json
@@ -43,5 +43,13 @@
   },
   "search": {
     "placeholder": "Search organizations..."
+  },
+  "filter": {
+    "subscription": {
+      "placeholder": "Subscription status",
+      "all": "All organizations",
+      "active": "With active subscription",
+      "inactive": "Without subscription"
+    }
   }
 }


### PR DESCRIPTION
Add a filter to the super admin organizations list page to allow filtering by active subscription status.

---
<a href="https://cursor.com/background-agent?bcId=bc-303f9632-d37d-4a52-ac2e-b4ade6dcfb3e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-303f9632-d37d-4a52-ac2e-b4ade6dcfb3e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces an active-subscription filter for the super admin organizations list, wired end-to-end across API, repository, routing, and UI.
> 
> - Backend: Adds `hasActiveSubscription` to `OrgsFilters`, query DTO, and controller; `LocalOrgsRepository` implements filtering via subquery on `SubscriptionRecord` (`cancelledAt IS NULL`), with updated logging and pagination preserved
> - Frontend: Extends route search schema and loader to pass `hasActiveSubscription`; adds `OrgsSubscriptionFilter` select and integrates it into `OrgsTable`, `OrgsPagination`, and `OrgsSearch`; updates i18n strings and generated API schemas to include the new query param
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 62b4064fd7384cfb232a642b3d75c1c23b552e74. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->