### PR TITLE
feat(AYC-000): add download-as-image button to chart widgets

### DIFF
--- a/ayunis-core-frontend/package-lock.json
+++ b/ayunis-core-frontend/package-lock.json
@@ -37,6 +37,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",
+        "html-to-image": "^1.11.13",
         "i18next": "^25.8.10",
         "i18next-browser-languagedetector": "^8.2.0",
         "lucide-react": "^0.476.0",
@@ -9534,6 +9535,12 @@
       "dependencies": {
         "void-elements": "3.1.0"
       }
+    },
+    "node_modules/html-to-image": {
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/html-to-image/-/html-to-image-1.11.13.tgz",
+      "integrity": "sha512-cuOPoI7WApyhBElTTb9oqsawRvZ0rHhaHwghRLlTuffoD1B2aDemlCruLeZrUIIdvG7gs9xeELEPm6PhuASqrg==",
+      "license": "MIT"
     },
     "node_modules/html-url-attributes": {
       "version": "3.0.1",

--- a/ayunis-core-frontend/package.json
+++ b/ayunis-core-frontend/package.json
@@ -48,6 +48,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
+    "html-to-image": "^1.11.13",
     "i18next": "^25.8.10",
     "i18next-browser-languagedetector": "^8.2.0",
     "lucide-react": "^0.476.0",

--- a/ayunis-core-frontend/src/widgets/charts/lib/useDownloadChartImage.ts
+++ b/ayunis-core-frontend/src/widgets/charts/lib/useDownloadChartImage.ts
@@ -1,0 +1,36 @@
+import { useCallback, useRef, useState } from 'react';
+import { toPng } from 'html-to-image';
+
+export function useDownloadChartImage(title?: string) {
+  const chartRef = useRef<HTMLDivElement>(null);
+  const [isDownloading, setIsDownloading] = useState(false);
+
+  const download = useCallback(async () => {
+    const node = chartRef.current;
+    if (!node) return;
+
+    setIsDownloading(true);
+    try {
+      const dataUrl = await toPng(node, {
+        backgroundColor: '#ffffff',
+        pixelRatio: 2,
+      });
+
+      const link = document.createElement('a');
+      link.download = `${slugify(title ?? 'chart')}.png`;
+      link.href = dataUrl;
+      link.click();
+    } finally {
+      setIsDownloading(false);
+    }
+  }, [title]);
+
+  return { chartRef, download, isDownloading };
+}
+
+function slugify(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '');
+}

--- a/ayunis-core-frontend/src/widgets/charts/lib/useDownloadChartImage.ts
+++ b/ayunis-core-frontend/src/widgets/charts/lib/useDownloadChartImage.ts
@@ -1,5 +1,6 @@
 import { useCallback, useRef, useState } from 'react';
 import { toPng } from 'html-to-image';
+import { slugifyForCssVar } from './ChartUtils';
 
 export function useDownloadChartImage(title?: string) {
   const chartRef = useRef<HTMLDivElement>(null);
@@ -14,10 +15,16 @@ export function useDownloadChartImage(title?: string) {
       const dataUrl = await toPng(node, {
         backgroundColor: '#ffffff',
         pixelRatio: 2,
+        filter: (domNode) => {
+          if (domNode instanceof Element) {
+            return !domNode.hasAttribute('data-exclude-from-export');
+          }
+          return true;
+        },
       });
 
       const link = document.createElement('a');
-      link.download = `${slugify(title ?? 'chart')}.png`;
+      link.download = `${slugifyForCssVar(title ?? 'chart')}.png`;
       link.href = dataUrl;
       link.click();
     } finally {
@@ -26,11 +33,4 @@ export function useDownloadChartImage(title?: string) {
   }, [title]);
 
   return { chartRef, download, isDownloading };
-}
-
-function slugify(text: string): string {
-  return text
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-|-$/g, '');
 }

