### PR TITLE
fix(AYC-000): update stale port 8001 references to 8002 for anonymize service

### DIFF
--- a/ayunis-core-backend/docker-compose.dev.yml
+++ b/ayunis-core-backend/docker-compose.dev.yml
@@ -123,7 +123,7 @@ services:
     container_name: ayunis-anonymize-dev
     restart: unless-stopped
     ports:
-      - '8001:8000' # Expose on 8001 to avoid conflicts
+      - '8002:8000' # Expose on 8002 to avoid conflicts
     healthcheck:
       test:
         [

--- a/ayunis-core-backend/orval.config.ts
+++ b/ayunis-core-backend/orval.config.ts
@@ -22,7 +22,7 @@ export default defineConfig({
   },
   anonymize: {
     input: {
-      target: 'http://localhost:8001/openapi.json',
+      target: 'http://localhost:8002/openapi.json',
     },
     output: {
       target: './src/common/clients/anonymize/generated',

--- a/ayunis-core-backend/src/common/clients/anonymize/client.ts
+++ b/ayunis-core-backend/src/common/clients/anonymize/client.ts
@@ -5,7 +5,7 @@ import type { AxiosRequestConfig } from 'axios';
 
 // Create axios instance for anonymize service with all configuration
 const anonymizeAxios = axios.create({
-  baseURL: process.env.ANONYMIZE_SERVICE_URL || 'http://localhost:8001',
+  baseURL: process.env.ANONYMIZE_SERVICE_URL || 'http://localhost:8002',
   timeout: 30000, // 30 seconds timeout for text analysis
   headers: {
     'Content-Type': 'application/json',

--- a/compose.dev.yml
+++ b/compose.dev.yml
@@ -106,7 +106,7 @@ services:
       dockerfile: Dockerfile
     restart: unless-stopped
     ports:
-      - '${ANONYMIZE_HOST_PORT:-8001}:8000'
+      - '${ANONYMIZE_HOST_PORT:-8002}:8000'
     healthcheck:
       test:
         [


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Port/config-only changes affecting local dev and client generation defaults; risk is limited to breaking dev connectivity if any external tooling still assumes `8001`.
> 
> **Overview**
> Updates the dev setup to run the `anonymize` service on host port `8002` instead of `8001`, aligning `docker-compose` port mappings and the repo-level `compose.dev.yml` default.
> 
> Adjusts local tooling/config to match: `orval.config.ts` now pulls the Anonymize OpenAPI spec from `http://localhost:8002`, and the Anonymize axios client default `baseURL` fallback changes to `http://localhost:8002` (still overridable via `ANONYMIZE_SERVICE_URL`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5a30d13eac04c492db1f48a31cb9d67ad8065550. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->