### PR TITLE
wip(AYC-90): add pin toggle to skills list

### DIFF
--- a/ayunis-core-frontend/src/pages/skills/api/useToggleSkillPinned.ts
+++ b/ayunis-core-frontend/src/pages/skills/api/useToggleSkillPinned.ts
@@ -1,0 +1,46 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useTranslation } from 'react-i18next';
+import { showSuccess, showError } from '@/shared/lib/toast';
+import {
+  skillsControllerTogglePinned,
+  getSkillsControllerFindAllQueryKey,
+} from '@/shared/api/generated/ayunisCoreAPI';
+import { useRouter } from '@tanstack/react-router';
+import extractErrorData from '@/shared/api/extract-error-data';
+
+interface ToggleSkillPinnedParams {
+  id: string;
+}
+
+export function useToggleSkillPinned() {
+  const { t } = useTranslation('skills');
+  const queryClient = useQueryClient();
+  const router = useRouter();
+
+  return useMutation({
+    mutationFn: async ({ id }: ToggleSkillPinnedParams) => {
+      return await skillsControllerTogglePinned(id);
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
+        queryKey: getSkillsControllerFindAllQueryKey(),
+      });
+      void router.invalidate();
+      showSuccess(t('togglePinned.success'));
+    },
+    onError: (error) => {
+      console.error('Toggle skill pinned failed:', error);
+      try {
+        const { code } = extractErrorData(error);
+        if (code === 'SKILL_NOT_FOUND') {
+          showError(t('togglePinned.notFound'));
+        } else {
+          showError(t('togglePinned.error'));
+        }
+      } catch {
+        // Non-AxiosError (network failure, request cancellation, etc.)
+        showError(t('togglePinned.error'));
+      }
+    },
+  });
+}

--- a/ayunis-core-frontend/src/pages/skills/ui/SkillCard.tsx
+++ b/ayunis-core-frontend/src/pages/skills/ui/SkillCard.tsx
@@ -1,9 +1,10 @@
 import { Button } from '@/shared/ui/shadcn/button';
 import { Badge } from '@/shared/ui/shadcn/badge';
 import { Switch } from '@/shared/ui/shadcn/switch';
-import { Trash2 } from 'lucide-react';
+import { Trash2, Pin } from 'lucide-react';
 import { useDeleteSkill } from '../api/useDeleteSkill';
 import { useToggleSkillActive } from '../api/useToggleSkillActive';
+import { useToggleSkillPinned } from '../api/useToggleSkillPinned';
 import { useConfirmation } from '@/widgets/confirmation-modal';
 import { useTranslation } from 'react-i18next';
 import type { Skill } from '../model/openapi';
@@ -24,6 +25,7 @@ export default function SkillCard({ skill }: Readonly<SkillCardProps>) {
   const { t } = useTranslation('skills');
   const deleteSkill = useDeleteSkill();
   const toggleActive = useToggleSkillActive();
+  const togglePinned = useToggleSkillPinned();
   const { confirm } = useConfirmation();
   const router = useRouter();
 
@@ -42,6 +44,10 @@ export default function SkillCard({ skill }: Readonly<SkillCardProps>) {
 
   function handleToggleActive() {
     toggleActive.mutate({ id: skill.id });
+  }
+
+  function handleTogglePinned() {
+    togglePinned.mutate({ id: skill.id });
   }
 
   function handleNavigateToDetail() {
@@ -83,6 +89,22 @@ export default function SkillCard({ skill }: Readonly<SkillCardProps>) {
             onClick={(e) => e.stopPropagation()}
           />
         </div>
+        {skill.isActive && (
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={(e) => {
+              e.stopPropagation();
+              handleTogglePinned();
+            }}
+            disabled={togglePinned.isPending}
+            title={skill.isPinned ? t('card.unpinLabel') : t('card.pinLabel')}
+          >
+            <Pin
+              className={`h-4 w-4 ${skill.isPinned ? 'fill-current' : ''}`}
+            />
+          </Button>
+        )}
         {!skill.isShared && (
           <Button
             variant="ghost"

--- a/ayunis-core-frontend/src/shared/locales/de/skills.json
+++ b/ayunis-core-frontend/src/shared/locales/de/skills.json
@@ -16,6 +16,8 @@
   "card": {
     "activeLabel": "Aktiv",
     "inactiveLabel": "Inaktiv",
+    "pinLabel": "An neuen Chat anheften",
+    "unpinLabel": "Von neuem Chat lösen",
     "confirmDelete": {
       "title": "Fähigkeit löschen",
       "description": "Sind Sie sicher, dass Sie \"{{title}}\" löschen möchten? Diese Aktion kann nicht rückgängig gemacht werden.",
@@ -54,6 +56,11 @@
   "toggleActive": {
     "success": "Fähigkeits-Status erfolgreich aktualisiert!",
     "error": "Fähigkeits-Status konnte nicht aktualisiert werden. Bitte versuchen Sie es erneut.",
+    "notFound": "Fähigkeit nicht gefunden. Sie wurde möglicherweise gelöscht."
+  },
+  "togglePinned": {
+    "success": "Anheft-Status erfolgreich aktualisiert!",
+    "error": "Anheft-Status konnte nicht aktualisiert werden. Bitte versuchen Sie es erneut.",
     "notFound": "Fähigkeit nicht gefunden. Sie wurde möglicherweise gelöscht."
   },
   "delete": {

--- a/ayunis-core-frontend/src/shared/locales/en/skills.json
+++ b/ayunis-core-frontend/src/shared/locales/en/skills.json
@@ -16,6 +16,8 @@
   "card": {
     "activeLabel": "Active",
     "inactiveLabel": "Inactive",
+    "pinLabel": "Pin to new chat",
+    "unpinLabel": "Unpin from new chat",
     "confirmDelete": {
       "title": "Delete Skill",
       "description": "Are you sure you want to delete \"{{title}}\"? This action cannot be undone.",
@@ -54,6 +56,11 @@
   "toggleActive": {
     "success": "Skill status updated successfully!",
     "error": "Failed to update skill status. Please try again.",
+    "notFound": "Skill not found. It may have been deleted."
+  },
+  "togglePinned": {
+    "success": "Skill pin status updated successfully!",
+    "error": "Failed to update skill pin status. Please try again.",
     "notFound": "Skill not found. It may have been deleted."
   },
   "delete": {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small, UI-scoped change that adds a new mutation and cache invalidation; main risk is incorrect query invalidation or inconsistent pinned state display.
> 
> **Overview**
> Adds a *pin/unpin* action to the skills list. `SkillCard` now shows a pin icon (only for active skills) that toggles `skill.isPinned` without navigating, and disables while the mutation is pending.
> 
> Introduces `useToggleSkillPinned`, which calls `skillsControllerTogglePinned`, invalidates the skills list query (and router) on success, and shows localized success/error toasts (including a `SKILL_NOT_FOUND` case). Updates `skills.json` (EN/DE) with new pin/unpin labels and toast messages.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f26eb79d6f36a6fcca714add3b4b8410180fecae. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->