### PR TITLE
feat(AYC-99): add skill knowledge bases frontend UI with toggle card and renamed translations

### DIFF
--- a/ayunis-core-frontend/src/pages/skill/api/index.ts
+++ b/ayunis-core-frontend/src/pages/skill/api/index.ts
@@ -4,3 +4,6 @@ export { default as useSkillSources } from './useSkillSources';
 export { useSkillMcpIntegrationsQueries } from './useSkillMcpIntegrationsQueries';
 export { useAssignMcpIntegration } from './useAssignMcpIntegration';
 export { useUnassignMcpIntegration } from './useUnassignMcpIntegration';
+export { useSkillKnowledgeBasesQueries } from './useSkillKnowledgeBasesQueries';
+export { useAssignKnowledgeBase } from './useAssignKnowledgeBase';
+export { useUnassignKnowledgeBase } from './useUnassignKnowledgeBase';

--- a/ayunis-core-frontend/src/pages/skill/api/useAssignKnowledgeBase.ts
+++ b/ayunis-core-frontend/src/pages/skill/api/useAssignKnowledgeBase.ts
@@ -1,0 +1,75 @@
+import { useQueryClient } from '@tanstack/react-query';
+import { useTranslation } from 'react-i18next';
+import {
+  useSkillKnowledgeBasesControllerAssignKnowledgeBase,
+  getSkillKnowledgeBasesControllerListSkillKnowledgeBasesQueryKey,
+} from '@/shared/api/generated/ayunisCoreAPI';
+import type { KnowledgeBaseResponseDto } from '@/shared/api/generated/ayunisCoreAPI.schemas';
+import { showSuccess, showError } from '@/shared/lib/toast';
+
+/**
+ * Hook to assign a knowledge base to a skill with optimistic updates
+ */
+export function useAssignKnowledgeBase(
+  availableKnowledgeBases?: KnowledgeBaseResponseDto[],
+) {
+  const { t } = useTranslation('skill');
+  const queryClient = useQueryClient();
+
+  return useSkillKnowledgeBasesControllerAssignKnowledgeBase({
+    mutation: {
+      onMutate: async ({ skillId, knowledgeBaseId }) => {
+        await queryClient.cancelQueries({
+          queryKey:
+            getSkillKnowledgeBasesControllerListSkillKnowledgeBasesQueryKey(
+              skillId,
+            ),
+        });
+
+        const previousAssignments = queryClient.getQueryData(
+          getSkillKnowledgeBasesControllerListSkillKnowledgeBasesQueryKey(
+            skillId,
+          ),
+        );
+
+        queryClient.setQueryData(
+          getSkillKnowledgeBasesControllerListSkillKnowledgeBasesQueryKey(
+            skillId,
+          ),
+          (old: KnowledgeBaseResponseDto[] | undefined) => {
+            if (!old) return old;
+            const knowledgeBase = availableKnowledgeBases?.find(
+              (kb) => kb.id === knowledgeBaseId,
+            );
+            return knowledgeBase ? [...old, knowledgeBase] : old;
+          },
+        );
+
+        return { previousAssignments };
+      },
+      onError: (error, variables, context) => {
+        if (context?.previousAssignments) {
+          queryClient.setQueryData(
+            getSkillKnowledgeBasesControllerListSkillKnowledgeBasesQueryKey(
+              variables.skillId,
+            ),
+            context.previousAssignments,
+          );
+        }
+        console.error('Assign knowledge base failed:', error);
+        showError(t('knowledgeBases.errors.failedToAssign'));
+      },
+      onSuccess: () => {
+        showSuccess(t('knowledgeBases.success.assigned'));
+      },
+      onSettled: (_data, _error, variables) => {
+        void queryClient.invalidateQueries({
+          queryKey:
+            getSkillKnowledgeBasesControllerListSkillKnowledgeBasesQueryKey(
+              variables.skillId,
+            ),
+        });
+      },
+    },
+  });
+}

