### PR TITLE
fix: team name input normalization AYC-55

### DIFF
--- a/ayunis-core-backend/src/iam/teams/application/use-cases/create-team/create-team.use-case.ts
+++ b/ayunis-core-backend/src/iam/teams/application/use-cases/create-team/create-team.use-case.ts
@@ -26,29 +26,31 @@ export class CreateTeamUseCase {
       throw new UnauthorizedAccessError();
     }
 
-    this.logger.log('createTeam', { name: command.name, orgId });
+    const trimmedName = command.name?.trim() || '';
 
-    if (!command.name || command.name.trim() === '') {
+    this.logger.log('createTeam', { name: trimmedName, orgId });
+
+    if (!trimmedName) {
       this.logger.warn('Attempted to create team with empty name');
       throw new TeamCreationFailedError('Team name cannot be empty');
     }
 
     try {
       const existingTeam = await this.teamsRepository.findByNameAndOrgId(
-        command.name,
+        trimmedName,
         orgId,
       );
 
       if (existingTeam) {
         this.logger.warn('Team with this name already exists', {
-          name: command.name,
+          name: trimmedName,
           orgId,
         });
-        throw new TeamNameAlreadyExistsError(command.name);
+        throw new TeamNameAlreadyExistsError(trimmedName);
       }
 
-      this.logger.debug('Creating new team', { name: command.name, orgId });
-      const team = new Team({ name: command.name, orgId });
+      this.logger.debug('Creating new team', { name: trimmedName, orgId });
+      const team = new Team({ name: trimmedName, orgId });
       const createdTeam = await this.teamsRepository.create(team);
       this.logger.debug('Team created successfully', {
         id: createdTeam.id,

--- a/ayunis-core-frontend/src/pages/admin-settings/teams-settings/ui/CreateTeamDialog.tsx
+++ b/ayunis-core-frontend/src/pages/admin-settings/teams-settings/ui/CreateTeamDialog.tsx
@@ -68,10 +68,9 @@ export function CreateTeamDialog({
                 placeholder={t('teams.createDialog.namePlaceholder')}
                 {...register('name', {
                   required: t('teams.createDialog.nameRequired'),
-                  minLength: {
-                    value: 1,
-                    message: t('teams.createDialog.nameRequired'),
-                  },
+                  validate: (value) =>
+                    value.trim().length >= 1 ||
+                    t('teams.createDialog.nameRequired'),
                   maxLength: {
                     value: 100,
                     message: t('teams.createDialog.nameTooLong'),


### PR DESCRIPTION
Normalize team name handling to prevent duplicate entries and improve frontend validation.

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Ensures team names are trimmed and validated consistently across backend and frontend to prevent duplicates and empty/whitespace-only names.
> 
> - Backend `CreateTeamUseCase`: trim `command.name` to `trimmedName`, reject empty after trim, use trimmed value for dedupe lookup, error messages, logging, and creation
> - Frontend `CreateTeamDialog`: replace minLength with trim-based validator to reject whitespace-only names; keep 100-char max length
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ced2b800eeb7fc8119cf9d6353c93a3b1acd29ba. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->