### PR TITLE
wip(AYC-92): add knowledge bases list page and sidebar entry

### DIFF
--- a/ayunis-core-frontend/src/app/routeTree.gen.ts
+++ b/ayunis-core-frontend/src/app/routeTree.gen.ts
@@ -23,6 +23,7 @@ import { Route as AuthenticatedSuperAdminSettingsIndexImport } from './routes/_a
 import { Route as AuthenticatedSkillsIndexImport } from './routes/_authenticated/skills.index'
 import { Route as AuthenticatedSettingsIndexImport } from './routes/_authenticated/settings.index'
 import { Route as AuthenticatedPromptsIndexImport } from './routes/_authenticated/prompts.index'
+import { Route as AuthenticatedKnowledgeBasesIndexImport } from './routes/_authenticated/knowledge-bases.index'
 import { Route as AuthenticatedChatsIndexImport } from './routes/_authenticated/chats.index'
 import { Route as AuthenticatedChatIndexImport } from './routes/_authenticated/chat.index'
 import { Route as AuthenticatedAgentsIndexImport } from './routes/_authenticated/agents.index'
@@ -121,6 +122,13 @@ const AuthenticatedPromptsIndexRoute = AuthenticatedPromptsIndexImport.update({
   path: '/prompts/',
   getParentRoute: () => AuthenticatedRoute,
 } as any)
