### PR TITLE
feat(AYC-98): add URL source UI to knowledge base detail page

### DIFF
--- a/ayunis-core-frontend/src/pages/knowledge-base/api/index.ts
+++ b/ayunis-core-frontend/src/pages/knowledge-base/api/index.ts
@@ -1,4 +1,5 @@
 export { useUpdateKnowledgeBase } from './useUpdateKnowledgeBase';
 export { useKnowledgeBaseDocuments } from './useKnowledgeBaseDocuments';
 export { useUploadDocument } from './useUploadDocument';
+export { useAddUrl } from './useAddUrl';
 export { useRemoveDocument } from './useRemoveDocument';

--- a/ayunis-core-frontend/src/pages/knowledge-base/api/useAddUrl.ts
+++ b/ayunis-core-frontend/src/pages/knowledge-base/api/useAddUrl.ts
@@ -1,0 +1,36 @@
+import { useQueryClient } from '@tanstack/react-query';
+import { useTranslation } from 'react-i18next';
+import { showSuccess, showError } from '@/shared/lib/toast';
+import {
+  useKnowledgeBasesControllerAddUrl,
+  getKnowledgeBasesControllerListDocumentsQueryKey,
+} from '@/shared/api/generated/ayunisCoreAPI';
+
+export function useAddUrl(knowledgeBaseId: string) {
+  const { t } = useTranslation('knowledge-bases');
+  const queryClient = useQueryClient();
+
+  const mutation = useKnowledgeBasesControllerAddUrl({
+    mutation: {
+      onSuccess: () => {
+        void queryClient.invalidateQueries({
+          queryKey:
+            getKnowledgeBasesControllerListDocumentsQueryKey(knowledgeBaseId),
+        });
+        showSuccess(t('detail.documents.addUrlSuccess'));
+      },
+      onError: () => {
+        showError(t('detail.documents.addUrlError'));
+      },
+    },
+  });
+
+  const addUrlAsync = async (url: string) => {
+    await mutation.mutateAsync({
+      id: knowledgeBaseId,
+      data: { url },
+    });
+  };
+
+  return { addUrlAsync, isAddingUrl: mutation.isPending };
+}

