### PR TITLE
chore: add scripts for db backup

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -347,7 +347,7 @@ crontab -e
 Add this line (adjust the path to your checkout):
 
 ```
-0 3 * * * . /opt/ayunis/ayunis-core/ayunis-core-backend/.env && /opt/ayunis/ayunis-core/scripts/backup.sh >> /var/log/ayunis-backup.log 2>&1
+0 3 * * * set -a && . /opt/ayunis/ayunis-core/ayunis-core-backend/.env && set +a && /opt/ayunis/ayunis-core/scripts/backup.sh >> /var/log/ayunis-backup.log 2>&1
 ```
 
 **2. (Recommended) Off-site copies with Hetzner Storage Box:**
@@ -355,7 +355,7 @@ Add this line (adjust the path to your checkout):
 Order a [Storage Box](https://www.hetzner.com/storage/storage-box/) and configure SSH key access, then set `BACKUP_REMOTE` in your cron entry:
 
 ```
-0 3 * * * . /opt/ayunis/ayunis-core/ayunis-core-backend/.env && BACKUP_REMOTE="u123456@u123456.your-storagebox.de:backups/" /opt/ayunis/ayunis-core/scripts/backup.sh >> /var/log/ayunis-backup.log 2>&1
+0 3 * * * set -a && . /opt/ayunis/ayunis-core/ayunis-core-backend/.env && set +a && BACKUP_REMOTE="u123456@u123456.your-storagebox.de:backups/" /opt/ayunis/ayunis-core/scripts/backup.sh >> /var/log/ayunis-backup.log 2>&1
 ```
 
 **3. Verify backups are running:**

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -332,6 +332,60 @@ MCP_ENCRYPTION_KEY must be a 64-character hex string (32 bytes). Generate a key 
    docker compose restart ayunis-core-backend
    ```
 
+## Backups
+
+### Setup
+
+Backups are handled by `scripts/backup.sh`, which dumps Postgres and tars the MinIO volume. Run it on the host via cron.
+
+**1. Configure cron (daily at 3 AM):**
+
+```bash
+crontab -e
+```
+
+Add this line (adjust the path to your checkout):
+
+```
+0 3 * * * . /opt/ayunis/ayunis-core/ayunis-core-backend/.env && /opt/ayunis/ayunis-core/scripts/backup.sh >> /var/log/ayunis-backup.log 2>&1
+```
+
+**2. (Recommended) Off-site copies with Hetzner Storage Box:**
+
+Order a [Storage Box](https://www.hetzner.com/storage/storage-box/) and configure SSH key access, then set `BACKUP_REMOTE` in your cron entry:
+
+```
+0 3 * * * . /opt/ayunis/ayunis-core/ayunis-core-backend/.env && BACKUP_REMOTE="u123456@u123456.your-storagebox.de:backups/" /opt/ayunis/ayunis-core/scripts/backup.sh >> /var/log/ayunis-backup.log 2>&1
+```
+
+**3. Verify backups are running:**
+
+```bash
+# Check the log
+tail -20 /var/log/ayunis-backup.log
+
+# List local backups
+ls -lh /opt/ayunis/backups/
+```
+
+### Restore
+
+```bash
+# Source your env vars
+source /opt/ayunis/ayunis-core/ayunis-core-backend/.env
+
+# List available backups and restore interactively
+./scripts/restore.sh
+```
+
+### Configuration
+
+| Variable | Default | Description |
+|---|---|---|
+| `BACKUP_DIR` | `/opt/ayunis/backups` | Local backup directory |
+| `BACKUP_RETENTION` | `30` | Days to keep old backups |
+| `BACKUP_REMOTE` | (none) | rsync target for off-site copies |
+
 ## Monitoring and Maintenance
 
 ### Health Checks

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -347,7 +347,7 @@ crontab -e
 Add this line (adjust the path to your checkout):
 
 ```
-0 3 * * * set -a && . /opt/ayunis/ayunis-core/ayunis-core-backend/.env && set +a && /opt/ayunis/ayunis-core/scripts/backup.sh >> /var/log/ayunis-backup.log 2>&1
+0 3 * * * /opt/ayunis/ayunis-core/scripts/backup.sh >> /var/log/ayunis-backup.log 2>&1
 ```
 
 **2. (Recommended) Off-site copies with Hetzner Storage Box:**
@@ -355,7 +355,7 @@ Add this line (adjust the path to your checkout):
 Order a [Storage Box](https://www.hetzner.com/storage/storage-box/) and configure SSH key access, then set `BACKUP_REMOTE` in your cron entry:
 
 ```
-0 3 * * * set -a && . /opt/ayunis/ayunis-core/ayunis-core-backend/.env && set +a && BACKUP_REMOTE="u123456@u123456.your-storagebox.de:backups/" /opt/ayunis/ayunis-core/scripts/backup.sh >> /var/log/ayunis-backup.log 2>&1
+0 3 * * * BACKUP_REMOTE="u123456@u123456.your-storagebox.de:backups/" /opt/ayunis/ayunis-core/scripts/backup.sh >> /var/log/ayunis-backup.log 2>&1
 ```
 
 **3. Verify backups are running:**

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Database and MinIO backup script for Ayunis Core
+# Intended to run on the host via cron.
+#
+# Required environment variables (sourced from ayunis-core-backend/.env):
+#   POSTGRES_USER, POSTGRES_DB
+#
+# Optional environment variables:
+#   BACKUP_DIR        — where to store backups (default: /opt/ayunis/backups)
+#   BACKUP_RETENTION  — days to keep old backups (default: 30)
+#   BACKUP_REMOTE     — rsync target for off-site copy (e.g. u123456@u123456.your-storagebox.de:backups/)
+
+set -euo pipefail
+
+BACKUP_DIR="${BACKUP_DIR:-/opt/ayunis/backups}"
+RETENTION_DAYS="${BACKUP_RETENTION:-30}"
+TIMESTAMP=$(date +%Y%m%d_%H%M%S)
+
+mkdir -p "$BACKUP_DIR"
+
+echo "[$(date)] Starting backup..."
+
+# --- Postgres ---
+echo "[$(date)] Dumping Postgres..."
+docker exec ayunis-postgres-prod \
+  pg_dump -U "$POSTGRES_USER" -d "$POSTGRES_DB" --format=custom \
+  > "$BACKUP_DIR/postgres_${TIMESTAMP}.dump"
+
+# --- MinIO (object storage) ---
+echo "[$(date)] Backing up MinIO data..."
+docker run --rm \
+  -v ayunis-core_minio-data:/data:ro \
+  -v "$BACKUP_DIR":/backup \
+  alpine tar czf "/backup/minio_${TIMESTAMP}.tar.gz" -C /data .
+
+# --- Prune old backups ---
+echo "[$(date)] Pruning backups older than ${RETENTION_DAYS} days..."
+find "$BACKUP_DIR" -name "postgres_*.dump" -mtime +"$RETENTION_DAYS" -delete
+find "$BACKUP_DIR" -name "minio_*.tar.gz" -mtime +"$RETENTION_DAYS" -delete
+
+# --- Off-site copy (optional) ---
+if [ -n "${BACKUP_REMOTE:-}" ]; then
+  echo "[$(date)] Syncing to remote: $BACKUP_REMOTE"
+  rsync -az --delete "$BACKUP_DIR/" "$BACKUP_REMOTE"
+fi
+
+echo "[$(date)] Backup completed: postgres_${TIMESTAMP}.dump, minio_${TIMESTAMP}.tar.gz"

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -6,32 +6,80 @@
 #   POSTGRES_USER, POSTGRES_DB
 #
 # Optional environment variables:
-#   BACKUP_DIR        — where to store backups (default: /opt/ayunis/backups)
-#   BACKUP_RETENTION  — days to keep old backups (default: 30)
-#   BACKUP_REMOTE     — rsync target for off-site copy (e.g. u123456@u123456.your-storagebox.de:backups/)
+#   BACKUP_DIR           — where to store backups (default: /opt/ayunis/backups)
+#   BACKUP_RETENTION     — days to keep old backups (default: 30)
+#   BACKUP_REMOTE        — rsync target for off-site copy (e.g. u123456@u123456.your-storagebox.de:backups/)
+#   COMPOSE_PROJECT_NAME — override if different from directory name
 
 set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_DIR="$(dirname "$SCRIPT_DIR")"
+
+# Source .env if POSTGRES_USER is not already set
+if [ -z "${POSTGRES_USER:-}" ]; then
+  ENV_FILE="$REPO_DIR/ayunis-core-backend/.env"
+  if [ -f "$ENV_FILE" ]; then
+    set -a
+    # Filter out comments and empty lines before sourcing
+    . <(grep -v '^\s*#' "$ENV_FILE" | grep -v '^\s*$')
+    set +a
+  else
+    echo "ERROR: $ENV_FILE not found and POSTGRES_USER not set" >&2
+    exit 1
+  fi
+fi
 
 BACKUP_DIR="${BACKUP_DIR:-/opt/ayunis/backups}"
 RETENTION_DAYS="${BACKUP_RETENTION:-30}"
 TIMESTAMP=$(date +%Y%m%d_%H%M%S)
 
+# Resolve the Docker Compose volume prefix
+COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME:-$(basename "$REPO_DIR" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9_-]//g')}"
+
 mkdir -p "$BACKUP_DIR"
+
+cleanup() {
+  if [ "${BACKUP_COMPLETE:-}" != "true" ]; then
+    echo "[$(date)] Backup failed, cleaning up partial files..." >&2
+    rm -f "$BACKUP_DIR/postgres_${TIMESTAMP}.dump" "$BACKUP_DIR/minio_${TIMESTAMP}.tar.gz"
+  fi
+}
+trap cleanup EXIT
 
 echo "[$(date)] Starting backup..."
 
 # --- Postgres ---
 echo "[$(date)] Dumping Postgres..."
+PG_DUMP="$BACKUP_DIR/postgres_${TIMESTAMP}.dump"
 docker exec ayunis-postgres-prod \
   pg_dump -U "$POSTGRES_USER" -d "$POSTGRES_DB" --format=custom \
-  > "$BACKUP_DIR/postgres_${TIMESTAMP}.dump"
+  > "$PG_DUMP"
+
+# Verify the dump is non-empty and valid
+if [ ! -s "$PG_DUMP" ]; then
+  echo "[$(date)] ERROR: Postgres dump is empty!" >&2
+  rm -f "$PG_DUMP"
+  exit 1
+fi
+# Quick validation — pg_restore can list the TOC
+docker exec -i ayunis-postgres-prod pg_restore --list < "$PG_DUMP" > /dev/null 2>&1 || {
+  echo "[$(date)] ERROR: Postgres dump is corrupted!" >&2
+  exit 1
+}
+echo "[$(date)] Postgres dump verified ($(du -h "$PG_DUMP" | cut -f1))"
 
 # --- MinIO (object storage) ---
 echo "[$(date)] Backing up MinIO data..."
+MINIO_TAR="$BACKUP_DIR/minio_${TIMESTAMP}.tar.gz"
 docker run --rm \
-  -v ayunis-core_minio-data:/data:ro \
+  -v "${COMPOSE_PROJECT_NAME}_minio-data:/data:ro" \
   -v "$BACKUP_DIR":/backup \
   alpine tar czf "/backup/minio_${TIMESTAMP}.tar.gz" -C /data .
+
+if [ ! -s "$MINIO_TAR" ]; then
+  echo "[$(date)] WARNING: MinIO backup is empty (volume may have no data)" >&2
+fi
 
 # --- Prune old backups ---
 echo "[$(date)] Pruning backups older than ${RETENTION_DAYS} days..."
@@ -41,7 +89,8 @@ find "$BACKUP_DIR" -name "minio_*.tar.gz" -mtime +"$RETENTION_DAYS" -delete
 # --- Off-site copy (optional) ---
 if [ -n "${BACKUP_REMOTE:-}" ]; then
   echo "[$(date)] Syncing to remote: $BACKUP_REMOTE"
-  rsync -az --delete "$BACKUP_DIR/" "$BACKUP_REMOTE"
+  rsync -az "$BACKUP_DIR/" "$BACKUP_REMOTE"
 fi
 
+BACKUP_COMPLETE="true"
 echo "[$(date)] Backup completed: postgres_${TIMESTAMP}.dump, minio_${TIMESTAMP}.tar.gz"

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -31,7 +31,7 @@ if [ -z "${POSTGRES_USER:-}" ]; then
 fi
 
 BACKUP_DIR="${BACKUP_DIR:-/opt/ayunis/backups}"
-RETENTION_DAYS="${BACKUP_RETENTION:-30}"
+RETENTION_DAYS="${BACKUP_RETENTION:-5}"
 TIMESTAMP=$(date +%Y%m%d_%H%M%S)
 
 # Resolve the Docker Compose volume prefix

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -86,11 +86,14 @@ echo "[$(date)] Pruning backups older than ${RETENTION_DAYS} days..."
 find "$BACKUP_DIR" -name "postgres_*.dump" -mtime +"$RETENTION_DAYS" -delete
 find "$BACKUP_DIR" -name "minio_*.tar.gz" -mtime +"$RETENTION_DAYS" -delete
 
+BACKUP_COMPLETE="true"
+
 # --- Off-site copy (optional) ---
 if [ -n "${BACKUP_REMOTE:-}" ]; then
   echo "[$(date)] Syncing to remote: $BACKUP_REMOTE"
-  rsync -az "$BACKUP_DIR/" "$BACKUP_REMOTE"
+  rsync -az "$BACKUP_DIR/" "$BACKUP_REMOTE" || {
+    echo "[$(date)] WARNING: Off-site sync failed (local backup is safe)" >&2
+  }
 fi
 
-BACKUP_COMPLETE="true"
 echo "[$(date)] Backup completed: postgres_${TIMESTAMP}.dump, minio_${TIMESTAMP}.tar.gz"

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -13,10 +13,32 @@
 #
 # Required environment variables (sourced from ayunis-core-backend/.env):
 #   POSTGRES_USER, POSTGRES_DB
+#
+# Optional environment variables:
+#   BACKUP_DIR           — where backups are stored (default: /opt/ayunis/backups)
+#   COMPOSE_PROJECT_NAME — override if different from directory name
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_DIR="$(dirname "$SCRIPT_DIR")"
+
+# Source .env if POSTGRES_USER is not already set
+if [ -z "${POSTGRES_USER:-}" ]; then
+  ENV_FILE="$REPO_DIR/ayunis-core-backend/.env"
+  if [ -f "$ENV_FILE" ]; then
+    set -a
+    . <(grep -v '^\s*#' "$ENV_FILE" | grep -v '^\s*$')
+    set +a
+  else
+    echo "ERROR: $ENV_FILE not found and POSTGRES_USER not set" >&2
+    exit 1
+  fi
+fi
+
 BACKUP_DIR="${BACKUP_DIR:-/opt/ayunis/backups}"
+
+COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME:-$(basename "$REPO_DIR" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9_-]//g')}"
 
 if [ -z "${1:-}" ]; then
   echo "Usage: $0 <timestamp>"
@@ -39,9 +61,10 @@ for f in "$PG_DUMP" "$MINIO_TAR"; do
 done
 
 echo "=== Ayunis Core Restore ==="
-echo "Timestamp: $TIMESTAMP"
-echo "Postgres:  $PG_DUMP ($(du -h "$PG_DUMP" | cut -f1))"
-echo "MinIO:     $MINIO_TAR ($(du -h "$MINIO_TAR" | cut -f1))"
+echo "Timestamp:  $TIMESTAMP"
+echo "Postgres:   $PG_DUMP ($(du -h "$PG_DUMP" | cut -f1))"
+echo "MinIO:      $MINIO_TAR ($(du -h "$MINIO_TAR" | cut -f1))"
+echo "Project:    $COMPOSE_PROJECT_NAME"
 echo ""
 read -p "This will OVERWRITE current data. Continue? [y/N] " -n 1 -r
 echo ""
@@ -51,18 +74,32 @@ if [[ ! $REPLY =~ ^[Yy]$ ]]; then
   exit 0
 fi
 
+# --- Stop the app so there are no active DB connections ---
+echo "[$(date)] Stopping app..."
+cd "$REPO_DIR"
+docker compose stop app 2>/dev/null || true
+
 # --- Restore Postgres ---
+# Use --clean to drop existing objects, --if-exists to avoid errors on missing objects,
+# and --single-transaction to roll back on error.
 echo "[$(date)] Restoring Postgres..."
 docker exec -i ayunis-postgres-prod \
-  pg_restore -U "$POSTGRES_USER" -d "$POSTGRES_DB" --clean --if-exists < "$PG_DUMP"
+  pg_restore -U "$POSTGRES_USER" -d "$POSTGRES_DB" \
+    --clean --if-exists --single-transaction \
+  < "$PG_DUMP"
 
 # --- Restore MinIO ---
 echo "[$(date)] Restoring MinIO data..."
-docker compose stop minio
+docker compose stop minio 2>/dev/null || true
 docker run --rm \
-  -v ayunis-core_minio-data:/data \
+  -v "${COMPOSE_PROJECT_NAME}_minio-data:/data" \
   -v "$BACKUP_DIR":/backup \
-  alpine sh -c "rm -rf /data/* && tar xzf /backup/minio_${TIMESTAMP}.tar.gz -C /data"
-docker compose start minio
+  alpine sh -c "find /data -mindepth 1 -delete && tar xzf /backup/minio_${TIMESTAMP}.tar.gz -C /data"
+
+# --- Restart services ---
+echo "[$(date)] Starting services..."
+docker compose start minio 2>/dev/null || true
+docker compose start app 2>/dev/null || true
 
 echo "[$(date)] Restore completed. Verify the application is working correctly."
+echo "[$(date)] If services didn't restart, run: docker compose up -d"

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Restore script for Ayunis Core backups
+#
+# Usage:
+#   ./scripts/restore.sh <timestamp>
+#
+# Example:
+#   ./scripts/restore.sh 20260210_030000
+#
+# This will restore from:
+#   postgres_20260210_030000.dump
+#   minio_20260210_030000.tar.gz
+#
+# Required environment variables (sourced from ayunis-core-backend/.env):
+#   POSTGRES_USER, POSTGRES_DB
+
+set -euo pipefail
+
+BACKUP_DIR="${BACKUP_DIR:-/opt/ayunis/backups}"
+
+if [ -z "${1:-}" ]; then
+  echo "Usage: $0 <timestamp>"
+  echo ""
+  echo "Available backups:"
+  ls -1 "$BACKUP_DIR"/postgres_*.dump 2>/dev/null | sed 's/.*postgres_/  /;s/\.dump//' || echo "  (none)"
+  exit 1
+fi
+
+TIMESTAMP="$1"
+PG_DUMP="$BACKUP_DIR/postgres_${TIMESTAMP}.dump"
+MINIO_TAR="$BACKUP_DIR/minio_${TIMESTAMP}.tar.gz"
+
+# Validate files exist
+for f in "$PG_DUMP" "$MINIO_TAR"; do
+  if [ ! -f "$f" ]; then
+    echo "ERROR: Backup file not found: $f"
+    exit 1
+  fi
+done
+
+echo "=== Ayunis Core Restore ==="
+echo "Timestamp: $TIMESTAMP"
+echo "Postgres:  $PG_DUMP ($(du -h "$PG_DUMP" | cut -f1))"
+echo "MinIO:     $MINIO_TAR ($(du -h "$MINIO_TAR" | cut -f1))"
+echo ""
+read -p "This will OVERWRITE current data. Continue? [y/N] " -n 1 -r
+echo ""
+
+if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+  echo "Aborted."
+  exit 0
+fi
+
+# --- Restore Postgres ---
+echo "[$(date)] Restoring Postgres..."
+docker exec -i ayunis-postgres-prod \
+  pg_restore -U "$POSTGRES_USER" -d "$POSTGRES_DB" --clean --if-exists < "$PG_DUMP"
+
+# --- Restore MinIO ---
+echo "[$(date)] Restoring MinIO data..."
+docker compose stop minio
+docker run --rm \
+  -v ayunis-core_minio-data:/data \
+  -v "$BACKUP_DIR":/backup \
+  alpine sh -c "rm -rf /data/* && tar xzf /backup/minio_${TIMESTAMP}.tar.gz -C /data"
+docker compose start minio
+
+echo "[$(date)] Restore completed. Verify the application is working correctly."


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Restore flow is destructive (drops and recreates the database and overwrites MinIO volume contents) and depends on hard-coded container/volume naming, so misconfiguration could cause data loss or failed restores.
> 
> **Overview**
> Adds **host-run backup and restore tooling** for production deployments: `scripts/backup.sh` creates a timestamped `pg_dump` (custom format) and a tarball of the MinIO Docker volume, validates outputs, prunes old backups, and can optionally `rsync` the backup directory to an off-site target.
> 
> Introduces `scripts/restore.sh` to perform an interactive restore that **drops/recreates the Postgres database**, restores via `pg_restore`, stages and swaps MinIO volume contents, and restarts `docker compose` services; `DEPLOYMENT.md` is updated with cron setup, restore instructions, and `BACKUP_*` configuration variables.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2fc38ba4c4e90e9bb61bb8a5ca1e8da22f78d564. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->