### PR TITLE
feat(AYC-82): add description hints for knowledge bases and skills

### DIFF
--- a/ayunis-core-frontend/src/pages/knowledge-base/ui/KnowledgeBaseDocumentsCard.tsx
+++ b/ayunis-core-frontend/src/pages/knowledge-base/ui/KnowledgeBaseDocumentsCard.tsx
@@ -5,9 +5,11 @@ import {
   CardHeader,
   CardTitle,
   CardDescription,
+  CardAction,
 } from '@/shared/ui/shadcn/card';
 import { Button } from '@/shared/ui/shadcn/button';
 import { Badge } from '@/shared/ui/shadcn/badge';
+import type { KnowledgeBaseDocumentResponseDto } from '@/shared/api/generated/ayunisCoreAPI.schemas';
 import { Upload, X, FileText, Loader2 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import {
@@ -40,71 +42,93 @@ export default function KnowledgeBaseDocumentsCard({
   return (
     <Card>
       <CardHeader>
-        <div className="flex items-center justify-between">
-          <div>
-            <CardTitle>{t('detail.documents.title')}</CardTitle>
-            <CardDescription>
-              {t('detail.documents.description')}
-            </CardDescription>
-          </div>
-          <div>
-            <input
-              ref={fileInputRef}
-              type="file"
-              accept={ACCEPTED_FILE_TYPES}
-              onChange={handleFileChange}
-              className="hidden"
-            />
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => fileInputRef.current?.click()}
-              disabled={isUploading}
-            >
-              {isUploading ? (
-                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-              ) : (
-                <Upload className="mr-2 h-4 w-4" />
-              )}
-              {t('detail.documents.upload')}
-            </Button>
-          </div>
-        </div>
+        <CardTitle>{t('detail.documents.title')}</CardTitle>
+        <CardDescription>{t('detail.documents.description')}</CardDescription>
+        <CardAction>
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept={ACCEPTED_FILE_TYPES}
+            onChange={handleFileChange}
+            className="hidden"
+          />
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => fileInputRef.current?.click()}
+            disabled={isUploading}
+          >
+            {isUploading ? (
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            ) : (
+              <Upload className="mr-2 h-4 w-4" />
+            )}
+            {t('detail.documents.upload')}
+          </Button>
+        </CardAction>
       </CardHeader>
       <CardContent>
-        {isLoading ? (
-          <div className="flex items-center justify-center py-8">
-            <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
-          </div>
-        ) : documents.length === 0 ? (
-          <p className="text-sm text-muted-foreground py-4 text-center">
-            {t('detail.documents.empty')}
-          </p>
-        ) : (
-          <div className="flex flex-wrap gap-2">
-            {documents.map((doc) => (
-              <Badge
-                key={doc.id}
-                variant="secondary"
-                className="flex items-center gap-1.5 py-1.5 px-3"
-              >
-                <FileText className="h-3.5 w-3.5" />
-                <span className="max-w-[200px] truncate">{doc.name}</span>
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="icon"
-                  onClick={() => removeDocument(doc.id)}
-                  disabled={isRemoving}
-                  className="ml-1 h-5 w-5 rounded-full"
-                >
-                  <X className="h-3 w-3" />
-                </Button>
-              </Badge>
-            ))}
-          </div>
-        )}
+        <DocumentsContent
+          isLoading={isLoading}
+          documents={documents}
+          removeDocument={removeDocument}
+          isRemoving={isRemoving}
+          emptyText={t('detail.documents.empty')}
+        />
       </CardContent>
     </Card>
+  );
+}
+
+function DocumentsContent({
+  isLoading,
+  documents,
+  removeDocument,
+  isRemoving,
+  emptyText,
+}: Readonly<{
+  isLoading: boolean;
+  documents: KnowledgeBaseDocumentResponseDto[];
+  removeDocument: (id: string) => void;
+  isRemoving: boolean;
+  emptyText: string;
+}>) {
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center py-8">
+        <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+  if (documents.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground py-4 text-center">
+        {emptyText}
+      </p>
+    );
+  }
+  return (
+    <div className="flex flex-wrap gap-2">
+      {documents.map((doc) => (
+        <Badge
+          key={doc.id}
+          variant="secondary"
+          className="flex items-center gap-1.5 py-1.5 px-3"
+        >
+          <FileText className="h-3.5 w-3.5" />
+          <span className="max-w-[200px] truncate">{doc.name}</span>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            onClick={() => removeDocument(doc.id)}
+            disabled={isRemoving}
+            className="ml-1 h-5 w-5 rounded-full"
+          >
+            <X className="h-3 w-3" />
+          </Button>
+        </Badge>
+      ))}
+    </div>
   );
 }

