### PR TITLE
fix(AYC-90): add access control and duplicate handling to skill activation

### DIFF
--- a/ayunis-core-backend/src/domain/messages/application/use-cases/create-user-message/create-user-message.command.ts
+++ b/ayunis-core-backend/src/domain/messages/application/use-cases/create-user-message/create-user-message.command.ts
@@ -28,14 +28,21 @@ export class CreateUserMessageCommand {
     public readonly threadId: UUID,
     public readonly text?: string,
     public readonly pendingImages: ImageUploadData[] = [],
+    public readonly skillInstructions?: string,
   ) {
     this.validate();
   }
 
   private validate(): void {
-    // Validate that at least text or images are provided
-    if (!this.text?.trim() && this.pendingImages.length === 0) {
-      throw new Error('Message must contain text or at least one image');
+    // Validate that at least text, images, or skill instructions are provided
+    if (
+      !this.text?.trim() &&
+      this.pendingImages.length === 0 &&
+      !this.skillInstructions?.trim()
+    ) {
+      throw new Error(
+        'Message must contain text, at least one image, or skill instructions',
+      );
     }
 
     // Validate each image

--- a/ayunis-core-backend/src/domain/messages/application/use-cases/create-user-message/create-user-message.use-case.ts
+++ b/ayunis-core-backend/src/domain/messages/application/use-cases/create-user-message/create-user-message.use-case.ts
@@ -52,6 +52,13 @@ export class CreateUserMessageUseCase {
       // Build content array
       const content: (TextMessageContent | ImageMessageContent)[] = [];
 
+      // Prepend skill instructions if provided (marked as isSkillInstruction)
+      if (command.skillInstructions?.trim()) {
+        content.push(
+          new TextMessageContent(command.skillInstructions, null, true),
+        );
+      }
+
       // Add text content if provided
       if (command.text?.trim()) {
         content.push(new TextMessageContent(command.text));

--- a/ayunis-core-backend/src/domain/runs/SUMMARY.md
+++ b/ayunis-core-backend/src/domain/runs/SUMMARY.md
@@ -14,4 +14,6 @@ The runs module is the central orchestrator for AI conversation execution. The `
 - **MessageCleanupService** — Ensures threads end with an assistant message after a run completes or is interrupted by deleting trailing non-assistant messages.
 - **SystemPromptBuilderService** — Builds system prompts from agent configuration, thread context, and active skills.
 
+Note: **SkillActivationService** (which handles copying skill sources, MCP integrations, and returning instructions to the thread) lives in the **skills module** (`src/domain/skills/application/services/skill-activation.service.ts`) and is consumed by both the runs module (`ExecuteRunUseCase`) and the tools module (`ActivateSkillToolHandler`).
+
 The module integrates with **threads** for conversation context, **messages** for creating and reading conversation history, **models** for inference routing, **tools** for executing tool calls during runs, **agents** for loading agent configurations, **skills** for on-demand skill activation and source/MCP injection, **usage** for tracking token consumption, and **chat-settings** for user-level system prompt injection.

--- a/ayunis-core-backend/src/domain/runs/application/use-cases/execute-run/execute-run.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/runs/application/use-cases/execute-run/execute-run.use-case.spec.ts
@@ -21,6 +21,10 @@ import type { ToolAssemblyService } from '../../services/tool-assembly.service';
 import type { ToolResultCollectorService } from '../../services/tool-result-collector.service';
 import type { MessageCleanupService } from '../../services/message-cleanup.service';
 import type { StreamingInferenceService } from '../../services/streaming-inference.service';
+import type { SkillActivationService } from 'src/domain/skills/application/services/skill-activation.service';
+import type { AssistantMessage } from 'src/domain/messages/domain/messages/assistant-message.entity';
+import { ToolResultMessageContent } from 'src/domain/messages/domain/message-contents/tool-result.message-content.entity';
+import { ToolType } from 'src/domain/tools/domain/value-objects/tool-type.enum';
 import { randomUUID } from 'crypto';
 
 describe('ExecuteRunUseCase', () => {
@@ -111,7 +115,197 @@ describe('ExecuteRunUseCase', () => {
       {
         executeStreamingInference: jest.fn(),
       } as unknown as StreamingInferenceService,
+      {
+        activateOnThread: jest.fn(),
+      } as unknown as jest.Mocked<SkillActivationService>,
     );
+  });
+
+  describe('skill activation via quick action', () => {
+    it('should append already-activated note to instructions when skillId is provided', async () => {
+      const skillId = randomUUID();
+      const thread = createMockThread();
+      findThreadUseCase.execute.mockResolvedValue({
+        thread,
+        isLongChat: false,
+      });
+
+      const skillActivationService = (
+        useCase as unknown as {
+          skillActivationService: jest.Mocked<SkillActivationService>;
+        }
+      ).skillActivationService;
+      skillActivationService.activateOnThread.mockResolvedValue({
+        instructions: 'Analyze the legal question.',
+        skillName: 'Legal Research',
+      });
+
+      const streamingInferenceService = (
+        useCase as unknown as {
+          streamingInferenceService: jest.Mocked<StreamingInferenceService>;
+        }
+      ).streamingInferenceService;
+      const assistantMessage = {
+        id: randomUUID(),
+        content: [{ type: 'text', text: 'Response' }],
+      } as unknown as AssistantMessage;
+
+      streamingInferenceService.executeStreamingInference.mockReturnValue(
+        (async function* () {
+          yield assistantMessage;
+        })(),
+      );
+
+      const toolResultCollectorService = (
+        useCase as unknown as {
+          toolResultCollectorService: jest.Mocked<ToolResultCollectorService>;
+        }
+      ).toolResultCollectorService;
+      toolResultCollectorService.exitLoopAfterAgentResponse.mockReturnValue(
+        true,
+      );
+
+      const input = new RunUserInput('Hilfe bei Rechtsrecherche', [], skillId);
+      const command = new ExecuteRunCommand({
+        threadId,
+        input,
+        streaming: true,
+      });
+
+      const generator = await useCase.execute(command);
+      // Drain the generator to completion
+      let drainResult = await generator.next();
+      while (!drainResult.done) {
+        drainResult = await generator.next();
+      }
+
+      // Verify the streaming inference was called with instructions containing the note
+      expect(
+        streamingInferenceService.executeStreamingInference,
+      ).toHaveBeenCalledWith(
+        expect.objectContaining({
+          instructions: expect.stringContaining(
+            'Skill "Legal Research" has already been activated on this thread. Do not call activate_skill for this skill.',
+          ),
+        }),
+      );
+    });
+
+    it('should preserve already-activated note after a subsequent refreshRunContext triggered by AI-initiated activate_skill', async () => {
+      const skillId = randomUUID();
+      const thread = createMockThread();
+      findThreadUseCase.execute.mockResolvedValue({
+        thread,
+        isLongChat: false,
+      });
+
+      const skillActivationService = (
+        useCase as unknown as {
+          skillActivationService: jest.Mocked<SkillActivationService>;
+        }
+      ).skillActivationService;
+      skillActivationService.activateOnThread.mockResolvedValue({
+        instructions: 'Analyze the legal question.',
+        skillName: 'Legal Research',
+      });
+
+      const streamingInferenceService = (
+        useCase as unknown as {
+          streamingInferenceService: jest.Mocked<StreamingInferenceService>;
+        }
+      ).streamingInferenceService;
+
+      // First inference: assistant calls activate_skill tool
+      const toolCallMessage = {
+        id: randomUUID(),
+        content: [
+          {
+            type: 'tool_use',
+            toolId: 'tool-1',
+            toolName: ToolType.ACTIVATE_SKILL,
+            input: { skill_name: 'Another Skill' },
+          },
+        ],
+      } as unknown as AssistantMessage;
+
+      // Second inference: assistant responds normally
+      const finalMessage = {
+        id: randomUUID(),
+        content: [{ type: 'text', text: 'Final response' }],
+      } as unknown as AssistantMessage;
+
+      let inferenceCallCount = 0;
+      streamingInferenceService.executeStreamingInference.mockImplementation(
+        () => {
+          inferenceCallCount++;
+          if (inferenceCallCount === 1) {
+            return (async function* () {
+              yield toolCallMessage;
+            })();
+          }
+          return (async function* () {
+            yield finalMessage;
+          })();
+        },
+      );
+
+      const toolResultCollectorService = (
+        useCase as unknown as {
+          toolResultCollectorService: jest.Mocked<ToolResultCollectorService>;
+        }
+      ).toolResultCollectorService;
+
+      let collectCallCount = 0;
+      toolResultCollectorService.collectToolResults.mockImplementation(
+        async () => {
+          collectCallCount++;
+          if (collectCallCount === 1) {
+            // First call: no pending results (initial processToolResults)
+            return [];
+          }
+          // Second call: activate_skill tool result
+          return [
+            new ToolResultMessageContent(
+              'tool-1',
+              ToolType.ACTIVATE_SKILL,
+              'Skill activated successfully',
+            ),
+          ];
+        },
+      );
+
+      // First call: don't exit (tool call); second call: exit
+      let exitCallCount = 0;
+      toolResultCollectorService.exitLoopAfterAgentResponse.mockImplementation(
+        () => {
+          exitCallCount++;
+          return exitCallCount > 1;
+        },
+      );
+
+      const input = new RunUserInput('Hilfe bei Rechtsrecherche', [], skillId);
+      const command = new ExecuteRunCommand({
+        threadId,
+        input,
+        streaming: true,
+      });
+
+      const generator = await useCase.execute(command);
+      let drainResult = await generator.next();
+      while (!drainResult.done) {
+        drainResult = await generator.next();
+      }
+
+      // The second inference call must still contain the note
+      // (after refreshRunContext was called again in processToolResults)
+      const secondCall =
+        streamingInferenceService.executeStreamingInference.mock.calls[1];
+      expect(secondCall).toBeDefined();
+      const secondCallParams = secondCall[0] as { instructions?: string };
+      expect(secondCallParams.instructions).toContain(
+        'Skill "Legal Research" has already been activated on this thread. Do not call activate_skill for this skill.',
+      );
+    });
   });
 
   describe('anonymous mode anonymization failure', () => {

--- a/ayunis-core-backend/src/domain/runs/application/use-cases/execute-run/run-params.interface.ts
+++ b/ayunis-core-backend/src/domain/runs/application/use-cases/execute-run/run-params.interface.ts
@@ -1,0 +1,26 @@
+import type { UUID } from 'crypto';
+import type { Thread } from 'src/domain/threads/domain/thread.entity';
+import type { Tool } from 'src/domain/tools/domain/tool.entity';
+import type { LanguageModel } from 'src/domain/models/domain/models/language.model';
+import type {
+  RunUserInput,
+  RunToolResultInput,
+} from '../../../domain/run-input.entity';
+import type { Agent } from 'src/domain/agents/domain/agent.entity';
+import type { Skill } from 'src/domain/skills/domain/skill.entity';
+
+export interface RunParams {
+  thread: Thread;
+  tools: Tool[];
+  model: LanguageModel;
+  input: RunUserInput | RunToolResultInput;
+  instructions?: string;
+  streaming?: boolean;
+  orgId: UUID;
+  isAnonymous: boolean;
+  agent?: Agent;
+  activeSkills: Skill[];
+  skillId?: UUID;
+  skillInstructions?: string;
+  activatedSkillName?: string;
+}

--- a/ayunis-core-backend/src/domain/runs/domain/run-input.entity.ts
+++ b/ayunis-core-backend/src/domain/runs/domain/run-input.entity.ts
@@ -1,3 +1,5 @@
+import type { UUID } from 'crypto';
+
 /**
  * Domain-layer data structure for image uploads.
  * Contains the raw binary data and metadata needed for image storage.
@@ -14,6 +16,7 @@ export class RunUserInput extends RunInput {
   constructor(
     public readonly text: string,
     public readonly pendingImages: ImageUploadData[] = [],
+    public readonly skillId?: UUID,
   ) {
     super();
   }

--- a/ayunis-core-backend/src/domain/runs/presenters/http/dto/send-message.dto.ts
+++ b/ayunis-core-backend/src/domain/runs/presenters/http/dto/send-message.dto.ts
@@ -168,6 +168,16 @@ export class SendMessageDto {
   toolResult?: ToolResultInput;
 
   @IsOptional()
+  @IsUUID()
+  @ApiProperty({
+    description:
+      'Skill ID to activate for this message — injects skill instructions and resources into the thread',
+    example: '550e8400-e29b-41d4-a716-446655440000',
+    required: false,
+  })
+  skillId?: UUID;
+
+  @IsOptional()
   @IsBoolean()
   @Transform(({ value }) => value === 'true' || value === true)
   @ApiProperty({

--- a/ayunis-core-backend/src/domain/runs/presenters/http/mappers/run-input.mapper.ts
+++ b/ayunis-core-backend/src/domain/runs/presenters/http/mappers/run-input.mapper.ts
@@ -5,6 +5,7 @@ import {
 } from 'src/domain/runs/domain/run-input.entity';
 import type { SendMessageDto } from '../dto/send-message.dto';
 import type { ImageUploadData } from 'src/domain/runs/domain/run-input.entity';
+import type { UUID } from 'crypto';
 
 export class RunInputMapper {
   /**
@@ -12,10 +13,12 @@ export class RunInputMapper {
    *
    * @param dto - The SendMessageDto from the request body
    * @param files - Array of uploaded files (from @UploadedFiles())
+   * @param skillId - Optional skill ID for skill activation
    */
   static toCommand(
     dto: SendMessageDto,
     files: Express.Multer.File[] = [],
+    skillId?: UUID,
   ): RunInput {
     // Handle tool result input
     if (dto.toolResult) {
@@ -33,6 +36,6 @@ export class RunInputMapper {
       altText: dto.imageAltTexts?.[index],
     }));
 
-    return new RunUserInput(dto.text ?? '', pendingImages);
+    return new RunUserInput(dto.text ?? '', pendingImages, skillId);
   }
 }

--- a/ayunis-core-backend/src/domain/skills/SUMMARY.md
+++ b/ayunis-core-backend/src/domain/skills/SUMMARY.md
@@ -24,7 +24,8 @@ skills/
 │   ├── ports/skill.repository.ts          # Abstract repository (includes activation + pinning methods)
 │   ├── services/
 │   │   ├── marketplace-skill-installation.service.ts  # Marketplace install logic (resolve name, create, activate)
-│   │   └── skill-access.service.ts        # Shared access-check logic for skill controllers
+│   │   ├── skill-access.service.ts        # Shared access-check logic (exported cross-module, used by runs)
+│   │   └── skill-activation.service.ts    # Activates a skill on a thread (sources, MCP, instructions)
 │   ├── listeners/
 │   │   ├── share-deleted.listener.ts      # Reconciles activations on share deletion
 │   │   └── user-created.listener.ts       # Installs pre-installed marketplace skills for new users
@@ -82,6 +83,7 @@ When a skill share is deleted, the `ShareDeletedListener` handles cleanup of act
 
 - **SourcesModule** — for source management (create/delete sources, batch fetch by IDs)
 - **McpModule** — for MCP integration validation and batch fetch
+- **ThreadsModule** — for adding sources and MCP integrations to threads during skill activation
 - **SharesModule** — for share authorization strategy registration
 - **UsersModule** — for resolving org-scoped share members (`FindAllUserIdsByOrgIdUseCase`)
 - **TeamsModule** — for resolving team-scoped share members (`FindAllUserIdsByTeamIdUseCase`)

--- a/ayunis-core-backend/src/domain/skills/application/services/skill-activation.service.spec.ts
+++ b/ayunis-core-backend/src/domain/skills/application/services/skill-activation.service.spec.ts
@@ -1,0 +1,206 @@
+import type { TestingModule } from '@nestjs/testing';
+import { Test } from '@nestjs/testing';
+import { Logger } from '@nestjs/common';
+import { SkillActivationService } from './skill-activation.service';
+import { SkillAccessService } from 'src/domain/skills/application/services/skill-access.service';
+import { AddSourceToThreadUseCase } from 'src/domain/threads/application/use-cases/add-source-to-thread/add-source-to-thread.use-case';
+import { AddMcpIntegrationToThreadUseCase } from 'src/domain/threads/application/use-cases/add-mcp-integration-to-thread/add-mcp-integration-to-thread.use-case';
+import { GetSourcesByIdsUseCase } from 'src/domain/sources/application/use-cases/get-sources-by-ids/get-sources-by-ids.use-case';
+import { SourceAlreadyAssignedError } from 'src/domain/threads/application/threads.errors';
+import { SkillNotFoundError } from 'src/domain/skills/application/skills.errors';
+import { Skill } from 'src/domain/skills/domain/skill.entity';
+import { Thread } from 'src/domain/threads/domain/thread.entity';
+import { UrlSource } from 'src/domain/sources/domain/sources/text-source.entity';
+import { TextType } from 'src/domain/sources/domain/source-type.enum';
+import type { UUID } from 'crypto';
+
+describe('SkillActivationService', () => {
+  let service: SkillActivationService;
+  let skillAccessService: jest.Mocked<SkillAccessService>;
+  let addSourceToThreadUseCase: jest.Mocked<AddSourceToThreadUseCase>;
+  let addMcpIntegrationToThreadUseCase: jest.Mocked<AddMcpIntegrationToThreadUseCase>;
+  let getSourcesByIdsUseCase: jest.Mocked<GetSourcesByIdsUseCase>;
+
+  const userId = '123e4567-e89b-12d3-a456-426614174000' as UUID;
+  const skillId = '550e8400-e29b-41d4-a716-446655440000' as UUID;
+  const sourceId1 = '660e8400-e29b-41d4-a716-446655440001' as UUID;
+  const sourceId2 = '660e8400-e29b-41d4-a716-446655440002' as UUID;
+  const mcpIntegrationId1 = '770e8400-e29b-41d4-a716-446655440001' as UUID;
+  const mcpIntegrationId2 = '770e8400-e29b-41d4-a716-446655440002' as UUID;
+
+  const makeThread = () =>
+    new Thread({
+      userId,
+      messages: [],
+    });
+
+  const makeSkill = (
+    overrides?: Partial<ConstructorParameters<typeof Skill>[0]>,
+  ) =>
+    new Skill({
+      id: skillId,
+      name: 'Legal Research',
+      shortDescription: 'Research legal topics.',
+      instructions: 'Analyze the legal question thoroughly.',
+      sourceIds: [sourceId1, sourceId2],
+      mcpIntegrationIds: [mcpIntegrationId1, mcpIntegrationId2],
+      userId,
+      ...overrides,
+    });
+
+  const makeSource = (id: UUID) =>
+    new UrlSource({
+      id,
+      url: `https://example.com/doc-${id}`,
+      contentChunks: [],
+      text: 'Sample document content.',
+      name: `Source ${id}`,
+      type: TextType.WEB,
+    });
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        SkillActivationService,
+        {
+          provide: SkillAccessService,
+          useValue: { findAccessibleSkill: jest.fn() },
+        },
+        {
+          provide: AddSourceToThreadUseCase,
+          useValue: { execute: jest.fn() },
+        },
+        {
+          provide: AddMcpIntegrationToThreadUseCase,
+          useValue: { execute: jest.fn() },
+        },
+        {
+          provide: GetSourcesByIdsUseCase,
+          useValue: { execute: jest.fn() },
+        },
+      ],
+    }).compile();
+
+    service = module.get(SkillActivationService);
+    skillAccessService = module.get(SkillAccessService);
+    addSourceToThreadUseCase = module.get(AddSourceToThreadUseCase);
+    addMcpIntegrationToThreadUseCase = module.get(
+      AddMcpIntegrationToThreadUseCase,
+    );
+    getSourcesByIdsUseCase = module.get(GetSourcesByIdsUseCase);
+
+    jest.spyOn(Logger.prototype, 'log').mockImplementation();
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  describe('activateOnThread', () => {
+    it('should add sources and MCP integrations from the skill to the thread', async () => {
+      const thread = makeThread();
+      const skill = makeSkill();
+      const sources = [makeSource(sourceId1), makeSource(sourceId2)];
+
+      skillAccessService.findAccessibleSkill.mockResolvedValue(skill);
+      getSourcesByIdsUseCase.execute.mockResolvedValue(sources);
+
+      const result = await service.activateOnThread(skillId, thread);
+
+      expect(skillAccessService.findAccessibleSkill).toHaveBeenCalledWith(
+        skillId,
+      );
+      expect(addSourceToThreadUseCase.execute).toHaveBeenCalledTimes(2);
+      expect(addMcpIntegrationToThreadUseCase.execute).toHaveBeenCalledTimes(2);
+      expect(result.instructions).toBe(
+        'Analyze the legal question thoroughly.',
+      );
+      expect(result.skillName).toBe('Legal Research');
+    });
+
+    it('should return the skill instructions and name', async () => {
+      const thread = makeThread();
+      const instructions =
+        'You are a municipal budget analyst. Provide detailed breakdowns.';
+      const skill = makeSkill({
+        name: 'Budget Analysis',
+        instructions,
+        sourceIds: [],
+        mcpIntegrationIds: [],
+      });
+
+      skillAccessService.findAccessibleSkill.mockResolvedValue(skill);
+      getSourcesByIdsUseCase.execute.mockResolvedValue([]);
+
+      const result = await service.activateOnThread(skillId, thread);
+
+      expect(result.instructions).toBe(instructions);
+      expect(result.skillName).toBe('Budget Analysis');
+    });
+
+    it('should propagate SkillNotFoundError when user cannot access the skill', async () => {
+      const thread = makeThread();
+      skillAccessService.findAccessibleSkill.mockRejectedValue(
+        new SkillNotFoundError(skillId),
+      );
+
+      await expect(service.activateOnThread(skillId, thread)).rejects.toThrow(
+        SkillNotFoundError,
+      );
+
+      expect(addSourceToThreadUseCase.execute).not.toHaveBeenCalled();
+      expect(addMcpIntegrationToThreadUseCase.execute).not.toHaveBeenCalled();
+    });
+
+    it('should skip sources that are already assigned to the thread', async () => {
+      const thread = makeThread();
+      const skill = makeSkill({ mcpIntegrationIds: [] });
+      const sources = [makeSource(sourceId1), makeSource(sourceId2)];
+
+      skillAccessService.findAccessibleSkill.mockResolvedValue(skill);
+      getSourcesByIdsUseCase.execute.mockResolvedValue(sources);
+      addSourceToThreadUseCase.execute
+        .mockRejectedValueOnce(new SourceAlreadyAssignedError(sourceId1))
+        .mockResolvedValueOnce(undefined);
+
+      const result = await service.activateOnThread(skillId, thread);
+
+      expect(addSourceToThreadUseCase.execute).toHaveBeenCalledTimes(2);
+      expect(result.instructions).toBe(
+        'Analyze the legal question thoroughly.',
+      );
+    });
+
+    it('should not crash when all sources are already assigned (repeated activation)', async () => {
+      const thread = makeThread();
+      const skill = makeSkill();
+      const sources = [makeSource(sourceId1), makeSource(sourceId2)];
+
+      skillAccessService.findAccessibleSkill.mockResolvedValue(skill);
+      getSourcesByIdsUseCase.execute.mockResolvedValue(sources);
+      addSourceToThreadUseCase.execute.mockRejectedValue(
+        new SourceAlreadyAssignedError(sourceId1),
+      );
+
+      const result = await service.activateOnThread(skillId, thread);
+
+      expect(result.instructions).toBe(
+        'Analyze the legal question thoroughly.',
+      );
+    });
+
+    it('should rethrow unexpected errors from addSourceToThread', async () => {
+      const thread = makeThread();
+      const skill = makeSkill({ mcpIntegrationIds: [] });
+      const sources = [makeSource(sourceId1)];
+
+      skillAccessService.findAccessibleSkill.mockResolvedValue(skill);
+      getSourcesByIdsUseCase.execute.mockResolvedValue(sources);
+      addSourceToThreadUseCase.execute.mockRejectedValue(
+        new Error('Database connection lost'),
+      );
+
+      await expect(service.activateOnThread(skillId, thread)).rejects.toThrow(
+        'Database connection lost',
+      );
+    });
+  });
+});

