### PR TITLE
fix: make data privacy mode tooltip shorter

### DIFF
--- a/ayunis-core-frontend/src/shared/locales/de/common.json
+++ b/ayunis-core-frontend/src/shared/locales/de/common.json
@@ -64,9 +64,9 @@
     "modelChangeDisabledTooltip": "Das Modell kann nicht geändert werden, wenn ein Agent ausgewählt ist.",
     "cancelTooltip": "Abbrechen",
     "sendTooltip": "Senden",
-    "anonymousModeEnabled": "Anonymer Modus aktiviert - Personenbezogene Daten werden entfernt",
-    "anonymousModeDisabled": "Klicken Sie, um den anonymen Modus zu aktivieren (entfernt persönliche Daten)",
-    "anonymousModeEnforced": "Anonymer Modus ist für dieses Modell erforderlich",
+    "anonymousModeEnabled": "Anonymer Modus",
+    "anonymousModeDisabled": "Anonymer Modus",
+    "anonymousModeEnforced": "Anonymer Modus",
     "agents": {
       "title": "Agenten"
     },

--- a/ayunis-core-frontend/src/shared/locales/de/common.json
+++ b/ayunis-core-frontend/src/shared/locales/de/common.json
@@ -66,7 +66,7 @@
     "sendTooltip": "Senden",
     "anonymousModeEnabled": "Anonymer Modus aktiviert - Personenbezogene Daten werden entfernt",
     "anonymousModeDisabled": "Klicken Sie, um den anonymen Modus zu aktivieren (entfernt persönliche Daten)",
-    "anonymousModeEnforced": "Datenschutzmodus ist für dieses Modell erforderlich",
+    "anonymousModeEnforced": "Anonymer Modus ist für dieses Modell erforderlich",
     "agents": {
       "title": "Agenten"
     },

--- a/ayunis-core-frontend/src/shared/locales/en/common.json
+++ b/ayunis-core-frontend/src/shared/locales/en/common.json
@@ -66,7 +66,7 @@
     "sendTooltip": "Send",
     "anonymousModeEnabled": "Anonymous mode enabled - PII will be redacted",
     "anonymousModeDisabled": "Click to enable anonymous mode (redacts personal data)",
-    "anonymousModeEnforced": "Privacy mode is required by this model",
+    "anonymousModeEnforced": "Anonymous mode is required by this model",
     "agents": {
       "title": "Agents"
     },

--- a/ayunis-core-frontend/src/shared/locales/en/common.json
+++ b/ayunis-core-frontend/src/shared/locales/en/common.json
@@ -64,9 +64,9 @@
     "modelChangeDisabledTooltip": "The model cannot be changed when an agent is selected.",
     "cancelTooltip": "Cancel",
     "sendTooltip": "Send",
-    "anonymousModeEnabled": "Anonymous mode enabled - PII will be redacted",
-    "anonymousModeDisabled": "Click to enable anonymous mode (redacts personal data)",
-    "anonymousModeEnforced": "Anonymous mode is required by this model",
+    "anonymousModeEnabled": "Anonymous Mode",
+    "anonymousModeDisabled": "Anonymous Mode",
+    "anonymousModeEnforced": "Anonymous Mode",
     "agents": {
       "title": "Agents"
     },


### PR DESCRIPTION
Rename data privacy mode tooltips to "Anonymous mode" / "Anonymer Modus" for consistency across all states.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-8a4b5c10-d548-4301-9fb0-f0d84152d0be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8a4b5c10-d548-4301-9fb0-f0d84152d0be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Text-only i18n copy change; no logic, data handling, or behavioral impact beyond updated tooltip wording.
> 
> **Overview**
> Updates the `chatInput.anonymousModeEnforced` tooltip copy in both `en` and `de` locale files to consistently refer to **“Anonymous mode”** (instead of “Privacy mode/Datenschutzmodus”) when a model requires it.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bb4539cb9f9617b9c07a52e5c2181d65861f3f6b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->