### PR TITLE
fix(AYC-91): fix artifact PDF/DOCX export and UX issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,8 +38,10 @@ RUN npm run build
 # Stage 3: Production
 FROM node:20-alpine AS production
 
-# Install runtime dependencies for bcrypt
-RUN apk add --no-cache python3 make g++ gcc
+# Install runtime dependencies for bcrypt and Chromium for Puppeteer PDF export
+RUN apk add --no-cache python3 make g++ gcc chromium
+
+ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser
 
 WORKDIR /app
 

--- a/ayunis-core-backend/Dockerfile.dev
+++ b/ayunis-core-backend/Dockerfile.dev
@@ -1,7 +1,10 @@
 FROM node:20-alpine
 
 # Install build dependencies for bcrypt and other native modules
-RUN apk add --no-cache python3 make g++ gcc curl
+# Install Chromium for Puppeteer PDF export
+RUN apk add --no-cache python3 make g++ gcc curl chromium
+
+ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser
 
 WORKDIR /app
 

--- a/ayunis-core-backend/package-lock.json
+++ b/ayunis-core-backend/package-lock.json
@@ -56,7 +56,7 @@
         "pdf-parse": "^1.1.1",
         "pg": "^8.18.0",
         "prom-client": "^15.1.3",
-        "puppeteer": "^24.37.4",
+        "puppeteer-core": "^24.37.5",
         "reflect-metadata": "^0.2.2",
         "rxjs": "^7.8.1",
         "sanitize-html": "^2.17.1",
