### PR TITLE
feat: resend expired invites

### DIFF
--- a/ayunis-core-backend/src/iam/invites/application/invites.errors.ts
+++ b/ayunis-core-backend/src/iam/invites/application/invites.errors.ts
@@ -7,6 +7,7 @@ import {
 export enum InvitesErrorCode {
   INVITE_NOT_FOUND = 'INVITE_NOT_FOUND',
   INVITE_EXPIRED = 'INVITE_EXPIRED',
+  INVITE_NOT_EXPIRED = 'INVITE_NOT_EXPIRED',
   INVITE_ALREADY_ACCEPTED = 'INVITE_ALREADY_ACCEPTED',
   INVALID_INVITE_TOKEN = 'INVALID_INVITE_TOKEN',
   INVITE_EMAIL_MISMATCH = 'INVITE_EMAIL_MISMATCH',
@@ -58,6 +59,23 @@ export class InviteNotFoundError extends InviteError {
 export class InviteExpiredError extends InviteError {
   constructor(metadata?: ErrorMetadata) {
     super('Invite has expired', InvitesErrorCode.INVITE_EXPIRED, 400, metadata);
+  }
+}
+
+/**
+ * Error thrown when trying to resend an invite that has not expired yet
+ */
+export class InviteNotExpiredError extends InviteError {
+  constructor(inviteId: string, metadata?: ErrorMetadata) {
+    super(
+      `Invite with ID '${inviteId}' has not expired yet`,
+      InvitesErrorCode.INVITE_NOT_EXPIRED,
+      400,
+      {
+        inviteId,
+        ...metadata,
+      },
+    );
   }
 }
 

--- a/ayunis-core-backend/src/iam/invites/application/services/invite-expiration.util.ts
+++ b/ayunis-core-backend/src/iam/invites/application/services/invite-expiration.util.ts
@@ -1,0 +1,40 @@
+/**
+ * Calculates the expiration date for an invite based on a duration string.
+ *
+ * @param inviteExpiresIn - Duration string in format: number + d/h/m/s (e.g., "7d", "24h", "60m", "3600s")
+ * @returns Date object representing the expiration time
+ * @throws Error if the format is invalid
+ */
+export function getInviteExpiresAt(inviteExpiresIn: string): Date {
+  // Parse duration like "7d", "24h", "60m", "3600s"
+  const match = inviteExpiresIn.match(/^(\d+)([dhms])$/);
+
+  if (!match) {
+    throw new Error(
+      `Invalid invite expires in format: ${inviteExpiresIn}. Expected format: number + d/h/m/s (e.g., "7d", "24h")`,
+    );
+  }
+
+  const [, amountStr, unit] = match;
+  const amount = parseInt(amountStr, 10);
+
+  let multiplier: number;
+  switch (unit) {
+    case 'd':
+      multiplier = 24 * 60 * 60 * 1000; // days to milliseconds
+      break;
+    case 'h':
+      multiplier = 60 * 60 * 1000; // hours to milliseconds
+      break;
+    case 'm':
+      multiplier = 60 * 1000; // minutes to milliseconds
+      break;
+    case 's':
+      multiplier = 1000; // seconds to milliseconds
+      break;
+    default:
+      throw new Error(`Unsupported time unit: ${unit}`);
+  }
+
+  return new Date(Date.now() + amount * multiplier);
+}

--- a/ayunis-core-backend/src/iam/invites/application/use-cases/resend-expired-invite/resend-expired-invite.command.ts
+++ b/ayunis-core-backend/src/iam/invites/application/use-cases/resend-expired-invite/resend-expired-invite.command.ts
@@ -1,0 +1,9 @@
+import { UUID } from 'crypto';
+
+export class ResendExpiredInviteCommand {
+  public readonly inviteId: UUID;
+
+  constructor(inviteId: UUID) {
+    this.inviteId = inviteId;
+  }
+}

--- a/ayunis-core-backend/src/iam/invites/application/use-cases/resend-expired-invite/resend-expired-invite.use-case.ts
+++ b/ayunis-core-backend/src/iam/invites/application/use-cases/resend-expired-invite/resend-expired-invite.use-case.ts
@@ -1,0 +1,126 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InvitesRepository } from '../../ports/invites.repository';
+import { Invite } from 'src/iam/invites/domain/invite.entity';
+import { ResendExpiredInviteCommand } from './resend-expired-invite.command';
+import { ConfigService } from '@nestjs/config';
+import { InviteJwtService } from '../../services/invite-jwt.service';
+import {
+  InviteNotFoundError,
+  InviteNotExpiredError,
+  UnexpectedInviteError,
+} from '../../invites.errors';
+import { ApplicationError } from 'src/common/errors/base.error';
+
+interface ResendExpiredInviteResult {
+  token: string;
+  invite: Invite;
+}
+
+@Injectable()
+export class ResendExpiredInviteUseCase {
+  private readonly logger = new Logger(ResendExpiredInviteUseCase.name);
+
+  constructor(
+    private readonly invitesRepository: InvitesRepository,
+    private readonly inviteJwtService: InviteJwtService,
+    private readonly configService: ConfigService,
+  ) {}
+
+  async execute(
+    command: ResendExpiredInviteCommand,
+  ): Promise<ResendExpiredInviteResult> {
+    this.logger.log('execute', { inviteId: command.inviteId });
+
+    try {
+      // 1. Find the existing invite
+      const existingInvite = await this.invitesRepository.findOne(
+        command.inviteId,
+      );
+      if (!existingInvite) {
+        throw new InviteNotFoundError(command.inviteId);
+      }
+
+      // 2. Verify it is actually expired
+      if (existingInvite.expiresAt >= new Date()) {
+        throw new InviteNotExpiredError(command.inviteId);
+      }
+
+      // 3. Delete the expired invite
+      await this.invitesRepository.delete(command.inviteId);
+
+      // 4. Create a new invite with the same data
+      const validDuration = this.configService.get<string>(
+        'auth.jwt.inviteExpiresIn',
+        '7d',
+      );
+      const inviteExpiresAt = this.getInviteExpiresAt(validDuration);
+
+      const newInvite = new Invite({
+        email: existingInvite.email,
+        orgId: existingInvite.orgId,
+        role: existingInvite.role,
+        inviterId: existingInvite.inviterId,
+        expiresAt: inviteExpiresAt,
+      });
+
+      await this.invitesRepository.create(newInvite);
+
+      // 5. Generate JWT token for the new invite
+      const inviteToken = this.inviteJwtService.generateInviteToken({
+        inviteId: newInvite.id,
+      });
+
+      this.logger.debug('Expired invite resent successfully', {
+        oldInviteId: command.inviteId,
+        newInviteId: newInvite.id,
+        email: newInvite.email,
+      });
+
+      return {
+        token: inviteToken,
+        invite: newInvite,
+      };
+    } catch (error) {
+      if (error instanceof ApplicationError) {
+        throw error;
+      }
+      this.logger.error('Error resending expired invite', {
+        error: error instanceof Error ? error.message : 'Unknown error',
+      });
+      throw new UnexpectedInviteError(error as Error);
+    }
+  }
+
+  private getInviteExpiresAt(inviteExpiresIn: string): Date {
+    const match = inviteExpiresIn.match(/^(\d+)([dhms])$/);
+
+    if (!match) {
+      throw new Error(
+        `Invalid invite expires in format: ${inviteExpiresIn}. Expected format: number + d/h/m/s (e.g., "7d", "24h")`,
+      );
+    }
+
+    const [, amountStr, unit] = match;
+    const amount = parseInt(amountStr, 10);
+
+    let multiplier: number;
+    switch (unit) {
+      case 'd':
+        multiplier = 24 * 60 * 60 * 1000;
+        break;
+      case 'h':
+        multiplier = 60 * 60 * 1000;
+        break;
+      case 'm':
+        multiplier = 60 * 1000;
+        break;
+      case 's':
+        multiplier = 1000;
+        break;
+      default:
+        throw new Error(`Unsupported time unit: ${unit}`);
+    }
+
+    return new Date(Date.now() + amount * multiplier);
+  }
+}

--- a/ayunis-core-backend/src/iam/invites/invites.module.ts
+++ b/ayunis-core-backend/src/iam/invites/invites.module.ts
@@ -24,6 +24,7 @@ import { GetInviteByTokenUseCase } from './application/use-cases/get-invite-by-t
 import { SendInvitationEmailUseCase } from './application/use-cases/send-invitation-email/send-invitation-email.use-case';
 import { DeleteInviteByEmailUseCase } from './application/use-cases/delete-invite-by-email/delete-invite-by-email.use-case';
 import { DeleteAllPendingInvitesUseCase } from './application/use-cases/delete-all-pending-invites/delete-all-pending-invites.use-case';
+import { ResendExpiredInviteUseCase } from './application/use-cases/resend-expired-invite/resend-expired-invite.use-case';
 
 // Presenters
 import { InvitesController } from './presenters/http/invites.controller';
@@ -82,6 +83,7 @@ import { EmailTemplatesModule } from '../../common/email-templates/email-templat
     AcceptInviteUseCase,
     DeleteInviteUseCase,
     DeleteAllPendingInvitesUseCase,
+    ResendExpiredInviteUseCase,
     GetInvitesByOrgUseCase,
     GetInviteByTokenUseCase,
     SendInvitationEmailUseCase,

--- a/ayunis-core-backend/src/iam/invites/presenters/http/invites.controller.ts
+++ b/ayunis-core-backend/src/iam/invites/presenters/http/invites.controller.ts
@@ -327,6 +327,7 @@ export class InvitesController {
 
   @Post(':id/resend')
   @RateLimit({ limit: 10, windowMs: 15 * 60 * 1000 })
+  @Roles(UserRole.ADMIN)
   @ApiOperation({
     summary: 'Resend an expired invite',
     description:

--- a/ayunis-core-frontend/src/pages/admin-settings/users-settings/api/useInviteResend.ts
+++ b/ayunis-core-frontend/src/pages/admin-settings/users-settings/api/useInviteResend.ts
@@ -20,15 +20,18 @@ function resendExpiredInvite(inviteId: string): Promise<ResendInviteResponse> {
   });
 }
 
-export function useInviteResend() {
+export function useInviteResend(
+  onInviteResent?: (response: ResendInviteResponse) => void,
+) {
   const queryClient = useQueryClient();
   const router = useRouter();
   const { t } = useTranslation('admin-settings-users');
 
   const mutation = useMutation({
     mutationFn: (inviteId: string) => resendExpiredInvite(inviteId),
-    onSuccess: () => {
+    onSuccess: (response: ResendInviteResponse) => {
       showSuccess(t('inviteResend.success'));
+      onInviteResent?.(response);
     },
     onError: (error) => {
       try {

--- a/ayunis-core-frontend/src/pages/admin-settings/users-settings/api/useInviteResend.ts
+++ b/ayunis-core-frontend/src/pages/admin-settings/users-settings/api/useInviteResend.ts
@@ -1,0 +1,65 @@
+import {
+  getInvitesControllerGetInvitesQueryKey,
+  getSubscriptionsControllerGetSubscriptionQueryKey,
+} from '@/shared/api/generated/ayunisCoreAPI';
+import { customAxiosInstance } from '@/shared/api/client';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { showError, showSuccess } from '@/shared/lib/toast';
+import { useRouter } from '@tanstack/react-router';
+import extractErrorData from '@/shared/api/extract-error-data';
+import { useTranslation } from 'react-i18next';
+
+interface ResendInviteResponse {
+  url: string | null;
+}
+
+function resendExpiredInvite(inviteId: string): Promise<ResendInviteResponse> {
+  return customAxiosInstance<ResendInviteResponse>({
+    url: `/invites/${inviteId}/resend`,
+    method: 'POST',
+  });
+}
+
+export function useInviteResend() {
+  const queryClient = useQueryClient();
+  const router = useRouter();
+  const { t } = useTranslation('admin-settings-users');
+
+  const mutation = useMutation({
+    mutationFn: (inviteId: string) => resendExpiredInvite(inviteId),
+    onSuccess: () => {
+      showSuccess(t('inviteResend.success'));
+    },
+    onError: (error) => {
+      try {
+        const { code } = extractErrorData(error);
+        switch (code) {
+          case 'INVITE_NOT_FOUND':
+            showError(t('inviteResend.error.inviteNotFound'));
+            break;
+          case 'INVITE_NOT_EXPIRED':
+            showError(t('inviteResend.error.inviteNotExpired'));
+            break;
+          default:
+            showError(t('inviteResend.error.unexpectedError'));
+        }
+      } catch {
+        showError(t('inviteResend.error.unexpectedError'));
+      }
+    },
+    onSettled: () => {
+      void queryClient.invalidateQueries({
+        queryKey: getInvitesControllerGetInvitesQueryKey(),
+      });
+      void queryClient.invalidateQueries({
+        queryKey: getSubscriptionsControllerGetSubscriptionQueryKey(),
+      });
+      void router.invalidate();
+    },
+  });
+
+  return {
+    resendInvite: mutation.mutate,
+    isResending: mutation.isPending,
+  };
+}

--- a/ayunis-core-frontend/src/pages/admin-settings/users-settings/ui/InvitesSection.tsx
+++ b/ayunis-core-frontend/src/pages/admin-settings/users-settings/ui/InvitesSection.tsx
@@ -8,7 +8,7 @@ import {
   DropdownMenuTrigger,
 } from '@/shared/ui/shadcn/dropdown-menu';
 import { Button } from '@/shared/ui/shadcn/button';
-import { MoreHorizontal, Trash2 } from 'lucide-react';
+import { MoreHorizontal, RefreshCw, Trash2 } from 'lucide-react';
 import {
   Card,
   CardAction,
@@ -19,6 +19,7 @@ import {
 import { Table, TableHeader } from '@/shared/ui/shadcn/table';
 import { useInviteDelete } from '../api/useInviteDelete';
 import { useDeleteAllInvites } from '../api/useDeleteAllInvites';
+import { useInviteResend } from '../api/useInviteResend';
 import type { Invite } from '../model/openapi';
 import { useConfirmation } from '@/widgets/confirmation-modal';
 import { useTranslation } from 'react-i18next';
@@ -39,6 +40,7 @@ export default function InvitesSection({
   const { t } = useTranslation('admin-settings-users');
   const { deleteInvite, isLoading: isDeletingInvite } = useInviteDelete();
   const { deleteAllInvites, isDeleting } = useDeleteAllInvites();
+  const { resendInvite, isResending } = useInviteResend();
   const { confirm } = useConfirmation();
 
   const handleDeleteInvite = (invite: Invite) => {
@@ -51,6 +53,18 @@ export default function InvitesSection({
       cancelText: t('confirmations.cancelText'),
       variant: 'destructive',
       onConfirm: () => deleteInvite({ id: invite.id }),
+    });
+  };
+
+  const handleResendInvite = (invite: Invite) => {
+    confirm({
+      title: t('confirmations.resendInviteTitle'),
+      description: t('confirmations.resendInviteDescription', {
+        email: invite.email,
+      }),
+      confirmText: t('confirmations.resendText'),
+      cancelText: t('confirmations.cancelText'),
+      onConfirm: () => resendInvite(invite.id),
     });
   };
 
@@ -129,6 +143,15 @@ export default function InvitesSection({
                         </Button>
                       </DropdownMenuTrigger>
                       <DropdownMenuContent align="end">
+                        {invite.status === 'expired' && (
+                          <DropdownMenuItem
+                            onClick={() => handleResendInvite(invite)}
+                            disabled={isResending}
+                          >
+                            <RefreshCw className="mr-2 h-4 w-4" />
+                            {t('users.resend')}
+                          </DropdownMenuItem>
+                        )}
                         <DropdownMenuItem
                           className="text-red-600"
                           onClick={() => handleDeleteInvite(invite)}

--- a/ayunis-core-frontend/src/shared/locales/de/admin-settings-users.json
+++ b/ayunis-core-frontend/src/shared/locales/de/admin-settings-users.json
@@ -30,6 +30,7 @@
     "changeRole": "Zu Rolle '{{role}}' ändern",
     "user": "Benutzer",
     "admin": "Administrator",
+    "resend": "Einladung erneut senden",
     "sendPasswordReset": "Passwort-Reset senden",
     "noInvitesFound": "Keine Einladungen gefunden",
     "total": "{{count}} gesamt"
@@ -77,7 +78,10 @@
     "changeRoleText": "Rolle ändern",
     "cancelText": "Abbrechen",
     "deleteAllInvitesTitle": "Alle ausstehenden Einladungen löschen",
-    "deleteAllInvitesDescription": "Sind Sie sicher, dass Sie alle {{count}} ausstehenden Einladungen löschen möchten? Diese Aktion kann nicht rückgängig gemacht werden."
+    "deleteAllInvitesDescription": "Sind Sie sicher, dass Sie alle {{count}} ausstehenden Einladungen löschen möchten? Diese Aktion kann nicht rückgängig gemacht werden.",
+    "resendInviteTitle": "Einladung erneut senden",
+    "resendInviteDescription": "Sind Sie sicher, dass Sie die Einladung für {{email}} erneut senden möchten? Die abgelaufene Einladung wird gelöscht und eine neue erstellt.",
+    "resendText": "Erneut senden"
   },
   "deleteAllInvites": {
     "success": "{{count}} ausstehende Einladung(en) erfolgreich gelöscht",
@@ -89,6 +93,14 @@
     "emailNotAvailable": "Einladung nicht möglich.",
     "userAlreadyExists": "Diese E-Mail-Adresse ist bereits als Benutzer in Ihrer Organisation registriert.",
     "emailProviderBlacklisted": "E-Mail-Adresse von diesem Provider ist nicht erlaubt. Bitte verwenden Sie Ihr Firmen E-Mail-Adresse."
+  },
+  "inviteResend": {
+    "success": "Einladung erfolgreich erneut gesendet!",
+    "error": {
+      "inviteNotFound": "Einladung nicht gefunden",
+      "inviteNotExpired": "Diese Einladung ist noch nicht abgelaufen.",
+      "unexpectedError": "Fehler beim erneuten Senden der Einladung. Bitte versuchen Sie es erneut."
+    }
   },
   "inviteDelete": {
     "error": {

--- a/ayunis-core-frontend/src/shared/locales/en/admin-settings-users.json
+++ b/ayunis-core-frontend/src/shared/locales/en/admin-settings-users.json
@@ -30,6 +30,7 @@
     "changeRole": "Change to role '{{role}}'",
     "user": "User",
     "admin": "Admin",
+    "resend": "Resend Invite",
     "sendPasswordReset": "Send Password Reset",
     "noInvitesFound": "No invites found",
     "total": "{{count}} total"
@@ -76,7 +77,10 @@
     "changeRoleText": "Change Role",
     "cancelText": "Cancel",
     "deleteAllInvitesTitle": "Delete All Pending Invites",
-    "deleteAllInvitesDescription": "Are you sure you want to delete all {{count}} pending invites? This action cannot be undone."
+    "deleteAllInvitesDescription": "Are you sure you want to delete all {{count}} pending invites? This action cannot be undone.",
+    "resendInviteTitle": "Resend Invite",
+    "resendInviteDescription": "Are you sure you want to resend the invite for {{email}}? The expired invite will be deleted and a new one will be created.",
+    "resendText": "Resend"
   },
   "deleteAllInvites": {
     "success": "{{count}} pending invite(s) deleted successfully",
@@ -88,6 +92,14 @@
     "emailNotAvailable": "Invite not possible.",
     "userAlreadyExists": "This email address is already registered as a user in your organization.",
     "emailProviderBlacklisted": "Email address from this provider is not allowed. Please use your company email address."
+  },
+  "inviteResend": {
+    "success": "Invite resent successfully!",
+    "error": {
+      "inviteNotFound": "Invite not found",
+      "inviteNotExpired": "This invite has not expired yet.",
+      "unexpectedError": "Failed to resend invite. Please try again."
+    }
   },
   "inviteDelete": {
     "error": {


### PR DESCRIPTION
Add a "Resend Invite" button for expired invites on the admin users page to allow administrators to easily re-issue invitations.

This PR introduces a backend endpoint (`POST /invites/:id/resend`) that deletes an expired invite, creates a new one with the same details, and sends a new invitation email. On the frontend, a "Resend Invite" button is added to the dropdown menu for expired invites in the invites table, along with a confirmation dialog and i18n translations.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-2dc12d67-7640-4c26-b0d5-6d19b460b8cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2dc12d67-7640-4c26-b0d5-6d19b460b8cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches invite lifecycle by deleting/recreating records and issuing new JWT tokens/emails, which could impact onboarding flows if expiry checks or persistence behavior are incorrect. Changes are scoped to the invites module and gated to expired invites with explicit error handling.
> 
> **Overview**
> Enables admins to **resend expired invites**: the backend adds `POST /invites/:id/resend` which validates the invite exists and is expired, deletes the old record, recreates a new invite with the same details and a fresh expiry, generates a new token, and (if configured) re-sends the invitation email.
> 
> This introduces a new `ResendExpiredInviteUseCase`/command and a dedicated `INVITE_NOT_EXPIRED` error code surfaced to the frontend. The admin invites table now shows a *Resend Invite* action for `expired` invites, wired through a new React Query mutation with confirmation dialog, cache invalidation, and i18n strings (EN/DE).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a1d155dbe00038a51701950121d775d8b945dac0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->