### PR TITLE
chore(AYC-000): enable strict typescript on backend

### DIFF
--- a/ayunis-core-backend/src/domain/tools/application/tool.factory.ts
+++ b/ayunis-core-backend/src/domain/tools/application/tool.factory.ts
@@ -75,6 +75,7 @@ export class ToolFactory {
     context?: unknown;
   }): Tool {
     const creator = this.creators[params.type];
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- runtime guard: noUncheckedIndexedAccess is not enabled
     if (!creator) {
       throw new ToolInvalidTypeError({ toolType: params.type });
     }
@@ -86,13 +87,13 @@ export class ToolFactory {
   }
 
   private createHttpTool(config?: ToolConfig): HttpTool {
-    if (config && config instanceof HttpToolConfig) {
+    if (config instanceof HttpToolConfig) {
       return new HttpTool(config);
     }
     throw new ToolInvalidConfigError({
       toolName: 'HTTP',
       metadata: {
-        configType: config?.constructor.name || 'null',
+        configType: config?.constructor.name ?? 'null',
       },
     });
   }
@@ -100,7 +101,7 @@ export class ToolFactory {
 
 function requireArrayContext<T>(
   context: unknown,
-  itemType: abstract new (...args: unknown[]) => T,
+  itemType: abstract new (...args: never[]) => T,
   toolType: ToolType,
 ): T[] {
   if (
@@ -114,7 +115,7 @@ function requireArrayContext<T>(
     toolType,
     metadata: {
       contextType:
-        (context as { constructor?: { name?: string } }).constructor?.name ||
+        (context as { constructor?: { name?: string } }).constructor?.name ??
         'null',
     },
   });

--- a/ayunis-core-backend/tsconfig.json
+++ b/ayunis-core-backend/tsconfig.json
@@ -17,11 +17,11 @@
     "baseUrl": "./",
     "incremental": true,
     "skipLibCheck": true,
-    "strictNullChecks": true,
+    "strict": true,
+    "strictPropertyInitialization": false,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
     "forceConsistentCasingInFileNames": true,
-    "noImplicitAny": false,
-    "strictBindCallApply": false,
-    "noFallthroughCasesInSwitch": false,
     "paths": {
       "@modelcontextprotocol/sdk/client/*": ["node_modules/@modelcontextprotocol/sdk/dist/cjs/client/*"]
     }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Turning on `strict` can surface new compile-time errors across the backend and may require follow-up fixes; the code changes here are small but affect tool creation error paths.
> 
> **Overview**
> Enables **full TypeScript strict mode** in the backend `tsconfig.json`, adding stricter compiler checks like `noImplicitReturns` and switch fallthrough detection (and disabling `strictPropertyInitialization`).
> 
> Adjusts `ToolFactory` runtime/typing guards to be strict-friendly: keeps an explicit `creator` existence check, tightens `requireArrayContext` constructor typing, and uses nullish coalescing for error metadata while simplifying the `HttpToolConfig` check.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3b12f64f90f53fd7a29e07adf3f6bd719b44d77e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->