### PR TITLE
fix(AYC-92): add i18n translations for knowledge base tool call displays

### DIFF
--- a/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/query-knowledge-base/query-knowledge-base.use-case.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/query-knowledge-base/query-knowledge-base.use-case.ts
@@ -89,7 +89,7 @@ export class QueryKnowledgeBaseUseCase {
         query: query.query,
         documentIds,
         type: IndexType.PARENT_CHILD,
-        limit: 50,
+        limit: 5,
       }),
     );
 

--- a/ayunis-core-backend/src/domain/runs/application/services/tool-assembly.service.ts
+++ b/ayunis-core-backend/src/domain/runs/application/services/tool-assembly.service.ts
@@ -72,7 +72,7 @@ export class ToolAssemblyService {
       // Only include skills in prompt when tools are enabled and not cloud-hosted,
       // otherwise the prompt would instruct the model to use activate_skill which isn't available
       skills: canUseTools && !isCloudHosted ? activeSkills : [],
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- threads created before knowledge bases feature may have undefined
+
       knowledgeBases: canUseTools ? (thread.knowledgeBases ?? []) : [],
       userSystemPrompt,
     });
@@ -272,7 +272,7 @@ export class ToolAssemblyService {
     }
 
     // Knowledge base tools are available if the thread has knowledge bases
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- threads created before knowledge bases feature may have undefined
+
     if ((thread.knowledgeBases?.length ?? 0) > 0) {
       tools.push(
         await this.assembleToolsUseCase.execute(

--- a/ayunis-core-frontend/src/shared/locales/de/chat.json
+++ b/ayunis-core-frontend/src/shared/locales/de/chat.json
@@ -37,6 +37,9 @@
       "source_get_text": "Datei durchsuchen",
       "code_execution": "Berechnung ausführen",
       "activate_skill": "Fähigkeit aktivieren",
+      "knowledge_query": "Wissen abrufen",
+      "knowledge_get_text": "Wissen abrufen",
+      "product_knowledge": "Produktwissen durchsuchen",
       "send_email": {
         "subject": "Betreff",
         "body": "Nachricht",

--- a/ayunis-core-frontend/src/shared/locales/en/chat.json
+++ b/ayunis-core-frontend/src/shared/locales/en/chat.json
@@ -37,6 +37,9 @@
       "source_get_text": "Query file",
       "code_execution": "Calculate",
       "activate_skill": "Activate skill",
+      "knowledge_query": "Search knowledge base",
+      "knowledge_get_text": "Read knowledge base document",
+      "product_knowledge": "Search product knowledge",
       "send_email": {
         "subject": "Subject",
         "body": "Body",

--- a/ayunis-core-frontend/src/widgets/app-sidebar/ui/AppSidebar.tsx
+++ b/ayunis-core-frontend/src/widgets/app-sidebar/ui/AppSidebar.tsx
@@ -74,11 +74,6 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
       url: '/agents',
       icon: Bot,
     },
-    {
-      title: t('sidebar.knowledge'),
-      url: '/knowledge-bases',
-      icon: Brain,
-    },
     ...(!cloudStatus?.isCloud
       ? [
           {
@@ -88,6 +83,11 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
           },
         ]
       : []),
+    {
+      title: t('sidebar.knowledge'),
+      url: '/knowledge-bases',
+      icon: Brain,
+    },
   ];
 
   return (


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small UX/i18n tweaks plus a conservative reduction in KB search result count; low likelihood of regressions aside from reduced recall in knowledge-base answers.
> 
> **Overview**
> Adds missing i18n labels in `chat.json` (EN/DE) for the new knowledge-base tool call displays (`knowledge_query`, `knowledge_get_text`) and a product-knowledge tool label.
> 
> Backend tweaks reduce `QueryKnowledgeBaseUseCase` search fanout from 50 to 5 results, and remove now-unneeded eslint suppression comments around `thread.knowledgeBases` handling. Frontend sidebar now shows the Knowledge Base navigation item regardless of cloud status (while Skills remains self-hosted only).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4f1fc4023d7d1f6011b2b99355540d287297d1b6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->