### PR TITLE
refactor: simplify model cleanup in threads AYC-000

### DIFF
--- a/ayunis-core-backend/src/db/migrations/1769677228515-RenameModelIdToPermittedModelId.ts
+++ b/ayunis-core-backend/src/db/migrations/1769677228515-RenameModelIdToPermittedModelId.ts
@@ -1,0 +1,37 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class RenameModelIdToPermittedModelId1769677228515
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Drop the existing index on modelId
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_threads_modelId"`);
+
+    // Rename the column
+    await queryRunner.query(
+      `ALTER TABLE "threads" RENAME COLUMN "modelId" TO "permittedModelId"`,
+    );
+
+    // Recreate the index with the new column name
+    await queryRunner.query(
+      `CREATE INDEX "IDX_threads_permittedModelId" ON "threads" ("permittedModelId")`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    // Drop the index on permittedModelId
+    await queryRunner.query(
+      `DROP INDEX IF EXISTS "IDX_threads_permittedModelId"`,
+    );
+
+    // Rename the column back
+    await queryRunner.query(
+      `ALTER TABLE "threads" RENAME COLUMN "permittedModelId" TO "modelId"`,
+    );
+
+    // Recreate the original index
+    await queryRunner.query(
+      `CREATE INDEX "IDX_threads_modelId" ON "threads" ("modelId")`,
+    );
+  }
+}

--- a/ayunis-core-backend/src/domain/models/application/use-cases/delete-permitted-model/delete-permitted-model.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/delete-permitted-model/delete-permitted-model.use-case.ts
@@ -7,8 +7,6 @@ import {
   CannotDeleteLastModelError,
   UnexpectedModelError,
 } from '../../models.errors';
-import { ReplaceModelWithUserDefaultUseCase } from 'src/domain/threads/application/use-cases/replace-model-with-user-default/replace-model-with-user-default.use-case';
-import { ReplaceModelWithUserDefaultCommand } from 'src/domain/threads/application/use-cases/replace-model-with-user-default/replace-model-with-user-default.command';
 import { ReplaceModelWithUserDefaultUseCase as ReplaceModelWithUserDefaultUseCaseAgents } from 'src/domain/agents/application/use-cases/replace-model-with-user-default/replace-model-with-user-default.use-case';
 import { ReplaceModelWithUserDefaultCommand as ReplaceModelWithUserDefaultCommandAgents } from 'src/domain/agents/application/use-cases/replace-model-with-user-default/replace-model-with-user-default.command';
 import { DeleteUserDefaultModelsByModelIdUseCase } from '../delete-user-default-models-by-model-id/delete-user-default-models-by-model-id.use-case';
