### PR TITLE
fix(AYC-90): use RETURNING clause in toggleSkillPinned to eliminate TOCTOU gap

### DIFF
--- a/ayunis-core-backend/src/db/migrations/1771676835732-AddIsPinnedToSkillActivations.ts
+++ b/ayunis-core-backend/src/db/migrations/1771676835732-AddIsPinnedToSkillActivations.ts
@@ -1,0 +1,14 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddIsPinnedToSkillActivations1771676835732 implements MigrationInterface {
+    name = 'AddIsPinnedToSkillActivations1771676835732'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "skill_activations" ADD "isPinned" boolean NOT NULL DEFAULT false`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "skill_activations" DROP COLUMN "isPinned"`);
+    }
+
+}

--- a/ayunis-core-backend/src/domain/skills/application/ports/skill.repository.ts
+++ b/ayunis-core-backend/src/domain/skills/application/ports/skill.repository.ts
@@ -26,4 +26,6 @@ export abstract class SkillRepository {
     retainUserIds: Set<UUID>,
   ): Promise<void>;
   abstract findByIds(ids: UUID[]): Promise<Skill[]>;
+  abstract toggleSkillPinned(skillId: UUID, userId: UUID): Promise<boolean>;
+  abstract getPinnedSkillIds(userId: UUID): Promise<Set<UUID>>;
 }

--- a/ayunis-core-backend/src/domain/skills/application/skills.errors.ts
+++ b/ayunis-core-backend/src/domain/skills/application/skills.errors.ts
@@ -15,6 +15,7 @@ export enum SkillErrorCode {
   UNSUPPORTED_FILE_TYPE = 'UNSUPPORTED_FILE_TYPE',
   EMPTY_FILE_DATA = 'EMPTY_FILE_DATA',
   MARKETPLACE_INSTALL_FAILED = 'MARKETPLACE_INSTALL_FAILED',
+  SKILL_NOT_ACTIVE = 'SKILL_NOT_ACTIVE',
   UNEXPECTED_SKILL_ERROR = 'UNEXPECTED_SKILL_ERROR',
 }
 
@@ -172,6 +173,17 @@ export class MarketplaceInstallFailedError extends SkillError {
       SkillErrorCode.MARKETPLACE_INSTALL_FAILED,
       500,
       { identifier, ...metadata },
+    );
+  }
+}
+
+export class SkillNotActiveError extends SkillError {
+  constructor(skillId: string, metadata?: ErrorMetadata) {
+    super(
+      `Skill with ID ${skillId} is not active and cannot be pinned`,
+      SkillErrorCode.SKILL_NOT_ACTIVE,
+      400,
+      metadata,
     );
   }
 }

