### PR TITLE
fix: add skill create modal translations

### DIFF
--- a/ayunis-core-frontend/src/pages/skill/api/useUpdateSkill.ts
+++ b/ayunis-core-frontend/src/pages/skill/api/useUpdateSkill.ts
@@ -12,13 +12,11 @@ import {
 import type { SkillResponseDto } from '@/shared/api/generated/ayunisCoreAPI.schemas';
 import { useRouter } from '@tanstack/react-router';
 
-const updateSkillSchema = z.object({
-  name: z.string().min(1, 'Name is required').max(255),
-  shortDescription: z.string().min(1, 'Short description is required'),
-  instructions: z.string().min(1, 'Instructions are required'),
-});
-
-type UpdateSkillData = z.infer<typeof updateSkillSchema>;
+type UpdateSkillData = {
+  name: string;
+  shortDescription: string;
+  instructions: string;
+};
 
 interface UseUpdateSkillProps {
   skill: SkillResponseDto;
@@ -28,6 +26,16 @@ export function useUpdateSkill({ skill }: UseUpdateSkillProps) {
   const { t } = useTranslation('skill');
   const queryClient = useQueryClient();
   const router = useRouter();
+
+  const updateSkillSchema = z.object({
+    name: z.string().min(1, t('properties.validation.nameRequired')).max(255),
+    shortDescription: z
+      .string()
+      .min(1, t('properties.validation.shortDescriptionRequired')),
+    instructions: z
+      .string()
+      .min(1, t('properties.validation.instructionsRequired')),
+  });
 
   const form = useForm<UpdateSkillData>({
     resolver: zodResolver(updateSkillSchema),

--- a/ayunis-core-frontend/src/pages/skills/api/useCreateSkill.ts
+++ b/ayunis-core-frontend/src/pages/skills/api/useCreateSkill.ts
@@ -11,18 +11,26 @@ import { useRouter } from '@tanstack/react-router';
 import extractErrorData from '@/shared/api/extract-error-data';
 import { showError } from '@/shared/lib/toast';
 
-const createSkillSchema = z.object({
-  name: z.string().min(1, 'Name is required'),
-  shortDescription: z.string().min(1, 'Short description is required'),
-  instructions: z.string().min(1, 'Instructions are required'),
-});
-
-export type CreateSkillData = z.infer<typeof createSkillSchema>;
+export type CreateSkillData = {
+  name: string;
+  shortDescription: string;
+  instructions: string;
+};
 
 export function useCreateSkill() {
   const { t } = useTranslation('skills');
   const queryClient = useQueryClient();
   const router = useRouter();
+
+  const createSkillSchema = z.object({
+    name: z.string().min(1, t('createDialog.validation.nameRequired')),
+    shortDescription: z
+      .string()
+      .min(1, t('createDialog.validation.shortDescriptionRequired')),
+    instructions: z
+      .string()
+      .min(1, t('createDialog.validation.instructionsRequired')),
+  });
 
   const form = useForm<CreateSkillData>({
     resolver: zodResolver(createSkillSchema),

--- a/ayunis-core-frontend/src/shared/locales/de/skill.json
+++ b/ayunis-core-frontend/src/shared/locales/de/skill.json
@@ -69,6 +69,11 @@
     "buttons": {
       "save": "Änderungen speichern",
       "saving": "Wird gespeichert..."
+    },
+    "validation": {
+      "nameRequired": "Name ist erforderlich",
+      "shortDescriptionRequired": "Kurzbeschreibung ist erforderlich",
+      "instructionsRequired": "Anweisungen sind erforderlich"
     }
   },
   "knowledgeBase": {

--- a/ayunis-core-frontend/src/shared/locales/de/skills.json
+++ b/ayunis-core-frontend/src/shared/locales/de/skills.json
@@ -40,6 +40,11 @@
       "cancel": "Abbrechen",
       "create": "Fähigkeit erstellen",
       "creating": "Wird erstellt..."
+    },
+    "validation": {
+      "nameRequired": "Name ist erforderlich",
+      "shortDescriptionRequired": "Kurzbeschreibung ist erforderlich",
+      "instructionsRequired": "Anweisungen sind erforderlich"
     }
   },
   "create": {

--- a/ayunis-core-frontend/src/shared/locales/en/skill.json
+++ b/ayunis-core-frontend/src/shared/locales/en/skill.json
@@ -69,6 +69,11 @@
     "buttons": {
       "save": "Save changes",
       "saving": "Saving..."
+    },
+    "validation": {
+      "nameRequired": "Name is required",
+      "shortDescriptionRequired": "Short description is required",
+      "instructionsRequired": "Instructions are required"
     }
   },
   "knowledgeBase": {

--- a/ayunis-core-frontend/src/shared/locales/en/skills.json
+++ b/ayunis-core-frontend/src/shared/locales/en/skills.json
@@ -40,6 +40,11 @@
       "cancel": "Cancel",
       "create": "Create Skill",
       "creating": "Creating..."
+    },
+    "validation": {
+      "nameRequired": "Name is required",
+      "shortDescriptionRequired": "Short description is required",
+      "instructionsRequired": "Instructions are required"
     }
   },
   "create": {


### PR DESCRIPTION
Fixes hardcoded English validation messages in skill create/update modals by using i18n.

The Zod validation schemas in `useCreateSkill.ts` and `useUpdateSkill.ts` had hardcoded English error messages, causing validation errors to always appear in English regardless of the user's locale. This PR moves the schemas into the hooks to allow access to the `t` function and introduces new translation keys.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-1ecd1f84-1ce0-4815-9481-9fc6e7617cd2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1ecd1f84-1ce0-4815-9481-9fc6e7617cd2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only changes client-side validation messages and adds i18n strings; minimal behavioral risk aside from potential missing/incorrect translation keys.
> 
> **Overview**
> Skill create and update forms now show **localized** validation errors instead of hardcoded English strings.
> 
> `useCreateSkill` and `useUpdateSkill` move their Zod schemas inside the hooks to access `t(...)`, and `en/de` locale files add new `validation` keys under `skills.createDialog` and `skill.properties`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7773d9f3546c9f4b23fff5f397d316b2ce3069af. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->