### PR TITLE
chore: add weekly cleanup of orphaned cursor branches

### DIFF
--- a/.github/workflows/cleanup-cursor-branches.yml
+++ b/.github/workflows/cleanup-cursor-branches.yml
@@ -45,7 +45,7 @@ jobs:
           echo ""
 
           # Get all non-cursor, non-main remote branches (potential base branches)
-          feature_branches=$(git branch -r | grep -v 'origin/cursor/' | grep -v 'origin/main' | grep -v 'origin/HEAD' | sed 's/origin\///' | xargs || true)
+          feature_branches=$(git branch -r | grep -v 'origin/cursor/' | grep -v '^[[:space:]]*origin/main$' | grep -v 'origin/HEAD' | sed 's/origin\///' | xargs || true)
 
           deleted_count=0
           skipped_count=0

--- a/.github/workflows/cleanup-cursor-branches.yml
+++ b/.github/workflows/cleanup-cursor-branches.yml
@@ -45,7 +45,7 @@ jobs:
           echo ""
 
           # Get all non-cursor, non-main remote branches (potential base branches)
-          feature_branches=$(git branch -r | grep -v 'origin/cursor/' | grep -v 'origin/main' | grep -v 'origin/HEAD' | sed 's/origin\///' | xargs)
+          feature_branches=$(git branch -r | grep -v 'origin/cursor/' | grep -v 'origin/main' | grep -v 'origin/HEAD' | sed 's/origin\///' | xargs || true)
 
           deleted_count=0
           skipped_count=0
@@ -79,7 +79,6 @@ jobs:
               if git merge-base --is-ancestor "$merge_base" "origin/$fb" 2>/dev/null; then
                 # Check if the cursor branch is based on this feature branch
                 # (cursor branch tip should have this feature branch in its history)
-                fb_tip=$(git rev-parse "origin/$fb" 2>/dev/null || echo "")
                 cursor_base=$(git merge-base "origin/$fb" "origin/$branch" 2>/dev/null || echo "")
                 
                 # If the cursor branch and feature branch share more history than just main