--- a/ayunis-core-backend/src/domain/skills/application/services/skill-activation.service.ts
+++ b/ayunis-core-backend/src/domain/skills/application/services/skill-activation.service.ts
@@ -1,0 +1,74 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { SkillAccessService } from 'src/domain/skills/application/services/skill-access.service';
+import { AddSourceToThreadUseCase } from 'src/domain/threads/application/use-cases/add-source-to-thread/add-source-to-thread.use-case';
+import { AddSourceCommand } from 'src/domain/threads/application/use-cases/add-source-to-thread/add-source.command';
+import { AddMcpIntegrationToThreadUseCase } from 'src/domain/threads/application/use-cases/add-mcp-integration-to-thread/add-mcp-integration-to-thread.use-case';
+import { AddMcpIntegrationToThreadCommand } from 'src/domain/threads/application/use-cases/add-mcp-integration-to-thread/add-mcp-integration-to-thread.command';
+import { GetSourcesByIdsUseCase } from 'src/domain/sources/application/use-cases/get-sources-by-ids/get-sources-by-ids.use-case';
+import { GetSourcesByIdsQuery } from 'src/domain/sources/application/use-cases/get-sources-by-ids/get-sources-by-ids.query';
+import { SourceAlreadyAssignedError } from 'src/domain/threads/application/threads.errors';
+import type { Thread } from 'src/domain/threads/domain/thread.entity';
+import type { UUID } from 'crypto';
+
+export interface SkillActivationResult {
+  instructions: string;
+  skillName: string;
+}
+
+@Injectable()
+export class SkillActivationService {
+  private readonly logger = new Logger(SkillActivationService.name);
+
+  constructor(
+    private readonly skillAccessService: SkillAccessService,
+    private readonly addSourceToThreadUseCase: AddSourceToThreadUseCase,
+    private readonly addMcpIntegrationToThreadUseCase: AddMcpIntegrationToThreadUseCase,
+    private readonly getSourcesByIdsUseCase: GetSourcesByIdsUseCase,
+  ) {}
+
+  /**
+   * Activates a skill on a thread by copying its sources and MCP integrations,
+   * and returns the skill's instructions for inclusion in the user message.
+   */
+  async activateOnThread(
+    skillId: UUID,
+    thread: Thread,
+  ): Promise<SkillActivationResult> {
+    this.logger.log('Activating skill on thread', {
+      skillId,
+      threadId: thread.id,
+    });
+
+    const skill = await this.skillAccessService.findAccessibleSkill(skillId);
+
+    // Copy skill's sources to the thread
+    const sources = await this.getSourcesByIdsUseCase.execute(
+      new GetSourcesByIdsQuery(skill.sourceIds),
+    );
+    for (const source of sources) {
+      try {
+        await this.addSourceToThreadUseCase.execute(
+          new AddSourceCommand(thread, source, skill.id),
+        );
+      } catch (error) {
+        if (error instanceof SourceAlreadyAssignedError) {
+          this.logger.log('Source already assigned to thread, skipping', {
+            sourceId: source.id,
+            threadId: thread.id,
+          });
+          continue;
+        }
+        throw error;
+      }
+    }
+
+    // Copy skill's MCP integrations to the thread
+    for (const mcpIntegrationId of skill.mcpIntegrationIds) {
+      await this.addMcpIntegrationToThreadUseCase.execute(
+        new AddMcpIntegrationToThreadCommand(thread.id, mcpIntegrationId),
+      );
+    }
+
+    return { instructions: skill.instructions, skillName: skill.name };
+  }
+}

