### PR TITLE
wip(AYC-98): add backend use case and endpoint for adding URL to knowledge base

### DIFF
--- a/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/add-url-to-knowledge-base/add-url-to-knowledge-base.command.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/add-url-to-knowledge-base/add-url-to-knowledge-base.command.ts
@@ -1,0 +1,13 @@
+import type { UUID } from 'crypto';
+
+export class AddUrlToKnowledgeBaseCommand {
+  readonly knowledgeBaseId: UUID;
+  readonly userId: UUID;
+  readonly url: string;
+
+  constructor(params: { knowledgeBaseId: UUID; userId: UUID; url: string }) {
+    this.knowledgeBaseId = params.knowledgeBaseId;
+    this.userId = params.userId;
+    this.url = params.url;
+  }
+}

--- a/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/add-url-to-knowledge-base/add-url-to-knowledge-base.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/add-url-to-knowledge-base/add-url-to-knowledge-base.use-case.spec.ts
@@ -1,0 +1,178 @@
+jest.mock('@nestjs-cls/transactional', () => ({
+  Transactional:
+    () =>
+    (_target: unknown, _propertyName: string, descriptor: PropertyDescriptor) =>
+      descriptor,
+}));
+
+import type { TestingModule } from '@nestjs/testing';
+import { Test } from '@nestjs/testing';
+import type { UUID } from 'crypto';
+import { AddUrlToKnowledgeBaseUseCase } from './add-url-to-knowledge-base.use-case';
+import { AddUrlToKnowledgeBaseCommand } from './add-url-to-knowledge-base.command';
+import { KnowledgeBaseRepository } from '../../ports/knowledge-base.repository';
+import { KnowledgeBase } from '../../../domain/knowledge-base.entity';
+import {
+  KnowledgeBaseNotFoundError,
+  UnexpectedKnowledgeBaseError,
+} from '../../knowledge-bases.errors';
+import { CreateTextSourceUseCase } from 'src/domain/sources/application/use-cases/create-text-source/create-text-source.use-case';
+import { UrlSource } from 'src/domain/sources/domain/sources/text-source.entity';
+import { TextType } from 'src/domain/sources/domain/source-type.enum';
+
+describe('AddUrlToKnowledgeBaseUseCase', () => {
+  let useCase: AddUrlToKnowledgeBaseUseCase;
+  let mockRepository: jest.Mocked<KnowledgeBaseRepository>;
+  let mockCreateTextSourceUseCase: jest.Mocked<CreateTextSourceUseCase>;
+
+  const userId = '11111111-1111-1111-1111-111111111111' as UUID;
+  const orgId = '22222222-2222-2222-2222-222222222222' as UUID;
+  const knowledgeBaseId = '33333333-3333-3333-3333-333333333333' as UUID;
+
+  beforeEach(async () => {
+    mockRepository = {
+      findById: jest.fn(),
+      findAllByUserId: jest.fn(),
+      save: jest.fn(),
+      delete: jest.fn(),
+      assignSourceToKnowledgeBase: jest.fn(),
+      findSourcesByKnowledgeBaseId: jest.fn(),
+      findSourceByIdAndKnowledgeBaseId: jest.fn(),
+    } as jest.Mocked<KnowledgeBaseRepository>;
+
+    mockCreateTextSourceUseCase = {
+      execute: jest.fn(),
+    } as unknown as jest.Mocked<CreateTextSourceUseCase>;
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AddUrlToKnowledgeBaseUseCase,
+        { provide: KnowledgeBaseRepository, useValue: mockRepository },
+        {
+          provide: CreateTextSourceUseCase,
+          useValue: mockCreateTextSourceUseCase,
+        },
+      ],
+    }).compile();
+
+    useCase = module.get(AddUrlToKnowledgeBaseUseCase);
+  });
+
+  it('should create a URL source and assign it to the knowledge base', async () => {
+    const knowledgeBase = new KnowledgeBase({
+      id: knowledgeBaseId,
+      name: 'Stadtratsprotokolle 2025',
+      orgId,
+      userId,
+    });
+    mockRepository.findById.mockResolvedValue(knowledgeBase);
+
+    const createdSource = new UrlSource({
+      url: 'https://example.com/stadtrat',
+      name: 'example.com/stadtrat',
+      type: TextType.WEB,
+      text: 'Webseite Inhalt...',
+      contentChunks: [],
+    });
+    mockCreateTextSourceUseCase.execute.mockResolvedValue(
+      createdSource as never,
+    );
+    mockRepository.assignSourceToKnowledgeBase.mockResolvedValue(undefined);
+
+    const command = new AddUrlToKnowledgeBaseCommand({
+      knowledgeBaseId,
+      userId,
+      url: 'https://example.com/stadtrat',
+    });
+
+    const result = await useCase.execute(command);
+
+    expect(result).toBe(createdSource);
+    expect(mockCreateTextSourceUseCase.execute).toHaveBeenCalledTimes(1);
+    expect(mockRepository.assignSourceToKnowledgeBase).toHaveBeenCalledWith(
+      createdSource.id,
+      knowledgeBaseId,
+    );
+  });
+
+  it('should throw KnowledgeBaseNotFoundError when KB does not belong to user', async () => {
+    const otherUserId = '99999999-9999-9999-9999-999999999999' as UUID;
+    const knowledgeBase = new KnowledgeBase({
+      id: knowledgeBaseId,
+      name: 'Anderer Benutzer KB',
+      orgId,
+      userId: otherUserId,
+    });
+    mockRepository.findById.mockResolvedValue(knowledgeBase);
+
+    const command = new AddUrlToKnowledgeBaseCommand({
+      knowledgeBaseId,
+      userId,
+      url: 'https://example.com/stadtrat',
+    });
+
+    await expect(useCase.execute(command)).rejects.toThrow(
+      KnowledgeBaseNotFoundError,
+    );
+    expect(mockCreateTextSourceUseCase.execute).not.toHaveBeenCalled();
+  });
+
+  it('should throw KnowledgeBaseNotFoundError when KB does not exist', async () => {
+    mockRepository.findById.mockResolvedValue(null);
+
+    const command = new AddUrlToKnowledgeBaseCommand({
+      knowledgeBaseId,
+      userId,
+      url: 'https://example.com/stadtrat',
+    });
+
+    await expect(useCase.execute(command)).rejects.toThrow(
+      KnowledgeBaseNotFoundError,
+    );
+  });
+
+  it('should re-throw ApplicationErrors without wrapping', async () => {
+    const knowledgeBase = new KnowledgeBase({
+      id: knowledgeBaseId,
+      name: 'Stadtratsprotokolle 2025',
+      orgId,
+      userId,
+    });
+    mockRepository.findById.mockResolvedValue(knowledgeBase);
+
+    const applicationError = new KnowledgeBaseNotFoundError('some-id');
+    mockCreateTextSourceUseCase.execute.mockRejectedValue(applicationError);
+
+    const command = new AddUrlToKnowledgeBaseCommand({
+      knowledgeBaseId,
+      userId,
+      url: 'https://example.com/stadtrat',
+    });
+
+    await expect(useCase.execute(command)).rejects.toThrow(applicationError);
+  });
+
+  it('should wrap non-ApplicationErrors in UnexpectedKnowledgeBaseError', async () => {
+    const knowledgeBase = new KnowledgeBase({
+      id: knowledgeBaseId,
+      name: 'Stadtratsprotokolle 2025',
+      orgId,
+      userId,
+    });
+    mockRepository.findById.mockResolvedValue(knowledgeBase);
+
+    mockCreateTextSourceUseCase.execute.mockRejectedValue(
+      new Error('connection timeout'),
+    );
+
+    const command = new AddUrlToKnowledgeBaseCommand({
+      knowledgeBaseId,
+      userId,
+      url: 'https://example.com/stadtrat',
+    });
+
+    await expect(useCase.execute(command)).rejects.toThrow(
+      UnexpectedKnowledgeBaseError,
+    );
+  });
+});

