### PR TITLE
feat: finalize release notes integration AYC-000

### DIFF
--- a/ayunis-core-frontend/src/features/useReleaseNotes.ts
+++ b/ayunis-core-frontend/src/features/useReleaseNotes.ts
@@ -4,6 +4,7 @@ import config from '@/shared/config';
 interface AnnouncableInit {
   org_id: string;
   anchor_query_selector: string;
+  hide_indicator: boolean;
 }
 
 declare global {
@@ -45,6 +46,7 @@ export function useReleaseNotes(): void {
     window.announcable_init = {
       org_id: orgId,
       anchor_query_selector: '#updates-button',
+      hide_indicator: true,
     };
 
     // Dynamically load the widget script

--- a/ayunis-core-frontend/src/widgets/app-sidebar/ui/AppSidebar.tsx
+++ b/ayunis-core-frontend/src/widgets/app-sidebar/ui/AppSidebar.tsx
@@ -7,7 +7,6 @@ import {
   LogOut,
   Plus,
   Bot,
-  Megaphone,
 } from 'lucide-react';
 
 import {
@@ -41,7 +40,7 @@ import { useTheme } from '@/features/theme';
 import { useSidebar } from '@/shared/ui/shadcn/sidebar';
 import { MeResponseDtoSystemRole } from '@/shared/api/generated/ayunisCoreAPI.schemas';
 import config from '@/shared/config';
-import { useReleaseNotes } from '@/features/useReleaseNotes';
+import { ReleaseNotesButton } from './ReleaseNotesButton';
 
 export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
   const { theme } = useTheme();
@@ -50,8 +49,6 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
   const { t } = useTranslation('common');
   const navigate = useNavigate();
   const { closeMobileWithCleanup } = useSidebar();
-  useReleaseNotes();
-
   useKeyboardShortcut(['j', 'Meta'], () => {
     void navigate({ to: '/chat' });
   });
@@ -81,15 +78,18 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
       <SidebarHeader>
         <SidebarMenu>
           <SidebarMenuItem>
-            <SidebarMenuButton size="lg" asChild>
-              <Link to="/">
-                <img
-                  src={theme === 'dark' ? brandFullDark : brandFullLight}
-                  alt="Ayunis Logo"
-                  className="w-full max-w-32"
-                />
-              </Link>
-            </SidebarMenuButton>
+            <div className="flex items-center justify-between w-full">
+              <SidebarMenuButton size="lg" asChild className="flex-1">
+                <Link to="/">
+                  <img
+                    src={theme === 'dark' ? brandFullDark : brandFullLight}
+                    alt="Ayunis Logo"
+                    className="w-full max-w-32"
+                  />
+                </Link>
+              </SidebarMenuButton>
+              {config.features.announcableOrgId && <ReleaseNotesButton />}
+            </div>
           </SidebarMenuItem>
         </SidebarMenu>
       </SidebarHeader>
@@ -122,14 +122,6 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
 
       <SidebarFooter>
         <SidebarMenu>
-          {config.features.announcableOrgId && (
-            <SidebarMenuItem>
-              <SidebarMenuButton id="updates-button">
-                <Megaphone />
-                <span>{t('sidebar.updates')}</span>
-              </SidebarMenuButton>
-            </SidebarMenuItem>
-          )}
           <SidebarMenuItem>
             <DropdownMenu>
               <DropdownMenuTrigger asChild>

--- a/ayunis-core-frontend/src/widgets/app-sidebar/ui/ReleaseNotesButton.tsx
+++ b/ayunis-core-frontend/src/widgets/app-sidebar/ui/ReleaseNotesButton.tsx
@@ -1,0 +1,40 @@
+import { useEffect, useRef, useState } from 'react';
+import { Bell } from 'lucide-react';
+import { SidebarMenuButton } from '@/shared/ui/shadcn/sidebar';
+import { useReleaseNotes } from '@/features/useReleaseNotes';
+
+export function ReleaseNotesButton() {
+  useReleaseNotes();
+
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const [hasNewReleaseNotes, setHasNewReleaseNotes] = useState(false);
+
+  useEffect(() => {
+    const node = buttonRef.current;
+    if (!node) return;
+    const check = () =>
+      setHasNewReleaseNotes(node.dataset.newReleaseNotes === 'true');
+    check();
+    const observer = new MutationObserver(check);
+    observer.observe(node, {
+      attributes: true,
+      attributeFilter: ['data-new-release-notes'],
+    });
+    return () => observer.disconnect();
+  }, []);
+
+  return (
+    <SidebarMenuButton
+      asChild
+      className="relative size-8 flex-shrink-0"
+      size="sm"
+    >
+      <button ref={buttonRef} id="updates-button">
+        <Bell className="size-4" />
+        {hasNewReleaseNotes && (
+          <span className="absolute top-1 right-1 size-2 rounded-full bg-red-500" />
+        )}
+      </button>
+    </SidebarMenuButton>
+  );
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk UI/integration change that mainly adjusts how the third-party release-notes widget is initialized and displayed; primary risk is regressions in the sidebar layout or the widget not attaching to `#updates-button` as expected.
> 
> **Overview**
> **Release notes integration is finalized and simplified in the sidebar UI.** The widget init now sets `hide_indicator: true` to suppress the vendor’s built-in badge.
> 
> The sidebar replaces the footer “Updates” menu item with a compact header `ReleaseNotesButton` (bell icon) next to the logo, and the widget hook (`useReleaseNotes`) is invoked from this new component. The button watches `data-new-release-notes` via a `MutationObserver` to render a custom red dot when new release notes are available.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fbb05186a4bf284193391451f93b7046ff727636. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->