### PR TITLE
fix(AYC-000): invalidate skill detail query on toggle active and pinned

### DIFF
--- a/ayunis-core-frontend/src/features/skill-actions/api/useToggleSkillActive.ts
+++ b/ayunis-core-frontend/src/features/skill-actions/api/useToggleSkillActive.ts
@@ -4,6 +4,7 @@ import { showSuccess, showError } from '@/shared/lib/toast';
 import {
   skillsControllerToggleActive,
   getSkillsControllerFindAllQueryKey,
+  getSkillsControllerFindOneQueryKey,
 } from '@/shared/api/generated/ayunisCoreAPI';
 import { useRouter } from '@tanstack/react-router';
 import extractErrorData from '@/shared/api/extract-error-data';
@@ -21,9 +22,12 @@ export function useToggleSkillActive() {
     mutationFn: async ({ id }: ToggleSkillActiveParams) => {
       return await skillsControllerToggleActive(id);
     },
-    onSuccess: () => {
+    onSuccess: (_data, { id }) => {
       void queryClient.invalidateQueries({
         queryKey: getSkillsControllerFindAllQueryKey(),
+      });
+      void queryClient.invalidateQueries({
+        queryKey: getSkillsControllerFindOneQueryKey(id),
       });
       void router.invalidate();
       showSuccess(t('toggleActive.success'));

--- a/ayunis-core-frontend/src/features/skill-actions/api/useToggleSkillPinned.ts
+++ b/ayunis-core-frontend/src/features/skill-actions/api/useToggleSkillPinned.ts
@@ -4,6 +4,7 @@ import { showSuccess, showError } from '@/shared/lib/toast';
 import {
   skillsControllerTogglePinned,
   getSkillsControllerFindAllQueryKey,
+  getSkillsControllerFindOneQueryKey,
 } from '@/shared/api/generated/ayunisCoreAPI';
 import { useRouter } from '@tanstack/react-router';
 import extractErrorData from '@/shared/api/extract-error-data';
@@ -21,9 +22,12 @@ export function useToggleSkillPinned() {
     mutationFn: async ({ id }: ToggleSkillPinnedParams) => {
       return await skillsControllerTogglePinned(id);
     },
-    onSuccess: () => {
+    onSuccess: (_data, { id }) => {
       void queryClient.invalidateQueries({
         queryKey: getSkillsControllerFindAllQueryKey(),
+      });
+      void queryClient.invalidateQueries({
+        queryKey: getSkillsControllerFindOneQueryKey(id),
       });
       void router.invalidate();
       showSuccess(t('togglePinned.success'));


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small change limited to React Query cache invalidation after mutations; low risk aside from potential extra refetching.
> 
> **Overview**
> Fixes stale skill detail data after toggling `active` or `pinned`.
> 
> Both `useToggleSkillActive` and `useToggleSkillPinned` now also invalidate the per-skill `getSkillsControllerFindOneQueryKey(id)` query (in addition to the skills list) by passing the `id` from the mutation params into `onSuccess`, ensuring the skill detail route refetches updated state.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 909a30de2386d7a9d28d6c7b39b9ace90b507881. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->