--- a/ayunis-core-frontend/src/pages/knowledge-base/ui/KnowledgeBaseDocumentsCard.tsx
+++ b/ayunis-core-frontend/src/pages/knowledge-base/ui/KnowledgeBaseDocumentsCard.tsx
@@ -1,4 +1,4 @@
-import { useRef } from 'react';
+import { useRef, useState } from 'react';
 import {
   Card,
   CardContent,
@@ -9,16 +9,39 @@ import {
 } from '@/shared/ui/shadcn/card';
 import { Button } from '@/shared/ui/shadcn/button';
 import { Badge } from '@/shared/ui/shadcn/badge';
-import type { KnowledgeBaseDocumentResponseDto } from '@/shared/api/generated/ayunisCoreAPI.schemas';
-import { Upload, X, FileText, Loader2 } from 'lucide-react';
+import { Input } from '@/shared/ui/shadcn/input';
+import { Label } from '@/shared/ui/shadcn/label';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@/shared/ui/shadcn/dialog';
+import {
+  KnowledgeBaseDocumentResponseDtoTextType,
+  type KnowledgeBaseDocumentResponseDto,
+} from '@/shared/api/generated/ayunisCoreAPI.schemas';
+import { Upload, X, FileText, Globe, Loader2 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import {
   useKnowledgeBaseDocuments,
   useUploadDocument,
+  useAddUrl,
   useRemoveDocument,
 } from '../api';
 
 const ACCEPTED_FILE_TYPES = '.pdf,.docx';
+
+function isValidUrl(value: string): boolean {
+  try {
+    const url = new URL(value);
+    return url.protocol === 'http:' || url.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
 
 export default function KnowledgeBaseDocumentsCard({
   knowledgeBaseId,
@@ -27,8 +50,11 @@ export default function KnowledgeBaseDocumentsCard({
 }>) {
   const { t } = useTranslation('knowledge-bases');
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const [urlDialogOpen, setUrlDialogOpen] = useState(false);
+  const [urlInput, setUrlInput] = useState('');
   const { documents, isLoading } = useKnowledgeBaseDocuments(knowledgeBaseId);
   const { uploadDocument, isUploading } = useUploadDocument(knowledgeBaseId);
+  const { addUrlAsync, isAddingUrl } = useAddUrl(knowledgeBaseId);
   const { removeDocument, isRemoving } = useRemoveDocument(knowledgeBaseId);
 
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -36,6 +62,26 @@ export default function KnowledgeBaseDocumentsCard({
     if (file) {
       uploadDocument(file);
       e.target.value = '';
+    }
+  };
+
+  const handleAddUrl = async () => {
+    const trimmed = urlInput.trim();
+    if (!trimmed || !isValidUrl(trimmed) || isAddingUrl) return;
+    try {
+      await addUrlAsync(trimmed);
+      setUrlInput('');
+      setUrlDialogOpen(false);
+    } catch {
+      // error toast is handled by the mutation's onError callback
+    }
+  };
+
+  const handleUrlDialogOpenChange = (open: boolean) => {
+    if (!open && isAddingUrl) return;
+    setUrlDialogOpen(open);
+    if (!open) {
+      setUrlInput('');
     }
   };
 
@@ -52,19 +98,34 @@ export default function KnowledgeBaseDocumentsCard({
             onChange={handleFileChange}
             className="hidden"
           />
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => fileInputRef.current?.click()}
-            disabled={isUploading}
-          >
-            {isUploading ? (
-              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-            ) : (
-              <Upload className="mr-2 h-4 w-4" />
-            )}
-            {t('detail.documents.upload')}
-          </Button>
+          <div className="flex gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setUrlDialogOpen(true)}
+              disabled={isAddingUrl}
+            >
+              {isAddingUrl ? (
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              ) : (
+                <Globe className="mr-2 h-4 w-4" />
+              )}
+              {t('detail.documents.addUrl')}
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => fileInputRef.current?.click()}
+              disabled={isUploading}
+            >
+              {isUploading ? (
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              ) : (
+                <Upload className="mr-2 h-4 w-4" />
+              )}
+              {t('detail.documents.upload')}
+            </Button>
+          </div>
         </CardAction>
       </CardHeader>
       <CardContent>
@@ -76,6 +137,15 @@ export default function KnowledgeBaseDocumentsCard({
           emptyText={t('detail.documents.empty')}
         />
       </CardContent>
+      <AddUrlDialog
+        open={urlDialogOpen}
+        onOpenChange={handleUrlDialogOpenChange}
+        urlInput={urlInput}
+        onUrlChange={setUrlInput}
+        onSubmit={() => void handleAddUrl()}
+        isAddingUrl={isAddingUrl}
+        t={t}
+      />
     </Card>
   );
 }
@@ -110,25 +180,108 @@ function DocumentsContent({
   return (
     <div className="flex flex-wrap gap-2">
       {documents.map((doc) => (
-        <Badge
+        <DocumentBadge
           key={doc.id}
-          variant="secondary"
-          className="flex items-center gap-1.5 py-1.5 px-3"
-        >
-          <FileText className="h-3.5 w-3.5" />
-          <span className="max-w-[200px] truncate">{doc.name}</span>
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon"
-            onClick={() => removeDocument(doc.id)}
-            disabled={isRemoving}
-            className="ml-1 h-5 w-5 rounded-full"
-          >
-            <X className="h-3 w-3" />
-          </Button>
-        </Badge>
+          doc={doc}
+          removeDocument={removeDocument}
+          isRemoving={isRemoving}
+        />
       ))}
     </div>
+  );
+}
+
+function DocumentBadge({
+  doc,
+  removeDocument,
+  isRemoving,
+}: Readonly<{
+  doc: KnowledgeBaseDocumentResponseDto;
+  removeDocument: (id: string) => void;
+  isRemoving: boolean;
+}>) {
+  const isWeb = doc.textType === KnowledgeBaseDocumentResponseDtoTextType.web;
+  const Icon = isWeb ? Globe : FileText;
+
+  return (
+    <Badge
+      variant="secondary"
+      className="flex items-center gap-1.5 py-1.5 px-3"
+      title={isWeb ? (doc.url ?? undefined) : undefined}
+    >
+      <Icon className="h-3.5 w-3.5 shrink-0" />
+      <span className="max-w-[200px] truncate">{doc.name}</span>
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon"
+        onClick={() => removeDocument(doc.id)}
+        disabled={isRemoving}
+        className="ml-1 h-5 w-5 rounded-full"
+      >
+        <X className="h-3 w-3" />
+      </Button>
+    </Badge>
+  );
+}
+
+function AddUrlDialog({
+  open,
+  onOpenChange,
+  urlInput,
+  onUrlChange,
+  onSubmit,
+  isAddingUrl,
+  t,
+}: Readonly<{
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  urlInput: string;
+  onUrlChange: (value: string) => void;
+  onSubmit: () => void;
+  isAddingUrl: boolean;
+  t: (key: string) => string;
+}>) {
+  const isUrlValid = urlInput.trim() !== '' && isValidUrl(urlInput.trim());
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{t('detail.documents.urlDialogTitle')}</DialogTitle>
+          <DialogDescription>
+            {t('detail.documents.urlDialogDescription')}
+          </DialogDescription>
+        </DialogHeader>
+        <div>
+          <Label htmlFor="add-url-input" className="sr-only">
+            {t('detail.documents.urlLabel')}
+          </Label>
+          <Input
+            id="add-url-input"
+            type="url"
+            placeholder={t('detail.documents.urlPlaceholder')}
+            value={urlInput}
+            onChange={(e) => onUrlChange(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' && isUrlValid && !isAddingUrl) onSubmit();
+            }}
+          />
+        </div>
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={isAddingUrl}
+          >
+            {t('detail.documents.urlDialogCancel')}
+          </Button>
+          <Button onClick={onSubmit} disabled={!isUrlValid || isAddingUrl}>
+            {isAddingUrl && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+            {t('detail.documents.addUrl')}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
@@ -2495,6 +2495,18 @@ export const KnowledgeBaseDocumentResponseDtoCreatedBy = {
   system: 'system',
 } as const;
 
+/**
+ * The text source subtype (e.g. file, web)
+ */
+export type KnowledgeBaseDocumentResponseDtoTextType = typeof KnowledgeBaseDocumentResponseDtoTextType[keyof typeof KnowledgeBaseDocumentResponseDtoTextType];
+
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const KnowledgeBaseDocumentResponseDtoTextType = {
+  file: 'file',
+  web: 'web',
+} as const;
+
 export interface KnowledgeBaseDocumentResponseDto {
   /** The unique identifier of the document */
   id: string;
@@ -2508,11 +2520,20 @@ export interface KnowledgeBaseDocumentResponseDto {
   createdAt: string;
   /** The date and time when the document was last updated */
   updatedAt: string;
+  /** The text source subtype (e.g. file, web) */
+  textType?: KnowledgeBaseDocumentResponseDtoTextType;
+  /** The URL of the source (only for web sources) */
+  url?: string;
 }
 
 export interface KnowledgeBaseDocumentListResponseDto {
   /** The list of documents in the knowledge base */
   data: KnowledgeBaseDocumentResponseDto[];
+}
+
+export interface AddUrlToKnowledgeBaseDto {
+  /** The URL to crawl and add to the knowledge base */
+  url: string;
 }
 
 export interface InstallSkillFromMarketplaceDto {

--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.ts
@@ -29,6 +29,7 @@ import type {
   AcceptInviteResponseDto,
   ActiveSubscriptionResponseDto,
   AddTeamMemberDto,
+  AddUrlToKnowledgeBaseDto,
   AgentResponseDto,
   AgentSourceResponseDto,
   AgentsControllerAddFileSourceBody,
@@ -9836,6 +9837,72 @@ export const useKnowledgeBasesControllerAddDocument = <TError = void,
       > => {
 
       const mutationOptions = getKnowledgeBasesControllerAddDocumentMutationOptions(options);
+
+      return useMutation(mutationOptions, queryClient);
+    }
+    
+/**
+ * @summary Add a URL source to a knowledge base
+ */
+export const knowledgeBasesControllerAddUrl = (
+    id: string,
+    addUrlToKnowledgeBaseDto: AddUrlToKnowledgeBaseDto,
+ signal?: AbortSignal
+) => {
+      
+      
+      return customAxiosInstance<KnowledgeBaseDocumentResponseDto>(
+      {url: `/knowledge-bases/${id}/urls`, method: 'POST',
+      headers: {'Content-Type': 'application/json', },
+      data: addUrlToKnowledgeBaseDto, signal
+    },
+      );
+    }
+  
+
+
+export const getKnowledgeBasesControllerAddUrlMutationOptions = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof knowledgeBasesControllerAddUrl>>, TError,{id: string;data: AddUrlToKnowledgeBaseDto}, TContext>, }
+): UseMutationOptions<Awaited<ReturnType<typeof knowledgeBasesControllerAddUrl>>, TError,{id: string;data: AddUrlToKnowledgeBaseDto}, TContext> => {
+
+const mutationKey = ['knowledgeBasesControllerAddUrl'];
+const {mutation: mutationOptions} = options ?
+      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
+      options
+      : {...options, mutation: {...options.mutation, mutationKey}}
+      : {mutation: { mutationKey, }};
+
+      
+
+
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof knowledgeBasesControllerAddUrl>>, {id: string;data: AddUrlToKnowledgeBaseDto}> = (props) => {
+          const {id,data} = props ?? {};
+
+          return  knowledgeBasesControllerAddUrl(id,data,)
+        }
+
+        
+
+
+  return  { mutationFn, ...mutationOptions }}
+
+    export type KnowledgeBasesControllerAddUrlMutationResult = NonNullable<Awaited<ReturnType<typeof knowledgeBasesControllerAddUrl>>>
+    export type KnowledgeBasesControllerAddUrlMutationBody = AddUrlToKnowledgeBaseDto
+    export type KnowledgeBasesControllerAddUrlMutationError = void
+
+    /**
+ * @summary Add a URL source to a knowledge base
+ */
+export const useKnowledgeBasesControllerAddUrl = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof knowledgeBasesControllerAddUrl>>, TError,{id: string;data: AddUrlToKnowledgeBaseDto}, TContext>, }
+ , queryClient?: QueryClient): UseMutationResult<
+        Awaited<ReturnType<typeof knowledgeBasesControllerAddUrl>>,
+        TError,
+        {id: string;data: AddUrlToKnowledgeBaseDto},
+        TContext
+      > => {
+
+      const mutationOptions = getKnowledgeBasesControllerAddUrlMutationOptions(options);
 
       return useMutation(mutationOptions, queryClient);
     }

--- a/ayunis-core-frontend/src/shared/api/openapi-schema.json
+++ b/ayunis-core-frontend/src/shared/api/openapi-schema.json
@@ -5049,6 +5049,52 @@
         ]
       }
     },
+    "/knowledge-bases/{id}/urls": {
+      "post": {
+        "operationId": "KnowledgeBasesController_addUrl",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "description": "The UUID of the knowledge base",
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AddUrlToKnowledgeBaseDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "The URL source has been added to the knowledge base",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/KnowledgeBaseDocumentResponseDto"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Knowledge base not found"
+          }
+        },
+        "summary": "Add a URL source to a knowledge base",
+        "tags": [
+          "knowledge-bases"
+        ]
+      }
+    },
     "/knowledge-bases/{id}/documents/{documentId}": {
       "delete": {
         "operationId": "KnowledgeBasesController_removeDocument",
@@ -11560,6 +11606,20 @@
             "description": "The date and time when the document was last updated",
             "example": "2025-01-15T10:00:00.000Z",
             "format": "date-time"
+          },
+          "textType": {
+            "type": "string",
+            "description": "The text source subtype (e.g. file, web)",
+            "enum": [
+              "file",
+              "web"
+            ],
+            "example": "web"
+          },
+          "url": {
+            "type": "string",
+            "description": "The URL of the source (only for web sources)",
+            "example": "https://example.com/page"
           }
         },
         "required": [
@@ -11584,6 +11644,19 @@
         },
         "required": [
           "data"
+        ]
+      },
+      "AddUrlToKnowledgeBaseDto": {
+        "type": "object",
+        "properties": {
+          "url": {
+            "type": "string",
+            "description": "The URL to crawl and add to the knowledge base",
+            "example": "https://example.com/page"
+          }
+        },
+        "required": [
+          "url"
         ]
       },
       "InstallSkillFromMarketplaceDto": {

--- a/ayunis-core-frontend/src/shared/locales/de/knowledge-bases.json
+++ b/ayunis-core-frontend/src/shared/locales/de/knowledge-bases.json
@@ -80,8 +80,16 @@
       "empty": "Noch keine Dokumente hochgeladen. Laden Sie eine PDF- oder DOCX-Datei hoch, um zu beginnen.",
       "uploadSuccess": "Dokument erfolgreich hochgeladen!",
       "uploadError": "Dokument konnte nicht hochgeladen werden. Bitte versuchen Sie es erneut.",
+      "addUrl": "URL hinzufügen",
+      "urlPlaceholder": "https://beispiel.de",
+      "urlDialogTitle": "Website-URL hinzufügen",
+      "urlDialogDescription": "Geben Sie die URL einer Website ein, um deren Inhalt in die Wissenssammlung zu importieren.",
+      "urlLabel": "Website-URL",
+      "addUrlSuccess": "URL erfolgreich hinzugefügt! Der Website-Inhalt wird verarbeitet.",
+      "addUrlError": "URL konnte nicht hinzugefügt werden. Bitte überprüfen Sie die URL und versuchen Sie es erneut.",
       "removeSuccess": "Dokument erfolgreich entfernt!",
-      "removeError": "Dokument konnte nicht entfernt werden. Bitte versuchen Sie es erneut."
+      "removeError": "Dokument konnte nicht entfernt werden. Bitte versuchen Sie es erneut.",
+      "urlDialogCancel": "Abbrechen"
     }
   }
 }

--- a/ayunis-core-frontend/src/shared/locales/en/knowledge-bases.json
+++ b/ayunis-core-frontend/src/shared/locales/en/knowledge-bases.json
@@ -80,8 +80,16 @@
       "empty": "No documents uploaded yet. Upload a PDF or DOCX file to get started.",
       "uploadSuccess": "Document uploaded successfully!",
       "uploadError": "Failed to upload document. Please try again.",
+      "addUrl": "Add URL",
+      "urlPlaceholder": "https://example.com",
+      "urlDialogTitle": "Add Website URL",
+      "urlDialogDescription": "Enter the URL of a website to import its content into the knowledge base.",
+      "urlLabel": "Website URL",
+      "addUrlSuccess": "URL added successfully! The website content is being processed.",
+      "addUrlError": "Failed to add URL. Please check the URL and try again.",
       "removeSuccess": "Document removed successfully!",
-      "removeError": "Failed to remove document. Please try again."
+      "removeError": "Failed to remove document. Please try again.",
+      "urlDialogCancel": "Cancel"
     }
   }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new URL-ingestion mutation and wires it into the documents UI; correctness depends on the new backend endpoint and updated generated types staying in sync. UI state/validation changes are localized but can affect document rendering and user flows on the knowledge base detail page.
> 
> **Overview**
> Adds the ability to **add a website URL as a knowledge base source** from the documents card, via a new `useAddUrl` mutation that calls `POST /knowledge-bases/:id/urls`, shows success/error toasts, and refreshes the documents list.
> 
> Updates the documents UI to include an *Add URL* dialog with basic `http(s)` validation and pending-state locking, and enhances document badges to distinguish web vs file sources (globe icon + URL tooltip) using new API fields (`textType`, `url`).
> 
> Regenerates the OpenAPI client/schema to include `AddUrlToKnowledgeBaseDto`, the new endpoint, and the `KnowledgeBaseDocumentResponseDtoTextType` enum, and adds EN/DE i18n strings for the new flow.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5d811d5c1572af46b38662765b6ac34d853c4968. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->