### PR TITLE
fix(AYC-000): copy message as rich text for proper formatting in word

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,1 +1,0 @@
-/Users/daniel/ayunis-ai/AGENTS.md/ayunis-core/AGENTS.md

--- a/ayunis-core-frontend/src/pages/chat/ui/ChatMessage.tsx
+++ b/ayunis-core-frontend/src/pages/chat/ui/ChatMessage.tsx
@@ -166,7 +166,10 @@ export default function ChatMessage({
           >
             {renderMessageContent(message, isStreaming)}
           </div>
-          <CopyMessageButton contentRef={messageContentRef} />
+          {/* eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- content may be undefined during streaming */}
+          {message.content?.some((c) => c.type === 'text') && (
+            <CopyMessageButton contentRef={messageContentRef} />
+          )}
         </div>
       </div>
     );

--- a/ayunis-core-frontend/src/pages/chat/ui/ChatMessage.tsx
+++ b/ayunis-core-frontend/src/pages/chat/ui/ChatMessage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import { Card, CardContent } from '@/shared/ui/shadcn/card';
 import { Avatar, AvatarFallback } from '@/shared/ui/shadcn/avatar';
 import { Dialog, DialogContent, DialogTitle } from '@/shared/ui/shadcn/dialog';
@@ -47,36 +47,38 @@ interface ChatMessageProps {
   readonly isStreaming?: boolean;
 }
 
-function CopyMessageButton({ message }: { readonly message: Message }) {
+function CopyMessageButton({
+  contentRef,
+}: {
+  readonly contentRef: React.RefObject<HTMLDivElement | null>;
+}) {
   const [copied, setCopied] = useState(false);
   const { t } = useTranslation('chat');
 
-  const extractTextContent = (message: Message): string => {
-    if (message.role !== 'assistant') return '';
-    // eslint-disable-next-line eqeqeq, @typescript-eslint/no-unnecessary-condition -- content may be undefined during streaming even if typed as required
-    if (message.content == null || message.content.length === 0) return '';
-
-    return message.content
-      .filter((content) => content.type === 'text')
-      .map((content) => (content as TextMessageContent).text)
-      .join('\n\n');
-  };
-
   const handleCopy = async () => {
-    const textContent = extractTextContent(message);
-    if (!textContent) return;
+    const el = contentRef.current;
+    if (!el) return;
+
+    const html = el.innerHTML;
+    const plainText = el.innerText;
+    if (!plainText.trim()) return;
 
     try {
-      await navigator.clipboard.writeText(textContent);
+      await navigator.clipboard.write([
+        new ClipboardItem({
+          'text/html': new Blob([html], { type: 'text/html' }),
+          'text/plain': new Blob([plainText], { type: 'text/plain' }),
+        }),
+      ]);
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
-    } catch (error) {
-      console.error('Failed to copy message:', error);
+    } catch {
+      // Fallback for browsers that don't support ClipboardItem
+      await navigator.clipboard.writeText(plainText);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
     }
   };
-
-  const textContent = extractTextContent(message);
-  if (!textContent) return null;
 
   return (
     <Tooltip>
@@ -106,6 +108,7 @@ export default function ChatMessage({
   isStreaming = false,
 }: ChatMessageProps) {
   const { theme } = useTheme();
+  const messageContentRef = useRef<HTMLDivElement>(null);
 
   const isUserMessage = message.role === 'user';
   const isAssistantMessage = message.role === 'assistant';
@@ -144,12 +147,13 @@ export default function ChatMessage({
         )}
         <div className="max-w-2xl min-w-0 space-y-1 w-full">
           <div
+            ref={messageContentRef}
             className="space-y-2 overflow-hidden w-full"
             data-testid="assistant-message"
           >
             {renderMessageContent(message, isStreaming)}
           </div>
-          <CopyMessageButton message={message} />
+          <CopyMessageButton contentRef={messageContentRef} />
         </div>
       </div>
     );


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Frontend-only change to clipboard behavior; main risk is browser/permission compatibility differences with `ClipboardItem` and HTML clipboard writes.
> 
> **Overview**
> Assistant message copying now captures the *rendered* message content and writes both `text/html` and `text/plain` to the clipboard (with a plain-text fallback), improving formatting when pasting into editors like Word.
> 
> This switches the copy source from message DTO text to DOM-marked `data-copyable` blocks via a ref, and only shows the copy button when the assistant message contains text content.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 974fb6657f6fb6006496d9cdc0e0136101ac5cd9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->