### PR TITLE
fix: prompt label translation

### DIFF
--- a/ayunis-core-frontend/src/pages/settings/chat-settings/ui/SystemPromptCard.tsx
+++ b/ayunis-core-frontend/src/pages/settings/chat-settings/ui/SystemPromptCard.tsx
@@ -46,7 +46,7 @@ function SystemPromptForm({
   return (
     <div className="space-y-2">
       <Label htmlFor="system-prompt-textarea">
-        {t('chat.systemPromptTitle')}
+        {t('chat.systemPromptLabel')}
       </Label>
       <div className="text-sm text-muted-foreground">
         {t('chat.systemPromptDescription')}

--- a/ayunis-core-frontend/src/shared/locales/de/settings.json
+++ b/ayunis-core-frontend/src/shared/locales/de/settings.json
@@ -57,6 +57,7 @@
     "selectDefaultModel": "Standardmodell auswählen",
     "none": "Kein Modell ausgewählt",
     "systemPromptTitle": "System-Prompt",
+    "systemPromptLabel": "Persönliche Anweisung",
     "systemPromptDescription": "Definieren Sie einen persönlichen System-Prompt, der in jede KI-Unterhaltung eingefügt wird. Verwenden Sie dies, um das KI-Verhalten an Ihre Präferenzen anzupassen.",
     "systemPromptPlaceholder": "z.B. Antworten Sie immer in Stichpunkten. Ich arbeite in der Finanzabteilung.",
     "systemPromptSaved": "System-Prompt erfolgreich gespeichert",

--- a/ayunis-core-frontend/src/shared/locales/en/settings.json
+++ b/ayunis-core-frontend/src/shared/locales/en/settings.json
@@ -57,6 +57,7 @@
     "selectDefaultModel": "Select default model",
     "none": "No model selected",
     "systemPromptTitle": "System Prompt",
+    "systemPromptLabel": "Personal Instruction",
     "systemPromptDescription": "Define a personal system prompt that gets injected into every AI conversation. Use this to customize AI behavior to your preferences.",
     "systemPromptPlaceholder": "e.g. Always respond in bullet points. I work in the finance department.",
     "systemPromptSaved": "System prompt saved successfully",


### PR DESCRIPTION
Update the system prompt textarea label to "Persönliche Anweisung" / "Personal Instruction" by introducing a new translation key.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-e7c369bc-d84f-4018-af10-53c2fa987e72"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e7c369bc-d84f-4018-af10-53c2fa987e72"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Translation-only UI text change with minimal scope and no behavior or data-flow impact.
> 
> **Overview**
> Changes the system prompt textarea label in `SystemPromptCard` to use a new translation key (`chat.systemPromptLabel`) instead of reusing the section title key.
> 
> Adds the corresponding English/German strings ("Personal Instruction" / "Persönliche Anweisung") to `settings.json` locale files.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7e40756ac5417fe28aa0bc513370fd435c71b501. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->