### PR TITLE
chore(AYC-000): add file size, madge, and markdownlint checks to pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -248,7 +248,7 @@ run_be_madge() {
   STATUS_FILE="$1"
   print_section "Circular Deps • madge (backend)"
   set +e
-  npx --yes madge --circular --extensions ts ayunis-core-backend/src/
+  npx --yes madge --circular --extensions ts --ts-config ayunis-core-backend/tsconfig.json ayunis-core-backend/src/
   STATUS=$?
   set -e
   printf "%s" "$STATUS" > "$STATUS_FILE"

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -30,6 +30,12 @@ FE_TS_STAGED=$(printf "%s" "$STAGED_FILES" | grep -E '^ayunis-core-frontend/src/
 # Backend: staged TS files
 BE_TS_STAGED=$(printf "%s" "$STAGED_FILES" | grep -E '^ayunis-core-backend/(src|apps|libs|test)/.*\.ts$' || true)
 
+# All staged TS/TSX files (for file size check)
+ALL_TS_STAGED=$(printf "%s" "$STAGED_FILES" | grep -E '\.(ts|tsx)$' || true)
+
+# Markdown: staged .md files
+MD_STAGED=$(printf "%s" "$STAGED_FILES" | grep -E '\.md$' || true)
+
 # Args depending on FIX mode (auto-fix enabled by default)
 if [ "$PRECOMMIT_NO_FIX" = "1" ]; then
   FE_PRETTIER_ARGS="--check --log-level warn"
@@ -56,6 +62,9 @@ DEPCRUISE_STATUS_FILE="$STATUS_DIR/depcruise.status"
 FE_DEPCRUISE_STATUS_FILE="$STATUS_DIR/fe_depcruise.status"
 BE_DUPLICATION_STATUS_FILE="$STATUS_DIR/be_duplication.status"
 FE_DUPLICATION_STATUS_FILE="$STATUS_DIR/fe_duplication.status"
+BE_MADGE_STATUS_FILE="$STATUS_DIR/be_madge.status"
+FILE_SIZE_STATUS_FILE="$STATUS_DIR/file_size.status"
+MARKDOWNLINT_STATUS_FILE="$STATUS_DIR/markdownlint.status"
 
 # Jobs
 run_fe_prettier() {
@@ -235,6 +244,40 @@ run_fe_duplication() {
   printf "%s" "$STATUS" > "$STATUS_FILE"
 }
 
+run_be_madge() {
+  STATUS_FILE="$1"
+  print_section "Circular Deps • madge (backend)"
+  set +e
+  npx --yes madge --circular --extensions ts ayunis-core-backend/src/
+  STATUS=$?
+  set -e
+  printf "%s" "$STATUS" > "$STATUS_FILE"
+}
+
+run_file_size() {
+  STATUS_FILE="$1"
+  print_section "File Size • check-file-size (staged TS/TSX)"
+  printf "%s\n" "$ALL_TS_STAGED" | sed 's#^# - #'
+  set +e
+  # shellcheck disable=SC2086
+  ./scripts/check-file-size.sh $ALL_TS_STAGED
+  STATUS=$?
+  set -e
+  printf "%s" "$STATUS" > "$STATUS_FILE"
+}
+
+run_markdownlint() {
+  STATUS_FILE="$1"
+  print_section "Markdown • markdownlint-cli2 (staged .md)"
+  printf "%s\n" "$MD_STAGED" | sed 's#^# - #'
+  set +e
+  # shellcheck disable=SC2086
+  npx --yes markdownlint-cli2 $MD_STAGED
+  STATUS=$?
+  set -e
+  printf "%s" "$STATUS" > "$STATUS_FILE"
+}
+
 # Launch jobs in parallel where possible
 if [ -n "$FE_STAGED" ]; then
   run_fe_prettier "$FE_PRETTIER_STATUS_FILE" &
@@ -256,6 +299,17 @@ if [ -n "$BE_TS_STAGED" ]; then
   run_complexity "$COMPLEXITY_STATUS_FILE" &
   run_depcruise "$DEPCRUISE_STATUS_FILE" &
   run_be_duplication "$BE_DUPLICATION_STATUS_FILE" &
+  run_be_madge "$BE_MADGE_STATUS_FILE" &
+fi
+
+# File size check (all staged TS/TSX)
+if [ -n "$ALL_TS_STAGED" ]; then
+  run_file_size "$FILE_SIZE_STATUS_FILE" &
+fi
+
+# Markdown lint (staged .md files)
+if [ -n "$MD_STAGED" ]; then
+  run_markdownlint "$MARKDOWNLINT_STATUS_FILE" &
 fi
 
 wait
@@ -272,6 +326,9 @@ DEPCRUISE_STATUS=$(cat "$DEPCRUISE_STATUS_FILE" 2>/dev/null || printf "0")
 FE_DEPCRUISE_STATUS=$(cat "$FE_DEPCRUISE_STATUS_FILE" 2>/dev/null || printf "0")
 BE_DUPLICATION_STATUS=$(cat "$BE_DUPLICATION_STATUS_FILE" 2>/dev/null || printf "0")
 FE_DUPLICATION_STATUS=$(cat "$FE_DUPLICATION_STATUS_FILE" 2>/dev/null || printf "0")
+BE_MADGE_STATUS=$(cat "$BE_MADGE_STATUS_FILE" 2>/dev/null || printf "0")
+FILE_SIZE_STATUS=$(cat "$FILE_SIZE_STATUS_FILE" 2>/dev/null || printf "0")
+MARKDOWNLINT_STATUS=$(cat "$MARKDOWNLINT_STATUS_FILE" 2>/dev/null || printf "0")
 
 # Summary and exit code
 FAILED=0
@@ -349,6 +406,28 @@ if [ -n "$BE_TS_STAGED" ]; then
     FAILED=1
   else
     printf "%b\n" "${GREEN}✅ Backend duplication check passed${NC}"
+  fi
+  if [ "$BE_MADGE_STATUS" -ne 0 ]; then
+    printf "%b\n" "${RED}❌ Backend circular dependency check failed${NC}"
+    FAILED=1
+  else
+    printf "%b\n" "${GREEN}✅ Backend circular dependency check passed${NC}"
+  fi
+fi
+if [ -n "$ALL_TS_STAGED" ]; then
+  if [ "$FILE_SIZE_STATUS" -ne 0 ]; then
+    printf "%b\n" "${RED}❌ File size check failed (files exceed line limit)${NC}"
+    FAILED=1
+  else
+    printf "%b\n" "${GREEN}✅ File size check passed${NC}"
+  fi
+fi
+if [ -n "$MD_STAGED" ]; then
+  if [ "$MARKDOWNLINT_STATUS" -ne 0 ]; then
+    printf "%b\n" "${RED}❌ Markdown lint failed${NC}"
+    FAILED=1
+  else
+    printf "%b\n" "${GREEN}✅ Markdown lint passed${NC}"
   fi
 fi
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Only changes local pre-commit tooling/CI-like guardrails; main risk is developer friction or false positives from new lint/size/dependency checks.
> 
> **Overview**
> Enhances `.husky/pre-commit` with three new parallelized checks: **backend circular dependency detection** via `madge`, a **line-count/file size gate** for all staged `*.ts`/`*.tsx` via `./scripts/check-file-size.sh`, and **Markdown linting** for staged `*.md` via `markdownlint-cli2`.
> 
> The hook now tracks these jobs with new status files and surfaces pass/fail results in the final summary, failing the commit when any new check fails.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 68cd58d4c553decc2c963709bec234bc3c14698b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->