@@ -12272,15 +12272,6 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
-    "node_modules/env-paths": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
-      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/error": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/error/-/error-4.4.0.tgz",
@@ -20491,27 +20482,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/puppeteer": {
-      "version": "24.37.5",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-24.37.5.tgz",
-      "integrity": "sha512-3PAOIQLceyEmn1Fi76GkGO2EVxztv5OtdlB1m8hMUZL3f8KDHnlvXbvCXv+Ls7KzF1R0KdKBqLuT/Hhrok12hQ==",
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@puppeteer/browsers": "2.13.0",
-        "chromium-bidi": "14.0.0",
-        "cosmiconfig": "^9.0.0",
-        "devtools-protocol": "0.0.1566079",
-        "puppeteer-core": "24.37.5",
-        "typed-query-selector": "^2.12.0"
-      },
-      "bin": {
-        "puppeteer": "lib/cjs/puppeteer/node/cli.js"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/puppeteer-core": {
       "version": "24.37.5",
       "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.37.5.tgz",
@@ -20528,32 +20498,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/puppeteer/node_modules/cosmiconfig": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.0.tgz",
-      "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
-      "license": "MIT",
-      "dependencies": {
-        "env-paths": "^2.2.1",
-        "import-fresh": "^3.3.0",
-        "js-yaml": "^4.1.0",
-        "parse-json": "^5.2.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/d-fischer"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.9.5"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
       }
     },
     "node_modules/pure-rand": {

--- a/ayunis-core-backend/package.json
+++ b/ayunis-core-backend/package.json
@@ -91,7 +91,7 @@
     "pdf-parse": "^1.1.1",
     "pg": "^8.18.0",
     "prom-client": "^15.1.3",
-    "puppeteer": "^24.37.4",
+    "puppeteer-core": "^24.37.5",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",
     "sanitize-html": "^2.17.1",

--- a/ayunis-core-backend/src/domain/artifacts/application/artifacts.errors.ts
+++ b/ayunis-core-backend/src/domain/artifacts/application/artifacts.errors.ts
@@ -61,15 +61,15 @@ export class ArtifactVersionConflictError extends ArtifactError {
 
 export class ArtifactContentTooLargeError extends ArtifactError {
   constructor(
-    contentSizeBytes: number,
-    maxSizeBytes: number,
+    contentLength: number,
+    maxLength: number,
     metadata?: ErrorMetadata,
   ) {
     super(
-      `Artifact content size (${contentSizeBytes} bytes) exceeds maximum (${maxSizeBytes} bytes)`,
+      `Artifact content length (${contentLength} characters) exceeds maximum (${maxLength} characters)`,
       ArtifactErrorCode.ARTIFACT_CONTENT_TOO_LARGE,
       400,
-      { contentSizeBytes, maxSizeBytes, ...metadata },
+      { contentLength, maxLength, ...metadata },
     );
   }
 }

--- a/ayunis-core-backend/src/domain/artifacts/infrastructure/export/html-document-export.service.spec.ts
+++ b/ayunis-core-backend/src/domain/artifacts/infrastructure/export/html-document-export.service.spec.ts
@@ -16,9 +16,8 @@ describe('HtmlDocumentExportService', () => {
     </table>
   `;
 
-  beforeAll(async () => {
+  beforeAll(() => {
     service = new HtmlDocumentExportService();
-    await service.onModuleInit();
   });
 
   afterAll(async () => {
@@ -55,6 +54,69 @@ describe('HtmlDocumentExportService', () => {
 
       expect(result).toBeInstanceOf(Buffer);
       expect(result.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('applyInlineStyles', () => {
+    const applyInlineStyles = (html: string): string => {
+      return (service as any).applyInlineStyles(html);
+    };
+
+    it('should not affect <pre> tags when styling <p> tags', () => {
+      const html = '<pre><code>const x = 1;</code></pre><p>Normal text</p>';
+      const result = applyInlineStyles(html);
+
+      expect(result).toContain('<pre><code>const x = 1;</code></pre>');
+      expect(result).toContain('<p style="margin-bottom:8pt"');
+      expect(result).not.toMatch(/<pre style=/);
+    });
+
+    it('should not affect <thead> tags when styling <th> tags', () => {
+      const html = '<table><thead><tr><th>Name</th></tr></thead></table>';
+      const result = applyInlineStyles(html);
+
+      expect(result).not.toMatch(/<thead style=/);
+      expect(result).toContain(
+        '<th style="border:1px solid #ccc;padding:6pt 8pt;text-align:left;background-color:#f5f5f5;font-weight:bold"',
+      );
+    });
+
+    it('should merge styles when element already has a style attribute', () => {
+      const html = '<p style="text-align:center">Centered paragraph</p>';
+      const result = applyInlineStyles(html);
+
+      // Should have exactly one style attribute with both values
+      const styleMatches = result.match(/style="[^"]*text-align:center[^"]*"/);
+      expect(styleMatches).not.toBeNull();
+      expect(result).toContain('margin-bottom:8pt');
+
+      // Must NOT have two separate style attributes
+      expect(result).not.toMatch(/style="[^"]*"\s+style="[^"]*"/);
+    });
+
+    it('should merge styles when other attributes separate the two style attributes', () => {
+      const html =
+        '<p class="intro" style="text-align:center">Centered paragraph</p>';
+      const result = applyInlineStyles(html);
+
+      // Should have exactly one style attribute with both values
+      expect(result).toContain('margin-bottom:8pt');
+      expect(result).toContain('text-align:center');
+
+      // The class attribute must be preserved
+      expect(result).toContain('class="intro"');
+
+      // Must NOT have two separate style attributes anywhere in the tag
+      expect(result).not.toMatch(/style="[^"]*"[^>]*style="[^"]*"/);
+    });
+
+    it('should not affect <ol> when styling <ol> does not break other tags', () => {
+      const html = '<ol><li>First</li></ol>';
+      const result = applyInlineStyles(html);
+
+      expect(result).toContain(
+        '<ol style="margin-bottom:8pt;padding-left:24pt"',
+      );
     });
   });
 

--- a/ayunis-core-backend/src/domain/artifacts/infrastructure/export/html-document-export.service.ts
+++ b/ayunis-core-backend/src/domain/artifacts/infrastructure/export/html-document-export.service.ts
@@ -24,7 +24,7 @@ export class HtmlDocumentExportService
     const wrappedHtml = this.wrapHtmlForDocx(html);
     const buffer = await htmlToDocx(wrappedHtml, null, {
       font: 'Arial',
-      fontSize: '12pt',
+      fontSize: 24, // half-points (OOXML standard): 24 = 12pt
       table: { row: { cantSplit: true } },
       footer: true,
       pageNumber: true,

--- a/ayunis-core-backend/src/domain/artifacts/infrastructure/export/html-document-export.service.ts
+++ b/ayunis-core-backend/src/domain/artifacts/infrastructure/export/html-document-export.service.ts
@@ -1,26 +1,18 @@
-import {
-  Injectable,
-  Logger,
-  OnModuleDestroy,
-  OnModuleInit,
-} from '@nestjs/common';
+import { Injectable, Logger, OnModuleDestroy } from '@nestjs/common';
 import { DocumentExportPort } from '../../application/ports/document-export.port';
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 import htmlToDocx = require('html-to-docx');
-import puppeteer, { Browser } from 'puppeteer';
+import puppeteer, { Browser } from 'puppeteer-core';
+import { existsSync } from 'fs';
 import { sanitizeHtmlContent } from '../../application/helpers/sanitize-html-content';
 
 @Injectable()
 export class HtmlDocumentExportService
-  implements DocumentExportPort, OnModuleInit, OnModuleDestroy
+  implements DocumentExportPort, OnModuleDestroy
 {
   private readonly logger = new Logger(HtmlDocumentExportService.name);
   private browser: Browser | null = null;
   private launchPromise: Promise<void> | null = null;
-
-  async onModuleInit(): Promise<void> {
-    await this.launchBrowser();
-  }
 
   async onModuleDestroy(): Promise<void> {
     await this.closeBrowser();
@@ -29,11 +21,19 @@ export class HtmlDocumentExportService
   async exportToDocx(html: string): Promise<Buffer> {
     this.logger.log('Exporting HTML to DOCX');
 
-    const wrappedHtml = this.wrapHtml(html);
+    const wrappedHtml = this.wrapHtmlForDocx(html);
     const buffer = await htmlToDocx(wrappedHtml, null, {
+      font: 'Arial',
+      fontSize: '12pt',
       table: { row: { cantSplit: true } },
       footer: true,
       pageNumber: true,
+      margins: {
+        top: 1440,
+        right: 1440,
+        bottom: 1440,
+        left: 1440,
+      },
     });
 
     return Buffer.from(buffer);
@@ -42,7 +42,7 @@ export class HtmlDocumentExportService
   async exportToPdf(html: string): Promise<Buffer> {
     this.logger.log('Exporting HTML to PDF');
 
-    const wrappedHtml = this.wrapHtml(html);
+    const wrappedHtml = this.wrapHtmlForPdf(html);
     const browser = await this.getBrowser();
     const page = await browser.newPage();
 
@@ -66,8 +66,8 @@ export class HtmlDocumentExportService
       return this.browser;
     }
 
-    this.logger.warn('Browser disconnected — relaunching');
     if (!this.launchPromise) {
+      this.logger.log('Launching Puppeteer browser (lazy init)');
       this.launchPromise = this.launchBrowser().finally(() => {
         this.launchPromise = null;
       });
@@ -77,11 +77,37 @@ export class HtmlDocumentExportService
   }
 
   private async launchBrowser(): Promise<void> {
+    const executablePath = this.resolveChromePath();
     this.browser = await puppeteer.launch({
       headless: true,
+      executablePath,
       args: ['--no-sandbox', '--disable-setuid-sandbox'],
     });
-    this.logger.log('Puppeteer browser launched');
+    this.logger.log(`Puppeteer browser launched (${executablePath})`);
+  }
+
+  private resolveChromePath(): string {
+    if (process.env.PUPPETEER_EXECUTABLE_PATH) {
+      return process.env.PUPPETEER_EXECUTABLE_PATH;
+    }
+
+    // Common Chrome/Chromium paths for local development
+    const candidates = [
+      '/usr/bin/chromium-browser',
+      '/usr/bin/chromium',
+      '/usr/bin/google-chrome',
+      '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+    ];
+
+    for (const candidate of candidates) {
+      if (existsSync(candidate)) {
+        return candidate;
+      }
+    }
+
+    throw new Error(
+      'No Chrome/Chromium executable found. Set PUPPETEER_EXECUTABLE_PATH.',
+    );
   }
 
   private async closeBrowser(): Promise<void> {
@@ -93,13 +119,23 @@ export class HtmlDocumentExportService
   }
 
   /**
-   * Wraps HTML content in a full document with styles for export.
+   * Wraps HTML for DOCX export using inline styles.
    *
-   * Re-sanitization here is intentional defense-in-depth: content stored
-   * before the sanitization fix may contain unsanitized HTML, so we
-   * sanitize at the export boundary regardless of upstream guarantees.
+   * html-to-docx ignores `<style>` blocks, so all styling must be inline.
+   * Document-level formatting (font, fontSize, margins) is set via
+   * html-to-docx API options in exportToDocx().
    */
-  private wrapHtml(unsafeHtml: string): string {
+  private wrapHtmlForDocx(unsafeHtml: string): string {
+    const html = sanitizeHtmlContent(unsafeHtml);
+    return this.applyInlineStyles(html);
+  }
+
+  /**
+   * Wraps HTML for PDF export with a `<style>` block.
+   *
+   * Puppeteer fully supports CSS `<style>` blocks.
+   */
+  private wrapHtmlForPdf(unsafeHtml: string): string {
     const html = sanitizeHtmlContent(unsafeHtml);
     return `<!DOCTYPE html>
 <html>
@@ -126,5 +162,61 @@ export class HtmlDocumentExportService
 </head>
 <body>${html}</body>
 </html>`;
+  }
+
+  /**
+   * Wraps HTML content with inline styles for DOCX compatibility.
+   */
+  private applyInlineStyles(html: string): string {
+    const styledHtml = html
+      .replace(/<h1(?=[\s>])/g, '<h1 style="font-size:20pt;margin-bottom:12pt"')
+      .replace(/<h2(?=[\s>])/g, '<h2 style="font-size:16pt;margin-bottom:10pt"')
+      .replace(/<h3(?=[\s>])/g, '<h3 style="font-size:14pt;margin-bottom:8pt"')
+      .replace(/<p(?=[\s>])/g, '<p style="margin-bottom:8pt"')
+      .replace(
+        /<ul(?=[\s>])/g,
+        '<ul style="margin-bottom:8pt;padding-left:24pt"',
+      )
+      .replace(
+        /<ol(?=[\s>])/g,
+        '<ol style="margin-bottom:8pt;padding-left:24pt"',
+      )
+      .replace(
+        /<table(?=[\s>])/g,
+        '<table style="border-collapse:collapse;width:100%;margin-bottom:12pt"',
+      )
+      .replace(
+        /<th(?=[\s>])/g,
+        '<th style="border:1px solid #ccc;padding:6pt 8pt;text-align:left;background-color:#f5f5f5;font-weight:bold"',
+      )
+      .replace(
+        /<td(?=[\s>])/g,
+        '<td style="border:1px solid #ccc;padding:6pt 8pt;text-align:left"',
+      )
+      .replace(/<a(?=[\s>])/g, '<a style="color:#1a73e8"');
+
+    const mergedHtml = this.mergeDuplicateStyles(styledHtml);
+
+    return `<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"></head>
+<body style="font-family:Arial,Helvetica,sans-serif;font-size:12pt;line-height:1.6;color:#333">${mergedHtml}</body>
+</html>`;
+  }
+
+  /**
+   * Merges duplicate `style` attributes on the same tag into one.
+   *
+   * When applyInlineStyles adds a style to a tag that already has one,
+   * the result is two style attributes. This method combines them.
+   */
+  private mergeDuplicateStyles(html: string): string {
+    return html.replace(
+      /style="([^"]*)"([^>]*?)\s+style="([^"]*)"/g,
+      (_, first: string, between: string, second: string) => {
+        const merged = first.replace(/;$/, '') + ';' + second;
+        return `style="${merged}"${between}`;
+      },
+    );
   }
 }

--- a/ayunis-core-frontend/package-lock.json
+++ b/ayunis-core-frontend/package-lock.json
@@ -5916,12 +5916,12 @@
       }
     },
     "node_modules/@types/react": {
-      "version": "19.2.14",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
-      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "version": "19.1.6",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.6.tgz",
+      "integrity": "sha512-JeG0rEWak0N6Itr6QUx+X60uQmN+5t3j9r/OVDtWzFXKaj6kD1BwJzOksD0FF6iWxZlbE1kB0q9vtnU2ekqa1Q==",
       "license": "MIT",
       "dependencies": {
-        "csstype": "^3.2.2"
+        "csstype": "^3.0.2"
       }
     },
     "node_modules/@types/react-dom": {

--- a/ayunis-core-frontend/package-lock.json
+++ b/ayunis-core-frontend/package-lock.json
@@ -5916,12 +5916,12 @@
       }
     },
     "node_modules/@types/react": {
-      "version": "19.1.6",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.6.tgz",
-      "integrity": "sha512-JeG0rEWak0N6Itr6QUx+X60uQmN+5t3j9r/OVDtWzFXKaj6kD1BwJzOksD0FF6iWxZlbE1kB0q9vtnU2ekqa1Q==",
+      "version": "19.2.14",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
+      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "license": "MIT",
       "dependencies": {
-        "csstype": "^3.0.2"
+        "csstype": "^3.2.2"
       }
     },
     "node_modules/@types/react-dom": {

--- a/ayunis-core-frontend/src/pages/chat/ui/ChatPage.tsx
+++ b/ayunis-core-frontend/src/pages/chat/ui/ChatPage.tsx
@@ -146,7 +146,7 @@ export default function ChatPage({
     threadId: thread.id,
   });
 
-  const { exportArtifact } = useExportArtifact({
+  const { exportArtifact, isExporting } = useExportArtifact({
     artifactId: openArtifactId ?? '',
     title: openArtifact?.title ?? 'document',
   });
@@ -547,6 +547,7 @@ export default function ChatPage({
                 onRevert={handleRevertArtifact}
                 onExport={handleExportArtifact}
                 onClose={handleCloseArtifact}
+                isExporting={isExporting}
               />
             </Suspense>
           ) : undefined

--- a/ayunis-core-frontend/src/widgets/artifact-editor/ui/ArtifactEditor.tsx
+++ b/ayunis-core-frontend/src/widgets/artifact-editor/ui/ArtifactEditor.tsx
@@ -19,6 +19,7 @@ interface ArtifactEditorProps {
   onRevert: (versionNumber: number) => void;
   onExport: (format: 'docx' | 'pdf') => void;
   onClose: () => void;
+  isExporting?: boolean;
 }
 
 export function ArtifactEditor({
@@ -27,6 +28,7 @@ export function ArtifactEditor({
   onRevert,
   onExport,
   onClose,
+  isExporting,
 }: ArtifactEditorProps) {
   const { t } = useTranslation('artifacts');
 
@@ -77,7 +79,7 @@ export function ArtifactEditor({
           {artifact.title}
         </h3>
         <div className="flex items-center gap-1">
-          <ExportButtons onExport={onExport} />
+          <ExportButtons onExport={onExport} isExporting={isExporting} />
           <Button
             variant="default"
             size="sm"

--- a/ayunis-core-frontend/src/widgets/artifact-editor/ui/ExportButtons.tsx
+++ b/ayunis-core-frontend/src/widgets/artifact-editor/ui/ExportButtons.tsx
@@ -4,9 +4,10 @@ import { useTranslation } from 'react-i18next';
 
 interface ExportButtonsProps {
   onExport: (format: 'docx' | 'pdf') => void;
+  isExporting?: boolean;
 }
 
-export function ExportButtons({ onExport }: ExportButtonsProps) {
+export function ExportButtons({ onExport, isExporting }: ExportButtonsProps) {
   const { t } = useTranslation('artifacts');
 
   return (
@@ -15,6 +16,7 @@ export function ExportButtons({ onExport }: ExportButtonsProps) {
         variant="ghost"
         size="sm"
         className="h-8 text-xs"
+        disabled={isExporting}
         onClick={() => onExport('docx')}
       >
         <FileDown className="mr-1 size-3.5" />
@@ -24,6 +26,7 @@ export function ExportButtons({ onExport }: ExportButtonsProps) {
         variant="ghost"
         size="sm"
         className="h-8 text-xs"
+        disabled={isExporting}
         onClick={() => onExport('pdf')}
       >
         <FileDown className="mr-1 size-3.5" />


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the document export implementation and container runtime dependencies (Chromium + `puppeteer-core`), which can affect production image size and PDF/DOCX generation behavior. Risk is moderate due to runtime environment coupling and HTML-to-DOCX styling transformations.
> 
> **Overview**
> Fixes artifact PDF/DOCX export by switching the backend to `puppeteer-core` and running against a system-installed Chromium, with lazy browser startup and explicit executable path resolution.
> 
> Improves DOCX output by generating DOCX-specific HTML with **inline styles** (since `html-to-docx` ignores `<style>` blocks), adds style-merge logic to avoid duplicate `style` attributes, and adds targeted unit tests around styling edge cases.
> 
> Updates Docker (prod + dev) to install Chromium and set `PUPPETEER_EXECUTABLE_PATH`, adjusts artifact size error messaging from *bytes* to *character length*, and disables frontend export buttons while an export is in progress.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1074c4594c62cd0c1d654b22b0ffd98b4275e05c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->