### PR TITLE
fix(AYC-000): use StringValue type for jwt expiresIn config

### DIFF
--- a/ayunis-core-backend/src/iam/authentication/authentication.module.ts
+++ b/ayunis-core-backend/src/iam/authentication/authentication.module.ts
@@ -1,6 +1,7 @@
 import { DynamicModule, Module } from '@nestjs/common';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { JwtModule, JwtService } from '@nestjs/jwt';
+import type { StringValue } from 'ms';
 import { PassportModule } from '@nestjs/passport';
 
 import { JwtStrategy } from './application/strategies/jwt.strategy';
@@ -60,7 +61,10 @@ export class AuthenticationModule {
               'dev-secret-change-in-production',
             ),
             signOptions: {
-              expiresIn: configService.get<string>('auth.jwt.expiresIn', '1h'),
+              expiresIn: configService.get<StringValue>(
+                'auth.jwt.expiresIn',
+                '1h',
+              ),
             },
           }),
         }),
@@ -74,14 +78,14 @@ export class AuthenticationModule {
             jwtService: JwtService,
           ) => {
             const provider =
-              options?.provider ||
+              options?.provider ??
               configService.get<AuthProvider>(
                 'auth.provider',
                 AuthProvider.LOCAL,
               );
 
             if (provider === AuthProvider.CLOUD) {
-              // TODO: Implement cloud authentication repository
+              // FUTURE: Implement cloud authentication repository
               throw new Error(
                 'Cloud authentication repository not implemented',
               );

--- a/ayunis-core-backend/src/iam/authentication/infrastructure/repositories/local/local-authentication.repository.ts
+++ b/ayunis-core-backend/src/iam/authentication/infrastructure/repositories/local/local-authentication.repository.ts
@@ -4,11 +4,12 @@ import { ConfigService } from '@nestjs/config';
 import { AuthenticationRepository } from '../../../application/ports/authentication.repository';
 import { ActiveUser } from '../../../domain/active-user.entity';
 import { AuthTokens } from 'src/iam/authentication/domain/auth-tokens.entity';
+import type { StringValue } from 'ms';
 
 interface JwtConfig {
   secret: string;
-  expiresIn: string;
-  refreshTokenExpiresIn: string;
+  expiresIn: StringValue;
+  refreshTokenExpiresIn: StringValue;
 }
 
 @Injectable()

--- a/ayunis-core-backend/src/iam/invites/application/services/invite-jwt.service.ts
+++ b/ayunis-core-backend/src/iam/invites/application/services/invite-jwt.service.ts
@@ -2,6 +2,7 @@ import { Injectable, Logger } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import { ConfigService } from '@nestjs/config';
 import { UUID } from 'crypto';
+import type { StringValue } from 'ms';
 import { InvalidInviteTokenError } from '../invites.errors';
 
 export interface InviteJwtPayload {
@@ -26,7 +27,7 @@ export class InviteJwtService {
       inviteId: params.inviteId,
     };
 
-    const expiresIn = this.configService.get<string>(
+    const expiresIn = this.configService.get<StringValue>(
       'auth.jwt.inviteExpiresIn',
       '2d',
     );

--- a/ayunis-core-backend/src/iam/invites/invites.module.ts
+++ b/ayunis-core-backend/src/iam/invites/invites.module.ts
@@ -2,6 +2,7 @@ import { forwardRef, Module } from '@nestjs/common';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { JwtModule } from '@nestjs/jwt';
+import type { StringValue } from 'ms';
 
 // Entities and Infrastructure
 import { InviteRecord } from './infrastructure/persistence/local/schema/invite.record';
@@ -50,7 +51,7 @@ import { EmailTemplatesModule } from '../../common/email-templates/email-templat
           'dev-secret-change-in-production',
         ),
         signOptions: {
-          expiresIn: configService.get<string>(
+          expiresIn: configService.get<StringValue>(
             'auth.jwt.inviteExpiresIn',
             '7d',
           ),

--- a/ayunis-core-backend/src/iam/users/application/services/email-confirmation-jwt.service.ts
+++ b/ayunis-core-backend/src/iam/users/application/services/email-confirmation-jwt.service.ts
@@ -2,6 +2,7 @@ import { Injectable, Logger } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import { ConfigService } from '@nestjs/config';
 import { UUID } from 'crypto';
+import type { StringValue } from 'ms';
 import { InvalidEmailConfirmationTokenError } from '../users.errors';
 
 export interface EmailConfirmationJwtPayload {
@@ -32,7 +33,7 @@ export class EmailConfirmationJwtService {
       email: params.email,
     };
 
-    const expiresIn = this.configService.get<string>(
+    const expiresIn = this.configService.get<StringValue>(
       'auth.jwt.emailConfirmationExpiresIn',
       '24h',
     );

--- a/ayunis-core-backend/src/iam/users/application/services/password-reset-jwt.service.ts
+++ b/ayunis-core-backend/src/iam/users/application/services/password-reset-jwt.service.ts
@@ -2,6 +2,7 @@ import { Injectable, Logger } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import { ConfigService } from '@nestjs/config';
 import { UUID } from 'crypto';
+import type { StringValue } from 'ms';
 import { InvalidTokenError } from '../../../authentication/application/authentication.errors';
 
 export interface PasswordResetJwtPayload {
@@ -29,7 +30,7 @@ export class PasswordResetJwtService {
       email: params.email,
     };
 
-    const expiresIn = this.configService.get<string>(
+    const expiresIn = this.configService.get<StringValue>(
       'auth.jwt.passwordResetExpiresIn',
       '2h',
     );

--- a/ayunis-core-backend/src/iam/users/users.module.ts
+++ b/ayunis-core-backend/src/iam/users/users.module.ts
@@ -8,6 +8,7 @@ import { Repository } from 'typeorm';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { HashingModule } from '../hashing/hashing.module';
 import { JwtModule } from '@nestjs/jwt';
+import type { StringValue } from 'ms';
 import { EmailsModule } from 'src/common/emails/emails.module';
 import { EmailTemplatesModule } from 'src/common/email-templates/email-templates.module';
 
@@ -60,7 +61,7 @@ import { SuperAdminUsersController } from './presenters/http/super-admin-users.c
           'dev-secret-change-in-production',
         ),
         signOptions: {
-          expiresIn: configService.get<string>(
+          expiresIn: configService.get<StringValue>(
             'auth.jwt.emailConfirmationExpiresIn',
             '24h',
           ),
@@ -73,7 +74,7 @@ import { SuperAdminUsersController } from './presenters/http/super-admin-users.c
     {
       provide: UsersRepository,
       useFactory: (userRepository: Repository<UserRecord>) => {
-        // TODO: Implement cloud users repository when auth.provider === AuthProvider.CLOUD
+        // FUTURE: Implement cloud users repository when auth.provider === AuthProvider.CLOUD
         return new LocalUsersRepository(userRepository);
       },
       inject: [getRepositoryToken(UserRecord)],


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Type-only adjustments to JWT expiry configuration plus minor comment/operator tweaks; behavior should be unchanged aside from edge cases where `options.provider` was falsy.
> 
> **Overview**
> Updates JWT expiry configuration typing across auth, invites, and users to use `ms`'s `StringValue` instead of plain `string`, aligning `ConfigService.get()` calls and local `JwtConfig` types with what `jsonwebtoken` expects for `expiresIn`.
> 
> Also replaces a couple of `// TODO` comments with `// FUTURE` and switches one provider selection from `||` to nullish coalescing (`??`) to avoid overriding intentionally falsy option values.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f32c7dbfe8f7e756e161b8c96dbcd3016eba5525. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->