--- a/ayunis-core-frontend/src/widgets/charts/ui/ChartCard.tsx
+++ b/ayunis-core-frontend/src/widgets/charts/ui/ChartCard.tsx
@@ -1,6 +1,7 @@
 // Utils
 import { useMemo } from 'react';
 import { cn } from '@/shared/lib/shadcn/utils';
+import { useDownloadChartImage } from '@/widgets/charts/lib/useDownloadChartImage';
 
 // UI
 import { ChartContainer, type ChartConfig } from '@/shared/ui/shadcn/chart';
@@ -11,6 +12,8 @@ import {
   CardContent,
   CardFooter,
 } from '@/shared/ui/shadcn/card';
+import { Button } from '@/shared/ui/shadcn/button';
+import { Download, Loader2 } from 'lucide-react';
 
 type ChartCardProps = {
   title?: string;
@@ -33,6 +36,8 @@ export function ChartCard({
   perPointPx = 70,
   children,
 }: Readonly<ChartCardProps>) {
+  const { chartRef, download, isDownloading } = useDownloadChartImage(title);
+
   const dynamicWidth = useMemo(() => {
     if (!xCount) {
       return undefined;
@@ -42,12 +47,19 @@ export function ChartCard({
   }, [xCount, threshold, perPointPx]);
 
   return (
-    <Card className={cn('my-2', className)}>
-      {title && (
-        <CardHeader>
-          <CardTitle>{title}</CardTitle>
-        </CardHeader>
-      )}
+    <Card className={cn('my-2', className)} ref={chartRef}>
+      <CardHeader className="flex flex-row items-center justify-between space-y-0">
+        {title && <CardTitle>{title}</CardTitle>}
+        <Button
+          variant="ghost"
+          size="icon-sm"
+          onClick={() => void download()}
+          disabled={isDownloading}
+          aria-label="Download chart as image"
+        >
+          {isDownloading ? <Loader2 className="animate-spin" /> : <Download />}
+        </Button>
+      </CardHeader>
 
       <CardContent className="overflow-auto">
         <ChartContainer

--- a/ayunis-core-frontend/src/widgets/charts/ui/ChartCard.tsx
+++ b/ayunis-core-frontend/src/widgets/charts/ui/ChartCard.tsx
@@ -9,6 +9,7 @@ import {
   Card,
   CardHeader,
   CardTitle,
+  CardAction,
   CardContent,
   CardFooter,
 } from '@/shared/ui/shadcn/card';
@@ -48,17 +49,23 @@ export function ChartCard({
 
   return (
     <Card className={cn('my-2', className)} ref={chartRef}>
-      <CardHeader className="flex flex-row items-center justify-between space-y-0">
+      <CardHeader>
         {title && <CardTitle>{title}</CardTitle>}
-        <Button
-          variant="ghost"
-          size="icon-sm"
-          onClick={() => void download()}
-          disabled={isDownloading}
-          aria-label="Download chart as image"
-        >
-          {isDownloading ? <Loader2 className="animate-spin" /> : <Download />}
-        </Button>
+        <CardAction data-exclude-from-export>
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            onClick={() => void download()}
+            disabled={isDownloading}
+            aria-label="Download chart as image"
+          >
+            {isDownloading ? (
+              <Loader2 className="animate-spin" />
+            ) : (
+              <Download />
+            )}
+          </Button>
+        </CardAction>
       </CardHeader>
 
       <CardContent className="overflow-auto">


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk UI-only change that adds a client-side export flow; main risk is minor UX/perf issues when rendering charts to PNG in the browser.
> 
> **Overview**
> Adds a **download-as-image** action to `ChartCard`, allowing users to export the rendered chart as a PNG.
> 
> Introduces a new `useDownloadChartImage` hook backed by `html-to-image` to snapshot the card DOM (with a white background, higher pixel ratio) while excluding UI controls via `data-exclude-from-export`, and wires up a loading/disabled state on the download button.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fb4721b169290ba257f427a509fa51e7941c20a0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->