--- a/ayunis-core-backend/src/domain/skills/skills.module.ts
+++ b/ayunis-core-backend/src/domain/skills/skills.module.ts
@@ -31,6 +31,7 @@ import { InstallSkillFromMarketplaceUseCase } from './application/use-cases/inst
 // Services
 import { MarketplaceSkillInstallationService } from './application/services/marketplace-skill-installation.service';
 import { SkillAccessService } from './application/services/skill-access.service';
+import { SkillActivationService } from './application/services/skill-activation.service';
 
 // Listeners
 import { ShareDeletedListener } from './application/listeners/share-deleted.listener';
@@ -47,6 +48,7 @@ import { SharesModule } from '../shares/shares.module';
 // IAM
 import { UsersModule } from 'src/iam/users/users.module';
 import { TeamsModule } from 'src/iam/teams/teams.module';
+import { ThreadsModule } from '../threads/threads.module';
 
 // Presenters
 import { SkillsController } from './presenters/http/skills.controller';
@@ -69,6 +71,7 @@ import { McpIntegrationDtoMapper } from '../mcp/presenters/http/mappers/mcp-inte
     forwardRef(() => SharesModule),
     UsersModule,
     TeamsModule,
+    forwardRef(() => ThreadsModule),
   ],
   providers: [
     {
@@ -77,6 +80,7 @@ import { McpIntegrationDtoMapper } from '../mcp/presenters/http/mappers/mcp-inte
     },
     // Services
     SkillAccessService,
+    SkillActivationService,
 
     // Use Cases
     CreateSkillUseCase,
@@ -124,6 +128,8 @@ import { McpIntegrationDtoMapper } from '../mcp/presenters/http/mappers/mcp-inte
     FindOneSkillUseCase,
     AddSourceToSkillUseCase,
     FindSkillByNameUseCase,
+    SkillAccessService,
+    SkillActivationService,
     SkillShareAuthorizationStrategy,
     getShareAuthStrategyToken(SharedEntityType.SKILL),
   ],

