### PR TITLE
feat: add voice dictation

### DIFF
--- a/ayunis-core-backend/eslint.config.mjs
+++ b/ayunis-core-backend/eslint.config.mjs
@@ -8,6 +8,7 @@ export default tseslint.config(
   {
     ignores: [
       'eslint.config.mjs',
+      'jest.setup.js',
       '**/node_modules/**',
       '**/dist/**',
       '**/build/**',

--- a/ayunis-core-backend/src/app/app.module.ts
+++ b/ayunis-core-backend/src/app/app.module.ts
@@ -18,6 +18,7 @@ import { PromptsModule } from '../domain/prompts/prompts.module';
 import { SharesModule } from '../domain/shares/shares.module';
 import { McpModule } from '../domain/mcp/mcp.module';
 import { UsageModule } from '../domain/usage/usage.module';
+import { TranscriptionsModule } from '../domain/transcriptions/transcriptions.module';
 import { IamModule } from '../iam/iam.module';
 import { AdminModule } from '../admin/admin.module';
 import { modelsConfig } from '../config/models.config';
@@ -120,6 +121,7 @@ import { SentryModule } from '@sentry/nestjs/setup';
     SharesModule,
     McpModule,
     UsageModule,
+    TranscriptionsModule,
     IamModule.register({
       authProvider:
         (process.env.AUTH_PROVIDER as AuthProvider) || AuthProvider.LOCAL,

--- a/ayunis-core-backend/src/domain/transcriptions/application/ports/transcription.port.ts
+++ b/ayunis-core-backend/src/domain/transcriptions/application/ports/transcription.port.ts
@@ -2,6 +2,7 @@ export abstract class TranscriptionPort {
   abstract transcribe(
     file: Buffer,
     fileName: string,
+    mimeType: string,
     language?: string,
   ): Promise<string>;
 }

--- a/ayunis-core-backend/src/domain/transcriptions/application/ports/transcription.port.ts
+++ b/ayunis-core-backend/src/domain/transcriptions/application/ports/transcription.port.ts
@@ -1,0 +1,7 @@
+export abstract class TranscriptionPort {
+  abstract transcribe(
+    file: Buffer,
+    fileName: string,
+    language?: string,
+  ): Promise<string>;
+}

--- a/ayunis-core-backend/src/domain/transcriptions/application/transcription.errors.ts
+++ b/ayunis-core-backend/src/domain/transcriptions/application/transcription.errors.ts
@@ -7,6 +7,8 @@ import {
   NotFoundException,
   ConflictException,
   ForbiddenException,
+  InternalServerErrorException,
+  ServiceUnavailableException,
 } from '@nestjs/common';
 
 /**
@@ -50,6 +52,18 @@ export abstract class TranscriptionError extends ApplicationError {
         });
       case 409:
         return new ConflictException({
+          code: this.code,
+          message: this.message,
+          ...(this.metadata && { metadata: this.metadata }),
+        });
+      case 500:
+        return new InternalServerErrorException({
+          code: this.code,
+          message: this.message,
+          ...(this.metadata && { metadata: this.metadata }),
+        });
+      case 503:
+        return new ServiceUnavailableException({
           code: this.code,
           message: this.message,
           ...(this.metadata && { metadata: this.metadata }),

--- a/ayunis-core-backend/src/domain/transcriptions/application/transcription.errors.ts
+++ b/ayunis-core-backend/src/domain/transcriptions/application/transcription.errors.ts
@@ -1,0 +1,97 @@
+import {
+  ApplicationError,
+  ErrorMetadata,
+} from '../../../common/errors/base.error';
+import {
+  BadRequestException,
+  NotFoundException,
+  ConflictException,
+  ForbiddenException,
+} from '@nestjs/common';
+
+/**
+ * Error codes specific to the Transcriptions domain
+ */
+export enum TranscriptionErrorCode {
+  TRANSCRIPTION_FAILED = 'TRANSCRIPTION_FAILED',
+  INVALID_AUDIO_FILE = 'INVALID_AUDIO_FILE',
+  TRANSCRIPTION_SERVICE_UNAVAILABLE = 'TRANSCRIPTION_SERVICE_UNAVAILABLE',
+}
+
+/**
+ * Base transcription error that all transcription-specific errors should extend
+ */
+export abstract class TranscriptionError extends ApplicationError {
+  constructor(
+    message: string,
+    code: TranscriptionErrorCode,
+    statusCode: number = 400,
+    metadata?: ErrorMetadata,
+  ) {
+    super(message, code, statusCode, metadata);
+  }
+
+  /**
+   * Convert to a NestJS HTTP exception
+   */
+  toHttpException() {
+    switch (this.statusCode) {
+      case 404:
+        return new NotFoundException({
+          code: this.code,
+          message: this.message,
+          ...(this.metadata && { metadata: this.metadata }),
+        });
+      case 403:
+        return new ForbiddenException({
+          code: this.code,
+          message: this.message,
+          ...(this.metadata && { metadata: this.metadata }),
+        });
+      case 409:
+        return new ConflictException({
+          code: this.code,
+          message: this.message,
+          ...(this.metadata && { metadata: this.metadata }),
+        });
+      default:
+        return new BadRequestException({
+          code: this.code,
+          message: this.message,
+          ...(this.metadata && { metadata: this.metadata }),
+        });
+    }
+  }
+}
+
+export class TranscriptionFailedError extends TranscriptionError {
+  constructor(
+    message: string = 'Transcription failed',
+    metadata?: ErrorMetadata,
+  ) {
+    super(message, TranscriptionErrorCode.TRANSCRIPTION_FAILED, 500, metadata);
+  }
+}
+
+export class InvalidAudioFileError extends TranscriptionError {
+  constructor(
+    message: string = 'Invalid audio file',
+    metadata?: ErrorMetadata,
+  ) {
+    super(message, TranscriptionErrorCode.INVALID_AUDIO_FILE, 400, metadata);
+  }
+}
+
+export class TranscriptionServiceUnavailableError extends TranscriptionError {
+  constructor(
+    message: string = 'Transcription service unavailable',
+    metadata?: ErrorMetadata,
+  ) {
+    super(
+      message,
+      TranscriptionErrorCode.TRANSCRIPTION_SERVICE_UNAVAILABLE,
+      503,
+      metadata,
+    );
+  }
+}

--- a/ayunis-core-backend/src/domain/transcriptions/application/use-cases/transcribe/transcribe.command.ts
+++ b/ayunis-core-backend/src/domain/transcriptions/application/use-cases/transcribe/transcribe.command.ts
@@ -1,0 +1,18 @@
+export class TranscribeCommand {
+  public readonly file: Buffer;
+  public readonly fileName: string;
+  public readonly mimeType: string;
+  public readonly language?: string;
+
+  constructor(params: {
+    file: Buffer;
+    fileName: string;
+    mimeType: string;
+    language?: string;
+  }) {
+    this.file = params.file;
+    this.fileName = params.fileName;
+    this.mimeType = params.mimeType;
+    this.language = params.language;
+  }
+}

--- a/ayunis-core-backend/src/domain/transcriptions/application/use-cases/transcribe/transcribe.use-case.ts
+++ b/ayunis-core-backend/src/domain/transcriptions/application/use-cases/transcribe/transcribe.use-case.ts
@@ -1,0 +1,79 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { TranscriptionPort } from '../../ports/transcription.port';
+import { TranscribeCommand } from './transcribe.command';
+import { ContextService } from 'src/common/context/services/context.service';
+import {
+  TranscriptionFailedError,
+  InvalidAudioFileError,
+} from '../../transcription.errors';
+import { ApplicationError } from 'src/common/errors/base.error';
+import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
+
+@Injectable()
+export class TranscribeUseCase {
+  private readonly logger = new Logger(TranscribeUseCase.name);
+
+  constructor(
+    private readonly transcriptionPort: TranscriptionPort,
+    private readonly contextService: ContextService,
+  ) {}
+
+  async execute(command: TranscribeCommand): Promise<string> {
+    this.logger.log('execute', {
+      fileName: command.fileName,
+      mimeType: command.mimeType,
+      language: command.language,
+    });
+
+    try {
+      const userId = this.contextService.get('userId');
+      if (!userId) {
+        throw new UnauthorizedAccessError();
+      }
+
+      // Validate audio file
+      if (!command.file || command.file.length === 0) {
+        throw new InvalidAudioFileError('Empty audio file');
+      }
+
+      // Basic MIME type validation
+      const supportedMimeTypes = [
+        'audio/webm',
+        'audio/mp4',
+        'audio/mpeg',
+        'audio/wav',
+        'audio/x-m4a',
+      ];
+      if (!supportedMimeTypes.includes(command.mimeType)) {
+        throw new InvalidAudioFileError(
+          `Unsupported audio format: ${command.mimeType}`,
+        );
+      }
+
+      // Call the transcription service
+      const transcriptedText = await this.transcriptionPort.transcribe(
+        command.file,
+        command.fileName,
+        command.language,
+      );
+
+      this.logger.log('Transcription completed', {
+        fileName: command.fileName,
+        textLength: transcriptedText.length,
+      });
+
+      return transcriptedText;
+    } catch (error) {
+      if (error instanceof ApplicationError) {
+        throw error;
+      }
+      this.logger.error('Failed to transcribe audio', {
+        fileName: command.fileName,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      });
+      throw new TranscriptionFailedError(
+        (error as Error)?.message ?? 'Unknown error during transcription',
+      );
+    }
+  }
+}

--- a/ayunis-core-backend/src/domain/transcriptions/infrastructure/mistral-transcription.service.ts
+++ b/ayunis-core-backend/src/domain/transcriptions/infrastructure/mistral-transcription.service.ts
@@ -23,18 +23,20 @@ export class MistralTranscriptionService extends TranscriptionPort {
   async transcribe(
     file: Buffer,
     fileName: string,
+    mimeType: string,
     language?: string,
   ): Promise<string> {
     this.logger.log('Starting transcription', {
       fileName,
       fileSize: file.length,
+      mimeType,
       language,
     });
 
     try {
       // Create a File object from the buffer for the Mistral API
       const audioFile = new File([new Uint8Array(file)], fileName, {
-        type: this.getMimeTypeFromFileName(fileName),
+        type: mimeType,
       });
 
       const transcriptionRequest = {
@@ -77,23 +79,6 @@ export class MistralTranscriptionService extends TranscriptionPort {
           error instanceof Error ? error.message : 'Unknown error'
         }`,
       );
-    }
-  }
-
-  private getMimeTypeFromFileName(fileName: string): string {
-    const extension = fileName.split('.').pop()?.toLowerCase();
-    switch (extension) {
-      case 'webm':
-        return 'audio/webm';
-      case 'mp4':
-      case 'm4a':
-        return 'audio/mp4';
-      case 'mp3':
-        return 'audio/mpeg';
-      case 'wav':
-        return 'audio/wav';
-      default:
-        return 'audio/webm'; // Default fallback
     }
   }
 

--- a/ayunis-core-backend/src/domain/transcriptions/infrastructure/mistral-transcription.service.ts
+++ b/ayunis-core-backend/src/domain/transcriptions/infrastructure/mistral-transcription.service.ts
@@ -16,6 +16,7 @@ export class MistralTranscriptionService extends TranscriptionPort {
     super();
     this.client = new Mistral({
       apiKey: this.configService.get('models.mistral.apiKey'),
+      timeoutMs: 30_000,
     });
   }
 
@@ -98,8 +99,17 @@ export class MistralTranscriptionService extends TranscriptionPort {
 
   private isServiceUnavailableError(error: unknown): boolean {
     // Check for common service unavailable indicators
-    const err = error as { status?: number; message?: string } | undefined;
+    const err = error as
+      | {
+          status?: number;
+          message?: string;
+          name?: string;
+        }
+      | undefined;
     if (err?.status === 503 || err?.status === 502) {
+      return true;
+    }
+    if (err?.name === 'RequestTimeoutError' || err?.name === 'TimeoutError') {
       return true;
     }
     if (

--- a/ayunis-core-backend/src/domain/transcriptions/presenters/http/dtos/transcription-response.dto.ts
+++ b/ayunis-core-backend/src/domain/transcriptions/presenters/http/dtos/transcription-response.dto.ts
@@ -1,0 +1,13 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class TranscriptionResponseDto {
+  @ApiProperty({
+    description: 'The transcribed text from the audio file',
+    example: 'Hello, this is a test transcription.',
+  })
+  text: string;
+
+  constructor(text: string) {
+    this.text = text;
+  }
+}

--- a/ayunis-core-backend/src/domain/transcriptions/presenters/http/transcriptions.controller.ts
+++ b/ayunis-core-backend/src/domain/transcriptions/presenters/http/transcriptions.controller.ts
@@ -29,7 +29,11 @@ export class TranscriptionsController {
   constructor(private readonly transcribeUseCase: TranscribeUseCase) {}
 
   @Post()
-  @UseInterceptors(FileInterceptor('file'))
+  @UseInterceptors(
+    FileInterceptor('file', {
+      limits: { fileSize: 25 * 1024 * 1024 }, // 25 MB limit
+    }),
+  )
   @ApiOperation({
     summary: 'Transcribe audio file to text',
     description:

--- a/ayunis-core-backend/src/domain/transcriptions/presenters/http/transcriptions.controller.ts
+++ b/ayunis-core-backend/src/domain/transcriptions/presenters/http/transcriptions.controller.ts
@@ -1,0 +1,101 @@
+import {
+  Controller,
+  Post,
+  UseInterceptors,
+  UploadedFile,
+  Body,
+  BadRequestException,
+  Logger,
+} from '@nestjs/common';
+import { FileInterceptor } from '@nestjs/platform-express';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiConsumes,
+  ApiBody,
+  ApiResponse,
+  ApiBearerAuth,
+} from '@nestjs/swagger';
+import { TranscribeUseCase } from '../../application/use-cases/transcribe/transcribe.use-case';
+import { TranscribeCommand } from '../../application/use-cases/transcribe/transcribe.command';
+import { TranscriptionResponseDto } from './dtos/transcription-response.dto';
+
+@ApiTags('transcriptions')
+@ApiBearerAuth()
+@Controller('transcriptions')
+export class TranscriptionsController {
+  private readonly logger = new Logger(TranscriptionsController.name);
+
+  constructor(private readonly transcribeUseCase: TranscribeUseCase) {}
+
+  @Post()
+  @UseInterceptors(FileInterceptor('file'))
+  @ApiOperation({
+    summary: 'Transcribe audio file to text',
+    description:
+      'Upload an audio file and receive the transcribed text. ' +
+      'Supports webm, mp4, mp3, wav, and m4a formats.',
+  })
+  @ApiConsumes('multipart/form-data')
+  @ApiBody({
+    schema: {
+      type: 'object',
+      required: ['file'],
+      properties: {
+        file: {
+          type: 'string',
+          format: 'binary',
+          description: 'The audio file to transcribe',
+        },
+        language: {
+          type: 'string',
+          description: 'Optional language hint (e.g., "en", "de")',
+          example: 'en',
+        },
+      },
+    },
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Audio successfully transcribed',
+    type: TranscriptionResponseDto,
+  })
+  @ApiResponse({
+    status: 400,
+    description: 'Invalid request or unsupported audio format',
+  })
+  @ApiResponse({
+    status: 401,
+    description: 'Unauthorized',
+  })
+  @ApiResponse({
+    status: 500,
+    description: 'Transcription failed',
+  })
+  async transcribe(
+    @UploadedFile() file: Express.Multer.File,
+    @Body('language') language?: string,
+  ): Promise<TranscriptionResponseDto> {
+    this.logger.log('Transcription request received', {
+      fileName: file?.originalname,
+      mimeType: file?.mimetype,
+      fileSize: file?.size,
+      language,
+    });
+
+    if (!file) {
+      throw new BadRequestException('No audio file provided');
+    }
+
+    const command = new TranscribeCommand({
+      file: file.buffer,
+      fileName: file.originalname,
+      mimeType: file.mimetype,
+      language,
+    });
+
+    const transcriptedText = await this.transcribeUseCase.execute(command);
+
+    return new TranscriptionResponseDto(transcriptedText);
+  }
+}

--- a/ayunis-core-backend/src/domain/transcriptions/transcriptions.module.ts
+++ b/ayunis-core-backend/src/domain/transcriptions/transcriptions.module.ts
@@ -1,0 +1,20 @@
+import { Module } from '@nestjs/common';
+import { TranscriptionsController } from './presenters/http/transcriptions.controller';
+import { TranscribeUseCase } from './application/use-cases/transcribe/transcribe.use-case';
+import { TranscriptionPort } from './application/ports/transcription.port';
+import { MistralTranscriptionService } from './infrastructure/mistral-transcription.service';
+import { ContextModule } from 'src/common/context/context.module';
+
+@Module({
+  imports: [ContextModule],
+  controllers: [TranscriptionsController],
+  providers: [
+    TranscribeUseCase,
+    {
+      provide: TranscriptionPort,
+      useClass: MistralTranscriptionService,
+    },
+  ],
+  exports: [TranscriptionPort],
+})
+export class TranscriptionsModule {}

--- a/ayunis-core-frontend/src/shared/locales/de/common.json
+++ b/ayunis-core-frontend/src/shared/locales/de/common.json
@@ -78,7 +78,12 @@
     },
     "fileSourceDisabled": "Um Dokumente hochzuladen, muss ein Embedding-Modell aktiviert sein.",
     "dropFilesHint": "Dateien hier ablegen",
-    "invalidDroppedFileType": "Einige Dateien wurden übersprungen, da sie nicht unterstützt werden."
+    "invalidDroppedFileType": "Einige Dateien wurden übersprungen, da sie nicht unterstützt werden.",
+    "microphoneTooltip": "Diktieren",
+    "microphoneRecording": "Aufnahme... Klicken zum Stoppen",
+    "transcribing": "Wird transkribiert...",
+    "microphonePermissionDenied": "Mikrofonzugriff verweigert",
+    "transcriptionFailed": "Transkription fehlgeschlagen"
   },
   "common": {
     "loading": "Laden...",

--- a/ayunis-core-frontend/src/shared/locales/de/common.json
+++ b/ayunis-core-frontend/src/shared/locales/de/common.json
@@ -83,6 +83,7 @@
     "microphoneRecording": "Aufnahme... Klicken zum Stoppen",
     "transcribing": "Wird transkribiert...",
     "microphonePermissionDenied": "Mikrofonzugriff verweigert",
+    "recordingNotSupported": "Sprachaufnahme wird in diesem Browser nicht unterstützt",
     "transcriptionFailed": "Transkription fehlgeschlagen"
   },
   "common": {

--- a/ayunis-core-frontend/src/shared/locales/en/common.json
+++ b/ayunis-core-frontend/src/shared/locales/en/common.json
@@ -83,6 +83,7 @@
     "microphoneRecording": "Recording... Click to stop",
     "transcribing": "Transcribing...",
     "microphonePermissionDenied": "Microphone access denied",
+    "recordingNotSupported": "Voice recording is not supported in this browser",
     "transcriptionFailed": "Transcription failed"
   },
   "common": {

--- a/ayunis-core-frontend/src/shared/locales/en/common.json
+++ b/ayunis-core-frontend/src/shared/locales/en/common.json
@@ -78,7 +78,12 @@
     },
     "fileSourceDisabled": "To upload documents, an embedding model must be enabled.",
     "dropFilesHint": "Drop files here",
-    "invalidDroppedFileType": "Some files were skipped because they are not supported."
+    "invalidDroppedFileType": "Some files were skipped because they are not supported.",
+    "microphoneTooltip": "Dictate",
+    "microphoneRecording": "Recording... Click to stop",
+    "transcribing": "Transcribing...",
+    "microphonePermissionDenied": "Microphone access denied",
+    "transcriptionFailed": "Transcription failed"
   },
   "common": {
     "loading": "Loading...",

--- a/ayunis-core-frontend/src/widgets/chat-input/api/useTranscribe.ts
+++ b/ayunis-core-frontend/src/widgets/chat-input/api/useTranscribe.ts
@@ -28,6 +28,7 @@ export function useTranscribe() {
           headers: {
             'Content-Type': 'multipart/form-data',
           },
+          timeout: 30_000,
         },
       );
 

--- a/ayunis-core-frontend/src/widgets/chat-input/api/useTranscribe.ts
+++ b/ayunis-core-frontend/src/widgets/chat-input/api/useTranscribe.ts
@@ -1,0 +1,43 @@
+import { useState } from 'react';
+import { axiosInstance } from '@/shared/api/client';
+
+interface TranscribeResult {
+  text: string;
+}
+
+export function useTranscribe() {
+  const [isTranscribing, setIsTranscribing] = useState(false);
+
+  async function transcribe(
+    audioBlob: Blob,
+    fileName: string,
+    language?: string,
+  ): Promise<string | null> {
+    setIsTranscribing(true);
+    try {
+      const formData = new FormData();
+      formData.append('file', audioBlob, fileName);
+      if (language) {
+        formData.append('language', language);
+      }
+
+      const response = await axiosInstance.post<TranscribeResult>(
+        '/transcriptions',
+        formData,
+        {
+          headers: {
+            'Content-Type': 'multipart/form-data',
+          },
+        },
+      );
+
+      return response.data.text;
+    } catch {
+      return null;
+    } finally {
+      setIsTranscribing(false);
+    }
+  }
+
+  return { transcribe, isTranscribing };
+}

--- a/ayunis-core-frontend/src/widgets/chat-input/hooks/index.ts
+++ b/ayunis-core-frontend/src/widgets/chat-input/hooks/index.ts
@@ -1,3 +1,4 @@
 export { usePendingImages, type PendingImage } from './usePendingImages';
 export { useImagePaste } from './useImagePaste';
 export { useFileDrop } from './useFileDrop';
+export { useVoiceRecording } from './useVoiceRecording';

--- a/ayunis-core-frontend/src/widgets/chat-input/hooks/useVoiceRecording.ts
+++ b/ayunis-core-frontend/src/widgets/chat-input/hooks/useVoiceRecording.ts
@@ -67,6 +67,11 @@ export function useVoiceRecording(
       setState('transcribing');
       const text = await transcribe(blob, fileName);
 
+      // Check if cancelled during transcription (e.g., component unmounted)
+      if (cancelledRef.current) {
+        return;
+      }
+
       if (text === null) {
         // API error
         onError('chatInput.transcriptionFailed');

--- a/ayunis-core-frontend/src/widgets/chat-input/hooks/useVoiceRecording.ts
+++ b/ayunis-core-frontend/src/widgets/chat-input/hooks/useVoiceRecording.ts
@@ -1,0 +1,156 @@
+import { useState, useRef, useCallback } from 'react';
+
+type RecordingState = 'idle' | 'recording' | 'transcribing';
+
+const MAX_RECORDING_DURATION_MS = 5 * 60 * 1000; // 5 minutes
+const MIN_RECORDING_DURATION_MS = 1000; // 1 second
+
+function getSupportedMimeType(): string {
+  if (MediaRecorder.isTypeSupported('audio/webm')) {
+    return 'audio/webm';
+  }
+  if (MediaRecorder.isTypeSupported('audio/mp4')) {
+    return 'audio/mp4';
+  }
+  // Fallback
+  return 'audio/webm';
+}
+
+function getFileExtension(mimeType: string): string {
+  if (mimeType.includes('mp4')) return 'mp4';
+  return 'webm';
+}
+
+export function useVoiceRecording(
+  onTranscriptionComplete: (text: string) => void,
+  onError: (errorKey: string) => void,
+  transcribe: (
+    audioBlob: Blob,
+    fileName: string,
+    language?: string,
+  ) => Promise<string | null>,
+) {
+  const [state, setState] = useState<RecordingState>('idle');
+  const mediaRecorderRef = useRef<MediaRecorder | null>(null);
+  const chunksRef = useRef<Blob[]>([]);
+  const startTimeRef = useRef<number>(0);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const streamRef = useRef<MediaStream | null>(null);
+
+  const cleanup = useCallback(() => {
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    }
+    if (streamRef.current) {
+      streamRef.current.getTracks().forEach((track) => track.stop());
+      streamRef.current = null;
+    }
+    mediaRecorderRef.current = null;
+    chunksRef.current = [];
+  }, []);
+
+  const processRecording = useCallback(
+    async (chunks: Blob[], mimeType: string) => {
+      const blob = new Blob(chunks, { type: mimeType });
+      const ext = getFileExtension(mimeType);
+      const fileName = `recording.${ext}`;
+
+      setState('transcribing');
+      const text = await transcribe(blob, fileName);
+
+      if (text) {
+        onTranscriptionComplete(text);
+      } else {
+        onError('chatInput.transcriptionFailed');
+      }
+      setState('idle');
+    },
+    [transcribe, onTranscriptionComplete, onError],
+  );
+
+  const startRecording = useCallback(async () => {
+    if (!navigator.mediaDevices?.getUserMedia) {
+      onError('chatInput.microphonePermissionDenied');
+      return;
+    }
+
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      streamRef.current = stream;
+
+      const mimeType = getSupportedMimeType();
+      const mediaRecorder = new MediaRecorder(stream, { mimeType });
+      mediaRecorderRef.current = mediaRecorder;
+      chunksRef.current = [];
+      startTimeRef.current = Date.now();
+
+      mediaRecorder.ondataavailable = (event) => {
+        if (event.data.size > 0) {
+          chunksRef.current.push(event.data);
+        }
+      };
+
+      mediaRecorder.onstop = () => {
+        const duration = Date.now() - startTimeRef.current;
+        const chunks = [...chunksRef.current];
+
+        // Stop all tracks
+        stream.getTracks().forEach((track) => track.stop());
+        streamRef.current = null;
+
+        if (timeoutRef.current) {
+          clearTimeout(timeoutRef.current);
+          timeoutRef.current = null;
+        }
+
+        // Discard very short recordings
+        if (duration < MIN_RECORDING_DURATION_MS) {
+          setState('idle');
+          return;
+        }
+
+        void processRecording(chunks, mimeType);
+      };
+
+      mediaRecorder.start();
+      setState('recording');
+
+      // Auto-stop after max duration
+      timeoutRef.current = setTimeout(() => {
+        if (
+          mediaRecorderRef.current &&
+          mediaRecorderRef.current.state === 'recording'
+        ) {
+          mediaRecorderRef.current.stop();
+        }
+      }, MAX_RECORDING_DURATION_MS);
+    } catch {
+      cleanup();
+      onError('chatInput.microphonePermissionDenied');
+    }
+  }, [onError, processRecording, cleanup]);
+
+  const stopRecording = useCallback(() => {
+    if (
+      mediaRecorderRef.current &&
+      mediaRecorderRef.current.state === 'recording'
+    ) {
+      mediaRecorderRef.current.stop();
+    }
+  }, []);
+
+  const isSupported =
+    typeof window !== 'undefined' &&
+    !!navigator.mediaDevices?.getUserMedia &&
+    typeof MediaRecorder !== 'undefined';
+
+  return {
+    state,
+    isRecording: state === 'recording',
+    isTranscribing: state === 'transcribing',
+    startRecording,
+    stopRecording,
+    isSupported,
+  };
+}

--- a/ayunis-core-frontend/src/widgets/chat-input/hooks/useVoiceRecording.ts
+++ b/ayunis-core-frontend/src/widgets/chat-input/hooks/useVoiceRecording.ts
@@ -82,7 +82,7 @@ export function useVoiceRecording(
 
   const startRecording = useCallback(async () => {
     if (!navigator.mediaDevices?.getUserMedia) {
-      onError('chatInput.microphonePermissionDenied');
+      onError('chatInput.recordingNotSupported');
       return;
     }
 
@@ -96,6 +96,13 @@ export function useVoiceRecording(
 
     try {
       const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+
+      // If cancelled during getUserMedia (e.g., component unmounted), clean up and return
+      if (cancelledRef.current) {
+        stream.getTracks().forEach((track) => track.stop());
+        return;
+      }
+
       streamRef.current = stream;
 
       const mimeType = getSupportedMimeType();

--- a/ayunis-core-frontend/src/widgets/chat-input/hooks/useVoiceRecording.ts
+++ b/ayunis-core-frontend/src/widgets/chat-input/hooks/useVoiceRecording.ts
@@ -1,6 +1,6 @@
 import { useState, useRef, useCallback, useEffect } from 'react';
 
-type RecordingState = 'idle' | 'recording' | 'transcribing';
+type RecordingState = 'idle' | 'starting' | 'recording' | 'transcribing';
 
 const MAX_RECORDING_DURATION_MS = 5 * 60 * 1000; // 5 minutes
 const MIN_RECORDING_DURATION_MS = 1000; // 1 second
@@ -36,8 +36,10 @@ export function useVoiceRecording(
   const startTimeRef = useRef<number>(0);
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const streamRef = useRef<MediaStream | null>(null);
+  const cancelledRef = useRef<boolean>(false);
 
   const cleanup = useCallback(() => {
+    cancelledRef.current = true;
     if (timeoutRef.current) {
       clearTimeout(timeoutRef.current);
       timeoutRef.current = null;
@@ -85,6 +87,14 @@ export function useVoiceRecording(
       return;
     }
 
+    // Prevent multiple concurrent startRecording calls
+    if (state !== 'idle') {
+      return;
+    }
+
+    setState('starting');
+    cancelledRef.current = false;
+
     try {
       const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
       streamRef.current = stream;
@@ -108,6 +118,11 @@ export function useVoiceRecording(
       };
 
       mediaRecorder.onstop = () => {
+        // If cleanup was called (e.g., unmount), skip processing entirely
+        if (cancelledRef.current) {
+          return;
+        }
+
         const duration = Date.now() - startTimeRef.current;
         const chunks = [...chunksRef.current];
 
@@ -143,9 +158,10 @@ export function useVoiceRecording(
       }, MAX_RECORDING_DURATION_MS);
     } catch {
       cleanup();
+      setState('idle');
       onError('chatInput.microphonePermissionDenied');
     }
-  }, [onError, processRecording, cleanup]);
+  }, [state, onError, processRecording, cleanup]);
 
   const stopRecording = useCallback(() => {
     if (
@@ -163,6 +179,7 @@ export function useVoiceRecording(
 
   return {
     state,
+    isStarting: state === 'starting',
     isRecording: state === 'recording',
     isTranscribing: state === 'transcribing',
     startRecording,

--- a/ayunis-core-frontend/src/widgets/chat-input/ui/MicrophoneButton.tsx
+++ b/ayunis-core-frontend/src/widgets/chat-input/ui/MicrophoneButton.tsx
@@ -26,6 +26,7 @@ export function MicrophoneButton({
   };
 
   const {
+    isStarting,
     isRecording,
     isTranscribing,
     startRecording,
@@ -37,7 +38,7 @@ export function MicrophoneButton({
     return null;
   }
 
-  const busy = isTranscribing || isApiTranscribing;
+  const busy = isStarting || isTranscribing || isApiTranscribing;
 
   const handleClick = () => {
     if (busy) return;

--- a/ayunis-core-frontend/src/widgets/chat-input/ui/MicrophoneButton.tsx
+++ b/ayunis-core-frontend/src/widgets/chat-input/ui/MicrophoneButton.tsx
@@ -1,0 +1,79 @@
+import { Mic, Loader2 } from 'lucide-react';
+import { Button } from '@/shared/ui/shadcn/button';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/shared/ui/shadcn/tooltip';
+import { useTranslation } from 'react-i18next';
+import { useVoiceRecording } from '../hooks/useVoiceRecording';
+import { useTranscribe } from '../api/useTranscribe';
+import { showError } from '@/shared/lib/toast';
+import { cn } from '@/shared/lib/shadcn/utils';
+
+interface MicrophoneButtonProps {
+  onTranscriptionComplete: (text: string) => void;
+}
+
+export function MicrophoneButton({
+  onTranscriptionComplete,
+}: MicrophoneButtonProps) {
+  const { t } = useTranslation('common');
+  const { transcribe, isTranscribing: isApiTranscribing } = useTranscribe();
+
+  const handleError = (errorKey: string) => {
+    showError(t(errorKey));
+  };
+
+  const {
+    isRecording,
+    isTranscribing,
+    startRecording,
+    stopRecording,
+    isSupported,
+  } = useVoiceRecording(onTranscriptionComplete, handleError, transcribe);
+
+  if (!isSupported) {
+    return null;
+  }
+
+  const busy = isTranscribing || isApiTranscribing;
+
+  const handleClick = () => {
+    if (busy) return;
+    if (isRecording) {
+      stopRecording();
+    } else {
+      void startRecording();
+    }
+  };
+
+  const tooltipText = busy
+    ? t('chatInput.transcribing')
+    : isRecording
+      ? t('chatInput.microphoneRecording')
+      : t('chatInput.microphoneTooltip');
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <div>
+          <Button
+            variant={isRecording ? 'destructive' : 'outline'}
+            size="icon"
+            className={cn('rounded-full', isRecording && 'animate-pulse')}
+            onClick={handleClick}
+            disabled={busy}
+          >
+            {busy ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              <Mic className="h-4 w-4" />
+            )}
+          </Button>
+        </div>
+      </TooltipTrigger>
+      <TooltipContent>{tooltipText}</TooltipContent>
+    </Tooltip>
+  );
+}

--- a/ayunis-core-frontend/src/widgets/chat-input/ui/SendButton.tsx
+++ b/ayunis-core-frontend/src/widgets/chat-input/ui/SendButton.tsx
@@ -1,0 +1,62 @@
+import { Button } from '@/shared/ui/shadcn/button';
+import { ArrowUp, Square } from 'lucide-react';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/shared/ui/shadcn/tooltip';
+import { useTranslation } from 'react-i18next';
+
+interface SendButtonProps {
+  isStreaming: boolean;
+  canSend: boolean;
+  onSend: () => void;
+  onCancel: () => void;
+}
+
+export function SendButton({
+  isStreaming,
+  canSend,
+  onSend,
+  onCancel,
+}: SendButtonProps) {
+  const { t } = useTranslation('common');
+
+  if (isStreaming) {
+    return (
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <div>
+            <Button
+              size="icon"
+              className="rounded-full border border-transparent"
+              onClick={onCancel}
+            >
+              <Square className="h-4 w-4" />
+            </Button>
+          </div>
+        </TooltipTrigger>
+        <TooltipContent>{t('chatInput.cancelTooltip')}</TooltipContent>
+      </Tooltip>
+    );
+  }
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <div>
+          <Button
+            disabled={!canSend}
+            className="rounded-full border border-transparent"
+            size="icon"
+            data-testid="send"
+            onClick={onSend}
+          >
+            <ArrowUp className="h-4 w-4" />
+          </Button>
+        </div>
+      </TooltipTrigger>
+      <TooltipContent>{t('chatInput.sendTooltip')}</TooltipContent>
+    </Tooltip>
+  );
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new authenticated multipart upload endpoint that forwards user audio to an external transcription provider (Mistral), introducing new data-flow and dependency/timeout/error handling risk. Frontend adds browser microphone recording logic that can fail across permissions and MediaRecorder support differences.
> 
> **Overview**
> Adds voice dictation end-to-end.
> 
> Backend introduces a new `TranscriptionsModule` with `POST /transcriptions` (multipart `file` + optional `language`) that validates size/format (25MB, basic audio MIME allowlist), requires an authenticated `userId` in context, and transcribes via a new `TranscriptionPort` implementation backed by Mistral (`voxtral-mini-latest`) with domain-specific error mapping.
> 
> Frontend adds a microphone button to `ChatInput` that records audio with `MediaRecorder`, uploads it via a new `useTranscribe` hook, and appends returned text into the textarea; it also refactors the existing send/cancel UI into a `SendButton` component and adds new i18n strings for dictation states/errors. Minor tooling tweak: ESLint now ignores `jest.setup.js`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 228a613e15c83dc6b6dfeecfe22544dc524b7175. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->