### PR TITLE
wip(AYC-94): auto-install pre-installed marketplace skills on user creation

### DIFF
--- a/ayunis-core-backend/src/common/emails/infrastructure/handlers/smpt.handler.ts
+++ b/ayunis-core-backend/src/common/emails/infrastructure/handlers/smpt.handler.ts
@@ -9,14 +9,14 @@ export class SmptHandler implements EmailHandlerPort {
   private readonly transporter: Transporter;
 
   constructor(configService: ConfigService) {
+    const user = configService.get<string>('emails.smtp.user');
+    const pass = configService.get<string>('emails.smtp.password');
+
     this.transporter = nodemailer.createTransport({
       host: configService.get<string>('emails.smtp.host'),
       port: configService.get<number>('emails.smtp.port'),
       secure: configService.get<boolean>('emails.smtp.secure'),
-      auth: {
-        user: configService.get<string>('emails.smtp.user'),
-        pass: configService.get<string>('emails.smtp.password'),
-      },
+      ...(user && pass ? { auth: { user, pass } } : {}),
       requireTLS: configService.get<boolean>('emails.smtp.requireTLS'),
     });
   }

--- a/ayunis-core-backend/src/domain/marketplace/SUMMARY.md
+++ b/ayunis-core-backend/src/domain/marketplace/SUMMARY.md
@@ -7,7 +7,7 @@ The marketplace module provides integration with the external Ayunis Marketplace
 - `GetMarketplaceSkillUseCase` — Fetches skill details from the marketplace by identifier
 
 **Ports:**
-- `MarketplaceClient` — Abstract port for marketplace API communication
+- `MarketplaceClient` — Abstract port for marketplace API communication (`getSkillByIdentifier`, `getPreInstalledSkills`)
 
 **Infrastructure:**
 - `MarketplaceHttpClient` — HTTP client implementation using the generated marketplace API client
@@ -26,4 +26,4 @@ The marketplace module provides integration with the external Ayunis Marketplace
 - Uses the generated marketplace API client from `src/common/clients/marketplace/`
 
 **Dependent Modules:**
-- **skills** — Uses `GetMarketplaceSkillUseCase` for installing marketplace skills via `InstallSkillFromMarketplaceUseCase`
+- **skills** — Uses `GetMarketplaceSkillUseCase` for installing marketplace skills via `InstallSkillFromMarketplaceUseCase`; `MarketplaceSkillInstallationService` consumes `MarketplaceClient.getPreInstalledSkills()` for pre-installed skill provisioning

--- a/ayunis-core-backend/src/domain/marketplace/application/ports/marketplace-client.port.ts
+++ b/ayunis-core-backend/src/domain/marketplace/application/ports/marketplace-client.port.ts
@@ -1,7 +1,12 @@
-import type { SkillResponseDto } from 'src/common/clients/marketplace/generated/ayunisMarketplaceAPI.schemas';
+import type {
+  SkillListResponseDto,
+  SkillResponseDto,
+} from 'src/common/clients/marketplace/generated/ayunisMarketplaceAPI.schemas';
 
 export abstract class MarketplaceClient {
   abstract getSkillByIdentifier(
     identifier: string,
   ): Promise<SkillResponseDto | null>;
+
+  abstract getPreInstalledSkills(): Promise<SkillListResponseDto[]>;
 }

--- a/ayunis-core-backend/src/domain/marketplace/application/use-cases/get-marketplace-skill/get-marketplace-skill.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/marketplace/application/use-cases/get-marketplace-skill/get-marketplace-skill.use-case.spec.ts
@@ -32,6 +32,7 @@ describe('GetMarketplaceSkillUseCase', () => {
   beforeEach(() => {
     marketplaceClient = {
       getSkillByIdentifier: jest.fn(),
+      getPreInstalledSkills: jest.fn(),
     } as jest.Mocked<MarketplaceClient>;
 
     useCase = new GetMarketplaceSkillUseCase(marketplaceClient);

--- a/ayunis-core-backend/src/domain/marketplace/infrastructure/http/marketplace-http-client.ts
+++ b/ayunis-core-backend/src/domain/marketplace/infrastructure/http/marketplace-http-client.ts
@@ -1,7 +1,10 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { MarketplaceClient } from '../../application/ports/marketplace-client.port';
 import { getAyunisMarketplaceAPI } from 'src/common/clients/marketplace/generated/ayunisMarketplaceAPI';
-import { SkillResponseDto } from 'src/common/clients/marketplace/generated/ayunisMarketplaceAPI.schemas';
+import {
+  SkillListResponseDto,
+  SkillResponseDto,
+} from 'src/common/clients/marketplace/generated/ayunisMarketplaceAPI.schemas';
 import { MarketplaceHttpError } from 'src/common/clients/marketplace/client';
 
 @Injectable()
@@ -21,6 +24,19 @@ export class MarketplaceHttpClient extends MarketplaceClient {
       }
       this.logger.warn('Failed to fetch marketplace skill', {
         identifier,
+        error: error instanceof Error ? error.message : 'Unknown error',
+        status:
+          error instanceof MarketplaceHttpError ? error.status : undefined,
+      });
+      throw error;
+    }
+  }
+
+  async getPreInstalledSkills(): Promise<SkillListResponseDto[]> {
+    try {
+      return await this.api.publicSkillsControllerListPreInstalled();
+    } catch (error) {
+      this.logger.warn('Failed to fetch pre-installed marketplace skills', {
         error: error instanceof Error ? error.message : 'Unknown error',
         status:
           error instanceof MarketplaceHttpError ? error.status : undefined,

--- a/ayunis-core-backend/src/domain/skills/application/listeners/user-created.listener.spec.ts
+++ b/ayunis-core-backend/src/domain/skills/application/listeners/user-created.listener.spec.ts
@@ -1,0 +1,42 @@
+import { UserCreatedListener } from './user-created.listener';
+import { UserCreatedEvent } from 'src/iam/users/application/events/user-created.event';
+import type { MarketplaceSkillInstallationService } from '../services/marketplace-skill-installation.service';
+import type { UUID } from 'crypto';
+
+const USER_ID = '00000000-0000-0000-0000-000000000001' as UUID;
+const ORG_ID = '00000000-0000-0000-0000-000000000002' as UUID;
+
+describe('UserCreatedListener', () => {
+  let listener: UserCreatedListener;
+  let skillInstallationService: jest.Mocked<MarketplaceSkillInstallationService>;
+
+  beforeEach(() => {
+    skillInstallationService = {
+      installAllPreInstalled: jest.fn().mockResolvedValue(3),
+      installFromMarketplace: jest.fn(),
+    } as unknown as jest.Mocked<MarketplaceSkillInstallationService>;
+
+    listener = new UserCreatedListener(skillInstallationService);
+  });
+
+  it('should delegate to installAllPreInstalled with the user ID from the event', async () => {
+    await listener.handleUserCreated(new UserCreatedEvent(USER_ID, ORG_ID));
+
+    expect(
+      skillInstallationService.installAllPreInstalled,
+    ).toHaveBeenCalledWith(USER_ID);
+    expect(
+      skillInstallationService.installAllPreInstalled,
+    ).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not throw when the service throws an unexpected error', async () => {
+    skillInstallationService.installAllPreInstalled.mockRejectedValue(
+      new Error('Unexpected failure'),
+    );
+
+    await expect(
+      listener.handleUserCreated(new UserCreatedEvent(USER_ID, ORG_ID)),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/ayunis-core-backend/src/domain/skills/application/listeners/user-created.listener.ts
+++ b/ayunis-core-backend/src/domain/skills/application/listeners/user-created.listener.ts
@@ -1,0 +1,39 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { OnEvent } from '@nestjs/event-emitter';
+import { UserCreatedEvent } from 'src/iam/users/application/events/user-created.event';
+import { MarketplaceSkillInstallationService } from '../services/marketplace-skill-installation.service';
+
+@Injectable()
+export class UserCreatedListener {
+  private readonly logger = new Logger(UserCreatedListener.name);
+
+  constructor(
+    private readonly skillInstallationService: MarketplaceSkillInstallationService,
+  ) {}
+
+  @OnEvent(UserCreatedEvent.EVENT_NAME)
+  async handleUserCreated(event: UserCreatedEvent): Promise<void> {
+    try {
+      this.logger.log('Installing pre-installed skills for new user', {
+        userId: event.userId,
+        orgId: event.orgId,
+      });
+
+      const successCount =
+        await this.skillInstallationService.installAllPreInstalled(
+          event.userId,
+        );
+
+      this.logger.log('Pre-installed skills installation complete', {
+        userId: event.userId,
+        count: successCount,
+      });
+    } catch (error) {
+      this.logger.error('Failed to install pre-installed skills', {
+        userId: event.userId,
+        orgId: event.orgId,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      });
+    }
+  }
+}

--- a/ayunis-core-backend/src/domain/skills/application/services/marketplace-skill-installation.service.spec.ts
+++ b/ayunis-core-backend/src/domain/skills/application/services/marketplace-skill-installation.service.spec.ts
@@ -1,0 +1,242 @@
+import { MarketplaceSkillInstallationService } from './marketplace-skill-installation.service';
+import type { GetMarketplaceSkillUseCase } from 'src/domain/marketplace/application/use-cases/get-marketplace-skill/get-marketplace-skill.use-case';
+import type { MarketplaceClient } from 'src/domain/marketplace/application/ports/marketplace-client.port';
+import type { SkillRepository } from '../ports/skill.repository';
+import type {
+  SkillListResponseDto,
+  SkillResponseDto,
+} from 'src/common/clients/marketplace/generated/ayunisMarketplaceAPI.schemas';
+import { Skill } from '../../domain/skill.entity';
+import type { UUID } from 'crypto';
+import { MarketplaceSkillNotFoundError } from 'src/domain/marketplace/application/marketplace.errors';
+
+const USER_ID = '550e8400-e29b-41d4-a716-446655440000' as UUID;
+
+const marketplaceSkill: SkillResponseDto = {
+  id: 'mp-skill-id',
+  identifier: 'meeting-summarizer',
+  name: 'Meeting Summarizer',
+  shortDescription: 'Summarize meetings and extract action items',
+  aiDescription: 'AI description for meeting summarizer',
+  instructions:
+    'You are a meeting summarization assistant. Analyze meeting notes.',
+  skillCategoryId: null,
+  iconUrl: null,
+} as SkillResponseDto;
+
+describe('MarketplaceSkillInstallationService', () => {
+  let service: MarketplaceSkillInstallationService;
+  let getMarketplaceSkillUseCase: jest.Mocked<GetMarketplaceSkillUseCase>;
+  let skillRepository: jest.Mocked<SkillRepository>;
+  let marketplaceClient: jest.Mocked<MarketplaceClient>;
+
+  beforeEach(() => {
+    getMarketplaceSkillUseCase = {
+      execute: jest.fn(),
+    } as unknown as jest.Mocked<GetMarketplaceSkillUseCase>;
+
+    skillRepository = {
+      create: jest.fn(),
+      findByNameAndOwner: jest.fn(),
+      activateSkill: jest.fn(),
+    } as unknown as jest.Mocked<SkillRepository>;
+
+    marketplaceClient = {
+      getPreInstalledSkills: jest.fn(),
+      getSkillByIdentifier: jest.fn(),
+    } as jest.Mocked<MarketplaceClient>;
+
+    service = new MarketplaceSkillInstallationService(
+      getMarketplaceSkillUseCase,
+      skillRepository,
+      marketplaceClient,
+    );
+  });
+
+  it('should install a marketplace skill, create it, and activate it', async () => {
+    getMarketplaceSkillUseCase.execute.mockResolvedValue(marketplaceSkill);
+    skillRepository.findByNameAndOwner.mockResolvedValue(null);
+    skillRepository.create.mockImplementation(async (skill: Skill) => skill);
+
+    const result = await service.installFromMarketplace(
+      'meeting-summarizer',
+      USER_ID,
+    );
+
+    expect(result.name).toBe('Meeting Summarizer');
+    expect(result.shortDescription).toBe(
+      'Summarize meetings and extract action items',
+    );
+    expect(result.instructions).toBe(
+      'You are a meeting summarization assistant. Analyze meeting notes.',
+    );
+    expect(result.marketplaceIdentifier).toBe('meeting-summarizer');
+    expect(result.userId).toBe(USER_ID);
+    expect(skillRepository.create).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'Meeting Summarizer' }),
+    );
+    expect(skillRepository.activateSkill).toHaveBeenCalledWith(
+      result.id,
+      USER_ID,
+    );
+  });
+
+  it('should append a numeric suffix when the name already exists', async () => {
+    getMarketplaceSkillUseCase.execute.mockResolvedValue(marketplaceSkill);
+
+    const existingSkill = new Skill({
+      name: 'Meeting Summarizer',
+      shortDescription: 'Existing',
+      instructions: 'Existing instructions',
+      userId: USER_ID,
+    });
+
+    skillRepository.findByNameAndOwner
+      .mockResolvedValueOnce(existingSkill) // "Meeting Summarizer" taken
+      .mockResolvedValueOnce(null); // "Meeting Summarizer 2" available
+
+    skillRepository.create.mockImplementation(async (skill: Skill) => skill);
+
+    const result = await service.installFromMarketplace(
+      'meeting-summarizer',
+      USER_ID,
+    );
+
+    expect(result.name).toBe('Meeting Summarizer 2');
+    expect(skillRepository.findByNameAndOwner).toHaveBeenCalledTimes(2);
+    expect(skillRepository.findByNameAndOwner).toHaveBeenCalledWith(
+      'Meeting Summarizer',
+      USER_ID,
+    );
+    expect(skillRepository.findByNameAndOwner).toHaveBeenCalledWith(
+      'Meeting Summarizer 2',
+      USER_ID,
+    );
+  });
+
+  it('should propagate MarketplaceSkillNotFoundError when skill does not exist', async () => {
+    getMarketplaceSkillUseCase.execute.mockRejectedValue(
+      new MarketplaceSkillNotFoundError('nonexistent-skill'),
+    );
+
+    await expect(
+      service.installFromMarketplace('nonexistent-skill', USER_ID),
+    ).rejects.toThrow(MarketplaceSkillNotFoundError);
+
+    expect(skillRepository.create).not.toHaveBeenCalled();
+  });
+
+  it('should propagate repository create failure', async () => {
+    getMarketplaceSkillUseCase.execute.mockResolvedValue(marketplaceSkill);
+    skillRepository.findByNameAndOwner.mockResolvedValue(null);
+    skillRepository.create.mockRejectedValue(
+      new Error('Unique constraint violation'),
+    );
+
+    await expect(
+      service.installFromMarketplace('meeting-summarizer', USER_ID),
+    ).rejects.toThrow('Unique constraint violation');
+
+    expect(skillRepository.activateSkill).not.toHaveBeenCalled();
+  });
+
+  it('should throw after exceeding maximum name resolution attempts', async () => {
+    getMarketplaceSkillUseCase.execute.mockResolvedValue(marketplaceSkill);
+
+    const existingSkill = new Skill({
+      name: 'Meeting Summarizer',
+      shortDescription: 'Existing',
+      instructions: 'Existing instructions',
+      userId: USER_ID,
+    });
+
+    // All names taken — returns existing skill every time
+    skillRepository.findByNameAndOwner.mockResolvedValue(existingSkill);
+
+    await expect(
+      service.installFromMarketplace('meeting-summarizer', USER_ID),
+    ).rejects.toThrow(/Could not resolve unique name/);
+
+    expect(skillRepository.create).not.toHaveBeenCalled();
+  });
+
+  describe('installAllPreInstalled', () => {
+    const makeSkillSummary = (
+      identifier: string,
+      name: string,
+    ): SkillListResponseDto =>
+      ({
+        id: `skill-${identifier}`,
+        identifier,
+        name,
+        shortDescription: `Short desc for ${name}`,
+        aiDescription: `AI desc for ${name}`,
+      }) as SkillListResponseDto;
+
+    const setupInstallMocks = (): void => {
+      getMarketplaceSkillUseCase.execute.mockImplementation(async (query) => ({
+        ...marketplaceSkill,
+        identifier: query.identifier,
+        name: query.identifier,
+      }));
+      skillRepository.findByNameAndOwner.mockResolvedValue(null);
+      skillRepository.create.mockImplementation(async (skill: Skill) => skill);
+    };
+
+    it('should install all pre-installed skills and return success count', async () => {
+      const skills = [
+        makeSkillSummary('email-writer', 'Email Writer'),
+        makeSkillSummary('meeting-notes', 'Meeting Notes'),
+      ];
+      marketplaceClient.getPreInstalledSkills.mockResolvedValue(skills);
+      setupInstallMocks();
+
+      const count = await service.installAllPreInstalled(USER_ID);
+
+      expect(count).toBe(2);
+      expect(marketplaceClient.getPreInstalledSkills).toHaveBeenCalled();
+    });
+
+    it('should return zero when marketplace returns empty array', async () => {
+      marketplaceClient.getPreInstalledSkills.mockResolvedValue([]);
+
+      const count = await service.installAllPreInstalled(USER_ID);
+
+      expect(count).toBe(0);
+      expect(getMarketplaceSkillUseCase.execute).not.toHaveBeenCalled();
+    });
+
+    it('should continue installing remaining skills when one fails', async () => {
+      const skills = [
+        makeSkillSummary('failing-skill', 'Failing Skill'),
+        makeSkillSummary('working-skill', 'Working Skill'),
+      ];
+      marketplaceClient.getPreInstalledSkills.mockResolvedValue(skills);
+
+      getMarketplaceSkillUseCase.execute
+        .mockRejectedValueOnce(new Error('Network error'))
+        .mockResolvedValueOnce({
+          ...marketplaceSkill,
+          identifier: 'working-skill',
+          name: 'Working Skill',
+        });
+      skillRepository.findByNameAndOwner.mockResolvedValue(null);
+      skillRepository.create.mockImplementation(async (skill: Skill) => skill);
+
+      const count = await service.installAllPreInstalled(USER_ID);
+
+      expect(count).toBe(1);
+    });
+
+    it('should return zero and not throw when marketplace is unavailable', async () => {
+      marketplaceClient.getPreInstalledSkills.mockRejectedValue(
+        new Error('Marketplace down'),
+      );
+
+      const count = await service.installAllPreInstalled(USER_ID);
+
+      expect(count).toBe(0);
+      expect(getMarketplaceSkillUseCase.execute).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/ayunis-core-backend/src/domain/skills/application/services/marketplace-skill-installation.service.ts
+++ b/ayunis-core-backend/src/domain/skills/application/services/marketplace-skill-installation.service.ts
@@ -1,0 +1,110 @@
+import { Inject, Injectable, Logger } from '@nestjs/common';
+import { UUID } from 'crypto';
+import { GetMarketplaceSkillUseCase } from 'src/domain/marketplace/application/use-cases/get-marketplace-skill/get-marketplace-skill.use-case';
+import { GetMarketplaceSkillQuery } from 'src/domain/marketplace/application/use-cases/get-marketplace-skill/get-marketplace-skill.query';
+import { MarketplaceClient } from 'src/domain/marketplace/application/ports/marketplace-client.port';
+import { SkillRepository } from '../ports/skill.repository';
+import { Skill } from '../../domain/skill.entity';
+
+const MAX_NAME_RESOLUTION_ATTEMPTS = 100;
+
+@Injectable()
+export class MarketplaceSkillInstallationService {
+  private readonly logger = new Logger(
+    MarketplaceSkillInstallationService.name,
+  );
+
+  constructor(
+    private readonly getMarketplaceSkillUseCase: GetMarketplaceSkillUseCase,
+    @Inject(SkillRepository)
+    private readonly skillRepository: SkillRepository,
+    private readonly marketplaceClient: MarketplaceClient,
+  ) {}
+
+  async installAllPreInstalled(userId: UUID): Promise<number> {
+    const preInstalledSkills = await this.fetchPreInstalledSkills();
+
+    if (preInstalledSkills.length === 0) {
+      this.logger.debug('No pre-installed skills found');
+      return 0;
+    }
+
+    let successCount = 0;
+    for (const skillSummary of preInstalledSkills) {
+      try {
+        await this.installFromMarketplace(skillSummary.identifier, userId);
+        this.logger.debug('Pre-installed skill created and activated', {
+          identifier: skillSummary.identifier,
+          userId,
+        });
+        successCount++;
+      } catch (error) {
+        this.logger.error('Failed to install individual pre-installed skill', {
+          identifier: skillSummary.identifier,
+          userId,
+          error: error instanceof Error ? error.message : 'Unknown error',
+        });
+      }
+    }
+
+    return successCount;
+  }
+
+  private async fetchPreInstalledSkills(): ReturnType<
+    MarketplaceClient['getPreInstalledSkills']
+  > {
+    try {
+      return await this.marketplaceClient.getPreInstalledSkills();
+    } catch (error) {
+      this.logger.warn(
+        'Marketplace unavailable, skipping pre-installed skills',
+        { error: error instanceof Error ? error.message : 'Unknown error' },
+      );
+      return [];
+    }
+  }
+
+  async installFromMarketplace(
+    identifier: string,
+    userId: UUID,
+  ): Promise<Skill> {
+    this.logger.log('installFromMarketplace', { identifier, userId });
+
+    const marketplaceSkill = await this.getMarketplaceSkillUseCase.execute(
+      new GetMarketplaceSkillQuery(identifier),
+    );
+
+    const name = await this.resolveUniqueName(marketplaceSkill.name, userId);
+
+    const skill = new Skill({
+      name,
+      shortDescription: marketplaceSkill.shortDescription,
+      instructions: marketplaceSkill.instructions,
+      marketplaceIdentifier: marketplaceSkill.identifier,
+      userId,
+    });
+
+    const created = await this.skillRepository.create(skill);
+    await this.skillRepository.activateSkill(created.id, userId);
+
+    return created;
+  }
+
+  private async resolveUniqueName(
+    baseName: string,
+    userId: UUID,
+  ): Promise<string> {
+    let name = baseName;
+    let suffix = 2;
+    while (await this.skillRepository.findByNameAndOwner(name, userId)) {
+      if (suffix > MAX_NAME_RESOLUTION_ATTEMPTS) {
+        throw new Error(
+          `Could not resolve unique name for "${baseName}" after ${MAX_NAME_RESOLUTION_ATTEMPTS} attempts`,
+        );
+      }
+      name = `${baseName} ${suffix}`;
+      suffix++;
+    }
+    return name;
+  }
+}

--- a/ayunis-core-backend/src/domain/skills/skills.module.ts
+++ b/ayunis-core-backend/src/domain/skills/skills.module.ts
@@ -27,8 +27,12 @@ import { ListSkillMcpIntegrationsUseCase } from './application/use-cases/list-sk
 import { FindSkillByNameUseCase } from './application/use-cases/find-skill-by-name/find-skill-by-name.use-case';
 import { InstallSkillFromMarketplaceUseCase } from './application/use-cases/install-skill-from-marketplace/install-skill-from-marketplace.use-case';
 
+// Services
+import { MarketplaceSkillInstallationService } from './application/services/marketplace-skill-installation.service';
+
 // Listeners
 import { ShareDeletedListener } from './application/listeners/share-deleted.listener';
+import { UserCreatedListener } from './application/listeners/user-created.listener';
 
 // Strategies
 import { SkillShareAuthorizationStrategy } from './application/strategies/skill-share-authorization.strategy';
@@ -84,8 +88,12 @@ import { McpIntegrationDtoMapper } from '../mcp/presenters/http/mappers/mcp-inte
     FindSkillByNameUseCase,
     InstallSkillFromMarketplaceUseCase,
 
+    // Services
+    MarketplaceSkillInstallationService,
+
     // Listeners
     ShareDeletedListener,
+    UserCreatedListener,
 
     // Strategies
     SkillShareAuthorizationStrategy,

--- a/ayunis-core-backend/src/iam/users/application/events/user-created.event.ts
+++ b/ayunis-core-backend/src/iam/users/application/events/user-created.event.ts
@@ -1,0 +1,10 @@
+import type { UUID } from 'crypto';
+
+export class UserCreatedEvent {
+  static readonly EVENT_NAME = 'user.created';
+
+  constructor(
+    public readonly userId: UUID,
+    public readonly orgId: UUID,
+  ) {}
+}

--- a/ayunis-core-backend/src/iam/users/application/use-cases/create-user/create-user.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/create-user/create-user.use-case.spec.ts
@@ -1,0 +1,140 @@
+import { CreateUserUseCase } from './create-user.use-case';
+import { CreateUserCommand } from './create-user.command';
+import { UserCreatedEvent } from '../../events/user-created.event';
+import { User } from '../../../domain/user.entity';
+import { UserRole } from '../../../domain/value-objects/role.object';
+import {
+  UserAlreadyExistsError,
+  UserEmailProviderBlacklistedError,
+} from '../../users.errors';
+import type { UsersRepository } from '../../ports/users.repository';
+import type { HashTextUseCase } from '../../../../hashing/application/use-cases/hash-text/hash-text.use-case';
+import type { SendWebhookUseCase } from 'src/common/webhooks/application/use-cases/send-webhook/send-webhook.use-case';
+import type { ConfigService } from '@nestjs/config';
+import type { EventEmitter2 } from '@nestjs/event-emitter';
+import type { UUID } from 'crypto';
+
+describe('CreateUserUseCase', () => {
+  let useCase: CreateUserUseCase;
+  let usersRepository: jest.Mocked<UsersRepository>;
+  let hashTextUseCase: jest.Mocked<HashTextUseCase>;
+  let sendWebhookUseCase: jest.Mocked<SendWebhookUseCase>;
+  let configService: jest.Mocked<ConfigService>;
+  let eventEmitter: jest.Mocked<EventEmitter2>;
+
+  const orgId = '550e8400-e29b-41d4-a716-446655440000' as UUID;
+
+  const validCommand = new CreateUserCommand({
+    email: 'maria.garcia@ayunis.de',
+    password: 'Sicher3sPasswort!',
+    orgId,
+    name: 'Maria Garcia',
+    role: UserRole.USER,
+    emailVerified: false,
+    hasAcceptedMarketing: true,
+  });
+
+  beforeEach(() => {
+    usersRepository = {
+      findOneByEmail: jest.fn().mockResolvedValue(null),
+      create: jest.fn().mockImplementation(async (user: User) => user),
+    } as unknown as jest.Mocked<UsersRepository>;
+
+    hashTextUseCase = {
+      execute: jest.fn().mockResolvedValue('hashed-password-value'),
+    } as unknown as jest.Mocked<HashTextUseCase>;
+
+    sendWebhookUseCase = {
+      execute: jest.fn().mockResolvedValue(undefined),
+    } as unknown as jest.Mocked<SendWebhookUseCase>;
+
+    configService = {
+      get: jest.fn().mockImplementation((key: string) => {
+        if (key === 'auth.emailProviderBlacklist') return ['tempmail.com'];
+        return undefined;
+      }),
+    } as unknown as jest.Mocked<ConfigService>;
+
+    eventEmitter = {
+      emitAsync: jest.fn().mockResolvedValue([]),
+    } as unknown as jest.Mocked<EventEmitter2>;
+
+    useCase = new CreateUserUseCase(
+      usersRepository,
+      hashTextUseCase,
+      sendWebhookUseCase,
+      configService,
+      eventEmitter,
+    );
+  });
+
+  it('should emit UserCreatedEvent with correct userId and orgId after user creation', async () => {
+    const result = await useCase.execute(validCommand);
+
+    expect(eventEmitter.emitAsync).toHaveBeenCalledWith(
+      UserCreatedEvent.EVENT_NAME,
+      expect.objectContaining({
+        userId: result.id,
+        orgId,
+      }),
+    );
+  });
+
+  it('should not emit UserCreatedEvent when user already exists', async () => {
+    usersRepository.findOneByEmail.mockResolvedValue(
+      new User({
+        email: validCommand.email,
+        emailVerified: false,
+        passwordHash: 'existing-hash',
+        role: UserRole.USER,
+        orgId,
+        name: 'Existing User',
+        hasAcceptedMarketing: false,
+      }),
+    );
+
+    await expect(useCase.execute(validCommand)).rejects.toThrow(
+      UserAlreadyExistsError,
+    );
+    expect(eventEmitter.emitAsync).not.toHaveBeenCalled();
+  });
+
+  it('should not emit UserCreatedEvent when email provider is blacklisted', async () => {
+    const blacklistedCommand = new CreateUserCommand({
+      ...validCommand,
+      email: 'user@tempmail.com',
+    });
+
+    await expect(useCase.execute(blacklistedCommand)).rejects.toThrow(
+      UserEmailProviderBlacklistedError,
+    );
+    expect(eventEmitter.emitAsync).not.toHaveBeenCalled();
+  });
+
+  it('should catch and log emitAsync rejection without throwing', async () => {
+    eventEmitter.emitAsync.mockRejectedValue(
+      new Error('Listener failed unexpectedly'),
+    );
+
+    const result = await useCase.execute(validCommand);
+
+    expect(result).toBeDefined();
+    expect(eventEmitter.emitAsync).toHaveBeenCalledWith(
+      UserCreatedEvent.EVENT_NAME,
+      expect.objectContaining({
+        userId: result.id,
+        orgId,
+      }),
+    );
+
+    // Flush microtask queue so the .catch() handler runs
+    await new Promise(process.nextTick);
+  });
+
+  it('should not emit UserCreatedEvent when repository create fails', async () => {
+    usersRepository.create.mockRejectedValue(new Error('Database error'));
+
+    await expect(useCase.execute(validCommand)).rejects.toThrow();
+    expect(eventEmitter.emitAsync).not.toHaveBeenCalled();
+  });
+});

--- a/dev
+++ b/dev
@@ -114,6 +114,7 @@ CODE_EXECUTION_SERVICE_URL=http://localhost:$CODE_EXEC_HOST_PORT
 ANONYMIZE_SERVICE_URL=http://localhost:$ANONYMIZE_HOST_PORT
 FRONTEND_BASEURL=http://localhost:$FRONTEND_PORT
 CORS_ALLOWED_ORIGINS=http://localhost:$FRONTEND_PORT,http://localhost:$BACKEND_PORT
+MARKETPLACE_SERVICE_URL=http://localhost:3002
 EOF
 
   # -- 3. Run database migrations ------------------------------------------


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches the user-creation flow and adds event-driven side effects that create/activate skills via an external marketplace API, which could impact onboarding behavior and error handling if misconfigured or unavailable.
> 
> **Overview**
> New users now get *best-effort* provisioning of marketplace “pre-installed” skills: `CreateUserUseCase` emits a new `UserCreatedEvent`, and a `UserCreatedListener` in the skills module reacts by installing/activating those skills.
> 
> This introduces `MarketplaceSkillInstallationService` to centralize marketplace install logic (unique-name resolution, create + activate) and refactors `InstallSkillFromMarketplaceUseCase` to delegate to it. The marketplace integration is extended with `MarketplaceClient.getPreInstalledSkills()` and an HTTP implementation, plus a small SMTP tweak to omit `auth` when credentials aren’t configured; dev setup adds `MARKETPLACE_SERVICE_URL`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 339f1bd39a48d139c57f85f4c5f1496d1a9601a6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->