### PR TITLE
feat(AYC-82): add marketplace integrations

### DIFF
--- a/ayunis-core-backend/package-lock.json
+++ b/ayunis-core-backend/package-lock.json
@@ -7128,7 +7128,7 @@
     },
     "node_modules/@swc/core": {
       "version": "1.11.21",
-      "devOptional": true,
+      "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -7170,6 +7170,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -7186,6 +7187,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -7202,6 +7204,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -7216,6 +7219,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -7230,6 +7234,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -7246,6 +7251,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -7262,6 +7268,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -7278,6 +7285,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -7294,6 +7302,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -7310,6 +7319,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -7321,7 +7331,7 @@
     },
     "node_modules/@swc/counter": {
       "version": "0.1.3",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/@swc/jest": {
@@ -7344,7 +7354,7 @@
     },
     "node_modules/@swc/types": {
       "version": "0.1.21",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@swc/counter": "^0.1.3"

--- a/ayunis-core-backend/package-lock.json
+++ b/ayunis-core-backend/package-lock.json
@@ -7128,7 +7128,7 @@
     },
     "node_modules/@swc/core": {
       "version": "1.11.21",
-      "dev": true,
+      "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -7170,7 +7170,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -7187,7 +7186,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -7204,7 +7202,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -7219,7 +7216,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -7234,7 +7230,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -7251,7 +7246,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -7268,7 +7262,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -7285,7 +7278,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -7302,7 +7294,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -7319,7 +7310,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -7331,7 +7321,7 @@
     },
     "node_modules/@swc/counter": {
       "version": "0.1.3",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0"
     },
     "node_modules/@swc/jest": {
@@ -7354,7 +7344,7 @@
     },
     "node_modules/@swc/types": {
       "version": "0.1.21",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@swc/counter": "^0.1.3"

--- a/ayunis-core-backend/src/common/clients/anonymize/generated/mSPresidioPIIDetectionAPI.schemas.ts
+++ b/ayunis-core-backend/src/common/clients/anonymize/generated/mSPresidioPIIDetectionAPI.schemas.ts
@@ -47,6 +47,7 @@ export interface HealthResponse {
  */
 export type Language = (typeof Language)[keyof typeof Language];
 
+// eslint-disable-next-line @typescript-eslint/no-redeclare
 export const Language = {
   en: 'en',
   de: 'de',

--- a/ayunis-core-backend/src/common/clients/anonymize/generated/mSPresidioPIIDetectionAPI.schemas.ts
+++ b/ayunis-core-backend/src/common/clients/anonymize/generated/mSPresidioPIIDetectionAPI.schemas.ts
@@ -47,7 +47,6 @@ export interface HealthResponse {
  */
 export type Language = (typeof Language)[keyof typeof Language];
 
-// eslint-disable-next-line @typescript-eslint/no-redeclare
 export const Language = {
   en: 'en',
   de: 'de',

--- a/ayunis-core-backend/src/common/clients/docling/generated/ayunisDocumentProcessing.schemas.ts
+++ b/ayunis-core-backend/src/common/clients/docling/generated/ayunisDocumentProcessing.schemas.ts
@@ -16,8 +16,6 @@ export interface BodyConvertFileConvertFilePost {
 export interface ConvertPathRequest {
   /** Path to the document file */
   path: string;
-  /** Force full-page OCR for scanned documents */
-  force_ocr?: boolean;
 }
 
 /**
@@ -56,7 +54,3 @@ export interface ValidationError {
   msg: string;
   type: string;
 }
-
-export type ConvertFileConvertFilePostParams = {
-  force_ocr?: boolean;
-};

--- a/ayunis-core-backend/src/common/clients/docling/generated/ayunisDocumentProcessing.ts
+++ b/ayunis-core-backend/src/common/clients/docling/generated/ayunisDocumentProcessing.ts
@@ -7,7 +7,6 @@
  */
 import type {
   BodyConvertFileConvertFilePost,
-  ConvertFileConvertFilePostParams,
   ConvertPathRequest,
   ConvertResponse,
   HealthResponse,
@@ -30,12 +29,11 @@ export const getAyunisDocumentProcessing = () => {
   /**
  * Convert an uploaded document file to Markdown.
 
-Supports PDF, DOCX, and PPTX formats. For scanned PDFs, set force_ocr=true.
+Supports PDF, DOCX, and PPTX formats.
  * @summary Convert uploaded file to Markdown
  */
   const convertFileConvertFilePost = (
     bodyConvertFileConvertFilePost: BodyConvertFileConvertFilePost,
-    params?: ConvertFileConvertFilePostParams,
   ) => {
     const formData = new FormData();
     formData.append(`file`, bodyConvertFileConvertFilePost.file);
@@ -45,14 +43,13 @@ Supports PDF, DOCX, and PPTX formats. For scanned PDFs, set force_ocr=true.
       method: 'POST',
       headers: { 'Content-Type': 'multipart/form-data' },
       data: formData,
-      params,
     });
   };
 
   /**
  * Convert a document file from a local path to Markdown.
 
-Supports PDF, DOCX, and PPTX formats. For scanned PDFs, set force_ocr=true.
+Supports PDF, DOCX, and PPTX formats.
  * @summary Convert file from path to Markdown
  */
   const convertPathConvertPathPost = (

--- a/ayunis-core-backend/src/common/clients/marketplace/generated/ayunisMarketplaceAPI.schemas.ts
+++ b/ayunis-core-backend/src/common/clients/marketplace/generated/ayunisMarketplaceAPI.schemas.ts
@@ -100,6 +100,72 @@ export interface SkillResponseDto {
   updatedAt: string;
 }
 
+export interface IntegrationConfigFieldDto {
+  /** Unique identifier within the schema */
+  key: string;
+  /** Display label for the frontend form */
+  label: string;
+  /** Field type: text (plaintext), url (validated URL), secret (encrypted at rest) */
+  type: 'text' | 'url' | 'secret';
+  /**
+   * HTTP header name this field maps to; if absent, field is internal config
+   * @nullable
+   */
+  headerName: string | null;
+  /**
+   * Optional prefix prepended to the value before sending
+   * @nullable
+   */
+  prefix: string | null;
+  /** Whether the field must be provided */
+  required: boolean;
+  /**
+   * Optional help text for the frontend form
+   * @nullable
+   */
+  help: string | null;
+  /**
+   * Fixed value from marketplace; if set, field is not shown in forms
+   * @nullable
+   */
+  value: string | null;
+}
+
+export interface IntegrationConfigSchemaDto {
+  /** Auth type for documentation/UI purposes */
+  authType: string;
+  /** Fields configured by org admin at install time */
+  orgFields: IntegrationConfigFieldDto[];
+  /** Fields configured by individual users */
+  userFields: IntegrationConfigFieldDto[];
+}
+
+export interface IntegrationResponseDto {
+  /** Integration UUID */
+  id: string;
+  /** Unique identifier (slug) */
+  identifier: string;
+  /** Display name */
+  name: string;
+  /** Description */
+  description: string;
+  /**
+   * Icon URL
+   * @nullable
+   */
+  iconUrl: string | null;
+  /** MCP server URL */
+  serverUrl: string;
+  /** Configuration schema */
+  configSchema: IntegrationConfigSchemaDto;
+  /** Whether the integration is published */
+  published: boolean;
+  /** Creation timestamp */
+  createdAt: string;
+  /** Last update timestamp */
+  updatedAt: string;
+}
+
 export type PublicSkillsControllerListParams = {
   /**
    * Filter by category ID

--- a/ayunis-core-backend/src/common/clients/marketplace/generated/ayunisMarketplaceAPI.schemas.ts
+++ b/ayunis-core-backend/src/common/clients/marketplace/generated/ayunisMarketplaceAPI.schemas.ts
@@ -100,45 +100,45 @@ export interface SkillResponseDto {
   updatedAt: string;
 }
 
-export interface IntegrationConfigFieldDto {
-  /** Unique identifier within the schema */
-  key: string;
-  /** Display label for the frontend form */
-  label: string;
-  /** Field type: text (plaintext), url (validated URL), secret (encrypted at rest) */
-  type: 'text' | 'url' | 'secret';
+export interface IntegrationListResponseDto {
+  /** Integration UUID */
+  id: string;
+  /** Unique identifier (slug) */
+  identifier: string;
+  /** Display name */
+  name: string;
+  /** Short description for marketplace display */
+  shortDescription: string;
   /**
-   * HTTP header name this field maps to; if absent, field is internal config
+   * Icon URL
    * @nullable
    */
-  headerName: string | null;
-  /**
-   * Optional prefix prepended to the value before sending
-   * @nullable
-   */
-  prefix: string | null;
-  /** Whether the field must be provided */
-  required: boolean;
-  /**
-   * Optional help text for the frontend form
-   * @nullable
-   */
-  help: string | null;
-  /**
-   * Fixed value from marketplace; if set, field is not shown in forms
-   * @nullable
-   */
-  value: string | null;
+  iconUrl: string | null;
+  /** Whether the integration is featured */
+  featured: boolean;
+  /** Whether the integration is published */
+  published: boolean;
+  /** Whether the integration is pre-installed */
+  preInstalled: boolean;
 }
 
-export interface IntegrationConfigSchemaDto {
-  /** Auth type for documentation/UI purposes */
-  authType: string;
-  /** Fields configured by org admin at install time */
-  orgFields: IntegrationConfigFieldDto[];
-  /** Fields configured by individual users */
-  userFields: IntegrationConfigFieldDto[];
+export interface PaginatedIntegrationsResponseDto {
+  /** List of integrations */
+  data: IntegrationListResponseDto[];
+  /** Total number of integrations matching the query */
+  total: number;
+  /** Current page number */
+  page: number;
+  /** Items per page */
+  limit: number;
+  /** Total number of pages */
+  totalPages: number;
 }
+
+/**
+ * Configuration schema (authType, orgFields, userFields, oauth)
+ */
+export type IntegrationResponseDtoConfigSchema = { [key: string]: unknown };
 
 export interface IntegrationResponseDto {
   /** Integration UUID */
@@ -147,7 +147,9 @@ export interface IntegrationResponseDto {
   identifier: string;
   /** Display name */
   name: string;
-  /** Description */
+  /** Short description for marketplace display */
+  shortDescription: string;
+  /** Full description */
   description: string;
   /**
    * Icon URL
@@ -156,10 +158,14 @@ export interface IntegrationResponseDto {
   iconUrl: string | null;
   /** MCP server URL */
   serverUrl: string;
-  /** Configuration schema */
-  configSchema: IntegrationConfigSchemaDto;
+  /** Configuration schema (authType, orgFields, userFields, oauth) */
+  configSchema: IntegrationResponseDtoConfigSchema;
+  /** Whether the integration is featured */
+  featured: boolean;
   /** Whether the integration is published */
   published: boolean;
+  /** Whether the integration is pre-installed */
+  preInstalled: boolean;
   /** Creation timestamp */
   createdAt: string;
   /** Last update timestamp */
@@ -167,20 +173,36 @@ export interface IntegrationResponseDto {
 }
 
 export type PublicSkillsControllerListParams = {
-  /**
-   * Filter by category ID
-   */
-  categoryId?: string;
-  /**
-   * Filter by featured status
-   */
-  featured?: string;
-  /**
-   * Maximum number of items per page
-   */
-  limit?: number;
-  /**
-   * Page number
-   */
-  page?: number;
+/**
+ * Filter by category ID
+ */
+categoryId?: string;
+/**
+ * Filter by featured status
+ */
+featured?: string;
+/**
+ * Maximum number of items per page
+ */
+limit?: number;
+/**
+ * Page number
+ */
+page?: number;
 };
+
+export type PublicIntegrationsControllerListParams = {
+/**
+ * Filter by featured status
+ */
+featured?: string;
+/**
+ * Maximum number of items per page
+ */
+limit?: number;
+/**
+ * Page number
+ */
+page?: number;
+};
+

--- a/ayunis-core-backend/src/common/clients/marketplace/generated/ayunisMarketplaceAPI.schemas.ts
+++ b/ayunis-core-backend/src/common/clients/marketplace/generated/ayunisMarketplaceAPI.schemas.ts
@@ -173,36 +173,35 @@ export interface IntegrationResponseDto {
 }
 
 export type PublicSkillsControllerListParams = {
-/**
- * Filter by category ID
- */
-categoryId?: string;
-/**
- * Filter by featured status
- */
-featured?: string;
-/**
- * Maximum number of items per page
- */
-limit?: number;
-/**
- * Page number
- */
-page?: number;
+  /**
+   * Filter by category ID
+   */
+  categoryId?: string;
+  /**
+   * Filter by featured status
+   */
+  featured?: string;
+  /**
+   * Maximum number of items per page
+   */
+  limit?: number;
+  /**
+   * Page number
+   */
+  page?: number;
 };
 
 export type PublicIntegrationsControllerListParams = {
-/**
- * Filter by featured status
- */
-featured?: string;
-/**
- * Maximum number of items per page
- */
-limit?: number;
-/**
- * Page number
- */
-page?: number;
+  /**
+   * Filter by featured status
+   */
+  featured?: string;
+  /**
+   * Maximum number of items per page
+   */
+  limit?: number;
+  /**
+   * Page number
+   */
+  page?: number;
 };
-

--- a/ayunis-core-backend/src/common/clients/marketplace/generated/ayunisMarketplaceAPI.ts
+++ b/ayunis-core-backend/src/common/clients/marketplace/generated/ayunisMarketplaceAPI.ts
@@ -6,457 +6,420 @@
  * OpenAPI spec version: 1.0
  */
 import type {
+  IntegrationListResponseDto,
   IntegrationResponseDto,
+  PaginatedIntegrationsResponseDto,
   PaginatedSkillsResponseDto,
+  PublicIntegrationsControllerListParams,
   PublicSkillsControllerListParams,
   SkillCategoryResponseDto,
   SkillListResponseDto,
-  SkillResponseDto,
+  SkillResponseDto
 } from './ayunisMarketplaceAPI.schemas';
 
 import { marketplaceAxiosInstance } from '../client';
 
-export const getAyunisMarketplaceAPI = () => {
-  const authControllerLoginPage = () => {
-    return marketplaceAxiosInstance<null>({
-      url: `/admin/login`,
-      method: 'GET',
-    });
-  };
 
-  const authControllerGoogleAuth = () => {
-    return marketplaceAxiosInstance<null>({
-      url: `/auth/google`,
-      method: 'GET',
-    });
-  };
 
-  const authControllerGoogleAuthCallback = () => {
-    return marketplaceAxiosInstance<null>({
-      url: `/auth/google/callback`,
-      method: 'GET',
-    });
-  };
-
-  const authControllerLogout = () => {
-    return marketplaceAxiosInstance<null>({
-      url: `/auth/logout`,
-      method: 'POST',
-    });
-  };
-
-  const adminControllerDashboard = () => {
-    return marketplaceAxiosInstance<null>({ url: `/admin`, method: 'GET' });
-  };
-
-  /**
-   * Retrieve all skill categories sorted by their sort order.
-   * @summary List all skill categories
-   */
-  const publicSkillCategoriesControllerList = () => {
-    return marketplaceAxiosInstance<SkillCategoryResponseDto[]>({
-      url: `/api/skill-categories`,
-      method: 'GET',
-    });
-  };
-
-  const adminSkillCategoriesControllerList = () => {
-    return marketplaceAxiosInstance<null>({
-      url: `/admin/skill-categories`,
-      method: 'GET',
-    });
-  };
-
-  const adminSkillCategoriesControllerCreate = () => {
-    return marketplaceAxiosInstance<null>({
-      url: `/admin/skill-categories`,
-      method: 'POST',
-    });
-  };
-
-  const adminSkillCategoriesControllerNewForm = () => {
-    return marketplaceAxiosInstance<null>({
-      url: `/admin/skill-categories/new`,
-      method: 'GET',
-    });
-  };
-
-  const adminSkillCategoriesControllerEditForm = (id: string) => {
-    return marketplaceAxiosInstance<null>({
-      url: `/admin/skill-categories/${id}/edit`,
-      method: 'GET',
-    });
-  };
-
-  const adminSkillCategoriesControllerUpdate = (id: string) => {
-    return marketplaceAxiosInstance<null>({
-      url: `/admin/skill-categories/${id}`,
-      method: 'POST',
-    });
-  };
-
-  const adminSkillCategoriesControllerDeleteConfirm = (id: string) => {
-    return marketplaceAxiosInstance<null>({
-      url: `/admin/skill-categories/${id}/delete`,
-      method: 'GET',
-    });
-  };
-
-  const adminSkillCategoriesControllerDelete = (id: string) => {
-    return marketplaceAxiosInstance<null>({
-      url: `/admin/skill-categories/${id}/delete`,
-      method: 'POST',
-    });
-  };
-
-  /**
-   * Retrieve a paginated list of published skills with optional filters for category, featured status, and pagination.
-   * @summary List published skills
-   */
-  const publicSkillsControllerList = (
+  export const getAyunisMarketplaceAPI = () => {
+const authControllerLoginPage = (
+    
+ ) => {
+      return marketplaceAxiosInstance<null>(
+      {url: `/admin/login`, method: 'GET'
+    },
+      );
+    }
+  
+const authControllerGoogleAuth = (
+    
+ ) => {
+      return marketplaceAxiosInstance<null>(
+      {url: `/auth/google`, method: 'GET'
+    },
+      );
+    }
+  
+const authControllerGoogleAuthCallback = (
+    
+ ) => {
+      return marketplaceAxiosInstance<null>(
+      {url: `/auth/google/callback`, method: 'GET'
+    },
+      );
+    }
+  
+const authControllerLogout = (
+    
+ ) => {
+      return marketplaceAxiosInstance<null>(
+      {url: `/auth/logout`, method: 'POST'
+    },
+      );
+    }
+  
+const adminControllerDashboard = (
+    
+ ) => {
+      return marketplaceAxiosInstance<null>(
+      {url: `/admin`, method: 'GET'
+    },
+      );
+    }
+  
+/**
+ * Retrieve all skill categories sorted by their sort order.
+ * @summary List all skill categories
+ */
+const publicSkillCategoriesControllerList = (
+    
+ ) => {
+      return marketplaceAxiosInstance<SkillCategoryResponseDto[]>(
+      {url: `/api/skill-categories`, method: 'GET'
+    },
+      );
+    }
+  
+const adminSkillCategoriesControllerList = (
+    
+ ) => {
+      return marketplaceAxiosInstance<null>(
+      {url: `/admin/skill-categories`, method: 'GET'
+    },
+      );
+    }
+  
+const adminSkillCategoriesControllerCreate = (
+    
+ ) => {
+      return marketplaceAxiosInstance<null>(
+      {url: `/admin/skill-categories`, method: 'POST'
+    },
+      );
+    }
+  
+const adminSkillCategoriesControllerNewForm = (
+    
+ ) => {
+      return marketplaceAxiosInstance<null>(
+      {url: `/admin/skill-categories/new`, method: 'GET'
+    },
+      );
+    }
+  
+const adminSkillCategoriesControllerEditForm = (
+    id: string,
+ ) => {
+      return marketplaceAxiosInstance<null>(
+      {url: `/admin/skill-categories/${id}/edit`, method: 'GET'
+    },
+      );
+    }
+  
+const adminSkillCategoriesControllerUpdate = (
+    id: string,
+ ) => {
+      return marketplaceAxiosInstance<null>(
+      {url: `/admin/skill-categories/${id}`, method: 'POST'
+    },
+      );
+    }
+  
+const adminSkillCategoriesControllerDeleteConfirm = (
+    id: string,
+ ) => {
+      return marketplaceAxiosInstance<null>(
+      {url: `/admin/skill-categories/${id}/delete`, method: 'GET'
+    },
+      );
+    }
+  
+const adminSkillCategoriesControllerDelete = (
+    id: string,
+ ) => {
+      return marketplaceAxiosInstance<null>(
+      {url: `/admin/skill-categories/${id}/delete`, method: 'POST'
+    },
+      );
+    }
+  
+/**
+ * Retrieve a paginated list of published skills with optional filters for category, featured status, and pagination.
+ * @summary List published skills
+ */
+const publicSkillsControllerList = (
     params?: PublicSkillsControllerListParams,
-  ) => {
-    return marketplaceAxiosInstance<PaginatedSkillsResponseDto>({
-      url: `/api/skills`,
-      method: 'GET',
-      params,
-    });
-  };
-
-  /**
-   * Retrieve all published skills that are marked as pre-installed for new organizations.
-   * @summary List pre-installed skills
-   */
-  const publicSkillsControllerListPreInstalled = () => {
-    return marketplaceAxiosInstance<SkillListResponseDto[]>({
-      url: `/api/skills/pre-installed`,
-      method: 'GET',
-    });
-  };
-
-  /**
-   * Retrieve full details of a published skill by its unique identifier slug.
-   * @summary Get a skill by identifier
-   */
-  const publicSkillsControllerGetByIdentifier = (identifier: string) => {
-    return marketplaceAxiosInstance<SkillResponseDto>({
-      url: `/api/skills/${identifier}`,
-      method: 'GET',
-    });
-  };
-
-  const adminSkillsControllerList = () => {
-    return marketplaceAxiosInstance<null>({
-      url: `/admin/skills`,
-      method: 'GET',
-    });
-  };
-
-  const adminSkillsControllerCreate = () => {
-    return marketplaceAxiosInstance<null>({
-      url: `/admin/skills`,
-      method: 'POST',
-    });
-  };
-
-  const adminSkillsControllerNewForm = () => {
-    return marketplaceAxiosInstance<null>({
-      url: `/admin/skills/new`,
-      method: 'GET',
-    });
-  };
-
-  const adminSkillsControllerEditForm = (id: string) => {
-    return marketplaceAxiosInstance<null>({
-      url: `/admin/skills/${id}/edit`,
-      method: 'GET',
-    });
-  };
-
-  const adminSkillsControllerUpdate = (id: string) => {
-    return marketplaceAxiosInstance<null>({
-      url: `/admin/skills/${id}`,
-      method: 'POST',
-    });
-  };
-
-  const adminSkillsControllerDeleteConfirm = (id: string) => {
-    return marketplaceAxiosInstance<null>({
-      url: `/admin/skills/${id}/delete`,
-      method: 'GET',
-    });
-  };
-
-  const adminSkillsControllerDelete = (id: string) => {
-    return marketplaceAxiosInstance<null>({
-      url: `/admin/skills/${id}/delete`,
-      method: 'POST',
-    });
-  };
-
-  const adminSkillsControllerPublish = (id: string) => {
-    return marketplaceAxiosInstance<null>({
-      url: `/admin/skills/${id}/publish`,
-      method: 'POST',
-    });
-  };
-
-  const adminSkillsControllerUnpublish = (id: string) => {
-    return marketplaceAxiosInstance<null>({
-      url: `/admin/skills/${id}/unpublish`,
-      method: 'POST',
-    });
-  };
-
-  /**
-   * Retrieve full details of a published integration by its unique identifier slug.
-   * @summary Get an integration by identifier
-   */
-  const publicIntegrationsControllerGetByIdentifier = (identifier: string) => {
-    return marketplaceAxiosInstance<IntegrationResponseDto>({
-      url: `/api/integrations/${identifier}`,
-      method: 'GET',
-    });
-  };
-
-  return {
-    authControllerLoginPage,
-    authControllerGoogleAuth,
-    authControllerGoogleAuthCallback,
-    authControllerLogout,
-    adminControllerDashboard,
-    publicSkillCategoriesControllerList,
-    adminSkillCategoriesControllerList,
-    adminSkillCategoriesControllerCreate,
-    adminSkillCategoriesControllerNewForm,
-    adminSkillCategoriesControllerEditForm,
-    adminSkillCategoriesControllerUpdate,
-    adminSkillCategoriesControllerDeleteConfirm,
-    adminSkillCategoriesControllerDelete,
-    publicSkillsControllerList,
-    publicSkillsControllerListPreInstalled,
-    publicSkillsControllerGetByIdentifier,
-    adminSkillsControllerList,
-    adminSkillsControllerCreate,
-    adminSkillsControllerNewForm,
-    adminSkillsControllerEditForm,
-    adminSkillsControllerUpdate,
-    adminSkillsControllerDeleteConfirm,
-    adminSkillsControllerDelete,
-    adminSkillsControllerPublish,
-    adminSkillsControllerUnpublish,
-    publicIntegrationsControllerGetByIdentifier,
-  };
-};
-export type AuthControllerLoginPageResult = NonNullable<
-  Awaited<
-    ReturnType<
-      ReturnType<typeof getAyunisMarketplaceAPI>['authControllerLoginPage']
-    >
-  >
->;
-export type AuthControllerGoogleAuthResult = NonNullable<
-  Awaited<
-    ReturnType<
-      ReturnType<typeof getAyunisMarketplaceAPI>['authControllerGoogleAuth']
-    >
-  >
->;
-export type AuthControllerGoogleAuthCallbackResult = NonNullable<
-  Awaited<
-    ReturnType<
-      ReturnType<
-        typeof getAyunisMarketplaceAPI
-      >['authControllerGoogleAuthCallback']
-    >
-  >
->;
-export type AuthControllerLogoutResult = NonNullable<
-  Awaited<
-    ReturnType<
-      ReturnType<typeof getAyunisMarketplaceAPI>['authControllerLogout']
-    >
-  >
->;
-export type AdminControllerDashboardResult = NonNullable<
-  Awaited<
-    ReturnType<
-      ReturnType<typeof getAyunisMarketplaceAPI>['adminControllerDashboard']
-    >
-  >
->;
-export type PublicSkillCategoriesControllerListResult = NonNullable<
-  Awaited<
-    ReturnType<
-      ReturnType<
-        typeof getAyunisMarketplaceAPI
-      >['publicSkillCategoriesControllerList']
-    >
-  >
->;
-export type AdminSkillCategoriesControllerListResult = NonNullable<
-  Awaited<
-    ReturnType<
-      ReturnType<
-        typeof getAyunisMarketplaceAPI
-      >['adminSkillCategoriesControllerList']
-    >
-  >
->;
-export type AdminSkillCategoriesControllerCreateResult = NonNullable<
-  Awaited<
-    ReturnType<
-      ReturnType<
-        typeof getAyunisMarketplaceAPI
-      >['adminSkillCategoriesControllerCreate']
-    >
-  >
->;
-export type AdminSkillCategoriesControllerNewFormResult = NonNullable<
-  Awaited<
-    ReturnType<
-      ReturnType<
-        typeof getAyunisMarketplaceAPI
-      >['adminSkillCategoriesControllerNewForm']
-    >
-  >
->;
-export type AdminSkillCategoriesControllerEditFormResult = NonNullable<
-  Awaited<
-    ReturnType<
-      ReturnType<
-        typeof getAyunisMarketplaceAPI
-      >['adminSkillCategoriesControllerEditForm']
-    >
-  >
->;
-export type AdminSkillCategoriesControllerUpdateResult = NonNullable<
-  Awaited<
-    ReturnType<
-      ReturnType<
-        typeof getAyunisMarketplaceAPI
-      >['adminSkillCategoriesControllerUpdate']
-    >
-  >
->;
-export type AdminSkillCategoriesControllerDeleteConfirmResult = NonNullable<
-  Awaited<
-    ReturnType<
-      ReturnType<
-        typeof getAyunisMarketplaceAPI
-      >['adminSkillCategoriesControllerDeleteConfirm']
-    >
-  >
->;
-export type AdminSkillCategoriesControllerDeleteResult = NonNullable<
-  Awaited<
-    ReturnType<
-      ReturnType<
-        typeof getAyunisMarketplaceAPI
-      >['adminSkillCategoriesControllerDelete']
-    >
-  >
->;
-export type PublicSkillsControllerListResult = NonNullable<
-  Awaited<
-    ReturnType<
-      ReturnType<typeof getAyunisMarketplaceAPI>['publicSkillsControllerList']
-    >
-  >
->;
-export type PublicSkillsControllerListPreInstalledResult = NonNullable<
-  Awaited<
-    ReturnType<
-      ReturnType<
-        typeof getAyunisMarketplaceAPI
-      >['publicSkillsControllerListPreInstalled']
-    >
-  >
->;
-export type PublicSkillsControllerGetByIdentifierResult = NonNullable<
-  Awaited<
-    ReturnType<
-      ReturnType<
-        typeof getAyunisMarketplaceAPI
-      >['publicSkillsControllerGetByIdentifier']
-    >
-  >
->;
-export type AdminSkillsControllerListResult = NonNullable<
-  Awaited<
-    ReturnType<
-      ReturnType<typeof getAyunisMarketplaceAPI>['adminSkillsControllerList']
-    >
-  >
->;
-export type AdminSkillsControllerCreateResult = NonNullable<
-  Awaited<
-    ReturnType<
-      ReturnType<typeof getAyunisMarketplaceAPI>['adminSkillsControllerCreate']
-    >
-  >
->;
-export type AdminSkillsControllerNewFormResult = NonNullable<
-  Awaited<
-    ReturnType<
-      ReturnType<typeof getAyunisMarketplaceAPI>['adminSkillsControllerNewForm']
-    >
-  >
->;
-export type AdminSkillsControllerEditFormResult = NonNullable<
-  Awaited<
-    ReturnType<
-      ReturnType<
-        typeof getAyunisMarketplaceAPI
-      >['adminSkillsControllerEditForm']
-    >
-  >
->;
-export type AdminSkillsControllerUpdateResult = NonNullable<
-  Awaited<
-    ReturnType<
-      ReturnType<typeof getAyunisMarketplaceAPI>['adminSkillsControllerUpdate']
-    >
-  >
->;
-export type AdminSkillsControllerDeleteConfirmResult = NonNullable<
-  Awaited<
-    ReturnType<
-      ReturnType<
-        typeof getAyunisMarketplaceAPI
-      >['adminSkillsControllerDeleteConfirm']
-    >
-  >
->;
-export type AdminSkillsControllerDeleteResult = NonNullable<
-  Awaited<
-    ReturnType<
-      ReturnType<typeof getAyunisMarketplaceAPI>['adminSkillsControllerDelete']
-    >
-  >
->;
-export type AdminSkillsControllerPublishResult = NonNullable<
-  Awaited<
-    ReturnType<
-      ReturnType<typeof getAyunisMarketplaceAPI>['adminSkillsControllerPublish']
-    >
-  >
->;
-export type AdminSkillsControllerUnpublishResult = NonNullable<
-  Awaited<
-    ReturnType<
-      ReturnType<
-        typeof getAyunisMarketplaceAPI
-      >['adminSkillsControllerUnpublish']
-    >
-  >
->;
-export type PublicIntegrationsControllerGetByIdentifierResult = NonNullable<
-  Awaited<
-    ReturnType<
-      ReturnType<
-        typeof getAyunisMarketplaceAPI
-      >['publicIntegrationsControllerGetByIdentifier']
-    >
-  >
->;
+ ) => {
+      return marketplaceAxiosInstance<PaginatedSkillsResponseDto>(
+      {url: `/api/skills`, method: 'GET',
+        params
+    },
+      );
+    }
+  
+/**
+ * Retrieve all published skills that are marked as pre-installed for new organizations.
+ * @summary List pre-installed skills
+ */
+const publicSkillsControllerListPreInstalled = (
+    
+ ) => {
+      return marketplaceAxiosInstance<SkillListResponseDto[]>(
+      {url: `/api/skills/pre-installed`, method: 'GET'
+    },
+      );
+    }
+  
+/**
+ * Retrieve full details of a published skill by its unique identifier slug.
+ * @summary Get a skill by identifier
+ */
+const publicSkillsControllerGetByIdentifier = (
+    identifier: string,
+ ) => {
+      return marketplaceAxiosInstance<SkillResponseDto>(
+      {url: `/api/skills/${identifier}`, method: 'GET'
+    },
+      );
+    }
+  
+const adminSkillsControllerList = (
+    
+ ) => {
+      return marketplaceAxiosInstance<null>(
+      {url: `/admin/skills`, method: 'GET'
+    },
+      );
+    }
+  
+const adminSkillsControllerCreate = (
+    
+ ) => {
+      return marketplaceAxiosInstance<null>(
+      {url: `/admin/skills`, method: 'POST'
+    },
+      );
+    }
+  
+const adminSkillsControllerNewForm = (
+    
+ ) => {
+      return marketplaceAxiosInstance<null>(
+      {url: `/admin/skills/new`, method: 'GET'
+    },
+      );
+    }
+  
+const adminSkillsControllerEditForm = (
+    id: string,
+ ) => {
+      return marketplaceAxiosInstance<null>(
+      {url: `/admin/skills/${id}/edit`, method: 'GET'
+    },
+      );
+    }
+  
+const adminSkillsControllerUpdate = (
+    id: string,
+ ) => {
+      return marketplaceAxiosInstance<null>(
+      {url: `/admin/skills/${id}`, method: 'POST'
+    },
+      );
+    }
+  
+const adminSkillsControllerDeleteConfirm = (
+    id: string,
+ ) => {
+      return marketplaceAxiosInstance<null>(
+      {url: `/admin/skills/${id}/delete`, method: 'GET'
+    },
+      );
+    }
+  
+const adminSkillsControllerDelete = (
+    id: string,
+ ) => {
+      return marketplaceAxiosInstance<null>(
+      {url: `/admin/skills/${id}/delete`, method: 'POST'
+    },
+      );
+    }
+  
+const adminSkillsControllerPublish = (
+    id: string,
+ ) => {
+      return marketplaceAxiosInstance<null>(
+      {url: `/admin/skills/${id}/publish`, method: 'POST'
+    },
+      );
+    }
+  
+const adminSkillsControllerUnpublish = (
+    id: string,
+ ) => {
+      return marketplaceAxiosInstance<null>(
+      {url: `/admin/skills/${id}/unpublish`, method: 'POST'
+    },
+      );
+    }
+  
+/**
+ * Retrieve a paginated list of published integrations with optional filters for featured status and pagination.
+ * @summary List published integrations
+ */
+const publicIntegrationsControllerList = (
+    params?: PublicIntegrationsControllerListParams,
+ ) => {
+      return marketplaceAxiosInstance<PaginatedIntegrationsResponseDto>(
+      {url: `/api/integrations`, method: 'GET',
+        params
+    },
+      );
+    }
+  
+/**
+ * Retrieve all published integrations that are marked as pre-installed for new organizations.
+ * @summary List pre-installed integrations
+ */
+const publicIntegrationsControllerListPreInstalled = (
+    
+ ) => {
+      return marketplaceAxiosInstance<IntegrationListResponseDto[]>(
+      {url: `/api/integrations/pre-installed`, method: 'GET'
+    },
+      );
+    }
+  
+/**
+ * Retrieve full details of a published integration by its unique identifier slug.
+ * @summary Get an integration by identifier
+ */
+const publicIntegrationsControllerGetByIdentifier = (
+    identifier: string,
+ ) => {
+      return marketplaceAxiosInstance<IntegrationResponseDto>(
+      {url: `/api/integrations/${identifier}`, method: 'GET'
+    },
+      );
+    }
+  
+const adminIntegrationsControllerList = (
+    
+ ) => {
+      return marketplaceAxiosInstance<null>(
+      {url: `/admin/integrations`, method: 'GET'
+    },
+      );
+    }
+  
+const adminIntegrationsControllerCreate = (
+    
+ ) => {
+      return marketplaceAxiosInstance<null>(
+      {url: `/admin/integrations`, method: 'POST'
+    },
+      );
+    }
+  
+const adminIntegrationsControllerNewForm = (
+    
+ ) => {
+      return marketplaceAxiosInstance<null>(
+      {url: `/admin/integrations/new`, method: 'GET'
+    },
+      );
+    }
+  
+const adminIntegrationsControllerEditForm = (
+    id: string,
+ ) => {
+      return marketplaceAxiosInstance<null>(
+      {url: `/admin/integrations/${id}/edit`, method: 'GET'
+    },
+      );
+    }
+  
+const adminIntegrationsControllerUpdate = (
+    id: string,
+ ) => {
+      return marketplaceAxiosInstance<null>(
+      {url: `/admin/integrations/${id}`, method: 'POST'
+    },
+      );
+    }
+  
+const adminIntegrationsControllerDeleteConfirm = (
+    id: string,
+ ) => {
+      return marketplaceAxiosInstance<null>(
+      {url: `/admin/integrations/${id}/delete`, method: 'GET'
+    },
+      );
+    }
+  
+const adminIntegrationsControllerDelete = (
+    id: string,
+ ) => {
+      return marketplaceAxiosInstance<null>(
+      {url: `/admin/integrations/${id}/delete`, method: 'POST'
+    },
+      );
+    }
+  
+const adminIntegrationsControllerPublish = (
+    id: string,
+ ) => {
+      return marketplaceAxiosInstance<null>(
+      {url: `/admin/integrations/${id}/publish`, method: 'POST'
+    },
+      );
+    }
+  
+const adminIntegrationsControllerUnpublish = (
+    id: string,
+ ) => {
+      return marketplaceAxiosInstance<null>(
+      {url: `/admin/integrations/${id}/unpublish`, method: 'POST'
+    },
+      );
+    }
+  
+return {authControllerLoginPage,authControllerGoogleAuth,authControllerGoogleAuthCallback,authControllerLogout,adminControllerDashboard,publicSkillCategoriesControllerList,adminSkillCategoriesControllerList,adminSkillCategoriesControllerCreate,adminSkillCategoriesControllerNewForm,adminSkillCategoriesControllerEditForm,adminSkillCategoriesControllerUpdate,adminSkillCategoriesControllerDeleteConfirm,adminSkillCategoriesControllerDelete,publicSkillsControllerList,publicSkillsControllerListPreInstalled,publicSkillsControllerGetByIdentifier,adminSkillsControllerList,adminSkillsControllerCreate,adminSkillsControllerNewForm,adminSkillsControllerEditForm,adminSkillsControllerUpdate,adminSkillsControllerDeleteConfirm,adminSkillsControllerDelete,adminSkillsControllerPublish,adminSkillsControllerUnpublish,publicIntegrationsControllerList,publicIntegrationsControllerListPreInstalled,publicIntegrationsControllerGetByIdentifier,adminIntegrationsControllerList,adminIntegrationsControllerCreate,adminIntegrationsControllerNewForm,adminIntegrationsControllerEditForm,adminIntegrationsControllerUpdate,adminIntegrationsControllerDeleteConfirm,adminIntegrationsControllerDelete,adminIntegrationsControllerPublish,adminIntegrationsControllerUnpublish}};
+export type AuthControllerLoginPageResult = NonNullable<Awaited<ReturnType<ReturnType<typeof getAyunisMarketplaceAPI>['authControllerLoginPage']>>>
+export type AuthControllerGoogleAuthResult = NonNullable<Awaited<ReturnType<ReturnType<typeof getAyunisMarketplaceAPI>['authControllerGoogleAuth']>>>
+export type AuthControllerGoogleAuthCallbackResult = NonNullable<Awaited<ReturnType<ReturnType<typeof getAyunisMarketplaceAPI>['authControllerGoogleAuthCallback']>>>
+export type AuthControllerLogoutResult = NonNullable<Awaited<ReturnType<ReturnType<typeof getAyunisMarketplaceAPI>['authControllerLogout']>>>
+export type AdminControllerDashboardResult = NonNullable<Awaited<ReturnType<ReturnType<typeof getAyunisMarketplaceAPI>['adminControllerDashboard']>>>
+export type PublicSkillCategoriesControllerListResult = NonNullable<Awaited<ReturnType<ReturnType<typeof getAyunisMarketplaceAPI>['publicSkillCategoriesControllerList']>>>
+export type AdminSkillCategoriesControllerListResult = NonNullable<Awaited<ReturnType<ReturnType<typeof getAyunisMarketplaceAPI>['adminSkillCategoriesControllerList']>>>
+export type AdminSkillCategoriesControllerCreateResult = NonNullable<Awaited<ReturnType<ReturnType<typeof getAyunisMarketplaceAPI>['adminSkillCategoriesControllerCreate']>>>
+export type AdminSkillCategoriesControllerNewFormResult = NonNullable<Awaited<ReturnType<ReturnType<typeof getAyunisMarketplaceAPI>['adminSkillCategoriesControllerNewForm']>>>
+export type AdminSkillCategoriesControllerEditFormResult = NonNullable<Awaited<ReturnType<ReturnType<typeof getAyunisMarketplaceAPI>['adminSkillCategoriesControllerEditForm']>>>
+export type AdminSkillCategoriesControllerUpdateResult = NonNullable<Awaited<ReturnType<ReturnType<typeof getAyunisMarketplaceAPI>['adminSkillCategoriesControllerUpdate']>>>
+export type AdminSkillCategoriesControllerDeleteConfirmResult = NonNullable<Awaited<ReturnType<ReturnType<typeof getAyunisMarketplaceAPI>['adminSkillCategoriesControllerDeleteConfirm']>>>
+export type AdminSkillCategoriesControllerDeleteResult = NonNullable<Awaited<ReturnType<ReturnType<typeof getAyunisMarketplaceAPI>['adminSkillCategoriesControllerDelete']>>>
+export type PublicSkillsControllerListResult = NonNullable<Awaited<ReturnType<ReturnType<typeof getAyunisMarketplaceAPI>['publicSkillsControllerList']>>>
+export type PublicSkillsControllerListPreInstalledResult = NonNullable<Awaited<ReturnType<ReturnType<typeof getAyunisMarketplaceAPI>['publicSkillsControllerListPreInstalled']>>>
+export type PublicSkillsControllerGetByIdentifierResult = NonNullable<Awaited<ReturnType<ReturnType<typeof getAyunisMarketplaceAPI>['publicSkillsControllerGetByIdentifier']>>>
+export type AdminSkillsControllerListResult = NonNullable<Awaited<ReturnType<ReturnType<typeof getAyunisMarketplaceAPI>['adminSkillsControllerList']>>>
+export type AdminSkillsControllerCreateResult = NonNullable<Awaited<ReturnType<ReturnType<typeof getAyunisMarketplaceAPI>['adminSkillsControllerCreate']>>>
+export type AdminSkillsControllerNewFormResult = NonNullable<Awaited<ReturnType<ReturnType<typeof getAyunisMarketplaceAPI>['adminSkillsControllerNewForm']>>>
+export type AdminSkillsControllerEditFormResult = NonNullable<Awaited<ReturnType<ReturnType<typeof getAyunisMarketplaceAPI>['adminSkillsControllerEditForm']>>>
+export type AdminSkillsControllerUpdateResult = NonNullable<Awaited<ReturnType<ReturnType<typeof getAyunisMarketplaceAPI>['adminSkillsControllerUpdate']>>>
+export type AdminSkillsControllerDeleteConfirmResult = NonNullable<Awaited<ReturnType<ReturnType<typeof getAyunisMarketplaceAPI>['adminSkillsControllerDeleteConfirm']>>>
+export type AdminSkillsControllerDeleteResult = NonNullable<Awaited<ReturnType<ReturnType<typeof getAyunisMarketplaceAPI>['adminSkillsControllerDelete']>>>
+export type AdminSkillsControllerPublishResult = NonNullable<Awaited<ReturnType<ReturnType<typeof getAyunisMarketplaceAPI>['adminSkillsControllerPublish']>>>
+export type AdminSkillsControllerUnpublishResult = NonNullable<Awaited<ReturnType<ReturnType<typeof getAyunisMarketplaceAPI>['adminSkillsControllerUnpublish']>>>
+export type PublicIntegrationsControllerListResult = NonNullable<Awaited<ReturnType<ReturnType<typeof getAyunisMarketplaceAPI>['publicIntegrationsControllerList']>>>
+export type PublicIntegrationsControllerListPreInstalledResult = NonNullable<Awaited<ReturnType<ReturnType<typeof getAyunisMarketplaceAPI>['publicIntegrationsControllerListPreInstalled']>>>
+export type PublicIntegrationsControllerGetByIdentifierResult = NonNullable<Awaited<ReturnType<ReturnType<typeof getAyunisMarketplaceAPI>['publicIntegrationsControllerGetByIdentifier']>>>
+export type AdminIntegrationsControllerListResult = NonNullable<Awaited<ReturnType<ReturnType<typeof getAyunisMarketplaceAPI>['adminIntegrationsControllerList']>>>
+export type AdminIntegrationsControllerCreateResult = NonNullable<Awaited<ReturnType<ReturnType<typeof getAyunisMarketplaceAPI>['adminIntegrationsControllerCreate']>>>
+export type AdminIntegrationsControllerNewFormResult = NonNullable<Awaited<ReturnType<ReturnType<typeof getAyunisMarketplaceAPI>['adminIntegrationsControllerNewForm']>>>
+export type AdminIntegrationsControllerEditFormResult = NonNullable<Awaited<ReturnType<ReturnType<typeof getAyunisMarketplaceAPI>['adminIntegrationsControllerEditForm']>>>
+export type AdminIntegrationsControllerUpdateResult = NonNullable<Awaited<ReturnType<ReturnType<typeof getAyunisMarketplaceAPI>['adminIntegrationsControllerUpdate']>>>
+export type AdminIntegrationsControllerDeleteConfirmResult = NonNullable<Awaited<ReturnType<ReturnType<typeof getAyunisMarketplaceAPI>['adminIntegrationsControllerDeleteConfirm']>>>
+export type AdminIntegrationsControllerDeleteResult = NonNullable<Awaited<ReturnType<ReturnType<typeof getAyunisMarketplaceAPI>['adminIntegrationsControllerDelete']>>>
+export type AdminIntegrationsControllerPublishResult = NonNullable<Awaited<ReturnType<ReturnType<typeof getAyunisMarketplaceAPI>['adminIntegrationsControllerPublish']>>>
+export type AdminIntegrationsControllerUnpublishResult = NonNullable<Awaited<ReturnType<ReturnType<typeof getAyunisMarketplaceAPI>['adminIntegrationsControllerUnpublish']>>>

--- a/ayunis-core-backend/src/common/clients/marketplace/generated/ayunisMarketplaceAPI.ts
+++ b/ayunis-core-backend/src/common/clients/marketplace/generated/ayunisMarketplaceAPI.ts
@@ -14,412 +14,650 @@ import type {
   PublicSkillsControllerListParams,
   SkillCategoryResponseDto,
   SkillListResponseDto,
-  SkillResponseDto
+  SkillResponseDto,
 } from './ayunisMarketplaceAPI.schemas';
 
 import { marketplaceAxiosInstance } from '../client';
 
+export const getAyunisMarketplaceAPI = () => {
+  const authControllerLoginPage = () => {
+    return marketplaceAxiosInstance<null>({
+      url: `/admin/login`,
+      method: 'GET',
+    });
+  };
 
+  const authControllerGoogleAuth = () => {
+    return marketplaceAxiosInstance<null>({
+      url: `/auth/google`,
+      method: 'GET',
+    });
+  };
 
-  export const getAyunisMarketplaceAPI = () => {
-const authControllerLoginPage = (
-    
- ) => {
-      return marketplaceAxiosInstance<null>(
-      {url: `/admin/login`, method: 'GET'
-    },
-      );
-    }
-  
-const authControllerGoogleAuth = (
-    
- ) => {
-      return marketplaceAxiosInstance<null>(
-      {url: `/auth/google`, method: 'GET'
-    },
-      );
-    }
-  
-const authControllerGoogleAuthCallback = (
-    
- ) => {
-      return marketplaceAxiosInstance<null>(
-      {url: `/auth/google/callback`, method: 'GET'
-    },
-      );
-    }
-  
-const authControllerLogout = (
-    
- ) => {
-      return marketplaceAxiosInstance<null>(
-      {url: `/auth/logout`, method: 'POST'
-    },
-      );
-    }
-  
-const adminControllerDashboard = (
-    
- ) => {
-      return marketplaceAxiosInstance<null>(
-      {url: `/admin`, method: 'GET'
-    },
-      );
-    }
-  
-/**
- * Retrieve all skill categories sorted by their sort order.
- * @summary List all skill categories
- */
-const publicSkillCategoriesControllerList = (
-    
- ) => {
-      return marketplaceAxiosInstance<SkillCategoryResponseDto[]>(
-      {url: `/api/skill-categories`, method: 'GET'
-    },
-      );
-    }
-  
-const adminSkillCategoriesControllerList = (
-    
- ) => {
-      return marketplaceAxiosInstance<null>(
-      {url: `/admin/skill-categories`, method: 'GET'
-    },
-      );
-    }
-  
-const adminSkillCategoriesControllerCreate = (
-    
- ) => {
-      return marketplaceAxiosInstance<null>(
-      {url: `/admin/skill-categories`, method: 'POST'
-    },
-      );
-    }
-  
-const adminSkillCategoriesControllerNewForm = (
-    
- ) => {
-      return marketplaceAxiosInstance<null>(
-      {url: `/admin/skill-categories/new`, method: 'GET'
-    },
-      );
-    }
-  
-const adminSkillCategoriesControllerEditForm = (
-    id: string,
- ) => {
-      return marketplaceAxiosInstance<null>(
-      {url: `/admin/skill-categories/${id}/edit`, method: 'GET'
-    },
-      );
-    }
-  
-const adminSkillCategoriesControllerUpdate = (
-    id: string,
- ) => {
-      return marketplaceAxiosInstance<null>(
-      {url: `/admin/skill-categories/${id}`, method: 'POST'
-    },
-      );
-    }
-  
-const adminSkillCategoriesControllerDeleteConfirm = (
-    id: string,
- ) => {
-      return marketplaceAxiosInstance<null>(
-      {url: `/admin/skill-categories/${id}/delete`, method: 'GET'
-    },
-      );
-    }
-  
-const adminSkillCategoriesControllerDelete = (
-    id: string,
- ) => {
-      return marketplaceAxiosInstance<null>(
-      {url: `/admin/skill-categories/${id}/delete`, method: 'POST'
-    },
-      );
-    }
-  
-/**
- * Retrieve a paginated list of published skills with optional filters for category, featured status, and pagination.
- * @summary List published skills
- */
-const publicSkillsControllerList = (
+  const authControllerGoogleAuthCallback = () => {
+    return marketplaceAxiosInstance<null>({
+      url: `/auth/google/callback`,
+      method: 'GET',
+    });
+  };
+
+  const authControllerLogout = () => {
+    return marketplaceAxiosInstance<null>({
+      url: `/auth/logout`,
+      method: 'POST',
+    });
+  };
+
+  const adminControllerDashboard = () => {
+    return marketplaceAxiosInstance<null>({ url: `/admin`, method: 'GET' });
+  };
+
+  /**
+   * Retrieve all skill categories sorted by their sort order.
+   * @summary List all skill categories
+   */
+  const publicSkillCategoriesControllerList = () => {
+    return marketplaceAxiosInstance<SkillCategoryResponseDto[]>({
+      url: `/api/skill-categories`,
+      method: 'GET',
+    });
+  };
+
+  const adminSkillCategoriesControllerList = () => {
+    return marketplaceAxiosInstance<null>({
+      url: `/admin/skill-categories`,
+      method: 'GET',
+    });
+  };
+
+  const adminSkillCategoriesControllerCreate = () => {
+    return marketplaceAxiosInstance<null>({
+      url: `/admin/skill-categories`,
+      method: 'POST',
+    });
+  };
+
+  const adminSkillCategoriesControllerNewForm = () => {
+    return marketplaceAxiosInstance<null>({
+      url: `/admin/skill-categories/new`,
+      method: 'GET',
+    });
+  };
+
+  const adminSkillCategoriesControllerEditForm = (id: string) => {
+    return marketplaceAxiosInstance<null>({
+      url: `/admin/skill-categories/${id}/edit`,
+      method: 'GET',
+    });
+  };
+
+  const adminSkillCategoriesControllerUpdate = (id: string) => {
+    return marketplaceAxiosInstance<null>({
+      url: `/admin/skill-categories/${id}`,
+      method: 'POST',
+    });
+  };
+
+  const adminSkillCategoriesControllerDeleteConfirm = (id: string) => {
+    return marketplaceAxiosInstance<null>({
+      url: `/admin/skill-categories/${id}/delete`,
+      method: 'GET',
+    });
+  };
+
+  const adminSkillCategoriesControllerDelete = (id: string) => {
+    return marketplaceAxiosInstance<null>({
+      url: `/admin/skill-categories/${id}/delete`,
+      method: 'POST',
+    });
+  };
+
+  /**
+   * Retrieve a paginated list of published skills with optional filters for category, featured status, and pagination.
+   * @summary List published skills
+   */
+  const publicSkillsControllerList = (
     params?: PublicSkillsControllerListParams,
- ) => {
-      return marketplaceAxiosInstance<PaginatedSkillsResponseDto>(
-      {url: `/api/skills`, method: 'GET',
-        params
-    },
-      );
-    }
-  
-/**
- * Retrieve all published skills that are marked as pre-installed for new organizations.
- * @summary List pre-installed skills
- */
-const publicSkillsControllerListPreInstalled = (
-    
- ) => {
-      return marketplaceAxiosInstance<SkillListResponseDto[]>(
-      {url: `/api/skills/pre-installed`, method: 'GET'
-    },
-      );
-    }
-  
-/**
- * Retrieve full details of a published skill by its unique identifier slug.
- * @summary Get a skill by identifier
- */
-const publicSkillsControllerGetByIdentifier = (
-    identifier: string,
- ) => {
-      return marketplaceAxiosInstance<SkillResponseDto>(
-      {url: `/api/skills/${identifier}`, method: 'GET'
-    },
-      );
-    }
-  
-const adminSkillsControllerList = (
-    
- ) => {
-      return marketplaceAxiosInstance<null>(
-      {url: `/admin/skills`, method: 'GET'
-    },
-      );
-    }
-  
-const adminSkillsControllerCreate = (
-    
- ) => {
-      return marketplaceAxiosInstance<null>(
-      {url: `/admin/skills`, method: 'POST'
-    },
-      );
-    }
-  
-const adminSkillsControllerNewForm = (
-    
- ) => {
-      return marketplaceAxiosInstance<null>(
-      {url: `/admin/skills/new`, method: 'GET'
-    },
-      );
-    }
-  
-const adminSkillsControllerEditForm = (
-    id: string,
- ) => {
-      return marketplaceAxiosInstance<null>(
-      {url: `/admin/skills/${id}/edit`, method: 'GET'
-    },
-      );
-    }
-  
-const adminSkillsControllerUpdate = (
-    id: string,
- ) => {
-      return marketplaceAxiosInstance<null>(
-      {url: `/admin/skills/${id}`, method: 'POST'
-    },
-      );
-    }
-  
-const adminSkillsControllerDeleteConfirm = (
-    id: string,
- ) => {
-      return marketplaceAxiosInstance<null>(
-      {url: `/admin/skills/${id}/delete`, method: 'GET'
-    },
-      );
-    }
-  
-const adminSkillsControllerDelete = (
-    id: string,
- ) => {
-      return marketplaceAxiosInstance<null>(
-      {url: `/admin/skills/${id}/delete`, method: 'POST'
-    },
-      );
-    }
-  
-const adminSkillsControllerPublish = (
-    id: string,
- ) => {
-      return marketplaceAxiosInstance<null>(
-      {url: `/admin/skills/${id}/publish`, method: 'POST'
-    },
-      );
-    }
-  
-const adminSkillsControllerUnpublish = (
-    id: string,
- ) => {
-      return marketplaceAxiosInstance<null>(
-      {url: `/admin/skills/${id}/unpublish`, method: 'POST'
-    },
-      );
-    }
-  
-/**
- * Retrieve a paginated list of published integrations with optional filters for featured status and pagination.
- * @summary List published integrations
- */
-const publicIntegrationsControllerList = (
+  ) => {
+    return marketplaceAxiosInstance<PaginatedSkillsResponseDto>({
+      url: `/api/skills`,
+      method: 'GET',
+      params,
+    });
+  };
+
+  /**
+   * Retrieve all published skills that are marked as pre-installed for new organizations.
+   * @summary List pre-installed skills
+   */
+  const publicSkillsControllerListPreInstalled = () => {
+    return marketplaceAxiosInstance<SkillListResponseDto[]>({
+      url: `/api/skills/pre-installed`,
+      method: 'GET',
+    });
+  };
+
+  /**
+   * Retrieve full details of a published skill by its unique identifier slug.
+   * @summary Get a skill by identifier
+   */
+  const publicSkillsControllerGetByIdentifier = (identifier: string) => {
+    return marketplaceAxiosInstance<SkillResponseDto>({
+      url: `/api/skills/${identifier}`,
+      method: 'GET',
+    });
+  };
+
+  const adminSkillsControllerList = () => {
+    return marketplaceAxiosInstance<null>({
+      url: `/admin/skills`,
+      method: 'GET',
+    });
+  };
+
+  const adminSkillsControllerCreate = () => {
+    return marketplaceAxiosInstance<null>({
+      url: `/admin/skills`,
+      method: 'POST',
+    });
+  };
+
+  const adminSkillsControllerNewForm = () => {
+    return marketplaceAxiosInstance<null>({
+      url: `/admin/skills/new`,
+      method: 'GET',
+    });
+  };
+
+  const adminSkillsControllerEditForm = (id: string) => {
+    return marketplaceAxiosInstance<null>({
+      url: `/admin/skills/${id}/edit`,
+      method: 'GET',
+    });
+  };
+
+  const adminSkillsControllerUpdate = (id: string) => {
+    return marketplaceAxiosInstance<null>({
+      url: `/admin/skills/${id}`,
+      method: 'POST',
+    });
+  };
+
+  const adminSkillsControllerDeleteConfirm = (id: string) => {
+    return marketplaceAxiosInstance<null>({
+      url: `/admin/skills/${id}/delete`,
+      method: 'GET',
+    });
+  };
+
+  const adminSkillsControllerDelete = (id: string) => {
+    return marketplaceAxiosInstance<null>({
+      url: `/admin/skills/${id}/delete`,
+      method: 'POST',
+    });
+  };
+
+  const adminSkillsControllerPublish = (id: string) => {
+    return marketplaceAxiosInstance<null>({
+      url: `/admin/skills/${id}/publish`,
+      method: 'POST',
+    });
+  };
+
+  const adminSkillsControllerUnpublish = (id: string) => {
+    return marketplaceAxiosInstance<null>({
+      url: `/admin/skills/${id}/unpublish`,
+      method: 'POST',
+    });
+  };
+
+  /**
+   * Retrieve a paginated list of published integrations with optional filters for featured status and pagination.
+   * @summary List published integrations
+   */
+  const publicIntegrationsControllerList = (
     params?: PublicIntegrationsControllerListParams,
- ) => {
-      return marketplaceAxiosInstance<PaginatedIntegrationsResponseDto>(
-      {url: `/api/integrations`, method: 'GET',
-        params
-    },
-      );
-    }
-  
-/**
- * Retrieve all published integrations that are marked as pre-installed for new organizations.
- * @summary List pre-installed integrations
- */
-const publicIntegrationsControllerListPreInstalled = (
-    
- ) => {
-      return marketplaceAxiosInstance<IntegrationListResponseDto[]>(
-      {url: `/api/integrations/pre-installed`, method: 'GET'
-    },
-      );
-    }
-  
-/**
- * Retrieve full details of a published integration by its unique identifier slug.
- * @summary Get an integration by identifier
- */
-const publicIntegrationsControllerGetByIdentifier = (
-    identifier: string,
- ) => {
-      return marketplaceAxiosInstance<IntegrationResponseDto>(
-      {url: `/api/integrations/${identifier}`, method: 'GET'
-    },
-      );
-    }
-  
-const adminIntegrationsControllerList = (
-    
- ) => {
-      return marketplaceAxiosInstance<null>(
-      {url: `/admin/integrations`, method: 'GET'
-    },
-      );
-    }
-  
-const adminIntegrationsControllerCreate = (
-    
- ) => {
-      return marketplaceAxiosInstance<null>(
-      {url: `/admin/integrations`, method: 'POST'
-    },
-      );
-    }
-  
-const adminIntegrationsControllerNewForm = (
-    
- ) => {
-      return marketplaceAxiosInstance<null>(
-      {url: `/admin/integrations/new`, method: 'GET'
-    },
-      );
-    }
-  
-const adminIntegrationsControllerEditForm = (
-    id: string,
- ) => {
-      return marketplaceAxiosInstance<null>(
-      {url: `/admin/integrations/${id}/edit`, method: 'GET'
-    },
-      );
-    }
-  
-const adminIntegrationsControllerUpdate = (
-    id: string,
- ) => {
-      return marketplaceAxiosInstance<null>(
-      {url: `/admin/integrations/${id}`, method: 'POST'
-    },
-      );
-    }
-  
-const adminIntegrationsControllerDeleteConfirm = (
-    id: string,
- ) => {
-      return marketplaceAxiosInstance<null>(
-      {url: `/admin/integrations/${id}/delete`, method: 'GET'
-    },
-      );
-    }
-  
-const adminIntegrationsControllerDelete = (
-    id: string,
- ) => {
-      return marketplaceAxiosInstance<null>(
-      {url: `/admin/integrations/${id}/delete`, method: 'POST'
-    },
-      );
-    }
-  
-const adminIntegrationsControllerPublish = (
-    id: string,
- ) => {
-      return marketplaceAxiosInstance<null>(
-      {url: `/admin/integrations/${id}/publish`, method: 'POST'
-    },
-      );
-    }
-  
-const adminIntegrationsControllerUnpublish = (
-    id: string,
- ) => {
-      return marketplaceAxiosInstance<null>(
-      {url: `/admin/integrations/${id}/unpublish`, method: 'POST'
-    },
-      );
-    }
-  
-return {authControllerLoginPage,authControllerGoogleAuth,authControllerGoogleAuthCallback,authControllerLogout,adminControllerDashboard,publicSkillCategoriesControllerList,adminSkillCategoriesControllerList,adminSkillCategoriesControllerCreate,adminSkillCategoriesControllerNewForm,adminSkillCategoriesControllerEditForm,adminSkillCategoriesControllerUpdate,adminSkillCategoriesControllerDeleteConfirm,adminSkillCategoriesControllerDelete,publicSkillsControllerList,publicSkillsControllerListPreInstalled,publicSkillsControllerGetByIdentifier,adminSkillsControllerList,adminSkillsControllerCreate,adminSkillsControllerNewForm,adminSkillsControllerEditForm,adminSkillsControllerUpdate,adminSkillsControllerDeleteConfirm,adminSkillsControllerDelete,adminSkillsControllerPublish,adminSkillsControllerUnpublish,publicIntegrationsControllerList,publicIntegrationsControllerListPreInstalled,publicIntegrationsControllerGetByIdentifier,adminIntegrationsControllerList,adminIntegrationsControllerCreate,adminIntegrationsControllerNewForm,adminIntegrationsControllerEditForm,adminIntegrationsControllerUpdate,adminIntegrationsControllerDeleteConfirm,adminIntegrationsControllerDelete,adminIntegrationsControllerPublish,adminIntegrationsControllerUnpublish}};
-export type AuthControllerLoginPageResult = NonNullable<Awaited<ReturnType<ReturnType<typeof getAyunisMarketplaceAPI>['authControllerLoginPage']>>>
-export type AuthControllerGoogleAuthResult = NonNullable<Awaited<ReturnType<ReturnType<typeof getAyunisMarketplaceAPI>['authControllerGoogleAuth']>>>
-export type AuthControllerGoogleAuthCallbackResult = NonNullable<Awaited<ReturnType<ReturnType<typeof getAyunisMarketplaceAPI>['authControllerGoogleAuthCallback']>>>
-export type AuthControllerLogoutResult = NonNullable<Awaited<ReturnType<ReturnType<typeof getAyunisMarketplaceAPI>['authControllerLogout']>>>
-export type AdminControllerDashboardResult = NonNullable<Awaited<ReturnType<ReturnType<typeof getAyunisMarketplaceAPI>['adminControllerDashboard']>>>
-export type PublicSkillCategoriesControllerListResult = NonNullable<Awaited<ReturnType<ReturnType<typeof getAyunisMarketplaceAPI>['publicSkillCategoriesControllerList']>>>
-export type AdminSkillCategoriesControllerListResult = NonNullable<Awaited<ReturnType<ReturnType<typeof getAyunisMarketplaceAPI>['adminSkillCategoriesControllerList']>>>
-export type AdminSkillCategoriesControllerCreateResult = NonNullable<Awaited<ReturnType<ReturnType<typeof getAyunisMarketplaceAPI>['adminSkillCategoriesControllerCreate']>>>
-export type AdminSkillCategoriesControllerNewFormResult = NonNullable<Awaited<ReturnType<ReturnType<typeof getAyunisMarketplaceAPI>['adminSkillCategoriesControllerNewForm']>>>
-export type AdminSkillCategoriesControllerEditFormResult = NonNullable<Awaited<ReturnType<ReturnType<typeof getAyunisMarketplaceAPI>['adminSkillCategoriesControllerEditForm']>>>
-export type AdminSkillCategoriesControllerUpdateResult = NonNullable<Awaited<ReturnType<ReturnType<typeof getAyunisMarketplaceAPI>['adminSkillCategoriesControllerUpdate']>>>
-export type AdminSkillCategoriesControllerDeleteConfirmResult = NonNullable<Awaited<ReturnType<ReturnType<typeof getAyunisMarketplaceAPI>['adminSkillCategoriesControllerDeleteConfirm']>>>
-export type AdminSkillCategoriesControllerDeleteResult = NonNullable<Awaited<ReturnType<ReturnType<typeof getAyunisMarketplaceAPI>['adminSkillCategoriesControllerDelete']>>>
-export type PublicSkillsControllerListResult = NonNullable<Awaited<ReturnType<ReturnType<typeof getAyunisMarketplaceAPI>['publicSkillsControllerList']>>>
-export type PublicSkillsControllerListPreInstalledResult = NonNullable<Awaited<ReturnType<ReturnType<typeof getAyunisMarketplaceAPI>['publicSkillsControllerListPreInstalled']>>>
-export type PublicSkillsControllerGetByIdentifierResult = NonNullable<Awaited<ReturnType<ReturnType<typeof getAyunisMarketplaceAPI>['publicSkillsControllerGetByIdentifier']>>>
-export type AdminSkillsControllerListResult = NonNullable<Awaited<ReturnType<ReturnType<typeof getAyunisMarketplaceAPI>['adminSkillsControllerList']>>>
-export type AdminSkillsControllerCreateResult = NonNullable<Awaited<ReturnType<ReturnType<typeof getAyunisMarketplaceAPI>['adminSkillsControllerCreate']>>>
-export type AdminSkillsControllerNewFormResult = NonNullable<Awaited<ReturnType<ReturnType<typeof getAyunisMarketplaceAPI>['adminSkillsControllerNewForm']>>>
-export type AdminSkillsControllerEditFormResult = NonNullable<Awaited<ReturnType<ReturnType<typeof getAyunisMarketplaceAPI>['adminSkillsControllerEditForm']>>>
-export type AdminSkillsControllerUpdateResult = NonNullable<Awaited<ReturnType<ReturnType<typeof getAyunisMarketplaceAPI>['adminSkillsControllerUpdate']>>>
-export type AdminSkillsControllerDeleteConfirmResult = NonNullable<Awaited<ReturnType<ReturnType<typeof getAyunisMarketplaceAPI>['adminSkillsControllerDeleteConfirm']>>>
-export type AdminSkillsControllerDeleteResult = NonNullable<Awaited<ReturnType<ReturnType<typeof getAyunisMarketplaceAPI>['adminSkillsControllerDelete']>>>
-export type AdminSkillsControllerPublishResult = NonNullable<Awaited<ReturnType<ReturnType<typeof getAyunisMarketplaceAPI>['adminSkillsControllerPublish']>>>
-export type AdminSkillsControllerUnpublishResult = NonNullable<Awaited<ReturnType<ReturnType<typeof getAyunisMarketplaceAPI>['adminSkillsControllerUnpublish']>>>
-export type PublicIntegrationsControllerListResult = NonNullable<Awaited<ReturnType<ReturnType<typeof getAyunisMarketplaceAPI>['publicIntegrationsControllerList']>>>
-export type PublicIntegrationsControllerListPreInstalledResult = NonNullable<Awaited<ReturnType<ReturnType<typeof getAyunisMarketplaceAPI>['publicIntegrationsControllerListPreInstalled']>>>
-export type PublicIntegrationsControllerGetByIdentifierResult = NonNullable<Awaited<ReturnType<ReturnType<typeof getAyunisMarketplaceAPI>['publicIntegrationsControllerGetByIdentifier']>>>
-export type AdminIntegrationsControllerListResult = NonNullable<Awaited<ReturnType<ReturnType<typeof getAyunisMarketplaceAPI>['adminIntegrationsControllerList']>>>
-export type AdminIntegrationsControllerCreateResult = NonNullable<Awaited<ReturnType<ReturnType<typeof getAyunisMarketplaceAPI>['adminIntegrationsControllerCreate']>>>
-export type AdminIntegrationsControllerNewFormResult = NonNullable<Awaited<ReturnType<ReturnType<typeof getAyunisMarketplaceAPI>['adminIntegrationsControllerNewForm']>>>
-export type AdminIntegrationsControllerEditFormResult = NonNullable<Awaited<ReturnType<ReturnType<typeof getAyunisMarketplaceAPI>['adminIntegrationsControllerEditForm']>>>
-export type AdminIntegrationsControllerUpdateResult = NonNullable<Awaited<ReturnType<ReturnType<typeof getAyunisMarketplaceAPI>['adminIntegrationsControllerUpdate']>>>
-export type AdminIntegrationsControllerDeleteConfirmResult = NonNullable<Awaited<ReturnType<ReturnType<typeof getAyunisMarketplaceAPI>['adminIntegrationsControllerDeleteConfirm']>>>
-export type AdminIntegrationsControllerDeleteResult = NonNullable<Awaited<ReturnType<ReturnType<typeof getAyunisMarketplaceAPI>['adminIntegrationsControllerDelete']>>>
-export type AdminIntegrationsControllerPublishResult = NonNullable<Awaited<ReturnType<ReturnType<typeof getAyunisMarketplaceAPI>['adminIntegrationsControllerPublish']>>>
-export type AdminIntegrationsControllerUnpublishResult = NonNullable<Awaited<ReturnType<ReturnType<typeof getAyunisMarketplaceAPI>['adminIntegrationsControllerUnpublish']>>>
+  ) => {
+    return marketplaceAxiosInstance<PaginatedIntegrationsResponseDto>({
+      url: `/api/integrations`,
+      method: 'GET',
+      params,
+    });
+  };
+
+  /**
+   * Retrieve all published integrations that are marked as pre-installed for new organizations.
+   * @summary List pre-installed integrations
+   */
+  const publicIntegrationsControllerListPreInstalled = () => {
+    return marketplaceAxiosInstance<IntegrationListResponseDto[]>({
+      url: `/api/integrations/pre-installed`,
+      method: 'GET',
+    });
+  };
+
+  /**
+   * Retrieve full details of a published integration by its unique identifier slug.
+   * @summary Get an integration by identifier
+   */
+  const publicIntegrationsControllerGetByIdentifier = (identifier: string) => {
+    return marketplaceAxiosInstance<IntegrationResponseDto>({
+      url: `/api/integrations/${identifier}`,
+      method: 'GET',
+    });
+  };
+
+  const adminIntegrationsControllerList = () => {
+    return marketplaceAxiosInstance<null>({
+      url: `/admin/integrations`,
+      method: 'GET',
+    });
+  };
+
+  const adminIntegrationsControllerCreate = () => {
+    return marketplaceAxiosInstance<null>({
+      url: `/admin/integrations`,
+      method: 'POST',
+    });
+  };
+
+  const adminIntegrationsControllerNewForm = () => {
+    return marketplaceAxiosInstance<null>({
+      url: `/admin/integrations/new`,
+      method: 'GET',
+    });
+  };
+
+  const adminIntegrationsControllerEditForm = (id: string) => {
+    return marketplaceAxiosInstance<null>({
+      url: `/admin/integrations/${id}/edit`,
+      method: 'GET',
+    });
+  };
+
+  const adminIntegrationsControllerUpdate = (id: string) => {
+    return marketplaceAxiosInstance<null>({
+      url: `/admin/integrations/${id}`,
+      method: 'POST',
+    });
+  };
+
+  const adminIntegrationsControllerDeleteConfirm = (id: string) => {
+    return marketplaceAxiosInstance<null>({
+      url: `/admin/integrations/${id}/delete`,
+      method: 'GET',
+    });
+  };
+
+  const adminIntegrationsControllerDelete = (id: string) => {
+    return marketplaceAxiosInstance<null>({
+      url: `/admin/integrations/${id}/delete`,
+      method: 'POST',
+    });
+  };
+
+  const adminIntegrationsControllerPublish = (id: string) => {
+    return marketplaceAxiosInstance<null>({
+      url: `/admin/integrations/${id}/publish`,
+      method: 'POST',
+    });
+  };
+
+  const adminIntegrationsControllerUnpublish = (id: string) => {
+    return marketplaceAxiosInstance<null>({
+      url: `/admin/integrations/${id}/unpublish`,
+      method: 'POST',
+    });
+  };
+
+  return {
+    authControllerLoginPage,
+    authControllerGoogleAuth,
+    authControllerGoogleAuthCallback,
+    authControllerLogout,
+    adminControllerDashboard,
+    publicSkillCategoriesControllerList,
+    adminSkillCategoriesControllerList,
+    adminSkillCategoriesControllerCreate,
+    adminSkillCategoriesControllerNewForm,
+    adminSkillCategoriesControllerEditForm,
+    adminSkillCategoriesControllerUpdate,
+    adminSkillCategoriesControllerDeleteConfirm,
+    adminSkillCategoriesControllerDelete,
+    publicSkillsControllerList,
+    publicSkillsControllerListPreInstalled,
+    publicSkillsControllerGetByIdentifier,
+    adminSkillsControllerList,
+    adminSkillsControllerCreate,
+    adminSkillsControllerNewForm,
+    adminSkillsControllerEditForm,
+    adminSkillsControllerUpdate,
+    adminSkillsControllerDeleteConfirm,
+    adminSkillsControllerDelete,
+    adminSkillsControllerPublish,
+    adminSkillsControllerUnpublish,
+    publicIntegrationsControllerList,
+    publicIntegrationsControllerListPreInstalled,
+    publicIntegrationsControllerGetByIdentifier,
+    adminIntegrationsControllerList,
+    adminIntegrationsControllerCreate,
+    adminIntegrationsControllerNewForm,
+    adminIntegrationsControllerEditForm,
+    adminIntegrationsControllerUpdate,
+    adminIntegrationsControllerDeleteConfirm,
+    adminIntegrationsControllerDelete,
+    adminIntegrationsControllerPublish,
+    adminIntegrationsControllerUnpublish,
+  };
+};
+export type AuthControllerLoginPageResult = NonNullable<
+  Awaited<
+    ReturnType<
+      ReturnType<typeof getAyunisMarketplaceAPI>['authControllerLoginPage']
+    >
+  >
+>;
+export type AuthControllerGoogleAuthResult = NonNullable<
+  Awaited<
+    ReturnType<
+      ReturnType<typeof getAyunisMarketplaceAPI>['authControllerGoogleAuth']
+    >
+  >
+>;
+export type AuthControllerGoogleAuthCallbackResult = NonNullable<
+  Awaited<
+    ReturnType<
+      ReturnType<
+        typeof getAyunisMarketplaceAPI
+      >['authControllerGoogleAuthCallback']
+    >
+  >
+>;
+export type AuthControllerLogoutResult = NonNullable<
+  Awaited<
+    ReturnType<
+      ReturnType<typeof getAyunisMarketplaceAPI>['authControllerLogout']
+    >
+  >
+>;
+export type AdminControllerDashboardResult = NonNullable<
+  Awaited<
+    ReturnType<
+      ReturnType<typeof getAyunisMarketplaceAPI>['adminControllerDashboard']
+    >
+  >
+>;
+export type PublicSkillCategoriesControllerListResult = NonNullable<
+  Awaited<
+    ReturnType<
+      ReturnType<
+        typeof getAyunisMarketplaceAPI
+      >['publicSkillCategoriesControllerList']
+    >
+  >
+>;
+export type AdminSkillCategoriesControllerListResult = NonNullable<
+  Awaited<
+    ReturnType<
+      ReturnType<
+        typeof getAyunisMarketplaceAPI
+      >['adminSkillCategoriesControllerList']
+    >
+  >
+>;
+export type AdminSkillCategoriesControllerCreateResult = NonNullable<
+  Awaited<
+    ReturnType<
+      ReturnType<
+        typeof getAyunisMarketplaceAPI
+      >['adminSkillCategoriesControllerCreate']
+    >
+  >
+>;
+export type AdminSkillCategoriesControllerNewFormResult = NonNullable<
+  Awaited<
+    ReturnType<
+      ReturnType<
+        typeof getAyunisMarketplaceAPI
+      >['adminSkillCategoriesControllerNewForm']
+    >
+  >
+>;
+export type AdminSkillCategoriesControllerEditFormResult = NonNullable<
+  Awaited<
+    ReturnType<
+      ReturnType<
+        typeof getAyunisMarketplaceAPI
+      >['adminSkillCategoriesControllerEditForm']
+    >
+  >
+>;
+export type AdminSkillCategoriesControllerUpdateResult = NonNullable<
+  Awaited<
+    ReturnType<
+      ReturnType<
+        typeof getAyunisMarketplaceAPI
+      >['adminSkillCategoriesControllerUpdate']
+    >
+  >
+>;
+export type AdminSkillCategoriesControllerDeleteConfirmResult = NonNullable<
+  Awaited<
+    ReturnType<
+      ReturnType<
+        typeof getAyunisMarketplaceAPI
+      >['adminSkillCategoriesControllerDeleteConfirm']
+    >
+  >
+>;
+export type AdminSkillCategoriesControllerDeleteResult = NonNullable<
+  Awaited<
+    ReturnType<
+      ReturnType<
+        typeof getAyunisMarketplaceAPI
+      >['adminSkillCategoriesControllerDelete']
+    >
+  >
+>;
+export type PublicSkillsControllerListResult = NonNullable<
+  Awaited<
+    ReturnType<
+      ReturnType<typeof getAyunisMarketplaceAPI>['publicSkillsControllerList']
+    >
+  >
+>;
+export type PublicSkillsControllerListPreInstalledResult = NonNullable<
+  Awaited<
+    ReturnType<
+      ReturnType<
+        typeof getAyunisMarketplaceAPI
+      >['publicSkillsControllerListPreInstalled']
+    >
+  >
+>;
+export type PublicSkillsControllerGetByIdentifierResult = NonNullable<
+  Awaited<
+    ReturnType<
+      ReturnType<
+        typeof getAyunisMarketplaceAPI
+      >['publicSkillsControllerGetByIdentifier']
+    >
+  >
+>;
+export type AdminSkillsControllerListResult = NonNullable<
+  Awaited<
+    ReturnType<
+      ReturnType<typeof getAyunisMarketplaceAPI>['adminSkillsControllerList']
+    >
+  >
+>;
+export type AdminSkillsControllerCreateResult = NonNullable<
+  Awaited<
+    ReturnType<
+      ReturnType<typeof getAyunisMarketplaceAPI>['adminSkillsControllerCreate']
+    >
+  >
+>;
+export type AdminSkillsControllerNewFormResult = NonNullable<
+  Awaited<
+    ReturnType<
+      ReturnType<typeof getAyunisMarketplaceAPI>['adminSkillsControllerNewForm']
+    >
+  >
+>;
+export type AdminSkillsControllerEditFormResult = NonNullable<
+  Awaited<
+    ReturnType<
+      ReturnType<
+        typeof getAyunisMarketplaceAPI
+      >['adminSkillsControllerEditForm']
+    >
+  >
+>;
+export type AdminSkillsControllerUpdateResult = NonNullable<
+  Awaited<
+    ReturnType<
+      ReturnType<typeof getAyunisMarketplaceAPI>['adminSkillsControllerUpdate']
+    >
+  >
+>;
+export type AdminSkillsControllerDeleteConfirmResult = NonNullable<
+  Awaited<
+    ReturnType<
+      ReturnType<
+        typeof getAyunisMarketplaceAPI
+      >['adminSkillsControllerDeleteConfirm']
+    >
+  >
+>;
+export type AdminSkillsControllerDeleteResult = NonNullable<
+  Awaited<
+    ReturnType<
+      ReturnType<typeof getAyunisMarketplaceAPI>['adminSkillsControllerDelete']
+    >
+  >
+>;
+export type AdminSkillsControllerPublishResult = NonNullable<
+  Awaited<
+    ReturnType<
+      ReturnType<typeof getAyunisMarketplaceAPI>['adminSkillsControllerPublish']
+    >
+  >
+>;
+export type AdminSkillsControllerUnpublishResult = NonNullable<
+  Awaited<
+    ReturnType<
+      ReturnType<
+        typeof getAyunisMarketplaceAPI
+      >['adminSkillsControllerUnpublish']
+    >
+  >
+>;
+export type PublicIntegrationsControllerListResult = NonNullable<
+  Awaited<
+    ReturnType<
+      ReturnType<
+        typeof getAyunisMarketplaceAPI
+      >['publicIntegrationsControllerList']
+    >
+  >
+>;
+export type PublicIntegrationsControllerListPreInstalledResult = NonNullable<
+  Awaited<
+    ReturnType<
+      ReturnType<
+        typeof getAyunisMarketplaceAPI
+      >['publicIntegrationsControllerListPreInstalled']
+    >
+  >
+>;
+export type PublicIntegrationsControllerGetByIdentifierResult = NonNullable<
+  Awaited<
+    ReturnType<
+      ReturnType<
+        typeof getAyunisMarketplaceAPI
+      >['publicIntegrationsControllerGetByIdentifier']
+    >
+  >
+>;
+export type AdminIntegrationsControllerListResult = NonNullable<
+  Awaited<
+    ReturnType<
+      ReturnType<
+        typeof getAyunisMarketplaceAPI
+      >['adminIntegrationsControllerList']
+    >
+  >
+>;
+export type AdminIntegrationsControllerCreateResult = NonNullable<
+  Awaited<
+    ReturnType<
+      ReturnType<
+        typeof getAyunisMarketplaceAPI
+      >['adminIntegrationsControllerCreate']
+    >
+  >
+>;
+export type AdminIntegrationsControllerNewFormResult = NonNullable<
+  Awaited<
+    ReturnType<
+      ReturnType<
+        typeof getAyunisMarketplaceAPI
+      >['adminIntegrationsControllerNewForm']
+    >
+  >
+>;
+export type AdminIntegrationsControllerEditFormResult = NonNullable<
+  Awaited<
+    ReturnType<
+      ReturnType<
+        typeof getAyunisMarketplaceAPI
+      >['adminIntegrationsControllerEditForm']
+    >
+  >
+>;
+export type AdminIntegrationsControllerUpdateResult = NonNullable<
+  Awaited<
+    ReturnType<
+      ReturnType<
+        typeof getAyunisMarketplaceAPI
+      >['adminIntegrationsControllerUpdate']
+    >
+  >
+>;
+export type AdminIntegrationsControllerDeleteConfirmResult = NonNullable<
+  Awaited<
+    ReturnType<
+      ReturnType<
+        typeof getAyunisMarketplaceAPI
+      >['adminIntegrationsControllerDeleteConfirm']
+    >
+  >
+>;
+export type AdminIntegrationsControllerDeleteResult = NonNullable<
+  Awaited<
+    ReturnType<
+      ReturnType<
+        typeof getAyunisMarketplaceAPI
+      >['adminIntegrationsControllerDelete']
+    >
+  >
+>;
+export type AdminIntegrationsControllerPublishResult = NonNullable<
+  Awaited<
+    ReturnType<
+      ReturnType<
+        typeof getAyunisMarketplaceAPI
+      >['adminIntegrationsControllerPublish']
+    >
+  >
+>;
+export type AdminIntegrationsControllerUnpublishResult = NonNullable<
+  Awaited<
+    ReturnType<
+      ReturnType<
+        typeof getAyunisMarketplaceAPI
+      >['adminIntegrationsControllerUnpublish']
+    >
+  >
+>;

--- a/ayunis-core-backend/src/common/clients/marketplace/generated/ayunisMarketplaceAPI.ts
+++ b/ayunis-core-backend/src/common/clients/marketplace/generated/ayunisMarketplaceAPI.ts
@@ -6,6 +6,7 @@
  * OpenAPI spec version: 1.0
  */
 import type {
+  IntegrationResponseDto,
   PaginatedSkillsResponseDto,
   PublicSkillsControllerListParams,
   SkillCategoryResponseDto,
@@ -207,6 +208,17 @@ export const getAyunisMarketplaceAPI = () => {
     });
   };
 
+  /**
+   * Retrieve full details of a published integration by its unique identifier slug.
+   * @summary Get an integration by identifier
+   */
+  const publicIntegrationsControllerGetByIdentifier = (identifier: string) => {
+    return marketplaceAxiosInstance<IntegrationResponseDto>({
+      url: `/api/integrations/${identifier}`,
+      method: 'GET',
+    });
+  };
+
   return {
     authControllerLoginPage,
     authControllerGoogleAuth,
@@ -233,6 +245,7 @@ export const getAyunisMarketplaceAPI = () => {
     adminSkillsControllerDelete,
     adminSkillsControllerPublish,
     adminSkillsControllerUnpublish,
+    publicIntegrationsControllerGetByIdentifier,
   };
 };
 export type AuthControllerLoginPageResult = NonNullable<
@@ -435,6 +448,15 @@ export type AdminSkillsControllerUnpublishResult = NonNullable<
       ReturnType<
         typeof getAyunisMarketplaceAPI
       >['adminSkillsControllerUnpublish']
+    >
+  >
+>;
+export type PublicIntegrationsControllerGetByIdentifierResult = NonNullable<
+  Awaited<
+    ReturnType<
+      ReturnType<
+        typeof getAyunisMarketplaceAPI
+      >['publicIntegrationsControllerGetByIdentifier']
     >
   >
 >;

--- a/ayunis-core-backend/src/common/validators/is-string-record.validator.spec.ts
+++ b/ayunis-core-backend/src/common/validators/is-string-record.validator.spec.ts
@@ -1,0 +1,68 @@
+import { validate } from 'class-validator';
+import { IsStringRecord } from './is-string-record.validator';
+
+class TestDto {
+  @IsStringRecord({ message: 'all values must be strings' })
+  data: Record<string, string>;
+}
+
+describe('IsStringRecord', () => {
+  function createDto(data: unknown): TestDto {
+    const dto = new TestDto();
+    dto.data = data as Record<string, string>;
+    return dto;
+  }
+
+  it('accepts an object with all string values', async () => {
+    const dto = createDto({ key1: 'value1', key2: 'value2' });
+    const errors = await validate(dto);
+    expect(errors).toHaveLength(0);
+  });
+
+  it('accepts an empty object', async () => {
+    const dto = createDto({});
+    const errors = await validate(dto);
+    expect(errors).toHaveLength(0);
+  });
+
+  it('rejects an object with a numeric value', async () => {
+    const dto = createDto({ apiToken: 123 });
+    const errors = await validate(dto);
+    expect(errors).toHaveLength(1);
+    expect(errors[0].constraints).toBeDefined();
+  });
+
+  it('rejects an object with a null value', async () => {
+    const dto = createDto({ key: null });
+    const errors = await validate(dto);
+    expect(errors).toHaveLength(1);
+  });
+
+  it('rejects an object with a boolean value', async () => {
+    const dto = createDto({ enabled: true });
+    const errors = await validate(dto);
+    expect(errors).toHaveLength(1);
+  });
+
+  it('rejects an object with a nested object value', async () => {
+    const dto = createDto({ nested: { inner: 'value' } });
+    const errors = await validate(dto);
+    expect(errors).toHaveLength(1);
+  });
+
+  it('rejects an object with an undefined value', async () => {
+    const dto = createDto({ key: undefined });
+    const errors = await validate(dto);
+    expect(errors).toHaveLength(1);
+  });
+
+  it('uses custom message when provided', async () => {
+    const dto = createDto({ key: 42 });
+    const errors = await validate(dto);
+    expect(errors[0].constraints).toEqual(
+      expect.objectContaining({
+        isStringRecord: 'all values must be strings',
+      }),
+    );
+  });
+});

--- a/ayunis-core-backend/src/common/validators/is-string-record.validator.spec.ts
+++ b/ayunis-core-backend/src/common/validators/is-string-record.validator.spec.ts
@@ -56,6 +56,18 @@ describe('IsStringRecord', () => {
     expect(errors).toHaveLength(1);
   });
 
+  it('rejects an array of strings', async () => {
+    const dto = createDto(['value1', 'value2']);
+    const errors = await validate(dto);
+    expect(errors).toHaveLength(1);
+  });
+
+  it('rejects an empty array', async () => {
+    const dto = createDto([]);
+    const errors = await validate(dto);
+    expect(errors).toHaveLength(1);
+  });
+
   it('uses custom message when provided', async () => {
     const dto = createDto({ key: 42 });
     const errors = await validate(dto);

--- a/ayunis-core-backend/src/common/validators/is-string-record.validator.ts
+++ b/ayunis-core-backend/src/common/validators/is-string-record.validator.ts
@@ -1,8 +1,5 @@
-import {
-  registerDecorator,
-  ValidationOptions,
-  ValidationArguments,
-} from 'class-validator';
+import type { ValidationOptions, ValidationArguments } from 'class-validator';
+import { registerDecorator } from 'class-validator';
 
 /**
  * Validates that a value is a plain object where every value is a string.
@@ -19,6 +16,9 @@ export function IsStringRecord(validationOptions?: ValidationOptions) {
       validator: {
         validate(value: unknown) {
           if (typeof value !== 'object' || value === null) {
+            return false;
+          }
+          if (Array.isArray(value)) {
             return false;
           }
           return Object.values(value).every((v) => typeof v === 'string');

--- a/ayunis-core-backend/src/common/validators/is-string-record.validator.ts
+++ b/ayunis-core-backend/src/common/validators/is-string-record.validator.ts
@@ -1,0 +1,32 @@
+import {
+  registerDecorator,
+  ValidationOptions,
+  ValidationArguments,
+} from 'class-validator';
+
+/**
+ * Validates that a value is a plain object where every value is a string.
+ * Use on `Record<string, string>` DTO fields to enforce type safety at runtime,
+ * since TypeScript's `Record<string, string>` is erased after compilation.
+ */
+export function IsStringRecord(validationOptions?: ValidationOptions) {
+  return function (object: object, propertyName: string) {
+    registerDecorator({
+      name: 'isStringRecord',
+      target: object.constructor,
+      propertyName: propertyName,
+      options: validationOptions,
+      validator: {
+        validate(value: unknown) {
+          if (typeof value !== 'object' || value === null) {
+            return false;
+          }
+          return Object.values(value).every((v) => typeof v === 'string');
+        },
+        defaultMessage(args: ValidationArguments) {
+          return `all values in ${args.property} must be strings`;
+        },
+      },
+    });
+  };
+}

--- a/ayunis-core-backend/src/db/migrations/1771418124769-AddMarketplaceMcpIntegrations.ts
+++ b/ayunis-core-backend/src/db/migrations/1771418124769-AddMarketplaceMcpIntegrations.ts
@@ -1,0 +1,35 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddMarketplaceMcpIntegrations1771418124769
+  implements MigrationInterface
+{
+  name = 'AddMarketplaceMcpIntegrations1771418124769';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE "mcp_integration_user_configs" ("id" character varying NOT NULL, "createdAt" TIMESTAMP NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP NOT NULL DEFAULT now(), "integration_id" uuid NOT NULL, "user_id" uuid NOT NULL, "config_values" jsonb NOT NULL DEFAULT '{}', CONSTRAINT "UQ_d2b5a8f0850eeab6b6dfb4885e8" UNIQUE ("integration_id", "user_id"), CONSTRAINT "PK_e7085d7749f13c8ba6b6a7e1f7d" PRIMARY KEY ("id"))`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "mcp_integrations" ADD "marketplace_identifier" character varying`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "mcp_integrations" ADD "config_schema" jsonb`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "mcp_integrations" ADD "org_config_values" jsonb DEFAULT '{}'`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "mcp_integrations" DROP COLUMN "org_config_values"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "mcp_integrations" DROP COLUMN "config_schema"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "mcp_integrations" DROP COLUMN "marketplace_identifier"`,
+    );
+    await queryRunner.query(`DROP TABLE "mcp_integration_user_configs"`);
+  }
+}

--- a/ayunis-core-backend/src/db/migrations/1771418124769-AddMarketplaceMcpIntegrations.ts
+++ b/ayunis-core-backend/src/db/migrations/1771418124769-AddMarketplaceMcpIntegrations.ts
@@ -1,4 +1,4 @@
-import { MigrationInterface, QueryRunner } from 'typeorm';
+import type { MigrationInterface, QueryRunner } from 'typeorm';
 
 export class AddMarketplaceMcpIntegrations1771418124769
   implements MigrationInterface
@@ -7,7 +7,7 @@ export class AddMarketplaceMcpIntegrations1771418124769
 
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(
-      `CREATE TABLE "mcp_integration_user_configs" ("id" character varying NOT NULL, "createdAt" TIMESTAMP NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP NOT NULL DEFAULT now(), "integration_id" uuid NOT NULL, "user_id" uuid NOT NULL, "config_values" jsonb NOT NULL DEFAULT '{}', CONSTRAINT "UQ_d2b5a8f0850eeab6b6dfb4885e8" UNIQUE ("integration_id", "user_id"), CONSTRAINT "PK_e7085d7749f13c8ba6b6a7e1f7d" PRIMARY KEY ("id"))`,
+      `CREATE TABLE "mcp_integration_user_configs" ("id" character varying NOT NULL, "createdAt" TIMESTAMP NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP NOT NULL DEFAULT now(), "integration_id" character varying NOT NULL, "user_id" uuid NOT NULL, "config_values" jsonb NOT NULL DEFAULT '{}', CONSTRAINT "UQ_d2b5a8f0850eeab6b6dfb4885e8" UNIQUE ("integration_id", "user_id"), CONSTRAINT "PK_e7085d7749f13c8ba6b6a7e1f7d" PRIMARY KEY ("id"))`,
     );
     await queryRunner.query(
       `ALTER TABLE "mcp_integrations" ADD "marketplace_identifier" character varying`,
@@ -19,7 +19,7 @@ export class AddMarketplaceMcpIntegrations1771418124769
       `ALTER TABLE "mcp_integrations" ADD "org_config_values" jsonb DEFAULT '{}'`,
     );
     await queryRunner.query(
-      `CREATE UNIQUE INDEX "UQ_marketplace_org_identifier" ON "mcp_integrations" ("org_id", "marketplace_identifier") WHERE "marketplace_identifier" IS NOT NULL`,
+      `CREATE UNIQUE INDEX "UQ_marketplace_org_identifier" ON "mcp_integrations" ("orgId", "marketplace_identifier") WHERE "marketplace_identifier" IS NOT NULL`,
     );
     await queryRunner.query(
       `ALTER TABLE "mcp_integration_user_configs" ADD CONSTRAINT "FK_user_config_integration" FOREIGN KEY ("integration_id") REFERENCES "mcp_integrations"("id") ON DELETE CASCADE`,

--- a/ayunis-core-backend/src/db/migrations/1771418124769-AddMarketplaceMcpIntegrations.ts
+++ b/ayunis-core-backend/src/db/migrations/1771418124769-AddMarketplaceMcpIntegrations.ts
@@ -18,9 +18,19 @@ export class AddMarketplaceMcpIntegrations1771418124769
     await queryRunner.query(
       `ALTER TABLE "mcp_integrations" ADD "org_config_values" jsonb DEFAULT '{}'`,
     );
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX "UQ_marketplace_org_identifier" ON "mcp_integrations" ("org_id", "marketplace_identifier") WHERE "marketplace_identifier" IS NOT NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "mcp_integration_user_configs" ADD CONSTRAINT "FK_user_config_integration" FOREIGN KEY ("integration_id") REFERENCES "mcp_integrations"("id") ON DELETE CASCADE`,
+    );
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "mcp_integration_user_configs" DROP CONSTRAINT "FK_user_config_integration"`,
+    );
+    await queryRunner.query(`DROP INDEX "UQ_marketplace_org_identifier"`);
     await queryRunner.query(
       `ALTER TABLE "mcp_integrations" DROP COLUMN "org_config_values"`,
     );

--- a/ayunis-core-backend/src/domain/marketplace/SUMMARY.md
+++ b/ayunis-core-backend/src/domain/marketplace/SUMMARY.md
@@ -1,10 +1,11 @@
 Marketplace Integration
-Fetch and preview marketplace skills for local installation
+Fetch and preview marketplace skills and integrations for local installation
 
-The marketplace module provides integration with the external Ayunis Marketplace service to browse and install pre-configured skills. Users can preview marketplace skill details before installing them into their local account.
+The marketplace module provides integration with the external Ayunis Marketplace service to browse and install pre-configured skills and MCP integrations. Users can preview marketplace item details before installing them into their local account.
 
 **Use Cases:**
 - `GetMarketplaceSkillUseCase` — Fetches skill details from the marketplace by identifier
+- `GetMarketplaceIntegrationUseCase` — Fetches MCP integration details (including config schema with org/user fields) from the marketplace by identifier
 
 **Ports:**
 - `MarketplaceClient` — Abstract port for marketplace API communication (`getSkillByIdentifier`, `getPreInstalledSkills`)
@@ -13,13 +14,17 @@ The marketplace module provides integration with the external Ayunis Marketplace
 - `MarketplaceHttpClient` — HTTP client implementation using the generated marketplace API client
 
 **Presenters:**
-- `MarketplaceController` — REST controller exposing `GET /marketplace/skills/:identifier` for previewing skills
+- `MarketplaceController` — REST controller exposing:
+  - `GET /marketplace/skills/:identifier` — Preview a marketplace skill before installation
+  - `GET /marketplace/integrations/:identifier` — Preview a marketplace integration before installation
 
 **DTOs:**
 - `MarketplaceSkillResponseDto` — Response DTO containing skill details (name, shortDescription, aiDescription, instructions, etc.)
+- `MarketplaceIntegrationResponseDto` — Response DTO containing integration details (name, shortDescription, description, serverUrl, configSchema with orgFields/userFields, etc.)
 
 **Errors:**
 - `MarketplaceSkillNotFoundError` — Skill with given identifier not found (404)
+- `MarketplaceIntegrationNotFoundError` — Integration with given identifier not found (404)
 - `MarketplaceUnavailableError` — Marketplace service is unavailable (503)
 
 **Module Dependencies:**
@@ -27,3 +32,4 @@ The marketplace module provides integration with the external Ayunis Marketplace
 
 **Dependent Modules:**
 - **skills** — Uses `GetMarketplaceSkillUseCase` for installing marketplace skills via `InstallSkillFromMarketplaceUseCase`; `MarketplaceSkillInstallationService` consumes `MarketplaceClient.getPreInstalledSkills()` for pre-installed skill provisioning
+- **mcp** — Uses `GetMarketplaceIntegrationUseCase` for installing marketplace MCP integrations via `InstallMarketplaceIntegrationUseCase`

--- a/ayunis-core-backend/src/domain/marketplace/application/marketplace.errors.ts
+++ b/ayunis-core-backend/src/domain/marketplace/application/marketplace.errors.ts
@@ -10,6 +10,16 @@ export class MarketplaceSkillNotFoundError extends ApplicationError {
   }
 }
 
+export class MarketplaceIntegrationNotFoundError extends ApplicationError {
+  constructor(identifier: string) {
+    super(
+      `Marketplace integration not found: ${identifier}`,
+      'MARKETPLACE_INTEGRATION_NOT_FOUND',
+      404,
+    );
+  }
+}
+
 export class MarketplaceUnavailableError extends ApplicationError {
   constructor() {
     super(

--- a/ayunis-core-backend/src/domain/marketplace/application/ports/marketplace-client.port.ts
+++ b/ayunis-core-backend/src/domain/marketplace/application/ports/marketplace-client.port.ts
@@ -1,4 +1,5 @@
 import type {
+  IntegrationResponseDto,
   SkillListResponseDto,
   SkillResponseDto,
 } from 'src/common/clients/marketplace/generated/ayunisMarketplaceAPI.schemas';
@@ -9,4 +10,8 @@ export abstract class MarketplaceClient {
   ): Promise<SkillResponseDto | null>;
 
   abstract getPreInstalledSkills(): Promise<SkillListResponseDto[]>;
+
+  abstract getIntegrationByIdentifier(
+    identifier: string,
+  ): Promise<IntegrationResponseDto | null>;
 }

--- a/ayunis-core-backend/src/domain/marketplace/application/use-cases/get-marketplace-integration/get-marketplace-integration.query.ts
+++ b/ayunis-core-backend/src/domain/marketplace/application/use-cases/get-marketplace-integration/get-marketplace-integration.query.ts
@@ -1,0 +1,3 @@
+export class GetMarketplaceIntegrationQuery {
+  constructor(public readonly identifier: string) {}
+}

--- a/ayunis-core-backend/src/domain/marketplace/application/use-cases/get-marketplace-integration/get-marketplace-integration.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/marketplace/application/use-cases/get-marketplace-integration/get-marketplace-integration.use-case.spec.ts
@@ -1,11 +1,11 @@
 import { GetMarketplaceIntegrationUseCase } from './get-marketplace-integration.use-case';
 import { GetMarketplaceIntegrationQuery } from './get-marketplace-integration.query';
-import { MarketplaceClient } from '../../ports/marketplace-client.port';
+import type { MarketplaceClient } from '../../ports/marketplace-client.port';
 import {
   MarketplaceIntegrationNotFoundError,
   MarketplaceUnavailableError,
 } from '../../marketplace.errors';
-import { IntegrationResponseDto } from 'src/common/clients/marketplace/generated/ayunisMarketplaceAPI.schemas';
+import type { IntegrationResponseDto } from 'src/common/clients/marketplace/generated/ayunisMarketplaceAPI.schemas';
 
 describe('GetMarketplaceIntegrationUseCase', () => {
   let useCase: GetMarketplaceIntegrationUseCase;
@@ -46,6 +46,7 @@ describe('GetMarketplaceIntegrationUseCase', () => {
   beforeEach(() => {
     marketplaceClient = {
       getSkillByIdentifier: jest.fn(),
+      getPreInstalledSkills: jest.fn(),
       getIntegrationByIdentifier: jest.fn(),
     } as jest.Mocked<MarketplaceClient>;
 

--- a/ayunis-core-backend/src/domain/marketplace/application/use-cases/get-marketplace-integration/get-marketplace-integration.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/marketplace/application/use-cases/get-marketplace-integration/get-marketplace-integration.use-case.spec.ts
@@ -15,10 +15,13 @@ describe('GetMarketplaceIntegrationUseCase', () => {
     id: '550e8400-e29b-41d4-a716-446655440000',
     identifier: 'oparl-council-data',
     name: 'OParl Council Data',
+    shortDescription: 'Access municipal council data via OParl',
     description:
       'Access municipal council data via the OParl standard interface',
     iconUrl: 'https://marketplace.ayunis.de/icons/oparl.png',
     serverUrl: 'https://mcp.ayunis.de/oparl',
+    featured: false,
+    preInstalled: false,
     configSchema: {
       authType: 'NO_AUTH',
       orgFields: [

--- a/ayunis-core-backend/src/domain/marketplace/application/use-cases/get-marketplace-integration/get-marketplace-integration.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/marketplace/application/use-cases/get-marketplace-integration/get-marketplace-integration.use-case.spec.ts
@@ -1,0 +1,99 @@
+import { GetMarketplaceIntegrationUseCase } from './get-marketplace-integration.use-case';
+import { GetMarketplaceIntegrationQuery } from './get-marketplace-integration.query';
+import { MarketplaceClient } from '../../ports/marketplace-client.port';
+import {
+  MarketplaceIntegrationNotFoundError,
+  MarketplaceUnavailableError,
+} from '../../marketplace.errors';
+import { IntegrationResponseDto } from 'src/common/clients/marketplace/generated/ayunisMarketplaceAPI.schemas';
+
+describe('GetMarketplaceIntegrationUseCase', () => {
+  let useCase: GetMarketplaceIntegrationUseCase;
+  let marketplaceClient: jest.Mocked<MarketplaceClient>;
+
+  const mockIntegration: IntegrationResponseDto = {
+    id: '550e8400-e29b-41d4-a716-446655440000',
+    identifier: 'oparl-council-data',
+    name: 'OParl Council Data',
+    description:
+      'Access municipal council data via the OParl standard interface',
+    iconUrl: 'https://marketplace.ayunis.de/icons/oparl.png',
+    serverUrl: 'https://mcp.ayunis.de/oparl',
+    configSchema: {
+      authType: 'NO_AUTH',
+      orgFields: [
+        {
+          key: 'oparlEndpointUrl',
+          type: 'url' as const,
+          label: 'OParl Endpoint URL',
+          headerName: 'X-Oparl-Endpoint-Url',
+          prefix: null,
+          required: true,
+          help: "Your municipality's OParl system endpoint URL",
+          value: null,
+        },
+      ],
+      userFields: [],
+    },
+    published: true,
+    createdAt: '2026-01-15T10:00:00.000Z',
+    updatedAt: '2026-02-10T14:30:00.000Z',
+  };
+
+  beforeEach(() => {
+    marketplaceClient = {
+      getSkillByIdentifier: jest.fn(),
+      getIntegrationByIdentifier: jest.fn(),
+    } as jest.Mocked<MarketplaceClient>;
+
+    useCase = new GetMarketplaceIntegrationUseCase(marketplaceClient);
+  });
+
+  it('should return integration details when integration is found', async () => {
+    marketplaceClient.getIntegrationByIdentifier.mockResolvedValue(
+      mockIntegration,
+    );
+
+    const result = await useCase.execute(
+      new GetMarketplaceIntegrationQuery('oparl-council-data'),
+    );
+
+    expect(result).toEqual(mockIntegration);
+    expect(marketplaceClient.getIntegrationByIdentifier).toHaveBeenCalledWith(
+      'oparl-council-data',
+    );
+  });
+
+  it('should throw MarketplaceIntegrationNotFoundError when integration is not found', async () => {
+    marketplaceClient.getIntegrationByIdentifier.mockResolvedValue(null);
+
+    await expect(
+      useCase.execute(
+        new GetMarketplaceIntegrationQuery('nonexistent-integration'),
+      ),
+    ).rejects.toThrow(MarketplaceIntegrationNotFoundError);
+  });
+
+  it('should throw MarketplaceUnavailableError when marketplace service fails', async () => {
+    marketplaceClient.getIntegrationByIdentifier.mockRejectedValue(
+      new Error('Connection refused'),
+    );
+
+    await expect(
+      useCase.execute(new GetMarketplaceIntegrationQuery('oparl-council-data')),
+    ).rejects.toThrow(MarketplaceUnavailableError);
+  });
+
+  it('should re-throw application errors without wrapping', async () => {
+    const notFoundError = new MarketplaceIntegrationNotFoundError(
+      'oparl-council-data',
+    );
+    marketplaceClient.getIntegrationByIdentifier.mockRejectedValue(
+      notFoundError,
+    );
+
+    await expect(
+      useCase.execute(new GetMarketplaceIntegrationQuery('oparl-council-data')),
+    ).rejects.toThrow(MarketplaceIntegrationNotFoundError);
+  });
+});

--- a/ayunis-core-backend/src/domain/marketplace/application/use-cases/get-marketplace-integration/get-marketplace-integration.use-case.ts
+++ b/ayunis-core-backend/src/domain/marketplace/application/use-cases/get-marketplace-integration/get-marketplace-integration.use-case.ts
@@ -1,0 +1,44 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { MarketplaceClient } from '../../ports/marketplace-client.port';
+import { GetMarketplaceIntegrationQuery } from './get-marketplace-integration.query';
+import { IntegrationResponseDto } from 'src/common/clients/marketplace/generated/ayunisMarketplaceAPI.schemas';
+import { ApplicationError } from 'src/common/errors/base.error';
+import {
+  MarketplaceIntegrationNotFoundError,
+  MarketplaceUnavailableError,
+} from '../../marketplace.errors';
+
+@Injectable()
+export class GetMarketplaceIntegrationUseCase {
+  private readonly logger = new Logger(GetMarketplaceIntegrationUseCase.name);
+
+  constructor(private readonly marketplaceClient: MarketplaceClient) {}
+
+  async execute(
+    query: GetMarketplaceIntegrationQuery,
+  ): Promise<IntegrationResponseDto> {
+    this.logger.log('execute', { identifier: query.identifier });
+
+    try {
+      const integration =
+        await this.marketplaceClient.getIntegrationByIdentifier(
+          query.identifier,
+        );
+
+      if (!integration) {
+        throw new MarketplaceIntegrationNotFoundError(query.identifier);
+      }
+
+      return integration;
+    } catch (error) {
+      if (error instanceof ApplicationError) {
+        throw error;
+      }
+      this.logger.error('Failed to fetch marketplace integration', {
+        identifier: query.identifier,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      });
+      throw new MarketplaceUnavailableError();
+    }
+  }
+}

--- a/ayunis-core-backend/src/domain/marketplace/application/use-cases/get-marketplace-skill/get-marketplace-skill.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/marketplace/application/use-cases/get-marketplace-skill/get-marketplace-skill.use-case.spec.ts
@@ -33,6 +33,7 @@ describe('GetMarketplaceSkillUseCase', () => {
     marketplaceClient = {
       getSkillByIdentifier: jest.fn(),
       getPreInstalledSkills: jest.fn(),
+      getIntegrationByIdentifier: jest.fn(),
     } as jest.Mocked<MarketplaceClient>;
 
     useCase = new GetMarketplaceSkillUseCase(marketplaceClient);

--- a/ayunis-core-backend/src/domain/marketplace/infrastructure/http/marketplace-http-client.ts
+++ b/ayunis-core-backend/src/domain/marketplace/infrastructure/http/marketplace-http-client.ts
@@ -2,6 +2,7 @@ import { Injectable, Logger } from '@nestjs/common';
 import { MarketplaceClient } from '../../application/ports/marketplace-client.port';
 import { getAyunisMarketplaceAPI } from 'src/common/clients/marketplace/generated/ayunisMarketplaceAPI';
 import {
+  IntegrationResponseDto,
   SkillListResponseDto,
   SkillResponseDto,
 } from 'src/common/clients/marketplace/generated/ayunisMarketplaceAPI.schemas';
@@ -37,6 +38,28 @@ export class MarketplaceHttpClient extends MarketplaceClient {
       return await this.api.publicSkillsControllerListPreInstalled();
     } catch (error) {
       this.logger.warn('Failed to fetch pre-installed marketplace skills', {
+        error: error instanceof Error ? error.message : 'Unknown error',
+        status:
+          error instanceof MarketplaceHttpError ? error.status : undefined,
+      });
+      throw error;
+    }
+  }
+
+  async getIntegrationByIdentifier(
+    identifier: string,
+  ): Promise<IntegrationResponseDto | null> {
+    try {
+      return await this.api.publicIntegrationsControllerGetByIdentifier(
+        identifier,
+      );
+    } catch (error) {
+      if (error instanceof MarketplaceHttpError && error.status === 404) {
+        this.logger.debug('Marketplace integration not found', { identifier });
+        return null;
+      }
+      this.logger.warn('Failed to fetch marketplace integration', {
+        identifier,
         error: error instanceof Error ? error.message : 'Unknown error',
         status:
           error instanceof MarketplaceHttpError ? error.status : undefined,

--- a/ayunis-core-backend/src/domain/marketplace/marketplace.module.ts
+++ b/ayunis-core-backend/src/domain/marketplace/marketplace.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { MarketplaceClient } from './application/ports/marketplace-client.port';
 import { MarketplaceHttpClient } from './infrastructure/http/marketplace-http-client';
 import { GetMarketplaceSkillUseCase } from './application/use-cases/get-marketplace-skill/get-marketplace-skill.use-case';
+import { GetMarketplaceIntegrationUseCase } from './application/use-cases/get-marketplace-integration/get-marketplace-integration.use-case';
 import { MarketplaceController } from './presenters/http/marketplace.controller';
 
 @Module({
@@ -11,8 +12,13 @@ import { MarketplaceController } from './presenters/http/marketplace.controller'
       useClass: MarketplaceHttpClient,
     },
     GetMarketplaceSkillUseCase,
+    GetMarketplaceIntegrationUseCase,
   ],
   controllers: [MarketplaceController],
-  exports: [MarketplaceClient, GetMarketplaceSkillUseCase],
+  exports: [
+    MarketplaceClient,
+    GetMarketplaceSkillUseCase,
+    GetMarketplaceIntegrationUseCase,
+  ],
 })
 export class MarketplaceModule {}

--- a/ayunis-core-backend/src/domain/marketplace/presenters/http/dto/marketplace-integration-response.dto.ts
+++ b/ayunis-core-backend/src/domain/marketplace/presenters/http/dto/marketplace-integration-response.dto.ts
@@ -1,0 +1,101 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export class MarketplaceIntegrationConfigFieldDto {
+  @ApiProperty({ description: 'Unique identifier within the schema' })
+  key: string;
+
+  @ApiProperty({ description: 'Display label for the frontend form' })
+  label: string;
+
+  @ApiProperty({
+    description: 'Field type',
+    enum: ['text', 'url', 'secret'],
+  })
+  type: 'text' | 'url' | 'secret';
+
+  @ApiPropertyOptional({
+    description:
+      'HTTP header name this field maps to; if absent, field is internal config',
+    type: 'string',
+    nullable: true,
+  })
+  headerName: string | null;
+
+  @ApiPropertyOptional({
+    description: 'Optional prefix prepended to the value before sending',
+    type: 'string',
+    nullable: true,
+  })
+  prefix: string | null;
+
+  @ApiProperty({ description: 'Whether the field must be provided' })
+  required: boolean;
+
+  @ApiPropertyOptional({
+    description: 'Optional help text for the frontend form',
+    type: 'string',
+    nullable: true,
+  })
+  help: string | null;
+
+  @ApiPropertyOptional({
+    description:
+      'Fixed value from marketplace; if set, field is not shown in forms',
+    type: 'string',
+    nullable: true,
+  })
+  value: string | null;
+}
+
+export class MarketplaceIntegrationConfigSchemaDto {
+  @ApiProperty({ description: 'Auth type for documentation/UI purposes' })
+  authType: string;
+
+  @ApiProperty({
+    description: 'Fields configured by org admin at install time',
+    type: [MarketplaceIntegrationConfigFieldDto],
+  })
+  orgFields: MarketplaceIntegrationConfigFieldDto[];
+
+  @ApiProperty({
+    description: 'Fields configured by individual users',
+    type: [MarketplaceIntegrationConfigFieldDto],
+  })
+  userFields: MarketplaceIntegrationConfigFieldDto[];
+}
+
+export class MarketplaceIntegrationResponseDto {
+  @ApiProperty({ description: 'Integration UUID' })
+  id: string;
+
+  @ApiProperty({ description: 'Unique identifier (slug)' })
+  identifier: string;
+
+  @ApiProperty({ description: 'Display name' })
+  name: string;
+
+  @ApiProperty({ description: 'Description' })
+  description: string;
+
+  @ApiPropertyOptional({
+    description: 'Icon URL',
+    type: 'string',
+    nullable: true,
+  })
+  iconUrl: string | null;
+
+  @ApiProperty({
+    description: 'Configuration schema',
+    type: MarketplaceIntegrationConfigSchemaDto,
+  })
+  configSchema: MarketplaceIntegrationConfigSchemaDto;
+
+  @ApiProperty({ description: 'Whether the integration is published' })
+  published: boolean;
+
+  @ApiProperty({ description: 'Creation timestamp' })
+  createdAt: string;
+
+  @ApiProperty({ description: 'Last update timestamp' })
+  updatedAt: string;
+}

--- a/ayunis-core-backend/src/domain/marketplace/presenters/http/dto/marketplace-integration-response.dto.ts
+++ b/ayunis-core-backend/src/domain/marketplace/presenters/http/dto/marketplace-integration-response.dto.ts
@@ -74,7 +74,10 @@ export class MarketplaceIntegrationResponseDto {
   @ApiProperty({ description: 'Display name' })
   name: string;
 
-  @ApiProperty({ description: 'Description' })
+  @ApiProperty({ description: 'Short description for marketplace display' })
+  shortDescription: string;
+
+  @ApiProperty({ description: 'Full description' })
   description: string;
 
   @ApiPropertyOptional({
@@ -84,14 +87,23 @@ export class MarketplaceIntegrationResponseDto {
   })
   iconUrl: string | null;
 
+  @ApiProperty({ description: 'MCP server URL' })
+  serverUrl: string;
+
   @ApiProperty({
-    description: 'Configuration schema',
-    type: MarketplaceIntegrationConfigSchemaDto,
+    description:
+      'Configuration schema (authType, orgFields, userFields, oauth)',
   })
-  configSchema: MarketplaceIntegrationConfigSchemaDto;
+  configSchema: { [key: string]: unknown };
+
+  @ApiProperty({ description: 'Whether the integration is featured' })
+  featured: boolean;
 
   @ApiProperty({ description: 'Whether the integration is published' })
   published: boolean;
+
+  @ApiProperty({ description: 'Whether the integration is pre-installed' })
+  preInstalled: boolean;
 
   @ApiProperty({ description: 'Creation timestamp' })
   createdAt: string;

--- a/ayunis-core-backend/src/domain/marketplace/presenters/http/dto/marketplace-integration-response.dto.ts
+++ b/ayunis-core-backend/src/domain/marketplace/presenters/http/dto/marketplace-integration-response.dto.ts
@@ -93,8 +93,9 @@ export class MarketplaceIntegrationResponseDto {
   @ApiProperty({
     description:
       'Configuration schema (authType, orgFields, userFields, oauth)',
+    type: MarketplaceIntegrationConfigSchemaDto,
   })
-  configSchema: { [key: string]: unknown };
+  configSchema: MarketplaceIntegrationConfigSchemaDto;
 
   @ApiProperty({ description: 'Whether the integration is featured' })
   featured: boolean;

--- a/ayunis-core-backend/src/domain/marketplace/presenters/http/marketplace.controller.ts
+++ b/ayunis-core-backend/src/domain/marketplace/presenters/http/marketplace.controller.ts
@@ -3,6 +3,9 @@ import { ApiTags, ApiOperation, ApiResponse, ApiParam } from '@nestjs/swagger';
 import { GetMarketplaceSkillUseCase } from '../../application/use-cases/get-marketplace-skill/get-marketplace-skill.use-case';
 import { GetMarketplaceSkillQuery } from '../../application/use-cases/get-marketplace-skill/get-marketplace-skill.query';
 import { MarketplaceSkillResponseDto } from './dto/marketplace-skill-response.dto';
+import { GetMarketplaceIntegrationUseCase } from '../../application/use-cases/get-marketplace-integration/get-marketplace-integration.use-case';
+import { GetMarketplaceIntegrationQuery } from '../../application/use-cases/get-marketplace-integration/get-marketplace-integration.query';
+import { MarketplaceIntegrationResponseDto } from './dto/marketplace-integration-response.dto';
 
 @ApiTags('marketplace')
 @Controller('marketplace')
@@ -11,6 +14,7 @@ export class MarketplaceController {
 
   constructor(
     private readonly getMarketplaceSkillUseCase: GetMarketplaceSkillUseCase,
+    private readonly getMarketplaceIntegrationUseCase: GetMarketplaceIntegrationUseCase,
   ) {}
 
   @Get('skills/:identifier')
@@ -33,6 +37,34 @@ export class MarketplaceController {
 
     return this.getMarketplaceSkillUseCase.execute(
       new GetMarketplaceSkillQuery(identifier),
+    );
+  }
+
+  @Get('integrations/:identifier')
+  @ApiOperation({
+    summary: 'Preview a marketplace integration before installation',
+  })
+  @ApiParam({
+    name: 'identifier',
+    description: 'The unique identifier slug of the marketplace integration',
+    type: 'string',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Returns the marketplace integration details',
+    type: MarketplaceIntegrationResponseDto,
+  })
+  @ApiResponse({
+    status: 404,
+    description: 'Marketplace integration not found',
+  })
+  async getIntegration(
+    @Param('identifier') identifier: string,
+  ): Promise<MarketplaceIntegrationResponseDto> {
+    this.logger.log('getIntegration', { identifier });
+
+    return this.getMarketplaceIntegrationUseCase.execute(
+      new GetMarketplaceIntegrationQuery(identifier),
     );
   }
 }

--- a/ayunis-core-backend/src/domain/marketplace/presenters/http/marketplace.controller.ts
+++ b/ayunis-core-backend/src/domain/marketplace/presenters/http/marketplace.controller.ts
@@ -63,8 +63,10 @@ export class MarketplaceController {
   ): Promise<MarketplaceIntegrationResponseDto> {
     this.logger.log('getIntegration', { identifier });
 
-    return this.getMarketplaceIntegrationUseCase.execute(
+    const integration = await this.getMarketplaceIntegrationUseCase.execute(
       new GetMarketplaceIntegrationQuery(identifier),
     );
+
+    return integration as unknown as MarketplaceIntegrationResponseDto;
   }
 }

--- a/ayunis-core-backend/src/domain/mcp/SUMMARY.md
+++ b/ayunis-core-backend/src/domain/mcp/SUMMARY.md
@@ -1,6 +1,59 @@
 Protocol Integrations
 Model Context Protocol server connections and capability discovery
 
-MCP integrations connect external tool servers to the platform using the Model Context Protocol. Organizations configure predefined or custom integrations with authentication, then discover available tools, resources, and prompts.
+MCP integrations connect external tool servers to the platform using the Model Context Protocol. Organizations configure predefined, custom, or marketplace integrations with authentication, then discover available tools, resources, and prompts.
 
-The MCP module manages connections to external Model Context Protocol servers at the organization level. Core entities include `McpIntegration` (abstract base with predefined and custom subtypes), `McpTool`, `McpResource`, and `McpPrompt`—the latter three are ephemeral entities fetched from remote servers, not persisted locally. Authentication is handled through a hierarchy supporting bearer tokens, custom headers, OAuth, and no-auth. Key use cases include creating, updating, deleting, and validating integrations, plus discovering server capabilities. The `McpClientService` handles actual server communication. The `ValidateIntegrationAccessService` provides shared validation logic for verifying user authentication, integration existence, organization ownership, and enabled state. Error handling includes `McpUnauthenticatedError` for missing authentication context. The module integrates with **agents** for MCP integration assignment and **tools** for wrapping discovered MCP tools, resources, and prompts as executable tool entities within the platform.
+The MCP module manages connections to external Model Context Protocol servers at the organization level. Core entities include `McpIntegration` (abstract base with predefined, custom, and marketplace subtypes), `McpIntegrationUserConfig` (per-user configuration values for marketplace integrations), `McpTool`, `McpResource`, and `McpPrompt`—the latter three are ephemeral entities fetched from remote servers, not persisted locally. Authentication is handled through a hierarchy supporting bearer tokens, custom headers, OAuth, and no-auth. `MarketplaceMcpIntegration` adds a marketplace identifier, a typed config schema (org-level and user-level fields), and org-level config values.
+
+**Use Cases:**
+- `CreateMcpIntegrationUseCase` — Creates predefined or custom integrations
+- `InstallMarketplaceIntegrationUseCase` — Installs a marketplace integration by identifier, persisting org-level config values and config schema
+- `GetMcpIntegrationUseCase` — Fetches a single integration by ID
+- `ListOrgMcpIntegrationsUseCase` — Lists all integrations for the current org
+- `ListAvailableMcpIntegrationsUseCase` — Lists enabled integrations for the current org
+- `UpdateMcpIntegrationUseCase` — Updates integration settings (name, credentials, org config values, etc.)
+- `DeleteMcpIntegrationUseCase` — Deletes an integration and its associated user configs
+- `EnableMcpIntegrationUseCase` / `DisableMcpIntegrationUseCase` — Toggles integration enabled state
+- `ValidateMcpIntegrationUseCase` — Validates connection to the MCP server
+- `ListPredefinedMcpIntegrationConfigsUseCase` — Lists available predefined integration configurations
+- `DiscoverMcpCapabilitiesUseCase` — Discovers tools, resources, and prompts from a server
+- `ExecuteMcpToolUseCase` — Executes a tool on a remote MCP server
+- `RetrieveMcpResourceUseCase` — Retrieves a resource from a remote MCP server
+- `GetMcpPromptUseCase` — Fetches a prompt from a remote MCP server
+- `SetUserMcpConfigUseCase` — Saves per-user config values for a marketplace integration
+- `GetUserMcpConfigUseCase` — Retrieves per-user config values (with secret masking)
+
+**Services:**
+- `McpClientService` — Handles actual server communication via the MCP SDK
+- `MarketplaceConfigService` — Resolves effective server URL and auth headers by merging org-level and user-level config values against the integration's config schema
+- `ConnectionValidationService` — Validates MCP server connectivity, used by `ValidateMcpIntegrationUseCase`
+
+**Ports:**
+- `McpIntegrationsRepository` — Persistence port for MCP integrations
+- `McpIntegrationUserConfigRepository` — Persistence port for per-user config values
+- `McpClientPort` — Abstract port for MCP server communication
+- `McpCredentialEncryptionPort` — Abstract port for credential encryption/decryption
+
+**Presenters:**
+- `McpIntegrationsController` — REST controller exposing:
+  - `POST /mcp-integrations/predefined` — Create predefined integration (admin)
+  - `POST /mcp-integrations/custom` — Create custom integration (admin)
+  - `POST /mcp-integrations/install-from-marketplace` — Install marketplace integration (admin)
+  - `GET /mcp-integrations` — List org integrations (admin)
+  - `GET /mcp-integrations/available` — List enabled integrations
+  - `GET /mcp-integrations/predefined/available` — List predefined configs (admin)
+  - `GET /mcp-integrations/:id` — Get integration by ID (admin)
+  - `PATCH /mcp-integrations/:id` — Update integration (admin)
+  - `DELETE /mcp-integrations/:id` — Delete integration (admin)
+  - `POST /mcp-integrations/:id/enable` — Enable integration (admin)
+  - `POST /mcp-integrations/:id/disable` — Disable integration (admin)
+  - `POST /mcp-integrations/:id/validate` — Validate connection (admin)
+  - `GET /mcp-integrations/:id/user-config` — Get user config (user, admin)
+  - `PATCH /mcp-integrations/:id/user-config` — Set user config (user, admin)
+
+**Module Dependencies:**
+- **marketplace** — `InstallMarketplaceIntegrationUseCase` uses `GetMarketplaceIntegrationUseCase` to fetch integration metadata from the marketplace
+
+**Dependent Modules:**
+- **agents** — Uses MCP integration assignment for agent tool access
+- **tools** — Wraps discovered MCP tools, resources, and prompts as executable tool entities

--- a/ayunis-core-backend/src/domain/mcp/application/factories/mcp-integration.factory.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/factories/mcp-integration.factory.spec.ts
@@ -9,7 +9,7 @@ import { OAuthMcpIntegrationAuth } from '../../domain/auth/oauth-mcp-integration
 import { CustomMcpIntegration } from '../../domain/integrations/custom-mcp-integration.entity';
 import { PredefinedMcpIntegration } from '../../domain/integrations/predefined-mcp-integration.entity';
 import { MarketplaceMcpIntegration } from '../../domain/integrations/marketplace-mcp-integration.entity';
-import { IntegrationConfigSchema } from '../../domain/value-objects/integration-config-schema';
+import type { IntegrationConfigSchema } from '../../domain/value-objects/integration-config-schema';
 
 describe('McpIntegrationFactory', () => {
   const orgId = randomUUID();

--- a/ayunis-core-backend/src/domain/mcp/application/factories/mcp-integration.factory.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/factories/mcp-integration.factory.spec.ts
@@ -8,6 +8,8 @@ import { CustomHeaderMcpIntegrationAuth } from '../../domain/auth/custom-header-
 import { OAuthMcpIntegrationAuth } from '../../domain/auth/oauth-mcp-integration-auth.entity';
 import { CustomMcpIntegration } from '../../domain/integrations/custom-mcp-integration.entity';
 import { PredefinedMcpIntegration } from '../../domain/integrations/predefined-mcp-integration.entity';
+import { MarketplaceMcpIntegration } from '../../domain/integrations/marketplace-mcp-integration.entity';
+import { IntegrationConfigSchema } from '../../domain/value-objects/integration-config-schema';
 
 describe('McpIntegrationFactory', () => {
   const orgId = randomUUID();
@@ -120,6 +122,83 @@ describe('McpIntegrationFactory', () => {
       expect((integration.auth as OAuthMcpIntegrationAuth).clientId).toBe(
         'client-id',
       );
+    });
+
+    it('creates marketplace integrations with config schema and org config values', () => {
+      const configSchema: IntegrationConfigSchema = {
+        authType: 'BEARER_TOKEN',
+        orgFields: [
+          {
+            key: 'authToken',
+            label: 'API Token',
+            type: 'secret',
+            headerName: 'Authorization',
+            prefix: 'Bearer ',
+            required: true,
+          },
+        ],
+        userFields: [],
+      };
+      const auth = new NoAuthMcpIntegrationAuth();
+
+      const integration = factory.createIntegration({
+        kind: McpIntegrationKind.MARKETPLACE,
+        orgId,
+        name,
+        serverUrl,
+        auth,
+        marketplaceIdentifier: 'oparl',
+        configSchema,
+        orgConfigValues: { authToken: 'encrypted-value' },
+      });
+
+      expect(integration).toBeInstanceOf(MarketplaceMcpIntegration);
+      expect(integration.kind).toBe(McpIntegrationKind.MARKETPLACE);
+      expect(integration.marketplaceIdentifier).toBe('oparl');
+      expect(integration.configSchema).toBe(configSchema);
+      expect(integration.orgConfigValues).toEqual({
+        authToken: 'encrypted-value',
+      });
+      expect(integration.serverUrl).toBe(serverUrl);
+    });
+
+    it('throws when marketplace integration is missing identifier', () => {
+      const configSchema: IntegrationConfigSchema = {
+        authType: 'NO_AUTH',
+        orgFields: [],
+        userFields: [],
+      };
+      const auth = new NoAuthMcpIntegrationAuth();
+
+      expect(() =>
+        factory.createIntegration({
+          kind: McpIntegrationKind.MARKETPLACE,
+          orgId,
+          name,
+          serverUrl,
+          auth,
+          marketplaceIdentifier: undefined as any,
+          configSchema,
+          orgConfigValues: {},
+        }),
+      ).toThrow('Marketplace integrations require an identifier');
+    });
+
+    it('throws when marketplace integration is missing config schema', () => {
+      const auth = new NoAuthMcpIntegrationAuth();
+
+      expect(() =>
+        factory.createIntegration({
+          kind: McpIntegrationKind.MARKETPLACE,
+          orgId,
+          name,
+          serverUrl,
+          auth,
+          marketplaceIdentifier: 'oparl',
+          configSchema: undefined as any,
+          orgConfigValues: {},
+        }),
+      ).toThrow('Marketplace integrations require a config schema');
     });
   });
 });

--- a/ayunis-core-backend/src/domain/mcp/application/factories/mcp-integration.factory.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/factories/mcp-integration.factory.ts
@@ -3,7 +3,9 @@ import { McpIntegration } from '../../domain/mcp-integration.entity';
 import { McpIntegrationKind } from '../../domain/value-objects/mcp-integration-kind.enum';
 import { CustomMcpIntegration } from '../../domain/integrations/custom-mcp-integration.entity';
 import { PredefinedMcpIntegration } from '../../domain/integrations/predefined-mcp-integration.entity';
+import { MarketplaceMcpIntegration } from '../../domain/integrations/marketplace-mcp-integration.entity';
 import { PredefinedMcpIntegrationSlug } from '../../domain/value-objects/predefined-mcp-integration-slug.enum';
+import { IntegrationConfigSchema } from '../../domain/value-objects/integration-config-schema';
 import { McpIntegrationAuth } from '../../domain/auth/mcp-integration-auth.entity';
 import { UUID } from 'crypto';
 
@@ -41,12 +43,14 @@ export class McpIntegrationFactory {
     returnsPii?: boolean;
   }): PredefinedMcpIntegration;
   createIntegration(params: {
-    kind: McpIntegrationKind;
+    kind: McpIntegrationKind.MARKETPLACE;
     orgId: UUID;
     name: string;
     serverUrl: string;
     auth: McpIntegrationAuth;
-    slug?: PredefinedMcpIntegrationSlug;
+    marketplaceIdentifier: string;
+    configSchema: IntegrationConfigSchema;
+    orgConfigValues: Record<string, string>;
     id?: UUID;
     enabled?: boolean;
     createdAt?: Date;
@@ -55,8 +59,26 @@ export class McpIntegrationFactory {
     lastConnectionError?: string;
     lastConnectionCheck?: Date;
     returnsPii?: boolean;
-  }): McpIntegration {
-    const base = {
+  }): MarketplaceMcpIntegration;
+  createIntegration(params: CreateIntegrationParams): McpIntegration {
+    const base = this.extractBaseParams(params);
+
+    switch (params.kind) {
+      case McpIntegrationKind.PREDEFINED:
+        return this.createPredefined(base, params);
+      case McpIntegrationKind.MARKETPLACE:
+        return this.createMarketplace(base, params);
+      case McpIntegrationKind.CUSTOM:
+        return new CustomMcpIntegration(base);
+      default:
+        throw new Error(
+          `Unknown MCP integration kind: ${params.kind as string}`,
+        );
+    }
+  }
+
+  private extractBaseParams(params: CreateIntegrationParams) {
+    return {
       id: params.id,
       orgId: params.orgId,
       name: params.name,
@@ -70,24 +92,53 @@ export class McpIntegrationFactory {
       lastConnectionCheck: params.lastConnectionCheck,
       returnsPii: params.returnsPii,
     } as const;
+  }
 
-    switch (params.kind) {
-      case McpIntegrationKind.PREDEFINED: {
-        if (!params.slug) {
-          throw new Error('Predefined integrations require a slug');
-        }
-
-        return new PredefinedMcpIntegration({
-          ...base,
-          slug: params.slug,
-        });
-      }
-      case McpIntegrationKind.CUSTOM:
-        return new CustomMcpIntegration(base);
-      default:
-        throw new Error(
-          `Unknown MCP integration kind: ${params.kind as string}`,
-        );
+  private createPredefined(
+    base: ReturnType<McpIntegrationFactory['extractBaseParams']>,
+    params: CreateIntegrationParams,
+  ): PredefinedMcpIntegration {
+    if (!params.slug) {
+      throw new Error('Predefined integrations require a slug');
     }
+    return new PredefinedMcpIntegration({ ...base, slug: params.slug });
+  }
+
+  private createMarketplace(
+    base: ReturnType<McpIntegrationFactory['extractBaseParams']>,
+    params: CreateIntegrationParams,
+  ): MarketplaceMcpIntegration {
+    if (!params.marketplaceIdentifier) {
+      throw new Error('Marketplace integrations require an identifier');
+    }
+    if (!params.configSchema) {
+      throw new Error('Marketplace integrations require a config schema');
+    }
+    return new MarketplaceMcpIntegration({
+      ...base,
+      marketplaceIdentifier: params.marketplaceIdentifier,
+      configSchema: params.configSchema,
+      orgConfigValues: params.orgConfigValues ?? {},
+    });
   }
 }
+
+type CreateIntegrationParams = {
+  kind: McpIntegrationKind;
+  orgId: UUID;
+  name: string;
+  serverUrl: string;
+  auth: McpIntegrationAuth;
+  slug?: PredefinedMcpIntegrationSlug;
+  marketplaceIdentifier?: string;
+  configSchema?: IntegrationConfigSchema;
+  orgConfigValues?: Record<string, string>;
+  id?: UUID;
+  enabled?: boolean;
+  createdAt?: Date;
+  updatedAt?: Date;
+  connectionStatus?: string;
+  lastConnectionError?: string;
+  lastConnectionCheck?: Date;
+  returnsPii?: boolean;
+};

--- a/ayunis-core-backend/src/domain/mcp/application/mcp.errors.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/mcp.errors.ts
@@ -16,6 +16,11 @@ export enum McpErrorCode {
   UNEXPECTED_MCP_ERROR = 'UNEXPECTED_MCP_ERROR',
   MCP_AUTH_NOT_IMPLEMENTED = 'MCP_AUTH_NOT_IMPLEMENTED',
   DUPLICATE_MCP_INTEGRATION = 'DUPLICATE_MCP_INTEGRATION',
+  MCP_OAUTH_NOT_SUPPORTED = 'MCP_OAUTH_NOT_SUPPORTED',
+  MCP_MISSING_REQUIRED_CONFIG = 'MCP_MISSING_REQUIRED_CONFIG',
+  MCP_MARKETPLACE_INTEGRATION_NOT_FOUND = 'MCP_MARKETPLACE_INTEGRATION_NOT_FOUND',
+  MCP_NOT_MARKETPLACE_INTEGRATION = 'MCP_NOT_MARKETPLACE_INTEGRATION',
+  MCP_NO_USER_FIELDS = 'MCP_NO_USER_FIELDS',
 }
 
 export abstract class McpError extends ApplicationError {
@@ -226,6 +231,61 @@ export class DuplicateMcpIntegrationError extends McpError {
       `A MCP integration with slug '${slug}' already exists for this organization. Only one MCP integration with the same slug is allowed per organization.`,
       McpErrorCode.DUPLICATE_MCP_INTEGRATION,
       409,
+      metadata,
+    );
+  }
+}
+
+export class McpOAuthNotSupportedError extends McpError {
+  constructor(metadata?: ErrorMetadata) {
+    super(
+      'OAuth authentication is not yet supported for marketplace integrations. Please use a different authentication method.',
+      McpErrorCode.MCP_OAUTH_NOT_SUPPORTED,
+      400,
+      metadata,
+    );
+  }
+}
+
+export class McpMissingRequiredConfigError extends McpError {
+  constructor(missingFields: string[], metadata?: ErrorMetadata) {
+    super(
+      `Missing required configuration fields: ${missingFields.join(', ')}`,
+      McpErrorCode.MCP_MISSING_REQUIRED_CONFIG,
+      400,
+      metadata,
+    );
+  }
+}
+
+export class McpMarketplaceIntegrationNotFoundError extends McpError {
+  constructor(identifier: string, metadata?: ErrorMetadata) {
+    super(
+      `Marketplace integration not found: ${identifier}`,
+      McpErrorCode.MCP_MARKETPLACE_INTEGRATION_NOT_FOUND,
+      404,
+      metadata,
+    );
+  }
+}
+
+export class McpNotMarketplaceIntegrationError extends McpError {
+  constructor(integrationId: string, metadata?: ErrorMetadata) {
+    super(
+      `MCP integration ${integrationId} is not a marketplace integration`,
+      McpErrorCode.MCP_NOT_MARKETPLACE_INTEGRATION,
+      400,
+      metadata,
+    );
+  }
+}
+
+export class McpNoUserFieldsError extends McpError {
+  constructor(integrationId: string, metadata?: ErrorMetadata) {
+    super(
+      `MCP integration ${integrationId} does not support user-level configuration`,
+      McpErrorCode.MCP_NO_USER_FIELDS,
+      400,
       metadata,
     );
   }

--- a/ayunis-core-backend/src/domain/mcp/application/mcp.errors.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/mcp.errors.ts
@@ -21,6 +21,7 @@ export enum McpErrorCode {
   MCP_MARKETPLACE_INTEGRATION_NOT_FOUND = 'MCP_MARKETPLACE_INTEGRATION_NOT_FOUND',
   MCP_NOT_MARKETPLACE_INTEGRATION = 'MCP_NOT_MARKETPLACE_INTEGRATION',
   MCP_NO_USER_FIELDS = 'MCP_NO_USER_FIELDS',
+  MCP_INVALID_CONFIG_KEYS = 'MCP_INVALID_CONFIG_KEYS',
 }
 
 export abstract class McpError extends ApplicationError {
@@ -236,6 +237,17 @@ export class DuplicateMcpIntegrationError extends McpError {
   }
 }
 
+export class DuplicateMarketplaceMcpIntegrationError extends McpError {
+  constructor(identifier: string, metadata?: ErrorMetadata) {
+    super(
+      `Marketplace integration '${identifier}' is already installed for this organization.`,
+      McpErrorCode.DUPLICATE_MCP_INTEGRATION,
+      409,
+      metadata,
+    );
+  }
+}
+
 export class McpOAuthNotSupportedError extends McpError {
   constructor(metadata?: ErrorMetadata) {
     super(
@@ -285,6 +297,17 @@ export class McpNoUserFieldsError extends McpError {
     super(
       `MCP integration ${integrationId} does not support user-level configuration`,
       McpErrorCode.MCP_NO_USER_FIELDS,
+      400,
+      metadata,
+    );
+  }
+}
+
+export class McpInvalidConfigKeysError extends McpError {
+  constructor(invalidKeys: string[], metadata?: ErrorMetadata) {
+    super(
+      `Unknown config keys: ${invalidKeys.join(', ')}`,
+      McpErrorCode.MCP_INVALID_CONFIG_KEYS,
       400,
       metadata,
     );

--- a/ayunis-core-backend/src/domain/mcp/application/ports/mcp-client.port.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/ports/mcp-client.port.ts
@@ -4,10 +4,8 @@
 export interface McpConnectionConfig {
   /** Base URL of the MCP server (uses Streamable HTTP transport, MCP protocol 2024-11-05+) */
   serverUrl: string;
-  /** Optional authentication header name (e.g., 'Authorization') */
-  authHeaderName?: string;
-  /** Optional authentication token value */
-  authToken?: string;
+  /** Optional headers to send with every MCP request (auth + config fields) */
+  headers?: Record<string, string>;
 }
 
 /**

--- a/ayunis-core-backend/src/domain/mcp/application/ports/mcp-integration-user-config.repository.port.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/ports/mcp-integration-user-config.repository.port.ts
@@ -1,5 +1,5 @@
-import { UUID } from 'crypto';
-import { McpIntegrationUserConfig } from '../../domain/mcp-integration-user-config.entity';
+import type { UUID } from 'crypto';
+import type { McpIntegrationUserConfig } from '../../domain/mcp-integration-user-config.entity';
 
 /**
  * Repository port for MCP integration user-level configuration.

--- a/ayunis-core-backend/src/domain/mcp/application/ports/mcp-integration-user-config.repository.port.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/ports/mcp-integration-user-config.repository.port.ts
@@ -1,0 +1,29 @@
+import { UUID } from 'crypto';
+import { McpIntegrationUserConfig } from '../../domain/mcp-integration-user-config.entity';
+
+/**
+ * Repository port for MCP integration user-level configuration.
+ * Manages per-user config values for marketplace integrations.
+ */
+export abstract class McpIntegrationUserConfigRepositoryPort {
+  /**
+   * Saves a user config (create or update).
+   */
+  abstract save(
+    config: McpIntegrationUserConfig,
+  ): Promise<McpIntegrationUserConfig>;
+
+  /**
+   * Finds user config by integration ID and user ID.
+   */
+  abstract findByIntegrationAndUser(
+    integrationId: UUID,
+    userId: UUID,
+  ): Promise<McpIntegrationUserConfig | null>;
+
+  /**
+   * Deletes all user configs for a given integration.
+   * Used when an integration is deleted.
+   */
+  abstract deleteByIntegrationId(integrationId: UUID): Promise<void>;
+}

--- a/ayunis-core-backend/src/domain/mcp/application/ports/mcp-integrations.repository.port.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/ports/mcp-integrations.repository.port.ts
@@ -9,10 +9,11 @@ import type { PredefinedMcpIntegrationSlug } from '../../domain/value-objects/pr
 export abstract class McpIntegrationsRepositoryPort {
   /**
    * Saves an MCP integration (create or update).
+   * Returns the same subtype that was passed in.
    * @param integration The integration to save
    * @returns The saved integration
    */
-  abstract save(integration: McpIntegration): Promise<McpIntegration>;
+  abstract save<T extends McpIntegration>(integration: T): Promise<T>;
 
   /**
    * Finds an MCP integration by its ID.

--- a/ayunis-core-backend/src/domain/mcp/application/ports/mcp-integrations.repository.port.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/ports/mcp-integrations.repository.port.ts
@@ -53,6 +53,18 @@ export abstract class McpIntegrationsRepositoryPort {
   ): Promise<McpIntegration | null>;
 
   /**
+   * Finds a marketplace MCP integration by organization ID and marketplace identifier.
+   * Used to check for duplicate marketplace installations.
+   * @param orgId The organization ID
+   * @param marketplaceIdentifier The marketplace integration identifier
+   * @returns The integration or null if not found
+   */
+  abstract findByOrgIdAndMarketplaceIdentifier(
+    orgId: UUID,
+    marketplaceIdentifier: string,
+  ): Promise<McpIntegration | null>;
+
+  /**
    * Deletes an MCP integration by its ID.
    * @param id The integration ID
    */

--- a/ayunis-core-backend/src/domain/mcp/application/services/connection-validation.service.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/services/connection-validation.service.spec.ts
@@ -91,9 +91,7 @@ describe('ConnectionValidationService', () => {
 
   it('sets status to unhealthy when validation throws an error', async () => {
     const integration = createIntegration();
-    validateUseCase.execute.mockRejectedValue(
-      new Error('Connection refused'),
-    );
+    validateUseCase.execute.mockRejectedValue(new Error('Connection refused'));
 
     await service.validateAndUpdateStatus(integration);
 
@@ -118,9 +116,7 @@ describe('ConnectionValidationService', () => {
 
   it('does not throw even when validation fails', async () => {
     const integration = createIntegration();
-    validateUseCase.execute.mockRejectedValue(
-      new Error('Connection refused'),
-    );
+    validateUseCase.execute.mockRejectedValue(new Error('Connection refused'));
 
     await expect(
       service.validateAndUpdateStatus(integration),

--- a/ayunis-core-backend/src/domain/mcp/application/services/connection-validation.service.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/services/connection-validation.service.spec.ts
@@ -1,0 +1,129 @@
+import { ConnectionValidationService } from './connection-validation.service';
+import { ValidateMcpIntegrationUseCase } from '../use-cases/validate-mcp-integration/validate-mcp-integration.use-case';
+import { McpIntegrationsRepositoryPort } from '../ports/mcp-integrations.repository.port';
+import { CustomMcpIntegration } from '../../domain/integrations/custom-mcp-integration.entity';
+import { NoAuthMcpIntegrationAuth } from '../../domain/auth/no-auth-mcp-integration-auth.entity';
+import { randomUUID } from 'crypto';
+
+describe('ConnectionValidationService', () => {
+  const orgId = randomUUID();
+  const integrationId = randomUUID();
+
+  let validateUseCase: jest.Mocked<ValidateMcpIntegrationUseCase>;
+  let repository: jest.Mocked<McpIntegrationsRepositoryPort>;
+  let service: ConnectionValidationService;
+
+  function createIntegration(): CustomMcpIntegration {
+    return new CustomMcpIntegration({
+      id: integrationId,
+      orgId,
+      name: 'Test Integration',
+      serverUrl: 'https://example.com/mcp',
+      auth: new NoAuthMcpIntegrationAuth(),
+    });
+  }
+
+  beforeEach(() => {
+    validateUseCase = {
+      execute: jest.fn(),
+    } as unknown as jest.Mocked<ValidateMcpIntegrationUseCase>;
+
+    repository = {
+      save: jest.fn(),
+      findById: jest.fn(),
+      findAll: jest.fn(),
+      findByOrgIdAndSlug: jest.fn(),
+      findByOrgIdAndMarketplaceIdentifier: jest.fn(),
+      delete: jest.fn(),
+    } as unknown as jest.Mocked<McpIntegrationsRepositoryPort>;
+
+    repository.save.mockImplementation(async (integration) => integration);
+
+    service = new ConnectionValidationService(validateUseCase, repository);
+  });
+
+  it('sets status to healthy when validation succeeds', async () => {
+    const integration = createIntegration();
+    validateUseCase.execute.mockResolvedValue({
+      isValid: true,
+      toolCount: 3,
+      resourceCount: 1,
+      promptCount: 0,
+    });
+
+    await service.validateAndUpdateStatus(integration);
+
+    expect(integration.connectionStatus).toBe('healthy');
+    expect(repository.save).toHaveBeenCalledWith(integration);
+  });
+
+  it('sets status to unhealthy when validation returns invalid', async () => {
+    const integration = createIntegration();
+    validateUseCase.execute.mockResolvedValue({
+      isValid: false,
+      toolCount: 0,
+      resourceCount: 0,
+      promptCount: 0,
+      errorMessage: 'Auth failed',
+    });
+
+    await service.validateAndUpdateStatus(integration);
+
+    expect(integration.connectionStatus).toBe('unhealthy');
+    expect(integration.lastConnectionError).toBe('Auth failed');
+    expect(repository.save).toHaveBeenCalledWith(integration);
+  });
+
+  it('sets status to unhealthy with default message when no errorMessage', async () => {
+    const integration = createIntegration();
+    validateUseCase.execute.mockResolvedValue({
+      isValid: false,
+      toolCount: 0,
+      resourceCount: 0,
+      promptCount: 0,
+    });
+
+    await service.validateAndUpdateStatus(integration);
+
+    expect(integration.connectionStatus).toBe('unhealthy');
+    expect(integration.lastConnectionError).toBe('Validation failed');
+  });
+
+  it('sets status to unhealthy when validation throws an error', async () => {
+    const integration = createIntegration();
+    validateUseCase.execute.mockRejectedValue(
+      new Error('Connection refused'),
+    );
+
+    await service.validateAndUpdateStatus(integration);
+
+    expect(integration.connectionStatus).toBe('unhealthy');
+    expect(integration.lastConnectionError).toBe(
+      'Validation failed: Connection refused',
+    );
+    expect(repository.save).toHaveBeenCalledWith(integration);
+  });
+
+  it('handles non-Error exceptions gracefully', async () => {
+    const integration = createIntegration();
+    validateUseCase.execute.mockRejectedValue('string error');
+
+    await service.validateAndUpdateStatus(integration);
+
+    expect(integration.connectionStatus).toBe('unhealthy');
+    expect(integration.lastConnectionError).toBe(
+      'Validation failed: Unknown error',
+    );
+  });
+
+  it('does not throw even when validation fails', async () => {
+    const integration = createIntegration();
+    validateUseCase.execute.mockRejectedValue(
+      new Error('Connection refused'),
+    );
+
+    await expect(
+      service.validateAndUpdateStatus(integration),
+    ).resolves.not.toThrow();
+  });
+});

--- a/ayunis-core-backend/src/domain/mcp/application/services/connection-validation.service.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/services/connection-validation.service.spec.ts
@@ -1,6 +1,6 @@
 import { ConnectionValidationService } from './connection-validation.service';
-import { ValidateMcpIntegrationUseCase } from '../use-cases/validate-mcp-integration/validate-mcp-integration.use-case';
-import { McpIntegrationsRepositoryPort } from '../ports/mcp-integrations.repository.port';
+import type { ValidateMcpIntegrationUseCase } from '../use-cases/validate-mcp-integration/validate-mcp-integration.use-case';
+import type { McpIntegrationsRepositoryPort } from '../ports/mcp-integrations.repository.port';
 import { CustomMcpIntegration } from '../../domain/integrations/custom-mcp-integration.entity';
 import { NoAuthMcpIntegrationAuth } from '../../domain/auth/no-auth-mcp-integration-auth.entity';
 import { randomUUID } from 'crypto';
@@ -42,7 +42,7 @@ describe('ConnectionValidationService', () => {
     service = new ConnectionValidationService(validateUseCase, repository);
   });
 
-  it('sets status to healthy when validation succeeds', async () => {
+  it('sets status to connected when validation succeeds', async () => {
     const integration = createIntegration();
     validateUseCase.execute.mockResolvedValue({
       isValid: true,
@@ -53,11 +53,11 @@ describe('ConnectionValidationService', () => {
 
     await service.validateAndUpdateStatus(integration);
 
-    expect(integration.connectionStatus).toBe('healthy');
+    expect(integration.connectionStatus).toBe('connected');
     expect(repository.save).toHaveBeenCalledWith(integration);
   });
 
-  it('sets status to unhealthy when validation returns invalid', async () => {
+  it('sets status to error when validation returns invalid', async () => {
     const integration = createIntegration();
     validateUseCase.execute.mockResolvedValue({
       isValid: false,
@@ -69,12 +69,12 @@ describe('ConnectionValidationService', () => {
 
     await service.validateAndUpdateStatus(integration);
 
-    expect(integration.connectionStatus).toBe('unhealthy');
+    expect(integration.connectionStatus).toBe('error');
     expect(integration.lastConnectionError).toBe('Auth failed');
     expect(repository.save).toHaveBeenCalledWith(integration);
   });
 
-  it('sets status to unhealthy with default message when no errorMessage', async () => {
+  it('sets status to error with default message when no errorMessage', async () => {
     const integration = createIntegration();
     validateUseCase.execute.mockResolvedValue({
       isValid: false,
@@ -85,17 +85,17 @@ describe('ConnectionValidationService', () => {
 
     await service.validateAndUpdateStatus(integration);
 
-    expect(integration.connectionStatus).toBe('unhealthy');
+    expect(integration.connectionStatus).toBe('error');
     expect(integration.lastConnectionError).toBe('Validation failed');
   });
 
-  it('sets status to unhealthy when validation throws an error', async () => {
+  it('sets status to error when validation throws an error', async () => {
     const integration = createIntegration();
     validateUseCase.execute.mockRejectedValue(new Error('Connection refused'));
 
     await service.validateAndUpdateStatus(integration);
 
-    expect(integration.connectionStatus).toBe('unhealthy');
+    expect(integration.connectionStatus).toBe('error');
     expect(integration.lastConnectionError).toBe(
       'Validation failed: Connection refused',
     );
@@ -108,7 +108,7 @@ describe('ConnectionValidationService', () => {
 
     await service.validateAndUpdateStatus(integration);
 
-    expect(integration.connectionStatus).toBe('unhealthy');
+    expect(integration.connectionStatus).toBe('error');
     expect(integration.lastConnectionError).toBe(
       'Validation failed: Unknown error',
     );

--- a/ayunis-core-backend/src/domain/mcp/application/services/connection-validation.service.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/services/connection-validation.service.ts
@@ -14,7 +14,9 @@ export class ConnectionValidationService {
     private readonly repository: McpIntegrationsRepositoryPort,
   ) {}
 
-  async validateAndUpdateStatus(integration: McpIntegration): Promise<void> {
+  async validateAndUpdateStatus(
+    integration: McpIntegration,
+  ): Promise<McpIntegration> {
     try {
       const result = await this.validateUseCase.execute({
         integrationId: integration.id,
@@ -36,6 +38,6 @@ export class ConnectionValidationService {
       integration.updateConnectionStatus('unhealthy', errorMessage);
     }
 
-    await this.repository.save(integration);
+    return this.repository.save(integration);
   }
 }

--- a/ayunis-core-backend/src/domain/mcp/application/services/connection-validation.service.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/services/connection-validation.service.ts
@@ -23,10 +23,10 @@ export class ConnectionValidationService {
       });
 
       if (result.isValid) {
-        integration.updateConnectionStatus('healthy', undefined);
+        integration.updateConnectionStatus('connected', undefined);
       } else {
         integration.updateConnectionStatus(
-          'unhealthy',
+          'error',
           result.errorMessage ?? 'Validation failed',
         );
       }
@@ -35,7 +35,7 @@ export class ConnectionValidationService {
         error instanceof Error
           ? `Validation failed: ${error.message}`
           : 'Validation failed: Unknown error';
-      integration.updateConnectionStatus('unhealthy', errorMessage);
+      integration.updateConnectionStatus('error', errorMessage);
     }
 
     return this.repository.save(integration);

--- a/ayunis-core-backend/src/domain/mcp/application/services/connection-validation.service.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/services/connection-validation.service.ts
@@ -1,0 +1,41 @@
+import { Injectable } from '@nestjs/common';
+import { ValidateMcpIntegrationUseCase } from '../use-cases/validate-mcp-integration/validate-mcp-integration.use-case';
+import { McpIntegrationsRepositoryPort } from '../ports/mcp-integrations.repository.port';
+import { McpIntegration } from '../../domain/mcp-integration.entity';
+
+/**
+ * Validates an MCP integration's connection and persists the resulting status.
+ * Never throws — captures all errors as connection status updates.
+ */
+@Injectable()
+export class ConnectionValidationService {
+  constructor(
+    private readonly validateUseCase: ValidateMcpIntegrationUseCase,
+    private readonly repository: McpIntegrationsRepositoryPort,
+  ) {}
+
+  async validateAndUpdateStatus(integration: McpIntegration): Promise<void> {
+    try {
+      const result = await this.validateUseCase.execute({
+        integrationId: integration.id,
+      });
+
+      if (result.isValid) {
+        integration.updateConnectionStatus('healthy', undefined);
+      } else {
+        integration.updateConnectionStatus(
+          'unhealthy',
+          result.errorMessage ?? 'Validation failed',
+        );
+      }
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error
+          ? `Validation failed: ${error.message}`
+          : 'Validation failed: Unknown error';
+      integration.updateConnectionStatus('unhealthy', errorMessage);
+    }
+
+    await this.repository.save(integration);
+  }
+}

--- a/ayunis-core-backend/src/domain/mcp/application/services/marketplace-config.service.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/services/marketplace-config.service.spec.ts
@@ -1,6 +1,6 @@
 import { MarketplaceConfigService } from './marketplace-config.service';
-import { McpCredentialEncryptionPort } from '../ports/mcp-credential-encryption.port';
-import { ConfigField } from '../../domain/value-objects/integration-config-schema';
+import type { McpCredentialEncryptionPort } from '../ports/mcp-credential-encryption.port';
+import type { ConfigField } from '../../domain/value-objects/integration-config-schema';
 import { McpMissingRequiredConfigError } from '../mcp.errors';
 
 describe('MarketplaceConfigService', () => {

--- a/ayunis-core-backend/src/domain/mcp/application/services/marketplace-config.service.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/services/marketplace-config.service.spec.ts
@@ -1,0 +1,334 @@
+import { MarketplaceConfigService } from './marketplace-config.service';
+import { McpCredentialEncryptionPort } from '../ports/mcp-credential-encryption.port';
+import { ConfigField } from '../../domain/value-objects/integration-config-schema';
+import { McpMissingRequiredConfigError } from '../mcp.errors';
+
+describe('MarketplaceConfigService', () => {
+  let service: MarketplaceConfigService;
+  let encryption: jest.Mocked<McpCredentialEncryptionPort>;
+
+  beforeEach(() => {
+    encryption = {
+      encrypt: jest.fn(),
+      decrypt: jest.fn(),
+    } as jest.Mocked<McpCredentialEncryptionPort>;
+
+    encryption.encrypt.mockImplementation(
+      async (plaintext) => `encrypted:${plaintext}`,
+    );
+
+    service = new MarketplaceConfigService(encryption);
+  });
+
+  describe('mergeFixedValues', () => {
+    it('should override user-provided values with fixed values from schema', () => {
+      const orgFields: ConfigField[] = [
+        {
+          key: 'authToken',
+          label: 'Token',
+          type: 'secret',
+          required: true,
+          value: 'sk-fixed-token',
+        },
+      ];
+
+      const result = service.mergeFixedValues(
+        { authToken: 'user-attempted-override' },
+        orgFields,
+      );
+
+      expect(result.authToken).toBe('sk-fixed-token');
+    });
+
+    it('should preserve user-provided values for fields without fixed values', () => {
+      const orgFields: ConfigField[] = [
+        {
+          key: 'endpointUrl',
+          label: 'Endpoint',
+          type: 'url',
+          required: true,
+        },
+      ];
+
+      const result = service.mergeFixedValues(
+        { endpointUrl: 'https://example.com/api' },
+        orgFields,
+      );
+
+      expect(result.endpointUrl).toBe('https://example.com/api');
+    });
+
+    it('should add fixed values even when user did not provide them', () => {
+      const orgFields: ConfigField[] = [
+        {
+          key: 'systemKey',
+          label: 'System Key',
+          type: 'text',
+          required: true,
+          value: 'system-value',
+        },
+      ];
+
+      const result = service.mergeFixedValues({}, orgFields);
+
+      expect(result.systemKey).toBe('system-value');
+    });
+  });
+
+  describe('validateRequiredFields', () => {
+    it('should not throw when all required fields are present', () => {
+      const orgFields: ConfigField[] = [
+        {
+          key: 'apiKey',
+          label: 'API Key',
+          type: 'secret',
+          required: true,
+        },
+        {
+          key: 'endpoint',
+          label: 'Endpoint',
+          type: 'url',
+          required: true,
+        },
+      ];
+
+      expect(() =>
+        service.validateRequiredFields(orgFields, {
+          apiKey: 'key-123',
+          endpoint: 'https://example.com',
+        }),
+      ).not.toThrow();
+    });
+
+    it('should throw McpMissingRequiredConfigError when required fields are missing', () => {
+      const orgFields: ConfigField[] = [
+        {
+          key: 'apiKey',
+          label: 'API Key',
+          type: 'secret',
+          required: true,
+        },
+        {
+          key: 'endpoint',
+          label: 'Endpoint',
+          type: 'url',
+          required: true,
+        },
+      ];
+
+      expect(() =>
+        service.validateRequiredFields(orgFields, {
+          endpoint: 'https://example.com',
+        }),
+      ).toThrow(McpMissingRequiredConfigError);
+    });
+
+    it('should not throw for missing optional fields', () => {
+      const orgFields: ConfigField[] = [
+        {
+          key: 'optionalField',
+          label: 'Optional',
+          type: 'text',
+          required: false,
+        },
+      ];
+
+      expect(() => service.validateRequiredFields(orgFields, {})).not.toThrow();
+    });
+
+    it('should treat empty string as missing for required fields', () => {
+      const orgFields: ConfigField[] = [
+        {
+          key: 'apiKey',
+          label: 'API Key',
+          type: 'secret',
+          required: true,
+        },
+      ];
+
+      expect(() =>
+        service.validateRequiredFields(orgFields, { apiKey: '' }),
+      ).toThrow(McpMissingRequiredConfigError);
+    });
+  });
+
+  describe('encryptSecretFields', () => {
+    it('should encrypt values for secret-type fields', async () => {
+      const orgFields: ConfigField[] = [
+        {
+          key: 'apiToken',
+          label: 'API Token',
+          type: 'secret',
+          required: true,
+        },
+      ];
+
+      const result = await service.encryptSecretFields(orgFields, {
+        apiToken: 'my-secret',
+      });
+
+      expect(result.apiToken).toBe('encrypted:my-secret');
+      expect(encryption.encrypt).toHaveBeenCalledWith('my-secret');
+    });
+
+    it('should not encrypt non-secret fields', async () => {
+      const orgFields: ConfigField[] = [
+        {
+          key: 'endpointUrl',
+          label: 'Endpoint',
+          type: 'url',
+          required: true,
+        },
+      ];
+
+      const result = await service.encryptSecretFields(orgFields, {
+        endpointUrl: 'https://example.com',
+      });
+
+      expect(result.endpointUrl).toBe('https://example.com');
+      expect(encryption.encrypt).not.toHaveBeenCalled();
+    });
+
+    it('should handle mix of secret and non-secret fields', async () => {
+      const orgFields: ConfigField[] = [
+        {
+          key: 'apiToken',
+          label: 'Token',
+          type: 'secret',
+          required: true,
+        },
+        {
+          key: 'endpointUrl',
+          label: 'Endpoint',
+          type: 'url',
+          required: true,
+        },
+      ];
+
+      const result = await service.encryptSecretFields(orgFields, {
+        apiToken: 'secret-value',
+        endpointUrl: 'https://example.com',
+      });
+
+      expect(result.apiToken).toBe('encrypted:secret-value');
+      expect(result.endpointUrl).toBe('https://example.com');
+    });
+  });
+
+  describe('mergeForUpdate', () => {
+    const orgFields: ConfigField[] = [
+      {
+        key: 'endpointUrl',
+        label: 'Endpoint URL',
+        type: 'url',
+        required: true,
+      },
+      {
+        key: 'apiToken',
+        label: 'API Token',
+        type: 'secret',
+        required: true,
+      },
+    ];
+
+    it('should update non-secret fields with provided values', async () => {
+      const result = await service.mergeForUpdate(
+        { endpointUrl: 'https://old.com', apiToken: 'encrypted:old-token' },
+        { endpointUrl: 'https://new.com' },
+        orgFields,
+      );
+
+      expect(result.endpointUrl).toBe('https://new.com');
+    });
+
+    it('should retain existing encrypted value when secret field is omitted', async () => {
+      const result = await service.mergeForUpdate(
+        { endpointUrl: 'https://old.com', apiToken: 'encrypted:old-token' },
+        { endpointUrl: 'https://new.com' },
+        orgFields,
+      );
+
+      expect(result.apiToken).toBe('encrypted:old-token');
+      expect(encryption.encrypt).not.toHaveBeenCalled();
+    });
+
+    it('should retain existing encrypted value when secret field is empty string', async () => {
+      const result = await service.mergeForUpdate(
+        { endpointUrl: 'https://old.com', apiToken: 'encrypted:old-token' },
+        { endpointUrl: 'https://new.com', apiToken: '' },
+        orgFields,
+      );
+
+      expect(result.apiToken).toBe('encrypted:old-token');
+    });
+
+    it('should encrypt new value when secret field is provided', async () => {
+      const result = await service.mergeForUpdate(
+        { endpointUrl: 'https://old.com', apiToken: 'encrypted:old-token' },
+        { endpointUrl: 'https://old.com', apiToken: 'new-secret-token' },
+        orgFields,
+      );
+
+      expect(result.apiToken).toBe('encrypted:new-secret-token');
+      expect(encryption.encrypt).toHaveBeenCalledWith('new-secret-token');
+    });
+
+    it('should preserve fixed-value fields from schema regardless of provided values', async () => {
+      const fieldsWithFixed: ConfigField[] = [
+        {
+          key: 'systemToken',
+          label: 'System Token',
+          type: 'secret',
+          required: true,
+          value: 'sk-fixed-system-token',
+        },
+        {
+          key: 'endpointUrl',
+          label: 'Endpoint',
+          type: 'url',
+          required: true,
+        },
+      ];
+
+      const result = await service.mergeForUpdate(
+        {
+          systemToken: 'encrypted:sk-fixed-system-token',
+          endpointUrl: 'https://old.com',
+        },
+        {
+          systemToken: 'user-override-attempt',
+          endpointUrl: 'https://new.com',
+        },
+        fieldsWithFixed,
+      );
+
+      expect(result.systemToken).toBe('encrypted:sk-fixed-system-token');
+      expect(result.endpointUrl).toBe('https://new.com');
+    });
+
+    it('should throw McpMissingRequiredConfigError when required field ends up missing', async () => {
+      const fieldsAllRequired: ConfigField[] = [
+        {
+          key: 'endpointUrl',
+          label: 'Endpoint',
+          type: 'url',
+          required: true,
+        },
+      ];
+
+      await expect(
+        service.mergeForUpdate({}, {}, fieldsAllRequired),
+      ).rejects.toThrow(McpMissingRequiredConfigError);
+    });
+
+    it('should keep existing non-secret value when not provided in update', async () => {
+      const result = await service.mergeForUpdate(
+        { endpointUrl: 'https://old.com', apiToken: 'encrypted:token' },
+        { apiToken: 'new-token' },
+        orgFields,
+      );
+
+      expect(result.endpointUrl).toBe('https://old.com');
+    });
+  });
+});

--- a/ayunis-core-backend/src/domain/mcp/application/services/marketplace-config.service.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/services/marketplace-config.service.ts
@@ -1,0 +1,134 @@
+import { Injectable } from '@nestjs/common';
+import { McpCredentialEncryptionPort } from '../ports/mcp-credential-encryption.port';
+import { ConfigField } from '../../domain/value-objects/integration-config-schema';
+import { McpMissingRequiredConfigError } from '../mcp.errors';
+
+/**
+ * Shared service for marketplace integration config processing.
+ * Handles merging fixed values, validating required fields, encrypting secrets,
+ * and merging values during updates (with secret retention).
+ */
+@Injectable()
+export class MarketplaceConfigService {
+  constructor(
+    private readonly credentialEncryption: McpCredentialEncryptionPort,
+  ) {}
+
+  /**
+   * Merges fixed (system-controlled) values from the config schema into user-provided values.
+   * Fixed values always take precedence over user-provided ones.
+   */
+  mergeFixedValues(
+    userProvided: Record<string, string>,
+    orgFields: ConfigField[],
+  ): Record<string, string> {
+    const merged = { ...userProvided };
+    for (const field of orgFields) {
+      if (field.value !== undefined) {
+        merged[field.key] = field.value;
+      }
+    }
+    return merged;
+  }
+
+  /**
+   * Validates that all required fields have non-empty values.
+   * Throws McpMissingRequiredConfigError if any required fields are missing.
+   */
+  validateRequiredFields(
+    orgFields: ConfigField[],
+    values: Record<string, string>,
+  ): void {
+    const missing = orgFields
+      .filter((field) => field.required && !values[field.key])
+      .map((field) => field.key);
+
+    if (missing.length > 0) {
+      throw new McpMissingRequiredConfigError(missing);
+    }
+  }
+
+  /**
+   * Encrypts values for fields marked as type 'secret'.
+   * Non-secret field values are passed through unchanged.
+   */
+  async encryptSecretFields(
+    orgFields: ConfigField[],
+    values: Record<string, string>,
+  ): Promise<Record<string, string>> {
+    const encrypted = { ...values };
+    const secretKeys = new Set(
+      orgFields.filter((f) => f.type === 'secret').map((f) => f.key),
+    );
+
+    for (const key of Object.keys(encrypted)) {
+      if (secretKeys.has(key)) {
+        encrypted[key] = await this.credentialEncryption.encrypt(
+          encrypted[key],
+        );
+      }
+    }
+    return encrypted;
+  }
+
+  /**
+   * Merges config values for an update operation with secret retention.
+   *
+   * For each org field:
+   * - Fixed-value fields: always use the value from the schema
+   * - Secret fields: if the provided value is missing or empty, keep the existing encrypted value;
+   *   otherwise encrypt the new value
+   * - Non-secret fields: use the provided value if present, otherwise keep existing
+   *
+   * After merging, validates required fields and returns the final merged+encrypted values.
+   */
+  async mergeForUpdate(
+    existingValues: Record<string, string>,
+    providedValues: Record<string, string>,
+    orgFields: ConfigField[],
+  ): Promise<Record<string, string>> {
+    const merged: Record<string, string> = {};
+
+    for (const field of orgFields) {
+      // Fixed-value fields always use schema value
+      if (field.value !== undefined) {
+        merged[field.key] = field.value;
+        continue;
+      }
+
+      const provided = providedValues[field.key];
+      const existing = existingValues[field.key];
+
+      if (field.type === 'secret') {
+        if (provided !== undefined && provided !== '') {
+          // New secret value — encrypt it
+          merged[field.key] = await this.credentialEncryption.encrypt(provided);
+        } else if (existing !== undefined) {
+          // Keep existing encrypted value
+          merged[field.key] = existing;
+        }
+      } else {
+        // Non-secret: use provided value if given, otherwise keep existing
+        if (provided !== undefined) {
+          merged[field.key] = provided;
+        } else if (existing !== undefined) {
+          merged[field.key] = existing;
+        }
+      }
+    }
+
+    // Re-encrypt fixed-value secret fields
+    const fixedSecretFields = orgFields.filter(
+      (f) => f.value !== undefined && f.type === 'secret',
+    );
+    for (const field of fixedSecretFields) {
+      merged[field.key] = await this.credentialEncryption.encrypt(
+        merged[field.key],
+      );
+    }
+
+    this.validateRequiredFields(orgFields, merged);
+
+    return merged;
+  }
+}

--- a/ayunis-core-backend/src/domain/mcp/application/services/mcp-client.service.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/services/mcp-client.service.spec.ts
@@ -65,7 +65,7 @@ describe('McpClientService', () => {
   });
 
   describe('buildConnectionConfig', () => {
-    it('returns base config for no-auth integrations', async () => {
+    it('returns base config with empty headers for no-auth integrations', async () => {
       const integration = new CustomMcpIntegration({
         ...baseIntegrationParams,
         auth: new NoAuthMcpIntegrationAuth(),
@@ -73,11 +73,14 @@ describe('McpClientService', () => {
 
       const config = await service.buildConnectionConfig(integration);
 
-      expect(config).toEqual({ serverUrl: baseIntegrationParams.serverUrl });
+      expect(config).toEqual({
+        serverUrl: baseIntegrationParams.serverUrl,
+        headers: {},
+      });
       expect(encryption.decrypt).not.toHaveBeenCalled();
     });
 
-    it('builds config for bearer auth', async () => {
+    it('builds config with Authorization header for bearer auth', async () => {
       const auth = new BearerMcpIntegrationAuth({
         authToken: 'encrypted-token',
       });
@@ -93,12 +96,11 @@ describe('McpClientService', () => {
 
       expect(config).toEqual({
         serverUrl: baseIntegrationParams.serverUrl,
-        authHeaderName: 'Authorization',
-        authToken: 'Bearer decrypted-token',
+        headers: { Authorization: 'Bearer decrypted-token' },
       });
     });
 
-    it('builds config for custom header auth', async () => {
+    it('builds config with custom header for custom header auth', async () => {
       const auth = new CustomHeaderMcpIntegrationAuth({
         secret: 'encrypted-secret',
         headerName: 'X-API-Key',
@@ -114,12 +116,11 @@ describe('McpClientService', () => {
 
       expect(config).toEqual({
         serverUrl: baseIntegrationParams.serverUrl,
-        authHeaderName: 'X-API-Key',
-        authToken: 'decrypted-secret',
+        headers: { 'X-API-Key': 'decrypted-secret' },
       });
     });
 
-    it('builds config for oauth auth with valid token', async () => {
+    it('builds config with Authorization header for oauth auth with valid token', async () => {
       const auth = new OAuthMcpIntegrationAuth({
         clientId: 'client',
         clientSecret: 'secret',
@@ -137,8 +138,7 @@ describe('McpClientService', () => {
 
       expect(config).toEqual({
         serverUrl: baseIntegrationParams.serverUrl,
-        authHeaderName: 'Authorization',
-        authToken: 'Bearer decrypted-token',
+        headers: { Authorization: 'Bearer decrypted-token' },
       });
     });
 

--- a/ayunis-core-backend/src/domain/mcp/application/services/mcp-client.service.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/services/mcp-client.service.spec.ts
@@ -10,7 +10,7 @@ import { PredefinedMcpIntegration } from '../../domain/integrations/predefined-m
 import { MarketplaceMcpIntegration } from '../../domain/integrations/marketplace-mcp-integration.entity';
 import { McpIntegrationUserConfig } from '../../domain/mcp-integration-user-config.entity';
 import { PredefinedMcpIntegrationSlug } from '../../domain/value-objects/predefined-mcp-integration-slug.enum';
-import { IntegrationConfigSchema } from '../../domain/value-objects/integration-config-schema';
+import type { IntegrationConfigSchema } from '../../domain/value-objects/integration-config-schema';
 import { BearerMcpIntegrationAuth } from '../../domain/auth/bearer-mcp-integration-auth.entity';
 import { CustomHeaderMcpIntegrationAuth } from '../../domain/auth/custom-header-mcp-integration-auth.entity';
 import { OAuthMcpIntegrationAuth } from '../../domain/auth/oauth-mcp-integration-auth.entity';

--- a/ayunis-core-backend/src/domain/mcp/application/services/mcp-client.service.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/services/mcp-client.service.spec.ts
@@ -3,10 +3,14 @@ import { Test } from '@nestjs/testing';
 import { McpClientService } from './mcp-client.service';
 import { McpClientPort } from '../ports/mcp-client.port';
 import { McpCredentialEncryptionPort } from '../ports/mcp-credential-encryption.port';
+import { McpIntegrationUserConfigRepositoryPort } from '../ports/mcp-integration-user-config.repository.port';
 import { randomUUID } from 'crypto';
 import { CustomMcpIntegration } from '../../domain/integrations/custom-mcp-integration.entity';
 import { PredefinedMcpIntegration } from '../../domain/integrations/predefined-mcp-integration.entity';
+import { MarketplaceMcpIntegration } from '../../domain/integrations/marketplace-mcp-integration.entity';
+import { McpIntegrationUserConfig } from '../../domain/mcp-integration-user-config.entity';
 import { PredefinedMcpIntegrationSlug } from '../../domain/value-objects/predefined-mcp-integration-slug.enum';
+import { IntegrationConfigSchema } from '../../domain/value-objects/integration-config-schema';
 import { BearerMcpIntegrationAuth } from '../../domain/auth/bearer-mcp-integration-auth.entity';
 import { CustomHeaderMcpIntegrationAuth } from '../../domain/auth/custom-header-mcp-integration-auth.entity';
 import { OAuthMcpIntegrationAuth } from '../../domain/auth/oauth-mcp-integration-auth.entity';
@@ -29,10 +33,17 @@ class MockCredentialEncryptionPort extends McpCredentialEncryptionPort {
   decrypt = jest.fn();
 }
 
+class MockUserConfigRepository extends McpIntegrationUserConfigRepositoryPort {
+  save = jest.fn();
+  findByIntegrationAndUser = jest.fn();
+  deleteByIntegrationId = jest.fn();
+}
+
 describe('McpClientService', () => {
   let service: McpClientService;
   let client: MockMcpClientPort;
   let encryption: MockCredentialEncryptionPort;
+  let userConfigRepo: MockUserConfigRepository;
 
   const baseIntegrationParams = {
     id: randomUUID(),
@@ -48,12 +59,17 @@ describe('McpClientService', () => {
   beforeAll(async () => {
     client = new MockMcpClientPort();
     encryption = new MockCredentialEncryptionPort();
+    userConfigRepo = new MockUserConfigRepository();
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         McpClientService,
         { provide: McpClientPort, useValue: client },
         { provide: McpCredentialEncryptionPort, useValue: encryption },
+        {
+          provide: McpIntegrationUserConfigRepositoryPort,
+          useValue: userConfigRepo,
+        },
       ],
     }).compile();
 
@@ -167,6 +183,284 @@ describe('McpClientService', () => {
       await expect(
         service.buildConnectionConfig(integration),
       ).rejects.toBeInstanceOf(McpAuthenticationError);
+    });
+  });
+
+  describe('buildConnectionConfig — marketplace integrations', () => {
+    const buildMarketplaceIntegration = (
+      configSchema: IntegrationConfigSchema,
+      orgConfigValues: Record<string, string>,
+    ) =>
+      new MarketplaceMcpIntegration({
+        id: baseIntegrationParams.id,
+        orgId: baseIntegrationParams.orgId,
+        name: 'OParl Integration',
+        serverUrl: 'https://mcp.ayunis.de/oparl',
+        marketplaceIdentifier: 'oparl-mcp',
+        configSchema,
+        orgConfigValues,
+        auth: new NoAuthMcpIntegrationAuth(),
+      });
+
+    it('maps org config fields to headers based on headerName', async () => {
+      const schema: IntegrationConfigSchema = {
+        authType: 'NO_AUTH',
+        orgFields: [
+          {
+            key: 'oparlEndpointUrl',
+            label: 'OParl Endpoint URL',
+            type: 'url',
+            headerName: 'X-Oparl-Endpoint-Url',
+            required: true,
+          },
+        ],
+        userFields: [],
+      };
+      const integration = buildMarketplaceIntegration(schema, {
+        oparlEndpointUrl: 'https://rim.ekom21.de/oparl',
+      });
+
+      const config = await service.buildConnectionConfig(integration);
+
+      expect(config).toEqual({
+        serverUrl: 'https://mcp.ayunis.de/oparl',
+        headers: { 'X-Oparl-Endpoint-Url': 'https://rim.ekom21.de/oparl' },
+      });
+      expect(encryption.decrypt).not.toHaveBeenCalled();
+    });
+
+    it('decrypts secret fields and applies prefix', async () => {
+      const schema: IntegrationConfigSchema = {
+        authType: 'BEARER_TOKEN',
+        orgFields: [
+          {
+            key: 'apiToken',
+            label: 'API Token',
+            type: 'secret',
+            headerName: 'Authorization',
+            prefix: 'Bearer ',
+            required: true,
+          },
+        ],
+        userFields: [],
+      };
+      const integration = buildMarketplaceIntegration(schema, {
+        apiToken: 'encrypted-token-value',
+      });
+
+      encryption.decrypt.mockResolvedValue('sk-live-abc123');
+
+      const config = await service.buildConnectionConfig(integration);
+
+      expect(config.headers).toEqual({
+        Authorization: 'Bearer sk-live-abc123',
+      });
+      expect(encryption.decrypt).toHaveBeenCalledWith('encrypted-token-value');
+    });
+
+    it('skips fields without headerName', async () => {
+      const schema: IntegrationConfigSchema = {
+        authType: 'OAUTH',
+        orgFields: [
+          {
+            key: 'clientId',
+            label: 'Client ID',
+            type: 'text',
+            required: true,
+          },
+          {
+            key: 'tenantId',
+            label: 'Tenant ID',
+            type: 'text',
+            headerName: 'X-Tenant-Id',
+            required: true,
+          },
+        ],
+        userFields: [],
+      };
+      const integration = buildMarketplaceIntegration(schema, {
+        clientId: 'my-client',
+        tenantId: 'tenant-42',
+      });
+
+      const config = await service.buildConnectionConfig(integration);
+
+      expect(config.headers).toEqual({ 'X-Tenant-Id': 'tenant-42' });
+    });
+
+    it('applies user config overrides for matching headerNames', async () => {
+      const userId = randomUUID();
+      const schema: IntegrationConfigSchema = {
+        authType: 'BEARER_TOKEN',
+        orgFields: [
+          {
+            key: 'orgToken',
+            label: 'Default API Token',
+            type: 'secret',
+            headerName: 'Authorization',
+            prefix: 'Bearer ',
+            required: true,
+          },
+        ],
+        userFields: [
+          {
+            key: 'personalToken',
+            label: 'Personal Access Token',
+            type: 'secret',
+            headerName: 'Authorization',
+            prefix: 'Bearer ',
+            required: false,
+          },
+        ],
+      };
+      const integration = buildMarketplaceIntegration(schema, {
+        orgToken: 'encrypted-org-token',
+      });
+
+      encryption.decrypt
+        .mockResolvedValueOnce('org-token-decrypted')
+        .mockResolvedValueOnce('personal-token-decrypted');
+
+      userConfigRepo.findByIntegrationAndUser.mockResolvedValue(
+        new McpIntegrationUserConfig({
+          integrationId: integration.id,
+          userId,
+          configValues: { personalToken: 'encrypted-personal-token' },
+        }),
+      );
+
+      const config = await service.buildConnectionConfig(integration, userId);
+
+      expect(config.headers).toEqual({
+        Authorization: 'Bearer personal-token-decrypted',
+      });
+      expect(userConfigRepo.findByIntegrationAndUser).toHaveBeenCalledWith(
+        integration.id,
+        userId,
+      );
+    });
+
+    it('uses org values when no user config exists', async () => {
+      const userId = randomUUID();
+      const schema: IntegrationConfigSchema = {
+        authType: 'BEARER_TOKEN',
+        orgFields: [
+          {
+            key: 'orgToken',
+            label: 'Token',
+            type: 'secret',
+            headerName: 'Authorization',
+            prefix: 'Bearer ',
+            required: true,
+          },
+        ],
+        userFields: [
+          {
+            key: 'personalToken',
+            label: 'Personal Token',
+            type: 'secret',
+            headerName: 'Authorization',
+            prefix: 'Bearer ',
+            required: false,
+          },
+        ],
+      };
+      const integration = buildMarketplaceIntegration(schema, {
+        orgToken: 'encrypted-org-token',
+      });
+
+      encryption.decrypt.mockResolvedValue('org-token-decrypted');
+      userConfigRepo.findByIntegrationAndUser.mockResolvedValue(null);
+
+      const config = await service.buildConnectionConfig(integration, userId);
+
+      expect(config.headers).toEqual({
+        Authorization: 'Bearer org-token-decrypted',
+      });
+    });
+
+    it('does not query user config when no userId provided', async () => {
+      const schema: IntegrationConfigSchema = {
+        authType: 'BEARER_TOKEN',
+        orgFields: [
+          {
+            key: 'apiToken',
+            label: 'Token',
+            type: 'secret',
+            headerName: 'Authorization',
+            prefix: 'Bearer ',
+            required: true,
+          },
+        ],
+        userFields: [
+          {
+            key: 'personalToken',
+            label: 'Personal Token',
+            type: 'secret',
+            headerName: 'Authorization',
+            prefix: 'Bearer ',
+            required: false,
+          },
+        ],
+      };
+      const integration = buildMarketplaceIntegration(schema, {
+        apiToken: 'encrypted-token',
+      });
+
+      encryption.decrypt.mockResolvedValue('decrypted-token');
+
+      await service.buildConnectionConfig(integration);
+
+      expect(userConfigRepo.findByIntegrationAndUser).not.toHaveBeenCalled();
+    });
+
+    it('handles multiple org fields mapping to different headers', async () => {
+      const schema: IntegrationConfigSchema = {
+        authType: 'CUSTOM_HEADER',
+        orgFields: [
+          {
+            key: 'apiKey',
+            label: 'API Key',
+            type: 'secret',
+            headerName: 'X-API-Key',
+            required: true,
+          },
+          {
+            key: 'tenantId',
+            label: 'Tenant ID',
+            type: 'text',
+            headerName: 'X-Tenant-Id',
+            required: true,
+          },
+        ],
+        userFields: [],
+      };
+      const integration = buildMarketplaceIntegration(schema, {
+        apiKey: 'encrypted-key',
+        tenantId: 'tenant-42',
+      });
+
+      encryption.decrypt.mockResolvedValue('decrypted-api-key');
+
+      const config = await service.buildConnectionConfig(integration);
+
+      expect(config.headers).toEqual({
+        'X-API-Key': 'decrypted-api-key',
+        'X-Tenant-Id': 'tenant-42',
+      });
+    });
+
+    it('returns empty headers when no org fields have values', async () => {
+      const schema: IntegrationConfigSchema = {
+        authType: 'NO_AUTH',
+        orgFields: [],
+        userFields: [],
+      };
+      const integration = buildMarketplaceIntegration(schema, {});
+
+      const config = await service.buildConnectionConfig(integration);
+
+      expect(config.headers).toEqual({});
     });
   });
 });

--- a/ayunis-core-backend/src/domain/mcp/application/services/mcp-client.service.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/services/mcp-client.service.ts
@@ -45,7 +45,7 @@ export class McpClientService {
    * @returns Connection configuration for MCP client
    * @throws McpAuthenticationError if authentication configuration fails
    */
-  // eslint-disable-next-line sonarjs/cognitive-complexity -- auth config branching inherently complex
+
   async buildConnectionConfig(
     integration: McpIntegration,
     userId?: UUID,
@@ -201,41 +201,6 @@ export class McpClientService {
         integrationId: integration.id,
       });
       throw new McpAuthenticationError('Authentication configuration failed');
-    }
-  }
-
-  /**
-   * Validates connection to an MCP server and updates integration status.
-   *
-   * @param integration The MCP integration entity
-   * @returns true if connection is valid, false otherwise
-   */
-  async validateConnection(
-    integration: McpIntegration,
-    userId?: UUID,
-  ): Promise<boolean> {
-    try {
-      const config = await this.buildConnectionConfig(integration, userId);
-      const result = await this.mcpClient.validateConnection(config);
-
-      integration.updateConnectionStatus(
-        result.valid ? 'connected' : 'error',
-        result.error,
-      );
-
-      return result.valid;
-    } catch (error) {
-      this.logger.error('Failed to validate connection', {
-        error: error as Error,
-        integrationId: integration.id,
-      });
-
-      integration.updateConnectionStatus(
-        'error',
-        'Authentication configuration failed',
-      );
-
-      return false;
     }
   }
 

--- a/ayunis-core-backend/src/domain/mcp/application/services/mcp-client.service.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/services/mcp-client.service.ts
@@ -1,4 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { UUID } from 'crypto';
 import {
   McpClientPort,
   McpConnectionConfig,
@@ -9,7 +10,10 @@ import {
   McpToolResult,
 } from '../ports/mcp-client.port';
 import { McpCredentialEncryptionPort } from '../ports/mcp-credential-encryption.port';
+import { McpIntegrationUserConfigRepositoryPort } from '../ports/mcp-integration-user-config.repository.port';
 import { McpIntegration } from '../../domain/mcp-integration.entity';
+import { MarketplaceMcpIntegration } from '../../domain/integrations/marketplace-mcp-integration.entity';
+import { ConfigField } from '../../domain/value-objects/integration-config-schema';
 import { BearerMcpIntegrationAuth } from '../../domain/auth/bearer-mcp-integration-auth.entity';
 import { CustomHeaderMcpIntegrationAuth } from '../../domain/auth/custom-header-mcp-integration-auth.entity';
 import { OAuthMcpIntegrationAuth } from '../../domain/auth/oauth-mcp-integration-auth.entity';
@@ -27,19 +31,112 @@ export class McpClientService {
   constructor(
     private readonly mcpClient: McpClientPort,
     private readonly credentialEncryption: McpCredentialEncryptionPort,
+    private readonly userConfigRepository: McpIntegrationUserConfigRepositoryPort,
   ) {}
 
   /**
    * Builds MCP connection configuration from integration entity.
-   * Delegates auth header generation to the integration entity with special
-   * handling for decryption of encrypted credentials.
+   * For marketplace integrations, resolves config fields to headers with
+   * optional per-user overrides. For legacy integrations, delegates auth
+   * header generation to the auth entity hierarchy.
    *
    * @param integration The MCP integration entity
+   * @param userId Optional user ID for per-user config resolution (marketplace only)
    * @returns Connection configuration for MCP client
    * @throws McpAuthenticationError if authentication configuration fails
    */
   // eslint-disable-next-line sonarjs/cognitive-complexity -- auth config branching inherently complex
   async buildConnectionConfig(
+    integration: McpIntegration,
+    userId?: UUID,
+  ): Promise<McpConnectionConfig> {
+    if (integration instanceof MarketplaceMcpIntegration) {
+      return this.buildMarketplaceConnectionConfig(integration, userId);
+    }
+    return this.buildLegacyConnectionConfig(integration);
+  }
+
+  /**
+   * Builds connection config for marketplace integrations by resolving
+   * config schema fields to HTTP headers, with optional user-level overrides.
+   */
+  private async buildMarketplaceConnectionConfig(
+    integration: MarketplaceMcpIntegration,
+    userId?: UUID,
+  ): Promise<McpConnectionConfig> {
+    try {
+      const headers: Record<string, string> = {};
+      const { configSchema, orgConfigValues } = integration;
+
+      // Apply org-level fields to headers
+      await this.applyConfigFieldHeaders(
+        headers,
+        configSchema.orgFields,
+        orgConfigValues,
+      );
+
+      // Apply user-level overrides if applicable
+      if (userId && configSchema.userFields.length > 0) {
+        const userConfig =
+          await this.userConfigRepository.findByIntegrationAndUser(
+            integration.id,
+            userId,
+          );
+
+        if (userConfig) {
+          await this.applyConfigFieldHeaders(
+            headers,
+            configSchema.userFields,
+            userConfig.configValues,
+          );
+        }
+      }
+
+      return { serverUrl: integration.serverUrl, headers };
+    } catch (error) {
+      if (error instanceof McpAuthenticationError) {
+        throw error;
+      }
+      this.logger.error('Failed to build marketplace connection config', {
+        error: error as Error,
+        integrationId: integration.id,
+      });
+      throw new McpAuthenticationError('Authentication configuration failed');
+    }
+  }
+
+  /**
+   * Applies config field values as HTTP headers.
+   * Only fields with a `headerName` are sent. Prefix is prepended if present.
+   * Secret fields are decrypted before sending.
+   */
+  private async applyConfigFieldHeaders(
+    headers: Record<string, string>,
+    fields: ConfigField[],
+    values: Record<string, string>,
+  ): Promise<void> {
+    for (const field of fields) {
+      const rawValue = values[field.key];
+      if (!rawValue || !field.headerName) continue;
+
+      const decryptedValue =
+        field.type === 'secret'
+          ? await this.credentialEncryption.decrypt(rawValue)
+          : rawValue;
+
+      const headerValue = field.prefix
+        ? `${field.prefix}${decryptedValue}`
+        : decryptedValue;
+
+      headers[field.headerName] = headerValue;
+    }
+  }
+
+  /**
+   * Builds connection config for legacy (Custom/Predefined) integrations
+   * using the auth entity hierarchy.
+   */
+  private async buildLegacyConnectionConfig(
     integration: McpIntegration,
   ): Promise<McpConnectionConfig> {
     const headers: Record<string, string> = {};
@@ -113,9 +210,12 @@ export class McpClientService {
    * @param integration The MCP integration entity
    * @returns true if connection is valid, false otherwise
    */
-  async validateConnection(integration: McpIntegration): Promise<boolean> {
+  async validateConnection(
+    integration: McpIntegration,
+    userId?: UUID,
+  ): Promise<boolean> {
     try {
-      const config = await this.buildConnectionConfig(integration);
+      const config = await this.buildConnectionConfig(integration, userId);
       const result = await this.mcpClient.validateConnection(config);
 
       integration.updateConnectionStatus(
@@ -146,8 +246,11 @@ export class McpClientService {
    * @returns List of available tools
    * @throws McpAuthenticationError on 401 responses
    */
-  async listTools(integration: McpIntegration): Promise<McpTool[]> {
-    const config = await this.buildConnectionConfig(integration);
+  async listTools(
+    integration: McpIntegration,
+    userId?: UUID,
+  ): Promise<McpTool[]> {
+    const config = await this.buildConnectionConfig(integration, userId);
 
     try {
       return await this.mcpClient.listTools(config);
@@ -165,8 +268,11 @@ export class McpClientService {
    * @returns List of available resources
    * @throws McpAuthenticationError on 401 responses
    */
-  async listResources(integration: McpIntegration): Promise<McpResource[]> {
-    const config = await this.buildConnectionConfig(integration);
+  async listResources(
+    integration: McpIntegration,
+    userId?: UUID,
+  ): Promise<McpResource[]> {
+    const config = await this.buildConnectionConfig(integration, userId);
 
     try {
       return await this.mcpClient.listResources(config);
@@ -186,8 +292,9 @@ export class McpClientService {
    */
   async listResourceTemplates(
     integration: McpIntegration,
+    userId?: UUID,
   ): Promise<McpResource[]> {
-    const config = await this.buildConnectionConfig(integration);
+    const config = await this.buildConnectionConfig(integration, userId);
 
     try {
       return await this.mcpClient.listResourceTemplates(config);
@@ -205,8 +312,11 @@ export class McpClientService {
    * @returns List of available prompts
    * @throws McpAuthenticationError on 401 responses
    */
-  async listPrompts(integration: McpIntegration): Promise<McpPrompt[]> {
-    const config = await this.buildConnectionConfig(integration);
+  async listPrompts(
+    integration: McpIntegration,
+    userId?: UUID,
+  ): Promise<McpPrompt[]> {
+    const config = await this.buildConnectionConfig(integration, userId);
 
     try {
       return await this.mcpClient.listPrompts(config);
@@ -228,8 +338,9 @@ export class McpClientService {
   async callTool(
     integration: McpIntegration,
     call: McpToolCall,
+    userId?: UUID,
   ): Promise<McpToolResult> {
-    const config = await this.buildConnectionConfig(integration);
+    const config = await this.buildConnectionConfig(integration, userId);
 
     try {
       return await this.mcpClient.callTool(config, call);
@@ -252,8 +363,9 @@ export class McpClientService {
     integration: McpIntegration,
     uri: string,
     parameters?: Record<string, unknown>,
+    userId?: UUID,
   ): Promise<{ content: unknown; mimeType: string }> {
-    const config = await this.buildConnectionConfig(integration);
+    const config = await this.buildConnectionConfig(integration, userId);
 
     try {
       return await this.mcpClient.readResource(config, uri, parameters);
@@ -276,8 +388,9 @@ export class McpClientService {
     integration: McpIntegration,
     name: string,
     args: Record<string, unknown>,
+    userId?: UUID,
   ): Promise<{ messages: unknown[] }> {
-    const config = await this.buildConnectionConfig(integration);
+    const config = await this.buildConnectionConfig(integration, userId);
 
     try {
       return await this.mcpClient.getPrompt(config, name, args);

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/create-mcp-integration/create-mcp-integration.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/create-mcp-integration/create-mcp-integration.use-case.spec.ts
@@ -11,7 +11,7 @@ import { ContextService } from 'src/common/context/services/context.service';
 import { McpIntegrationFactory } from '../../factories/mcp-integration.factory';
 import { McpIntegrationAuthFactory } from '../../factories/mcp-integration-auth.factory';
 import { McpCredentialEncryptionPort } from '../../ports/mcp-credential-encryption.port';
-import { ValidateMcpIntegrationUseCase } from '../validate-mcp-integration/validate-mcp-integration.use-case';
+import type { ValidateMcpIntegrationUseCase } from '../validate-mcp-integration/validate-mcp-integration.use-case';
 import { ConnectionValidationService } from '../../services/connection-validation.service';
 import { McpAuthMethod } from '../../../domain/value-objects/mcp-auth-method.enum';
 import { McpIntegrationKind } from '../../../domain/value-objects/mcp-integration-kind.enum';

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/create-mcp-integration/create-mcp-integration.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/create-mcp-integration/create-mcp-integration.use-case.spec.ts
@@ -74,6 +74,7 @@ describe('CreateMcpIntegrationUseCase', () => {
       findById: jest.fn(),
       findAll: jest.fn(),
       findByOrgIdAndSlug: jest.fn(),
+      findByOrgIdAndMarketplaceIdentifier: jest.fn(),
       delete: jest.fn(),
     } as any;
 

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/create-mcp-integration/create-mcp-integration.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/create-mcp-integration/create-mcp-integration.use-case.spec.ts
@@ -12,6 +12,7 @@ import { McpIntegrationFactory } from '../../factories/mcp-integration.factory';
 import { McpIntegrationAuthFactory } from '../../factories/mcp-integration-auth.factory';
 import { McpCredentialEncryptionPort } from '../../ports/mcp-credential-encryption.port';
 import { ValidateMcpIntegrationUseCase } from '../validate-mcp-integration/validate-mcp-integration.use-case';
+import { ConnectionValidationService } from '../../services/connection-validation.service';
 import { McpAuthMethod } from '../../../domain/value-objects/mcp-auth-method.enum';
 import { McpIntegrationKind } from '../../../domain/value-objects/mcp-integration-kind.enum';
 import { PredefinedMcpIntegrationSlug } from '../../../domain/value-objects/predefined-mcp-integration-slug.enum';
@@ -45,6 +46,7 @@ describe('CreateMcpIntegrationUseCase', () => {
   let authFactory: McpIntegrationAuthFactory;
   let encryption: jest.Mocked<McpCredentialEncryptionPort>;
   let validateUseCase: jest.Mocked<ValidateMcpIntegrationUseCase>;
+  let connectionValidationService: ConnectionValidationService;
   let factorySpy: jest.SpyInstance;
   let authSpy: jest.SpyInstance;
   let savedIntegrations: McpIntegration[];
@@ -123,6 +125,11 @@ describe('CreateMcpIntegrationUseCase', () => {
       execute: jest.fn().mockResolvedValue({ isValid: true }),
     } as any;
 
+    connectionValidationService = new ConnectionValidationService(
+      validateUseCase,
+      repository,
+    );
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         CreateMcpIntegrationUseCase,
@@ -132,7 +139,10 @@ describe('CreateMcpIntegrationUseCase', () => {
         { provide: McpIntegrationFactory, useValue: factory },
         { provide: McpIntegrationAuthFactory, useValue: authFactory },
         { provide: McpCredentialEncryptionPort, useValue: encryption },
-        { provide: ValidateMcpIntegrationUseCase, useValue: validateUseCase },
+        {
+          provide: ConnectionValidationService,
+          useValue: connectionValidationService,
+        },
       ],
     }).compile();
 

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/create-mcp-integration/create-mcp-integration.use-case.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/create-mcp-integration/create-mcp-integration.use-case.ts
@@ -172,9 +172,7 @@ export class CreateMcpIntegrationUseCase {
       });
 
       // Save integration first to get ID
-      const savedIntegration = (await this.repository.save(
-        integration,
-      )) as PredefinedMcpIntegration;
+      const savedIntegration = await this.repository.save(integration);
 
       // Validate connection (don't throw on failure)
       await this.validateAndUpdateConnectionStatus(savedIntegration);
@@ -293,9 +291,7 @@ export class CreateMcpIntegrationUseCase {
       }
 
       // Save integration first to get ID
-      const savedIntegration = (await this.repository.save(
-        integration,
-      )) as CustomMcpIntegration;
+      const savedIntegration = await this.repository.save(integration);
 
       // Validate connection (don't throw on failure)
       await this.validateAndUpdateConnectionStatus(savedIntegration);

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/create-mcp-integration/create-mcp-integration.use-case.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/create-mcp-integration/create-mcp-integration.use-case.ts
@@ -318,7 +318,6 @@ export class CreateMcpIntegrationUseCase {
     }
   }
 
-
   private isValidUrl(url: string): boolean {
     try {
       const parsedUrl = new URL(url);

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/discover-mcp-capabilities/discover-mcp-capabilities.use-case.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/discover-mcp-capabilities/discover-mcp-capabilities.use-case.ts
@@ -82,11 +82,12 @@ export class DiscoverMcpCapabilitiesUseCase {
       }
 
       // Discover capabilities from MCP server
+      const userId = this.contextService.get('userId');
       const [tools, resources, resourceTemplates, prompts] = await Promise.all([
-        this.mcpClientService.listTools(integration),
-        this.mcpClientService.listResources(integration),
-        this.mcpClientService.listResourceTemplates(integration),
-        this.mcpClientService.listPrompts(integration),
+        this.mcpClientService.listTools(integration, userId),
+        this.mcpClientService.listResources(integration, userId),
+        this.mcpClientService.listResourceTemplates(integration, userId),
+        this.mcpClientService.listPrompts(integration, userId),
       ]);
 
       // Map to domain entities

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/execute-mcp-tool/execute-mcp-tool.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/execute-mcp-tool/execute-mcp-tool.use-case.spec.ts
@@ -23,6 +23,7 @@ import { BearerMcpIntegrationAuth } from '../../../domain/auth/bearer-mcp-integr
 import { McpIntegrationKind } from '../../../domain/value-objects/mcp-integration-kind.enum';
 
 const mockOrgId = randomUUID();
+const mockUserId = randomUUID();
 const mockIntegrationId = randomUUID();
 const mockToolName = 'test-tool';
 const mockParameters = { foo: 'bar' };
@@ -101,7 +102,11 @@ describe('ExecuteMcpToolUseCase', () => {
   it('returns successful tool execution result', async () => {
     const integration = buildPredefined();
     repository.findById.mockResolvedValue(integration);
-    contextService.get.mockReturnValue(mockOrgId);
+    contextService.get.mockImplementation((key?: string | symbol) => {
+      if (key === 'orgId') return mockOrgId;
+      if (key === 'userId') return mockUserId;
+      return undefined;
+    });
     mcpClientService.callTool.mockResolvedValue({
       isError: false,
       content: { result: 'ok' },
@@ -110,10 +115,14 @@ describe('ExecuteMcpToolUseCase', () => {
     const result = await useCase.execute(buildCommand());
 
     expect(result).toEqual({ isError: false, content: { result: 'ok' } });
-    expect(mcpClientService.callTool).toHaveBeenCalledWith(integration, {
-      toolName: mockToolName,
-      parameters: mockParameters,
-    });
+    expect(mcpClientService.callTool).toHaveBeenCalledWith(
+      integration,
+      {
+        toolName: mockToolName,
+        parameters: mockParameters,
+      },
+      mockUserId,
+    );
     expect(loggerLogSpy).toHaveBeenCalled();
   });
 
@@ -178,10 +187,14 @@ describe('ExecuteMcpToolUseCase', () => {
     expect(loggerErrorSpy).toHaveBeenCalled();
   });
 
-  it('passes custom integrations to client service', async () => {
+  it('passes custom integrations to client service with userId', async () => {
     const integration = buildCustom();
     repository.findById.mockResolvedValue(integration);
-    contextService.get.mockReturnValue(mockOrgId);
+    contextService.get.mockImplementation((key?: string | symbol) => {
+      if (key === 'orgId') return mockOrgId;
+      if (key === 'userId') return mockUserId;
+      return undefined;
+    });
     mcpClientService.callTool.mockResolvedValue({
       isError: false,
       content: {},
@@ -189,10 +202,14 @@ describe('ExecuteMcpToolUseCase', () => {
 
     await useCase.execute(buildCommand());
 
-    expect(mcpClientService.callTool).toHaveBeenCalledWith(integration, {
-      toolName: mockToolName,
-      parameters: mockParameters,
-    });
+    expect(mcpClientService.callTool).toHaveBeenCalledWith(
+      integration,
+      {
+        toolName: mockToolName,
+        parameters: mockParameters,
+      },
+      mockUserId,
+    );
     expect(integration.kind).toBe(McpIntegrationKind.CUSTOM);
   });
 });

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/execute-mcp-tool/execute-mcp-tool.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/execute-mcp-tool/execute-mcp-tool.use-case.spec.ts
@@ -64,6 +64,7 @@ describe('ExecuteMcpToolUseCase', () => {
       save: jest.fn(),
       findAll: jest.fn(),
       findByOrgIdAndSlug: jest.fn(),
+      findByOrgIdAndMarketplaceIdentifier: jest.fn(),
       delete: jest.fn(),
     } as any;
 

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/execute-mcp-tool/execute-mcp-tool.use-case.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/execute-mcp-tool/execute-mcp-tool.use-case.ts
@@ -2,6 +2,7 @@ import { Injectable, Logger } from '@nestjs/common';
 import { ExecuteMcpToolCommand } from './execute-mcp-tool.command';
 import { McpToolCall } from '../../ports/mcp-client.port';
 import { McpClientService } from '../../services/mcp-client.service';
+import { ContextService } from 'src/common/context/services/context.service';
 import { UnexpectedMcpError } from '../../mcp.errors';
 import { ApplicationError } from 'src/common/errors/base.error';
 import { ValidateIntegrationAccessService } from '../../services/validate-integration-access.service';
@@ -22,6 +23,7 @@ export class ExecuteMcpToolUseCase {
   constructor(
     private readonly mcpClientService: McpClientService,
     private readonly validateIntegrationAccess: ValidateIntegrationAccessService,
+    private readonly contextService: ContextService,
   ) {}
 
   async execute(command: ExecuteMcpToolCommand): Promise<ToolExecutionResult> {

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/execute-mcp-tool/execute-mcp-tool.use-case.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/execute-mcp-tool/execute-mcp-tool.use-case.ts
@@ -37,6 +37,7 @@ export class ExecuteMcpToolUseCase {
 
       // Execute tool (errors are caught and returned, not thrown)
       try {
+        const userId = this.contextService.get('userId');
         const toolCall: McpToolCall = {
           toolName: command.toolName,
           parameters: command.parameters,
@@ -45,6 +46,7 @@ export class ExecuteMcpToolUseCase {
         const result = await this.mcpClientService.callTool(
           integration,
           toolCall,
+          userId,
         );
 
         const duration = Date.now() - startTime;

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/get-mcp-prompt/get-mcp-prompt.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/get-mcp-prompt/get-mcp-prompt.use-case.spec.ts
@@ -33,10 +33,17 @@ describe('GetMcpPromptUseCase', () => {
   let loggerErrorSpy: jest.SpyInstance;
 
   const mockOrgId = 'org-123' as UUID;
+  const mockUserId = 'user-789' as UUID;
   const mockIntegrationId = 'integration-456' as UUID;
   const mockPromptName = 'test-prompt';
 
-  beforeAll(async () => {
+  const mockContextGet = (key?: string | symbol) => {
+    if (key === 'orgId') return mockOrgId;
+    if (key === 'userId') return mockUserId;
+    return undefined;
+  };
+
+  beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         GetMcpPromptUseCase,
@@ -110,7 +117,7 @@ describe('GetMcpPromptUseCase', () => {
         description: 'Test prompt description',
       };
 
-      jest.spyOn(contextService, 'get').mockReturnValue(mockOrgId);
+      jest.spyOn(contextService, 'get').mockImplementation(mockContextGet);
       jest.spyOn(repository, 'findById').mockResolvedValue(mockIntegration);
       jest.spyOn(registryService, 'getConfig').mockReturnValue({
         slug: PredefinedMcpIntegrationSlug.TEST,
@@ -146,6 +153,7 @@ describe('GetMcpPromptUseCase', () => {
         mockIntegration,
         mockPromptName,
         mockArguments,
+        mockUserId,
       );
       expect(loggerLogSpy).toHaveBeenCalledWith('getMcpPrompt', {
         id: mockIntegrationId,
@@ -175,7 +183,7 @@ describe('GetMcpPromptUseCase', () => {
         messages: [{ role: 'user', content: { text: 'Hello' } }],
       };
 
-      jest.spyOn(contextService, 'get').mockReturnValue(mockOrgId);
+      jest.spyOn(contextService, 'get').mockImplementation(mockContextGet);
       jest.spyOn(repository, 'findById').mockResolvedValue(mockIntegration);
       jest
         .spyOn(mcpClientService, 'getPrompt')
@@ -195,6 +203,7 @@ describe('GetMcpPromptUseCase', () => {
         mockIntegration,
         mockPromptName,
         {},
+        mockUserId,
       );
     });
 
@@ -217,7 +226,7 @@ describe('GetMcpPromptUseCase', () => {
         messages: [{ role: 'user', content: { text: 'Hello' } }],
       };
 
-      jest.spyOn(contextService, 'get').mockReturnValue(mockOrgId);
+      jest.spyOn(contextService, 'get').mockImplementation(mockContextGet);
       jest.spyOn(repository, 'findById').mockResolvedValue(mockIntegration);
       jest
         .spyOn(mcpClientService, 'getPrompt')
@@ -233,12 +242,13 @@ describe('GetMcpPromptUseCase', () => {
         mockIntegration,
         mockPromptName,
         {},
+        mockUserId,
       );
     });
 
     it('should throw McpIntegrationNotFoundError when integration does not exist', async () => {
       // Arrange
-      jest.spyOn(contextService, 'get').mockReturnValue(mockOrgId);
+      jest.spyOn(contextService, 'get').mockImplementation(mockContextGet);
       jest.spyOn(repository, 'findById').mockResolvedValue(null);
 
       const query = new GetMcpPromptQuery(mockIntegrationId, mockPromptName);
@@ -266,7 +276,7 @@ describe('GetMcpPromptUseCase', () => {
         updatedAt: new Date(),
       });
 
-      jest.spyOn(contextService, 'get').mockReturnValue(mockOrgId);
+      jest.spyOn(contextService, 'get').mockImplementation(mockContextGet);
       jest.spyOn(repository, 'findById').mockResolvedValue(mockIntegration);
 
       const query = new GetMcpPromptQuery(mockIntegrationId, mockPromptName);
@@ -293,7 +303,7 @@ describe('GetMcpPromptUseCase', () => {
         updatedAt: new Date(),
       });
 
-      jest.spyOn(contextService, 'get').mockReturnValue(mockOrgId);
+      jest.spyOn(contextService, 'get').mockImplementation(mockContextGet);
       jest.spyOn(repository, 'findById').mockResolvedValue(mockIntegration);
 
       const query = new GetMcpPromptQuery(mockIntegrationId, mockPromptName);
@@ -308,7 +318,7 @@ describe('GetMcpPromptUseCase', () => {
 
     it('should throw UnauthorizedException when user is not authenticated', async () => {
       // Arrange
-      jest.spyOn(contextService, 'get').mockReturnValue(undefined);
+      jest.spyOn(contextService, 'get').mockImplementation(() => undefined);
 
       const query = new GetMcpPromptQuery(mockIntegrationId, mockPromptName);
 
@@ -339,7 +349,7 @@ describe('GetMcpPromptUseCase', () => {
         messages: [{ role: 'user', content: { text: 'Hello' } }],
       };
 
-      jest.spyOn(contextService, 'get').mockReturnValue(mockOrgId);
+      jest.spyOn(contextService, 'get').mockImplementation(mockContextGet);
       jest.spyOn(repository, 'findById').mockResolvedValue(mockIntegration);
       jest.spyOn(registryService, 'getConfig').mockReturnValue({
         slug: PredefinedMcpIntegrationSlug.TEST,
@@ -379,7 +389,7 @@ describe('GetMcpPromptUseCase', () => {
         updatedAt: new Date(),
       });
 
-      jest.spyOn(contextService, 'get').mockReturnValue(mockOrgId);
+      jest.spyOn(contextService, 'get').mockImplementation(mockContextGet);
       jest.spyOn(repository, 'findById').mockResolvedValue(mockIntegration);
       jest.spyOn(registryService, 'getConfig').mockReturnValue({
         slug: PredefinedMcpIntegrationSlug.TEST,
@@ -424,7 +434,7 @@ describe('GetMcpPromptUseCase', () => {
         ],
       };
 
-      jest.spyOn(contextService, 'get').mockReturnValue(mockOrgId);
+      jest.spyOn(contextService, 'get').mockImplementation(mockContextGet);
       jest.spyOn(repository, 'findById').mockResolvedValue(mockIntegration);
       jest.spyOn(registryService, 'getConfig').mockReturnValue({
         slug: PredefinedMcpIntegrationSlug.TEST,

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/get-mcp-prompt/get-mcp-prompt.use-case.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/get-mcp-prompt/get-mcp-prompt.use-case.ts
@@ -67,10 +67,12 @@ export class GetMcpPromptUseCase {
       }
 
       // Retrieve prompt from MCP server
+      const userId = this.contextService.get('userId');
       const promptResponse = await this.mcpClientService.getPrompt(
         integration,
         query.promptName,
         query.args || {},
+        userId,
       );
 
       this.logger.log('promptRetrieved', {

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/get-user-mcp-config/get-user-mcp-config.query.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/get-user-mcp-config/get-user-mcp-config.query.ts
@@ -1,0 +1,5 @@
+import { UUID } from 'crypto';
+
+export class GetUserMcpConfigQuery {
+  constructor(public readonly integrationId: UUID) {}
+}

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/get-user-mcp-config/get-user-mcp-config.query.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/get-user-mcp-config/get-user-mcp-config.query.ts
@@ -1,4 +1,4 @@
-import { UUID } from 'crypto';
+import type { UUID } from 'crypto';
 
 export class GetUserMcpConfigQuery {
   constructor(public readonly integrationId: UUID) {}

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/get-user-mcp-config/get-user-mcp-config.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/get-user-mcp-config/get-user-mcp-config.use-case.spec.ts
@@ -1,0 +1,76 @@
+import { GetUserMcpConfigUseCase } from './get-user-mcp-config.use-case';
+import { GetUserMcpConfigQuery } from './get-user-mcp-config.query';
+import { McpIntegrationUserConfigRepositoryPort } from '../../ports/mcp-integration-user-config.repository.port';
+import { ContextService } from 'src/common/context/services/context.service';
+import { McpIntegrationUserConfig } from '../../../domain/mcp-integration-user-config.entity';
+import { UUID } from 'crypto';
+
+describe('GetUserMcpConfigUseCase', () => {
+  let useCase: GetUserMcpConfigUseCase;
+  let userConfigRepository: jest.Mocked<McpIntegrationUserConfigRepositoryPort>;
+  let contextService: jest.Mocked<ContextService>;
+
+  const userId = '770e8400-e29b-41d4-a716-446655440001' as UUID;
+  const integrationId = '550e8400-e29b-41d4-a716-446655440000' as UUID;
+
+  beforeEach(() => {
+    userConfigRepository = {
+      save: jest.fn(),
+      findByIntegrationAndUser: jest.fn(),
+      deleteByIntegrationId: jest.fn(),
+    } as jest.Mocked<McpIntegrationUserConfigRepositoryPort>;
+
+    contextService = {
+      get: jest.fn(),
+    } as unknown as jest.Mocked<ContextService>;
+
+    contextService.get.mockReturnValue(userId);
+
+    useCase = new GetUserMcpConfigUseCase(userConfigRepository, contextService);
+  });
+
+  it('should return masked config values when user config exists', async () => {
+    const userConfig = new McpIntegrationUserConfig({
+      integrationId,
+      userId,
+      configValues: {
+        personalToken: 'encrypted:my-secret-token',
+        tenantId: 'my-tenant-123',
+      },
+    });
+    userConfigRepository.findByIntegrationAndUser.mockResolvedValue(userConfig);
+
+    const result = await useCase.execute(
+      new GetUserMcpConfigQuery(integrationId),
+    );
+
+    expect(result.hasConfig).toBe(true);
+    expect(result.configValues).toEqual({
+      personalToken: '***',
+      tenantId: '***',
+    });
+    expect(userConfigRepository.findByIntegrationAndUser).toHaveBeenCalledWith(
+      integrationId,
+      userId,
+    );
+  });
+
+  it('should return empty result when no user config exists', async () => {
+    userConfigRepository.findByIntegrationAndUser.mockResolvedValue(null);
+
+    const result = await useCase.execute(
+      new GetUserMcpConfigQuery(integrationId),
+    );
+
+    expect(result.hasConfig).toBe(false);
+    expect(result.configValues).toEqual({});
+  });
+
+  it('should throw when user is not authenticated', async () => {
+    contextService.get.mockReturnValue(undefined);
+
+    await expect(
+      useCase.execute(new GetUserMcpConfigQuery(integrationId)),
+    ).rejects.toThrow('User not authenticated');
+  });
+});

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/get-user-mcp-config/get-user-mcp-config.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/get-user-mcp-config/get-user-mcp-config.use-case.spec.ts
@@ -1,19 +1,70 @@
 import { GetUserMcpConfigUseCase } from './get-user-mcp-config.use-case';
 import { GetUserMcpConfigQuery } from './get-user-mcp-config.query';
+import { McpIntegrationsRepositoryPort } from '../../ports/mcp-integrations.repository.port';
 import { McpIntegrationUserConfigRepositoryPort } from '../../ports/mcp-integration-user-config.repository.port';
 import { ContextService } from 'src/common/context/services/context.service';
 import { McpIntegrationUserConfig } from '../../../domain/mcp-integration-user-config.entity';
+import { MarketplaceMcpIntegration } from '../../../domain/integrations/marketplace-mcp-integration.entity';
+import { NoAuthMcpIntegrationAuth } from '../../../domain/auth/no-auth-mcp-integration-auth.entity';
+import {
+  McpIntegrationNotFoundError,
+  McpIntegrationAccessDeniedError,
+} from '../../mcp.errors';
 import { UUID } from 'crypto';
 
 describe('GetUserMcpConfigUseCase', () => {
   let useCase: GetUserMcpConfigUseCase;
+  let integrationRepository: jest.Mocked<McpIntegrationsRepositoryPort>;
   let userConfigRepository: jest.Mocked<McpIntegrationUserConfigRepositoryPort>;
   let contextService: jest.Mocked<ContextService>;
 
   const userId = '770e8400-e29b-41d4-a716-446655440001' as UUID;
+  const orgId = '660e8400-e29b-41d4-a716-446655440001' as UUID;
   const integrationId = '550e8400-e29b-41d4-a716-446655440000' as UUID;
 
+  const createMarketplaceIntegration = (overrideOrgId?: UUID) =>
+    new MarketplaceMcpIntegration({
+      id: integrationId,
+      orgId: overrideOrgId ?? orgId,
+      name: 'Locaboo Booking',
+      serverUrl: 'https://mcp.ayunis.de/locaboo',
+      auth: new NoAuthMcpIntegrationAuth({}),
+      marketplaceIdentifier: 'locaboo-booking',
+      configSchema: {
+        authType: 'BEARER_TOKEN',
+        orgFields: [],
+        userFields: [
+          {
+            key: 'personalToken',
+            type: 'secret' as const,
+            label: 'Personal Access Token',
+            headerName: 'Authorization',
+            prefix: 'Bearer ',
+            required: false,
+          },
+          {
+            key: 'tenantId',
+            type: 'text' as const,
+            label: 'Tenant ID',
+            headerName: 'X-Tenant-Id',
+            required: false,
+          },
+        ],
+      },
+      orgConfigValues: {},
+    });
+
   beforeEach(() => {
+    integrationRepository = {
+      save: jest.fn(),
+      findById: jest.fn(),
+      findByIds: jest.fn(),
+      findAll: jest.fn(),
+      findByOrgIdAndSlug: jest.fn(),
+      findByOrgIdAndMarketplaceIdentifier: jest.fn(),
+      delete: jest.fn(),
+    } as jest.Mocked<McpIntegrationsRepositoryPort>;
+
     userConfigRepository = {
       save: jest.fn(),
       findByIntegrationAndUser: jest.fn(),
@@ -24,12 +75,24 @@ describe('GetUserMcpConfigUseCase', () => {
       get: jest.fn(),
     } as unknown as jest.Mocked<ContextService>;
 
-    contextService.get.mockReturnValue(userId);
+    contextService.get.mockImplementation((key?: string | symbol) => {
+      if (key === 'userId') return userId;
+      if (key === 'orgId') return orgId;
+      return undefined;
+    });
 
-    useCase = new GetUserMcpConfigUseCase(userConfigRepository, contextService);
+    integrationRepository.findById.mockResolvedValue(
+      createMarketplaceIntegration(),
+    );
+
+    useCase = new GetUserMcpConfigUseCase(
+      integrationRepository,
+      userConfigRepository,
+      contextService,
+    );
   });
 
-  it('should return masked config values when user config exists', async () => {
+  it('should mask only secret fields and return non-secret values as-is', async () => {
     const userConfig = new McpIntegrationUserConfig({
       integrationId,
       userId,
@@ -47,7 +110,7 @@ describe('GetUserMcpConfigUseCase', () => {
     expect(result.hasConfig).toBe(true);
     expect(result.configValues).toEqual({
       personalToken: '***',
-      tenantId: '***',
+      tenantId: 'my-tenant-123',
     });
     expect(userConfigRepository.findByIntegrationAndUser).toHaveBeenCalledWith(
       integrationId,
@@ -64,6 +127,25 @@ describe('GetUserMcpConfigUseCase', () => {
 
     expect(result.hasConfig).toBe(false);
     expect(result.configValues).toEqual({});
+  });
+
+  it('should throw McpIntegrationNotFoundError when integration does not exist', async () => {
+    integrationRepository.findById.mockResolvedValue(null);
+
+    await expect(
+      useCase.execute(new GetUserMcpConfigQuery(integrationId)),
+    ).rejects.toThrow(McpIntegrationNotFoundError);
+  });
+
+  it('should throw McpIntegrationAccessDeniedError when integration belongs to a different org', async () => {
+    const differentOrgId = '990e8400-e29b-41d4-a716-446655440099' as UUID;
+    integrationRepository.findById.mockResolvedValue(
+      createMarketplaceIntegration(differentOrgId),
+    );
+
+    await expect(
+      useCase.execute(new GetUserMcpConfigQuery(integrationId)),
+    ).rejects.toThrow(McpIntegrationAccessDeniedError);
   });
 
   it('should throw when user is not authenticated', async () => {

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/get-user-mcp-config/get-user-mcp-config.use-case.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/get-user-mcp-config/get-user-mcp-config.use-case.ts
@@ -1,0 +1,46 @@
+import { Injectable, Logger, UnauthorizedException } from '@nestjs/common';
+import { GetUserMcpConfigQuery } from './get-user-mcp-config.query';
+import { McpIntegrationUserConfigRepositoryPort } from '../../ports/mcp-integration-user-config.repository.port';
+import { ContextService } from 'src/common/context/services/context.service';
+
+export interface UserMcpConfigResult {
+  hasConfig: boolean;
+  /** Config values with secret values masked (keys only, values replaced with '***') */
+  configValues: Record<string, string>;
+}
+
+@Injectable()
+export class GetUserMcpConfigUseCase {
+  private readonly logger = new Logger(GetUserMcpConfigUseCase.name);
+
+  constructor(
+    private readonly userConfigRepository: McpIntegrationUserConfigRepositoryPort,
+    private readonly contextService: ContextService,
+  ) {}
+
+  async execute(query: GetUserMcpConfigQuery): Promise<UserMcpConfigResult> {
+    this.logger.log('execute', { integrationId: query.integrationId });
+
+    const userId = this.contextService.get('userId');
+    if (!userId) {
+      throw new UnauthorizedException('User not authenticated');
+    }
+
+    const config = await this.userConfigRepository.findByIntegrationAndUser(
+      query.integrationId,
+      userId,
+    );
+
+    if (!config) {
+      return { hasConfig: false, configValues: {} };
+    }
+
+    // Return keys with masked values — never expose secrets
+    const maskedValues: Record<string, string> = {};
+    for (const key of Object.keys(config.configValues)) {
+      maskedValues[key] = '***';
+    }
+
+    return { hasConfig: true, configValues: maskedValues };
+  }
+}

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/install-marketplace-integration/install-marketplace-integration.command.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/install-marketplace-integration/install-marketplace-integration.command.ts
@@ -1,0 +1,7 @@
+export class InstallMarketplaceIntegrationCommand {
+  constructor(
+    public readonly identifier: string,
+    public readonly orgConfigValues: Record<string, string>,
+    public readonly returnsPii?: boolean,
+  ) {}
+}

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/install-marketplace-integration/install-marketplace-integration.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/install-marketplace-integration/install-marketplace-integration.use-case.spec.ts
@@ -3,6 +3,7 @@ import { InstallMarketplaceIntegrationCommand } from './install-marketplace-inte
 import { GetMarketplaceIntegrationUseCase } from 'src/domain/marketplace/application/use-cases/get-marketplace-integration/get-marketplace-integration.use-case';
 import { McpIntegrationsRepositoryPort } from '../../ports/mcp-integrations.repository.port';
 import { McpCredentialEncryptionPort } from '../../ports/mcp-credential-encryption.port';
+import { MarketplaceConfigService } from '../../services/marketplace-config.service';
 import { McpIntegrationFactory } from '../../factories/mcp-integration.factory';
 import { McpIntegrationAuthFactory } from '../../factories/mcp-integration-auth.factory';
 import { ValidateMcpIntegrationUseCase } from '../validate-mcp-integration/validate-mcp-integration.use-case';
@@ -24,6 +25,7 @@ describe('InstallMarketplaceIntegrationUseCase', () => {
   let getMarketplaceIntegrationUseCase: jest.Mocked<GetMarketplaceIntegrationUseCase>;
   let repository: jest.Mocked<McpIntegrationsRepositoryPort>;
   let credentialEncryption: jest.Mocked<McpCredentialEncryptionPort>;
+  let marketplaceConfigService: MarketplaceConfigService;
   let factory: McpIntegrationFactory;
   let authFactory: McpIntegrationAuthFactory;
   let validateUseCase: jest.Mocked<ValidateMcpIntegrationUseCase>;
@@ -151,10 +153,14 @@ describe('InstallMarketplaceIntegrationUseCase', () => {
       promptCount: 0,
     });
 
+    marketplaceConfigService = new MarketplaceConfigService(
+      credentialEncryption,
+    );
+
     useCase = new InstallMarketplaceIntegrationUseCase(
       getMarketplaceIntegrationUseCase,
       repository,
-      credentialEncryption,
+      marketplaceConfigService,
       factory,
       authFactory,
       validateUseCase,

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/install-marketplace-integration/install-marketplace-integration.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/install-marketplace-integration/install-marketplace-integration.use-case.spec.ts
@@ -34,9 +34,12 @@ describe('InstallMarketplaceIntegrationUseCase', () => {
     id: '550e8400-e29b-41d4-a716-446655440000',
     identifier: 'oparl-council-data',
     name: 'OParl Council Data',
+    shortDescription: 'Access municipal council data',
     description: 'Access municipal council data via OParl',
     iconUrl: 'https://marketplace.ayunis.de/icons/oparl.png',
     serverUrl: 'https://mcp.ayunis.de/oparl',
+    featured: false,
+    preInstalled: false,
     configSchema: {
       authType: 'NO_AUTH',
       orgFields: [

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/install-marketplace-integration/install-marketplace-integration.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/install-marketplace-integration/install-marketplace-integration.use-case.spec.ts
@@ -7,6 +7,7 @@ import { MarketplaceConfigService } from '../../services/marketplace-config.serv
 import { McpIntegrationFactory } from '../../factories/mcp-integration.factory';
 import { McpIntegrationAuthFactory } from '../../factories/mcp-integration-auth.factory';
 import { ValidateMcpIntegrationUseCase } from '../validate-mcp-integration/validate-mcp-integration.use-case';
+import { ConnectionValidationService } from '../../services/connection-validation.service';
 import { ContextService } from 'src/common/context/services/context.service';
 import { MarketplaceMcpIntegration } from '../../../domain/integrations/marketplace-mcp-integration.entity';
 import { NoAuthMcpIntegrationAuth } from '../../../domain/auth/no-auth-mcp-integration-auth.entity';
@@ -29,6 +30,7 @@ describe('InstallMarketplaceIntegrationUseCase', () => {
   let factory: McpIntegrationFactory;
   let authFactory: McpIntegrationAuthFactory;
   let validateUseCase: jest.Mocked<ValidateMcpIntegrationUseCase>;
+  let connectionValidationService: ConnectionValidationService;
   let contextService: jest.Mocked<ContextService>;
 
   const orgId = '660e8400-e29b-41d4-a716-446655440001' as UUID;
@@ -156,6 +158,10 @@ describe('InstallMarketplaceIntegrationUseCase', () => {
     marketplaceConfigService = new MarketplaceConfigService(
       credentialEncryption,
     );
+    connectionValidationService = new ConnectionValidationService(
+      validateUseCase,
+      repository,
+    );
 
     useCase = new InstallMarketplaceIntegrationUseCase(
       getMarketplaceIntegrationUseCase,
@@ -163,7 +169,7 @@ describe('InstallMarketplaceIntegrationUseCase', () => {
       marketplaceConfigService,
       factory,
       authFactory,
-      validateUseCase,
+      connectionValidationService,
       contextService,
     );
   });

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/install-marketplace-integration/install-marketplace-integration.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/install-marketplace-integration/install-marketplace-integration.use-case.spec.ts
@@ -1,14 +1,14 @@
 import { InstallMarketplaceIntegrationUseCase } from './install-marketplace-integration.use-case';
 import { InstallMarketplaceIntegrationCommand } from './install-marketplace-integration.command';
-import { GetMarketplaceIntegrationUseCase } from 'src/domain/marketplace/application/use-cases/get-marketplace-integration/get-marketplace-integration.use-case';
-import { McpIntegrationsRepositoryPort } from '../../ports/mcp-integrations.repository.port';
-import { McpCredentialEncryptionPort } from '../../ports/mcp-credential-encryption.port';
+import type { GetMarketplaceIntegrationUseCase } from 'src/domain/marketplace/application/use-cases/get-marketplace-integration/get-marketplace-integration.use-case';
+import type { McpIntegrationsRepositoryPort } from '../../ports/mcp-integrations.repository.port';
+import type { McpCredentialEncryptionPort } from '../../ports/mcp-credential-encryption.port';
 import { MarketplaceConfigService } from '../../services/marketplace-config.service';
 import { McpIntegrationFactory } from '../../factories/mcp-integration.factory';
 import { McpIntegrationAuthFactory } from '../../factories/mcp-integration-auth.factory';
-import { ValidateMcpIntegrationUseCase } from '../validate-mcp-integration/validate-mcp-integration.use-case';
+import type { ValidateMcpIntegrationUseCase } from '../validate-mcp-integration/validate-mcp-integration.use-case';
 import { ConnectionValidationService } from '../../services/connection-validation.service';
-import { ContextService } from 'src/common/context/services/context.service';
+import type { ContextService } from 'src/common/context/services/context.service';
 import { MarketplaceMcpIntegration } from '../../../domain/integrations/marketplace-mcp-integration.entity';
 import { NoAuthMcpIntegrationAuth } from '../../../domain/auth/no-auth-mcp-integration-auth.entity';
 import { McpIntegrationKind } from '../../../domain/value-objects/mcp-integration-kind.enum';
@@ -18,8 +18,8 @@ import {
   DuplicateMarketplaceMcpIntegrationError,
 } from '../../mcp.errors';
 import { MarketplaceIntegrationNotFoundError } from 'src/domain/marketplace/application/marketplace.errors';
-import { IntegrationResponseDto } from 'src/common/clients/marketplace/generated/ayunisMarketplaceAPI.schemas';
-import { UUID } from 'crypto';
+import type { IntegrationResponseDto } from 'src/common/clients/marketplace/generated/ayunisMarketplaceAPI.schemas';
+import type { UUID } from 'crypto';
 
 describe('InstallMarketplaceIntegrationUseCase', () => {
   let useCase: InstallMarketplaceIntegrationUseCase;

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/install-marketplace-integration/install-marketplace-integration.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/install-marketplace-integration/install-marketplace-integration.use-case.spec.ts
@@ -1,0 +1,355 @@
+import { InstallMarketplaceIntegrationUseCase } from './install-marketplace-integration.use-case';
+import { InstallMarketplaceIntegrationCommand } from './install-marketplace-integration.command';
+import { MarketplaceClient } from 'src/domain/marketplace/application/ports/marketplace-client.port';
+import { McpIntegrationsRepositoryPort } from '../../ports/mcp-integrations.repository.port';
+import { McpCredentialEncryptionPort } from '../../ports/mcp-credential-encryption.port';
+import { McpIntegrationFactory } from '../../factories/mcp-integration.factory';
+import { McpIntegrationAuthFactory } from '../../factories/mcp-integration-auth.factory';
+import { ValidateMcpIntegrationUseCase } from '../validate-mcp-integration/validate-mcp-integration.use-case';
+import { ContextService } from 'src/common/context/services/context.service';
+import { MarketplaceMcpIntegration } from '../../../domain/integrations/marketplace-mcp-integration.entity';
+import { NoAuthMcpIntegrationAuth } from '../../../domain/auth/no-auth-mcp-integration-auth.entity';
+import { McpIntegrationKind } from '../../../domain/value-objects/mcp-integration-kind.enum';
+import {
+  McpOAuthNotSupportedError,
+  McpMissingRequiredConfigError,
+  McpMarketplaceIntegrationNotFoundError,
+} from '../../mcp.errors';
+import { IntegrationResponseDto } from 'src/common/clients/marketplace/generated/ayunisMarketplaceAPI.schemas';
+import { UUID } from 'crypto';
+
+describe('InstallMarketplaceIntegrationUseCase', () => {
+  let useCase: InstallMarketplaceIntegrationUseCase;
+  let marketplaceClient: jest.Mocked<MarketplaceClient>;
+  let repository: jest.Mocked<McpIntegrationsRepositoryPort>;
+  let credentialEncryption: jest.Mocked<McpCredentialEncryptionPort>;
+  let factory: McpIntegrationFactory;
+  let authFactory: McpIntegrationAuthFactory;
+  let validateUseCase: jest.Mocked<ValidateMcpIntegrationUseCase>;
+  let contextService: jest.Mocked<ContextService>;
+
+  const orgId = '660e8400-e29b-41d4-a716-446655440001' as UUID;
+
+  const oparlMarketplaceResponse: IntegrationResponseDto = {
+    id: '550e8400-e29b-41d4-a716-446655440000',
+    identifier: 'oparl-council-data',
+    name: 'OParl Council Data',
+    description: 'Access municipal council data via OParl',
+    iconUrl: 'https://marketplace.ayunis.de/icons/oparl.png',
+    serverUrl: 'https://mcp.ayunis.de/oparl',
+    configSchema: {
+      authType: 'NO_AUTH',
+      orgFields: [
+        {
+          key: 'oparlEndpointUrl',
+          type: 'url' as const,
+          label: 'OParl Endpoint URL',
+          headerName: 'X-Oparl-Endpoint-Url',
+          prefix: null,
+          required: true,
+          help: "Your municipality's OParl endpoint",
+          value: null,
+        },
+      ],
+      userFields: [],
+    },
+    published: true,
+    createdAt: '2026-01-15T10:00:00.000Z',
+    updatedAt: '2026-02-10T14:30:00.000Z',
+  };
+
+  const bearerWithFixedValueResponse: IntegrationResponseDto = {
+    ...oparlMarketplaceResponse,
+    identifier: 'fixed-auth-integration',
+    name: 'Fixed Auth Integration',
+    serverUrl: 'https://mcp.ayunis.de/fixed',
+    configSchema: {
+      authType: 'BEARER_TOKEN',
+      orgFields: [
+        {
+          key: 'authToken',
+          type: 'secret' as const,
+          label: 'API Token',
+          headerName: 'Authorization',
+          prefix: 'Bearer ',
+          required: true,
+          help: null,
+          value: 'sk-fixed-token-we-control',
+        },
+      ],
+      userFields: [],
+    },
+  };
+
+  const oauthIntegrationResponse: IntegrationResponseDto = {
+    ...oparlMarketplaceResponse,
+    identifier: 'oauth-integration',
+    name: 'OAuth Integration',
+    configSchema: {
+      authType: 'OAUTH',
+      orgFields: [
+        {
+          key: 'clientId',
+          type: 'text' as const,
+          label: 'Client ID',
+          headerName: null,
+          prefix: null,
+          required: true,
+          help: null,
+          value: null,
+        },
+      ],
+      userFields: [],
+    },
+  };
+
+  beforeEach(() => {
+    marketplaceClient = {
+      getSkillByIdentifier: jest.fn(),
+      getIntegrationByIdentifier: jest.fn(),
+    } as jest.Mocked<MarketplaceClient>;
+
+    repository = {
+      save: jest.fn(),
+      findById: jest.fn(),
+      findByIds: jest.fn(),
+      findAll: jest.fn(),
+      findByOrgIdAndSlug: jest.fn(),
+      delete: jest.fn(),
+    } as jest.Mocked<McpIntegrationsRepositoryPort>;
+
+    credentialEncryption = {
+      encrypt: jest.fn(),
+      decrypt: jest.fn(),
+    } as jest.Mocked<McpCredentialEncryptionPort>;
+
+    factory = new McpIntegrationFactory();
+    authFactory = new McpIntegrationAuthFactory();
+
+    validateUseCase = {
+      execute: jest.fn(),
+    } as unknown as jest.Mocked<ValidateMcpIntegrationUseCase>;
+
+    contextService = {
+      get: jest.fn(),
+    } as unknown as jest.Mocked<ContextService>;
+
+    contextService.get.mockReturnValue(orgId);
+
+    repository.save.mockImplementation(async (integration) => integration);
+    credentialEncryption.encrypt.mockImplementation(
+      async (plaintext) => `encrypted:${plaintext}`,
+    );
+    validateUseCase.execute.mockResolvedValue({
+      isValid: true,
+      toolCount: 3,
+      resourceCount: 0,
+      promptCount: 0,
+    });
+
+    useCase = new InstallMarketplaceIntegrationUseCase(
+      marketplaceClient,
+      repository,
+      credentialEncryption,
+      factory,
+      authFactory,
+      validateUseCase,
+      contextService,
+    );
+  });
+
+  it('should install an integration with org config values', async () => {
+    marketplaceClient.getIntegrationByIdentifier.mockResolvedValue(
+      oparlMarketplaceResponse,
+    );
+
+    const result = await useCase.execute(
+      new InstallMarketplaceIntegrationCommand('oparl-council-data', {
+        oparlEndpointUrl: 'https://rim.ekom21.de/oparl/v1',
+      }),
+    );
+
+    expect(result).toBeInstanceOf(MarketplaceMcpIntegration);
+    expect(result.marketplaceIdentifier).toBe('oparl-council-data');
+    expect(result.name).toBe('OParl Council Data');
+    expect(result.serverUrl).toBe('https://mcp.ayunis.de/oparl');
+    expect(result.orgConfigValues).toEqual({
+      oparlEndpointUrl: 'https://rim.ekom21.de/oparl/v1',
+    });
+    expect(result.kind).toBe(McpIntegrationKind.MARKETPLACE);
+    expect(repository.save).toHaveBeenCalledTimes(2); // initial save + after validation
+  });
+
+  it('should merge fixed values from config schema', async () => {
+    marketplaceClient.getIntegrationByIdentifier.mockResolvedValue(
+      bearerWithFixedValueResponse,
+    );
+
+    const result = await useCase.execute(
+      new InstallMarketplaceIntegrationCommand('fixed-auth-integration', {}),
+    );
+
+    expect(result.orgConfigValues).toEqual({
+      authToken: 'encrypted:sk-fixed-token-we-control',
+    });
+    expect(credentialEncryption.encrypt).toHaveBeenCalledWith(
+      'sk-fixed-token-we-control',
+    );
+  });
+
+  it('should encrypt secret-type field values', async () => {
+    const integrationWithSecret: IntegrationResponseDto = {
+      ...oparlMarketplaceResponse,
+      identifier: 'secret-integration',
+      configSchema: {
+        authType: 'BEARER_TOKEN',
+        orgFields: [
+          {
+            key: 'apiToken',
+            type: 'secret' as const,
+            label: 'API Token',
+            headerName: 'Authorization',
+            prefix: 'Bearer ',
+            required: true,
+            help: null,
+            value: null,
+          },
+        ],
+        userFields: [],
+      },
+    };
+    marketplaceClient.getIntegrationByIdentifier.mockResolvedValue(
+      integrationWithSecret,
+    );
+
+    const result = await useCase.execute(
+      new InstallMarketplaceIntegrationCommand('secret-integration', {
+        apiToken: 'my-secret-token',
+      }),
+    );
+
+    expect(result.orgConfigValues).toEqual({
+      apiToken: 'encrypted:my-secret-token',
+    });
+  });
+
+  it('should not encrypt non-secret field values', async () => {
+    marketplaceClient.getIntegrationByIdentifier.mockResolvedValue(
+      oparlMarketplaceResponse,
+    );
+
+    const result = await useCase.execute(
+      new InstallMarketplaceIntegrationCommand('oparl-council-data', {
+        oparlEndpointUrl: 'https://rim.ekom21.de/oparl/v1',
+      }),
+    );
+
+    expect(result.orgConfigValues).toEqual({
+      oparlEndpointUrl: 'https://rim.ekom21.de/oparl/v1',
+    });
+    expect(credentialEncryption.encrypt).not.toHaveBeenCalled();
+  });
+
+  it('should reject OAUTH auth type', async () => {
+    marketplaceClient.getIntegrationByIdentifier.mockResolvedValue(
+      oauthIntegrationResponse,
+    );
+
+    await expect(
+      useCase.execute(
+        new InstallMarketplaceIntegrationCommand('oauth-integration', {
+          clientId: 'my-client',
+        }),
+      ),
+    ).rejects.toThrow(McpOAuthNotSupportedError);
+  });
+
+  it('should throw when required org fields are missing', async () => {
+    marketplaceClient.getIntegrationByIdentifier.mockResolvedValue(
+      oparlMarketplaceResponse,
+    );
+
+    await expect(
+      useCase.execute(
+        new InstallMarketplaceIntegrationCommand('oparl-council-data', {}),
+      ),
+    ).rejects.toThrow(McpMissingRequiredConfigError);
+  });
+
+  it('should throw when marketplace integration is not found', async () => {
+    marketplaceClient.getIntegrationByIdentifier.mockResolvedValue(null);
+
+    await expect(
+      useCase.execute(
+        new InstallMarketplaceIntegrationCommand('nonexistent', {}),
+      ),
+    ).rejects.toThrow(McpMarketplaceIntegrationNotFoundError);
+  });
+
+  it('should validate connection after saving and update status', async () => {
+    marketplaceClient.getIntegrationByIdentifier.mockResolvedValue(
+      oparlMarketplaceResponse,
+    );
+    validateUseCase.execute.mockResolvedValue({
+      isValid: false,
+      errorMessage: 'Connection refused',
+    });
+
+    const result = await useCase.execute(
+      new InstallMarketplaceIntegrationCommand('oparl-council-data', {
+        oparlEndpointUrl: 'https://rim.ekom21.de/oparl/v1',
+      }),
+    );
+
+    expect(validateUseCase.execute).toHaveBeenCalled();
+    // Integration still returned even if validation fails
+    expect(result).toBeInstanceOf(MarketplaceMcpIntegration);
+  });
+
+  it('should set returnsPii when provided', async () => {
+    marketplaceClient.getIntegrationByIdentifier.mockResolvedValue(
+      oparlMarketplaceResponse,
+    );
+
+    const result = await useCase.execute(
+      new InstallMarketplaceIntegrationCommand(
+        'oparl-council-data',
+        { oparlEndpointUrl: 'https://rim.ekom21.de/oparl/v1' },
+        true,
+      ),
+    );
+
+    expect(result.returnsPii).toBe(true);
+  });
+
+  it('should use NoAuth for the auth entity since auth is handled via config headers', async () => {
+    marketplaceClient.getIntegrationByIdentifier.mockResolvedValue(
+      oparlMarketplaceResponse,
+    );
+
+    const result = await useCase.execute(
+      new InstallMarketplaceIntegrationCommand('oparl-council-data', {
+        oparlEndpointUrl: 'https://rim.ekom21.de/oparl/v1',
+      }),
+    );
+
+    expect(result.auth).toBeInstanceOf(NoAuthMcpIntegrationAuth);
+  });
+
+  it('should fixed values take precedence over user-provided values', async () => {
+    marketplaceClient.getIntegrationByIdentifier.mockResolvedValue(
+      bearerWithFixedValueResponse,
+    );
+
+    const result = await useCase.execute(
+      new InstallMarketplaceIntegrationCommand('fixed-auth-integration', {
+        authToken: 'user-attempted-override',
+      }),
+    );
+
+    // Fixed value from marketplace should win
+    expect(result.orgConfigValues).toEqual({
+      authToken: 'encrypted:sk-fixed-token-we-control',
+    });
+  });
+});

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/install-marketplace-integration/install-marketplace-integration.use-case.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/install-marketplace-integration/install-marketplace-integration.use-case.ts
@@ -1,0 +1,214 @@
+import { Injectable, Logger, UnauthorizedException } from '@nestjs/common';
+import { InstallMarketplaceIntegrationCommand } from './install-marketplace-integration.command';
+import { MarketplaceClient } from 'src/domain/marketplace/application/ports/marketplace-client.port';
+import { McpIntegrationsRepositoryPort } from '../../ports/mcp-integrations.repository.port';
+import { McpCredentialEncryptionPort } from '../../ports/mcp-credential-encryption.port';
+import { McpIntegrationFactory } from '../../factories/mcp-integration.factory';
+import { McpIntegrationAuthFactory } from '../../factories/mcp-integration-auth.factory';
+import { ValidateMcpIntegrationUseCase } from '../validate-mcp-integration/validate-mcp-integration.use-case';
+import { ContextService } from 'src/common/context/services/context.service';
+import { McpIntegrationKind } from '../../../domain/value-objects/mcp-integration-kind.enum';
+import { McpAuthMethod } from '../../../domain/value-objects/mcp-auth-method.enum';
+import { MarketplaceMcpIntegration } from '../../../domain/integrations/marketplace-mcp-integration.entity';
+import {
+  IntegrationConfigSchema,
+  ConfigField,
+} from '../../../domain/value-objects/integration-config-schema';
+import { IntegrationConfigSchemaDto } from 'src/common/clients/marketplace/generated/ayunisMarketplaceAPI.schemas';
+import {
+  McpOAuthNotSupportedError,
+  McpMissingRequiredConfigError,
+  McpMarketplaceIntegrationNotFoundError,
+  UnexpectedMcpError,
+} from '../../mcp.errors';
+import { ApplicationError } from 'src/common/errors/base.error';
+
+@Injectable()
+export class InstallMarketplaceIntegrationUseCase {
+  private readonly logger = new Logger(
+    InstallMarketplaceIntegrationUseCase.name,
+  );
+
+  constructor(
+    private readonly marketplaceClient: MarketplaceClient,
+    private readonly repository: McpIntegrationsRepositoryPort,
+    private readonly credentialEncryption: McpCredentialEncryptionPort,
+    private readonly factory: McpIntegrationFactory,
+    private readonly authFactory: McpIntegrationAuthFactory,
+    private readonly validateUseCase: ValidateMcpIntegrationUseCase,
+    private readonly contextService: ContextService,
+  ) {}
+
+  async execute(
+    command: InstallMarketplaceIntegrationCommand,
+  ): Promise<MarketplaceMcpIntegration> {
+    this.logger.log('execute', { identifier: command.identifier });
+
+    const orgId = this.contextService.get('orgId');
+    if (!orgId) {
+      throw new UnauthorizedException('User not authenticated');
+    }
+
+    try {
+      const marketplaceIntegration =
+        await this.marketplaceClient.getIntegrationByIdentifier(
+          command.identifier,
+        );
+
+      if (!marketplaceIntegration) {
+        throw new McpMarketplaceIntegrationNotFoundError(command.identifier);
+      }
+
+      const configSchema = this.parseConfigSchema(
+        marketplaceIntegration.configSchema,
+      );
+
+      if (configSchema.authType === (McpAuthMethod.OAUTH as string)) {
+        throw new McpOAuthNotSupportedError();
+      }
+
+      const mergedValues = this.mergeFixedValues(
+        command.orgConfigValues,
+        configSchema.orgFields,
+      );
+
+      this.validateRequiredFields(configSchema.orgFields, mergedValues);
+
+      const encryptedValues = await this.encryptSecretFields(
+        configSchema.orgFields,
+        mergedValues,
+      );
+
+      const auth = this.authFactory.createAuth({
+        method: McpAuthMethod.NO_AUTH,
+      });
+
+      const integration = this.factory.createIntegration({
+        kind: McpIntegrationKind.MARKETPLACE,
+        orgId,
+        name: marketplaceIntegration.name,
+        serverUrl: marketplaceIntegration.serverUrl,
+        auth,
+        marketplaceIdentifier: command.identifier,
+        configSchema,
+        orgConfigValues: encryptedValues,
+        returnsPii: command.returnsPii,
+      });
+
+      const saved = await this.repository.save(integration);
+
+      await this.validateAndUpdateConnectionStatus(saved);
+
+      return saved;
+    } catch (error) {
+      if (
+        error instanceof ApplicationError ||
+        error instanceof UnauthorizedException
+      ) {
+        throw error;
+      }
+      this.logger.error('Unexpected error installing marketplace integration', {
+        identifier: command.identifier,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      });
+      throw new UnexpectedMcpError('Unexpected error occurred');
+    }
+  }
+
+  private parseConfigSchema(
+    dto: IntegrationConfigSchemaDto,
+  ): IntegrationConfigSchema {
+    return {
+      authType: dto.authType,
+      orgFields: dto.orgFields.map((f) => this.parseConfigField(f)),
+      userFields: dto.userFields.map((f) => this.parseConfigField(f)),
+    };
+  }
+
+  private parseConfigField(
+    field: IntegrationConfigSchemaDto['orgFields'][number],
+  ): ConfigField {
+    return {
+      key: field.key,
+      label: field.label,
+      type: field.type,
+      headerName: field.headerName ?? undefined,
+      prefix: field.prefix ?? undefined,
+      required: field.required,
+      help: field.help ?? undefined,
+      value: field.value ?? undefined,
+    };
+  }
+
+  private mergeFixedValues(
+    userProvided: Record<string, string>,
+    orgFields: ConfigField[],
+  ): Record<string, string> {
+    const merged = { ...userProvided };
+    for (const field of orgFields) {
+      if (field.value !== undefined) {
+        merged[field.key] = field.value;
+      }
+    }
+    return merged;
+  }
+
+  private validateRequiredFields(
+    orgFields: ConfigField[],
+    values: Record<string, string>,
+  ): void {
+    const missing = orgFields
+      .filter((field) => field.required && !values[field.key])
+      .map((field) => field.key);
+
+    if (missing.length > 0) {
+      throw new McpMissingRequiredConfigError(missing);
+    }
+  }
+
+  private async encryptSecretFields(
+    orgFields: ConfigField[],
+    values: Record<string, string>,
+  ): Promise<Record<string, string>> {
+    const encrypted = { ...values };
+    const secretKeys = new Set(
+      orgFields.filter((f) => f.type === 'secret').map((f) => f.key),
+    );
+
+    for (const key of Object.keys(encrypted)) {
+      if (secretKeys.has(key)) {
+        encrypted[key] = await this.credentialEncryption.encrypt(
+          encrypted[key],
+        );
+      }
+    }
+    return encrypted;
+  }
+
+  private async validateAndUpdateConnectionStatus(
+    integration: MarketplaceMcpIntegration,
+  ): Promise<void> {
+    try {
+      const validationResult = await this.validateUseCase.execute({
+        integrationId: integration.id,
+      });
+
+      if (validationResult.isValid) {
+        integration.updateConnectionStatus('healthy', undefined);
+      } else {
+        integration.updateConnectionStatus(
+          'unhealthy',
+          validationResult.errorMessage ?? 'Validation failed',
+        );
+      }
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error
+          ? `Validation failed: ${error.message}`
+          : 'Validation failed: Unknown error';
+      integration.updateConnectionStatus('unhealthy', errorMessage);
+    }
+
+    await this.repository.save(integration);
+  }
+}

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/install-marketplace-integration/install-marketplace-integration.use-case.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/install-marketplace-integration/install-marketplace-integration.use-case.ts
@@ -133,9 +133,10 @@ export class InstallMarketplaceIntegrationUseCase {
 
       const saved = await this.repository.save(integration);
 
-      await this.connectionValidationService.validateAndUpdateStatus(saved);
+      const validated =
+        await this.connectionValidationService.validateAndUpdateStatus(saved);
 
-      return saved;
+      return validated as MarketplaceMcpIntegration;
     } catch (error) {
       if (
         error instanceof ApplicationError ||

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/install-marketplace-integration/install-marketplace-integration.use-case.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/install-marketplace-integration/install-marketplace-integration.use-case.ts
@@ -14,7 +14,35 @@ import {
   IntegrationConfigSchema,
   ConfigField,
 } from '../../../domain/value-objects/integration-config-schema';
-import { IntegrationConfigSchemaDto } from 'src/common/clients/marketplace/generated/ayunisMarketplaceAPI.schemas';
+import { IntegrationResponseDtoConfigSchema } from 'src/common/clients/marketplace/generated/ayunisMarketplaceAPI.schemas';
+
+/**
+ * Runtime shape of the configSchema returned by the marketplace API.
+ * The OpenAPI spec declares this as a generic object, so we cast at the boundary.
+ */
+interface MarketplaceConfigSchemaDto {
+  authType: string;
+  orgFields: Array<{
+    key: string;
+    label: string;
+    type: 'text' | 'url' | 'secret';
+    headerName: string | null;
+    prefix: string | null;
+    required: boolean;
+    help: string | null;
+    value: string | null;
+  }>;
+  userFields: Array<{
+    key: string;
+    label: string;
+    type: 'text' | 'url' | 'secret';
+    headerName: string | null;
+    prefix: string | null;
+    required: boolean;
+    help: string | null;
+    value: string | null;
+  }>;
+}
 import {
   McpOAuthNotSupportedError,
   McpMissingRequiredConfigError,
@@ -116,17 +144,18 @@ export class InstallMarketplaceIntegrationUseCase {
   }
 
   private parseConfigSchema(
-    dto: IntegrationConfigSchemaDto,
+    dto: IntegrationResponseDtoConfigSchema,
   ): IntegrationConfigSchema {
+    const schema = dto as unknown as MarketplaceConfigSchemaDto;
     return {
-      authType: dto.authType,
-      orgFields: dto.orgFields.map((f) => this.parseConfigField(f)),
-      userFields: dto.userFields.map((f) => this.parseConfigField(f)),
+      authType: schema.authType,
+      orgFields: schema.orgFields.map((f) => this.parseConfigField(f)),
+      userFields: schema.userFields.map((f) => this.parseConfigField(f)),
     };
   }
 
   private parseConfigField(
-    field: IntegrationConfigSchemaDto['orgFields'][number],
+    field: MarketplaceConfigSchemaDto['orgFields'][number],
   ): ConfigField {
     return {
       key: field.key,

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/list-org-mcp-integrations/list-org-mcp-integrations.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/list-org-mcp-integrations/list-org-mcp-integrations.use-case.spec.ts
@@ -31,6 +31,7 @@ describe('ListOrgMcpIntegrationsUseCase', () => {
       findById: jest.fn(),
       findAll: jest.fn(),
       findByOrgIdAndSlug: jest.fn(),
+      findByOrgIdAndMarketplaceIdentifier: jest.fn(),
       delete: jest.fn(),
     };
 

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/retrieve-mcp-resource/retrieve-mcp-resource.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/retrieve-mcp-resource/retrieve-mcp-resource.use-case.spec.ts
@@ -28,6 +28,7 @@ describe('RetrieveMcpResourceUseCase', () => {
   let loggerErrorSpy: jest.SpyInstance;
 
   const mockOrgId = randomUUID();
+  const mockUserId = randomUUID();
   const mockIntegrationId = randomUUID();
   const mockResourceUri = 'dataset://sales-data.csv';
 
@@ -95,7 +96,11 @@ describe('RetrieveMcpResourceUseCase', () => {
       const integration = buildIntegration();
       const mockResponse = { content: 'file-content', mimeType: 'text/plain' };
 
-      contextService.get.mockReturnValue(mockOrgId);
+      contextService.get.mockImplementation((key?: string | symbol) => {
+        if (key === 'orgId') return mockOrgId;
+        if (key === 'userId') return mockUserId;
+        return undefined;
+      });
       repository.findById.mockResolvedValue(integration);
       mcpClientService.readResource.mockResolvedValue(mockResponse);
 
@@ -108,6 +113,7 @@ describe('RetrieveMcpResourceUseCase', () => {
         integration,
         mockResourceUri,
         undefined,
+        mockUserId,
       );
       expect(loggerLogSpy).toHaveBeenCalledWith('retrieveMcpResource', {
         integrationId: mockIntegrationId,
@@ -116,11 +122,15 @@ describe('RetrieveMcpResourceUseCase', () => {
       });
     });
 
-    it('passes parameters through to client service', async () => {
+    it('passes parameters through to client service with userId', async () => {
       const integration = buildIntegration();
       const parameters = { id: '123', locale: 'en' };
 
-      contextService.get.mockReturnValue(mockOrgId);
+      contextService.get.mockImplementation((key?: string | symbol) => {
+        if (key === 'orgId') return mockOrgId;
+        if (key === 'userId') return mockUserId;
+        return undefined;
+      });
       repository.findById.mockResolvedValue(integration);
       mcpClientService.readResource.mockResolvedValue({
         content: { data: true },
@@ -139,6 +149,7 @@ describe('RetrieveMcpResourceUseCase', () => {
         integration,
         mockResourceUri,
         parameters,
+        mockUserId,
       );
     });
 

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/retrieve-mcp-resource/retrieve-mcp-resource.use-case.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/retrieve-mcp-resource/retrieve-mcp-resource.use-case.ts
@@ -1,6 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { RetrieveMcpResourceCommand } from './retrieve-mcp-resource.command';
 import { McpClientService } from '../../services/mcp-client.service';
+import { ContextService } from 'src/common/context/services/context.service';
 import { UnexpectedMcpError } from '../../mcp.errors';
 import { ApplicationError } from 'src/common/errors/base.error';
 import { ValidateIntegrationAccessService } from '../../services/validate-integration-access.service';
@@ -12,6 +13,7 @@ export class RetrieveMcpResourceUseCase {
   constructor(
     private readonly mcpClientService: McpClientService,
     private readonly validateIntegrationAccess: ValidateIntegrationAccessService,
+    private readonly contextService: ContextService,
   ) {}
 
   async execute(

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/retrieve-mcp-resource/retrieve-mcp-resource.use-case.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/retrieve-mcp-resource/retrieve-mcp-resource.use-case.ts
@@ -28,10 +28,12 @@ export class RetrieveMcpResourceUseCase {
       );
 
       // Retrieve resource content with parameters (for URI template substitution)
+      const userId = this.contextService.get('userId');
       const { content, mimeType } = await this.mcpClientService.readResource(
         integration,
         command.resourceUri,
         command.parameters,
+        userId,
       );
 
       return { content, mimeType };

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/set-user-mcp-config/set-user-mcp-config.command.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/set-user-mcp-config/set-user-mcp-config.command.ts
@@ -1,4 +1,4 @@
-import { UUID } from 'crypto';
+import type { UUID } from 'crypto';
 
 export class SetUserMcpConfigCommand {
   constructor(

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/set-user-mcp-config/set-user-mcp-config.command.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/set-user-mcp-config/set-user-mcp-config.command.ts
@@ -1,0 +1,8 @@
+import { UUID } from 'crypto';
+
+export class SetUserMcpConfigCommand {
+  constructor(
+    public readonly integrationId: UUID,
+    public readonly configValues: Record<string, string>,
+  ) {}
+}

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/set-user-mcp-config/set-user-mcp-config.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/set-user-mcp-config/set-user-mcp-config.use-case.spec.ts
@@ -1,0 +1,222 @@
+import { SetUserMcpConfigUseCase } from './set-user-mcp-config.use-case';
+import { SetUserMcpConfigCommand } from './set-user-mcp-config.command';
+import { McpIntegrationsRepositoryPort } from '../../ports/mcp-integrations.repository.port';
+import { McpIntegrationUserConfigRepositoryPort } from '../../ports/mcp-integration-user-config.repository.port';
+import { McpCredentialEncryptionPort } from '../../ports/mcp-credential-encryption.port';
+import { ContextService } from 'src/common/context/services/context.service';
+import { MarketplaceMcpIntegration } from '../../../domain/integrations/marketplace-mcp-integration.entity';
+import { CustomMcpIntegration } from '../../../domain/integrations/custom-mcp-integration.entity';
+import { McpIntegrationUserConfig } from '../../../domain/mcp-integration-user-config.entity';
+import { NoAuthMcpIntegrationAuth } from '../../../domain/auth/no-auth-mcp-integration-auth.entity';
+import {
+  McpIntegrationNotFoundError,
+  McpNotMarketplaceIntegrationError,
+  McpNoUserFieldsError,
+} from '../../mcp.errors';
+import { UUID } from 'crypto';
+
+describe('SetUserMcpConfigUseCase', () => {
+  let useCase: SetUserMcpConfigUseCase;
+  let integrationRepository: jest.Mocked<McpIntegrationsRepositoryPort>;
+  let userConfigRepository: jest.Mocked<McpIntegrationUserConfigRepositoryPort>;
+  let credentialEncryption: jest.Mocked<McpCredentialEncryptionPort>;
+  let contextService: jest.Mocked<ContextService>;
+
+  const userId = '770e8400-e29b-41d4-a716-446655440001' as UUID;
+  const orgId = '660e8400-e29b-41d4-a716-446655440001' as UUID;
+  const integrationId = '550e8400-e29b-41d4-a716-446655440000' as UUID;
+
+  const createMarketplaceIntegration = (
+    userFields: MarketplaceMcpIntegration['configSchema']['userFields'],
+  ) =>
+    new MarketplaceMcpIntegration({
+      id: integrationId,
+      orgId,
+      name: 'Locaboo Booking',
+      serverUrl: 'https://mcp.ayunis.de/locaboo',
+      auth: new NoAuthMcpIntegrationAuth({}),
+      marketplaceIdentifier: 'locaboo-booking',
+      configSchema: {
+        authType: 'BEARER_TOKEN',
+        orgFields: [
+          {
+            key: 'orgToken',
+            type: 'secret' as const,
+            label: 'Default API Token',
+            headerName: 'Authorization',
+            prefix: 'Bearer ',
+            required: true,
+          },
+        ],
+        userFields,
+      },
+      orgConfigValues: { orgToken: 'encrypted:org-token' },
+    });
+
+  beforeEach(() => {
+    integrationRepository = {
+      save: jest.fn(),
+      findById: jest.fn(),
+      findByIds: jest.fn(),
+      findAll: jest.fn(),
+      findByOrgIdAndSlug: jest.fn(),
+      delete: jest.fn(),
+    } as jest.Mocked<McpIntegrationsRepositoryPort>;
+
+    userConfigRepository = {
+      save: jest.fn(),
+      findByIntegrationAndUser: jest.fn(),
+      deleteByIntegrationId: jest.fn(),
+    } as jest.Mocked<McpIntegrationUserConfigRepositoryPort>;
+
+    credentialEncryption = {
+      encrypt: jest.fn(),
+      decrypt: jest.fn(),
+    } as jest.Mocked<McpCredentialEncryptionPort>;
+
+    contextService = {
+      get: jest.fn(),
+    } as unknown as jest.Mocked<ContextService>;
+
+    contextService.get.mockReturnValue(userId);
+    credentialEncryption.encrypt.mockImplementation(
+      async (plaintext) => `encrypted:${plaintext}`,
+    );
+    userConfigRepository.save.mockImplementation(async (config) => config);
+    userConfigRepository.findByIntegrationAndUser.mockResolvedValue(null);
+
+    useCase = new SetUserMcpConfigUseCase(
+      integrationRepository,
+      userConfigRepository,
+      credentialEncryption,
+      contextService,
+    );
+  });
+
+  it('should create a new user config for a marketplace integration', async () => {
+    const integration = createMarketplaceIntegration([
+      {
+        key: 'personalToken',
+        type: 'secret' as const,
+        label: 'Personal Access Token',
+        headerName: 'Authorization',
+        prefix: 'Bearer ',
+        required: false,
+      },
+    ]);
+    integrationRepository.findById.mockResolvedValue(integration);
+
+    const result = await useCase.execute(
+      new SetUserMcpConfigCommand(integrationId, {
+        personalToken: 'my-personal-token',
+      }),
+    );
+
+    expect(result).toBeInstanceOf(McpIntegrationUserConfig);
+    expect(result.integrationId).toBe(integrationId);
+    expect(result.userId).toBe(userId);
+    expect(result.configValues).toEqual({
+      personalToken: 'encrypted:my-personal-token',
+    });
+    expect(userConfigRepository.save).toHaveBeenCalled();
+  });
+
+  it('should update existing user config', async () => {
+    const integration = createMarketplaceIntegration([
+      {
+        key: 'personalToken',
+        type: 'secret' as const,
+        label: 'Personal Access Token',
+        headerName: 'Authorization',
+        prefix: 'Bearer ',
+        required: false,
+      },
+    ]);
+    integrationRepository.findById.mockResolvedValue(integration);
+
+    const existingConfig = new McpIntegrationUserConfig({
+      integrationId,
+      userId,
+      configValues: { personalToken: 'encrypted:old-token' },
+    });
+    userConfigRepository.findByIntegrationAndUser.mockResolvedValue(
+      existingConfig,
+    );
+
+    const result = await useCase.execute(
+      new SetUserMcpConfigCommand(integrationId, {
+        personalToken: 'new-personal-token',
+      }),
+    );
+
+    expect(result.configValues).toEqual({
+      personalToken: 'encrypted:new-personal-token',
+    });
+  });
+
+  it('should throw when integration is not found', async () => {
+    integrationRepository.findById.mockResolvedValue(null);
+
+    await expect(
+      useCase.execute(
+        new SetUserMcpConfigCommand(integrationId, {
+          personalToken: 'token',
+        }),
+      ),
+    ).rejects.toThrow(McpIntegrationNotFoundError);
+  });
+
+  it('should throw when integration is not a marketplace integration', async () => {
+    const customIntegration = new CustomMcpIntegration({
+      id: integrationId,
+      orgId,
+      name: 'Custom Integration',
+      serverUrl: 'https://custom.example.com/mcp',
+      auth: new NoAuthMcpIntegrationAuth({}),
+    });
+    integrationRepository.findById.mockResolvedValue(customIntegration);
+
+    await expect(
+      useCase.execute(
+        new SetUserMcpConfigCommand(integrationId, {
+          personalToken: 'token',
+        }),
+      ),
+    ).rejects.toThrow(McpNotMarketplaceIntegrationError);
+  });
+
+  it('should throw when integration has no user fields', async () => {
+    const integration = createMarketplaceIntegration([]);
+    integrationRepository.findById.mockResolvedValue(integration);
+
+    await expect(
+      useCase.execute(
+        new SetUserMcpConfigCommand(integrationId, {
+          personalToken: 'token',
+        }),
+      ),
+    ).rejects.toThrow(McpNoUserFieldsError);
+  });
+
+  it('should not encrypt non-secret field values', async () => {
+    const integration = createMarketplaceIntegration([
+      {
+        key: 'tenantId',
+        type: 'text' as const,
+        label: 'Tenant ID',
+        headerName: 'X-Tenant-Id',
+        required: false,
+      },
+    ]);
+    integrationRepository.findById.mockResolvedValue(integration);
+
+    const result = await useCase.execute(
+      new SetUserMcpConfigCommand(integrationId, {
+        tenantId: 'my-tenant-123',
+      }),
+    );
+
+    expect(result.configValues).toEqual({ tenantId: 'my-tenant-123' });
+    expect(credentialEncryption.encrypt).not.toHaveBeenCalled();
+  });
+});

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/set-user-mcp-config/set-user-mcp-config.use-case.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/set-user-mcp-config/set-user-mcp-config.use-case.ts
@@ -1,0 +1,98 @@
+import { Injectable, Logger, UnauthorizedException } from '@nestjs/common';
+import { SetUserMcpConfigCommand } from './set-user-mcp-config.command';
+import { McpIntegrationsRepositoryPort } from '../../ports/mcp-integrations.repository.port';
+import { McpIntegrationUserConfigRepositoryPort } from '../../ports/mcp-integration-user-config.repository.port';
+import { McpCredentialEncryptionPort } from '../../ports/mcp-credential-encryption.port';
+import { ContextService } from 'src/common/context/services/context.service';
+import { McpIntegrationUserConfig } from '../../../domain/mcp-integration-user-config.entity';
+import { MarketplaceMcpIntegration } from '../../../domain/integrations/marketplace-mcp-integration.entity';
+import { ConfigField } from '../../../domain/value-objects/integration-config-schema';
+import {
+  McpIntegrationNotFoundError,
+  McpNotMarketplaceIntegrationError,
+  McpNoUserFieldsError,
+} from '../../mcp.errors';
+
+@Injectable()
+export class SetUserMcpConfigUseCase {
+  private readonly logger = new Logger(SetUserMcpConfigUseCase.name);
+
+  constructor(
+    private readonly integrationRepository: McpIntegrationsRepositoryPort,
+    private readonly userConfigRepository: McpIntegrationUserConfigRepositoryPort,
+    private readonly credentialEncryption: McpCredentialEncryptionPort,
+    private readonly contextService: ContextService,
+  ) {}
+
+  async execute(
+    command: SetUserMcpConfigCommand,
+  ): Promise<McpIntegrationUserConfig> {
+    this.logger.log('execute', { integrationId: command.integrationId });
+
+    const userId = this.contextService.get('userId');
+    if (!userId) {
+      throw new UnauthorizedException('User not authenticated');
+    }
+
+    const integration = await this.integrationRepository.findById(
+      command.integrationId,
+    );
+
+    if (!integration) {
+      throw new McpIntegrationNotFoundError(command.integrationId);
+    }
+
+    if (!integration.isMarketplace()) {
+      throw new McpNotMarketplaceIntegrationError(command.integrationId);
+    }
+
+    const marketplaceIntegration = integration as MarketplaceMcpIntegration;
+    const { userFields } = marketplaceIntegration.configSchema;
+
+    if (!userFields || userFields.length === 0) {
+      throw new McpNoUserFieldsError(command.integrationId);
+    }
+
+    const encryptedValues = await this.encryptSecretFields(
+      userFields,
+      command.configValues,
+    );
+
+    const existing = await this.userConfigRepository.findByIntegrationAndUser(
+      command.integrationId,
+      userId,
+    );
+
+    if (existing) {
+      existing.updateConfigValues(encryptedValues);
+      return this.userConfigRepository.save(existing);
+    }
+
+    const userConfig = new McpIntegrationUserConfig({
+      integrationId: command.integrationId,
+      userId,
+      configValues: encryptedValues,
+    });
+
+    return this.userConfigRepository.save(userConfig);
+  }
+
+  private async encryptSecretFields(
+    userFields: ConfigField[],
+    values: Record<string, string>,
+  ): Promise<Record<string, string>> {
+    const encrypted = { ...values };
+    const secretKeys = new Set(
+      userFields.filter((f) => f.type === 'secret').map((f) => f.key),
+    );
+
+    for (const key of Object.keys(encrypted)) {
+      if (secretKeys.has(key)) {
+        encrypted[key] = await this.credentialEncryption.encrypt(
+          encrypted[key],
+        );
+      }
+    }
+    return encrypted;
+  }
+}

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/set-user-mcp-config/set-user-mcp-config.use-case.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/set-user-mcp-config/set-user-mcp-config.use-case.ts
@@ -4,11 +4,12 @@ import { SetUserMcpConfigCommand } from './set-user-mcp-config.command';
 import { UserMcpConfigResult } from '../get-user-mcp-config/get-user-mcp-config.use-case';
 import { McpIntegrationsRepositoryPort } from '../../ports/mcp-integrations.repository.port';
 import { McpIntegrationUserConfigRepositoryPort } from '../../ports/mcp-integration-user-config.repository.port';
-import { McpCredentialEncryptionPort } from '../../ports/mcp-credential-encryption.port';
 import { ContextService } from 'src/common/context/services/context.service';
 import { McpIntegrationUserConfig } from '../../../domain/mcp-integration-user-config.entity';
 import { MarketplaceMcpIntegration } from '../../../domain/integrations/marketplace-mcp-integration.entity';
 import { ConfigField } from '../../../domain/value-objects/integration-config-schema';
+import { SECRET_MASK } from '../../../domain/value-objects/secret-mask.constant';
+import { MarketplaceConfigService } from '../../services/marketplace-config.service';
 import {
   McpIntegrationNotFoundError,
   McpIntegrationAccessDeniedError,
@@ -24,8 +25,8 @@ export class SetUserMcpConfigUseCase {
   constructor(
     private readonly integrationRepository: McpIntegrationsRepositoryPort,
     private readonly userConfigRepository: McpIntegrationUserConfigRepositoryPort,
-    private readonly credentialEncryption: McpCredentialEncryptionPort,
     private readonly contextService: ContextService,
+    private readonly marketplaceConfigService: MarketplaceConfigService,
   ) {}
 
   async execute(
@@ -39,6 +40,9 @@ export class SetUserMcpConfigUseCase {
     }
 
     const orgId = this.contextService.get('orgId');
+    if (!orgId) {
+      throw new UnauthorizedException('User not authenticated');
+    }
 
     const integration = await this.integrationRepository.findById(
       command.integrationId,
@@ -65,15 +69,27 @@ export class SetUserMcpConfigUseCase {
 
     this.validateConfigKeys(userFields, command.configValues);
 
-    const encryptedValues = await this.encryptSecretFields(
-      userFields,
+    const existing = await this.userConfigRepository.findByIntegrationAndUser(
+      command.integrationId,
+      userId,
+    );
+
+    const mergedValues = await this.mergeUserConfigValues(
+      existing?.configValues ?? {},
       command.configValues,
+      userFields,
+    );
+
+    this.marketplaceConfigService.validateRequiredFields(
+      userFields,
+      mergedValues,
     );
 
     const saved = await this.saveConfig(
       command.integrationId,
       userId,
-      encryptedValues,
+      mergedValues,
+      existing,
     );
 
     return this.maskResult(saved.configValues, userFields);
@@ -91,16 +107,48 @@ export class SetUserMcpConfigUseCase {
     }
   }
 
+  /**
+   * Merges new config values with existing ones, handling the secret mask sentinel.
+   * - If new value is SECRET_MASK → keep existing encrypted value
+   * - If new value is provided and not the mask → encrypt (for secrets) or use as-is
+   * - If field is missing from new values → keep existing value
+   */
+  private async mergeUserConfigValues(
+    existingValues: Record<string, string>,
+    providedValues: Record<string, string>,
+    userFields: ConfigField[],
+  ): Promise<Record<string, string>> {
+    const merged: Record<string, string> = {};
+
+    for (const field of userFields) {
+      const provided = providedValues[field.key];
+      const existing = existingValues[field.key];
+
+      if (provided === SECRET_MASK && existing !== undefined) {
+        merged[field.key] = existing;
+      } else if (provided === SECRET_MASK) {
+        // SECRET_MASK with no existing value — skip, don't store the mask literal
+      } else if (provided !== undefined) {
+        merged[field.key] =
+          field.type === 'secret'
+            ? await this.marketplaceConfigService
+                .encryptSecretFields([field], { [field.key]: provided })
+                .then((r) => r[field.key])
+            : provided;
+      } else if (existing !== undefined) {
+        merged[field.key] = existing;
+      }
+    }
+
+    return merged;
+  }
+
   private async saveConfig(
     integrationId: UUID,
     userId: UUID,
     encryptedValues: Record<string, string>,
+    existing: McpIntegrationUserConfig | null,
   ): Promise<McpIntegrationUserConfig> {
-    const existing = await this.userConfigRepository.findByIntegrationAndUser(
-      integrationId,
-      userId,
-    );
-
     if (existing) {
       existing.updateConfigValues(encryptedValues);
       return this.userConfigRepository.save(existing);
@@ -125,28 +173,9 @@ export class SetUserMcpConfigUseCase {
 
     const maskedValues: Record<string, string> = {};
     for (const [key, value] of Object.entries(configValues)) {
-      maskedValues[key] = secretKeys.has(key) ? '***' : value;
+      maskedValues[key] = secretKeys.has(key) ? SECRET_MASK : value;
     }
 
     return { hasConfig: true, configValues: maskedValues };
-  }
-
-  private async encryptSecretFields(
-    userFields: ConfigField[],
-    values: Record<string, string>,
-  ): Promise<Record<string, string>> {
-    const encrypted = { ...values };
-    const secretKeys = new Set(
-      userFields.filter((f) => f.type === 'secret').map((f) => f.key),
-    );
-
-    for (const key of Object.keys(encrypted)) {
-      if (secretKeys.has(key)) {
-        encrypted[key] = await this.credentialEncryption.encrypt(
-          encrypted[key],
-        );
-      }
-    }
-    return encrypted;
   }
 }

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/update-mcp-integration/update-mcp-integration.command.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/update-mcp-integration/update-mcp-integration.command.ts
@@ -1,9 +1,26 @@
+interface UpdateMcpIntegrationParams {
+  integrationId: string;
+  name?: string;
+  credentials?: string;
+  authHeaderName?: string;
+  returnsPii?: boolean;
+  orgConfigValues?: Record<string, string>;
+}
+
 export class UpdateMcpIntegrationCommand {
-  constructor(
-    public readonly integrationId: string,
-    public readonly name?: string,
-    public readonly credentials?: string,
-    public readonly authHeaderName?: string,
-    public readonly returnsPii?: boolean,
-  ) {}
+  public readonly integrationId: string;
+  public readonly name?: string;
+  public readonly credentials?: string;
+  public readonly authHeaderName?: string;
+  public readonly returnsPii?: boolean;
+  public readonly orgConfigValues?: Record<string, string>;
+
+  constructor(params: UpdateMcpIntegrationParams) {
+    this.integrationId = params.integrationId;
+    this.name = params.name;
+    this.credentials = params.credentials;
+    this.authHeaderName = params.authHeaderName;
+    this.returnsPii = params.returnsPii;
+    this.orgConfigValues = params.orgConfigValues;
+  }
 }

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/update-mcp-integration/update-mcp-integration.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/update-mcp-integration/update-mcp-integration.use-case.spec.ts
@@ -5,9 +5,18 @@ import { UpdateMcpIntegrationCommand } from './update-mcp-integration.command';
 import type { McpIntegrationsRepositoryPort } from '../../ports/mcp-integrations.repository.port';
 import type { ContextService } from 'src/common/context/services/context.service';
 import type { McpCredentialEncryptionPort } from '../../ports/mcp-credential-encryption.port';
+import { MarketplaceConfigService } from '../../services/marketplace-config.service';
+import { ValidateMcpIntegrationUseCase } from '../validate-mcp-integration/validate-mcp-integration.use-case';
 import { CustomMcpIntegration } from '../../../domain/integrations/custom-mcp-integration.entity';
+import { MarketplaceMcpIntegration } from '../../../domain/integrations/marketplace-mcp-integration.entity';
 import { BearerMcpIntegrationAuth } from '../../../domain/auth/bearer-mcp-integration-auth.entity';
 import { CustomHeaderMcpIntegrationAuth } from '../../../domain/auth/custom-header-mcp-integration-auth.entity';
+import { NoAuthMcpIntegrationAuth } from '../../../domain/auth/no-auth-mcp-integration-auth.entity';
+import {
+  McpNotMarketplaceIntegrationError,
+  McpMissingRequiredConfigError,
+} from '../../mcp.errors';
+import { IntegrationConfigSchema } from '../../../domain/value-objects/integration-config-schema';
 
 describe('UpdateMcpIntegrationUseCase', () => {
   const orgId = randomUUID();
@@ -16,6 +25,8 @@ describe('UpdateMcpIntegrationUseCase', () => {
   let repository: jest.Mocked<McpIntegrationsRepositoryPort>;
   let context: jest.Mocked<ContextService>;
   let encryption: jest.Mocked<McpCredentialEncryptionPort>;
+  let marketplaceConfigService: MarketplaceConfigService;
+  let validateUseCase: jest.Mocked<ValidateMcpIntegrationUseCase>;
   let useCase: UpdateMcpIntegrationUseCase;
 
   beforeEach(() => {
@@ -37,9 +48,30 @@ describe('UpdateMcpIntegrationUseCase', () => {
       decrypt: jest.fn(),
     } as unknown as jest.Mocked<McpCredentialEncryptionPort>;
 
-    useCase = new UpdateMcpIntegrationUseCase(repository, context, encryption);
+    validateUseCase = {
+      execute: jest.fn(),
+    } as unknown as jest.Mocked<ValidateMcpIntegrationUseCase>;
+
+    marketplaceConfigService = new MarketplaceConfigService(encryption);
+
+    useCase = new UpdateMcpIntegrationUseCase(
+      repository,
+      context,
+      encryption,
+      marketplaceConfigService,
+      validateUseCase,
+    );
     context.get.mockReturnValue(orgId);
     repository.save.mockImplementation(async (integration) => integration);
+    encryption.encrypt.mockImplementation(
+      async (plaintext) => `encrypted:${plaintext}`,
+    );
+    validateUseCase.execute.mockResolvedValue({
+      isValid: true,
+      toolCount: 3,
+      resourceCount: 0,
+      promptCount: 0,
+    });
   });
 
   it('updates name and rotates bearer token credentials', async () => {
@@ -55,11 +87,11 @@ describe('UpdateMcpIntegrationUseCase', () => {
     repository.findById.mockResolvedValue(integration);
     encryption.encrypt.mockResolvedValue('encrypted-new');
 
-    const command = new UpdateMcpIntegrationCommand(
+    const command = new UpdateMcpIntegrationCommand({
       integrationId,
-      'New Name',
-      'new-token',
-    );
+      name: 'New Name',
+      credentials: 'new-token',
+    });
 
     const result = await useCase.execute(command);
 
@@ -86,12 +118,10 @@ describe('UpdateMcpIntegrationUseCase', () => {
 
     repository.findById.mockResolvedValue(integration);
 
-    const command = new UpdateMcpIntegrationCommand(
+    const command = new UpdateMcpIntegrationCommand({
       integrationId,
-      undefined,
-      undefined,
-      'X-NEW-KEY',
-    );
+      authHeaderName: 'X-NEW-KEY',
+    });
 
     const result = await useCase.execute(command);
 
@@ -106,7 +136,232 @@ describe('UpdateMcpIntegrationUseCase', () => {
     context.get.mockReturnValueOnce(undefined);
 
     await expect(
-      useCase.execute(new UpdateMcpIntegrationCommand(integrationId)),
+      useCase.execute(new UpdateMcpIntegrationCommand({ integrationId })),
     ).rejects.toBeInstanceOf(UnauthorizedException);
+  });
+
+  describe('marketplace orgConfigValues', () => {
+    const configSchema: IntegrationConfigSchema = {
+      authType: 'NO_AUTH',
+      orgFields: [
+        {
+          key: 'endpointUrl',
+          label: 'Endpoint URL',
+          type: 'url',
+          headerName: 'X-Endpoint-Url',
+          required: true,
+        },
+        {
+          key: 'apiToken',
+          label: 'API Token',
+          type: 'secret',
+          headerName: 'Authorization',
+          prefix: 'Bearer ',
+          required: true,
+        },
+      ],
+      userFields: [],
+    };
+
+    function createMarketplaceIntegration(
+      overrides: Partial<{
+        orgConfigValues: Record<string, string>;
+      }> = {},
+    ): MarketplaceMcpIntegration {
+      return new MarketplaceMcpIntegration({
+        id: integrationId,
+        orgId,
+        name: 'OParl Council Data',
+        serverUrl: 'https://mcp.ayunis.de/oparl',
+        marketplaceIdentifier: 'oparl-council-data',
+        configSchema,
+        orgConfigValues: overrides.orgConfigValues ?? {
+          endpointUrl: 'https://rim.ekom21.de/oparl/v1',
+          apiToken: 'encrypted:old-api-token',
+        },
+        auth: new NoAuthMcpIntegrationAuth(),
+      });
+    }
+
+    it('updates non-secret orgConfigValues for a marketplace integration', async () => {
+      const integration = createMarketplaceIntegration();
+      repository.findById.mockResolvedValue(integration);
+
+      const command = new UpdateMcpIntegrationCommand({
+        integrationId,
+        orgConfigValues: { endpointUrl: 'https://new-endpoint.de/oparl/v1' },
+      });
+
+      const result = await useCase.execute(command);
+
+      const marketplace = result as MarketplaceMcpIntegration;
+      expect(marketplace.orgConfigValues.endpointUrl).toBe(
+        'https://new-endpoint.de/oparl/v1',
+      );
+    });
+
+    it('retains existing encrypted value for omitted secret fields', async () => {
+      const integration = createMarketplaceIntegration();
+      repository.findById.mockResolvedValue(integration);
+
+      const command = new UpdateMcpIntegrationCommand({
+        integrationId,
+        orgConfigValues: { endpointUrl: 'https://new-endpoint.de/oparl/v1' },
+      });
+
+      const result = await useCase.execute(command);
+
+      const marketplace = result as MarketplaceMcpIntegration;
+      expect(marketplace.orgConfigValues.apiToken).toBe(
+        'encrypted:old-api-token',
+      );
+    });
+
+    it('encrypts new value when secret field is provided', async () => {
+      const integration = createMarketplaceIntegration();
+      repository.findById.mockResolvedValue(integration);
+
+      const command = new UpdateMcpIntegrationCommand({
+        integrationId,
+        orgConfigValues: {
+          endpointUrl: 'https://rim.ekom21.de/oparl/v1',
+          apiToken: 'new-secret-token',
+        },
+      });
+
+      const result = await useCase.execute(command);
+
+      const marketplace = result as MarketplaceMcpIntegration;
+      expect(marketplace.orgConfigValues.apiToken).toBe(
+        'encrypted:new-secret-token',
+      );
+      expect(encryption.encrypt).toHaveBeenCalledWith('new-secret-token');
+    });
+
+    it('rejects orgConfigValues for non-marketplace integrations', async () => {
+      const integration = new CustomMcpIntegration({
+        id: integrationId,
+        orgId,
+        name: 'Custom Integration',
+        serverUrl: 'https://example.com/mcp',
+        auth: new NoAuthMcpIntegrationAuth(),
+      });
+      repository.findById.mockResolvedValue(integration);
+
+      const command = new UpdateMcpIntegrationCommand({
+        integrationId,
+        orgConfigValues: { someField: 'value' },
+      });
+
+      await expect(useCase.execute(command)).rejects.toThrow(
+        McpNotMarketplaceIntegrationError,
+      );
+    });
+
+    it('validates required fields are present after merge', async () => {
+      const integration = createMarketplaceIntegration({
+        orgConfigValues: { apiToken: 'encrypted:token' },
+      });
+      repository.findById.mockResolvedValue(integration);
+
+      // endpointUrl is required but not in existing and not provided
+      const command = new UpdateMcpIntegrationCommand({
+        integrationId,
+        orgConfigValues: {},
+      });
+
+      await expect(useCase.execute(command)).rejects.toThrow(
+        McpMissingRequiredConfigError,
+      );
+    });
+
+    it('preserves fixed-value fields from schema', async () => {
+      const schemaWithFixed: IntegrationConfigSchema = {
+        authType: 'BEARER_TOKEN',
+        orgFields: [
+          {
+            key: 'systemToken',
+            label: 'System Token',
+            type: 'secret',
+            required: true,
+            value: 'sk-fixed-system-token',
+          },
+          {
+            key: 'endpointUrl',
+            label: 'Endpoint',
+            type: 'url',
+            required: true,
+          },
+        ],
+        userFields: [],
+      };
+
+      const integration = new MarketplaceMcpIntegration({
+        id: integrationId,
+        orgId,
+        name: 'Fixed Value Integration',
+        serverUrl: 'https://mcp.ayunis.de/fixed',
+        marketplaceIdentifier: 'fixed-integration',
+        configSchema: schemaWithFixed,
+        orgConfigValues: {
+          systemToken: 'encrypted:sk-fixed-system-token',
+          endpointUrl: 'https://old.com',
+        },
+        auth: new NoAuthMcpIntegrationAuth(),
+      });
+      repository.findById.mockResolvedValue(integration);
+
+      const command = new UpdateMcpIntegrationCommand({
+        integrationId,
+        orgConfigValues: {
+          systemToken: 'user-override-attempt',
+          endpointUrl: 'https://new.com',
+        },
+      });
+
+      const result = await useCase.execute(command);
+
+      const marketplace = result as MarketplaceMcpIntegration;
+      // Fixed value should be re-encrypted from schema, not user override
+      expect(marketplace.orgConfigValues.systemToken).toBe(
+        'encrypted:sk-fixed-system-token',
+      );
+      expect(marketplace.orgConfigValues.endpointUrl).toBe('https://new.com');
+    });
+
+    it('triggers connection validation after org config update', async () => {
+      const integration = createMarketplaceIntegration();
+      repository.findById.mockResolvedValue(integration);
+
+      const command = new UpdateMcpIntegrationCommand({
+        integrationId,
+        orgConfigValues: { endpointUrl: 'https://new-endpoint.de/oparl/v1' },
+      });
+
+      await useCase.execute(command);
+
+      expect(validateUseCase.execute).toHaveBeenCalledWith({
+        integrationId: integration.id,
+      });
+      // save called twice: once for update, once after validation
+      expect(repository.save).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not fail update when connection validation fails', async () => {
+      const integration = createMarketplaceIntegration();
+      repository.findById.mockResolvedValue(integration);
+      validateUseCase.execute.mockRejectedValue(
+        new Error('Connection refused'),
+      );
+
+      const command = new UpdateMcpIntegrationCommand({
+        integrationId,
+        orgConfigValues: { endpointUrl: 'https://new-endpoint.de/oparl/v1' },
+      });
+
+      // Should not throw even though validation failed
+      const result = await useCase.execute(command);
+      expect(result).toBeInstanceOf(MarketplaceMcpIntegration);
+    });
   });
 });

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/update-mcp-integration/update-mcp-integration.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/update-mcp-integration/update-mcp-integration.use-case.spec.ts
@@ -7,7 +7,7 @@ import type { ContextService } from 'src/common/context/services/context.service
 import type { McpCredentialEncryptionPort } from '../../ports/mcp-credential-encryption.port';
 import { MarketplaceConfigService } from '../../services/marketplace-config.service';
 import { ConnectionValidationService } from '../../services/connection-validation.service';
-import { ValidateMcpIntegrationUseCase } from '../validate-mcp-integration/validate-mcp-integration.use-case';
+import type { ValidateMcpIntegrationUseCase } from '../validate-mcp-integration/validate-mcp-integration.use-case';
 import { CustomMcpIntegration } from '../../../domain/integrations/custom-mcp-integration.entity';
 import { MarketplaceMcpIntegration } from '../../../domain/integrations/marketplace-mcp-integration.entity';
 import { BearerMcpIntegrationAuth } from '../../../domain/auth/bearer-mcp-integration-auth.entity';
@@ -17,7 +17,7 @@ import {
   McpNotMarketplaceIntegrationError,
   McpMissingRequiredConfigError,
 } from '../../mcp.errors';
-import { IntegrationConfigSchema } from '../../../domain/value-objects/integration-config-schema';
+import type { IntegrationConfigSchema } from '../../../domain/value-objects/integration-config-schema';
 
 describe('UpdateMcpIntegrationUseCase', () => {
   const orgId = randomUUID();

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/update-mcp-integration/update-mcp-integration.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/update-mcp-integration/update-mcp-integration.use-case.spec.ts
@@ -6,6 +6,7 @@ import type { McpIntegrationsRepositoryPort } from '../../ports/mcp-integrations
 import type { ContextService } from 'src/common/context/services/context.service';
 import type { McpCredentialEncryptionPort } from '../../ports/mcp-credential-encryption.port';
 import { MarketplaceConfigService } from '../../services/marketplace-config.service';
+import { ConnectionValidationService } from '../../services/connection-validation.service';
 import { ValidateMcpIntegrationUseCase } from '../validate-mcp-integration/validate-mcp-integration.use-case';
 import { CustomMcpIntegration } from '../../../domain/integrations/custom-mcp-integration.entity';
 import { MarketplaceMcpIntegration } from '../../../domain/integrations/marketplace-mcp-integration.entity';
@@ -27,6 +28,7 @@ describe('UpdateMcpIntegrationUseCase', () => {
   let encryption: jest.Mocked<McpCredentialEncryptionPort>;
   let marketplaceConfigService: MarketplaceConfigService;
   let validateUseCase: jest.Mocked<ValidateMcpIntegrationUseCase>;
+  let connectionValidationService: ConnectionValidationService;
   let useCase: UpdateMcpIntegrationUseCase;
 
   beforeEach(() => {
@@ -53,13 +55,17 @@ describe('UpdateMcpIntegrationUseCase', () => {
     } as unknown as jest.Mocked<ValidateMcpIntegrationUseCase>;
 
     marketplaceConfigService = new MarketplaceConfigService(encryption);
+    connectionValidationService = new ConnectionValidationService(
+      validateUseCase,
+      repository,
+    );
 
     useCase = new UpdateMcpIntegrationUseCase(
       repository,
       context,
       encryption,
       marketplaceConfigService,
-      validateUseCase,
+      connectionValidationService,
     );
     context.get.mockReturnValue(orgId);
     repository.save.mockImplementation(async (integration) => integration);

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/update-mcp-integration/update-mcp-integration.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/update-mcp-integration/update-mcp-integration.use-case.spec.ts
@@ -24,6 +24,7 @@ describe('UpdateMcpIntegrationUseCase', () => {
       save: jest.fn(),
       findAll: jest.fn(),
       findByOrgIdAndSlug: jest.fn(),
+      findByOrgIdAndMarketplaceIdentifier: jest.fn(),
       delete: jest.fn(),
     } as unknown as jest.Mocked<McpIntegrationsRepositoryPort>;
 

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/update-mcp-integration/update-mcp-integration.use-case.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/update-mcp-integration/update-mcp-integration.use-case.ts
@@ -186,6 +186,7 @@ export class UpdateMcpIntegrationUseCase {
             `Credential rotation is not supported for auth method ${authMethod}.`,
           );
         }
+        return;
       }
     }
   }

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/update-mcp-integration/update-mcp-integration.use-case.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/update-mcp-integration/update-mcp-integration.use-case.ts
@@ -76,10 +76,11 @@ export class UpdateMcpIntegrationUseCase {
         await this.updateOrgConfigValues(integration, command.orgConfigValues);
       }
 
-      const saved = await this.repository.save(integration);
+      let saved = await this.repository.save(integration);
 
       if (command.orgConfigValues !== undefined) {
-        await this.connectionValidationService.validateAndUpdateStatus(saved);
+        saved =
+          await this.connectionValidationService.validateAndUpdateStatus(saved);
       }
 
       return saved;

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/validate-mcp-integration/validate-mcp-integration.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/validate-mcp-integration/validate-mcp-integration.use-case.spec.ts
@@ -1,9 +1,9 @@
 import { randomUUID } from 'crypto';
 import { ValidateMcpIntegrationUseCase } from './validate-mcp-integration.use-case';
 import { ValidateMcpIntegrationCommand } from './validate-mcp-integration.command';
-import { McpIntegrationsRepositoryPort } from '../../ports/mcp-integrations.repository.port';
-import { McpClientService } from '../../services/mcp-client.service';
-import { ContextService } from 'src/common/context/services/context.service';
+import type { McpIntegrationsRepositoryPort } from '../../ports/mcp-integrations.repository.port';
+import type { McpClientService } from '../../services/mcp-client.service';
+import type { ContextService } from 'src/common/context/services/context.service';
 import { MarketplaceMcpIntegration } from '../../../domain/integrations/marketplace-mcp-integration.entity';
 import { NoAuthMcpIntegrationAuth } from '../../../domain/auth/no-auth-mcp-integration-auth.entity';
 

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/validate-mcp-integration/validate-mcp-integration.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/validate-mcp-integration/validate-mcp-integration.use-case.spec.ts
@@ -1,0 +1,106 @@
+import { randomUUID } from 'crypto';
+import { ValidateMcpIntegrationUseCase } from './validate-mcp-integration.use-case';
+import { ValidateMcpIntegrationCommand } from './validate-mcp-integration.command';
+import { McpIntegrationsRepositoryPort } from '../../ports/mcp-integrations.repository.port';
+import { McpClientService } from '../../services/mcp-client.service';
+import { ContextService } from 'src/common/context/services/context.service';
+import { MarketplaceMcpIntegration } from '../../../domain/integrations/marketplace-mcp-integration.entity';
+import { NoAuthMcpIntegrationAuth } from '../../../domain/auth/no-auth-mcp-integration-auth.entity';
+
+describe('ValidateMcpIntegrationUseCase', () => {
+  let useCase: ValidateMcpIntegrationUseCase;
+  let repository: jest.Mocked<McpIntegrationsRepositoryPort>;
+  let mcpClientService: jest.Mocked<McpClientService>;
+  let contextService: jest.Mocked<ContextService>;
+
+  const orgId = randomUUID();
+  const userId = randomUUID();
+  const integrationId = randomUUID();
+
+  const buildIntegration = () =>
+    new MarketplaceMcpIntegration({
+      id: integrationId,
+      orgId,
+      name: 'Locaboo Booking',
+      serverUrl: 'https://mcp.ayunis.de/locaboo',
+      auth: new NoAuthMcpIntegrationAuth({}),
+      marketplaceIdentifier: 'locaboo-booking',
+      configSchema: {
+        authType: 'BEARER_TOKEN',
+        orgFields: [],
+        userFields: [
+          {
+            key: 'personalToken',
+            type: 'secret' as const,
+            label: 'Personal Access Token',
+            headerName: 'Authorization',
+            prefix: 'Bearer ',
+            required: true,
+          },
+        ],
+      },
+      orgConfigValues: {},
+    });
+
+  beforeEach(() => {
+    repository = {
+      save: jest.fn(),
+      findById: jest.fn(),
+      findByIds: jest.fn(),
+      findAll: jest.fn(),
+      findByOrgIdAndSlug: jest.fn(),
+      findByOrgIdAndMarketplaceIdentifier: jest.fn(),
+      delete: jest.fn(),
+    } as jest.Mocked<McpIntegrationsRepositoryPort>;
+
+    mcpClientService = {
+      listTools: jest.fn().mockResolvedValue([{ name: 'book-room' }]),
+      listResources: jest.fn().mockResolvedValue([]),
+      listResourceTemplates: jest.fn().mockResolvedValue([]),
+      listPrompts: jest.fn().mockResolvedValue([]),
+    } as unknown as jest.Mocked<McpClientService>;
+
+    contextService = {
+      get: jest.fn(),
+    } as unknown as jest.Mocked<ContextService>;
+
+    contextService.get.mockImplementation((key?: string | symbol) => {
+      if (key === 'orgId') return orgId;
+      if (key === 'userId') return userId;
+      return undefined;
+    });
+
+    repository.findById.mockResolvedValue(buildIntegration());
+
+    useCase = new ValidateMcpIntegrationUseCase(
+      repository,
+      mcpClientService,
+      contextService,
+    );
+  });
+
+  it('should pass userId to MCP client when collecting capabilities', async () => {
+    const command = new ValidateMcpIntegrationCommand(integrationId);
+    const integration = buildIntegration();
+    repository.findById.mockResolvedValue(integration);
+
+    await useCase.execute(command);
+
+    expect(mcpClientService.listTools).toHaveBeenCalledWith(
+      integration,
+      userId,
+    );
+    expect(mcpClientService.listResources).toHaveBeenCalledWith(
+      integration,
+      userId,
+    );
+    expect(mcpClientService.listResourceTemplates).toHaveBeenCalledWith(
+      integration,
+      userId,
+    );
+    expect(mcpClientService.listPrompts).toHaveBeenCalledWith(
+      integration,
+      userId,
+    );
+  });
+});

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/validate-mcp-integration/validate-mcp-integration.use-case.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/validate-mcp-integration/validate-mcp-integration.use-case.ts
@@ -42,6 +42,7 @@ export class ValidateMcpIntegrationUseCase {
 
     try {
       const orgId = this.getOrgIdOrThrow();
+      const userId = this.contextService.get('userId');
       const integration = await this.getIntegrationOrThrow(
         command.integrationId,
       );
@@ -51,6 +52,7 @@ export class ValidateMcpIntegrationUseCase {
       const capabilityResult = await this.collectCapabilities(
         integration,
         command.integrationId,
+        userId,
       );
 
       if (capabilityResult.kind === 'failure') {
@@ -145,6 +147,7 @@ export class ValidateMcpIntegrationUseCase {
   private async collectCapabilities(
     integration: McpIntegration,
     integrationId: UUID,
+    userId?: UUID,
   ): Promise<
     | {
         kind: 'success';
@@ -161,10 +164,10 @@ export class ValidateMcpIntegrationUseCase {
       Promise<unknown[]>,
       Promise<unknown[]>,
     ] = [
-      this.mcpClientService.listTools(integration),
-      this.mcpClientService.listResources(integration),
-      this.mcpClientService.listResourceTemplates(integration),
-      this.mcpClientService.listPrompts(integration),
+      this.mcpClientService.listTools(integration, userId),
+      this.mcpClientService.listResources(integration, userId),
+      this.mcpClientService.listResourceTemplates(integration, userId),
+      this.mcpClientService.listPrompts(integration, userId),
     ];
 
     const [toolsResult, resourcesResult, templatesResult, promptsResult] =

--- a/ayunis-core-backend/src/domain/mcp/domain/index.ts
+++ b/ayunis-core-backend/src/domain/mcp/domain/index.ts
@@ -2,6 +2,8 @@ export { McpIntegration } from './mcp-integration.entity';
 export { McpIntegrationKind } from './value-objects/mcp-integration-kind.enum';
 export { CustomMcpIntegration } from './integrations/custom-mcp-integration.entity';
 export { PredefinedMcpIntegration } from './integrations/predefined-mcp-integration.entity';
+export { MarketplaceMcpIntegration } from './integrations/marketplace-mcp-integration.entity';
+export { McpIntegrationUserConfig } from './mcp-integration-user-config.entity';
 
 export { McpIntegrationAuth } from './auth/mcp-integration-auth.entity';
 export { NoAuthMcpIntegrationAuth } from './auth/no-auth-mcp-integration-auth.entity';
@@ -11,3 +13,9 @@ export { OAuthMcpIntegrationAuth } from './auth/oauth-mcp-integration-auth.entit
 
 export { McpAuthMethod } from './value-objects/mcp-auth-method.enum';
 export { PredefinedMcpIntegrationSlug } from './value-objects/predefined-mcp-integration-slug.enum';
+
+export type {
+  IntegrationConfigSchema,
+  ConfigField,
+  OAuthConfig,
+} from './value-objects/integration-config-schema';

--- a/ayunis-core-backend/src/domain/mcp/domain/integrations/marketplace-mcp-integration.entity.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/domain/integrations/marketplace-mcp-integration.entity.spec.ts
@@ -1,0 +1,146 @@
+import { randomUUID } from 'crypto';
+import { MarketplaceMcpIntegration } from './marketplace-mcp-integration.entity';
+import { McpIntegrationKind } from '../value-objects/mcp-integration-kind.enum';
+import { NoAuthMcpIntegrationAuth } from '../auth/no-auth-mcp-integration-auth.entity';
+import { IntegrationConfigSchema } from '../value-objects/integration-config-schema';
+
+describe('MarketplaceMcpIntegration', () => {
+  const orgId = randomUUID();
+  const configSchema: IntegrationConfigSchema = {
+    authType: 'BEARER_TOKEN',
+    orgFields: [
+      {
+        key: 'authToken',
+        label: 'API Token',
+        type: 'secret',
+        headerName: 'Authorization',
+        prefix: 'Bearer ',
+        required: true,
+      },
+      {
+        key: 'oparlEndpointUrl',
+        label: 'OParl Endpoint URL',
+        type: 'url',
+        headerName: 'X-Oparl-Endpoint-Url',
+        required: true,
+        help: "Your municipality's OParl system endpoint URL",
+      },
+    ],
+    userFields: [
+      {
+        key: 'personalToken',
+        label: 'Personal Access Token',
+        type: 'secret',
+        headerName: 'Authorization',
+        prefix: 'Bearer ',
+        required: false,
+        help: 'Optional — overrides the org-wide token',
+      },
+    ],
+  };
+
+  it('should create with marketplace kind', () => {
+    const integration = new MarketplaceMcpIntegration({
+      orgId,
+      name: 'OParl Integration',
+      serverUrl: 'https://oparl-mcp.ayunis.de/mcp',
+      marketplaceIdentifier: 'oparl',
+      configSchema,
+      orgConfigValues: {
+        authToken: 'encrypted-token-value',
+        oparlEndpointUrl: 'https://rim.ekom21.de/oparl/v1',
+      },
+      auth: new NoAuthMcpIntegrationAuth(),
+    });
+
+    expect(integration.kind).toBe(McpIntegrationKind.MARKETPLACE);
+  });
+
+  it('should expose marketplace-specific properties', () => {
+    const integration = new MarketplaceMcpIntegration({
+      orgId,
+      name: 'OParl Integration',
+      serverUrl: 'https://oparl-mcp.ayunis.de/mcp',
+      marketplaceIdentifier: 'oparl',
+      configSchema,
+      orgConfigValues: {
+        authToken: 'encrypted-token-value',
+        oparlEndpointUrl: 'https://rim.ekom21.de/oparl/v1',
+      },
+      auth: new NoAuthMcpIntegrationAuth(),
+    });
+
+    expect(integration.marketplaceIdentifier).toBe('oparl');
+    expect(integration.configSchema).toBe(configSchema);
+    expect(integration.orgConfigValues).toEqual({
+      authToken: 'encrypted-token-value',
+      oparlEndpointUrl: 'https://rim.ekom21.de/oparl/v1',
+    });
+    expect(integration.serverUrl).toBe('https://oparl-mcp.ayunis.de/mcp');
+  });
+
+  it('should be identified as marketplace via isMarketplace()', () => {
+    const integration = new MarketplaceMcpIntegration({
+      orgId,
+      name: 'OParl Integration',
+      serverUrl: 'https://oparl-mcp.ayunis.de/mcp',
+      marketplaceIdentifier: 'oparl',
+      configSchema,
+      orgConfigValues: {},
+      auth: new NoAuthMcpIntegrationAuth(),
+    });
+
+    expect(integration.isMarketplace()).toBe(true);
+    expect(integration.isPredefined()).toBe(false);
+    expect(integration.isCustom()).toBe(false);
+  });
+
+  it('should allow updating org config values', () => {
+    const integration = new MarketplaceMcpIntegration({
+      orgId,
+      name: 'OParl Integration',
+      serverUrl: 'https://oparl-mcp.ayunis.de/mcp',
+      marketplaceIdentifier: 'oparl',
+      configSchema,
+      orgConfigValues: { authToken: 'old-token' },
+      auth: new NoAuthMcpIntegrationAuth(),
+    });
+
+    const previousUpdatedAt = integration.updatedAt;
+
+    integration.updateOrgConfigValues({ authToken: 'new-token' });
+
+    expect(integration.orgConfigValues).toEqual({ authToken: 'new-token' });
+    expect(integration.updatedAt.getTime()).toBeGreaterThanOrEqual(
+      previousUpdatedAt.getTime(),
+    );
+  });
+
+  it('should default to empty org config values', () => {
+    const integration = new MarketplaceMcpIntegration({
+      orgId,
+      name: 'Zero Config Integration',
+      serverUrl: 'https://example.com/mcp',
+      marketplaceIdentifier: 'zero-config',
+      configSchema: {
+        authType: 'BEARER_TOKEN',
+        orgFields: [
+          {
+            key: 'token',
+            type: 'secret',
+            label: 'Token',
+            headerName: 'Authorization',
+            prefix: 'Bearer ',
+            required: true,
+            value: 'sk-fixed-token',
+          },
+        ],
+        userFields: [],
+      },
+      orgConfigValues: {},
+      auth: new NoAuthMcpIntegrationAuth(),
+    });
+
+    expect(integration.orgConfigValues).toEqual({});
+  });
+});

--- a/ayunis-core-backend/src/domain/mcp/domain/integrations/marketplace-mcp-integration.entity.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/domain/integrations/marketplace-mcp-integration.entity.spec.ts
@@ -2,7 +2,7 @@ import { randomUUID } from 'crypto';
 import { MarketplaceMcpIntegration } from './marketplace-mcp-integration.entity';
 import { McpIntegrationKind } from '../value-objects/mcp-integration-kind.enum';
 import { NoAuthMcpIntegrationAuth } from '../auth/no-auth-mcp-integration-auth.entity';
-import { IntegrationConfigSchema } from '../value-objects/integration-config-schema';
+import type { IntegrationConfigSchema } from '../value-objects/integration-config-schema';
 
 describe('MarketplaceMcpIntegration', () => {
   const orgId = randomUUID();

--- a/ayunis-core-backend/src/domain/mcp/domain/integrations/marketplace-mcp-integration.entity.ts
+++ b/ayunis-core-backend/src/domain/mcp/domain/integrations/marketplace-mcp-integration.entity.ts
@@ -1,0 +1,71 @@
+import { UUID } from 'crypto';
+import { McpIntegration } from '../mcp-integration.entity';
+import { McpIntegrationAuth } from '../auth/mcp-integration-auth.entity';
+import { McpIntegrationKind } from '../value-objects/mcp-integration-kind.enum';
+import { IntegrationConfigSchema } from '../value-objects/integration-config-schema';
+
+/**
+ * MCP integration installed from the Ayunis marketplace.
+ * Auth is handled via config fields → headers rather than the legacy auth entity hierarchy.
+ * The auth entity is always NoAuthMcpIntegrationAuth.
+ */
+export class MarketplaceMcpIntegration extends McpIntegration {
+  public readonly marketplaceIdentifier: string;
+  public readonly configSchema: IntegrationConfigSchema;
+  private _orgConfigValues: Record<string, string>;
+  private readonly _serverUrl: string;
+
+  constructor(params: {
+    id?: UUID;
+    orgId: UUID;
+    name: string;
+    serverUrl: string;
+    marketplaceIdentifier: string;
+    configSchema: IntegrationConfigSchema;
+    orgConfigValues: Record<string, string>;
+    auth: McpIntegrationAuth;
+    enabled?: boolean;
+    createdAt?: Date;
+    updatedAt?: Date;
+    connectionStatus?: string;
+    lastConnectionError?: string;
+    lastConnectionCheck?: Date;
+    returnsPii?: boolean;
+  }) {
+    super({
+      id: params.id,
+      orgId: params.orgId,
+      name: params.name,
+      enabled: params.enabled,
+      createdAt: params.createdAt,
+      updatedAt: params.updatedAt,
+      connectionStatus: params.connectionStatus,
+      lastConnectionError: params.lastConnectionError,
+      lastConnectionCheck: params.lastConnectionCheck,
+      returnsPii: params.returnsPii,
+      auth: params.auth,
+    });
+
+    this.marketplaceIdentifier = params.marketplaceIdentifier;
+    this.configSchema = params.configSchema;
+    this._orgConfigValues = { ...params.orgConfigValues };
+    this._serverUrl = params.serverUrl;
+  }
+
+  get kind(): McpIntegrationKind {
+    return McpIntegrationKind.MARKETPLACE;
+  }
+
+  get serverUrl(): string {
+    return this._serverUrl;
+  }
+
+  get orgConfigValues(): Record<string, string> {
+    return { ...this._orgConfigValues };
+  }
+
+  updateOrgConfigValues(values: Record<string, string>): void {
+    this._orgConfigValues = { ...values };
+    this.touch();
+  }
+}

--- a/ayunis-core-backend/src/domain/mcp/domain/integrations/marketplace-mcp-integration.entity.ts
+++ b/ayunis-core-backend/src/domain/mcp/domain/integrations/marketplace-mcp-integration.entity.ts
@@ -1,8 +1,8 @@
-import { UUID } from 'crypto';
+import type { UUID } from 'crypto';
 import { McpIntegration } from '../mcp-integration.entity';
-import { McpIntegrationAuth } from '../auth/mcp-integration-auth.entity';
+import type { McpIntegrationAuth } from '../auth/mcp-integration-auth.entity';
 import { McpIntegrationKind } from '../value-objects/mcp-integration-kind.enum';
-import { IntegrationConfigSchema } from '../value-objects/integration-config-schema';
+import type { IntegrationConfigSchema } from '../value-objects/integration-config-schema';
 
 /**
  * MCP integration installed from the Ayunis marketplace.

--- a/ayunis-core-backend/src/domain/mcp/domain/mcp-integration-user-config.entity.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/domain/mcp-integration-user-config.entity.spec.ts
@@ -1,0 +1,92 @@
+import { randomUUID } from 'crypto';
+import { McpIntegrationUserConfig } from './mcp-integration-user-config.entity';
+
+describe('McpIntegrationUserConfig', () => {
+  const integrationId = randomUUID();
+  const userId = randomUUID();
+
+  it('should create with provided values', () => {
+    const config = new McpIntegrationUserConfig({
+      integrationId,
+      userId,
+      configValues: { personalToken: 'encrypted-personal-token' },
+    });
+
+    expect(config.id).toBeDefined();
+    expect(config.integrationId).toBe(integrationId);
+    expect(config.userId).toBe(userId);
+    expect(config.configValues).toEqual({
+      personalToken: 'encrypted-personal-token',
+    });
+    expect(config.createdAt).toBeInstanceOf(Date);
+    expect(config.updatedAt).toBeInstanceOf(Date);
+  });
+
+  it('should restore from persisted state with explicit id and dates', () => {
+    const id = randomUUID();
+    const createdAt = new Date('2025-06-01T00:00:00.000Z');
+    const updatedAt = new Date('2025-06-15T00:00:00.000Z');
+
+    const config = new McpIntegrationUserConfig({
+      id,
+      integrationId,
+      userId,
+      configValues: { token: 'value' },
+      createdAt,
+      updatedAt,
+    });
+
+    expect(config.id).toBe(id);
+    expect(config.createdAt).toBe(createdAt);
+    expect(config.updatedAt).toBe(updatedAt);
+  });
+
+  it('should update config values and refresh updatedAt', () => {
+    const config = new McpIntegrationUserConfig({
+      integrationId,
+      userId,
+      configValues: { personalToken: 'old-token' },
+    });
+
+    const previousUpdatedAt = config.updatedAt;
+
+    config.updateConfigValues({ personalToken: 'new-encrypted-token' });
+
+    expect(config.configValues).toEqual({
+      personalToken: 'new-encrypted-token',
+    });
+    expect(config.updatedAt.getTime()).toBeGreaterThanOrEqual(
+      previousUpdatedAt.getTime(),
+    );
+  });
+
+  it('should return value for a specific config key', () => {
+    const config = new McpIntegrationUserConfig({
+      integrationId,
+      userId,
+      configValues: {
+        personalToken: 'encrypted-token',
+        otherSetting: 'some-value',
+      },
+    });
+
+    expect(config.getConfigValue('personalToken')).toBe('encrypted-token');
+    expect(config.getConfigValue('otherSetting')).toBe('some-value');
+    expect(config.getConfigValue('nonexistent')).toBeUndefined();
+  });
+
+  it('should return a defensive copy of config values', () => {
+    const config = new McpIntegrationUserConfig({
+      integrationId,
+      userId,
+      configValues: { personalToken: 'encrypted-token' },
+    });
+
+    const values = config.configValues;
+    values['injected'] = 'hacked';
+
+    expect(config.configValues).toEqual({
+      personalToken: 'encrypted-token',
+    });
+  });
+});

--- a/ayunis-core-backend/src/domain/mcp/domain/mcp-integration-user-config.entity.ts
+++ b/ayunis-core-backend/src/domain/mcp/domain/mcp-integration-user-config.entity.ts
@@ -1,4 +1,5 @@
-import { randomUUID, UUID } from 'crypto';
+import type { UUID } from 'crypto';
+import { randomUUID } from 'crypto';
 
 /**
  * Per-user configuration for a marketplace MCP integration.

--- a/ayunis-core-backend/src/domain/mcp/domain/mcp-integration-user-config.entity.ts
+++ b/ayunis-core-backend/src/domain/mcp/domain/mcp-integration-user-config.entity.ts
@@ -1,0 +1,46 @@
+import { randomUUID, UUID } from 'crypto';
+
+/**
+ * Per-user configuration for a marketplace MCP integration.
+ * Stores user-level config values (e.g. personal access tokens)
+ * that override org-level values for matching header names at runtime.
+ *
+ * Unique constraint: one config per (integrationId, userId) pair.
+ */
+export class McpIntegrationUserConfig {
+  public readonly id: UUID;
+  public readonly integrationId: UUID;
+  public readonly userId: UUID;
+  private _configValues: Record<string, string>;
+  public readonly createdAt: Date;
+  public updatedAt: Date;
+
+  constructor(params: {
+    id?: UUID;
+    integrationId: UUID;
+    userId: UUID;
+    configValues: Record<string, string>;
+    createdAt?: Date;
+    updatedAt?: Date;
+  }) {
+    this.id = params.id ?? randomUUID();
+    this.integrationId = params.integrationId;
+    this.userId = params.userId;
+    this._configValues = { ...params.configValues };
+    this.createdAt = params.createdAt ?? new Date();
+    this.updatedAt = params.updatedAt ?? new Date();
+  }
+
+  get configValues(): Record<string, string> {
+    return { ...this._configValues };
+  }
+
+  updateConfigValues(values: Record<string, string>): void {
+    this._configValues = { ...values };
+    this.updatedAt = new Date();
+  }
+
+  getConfigValue(key: string): string | undefined {
+    return this._configValues[key];
+  }
+}

--- a/ayunis-core-backend/src/domain/mcp/domain/mcp-integration.entity.ts
+++ b/ayunis-core-backend/src/domain/mcp/domain/mcp-integration.entity.ts
@@ -108,6 +108,10 @@ export abstract class McpIntegration {
     return this.kind === McpIntegrationKind.CUSTOM;
   }
 
+  isMarketplace(): boolean {
+    return this.kind === McpIntegrationKind.MARKETPLACE;
+  }
+
   updateReturnsPii(value: boolean): void {
     this.returnsPii = value;
     this.touch();
@@ -120,3 +124,4 @@ export abstract class McpIntegration {
 
 export { CustomMcpIntegration } from './integrations/custom-mcp-integration.entity';
 export { PredefinedMcpIntegration } from './integrations/predefined-mcp-integration.entity';
+export { MarketplaceMcpIntegration } from './integrations/marketplace-mcp-integration.entity';

--- a/ayunis-core-backend/src/domain/mcp/domain/value-objects/integration-config-schema.ts
+++ b/ayunis-core-backend/src/domain/mcp/domain/value-objects/integration-config-schema.ts
@@ -1,0 +1,51 @@
+/**
+ * Defines a single configuration field for a marketplace MCP integration.
+ * Each field with a `headerName` maps to an HTTP header sent on every MCP request.
+ * Fields without `headerName` are internal config consumed by ayunis-core (e.g. OAuth credentials).
+ */
+export interface ConfigField {
+  /** Unique identifier within the schema */
+  key: string;
+  /** Display label for the frontend form */
+  label: string;
+  /** Field type: text (plaintext), url (validated URL), secret (encrypted at rest) */
+  type: 'text' | 'url' | 'secret';
+  /** HTTP header name this field maps to; if absent, field is internal config */
+  headerName?: string;
+  /** Optional prefix prepended to the value before sending (e.g., "Bearer ") */
+  prefix?: string;
+  /** Whether the field must be provided */
+  required: boolean;
+  /** Optional help text for the frontend form */
+  help?: string;
+  /** Fixed value from marketplace; if set, field is not shown in forms */
+  value?: string;
+}
+
+/**
+ * OAuth configuration for future OAuth support.
+ * Core rejects OAUTH authType at install in v1.
+ */
+export interface OAuthConfig {
+  authorizationUrl: string;
+  tokenUrl: string;
+  scopes: string[];
+  /** Whether admin authorizes once (org) or each user authorizes separately (user) */
+  level: 'org' | 'user';
+}
+
+/**
+ * Configuration schema for a marketplace MCP integration.
+ * Declares what fields are needed, at which level (org vs user),
+ * their header mappings, and whether they're secret.
+ */
+export interface IntegrationConfigSchema {
+  /** Auth type for documentation/UI purposes; does not drive transport behavior */
+  authType: string;
+  /** Fields configured by org admin at install time */
+  orgFields: ConfigField[];
+  /** Fields configured by individual users (optional, per-user overrides) */
+  userFields: ConfigField[];
+  /** Future OAuth configuration */
+  oauth?: OAuthConfig;
+}

--- a/ayunis-core-backend/src/domain/mcp/domain/value-objects/mcp-integration-kind.enum.ts
+++ b/ayunis-core-backend/src/domain/mcp/domain/value-objects/mcp-integration-kind.enum.ts
@@ -1,4 +1,5 @@
 export enum McpIntegrationKind {
   PREDEFINED = 'predefined',
   CUSTOM = 'custom',
+  MARKETPLACE = 'marketplace',
 }

--- a/ayunis-core-backend/src/domain/mcp/domain/value-objects/secret-mask.constant.ts
+++ b/ayunis-core-backend/src/domain/mcp/domain/value-objects/secret-mask.constant.ts
@@ -1,0 +1,5 @@
+/**
+ * Sentinel value used to mask secret fields in API responses.
+ * When the frontend sends this value back, it means "keep the existing secret".
+ */
+export const SECRET_MASK = '••••••';

--- a/ayunis-core-backend/src/domain/mcp/infrastructure/clients/mcp-sdk-client.adapter.ts
+++ b/ayunis-core-backend/src/domain/mcp/infrastructure/clients/mcp-sdk-client.adapter.ts
@@ -242,18 +242,16 @@ export class McpSdkClientAdapter extends McpClientPort {
    */
   private async createClient(config: McpConnectionConfig): Promise<Client> {
     // Create Streamable HTTP transport (MCP protocol 2024-11-05+)
-    // Only pass requestInit with headers when we have authentication to add
+    // Only pass requestInit with headers when we have headers to add
     // Otherwise, let the SDK handle the default headers (Accept, Content-Type, etc.)
-    const transport =
-      config.authHeaderName && config.authToken
-        ? new StreamableHTTPClientTransport(new URL(config.serverUrl), {
-            requestInit: {
-              headers: {
-                [config.authHeaderName]: config.authToken,
-              },
-            },
-          })
-        : new StreamableHTTPClientTransport(new URL(config.serverUrl));
+    const hasHeaders = config.headers && Object.keys(config.headers).length > 0;
+    const transport = hasHeaders
+      ? new StreamableHTTPClientTransport(new URL(config.serverUrl), {
+          requestInit: {
+            headers: { ...config.headers },
+          },
+        })
+      : new StreamableHTTPClientTransport(new URL(config.serverUrl));
 
     // Create client with capabilities
     const client = new Client({ name: 'ayunis-core', version: '1.0.0' });

--- a/ayunis-core-backend/src/domain/mcp/infrastructure/persistence/postgres/mappers/mcp-integration.mapper.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/infrastructure/persistence/postgres/mappers/mcp-integration.mapper.spec.ts
@@ -5,7 +5,7 @@ import { PredefinedMcpIntegration } from '../../../../domain/integrations/predef
 import { MarketplaceMcpIntegration } from '../../../../domain/integrations/marketplace-mcp-integration.entity';
 import { McpIntegrationKind } from '../../../../domain/value-objects/mcp-integration-kind.enum';
 import { PredefinedMcpIntegrationSlug } from '../../../../domain/value-objects/predefined-mcp-integration-slug.enum';
-import { IntegrationConfigSchema } from '../../../../domain/value-objects/integration-config-schema';
+import type { IntegrationConfigSchema } from '../../../../domain/value-objects/integration-config-schema';
 import { NoAuthMcpIntegrationAuth } from '../../../../domain/auth/no-auth-mcp-integration-auth.entity';
 import { BearerMcpIntegrationAuth } from '../../../../domain/auth/bearer-mcp-integration-auth.entity';
 import { CustomHeaderMcpIntegrationAuth } from '../../../../domain/auth/custom-header-mcp-integration-auth.entity';

--- a/ayunis-core-backend/src/domain/mcp/infrastructure/persistence/postgres/mappers/mcp-integration.mapper.ts
+++ b/ayunis-core-backend/src/domain/mcp/infrastructure/persistence/postgres/mappers/mcp-integration.mapper.ts
@@ -177,9 +177,7 @@ export class McpIntegrationMapper {
     return record;
   }
 
-  private authFromRecord(
-    record: McpIntegrationAuthRecord,
-  ): McpIntegrationAuth {
+  private authFromRecord(record: McpIntegrationAuthRecord): McpIntegrationAuth {
     if (record instanceof NoAuthMcpIntegrationAuthRecord) {
       return this.noAuthFromRecord(record);
     }

--- a/ayunis-core-backend/src/domain/mcp/infrastructure/persistence/postgres/mcp-integration-user-config.repository.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/infrastructure/persistence/postgres/mcp-integration-user-config.repository.spec.ts
@@ -1,0 +1,114 @@
+import { randomUUID } from 'crypto';
+import { Repository } from 'typeorm';
+import { McpIntegrationUserConfigRepository } from './mcp-integration-user-config.repository';
+import { McpIntegrationUserConfigRecord } from './schema/mcp-integration-user-config.record';
+import { McpIntegrationUserConfig } from '../../../domain/mcp-integration-user-config.entity';
+
+describe('McpIntegrationUserConfigRepository', () => {
+  let repository: McpIntegrationUserConfigRepository;
+  let mockTypeOrmRepo: jest.Mocked<Repository<McpIntegrationUserConfigRecord>>;
+
+  const integrationId = randomUUID();
+  const userId = randomUUID();
+  const configId = randomUUID();
+  const now = new Date('2026-01-15T10:00:00.000Z');
+
+  beforeEach(() => {
+    mockTypeOrmRepo = {
+      save: jest.fn(),
+      findOne: jest.fn(),
+      delete: jest.fn(),
+    } as unknown as jest.Mocked<Repository<McpIntegrationUserConfigRecord>>;
+
+    repository = new McpIntegrationUserConfigRepository(mockTypeOrmRepo);
+  });
+
+  describe('save', () => {
+    it('should persist user config and return domain entity', async () => {
+      const config = new McpIntegrationUserConfig({
+        id: configId,
+        integrationId,
+        userId,
+        configValues: { personalToken: 'encrypted-user-token' },
+        createdAt: now,
+        updatedAt: now,
+      });
+
+      const savedRecord = new McpIntegrationUserConfigRecord();
+      savedRecord.id = configId;
+      savedRecord.integrationId = integrationId;
+      savedRecord.userId = userId;
+      savedRecord.configValues = { personalToken: 'encrypted-user-token' };
+      savedRecord.createdAt = now;
+      savedRecord.updatedAt = now;
+
+      mockTypeOrmRepo.save.mockResolvedValue(savedRecord);
+
+      const result = await repository.save(config);
+
+      expect(mockTypeOrmRepo.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: configId,
+          integrationId,
+          userId,
+          configValues: { personalToken: 'encrypted-user-token' },
+        }),
+      );
+      expect(result).toBeInstanceOf(McpIntegrationUserConfig);
+      expect(result.id).toBe(configId);
+      expect(result.configValues).toEqual({
+        personalToken: 'encrypted-user-token',
+      });
+    });
+  });
+
+  describe('findByIntegrationAndUser', () => {
+    it('should return domain entity when config exists', async () => {
+      const record = new McpIntegrationUserConfigRecord();
+      record.id = configId;
+      record.integrationId = integrationId;
+      record.userId = userId;
+      record.configValues = { personalToken: 'encrypted-user-token' };
+      record.createdAt = now;
+      record.updatedAt = now;
+
+      mockTypeOrmRepo.findOne.mockResolvedValue(record);
+
+      const result = await repository.findByIntegrationAndUser(
+        integrationId,
+        userId,
+      );
+
+      expect(mockTypeOrmRepo.findOne).toHaveBeenCalledWith({
+        where: { integrationId, userId },
+      });
+      expect(result).toBeInstanceOf(McpIntegrationUserConfig);
+      expect(result?.integrationId).toBe(integrationId);
+      expect(result?.userId).toBe(userId);
+    });
+
+    it('should return null when no config exists', async () => {
+      mockTypeOrmRepo.findOne.mockResolvedValue(null);
+
+      const result = await repository.findByIntegrationAndUser(
+        integrationId,
+        userId,
+      );
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('deleteByIntegrationId', () => {
+    it('should delete all user configs for the given integration', async () => {
+      mockTypeOrmRepo.delete.mockResolvedValue({
+        affected: 3,
+        raw: [],
+      });
+
+      await repository.deleteByIntegrationId(integrationId);
+
+      expect(mockTypeOrmRepo.delete).toHaveBeenCalledWith({ integrationId });
+    });
+  });
+});

--- a/ayunis-core-backend/src/domain/mcp/infrastructure/persistence/postgres/mcp-integration-user-config.repository.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/infrastructure/persistence/postgres/mcp-integration-user-config.repository.spec.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'crypto';
-import { Repository } from 'typeorm';
+import type { Repository } from 'typeorm';
 import { McpIntegrationUserConfigRepository } from './mcp-integration-user-config.repository';
 import { McpIntegrationUserConfigRecord } from './schema/mcp-integration-user-config.record';
 import { McpIntegrationUserConfig } from '../../../domain/mcp-integration-user-config.entity';

--- a/ayunis-core-backend/src/domain/mcp/infrastructure/persistence/postgres/mcp-integration-user-config.repository.ts
+++ b/ayunis-core-backend/src/domain/mcp/infrastructure/persistence/postgres/mcp-integration-user-config.repository.ts
@@ -1,0 +1,86 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { UUID } from 'crypto';
+import { McpIntegrationUserConfigRepositoryPort } from '../../../application/ports/mcp-integration-user-config.repository.port';
+import { McpIntegrationUserConfig } from '../../../domain/mcp-integration-user-config.entity';
+import { McpIntegrationUserConfigRecord } from './schema/mcp-integration-user-config.record';
+
+/**
+ * PostgreSQL implementation of the MCP integration user config repository.
+ * Handles persistence of per-user configuration for marketplace integrations.
+ */
+@Injectable()
+export class McpIntegrationUserConfigRepository extends McpIntegrationUserConfigRepositoryPort {
+  private readonly logger = new Logger(McpIntegrationUserConfigRepository.name);
+
+  constructor(
+    @InjectRepository(McpIntegrationUserConfigRecord)
+    private readonly repository: Repository<McpIntegrationUserConfigRecord>,
+  ) {
+    super();
+  }
+
+  async save(
+    config: McpIntegrationUserConfig,
+  ): Promise<McpIntegrationUserConfig> {
+    this.logger.log('save', {
+      configId: config.id,
+      integrationId: config.integrationId,
+      userId: config.userId,
+    });
+
+    const record = this.toRecord(config);
+    const saved = await this.repository.save(record);
+    return this.toDomain(saved);
+  }
+
+  async findByIntegrationAndUser(
+    integrationId: UUID,
+    userId: UUID,
+  ): Promise<McpIntegrationUserConfig | null> {
+    this.logger.log('findByIntegrationAndUser', { integrationId, userId });
+
+    const record = await this.repository.findOne({
+      where: { integrationId, userId },
+    });
+
+    if (!record) {
+      return null;
+    }
+
+    return this.toDomain(record);
+  }
+
+  async deleteByIntegrationId(integrationId: UUID): Promise<void> {
+    this.logger.log('deleteByIntegrationId', { integrationId });
+
+    await this.repository.delete({ integrationId });
+  }
+
+  private toRecord(
+    entity: McpIntegrationUserConfig,
+  ): McpIntegrationUserConfigRecord {
+    const record = new McpIntegrationUserConfigRecord();
+    record.id = entity.id;
+    record.integrationId = entity.integrationId;
+    record.userId = entity.userId;
+    record.configValues = entity.configValues;
+    record.createdAt = entity.createdAt;
+    record.updatedAt = entity.updatedAt;
+    return record;
+  }
+
+  private toDomain(
+    record: McpIntegrationUserConfigRecord,
+  ): McpIntegrationUserConfig {
+    return new McpIntegrationUserConfig({
+      id: record.id,
+      integrationId: record.integrationId,
+      userId: record.userId,
+      configValues: record.configValues,
+      createdAt: record.createdAt,
+      updatedAt: record.updatedAt,
+    });
+  }
+}

--- a/ayunis-core-backend/src/domain/mcp/infrastructure/persistence/postgres/mcp-integration-user-config.repository.ts
+++ b/ayunis-core-backend/src/domain/mcp/infrastructure/persistence/postgres/mcp-integration-user-config.repository.ts
@@ -76,7 +76,7 @@ export class McpIntegrationUserConfigRepository extends McpIntegrationUserConfig
   ): McpIntegrationUserConfig {
     return new McpIntegrationUserConfig({
       id: record.id,
-      integrationId: record.integrationId,
+      integrationId: record.integrationId as UUID,
       userId: record.userId,
       configValues: record.configValues,
       createdAt: record.createdAt,

--- a/ayunis-core-backend/src/domain/mcp/infrastructure/persistence/postgres/mcp-integrations.repository.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/infrastructure/persistence/postgres/mcp-integrations.repository.spec.ts
@@ -4,7 +4,7 @@ import { McpIntegrationsRepository } from './mcp-integrations.repository';
 import { McpIntegrationRecord } from './schema/mcp-integration.record';
 import { McpIntegrationAuthRecord } from './schema/mcp-integration-auth.record';
 import type { PredefinedMcpIntegrationRecord } from './schema/predefined-mcp-integration.record';
-import { MarketplaceMcpIntegrationRecord } from './schema/marketplace-mcp-integration.record';
+import type { MarketplaceMcpIntegrationRecord } from './schema/marketplace-mcp-integration.record';
 import { McpIntegrationMapper } from './mappers/mcp-integration.mapper';
 import { McpIntegrationFactory } from '../../../application/factories/mcp-integration.factory';
 import { McpIntegrationAuthFactory } from '../../../application/factories/mcp-integration-auth.factory';

--- a/ayunis-core-backend/src/domain/mcp/infrastructure/persistence/postgres/mcp-integrations.repository.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/infrastructure/persistence/postgres/mcp-integrations.repository.spec.ts
@@ -4,6 +4,7 @@ import { McpIntegrationsRepository } from './mcp-integrations.repository';
 import { McpIntegrationRecord } from './schema/mcp-integration.record';
 import { McpIntegrationAuthRecord } from './schema/mcp-integration-auth.record';
 import type { PredefinedMcpIntegrationRecord } from './schema/predefined-mcp-integration.record';
+import { MarketplaceMcpIntegrationRecord } from './schema/marketplace-mcp-integration.record';
 import { McpIntegrationMapper } from './mappers/mcp-integration.mapper';
 import { McpIntegrationFactory } from '../../../application/factories/mcp-integration.factory';
 import { McpIntegrationAuthFactory } from '../../../application/factories/mcp-integration-auth.factory';
@@ -35,6 +36,7 @@ describe('McpIntegrationsRepository', () => {
   let ormRepository: InMemoryRepository<McpIntegrationRecord>;
   let authRepository: InMemoryRepository<McpIntegrationAuthRecord>;
   let predefinedRepository: InMemoryRepository<PredefinedMcpIntegrationRecord>;
+  let marketplaceRepository: InMemoryRepository<MarketplaceMcpIntegrationRecord>;
   let mapper: McpIntegrationMapper;
 
   beforeEach(() => {
@@ -42,6 +44,8 @@ describe('McpIntegrationsRepository', () => {
     authRepository = new InMemoryRepository<McpIntegrationAuthRecord>();
     predefinedRepository =
       new InMemoryRepository<PredefinedMcpIntegrationRecord>();
+    marketplaceRepository =
+      new InMemoryRepository<MarketplaceMcpIntegrationRecord>();
     mapper = new McpIntegrationMapper(
       new McpIntegrationFactory(),
       new McpIntegrationAuthFactory(),
@@ -67,6 +71,7 @@ describe('McpIntegrationsRepository', () => {
       ormRepository as unknown as Repository<McpIntegrationRecord>,
       authRepository as unknown as Repository<McpIntegrationAuthRecord>,
       predefinedRepository as unknown as Repository<PredefinedMcpIntegrationRecord>,
+      marketplaceRepository as unknown as Repository<MarketplaceMcpIntegrationRecord>,
       mapper,
     );
   });

--- a/ayunis-core-backend/src/domain/mcp/infrastructure/persistence/postgres/mcp-integrations.repository.ts
+++ b/ayunis-core-backend/src/domain/mcp/infrastructure/persistence/postgres/mcp-integrations.repository.ts
@@ -8,6 +8,7 @@ import { PredefinedMcpIntegrationSlug } from '../../../domain/value-objects/pred
 import { McpIntegrationRecord } from './schema/mcp-integration.record';
 import { McpIntegrationAuthRecord } from './schema/mcp-integration-auth.record';
 import { PredefinedMcpIntegrationRecord } from './schema/predefined-mcp-integration.record';
+import { MarketplaceMcpIntegrationRecord } from './schema/marketplace-mcp-integration.record';
 import { McpIntegrationMapper } from './mappers/mcp-integration.mapper';
 
 /**
@@ -25,6 +26,8 @@ export class McpIntegrationsRepository extends McpIntegrationsRepositoryPort {
     private readonly authRepository: Repository<McpIntegrationAuthRecord>,
     @InjectRepository(PredefinedMcpIntegrationRecord)
     private readonly predefinedRepository: Repository<PredefinedMcpIntegrationRecord>,
+    @InjectRepository(MarketplaceMcpIntegrationRecord)
+    private readonly marketplaceRepository: Repository<MarketplaceMcpIntegrationRecord>,
     private readonly mcpIntegrationMapper: McpIntegrationMapper,
   ) {
     super();
@@ -138,6 +141,29 @@ export class McpIntegrationsRepository extends McpIntegrationsRepositoryPort {
       },
       relations: {
         auth: true,
+      },
+    });
+
+    if (!record) {
+      return null;
+    }
+
+    return this.mcpIntegrationMapper.toDomain(record);
+  }
+
+  async findByOrgIdAndMarketplaceIdentifier(
+    orgId: UUID,
+    marketplaceIdentifier: string,
+  ): Promise<McpIntegration | null> {
+    this.logger.log('findByOrgIdAndMarketplaceIdentifier', {
+      orgId,
+      marketplaceIdentifier,
+    });
+
+    const record = await this.marketplaceRepository.findOne({
+      where: {
+        orgId,
+        marketplaceIdentifier,
       },
     });
 

--- a/ayunis-core-backend/src/domain/mcp/infrastructure/persistence/postgres/mcp-integrations.repository.ts
+++ b/ayunis-core-backend/src/domain/mcp/infrastructure/persistence/postgres/mcp-integrations.repository.ts
@@ -165,6 +165,9 @@ export class McpIntegrationsRepository extends McpIntegrationsRepositoryPort {
         orgId,
         marketplaceIdentifier,
       },
+      relations: {
+        auth: true,
+      },
     });
 
     if (!record) {

--- a/ayunis-core-backend/src/domain/mcp/infrastructure/persistence/postgres/mcp-integrations.repository.ts
+++ b/ayunis-core-backend/src/domain/mcp/infrastructure/persistence/postgres/mcp-integrations.repository.ts
@@ -30,7 +30,7 @@ export class McpIntegrationsRepository extends McpIntegrationsRepositoryPort {
     super();
   }
 
-  async save(integration: McpIntegration): Promise<McpIntegration> {
+  async save<T extends McpIntegration>(integration: T): Promise<T> {
     this.logger.log('save', { integrationId: integration.id });
 
     const recordResult = this.mcpIntegrationMapper.toRecord(integration);
@@ -75,7 +75,7 @@ export class McpIntegrationsRepository extends McpIntegrationsRepositoryPort {
       );
     }
 
-    return this.mcpIntegrationMapper.toDomain(reloadedRecord);
+    return this.mcpIntegrationMapper.toDomain(reloadedRecord) as T;
   }
 
   async findById(id: UUID): Promise<McpIntegration | null> {

--- a/ayunis-core-backend/src/domain/mcp/infrastructure/persistence/postgres/schema/index.ts
+++ b/ayunis-core-backend/src/domain/mcp/infrastructure/persistence/postgres/schema/index.ts
@@ -1,9 +1,12 @@
 export { McpIntegrationRecord } from './mcp-integration.record';
 export { CustomMcpIntegrationRecord } from './custom-mcp-integration.record';
 export { PredefinedMcpIntegrationRecord } from './predefined-mcp-integration.record';
+export { MarketplaceMcpIntegrationRecord } from './marketplace-mcp-integration.record';
 
 export { McpIntegrationAuthRecord } from './mcp-integration-auth.record';
 export { NoAuthMcpIntegrationAuthRecord } from './no-auth-mcp-integration-auth.record';
 export { BearerMcpIntegrationAuthRecord } from './bearer-mcp-integration-auth.record';
 export { CustomHeaderMcpIntegrationAuthRecord } from './custom-header-mcp-integration-auth.record';
 export { OAuthMcpIntegrationAuthRecord } from './oauth-mcp-integration-auth.record';
+
+export { McpIntegrationUserConfigRecord } from './mcp-integration-user-config.record';

--- a/ayunis-core-backend/src/domain/mcp/infrastructure/persistence/postgres/schema/marketplace-mcp-integration.record.ts
+++ b/ayunis-core-backend/src/domain/mcp/infrastructure/persistence/postgres/schema/marketplace-mcp-integration.record.ts
@@ -1,9 +1,10 @@
-import { ChildEntity, Column } from 'typeorm';
+import { ChildEntity, Column, Unique } from 'typeorm';
 import { McpIntegrationRecord } from './mcp-integration.record';
 import { McpIntegrationKind } from '../../../../domain/value-objects/mcp-integration-kind.enum';
 import { IntegrationConfigSchema } from '../../../../domain/value-objects/integration-config-schema';
 
 @ChildEntity(McpIntegrationKind.MARKETPLACE)
+@Unique(['orgId', 'marketplaceIdentifier'])
 export class MarketplaceMcpIntegrationRecord extends McpIntegrationRecord {
   @Column({ name: 'marketplace_identifier' })
   marketplaceIdentifier: string;

--- a/ayunis-core-backend/src/domain/mcp/infrastructure/persistence/postgres/schema/marketplace-mcp-integration.record.ts
+++ b/ayunis-core-backend/src/domain/mcp/infrastructure/persistence/postgres/schema/marketplace-mcp-integration.record.ts
@@ -1,0 +1,16 @@
+import { ChildEntity, Column } from 'typeorm';
+import { McpIntegrationRecord } from './mcp-integration.record';
+import { McpIntegrationKind } from '../../../../domain/value-objects/mcp-integration-kind.enum';
+import { IntegrationConfigSchema } from '../../../../domain/value-objects/integration-config-schema';
+
+@ChildEntity(McpIntegrationKind.MARKETPLACE)
+export class MarketplaceMcpIntegrationRecord extends McpIntegrationRecord {
+  @Column({ name: 'marketplace_identifier' })
+  marketplaceIdentifier: string;
+
+  @Column({ name: 'config_schema', type: 'jsonb' })
+  configSchema: IntegrationConfigSchema;
+
+  @Column({ name: 'org_config_values', type: 'jsonb', default: '{}' })
+  orgConfigValues: Record<string, string>;
+}

--- a/ayunis-core-backend/src/domain/mcp/infrastructure/persistence/postgres/schema/mcp-integration-user-config.record.ts
+++ b/ayunis-core-backend/src/domain/mcp/infrastructure/persistence/postgres/schema/mcp-integration-user-config.record.ts
@@ -5,8 +5,8 @@ import { UUID } from 'crypto';
 @Entity('mcp_integration_user_configs')
 @Unique(['integrationId', 'userId'])
 export class McpIntegrationUserConfigRecord extends BaseRecord {
-  @Column({ name: 'integration_id', type: 'uuid' })
-  integrationId: UUID;
+  @Column({ name: 'integration_id', type: 'varchar' })
+  integrationId: string;
 
   @Column({ name: 'user_id', type: 'uuid' })
   userId: UUID;

--- a/ayunis-core-backend/src/domain/mcp/infrastructure/persistence/postgres/schema/mcp-integration-user-config.record.ts
+++ b/ayunis-core-backend/src/domain/mcp/infrastructure/persistence/postgres/schema/mcp-integration-user-config.record.ts
@@ -1,0 +1,16 @@
+import { Column, Entity, Unique } from 'typeorm';
+import { BaseRecord } from '../../../../../../common/db/base-record';
+import { UUID } from 'crypto';
+
+@Entity('mcp_integration_user_configs')
+@Unique(['integrationId', 'userId'])
+export class McpIntegrationUserConfigRecord extends BaseRecord {
+  @Column({ name: 'integration_id', type: 'uuid' })
+  integrationId: UUID;
+
+  @Column({ name: 'user_id', type: 'uuid' })
+  userId: UUID;
+
+  @Column({ name: 'config_values', type: 'jsonb', default: '{}' })
+  configValues: Record<string, string>;
+}

--- a/ayunis-core-backend/src/domain/mcp/infrastructure/persistence/postgres/schema/mcp-integration.record.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/infrastructure/persistence/postgres/schema/mcp-integration.record.spec.ts
@@ -3,13 +3,16 @@ import {
   BearerMcpIntegrationAuthRecord,
   CustomHeaderMcpIntegrationAuthRecord,
   CustomMcpIntegrationRecord,
+  MarketplaceMcpIntegrationRecord,
   McpIntegrationAuthRecord,
   McpIntegrationRecord,
+  McpIntegrationUserConfigRecord,
   NoAuthMcpIntegrationAuthRecord,
   OAuthMcpIntegrationAuthRecord,
   PredefinedMcpIntegrationRecord,
 } from './index';
 import { PredefinedMcpIntegrationSlug } from '../../../../domain/value-objects/predefined-mcp-integration-slug.enum';
+import { IntegrationConfigSchema } from '../../../../domain/value-objects/integration-config-schema';
 
 describe('MCP Integration Persistence Records', () => {
   it('should instantiate custom integration record with base fields', () => {
@@ -90,5 +93,56 @@ describe('MCP Integration Persistence Records', () => {
 
     expect(auth.clientId).toBe('client');
     expect(auth.accessToken).toBe('access');
+  });
+
+  it('should instantiate marketplace integration record with config schema and org config values', () => {
+    const configSchema: IntegrationConfigSchema = {
+      authType: 'BEARER_TOKEN',
+      orgFields: [
+        {
+          key: 'apiToken',
+          label: 'API Token',
+          type: 'secret',
+          headerName: 'Authorization',
+          prefix: 'Bearer ',
+          required: true,
+        },
+      ],
+      userFields: [],
+    };
+
+    const record = new MarketplaceMcpIntegrationRecord();
+    record.id = randomUUID();
+    record.orgId = randomUUID();
+    record.name = 'OParl Integration';
+    record.serverUrl = 'https://mcp.ayunis.de/oparl';
+    record.marketplaceIdentifier = 'oparl-mcp';
+    record.configSchema = configSchema;
+    record.orgConfigValues = { apiToken: 'encrypted-token-value' };
+    record.enabled = true;
+
+    expect(record).toBeInstanceOf(MarketplaceMcpIntegrationRecord);
+    expect(record).toBeInstanceOf(McpIntegrationRecord);
+    expect(record.marketplaceIdentifier).toBe('oparl-mcp');
+    expect(record.configSchema.authType).toBe('BEARER_TOKEN');
+    expect(record.configSchema.orgFields).toHaveLength(1);
+    expect(record.orgConfigValues).toEqual({
+      apiToken: 'encrypted-token-value',
+    });
+  });
+
+  it('should instantiate user config record with integration and user references', () => {
+    const record = new McpIntegrationUserConfigRecord();
+    record.id = randomUUID();
+    record.integrationId = randomUUID();
+    record.userId = randomUUID();
+    record.configValues = { personalToken: 'encrypted-user-token' };
+
+    expect(record).toBeInstanceOf(McpIntegrationUserConfigRecord);
+    expect(record.integrationId).toBeDefined();
+    expect(record.userId).toBeDefined();
+    expect(record.configValues).toEqual({
+      personalToken: 'encrypted-user-token',
+    });
   });
 });

--- a/ayunis-core-backend/src/domain/mcp/infrastructure/persistence/postgres/schema/mcp-integration.record.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/infrastructure/persistence/postgres/schema/mcp-integration.record.spec.ts
@@ -12,7 +12,7 @@ import {
   PredefinedMcpIntegrationRecord,
 } from './index';
 import { PredefinedMcpIntegrationSlug } from '../../../../domain/value-objects/predefined-mcp-integration-slug.enum';
-import { IntegrationConfigSchema } from '../../../../domain/value-objects/integration-config-schema';
+import type { IntegrationConfigSchema } from '../../../../domain/value-objects/integration-config-schema';
 
 describe('MCP Integration Persistence Records', () => {
   it('should instantiate custom integration record with base fields', () => {

--- a/ayunis-core-backend/src/domain/mcp/mcp.module.ts
+++ b/ayunis-core-backend/src/domain/mcp/mcp.module.ts
@@ -6,6 +6,7 @@ import { McpClientPort } from './application/ports/mcp-client.port';
 import { McpSdkClientAdapter } from './infrastructure/clients/mcp-sdk-client.adapter';
 import { McpClientService } from './application/services/mcp-client.service';
 import { MarketplaceConfigService } from './application/services/marketplace-config.service';
+import { ConnectionValidationService } from './application/services/connection-validation.service';
 import { PredefinedMcpIntegrationRegistry } from './application/registries/predefined-mcp-integration-registry.service';
 import { McpIntegrationsRepositoryPort } from './application/ports/mcp-integrations.repository.port';
 import { McpIntegrationsRepository } from './infrastructure/persistence/postgres/mcp-integrations.repository';
@@ -95,6 +96,7 @@ import { PredefinedConfigDtoMapper } from './presenters/http/mappers/predefined-
     McpIntegrationAuthFactory,
     McpClientService,
     MarketplaceConfigService,
+    ConnectionValidationService,
     PredefinedMcpIntegrationRegistry,
     ValidateIntegrationAccessService,
     // Use Cases

--- a/ayunis-core-backend/src/domain/mcp/mcp.module.ts
+++ b/ayunis-core-backend/src/domain/mcp/mcp.module.ts
@@ -5,6 +5,7 @@ import { McpCredentialEncryptionService } from './infrastructure/encryption/mcp-
 import { McpClientPort } from './application/ports/mcp-client.port';
 import { McpSdkClientAdapter } from './infrastructure/clients/mcp-sdk-client.adapter';
 import { McpClientService } from './application/services/mcp-client.service';
+import { MarketplaceConfigService } from './application/services/marketplace-config.service';
 import { PredefinedMcpIntegrationRegistry } from './application/registries/predefined-mcp-integration-registry.service';
 import { McpIntegrationsRepositoryPort } from './application/ports/mcp-integrations.repository.port';
 import { McpIntegrationsRepository } from './infrastructure/persistence/postgres/mcp-integrations.repository';
@@ -93,6 +94,7 @@ import { PredefinedConfigDtoMapper } from './presenters/http/mappers/predefined-
     McpIntegrationFactory,
     McpIntegrationAuthFactory,
     McpClientService,
+    MarketplaceConfigService,
     PredefinedMcpIntegrationRegistry,
     ValidateIntegrationAccessService,
     // Use Cases

--- a/ayunis-core-backend/src/domain/mcp/mcp.module.ts
+++ b/ayunis-core-backend/src/domain/mcp/mcp.module.ts
@@ -26,9 +26,13 @@ import { McpIntegrationMapper } from './infrastructure/persistence/postgres/mapp
 import { McpIntegrationFactory } from './application/factories/mcp-integration.factory';
 import { McpIntegrationAuthFactory } from './application/factories/mcp-integration-auth.factory';
 import { SourcesModule } from '../sources/sources.module';
+import { MarketplaceModule } from '../marketplace/marketplace.module';
 
 // Use Cases
 import { CreateMcpIntegrationUseCase } from './application/use-cases/create-mcp-integration/create-mcp-integration.use-case';
+import { InstallMarketplaceIntegrationUseCase } from './application/use-cases/install-marketplace-integration/install-marketplace-integration.use-case';
+import { SetUserMcpConfigUseCase } from './application/use-cases/set-user-mcp-config/set-user-mcp-config.use-case';
+import { GetUserMcpConfigUseCase } from './application/use-cases/get-user-mcp-config/get-user-mcp-config.use-case';
 import { GetMcpIntegrationUseCase } from './application/use-cases/get-mcp-integration/get-mcp-integration.use-case';
 import { GetMcpIntegrationsByIdsUseCase } from './application/use-cases/get-mcp-integrations-by-ids/get-mcp-integrations-by-ids.use-case';
 import { ListOrgMcpIntegrationsUseCase } from './application/use-cases/list-org-mcp-integrations/list-org-mcp-integrations.use-case';
@@ -65,6 +69,7 @@ import { PredefinedConfigDtoMapper } from './presenters/http/mappers/predefined-
       McpIntegrationUserConfigRecord,
     ]),
     SourcesModule, // Import sources module for CreateDataSourceUseCase
+    MarketplaceModule,
   ],
   controllers: [McpIntegrationsController],
   providers: [
@@ -106,6 +111,9 @@ import { PredefinedConfigDtoMapper } from './presenters/http/mappers/predefined-
     DiscoverMcpCapabilitiesUseCase,
     ExecuteMcpToolUseCase,
     GetMcpPromptUseCase,
+    InstallMarketplaceIntegrationUseCase,
+    SetUserMcpConfigUseCase,
+    GetUserMcpConfigUseCase,
     // Mappers
     McpIntegrationDtoMapper,
     PredefinedConfigDtoMapper,

--- a/ayunis-core-backend/src/domain/mcp/mcp.module.ts
+++ b/ayunis-core-backend/src/domain/mcp/mcp.module.ts
@@ -8,12 +8,16 @@ import { McpClientService } from './application/services/mcp-client.service';
 import { PredefinedMcpIntegrationRegistry } from './application/registries/predefined-mcp-integration-registry.service';
 import { McpIntegrationsRepositoryPort } from './application/ports/mcp-integrations.repository.port';
 import { McpIntegrationsRepository } from './infrastructure/persistence/postgres/mcp-integrations.repository';
+import { McpIntegrationUserConfigRepositoryPort } from './application/ports/mcp-integration-user-config.repository.port';
+import { McpIntegrationUserConfigRepository } from './infrastructure/persistence/postgres/mcp-integration-user-config.repository';
 import {
   BearerMcpIntegrationAuthRecord,
   CustomHeaderMcpIntegrationAuthRecord,
   CustomMcpIntegrationRecord,
+  MarketplaceMcpIntegrationRecord,
   McpIntegrationAuthRecord,
   McpIntegrationRecord,
+  McpIntegrationUserConfigRecord,
   NoAuthMcpIntegrationAuthRecord,
   OAuthMcpIntegrationAuthRecord,
   PredefinedMcpIntegrationRecord,
@@ -52,11 +56,13 @@ import { PredefinedConfigDtoMapper } from './presenters/http/mappers/predefined-
       McpIntegrationRecord,
       CustomMcpIntegrationRecord,
       PredefinedMcpIntegrationRecord,
+      MarketplaceMcpIntegrationRecord,
       McpIntegrationAuthRecord,
       NoAuthMcpIntegrationAuthRecord,
       BearerMcpIntegrationAuthRecord,
       CustomHeaderMcpIntegrationAuthRecord,
       OAuthMcpIntegrationAuthRecord,
+      McpIntegrationUserConfigRecord,
     ]),
     SourcesModule, // Import sources module for CreateDataSourceUseCase
   ],
@@ -73,6 +79,10 @@ import { PredefinedConfigDtoMapper } from './presenters/http/mappers/predefined-
     {
       provide: McpIntegrationsRepositoryPort,
       useClass: McpIntegrationsRepository,
+    },
+    {
+      provide: McpIntegrationUserConfigRepositoryPort,
+      useClass: McpIntegrationUserConfigRepository,
     },
     McpIntegrationMapper,
     McpIntegrationFactory,
@@ -104,6 +114,7 @@ import { PredefinedConfigDtoMapper } from './presenters/http/mappers/predefined-
     McpCredentialEncryptionPort,
     McpClientPort,
     McpIntegrationsRepositoryPort,
+    McpIntegrationUserConfigRepositoryPort,
     PredefinedMcpIntegrationRegistry,
     RetrieveMcpResourceUseCase,
     DiscoverMcpCapabilitiesUseCase,

--- a/ayunis-core-backend/src/domain/mcp/presenters/http/dto/install-marketplace-integration.dto.ts
+++ b/ayunis-core-backend/src/domain/mcp/presenters/http/dto/install-marketplace-integration.dto.ts
@@ -1,0 +1,45 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  IsString,
+  IsNotEmpty,
+  IsObject,
+  IsOptional,
+  IsBoolean,
+} from 'class-validator';
+
+/**
+ * DTO for installing a marketplace MCP integration.
+ * The identifier references the integration on the marketplace.
+ * orgConfigValues contains user-provided org-level configuration values
+ * (fixed-value fields from the schema are merged server-side).
+ */
+export class InstallMarketplaceIntegrationDto {
+  @ApiProperty({
+    description: 'Marketplace integration identifier',
+    example: 'oparl-council-data',
+  })
+  @IsString()
+  @IsNotEmpty()
+  identifier: string;
+
+  @ApiProperty({
+    description:
+      'Organization-level configuration values (key-value pairs matching config schema orgFields)',
+    example: {
+      oparlEndpointUrl: 'https://rim.ekom21.de/oparl/v1',
+    },
+    type: 'object',
+    additionalProperties: { type: 'string' },
+  })
+  @IsObject()
+  orgConfigValues: Record<string, string>;
+
+  @ApiPropertyOptional({
+    description:
+      'Whether tools from this integration may return PII data that should be anonymized in anonymous mode',
+    example: false,
+  })
+  @IsOptional()
+  @IsBoolean()
+  returnsPii?: boolean;
+}

--- a/ayunis-core-backend/src/domain/mcp/presenters/http/dto/install-marketplace-integration.dto.ts
+++ b/ayunis-core-backend/src/domain/mcp/presenters/http/dto/install-marketplace-integration.dto.ts
@@ -6,6 +6,7 @@ import {
   IsOptional,
   IsBoolean,
 } from 'class-validator';
+import { IsStringRecord } from 'src/common/validators/is-string-record.validator';
 
 /**
  * DTO for installing a marketplace MCP integration.
@@ -32,6 +33,7 @@ export class InstallMarketplaceIntegrationDto {
     additionalProperties: { type: 'string' },
   })
   @IsObject()
+  @IsStringRecord({ message: 'all values in orgConfigValues must be strings' })
   orgConfigValues: Record<string, string>;
 
   @ApiPropertyOptional({

--- a/ayunis-core-backend/src/domain/mcp/presenters/http/dto/mcp-integration-response.dto.ts
+++ b/ayunis-core-backend/src/domain/mcp/presenters/http/dto/mcp-integration-response.dto.ts
@@ -21,10 +21,10 @@ export class McpIntegrationResponseDto {
 
   @ApiProperty({
     description: 'Type of integration',
-    enum: ['predefined', 'custom'],
+    enum: ['predefined', 'custom', 'marketplace'],
     example: 'predefined',
   })
-  type: 'predefined' | 'custom';
+  type: 'predefined' | 'custom' | 'marketplace';
 
   @ApiProperty({
     description:
@@ -115,4 +115,31 @@ export class McpIntegrationResponseDto {
     example: true,
   })
   returnsPii: boolean;
+
+  @ApiProperty({
+    description:
+      'Marketplace integration identifier (only for marketplace integrations)',
+    required: false,
+    example: 'oparl-council-data',
+  })
+  marketplaceIdentifier?: string;
+
+  @ApiProperty({
+    description:
+      'Configuration schema from marketplace (only for marketplace integrations)',
+    required: false,
+  })
+  configSchema?: {
+    authType: string;
+    orgFields: unknown[];
+    userFields: unknown[];
+  };
+
+  @ApiProperty({
+    description:
+      'Whether this marketplace integration has user-level config fields',
+    required: false,
+    example: false,
+  })
+  hasUserFields?: boolean;
 }

--- a/ayunis-core-backend/src/domain/mcp/presenters/http/dto/mcp-integration-response.dto.ts
+++ b/ayunis-core-backend/src/domain/mcp/presenters/http/dto/mcp-integration-response.dto.ts
@@ -142,4 +142,13 @@ export class McpIntegrationResponseDto {
     example: false,
   })
   hasUserFields?: boolean;
+
+  @ApiProperty({
+    description:
+      'Current org-level config values for marketplace integrations. ' +
+      'Non-secret fields contain plaintext values. Secret fields are masked with "••••••".',
+    required: false,
+    example: { endpointUrl: 'https://example.com/api', apiToken: '••••••' },
+  })
+  orgConfigValues?: Record<string, string>;
 }

--- a/ayunis-core-backend/src/domain/mcp/presenters/http/dto/update-mcp-integration.dto.ts
+++ b/ayunis-core-backend/src/domain/mcp/presenters/http/dto/update-mcp-integration.dto.ts
@@ -3,6 +3,7 @@ import {
   IsString,
   IsOptional,
   IsBoolean,
+  IsObject,
   Length,
   MinLength,
 } from 'class-validator';
@@ -62,4 +63,14 @@ export class UpdateMcpIntegrationDto {
   @IsOptional()
   @IsBoolean()
   returnsPii?: boolean;
+
+  @ApiPropertyOptional({
+    description:
+      'Org-level config values for marketplace integrations. ' +
+      'For secret fields, omit or send empty string to keep the existing value.',
+    example: { endpointUrl: 'https://example.com/api' },
+  })
+  @IsOptional()
+  @IsObject()
+  orgConfigValues?: Record<string, string>;
 }

--- a/ayunis-core-backend/src/domain/mcp/presenters/http/dto/update-mcp-integration.dto.ts
+++ b/ayunis-core-backend/src/domain/mcp/presenters/http/dto/update-mcp-integration.dto.ts
@@ -7,6 +7,7 @@ import {
   Length,
   MinLength,
 } from 'class-validator';
+import { IsStringRecord } from 'src/common/validators/is-string-record.validator';
 
 /**
  * DTO for updating an existing MCP integration.
@@ -72,5 +73,6 @@ export class UpdateMcpIntegrationDto {
   })
   @IsOptional()
   @IsObject()
+  @IsStringRecord({ message: 'all values in orgConfigValues must be strings' })
   orgConfigValues?: Record<string, string>;
 }

--- a/ayunis-core-backend/src/domain/mcp/presenters/http/dto/user-config.dto.ts
+++ b/ayunis-core-backend/src/domain/mcp/presenters/http/dto/user-config.dto.ts
@@ -1,0 +1,38 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsObject } from 'class-validator';
+
+/**
+ * DTO for setting per-user configuration on a marketplace MCP integration.
+ */
+export class SetUserConfigDto {
+  @ApiProperty({
+    description:
+      'User-level configuration values (key-value pairs matching config schema userFields)',
+    example: { personalToken: 'my-personal-access-token' },
+    type: 'object',
+    additionalProperties: { type: 'string' },
+  })
+  @IsObject()
+  configValues: Record<string, string>;
+}
+
+/**
+ * Response DTO for user configuration.
+ * Secret values are masked — only keys are visible.
+ */
+export class UserConfigResponseDto {
+  @ApiProperty({
+    description: 'Whether the user has configured values for this integration',
+    example: true,
+  })
+  hasConfig: boolean;
+
+  @ApiProperty({
+    description:
+      'Configuration values with secret values masked (keys present, values replaced with "***")',
+    example: { personalToken: '***' },
+    type: 'object',
+    additionalProperties: { type: 'string' },
+  })
+  configValues: Record<string, string>;
+}

--- a/ayunis-core-backend/src/domain/mcp/presenters/http/dto/user-config.dto.ts
+++ b/ayunis-core-backend/src/domain/mcp/presenters/http/dto/user-config.dto.ts
@@ -1,5 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsObject } from 'class-validator';
+import { IsStringRecord } from 'src/common/validators/is-string-record.validator';
 
 /**
  * DTO for setting per-user configuration on a marketplace MCP integration.
@@ -13,6 +14,7 @@ export class SetUserConfigDto {
     additionalProperties: { type: 'string' },
   })
   @IsObject()
+  @IsStringRecord({ message: 'all values in configValues must be strings' })
   configValues: Record<string, string>;
 }
 
@@ -29,8 +31,8 @@ export class UserConfigResponseDto {
 
   @ApiProperty({
     description:
-      'Configuration values with secret values masked (keys present, values replaced with "***")',
-    example: { personalToken: '***' },
+      'Configuration values with secret values masked (keys present, values replaced with "••••••")',
+    example: { personalToken: '••••••' },
     type: 'object',
     additionalProperties: { type: 'string' },
   })

--- a/ayunis-core-backend/src/domain/mcp/presenters/http/mappers/mcp-integration-dto.mapper.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/presenters/http/mappers/mcp-integration-dto.mapper.spec.ts
@@ -7,7 +7,8 @@ import { BearerMcpIntegrationAuth } from '../../../domain/auth/bearer-mcp-integr
 import { CustomHeaderMcpIntegrationAuth } from '../../../domain/auth/custom-header-mcp-integration-auth.entity';
 import { NoAuthMcpIntegrationAuth } from '../../../domain/auth/no-auth-mcp-integration-auth.entity';
 import { PredefinedMcpIntegrationSlug } from '../../../domain/value-objects/predefined-mcp-integration-slug.enum';
-import { IntegrationConfigSchema } from '../../../domain/value-objects/integration-config-schema';
+import type { IntegrationConfigSchema } from '../../../domain/value-objects/integration-config-schema';
+import { SECRET_MASK } from '../../../domain/value-objects/secret-mask.constant';
 
 describe('McpIntegrationDtoMapper', () => {
   const mapper = new McpIntegrationDtoMapper();
@@ -115,7 +116,7 @@ describe('McpIntegrationDtoMapper', () => {
     expect(dto.serverUrl).toBeUndefined();
     expect(dto.slug).toBeUndefined();
     // Secret field is masked
-    expect(dto.orgConfigValues).toEqual({ apiToken: '••••••' });
+    expect(dto.orgConfigValues).toEqual({ apiToken: SECRET_MASK });
   });
 
   it('maps marketplace integration without user fields', () => {
@@ -187,7 +188,7 @@ describe('McpIntegrationDtoMapper', () => {
 
     expect(dto.orgConfigValues).toEqual({
       endpointUrl: 'https://rim.ekom21.de/oparl/v1',
-      apiToken: '••••••',
+      apiToken: SECRET_MASK,
       description: 'Municipal council data',
     });
   });

--- a/ayunis-core-backend/src/domain/mcp/presenters/http/mappers/mcp-integration-dto.mapper.ts
+++ b/ayunis-core-backend/src/domain/mcp/presenters/http/mappers/mcp-integration-dto.mapper.ts
@@ -8,6 +8,7 @@ import { McpIntegrationResponseDto } from '../dto/mcp-integration-response.dto';
 import { PredefinedMcpIntegration } from 'src/domain/mcp/domain';
 import { MarketplaceMcpIntegration } from 'src/domain/mcp/domain/integrations/marketplace-mcp-integration.entity';
 import { ConfigField } from 'src/domain/mcp/domain/value-objects/integration-config-schema';
+import { SECRET_MASK } from 'src/domain/mcp/domain/value-objects/secret-mask.constant';
 
 /**
  * Mapper for converting MCP integration entities to DTOs.
@@ -77,10 +78,10 @@ export class McpIntegrationDtoMapper {
     switch (integration.kind) {
       case McpIntegrationKind.PREDEFINED:
         return 'predefined';
+      case McpIntegrationKind.CUSTOM:
+        return 'custom';
       case McpIntegrationKind.MARKETPLACE:
         return 'marketplace';
-      default:
-        return 'custom';
     }
   }
 
@@ -132,7 +133,7 @@ export class McpIntegrationDtoMapper {
       }
 
       if (field.type === 'secret') {
-        masked[field.key] = '••••••';
+        masked[field.key] = SECRET_MASK;
       } else {
         masked[field.key] = currentValue;
       }

--- a/ayunis-core-backend/src/domain/mcp/presenters/http/mcp-integrations.controller.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/presenters/http/mcp-integrations.controller.spec.ts
@@ -14,6 +14,9 @@ import { EnableMcpIntegrationUseCase } from '../../application/use-cases/enable-
 import { DisableMcpIntegrationUseCase } from '../../application/use-cases/disable-mcp-integration/disable-mcp-integration.use-case';
 import { ValidateMcpIntegrationUseCase } from '../../application/use-cases/validate-mcp-integration/validate-mcp-integration.use-case';
 import { ListPredefinedMcpIntegrationConfigsUseCase } from '../../application/use-cases/list-predefined-mcp-integration-configs/list-predefined-mcp-integration-configs.use-case';
+import { InstallMarketplaceIntegrationUseCase } from '../../application/use-cases/install-marketplace-integration/install-marketplace-integration.use-case';
+import { SetUserMcpConfigUseCase } from '../../application/use-cases/set-user-mcp-config/set-user-mcp-config.use-case';
+import { GetUserMcpConfigUseCase } from '../../application/use-cases/get-user-mcp-config/get-user-mcp-config.use-case';
 import {
   PredefinedMcpIntegration,
   CustomMcpIntegration,
@@ -70,6 +73,15 @@ describe('McpIntegrationsController', () => {
     const mockListConfigsUseCase = {
       execute: jest.fn(),
     };
+    const mockInstallMarketplaceUseCase = {
+      execute: jest.fn(),
+    };
+    const mockSetUserConfigUseCase = {
+      execute: jest.fn(),
+    };
+    const mockGetUserConfigUseCase = {
+      execute: jest.fn(),
+    };
 
     const module: TestingModule = await Test.createTestingModule({
       controllers: [McpIntegrationsController],
@@ -115,6 +127,18 @@ describe('McpIntegrationsController', () => {
         {
           provide: ListPredefinedMcpIntegrationConfigsUseCase,
           useValue: mockListConfigsUseCase,
+        },
+        {
+          provide: InstallMarketplaceIntegrationUseCase,
+          useValue: mockInstallMarketplaceUseCase,
+        },
+        {
+          provide: SetUserMcpConfigUseCase,
+          useValue: mockSetUserConfigUseCase,
+        },
+        {
+          provide: GetUserMcpConfigUseCase,
+          useValue: mockGetUserConfigUseCase,
         },
         {
           provide: ConfigService,

--- a/ayunis-core-backend/src/domain/mcp/presenters/http/mcp-integrations.controller.ts
+++ b/ayunis-core-backend/src/domain/mcp/presenters/http/mcp-integrations.controller.ts
@@ -377,6 +377,7 @@ export class McpIntegrationsController {
   }
 
   @Get(':id/user-config')
+  @Roles(UserRole.USER, UserRole.ADMIN)
   @ApiOperation({
     summary: 'Get current user config for a marketplace MCP integration',
   })
@@ -402,6 +403,7 @@ export class McpIntegrationsController {
   }
 
   @Patch(':id/user-config')
+  @Roles(UserRole.USER, UserRole.ADMIN)
   @ApiOperation({
     summary: 'Set current user config for a marketplace MCP integration',
   })

--- a/ayunis-core-backend/src/domain/mcp/presenters/http/mcp-integrations.controller.ts
+++ b/ayunis-core-backend/src/domain/mcp/presenters/http/mcp-integrations.controller.ts
@@ -421,18 +421,7 @@ export class McpIntegrationsController {
 
     const command = new SetUserMcpConfigCommand(id, dto.configValues);
 
-    const config = await this.setUserMcpConfigUseCase.execute(command);
-
-    // Return masked values
-    const maskedValues: Record<string, string> = {};
-    for (const key of Object.keys(config.configValues)) {
-      maskedValues[key] = '***';
-    }
-
-    return {
-      hasConfig: true,
-      configValues: maskedValues,
-    };
+    return this.setUserMcpConfigUseCase.execute(command);
   }
 
   @Post(':id/validate')

--- a/ayunis-core-backend/src/domain/mcp/presenters/http/mcp-integrations.controller.ts
+++ b/ayunis-core-backend/src/domain/mcp/presenters/http/mcp-integrations.controller.ts
@@ -267,13 +267,14 @@ export class McpIntegrationsController {
   ): Promise<McpIntegrationResponseDto> {
     this.logger.log('update', { id });
 
-    const command = new UpdateMcpIntegrationCommand(
-      id,
-      dto.name,
-      dto.credentials,
-      dto.authHeaderName,
-      dto.returnsPii,
-    );
+    const command = new UpdateMcpIntegrationCommand({
+      integrationId: id,
+      name: dto.name,
+      credentials: dto.credentials,
+      authHeaderName: dto.authHeaderName,
+      returnsPii: dto.returnsPii,
+      orgConfigValues: dto.orgConfigValues,
+    });
 
     const integration = await this.updateMcpIntegrationUseCase.execute(command);
     return this.mcpIntegrationDtoMapper.toDto(integration);

--- a/ayunis-core-backend/src/domain/mcp/presenters/http/mcp-integrations.controller.ts
+++ b/ayunis-core-backend/src/domain/mcp/presenters/http/mcp-integrations.controller.ts
@@ -27,6 +27,8 @@ import { UserRole } from 'src/iam/users/domain/value-objects/role.object';
 import { CreatePredefinedIntegrationDto } from './dto/create-predefined-integration.dto';
 import { CreateCustomIntegrationDto } from './dto/create-custom-integration.dto';
 import { UpdateMcpIntegrationDto } from './dto/update-mcp-integration.dto';
+import { InstallMarketplaceIntegrationDto } from './dto/install-marketplace-integration.dto';
+import { SetUserConfigDto, UserConfigResponseDto } from './dto/user-config.dto';
 import { McpIntegrationResponseDto } from './dto/mcp-integration-response.dto';
 import { ValidationResponseDto } from './dto/validation-response.dto';
 import { PredefinedConfigResponseDto } from './dto/predefined-config-response.dto';
@@ -46,6 +48,9 @@ import { EnableMcpIntegrationUseCase } from '../../application/use-cases/enable-
 import { DisableMcpIntegrationUseCase } from '../../application/use-cases/disable-mcp-integration/disable-mcp-integration.use-case';
 import { ValidateMcpIntegrationUseCase } from '../../application/use-cases/validate-mcp-integration/validate-mcp-integration.use-case';
 import { ListPredefinedMcpIntegrationConfigsUseCase } from '../../application/use-cases/list-predefined-mcp-integration-configs/list-predefined-mcp-integration-configs.use-case';
+import { InstallMarketplaceIntegrationUseCase } from '../../application/use-cases/install-marketplace-integration/install-marketplace-integration.use-case';
+import { SetUserMcpConfigUseCase } from '../../application/use-cases/set-user-mcp-config/set-user-mcp-config.use-case';
+import { GetUserMcpConfigUseCase } from '../../application/use-cases/get-user-mcp-config/get-user-mcp-config.use-case';
 
 // Commands and Queries
 import { CreatePredefinedMcpIntegrationCommand } from '../../application/use-cases/create-mcp-integration/create-predefined-mcp-integration.command';
@@ -56,6 +61,9 @@ import { DeleteMcpIntegrationCommand } from '../../application/use-cases/delete-
 import { EnableMcpIntegrationCommand } from '../../application/use-cases/enable-mcp-integration/enable-mcp-integration.command';
 import { DisableMcpIntegrationCommand } from '../../application/use-cases/disable-mcp-integration/disable-mcp-integration.command';
 import { ValidateMcpIntegrationCommand } from '../../application/use-cases/validate-mcp-integration/validate-mcp-integration.command';
+import { InstallMarketplaceIntegrationCommand } from '../../application/use-cases/install-marketplace-integration/install-marketplace-integration.command';
+import { SetUserMcpConfigCommand } from '../../application/use-cases/set-user-mcp-config/set-user-mcp-config.command';
+import { GetUserMcpConfigQuery } from '../../application/use-cases/get-user-mcp-config/get-user-mcp-config.query';
 import { CredentialFieldValue } from '../../domain/predefined-mcp-integration-config';
 import { ConfigService } from '@nestjs/config';
 
@@ -80,6 +88,9 @@ export class McpIntegrationsController {
     private readonly disableMcpIntegrationUseCase: DisableMcpIntegrationUseCase,
     private readonly validateMcpIntegrationUseCase: ValidateMcpIntegrationUseCase,
     private readonly listPredefinedConfigsUseCase: ListPredefinedMcpIntegrationConfigsUseCase,
+    private readonly installMarketplaceIntegrationUseCase: InstallMarketplaceIntegrationUseCase,
+    private readonly setUserMcpConfigUseCase: SetUserMcpConfigUseCase,
+    private readonly getUserMcpConfigUseCase: GetUserMcpConfigUseCase,
     private readonly mcpIntegrationDtoMapper: McpIntegrationDtoMapper,
     private readonly predefinedConfigDtoMapper: PredefinedConfigDtoMapper,
     private readonly configService: ConfigService,
@@ -325,6 +336,103 @@ export class McpIntegrationsController {
     );
 
     return this.mcpIntegrationDtoMapper.toDto(integration);
+  }
+
+  @Post('install-from-marketplace')
+  @Roles(UserRole.ADMIN)
+  @ApiOperation({
+    summary: 'Install an MCP integration from the marketplace',
+  })
+  @ApiBody({ type: InstallMarketplaceIntegrationDto })
+  @ApiResponse({
+    status: 201,
+    description: 'Integration installed successfully',
+    type: McpIntegrationResponseDto,
+  })
+  @ApiResponse({
+    status: 400,
+    description: 'Missing required config fields or OAuth not supported',
+  })
+  @ApiResponse({
+    status: 404,
+    description: 'Marketplace integration not found',
+  })
+  async installFromMarketplace(
+    @Body() dto: InstallMarketplaceIntegrationDto,
+  ): Promise<McpIntegrationResponseDto> {
+    this.logger.log('installFromMarketplace', {
+      identifier: dto.identifier,
+    });
+
+    const command = new InstallMarketplaceIntegrationCommand(
+      dto.identifier,
+      dto.orgConfigValues,
+      dto.returnsPii,
+    );
+
+    const integration =
+      await this.installMarketplaceIntegrationUseCase.execute(command);
+    return this.mcpIntegrationDtoMapper.toDto(integration);
+  }
+
+  @Get(':id/user-config')
+  @ApiOperation({
+    summary: 'Get current user config for a marketplace MCP integration',
+  })
+  @ApiParam({ name: 'id', type: 'string', format: 'uuid' })
+  @ApiResponse({
+    status: 200,
+    description: 'User configuration (secret values masked)',
+    type: UserConfigResponseDto,
+  })
+  async getUserConfig(
+    @Param('id', ParseUUIDPipe) id: UUID,
+  ): Promise<UserConfigResponseDto> {
+    this.logger.log('getUserConfig', { id });
+
+    const result = await this.getUserMcpConfigUseCase.execute(
+      new GetUserMcpConfigQuery(id),
+    );
+
+    return {
+      hasConfig: result.hasConfig,
+      configValues: result.configValues,
+    };
+  }
+
+  @Patch(':id/user-config')
+  @ApiOperation({
+    summary: 'Set current user config for a marketplace MCP integration',
+  })
+  @ApiParam({ name: 'id', type: 'string', format: 'uuid' })
+  @ApiBody({ type: SetUserConfigDto })
+  @ApiResponse({
+    status: 200,
+    description: 'User configuration saved',
+    type: UserConfigResponseDto,
+  })
+  @ApiResponse({ status: 400, description: 'Integration has no user fields' })
+  @ApiResponse({ status: 404, description: 'Integration not found' })
+  async setUserConfig(
+    @Param('id', ParseUUIDPipe) id: UUID,
+    @Body() dto: SetUserConfigDto,
+  ): Promise<UserConfigResponseDto> {
+    this.logger.log('setUserConfig', { id });
+
+    const command = new SetUserMcpConfigCommand(id, dto.configValues);
+
+    const config = await this.setUserMcpConfigUseCase.execute(command);
+
+    // Return masked values
+    const maskedValues: Record<string, string> = {};
+    for (const key of Object.keys(config.configValues)) {
+      maskedValues[key] = '***';
+    }
+
+    return {
+      hasConfig: true,
+      configValues: maskedValues,
+    };
   }
 
   @Post(':id/validate')

--- a/ayunis-core-backend/src/domain/skills/application/services/marketplace-skill-installation.service.spec.ts
+++ b/ayunis-core-backend/src/domain/skills/application/services/marketplace-skill-installation.service.spec.ts
@@ -44,6 +44,7 @@ describe('MarketplaceSkillInstallationService', () => {
     marketplaceClient = {
       getPreInstalledSkills: jest.fn(),
       getSkillByIdentifier: jest.fn(),
+      getIntegrationByIdentifier: jest.fn(),
     } as jest.Mocked<MarketplaceClient>;
 
     service = new MarketplaceSkillInstallationService(

--- a/ayunis-core-frontend/src/app/routes/_authenticated/install.tsx
+++ b/ayunis-core-frontend/src/app/routes/_authenticated/install.tsx
@@ -1,7 +1,13 @@
 import { createFileRoute } from '@tanstack/react-router';
 import { z } from 'zod';
-import { InstallPage } from '@/pages/install';
-import InstallIntegrationPage from '@/pages/install/ui/InstallIntegrationPage';
+import {
+  InstallPage,
+  InstallIntegrationPage,
+  InstallErrorState,
+} from '@/pages/install';
+import AppLayout from '@/layouts/app-layout';
+import FullScreenMessageLayout from '@/layouts/full-screen-message-layout/ui/FullScreenMessageLayout';
+import { useTranslation } from 'react-i18next';
 
 const searchSchema = z.object({
   skill: z.string().optional(),
@@ -15,10 +21,32 @@ export const Route = createFileRoute('/_authenticated/install')({
 
 function RouteComponent() {
   const { skill, integration } = Route.useSearch();
+  const { user } = Route.useRouteContext();
+  const isAdmin = user?.role === 'admin';
 
   if (integration) {
+    if (!isAdmin) {
+      return <AdminRequiredMessage />;
+    }
     return <InstallIntegrationPage integrationIdentifier={integration} />;
   }
 
   return <InstallPage skillIdentifier={skill} />;
+}
+
+function AdminRequiredMessage() {
+  const { t } = useTranslation('install-integration');
+
+  return (
+    <AppLayout>
+      <FullScreenMessageLayout>
+        <InstallErrorState
+          title={t('error.adminRequired.title')}
+          description={t('error.adminRequired.description')}
+          backTo="/"
+          backLabel={t('action.backToIntegrations')}
+        />
+      </FullScreenMessageLayout>
+    </AppLayout>
+  );
 }

--- a/ayunis-core-frontend/src/app/routes/_authenticated/install.tsx
+++ b/ayunis-core-frontend/src/app/routes/_authenticated/install.tsx
@@ -1,9 +1,11 @@
 import { createFileRoute } from '@tanstack/react-router';
 import { z } from 'zod';
 import { InstallPage } from '@/pages/install';
+import InstallIntegrationPage from '@/pages/install/ui/InstallIntegrationPage';
 
 const searchSchema = z.object({
   skill: z.string().optional(),
+  integration: z.string().optional(),
 });
 
 export const Route = createFileRoute('/_authenticated/install')({
@@ -12,6 +14,11 @@ export const Route = createFileRoute('/_authenticated/install')({
 });
 
 function RouteComponent() {
-  const { skill } = Route.useSearch();
+  const { skill, integration } = Route.useSearch();
+
+  if (integration) {
+    return <InstallIntegrationPage integrationIdentifier={integration} />;
+  }
+
   return <InstallPage skillIdentifier={skill} />;
 }

--- a/ayunis-core-frontend/src/i18n.ts
+++ b/ayunis-core-frontend/src/i18n.ts
@@ -38,6 +38,8 @@ import enChats from './shared/locales/en/chats.json';
 import deChats from './shared/locales/de/chats.json';
 import enInstall from './shared/locales/en/install.json';
 import deInstall from './shared/locales/de/install.json';
+import enInstallIntegration from './shared/locales/en/install-integration.json';
+import deInstallIntegration from './shared/locales/de/install-integration.json';
 import enSkills from './shared/locales/en/skills.json';
 import deSkills from './shared/locales/de/skills.json';
 import enSkill from './shared/locales/en/skill.json';
@@ -63,6 +65,7 @@ const resources = {
     agents: enAgents,
     agent: enAgent,
     install: enInstall,
+    'install-integration': enInstallIntegration,
     skills: enSkills,
     skill: enSkill,
   },
@@ -85,6 +88,7 @@ const resources = {
     agents: deAgents,
     agent: deAgent,
     install: deInstall,
+    'install-integration': deInstallIntegration,
     skills: deSkills,
     skill: deSkill,
   },

--- a/ayunis-core-frontend/src/pages/admin-settings/integrations-settings/api/useUserConfig.ts
+++ b/ayunis-core-frontend/src/pages/admin-settings/integrations-settings/api/useUserConfig.ts
@@ -1,0 +1,51 @@
+import { useQueryClient } from '@tanstack/react-query';
+import { useTranslation } from 'react-i18next';
+import {
+  useMcpIntegrationsControllerGetUserConfig,
+  useMcpIntegrationsControllerSetUserConfig,
+  getMcpIntegrationsControllerGetUserConfigQueryKey,
+} from '@/shared/api/generated/ayunisCoreAPI';
+import { showError, showSuccess } from '@/shared/lib/toast';
+
+export function useGetUserConfig(integrationId: string) {
+  const { data, isLoading } =
+    useMcpIntegrationsControllerGetUserConfig(integrationId);
+
+  return {
+    userConfig: data,
+    isLoadingUserConfig: isLoading,
+  };
+}
+
+export function useSetUserConfig(
+  integrationId: string,
+  onSuccess?: () => void,
+) {
+  const { t } = useTranslation('admin-settings-integrations');
+  const queryClient = useQueryClient();
+
+  const mutation = useMcpIntegrationsControllerSetUserConfig({
+    mutation: {
+      onSuccess: () => {
+        void queryClient.invalidateQueries({
+          queryKey:
+            getMcpIntegrationsControllerGetUserConfigQueryKey(integrationId),
+        });
+        showSuccess(t('integrations.userConfig.success'));
+        onSuccess?.();
+      },
+      onError: () => {
+        showError(t('integrations.userConfig.error'));
+      },
+    },
+  });
+
+  function setUserConfig(configValues: Record<string, string>) {
+    mutation.mutate({ id: integrationId, data: { configValues } });
+  }
+
+  return {
+    setUserConfig,
+    isSaving: mutation.isPending,
+  };
+}

--- a/ayunis-core-frontend/src/pages/admin-settings/integrations-settings/lib/helpers.ts
+++ b/ayunis-core-frontend/src/pages/admin-settings/integrations-settings/lib/helpers.ts
@@ -30,13 +30,20 @@ export function getStatusBadgeVariant(
  * Get display text for integration type
  */
 export function getIntegrationTypeLabel(type: McpIntegration['type']): string {
-  return type === 'predefined'
-    ? i18n.t('integrations.helpers.type.predefined', {
-        ns: 'admin-settings-integrations',
-      })
-    : i18n.t('integrations.helpers.type.custom', {
+  switch (type) {
+    case 'predefined':
+      return i18n.t('integrations.helpers.type.predefined', {
         ns: 'admin-settings-integrations',
       });
+    case 'marketplace':
+      return i18n.t('integrations.helpers.type.marketplace', {
+        ns: 'admin-settings-integrations',
+      });
+    default:
+      return i18n.t('integrations.helpers.type.custom', {
+        ns: 'admin-settings-integrations',
+      });
+  }
 }
 
 /**

--- a/ayunis-core-frontend/src/pages/admin-settings/integrations-settings/lib/helpers.ts
+++ b/ayunis-core-frontend/src/pages/admin-settings/integrations-settings/lib/helpers.ts
@@ -39,7 +39,7 @@ export function getIntegrationTypeLabel(type: McpIntegration['type']): string {
       return i18n.t('integrations.helpers.type.marketplace', {
         ns: 'admin-settings-integrations',
       });
-    default:
+    case 'custom':
       return i18n.t('integrations.helpers.type.custom', {
         ns: 'admin-settings-integrations',
       });

--- a/ayunis-core-frontend/src/pages/admin-settings/integrations-settings/ui/edit-integration-dialog.tsx
+++ b/ayunis-core-frontend/src/pages/admin-settings/integrations-settings/ui/edit-integration-dialog.tsx
@@ -19,7 +19,7 @@ import {
 } from '@/shared/ui/shadcn/form';
 import { Input } from '@/shared/ui/shadcn/input';
 import { PasswordInput } from '@/shared/ui/shadcn/password-input';
-import { Label } from '@/shared/ui/shadcn/label';
+import { ConfigFieldInput } from '@/shared/ui/config-field-input';
 import { Button } from '@/shared/ui/shadcn/button';
 import type { McpIntegration, UpdateIntegrationFormData } from '../model/types';
 import { useUpdateIntegration } from '../api/useUpdateIntegration';
@@ -40,7 +40,9 @@ function getEditableOrgFields(
 ): MarketplaceIntegrationConfigFieldDto[] {
   const schema = integration.configSchema as ConfigSchema | undefined;
   if (!schema?.orgFields) return [];
-  return schema.orgFields.filter((field) => field.value == null);
+  return schema.orgFields.filter(
+    (field) => field.value === null || field.value === undefined,
+  );
 }
 
 export function EditIntegrationDialog({
@@ -208,11 +210,10 @@ export function EditIntegrationDialog({
                     {t('integrations.editDialog.configDescription')}
                   </p>
                   {editableFields.map((field) => (
-                    <MarketplaceConfigFieldInput
+                    <ConfigFieldInput
                       key={field.key}
                       field={field}
                       value={configFormValues[field.key] ?? ''}
-                      hasExistingValue={field.key in currentOrgValues}
                       onChange={(value) =>
                         setConfigFormValues((prev) => ({
                           ...prev,
@@ -220,9 +221,11 @@ export function EditIntegrationDialog({
                         }))
                       }
                       disabled={isUpdating}
-                      secretPlaceholder={t(
-                        'integrations.editDialog.secretPlaceholder',
-                      )}
+                      secretPlaceholder={
+                        field.key in currentOrgValues
+                          ? t('integrations.editDialog.secretPlaceholder')
+                          : undefined
+                      }
                     />
                   ))}
                 </div>
@@ -330,57 +333,5 @@ export function EditIntegrationDialog({
         </DialogContent>
       )}
     </Dialog>
-  );
-}
-
-interface MarketplaceConfigFieldInputProps {
-  field: MarketplaceIntegrationConfigFieldDto;
-  value: string;
-  hasExistingValue: boolean;
-  onChange: (value: string) => void;
-  disabled: boolean;
-  secretPlaceholder: string;
-}
-
-function MarketplaceConfigFieldInput({
-  field,
-  value,
-  hasExistingValue,
-  onChange,
-  disabled,
-  secretPlaceholder,
-}: MarketplaceConfigFieldInputProps) {
-  const inputId = `config-field-${field.key}`;
-
-  return (
-    <div className="space-y-2">
-      <Label htmlFor={inputId}>
-        {field.label}
-        {field.required && <span className="ml-1 text-destructive">*</span>}
-      </Label>
-      {field.type === 'secret' ? (
-        <PasswordInput
-          id={inputId}
-          value={value}
-          onChange={(e) => onChange(e.target.value)}
-          disabled={disabled}
-          placeholder={
-            hasExistingValue ? secretPlaceholder : (field.help ?? '')
-          }
-        />
-      ) : (
-        <Input
-          id={inputId}
-          type={field.type === 'url' ? 'url' : 'text'}
-          value={value}
-          onChange={(e) => onChange(e.target.value)}
-          disabled={disabled}
-          placeholder={field.help ?? ''}
-        />
-      )}
-      {field.help && (
-        <p className="text-xs text-muted-foreground">{field.help}</p>
-      )}
-    </div>
   );
 }

--- a/ayunis-core-frontend/src/pages/admin-settings/integrations-settings/ui/edit-integration-dialog.tsx
+++ b/ayunis-core-frontend/src/pages/admin-settings/integrations-settings/ui/edit-integration-dialog.tsx
@@ -31,8 +31,6 @@ interface EditIntegrationDialogProps {
   onOpenChange: (open: boolean) => void;
 }
 
-const SECRET_MASK = '••••••';
-
 interface ConfigSchema {
   orgFields: MarketplaceIntegrationConfigFieldDto[];
 }
@@ -95,6 +93,9 @@ export function EditIntegrationDialog({
         setConfigFormValues(initial);
       }
     }
+    // Only reset form when the dialog opens with a (potentially different) integration.
+    // Derived values (editableFields, currentOrgValues, isMarketplace) are new references
+    // every render — including them would cause infinite re-render loops.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [integration, open]);
 
@@ -211,9 +212,7 @@ export function EditIntegrationDialog({
                       key={field.key}
                       field={field}
                       value={configFormValues[field.key] ?? ''}
-                      hasExistingValue={
-                        currentOrgValues[field.key] === SECRET_MASK
-                      }
+                      hasExistingValue={field.key in currentOrgValues}
                       onChange={(value) =>
                         setConfigFormValues((prev) => ({
                           ...prev,

--- a/ayunis-core-frontend/src/pages/admin-settings/integrations-settings/ui/integration-card.tsx
+++ b/ayunis-core-frontend/src/pages/admin-settings/integrations-settings/ui/integration-card.tsx
@@ -95,11 +95,9 @@ export function IntegrationCard({
             </Button>
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end">
-            {!isMarketplace && (
-              <DropdownMenuItem onClick={() => onEdit(integration)}>
-                {t('integrations.card.edit')}
-              </DropdownMenuItem>
-            )}
+            <DropdownMenuItem onClick={() => onEdit(integration)}>
+              {t('integrations.card.edit')}
+            </DropdownMenuItem>
             <DropdownMenuItem
               onClick={() => onDelete(integration)}
               className="text-red-600"

--- a/ayunis-core-frontend/src/pages/admin-settings/integrations-settings/ui/integration-card.tsx
+++ b/ayunis-core-frontend/src/pages/admin-settings/integrations-settings/ui/integration-card.tsx
@@ -7,7 +7,8 @@ import {
   DropdownMenuTrigger,
 } from '@/shared/ui/shadcn/dropdown-menu';
 import { Switch } from '@/shared/ui/shadcn/switch';
-import { MoreVertical, Loader2 } from 'lucide-react';
+import { Badge } from '@/shared/ui/shadcn/badge';
+import { MoreVertical, Loader2, User } from 'lucide-react';
 import type { McpIntegration } from '../model/types';
 import { getIntegrationTypeLabel } from '../lib/helpers';
 import {
@@ -24,6 +25,7 @@ interface IntegrationCardProps {
   onDelete: (integration: McpIntegration) => void;
   onToggleEnabled: (integration: McpIntegration, enabled: boolean) => void;
   onValidate: (integration: McpIntegration) => void;
+  onUserConfig?: (integration: McpIntegration) => void;
   isTogglingEnabled?: boolean;
   isValidating?: boolean;
 }
@@ -34,26 +36,42 @@ export function IntegrationCard({
   onDelete,
   onToggleEnabled,
   onValidate,
+  onUserConfig,
   isTogglingEnabled = false,
   isValidating = false,
 }: Readonly<IntegrationCardProps>) {
   const { t } = useTranslation('admin-settings-integrations');
-  const typeLabel = getIntegrationTypeLabel(integration.type);
-  const integrationKey = `integration-${integration.id}`;
+  const isMarketplace = integration.type === 'marketplace';
+  const hasUserFields = integration.hasUserFields === true;
 
   return (
     <Item variant="outline">
       <ItemContent>
-        <ItemTitle>{integration.name}</ItemTitle>
+        <ItemTitle>
+          {integration.name}
+          {isMarketplace && (
+            <Badge variant="secondary" className="ml-2">
+              {t('integrations.card.marketplace')}
+            </Badge>
+          )}
+        </ItemTitle>
         <ItemDescription>
-          {integration.type === 'predefined'
-            ? ``
-            : `${typeLabel} - ${integration.serverUrl}`}
+          <IntegrationDescription integration={integration} />
         </ItemDescription>
       </ItemContent>
       <ItemActions>
+        {isMarketplace && hasUserFields && onUserConfig && (
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => onUserConfig(integration)}
+          >
+            <User className="h-4 w-4" />
+            {t('integrations.card.userConfig')}
+          </Button>
+        )}
         <Switch
-          id={integrationKey}
+          id={`integration-${integration.id}`}
           checked={integration.enabled}
           onCheckedChange={(checked) => onToggleEnabled(integration, checked)}
           disabled={isTogglingEnabled}
@@ -77,9 +95,11 @@ export function IntegrationCard({
             </Button>
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end">
-            <DropdownMenuItem onClick={() => onEdit(integration)}>
-              {t('integrations.card.edit')}
-            </DropdownMenuItem>
+            {!isMarketplace && (
+              <DropdownMenuItem onClick={() => onEdit(integration)}>
+                {t('integrations.card.edit')}
+              </DropdownMenuItem>
+            )}
             <DropdownMenuItem
               onClick={() => onDelete(integration)}
               className="text-red-600"
@@ -90,5 +110,26 @@ export function IntegrationCard({
         </DropdownMenu>
       </ItemActions>
     </Item>
+  );
+}
+
+function IntegrationDescription({
+  integration,
+}: {
+  integration: McpIntegration;
+}) {
+  if (integration.type === 'marketplace') {
+    return <>{integration.marketplaceIdentifier ?? ''}</>;
+  }
+
+  if (integration.type === 'predefined') {
+    return <></>;
+  }
+
+  const typeLabel = getIntegrationTypeLabel(integration.type);
+  return (
+    <>
+      {typeLabel} - {integration.serverUrl}
+    </>
   );
 }

--- a/ayunis-core-frontend/src/pages/admin-settings/integrations-settings/ui/integrations-list.tsx
+++ b/ayunis-core-frontend/src/pages/admin-settings/integrations-settings/ui/integrations-list.tsx
@@ -10,12 +10,14 @@ interface IntegrationsListProps {
   integrations: McpIntegration[];
   onEdit: (integration: McpIntegration) => void;
   onDelete: (integration: McpIntegration) => void;
+  onUserConfig?: (integration: McpIntegration) => void;
 }
 
 export function IntegrationsList({
   integrations,
   onEdit,
   onDelete,
+  onUserConfig,
 }: Readonly<IntegrationsListProps>) {
   const { t } = useTranslation('admin-settings-integrations');
   const { toggleIntegration, togglingIds } = useToggleIntegration();
@@ -51,6 +53,7 @@ export function IntegrationsList({
             onDelete={onDelete}
             onToggleEnabled={toggleIntegration}
             onValidate={validateIntegration}
+            onUserConfig={onUserConfig}
             isTogglingEnabled={togglingIds.has(integration.id)}
             isValidating={validatingIds.has(integration.id)}
           />

--- a/ayunis-core-frontend/src/pages/admin-settings/integrations-settings/ui/mcp-integrations-page.tsx
+++ b/ayunis-core-frontend/src/pages/admin-settings/integrations-settings/ui/mcp-integrations-page.tsx
@@ -109,7 +109,6 @@ export function McpIntegrationsPage({
     );
   }
 
-
   return (
     <SettingsLayout
       action={

--- a/ayunis-core-frontend/src/pages/admin-settings/integrations-settings/ui/mcp-integrations-page.tsx
+++ b/ayunis-core-frontend/src/pages/admin-settings/integrations-settings/ui/mcp-integrations-page.tsx
@@ -2,12 +2,13 @@ import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button } from '@/shared/ui/shadcn/button';
 import { Skeleton } from '@/shared/ui/shadcn/skeleton';
-import { Plus, AlertCircle } from 'lucide-react';
+import { Plus, AlertCircle, ExternalLink } from 'lucide-react';
 import { IntegrationsList } from './integrations-list';
 import { CreatePredefinedDialog } from './create-predefined-dialog';
 import { CreateCustomDialog } from './create-custom-dialog';
 import { EditIntegrationDialog } from './edit-integration-dialog';
 import { DeleteConfirmationDialog } from './delete-confirmation-dialog';
+import { UserConfigDialog } from './user-config-dialog';
 import SettingsLayout from '../../admin-settings-layout';
 import { useMcpIntegrationsQueries } from '../api/useMcpIntegrationsQueries';
 import type { McpIntegration } from '../model/types';
@@ -38,6 +39,8 @@ export function McpIntegrationsPage({
     null,
   );
   const [deleteIntegration, setDeleteIntegration] =
+    useState<McpIntegration | null>(null);
+  const [userConfigIntegration, setUserConfigIntegration] =
     useState<McpIntegration | null>(null);
   const [comingSoonOpen, setComingSoonOpen] = useState(false);
 
@@ -106,41 +109,17 @@ export function McpIntegrationsPage({
     );
   }
 
-  const headerActions = (
-    <div className="flex gap-2">
-      {isCloud ? (
-        <Button
-          variant="default"
-          size="sm"
-          onClick={handleOpenCreatePredefined}
-        >
-          <Plus className="h-4 w-4" />
-          {t('integrations.page.add')}
-        </Button>
-      ) : (
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button size="sm">
-              <Plus className="h-4 w-4" />
-              {t('integrations.page.add')}
-            </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="end">
-            <DropdownMenuItem onClick={handleOpenCreatePredefined}>
-              {t('integrations.page.addPredefined')}
-            </DropdownMenuItem>
-            <DropdownMenuItem onClick={() => setCreateCustomOpen(true)}>
-              {t('integrations.page.addCustom')}
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
-      )}
-    </div>
-  );
 
   return (
     <SettingsLayout
-      action={headerActions}
+      action={
+        <HeaderActions
+          isCloud={isCloud}
+          onCreatePredefined={handleOpenCreatePredefined}
+          onCreateCustom={() => setCreateCustomOpen(true)}
+          t={t}
+        />
+      }
       title={tLayout('layout.integrations')}
     >
       <div className="space-y-4">
@@ -148,6 +127,7 @@ export function McpIntegrationsPage({
           integrations={integrations}
           onEdit={setEditIntegration}
           onDelete={setDeleteIntegration}
+          onUserConfig={setUserConfigIntegration}
         />
 
         <CreatePredefinedDialog
@@ -174,11 +154,69 @@ export function McpIntegrationsPage({
           onOpenChange={(open) => !open && setDeleteIntegration(null)}
         />
 
+        <UserConfigDialog
+          integration={userConfigIntegration}
+          open={!!userConfigIntegration}
+          onOpenChange={(open) => !open && setUserConfigIntegration(null)}
+        />
+
         <ComingSoonDialog
           open={comingSoonOpen}
           onOpenChange={setComingSoonOpen}
         />
       </div>
     </SettingsLayout>
+  );
+}
+
+function HeaderActions({
+  isCloud,
+  onCreatePredefined,
+  onCreateCustom,
+  t,
+}: {
+  isCloud: boolean;
+  onCreatePredefined: () => void;
+  onCreateCustom: () => void;
+  t: (key: string) => string;
+}) {
+  return (
+    <div className="flex gap-2">
+      <Button variant="outline" size="sm" asChild>
+        <a
+          href="https://marketplace.ayunis.de/integrations"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <ExternalLink className="h-4 w-4" />
+          {t('integrations.page.browseMarketplace')}
+        </a>
+      </Button>
+      {isCloud ? (
+        <Button variant="default" size="sm" onClick={onCreatePredefined}>
+          <Plus className="h-4 w-4" />
+          {t('integrations.page.add')}
+        </Button>
+      ) : (
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button size="sm">
+              <Plus className="h-4 w-4" />
+              {t('integrations.page.add')}
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <DropdownMenuItem onClick={onCreatePredefined}>
+              {t('integrations.page.addPredefined')}
+            </DropdownMenuItem>
+            {!isCloud && (
+              <DropdownMenuItem onClick={onCreateCustom}>
+                {t('integrations.page.addCustom')}
+              </DropdownMenuItem>
+            )}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      )}
+    </div>
   );
 }

--- a/ayunis-core-frontend/src/pages/admin-settings/integrations-settings/ui/user-config-dialog.tsx
+++ b/ayunis-core-frontend/src/pages/admin-settings/integrations-settings/ui/user-config-dialog.tsx
@@ -9,13 +9,12 @@ import {
   DialogTitle,
 } from '@/shared/ui/shadcn/dialog';
 import { Button } from '@/shared/ui/shadcn/button';
-import { Input } from '@/shared/ui/shadcn/input';
-import { PasswordInput } from '@/shared/ui/shadcn/password-input';
-import { Label } from '@/shared/ui/shadcn/label';
+import { ConfigFieldInput } from '@/shared/ui/config-field-input';
 import { Skeleton } from '@/shared/ui/shadcn/skeleton';
 import { useGetUserConfig, useSetUserConfig } from '../api/useUserConfig';
 import type { McpIntegration } from '../model/types';
 import type { MarketplaceIntegrationConfigFieldDto } from '@/shared/api/generated/ayunisCoreAPI.schemas';
+import { SECRET_MASK } from '@/shared/constants/secret-mask';
 
 interface UserConfigDialogProps {
   integration: McpIntegration | null;
@@ -84,7 +83,7 @@ function UserConfigForm({
   return (
     <form onSubmit={handleSubmit} className="space-y-4">
       {userFields.map((field) => (
-        <UserConfigFieldInput
+        <ConfigFieldInput
           key={field.key}
           field={field}
           value={formValues[field.key] ?? ''}
@@ -92,6 +91,7 @@ function UserConfigForm({
             setFormValues((prev) => ({ ...prev, [field.key]: value }))
           }
           disabled={isSaving}
+          idPrefix="user-config"
         />
       ))}
       <DialogFooter>
@@ -130,8 +130,8 @@ function initFormFromExisting(
   const initial: Record<string, string> = {};
   for (const field of fields) {
     const existingValue = existing[field.key];
-    // Secret fields come back as "***" — don't prefill
-    if (existingValue && existingValue !== '***') {
+    // Secret fields come back masked — don't prefill
+    if (existingValue && existingValue !== SECRET_MASK) {
       initial[field.key] = existingValue;
     }
   }
@@ -147,52 +147,6 @@ function UserConfigLoadingSkeleton() {
         <Skeleton className="h-10 w-24" />
         <Skeleton className="h-10 w-24" />
       </div>
-    </div>
-  );
-}
-
-interface UserConfigFieldInputProps {
-  field: MarketplaceIntegrationConfigFieldDto;
-  value: string;
-  onChange: (value: string) => void;
-  disabled: boolean;
-}
-
-function UserConfigFieldInput({
-  field,
-  value,
-  onChange,
-  disabled,
-}: UserConfigFieldInputProps) {
-  const inputId = `user-config-${field.key}`;
-
-  return (
-    <div className="space-y-2">
-      <Label htmlFor={inputId}>
-        {field.label}
-        {field.required && <span className="ml-1 text-destructive">*</span>}
-      </Label>
-      {field.type === 'secret' ? (
-        <PasswordInput
-          id={inputId}
-          value={value}
-          onChange={(e) => onChange(e.target.value)}
-          disabled={disabled}
-          placeholder={field.help ?? ''}
-        />
-      ) : (
-        <Input
-          id={inputId}
-          type={field.type === 'url' ? 'url' : 'text'}
-          value={value}
-          onChange={(e) => onChange(e.target.value)}
-          disabled={disabled}
-          placeholder={field.help ?? ''}
-        />
-      )}
-      {field.help && (
-        <p className="text-xs text-muted-foreground">{field.help}</p>
-      )}
     </div>
   );
 }

--- a/ayunis-core-frontend/src/pages/admin-settings/integrations-settings/ui/user-config-dialog.tsx
+++ b/ayunis-core-frontend/src/pages/admin-settings/integrations-settings/ui/user-config-dialog.tsx
@@ -1,0 +1,198 @@
+import { useState, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/shared/ui/shadcn/dialog';
+import { Button } from '@/shared/ui/shadcn/button';
+import { Input } from '@/shared/ui/shadcn/input';
+import { PasswordInput } from '@/shared/ui/shadcn/password-input';
+import { Label } from '@/shared/ui/shadcn/label';
+import { Skeleton } from '@/shared/ui/shadcn/skeleton';
+import { useGetUserConfig, useSetUserConfig } from '../api/useUserConfig';
+import type { McpIntegration } from '../model/types';
+import type { MarketplaceIntegrationConfigFieldDto } from '@/shared/api/generated/ayunisCoreAPI.schemas';
+
+interface UserConfigDialogProps {
+  integration: McpIntegration | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function UserConfigDialog({
+  integration,
+  open,
+  onOpenChange,
+}: UserConfigDialogProps) {
+  const { t } = useTranslation('admin-settings-integrations');
+
+  if (!integration) return null;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-[525px]">
+        <DialogHeader>
+          <DialogTitle>
+            {t('integrations.userConfig.title', { name: integration.name })}
+          </DialogTitle>
+          <DialogDescription>
+            {t('integrations.userConfig.description')}
+          </DialogDescription>
+        </DialogHeader>
+        <UserConfigForm
+          integration={integration}
+          onClose={() => onOpenChange(false)}
+        />
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function UserConfigForm({
+  integration,
+  onClose,
+}: {
+  integration: McpIntegration;
+  onClose: () => void;
+}) {
+  const { t } = useTranslation('admin-settings-integrations');
+  const { userConfig, isLoadingUserConfig } = useGetUserConfig(integration.id);
+  const { setUserConfig, isSaving } = useSetUserConfig(integration.id, onClose);
+  const [formValues, setFormValues] = useState<Record<string, string>>({});
+
+  const userFields = getUserFields(integration);
+
+  useEffect(() => {
+    if (userConfig?.configValues) {
+      initFormFromExisting(userConfig.configValues, userFields, setFormValues);
+    }
+  }, [userConfig]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  if (isLoadingUserConfig) {
+    return <UserConfigLoadingSkeleton />;
+  }
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    setUserConfig(formValues);
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      {userFields.map((field) => (
+        <UserConfigFieldInput
+          key={field.key}
+          field={field}
+          value={formValues[field.key] ?? ''}
+          onChange={(value) =>
+            setFormValues((prev) => ({ ...prev, [field.key]: value }))
+          }
+          disabled={isSaving}
+        />
+      ))}
+      <DialogFooter>
+        <Button
+          type="button"
+          variant="outline"
+          onClick={onClose}
+          disabled={isSaving}
+        >
+          {t('integrations.userConfig.cancel')}
+        </Button>
+        <Button type="submit" disabled={isSaving}>
+          {isSaving
+            ? t('integrations.userConfig.saving')
+            : t('integrations.userConfig.save')}
+        </Button>
+      </DialogFooter>
+    </form>
+  );
+}
+
+function getUserFields(
+  integration: McpIntegration,
+): MarketplaceIntegrationConfigFieldDto[] {
+  const schema = integration.configSchema as
+    | { userFields?: MarketplaceIntegrationConfigFieldDto[] }
+    | undefined;
+  return schema?.userFields ?? [];
+}
+
+function initFormFromExisting(
+  existing: Record<string, string>,
+  fields: MarketplaceIntegrationConfigFieldDto[],
+  setFormValues: (values: Record<string, string>) => void,
+) {
+  const initial: Record<string, string> = {};
+  for (const field of fields) {
+    const existingValue = existing[field.key];
+    // Secret fields come back as "***" — don't prefill
+    if (existingValue && existingValue !== '***') {
+      initial[field.key] = existingValue;
+    }
+  }
+  setFormValues(initial);
+}
+
+function UserConfigLoadingSkeleton() {
+  return (
+    <div className="space-y-4">
+      <Skeleton className="h-10 w-full" />
+      <Skeleton className="h-10 w-full" />
+      <div className="flex justify-end gap-2">
+        <Skeleton className="h-10 w-24" />
+        <Skeleton className="h-10 w-24" />
+      </div>
+    </div>
+  );
+}
+
+interface UserConfigFieldInputProps {
+  field: MarketplaceIntegrationConfigFieldDto;
+  value: string;
+  onChange: (value: string) => void;
+  disabled: boolean;
+}
+
+function UserConfigFieldInput({
+  field,
+  value,
+  onChange,
+  disabled,
+}: UserConfigFieldInputProps) {
+  const inputId = `user-config-${field.key}`;
+
+  return (
+    <div className="space-y-2">
+      <Label htmlFor={inputId}>
+        {field.label}
+        {field.required && <span className="ml-1 text-destructive">*</span>}
+      </Label>
+      {field.type === 'secret' ? (
+        <PasswordInput
+          id={inputId}
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          disabled={disabled}
+          placeholder={field.help ?? ''}
+        />
+      ) : (
+        <Input
+          id={inputId}
+          type={field.type === 'url' ? 'url' : 'text'}
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          disabled={disabled}
+          placeholder={field.help ?? ''}
+        />
+      )}
+      {field.help && (
+        <p className="text-xs text-muted-foreground">{field.help}</p>
+      )}
+    </div>
+  );
+}

--- a/ayunis-core-frontend/src/pages/install/api/useFetchMarketplaceIntegration.ts
+++ b/ayunis-core-frontend/src/pages/install/api/useFetchMarketplaceIntegration.ts
@@ -1,0 +1,8 @@
+export {
+  marketplaceControllerGetIntegration,
+  getMarketplaceControllerGetIntegrationQueryKey,
+  getMarketplaceControllerGetIntegrationQueryOptions,
+  useMarketplaceControllerGetIntegration,
+} from '@/shared/api/generated/ayunisCoreAPI';
+
+export type { MarketplaceIntegrationResponseDto } from '@/shared/api/generated/ayunisCoreAPI.schemas';

--- a/ayunis-core-frontend/src/pages/install/api/useInstallIntegrationFromMarketplace.ts
+++ b/ayunis-core-frontend/src/pages/install/api/useInstallIntegrationFromMarketplace.ts
@@ -1,0 +1,52 @@
+import { useQueryClient } from '@tanstack/react-query';
+import { useRouter } from '@tanstack/react-router';
+import { useTranslation } from 'react-i18next';
+import {
+  useMcpIntegrationsControllerInstallFromMarketplace,
+  getMcpIntegrationsControllerListQueryKey,
+} from '@/shared/api/generated/ayunisCoreAPI';
+import extractErrorData from '@/shared/api/extract-error-data';
+import { showError, showSuccess } from '@/shared/lib/toast';
+
+export function useInstallIntegrationFromMarketplace() {
+  const { t } = useTranslation('install-integration');
+  const queryClient = useQueryClient();
+  const router = useRouter();
+
+  return useMcpIntegrationsControllerInstallFromMarketplace({
+    mutation: {
+      onSuccess: () => {
+        showSuccess(t('success'));
+        void queryClient.invalidateQueries({
+          queryKey: getMcpIntegrationsControllerListQueryKey(),
+        });
+        void router.navigate({
+          to: '/admin-settings/integrations',
+        });
+      },
+      onError: (error) => {
+        try {
+          const { code } = extractErrorData(error);
+          switch (code) {
+            case 'MARKETPLACE_INTEGRATION_NOT_FOUND':
+              showError(t('error.notFound.description'));
+              break;
+            case 'MARKETPLACE_UNAVAILABLE':
+              showError(t('error.unavailable'));
+              break;
+            case 'MCP_OAUTH_NOT_SUPPORTED':
+              showError(t('error.oauthNotSupported'));
+              break;
+            case 'MCP_MISSING_REQUIRED_CONFIG':
+              showError(t('error.missingRequiredConfig'));
+              break;
+            default:
+              showError(t('error.generic'));
+          }
+        } catch {
+          showError(t('error.generic'));
+        }
+      },
+    },
+  });
+}

--- a/ayunis-core-frontend/src/pages/install/api/useInstallIntegrationFromMarketplace.ts
+++ b/ayunis-core-frontend/src/pages/install/api/useInstallIntegrationFromMarketplace.ts
@@ -40,6 +40,9 @@ export function useInstallIntegrationFromMarketplace() {
             case 'MCP_MISSING_REQUIRED_CONFIG':
               showError(t('error.missingRequiredConfig'));
               break;
+            case 'DUPLICATE_MCP_INTEGRATION':
+              showError(t('error.alreadyInstalled'));
+              break;
             default:
               showError(t('error.generic'));
           }

--- a/ayunis-core-frontend/src/pages/install/index.ts
+++ b/ayunis-core-frontend/src/pages/install/index.ts
@@ -1,1 +1,2 @@
 export { default as InstallPage } from './ui/InstallPage';
+export { default as InstallIntegrationPage } from './ui/InstallIntegrationPage';

--- a/ayunis-core-frontend/src/pages/install/index.ts
+++ b/ayunis-core-frontend/src/pages/install/index.ts
@@ -1,2 +1,3 @@
 export { default as InstallPage } from './ui/InstallPage';
 export { default as InstallIntegrationPage } from './ui/InstallIntegrationPage';
+export { InstallErrorState } from './ui/InstallErrorState';

--- a/ayunis-core-frontend/src/pages/install/ui/InstallErrorState.tsx
+++ b/ayunis-core-frontend/src/pages/install/ui/InstallErrorState.tsx
@@ -13,13 +13,19 @@ import { Link } from '@tanstack/react-router';
 interface InstallErrorStateProps {
   title: string;
   description: string;
+  backTo?: string;
+  backLabel?: string;
 }
 
 export function InstallErrorState({
   title,
   description,
+  backTo,
+  backLabel,
 }: Readonly<InstallErrorStateProps>) {
   const { t } = useTranslation('install');
+  const linkTo = backTo ?? '/skills';
+  const linkLabel = backLabel ?? t('action.backToSkills');
 
   return (
     <Card className="w-full max-w-lg">
@@ -32,7 +38,7 @@ export function InstallErrorState({
       </CardHeader>
       <CardFooter className="justify-center">
         <Button variant="outline" asChild>
-          <Link to="/skills">{t('action.backToSkills')}</Link>
+          <Link to={linkTo}>{linkLabel}</Link>
         </Button>
       </CardFooter>
     </Card>

--- a/ayunis-core-frontend/src/pages/install/ui/InstallIntegrationPage.tsx
+++ b/ayunis-core-frontend/src/pages/install/ui/InstallIntegrationPage.tsx
@@ -1,12 +1,26 @@
 import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Link } from '@tanstack/react-router';
+import type { TFunction } from 'i18next';
+import { Plug } from 'lucide-react';
 import AppLayout from '@/layouts/app-layout';
 import FullScreenMessageLayout from '@/layouts/full-screen-message-layout/ui/FullScreenMessageLayout';
-import { useTranslation } from 'react-i18next';
 import { useMarketplaceControllerGetIntegration } from '../api/useFetchMarketplaceIntegration';
 import { useInstallIntegrationFromMarketplace } from '../api/useInstallIntegrationFromMarketplace';
 import { InstallErrorState } from './InstallErrorState';
 import { InstallLoadingSkeleton } from './InstallLoadingSkeleton';
 import type { MarketplaceIntegrationResponseDto } from '../api/useFetchMarketplaceIntegration';
+import type { MarketplaceIntegrationConfigFieldDto } from '@/shared/api/generated/ayunisCoreAPI.schemas';
+import { Button } from '@/shared/ui/shadcn/button';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from '@/shared/ui/shadcn/card';
+import { ConfigFieldInput } from '@/shared/ui/config-field-input';
 
 interface InstallIntegrationPageProps {
   integrationIdentifier: string | undefined;
@@ -131,29 +145,11 @@ function InstallIntegrationCard({
   );
 }
 
-// Extracted to keep complexity low and reuse types
-import type { MarketplaceIntegrationConfigFieldDto } from '@/shared/api/generated/ayunisCoreAPI.schemas';
-import { Button } from '@/shared/ui/shadcn/button';
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardFooter,
-  CardHeader,
-  CardTitle,
-} from '@/shared/ui/shadcn/card';
-import { Input } from '@/shared/ui/shadcn/input';
-import { PasswordInput } from '@/shared/ui/shadcn/password-input';
-import { Label } from '@/shared/ui/shadcn/label';
-import { Plug } from 'lucide-react';
-import { Link } from '@tanstack/react-router';
-import type { TFunction } from 'i18next';
-
 function getEditableOrgFields(
   integration: MarketplaceIntegrationResponseDto,
 ): MarketplaceIntegrationConfigFieldDto[] {
   return integration.configSchema.orgFields.filter(
-    (field) => field.value == null,
+    (field) => field.value === null || field.value === undefined,
   );
 }
 
@@ -242,51 +238,5 @@ function InstallIntegrationCardView({
         </Button>
       </CardFooter>
     </Card>
-  );
-}
-
-interface ConfigFieldInputProps {
-  field: MarketplaceIntegrationConfigFieldDto;
-  value: string;
-  onChange: (value: string) => void;
-  disabled: boolean;
-}
-
-function ConfigFieldInput({
-  field,
-  value,
-  onChange,
-  disabled,
-}: ConfigFieldInputProps) {
-  const inputId = `config-field-${field.key}`;
-
-  return (
-    <div className="space-y-2">
-      <Label htmlFor={inputId}>
-        {field.label}
-        {field.required && <span className="ml-1 text-destructive">*</span>}
-      </Label>
-      {field.type === 'secret' ? (
-        <PasswordInput
-          id={inputId}
-          value={value}
-          onChange={(e) => onChange(e.target.value)}
-          disabled={disabled}
-          placeholder={field.help ?? ''}
-        />
-      ) : (
-        <Input
-          id={inputId}
-          type={field.type === 'url' ? 'url' : 'text'}
-          value={value}
-          onChange={(e) => onChange(e.target.value)}
-          disabled={disabled}
-          placeholder={field.help ?? ''}
-        />
-      )}
-      {field.help && (
-        <p className="text-xs text-muted-foreground">{field.help}</p>
-      )}
-    </div>
   );
 }

--- a/ayunis-core-frontend/src/pages/install/ui/InstallIntegrationPage.tsx
+++ b/ayunis-core-frontend/src/pages/install/ui/InstallIntegrationPage.tsx
@@ -1,0 +1,292 @@
+import { useState } from 'react';
+import AppLayout from '@/layouts/app-layout';
+import FullScreenMessageLayout from '@/layouts/full-screen-message-layout/ui/FullScreenMessageLayout';
+import { useTranslation } from 'react-i18next';
+import { useMarketplaceControllerGetIntegration } from '../api/useFetchMarketplaceIntegration';
+import { useInstallIntegrationFromMarketplace } from '../api/useInstallIntegrationFromMarketplace';
+import { InstallErrorState } from './InstallErrorState';
+import { InstallLoadingSkeleton } from './InstallLoadingSkeleton';
+import type { MarketplaceIntegrationResponseDto } from '../api/useFetchMarketplaceIntegration';
+
+interface InstallIntegrationPageProps {
+  integrationIdentifier: string | undefined;
+}
+
+export default function InstallIntegrationPage({
+  integrationIdentifier,
+}: InstallIntegrationPageProps) {
+  const { t } = useTranslation('install-integration');
+
+  if (!integrationIdentifier) {
+    return (
+      <AppLayout>
+        <FullScreenMessageLayout>
+          <InstallErrorState
+            title={t('error.missingIdentifier.title')}
+            description={t('error.missingIdentifier.description')}
+            backTo="/admin-settings/integrations"
+            backLabel={t('action.backToIntegrations')}
+          />
+        </FullScreenMessageLayout>
+      </AppLayout>
+    );
+  }
+
+  return (
+    <AppLayout>
+      <FullScreenMessageLayout>
+        <InstallIntegrationContent
+          integrationIdentifier={integrationIdentifier}
+        />
+      </FullScreenMessageLayout>
+    </AppLayout>
+  );
+}
+
+function InstallIntegrationContent({
+  integrationIdentifier,
+}: {
+  integrationIdentifier: string;
+}) {
+  const { t } = useTranslation('install-integration');
+  const {
+    data: integration,
+    isLoading,
+    isError,
+  } = useMarketplaceControllerGetIntegration(integrationIdentifier);
+  const installMutation = useInstallIntegrationFromMarketplace();
+  const [formValues, setFormValues] = useState<Record<string, string>>({});
+
+  if (isLoading) {
+    return <InstallLoadingSkeleton />;
+  }
+
+  if (isError || !integration) {
+    return (
+      <InstallErrorState
+        title={t('error.fetchFailed.title')}
+        description={t('error.fetchFailed.description')}
+        backTo="/admin-settings/integrations"
+        backLabel={t('action.backToIntegrations')}
+      />
+    );
+  }
+
+  const handleInstall = () => {
+    installMutation.mutate({
+      data: {
+        identifier: integrationIdentifier,
+        orgConfigValues: formValues,
+      },
+    });
+  };
+
+  return (
+    <InstallIntegrationCard
+      integration={integration}
+      formValues={formValues}
+      onFormValuesChange={setFormValues}
+      onInstall={handleInstall}
+      isInstalling={installMutation.isPending}
+    />
+  );
+}
+
+interface InstallIntegrationCardProps {
+  integration: MarketplaceIntegrationResponseDto;
+  formValues: Record<string, string>;
+  onFormValuesChange: (values: Record<string, string>) => void;
+  onInstall: () => void;
+  isInstalling: boolean;
+}
+
+function InstallIntegrationCard({
+  integration,
+  formValues,
+  onFormValuesChange,
+  onInstall,
+  isInstalling,
+}: InstallIntegrationCardProps) {
+  const { t } = useTranslation('install-integration');
+
+  const editableFields = getEditableOrgFields(integration);
+  const isZeroConfig = editableFields.length === 0;
+  const allRequiredFilled = checkRequiredFieldsFilled(
+    editableFields,
+    formValues,
+  );
+
+  return (
+    <InstallIntegrationCardView
+      integration={integration}
+      editableFields={editableFields}
+      isZeroConfig={isZeroConfig}
+      allRequiredFilled={allRequiredFilled}
+      formValues={formValues}
+      onFormValuesChange={onFormValuesChange}
+      onInstall={onInstall}
+      isInstalling={isInstalling}
+      t={t}
+    />
+  );
+}
+
+// Extracted to keep complexity low and reuse types
+import type { MarketplaceIntegrationConfigFieldDto } from '@/shared/api/generated/ayunisCoreAPI.schemas';
+import { Button } from '@/shared/ui/shadcn/button';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from '@/shared/ui/shadcn/card';
+import { Input } from '@/shared/ui/shadcn/input';
+import { PasswordInput } from '@/shared/ui/shadcn/password-input';
+import { Label } from '@/shared/ui/shadcn/label';
+import { Plug } from 'lucide-react';
+import { Link } from '@tanstack/react-router';
+import type { TFunction } from 'i18next';
+
+function getEditableOrgFields(
+  integration: MarketplaceIntegrationResponseDto,
+): MarketplaceIntegrationConfigFieldDto[] {
+  return integration.configSchema.orgFields.filter(
+    (field) => field.value == null,
+  );
+}
+
+function checkRequiredFieldsFilled(
+  fields: MarketplaceIntegrationConfigFieldDto[],
+  values: Record<string, string>,
+): boolean {
+  return fields
+    .filter((f) => f.required)
+    .every((f) => (values[f.key] ?? '').trim().length > 0);
+}
+
+interface InstallIntegrationCardViewProps {
+  integration: MarketplaceIntegrationResponseDto;
+  editableFields: MarketplaceIntegrationConfigFieldDto[];
+  isZeroConfig: boolean;
+  allRequiredFilled: boolean;
+  formValues: Record<string, string>;
+  onFormValuesChange: (values: Record<string, string>) => void;
+  onInstall: () => void;
+  isInstalling: boolean;
+  t: TFunction;
+}
+
+function InstallIntegrationCardView({
+  integration,
+  editableFields,
+  isZeroConfig,
+  allRequiredFilled,
+  formValues,
+  onFormValuesChange,
+  onInstall,
+  isInstalling,
+  t,
+}: InstallIntegrationCardViewProps) {
+  return (
+    <Card className="w-full max-w-lg">
+      <CardHeader className="text-center">
+        <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-primary/10">
+          {integration.iconUrl ? (
+            <img
+              src={integration.iconUrl}
+              alt={integration.name}
+              className="h-10 w-10 rounded-full object-cover"
+            />
+          ) : (
+            <Plug className="h-8 w-8 text-primary" />
+          )}
+        </div>
+        <CardTitle className="text-xl">{integration.name}</CardTitle>
+        <CardDescription>{integration.description}</CardDescription>
+      </CardHeader>
+
+      <CardContent className="space-y-4">
+        <div className="rounded-md bg-muted/50 p-4">
+          <p className="text-sm text-muted-foreground">
+            {isZeroConfig
+              ? t('detail.zeroConfigNote')
+              : t('detail.installNote')}
+          </p>
+        </div>
+
+        {editableFields.map((field) => (
+          <ConfigFieldInput
+            key={field.key}
+            field={field}
+            value={formValues[field.key] ?? ''}
+            onChange={(value) =>
+              onFormValuesChange({ ...formValues, [field.key]: value })
+            }
+            disabled={isInstalling}
+          />
+        ))}
+      </CardContent>
+
+      <CardFooter className="flex gap-3">
+        <Button variant="outline" className="flex-1" asChild>
+          <Link to="/admin-settings/integrations">{t('action.cancel')}</Link>
+        </Button>
+        <Button
+          className="flex-1"
+          onClick={onInstall}
+          disabled={isInstalling || !allRequiredFilled}
+        >
+          {isInstalling ? t('action.installing') : t('action.install')}
+        </Button>
+      </CardFooter>
+    </Card>
+  );
+}
+
+interface ConfigFieldInputProps {
+  field: MarketplaceIntegrationConfigFieldDto;
+  value: string;
+  onChange: (value: string) => void;
+  disabled: boolean;
+}
+
+function ConfigFieldInput({
+  field,
+  value,
+  onChange,
+  disabled,
+}: ConfigFieldInputProps) {
+  const inputId = `config-field-${field.key}`;
+
+  return (
+    <div className="space-y-2">
+      <Label htmlFor={inputId}>
+        {field.label}
+        {field.required && <span className="ml-1 text-destructive">*</span>}
+      </Label>
+      {field.type === 'secret' ? (
+        <PasswordInput
+          id={inputId}
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          disabled={disabled}
+          placeholder={field.help ?? ''}
+        />
+      ) : (
+        <Input
+          id={inputId}
+          type={field.type === 'url' ? 'url' : 'text'}
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          disabled={disabled}
+          placeholder={field.help ?? ''}
+        />
+      )}
+      {field.help && (
+        <p className="text-xs text-muted-foreground">{field.help}</p>
+      )}
+    </div>
+  );
+}

--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
@@ -2194,14 +2194,14 @@ export interface InstallMarketplaceIntegrationDto {
 }
 
 /**
- * Configuration values with secret values masked (keys present, values replaced with "***")
+ * Configuration values with secret values masked (keys present, values replaced with "••••••")
  */
 export type UserConfigResponseDtoConfigValues = {[key: string]: string};
 
 export interface UserConfigResponseDto {
   /** Whether the user has configured values for this integration */
   hasConfig: boolean;
-  /** Configuration values with secret values masked (keys present, values replaced with "***") */
+  /** Configuration values with secret values masked (keys present, values replaced with "••••••") */
   configValues: UserConfigResponseDtoConfigValues;
 }
 

--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
@@ -2310,17 +2310,25 @@ export interface MarketplaceIntegrationResponseDto {
   identifier: string;
   /** Display name */
   name: string;
-  /** Description */
+  /** Short description for marketplace display */
+  shortDescription: string;
+  /** Full description */
   description: string;
   /**
    * Icon URL
    * @nullable
    */
   iconUrl?: string | null;
-  /** Configuration schema */
+  /** MCP server URL */
+  serverUrl: string;
+  /** Configuration schema (authType, orgFields, userFields, oauth) */
   configSchema: MarketplaceIntegrationConfigSchemaDto;
+  /** Whether the integration is featured */
+  featured: boolean;
   /** Whether the integration is published */
   published: boolean;
+  /** Whether the integration is pre-installed */
+  preInstalled: boolean;
   /** Creation timestamp */
   createdAt: string;
   /** Last update timestamp */

--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
@@ -1782,6 +1782,7 @@ export type McpIntegrationResponseDtoType = typeof McpIntegrationResponseDtoType
 export const McpIntegrationResponseDtoType = {
   predefined: 'predefined',
   custom: 'custom',
+  marketplace: 'marketplace',
 } as const;
 
 /**
@@ -1811,6 +1812,11 @@ export const McpIntegrationResponseDtoConnectionStatus = {
   error: 'error',
   unknown: 'unknown',
 } as const;
+
+/**
+ * Configuration schema from marketplace (only for marketplace integrations)
+ */
+export type McpIntegrationResponseDtoConfigSchema = { [key: string]: unknown };
 
 export interface McpIntegrationResponseDto {
   /** Unique identifier of the integration */
@@ -1845,6 +1851,12 @@ export interface McpIntegrationResponseDto {
   updatedAt: string;
   /** Whether tools from this integration may return PII data that should be anonymized in anonymous mode */
   returnsPii: boolean;
+  /** Marketplace integration identifier (only for marketplace integrations) */
+  marketplaceIdentifier?: string;
+  /** Configuration schema from marketplace (only for marketplace integrations) */
+  configSchema?: McpIntegrationResponseDtoConfigSchema;
+  /** Whether this marketplace integration has user-level config fields */
+  hasUserFields?: boolean;
 }
 
 /**
@@ -2154,6 +2166,42 @@ export interface UpdateMcpIntegrationDto {
 }
 
 /**
+ * Organization-level configuration values (key-value pairs matching config schema orgFields)
+ */
+export type InstallMarketplaceIntegrationDtoOrgConfigValues = {[key: string]: string};
+
+export interface InstallMarketplaceIntegrationDto {
+  /** Marketplace integration identifier */
+  identifier: string;
+  /** Organization-level configuration values (key-value pairs matching config schema orgFields) */
+  orgConfigValues: InstallMarketplaceIntegrationDtoOrgConfigValues;
+  /** Whether tools from this integration may return PII data that should be anonymized in anonymous mode */
+  returnsPii?: boolean;
+}
+
+/**
+ * Configuration values with secret values masked (keys present, values replaced with "***")
+ */
+export type UserConfigResponseDtoConfigValues = {[key: string]: string};
+
+export interface UserConfigResponseDto {
+  /** Whether the user has configured values for this integration */
+  hasConfig: boolean;
+  /** Configuration values with secret values masked (keys present, values replaced with "***") */
+  configValues: UserConfigResponseDtoConfigValues;
+}
+
+/**
+ * User-level configuration values (key-value pairs matching config schema userFields)
+ */
+export type SetUserConfigDtoConfigValues = {[key: string]: string};
+
+export interface SetUserConfigDto {
+  /** User-level configuration values (key-value pairs matching config schema userFields) */
+  configValues: SetUserConfigDtoConfigValues;
+}
+
+/**
  * Discovered capabilities from the MCP server
  */
 export type ValidationResponseDtoCapabilities = { [key: string]: unknown };
@@ -2165,6 +2213,118 @@ export interface ValidationResponseDto {
   capabilities: ValidationResponseDtoCapabilities;
   /** Error message if validation failed */
   error?: string;
+}
+
+export interface MarketplaceSkillResponseDto {
+  /** Skill UUID */
+  id: string;
+  /** Unique identifier (slug) */
+  identifier: string;
+  /** Display name */
+  name: string;
+  /** Short description for marketplace display */
+  shortDescription: string;
+  /** Description shown to LLM to decide activation */
+  aiDescription: string;
+  /** Detailed instructions injected into the conversation when the skill is activated */
+  instructions: string;
+  /**
+   * Skill category ID
+   * @nullable
+   */
+  skillCategoryId?: string | null;
+  /**
+   * Icon URL
+   * @nullable
+   */
+  iconUrl?: string | null;
+  /** Whether the skill is featured */
+  featured: boolean;
+  /** Whether the skill is published */
+  published: boolean;
+  /** Whether the skill is pre-installed */
+  preInstalled: boolean;
+  /** Creation timestamp */
+  createdAt: string;
+  /** Last update timestamp */
+  updatedAt: string;
+}
+
+/**
+ * Field type
+ */
+export type MarketplaceIntegrationConfigFieldDtoType = typeof MarketplaceIntegrationConfigFieldDtoType[keyof typeof MarketplaceIntegrationConfigFieldDtoType];
+
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const MarketplaceIntegrationConfigFieldDtoType = {
+  text: 'text',
+  url: 'url',
+  secret: 'secret',
+} as const;
+
+export interface MarketplaceIntegrationConfigFieldDto {
+  /** Unique identifier within the schema */
+  key: string;
+  /** Display label for the frontend form */
+  label: string;
+  /** Field type */
+  type: MarketplaceIntegrationConfigFieldDtoType;
+  /**
+   * HTTP header name this field maps to; if absent, field is internal config
+   * @nullable
+   */
+  headerName?: string | null;
+  /**
+   * Optional prefix prepended to the value before sending
+   * @nullable
+   */
+  prefix?: string | null;
+  /** Whether the field must be provided */
+  required: boolean;
+  /**
+   * Optional help text for the frontend form
+   * @nullable
+   */
+  help?: string | null;
+  /**
+   * Fixed value from marketplace; if set, field is not shown in forms
+   * @nullable
+   */
+  value?: string | null;
+}
+
+export interface MarketplaceIntegrationConfigSchemaDto {
+  /** Auth type for documentation/UI purposes */
+  authType: string;
+  /** Fields configured by org admin at install time */
+  orgFields: MarketplaceIntegrationConfigFieldDto[];
+  /** Fields configured by individual users */
+  userFields: MarketplaceIntegrationConfigFieldDto[];
+}
+
+export interface MarketplaceIntegrationResponseDto {
+  /** Integration UUID */
+  id: string;
+  /** Unique identifier (slug) */
+  identifier: string;
+  /** Display name */
+  name: string;
+  /** Description */
+  description: string;
+  /**
+   * Icon URL
+   * @nullable
+   */
+  iconUrl?: string | null;
+  /** Configuration schema */
+  configSchema: MarketplaceIntegrationConfigSchemaDto;
+  /** Whether the integration is published */
+  published: boolean;
+  /** Creation timestamp */
+  createdAt: string;
+  /** Last update timestamp */
+  updatedAt: string;
 }
 
 export interface InstallSkillFromMarketplaceDto {
@@ -2235,41 +2395,6 @@ export interface SkillSourceResponseDto {
   name: string;
   /** The type of source */
   type: string;
-}
-
-export interface MarketplaceSkillResponseDto {
-  /** Skill UUID */
-  id: string;
-  /** Unique identifier (slug) */
-  identifier: string;
-  /** Display name */
-  name: string;
-  /** Short description for marketplace display */
-  shortDescription: string;
-  /** Description shown to LLM to decide activation */
-  aiDescription: string;
-  /** Detailed instructions injected into the conversation when the skill is activated */
-  instructions: string;
-  /**
-   * Skill category ID
-   * @nullable
-   */
-  skillCategoryId?: string | null;
-  /**
-   * Icon URL
-   * @nullable
-   */
-  iconUrl?: string | null;
-  /** Whether the skill is featured */
-  featured: boolean;
-  /** Whether the skill is published */
-  published: boolean;
-  /** Whether the skill is pre-installed */
-  preInstalled: boolean;
-  /** Creation timestamp */
-  createdAt: string;
-  /** Last update timestamp */
-  updatedAt: string;
 }
 
 /**

--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
@@ -1818,6 +1818,11 @@ export const McpIntegrationResponseDtoConnectionStatus = {
  */
 export type McpIntegrationResponseDtoConfigSchema = { [key: string]: unknown };
 
+/**
+ * Current org-level config values for marketplace integrations. Non-secret fields contain plaintext values. Secret fields are masked with "••••••".
+ */
+export type McpIntegrationResponseDtoOrgConfigValues = { [key: string]: unknown };
+
 export interface McpIntegrationResponseDto {
   /** Unique identifier of the integration */
   id: string;
@@ -1857,6 +1862,8 @@ export interface McpIntegrationResponseDto {
   configSchema?: McpIntegrationResponseDtoConfigSchema;
   /** Whether this marketplace integration has user-level config fields */
   hasUserFields?: boolean;
+  /** Current org-level config values for marketplace integrations. Non-secret fields contain plaintext values. Secret fields are masked with "••••••". */
+  orgConfigValues?: McpIntegrationResponseDtoOrgConfigValues;
 }
 
 /**
@@ -2150,6 +2157,11 @@ export interface PredefinedConfigResponseDto {
   credentialFields?: CredentialFieldDto[];
 }
 
+/**
+ * Org-level config values for marketplace integrations. For secret fields, omit or send empty string to keep the existing value.
+ */
+export type UpdateMcpIntegrationDtoOrgConfigValues = { [key: string]: unknown };
+
 export interface UpdateMcpIntegrationDto {
   /**
    * The new name for the integration
@@ -2163,6 +2175,8 @@ export interface UpdateMcpIntegrationDto {
   authHeaderName?: string;
   /** Whether tools from this integration may return PII data that should be anonymized in anonymous mode. */
   returnsPii?: boolean;
+  /** Org-level config values for marketplace integrations. For secret fields, omit or send empty string to keep the existing value. */
+  orgConfigValues?: UpdateMcpIntegrationDtoOrgConfigValues;
 }
 
 /**

--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.ts
@@ -60,12 +60,14 @@ import type {
   ForgotPasswordDto,
   GetThreadResponseDto,
   GetThreadsResponseDto,
+  InstallMarketplaceIntegrationDto,
   InstallSkillFromMarketplaceDto,
   InviteDetailResponseDto,
   InvitesControllerGetInvitesParams,
   IsCloudResponseDto,
   LanguageModelResponseDto,
   LoginDto,
+  MarketplaceIntegrationResponseDto,
   MarketplaceSkillResponseDto,
   McpIntegrationResponseDto,
   MeResponseDto,
@@ -89,6 +91,7 @@ import type {
   RunsControllerSendMessage200,
   RunsControllerSendMessageBody,
   SetOrgDefaultModelDto,
+  SetUserConfigDto,
   SetUserDefaultModelDto,
   ShareResponseDto,
   SharesControllerGetSharesParams,
@@ -148,6 +151,7 @@ import type {
   UsageControllerGetUsageStatsParams,
   UsageControllerGetUserUsageParams,
   UsageStatsResponseDto,
+  UserConfigResponseDto,
   UserControllerGetUsersInOrganizationParams,
   UserControllerValidateResetToken200,
   UserControllerValidateResetTokenParams,
@@ -8596,6 +8600,229 @@ export const useMcpIntegrationsControllerDisable = <TError = void,
     }
     
 /**
+ * @summary Install an MCP integration from the marketplace
+ */
+export const mcpIntegrationsControllerInstallFromMarketplace = (
+    installMarketplaceIntegrationDto: InstallMarketplaceIntegrationDto,
+ signal?: AbortSignal
+) => {
+      
+      
+      return customAxiosInstance<McpIntegrationResponseDto>(
+      {url: `/mcp-integrations/install-from-marketplace`, method: 'POST',
+      headers: {'Content-Type': 'application/json', },
+      data: installMarketplaceIntegrationDto, signal
+    },
+      );
+    }
+  
+
+
+export const getMcpIntegrationsControllerInstallFromMarketplaceMutationOptions = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof mcpIntegrationsControllerInstallFromMarketplace>>, TError,{data: InstallMarketplaceIntegrationDto}, TContext>, }
+): UseMutationOptions<Awaited<ReturnType<typeof mcpIntegrationsControllerInstallFromMarketplace>>, TError,{data: InstallMarketplaceIntegrationDto}, TContext> => {
+
+const mutationKey = ['mcpIntegrationsControllerInstallFromMarketplace'];
+const {mutation: mutationOptions} = options ?
+      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
+      options
+      : {...options, mutation: {...options.mutation, mutationKey}}
+      : {mutation: { mutationKey, }};
+
+      
+
+
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof mcpIntegrationsControllerInstallFromMarketplace>>, {data: InstallMarketplaceIntegrationDto}> = (props) => {
+          const {data} = props ?? {};
+
+          return  mcpIntegrationsControllerInstallFromMarketplace(data,)
+        }
+
+        
+
+
+  return  { mutationFn, ...mutationOptions }}
+
+    export type McpIntegrationsControllerInstallFromMarketplaceMutationResult = NonNullable<Awaited<ReturnType<typeof mcpIntegrationsControllerInstallFromMarketplace>>>
+    export type McpIntegrationsControllerInstallFromMarketplaceMutationBody = InstallMarketplaceIntegrationDto
+    export type McpIntegrationsControllerInstallFromMarketplaceMutationError = void
+
+    /**
+ * @summary Install an MCP integration from the marketplace
+ */
+export const useMcpIntegrationsControllerInstallFromMarketplace = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof mcpIntegrationsControllerInstallFromMarketplace>>, TError,{data: InstallMarketplaceIntegrationDto}, TContext>, }
+ , queryClient?: QueryClient): UseMutationResult<
+        Awaited<ReturnType<typeof mcpIntegrationsControllerInstallFromMarketplace>>,
+        TError,
+        {data: InstallMarketplaceIntegrationDto},
+        TContext
+      > => {
+
+      const mutationOptions = getMcpIntegrationsControllerInstallFromMarketplaceMutationOptions(options);
+
+      return useMutation(mutationOptions, queryClient);
+    }
+    
+/**
+ * @summary Get current user config for a marketplace MCP integration
+ */
+export const mcpIntegrationsControllerGetUserConfig = (
+    id: string,
+ signal?: AbortSignal
+) => {
+      
+      
+      return customAxiosInstance<UserConfigResponseDto>(
+      {url: `/mcp-integrations/${id}/user-config`, method: 'GET', signal
+    },
+      );
+    }
+  
+
+
+
+export const getMcpIntegrationsControllerGetUserConfigQueryKey = (id?: string,) => {
+    return [
+    `/mcp-integrations/${id}/user-config`
+    ] as const;
+    }
+
+    
+export const getMcpIntegrationsControllerGetUserConfigQueryOptions = <TData = Awaited<ReturnType<typeof mcpIntegrationsControllerGetUserConfig>>, TError = unknown>(id: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof mcpIntegrationsControllerGetUserConfig>>, TError, TData>>, }
+) => {
+
+const {query: queryOptions} = options ?? {};
+
+  const queryKey =  queryOptions?.queryKey ?? getMcpIntegrationsControllerGetUserConfigQueryKey(id);
+
+  
+
+    const queryFn: QueryFunction<Awaited<ReturnType<typeof mcpIntegrationsControllerGetUserConfig>>> = ({ signal }) => mcpIntegrationsControllerGetUserConfig(id, signal);
+
+      
+
+      
+
+   return  { queryKey, queryFn, enabled: !!(id), ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof mcpIntegrationsControllerGetUserConfig>>, TError, TData> & { queryKey: DataTag<QueryKey, TData, TError> }
+}
+
+export type McpIntegrationsControllerGetUserConfigQueryResult = NonNullable<Awaited<ReturnType<typeof mcpIntegrationsControllerGetUserConfig>>>
+export type McpIntegrationsControllerGetUserConfigQueryError = unknown
+
+
+export function useMcpIntegrationsControllerGetUserConfig<TData = Awaited<ReturnType<typeof mcpIntegrationsControllerGetUserConfig>>, TError = unknown>(
+ id: string, options: { query:Partial<UseQueryOptions<Awaited<ReturnType<typeof mcpIntegrationsControllerGetUserConfig>>, TError, TData>> & Pick<
+        DefinedInitialDataOptions<
+          Awaited<ReturnType<typeof mcpIntegrationsControllerGetUserConfig>>,
+          TError,
+          Awaited<ReturnType<typeof mcpIntegrationsControllerGetUserConfig>>
+        > , 'initialData'
+      >, }
+ , queryClient?: QueryClient
+  ):  DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useMcpIntegrationsControllerGetUserConfig<TData = Awaited<ReturnType<typeof mcpIntegrationsControllerGetUserConfig>>, TError = unknown>(
+ id: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof mcpIntegrationsControllerGetUserConfig>>, TError, TData>> & Pick<
+        UndefinedInitialDataOptions<
+          Awaited<ReturnType<typeof mcpIntegrationsControllerGetUserConfig>>,
+          TError,
+          Awaited<ReturnType<typeof mcpIntegrationsControllerGetUserConfig>>
+        > , 'initialData'
+      >, }
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useMcpIntegrationsControllerGetUserConfig<TData = Awaited<ReturnType<typeof mcpIntegrationsControllerGetUserConfig>>, TError = unknown>(
+ id: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof mcpIntegrationsControllerGetUserConfig>>, TError, TData>>, }
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+/**
+ * @summary Get current user config for a marketplace MCP integration
+ */
+
+export function useMcpIntegrationsControllerGetUserConfig<TData = Awaited<ReturnType<typeof mcpIntegrationsControllerGetUserConfig>>, TError = unknown>(
+ id: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof mcpIntegrationsControllerGetUserConfig>>, TError, TData>>, }
+ , queryClient?: QueryClient 
+ ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
+
+  const queryOptions = getMcpIntegrationsControllerGetUserConfigQueryOptions(id,options)
+
+  const query = useQuery(queryOptions, queryClient) as  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+
+  query.queryKey = queryOptions.queryKey ;
+
+  return query;
+}
+
+
+
+
+
+/**
+ * @summary Set current user config for a marketplace MCP integration
+ */
+export const mcpIntegrationsControllerSetUserConfig = (
+    id: string,
+    setUserConfigDto: SetUserConfigDto,
+ ) => {
+      
+      
+      return customAxiosInstance<UserConfigResponseDto>(
+      {url: `/mcp-integrations/${id}/user-config`, method: 'PATCH',
+      headers: {'Content-Type': 'application/json', },
+      data: setUserConfigDto
+    },
+      );
+    }
+  
+
+
+export const getMcpIntegrationsControllerSetUserConfigMutationOptions = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof mcpIntegrationsControllerSetUserConfig>>, TError,{id: string;data: SetUserConfigDto}, TContext>, }
+): UseMutationOptions<Awaited<ReturnType<typeof mcpIntegrationsControllerSetUserConfig>>, TError,{id: string;data: SetUserConfigDto}, TContext> => {
+
+const mutationKey = ['mcpIntegrationsControllerSetUserConfig'];
+const {mutation: mutationOptions} = options ?
+      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
+      options
+      : {...options, mutation: {...options.mutation, mutationKey}}
+      : {mutation: { mutationKey, }};
+
+      
+
+
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof mcpIntegrationsControllerSetUserConfig>>, {id: string;data: SetUserConfigDto}> = (props) => {
+          const {id,data} = props ?? {};
+
+          return  mcpIntegrationsControllerSetUserConfig(id,data,)
+        }
+
+        
+
+
+  return  { mutationFn, ...mutationOptions }}
+
+    export type McpIntegrationsControllerSetUserConfigMutationResult = NonNullable<Awaited<ReturnType<typeof mcpIntegrationsControllerSetUserConfig>>>
+    export type McpIntegrationsControllerSetUserConfigMutationBody = SetUserConfigDto
+    export type McpIntegrationsControllerSetUserConfigMutationError = void
+
+    /**
+ * @summary Set current user config for a marketplace MCP integration
+ */
+export const useMcpIntegrationsControllerSetUserConfig = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof mcpIntegrationsControllerSetUserConfig>>, TError,{id: string;data: SetUserConfigDto}, TContext>, }
+ , queryClient?: QueryClient): UseMutationResult<
+        Awaited<ReturnType<typeof mcpIntegrationsControllerSetUserConfig>>,
+        TError,
+        {id: string;data: SetUserConfigDto},
+        TContext
+      > => {
+
+      const mutationOptions = getMcpIntegrationsControllerSetUserConfigMutationOptions(options);
+
+      return useMutation(mutationOptions, queryClient);
+    }
+    
+/**
  * @summary Validate MCP integration connection
  */
 export const mcpIntegrationsControllerValidate = (
@@ -8658,6 +8885,192 @@ export const useMcpIntegrationsControllerValidate = <TError = void,
       return useMutation(mutationOptions, queryClient);
     }
     
+/**
+ * @summary Preview a marketplace skill before installation
+ */
+export const marketplaceControllerGetSkill = (
+    identifier: string,
+ signal?: AbortSignal
+) => {
+      
+      
+      return customAxiosInstance<MarketplaceSkillResponseDto>(
+      {url: `/marketplace/skills/${identifier}`, method: 'GET', signal
+    },
+      );
+    }
+  
+
+
+
+export const getMarketplaceControllerGetSkillQueryKey = (identifier?: string,) => {
+    return [
+    `/marketplace/skills/${identifier}`
+    ] as const;
+    }
+
+    
+export const getMarketplaceControllerGetSkillQueryOptions = <TData = Awaited<ReturnType<typeof marketplaceControllerGetSkill>>, TError = void>(identifier: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof marketplaceControllerGetSkill>>, TError, TData>>, }
+) => {
+
+const {query: queryOptions} = options ?? {};
+
+  const queryKey =  queryOptions?.queryKey ?? getMarketplaceControllerGetSkillQueryKey(identifier);
+
+  
+
+    const queryFn: QueryFunction<Awaited<ReturnType<typeof marketplaceControllerGetSkill>>> = ({ signal }) => marketplaceControllerGetSkill(identifier, signal);
+
+      
+
+      
+
+   return  { queryKey, queryFn, enabled: !!(identifier), ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof marketplaceControllerGetSkill>>, TError, TData> & { queryKey: DataTag<QueryKey, TData, TError> }
+}
+
+export type MarketplaceControllerGetSkillQueryResult = NonNullable<Awaited<ReturnType<typeof marketplaceControllerGetSkill>>>
+export type MarketplaceControllerGetSkillQueryError = void
+
+
+export function useMarketplaceControllerGetSkill<TData = Awaited<ReturnType<typeof marketplaceControllerGetSkill>>, TError = void>(
+ identifier: string, options: { query:Partial<UseQueryOptions<Awaited<ReturnType<typeof marketplaceControllerGetSkill>>, TError, TData>> & Pick<
+        DefinedInitialDataOptions<
+          Awaited<ReturnType<typeof marketplaceControllerGetSkill>>,
+          TError,
+          Awaited<ReturnType<typeof marketplaceControllerGetSkill>>
+        > , 'initialData'
+      >, }
+ , queryClient?: QueryClient
+  ):  DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useMarketplaceControllerGetSkill<TData = Awaited<ReturnType<typeof marketplaceControllerGetSkill>>, TError = void>(
+ identifier: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof marketplaceControllerGetSkill>>, TError, TData>> & Pick<
+        UndefinedInitialDataOptions<
+          Awaited<ReturnType<typeof marketplaceControllerGetSkill>>,
+          TError,
+          Awaited<ReturnType<typeof marketplaceControllerGetSkill>>
+        > , 'initialData'
+      >, }
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useMarketplaceControllerGetSkill<TData = Awaited<ReturnType<typeof marketplaceControllerGetSkill>>, TError = void>(
+ identifier: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof marketplaceControllerGetSkill>>, TError, TData>>, }
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+/**
+ * @summary Preview a marketplace skill before installation
+ */
+
+export function useMarketplaceControllerGetSkill<TData = Awaited<ReturnType<typeof marketplaceControllerGetSkill>>, TError = void>(
+ identifier: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof marketplaceControllerGetSkill>>, TError, TData>>, }
+ , queryClient?: QueryClient 
+ ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
+
+  const queryOptions = getMarketplaceControllerGetSkillQueryOptions(identifier,options)
+
+  const query = useQuery(queryOptions, queryClient) as  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+
+  query.queryKey = queryOptions.queryKey ;
+
+  return query;
+}
+
+
+
+
+
+/**
+ * @summary Preview a marketplace integration before installation
+ */
+export const marketplaceControllerGetIntegration = (
+    identifier: string,
+ signal?: AbortSignal
+) => {
+      
+      
+      return customAxiosInstance<MarketplaceIntegrationResponseDto>(
+      {url: `/marketplace/integrations/${identifier}`, method: 'GET', signal
+    },
+      );
+    }
+  
+
+
+
+export const getMarketplaceControllerGetIntegrationQueryKey = (identifier?: string,) => {
+    return [
+    `/marketplace/integrations/${identifier}`
+    ] as const;
+    }
+
+    
+export const getMarketplaceControllerGetIntegrationQueryOptions = <TData = Awaited<ReturnType<typeof marketplaceControllerGetIntegration>>, TError = void>(identifier: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof marketplaceControllerGetIntegration>>, TError, TData>>, }
+) => {
+
+const {query: queryOptions} = options ?? {};
+
+  const queryKey =  queryOptions?.queryKey ?? getMarketplaceControllerGetIntegrationQueryKey(identifier);
+
+  
+
+    const queryFn: QueryFunction<Awaited<ReturnType<typeof marketplaceControllerGetIntegration>>> = ({ signal }) => marketplaceControllerGetIntegration(identifier, signal);
+
+      
+
+      
+
+   return  { queryKey, queryFn, enabled: !!(identifier), ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof marketplaceControllerGetIntegration>>, TError, TData> & { queryKey: DataTag<QueryKey, TData, TError> }
+}
+
+export type MarketplaceControllerGetIntegrationQueryResult = NonNullable<Awaited<ReturnType<typeof marketplaceControllerGetIntegration>>>
+export type MarketplaceControllerGetIntegrationQueryError = void
+
+
+export function useMarketplaceControllerGetIntegration<TData = Awaited<ReturnType<typeof marketplaceControllerGetIntegration>>, TError = void>(
+ identifier: string, options: { query:Partial<UseQueryOptions<Awaited<ReturnType<typeof marketplaceControllerGetIntegration>>, TError, TData>> & Pick<
+        DefinedInitialDataOptions<
+          Awaited<ReturnType<typeof marketplaceControllerGetIntegration>>,
+          TError,
+          Awaited<ReturnType<typeof marketplaceControllerGetIntegration>>
+        > , 'initialData'
+      >, }
+ , queryClient?: QueryClient
+  ):  DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useMarketplaceControllerGetIntegration<TData = Awaited<ReturnType<typeof marketplaceControllerGetIntegration>>, TError = void>(
+ identifier: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof marketplaceControllerGetIntegration>>, TError, TData>> & Pick<
+        UndefinedInitialDataOptions<
+          Awaited<ReturnType<typeof marketplaceControllerGetIntegration>>,
+          TError,
+          Awaited<ReturnType<typeof marketplaceControllerGetIntegration>>
+        > , 'initialData'
+      >, }
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useMarketplaceControllerGetIntegration<TData = Awaited<ReturnType<typeof marketplaceControllerGetIntegration>>, TError = void>(
+ identifier: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof marketplaceControllerGetIntegration>>, TError, TData>>, }
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+/**
+ * @summary Preview a marketplace integration before installation
+ */
+
+export function useMarketplaceControllerGetIntegration<TData = Awaited<ReturnType<typeof marketplaceControllerGetIntegration>>, TError = void>(
+ identifier: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof marketplaceControllerGetIntegration>>, TError, TData>>, }
+ , queryClient?: QueryClient 
+ ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
+
+  const queryOptions = getMarketplaceControllerGetIntegrationQueryOptions(identifier,options)
+
+  const query = useQuery(queryOptions, queryClient) as  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+
+  query.queryKey = queryOptions.queryKey ;
+
+  return query;
+}
+
+
+
+
+
 /**
  * @summary Install a skill from the marketplace
  */
@@ -9657,99 +10070,6 @@ export function useSkillMcpIntegrationsControllerListSkillMcpIntegrations<TData 
  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
 
   const queryOptions = getSkillMcpIntegrationsControllerListSkillMcpIntegrationsQueryOptions(skillId,options)
-
-  const query = useQuery(queryOptions, queryClient) as  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
-
-  query.queryKey = queryOptions.queryKey ;
-
-  return query;
-}
-
-
-
-
-
-/**
- * @summary Preview a marketplace skill before installation
- */
-export const marketplaceControllerGetSkill = (
-    identifier: string,
- signal?: AbortSignal
-) => {
-      
-      
-      return customAxiosInstance<MarketplaceSkillResponseDto>(
-      {url: `/marketplace/skills/${identifier}`, method: 'GET', signal
-    },
-      );
-    }
-  
-
-
-
-export const getMarketplaceControllerGetSkillQueryKey = (identifier?: string,) => {
-    return [
-    `/marketplace/skills/${identifier}`
-    ] as const;
-    }
-
-    
-export const getMarketplaceControllerGetSkillQueryOptions = <TData = Awaited<ReturnType<typeof marketplaceControllerGetSkill>>, TError = void>(identifier: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof marketplaceControllerGetSkill>>, TError, TData>>, }
-) => {
-
-const {query: queryOptions} = options ?? {};
-
-  const queryKey =  queryOptions?.queryKey ?? getMarketplaceControllerGetSkillQueryKey(identifier);
-
-  
-
-    const queryFn: QueryFunction<Awaited<ReturnType<typeof marketplaceControllerGetSkill>>> = ({ signal }) => marketplaceControllerGetSkill(identifier, signal);
-
-      
-
-      
-
-   return  { queryKey, queryFn, enabled: !!(identifier), ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof marketplaceControllerGetSkill>>, TError, TData> & { queryKey: DataTag<QueryKey, TData, TError> }
-}
-
-export type MarketplaceControllerGetSkillQueryResult = NonNullable<Awaited<ReturnType<typeof marketplaceControllerGetSkill>>>
-export type MarketplaceControllerGetSkillQueryError = void
-
-
-export function useMarketplaceControllerGetSkill<TData = Awaited<ReturnType<typeof marketplaceControllerGetSkill>>, TError = void>(
- identifier: string, options: { query:Partial<UseQueryOptions<Awaited<ReturnType<typeof marketplaceControllerGetSkill>>, TError, TData>> & Pick<
-        DefinedInitialDataOptions<
-          Awaited<ReturnType<typeof marketplaceControllerGetSkill>>,
-          TError,
-          Awaited<ReturnType<typeof marketplaceControllerGetSkill>>
-        > , 'initialData'
-      >, }
- , queryClient?: QueryClient
-  ):  DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
-export function useMarketplaceControllerGetSkill<TData = Awaited<ReturnType<typeof marketplaceControllerGetSkill>>, TError = void>(
- identifier: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof marketplaceControllerGetSkill>>, TError, TData>> & Pick<
-        UndefinedInitialDataOptions<
-          Awaited<ReturnType<typeof marketplaceControllerGetSkill>>,
-          TError,
-          Awaited<ReturnType<typeof marketplaceControllerGetSkill>>
-        > , 'initialData'
-      >, }
- , queryClient?: QueryClient
-  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
-export function useMarketplaceControllerGetSkill<TData = Awaited<ReturnType<typeof marketplaceControllerGetSkill>>, TError = void>(
- identifier: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof marketplaceControllerGetSkill>>, TError, TData>>, }
- , queryClient?: QueryClient
-  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
-/**
- * @summary Preview a marketplace skill before installation
- */
-
-export function useMarketplaceControllerGetSkill<TData = Awaited<ReturnType<typeof marketplaceControllerGetSkill>>, TError = void>(
- identifier: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof marketplaceControllerGetSkill>>, TError, TData>>, }
- , queryClient?: QueryClient 
- ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
-
-  const queryOptions = getMarketplaceControllerGetSkillQueryOptions(identifier,options)
 
   const query = useQuery(queryOptions, queryClient) as  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
 

--- a/ayunis-core-frontend/src/shared/api/openapi-schema.json
+++ b/ayunis-core-frontend/src/shared/api/openapi-schema.json
@@ -7006,7 +7006,8 @@
               "ayunis",
               "otc",
               "azure",
-              "gemini"
+              "gemini",
+              "stackit"
             ],
             "description": "The provider of the model"
           },
@@ -7079,7 +7080,8 @@
               "ayunis",
               "otc",
               "azure",
-              "gemini"
+              "gemini",
+              "stackit"
             ],
             "description": "The model provider identifier",
             "example": "openai"
@@ -7163,7 +7165,8 @@
               "ayunis",
               "otc",
               "azure",
-              "gemini"
+              "gemini",
+              "stackit"
             ],
             "description": "The provider of the model"
           },
@@ -7296,7 +7299,8 @@
               "ayunis",
               "otc",
               "azure",
-              "gemini"
+              "gemini",
+              "stackit"
             ],
             "description": "The provider of the model"
           },
@@ -7357,7 +7361,8 @@
               "ayunis",
               "otc",
               "azure",
-              "gemini"
+              "gemini",
+              "stackit"
             ],
             "example": "openai"
           },
@@ -7424,7 +7429,8 @@
               "ayunis",
               "otc",
               "azure",
-              "gemini"
+              "gemini",
+              "stackit"
             ],
             "example": "openai"
           },
@@ -7491,7 +7497,8 @@
               "ayunis",
               "otc",
               "azure",
-              "gemini"
+              "gemini",
+              "stackit"
             ],
             "example": "openai"
           },
@@ -7545,7 +7552,8 @@
               "ayunis",
               "otc",
               "azure",
-              "gemini"
+              "gemini",
+              "stackit"
             ],
             "example": "openai"
           },
@@ -7604,7 +7612,8 @@
               "ayunis",
               "otc",
               "azure",
-              "gemini"
+              "gemini",
+              "stackit"
             ],
             "description": "The provider of the model",
             "example": "openai"
@@ -7698,7 +7707,8 @@
               "ayunis",
               "otc",
               "azure",
-              "gemini"
+              "gemini",
+              "stackit"
             ],
             "description": "The provider of the model",
             "example": "openai"
@@ -10821,26 +10831,42 @@
             "type": "string",
             "description": "Display name"
           },
+          "shortDescription": {
+            "type": "string",
+            "description": "Short description for marketplace display"
+          },
           "description": {
             "type": "string",
-            "description": "Description"
+            "description": "Full description"
           },
           "iconUrl": {
             "type": "string",
             "description": "Icon URL",
             "nullable": true
           },
+          "serverUrl": {
+            "type": "string",
+            "description": "MCP server URL"
+          },
           "configSchema": {
-            "description": "Configuration schema",
+            "description": "Configuration schema (authType, orgFields, userFields, oauth)",
             "allOf": [
               {
                 "$ref": "#/components/schemas/MarketplaceIntegrationConfigSchemaDto"
               }
             ]
           },
+          "featured": {
+            "type": "boolean",
+            "description": "Whether the integration is featured"
+          },
           "published": {
             "type": "boolean",
             "description": "Whether the integration is published"
+          },
+          "preInstalled": {
+            "type": "boolean",
+            "description": "Whether the integration is pre-installed"
           },
           "createdAt": {
             "type": "string",
@@ -10855,9 +10881,13 @@
           "id",
           "identifier",
           "name",
+          "shortDescription",
           "description",
+          "serverUrl",
           "configSchema",
+          "featured",
           "published",
+          "preInstalled",
           "createdAt",
           "updatedAt"
         ]
@@ -11531,7 +11561,8 @@
               "ayunis",
               "otc",
               "azure",
-              "gemini"
+              "gemini",
+              "stackit"
             ],
             "description": "Model provider"
           },
@@ -11671,7 +11702,8 @@
               "ayunis",
               "otc",
               "azure",
-              "gemini"
+              "gemini",
+              "stackit"
             ],
             "description": "Model provider"
           },

--- a/ayunis-core-frontend/src/shared/api/openapi-schema.json
+++ b/ayunis-core-frontend/src/shared/api/openapi-schema.json
@@ -4475,6 +4475,122 @@
         ]
       }
     },
+    "/mcp-integrations/install-from-marketplace": {
+      "post": {
+        "operationId": "McpIntegrationsController_installFromMarketplace",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/InstallMarketplaceIntegrationDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Integration installed successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/McpIntegrationResponseDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing required config fields or OAuth not supported"
+          },
+          "404": {
+            "description": "Marketplace integration not found"
+          }
+        },
+        "summary": "Install an MCP integration from the marketplace",
+        "tags": [
+          "mcp-integrations"
+        ]
+      }
+    },
+    "/mcp-integrations/{id}/user-config": {
+      "get": {
+        "operationId": "McpIntegrationsController_getUserConfig",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "User configuration (secret values masked)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserConfigResponseDto"
+                }
+              }
+            }
+          }
+        },
+        "summary": "Get current user config for a marketplace MCP integration",
+        "tags": [
+          "mcp-integrations"
+        ]
+      },
+      "patch": {
+        "operationId": "McpIntegrationsController_setUserConfig",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetUserConfigDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "User configuration saved",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserConfigResponseDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Integration has no user fields"
+          },
+          "404": {
+            "description": "Integration not found"
+          }
+        },
+        "summary": "Set current user config for a marketplace MCP integration",
+        "tags": [
+          "mcp-integrations"
+        ]
+      }
+    },
     "/mcp-integrations/{id}/validate": {
       "post": {
         "operationId": "McpIntegrationsController_validate",
@@ -4507,6 +4623,76 @@
         "summary": "Validate MCP integration connection",
         "tags": [
           "mcp-integrations"
+        ]
+      }
+    },
+    "/marketplace/skills/{identifier}": {
+      "get": {
+        "operationId": "MarketplaceController_getSkill",
+        "parameters": [
+          {
+            "name": "identifier",
+            "required": true,
+            "in": "path",
+            "description": "The unique identifier slug of the marketplace skill",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns the marketplace skill details",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MarketplaceSkillResponseDto"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Marketplace skill not found"
+          }
+        },
+        "summary": "Preview a marketplace skill before installation",
+        "tags": [
+          "marketplace"
+        ]
+      }
+    },
+    "/marketplace/integrations/{identifier}": {
+      "get": {
+        "operationId": "MarketplaceController_getIntegration",
+        "parameters": [
+          {
+            "name": "identifier",
+            "required": true,
+            "in": "path",
+            "description": "The unique identifier slug of the marketplace integration",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns the marketplace integration details",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MarketplaceIntegrationResponseDto"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Marketplace integration not found"
+          }
+        },
+        "summary": "Preview a marketplace integration before installation",
+        "tags": [
+          "marketplace"
         ]
       }
     },
@@ -5060,41 +5246,6 @@
         "summary": "List MCP integrations assigned to skill",
         "tags": [
           "skills"
-        ]
-      }
-    },
-    "/marketplace/skills/{identifier}": {
-      "get": {
-        "operationId": "MarketplaceController_getSkill",
-        "parameters": [
-          {
-            "name": "identifier",
-            "required": true,
-            "in": "path",
-            "description": "The unique identifier slug of the marketplace skill",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Returns the marketplace skill details",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/MarketplaceSkillResponseDto"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Marketplace skill not found"
-          }
-        },
-        "summary": "Preview a marketplace skill before installation",
-        "tags": [
-          "marketplace"
         ]
       }
     },
@@ -6855,8 +7006,7 @@
               "ayunis",
               "otc",
               "azure",
-              "gemini",
-              "stackit"
+              "gemini"
             ],
             "description": "The provider of the model"
           },
@@ -6929,8 +7079,7 @@
               "ayunis",
               "otc",
               "azure",
-              "gemini",
-              "stackit"
+              "gemini"
             ],
             "description": "The model provider identifier",
             "example": "openai"
@@ -7014,8 +7163,7 @@
               "ayunis",
               "otc",
               "azure",
-              "gemini",
-              "stackit"
+              "gemini"
             ],
             "description": "The provider of the model"
           },
@@ -7148,8 +7296,7 @@
               "ayunis",
               "otc",
               "azure",
-              "gemini",
-              "stackit"
+              "gemini"
             ],
             "description": "The provider of the model"
           },
@@ -7210,8 +7357,7 @@
               "ayunis",
               "otc",
               "azure",
-              "gemini",
-              "stackit"
+              "gemini"
             ],
             "example": "openai"
           },
@@ -7278,8 +7424,7 @@
               "ayunis",
               "otc",
               "azure",
-              "gemini",
-              "stackit"
+              "gemini"
             ],
             "example": "openai"
           },
@@ -7346,8 +7491,7 @@
               "ayunis",
               "otc",
               "azure",
-              "gemini",
-              "stackit"
+              "gemini"
             ],
             "example": "openai"
           },
@@ -7401,8 +7545,7 @@
               "ayunis",
               "otc",
               "azure",
-              "gemini",
-              "stackit"
+              "gemini"
             ],
             "example": "openai"
           },
@@ -7461,8 +7604,7 @@
               "ayunis",
               "otc",
               "azure",
-              "gemini",
-              "stackit"
+              "gemini"
             ],
             "description": "The provider of the model",
             "example": "openai"
@@ -7556,8 +7698,7 @@
               "ayunis",
               "otc",
               "azure",
-              "gemini",
-              "stackit"
+              "gemini"
             ],
             "description": "The provider of the model",
             "example": "openai"
@@ -9792,7 +9933,8 @@
             "description": "Type of integration",
             "enum": [
               "predefined",
-              "custom"
+              "custom",
+              "marketplace"
             ],
             "example": "predefined"
           },
@@ -9875,6 +10017,20 @@
             "type": "boolean",
             "description": "Whether tools from this integration may return PII data that should be anonymized in anonymous mode",
             "example": true
+          },
+          "marketplaceIdentifier": {
+            "type": "string",
+            "description": "Marketplace integration identifier (only for marketplace integrations)",
+            "example": "oparl-council-data"
+          },
+          "configSchema": {
+            "type": "object",
+            "description": "Configuration schema from marketplace (only for marketplace integrations)"
+          },
+          "hasUserFields": {
+            "type": "boolean",
+            "description": "Whether this marketplace integration has user-level config fields",
+            "example": false
           }
         },
         "required": [
@@ -10399,6 +10555,77 @@
           }
         }
       },
+      "InstallMarketplaceIntegrationDto": {
+        "type": "object",
+        "properties": {
+          "identifier": {
+            "type": "string",
+            "description": "Marketplace integration identifier",
+            "example": "oparl-council-data"
+          },
+          "orgConfigValues": {
+            "type": "object",
+            "description": "Organization-level configuration values (key-value pairs matching config schema orgFields)",
+            "example": {
+              "oparlEndpointUrl": "https://rim.ekom21.de/oparl/v1"
+            },
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "returnsPii": {
+            "type": "boolean",
+            "description": "Whether tools from this integration may return PII data that should be anonymized in anonymous mode",
+            "example": false
+          }
+        },
+        "required": [
+          "identifier",
+          "orgConfigValues"
+        ]
+      },
+      "UserConfigResponseDto": {
+        "type": "object",
+        "properties": {
+          "hasConfig": {
+            "type": "boolean",
+            "description": "Whether the user has configured values for this integration",
+            "example": true
+          },
+          "configValues": {
+            "type": "object",
+            "description": "Configuration values with secret values masked (keys present, values replaced with \"***\")",
+            "example": {
+              "personalToken": "***"
+            },
+            "additionalProperties": {
+              "type": "string"
+            }
+          }
+        },
+        "required": [
+          "hasConfig",
+          "configValues"
+        ]
+      },
+      "SetUserConfigDto": {
+        "type": "object",
+        "properties": {
+          "configValues": {
+            "type": "object",
+            "description": "User-level configuration values (key-value pairs matching config schema userFields)",
+            "example": {
+              "personalToken": "my-personal-access-token"
+            },
+            "additionalProperties": {
+              "type": "string"
+            }
+          }
+        },
+        "required": [
+          "configValues"
+        ]
+      },
       "ValidationResponseDto": {
         "type": "object",
         "properties": {
@@ -10425,6 +10652,214 @@
         "required": [
           "valid",
           "capabilities"
+        ]
+      },
+      "MarketplaceSkillResponseDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Skill UUID"
+          },
+          "identifier": {
+            "type": "string",
+            "description": "Unique identifier (slug)"
+          },
+          "name": {
+            "type": "string",
+            "description": "Display name"
+          },
+          "shortDescription": {
+            "type": "string",
+            "description": "Short description for marketplace display"
+          },
+          "aiDescription": {
+            "type": "string",
+            "description": "Description shown to LLM to decide activation"
+          },
+          "instructions": {
+            "type": "string",
+            "description": "Detailed instructions injected into the conversation when the skill is activated"
+          },
+          "skillCategoryId": {
+            "type": "string",
+            "description": "Skill category ID",
+            "nullable": true
+          },
+          "iconUrl": {
+            "type": "string",
+            "description": "Icon URL",
+            "nullable": true
+          },
+          "featured": {
+            "type": "boolean",
+            "description": "Whether the skill is featured"
+          },
+          "published": {
+            "type": "boolean",
+            "description": "Whether the skill is published"
+          },
+          "preInstalled": {
+            "type": "boolean",
+            "description": "Whether the skill is pre-installed"
+          },
+          "createdAt": {
+            "type": "string",
+            "description": "Creation timestamp"
+          },
+          "updatedAt": {
+            "type": "string",
+            "description": "Last update timestamp"
+          }
+        },
+        "required": [
+          "id",
+          "identifier",
+          "name",
+          "shortDescription",
+          "aiDescription",
+          "instructions",
+          "featured",
+          "published",
+          "preInstalled",
+          "createdAt",
+          "updatedAt"
+        ]
+      },
+      "MarketplaceIntegrationConfigFieldDto": {
+        "type": "object",
+        "properties": {
+          "key": {
+            "type": "string",
+            "description": "Unique identifier within the schema"
+          },
+          "label": {
+            "type": "string",
+            "description": "Display label for the frontend form"
+          },
+          "type": {
+            "type": "string",
+            "description": "Field type",
+            "enum": [
+              "text",
+              "url",
+              "secret"
+            ]
+          },
+          "headerName": {
+            "type": "string",
+            "description": "HTTP header name this field maps to; if absent, field is internal config",
+            "nullable": true
+          },
+          "prefix": {
+            "type": "string",
+            "description": "Optional prefix prepended to the value before sending",
+            "nullable": true
+          },
+          "required": {
+            "type": "boolean",
+            "description": "Whether the field must be provided"
+          },
+          "help": {
+            "type": "string",
+            "description": "Optional help text for the frontend form",
+            "nullable": true
+          },
+          "value": {
+            "type": "string",
+            "description": "Fixed value from marketplace; if set, field is not shown in forms",
+            "nullable": true
+          }
+        },
+        "required": [
+          "key",
+          "label",
+          "type",
+          "required"
+        ]
+      },
+      "MarketplaceIntegrationConfigSchemaDto": {
+        "type": "object",
+        "properties": {
+          "authType": {
+            "type": "string",
+            "description": "Auth type for documentation/UI purposes"
+          },
+          "orgFields": {
+            "description": "Fields configured by org admin at install time",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/MarketplaceIntegrationConfigFieldDto"
+            }
+          },
+          "userFields": {
+            "description": "Fields configured by individual users",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/MarketplaceIntegrationConfigFieldDto"
+            }
+          }
+        },
+        "required": [
+          "authType",
+          "orgFields",
+          "userFields"
+        ]
+      },
+      "MarketplaceIntegrationResponseDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Integration UUID"
+          },
+          "identifier": {
+            "type": "string",
+            "description": "Unique identifier (slug)"
+          },
+          "name": {
+            "type": "string",
+            "description": "Display name"
+          },
+          "description": {
+            "type": "string",
+            "description": "Description"
+          },
+          "iconUrl": {
+            "type": "string",
+            "description": "Icon URL",
+            "nullable": true
+          },
+          "configSchema": {
+            "description": "Configuration schema",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/MarketplaceIntegrationConfigSchemaDto"
+              }
+            ]
+          },
+          "published": {
+            "type": "boolean",
+            "description": "Whether the integration is published"
+          },
+          "createdAt": {
+            "type": "string",
+            "description": "Creation timestamp"
+          },
+          "updatedAt": {
+            "type": "string",
+            "description": "Last update timestamp"
+          }
+        },
+        "required": [
+          "id",
+          "identifier",
+          "name",
+          "description",
+          "configSchema",
+          "published",
+          "createdAt",
+          "updatedAt"
         ]
       },
       "InstallSkillFromMarketplaceDto": {
@@ -10601,78 +11036,6 @@
           "id",
           "name",
           "type"
-        ]
-      },
-      "MarketplaceSkillResponseDto": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string",
-            "description": "Skill UUID"
-          },
-          "identifier": {
-            "type": "string",
-            "description": "Unique identifier (slug)"
-          },
-          "name": {
-            "type": "string",
-            "description": "Display name"
-          },
-          "shortDescription": {
-            "type": "string",
-            "description": "Short description for marketplace display"
-          },
-          "aiDescription": {
-            "type": "string",
-            "description": "Description shown to LLM to decide activation"
-          },
-          "instructions": {
-            "type": "string",
-            "description": "Detailed instructions injected into the conversation when the skill is activated"
-          },
-          "skillCategoryId": {
-            "type": "string",
-            "description": "Skill category ID",
-            "nullable": true
-          },
-          "iconUrl": {
-            "type": "string",
-            "description": "Icon URL",
-            "nullable": true
-          },
-          "featured": {
-            "type": "boolean",
-            "description": "Whether the skill is featured"
-          },
-          "published": {
-            "type": "boolean",
-            "description": "Whether the skill is published"
-          },
-          "preInstalled": {
-            "type": "boolean",
-            "description": "Whether the skill is pre-installed"
-          },
-          "createdAt": {
-            "type": "string",
-            "description": "Creation timestamp"
-          },
-          "updatedAt": {
-            "type": "string",
-            "description": "Last update timestamp"
-          }
-        },
-        "required": [
-          "id",
-          "identifier",
-          "name",
-          "shortDescription",
-          "aiDescription",
-          "instructions",
-          "featured",
-          "published",
-          "preInstalled",
-          "createdAt",
-          "updatedAt"
         ]
       },
       "MessageContentResponseDto": {
@@ -11168,8 +11531,7 @@
               "ayunis",
               "otc",
               "azure",
-              "gemini",
-              "stackit"
+              "gemini"
             ],
             "description": "Model provider"
           },
@@ -11309,8 +11671,7 @@
               "ayunis",
               "otc",
               "azure",
-              "gemini",
-              "stackit"
+              "gemini"
             ],
             "description": "Model provider"
           },

--- a/ayunis-core-frontend/src/shared/api/openapi-schema.json
+++ b/ayunis-core-frontend/src/shared/api/openapi-schema.json
@@ -18,7 +18,9 @@
           }
         },
         "summary": "Check if the deployment is running in a cloud environment",
-        "tags": ["app"]
+        "tags": [
+          "app"
+        ]
       }
     },
     "/health": {
@@ -31,7 +33,9 @@
           }
         },
         "summary": "Check if the deployment is healthy",
-        "tags": ["app"]
+        "tags": [
+          "app"
+        ]
       }
     },
     "/models/available": {
@@ -57,7 +61,9 @@
           }
         },
         "summary": "Get all available models",
-        "tags": ["models"]
+        "tags": [
+          "models"
+        ]
       }
     },
     "/models/providers": {
@@ -80,7 +86,9 @@
           }
         },
         "summary": "Get all available model providers with their info",
-        "tags": ["models"]
+        "tags": [
+          "models"
+        ]
       }
     },
     "/models/permitted": {
@@ -109,7 +117,9 @@
           }
         },
         "summary": "Create a permitted model",
-        "tags": ["models"]
+        "tags": [
+          "models"
+        ]
       }
     },
     "/models/permitted/{id}": {
@@ -134,7 +144,9 @@
           }
         },
         "summary": "Delete a permitted model",
-        "tags": ["models"]
+        "tags": [
+          "models"
+        ]
       },
       "patch": {
         "operationId": "ModelsController_updatePermittedModel",
@@ -177,7 +189,9 @@
           }
         },
         "summary": "Update a permitted model",
-        "tags": ["models"]
+        "tags": [
+          "models"
+        ]
       }
     },
     "/models/permitted/language-models": {
@@ -203,7 +217,9 @@
           }
         },
         "summary": "Get all permitted language models",
-        "tags": ["models"]
+        "tags": [
+          "models"
+        ]
       }
     },
     "/models/default": {
@@ -227,7 +243,9 @@
           }
         },
         "summary": "Get the effective default model for the user",
-        "tags": ["models"]
+        "tags": [
+          "models"
+        ]
       }
     },
     "/models/org/default": {
@@ -251,7 +269,9 @@
           }
         },
         "summary": "Get the organization default model",
-        "tags": ["models"]
+        "tags": [
+          "models"
+        ]
       },
       "put": {
         "description": "Sets the specified permitted model as the organization default. If a default already exists, it will be updated to the new model.",
@@ -286,7 +306,9 @@
           }
         },
         "summary": "Set or update the organization default model",
-        "tags": ["models"]
+        "tags": [
+          "models"
+        ]
       }
     },
     "/models/user/default": {
@@ -310,7 +332,9 @@
           }
         },
         "summary": "Get the user-specific default model",
-        "tags": ["models"]
+        "tags": [
+          "models"
+        ]
       },
       "put": {
         "description": "Sets the specified permitted model as the user default. If a default already exists, it will be updated to the new model.",
@@ -345,7 +369,9 @@
           }
         },
         "summary": "Set or update the user default model",
-        "tags": ["models"]
+        "tags": [
+          "models"
+        ]
       },
       "delete": {
         "operationId": "ModelsController_deleteUserDefaultModel",
@@ -359,7 +385,9 @@
           }
         },
         "summary": "Delete the user default model",
-        "tags": ["models"]
+        "tags": [
+          "models"
+        ]
       }
     },
     "/models/provider/{provider}": {
@@ -395,7 +423,9 @@
           }
         },
         "summary": "Get model provider information",
-        "tags": ["models"]
+        "tags": [
+          "models"
+        ]
       }
     },
     "/models/embedding/enabled": {
@@ -418,7 +448,9 @@
           }
         },
         "summary": "Check if an embedding model is enabled for this org",
-        "tags": ["models"]
+        "tags": [
+          "models"
+        ]
       }
     },
     "/super-admin/models/{orgId}/available": {
@@ -460,7 +492,9 @@
           }
         },
         "summary": "Get all available models",
-        "tags": ["Super Admin Models"]
+        "tags": [
+          "Super Admin Models"
+        ]
       }
     },
     "/super-admin/models/{orgId}/default-model": {
@@ -515,7 +549,9 @@
           }
         },
         "summary": "Set or update the organization default model",
-        "tags": ["Super Admin Models"]
+        "tags": [
+          "Super Admin Models"
+        ]
       }
     },
     "/super-admin/models/catalog/{id}": {
@@ -550,7 +586,9 @@
           }
         },
         "summary": "Delete a model from the catalog",
-        "tags": ["Super Admin Models"]
+        "tags": [
+          "Super Admin Models"
+        ]
       },
       "get": {
         "description": "Retrieve a specific model from the master catalog by its ID. This endpoint is only accessible to super admins.",
@@ -597,7 +635,9 @@
           }
         },
         "summary": "Get a model by ID from the catalog",
-        "tags": ["Super Admin Models"]
+        "tags": [
+          "Super Admin Models"
+        ]
       }
     },
     "/super-admin/models/{orgId}/permitted-models": {
@@ -646,7 +686,9 @@
           }
         },
         "summary": "Get all permitted models for a specific organization",
-        "tags": ["Super Admin Models"]
+        "tags": [
+          "Super Admin Models"
+        ]
       },
       "post": {
         "description": "Create a new permitted model for the specified organization. This endpoint is only accessible to super admins.",
@@ -692,7 +734,9 @@
           }
         },
         "summary": "Create a permitted model for a specific organization",
-        "tags": ["Super Admin Models"]
+        "tags": [
+          "Super Admin Models"
+        ]
       }
     },
     "/super-admin/models/{orgId}/permitted-models/{id}": {
@@ -741,7 +785,9 @@
           }
         },
         "summary": "Delete a permitted model for a specific organization",
-        "tags": ["Super Admin Models"]
+        "tags": [
+          "Super Admin Models"
+        ]
       },
       "patch": {
         "description": "Update the settings of a permitted model for the specified organization. This endpoint is only accessible to super admins.",
@@ -812,7 +858,9 @@
           }
         },
         "summary": "Update a permitted model for a specific organization",
-        "tags": ["Super Admin Models"]
+        "tags": [
+          "Super Admin Models"
+        ]
       }
     },
     "/super-admin/models/catalog": {
@@ -849,7 +897,9 @@
           }
         },
         "summary": "Get all models in the catalog",
-        "tags": ["Super Admin Models"]
+        "tags": [
+          "Super Admin Models"
+        ]
       }
     },
     "/super-admin/models/catalog/language": {
@@ -892,7 +942,9 @@
           }
         },
         "summary": "Create a new language model in the catalog",
-        "tags": ["Super Admin Models"]
+        "tags": [
+          "Super Admin Models"
+        ]
       }
     },
     "/super-admin/models/catalog/language/{id}": {
@@ -947,7 +999,9 @@
           }
         },
         "summary": "Update a language model in the catalog",
-        "tags": ["Super Admin Models"]
+        "tags": [
+          "Super Admin Models"
+        ]
       }
     },
     "/super-admin/models/catalog/embedding": {
@@ -990,7 +1044,9 @@
           }
         },
         "summary": "Create a new embedding model in the catalog",
-        "tags": ["Super Admin Models"]
+        "tags": [
+          "Super Admin Models"
+        ]
       }
     },
     "/super-admin/models/catalog/embedding/{id}": {
@@ -1045,7 +1101,9 @@
           }
         },
         "summary": "Update an embedding model in the catalog",
-        "tags": ["Super Admin Models"]
+        "tags": [
+          "Super Admin Models"
+        ]
       }
     },
     "/super-admin/orgs": {
@@ -1083,7 +1141,9 @@
           }
         },
         "summary": "Create a new organization",
-        "tags": ["Super Admin Orgs"]
+        "tags": [
+          "Super Admin Orgs"
+        ]
       },
       "get": {
         "description": "Retrieve paginated organizations in the system. Only accessible to users with the super admin system role.",
@@ -1138,7 +1198,9 @@
           }
         },
         "summary": "List all organizations",
-        "tags": ["Super Admin Orgs"]
+        "tags": [
+          "Super Admin Orgs"
+        ]
       }
     },
     "/super-admin/orgs/{id}": {
@@ -1172,7 +1234,9 @@
           }
         },
         "summary": "Get an organization by ID",
-        "tags": ["Super Admin Orgs"]
+        "tags": [
+          "Super Admin Orgs"
+        ]
       }
     },
     "/users": {
@@ -1232,7 +1296,9 @@
           }
         },
         "summary": "Get users in current organization",
-        "tags": ["Users"]
+        "tags": [
+          "Users"
+        ]
       }
     },
     "/users/{id}/role": {
@@ -1288,7 +1354,9 @@
           }
         },
         "summary": "Update user role",
-        "tags": ["Users"]
+        "tags": [
+          "Users"
+        ]
       }
     },
     "/users/name": {
@@ -1332,7 +1400,9 @@
           }
         },
         "summary": "Update user name",
-        "tags": ["Users"]
+        "tags": [
+          "Users"
+        ]
       }
     },
     "/users/password": {
@@ -1366,7 +1436,9 @@
           }
         },
         "summary": "Update user password",
-        "tags": ["Users"]
+        "tags": [
+          "Users"
+        ]
       }
     },
     "/users/confirm-email": {
@@ -1400,7 +1472,9 @@
           }
         },
         "summary": "Confirm user email",
-        "tags": ["Users"]
+        "tags": [
+          "Users"
+        ]
       }
     },
     "/users/resend-confirmation": {
@@ -1431,7 +1505,9 @@
           }
         },
         "summary": "Resend email confirmation",
-        "tags": ["Users"]
+        "tags": [
+          "Users"
+        ]
       }
     },
     "/users/{id}": {
@@ -1466,7 +1542,9 @@
           }
         },
         "summary": "Delete a user",
-        "tags": ["Users"]
+        "tags": [
+          "Users"
+        ]
       }
     },
     "/users/{id}/trigger-password-reset": {
@@ -1497,7 +1575,9 @@
           }
         },
         "summary": "Trigger password reset for a user",
-        "tags": ["Users"]
+        "tags": [
+          "Users"
+        ]
       }
     },
     "/users/forgot-password": {
@@ -1528,7 +1608,9 @@
           }
         },
         "summary": "Trigger password reset",
-        "tags": ["Users"]
+        "tags": [
+          "Users"
+        ]
       }
     },
     "/users/reset-password": {
@@ -1562,7 +1644,9 @@
           }
         },
         "summary": "Reset password with token",
-        "tags": ["Users"]
+        "tags": [
+          "Users"
+        ]
       }
     },
     "/users/validate-reset-token": {
@@ -1606,7 +1690,9 @@
           }
         },
         "summary": "Validate password reset token",
-        "tags": ["Users"]
+        "tags": [
+          "Users"
+        ]
       }
     },
     "/super-admin/users/{orgId}": {
@@ -1680,7 +1766,9 @@
           }
         },
         "summary": "Get users by organization ID",
-        "tags": ["Super Admin Users"]
+        "tags": [
+          "Super Admin Users"
+        ]
       }
     },
     "/super-admin/users/{userId}": {
@@ -1715,7 +1803,9 @@
           }
         },
         "summary": "Delete a user",
-        "tags": ["Super Admin Users"]
+        "tags": [
+          "Super Admin Users"
+        ]
       }
     },
     "/super-admin/users/{userId}/trigger-password-reset": {
@@ -1750,7 +1840,9 @@
           }
         },
         "summary": "Trigger password reset for a user",
-        "tags": ["Super Admin Users"]
+        "tags": [
+          "Super Admin Users"
+        ]
       }
     },
     "/super-admin/users/{orgId}/create": {
@@ -1806,7 +1898,9 @@
           }
         },
         "summary": "Create a new user in an organization",
-        "tags": ["Super Admin Users"]
+        "tags": [
+          "Super Admin Users"
+        ]
       }
     },
     "/invites": {
@@ -1843,7 +1937,9 @@
           }
         },
         "summary": "Create a new invite",
-        "tags": ["invites"]
+        "tags": [
+          "invites"
+        ]
       },
       "get": {
         "description": "Retrieve paginated invites with optional search",
@@ -1898,7 +1994,9 @@
           }
         },
         "summary": "Get all invites for current user's organization",
-        "tags": ["invites"]
+        "tags": [
+          "invites"
+        ]
       }
     },
     "/invites/bulk": {
@@ -1935,7 +2033,9 @@
           }
         },
         "summary": "Create multiple invites in bulk",
-        "tags": ["invites"]
+        "tags": [
+          "invites"
+        ]
       }
     },
     "/invites/{token}": {
@@ -1973,7 +2073,9 @@
           }
         },
         "summary": "Get a single invite by token",
-        "tags": ["invites"]
+        "tags": [
+          "invites"
+        ]
       }
     },
     "/invites/accept": {
@@ -2013,7 +2115,9 @@
           }
         },
         "summary": "Accept an invite",
-        "tags": ["invites"]
+        "tags": [
+          "invites"
+        ]
       }
     },
     "/invites/{id}/resend": {
@@ -2054,7 +2158,9 @@
           }
         },
         "summary": "Resend an expired invite",
-        "tags": ["invites"]
+        "tags": [
+          "invites"
+        ]
       }
     },
     "/invites/all": {
@@ -2081,7 +2187,9 @@
           }
         },
         "summary": "Delete all pending invites",
-        "tags": ["invites"]
+        "tags": [
+          "invites"
+        ]
       }
     },
     "/invites/{id}": {
@@ -2115,99 +2223,9 @@
           }
         },
         "summary": "Delete an invite",
-        "tags": ["invites"]
-      }
-    },
-    "/subscriptions": {
-      "get": {
-        "operationId": "SubscriptionsController_getSubscription",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "description": "Successfully retrieved subscription details",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/SubscriptionResponseDtoNullable"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "User is not authorized to access this organization's subscription"
-          },
-          "404": {
-            "description": "No subscription found for the organization"
-          },
-          "500": {
-            "description": "Internal server error"
-          }
-        },
-        "summary": "Get subscription details for the current organization",
-        "tags": ["subscriptions"]
-      },
-      "post": {
-        "operationId": "SubscriptionsController_createSubscription",
-        "parameters": [],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/CreateSubscriptionRequestDto"
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "Successfully created subscription",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/SubscriptionResponseDto"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Invalid subscription data provided"
-          },
-          "403": {
-            "description": "User is not authorized to create a subscription for this organization"
-          },
-          "409": {
-            "description": "Subscription already exists for this organization"
-          },
-          "500": {
-            "description": "Internal server error"
-          }
-        },
-        "summary": "Create a new subscription for the current organization",
-        "tags": ["subscriptions"]
-      },
-      "delete": {
-        "operationId": "SubscriptionsController_cancelSubscription",
-        "parameters": [],
-        "responses": {
-          "204": {
-            "description": "Successfully cancelled subscription"
-          },
-          "403": {
-            "description": "User is not authorized to cancel this organization's subscription"
-          },
-          "404": {
-            "description": "No subscription found for the organization"
-          },
-          "409": {
-            "description": "Subscription is already cancelled"
-          },
-          "500": {
-            "description": "Internal server error"
-          }
-        },
-        "summary": "Cancel the subscription for the current organization",
-        "tags": ["subscriptions"]
+        "tags": [
+          "invites"
+        ]
       }
     },
     "/subscriptions/active": {
@@ -2230,7 +2248,9 @@
           }
         },
         "summary": "Check if the current organization has an active subscription",
-        "tags": ["subscriptions"]
+        "tags": [
+          "subscriptions"
+        ]
       }
     },
     "/subscriptions/price": {
@@ -2256,99 +2276,9 @@
           }
         },
         "summary": "Get the current price per seat monthly",
-        "tags": ["subscriptions"]
-      }
-    },
-    "/subscriptions/seats": {
-      "put": {
-        "operationId": "SubscriptionsController_updateSeats",
-        "parameters": [],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/UpdateSeatsDto"
-              }
-            }
-          }
-        },
-        "responses": {
-          "204": {
-            "description": "Successfully updated seats"
-          },
-          "400": {
-            "description": "Invalid seat update data provided"
-          },
-          "403": {
-            "description": "User is not authorized to update seats for this organization"
-          },
-          "500": {
-            "description": "Internal server error"
-          }
-        },
-        "summary": "Update the number of seats for the current organization",
-        "tags": ["subscriptions"]
-      }
-    },
-    "/subscriptions/billing-info": {
-      "put": {
-        "operationId": "SubscriptionsController_updateBillingInfo",
-        "parameters": [],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/UpdateBillingInfoDto"
-              }
-            }
-          }
-        },
-        "responses": {
-          "204": {
-            "description": "Successfully updated billing information"
-          },
-          "400": {
-            "description": "Invalid billing information provided"
-          },
-          "403": {
-            "description": "User is not authorized to update billing information for this organization"
-          },
-          "404": {
-            "description": "No subscription found for the organization"
-          },
-          "500": {
-            "description": "Internal server error"
-          }
-        },
-        "summary": "Update the billing information for the current organization",
-        "tags": ["subscriptions"]
-      }
-    },
-    "/subscriptions/uncancel": {
-      "post": {
-        "operationId": "SubscriptionsController_uncancelSubscription",
-        "parameters": [],
-        "responses": {
-          "204": {
-            "description": "Successfully uncancelled subscription"
-          },
-          "403": {
-            "description": "User is not authorized to uncancel this organization's subscription"
-          },
-          "404": {
-            "description": "No subscription found for the organization"
-          },
-          "409": {
-            "description": "Subscription is not cancelled"
-          },
-          "500": {
-            "description": "Internal server error"
-          }
-        },
-        "summary": "Uncancel the subscription for the current organization",
-        "tags": ["subscriptions"]
+        "tags": [
+          "subscriptions"
+        ]
       }
     },
     "/super-admin/subscriptions/{orgId}": {
@@ -2387,7 +2317,9 @@
           }
         },
         "summary": "Get subscription details for a specific organization",
-        "tags": ["Super Admin Subscriptions"]
+        "tags": [
+          "Super Admin Subscriptions"
+        ]
       },
       "post": {
         "description": "Create a new subscription for the specified organization. This endpoint is only accessible to super admins.",
@@ -2440,7 +2372,9 @@
           }
         },
         "summary": "Create a new subscription for a specific organization",
-        "tags": ["Super Admin Subscriptions"]
+        "tags": [
+          "Super Admin Subscriptions"
+        ]
       },
       "delete": {
         "description": "Cancel the subscription for the specified organization. This endpoint is only accessible to super admins.",
@@ -2476,7 +2410,9 @@
           }
         },
         "summary": "Cancel the subscription for a specific organization",
-        "tags": ["Super Admin Subscriptions"]
+        "tags": [
+          "Super Admin Subscriptions"
+        ]
       }
     },
     "/super-admin/subscriptions/{orgId}/seats": {
@@ -2524,7 +2460,9 @@
           }
         },
         "summary": "Update the number of seats for a specific organization",
-        "tags": ["Super Admin Subscriptions"]
+        "tags": [
+          "Super Admin Subscriptions"
+        ]
       }
     },
     "/super-admin/subscriptions/{orgId}/billing-info": {
@@ -2572,7 +2510,9 @@
           }
         },
         "summary": "Update the billing information for a specific organization",
-        "tags": ["Super Admin Subscriptions"]
+        "tags": [
+          "Super Admin Subscriptions"
+        ]
       }
     },
     "/super-admin/subscriptions/{orgId}/uncancel": {
@@ -2610,7 +2550,9 @@
           }
         },
         "summary": "Uncancel the subscription for a specific organization",
-        "tags": ["Super Admin Subscriptions"]
+        "tags": [
+          "Super Admin Subscriptions"
+        ]
       }
     },
     "/storage/upload": {
@@ -2624,7 +2566,9 @@
             "multipart/form-data": {
               "schema": {
                 "type": "object",
-                "required": ["file"],
+                "required": [
+                  "file"
+                ],
                 "properties": {
                   "file": {
                     "type": "string",
@@ -2652,7 +2596,9 @@
           }
         },
         "summary": "Upload a file to object storage",
-        "tags": ["storage"]
+        "tags": [
+          "storage"
+        ]
       }
     },
     "/storage/{objectName}": {
@@ -2674,7 +2620,9 @@
             "description": ""
           }
         },
-        "tags": ["storage"]
+        "tags": [
+          "storage"
+        ]
       },
       "delete": {
         "operationId": "StorageController_deleteFile",
@@ -2694,7 +2642,9 @@
             "description": ""
           }
         },
-        "tags": ["storage"]
+        "tags": [
+          "storage"
+        ]
       }
     },
     "/storage/url/{objectName}": {
@@ -2716,7 +2666,9 @@
             "description": ""
           }
         },
-        "tags": ["storage"]
+        "tags": [
+          "storage"
+        ]
       }
     },
     "/retrievers/url": {
@@ -2739,7 +2691,9 @@
           }
         },
         "summary": "Retrieve content from a URL",
-        "tags": ["retrievers"]
+        "tags": [
+          "retrievers"
+        ]
       }
     },
     "/threads": {
@@ -2775,7 +2729,9 @@
           }
         },
         "summary": "Create a new thread",
-        "tags": ["threads"]
+        "tags": [
+          "threads"
+        ]
       },
       "get": {
         "operationId": "ThreadsController_findAll",
@@ -2834,7 +2790,9 @@
           }
         },
         "summary": "Get all threads for the current user",
-        "tags": ["threads"]
+        "tags": [
+          "threads"
+        ]
       }
     },
     "/threads/{id}": {
@@ -2871,7 +2829,9 @@
           }
         },
         "summary": "Get a thread by ID",
-        "tags": ["threads"]
+        "tags": [
+          "threads"
+        ]
       },
       "delete": {
         "operationId": "ThreadsController_delete",
@@ -2899,7 +2859,9 @@
           }
         },
         "summary": "Delete a thread",
-        "tags": ["threads"]
+        "tags": [
+          "threads"
+        ]
       }
     },
     "/threads/{id}/title": {
@@ -2942,7 +2904,9 @@
           }
         },
         "summary": "Update a thread title",
-        "tags": ["threads"]
+        "tags": [
+          "threads"
+        ]
       }
     },
     "/threads/{id}/sources": {
@@ -2992,7 +2956,9 @@
           }
         },
         "summary": "Get all sources for a thread",
-        "tags": ["threads"]
+        "tags": [
+          "threads"
+        ]
       }
     },
     "/threads/{id}/sources/file": {
@@ -3031,7 +2997,9 @@
                     "description": "A description of the file source"
                   }
                 },
-                "required": ["file"]
+                "required": [
+                  "file"
+                ]
               }
             }
           }
@@ -3042,7 +3010,9 @@
           }
         },
         "summary": "Add a file source to a thread",
-        "tags": ["threads"]
+        "tags": [
+          "threads"
+        ]
       }
     },
     "/threads/{id}/sources/{sourceId}": {
@@ -3079,7 +3049,9 @@
           }
         },
         "summary": "Remove a source from a thread",
-        "tags": ["threads"]
+        "tags": [
+          "threads"
+        ]
       }
     },
     "/threads/{id}/sources/{sourceId}/download": {
@@ -3127,7 +3099,9 @@
           }
         },
         "summary": "Download a data source as CSV",
-        "tags": ["threads"]
+        "tags": [
+          "threads"
+        ]
       }
     },
     "/agents": {
@@ -3163,7 +3137,9 @@
           }
         },
         "summary": "Create a new agent",
-        "tags": ["agents"]
+        "tags": [
+          "agents"
+        ]
       },
       "get": {
         "operationId": "AgentsController_findAll",
@@ -3187,7 +3163,9 @@
           }
         },
         "summary": "Get all agents for the current user",
-        "tags": ["agents"]
+        "tags": [
+          "agents"
+        ]
       }
     },
     "/agents/{id}": {
@@ -3224,7 +3202,9 @@
           }
         },
         "summary": "Get an agent by ID",
-        "tags": ["agents"]
+        "tags": [
+          "agents"
+        ]
       },
       "put": {
         "operationId": "AgentsController_update",
@@ -3272,7 +3252,9 @@
           }
         },
         "summary": "Update an agent",
-        "tags": ["agents"]
+        "tags": [
+          "agents"
+        ]
       },
       "delete": {
         "operationId": "AgentsController_delete",
@@ -3300,7 +3282,9 @@
           }
         },
         "summary": "Delete an agent",
-        "tags": ["agents"]
+        "tags": [
+          "agents"
+        ]
       }
     },
     "/agents/{id}/sources": {
@@ -3340,7 +3324,9 @@
           }
         },
         "summary": "Get all sources for an agent",
-        "tags": ["agents"]
+        "tags": [
+          "agents"
+        ]
       }
     },
     "/agents/{id}/sources/file": {
@@ -3371,7 +3357,9 @@
                     "description": "The file to upload"
                   }
                 },
-                "required": ["file"]
+                "required": [
+                  "file"
+                ]
               }
             }
           }
@@ -3391,7 +3379,9 @@
           }
         },
         "summary": "Add a file source to an agent",
-        "tags": ["agents"]
+        "tags": [
+          "agents"
+        ]
       }
     },
     "/agents/{id}/sources/{sourceAssignmentId}": {
@@ -3428,7 +3418,9 @@
           }
         },
         "summary": "Remove a source from an agent",
-        "tags": ["agents"]
+        "tags": [
+          "agents"
+        ]
       }
     },
     "/agents/{agentId}/mcp-integrations/{integrationId}": {
@@ -3481,7 +3473,9 @@
           }
         },
         "summary": "Assign MCP integration to agent",
-        "tags": ["agents"]
+        "tags": [
+          "agents"
+        ]
       },
       "delete": {
         "operationId": "AgentsController_unassignMcpIntegration",
@@ -3523,7 +3517,9 @@
           }
         },
         "summary": "Unassign MCP integration from agent",
-        "tags": ["agents"]
+        "tags": [
+          "agents"
+        ]
       }
     },
     "/agents/{agentId}/mcp-integrations": {
@@ -3560,7 +3556,9 @@
           }
         },
         "summary": "List MCP integrations assigned to agent",
-        "tags": ["agents"]
+        "tags": [
+          "agents"
+        ]
       }
     },
     "/shares": {
@@ -3603,7 +3601,9 @@
           }
         },
         "summary": "Create a share for an agent",
-        "tags": ["shares"]
+        "tags": [
+          "shares"
+        ]
       },
       "get": {
         "operationId": "SharesController_getShares",
@@ -3624,7 +3624,11 @@
             "in": "query",
             "description": "Type of the entity",
             "schema": {
-              "enum": ["agent", "prompt", "skill"],
+              "enum": [
+                "agent",
+                "prompt",
+                "skill"
+              ],
               "type": "string"
             }
           }
@@ -3654,7 +3658,9 @@
           }
         },
         "summary": "Get shares for an entity",
-        "tags": ["shares"]
+        "tags": [
+          "shares"
+        ]
       }
     },
     "/shares/skills": {
@@ -3694,7 +3700,9 @@
           }
         },
         "summary": "Create a share for a skill",
-        "tags": ["shares"]
+        "tags": [
+          "shares"
+        ]
       }
     },
     "/shares/{id}": {
@@ -3727,7 +3735,9 @@
           }
         },
         "summary": "Delete a share",
-        "tags": ["shares"]
+        "tags": [
+          "shares"
+        ]
       }
     },
     "/teams": {
@@ -3759,7 +3769,9 @@
           }
         },
         "summary": "List all teams for the current organization",
-        "tags": ["teams"]
+        "tags": [
+          "teams"
+        ]
       },
       "post": {
         "operationId": "TeamsController_createTeam",
@@ -3802,7 +3814,9 @@
           }
         },
         "summary": "Create a new team for the current organization",
-        "tags": ["teams"]
+        "tags": [
+          "teams"
+        ]
       }
     },
     "/teams/me": {
@@ -3831,7 +3845,9 @@
           }
         },
         "summary": "List teams the current user is a member of",
-        "tags": ["teams"]
+        "tags": [
+          "teams"
+        ]
       }
     },
     "/teams/{id}": {
@@ -3872,7 +3888,9 @@
           }
         },
         "summary": "Get a team by ID",
-        "tags": ["teams"]
+        "tags": [
+          "teams"
+        ]
       },
       "patch": {
         "operationId": "TeamsController_updateTeam",
@@ -3927,7 +3945,9 @@
           }
         },
         "summary": "Update a team in the current organization",
-        "tags": ["teams"]
+        "tags": [
+          "teams"
+        ]
       },
       "delete": {
         "operationId": "TeamsController_deleteTeam",
@@ -3959,7 +3979,9 @@
           }
         },
         "summary": "Delete a team from the current organization",
-        "tags": ["teams"]
+        "tags": [
+          "teams"
+        ]
       }
     },
     "/teams/{id}/members": {
@@ -4022,7 +4044,9 @@
           }
         },
         "summary": "List members of a team",
-        "tags": ["teams"]
+        "tags": [
+          "teams"
+        ]
       },
       "post": {
         "operationId": "TeamsController_addTeamMember",
@@ -4077,7 +4101,9 @@
           }
         },
         "summary": "Add a user to a team",
-        "tags": ["teams"]
+        "tags": [
+          "teams"
+        ]
       }
     },
     "/teams/{id}/members/{userId}": {
@@ -4119,7 +4145,9 @@
           }
         },
         "summary": "Remove a user from a team",
-        "tags": ["teams"]
+        "tags": [
+          "teams"
+        ]
       }
     },
     "/mcp-integrations/predefined": {
@@ -4155,7 +4183,9 @@
           }
         },
         "summary": "Create a new predefined MCP integration",
-        "tags": ["mcp-integrations"]
+        "tags": [
+          "mcp-integrations"
+        ]
       }
     },
     "/mcp-integrations/custom": {
@@ -4188,7 +4218,9 @@
           }
         },
         "summary": "Create a new custom MCP integration",
-        "tags": ["mcp-integrations"]
+        "tags": [
+          "mcp-integrations"
+        ]
       }
     },
     "/mcp-integrations": {
@@ -4211,7 +4243,9 @@
           }
         },
         "summary": "List all MCP integrations for organization",
-        "tags": ["mcp-integrations"]
+        "tags": [
+          "mcp-integrations"
+        ]
       }
     },
     "/mcp-integrations/predefined/available": {
@@ -4234,7 +4268,9 @@
           }
         },
         "summary": "List available predefined MCP integration configurations",
-        "tags": ["mcp-integrations"]
+        "tags": [
+          "mcp-integrations"
+        ]
       }
     },
     "/mcp-integrations/available": {
@@ -4257,7 +4293,9 @@
           }
         },
         "summary": "List all available (enabled) MCP integrations for organization",
-        "tags": ["mcp-integrations"]
+        "tags": [
+          "mcp-integrations"
+        ]
       }
     },
     "/mcp-integrations/{id}": {
@@ -4290,7 +4328,9 @@
           }
         },
         "summary": "Get MCP integration by ID",
-        "tags": ["mcp-integrations"]
+        "tags": [
+          "mcp-integrations"
+        ]
       },
       "patch": {
         "operationId": "McpIntegrationsController_update",
@@ -4334,7 +4374,9 @@
           }
         },
         "summary": "Update MCP integration",
-        "tags": ["mcp-integrations"]
+        "tags": [
+          "mcp-integrations"
+        ]
       },
       "delete": {
         "operationId": "McpIntegrationsController_delete",
@@ -4358,7 +4400,9 @@
           }
         },
         "summary": "Delete MCP integration",
-        "tags": ["mcp-integrations"]
+        "tags": [
+          "mcp-integrations"
+        ]
       }
     },
     "/mcp-integrations/{id}/enable": {
@@ -4391,7 +4435,9 @@
           }
         },
         "summary": "Enable MCP integration",
-        "tags": ["mcp-integrations"]
+        "tags": [
+          "mcp-integrations"
+        ]
       }
     },
     "/mcp-integrations/{id}/disable": {
@@ -4424,7 +4470,9 @@
           }
         },
         "summary": "Disable MCP integration",
-        "tags": ["mcp-integrations"]
+        "tags": [
+          "mcp-integrations"
+        ]
       }
     },
     "/mcp-integrations/install-from-marketplace": {
@@ -4460,7 +4508,9 @@
           }
         },
         "summary": "Install an MCP integration from the marketplace",
-        "tags": ["mcp-integrations"]
+        "tags": [
+          "mcp-integrations"
+        ]
       }
     },
     "/mcp-integrations/{id}/user-config": {
@@ -4490,7 +4540,9 @@
           }
         },
         "summary": "Get current user config for a marketplace MCP integration",
-        "tags": ["mcp-integrations"]
+        "tags": [
+          "mcp-integrations"
+        ]
       },
       "patch": {
         "operationId": "McpIntegrationsController_setUserConfig",
@@ -4534,7 +4586,9 @@
           }
         },
         "summary": "Set current user config for a marketplace MCP integration",
-        "tags": ["mcp-integrations"]
+        "tags": [
+          "mcp-integrations"
+        ]
       }
     },
     "/mcp-integrations/{id}/validate": {
@@ -4567,7 +4621,9 @@
           }
         },
         "summary": "Validate MCP integration connection",
-        "tags": ["mcp-integrations"]
+        "tags": [
+          "mcp-integrations"
+        ]
       }
     },
     "/marketplace/skills/{identifier}": {
@@ -4600,7 +4656,9 @@
           }
         },
         "summary": "Preview a marketplace skill before installation",
-        "tags": ["marketplace"]
+        "tags": [
+          "marketplace"
+        ]
       }
     },
     "/marketplace/integrations/{identifier}": {
@@ -4633,7 +4691,9 @@
           }
         },
         "summary": "Preview a marketplace integration before installation",
-        "tags": ["marketplace"]
+        "tags": [
+          "marketplace"
+        ]
       }
     },
     "/skills/install-from-marketplace": {
@@ -4666,7 +4726,9 @@
           }
         },
         "summary": "Install a skill from the marketplace",
-        "tags": ["skills"]
+        "tags": [
+          "skills"
+        ]
       }
     },
     "/skills": {
@@ -4702,7 +4764,9 @@
           }
         },
         "summary": "Create a new skill",
-        "tags": ["skills"]
+        "tags": [
+          "skills"
+        ]
       },
       "get": {
         "operationId": "SkillsController_findAll",
@@ -4723,7 +4787,9 @@
           }
         },
         "summary": "Get all skills for the current user",
-        "tags": ["skills"]
+        "tags": [
+          "skills"
+        ]
       }
     },
     "/skills/{id}": {
@@ -4757,7 +4823,9 @@
           }
         },
         "summary": "Get a skill by ID",
-        "tags": ["skills"]
+        "tags": [
+          "skills"
+        ]
       },
       "put": {
         "operationId": "SkillsController_update",
@@ -4805,7 +4873,9 @@
           }
         },
         "summary": "Update a skill",
-        "tags": ["skills"]
+        "tags": [
+          "skills"
+        ]
       },
       "delete": {
         "operationId": "SkillsController_delete",
@@ -4830,7 +4900,9 @@
           }
         },
         "summary": "Delete a skill",
-        "tags": ["skills"]
+        "tags": [
+          "skills"
+        ]
       }
     },
     "/skills/{id}/toggle-active": {
@@ -4864,7 +4936,9 @@
           }
         },
         "summary": "Toggle skill active/inactive status",
-        "tags": ["skills"]
+        "tags": [
+          "skills"
+        ]
       }
     },
     "/skills/{id}/toggle-pinned": {
@@ -4940,7 +5014,9 @@
           }
         },
         "summary": "Get all sources for a skill",
-        "tags": ["skills"]
+        "tags": [
+          "skills"
+        ]
       }
     },
     "/skills/{id}/sources/file": {
@@ -4971,7 +5047,9 @@
                     "description": "The file to upload"
                   }
                 },
-                "required": ["file"]
+                "required": [
+                  "file"
+                ]
               }
             }
           }
@@ -4995,7 +5073,9 @@
           }
         },
         "summary": "Add a file source to a skill",
-        "tags": ["skills"]
+        "tags": [
+          "skills"
+        ]
       }
     },
     "/skills/{id}/sources/{sourceId}": {
@@ -5032,7 +5112,9 @@
           }
         },
         "summary": "Remove a source from a skill",
-        "tags": ["skills"]
+        "tags": [
+          "skills"
+        ]
       }
     },
     "/skills/{skillId}/mcp-integrations/{integrationId}": {
@@ -5079,7 +5161,9 @@
           }
         },
         "summary": "Assign MCP integration to skill",
-        "tags": ["skills"]
+        "tags": [
+          "skills"
+        ]
       },
       "delete": {
         "operationId": "SkillMcpIntegrationsController_unassignMcpIntegration",
@@ -5121,7 +5205,9 @@
           }
         },
         "summary": "Unassign MCP integration from skill",
-        "tags": ["skills"]
+        "tags": [
+          "skills"
+        ]
       }
     },
     "/skills/{skillId}/mcp-integrations": {
@@ -5158,7 +5244,9 @@
           }
         },
         "summary": "List MCP integrations assigned to skill",
-        "tags": ["skills"]
+        "tags": [
+          "skills"
+        ]
       }
     },
     "/runs/send-message": {
@@ -5172,7 +5260,9 @@
             "multipart/form-data": {
               "schema": {
                 "type": "object",
-                "required": ["threadId"],
+                "required": [
+                  "threadId"
+                ],
                 "properties": {
                   "threadId": {
                     "type": "string",
@@ -5241,58 +5331,6 @@
                       "thread": "#/components/schemas/RunThreadResponseDto"
                     }
                   }
-                },
-                "examples": {
-                  "session-event": {
-                    "summary": "Session establishment event",
-                    "value": {
-                      "type": "session",
-                      "success": true,
-                      "threadId": "123e4567-e89b-12d3-a456-426614174000",
-                      "timestamp": "2024-01-01T12:00:00.000Z",
-                      "streaming": true
-                    }
-                  },
-                  "message-event": {
-                    "summary": "Message event",
-                    "value": {
-                      "type": "message",
-                      "message": {
-                        "id": "123e4567-e89b-12d3-a456-426614174000",
-                        "threadId": "123e4567-e89b-12d3-a456-426614174000",
-                        "role": "assistant",
-                        "content": [
-                          {
-                            "type": "text",
-                            "text": "Hello!"
-                          }
-                        ],
-                        "createdAt": "2024-01-01T12:00:00.000Z"
-                      },
-                      "threadId": "123e4567-e89b-12d3-a456-426614174000",
-                      "timestamp": "2024-01-01T12:00:00.000Z"
-                    }
-                  },
-                  "error-event": {
-                    "summary": "Error event",
-                    "value": {
-                      "type": "error",
-                      "message": "An error occurred while processing your request",
-                      "threadId": "123e4567-e89b-12d3-a456-426614174000",
-                      "timestamp": "2024-01-01T12:00:00.000Z",
-                      "code": "EXECUTION_ERROR"
-                    }
-                  },
-                  "thread-event": {
-                    "summary": "Thread update event",
-                    "value": {
-                      "type": "thread",
-                      "threadId": "123e4567-e89b-12d3-a456-426614174000",
-                      "updateType": "title_updated",
-                      "title": "Discussion about AI and machine learning",
-                      "timestamp": "2024-01-01T12:00:00.000Z"
-                    }
-                  }
                 }
               }
             },
@@ -5331,7 +5369,9 @@
           }
         },
         "summary": "Send a message with optional images and receive streaming response",
-        "tags": ["runs"]
+        "tags": [
+          "runs"
+        ]
       }
     },
     "/super-admin/trials": {
@@ -5369,7 +5409,9 @@
           }
         },
         "summary": "Create a new trial",
-        "tags": ["Super Admin Trials"]
+        "tags": [
+          "Super Admin Trials"
+        ]
       }
     },
     "/super-admin/trials/{orgId}": {
@@ -5406,7 +5448,9 @@
           }
         },
         "summary": "Get a trial by organization ID",
-        "tags": ["Super Admin Trials"]
+        "tags": [
+          "Super Admin Trials"
+        ]
       },
       "put": {
         "description": "Update a trial for an organization. Can update maxMessages and/or messagesSent. Only accessible to users with the super admin system role.",
@@ -5452,7 +5496,9 @@
           }
         },
         "summary": "Update a trial",
-        "tags": ["Super Admin Trials"]
+        "tags": [
+          "Super Admin Trials"
+        ]
       }
     },
     "/usage/config": {
@@ -5473,7 +5519,9 @@
           }
         },
         "summary": "Get usage dashboard configuration",
-        "tags": ["Admin Usage"]
+        "tags": [
+          "Admin Usage"
+        ]
       }
     },
     "/usage/stats": {
@@ -5515,7 +5563,9 @@
           }
         },
         "summary": "Get overall usage statistics",
-        "tags": ["Admin Usage"]
+        "tags": [
+          "Admin Usage"
+        ]
       }
     },
     "/usage/providers": {
@@ -5587,7 +5637,9 @@
           }
         },
         "summary": "Get usage statistics by provider",
-        "tags": ["Admin Usage"]
+        "tags": [
+          "Admin Usage"
+        ]
       }
     },
     "/usage/providers/chart": {
@@ -5645,7 +5697,9 @@
           }
         },
         "summary": "Get provider usage time series aligned by date (chart-ready)",
-        "tags": ["Admin Usage"]
+        "tags": [
+          "Admin Usage"
+        ]
       }
     },
     "/usage/models": {
@@ -5707,7 +5761,9 @@
           }
         },
         "summary": "Get usage distribution by model",
-        "tags": ["Admin Usage"]
+        "tags": [
+          "Admin Usage"
+        ]
       }
     },
     "/usage/users": {
@@ -5771,7 +5827,12 @@
             "in": "query",
             "description": "Field to sort users by. Defaults to tokens.",
             "schema": {
-              "enum": ["tokens", "requests", "lastActivity", "userName"],
+              "enum": [
+                "tokens",
+                "requests",
+                "lastActivity",
+                "userName"
+              ],
               "type": "string"
             }
           },
@@ -5781,7 +5842,10 @@
             "in": "query",
             "description": "Sort order (ascending or descending). Defaults to desc.",
             "schema": {
-              "enum": ["asc", "desc"],
+              "enum": [
+                "asc",
+                "desc"
+              ],
               "type": "string"
             }
           }
@@ -5799,7 +5863,9 @@
           }
         },
         "summary": "Get usage statistics by user",
-        "tags": ["Admin Usage"]
+        "tags": [
+          "Admin Usage"
+        ]
       }
     },
     "/super-admin/usage/{orgId}/config": {
@@ -5829,7 +5895,9 @@
           }
         },
         "summary": "Get usage dashboard configuration for an organization",
-        "tags": ["Super Admin Usage"]
+        "tags": [
+          "Super Admin Usage"
+        ]
       }
     },
     "/super-admin/usage/{orgId}/stats": {
@@ -5876,7 +5944,9 @@
           }
         },
         "summary": "Get overall usage statistics for an organization",
-        "tags": ["Super Admin Usage"]
+        "tags": [
+          "Super Admin Usage"
+        ]
       }
     },
     "/super-admin/usage/{orgId}/models": {
@@ -5939,7 +6009,9 @@
           }
         },
         "summary": "Get usage distribution by model for an organization",
-        "tags": ["Super Admin Usage"]
+        "tags": [
+          "Super Admin Usage"
+        ]
       }
     },
     "/super-admin/usage/{orgId}/providers": {
@@ -6010,7 +6082,9 @@
           }
         },
         "summary": "Get usage statistics by provider for an organization",
-        "tags": ["Super Admin Usage"]
+        "tags": [
+          "Super Admin Usage"
+        ]
       }
     },
     "/super-admin/usage/{orgId}/providers/chart": {
@@ -6073,7 +6147,9 @@
           }
         },
         "summary": "Get provider usage time series for an organization (chart-ready)",
-        "tags": ["Super Admin Usage"]
+        "tags": [
+          "Super Admin Usage"
+        ]
       }
     },
     "/super-admin/usage/{orgId}/users": {
@@ -6135,7 +6211,12 @@
             "required": false,
             "in": "query",
             "schema": {
-              "enum": ["tokens", "requests", "lastActivity", "userName"],
+              "enum": [
+                "tokens",
+                "requests",
+                "lastActivity",
+                "userName"
+              ],
               "type": "string"
             }
           },
@@ -6144,7 +6225,10 @@
             "required": false,
             "in": "query",
             "schema": {
-              "enum": ["asc", "desc"],
+              "enum": [
+                "asc",
+                "desc"
+              ],
               "type": "string"
             }
           }
@@ -6162,7 +6246,9 @@
           }
         },
         "summary": "Get usage statistics by user for an organization",
-        "tags": ["Super Admin Usage"]
+        "tags": [
+          "Super Admin Usage"
+        ]
       }
     },
     "/super-admin/global-usage/providers/chart": {
@@ -6215,7 +6301,9 @@
           }
         },
         "summary": "Get global provider usage time series across all organizations (chart-ready)",
-        "tags": ["Super Admin Global Usage"]
+        "tags": [
+          "Super Admin Global Usage"
+        ]
       }
     },
     "/super-admin/global-usage/models": {
@@ -6260,7 +6348,9 @@
           }
         },
         "summary": "Get global model distribution across all organizations",
-        "tags": ["Super Admin Global Usage"]
+        "tags": [
+          "Super Admin Global Usage"
+        ]
       }
     },
     "/chat-settings/system-prompt": {
@@ -6281,7 +6371,9 @@
           }
         },
         "summary": "Get the user system prompt",
-        "tags": ["Chat Settings"]
+        "tags": [
+          "Chat Settings"
+        ]
       },
       "put": {
         "description": "Creates or replaces the custom system prompt for the authenticated user.",
@@ -6313,7 +6405,9 @@
           }
         },
         "summary": "Set or update the user system prompt",
-        "tags": ["Chat Settings"]
+        "tags": [
+          "Chat Settings"
+        ]
       },
       "delete": {
         "description": "Deletes the custom system prompt for the authenticated user.",
@@ -6325,7 +6419,9 @@
           }
         },
         "summary": "Delete the user system prompt",
-        "tags": ["Chat Settings"]
+        "tags": [
+          "Chat Settings"
+        ]
       }
     },
     "/prompts": {
@@ -6361,7 +6457,9 @@
           }
         },
         "summary": "Create a new prompt",
-        "tags": ["prompts"]
+        "tags": [
+          "prompts"
+        ]
       },
       "get": {
         "operationId": "PromptsController_findAll",
@@ -6385,7 +6483,9 @@
           }
         },
         "summary": "Get all prompts for the current user",
-        "tags": ["prompts"]
+        "tags": [
+          "prompts"
+        ]
       }
     },
     "/prompts/{id}": {
@@ -6422,7 +6522,9 @@
           }
         },
         "summary": "Get a prompt by ID",
-        "tags": ["prompts"]
+        "tags": [
+          "prompts"
+        ]
       },
       "put": {
         "operationId": "PromptsController_update",
@@ -6470,7 +6572,9 @@
           }
         },
         "summary": "Update a prompt",
-        "tags": ["prompts"]
+        "tags": [
+          "prompts"
+        ]
       },
       "delete": {
         "operationId": "PromptsController_delete",
@@ -6498,7 +6602,9 @@
           }
         },
         "summary": "Delete a prompt",
-        "tags": ["prompts"]
+        "tags": [
+          "prompts"
+        ]
       }
     },
     "/transcriptions": {
@@ -6512,7 +6618,9 @@
             "multipart/form-data": {
               "schema": {
                 "type": "object",
-                "required": ["file"],
+                "required": [
+                  "file"
+                ],
                 "properties": {
                   "file": {
                     "type": "string",
@@ -6556,7 +6664,9 @@
           }
         ],
         "summary": "Transcribe audio file to text",
-        "tags": ["transcriptions"]
+        "tags": [
+          "transcriptions"
+        ]
       }
     },
     "/auth/login": {
@@ -6608,7 +6718,9 @@
           }
         },
         "summary": "User login",
-        "tags": ["Authentication"]
+        "tags": [
+          "Authentication"
+        ]
       }
     },
     "/auth/register": {
@@ -6660,7 +6772,9 @@
           }
         },
         "summary": "User registration",
-        "tags": ["Authentication"]
+        "tags": [
+          "Authentication"
+        ]
       }
     },
     "/auth/refresh": {
@@ -6706,7 +6820,9 @@
           }
         ],
         "summary": "Refresh authentication tokens",
-        "tags": ["Authentication"]
+        "tags": [
+          "Authentication"
+        ]
       }
     },
     "/auth/me": {
@@ -6747,7 +6863,9 @@
           }
         },
         "summary": "Get current user information",
-        "tags": ["Authentication"]
+        "tags": [
+          "Authentication"
+        ]
       }
     },
     "/auth/logout": {
@@ -6768,7 +6886,9 @@
           }
         },
         "summary": "User logout",
-        "tags": ["Authentication"]
+        "tags": [
+          "Authentication"
+        ]
       }
     }
   },
@@ -6801,7 +6921,10 @@
             "example": false
           }
         },
-        "required": ["isCloud", "isRegistrationDisabled"]
+        "required": [
+          "isCloud",
+          "isRegistrationDisabled"
+        ]
       },
       "ModelWithConfigResponseDto": {
         "type": "object",
@@ -6918,12 +7041,22 @@
           },
           "hostedIn": {
             "type": "string",
-            "enum": ["DE", "EU", "US", "SELF_HOSTED", "AYUNIS"],
+            "enum": [
+              "DE",
+              "EU",
+              "US",
+              "SELF_HOSTED",
+              "AYUNIS"
+            ],
             "description": "The location where the provider hosts their services",
             "example": "US"
           }
         },
-        "required": ["provider", "displayName", "hostedIn"]
+        "required": [
+          "provider",
+          "displayName",
+          "hostedIn"
+        ]
       },
       "CreatePermittedModelDto": {
         "type": "object",
@@ -6940,7 +7073,9 @@
             "default": false
           }
         },
-        "required": ["modelId"]
+        "required": [
+          "modelId"
+        ]
       },
       "UpdatePermittedModelDto": {
         "type": "object",
@@ -6951,7 +7086,9 @@
             "example": true
           }
         },
-        "required": ["anonymousOnly"]
+        "required": [
+          "anonymousOnly"
+        ]
       },
       "PermittedLanguageModelResponseDto": {
         "type": "object",
@@ -6991,7 +7128,9 @@
           },
           "type": {
             "type": "string",
-            "enum": ["language"],
+            "enum": [
+              "language"
+            ],
             "description": "The type of the model (always language)"
           },
           "isArchived": {
@@ -7042,7 +7181,9 @@
             ]
           }
         },
-        "required": ["permittedLanguageModel"]
+        "required": [
+          "permittedLanguageModel"
+        ]
       },
       "SetUserDefaultModelDto": {
         "type": "object",
@@ -7053,7 +7194,9 @@
             "example": "123e4567-e89b-12d3-a456-426614174000"
           }
         },
-        "required": ["permittedModelId"]
+        "required": [
+          "permittedModelId"
+        ]
       },
       "SetOrgDefaultModelDto": {
         "type": "object",
@@ -7064,7 +7207,9 @@
             "example": "123e4567-e89b-12d3-a456-426614174000"
           }
         },
-        "required": ["permittedModelId"]
+        "required": [
+          "permittedModelId"
+        ]
       },
       "EmbeddingModelEnabledResponseDto": {
         "type": "object",
@@ -7075,7 +7220,9 @@
             "example": true
           }
         },
-        "required": ["isEmbeddingModelEnabled"]
+        "required": [
+          "isEmbeddingModelEnabled"
+        ]
       },
       "PermittedEmbeddingModelResponseDto": {
         "type": "object",
@@ -7115,7 +7262,9 @@
           },
           "type": {
             "type": "string",
-            "enum": ["embedding"],
+            "enum": [
+              "embedding"
+            ],
             "description": "The type of the model (always embedding)"
           },
           "isArchived": {
@@ -7309,7 +7458,11 @@
           "dimensions": {
             "type": "number",
             "description": "The dimensions of the embedding",
-            "enum": [1024, 1536, 2560],
+            "enum": [
+              1024,
+              1536,
+              2560
+            ],
             "example": 1536
           },
           "isArchived": {
@@ -7360,7 +7513,11 @@
           "dimensions": {
             "type": "number",
             "description": "The dimensions of the embedding",
-            "enum": [1024, 1536, 2560],
+            "enum": [
+              1024,
+              1536,
+              2560
+            ],
             "example": 1536
           },
           "isArchived": {
@@ -7416,7 +7573,9 @@
           },
           "type": {
             "type": "string",
-            "enum": ["language"],
+            "enum": [
+              "language"
+            ],
             "description": "The type of the model (always language)"
           },
           "isArchived": {
@@ -7509,7 +7668,9 @@
           },
           "type": {
             "type": "string",
-            "enum": ["embedding"],
+            "enum": [
+              "embedding"
+            ],
             "description": "The type of the model (always embedding)"
           },
           "isArchived": {
@@ -7562,7 +7723,9 @@
             "example": "Acme Corporation"
           }
         },
-        "required": ["name"]
+        "required": [
+          "name"
+        ]
       },
       "SuperAdminOrgResponseDto": {
         "type": "object",
@@ -7585,7 +7748,11 @@
             "example": "2024-01-15T10:30:00Z"
           }
         },
-        "required": ["id", "name", "createdAt"]
+        "required": [
+          "id",
+          "name",
+          "createdAt"
+        ]
       },
       "PaginationDto": {
         "type": "object",
@@ -7606,7 +7773,10 @@
             "example": 150
           }
         },
-        "required": ["limit", "offset"]
+        "required": [
+          "limit",
+          "offset"
+        ]
       },
       "SuperAdminOrgListResponseDto": {
         "type": "object",
@@ -7627,7 +7797,10 @@
             ]
           }
         },
-        "required": ["data", "pagination"]
+        "required": [
+          "data",
+          "pagination"
+        ]
       },
       "UserResponseDto": {
         "type": "object",
@@ -7651,7 +7824,10 @@
           "role": {
             "type": "string",
             "description": "User role",
-            "enum": ["admin", "user"],
+            "enum": [
+              "admin",
+              "user"
+            ],
             "example": "user"
           },
           "orgId": {
@@ -7667,7 +7843,14 @@
             "example": "2024-01-15T10:30:00Z"
           }
         },
-        "required": ["id", "name", "email", "role", "orgId", "createdAt"]
+        "required": [
+          "id",
+          "name",
+          "email",
+          "role",
+          "orgId",
+          "createdAt"
+        ]
       },
       "PaginatedUsersListResponseDto": {
         "type": "object",
@@ -7688,7 +7871,10 @@
             ]
           }
         },
-        "required": ["data", "pagination"]
+        "required": [
+          "data",
+          "pagination"
+        ]
       },
       "UpdateUserRoleDto": {
         "type": "object",
@@ -7696,11 +7882,16 @@
           "role": {
             "type": "string",
             "description": "New role for the user",
-            "enum": ["admin", "user"],
+            "enum": [
+              "admin",
+              "user"
+            ],
             "example": "admin"
           }
         },
-        "required": ["role"]
+        "required": [
+          "role"
+        ]
       },
       "UpdateUserNameDto": {
         "type": "object",
@@ -7713,7 +7904,9 @@
             "maxLength": 100
           }
         },
-        "required": ["name"]
+        "required": [
+          "name"
+        ]
       },
       "UpdatePasswordDto": {
         "type": "object",
@@ -7752,7 +7945,9 @@
             "example": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
           }
         },
-        "required": ["token"]
+        "required": [
+          "token"
+        ]
       },
       "ResendEmailConfirmationDto": {
         "type": "object",
@@ -7764,7 +7959,9 @@
             "format": "email"
           }
         },
-        "required": ["email"]
+        "required": [
+          "email"
+        ]
       },
       "ForgotPasswordDto": {
         "type": "object",
@@ -7775,7 +7972,9 @@
             "example": "user@example.com"
           }
         },
-        "required": ["email"]
+        "required": [
+          "email"
+        ]
       },
       "ResetPasswordDto": {
         "type": "object",
@@ -7798,7 +7997,11 @@
             "minLength": 8
           }
         },
-        "required": ["resetToken", "newPassword", "newPasswordConfirmation"]
+        "required": [
+          "resetToken",
+          "newPassword",
+          "newPasswordConfirmation"
+        ]
       },
       "CreateUserDto": {
         "type": "object",
@@ -7816,7 +8019,10 @@
           "role": {
             "type": "string",
             "description": "Role for the user",
-            "enum": ["admin", "user"],
+            "enum": [
+              "admin",
+              "user"
+            ],
             "example": "user"
           },
           "sendPasswordResetEmail": {
@@ -7825,7 +8031,12 @@
             "example": true
           }
         },
-        "required": ["email", "name", "role", "sendPasswordResetEmail"]
+        "required": [
+          "email",
+          "name",
+          "role",
+          "sendPasswordResetEmail"
+        ]
       },
       "CreateInviteDto": {
         "type": "object",
@@ -7838,11 +8049,17 @@
           "role": {
             "type": "string",
             "description": "Role to assign to the invited user",
-            "enum": ["admin", "user"],
+            "enum": [
+              "admin",
+              "user"
+            ],
             "example": "user"
           }
         },
-        "required": ["email", "role"]
+        "required": [
+          "email",
+          "role"
+        ]
       },
       "CreateInviteResponseDto": {
         "type": "object",
@@ -7854,7 +8071,9 @@
             "nullable": true
           }
         },
-        "required": ["url"]
+        "required": [
+          "url"
+        ]
       },
       "CreateBulkInviteItemDto": {
         "type": "object",
@@ -7867,11 +8086,17 @@
           "role": {
             "type": "string",
             "description": "Role to assign to the invited user",
-            "enum": ["admin", "user"],
+            "enum": [
+              "admin",
+              "user"
+            ],
             "example": "user"
           }
         },
-        "required": ["email", "role"]
+        "required": [
+          "email",
+          "role"
+        ]
       },
       "CreateBulkInvitesDto": {
         "type": "object",
@@ -7886,7 +8111,9 @@
             }
           }
         },
-        "required": ["invites"]
+        "required": [
+          "invites"
+        ]
       },
       "BulkInviteResultDto": {
         "type": "object",
@@ -7899,7 +8126,10 @@
           "role": {
             "type": "string",
             "description": "Role assigned to the invited user",
-            "enum": ["admin", "user"],
+            "enum": [
+              "admin",
+              "user"
+            ],
             "example": "user"
           },
           "success": {
@@ -7961,7 +8191,12 @@
             }
           }
         },
-        "required": ["totalCount", "successCount", "failureCount", "results"]
+        "required": [
+          "totalCount",
+          "successCount",
+          "failureCount",
+          "results"
+        ]
       },
       "InviteResponseDto": {
         "type": "object",
@@ -7980,13 +8215,20 @@
           "role": {
             "type": "string",
             "description": "Role assigned to the invited user",
-            "enum": ["admin", "user"],
+            "enum": [
+              "admin",
+              "user"
+            ],
             "example": "user"
           },
           "status": {
             "type": "string",
             "description": "Current status of the invite",
-            "enum": ["pending", "accepted", "expired"],
+            "enum": [
+              "pending",
+              "accepted",
+              "expired"
+            ],
             "example": "pending"
           },
           "sentDate": {
@@ -8008,7 +8250,14 @@
             "example": "2023-12-02T15:30:00Z"
           }
         },
-        "required": ["id", "email", "role", "status", "sentDate", "expiresAt"]
+        "required": [
+          "id",
+          "email",
+          "role",
+          "status",
+          "sentDate",
+          "expiresAt"
+        ]
       },
       "PaginatedInvitesListResponseDto": {
         "type": "object",
@@ -8029,7 +8278,10 @@
             ]
           }
         },
-        "required": ["data", "pagination"]
+        "required": [
+          "data",
+          "pagination"
+        ]
       },
       "InviteDetailResponseDto": {
         "type": "object",
@@ -8048,13 +8300,20 @@
           "role": {
             "type": "string",
             "description": "Role assigned to the invited user",
-            "enum": ["admin", "user"],
+            "enum": [
+              "admin",
+              "user"
+            ],
             "example": "user"
           },
           "status": {
             "type": "string",
             "description": "Current status of the invite",
-            "enum": ["pending", "accepted", "expired"],
+            "enum": [
+              "pending",
+              "accepted",
+              "expired"
+            ],
             "example": "pending"
           },
           "sentDate": {
@@ -8143,7 +8402,11 @@
             "format": "uuid"
           }
         },
-        "required": ["inviteId", "email", "orgId"]
+        "required": [
+          "inviteId",
+          "email",
+          "orgId"
+        ]
       },
       "DeleteAllPendingInvitesResponseDto": {
         "type": "object",
@@ -8153,7 +8416,9 @@
             "description": "Number of invites deleted"
           }
         },
-        "required": ["deletedCount"]
+        "required": [
+          "deletedCount"
+        ]
       },
       "ActiveSubscriptionResponseDto": {
         "type": "object",
@@ -8274,7 +8539,10 @@
           "renewalCycle": {
             "type": "string",
             "description": "Renewal cycle of the subscription",
-            "enum": ["monthly", "yearly"],
+            "enum": [
+              "monthly",
+              "yearly"
+            ],
             "example": "monthly"
           },
           "renewalCycleAnchor": {
@@ -8390,17 +8658,6 @@
           "country"
         ]
       },
-      "ActiveSubscriptionResponseDto": {
-        "type": "object",
-        "properties": {
-          "hasActiveSubscription": {
-            "type": "boolean",
-            "description": "Whether the organization has an active subscription",
-            "example": true
-          }
-        },
-        "required": ["hasActiveSubscription"]
-      },
       "UpdateBillingInfoDto": {
         "type": "object",
         "properties": {
@@ -8449,17 +8706,6 @@
           "country"
         ]
       },
-      "PriceResponseDto": {
-        "type": "object",
-        "properties": {
-          "pricePerSeatMonthly": {
-            "type": "number",
-            "description": "Current price per seat per month in the configured currency",
-            "example": 29.99
-          }
-        },
-        "required": ["pricePerSeatMonthly"]
-      },
       "UpdateSeatsDto": {
         "type": "object",
         "properties": {}
@@ -8494,7 +8740,11 @@
             "example": "2024-01-01T00:00:00.000Z"
           }
         },
-        "required": ["objectName", "size", "etag"]
+        "required": [
+          "objectName",
+          "size",
+          "etag"
+        ]
       },
       "RetrieveUrlDto": {
         "type": "object",
@@ -8505,7 +8755,9 @@
             "example": "https://example.com/article"
           }
         },
-        "required": ["url"]
+        "required": [
+          "url"
+        ]
       },
       "CreateThreadDto": {
         "type": "object",
@@ -8552,7 +8804,9 @@
             "type": "string",
             "description": "Role of the message sender",
             "example": "user",
-            "enum": ["user"]
+            "enum": [
+              "user"
+            ]
           },
           "content": {
             "type": "array",
@@ -8569,7 +8823,13 @@
             }
           }
         },
-        "required": ["id", "threadId", "createdAt", "role", "content"]
+        "required": [
+          "id",
+          "threadId",
+          "createdAt",
+          "role",
+          "content"
+        ]
       },
       "SystemMessageResponseDto": {
         "type": "object",
@@ -8593,7 +8853,9 @@
             "type": "string",
             "description": "Role of the message sender",
             "example": "system",
-            "enum": ["system"]
+            "enum": [
+              "system"
+            ]
           },
           "content": {
             "type": "array",
@@ -8603,7 +8865,13 @@
             }
           }
         },
-        "required": ["id", "threadId", "createdAt", "role", "content"]
+        "required": [
+          "id",
+          "threadId",
+          "createdAt",
+          "role",
+          "content"
+        ]
       },
       "AssistantMessageResponseDto": {
         "type": "object",
@@ -8627,7 +8895,9 @@
             "type": "string",
             "description": "Role of the message sender",
             "example": "assistant",
-            "enum": ["assistant"]
+            "enum": [
+              "assistant"
+            ]
           },
           "content": {
             "type": "array",
@@ -8647,7 +8917,13 @@
             }
           }
         },
-        "required": ["id", "threadId", "createdAt", "role", "content"]
+        "required": [
+          "id",
+          "threadId",
+          "createdAt",
+          "role",
+          "content"
+        ]
       },
       "ToolResultMessageResponseDto": {
         "type": "object",
@@ -8671,7 +8947,9 @@
             "type": "string",
             "description": "Role of the message sender",
             "example": "tool",
-            "enum": ["tool"]
+            "enum": [
+              "tool"
+            ]
           },
           "content": {
             "type": "array",
@@ -8681,7 +8959,13 @@
             }
           }
         },
-        "required": ["id", "threadId", "createdAt", "role", "content"]
+        "required": [
+          "id",
+          "threadId",
+          "createdAt",
+          "role",
+          "content"
+        ]
       },
       "TextMessageContentResponseDto": {
         "type": "object",
@@ -8690,7 +8974,13 @@
             "type": "string",
             "description": "Type of the message content",
             "example": "text",
-            "enum": ["text", "tool_use", "tool_result", "thinking", "image"]
+            "enum": [
+              "text",
+              "tool_use",
+              "tool_result",
+              "thinking",
+              "image"
+            ]
           },
           "text": {
             "type": "string",
@@ -8703,7 +8993,10 @@
             "example": false
           }
         },
-        "required": ["type", "text"]
+        "required": [
+          "type",
+          "text"
+        ]
       },
       "ToolUseMessageContentResponseDto": {
         "type": "object",
@@ -8712,7 +9005,13 @@
             "type": "string",
             "description": "Type of the message content",
             "example": "text",
-            "enum": ["text", "tool_use", "tool_result", "thinking", "image"]
+            "enum": [
+              "text",
+              "tool_use",
+              "tool_result",
+              "thinking",
+              "image"
+            ]
           },
           "id": {
             "type": "string",
@@ -8733,7 +9032,12 @@
             }
           }
         },
-        "required": ["type", "id", "name", "params"]
+        "required": [
+          "type",
+          "id",
+          "name",
+          "params"
+        ]
       },
       "ToolResultMessageContentResponseDto": {
         "type": "object",
@@ -8742,7 +9046,13 @@
             "type": "string",
             "description": "Type of the message content",
             "example": "text",
-            "enum": ["text", "tool_use", "tool_result", "thinking", "image"]
+            "enum": [
+              "text",
+              "tool_use",
+              "tool_result",
+              "thinking",
+              "image"
+            ]
           },
           "toolId": {
             "type": "string",
@@ -8760,7 +9070,12 @@
             "example": "The current temperature in New York is 22°C with partly cloudy skies."
           }
         },
-        "required": ["type", "toolId", "toolName", "result"]
+        "required": [
+          "type",
+          "toolId",
+          "toolName",
+          "result"
+        ]
       },
       "ThinkingMessageContentResponseDto": {
         "type": "object",
@@ -8769,7 +9084,13 @@
             "type": "string",
             "description": "Type of the message content",
             "example": "text",
-            "enum": ["text", "tool_use", "tool_result", "thinking", "image"]
+            "enum": [
+              "text",
+              "tool_use",
+              "tool_result",
+              "thinking",
+              "image"
+            ]
           },
           "thinking": {
             "type": "string",
@@ -8777,7 +9098,10 @@
             "example": "I am thinking about the best way to help you."
           }
         },
-        "required": ["type", "thinking"]
+        "required": [
+          "type",
+          "thinking"
+        ]
       },
       "ImageMessageContentResponseDto": {
         "type": "object",
@@ -8786,7 +9110,13 @@
             "type": "string",
             "description": "Type of the message content",
             "example": "text",
-            "enum": ["text", "tool_use", "tool_result", "thinking", "image"]
+            "enum": [
+              "text",
+              "tool_use",
+              "tool_result",
+              "thinking",
+              "image"
+            ]
           },
           "imageUrl": {
             "type": "string",
@@ -8799,7 +9129,10 @@
             "example": "Screenshot of the reported issue"
           }
         },
-        "required": ["type", "imageUrl"]
+        "required": [
+          "type",
+          "imageUrl"
+        ]
       },
       "ModelResponseDto": {
         "type": "object",
@@ -8863,12 +9196,19 @@
           "type": {
             "type": "string",
             "description": "Type of source",
-            "enum": ["text", "data"]
+            "enum": [
+              "text",
+              "data"
+            ]
           },
           "createdBy": {
             "type": "string",
             "description": "Creator of the source",
-            "enum": ["user", "llm", "system"]
+            "enum": [
+              "user",
+              "llm",
+              "system"
+            ]
           },
           "createdAt": {
             "type": "string",
@@ -8907,12 +9247,19 @@
           "type": {
             "type": "string",
             "description": "Type of source",
-            "enum": ["text", "data"]
+            "enum": [
+              "text",
+              "data"
+            ]
           },
           "createdBy": {
             "type": "string",
             "description": "Creator of the source",
-            "enum": ["user", "llm", "system"]
+            "enum": [
+              "user",
+              "llm",
+              "system"
+            ]
           },
           "createdAt": {
             "type": "string",
@@ -8925,12 +9272,19 @@
           "textType": {
             "type": "string",
             "description": "Type of text",
-            "enum": ["file", "web"]
+            "enum": [
+              "file",
+              "web"
+            ]
           },
           "fileType": {
             "type": "string",
             "description": "Type of file",
-            "enum": ["pdf", "docx", "pptx"]
+            "enum": [
+              "pdf",
+              "docx",
+              "pptx"
+            ]
           }
         },
         "required": [
@@ -8963,12 +9317,19 @@
           "type": {
             "type": "string",
             "description": "Type of source",
-            "enum": ["text", "data"]
+            "enum": [
+              "text",
+              "data"
+            ]
           },
           "createdBy": {
             "type": "string",
             "description": "Creator of the source",
-            "enum": ["user", "llm", "system"]
+            "enum": [
+              "user",
+              "llm",
+              "system"
+            ]
           },
           "createdAt": {
             "type": "string",
@@ -8981,7 +9342,10 @@
           "textType": {
             "type": "string",
             "description": "Type of text",
-            "enum": ["file", "web"]
+            "enum": [
+              "file",
+              "web"
+            ]
           },
           "url": {
             "type": "string",
@@ -9018,12 +9382,19 @@
           "type": {
             "type": "string",
             "description": "Type of source",
-            "enum": ["text", "data"]
+            "enum": [
+              "text",
+              "data"
+            ]
           },
           "createdBy": {
             "type": "string",
             "description": "Creator of the source",
-            "enum": ["user", "llm", "system"]
+            "enum": [
+              "user",
+              "llm",
+              "system"
+            ]
           },
           "createdAt": {
             "type": "string",
@@ -9036,7 +9407,9 @@
           "dataType": {
             "type": "string",
             "description": "Type of data",
-            "enum": ["csv"]
+            "enum": [
+              "csv"
+            ]
           },
           "data": {
             "type": "object",
@@ -9193,7 +9566,12 @@
             "example": false
           }
         },
-        "required": ["id", "createdAt", "updatedAt", "isAnonymous"]
+        "required": [
+          "id",
+          "createdAt",
+          "updatedAt",
+          "isAnonymous"
+        ]
       },
       "GetThreadsResponseDto": {
         "type": "object",
@@ -9214,7 +9592,10 @@
             ]
           }
         },
-        "required": ["data", "pagination"]
+        "required": [
+          "data",
+          "pagination"
+        ]
       },
       "UpdateThreadTitleDto": {
         "type": "object",
@@ -9227,7 +9608,9 @@
             "maxLength": 200
           }
         },
-        "required": ["title"]
+        "required": [
+          "title"
+        ]
       },
       "ToolAssignmentDto": {
         "type": "object",
@@ -9263,7 +9646,9 @@
             "format": "uuid"
           }
         },
-        "required": ["type"]
+        "required": [
+          "type"
+        ]
       },
       "CreateAgentDto": {
         "type": "object",
@@ -9294,7 +9679,12 @@
             }
           }
         },
-        "required": ["name", "instructions", "modelId", "toolAssignments"]
+        "required": [
+          "name",
+          "instructions",
+          "modelId",
+          "toolAssignments"
+        ]
       },
       "ToolResponseDto": {
         "type": "object",
@@ -9324,7 +9714,9 @@
             ]
           }
         },
-        "required": ["type"]
+        "required": [
+          "type"
+        ]
       },
       "AgentSourceResponseDto": {
         "type": "object",
@@ -9350,10 +9742,18 @@
             "type": "string",
             "description": "The type of source",
             "example": "file",
-            "enum": ["file", "url"]
+            "enum": [
+              "file",
+              "url"
+            ]
           }
         },
-        "required": ["id", "sourceId", "name", "type"]
+        "required": [
+          "id",
+          "sourceId",
+          "name",
+          "type"
+        ]
       },
       "AgentResponseDto": {
         "type": "object",
@@ -9467,7 +9867,11 @@
             "format": "uuid"
           }
         },
-        "required": ["name", "instructions", "modelId"]
+        "required": [
+          "name",
+          "instructions",
+          "modelId"
+        ]
       },
       "McpIntegrationResponseDto": {
         "type": "object",
@@ -9485,7 +9889,11 @@
           "type": {
             "type": "string",
             "description": "Type of integration",
-            "enum": ["predefined", "custom", "marketplace"],
+            "enum": [
+              "predefined",
+              "custom",
+              "marketplace"
+            ],
             "example": "predefined"
           },
           "slug": {
@@ -9511,7 +9919,12 @@
           "authMethod": {
             "type": "string",
             "description": "Authentication method used",
-            "enum": ["NO_AUTH", "BEARER_TOKEN", "CUSTOM_HEADER", "OAUTH"],
+            "enum": [
+              "NO_AUTH",
+              "BEARER_TOKEN",
+              "CUSTOM_HEADER",
+              "OAUTH"
+            ],
             "example": "BEARER_TOKEN"
           },
           "authHeaderName": {
@@ -9527,7 +9940,12 @@
           "connectionStatus": {
             "type": "string",
             "description": "Connection status of the integration",
-            "enum": ["connected", "disconnected", "error", "unknown"],
+            "enum": [
+              "connected",
+              "disconnected",
+              "error",
+              "unknown"
+            ],
             "example": "connected"
           },
           "lastConnectionError": {
@@ -9599,7 +10017,11 @@
           "entityType": {
             "type": "string",
             "description": "Type of entity being shared",
-            "enum": ["agent", "prompt", "skill"]
+            "enum": [
+              "agent",
+              "prompt",
+              "skill"
+            ]
           },
           "agentId": {
             "type": "string",
@@ -9612,7 +10034,10 @@
             "format": "uuid"
           }
         },
-        "required": ["entityType", "agentId"]
+        "required": [
+          "entityType",
+          "agentId"
+        ]
       },
       "ShareResponseDto": {
         "type": "object",
@@ -9625,7 +10050,11 @@
           "entityType": {
             "type": "string",
             "description": "Type of entity being shared",
-            "enum": ["agent", "prompt", "skill"]
+            "enum": [
+              "agent",
+              "prompt",
+              "skill"
+            ]
           },
           "entityId": {
             "type": "string",
@@ -9635,7 +10064,10 @@
           "scopeType": {
             "type": "string",
             "description": "Type of share scope (organization, user, or team)",
-            "enum": ["org", "team"]
+            "enum": [
+              "org",
+              "team"
+            ]
           },
           "ownerId": {
             "type": "string",
@@ -9678,7 +10110,11 @@
           "entityType": {
             "type": "string",
             "description": "Type of entity being shared",
-            "enum": ["agent", "prompt", "skill"]
+            "enum": [
+              "agent",
+              "prompt",
+              "skill"
+            ]
           },
           "skillId": {
             "type": "string",
@@ -9691,7 +10127,10 @@
             "format": "uuid"
           }
         },
-        "required": ["entityType", "skillId"]
+        "required": [
+          "entityType",
+          "skillId"
+        ]
       },
       "CreateTeamDto": {
         "type": "object",
@@ -9702,7 +10141,9 @@
             "example": "Engineering"
           }
         },
-        "required": ["name"]
+        "required": [
+          "name"
+        ]
       },
       "UpdateTeamDto": {
         "type": "object",
@@ -9713,7 +10154,9 @@
             "example": "Engineering"
           }
         },
-        "required": ["name"]
+        "required": [
+          "name"
+        ]
       },
       "TeamResponseDto": {
         "type": "object",
@@ -9746,7 +10189,13 @@
             "example": "2024-01-15T10:30:00.000Z"
           }
         },
-        "required": ["id", "name", "orgId", "createdAt", "updatedAt"]
+        "required": [
+          "id",
+          "name",
+          "orgId",
+          "createdAt",
+          "updatedAt"
+        ]
       },
       "TeamMemberResponseDto": {
         "type": "object",
@@ -9774,7 +10223,10 @@
           "userRole": {
             "type": "string",
             "description": "The role of the team member in the organization",
-            "enum": ["admin", "user"],
+            "enum": [
+              "admin",
+              "user"
+            ],
             "example": "user"
           },
           "joinedAt": {
@@ -9812,7 +10264,10 @@
             ]
           }
         },
-        "required": ["data", "pagination"]
+        "required": [
+          "data",
+          "pagination"
+        ]
       },
       "AddTeamMemberDto": {
         "type": "object",
@@ -9823,7 +10278,9 @@
             "example": "550e8400-e29b-41d4-a716-446655440001"
           }
         },
-        "required": ["userId"]
+        "required": [
+          "userId"
+        ]
       },
       "ListTeamMembersQueryDto": {
         "type": "object",
@@ -9848,7 +10305,11 @@
           "name": {
             "type": "string",
             "description": "The name/type of the credential field",
-            "enum": ["token", "clientId", "clientSecret"],
+            "enum": [
+              "token",
+              "clientId",
+              "clientSecret"
+            ],
             "example": "token"
           },
           "value": {
@@ -9857,7 +10318,10 @@
             "example": "sk_test_123abc"
           }
         },
-        "required": ["name", "value"]
+        "required": [
+          "name",
+          "value"
+        ]
       },
       "CreatePredefinedIntegrationDto": {
         "type": "object",
@@ -9866,7 +10330,11 @@
             "type": "string",
             "description": "The predefined integration slug",
             "example": "TEST",
-            "enum": ["TEST", "LOCABOO", "LEGAL_CODES"]
+            "enum": [
+              "TEST",
+              "LOCABOO",
+              "LEGAL_CODES"
+            ]
           },
           "configValues": {
             "description": "List of config values for credential fields",
@@ -9888,7 +10356,10 @@
             "default": true
           }
         },
-        "required": ["slug", "configValues"]
+        "required": [
+          "slug",
+          "configValues"
+        ]
       },
       "CreateCustomIntegrationDto": {
         "type": "object",
@@ -9908,7 +10379,12 @@
           "authMethod": {
             "type": "string",
             "description": "Authentication method for the MCP server",
-            "enum": ["NO_AUTH", "BEARER_TOKEN", "CUSTOM_HEADER", "OAUTH"],
+            "enum": [
+              "NO_AUTH",
+              "BEARER_TOKEN",
+              "CUSTOM_HEADER",
+              "OAUTH"
+            ],
             "example": "CUSTOM_HEADER",
             "nullable": true
           },
@@ -9929,7 +10405,10 @@
             "default": true
           }
         },
-        "required": ["name", "serverUrl"]
+        "required": [
+          "name",
+          "serverUrl"
+        ]
       },
       "CredentialFieldDto": {
         "type": "object",
@@ -9942,7 +10421,11 @@
           "type": {
             "type": "string",
             "description": "Input type (text or password)",
-            "enum": ["token", "clientId", "clientSecret"],
+            "enum": [
+              "token",
+              "clientId",
+              "clientSecret"
+            ],
             "example": "token"
           },
           "required": {
@@ -9956,7 +10439,11 @@
             "example": "Your Locaboo 3 API token will be used to authenticate with Locaboo 4"
           }
         },
-        "required": ["label", "type", "required"]
+        "required": [
+          "label",
+          "type",
+          "required"
+        ]
       },
       "PredefinedConfigResponseDto": {
         "type": "object",
@@ -9979,7 +10466,12 @@
           "authType": {
             "type": "string",
             "description": "Authentication method for this integration",
-            "enum": ["NO_AUTH", "BEARER_TOKEN", "API_KEY", "OAUTH"],
+            "enum": [
+              "NO_AUTH",
+              "BEARER_TOKEN",
+              "API_KEY",
+              "OAUTH"
+            ],
             "example": "BEARER_TOKEN"
           },
           "authHeaderName": {
@@ -9995,7 +10487,12 @@
             }
           }
         },
-        "required": ["slug", "displayName", "description", "authType"]
+        "required": [
+          "slug",
+          "displayName",
+          "description",
+          "authType"
+        ]
       },
       "UpdateMcpIntegrationDto": {
         "type": "object",
@@ -10055,7 +10552,10 @@
             "example": false
           }
         },
-        "required": ["identifier", "orgConfigValues"]
+        "required": [
+          "identifier",
+          "orgConfigValues"
+        ]
       },
       "UserConfigResponseDto": {
         "type": "object",
@@ -10067,16 +10567,19 @@
           },
           "configValues": {
             "type": "object",
-            "description": "Configuration values with secret values masked (keys present, values replaced with \"***\")",
+            "description": "Configuration values with secret values masked (keys present, values replaced with \"••••••\")",
             "example": {
-              "personalToken": "***"
+              "personalToken": "••••••"
             },
             "additionalProperties": {
               "type": "string"
             }
           }
         },
-        "required": ["hasConfig", "configValues"]
+        "required": [
+          "hasConfig",
+          "configValues"
+        ]
       },
       "SetUserConfigDto": {
         "type": "object",
@@ -10092,7 +10595,9 @@
             }
           }
         },
-        "required": ["configValues"]
+        "required": [
+          "configValues"
+        ]
       },
       "ValidationResponseDto": {
         "type": "object",
@@ -10117,7 +10622,10 @@
             "example": "Connection timeout"
           }
         },
-        "required": ["valid", "capabilities"]
+        "required": [
+          "valid",
+          "capabilities"
+        ]
       },
       "MarketplaceSkillResponseDto": {
         "type": "object",
@@ -10205,7 +10713,11 @@
           "type": {
             "type": "string",
             "description": "Field type",
-            "enum": ["text", "url", "secret"]
+            "enum": [
+              "text",
+              "url",
+              "secret"
+            ]
           },
           "headerName": {
             "type": "string",
@@ -10232,7 +10744,12 @@
             "nullable": true
           }
         },
-        "required": ["key", "label", "type", "required"]
+        "required": [
+          "key",
+          "label",
+          "type",
+          "required"
+        ]
       },
       "MarketplaceIntegrationConfigSchemaDto": {
         "type": "object",
@@ -10256,7 +10773,11 @@
             }
           }
         },
-        "required": ["authType", "orgFields", "userFields"]
+        "required": [
+          "authType",
+          "orgFields",
+          "userFields"
+        ]
       },
       "MarketplaceIntegrationResponseDto": {
         "type": "object",
@@ -10343,7 +10864,9 @@
             "example": "meeting-summarizer"
           }
         },
-        "required": ["identifier"]
+        "required": [
+          "identifier"
+        ]
       },
       "SkillResponseDto": {
         "type": "object",
@@ -10449,7 +10972,11 @@
             "example": true
           }
         },
-        "required": ["name", "shortDescription", "instructions"]
+        "required": [
+          "name",
+          "shortDescription",
+          "instructions"
+        ]
       },
       "UpdateSkillDto": {
         "type": "object",
@@ -10472,7 +10999,11 @@
             "example": "You are a legal research assistant. When activated, search through the attached legal databases..."
           }
         },
-        "required": ["name", "shortDescription", "instructions"]
+        "required": [
+          "name",
+          "shortDescription",
+          "instructions"
+        ]
       },
       "SkillSourceResponseDto": {
         "type": "object",
@@ -10494,7 +11025,11 @@
             "example": "file"
           }
         },
-        "required": ["id", "name", "type"]
+        "required": [
+          "id",
+          "name",
+          "type"
+        ]
       },
       "MessageContentResponseDto": {
         "type": "object",
@@ -10503,10 +11038,18 @@
             "type": "string",
             "description": "Type of the message content",
             "example": "text",
-            "enum": ["text", "tool_use", "tool_result", "thinking", "image"]
+            "enum": [
+              "text",
+              "tool_use",
+              "tool_result",
+              "thinking",
+              "image"
+            ]
           }
         },
-        "required": ["type"]
+        "required": [
+          "type"
+        ]
       },
       "RunSessionResponseDto": {
         "type": "object",
@@ -10515,7 +11058,9 @@
             "type": "string",
             "description": "Response type identifier",
             "example": "session",
-            "enum": ["session"]
+            "enum": [
+              "session"
+            ]
           },
           "success": {
             "type": "boolean",
@@ -10538,7 +11083,11 @@
             "example": "2024-01-01T12:00:00.000Z"
           }
         },
-        "required": ["type", "threadId", "timestamp"]
+        "required": [
+          "type",
+          "threadId",
+          "timestamp"
+        ]
       },
       "RunMessageResponseDto": {
         "type": "object",
@@ -10547,7 +11096,9 @@
             "type": "string",
             "description": "Response type identifier",
             "example": "message",
-            "enum": ["message"]
+            "enum": [
+              "message"
+            ]
           },
           "message": {
             "description": "The message data",
@@ -10577,7 +11128,12 @@
             "example": "2024-01-01T12:00:00.000Z"
           }
         },
-        "required": ["type", "message", "threadId", "timestamp"]
+        "required": [
+          "type",
+          "message",
+          "threadId",
+          "timestamp"
+        ]
       },
       "RunErrorResponseDto": {
         "type": "object",
@@ -10586,7 +11142,9 @@
             "type": "string",
             "description": "Response type identifier",
             "example": "error",
-            "enum": ["error"]
+            "enum": [
+              "error"
+            ]
           },
           "message": {
             "type": "string",
@@ -10616,7 +11174,12 @@
             }
           }
         },
-        "required": ["type", "message", "threadId", "timestamp"]
+        "required": [
+          "type",
+          "message",
+          "threadId",
+          "timestamp"
+        ]
       },
       "RunThreadResponseDto": {
         "type": "object",
@@ -10625,7 +11188,9 @@
             "type": "string",
             "description": "Response type identifier",
             "example": "thread",
-            "enum": ["thread"]
+            "enum": [
+              "thread"
+            ]
           },
           "threadId": {
             "type": "string",
@@ -10636,7 +11201,9 @@
             "type": "string",
             "description": "Type of thread update",
             "example": "title_updated",
-            "enum": ["title_updated"]
+            "enum": [
+              "title_updated"
+            ]
           },
           "title": {
             "type": "string",
@@ -10649,7 +11216,13 @@
             "example": "2024-01-01T12:00:00.000Z"
           }
         },
-        "required": ["type", "threadId", "updateType", "title", "timestamp"]
+        "required": [
+          "type",
+          "threadId",
+          "updateType",
+          "title",
+          "timestamp"
+        ]
       },
       "TextInput": {
         "type": "object",
@@ -10657,7 +11230,9 @@
           "type": {
             "type": "string",
             "description": "The type of input",
-            "enum": ["text"],
+            "enum": [
+              "text"
+            ],
             "example": "text"
           },
           "text": {
@@ -10666,7 +11241,10 @@
             "example": "What is the weather forecast for New York tomorrow?"
           }
         },
-        "required": ["type", "text"]
+        "required": [
+          "type",
+          "text"
+        ]
       },
       "ToolResultInput": {
         "type": "object",
@@ -10674,7 +11252,9 @@
           "type": {
             "type": "string",
             "description": "The type of input",
-            "enum": ["tool_result"],
+            "enum": [
+              "tool_result"
+            ],
             "example": "tool_result"
           },
           "toolId": {
@@ -10693,7 +11273,12 @@
             "example": "{\"location\":\"New York\",\"forecast\":\"Partly cloudy with a high of 75°F and a low of 60°F\",\"precipitation\":\"20%\"}"
           }
         },
-        "required": ["type", "toolId", "toolName", "result"]
+        "required": [
+          "type",
+          "toolId",
+          "toolName",
+          "result"
+        ]
       },
       "SendMessageDto": {
         "type": "object",
@@ -10740,7 +11325,9 @@
             "default": true
           }
         },
-        "required": ["threadId"]
+        "required": [
+          "threadId"
+        ]
       },
       "SuperAdminTrialResponseDto": {
         "type": "object",
@@ -10820,7 +11407,10 @@
             "minimum": 1
           }
         },
-        "required": ["orgId", "maxMessages"]
+        "required": [
+          "orgId",
+          "maxMessages"
+        ]
       },
       "UpdateTrialRequestDto": {
         "type": "object",
@@ -10848,7 +11438,9 @@
             "example": true
           }
         },
-        "required": ["isSelfHosted"]
+        "required": [
+          "isSelfHosted"
+        ]
       },
       "UsageStatsResponseDto": {
         "type": "object",
@@ -10875,7 +11467,11 @@
           },
           "topModels": {
             "description": "List of the most frequently used model names, ordered by usage",
-            "example": ["gpt-4", "claude-3-sonnet", "gpt-3.5-turbo"],
+            "example": [
+              "gpt-4",
+              "claude-3-sonnet",
+              "gpt-3.5-turbo"
+            ],
             "type": "array",
             "items": {
               "type": "string"
@@ -10907,7 +11503,11 @@
             "description": "Number of requests at this point"
           }
         },
-        "required": ["date", "tokens", "requests"]
+        "required": [
+          "date",
+          "tokens",
+          "requests"
+        ]
       },
       "ProviderUsageDto": {
         "type": "object",
@@ -10968,7 +11568,9 @@
             }
           }
         },
-        "required": ["providers"]
+        "required": [
+          "providers"
+        ]
       },
       "ProviderValuesDto": {
         "type": "object",
@@ -11016,7 +11618,10 @@
             ]
           }
         },
-        "required": ["date", "values"]
+        "required": [
+          "date",
+          "values"
+        ]
       },
       "ProviderUsageChartResponseDto": {
         "type": "object",
@@ -11029,7 +11634,9 @@
             }
           }
         },
-        "required": ["timeSeries"]
+        "required": [
+          "timeSeries"
+        ]
       },
       "ModelDistributionDto": {
         "type": "object",
@@ -11097,7 +11704,9 @@
             }
           }
         },
-        "required": ["models"]
+        "required": [
+          "models"
+        ]
       },
       "UserUsageDto": {
         "type": "object",
@@ -11162,7 +11771,10 @@
             ]
           }
         },
-        "required": ["data", "pagination"]
+        "required": [
+          "data",
+          "pagination"
+        ]
       },
       "UserSystemPromptResponseDto": {
         "type": "object",
@@ -11174,7 +11786,9 @@
             "nullable": true
           }
         },
-        "required": ["systemPrompt"]
+        "required": [
+          "systemPrompt"
+        ]
       },
       "UpsertUserSystemPromptDto": {
         "type": "object",
@@ -11186,7 +11800,9 @@
             "maxLength": 10000
           }
         },
-        "required": ["systemPrompt"]
+        "required": [
+          "systemPrompt"
+        ]
       },
       "CreatePromptDto": {
         "type": "object",
@@ -11204,7 +11820,10 @@
             "example": "You are a helpful assistant that helps with project planning. Please provide detailed step-by-step guidance for managing projects effectively."
           }
         },
-        "required": ["title", "content"]
+        "required": [
+          "title",
+          "content"
+        ]
       },
       "PromptResponseDto": {
         "type": "object",
@@ -11269,7 +11888,10 @@
             "example": "You are an expert project planning assistant. Provide comprehensive guidance for project management, including risk assessment and timeline optimization."
           }
         },
-        "required": ["title", "content"]
+        "required": [
+          "title",
+          "content"
+        ]
       },
       "TranscriptionResponseDto": {
         "type": "object",
@@ -11280,7 +11902,9 @@
             "example": "Hello, this is a test transcription."
           }
         },
-        "required": ["text"]
+        "required": [
+          "text"
+        ]
       },
       "LoginDto": {
         "type": "object",
@@ -11296,7 +11920,10 @@
             "example": "password123"
           }
         },
-        "required": ["email", "password"]
+        "required": [
+          "email",
+          "password"
+        ]
       },
       "SuccessResponseDto": {
         "type": "object",
@@ -11307,7 +11934,9 @@
             "example": true
           }
         },
-        "required": ["success"]
+        "required": [
+          "success"
+        ]
       },
       "ErrorResponseDto": {
         "type": "object",
@@ -11318,7 +11947,9 @@
             "example": "Authentication failed"
           }
         },
-        "required": ["message"]
+        "required": [
+          "message"
+        ]
       },
       "RegisterDto": {
         "type": "object",
@@ -11368,13 +11999,19 @@
           "role": {
             "type": "string",
             "description": "User role",
-            "enum": ["admin", "user"],
+            "enum": [
+              "admin",
+              "user"
+            ],
             "example": "user"
           },
           "systemRole": {
             "type": "string",
             "description": "User system role",
-            "enum": ["customer", "super_admin"],
+            "enum": [
+              "customer",
+              "super_admin"
+            ],
             "example": "super_admin"
           },
           "name": {
@@ -11383,7 +12020,12 @@
             "example": "John Doe"
           }
         },
-        "required": ["email", "role", "systemRole", "name"]
+        "required": [
+          "email",
+          "role",
+          "systemRole",
+          "name"
+        ]
       }
     }
   }

--- a/ayunis-core-frontend/src/shared/api/openapi-schema.json
+++ b/ayunis-core-frontend/src/shared/api/openapi-schema.json
@@ -18,9 +18,7 @@
           }
         },
         "summary": "Check if the deployment is running in a cloud environment",
-        "tags": [
-          "app"
-        ]
+        "tags": ["app"]
       }
     },
     "/health": {
@@ -33,9 +31,7 @@
           }
         },
         "summary": "Check if the deployment is healthy",
-        "tags": [
-          "app"
-        ]
+        "tags": ["app"]
       }
     },
     "/models/available": {
@@ -61,9 +57,7 @@
           }
         },
         "summary": "Get all available models",
-        "tags": [
-          "models"
-        ]
+        "tags": ["models"]
       }
     },
     "/models/providers": {
@@ -86,9 +80,7 @@
           }
         },
         "summary": "Get all available model providers with their info",
-        "tags": [
-          "models"
-        ]
+        "tags": ["models"]
       }
     },
     "/models/permitted": {
@@ -117,9 +109,7 @@
           }
         },
         "summary": "Create a permitted model",
-        "tags": [
-          "models"
-        ]
+        "tags": ["models"]
       }
     },
     "/models/permitted/{id}": {
@@ -144,9 +134,7 @@
           }
         },
         "summary": "Delete a permitted model",
-        "tags": [
-          "models"
-        ]
+        "tags": ["models"]
       },
       "patch": {
         "operationId": "ModelsController_updatePermittedModel",
@@ -189,9 +177,7 @@
           }
         },
         "summary": "Update a permitted model",
-        "tags": [
-          "models"
-        ]
+        "tags": ["models"]
       }
     },
     "/models/permitted/language-models": {
@@ -217,9 +203,7 @@
           }
         },
         "summary": "Get all permitted language models",
-        "tags": [
-          "models"
-        ]
+        "tags": ["models"]
       }
     },
     "/models/default": {
@@ -243,9 +227,7 @@
           }
         },
         "summary": "Get the effective default model for the user",
-        "tags": [
-          "models"
-        ]
+        "tags": ["models"]
       }
     },
     "/models/org/default": {
@@ -269,9 +251,7 @@
           }
         },
         "summary": "Get the organization default model",
-        "tags": [
-          "models"
-        ]
+        "tags": ["models"]
       },
       "put": {
         "description": "Sets the specified permitted model as the organization default. If a default already exists, it will be updated to the new model.",
@@ -306,9 +286,7 @@
           }
         },
         "summary": "Set or update the organization default model",
-        "tags": [
-          "models"
-        ]
+        "tags": ["models"]
       }
     },
     "/models/user/default": {
@@ -332,9 +310,7 @@
           }
         },
         "summary": "Get the user-specific default model",
-        "tags": [
-          "models"
-        ]
+        "tags": ["models"]
       },
       "put": {
         "description": "Sets the specified permitted model as the user default. If a default already exists, it will be updated to the new model.",
@@ -369,9 +345,7 @@
           }
         },
         "summary": "Set or update the user default model",
-        "tags": [
-          "models"
-        ]
+        "tags": ["models"]
       },
       "delete": {
         "operationId": "ModelsController_deleteUserDefaultModel",
@@ -385,9 +359,7 @@
           }
         },
         "summary": "Delete the user default model",
-        "tags": [
-          "models"
-        ]
+        "tags": ["models"]
       }
     },
     "/models/provider/{provider}": {
@@ -423,9 +395,7 @@
           }
         },
         "summary": "Get model provider information",
-        "tags": [
-          "models"
-        ]
+        "tags": ["models"]
       }
     },
     "/models/embedding/enabled": {
@@ -448,9 +418,7 @@
           }
         },
         "summary": "Check if an embedding model is enabled for this org",
-        "tags": [
-          "models"
-        ]
+        "tags": ["models"]
       }
     },
     "/super-admin/models/{orgId}/available": {
@@ -492,9 +460,7 @@
           }
         },
         "summary": "Get all available models",
-        "tags": [
-          "Super Admin Models"
-        ]
+        "tags": ["Super Admin Models"]
       }
     },
     "/super-admin/models/{orgId}/default-model": {
@@ -549,9 +515,7 @@
           }
         },
         "summary": "Set or update the organization default model",
-        "tags": [
-          "Super Admin Models"
-        ]
+        "tags": ["Super Admin Models"]
       }
     },
     "/super-admin/models/catalog/{id}": {
@@ -586,9 +550,7 @@
           }
         },
         "summary": "Delete a model from the catalog",
-        "tags": [
-          "Super Admin Models"
-        ]
+        "tags": ["Super Admin Models"]
       },
       "get": {
         "description": "Retrieve a specific model from the master catalog by its ID. This endpoint is only accessible to super admins.",
@@ -635,9 +597,7 @@
           }
         },
         "summary": "Get a model by ID from the catalog",
-        "tags": [
-          "Super Admin Models"
-        ]
+        "tags": ["Super Admin Models"]
       }
     },
     "/super-admin/models/{orgId}/permitted-models": {
@@ -686,9 +646,7 @@
           }
         },
         "summary": "Get all permitted models for a specific organization",
-        "tags": [
-          "Super Admin Models"
-        ]
+        "tags": ["Super Admin Models"]
       },
       "post": {
         "description": "Create a new permitted model for the specified organization. This endpoint is only accessible to super admins.",
@@ -734,9 +692,7 @@
           }
         },
         "summary": "Create a permitted model for a specific organization",
-        "tags": [
-          "Super Admin Models"
-        ]
+        "tags": ["Super Admin Models"]
       }
     },
     "/super-admin/models/{orgId}/permitted-models/{id}": {
@@ -785,9 +741,7 @@
           }
         },
         "summary": "Delete a permitted model for a specific organization",
-        "tags": [
-          "Super Admin Models"
-        ]
+        "tags": ["Super Admin Models"]
       },
       "patch": {
         "description": "Update the settings of a permitted model for the specified organization. This endpoint is only accessible to super admins.",
@@ -858,9 +812,7 @@
           }
         },
         "summary": "Update a permitted model for a specific organization",
-        "tags": [
-          "Super Admin Models"
-        ]
+        "tags": ["Super Admin Models"]
       }
     },
     "/super-admin/models/catalog": {
@@ -897,9 +849,7 @@
           }
         },
         "summary": "Get all models in the catalog",
-        "tags": [
-          "Super Admin Models"
-        ]
+        "tags": ["Super Admin Models"]
       }
     },
     "/super-admin/models/catalog/language": {
@@ -942,9 +892,7 @@
           }
         },
         "summary": "Create a new language model in the catalog",
-        "tags": [
-          "Super Admin Models"
-        ]
+        "tags": ["Super Admin Models"]
       }
     },
     "/super-admin/models/catalog/language/{id}": {
@@ -999,9 +947,7 @@
           }
         },
         "summary": "Update a language model in the catalog",
-        "tags": [
-          "Super Admin Models"
-        ]
+        "tags": ["Super Admin Models"]
       }
     },
     "/super-admin/models/catalog/embedding": {
@@ -1044,9 +990,7 @@
           }
         },
         "summary": "Create a new embedding model in the catalog",
-        "tags": [
-          "Super Admin Models"
-        ]
+        "tags": ["Super Admin Models"]
       }
     },
     "/super-admin/models/catalog/embedding/{id}": {
@@ -1101,9 +1045,7 @@
           }
         },
         "summary": "Update an embedding model in the catalog",
-        "tags": [
-          "Super Admin Models"
-        ]
+        "tags": ["Super Admin Models"]
       }
     },
     "/super-admin/orgs": {
@@ -1141,9 +1083,7 @@
           }
         },
         "summary": "Create a new organization",
-        "tags": [
-          "Super Admin Orgs"
-        ]
+        "tags": ["Super Admin Orgs"]
       },
       "get": {
         "description": "Retrieve paginated organizations in the system. Only accessible to users with the super admin system role.",
@@ -1198,9 +1138,7 @@
           }
         },
         "summary": "List all organizations",
-        "tags": [
-          "Super Admin Orgs"
-        ]
+        "tags": ["Super Admin Orgs"]
       }
     },
     "/super-admin/orgs/{id}": {
@@ -1234,9 +1172,7 @@
           }
         },
         "summary": "Get an organization by ID",
-        "tags": [
-          "Super Admin Orgs"
-        ]
+        "tags": ["Super Admin Orgs"]
       }
     },
     "/users": {
@@ -1296,9 +1232,7 @@
           }
         },
         "summary": "Get users in current organization",
-        "tags": [
-          "Users"
-        ]
+        "tags": ["Users"]
       }
     },
     "/users/{id}/role": {
@@ -1354,9 +1288,7 @@
           }
         },
         "summary": "Update user role",
-        "tags": [
-          "Users"
-        ]
+        "tags": ["Users"]
       }
     },
     "/users/name": {
@@ -1400,9 +1332,7 @@
           }
         },
         "summary": "Update user name",
-        "tags": [
-          "Users"
-        ]
+        "tags": ["Users"]
       }
     },
     "/users/password": {
@@ -1436,9 +1366,7 @@
           }
         },
         "summary": "Update user password",
-        "tags": [
-          "Users"
-        ]
+        "tags": ["Users"]
       }
     },
     "/users/confirm-email": {
@@ -1472,9 +1400,7 @@
           }
         },
         "summary": "Confirm user email",
-        "tags": [
-          "Users"
-        ]
+        "tags": ["Users"]
       }
     },
     "/users/resend-confirmation": {
@@ -1505,9 +1431,7 @@
           }
         },
         "summary": "Resend email confirmation",
-        "tags": [
-          "Users"
-        ]
+        "tags": ["Users"]
       }
     },
     "/users/{id}": {
@@ -1542,9 +1466,7 @@
           }
         },
         "summary": "Delete a user",
-        "tags": [
-          "Users"
-        ]
+        "tags": ["Users"]
       }
     },
     "/users/{id}/trigger-password-reset": {
@@ -1575,9 +1497,7 @@
           }
         },
         "summary": "Trigger password reset for a user",
-        "tags": [
-          "Users"
-        ]
+        "tags": ["Users"]
       }
     },
     "/users/forgot-password": {
@@ -1608,9 +1528,7 @@
           }
         },
         "summary": "Trigger password reset",
-        "tags": [
-          "Users"
-        ]
+        "tags": ["Users"]
       }
     },
     "/users/reset-password": {
@@ -1644,9 +1562,7 @@
           }
         },
         "summary": "Reset password with token",
-        "tags": [
-          "Users"
-        ]
+        "tags": ["Users"]
       }
     },
     "/users/validate-reset-token": {
@@ -1690,9 +1606,7 @@
           }
         },
         "summary": "Validate password reset token",
-        "tags": [
-          "Users"
-        ]
+        "tags": ["Users"]
       }
     },
     "/super-admin/users/{orgId}": {
@@ -1766,9 +1680,7 @@
           }
         },
         "summary": "Get users by organization ID",
-        "tags": [
-          "Super Admin Users"
-        ]
+        "tags": ["Super Admin Users"]
       }
     },
     "/super-admin/users/{userId}": {
@@ -1803,9 +1715,7 @@
           }
         },
         "summary": "Delete a user",
-        "tags": [
-          "Super Admin Users"
-        ]
+        "tags": ["Super Admin Users"]
       }
     },
     "/super-admin/users/{userId}/trigger-password-reset": {
@@ -1840,9 +1750,7 @@
           }
         },
         "summary": "Trigger password reset for a user",
-        "tags": [
-          "Super Admin Users"
-        ]
+        "tags": ["Super Admin Users"]
       }
     },
     "/super-admin/users/{orgId}/create": {
@@ -1898,9 +1806,7 @@
           }
         },
         "summary": "Create a new user in an organization",
-        "tags": [
-          "Super Admin Users"
-        ]
+        "tags": ["Super Admin Users"]
       }
     },
     "/invites": {
@@ -1937,9 +1843,7 @@
           }
         },
         "summary": "Create a new invite",
-        "tags": [
-          "invites"
-        ]
+        "tags": ["invites"]
       },
       "get": {
         "description": "Retrieve paginated invites with optional search",
@@ -1994,9 +1898,7 @@
           }
         },
         "summary": "Get all invites for current user's organization",
-        "tags": [
-          "invites"
-        ]
+        "tags": ["invites"]
       }
     },
     "/invites/bulk": {
@@ -2033,9 +1935,7 @@
           }
         },
         "summary": "Create multiple invites in bulk",
-        "tags": [
-          "invites"
-        ]
+        "tags": ["invites"]
       }
     },
     "/invites/{token}": {
@@ -2073,9 +1973,7 @@
           }
         },
         "summary": "Get a single invite by token",
-        "tags": [
-          "invites"
-        ]
+        "tags": ["invites"]
       }
     },
     "/invites/accept": {
@@ -2115,9 +2013,7 @@
           }
         },
         "summary": "Accept an invite",
-        "tags": [
-          "invites"
-        ]
+        "tags": ["invites"]
       }
     },
     "/invites/{id}/resend": {
@@ -2158,9 +2054,7 @@
           }
         },
         "summary": "Resend an expired invite",
-        "tags": [
-          "invites"
-        ]
+        "tags": ["invites"]
       }
     },
     "/invites/all": {
@@ -2187,9 +2081,7 @@
           }
         },
         "summary": "Delete all pending invites",
-        "tags": [
-          "invites"
-        ]
+        "tags": ["invites"]
       }
     },
     "/invites/{id}": {
@@ -2223,9 +2115,99 @@
           }
         },
         "summary": "Delete an invite",
-        "tags": [
-          "invites"
-        ]
+        "tags": ["invites"]
+      }
+    },
+    "/subscriptions": {
+      "get": {
+        "operationId": "SubscriptionsController_getSubscription",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved subscription details",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SubscriptionResponseDtoNullable"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "User is not authorized to access this organization's subscription"
+          },
+          "404": {
+            "description": "No subscription found for the organization"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "summary": "Get subscription details for the current organization",
+        "tags": ["subscriptions"]
+      },
+      "post": {
+        "operationId": "SubscriptionsController_createSubscription",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateSubscriptionRequestDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Successfully created subscription",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SubscriptionResponseDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid subscription data provided"
+          },
+          "403": {
+            "description": "User is not authorized to create a subscription for this organization"
+          },
+          "409": {
+            "description": "Subscription already exists for this organization"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "summary": "Create a new subscription for the current organization",
+        "tags": ["subscriptions"]
+      },
+      "delete": {
+        "operationId": "SubscriptionsController_cancelSubscription",
+        "parameters": [],
+        "responses": {
+          "204": {
+            "description": "Successfully cancelled subscription"
+          },
+          "403": {
+            "description": "User is not authorized to cancel this organization's subscription"
+          },
+          "404": {
+            "description": "No subscription found for the organization"
+          },
+          "409": {
+            "description": "Subscription is already cancelled"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "summary": "Cancel the subscription for the current organization",
+        "tags": ["subscriptions"]
       }
     },
     "/subscriptions/active": {
@@ -2248,9 +2230,7 @@
           }
         },
         "summary": "Check if the current organization has an active subscription",
-        "tags": [
-          "subscriptions"
-        ]
+        "tags": ["subscriptions"]
       }
     },
     "/subscriptions/price": {
@@ -2276,9 +2256,99 @@
           }
         },
         "summary": "Get the current price per seat monthly",
-        "tags": [
-          "subscriptions"
-        ]
+        "tags": ["subscriptions"]
+      }
+    },
+    "/subscriptions/seats": {
+      "put": {
+        "operationId": "SubscriptionsController_updateSeats",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateSeatsDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "description": "Successfully updated seats"
+          },
+          "400": {
+            "description": "Invalid seat update data provided"
+          },
+          "403": {
+            "description": "User is not authorized to update seats for this organization"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "summary": "Update the number of seats for the current organization",
+        "tags": ["subscriptions"]
+      }
+    },
+    "/subscriptions/billing-info": {
+      "put": {
+        "operationId": "SubscriptionsController_updateBillingInfo",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateBillingInfoDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "description": "Successfully updated billing information"
+          },
+          "400": {
+            "description": "Invalid billing information provided"
+          },
+          "403": {
+            "description": "User is not authorized to update billing information for this organization"
+          },
+          "404": {
+            "description": "No subscription found for the organization"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "summary": "Update the billing information for the current organization",
+        "tags": ["subscriptions"]
+      }
+    },
+    "/subscriptions/uncancel": {
+      "post": {
+        "operationId": "SubscriptionsController_uncancelSubscription",
+        "parameters": [],
+        "responses": {
+          "204": {
+            "description": "Successfully uncancelled subscription"
+          },
+          "403": {
+            "description": "User is not authorized to uncancel this organization's subscription"
+          },
+          "404": {
+            "description": "No subscription found for the organization"
+          },
+          "409": {
+            "description": "Subscription is not cancelled"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "summary": "Uncancel the subscription for the current organization",
+        "tags": ["subscriptions"]
       }
     },
     "/super-admin/subscriptions/{orgId}": {
@@ -2317,9 +2387,7 @@
           }
         },
         "summary": "Get subscription details for a specific organization",
-        "tags": [
-          "Super Admin Subscriptions"
-        ]
+        "tags": ["Super Admin Subscriptions"]
       },
       "post": {
         "description": "Create a new subscription for the specified organization. This endpoint is only accessible to super admins.",
@@ -2372,9 +2440,7 @@
           }
         },
         "summary": "Create a new subscription for a specific organization",
-        "tags": [
-          "Super Admin Subscriptions"
-        ]
+        "tags": ["Super Admin Subscriptions"]
       },
       "delete": {
         "description": "Cancel the subscription for the specified organization. This endpoint is only accessible to super admins.",
@@ -2410,9 +2476,7 @@
           }
         },
         "summary": "Cancel the subscription for a specific organization",
-        "tags": [
-          "Super Admin Subscriptions"
-        ]
+        "tags": ["Super Admin Subscriptions"]
       }
     },
     "/super-admin/subscriptions/{orgId}/seats": {
@@ -2460,9 +2524,7 @@
           }
         },
         "summary": "Update the number of seats for a specific organization",
-        "tags": [
-          "Super Admin Subscriptions"
-        ]
+        "tags": ["Super Admin Subscriptions"]
       }
     },
     "/super-admin/subscriptions/{orgId}/billing-info": {
@@ -2510,9 +2572,7 @@
           }
         },
         "summary": "Update the billing information for a specific organization",
-        "tags": [
-          "Super Admin Subscriptions"
-        ]
+        "tags": ["Super Admin Subscriptions"]
       }
     },
     "/super-admin/subscriptions/{orgId}/uncancel": {
@@ -2550,9 +2610,7 @@
           }
         },
         "summary": "Uncancel the subscription for a specific organization",
-        "tags": [
-          "Super Admin Subscriptions"
-        ]
+        "tags": ["Super Admin Subscriptions"]
       }
     },
     "/storage/upload": {
@@ -2566,9 +2624,7 @@
             "multipart/form-data": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "file"
-                ],
+                "required": ["file"],
                 "properties": {
                   "file": {
                     "type": "string",
@@ -2596,9 +2652,7 @@
           }
         },
         "summary": "Upload a file to object storage",
-        "tags": [
-          "storage"
-        ]
+        "tags": ["storage"]
       }
     },
     "/storage/{objectName}": {
@@ -2620,9 +2674,7 @@
             "description": ""
           }
         },
-        "tags": [
-          "storage"
-        ]
+        "tags": ["storage"]
       },
       "delete": {
         "operationId": "StorageController_deleteFile",
@@ -2642,9 +2694,7 @@
             "description": ""
           }
         },
-        "tags": [
-          "storage"
-        ]
+        "tags": ["storage"]
       }
     },
     "/storage/url/{objectName}": {
@@ -2666,9 +2716,7 @@
             "description": ""
           }
         },
-        "tags": [
-          "storage"
-        ]
+        "tags": ["storage"]
       }
     },
     "/retrievers/url": {
@@ -2691,9 +2739,7 @@
           }
         },
         "summary": "Retrieve content from a URL",
-        "tags": [
-          "retrievers"
-        ]
+        "tags": ["retrievers"]
       }
     },
     "/threads": {
@@ -2729,9 +2775,7 @@
           }
         },
         "summary": "Create a new thread",
-        "tags": [
-          "threads"
-        ]
+        "tags": ["threads"]
       },
       "get": {
         "operationId": "ThreadsController_findAll",
@@ -2790,9 +2834,7 @@
           }
         },
         "summary": "Get all threads for the current user",
-        "tags": [
-          "threads"
-        ]
+        "tags": ["threads"]
       }
     },
     "/threads/{id}": {
@@ -2829,9 +2871,7 @@
           }
         },
         "summary": "Get a thread by ID",
-        "tags": [
-          "threads"
-        ]
+        "tags": ["threads"]
       },
       "delete": {
         "operationId": "ThreadsController_delete",
@@ -2859,9 +2899,7 @@
           }
         },
         "summary": "Delete a thread",
-        "tags": [
-          "threads"
-        ]
+        "tags": ["threads"]
       }
     },
     "/threads/{id}/title": {
@@ -2904,9 +2942,7 @@
           }
         },
         "summary": "Update a thread title",
-        "tags": [
-          "threads"
-        ]
+        "tags": ["threads"]
       }
     },
     "/threads/{id}/sources": {
@@ -2956,9 +2992,7 @@
           }
         },
         "summary": "Get all sources for a thread",
-        "tags": [
-          "threads"
-        ]
+        "tags": ["threads"]
       }
     },
     "/threads/{id}/sources/file": {
@@ -2997,9 +3031,7 @@
                     "description": "A description of the file source"
                   }
                 },
-                "required": [
-                  "file"
-                ]
+                "required": ["file"]
               }
             }
           }
@@ -3010,9 +3042,7 @@
           }
         },
         "summary": "Add a file source to a thread",
-        "tags": [
-          "threads"
-        ]
+        "tags": ["threads"]
       }
     },
     "/threads/{id}/sources/{sourceId}": {
@@ -3049,9 +3079,7 @@
           }
         },
         "summary": "Remove a source from a thread",
-        "tags": [
-          "threads"
-        ]
+        "tags": ["threads"]
       }
     },
     "/threads/{id}/sources/{sourceId}/download": {
@@ -3099,9 +3127,7 @@
           }
         },
         "summary": "Download a data source as CSV",
-        "tags": [
-          "threads"
-        ]
+        "tags": ["threads"]
       }
     },
     "/agents": {
@@ -3137,9 +3163,7 @@
           }
         },
         "summary": "Create a new agent",
-        "tags": [
-          "agents"
-        ]
+        "tags": ["agents"]
       },
       "get": {
         "operationId": "AgentsController_findAll",
@@ -3163,9 +3187,7 @@
           }
         },
         "summary": "Get all agents for the current user",
-        "tags": [
-          "agents"
-        ]
+        "tags": ["agents"]
       }
     },
     "/agents/{id}": {
@@ -3202,9 +3224,7 @@
           }
         },
         "summary": "Get an agent by ID",
-        "tags": [
-          "agents"
-        ]
+        "tags": ["agents"]
       },
       "put": {
         "operationId": "AgentsController_update",
@@ -3252,9 +3272,7 @@
           }
         },
         "summary": "Update an agent",
-        "tags": [
-          "agents"
-        ]
+        "tags": ["agents"]
       },
       "delete": {
         "operationId": "AgentsController_delete",
@@ -3282,9 +3300,7 @@
           }
         },
         "summary": "Delete an agent",
-        "tags": [
-          "agents"
-        ]
+        "tags": ["agents"]
       }
     },
     "/agents/{id}/sources": {
@@ -3324,9 +3340,7 @@
           }
         },
         "summary": "Get all sources for an agent",
-        "tags": [
-          "agents"
-        ]
+        "tags": ["agents"]
       }
     },
     "/agents/{id}/sources/file": {
@@ -3357,9 +3371,7 @@
                     "description": "The file to upload"
                   }
                 },
-                "required": [
-                  "file"
-                ]
+                "required": ["file"]
               }
             }
           }
@@ -3379,9 +3391,7 @@
           }
         },
         "summary": "Add a file source to an agent",
-        "tags": [
-          "agents"
-        ]
+        "tags": ["agents"]
       }
     },
     "/agents/{id}/sources/{sourceAssignmentId}": {
@@ -3418,9 +3428,7 @@
           }
         },
         "summary": "Remove a source from an agent",
-        "tags": [
-          "agents"
-        ]
+        "tags": ["agents"]
       }
     },
     "/agents/{agentId}/mcp-integrations/{integrationId}": {
@@ -3473,9 +3481,7 @@
           }
         },
         "summary": "Assign MCP integration to agent",
-        "tags": [
-          "agents"
-        ]
+        "tags": ["agents"]
       },
       "delete": {
         "operationId": "AgentsController_unassignMcpIntegration",
@@ -3517,9 +3523,7 @@
           }
         },
         "summary": "Unassign MCP integration from agent",
-        "tags": [
-          "agents"
-        ]
+        "tags": ["agents"]
       }
     },
     "/agents/{agentId}/mcp-integrations": {
@@ -3556,9 +3560,7 @@
           }
         },
         "summary": "List MCP integrations assigned to agent",
-        "tags": [
-          "agents"
-        ]
+        "tags": ["agents"]
       }
     },
     "/shares": {
@@ -3601,9 +3603,7 @@
           }
         },
         "summary": "Create a share for an agent",
-        "tags": [
-          "shares"
-        ]
+        "tags": ["shares"]
       },
       "get": {
         "operationId": "SharesController_getShares",
@@ -3624,11 +3624,7 @@
             "in": "query",
             "description": "Type of the entity",
             "schema": {
-              "enum": [
-                "agent",
-                "prompt",
-                "skill"
-              ],
+              "enum": ["agent", "prompt", "skill"],
               "type": "string"
             }
           }
@@ -3658,9 +3654,7 @@
           }
         },
         "summary": "Get shares for an entity",
-        "tags": [
-          "shares"
-        ]
+        "tags": ["shares"]
       }
     },
     "/shares/skills": {
@@ -3700,9 +3694,7 @@
           }
         },
         "summary": "Create a share for a skill",
-        "tags": [
-          "shares"
-        ]
+        "tags": ["shares"]
       }
     },
     "/shares/{id}": {
@@ -3735,9 +3727,7 @@
           }
         },
         "summary": "Delete a share",
-        "tags": [
-          "shares"
-        ]
+        "tags": ["shares"]
       }
     },
     "/teams": {
@@ -3769,9 +3759,7 @@
           }
         },
         "summary": "List all teams for the current organization",
-        "tags": [
-          "teams"
-        ]
+        "tags": ["teams"]
       },
       "post": {
         "operationId": "TeamsController_createTeam",
@@ -3814,9 +3802,7 @@
           }
         },
         "summary": "Create a new team for the current organization",
-        "tags": [
-          "teams"
-        ]
+        "tags": ["teams"]
       }
     },
     "/teams/me": {
@@ -3845,9 +3831,7 @@
           }
         },
         "summary": "List teams the current user is a member of",
-        "tags": [
-          "teams"
-        ]
+        "tags": ["teams"]
       }
     },
     "/teams/{id}": {
@@ -3888,9 +3872,7 @@
           }
         },
         "summary": "Get a team by ID",
-        "tags": [
-          "teams"
-        ]
+        "tags": ["teams"]
       },
       "patch": {
         "operationId": "TeamsController_updateTeam",
@@ -3945,9 +3927,7 @@
           }
         },
         "summary": "Update a team in the current organization",
-        "tags": [
-          "teams"
-        ]
+        "tags": ["teams"]
       },
       "delete": {
         "operationId": "TeamsController_deleteTeam",
@@ -3979,9 +3959,7 @@
           }
         },
         "summary": "Delete a team from the current organization",
-        "tags": [
-          "teams"
-        ]
+        "tags": ["teams"]
       }
     },
     "/teams/{id}/members": {
@@ -4044,9 +4022,7 @@
           }
         },
         "summary": "List members of a team",
-        "tags": [
-          "teams"
-        ]
+        "tags": ["teams"]
       },
       "post": {
         "operationId": "TeamsController_addTeamMember",
@@ -4101,9 +4077,7 @@
           }
         },
         "summary": "Add a user to a team",
-        "tags": [
-          "teams"
-        ]
+        "tags": ["teams"]
       }
     },
     "/teams/{id}/members/{userId}": {
@@ -4145,9 +4119,7 @@
           }
         },
         "summary": "Remove a user from a team",
-        "tags": [
-          "teams"
-        ]
+        "tags": ["teams"]
       }
     },
     "/mcp-integrations/predefined": {
@@ -4183,9 +4155,7 @@
           }
         },
         "summary": "Create a new predefined MCP integration",
-        "tags": [
-          "mcp-integrations"
-        ]
+        "tags": ["mcp-integrations"]
       }
     },
     "/mcp-integrations/custom": {
@@ -4218,9 +4188,7 @@
           }
         },
         "summary": "Create a new custom MCP integration",
-        "tags": [
-          "mcp-integrations"
-        ]
+        "tags": ["mcp-integrations"]
       }
     },
     "/mcp-integrations": {
@@ -4243,9 +4211,7 @@
           }
         },
         "summary": "List all MCP integrations for organization",
-        "tags": [
-          "mcp-integrations"
-        ]
+        "tags": ["mcp-integrations"]
       }
     },
     "/mcp-integrations/predefined/available": {
@@ -4268,9 +4234,7 @@
           }
         },
         "summary": "List available predefined MCP integration configurations",
-        "tags": [
-          "mcp-integrations"
-        ]
+        "tags": ["mcp-integrations"]
       }
     },
     "/mcp-integrations/available": {
@@ -4293,9 +4257,7 @@
           }
         },
         "summary": "List all available (enabled) MCP integrations for organization",
-        "tags": [
-          "mcp-integrations"
-        ]
+        "tags": ["mcp-integrations"]
       }
     },
     "/mcp-integrations/{id}": {
@@ -4328,9 +4290,7 @@
           }
         },
         "summary": "Get MCP integration by ID",
-        "tags": [
-          "mcp-integrations"
-        ]
+        "tags": ["mcp-integrations"]
       },
       "patch": {
         "operationId": "McpIntegrationsController_update",
@@ -4374,9 +4334,7 @@
           }
         },
         "summary": "Update MCP integration",
-        "tags": [
-          "mcp-integrations"
-        ]
+        "tags": ["mcp-integrations"]
       },
       "delete": {
         "operationId": "McpIntegrationsController_delete",
@@ -4400,9 +4358,7 @@
           }
         },
         "summary": "Delete MCP integration",
-        "tags": [
-          "mcp-integrations"
-        ]
+        "tags": ["mcp-integrations"]
       }
     },
     "/mcp-integrations/{id}/enable": {
@@ -4435,9 +4391,7 @@
           }
         },
         "summary": "Enable MCP integration",
-        "tags": [
-          "mcp-integrations"
-        ]
+        "tags": ["mcp-integrations"]
       }
     },
     "/mcp-integrations/{id}/disable": {
@@ -4470,9 +4424,7 @@
           }
         },
         "summary": "Disable MCP integration",
-        "tags": [
-          "mcp-integrations"
-        ]
+        "tags": ["mcp-integrations"]
       }
     },
     "/mcp-integrations/install-from-marketplace": {
@@ -4508,9 +4460,7 @@
           }
         },
         "summary": "Install an MCP integration from the marketplace",
-        "tags": [
-          "mcp-integrations"
-        ]
+        "tags": ["mcp-integrations"]
       }
     },
     "/mcp-integrations/{id}/user-config": {
@@ -4540,9 +4490,7 @@
           }
         },
         "summary": "Get current user config for a marketplace MCP integration",
-        "tags": [
-          "mcp-integrations"
-        ]
+        "tags": ["mcp-integrations"]
       },
       "patch": {
         "operationId": "McpIntegrationsController_setUserConfig",
@@ -4586,9 +4534,7 @@
           }
         },
         "summary": "Set current user config for a marketplace MCP integration",
-        "tags": [
-          "mcp-integrations"
-        ]
+        "tags": ["mcp-integrations"]
       }
     },
     "/mcp-integrations/{id}/validate": {
@@ -4621,9 +4567,7 @@
           }
         },
         "summary": "Validate MCP integration connection",
-        "tags": [
-          "mcp-integrations"
-        ]
+        "tags": ["mcp-integrations"]
       }
     },
     "/marketplace/skills/{identifier}": {
@@ -4656,9 +4600,7 @@
           }
         },
         "summary": "Preview a marketplace skill before installation",
-        "tags": [
-          "marketplace"
-        ]
+        "tags": ["marketplace"]
       }
     },
     "/marketplace/integrations/{identifier}": {
@@ -4691,9 +4633,7 @@
           }
         },
         "summary": "Preview a marketplace integration before installation",
-        "tags": [
-          "marketplace"
-        ]
+        "tags": ["marketplace"]
       }
     },
     "/skills/install-from-marketplace": {
@@ -4726,9 +4666,7 @@
           }
         },
         "summary": "Install a skill from the marketplace",
-        "tags": [
-          "skills"
-        ]
+        "tags": ["skills"]
       }
     },
     "/skills": {
@@ -4764,9 +4702,7 @@
           }
         },
         "summary": "Create a new skill",
-        "tags": [
-          "skills"
-        ]
+        "tags": ["skills"]
       },
       "get": {
         "operationId": "SkillsController_findAll",
@@ -4787,9 +4723,7 @@
           }
         },
         "summary": "Get all skills for the current user",
-        "tags": [
-          "skills"
-        ]
+        "tags": ["skills"]
       }
     },
     "/skills/{id}": {
@@ -4823,9 +4757,7 @@
           }
         },
         "summary": "Get a skill by ID",
-        "tags": [
-          "skills"
-        ]
+        "tags": ["skills"]
       },
       "put": {
         "operationId": "SkillsController_update",
@@ -4873,9 +4805,7 @@
           }
         },
         "summary": "Update a skill",
-        "tags": [
-          "skills"
-        ]
+        "tags": ["skills"]
       },
       "delete": {
         "operationId": "SkillsController_delete",
@@ -4900,9 +4830,7 @@
           }
         },
         "summary": "Delete a skill",
-        "tags": [
-          "skills"
-        ]
+        "tags": ["skills"]
       }
     },
     "/skills/{id}/toggle-active": {
@@ -4936,9 +4864,7 @@
           }
         },
         "summary": "Toggle skill active/inactive status",
-        "tags": [
-          "skills"
-        ]
+        "tags": ["skills"]
       }
     },
     "/skills/{id}/toggle-pinned": {
@@ -5014,9 +4940,7 @@
           }
         },
         "summary": "Get all sources for a skill",
-        "tags": [
-          "skills"
-        ]
+        "tags": ["skills"]
       }
     },
     "/skills/{id}/sources/file": {
@@ -5047,9 +4971,7 @@
                     "description": "The file to upload"
                   }
                 },
-                "required": [
-                  "file"
-                ]
+                "required": ["file"]
               }
             }
           }
@@ -5073,9 +4995,7 @@
           }
         },
         "summary": "Add a file source to a skill",
-        "tags": [
-          "skills"
-        ]
+        "tags": ["skills"]
       }
     },
     "/skills/{id}/sources/{sourceId}": {
@@ -5112,9 +5032,7 @@
           }
         },
         "summary": "Remove a source from a skill",
-        "tags": [
-          "skills"
-        ]
+        "tags": ["skills"]
       }
     },
     "/skills/{skillId}/mcp-integrations/{integrationId}": {
@@ -5161,9 +5079,7 @@
           }
         },
         "summary": "Assign MCP integration to skill",
-        "tags": [
-          "skills"
-        ]
+        "tags": ["skills"]
       },
       "delete": {
         "operationId": "SkillMcpIntegrationsController_unassignMcpIntegration",
@@ -5205,9 +5121,7 @@
           }
         },
         "summary": "Unassign MCP integration from skill",
-        "tags": [
-          "skills"
-        ]
+        "tags": ["skills"]
       }
     },
     "/skills/{skillId}/mcp-integrations": {
@@ -5244,9 +5158,7 @@
           }
         },
         "summary": "List MCP integrations assigned to skill",
-        "tags": [
-          "skills"
-        ]
+        "tags": ["skills"]
       }
     },
     "/runs/send-message": {
@@ -5260,9 +5172,7 @@
             "multipart/form-data": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "threadId"
-                ],
+                "required": ["threadId"],
                 "properties": {
                   "threadId": {
                     "type": "string",
@@ -5421,9 +5331,7 @@
           }
         },
         "summary": "Send a message with optional images and receive streaming response",
-        "tags": [
-          "runs"
-        ]
+        "tags": ["runs"]
       }
     },
     "/super-admin/trials": {
@@ -5461,9 +5369,7 @@
           }
         },
         "summary": "Create a new trial",
-        "tags": [
-          "Super Admin Trials"
-        ]
+        "tags": ["Super Admin Trials"]
       }
     },
     "/super-admin/trials/{orgId}": {
@@ -5500,9 +5406,7 @@
           }
         },
         "summary": "Get a trial by organization ID",
-        "tags": [
-          "Super Admin Trials"
-        ]
+        "tags": ["Super Admin Trials"]
       },
       "put": {
         "description": "Update a trial for an organization. Can update maxMessages and/or messagesSent. Only accessible to users with the super admin system role.",
@@ -5548,9 +5452,7 @@
           }
         },
         "summary": "Update a trial",
-        "tags": [
-          "Super Admin Trials"
-        ]
+        "tags": ["Super Admin Trials"]
       }
     },
     "/usage/config": {
@@ -5571,9 +5473,7 @@
           }
         },
         "summary": "Get usage dashboard configuration",
-        "tags": [
-          "Admin Usage"
-        ]
+        "tags": ["Admin Usage"]
       }
     },
     "/usage/stats": {
@@ -5615,9 +5515,7 @@
           }
         },
         "summary": "Get overall usage statistics",
-        "tags": [
-          "Admin Usage"
-        ]
+        "tags": ["Admin Usage"]
       }
     },
     "/usage/providers": {
@@ -5689,9 +5587,7 @@
           }
         },
         "summary": "Get usage statistics by provider",
-        "tags": [
-          "Admin Usage"
-        ]
+        "tags": ["Admin Usage"]
       }
     },
     "/usage/providers/chart": {
@@ -5749,9 +5645,7 @@
           }
         },
         "summary": "Get provider usage time series aligned by date (chart-ready)",
-        "tags": [
-          "Admin Usage"
-        ]
+        "tags": ["Admin Usage"]
       }
     },
     "/usage/models": {
@@ -5813,9 +5707,7 @@
           }
         },
         "summary": "Get usage distribution by model",
-        "tags": [
-          "Admin Usage"
-        ]
+        "tags": ["Admin Usage"]
       }
     },
     "/usage/users": {
@@ -5879,12 +5771,7 @@
             "in": "query",
             "description": "Field to sort users by. Defaults to tokens.",
             "schema": {
-              "enum": [
-                "tokens",
-                "requests",
-                "lastActivity",
-                "userName"
-              ],
+              "enum": ["tokens", "requests", "lastActivity", "userName"],
               "type": "string"
             }
           },
@@ -5894,10 +5781,7 @@
             "in": "query",
             "description": "Sort order (ascending or descending). Defaults to desc.",
             "schema": {
-              "enum": [
-                "asc",
-                "desc"
-              ],
+              "enum": ["asc", "desc"],
               "type": "string"
             }
           }
@@ -5915,9 +5799,7 @@
           }
         },
         "summary": "Get usage statistics by user",
-        "tags": [
-          "Admin Usage"
-        ]
+        "tags": ["Admin Usage"]
       }
     },
     "/super-admin/usage/{orgId}/config": {
@@ -5947,9 +5829,7 @@
           }
         },
         "summary": "Get usage dashboard configuration for an organization",
-        "tags": [
-          "Super Admin Usage"
-        ]
+        "tags": ["Super Admin Usage"]
       }
     },
     "/super-admin/usage/{orgId}/stats": {
@@ -5996,9 +5876,7 @@
           }
         },
         "summary": "Get overall usage statistics for an organization",
-        "tags": [
-          "Super Admin Usage"
-        ]
+        "tags": ["Super Admin Usage"]
       }
     },
     "/super-admin/usage/{orgId}/models": {
@@ -6061,9 +5939,7 @@
           }
         },
         "summary": "Get usage distribution by model for an organization",
-        "tags": [
-          "Super Admin Usage"
-        ]
+        "tags": ["Super Admin Usage"]
       }
     },
     "/super-admin/usage/{orgId}/providers": {
@@ -6134,9 +6010,7 @@
           }
         },
         "summary": "Get usage statistics by provider for an organization",
-        "tags": [
-          "Super Admin Usage"
-        ]
+        "tags": ["Super Admin Usage"]
       }
     },
     "/super-admin/usage/{orgId}/providers/chart": {
@@ -6199,9 +6073,7 @@
           }
         },
         "summary": "Get provider usage time series for an organization (chart-ready)",
-        "tags": [
-          "Super Admin Usage"
-        ]
+        "tags": ["Super Admin Usage"]
       }
     },
     "/super-admin/usage/{orgId}/users": {
@@ -6263,12 +6135,7 @@
             "required": false,
             "in": "query",
             "schema": {
-              "enum": [
-                "tokens",
-                "requests",
-                "lastActivity",
-                "userName"
-              ],
+              "enum": ["tokens", "requests", "lastActivity", "userName"],
               "type": "string"
             }
           },
@@ -6277,10 +6144,7 @@
             "required": false,
             "in": "query",
             "schema": {
-              "enum": [
-                "asc",
-                "desc"
-              ],
+              "enum": ["asc", "desc"],
               "type": "string"
             }
           }
@@ -6298,9 +6162,7 @@
           }
         },
         "summary": "Get usage statistics by user for an organization",
-        "tags": [
-          "Super Admin Usage"
-        ]
+        "tags": ["Super Admin Usage"]
       }
     },
     "/super-admin/global-usage/providers/chart": {
@@ -6353,9 +6215,7 @@
           }
         },
         "summary": "Get global provider usage time series across all organizations (chart-ready)",
-        "tags": [
-          "Super Admin Global Usage"
-        ]
+        "tags": ["Super Admin Global Usage"]
       }
     },
     "/super-admin/global-usage/models": {
@@ -6400,9 +6260,7 @@
           }
         },
         "summary": "Get global model distribution across all organizations",
-        "tags": [
-          "Super Admin Global Usage"
-        ]
+        "tags": ["Super Admin Global Usage"]
       }
     },
     "/chat-settings/system-prompt": {
@@ -6423,9 +6281,7 @@
           }
         },
         "summary": "Get the user system prompt",
-        "tags": [
-          "Chat Settings"
-        ]
+        "tags": ["Chat Settings"]
       },
       "put": {
         "description": "Creates or replaces the custom system prompt for the authenticated user.",
@@ -6457,9 +6313,7 @@
           }
         },
         "summary": "Set or update the user system prompt",
-        "tags": [
-          "Chat Settings"
-        ]
+        "tags": ["Chat Settings"]
       },
       "delete": {
         "description": "Deletes the custom system prompt for the authenticated user.",
@@ -6471,9 +6325,7 @@
           }
         },
         "summary": "Delete the user system prompt",
-        "tags": [
-          "Chat Settings"
-        ]
+        "tags": ["Chat Settings"]
       }
     },
     "/prompts": {
@@ -6509,9 +6361,7 @@
           }
         },
         "summary": "Create a new prompt",
-        "tags": [
-          "prompts"
-        ]
+        "tags": ["prompts"]
       },
       "get": {
         "operationId": "PromptsController_findAll",
@@ -6535,9 +6385,7 @@
           }
         },
         "summary": "Get all prompts for the current user",
-        "tags": [
-          "prompts"
-        ]
+        "tags": ["prompts"]
       }
     },
     "/prompts/{id}": {
@@ -6574,9 +6422,7 @@
           }
         },
         "summary": "Get a prompt by ID",
-        "tags": [
-          "prompts"
-        ]
+        "tags": ["prompts"]
       },
       "put": {
         "operationId": "PromptsController_update",
@@ -6624,9 +6470,7 @@
           }
         },
         "summary": "Update a prompt",
-        "tags": [
-          "prompts"
-        ]
+        "tags": ["prompts"]
       },
       "delete": {
         "operationId": "PromptsController_delete",
@@ -6654,9 +6498,7 @@
           }
         },
         "summary": "Delete a prompt",
-        "tags": [
-          "prompts"
-        ]
+        "tags": ["prompts"]
       }
     },
     "/transcriptions": {
@@ -6670,9 +6512,7 @@
             "multipart/form-data": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "file"
-                ],
+                "required": ["file"],
                 "properties": {
                   "file": {
                     "type": "string",
@@ -6716,9 +6556,7 @@
           }
         ],
         "summary": "Transcribe audio file to text",
-        "tags": [
-          "transcriptions"
-        ]
+        "tags": ["transcriptions"]
       }
     },
     "/auth/login": {
@@ -6770,9 +6608,7 @@
           }
         },
         "summary": "User login",
-        "tags": [
-          "Authentication"
-        ]
+        "tags": ["Authentication"]
       }
     },
     "/auth/register": {
@@ -6824,9 +6660,7 @@
           }
         },
         "summary": "User registration",
-        "tags": [
-          "Authentication"
-        ]
+        "tags": ["Authentication"]
       }
     },
     "/auth/refresh": {
@@ -6872,9 +6706,7 @@
           }
         ],
         "summary": "Refresh authentication tokens",
-        "tags": [
-          "Authentication"
-        ]
+        "tags": ["Authentication"]
       }
     },
     "/auth/me": {
@@ -6915,9 +6747,7 @@
           }
         },
         "summary": "Get current user information",
-        "tags": [
-          "Authentication"
-        ]
+        "tags": ["Authentication"]
       }
     },
     "/auth/logout": {
@@ -6938,9 +6768,7 @@
           }
         },
         "summary": "User logout",
-        "tags": [
-          "Authentication"
-        ]
+        "tags": ["Authentication"]
       }
     }
   },
@@ -6973,10 +6801,7 @@
             "example": false
           }
         },
-        "required": [
-          "isCloud",
-          "isRegistrationDisabled"
-        ]
+        "required": ["isCloud", "isRegistrationDisabled"]
       },
       "ModelWithConfigResponseDto": {
         "type": "object",
@@ -7093,22 +6918,12 @@
           },
           "hostedIn": {
             "type": "string",
-            "enum": [
-              "DE",
-              "EU",
-              "US",
-              "SELF_HOSTED",
-              "AYUNIS"
-            ],
+            "enum": ["DE", "EU", "US", "SELF_HOSTED", "AYUNIS"],
             "description": "The location where the provider hosts their services",
             "example": "US"
           }
         },
-        "required": [
-          "provider",
-          "displayName",
-          "hostedIn"
-        ]
+        "required": ["provider", "displayName", "hostedIn"]
       },
       "CreatePermittedModelDto": {
         "type": "object",
@@ -7125,9 +6940,7 @@
             "default": false
           }
         },
-        "required": [
-          "modelId"
-        ]
+        "required": ["modelId"]
       },
       "UpdatePermittedModelDto": {
         "type": "object",
@@ -7138,9 +6951,7 @@
             "example": true
           }
         },
-        "required": [
-          "anonymousOnly"
-        ]
+        "required": ["anonymousOnly"]
       },
       "PermittedLanguageModelResponseDto": {
         "type": "object",
@@ -7180,9 +6991,7 @@
           },
           "type": {
             "type": "string",
-            "enum": [
-              "language"
-            ],
+            "enum": ["language"],
             "description": "The type of the model (always language)"
           },
           "isArchived": {
@@ -7233,9 +7042,7 @@
             ]
           }
         },
-        "required": [
-          "permittedLanguageModel"
-        ]
+        "required": ["permittedLanguageModel"]
       },
       "SetUserDefaultModelDto": {
         "type": "object",
@@ -7246,9 +7053,7 @@
             "example": "123e4567-e89b-12d3-a456-426614174000"
           }
         },
-        "required": [
-          "permittedModelId"
-        ]
+        "required": ["permittedModelId"]
       },
       "SetOrgDefaultModelDto": {
         "type": "object",
@@ -7259,9 +7064,7 @@
             "example": "123e4567-e89b-12d3-a456-426614174000"
           }
         },
-        "required": [
-          "permittedModelId"
-        ]
+        "required": ["permittedModelId"]
       },
       "EmbeddingModelEnabledResponseDto": {
         "type": "object",
@@ -7272,9 +7075,7 @@
             "example": true
           }
         },
-        "required": [
-          "isEmbeddingModelEnabled"
-        ]
+        "required": ["isEmbeddingModelEnabled"]
       },
       "PermittedEmbeddingModelResponseDto": {
         "type": "object",
@@ -7314,9 +7115,7 @@
           },
           "type": {
             "type": "string",
-            "enum": [
-              "embedding"
-            ],
+            "enum": ["embedding"],
             "description": "The type of the model (always embedding)"
           },
           "isArchived": {
@@ -7510,11 +7309,7 @@
           "dimensions": {
             "type": "number",
             "description": "The dimensions of the embedding",
-            "enum": [
-              1024,
-              1536,
-              2560
-            ],
+            "enum": [1024, 1536, 2560],
             "example": 1536
           },
           "isArchived": {
@@ -7565,11 +7360,7 @@
           "dimensions": {
             "type": "number",
             "description": "The dimensions of the embedding",
-            "enum": [
-              1024,
-              1536,
-              2560
-            ],
+            "enum": [1024, 1536, 2560],
             "example": 1536
           },
           "isArchived": {
@@ -7625,9 +7416,7 @@
           },
           "type": {
             "type": "string",
-            "enum": [
-              "language"
-            ],
+            "enum": ["language"],
             "description": "The type of the model (always language)"
           },
           "isArchived": {
@@ -7720,9 +7509,7 @@
           },
           "type": {
             "type": "string",
-            "enum": [
-              "embedding"
-            ],
+            "enum": ["embedding"],
             "description": "The type of the model (always embedding)"
           },
           "isArchived": {
@@ -7775,9 +7562,7 @@
             "example": "Acme Corporation"
           }
         },
-        "required": [
-          "name"
-        ]
+        "required": ["name"]
       },
       "SuperAdminOrgResponseDto": {
         "type": "object",
@@ -7800,11 +7585,7 @@
             "example": "2024-01-15T10:30:00Z"
           }
         },
-        "required": [
-          "id",
-          "name",
-          "createdAt"
-        ]
+        "required": ["id", "name", "createdAt"]
       },
       "PaginationDto": {
         "type": "object",
@@ -7825,10 +7606,7 @@
             "example": 150
           }
         },
-        "required": [
-          "limit",
-          "offset"
-        ]
+        "required": ["limit", "offset"]
       },
       "SuperAdminOrgListResponseDto": {
         "type": "object",
@@ -7849,10 +7627,7 @@
             ]
           }
         },
-        "required": [
-          "data",
-          "pagination"
-        ]
+        "required": ["data", "pagination"]
       },
       "UserResponseDto": {
         "type": "object",
@@ -7876,10 +7651,7 @@
           "role": {
             "type": "string",
             "description": "User role",
-            "enum": [
-              "admin",
-              "user"
-            ],
+            "enum": ["admin", "user"],
             "example": "user"
           },
           "orgId": {
@@ -7895,14 +7667,7 @@
             "example": "2024-01-15T10:30:00Z"
           }
         },
-        "required": [
-          "id",
-          "name",
-          "email",
-          "role",
-          "orgId",
-          "createdAt"
-        ]
+        "required": ["id", "name", "email", "role", "orgId", "createdAt"]
       },
       "PaginatedUsersListResponseDto": {
         "type": "object",
@@ -7923,10 +7688,7 @@
             ]
           }
         },
-        "required": [
-          "data",
-          "pagination"
-        ]
+        "required": ["data", "pagination"]
       },
       "UpdateUserRoleDto": {
         "type": "object",
@@ -7934,16 +7696,11 @@
           "role": {
             "type": "string",
             "description": "New role for the user",
-            "enum": [
-              "admin",
-              "user"
-            ],
+            "enum": ["admin", "user"],
             "example": "admin"
           }
         },
-        "required": [
-          "role"
-        ]
+        "required": ["role"]
       },
       "UpdateUserNameDto": {
         "type": "object",
@@ -7956,9 +7713,7 @@
             "maxLength": 100
           }
         },
-        "required": [
-          "name"
-        ]
+        "required": ["name"]
       },
       "UpdatePasswordDto": {
         "type": "object",
@@ -7997,9 +7752,7 @@
             "example": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
           }
         },
-        "required": [
-          "token"
-        ]
+        "required": ["token"]
       },
       "ResendEmailConfirmationDto": {
         "type": "object",
@@ -8011,9 +7764,7 @@
             "format": "email"
           }
         },
-        "required": [
-          "email"
-        ]
+        "required": ["email"]
       },
       "ForgotPasswordDto": {
         "type": "object",
@@ -8024,9 +7775,7 @@
             "example": "user@example.com"
           }
         },
-        "required": [
-          "email"
-        ]
+        "required": ["email"]
       },
       "ResetPasswordDto": {
         "type": "object",
@@ -8049,11 +7798,7 @@
             "minLength": 8
           }
         },
-        "required": [
-          "resetToken",
-          "newPassword",
-          "newPasswordConfirmation"
-        ]
+        "required": ["resetToken", "newPassword", "newPasswordConfirmation"]
       },
       "CreateUserDto": {
         "type": "object",
@@ -8071,10 +7816,7 @@
           "role": {
             "type": "string",
             "description": "Role for the user",
-            "enum": [
-              "admin",
-              "user"
-            ],
+            "enum": ["admin", "user"],
             "example": "user"
           },
           "sendPasswordResetEmail": {
@@ -8083,12 +7825,7 @@
             "example": true
           }
         },
-        "required": [
-          "email",
-          "name",
-          "role",
-          "sendPasswordResetEmail"
-        ]
+        "required": ["email", "name", "role", "sendPasswordResetEmail"]
       },
       "CreateInviteDto": {
         "type": "object",
@@ -8101,17 +7838,11 @@
           "role": {
             "type": "string",
             "description": "Role to assign to the invited user",
-            "enum": [
-              "admin",
-              "user"
-            ],
+            "enum": ["admin", "user"],
             "example": "user"
           }
         },
-        "required": [
-          "email",
-          "role"
-        ]
+        "required": ["email", "role"]
       },
       "CreateInviteResponseDto": {
         "type": "object",
@@ -8123,9 +7854,7 @@
             "nullable": true
           }
         },
-        "required": [
-          "url"
-        ]
+        "required": ["url"]
       },
       "CreateBulkInviteItemDto": {
         "type": "object",
@@ -8138,17 +7867,11 @@
           "role": {
             "type": "string",
             "description": "Role to assign to the invited user",
-            "enum": [
-              "admin",
-              "user"
-            ],
+            "enum": ["admin", "user"],
             "example": "user"
           }
         },
-        "required": [
-          "email",
-          "role"
-        ]
+        "required": ["email", "role"]
       },
       "CreateBulkInvitesDto": {
         "type": "object",
@@ -8163,9 +7886,7 @@
             }
           }
         },
-        "required": [
-          "invites"
-        ]
+        "required": ["invites"]
       },
       "BulkInviteResultDto": {
         "type": "object",
@@ -8178,10 +7899,7 @@
           "role": {
             "type": "string",
             "description": "Role assigned to the invited user",
-            "enum": [
-              "admin",
-              "user"
-            ],
+            "enum": ["admin", "user"],
             "example": "user"
           },
           "success": {
@@ -8243,12 +7961,7 @@
             }
           }
         },
-        "required": [
-          "totalCount",
-          "successCount",
-          "failureCount",
-          "results"
-        ]
+        "required": ["totalCount", "successCount", "failureCount", "results"]
       },
       "InviteResponseDto": {
         "type": "object",
@@ -8267,20 +7980,13 @@
           "role": {
             "type": "string",
             "description": "Role assigned to the invited user",
-            "enum": [
-              "admin",
-              "user"
-            ],
+            "enum": ["admin", "user"],
             "example": "user"
           },
           "status": {
             "type": "string",
             "description": "Current status of the invite",
-            "enum": [
-              "pending",
-              "accepted",
-              "expired"
-            ],
+            "enum": ["pending", "accepted", "expired"],
             "example": "pending"
           },
           "sentDate": {
@@ -8302,14 +8008,7 @@
             "example": "2023-12-02T15:30:00Z"
           }
         },
-        "required": [
-          "id",
-          "email",
-          "role",
-          "status",
-          "sentDate",
-          "expiresAt"
-        ]
+        "required": ["id", "email", "role", "status", "sentDate", "expiresAt"]
       },
       "PaginatedInvitesListResponseDto": {
         "type": "object",
@@ -8330,10 +8029,7 @@
             ]
           }
         },
-        "required": [
-          "data",
-          "pagination"
-        ]
+        "required": ["data", "pagination"]
       },
       "InviteDetailResponseDto": {
         "type": "object",
@@ -8352,20 +8048,13 @@
           "role": {
             "type": "string",
             "description": "Role assigned to the invited user",
-            "enum": [
-              "admin",
-              "user"
-            ],
+            "enum": ["admin", "user"],
             "example": "user"
           },
           "status": {
             "type": "string",
             "description": "Current status of the invite",
-            "enum": [
-              "pending",
-              "accepted",
-              "expired"
-            ],
+            "enum": ["pending", "accepted", "expired"],
             "example": "pending"
           },
           "sentDate": {
@@ -8454,11 +8143,7 @@
             "format": "uuid"
           }
         },
-        "required": [
-          "inviteId",
-          "email",
-          "orgId"
-        ]
+        "required": ["inviteId", "email", "orgId"]
       },
       "DeleteAllPendingInvitesResponseDto": {
         "type": "object",
@@ -8468,9 +8153,7 @@
             "description": "Number of invites deleted"
           }
         },
-        "required": [
-          "deletedCount"
-        ]
+        "required": ["deletedCount"]
       },
       "ActiveSubscriptionResponseDto": {
         "type": "object",
@@ -8591,10 +8274,7 @@
           "renewalCycle": {
             "type": "string",
             "description": "Renewal cycle of the subscription",
-            "enum": [
-              "monthly",
-              "yearly"
-            ],
+            "enum": ["monthly", "yearly"],
             "example": "monthly"
           },
           "renewalCycleAnchor": {
@@ -8710,6 +8390,17 @@
           "country"
         ]
       },
+      "ActiveSubscriptionResponseDto": {
+        "type": "object",
+        "properties": {
+          "hasActiveSubscription": {
+            "type": "boolean",
+            "description": "Whether the organization has an active subscription",
+            "example": true
+          }
+        },
+        "required": ["hasActiveSubscription"]
+      },
       "UpdateBillingInfoDto": {
         "type": "object",
         "properties": {
@@ -8758,6 +8449,17 @@
           "country"
         ]
       },
+      "PriceResponseDto": {
+        "type": "object",
+        "properties": {
+          "pricePerSeatMonthly": {
+            "type": "number",
+            "description": "Current price per seat per month in the configured currency",
+            "example": 29.99
+          }
+        },
+        "required": ["pricePerSeatMonthly"]
+      },
       "UpdateSeatsDto": {
         "type": "object",
         "properties": {}
@@ -8792,11 +8494,7 @@
             "example": "2024-01-01T00:00:00.000Z"
           }
         },
-        "required": [
-          "objectName",
-          "size",
-          "etag"
-        ]
+        "required": ["objectName", "size", "etag"]
       },
       "RetrieveUrlDto": {
         "type": "object",
@@ -8807,9 +8505,7 @@
             "example": "https://example.com/article"
           }
         },
-        "required": [
-          "url"
-        ]
+        "required": ["url"]
       },
       "CreateThreadDto": {
         "type": "object",
@@ -8856,9 +8552,7 @@
             "type": "string",
             "description": "Role of the message sender",
             "example": "user",
-            "enum": [
-              "user"
-            ]
+            "enum": ["user"]
           },
           "content": {
             "type": "array",
@@ -8875,13 +8569,7 @@
             }
           }
         },
-        "required": [
-          "id",
-          "threadId",
-          "createdAt",
-          "role",
-          "content"
-        ]
+        "required": ["id", "threadId", "createdAt", "role", "content"]
       },
       "SystemMessageResponseDto": {
         "type": "object",
@@ -8905,9 +8593,7 @@
             "type": "string",
             "description": "Role of the message sender",
             "example": "system",
-            "enum": [
-              "system"
-            ]
+            "enum": ["system"]
           },
           "content": {
             "type": "array",
@@ -8917,13 +8603,7 @@
             }
           }
         },
-        "required": [
-          "id",
-          "threadId",
-          "createdAt",
-          "role",
-          "content"
-        ]
+        "required": ["id", "threadId", "createdAt", "role", "content"]
       },
       "AssistantMessageResponseDto": {
         "type": "object",
@@ -8947,9 +8627,7 @@
             "type": "string",
             "description": "Role of the message sender",
             "example": "assistant",
-            "enum": [
-              "assistant"
-            ]
+            "enum": ["assistant"]
           },
           "content": {
             "type": "array",
@@ -8969,13 +8647,7 @@
             }
           }
         },
-        "required": [
-          "id",
-          "threadId",
-          "createdAt",
-          "role",
-          "content"
-        ]
+        "required": ["id", "threadId", "createdAt", "role", "content"]
       },
       "ToolResultMessageResponseDto": {
         "type": "object",
@@ -8999,9 +8671,7 @@
             "type": "string",
             "description": "Role of the message sender",
             "example": "tool",
-            "enum": [
-              "tool"
-            ]
+            "enum": ["tool"]
           },
           "content": {
             "type": "array",
@@ -9011,13 +8681,7 @@
             }
           }
         },
-        "required": [
-          "id",
-          "threadId",
-          "createdAt",
-          "role",
-          "content"
-        ]
+        "required": ["id", "threadId", "createdAt", "role", "content"]
       },
       "TextMessageContentResponseDto": {
         "type": "object",
@@ -9026,13 +8690,7 @@
             "type": "string",
             "description": "Type of the message content",
             "example": "text",
-            "enum": [
-              "text",
-              "tool_use",
-              "tool_result",
-              "thinking",
-              "image"
-            ]
+            "enum": ["text", "tool_use", "tool_result", "thinking", "image"]
           },
           "text": {
             "type": "string",
@@ -9045,10 +8703,7 @@
             "example": false
           }
         },
-        "required": [
-          "type",
-          "text"
-        ]
+        "required": ["type", "text"]
       },
       "ToolUseMessageContentResponseDto": {
         "type": "object",
@@ -9057,13 +8712,7 @@
             "type": "string",
             "description": "Type of the message content",
             "example": "text",
-            "enum": [
-              "text",
-              "tool_use",
-              "tool_result",
-              "thinking",
-              "image"
-            ]
+            "enum": ["text", "tool_use", "tool_result", "thinking", "image"]
           },
           "id": {
             "type": "string",
@@ -9084,12 +8733,7 @@
             }
           }
         },
-        "required": [
-          "type",
-          "id",
-          "name",
-          "params"
-        ]
+        "required": ["type", "id", "name", "params"]
       },
       "ToolResultMessageContentResponseDto": {
         "type": "object",
@@ -9098,13 +8742,7 @@
             "type": "string",
             "description": "Type of the message content",
             "example": "text",
-            "enum": [
-              "text",
-              "tool_use",
-              "tool_result",
-              "thinking",
-              "image"
-            ]
+            "enum": ["text", "tool_use", "tool_result", "thinking", "image"]
           },
           "toolId": {
             "type": "string",
@@ -9122,12 +8760,7 @@
             "example": "The current temperature in New York is 22°C with partly cloudy skies."
           }
         },
-        "required": [
-          "type",
-          "toolId",
-          "toolName",
-          "result"
-        ]
+        "required": ["type", "toolId", "toolName", "result"]
       },
       "ThinkingMessageContentResponseDto": {
         "type": "object",
@@ -9136,13 +8769,7 @@
             "type": "string",
             "description": "Type of the message content",
             "example": "text",
-            "enum": [
-              "text",
-              "tool_use",
-              "tool_result",
-              "thinking",
-              "image"
-            ]
+            "enum": ["text", "tool_use", "tool_result", "thinking", "image"]
           },
           "thinking": {
             "type": "string",
@@ -9150,10 +8777,7 @@
             "example": "I am thinking about the best way to help you."
           }
         },
-        "required": [
-          "type",
-          "thinking"
-        ]
+        "required": ["type", "thinking"]
       },
       "ImageMessageContentResponseDto": {
         "type": "object",
@@ -9162,13 +8786,7 @@
             "type": "string",
             "description": "Type of the message content",
             "example": "text",
-            "enum": [
-              "text",
-              "tool_use",
-              "tool_result",
-              "thinking",
-              "image"
-            ]
+            "enum": ["text", "tool_use", "tool_result", "thinking", "image"]
           },
           "imageUrl": {
             "type": "string",
@@ -9181,10 +8799,7 @@
             "example": "Screenshot of the reported issue"
           }
         },
-        "required": [
-          "type",
-          "imageUrl"
-        ]
+        "required": ["type", "imageUrl"]
       },
       "ModelResponseDto": {
         "type": "object",
@@ -9248,19 +8863,12 @@
           "type": {
             "type": "string",
             "description": "Type of source",
-            "enum": [
-              "text",
-              "data"
-            ]
+            "enum": ["text", "data"]
           },
           "createdBy": {
             "type": "string",
             "description": "Creator of the source",
-            "enum": [
-              "user",
-              "llm",
-              "system"
-            ]
+            "enum": ["user", "llm", "system"]
           },
           "createdAt": {
             "type": "string",
@@ -9299,19 +8907,12 @@
           "type": {
             "type": "string",
             "description": "Type of source",
-            "enum": [
-              "text",
-              "data"
-            ]
+            "enum": ["text", "data"]
           },
           "createdBy": {
             "type": "string",
             "description": "Creator of the source",
-            "enum": [
-              "user",
-              "llm",
-              "system"
-            ]
+            "enum": ["user", "llm", "system"]
           },
           "createdAt": {
             "type": "string",
@@ -9324,19 +8925,12 @@
           "textType": {
             "type": "string",
             "description": "Type of text",
-            "enum": [
-              "file",
-              "web"
-            ]
+            "enum": ["file", "web"]
           },
           "fileType": {
             "type": "string",
             "description": "Type of file",
-            "enum": [
-              "pdf",
-              "docx",
-              "pptx"
-            ]
+            "enum": ["pdf", "docx", "pptx"]
           }
         },
         "required": [
@@ -9369,19 +8963,12 @@
           "type": {
             "type": "string",
             "description": "Type of source",
-            "enum": [
-              "text",
-              "data"
-            ]
+            "enum": ["text", "data"]
           },
           "createdBy": {
             "type": "string",
             "description": "Creator of the source",
-            "enum": [
-              "user",
-              "llm",
-              "system"
-            ]
+            "enum": ["user", "llm", "system"]
           },
           "createdAt": {
             "type": "string",
@@ -9394,10 +8981,7 @@
           "textType": {
             "type": "string",
             "description": "Type of text",
-            "enum": [
-              "file",
-              "web"
-            ]
+            "enum": ["file", "web"]
           },
           "url": {
             "type": "string",
@@ -9434,19 +9018,12 @@
           "type": {
             "type": "string",
             "description": "Type of source",
-            "enum": [
-              "text",
-              "data"
-            ]
+            "enum": ["text", "data"]
           },
           "createdBy": {
             "type": "string",
             "description": "Creator of the source",
-            "enum": [
-              "user",
-              "llm",
-              "system"
-            ]
+            "enum": ["user", "llm", "system"]
           },
           "createdAt": {
             "type": "string",
@@ -9459,9 +9036,7 @@
           "dataType": {
             "type": "string",
             "description": "Type of data",
-            "enum": [
-              "csv"
-            ]
+            "enum": ["csv"]
           },
           "data": {
             "type": "object",
@@ -9618,12 +9193,7 @@
             "example": false
           }
         },
-        "required": [
-          "id",
-          "createdAt",
-          "updatedAt",
-          "isAnonymous"
-        ]
+        "required": ["id", "createdAt", "updatedAt", "isAnonymous"]
       },
       "GetThreadsResponseDto": {
         "type": "object",
@@ -9644,10 +9214,7 @@
             ]
           }
         },
-        "required": [
-          "data",
-          "pagination"
-        ]
+        "required": ["data", "pagination"]
       },
       "UpdateThreadTitleDto": {
         "type": "object",
@@ -9660,9 +9227,7 @@
             "maxLength": 200
           }
         },
-        "required": [
-          "title"
-        ]
+        "required": ["title"]
       },
       "ToolAssignmentDto": {
         "type": "object",
@@ -9698,9 +9263,7 @@
             "format": "uuid"
           }
         },
-        "required": [
-          "type"
-        ]
+        "required": ["type"]
       },
       "CreateAgentDto": {
         "type": "object",
@@ -9731,12 +9294,7 @@
             }
           }
         },
-        "required": [
-          "name",
-          "instructions",
-          "modelId",
-          "toolAssignments"
-        ]
+        "required": ["name", "instructions", "modelId", "toolAssignments"]
       },
       "ToolResponseDto": {
         "type": "object",
@@ -9766,9 +9324,7 @@
             ]
           }
         },
-        "required": [
-          "type"
-        ]
+        "required": ["type"]
       },
       "AgentSourceResponseDto": {
         "type": "object",
@@ -9794,18 +9350,10 @@
             "type": "string",
             "description": "The type of source",
             "example": "file",
-            "enum": [
-              "file",
-              "url"
-            ]
+            "enum": ["file", "url"]
           }
         },
-        "required": [
-          "id",
-          "sourceId",
-          "name",
-          "type"
-        ]
+        "required": ["id", "sourceId", "name", "type"]
       },
       "AgentResponseDto": {
         "type": "object",
@@ -9919,11 +9467,7 @@
             "format": "uuid"
           }
         },
-        "required": [
-          "name",
-          "instructions",
-          "modelId"
-        ]
+        "required": ["name", "instructions", "modelId"]
       },
       "McpIntegrationResponseDto": {
         "type": "object",
@@ -9941,11 +9485,7 @@
           "type": {
             "type": "string",
             "description": "Type of integration",
-            "enum": [
-              "predefined",
-              "custom",
-              "marketplace"
-            ],
+            "enum": ["predefined", "custom", "marketplace"],
             "example": "predefined"
           },
           "slug": {
@@ -9971,12 +9511,7 @@
           "authMethod": {
             "type": "string",
             "description": "Authentication method used",
-            "enum": [
-              "NO_AUTH",
-              "BEARER_TOKEN",
-              "CUSTOM_HEADER",
-              "OAUTH"
-            ],
+            "enum": ["NO_AUTH", "BEARER_TOKEN", "CUSTOM_HEADER", "OAUTH"],
             "example": "BEARER_TOKEN"
           },
           "authHeaderName": {
@@ -9992,12 +9527,7 @@
           "connectionStatus": {
             "type": "string",
             "description": "Connection status of the integration",
-            "enum": [
-              "connected",
-              "disconnected",
-              "error",
-              "unknown"
-            ],
+            "enum": ["connected", "disconnected", "error", "unknown"],
             "example": "connected"
           },
           "lastConnectionError": {
@@ -10041,6 +9571,14 @@
             "type": "boolean",
             "description": "Whether this marketplace integration has user-level config fields",
             "example": false
+          },
+          "orgConfigValues": {
+            "type": "object",
+            "description": "Current org-level config values for marketplace integrations. Non-secret fields contain plaintext values. Secret fields are masked with \"••••••\".",
+            "example": {
+              "endpointUrl": "https://example.com/api",
+              "apiToken": "••••••"
+            }
           }
         },
         "required": [
@@ -10061,11 +9599,7 @@
           "entityType": {
             "type": "string",
             "description": "Type of entity being shared",
-            "enum": [
-              "agent",
-              "prompt",
-              "skill"
-            ]
+            "enum": ["agent", "prompt", "skill"]
           },
           "agentId": {
             "type": "string",
@@ -10078,10 +9612,7 @@
             "format": "uuid"
           }
         },
-        "required": [
-          "entityType",
-          "agentId"
-        ]
+        "required": ["entityType", "agentId"]
       },
       "ShareResponseDto": {
         "type": "object",
@@ -10094,11 +9625,7 @@
           "entityType": {
             "type": "string",
             "description": "Type of entity being shared",
-            "enum": [
-              "agent",
-              "prompt",
-              "skill"
-            ]
+            "enum": ["agent", "prompt", "skill"]
           },
           "entityId": {
             "type": "string",
@@ -10108,10 +9635,7 @@
           "scopeType": {
             "type": "string",
             "description": "Type of share scope (organization, user, or team)",
-            "enum": [
-              "org",
-              "team"
-            ]
+            "enum": ["org", "team"]
           },
           "ownerId": {
             "type": "string",
@@ -10154,11 +9678,7 @@
           "entityType": {
             "type": "string",
             "description": "Type of entity being shared",
-            "enum": [
-              "agent",
-              "prompt",
-              "skill"
-            ]
+            "enum": ["agent", "prompt", "skill"]
           },
           "skillId": {
             "type": "string",
@@ -10171,10 +9691,7 @@
             "format": "uuid"
           }
         },
-        "required": [
-          "entityType",
-          "skillId"
-        ]
+        "required": ["entityType", "skillId"]
       },
       "CreateTeamDto": {
         "type": "object",
@@ -10185,9 +9702,7 @@
             "example": "Engineering"
           }
         },
-        "required": [
-          "name"
-        ]
+        "required": ["name"]
       },
       "UpdateTeamDto": {
         "type": "object",
@@ -10198,9 +9713,7 @@
             "example": "Engineering"
           }
         },
-        "required": [
-          "name"
-        ]
+        "required": ["name"]
       },
       "TeamResponseDto": {
         "type": "object",
@@ -10233,13 +9746,7 @@
             "example": "2024-01-15T10:30:00.000Z"
           }
         },
-        "required": [
-          "id",
-          "name",
-          "orgId",
-          "createdAt",
-          "updatedAt"
-        ]
+        "required": ["id", "name", "orgId", "createdAt", "updatedAt"]
       },
       "TeamMemberResponseDto": {
         "type": "object",
@@ -10267,10 +9774,7 @@
           "userRole": {
             "type": "string",
             "description": "The role of the team member in the organization",
-            "enum": [
-              "admin",
-              "user"
-            ],
+            "enum": ["admin", "user"],
             "example": "user"
           },
           "joinedAt": {
@@ -10308,10 +9812,7 @@
             ]
           }
         },
-        "required": [
-          "data",
-          "pagination"
-        ]
+        "required": ["data", "pagination"]
       },
       "AddTeamMemberDto": {
         "type": "object",
@@ -10322,9 +9823,7 @@
             "example": "550e8400-e29b-41d4-a716-446655440001"
           }
         },
-        "required": [
-          "userId"
-        ]
+        "required": ["userId"]
       },
       "ListTeamMembersQueryDto": {
         "type": "object",
@@ -10349,11 +9848,7 @@
           "name": {
             "type": "string",
             "description": "The name/type of the credential field",
-            "enum": [
-              "token",
-              "clientId",
-              "clientSecret"
-            ],
+            "enum": ["token", "clientId", "clientSecret"],
             "example": "token"
           },
           "value": {
@@ -10362,10 +9857,7 @@
             "example": "sk_test_123abc"
           }
         },
-        "required": [
-          "name",
-          "value"
-        ]
+        "required": ["name", "value"]
       },
       "CreatePredefinedIntegrationDto": {
         "type": "object",
@@ -10374,11 +9866,7 @@
             "type": "string",
             "description": "The predefined integration slug",
             "example": "TEST",
-            "enum": [
-              "TEST",
-              "LOCABOO",
-              "LEGAL_CODES"
-            ]
+            "enum": ["TEST", "LOCABOO", "LEGAL_CODES"]
           },
           "configValues": {
             "description": "List of config values for credential fields",
@@ -10400,10 +9888,7 @@
             "default": true
           }
         },
-        "required": [
-          "slug",
-          "configValues"
-        ]
+        "required": ["slug", "configValues"]
       },
       "CreateCustomIntegrationDto": {
         "type": "object",
@@ -10423,12 +9908,7 @@
           "authMethod": {
             "type": "string",
             "description": "Authentication method for the MCP server",
-            "enum": [
-              "NO_AUTH",
-              "BEARER_TOKEN",
-              "CUSTOM_HEADER",
-              "OAUTH"
-            ],
+            "enum": ["NO_AUTH", "BEARER_TOKEN", "CUSTOM_HEADER", "OAUTH"],
             "example": "CUSTOM_HEADER",
             "nullable": true
           },
@@ -10449,10 +9929,7 @@
             "default": true
           }
         },
-        "required": [
-          "name",
-          "serverUrl"
-        ]
+        "required": ["name", "serverUrl"]
       },
       "CredentialFieldDto": {
         "type": "object",
@@ -10465,11 +9942,7 @@
           "type": {
             "type": "string",
             "description": "Input type (text or password)",
-            "enum": [
-              "token",
-              "clientId",
-              "clientSecret"
-            ],
+            "enum": ["token", "clientId", "clientSecret"],
             "example": "token"
           },
           "required": {
@@ -10483,11 +9956,7 @@
             "example": "Your Locaboo 3 API token will be used to authenticate with Locaboo 4"
           }
         },
-        "required": [
-          "label",
-          "type",
-          "required"
-        ]
+        "required": ["label", "type", "required"]
       },
       "PredefinedConfigResponseDto": {
         "type": "object",
@@ -10510,12 +9979,7 @@
           "authType": {
             "type": "string",
             "description": "Authentication method for this integration",
-            "enum": [
-              "NO_AUTH",
-              "BEARER_TOKEN",
-              "API_KEY",
-              "OAUTH"
-            ],
+            "enum": ["NO_AUTH", "BEARER_TOKEN", "API_KEY", "OAUTH"],
             "example": "BEARER_TOKEN"
           },
           "authHeaderName": {
@@ -10531,12 +9995,7 @@
             }
           }
         },
-        "required": [
-          "slug",
-          "displayName",
-          "description",
-          "authType"
-        ]
+        "required": ["slug", "displayName", "description", "authType"]
       },
       "UpdateMcpIntegrationDto": {
         "type": "object",
@@ -10562,6 +10021,13 @@
             "type": "boolean",
             "description": "Whether tools from this integration may return PII data that should be anonymized in anonymous mode.",
             "example": true
+          },
+          "orgConfigValues": {
+            "type": "object",
+            "description": "Org-level config values for marketplace integrations. For secret fields, omit or send empty string to keep the existing value.",
+            "example": {
+              "endpointUrl": "https://example.com/api"
+            }
           }
         }
       },
@@ -10589,10 +10055,7 @@
             "example": false
           }
         },
-        "required": [
-          "identifier",
-          "orgConfigValues"
-        ]
+        "required": ["identifier", "orgConfigValues"]
       },
       "UserConfigResponseDto": {
         "type": "object",
@@ -10613,10 +10076,7 @@
             }
           }
         },
-        "required": [
-          "hasConfig",
-          "configValues"
-        ]
+        "required": ["hasConfig", "configValues"]
       },
       "SetUserConfigDto": {
         "type": "object",
@@ -10632,9 +10092,7 @@
             }
           }
         },
-        "required": [
-          "configValues"
-        ]
+        "required": ["configValues"]
       },
       "ValidationResponseDto": {
         "type": "object",
@@ -10659,10 +10117,7 @@
             "example": "Connection timeout"
           }
         },
-        "required": [
-          "valid",
-          "capabilities"
-        ]
+        "required": ["valid", "capabilities"]
       },
       "MarketplaceSkillResponseDto": {
         "type": "object",
@@ -10750,11 +10205,7 @@
           "type": {
             "type": "string",
             "description": "Field type",
-            "enum": [
-              "text",
-              "url",
-              "secret"
-            ]
+            "enum": ["text", "url", "secret"]
           },
           "headerName": {
             "type": "string",
@@ -10781,12 +10232,7 @@
             "nullable": true
           }
         },
-        "required": [
-          "key",
-          "label",
-          "type",
-          "required"
-        ]
+        "required": ["key", "label", "type", "required"]
       },
       "MarketplaceIntegrationConfigSchemaDto": {
         "type": "object",
@@ -10810,11 +10256,7 @@
             }
           }
         },
-        "required": [
-          "authType",
-          "orgFields",
-          "userFields"
-        ]
+        "required": ["authType", "orgFields", "userFields"]
       },
       "MarketplaceIntegrationResponseDto": {
         "type": "object",
@@ -10901,9 +10343,7 @@
             "example": "meeting-summarizer"
           }
         },
-        "required": [
-          "identifier"
-        ]
+        "required": ["identifier"]
       },
       "SkillResponseDto": {
         "type": "object",
@@ -11009,11 +10449,7 @@
             "example": true
           }
         },
-        "required": [
-          "name",
-          "shortDescription",
-          "instructions"
-        ]
+        "required": ["name", "shortDescription", "instructions"]
       },
       "UpdateSkillDto": {
         "type": "object",
@@ -11036,11 +10472,7 @@
             "example": "You are a legal research assistant. When activated, search through the attached legal databases..."
           }
         },
-        "required": [
-          "name",
-          "shortDescription",
-          "instructions"
-        ]
+        "required": ["name", "shortDescription", "instructions"]
       },
       "SkillSourceResponseDto": {
         "type": "object",
@@ -11062,11 +10494,7 @@
             "example": "file"
           }
         },
-        "required": [
-          "id",
-          "name",
-          "type"
-        ]
+        "required": ["id", "name", "type"]
       },
       "MessageContentResponseDto": {
         "type": "object",
@@ -11075,18 +10503,10 @@
             "type": "string",
             "description": "Type of the message content",
             "example": "text",
-            "enum": [
-              "text",
-              "tool_use",
-              "tool_result",
-              "thinking",
-              "image"
-            ]
+            "enum": ["text", "tool_use", "tool_result", "thinking", "image"]
           }
         },
-        "required": [
-          "type"
-        ]
+        "required": ["type"]
       },
       "RunSessionResponseDto": {
         "type": "object",
@@ -11095,9 +10515,7 @@
             "type": "string",
             "description": "Response type identifier",
             "example": "session",
-            "enum": [
-              "session"
-            ]
+            "enum": ["session"]
           },
           "success": {
             "type": "boolean",
@@ -11120,11 +10538,7 @@
             "example": "2024-01-01T12:00:00.000Z"
           }
         },
-        "required": [
-          "type",
-          "threadId",
-          "timestamp"
-        ]
+        "required": ["type", "threadId", "timestamp"]
       },
       "RunMessageResponseDto": {
         "type": "object",
@@ -11133,9 +10547,7 @@
             "type": "string",
             "description": "Response type identifier",
             "example": "message",
-            "enum": [
-              "message"
-            ]
+            "enum": ["message"]
           },
           "message": {
             "description": "The message data",
@@ -11165,12 +10577,7 @@
             "example": "2024-01-01T12:00:00.000Z"
           }
         },
-        "required": [
-          "type",
-          "message",
-          "threadId",
-          "timestamp"
-        ]
+        "required": ["type", "message", "threadId", "timestamp"]
       },
       "RunErrorResponseDto": {
         "type": "object",
@@ -11179,9 +10586,7 @@
             "type": "string",
             "description": "Response type identifier",
             "example": "error",
-            "enum": [
-              "error"
-            ]
+            "enum": ["error"]
           },
           "message": {
             "type": "string",
@@ -11211,12 +10616,7 @@
             }
           }
         },
-        "required": [
-          "type",
-          "message",
-          "threadId",
-          "timestamp"
-        ]
+        "required": ["type", "message", "threadId", "timestamp"]
       },
       "RunThreadResponseDto": {
         "type": "object",
@@ -11225,9 +10625,7 @@
             "type": "string",
             "description": "Response type identifier",
             "example": "thread",
-            "enum": [
-              "thread"
-            ]
+            "enum": ["thread"]
           },
           "threadId": {
             "type": "string",
@@ -11238,9 +10636,7 @@
             "type": "string",
             "description": "Type of thread update",
             "example": "title_updated",
-            "enum": [
-              "title_updated"
-            ]
+            "enum": ["title_updated"]
           },
           "title": {
             "type": "string",
@@ -11253,13 +10649,7 @@
             "example": "2024-01-01T12:00:00.000Z"
           }
         },
-        "required": [
-          "type",
-          "threadId",
-          "updateType",
-          "title",
-          "timestamp"
-        ]
+        "required": ["type", "threadId", "updateType", "title", "timestamp"]
       },
       "TextInput": {
         "type": "object",
@@ -11267,9 +10657,7 @@
           "type": {
             "type": "string",
             "description": "The type of input",
-            "enum": [
-              "text"
-            ],
+            "enum": ["text"],
             "example": "text"
           },
           "text": {
@@ -11278,10 +10666,7 @@
             "example": "What is the weather forecast for New York tomorrow?"
           }
         },
-        "required": [
-          "type",
-          "text"
-        ]
+        "required": ["type", "text"]
       },
       "ToolResultInput": {
         "type": "object",
@@ -11289,9 +10674,7 @@
           "type": {
             "type": "string",
             "description": "The type of input",
-            "enum": [
-              "tool_result"
-            ],
+            "enum": ["tool_result"],
             "example": "tool_result"
           },
           "toolId": {
@@ -11310,12 +10693,7 @@
             "example": "{\"location\":\"New York\",\"forecast\":\"Partly cloudy with a high of 75°F and a low of 60°F\",\"precipitation\":\"20%\"}"
           }
         },
-        "required": [
-          "type",
-          "toolId",
-          "toolName",
-          "result"
-        ]
+        "required": ["type", "toolId", "toolName", "result"]
       },
       "SendMessageDto": {
         "type": "object",
@@ -11362,9 +10740,7 @@
             "default": true
           }
         },
-        "required": [
-          "threadId"
-        ]
+        "required": ["threadId"]
       },
       "SuperAdminTrialResponseDto": {
         "type": "object",
@@ -11444,10 +10820,7 @@
             "minimum": 1
           }
         },
-        "required": [
-          "orgId",
-          "maxMessages"
-        ]
+        "required": ["orgId", "maxMessages"]
       },
       "UpdateTrialRequestDto": {
         "type": "object",
@@ -11475,9 +10848,7 @@
             "example": true
           }
         },
-        "required": [
-          "isSelfHosted"
-        ]
+        "required": ["isSelfHosted"]
       },
       "UsageStatsResponseDto": {
         "type": "object",
@@ -11504,11 +10875,7 @@
           },
           "topModels": {
             "description": "List of the most frequently used model names, ordered by usage",
-            "example": [
-              "gpt-4",
-              "claude-3-sonnet",
-              "gpt-3.5-turbo"
-            ],
+            "example": ["gpt-4", "claude-3-sonnet", "gpt-3.5-turbo"],
             "type": "array",
             "items": {
               "type": "string"
@@ -11540,11 +10907,7 @@
             "description": "Number of requests at this point"
           }
         },
-        "required": [
-          "date",
-          "tokens",
-          "requests"
-        ]
+        "required": ["date", "tokens", "requests"]
       },
       "ProviderUsageDto": {
         "type": "object",
@@ -11605,9 +10968,7 @@
             }
           }
         },
-        "required": [
-          "providers"
-        ]
+        "required": ["providers"]
       },
       "ProviderValuesDto": {
         "type": "object",
@@ -11655,10 +11016,7 @@
             ]
           }
         },
-        "required": [
-          "date",
-          "values"
-        ]
+        "required": ["date", "values"]
       },
       "ProviderUsageChartResponseDto": {
         "type": "object",
@@ -11671,9 +11029,7 @@
             }
           }
         },
-        "required": [
-          "timeSeries"
-        ]
+        "required": ["timeSeries"]
       },
       "ModelDistributionDto": {
         "type": "object",
@@ -11741,9 +11097,7 @@
             }
           }
         },
-        "required": [
-          "models"
-        ]
+        "required": ["models"]
       },
       "UserUsageDto": {
         "type": "object",
@@ -11808,10 +11162,7 @@
             ]
           }
         },
-        "required": [
-          "data",
-          "pagination"
-        ]
+        "required": ["data", "pagination"]
       },
       "UserSystemPromptResponseDto": {
         "type": "object",
@@ -11823,9 +11174,7 @@
             "nullable": true
           }
         },
-        "required": [
-          "systemPrompt"
-        ]
+        "required": ["systemPrompt"]
       },
       "UpsertUserSystemPromptDto": {
         "type": "object",
@@ -11837,9 +11186,7 @@
             "maxLength": 10000
           }
         },
-        "required": [
-          "systemPrompt"
-        ]
+        "required": ["systemPrompt"]
       },
       "CreatePromptDto": {
         "type": "object",
@@ -11857,10 +11204,7 @@
             "example": "You are a helpful assistant that helps with project planning. Please provide detailed step-by-step guidance for managing projects effectively."
           }
         },
-        "required": [
-          "title",
-          "content"
-        ]
+        "required": ["title", "content"]
       },
       "PromptResponseDto": {
         "type": "object",
@@ -11925,10 +11269,7 @@
             "example": "You are an expert project planning assistant. Provide comprehensive guidance for project management, including risk assessment and timeline optimization."
           }
         },
-        "required": [
-          "title",
-          "content"
-        ]
+        "required": ["title", "content"]
       },
       "TranscriptionResponseDto": {
         "type": "object",
@@ -11939,9 +11280,7 @@
             "example": "Hello, this is a test transcription."
           }
         },
-        "required": [
-          "text"
-        ]
+        "required": ["text"]
       },
       "LoginDto": {
         "type": "object",
@@ -11957,10 +11296,7 @@
             "example": "password123"
           }
         },
-        "required": [
-          "email",
-          "password"
-        ]
+        "required": ["email", "password"]
       },
       "SuccessResponseDto": {
         "type": "object",
@@ -11971,9 +11307,7 @@
             "example": true
           }
         },
-        "required": [
-          "success"
-        ]
+        "required": ["success"]
       },
       "ErrorResponseDto": {
         "type": "object",
@@ -11984,9 +11318,7 @@
             "example": "Authentication failed"
           }
         },
-        "required": [
-          "message"
-        ]
+        "required": ["message"]
       },
       "RegisterDto": {
         "type": "object",
@@ -12036,19 +11368,13 @@
           "role": {
             "type": "string",
             "description": "User role",
-            "enum": [
-              "admin",
-              "user"
-            ],
+            "enum": ["admin", "user"],
             "example": "user"
           },
           "systemRole": {
             "type": "string",
             "description": "User system role",
-            "enum": [
-              "customer",
-              "super_admin"
-            ],
+            "enum": ["customer", "super_admin"],
             "example": "super_admin"
           },
           "name": {
@@ -12057,12 +11383,7 @@
             "example": "John Doe"
           }
         },
-        "required": [
-          "email",
-          "role",
-          "systemRole",
-          "name"
-        ]
+        "required": ["email", "role", "systemRole", "name"]
       }
     }
   }

--- a/ayunis-core-frontend/src/shared/constants/secret-mask.ts
+++ b/ayunis-core-frontend/src/shared/constants/secret-mask.ts
@@ -1,0 +1,5 @@
+/**
+ * Sentinel value used to mask secret fields in API responses.
+ * Must match the backend's SECRET_MASK constant.
+ */
+export const SECRET_MASK = '••••••';

--- a/ayunis-core-frontend/src/shared/locales/de/admin-settings-integrations.json
+++ b/ayunis-core-frontend/src/shared/locales/de/admin-settings-integrations.json
@@ -130,6 +130,8 @@
       "credentials": "Anmeldedaten (Optional)",
       "credentialsPlaceholder": "Leer lassen, um bestehende beizubehalten",
       "noCredentialsMessage": "Diese Integration verwendet keine Authentifizierungsdaten.",
+      "configDescription": "Aktualisieren Sie die Konfigurationswerte für diese Marketplace-Integration.",
+      "secretPlaceholder": "Leer lassen, um aktuellen Wert beizubehalten",
       "cancel": "Abbrechen",
       "updating": "Wird aktualisiert...",
       "update": "Aktualisieren"

--- a/ayunis-core-frontend/src/shared/locales/de/admin-settings-integrations.json
+++ b/ayunis-core-frontend/src/shared/locales/de/admin-settings-integrations.json
@@ -50,7 +50,8 @@
       "retry": "Erneut versuchen",
       "addPredefined": "Vordefinierte hinzufügen",
       "addCustom": "Benutzerdefinierte hinzufügen",
-      "add": "Integration hinzufügen"
+      "add": "Integration hinzufügen",
+      "browseMarketplace": "Marktplatz durchsuchen"
     },
     "card": {
       "openMenu": "Menü öffnen",
@@ -60,7 +61,9 @@
       "credentials": "Anmeldedaten",
       "enableIntegration": "Integration aktivieren",
       "testing": "Teste...",
-      "testConnection": "Verbindung testen"
+      "testConnection": "Verbindung testen",
+      "marketplace": "Marktplatz",
+      "userConfig": "Meine Konfiguration"
     },
     "list": {
       "noIntegrationsTitle": "Noch keine Integrationen",
@@ -138,10 +141,20 @@
       "deleting": "Wird gelöscht...",
       "delete": "Löschen"
     },
+    "userConfig": {
+      "title": "Benutzerkonfiguration — {{name}}",
+      "description": "Legen Sie Ihre persönliche Konfiguration für diese Integration fest. Diese Werte überschreiben die Organisationsstandards.",
+      "save": "Speichern",
+      "saving": "Wird gespeichert…",
+      "cancel": "Abbrechen",
+      "success": "Benutzerkonfiguration erfolgreich gespeichert",
+      "error": "Benutzerkonfiguration konnte nicht gespeichert werden. Bitte versuchen Sie es erneut."
+    },
     "helpers": {
       "type": {
         "predefined": "Vordefiniert",
-        "custom": "Benutzerdefiniert"
+        "custom": "Benutzerdefiniert",
+        "marketplace": "Marktplatz"
       },
       "authMethod": {
         "none": "Keine",

--- a/ayunis-core-frontend/src/shared/locales/de/install-integration.json
+++ b/ayunis-core-frontend/src/shared/locales/de/install-integration.json
@@ -36,6 +36,7 @@
       "title": "Administratorzugriff erforderlich",
       "description": "Sie benötigen Administratorrechte, um Integrationen zu installieren."
     },
+    "alreadyInstalled": "Diese Integration ist bereits in Ihrer Organisation installiert.",
     "generic": "Beim Installieren der Integration ist ein Fehler aufgetreten. Bitte versuchen Sie es erneut."
   }
 }

--- a/ayunis-core-frontend/src/shared/locales/de/install-integration.json
+++ b/ayunis-core-frontend/src/shared/locales/de/install-integration.json
@@ -1,0 +1,41 @@
+{
+  "title": "Integration installieren",
+  "detail": {
+    "installNote": "Diese Integration wird Ihrer Organisation hinzugefügt. Konfigurieren Sie die erforderlichen Felder unten.",
+    "zeroConfigNote": "Diese Integration erfordert keine zusätzliche Konfiguration und wird sofort installiert.",
+    "adminOnly": "Nur Organisationsadministratoren können Integrationen installieren."
+  },
+  "field": {
+    "required": "Erforderlich",
+    "optional": "Optional"
+  },
+  "action": {
+    "install": "Integration installieren",
+    "installing": "Wird installiert…",
+    "cancel": "Abbrechen",
+    "backToIntegrations": "Zurück zu Integrationen"
+  },
+  "success": "Integration erfolgreich installiert!",
+  "error": {
+    "missingIdentifier": {
+      "title": "Fehlende Integrations-Kennung",
+      "description": "Es wurde keine Integrations-Kennung angegeben. Bitte verwenden Sie einen gültigen Installationslink aus dem Marktplatz."
+    },
+    "notFound": {
+      "title": "Integration nicht gefunden",
+      "description": "Die angeforderte Integration konnte im Marktplatz nicht gefunden werden. Sie wurde möglicherweise entfernt oder deaktiviert."
+    },
+    "fetchFailed": {
+      "title": "Integration konnte nicht geladen werden",
+      "description": "Die Integrationsdetails konnten nicht vom Marktplatz geladen werden. Bitte versuchen Sie es später erneut."
+    },
+    "unavailable": "Der Marktplatz ist derzeit nicht verfügbar. Bitte versuchen Sie es später erneut.",
+    "oauthNotSupported": "OAuth-Integrationen werden noch nicht unterstützt.",
+    "missingRequiredConfig": "Bitte füllen Sie alle erforderlichen Felder aus.",
+    "adminRequired": {
+      "title": "Administratorzugriff erforderlich",
+      "description": "Sie benötigen Administratorrechte, um Integrationen zu installieren."
+    },
+    "generic": "Beim Installieren der Integration ist ein Fehler aufgetreten. Bitte versuchen Sie es erneut."
+  }
+}

--- a/ayunis-core-frontend/src/shared/locales/en/admin-settings-integrations.json
+++ b/ayunis-core-frontend/src/shared/locales/en/admin-settings-integrations.json
@@ -50,7 +50,8 @@
       "retry": "Retry",
       "addPredefined": "Add Predefined",
       "addCustom": "Add Custom",
-      "add": "Add Integration"
+      "add": "Add Integration",
+      "browseMarketplace": "Browse Marketplace"
     },
     "card": {
       "openMenu": "Open menu",
@@ -60,7 +61,9 @@
       "credentials": "Credentials",
       "enableIntegration": "Enable integration",
       "testing": "Testing...",
-      "testConnection": "Test Connection"
+      "testConnection": "Test Connection",
+      "marketplace": "Marketplace",
+      "userConfig": "My Config"
     },
     "list": {
       "noIntegrationsTitle": "No integrations yet",
@@ -137,10 +140,20 @@
       "deleting": "Deleting...",
       "delete": "Delete"
     },
+    "userConfig": {
+      "title": "User Configuration — {{name}}",
+      "description": "Set your personal configuration for this integration. These values override organization defaults.",
+      "save": "Save",
+      "saving": "Saving…",
+      "cancel": "Cancel",
+      "success": "User configuration saved successfully",
+      "error": "Failed to save user configuration. Please try again."
+    },
     "helpers": {
       "type": {
         "predefined": "Predefined",
-        "custom": "Custom"
+        "custom": "Custom",
+        "marketplace": "Marketplace"
       },
       "authMethod": {
         "none": "None",

--- a/ayunis-core-frontend/src/shared/locales/en/admin-settings-integrations.json
+++ b/ayunis-core-frontend/src/shared/locales/en/admin-settings-integrations.json
@@ -129,6 +129,8 @@
       "credentials": "Credentials (Optional)",
       "credentialsPlaceholder": "Leave empty to keep existing",
       "noCredentialsMessage": "This integration does not use authentication credentials.",
+      "configDescription": "Update the configuration values for this marketplace integration.",
+      "secretPlaceholder": "Leave empty to keep current value",
       "cancel": "Cancel",
       "updating": "Updating...",
       "update": "Update"

--- a/ayunis-core-frontend/src/shared/locales/en/install-integration.json
+++ b/ayunis-core-frontend/src/shared/locales/en/install-integration.json
@@ -1,0 +1,41 @@
+{
+  "title": "Install Integration",
+  "detail": {
+    "installNote": "This integration will be added to your organization. Configure the required fields below.",
+    "zeroConfigNote": "This integration requires no additional configuration and will be installed immediately.",
+    "adminOnly": "Only organization admins can install integrations."
+  },
+  "field": {
+    "required": "Required",
+    "optional": "Optional"
+  },
+  "action": {
+    "install": "Install Integration",
+    "installing": "Installing…",
+    "cancel": "Cancel",
+    "backToIntegrations": "Back to Integrations"
+  },
+  "success": "Integration installed successfully!",
+  "error": {
+    "missingIdentifier": {
+      "title": "Missing Integration Identifier",
+      "description": "No integration identifier was provided. Please use a valid install link from the marketplace."
+    },
+    "notFound": {
+      "title": "Integration Not Found",
+      "description": "The requested integration could not be found in the marketplace. It may have been removed or unpublished."
+    },
+    "fetchFailed": {
+      "title": "Unable to Load Integration",
+      "description": "Could not load integration details from the marketplace. Please try again later."
+    },
+    "unavailable": "The marketplace is currently unavailable. Please try again later.",
+    "oauthNotSupported": "OAuth integrations are not yet supported.",
+    "missingRequiredConfig": "Please fill in all required fields.",
+    "adminRequired": {
+      "title": "Admin Access Required",
+      "description": "You need administrator privileges to install integrations."
+    },
+    "generic": "Something went wrong while installing the integration. Please try again."
+  }
+}

--- a/ayunis-core-frontend/src/shared/locales/en/install-integration.json
+++ b/ayunis-core-frontend/src/shared/locales/en/install-integration.json
@@ -36,6 +36,7 @@
       "title": "Admin Access Required",
       "description": "You need administrator privileges to install integrations."
     },
+    "alreadyInstalled": "This integration is already installed in your organization.",
     "generic": "Something went wrong while installing the integration. Please try again."
   }
 }

--- a/ayunis-core-frontend/src/shared/ui/config-field-input/ConfigFieldInput.tsx
+++ b/ayunis-core-frontend/src/shared/ui/config-field-input/ConfigFieldInput.tsx
@@ -1,0 +1,60 @@
+import { Input } from '@/shared/ui/shadcn/input';
+import { PasswordInput } from '@/shared/ui/shadcn/password-input';
+import { Label } from '@/shared/ui/shadcn/label';
+import type { MarketplaceIntegrationConfigFieldDto } from '@/shared/api/generated/ayunisCoreAPI.schemas';
+
+interface ConfigFieldInputProps {
+  field: MarketplaceIntegrationConfigFieldDto;
+  value: string;
+  onChange: (value: string) => void;
+  disabled: boolean;
+  /** Override placeholder for secret fields (e.g. "Leave blank to keep existing") */
+  secretPlaceholder?: string;
+  /** Prefix for the input id attribute (default: "config-field") */
+  idPrefix?: string;
+}
+
+export function ConfigFieldInput({
+  field,
+  value,
+  onChange,
+  disabled,
+  secretPlaceholder,
+  idPrefix = 'config-field',
+}: ConfigFieldInputProps) {
+  const inputId = `${idPrefix}-${field.key}`;
+  const placeholder =
+    field.type === 'secret' && secretPlaceholder
+      ? secretPlaceholder
+      : (field.help ?? '');
+
+  return (
+    <div className="space-y-2">
+      <Label htmlFor={inputId}>
+        {field.label}
+        {field.required && <span className="ml-1 text-destructive">*</span>}
+      </Label>
+      {field.type === 'secret' ? (
+        <PasswordInput
+          id={inputId}
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          disabled={disabled}
+          placeholder={placeholder}
+        />
+      ) : (
+        <Input
+          id={inputId}
+          type={field.type === 'url' ? 'url' : 'text'}
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          disabled={disabled}
+          placeholder={field.help ?? ''}
+        />
+      )}
+      {field.help && (
+        <p className="text-xs text-muted-foreground">{field.help}</p>
+      )}
+    </div>
+  );
+}

--- a/ayunis-core-frontend/src/shared/ui/config-field-input/index.ts
+++ b/ayunis-core-frontend/src/shared/ui/config-field-input/index.ts
@@ -1,0 +1,1 @@
+export { ConfigFieldInput } from './ConfigFieldInput';


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Touches persistence and core MCP connection/auth wiring (new tables/columns, new header resolution, user-scoped overrides), so regressions could break tool execution or config security if misapplied.
> 
> **Overview**
> Adds **marketplace integrations** alongside marketplace skills: the generated marketplace client now supports `/api/integrations` and the backend exposes `GET /marketplace/integrations/:identifier` via a new `GetMarketplaceIntegrationUseCase` (with dedicated not-found error + DTO).
> 
> Introduces **installable marketplace MCP integrations**: DB migration adds `marketplace_identifier`, `config_schema`, `org_config_values` to `mcp_integrations` plus a new `mcp_integration_user_configs` table; MCP domain/factories gain `MarketplaceMcpIntegration`, install flow (`InstallMarketplaceIntegrationUseCase`) merges fixed schema values, validates required fields, encrypts secrets, rejects OAuth for now, prevents duplicates, and validates connection via a new `ConnectionValidationService`.
> 
> Updates MCP execution paths to support **header-based config + optional per-user overrides** by changing `McpConnectionConfig` to `headers`, extending `McpClientService` to resolve headers from marketplace schemas (including decrypting secrets), threading `userId` through capability discovery/tool execution/resource/prompt calls, and ensuring integration deletion also removes user configs. Also adds `IsStringRecord` validator with tests and removes the unused `force_ocr` param from the generated Docling client.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 868fa1a68565ed0c3620123719bc74bc1bc5ca9c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->