### PR TITLE
feat: use mistral document ai for pdf parsing

### DIFF
--- a/ayunis-core-backend/src/domain/retrievers/file-retrievers/application/use-cases/retrieve-file-content/retrieve-file-content.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/retrievers/file-retrievers/application/use-cases/retrieve-file-content/retrieve-file-content.use-case.spec.ts
@@ -56,8 +56,8 @@ describe('ProcessFileUseCase', () => {
   it('should process file successfully', async () => {
     const command = new RetrieveFileContentCommand({
       fileData: Buffer.from('test file content'),
-      fileName: 'test.txt',
-      fileType: 'text/plain',
+      fileName: 'test.pdf',
+      fileType: 'application/pdf',
     });
     const expectedResult = new FileRetrieverResult([
       new FileRetrieverPage('processed content', 1),

--- a/ayunis-core-backend/src/domain/retrievers/file-retrievers/file-retriever.module.ts
+++ b/ayunis-core-backend/src/domain/retrievers/file-retrievers/file-retriever.module.ts
@@ -21,17 +21,22 @@ import retrievalConfig from 'src/config/retrieval.config';
       useFactory: (
         npmPdfParseHandler: NpmPdfParseFileRetrieverHandler,
         doclingHandler: DoclingFileRetrieverHandler,
+        mistralHandler: MistralFileRetrieverHandler,
       ) => {
         const registry = new FileRetrieverRegistry();
-        // Note: MistralFileRetrieverHandler not registered - requires permitted provider check
         registry.registerHandler(
           FileRetrieverType.NPM_PDF_PARSE,
           npmPdfParseHandler,
         );
         registry.registerHandler(FileRetrieverType.DOCLING, doclingHandler);
+        registry.registerHandler(FileRetrieverType.MISTRAL, mistralHandler);
         return registry;
       },
-      inject: [NpmPdfParseFileRetrieverHandler, DoclingFileRetrieverHandler],
+      inject: [
+        NpmPdfParseFileRetrieverHandler,
+        DoclingFileRetrieverHandler,
+        MistralFileRetrieverHandler,
+      ],
     },
   ],
   exports: [RetrieveFileContentUseCase, FileRetrieverRegistry],

--- a/ayunis-core-backend/src/domain/retrievers/file-retrievers/infrastructure/adapters/mistral-file-retriever.handler.ts
+++ b/ayunis-core-backend/src/domain/retrievers/file-retrievers/infrastructure/adapters/mistral-file-retriever.handler.ts
@@ -19,11 +19,14 @@ export class MistralFileRetrieverHandler extends FileRetrieverHandler {
   private readonly logger = new Logger(MistralFileRetrieverHandler.name);
   private readonly client: Mistral;
   private readonly MODEL_NAME = 'mistral-ocr-latest';
+  // 5 minutes timeout for large document OCR processing
+  private readonly TIMEOUT_MS = 5 * 60 * 1000;
 
   constructor(private readonly configService: ConfigService) {
     super();
     this.client = new Mistral({
       apiKey: this.configService.get('retrieval.mistral.apiKey'),
+      timeoutMs: this.TIMEOUT_MS,
     });
   }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces Mistral OCR as the primary PDF parser with structured fallbacks and stricter type handling.
> 
> - Update handler selection in `retrieve-file-content.use-case`: `pdf` → `MISTRAL` (if API key) → `DOCLING` → `NPM_PDF_PARSE`; `docx/pptx` → `DOCLING` only; others throw `InvalidFileTypeError`
> - Register `MistralFileRetrieverHandler` in `FileRetrieverModule` and inject into `FileRetrieverRegistry`
> - Add 5-minute timeout to Mistral client in `mistral-file-retriever.handler`
> - Adjust unit test to use a PDF input
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3cfc16df303a3577c4c05e16b11000a8f4d36ba1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->