### PR TITLE
fix: improve chat input accessibility

### DIFF
--- a/.github/workflows/complexity-check.yml
+++ b/.github/workflows/complexity-check.yml
@@ -38,8 +38,8 @@ jobs:
           LENGTH_THRESHOLD=50   # Function length in lines
           ARGS_THRESHOLD=5      # Number of arguments
           
-          # Filter out generated code and entity files (same as pre-commit hook)
-          FILTERED=$(echo "${{ steps.changed-files.outputs.all_changed_files }}" | tr ' ' '\n' | grep -v '/generated/' | grep -v '\.entity\.ts$' || true)
+          # Filter out generated code, entity files, and frontend (lizard doesn't handle React/JSX well)
+          FILTERED=$(echo "${{ steps.changed-files.outputs.all_changed_files }}" | tr ' ' '\n' | grep -v '/generated/' | grep -v '\.entity\.ts$' | grep -v '^ayunis-core-frontend/' || true)
           
           if [ -z "$FILTERED" ]; then
             echo "✅ No non-generated TypeScript files to check"

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -173,11 +173,10 @@ run_be_tsc() {
 
 run_complexity() {
   STATUS_FILE="$1"
-  print_section "Complexity • Lizard (staged TS)"
-  ALL_TS_STAGED=$(printf "%s\n%s" "$BE_TS_STAGED" "$FE_TS_STAGED" | sed '/^$/d')
-  printf "%s\n" "$ALL_TS_STAGED" | sed 's#^# - #'
+  print_section "Complexity • Lizard (staged backend TS)"
+  printf "%s\n" "$BE_TS_STAGED" | sed 's#^# - #'
   set +e
-  printf "%s" "$ALL_TS_STAGED" | tr '\n' ' ' | xargs ./scripts/check-complexity.sh
+  printf "%s" "$BE_TS_STAGED" | tr '\n' ' ' | xargs ./scripts/check-complexity.sh
   STATUS=$?
   set -e
   printf "%s" "$STATUS" > "$STATUS_FILE"
@@ -197,9 +196,8 @@ if [ -n "$BE_TS_STAGED" ]; then
   run_be_tsc "$BE_TSC_STATUS_FILE" &
 fi
 
-# Complexity check runs on all staged TS files (backend + frontend)
-ALL_TS_STAGED=$(printf "%s\n%s" "$BE_TS_STAGED" "$FE_TS_STAGED" | sed '/^$/d')
-if [ -n "$ALL_TS_STAGED" ]; then
+# Complexity check runs on backend TS files only (lizard doesn't handle React/JSX well)
+if [ -n "$BE_TS_STAGED" ]; then
   run_complexity "$COMPLEXITY_STATUS_FILE" &
 fi
 
@@ -259,9 +257,8 @@ if [ -n "$BE_TS_STAGED" ]; then
   fi
 fi
 
-# Complexity check result (runs on both backend + frontend TS files)
-ALL_TS_STAGED_CHECK=$(printf "%s\n%s" "$BE_TS_STAGED" "$FE_TS_STAGED" | sed '/^$/d')
-if [ -n "$ALL_TS_STAGED_CHECK" ]; then
+# Complexity check result (backend only)
+if [ -n "$BE_TS_STAGED" ]; then
   if [ "$COMPLEXITY_STATUS" -ne 0 ]; then
     printf "%b\n" "${RED}❌ Complexity check failed (CCN>10, length>50, or args>5)${NC}"
     FAILED=1

--- a/ayunis-core-frontend/src/shared/locales/de/common.json
+++ b/ayunis-core-frontend/src/shared/locales/de/common.json
@@ -84,7 +84,8 @@
     "transcribing": "Wird transkribiert...",
     "microphonePermissionDenied": "Mikrofonzugriff verweigert",
     "recordingNotSupported": "Sprachaufnahme wird in diesem Browser nicht unterstützt",
-    "transcriptionFailed": "Transkription fehlgeschlagen"
+    "transcriptionFailed": "Transkription fehlgeschlagen",
+    "modelSelectorAriaLabel": "KI-Modell auswählen"
   },
   "common": {
     "loading": "Laden...",

--- a/ayunis-core-frontend/src/shared/locales/en/common.json
+++ b/ayunis-core-frontend/src/shared/locales/en/common.json
@@ -84,7 +84,8 @@
     "transcribing": "Transcribing...",
     "microphonePermissionDenied": "Microphone access denied",
     "recordingNotSupported": "Voice recording is not supported in this browser",
-    "transcriptionFailed": "Transcription failed"
+    "transcriptionFailed": "Transcription failed",
+    "modelSelectorAriaLabel": "Select AI model"
   },
   "common": {
     "loading": "Loading...",

--- a/ayunis-core-frontend/src/widgets/chat-input/ui/AgentButton.tsx
+++ b/ayunis-core-frontend/src/widgets/chat-input/ui/AgentButton.tsx
@@ -65,7 +65,12 @@ export default function AgentButton({
       <DropdownMenu>
         <DropdownMenuTrigger asChild disabled={isDisabled}>
           <TooltipTrigger asChild>
-            <Button variant="outline" size="icon" disabled={isDisabled}>
+            <Button
+              variant="outline"
+              size="icon"
+              disabled={isDisabled}
+              aria-label={t('chatInput.agentButtonTooltip')}
+            >
               <Bot className="h-4 w-4" />
             </Button>
           </TooltipTrigger>

--- a/ayunis-core-frontend/src/widgets/chat-input/ui/AnonymousButton.tsx
+++ b/ayunis-core-frontend/src/widgets/chat-input/ui/AnonymousButton.tsx
@@ -44,6 +44,7 @@ export function AnonymousButton({
           size="icon"
           disabled={effectiveIsDisabled}
           onClick={() => onAnonymousChange?.(!isAnonymous)}
+          aria-label={getTooltipContent()}
         >
           <ShieldCheck className="h-4 w-4" />
         </Button>

--- a/ayunis-core-frontend/src/widgets/chat-input/ui/ChatInput.tsx
+++ b/ayunis-core-frontend/src/widgets/chat-input/ui/ChatInput.tsx
@@ -273,6 +273,7 @@ const ChatInput = forwardRef<ChatInputRef, ChatInputProps>(
                 onFocus={() => setIsFocused(true)}
                 onBlur={() => setIsFocused(false)}
                 placeholder={t('chatInput.placeholder')}
+                aria-label={t('chatInput.placeholder')}
                 className="border-0 border-none bg-transparent rounded-none resize-none focus:outline-none p-0"
                 data-testid="input"
               />

--- a/ayunis-core-frontend/src/widgets/chat-input/ui/MicrophoneButton.tsx
+++ b/ayunis-core-frontend/src/widgets/chat-input/ui/MicrophoneButton.tsx
@@ -65,6 +65,7 @@ export function MicrophoneButton({
             className={cn('rounded-full', isRecording && 'animate-pulse')}
             onClick={handleClick}
             disabled={busy}
+            aria-label={tooltipText}
           >
             {busy ? (
               <Loader2 className="h-4 w-4 animate-spin" />

--- a/ayunis-core-frontend/src/widgets/chat-input/ui/ModelSelector.tsx
+++ b/ayunis-core-frontend/src/widgets/chat-input/ui/ModelSelector.tsx
@@ -7,6 +7,7 @@ import {
 } from '@/shared/ui/shadcn/select';
 import { usePermittedModels } from '@/features/usePermittedModels';
 import { getFlagByProvider } from '@/shared/lib/getFlagByProvider';
+import { useTranslation } from 'react-i18next';
 
 interface ModelSelectorProps {
   isDisabled: boolean;
@@ -19,6 +20,7 @@ export default function ModelSelector({
   selectedModelId,
   onModelChange,
 }: ModelSelectorProps) {
+  const { t } = useTranslation('common');
   const {
     models,
     placeholder,
@@ -51,6 +53,7 @@ export default function ModelSelector({
       <SelectTrigger
         className="border-none shadow-none"
         disabled={isDisabled || isDisabledModels}
+        aria-label={t('chatInput.modelSelectorAriaLabel')}
       >
         <SelectValue placeholder={placeholder} />
       </SelectTrigger>

--- a/ayunis-core-frontend/src/widgets/chat-input/ui/PlusButton.tsx
+++ b/ayunis-core-frontend/src/widgets/chat-input/ui/PlusButton.tsx
@@ -89,7 +89,11 @@ export default function PlusButton({
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
           <TooltipTrigger asChild>
-            <Button size="icon" variant="outline">
+            <Button
+              size="icon"
+              variant="outline"
+              aria-label={t('chatInput.addButtonTooltip')}
+            >
               {isLoading ? (
                 <Loader2 className="h-4 w-4 animate-spin" />
               ) : (

--- a/ayunis-core-frontend/src/widgets/chat-input/ui/SendButton.tsx
+++ b/ayunis-core-frontend/src/widgets/chat-input/ui/SendButton.tsx
@@ -31,6 +31,7 @@ export function SendButton({
               size="icon"
               className="rounded-full border border-transparent"
               onClick={onCancel}
+              aria-label={t('chatInput.cancelTooltip')}
             >
               <Square className="h-4 w-4" />
             </Button>
@@ -51,6 +52,7 @@ export function SendButton({
             size="icon"
             data-testid="send"
             onClick={onSend}
+            aria-label={t('chatInput.sendTooltip')}
           >
             <ArrowUp className="h-4 w-4" />
           </Button>


### PR DESCRIPTION
…end (AYC-0)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to accessibility attributes/i18n strings in the frontend and CI/pre-commit filtering to avoid running `lizard` on React/JSX files.
> 
> **Overview**
> Improves chat input accessibility by adding missing `aria-label`s to key controls (agent/add/anonymous/microphone/send buttons, message textarea, and model selector) and introducing a new i18n string (`chatInput.modelSelectorAriaLabel`) in `en`/`de`.
> 
> Adjusts developer/CI complexity checks to **exclude frontend** files: the GitHub `complexity-check` workflow and `.husky/pre-commit` now run `lizard` only on backend TypeScript to avoid React/JSX parsing issues.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e47e53b968e24a4828597e34ee9fd97cf2cb98e6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->