--- a/ayunis-core-backend/src/domain/skills/application/strategies/skill-share-authorization.strategy.spec.ts
+++ b/ayunis-core-backend/src/domain/skills/application/strategies/skill-share-authorization.strategy.spec.ts
@@ -23,6 +23,8 @@ describe('SkillShareAuthorizationStrategy', () => {
       isSkillActive: jest.fn(),
       getActiveSkillIds: jest.fn(),
       findByIds: jest.fn(),
+      toggleSkillPinned: jest.fn(),
+      getPinnedSkillIds: jest.fn(),
     };
 
     const module: TestingModule = await Test.createTestingModule({

--- a/ayunis-core-backend/src/domain/skills/application/use-cases/find-all-skills/find-all-skills.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/skills/application/use-cases/find-all-skills/find-all-skills.use-case.spec.ts
@@ -43,6 +43,8 @@ describe('FindAllSkillsUseCase', () => {
     const mockSkillRepository = {
       findAllByOwner: jest.fn(),
       findByIds: jest.fn(),
+      toggleSkillPinned: jest.fn(),
+      getPinnedSkillIds: jest.fn(),
     };
 
     const mockFindSharesByScopeUseCase = {

--- a/ayunis-core-backend/src/domain/skills/application/use-cases/find-skill-by-name/find-skill-by-name.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/skills/application/use-cases/find-skill-by-name/find-skill-by-name.use-case.spec.ts
@@ -38,6 +38,8 @@ describe('FindSkillByNameUseCase', () => {
     skillRepository = {
       findByNameAndOwner: jest.fn(),
       findByIds: jest.fn(),
+      toggleSkillPinned: jest.fn(),
+      getPinnedSkillIds: jest.fn(),
     } as unknown as jest.Mocked<SkillRepository>;
 
     findSharesByScopeUseCase = {

--- a/ayunis-core-backend/src/domain/skills/application/use-cases/list-skill-mcp-integrations/list-skill-mcp-integrations.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/skills/application/use-cases/list-skill-mcp-integrations/list-skill-mcp-integrations.use-case.spec.ts
@@ -44,6 +44,8 @@ describe('ListSkillMcpIntegrationsUseCase', () => {
       deactivateAllExceptOwner: jest.fn(),
       deactivateUsersNotInSet: jest.fn(),
       findByIds: jest.fn(),
+      toggleSkillPinned: jest.fn(),
+      getPinnedSkillIds: jest.fn(),
     } as jest.Mocked<SkillRepository>;
 
     const mockGetMcpIntegrationsByIdsUseCase = {

--- a/ayunis-core-backend/src/domain/skills/application/use-cases/list-skill-sources/list-skill-sources.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/skills/application/use-cases/list-skill-sources/list-skill-sources.use-case.spec.ts
@@ -42,6 +42,8 @@ describe('ListSkillSourcesUseCase', () => {
       deactivateAllExceptOwner: jest.fn(),
       deactivateUsersNotInSet: jest.fn(),
       findByIds: jest.fn(),
+      toggleSkillPinned: jest.fn(),
+      getPinnedSkillIds: jest.fn(),
     } as jest.Mocked<SkillRepository>;
 
     const mockGetSourcesByIdsUseCase = {

--- a/ayunis-core-backend/src/domain/skills/application/use-cases/toggle-skill-active/toggle-skill-active.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/skills/application/use-cases/toggle-skill-active/toggle-skill-active.use-case.spec.ts
@@ -39,6 +39,8 @@ describe('ToggleSkillActiveUseCase', () => {
     const mockSkillRepository = {
       findOne: jest.fn(),
       findByIds: jest.fn(),
+      toggleSkillPinned: jest.fn(),
+      getPinnedSkillIds: jest.fn(),
       update: jest.fn(),
       isSkillActive: jest.fn(),
       activateSkill: jest.fn(),

--- a/ayunis-core-backend/src/domain/skills/infrastructure/persistence/local/local-skill.repository.spec.ts
+++ b/ayunis-core-backend/src/domain/skills/infrastructure/persistence/local/local-skill.repository.spec.ts
@@ -1,0 +1,120 @@
+import type { EntityManager, Repository } from 'typeorm';
+import type { TransactionHost } from '@nestjs-cls/transactional';
+import type { TransactionalAdapterTypeOrm } from '@nestjs-cls/transactional-adapter-typeorm';
+import { randomUUID } from 'crypto';
+
+import { LocalSkillRepository } from './local-skill.repository';
+import type { SkillRecord } from './schema/skill.record';
+import { SkillActivationRecord } from './schema/skill-activation.record';
+import type { SkillMapper } from './mappers/skill.mapper';
+import { SkillNotActiveError } from '../../../application/skills.errors';
+
+describe('LocalSkillRepository', () => {
+  let repository: LocalSkillRepository;
+  let activationRepo: jest.Mocked<Repository<SkillActivationRecord>>;
+  let mockManager: {
+    findOne: jest.Mock;
+    find: jest.Mock;
+    query: jest.Mock;
+    createQueryBuilder: jest.Mock;
+  };
+
+  const userId = randomUUID();
+  const skillId = randomUUID();
+
+  beforeEach(() => {
+    activationRepo = {
+      find: jest.fn(),
+      count: jest.fn(),
+      manager: {} as EntityManager,
+    } as unknown as jest.Mocked<Repository<SkillActivationRecord>>;
+
+    const skillRepo = {
+      manager: {} as EntityManager,
+    } as unknown as jest.Mocked<Repository<SkillRecord>>;
+
+    const mockQueryBuilder = {
+      update: jest.fn().mockReturnThis(),
+      set: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      execute: jest.fn(),
+    };
+
+    mockManager = {
+      findOne: jest.fn(),
+      find: jest.fn(),
+      query: jest.fn(),
+      createQueryBuilder: jest.fn().mockReturnValue(mockQueryBuilder),
+    };
+
+    const txHost = {
+      tx: mockManager,
+    } as unknown as TransactionHost<TransactionalAdapterTypeOrm>;
+
+    const mapper = {} as SkillMapper;
+
+    repository = new LocalSkillRepository(
+      skillRepo,
+      activationRepo,
+      mapper,
+      txHost,
+    );
+  });
+
+  describe('toggleSkillPinned', () => {
+    it('should toggle isPinned and return new value using RETURNING clause', async () => {
+      mockManager.query.mockResolvedValue([{ isPinned: true }]);
+
+      const result = await repository.toggleSkillPinned(skillId, userId);
+
+      expect(result).toBe(true);
+      expect(mockManager.query).toHaveBeenCalledWith(
+        expect.stringContaining('UPDATE skill_activations'),
+        [skillId, userId],
+      );
+    });
+
+    it('should return false when skill was unpinned', async () => {
+      mockManager.query.mockResolvedValue([{ isPinned: false }]);
+
+      const result = await repository.toggleSkillPinned(skillId, userId);
+
+      expect(result).toBe(false);
+    });
+
+    it('should throw SkillNotActiveError when no activation row exists', async () => {
+      mockManager.query.mockResolvedValue([]);
+
+      await expect(
+        repository.toggleSkillPinned(skillId, userId),
+      ).rejects.toThrow(SkillNotActiveError);
+    });
+  });
+
+  describe('getPinnedSkillIds', () => {
+    it('should return only pinned skill IDs', async () => {
+      const pinnedSkillId1 = randomUUID();
+      const pinnedSkillId2 = randomUUID();
+      mockManager.find.mockResolvedValue([
+        { skillId: pinnedSkillId1 } as SkillActivationRecord,
+        { skillId: pinnedSkillId2 } as SkillActivationRecord,
+      ]);
+
+      const result = await repository.getPinnedSkillIds(userId);
+
+      expect(result).toEqual(new Set([pinnedSkillId1, pinnedSkillId2]));
+      expect(mockManager.find).toHaveBeenCalledWith(SkillActivationRecord, {
+        where: { userId, isPinned: true },
+        select: ['skillId'],
+      });
+    });
+
+    it('should return an empty set when no skills are pinned', async () => {
+      mockManager.find.mockResolvedValue([]);
+
+      const result = await repository.getPinnedSkillIds(userId);
+
+      expect(result).toEqual(new Set());
+    });
+  });
+});

--- a/ayunis-core-backend/src/domain/skills/infrastructure/persistence/local/schema/skill-activation.record.ts
+++ b/ayunis-core-backend/src/domain/skills/infrastructure/persistence/local/schema/skill-activation.record.ts
@@ -28,6 +28,9 @@ export class SkillActivationRecord {
   @ManyToOne(() => UserRecord, { nullable: false, onDelete: 'CASCADE' })
   user: UserRecord;
 
+  @Column({ default: false })
+  isPinned: boolean;
+
   @CreateDateColumn()
   createdAt: Date;
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Includes a schema migration and new persistence logic that changes how `skill_activations` rows are updated/read; mistakes could break pin/unpin behavior or throw errors in production.
> 
> **Overview**
> Adds skill pinning support by introducing an `isPinned` flag on `skill_activations` (TypeORM entity + DB migration), plus repository APIs to toggle pin state and list pinned skills.
> 
> `LocalSkillRepository.toggleSkillPinned` now flips `isPinned` and returns the new value using a single `UPDATE ... RETURNING` query (closing a TOCTOU gap) and throws the new `SkillNotActiveError` if no activation row exists; tests and module docs/mocks are updated accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5880b8a00b05ba927a33c7feee7636a1f50c70c1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->