### PR TITLE
fix: invalidate agent cache when user is added to team

### DIFF
--- a/ayunis-core-frontend/src/pages/admin-settings/team-detail/api/useAddTeamMember.ts
+++ b/ayunis-core-frontend/src/pages/admin-settings/team-detail/api/useAddTeamMember.ts
@@ -5,6 +5,7 @@ import {
   useTeamsControllerAddTeamMember,
   getTeamsControllerListTeamMembersQueryKey,
   getTeamsControllerGetTeamQueryKey,
+  getAgentsControllerFindAllQueryKey,
 } from '@/shared/api/generated/ayunisCoreAPI';
 import { showError, showSuccess } from '@/shared/lib/toast';
 
@@ -39,6 +40,10 @@ export function useAddTeamMember(teamId: string, onSuccess?: () => void) {
         });
         void queryClient.invalidateQueries({
           queryKey: getTeamsControllerGetTeamQueryKey(teamId),
+        });
+        // Invalidate agents cache since team membership affects access to shared agents
+        void queryClient.invalidateQueries({
+          queryKey: getAgentsControllerFindAllQueryKey(),
         });
         void router.invalidate();
       },

--- a/ayunis-core-frontend/src/pages/admin-settings/team-detail/api/useRemoveTeamMember.ts
+++ b/ayunis-core-frontend/src/pages/admin-settings/team-detail/api/useRemoveTeamMember.ts
@@ -7,6 +7,7 @@ import {
   useTeamsControllerRemoveTeamMember,
   getTeamsControllerListTeamMembersQueryKey,
   getTeamsControllerGetTeamQueryKey,
+  getAgentsControllerFindAllQueryKey,
 } from '@/shared/api/generated/ayunisCoreAPI';
 import { showError, showSuccess } from '@/shared/lib/toast';
 
@@ -45,6 +46,10 @@ export function useRemoveTeamMember(teamId: string) {
         });
         void queryClient.invalidateQueries({
           queryKey: getTeamsControllerGetTeamQueryKey(teamId),
+        });
+        // Invalidate agents cache since team membership affects access to shared agents
+        void queryClient.invalidateQueries({
+          queryKey: getAgentsControllerFindAllQueryKey(),
         });
         void router.invalidate();
       },


### PR DESCRIPTION
Invalidate the agents list cache when adding or removing team members to ensure shared agents are immediately visible.

Previously, changes to team membership (adding or removing users) did not trigger an invalidation of the agents list cache. This meant that shared agents, whose visibility depends on team membership, would only appear or disappear after a manual page refresh. This PR ensures the agents list is up-to-date immediately after a team membership change.

---
<a href="https://cursor.com/background-agent?bcId=bc-61d62837-c090-4a97-a5b2-4d6ce6a0f156"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-61d62837-c090-4a97-a5b2-4d6ce6a0f156"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: client-side cache invalidation only, but it may trigger extra agent list refetches after add/remove operations.
> 
> **Overview**
> Ensures shared agents appear/disappear immediately after team membership updates by also invalidating the agents list query (via `getAgentsControllerFindAllQueryKey()`) when adding or removing a team member.
> 
> This change runs in the `onSettled` handlers of `useAddTeamMember` and `useRemoveTeamMember`, alongside the existing team/member query invalidations and router refresh.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fabe91c140e65c05db14d32333de30a380cd5bff. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->