### PR TITLE
wip(AYC-99): add skill knowledge base use cases and controller

### DIFF
--- a/ayunis-core-backend/src/domain/knowledge-bases/application/ports/knowledge-base.repository.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/application/ports/knowledge-base.repository.ts
@@ -4,6 +4,7 @@ import type { Source } from 'src/domain/sources/domain/source.entity';
 
 export abstract class KnowledgeBaseRepository {
   abstract findById(id: UUID): Promise<KnowledgeBase | null>;
+  abstract findByIds(ids: UUID[]): Promise<KnowledgeBase[]>;
   abstract findAllByUserId(userId: UUID): Promise<KnowledgeBase[]>;
   abstract save(knowledgeBase: KnowledgeBase): Promise<KnowledgeBase>;
   abstract delete(knowledgeBase: KnowledgeBase): Promise<void>;

--- a/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/add-document-to-knowledge-base/add-document-to-knowledge-base.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/add-document-to-knowledge-base/add-document-to-knowledge-base.use-case.spec.ts
@@ -30,6 +30,7 @@ describe('AddDocumentToKnowledgeBaseUseCase', () => {
     mockRepository = {
       findById: jest.fn(),
       findAllByUserId: jest.fn(),
+      findByIds: jest.fn(),
       save: jest.fn(),
       delete: jest.fn(),
       assignSourceToKnowledgeBase: jest.fn(),

--- a/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/add-url-to-knowledge-base/add-url-to-knowledge-base.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/add-url-to-knowledge-base/add-url-to-knowledge-base.use-case.spec.ts
@@ -33,6 +33,7 @@ describe('AddUrlToKnowledgeBaseUseCase', () => {
     mockRepository = {
       findById: jest.fn(),
       findAllByUserId: jest.fn(),
+      findByIds: jest.fn(),
       save: jest.fn(),
       delete: jest.fn(),
       assignSourceToKnowledgeBase: jest.fn(),

--- a/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/create-knowledge-base/create-knowledge-base.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/create-knowledge-base/create-knowledge-base.use-case.spec.ts
@@ -18,6 +18,7 @@ describe('CreateKnowledgeBaseUseCase', () => {
     mockRepository = {
       findById: jest.fn(),
       findAllByUserId: jest.fn(),
+      findByIds: jest.fn(),
       save: jest.fn(),
       delete: jest.fn(),
       assignSourceToKnowledgeBase: jest.fn(),

--- a/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/delete-knowledge-base/delete-knowledge-base.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/delete-knowledge-base/delete-knowledge-base.use-case.spec.ts
@@ -42,6 +42,7 @@ describe('DeleteKnowledgeBaseUseCase', () => {
     mockKbRepository = {
       findById: jest.fn(),
       findAllByUserId: jest.fn(),
+      findByIds: jest.fn(),
       save: jest.fn(),
       delete: jest.fn(),
       assignSourceToKnowledgeBase: jest.fn(),

--- a/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/find-knowledge-base/find-knowledge-base.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/find-knowledge-base/find-knowledge-base.use-case.spec.ts
@@ -22,6 +22,7 @@ describe('FindKnowledgeBaseUseCase', () => {
     mockRepository = {
       findById: jest.fn(),
       findAllByUserId: jest.fn(),
+      findByIds: jest.fn(),
       save: jest.fn(),
       delete: jest.fn(),
       assignSourceToKnowledgeBase: jest.fn(),

--- a/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/list-knowledge-base-documents/list-knowledge-base-documents.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/list-knowledge-base-documents/list-knowledge-base-documents.use-case.spec.ts
@@ -21,6 +21,7 @@ describe('ListKnowledgeBaseDocumentsUseCase', () => {
     mockRepository = {
       findById: jest.fn(),
       findAllByUserId: jest.fn(),
+      findByIds: jest.fn(),
       save: jest.fn(),
       delete: jest.fn(),
       assignSourceToKnowledgeBase: jest.fn(),

--- a/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/list-knowledge-bases/list-knowledge-bases.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/list-knowledge-bases/list-knowledge-bases.use-case.spec.ts
@@ -18,6 +18,7 @@ describe('ListKnowledgeBasesUseCase', () => {
     mockRepository = {
       findById: jest.fn(),
       findAllByUserId: jest.fn(),
+      findByIds: jest.fn(),
       save: jest.fn(),
       delete: jest.fn(),
       assignSourceToKnowledgeBase: jest.fn(),

--- a/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/query-knowledge-base/query-knowledge-base.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/query-knowledge-base/query-knowledge-base.use-case.spec.ts
@@ -32,6 +32,7 @@ describe('QueryKnowledgeBaseUseCase', () => {
     mockKbRepo = {
       findById: jest.fn(),
       findAllByUserId: jest.fn(),
+      findByIds: jest.fn(),
       save: jest.fn(),
       delete: jest.fn(),
       assignSourceToKnowledgeBase: jest.fn(),

--- a/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/remove-document-from-knowledge-base/remove-document-from-knowledge-base.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/remove-document-from-knowledge-base/remove-document-from-knowledge-base.use-case.spec.ts
@@ -34,6 +34,7 @@ describe('RemoveDocumentFromKnowledgeBaseUseCase', () => {
     mockRepository = {
       findById: jest.fn(),
       findAllByUserId: jest.fn(),
+      findByIds: jest.fn(),
       save: jest.fn(),
       delete: jest.fn(),
       assignSourceToKnowledgeBase: jest.fn(),

--- a/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/update-knowledge-base/update-knowledge-base.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/update-knowledge-base/update-knowledge-base.use-case.spec.ts
@@ -31,6 +31,7 @@ describe('UpdateKnowledgeBaseUseCase', () => {
     mockRepository = {
       findById: jest.fn(),
       findAllByUserId: jest.fn(),
+      findByIds: jest.fn(),
       save: jest.fn(),
       delete: jest.fn(),
       assignSourceToKnowledgeBase: jest.fn(),

--- a/ayunis-core-backend/src/domain/knowledge-bases/infrastructure/persistence/local/local-knowledge-base.repository.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/infrastructure/persistence/local/local-knowledge-base.repository.ts
@@ -34,6 +34,17 @@ export class LocalKnowledgeBaseRepository extends KnowledgeBaseRepository {
     return this.mapper.toDomain(record);
   }
 
+  async findByIds(ids: UUID[]): Promise<KnowledgeBase[]> {
+    this.logger.debug(`findByIds: ${ids.length} ids`);
+    if (ids.length === 0) {
+      return [];
+    }
+    const records = await this.repository.find({
+      where: ids.map((id) => ({ id })),
+    });
+    return records.map((record) => this.mapper.toDomain(record));
+  }
+
   async findAllByUserId(userId: UUID): Promise<KnowledgeBase[]> {
     this.logger.debug(`findAllByUserId: ${userId}`);
     const records = await this.repository.find({

--- a/ayunis-core-backend/src/domain/skills/application/skills.errors.ts
+++ b/ayunis-core-backend/src/domain/skills/application/skills.errors.ts
@@ -11,6 +11,10 @@ export enum SkillErrorCode {
   MCP_INTEGRATION_DISABLED = 'MCP_INTEGRATION_DISABLED',
   MCP_INTEGRATION_WRONG_ORGANIZATION = 'MCP_INTEGRATION_WRONG_ORGANIZATION',
   MCP_INTEGRATION_NOT_ASSIGNED = 'MCP_INTEGRATION_NOT_ASSIGNED',
+  KNOWLEDGE_BASE_NOT_FOUND = 'KNOWLEDGE_BASE_NOT_FOUND',
+  KNOWLEDGE_BASE_ALREADY_ASSIGNED = 'KNOWLEDGE_BASE_ALREADY_ASSIGNED',
+  KNOWLEDGE_BASE_WRONG_ORGANIZATION = 'KNOWLEDGE_BASE_WRONG_ORGANIZATION',
+  KNOWLEDGE_BASE_NOT_ASSIGNED = 'KNOWLEDGE_BASE_NOT_ASSIGNED',
   MISSING_FILE = 'MISSING_FILE',
   UNSUPPORTED_FILE_TYPE = 'UNSUPPORTED_FILE_TYPE',
   EMPTY_FILE_DATA = 'EMPTY_FILE_DATA',
@@ -123,6 +127,50 @@ export class SkillMcpIntegrationNotAssignedError extends SkillError {
     super(
       `MCP integration with ID ${integrationId} is not assigned to this skill`,
       SkillErrorCode.MCP_INTEGRATION_NOT_ASSIGNED,
+      404,
+      metadata,
+    );
+  }
+}
+
+export class SkillKnowledgeBaseNotFoundError extends SkillError {
+  constructor(knowledgeBaseId: string, metadata?: ErrorMetadata) {
+    super(
+      `Knowledge base with ID ${knowledgeBaseId} not found`,
+      SkillErrorCode.KNOWLEDGE_BASE_NOT_FOUND,
+      404,
+      metadata,
+    );
+  }
+}
+
+export class SkillKnowledgeBaseAlreadyAssignedError extends SkillError {
+  constructor(knowledgeBaseId: string, metadata?: ErrorMetadata) {
+    super(
+      `Knowledge base with ID ${knowledgeBaseId} is already assigned to this skill`,
+      SkillErrorCode.KNOWLEDGE_BASE_ALREADY_ASSIGNED,
+      409,
+      metadata,
+    );
+  }
+}
+
+export class SkillKnowledgeBaseWrongOrganizationError extends SkillError {
+  constructor(knowledgeBaseId: string, metadata?: ErrorMetadata) {
+    super(
+      `Knowledge base with ID ${knowledgeBaseId} does not belong to your organization`,
+      SkillErrorCode.KNOWLEDGE_BASE_WRONG_ORGANIZATION,
+      403,
+      metadata,
+    );
+  }
+}
+
+export class SkillKnowledgeBaseNotAssignedError extends SkillError {
+  constructor(knowledgeBaseId: string, metadata?: ErrorMetadata) {
+    super(
+      `Knowledge base with ID ${knowledgeBaseId} is not assigned to this skill`,
+      SkillErrorCode.KNOWLEDGE_BASE_NOT_ASSIGNED,
       404,
       metadata,
     );

--- a/ayunis-core-backend/src/domain/skills/application/use-cases/assign-knowledge-base-to-skill/assign-knowledge-base-to-skill.command.ts
+++ b/ayunis-core-backend/src/domain/skills/application/use-cases/assign-knowledge-base-to-skill/assign-knowledge-base-to-skill.command.ts
@@ -1,0 +1,8 @@
+import type { UUID } from 'crypto';
+
+export class AssignKnowledgeBaseToSkillCommand {
+  constructor(
+    public readonly skillId: UUID,
+    public readonly knowledgeBaseId: UUID,
+  ) {}
+}

--- a/ayunis-core-backend/src/domain/skills/application/use-cases/assign-knowledge-base-to-skill/assign-knowledge-base-to-skill.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/skills/application/use-cases/assign-knowledge-base-to-skill/assign-knowledge-base-to-skill.use-case.spec.ts
@@ -1,0 +1,223 @@
+import type { TestingModule } from '@nestjs/testing';
+import { Test } from '@nestjs/testing';
+
+jest.mock('@nestjs-cls/transactional', () => ({
+  Transactional:
+    () => (_target: unknown, _key: string, descriptor: PropertyDescriptor) =>
+      descriptor,
+}));
+
+import { Logger } from '@nestjs/common';
+import { AssignKnowledgeBaseToSkillUseCase } from './assign-knowledge-base-to-skill.use-case';
+import { AssignKnowledgeBaseToSkillCommand } from './assign-knowledge-base-to-skill.command';
+import { SkillRepository } from '../../ports/skill.repository';
+import { KnowledgeBaseRepository } from 'src/domain/knowledge-bases/application/ports/knowledge-base.repository';
+import { ContextService } from 'src/common/context/services/context.service';
+import { Skill } from '../../../domain/skill.entity';
+import { KnowledgeBase } from 'src/domain/knowledge-bases/domain/knowledge-base.entity';
+import {
+  SkillNotFoundError,
+  SkillKnowledgeBaseNotFoundError,
+  SkillKnowledgeBaseAlreadyAssignedError,
+  SkillKnowledgeBaseWrongOrganizationError,
+  UnexpectedSkillError,
+} from '../../skills.errors';
+import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
+import type { UUID } from 'crypto';
+
+describe('AssignKnowledgeBaseToSkillUseCase', () => {
+  let useCase: AssignKnowledgeBaseToSkillUseCase;
+  let skillRepository: jest.Mocked<SkillRepository>;
+  let knowledgeBaseRepository: jest.Mocked<KnowledgeBaseRepository>;
+  let contextService: jest.Mocked<ContextService>;
+
+  const mockUserId = '123e4567-e89b-12d3-a456-426614174000' as UUID;
+  const mockOrgId = '123e4567-e89b-12d3-a456-426614174003' as UUID;
+  const mockSkillId = '123e4567-e89b-12d3-a456-426614174001' as UUID;
+  const mockKbId = '123e4567-e89b-12d3-a456-426614174010' as UUID;
+
+  beforeEach(async () => {
+    const mockSkillRepository = {
+      findOne: jest.fn(),
+      update: jest.fn(),
+    };
+
+    const mockKnowledgeBaseRepository = {
+      findById: jest.fn(),
+    };
+
+    const mockContextService = {
+      get: jest.fn((key: string) => {
+        if (key === 'userId') return mockUserId;
+        if (key === 'orgId') return mockOrgId;
+        return undefined;
+      }),
+    } as unknown as jest.Mocked<ContextService>;
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AssignKnowledgeBaseToSkillUseCase,
+        { provide: SkillRepository, useValue: mockSkillRepository },
+        {
+          provide: KnowledgeBaseRepository,
+          useValue: mockKnowledgeBaseRepository,
+        },
+        { provide: ContextService, useValue: mockContextService },
+      ],
+    }).compile();
+
+    useCase = module.get(AssignKnowledgeBaseToSkillUseCase);
+    skillRepository = module.get(SkillRepository);
+    knowledgeBaseRepository = module.get(KnowledgeBaseRepository);
+    contextService = module.get(ContextService);
+
+    jest.spyOn(Logger.prototype, 'log').mockImplementation();
+    jest.spyOn(Logger.prototype, 'error').mockImplementation();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const createMockSkill = (knowledgeBaseIds: UUID[] = []): Skill =>
+    new Skill({
+      id: mockSkillId,
+      name: 'Test Skill',
+      shortDescription: 'A test skill',
+      instructions: 'Test instructions',
+      knowledgeBaseIds,
+      userId: mockUserId,
+    });
+
+  const createMockKnowledgeBase = (
+    id: UUID = mockKbId,
+    orgId: UUID = mockOrgId,
+  ): KnowledgeBase =>
+    new KnowledgeBase({
+      id,
+      name: 'Test KB',
+      description: 'A test knowledge base',
+      orgId,
+      userId: mockUserId,
+    });
+
+  it('should assign a knowledge base to the skill', async () => {
+    const command = new AssignKnowledgeBaseToSkillCommand(
+      mockSkillId,
+      mockKbId,
+    );
+    const skill = createMockSkill();
+    const kb = createMockKnowledgeBase();
+
+    skillRepository.findOne.mockResolvedValue(skill);
+    knowledgeBaseRepository.findById.mockResolvedValue(kb);
+    skillRepository.update.mockImplementation(async (s: Skill) => s);
+
+    const result = await useCase.execute(command);
+
+    expect(result.knowledgeBaseIds).toContain(mockKbId);
+    expect(skillRepository.update).toHaveBeenCalled();
+  });
+
+  it('should throw UnauthorizedAccessError when user not authenticated', async () => {
+    contextService.get.mockReturnValue(null);
+    const command = new AssignKnowledgeBaseToSkillCommand(
+      mockSkillId,
+      mockKbId,
+    );
+
+    await expect(useCase.execute(command)).rejects.toThrow(
+      UnauthorizedAccessError,
+    );
+  });
+
+  it('should throw UnauthorizedAccessError when orgId is missing', async () => {
+    contextService.get.mockImplementation((key?: string | symbol) => {
+      if (key === 'userId') return mockUserId;
+      return null;
+    });
+    const command = new AssignKnowledgeBaseToSkillCommand(
+      mockSkillId,
+      mockKbId,
+    );
+
+    await expect(useCase.execute(command)).rejects.toThrow(
+      UnauthorizedAccessError,
+    );
+  });
+
+  it('should throw SkillNotFoundError when skill does not exist', async () => {
+    skillRepository.findOne.mockResolvedValue(null);
+    const command = new AssignKnowledgeBaseToSkillCommand(
+      mockSkillId,
+      mockKbId,
+    );
+
+    await expect(useCase.execute(command)).rejects.toThrow(SkillNotFoundError);
+  });
+
+  it('should throw SkillKnowledgeBaseNotFoundError when KB does not exist', async () => {
+    const skill = createMockSkill();
+    skillRepository.findOne.mockResolvedValue(skill);
+    knowledgeBaseRepository.findById.mockResolvedValue(null);
+
+    const command = new AssignKnowledgeBaseToSkillCommand(
+      mockSkillId,
+      mockKbId,
+    );
+
+    await expect(useCase.execute(command)).rejects.toThrow(
+      SkillKnowledgeBaseNotFoundError,
+    );
+  });
+
+  it('should throw SkillKnowledgeBaseWrongOrganizationError when KB belongs to different org', async () => {
+    const skill = createMockSkill();
+    const otherOrgId = '123e4567-e89b-12d3-a456-426614174099' as UUID;
+    const kb = createMockKnowledgeBase(mockKbId, otherOrgId);
+
+    skillRepository.findOne.mockResolvedValue(skill);
+    knowledgeBaseRepository.findById.mockResolvedValue(kb);
+
+    const command = new AssignKnowledgeBaseToSkillCommand(
+      mockSkillId,
+      mockKbId,
+    );
+
+    await expect(useCase.execute(command)).rejects.toThrow(
+      SkillKnowledgeBaseWrongOrganizationError,
+    );
+  });
+
+  it('should throw SkillKnowledgeBaseAlreadyAssignedError when KB is already assigned', async () => {
+    const skill = createMockSkill([mockKbId]);
+    const kb = createMockKnowledgeBase();
+
+    skillRepository.findOne.mockResolvedValue(skill);
+    knowledgeBaseRepository.findById.mockResolvedValue(kb);
+
+    const command = new AssignKnowledgeBaseToSkillCommand(
+      mockSkillId,
+      mockKbId,
+    );
+
+    await expect(useCase.execute(command)).rejects.toThrow(
+      SkillKnowledgeBaseAlreadyAssignedError,
+    );
+  });
+
+  it('should wrap unexpected errors in UnexpectedSkillError', async () => {
+    skillRepository.findOne.mockRejectedValue(
+      new Error('Database connection failed'),
+    );
+
+    const command = new AssignKnowledgeBaseToSkillCommand(
+      mockSkillId,
+      mockKbId,
+    );
+
+    await expect(useCase.execute(command)).rejects.toThrow(
+      UnexpectedSkillError,
+    );
+  });
+});

--- a/ayunis-core-backend/src/domain/skills/application/use-cases/assign-knowledge-base-to-skill/assign-knowledge-base-to-skill.use-case.ts
+++ b/ayunis-core-backend/src/domain/skills/application/use-cases/assign-knowledge-base-to-skill/assign-knowledge-base-to-skill.use-case.ts
@@ -1,0 +1,82 @@
+import { Inject, Injectable, Logger } from '@nestjs/common';
+import { Transactional } from '@nestjs-cls/transactional';
+import { AssignKnowledgeBaseToSkillCommand } from './assign-knowledge-base-to-skill.command';
+import { SkillRepository } from '../../ports/skill.repository';
+import { KnowledgeBaseRepository } from 'src/domain/knowledge-bases/application/ports/knowledge-base.repository';
+import { ContextService } from 'src/common/context/services/context.service';
+import { Skill } from '../../../domain/skill.entity';
+import {
+  SkillNotFoundError,
+  SkillKnowledgeBaseNotFoundError,
+  SkillKnowledgeBaseAlreadyAssignedError,
+  SkillKnowledgeBaseWrongOrganizationError,
+  UnexpectedSkillError,
+} from '../../skills.errors';
+import { ApplicationError } from 'src/common/errors/base.error';
+import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
+
+@Injectable()
+export class AssignKnowledgeBaseToSkillUseCase {
+  private readonly logger = new Logger(AssignKnowledgeBaseToSkillUseCase.name);
+
+  constructor(
+    @Inject(SkillRepository)
+    private readonly skillRepository: SkillRepository,
+    @Inject(KnowledgeBaseRepository)
+    private readonly knowledgeBaseRepository: KnowledgeBaseRepository,
+    private readonly contextService: ContextService,
+  ) {}
+
+  @Transactional()
+  async execute(command: AssignKnowledgeBaseToSkillCommand): Promise<Skill> {
+    this.logger.log('Assigning knowledge base to skill', {
+      skillId: command.skillId,
+      knowledgeBaseId: command.knowledgeBaseId,
+    });
+
+    try {
+      const userId = this.contextService.get('userId');
+      const orgId = this.contextService.get('orgId');
+      if (!userId || !orgId) {
+        throw new UnauthorizedAccessError();
+      }
+
+      const skill = await this.skillRepository.findOne(command.skillId, userId);
+      if (!skill) {
+        throw new SkillNotFoundError(command.skillId);
+      }
+
+      const knowledgeBase = await this.knowledgeBaseRepository.findById(
+        command.knowledgeBaseId,
+      );
+      if (!knowledgeBase) {
+        throw new SkillKnowledgeBaseNotFoundError(command.knowledgeBaseId);
+      }
+
+      if (knowledgeBase.orgId !== orgId) {
+        throw new SkillKnowledgeBaseWrongOrganizationError(
+          command.knowledgeBaseId,
+        );
+      }
+
+      if (skill.knowledgeBaseIds.includes(command.knowledgeBaseId)) {
+        throw new SkillKnowledgeBaseAlreadyAssignedError(
+          command.knowledgeBaseId,
+        );
+      }
+
+      const updatedSkill = new Skill({
+        ...skill,
+        knowledgeBaseIds: [...skill.knowledgeBaseIds, command.knowledgeBaseId],
+      });
+
+      return await this.skillRepository.update(updatedSkill);
+    } catch (error) {
+      if (error instanceof ApplicationError) throw error;
+      this.logger.error('Unexpected error assigning knowledge base', {
+        error: error as Error,
+      });
+      throw new UnexpectedSkillError(error);
+    }
+  }
+}

--- a/ayunis-core-backend/src/domain/skills/application/use-cases/list-skill-knowledge-bases/list-skill-knowledge-bases.query.ts
+++ b/ayunis-core-backend/src/domain/skills/application/use-cases/list-skill-knowledge-bases/list-skill-knowledge-bases.query.ts
@@ -1,0 +1,5 @@
+import type { UUID } from 'crypto';
+
+export class ListSkillKnowledgeBasesQuery {
+  constructor(public readonly skillId: UUID) {}
+}

--- a/ayunis-core-backend/src/domain/skills/application/use-cases/list-skill-knowledge-bases/list-skill-knowledge-bases.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/skills/application/use-cases/list-skill-knowledge-bases/list-skill-knowledge-bases.use-case.spec.ts
@@ -1,0 +1,193 @@
+import type { TestingModule } from '@nestjs/testing';
+import { Test } from '@nestjs/testing';
+import { Logger } from '@nestjs/common';
+import { ListSkillKnowledgeBasesUseCase } from './list-skill-knowledge-bases.use-case';
+import { ListSkillKnowledgeBasesQuery } from './list-skill-knowledge-bases.query';
+import { KnowledgeBaseRepository } from 'src/domain/knowledge-bases/application/ports/knowledge-base.repository';
+import { ContextService } from 'src/common/context/services/context.service';
+import { SkillAccessService } from '../../services/skill-access.service';
+import { Skill } from '../../../domain/skill.entity';
+import { KnowledgeBase } from 'src/domain/knowledge-bases/domain/knowledge-base.entity';
+import { SkillNotFoundError, UnexpectedSkillError } from '../../skills.errors';
+import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
+import type { UUID } from 'crypto';
+
+describe('ListSkillKnowledgeBasesUseCase', () => {
+  let useCase: ListSkillKnowledgeBasesUseCase;
+  let knowledgeBaseRepository: jest.Mocked<KnowledgeBaseRepository>;
+  let contextService: jest.Mocked<ContextService>;
+  let skillAccessService: jest.Mocked<SkillAccessService>;
+
+  const mockUserId = '123e4567-e89b-12d3-a456-426614174000' as UUID;
+  const mockOrgId = '123e4567-e89b-12d3-a456-426614174003' as UUID;
+  const mockSkillId = '123e4567-e89b-12d3-a456-426614174001' as UUID;
+  const mockKbId1 = '123e4567-e89b-12d3-a456-426614174010' as UUID;
+  const mockKbId2 = '123e4567-e89b-12d3-a456-426614174011' as UUID;
+
+  beforeEach(async () => {
+    const mockKnowledgeBaseRepository = {
+      findById: jest.fn(),
+      findByIds: jest.fn(),
+      findAllByUserId: jest.fn(),
+      save: jest.fn(),
+      delete: jest.fn(),
+      assignSourceToKnowledgeBase: jest.fn(),
+      findSourcesByKnowledgeBaseId: jest.fn(),
+      findSourceByIdAndKnowledgeBaseId: jest.fn(),
+    } as jest.Mocked<KnowledgeBaseRepository>;
+
+    const mockContextService = {
+      get: jest.fn((key: string) => {
+        if (key === 'userId') return mockUserId;
+        if (key === 'orgId') return mockOrgId;
+        return undefined;
+      }),
+    } as unknown as jest.Mocked<ContextService>;
+
+    const mockSkillAccessService = {
+      findAccessibleSkill: jest.fn(),
+    } as unknown as jest.Mocked<SkillAccessService>;
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ListSkillKnowledgeBasesUseCase,
+        {
+          provide: KnowledgeBaseRepository,
+          useValue: mockKnowledgeBaseRepository,
+        },
+        { provide: ContextService, useValue: mockContextService },
+        { provide: SkillAccessService, useValue: mockSkillAccessService },
+      ],
+    }).compile();
+
+    useCase = module.get(ListSkillKnowledgeBasesUseCase);
+    knowledgeBaseRepository = module.get(KnowledgeBaseRepository);
+    contextService = module.get(ContextService);
+    skillAccessService = module.get(SkillAccessService);
+
+    jest.spyOn(Logger.prototype, 'log').mockImplementation();
+    jest.spyOn(Logger.prototype, 'error').mockImplementation();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const createMockSkill = (knowledgeBaseIds: UUID[] = []): Skill =>
+    new Skill({
+      id: mockSkillId,
+      name: 'Test Skill',
+      shortDescription: 'A test skill',
+      instructions: 'Test instructions',
+      knowledgeBaseIds,
+      userId: mockUserId,
+    });
+
+  const createMockKnowledgeBase = (
+    id: UUID,
+    name: string,
+    orgId: UUID = mockOrgId,
+  ): KnowledgeBase =>
+    new KnowledgeBase({
+      id,
+      name,
+      description: `Description for ${name}`,
+      orgId,
+      userId: mockUserId,
+    });
+
+  describe('execute', () => {
+    it('should return knowledge bases for an accessible skill', async () => {
+      const query = new ListSkillKnowledgeBasesQuery(mockSkillId);
+      const skill = createMockSkill([mockKbId1, mockKbId2]);
+      const kb1 = createMockKnowledgeBase(mockKbId1, 'Legal KB');
+      const kb2 = createMockKnowledgeBase(mockKbId2, 'HR KB');
+
+      skillAccessService.findAccessibleSkill.mockResolvedValue(skill);
+      knowledgeBaseRepository.findByIds.mockResolvedValue([kb1, kb2]);
+
+      const result = await useCase.execute(query);
+
+      expect(skillAccessService.findAccessibleSkill).toHaveBeenCalledWith(
+        mockSkillId,
+      );
+      expect(knowledgeBaseRepository.findByIds).toHaveBeenCalledWith([
+        mockKbId1,
+        mockKbId2,
+      ]);
+      expect(result).toHaveLength(2);
+      expect(result[0]).toBe(kb1);
+      expect(result[1]).toBe(kb2);
+    });
+
+    it('should filter out knowledge bases from other organizations', async () => {
+      const query = new ListSkillKnowledgeBasesQuery(mockSkillId);
+      const otherOrgId = '123e4567-e89b-12d3-a456-426614174099' as UUID;
+      const skill = createMockSkill([mockKbId1, mockKbId2]);
+      const kb1 = createMockKnowledgeBase(mockKbId1, 'Own Org KB', mockOrgId);
+      const kb2 = createMockKnowledgeBase(
+        mockKbId2,
+        'Other Org KB',
+        otherOrgId,
+      );
+
+      skillAccessService.findAccessibleSkill.mockResolvedValue(skill);
+      knowledgeBaseRepository.findByIds.mockResolvedValue([kb1, kb2]);
+
+      const result = await useCase.execute(query);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toBe(kb1);
+    });
+
+    it('should return empty array when skill has no knowledge bases', async () => {
+      const query = new ListSkillKnowledgeBasesQuery(mockSkillId);
+      const skill = createMockSkill([]);
+
+      skillAccessService.findAccessibleSkill.mockResolvedValue(skill);
+
+      const result = await useCase.execute(query);
+
+      expect(knowledgeBaseRepository.findByIds).not.toHaveBeenCalled();
+      expect(result).toEqual([]);
+    });
+
+    it('should throw UnauthorizedAccessError when orgId is missing', async () => {
+      const query = new ListSkillKnowledgeBasesQuery(mockSkillId);
+      contextService.get.mockReturnValue(null);
+
+      await expect(useCase.execute(query)).rejects.toThrow(
+        UnauthorizedAccessError,
+      );
+      expect(skillAccessService.findAccessibleSkill).not.toHaveBeenCalled();
+    });
+
+    it('should throw SkillNotFoundError when skill is not accessible', async () => {
+      const query = new ListSkillKnowledgeBasesQuery(mockSkillId);
+      skillAccessService.findAccessibleSkill.mockRejectedValue(
+        new SkillNotFoundError(mockSkillId),
+      );
+
+      await expect(useCase.execute(query)).rejects.toThrow(SkillNotFoundError);
+    });
+
+    it('should wrap unexpected errors in UnexpectedSkillError', async () => {
+      const query = new ListSkillKnowledgeBasesQuery(mockSkillId);
+      skillAccessService.findAccessibleSkill.mockRejectedValue(
+        new Error('Database connection failed'),
+      );
+
+      await expect(useCase.execute(query)).rejects.toThrow(
+        UnexpectedSkillError,
+      );
+    });
+
+    it('should rethrow ApplicationError without wrapping', async () => {
+      const query = new ListSkillKnowledgeBasesQuery(mockSkillId);
+      const appError = new SkillNotFoundError(mockSkillId);
+      skillAccessService.findAccessibleSkill.mockRejectedValue(appError);
+
+      await expect(useCase.execute(query)).rejects.toThrow(appError);
+    });
+  });
+});

--- a/ayunis-core-backend/src/domain/skills/application/use-cases/list-skill-knowledge-bases/list-skill-knowledge-bases.use-case.ts
+++ b/ayunis-core-backend/src/domain/skills/application/use-cases/list-skill-knowledge-bases/list-skill-knowledge-bases.use-case.ts
@@ -1,0 +1,56 @@
+import { Inject, Injectable, Logger } from '@nestjs/common';
+import { ListSkillKnowledgeBasesQuery } from './list-skill-knowledge-bases.query';
+import { KnowledgeBase } from 'src/domain/knowledge-bases/domain/knowledge-base.entity';
+import { KnowledgeBaseRepository } from 'src/domain/knowledge-bases/application/ports/knowledge-base.repository';
+import { UnexpectedSkillError } from '../../skills.errors';
+import { ApplicationError } from 'src/common/errors/base.error';
+import { SkillAccessService } from '../../services/skill-access.service';
+import { ContextService } from 'src/common/context/services/context.service';
+import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
+
+@Injectable()
+export class ListSkillKnowledgeBasesUseCase {
+  private readonly logger = new Logger(ListSkillKnowledgeBasesUseCase.name);
+
+  constructor(
+    @Inject(KnowledgeBaseRepository)
+    private readonly knowledgeBaseRepository: KnowledgeBaseRepository,
+    private readonly skillAccessService: SkillAccessService,
+    private readonly contextService: ContextService,
+  ) {}
+
+  async execute(query: ListSkillKnowledgeBasesQuery): Promise<KnowledgeBase[]> {
+    this.logger.log('Listing knowledge bases for skill', {
+      skillId: query.skillId,
+    });
+
+    try {
+      const orgId = this.contextService.get('orgId');
+      if (!orgId) {
+        throw new UnauthorizedAccessError();
+      }
+
+      const skill = await this.skillAccessService.findAccessibleSkill(
+        query.skillId,
+      );
+
+      if (skill.knowledgeBaseIds.length === 0) {
+        return [];
+      }
+
+      const knowledgeBases = await this.knowledgeBaseRepository.findByIds(
+        skill.knowledgeBaseIds,
+      );
+
+      return knowledgeBases.filter((kb) => kb.orgId === orgId);
+    } catch (error) {
+      if (error instanceof ApplicationError) {
+        throw error;
+      }
+      this.logger.error('Unexpected error listing skill knowledge bases', {
+        error: error as Error,
+      });
+      throw new UnexpectedSkillError(error);
+    }
+  }
+}

--- a/ayunis-core-backend/src/domain/skills/application/use-cases/unassign-knowledge-base-from-skill/unassign-knowledge-base-from-skill.command.ts
+++ b/ayunis-core-backend/src/domain/skills/application/use-cases/unassign-knowledge-base-from-skill/unassign-knowledge-base-from-skill.command.ts
@@ -1,0 +1,8 @@
+import type { UUID } from 'crypto';
+
+export class UnassignKnowledgeBaseFromSkillCommand {
+  constructor(
+    public readonly skillId: UUID,
+    public readonly knowledgeBaseId: UUID,
+  ) {}
+}

--- a/ayunis-core-backend/src/domain/skills/application/use-cases/unassign-knowledge-base-from-skill/unassign-knowledge-base-from-skill.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/skills/application/use-cases/unassign-knowledge-base-from-skill/unassign-knowledge-base-from-skill.use-case.spec.ts
@@ -1,0 +1,159 @@
+import type { TestingModule } from '@nestjs/testing';
+import { Test } from '@nestjs/testing';
+
+jest.mock('@nestjs-cls/transactional', () => ({
+  Transactional:
+    () => (_target: unknown, _key: string, descriptor: PropertyDescriptor) =>
+      descriptor,
+}));
+
+import { Logger } from '@nestjs/common';
+import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
+import { UnassignKnowledgeBaseFromSkillUseCase } from './unassign-knowledge-base-from-skill.use-case';
+import { UnassignKnowledgeBaseFromSkillCommand } from './unassign-knowledge-base-from-skill.command';
+import { SkillRepository } from '../../ports/skill.repository';
+import { ContextService } from 'src/common/context/services/context.service';
+import { Skill } from '../../../domain/skill.entity';
+import {
+  SkillNotFoundError,
+  SkillKnowledgeBaseNotAssignedError,
+  UnexpectedSkillError,
+} from '../../skills.errors';
+import type { UUID } from 'crypto';
+
+describe('UnassignKnowledgeBaseFromSkillUseCase', () => {
+  let useCase: UnassignKnowledgeBaseFromSkillUseCase;
+  let skillRepository: jest.Mocked<SkillRepository>;
+  let contextService: jest.Mocked<ContextService>;
+
+  const mockUserId = '123e4567-e89b-12d3-a456-426614174000' as UUID;
+  const mockSkillId = '123e4567-e89b-12d3-a456-426614174001' as UUID;
+  const mockKbId = '123e4567-e89b-12d3-a456-426614174010' as UUID;
+
+  beforeEach(async () => {
+    const mockSkillRepository = {
+      findOne: jest.fn(),
+      update: jest.fn(),
+    };
+
+    const mockContextService = {
+      get: jest.fn((key: string) => {
+        if (key === 'userId') return mockUserId;
+        return undefined;
+      }),
+    } as unknown as jest.Mocked<ContextService>;
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        UnassignKnowledgeBaseFromSkillUseCase,
+        { provide: SkillRepository, useValue: mockSkillRepository },
+        { provide: ContextService, useValue: mockContextService },
+      ],
+    }).compile();
+
+    useCase = module.get(UnassignKnowledgeBaseFromSkillUseCase);
+    skillRepository = module.get(SkillRepository);
+    contextService = module.get(ContextService);
+
+    jest.spyOn(Logger.prototype, 'log').mockImplementation();
+    jest.spyOn(Logger.prototype, 'error').mockImplementation();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const createMockSkill = (knowledgeBaseIds: UUID[] = []): Skill =>
+    new Skill({
+      id: mockSkillId,
+      name: 'Test Skill',
+      shortDescription: 'A test skill',
+      instructions: 'Test instructions',
+      knowledgeBaseIds,
+      userId: mockUserId,
+    });
+
+  it('should unassign a knowledge base from the skill', async () => {
+    const skill = createMockSkill([mockKbId]);
+    const command = new UnassignKnowledgeBaseFromSkillCommand(
+      mockSkillId,
+      mockKbId,
+    );
+
+    skillRepository.findOne.mockResolvedValue(skill);
+    skillRepository.update.mockImplementation(async (s: Skill) => s);
+
+    const result = await useCase.execute(command);
+
+    expect(result.knowledgeBaseIds).not.toContain(mockKbId);
+    expect(result.knowledgeBaseIds).toHaveLength(0);
+    expect(skillRepository.update).toHaveBeenCalled();
+  });
+
+  it('should only remove the specified knowledge base', async () => {
+    const otherKbId = '123e4567-e89b-12d3-a456-426614174011' as UUID;
+    const skill = createMockSkill([mockKbId, otherKbId]);
+    const command = new UnassignKnowledgeBaseFromSkillCommand(
+      mockSkillId,
+      mockKbId,
+    );
+
+    skillRepository.findOne.mockResolvedValue(skill);
+    skillRepository.update.mockImplementation(async (s: Skill) => s);
+
+    const result = await useCase.execute(command);
+
+    expect(result.knowledgeBaseIds).toEqual([otherKbId]);
+  });
+
+  it('should throw UnauthorizedAccessError when user not authenticated', async () => {
+    contextService.get.mockReturnValue(null);
+    const command = new UnassignKnowledgeBaseFromSkillCommand(
+      mockSkillId,
+      mockKbId,
+    );
+
+    await expect(useCase.execute(command)).rejects.toThrow(
+      UnauthorizedAccessError,
+    );
+  });
+
+  it('should throw SkillNotFoundError when skill does not exist', async () => {
+    skillRepository.findOne.mockResolvedValue(null);
+    const command = new UnassignKnowledgeBaseFromSkillCommand(
+      mockSkillId,
+      mockKbId,
+    );
+
+    await expect(useCase.execute(command)).rejects.toThrow(SkillNotFoundError);
+  });
+
+  it('should throw SkillKnowledgeBaseNotAssignedError when KB is not assigned', async () => {
+    const skill = createMockSkill([]);
+    skillRepository.findOne.mockResolvedValue(skill);
+
+    const command = new UnassignKnowledgeBaseFromSkillCommand(
+      mockSkillId,
+      mockKbId,
+    );
+
+    await expect(useCase.execute(command)).rejects.toThrow(
+      SkillKnowledgeBaseNotAssignedError,
+    );
+  });
+
+  it('should wrap unexpected errors in UnexpectedSkillError', async () => {
+    skillRepository.findOne.mockRejectedValue(
+      new Error('Database connection failed'),
+    );
+
+    const command = new UnassignKnowledgeBaseFromSkillCommand(
+      mockSkillId,
+      mockKbId,
+    );
+
+    await expect(useCase.execute(command)).rejects.toThrow(
+      UnexpectedSkillError,
+    );
+  });
+});

--- a/ayunis-core-backend/src/domain/skills/application/use-cases/unassign-knowledge-base-from-skill/unassign-knowledge-base-from-skill.use-case.ts
+++ b/ayunis-core-backend/src/domain/skills/application/use-cases/unassign-knowledge-base-from-skill/unassign-knowledge-base-from-skill.use-case.ts
@@ -1,0 +1,69 @@
+import { Inject, Injectable, Logger } from '@nestjs/common';
+import { Transactional } from '@nestjs-cls/transactional';
+import { SkillRepository } from '../../ports/skill.repository';
+import { ContextService } from 'src/common/context/services/context.service';
+import { UnassignKnowledgeBaseFromSkillCommand } from './unassign-knowledge-base-from-skill.command';
+import { Skill } from '../../../domain/skill.entity';
+import {
+  SkillNotFoundError,
+  SkillKnowledgeBaseNotAssignedError,
+  UnexpectedSkillError,
+} from '../../skills.errors';
+import { ApplicationError } from 'src/common/errors/base.error';
+import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
+
+@Injectable()
+export class UnassignKnowledgeBaseFromSkillUseCase {
+  private readonly logger = new Logger(
+    UnassignKnowledgeBaseFromSkillUseCase.name,
+  );
+
+  constructor(
+    @Inject(SkillRepository)
+    private readonly skillRepository: SkillRepository,
+    private readonly contextService: ContextService,
+  ) {}
+
+  @Transactional()
+  async execute(
+    command: UnassignKnowledgeBaseFromSkillCommand,
+  ): Promise<Skill> {
+    this.logger.log('Unassigning knowledge base from skill', {
+      skillId: command.skillId,
+      knowledgeBaseId: command.knowledgeBaseId,
+    });
+
+    try {
+      const userId = this.contextService.get('userId');
+      if (!userId) {
+        throw new UnauthorizedAccessError();
+      }
+
+      const skill = await this.skillRepository.findOne(command.skillId, userId);
+      if (!skill) {
+        throw new SkillNotFoundError(command.skillId);
+      }
+
+      if (!skill.knowledgeBaseIds.includes(command.knowledgeBaseId)) {
+        throw new SkillKnowledgeBaseNotAssignedError(command.knowledgeBaseId);
+      }
+
+      const updatedSkill = new Skill({
+        ...skill,
+        knowledgeBaseIds: skill.knowledgeBaseIds.filter(
+          (id) => id !== command.knowledgeBaseId,
+        ),
+      });
+
+      return await this.skillRepository.update(updatedSkill);
+    } catch (error) {
+      if (error instanceof ApplicationError) {
+        throw error;
+      }
+      this.logger.error('Unexpected error unassigning knowledge base', {
+        error: error as Error,
+      });
+      throw new UnexpectedSkillError(error);
+    }
+  }
+}

--- a/ayunis-core-backend/src/domain/skills/application/use-cases/update-skill/update-skill.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/skills/application/use-cases/update-skill/update-skill.use-case.spec.ts
@@ -158,6 +158,32 @@ describe('UpdateSkillUseCase', () => {
     expect(skillRepository.findByNameAndOwner).not.toHaveBeenCalled();
   });
 
+  it('should preserve knowledgeBaseIds on update', async () => {
+    const kbIds = ['bbb00000-0000-0000-0000-000000000000' as UUID];
+    const existingSkill = new Skill({
+      id: mockSkillId,
+      name: 'Legal Research',
+      shortDescription: 'Research legal topics.',
+      instructions: 'Original instructions.',
+      userId: mockUserId,
+      knowledgeBaseIds: kbIds,
+    });
+
+    const command = new UpdateSkillCommand({
+      skillId: mockSkillId,
+      name: 'Legal Research',
+      shortDescription: 'Updated.',
+      instructions: 'Updated.',
+    });
+
+    skillRepository.findOne.mockResolvedValue(existingSkill);
+    skillRepository.update.mockImplementation(async (skill: Skill) => skill);
+
+    const result = await useCase.execute(command);
+
+    expect(result.knowledgeBaseIds).toEqual(kbIds);
+  });
+
   it('should preserve mcpIntegrationIds on update', async () => {
     const mcpIds = ['aaa00000-0000-0000-0000-000000000000' as UUID];
     const existingSkill = new Skill({

--- a/ayunis-core-backend/src/domain/skills/presenters/http/skill-knowledge-bases.controller.ts
+++ b/ayunis-core-backend/src/domain/skills/presenters/http/skill-knowledge-bases.controller.ts
@@ -1,0 +1,150 @@
+import {
+  Controller,
+  Post,
+  Get,
+  Delete,
+  Param,
+  ParseUUIDPipe,
+  Logger,
+  HttpCode,
+  HttpStatus,
+} from '@nestjs/common';
+import { UUID } from 'crypto';
+import { ApiTags, ApiOperation, ApiResponse, ApiParam } from '@nestjs/swagger';
+import { AssignKnowledgeBaseToSkillUseCase } from '../../application/use-cases/assign-knowledge-base-to-skill/assign-knowledge-base-to-skill.use-case';
+import { UnassignKnowledgeBaseFromSkillUseCase } from '../../application/use-cases/unassign-knowledge-base-from-skill/unassign-knowledge-base-from-skill.use-case';
+import { ListSkillKnowledgeBasesUseCase } from '../../application/use-cases/list-skill-knowledge-bases/list-skill-knowledge-bases.use-case';
+
+import { AssignKnowledgeBaseToSkillCommand } from '../../application/use-cases/assign-knowledge-base-to-skill/assign-knowledge-base-to-skill.command';
+import { UnassignKnowledgeBaseFromSkillCommand } from '../../application/use-cases/unassign-knowledge-base-from-skill/unassign-knowledge-base-from-skill.command';
+import { ListSkillKnowledgeBasesQuery } from '../../application/use-cases/list-skill-knowledge-bases/list-skill-knowledge-bases.query';
+
+import { SkillAccessService } from '../../application/services/skill-access.service';
+
+import { SkillResponseDto } from './dto/skill-response.dto';
+import { SkillDtoMapper } from './mappers/skill.mapper';
+import { KnowledgeBaseResponseDto } from 'src/domain/knowledge-bases/presenters/http/dto/knowledge-base-response.dto';
+import { KnowledgeBaseDtoMapper } from 'src/domain/knowledge-bases/presenters/http/mappers/knowledge-base-dto.mapper';
+import { RequireFeature } from 'src/common/guards/feature.guard';
+import { FeatureFlag } from 'src/config/features.config';
+
+@ApiTags('skills')
+@RequireFeature(FeatureFlag.Skills)
+@RequireFeature(FeatureFlag.KnowledgeBases)
+@Controller('skills')
+export class SkillKnowledgeBasesController {
+  private readonly logger = new Logger(SkillKnowledgeBasesController.name);
+
+  constructor(
+    private readonly assignKnowledgeBaseToSkillUseCase: AssignKnowledgeBaseToSkillUseCase,
+    private readonly unassignKnowledgeBaseFromSkillUseCase: UnassignKnowledgeBaseFromSkillUseCase,
+    private readonly listSkillKnowledgeBasesUseCase: ListSkillKnowledgeBasesUseCase,
+    private readonly skillDtoMapper: SkillDtoMapper,
+    private readonly knowledgeBaseDtoMapper: KnowledgeBaseDtoMapper,
+    private readonly skillAccessService: SkillAccessService,
+  ) {}
+
+  @Post(':skillId/knowledge-bases/:knowledgeBaseId')
+  @ApiOperation({ summary: 'Assign knowledge base to skill' })
+  @ApiParam({
+    name: 'skillId',
+    description: 'The UUID of the skill',
+    type: 'string',
+    format: 'uuid',
+  })
+  @ApiParam({
+    name: 'knowledgeBaseId',
+    description: 'The UUID of the knowledge base to assign',
+    type: 'string',
+    format: 'uuid',
+  })
+  @ApiResponse({
+    status: 201,
+    description: 'The knowledge base has been successfully assigned',
+    type: SkillResponseDto,
+  })
+  @ApiResponse({
+    status: 404,
+    description: 'Skill or knowledge base not found',
+  })
+  @ApiResponse({ status: 409, description: 'Knowledge base already assigned' })
+  @HttpCode(HttpStatus.CREATED)
+  async assignKnowledgeBase(
+    @Param('skillId', ParseUUIDPipe) skillId: UUID,
+    @Param('knowledgeBaseId', ParseUUIDPipe) knowledgeBaseId: UUID,
+  ): Promise<SkillResponseDto> {
+    this.logger.log('assignKnowledgeBase', { skillId, knowledgeBaseId });
+
+    const skill = await this.assignKnowledgeBaseToSkillUseCase.execute(
+      new AssignKnowledgeBaseToSkillCommand(skillId, knowledgeBaseId),
+    );
+
+    const context = await this.skillAccessService.resolveUserContext(skillId);
+
+    return this.skillDtoMapper.toDto(skill, context);
+  }
+
+  @Delete(':skillId/knowledge-bases/:knowledgeBaseId')
+  @ApiOperation({ summary: 'Unassign knowledge base from skill' })
+  @ApiParam({
+    name: 'skillId',
+    description: 'The UUID of the skill',
+    type: 'string',
+    format: 'uuid',
+  })
+  @ApiParam({
+    name: 'knowledgeBaseId',
+    description: 'The UUID of the knowledge base to unassign',
+    type: 'string',
+    format: 'uuid',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'The knowledge base has been successfully unassigned',
+    type: SkillResponseDto,
+  })
+  @ApiResponse({
+    status: 404,
+    description: 'Skill not found or knowledge base not assigned',
+  })
+  async unassignKnowledgeBase(
+    @Param('skillId', ParseUUIDPipe) skillId: UUID,
+    @Param('knowledgeBaseId', ParseUUIDPipe) knowledgeBaseId: UUID,
+  ): Promise<SkillResponseDto> {
+    this.logger.log('unassignKnowledgeBase', { skillId, knowledgeBaseId });
+
+    const skill = await this.unassignKnowledgeBaseFromSkillUseCase.execute(
+      new UnassignKnowledgeBaseFromSkillCommand(skillId, knowledgeBaseId),
+    );
+
+    const context = await this.skillAccessService.resolveUserContext(skillId);
+
+    return this.skillDtoMapper.toDto(skill, context);
+  }
+
+  @Get(':skillId/knowledge-bases')
+  @ApiOperation({ summary: 'List knowledge bases assigned to skill' })
+  @ApiParam({
+    name: 'skillId',
+    description: 'The UUID of the skill',
+    type: 'string',
+    format: 'uuid',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Returns all knowledge bases assigned to the skill',
+    type: [KnowledgeBaseResponseDto],
+  })
+  @ApiResponse({ status: 404, description: 'Skill not found' })
+  async listSkillKnowledgeBases(
+    @Param('skillId', ParseUUIDPipe) skillId: UUID,
+  ): Promise<KnowledgeBaseResponseDto[]> {
+    this.logger.log('listSkillKnowledgeBases', { skillId });
+
+    const knowledgeBases = await this.listSkillKnowledgeBasesUseCase.execute(
+      new ListSkillKnowledgeBasesQuery(skillId),
+    );
+
+    return this.knowledgeBaseDtoMapper.toDtoArray(knowledgeBases);
+  }
+}

--- a/ayunis-core-backend/src/domain/skills/skills.module.ts
+++ b/ayunis-core-backend/src/domain/skills/skills.module.ts
@@ -27,6 +27,9 @@ import { ListSkillSourcesUseCase } from './application/use-cases/list-skill-sour
 import { AssignMcpIntegrationToSkillUseCase } from './application/use-cases/assign-mcp-integration-to-skill/assign-mcp-integration-to-skill.use-case';
 import { UnassignMcpIntegrationFromSkillUseCase } from './application/use-cases/unassign-mcp-integration-from-skill/unassign-mcp-integration-from-skill.use-case';
 import { ListSkillMcpIntegrationsUseCase } from './application/use-cases/list-skill-mcp-integrations/list-skill-mcp-integrations.use-case';
+import { AssignKnowledgeBaseToSkillUseCase } from './application/use-cases/assign-knowledge-base-to-skill/assign-knowledge-base-to-skill.use-case';
+import { UnassignKnowledgeBaseFromSkillUseCase } from './application/use-cases/unassign-knowledge-base-from-skill/unassign-knowledge-base-from-skill.use-case';
+import { ListSkillKnowledgeBasesUseCase } from './application/use-cases/list-skill-knowledge-bases/list-skill-knowledge-bases.use-case';
 import { FindSkillByNameUseCase } from './application/use-cases/find-skill-by-name/find-skill-by-name.use-case';
 import { InstallSkillFromMarketplaceUseCase } from './application/use-cases/install-skill-from-marketplace/install-skill-from-marketplace.use-case';
 
@@ -56,8 +59,10 @@ import { ThreadsModule } from '../threads/threads.module';
 import { SkillsController } from './presenters/http/skills.controller';
 import { SkillSourcesController } from './presenters/http/skill-sources.controller';
 import { SkillMcpIntegrationsController } from './presenters/http/skill-mcp-integrations.controller';
+import { SkillKnowledgeBasesController } from './presenters/http/skill-knowledge-bases.controller';
 import { SkillDtoMapper } from './presenters/http/mappers/skill.mapper';
 import { McpIntegrationDtoMapper } from '../mcp/presenters/http/mappers/mcp-integration-dto.mapper';
+import { KnowledgeBaseDtoMapper } from '../knowledge-bases/presenters/http/mappers/knowledge-base-dto.mapper';
 
 @Module({
   imports: [
@@ -101,6 +106,9 @@ import { McpIntegrationDtoMapper } from '../mcp/presenters/http/mappers/mcp-inte
     AssignMcpIntegrationToSkillUseCase,
     UnassignMcpIntegrationFromSkillUseCase,
     ListSkillMcpIntegrationsUseCase,
+    AssignKnowledgeBaseToSkillUseCase,
+    UnassignKnowledgeBaseFromSkillUseCase,
+    ListSkillKnowledgeBasesUseCase,
     FindSkillByNameUseCase,
     InstallSkillFromMarketplaceUseCase,
 
@@ -121,11 +129,13 @@ import { McpIntegrationDtoMapper } from '../mcp/presenters/http/mappers/mcp-inte
     // Presenters
     SkillDtoMapper,
     McpIntegrationDtoMapper,
+    KnowledgeBaseDtoMapper,
   ],
   controllers: [
     SkillsController,
     SkillSourcesController,
     SkillMcpIntegrationsController,
+    SkillKnowledgeBasesController,
   ],
   exports: [
     FindActiveSkillsUseCase,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds new skill↔knowledge base association use cases and HTTP endpoints with org/user access checks; mistakes here could expose cross-organization knowledge bases or break skill updates.
> 
> **Overview**
> Adds first-class support for managing *knowledge base assignments on skills*: new use cases to `assign`, `unassign`, and `list` a skill’s knowledge bases, plus a new `SkillKnowledgeBasesController` exposing `POST/DELETE/GET /skills/:skillId/knowledge-bases` routes behind the `Skills` and `KnowledgeBases` feature flags.
> 
> Extends `KnowledgeBaseRepository` with `findByIds` (implemented in `LocalKnowledgeBaseRepository`) to batch-load assigned knowledge bases, and introduces new `SkillErrorCode`s/errors for knowledge-base assignment edge cases (not found, already assigned, wrong org, not assigned). Also adds coverage to ensure `UpdateSkillUseCase` preserves `knowledgeBaseIds` during updates and updates mocks in existing KB tests for the new repository method.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1675edbf1bbfabcb6f26940bb1f504335a4a7a47. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->