### PR TITLE
fix(AYC-000): allow emojis and unicode in skill name validation

### DIFF
--- a/ayunis-core-backend/src/domain/skills/domain/skill.entity.spec.ts
+++ b/ayunis-core-backend/src/domain/skills/domain/skill.entity.spec.ts
@@ -133,10 +133,38 @@ describe('Skill Entity', () => {
       );
     });
 
-    it('should reject names with unicode characters', () => {
-      expect(() => new Skill({ ...validParams, name: 'Recht Résumé' })).toThrow(
-        InvalidSkillNameError,
-      );
+    it('should accept names with unicode letters', () => {
+      const skill = new Skill({ ...validParams, name: 'Recht Résumé' });
+      expect(skill.name).toBe('Recht Résumé');
+    });
+
+    it('should accept names with German umlauts', () => {
+      const skill = new Skill({ ...validParams, name: 'Bürgerhilfe' });
+      expect(skill.name).toBe('Bürgerhilfe');
+    });
+
+    it('should accept names with emojis', () => {
+      const skill = new Skill({ ...validParams, name: '🔍 Research' });
+      expect(skill.name).toBe('🔍 Research');
+    });
+
+    it('should accept a single emoji as name', () => {
+      const skill = new Skill({ ...validParams, name: '📚' });
+      expect(skill.name).toBe('📚');
+    });
+
+    it('should reject names with invisible emoji components', () => {
+      // ZWJ (U+200D) should not be allowed
+      expect(
+        () => new Skill({ ...validParams, name: 'Test\u200DSkill' }),
+      ).toThrow(InvalidSkillNameError);
+    });
+
+    it('should reject names ending with variation selector', () => {
+      // Variation selector (U+FE0F) should not be allowed
+      expect(
+        () => new Skill({ ...validParams, name: 'Test\uFE0F' }),
+      ).toThrow(InvalidSkillNameError);
     });
   });
 });

--- a/ayunis-core-backend/src/domain/skills/domain/skill.entity.ts
+++ b/ayunis-core-backend/src/domain/skills/domain/skill.entity.ts
@@ -2,18 +2,22 @@ import type { UUID } from 'crypto';
 import { randomUUID } from 'crypto';
 
 /**
- * Valid skill names: letters, numbers, hyphens, and spaces.
- * Must start and end with a letter or number.
+ * Valid skill names: Unicode letters, numbers, emojis, hyphens, and spaces.
+ * Must start and end with a letter, number, or emoji.
  * No consecutive spaces. Min length 1.
+ *
+ * Uses \p{Emoji_Presentation} for visible emojis only — excludes invisible
+ * components like ZWJ (U+200D) and variation selectors (U+FE0E/FE0F).
  */
