### PR TITLE
fix(AYC-000): increase max tokens for anthropic, bedrock, and mistral handlers

### DIFF
--- a/ayunis-core-backend/src/domain/models/infrastructure/stream-inference/base-anthropic.stream-inference.ts
+++ b/ayunis-core-backend/src/domain/models/infrastructure/stream-inference/base-anthropic.stream-inference.ts
@@ -64,7 +64,7 @@ export abstract class BaseAnthropicStreamInferenceHandler
         messages: anthropicMessages,
         tools: anthropicTools,
         tool_choice: anthropicToolChoice,
-        max_tokens: 10000,
+        max_tokens: 100000,
         stream: true,
       };
 

--- a/ayunis-core-backend/src/domain/models/infrastructure/stream-inference/base-anthropic.stream-inference.ts
+++ b/ayunis-core-backend/src/domain/models/infrastructure/stream-inference/base-anthropic.stream-inference.ts
@@ -64,7 +64,7 @@ export abstract class BaseAnthropicStreamInferenceHandler
         messages: anthropicMessages,
         tools: anthropicTools,
         tool_choice: anthropicToolChoice,
-        max_tokens: 100000,
+        max_tokens: 64000,
         stream: true,
       };
 

--- a/ayunis-core-backend/src/domain/models/infrastructure/stream-inference/bedrock.stream-inference.ts
+++ b/ayunis-core-backend/src/domain/models/infrastructure/stream-inference/bedrock.stream-inference.ts
@@ -177,7 +177,7 @@ export class BedrockStreamInferenceHandler implements StreamInferenceHandler {
 
     const requestBody: BedrockAnthropicRequest = {
       anthropic_version: 'bedrock-2023-05-31',
-      max_tokens: 4096,
+      max_tokens: 100000,
       system: systemPrompt,
       messages: anthropicMessages,
       tools: anthropicTools,

--- a/ayunis-core-backend/src/domain/models/infrastructure/stream-inference/bedrock.stream-inference.ts
+++ b/ayunis-core-backend/src/domain/models/infrastructure/stream-inference/bedrock.stream-inference.ts
@@ -177,7 +177,7 @@ export class BedrockStreamInferenceHandler implements StreamInferenceHandler {
 
     const requestBody: BedrockAnthropicRequest = {
       anthropic_version: 'bedrock-2023-05-31',
-      max_tokens: 100000,
+      max_tokens: 64000,
       system: systemPrompt,
       messages: anthropicMessages,
       tools: anthropicTools,

--- a/ayunis-core-backend/src/domain/models/infrastructure/stream-inference/mistral.stream-inference.ts
+++ b/ayunis-core-backend/src/domain/models/infrastructure/stream-inference/mistral.stream-inference.ts
@@ -65,7 +65,7 @@ export class MistralStreamInferenceHandler implements StreamInferenceHandler {
           : mistralMessages,
         tools: mistralTools,
         toolChoice: mistralToolChoice,
-        maxTokens: 10000,
+        maxTokens: 100000,
         stream: true,
       };
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Larger token limits can significantly increase latency and provider spend, and may surface provider-side limit/timeout issues; otherwise the change is a simple parameter bump.
> 
> **Overview**
> Increases the maximum output token limits for streaming inference requests across providers to support much longer generations.
> 
> Specifically raises `max_tokens` for Anthropic and Bedrock Anthropic requests to `64000`, and raises Mistral streaming `maxTokens` to `100000`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 87e22db0929cf8ed119cbcb38176172256408f27. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->