### PR TITLE
wip(AYC-99): add knowledgeBaseIds to skill entity and persistence layer

### DIFF
--- a/.pi
+++ b/.pi
@@ -1,0 +1,1 @@
+/Users/daniel/dev/ayunis/ayunis-core/.pi

--- a/ayunis-core-backend/src/db/migrations/1772137409529-AddSkillKnowledgeBasesJoinTable.ts
+++ b/ayunis-core-backend/src/db/migrations/1772137409529-AddSkillKnowledgeBasesJoinTable.ts
@@ -1,0 +1,41 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddSkillKnowledgeBasesJoinTable1772137409529
+  implements MigrationInterface
+{
+  name = 'AddSkillKnowledgeBasesJoinTable1772137409529';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE "skill_knowledge_bases" ("skillsId" character varying NOT NULL, "knowledgeBasesId" character varying NOT NULL, CONSTRAINT "PK_aff430c73f5d25384d854307134" PRIMARY KEY ("skillsId", "knowledgeBasesId"))`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_c1ca1820a2d10818eb5f0e5ca8" ON "skill_knowledge_bases" ("skillsId")`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_27f6c71ffde24fb47e6bc026b7" ON "skill_knowledge_bases" ("knowledgeBasesId")`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "skill_knowledge_bases" ADD CONSTRAINT "FK_c1ca1820a2d10818eb5f0e5ca8d" FOREIGN KEY ("skillsId") REFERENCES "skills"("id") ON DELETE CASCADE ON UPDATE CASCADE`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "skill_knowledge_bases" ADD CONSTRAINT "FK_27f6c71ffde24fb47e6bc026b7b" FOREIGN KEY ("knowledgeBasesId") REFERENCES "knowledge_bases"("id") ON DELETE CASCADE ON UPDATE CASCADE`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "skill_knowledge_bases" DROP CONSTRAINT "FK_27f6c71ffde24fb47e6bc026b7b"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "skill_knowledge_bases" DROP CONSTRAINT "FK_c1ca1820a2d10818eb5f0e5ca8d"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_27f6c71ffde24fb47e6bc026b7"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_c1ca1820a2d10818eb5f0e5ca8"`,
+    );
+    await queryRunner.query(`DROP TABLE "skill_knowledge_bases"`);
+  }
+}

--- a/ayunis-core-backend/src/domain/skills/domain/skill.entity.spec.ts
+++ b/ayunis-core-backend/src/domain/skills/domain/skill.entity.spec.ts
@@ -21,6 +21,7 @@ describe('Skill Entity', () => {
     expect(skill.userId).toBe(mockUserId);
     expect(skill.sourceIds).toEqual([]);
     expect(skill.mcpIntegrationIds).toEqual([]);
+    expect(skill.knowledgeBaseIds).toEqual([]);
     expect(skill.createdAt).toBeInstanceOf(Date);
     expect(skill.updatedAt).toBeInstanceOf(Date);
   });
