### PR TITLE
refactor(AYC-86): extract skill activation into separate entity

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,6 +83,36 @@ Do NOT trust your own assessment of code correctness. Verify through observable 
 
 ---
 
+## Forbidden Actions
+
+These rules exist because an agent violated them and caused data loss. They are non-negotiable.
+
+### Never kill processes
+
+You do not understand what is running on the host machine. Processes that look like "just postgres" or "just ssh" may be Colima's infrastructure, SSH tunnels, or other critical services. If a port is occupied or a process is blocking something, **describe the problem and ask** — never `kill`, `pkill`, or `killall`.
+
+### Never use destructive Docker flags
+
+Never use `docker compose down -v`, `docker volume rm`, `docker system prune`, or any command that deletes volumes. Volumes contain database data that cannot be restored. The only safe Docker commands are:
+
+- `docker compose up` / `docker compose down` (without `-v`)
+- `docker compose ps` / `docker compose logs`
+- `docker compose exec` (to run commands inside containers)
+
+### Never modify system or infrastructure state
+
+Do not stop/restart Colima, edit Docker configs, change network settings, modify `/etc/hosts`, or touch anything outside the repository that isn't a source file.
+
+### When the environment is broken, stop and ask
+
+If Docker won't start, ports are occupied, containers won't come up, or anything infrastructure-related is failing: **describe what you see and ask for instructions.** Do not attempt to diagnose or fix environment issues autonomously. Every escalating "fix" risks making things worse.
+
+### General rule
+
+If an action is irreversible and isn't writing/editing source code, **ask first**.
+
+---
+
 ## Development Skills
 
 For detailed development workflows, patterns, and validation checklists, use the appropriate skill:

