### PR TITLE
fix: display user roles for super admins

### DIFF
--- a/ayunis-core-frontend/src/pages/super-admin-settings/org/ui/UsersTable.tsx
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/org/ui/UsersTable.tsx
@@ -126,6 +126,7 @@ export default function UsersTable({
                   <TableHead>{t('table.name')}</TableHead>
                   <TableHead>{t('table.createdAt')}</TableHead>
                   <TableHead>{t('table.email')}</TableHead>
+                  <TableHead>{t('table.role')}</TableHead>
                   <TableHead className="w-[100px]">
                     {t('table.actions')}
                   </TableHead>
@@ -137,6 +138,11 @@ export default function UsersTable({
                     <TableCell className="font-medium">{user.name}</TableCell>
                     <TableCell>{formatDate(user.createdAt)}</TableCell>
                     <TableCell>{user.email}</TableCell>
+                    <TableCell className="capitalize">
+                      {user.role === 'admin'
+                        ? t('table.roleAdmin')
+                        : t('table.roleUser')}
+                    </TableCell>
                     <TableCell className="w-[100px]">
                       <DropdownMenu>
                         <DropdownMenuTrigger asChild>

--- a/ayunis-core-frontend/src/shared/locales/de/super-admin-settings-org.json
+++ b/ayunis-core-frontend/src/shared/locales/de/super-admin-settings-org.json
@@ -11,6 +11,9 @@
     "name": "Name",
     "createdAt": "Erstellt am",
     "email": "E-Mail",
+    "role": "Rolle",
+    "roleAdmin": "Administrator",
+    "roleUser": "Benutzer",
     "actions": "Aktionen",
     "sendPasswordReset": "Passwort-Reset senden",
     "delete": "Löschen"

--- a/ayunis-core-frontend/src/shared/locales/en/super-admin-settings-org.json
+++ b/ayunis-core-frontend/src/shared/locales/en/super-admin-settings-org.json
@@ -11,6 +11,9 @@
     "name": "Name",
     "createdAt": "Created",
     "email": "Email",
+    "role": "Role",
+    "roleAdmin": "Admin",
+    "roleUser": "User",
     "actions": "Actions",
     "sendPasswordReset": "Send Password Reset",
     "delete": "Delete"


### PR DESCRIPTION
Add a 'Role' column to the super-admin users table on the org detail page to display each user's role.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-5366f5a1-885c-4896-9fb1-f9725088f6b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5366f5a1-885c-4896-9fb1-f9725088f6b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/i18n-only change that adds a derived display field to an existing table without affecting auth, permissions, or data mutations.
> 
> **Overview**
> **Super-admin org user list now displays user roles.** The users table adds a new `Role` column that renders each user’s role as a translated label (admin vs user).
> 
> **Localization updated.** Adds `table.role`, `table.roleAdmin`, and `table.roleUser` keys to `en` and `de` `super-admin-settings-org.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cfe76e2c44b5ab0d5998479f771eeab1190e622c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->