### PR TITLE
chore(AYC-000): add wip prefix for changelog-excluded PRs

### DIFF
--- a/.claude/skills/git-commit/SKILL.md
+++ b/.claude/skills/git-commit/SKILL.md
@@ -7,31 +7,61 @@ description: Use when committing changes. Ensures correct commit message format,
 
 ## Commit Message Format
 
-```
+```text
 <type>(<task-id>): <short description>
 ```
 
 **Examples from project history:**
 
-```
+```text
 feat(AYC-51): add marketplace agent install page in frontend
 fix(AYC-42): invalidate router cache when agent model is updated
 refactor(AYC-30): update LongChatWarning component
+wip(AYC-60): add source entity and repository port
 ```
 
 ## Rules
 
 1. **Task ID is required.** Always ask the user for the task ID if not provided. Format: `AYC-<number>`. Never invent a task ID.
-2. **Type** must be one of: `feat`, `fix`, `chore`, `refactor`, `ci`, `docs`, `test`, `perf`.
+2. **Type** must be one of: `feat`, `fix`, `chore`, `refactor`, `ci`, `docs`, `test`, `perf`, `wip`.
 3. **Short description** is lowercase, imperative mood, no period at end.
 4. **Body** (optional) — separated by blank line, bullet points with `-`, wrap at ~72 chars.
 5. For `chore` commits without a task (e.g., release, tooling), the scope can be omitted or use a non-AYC scope: `chore(main): release 1.8.0`.
+
+## WIP vs Semantic Types — Changelog Hygiene
+
+This project uses **release-please** to auto-generate changelogs from squash-merged PR titles on `main`. Only semantic types (`feat`, `fix`, `refactor`, `perf`, `docs`, `ci`, `chore`, `test`) appear in the changelog. The `wip` type is **excluded from the changelog and does not trigger version bumps**.
+
+### When to use `wip:`
+
+Use `wip:` for any PR that is **part of a larger feature but does not complete it**. This is the default for stacked PRs in a multi-branch feature:
+
+```text
+wip(AYC-60): add source entity and repository port        ← stack branch 1
+wip(AYC-60): implement source ingestion use case           ← stack branch 2
+feat(AYC-60): add source management API and UI             ← final branch, completes the feature
+```
+
+Only the last PR uses `feat:` — that's the one that appears in the changelog as a single entry.
+
+### When to use semantic types
+
+Use `feat:`, `fix:`, etc. when the PR **delivers a complete, user-visible change** on its own:
+
+- A standalone bug fix → `fix(AYC-42): correct date validation`
+- A self-contained feature in a single PR → `feat(AYC-51): add agent install page`
+- CI/tooling change → `ci(AYC-000): add dead code workflow`
+
+### Rule of thumb
+
+> If this PR were the only one merged, would the change make sense to a user reading the changelog? If yes → semantic type. If no → `wip:`.
 
 ## Pre-commit Checks
 
 The project has a pre-commit hook that enforces:
 
 - **Commit message must include `AYC-` prefix** (validated by `commit-msg` hook)
+- **Commit message must start with a valid type** (`feat`, `fix`, `chore`, `wip`, etc.)
 - **ESLint, Prettier, TypeScript typecheck** on staged files
 - **Lizard complexity check** (CCN ≤ 10, length ≤ 50 lines, args ≤ 5)
 

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -25,3 +25,4 @@ jobs:
             ci
             chore
             revert
+            wip

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -12,9 +12,9 @@ SUBJECT=$(grep -vE '^\s*#' "$MSG_FILE" | sed '/^\s*$/d' | head -n 1)
 
 # 1) Require type prefix at start (case-insensitive):
 #    feat|feature|fix|chore|refactor|docs|style|perf|test|build|ci|revert|check
-echo "$SUBJECT" | grep -qiE '^(feat|feature|fix|chore|refactor|docs|style|perf|test|build|ci|revert|check)(\(.+\))?:\s' || {
-  printf "\033[31mCommit message must start with a type (e.g., feat:, fix:, feature:, chore:, ...).\033[0m\n" >&2
-  printf "Examples:\n  feat: add new booking widget\n  fix: correct date validation\n  feature: implement task board drag-and-drop\n" >&2
+echo "$SUBJECT" | grep -qiE '^(feat|feature|fix|chore|refactor|docs|style|perf|test|build|ci|revert|check|wip)(\(.+\))?:\s' || {
+  printf "\033[31mCommit message must start with a type (e.g., feat:, fix:, wip:, chore:, ...).\033[0m\n" >&2
+  printf "Examples:\n  feat: add new booking widget\n  fix: correct date validation\n  wip: partial implementation of task board\n" >&2
   exit 1
 }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Docs and workflow/regex validation-only changes; affects developer tooling but not runtime behavior.
> 
> **Overview**
> Adds `wip` as an accepted conventional-commit type across tooling, so stacked/incomplete PRs can be merged without polluting release notes.
> 
> Updates the git commit guidance (`.claude/skills/git-commit/SKILL.md`) with rules and examples for `wip` vs semantic types, and extends both the Husky `commit-msg` regex and the PR title check workflow to allow `wip` prefixes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 415ff761cdd663f8c33043ec7ae80b13a97222c2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->