### PR TITLE
chore: add Docker logging rotation, resource limits, and Dozzle

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,18 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
+    logging:
+      driver: json-file
+      options:
+        max-size: "50m"
+        max-file: "5"
+    deploy:
+      resources:
+        limits:
+          memory: 1G
+          cpus: "1"
+        reservations:
+          memory: 512M
 
   minio:
     image: quay.io/minio/minio:latest
@@ -39,6 +51,18 @@ services:
     # Only expose console port externally if needed
     ports:
       - "9001:9001"
+    logging:
+      driver: json-file
+      options:
+        max-size: "50m"
+        max-file: "5"
+    deploy:
+      resources:
+        limits:
+          memory: 512M
+          cpus: "0.5"
+        reservations:
+          memory: 256M
 
   docker-socket-proxy:
     image: tecnativa/docker-socket-proxy:latest
@@ -73,6 +97,16 @@ services:
     networks:
       - docker-proxy-network
     # No need to expose ports - only accessed internally
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+    deploy:
+      resources:
+        limits:
+          memory: 128M
+          cpus: "0.25"
 
   code-execution:
     build:
@@ -101,6 +135,16 @@ services:
       retries: 3
       start_period: 10s
     # Now running with restricted Docker access through proxy
+    logging:
+      driver: json-file
+      options:
+        max-size: "50m"
+        max-file: "5"
+    deploy:
+      resources:
+        limits:
+          memory: 256M
+          cpus: "0.5"
 
   anonymize:
     build:
@@ -120,6 +164,18 @@ services:
       timeout: 10s
       retries: 3
       start_period: 30s # Longer start period for model loading
+    logging:
+      driver: json-file
+      options:
+        max-size: "50m"
+        max-file: "5"
+    deploy:
+      resources:
+        limits:
+          memory: 2G
+          cpus: "2"
+        reservations:
+          memory: 1G
 
   app:
     build:
@@ -161,6 +217,39 @@ services:
       timeout: 10s
       retries: 3
       start_period: 40s
+    logging:
+      driver: json-file
+      options:
+        max-size: "50m"
+        max-file: "5"
+    deploy:
+      resources:
+        limits:
+          memory: 1G
+          cpus: "2"
+        reservations:
+          memory: 512M
+
+  dozzle:
+    image: amir20/dozzle:latest
+    container_name: ayunis-dozzle-prod
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:8888:8080" # localhost only for security
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    networks:
+      - ayunis-network
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+    deploy:
+      resources:
+        limits:
+          memory: 128M
+          cpus: "0.25"
 
 volumes:
   postgres-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -238,8 +238,9 @@ services:
       - "127.0.0.1:8888:8080" # localhost only for security
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
-    networks:
-      - ayunis-network
+    # No network needed - Dozzle only requires the Docker socket.
+    # Keeping it off ayunis-network ensures the 127.0.0.1 port binding
+    # is the only access path (other containers cannot reach dozzle:8080).
     logging:
       driver: json-file
       options:


### PR DESCRIPTION
## Summary

Adds production-ready logging and resource management to the Docker Compose stack.

## Changes

### Log Rotation
- All services now use `json-file` driver with rotation
- 50MB max size, 5 files retained (smaller for low-traffic services)
- Prevents disk space exhaustion from unbounded log growth

### Resource Limits
| Service | Memory Limit | CPU Limit | Memory Reserved |
|---------|-------------|-----------|-----------------|
| postgres | 1G | 1 | 512M |
| minio | 512M | 0.5 | 256M |
| docker-socket-proxy | 128M | 0.25 | - |
| code-execution | 256M | 0.5 | - |
| anonymize | 2G | 2 | 1G |
| app | 1G | 2 | 512M |

**Note:** anonymize needs 2G because it loads two spaCy `lg` models (~500MB each)

### Dozzle Log Viewer
- Live web UI for viewing container logs
- Accessible at `localhost:8888` (bound to 127.0.0.1 for security)
- Useful for debugging without SSH

## Total Stack Requirements
~5G RAM recommended for the full stack with headroom

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Compose-only operational changes; main risk is misconfigured resource limits/log rotation affecting service stability or troubleshooting in production.
> 
> **Overview**
> Adds **log rotation** across the Compose stack by configuring the `json-file` logging driver with size/file limits per service to prevent unbounded disk usage.
> 
> Introduces **per-service resource constraints** via `deploy.resources` (CPU/memory limits and select reservations) for `postgres`, `minio`, `docker-socket-proxy`, `code-execution`, `anonymize`, and `app`.
> 
> Adds a `dozzle` service for live log viewing, bound to `127.0.0.1:8888` and mounted read-only to the Docker socket.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7f23e173c3c649c759d82df593156ae0f7cb0f9d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->