-const SKILL_NAME_PATTERN = /^[a-zA-Z0-9]([a-zA-Z0-9 -]*[a-zA-Z0-9])?$/;
+const SKILL_NAME_PATTERN =
+  /^[\p{L}\p{N}\p{Emoji_Presentation}]([\p{L}\p{N}\p{Emoji_Presentation} -]*[\p{L}\p{N}\p{Emoji_Presentation}])?$/u;
 const CONSECUTIVE_SPACES = / {2}/;
 
 export class InvalidSkillNameError extends Error {
   constructor(name: string) {
     super(
-      `Invalid skill name "${name}". Names must contain only letters, numbers, hyphens, and spaces, ` +
-        `must start and end with a letter or number, and must not contain consecutive spaces.`,
+      `Invalid skill name "${name}". Names must contain only letters, numbers, emojis, hyphens, and spaces, ` +
+        `must start and end with a letter, number, or emoji, and must not contain consecutive spaces.`,
     );
     this.name = 'InvalidSkillNameError';
   }

--- a/ayunis-core-backend/src/domain/skills/presenters/http/dto/base-skill.dto.ts
+++ b/ayunis-core-backend/src/domain/skills/presenters/http/dto/base-skill.dto.ts
@@ -4,7 +4,7 @@ import { IsString, IsNotEmpty, Length, Matches } from 'class-validator';
 export class BaseSkillDto {
   @ApiProperty({
     description:
-      'The name of the skill (must be unique per user). Only letters, numbers, hyphens, and spaces allowed. Must start and end with a letter or number.',
+      'The name of the skill (must be unique per user). Only letters, numbers, emojis, hyphens, and spaces allowed. Must start and end with a letter, number, or emoji.',
     example: 'Legal Research',
     minLength: 1,
     maxLength: 255,
@@ -12,10 +12,13 @@ export class BaseSkillDto {
   @IsString()
   @IsNotEmpty()
   @Length(1, 255)
-  @Matches(/^[a-zA-Z0-9]([a-zA-Z0-9 -]*[a-zA-Z0-9])?$/, {
-    message:
-      'Name must contain only letters, numbers, hyphens, and spaces, and must start and end with a letter or number',
-  })
+  @Matches(
+    /^[\p{L}\p{N}\p{Emoji_Presentation}]([\p{L}\p{N}\p{Emoji_Presentation} -]*[\p{L}\p{N}\p{Emoji_Presentation}])?$/u,
+    {
+      message:
+        'Name must contain only letters, numbers, emojis, hyphens, and spaces, and must start and end with a letter, number, or emoji',
+    },
+  )
   @Matches(/^(?!.* {2})/, {
     message: 'Name must not contain consecutive spaces',
   })

--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
@@ -2540,7 +2540,7 @@ export interface SkillResponseDto {
 
 export interface CreateSkillDto {
   /**
-   * The name of the skill (must be unique per user). Only letters, numbers, hyphens, and spaces allowed. Must start and end with a letter or number.
+   * The name of the skill (must be unique per user). Only letters, numbers, emojis, hyphens, and spaces allowed. Must start and end with a letter, number, or emoji.
    * @minLength 1
    * @maxLength 255
    */
@@ -2555,7 +2555,7 @@ export interface CreateSkillDto {
 
 export interface UpdateSkillDto {
   /**
-   * The name of the skill (must be unique per user). Only letters, numbers, hyphens, and spaces allowed. Must start and end with a letter or number.
+   * The name of the skill (must be unique per user). Only letters, numbers, emojis, hyphens, and spaces allowed. Must start and end with a letter, number, or emoji.
    * @minLength 1
    * @maxLength 255
    */

--- a/ayunis-core-frontend/src/shared/api/openapi-schema.json
+++ b/ayunis-core-frontend/src/shared/api/openapi-schema.json
@@ -11633,7 +11633,7 @@
         "properties": {
           "name": {
             "type": "string",
-            "description": "The name of the skill (must be unique per user). Only letters, numbers, hyphens, and spaces allowed. Must start and end with a letter or number.",
+            "description": "The name of the skill (must be unique per user). Only letters, numbers, emojis, hyphens, and spaces allowed. Must start and end with a letter, number, or emoji.",
             "example": "Legal Research",
             "minLength": 1,
             "maxLength": 255
@@ -11665,7 +11665,7 @@
         "properties": {
           "name": {
             "type": "string",
-            "description": "The name of the skill (must be unique per user). Only letters, numbers, hyphens, and spaces allowed. Must start and end with a letter or number.",
+            "description": "The name of the skill (must be unique per user). Only letters, numbers, emojis, hyphens, and spaces allowed. Must start and end with a letter, number, or emoji.",
             "example": "Legal Research",
             "minLength": 1,
             "maxLength": 255


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes backend/domain and request DTO validation rules for skill names, which can impact what gets accepted/rejected and potentially affect persisted data and client-side assumptions. Regex relies on Unicode property escapes and emoji handling, so edge cases across runtimes/locales should be watched.
> 
> **Overview**
> **Skill name validation is broadened to support Unicode letters and visible emojis.** The backend `Skill` entity and `BaseSkillDto` now validate names using Unicode-aware regex (`\p{L}`, `\p{N}`, `\p{Emoji_Presentation}`) instead of ASCII-only rules, while keeping constraints like no consecutive spaces and requiring valid start/end characters.
> 
> Tests are updated to assert acceptance of accented characters/umlauts and emoji-only or emoji-prefixed names, and to explicitly reject invisible emoji components (e.g., ZWJ and variation selectors). Frontend generated OpenAPI schema text is updated to reflect the new validation description.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c55912cdc454c3415694411934ffefdc2f694eef. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->