### PR TITLE
fix: fix team creation logic errors AYC-55

### DIFF
--- a/ayunis-core-backend/src/iam/teams/infrastructure/repositories/local/local-teams.repository.ts
+++ b/ayunis-core-backend/src/iam/teams/infrastructure/repositories/local/local-teams.repository.ts
@@ -42,7 +42,7 @@ export class LocalTeamsRepository extends TeamsRepository {
     } catch (error) {
       const err = error instanceof Error ? error : new Error('Unknown error');
       this.logger.error('Error finding team', { error: err, id });
-      throw new TeamNotFoundError(id);
+      throw new TeamRetrievalFailedError(err.message);
     }
   }
 

--- a/ayunis-core-frontend/src/pages/admin-settings/teams-settings/api/useCreateTeam.ts
+++ b/ayunis-core-frontend/src/pages/admin-settings/teams-settings/api/useCreateTeam.ts
@@ -7,17 +7,16 @@ import {
 import type { CreateTeamFormData } from '../model/types';
 import extractErrorData from '@/shared/api/extract-error-data';
 import { showError, showSuccess } from '@/shared/lib/toast';
+import { useRouter } from '@tanstack/react-router';
 
 export function useCreateTeam(onSuccess?: () => void) {
   const queryClient = useQueryClient();
+  const router = useRouter();
   const { t } = useTranslation('admin-settings-teams');
 
   const mutation = useTeamsControllerCreateTeam({
     mutation: {
       onSuccess: () => {
-        void queryClient.invalidateQueries({
-          queryKey: getTeamsControllerListTeamsQueryKey(),
-        });
         showSuccess(t('teams.createTeam.success'));
         onSuccess?.();
       },
@@ -35,6 +34,12 @@ export function useCreateTeam(onSuccess?: () => void) {
         } catch {
           showError(t('teams.createTeam.error'));
         }
+      },
+      onSettled: () => {
+        void queryClient.invalidateQueries({
+          queryKey: getTeamsControllerListTeamsQueryKey(),
+        });
+        void router.invalidate();
       },
     },
   });

--- a/ayunis-core-frontend/src/pages/prompts/api/useDeletePrompt.ts
+++ b/ayunis-core-frontend/src/pages/prompts/api/useDeletePrompt.ts
@@ -3,6 +3,7 @@ import {
   getPromptsControllerFindAllQueryKey,
 } from '@/shared/api/generated/ayunisCoreAPI';
 import { useQueryClient } from '@tanstack/react-query';
+import { useRouter } from '@tanstack/react-router';
 import { useTranslation } from 'react-i18next';
 import { showError, showSuccess } from '@/shared/lib/toast';
 import extractErrorData from '@/shared/api/extract-error-data';
@@ -10,6 +11,7 @@ import extractErrorData from '@/shared/api/extract-error-data';
 export function useDeletePrompt() {
   const { t } = useTranslation('prompts');
   const queryClient = useQueryClient();
+  const router = useRouter();
 
   return usePromptsControllerDelete({
     mutation: {
@@ -37,6 +39,7 @@ export function useDeletePrompt() {
         void queryClient.invalidateQueries({
           queryKey: getPromptsControllerFindAllQueryKey(),
         });
+        void router.invalidate();
       },
     },
   });


### PR DESCRIPTION
Fixes UI data reactivity for teams and prompts lists and corrects backend error handling for team retrieval.

The frontend fixes address issues where lists using `Route.useLoaderData()` were not updating after create/delete operations, requiring `router.invalidate()` in addition to `queryClient.invalidateQueries()`. The backend fix ensures `findById` throws `TeamRetrievalFailedError` on database errors, aligning with other repository methods and providing a semantically correct HTTP 500 response instead of a 404.

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Improves error semantics and UI data freshness.
> 
> - Backend: In `local-teams.repository.ts`, `findById` now throws `TeamRetrievalFailedError` on exceptions instead of `TeamNotFoundError`, aligning with other retrieval methods and avoiding false 404s.
> - Frontend: In `useCreateTeam` and `useDeletePrompt`, move cache refresh to `onSettled` and add `router.invalidate()` alongside `queryClient.invalidateQueries()` to ensure lists using `Route.useLoaderData()` update after create/delete.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bc4a04303e679c797d36b5d13c67ad6460282384. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->