--- a/ayunis-core-frontend/src/pages/knowledge-base/ui/KnowledgeBasePropertiesCard.tsx
+++ b/ayunis-core-frontend/src/pages/knowledge-base/ui/KnowledgeBasePropertiesCard.tsx
@@ -8,6 +8,7 @@ import {
 import {
   Form,
   FormControl,
+  FormDescription,
   FormField,
   FormItem,
   FormLabel,
@@ -65,6 +66,9 @@ export default function KnowledgeBasePropertiesCard({
                       {...field}
                     />
                   </FormControl>
+                  <FormDescription>
+                    {t('detail.properties.form.descriptionHint')}
+                  </FormDescription>
                   <FormMessage />
                 </FormItem>
               )}

--- a/ayunis-core-frontend/src/pages/knowledge-bases/ui/CreateKnowledgeBaseDialog.tsx
+++ b/ayunis-core-frontend/src/pages/knowledge-bases/ui/CreateKnowledgeBaseDialog.tsx
@@ -52,6 +52,7 @@ export default function CreateKnowledgeBaseDialog({
             control={form.control}
             name="description"
             translationNamespace="knowledge-bases"
+            multiline
           />
         </div>
       </Form>

--- a/ayunis-core-frontend/src/pages/skill/ui/SkillPropertiesCard.tsx
+++ b/ayunis-core-frontend/src/pages/skill/ui/SkillPropertiesCard.tsx
@@ -8,6 +8,7 @@ import {
 import {
   Form,
   FormControl,
+  FormDescription,
   FormField,
   FormItem,
   FormLabel,
@@ -67,6 +68,9 @@ export default function SkillPropertiesCard({
                       {...field}
                     />
                   </FormControl>
+                  <FormDescription>
+                    {t('properties.form.shortDescriptionHint')}
+                  </FormDescription>
                   <FormMessage />
                 </FormItem>
               )}

--- a/ayunis-core-frontend/src/shared/locales/de/knowledge-bases.json
+++ b/ayunis-core-frontend/src/shared/locales/de/knowledge-bases.json
@@ -23,7 +23,8 @@
       "nameLabel": "Name",
       "namePlaceholder": "Name der Wissenssammlung eingeben...",
       "shortDescriptionLabel": "Beschreibung",
-      "shortDescriptionPlaceholder": "Optionale Beschreibung eingeben..."
+      "shortDescriptionPlaceholder": "Optionale Beschreibung eingeben...",
+      "shortDescriptionHint": "Eine gute Beschreibung hilft der KI zu verstehen, wann diese Wissenssammlung verwendet werden soll."
     },
     "validation": {
       "nameRequired": "Name ist erforderlich"
@@ -51,7 +52,8 @@
         "nameLabel": "Name",
         "namePlaceholder": "Name der Wissenssammlung eingeben...",
         "descriptionLabel": "Beschreibung",
-        "descriptionPlaceholder": "Optionale Beschreibung eingeben..."
+        "descriptionPlaceholder": "Optionale Beschreibung eingeben...",
+        "descriptionHint": "Eine gute Beschreibung hilft der KI zu verstehen, wann diese Wissenssammlung verwendet werden soll."
       },
       "buttons": {
         "save": "Speichern",

--- a/ayunis-core-frontend/src/shared/locales/de/skill.json
+++ b/ayunis-core-frontend/src/shared/locales/de/skill.json
@@ -63,6 +63,7 @@
       "namePlaceholder": "Name der Fähigkeit eingeben...",
       "shortDescriptionLabel": "Kurzbeschreibung",
       "shortDescriptionPlaceholder": "Kurze Beschreibung, damit die KI entscheiden kann, wann diese Fähigkeit aktiviert werden soll...",
+      "shortDescriptionHint": "Eine gute Beschreibung hilft der KI zu verstehen, wann diese Fähigkeit verwendet werden soll.",
       "instructionsLabel": "Anweisungen",
       "instructionsPlaceholder": "Detaillierte Anweisungen, die eingefügt werden, wenn die Fähigkeit aktiviert wird..."
     },

--- a/ayunis-core-frontend/src/shared/locales/de/skills.json
+++ b/ayunis-core-frontend/src/shared/locales/de/skills.json
@@ -35,6 +35,7 @@
       "namePlaceholder": "Name der Fähigkeit eingeben...",
       "shortDescriptionLabel": "Kurzbeschreibung",
       "shortDescriptionPlaceholder": "Kurze Beschreibung dessen, was diese Fähigkeit macht...",
+      "shortDescriptionHint": "Eine gute Beschreibung hilft der KI zu verstehen, wann diese Fähigkeit verwendet werden soll.",
       "instructionsLabel": "Detaillierte Anweisungen",
       "instructionsPlaceholder": "Detaillierte Anweisungen für diese Fähigkeit eingeben..."
     },

--- a/ayunis-core-frontend/src/shared/locales/en/knowledge-bases.json
+++ b/ayunis-core-frontend/src/shared/locales/en/knowledge-bases.json
@@ -23,7 +23,8 @@
       "nameLabel": "Name",
       "namePlaceholder": "Enter knowledge base name...",
       "shortDescriptionLabel": "Description",
-      "shortDescriptionPlaceholder": "Enter an optional description..."
+      "shortDescriptionPlaceholder": "Enter an optional description...",
+      "shortDescriptionHint": "A good description helps the AI understand when to use this knowledge base."
     },
     "validation": {
       "nameRequired": "Name is required"
@@ -51,7 +52,8 @@
         "nameLabel": "Name",
         "namePlaceholder": "Enter knowledge base name...",
         "descriptionLabel": "Description",
-        "descriptionPlaceholder": "Enter an optional description..."
+        "descriptionPlaceholder": "Enter an optional description...",
+        "descriptionHint": "A good description helps the AI understand when to use this knowledge base."
       },
       "buttons": {
         "save": "Save",

--- a/ayunis-core-frontend/src/shared/locales/en/skill.json
+++ b/ayunis-core-frontend/src/shared/locales/en/skill.json
@@ -63,6 +63,7 @@
       "namePlaceholder": "Enter skill name...",
       "shortDescriptionLabel": "Short Description",
       "shortDescriptionPlaceholder": "Brief description for the AI to decide when to activate this skill...",
+      "shortDescriptionHint": "A good description helps the AI understand when to use this skill.",
       "instructionsLabel": "Instructions",
       "instructionsPlaceholder": "Detailed instructions injected when the skill is activated..."
     },

--- a/ayunis-core-frontend/src/shared/locales/en/skills.json
+++ b/ayunis-core-frontend/src/shared/locales/en/skills.json
@@ -35,6 +35,7 @@
       "namePlaceholder": "Enter skill name...",
       "shortDescriptionLabel": "Short Description",
       "shortDescriptionPlaceholder": "Brief description of what this skill does...",
+      "shortDescriptionHint": "A good description helps the AI understand when to use this skill.",
       "instructionsLabel": "Detailed Instructions",
       "instructionsPlaceholder": "Enter detailed instructions for this skill..."
     },

--- a/ayunis-core-frontend/src/widgets/entity-form-fields/ui/ShortDescriptionField.tsx
+++ b/ayunis-core-frontend/src/widgets/entity-form-fields/ui/ShortDescriptionField.tsx
@@ -1,11 +1,13 @@
 import {
   FormControl,
+  FormDescription,
   FormField,
   FormItem,
   FormLabel,
   FormMessage,
 } from '@/shared/ui/shadcn/form';
 import { Input } from '@/shared/ui/shadcn/input';
+import { Textarea } from '@/shared/ui/shadcn/textarea';
 import { useTranslation } from 'react-i18next';
 import type { Control, FieldPath, FieldValues } from 'react-hook-form';
 
@@ -15,6 +17,7 @@ interface ShortDescriptionFieldProps<TFieldValues extends FieldValues> {
   translationNamespace: string;
   translationPrefix?: string;
   disabled?: boolean;
+  multiline?: boolean;
 }
 
 export default function ShortDescriptionField<
@@ -25,8 +28,11 @@ export default function ShortDescriptionField<
   translationNamespace,
   translationPrefix = 'createDialog',
   disabled = false,
+  multiline = false,
 }: Readonly<ShortDescriptionFieldProps<TFieldValues>>) {
   const { t } = useTranslation(translationNamespace);
+  const hintKey = `${translationPrefix}.form.shortDescriptionHint`;
+  const hint = t(hintKey, { defaultValue: '' });
 
   return (
     <FormField
@@ -38,14 +44,26 @@ export default function ShortDescriptionField<
             {t(`${translationPrefix}.form.shortDescriptionLabel`)}
           </FormLabel>
           <FormControl>
-            <Input
-              placeholder={t(
-                `${translationPrefix}.form.shortDescriptionPlaceholder`,
-              )}
-              disabled={disabled}
-              {...field}
-            />
+            {multiline ? (
+              <Textarea
+                placeholder={t(
+                  `${translationPrefix}.form.shortDescriptionPlaceholder`,
+                )}
+                className="min-h-[80px] max-h-[200px]"
+                disabled={disabled}
+                {...field}
+              />
+            ) : (
+              <Input
+                placeholder={t(
+                  `${translationPrefix}.form.shortDescriptionPlaceholder`,
+                )}
+                disabled={disabled}
+                {...field}
+              />
+            )}
           </FormControl>
+          {hint && <FormDescription>{hint}</FormDescription>}
           <FormMessage />
         </FormItem>
       )}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Primarily UI/UX and i18n copy changes with a small reusable form-field enhancement; low risk aside from minor layout/regression potential in forms/cards.
> 
> **Overview**
> Adds localized *hint text* under knowledge-base and skill description/short-description fields (create + edit flows), including new `*.form.*Hint` translation keys in `en`/`de` locale files.
> 
> Enhances the shared `ShortDescriptionField` to optionally render a `Textarea` (`multiline`) and display a `FormDescription` hint when available; the knowledge-base create dialog now uses the multiline variant.
> 
> Refactors `KnowledgeBaseDocumentsCard` header layout to use `CardAction` and extracts the documents list/loading/empty-state rendering into a small `DocumentsContent` component (no behavior change intended).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fc955435237b67081cb71c7d0873eaa1300ef4e6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->