### PR TITLE
fix(AYC-95): wire up pinned skills below chat input on new chat page

### DIFF
--- a/ayunis-core-frontend/src/pages/chat/api/useDownloadSource.ts
+++ b/ayunis-core-frontend/src/pages/chat/api/useDownloadSource.ts
@@ -1,0 +1,36 @@
+import { showError } from '@/shared/lib/toast';
+import { useTranslation } from 'react-i18next';
+import { useCallback } from 'react';
+import { threadsControllerDownloadSource } from '@/shared/api/generated/ayunisCoreAPI';
+import type { Thread } from '../model/openapi';
+
+export function useDownloadSource(thread: Thread) {
+  const { t } = useTranslation('chat');
+
+  const downloadSource = useCallback(
+    async (sourceId: string) => {
+      try {
+        const blob = await threadsControllerDownloadSource(thread.id, sourceId);
+
+        const url = window.URL.createObjectURL(blob);
+        const link = document.createElement('a');
+        link.href = url;
+
+        const source = thread.sources.find((s) => s.id === sourceId);
+        link.download = source?.name ?? 'download.csv';
+
+        document.body.appendChild(link);
+        link.click();
+
+        document.body.removeChild(link);
+        window.URL.revokeObjectURL(url);
+      } catch (error) {
+        console.error('Failed to download source', error);
+        showError(t('chat.errorDownloadSource'));
+      }
+    },
+    [thread.id, thread.sources, t],
+  );
+
+  return { downloadSource };
+}

--- a/ayunis-core-frontend/src/pages/new-chat/ui/NewChatPage.tsx
+++ b/ayunis-core-frontend/src/pages/new-chat/ui/NewChatPage.tsx
@@ -12,6 +12,7 @@ import { usePermittedModels } from '@/features/usePermittedModels';
 import { useTimeBasedGreeting } from '../model/useTimeBasedGreeting';
 import { useChatContext } from '@/shared/contexts/chat/useChatContext';
 import type { KnowledgeBaseSummary } from '@/shared/contexts/chat/chatContext';
