### PR TITLE
fix(AYC-000): fail loudly when anonymization service is unavailable in anonymous mode

### DIFF
--- a/ayunis-core-backend/src/domain/runs/application/runs.errors.ts
+++ b/ayunis-core-backend/src/domain/runs/application/runs.errors.ts
@@ -11,6 +11,7 @@ export enum RunErrorCode {
   RUN_TOOL_NOT_FOUND = 'RUN_TOOL_NOT_FOUND',
   RUN_TOOL_EXECUTION_FAILED = 'RUN_TOOL_EXECUTION_FAILED',
   RUN_NO_MODEL_FOUND = 'RUN_NO_MODEL_FOUND',
+  RUN_ANONYMIZATION_UNAVAILABLE = 'RUN_ANONYMIZATION_UNAVAILABLE',
   THREAD_AGENT_NO_LONGER_ACCESSIBLE = 'THREAD_AGENT_NO_LONGER_ACCESSIBLE',
 }
 
@@ -102,6 +103,21 @@ export class RunToolExecutionFailedError extends RunError {
       `Tool '${toolName}' execution failed`,
       RunErrorCode.RUN_TOOL_EXECUTION_FAILED,
       400,
+      metadata,
+    );
+  }
+}
+
+/**
+ * Error thrown when anonymous mode is enabled but the anonymization service
+ * is unavailable. The message must not be sent without anonymization.
+ */
+export class RunAnonymizationUnavailableError extends RunError {
+  constructor(metadata?: ErrorMetadata) {
+    super(
+      'Anonymization is currently unavailable. Your message was not sent to protect your data.',
+      RunErrorCode.RUN_ANONYMIZATION_UNAVAILABLE,
+      503,
       metadata,
     );
   }

--- a/ayunis-core-backend/src/domain/runs/application/services/tool-result-collector.service.spec.ts
+++ b/ayunis-core-backend/src/domain/runs/application/services/tool-result-collector.service.spec.ts
@@ -1,0 +1,130 @@
+import { AnonymizationFailedError } from 'src/common/anonymization/application/anonymization.errors';
+import type { AnonymizeTextUseCase } from 'src/common/anonymization/application/use-cases/anonymize-text/anonymize-text.use-case';
+import { RunAnonymizationUnavailableError } from '../runs.errors';
+import { ToolResultMessageContent } from 'src/domain/messages/domain/message-contents/tool-result.message-content.entity';
+import { ToolUseMessageContent } from 'src/domain/messages/domain/message-contents/tool-use.message-content.entity';
+import type { Thread } from 'src/domain/threads/domain/thread.entity';
+import type { Tool } from 'src/domain/tools/domain/tool.entity';
+import type { ExecuteToolUseCase } from 'src/domain/tools/application/use-cases/execute-tool/execute-tool.use-case';
+import type { CheckToolCapabilitiesUseCase } from 'src/domain/tools/application/use-cases/check-tool-capabilities/check-tool-capabilities.use-case';
+import { ToolResultCollectorService } from './tool-result-collector.service';
+import { randomUUID } from 'crypto';
+
+describe('ToolResultCollectorService', () => {
+  let service: ToolResultCollectorService;
+  let executeToolUseCase: jest.Mocked<ExecuteToolUseCase>;
+  let checkToolCapabilitiesUseCase: jest.Mocked<CheckToolCapabilitiesUseCase>;
+  let anonymizeTextUseCase: jest.Mocked<AnonymizeTextUseCase>;
+
+  const orgId = randomUUID();
+  const threadId = randomUUID();
+  const toolUseId = randomUUID();
+
+  beforeEach(() => {
+    executeToolUseCase = {
+      execute: jest.fn(),
+    } as unknown as jest.Mocked<ExecuteToolUseCase>;
+
+    checkToolCapabilitiesUseCase = {
+      execute: jest.fn(),
+    } as unknown as jest.Mocked<CheckToolCapabilitiesUseCase>;
+
+    anonymizeTextUseCase = {
+      execute: jest.fn(),
+    } as unknown as jest.Mocked<AnonymizeTextUseCase>;
+
+    service = new ToolResultCollectorService(
+      executeToolUseCase,
+      checkToolCapabilitiesUseCase,
+      anonymizeTextUseCase,
+    );
+  });
+
+  describe('anonymous mode tool result anonymization failure', () => {
+    it('should throw RunAnonymizationUnavailableError when anonymize service is unavailable for PII-returning tool', async () => {
+      const toolName = 'search_citizens_database';
+      const tool = {
+        name: toolName,
+        type: 'search',
+        returnsPii: true,
+      } as unknown as Tool;
+
+      const toolUseContent = Object.assign(
+        Object.create(ToolUseMessageContent.prototype),
+        { id: toolUseId, name: toolName, params: { query: 'Mustermann' } },
+      );
+
+      checkToolCapabilitiesUseCase.execute.mockReturnValue({
+        isDisplayable: false,
+        isExecutable: true,
+      });
+
+      executeToolUseCase.execute.mockResolvedValue(
+        'Max Mustermann, Hauptstraße 42, 80331 München, Tel: 089-12345678',
+      );
+
+      anonymizeTextUseCase.execute.mockRejectedValue(
+        new AnonymizationFailedError('Connection refused'),
+      );
+
+      const thread = {
+        id: threadId,
+        getLastMessage: jest.fn().mockReturnValue({
+          content: [toolUseContent],
+        }),
+      } as unknown as Thread;
+
+      await expect(
+        service.collectToolResults({
+          thread,
+          tools: [tool],
+          input: null,
+          orgId,
+          isAnonymous: true,
+        }),
+      ).rejects.toThrow(RunAnonymizationUnavailableError);
+    });
+
+    it('should not anonymize tool results when anonymous mode is disabled', async () => {
+      const toolName = 'search_citizens_database';
+      const tool = {
+        name: toolName,
+        type: 'search',
+        returnsPii: true,
+      } as unknown as Tool;
+
+      const toolUseContent = Object.assign(
+        Object.create(ToolUseMessageContent.prototype),
+        { id: toolUseId, name: toolName, params: { query: 'Mustermann' } },
+      );
+
+      checkToolCapabilitiesUseCase.execute.mockReturnValue({
+        isDisplayable: false,
+        isExecutable: true,
+      });
+
+      const rawResult = 'Max Mustermann, Hauptstraße 42, 80331 München';
+      executeToolUseCase.execute.mockResolvedValue(rawResult);
+
+      const thread = {
+        id: threadId,
+        getLastMessage: jest.fn().mockReturnValue({
+          content: [toolUseContent],
+        }),
+      } as unknown as Thread;
+
+      const results = await service.collectToolResults({
+        thread,
+        tools: [tool],
+        input: null,
+        orgId,
+        isAnonymous: false,
+      });
+
+      expect(results).toHaveLength(1);
+      expect(results[0]).toBeInstanceOf(ToolResultMessageContent);
+      expect(results[0].result).toBe(rawResult);
+      expect(anonymizeTextUseCase.execute).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/ayunis-core-backend/src/domain/runs/application/services/tool-result-collector.service.ts
+++ b/ayunis-core-backend/src/domain/runs/application/services/tool-result-collector.service.ts
@@ -14,7 +14,10 @@ import { ToolExecutionFailedError } from 'src/domain/tools/application/tools.err
 import { AnonymizeTextUseCase } from 'src/common/anonymization/application/use-cases/anonymize-text/anonymize-text.use-case';
 import { AnonymizeTextCommand } from 'src/common/anonymization/application/use-cases/anonymize-text/anonymize-text.command';
 import { ApplicationError } from 'src/common/errors/base.error';
-import { RunToolExecutionFailedError } from '../runs.errors';
+import {
+  RunAnonymizationUnavailableError,
+  RunToolExecutionFailedError,
+} from '../runs.errors';
 import { RunToolResultInput } from '../../domain/run-input.entity';
 
 const MAX_TOOL_RESULT_LENGTH = 20000;
@@ -184,10 +187,9 @@ export class ToolResultCollectorService {
       );
       return result.anonymizedText;
     } catch (error) {
-      this.logger.error('Failed to anonymize tool result, returning original', {
-        error: error as Error,
+      throw new RunAnonymizationUnavailableError({
+        originalError: error instanceof Error ? error.message : 'Unknown error',
       });
-      return text;
     }
   }
 }

--- a/ayunis-core-backend/src/domain/runs/application/use-cases/execute-run/execute-run.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/runs/application/use-cases/execute-run/execute-run.use-case.spec.ts
@@ -1,0 +1,178 @@
+import { AnonymizationFailedError } from 'src/common/anonymization/application/anonymization.errors';
+import type { AnonymizeTextUseCase } from 'src/common/anonymization/application/use-cases/anonymize-text/anonymize-text.use-case';
+import { RunAnonymizationUnavailableError } from '../../runs.errors';
+import type { ContextService } from 'src/common/context/services/context.service';
+import type { FindOneAgentUseCase } from 'src/domain/agents/application/use-cases/find-one-agent/find-one-agent.use-case';
+import type { CreateAssistantMessageUseCase } from 'src/domain/messages/application/use-cases/create-assistant-message/create-assistant-message.use-case';
+import type { CreateToolResultMessageUseCase } from 'src/domain/messages/application/use-cases/create-tool-result-message/create-tool-result-message.use-case';
+import type { CreateUserMessageUseCase } from 'src/domain/messages/application/use-cases/create-user-message/create-user-message.use-case';
+import type { TrimMessagesForContextUseCase } from 'src/domain/messages/application/use-cases/trim-messages-for-context/trim-messages-for-context.use-case';
+import type { GetInferenceUseCase } from 'src/domain/models/application/use-cases/get-inference/get-inference.use-case';
+import type { LanguageModel } from 'src/domain/models/domain/models/language.model';
+import type { PermittedLanguageModel } from 'src/domain/models/domain/permitted-model.entity';
+import type { AddMessageToThreadUseCase } from 'src/domain/threads/application/use-cases/add-message-to-thread/add-message-to-thread.use-case';
+import type { FindThreadUseCase } from 'src/domain/threads/application/use-cases/find-thread/find-thread.use-case';
+import type { Thread } from 'src/domain/threads/domain/thread.entity';
+import { ExecuteRunUseCase } from './execute-run.use-case';
+import { ExecuteRunCommand } from './execute-run.command';
+import { RunUserInput } from '../../../domain/run-input.entity';
+import type { CollectUsageAsyncService } from '../../services/collect-usage-async.service';
+import type { ToolAssemblyService } from '../../services/tool-assembly.service';
+import type { ToolResultCollectorService } from '../../services/tool-result-collector.service';
+import type { MessageCleanupService } from '../../services/message-cleanup.service';
+import type { StreamingInferenceService } from '../../services/streaming-inference.service';
+import { randomUUID } from 'crypto';
+
+describe('ExecuteRunUseCase', () => {
+  let useCase: ExecuteRunUseCase;
+  let anonymizeTextUseCase: jest.Mocked<AnonymizeTextUseCase>;
+  let findThreadUseCase: jest.Mocked<FindThreadUseCase>;
+  let contextService: jest.Mocked<ContextService>;
+  let toolAssemblyService: jest.Mocked<ToolAssemblyService>;
+  let messageCleanupService: jest.Mocked<MessageCleanupService>;
+
+  const userId = randomUUID();
+  const orgId = randomUUID();
+  const threadId = randomUUID();
+
+  function createMockThread(overrides: Partial<Thread> = {}): Thread {
+    const model = {
+      model: {
+        name: 'gpt-4',
+        canUseTools: true,
+        canVision: false,
+      } as LanguageModel,
+      anonymousOnly: false,
+    } as PermittedLanguageModel;
+
+    return {
+      id: threadId,
+      userId,
+      agentId: null,
+      model,
+      isAnonymous: false,
+      messages: [],
+      getLastMessage: jest.fn().mockReturnValue(null),
+      ...overrides,
+    } as unknown as Thread;
+  }
+
+  beforeEach(() => {
+    anonymizeTextUseCase = {
+      execute: jest.fn(),
+    } as unknown as jest.Mocked<AnonymizeTextUseCase>;
+
+    findThreadUseCase = {
+      execute: jest.fn(),
+    } as unknown as jest.Mocked<FindThreadUseCase>;
+
+    contextService = {
+      get: jest.fn(),
+    } as unknown as jest.Mocked<ContextService>;
+
+    toolAssemblyService = {
+      findActiveSkills: jest.fn().mockResolvedValue([]),
+      buildRunContext: jest.fn().mockResolvedValue({
+        tools: [],
+        instructions: 'Du bist ein hilfreicher Assistent der Stadtverwaltung',
+      }),
+    } as unknown as jest.Mocked<ToolAssemblyService>;
+
+    messageCleanupService = {
+      cleanupTrailingNonAssistantMessages: jest
+        .fn()
+        .mockResolvedValue(undefined),
+    } as unknown as jest.Mocked<MessageCleanupService>;
+
+    contextService.get.mockImplementation((key?: string | symbol) => {
+      if (key === 'userId') return userId;
+      if (key === 'orgId') return orgId;
+      return undefined;
+    });
+
+    useCase = new ExecuteRunUseCase(
+      { execute: jest.fn() } as unknown as CreateUserMessageUseCase,
+      { execute: jest.fn() } as unknown as CreateAssistantMessageUseCase,
+      { execute: jest.fn() } as unknown as CreateToolResultMessageUseCase,
+      { execute: jest.fn() } as unknown as GetInferenceUseCase,
+      findThreadUseCase,
+      { execute: jest.fn() } as unknown as FindOneAgentUseCase,
+      { execute: jest.fn() } as unknown as AddMessageToThreadUseCase,
+      contextService,
+      anonymizeTextUseCase,
+      { collect: jest.fn() } as unknown as CollectUsageAsyncService,
+      { execute: jest.fn() } as unknown as TrimMessagesForContextUseCase,
+      toolAssemblyService,
+      {
+        collectToolResults: jest.fn().mockResolvedValue([]),
+        exitLoopAfterAgentResponse: jest.fn().mockReturnValue(true),
+      } as unknown as ToolResultCollectorService,
+      messageCleanupService,
+      {
+        executeStreamingInference: jest.fn(),
+      } as unknown as StreamingInferenceService,
+    );
+  });
+
+  describe('anonymous mode anonymization failure', () => {
+    it('should throw RunAnonymizationUnavailableError when anonymize service is unavailable and thread is anonymous', async () => {
+      const thread = createMockThread({ isAnonymous: true });
+      findThreadUseCase.execute.mockResolvedValue({
+        thread,
+        isLongChat: false,
+      });
+      anonymizeTextUseCase.execute.mockRejectedValue(
+        new AnonymizationFailedError('Connection refused'),
+      );
+
+      const input = new RunUserInput(
+        'Mein Name ist Max Mustermann und ich wohne in München',
+        [],
+      );
+      const command = new ExecuteRunCommand({
+        threadId,
+        input,
+        streaming: false,
+      });
+
+      const generator = await useCase.execute(command);
+      await expect(generator.next()).rejects.toThrow(
+        RunAnonymizationUnavailableError,
+      );
+    });
+
+    it('should throw RunAnonymizationUnavailableError when anonymize service fails for model-enforced anonymous mode', async () => {
+      const model = {
+        model: {
+          name: 'gpt-4',
+          canUseTools: true,
+          canVision: false,
+        } as LanguageModel,
+        anonymousOnly: true,
+      } as PermittedLanguageModel;
+      const thread = createMockThread({ isAnonymous: false, model });
+      findThreadUseCase.execute.mockResolvedValue({
+        thread,
+        isLongChat: false,
+      });
+      anonymizeTextUseCase.execute.mockRejectedValue(
+        new AnonymizationFailedError('Service timeout'),
+      );
+
+      const input = new RunUserInput(
+        'Kontaktieren Sie mich unter max@example.de',
+        [],
+      );
+      const command = new ExecuteRunCommand({
+        threadId,
+        input,
+        streaming: false,
+      });
+
+      const generator = await useCase.execute(command);
+      await expect(generator.next()).rejects.toThrow(
+        RunAnonymizationUnavailableError,
+      );
+    });
+  });
+});

--- a/ayunis-core-backend/src/domain/runs/application/use-cases/execute-run/execute-run.use-case.ts
+++ b/ayunis-core-backend/src/domain/runs/application/use-cases/execute-run/execute-run.use-case.ts
@@ -13,6 +13,7 @@ import { GetInferenceCommand } from '../../../../models/application/use-cases/ge
 import { CreateAssistantMessageUseCase } from '../../../../messages/application/use-cases/create-assistant-message/create-assistant-message.use-case';
 import { CreateAssistantMessageCommand } from '../../../../messages/application/use-cases/create-assistant-message/create-assistant-message.command';
 import {
+  RunAnonymizationUnavailableError,
   RunExecutionFailedError,
   RunInvalidInputError,
   RunMaxIterationsReachedError,
@@ -418,11 +419,12 @@ export class ExecuteRunUseCase {
       }
       return result.anonymizedText;
     } catch (error) {
-      this.logger.error('Failed to anonymize text, returning original', {
+      this.logger.error('Anonymization service unavailable', {
         error: error as Error,
       });
-      // Return original text on anonymization failure to not block the conversation
-      return text;
+      throw new RunAnonymizationUnavailableError({
+        originalError: error instanceof Error ? error.message : 'Unknown error',
+      });
     }
   }
 

--- a/ayunis-core-frontend/src/pages/chat/hooks/useRunErrorHandler.ts
+++ b/ayunis-core-frontend/src/pages/chat/hooks/useRunErrorHandler.ts
@@ -1,0 +1,60 @@
+import { useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useQueryClient } from '@tanstack/react-query';
+import type { RunErrorResponseDto } from '@/shared/api/generated/ayunisCoreAPI.schemas';
+import {
+  getThreadsControllerFindOneQueryKey,
+  getAgentsControllerFindAllQueryKey,
+} from '@/shared/api/generated/ayunisCoreAPI';
+import { showError } from '@/shared/lib/toast';
+
+export function useRunErrorHandler(threadId: string) {
+  const { t } = useTranslation();
+  const queryClient = useQueryClient();
+
+  return useCallback(
+    (error: RunErrorResponseDto) => {
+      switch (error.code) {
+        case 'EXECUTION_ERROR':
+          showError(t('chat.errorExecutionError'));
+          break;
+        case 'RUN_NO_MODEL_FOUND':
+          showError(t('chat.errorNoModelFound'));
+          break;
+        case 'RUN_MAX_ITERATIONS_REACHED':
+          showError(t('chat.errorMaxIterationsReached'));
+          break;
+        case 'RUN_TOOL_NOT_FOUND':
+          showError(t('chat.errorToolNotFound'));
+          break;
+        case 'RUN_ANONYMIZATION_UNAVAILABLE':
+          showError(t('chat.errorAnonymizationUnavailable'));
+          break;
+        case 'THREAD_AGENT_NO_LONGER_ACCESSIBLE':
+          void queryClient.invalidateQueries({
+            queryKey: getAgentsControllerFindAllQueryKey(),
+          });
+          void queryClient.invalidateQueries({
+            queryKey: getThreadsControllerFindOneQueryKey(threadId),
+          });
+          showError(t('chat.unavailableAgentWarningTitle'));
+          break;
+        case 'QUOTA_EXCEEDED': {
+          const retryMinutes = error.details?.retryAfterSeconds
+            ? Math.ceil(Number(error.details.retryAfterSeconds) / 60)
+            : null;
+          showError(
+            retryMinutes
+              ? t('chat.errorQuotaExceededWithTime', { minutes: retryMinutes })
+              : t('chat.errorQuotaExceeded'),
+          );
+          break;
+        }
+        case undefined:
+        default:
+          showError(t('chat.errorUnexpected'));
+      }
+    },
+    [t, queryClient, threadId],
+  );
+}

--- a/ayunis-core-frontend/src/pages/chat/ui/ChatHeader.tsx
+++ b/ayunis-core-frontend/src/pages/chat/ui/ChatHeader.tsx
@@ -1,0 +1,89 @@
+import { useTranslation } from 'react-i18next';
+import { MoreVertical, ShieldCheck, Trash2, Pencil } from 'lucide-react';
+import ContentAreaHeader from '@/widgets/content-area-header/ui/ContentAreaHeader';
+import { Button } from '@/shared/ui/shadcn/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/shared/ui/shadcn/dropdown-menu';
+import { Badge } from '@/shared/ui/shadcn/badge';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/shared/ui/shadcn/tooltip';
+
+interface ChatHeaderProps {
+  readonly threadTitle?: string;
+  readonly isAnonymous: boolean;
+  readonly onRename: (openDialog?: boolean) => void;
+  readonly onDelete: () => void;
+}
+
+export default function ChatHeader({
+  threadTitle,
+  isAnonymous,
+  onRename,
+  onDelete,
+}: Readonly<ChatHeaderProps>) {
+  const { t } = useTranslation();
+
+  return (
+    <ContentAreaHeader
+      title={
+        <span
+          className="group inline-flex items-center gap-2"
+          data-testid="header"
+        >
+          {/* eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- intentional: empty string should show "Untitled" */}
+          {threadTitle || t('chat.untitled')}
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                onClick={() => onRename()}
+                variant="ghost"
+                className="opacity-0 group-hover:opacity-100"
+                aria-label={t('chat.renameThread')}
+              >
+                <Pencil className="h-3.5 w-3.5 text-muted-foreground" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>{t('chat.renameThread')}</TooltipContent>
+          </Tooltip>
+          {isAnonymous && (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Badge variant="secondary">
+                  <ShieldCheck className="h-3 w-3" />
+                  {t('chat.anonymousMode')}
+                </Badge>
+              </TooltipTrigger>
+              <TooltipContent>{t('chat.anonymousModeTooltip')}</TooltipContent>
+            </Tooltip>
+          )}
+        </span>
+      }
+      action={
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button variant="ghost" size="icon">
+              <MoreVertical className="h-5 w-5 text-primary" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <DropdownMenuItem onClick={() => onRename(true)}>
+              <Pencil className="h-4 w-4" />
+              <span>{t('chat.renameThread')}</span>
+            </DropdownMenuItem>
+            <DropdownMenuItem onClick={onDelete} variant="destructive">
+              <Trash2 className="h-4 w-4" />
+              <span>{t('chat.deleteThread')}</span>
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      }
+    />
+  );
+}

--- a/ayunis-core-frontend/src/shared/locales/de/chat.json
+++ b/ayunis-core-frontend/src/shared/locales/de/chat.json
@@ -17,6 +17,7 @@
     "errorNoModelFound": "Kein Modell gefunden",
     "errorMaxIterationsReached": "Maximale Anzahl an Iterationen erreicht",
     "errorToolNotFound": "Tool nicht gefunden",
+    "errorAnonymizationUnavailable": "Die Anonymisierung ist derzeit nicht verfügbar. Ihre Nachricht wurde nicht gesendet, um Ihre Daten zu schützen.",
     "errorSendMessage": "Nachricht konnte nicht gesendet werden. Bitte aktualisieren Sie die Seite und versuchen Sie es erneut.",
     "errorQuotaExceeded": "Sie haben das Nachrichtenlimit erreicht. Bitte versuchen Sie es später erneut.",
     "errorQuotaExceededWithTime": "Sie haben das Nachrichtenlimit erreicht. Bitte versuchen Sie es in {{minutes}} Minuten erneut.",

--- a/ayunis-core-frontend/src/shared/locales/en/chat.json
+++ b/ayunis-core-frontend/src/shared/locales/en/chat.json
@@ -17,6 +17,7 @@
     "errorNoModelFound": "No model found",
     "errorMaxIterationsReached": "Maximal number of iterations reached",
     "errorToolNotFound": "Tool not found",
+    "errorAnonymizationUnavailable": "Anonymization is currently unavailable. Your message was not sent to protect your data.",
     "errorSendMessage": "Message could not be sent. Please refresh the page and try again.",
     "errorQuotaExceeded": "You have reached the message limit. Please try again later.",
     "errorQuotaExceededWithTime": "You have reached the message limit. Please try again in {{minutes}} minutes.",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes alter run execution control flow to hard-fail on anonymization outages, which can block message sending/tool execution in anonymous mode. UI refactors are low risk but may affect error display paths if codes or query invalidation logic are wrong.
> 
> **Overview**
> **Anonymous-mode privacy behavior is tightened**: when anonymization fails, the backend now throws `RunAnonymizationUnavailableError` (`RUN_ANONYMIZATION_UNAVAILABLE`, HTTP 503) instead of continuing with unanonymized text.
> 
> This is enforced both for user input anonymization in `ExecuteRunUseCase` and for PII-returning tool results in `ToolResultCollectorService`, with new unit tests covering the failure paths.
> 
> On the frontend, error handling is refactored into `useRunErrorHandler`, `ChatHeader` is extracted from `ChatPage`, and new EN/DE translations plus toast handling are added for the anonymization-unavailable error code.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d1d76466ff119ea9430e8414549f8d28701ba039. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->