### PR TITLE
ci: trigger docs update after deploy

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -162,7 +162,7 @@ jobs:
   trigger-docs-update:
     name: Trigger Docs Update
     runs-on: ubuntu-latest
-    needs: [release-please, deploy-production, notify-slack]
+    needs: [release-please, deploy-production]
     if: ${{ needs.release-please.outputs.releases_created == 'true' }}
     steps:
       - name: Trigger docs update workflow

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -158,3 +158,16 @@ jobs:
             -H 'Content-Type: application/json' \
             -d "$PAYLOAD" \
             "$SLACK_WEBHOOK_URL"
+
+  trigger-docs-update:
+    name: Trigger Docs Update
+    runs-on: ubuntu-latest
+    needs: [release-please, deploy-production, notify-slack]
+    if: ${{ needs.release-please.outputs.releases_created == 'true' }}
+    steps:
+      - name: Trigger docs update workflow
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.DOCS_REPO_PAT }}
+          repository: ayunis/ayunis-core-docs
+          event-type: release-published


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a post-deploy docs update step to the Release Please workflow.
> 
> - New `trigger-docs-update` job runs after `release-please` and `deploy-production` when a release is created
> - Uses `peter-evans/repository-dispatch@v3` with `DOCS_REPO_PAT` to send `release-published` event to `ayunis/ayunis-core-docs`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2de1a0eb42fb70692badcf12d859dc0d507b2c14. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->