### PR TITLE
fix: show updated model in chat when agent was updated

### DIFF
--- a/ayunis-core-frontend/src/pages/agent/api/useUpdateAgent.ts
+++ b/ayunis-core-frontend/src/pages/agent/api/useUpdateAgent.ts
@@ -10,6 +10,7 @@ import {
   getAgentsControllerFindOneQueryKey,
 } from '@/shared/api/generated/ayunisCoreAPI';
 import type { AgentResponseDto } from '@/shared/api';
+import { useRouter } from '@tanstack/react-router';
 
 const updateAgentSchema = z.object({
   name: z.string().min(1, 'Name is required'),
@@ -26,6 +27,7 @@ interface UseUpdateAgentProps {
 export function useUpdateAgent({ agent }: UseUpdateAgentProps) {
   const { t } = useTranslation('agents');
   const queryClient = useQueryClient();
+  const router = useRouter();
 
   const form = useForm<UpdateAgentData>({
     resolver: zodResolver(updateAgentSchema),
@@ -42,11 +44,12 @@ export function useUpdateAgent({ agent }: UseUpdateAgentProps) {
     },
     onSuccess: () => {
       void queryClient.invalidateQueries({
-        queryKey: [getAgentsControllerFindAllQueryKey()],
+        queryKey: getAgentsControllerFindAllQueryKey(),
       });
       void queryClient.invalidateQueries({
-        queryKey: [getAgentsControllerFindOneQueryKey(agent.id)],
+        queryKey: getAgentsControllerFindOneQueryKey(agent.id),
       });
+      void router.invalidate();
       toast.success(t('update.success'));
     },
     onError: () => {

--- a/ayunis-core-frontend/src/pages/agents/api/useUpdateAgent.ts
+++ b/ayunis-core-frontend/src/pages/agents/api/useUpdateAgent.ts
@@ -11,6 +11,7 @@ import {
 } from '@/shared/api/generated/ayunisCoreAPI';
 import { ToolAssignmentDtoType } from '@/shared/api/generated/ayunisCoreAPI.schemas';
 import extractErrorData from '@/shared/api/extract-error-data';
+import { useRouter } from '@tanstack/react-router';
 
 const updateAgentSchema = z.object({
   name: z.string().min(1, 'Name is required'),
@@ -44,6 +45,7 @@ export function useUpdateAgent({
 }: UseUpdateAgentProps) {
   const { t } = useTranslation('agents');
   const queryClient = useQueryClient();
+  const router = useRouter();
 
   const form = useForm<UpdateAgentData>({
     resolver: zodResolver(updateAgentSchema),
@@ -61,11 +63,12 @@ export function useUpdateAgent({
     },
     onSuccess: () => {
       void queryClient.invalidateQueries({
-        queryKey: [getAgentsControllerFindAllQueryKey()],
+        queryKey: getAgentsControllerFindAllQueryKey(),
       });
       void queryClient.invalidateQueries({
-        queryKey: [getAgentsControllerFindOneQueryKey(agentId)],
+        queryKey: getAgentsControllerFindOneQueryKey(agentId),
       });
+      void router.invalidate();
       toast.success(t('update.success'));
       onSuccessCallback?.();
     },


### PR DESCRIPTION
Invalidate agent cache and router after agent model updates to display the new model in the chat input.

Previously, the `useUpdateAgent` hooks were missing `router.invalidate()` calls and had incorrect `queryKey` wrapping, preventing the TanStack Router loader cache from refreshing and thus showing stale agent data.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-45e54e14-a504-4aaa-9c94-18b3ef2dd36b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-45e54e14-a504-4aaa-9c94-18b3ef2dd36b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small frontend cache-invalidation changes limited to `useUpdateAgent` hooks; main risk is over/under-invalidation causing stale data or extra refetching.
> 
> **Overview**
> Ensures updated agent data (notably `modelId`) is reflected immediately after saving by fixing cache invalidation behavior in both `useUpdateAgent` hooks.
> 
> On successful agent update, the hooks now invalidate React Query caches using the correct `queryKey` shape (no extra array wrapping) for `findAll` and `findOne`, and additionally call `router.invalidate()` to refresh TanStack Router loader cache so routes like chat don’t continue showing stale agent state.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5b59331a6ca9bbf47de5349777f1e8ed947dbe4e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->