--- a/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/add-url-to-knowledge-base/add-url-to-knowledge-base.use-case.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/add-url-to-knowledge-base/add-url-to-knowledge-base.use-case.ts
@@ -1,0 +1,61 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Transactional } from '@nestjs-cls/transactional';
+import type { TextSource } from 'src/domain/sources/domain/sources/text-source.entity';
+import { CreateTextSourceUseCase } from 'src/domain/sources/application/use-cases/create-text-source/create-text-source.use-case';
+import { CreateUrlSourceCommand } from 'src/domain/sources/application/use-cases/create-text-source/create-text-source.command';
+import { ApplicationError } from 'src/common/errors/base.error';
+import { KnowledgeBaseRepository } from '../../ports/knowledge-base.repository';
+import {
+  KnowledgeBaseNotFoundError,
+  UnexpectedKnowledgeBaseError,
+} from '../../knowledge-bases.errors';
+import { AddUrlToKnowledgeBaseCommand } from './add-url-to-knowledge-base.command';
+
+@Injectable()
+export class AddUrlToKnowledgeBaseUseCase {
+  private readonly logger = new Logger(AddUrlToKnowledgeBaseUseCase.name);
+
+  constructor(
+    private readonly knowledgeBaseRepository: KnowledgeBaseRepository,
+    private readonly createTextSourceUseCase: CreateTextSourceUseCase,
+  ) {}
+
+  @Transactional()
+  async execute(command: AddUrlToKnowledgeBaseCommand): Promise<TextSource> {
+    this.logger.log('Adding URL to knowledge base', {
+      knowledgeBaseId: command.knowledgeBaseId,
+      url: command.url,
+    });
+
+    try {
+      const knowledgeBase = await this.knowledgeBaseRepository.findById(
+        command.knowledgeBaseId,
+      );
+      if (knowledgeBase?.userId !== command.userId) {
+        throw new KnowledgeBaseNotFoundError(command.knowledgeBaseId);
+      }
+
+      const source = await this.createTextSourceUseCase.execute(
+        new CreateUrlSourceCommand({ url: command.url }),
+      );
+
+      await this.knowledgeBaseRepository.assignSourceToKnowledgeBase(
+        source.id,
+        command.knowledgeBaseId,
+      );
+
+      return source;
+    } catch (error) {
+      if (error instanceof ApplicationError) {
+        throw error;
+      }
+      this.logger.error('Error adding URL to knowledge base', {
+        error: error as Error,
+      });
+      throw new UnexpectedKnowledgeBaseError(
+        'Error adding URL to knowledge base',
+        { error: error as Error },
+      );
+    }
+  }
+}

