### PR TITLE
ci: clean up after deploy

### DIFF
--- a/.github/workflows/deploy-internal-manual.yml
+++ b/.github/workflows/deploy-internal-manual.yml
@@ -37,9 +37,9 @@ jobs:
               git reset --hard "origin/$RELEASE_TAG"
             fi
             docker compose down
-            docker compose up -d --build
-            # Clean up old images and build cache (keep only what's currently used)
+            # Clean up old images and build cache before building new ones
             docker image prune -af
             docker builder prune -af
+            docker compose up -d --build
             sleep 60
             docker compose ps

--- a/.github/workflows/deploy-internal-manual.yml
+++ b/.github/workflows/deploy-internal-manual.yml
@@ -38,5 +38,8 @@ jobs:
             fi
             docker compose down
             docker compose up -d --build
+            # Clean up old images and build cache (keep only what's currently used)
+            docker image prune -af
+            docker builder prune -af
             sleep 60
             docker compose ps

--- a/.github/workflows/deploy-production-manual.yml
+++ b/.github/workflows/deploy-production-manual.yml
@@ -37,9 +37,9 @@ jobs:
               git reset --hard "origin/$RELEASE_TAG"
             fi
             docker compose down
-            docker compose up -d --build
-            # Clean up old images and build cache (keep only what's currently used)
+            # Clean up old images and build cache before building new ones
             docker image prune -af
             docker builder prune -af
+            docker compose up -d --build
             sleep 60
             docker compose ps

--- a/.github/workflows/deploy-production-manual.yml
+++ b/.github/workflows/deploy-production-manual.yml
@@ -38,5 +38,8 @@ jobs:
             fi
             docker compose down
             docker compose up -d --build
+            # Clean up old images and build cache (keep only what's currently used)
+            docker image prune -af
+            docker builder prune -af
             sleep 60
             docker compose ps

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -27,9 +27,9 @@ jobs:
             git fetch origin main
             git reset --hard origin/main
             docker compose down
-            docker compose up -d --build
-            # Clean up old images and build cache (keep only what's currently used)
+            # Clean up old images and build cache before building new ones
             docker image prune -af
             docker builder prune -af
+            docker compose up -d --build
             sleep 60
             docker compose ps

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -28,5 +28,8 @@ jobs:
             git reset --hard origin/main
             docker compose down
             docker compose up -d --build
+            # Clean up old images and build cache (keep only what's currently used)
+            docker image prune -af
+            docker builder prune -af
             sleep 60
             docker compose ps


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk because deploy workflows now aggressively prune *all* Docker images and build cache on the target hosts, which could impact other running services or slow subsequent builds if those hosts are shared.
> 
> **Overview**
> Deployment workflows now clean up Docker state on the remote host before rebuilding.
> 
> For internal, production (manual), and staging deploys, the SSH deploy script runs `docker image prune -af` and `docker builder prune -af` after `docker compose down` to remove old images/build cache prior to `docker compose up -d --build`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1e180ef8178456f9208945c317e950caf3253ee1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->