### PR TITLE
feat: Add disclaimer about AI accuracy and fact checking to chat page

### DIFF
--- a/ayunis-core-frontend/src/pages/chat/ui/ChatPage.tsx
+++ b/ayunis-core-frontend/src/pages/chat/ui/ChatPage.tsx
@@ -479,18 +479,15 @@ export default function ChatPage({
     </div>
   );
 
-  // Long chat warning banner
-  const longChatWarning = thread.isLongChat && <LongChatWarning />;
-
   // Chat Input
   // Agent, model, and anonymous mode controls are always disabled on ChatPage
   // because the thread already has messages (ChatPage is only shown after first message)
   const chatInput = (
     <>
-      {longChatWarning}
       <p className="text-xs text-muted-foreground text-center mb-2">
         {t('chat.inputDisclaimer')}
       </p>
+      {thread.isLongChat && <LongChatWarning />}
       <ChatInput
         ref={chatInputRef}
         modelId={

--- a/ayunis-core-frontend/src/pages/chat/ui/ChatPage.tsx
+++ b/ayunis-core-frontend/src/pages/chat/ui/ChatPage.tsx
@@ -488,6 +488,9 @@ export default function ChatPage({
   const chatInput = (
     <>
       {longChatWarning}
+      <p className="text-xs text-muted-foreground text-center mb-2">
+        {t('chat.inputDisclaimer')}
+      </p>
       <ChatInput
         ref={chatInputRef}
         modelId={

--- a/ayunis-core-frontend/src/shared/locales/de/chat.json
+++ b/ayunis-core-frontend/src/shared/locales/de/chat.json
@@ -62,7 +62,8 @@
       "emptyState": "Keine Diagrammdaten verfügbar"
     },
     "longChatWarningTitle": "Konversation zu lang",
-    "longChatWarningDescription": "Für bessere Ergebnisse sollten Sie einen neuen Chat starten."
+    "longChatWarningDescription": "Für bessere Ergebnisse sollten Sie einen neuen Chat starten.",
+    "inputDisclaimer": "Eingaben werden nicht für Training verwendet. KI kann Fehler machen—Antworten prüfen."
   },
   "newChat": {
     "newChat": "Neuer Chat",

--- a/ayunis-core-frontend/src/shared/locales/en/chat.json
+++ b/ayunis-core-frontend/src/shared/locales/en/chat.json
@@ -62,7 +62,8 @@
       "emptyState": "No chart data available"
     },
     "longChatWarningTitle": "Conversation too long",
-    "longChatWarningDescription": "For better results, consider starting a new chat."
+    "longChatWarningDescription": "For better results, consider starting a new chat.",
+    "inputDisclaimer": "Input not used for training. AI can make mistakes—verify answers."
   },
   "newChat": {
     "newChat": "New Chat",


### PR DESCRIPTION
Add a disclaimer above the chat input field on `/chats/<id>` pages to inform users about data usage and AI model limitations.

---
[Slack Thread](https://locaboo.slack.com/archives/C0375HX2C4S/p1768924546749919?thread_ts=1768924546.749919&cid=C0375HX2C4S)

<a href="https://cursor.com/background-agent?bcId=bc-51c6df89-f676-41ad-bbd5-41247748ed19"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-51c6df89-f676-41ad-bbd5-41247748ed19"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a brief, localized disclaimer above the chat input to inform users about data usage and AI limitations.
> 
> - Renders `t('chat.inputDisclaimer')` as a small paragraph above `ChatInput` in `ChatPage.tsx`; removes the unused `longChatWarning` var and keeps `LongChatWarning` shown only when `thread.isLongChat`
> - Adds `chat.inputDisclaimer` translations to `en/chat.json` and `de/chat.json` (and minor JSON formatting update)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b34b234c8601d7b56eaaf4b5eccd7f8cb9699e7d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->