### PR TITLE
refactor(AYC-000): simplify null check with optional chaining in update-team use case

### DIFF
--- a/ayunis-core-backend/src/iam/teams/application/use-cases/update-team/update-team.use-case.ts
+++ b/ayunis-core-backend/src/iam/teams/application/use-cases/update-team/update-team.use-case.ts
@@ -43,7 +43,7 @@ export class UpdateTeamUseCase {
     try {
       const team = await this.teamsRepository.findById(command.teamId);
 
-      if (!team || team.orgId !== orgId) {
+      if (team?.orgId !== orgId) {
         this.logger.warn('Team not found or belongs to different org', {
           teamId: command.teamId,
           orgId,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Refactor-only change in `UpdateTeamUseCase` that rewrites the team ownership/not-found guard using optional chaining; expected behavior remains the same and doesn’t affect data flow or security logic.
> 
> **Overview**
> Simplifies the not-found/organization-mismatch guard in `UpdateTeamUseCase` by replacing the explicit `!team || team.orgId !== orgId` check with an optional-chaining comparison (`team?.orgId !== orgId`). No other update-team behavior is changed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ff957f6bb72a8e97b9b5c30dbbe0c9da679a9a6e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->