--- a/ayunis-core-backend/src/domain/knowledge-bases/knowledge-bases.module.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/knowledge-bases.module.ts
@@ -11,6 +11,7 @@ import { DeleteKnowledgeBaseUseCase } from './application/use-cases/delete-knowl
 import { FindKnowledgeBaseUseCase } from './application/use-cases/find-knowledge-base/find-knowledge-base.use-case';
 import { ListKnowledgeBasesUseCase } from './application/use-cases/list-knowledge-bases/list-knowledge-bases.use-case';
 import { AddDocumentToKnowledgeBaseUseCase } from './application/use-cases/add-document-to-knowledge-base/add-document-to-knowledge-base.use-case';
+import { AddUrlToKnowledgeBaseUseCase } from './application/use-cases/add-url-to-knowledge-base/add-url-to-knowledge-base.use-case';
 import { RemoveDocumentFromKnowledgeBaseUseCase } from './application/use-cases/remove-document-from-knowledge-base/remove-document-from-knowledge-base.use-case';
 import { ListKnowledgeBaseDocumentsUseCase } from './application/use-cases/list-knowledge-base-documents/list-knowledge-base-documents.use-case';
 import { QueryKnowledgeBaseUseCase } from './application/use-cases/query-knowledge-base/query-knowledge-base.use-case';
@@ -35,6 +36,7 @@ import { KnowledgeBaseDtoMapper } from './presenters/http/mappers/knowledge-base
     FindKnowledgeBaseUseCase,
     ListKnowledgeBasesUseCase,
     AddDocumentToKnowledgeBaseUseCase,
+    AddUrlToKnowledgeBaseUseCase,
     RemoveDocumentFromKnowledgeBaseUseCase,
     ListKnowledgeBaseDocumentsUseCase,
     QueryKnowledgeBaseUseCase,
@@ -51,6 +53,7 @@ import { KnowledgeBaseDtoMapper } from './presenters/http/mappers/knowledge-base
     FindKnowledgeBaseUseCase,
     ListKnowledgeBasesUseCase,
     AddDocumentToKnowledgeBaseUseCase,
+    AddUrlToKnowledgeBaseUseCase,
     RemoveDocumentFromKnowledgeBaseUseCase,
     ListKnowledgeBaseDocumentsUseCase,
     QueryKnowledgeBaseUseCase,

