### PR TITLE
fix: make tooltip for anonymous mode shorter AYC-000

### DIFF
--- a/ayunis-core-frontend/src/shared/locales/de/common.json
+++ b/ayunis-core-frontend/src/shared/locales/de/common.json
@@ -64,8 +64,8 @@
     "modelChangeDisabledTooltip": "Das Modell kann nicht geändert werden, wenn ein Agent ausgewählt ist.",
     "cancelTooltip": "Abbrechen",
     "sendTooltip": "Senden",
-    "anonymousModeEnabled": "Anonymer Modus aktiviert - Personenbezogene Daten werden entfernt",
-    "anonymousModeDisabled": "Klicken Sie, um den anonymen Modus zu aktivieren (entfernt persönliche Daten)",
+    "anonymousModeEnabled": "Anonymen Modus deaktivieren",
+    "anonymousModeDisabled": "Anonymen Modus aktivieren",
     "anonymousModeEnforced": "Datenschutzmodus ist für dieses Modell erforderlich",
     "agents": {
       "title": "Agenten"

--- a/ayunis-core-frontend/src/shared/locales/en/common.json
+++ b/ayunis-core-frontend/src/shared/locales/en/common.json
@@ -64,8 +64,8 @@
     "modelChangeDisabledTooltip": "The model cannot be changed when an agent is selected.",
     "cancelTooltip": "Cancel",
     "sendTooltip": "Send",
-    "anonymousModeEnabled": "Anonymous mode enabled - PII will be redacted",
-    "anonymousModeDisabled": "Click to enable anonymous mode (redacts personal data)",
+    "anonymousModeEnabled": "Deactivate Anonymous Mode",
+    "anonymousModeDisabled": "Activate Anonymous Mode",
     "anonymousModeEnforced": "Privacy mode is required by this model",
     "agents": {
       "title": "Agents"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Text-only i18n changes; no behavioral or logic changes beyond what the tooltip displays.
> 
> **Overview**
> Updates the `chatInput.anonymousModeEnabled`/`chatInput.anonymousModeDisabled` i18n strings in `en/common.json` and `de/common.json` to shorter, action-oriented tooltip text (activate/deactivate anonymous mode) instead of longer explanations about PII redaction.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 64af47c3d0be1629226bb05a539b1cd0e9ae8084. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->