### PR TITLE
wip(AYC-96): add global user usage backend endpoint

### DIFF
--- a/ayunis-core-backend/src/domain/skills/domain/skill.entity.spec.ts
+++ b/ayunis-core-backend/src/domain/skills/domain/skill.entity.spec.ts
@@ -162,9 +162,9 @@ describe('Skill Entity', () => {
 
     it('should reject names ending with variation selector', () => {
       // Variation selector (U+FE0F) should not be allowed
-      expect(
-        () => new Skill({ ...validParams, name: 'Test\uFE0F' }),
-      ).toThrow(InvalidSkillNameError);
+      expect(() => new Skill({ ...validParams, name: 'Test\uFE0F' })).toThrow(
+        InvalidSkillNameError,
+      );
     });
   });
 });

--- a/ayunis-core-backend/src/domain/usage/SUMMARY.md
+++ b/ayunis-core-backend/src/domain/usage/SUMMARY.md
@@ -7,9 +7,9 @@ The usage module provides comprehensive analytics for AI resource consumption. T
 
 **Organization-scoped use cases**: collecting usage after each run (`CollectUsageUseCase`), querying provider-level usage (`GetProviderUsageUseCase`), model distribution analytics (`GetModelDistributionUseCase`), aggregate stats (`GetUsageStatsUseCase`), and per-user usage reports (`GetUserUsageUseCase`).
 
-**Global (cross-organization) use cases**: `GetGlobalProviderUsageUseCase` and `GetGlobalModelDistributionUseCase` aggregate usage data across all organizations for super admin analytics dashboards.
+**Global (cross-organization) use cases**: `GetGlobalProviderUsageUseCase`, `GetGlobalModelDistributionUseCase`, and `GetGlobalUserUsageUseCase` aggregate usage data across all organizations for super admin analytics dashboards.
 
-**Ports**: `UsageRepository` defines abstract methods for both organization-scoped queries and global analytics (`getGlobalProviderUsage`, `getGlobalModelDistribution`).
+**Ports**: `UsageRepository` defines abstract methods for both organization-scoped queries and global analytics (`getGlobalProviderUsage`, `getGlobalModelDistribution`, `getGlobalUserUsage`).
 
 **Presentation layer**: `UsageController` serves organization member requests. Super admin controllers include `SuperAdminUsageController` (org-scoped stats/models), `SuperAdminUsageDataController` (org-scoped providers/users), and `SuperAdminGlobalUsageController` (cross-organization global analytics).
 

--- a/ayunis-core-backend/src/domain/usage/application/ports/usage.repository.ts
+++ b/ayunis-core-backend/src/domain/usage/application/ports/usage.repository.ts
@@ -5,6 +5,7 @@ import type { GetProviderUsageQuery } from '../use-cases/get-provider-usage/get-
 import type { GetModelDistributionQuery } from '../use-cases/get-model-distribution/get-model-distribution.query';
 import type { GetGlobalProviderUsageQuery } from '../use-cases/get-global-provider-usage/get-global-provider-usage.query';
 import type { GetGlobalModelDistributionQuery } from '../use-cases/get-global-model-distribution/get-global-model-distribution.query';
+import type { GetGlobalUserUsageQuery } from '../use-cases/get-global-user-usage/get-global-user-usage.query';
 import type { GetUsageStatsQuery } from '../use-cases/get-usage-stats/get-usage-stats.query';
 import type { Paginated } from 'src/common/pagination';
 import { UsageStats } from '../../domain/usage-stats.entity';
@@ -12,12 +13,14 @@ import { ProviderUsage } from '../../domain/provider-usage.entity';
 import { TimeSeriesPoint } from '../../domain/time-series-point.entity';
 import { ModelDistribution } from '../../domain/model-distribution.entity';
 import { UserUsageItem } from '../../domain/user-usage-item.entity';
