### PR TITLE
feat: add stackit as openai-compatible model provider

### DIFF
--- a/ayunis-core-backend/src/config/models.config.ts
+++ b/ayunis-core-backend/src/config/models.config.ts
@@ -40,4 +40,8 @@ export const modelsConfig = registerAs('models', () => ({
   gemini: {
     apiKey: process.env.GEMINI_API_KEY,
   },
+  stackit: {
+    apiKey: process.env.STACKIT_TOKEN,
+    baseURL: 'https://api.openai-compat.model-serving.eu01.onstackit.cloud/v1',
+  },
 }));

--- a/ayunis-core-backend/src/db/migrations/1771435357941-AddStackitToModelProviderEnum.ts
+++ b/ayunis-core-backend/src/db/migrations/1771435357941-AddStackitToModelProviderEnum.ts
@@ -1,0 +1,40 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddStackitToModelProviderEnum1771435357941 implements MigrationInterface {
+    name = 'AddStackitToModelProviderEnum1771435357941'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`DROP INDEX "public"."IDX_7c11834d93fa8eaf208a48d66a"`);
+        await queryRunner.query(`ALTER TYPE "public"."models_provider_enum" RENAME TO "models_provider_enum_old"`);
+        await queryRunner.query(`CREATE TYPE "public"."models_provider_enum" AS ENUM('openai', 'anthropic', 'bedrock', 'mistral', 'ollama', 'synaforce', 'ayunis', 'otc', 'azure', 'gemini', 'stackit')`);
+        await queryRunner.query(`ALTER TABLE "models" ALTER COLUMN "provider" TYPE "public"."models_provider_enum" USING "provider"::"text"::"public"."models_provider_enum"`);
+        await queryRunner.query(`DROP TYPE "public"."models_provider_enum_old"`);
+        await queryRunner.query(`DROP INDEX "public"."IDX_a84595aeab2b176022e1ef6b0c"`);
+        await queryRunner.query(`DROP INDEX "public"."IDX_4eca2a1e72564bfdec6c88dcf3"`);
+        await queryRunner.query(`ALTER TYPE "public"."usage_provider_enum" RENAME TO "usage_provider_enum_old"`);
+        await queryRunner.query(`CREATE TYPE "public"."usage_provider_enum" AS ENUM('openai', 'anthropic', 'bedrock', 'mistral', 'ollama', 'synaforce', 'ayunis', 'otc', 'azure', 'gemini', 'stackit')`);
+        await queryRunner.query(`ALTER TABLE "usage" ALTER COLUMN "provider" TYPE "public"."usage_provider_enum" USING "provider"::"text"::"public"."usage_provider_enum"`);
+        await queryRunner.query(`DROP TYPE "public"."usage_provider_enum_old"`);
+        await queryRunner.query(`CREATE UNIQUE INDEX "IDX_7c11834d93fa8eaf208a48d66a" ON "models" ("name", "provider") `);
+        await queryRunner.query(`CREATE INDEX "IDX_a84595aeab2b176022e1ef6b0c" ON "usage" ("organizationId", "provider", "createdAt") `);
+        await queryRunner.query(`CREATE INDEX "IDX_4eca2a1e72564bfdec6c88dcf3" ON "usage" ("provider", "createdAt") `);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`DROP INDEX "public"."IDX_4eca2a1e72564bfdec6c88dcf3"`);
+        await queryRunner.query(`DROP INDEX "public"."IDX_a84595aeab2b176022e1ef6b0c"`);
+        await queryRunner.query(`DROP INDEX "public"."IDX_7c11834d93fa8eaf208a48d66a"`);
+        await queryRunner.query(`CREATE TYPE "public"."usage_provider_enum_old" AS ENUM('anthropic', 'ayunis', 'azure', 'bedrock', 'gemini', 'mistral', 'ollama', 'openai', 'otc', 'synaforce')`);
+        await queryRunner.query(`ALTER TABLE "usage" ALTER COLUMN "provider" TYPE "public"."usage_provider_enum_old" USING "provider"::"text"::"public"."usage_provider_enum_old"`);
+        await queryRunner.query(`DROP TYPE "public"."usage_provider_enum"`);
+        await queryRunner.query(`ALTER TYPE "public"."usage_provider_enum_old" RENAME TO "usage_provider_enum"`);
+        await queryRunner.query(`CREATE INDEX "IDX_4eca2a1e72564bfdec6c88dcf3" ON "usage" ("createdAt", "provider") `);
+        await queryRunner.query(`CREATE INDEX "IDX_a84595aeab2b176022e1ef6b0c" ON "usage" ("createdAt", "organizationId", "provider") `);
+        await queryRunner.query(`CREATE TYPE "public"."models_provider_enum_old" AS ENUM('anthropic', 'ayunis', 'azure', 'bedrock', 'gemini', 'mistral', 'ollama', 'openai', 'otc', 'synaforce')`);
+        await queryRunner.query(`ALTER TABLE "models" ALTER COLUMN "provider" TYPE "public"."models_provider_enum_old" USING "provider"::"text"::"public"."models_provider_enum_old"`);
+        await queryRunner.query(`DROP TYPE "public"."models_provider_enum"`);
+        await queryRunner.query(`ALTER TYPE "public"."models_provider_enum_old" RENAME TO "models_provider_enum"`);
+        await queryRunner.query(`CREATE UNIQUE INDEX "IDX_7c11834d93fa8eaf208a48d66a" ON "models" ("name", "provider") `);
+    }
+
+}

--- a/ayunis-core-backend/src/domain/models/SUMMARY.md
+++ b/ayunis-core-backend/src/domain/models/SUMMARY.md
@@ -1,6 +1,6 @@
 AI Models
 Multi-provider language and embedding model management system
 
-Models manages AI model definitions across providers (Ollama, Mistral, Anthropic, OpenAI), organization-level model permissions, user and org default selections, and inference routing for language and embedding workloads.
+Models manages AI model definitions across providers (Ollama, Mistral, Anthropic, OpenAI, STACKIT), organization-level model permissions, user and org default selections, and inference routing for language and embedding workloads.
 
 The models module is the central registry for AI model configuration. The abstract `Model` entity splits into `LanguageModel` (with pricing, context window, tool choice support) and `EmbeddingModel` (with dimensions). `PermittedModel` controls which models an organization can use, with default and anonymous-only flags. `ModelProviderInfoEntity` describes provider metadata and hosting locations. Key use cases include CRUD for models and permitted models, managing org/user default model preferences, checking model permissions, retrieving provider info, and routing inference requests. The module integrates with **agents** and **threads** for model selection, **runs** for inference execution, **rag** for embedding model access, and **usage** for tracking token consumption and costs per provider.

--- a/ayunis-core-backend/src/domain/models/application/registry/model-provider-info.registry.ts
+++ b/ayunis-core-backend/src/domain/models/application/registry/model-provider-info.registry.ts
@@ -72,6 +72,12 @@ const MODEL_PROVIDER_CONFIGS: ModelProviderConfig[] = [
     hostedIn: ModelProviderLocation.US,
     configKey: 'models.gemini.apiKey',
   },
+  {
+    provider: ModelProvider.STACKIT,
+    displayName: 'Stackit',
+    hostedIn: ModelProviderLocation.DE,
+    configKey: 'models.stackit.apiKey',
+  },
 ];
 
 @Injectable()

--- a/ayunis-core-backend/src/domain/models/application/use-cases/get-available-models/get-available-models.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/get-available-models/get-available-models.use-case.spec.ts
@@ -50,6 +50,7 @@ describe('GetAvailableModelsUseCase', () => {
           [ModelProvider.AYUNIS]: 'models.ayunis.baseURL',
           [ModelProvider.AZURE]: 'models.azure.apiKey',
           [ModelProvider.GEMINI]: 'models.gemini.apiKey',
+          [ModelProvider.STACKIT]: 'models.stackit.apiKey',
         };
         return configMap[provider];
       }),

--- a/ayunis-core-backend/src/domain/models/domain/value-objects/model-provider.enum.ts
+++ b/ayunis-core-backend/src/domain/models/domain/value-objects/model-provider.enum.ts
@@ -9,4 +9,5 @@ export enum ModelProvider {
   OTC = 'otc',
   AZURE = 'azure',
   GEMINI = 'gemini',
+  STACKIT = 'stackit',
 }

--- a/ayunis-core-backend/src/domain/models/infrastructure/inference/stackit.inference.ts
+++ b/ayunis-core-backend/src/domain/models/infrastructure/inference/stackit.inference.ts
@@ -1,0 +1,15 @@
+import { Injectable } from '@nestjs/common';
+import { BaseOpenAIChatInferenceHandler } from './base-openai-chat.inference';
+import { ConfigService } from '@nestjs/config';
+import OpenAI from 'openai';
+
+@Injectable()
+export class StackitInferenceHandler extends BaseOpenAIChatInferenceHandler {
+  constructor(private readonly configService: ConfigService) {
+    super();
+    this.client = new OpenAI({
+      apiKey: this.configService.get('models.stackit.apiKey'),
+      baseURL: this.configService.get('models.stackit.baseURL'),
+    });
+  }
+}

--- a/ayunis-core-backend/src/domain/models/infrastructure/stream-inference/stackit.stream-inference.ts
+++ b/ayunis-core-backend/src/domain/models/infrastructure/stream-inference/stackit.stream-inference.ts
@@ -1,0 +1,15 @@
+import { Injectable } from '@nestjs/common';
+import { BaseOpenAIChatStreamInferenceHandler } from './base-openai-chat.stream-inference';
+import { ConfigService } from '@nestjs/config';
+import OpenAI from 'openai';
+
+@Injectable()
+export class StackitStreamInferenceHandler extends BaseOpenAIChatStreamInferenceHandler {
+  constructor(private readonly configService: ConfigService) {
+    super();
+    this.client = new OpenAI({
+      apiKey: this.configService.get('models.stackit.apiKey'),
+      baseURL: this.configService.get('models.stackit.baseURL'),
+    });
+  }
+}

--- a/ayunis-core-backend/src/domain/models/models.module.ts
+++ b/ayunis-core-backend/src/domain/models/models.module.ts
@@ -72,6 +72,8 @@ import { AzureInferenceHandler } from './infrastructure/inference/azure.inferenc
 import { AzureStreamInferenceHandler } from './infrastructure/stream-inference/azure.stream-inference';
 import { GeminiInferenceHandler } from './infrastructure/inference/gemini.inference';
 import { GeminiStreamInferenceHandler } from './infrastructure/stream-inference/gemini.stream-inference';
+import { StackitInferenceHandler } from './infrastructure/inference/stackit.inference';
+import { StackitStreamInferenceHandler } from './infrastructure/stream-inference/stackit.stream-inference';
 import { ConfigService } from '@nestjs/config';
 import { StorageModule } from '../storage/storage.module';
 import { MessagesModule } from '../messages/messages.module';
@@ -119,6 +121,8 @@ import { MessagesModule } from '../messages/messages.module';
     AzureStreamInferenceHandler,
     GeminiInferenceHandler,
     GeminiStreamInferenceHandler,
+    StackitInferenceHandler,
+    StackitStreamInferenceHandler,
     MockStreamInferenceHandler,
     MockInferenceHandler,
     {
@@ -134,6 +138,7 @@ import { MessagesModule } from '../messages/messages.module';
         bedrockHandler: BedrockStreamInferenceHandler,
         azureHandler: AzureStreamInferenceHandler,
         geminiHandler: GeminiStreamInferenceHandler,
+        stackitHandler: StackitStreamInferenceHandler,
         mockHandler: MockStreamInferenceHandler,
         configService: ConfigService,
       ) => {
@@ -148,6 +153,7 @@ import { MessagesModule } from '../messages/messages.module';
         registry.register(ModelProvider.OTC, otcHandler);
         registry.register(ModelProvider.AZURE, azureHandler);
         registry.register(ModelProvider.GEMINI, geminiHandler);
+        registry.register(ModelProvider.STACKIT, stackitHandler);
         registry.registerMockHandler(mockHandler);
         return registry;
       },
@@ -162,6 +168,7 @@ import { MessagesModule } from '../messages/messages.module';
         BedrockStreamInferenceHandler,
         AzureStreamInferenceHandler,
         GeminiStreamInferenceHandler,
+        StackitStreamInferenceHandler,
         MockStreamInferenceHandler,
         ConfigService,
       ],
@@ -179,6 +186,7 @@ import { MessagesModule } from '../messages/messages.module';
         otcHandler: OtcInferenceHandler,
         azureHandler: AzureInferenceHandler,
         geminiHandler: GeminiInferenceHandler,
+        stackitHandler: StackitInferenceHandler,
         mockHandler: MockInferenceHandler,
         configService: ConfigService,
       ) => {
@@ -193,6 +201,7 @@ import { MessagesModule } from '../messages/messages.module';
         registry.register(ModelProvider.OTC, otcHandler);
         registry.register(ModelProvider.AZURE, azureHandler);
         registry.register(ModelProvider.GEMINI, geminiHandler);
+        registry.register(ModelProvider.STACKIT, stackitHandler);
         registry.registerMockHandler(mockHandler);
         return registry;
       },
@@ -207,6 +216,7 @@ import { MessagesModule } from '../messages/messages.module';
         OtcInferenceHandler,
         AzureInferenceHandler,
         GeminiInferenceHandler,
+        StackitInferenceHandler,
         MockInferenceHandler,
         ConfigService,
       ],

