### PR TITLE
fix: improve help texts when password reset link expired

### DIFF
--- a/ayunis-core-backend/src/common/email-templates/domain/email-template.entity.ts
+++ b/ayunis-core-backend/src/common/email-templates/domain/email-template.entity.ts
@@ -25,6 +25,7 @@ export interface InvitationTemplateContent {
 
 export interface PasswordResetTemplateContent {
   resetUrl: string;
+  forgotPasswordUrl: string;
   userEmail: string;
   companyName: string;
   productName: string;
@@ -60,6 +61,7 @@ export class PasswordResetTemplate extends EmailTemplate {
   constructor(public readonly content: PasswordResetTemplateContent) {
     super(EmailTemplateType.PASSWORD_RESET, {
       resetUrl: content.resetUrl,
+      forgotPasswordUrl: content.forgotPasswordUrl,
       userEmail: content.userEmail,
       companyName: content.companyName,
       productName: content.productName,

--- a/ayunis-core-backend/src/common/email-templates/infrastructure/mjml/templates/password-reset.template.ts
+++ b/ayunis-core-backend/src/common/email-templates/infrastructure/mjml/templates/password-reset.template.ts
@@ -16,15 +16,16 @@ export function passwordResetText(template: PasswordResetTemplateContent) {
 
   ${template.resetUrl}
 
+  Link abgelaufen? Neue E-Mail anfordern: ${template.forgotPasswordUrl}
+
   Dieser Link läuft in 24 Stunden ab. Falls Sie diese Anfrage nicht gestellt haben, können Sie diese E-Mail ignorieren.
 
   Aus Sicherheitsgründen wird dieser Link nur einmal funktionieren. Nach dem Klicken können Sie ein neues Passwort festlegen.
 
-  Link abgelaufen? Falls der Link nicht mehr funktioniert, können Sie einfach eine neue E-Mail anfordern: ${template.forgotPasswordUrl}
-
   Diese E-Mail wurde gesendet an ${template.userEmail}
 
-  Bei Fragen wenden Sie sich bitte an unser Support-Team unter help@ayunis.com
+  Probleme beim Zurücksetzen? Versuchen Sie, eine neue E-Mail anzufordern: ${template.forgotPasswordUrl}
+  Falls das Problem weiterhin besteht, wenden Sie sich bitte an unser Support-Team unter help@ayunis.com
 
   ${template.currentYear} ${template.companyName} . Alle Rechte vorbehalten.
   `;
@@ -84,6 +85,10 @@ export function passwordResetHtml(template: PasswordResetTemplateContent) {
           Passwort zurücksetzen
         </mj-button>
 
+        <mj-text color="#6b7280" font-size="12px" align="center" padding-top="12px">
+          Link abgelaufen? <a href="${template.forgotPasswordUrl}" style="color: #7c3aed; text-decoration: underline;">Neue E-Mail anfordern</a>
+        </mj-text>
+
       </mj-column>
     </mj-section>
 
@@ -96,20 +101,11 @@ export function passwordResetHtml(template: PasswordResetTemplateContent) {
       </mj-column>
     </mj-section>
 
-    <!-- Expired Link Hint -->
-    <mj-section background-color="#f5f3ff" padding="20px 24px">
-      <mj-column>
-        <mj-text color="#5b21b6" font-size="14px" align="center">
-          <strong>Link abgelaufen?</strong> Falls der Link nicht mehr funktioniert, können Sie einfach <a href="${template.forgotPasswordUrl}" style="color: #7c3aed; text-decoration: underline;">eine neue E-Mail anfordern</a>.
-        </mj-text>
-      </mj-column>
-    </mj-section>
-
     <!-- Help Section -->
     <mj-section background-color="#f0f9ff" padding="20px 24px">
       <mj-column>
         <mj-text color="#1e40af" font-size="14px" align="center">
-          <strong>Probleme beim Zurücksetzen?</strong> Falls Sie weiterhin Schwierigkeiten haben, wenden Sie sich bitte an unser Support-Team unter help@ayunis.com
+          <strong>Probleme beim Zurücksetzen?</strong> Versuchen Sie, <a href="${template.forgotPasswordUrl}" style="color: #2563eb; text-decoration: underline;">eine neue E-Mail anzufordern</a>. Falls das Problem weiterhin besteht, wenden Sie sich bitte an unser Support-Team unter help@ayunis.com
         </mj-text>
       </mj-column>
     </mj-section>

--- a/ayunis-core-backend/src/common/email-templates/infrastructure/mjml/templates/password-reset.template.ts
+++ b/ayunis-core-backend/src/common/email-templates/infrastructure/mjml/templates/password-reset.template.ts
@@ -20,6 +20,8 @@ export function passwordResetText(template: PasswordResetTemplateContent) {
 
   Aus Sicherheitsgründen wird dieser Link nur einmal funktionieren. Nach dem Klicken können Sie ein neues Passwort festlegen.
 
+  Link abgelaufen? Falls der Link nicht mehr funktioniert, können Sie einfach eine neue E-Mail anfordern: ${template.forgotPasswordUrl}
+
   Diese E-Mail wurde gesendet an ${template.userEmail}
 
   Bei Fragen wenden Sie sich bitte an unser Support-Team unter help@ayunis.com
@@ -90,6 +92,15 @@ export function passwordResetHtml(template: PasswordResetTemplateContent) {
       <mj-column>
         <mj-text color="#92400e" font-size="14px" align="center">
           <strong>Wichtiger Sicherheitshinweis:</strong> Dieser Link läuft in 24 Stunden ab und kann nur einmal verwendet werden. Falls Sie diese Anfrage nicht gestellt haben, können Sie diese E-Mail ignorieren.
+        </mj-text>
+      </mj-column>
+    </mj-section>
+
+    <!-- Expired Link Hint -->
+    <mj-section background-color="#f5f3ff" padding="20px 24px">
+      <mj-column>
+        <mj-text color="#5b21b6" font-size="14px" align="center">
+          <strong>Link abgelaufen?</strong> Falls der Link nicht mehr funktioniert, können Sie einfach <a href="${template.forgotPasswordUrl}" style="color: #7c3aed; text-decoration: underline;">eine neue E-Mail anfordern</a>.
         </mj-text>
       </mj-column>
     </mj-section>

--- a/ayunis-core-backend/src/config/app.config.ts
+++ b/ayunis-core-backend/src/config/app.config.ts
@@ -11,6 +11,8 @@ export const appConfig = registerAs('app', () => ({
       process.env.EMAIL_CONFIRM_ENDPOINT || '/confirm-email',
     passwordResetEndpoint:
       process.env.PASSWORD_RESET_ENDPOINT || '/password/reset',
+    forgotPasswordEndpoint:
+      process.env.FORGOT_PASSWORD_ENDPOINT || '/password/forgot',
     inviteAcceptEndpoint:
       process.env.INVITE_ACCEPT_ENDPOINT || '/accept-invite',
   },

--- a/ayunis-core-backend/src/iam/users/application/use-cases/send-password-reset-email/send-password-reset-email.use-case.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/send-password-reset-email/send-password-reset-email.use-case.ts
@@ -34,6 +34,7 @@ export class SendPasswordResetEmailUseCase {
         'app.frontend.passwordResetEndpoint',
       );
       const resetUrl = `${frontendBaseUrl}${passwordResetEndpoint}?token=${command.resetToken}`;
+      const forgotPasswordUrl = `${frontendBaseUrl}/password/forgot`;
 
       // Create password reset email template
       this.logger.debug('Creating password reset email template', {
@@ -41,6 +42,7 @@ export class SendPasswordResetEmailUseCase {
       });
       const template = new PasswordResetTemplate({
         resetUrl,
+        forgotPasswordUrl,
         userEmail: command.userEmail,
         companyName: 'Ayunis',
         productName: 'Ayunis Core',

--- a/ayunis-core-backend/src/iam/users/application/use-cases/send-password-reset-email/send-password-reset-email.use-case.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/send-password-reset-email/send-password-reset-email.use-case.ts
@@ -33,8 +33,11 @@ export class SendPasswordResetEmailUseCase {
       const passwordResetEndpoint = this.configService.get<string>(
         'app.frontend.passwordResetEndpoint',
       );
+      const forgotPasswordEndpoint = this.configService.get<string>(
+        'app.frontend.forgotPasswordEndpoint',
+      );
       const resetUrl = `${frontendBaseUrl}${passwordResetEndpoint}?token=${command.resetToken}`;
-      const forgotPasswordUrl = `${frontendBaseUrl}/password/forgot`;
+      const forgotPasswordUrl = `${frontendBaseUrl}${forgotPasswordEndpoint}`;
 
       // Create password reset email template
       this.logger.debug('Creating password reset email template', {


### PR DESCRIPTION
Add a hint to the password reset email to guide users on requesting a new link if the current one has expired.

---
<a href="https://cursor.com/background-agent?bcId=bc-41882b27-98fb-4a6f-88f1-d175b23dc279"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-41882b27-98fb-4a6f-88f1-d175b23dc279"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enhances password reset emails with an explicit path to request a new link and wires config to generate that URL.
> 
> - Adds `forgotPasswordUrl` to `PasswordResetTemplateContent` and passes it through `PasswordResetTemplate`
> - Updates text/MJML templates for password reset to include “request new email” links and guidance
> - Introduces `frontend.forgotPasswordEndpoint` in `app.config.ts` (with env override) and uses it in `SendPasswordResetEmailUseCase` to build `forgotPasswordUrl`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6af51f8c815795d8f98985dfa5c2832757edc57e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->