### PR TITLE
feat: group agents in chat input

### DIFF
--- a/ayunis-core-frontend/src/widgets/chat-input/ui/AgentButton.tsx
+++ b/ayunis-core-frontend/src/widgets/chat-input/ui/AgentButton.tsx
@@ -82,9 +82,11 @@ export default function AgentButton({
             <>
               {/* Personal Agents Group */}
               <DropdownMenuGroup>
-                <DropdownMenuLabel className="text-xs text-muted-foreground font-normal">
-                  {tAgents('tabs.personal')}
-                </DropdownMenuLabel>
+                {sharedAgents.length > 0 && (
+                  <DropdownMenuLabel className="text-xs text-muted-foreground font-normal">
+                    {tAgents('tabs.personal')}
+                  </DropdownMenuLabel>
+                )}
                 {personalAgents.length > 0 ? (
                   personalAgents.map(renderAgentItem)
                 ) : (
@@ -94,22 +96,16 @@ export default function AgentButton({
                 )}
               </DropdownMenuGroup>
               {/* Shared Agents Group */}
-              <DropdownMenuSeparator />
-              <DropdownMenuGroup>
-                <DropdownMenuLabel className="text-xs text-muted-foreground font-normal">
-                  {tAgents('tabs.shared')}
-                </DropdownMenuLabel>
-                {sharedAgents.length > 0 ? (
-                  sharedAgents.map(renderAgentItem)
-                ) : (
-                  <DropdownMenuItem disabled className="text-muted-foreground">
-                    {tAgents('emptyState.shared.title')}
-                  </DropdownMenuItem>
-                )}
-              </DropdownMenuGroup>
+              {sharedAgents.length > 0 && (
+                <DropdownMenuGroup>
+                  <DropdownMenuLabel className="text-xs text-muted-foreground font-normal">
+                    {tAgents('tabs.shared')}
+                  </DropdownMenuLabel>
+                  {sharedAgents.map(renderAgentItem)}
+                </DropdownMenuGroup>
+              )}
             </>
           )}
-          <DropdownMenuSeparator />
           <DropdownMenuGroup>
             <DropdownMenuItem onClick={() => void navigate({ to: '/agents' })}>
               <Plus /> {t('chatInput.createFirstAgent')}


### PR DESCRIPTION
Group agents in the ChatInput dropdown by "shared" status to align with the agent list's grouping schema.

---
<a href="https://cursor.com/background-agent?bcId=bc-11951409-9dfe-477b-90d8-34d7b3e48a9b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-11951409-9dfe-477b-90d8-34d7b3e48a9b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves the ChatInput agent selector by grouping agents and refining the dropdown UI.
> 
> - Split `agents` into `personalAgents` and `sharedAgents` via `useMemo`, sorted alphabetically
> - Dropdown now renders separate groups with translated labels (`agents` namespace), selection checkmarks, and per-group empty states; handles global empty state
> - Extracted `renderAgentItem` helper for concise item rendering
> - Preserves "Create Agent" navigation and existing tools section
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c4bf7488bfc3142bcefe77c56411c96f79f450d5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->