+import { GlobalUserUsageItem } from '../../domain/global-user-usage-item.entity';
 export {
   UsageStats,
   ProviderUsage,
   TimeSeriesPoint,
   ModelDistribution,
   UserUsageItem,
+  GlobalUserUsageItem,
 };
 
 export abstract class UsageRepository {
@@ -61,4 +64,8 @@ export abstract class UsageRepository {
   abstract getGlobalModelDistribution(
     query: GetGlobalModelDistributionQuery,
   ): Promise<ModelDistribution[]>;
+
+  abstract getGlobalUserUsage(
+    query: GetGlobalUserUsageQuery,
+  ): Promise<GlobalUserUsageItem[]>;
 }

--- a/ayunis-core-backend/src/domain/usage/application/usage.utils.spec.ts
+++ b/ayunis-core-backend/src/domain/usage/application/usage.utils.spec.ts
@@ -1,0 +1,36 @@
+import { validateOptionalDateRange } from './usage.utils';
+import { InvalidDateRangeError } from './usage.errors';
+
+describe('validateOptionalDateRange', () => {
+  it('should not throw when both dates are undefined', () => {
+    expect(() => validateOptionalDateRange(undefined, undefined)).not.toThrow();
+  });
+
+  it('should not throw when both dates are provided and valid', () => {
+    const startDate = new Date('2024-01-01');
+    const endDate = new Date('2024-01-31');
+    expect(() => validateOptionalDateRange(startDate, endDate)).not.toThrow();
+  });
+
+  it('should throw when only startDate is provided', () => {
+    const startDate = new Date('2024-01-01');
+    expect(() => validateOptionalDateRange(startDate, undefined)).toThrow(
+      InvalidDateRangeError,
+    );
+  });
+
+  it('should throw when only endDate is provided', () => {
+    const endDate = new Date('2024-01-31');
+    expect(() => validateOptionalDateRange(undefined, endDate)).toThrow(
+      InvalidDateRangeError,
+    );
+  });
+
+  it('should throw when start date is after end date', () => {
+    const startDate = new Date('2024-01-31');
+    const endDate = new Date('2024-01-01');
+    expect(() => validateOptionalDateRange(startDate, endDate)).toThrow(
+      InvalidDateRangeError,
+    );
+  });
+});

--- a/ayunis-core-backend/src/domain/usage/application/usage.utils.ts
+++ b/ayunis-core-backend/src/domain/usage/application/usage.utils.ts
@@ -4,6 +4,27 @@ import { ModelDistribution } from '../domain/model-distribution.entity';
 import { ProviderUsage } from '../domain/provider-usage.entity';
 
 /**
+ * Validates that both startDate and endDate are provided together (or neither),
+ * and if both are present, validates the range.
+ * @throws InvalidDateRangeError if only one is provided or the range is invalid
+ */
+export function validateOptionalDateRange(
+  startDate?: Date,
+  endDate?: Date,
+): void {
+  const hasStart = startDate !== undefined;
+  const hasEnd = endDate !== undefined;
+  if (hasStart !== hasEnd) {
+    throw new InvalidDateRangeError(
+      'Both startDate and endDate must be provided, or neither',
+    );
+  }
+  if (startDate && endDate) {
+    validateDateRange(startDate, endDate);
+  }
+}
+
+/**
  * Validates that a date range is valid for usage queries.
  * @throws InvalidDateRangeError if the date range is invalid
  */

--- a/ayunis-core-backend/src/domain/usage/application/use-cases/get-global-model-distribution/get-global-model-distribution.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/usage/application/use-cases/get-global-model-distribution/get-global-model-distribution.use-case.spec.ts
@@ -1,0 +1,164 @@
+import type { TestingModule } from '@nestjs/testing';
+import { Test } from '@nestjs/testing';
+import { GetGlobalModelDistributionUseCase } from './get-global-model-distribution.use-case';
+import { GetGlobalModelDistributionQuery } from './get-global-model-distribution.query';
+import { UsageRepository } from '../../ports/usage.repository';
+import { InvalidDateRangeError } from '../../usage.errors';
+import { ModelDistribution } from '../../../domain/model-distribution.entity';
+import { ModelProvider } from '../../../../models/domain/value-objects/model-provider.enum';
+import type { UUID } from 'crypto';
+
+describe('GetGlobalModelDistributionUseCase', () => {
+  let useCase: GetGlobalModelDistributionUseCase;
+  let mockUsageRepository: Partial<UsageRepository>;
+
+  beforeAll(async () => {
+    mockUsageRepository = {
+      getGlobalModelDistribution: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        GetGlobalModelDistributionUseCase,
+        { provide: UsageRepository, useValue: mockUsageRepository },
+      ],
+    }).compile();
+
+    useCase = module.get<GetGlobalModelDistributionUseCase>(
+      GetGlobalModelDistributionUseCase,
+    );
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(useCase).toBeDefined();
+  });
+
+  describe('successful execution', () => {
+    it('should return model distribution with recalculated percentages', async () => {
+      const mockModels = [
+        new ModelDistribution({
+          modelId: 'model-1' as UUID,
+          modelName: 'gpt-4',
+          displayName: 'GPT-4',
+          provider: ModelProvider.OPENAI,
+          tokens: 600,
+          requests: 6,
+          percentage: 0,
+        }),
+        new ModelDistribution({
+          modelId: 'model-2' as UUID,
+          modelName: 'claude-3',
+          displayName: 'Claude 3',
+          provider: ModelProvider.ANTHROPIC,
+          tokens: 400,
+          requests: 4,
+          percentage: 0,
+        }),
+      ];
+
+      jest
+        .spyOn(mockUsageRepository, 'getGlobalModelDistribution')
+        .mockResolvedValue(mockModels);
+
+      const query = new GetGlobalModelDistributionQuery({});
+      const result = await useCase.execute(query);
+
+      expect(result).toHaveLength(2);
+      expect(result[0].percentage).toBe(60);
+      expect(result[1].percentage).toBe(40);
+    });
+
+    it('should return empty array when no models', async () => {
+      jest
+        .spyOn(mockUsageRepository, 'getGlobalModelDistribution')
+        .mockResolvedValue([]);
+
+      const query = new GetGlobalModelDistributionQuery({});
+      const result = await useCase.execute(query);
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('date range validation', () => {
+    it('should throw InvalidDateRangeError when only startDate is provided', async () => {
+      const query = new GetGlobalModelDistributionQuery({
+        startDate: new Date('2024-01-01'),
+      });
+
+      await expect(useCase.execute(query)).rejects.toThrow(
+        InvalidDateRangeError,
+      );
+    });
+
+    it('should throw InvalidDateRangeError when only endDate is provided', async () => {
+      const query = new GetGlobalModelDistributionQuery({
+        endDate: new Date('2024-01-31'),
+      });
+
+      await expect(useCase.execute(query)).rejects.toThrow(
+        InvalidDateRangeError,
+      );
+    });
+
+    it('should throw InvalidDateRangeError when start date is after end date', async () => {
+      const query = new GetGlobalModelDistributionQuery({
+        startDate: new Date('2024-01-31'),
+        endDate: new Date('2024-01-01'),
+      });
+
+      await expect(useCase.execute(query)).rejects.toThrow(
+        InvalidDateRangeError,
+      );
+    });
+
+    it('should accept valid date range', async () => {
+      jest
+        .spyOn(mockUsageRepository, 'getGlobalModelDistribution')
+        .mockResolvedValue([]);
+
+      const query = new GetGlobalModelDistributionQuery({
+        startDate: new Date('2024-01-01'),
+        endDate: new Date('2024-01-31'),
+      });
+
+      await expect(useCase.execute(query)).resolves.toBeDefined();
+    });
+
+    it('should accept query without date range', async () => {
+      jest
+        .spyOn(mockUsageRepository, 'getGlobalModelDistribution')
+        .mockResolvedValue([]);
+
+      const query = new GetGlobalModelDistributionQuery({});
+
+      await expect(useCase.execute(query)).resolves.toBeDefined();
+    });
+  });
+
+  describe('maxModels validation', () => {
+    it('should throw InvalidDateRangeError when maxModels is zero', async () => {
+      const query = new GetGlobalModelDistributionQuery({
+        maxModels: 0,
+      });
+
+      await expect(useCase.execute(query)).rejects.toThrow(
+        InvalidDateRangeError,
+      );
+    });
+
+    it('should throw InvalidDateRangeError when maxModels is negative', async () => {
+      const query = new GetGlobalModelDistributionQuery({
+        maxModels: -1,
+      });
+
+      await expect(useCase.execute(query)).rejects.toThrow(
+        InvalidDateRangeError,
+      );
+    });
+  });
+});

--- a/ayunis-core-backend/src/domain/usage/application/use-cases/get-global-model-distribution/get-global-model-distribution.use-case.ts
+++ b/ayunis-core-backend/src/domain/usage/application/use-cases/get-global-model-distribution/get-global-model-distribution.use-case.ts
@@ -3,7 +3,10 @@ import { GetGlobalModelDistributionQuery } from './get-global-model-distribution
 import { UsageRepository } from '../../ports/usage.repository';
 import { ModelDistribution } from '../../../domain/model-distribution.entity';
 import { InvalidDateRangeError } from '../../usage.errors';
-import { validateDateRange, processModelDistribution } from '../../usage.utils';
+import {
+  validateOptionalDateRange,
+  processModelDistribution,
+} from '../../usage.utils';
 
 @Injectable()
 export class GetGlobalModelDistributionUseCase {
@@ -12,9 +15,7 @@ export class GetGlobalModelDistributionUseCase {
   async execute(
     query: GetGlobalModelDistributionQuery,
   ): Promise<ModelDistribution[]> {
-    if (query.startDate && query.endDate) {
-      validateDateRange(query.startDate, query.endDate);
-    }
+    validateOptionalDateRange(query.startDate, query.endDate);
 
     if (query.maxModels <= 0) {
       throw new InvalidDateRangeError('Max models must be greater than 0');

--- a/ayunis-core-backend/src/domain/usage/application/use-cases/get-global-provider-usage/get-global-provider-usage.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/usage/application/use-cases/get-global-provider-usage/get-global-provider-usage.use-case.spec.ts
@@ -1,0 +1,137 @@
+import type { TestingModule } from '@nestjs/testing';
+import { Test } from '@nestjs/testing';
+import { GetGlobalProviderUsageUseCase } from './get-global-provider-usage.use-case';
+import { GetGlobalProviderUsageQuery } from './get-global-provider-usage.query';
+import { UsageRepository } from '../../ports/usage.repository';
+import { InvalidDateRangeError } from '../../usage.errors';
+import { ProviderUsage } from '../../../domain/provider-usage.entity';
+import { ModelProvider } from '../../../../models/domain/value-objects/model-provider.enum';
+
+describe('GetGlobalProviderUsageUseCase', () => {
+  let useCase: GetGlobalProviderUsageUseCase;
+  let mockUsageRepository: Partial<UsageRepository>;
+
+  beforeAll(async () => {
+    mockUsageRepository = {
+      getGlobalProviderUsage: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        GetGlobalProviderUsageUseCase,
+        { provide: UsageRepository, useValue: mockUsageRepository },
+      ],
+    }).compile();
+
+    useCase = module.get<GetGlobalProviderUsageUseCase>(
+      GetGlobalProviderUsageUseCase,
+    );
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(useCase).toBeDefined();
+  });
+
+  describe('successful execution', () => {
+    it('should return provider usage with recalculated percentages', async () => {
+      const mockProviderUsage = [
+        new ProviderUsage({
+          provider: ModelProvider.OPENAI,
+          tokens: 600,
+          requests: 6,
+          percentage: 0,
+          timeSeriesData: [],
+        }),
+        new ProviderUsage({
+          provider: ModelProvider.ANTHROPIC,
+          tokens: 400,
+          requests: 4,
+          percentage: 0,
+          timeSeriesData: [],
+        }),
+      ];
+
+      jest
+        .spyOn(mockUsageRepository, 'getGlobalProviderUsage')
+        .mockResolvedValue(mockProviderUsage);
+
+      const query = new GetGlobalProviderUsageQuery({});
+      const result = await useCase.execute(query);
+
+      expect(result).toHaveLength(2);
+      expect(result[0].percentage).toBe(60);
+      expect(result[1].percentage).toBe(40);
+    });
+
+    it('should return empty array when no providers', async () => {
+      jest
+        .spyOn(mockUsageRepository, 'getGlobalProviderUsage')
+        .mockResolvedValue([]);
+
+      const query = new GetGlobalProviderUsageQuery({});
+      const result = await useCase.execute(query);
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('date range validation', () => {
+    it('should throw InvalidDateRangeError when only startDate is provided', async () => {
+      const query = new GetGlobalProviderUsageQuery({
+        startDate: new Date('2024-01-01'),
+      });
+
+      await expect(useCase.execute(query)).rejects.toThrow(
+        InvalidDateRangeError,
+      );
+    });
+
+    it('should throw InvalidDateRangeError when only endDate is provided', async () => {
+      const query = new GetGlobalProviderUsageQuery({
+        endDate: new Date('2024-01-31'),
+      });
+
+      await expect(useCase.execute(query)).rejects.toThrow(
+        InvalidDateRangeError,
+      );
+    });
+
+    it('should throw InvalidDateRangeError when start date is after end date', async () => {
+      const query = new GetGlobalProviderUsageQuery({
+        startDate: new Date('2024-01-31'),
+        endDate: new Date('2024-01-01'),
+      });
+
+      await expect(useCase.execute(query)).rejects.toThrow(
+        InvalidDateRangeError,
+      );
+    });
+
+    it('should accept valid date range', async () => {
+      jest
+        .spyOn(mockUsageRepository, 'getGlobalProviderUsage')
+        .mockResolvedValue([]);
+
+      const query = new GetGlobalProviderUsageQuery({
+        startDate: new Date('2024-01-01'),
+        endDate: new Date('2024-01-31'),
+      });
+
+      await expect(useCase.execute(query)).resolves.toBeDefined();
+    });
+
+    it('should accept query without date range', async () => {
+      jest
+        .spyOn(mockUsageRepository, 'getGlobalProviderUsage')
+        .mockResolvedValue([]);
+
+      const query = new GetGlobalProviderUsageQuery({});
+
+      await expect(useCase.execute(query)).resolves.toBeDefined();
+    });
+  });
+});

--- a/ayunis-core-backend/src/domain/usage/application/use-cases/get-global-provider-usage/get-global-provider-usage.use-case.ts
+++ b/ayunis-core-backend/src/domain/usage/application/use-cases/get-global-provider-usage/get-global-provider-usage.use-case.ts
@@ -3,7 +3,7 @@ import { GetGlobalProviderUsageQuery } from './get-global-provider-usage.query';
 import { UsageRepository } from '../../ports/usage.repository';
 import { ProviderUsage } from '../../../domain/provider-usage.entity';
 import {
-  validateDateRange,
+  validateOptionalDateRange,
   calculateProviderPercentages,
 } from '../../usage.utils';
 
@@ -12,9 +12,7 @@ export class GetGlobalProviderUsageUseCase {
   constructor(private readonly usageRepository: UsageRepository) {}
 
   async execute(query: GetGlobalProviderUsageQuery): Promise<ProviderUsage[]> {
-    if (query.startDate && query.endDate) {
-      validateDateRange(query.startDate, query.endDate);
-    }
+    validateOptionalDateRange(query.startDate, query.endDate);
 
     const providerUsage =
       await this.usageRepository.getGlobalProviderUsage(query);

--- a/ayunis-core-backend/src/domain/usage/application/use-cases/get-global-user-usage/get-global-user-usage.query.ts
+++ b/ayunis-core-backend/src/domain/usage/application/use-cases/get-global-user-usage/get-global-user-usage.query.ts
@@ -1,0 +1,9 @@
+export class GetGlobalUserUsageQuery {
+  public readonly startDate?: Date;
+  public readonly endDate?: Date;
+
+  constructor(params: { startDate?: Date; endDate?: Date }) {
+    this.startDate = params.startDate;
+    this.endDate = params.endDate;
+  }
+}

--- a/ayunis-core-backend/src/domain/usage/application/use-cases/get-global-user-usage/get-global-user-usage.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/usage/application/use-cases/get-global-user-usage/get-global-user-usage.use-case.spec.ts
@@ -1,0 +1,175 @@
+import type { TestingModule } from '@nestjs/testing';
+import { Test } from '@nestjs/testing';
+import { GetGlobalUserUsageUseCase } from './get-global-user-usage.use-case';
+import { GetGlobalUserUsageQuery } from './get-global-user-usage.query';
+import { UsageRepository } from '../../ports/usage.repository';
+import { InvalidDateRangeError } from '../../usage.errors';
+import { GlobalUserUsageItem } from '../../../domain/global-user-usage-item.entity';
+import type { UUID } from 'crypto';
+
+describe('GetGlobalUserUsageUseCase', () => {
+  let useCase: GetGlobalUserUsageUseCase;
+  let mockUsageRepository: Partial<UsageRepository>;
+
+  beforeAll(async () => {
+    mockUsageRepository = {
+      getGlobalUserUsage: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        GetGlobalUserUsageUseCase,
+        { provide: UsageRepository, useValue: mockUsageRepository },
+      ],
+    }).compile();
+
+    useCase = module.get<GetGlobalUserUsageUseCase>(GetGlobalUserUsageUseCase);
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(useCase).toBeDefined();
+  });
+
+  describe('successful execution', () => {
+    it('should return global user usage data from repository', async () => {
+      const userId = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890' as UUID;
+      const mockItems = [
+        new GlobalUserUsageItem({
+          userId,
+          userName: 'Alice Müller',
+          userEmail: 'alice@stadt-koeln.de',
+          tokens: 15000,
+          requests: 42,
+          lastActivity: new Date(),
+          isActive: true,
+          organizationName: 'Stadt Köln',
+        }),
+      ];
+
+      jest
+        .spyOn(mockUsageRepository, 'getGlobalUserUsage')
+        .mockResolvedValue(mockItems);
+
+      const query = new GetGlobalUserUsageQuery({});
+      const result = await useCase.execute(query);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].userId).toBe(userId);
+      expect(result[0].organizationName).toBe('Stadt Köln');
+    });
+
+    it('should pass date filters to repository', async () => {
+      jest
+        .spyOn(mockUsageRepository, 'getGlobalUserUsage')
+        .mockResolvedValue([]);
+
+      const startDate = new Date('2025-01-01');
+      const endDate = new Date('2025-01-31');
+      const query = new GetGlobalUserUsageQuery({ startDate, endDate });
+
+      await useCase.execute(query);
+
+      expect(mockUsageRepository.getGlobalUserUsage).toHaveBeenCalledWith(
+        query,
+      );
+    });
+
+    it('should return empty array when no usage data exists', async () => {
+      jest
+        .spyOn(mockUsageRepository, 'getGlobalUserUsage')
+        .mockResolvedValue([]);
+
+      const query = new GetGlobalUserUsageQuery({});
+      const result = await useCase.execute(query);
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('date range validation', () => {
+    it('should throw InvalidDateRangeError when start date is after end date', async () => {
+      const query = new GetGlobalUserUsageQuery({
+        startDate: new Date('2025-01-31'),
+        endDate: new Date('2025-01-01'),
+      });
+
+      await expect(useCase.execute(query)).rejects.toThrow(
+        InvalidDateRangeError,
+      );
+    });
+
+    it('should throw InvalidDateRangeError when start date is in the future', async () => {
+      const futureStart = new Date();
+      futureStart.setDate(futureStart.getDate() + 1);
+      const futureEnd = new Date();
+      futureEnd.setDate(futureEnd.getDate() + 2);
+
+      const query = new GetGlobalUserUsageQuery({
+        startDate: futureStart,
+        endDate: futureEnd,
+      });
+
+      await expect(useCase.execute(query)).rejects.toThrow(
+        InvalidDateRangeError,
+      );
+    });
+
+    it('should throw InvalidDateRangeError when date range exceeds 730 days', async () => {
+      const query = new GetGlobalUserUsageQuery({
+        startDate: new Date('2022-01-01'),
+        endDate: new Date('2024-12-31'),
+      });
+
+      await expect(useCase.execute(query)).rejects.toThrow(
+        InvalidDateRangeError,
+      );
+    });
+
+    it('should accept valid date range', async () => {
+      jest
+        .spyOn(mockUsageRepository, 'getGlobalUserUsage')
+        .mockResolvedValue([]);
+
+      const query = new GetGlobalUserUsageQuery({
+        startDate: new Date('2025-01-01'),
+        endDate: new Date('2025-01-31'),
+      });
+
+      await expect(useCase.execute(query)).resolves.toBeDefined();
+    });
+
+    it('should accept query without date range', async () => {
+      jest
+        .spyOn(mockUsageRepository, 'getGlobalUserUsage')
+        .mockResolvedValue([]);
+
+      const query = new GetGlobalUserUsageQuery({});
+
+      await expect(useCase.execute(query)).resolves.toBeDefined();
+    });
+
+    it('should throw InvalidDateRangeError when only startDate is provided', async () => {
+      const query = new GetGlobalUserUsageQuery({
+        startDate: new Date('2025-06-01'),
+      });
+
+      await expect(useCase.execute(query)).rejects.toThrow(
+        InvalidDateRangeError,
+      );
+    });
+
+    it('should throw InvalidDateRangeError when only endDate is provided', async () => {
+      const query = new GetGlobalUserUsageQuery({
+        endDate: new Date('2025-06-30'),
+      });
+
+      await expect(useCase.execute(query)).rejects.toThrow(
+        InvalidDateRangeError,
+      );
+    });
+  });
+});

--- a/ayunis-core-backend/src/domain/usage/application/use-cases/get-global-user-usage/get-global-user-usage.use-case.ts
+++ b/ayunis-core-backend/src/domain/usage/application/use-cases/get-global-user-usage/get-global-user-usage.use-case.ts
@@ -1,0 +1,18 @@
+import { Injectable } from '@nestjs/common';
+import { GetGlobalUserUsageQuery } from './get-global-user-usage.query';
+import { UsageRepository } from '../../ports/usage.repository';
+import { GlobalUserUsageItem } from '../../../domain/global-user-usage-item.entity';
+import { validateOptionalDateRange } from '../../usage.utils';
+
+@Injectable()
+export class GetGlobalUserUsageUseCase {
+  constructor(private readonly usageRepository: UsageRepository) {}
+
+  async execute(
+    query: GetGlobalUserUsageQuery,
+  ): Promise<GlobalUserUsageItem[]> {
+    validateOptionalDateRange(query.startDate, query.endDate);
+
+    return this.usageRepository.getGlobalUserUsage(query);
+  }
+}

--- a/ayunis-core-backend/src/domain/usage/application/use-cases/get-model-distribution/get-model-distribution.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/usage/application/use-cases/get-model-distribution/get-model-distribution.use-case.spec.ts
@@ -263,6 +263,28 @@ describe('GetModelDistributionUseCase', () => {
       );
     });
 
+    it('should throw InvalidDateRangeError when only startDate is provided', async () => {
+      const query = new GetModelDistributionQuery({
+        organizationId: orgId,
+        startDate: new Date('2024-01-01'),
+      });
+
+      await expect(useCase.execute(query)).rejects.toThrow(
+        InvalidDateRangeError,
+      );
+    });
+
+    it('should throw InvalidDateRangeError when only endDate is provided', async () => {
+      const query = new GetModelDistributionQuery({
+        organizationId: orgId,
+        endDate: new Date('2024-01-31'),
+      });
+
+      await expect(useCase.execute(query)).rejects.toThrow(
+        InvalidDateRangeError,
+      );
+    });
+
     it('should accept valid date range', async () => {
       const startDate = new Date('2024-01-01');
       const endDate = new Date('2024-01-31');

--- a/ayunis-core-backend/src/domain/usage/application/use-cases/get-model-distribution/get-model-distribution.use-case.ts
+++ b/ayunis-core-backend/src/domain/usage/application/use-cases/get-model-distribution/get-model-distribution.use-case.ts
@@ -3,7 +3,10 @@ import { GetModelDistributionQuery } from './get-model-distribution.query';
 import { UsageRepository } from '../../ports/usage.repository';
 import { ModelDistribution } from '../../../domain/model-distribution.entity';
 import { InvalidDateRangeError } from '../../usage.errors';
-import { validateDateRange, processModelDistribution } from '../../usage.utils';
+import {
+  validateOptionalDateRange,
+  processModelDistribution,
+} from '../../usage.utils';
 
 @Injectable()
 export class GetModelDistributionUseCase {
@@ -12,9 +15,7 @@ export class GetModelDistributionUseCase {
   async execute(
     query: GetModelDistributionQuery,
   ): Promise<ModelDistribution[]> {
-    if (query.startDate && query.endDate) {
-      validateDateRange(query.startDate, query.endDate);
-    }
+    validateOptionalDateRange(query.startDate, query.endDate);
 
     if (query.maxModels <= 0) {
       throw new InvalidDateRangeError('Max models must be greater than 0');

--- a/ayunis-core-backend/src/domain/usage/application/use-cases/get-provider-usage/get-provider-usage.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/usage/application/use-cases/get-provider-usage/get-provider-usage.use-case.spec.ts
@@ -209,6 +209,28 @@ describe('GetProviderUsageUseCase', () => {
       await expect(useCase.execute(query)).resolves.toBeDefined();
     });
 
+    it('should throw InvalidDateRangeError when only startDate is provided', async () => {
+      const query = new GetProviderUsageQuery({
+        organizationId: orgId,
+        startDate: new Date('2024-01-01'),
+      });
+
+      await expect(useCase.execute(query)).rejects.toThrow(
+        InvalidDateRangeError,
+      );
+    });
+
+    it('should throw InvalidDateRangeError when only endDate is provided', async () => {
+      const query = new GetProviderUsageQuery({
+        organizationId: orgId,
+        endDate: new Date('2024-01-31'),
+      });
+
+      await expect(useCase.execute(query)).rejects.toThrow(
+        InvalidDateRangeError,
+      );
+    });
+
     it('should accept query without date range', async () => {
       const query = new GetProviderUsageQuery({ organizationId: orgId });
 

--- a/ayunis-core-backend/src/domain/usage/application/use-cases/get-provider-usage/get-provider-usage.use-case.ts
+++ b/ayunis-core-backend/src/domain/usage/application/use-cases/get-provider-usage/get-provider-usage.use-case.ts
@@ -3,7 +3,7 @@ import { GetProviderUsageQuery } from './get-provider-usage.query';
 import { UsageRepository } from '../../ports/usage.repository';
 import { ProviderUsage } from '../../../domain/provider-usage.entity';
 import {
-  validateDateRange,
+  validateOptionalDateRange,
   calculateProviderPercentages,
 } from '../../usage.utils';
 
@@ -12,9 +12,7 @@ export class GetProviderUsageUseCase {
   constructor(private readonly usageRepository: UsageRepository) {}
 
   async execute(query: GetProviderUsageQuery): Promise<ProviderUsage[]> {
-    if (query.startDate && query.endDate) {
-      validateDateRange(query.startDate, query.endDate);
-    }
+    validateOptionalDateRange(query.startDate, query.endDate);
 
     const providerUsage = await this.usageRepository.getProviderUsage(query);
 

--- a/ayunis-core-backend/src/domain/usage/application/use-cases/get-usage-stats/get-usage-stats.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/usage/application/use-cases/get-usage-stats/get-usage-stats.use-case.spec.ts
@@ -191,6 +191,28 @@ describe('GetUsageStatsUseCase', () => {
       await expect(useCase.execute(query)).resolves.toBeDefined();
     });
 
+    it('should throw InvalidDateRangeError when only startDate is provided', async () => {
+      const query = new GetUsageStatsQuery({
+        organizationId: orgId,
+        startDate: new Date('2024-01-01'),
+      });
+
+      await expect(useCase.execute(query)).rejects.toThrow(
+        InvalidDateRangeError,
+      );
+    });
+
+    it('should throw InvalidDateRangeError when only endDate is provided', async () => {
+      const query = new GetUsageStatsQuery({
+        organizationId: orgId,
+        endDate: new Date('2024-01-31'),
+      });
+
+      await expect(useCase.execute(query)).rejects.toThrow(
+        InvalidDateRangeError,
+      );
+    });
+
     it('should accept query without date range', async () => {
       const query = new GetUsageStatsQuery({ organizationId: orgId });
 

--- a/ayunis-core-backend/src/domain/usage/application/use-cases/get-usage-stats/get-usage-stats.use-case.ts
+++ b/ayunis-core-backend/src/domain/usage/application/use-cases/get-usage-stats/get-usage-stats.use-case.ts
@@ -2,17 +2,14 @@ import { Injectable } from '@nestjs/common';
 import { GetUsageStatsQuery } from './get-usage-stats.query';
 import { UsageRepository } from '../../ports/usage.repository';
 import { UsageStats } from '../../../domain/usage-stats.entity';
-import { InvalidDateRangeError } from '../../usage.errors';
-import { UsageConstants } from '../../../domain/value-objects/usage.constants';
+import { validateOptionalDateRange } from '../../usage.utils';
 
 @Injectable()
 export class GetUsageStatsUseCase {
   constructor(private readonly usageRepository: UsageRepository) {}
 
   async execute(query: GetUsageStatsQuery): Promise<UsageStats> {
-    if (query.startDate && query.endDate) {
-      this.validateDateRange(query.startDate, query.endDate);
-    }
+    validateOptionalDateRange(query.startDate, query.endDate);
 
     const stats = await this.usageRepository.getUsageStats({
       organizationId: query.organizationId,
@@ -30,27 +27,5 @@ export class GetUsageStatsUseCase {
       totalUsers: Math.max(0, stats.totalUsers),
       topModels: stats.topModels || [],
     });
-  }
-
-  private validateDateRange(startDate: Date, endDate: Date): void {
-    if (startDate > endDate) {
-      throw new InvalidDateRangeError('Start date cannot be after end date');
-    }
-
-    const now = new Date();
-    if (startDate > now) {
-      throw new InvalidDateRangeError('Start date cannot be in the future');
-    }
-
-    // Check if date range is reasonable (guard against heavy queries)
-    const maxDays = UsageConstants.MAX_DATE_RANGE_DAYS;
-    const daysDiff = Math.ceil(
-      (endDate.getTime() - startDate.getTime()) / (1000 * 60 * 60 * 24),
-    );
-    if (daysDiff > maxDays) {
-      throw new InvalidDateRangeError(
-        `Date range cannot exceed ${maxDays} days`,
-      );
-    }
   }
 }

--- a/ayunis-core-backend/src/domain/usage/application/use-cases/get-user-usage/get-user-usage.use-case.ts
+++ b/ayunis-core-backend/src/domain/usage/application/use-cases/get-user-usage/get-user-usage.use-case.ts
@@ -1,10 +1,8 @@
 import { Injectable } from '@nestjs/common';
 import { GetUserUsageQuery } from './get-user-usage.query';
 import { UsageRepository, UserUsageItem } from '../../ports/usage.repository';
-import {
-  InvalidDateRangeError,
-  InvalidPaginationError,
-} from '../../usage.errors';
+import { InvalidPaginationError } from '../../usage.errors';
+import { validateOptionalDateRange } from '../../usage.utils';
 import { UsageConstants } from '../../../domain/value-objects/usage.constants';
 import { Paginated } from 'src/common/pagination';
 
@@ -15,35 +13,12 @@ export class GetUserUsageUseCase {
   async execute(query: GetUserUsageQuery): Promise<Paginated<UserUsageItem>> {
     this.validateQuery(query);
 
-    const userUsageResult = await this.usageRepository.getUserUsage(query);
-
-    return this.processUserUsageResult(userUsageResult);
+    return this.usageRepository.getUserUsage(query);
   }
 
   private validateQuery(query: GetUserUsageQuery): void {
     // Validate date range if provided
-    if (query.startDate && query.endDate) {
-      if (query.startDate > query.endDate) {
-        throw new InvalidDateRangeError('Start date cannot be after end date');
-      }
-
-      const now = new Date();
-      if (query.startDate > now) {
-        throw new InvalidDateRangeError('Start date cannot be in the future');
-      }
-
-      // Check if date range is reasonable (not more than 2 years)
-      const maxDays = 730; // 2 years
-      const daysDiff = Math.ceil(
-        (query.endDate.getTime() - query.startDate.getTime()) /
-          (1000 * 60 * 60 * 24),
-      );
-      if (daysDiff > maxDays) {
-        throw new InvalidDateRangeError(
-          `Date range cannot exceed ${maxDays} days`,
-        );
-      }
-    }
+    validateOptionalDateRange(query.startDate, query.endDate);
 
     // Validate pagination
     if (query.limit <= 0) {
@@ -79,36 +54,5 @@ export class GetUserUsageUseCase {
         `Invalid sort order: ${query.sortOrder}`,
       );
     }
-  }
-
-  private processUserUsageResult(
-    result: Paginated<UserUsageItem>,
-  ): Paginated<UserUsageItem> {
-    const now = new Date();
-    const activeThresholdDate = new Date(
-      now.getTime() -
-        UsageConstants.ACTIVE_USER_DAYS_THRESHOLD * 24 * 60 * 60 * 1000,
-    );
-
-    // Process each user to determine activity status
-    const processedUsers = result.data.map((user) => {
-      // Determine if user is active based on last activity
-      // Users with no activity (lastActivity === null) are considered inactive
-      const isActive = user.lastActivity
-        ? user.lastActivity >= activeThresholdDate
-        : false;
-
-      return {
-        ...user,
-        isActive,
-      };
-    });
-
-    return new Paginated<UserUsageItem>({
-      data: processedUsers,
-      limit: result.limit,
-      offset: result.offset,
-      total: result.total,
-    });
   }
 }

--- a/ayunis-core-backend/src/domain/usage/domain/global-user-usage-item.entity.ts
+++ b/ayunis-core-backend/src/domain/usage/domain/global-user-usage-item.entity.ts
@@ -1,0 +1,20 @@
+import type { UUID } from 'crypto';
+import { UserUsageItem } from './user-usage-item.entity';
+
+export class GlobalUserUsageItem extends UserUsageItem {
+  public readonly organizationName: string;
+
+  constructor(params: {
+    userId: UUID;
+    userName: string;
+    userEmail: string;
+    tokens: number;
+    requests: number;
+    lastActivity: Date | null;
+    isActive: boolean;
+    organizationName: string;
+  }) {
+    super(params);
+    this.organizationName = params.organizationName;
+  }
+}

--- a/ayunis-core-backend/src/domain/usage/domain/user-usage-item.entity.spec.ts
+++ b/ayunis-core-backend/src/domain/usage/domain/user-usage-item.entity.spec.ts
@@ -1,0 +1,63 @@
+import { UserUsageItem } from './user-usage-item.entity';
+import { UsageConstants } from './value-objects/usage.constants';
+
+describe('UserUsageItem', () => {
+  describe('computeIsActive', () => {
+    it('should return true when lastActivity is within the threshold', () => {
+      const recentDate = new Date();
+      recentDate.setDate(recentDate.getDate() - 5); // 5 days ago
+
+      expect(UserUsageItem.computeIsActive(recentDate)).toBe(true);
+    });
+
+    it('should return false when lastActivity is older than the threshold', () => {
+      const oldDate = new Date();
+      oldDate.setDate(
+        oldDate.getDate() - (UsageConstants.ACTIVE_USER_DAYS_THRESHOLD + 10),
+      );
+
+      expect(UserUsageItem.computeIsActive(oldDate)).toBe(false);
+    });
+
+    it('should return false when lastActivity is null', () => {
+      expect(UserUsageItem.computeIsActive(null)).toBe(false);
+    });
+
+    it('should return true at the exact boundary of the threshold', () => {
+      // Activity exactly at the threshold boundary should be considered active
+      const boundaryDate = new Date(
+        Date.now() -
+          UsageConstants.ACTIVE_USER_DAYS_THRESHOLD * 24 * 60 * 60 * 1000,
+      );
+
+      expect(UserUsageItem.computeIsActive(boundaryDate)).toBe(true);
+    });
+
+    it('should return false one millisecond past the threshold', () => {
+      const justPastThreshold = new Date(
+        Date.now() -
+          UsageConstants.ACTIVE_USER_DAYS_THRESHOLD * 24 * 60 * 60 * 1000 -
+          1,
+      );
+
+      expect(UserUsageItem.computeIsActive(justPastThreshold)).toBe(false);
+    });
+  });
+
+  describe('getActiveThresholdDate', () => {
+    it('should return a date that is ACTIVE_USER_DAYS_THRESHOLD days in the past', () => {
+      const before = Date.now();
+      const thresholdDate = UserUsageItem.getActiveThresholdDate();
+      const after = Date.now();
+
+      const expectedMs =
+        UsageConstants.ACTIVE_USER_DAYS_THRESHOLD * 24 * 60 * 60 * 1000;
+
+      // The threshold date should be within the expected range
+      expect(thresholdDate.getTime()).toBeGreaterThanOrEqual(
+        before - expectedMs,
+      );
+      expect(thresholdDate.getTime()).toBeLessThanOrEqual(after - expectedMs);
+    });
+  });
+});

--- a/ayunis-core-backend/src/domain/usage/domain/user-usage-item.entity.ts
+++ b/ayunis-core-backend/src/domain/usage/domain/user-usage-item.entity.ts
@@ -1,4 +1,5 @@
 import type { UUID } from 'crypto';
+import { UsageConstants } from './value-objects/usage.constants';
 
 export class UserUsageItem {
   public readonly userId: UUID;
@@ -25,5 +26,26 @@ export class UserUsageItem {
     this.requests = params.requests;
     this.lastActivity = params.lastActivity;
     this.isActive = params.isActive;
+  }
+
+  /**
+   * Returns the threshold date for determining active users.
+   * Users with activity on or after this date are considered active.
+   */
+  static getActiveThresholdDate(): Date {
+    const thresholdMs =
+      UsageConstants.ACTIVE_USER_DAYS_THRESHOLD * 24 * 60 * 60 * 1000;
+    return new Date(Date.now() - thresholdMs);
+  }
+
+  /**
+   * Determines whether a user is active based on their last activity date.
+   * A user is active if their last activity is within the configured threshold.
+   */
+  static computeIsActive(lastActivity: Date | null): boolean {
+    if (!lastActivity) {
+      return false;
+    }
+    return lastActivity >= UserUsageItem.getActiveThresholdDate();
   }
 }

--- a/ayunis-core-backend/src/domain/usage/domain/value-objects/usage.constants.ts
+++ b/ayunis-core-backend/src/domain/usage/domain/value-objects/usage.constants.ts
@@ -4,4 +4,5 @@ export const UsageConstants = {
   DEFAULT_USER_USAGE_LIMIT: 50,
   MAX_USER_USAGE_LIMIT: 1000,
   MAX_DATE_RANGE_DAYS: 730, // 2 years, guard against heavy queries
+  GLOBAL_USER_USAGE_LIMIT: 20,
 } as const;

--- a/ayunis-core-backend/src/domain/usage/infrastructure/persistence/local-usage/mappers/usage-query.mapper.ts
+++ b/ayunis-core-backend/src/domain/usage/infrastructure/persistence/local-usage/mappers/usage-query.mapper.ts
@@ -18,8 +18,8 @@ export class UsageQueryMapper {
       (point) =>
         new TimeSeriesPoint({
           date: new Date(point.date),
-          tokens: parseInt(point.tokens),
-          requests: parseInt(point.requests),
+          tokens: parseInt(point.tokens, 10),
+          requests: parseInt(point.requests, 10),
         }),
     );
   }
@@ -29,8 +29,8 @@ export class UsageQueryMapper {
     totalTokens: number,
     timeSeries?: TimeSeriesPoint[],
   ): ProviderUsage {
-    const tokens = parseInt(row.tokens);
-    const requests = parseInt(row.requests);
+    const tokens = parseInt(row.tokens, 10);
+    const requests = parseInt(row.requests, 10);
     const percentage = totalTokens > 0 ? (tokens / totalTokens) * 100 : 0;
     return new ProviderUsage({
       provider: row.provider as ModelProvider,
@@ -45,10 +45,13 @@ export class UsageQueryMapper {
     totalTokens: number;
     items: ModelDistribution[];
   } {
-    const totalTokens = rows.reduce((sum, r) => sum + parseInt(r.tokens), 0);
+    const totalTokens = rows.reduce(
+      (sum, r) => sum + parseInt(r.tokens, 10),
+      0,
+    );
     const items: ModelDistribution[] = rows.map((r) => {
-      const tokens = parseInt(r.tokens);
-      const requests = parseInt(r.requests);
+      const tokens = parseInt(r.tokens, 10);
+      const requests = parseInt(r.requests, 10);
       const percentage = totalTokens > 0 ? (tokens / totalTokens) * 100 : 0;
       return new ModelDistribution({
         modelId: r.modelId as unknown as UUID,

--- a/ayunis-core-backend/src/domain/usage/infrastructure/persistence/local-usage/queries/count-active-users-since.db-query.ts
+++ b/ayunis-core-backend/src/domain/usage/infrastructure/persistence/local-usage/queries/count-active-users-since.db-query.ts
@@ -14,5 +14,5 @@ export async function countActiveUsersSince(
     .andWhere('usage.createdAt >= :activeDate', { activeDate })
     .getRawOne<{ activeUsers: string }>()) ?? { activeUsers: '0' };
 
-  return parseInt(result.activeUsers) || 0;
+  return parseInt(result.activeUsers, 10) || 0;
 }

--- a/ayunis-core-backend/src/domain/usage/infrastructure/persistence/local-usage/queries/get-global-user-usage-rows.db-query.ts
+++ b/ayunis-core-backend/src/domain/usage/infrastructure/persistence/local-usage/queries/get-global-user-usage-rows.db-query.ts
@@ -1,0 +1,83 @@
+import type { Repository } from 'typeorm';
+import { UsageRecord } from '../schema/usage.record';
+import type { UserRecord } from 'src/iam/users/infrastructure/repositories/local/schema/user.record';
+
+export interface GlobalUserUsageRow {
+  userId: string;
+  userName: string | null;
+  userEmail: string | null;
+  tokens: string | null;
+  requests: string;
+  lastActivity: Date | null;
+  organizationName: string | null;
+}
+
+export interface GetGlobalUserUsageQueryParams {
+  usageRepository: Repository<UsageRecord>;
+  userRepository: Repository<UserRecord>;
+  startDate?: Date;
+  endDate?: Date;
+  limit: number;
+}
+
+export async function getGlobalUserUsageRows(
+  params: GetGlobalUserUsageQueryParams,
+): Promise<GlobalUserUsageRow[]> {
+  // Subquery: aggregate tokens and requests per user (optionally filtered by date)
+  const usageSubquery = params.usageRepository.manager
+    .createQueryBuilder()
+    .select('usage.userId', 'userId')
+    .addSelect('SUM(usage.totalTokens)', 'tokens')
+    .addSelect('COUNT(usage.id)', 'requests')
+    .from(UsageRecord, 'usage')
+    .groupBy('usage.userId');
+
+  if (params.startDate) {
+    usageSubquery.andWhere('usage.createdAt >= :startDate', {
+      startDate: params.startDate,
+    });
+  }
+  if (params.endDate) {
+    usageSubquery.andWhere('usage.createdAt <= :endDate', {
+      endDate: params.endDate,
+    });
+  }
+
+  // Subquery: last activity per user (no date filter — always global)
+  const lastActivitySubquery = params.usageRepository.manager
+    .createQueryBuilder()
+    .select('usageAll.userId', 'userId')
+    .addSelect('MAX(usageAll.createdAt)', 'lastActivity')
+    .from(UsageRecord, 'usageAll')
+    .groupBy('usageAll.userId');
+
+  const qb = params.userRepository
+    .createQueryBuilder('user')
+    .innerJoin('user.org', 'org')
+    .innerJoin(
+      `(${usageSubquery.getQuery()})`,
+      'usageagg',
+      'CAST("usageagg"."userId" AS uuid) = CAST("user"."id" AS uuid)',
+    )
+    .leftJoin(
+      `(${lastActivitySubquery.getQuery()})`,
+      'lastactivityagg',
+      'CAST("lastactivityagg"."userId" AS uuid) = CAST("user"."id" AS uuid)',
+    )
+    .select('user.id', 'userId')
+    .addSelect('user.name', 'userName')
+    .addSelect('user.email', 'userEmail')
+    .addSelect('COALESCE("usageagg"."tokens", 0)', 'tokens')
+    .addSelect('COALESCE("usageagg"."requests", 0)', 'requests')
+    .addSelect('"lastactivityagg"."lastActivity"', 'lastActivity')
+    .addSelect('org.name', 'organizationName')
+    .setParameters({
+      ...usageSubquery.getParameters(),
+      ...lastActivitySubquery.getParameters(),
+    })
+    .orderBy('COALESCE("usageagg"."tokens", 0)', 'DESC')
+    .addOrderBy('user.name', 'ASC')
+    .limit(params.limit);
+
+  return await qb.getRawMany<GlobalUserUsageRow>();
+}

--- a/ayunis-core-backend/src/domain/usage/presenters/http/dto/base-user-usage.dto.ts
+++ b/ayunis-core-backend/src/domain/usage/presenters/http/dto/base-user-usage.dto.ts
@@ -1,0 +1,29 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class BaseUserUsageDto {
+  @ApiProperty({ description: 'User ID' })
+  userId: string;
+
+  @ApiProperty({ description: 'User name' })
+  userName: string;
+
+  @ApiProperty({ description: 'User email' })
+  userEmail: string;
+
+  @ApiProperty({ description: 'Total tokens for this user' })
+  tokens: number;
+
+  @ApiProperty({ description: 'Total requests for this user' })
+  requests: number;
+
+  @ApiProperty({
+    type: String,
+    format: 'date-time',
+    description: 'Last activity date (null if no activity)',
+    nullable: true,
+  })
+  lastActivity: Date | null;
+
+  @ApiProperty({ description: 'Whether the user is considered active' })
+  isActive: boolean;
+}

--- a/ayunis-core-backend/src/domain/usage/presenters/http/dto/global-user-usage-response.dto.ts
+++ b/ayunis-core-backend/src/domain/usage/presenters/http/dto/global-user-usage-response.dto.ts
@@ -1,0 +1,15 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { BaseUserUsageDto } from './base-user-usage.dto';
+
+export class GlobalUserUsageDto extends BaseUserUsageDto {
+  @ApiProperty({ description: 'Name of the organization the user belongs to' })
+  organizationName: string;
+}
+
+export class GlobalUserUsageResponseDto {
+  @ApiProperty({
+    description: 'Top users by token usage across all organizations',
+    type: [GlobalUserUsageDto],
+  })
+  data: GlobalUserUsageDto[];
+}

--- a/ayunis-core-backend/src/domain/usage/presenters/http/dto/user-usage-response.dto.ts
+++ b/ayunis-core-backend/src/domain/usage/presenters/http/dto/user-usage-response.dto.ts
@@ -1,33 +1,8 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { PaginationDto } from 'src/common/pagination';
+import { BaseUserUsageDto } from './base-user-usage.dto';
 
-export class UserUsageDto {
-  @ApiProperty({ description: 'User ID' })
-  userId: string;
-
-  @ApiProperty({ description: 'User name' })
-  userName: string;
-
-  @ApiProperty({ description: 'User email' })
-  userEmail: string;
-
-  @ApiProperty({ description: 'Total tokens for this user' })
-  tokens: number;
-
-  @ApiProperty({ description: 'Total requests for this user' })
-  requests: number;
-
-  @ApiProperty({
-    type: String,
-    format: 'date-time',
-    description: 'Last activity date (null if no activity)',
-    nullable: true,
-  })
-  lastActivity: Date | null;
-
-  @ApiProperty({ description: 'Whether the user is considered active' })
-  isActive: boolean;
-}
+export class UserUsageDto extends BaseUserUsageDto {}
 
 export class UserUsageResponseDto {
   @ApiProperty({ description: 'User usage statistics', type: [UserUsageDto] })

--- a/ayunis-core-backend/src/domain/usage/presenters/http/mappers/global-user-usage-response-dto.mapper.ts
+++ b/ayunis-core-backend/src/domain/usage/presenters/http/mappers/global-user-usage-response-dto.mapper.ts
@@ -1,0 +1,28 @@
+import { Injectable } from '@nestjs/common';
+import { GlobalUserUsageItem } from '../../../domain/global-user-usage-item.entity';
+import {
+  GlobalUserUsageResponseDto,
+  GlobalUserUsageDto,
+} from '../dto/global-user-usage-response.dto';
+
+@Injectable()
+export class GlobalUserUsageResponseDtoMapper {
+  toDto(items: GlobalUserUsageItem[]): GlobalUserUsageResponseDto {
+    return {
+      data: items.map((item) => this.toItemDto(item)),
+    };
+  }
+
+  private toItemDto(item: GlobalUserUsageItem): GlobalUserUsageDto {
+    return {
+      userId: item.userId,
+      userName: item.userName,
+      userEmail: item.userEmail,
+      tokens: item.tokens,
+      requests: item.requests,
+      lastActivity: item.lastActivity,
+      isActive: item.isActive,
+      organizationName: item.organizationName,
+    };
+  }
+}

--- a/ayunis-core-backend/src/domain/usage/presenters/http/mappers/super-admin-global-usage-response.mapper.ts
+++ b/ayunis-core-backend/src/domain/usage/presenters/http/mappers/super-admin-global-usage-response.mapper.ts
@@ -1,0 +1,37 @@
+import { Injectable } from '@nestjs/common';
+import { ProviderUsageChartResponseDtoMapper } from './provider-usage-chart-response-dto.mapper';
+import { ModelDistributionResponseDtoMapper } from './model-distribution-response-dto.mapper';
+import { GlobalUserUsageResponseDtoMapper } from './global-user-usage-response-dto.mapper';
+import { ProviderUsage } from '../../../domain/provider-usage.entity';
+import { ModelDistribution } from '../../../domain/model-distribution.entity';
+import { GlobalUserUsageItem } from '../../../domain/global-user-usage-item.entity';
+import { ProviderUsageChartResponseDto } from '../dto/provider-usage-chart-response.dto';
+import { ModelDistributionResponseDto } from '../dto/model-distribution-response.dto';
+import { GlobalUserUsageResponseDto } from '../dto/global-user-usage-response.dto';
+
+@Injectable()
+export class SuperAdminGlobalUsageResponseMapper {
+  constructor(
+    private readonly providerUsageChartMapper: ProviderUsageChartResponseDtoMapper,
+    private readonly modelDistributionMapper: ModelDistributionResponseDtoMapper,
+    private readonly globalUserUsageMapper: GlobalUserUsageResponseDtoMapper,
+  ) {}
+
+  toProviderUsageChartDto(
+    providerUsage: ProviderUsage[],
+  ): ProviderUsageChartResponseDto {
+    return this.providerUsageChartMapper.toDto(providerUsage);
+  }
+
+  toModelDistributionDto(
+    modelDistribution: ModelDistribution[],
+  ): ModelDistributionResponseDto {
+    return this.modelDistributionMapper.toDto(modelDistribution);
+  }
+
+  toGlobalUserUsageDto(
+    items: GlobalUserUsageItem[],
+  ): GlobalUserUsageResponseDto {
+    return this.globalUserUsageMapper.toDto(items);
+  }
+}

--- a/ayunis-core-backend/src/domain/usage/presenters/http/mappers/usage-response.mapper.ts
+++ b/ayunis-core-backend/src/domain/usage/presenters/http/mappers/usage-response.mapper.ts
@@ -1,0 +1,51 @@
+import { Injectable } from '@nestjs/common';
+import { UsageStatsResponseDtoMapper } from './usage-stats-response-dto.mapper';
+import { ProviderUsageResponseDtoMapper } from './provider-usage-response-dto.mapper';
+import { ProviderUsageChartResponseDtoMapper } from './provider-usage-chart-response-dto.mapper';
+import { ModelDistributionResponseDtoMapper } from './model-distribution-response-dto.mapper';
+import { UserUsageResponseDtoMapper } from './user-usage-response-dto.mapper';
+import { UsageStats } from '../../../domain/usage-stats.entity';
+import { ProviderUsage } from '../../../domain/provider-usage.entity';
+import { ModelDistribution } from '../../../domain/model-distribution.entity';
+import { UserUsageItem } from '../../../domain/user-usage-item.entity';
+import { Paginated } from 'src/common/pagination';
+import { UsageStatsResponseDto } from '../dto/usage-stats-response.dto';
+import { ProviderUsageResponseDto } from '../dto/provider-usage-response.dto';
+import { ProviderUsageChartResponseDto } from '../dto/provider-usage-chart-response.dto';
+import { ModelDistributionResponseDto } from '../dto/model-distribution-response.dto';
+import { UserUsageResponseDto } from '../dto/user-usage-response.dto';
+
+@Injectable()
+export class UsageResponseMapper {
+  constructor(
+    private readonly usageStatsMapper: UsageStatsResponseDtoMapper,
+    private readonly providerUsageMapper: ProviderUsageResponseDtoMapper,
+    private readonly providerUsageChartMapper: ProviderUsageChartResponseDtoMapper,
+    private readonly modelDistributionMapper: ModelDistributionResponseDtoMapper,
+    private readonly userUsageMapper: UserUsageResponseDtoMapper,
+  ) {}
+
+  toUsageStatsDto(stats: UsageStats): UsageStatsResponseDto {
+    return this.usageStatsMapper.toDto(stats);
+  }
+
+  toProviderUsageDto(providerUsage: ProviderUsage[]): ProviderUsageResponseDto {
+    return this.providerUsageMapper.toDto(providerUsage);
+  }
+
+  toProviderUsageChartDto(
+    providerUsage: ProviderUsage[],
+  ): ProviderUsageChartResponseDto {
+    return this.providerUsageChartMapper.toDto(providerUsage);
+  }
+
+  toModelDistributionDto(
+    modelDistribution: ModelDistribution[],
+  ): ModelDistributionResponseDto {
+    return this.modelDistributionMapper.toDto(modelDistribution);
+  }
+
+  toUserUsageDto(userUsage: Paginated<UserUsageItem>): UserUsageResponseDto {
+    return this.userUsageMapper.toDto(userUsage);
+  }
+}

--- a/ayunis-core-backend/src/domain/usage/presenters/http/super-admin-global-usage.controller.ts
+++ b/ayunis-core-backend/src/domain/usage/presenters/http/super-admin-global-usage.controller.ts
@@ -2,16 +2,19 @@ import { Controller, Get, Query } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiResponse, ApiQuery } from '@nestjs/swagger';
 import { ProviderUsageChartResponseDto } from './dto/provider-usage-chart-response.dto';
 import { ModelDistributionResponseDto } from './dto/model-distribution-response.dto';
-import { ProviderUsageChartResponseDtoMapper } from './mappers/provider-usage-chart-response-dto.mapper';
-import { ModelDistributionResponseDtoMapper } from './mappers/model-distribution-response-dto.mapper';
+import { SuperAdminGlobalUsageResponseMapper } from './mappers/super-admin-global-usage-response.mapper';
+import { GlobalUserUsageResponseDto } from './dto/global-user-usage-response.dto';
 import { UUID } from 'crypto';
 import { ModelProvider } from '../../../models/domain/value-objects/model-provider.enum';
 import { GetGlobalProviderUsageUseCase } from '../../application/use-cases/get-global-provider-usage/get-global-provider-usage.use-case';
 import { GetGlobalModelDistributionUseCase } from '../../application/use-cases/get-global-model-distribution/get-global-model-distribution.use-case';
+import { GetGlobalUserUsageUseCase } from '../../application/use-cases/get-global-user-usage/get-global-user-usage.use-case';
 import { GetGlobalProviderUsageQuery } from '../../application/use-cases/get-global-provider-usage/get-global-provider-usage.query';
 import { GetGlobalModelDistributionQuery } from '../../application/use-cases/get-global-model-distribution/get-global-model-distribution.query';
+import { GetGlobalUserUsageQuery } from '../../application/use-cases/get-global-user-usage/get-global-user-usage.query';
 import { SystemRoles } from 'src/iam/authorization/application/decorators/system-roles.decorator';
 import { SystemRole } from 'src/iam/users/domain/value-objects/system-role.enum';
+import { parseDate } from './utils/parse-date.util';
 
 @ApiTags('Super Admin Global Usage')
 @Controller('super-admin/global-usage')
@@ -20,8 +23,8 @@ export class SuperAdminGlobalUsageController {
   constructor(
     private readonly getGlobalProviderUsageUseCase: GetGlobalProviderUsageUseCase,
     private readonly getGlobalModelDistributionUseCase: GetGlobalModelDistributionUseCase,
-    private readonly providerUsageChartMapper: ProviderUsageChartResponseDtoMapper,
-    private readonly modelDistributionMapper: ModelDistributionResponseDtoMapper,
+    private readonly getGlobalUserUsageUseCase: GetGlobalUserUsageUseCase,
+    private readonly mapper: SuperAdminGlobalUsageResponseMapper,
   ) {}
 
   @Get('providers/chart')
@@ -41,15 +44,15 @@ export class SuperAdminGlobalUsageController {
     @Query('modelId') modelId?: string,
   ) {
     const query = new GetGlobalProviderUsageQuery({
-      startDate: startDate ? new Date(startDate) : undefined,
-      endDate: endDate ? new Date(endDate) : undefined,
+      startDate: startDate ? parseDate(startDate, 'startDate') : undefined,
+      endDate: endDate ? parseDate(endDate, 'endDate') : undefined,
       includeTimeSeriesData: true,
       provider: provider as ModelProvider | undefined,
       modelId: modelId as UUID | undefined,
     });
     const providerUsage =
       await this.getGlobalProviderUsageUseCase.execute(query);
-    return this.providerUsageChartMapper.toDto(providerUsage);
+    return this.mapper.toProviderUsageChartDto(providerUsage);
   }
 
   @Get('models')
@@ -66,12 +69,31 @@ export class SuperAdminGlobalUsageController {
     @Query('modelId') modelId?: string,
   ) {
     const query = new GetGlobalModelDistributionQuery({
-      startDate: startDate ? new Date(startDate) : undefined,
-      endDate: endDate ? new Date(endDate) : undefined,
+      startDate: startDate ? parseDate(startDate, 'startDate') : undefined,
+      endDate: endDate ? parseDate(endDate, 'endDate') : undefined,
       modelId: modelId as UUID | undefined,
     });
     const modelDistribution =
       await this.getGlobalModelDistributionUseCase.execute(query);
-    return this.modelDistributionMapper.toDto(modelDistribution);
+    return this.mapper.toModelDistributionDto(modelDistribution);
+  }
+
+  @Get('users')
+  @ApiOperation({
+    summary: 'Get top 20 users by token usage across all organizations',
+  })
+  @ApiResponse({ status: 200, type: GlobalUserUsageResponseDto })
+  @ApiQuery({ name: 'startDate', type: String, required: false })
+  @ApiQuery({ name: 'endDate', type: String, required: false })
+  async getGlobalUserUsage(
+    @Query('startDate') startDate?: string,
+    @Query('endDate') endDate?: string,
+  ) {
+    const query = new GetGlobalUserUsageQuery({
+      startDate: startDate ? parseDate(startDate, 'startDate') : undefined,
+      endDate: endDate ? parseDate(endDate, 'endDate') : undefined,
+    });
+    const userUsage = await this.getGlobalUserUsageUseCase.execute(query);
+    return this.mapper.toGlobalUserUsageDto(userUsage);
   }
 }

--- a/ayunis-core-backend/src/domain/usage/presenters/http/super-admin-usage-data.controller.ts
+++ b/ayunis-core-backend/src/domain/usage/presenters/http/super-admin-usage-data.controller.ts
@@ -12,6 +12,7 @@ import { UserUsageResponseDto } from './dto/user-usage-response.dto';
 import { ProviderUsageResponseDtoMapper } from './mappers/provider-usage-response-dto.mapper';
 import { ProviderUsageChartResponseDtoMapper } from './mappers/provider-usage-chart-response-dto.mapper';
 import { UserUsageResponseDtoMapper } from './mappers/user-usage-response-dto.mapper';
+import { parseDate } from './utils/parse-date.util';
 import { UUID } from 'crypto';
 import { ModelProvider } from '../../../models/domain/value-objects/model-provider.enum';
 import { GetProviderUsageUseCase } from '../../application/use-cases/get-provider-usage/get-provider-usage.use-case';
@@ -59,8 +60,8 @@ export class SuperAdminUsageDataController {
   ) {
     const query = new GetProviderUsageQuery({
       organizationId: orgId,
-      startDate: startDate ? new Date(startDate) : undefined,
-      endDate: endDate ? new Date(endDate) : undefined,
+      startDate: startDate ? parseDate(startDate, 'startDate') : undefined,
+      endDate: endDate ? parseDate(endDate, 'endDate') : undefined,
       includeTimeSeriesData: includeTimeSeries,
       provider: provider as ModelProvider | undefined,
       modelId: modelId as UUID | undefined,
@@ -88,8 +89,8 @@ export class SuperAdminUsageDataController {
   ) {
     const query = new GetProviderUsageQuery({
       organizationId: orgId,
-      startDate: startDate ? new Date(startDate) : undefined,
-      endDate: endDate ? new Date(endDate) : undefined,
+      startDate: startDate ? parseDate(startDate, 'startDate') : undefined,
+      endDate: endDate ? parseDate(endDate, 'endDate') : undefined,
       includeTimeSeriesData: true,
       provider: provider as ModelProvider | undefined,
       modelId: modelId as UUID | undefined,
@@ -125,8 +126,8 @@ export class SuperAdminUsageDataController {
   ) {
     const query = new GetUserUsageQuery({
       organizationId: orgId,
-      startDate: startDate ? new Date(startDate) : undefined,
-      endDate: endDate ? new Date(endDate) : undefined,
+      startDate: startDate ? parseDate(startDate, 'startDate') : undefined,
+      endDate: endDate ? parseDate(endDate, 'endDate') : undefined,
       limit,
       offset,
       searchTerm: search,

--- a/ayunis-core-backend/src/domain/usage/presenters/http/super-admin-usage.controller.ts
+++ b/ayunis-core-backend/src/domain/usage/presenters/http/super-admin-usage.controller.ts
@@ -12,6 +12,7 @@ import { ModelDistributionResponseDto } from './dto/model-distribution-response.
 import { UsageStatsResponseDtoMapper } from './mappers/usage-stats-response-dto.mapper';
 import { ModelDistributionResponseDtoMapper } from './mappers/model-distribution-response-dto.mapper';
 import { ConfigService } from '@nestjs/config';
+import { parseDate } from './utils/parse-date.util';
 import { UUID } from 'crypto';
 import { GetModelDistributionUseCase } from '../../application/use-cases/get-model-distribution/get-model-distribution.use-case';
 import { GetUsageStatsUseCase } from '../../application/use-cases/get-usage-stats/get-usage-stats.use-case';
@@ -60,8 +61,8 @@ export class SuperAdminUsageController {
   ) {
     const query = new GetUsageStatsQuery({
       organizationId: orgId,
-      startDate: startDate ? new Date(startDate) : undefined,
-      endDate: endDate ? new Date(endDate) : undefined,
+      startDate: startDate ? parseDate(startDate, 'startDate') : undefined,
+      endDate: endDate ? parseDate(endDate, 'endDate') : undefined,
     });
     const stats = await this.getUsageStatsUseCase.execute(query);
     return this.usageStatsMapper.toDto(stats);
@@ -86,8 +87,8 @@ export class SuperAdminUsageController {
   ) {
     const query = new GetModelDistributionQuery({
       organizationId: orgId,
-      startDate: startDate ? new Date(startDate) : undefined,
-      endDate: endDate ? new Date(endDate) : undefined,
+      startDate: startDate ? parseDate(startDate, 'startDate') : undefined,
+      endDate: endDate ? parseDate(endDate, 'endDate') : undefined,
       maxModels,
       modelId: modelId as UUID | undefined,
     });

--- a/ayunis-core-backend/src/domain/usage/presenters/http/usage-use-cases.facade.ts
+++ b/ayunis-core-backend/src/domain/usage/presenters/http/usage-use-cases.facade.ts
@@ -1,0 +1,42 @@
+import { Injectable } from '@nestjs/common';
+import { GetProviderUsageUseCase } from '../../application/use-cases/get-provider-usage/get-provider-usage.use-case';
+import { GetModelDistributionUseCase } from '../../application/use-cases/get-model-distribution/get-model-distribution.use-case';
+import { GetUserUsageUseCase } from '../../application/use-cases/get-user-usage/get-user-usage.use-case';
+import { GetUsageStatsUseCase } from '../../application/use-cases/get-usage-stats/get-usage-stats.use-case';
+import { GetProviderUsageQuery } from '../../application/use-cases/get-provider-usage/get-provider-usage.query';
+import { GetModelDistributionQuery } from '../../application/use-cases/get-model-distribution/get-model-distribution.query';
+import { GetUserUsageQuery } from '../../application/use-cases/get-user-usage/get-user-usage.query';
+import { GetUsageStatsQuery } from '../../application/use-cases/get-usage-stats/get-usage-stats.query';
+import { UsageStats } from '../../domain/usage-stats.entity';
+import { ProviderUsage } from '../../domain/provider-usage.entity';
+import { ModelDistribution } from '../../domain/model-distribution.entity';
+import { UserUsageItem } from '../../domain/user-usage-item.entity';
+import { Paginated } from 'src/common/pagination';
+
+@Injectable()
+export class UsageUseCasesFacade {
+  constructor(
+    private readonly getProviderUsageUseCase: GetProviderUsageUseCase,
+    private readonly getModelDistributionUseCase: GetModelDistributionUseCase,
+    private readonly getUserUsageUseCase: GetUserUsageUseCase,
+    private readonly getUsageStatsUseCase: GetUsageStatsUseCase,
+  ) {}
+
+  getProviderUsage(query: GetProviderUsageQuery): Promise<ProviderUsage[]> {
+    return this.getProviderUsageUseCase.execute(query);
+  }
+
+  getModelDistribution(
+    query: GetModelDistributionQuery,
+  ): Promise<ModelDistribution[]> {
+    return this.getModelDistributionUseCase.execute(query);
+  }
+
+  getUserUsage(query: GetUserUsageQuery): Promise<Paginated<UserUsageItem>> {
+    return this.getUserUsageUseCase.execute(query);
+  }
+
+  getUsageStats(query: GetUsageStatsQuery): Promise<UsageStats> {
+    return this.getUsageStatsUseCase.execute(query);
+  }
+}

--- a/ayunis-core-backend/src/domain/usage/presenters/http/utils/parse-date.util.spec.ts
+++ b/ayunis-core-backend/src/domain/usage/presenters/http/utils/parse-date.util.spec.ts
@@ -1,0 +1,22 @@
+import { BadRequestException } from '@nestjs/common';
+import { parseDate } from './parse-date.util';
+
+describe('parseDate', () => {
+  it('should parse a valid date string', () => {
+    const result = parseDate('2024-01-15', 'startDate');
+    expect(result).toBeInstanceOf(Date);
+    expect(result.getFullYear()).toBe(2024);
+    expect(result.getMonth()).toBe(0); // January
+    expect(result.getDate()).toBe(15);
+  });
+
+  it('should throw BadRequestException for an invalid string', () => {
+    expect(() => parseDate('garbage', 'startDate')).toThrow(
+      BadRequestException,
+    );
+  });
+
+  it('should throw BadRequestException for an empty string', () => {
+    expect(() => parseDate('', 'startDate')).toThrow(BadRequestException);
+  });
+});

--- a/ayunis-core-backend/src/domain/usage/presenters/http/utils/parse-date.util.ts
+++ b/ayunis-core-backend/src/domain/usage/presenters/http/utils/parse-date.util.ts
@@ -1,0 +1,15 @@
+import { BadRequestException } from '@nestjs/common';
+
+/**
+ * Parses a date string from a query parameter, throwing a BadRequestException
+ * if the string is not a valid date.
+ */
+export function parseDate(value: string, paramName: string): Date {
+  const date = new Date(value);
+  if (isNaN(date.getTime())) {
+    throw new BadRequestException(
+      `Invalid date string for '${paramName}': ${value}`,
+    );
+  }
+  return date;
+}

--- a/ayunis-core-backend/src/domain/usage/usage.module.ts
+++ b/ayunis-core-backend/src/domain/usage/usage.module.ts
@@ -4,6 +4,7 @@ import { GetProviderUsageUseCase } from './application/use-cases/get-provider-us
 import { GetModelDistributionUseCase } from './application/use-cases/get-model-distribution/get-model-distribution.use-case';
 import { GetGlobalProviderUsageUseCase } from './application/use-cases/get-global-provider-usage/get-global-provider-usage.use-case';
 import { GetGlobalModelDistributionUseCase } from './application/use-cases/get-global-model-distribution/get-global-model-distribution.use-case';
+import { GetGlobalUserUsageUseCase } from './application/use-cases/get-global-user-usage/get-global-user-usage.use-case';
 import { GetUserUsageUseCase } from './application/use-cases/get-user-usage/get-user-usage.use-case';
 import { GetUsageStatsUseCase } from './application/use-cases/get-usage-stats/get-usage-stats.use-case';
 import { UsageController } from './presenters/http/usage.controller';
@@ -16,6 +17,10 @@ import { ProviderUsageResponseDtoMapper } from './presenters/http/mappers/provid
 import { ProviderUsageChartResponseDtoMapper } from './presenters/http/mappers/provider-usage-chart-response-dto.mapper';
 import { ModelDistributionResponseDtoMapper } from './presenters/http/mappers/model-distribution-response-dto.mapper';
 import { UserUsageResponseDtoMapper } from './presenters/http/mappers/user-usage-response-dto.mapper';
+import { GlobalUserUsageResponseDtoMapper } from './presenters/http/mappers/global-user-usage-response-dto.mapper';
+import { SuperAdminGlobalUsageResponseMapper } from './presenters/http/mappers/super-admin-global-usage-response.mapper';
+import { UsageResponseMapper } from './presenters/http/mappers/usage-response.mapper';
+import { UsageUseCasesFacade } from './presenters/http/usage-use-cases.facade';
 
 @Module({
   imports: [LocalUsageRepositoryModule],
@@ -32,6 +37,7 @@ import { UserUsageResponseDtoMapper } from './presenters/http/mappers/user-usage
     GetModelDistributionUseCase,
     GetGlobalProviderUsageUseCase,
     GetGlobalModelDistributionUseCase,
+    GetGlobalUserUsageUseCase,
     GetUserUsageUseCase,
     GetUsageStatsUseCase,
 
@@ -41,6 +47,10 @@ import { UserUsageResponseDtoMapper } from './presenters/http/mappers/user-usage
     ProviderUsageChartResponseDtoMapper,
     ModelDistributionResponseDtoMapper,
     UserUsageResponseDtoMapper,
+    GlobalUserUsageResponseDtoMapper,
+    SuperAdminGlobalUsageResponseMapper,
+    UsageResponseMapper,
+    UsageUseCasesFacade,
   ],
   exports: [
     CollectUsageUseCase,
@@ -48,6 +58,7 @@ import { UserUsageResponseDtoMapper } from './presenters/http/mappers/user-usage
     GetModelDistributionUseCase,
     GetGlobalProviderUsageUseCase,
     GetGlobalModelDistributionUseCase,
+    GetGlobalUserUsageUseCase,
     GetUserUsageUseCase,
     GetUsageStatsUseCase,
   ],

--- a/ayunis-core-frontend/src/pages/super-admin-settings/usage/api/useGlobalUserUsage.ts
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/usage/api/useGlobalUserUsage.ts
@@ -1,0 +1,10 @@
+import {
+  useSuperAdminGlobalUsageControllerGetGlobalUserUsage,
+  type SuperAdminGlobalUsageControllerGetGlobalUserUsageParams,
+} from '@/shared/api';
+
+export function useGlobalUserUsage(
+  params?: SuperAdminGlobalUsageControllerGetGlobalUserUsageParams,
+) {
+  return useSuperAdminGlobalUsageControllerGetGlobalUserUsage(params);
+}

--- a/ayunis-core-frontend/src/pages/super-admin-settings/usage/ui/GlobalTopUsersTable.tsx
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/usage/ui/GlobalTopUsersTable.tsx
@@ -1,0 +1,29 @@
+import { useGlobalUserUsage } from '../api/useGlobalUserUsage';
+import { GlobalTopUsersTableWidget } from '@/widgets/global-top-users-table';
+
+interface GlobalTopUsersTableProps {
+  startDate?: Date;
+  endDate?: Date;
+}
+
+export function GlobalTopUsersTable({
+  startDate,
+  endDate,
+}: Readonly<GlobalTopUsersTableProps>) {
+  const {
+    data: response,
+    isLoading,
+    error,
+  } = useGlobalUserUsage({
+    startDate: startDate?.toISOString(),
+    endDate: endDate?.toISOString(),
+  });
+
+  return (
+    <GlobalTopUsersTableWidget
+      users={response?.data}
+      isLoading={isLoading}
+      error={error}
+    />
+  );
+}

--- a/ayunis-core-frontend/src/pages/super-admin-settings/usage/ui/GlobalUsagePage.tsx
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/usage/ui/GlobalUsagePage.tsx
@@ -4,6 +4,7 @@ import SuperAdminSettingsLayout from '../../super-admin-settings-layout';
 import { GlobalUsageFilters } from './GlobalUsageFilters';
 import { GlobalProviderConsumption } from './GlobalProviderConsumption';
 import { GlobalModelDistribution } from './GlobalModelDistribution';
+import { GlobalTopUsersTable } from './GlobalTopUsersTable';
 
 export default function GlobalUsagePage() {
   const { t } = useTranslation('super-admin-settings-layout');
@@ -38,6 +39,10 @@ export default function GlobalUsagePage() {
             startDate={dateRange.startDate}
             endDate={dateRange.endDate}
             selectedModel={selectedModel}
+          />
+          <GlobalTopUsersTable
+            startDate={dateRange.startDate}
+            endDate={dateRange.endDate}
           />
         </div>
       </div>

--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
@@ -2979,6 +2979,33 @@ export interface UserUsageResponseDto {
   pagination: PaginationDto;
 }
 
+export interface GlobalUserUsageDto {
+  /** User ID */
+  userId: string;
+  /** User name */
+  userName: string;
+  /** User email */
+  userEmail: string;
+  /** Total tokens for this user */
+  tokens: number;
+  /** Total requests for this user */
+  requests: number;
+  /**
+   * Last activity date (null if no activity)
+   * @nullable
+   */
+  lastActivity: string | null;
+  /** Whether the user is considered active */
+  isActive: boolean;
+  /** Name of the organization the user belongs to */
+  organizationName: string;
+}
+
+export interface GlobalUserUsageResponseDto {
+  /** Top users by token usage across all organizations */
+  data: GlobalUserUsageDto[];
+}
+
 export interface UserSystemPromptResponseDto {
   /**
    * The custom system prompt for the user, or null if not set
@@ -3465,6 +3492,11 @@ export type SuperAdminGlobalUsageControllerGetGlobalModelDistributionParams = {
 startDate?: string;
 endDate?: string;
 modelId?: string;
+};
+
+export type SuperAdminGlobalUsageControllerGetGlobalUserUsageParams = {
+startDate?: string;
+endDate?: string;
 };
 
 export type TranscriptionsControllerTranscribeBody = {

--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.ts
@@ -62,6 +62,7 @@ import type {
   ForgotPasswordDto,
   GetThreadResponseDto,
   GetThreadsResponseDto,
+  GlobalUserUsageResponseDto,
   InstallMarketplaceIntegrationDto,
   InstallSkillFromMarketplaceDto,
   InviteDetailResponseDto,
@@ -111,6 +112,7 @@ import type {
   SuccessResponseDto,
   SuperAdminGlobalUsageControllerGetGlobalModelDistributionParams,
   SuperAdminGlobalUsageControllerGetGlobalProviderUsageChartParams,
+  SuperAdminGlobalUsageControllerGetGlobalUserUsageParams,
   SuperAdminModelsControllerGetAllCatalogModels200Item,
   SuperAdminModelsControllerGetCatalogModelById200,
   SuperAdminModelsControllerGetPermittedModels200Item,
@@ -12567,6 +12569,100 @@ export function useSuperAdminGlobalUsageControllerGetGlobalModelDistribution<TDa
  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
 
   const queryOptions = getSuperAdminGlobalUsageControllerGetGlobalModelDistributionQueryOptions(params,options)
+
+  const query = useQuery(queryOptions, queryClient) as  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+
+  query.queryKey = queryOptions.queryKey ;
+
+  return query;
+}
+
+
+
+
+
+/**
+ * @summary Get top 20 users by token usage across all organizations
+ */
+export const superAdminGlobalUsageControllerGetGlobalUserUsage = (
+    params?: SuperAdminGlobalUsageControllerGetGlobalUserUsageParams,
+ signal?: AbortSignal
+) => {
+      
+      
+      return customAxiosInstance<GlobalUserUsageResponseDto>(
+      {url: `/super-admin/global-usage/users`, method: 'GET',
+        params, signal
+    },
+      );
+    }
+  
+
+
+
+export const getSuperAdminGlobalUsageControllerGetGlobalUserUsageQueryKey = (params?: SuperAdminGlobalUsageControllerGetGlobalUserUsageParams,) => {
+    return [
+    `/super-admin/global-usage/users`, ...(params ? [params]: [])
+    ] as const;
+    }
+
+    
+export const getSuperAdminGlobalUsageControllerGetGlobalUserUsageQueryOptions = <TData = Awaited<ReturnType<typeof superAdminGlobalUsageControllerGetGlobalUserUsage>>, TError = unknown>(params?: SuperAdminGlobalUsageControllerGetGlobalUserUsageParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof superAdminGlobalUsageControllerGetGlobalUserUsage>>, TError, TData>>, }
+) => {
+
+const {query: queryOptions} = options ?? {};
+
+  const queryKey =  queryOptions?.queryKey ?? getSuperAdminGlobalUsageControllerGetGlobalUserUsageQueryKey(params);
+
+  
+
+    const queryFn: QueryFunction<Awaited<ReturnType<typeof superAdminGlobalUsageControllerGetGlobalUserUsage>>> = ({ signal }) => superAdminGlobalUsageControllerGetGlobalUserUsage(params, signal);
+
+      
+
+      
+
+   return  { queryKey, queryFn, ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof superAdminGlobalUsageControllerGetGlobalUserUsage>>, TError, TData> & { queryKey: DataTag<QueryKey, TData, TError> }
+}
+
+export type SuperAdminGlobalUsageControllerGetGlobalUserUsageQueryResult = NonNullable<Awaited<ReturnType<typeof superAdminGlobalUsageControllerGetGlobalUserUsage>>>
+export type SuperAdminGlobalUsageControllerGetGlobalUserUsageQueryError = unknown
+
+
+export function useSuperAdminGlobalUsageControllerGetGlobalUserUsage<TData = Awaited<ReturnType<typeof superAdminGlobalUsageControllerGetGlobalUserUsage>>, TError = unknown>(
+ params: undefined |  SuperAdminGlobalUsageControllerGetGlobalUserUsageParams, options: { query:Partial<UseQueryOptions<Awaited<ReturnType<typeof superAdminGlobalUsageControllerGetGlobalUserUsage>>, TError, TData>> & Pick<
+        DefinedInitialDataOptions<
+          Awaited<ReturnType<typeof superAdminGlobalUsageControllerGetGlobalUserUsage>>,
+          TError,
+          Awaited<ReturnType<typeof superAdminGlobalUsageControllerGetGlobalUserUsage>>
+        > , 'initialData'
+      >, }
+ , queryClient?: QueryClient
+  ):  DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useSuperAdminGlobalUsageControllerGetGlobalUserUsage<TData = Awaited<ReturnType<typeof superAdminGlobalUsageControllerGetGlobalUserUsage>>, TError = unknown>(
+ params?: SuperAdminGlobalUsageControllerGetGlobalUserUsageParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof superAdminGlobalUsageControllerGetGlobalUserUsage>>, TError, TData>> & Pick<
+        UndefinedInitialDataOptions<
+          Awaited<ReturnType<typeof superAdminGlobalUsageControllerGetGlobalUserUsage>>,
+          TError,
+          Awaited<ReturnType<typeof superAdminGlobalUsageControllerGetGlobalUserUsage>>
+        > , 'initialData'
+      >, }
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useSuperAdminGlobalUsageControllerGetGlobalUserUsage<TData = Awaited<ReturnType<typeof superAdminGlobalUsageControllerGetGlobalUserUsage>>, TError = unknown>(
+ params?: SuperAdminGlobalUsageControllerGetGlobalUserUsageParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof superAdminGlobalUsageControllerGetGlobalUserUsage>>, TError, TData>>, }
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+/**
+ * @summary Get top 20 users by token usage across all organizations
+ */
+
+export function useSuperAdminGlobalUsageControllerGetGlobalUserUsage<TData = Awaited<ReturnType<typeof superAdminGlobalUsageControllerGetGlobalUserUsage>>, TError = unknown>(
+ params?: SuperAdminGlobalUsageControllerGetGlobalUserUsageParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof superAdminGlobalUsageControllerGetGlobalUserUsage>>, TError, TData>>, }
+ , queryClient?: QueryClient 
+ ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
+
+  const queryOptions = getSuperAdminGlobalUsageControllerGetGlobalUserUsageQueryOptions(params,options)
 
   const query = useQuery(queryOptions, queryClient) as  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
 

--- a/ayunis-core-frontend/src/shared/api/openapi-schema.json
+++ b/ayunis-core-frontend/src/shared/api/openapi-schema.json
@@ -6745,6 +6745,45 @@
         ]
       }
     },
+    "/super-admin/global-usage/users": {
+      "get": {
+        "operationId": "SuperAdminGlobalUsageController_getGlobalUserUsage",
+        "parameters": [
+          {
+            "name": "startDate",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "endDate",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GlobalUserUsageResponseDto"
+                }
+              }
+            }
+          }
+        },
+        "summary": "Get top 20 users by token usage across all organizations",
+        "tags": [
+          "Super Admin Global Usage"
+        ]
+      }
+    },
     "/chat-settings/system-prompt": {
       "get": {
         "description": "Returns the custom system prompt for the authenticated user, or null if not set.",
@@ -12456,6 +12495,70 @@
         "required": [
           "data",
           "pagination"
+        ]
+      },
+      "GlobalUserUsageDto": {
+        "type": "object",
+        "properties": {
+          "userId": {
+            "type": "string",
+            "description": "User ID"
+          },
+          "userName": {
+            "type": "string",
+            "description": "User name"
+          },
+          "userEmail": {
+            "type": "string",
+            "description": "User email"
+          },
+          "tokens": {
+            "type": "number",
+            "description": "Total tokens for this user"
+          },
+          "requests": {
+            "type": "number",
+            "description": "Total requests for this user"
+          },
+          "lastActivity": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Last activity date (null if no activity)",
+            "nullable": true
+          },
+          "isActive": {
+            "type": "boolean",
+            "description": "Whether the user is considered active"
+          },
+          "organizationName": {
+            "type": "string",
+            "description": "Name of the organization the user belongs to"
+          }
+        },
+        "required": [
+          "userId",
+          "userName",
+          "userEmail",
+          "tokens",
+          "requests",
+          "lastActivity",
+          "isActive",
+          "organizationName"
+        ]
+      },
+      "GlobalUserUsageResponseDto": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "description": "Top users by token usage across all organizations",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GlobalUserUsageDto"
+            }
+          }
+        },
+        "required": [
+          "data"
         ]
       },
       "UserSystemPromptResponseDto": {

--- a/ayunis-core-frontend/src/shared/lib/format-relative-date.ts
+++ b/ayunis-core-frontend/src/shared/lib/format-relative-date.ts
@@ -1,0 +1,20 @@
+import { formatDistanceToNow } from 'date-fns';
+import { de, enUS } from 'date-fns/locale';
+
+/**
+ * Format a date string as a human-readable relative time (e.g., "3 days ago").
+ * Selects locale based on the provided language code.
+ */
+export function formatRelativeDate(
+  dateString: string,
+  language: string,
+): string {
+  try {
+    return formatDistanceToNow(new Date(dateString), {
+      addSuffix: true,
+      locale: language === 'de' ? de : enUS,
+    });
+  } catch {
+    return '—';
+  }
+}

--- a/ayunis-core-frontend/src/shared/locales/de/admin-settings-usage.json
+++ b/ayunis-core-frontend/src/shared/locales/de/admin-settings-usage.json
@@ -36,6 +36,22 @@
       "description": "Anzeigen der Gesamtzahl der Besucher im ausgewählten Zeitraum"
     }
   },
+  "globalTopUsers": {
+    "title": "Top Nutzer nach Token-Verbrauch",
+    "description": "Die 20 Nutzer mit dem höchsten Token-Verbrauch über alle Organisationen",
+    "rank": "Rang",
+    "name": "Name",
+    "email": "E-Mail",
+    "organization": "Organisation",
+    "tokens": "Tokens",
+    "requests": "Anfragen",
+    "lastActivity": "Letzte Aktivität",
+    "lastActivityHint": "Zeigt die letzte Aktivität insgesamt, nicht nach Zeitraum gefiltert",
+    "empty": "Keine Nutzungsdaten vorhanden",
+    "active": "Aktiv",
+    "inactive": "Inaktiv",
+    "allProvidersNote": "Über alle Anbieter und Modelle"
+  },
   "userUsage": {
     "title": "Nutzerverbrauch",
     "subtitle": "Individual Nutzerverbrauch",

--- a/ayunis-core-frontend/src/shared/locales/en/admin-settings-usage.json
+++ b/ayunis-core-frontend/src/shared/locales/en/admin-settings-usage.json
@@ -36,6 +36,22 @@
       "description": "Showing total tokens consumed"
     }
   },
+  "globalTopUsers": {
+    "title": "Top Users by Token Usage",
+    "description": "Top 20 users by token consumption across all organizations",
+    "rank": "Rank",
+    "name": "Name",
+    "email": "Email",
+    "organization": "Organization",
+    "tokens": "Tokens",
+    "requests": "Requests",
+    "lastActivity": "Last Activity",
+    "lastActivityHint": "Shows overall last activity, not filtered by date range",
+    "empty": "No usage data available",
+    "active": "Active",
+    "inactive": "Inactive",
+    "allProvidersNote": "Across all providers and models"
+  },
   "userUsage": {
     "title": "User Usage",
     "subtitle": "Individual user consumption breakdown",

--- a/ayunis-core-frontend/src/widgets/global-top-users-table/index.ts
+++ b/ayunis-core-frontend/src/widgets/global-top-users-table/index.ts
@@ -1,0 +1,1 @@
+export { GlobalTopUsersTableWidget } from './ui/GlobalTopUsersTableWidget';

--- a/ayunis-core-frontend/src/widgets/global-top-users-table/ui/GlobalTopUsersTableContent.tsx
+++ b/ayunis-core-frontend/src/widgets/global-top-users-table/ui/GlobalTopUsersTableContent.tsx
@@ -1,0 +1,133 @@
+import type { GlobalUserUsageDto } from '@/shared/api';
+import { useTranslation } from 'react-i18next';
+import { Info } from 'lucide-react';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/shared/ui/shadcn/table';
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardContent,
+} from '@/shared/ui/shadcn/card';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/shared/ui/shadcn/tooltip';
+import { Badge } from '@/shared/ui/shadcn/badge';
+import { formatCompactNumber } from '@/shared/lib/formatCompactNumber';
+import { formatRelativeDate } from '@/shared/lib/format-relative-date';
+
+interface GlobalTopUsersTableContentProps {
+  users: GlobalUserUsageDto[];
+}
+
+export function GlobalTopUsersTableContent({
+  users,
+}: Readonly<GlobalTopUsersTableContentProps>) {
+  const { t, i18n } = useTranslation('admin-settings-usage');
+
+  const formatCompact = (value: number) =>
+    formatCompactNumber(value, i18n.language);
+
+  const renderLastActivity = (lastActivity: string | null) => {
+    if (!lastActivity) {
+      return <span className="text-muted-foreground">-</span>;
+    }
+
+    return (
+      <span className="text-sm">
+        {formatRelativeDate(lastActivity, i18n.language)}
+      </span>
+    );
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{t('globalTopUsers.title')}</CardTitle>
+        <CardDescription>
+          {t('globalTopUsers.description')}
+          {' · '}
+          <span className="text-muted-foreground/70">
+            {t('globalTopUsers.allProvidersNote')}
+          </span>
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <Table>
+          <TableHeader>
+            <TableRow className="border-border/40">
+              <TableHead className="w-12">{t('globalTopUsers.rank')}</TableHead>
+              <TableHead>{t('globalTopUsers.name')}</TableHead>
+              <TableHead>{t('globalTopUsers.email')}</TableHead>
+              <TableHead>{t('globalTopUsers.organization')}</TableHead>
+              <TableHead className="text-right">
+                {t('globalTopUsers.tokens')}
+              </TableHead>
+              <TableHead className="text-right">
+                {t('globalTopUsers.requests')}
+              </TableHead>
+              <TableHead>
+                <TooltipProvider>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <span className="inline-flex items-center gap-1">
+                        {t('globalTopUsers.lastActivity')}
+                        <Info className="h-3 w-3 text-muted-foreground" />
+                      </span>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      <p>{t('globalTopUsers.lastActivityHint')}</p>
+                    </TooltipContent>
+                  </Tooltip>
+                </TooltipProvider>
+              </TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {users.map((user, index) => (
+              <TableRow
+                key={user.userId}
+                className="border-border/20 transition hover:bg-muted/20"
+              >
+                <TableCell className="font-medium text-muted-foreground">
+                  {index + 1}
+                </TableCell>
+                <TableCell>
+                  <div className="flex items-center gap-2">
+                    <Badge variant={user.isActive ? 'default' : 'secondary'}>
+                      {user.isActive
+                        ? t('globalTopUsers.active')
+                        : t('globalTopUsers.inactive')}
+                    </Badge>
+                    <span className="font-medium">{user.userName}</span>
+                  </div>
+                </TableCell>
+                <TableCell className="text-muted-foreground">
+                  {user.userEmail}
+                </TableCell>
+                <TableCell>{user.organizationName}</TableCell>
+                <TableCell className="text-right font-medium">
+                  {formatCompact(user.tokens)}
+                </TableCell>
+                <TableCell className="text-right font-medium">
+                  {formatCompact(user.requests)}
+                </TableCell>
+                <TableCell>{renderLastActivity(user.lastActivity)}</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </CardContent>
+    </Card>
+  );
+}

--- a/ayunis-core-frontend/src/widgets/global-top-users-table/ui/GlobalTopUsersTableEmpty.tsx
+++ b/ayunis-core-frontend/src/widgets/global-top-users-table/ui/GlobalTopUsersTableEmpty.tsx
@@ -1,0 +1,40 @@
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardContent,
+} from '@/shared/ui/shadcn/card';
+import {
+  Empty,
+  EmptyHeader,
+  EmptyTitle,
+  EmptyDescription,
+  EmptyMedia,
+} from '@/shared/ui/shadcn/empty';
+import { useTranslation } from 'react-i18next';
+import { Users } from 'lucide-react';
+
+export function GlobalTopUsersTableEmpty() {
+  const { t } = useTranslation('admin-settings-usage');
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{t('globalTopUsers.title')}</CardTitle>
+        <CardDescription>{t('globalTopUsers.description')}</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <Empty>
+          <EmptyMedia variant="icon">
+            <Users className="text-muted-foreground" />
+          </EmptyMedia>
+          <EmptyHeader>
+            <EmptyTitle>{t('globalTopUsers.empty')}</EmptyTitle>
+            <EmptyDescription>{t('charts.noDataDescription')}</EmptyDescription>
+          </EmptyHeader>
+        </Empty>
+      </CardContent>
+    </Card>
+  );
+}

--- a/ayunis-core-frontend/src/widgets/global-top-users-table/ui/GlobalTopUsersTableError.tsx
+++ b/ayunis-core-frontend/src/widgets/global-top-users-table/ui/GlobalTopUsersTableError.tsx
@@ -1,0 +1,48 @@
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardContent,
+} from '@/shared/ui/shadcn/card';
+import {
+  Empty,
+  EmptyHeader,
+  EmptyTitle,
+  EmptyDescription,
+  EmptyMedia,
+} from '@/shared/ui/shadcn/empty';
+import { useTranslation } from 'react-i18next';
+import { AlertCircle } from 'lucide-react';
+
+interface GlobalTopUsersTableErrorProps {
+  error: unknown;
+}
+
+export function GlobalTopUsersTableError({
+  error,
+}: Readonly<GlobalTopUsersTableErrorProps>) {
+  const { t } = useTranslation('admin-settings-usage');
+  const errorMessage =
+    error instanceof Error ? error.message : t('charts.errorUnknown');
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{t('globalTopUsers.title')}</CardTitle>
+        <CardDescription>{t('globalTopUsers.description')}</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <Empty>
+          <EmptyMedia variant="icon">
+            <AlertCircle className="text-destructive" />
+          </EmptyMedia>
+          <EmptyHeader>
+            <EmptyTitle>{t('charts.errorTitle')}</EmptyTitle>
+            <EmptyDescription>{errorMessage}</EmptyDescription>
+          </EmptyHeader>
+        </Empty>
+      </CardContent>
+    </Card>
+  );
+}

--- a/ayunis-core-frontend/src/widgets/global-top-users-table/ui/GlobalTopUsersTableLoading.tsx
+++ b/ayunis-core-frontend/src/widgets/global-top-users-table/ui/GlobalTopUsersTableLoading.tsx
@@ -1,0 +1,29 @@
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardContent,
+} from '@/shared/ui/shadcn/card';
+import { Skeleton } from '@/shared/ui/shadcn/skeleton';
+import { useTranslation } from 'react-i18next';
+
+export function GlobalTopUsersTableLoading() {
+  const { t } = useTranslation('admin-settings-usage');
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{t('globalTopUsers.title')}</CardTitle>
+        <CardDescription>{t('globalTopUsers.description')}</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className="space-y-2">
+          {Array.from({ length: 5 }, (_, i) => (
+            <Skeleton key={i} className="h-16 w-full" />
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/ayunis-core-frontend/src/widgets/global-top-users-table/ui/GlobalTopUsersTableWidget.tsx
+++ b/ayunis-core-frontend/src/widgets/global-top-users-table/ui/GlobalTopUsersTableWidget.tsx
@@ -1,0 +1,23 @@
+import type { GlobalUserUsageDto } from '@/shared/api';
+import { GlobalTopUsersTableContent } from './GlobalTopUsersTableContent';
+import { GlobalTopUsersTableLoading } from './GlobalTopUsersTableLoading';
+import { GlobalTopUsersTableError } from './GlobalTopUsersTableError';
+import { GlobalTopUsersTableEmpty } from './GlobalTopUsersTableEmpty';
+
+interface GlobalTopUsersTableWidgetProps {
+  users?: GlobalUserUsageDto[];
+  isLoading: boolean;
+  error: unknown;
+}
+
+export function GlobalTopUsersTableWidget({
+  users,
+  isLoading,
+  error,
+}: Readonly<GlobalTopUsersTableWidgetProps>) {
+  if (isLoading) return <GlobalTopUsersTableLoading />;
+  if (error) return <GlobalTopUsersTableError error={error} />;
+  if (!users?.length) return <GlobalTopUsersTableEmpty />;
+
+  return <GlobalTopUsersTableContent users={users} />;
+}

--- a/ayunis-core-frontend/src/widgets/user-usage-table/ui/UserUsageTableRow.tsx
+++ b/ayunis-core-frontend/src/widgets/user-usage-table/ui/UserUsageTableRow.tsx
@@ -1,10 +1,9 @@
 import type { UserUsageDto } from '@/shared/api/generated/ayunisCoreAPI.schemas';
-import { formatDistanceToNow } from 'date-fns';
-import { de, enUS } from 'date-fns/locale';
 import { useTranslation } from 'react-i18next';
 import { TableCell, TableRow } from '@/shared/ui/shadcn/table';
 import { Badge } from '@/shared/ui/shadcn/badge';
 import { formatCompactNumber } from '@/shared/lib/formatCompactNumber';
+import { formatRelativeDate } from '@/shared/lib/format-relative-date';
 
 interface UserUsageTableRowProps {
   user: UserUsageDto;
@@ -41,12 +40,9 @@ export function UserUsageTableRow({ user }: Readonly<UserUsageTableRowProps>) {
           <span className="text-sm">
             {/* eslint-disable-next-line sonarjs/todo-tag -- DTO typing issue: lastActivity has incorrect type in the generated DTO */}
             {/* TODO: Fix typing issue on the dto level */}
-            {formatDistanceToNow(
-              new Date(user.lastActivity as unknown as string),
-              {
-                addSuffix: true,
-                locale: i18n.language === 'de' ? de : enUS,
-              },
+            {formatRelativeDate(
+              user.lastActivity as unknown as string,
+              i18n.language,
             )}
           </span>
         ) : (


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new super-admin global usage endpoint backed by new SQL aggregation queries and refactors date parsing/validation, which could impact query performance and request validation behavior. Changes are contained to the usage analytics module and UI, but touch persistence and API contracts.
> 
> **Overview**
> Adds a new super-admin global usage API (`GET /super-admin/global-usage/users`) to return the **top 20 users by token usage across all organizations**, including org name and activity status, and wires it through `UsageRepository`/`LocalUsageRepository` with new aggregation query logic.
> 
> Standardizes usage query validation by introducing `validateOptionalDateRange` (requiring *both* `startDate` and `endDate` or neither) and applies it across usage use-cases; controllers now use a shared `parseDate` helper for stricter query-param parsing.
> 
> Updates the frontend super-admin global usage page to display a new “Top Users” table (new widget, translations, and generated API types), and factors out a shared `formatRelativeDate` helper used by both user-usage tables.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b9e7d8419de8dede99737d585db0d9f815fe919a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->