### PR TITLE
fix: remove client directive AYC-000

### DIFF
--- a/ayunis-core-frontend/src/shared/ui/shadcn/combobox.tsx
+++ b/ayunis-core-frontend/src/shared/ui/shadcn/combobox.tsx
@@ -1,6 +1,4 @@
 /* eslint-disable react-refresh/only-export-components */
-'use client';
-
 import * as React from 'react';
 import { Combobox as ComboboxPrimitive } from '@base-ui/react';
 import { CheckIcon, ChevronDownIcon, XIcon } from 'lucide-react';


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk because `Combobox` is interactive and removing `'use client'` can break runtime behavior or Next.js Server Component boundaries if this file is consumed in client-only contexts.
> 
> **Overview**
> Removes the `'use client'` directive from `src/shared/ui/shadcn/combobox.tsx`, making the shared `Combobox` module no longer explicitly marked as a client component.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1a0679d9c6bc14022d9deb913eacd4cf261ab17b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->