--- a/ayunis-core-backend/src/iam/invites/application/use-cases/create-invite/create-invite.use-case.ts
+++ b/ayunis-core-backend/src/iam/invites/application/use-cases/create-invite/create-invite.use-case.ts
@@ -120,10 +120,7 @@ export class CreateInviteUseCase {
     orgId: UUID,
     userId: UUID,
   ): Promise<void> {
-    const isCloud = this.configService.get<boolean>(
-      'app.isCloudHosted',
-      false,
-    );
+    const isCloud = this.configService.get<boolean>('app.isCloudHosted', false);
     if (!isCloud) {
       return;
     }

--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
@@ -2458,6 +2458,8 @@ export interface SendMessageDto {
   imageAltTexts?: string[];
   /** Tool result input (for tool_result type only) */
   toolResult?: ToolResultInput;
+  /** Skill ID to activate for this message — injects skill instructions and resources into the thread */
+  skillId?: string;
   /** Enable streaming mode for real-time response updates */
   streaming?: boolean;
 }
@@ -2963,6 +2965,8 @@ export type RunsControllerSendMessageBody = {
   imageAltTexts?: string;
   /** JSON object for tool result input */
   toolResult?: string;
+  /** Skill ID to activate for this message */
+  skillId?: string;
   streaming?: boolean;
 };
 

--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.ts
@@ -9785,6 +9785,9 @@ if(runsControllerSendMessageBody.imageAltTexts !== undefined) {
 if(runsControllerSendMessageBody.toolResult !== undefined) {
  formData.append(`toolResult`, runsControllerSendMessageBody.toolResult)
  }
+if(runsControllerSendMessageBody.skillId !== undefined) {
+ formData.append(`skillId`, runsControllerSendMessageBody.skillId)
+ }
 if(runsControllerSendMessageBody.streaming !== undefined) {
  formData.append(`streaming`, runsControllerSendMessageBody.streaming.toString())
  }

--- a/ayunis-core-frontend/src/shared/api/openapi-schema.json
+++ b/ayunis-core-frontend/src/shared/api/openapi-schema.json
@@ -5137,6 +5137,11 @@
                     "type": "string",
                     "description": "JSON object for tool result input"
                   },
+                  "skillId": {
+                    "type": "string",
+                    "format": "uuid",
+                    "description": "Skill ID to activate for this message"
+                  },
                   "streaming": {
                     "type": "boolean",
                     "default": true
@@ -10951,6 +10956,11 @@
                 "$ref": "#/components/schemas/ToolResultInput"
               }
             ]