+import { PinnedSkills } from './PinnedSkills';
 
 interface NewChatPageProps {
   prefilledPrompt?: string;
@@ -32,7 +33,8 @@ export default function NewChatPage({
   const { initiateChat } = useInitiateChat();
   const { models } = usePermittedModels();
   const greeting = useTimeBasedGreeting();
-  const { setPendingImages, setPendingKnowledgeBases } = useChatContext();
+  const { setPendingImages, setPendingKnowledgeBases, setPendingSkillId } =
+    useChatContext();
   const [modelId, setModelId] = useState(selectedModelId);
   const [agentId, setAgentId] = useState(selectedAgentId);
   const [isAnonymous, setIsAnonymous] = useState(false);
@@ -47,6 +49,8 @@ export default function NewChatPage({
   const [selectedKnowledgeBases, setSelectedKnowledgeBases] = useState<
     KnowledgeBaseSummary[]
   >([]);
+  const [selectedSkillId, setSelectedSkillId] = useState<string>();
+  const [selectedSkillName, setSelectedSkillName] = useState<string>();
   const selectedAgent = agents.find((agent) => agent.id === agentId);
   const selectedModel = models.find((m) => m.id === modelId);
 
@@ -89,6 +93,21 @@ export default function NewChatPage({
     setModelId(undefined);
   }
 
+  function handleSkillSelect(skillId: string, skillName: string) {
+    if (selectedSkillId === skillId) {
+      setSelectedSkillId(undefined);
+      setSelectedSkillName(undefined);
+    } else {
+      setSelectedSkillId(skillId);
+      setSelectedSkillName(skillName);
+    }
+  }
+
+  function handleSkillRemove() {
+    setSelectedSkillId(undefined);
+    setSelectedSkillName(undefined);
+  }
+
   function handleAgentRemove() {
     setAgentId(undefined);
     setModelId(selectedModelId);
@@ -97,6 +116,7 @@ export default function NewChatPage({
   function handleSend(
     message: string,
     imageFiles?: Array<{ file: File; altText?: string }>,
+    skillId?: string,
   ) {
     if (!modelId && !agentId) {
       showError(t('newChat.noModelOrAgentError'));
@@ -111,6 +131,8 @@ export default function NewChatPage({
     // Store selected KBs in context for ChatPage to attach after thread creation
     // Always set — even when empty — to clear stale KBs from a previous failed attempt
     setPendingKnowledgeBases(selectedKnowledgeBases);
+
+    setPendingSkillId(skillId);
 
     initiateChat(message, modelId, agentId, sources, isAnonymous);
   }
@@ -154,6 +176,13 @@ export default function NewChatPage({
           onAnonymousChange={setIsAnonymous}
           isAnonymousEnforced={isAnonymousEnforced}
           isVisionEnabled={isVisionEnabled}
+          selectedSkillId={selectedSkillId}
+          selectedSkillName={selectedSkillName}
+          onSkillRemove={handleSkillRemove}
+        />
+        <PinnedSkills
+          onSkillSelect={handleSkillSelect}
+          selectedSkillId={selectedSkillId}
         />
       </div>
     </NewChatPageLayout>

--- a/ayunis-core-frontend/src/pages/new-chat/ui/PinnedSkills.tsx
+++ b/ayunis-core-frontend/src/pages/new-chat/ui/PinnedSkills.tsx
@@ -4,7 +4,7 @@ import { useSkillsControllerFindAll } from '@/shared/api/generated/ayunisCoreAPI
 import { useIsSkillsEnabled } from '@/features/feature-toggles';
 
 interface PinnedSkillsProps {
-  onSkillSelect: (skillId: string) => void;
+  onSkillSelect: (skillId: string, skillName: string) => void;
   selectedSkillId?: string;
 }
 
@@ -30,7 +30,7 @@ export function PinnedSkills({
           key={skill.id}
           variant={selectedSkillId === skill.id ? 'default' : 'outline'}
           size="sm"
-          onClick={() => onSkillSelect(skill.id)}
+          onClick={() => onSkillSelect(skill.id, skill.name)}
         >
           <Sparkles className="h-4 w-4" />
           {skill.name}

--- a/ayunis-core-frontend/src/shared/contexts/chat/ChatContextProvider.tsx
+++ b/ayunis-core-frontend/src/shared/contexts/chat/ChatContextProvider.tsx
@@ -25,6 +25,7 @@ export const ChatContextProvider = ({
   const [pendingKnowledgeBases, setPendingKnowledgeBases] = useState<
     KnowledgeBaseSummary[]
   >([]);
+  const [pendingSkillId, setPendingSkillId] = useState<string | undefined>();
 
   // Memoize the context value to prevent unnecessary re-renders
   const contextValue = useMemo(
@@ -37,8 +38,16 @@ export const ChatContextProvider = ({
       setPendingImages,
       pendingKnowledgeBases,
       setPendingKnowledgeBases,
+      pendingSkillId,
+      setPendingSkillId,
     }),
-    [pendingMessage, sources, pendingImages, pendingKnowledgeBases],
+    [
+      pendingMessage,
+      sources,
+      pendingImages,
+      pendingKnowledgeBases,
+      pendingSkillId,
+    ],
   );
 
   return (

--- a/ayunis-core-frontend/src/shared/contexts/chat/chatContext.ts
+++ b/ayunis-core-frontend/src/shared/contexts/chat/chatContext.ts
@@ -32,6 +32,8 @@ type ChatContextType = {
   setPendingImages: (images: PendingImageFile[]) => void;
   pendingKnowledgeBases: KnowledgeBaseSummary[];
   setPendingKnowledgeBases: (kbs: KnowledgeBaseSummary[]) => void;
+  pendingSkillId: string | undefined;
+  setPendingSkillId: (skillId: string | undefined) => void;
 };
 
 export const ChatContext = createContext<ChatContextType>({
@@ -50,5 +52,9 @@ export const ChatContext = createContext<ChatContextType>({
   pendingKnowledgeBases: [],
   setPendingKnowledgeBases: () => {
     throw new Error('setPendingKnowledgeBases is not implemented');
+  },
+  pendingSkillId: undefined,
+  setPendingSkillId: () => {
+    throw new Error('setPendingSkillId is not implemented');
   },
 });


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches chat send flow by adding `skillId` propagation via shared context, which could affect first-message behavior if not handled consistently. The rest is UI wiring and a small refactor of download logic.
> 
> **Overview**
> Enables selecting a pinned skill on the *new chat* screen and carrying that selection through thread creation by storing `pendingSkillId` in `ChatContext` and sending it with the first `sendTextMessage` call from `ChatPage` (then clearing it after send).
> 
> Updates the pinned skills UI to pass both skill id and name, and feeds the selected skill into `ChatInput` so it can be displayed/removed.
> 
> Refactors “download source” logic out of `ChatPage` into a new `useDownloadSource` hook, keeping the behavior (API call, blob download, toast on failure) but removing inline duplication.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 55a78704a33a5c8edee3010ffb6d7616e941c731. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->