### PR TITLE
wip(AYC-90): add isSkillInstruction to text content and fix OpenAI multi-content

### DIFF
--- a/.claude/skills/git-workflow/SKILL.md
+++ b/.claude/skills/git-workflow/SKILL.md
@@ -95,12 +95,27 @@ gt modify -m "<type>(AYC-<number>): <description>"
 
 Note: `gt modify` without `--commit` amends the existing commit. With `--commit` it creates an additional commit on the branch — that's not what we want for fixes.
 
+### Pushing to remote
+
+**Never use raw `git push`** — always use `gt submit`. Raw pushes bypass Graphite's metadata and desynchronize remote base branches, causing merge conflicts on GitHub.
+
+```bash
+# Push the current branch only
+gt submit --force --no-interactive
+
+# Push the entire stack
+gt submit --stack --force --no-interactive
+```
+
+Use `--force` to ensure remote refs are updated even if Graphite thinks they're current. Add `--publish` to take PRs out of draft.
+
 ### Rules
 
 - Each logical unit of work gets its own `gt create` — one stacked branch per batch/task
 - Fixes and amendments use `gt modify`, never `gt create`
 - Never use `--no-verify` — let the hooks run
 - Never use raw `git commit` — always go through `gt`
+- Never use raw `git push` — always go through `gt submit`
 
 ## Pre-commit Hooks
 

--- a/ayunis-core-backend/src/domain/messages/domain/message-contents/text-message-content.entity.ts
+++ b/ayunis-core-backend/src/domain/messages/domain/message-contents/text-message-content.entity.ts
@@ -6,11 +6,17 @@ import type { ProviderMetadata } from './provider-metadata.type';
 export class TextMessageContent extends MessageContent {
   public text: string;
   public readonly providerMetadata: ProviderMetadata;
+  public readonly isSkillInstruction: boolean;
 
-  constructor(text: string, providerMetadata: ProviderMetadata = null) {
+  constructor(
+    text: string,
+    providerMetadata: ProviderMetadata = null,
+    isSkillInstruction = false,
+  ) {
     super(MessageContentType.TEXT);
     // Sanitize text to handle invalid Unicode escape sequences
     this.text = sanitizeUnicodeEscapes(text);
     this.providerMetadata = providerMetadata;
+    this.isSkillInstruction = isSkillInstruction;
   }
 }

--- a/ayunis-core-backend/src/domain/messages/infrastructure/persistence/local/mappers/message.mapper.ts
+++ b/ayunis-core-backend/src/domain/messages/infrastructure/persistence/local/mappers/message.mapper.ts
@@ -29,6 +29,9 @@ export class MessageMapper {
           ...(content.providerMetadata && {
             providerMetadata: content.providerMetadata,
           }),
+          ...(content.isSkillInstruction && {
+            isSkillInstruction: true,
+          }),
         };
       }
       if (content instanceof ToolUseMessageContent) {
@@ -80,7 +83,11 @@ export class MessageMapper {
           createdAt: messageEntity.createdAt,
           content: messageEntity.content.map((content) => {
             if (content.type === MessageContentType.TEXT) {
-              return new TextMessageContent(content.text);
+              return new TextMessageContent(
+                content.text,
+                null,
+                content.isSkillInstruction ?? false,
+              );
             }
             if (content.type === MessageContentType.IMAGE) {
               return new ImageMessageContent(

--- a/ayunis-core-backend/src/domain/messages/infrastructure/persistence/local/schema/message.record.ts
+++ b/ayunis-core-backend/src/domain/messages/infrastructure/persistence/local/schema/message.record.ts
@@ -10,6 +10,7 @@ interface TextMessageContentData {
   type: MessageContentType.TEXT;
   text: string;
   providerMetadata?: ProviderMetadata;
+  isSkillInstruction?: boolean;
 }
 
 interface ToolUseMessageContentData {

--- a/ayunis-core-backend/src/domain/models/infrastructure/converters/openai-chat-message.converter.ts
+++ b/ayunis-core-backend/src/domain/models/infrastructure/converters/openai-chat-message.converter.ts
@@ -67,12 +67,13 @@ export class OpenAIChatMessageConverter {
   private convertUserMessage(
     message: Message,
   ): OpenAI.ChatCompletionMessageParam[] {
-    return message.content
+    const contentParts: OpenAI.ChatCompletionContentPart[] = message.content
       .filter((c) => c instanceof TextMessageContent)
-      .map((c) => ({
-        role: 'user' as const,
-        content: [{ type: 'text' as const, text: c.text }],
-      }));
+      .map((c) => ({ type: 'text' as const, text: c.text }));
+
+    if (contentParts.length === 0) return [];
+
+    return [{ role: 'user' as const, content: contentParts }];
   }
 
   private convertAssistantMessage(

--- a/ayunis-core-backend/src/domain/threads/presenters/http/dto/get-thread-response.dto/message-response.dto.ts
+++ b/ayunis-core-backend/src/domain/threads/presenters/http/dto/get-thread-response.dto/message-response.dto.ts
@@ -17,6 +17,13 @@ export class TextMessageContentResponseDto extends MessageContentResponseDto {
     example: 'Hello, how can I help you today?',
   })
   text: string;
+
+  @ApiProperty({
+    description: 'Whether this text content contains skill instructions',
+    example: false,
+    required: false,
+  })
+  isSkillInstruction?: boolean;
 }
 
 export class ToolUseMessageContentResponseDto extends MessageContentResponseDto {

--- a/ayunis-core-backend/src/domain/threads/presenters/http/mappers/message.mapper.ts
+++ b/ayunis-core-backend/src/domain/threads/presenters/http/mappers/message.mapper.ts
@@ -169,6 +169,7 @@ export class MessageDtoMapper {
     return {
       type: content.type,
       text: content.text,
+      ...(content.isSkillInstruction && { isSkillInstruction: true }),
     };
   }
 

--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
@@ -1214,6 +1214,8 @@ export interface TextMessageContentResponseDto {
   type: TextMessageContentResponseDtoType;
   /** The text content of the message */
   text: string;
+  /** Whether this text content contains skill instructions */
+  isSkillInstruction?: boolean;
 }
 
 /**

--- a/ayunis-core-frontend/src/shared/api/openapi-schema.json
+++ b/ayunis-core-frontend/src/shared/api/openapi-schema.json
@@ -8882,6 +8882,11 @@
             "type": "string",
             "description": "The text content of the message",
             "example": "Hello, how can I help you today?"
+          },
+          "isSkillInstruction": {
+            "type": "boolean",
+            "description": "Whether this text content contains skill instructions",
+            "example": false
           }
         },
         "required": [


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches message serialization across DB JSON, API contracts, and OpenAI request shaping; incorrect mapping could break backward compatibility for stored messages or downstream model calls.
> 
> **Overview**
> Adds an optional `isSkillInstruction` flag to `TextMessageContent` and threads it through local message persistence (record schema + domain/record mappers) and the thread HTTP response DTOs/OpenAPI-generated frontend types.
> 
> Fixes OpenAI chat conversion for user messages by emitting **one** `user` message with a multi-part `content` array (and returning `[]` when there’s no text), instead of generating multiple `user` messages.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8fc2fb033124dc699ae8681d2bfde558c9599a51. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->