### PR TITLE
wip(AYC-99): add knowledge base relation to skill repository and module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ node_modules
 # Auto-generated type-checking tsconfig files (tool-generated with hash names)
 tsconfig.?????????*.json
 # Agent config (symlinked from ayunis-ai)
+.pi
 .pi/
 .claude/
 AGENTS.md

--- a/.pi
+++ b/.pi
@@ -1,1 +1,0 @@
-/Users/daniel/dev/ayunis/ayunis-core/.pi

--- a/ayunis-core-backend/src/domain/skills/application/use-cases/update-skill/update-skill.use-case.ts
+++ b/ayunis-core-backend/src/domain/skills/application/use-cases/update-skill/update-skill.use-case.ts
@@ -56,6 +56,7 @@ export class UpdateSkillUseCase {
         instructions: command.instructions,
         sourceIds: existingSkill.sourceIds,
         mcpIntegrationIds: existingSkill.mcpIntegrationIds,
+        knowledgeBaseIds: existingSkill.knowledgeBaseIds,
         userId,
         createdAt: existingSkill.createdAt,
         updatedAt: new Date(),

--- a/ayunis-core-backend/src/domain/skills/skills.module.ts
+++ b/ayunis-core-backend/src/domain/skills/skills.module.ts
@@ -9,6 +9,8 @@ import { SkillRepository } from './application/ports/skill.repository';
 import { SkillRecord } from './infrastructure/persistence/local/schema/skill.record';
 import { SkillActivationRecord } from './infrastructure/persistence/local/schema/skill-activation.record';
 import { McpIntegrationRecord } from '../mcp/infrastructure/persistence/postgres/schema/mcp-integration.record';
+import { KnowledgeBaseRecord } from '../knowledge-bases/infrastructure/persistence/local/schema/knowledge-base.record';
+import { KnowledgeBasesModule } from '../knowledge-bases/knowledge-bases.module';
 
 // Use Cases
 import { CreateSkillUseCase } from './application/use-cases/create-skill/create-skill.use-case';
@@ -63,10 +65,12 @@ import { McpIntegrationDtoMapper } from '../mcp/presenters/http/mappers/mcp-inte
       SkillRecord,
       SkillActivationRecord,
       McpIntegrationRecord,
+      KnowledgeBaseRecord,
     ]),
     LocalSkillRepositoryModule,
     SourcesModule,
     McpModule,
+    KnowledgeBasesModule,
     MarketplaceModule,
     forwardRef(() => SharesModule),
     UsersModule,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Updates skill persistence to load and maintain `knowledgeBases` many-to-many relations on create/update/read paths, which can affect stored relations and query performance. Also wires `KnowledgeBasesModule`/`KnowledgeBaseRecord` into the skills module, impacting DI and TypeORM metadata.
> 
> **Overview**
> Skills now persist and return `knowledgeBases` relationships alongside sources and MCP integrations. `LocalSkillRepository` adds knowledge-base relation handling on create/update (add/remove diffs) and consistently loads relations via a shared `SKILL_RELATIONS` list.
> 
> `UpdateSkillUseCase` preserves `knowledgeBaseIds` when updating, and `SkillsModule` registers `KnowledgeBaseRecord` and imports `KnowledgeBasesModule` to support the new relation. `.gitignore` is updated to ignore `.pi` (and removes the tracked `.pi` file).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 86fb6f6e7886a408788e551f57f0abaa3bbf00d1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->