--- a/ayunis-core-frontend/src/pages/skill/api/useSkillKnowledgeBasesQueries.ts
+++ b/ayunis-core-frontend/src/pages/skill/api/useSkillKnowledgeBasesQueries.ts
@@ -1,0 +1,34 @@
+import {
+  useKnowledgeBasesControllerFindAll,
+  useSkillKnowledgeBasesControllerListSkillKnowledgeBases,
+} from '@/shared/api/generated/ayunisCoreAPI';
+
+/**
+ * Hook to fetch both available and assigned knowledge bases for a skill
+ */
+export function useSkillKnowledgeBasesQueries(skillId: string) {
+  const {
+    data: availableKnowledgeBases,
+    isLoading: loadingAvailable,
+    isError: errorAvailable,
+    refetch: refetchAvailable,
+  } = useKnowledgeBasesControllerFindAll();
+
+  const {
+    data: assignedKnowledgeBases,
+    isLoading: loadingAssigned,
+    isError: errorAssigned,
+    refetch: refetchAssigned,
+  } = useSkillKnowledgeBasesControllerListSkillKnowledgeBases(skillId);
+
+  return {
+    availableKnowledgeBases: availableKnowledgeBases?.data,
+    assignedKnowledgeBases,
+    isLoading: loadingAvailable || loadingAssigned,
+    isError: errorAvailable || errorAssigned,
+    refetch: () => {
+      void refetchAvailable();
+      void refetchAssigned();
+    },
+  };
+}

--- a/ayunis-core-frontend/src/pages/skill/api/useUnassignKnowledgeBase.ts
+++ b/ayunis-core-frontend/src/pages/skill/api/useUnassignKnowledgeBase.ts
@@ -1,0 +1,70 @@
+import { useQueryClient } from '@tanstack/react-query';
+import { useTranslation } from 'react-i18next';
+import {
+  useSkillKnowledgeBasesControllerUnassignKnowledgeBase,
+  getSkillKnowledgeBasesControllerListSkillKnowledgeBasesQueryKey,
+} from '@/shared/api/generated/ayunisCoreAPI';
+import type { KnowledgeBaseResponseDto } from '@/shared/api/generated/ayunisCoreAPI.schemas';
+import { showSuccess, showError } from '@/shared/lib/toast';
+
+/**
+ * Hook to unassign a knowledge base from a skill with optimistic updates
+ */
+export function useUnassignKnowledgeBase() {
+  const { t } = useTranslation('skill');
+  const queryClient = useQueryClient();
+
+  return useSkillKnowledgeBasesControllerUnassignKnowledgeBase({
+    mutation: {
+      onMutate: async ({ skillId, knowledgeBaseId }) => {
+        await queryClient.cancelQueries({
+          queryKey:
+            getSkillKnowledgeBasesControllerListSkillKnowledgeBasesQueryKey(
+              skillId,
+            ),
+        });
+
+        const previousAssignments = queryClient.getQueryData(
+          getSkillKnowledgeBasesControllerListSkillKnowledgeBasesQueryKey(
+            skillId,
+          ),
+        );
+
+        queryClient.setQueryData(
+          getSkillKnowledgeBasesControllerListSkillKnowledgeBasesQueryKey(
+            skillId,
+          ),
+          (old: KnowledgeBaseResponseDto[] | undefined) => {
+            if (!old) return old;
+            return old.filter((kb) => kb.id !== knowledgeBaseId);
+          },
+        );
+
+        return { previousAssignments };
+      },
+      onError: (error, variables, context) => {
+        if (context?.previousAssignments) {
+          queryClient.setQueryData(
+            getSkillKnowledgeBasesControllerListSkillKnowledgeBasesQueryKey(
+              variables.skillId,
+            ),
+            context.previousAssignments,
+          );
+        }
+        console.error('Unassign knowledge base failed:', error);
+        showError(t('knowledgeBases.errors.failedToUnassign'));
+      },
+      onSuccess: () => {
+        showSuccess(t('knowledgeBases.success.unassigned'));
+      },
+      onSettled: (_data, _error, variables) => {
+        void queryClient.invalidateQueries({
+          queryKey:
+            getSkillKnowledgeBasesControllerListSkillKnowledgeBasesQueryKey(
+              variables.skillId,
+            ),
+        });
+      },
+    },
+  });
+}

