### PR TITLE
fix: group agents in chats filter

### DIFF
--- a/ayunis-core-frontend/src/pages/chats/ui/ChatsFilters.tsx
+++ b/ayunis-core-frontend/src/pages/chats/ui/ChatsFilters.tsx
@@ -110,20 +110,24 @@ export default function ChatsFilters({
           {agents.length > 0 && (
             <>
               {/* Personal Agents Group */}
-              <SelectGroup>
-                {sharedAgents.length > 0 && (
-                  <SelectLabel>{tAgents('tabs.personal')}</SelectLabel>
-                )}
-                {personalAgents.map((agent) => (
-                  <SelectItem key={agent.id} value={agent.id}>
-                    {agent.name}
-                  </SelectItem>
-                ))}
-              </SelectGroup>
+              {personalAgents.length > 0 && (
+                <SelectGroup>
+                  {sharedAgents.length > 0 && (
+                    <SelectLabel>{tAgents('tabs.personal')}</SelectLabel>
+                  )}
+                  {personalAgents.map((agent) => (
+                    <SelectItem key={agent.id} value={agent.id}>
+                      {agent.name}
+                    </SelectItem>
+                  ))}
+                </SelectGroup>
+              )}
               {/* Shared Agents Group */}
               {sharedAgents.length > 0 && (
                 <SelectGroup>
-                  <SelectLabel>{tAgents('tabs.shared')}</SelectLabel>
+                  {personalAgents.length > 0 && (
+                    <SelectLabel>{tAgents('tabs.shared')}</SelectLabel>
+                  )}
                   {sharedAgents.map((agent) => (
                     <SelectItem key={agent.id} value={agent.id}>
                       {agent.name}

--- a/ayunis-core-frontend/src/widgets/chat-input/ui/AgentButton.tsx
+++ b/ayunis-core-frontend/src/widgets/chat-input/ui/AgentButton.tsx
@@ -82,7 +82,7 @@ export default function AgentButton({
             <>
               {/* Personal Agents Group */}
               <DropdownMenuGroup>
-                {sharedAgents.length > 0 && (
+                {sharedAgents.length > 0 && personalAgents.length > 0 && (
                   <DropdownMenuLabel className="text-xs text-muted-foreground font-normal">
                     {tAgents('tabs.personal')}
                   </DropdownMenuLabel>
@@ -98,9 +98,11 @@ export default function AgentButton({
               {/* Shared Agents Group */}
               {sharedAgents.length > 0 && (
                 <DropdownMenuGroup>
-                  <DropdownMenuLabel className="text-xs text-muted-foreground font-normal">
-                    {tAgents('tabs.shared')}
-                  </DropdownMenuLabel>
+                  {personalAgents.length > 0 && (
+                    <DropdownMenuLabel className="text-xs text-muted-foreground font-normal">
+                      {tAgents('tabs.shared')}
+                    </DropdownMenuLabel>
+                  )}
                   {sharedAgents.map(renderAgentItem)}
                 </DropdownMenuGroup>
               )}


### PR DESCRIPTION
Group agents in the `/chats` page filter dropdown to match the `AgentSelector`'s grouping logic.

The agent filter dropdown on the `/chats` page now categorizes agents into "Personal" and "Shared" groups, sorted alphabetically within each, consistent with how agents are presented in the `AgentButton` component within the ChatInput. This ensures a uniform user experience across the application. Group labels are displayed only when both personal and shared agents are present.

---
[Slack Thread](https://locaboo.slack.com/archives/C0375HX2C4S/p1770128229942249?thread_ts=1770128229.942249&cid=C0375HX2C4S)

<a href="https://cursor.com/background-agent?bcId=bc-2787e47d-b2b4-533a-b8fc-fc9f90daf546"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2787e47d-b2b4-533a-b8fc-fc9f90daf546"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change: adjusts dropdown rendering/sorting and label conditions without touching data fetching or navigation behavior beyond the selected `agentId` value.
> 
> **Overview**
> Updates the `/chats` agent filter dropdown to match the chat input agent selector by **splitting agents into *Personal* vs *Shared* groups**, sorting each group alphabetically, and using `SelectGroup`/`SelectLabel` for grouped display.
> 
> Also tightens label rendering in `AgentButton` so group labels only appear when both groups are present, keeping the grouping UI consistent across components.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ac1e3a73b18c5e8673650c7f611100805524d1fc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->