### PR TITLE
ci: fix release workflow docs dependency

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -162,7 +162,7 @@ jobs:
   trigger-docs-update:
     name: Trigger Docs Update
     runs-on: ubuntu-latest
-    needs: [release-please, deploy-production, notify-slack]
+    needs: [release-please, deploy-production]
     if: ${{ needs.release-please.outputs.releases_created == 'true' }}
     steps:
       - name: Trigger docs update workflow


### PR DESCRIPTION
Remove `notify-slack` from `trigger-docs-update` job's `needs` to prevent docs updates from being blocked by notification failures.

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Removes unnecessary dependency to ensure docs updates run independently of Slack notifications.
> 
> - In `.github/workflows/release-please.yml`, `trigger-docs-update` now needs only `release-please` and `deploy-production` (drops `notify-slack`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 52cca31a3ec4a2c72311f91b402be937ca252efd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->