--- a/ayunis-core-frontend/src/pages/skill/ui/SkillKnowledgeBasesCard.tsx
+++ b/ayunis-core-frontend/src/pages/skill/ui/SkillKnowledgeBasesCard.tsx
@@ -1,0 +1,155 @@
+import { useParams } from '@tanstack/react-router';
+import { useTranslation } from 'react-i18next';
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+} from '@/shared/ui/shadcn/card';
+import { Switch } from '@/shared/ui/shadcn/switch';
+import { Separator } from '@/shared/ui/shadcn/separator';
+import { Skeleton } from '@/shared/ui/shadcn/skeleton';
+import {
+  Item,
+  ItemActions,
+  ItemContent,
+  ItemDescription,
+  ItemTitle,
+} from '@/shared/ui/shadcn/item';
+import { Button } from '@/shared/ui/shadcn/button';
+import { cn } from '@/shared/lib/shadcn/utils';
+import {
+  useSkillKnowledgeBasesQueries,
+  useAssignKnowledgeBase,
+  useUnassignKnowledgeBase,
+} from '../api';
+
+export default function SkillKnowledgeBasesCard({
+  disabled = false,
+}: Readonly<{
+  disabled?: boolean;
+}>) {
+  const { t } = useTranslation('skill');
+  const { id: skillId } = useParams({ from: '/_authenticated/skills/$id' });
+
+  const data = useSkillKnowledgeBasesQueries(skillId);
+  const assignMutation = useAssignKnowledgeBase(data.availableKnowledgeBases);
+  const unassignMutation = useUnassignKnowledgeBase();
+
+  const handleToggle = (knowledgeBaseId: string) => {
+    const isCurrentlyAssigned =
+      data.assignedKnowledgeBases?.some((kb) => kb.id === knowledgeBaseId) ??
+      false;
+    if (isCurrentlyAssigned) {
+      unassignMutation.mutate({ skillId, knowledgeBaseId });
+    } else {
+      assignMutation.mutate({ skillId, knowledgeBaseId });
+    }
+  };
+
+  const isAssigned = (knowledgeBaseId: string): boolean => {
+    return (
+      data.assignedKnowledgeBases?.some((kb) => kb.id === knowledgeBaseId) ??
+      false
+    );
+  };
+
+  const isPending = assignMutation.isPending || unassignMutation.isPending;
+
+  if (data.isLoading) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>{t('knowledgeBases.title')}</CardTitle>
+          <CardDescription>{t('knowledgeBases.description')}</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <Skeleton className="h-16 w-full" />
+          <Skeleton className="h-16 w-full" />
+          <Skeleton className="h-16 w-full" />
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (data.isError) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>{t('knowledgeBases.title')}</CardTitle>
+          <CardDescription>{t('knowledgeBases.description')}</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="flex flex-col items-center justify-center p-8 text-center">
+            <p className="text-sm text-destructive mb-4">
+              {t('knowledgeBases.errors.failedToLoad')}
+            </p>
+            <Button variant="link" onClick={data.refetch}>
+              {t('knowledgeBases.retryButton')}
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (
+    !data.availableKnowledgeBases ||
+    data.availableKnowledgeBases.length === 0
+  ) {
+    return null;
+  }
+
+  const sortedKnowledgeBases = [...data.availableKnowledgeBases].sort((a, b) =>
+    a.name.localeCompare(b.name),
+  );
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{t('knowledgeBases.title')}</CardTitle>
+        <CardDescription>{t('knowledgeBases.description')}</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className="space-y-4">
+          {sortedKnowledgeBases.map((knowledgeBase, index) => {
+            const assigned = isAssigned(knowledgeBase.id);
+
+            return (
+              <div key={knowledgeBase.id}>
+                {index > 0 && <Separator className="my-4" />}
+                <Item
+                  className={cn(
+                    index === 0 && 'pt-0',
+                    index === sortedKnowledgeBases.length - 1 && 'pb-0',
+                    'px-0',
+                  )}
+                >
+                  <ItemContent>
+                    <ItemTitle>{knowledgeBase.name}</ItemTitle>
+                    {knowledgeBase.description && (
+                      <ItemDescription>
+                        {knowledgeBase.description}
+                      </ItemDescription>
+                    )}
+                  </ItemContent>
+                  <ItemActions>
+                    <Switch
+                      checked={assigned}
+                      onCheckedChange={() => handleToggle(knowledgeBase.id)}
+                      disabled={disabled || isPending}
+                      aria-label={t('knowledgeBases.toggleAriaLabel', {
+                        name: knowledgeBase.name,
+                      })}
+                    />
+                  </ItemActions>
+                </Item>
+              </div>
+            );
+          })}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/ayunis-core-frontend/src/pages/skill/ui/SkillPage.tsx
+++ b/ayunis-core-frontend/src/pages/skill/ui/SkillPage.tsx
@@ -7,6 +7,7 @@ import type {
 import ContentAreaHeader from '@/widgets/content-area-header/ui/ContentAreaHeader';
 import ContentAreaLayout from '@/layouts/content-area-layout/ui/ContentAreaLayout';
 import SkillPropertiesCard from './SkillPropertiesCard';
+import SkillKnowledgeBasesCard from './SkillKnowledgeBasesCard';
 import { KnowledgeBaseCard } from '@/widgets/knowledge-base-card';
 import SkillMcpIntegrationsCard from './SkillMcpIntegrationsCard';
 import { SharesTab } from '@/widgets/shares-tab';
@@ -168,6 +169,8 @@ export function SkillPage({
           isReadOnly ? (
             <div className="grid gap-4">
               <SkillPropertiesCard skill={skill} disabled />
+              {isEmbeddingModelEnabled && <SkillKnowledgeBasesCard disabled />}
+              <SkillMcpIntegrationsCard disabled />
               <KnowledgeBaseCard
                 entity={skill}
                 isEnabled={isEmbeddingModelEnabled}
@@ -175,7 +178,6 @@ export function SkillPage({
                 translationNamespace="skill"
                 sourcesHook={sourcesHook}
               />
-              <SkillMcpIntegrationsCard disabled />
             </div>
           ) : (
             <Tabs
@@ -192,13 +194,14 @@ export function SkillPage({
               <TabsContent value="config" className="mt-4">
                 <div className="grid gap-4">
                   <SkillPropertiesCard skill={skill} />
+                  {isEmbeddingModelEnabled && <SkillKnowledgeBasesCard />}
+                  <SkillMcpIntegrationsCard />
                   <KnowledgeBaseCard
                     entity={skill}
                     isEnabled={isEmbeddingModelEnabled}
                     translationNamespace="skill"
                     sourcesHook={sourcesHook}
                   />
-                  <SkillMcpIntegrationsCard />
                 </div>
               </TabsContent>
               <TabsContent value="share" className="mt-4">

--- a/ayunis-core-frontend/src/shared/locales/de/agent.json
+++ b/ayunis-core-frontend/src/shared/locales/de/agent.json
@@ -23,9 +23,9 @@
       "saving": "Wird gespeichert..."
     }
   },
-  "knowledgeBase": {
-    "title": "Wissenssammlung",
-    "description": "Konfigurieren Sie, welches Wissen der Agent zur Verfügung hat",
+  "additionalDocuments": {
+    "title": "Zusätzliche Dokumente",
+    "description": "Dokumente direkt zu diesem Agent hochladen",
     "adding": "Hinzufügen...",
     "addSource": "Quelle hinzufügen",
     "disabledTooltip": "Um Dokumente hochzuladen, muss ein Embedding-Modell aktiviert sein."

--- a/ayunis-core-frontend/src/shared/locales/de/skill.json
+++ b/ayunis-core-frontend/src/shared/locales/de/skill.json
@@ -77,12 +77,27 @@
       "instructionsRequired": "Anweisungen sind erforderlich"
     }
   },
-  "knowledgeBase": {
-    "title": "Wissenssammlung",
-    "description": "Konfigurieren Sie, auf welches Wissen die Fähigkeit Zugriff hat",
+  "additionalDocuments": {
+    "title": "Zusätzliche Dokumente",
+    "description": "Dokumente direkt zu dieser Fähigkeit hochladen",
     "adding": "Wird hinzugefügt...",
     "addSource": "Quelle hinzufügen",
     "disabledTooltip": "Um Dokumente hochzuladen, muss ein Embedding-Modell aktiviert sein."
+  },
+  "knowledgeBases": {
+    "title": "Wissenssammlungen",
+    "description": "Gemeinsame Wissenssammlungen mit dieser Fähigkeit verbinden",
+    "toggleAriaLabel": "{{name}} Wissenssammlung umschalten",
+    "retryButton": "Erneut versuchen",
+    "success": {
+      "assigned": "Wissenssammlung verbunden",
+      "unassigned": "Wissenssammlung getrennt"
+    },
+    "errors": {
+      "failedToLoad": "Wissenssammlungen konnten nicht geladen werden. Bitte versuchen Sie es erneut.",
+      "failedToAssign": "Wissenssammlung konnte nicht verbunden werden. Bitte versuchen Sie es erneut.",
+      "failedToUnassign": "Wissenssammlung konnte nicht getrennt werden. Bitte versuchen Sie es erneut."
+    }
   },
   "sources": {
     "addedSuccessfully": "Quelle erfolgreich hinzugefügt",

--- a/ayunis-core-frontend/src/shared/locales/en/agent.json
+++ b/ayunis-core-frontend/src/shared/locales/en/agent.json
@@ -23,9 +23,9 @@
       "saving": "Saving..."
     }
   },
-  "knowledgeBase": {
-    "title": "Knowledge Base",
-    "description": "Configure which knowledge the agent has access to",
+  "additionalDocuments": {
+    "title": "Additional Documents",
+    "description": "Upload documents directly to this agent",
     "adding": "Adding...",
     "addSource": "Add Source",
     "disabledTooltip": "To upload documents, an embedding model must be enabled."

--- a/ayunis-core-frontend/src/shared/locales/en/skill.json
+++ b/ayunis-core-frontend/src/shared/locales/en/skill.json
@@ -77,12 +77,27 @@
       "instructionsRequired": "Instructions are required"
     }
   },
-  "knowledgeBase": {
-    "title": "Knowledge Base",
-    "description": "Configure which knowledge the skill has access to",
+  "additionalDocuments": {
+    "title": "Additional Documents",
+    "description": "Upload documents directly to this skill",
     "adding": "Adding...",
     "addSource": "Add Source",
     "disabledTooltip": "To upload documents, an embedding model must be enabled."
+  },
+  "knowledgeBases": {
+    "title": "Knowledge Bases",
+    "description": "Connect shared knowledge bases to this skill",
+    "toggleAriaLabel": "Toggle {{name}} knowledge base",
+    "retryButton": "Retry",
+    "success": {
+      "assigned": "Knowledge base connected",
+      "unassigned": "Knowledge base disconnected"
+    },
+    "errors": {
+      "failedToLoad": "Failed to load knowledge bases. Please try again.",
+      "failedToAssign": "Failed to connect knowledge base. Please try again.",
+      "failedToUnassign": "Failed to disconnect knowledge base. Please try again."
+    }
   },
   "sources": {
     "addedSuccessfully": "Source added successfully",

--- a/ayunis-core-frontend/src/widgets/knowledge-base-card/ui/KnowledgeBaseCard.tsx
+++ b/ayunis-core-frontend/src/widgets/knowledge-base-card/ui/KnowledgeBaseCard.tsx
@@ -62,7 +62,7 @@ export default function KnowledgeBaseCard({
   function handleFileChange(event: React.ChangeEvent<HTMLInputElement>) {
     const file = event.target.files?.[0];
     if (!isEnabled) {
-      showError(t('knowledgeBase.disabledTooltip'));
+      showError(t('additionalDocuments.disabledTooltip'));
       return;
     }
     if (file) {
@@ -76,8 +76,10 @@ export default function KnowledgeBaseCard({
   return (
     <Card>
       <CardHeader>
-        <CardTitle>{t('knowledgeBase.title')}</CardTitle>
-        <CardDescription>{t('knowledgeBase.description')}</CardDescription>
+        <CardTitle>{t('additionalDocuments.title')}</CardTitle>
+        <CardDescription>
+          {t('additionalDocuments.description')}
+        </CardDescription>
       </CardHeader>
       <CardContent>
         <div className="space-y-4">
@@ -120,7 +122,7 @@ export default function KnowledgeBaseCard({
               />
               <TooltipIf
                 condition={!isEnabled}
-                tooltip={t('knowledgeBase.disabledTooltip')}
+                tooltip={t('additionalDocuments.disabledTooltip')}
               >
                 <Button
                   variant="outline"
@@ -128,8 +130,8 @@ export default function KnowledgeBaseCard({
                   disabled={addFileSourcePending || removeSourcePending}
                 >
                   {addFileSourcePending
-                    ? t('knowledgeBase.adding')
-                    : t('knowledgeBase.addSource')}
+                    ? t('additionalDocuments.adding')
+                    : t('additionalDocuments.addSource')}
                 </Button>
               </TooltipIf>
             </>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds new skill-to-knowledge-base assignment mutations with optimistic cache updates; incorrect query key/data shape assumptions could cause UI inconsistency or failed rollbacks. Translation key renames may break labels if any consumers weren’t updated.
> 
> **Overview**
> Adds a new **Skill Knowledge Bases** card (`SkillKnowledgeBasesCard`) that lists all knowledge bases and lets users assign/unassign them to a skill via toggle switches (with loading/error states and retry).
> 
> Introduces new React Query hooks (`useSkillKnowledgeBasesQueries`, `useAssignKnowledgeBase`, `useUnassignKnowledgeBase`) that fetch available/assigned knowledge bases and perform assign/unassign mutations with optimistic updates + cache invalidation.
> 
> Renames document-upload i18n keys from `knowledgeBase.*` to `additionalDocuments.*` in `agent.json`/`skill.json`, updates `KnowledgeBaseCard` to use the new keys, and adds new `skill.knowledgeBases.*` strings for the toggle card.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8769e226de119c6a693c2b99389abf29b1290774. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->