### PR TITLE
wip(AYC-000): show mcp integration description in integrations card

### DIFF
--- a/ayunis-core-frontend/src/widgets/mcp-integrations-card/ui/McpIntegrationsCard.tsx
+++ b/ayunis-core-frontend/src/widgets/mcp-integrations-card/ui/McpIntegrationsCard.tsx
@@ -12,6 +12,7 @@ import {
   Item,
   ItemActions,
   ItemContent,
+  ItemDescription,
   ItemTitle,
 } from '@/shared/ui/shadcn/item';
 import { cn } from '@/shared/lib/shadcn/utils';
@@ -129,6 +130,11 @@ export default function McpIntegrationsCard({
                 >
                   <ItemContent>
                     <ItemTitle>{integration.name}</ItemTitle>
+                    {integration.description && (
+                      <ItemDescription>
+                        {integration.description}
+                      </ItemDescription>
+                    )}
                   </ItemContent>
                   <ItemActions>
                     <Switch


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> UI-only change that conditionally renders existing API data; minimal behavioral risk beyond layout/overflow differences.
> 
> **Overview**
> The MCP integrations card now renders each integration’s `description` (when present) under the integration name using `ItemDescription`, improving the information shown alongside the toggle.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7b0fd40061ba665bf4819e6b5ff837f21ff6fc55. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->