### PR TITLE
fix(AYC-90): fix infinite retry loop, stale pendingSkillId, and skill name desync

### DIFF
--- a/ayunis-core-frontend/src/pages/chat/api/useMessageSend.ts
+++ b/ayunis-core-frontend/src/pages/chat/api/useMessageSend.ts
@@ -22,6 +22,7 @@ export interface PendingImage {
 export interface SendMessageInput {
   text: string;
   images?: PendingImage[];
+  skillId?: string;
 }
 
 interface SendToolResultInput {
@@ -46,6 +47,7 @@ interface SendMessagePayload {
   images?: File[];
   imageAltTexts?: string[];
   toolResult?: SendToolResultInput;
+  skillId?: string;
   streaming?: boolean;
 }
 
@@ -95,6 +97,10 @@ export function useMessageSend(params: UseMessageSendParams) {
 
         if (payload.toolResult) {
           formData.append('toolResult', JSON.stringify(payload.toolResult));
+        }
+
+        if (payload.skillId) {
+          formData.append('skillId', payload.skillId);
         }
 
         if (payload.streaming !== undefined) {
@@ -254,6 +260,10 @@ export function useMessageSend(params: UseMessageSendParams) {
       if (input.images && input.images.length > 0) {
         payload.images = input.images.map((img) => img.file);
         payload.imageAltTexts = input.images.map((img) => img.altText ?? '');
+      }
+
+      if (input.skillId) {
+        payload.skillId = input.skillId;
       }
 
       return sendMessage(payload);

--- a/ayunis-core-frontend/src/pages/chat/ui/ChatMessage.tsx
+++ b/ayunis-core-frontend/src/pages/chat/ui/ChatMessage.tsx
@@ -29,6 +29,7 @@ import ExecutableToolWidget from './chat-widgets/ExecutableToolWidget';
 import ThinkingBlockWidget from './chat-widgets/ThinkingBlockWidget';
 import CreateCalendarEventWidget from './chat-widgets/CreateCalendarEventWidget';
 import CreateSkillWidget from './chat-widgets/CreateSkillWidget';
+import SkillInstructionWidget from './chat-widgets/SkillInstructionWidget';
 import {
   BarChartWidget,
   LineChartWidget,
@@ -222,11 +223,18 @@ function renderMessageContent(message: Message, isStreaming?: boolean) {
             </div>
           )}
 
-          {texts.map((textContent, index) => (
-            <Markdown key={`text-${index}-${textContent.text.slice(0, 50)}`}>
-              {textContent.text}
-            </Markdown>
-          ))}
+          {texts.map((textContent, index) =>
+            textContent.isSkillInstruction ? (
+              <SkillInstructionWidget
+                key={`skill-instruction-${index}-${textContent.text.slice(0, 50)}`}
+                content={textContent}
+              />
+            ) : (
+              <Markdown key={`text-${index}-${textContent.text.slice(0, 50)}`}>
+                {textContent.text}
+              </Markdown>
+            ),
+          )}
         </>
       );
     }

--- a/ayunis-core-frontend/src/pages/chat/ui/ChatPage.tsx
+++ b/ayunis-core-frontend/src/pages/chat/ui/ChatPage.tsx
@@ -366,6 +366,7 @@ export default function ChatPage({
             images: buildPendingImages(),
             skillId: pendingSkillId || undefined,
           });
+          setPendingSkillId('');
         } catch (error) {
           if (error instanceof AxiosError && error.response?.status === 403) {
             showError(t('chat.upgradeToProError'));
@@ -377,7 +378,6 @@ export default function ChatPage({
           setIsProcessingPendingSources(false);
           setPendingMessage('');
           setPendingImages([]);
-          setPendingSkillId('');
         }
       }
     }

--- a/ayunis-core-frontend/src/pages/chat/ui/chat-widgets/SkillInstructionWidget.tsx
+++ b/ayunis-core-frontend/src/pages/chat/ui/chat-widgets/SkillInstructionWidget.tsx
@@ -1,0 +1,26 @@
+import { useTranslation } from 'react-i18next';
+import AgentActivityHint from '@/widgets/agent-activity-hint/ui/AgentActivityHint';
+import { Sparkles } from 'lucide-react';
+import { useState } from 'react';
+import type { TextMessageContentResponseDto } from '@/shared/api/generated/ayunisCoreAPI.schemas';
+
+interface SkillInstructionWidgetProps {
+  content: TextMessageContentResponseDto;
+}
+
+export default function SkillInstructionWidget({
+  content,
+}: Readonly<SkillInstructionWidgetProps>) {
+  const { t } = useTranslation('chat');
+  const [open, setOpen] = useState(false);
+
+  return (
+    <AgentActivityHint
+      open={open}
+      onOpenChange={setOpen}
+      icon={<Sparkles className="h-4 w-4" />}
+      hint={t('chat.skillInstructions')}
+      input={content.text}
+    />
+  );
+}

--- a/ayunis-core-frontend/src/pages/new-chat/api/useInitiateChat.tsx
+++ b/ayunis-core-frontend/src/pages/new-chat/api/useInitiateChat.tsx
@@ -7,7 +7,7 @@ import type { SourceResponseDtoType } from '@/shared/api';
 import { useQueryClient } from '@tanstack/react-query';
 
 export const useInitiateChat = () => {
-  const { setPendingMessage, setSources } = useChatContext();
+  const { setPendingMessage, setPendingSkillId, setSources } = useChatContext();
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const createThreadMutation = useThreadsControllerCreate({
@@ -24,8 +24,9 @@ export const useInitiateChat = () => {
       },
       onError: (error) => {
         console.error('Failed to create thread:', error);
-        // Clear pending message on error
+        // Clear pending message and skill on error
         setPendingMessage('');
+        setPendingSkillId('');
       },
     },
   });

--- a/ayunis-core-frontend/src/pages/new-chat/api/useInitiateChat.tsx
+++ b/ayunis-core-frontend/src/pages/new-chat/api/useInitiateChat.tsx
@@ -6,7 +6,7 @@ import type { CreateThreadData } from '../model/openapi';
 import type { SourceResponseDtoType } from '@/shared/api';
 import { useQueryClient } from '@tanstack/react-query';
 
-export const useInitiateChat = () => {
+export const useInitiateChat = (options?: { onSuccess?: () => void }) => {
   const { setPendingMessage, setPendingSkillId, setSources } = useChatContext();
   const navigate = useNavigate();
   const queryClient = useQueryClient();
@@ -16,6 +16,7 @@ export const useInitiateChat = () => {
         void queryClient.invalidateQueries({
           queryKey: getThreadsControllerFindAllQueryKey(),
         });
+        options?.onSuccess?.();
         // Navigate to the new thread
         void navigate({
           to: '/chats/$threadId',

--- a/ayunis-core-frontend/src/pages/new-chat/ui/NewChatPage.tsx
+++ b/ayunis-core-frontend/src/pages/new-chat/ui/NewChatPage.tsx
@@ -30,7 +30,12 @@ export default function NewChatPage({
   agents,
 }: Readonly<NewChatPageProps>) {
   const { t } = useTranslation('chat');
-  const { initiateChat } = useInitiateChat();
+  const [selectedSkillId, setSelectedSkillId] = useState<string | undefined>(
+    undefined,
+  );
+  const { initiateChat } = useInitiateChat({
+    onSuccess: () => setSelectedSkillId(undefined),
+  });
   const { models } = usePermittedModels();
   const chatInputRef = useRef<ChatInputRef>(null);
   const greeting = useTimeBasedGreeting();
@@ -39,9 +44,6 @@ export default function NewChatPage({
   const [agentId, setAgentId] = useState(selectedAgentId);
   const [isAnonymous, setIsAnonymous] = useState(false);
   const { data: skills } = useSkillsControllerFindAll();
-  const [selectedSkillId, setSelectedSkillId] = useState<string | undefined>(
-    undefined,
-  );
   const selectedSkillName = useMemo(
     () => skills?.find((s) => s.id === selectedSkillId)?.name,
     [skills, selectedSkillId],
@@ -124,7 +126,6 @@ export default function NewChatPage({
     }
 
     initiateChat(message, modelId, agentId, sources, isAnonymous);
-    setSelectedSkillId(undefined);
   }
 
   return (

--- a/ayunis-core-frontend/src/pages/new-chat/ui/NewChatPage.tsx
+++ b/ayunis-core-frontend/src/pages/new-chat/ui/NewChatPage.tsx
@@ -13,6 +13,7 @@ import { SourceResponseDtoType } from '@/shared/api/generated/ayunisCoreAPI.sche
 import { usePermittedModels } from '@/features/usePermittedModels';
 import { useTimeBasedGreeting } from '../model/useTimeBasedGreeting';
 import { useChatContext } from '@/shared/contexts/chat/useChatContext';
+import { keepPreviousData } from '@tanstack/react-query';
 
 interface NewChatPageProps {
   prefilledPrompt?: string;
@@ -43,7 +44,9 @@ export default function NewChatPage({
   const [modelId, setModelId] = useState(selectedModelId);
   const [agentId, setAgentId] = useState(selectedAgentId);
   const [isAnonymous, setIsAnonymous] = useState(false);
-  const { data: skills } = useSkillsControllerFindAll();
+  const { data: skills } = useSkillsControllerFindAll({
+    query: { placeholderData: keepPreviousData },
+  });
   const selectedSkillName = useMemo(
     () => skills?.find((s) => s.id === selectedSkillId)?.name,
     [skills, selectedSkillId],

--- a/ayunis-core-frontend/src/shared/contexts/chat/ChatContextProvider.tsx
+++ b/ayunis-core-frontend/src/shared/contexts/chat/ChatContextProvider.tsx
@@ -22,6 +22,7 @@ export const ChatContextProvider = ({
     }>
   >([]);
   const [pendingImages, setPendingImages] = useState<PendingImageFile[]>([]);
+  const [pendingSkillId, setPendingSkillId] = useState('');
 
   // Memoize the context value to prevent unnecessary re-renders
   const contextValue = useMemo(
@@ -32,8 +33,10 @@ export const ChatContextProvider = ({
       setSources,
       pendingImages,
       setPendingImages,
+      pendingSkillId,
+      setPendingSkillId,
     }),
-    [pendingMessage, sources, pendingImages],
+    [pendingMessage, sources, pendingImages, pendingSkillId],
   );
 
   return (

--- a/ayunis-core-frontend/src/shared/contexts/chat/chatContext.ts
+++ b/ayunis-core-frontend/src/shared/contexts/chat/chatContext.ts
@@ -25,6 +25,8 @@ type ChatContextType = {
   ) => void;
   pendingImages: PendingImageFile[];
   setPendingImages: (images: PendingImageFile[]) => void;
+  pendingSkillId: string;
+  setPendingSkillId: (id: string) => void;
 };
 
 export const ChatContext = createContext<ChatContextType>({
@@ -39,5 +41,9 @@ export const ChatContext = createContext<ChatContextType>({
   pendingImages: [],
   setPendingImages: () => {
     throw new Error('setPendingImages is not implemented');
+  },
+  pendingSkillId: '',
+  setPendingSkillId: () => {
+    throw new Error('setPendingSkillId is not implemented');
   },
 });

--- a/ayunis-core-frontend/src/shared/locales/de/chat.json
+++ b/ayunis-core-frontend/src/shared/locales/de/chat.json
@@ -26,6 +26,7 @@
     "errorUpdateAgent": "Agent konnte nicht aktualisiert werden",
     "errorRemoveAgent": "Agent konnte nicht entfernt werden",
     "thinking": "Nachdenken",
+    "skillInstructions": "Skill-Anweisungen",
     "copyToClipboard": "In die Zwischenablage kopieren",
     "tools": {
       "internet_search": "Im Internet suchen",

--- a/ayunis-core-frontend/src/shared/locales/en/chat.json
+++ b/ayunis-core-frontend/src/shared/locales/en/chat.json
@@ -26,6 +26,7 @@
     "errorUpdateAgent": "Agent could not be updated",
     "errorRemoveAgent": "Agent could not be removed",
     "thinking": "Thinking",
+    "skillInstructions": "Skill instructions",
     "copyToClipboard": "Copy to clipboard",
     "tools": {
       "internet_search": "Search the internet",

--- a/ayunis-core-frontend/src/widgets/chat-input/ui/SkillBadge.tsx
+++ b/ayunis-core-frontend/src/widgets/chat-input/ui/SkillBadge.tsx
@@ -1,0 +1,21 @@
+import { Sparkles, XIcon } from 'lucide-react';
+import { Badge } from '@/shared/ui/shadcn/badge';
+
+interface SkillBadgeProps {
+  skillName: string;
+  onRemove: () => void;
+}
+
+export function SkillBadge({ skillName, onRemove }: Readonly<SkillBadgeProps>) {
+  return (
+    <Badge
+      variant="outline"
+      className="flex items-center gap-1 rounded-full border-none"
+      onClick={() => onRemove()}
+    >
+      <Sparkles className="h-3 w-3" />
+      {skillName}
+      <XIcon className="h-3 w-3 cursor-pointer" />
+    </Badge>
+  );
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches the chat send pipeline and pending-message deduping/state reset logic, so regressions could cause missing/duplicated first messages or incorrect skill activation, though changes are frontend-scoped.
> 
> **Overview**
> Adds end-to-end *skill selection support* for the first message of a newly created thread by storing `pendingSkillId` in chat context, passing it through `ChatInput`/`NewChatPage`, and including `skillId` in the multipart `/runs/send-message` request.
> 
> Refactors the “send pending message after thread creation” effect in `ChatPage` to avoid duplicate sends via a `pendingMessage::pendingSkillId` dedupe key, resets stale `pendingSkillId` after send/error, and factors source/image preprocessing into memoized helpers.
> 
> Improves UX around skills by showing a removable `SkillBadge` in the input (with skill name kept in sync via `useSkillsControllerFindAll`) and rendering `isSkillInstruction` user text blocks via a new `SkillInstructionWidget`, plus adds i18n strings for the skill-instructions label.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6f45591c21f6a4c68c68e087fe6250d76a903398. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->