--- a/ayunis-core-backend/src/domain/knowledge-bases/presenters/http/dto/add-url-to-knowledge-base.dto.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/presenters/http/dto/add-url-to-knowledge-base.dto.ts
@@ -1,0 +1,12 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsUrl } from 'class-validator';
+
+export class AddUrlToKnowledgeBaseDto {
+  @ApiProperty({
+    description: 'The URL to crawl and add to the knowledge base',
+    example: 'https://example.com/page',
+  })
+  @IsUrl({ require_protocol: true })
+  @IsNotEmpty()
+  url: string;
+}

--- a/ayunis-core-backend/src/domain/knowledge-bases/presenters/http/dto/knowledge-base-document-response.dto.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/presenters/http/dto/knowledge-base-document-response.dto.ts
@@ -1,5 +1,8 @@
-import { ApiProperty } from '@nestjs/swagger';
-import { SourceType } from 'src/domain/sources/domain/source-type.enum';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  SourceType,
+  TextType,
+} from 'src/domain/sources/domain/source-type.enum';
 import { SourceCreator } from 'src/domain/sources/domain/source-creator.enum';
 
 export class KnowledgeBaseDocumentResponseDto {
@@ -46,6 +49,19 @@ export class KnowledgeBaseDocumentResponseDto {
     format: 'date-time',
   })
   updatedAt: string;
+
+  @ApiPropertyOptional({
+    description: 'The text source subtype (e.g. file, web)',
+    enum: TextType,
+    example: TextType.WEB,
+  })
+  textType?: TextType;
+
+  @ApiPropertyOptional({
+    description: 'The URL of the source (only for web sources)',
+    example: 'https://example.com/page',
+  })
+  url?: string;
 }
 
 export class KnowledgeBaseDocumentListResponseDto {

--- a/ayunis-core-backend/src/domain/knowledge-bases/presenters/http/mappers/knowledge-base-dto.mapper.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/presenters/http/mappers/knowledge-base-dto.mapper.ts
@@ -1,6 +1,10 @@
 import { Injectable } from '@nestjs/common';
 import type { KnowledgeBase } from '../../../domain/knowledge-base.entity';
 import type { Source } from 'src/domain/sources/domain/source.entity';
+import {
+  TextSource,
+  UrlSource,
+} from 'src/domain/sources/domain/sources/text-source.entity';
 import type { KnowledgeBaseResponseDto } from '../dto/knowledge-base-response.dto';
 import type { KnowledgeBaseDocumentResponseDto } from '../dto/knowledge-base-document-response.dto';
 
@@ -21,7 +25,7 @@ export class KnowledgeBaseDtoMapper {
   }
 
   toDocumentDto(source: Source): KnowledgeBaseDocumentResponseDto {
-    return {
+    const dto: KnowledgeBaseDocumentResponseDto = {
       id: source.id,
       name: source.name,
       type: source.type,
@@ -29,5 +33,15 @@ export class KnowledgeBaseDtoMapper {
       createdAt: source.createdAt.toISOString(),
       updatedAt: source.updatedAt.toISOString(),
     };
+
+    if (source instanceof TextSource) {
+      dto.textType = source.textType;
+    }
+
+    if (source instanceof UrlSource) {
+      dto.url = source.url;
+    }
+
+    return dto;
   }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new public API path that accepts user-supplied URLs and triggers URL retrieval/indexing via existing source-creation logic, which can impact external I/O and error handling. Also changes the document response schema by adding optional `textType`/`url` fields that may affect API consumers.
> 
> **Overview**
> Adds support for attaching a web URL as a knowledge-base document via a new `AddUrlToKnowledgeBaseUseCase` and `POST /knowledge-bases/:id/urls`, validating the request body with `AddUrlToKnowledgeBaseDto`.
> 
> The use case verifies the knowledge base belongs to the user, creates a URL text source via `CreateTextSourceUseCase`, assigns it to the knowledge base, and standardizes error handling (rethrow `ApplicationError`, otherwise wrap as `UnexpectedKnowledgeBaseError`). The document response DTO/mapping is extended to optionally include `textType` and `url` for text/URL sources.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8e6480392d6dc34a8733d8bbaffd10ffe281de1b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->