--- a/ayunis-core-backend/src/db/migrations/1771234503886-ExtractSkillActivation.ts
+++ b/ayunis-core-backend/src/db/migrations/1771234503886-ExtractSkillActivation.ts
@@ -1,0 +1,35 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class ExtractSkillActivation1771234503886 implements MigrationInterface {
+  name = 'ExtractSkillActivation1771234503886';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE "skill_activations" ("id" uuid NOT NULL, "skillId" character varying NOT NULL, "userId" character varying NOT NULL, "createdAt" TIMESTAMP NOT NULL DEFAULT now(), CONSTRAINT "UQ_skill_activation_skillId_userId" UNIQUE ("skillId", "userId"), CONSTRAINT "PK_0b22559d50b2d24952dc2a8b098" PRIMARY KEY ("id"))`,
+    );
+    // Migrate existing isActive=true skills into skill_activations
+    await queryRunner.query(
+      `INSERT INTO "skill_activations" ("id", "skillId", "userId", "createdAt") SELECT gen_random_uuid(), "id", "userId", NOW() FROM "skills" WHERE "isActive" = true`,
+    );
+    await queryRunner.query(`ALTER TABLE "skills" DROP COLUMN "isActive"`);
+    await queryRunner.query(
+      `ALTER TABLE "skill_activations" ADD CONSTRAINT "FK_6416c05feb99f4b56b7ce4af155" FOREIGN KEY ("skillId") REFERENCES "skills"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "skill_activations" ADD CONSTRAINT "FK_8caf15dc7766481cd4197e566f8" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "skill_activations" DROP CONSTRAINT "FK_8caf15dc7766481cd4197e566f8"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "skill_activations" DROP CONSTRAINT "FK_6416c05feb99f4b56b7ce4af155"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "skills" ADD "isActive" boolean NOT NULL DEFAULT false`,
+    );
+    await queryRunner.query(`DROP TABLE "skill_activations"`);
+  }
+}

--- a/ayunis-core-backend/src/domain/runs/application/services/system-prompt-builder.service.spec.ts
+++ b/ayunis-core-backend/src/domain/runs/application/services/system-prompt-builder.service.spec.ts
@@ -18,7 +18,6 @@ describe('SystemPromptBuilderService', () => {
           shortDescription:
             'Knowledge about German administrative law procedures',
           instructions: 'Full instructions here...',
-          isActive: true,
           userId: randomUUID(),
         }),
         new Skill({
@@ -27,7 +26,6 @@ describe('SystemPromptBuilderService', () => {
           shortDescription:
             'Analyze datasets and produce statistical summaries',
           instructions: 'Full data analysis instructions...',
-          isActive: true,
           userId: randomUUID(),
         }),
       ];
@@ -147,7 +145,6 @@ describe('SystemPromptBuilderService', () => {
           name: 'QA Helper',
           shortDescription: 'Handles <special> "quoted" queries & more',
           instructions: 'Instructions...',
-          isActive: true,
           userId: randomUUID(),
         }),
       ];

--- a/ayunis-core-backend/src/domain/skills/SUMMARY.md
+++ b/ayunis-core-backend/src/domain/skills/SUMMARY.md
@@ -7,7 +7,7 @@ Skills are reusable knowledge + integration bundles that an AI assistant can act
 ## Key Concepts
 
 - **Skill**: A named bundle with a short description (shown in system prompt), long description (instructions, returned on activation), sources, and MCP integrations.
-- **Activation**: Skills have an `isActive` boolean. Only active skills are surfaced in the system prompt as available for the LLM to activate.
+- **Activation**: Skill activation is tracked in a separate `skill_activations` table (via `SkillActivationRecord`). Only active skills are surfaced in the system prompt as available for the LLM to activate. The repository provides `activateSkill`, `deactivateSkill`, `isSkillActive`, and `getActiveSkillIds` methods to manage activation state.
 - **On-demand injection**: The LLM activates a skill via the `activate_skill` tool, which injects the skill's instructions and attaches its sources/MCP integrations to the thread.
 - **Name uniqueness**: Skill names must be unique per user (enforced at repository level) because the `activate_skill` tool uses the name as the identifier.
 
@@ -19,7 +19,7 @@ skills/
 ├── domain/
 │   └── skill.entity.ts                    # Skill domain entity
 ├── application/
-│   ├── ports/skill.repository.ts          # Abstract repository
+│   ├── ports/skill.repository.ts          # Abstract repository (includes activation methods)
 │   ├── skills.errors.ts                   # Domain errors
 │   └── use-cases/
 │       ├── create-skill/
@@ -38,7 +38,9 @@ skills/
 │       └── list-skill-mcp-integrations/
 ├── infrastructure/
 │   └── persistence/local/
-│       ├── schema/skill.record.ts          # TypeORM entity (ManyToMany for sources + MCP)
+│       ├── schema/
+│       │   ├── skill.record.ts             # TypeORM entity (ManyToMany for sources + MCP)
+│       │   └── skill-activation.record.ts  # Activation state (unique per skillId + userId)
 │       ├── mappers/skill.mapper.ts
 │       ├── local-skill.repository.ts
 │       └── local-skill-repository.module.ts
@@ -55,6 +57,8 @@ skills/
 ## Design Decisions
 
 Both sources and MCP integrations use the same `@ManyToMany` + `@JoinTable` pattern. The domain entity stores `sourceIds: UUID[]` and `mcpIntegrationIds: UUID[]`. Full entity objects are fetched via dedicated list use cases (`ListSkillSourcesUseCase`, `ListSkillMcpIntegrationsUseCase`) that batch-fetch by IDs.
+
+Activation state is stored in a separate `skill_activations` table rather than a boolean on the skill entity. This allows tracking activation per user without modifying the skill record itself. The `SkillActivationRecord` has a unique constraint on `(skillId, userId)` to ensure each user can only have one activation per skill. The repository uses atomic upsert operations (`INSERT ... ON CONFLICT DO NOTHING`) to handle concurrent activation requests safely.
 
 ## Dependencies
 

--- a/ayunis-core-backend/src/domain/skills/application/ports/skill.repository.ts
+++ b/ayunis-core-backend/src/domain/skills/application/ports/skill.repository.ts
@@ -12,4 +12,8 @@ export abstract class SkillRepository {
     name: string,
     userId: UUID,
   ): Promise<Skill | null>;
+  abstract activateSkill(skillId: UUID, userId: UUID): Promise<void>;
+  abstract deactivateSkill(skillId: UUID, userId: UUID): Promise<void>;
+  abstract isSkillActive(skillId: UUID, userId: UUID): Promise<boolean>;
+  abstract getActiveSkillIds(userId: UUID): Promise<Set<UUID>>;
 }

--- a/ayunis-core-backend/src/domain/skills/application/use-cases/create-skill/create-skill.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/skills/application/use-cases/create-skill/create-skill.use-case.spec.ts
@@ -18,6 +18,7 @@ describe('CreateSkillUseCase', () => {
     const mockSkillRepository = {
       create: jest.fn(),
       findByNameAndOwner: jest.fn(),
+      activateSkill: jest.fn(),
     };
 
     const mockContextService = {
@@ -99,7 +100,7 @@ describe('CreateSkillUseCase', () => {
     expect(skillRepository.create).not.toHaveBeenCalled();
   });
 
-  it('should create a skill with isActive true when explicitly set', async () => {
+  it('should activate the skill when isActive is true in command', async () => {
     const command = new CreateSkillCommand({
       name: 'Active Skill',
       shortDescription: 'An active skill.',
@@ -107,26 +108,44 @@ describe('CreateSkillUseCase', () => {
       isActive: true,
     });
 
+    const createdSkill = new Skill({
+      name: command.name,
+      shortDescription: command.shortDescription,
+      instructions: command.instructions,
+      userId: mockUserId,
+    });
+
     skillRepository.findByNameAndOwner.mockResolvedValue(null);
-    skillRepository.create.mockImplementation(async (skill: Skill) => skill);
+    skillRepository.create.mockResolvedValue(createdSkill);
+    skillRepository.activateSkill.mockResolvedValue(undefined);
 
-    const result = await useCase.execute(command);
+    await useCase.execute(command);
 
-    expect(result.isActive).toBe(true);
+    expect(skillRepository.activateSkill).toHaveBeenCalledWith(
+      createdSkill.id,
+      mockUserId,
+    );
   });
 
-  it('should set isActive to false by default', async () => {
+  it('should not activate the skill when isActive is not set', async () => {
     const command = new CreateSkillCommand({
       name: 'Data Analysis',
       shortDescription: 'Analyze data.',
       instructions: 'You are a data analysis expert.',
     });
 
+    const createdSkill = new Skill({
+      name: command.name,
+      shortDescription: command.shortDescription,
+      instructions: command.instructions,
+      userId: mockUserId,
+    });
+
     skillRepository.findByNameAndOwner.mockResolvedValue(null);
-    skillRepository.create.mockImplementation(async (skill: Skill) => skill);
+    skillRepository.create.mockResolvedValue(createdSkill);
 
-    const result = await useCase.execute(command);
+    await useCase.execute(command);
 
-    expect(result.isActive).toBe(false);
+    expect(skillRepository.activateSkill).not.toHaveBeenCalled();
   });
 });

--- a/ayunis-core-backend/src/domain/skills/application/use-cases/create-skill/create-skill.use-case.ts
+++ b/ayunis-core-backend/src/domain/skills/application/use-cases/create-skill/create-skill.use-case.ts
@@ -40,11 +40,16 @@ export class CreateSkillUseCase {
         name: command.name,
         shortDescription: command.shortDescription,
         instructions: command.instructions,
-        isActive: command.isActive,
         userId,
       });
 
-      return this.skillRepository.create(skill);
+      const created = await this.skillRepository.create(skill);
+
+      if (command.isActive) {
+        await this.skillRepository.activateSkill(created.id, userId);
+      }
+
+      return created;
     } catch (error) {
       if (error instanceof ApplicationError) throw error;
       this.logger.error('Error creating skill', { error: error as Error });

--- a/ayunis-core-backend/src/domain/skills/application/use-cases/toggle-skill-active/toggle-skill-active.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/skills/application/use-cases/toggle-skill-active/toggle-skill-active.use-case.spec.ts
@@ -27,6 +27,9 @@ describe('ToggleSkillActiveUseCase', () => {
     const mockSkillRepository = {
       findOne: jest.fn(),
       update: jest.fn(),
+      isSkillActive: jest.fn(),
+      activateSkill: jest.fn(),
+      deactivateSkill: jest.fn(),
     };
 
     const mockContextService = {
@@ -55,44 +58,54 @@ describe('ToggleSkillActiveUseCase', () => {
     jest.clearAllMocks();
   });
 
-  it('should toggle inactive skill to active', async () => {
-    const inactiveSkill = new Skill({
+  it('should activate an inactive skill', async () => {
+    const skill = new Skill({
       id: mockSkillId,
       name: 'Legal Research',
       shortDescription: 'Research legal topics.',
       instructions: 'Instructions.',
       userId: mockUserId,
-      isActive: false,
     });
 
-    skillRepository.findOne.mockResolvedValue(inactiveSkill);
-    skillRepository.update.mockImplementation(async (skill: Skill) => skill);
+    skillRepository.findOne.mockResolvedValue(skill);
+    skillRepository.isSkillActive.mockResolvedValue(false);
+    skillRepository.activateSkill.mockResolvedValue(undefined);
 
     const result = await useCase.execute(
       new ToggleSkillActiveCommand({ skillId: mockSkillId }),
     );
 
     expect(result.isActive).toBe(true);
+    expect(skillRepository.activateSkill).toHaveBeenCalledWith(
+      mockSkillId,
+      mockUserId,
+    );
+    expect(skillRepository.deactivateSkill).not.toHaveBeenCalled();
   });
 
-  it('should toggle active skill to inactive', async () => {
-    const activeSkill = new Skill({
+  it('should deactivate an active skill', async () => {
+    const skill = new Skill({
       id: mockSkillId,
       name: 'Legal Research',
       shortDescription: 'Research legal topics.',
       instructions: 'Instructions.',
       userId: mockUserId,
-      isActive: true,
     });
 
-    skillRepository.findOne.mockResolvedValue(activeSkill);
-    skillRepository.update.mockImplementation(async (skill: Skill) => skill);
+    skillRepository.findOne.mockResolvedValue(skill);
+    skillRepository.isSkillActive.mockResolvedValue(true);
+    skillRepository.deactivateSkill.mockResolvedValue(undefined);
 
     const result = await useCase.execute(
       new ToggleSkillActiveCommand({ skillId: mockSkillId }),
     );
 
     expect(result.isActive).toBe(false);
+    expect(skillRepository.deactivateSkill).toHaveBeenCalledWith(
+      mockSkillId,
+      mockUserId,
+    );
+    expect(skillRepository.activateSkill).not.toHaveBeenCalled();
   });
 
   it('should throw SkillNotFoundError when skill does not exist', async () => {

--- a/ayunis-core-backend/src/domain/skills/application/use-cases/update-skill/update-skill.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/skills/application/use-cases/update-skill/update-skill.use-case.spec.ts
@@ -157,7 +157,7 @@ describe('UpdateSkillUseCase', () => {
     expect(skillRepository.findByNameAndOwner).not.toHaveBeenCalled();
   });
 
-  it('should preserve isActive and mcpIntegrationIds on update', async () => {
+  it('should preserve mcpIntegrationIds on update', async () => {
     const mcpIds = ['aaa00000-0000-0000-0000-000000000000' as UUID];
     const existingSkill = new Skill({
       id: mockSkillId,
@@ -165,7 +165,6 @@ describe('UpdateSkillUseCase', () => {
       shortDescription: 'Research legal topics.',
       instructions: 'Original instructions.',
       userId: mockUserId,
-      isActive: true,
       mcpIntegrationIds: mcpIds,
     });
 
@@ -181,7 +180,6 @@ describe('UpdateSkillUseCase', () => {
 
     const result = await useCase.execute(command);
 
-    expect(result.isActive).toBe(true);
     expect(result.mcpIntegrationIds).toEqual(mcpIds);
   });
 });

--- a/ayunis-core-backend/src/domain/skills/application/use-cases/update-skill/update-skill.use-case.ts
+++ b/ayunis-core-backend/src/domain/skills/application/use-cases/update-skill/update-skill.use-case.ts
@@ -54,7 +54,6 @@ export class UpdateSkillUseCase {
         name: command.name,
         shortDescription: command.shortDescription,
         instructions: command.instructions,
-        isActive: existingSkill.isActive,
         sourceIds: existingSkill.sourceIds,
         mcpIntegrationIds: existingSkill.mcpIntegrationIds,
         userId,

--- a/ayunis-core-backend/src/domain/skills/domain/skill.entity.spec.ts
+++ b/ayunis-core-backend/src/domain/skills/domain/skill.entity.spec.ts
@@ -19,7 +19,6 @@ describe('Skill Entity', () => {
     );
     expect(skill.instructions).toBe('You are a legal research assistant...');
     expect(skill.userId).toBe(mockUserId);
-    expect(skill.isActive).toBe(false);
     expect(skill.sourceIds).toEqual([]);
     expect(skill.mcpIntegrationIds).toEqual([]);
     expect(skill.createdAt).toBeInstanceOf(Date);
@@ -38,18 +37,6 @@ describe('Skill Entity', () => {
     });
 
     expect(skill.id).toBe(explicitId);
-  });
-
-  it('should respect isActive when explicitly set to true', () => {
-    const skill = new Skill({
-      name: 'Active Skill',
-      shortDescription: 'An active skill.',
-      instructions: 'Instructions here.',
-      userId: mockUserId,
-      isActive: true,
-    });
-
-    expect(skill.isActive).toBe(true);
   });
 
   it('should preserve source IDs and MCP integration IDs when provided', () => {

--- a/ayunis-core-backend/src/domain/skills/domain/skill.entity.ts
+++ b/ayunis-core-backend/src/domain/skills/domain/skill.entity.ts
@@ -29,7 +29,6 @@ export class Skill {
   public readonly name: string;
   public readonly shortDescription: string;
   public readonly instructions: string;
-  public readonly isActive: boolean;
   public readonly sourceIds: UUID[];
   public readonly mcpIntegrationIds: UUID[];
   public readonly userId: UUID;
@@ -41,7 +40,6 @@ export class Skill {
     name: string;
     shortDescription: string;
     instructions: string;
-    isActive?: boolean;
     sourceIds?: UUID[];
     mcpIntegrationIds?: UUID[];
     userId: UUID;
@@ -53,7 +51,6 @@ export class Skill {
     this.name = params.name;
     this.shortDescription = params.shortDescription;
     this.instructions = params.instructions;
-    this.isActive = params.isActive ?? false;
     this.sourceIds = params.sourceIds ?? [];
     this.mcpIntegrationIds = params.mcpIntegrationIds ?? [];
     this.userId = params.userId;

--- a/ayunis-core-backend/src/domain/skills/infrastructure/persistence/local/local-skill-repository.module.ts
+++ b/ayunis-core-backend/src/domain/skills/infrastructure/persistence/local/local-skill-repository.module.ts
@@ -2,10 +2,11 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { LocalSkillRepository } from './local-skill.repository';
 import { SkillRecord } from './schema/skill.record';
+import { SkillActivationRecord } from './schema/skill-activation.record';
 import { SkillMapper } from './mappers/skill.mapper';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([SkillRecord])],
+  imports: [TypeOrmModule.forFeature([SkillRecord, SkillActivationRecord])],
   providers: [SkillMapper, LocalSkillRepository],
   exports: [LocalSkillRepository, SkillMapper],
 })

--- a/ayunis-core-backend/src/domain/skills/infrastructure/persistence/local/mappers/skill.mapper.spec.ts
+++ b/ayunis-core-backend/src/domain/skills/infrastructure/persistence/local/mappers/skill.mapper.spec.ts
@@ -22,7 +22,6 @@ describe('SkillMapper', () => {
       record.name = 'Legal Research';
       record.shortDescription = 'Research legal topics.';
       record.instructions = 'You are a legal research assistant.';
-      record.isActive = true;
       record.userId = mockUserId;
       record.sources = [{ id: mockSourceId } as any];
       record.mcpIntegrations = [{ id: mockMcpId } as any];
@@ -35,7 +34,6 @@ describe('SkillMapper', () => {
       expect(domain.name).toBe('Legal Research');
       expect(domain.shortDescription).toBe('Research legal topics.');
       expect(domain.instructions).toBe('You are a legal research assistant.');
-      expect(domain.isActive).toBe(true);
       expect(domain.userId).toBe(mockUserId);
       expect(domain.sourceIds).toEqual([mockSourceId]);
       expect(domain.mcpIntegrationIds).toEqual([mockMcpId]);
@@ -49,7 +47,6 @@ describe('SkillMapper', () => {
       record.name = 'Minimal Skill';
       record.shortDescription = 'Short.';
       record.instructions = 'Instructions.';
-      record.isActive = false;
       record.userId = mockUserId;
       record.createdAt = new Date('2026-01-01');
       record.updatedAt = new Date('2026-01-02');
@@ -68,7 +65,6 @@ describe('SkillMapper', () => {
         name: 'Legal Research',
         shortDescription: 'Research legal topics.',
         instructions: 'You are a legal research assistant.',
-        isActive: true,
         userId: mockUserId,
         sourceIds: [mockSourceId],
         mcpIntegrationIds: [mockMcpId],
@@ -80,7 +76,6 @@ describe('SkillMapper', () => {
       expect(record.name).toBe('Legal Research');
       expect(record.shortDescription).toBe('Research legal topics.');
       expect(record.instructions).toBe('You are a legal research assistant.');
-      expect(record.isActive).toBe(true);
       expect(record.userId).toBe(mockUserId);
     });
   });

--- a/ayunis-core-backend/src/domain/skills/infrastructure/persistence/local/mappers/skill.mapper.ts
+++ b/ayunis-core-backend/src/domain/skills/infrastructure/persistence/local/mappers/skill.mapper.ts
@@ -10,7 +10,6 @@ export class SkillMapper {
       name: record.name,
       shortDescription: record.shortDescription,
       instructions: record.instructions,
-      isActive: record.isActive,
       sourceIds: record.sources?.map((source) => source.id) ?? [],
       mcpIntegrationIds:
         record.mcpIntegrations?.map((integration) => integration.id) ?? [],
@@ -26,7 +25,6 @@ export class SkillMapper {
     record.name = domain.name;
     record.shortDescription = domain.shortDescription;
     record.instructions = domain.instructions;
-    record.isActive = domain.isActive;
     record.userId = domain.userId;
     return record;
   }

--- a/ayunis-core-backend/src/domain/skills/infrastructure/persistence/local/schema/skill-activation.record.ts
+++ b/ayunis-core-backend/src/domain/skills/infrastructure/persistence/local/schema/skill-activation.record.ts
@@ -1,0 +1,33 @@
+import {
+  Entity,
+  Column,
+  ManyToOne,
+  Unique,
+  PrimaryColumn,
+  CreateDateColumn,
+} from 'typeorm';
+import { UUID } from 'crypto';
+import { SkillRecord } from './skill.record';
+import { UserRecord } from '../../../../../../iam/users/infrastructure/repositories/local/schema/user.record';
+
+@Entity({ name: 'skill_activations' })
+@Unique('UQ_skill_activation_skillId_userId', ['skillId', 'userId'])
+export class SkillActivationRecord {
+  @PrimaryColumn('uuid')
+  id: UUID;
+
+  @Column({ nullable: false })
+  skillId: UUID;
+
+  @Column({ nullable: false })
+  userId: UUID;
+
+  @ManyToOne(() => SkillRecord, { nullable: false, onDelete: 'CASCADE' })
+  skill: SkillRecord;
+
+  @ManyToOne(() => UserRecord, { nullable: false, onDelete: 'CASCADE' })
+  user: UserRecord;
+
+  @CreateDateColumn()
+  createdAt: Date;
+}

--- a/ayunis-core-backend/src/domain/skills/infrastructure/persistence/local/schema/skill.record.ts
+++ b/ayunis-core-backend/src/domain/skills/infrastructure/persistence/local/schema/skill.record.ts
@@ -24,9 +24,6 @@ export class SkillRecord extends BaseRecord {
   @Column({ nullable: false })
   instructions: string;
 
-  @Column({ default: false })
-  isActive: boolean;
-
   @Column({ nullable: false })
   userId: UUID;
 

--- a/ayunis-core-backend/src/domain/skills/presenters/http/mappers/skill.mapper.ts
+++ b/ayunis-core-backend/src/domain/skills/presenters/http/mappers/skill.mapper.ts
@@ -8,21 +8,23 @@ import { Source } from 'src/domain/sources/domain/source.entity';
 
 @Injectable()
 export class SkillDtoMapper {
-  toDto(skill: Skill): SkillResponseDto {
+  toDto(skill: Skill, isActive: boolean): SkillResponseDto {
     return {
       id: skill.id,
       name: skill.name,
       shortDescription: skill.shortDescription,
       instructions: skill.instructions,
-      isActive: skill.isActive,
+      isActive,
       userId: skill.userId,
       createdAt: skill.createdAt,
       updatedAt: skill.updatedAt,
     };
   }
 
-  toDtoArray(skills: Skill[]): SkillResponseDto[] {
-    return skills.map((skill) => this.toDto(skill));
+  toDtoArray(skills: Skill[], activeSkillIds: Set<string>): SkillResponseDto[] {
+    return skills.map((skill) =>
+      this.toDto(skill, activeSkillIds.has(skill.id)),
+    );
   }
 
   sourceToDto(source: Source): SkillSourceResponseDto {

--- a/ayunis-core-backend/src/domain/skills/skills.module.ts
+++ b/ayunis-core-backend/src/domain/skills/skills.module.ts
@@ -6,6 +6,7 @@ import { LocalSkillRepositoryModule } from './infrastructure/persistence/local/l
 import { LocalSkillRepository } from './infrastructure/persistence/local/local-skill.repository';
 import { SkillRepository } from './application/ports/skill.repository';
 import { SkillRecord } from './infrastructure/persistence/local/schema/skill.record';
+import { SkillActivationRecord } from './infrastructure/persistence/local/schema/skill-activation.record';
 import { McpIntegrationRecord } from '../mcp/infrastructure/persistence/postgres/schema/mcp-integration.record';
 
 // Use Cases
@@ -31,7 +32,11 @@ import { McpIntegrationDtoMapper } from '../mcp/presenters/http/mappers/mcp-inte
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([SkillRecord, McpIntegrationRecord]),
+    TypeOrmModule.forFeature([
+      SkillRecord,
+      SkillActivationRecord,
+      McpIntegrationRecord,
+    ]),
     LocalSkillRepositoryModule,
     SourcesModule,
     McpModule,


### PR DESCRIPTION
- Add skill_activations table with (skillId, userId) unique constraint
- Remove isActive column from skills table
- Add SkillActivationRecord with cascade deletes on skill/user
- Update repository port with activateSkill, deactivateSkill, isSkillActive, getActiveSkillIds
- Toggle use case now inserts/deletes activation rows instead of flipping boolean
- Create use case activates skill separately when isActive is true
- Controller resolves activation state from activation table for all responses
- API contract (SkillResponseDto) unchanged, no frontend changes needed
- Migration includes data migration for existing isActive=true rows
- Add forbidden actions section to AGENTS.md

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches database schema and migration logic and rewires how activation is computed across use cases/controllers, so mistakes could silently change activation status or break existing data during rollout.
> 
> **Overview**
> **Skill activation is now persisted separately**: adds `skill_activations` (+ `SkillActivationRecord`) with `(skillId,userId)` uniqueness, migrates existing active skills into it, and drops `skills.isActive` via a TypeORM migration.
> 
> Updates the skills domain/API implementation to use activation records: `SkillRepository` gains activation methods, `LocalSkillRepository` implements them (including atomic upsert for activation), `ToggleSkillActiveUseCase` switches to insert/delete semantics, and all `SkillsController` responses now compute `isActive` from activation state while keeping the DTO contract unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c000d0b98252255efa679cce139c4772c0a4042f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->