@@ -39,7 +37,6 @@ export class DeletePermittedModelUseCase {
     private readonly permittedModelsRepository: PermittedModelsRepository,
     private readonly deleteUserDefaultModelByModelIdUseCase: DeleteUserDefaultModelsByModelIdUseCase,
     private readonly getPermittedModelsUseCase: GetPermittedModelsUseCase,
-    private readonly replaceModelWithUserDefaultUseCase: ReplaceModelWithUserDefaultUseCase,
     private readonly replaceModelWithUserDefaultUseCaseAgents: ReplaceModelWithUserDefaultUseCaseAgents,
     private readonly findAllThreadsByOrgWithSourcesUseCase: FindAllThreadsByOrgWithSourcesUseCase,
     private readonly deleteSourcesUseCase: DeleteSourcesUseCase,
@@ -137,19 +134,8 @@ export class DeletePermittedModelUseCase {
       new DeleteUserDefaultModelsByModelIdCommand(model.id),
     );
 
-    this.logger.debug('Replacing model in all threads that use it', {
-      modelId: model.id,
-    });
-
-    // Replace the model in all threads that use it
-    // Because the user default model is deleted, this will fall back
-    // to the org default model or the first available model
-    await this.replaceModelWithUserDefaultUseCase.execute(
-      new ReplaceModelWithUserDefaultCommand({
-        orgId,
-        oldPermittedModelId: model.id,
-      }),
-    );
+    // Threads that use this model will show a warning at runtime
+    // when the user tries to continue the conversation (see ExecuteRunUseCase.pickModel)
 
     this.logger.debug('Replacing model in all agents that use it', {
       modelId: model.id,

--- a/ayunis-core-backend/src/domain/models/application/use-cases/is-model-permitted/is-model-permitted.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/is-model-permitted/is-model-permitted.use-case.ts
@@ -16,13 +16,19 @@ export class IsModelPermittedUseCase {
     const permittedModel = await this.permittedModelsRepository.findOne({
       id: query.modelId,
     });
+
+    // If model doesn't exist, it's not permitted (model was deleted)
+    if (!permittedModel) {
+      return false;
+    }
+
     const orgId = this.contextService.get('orgId');
     const systemRole = this.contextService.get('systemRole');
     const isSuperAdmin = systemRole === SystemRole.SUPER_ADMIN;
-    const isFromOrg = orgId === permittedModel?.orgId;
+    const isFromOrg = orgId === permittedModel.orgId;
     if (!isFromOrg && !isSuperAdmin) {
       throw new UnauthorizedAccessError();
     }
-    return !!permittedModel;
+    return true;
   }
 }

--- a/ayunis-core-backend/src/domain/runs/application/runs.errors.ts
+++ b/ayunis-core-backend/src/domain/runs/application/runs.errors.ts
@@ -19,6 +19,7 @@ export enum RunErrorCode {
   RUN_TOOL_EXECUTION_FAILED = 'RUN_TOOL_EXECUTION_FAILED',
   RUN_NO_MODEL_FOUND = 'RUN_NO_MODEL_FOUND',
   THREAD_AGENT_NO_LONGER_ACCESSIBLE = 'THREAD_AGENT_NO_LONGER_ACCESSIBLE',
+  THREAD_MODEL_NO_LONGER_ACCESSIBLE = 'THREAD_MODEL_NO_LONGER_ACCESSIBLE',
 }
 
 /**
@@ -151,6 +152,21 @@ export class ThreadAgentNoLongerAccessibleError extends RunError {
       RunErrorCode.THREAD_AGENT_NO_LONGER_ACCESSIBLE,
       403,
       { threadId, agentId, ...metadata },
+    );
+  }
+}
+
+/**
+ * Error thrown when the model used in a thread is no longer accessible
+ * (e.g., model was removed from the organization's permitted models)
+ */
+export class ThreadModelNoLongerAccessibleError extends RunError {
+  constructor(threadId: string, modelId: string, metadata?: ErrorMetadata) {
+    super(
+      `The model used in this conversation is no longer accessible.`,
+      RunErrorCode.THREAD_MODEL_NO_LONGER_ACCESSIBLE,
+      403,
+      { threadId, modelId, ...metadata },
     );
   }
 }

--- a/ayunis-core-backend/src/domain/runs/application/use-cases/execute-run/execute-run.use-case.ts
+++ b/ayunis-core-backend/src/domain/runs/application/use-cases/execute-run/execute-run.use-case.ts
@@ -392,6 +392,10 @@ export class ExecuteRunUseCase {
     if (agent) {
       return agent.model;
     }
+    // Check if the thread had a model but it was deleted (modelId exists but model is undefined)
+    if (thread.modelId && !thread.model) {
+      throw new ThreadModelNoLongerAccessibleError(thread.id, thread.modelId);
+    }
     if (thread.model) {
       // Verify the model is still permitted in the organization
       const isPermitted = await this.isModelPermittedUseCase.execute(

--- a/ayunis-core-backend/src/domain/runs/application/use-cases/execute-run/execute-run.use-case.ts
+++ b/ayunis-core-backend/src/domain/runs/application/use-cases/execute-run/execute-run.use-case.ts
@@ -392,9 +392,12 @@ export class ExecuteRunUseCase {
     if (agent) {
       return agent.model;
     }
-    // Check if the thread had a model but it was deleted (modelId exists but model is undefined)
-    if (thread.modelId && !thread.model) {
-      throw new ThreadModelNoLongerAccessibleError(thread.id, thread.modelId);
+    // Check if the thread had a model but it was deleted (permittedModelId exists but model is undefined)
+    if (thread.permittedModelId && !thread.model) {
+      throw new ThreadModelNoLongerAccessibleError(
+        thread.id,
+        thread.permittedModelId,
+      );
     }
     if (thread.model) {
       // Verify the model is still permitted in the organization

--- a/ayunis-core-backend/src/domain/threads/application/ports/threads.repository.ts
+++ b/ayunis-core-backend/src/domain/threads/application/ports/threads.repository.ts
@@ -29,7 +29,7 @@ export abstract class ThreadsRepository {
     pagination?: ThreadsPagination,
   ): Promise<Paginated<Thread>>;
   abstract findAllByModel(
-    modelId: UUID,
+    permittedModelId: UUID,
     options?: ThreadsFindAllOptions,
   ): Promise<Thread[]>;
   abstract findAllByAgent(

--- a/ayunis-core-backend/src/domain/threads/application/use-cases/create-thread/create-thread.command.ts
+++ b/ayunis-core-backend/src/domain/threads/application/use-cases/create-thread/create-thread.command.ts
@@ -1,20 +1,20 @@
 import { UUID } from 'crypto';
 
 export class CreateThreadCommand {
-  modelId?: UUID;
+  permittedModelId?: UUID;
   agentId?: UUID;
   title?: string;
   instruction?: string;
   isAnonymous?: boolean;
 
   constructor(params: {
-    modelId?: UUID;
+    permittedModelId?: UUID;
     agentId?: UUID;
     title?: string;
     instruction?: string;
     isAnonymous?: boolean;
   }) {
-    this.modelId = params.modelId;
+    this.permittedModelId = params.permittedModelId;
     this.agentId = params.agentId;
     this.title = params.title;
     this.instruction = params.instruction;

--- a/ayunis-core-backend/src/domain/threads/application/use-cases/create-thread/create-thread.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/threads/application/use-cases/create-thread/create-thread.use-case.spec.ts
@@ -85,7 +85,7 @@ describe('CreateThreadUseCase', () => {
     it('should create a thread with model successfully', async () => {
       // Arrange
       const command = new CreateThreadCommand({
-        modelId: mockModelId,
+        permittedModelId: mockModelId,
       });
 
       const now = new Date();
@@ -134,7 +134,7 @@ describe('CreateThreadUseCase', () => {
       // Assert
       expect(getModelExecuteSpy).toHaveBeenCalledWith(
         expect.objectContaining({
-          id: command.modelId,
+          id: command.permittedModelId,
         }),
       );
       expect(getAgentExecuteSpy).not.toHaveBeenCalled();
@@ -165,7 +165,7 @@ describe('CreateThreadUseCase', () => {
     it('should log execution details', async () => {
       // Arrange
       const command = new CreateThreadCommand({
-        modelId: mockModelId,
+        permittedModelId: mockModelId,
       });
 
       const now = new Date();
@@ -219,7 +219,7 @@ describe('CreateThreadUseCase', () => {
     it('should handle repository creation errors', async () => {
       // Arrange
       const command = new CreateThreadCommand({
-        modelId: mockModelId,
+        permittedModelId: mockModelId,
       });
 
       const now = new Date();

--- a/ayunis-core-backend/src/domain/threads/application/use-cases/create-thread/create-thread.use-case.ts
+++ b/ayunis-core-backend/src/domain/threads/application/use-cases/create-thread/create-thread.use-case.ts
@@ -39,10 +39,10 @@ export class CreateThreadUseCase {
       let agent: Agent | undefined;
       let agentId: UUID | undefined;
 
-      if (command.modelId) {
+      if (command.permittedModelId) {
         model = await this.getPermittedLanguageModelUseCase.execute(
           new GetPermittedLanguageModelQuery({
-            id: command.modelId,
+            id: command.permittedModelId,
           }),
         );
       }

--- a/ayunis-core-backend/src/domain/threads/domain/thread.entity.ts
+++ b/ayunis-core-backend/src/domain/threads/domain/thread.entity.ts
@@ -6,7 +6,7 @@ import { SourceAssignment } from './thread-source-assignment.entity';
 export class Thread {
   id: UUID;
   userId: UUID;
-  modelId?: UUID;
+  permittedModelId?: UUID;
   model?: PermittedLanguageModel;
   agentId?: UUID;
   sourceAssignments?: SourceAssignment[];
@@ -19,7 +19,7 @@ export class Thread {
   constructor(params: {
     id?: UUID;
     userId: UUID;
-    modelId?: UUID;
+    permittedModelId?: UUID;
     model?: PermittedLanguageModel;
     agentId?: UUID;
     sourceAssignments?: SourceAssignment[];
@@ -31,7 +31,7 @@ export class Thread {
   }) {
     this.id = params.id ?? randomUUID();
     this.userId = params.userId;
-    this.modelId = params.modelId;
+    this.permittedModelId = params.permittedModelId;
     this.model = params.model;
     this.agentId = params.agentId;
     this.sourceAssignments = params.sourceAssignments;

--- a/ayunis-core-backend/src/domain/threads/domain/thread.entity.ts
+++ b/ayunis-core-backend/src/domain/threads/domain/thread.entity.ts
@@ -6,6 +6,7 @@ import { SourceAssignment } from './thread-source-assignment.entity';
 export class Thread {
   id: UUID;
   userId: UUID;
+  modelId?: UUID;
   model?: PermittedLanguageModel;
   agentId?: UUID;
   sourceAssignments?: SourceAssignment[];
@@ -18,6 +19,7 @@ export class Thread {
   constructor(params: {
     id?: UUID;
     userId: UUID;
+    modelId?: UUID;
     model?: PermittedLanguageModel;
     agentId?: UUID;
     sourceAssignments?: SourceAssignment[];
@@ -29,6 +31,7 @@ export class Thread {
   }) {
     this.id = params.id ?? randomUUID();
     this.userId = params.userId;
+    this.modelId = params.modelId;
     this.model = params.model;
     this.agentId = params.agentId;
     this.sourceAssignments = params.sourceAssignments;

--- a/ayunis-core-backend/src/domain/threads/infrastructure/persistence/local/local-threads.repository.ts
+++ b/ayunis-core-backend/src/domain/threads/infrastructure/persistence/local/local-threads.repository.ts
@@ -161,12 +161,12 @@ export class LocalThreadsRepository extends ThreadsRepository {
   }
 
   async findAllByModel(
-    modelId: UUID,
+    permittedModelId: UUID,
     options?: ThreadsFindAllOptions,
   ): Promise<Thread[]> {
-    this.logger.log('findAllByModel', { modelId });
+    this.logger.log('findAllByModel', { permittedModelId });
     const threadEntities = await this.threadRepository.find({
-      where: { modelId },
+      where: { permittedModelId },
       relations: this.getRelations(options),
       order: options?.withMessages
         ? {
@@ -291,7 +291,7 @@ export class LocalThreadsRepository extends ThreadsRepository {
       .createQueryBuilder()
       .update(ThreadRecord)
       .set({
-        modelId: params.permittedModelId,
+        permittedModelId: params.permittedModelId,
         agentId: () => 'NULL',
       })
       .where('id = :threadId AND userId = :userId', {

--- a/ayunis-core-backend/src/domain/threads/infrastructure/persistence/local/mappers/thread.mapper.ts
+++ b/ayunis-core-backend/src/domain/threads/infrastructure/persistence/local/mappers/thread.mapper.ts
@@ -18,7 +18,7 @@ export class ThreadMapper {
     const record = new ThreadRecord();
     record.id = thread.id;
     record.userId = thread.userId;
-    record.modelId = thread.modelId ?? thread.model?.id;
+    record.permittedModelId = thread.permittedModelId ?? thread.model?.id;
     record.model = thread.model
       ? this.permittedModelMapper.toRecord(thread.model)
       : undefined;
@@ -40,9 +40,9 @@ export class ThreadMapper {
     return new Thread({
       id: threadEntity.id,
       userId: threadEntity.userId,
-      modelId: threadEntity.modelId,
+      permittedModelId: threadEntity.permittedModelId,
       model:
-        threadEntity.modelId && threadEntity.model
+        threadEntity.permittedModelId && threadEntity.model
           ? (this.permittedModelMapper.toDomain(
               threadEntity.model,
             ) as PermittedLanguageModel)

--- a/ayunis-core-backend/src/domain/threads/infrastructure/persistence/local/mappers/thread.mapper.ts
+++ b/ayunis-core-backend/src/domain/threads/infrastructure/persistence/local/mappers/thread.mapper.ts
@@ -18,7 +18,7 @@ export class ThreadMapper {
     const record = new ThreadRecord();
     record.id = thread.id;
     record.userId = thread.userId;
-    record.modelId = thread.model?.id;
+    record.modelId = thread.modelId ?? thread.model?.id;
     record.model = thread.model
       ? this.permittedModelMapper.toRecord(thread.model)
       : undefined;
@@ -40,6 +40,7 @@ export class ThreadMapper {
     return new Thread({
       id: threadEntity.id,
       userId: threadEntity.userId,
+      modelId: threadEntity.modelId,
       model:
         threadEntity.modelId && threadEntity.model
           ? (this.permittedModelMapper.toDomain(

--- a/ayunis-core-backend/src/domain/threads/infrastructure/persistence/local/schema/thread.record.ts
+++ b/ayunis-core-backend/src/domain/threads/infrastructure/persistence/local/schema/thread.record.ts
@@ -1,6 +1,13 @@
 import { UUID } from 'crypto';
 import { MessageRecord } from '../../../../../messages/infrastructure/persistence/local/schema/message.record';
-import { Column, Entity, OneToMany, Index, ManyToOne } from 'typeorm';
+import {
+  Column,
+  Entity,
+  OneToMany,
+  Index,
+  ManyToOne,
+  JoinColumn,
+} from 'typeorm';
 import { BaseRecord } from '../../../../../../common/db/base-record';
 import { PermittedModelRecord } from '../../../../../models/infrastructure/persistence/local-permitted-models/schema/permitted-model.record';
 import { AgentRecord } from '../../../../../agents/infrastructure/persistence/local/schema/agent.record';
@@ -14,9 +21,12 @@ export class ThreadRecord extends BaseRecord {
 
   @Column({ nullable: true })
   @Index()
-  modelId?: UUID;
+  permittedModelId?: UUID;
 
-  @ManyToOne(() => PermittedModelRecord, { onDelete: 'SET NULL' })
+  @ManyToOne(() => PermittedModelRecord, {
+    onDelete: 'SET NULL',
+  })
+  @JoinColumn({ name: 'permittedModelId' })
   model?: PermittedModelRecord;
 
   @Column({ nullable: true })

--- a/ayunis-core-backend/src/domain/threads/presenters/http/dto/create-thread.dto.ts
+++ b/ayunis-core-backend/src/domain/threads/presenters/http/dto/create-thread.dto.ts
@@ -4,14 +4,14 @@ import { UUID } from 'crypto';
 
 export class CreateThreadDto {
   @ApiPropertyOptional({
-    description: 'The id of the model',
+    description: 'The id of the permitted model',
     example: '123e4567-e89b-12d3-a456-426614174000',
     type: 'string',
     format: 'uuid',
   })
   @IsUUID()
   @IsOptional()
-  modelId?: UUID;
+  permittedModelId?: UUID;
 
   @ApiPropertyOptional({
     description: 'The id of the agent',

--- a/ayunis-core-backend/src/domain/threads/presenters/http/threads.controller.ts
+++ b/ayunis-core-backend/src/domain/threads/presenters/http/threads.controller.ts
@@ -129,11 +129,11 @@ export class ThreadsController {
     @Body() createThreadDto: CreateThreadDto,
   ): Promise<GetThreadResponseDto> {
     this.logger.log('create', {
-      modelId: createThreadDto.modelId,
+      permittedModelId: createThreadDto.permittedModelId,
     });
     const thread = await this.createThreadUseCase.execute(
       new CreateThreadCommand({
-        modelId: createThreadDto.modelId,
+        permittedModelId: createThreadDto.permittedModelId,
         agentId: createThreadDto.agentId,
         isAnonymous: createThreadDto.isAnonymous,
       }),

--- a/ayunis-core-frontend/src/pages/chat/ui/ChatPage.tsx
+++ b/ayunis-core-frontend/src/pages/chat/ui/ChatPage.tsx
@@ -214,7 +214,7 @@ export default function ChatPage({
           void queryClient.invalidateQueries({
             queryKey: getThreadsControllerFindOneQueryKey(thread.id),
           });
-          showError(t('chat.unavailableAgentWarningTitle'));
+          showError(t('chat.unavailableModelWarningTitle'));
           break;
         case 'QUOTA_EXCEEDED': {
           const retryMinutes = error.details?.retryAfterSeconds

--- a/ayunis-core-frontend/src/pages/chat/ui/ChatPage.tsx
+++ b/ayunis-core-frontend/src/pages/chat/ui/ChatPage.tsx
@@ -47,6 +47,7 @@ import {
   getThreadsControllerFindAllQueryKey,
   getThreadsControllerFindOneQueryKey,
   getAgentsControllerFindAllQueryKey,
+  getModelsControllerGetPermittedLanguageModelsQueryKey,
   threadsControllerFindOne,
   threadsControllerDownloadSource,
 } from '@/shared/api/generated/ayunisCoreAPI';
@@ -199,6 +200,16 @@ export default function ChatPage({
           // Refresh the agents list and thread to show the warning
           void queryClient.invalidateQueries({
             queryKey: getAgentsControllerFindAllQueryKey(),
+          });
+          void queryClient.invalidateQueries({
+            queryKey: getThreadsControllerFindOneQueryKey(thread.id),
+          });
+          showError(t('chat.unavailableAgentWarningTitle'));
+          break;
+        case 'THREAD_MODEL_NO_LONGER_ACCESSIBLE':
+          // Refresh the models list and thread to show the warning
+          void queryClient.invalidateQueries({
+            queryKey: getModelsControllerGetPermittedLanguageModelsQueryKey(),
           });
           void queryClient.invalidateQueries({
             queryKey: getThreadsControllerFindOneQueryKey(thread.id),

--- a/ayunis-core-frontend/src/shared/locales/de/chat.json
+++ b/ayunis-core-frontend/src/shared/locales/de/chat.json
@@ -65,6 +65,7 @@
     "longChatWarningDescription": "Für bessere Ergebnisse sollten Sie einen neuen Chat starten.",
     "unavailableAgentWarningTitle": "Agent nicht mehr verfügbar",
     "unavailableAgentWarningDescription": "Der Agent oder das Modell dieser Unterhaltung ist nicht mehr verfügbar. Sie können die Nachrichtenhistorie noch einsehen, aber die Unterhaltung nicht fortsetzen.",
+    "unavailableModelWarningTitle": "Modell nicht mehr verfügbar",
     "inputDisclaimer": "Eingaben werden nicht für Training verwendet. KI kann Fehler machen—Antworten prüfen."
   },
   "newChat": {

--- a/ayunis-core-frontend/src/shared/locales/en/chat.json
+++ b/ayunis-core-frontend/src/shared/locales/en/chat.json
@@ -65,6 +65,7 @@
     "longChatWarningDescription": "For better results, consider starting a new chat.",
     "unavailableAgentWarningTitle": "Agent no longer available",
     "unavailableAgentWarningDescription": "The agent or model used in this conversation is no longer accessible. You can still view your message history, but you cannot continue this conversation.",
+    "unavailableModelWarningTitle": "Model no longer available",
     "inputDisclaimer": "Input not used for training. AI can make mistakes—verify answers."
   },
   "newChat": {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Includes a DB migration renaming a `threads` column and changes run execution to hard-fail when a thread’s model is no longer permitted, which can block continuing existing conversations if misconfigured.
> 
> **Overview**
> Renames `threads.modelId` to `threads.permittedModelId` (with index rename) and updates the threads domain/API surface (`CreateThreadDto`/`CreateThreadCommand`, `Thread` entity, repository queries, TypeORM record + mapper) to use the new field.
> 
> Simplifies permitted model deletion by **stopping automatic model replacement in threads**; instead `ExecuteRunUseCase.pickModel` now validates that the thread’s model still exists/is permitted and throws a new `THREAD_MODEL_NO_LONGER_ACCESSIBLE` (403) error.
> 
> Adds frontend handling for the new run error in `ChatPage` (invalidate models + thread queries, show a dedicated toast) and introduces `unavailableModelWarningTitle` translations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 02bd550ca6e74ba4c4eee3c99c14ee91aab59422. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->