### PR TITLE
perf(AYC-000): optimize backend test performance in CI

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -12,8 +12,39 @@ on:
       - 'ayunis-core-backend/**'
 
 jobs:
+  lint-and-typecheck:
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: ayunis-core-backend
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: ayunis-core-backend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run TypeScript type check
+        run: npx tsc --noEmit
+
+      - name: Run linter
+        run: npm run lint
+
   test:
     runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3]
 
     # Service containers to run with this job
     services:
@@ -102,29 +133,12 @@ jobs:
           DISABLE_EMAIL_CONFIRMATION=true
           EOF
 
-      - name: Build application
-        run: npm run build
-
       - name: Run migrations
         run: npm run typeorm migration:run -- -d src/db/datasource.ts
         env:
           NODE_ENV: test
 
-      - name: Run TypeScript type check
-        run: npx tsc --noEmit
-
-      - name: Run linter
-        run: npm run lint
-
-      - name: Run unit tests
-        run: npm run test:cov
+      - name: Run unit tests (shard ${{ matrix.shard }}/3)
+        run: npx jest --shard=${{ matrix.shard }}/3
         env:
           NODE_ENV: test
-
-      - name: Upload coverage reports
-        if: always()
-        uses: actions/upload-artifact@v6
-        with:
-          name: coverage-reports
-          path: ayunis-core-backend/coverage/
-          retention-days: 7

--- a/ayunis-core-backend/package-lock.json
+++ b/ayunis-core-backend/package-lock.json
@@ -68,6 +68,7 @@
         "@nestjs/testing": "^11.0.1",
         "@swc/cli": "^0.6.0",
         "@swc/core": "^1.10.7",
+        "@swc/jest": "^0.2.39",
         "@types/bcrypt": "^5.0.2",
         "@types/cookie-parser": "^1.4.8",
         "@types/express": "^5.0.0",
@@ -3206,6 +3207,19 @@
         "node-notifier": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@jest/create-cache-key-function": {
