### PR TITLE
chore: add Dependabot for automated dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -82,7 +82,7 @@ updates:
     open-pull-requests-limit: 5
 
   # Anonymize service (Python/uv)
-  - package-ecosystem: "pip"
+  - package-ecosystem: "uv"
     directory: "/ayunis-core-anonymize"
     schedule:
       interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,176 @@
+version: 2
+updates:
+  # Root package.json (husky, etc.)
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "chore(deps)"
+    labels:
+      - "dependencies"
+    open-pull-requests-limit: 10
+
+  # Backend (NestJS)
+  - package-ecosystem: "npm"
+    directory: "/ayunis-core-backend"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "chore(deps-backend)"
+    labels:
+      - "dependencies"
+      - "backend"
+    open-pull-requests-limit: 10
+    groups:
+      nest:
+        patterns:
+          - "@nestjs/*"
+      typescript:
+        patterns:
+          - "typescript"
+          - "ts-*"
+          - "@types/*"
+      testing:
+        patterns:
+          - "jest"
+          - "@jest/*"
+          - "supertest"
+
+  # Frontend (React/Vite)
+  - package-ecosystem: "npm"
+    directory: "/ayunis-core-frontend"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "chore(deps-frontend)"
+    labels:
+      - "dependencies"
+      - "frontend"
+    open-pull-requests-limit: 10
+    groups:
+      react:
+        patterns:
+          - "react"
+          - "react-dom"
+          - "@types/react*"
+      tanstack:
+        patterns:
+          - "@tanstack/*"
+      radix:
+        patterns:
+          - "@radix-ui/*"
+      vite:
+        patterns:
+          - "vite"
+          - "@vitejs/*"
+
+  # E2E UI Tests (Playwright)
+  - package-ecosystem: "npm"
+    directory: "/ayunis-core-e2e-ui-tests"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "chore(deps-e2e)"
+    labels:
+      - "dependencies"
+      - "testing"
+    open-pull-requests-limit: 5
+
+  # Anonymize service (Python/uv)
+  - package-ecosystem: "pip"
+    directory: "/ayunis-core-anonymize"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "chore(deps-anonymize)"
+    labels:
+      - "dependencies"
+      - "python"
+    open-pull-requests-limit: 5
+
+  # Code execution service (Python)
+  - package-ecosystem: "pip"
+    directory: "/ayunis-core-code-execution"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "chore(deps-code-execution)"
+    labels:
+      - "dependencies"
+      - "python"
+    open-pull-requests-limit: 5
+
+  # Docker base images
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "chore(deps-docker)"
+    labels:
+      - "dependencies"
+      - "docker"
+
+  - package-ecosystem: "docker"
+    directory: "/ayunis-core-backend"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "chore(deps-docker)"
+    labels:
+      - "dependencies"
+      - "docker"
+
+  - package-ecosystem: "docker"
+    directory: "/ayunis-core-anonymize"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "chore(deps-docker)"
+    labels:
+      - "dependencies"
+      - "docker"
+
+  - package-ecosystem: "docker"
+    directory: "/ayunis-core-code-execution"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "chore(deps-docker)"
+    labels:
+      - "dependencies"
+      - "docker"
+
+  - package-ecosystem: "docker"
+    directory: "/ayunis-core-e2e-ui-tests"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "chore(deps-docker)"
+    labels:
+      - "dependencies"
+      - "docker"
+
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "chore(deps-actions)"
+    labels:
+      - "dependencies"
+      - "ci"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -120,17 +120,6 @@ updates:
       - "docker"
 
   - package-ecosystem: "docker"
-    directory: "/ayunis-core-backend"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-    commit-message:
-      prefix: "chore(deps-docker)"
-    labels:
-      - "dependencies"
-      - "docker"
-
-  - package-ecosystem: "docker"
     directory: "/ayunis-core-anonymize"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
## Summary

Add Dependabot configuration to automatically keep dependencies up to date across all services.

## What's monitored

**npm ecosystems:**
- `/` — root (husky, shared tooling)
- `/ayunis-core-backend` — NestJS backend
- `/ayunis-core-frontend` — React/Vite frontend
- `/ayunis-core-e2e-ui-tests` — Playwright tests

**pip ecosystems:**
- `/ayunis-core-anonymize` — Python anonymization service
- `/ayunis-core-code-execution` — Python code execution service

**Docker:**
- All Dockerfiles monitored for base image updates

**GitHub Actions:**
- Workflow action version updates

## Configuration highlights

- **Weekly schedule** — runs every Monday
- **Grouped updates** — related packages bundled (e.g., all @nestjs/*, all @radix-ui/*)
- **Labeled PRs** — easy filtering by service (backend, frontend, python, docker, ci)
- **PR limits** — 5-10 per ecosystem to prevent notification overload

## After merging

Dependabot will start opening PRs for outdated dependencies. Each PR will:
- Include changelog/release notes
- Run CI checks
- Be labeled for easy triage

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI/config-only change that doesn’t affect runtime behavior until Dependabot opens update PRs; main risk is increased PR volume or missed directory/ecosystem coverage due to configuration errors.
> 
> **Overview**
> Adds `.github/dependabot.yml` to enable weekly Dependabot updates across the monorepo, covering npm (root/backend/frontend/e2e), Python (`uv` and `pip` services), Docker base images, and GitHub Actions.
> 
> Configures per-area PR limits, labels, and commit-message prefixes, and groups common dependency families (e.g., NestJS/TypeScript/Jest; React/TanStack/Radix/Vite) to reduce PR noise.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2a36d0261bc230498a7629b9bcb8efb39fc2b63c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->