### PR TITLE
feat: add total user count to user table

### DIFF
--- a/ayunis-core-frontend/src/pages/admin-settings/users-settings/ui/UsersSection.tsx
+++ b/ayunis-core-frontend/src/pages/admin-settings/users-settings/ui/UsersSection.tsx
@@ -31,12 +31,14 @@ import { useTranslation } from 'react-i18next';
 
 interface UsersSectionProps {
   users: User[];
+  total: number;
   searchSlot?: ReactNode;
   paginationSlot?: ReactNode;
 }
 
 export default function UsersSection({
   users,
+  total,
   searchSlot,
   paginationSlot,
 }: UsersSectionProps) {
@@ -118,7 +120,12 @@ export default function UsersSection({
   return (
     <Card>
       <CardHeader>
-        <CardTitle>{t('users.users')}</CardTitle>
+        <CardTitle>
+          {t('users.users')}
+          <span className="ml-2 text-sm font-normal text-muted-foreground">
+            {t('users.total', { count: total })}
+          </span>
+        </CardTitle>
       </CardHeader>
       <CardContent>
         {searchSlot && <div className="mb-4">{searchSlot}</div>}

--- a/ayunis-core-frontend/src/pages/admin-settings/users-settings/ui/UsersSettingsPage.tsx
+++ b/ayunis-core-frontend/src/pages/admin-settings/users-settings/ui/UsersSettingsPage.tsx
@@ -62,6 +62,7 @@ export default function UsersSettingsPage({
         )}
         <UsersSection
           users={users}
+          total={total}
           searchSlot={<UsersSearch search={search} />}
           paginationSlot={
             <UsersPagination

--- a/ayunis-core-frontend/src/pages/super-admin-settings/org/ui/UsersTable.tsx
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/org/ui/UsersTable.tsx
@@ -96,7 +96,12 @@ export default function UsersTable({
       <CardHeader>
         <div className="flex items-center justify-between">
           <div>
-            <CardTitle>{t('header.title')}</CardTitle>
+            <CardTitle>
+              {t('header.title')}
+              <span className="ml-2 text-sm font-normal text-muted-foreground">
+                {t('header.total', { count: total })}
+              </span>
+            </CardTitle>
             <CardDescription>{t('header.description')}</CardDescription>
           </div>
           <CreateUserDialog orgId={orgId} />

--- a/ayunis-core-frontend/src/shared/locales/de/admin-settings-users.json
+++ b/ayunis-core-frontend/src/shared/locales/de/admin-settings-users.json
@@ -31,7 +31,8 @@
     "user": "Benutzer",
     "admin": "Administrator",
     "sendPasswordReset": "Passwort-Reset senden",
-    "noInvitesFound": "Keine Einladungen gefunden"
+    "noInvitesFound": "Keine Einladungen gefunden",
+    "total": "{{count}} gesamt"
   },
   "inviteDialog": {
     "inviteUser": "Benutzer einladen",

--- a/ayunis-core-frontend/src/shared/locales/de/super-admin-settings-org.json
+++ b/ayunis-core-frontend/src/shared/locales/de/super-admin-settings-org.json
@@ -4,7 +4,8 @@
   },
   "header": {
     "title": "Benutzer",
-    "description": "Benutzer dieser Organisation anzeigen und verwalten."
+    "description": "Benutzer dieser Organisation anzeigen und verwalten.",
+    "total": "{{count}} gesamt"
   },
   "table": {
     "name": "Name",

--- a/ayunis-core-frontend/src/shared/locales/en/admin-settings-users.json
+++ b/ayunis-core-frontend/src/shared/locales/en/admin-settings-users.json
@@ -31,7 +31,8 @@
     "user": "User",
     "admin": "Admin",
     "sendPasswordReset": "Send Password Reset",
-    "noInvitesFound": "No invites found"
+    "noInvitesFound": "No invites found",
+    "total": "{{count}} total"
   },
   "inviteDialog": {
     "inviteUser": "Invite User",

--- a/ayunis-core-frontend/src/shared/locales/en/super-admin-settings-org.json
+++ b/ayunis-core-frontend/src/shared/locales/en/super-admin-settings-org.json
@@ -4,7 +4,8 @@
   },
   "header": {
     "title": "Users",
-    "description": "View and manage users in this organization."
+    "description": "View and manage users in this organization.",
+    "total": "{{count}} total"
   },
   "table": {
     "name": "Name",


### PR DESCRIPTION
Add a total user count hint to the super admin users table next to the title.

---
<a href="https://cursor.com/background-agent?bcId=bc-a0ffc180-9a65-4354-9398-0c3ab77d226f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a0ffc180-9a65-4354-9398-0c3ab77d226f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/i18n-only change that adds a displayed total count and threads a new `total` prop; main risk is missing/incorrect totals or translation keys causing rendering issues.
> 
> **Overview**
> Adds a *total user count hint* next to the users table titles in both admin and super-admin views.
> 
> `UsersSection` now requires a `total` prop (wired through `UsersSettingsPage` from pagination metadata), and both `admin-settings-users` and `super-admin-settings-org` locales (EN/DE) add a `total` translation string to render the count.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit da93e7aa026283b17d8550527806df9211aede89. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->