--- a/ayunis-core-backend/src/iam/teams/application/use-cases/find-all-user-ids-by-team-id/find-all-user-ids-by-team-id.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/teams/application/use-cases/find-all-user-ids-by-team-id/find-all-user-ids-by-team-id.use-case.spec.ts
@@ -43,9 +43,9 @@ describe('FindAllUserIdsByTeamIdUseCase', () => {
     );
 
     expect(result).toEqual([userId1, userId2]);
-    expect(
-      teamMembersRepository.findAllUserIdsByTeamId,
-    ).toHaveBeenCalledWith(teamId);
+    expect(teamMembersRepository.findAllUserIdsByTeamId).toHaveBeenCalledWith(
+      teamId,
+    );
   });
 
   it('should return empty array when team has no members', async () => {

--- a/ayunis-core-frontend/src/features/models/constants/providers.ts
+++ b/ayunis-core-frontend/src/features/models/constants/providers.ts
@@ -18,6 +18,7 @@ const PROVIDER_LABELS: Record<string, string> = {
   ayunis: 'Ayunis',
   azure: 'MS Azure',
   gemini: 'Gemini',
+  stackit: 'Stackit',
 };
 
 /**

--- a/ayunis-core-frontend/src/pages/admin-settings/model-settings/ui/ModelTypeCard.tsx
+++ b/ayunis-core-frontend/src/pages/admin-settings/model-settings/ui/ModelTypeCard.tsx
@@ -36,6 +36,7 @@ function getHostingPriority(
     case 'ayunis':
     case 'synaforce':
     case 'ollama':
+    case 'stackit':
       return 0; // DE
     case 'mistral':
     case 'bedrock':

--- a/ayunis-core-frontend/src/pages/super-admin-settings/org/ui/ModelTypeCard.tsx
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/org/ui/ModelTypeCard.tsx
@@ -37,6 +37,7 @@ function getHostingPriority(
     case 'ayunis':
     case 'synaforce':
     case 'ollama':
+    case 'stackit':
       return 0; // DE
     case 'mistral':
     case 'bedrock':

--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
@@ -30,6 +30,7 @@ export const ModelWithConfigResponseDtoProvider = {
   otc: 'otc',
   azure: 'azure',
   gemini: 'gemini',
+  stackit: 'stackit',
 } as const;
 
 export interface ModelWithConfigResponseDto {
@@ -85,6 +86,7 @@ export const ModelProviderInfoResponseDtoProvider = {
   otc: 'otc',
   azure: 'azure',
   gemini: 'gemini',
+  stackit: 'stackit',
 } as const;
 
 /**
@@ -141,6 +143,7 @@ export const PermittedLanguageModelResponseDtoProvider = {
   otc: 'otc',
   azure: 'azure',
   gemini: 'gemini',
+  stackit: 'stackit',
 } as const;
 
 /**
@@ -226,6 +229,7 @@ export const PermittedEmbeddingModelResponseDtoProvider = {
   otc: 'otc',
   azure: 'azure',
   gemini: 'gemini',
+  stackit: 'stackit',
 } as const;
 
 /**
@@ -279,6 +283,7 @@ export const CreateLanguageModelRequestDtoProvider = {
   otc: 'otc',
   azure: 'azure',
   gemini: 'gemini',
+  stackit: 'stackit',
 } as const;
 
 export interface CreateLanguageModelRequestDto {
@@ -318,6 +323,7 @@ export const UpdateLanguageModelRequestDtoProvider = {
   otc: 'otc',
   azure: 'azure',
   gemini: 'gemini',
+  stackit: 'stackit',
 } as const;
 
 export interface UpdateLanguageModelRequestDto {
@@ -357,6 +363,7 @@ export const CreateEmbeddingModelRequestDtoProvider = {
   otc: 'otc',
   azure: 'azure',
   gemini: 'gemini',
+  stackit: 'stackit',
 } as const;
 
 /**
@@ -403,6 +410,7 @@ export const UpdateEmbeddingModelRequestDtoProvider = {
   otc: 'otc',
   azure: 'azure',
   gemini: 'gemini',
+  stackit: 'stackit',
 } as const;
 
 /**
@@ -449,6 +457,7 @@ export const LanguageModelResponseDtoProvider = {
   otc: 'otc',
   azure: 'azure',
   gemini: 'gemini',
+  stackit: 'stackit',
 } as const;
 
 /**
@@ -507,6 +516,7 @@ export const EmbeddingModelResponseDtoProvider = {
   otc: 'otc',
   azure: 'azure',
   gemini: 'gemini',
+  stackit: 'stackit',
 } as const;
 
 /**
@@ -2542,6 +2552,7 @@ export const ProviderUsageDtoProvider = {
   otc: 'otc',
   azure: 'azure',
   gemini: 'gemini',
+  stackit: 'stackit',
 } as const;
 
 export interface ProviderUsageDto {
@@ -2607,6 +2618,7 @@ export const ModelDistributionDtoProvider = {
   otc: 'otc',
   azure: 'azure',
   gemini: 'gemini',
+  stackit: 'stackit',
 } as const;
 
 export interface ModelDistributionDto {

--- a/ayunis-core-frontend/src/shared/api/openapi-schema.json
+++ b/ayunis-core-frontend/src/shared/api/openapi-schema.json
@@ -18,7 +18,9 @@
           }
         },
         "summary": "Check if the deployment is running in a cloud environment",
-        "tags": ["app"]
+        "tags": [
+          "app"
+        ]
       }
     },
     "/health": {
@@ -31,7 +33,9 @@
           }
         },
         "summary": "Check if the deployment is healthy",
-        "tags": ["app"]
+        "tags": [
+          "app"
+        ]
       }
     },
     "/models/available": {
@@ -57,7 +61,9 @@
           }
         },
         "summary": "Get all available models",
-        "tags": ["models"]
+        "tags": [
+          "models"
+        ]
       }
     },
     "/models/providers": {
@@ -80,7 +86,9 @@
           }
         },
         "summary": "Get all available model providers with their info",
-        "tags": ["models"]
+        "tags": [
+          "models"
+        ]
       }
     },
     "/models/permitted": {
@@ -109,7 +117,9 @@
           }
         },
         "summary": "Create a permitted model",
-        "tags": ["models"]
+        "tags": [
+          "models"
+        ]
       }
     },
     "/models/permitted/{id}": {
@@ -134,7 +144,9 @@
           }
         },
         "summary": "Delete a permitted model",
-        "tags": ["models"]
+        "tags": [
+          "models"
+        ]
       },
       "patch": {
         "operationId": "ModelsController_updatePermittedModel",
@@ -177,7 +189,9 @@
           }
         },
         "summary": "Update a permitted model",
-        "tags": ["models"]
+        "tags": [
+          "models"
+        ]
       }
     },
     "/models/permitted/language-models": {
@@ -203,7 +217,9 @@
           }
         },
         "summary": "Get all permitted language models",
-        "tags": ["models"]
+        "tags": [
+          "models"
+        ]
       }
     },
     "/models/default": {
@@ -227,7 +243,9 @@
           }
         },
         "summary": "Get the effective default model for the user",
-        "tags": ["models"]
+        "tags": [
+          "models"
+        ]
       }
     },
     "/models/org/default": {
@@ -251,7 +269,9 @@
           }
         },
         "summary": "Get the organization default model",
-        "tags": ["models"]
+        "tags": [
+          "models"
+        ]
       },
       "put": {
         "description": "Sets the specified permitted model as the organization default. If a default already exists, it will be updated to the new model.",
@@ -286,7 +306,9 @@
           }
         },
         "summary": "Set or update the organization default model",
-        "tags": ["models"]
+        "tags": [
+          "models"
+        ]
       }
     },
     "/models/user/default": {
@@ -310,7 +332,9 @@
           }
         },
         "summary": "Get the user-specific default model",
-        "tags": ["models"]
+        "tags": [
+          "models"
+        ]
       },
       "put": {
         "description": "Sets the specified permitted model as the user default. If a default already exists, it will be updated to the new model.",
@@ -345,7 +369,9 @@
           }
         },
         "summary": "Set or update the user default model",
-        "tags": ["models"]
+        "tags": [
+          "models"
+        ]
       },
       "delete": {
         "operationId": "ModelsController_deleteUserDefaultModel",
@@ -359,7 +385,9 @@
           }
         },
         "summary": "Delete the user default model",
-        "tags": ["models"]
+        "tags": [
+          "models"
+        ]
       }
     },
     "/models/provider/{provider}": {
@@ -395,7 +423,9 @@
           }
         },
         "summary": "Get model provider information",
-        "tags": ["models"]
+        "tags": [
+          "models"
+        ]
       }
     },
     "/models/embedding/enabled": {
@@ -418,7 +448,9 @@
           }
         },
         "summary": "Check if an embedding model is enabled for this org",
-        "tags": ["models"]
+        "tags": [
+          "models"
+        ]
       }
     },
     "/super-admin/models/{orgId}/available": {
@@ -460,7 +492,9 @@
           }
         },
         "summary": "Get all available models",
-        "tags": ["Super Admin Models"]
+        "tags": [
+          "Super Admin Models"
+        ]
       }
     },
     "/super-admin/models/{orgId}/default-model": {
@@ -515,7 +549,9 @@
           }
         },
         "summary": "Set or update the organization default model",
-        "tags": ["Super Admin Models"]
+        "tags": [
+          "Super Admin Models"
+        ]
       }
     },
     "/super-admin/models/catalog/{id}": {
@@ -550,7 +586,9 @@
           }
         },
         "summary": "Delete a model from the catalog",
-        "tags": ["Super Admin Models"]
+        "tags": [
+          "Super Admin Models"
+        ]
       },
       "get": {
         "description": "Retrieve a specific model from the master catalog by its ID. This endpoint is only accessible to super admins.",
@@ -597,7 +635,9 @@
           }
         },
         "summary": "Get a model by ID from the catalog",
-        "tags": ["Super Admin Models"]
+        "tags": [
+          "Super Admin Models"
+        ]
       }
     },
     "/super-admin/models/{orgId}/permitted-models": {
@@ -646,7 +686,9 @@
           }
         },
         "summary": "Get all permitted models for a specific organization",
-        "tags": ["Super Admin Models"]
+        "tags": [
+          "Super Admin Models"
+        ]
       },
       "post": {
         "description": "Create a new permitted model for the specified organization. This endpoint is only accessible to super admins.",
@@ -692,7 +734,9 @@
           }
         },
         "summary": "Create a permitted model for a specific organization",
-        "tags": ["Super Admin Models"]
+        "tags": [
+          "Super Admin Models"
+        ]
       }
     },
     "/super-admin/models/{orgId}/permitted-models/{id}": {
@@ -741,7 +785,9 @@
           }
         },
         "summary": "Delete a permitted model for a specific organization",
-        "tags": ["Super Admin Models"]
+        "tags": [
+          "Super Admin Models"
+        ]
       },
       "patch": {
         "description": "Update the settings of a permitted model for the specified organization. This endpoint is only accessible to super admins.",
@@ -812,7 +858,9 @@
           }
         },
         "summary": "Update a permitted model for a specific organization",
-        "tags": ["Super Admin Models"]
+        "tags": [
+          "Super Admin Models"
+        ]
       }
     },
     "/super-admin/models/catalog": {
@@ -849,7 +897,9 @@
           }
         },
         "summary": "Get all models in the catalog",
-        "tags": ["Super Admin Models"]
+        "tags": [
+          "Super Admin Models"
+        ]
       }
     },
     "/super-admin/models/catalog/language": {
@@ -892,7 +942,9 @@
           }
         },
         "summary": "Create a new language model in the catalog",
-        "tags": ["Super Admin Models"]
+        "tags": [
+          "Super Admin Models"
+        ]
       }
     },
     "/super-admin/models/catalog/language/{id}": {
@@ -947,7 +999,9 @@
           }
         },
         "summary": "Update a language model in the catalog",
-        "tags": ["Super Admin Models"]
+        "tags": [
+          "Super Admin Models"
+        ]
       }
     },
     "/super-admin/models/catalog/embedding": {
@@ -990,7 +1044,9 @@
           }
         },
         "summary": "Create a new embedding model in the catalog",
-        "tags": ["Super Admin Models"]
+        "tags": [
+          "Super Admin Models"
+        ]
       }
     },
     "/super-admin/models/catalog/embedding/{id}": {
@@ -1045,7 +1101,9 @@
           }
         },
         "summary": "Update an embedding model in the catalog",
-        "tags": ["Super Admin Models"]
+        "tags": [
+          "Super Admin Models"
+        ]
       }
     },
     "/super-admin/orgs": {
@@ -1083,7 +1141,9 @@
           }
         },
         "summary": "Create a new organization",
-        "tags": ["Super Admin Orgs"]
+        "tags": [
+          "Super Admin Orgs"
+        ]
       },
       "get": {
         "description": "Retrieve paginated organizations in the system. Only accessible to users with the super admin system role.",
@@ -1138,7 +1198,9 @@
           }
         },
         "summary": "List all organizations",
-        "tags": ["Super Admin Orgs"]
+        "tags": [
+          "Super Admin Orgs"
+        ]
       }
     },
     "/super-admin/orgs/{id}": {
@@ -1172,7 +1234,9 @@
           }
         },
         "summary": "Get an organization by ID",
-        "tags": ["Super Admin Orgs"]
+        "tags": [
+          "Super Admin Orgs"
+        ]
       }
     },
     "/users": {
@@ -1232,7 +1296,9 @@
           }
         },
         "summary": "Get users in current organization",
-        "tags": ["Users"]
+        "tags": [
+          "Users"
+        ]
       }
     },
     "/users/{id}/role": {
@@ -1288,7 +1354,9 @@
           }
         },
         "summary": "Update user role",
-        "tags": ["Users"]
+        "tags": [
+          "Users"
+        ]
       }
     },
     "/users/name": {
@@ -1332,7 +1400,9 @@
           }
         },
         "summary": "Update user name",
-        "tags": ["Users"]
+        "tags": [
+          "Users"
+        ]
       }
     },
     "/users/password": {
@@ -1366,7 +1436,9 @@
           }
         },
         "summary": "Update user password",
-        "tags": ["Users"]
+        "tags": [
+          "Users"
+        ]
       }
     },
     "/users/confirm-email": {
@@ -1400,7 +1472,9 @@
           }
         },
         "summary": "Confirm user email",
-        "tags": ["Users"]
+        "tags": [
+          "Users"
+        ]
       }
     },
     "/users/resend-confirmation": {
@@ -1431,7 +1505,9 @@
           }
         },
         "summary": "Resend email confirmation",
-        "tags": ["Users"]
+        "tags": [
+          "Users"
+        ]
       }
     },
     "/users/{id}": {
@@ -1466,7 +1542,9 @@
           }
         },
         "summary": "Delete a user",
-        "tags": ["Users"]
+        "tags": [
+          "Users"
+        ]
       }
     },
     "/users/{id}/trigger-password-reset": {
@@ -1497,7 +1575,9 @@
           }
         },
         "summary": "Trigger password reset for a user",
-        "tags": ["Users"]
+        "tags": [
+          "Users"
+        ]
       }
     },
     "/users/forgot-password": {
@@ -1528,7 +1608,9 @@
           }
         },
         "summary": "Trigger password reset",
-        "tags": ["Users"]
+        "tags": [
+          "Users"
+        ]
       }
     },
     "/users/reset-password": {
@@ -1562,7 +1644,9 @@
           }
         },
         "summary": "Reset password with token",
-        "tags": ["Users"]
+        "tags": [
+          "Users"
+        ]
       }
     },
     "/users/validate-reset-token": {
@@ -1606,7 +1690,9 @@
           }
         },
         "summary": "Validate password reset token",
-        "tags": ["Users"]
+        "tags": [
+          "Users"
+        ]
       }
     },
     "/super-admin/users/{orgId}": {
@@ -1680,7 +1766,9 @@
           }
         },
         "summary": "Get users by organization ID",
-        "tags": ["Super Admin Users"]
+        "tags": [
+          "Super Admin Users"
+        ]
       }
     },
     "/super-admin/users/{userId}": {
@@ -1715,7 +1803,9 @@
           }
         },
         "summary": "Delete a user",
-        "tags": ["Super Admin Users"]
+        "tags": [
+          "Super Admin Users"
+        ]
       }
     },
     "/super-admin/users/{userId}/trigger-password-reset": {
@@ -1750,7 +1840,9 @@
           }
         },
         "summary": "Trigger password reset for a user",
-        "tags": ["Super Admin Users"]
+        "tags": [
+          "Super Admin Users"
+        ]
       }
     },
     "/super-admin/users/{orgId}/create": {
@@ -1806,7 +1898,9 @@
           }
         },
         "summary": "Create a new user in an organization",
-        "tags": ["Super Admin Users"]
+        "tags": [
+          "Super Admin Users"
+        ]
       }
     },
     "/invites": {
@@ -1843,7 +1937,9 @@
           }
         },
         "summary": "Create a new invite",
-        "tags": ["invites"]
+        "tags": [
+          "invites"
+        ]
       },
       "get": {
         "description": "Retrieve paginated invites with optional search",
@@ -1898,7 +1994,9 @@
           }
         },
         "summary": "Get all invites for current user's organization",
-        "tags": ["invites"]
+        "tags": [
+          "invites"
+        ]
       }
     },
     "/invites/bulk": {
@@ -1935,7 +2033,9 @@
           }
         },
         "summary": "Create multiple invites in bulk",
-        "tags": ["invites"]
+        "tags": [
+          "invites"
+        ]
       }
     },
     "/invites/{token}": {
@@ -1973,7 +2073,9 @@
           }
         },
         "summary": "Get a single invite by token",
-        "tags": ["invites"]
+        "tags": [
+          "invites"
+        ]
       }
     },
     "/invites/accept": {
@@ -2013,7 +2115,9 @@
           }
         },
         "summary": "Accept an invite",
-        "tags": ["invites"]
+        "tags": [
+          "invites"
+        ]
       }
     },
     "/invites/{id}/resend": {
@@ -2054,7 +2158,9 @@
           }
         },
         "summary": "Resend an expired invite",
-        "tags": ["invites"]
+        "tags": [
+          "invites"
+        ]
       }
     },
     "/invites/all": {
@@ -2081,7 +2187,9 @@
           }
         },
         "summary": "Delete all pending invites",
-        "tags": ["invites"]
+        "tags": [
+          "invites"
+        ]
       }
     },
     "/invites/{id}": {
@@ -2115,7 +2223,9 @@
           }
         },
         "summary": "Delete an invite",
-        "tags": ["invites"]
+        "tags": [
+          "invites"
+        ]
       }
     },
     "/subscriptions": {
@@ -2144,7 +2254,9 @@
           }
         },
         "summary": "Get subscription details for the current organization",
-        "tags": ["subscriptions"]
+        "tags": [
+          "subscriptions"
+        ]
       },
       "post": {
         "operationId": "SubscriptionsController_createSubscription",
@@ -2184,7 +2296,9 @@
           }
         },
         "summary": "Create a new subscription for the current organization",
-        "tags": ["subscriptions"]
+        "tags": [
+          "subscriptions"
+        ]
       },
       "delete": {
         "operationId": "SubscriptionsController_cancelSubscription",
@@ -2207,7 +2321,9 @@
           }
         },
         "summary": "Cancel the subscription for the current organization",
-        "tags": ["subscriptions"]
+        "tags": [
+          "subscriptions"
+        ]
       }
     },
     "/subscriptions/active": {
@@ -2230,7 +2346,9 @@
           }
         },
         "summary": "Check if the current organization has an active subscription",
-        "tags": ["subscriptions"]
+        "tags": [
+          "subscriptions"
+        ]
       }
     },
     "/subscriptions/price": {
@@ -2256,7 +2374,9 @@
           }
         },
         "summary": "Get the current price per seat monthly",
-        "tags": ["subscriptions"]
+        "tags": [
+          "subscriptions"
+        ]
       }
     },
     "/subscriptions/seats": {
@@ -2288,7 +2408,9 @@
           }
         },
         "summary": "Update the number of seats for the current organization",
-        "tags": ["subscriptions"]
+        "tags": [
+          "subscriptions"
+        ]
       }
     },
     "/subscriptions/billing-info": {
@@ -2323,7 +2445,9 @@
           }
         },
         "summary": "Update the billing information for the current organization",
-        "tags": ["subscriptions"]
+        "tags": [
+          "subscriptions"
+        ]
       }
     },
     "/subscriptions/uncancel": {
@@ -2348,7 +2472,9 @@
           }
         },
         "summary": "Uncancel the subscription for the current organization",
-        "tags": ["subscriptions"]
+        "tags": [
+          "subscriptions"
+        ]
       }
     },
     "/super-admin/subscriptions/{orgId}": {
@@ -2387,7 +2513,9 @@
           }
         },
         "summary": "Get subscription details for a specific organization",
-        "tags": ["Super Admin Subscriptions"]
+        "tags": [
+          "Super Admin Subscriptions"
+        ]
       },
       "post": {
         "description": "Create a new subscription for the specified organization. This endpoint is only accessible to super admins.",
@@ -2440,7 +2568,9 @@
           }
         },
         "summary": "Create a new subscription for a specific organization",
-        "tags": ["Super Admin Subscriptions"]
+        "tags": [
+          "Super Admin Subscriptions"
+        ]
       },
       "delete": {
         "description": "Cancel the subscription for the specified organization. This endpoint is only accessible to super admins.",
@@ -2476,7 +2606,9 @@
           }
         },
         "summary": "Cancel the subscription for a specific organization",
-        "tags": ["Super Admin Subscriptions"]
+        "tags": [
+          "Super Admin Subscriptions"
+        ]
       }
     },
     "/super-admin/subscriptions/{orgId}/seats": {
@@ -2524,7 +2656,9 @@
           }
         },
         "summary": "Update the number of seats for a specific organization",
-        "tags": ["Super Admin Subscriptions"]
+        "tags": [
+          "Super Admin Subscriptions"
+        ]
       }
     },
     "/super-admin/subscriptions/{orgId}/billing-info": {
@@ -2572,7 +2706,9 @@
           }
         },
         "summary": "Update the billing information for a specific organization",
-        "tags": ["Super Admin Subscriptions"]
+        "tags": [
+          "Super Admin Subscriptions"
+        ]
       }
     },
     "/super-admin/subscriptions/{orgId}/uncancel": {
@@ -2610,7 +2746,9 @@
           }
         },
         "summary": "Uncancel the subscription for a specific organization",
-        "tags": ["Super Admin Subscriptions"]
+        "tags": [
+          "Super Admin Subscriptions"
+        ]
       }
     },
     "/storage/upload": {
@@ -2624,7 +2762,9 @@
             "multipart/form-data": {
               "schema": {
                 "type": "object",
-                "required": ["file"],
+                "required": [
+                  "file"
+                ],
                 "properties": {
                   "file": {
                     "type": "string",
@@ -2652,7 +2792,9 @@
           }
         },
         "summary": "Upload a file to object storage",
-        "tags": ["storage"]
+        "tags": [
+          "storage"
+        ]
       }
     },
     "/storage/{objectName}": {
@@ -2674,7 +2816,9 @@
             "description": ""
           }
         },
-        "tags": ["storage"]
+        "tags": [
+          "storage"
+        ]
       },
       "delete": {
         "operationId": "StorageController_deleteFile",
@@ -2694,7 +2838,9 @@
             "description": ""
           }
         },
-        "tags": ["storage"]
+        "tags": [
+          "storage"
+        ]
       }
     },
     "/storage/url/{objectName}": {
@@ -2716,7 +2862,9 @@
             "description": ""
           }
         },
-        "tags": ["storage"]
+        "tags": [
+          "storage"
+        ]
       }
     },
     "/retrievers/url": {
@@ -2739,7 +2887,9 @@
           }
         },
         "summary": "Retrieve content from a URL",
-        "tags": ["retrievers"]
+        "tags": [
+          "retrievers"
+        ]
       }
     },
     "/threads": {
@@ -2775,7 +2925,9 @@
           }
         },
         "summary": "Create a new thread",
-        "tags": ["threads"]
+        "tags": [
+          "threads"
+        ]
       },
       "get": {
         "operationId": "ThreadsController_findAll",
@@ -2834,7 +2986,9 @@
           }
         },
         "summary": "Get all threads for the current user",
-        "tags": ["threads"]
+        "tags": [
+          "threads"
+        ]
       }
     },
     "/threads/{id}": {
@@ -2871,7 +3025,9 @@
           }
         },
         "summary": "Get a thread by ID",
-        "tags": ["threads"]
+        "tags": [
+          "threads"
+        ]
       },
       "delete": {
         "operationId": "ThreadsController_delete",
@@ -2899,7 +3055,9 @@
           }
         },
         "summary": "Delete a thread",
-        "tags": ["threads"]
+        "tags": [
+          "threads"
+        ]
       }
     },
     "/threads/{id}/title": {
@@ -2942,7 +3100,9 @@
           }
         },
         "summary": "Update a thread title",
-        "tags": ["threads"]
+        "tags": [
+          "threads"
+        ]
       }
     },
     "/threads/{id}/sources": {
@@ -2992,7 +3152,9 @@
           }
         },
         "summary": "Get all sources for a thread",
-        "tags": ["threads"]
+        "tags": [
+          "threads"
+        ]
       }
     },
     "/threads/{id}/sources/file": {
@@ -3031,7 +3193,9 @@
                     "description": "A description of the file source"
                   }
                 },
-                "required": ["file"]
+                "required": [
+                  "file"
+                ]
               }
             }
           }
@@ -3042,7 +3206,9 @@
           }
         },
         "summary": "Add a file source to a thread",
-        "tags": ["threads"]
+        "tags": [
+          "threads"
+        ]
       }
     },
     "/threads/{id}/sources/{sourceId}": {
@@ -3079,7 +3245,9 @@
           }
         },
         "summary": "Remove a source from a thread",
-        "tags": ["threads"]
+        "tags": [
+          "threads"
+        ]
       }
     },
     "/threads/{id}/sources/{sourceId}/download": {
@@ -3127,7 +3295,9 @@
           }
         },
         "summary": "Download a data source as CSV",
-        "tags": ["threads"]
+        "tags": [
+          "threads"
+        ]
       }
     },
     "/agents": {
@@ -3163,7 +3333,9 @@
           }
         },
         "summary": "Create a new agent",
-        "tags": ["agents"]
+        "tags": [
+          "agents"
+        ]
       },
       "get": {
         "operationId": "AgentsController_findAll",
@@ -3187,7 +3359,9 @@
           }
         },
         "summary": "Get all agents for the current user",
-        "tags": ["agents"]
+        "tags": [
+          "agents"
+        ]
       }
     },
     "/agents/{id}": {
@@ -3224,7 +3398,9 @@
           }
         },
         "summary": "Get an agent by ID",
-        "tags": ["agents"]
+        "tags": [
+          "agents"
+        ]
       },
       "put": {
         "operationId": "AgentsController_update",
@@ -3272,7 +3448,9 @@
           }
         },
         "summary": "Update an agent",
-        "tags": ["agents"]
+        "tags": [
+          "agents"
+        ]
       },
       "delete": {
         "operationId": "AgentsController_delete",
@@ -3300,7 +3478,9 @@
           }
         },
         "summary": "Delete an agent",
-        "tags": ["agents"]
+        "tags": [
+          "agents"
+        ]
       }
     },
     "/agents/{id}/sources": {
@@ -3340,7 +3520,9 @@
           }
         },
         "summary": "Get all sources for an agent",
-        "tags": ["agents"]
+        "tags": [
+          "agents"
+        ]
       }
     },
     "/agents/{id}/sources/file": {
@@ -3371,7 +3553,9 @@
                     "description": "The file to upload"
                   }
                 },
-                "required": ["file"]
+                "required": [
+                  "file"
+                ]
               }
             }
           }
@@ -3391,7 +3575,9 @@
           }
         },
         "summary": "Add a file source to an agent",
-        "tags": ["agents"]
+        "tags": [
+          "agents"
+        ]
       }
     },
     "/agents/{id}/sources/{sourceAssignmentId}": {
@@ -3428,7 +3614,9 @@
           }
         },
         "summary": "Remove a source from an agent",
-        "tags": ["agents"]
+        "tags": [
+          "agents"
+        ]
       }
     },
     "/agents/{agentId}/mcp-integrations/{integrationId}": {
@@ -3481,7 +3669,9 @@
           }
         },
         "summary": "Assign MCP integration to agent",
-        "tags": ["agents"]
+        "tags": [
+          "agents"
+        ]
       },
       "delete": {
         "operationId": "AgentsController_unassignMcpIntegration",
@@ -3523,7 +3713,9 @@
           }
         },
         "summary": "Unassign MCP integration from agent",
-        "tags": ["agents"]
+        "tags": [
+          "agents"
+        ]
       }
     },
     "/agents/{agentId}/mcp-integrations": {
@@ -3560,7 +3752,9 @@
           }
         },
         "summary": "List MCP integrations assigned to agent",
-        "tags": ["agents"]
+        "tags": [
+          "agents"
+        ]
       }
     },
     "/shares": {
@@ -3603,7 +3797,9 @@
           }
         },
         "summary": "Create a share for an agent",
-        "tags": ["shares"]
+        "tags": [
+          "shares"
+        ]
       },
       "get": {
         "operationId": "SharesController_getShares",
@@ -3624,7 +3820,11 @@
             "in": "query",
             "description": "Type of the entity",
             "schema": {
-              "enum": ["agent", "prompt", "skill"],
+              "enum": [
+                "agent",
+                "prompt",
+                "skill"
+              ],
               "type": "string"
             }
           }
@@ -3654,7 +3854,9 @@
           }
         },
         "summary": "Get shares for an entity",
-        "tags": ["shares"]
+        "tags": [
+          "shares"
+        ]
       }
     },
     "/shares/skills": {
@@ -3694,7 +3896,9 @@
           }
         },
         "summary": "Create a share for a skill",
-        "tags": ["shares"]
+        "tags": [
+          "shares"
+        ]
       }
     },
     "/shares/{id}": {
@@ -3727,7 +3931,9 @@
           }
         },
         "summary": "Delete a share",
-        "tags": ["shares"]
+        "tags": [
+          "shares"
+        ]
       }
     },
     "/teams": {
@@ -3759,7 +3965,9 @@
           }
         },
         "summary": "List all teams for the current organization",
-        "tags": ["teams"]
+        "tags": [
+          "teams"
+        ]
       },
       "post": {
         "operationId": "TeamsController_createTeam",
@@ -3802,7 +4010,9 @@
           }
         },
         "summary": "Create a new team for the current organization",
-        "tags": ["teams"]
+        "tags": [
+          "teams"
+        ]
       }
     },
     "/teams/me": {
@@ -3831,7 +4041,9 @@
           }
         },
         "summary": "List teams the current user is a member of",
-        "tags": ["teams"]
+        "tags": [
+          "teams"
+        ]
       }
     },
     "/teams/{id}": {
@@ -3872,7 +4084,9 @@
           }
         },
         "summary": "Get a team by ID",
-        "tags": ["teams"]
+        "tags": [
+          "teams"
+        ]
       },
       "patch": {
         "operationId": "TeamsController_updateTeam",
@@ -3927,7 +4141,9 @@
           }
         },
         "summary": "Update a team in the current organization",
-        "tags": ["teams"]
+        "tags": [
+          "teams"
+        ]
       },
       "delete": {
         "operationId": "TeamsController_deleteTeam",
@@ -3959,7 +4175,9 @@
           }
         },
         "summary": "Delete a team from the current organization",
-        "tags": ["teams"]
+        "tags": [
+          "teams"
+        ]
       }
     },
     "/teams/{id}/members": {
@@ -4022,7 +4240,9 @@
           }
         },
         "summary": "List members of a team",
-        "tags": ["teams"]
+        "tags": [
+          "teams"
+        ]
       },
       "post": {
         "operationId": "TeamsController_addTeamMember",
@@ -4077,7 +4297,9 @@
           }
         },
         "summary": "Add a user to a team",
-        "tags": ["teams"]
+        "tags": [
+          "teams"
+        ]
       }
     },
     "/teams/{id}/members/{userId}": {
@@ -4119,7 +4341,9 @@
           }
         },
         "summary": "Remove a user from a team",
-        "tags": ["teams"]
+        "tags": [
+          "teams"
+        ]
       }
     },
     "/mcp-integrations/predefined": {
@@ -4155,7 +4379,9 @@
           }
         },
         "summary": "Create a new predefined MCP integration",
-        "tags": ["mcp-integrations"]
+        "tags": [
+          "mcp-integrations"
+        ]
       }
     },
     "/mcp-integrations/custom": {
@@ -4188,7 +4414,9 @@
           }
         },
         "summary": "Create a new custom MCP integration",
-        "tags": ["mcp-integrations"]
+        "tags": [
+          "mcp-integrations"
+        ]
       }
     },
     "/mcp-integrations": {
@@ -4211,7 +4439,9 @@
           }
         },
         "summary": "List all MCP integrations for organization",
-        "tags": ["mcp-integrations"]
+        "tags": [
+          "mcp-integrations"
+        ]
       }
     },
     "/mcp-integrations/predefined/available": {
@@ -4234,7 +4464,9 @@
           }
         },
         "summary": "List available predefined MCP integration configurations",
-        "tags": ["mcp-integrations"]
+        "tags": [
+          "mcp-integrations"
+        ]
       }
     },
     "/mcp-integrations/available": {
@@ -4257,7 +4489,9 @@
           }
         },
         "summary": "List all available (enabled) MCP integrations for organization",
-        "tags": ["mcp-integrations"]
+        "tags": [
+          "mcp-integrations"
+        ]
       }
     },
     "/mcp-integrations/{id}": {
@@ -4290,7 +4524,9 @@
           }
         },
         "summary": "Get MCP integration by ID",
-        "tags": ["mcp-integrations"]
+        "tags": [
+          "mcp-integrations"
+        ]
       },
       "patch": {
         "operationId": "McpIntegrationsController_update",
@@ -4334,7 +4570,9 @@
           }
         },
         "summary": "Update MCP integration",
-        "tags": ["mcp-integrations"]
+        "tags": [
+          "mcp-integrations"
+        ]
       },
       "delete": {
         "operationId": "McpIntegrationsController_delete",
@@ -4358,7 +4596,9 @@
           }
         },
         "summary": "Delete MCP integration",
-        "tags": ["mcp-integrations"]
+        "tags": [
+          "mcp-integrations"
+        ]
       }
     },
     "/mcp-integrations/{id}/enable": {
@@ -4391,7 +4631,9 @@
           }
         },
         "summary": "Enable MCP integration",
-        "tags": ["mcp-integrations"]
+        "tags": [
+          "mcp-integrations"
+        ]
       }
     },
     "/mcp-integrations/{id}/disable": {
@@ -4424,7 +4666,9 @@
           }
         },
         "summary": "Disable MCP integration",
-        "tags": ["mcp-integrations"]
+        "tags": [
+          "mcp-integrations"
+        ]
       }
     },
     "/mcp-integrations/{id}/validate": {
@@ -4457,7 +4701,9 @@
           }
         },
         "summary": "Validate MCP integration connection",
-        "tags": ["mcp-integrations"]
+        "tags": [
+          "mcp-integrations"
+        ]
       }
     },
     "/skills/install-from-marketplace": {
@@ -4490,7 +4736,9 @@
           }
         },
         "summary": "Install a skill from the marketplace",
-        "tags": ["skills"]
+        "tags": [
+          "skills"
+        ]
       }
     },
     "/skills": {
@@ -4526,7 +4774,9 @@
           }
         },
         "summary": "Create a new skill",
-        "tags": ["skills"]
+        "tags": [
+          "skills"
+        ]
       },
       "get": {
         "operationId": "SkillsController_findAll",
@@ -4547,7 +4797,9 @@
           }
         },
         "summary": "Get all skills for the current user",
-        "tags": ["skills"]
+        "tags": [
+          "skills"
+        ]
       }
     },
     "/skills/{id}": {
@@ -4581,7 +4833,9 @@
           }
         },
         "summary": "Get a skill by ID",
-        "tags": ["skills"]
+        "tags": [
+          "skills"
+        ]
       },
       "put": {
         "operationId": "SkillsController_update",
@@ -4629,7 +4883,9 @@
           }
         },
         "summary": "Update a skill",
-        "tags": ["skills"]
+        "tags": [
+          "skills"
+        ]
       },
       "delete": {
         "operationId": "SkillsController_delete",
@@ -4654,7 +4910,9 @@
           }
         },
         "summary": "Delete a skill",
-        "tags": ["skills"]
+        "tags": [
+          "skills"
+        ]
       }
     },
     "/skills/{id}/toggle-active": {
@@ -4688,7 +4946,9 @@
           }
         },
         "summary": "Toggle skill active/inactive status",
-        "tags": ["skills"]
+        "tags": [
+          "skills"
+        ]
       }
     },
     "/skills/{id}/sources": {
@@ -4725,7 +4985,9 @@
           }
         },
         "summary": "Get all sources for a skill",
-        "tags": ["skills"]
+        "tags": [
+          "skills"
+        ]
       }
     },
     "/skills/{id}/sources/file": {
@@ -4756,7 +5018,9 @@
                     "description": "The file to upload"
                   }
                 },
-                "required": ["file"]
+                "required": [
+                  "file"
+                ]
               }
             }
           }
@@ -4780,7 +5044,9 @@
           }
         },
         "summary": "Add a file source to a skill",
-        "tags": ["skills"]
+        "tags": [
+          "skills"
+        ]
       }
     },
     "/skills/{id}/sources/{sourceId}": {
@@ -4817,7 +5083,9 @@
           }
         },
         "summary": "Remove a source from a skill",
-        "tags": ["skills"]
+        "tags": [
+          "skills"
+        ]
       }
     },
     "/skills/{skillId}/mcp-integrations/{integrationId}": {
@@ -4864,7 +5132,9 @@
           }
         },
         "summary": "Assign MCP integration to skill",
-        "tags": ["skills"]
+        "tags": [
+          "skills"
+        ]
       },
       "delete": {
         "operationId": "SkillsController_unassignMcpIntegration",
@@ -4906,7 +5176,9 @@
           }
         },
         "summary": "Unassign MCP integration from skill",
-        "tags": ["skills"]
+        "tags": [
+          "skills"
+        ]
       }
     },
     "/skills/{skillId}/mcp-integrations": {
@@ -4943,7 +5215,9 @@
           }
         },
         "summary": "List MCP integrations assigned to skill",
-        "tags": ["skills"]
+        "tags": [
+          "skills"
+        ]
       }
     },
     "/marketplace/skills/{identifier}": {
@@ -4976,7 +5250,9 @@
           }
         },
         "summary": "Preview a marketplace skill before installation",
-        "tags": ["marketplace"]
+        "tags": [
+          "marketplace"
+        ]
       }
     },
     "/runs/send-message": {
@@ -4990,7 +5266,9 @@
             "multipart/form-data": {
               "schema": {
                 "type": "object",
-                "required": ["threadId"],
+                "required": [
+                  "threadId"
+                ],
                 "properties": {
                   "threadId": {
                     "type": "string",
@@ -5144,7 +5422,9 @@
           }
         },
         "summary": "Send a message with optional images and receive streaming response",
-        "tags": ["runs"]
+        "tags": [
+          "runs"
+        ]
       }
     },
     "/super-admin/trials": {
@@ -5182,7 +5462,9 @@
           }
         },
         "summary": "Create a new trial",
-        "tags": ["Super Admin Trials"]
+        "tags": [
+          "Super Admin Trials"
+        ]
       }
     },
     "/super-admin/trials/{orgId}": {
@@ -5219,7 +5501,9 @@
           }
         },
         "summary": "Get a trial by organization ID",
-        "tags": ["Super Admin Trials"]
+        "tags": [
+          "Super Admin Trials"
+        ]
       },
       "put": {
         "description": "Update a trial for an organization. Can update maxMessages and/or messagesSent. Only accessible to users with the super admin system role.",
@@ -5265,7 +5549,9 @@
           }
         },
         "summary": "Update a trial",
-        "tags": ["Super Admin Trials"]
+        "tags": [
+          "Super Admin Trials"
+        ]
       }
     },
     "/usage/config": {
@@ -5286,7 +5572,9 @@
           }
         },
         "summary": "Get usage dashboard configuration",
-        "tags": ["Admin Usage"]
+        "tags": [
+          "Admin Usage"
+        ]
       }
     },
     "/usage/stats": {
@@ -5328,7 +5616,9 @@
           }
         },
         "summary": "Get overall usage statistics",
-        "tags": ["Admin Usage"]
+        "tags": [
+          "Admin Usage"
+        ]
       }
     },
     "/usage/providers": {
@@ -5400,7 +5690,9 @@
           }
         },
         "summary": "Get usage statistics by provider",
-        "tags": ["Admin Usage"]
+        "tags": [
+          "Admin Usage"
+        ]
       }
     },
     "/usage/providers/chart": {
@@ -5458,7 +5750,9 @@
           }
         },
         "summary": "Get provider usage time series aligned by date (chart-ready)",
-        "tags": ["Admin Usage"]
+        "tags": [
+          "Admin Usage"
+        ]
       }
     },
     "/usage/models": {
@@ -5520,7 +5814,9 @@
           }
         },
         "summary": "Get usage distribution by model",
-        "tags": ["Admin Usage"]
+        "tags": [
+          "Admin Usage"
+        ]
       }
     },
     "/usage/users": {
@@ -5584,7 +5880,12 @@
             "in": "query",
             "description": "Field to sort users by. Defaults to tokens.",
             "schema": {
-              "enum": ["tokens", "requests", "lastActivity", "userName"],
+              "enum": [
+                "tokens",
+                "requests",
+                "lastActivity",
+                "userName"
+              ],
               "type": "string"
             }
           },
@@ -5594,7 +5895,10 @@
             "in": "query",
             "description": "Sort order (ascending or descending). Defaults to desc.",
             "schema": {
-              "enum": ["asc", "desc"],
+              "enum": [
+                "asc",
+                "desc"
+              ],
               "type": "string"
             }
           }
@@ -5612,7 +5916,9 @@
           }
         },
         "summary": "Get usage statistics by user",
-        "tags": ["Admin Usage"]
+        "tags": [
+          "Admin Usage"
+        ]
       }
     },
     "/super-admin/usage/{orgId}/config": {
@@ -5642,7 +5948,9 @@
           }
         },
         "summary": "Get usage dashboard configuration for an organization",
-        "tags": ["Super Admin Usage"]
+        "tags": [
+          "Super Admin Usage"
+        ]
       }
     },
     "/super-admin/usage/{orgId}/stats": {
@@ -5689,7 +5997,9 @@
           }
         },
         "summary": "Get overall usage statistics for an organization",
-        "tags": ["Super Admin Usage"]
+        "tags": [
+          "Super Admin Usage"
+        ]
       }
     },
     "/super-admin/usage/{orgId}/models": {
@@ -5752,7 +6062,9 @@
           }
         },
         "summary": "Get usage distribution by model for an organization",
-        "tags": ["Super Admin Usage"]
+        "tags": [
+          "Super Admin Usage"
+        ]
       }
     },
     "/super-admin/usage/{orgId}/providers": {
@@ -5823,7 +6135,9 @@
           }
         },
         "summary": "Get usage statistics by provider for an organization",
-        "tags": ["Super Admin Usage"]
+        "tags": [
+          "Super Admin Usage"
+        ]
       }
     },
     "/super-admin/usage/{orgId}/providers/chart": {
@@ -5886,7 +6200,9 @@
           }
         },
         "summary": "Get provider usage time series for an organization (chart-ready)",
-        "tags": ["Super Admin Usage"]
+        "tags": [
+          "Super Admin Usage"
+        ]
       }
     },
     "/super-admin/usage/{orgId}/users": {
@@ -5948,7 +6264,12 @@
             "required": false,
             "in": "query",
             "schema": {
-              "enum": ["tokens", "requests", "lastActivity", "userName"],
+              "enum": [
+                "tokens",
+                "requests",
+                "lastActivity",
+                "userName"
+              ],
               "type": "string"
             }
           },
@@ -5957,7 +6278,10 @@
             "required": false,
             "in": "query",
             "schema": {
-              "enum": ["asc", "desc"],
+              "enum": [
+                "asc",
+                "desc"
+              ],
               "type": "string"
             }
           }
@@ -5975,7 +6299,9 @@
           }
         },
         "summary": "Get usage statistics by user for an organization",
-        "tags": ["Super Admin Usage"]
+        "tags": [
+          "Super Admin Usage"
+        ]
       }
     },
     "/super-admin/global-usage/providers/chart": {
@@ -6028,7 +6354,9 @@
           }
         },
         "summary": "Get global provider usage time series across all organizations (chart-ready)",
-        "tags": ["Super Admin Global Usage"]
+        "tags": [
+          "Super Admin Global Usage"
+        ]
       }
     },
     "/super-admin/global-usage/models": {
@@ -6073,7 +6401,9 @@
           }
         },
         "summary": "Get global model distribution across all organizations",
-        "tags": ["Super Admin Global Usage"]
+        "tags": [
+          "Super Admin Global Usage"
+        ]
       }
     },
     "/chat-settings/system-prompt": {
@@ -6094,7 +6424,9 @@
           }
         },
         "summary": "Get the user system prompt",
-        "tags": ["Chat Settings"]
+        "tags": [
+          "Chat Settings"
+        ]
       },
       "put": {
         "description": "Creates or replaces the custom system prompt for the authenticated user.",
@@ -6126,7 +6458,9 @@
           }
         },
         "summary": "Set or update the user system prompt",
-        "tags": ["Chat Settings"]
+        "tags": [
+          "Chat Settings"
+        ]
       },
       "delete": {
         "description": "Deletes the custom system prompt for the authenticated user.",
@@ -6138,7 +6472,9 @@
           }
         },
         "summary": "Delete the user system prompt",
-        "tags": ["Chat Settings"]
+        "tags": [
+          "Chat Settings"
+        ]
       }
     },
     "/prompts": {
@@ -6174,7 +6510,9 @@
           }
         },
         "summary": "Create a new prompt",
-        "tags": ["prompts"]
+        "tags": [
+          "prompts"
+        ]
       },
       "get": {
         "operationId": "PromptsController_findAll",
@@ -6198,7 +6536,9 @@
           }
         },
         "summary": "Get all prompts for the current user",
-        "tags": ["prompts"]
+        "tags": [
+          "prompts"
+        ]
       }
     },
     "/prompts/{id}": {
@@ -6235,7 +6575,9 @@
           }
         },
         "summary": "Get a prompt by ID",
-        "tags": ["prompts"]
+        "tags": [
+          "prompts"
+        ]
       },
       "put": {
         "operationId": "PromptsController_update",
@@ -6283,7 +6625,9 @@
           }
         },
         "summary": "Update a prompt",
-        "tags": ["prompts"]
+        "tags": [
+          "prompts"
+        ]
       },
       "delete": {
         "operationId": "PromptsController_delete",
@@ -6311,7 +6655,9 @@
           }
         },
         "summary": "Delete a prompt",
-        "tags": ["prompts"]
+        "tags": [
+          "prompts"
+        ]
       }
     },
     "/transcriptions": {
@@ -6325,7 +6671,9 @@
             "multipart/form-data": {
               "schema": {
                 "type": "object",
-                "required": ["file"],
+                "required": [
+                  "file"
+                ],
                 "properties": {
                   "file": {
                     "type": "string",
@@ -6369,7 +6717,9 @@
           }
         ],
         "summary": "Transcribe audio file to text",
-        "tags": ["transcriptions"]
+        "tags": [
+          "transcriptions"
+        ]
       }
     },
     "/auth/login": {
@@ -6421,7 +6771,9 @@
           }
         },
         "summary": "User login",
-        "tags": ["Authentication"]
+        "tags": [
+          "Authentication"
+        ]
       }
     },
     "/auth/register": {
@@ -6473,7 +6825,9 @@
           }
         },
         "summary": "User registration",
-        "tags": ["Authentication"]
+        "tags": [
+          "Authentication"
+        ]
       }
     },
     "/auth/refresh": {
@@ -6519,7 +6873,9 @@
           }
         ],
         "summary": "Refresh authentication tokens",
-        "tags": ["Authentication"]
+        "tags": [
+          "Authentication"
+        ]
       }
     },
     "/auth/me": {
@@ -6560,7 +6916,9 @@
           }
         },
         "summary": "Get current user information",
-        "tags": ["Authentication"]
+        "tags": [
+          "Authentication"
+        ]
       }
     },
     "/auth/logout": {
@@ -6581,7 +6939,9 @@
           }
         },
         "summary": "User logout",
-        "tags": ["Authentication"]
+        "tags": [
+          "Authentication"
+        ]
       }
     }
   },
@@ -6614,7 +6974,10 @@
             "example": false
           }
         },
-        "required": ["isCloud", "isRegistrationDisabled"]
+        "required": [
+          "isCloud",
+          "isRegistrationDisabled"
+        ]
       },
       "ModelWithConfigResponseDto": {
         "type": "object",
@@ -6644,7 +7007,8 @@
               "ayunis",
               "otc",
               "azure",
-              "gemini"
+              "gemini",
+              "stackit"
             ],
             "description": "The provider of the model"
           },
@@ -6717,7 +7081,8 @@
               "ayunis",
               "otc",
               "azure",
-              "gemini"
+              "gemini",
+              "stackit"
             ],
             "description": "The model provider identifier",
             "example": "openai"
@@ -6729,12 +7094,22 @@
           },
           "hostedIn": {
             "type": "string",
-            "enum": ["DE", "EU", "US", "SELF_HOSTED", "AYUNIS"],
+            "enum": [
+              "DE",
+              "EU",
+              "US",
+              "SELF_HOSTED",
+              "AYUNIS"
+            ],
             "description": "The location where the provider hosts their services",
             "example": "US"
           }
         },
-        "required": ["provider", "displayName", "hostedIn"]
+        "required": [
+          "provider",
+          "displayName",
+          "hostedIn"
+        ]
       },
       "CreatePermittedModelDto": {
         "type": "object",
@@ -6751,7 +7126,9 @@
             "default": false
           }
         },
-        "required": ["modelId"]
+        "required": [
+          "modelId"
+        ]
       },
       "UpdatePermittedModelDto": {
         "type": "object",
@@ -6762,7 +7139,9 @@
             "example": true
           }
         },
-        "required": ["anonymousOnly"]
+        "required": [
+          "anonymousOnly"
+        ]
       },
       "PermittedLanguageModelResponseDto": {
         "type": "object",
@@ -6787,7 +7166,8 @@
               "ayunis",
               "otc",
               "azure",
-              "gemini"
+              "gemini",
+              "stackit"
             ],
             "description": "The provider of the model"
           },
@@ -6801,7 +7181,9 @@
           },
           "type": {
             "type": "string",
-            "enum": ["language"],
+            "enum": [
+              "language"
+            ],
             "description": "The type of the model (always language)"
           },
           "isArchived": {
@@ -6852,7 +7234,9 @@
             ]
           }
         },
-        "required": ["permittedLanguageModel"]
+        "required": [
+          "permittedLanguageModel"
+        ]
       },
       "SetUserDefaultModelDto": {
         "type": "object",
@@ -6863,7 +7247,9 @@
             "example": "123e4567-e89b-12d3-a456-426614174000"
           }
         },
-        "required": ["permittedModelId"]
+        "required": [
+          "permittedModelId"
+        ]
       },
       "SetOrgDefaultModelDto": {
         "type": "object",
@@ -6874,7 +7260,9 @@
             "example": "123e4567-e89b-12d3-a456-426614174000"
           }
         },
-        "required": ["permittedModelId"]
+        "required": [
+          "permittedModelId"
+        ]
       },
       "EmbeddingModelEnabledResponseDto": {
         "type": "object",
@@ -6885,7 +7273,9 @@
             "example": true
           }
         },
-        "required": ["isEmbeddingModelEnabled"]
+        "required": [
+          "isEmbeddingModelEnabled"
+        ]
       },
       "PermittedEmbeddingModelResponseDto": {
         "type": "object",
@@ -6910,7 +7300,8 @@
               "ayunis",
               "otc",
               "azure",
-              "gemini"
+              "gemini",
+              "stackit"
             ],
             "description": "The provider of the model"
           },
@@ -6924,7 +7315,9 @@
           },
           "type": {
             "type": "string",
-            "enum": ["embedding"],
+            "enum": [
+              "embedding"
+            ],
             "description": "The type of the model (always embedding)"
           },
           "isArchived": {
@@ -6969,7 +7362,8 @@
               "ayunis",
               "otc",
               "azure",
-              "gemini"
+              "gemini",
+              "stackit"
             ],
             "example": "openai"
           },
@@ -7036,7 +7430,8 @@
               "ayunis",
               "otc",
               "azure",
-              "gemini"
+              "gemini",
+              "stackit"
             ],
             "example": "openai"
           },
@@ -7103,7 +7498,8 @@
               "ayunis",
               "otc",
               "azure",
-              "gemini"
+              "gemini",
+              "stackit"
             ],
             "example": "openai"
           },
@@ -7115,7 +7511,11 @@
           "dimensions": {
             "type": "number",
             "description": "The dimensions of the embedding",
-            "enum": [1024, 1536, 2560],
+            "enum": [
+              1024,
+              1536,
+              2560
+            ],
             "example": 1536
           },
           "isArchived": {
@@ -7153,7 +7553,8 @@
               "ayunis",
               "otc",
               "azure",
-              "gemini"
+              "gemini",
+              "stackit"
             ],
             "example": "openai"
           },
@@ -7165,7 +7566,11 @@
           "dimensions": {
             "type": "number",
             "description": "The dimensions of the embedding",
-            "enum": [1024, 1536, 2560],
+            "enum": [
+              1024,
+              1536,
+              2560
+            ],
             "example": 1536
           },
           "isArchived": {
@@ -7208,7 +7613,8 @@
               "ayunis",
               "otc",
               "azure",
-              "gemini"
+              "gemini",
+              "stackit"
             ],
             "description": "The provider of the model",
             "example": "openai"
@@ -7220,7 +7626,9 @@
           },
           "type": {
             "type": "string",
-            "enum": ["language"],
+            "enum": [
+              "language"
+            ],
             "description": "The type of the model (always language)"
           },
           "isArchived": {
@@ -7300,7 +7708,8 @@
               "ayunis",
               "otc",
               "azure",
-              "gemini"
+              "gemini",
+              "stackit"
             ],
             "description": "The provider of the model",
             "example": "openai"
@@ -7312,7 +7721,9 @@
           },
           "type": {
             "type": "string",
-            "enum": ["embedding"],
+            "enum": [
+              "embedding"
+            ],
             "description": "The type of the model (always embedding)"
           },
           "isArchived": {
@@ -7365,7 +7776,9 @@
             "example": "Acme Corporation"
           }
         },
-        "required": ["name"]
+        "required": [
+          "name"
+        ]
       },
       "SuperAdminOrgResponseDto": {
         "type": "object",
@@ -7388,7 +7801,11 @@
             "example": "2024-01-15T10:30:00Z"
           }
         },
-        "required": ["id", "name", "createdAt"]
+        "required": [
+          "id",
+          "name",
+          "createdAt"
+        ]
       },
       "PaginationDto": {
         "type": "object",
@@ -7409,7 +7826,10 @@
             "example": 150
           }
         },
-        "required": ["limit", "offset"]
+        "required": [
+          "limit",
+          "offset"
+        ]
       },
       "SuperAdminOrgListResponseDto": {
         "type": "object",
@@ -7430,7 +7850,10 @@
             ]
           }
         },
-        "required": ["data", "pagination"]
+        "required": [
+          "data",
+          "pagination"
+        ]
       },
       "UserResponseDto": {
         "type": "object",
@@ -7454,7 +7877,10 @@
           "role": {
             "type": "string",
             "description": "User role",
-            "enum": ["admin", "user"],
+            "enum": [
+              "admin",
+              "user"
+            ],
             "example": "user"
           },
           "orgId": {
@@ -7470,7 +7896,14 @@
             "example": "2024-01-15T10:30:00Z"
           }
         },
-        "required": ["id", "name", "email", "role", "orgId", "createdAt"]
+        "required": [
+          "id",
+          "name",
+          "email",
+          "role",
+          "orgId",
+          "createdAt"
+        ]
       },
       "PaginatedUsersListResponseDto": {
         "type": "object",
@@ -7491,7 +7924,10 @@
             ]
           }
         },
-        "required": ["data", "pagination"]
+        "required": [
+          "data",
+          "pagination"
+        ]
       },
       "UpdateUserRoleDto": {
         "type": "object",
@@ -7499,11 +7935,16 @@
           "role": {
             "type": "string",
             "description": "New role for the user",
-            "enum": ["admin", "user"],
+            "enum": [
+              "admin",
+              "user"
+            ],
             "example": "admin"
           }
         },
-        "required": ["role"]
+        "required": [
+          "role"
+        ]
       },
       "UpdateUserNameDto": {
         "type": "object",
@@ -7516,7 +7957,9 @@
             "maxLength": 100
           }
         },
-        "required": ["name"]
+        "required": [
+          "name"
+        ]
       },
       "UpdatePasswordDto": {
         "type": "object",
@@ -7555,7 +7998,9 @@
             "example": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
           }
         },
-        "required": ["token"]
+        "required": [
+          "token"
+        ]
       },
       "ResendEmailConfirmationDto": {
         "type": "object",
@@ -7567,7 +8012,9 @@
             "format": "email"
           }
         },
-        "required": ["email"]
+        "required": [
+          "email"
+        ]
       },
       "ForgotPasswordDto": {
         "type": "object",
@@ -7578,7 +8025,9 @@
             "example": "user@example.com"
           }
         },
-        "required": ["email"]
+        "required": [
+          "email"
+        ]
       },
       "ResetPasswordDto": {
         "type": "object",
@@ -7601,7 +8050,11 @@
             "minLength": 8
           }
         },
-        "required": ["resetToken", "newPassword", "newPasswordConfirmation"]
+        "required": [
+          "resetToken",
+          "newPassword",
+          "newPasswordConfirmation"
+        ]
       },
       "CreateUserDto": {
         "type": "object",
@@ -7619,7 +8072,10 @@
           "role": {
             "type": "string",
             "description": "Role for the user",
-            "enum": ["admin", "user"],
+            "enum": [
+              "admin",
+              "user"
+            ],
             "example": "user"
           },
           "sendPasswordResetEmail": {
@@ -7628,7 +8084,12 @@
             "example": true
           }
         },
-        "required": ["email", "name", "role", "sendPasswordResetEmail"]
+        "required": [
+          "email",
+          "name",
+          "role",
+          "sendPasswordResetEmail"
+        ]
       },
       "CreateInviteDto": {
         "type": "object",
@@ -7641,11 +8102,17 @@
           "role": {
             "type": "string",
             "description": "Role to assign to the invited user",
-            "enum": ["admin", "user"],
+            "enum": [
+              "admin",
+              "user"
+            ],
             "example": "user"
           }
         },
-        "required": ["email", "role"]
+        "required": [
+          "email",
+          "role"
+        ]
       },
       "CreateInviteResponseDto": {
         "type": "object",
@@ -7657,7 +8124,9 @@
             "nullable": true
           }
         },
-        "required": ["url"]
+        "required": [
+          "url"
+        ]
       },
       "CreateBulkInviteItemDto": {
         "type": "object",
@@ -7670,11 +8139,17 @@
           "role": {
             "type": "string",
             "description": "Role to assign to the invited user",
-            "enum": ["admin", "user"],
+            "enum": [
+              "admin",
+              "user"
+            ],
             "example": "user"
           }
         },
-        "required": ["email", "role"]
+        "required": [
+          "email",
+          "role"
+        ]
       },
       "CreateBulkInvitesDto": {
         "type": "object",
@@ -7689,7 +8164,9 @@
             }
           }
         },
-        "required": ["invites"]
+        "required": [
+          "invites"
+        ]
       },
       "BulkInviteResultDto": {
         "type": "object",
@@ -7702,7 +8179,10 @@
           "role": {
             "type": "string",
             "description": "Role assigned to the invited user",
-            "enum": ["admin", "user"],
+            "enum": [
+              "admin",
+              "user"
+            ],
             "example": "user"
           },
           "success": {
@@ -7764,7 +8244,12 @@
             }
           }
         },
-        "required": ["totalCount", "successCount", "failureCount", "results"]
+        "required": [
+          "totalCount",
+          "successCount",
+          "failureCount",
+          "results"
+        ]
       },
       "InviteResponseDto": {
         "type": "object",
@@ -7783,13 +8268,20 @@
           "role": {
             "type": "string",
             "description": "Role assigned to the invited user",
-            "enum": ["admin", "user"],
+            "enum": [
+              "admin",
+              "user"
+            ],
             "example": "user"
           },
           "status": {
             "type": "string",
             "description": "Current status of the invite",
-            "enum": ["pending", "accepted", "expired"],
+            "enum": [
+              "pending",
+              "accepted",
+              "expired"
+            ],
             "example": "pending"
           },
           "sentDate": {
@@ -7811,7 +8303,14 @@
             "example": "2023-12-02T15:30:00Z"
           }
         },
-        "required": ["id", "email", "role", "status", "sentDate", "expiresAt"]
+        "required": [
+          "id",
+          "email",
+          "role",
+          "status",
+          "sentDate",
+          "expiresAt"
+        ]
       },
       "PaginatedInvitesListResponseDto": {
         "type": "object",
@@ -7832,7 +8331,10 @@
             ]
           }
         },
-        "required": ["data", "pagination"]
+        "required": [
+          "data",
+          "pagination"
+        ]
       },
       "InviteDetailResponseDto": {
         "type": "object",
@@ -7851,13 +8353,20 @@
           "role": {
             "type": "string",
             "description": "Role assigned to the invited user",
-            "enum": ["admin", "user"],
+            "enum": [
+              "admin",
+              "user"
+            ],
             "example": "user"
           },
           "status": {
             "type": "string",
             "description": "Current status of the invite",
-            "enum": ["pending", "accepted", "expired"],
+            "enum": [
+              "pending",
+              "accepted",
+              "expired"
+            ],
             "example": "pending"
           },
           "sentDate": {
@@ -7946,7 +8455,11 @@
             "format": "uuid"
           }
         },
-        "required": ["inviteId", "email", "orgId"]
+        "required": [
+          "inviteId",
+          "email",
+          "orgId"
+        ]
       },
       "DeleteAllPendingInvitesResponseDto": {
         "type": "object",
@@ -7956,7 +8469,9 @@
             "description": "Number of invites deleted"
           }
         },
-        "required": ["deletedCount"]
+        "required": [
+          "deletedCount"
+        ]
       },
       "SubscriptionBillingInfoResponseDto": {
         "type": "object",
@@ -8051,7 +8566,10 @@
           "renewalCycle": {
             "type": "string",
             "description": "Renewal cycle of the subscription",
-            "enum": ["monthly", "yearly"],
+            "enum": [
+              "monthly",
+              "yearly"
+            ],
             "example": "monthly"
           },
           "renewalCycleAnchor": {
@@ -8176,7 +8694,9 @@
             "example": true
           }
         },
-        "required": ["hasActiveSubscription"]
+        "required": [
+          "hasActiveSubscription"
+        ]
       },
       "UpdateBillingInfoDto": {
         "type": "object",
@@ -8235,7 +8755,9 @@
             "example": 29.99
           }
         },
-        "required": ["pricePerSeatMonthly"]
+        "required": [
+          "pricePerSeatMonthly"
+        ]
       },
       "UpdateSeatsDto": {
         "type": "object",
@@ -8271,7 +8793,11 @@
             "example": "2024-01-01T00:00:00.000Z"
           }
         },
-        "required": ["objectName", "size", "etag"]
+        "required": [
+          "objectName",
+          "size",
+          "etag"
+        ]
       },
       "RetrieveUrlDto": {
         "type": "object",
@@ -8282,7 +8808,9 @@
             "example": "https://example.com/article"
           }
         },
-        "required": ["url"]
+        "required": [
+          "url"
+        ]
       },
       "CreateThreadDto": {
         "type": "object",
@@ -8329,7 +8857,9 @@
             "type": "string",
             "description": "Role of the message sender",
             "example": "user",
-            "enum": ["user"]
+            "enum": [
+              "user"
+            ]
           },
           "content": {
             "type": "array",
@@ -8346,7 +8876,13 @@
             }
           }
         },
-        "required": ["id", "threadId", "createdAt", "role", "content"]
+        "required": [
+          "id",
+          "threadId",
+          "createdAt",
+          "role",
+          "content"
+        ]
       },
       "SystemMessageResponseDto": {
         "type": "object",
@@ -8370,7 +8906,9 @@
             "type": "string",
             "description": "Role of the message sender",
             "example": "system",
-            "enum": ["system"]
+            "enum": [
+              "system"
+            ]
           },
           "content": {
             "type": "array",
@@ -8380,7 +8918,13 @@
             }
           }
         },
-        "required": ["id", "threadId", "createdAt", "role", "content"]
+        "required": [
+          "id",
+          "threadId",
+          "createdAt",
+          "role",
+          "content"
+        ]
       },
       "AssistantMessageResponseDto": {
         "type": "object",
@@ -8404,7 +8948,9 @@
             "type": "string",
             "description": "Role of the message sender",
             "example": "assistant",
-            "enum": ["assistant"]
+            "enum": [
+              "assistant"
+            ]
           },
           "content": {
             "type": "array",
@@ -8424,7 +8970,13 @@
             }
           }
         },
-        "required": ["id", "threadId", "createdAt", "role", "content"]
+        "required": [
+          "id",
+          "threadId",
+          "createdAt",
+          "role",
+          "content"
+        ]
       },
       "ToolResultMessageResponseDto": {
         "type": "object",
@@ -8448,7 +9000,9 @@
             "type": "string",
             "description": "Role of the message sender",
             "example": "tool",
-            "enum": ["tool"]
+            "enum": [
+              "tool"
+            ]
           },
           "content": {
             "type": "array",
@@ -8458,7 +9012,13 @@
             }
           }
         },
-        "required": ["id", "threadId", "createdAt", "role", "content"]
+        "required": [
+          "id",
+          "threadId",
+          "createdAt",
+          "role",
+          "content"
+        ]
       },
       "TextMessageContentResponseDto": {
         "type": "object",
@@ -8467,7 +9027,13 @@
             "type": "string",
             "description": "Type of the message content",
             "example": "text",
-            "enum": ["text", "tool_use", "tool_result", "thinking", "image"]
+            "enum": [
+              "text",
+              "tool_use",
+              "tool_result",
+              "thinking",
+              "image"
+            ]
           },
           "text": {
             "type": "string",
@@ -8475,7 +9041,10 @@
             "example": "Hello, how can I help you today?"
           }
         },
-        "required": ["type", "text"]
+        "required": [
+          "type",
+          "text"
+        ]
       },
       "ToolUseMessageContentResponseDto": {
         "type": "object",
@@ -8484,7 +9053,13 @@
             "type": "string",
             "description": "Type of the message content",
             "example": "text",
-            "enum": ["text", "tool_use", "tool_result", "thinking", "image"]
+            "enum": [
+              "text",
+              "tool_use",
+              "tool_result",
+              "thinking",
+              "image"
+            ]
           },
           "id": {
             "type": "string",
@@ -8505,7 +9080,12 @@
             }
           }
         },
-        "required": ["type", "id", "name", "params"]
+        "required": [
+          "type",
+          "id",
+          "name",
+          "params"
+        ]
       },
       "ToolResultMessageContentResponseDto": {
         "type": "object",
@@ -8514,7 +9094,13 @@
             "type": "string",
             "description": "Type of the message content",
             "example": "text",
-            "enum": ["text", "tool_use", "tool_result", "thinking", "image"]
+            "enum": [
+              "text",
+              "tool_use",
+              "tool_result",
+              "thinking",
+              "image"
+            ]
           },
           "toolId": {
             "type": "string",
@@ -8532,7 +9118,12 @@
             "example": "The current temperature in New York is 22°C with partly cloudy skies."
           }
         },
-        "required": ["type", "toolId", "toolName", "result"]
+        "required": [
+          "type",
+          "toolId",
+          "toolName",
+          "result"
+        ]
       },
       "ThinkingMessageContentResponseDto": {
         "type": "object",
@@ -8541,7 +9132,13 @@
             "type": "string",
             "description": "Type of the message content",
             "example": "text",
-            "enum": ["text", "tool_use", "tool_result", "thinking", "image"]
+            "enum": [
+              "text",
+              "tool_use",
+              "tool_result",
+              "thinking",
+              "image"
+            ]
           },
           "thinking": {
             "type": "string",
@@ -8549,7 +9146,10 @@
             "example": "I am thinking about the best way to help you."
           }
         },
-        "required": ["type", "thinking"]
+        "required": [
+          "type",
+          "thinking"
+        ]
       },
       "ImageMessageContentResponseDto": {
         "type": "object",
@@ -8558,7 +9158,13 @@
             "type": "string",
             "description": "Type of the message content",
             "example": "text",
-            "enum": ["text", "tool_use", "tool_result", "thinking", "image"]
+            "enum": [
+              "text",
+              "tool_use",
+              "tool_result",
+              "thinking",
+              "image"
+            ]
           },
           "imageUrl": {
             "type": "string",
@@ -8571,7 +9177,10 @@
             "example": "Screenshot of the reported issue"
           }
         },
-        "required": ["type", "imageUrl"]
+        "required": [
+          "type",
+          "imageUrl"
+        ]
       },
       "ModelResponseDto": {
         "type": "object",
@@ -8635,12 +9244,19 @@
           "type": {
             "type": "string",
             "description": "Type of source",
-            "enum": ["text", "data"]
+            "enum": [
+              "text",
+              "data"
+            ]
           },
           "createdBy": {
             "type": "string",
             "description": "Creator of the source",
-            "enum": ["user", "llm", "system"]
+            "enum": [
+              "user",
+              "llm",
+              "system"
+            ]
           },
           "createdAt": {
             "type": "string",
@@ -8679,12 +9295,19 @@
           "type": {
             "type": "string",
             "description": "Type of source",
-            "enum": ["text", "data"]
+            "enum": [
+              "text",
+              "data"
+            ]
           },
           "createdBy": {
             "type": "string",
             "description": "Creator of the source",
-            "enum": ["user", "llm", "system"]
+            "enum": [
+              "user",
+              "llm",
+              "system"
+            ]
           },
           "createdAt": {
             "type": "string",
@@ -8697,12 +9320,19 @@
           "textType": {
             "type": "string",
             "description": "Type of text",
-            "enum": ["file", "web"]
+            "enum": [
+              "file",
+              "web"
+            ]
           },
           "fileType": {
             "type": "string",
             "description": "Type of file",
-            "enum": ["pdf", "docx", "pptx"]
+            "enum": [
+              "pdf",
+              "docx",
+              "pptx"
+            ]
           }
         },
         "required": [
@@ -8735,12 +9365,19 @@
           "type": {
             "type": "string",
             "description": "Type of source",
-            "enum": ["text", "data"]
+            "enum": [
+              "text",
+              "data"
+            ]
           },
           "createdBy": {
             "type": "string",
             "description": "Creator of the source",
-            "enum": ["user", "llm", "system"]
+            "enum": [
+              "user",
+              "llm",
+              "system"
+            ]
           },
           "createdAt": {
             "type": "string",
@@ -8753,7 +9390,10 @@
           "textType": {
             "type": "string",
             "description": "Type of text",
-            "enum": ["file", "web"]
+            "enum": [
+              "file",
+              "web"
+            ]
           },
           "url": {
             "type": "string",
@@ -8790,12 +9430,19 @@
           "type": {
             "type": "string",
             "description": "Type of source",
-            "enum": ["text", "data"]
+            "enum": [
+              "text",
+              "data"
+            ]
           },
           "createdBy": {
             "type": "string",
             "description": "Creator of the source",
-            "enum": ["user", "llm", "system"]
+            "enum": [
+              "user",
+              "llm",
+              "system"
+            ]
           },
           "createdAt": {
             "type": "string",
@@ -8808,7 +9455,9 @@
           "dataType": {
             "type": "string",
             "description": "Type of data",
-            "enum": ["csv"]
+            "enum": [
+              "csv"
+            ]
           },
           "data": {
             "type": "object",
@@ -8965,7 +9614,12 @@
             "example": false
           }
         },
-        "required": ["id", "createdAt", "updatedAt", "isAnonymous"]
+        "required": [
+          "id",
+          "createdAt",
+          "updatedAt",
+          "isAnonymous"
+        ]
       },
       "GetThreadsResponseDto": {
         "type": "object",
@@ -8986,7 +9640,10 @@
             ]
           }
         },
-        "required": ["data", "pagination"]
+        "required": [
+          "data",
+          "pagination"
+        ]
       },
       "UpdateThreadTitleDto": {
         "type": "object",
@@ -8999,7 +9656,9 @@
             "maxLength": 200
           }
         },
-        "required": ["title"]
+        "required": [
+          "title"
+        ]
       },
       "ToolAssignmentDto": {
         "type": "object",
@@ -9035,7 +9694,9 @@
             "format": "uuid"
           }
         },
-        "required": ["type"]
+        "required": [
+          "type"
+        ]
       },
       "CreateAgentDto": {
         "type": "object",
@@ -9066,7 +9727,12 @@
             }
           }
         },
-        "required": ["name", "instructions", "modelId", "toolAssignments"]
+        "required": [
+          "name",
+          "instructions",
+          "modelId",
+          "toolAssignments"
+        ]
       },
       "ToolResponseDto": {
         "type": "object",
@@ -9096,7 +9762,9 @@
             ]
           }
         },
-        "required": ["type"]
+        "required": [
+          "type"
+        ]
       },
       "AgentSourceResponseDto": {
         "type": "object",
@@ -9122,10 +9790,18 @@
             "type": "string",
             "description": "The type of source",
             "example": "file",
-            "enum": ["file", "url"]
+            "enum": [
+              "file",
+              "url"
+            ]
           }
         },
-        "required": ["id", "sourceId", "name", "type"]
+        "required": [
+          "id",
+          "sourceId",
+          "name",
+          "type"
+        ]
       },
       "AgentResponseDto": {
         "type": "object",
@@ -9239,7 +9915,11 @@
             "format": "uuid"
           }
         },
-        "required": ["name", "instructions", "modelId"]
+        "required": [
+          "name",
+          "instructions",
+          "modelId"
+        ]
       },
       "McpIntegrationResponseDto": {
         "type": "object",
@@ -9257,7 +9937,10 @@
           "type": {
             "type": "string",
             "description": "Type of integration",
-            "enum": ["predefined", "custom"],
+            "enum": [
+              "predefined",
+              "custom"
+            ],
             "example": "predefined"
           },
           "slug": {
@@ -9283,7 +9966,12 @@
           "authMethod": {
             "type": "string",
             "description": "Authentication method used",
-            "enum": ["NO_AUTH", "BEARER_TOKEN", "CUSTOM_HEADER", "OAUTH"],
+            "enum": [
+              "NO_AUTH",
+              "BEARER_TOKEN",
+              "CUSTOM_HEADER",
+              "OAUTH"
+            ],
             "example": "BEARER_TOKEN"
           },
           "authHeaderName": {
@@ -9299,7 +9987,12 @@
           "connectionStatus": {
             "type": "string",
             "description": "Connection status of the integration",
-            "enum": ["connected", "disconnected", "error", "unknown"],
+            "enum": [
+              "connected",
+              "disconnected",
+              "error",
+              "unknown"
+            ],
             "example": "connected"
           },
           "lastConnectionError": {
@@ -9349,7 +10042,11 @@
           "entityType": {
             "type": "string",
             "description": "Type of entity being shared",
-            "enum": ["agent", "prompt", "skill"]
+            "enum": [
+              "agent",
+              "prompt",
+              "skill"
+            ]
           },
           "agentId": {
             "type": "string",
@@ -9362,7 +10059,10 @@
             "format": "uuid"
           }
         },
-        "required": ["entityType", "agentId"]
+        "required": [
+          "entityType",
+          "agentId"
+        ]
       },
       "ShareResponseDto": {
         "type": "object",
@@ -9375,7 +10075,11 @@
           "entityType": {
             "type": "string",
             "description": "Type of entity being shared",
-            "enum": ["agent", "prompt", "skill"]
+            "enum": [
+              "agent",
+              "prompt",
+              "skill"
+            ]
           },
           "entityId": {
             "type": "string",
@@ -9385,7 +10089,10 @@
           "scopeType": {
             "type": "string",
             "description": "Type of share scope (organization, user, or team)",
-            "enum": ["org", "team"]
+            "enum": [
+              "org",
+              "team"
+            ]
           },
           "ownerId": {
             "type": "string",
@@ -9428,7 +10135,11 @@
           "entityType": {
             "type": "string",
             "description": "Type of entity being shared",
-            "enum": ["agent", "prompt", "skill"]
+            "enum": [
+              "agent",
+              "prompt",
+              "skill"
+            ]
           },
           "skillId": {
             "type": "string",
@@ -9441,7 +10152,10 @@
             "format": "uuid"
           }
         },
-        "required": ["entityType", "skillId"]
+        "required": [
+          "entityType",
+          "skillId"
+        ]
       },
       "CreateTeamDto": {
         "type": "object",
@@ -9452,7 +10166,9 @@
             "example": "Engineering"
           }
         },
-        "required": ["name"]
+        "required": [
+          "name"
+        ]
       },
       "UpdateTeamDto": {
         "type": "object",
@@ -9463,7 +10179,9 @@
             "example": "Engineering"
           }
         },
-        "required": ["name"]
+        "required": [
+          "name"
+        ]
       },
       "TeamResponseDto": {
         "type": "object",
@@ -9496,7 +10214,13 @@
             "example": "2024-01-15T10:30:00.000Z"
           }
         },
-        "required": ["id", "name", "orgId", "createdAt", "updatedAt"]
+        "required": [
+          "id",
+          "name",
+          "orgId",
+          "createdAt",
+          "updatedAt"
+        ]
       },
       "TeamMemberResponseDto": {
         "type": "object",
@@ -9524,7 +10248,10 @@
           "userRole": {
             "type": "string",
             "description": "The role of the team member in the organization",
-            "enum": ["admin", "user"],
+            "enum": [
+              "admin",
+              "user"
+            ],
             "example": "user"
           },
           "joinedAt": {
@@ -9562,7 +10289,10 @@
             ]
           }
         },
-        "required": ["data", "pagination"]
+        "required": [
+          "data",
+          "pagination"
+        ]
       },
       "AddTeamMemberDto": {
         "type": "object",
@@ -9573,7 +10303,9 @@
             "example": "550e8400-e29b-41d4-a716-446655440001"
           }
         },
-        "required": ["userId"]
+        "required": [
+          "userId"
+        ]
       },
       "ListTeamMembersQueryDto": {
         "type": "object",
@@ -9598,7 +10330,11 @@
           "name": {
             "type": "string",
             "description": "The name/type of the credential field",
-            "enum": ["token", "clientId", "clientSecret"],
+            "enum": [
+              "token",
+              "clientId",
+              "clientSecret"
+            ],
             "example": "token"
           },
           "value": {
@@ -9607,7 +10343,10 @@
             "example": "sk_test_123abc"
           }
         },
-        "required": ["name", "value"]
+        "required": [
+          "name",
+          "value"
+        ]
       },
       "CreatePredefinedIntegrationDto": {
         "type": "object",
@@ -9616,7 +10355,11 @@
             "type": "string",
             "description": "The predefined integration slug",
             "example": "TEST",
-            "enum": ["TEST", "LOCABOO", "LEGAL_CODES"]
+            "enum": [
+              "TEST",
+              "LOCABOO",
+              "LEGAL_CODES"
+            ]
           },
           "configValues": {
             "description": "List of config values for credential fields",
@@ -9638,7 +10381,10 @@
             "default": true
           }
         },
-        "required": ["slug", "configValues"]
+        "required": [
+          "slug",
+          "configValues"
+        ]
       },
       "CreateCustomIntegrationDto": {
         "type": "object",
@@ -9658,7 +10404,12 @@
           "authMethod": {
             "type": "string",
             "description": "Authentication method for the MCP server",
-            "enum": ["NO_AUTH", "BEARER_TOKEN", "CUSTOM_HEADER", "OAUTH"],
+            "enum": [
+              "NO_AUTH",
+              "BEARER_TOKEN",
+              "CUSTOM_HEADER",
+              "OAUTH"
+            ],
             "example": "CUSTOM_HEADER",
             "nullable": true
           },
@@ -9679,7 +10430,10 @@
             "default": true
           }
         },
-        "required": ["name", "serverUrl"]
+        "required": [
+          "name",
+          "serverUrl"
+        ]
       },
       "CredentialFieldDto": {
         "type": "object",
@@ -9692,7 +10446,11 @@
           "type": {
             "type": "string",
             "description": "Input type (text or password)",
-            "enum": ["token", "clientId", "clientSecret"],
+            "enum": [
+              "token",
+              "clientId",
+              "clientSecret"
+            ],
             "example": "token"
           },
           "required": {
@@ -9706,7 +10464,11 @@
             "example": "Your Locaboo 3 API token will be used to authenticate with Locaboo 4"
           }
         },
-        "required": ["label", "type", "required"]
+        "required": [
+          "label",
+          "type",
+          "required"
+        ]
       },
       "PredefinedConfigResponseDto": {
         "type": "object",
@@ -9729,7 +10491,12 @@
           "authType": {
             "type": "string",
             "description": "Authentication method for this integration",
-            "enum": ["NO_AUTH", "BEARER_TOKEN", "API_KEY", "OAUTH"],
+            "enum": [
+              "NO_AUTH",
+              "BEARER_TOKEN",
+              "API_KEY",
+              "OAUTH"
+            ],
             "example": "BEARER_TOKEN"
           },
           "authHeaderName": {
@@ -9745,7 +10512,12 @@
             }
           }
         },
-        "required": ["slug", "displayName", "description", "authType"]
+        "required": [
+          "slug",
+          "displayName",
+          "description",
+          "authType"
+        ]
       },
       "UpdateMcpIntegrationDto": {
         "type": "object",
@@ -9797,7 +10569,10 @@
             "example": "Connection timeout"
           }
         },
-        "required": ["valid", "capabilities"]
+        "required": [
+          "valid",
+          "capabilities"
+        ]
       },
       "InstallSkillFromMarketplaceDto": {
         "type": "object",
@@ -9808,7 +10583,9 @@
             "example": "meeting-summarizer"
           }
         },
-        "required": ["identifier"]
+        "required": [
+          "identifier"
+        ]
       },
       "SkillResponseDto": {
         "type": "object",
@@ -9908,7 +10685,11 @@
             "example": true
           }
         },
-        "required": ["name", "shortDescription", "instructions"]
+        "required": [
+          "name",
+          "shortDescription",
+          "instructions"
+        ]
       },
       "UpdateSkillDto": {
         "type": "object",
@@ -9931,7 +10712,11 @@
             "example": "You are a legal research assistant. When activated, search through the attached legal databases..."
           }
         },
-        "required": ["name", "shortDescription", "instructions"]
+        "required": [
+          "name",
+          "shortDescription",
+          "instructions"
+        ]
       },
       "SkillSourceResponseDto": {
         "type": "object",
@@ -9953,7 +10738,11 @@
             "example": "file"
           }
         },
-        "required": ["id", "name", "type"]
+        "required": [
+          "id",
+          "name",
+          "type"
+        ]
       },
       "MarketplaceSkillResponseDto": {
         "type": "object",
@@ -10034,10 +10823,18 @@
             "type": "string",
             "description": "Type of the message content",
             "example": "text",
-            "enum": ["text", "tool_use", "tool_result", "thinking", "image"]
+            "enum": [
+              "text",
+              "tool_use",
+              "tool_result",
+              "thinking",
+              "image"
+            ]
           }
         },
-        "required": ["type"]
+        "required": [
+          "type"
+        ]
       },
       "RunSessionResponseDto": {
         "type": "object",
@@ -10046,7 +10843,9 @@
             "type": "string",
             "description": "Response type identifier",
             "example": "session",
-            "enum": ["session"]
+            "enum": [
+              "session"
+            ]
           },
           "success": {
             "type": "boolean",
@@ -10069,7 +10868,11 @@
             "example": "2024-01-01T12:00:00.000Z"
           }
         },
-        "required": ["type", "threadId", "timestamp"]
+        "required": [
+          "type",
+          "threadId",
+          "timestamp"
+        ]
       },
       "RunMessageResponseDto": {
         "type": "object",
@@ -10078,7 +10881,9 @@
             "type": "string",
             "description": "Response type identifier",
             "example": "message",
-            "enum": ["message"]
+            "enum": [
+              "message"
+            ]
           },
           "message": {
             "description": "The message data",
@@ -10108,7 +10913,12 @@
             "example": "2024-01-01T12:00:00.000Z"
           }
         },
-        "required": ["type", "message", "threadId", "timestamp"]
+        "required": [
+          "type",
+          "message",
+          "threadId",
+          "timestamp"
+        ]
       },
       "RunErrorResponseDto": {
         "type": "object",
@@ -10117,7 +10927,9 @@
             "type": "string",
             "description": "Response type identifier",
             "example": "error",
-            "enum": ["error"]
+            "enum": [
+              "error"
+            ]
           },
           "message": {
             "type": "string",
@@ -10147,7 +10959,12 @@
             }
           }
         },
-        "required": ["type", "message", "threadId", "timestamp"]
+        "required": [
+          "type",
+          "message",
+          "threadId",
+          "timestamp"
+        ]
       },
       "RunThreadResponseDto": {
         "type": "object",
@@ -10156,7 +10973,9 @@
             "type": "string",
             "description": "Response type identifier",
             "example": "thread",
-            "enum": ["thread"]
+            "enum": [
+              "thread"
+            ]
           },
           "threadId": {
             "type": "string",
@@ -10167,7 +10986,9 @@
             "type": "string",
             "description": "Type of thread update",
             "example": "title_updated",
-            "enum": ["title_updated"]
+            "enum": [
+              "title_updated"
+            ]
           },
           "title": {
             "type": "string",
@@ -10180,7 +11001,13 @@
             "example": "2024-01-01T12:00:00.000Z"
           }
         },
-        "required": ["type", "threadId", "updateType", "title", "timestamp"]
+        "required": [
+          "type",
+          "threadId",
+          "updateType",
+          "title",
+          "timestamp"
+        ]
       },
       "TextInput": {
         "type": "object",
@@ -10188,7 +11015,9 @@
           "type": {
             "type": "string",
             "description": "The type of input",
-            "enum": ["text"],
+            "enum": [
+              "text"
+            ],
             "example": "text"
           },
           "text": {
@@ -10197,7 +11026,10 @@
             "example": "What is the weather forecast for New York tomorrow?"
           }
         },
-        "required": ["type", "text"]
+        "required": [
+          "type",
+          "text"
+        ]
       },
       "ToolResultInput": {
         "type": "object",
@@ -10205,7 +11037,9 @@
           "type": {
             "type": "string",
             "description": "The type of input",
-            "enum": ["tool_result"],
+            "enum": [
+              "tool_result"
+            ],
             "example": "tool_result"
           },
           "toolId": {
@@ -10224,7 +11058,12 @@
             "example": "{\"location\":\"New York\",\"forecast\":\"Partly cloudy with a high of 75°F and a low of 60°F\",\"precipitation\":\"20%\"}"
           }
         },
-        "required": ["type", "toolId", "toolName", "result"]
+        "required": [
+          "type",
+          "toolId",
+          "toolName",
+          "result"
+        ]
       },
       "SendMessageDto": {
         "type": "object",
@@ -10266,7 +11105,9 @@
             "default": true
           }
         },
-        "required": ["threadId"]
+        "required": [
+          "threadId"
+        ]
       },
       "SuperAdminTrialResponseDto": {
         "type": "object",
@@ -10346,7 +11187,10 @@
             "minimum": 1
           }
         },
-        "required": ["orgId", "maxMessages"]
+        "required": [
+          "orgId",
+          "maxMessages"
+        ]
       },
       "UpdateTrialRequestDto": {
         "type": "object",
@@ -10374,7 +11218,9 @@
             "example": true
           }
         },
-        "required": ["isSelfHosted"]
+        "required": [
+          "isSelfHosted"
+        ]
       },
       "UsageStatsResponseDto": {
         "type": "object",
@@ -10401,7 +11247,11 @@
           },
           "topModels": {
             "description": "List of the most frequently used model names, ordered by usage",
-            "example": ["gpt-4", "claude-3-sonnet", "gpt-3.5-turbo"],
+            "example": [
+              "gpt-4",
+              "claude-3-sonnet",
+              "gpt-3.5-turbo"
+            ],
             "type": "array",
             "items": {
               "type": "string"
@@ -10433,7 +11283,11 @@
             "description": "Number of requests at this point"
           }
         },
-        "required": ["date", "tokens", "requests"]
+        "required": [
+          "date",
+          "tokens",
+          "requests"
+        ]
       },
       "ProviderUsageDto": {
         "type": "object",
@@ -10450,7 +11304,8 @@
               "ayunis",
               "otc",
               "azure",
-              "gemini"
+              "gemini",
+              "stackit"
             ],
             "description": "Model provider"
           },
@@ -10493,7 +11348,9 @@
             }
           }
         },
-        "required": ["providers"]
+        "required": [
+          "providers"
+        ]
       },
       "ProviderValuesDto": {
         "type": "object",
@@ -10541,7 +11398,10 @@
             ]
           }
         },
-        "required": ["date", "values"]
+        "required": [
+          "date",
+          "values"
+        ]
       },
       "ProviderUsageChartResponseDto": {
         "type": "object",
@@ -10554,7 +11414,9 @@
             }
           }
         },
-        "required": ["timeSeries"]
+        "required": [
+          "timeSeries"
+        ]
       },
       "ModelDistributionDto": {
         "type": "object",
@@ -10583,7 +11445,8 @@
               "ayunis",
               "otc",
               "azure",
-              "gemini"
+              "gemini",
+              "stackit"
             ],
             "description": "Model provider"
           },
@@ -10621,7 +11484,9 @@
             }
           }
         },
-        "required": ["models"]
+        "required": [
+          "models"
+        ]
       },
       "UserUsageDto": {
         "type": "object",
@@ -10686,7 +11551,10 @@
             ]
           }
         },
-        "required": ["data", "pagination"]
+        "required": [
+          "data",
+          "pagination"
+        ]
       },
       "UserSystemPromptResponseDto": {
         "type": "object",
@@ -10698,7 +11566,9 @@
             "nullable": true
           }
         },
-        "required": ["systemPrompt"]
+        "required": [
+          "systemPrompt"
+        ]
       },
       "UpsertUserSystemPromptDto": {
         "type": "object",
@@ -10710,7 +11580,9 @@
             "maxLength": 10000
           }
         },
-        "required": ["systemPrompt"]
+        "required": [
+          "systemPrompt"
+        ]
       },
       "CreatePromptDto": {
         "type": "object",
@@ -10728,7 +11600,10 @@
             "example": "You are a helpful assistant that helps with project planning. Please provide detailed step-by-step guidance for managing projects effectively."
           }
         },
-        "required": ["title", "content"]
+        "required": [
+          "title",
+          "content"
+        ]
       },
       "PromptResponseDto": {
         "type": "object",
@@ -10793,7 +11668,10 @@
             "example": "You are an expert project planning assistant. Provide comprehensive guidance for project management, including risk assessment and timeline optimization."
           }
         },
-        "required": ["title", "content"]
+        "required": [
+          "title",
+          "content"
+        ]
       },
       "TranscriptionResponseDto": {
         "type": "object",
@@ -10804,7 +11682,9 @@
             "example": "Hello, this is a test transcription."
           }
         },
-        "required": ["text"]
+        "required": [
+          "text"
+        ]
       },
       "LoginDto": {
         "type": "object",
@@ -10820,7 +11700,10 @@
             "example": "password123"
           }
         },
-        "required": ["email", "password"]
+        "required": [
+          "email",
+          "password"
+        ]
       },
       "SuccessResponseDto": {
         "type": "object",
@@ -10831,7 +11714,9 @@
             "example": true
           }
         },
-        "required": ["success"]
+        "required": [
+          "success"
+        ]
       },
       "ErrorResponseDto": {
         "type": "object",
@@ -10842,7 +11727,9 @@
             "example": "Authentication failed"
           }
         },
-        "required": ["message"]
+        "required": [
+          "message"
+        ]
       },
       "RegisterDto": {
         "type": "object",
@@ -10892,13 +11779,19 @@
           "role": {
             "type": "string",
             "description": "User role",
-            "enum": ["admin", "user"],
+            "enum": [
+              "admin",
+              "user"
+            ],
             "example": "user"
           },
           "systemRole": {
             "type": "string",
             "description": "User system role",
-            "enum": ["customer", "super_admin"],
+            "enum": [
+              "customer",
+              "super_admin"
+            ],
             "example": "super_admin"
           },
           "name": {
@@ -10907,7 +11800,12 @@
             "example": "John Doe"
           }
         },
-        "required": ["email", "role", "systemRole", "name"]
+        "required": [
+          "email",
+          "role",
+          "systemRole",
+          "name"
+        ]
       }
     }
   }

--- a/ayunis-core-frontend/src/shared/lib/getFlagByProvider.ts
+++ b/ayunis-core-frontend/src/shared/lib/getFlagByProvider.ts
@@ -8,6 +8,7 @@ export function getFlagByProvider(provider: Provider): string {
     case 'ayunis':
     case 'synaforce':
     case 'ollama':
+    case 'stackit':
       return `🇩🇪`;
     case 'mistral':
     case 'bedrock':


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Includes a PostgreSQL enum migration and new inference routing paths, which can impact existing deployments if migrations or provider configuration are incorrect; changes are otherwise additive and isolated to model-provider plumbing.
> 
> **Overview**
> Adds **STACKIT** as a new model provider end-to-end.
> 
> Backend adds `models.stackit` configuration (token + OpenAI-compatible base URL), introduces `StackitInferenceHandler` and `StackitStreamInferenceHandler` wired into the inference registries, registers provider metadata (hosted in DE), and extends the `ModelProvider` enum plus a TypeORM migration to add `stackit` to the `models`/`usage` provider enums.
> 
> Frontend updates generated API schema enums and UI/provider constants so `stackit` appears with the correct label and DE hosting priority in admin/super-admin model settings.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e501733a45f92acfdced8110fb4c104b49658d86. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->