+          },
+          "skillId": {
+            "type": "string",
+            "description": "Skill ID to activate for this message — injects skill instructions and resources into the thread",
+            "example": "550e8400-e29b-41d4-a716-446655440000"
           },
           "streaming": {
             "type": "boolean",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches run orchestration and thread mutation during skill activation, which can affect inference context and message creation if activation or refresh logic is wrong, but changes are scoped and covered by new unit tests.
> 
> **Overview**
> Adds *quick-action* skill activation to `POST /runs/send-message` via optional `skillId`, allowing a run to activate a skill even without user text/images and injecting the skill’s instructions into the created user message.
> 
> Introduces `SkillActivationService` to centralize activation (access-checked skill lookup, copying sources/MCP integrations onto the thread, and returning instructions), and refactors both `ExecuteRunUseCase` and `ActivateSkillToolHandler` to delegate to it; `ExecuteRunUseCase` also appends an `<already_activated_skill>` note into refreshed run instructions to prevent redundant `activate_skill` calls.
> 
> Hardens source assignment against duplicates by making `AddSourceToThreadUseCase` re-fetch the thread from the DB before checking/adding assignments, and updates backend/Swagger + generated frontend API clients to include the new `skillId` field.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9397a2eacc6f70781d711a8daee55f5d42e72e0b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->