+
+const AuthenticatedKnowledgeBasesIndexRoute =
+  AuthenticatedKnowledgeBasesIndexImport.update({
+    id: '/knowledge-bases/',
+    path: '/knowledge-bases/',
+    getParentRoute: () => AuthenticatedRoute,
+  } as any)
 
 const AuthenticatedChatsIndexRoute = AuthenticatedChatsIndexImport.update({
   id: '/chats/',
@@ -441,6 +449,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedChatsIndexImport
       parentRoute: typeof AuthenticatedImport
     }
+    '/_authenticated/knowledge-bases/': {
+      id: '/_authenticated/knowledge-bases/'
+      path: '/knowledge-bases'
+      fullPath: '/knowledge-bases'
+      preLoaderRoute: typeof AuthenticatedKnowledgeBasesIndexImport
+      parentRoute: typeof AuthenticatedImport
+    }
     '/_authenticated/prompts/': {
       id: '/_authenticated/prompts/'
       path: '/prompts'
@@ -532,6 +547,7 @@ interface AuthenticatedRouteChildren {
   AuthenticatedAgentsIndexRoute: typeof AuthenticatedAgentsIndexRoute
   AuthenticatedChatIndexRoute: typeof AuthenticatedChatIndexRoute
   AuthenticatedChatsIndexRoute: typeof AuthenticatedChatsIndexRoute
+  AuthenticatedKnowledgeBasesIndexRoute: typeof AuthenticatedKnowledgeBasesIndexRoute
   AuthenticatedPromptsIndexRoute: typeof AuthenticatedPromptsIndexRoute
   AuthenticatedSettingsIndexRoute: typeof AuthenticatedSettingsIndexRoute
   AuthenticatedSkillsIndexRoute: typeof AuthenticatedSkillsIndexRoute
@@ -561,6 +577,7 @@ const AuthenticatedRouteChildren: AuthenticatedRouteChildren = {
   AuthenticatedAgentsIndexRoute: AuthenticatedAgentsIndexRoute,
   AuthenticatedChatIndexRoute: AuthenticatedChatIndexRoute,
   AuthenticatedChatsIndexRoute: AuthenticatedChatsIndexRoute,
+  AuthenticatedKnowledgeBasesIndexRoute: AuthenticatedKnowledgeBasesIndexRoute,
   AuthenticatedPromptsIndexRoute: AuthenticatedPromptsIndexRoute,
   AuthenticatedSettingsIndexRoute: AuthenticatedSettingsIndexRoute,
   AuthenticatedSkillsIndexRoute: AuthenticatedSkillsIndexRoute,
@@ -609,6 +626,7 @@ export interface FileRoutesByFullPath {
   '/agents': typeof AuthenticatedAgentsIndexRoute
   '/chat': typeof AuthenticatedChatIndexRoute
   '/chats': typeof AuthenticatedChatsIndexRoute
+  '/knowledge-bases': typeof AuthenticatedKnowledgeBasesIndexRoute
   '/prompts': typeof AuthenticatedPromptsIndexRoute
   '/settings': typeof AuthenticatedSettingsIndexRoute
   '/skills': typeof AuthenticatedSkillsIndexRoute
@@ -646,6 +664,7 @@ export interface FileRoutesByTo {
   '/agents': typeof AuthenticatedAgentsIndexRoute
   '/chat': typeof AuthenticatedChatIndexRoute
   '/chats': typeof AuthenticatedChatsIndexRoute
+  '/knowledge-bases': typeof AuthenticatedKnowledgeBasesIndexRoute
   '/prompts': typeof AuthenticatedPromptsIndexRoute
   '/settings': typeof AuthenticatedSettingsIndexRoute
   '/skills': typeof AuthenticatedSkillsIndexRoute
@@ -684,6 +703,7 @@ export interface FileRoutesById {
   '/_authenticated/agents/': typeof AuthenticatedAgentsIndexRoute
   '/_authenticated/chat/': typeof AuthenticatedChatIndexRoute
   '/_authenticated/chats/': typeof AuthenticatedChatsIndexRoute
+  '/_authenticated/knowledge-bases/': typeof AuthenticatedKnowledgeBasesIndexRoute
   '/_authenticated/prompts/': typeof AuthenticatedPromptsIndexRoute
   '/_authenticated/settings/': typeof AuthenticatedSettingsIndexRoute
   '/_authenticated/skills/': typeof AuthenticatedSkillsIndexRoute
@@ -723,6 +743,7 @@ export interface FileRouteTypes {
     | '/agents'
     | '/chat'
     | '/chats'
+    | '/knowledge-bases'
     | '/prompts'
     | '/settings'
     | '/skills'
@@ -759,6 +780,7 @@ export interface FileRouteTypes {
     | '/agents'
     | '/chat'
     | '/chats'
+    | '/knowledge-bases'
     | '/prompts'
     | '/settings'
     | '/skills'
@@ -795,6 +817,7 @@ export interface FileRouteTypes {
     | '/_authenticated/agents/'
     | '/_authenticated/chat/'
     | '/_authenticated/chats/'
+    | '/_authenticated/knowledge-bases/'
     | '/_authenticated/prompts/'
     | '/_authenticated/settings/'
     | '/_authenticated/skills/'
@@ -874,6 +897,7 @@ export const routeTree = rootRoute
         "/_authenticated/agents/",
         "/_authenticated/chat/",
         "/_authenticated/chats/",
+        "/_authenticated/knowledge-bases/",
         "/_authenticated/prompts/",
         "/_authenticated/settings/",
         "/_authenticated/skills/",
@@ -965,6 +989,10 @@ export const routeTree = rootRoute
     },
     "/_authenticated/chats/": {
       "filePath": "_authenticated/chats.index.tsx",
+      "parent": "/_authenticated"
+    },
+    "/_authenticated/knowledge-bases/": {
+      "filePath": "_authenticated/knowledge-bases.index.tsx",
       "parent": "/_authenticated"
     },
     "/_authenticated/prompts/": {

--- a/ayunis-core-frontend/src/app/routes/_authenticated/knowledge-bases.index.tsx
+++ b/ayunis-core-frontend/src/app/routes/_authenticated/knowledge-bases.index.tsx
@@ -1,0 +1,22 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { KnowledgeBasesPage } from '@/pages/knowledge-bases';
+import {
+  knowledgeBasesControllerFindAll,
+  getKnowledgeBasesControllerFindAllQueryKey,
+} from '@/shared/api/generated/ayunisCoreAPI';
+
+export const Route = createFileRoute('/_authenticated/knowledge-bases/')({
+  component: RouteComponent,
+  loader: async ({ context: { queryClient } }) => {
+    const knowledgeBases = await queryClient.fetchQuery({
+      queryKey: getKnowledgeBasesControllerFindAllQueryKey(),
+      queryFn: () => knowledgeBasesControllerFindAll(),
+    });
+    return { knowledgeBases };
+  },
+});
+
+function RouteComponent() {
+  const { knowledgeBases } = Route.useLoaderData();
+  return <KnowledgeBasesPage knowledgeBases={knowledgeBases.data} />;
+}

--- a/ayunis-core-frontend/src/i18n.ts
+++ b/ayunis-core-frontend/src/i18n.ts
@@ -44,6 +44,8 @@ import enSkills from './shared/locales/en/skills.json';
 import deSkills from './shared/locales/de/skills.json';
 import enSkill from './shared/locales/en/skill.json';
 import deSkill from './shared/locales/de/skill.json';
+import enKnowledgeBases from './shared/locales/en/knowledge-bases.json';
+import deKnowledgeBases from './shared/locales/de/knowledge-bases.json';
 
 const resources = {
   en: {
@@ -68,6 +70,7 @@ const resources = {
     'install-integration': enInstallIntegration,
     skills: enSkills,
     skill: enSkill,
+    'knowledge-bases': enKnowledgeBases,
   },
   de: {
     auth: deAuth,
@@ -91,6 +94,7 @@ const resources = {
     'install-integration': deInstallIntegration,
     skills: deSkills,
     skill: deSkill,
+    'knowledge-bases': deKnowledgeBases,
   },
 };
 

--- a/ayunis-core-frontend/src/pages/knowledge-bases/api/useCreateKnowledgeBase.ts
+++ b/ayunis-core-frontend/src/pages/knowledge-bases/api/useCreateKnowledgeBase.ts
@@ -1,0 +1,78 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import * as z from 'zod';
+import { useTranslation } from 'react-i18next';
+import {
+  knowledgeBasesControllerCreate,
+  getKnowledgeBasesControllerFindAllQueryKey,
+} from '@/shared/api/generated/ayunisCoreAPI';
+import { useRouter } from '@tanstack/react-router';
+import { showError, showSuccess } from '@/shared/lib/toast';
+
+export type CreateKnowledgeBaseData = {
+  name: string;
+  description?: string;
+};
+
+interface UseCreateKnowledgeBaseOptions {
+  onClose?: () => void;
+}
+
+export function useCreateKnowledgeBase({
+  onClose,
+}: UseCreateKnowledgeBaseOptions = {}) {
+  const { t } = useTranslation('knowledge-bases');
+  const queryClient = useQueryClient();
+  const router = useRouter();
+
+  const createKnowledgeBaseSchema = z.object({
+    name: z.string().min(1, t('createDialog.validation.nameRequired')).max(255),
+    description: z.string().max(2000).optional(),
+  });
+
+  const form = useForm<CreateKnowledgeBaseData>({
+    resolver: zodResolver(createKnowledgeBaseSchema),
+    defaultValues: {
+      name: '',
+      description: '',
+    },
+  });
+
+  const mutation = useMutation({
+    mutationFn: async (data: CreateKnowledgeBaseData) => {
+      return await knowledgeBasesControllerCreate({
+        name: data.name,
+        description: data.description ?? '',
+      });
+    },
+    onSuccess: () => {
+      showSuccess(t('create.success'));
+      onClose?.();
+    },
+    onError: () => {
+      showError(t('create.error'));
+    },
+    onSettled: () => {
+      void queryClient.invalidateQueries({
+        queryKey: getKnowledgeBasesControllerFindAllQueryKey(),
+      });
+      void router.invalidate();
+    },
+  });
+
+  const onSubmit = (data: CreateKnowledgeBaseData) => {
+    mutation.mutate(data);
+  };
+
+  const resetForm = () => {
+    form.reset();
+  };
+
+  return {
+    form,
+    onSubmit,
+    resetForm,
+    isLoading: mutation.isPending,
+  };
+}

--- a/ayunis-core-frontend/src/pages/knowledge-bases/api/useDeleteKnowledgeBase.ts
+++ b/ayunis-core-frontend/src/pages/knowledge-bases/api/useDeleteKnowledgeBase.ts
@@ -1,0 +1,44 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useTranslation } from 'react-i18next';
+import { showSuccess, showError } from '@/shared/lib/toast';
+import {
+  knowledgeBasesControllerDelete,
+  getKnowledgeBasesControllerFindAllQueryKey,
+} from '@/shared/api/generated/ayunisCoreAPI';
+import { useRouter } from '@tanstack/react-router';
+import extractErrorData from '@/shared/api/extract-error-data';
+
+interface DeleteKnowledgeBaseParams {
+  id: string;
+}
+
+export function useDeleteKnowledgeBase() {
+  const { t } = useTranslation('knowledge-bases');
+  const queryClient = useQueryClient();
+  const router = useRouter();
+
+  return useMutation({
+    mutationFn: async ({ id }: DeleteKnowledgeBaseParams) => {
+      await knowledgeBasesControllerDelete(id);
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
+        queryKey: getKnowledgeBasesControllerFindAllQueryKey(),
+      });
+      void router.invalidate();
+      showSuccess(t('delete.success'));
+    },
+    onError: (error) => {
+      try {
+        const { code } = extractErrorData(error);
+        if (code === 'KNOWLEDGE_BASE_NOT_FOUND') {
+          showError(t('delete.notFound'));
+        } else {
+          showError(t('delete.error'));
+        }
+      } catch {
+        showError(t('delete.error'));
+      }
+    },
+  });
+}

--- a/ayunis-core-frontend/src/pages/knowledge-bases/index.ts
+++ b/ayunis-core-frontend/src/pages/knowledge-bases/index.ts
@@ -1,0 +1,1 @@
+export { default as KnowledgeBasesPage } from './ui/KnowledgeBasesPage';

--- a/ayunis-core-frontend/src/pages/knowledge-bases/model/openapi.ts
+++ b/ayunis-core-frontend/src/pages/knowledge-bases/model/openapi.ts
@@ -1,0 +1,3 @@
+import type { KnowledgeBaseResponseDto } from '@/shared/api/generated/ayunisCoreAPI.schemas';
+
+export type KnowledgeBase = KnowledgeBaseResponseDto;

--- a/ayunis-core-frontend/src/pages/knowledge-bases/ui/CreateKnowledgeBaseDialog.tsx
+++ b/ayunis-core-frontend/src/pages/knowledge-bases/ui/CreateKnowledgeBaseDialog.tsx
@@ -1,0 +1,60 @@
+import { useState } from 'react';
+import { Form } from '@/shared/ui/shadcn/form';
+import { useCreateKnowledgeBase } from '../api/useCreateKnowledgeBase';
+import {
+  CreateEntityDialog,
+  useCreateDialogTranslations,
+} from '@/widgets/create-entity-dialog';
+import { NameField, ShortDescriptionField } from '@/widgets/entity-form-fields';
+
+interface CreateKnowledgeBaseDialogProps {
+  buttonText?: string;
+  showIcon?: boolean;
+  buttonClassName?: string;
+}
+
+export default function CreateKnowledgeBaseDialog({
+  buttonText,
+  showIcon = false,
+  buttonClassName = '',
+}: Readonly<CreateKnowledgeBaseDialogProps>) {
+  const translations = useCreateDialogTranslations('knowledge-bases');
+  const [isOpen, setIsOpen] = useState(false);
+  const handleClose = () => {
+    resetForm();
+    setIsOpen(false);
+  };
+
+  const { form, onSubmit, resetForm, isLoading } = useCreateKnowledgeBase({
+    onClose: handleClose,
+  });
+
+  return (
+    <CreateEntityDialog
+      isOpen={isOpen}
+      onOpenChange={setIsOpen}
+      onCancel={handleClose}
+      onSubmit={(e) => void form.handleSubmit(onSubmit)(e)}
+      isLoading={isLoading}
+      translations={translations}
+      buttonText={buttonText}
+      showIcon={showIcon}
+      buttonClassName={buttonClassName}
+    >
+      <Form {...form}>
+        <div className="space-y-6">
+          <NameField
+            control={form.control}
+            name="name"
+            translationNamespace="knowledge-bases"
+          />
+          <ShortDescriptionField
+            control={form.control}
+            name="description"
+            translationNamespace="knowledge-bases"
+          />
+        </div>
+      </Form>
+    </CreateEntityDialog>
+  );
+}

--- a/ayunis-core-frontend/src/pages/knowledge-bases/ui/KnowledgeBaseCard.tsx
+++ b/ayunis-core-frontend/src/pages/knowledge-bases/ui/KnowledgeBaseCard.tsx
@@ -1,0 +1,66 @@
+import { Button } from '@/shared/ui/shadcn/button';
+import { Trash2 } from 'lucide-react';
+import { useDeleteKnowledgeBase } from '../api/useDeleteKnowledgeBase';
+import { useConfirmation } from '@/widgets/confirmation-modal';
+import { useTranslation } from 'react-i18next';
+import type { KnowledgeBase } from '../model/openapi';
+import {
+  Item,
+  ItemActions,
+  ItemContent,
+  ItemDescription,
+  ItemTitle,
+} from '@/shared/ui/shadcn/item';
+
+interface KnowledgeBaseCardProps {
+  knowledgeBase: KnowledgeBase;
+}
+
+export default function KnowledgeBaseCard({
+  knowledgeBase,
+}: Readonly<KnowledgeBaseCardProps>) {
+  const { t } = useTranslation('knowledge-bases');
+  const deleteKnowledgeBase = useDeleteKnowledgeBase();
+  const { confirm } = useConfirmation();
+
+  function handleDelete() {
+    confirm({
+      title: t('card.confirmDelete.title'),
+      description: t('card.confirmDelete.description', {
+        title: knowledgeBase.name,
+      }),
+      confirmText: t('card.confirmDelete.confirmText'),
+      cancelText: t('card.confirmDelete.cancelText'),
+      variant: 'destructive',
+      onConfirm: () => {
+        deleteKnowledgeBase.mutate({ id: knowledgeBase.id });
+      },
+    });
+  }
+
+  return (
+    <Item variant="outline">
+      <ItemContent>
+        <ItemTitle>
+          <span>{knowledgeBase.name}</span>
+        </ItemTitle>
+        {knowledgeBase.description && (
+          <ItemDescription>{knowledgeBase.description}</ItemDescription>
+        )}
+      </ItemContent>
+      <ItemActions>
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={(e) => {
+            e.stopPropagation();
+            handleDelete();
+          }}
+          disabled={deleteKnowledgeBase.isPending}
+        >
+          <Trash2 className="h-4 w-4" />
+        </Button>
+      </ItemActions>
+    </Item>
+  );
+}

--- a/ayunis-core-frontend/src/pages/knowledge-bases/ui/KnowledgeBasesEmptyState.tsx
+++ b/ayunis-core-frontend/src/pages/knowledge-bases/ui/KnowledgeBasesEmptyState.tsx
@@ -1,0 +1,20 @@
+import CreateKnowledgeBaseDialog from './CreateKnowledgeBaseDialog';
+import { useTranslation } from 'react-i18next';
+import { EmptyState } from '@/widgets/empty-state';
+
+export default function KnowledgeBasesEmptyState() {
+  const { t } = useTranslation('knowledge-bases');
+
+  return (
+    <EmptyState
+      title={t('emptyState.title')}
+      description={t('emptyState.description')}
+      action={
+        <CreateKnowledgeBaseDialog
+          buttonText={t('createDialog.buttonTextFirst')}
+          showIcon={true}
+        />
+      }
+    />
+  );
+}

--- a/ayunis-core-frontend/src/pages/knowledge-bases/ui/KnowledgeBasesPage.tsx
+++ b/ayunis-core-frontend/src/pages/knowledge-bases/ui/KnowledgeBasesPage.tsx
@@ -1,0 +1,60 @@
+import AppLayout from '@/layouts/app-layout';
+import ContentAreaLayout from '@/layouts/content-area-layout/ui/ContentAreaLayout';
+import ContentAreaHeader from '@/widgets/content-area-header/ui/ContentAreaHeader';
+import CreateKnowledgeBaseDialog from './CreateKnowledgeBaseDialog';
+import KnowledgeBaseCard from './KnowledgeBaseCard';
+import KnowledgeBasesEmptyState from './KnowledgeBasesEmptyState';
+import FullScreenMessageLayout from '@/layouts/full-screen-message-layout/ui/FullScreenMessageLayout';
+import type { KnowledgeBase } from '../model/openapi';
+import { useTranslation } from 'react-i18next';
+
+interface KnowledgeBasesPageProps {
+  knowledgeBases: KnowledgeBase[];
+}
+
+export default function KnowledgeBasesPage({
+  knowledgeBases,
+}: Readonly<KnowledgeBasesPageProps>) {
+  const { t } = useTranslation('knowledge-bases');
+
+  if (knowledgeBases.length === 0) {
+    return (
+      <AppLayout>
+        <FullScreenMessageLayout
+          header={
+            <ContentAreaHeader
+              title={t('page.title')}
+              action={<CreateKnowledgeBaseDialog />}
+            />
+          }
+        >
+          <KnowledgeBasesEmptyState />
+        </FullScreenMessageLayout>
+      </AppLayout>
+    );
+  }
+
+  const sortedKnowledgeBases = [...knowledgeBases].sort((a, b) =>
+    a.name.localeCompare(b.name),
+  );
+
+  return (
+    <AppLayout>
+      <ContentAreaLayout
+        contentHeader={
+          <ContentAreaHeader
+            title={t('page.title')}
+            action={<CreateKnowledgeBaseDialog />}
+          />
+        }
+        contentArea={
+          <div className="space-y-3">
+            {sortedKnowledgeBases.map((kb) => (
+              <KnowledgeBaseCard key={kb.id} knowledgeBase={kb} />
+            ))}
+          </div>
+        }
+      />
+    </AppLayout>
+  );
+}

--- a/ayunis-core-frontend/src/shared/locales/de/common.json
+++ b/ayunis-core-frontend/src/shared/locales/de/common.json
@@ -6,6 +6,7 @@
     "prompts": "Prompts",
     "agents": "Agenten",
     "skills": "Fähigkeiten",
+    "knowledge": "Wissen",
     "accountSettings": "Konto-Einstellungen",
     "adminSettings": "Admin-Einstellungen",
     "superAdminSettings": "Super Admin-Einstellungen",

--- a/ayunis-core-frontend/src/shared/locales/de/knowledge-bases.json
+++ b/ayunis-core-frontend/src/shared/locales/de/knowledge-bases.json
@@ -1,0 +1,46 @@
+{
+  "page": {
+    "title": "Meine Wissenssammlungen"
+  },
+  "emptyState": {
+    "title": "Noch keine Wissenssammlungen",
+    "description": "Erstellen Sie Ihre erste Wissenssammlung. Laden Sie Dokumente hoch und nutzen Sie sie in Ihren Chats als Kontext für die KI."
+  },
+  "card": {
+    "confirmDelete": {
+      "title": "Wissenssammlung löschen",
+      "description": "Sind Sie sicher, dass Sie \"{{title}}\" löschen möchten? Alle zugehörigen Dokumente werden ebenfalls gelöscht. Diese Aktion kann nicht rückgängig gemacht werden.",
+      "confirmText": "Löschen",
+      "cancelText": "Abbrechen"
+    }
+  },
+  "createDialog": {
+    "buttonText": "Wissenssammlung hinzufügen",
+    "buttonTextFirst": "Erstellen Sie Ihre erste Wissenssammlung",
+    "title": "Neue Wissenssammlung erstellen",
+    "description": "Erstellen Sie eine neue Wissenssammlung, um Dokumente zu organisieren und in Chats zu nutzen.",
+    "form": {
+      "nameLabel": "Name",
+      "namePlaceholder": "Name der Wissenssammlung eingeben...",
+      "shortDescriptionLabel": "Beschreibung",
+      "shortDescriptionPlaceholder": "Optionale Beschreibung eingeben..."
+    },
+    "validation": {
+      "nameRequired": "Name ist erforderlich"
+    },
+    "buttons": {
+      "cancel": "Abbrechen",
+      "create": "Erstellen",
+      "creating": "Wird erstellt..."
+    }
+  },
+  "create": {
+    "success": "Wissenssammlung erfolgreich erstellt!",
+    "error": "Wissenssammlung konnte nicht erstellt werden. Bitte versuchen Sie es erneut."
+  },
+  "delete": {
+    "success": "Wissenssammlung erfolgreich gelöscht!",
+    "error": "Wissenssammlung konnte nicht gelöscht werden. Bitte versuchen Sie es erneut.",
+    "notFound": "Wissenssammlung nicht gefunden. Sie wurde möglicherweise gelöscht."
+  }
+}

--- a/ayunis-core-frontend/src/shared/locales/en/common.json
+++ b/ayunis-core-frontend/src/shared/locales/en/common.json
@@ -6,6 +6,7 @@
     "prompts": "Prompts",
     "agents": "Agents",
     "skills": "Skills",
+    "knowledge": "Knowledge",
     "accountSettings": "Account Settings",
     "adminSettings": "Admin Settings",
     "superAdminSettings": "Super Admin Settings",

--- a/ayunis-core-frontend/src/shared/locales/en/knowledge-bases.json
+++ b/ayunis-core-frontend/src/shared/locales/en/knowledge-bases.json
@@ -1,0 +1,46 @@
+{
+  "page": {
+    "title": "My Knowledge Bases"
+  },
+  "emptyState": {
+    "title": "No knowledge bases yet",
+    "description": "Create your first knowledge base. Upload documents and use them in your chats as context for the AI."
+  },
+  "card": {
+    "confirmDelete": {
+      "title": "Delete Knowledge Base",
+      "description": "Are you sure you want to delete \"{{title}}\"? All associated documents will also be deleted. This action cannot be undone.",
+      "confirmText": "Delete",
+      "cancelText": "Cancel"
+    }
+  },
+  "createDialog": {
+    "buttonText": "Add Knowledge Base",
+    "buttonTextFirst": "Create your first knowledge base",
+    "title": "Create New Knowledge Base",
+    "description": "Create a new knowledge base to organize documents and use them in chats.",
+    "form": {
+      "nameLabel": "Name",
+      "namePlaceholder": "Enter knowledge base name...",
+      "shortDescriptionLabel": "Description",
+      "shortDescriptionPlaceholder": "Enter an optional description..."
+    },
+    "validation": {
+      "nameRequired": "Name is required"
+    },
+    "buttons": {
+      "cancel": "Cancel",
+      "create": "Create",
+      "creating": "Creating..."
+    }
+  },
+  "create": {
+    "success": "Knowledge base created successfully!",
+    "error": "Failed to create knowledge base. Please try again."
+  },
+  "delete": {
+    "success": "Knowledge base deleted successfully!",
+    "error": "Failed to delete knowledge base. Please try again.",
+    "notFound": "Knowledge base not found. It may have been deleted."
+  }
+}

--- a/ayunis-core-frontend/src/widgets/app-sidebar/ui/AppSidebar.tsx
+++ b/ayunis-core-frontend/src/widgets/app-sidebar/ui/AppSidebar.tsx
@@ -7,6 +7,7 @@ import {
   LogOut,
   Plus,
   Bot,
+  Brain,
   Sparkles,
 } from 'lucide-react';
 
@@ -72,6 +73,11 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
       title: t('sidebar.agents'),
       url: '/agents',
       icon: Bot,
+    },
+    {
+      title: t('sidebar.knowledge'),
+      url: '/knowledge-bases',
+      icon: Brain,
     },
     ...(!cloudStatus?.isCloud
       ? [


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds new route + data mutations (create/delete) that can affect user data and cache consistency if API contracts or query invalidation are wrong; otherwise changes are localized to the new feature area.
> 
> **Overview**
> Adds a new authenticated `/_authenticated/knowledge-bases/` route (wired into the generated `routeTree`) that preloads knowledge bases via React Query and renders a new `KnowledgeBasesPage`.
> 
> Introduces a Knowledge Bases list UI with empty state plus create and delete flows: a create dialog backed by a `useCreateKnowledgeBase` mutation (form validation, success/error toasts, query invalidation) and card-level delete with confirmation and error-code-aware messaging.
> 
> Updates navigation and localization by adding a sidebar entry (new Brain icon) linking to `/knowledge-bases`, registering the `knowledge-bases` i18n namespace, and adding EN/DE translation files plus a new `common.sidebar.knowledge` label.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 97223e1be20c466d02122786d0916a4df2b6ad8e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->