### PR TITLE
Forgot password URL configuration

### DIFF
--- a/ayunis-core-backend/src/config/app.config.ts
+++ b/ayunis-core-backend/src/config/app.config.ts
@@ -11,6 +11,8 @@ export const appConfig = registerAs('app', () => ({
       process.env.EMAIL_CONFIRM_ENDPOINT || '/confirm-email',
     passwordResetEndpoint:
       process.env.PASSWORD_RESET_ENDPOINT || '/password/reset',
+    forgotPasswordEndpoint:
+      process.env.FORGOT_PASSWORD_ENDPOINT || '/password/forgot',
     inviteAcceptEndpoint:
       process.env.INVITE_ACCEPT_ENDPOINT || '/accept-invite',
   },

--- a/ayunis-core-backend/src/iam/users/application/use-cases/send-password-reset-email/send-password-reset-email.use-case.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/send-password-reset-email/send-password-reset-email.use-case.ts
@@ -33,8 +33,11 @@ export class SendPasswordResetEmailUseCase {
       const passwordResetEndpoint = this.configService.get<string>(
         'app.frontend.passwordResetEndpoint',
       );
+      const forgotPasswordEndpoint = this.configService.get<string>(
+        'app.frontend.forgotPasswordEndpoint',
+      );
       const resetUrl = `${frontendBaseUrl}${passwordResetEndpoint}?token=${command.resetToken}`;
-      const forgotPasswordUrl = `${frontendBaseUrl}/password/forgot`;
+      const forgotPasswordUrl = `${frontendBaseUrl}${forgotPasswordEndpoint}`;
 
       // Create password reset email template
       this.logger.debug('Creating password reset email template', {


### PR DESCRIPTION
Make the forgot password URL configurable to align with existing frontend endpoint configuration patterns.

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds configuration to control the "forgot password" link used in password reset emails.
> 
> - Introduces `app.frontend.forgotPasswordEndpoint` (env: `FORGOT_PASSWORD_ENDPOINT`, default: `/password/forgot`) in `app.config.ts`
> - Updates `send-password-reset-email.use-case.ts` to build `forgotPasswordUrl` from config instead of a hardcoded path; `resetUrl` still uses `passwordResetEndpoint`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 81a68ad2403e0c1ac6fccf8361f9d964aaf44de7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->