--- a/.github/workflows/cleanup-cursor-branches.yml
+++ b/.github/workflows/cleanup-cursor-branches.yml
@@ -1,0 +1,118 @@
+name: Cleanup Cursor Branches
+
+on:
+  schedule:
+    # Run every Sunday at 3:00 AM UTC
+    - cron: '0 3 * * 0'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run (list branches without deleting)'
+        type: boolean
+        default: false
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Cleanup orphaned cursor branches
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
+        run: |
+          set -euo pipefail
+
+          echo "🔍 Fetching all remote branches..."
+          git fetch --all --prune
+
+          echo ""
+          echo "📋 Finding cursor/* branches..."
+          cursor_branches=$(git branch -r --list 'origin/cursor/*' | sed 's/origin\///' | xargs)
+
+          if [ -z "$cursor_branches" ]; then
+            echo "✅ No cursor branches found. Nothing to clean up."
+            exit 0
+          fi
+
+          echo "Found $(echo $cursor_branches | wc -w) cursor branches"
+          echo ""
+
+          # Get all non-cursor, non-main remote branches (potential base branches)
+          feature_branches=$(git branch -r | grep -v 'origin/cursor/' | grep -v 'origin/main' | grep -v 'origin/HEAD' | sed 's/origin\///' | xargs)
+
+          deleted_count=0
+          skipped_count=0
+
+          for branch in $cursor_branches; do
+            echo "----------------------------------------"
+            echo "Checking: $branch"
+            
+            # Find the merge-base between this cursor branch and main
+            merge_base=$(git merge-base origin/main "origin/$branch" 2>/dev/null || echo "")
+            
+            if [ -z "$merge_base" ]; then
+              echo "  ⚠️  Could not determine merge base, skipping"
+              skipped_count=$((skipped_count + 1))
+              continue
+            fi
+
+            # Check which branches contain this merge-base commit
+            # If only main contains it, the original base branch was merged and deleted
+            branches_with_base=$(git branch -r --contains "$merge_base" 2>/dev/null | grep -v 'origin/cursor/' | grep -v 'origin/HEAD' | sed 's/origin\///' | xargs)
+            
+            echo "  📍 Merge-base: ${merge_base:0:8}"
+            echo "  📂 Non-cursor branches containing merge-base: $branches_with_base"
+
+            # Check if any feature branch (non-main, non-cursor) still contains this merge-base
+            # AND is an ancestor of the cursor branch (i.e., cursor branched from it)
+            base_branch_exists=false
+            
+            for fb in $feature_branches; do
+              # Check if this feature branch contains the merge-base
+              if git merge-base --is-ancestor "$merge_base" "origin/$fb" 2>/dev/null; then
+                # Check if the cursor branch is based on this feature branch
+                # (cursor branch tip should have this feature branch in its history)
+                fb_tip=$(git rev-parse "origin/$fb" 2>/dev/null || echo "")
+                cursor_base=$(git merge-base "origin/$fb" "origin/$branch" 2>/dev/null || echo "")
+                
+                # If the cursor branch and feature branch share more history than just main
+                if [ -n "$cursor_base" ] && [ "$cursor_base" != "$merge_base" ]; then
+                  echo "  🌿 Found active base branch: $fb"
+                  base_branch_exists=true
+                  break
+                fi
+              fi
+            done
+
+            if [ "$base_branch_exists" = true ]; then
+              echo "  ⏭️  Keeping (base branch still exists)"
+              skipped_count=$((skipped_count + 1))
+            else
+              echo "  🕸️  Orphaned (base branch was merged to main)"
+              if [ "$DRY_RUN" = "true" ]; then
+                echo "  🔸 [DRY RUN] Would delete: $branch"
+              else
+                echo "  🗑️  Deleting: $branch"
+                git push origin --delete "$branch" || echo "  ⚠️  Failed to delete"
+              fi
+              deleted_count=$((deleted_count + 1))
+            fi
+          done
+
+          echo ""
+          echo "========================================"
+          echo "📊 Summary"
+          echo "========================================"
+          if [ "$DRY_RUN" = "true" ]; then
+            echo "🔸 Branches that would be deleted: $deleted_count"
+          else
+            echo "🗑️  Branches deleted: $deleted_count"
+          fi
+          echo "⏭️  Branches kept: $skipped_count"


### PR DESCRIPTION
## Summary

Adds a GitHub Action that automatically cleans up stale Cursor branches every Sunday.

## Problem

Cursor creates many branches (currently 48) that become orphaned when their base feature branches are merged to main. These accumulate and clutter the repository.

## Solution

Weekly scheduled workflow that:
- Finds all `cursor/*` branches
- Detects orphaned ones by checking if their base branch still exists
- Deletes branches whose base has been merged to main
- Keeps branches that are still based on active feature branches

## Features

- **Schedule:** Runs every Sunday at 3:00 AM UTC
- **Manual trigger:** Can be run anytime via Actions UI
- **Dry-run mode:** Preview deletions without actually deleting
- **Safe:** Only deletes cursor branches, never touches feature branches or main

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Automation can delete remote branches, so misclassification bugs could remove branches unintentionally; scope is limited to `cursor/*` and supports dry-run to validate behavior.
> 
> **Overview**
> Adds a new scheduled/manual GitHub Actions workflow (`.github/workflows/cleanup-cursor-branches.yml`) that **automatically deletes orphaned `cursor/*` remote branches**.
> 
> The job fetches all remotes, detects whether each `cursor/*` branch still has an active non-`main` base branch (via `git merge-base` ancestry checks), and deletes it via `git push origin --delete` when it appears orphaned; it also supports a `workflow_dispatch` *dry-run* mode that only reports what would be deleted.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3ef8867729c48b6e41d58eb1500f43b2ec255945. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->