@@ -58,6 +59,24 @@ describe('Skill Entity', () => {
     expect(skill.sourceIds).toEqual(sourceIds);
     expect(skill.mcpIntegrationIds).toEqual(mcpIds);
     expect(skill.mcpIntegrationIds).toHaveLength(2);
+  });
+
+  it('should preserve knowledge base IDs when provided', () => {
+    const knowledgeBaseIds = [
+      '333e4567-e89b-12d3-a456-426614174000' as UUID,
+      '444e4567-e89b-12d3-a456-426614174000' as UUID,
+    ];
+
+    const skill = new Skill({
+      name: 'KB Skill',
+      shortDescription: 'Skill with knowledge bases.',
+      instructions: 'Use these knowledge bases...',
+      userId: mockUserId,
+      knowledgeBaseIds,
+    });
+
+    expect(skill.knowledgeBaseIds).toEqual(knowledgeBaseIds);
+    expect(skill.knowledgeBaseIds).toHaveLength(2);
   });
 
   describe('name validation', () => {

--- a/ayunis-core-backend/src/domain/skills/domain/skill.entity.ts
+++ b/ayunis-core-backend/src/domain/skills/domain/skill.entity.ts
@@ -36,6 +36,7 @@ export class Skill {
   public readonly instructions: string;
   public readonly sourceIds: UUID[];
   public readonly mcpIntegrationIds: UUID[];
+  public readonly knowledgeBaseIds: UUID[];
   public readonly marketplaceIdentifier: string | null;
   public readonly userId: UUID;
   public readonly createdAt: Date;
@@ -48,6 +49,7 @@ export class Skill {
     instructions: string;
     sourceIds?: UUID[];
     mcpIntegrationIds?: UUID[];
+    knowledgeBaseIds?: UUID[];
     marketplaceIdentifier?: string | null;
     userId: UUID;
     createdAt?: Date;
@@ -60,6 +62,7 @@ export class Skill {
     this.instructions = params.instructions;
     this.sourceIds = params.sourceIds ?? [];
     this.mcpIntegrationIds = params.mcpIntegrationIds ?? [];
+    this.knowledgeBaseIds = params.knowledgeBaseIds ?? [];
     this.marketplaceIdentifier = params.marketplaceIdentifier ?? null;
     this.userId = params.userId;
     this.createdAt = params.createdAt ?? new Date();

--- a/ayunis-core-backend/src/domain/skills/infrastructure/persistence/local/mappers/skill.mapper.spec.ts
+++ b/ayunis-core-backend/src/domain/skills/infrastructure/persistence/local/mappers/skill.mapper.spec.ts
@@ -10,6 +10,7 @@ describe('SkillMapper', () => {
   const mockSkillId = '550e8400-e29b-41d4-a716-446655440000' as UUID;
   const mockSourceId = '770e8400-e29b-41d4-a716-446655440000' as UUID;
   const mockMcpId = '660e8400-e29b-41d4-a716-446655440000' as UUID;
+  const mockKbId = '880e8400-e29b-41d4-a716-446655440000' as UUID;
 
   beforeEach(() => {
     mapper = new SkillMapper();
@@ -25,6 +26,7 @@ describe('SkillMapper', () => {
       record.userId = mockUserId;
       record.sources = [{ id: mockSourceId } as any];
       record.mcpIntegrations = [{ id: mockMcpId } as any];
+      record.knowledgeBases = [{ id: mockKbId } as any];
       record.createdAt = new Date('2026-01-01');
       record.updatedAt = new Date('2026-01-02');
 
@@ -37,6 +39,7 @@ describe('SkillMapper', () => {
       expect(domain.userId).toBe(mockUserId);
       expect(domain.sourceIds).toEqual([mockSourceId]);
       expect(domain.mcpIntegrationIds).toEqual([mockMcpId]);
+      expect(domain.knowledgeBaseIds).toEqual([mockKbId]);
       expect(domain.createdAt).toEqual(new Date('2026-01-01'));
       expect(domain.updatedAt).toEqual(new Date('2026-01-02'));
     });
@@ -55,6 +58,7 @@ describe('SkillMapper', () => {
 
       expect(domain.sourceIds).toEqual([]);
       expect(domain.mcpIntegrationIds).toEqual([]);
+      expect(domain.knowledgeBaseIds).toEqual([]);
     });
   });
 

--- a/ayunis-core-backend/src/domain/skills/infrastructure/persistence/local/mappers/skill.mapper.ts
+++ b/ayunis-core-backend/src/domain/skills/infrastructure/persistence/local/mappers/skill.mapper.ts
@@ -13,6 +13,7 @@ export class SkillMapper {
       sourceIds: record.sources?.map((source) => source.id) ?? [],
       mcpIntegrationIds:
         record.mcpIntegrations?.map((integration) => integration.id) ?? [],
+      knowledgeBaseIds: record.knowledgeBases?.map((kb) => kb.id) ?? [],
       marketplaceIdentifier: record.marketplaceIdentifier ?? null,
       userId: record.userId,
       createdAt: record.createdAt,

--- a/ayunis-core-backend/src/domain/skills/infrastructure/persistence/local/schema/skill.record.ts
+++ b/ayunis-core-backend/src/domain/skills/infrastructure/persistence/local/schema/skill.record.ts
@@ -11,6 +11,7 @@ import { UUID } from 'crypto';
 import { UserRecord } from '../../../../../../iam/users/infrastructure/repositories/local/schema/user.record';
 import { SourceRecord } from '../../../../../sources/infrastructure/persistence/local/schema/source.record';
 import { McpIntegrationRecord } from '../../../../../mcp/infrastructure/persistence/postgres/schema/mcp-integration.record';
+import { KnowledgeBaseRecord } from '../../../../../knowledge-bases/infrastructure/persistence/local/schema/knowledge-base.record';
 
 @Entity({ name: 'skills' })
 @Unique('UQ_skill_name_userId', ['name', 'userId'])
@@ -40,4 +41,8 @@ export class SkillRecord extends BaseRecord {
   @ManyToMany(() => McpIntegrationRecord)
   @JoinTable({ name: 'skill_mcp_integrations' })
   mcpIntegrations?: McpIntegrationRecord[];
+
+  @ManyToMany(() => KnowledgeBaseRecord)
+  @JoinTable({ name: 'skill_knowledge_bases' })
+  knowledgeBases?: KnowledgeBaseRecord[];
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces a new DB join table and ORM relation for skills↔knowledge bases; schema changes and relation-loading expectations could affect persistence/query behavior if not migrated or fetched correctly.
> 
> **Overview**
> **Skills can now be linked to knowledge bases.** The `Skill` domain entity gains `knowledgeBaseIds` (defaulting to `[]`) with updated unit tests to cover the new field.
> 
> On the persistence side, `SkillRecord` adds a `ManyToMany` relation to `KnowledgeBaseRecord` via a new `skill_knowledge_bases` join table, with the mapper populating `knowledgeBaseIds` from loaded relations; a TypeORM migration creates/drops this table with indexes and cascading FKs.
> 
> Also adds a `.pi` file containing a local filesystem path (likely accidental).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c5c4a1901840376ff51b14cf98db240c11f4ff40. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->