### PR TITLE
ci: improve deployment slack message

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -94,10 +94,23 @@ jobs:
           HTML_URL: ${{ needs.release-please.outputs.html_url }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         run: |
+          # Convert GitHub Markdown to Slack mrkdwn format
+          SLACK_BODY=$(echo "$BODY" | \
+            # Remove the version header line (## [x.x.x](url) (date)) - we show this in the header already
+            sed '/^## \[/d' | \
+            # Convert ### headers to bold
+            sed 's/^### \(.*\)/*\1*/g' | \
+            # Convert markdown links [text](url) to Slack format <url|text>
+            sed 's/\[\([^]]*\)\](\([^)]*\))/<\2|\1>/g' | \
+            # Convert bullet points to proper bullets
+            sed 's/^\* /• /g' | \
+            # Remove empty lines at the start
+            sed '/./,$!d')
+
           # Build JSON payload using jq (properly escapes all special characters)
           PAYLOAD=$(jq -n \
             --arg tag "$TAG_NAME" \
-            --arg body "$BODY" \
+            --arg body "$SLACK_BODY" \
             --arg url "$HTML_URL" \
             '{
               blocks: [

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -107,6 +107,16 @@ jobs:
             # Remove empty lines at the start
             sed '/./,$!d')
 
+          # Fallback if body is empty after processing
+          if [ -z "$SLACK_BODY" ]; then
+            SLACK_BODY="No changelog entries."
+          fi
+
+          # Truncate if exceeding Slack's 3000 char limit for section blocks
+          if [ ${#SLACK_BODY} -gt 2900 ]; then
+            SLACK_BODY="${SLACK_BODY:0:2900}..."
+          fi
+
           # Build JSON payload using jq (properly escapes all special characters)
           PAYLOAD=$(jq -n \
             --arg tag "$TAG_NAME" \


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Improves the release Slack notification formatting and robustness.
> 
> - Transforms GitHub changelog markdown to Slack `mrkdwn` (remove version header, make `###` bold, convert `[text](url)` links, and normalize bullets)
> - Adds fallback when the body is empty and truncates messages to ~2900 chars to respect Slack limits
> - Uses the processed `SLACK_BODY` in the JSON payload instead of the raw body
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b9e72b692028ea6f42df86b352c041a640e09a88. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->