### PR TITLE
docs(AYC-000): fix new-module skill inaccuracies

### DIFF
--- a/.claude/skills/ayunis-core-backend-dev/SKILL.md
+++ b/.claude/skills/ayunis-core-backend-dev/SKILL.md
@@ -72,12 +72,26 @@ npm run test                   # All tests pass
 curl http://localhost:3000/api/health  # Service responds
 ```
 
+## TypeScript Strictness
+
+The backend uses `strict: true` in `tsconfig.json` (with `strictPropertyInitialization: false` for TypeORM entities). This means:
+
+- No implicit `any` — every variable must have a type or be inferable
+- `strictBindCallApply`, `strictFunctionTypes`, `strictNullChecks` — all enabled
+- `noImplicitReturns: true` — every code path must return
+
+ESLint enforces `@typescript-eslint/no-explicit-any: error`. Use `unknown` and narrow with type guards. The `sonarjs` plugin is also active — it flags cognitive complexity (threshold: 15), duplicate code, and other code smells.
+
+Use `Logger` (from `@nestjs/common`) instead of `console.*`. The `no-console` rule is enforced with only `console.warn` and `console.error` allowed.
+
 ## Complexity Thresholds
 
 Enforced by Husky pre-commit and CI:
+
 - Cyclomatic complexity (CCN) ≤ 10
 - Function length ≤ 50 lines
 - Arguments ≤ 5
+- File size ≤ 500 lines (excluding tests, migrations, records)
 
 ```bash
 # From repo root
@@ -97,7 +111,7 @@ cat ayunis-core-backend/src/domain/[module]/SUMMARY.md
 
 ## Module Structure (Hexagonal)
 
-```
+```text
 [module]/
 ├── SUMMARY.md           # ← Read this first
 ├── domain/              # Pure entities, no decorators
@@ -194,7 +208,8 @@ npm run migration:generate:dev -- src/db/migrations/Name  # New migration
 | Batch changes | Harder to identify breakage | One change → validate → commit |
 | `return true` to pass test | Reward hacking | Fix root cause |
 | Edit test files to pass | Gaming the validator | Tests define correctness |
-| Use `any` type | Hides errors | Use `unknown` or specific types |
+| Use `any` type | `no-explicit-any: error` blocks commit | Use `unknown` or specific types, narrow with type guards |
+| Use `console.*` | `no-console` rule enforced | Use NestJS `Logger` (`this.logger.log(...)`) |
 | Pass userId through commands | Breaks ContextService pattern | Use `contextService.get()` |
 | Import across module boundaries | Circular dependencies | Use ports/adapters |
 | Write complex functions | CCN>10 triggers CI failure | Split into smaller functions |

--- a/.claude/skills/ayunis-core-frontend-dev/SKILL.md
+++ b/.claude/skills/ayunis-core-frontend-dev/SKILL.md
@@ -22,12 +22,18 @@ npm run build                  # Must succeed
 npm run lint                   # Must pass
 ```
 
+## TypeScript & Lint Strictness
+
+ESLint enforces `@typescript-eslint/no-explicit-any: error`. Use `unknown` or specific types — never `any`. The `sonarjs` plugin is also active (cognitive complexity threshold: 15).
+
 ## Complexity Thresholds
 
 Enforced by Husky pre-commit and CI:
+
 - Cyclomatic complexity (CCN) ≤ 10
 - Function length ≤ 50 lines
 - Arguments ≤ 5
+- File size ≤ 500 lines (excluding tests, generated code)
 
 ```bash
 # From repo root
@@ -39,7 +45,7 @@ If a function exceeds these limits, **refactor it** into smaller units.
 
 ## Architecture (Feature-Sliced Design)
 
-```
+```text
 src/
 ├── pages/      # Route components (compose widgets/features)
 ├── widgets/    # Reusable composites (used in ≥2 pages)
@@ -105,5 +111,5 @@ npm run openapi:update      # Regenerate API client
 | Edit generated API client | Will be overwritten | Run `openapi:update` |
 | Import upward across layers | Breaks FSD architecture | Respect `pages → widgets → features → shared` |
 | Batch changes | Harder to identify breakage | One change → validate → commit |
-| Use `any` type | Hides errors | Use `unknown` or specific types |
+| Use `any` type | `no-explicit-any: error` blocks commit | Use `unknown` or specific types, narrow with type guards |
 | Write complex functions | CCN>10 triggers CI failure | Split into smaller functions |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ For architecture overview and module navigation, see [ARCHITECTURE.md](ARCHITECT
 
 **Ayunis Core** is an open-source AI gateway enabling municipalities to run customizable AI assistants with multi-provider LLM support, tool integration, document retrieval (RAG), and organization-scoped access control.
 
-```
+```text
 ayunis-core/
 ├── ayunis-core-backend/          # NestJS API server (hexagonal architecture)
 ├── ayunis-core-frontend/         # React SPA (Feature-Sliced Design)
@@ -113,6 +113,19 @@ If an action is irreversible and isn't writing/editing source code, **ask first*
 
 ---
 
+## Code Quality Enforcement
+
+The following rules are enforced by ESLint, pre-commit hooks, and CI. Violations block commits and PRs.
+
+- **Strict TypeScript** — Backend uses `strict: true` (no implicit any, strict null checks, strict bind/call/apply). Frontend uses strict null checks.
+- **`no-explicit-any: error`** — Both backend and frontend. Use `unknown` or specific types. If `any` is truly unavoidable (e.g., TypeORM pgvector), add a targeted `eslint-disable` comment with a justification.
+- **sonarjs** — Both packages use `eslint-plugin-sonarjs` (recommended config). Cognitive complexity threshold: 15. Lizard enforces the stricter CCN ≤ 10 for individual functions.
+- **File size limit** — 500 lines per file (excluding tests, migrations, records, generated code). Enforced by `scripts/check-file-size.sh` in pre-commit.
+- **No `console.*`** — Use NestJS `Logger` on the backend. `console.warn` and `console.error` are allowed in specific infrastructure code.
+- **Circular dependency detection** — `madge` runs in pre-commit and CI.
+
+---
+
 ## Development Skills
 
 For detailed development workflows, patterns, and validation checklists, use the appropriate skill:
@@ -121,3 +134,5 @@ For detailed development workflows, patterns, and validation checklists, use the
 - **Backend work** → `ayunis-core-backend-dev` skill (NestJS, hexagonal patterns, TDD, validation)
 - **Frontend work** → `ayunis-core-frontend-dev` skill (React, Feature-Sliced Design, API client, hooks)
 - **Database migrations** → `ayunis-core-migrations` skill (TypeORM entity changes, auto-generated migrations)
+- **New backend module** → `new-module` skill (scaffold hexagonal module with entity, ports, use cases, controller)
+- **New frontend page** → `new-page` skill (scaffold FSD page with route, component, barrel export)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only updates; no runtime, build, or behavioral changes to the application.
> 
> **Overview**
> Clarifies and expands documentation around **code-quality enforcement** across the repo.
> 
> Backend and frontend skill docs now explicitly call out TypeScript strictness, `no-explicit-any`, `sonarjs` cognitive complexity limits, file-size limits, and backend logging expectations (use NestJS `Logger` instead of `console.*`), plus minor formatting fixes to code blocks.
> 
> `AGENTS.md` adds a consolidated **Code Quality Enforcement** section and updates the skills list to include the `new-module` and `new-page` scaffolding skills.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 076967643990ee1276d8809faaf60d507949bbc6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->