+      "version": "30.2.0",
+      "resolved": "https://registry.npmjs.org/@jest/create-cache-key-function/-/create-cache-key-function-30.2.0.tgz",
+      "integrity": "sha512-44F4l4Enf+MirJN8X/NhdGkl71k5rBYiwdVlo4HxOwbu0sHV8QKrGEedb1VUU4K3W7fBKE0HGfbn7eZm0Ti3zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.2.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/@jest/diff-sequences": {
@@ -7309,6 +7323,24 @@
       "version": "0.1.3",
       "devOptional": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/@swc/jest": {
+      "version": "0.2.39",
+      "resolved": "https://registry.npmjs.org/@swc/jest/-/jest-0.2.39.tgz",
+      "integrity": "sha512-eyokjOwYd0Q8RnMHri+8/FS1HIrIUKK/sRrFp8c1dThUOfNeCWbLmBP1P5VsKdvmkd25JaH+OKYwEYiAYg9YAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/create-cache-key-function": "^30.0.0",
+        "@swc/counter": "^0.1.3",
+        "jsonc-parser": "^3.2.0"
+      },
+      "engines": {
+        "npm": ">= 7.0.0"
+      },
+      "peerDependencies": {
+        "@swc/core": "*"
+      }
     },
     "node_modules/@swc/types": {
       "version": "0.1.21",

--- a/ayunis-core-backend/package.json
+++ b/ayunis-core-backend/package.json
@@ -101,6 +101,7 @@
     "@nestjs/testing": "^11.0.1",
     "@swc/cli": "^0.6.0",
     "@swc/core": "^1.10.7",
+    "@swc/jest": "^0.2.39",
     "@types/bcrypt": "^5.0.2",
     "@types/cookie-parser": "^1.4.8",
     "@types/express": "^5.0.0",
@@ -141,10 +142,24 @@
     "rootDir": "src",
     "testRegex": ".*\\.spec\\.ts$",
     "transform": {
-      "^.+\\.ts$": "ts-jest"
+      "^.+\\.ts$": [
+        "ts-jest",
+        {
+          "isolatedModules": true
+        }
+      ]
     },
     "collectCoverageFrom": [
-      "**/*.(t|j)s"
+      "**/*.(t|j)s",
+      "!**/*.spec.ts",
+      "!**/*.d.ts",
+      "!**/migrations/**",
+      "!**/db/datasource.ts",
+      "!**/main.ts",
+      "!**/*.module.ts",
+      "!**/*.record.ts",
+      "!**/index.ts",
+      "!**/cli/**"
     ],
     "coverageDirectory": "../coverage",
     "testEnvironment": "node",

--- a/ayunis-core-backend/src/app/application/use-cases/is-cloud/is-cloud.use-case.spec.ts
+++ b/ayunis-core-backend/src/app/application/use-cases/is-cloud/is-cloud.use-case.spec.ts
@@ -7,7 +7,7 @@ describe('IsCloudUseCase', () => {
   let useCase: IsCloudUseCase;
   let configService: jest.Mocked<ConfigService>;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     const mockConfigService = {
       get: jest.fn(),
     };
@@ -21,6 +21,9 @@ describe('IsCloudUseCase', () => {
 
     useCase = module.get<IsCloudUseCase>(IsCloudUseCase);
     configService = module.get(ConfigService);
+  });
+  beforeEach(() => {
+    jest.clearAllMocks();
   });
 
   describe('execute', () => {

--- a/ayunis-core-backend/src/domain/agents/application/strategies/agent-share-authorization.strategy.spec.ts
+++ b/ayunis-core-backend/src/domain/agents/application/strategies/agent-share-authorization.strategy.spec.ts
@@ -9,7 +9,7 @@ describe('AgentShareAuthorizationStrategy', () => {
   let strategy: AgentShareAuthorizationStrategy;
   let agentRepository: jest.Mocked<AgentRepository>;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     const mockAgentRepository = {
       create: jest.fn(),
       delete: jest.fn(),
@@ -35,6 +35,9 @@ describe('AgentShareAuthorizationStrategy', () => {
       AgentShareAuthorizationStrategy,
     );
     agentRepository = module.get(AgentRepository);
+  });
+  beforeEach(() => {
+    jest.clearAllMocks();
   });
 
   describe('canViewShares', () => {

--- a/ayunis-core-backend/src/domain/agents/application/use-cases/add-source-to-agent/add-source-to-agent.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/agents/application/use-cases/add-source-to-agent/add-source-to-agent.use-case.spec.ts
@@ -45,7 +45,7 @@ describe('AddSourceToAgentUseCase', () => {
   let logSpy: jest.SpyInstance;
   let errorSpy: jest.SpyInstance;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     const mockAgentRepository = {
       findOne: jest.fn(),
       update: jest.fn(),

--- a/ayunis-core-backend/src/domain/agents/application/use-cases/delete-agent/delete-agent.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/agents/application/use-cases/delete-agent/delete-agent.use-case.spec.ts
@@ -28,7 +28,7 @@ describe('DeleteAgentUseCase', () => {
   const userId = randomUUID();
   const orgId = randomUUID();
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     mockAgentRepository = {
       create: jest.fn(),
       findOne: jest.fn(),
@@ -54,6 +54,14 @@ describe('DeleteAgentUseCase', () => {
     }).compile();
 
     useCase = module.get<DeleteAgentUseCase>(DeleteAgentUseCase);
+  });
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockContextService.get.mockImplementation((key: string) => {
+      if (key === 'userId') return userId;
+      if (key === 'orgId') return orgId;
+      return undefined;
+    });
   });
 
   it('should be defined', () => {

--- a/ayunis-core-backend/src/domain/agents/application/use-cases/unassign-mcp-integration-from-agent/unassign-mcp-integration-from-agent.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/agents/application/use-cases/unassign-mcp-integration-from-agent/unassign-mcp-integration-from-agent.use-case.spec.ts
@@ -36,7 +36,7 @@ describe('UnassignMcpIntegrationFromAgentUseCase', () => {
   const mockIntegrationId1 = randomUUID();
   const mockIntegrationId2 = randomUUID();
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     const mockAgentRepository = {
       create: jest.fn(),
       findOne: jest.fn(),

--- a/ayunis-core-backend/src/domain/agents/infrastructure/persistence/local/mappers/agent.mapper.spec.ts
+++ b/ayunis-core-backend/src/domain/agents/infrastructure/persistence/local/mappers/agent.mapper.spec.ts
@@ -37,7 +37,7 @@ describe('AgentMapper', () => {
       }),
     });
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     const mockPermittedModelMapper = {
       toDomain: jest.fn(),
       toRecord: jest.fn(),

--- a/ayunis-core-backend/src/domain/mcp/application/registries/predefined-mcp-integration-registry.service.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/registries/predefined-mcp-integration-registry.service.spec.ts
@@ -11,14 +11,14 @@ describe('PredefinedMcpIntegrationRegistryService', () => {
   let configService: ConfigService;
 
   describe('with Locaboo 4 URL configured', () => {
-    beforeEach(async () => {
+    beforeAll(async () => {
       const module: TestingModule = await Test.createTestingModule({
         providers: [
           PredefinedMcpIntegrationRegistry,
           {
             provide: ConfigService,
             useValue: {
-              get: jest.fn((key: string) => {
+              get: jest.fn((key: string): unknown => {
                 if (key === 'mcp.locaboo4Url') {
                   return 'https://api.locaboo.example.com';
                 }
@@ -186,9 +186,12 @@ describe('PredefinedMcpIntegrationRegistryService', () => {
       });
     });
   });
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
 
   describe('without Locaboo 4 URL configured', () => {
-    beforeEach(async () => {
+    beforeAll(async () => {
       const module: TestingModule = await Test.createTestingModule({
         providers: [
           PredefinedMcpIntegrationRegistry,

--- a/ayunis-core-backend/src/domain/mcp/application/services/mcp-client.service.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/services/mcp-client.service.spec.ts
@@ -45,7 +45,7 @@ describe('McpClientService', () => {
     connectionStatus: 'pending',
   } as const;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     client = new MockMcpClientPort();
     encryption = new MockCredentialEncryptionPort();
 
@@ -59,6 +59,9 @@ describe('McpClientService', () => {
 
     module.useLogger(false);
     service = module.get(McpClientService);
+  });
+  beforeEach(() => {
+    jest.clearAllMocks();
   });
 
   describe('buildConnectionConfig', () => {

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/delete-mcp-integration/delete-mcp-integration.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/delete-mcp-integration/delete-mcp-integration.use-case.spec.ts
@@ -45,7 +45,7 @@ describe('DeleteMcpIntegrationUseCase', () => {
       updatedAt: overrides.updatedAt,
     });
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         DeleteMcpIntegrationUseCase,

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/disable-mcp-integration/disable-mcp-integration.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/disable-mcp-integration/disable-mcp-integration.use-case.spec.ts
@@ -25,7 +25,7 @@ describe('DisableMcpIntegrationUseCase', () => {
   const mockOrgId = 'org-123' as UUID;
   const mockIntegrationId = 'integration-456' as UUID;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         DisableMcpIntegrationUseCase,

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/discover-mcp-capabilities/discover-mcp-capabilities.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/discover-mcp-capabilities/discover-mcp-capabilities.use-case.spec.ts
@@ -72,7 +72,7 @@ describe('DiscoverMcpCapabilitiesUseCase', () => {
       updatedAt: overrides.updatedAt,
     });
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         DiscoverMcpCapabilitiesUseCase,

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/enable-mcp-integration/enable-mcp-integration.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/enable-mcp-integration/enable-mcp-integration.use-case.spec.ts
@@ -27,7 +27,7 @@ describe('EnableMcpIntegrationUseCase', () => {
   const mockOrgId = 'org-123' as UUID;
   const mockIntegrationId = 'integration-456' as UUID;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         EnableMcpIntegrationUseCase,

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/execute-mcp-tool/execute-mcp-tool.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/execute-mcp-tool/execute-mcp-tool.use-case.spec.ts
@@ -57,7 +57,7 @@ describe('ExecuteMcpToolUseCase', () => {
   let loggerWarnSpy: jest.SpyInstance;
   let loggerErrorSpy: jest.SpyInstance;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     repository = {
       findById: jest.fn(),
       save: jest.fn(),

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/get-mcp-integration/get-mcp-integration.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/get-mcp-integration/get-mcp-integration.use-case.spec.ts
@@ -25,7 +25,7 @@ describe('GetMcpIntegrationUseCase', () => {
   const mockOrgId = 'org-123' as UUID;
   const mockIntegrationId = 'integration-456' as UUID;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         GetMcpIntegrationUseCase,

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/get-mcp-prompt/get-mcp-prompt.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/get-mcp-prompt/get-mcp-prompt.use-case.spec.ts
@@ -36,7 +36,7 @@ describe('GetMcpPromptUseCase', () => {
   const mockIntegrationId = 'integration-456' as UUID;
   const mockPromptName = 'test-prompt';
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         GetMcpPromptUseCase,
@@ -164,7 +164,7 @@ describe('GetMcpPromptUseCase', () => {
         id: mockIntegrationId,
         name: 'Custom Integration',
         orgId: mockOrgId,
-        serverUrl: 'http://custom-server.com/mcp',
+        serverUrl: 'https://custom-server.example.com/mcp',
         auth: new NoAuthMcpIntegrationAuth(),
         enabled: true,
         createdAt: new Date(),
@@ -204,7 +204,7 @@ describe('GetMcpPromptUseCase', () => {
         id: mockIntegrationId,
         name: 'Custom Integration',
         orgId: mockOrgId,
-        serverUrl: 'http://custom-server.com/mcp',
+        serverUrl: 'https://custom-server.example.com/mcp',
         auth: new BearerMcpIntegrationAuth({
           authToken: 'encrypted-token-123',
         }),

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/list-org-mcp-integrations/list-org-mcp-integrations.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/list-org-mcp-integrations/list-org-mcp-integrations.use-case.spec.ts
@@ -25,7 +25,7 @@ describe('ListOrgMcpIntegrationsUseCase', () => {
   const mockIntegrationId1 = randomUUID();
   const mockIntegrationId2 = randomUUID();
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     const mockRepository = {
       save: jest.fn(),
       findById: jest.fn(),
@@ -65,6 +65,13 @@ describe('ListOrgMcpIntegrationsUseCase', () => {
 
   afterEach(() => {
     jest.clearAllMocks();
+  });
+
+  beforeEach(() => {
+    (contextService.get as jest.Mock).mockImplementation((key?: string) => {
+      if (key === 'orgId') return mockOrgId;
+      return undefined;
+    });
   });
 
   describe('execute', () => {

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/list-predefined-mcp-integration-configs/list-predefined-mcp-integration-configs.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/list-predefined-mcp-integration-configs/list-predefined-mcp-integration-configs.use-case.spec.ts
@@ -14,7 +14,7 @@ describe('ListPredefinedMcpIntegrationConfigsUseCase', () => {
   let loggerLogSpy: jest.SpyInstance;
   let loggerErrorSpy: jest.SpyInstance;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         ListPredefinedMcpIntegrationConfigsUseCase,
@@ -121,7 +121,7 @@ describe('ListPredefinedMcpIntegrationConfigsUseCase', () => {
         Reflect.getMetadata(
           'design:paramtypes',
           ListPredefinedMcpIntegrationConfigsUseCase,
-        ) || [];
+        ) ?? [];
 
       // Should only have PredefinedMcpIntegrationRegistryService
       expect(constructorParams.length).toBe(1);

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/retrieve-mcp-resource/retrieve-mcp-resource.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/retrieve-mcp-resource/retrieve-mcp-resource.use-case.spec.ts
@@ -51,7 +51,7 @@ describe('RetrieveMcpResourceUseCase', () => {
       updatedAt: overrides.updatedAt,
     });
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         RetrieveMcpResourceUseCase,

--- a/ayunis-core-backend/src/domain/mcp/infrastructure/encryption/mcp-credential-encryption.service.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/infrastructure/encryption/mcp-credential-encryption.service.spec.ts
@@ -10,7 +10,7 @@ describe('McpCredentialEncryptionService', () => {
   const mockEncryptionKey =
     'abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789'; // 64 hex chars = 32 bytes
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         McpCredentialEncryptionService,
@@ -32,6 +32,9 @@ describe('McpCredentialEncryptionService', () => {
       McpCredentialEncryptionService,
     );
     configService = module.get<ConfigService>(ConfigService);
+  });
+  beforeEach(() => {
+    jest.clearAllMocks();
   });
 
   it('should be defined', () => {
@@ -59,8 +62,9 @@ describe('McpCredentialEncryptionService', () => {
     it('should throw error when encryption key is missing', async () => {
       jest.spyOn(configService, 'get').mockReturnValue(undefined);
 
-      // Re-instantiate service to trigger constructor error
+      // Re-instantiate service to trigger constructor validation
       expect(() => {
+        // eslint-disable-next-line sonarjs/constructor-for-side-effects
         new McpCredentialEncryptionService(configService);
       }).toThrow('MCP_ENCRYPTION_KEY environment variable is not configured');
     });
@@ -69,6 +73,7 @@ describe('McpCredentialEncryptionService', () => {
       jest.spyOn(configService, 'get').mockReturnValue('');
 
       expect(() => {
+        // eslint-disable-next-line sonarjs/constructor-for-side-effects
         new McpCredentialEncryptionService(configService);
       }).toThrow('MCP_ENCRYPTION_KEY environment variable is not configured');
     });
@@ -77,6 +82,7 @@ describe('McpCredentialEncryptionService', () => {
       jest.spyOn(configService, 'get').mockReturnValue('tooshort');
 
       expect(() => {
+        // eslint-disable-next-line sonarjs/constructor-for-side-effects
         new McpCredentialEncryptionService(configService);
       }).toThrow(
         'MCP_ENCRYPTION_KEY must be a 64-character hex string (32 bytes)',

--- a/ayunis-core-backend/src/domain/messages/application/use-cases/create-assistant-message/create-assistant-message.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/messages/application/use-cases/create-assistant-message/create-assistant-message.use-case.spec.ts
@@ -14,7 +14,7 @@ describe('CreateAssistantMessageUseCase', () => {
   let useCase: CreateAssistantMessageUseCase;
   let mockMessagesRepository: Partial<MessagesRepository>;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     mockMessagesRepository = {
       create: jest.fn(),
     };
@@ -29,6 +29,9 @@ describe('CreateAssistantMessageUseCase', () => {
     useCase = module.get<CreateAssistantMessageUseCase>(
       CreateAssistantMessageUseCase,
     );
+  });
+  beforeEach(() => {
+    jest.clearAllMocks();
   });
 
   it('should be defined', () => {

--- a/ayunis-core-backend/src/domain/messages/application/use-cases/create-system-message/create-system-message.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/messages/application/use-cases/create-system-message/create-system-message.use-case.spec.ts
@@ -13,7 +13,7 @@ describe('CreateSystemMessageUseCase', () => {
   let useCase: CreateSystemMessageUseCase;
   let mockMessagesRepository: Partial<MessagesRepository>;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     mockMessagesRepository = {
       create: jest.fn(),
     };
@@ -28,6 +28,9 @@ describe('CreateSystemMessageUseCase', () => {
     useCase = module.get<CreateSystemMessageUseCase>(
       CreateSystemMessageUseCase,
     );
+  });
+  beforeEach(() => {
+    jest.clearAllMocks();
   });
 
   it('should be defined', () => {

--- a/ayunis-core-backend/src/domain/messages/application/use-cases/create-tool-result-message/create-tool-result-message.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/messages/application/use-cases/create-tool-result-message/create-tool-result-message.use-case.spec.ts
@@ -13,7 +13,7 @@ describe('CreateToolResultMessageUseCase', () => {
   let useCase: CreateToolResultMessageUseCase;
   let mockMessagesRepository: Partial<MessagesRepository>;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     mockMessagesRepository = {
       create: jest.fn(),
     };
@@ -28,6 +28,9 @@ describe('CreateToolResultMessageUseCase', () => {
     useCase = module.get<CreateToolResultMessageUseCase>(
       CreateToolResultMessageUseCase,
     );
+  });
+  beforeEach(() => {
+    jest.clearAllMocks();
   });
 
   it('should be defined', () => {

--- a/ayunis-core-backend/src/domain/messages/application/use-cases/create-user-message/create-user-message.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/messages/application/use-cases/create-user-message/create-user-message.use-case.spec.ts
@@ -22,7 +22,7 @@ describe('CreateUserMessageUseCase', () => {
 
   const mockOrgId = randomUUID();
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     mockMessagesRepository = {
       create: jest.fn(),
     };
@@ -50,6 +50,12 @@ describe('CreateUserMessageUseCase', () => {
     }).compile();
 
     useCase = module.get<CreateUserMessageUseCase>(CreateUserMessageUseCase);
+  });
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (mockContextService.get as jest.Mock).mockReturnValue(mockOrgId);
+    (mockUploadObjectUseCase.execute as jest.Mock).mockResolvedValue(undefined);
+    (mockDeleteObjectUseCase.execute as jest.Mock).mockResolvedValue(undefined);
   });
 
   it('should be defined', () => {

--- a/ayunis-core-backend/src/domain/messages/application/use-cases/trim-messages-for-context/trim-messages-for-context.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/messages/application/use-cases/trim-messages-for-context/trim-messages-for-context.use-case.spec.ts
@@ -42,7 +42,7 @@ describe('TrimMessagesForContextUseCase', () => {
     });
   };
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     mockCountTokensUseCase = {
       execute: jest.fn(),
     } as unknown as jest.Mocked<CountTokensUseCase>;
@@ -57,6 +57,9 @@ describe('TrimMessagesForContextUseCase', () => {
     useCase = module.get<TrimMessagesForContextUseCase>(
       TrimMessagesForContextUseCase,
     );
+  });
+  beforeEach(() => {
+    jest.clearAllMocks();
   });
 
   it('should be defined', () => {

--- a/ayunis-core-backend/src/domain/models/application/registry/inference-handler.registry.spec.ts
+++ b/ayunis-core-backend/src/domain/models/application/registry/inference-handler.registry.spec.ts
@@ -12,7 +12,7 @@ describe('InferenceHandlerRegistry', () => {
   let registry: InferenceHandlerRegistry;
   let mockMistralHandler: Partial<InferenceHandler>;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     mockMistralHandler = {} as InferenceHandler;
 
     const mockConfigService = {
@@ -48,6 +48,9 @@ describe('InferenceHandlerRegistry', () => {
     }).compile();
 
     registry = module.get<InferenceHandlerRegistry>(InferenceHandlerRegistry);
+  });
+  beforeEach(() => {
+    jest.clearAllMocks();
   });
 
   it('should be defined', () => {

--- a/ayunis-core-backend/src/domain/models/application/use-cases/create-permitted-model/create-permitted-model.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/create-permitted-model/create-permitted-model.use-case.spec.ts
@@ -22,7 +22,7 @@ describe('CreatePermittedModelUseCase', () => {
   const mockOrgId = '123e4567-e89b-12d3-a456-426614174000' as UUID;
   const mockModelId = '123e4567-e89b-12d3-a456-426614174001' as UUID;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     const mockPermittedModelsRepository = {
       create: jest.fn(),
       findAll: jest.fn(),

--- a/ayunis-core-backend/src/domain/models/application/use-cases/get-permitted-models/get-permitted-models.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/get-permitted-models/get-permitted-models.use-case.spec.ts
@@ -14,7 +14,7 @@ describe('GetPermittedModelsUseCase', () => {
 
   const mockOrgId = '123e4567-e89b-12d3-a456-426614174000' as any;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     const mockPermittedModelsRepository = {
       findAll: jest.fn(),
       create: jest.fn(),

--- a/ayunis-core-backend/src/domain/models/application/use-cases/update-language-model/update-language-model.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/update-language-model/update-language-model.use-case.spec.ts
@@ -17,7 +17,7 @@ describe('UpdateLanguageModelUseCase', () => {
 
   const mockModelId = '123e4567-e89b-12d3-a456-426614174001' as UUID;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     const mockModelsRepository = {
       findOne: jest.fn(),
       save: jest.fn(),

--- a/ayunis-core-backend/src/domain/prompts/application/use-cases/create-prompt/create-prompt.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/prompts/application/use-cases/create-prompt/create-prompt.use-case.spec.ts
@@ -13,7 +13,7 @@ describe('CreatePromptUseCase', () => {
 
   const mockUserId = '123e4567-e89b-12d3-a456-426614174000' as any;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     const mockPromptsRepository = {
       create: jest.fn(),
       findById: jest.fn(),

--- a/ayunis-core-backend/src/domain/rag/embeddings/application/use-cases/get-available-providers/get-available-providers.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/rag/embeddings/application/use-cases/get-available-providers/get-available-providers.use-case.spec.ts
@@ -9,7 +9,7 @@ describe('GetAvailableProvidersUseCase', () => {
   let useCase: GetAvailableProvidersUseCase;
   let mockProviderRegistry: Partial<EmbeddingsHandlerRegistry>;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     mockProviderRegistry = {
       getHandler: jest.fn(),
       getAvailableProviders: jest.fn(),
@@ -26,6 +26,9 @@ describe('GetAvailableProvidersUseCase', () => {
     useCase = module.get<GetAvailableProvidersUseCase>(
       GetAvailableProvidersUseCase,
     );
+  });
+  beforeEach(() => {
+    jest.clearAllMocks();
   });
 
   it('should be defined', () => {

--- a/ayunis-core-backend/src/domain/rag/splitters/application/use-cases/split-text/split-text.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/rag/splitters/application/use-cases/split-text/split-text.use-case.spec.ts
@@ -10,7 +10,7 @@ describe('ProcessTextUseCase', () => {
   let useCase: SplitTextUseCase;
   let mockProviderRegistry: Partial<SplitterHandlerRegistry>;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     const mockHandler = {
       processText: jest.fn(),
       isAvailable: jest.fn().mockReturnValue(true),
@@ -31,6 +31,9 @@ describe('ProcessTextUseCase', () => {
     }).compile();
 
     useCase = module.get<SplitTextUseCase>(SplitTextUseCase);
+  });
+  beforeEach(() => {
+    jest.clearAllMocks();
   });
 
   it('should be defined', () => {

--- a/ayunis-core-backend/src/domain/retrievers/file-retrievers/application/use-cases/retrieve-file-content/retrieve-file-content.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/retrievers/file-retrievers/application/use-cases/retrieve-file-content/retrieve-file-content.use-case.spec.ts
@@ -27,7 +27,7 @@ describe('ProcessFileUseCase', () => {
     },
   };
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     mockHandler = { processFile: jest.fn() };
     mockRegistry = {
       getHandler: jest.fn().mockReturnValue(mockHandler),
@@ -48,6 +48,9 @@ describe('ProcessFileUseCase', () => {
     useCase = module.get<RetrieveFileContentUseCase>(
       RetrieveFileContentUseCase,
     );
+  });
+  beforeEach(() => {
+    jest.clearAllMocks();
   });
 
   it('should be defined', () => {

--- a/ayunis-core-backend/src/domain/retrievers/internet-search-retrievers/application/use-cases/search-web/search-web.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/retrievers/internet-search-retrievers/application/use-cases/search-web/search-web.use-case.spec.ts
@@ -10,7 +10,7 @@ describe('SearchWebUseCase', () => {
   let useCase: SearchWebUseCase;
   let mockHandler: Partial<InternetSearchHandler>;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     mockHandler = {
       search: jest.fn(),
     };
@@ -23,6 +23,9 @@ describe('SearchWebUseCase', () => {
     }).compile();
 
     useCase = module.get<SearchWebUseCase>(SearchWebUseCase);
+  });
+  beforeEach(() => {
+    jest.clearAllMocks();
   });
 
   it('should be defined', () => {

--- a/ayunis-core-backend/src/domain/retrievers/url-retrievers/application/use-cases/retrieve-url/retrieve-url.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/retrievers/url-retrievers/application/use-cases/retrieve-url/retrieve-url.use-case.spec.ts
@@ -10,7 +10,7 @@ describe('RetrieveUrlUseCase', () => {
   let useCase: RetrieveUrlUseCase;
   let mockHandler: Partial<UrlRetrieverHandler>;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     mockHandler = {
       retrieveUrl: jest.fn(),
     };
@@ -23,6 +23,9 @@ describe('RetrieveUrlUseCase', () => {
     }).compile();
 
     useCase = module.get<RetrieveUrlUseCase>(RetrieveUrlUseCase);
+  });
+  beforeEach(() => {
+    jest.clearAllMocks();
   });
 
   it('should be defined', () => {

--- a/ayunis-core-backend/src/domain/shares/application/use-cases/create-share/create-share.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/shares/application/use-cases/create-share/create-share.use-case.spec.ts
@@ -24,7 +24,7 @@ describe('CreateShareUseCase', () => {
   const mockOrgId = randomUUID();
   const mockAgentId = randomUUID();
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         CreateShareUseCase,
@@ -69,6 +69,9 @@ describe('CreateShareUseCase', () => {
       canCreateShare: jest.fn(),
       canDeleteShare: jest.fn(),
     };
+  });
+  beforeEach(() => {
+    jest.clearAllMocks();
   });
 
   describe('execute', () => {

--- a/ayunis-core-backend/src/domain/shares/application/use-cases/delete-share/delete-share.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/shares/application/use-cases/delete-share/delete-share.use-case.spec.ts
@@ -31,7 +31,7 @@ describe('DeleteShareUseCase', () => {
   const mockUserId = randomUUID();
   const mockOrgId = randomUUID();
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         DeleteShareUseCase,
@@ -62,6 +62,9 @@ describe('DeleteShareUseCase', () => {
     contextService = module.get<ContextService>(ContextService);
     repository = module.get<SharesRepository>(SharesRepository);
     eventEmitter = module.get<EventEmitter2>(EventEmitter2);
+  });
+  beforeEach(() => {
+    jest.clearAllMocks();
   });
 
   it('should emit event with empty remainingScopes when no other shares exist for a skill', async () => {

--- a/ayunis-core-backend/src/domain/shares/presenters/http/shares.controller.spec.ts
+++ b/ayunis-core-backend/src/domain/shares/presenters/http/shares.controller.spec.ts
@@ -28,7 +28,7 @@ describe('SharesController', () => {
   const mockShareId = randomUUID();
   const mockOrgId = randomUUID();
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [SharesController],
       providers: [
@@ -71,6 +71,9 @@ describe('SharesController', () => {
     deleteShareUseCase = module.get<DeleteShareUseCase>(DeleteShareUseCase);
     getSharesUseCase = module.get<GetSharesUseCase>(GetSharesUseCase);
     shareDtoMapper = module.get<ShareDtoMapper>(ShareDtoMapper);
+  });
+  beforeEach(() => {
+    jest.clearAllMocks();
   });
 
   describe('createShare', () => {

--- a/ayunis-core-backend/src/domain/skills/application/listeners/share-deleted.listener.spec.ts
+++ b/ayunis-core-backend/src/domain/skills/application/listeners/share-deleted.listener.spec.ts
@@ -18,7 +18,7 @@ describe('ShareDeletedListener', () => {
   let findAllUserIdsByOrgId: { execute: jest.Mock };
   let findAllUserIdsByTeamId: { execute: jest.Mock };
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     skillRepository = {
       deactivateAllExceptOwner: jest.fn().mockResolvedValue(undefined),
       deactivateUsersNotInSet: jest.fn().mockResolvedValue(undefined),
@@ -48,6 +48,9 @@ describe('ShareDeletedListener', () => {
     }).compile();
 
     listener = module.get<ShareDeletedListener>(ShareDeletedListener);
+  });
+  beforeEach(() => {
+    jest.clearAllMocks();
   });
 
   it('should deactivate all non-owner activations when no remaining scopes exist', async () => {

--- a/ayunis-core-backend/src/domain/skills/application/strategies/skill-share-authorization.strategy.spec.ts
+++ b/ayunis-core-backend/src/domain/skills/application/strategies/skill-share-authorization.strategy.spec.ts
@@ -9,7 +9,7 @@ describe('SkillShareAuthorizationStrategy', () => {
   let strategy: SkillShareAuthorizationStrategy;
   let skillRepository: jest.Mocked<SkillRepository>;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     const mockSkillRepository = {
       create: jest.fn(),
       update: jest.fn(),
@@ -39,6 +39,9 @@ describe('SkillShareAuthorizationStrategy', () => {
       SkillShareAuthorizationStrategy,
     );
     skillRepository = module.get(SkillRepository);
+  });
+  beforeEach(() => {
+    jest.clearAllMocks();
   });
 
   describe('canViewShares', () => {

--- a/ayunis-core-backend/src/domain/skills/application/use-cases/create-skill/create-skill.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/skills/application/use-cases/create-skill/create-skill.use-case.spec.ts
@@ -15,7 +15,7 @@ describe('CreateSkillUseCase', () => {
 
   const mockUserId = '123e4567-e89b-12d3-a456-426614174000' as UUID;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     const mockSkillRepository = {
       create: jest.fn(),
       findByNameAndOwner: jest.fn(),

--- a/ayunis-core-backend/src/domain/skills/application/use-cases/delete-skill/delete-skill.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/skills/application/use-cases/delete-skill/delete-skill.use-case.spec.ts
@@ -24,7 +24,7 @@ describe('DeleteSkillUseCase', () => {
   const mockUserId = '123e4567-e89b-12d3-a456-426614174000' as UUID;
   const mockSkillId = '550e8400-e29b-41d4-a716-446655440000' as UUID;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     const mockSkillRepository = {
       findOne: jest.fn(),
       delete: jest.fn(),

--- a/ayunis-core-backend/src/domain/skills/application/use-cases/find-all-skills/find-all-skills.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/skills/application/use-cases/find-all-skills/find-all-skills.use-case.spec.ts
@@ -39,7 +39,7 @@ describe('FindAllSkillsUseCase', () => {
       createdAt: new Date(),
     });
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     const mockSkillRepository = {
       findAllByOwner: jest.fn(),
       findByIds: jest.fn(),

--- a/ayunis-core-backend/src/domain/skills/application/use-cases/update-skill/update-skill.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/skills/application/use-cases/update-skill/update-skill.use-case.spec.ts
@@ -27,7 +27,7 @@ describe('UpdateSkillUseCase', () => {
   const mockUserId = '123e4567-e89b-12d3-a456-426614174000' as UUID;
   const mockSkillId = '550e8400-e29b-41d4-a716-446655440000' as UUID;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     const mockSkillRepository = {
       findOne: jest.fn(),
       findByNameAndOwner: jest.fn(),

--- a/ayunis-core-backend/src/domain/sources/application/use-cases/delete-source/delete-source.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/sources/application/use-cases/delete-source/delete-source.use-case.spec.ts
@@ -21,7 +21,7 @@ describe('DeleteSourceUseCase', () => {
   let useCase: DeleteSourceUseCase;
   let mockSourceRepository: Partial<SourceRepository>;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     mockSourceRepository = {
       delete: jest.fn(),
     };
@@ -41,6 +41,9 @@ describe('DeleteSourceUseCase', () => {
     }).compile();
 
     useCase = module.get<DeleteSourceUseCase>(DeleteSourceUseCase);
+  });
+  beforeEach(() => {
+    jest.clearAllMocks();
   });
 
   it('should be defined', () => {

--- a/ayunis-core-backend/src/domain/sources/application/use-cases/get-text-source-by-id/get-text-source-by-id.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/sources/application/use-cases/get-text-source-by-id/get-text-source-by-id.use-case.spec.ts
@@ -11,7 +11,7 @@ describe('GetSourceByIdUseCase', () => {
   let useCase: GetTextSourceByIdUseCase;
   let mockSourceRepository: Partial<SourceRepository>;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     mockSourceRepository = {
       findById: jest.fn(),
     };
@@ -27,6 +27,9 @@ describe('GetSourceByIdUseCase', () => {
     }).compile();
 
     useCase = module.get<GetTextSourceByIdUseCase>(GetTextSourceByIdUseCase);
+  });
+  beforeEach(() => {
+    jest.clearAllMocks();
   });
 
   it('should be defined', () => {

--- a/ayunis-core-backend/src/domain/storage/application/use-cases/delete-object/delete-object.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/storage/application/use-cases/delete-object/delete-object.use-case.spec.ts
@@ -17,7 +17,7 @@ describe('DeleteObjectUseCase', () => {
     },
   };
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     mockObjectStorage = {
       delete: jest.fn(),
       exists: jest.fn(),
@@ -36,6 +36,9 @@ describe('DeleteObjectUseCase', () => {
     }).compile();
 
     useCase = module.get<DeleteObjectUseCase>(DeleteObjectUseCase);
+  });
+  beforeEach(() => {
+    jest.clearAllMocks();
   });
 
   it('should be defined', () => {

--- a/ayunis-core-backend/src/domain/storage/application/use-cases/download-object/download-object.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/storage/application/use-cases/download-object/download-object.use-case.spec.ts
@@ -18,7 +18,7 @@ describe('DownloadObjectUseCase', () => {
     },
   };
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     mockObjectStorage = {
       download: jest.fn(),
       exists: jest.fn(),
@@ -37,6 +37,9 @@ describe('DownloadObjectUseCase', () => {
     }).compile();
 
     useCase = module.get<DownloadObjectUseCase>(DownloadObjectUseCase);
+  });
+  beforeEach(() => {
+    jest.clearAllMocks();
   });
 
   it('should be defined', () => {

--- a/ayunis-core-backend/src/domain/storage/application/use-cases/get-object-info/get-object-info.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/storage/application/use-cases/get-object-info/get-object-info.use-case.spec.ts
@@ -18,7 +18,7 @@ describe('GetObjectInfoUseCase', () => {
     },
   };
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     mockObjectStorage = {
       getObjectInfo: jest.fn(),
     };
@@ -36,6 +36,9 @@ describe('GetObjectInfoUseCase', () => {
     }).compile();
 
     useCase = module.get<GetObjectInfoUseCase>(GetObjectInfoUseCase);
+  });
+  beforeEach(() => {
+    jest.clearAllMocks();
   });
 
   it('should be defined', () => {

--- a/ayunis-core-backend/src/domain/storage/application/use-cases/get-presigned-url/get-presigned-url.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/storage/application/use-cases/get-presigned-url/get-presigned-url.use-case.spec.ts
@@ -19,7 +19,7 @@ describe('GetPresignedUrlUseCase', () => {
     },
   };
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     mockObjectStorage = {
       getPresignedUrl: jest.fn(),
       exists: jest.fn(),
@@ -38,6 +38,9 @@ describe('GetPresignedUrlUseCase', () => {
     }).compile();
 
     useCase = module.get<GetPresignedUrlUseCase>(GetPresignedUrlUseCase);
+  });
+  beforeEach(() => {
+    jest.clearAllMocks();
   });
 
   it('should be defined', () => {

--- a/ayunis-core-backend/src/domain/storage/application/use-cases/upload-object/upload-object.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/storage/application/use-cases/upload-object/upload-object.use-case.spec.ts
@@ -23,7 +23,7 @@ describe('UploadObjectUseCase', () => {
     },
   };
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     mockObjectStorage = {
       upload: jest.fn(),
     };
@@ -41,6 +41,9 @@ describe('UploadObjectUseCase', () => {
     }).compile();
 
     useCase = module.get<UploadObjectUseCase>(UploadObjectUseCase);
+  });
+  beforeEach(() => {
+    jest.clearAllMocks();
   });
 
   it('should be defined', () => {

--- a/ayunis-core-backend/src/domain/threads/application/listeners/share-deleted.listener.spec.ts
+++ b/ayunis-core-backend/src/domain/threads/application/listeners/share-deleted.listener.spec.ts
@@ -15,7 +15,7 @@ describe('ShareDeletedListener (threads)', () => {
   let findAllUserIdsByOrgId: { execute: jest.Mock };
   let findAllUserIdsByTeamId: { execute: jest.Mock };
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     removeSkillSources = {
       execute: jest.fn().mockResolvedValue(undefined),
     };
@@ -47,6 +47,9 @@ describe('ShareDeletedListener (threads)', () => {
     }).compile();
 
     listener = module.get<ShareDeletedListener>(ShareDeletedListener);
+  });
+  beforeEach(() => {
+    jest.clearAllMocks();
   });
 
   it('should remove skill sources from all non-owner users when no remaining scopes exist', async () => {

--- a/ayunis-core-backend/src/domain/threads/application/use-cases/add-mcp-integration-to-thread/add-mcp-integration-to-thread.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/threads/application/use-cases/add-mcp-integration-to-thread/add-mcp-integration-to-thread.use-case.spec.ts
@@ -18,7 +18,7 @@ describe('AddMcpIntegrationToThreadUseCase', () => {
   const mockMcpIntegrationId = '123e4567-e89b-12d3-a456-426614174002' as UUID;
   const mockMcpIntegrationId2 = '123e4567-e89b-12d3-a456-426614174003' as UUID;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     const mockThreadsRepository = {
       findOne: jest.fn(),
       updateMcpIntegrations: jest.fn(),

--- a/ayunis-core-backend/src/domain/threads/application/use-cases/add-source-to-thread/add-source-to-thread.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/threads/application/use-cases/add-source-to-thread/add-source-to-thread.use-case.spec.ts
@@ -30,7 +30,7 @@ describe('AddSourceToThreadUseCase', () => {
   const mockUserId = randomUUID();
   const mockOrgId = randomUUID();
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     const mockThreadsRepository = {
       updateSourceAssignments: jest.fn(),
     };

--- a/ayunis-core-backend/src/domain/threads/application/use-cases/generate-and-set-thread-title/generate-and-set-thread-title.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/threads/application/use-cases/generate-and-set-thread-title/generate-and-set-thread-title.use-case.spec.ts
@@ -7,7 +7,7 @@ import { GetInferenceUseCase } from 'src/domain/models/application/use-cases/get
 describe('GenerateAndSetThreadTitleUseCase - Markdown Stripping', () => {
   let useCase: GenerateAndSetThreadTitleUseCase;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         GenerateAndSetThreadTitleUseCase,
@@ -25,6 +25,9 @@ describe('GenerateAndSetThreadTitleUseCase - Markdown Stripping', () => {
     useCase = module.get<GenerateAndSetThreadTitleUseCase>(
       GenerateAndSetThreadTitleUseCase,
     );
+  });
+  beforeEach(() => {
+    jest.clearAllMocks();
   });
 
   describe('stripMarkdownFormatting', () => {

--- a/ayunis-core-backend/src/domain/threads/application/use-cases/remove-skill-sources-from-threads/remove-skill-sources-from-threads.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/threads/application/use-cases/remove-skill-sources-from-threads/remove-skill-sources-from-threads.use-case.spec.ts
@@ -10,7 +10,7 @@ describe('RemoveSkillSourcesFromThreadsUseCase', () => {
   let useCase: RemoveSkillSourcesFromThreadsUseCase;
   let threadsRepository: jest.Mocked<ThreadsRepository>;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     const mockThreadsRepository = {
       removeSourceAssignmentsByOriginSkill: jest.fn(),
     };

--- a/ayunis-core-backend/src/domain/tools/application/handlers/activate-skill-tool.handler.spec.ts
+++ b/ayunis-core-backend/src/domain/tools/application/handlers/activate-skill-tool.handler.spec.ts
@@ -37,7 +37,7 @@ describe('ActivateSkillToolHandler', () => {
   const mockSkillId = randomUUID();
   const mockSourceId = randomUUID();
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     mockFindSkillByName = {
       execute: jest.fn(),
     } as any;

--- a/ayunis-core-backend/src/domain/tools/application/handlers/source-query-tool.handler.spec.ts
+++ b/ayunis-core-backend/src/domain/tools/application/handlers/source-query-tool.handler.spec.ts
@@ -30,7 +30,7 @@ describe('SourceQueryToolHandler', () => {
   const mockOrgId = randomUUID();
   const mockThreadId = randomUUID();
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     mockGetSourceByIdUseCase = {
       execute: jest.fn(),
     } as unknown as jest.Mocked<GetTextSourceByIdUseCase>;
@@ -54,6 +54,9 @@ describe('SourceQueryToolHandler', () => {
     }).compile();
 
     handler = module.get<SourceQueryToolHandler>(SourceQueryToolHandler);
+  });
+  beforeEach(() => {
+    jest.clearAllMocks();
   });
 
   it('should be defined', () => {

--- a/ayunis-core-backend/src/domain/tools/application/use-cases/check-tool-capabilities/check-tool-capabilities.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/tools/application/use-cases/check-tool-capabilities/check-tool-capabilities.use-case.spec.ts
@@ -29,7 +29,7 @@ class MockTool extends Tool {
 describe('CheckToolCapabilitiesUseCase', () => {
   let useCase: CheckToolCapabilitiesUseCase;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [CheckToolCapabilitiesUseCase],
     }).compile();
@@ -37,6 +37,9 @@ describe('CheckToolCapabilitiesUseCase', () => {
     useCase = module.get<CheckToolCapabilitiesUseCase>(
       CheckToolCapabilitiesUseCase,
     );
+  });
+  beforeEach(() => {
+    jest.clearAllMocks();
   });
 
   it('should be defined', () => {

--- a/ayunis-core-backend/src/domain/tools/application/use-cases/execute-tool/execute-tool.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/tools/application/use-cases/execute-tool/execute-tool.use-case.spec.ts
@@ -41,7 +41,7 @@ describe('ExecuteToolUseCase', () => {
 
   const mockContext = '123e4567-e89b-12d3-a456-426614174000' as any;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     mockHandler = {
       execute: jest.fn(),
     };
@@ -58,6 +58,9 @@ describe('ExecuteToolUseCase', () => {
     }).compile();
 
     useCase = module.get<ExecuteToolUseCase>(ExecuteToolUseCase);
+  });
+  beforeEach(() => {
+    jest.clearAllMocks();
   });
 
   it('should be defined', () => {

--- a/ayunis-core-backend/src/domain/usage/application/use-cases/collect-usage/collect-usage.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/usage/application/use-cases/collect-usage/collect-usage.use-case.spec.ts
@@ -42,7 +42,7 @@ describe('CollectUsageUseCase', () => {
     });
   };
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     mockUsageRepository = {
       save: jest.fn().mockResolvedValue(undefined),
     };
@@ -64,6 +64,17 @@ describe('CollectUsageUseCase', () => {
     }).compile();
 
     useCase = module.get<CollectUsageUseCase>(CollectUsageUseCase);
+  });
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (mockContextService.get as jest.Mock).mockImplementation(
+      (key?: 'userId' | 'orgId') => {
+        if (key === 'userId') return userId;
+        if (key === 'orgId') return orgId;
+        return undefined;
+      },
+    );
+    (mockUsageRepository.save as jest.Mock).mockResolvedValue(undefined);
   });
 
   it('should be defined', () => {

--- a/ayunis-core-backend/src/domain/usage/application/use-cases/get-model-distribution/get-model-distribution.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/usage/application/use-cases/get-model-distribution/get-model-distribution.use-case.spec.ts
@@ -14,7 +14,7 @@ describe('GetModelDistributionUseCase', () => {
 
   const orgId = 'org-id' as UUID;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     mockUsageRepository = {
       getModelDistribution: jest.fn(),
     };
@@ -29,6 +29,9 @@ describe('GetModelDistributionUseCase', () => {
     useCase = module.get<GetModelDistributionUseCase>(
       GetModelDistributionUseCase,
     );
+  });
+  beforeEach(() => {
+    jest.clearAllMocks();
   });
 
   it('should be defined', () => {

--- a/ayunis-core-backend/src/domain/usage/application/use-cases/get-provider-usage/get-provider-usage.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/usage/application/use-cases/get-provider-usage/get-provider-usage.use-case.spec.ts
@@ -15,7 +15,7 @@ describe('GetProviderUsageUseCase', () => {
 
   const orgId = 'org-id' as UUID;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     mockUsageRepository = {
       getProviderUsage: jest.fn(),
     };
@@ -28,6 +28,9 @@ describe('GetProviderUsageUseCase', () => {
     }).compile();
 
     useCase = module.get<GetProviderUsageUseCase>(GetProviderUsageUseCase);
+  });
+  beforeEach(() => {
+    jest.clearAllMocks();
   });
 
   it('should be defined', () => {

--- a/ayunis-core-backend/src/domain/usage/application/use-cases/get-usage-stats/get-usage-stats.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/usage/application/use-cases/get-usage-stats/get-usage-stats.use-case.spec.ts
@@ -13,7 +13,7 @@ describe('GetUsageStatsUseCase', () => {
 
   const orgId = 'org-id' as UUID;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     mockUsageRepository = {
       getUsageStats: jest.fn(),
     };
@@ -26,6 +26,9 @@ describe('GetUsageStatsUseCase', () => {
     }).compile();
 
     useCase = module.get<GetUsageStatsUseCase>(GetUsageStatsUseCase);
+  });
+  beforeEach(() => {
+    jest.clearAllMocks();
   });
 
   it('should be defined', () => {

--- a/ayunis-core-backend/src/domain/usage/application/use-cases/get-user-usage/get-user-usage.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/usage/application/use-cases/get-user-usage/get-user-usage.use-case.spec.ts
@@ -18,7 +18,7 @@ describe('GetUserUsageUseCase', () => {
 
   const orgId = 'org-id' as UUID;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     mockUsageRepository = {
       getUserUsage: jest.fn(),
     };
@@ -31,6 +31,9 @@ describe('GetUserUsageUseCase', () => {
     }).compile();
 
     useCase = module.get<GetUserUsageUseCase>(GetUserUsageUseCase);
+  });
+  beforeEach(() => {
+    jest.clearAllMocks();
   });
 
   it('should be defined', () => {

--- a/ayunis-core-backend/src/iam/authentication/application/use-cases/get-current-user/get-current-user.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/authentication/application/use-cases/get-current-user/get-current-user.use-case.spec.ts
@@ -14,7 +14,7 @@ describe('GetCurrentUserUseCase', () => {
   let mockJwtService: Partial<JwtService>;
   let mockFindUserByIdUseCase: Partial<FindUserByIdUseCase>;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     mockJwtService = { verify: jest.fn() };
     mockFindUserByIdUseCase = { execute: jest.fn() };
 
@@ -27,6 +27,9 @@ describe('GetCurrentUserUseCase', () => {
     }).compile();
 
     useCase = module.get<GetCurrentUserUseCase>(GetCurrentUserUseCase);
+  });
+  beforeEach(() => {
+    jest.clearAllMocks();
   });
 
   it('should be defined', () => {

--- a/ayunis-core-backend/src/iam/authentication/application/use-cases/login/login.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/authentication/application/use-cases/login/login.use-case.spec.ts
@@ -14,7 +14,7 @@ describe('LoginUseCase', () => {
   let useCase: LoginUseCase;
   let mockAuthRepository: Partial<AuthenticationRepository>;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     mockAuthRepository = {
       generateTokens: jest.fn(),
     };
@@ -30,6 +30,9 @@ describe('LoginUseCase', () => {
     }).compile();
 
     useCase = module.get<LoginUseCase>(LoginUseCase);
+  });
+  beforeEach(() => {
+    jest.clearAllMocks();
   });
 
   it('should be defined', () => {

--- a/ayunis-core-backend/src/iam/authentication/application/use-cases/refresh-token/refresh-token.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/authentication/application/use-cases/refresh-token/refresh-token.use-case.spec.ts
@@ -18,7 +18,7 @@ describe('RefreshTokenUseCase', () => {
   let mockJwtService: Partial<JwtService>;
   let mockFindUserByIdUseCase: Partial<FindUserByIdUseCase>;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     mockAuthRepository = {
       generateTokens: jest.fn(),
     };
@@ -42,6 +42,9 @@ describe('RefreshTokenUseCase', () => {
     }).compile();
 
     useCase = module.get<RefreshTokenUseCase>(RefreshTokenUseCase);
+  });
+  beforeEach(() => {
+    jest.clearAllMocks();
   });
 
   it('should be defined', () => {

--- a/ayunis-core-backend/src/iam/authentication/application/use-cases/register-user/register-user.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/authentication/application/use-cases/register-user/register-user.use-case.spec.ts
@@ -34,7 +34,7 @@ describe('RegisterUserUseCase', () => {
   let mockCreateOrgUseCase: Partial<CreateOrgUseCase>;
   let mockFindUserByEmailUseCase: Partial<FindUserByEmailUseCase>;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     mockCreateAdminUserUseCase = {
       execute: jest.fn(),
     };
@@ -82,6 +82,9 @@ describe('RegisterUserUseCase', () => {
     }).compile();
 
     useCase = module.get<RegisterUserUseCase>(RegisterUserUseCase);
+  });
+  beforeEach(() => {
+    jest.clearAllMocks();
   });
 
   it('should be defined', () => {

--- a/ayunis-core-backend/src/iam/authentication/presenters/http/authentication.controller.spec.ts
+++ b/ayunis-core-backend/src/iam/authentication/presenters/http/authentication.controller.spec.ts
@@ -25,7 +25,7 @@ describe('AuthenticationController', () => {
   let mockConfigService: Partial<ConfigService>;
   let mockJwtService: Partial<JwtService>;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     mockLoginUseCase = {
       execute: jest.fn(),
     };
@@ -62,6 +62,9 @@ describe('AuthenticationController', () => {
     }).compile();
 
     controller = module.get<AuthenticationController>(AuthenticationController);
+  });
+  beforeEach(() => {
+    jest.clearAllMocks();
   });
 
   it('should be defined', () => {
@@ -150,7 +153,7 @@ describe('AuthenticationController', () => {
           if (key === 'auth.cookie.httpOnly') return true;
           if (key === 'auth.cookie.secure') return false;
           if (key === 'auth.cookie.sameSite') return 'lax';
-          return defaultValue || null;
+          return defaultValue ?? null;
         });
 
       // Mock cookies

--- a/ayunis-core-backend/src/iam/hashing/application/use-cases/compare-hash/compare-hash.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/hashing/application/use-cases/compare-hash/compare-hash.use-case.spec.ts
@@ -9,7 +9,7 @@ describe('CompareHashUseCase', () => {
   let useCase: CompareHashUseCase;
   let mockHashingHandler: Partial<HashingHandler>;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     mockHashingHandler = {
       compare: jest.fn(),
     };
@@ -25,6 +25,9 @@ describe('CompareHashUseCase', () => {
     }).compile();
 
     useCase = module.get<CompareHashUseCase>(CompareHashUseCase);
+  });
+  beforeEach(() => {
+    jest.clearAllMocks();
   });
 
   it('should be defined', () => {

--- a/ayunis-core-backend/src/iam/hashing/application/use-cases/hash-text/hash-text.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/hashing/application/use-cases/hash-text/hash-text.use-case.spec.ts
@@ -9,7 +9,7 @@ describe('HashTextUseCase', () => {
   let useCase: HashTextUseCase;
   let mockHashingHandler: Partial<HashingHandler>;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     mockHashingHandler = {
       hash: jest.fn(),
     };
@@ -25,6 +25,9 @@ describe('HashTextUseCase', () => {
     }).compile();
 
     useCase = module.get<HashTextUseCase>(HashTextUseCase);
+  });
+  beforeEach(() => {
+    jest.clearAllMocks();
   });
 
   it('should be defined', () => {

--- a/ayunis-core-backend/src/iam/invites/application/use-cases/delete-all-pending-invites/delete-all-pending-invites.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/invites/application/use-cases/delete-all-pending-invites/delete-all-pending-invites.use-case.spec.ts
@@ -11,7 +11,7 @@ describe('DeleteAllPendingInvitesUseCase', () => {
 
   const mockOrgId = '123e4567-e89b-12d3-a456-426614174001';
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     const mockInvitesRepository = {
       deleteAllPendingByOrg: jest.fn(),
     };

--- a/ayunis-core-backend/src/iam/orgs/application/use-cases/create-org/create-org.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/orgs/application/use-cases/create-org/create-org.use-case.spec.ts
@@ -11,7 +11,7 @@ describe('CreateOrgUseCase', () => {
   let useCase: CreateOrgUseCase;
   let mockOrgsRepository: Partial<OrgsRepository>;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     mockOrgsRepository = {
       create: jest.fn(),
     };
@@ -24,6 +24,9 @@ describe('CreateOrgUseCase', () => {
     }).compile();
 
     useCase = module.get<CreateOrgUseCase>(CreateOrgUseCase);
+  });
+  beforeEach(() => {
+    jest.clearAllMocks();
   });
 
   it('should be defined', () => {

--- a/ayunis-core-backend/src/iam/orgs/application/use-cases/delete-org/delete-org.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/orgs/application/use-cases/delete-org/delete-org.use-case.spec.ts
@@ -10,7 +10,7 @@ describe('DeleteOrgUseCase', () => {
   let useCase: DeleteOrgUseCase;
   let mockOrgsRepository: Partial<OrgsRepository>;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     mockOrgsRepository = {
       delete: jest.fn(),
     };
@@ -23,6 +23,9 @@ describe('DeleteOrgUseCase', () => {
     }).compile();
 
     useCase = module.get<DeleteOrgUseCase>(DeleteOrgUseCase);
+  });
+  beforeEach(() => {
+    jest.clearAllMocks();
   });
 
   it('should be defined', () => {

--- a/ayunis-core-backend/src/iam/orgs/application/use-cases/find-org-by-id/find-org-by-id.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/orgs/application/use-cases/find-org-by-id/find-org-by-id.use-case.spec.ts
@@ -11,7 +11,7 @@ describe('FindOrgByIdUseCase', () => {
   let useCase: FindOrgByIdUseCase;
   let mockOrgsRepository: Partial<OrgsRepository>;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     mockOrgsRepository = {
       findById: jest.fn(),
     };
@@ -24,6 +24,9 @@ describe('FindOrgByIdUseCase', () => {
     }).compile();
 
     useCase = module.get<FindOrgByIdUseCase>(FindOrgByIdUseCase);
+  });
+  beforeEach(() => {
+    jest.clearAllMocks();
   });
 
   it('should be defined', () => {

--- a/ayunis-core-backend/src/iam/orgs/application/use-cases/super-admin-get-all-orgs/super-admin-get-all-orgs.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/orgs/application/use-cases/super-admin-get-all-orgs/super-admin-get-all-orgs.use-case.spec.ts
@@ -15,7 +15,7 @@ describe('SuperAdminGetAllOrgsUseCase', () => {
   let orgsRepository: jest.Mocked<OrgsRepository>;
   let contextService: jest.Mocked<ContextService>;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         SuperAdminGetAllOrgsUseCase,
@@ -37,6 +37,9 @@ describe('SuperAdminGetAllOrgsUseCase', () => {
     useCase = module.get(SuperAdminGetAllOrgsUseCase);
     orgsRepository = module.get(OrgsRepository);
     contextService = module.get(ContextService);
+  });
+  beforeEach(() => {
+    jest.clearAllMocks();
   });
 
   it('should return paginated orgs when requester is super admin', async () => {

--- a/ayunis-core-backend/src/iam/orgs/application/use-cases/update-org/update-org.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/orgs/application/use-cases/update-org/update-org.use-case.spec.ts
@@ -11,7 +11,7 @@ describe('UpdateOrgUseCase', () => {
   let useCase: UpdateOrgUseCase;
   let mockOrgsRepository: Partial<OrgsRepository>;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     mockOrgsRepository = {
       update: jest.fn(),
     };
@@ -24,6 +24,9 @@ describe('UpdateOrgUseCase', () => {
     }).compile();
 
     useCase = module.get<UpdateOrgUseCase>(UpdateOrgUseCase);
+  });
+  beforeEach(() => {
+    jest.clearAllMocks();
   });
 
   it('should be defined', () => {

--- a/ayunis-core-backend/src/iam/subscriptions/application/use-cases/has-active-subscription/has-active-subscription.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/subscriptions/application/use-cases/has-active-subscription/has-active-subscription.use-case.spec.ts
@@ -19,7 +19,7 @@ describe('HasActiveSubscriptionUseCase', () => {
 
   const mockOrgId = '123e4567-e89b-12d3-a456-426614174000' as any;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     const mockSubscriptionRepository = {
       findByOrgId: jest.fn(),
       create: jest.fn(),

--- a/ayunis-core-backend/src/iam/teams/application/use-cases/create-team/create-team.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/teams/application/use-cases/create-team/create-team.use-case.spec.ts
@@ -20,7 +20,7 @@ describe('CreateTeamUseCase', () => {
 
   const mockOrgId = 'org-123' as UUID;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     mockTeamsRepository = {
       findByNameAndOrgId: jest.fn(),
       create: jest.fn(),
@@ -39,6 +39,9 @@ describe('CreateTeamUseCase', () => {
     }).compile();
 
     useCase = module.get<CreateTeamUseCase>(CreateTeamUseCase);
+  });
+  beforeEach(() => {
+    jest.clearAllMocks();
   });
 
   it('should be defined', () => {

--- a/ayunis-core-backend/src/iam/teams/application/use-cases/find-all-user-ids-by-team-id/find-all-user-ids-by-team-id.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/teams/application/use-cases/find-all-user-ids-by-team-id/find-all-user-ids-by-team-id.use-case.spec.ts
@@ -9,7 +9,7 @@ describe('FindAllUserIdsByTeamIdUseCase', () => {
   let useCase: FindAllUserIdsByTeamIdUseCase;
   let teamMembersRepository: { findAllUserIdsByTeamId: jest.Mock };
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     teamMembersRepository = {
       findAllUserIdsByTeamId: jest.fn(),
     };
@@ -27,6 +27,9 @@ describe('FindAllUserIdsByTeamIdUseCase', () => {
     useCase = module.get<FindAllUserIdsByTeamIdUseCase>(
       FindAllUserIdsByTeamIdUseCase,
     );
+  });
+  beforeEach(() => {
+    jest.clearAllMocks();
   });
 
   it('should return all user IDs for a team', async () => {

--- a/ayunis-core-backend/src/iam/teams/application/use-cases/list-teams/list-teams.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/teams/application/use-cases/list-teams/list-teams.use-case.spec.ts
@@ -15,7 +15,7 @@ describe('ListTeamsUseCase', () => {
 
   const mockOrgId = 'org-123' as UUID;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     mockTeamsRepository = {
       findByOrgId: jest.fn(),
     };
@@ -33,6 +33,9 @@ describe('ListTeamsUseCase', () => {
     }).compile();
 
     useCase = module.get<ListTeamsUseCase>(ListTeamsUseCase);
+  });
+  beforeEach(() => {
+    jest.clearAllMocks();
   });
 
   it('should be defined', () => {

--- a/ayunis-core-backend/src/iam/users/application/use-cases/create-admin-user/create-admin-user.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/create-admin-user/create-admin-user.use-case.spec.ts
@@ -16,7 +16,7 @@ describe('CreateAdminUserUseCase', () => {
   let mockHashTextUseCase: Partial<HashTextUseCase>;
   let mockCreateUserUseCase: Partial<CreateUserUseCase>;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     mockUsersRepository = {
       findOneByEmail: jest.fn(),
       create: jest.fn(),
@@ -38,6 +38,9 @@ describe('CreateAdminUserUseCase', () => {
     }).compile();
 
     useCase = module.get<CreateAdminUserUseCase>(CreateAdminUserUseCase);
+  });
+  beforeEach(() => {
+    jest.clearAllMocks();
   });
 
   it('should be defined', () => {

--- a/ayunis-core-backend/src/iam/users/application/use-cases/create-regular-user/create-regular-user.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/create-regular-user/create-regular-user.use-case.spec.ts
@@ -16,7 +16,7 @@ describe('CreateRegularUserUseCase', () => {
   let mockHashTextUseCase: Partial<HashTextUseCase>;
   let mockCreateUserUseCase: Partial<CreateUserUseCase>;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     mockUsersRepository = {
       findOneByEmail: jest.fn(),
       create: jest.fn(),
@@ -38,6 +38,9 @@ describe('CreateRegularUserUseCase', () => {
     }).compile();
 
     useCase = module.get<CreateRegularUserUseCase>(CreateRegularUserUseCase);
+  });
+  beforeEach(() => {
+    jest.clearAllMocks();
   });
 
   it('should be defined', () => {

--- a/ayunis-core-backend/src/iam/users/application/use-cases/find-user-by-id/find-user-by-id.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/find-user-by-id/find-user-by-id.use-case.spec.ts
@@ -11,7 +11,7 @@ describe('FindUserByIdUseCase', () => {
   let useCase: FindUserByIdUseCase;
   let mockUsersRepository: Partial<UsersRepository>;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     mockUsersRepository = {
       findOneById: jest.fn(),
     };
@@ -24,6 +24,9 @@ describe('FindUserByIdUseCase', () => {
     }).compile();
 
     useCase = module.get<FindUserByIdUseCase>(FindUserByIdUseCase);
+  });
+  beforeEach(() => {
+    jest.clearAllMocks();
   });
 
   it('should be defined', () => {

--- a/ayunis-core-backend/src/iam/users/application/use-cases/find-users-by-org-id/find-users-by-org-id.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/find-users-by-org-id/find-users-by-org-id.use-case.spec.ts
@@ -15,7 +15,7 @@ describe('FindUsersByOrgIdUseCase', () => {
   let mockUsersRepository: Partial<UsersRepository>;
   let mockContextService: any;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     mockUsersRepository = {
       findManyByOrgId: jest.fn(),
     };
@@ -35,11 +35,14 @@ describe('FindUsersByOrgIdUseCase', () => {
     useCase = module.get<FindUsersByOrgIdUseCase>(FindUsersByOrgIdUseCase);
 
     // Configure ContextService mock to return ADMIN role
-    mockContextService.get.mockImplementation((key: string) => {
+    mockContextService.get.mockImplementation((key: string): unknown => {
       if (key === 'systemRole') return SystemRole.SUPER_ADMIN;
       if (key === 'role') return UserRole.ADMIN;
       return null;
     });
+  });
+  beforeEach(() => {
+    jest.clearAllMocks();
   });
 
   it('should be defined', () => {

--- a/ayunis-core-backend/src/iam/users/application/use-cases/is-valid-password/is-valid-password.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/is-valid-password/is-valid-password.use-case.spec.ts
@@ -8,7 +8,7 @@ describe('IsValidPasswordUseCase', () => {
   let useCase: IsValidPasswordUseCase;
   let mockUsersRepository: Partial<UsersRepository>;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     mockUsersRepository = {
       isValidPassword: jest.fn(),
     };
@@ -21,6 +21,9 @@ describe('IsValidPasswordUseCase', () => {
     }).compile();
 
     useCase = module.get<IsValidPasswordUseCase>(IsValidPasswordUseCase);
+  });
+  beforeEach(() => {
+    jest.clearAllMocks();
   });
 
   it('should be defined', () => {

--- a/ayunis-core-backend/src/iam/users/application/use-cases/update-user-name/update-user-name.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/update-user-name/update-user-name.use-case.spec.ts
@@ -13,7 +13,7 @@ describe('UpdateUserNameUseCase', () => {
   let mockUsersRepository: Partial<UsersRepository>;
   let mockSendWebhookUseCase: Partial<SendWebhookUseCase>;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     mockUsersRepository = {
       findOneById: jest.fn(),
       update: jest.fn(),
@@ -31,6 +31,9 @@ describe('UpdateUserNameUseCase', () => {
     }).compile();
 
     useCase = module.get<UpdateUserNameUseCase>(UpdateUserNameUseCase);
+  });
+  beforeEach(() => {
+    jest.clearAllMocks();
   });
 
   it('should be defined', () => {

--- a/ayunis-core-backend/src/iam/users/application/use-cases/update-user-role/update-user-role.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/update-user-role/update-user-role.use-case.spec.ts
@@ -14,7 +14,7 @@ describe('UpdateUserRoleUseCase', () => {
   let mockUsersRepository: Partial<UsersRepository>;
   let mockSendWebhookUseCase: Partial<SendWebhookUseCase>;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     mockUsersRepository = {
       findOneById: jest.fn(),
       update: jest.fn(),
@@ -31,6 +31,9 @@ describe('UpdateUserRoleUseCase', () => {
     }).compile();
 
     useCase = module.get<UpdateUserRoleUseCase>(UpdateUserRoleUseCase);
+  });
+  beforeEach(() => {
+    jest.clearAllMocks();
   });
 
   it('should be defined', () => {

--- a/ayunis-core-backend/src/iam/users/application/use-cases/validate-user/validate-user.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/validate-user/validate-user.use-case.spec.ts
@@ -17,7 +17,7 @@ describe('ValidateUserUseCase', () => {
   let mockUsersRepository: Partial<UsersRepository>;
   let mockCompareHashUseCase: Partial<CompareHashUseCase>;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     mockUsersRepository = {
       findOneByEmail: jest.fn(),
     };
@@ -34,6 +34,9 @@ describe('ValidateUserUseCase', () => {
     }).compile();
 
     useCase = module.get<ValidateUserUseCase>(ValidateUserUseCase);
+  });
+  beforeEach(() => {
+    jest.clearAllMocks();
   });
 
   it('should be defined', () => {


### PR DESCRIPTION
- enable ts-jest isolatedModules for 3.8x faster transpilation
- scope collectCoverageFrom to exclude migrations, records, barrels
- split CI into parallel lint-and-typecheck + test jobs
- add jest --shard=N/3 matrix strategy for parallel test execution
- remove redundant npm run build step from CI
- move createTestingModule from beforeEach to beforeAll in 89 spec files
- add jest.clearAllMocks() in beforeEach to reset mock state
- fix pre-existing eslint warnings in touched spec files

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily CI and test-harness changes; production code paths are unchanged, with main risk being missed regressions if sharded tests or coverage settings behave differently in CI.
> 
> **Overview**
> Speeds up backend CI by splitting checks into a separate `lint-and-typecheck` job and running Jest unit tests in a 3-way shard matrix (and removing the redundant `npm run build`/coverage artifact upload from the test workflow).
> 
> Optimizes the Jest setup by enabling `ts-jest` `isolatedModules` and narrowing `collectCoverageFrom` exclusions, plus refactoring many spec files to build Nest testing modules once (`beforeAll`) and reset mocks per-test (`jest.clearAllMocks()`), with a few minor test cleanups (e.g., URL/`??` defaulting tweaks).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f8612bf6126347cae833403f948d1109b0cae045. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->