### PR TITLE
fix(AYC-51): fix tool schema validation

### DIFF
--- a/ayunis-core-backend/package-lock.json
+++ b/ayunis-core-backend/package-lock.json
@@ -31,6 +31,7 @@
         "@nestjs/typeorm": "^11.0.0",
         "@sentry/nestjs": "^10.25.0",
         "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
         "axios": "^1.12.2",
         "bcrypt": "^5.1.1",
         "cheerio": "^1.0.0",
@@ -10235,6 +10236,8 @@
     },
     "node_modules/ajv-formats": {
       "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.0.0"

--- a/ayunis-core-backend/package.json
+++ b/ayunis-core-backend/package.json
@@ -64,6 +64,7 @@
     "@nestjs/typeorm": "^11.0.0",
     "@sentry/nestjs": "^10.25.0",
     "ajv": "^8.17.1",
+    "ajv-formats": "^3.0.1",
     "axios": "^1.12.2",
     "bcrypt": "^5.1.1",
     "cheerio": "^1.0.0",

--- a/ayunis-core-backend/src/common/validators/ajv.factory.ts
+++ b/ayunis-core-backend/src/common/validators/ajv.factory.ts
@@ -1,0 +1,12 @@
+import Ajv from 'ajv';
+import addFormats from 'ajv-formats';
+
+/**
+ * Creates an Ajv instance with standard JSON Schema format support (uri, email, date-time, etc.).
+ * Use this instead of `new Ajv()` to ensure format keywords in schemas are recognized.
+ */
+export function createAjv(): Ajv {
+  const ajv = new Ajv();
+  addFormats(ajv);
+  return ajv;
+}

--- a/ayunis-core-backend/src/common/validators/jsonSchema.validator.ts
+++ b/ayunis-core-backend/src/common/validators/jsonSchema.validator.ts
@@ -4,7 +4,7 @@ import {
   ValidationOptions,
   ValidationArguments,
 } from 'class-validator';
-import Ajv from 'ajv';
+import { createAjv } from './ajv.factory';
 
 // Basic validation that a value is a JSON Schema object
 export function IsJsonSchema(validationOptions?: ValidationOptions) {
@@ -20,7 +20,7 @@ export function IsJsonSchema(validationOptions?: ValidationOptions) {
             return false;
           }
 
-          const ajv = new Ajv();
+          const ajv = createAjv();
           return ajv.validateSchema(value) === true;
         },
         defaultMessage(args: ValidationArguments) {

--- a/ayunis-core-backend/src/domain/tools/domain/tools/bar-chart-tool.entity.ts
+++ b/ayunis-core-backend/src/domain/tools/domain/tools/bar-chart-tool.entity.ts
@@ -1,4 +1,4 @@
-import Ajv from 'ajv';
+import { createAjv } from 'src/common/validators/ajv.factory';
 import { ToolType } from '../value-objects/tool-type.enum';
 import { FromSchema, JSONSchema } from 'json-schema-to-ts';
 import { DisplayableTool } from '../displayable-tool.entity';
@@ -63,7 +63,7 @@ export class BarChartTool extends DisplayableTool {
   }
 
   validateParams(params: Record<string, any>): BarChartToolParameters {
-    const ajv = new Ajv();
+    const ajv = createAjv();
     const validate = ajv.compile(this.parameters);
     const valid = validate(params);
     if (!valid) {

--- a/ayunis-core-backend/src/domain/tools/domain/tools/code-execution-tool.entity.ts
+++ b/ayunis-core-backend/src/domain/tools/domain/tools/code-execution-tool.entity.ts
@@ -1,4 +1,4 @@
-import Ajv from 'ajv';
+import { createAjv } from 'src/common/validators/ajv.factory';
 import { Tool } from '../tool.entity';
 import { FromSchema, JSONSchema } from 'json-schema-to-ts';
 import { ToolType } from '../value-objects/tool-type.enum';
@@ -59,7 +59,7 @@ ${csvLongDescription}`.trim(),
   }
 
   validateParams(params: Record<string, any>): CodeExecutionToolParameters {
-    const ajv = new Ajv();
+    const ajv = createAjv();
     const validate = ajv.compile(this.parameters);
     const valid = validate(params);
     if (!valid) {

--- a/ayunis-core-backend/src/domain/tools/domain/tools/create-calendar-event-tool.entity.ts
+++ b/ayunis-core-backend/src/domain/tools/domain/tools/create-calendar-event-tool.entity.ts
@@ -1,4 +1,4 @@
-import Ajv from 'ajv';
+import { createAjv } from 'src/common/validators/ajv.factory';
 import { FromSchema, JSONSchema } from 'json-schema-to-ts';
 import { DisplayableTool } from '../displayable-tool.entity';
 import { ToolType } from '../value-objects/tool-type.enum';
@@ -47,7 +47,7 @@ export class CreateCalendarEventTool extends DisplayableTool {
   }
 
   validateParams(params: Record<string, any>): CreateCalendarEventParameters {
-    const ajv = new Ajv();
+    const ajv = createAjv();
     const validate = ajv.compile(this.parameters);
     const valid = validate(params);
     if (!valid) {

--- a/ayunis-core-backend/src/domain/tools/domain/tools/http-tool.entity.ts
+++ b/ayunis-core-backend/src/domain/tools/domain/tools/http-tool.entity.ts
@@ -1,4 +1,4 @@
-import Ajv from 'ajv';
+import { createAjv } from 'src/common/validators/ajv.factory';
 import { ConfigurableTool } from '../configurable-tool.entity';
 import { ToolConfig } from '../tool-config.entity';
 import { UUID } from 'crypto';
@@ -64,7 +64,7 @@ export class HttpTool extends ConfigurableTool<HttpToolConfig> {
   }
 
   validateParams(params: Record<string, any>): HttpToolParameters {
-    const ajv = new Ajv();
+    const ajv = createAjv();
     const validate = ajv.compile(this.parameters);
     const valid = validate(params);
     if (!valid) {

--- a/ayunis-core-backend/src/domain/tools/domain/tools/internet-search-tool.entity.ts
+++ b/ayunis-core-backend/src/domain/tools/domain/tools/internet-search-tool.entity.ts
@@ -1,6 +1,6 @@
 import { FromSchema, JSONSchema } from 'json-schema-to-ts';
 import { ToolType } from '../value-objects/tool-type.enum';
-import Ajv from 'ajv';
+import { createAjv } from 'src/common/validators/ajv.factory';
 import { Tool } from '../tool.entity';
 
 const internetSearchToolParameters = {
@@ -29,7 +29,7 @@ export class InternetSearchTool extends Tool {
   }
 
   validateParams(params: Record<string, any>): InternetSearchToolParameters {
-    const ajv = new Ajv();
+    const ajv = createAjv();
     const validate = ajv.compile(this.parameters);
     const valid = validate(params);
     if (!valid) {

--- a/ayunis-core-backend/src/domain/tools/domain/tools/line-chart-tool.entity.ts
+++ b/ayunis-core-backend/src/domain/tools/domain/tools/line-chart-tool.entity.ts
@@ -1,4 +1,4 @@
-import Ajv from 'ajv';
+import { createAjv } from 'src/common/validators/ajv.factory';
 import { ToolType } from '../value-objects/tool-type.enum';
 import { FromSchema, JSONSchema } from 'json-schema-to-ts';
 import { DisplayableTool } from '../displayable-tool.entity';
@@ -63,7 +63,7 @@ export class LineChartTool extends DisplayableTool {
   }
 
   validateParams(params: Record<string, any>): LineChartToolParameters {
-    const ajv = new Ajv();
+    const ajv = createAjv();
     const validate = ajv.compile(this.parameters);
     const valid = validate(params);
     if (!valid) {

--- a/ayunis-core-backend/src/domain/tools/domain/tools/mcp-integration-prompt.entity.ts
+++ b/ayunis-core-backend/src/domain/tools/domain/tools/mcp-integration-prompt.entity.ts
@@ -1,4 +1,4 @@
-import Ajv from 'ajv';
+import { createAjv } from 'src/common/validators/ajv.factory';
 import { Tool } from '../tool.entity';
 import { ToolType } from '../value-objects/tool-type.enum';
 import { FromSchema, JSONSchema } from 'json-schema-to-ts';
@@ -41,7 +41,7 @@ export class McpPromptTool extends Tool {
   validateParams(
     params: Record<string, any>,
   ): FromSchema<typeof this.parameters> {
-    const ajv = new Ajv();
+    const ajv = createAjv();
     const validate = ajv.compile(this.parameters);
     const valid = validate(params);
     if (!valid) {

--- a/ayunis-core-backend/src/domain/tools/domain/tools/mcp-integration-resource.entity.ts
+++ b/ayunis-core-backend/src/domain/tools/domain/tools/mcp-integration-resource.entity.ts
@@ -1,4 +1,4 @@
-import Ajv from 'ajv';
+import { createAjv } from 'src/common/validators/ajv.factory';
 import { Tool } from '../tool.entity';
 import { ToolType } from '../value-objects/tool-type.enum';
 import { FromSchema, JSONSchema } from 'json-schema-to-ts';
@@ -40,7 +40,7 @@ export class McpIntegrationResource extends Tool {
   }
 
   validateParams(params: Record<string, any>): McpResourceToolParameters {
-    const ajv = new Ajv();
+    const ajv = createAjv();
     const validate = ajv.compile(this.parameters);
     const valid = validate(params);
     if (!valid) {

--- a/ayunis-core-backend/src/domain/tools/domain/tools/mcp-integration-tool.entity.ts
+++ b/ayunis-core-backend/src/domain/tools/domain/tools/mcp-integration-tool.entity.ts
@@ -1,4 +1,4 @@
-import Ajv from 'ajv';
+import { createAjv } from 'src/common/validators/ajv.factory';
 import { Tool } from '../tool.entity';
 import { ToolType } from '../value-objects/tool-type.enum';
 import { FromSchema } from 'json-schema-to-ts';
@@ -28,7 +28,7 @@ export class McpIntegrationTool extends Tool {
   validateParams(
     params: Record<string, any>,
   ): FromSchema<typeof this.parameters> {
-    const ajv = new Ajv();
+    const ajv = createAjv();
     const validate = ajv.compile(this.parameters);
     const valid = validate(params);
     if (!valid) {

--- a/ayunis-core-backend/src/domain/tools/domain/tools/pie-chart-tool.entity.ts
+++ b/ayunis-core-backend/src/domain/tools/domain/tools/pie-chart-tool.entity.ts
@@ -1,4 +1,4 @@
-import Ajv from 'ajv';
+import { createAjv } from 'src/common/validators/ajv.factory';
 import { ToolType } from '../value-objects/tool-type.enum';
 import { FromSchema, JSONSchema } from 'json-schema-to-ts';
 import { DisplayableTool } from '../displayable-tool.entity';
@@ -52,7 +52,7 @@ export class PieChartTool extends DisplayableTool {
   }
 
   validateParams(params: Record<string, any>): PieChartToolParameters {
-    const ajv = new Ajv();
+    const ajv = createAjv();
     const validate = ajv.compile(this.parameters);
     const valid = validate(params);
     if (!valid) {

--- a/ayunis-core-backend/src/domain/tools/domain/tools/product-knowledge-tool.entity.ts
+++ b/ayunis-core-backend/src/domain/tools/domain/tools/product-knowledge-tool.entity.ts
@@ -1,6 +1,6 @@
 import { FromSchema, JSONSchema } from 'json-schema-to-ts';
 import { ToolType } from '../value-objects/tool-type.enum';
-import Ajv from 'ajv';
+import { createAjv } from 'src/common/validators/ajv.factory';
 import { Tool } from '../tool.entity';
 
 export enum ProductKnowledgeTopic {
@@ -41,7 +41,7 @@ export class ProductKnowledgeTool extends Tool {
   }
 
   validateParams(params: Record<string, any>): ProductKnowledgeToolParameters {
-    const ajv = new Ajv();
+    const ajv = createAjv();
     const validate = ajv.compile(this.parameters);
     const valid = validate(params);
     if (!valid) {

--- a/ayunis-core-backend/src/domain/tools/domain/tools/send-email-tool.entity.ts
+++ b/ayunis-core-backend/src/domain/tools/domain/tools/send-email-tool.entity.ts
@@ -1,4 +1,4 @@
-import Ajv from 'ajv';
+import { createAjv } from 'src/common/validators/ajv.factory';
 import { ToolType } from '../value-objects/tool-type.enum';
 import { FromSchema, JSONSchema } from 'json-schema-to-ts';
 import { DisplayableTool } from '../displayable-tool.entity';
@@ -38,7 +38,7 @@ export class SendEmailTool extends DisplayableTool {
   }
 
   validateParams(params: Record<string, any>): SendEmailToolParameters {
-    const ajv = new Ajv();
+    const ajv = createAjv();
     const validate = ajv.compile(this.parameters);
     const valid = validate(params);
     if (!valid) {

--- a/ayunis-core-backend/src/domain/tools/domain/tools/source-get-text-tool.entity.ts
+++ b/ayunis-core-backend/src/domain/tools/domain/tools/source-get-text-tool.entity.ts
@@ -1,5 +1,5 @@
 import { JSONSchema } from 'json-schema-to-ts';
-import Ajv from 'ajv';
+import { createAjv } from 'src/common/validators/ajv.factory';
 import { ToolType } from '../value-objects/tool-type.enum';
 import { Source } from 'src/domain/sources/domain/source.entity';
 import { Tool } from '../tool.entity';
@@ -50,7 +50,7 @@ export class SourceGetTextTool extends Tool {
   }
 
   validateParams(params: Record<string, unknown>): SourceGetTextToolParameters {
-    const ajv = new Ajv();
+    const ajv = createAjv();
     const validate = ajv.compile(this.parameters);
     const valid = validate(params);
     if (!valid) {

--- a/ayunis-core-backend/src/domain/tools/domain/tools/source-query-tool.entity.ts
+++ b/ayunis-core-backend/src/domain/tools/domain/tools/source-query-tool.entity.ts
@@ -1,5 +1,5 @@
 import { JSONSchema } from 'json-schema-to-ts';
-import Ajv from 'ajv';
+import { createAjv } from 'src/common/validators/ajv.factory';
 import { ToolType } from '../value-objects/tool-type.enum';
 import { Source } from 'src/domain/sources/domain/source.entity';
 import { Tool } from '../tool.entity';
@@ -41,7 +41,7 @@ export class SourceQueryTool extends Tool {
   }
 
   validateParams(params: Record<string, any>): SourceQueryToolParameters {
-    const ajv = new Ajv();
+    const ajv = createAjv();
     const validate = ajv.compile(this.parameters);
     const valid = validate(params);
     if (!valid) {

--- a/ayunis-core-backend/src/domain/tools/domain/tools/website-content-tool.entity.ts
+++ b/ayunis-core-backend/src/domain/tools/domain/tools/website-content-tool.entity.ts
@@ -1,7 +1,7 @@
 import { FromSchema, JSONSchema } from 'json-schema-to-ts';
 import { ToolType } from '../value-objects/tool-type.enum';
 import { Tool } from '../tool.entity';
-import Ajv from 'ajv';
+import { createAjv } from 'src/common/validators/ajv.factory';
 
 const websiteContentToolParameters = {
   type: 'object' as const,
@@ -27,7 +27,7 @@ export class WebsiteContentTool extends Tool {
   }
 
   validateParams(params: Record<string, any>): WebsiteContentToolParameters {
-    const ajv = new Ajv();
+    const ajv = createAjv();
     const validate = ajv.compile(this.parameters);
     const valid = validate(params);
     if (!valid) {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small, localized change to validation setup and a dependency addition; main risk is subtle behavior change if any existing schemas relied on formats being ignored.
> 
> **Overview**
> Fixes tool JSON Schema validation by standardizing AJV construction with built-in `format` keyword support.
> 
> Adds `ajv-formats` and a new `createAjv()` factory, then updates the `IsJsonSchema` validator and all tool `validateParams()` implementations to use it instead of `new Ajv()` so schemas using formats like `uri`, `email`, or `date-time` validate correctly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5f7dbce1053323149c5a228a208c58b1ab63916d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->