### PR TITLE
wip(AYC-96): instrument domain services with prometheus metrics

### DIFF
--- a/ayunis-core-backend/src/domain/messages/application/use-cases/create-assistant-message/create-assistant-message.use-case.ts
+++ b/ayunis-core-backend/src/domain/messages/application/use-cases/create-assistant-message/create-assistant-message.use-case.ts
@@ -1,4 +1,6 @@
 import { Injectable, Logger, Inject } from '@nestjs/common';
+import { Counter } from 'prom-client';
+import { InjectMetric } from '@willsoto/nestjs-prometheus';
 import { CreateAssistantMessageCommand } from './create-assistant-message.command';
 import { AssistantMessage } from '../../../domain/messages/assistant-message.entity';
 import {
@@ -7,6 +9,9 @@ import {
 } from '../../ports/messages.repository';
 import { MessageRole } from '../../../domain/value-objects/message-role.object';
 import { MessageCreationError } from '../../messages.errors';
+import { ContextService } from 'src/common/context/services/context.service';
+import { AYUNIS_MESSAGES_TOTAL } from 'src/metrics/metrics.constants';
+import { getUserContextLabels, safeMetric } from 'src/metrics/metrics.utils';
 
 @Injectable()
 export class CreateAssistantMessageUseCase {
@@ -15,6 +20,9 @@ export class CreateAssistantMessageUseCase {
   constructor(
     @Inject(MESSAGES_REPOSITORY)
     private readonly messagesRepository: MessagesRepository,
+    private readonly contextService: ContextService,
+    @InjectMetric(AYUNIS_MESSAGES_TOTAL)
+    private readonly messagesCounter: Counter<string>,
   ) {}
 
   async execute(
@@ -30,9 +38,16 @@ export class CreateAssistantMessageUseCase {
     });
 
     try {
-      return (await this.messagesRepository.create(
+      const saved = (await this.messagesRepository.create(
         assistantMessage,
       )) as AssistantMessage;
+
+      safeMetric(this.logger, () => {
+        const labels = getUserContextLabels(this.contextService);
+        this.messagesCounter.inc({ ...labels, role: 'assistant' });
+      });
+
+      return saved;
     } catch (error) {
       this.logger.error('Failed to create assistant message', {
         threadId: command.threadId,

--- a/ayunis-core-backend/src/domain/messages/application/use-cases/create-user-message/create-user-message.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/messages/application/use-cases/create-user-message/create-user-message.use-case.spec.ts
@@ -12,6 +12,8 @@ import { UploadObjectUseCase } from 'src/domain/storage/application/use-cases/up
 import { DeleteObjectUseCase } from 'src/domain/storage/application/use-cases/delete-object/delete-object.use-case';
 import { ContextService } from 'src/common/context/services/context.service';
 import { UnauthorizedException } from '@nestjs/common';
+import { getToken } from '@willsoto/nestjs-prometheus';
+import { AYUNIS_MESSAGES_TOTAL } from 'src/metrics/metrics.constants';
 
 describe('CreateUserMessageUseCase', () => {
   let useCase: CreateUserMessageUseCase;
@@ -46,6 +48,10 @@ describe('CreateUserMessageUseCase', () => {
         { provide: UploadObjectUseCase, useValue: mockUploadObjectUseCase },
         { provide: DeleteObjectUseCase, useValue: mockDeleteObjectUseCase },
         { provide: ContextService, useValue: mockContextService },
+        {
+          provide: getToken(AYUNIS_MESSAGES_TOTAL),
+          useValue: { inc: jest.fn() },
+        },
       ],
     }).compile();
 

--- a/ayunis-core-backend/src/domain/messages/application/use-cases/save-assistant-message/save-assistant-message.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/messages/application/use-cases/save-assistant-message/save-assistant-message.use-case.spec.ts
@@ -1,0 +1,101 @@
+import type { TestingModule } from '@nestjs/testing';
+import { Test } from '@nestjs/testing';
+import { SaveAssistantMessageUseCase } from './save-assistant-message.use-case';
+import type { MessagesRepository } from '../../ports/messages.repository';
+import { MESSAGES_REPOSITORY } from '../../ports/messages.repository';
+import { SaveAssistantMessageCommand } from './save-assistant-message.command';
+import { AssistantMessage } from '../../../domain/messages/assistant-message.entity';
+import { MessageCreationError } from '../../messages.errors';
+import { randomUUID } from 'crypto';
+import { ContextService } from 'src/common/context/services/context.service';
+import { getToken } from '@willsoto/nestjs-prometheus';
+import { AYUNIS_MESSAGES_TOTAL } from 'src/metrics/metrics.constants';
+
+describe('SaveAssistantMessageUseCase', () => {
+  let useCase: SaveAssistantMessageUseCase;
+  let mockMessagesRepository: Partial<MessagesRepository>;
+  let mockContextService: Partial<ContextService>;
+  let mockMessagesCounter: { inc: jest.Mock };
+
+  beforeAll(async () => {
+    mockMessagesRepository = {
+      create: jest.fn(),
+    };
+
+    mockContextService = {
+      get: jest.fn().mockReturnValue(randomUUID()),
+    };
+
+    mockMessagesCounter = { inc: jest.fn() };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        SaveAssistantMessageUseCase,
+        { provide: MESSAGES_REPOSITORY, useValue: mockMessagesRepository },
+        { provide: ContextService, useValue: mockContextService },
+        {
+          provide: getToken(AYUNIS_MESSAGES_TOTAL),
+          useValue: mockMessagesCounter,
+        },
+      ],
+    }).compile();
+
+    useCase = module.get<SaveAssistantMessageUseCase>(
+      SaveAssistantMessageUseCase,
+    );
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (mockContextService.get as jest.Mock).mockReturnValue(randomUUID());
+  });
+
+  it('should be defined', () => {
+    expect(useCase).toBeDefined();
+  });
+
+  it('should save an assistant message and increment the metric', async () => {
+    const threadId = randomUUID();
+    const message = new AssistantMessage({ threadId, content: [] });
+    const command = new SaveAssistantMessageCommand(message);
+
+    jest.spyOn(mockMessagesRepository, 'create').mockResolvedValue(message);
+
+    const result = await useCase.execute(command);
+
+    expect(result).toBe(message);
+    expect(mockMessagesRepository.create).toHaveBeenCalledWith(message);
+    expect(mockMessagesCounter.inc).toHaveBeenCalledWith(
+      expect.objectContaining({ role: 'assistant' }),
+    );
+  });
+
+  it('should throw MessageCreationError when repository fails', async () => {
+    const threadId = randomUUID();
+    const message = new AssistantMessage({ threadId, content: [] });
+    const command = new SaveAssistantMessageCommand(message);
+
+    jest
+      .spyOn(mockMessagesRepository, 'create')
+      .mockRejectedValue(new Error('Database error'));
+
+    await expect(useCase.execute(command)).rejects.toThrow(
+      MessageCreationError,
+    );
+  });
+
+  it('should not propagate metric errors', async () => {
+    const threadId = randomUUID();
+    const message = new AssistantMessage({ threadId, content: [] });
+    const command = new SaveAssistantMessageCommand(message);
+
+    jest.spyOn(mockMessagesRepository, 'create').mockResolvedValue(message);
+    mockMessagesCounter.inc.mockImplementation(() => {
+      throw new Error('Metric registration error');
+    });
+
+    const result = await useCase.execute(command);
+
+    expect(result).toBe(message);
+  });
+});

--- a/ayunis-core-backend/src/domain/messages/application/use-cases/save-assistant-message/save-assistant-message.use-case.ts
+++ b/ayunis-core-backend/src/domain/messages/application/use-cases/save-assistant-message/save-assistant-message.use-case.ts
@@ -1,4 +1,6 @@
 import { Injectable, Logger, Inject } from '@nestjs/common';
+import { Counter } from 'prom-client';
+import { InjectMetric } from '@willsoto/nestjs-prometheus';
 import { SaveAssistantMessageCommand } from './save-assistant-message.command';
 import { AssistantMessage } from '../../../domain/messages/assistant-message.entity';
 import {
@@ -7,6 +9,9 @@ import {
 } from '../../ports/messages.repository';
 import { MessageRole } from '../../../domain/value-objects/message-role.object';
 import { MessageCreationError } from '../../messages.errors';
+import { ContextService } from 'src/common/context/services/context.service';
+import { AYUNIS_MESSAGES_TOTAL } from 'src/metrics/metrics.constants';
+import { getUserContextLabels, safeMetric } from 'src/metrics/metrics.utils';
 
 @Injectable()
 export class SaveAssistantMessageUseCase {
@@ -15,6 +20,9 @@ export class SaveAssistantMessageUseCase {
   constructor(
     @Inject(MESSAGES_REPOSITORY)
     private readonly messagesRepository: MessagesRepository,
+    private readonly contextService: ContextService,
+    @InjectMetric(AYUNIS_MESSAGES_TOTAL)
+    private readonly messagesCounter: Counter<string>,
   ) {}
 
   async execute(
@@ -26,9 +34,16 @@ export class SaveAssistantMessageUseCase {
     });
 
     try {
-      return (await this.messagesRepository.create(
+      const saved = (await this.messagesRepository.create(
         command.message,
       )) as AssistantMessage;
+
+      safeMetric(this.logger, () => {
+        const labels = getUserContextLabels(this.contextService);
+        this.messagesCounter.inc({ ...labels, role: 'assistant' });
+      });
+
+      return saved;
     } catch (error) {
       this.logger.error('Failed to save assistant message', {
         messageId: command.message.id,

--- a/ayunis-core-backend/src/domain/runs/application/services/non-streaming-inference.service.spec.ts
+++ b/ayunis-core-backend/src/domain/runs/application/services/non-streaming-inference.service.spec.ts
@@ -1,0 +1,93 @@
+import { Logger } from '@nestjs/common';
+import { NonStreamingInferenceService } from './non-streaming-inference.service';
+import type { GetInferenceUseCase } from 'src/domain/models/application/use-cases/get-inference/get-inference.use-case';
+import { InferenceResponse } from 'src/domain/models/application/ports/inference.handler';
+import type { LanguageModel } from 'src/domain/models/domain/models/language.model';
+import type { Message } from 'src/domain/messages/domain/message.entity';
+import type { Tool } from 'src/domain/tools/domain/tool.entity';
+
+describe('NonStreamingInferenceService', () => {
+  let service: NonStreamingInferenceService;
+  let getInferenceUseCase: { execute: jest.Mock };
+  let histogram: { observe: jest.Mock };
+  let errorCounter: { inc: jest.Mock };
+
+  const model = { name: 'gpt-4o', provider: 'openai' } as LanguageModel;
+  const messages = [] as Message[];
+  const tools = [] as Tool[];
+
+  beforeEach(() => {
+    getInferenceUseCase = { execute: jest.fn() };
+    histogram = { observe: jest.fn() };
+    errorCounter = { inc: jest.fn() };
+
+    service = new NonStreamingInferenceService(
+      getInferenceUseCase as unknown as GetInferenceUseCase,
+      histogram as never,
+      errorCounter as never,
+    );
+
+    jest.spyOn(Logger.prototype, 'warn').mockImplementation();
+  });
+
+  it('should return inference response and observe duration on histogram', async () => {
+    const response = new InferenceResponse([], {
+      inputTokens: 100,
+      outputTokens: 50,
+    });
+    getInferenceUseCase.execute.mockResolvedValue(response);
+
+    const result = await service.execute({ model, messages, tools });
+
+    expect(result).toBe(response);
+    expect(histogram.observe).toHaveBeenCalledWith(
+      { model: 'gpt-4o', provider: 'openai', streaming: 'false' },
+      expect.any(Number),
+    );
+    expect(errorCounter.inc).not.toHaveBeenCalled();
+  });
+
+  it('should increment error counter and rethrow when inference fails', async () => {
+    const error = Object.assign(new Error('Request timeout'), { status: 408 });
+    getInferenceUseCase.execute.mockRejectedValue(error);
+
+    await expect(service.execute({ model, messages, tools })).rejects.toThrow(
+      error,
+    );
+
+    expect(histogram.observe).toHaveBeenCalled();
+    expect(errorCounter.inc).toHaveBeenCalledWith({
+      model: 'gpt-4o',
+      provider: 'openai',
+      error_type: 'timeout',
+      streaming: 'false',
+    });
+  });
+
+  it('should not propagate metric failures from histogram', async () => {
+    const response = new InferenceResponse([], {
+      inputTokens: 10,
+      outputTokens: 5,
+    });
+    getInferenceUseCase.execute.mockResolvedValue(response);
+    histogram.observe.mockImplementation(() => {
+      throw new Error('prometheus broken');
+    });
+
+    const result = await service.execute({ model, messages, tools });
+
+    expect(result).toBe(response);
+  });
+
+  it('should not propagate metric failures from error counter', async () => {
+    const inferenceError = new Error('some provider error');
+    getInferenceUseCase.execute.mockRejectedValue(inferenceError);
+    errorCounter.inc.mockImplementation(() => {
+      throw new Error('prometheus broken');
+    });
+
+    await expect(service.execute({ model, messages, tools })).rejects.toThrow(
+      inferenceError,
+    );
+  });
+});

--- a/ayunis-core-backend/src/domain/runs/application/services/non-streaming-inference.service.ts
+++ b/ayunis-core-backend/src/domain/runs/application/services/non-streaming-inference.service.ts
@@ -1,0 +1,70 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Counter, Histogram } from 'prom-client';
+import { InjectMetric } from '@willsoto/nestjs-prometheus';
+import { GetInferenceUseCase } from 'src/domain/models/application/use-cases/get-inference/get-inference.use-case';
+import { GetInferenceCommand } from 'src/domain/models/application/use-cases/get-inference/get-inference.command';
+import { InferenceResponse } from 'src/domain/models/application/ports/inference.handler';
+import { ModelToolChoice } from 'src/domain/models/domain/value-objects/model-tool-choice.enum';
+import { LanguageModel } from 'src/domain/models/domain/models/language.model';
+import { Message } from 'src/domain/messages/domain/message.entity';
+import { Tool } from 'src/domain/tools/domain/tool.entity';
+import {
+  AYUNIS_INFERENCE_DURATION_SECONDS,
+  AYUNIS_INFERENCE_ERRORS_TOTAL,
+} from 'src/metrics/metrics.constants';
+import { recordInferenceMetrics } from 'src/metrics/record-inference-metrics.helper';
+
+/**
+ * Executes non-streaming inference with metrics instrumentation.
+ */
+@Injectable()
+export class NonStreamingInferenceService {
+  private readonly logger = new Logger(NonStreamingInferenceService.name);
+
+  constructor(
+    private readonly getInferenceUseCase: GetInferenceUseCase,
+    @InjectMetric(AYUNIS_INFERENCE_DURATION_SECONDS)
+    private readonly inferenceHistogram: Histogram<string>,
+    @InjectMetric(AYUNIS_INFERENCE_ERRORS_TOTAL)
+    private readonly inferenceErrorsCounter: Counter<string>,
+  ) {}
+
+  async execute(params: {
+    model: LanguageModel;
+    messages: Message[];
+    tools: Tool[];
+    instructions?: string;
+  }): Promise<InferenceResponse> {
+    const startTime = Date.now();
+    const metricsOpts = {
+      histogram: this.inferenceHistogram,
+      errorCounter: this.inferenceErrorsCounter,
+      logger: this.logger,
+      model: params.model.name,
+      provider: params.model.provider,
+      streaming: 'false' as const,
+    };
+
+    let inferenceError: unknown;
+    try {
+      return await this.getInferenceUseCase.execute(
+        new GetInferenceCommand({
+          model: params.model,
+          messages: params.messages,
+          tools: params.tools,
+          toolChoice: ModelToolChoice.AUTO,
+          instructions: params.instructions,
+        }),
+      );
+    } catch (error) {
+      inferenceError = error;
+      throw error;
+    } finally {
+      recordInferenceMetrics(
+        metricsOpts,
+        Date.now() - startTime,
+        inferenceError,
+      );
+    }
+  }
+}

--- a/ayunis-core-backend/src/domain/runs/application/use-cases/execute-run/execute-run.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/runs/application/use-cases/execute-run/execute-run.use-case.spec.ts
@@ -7,7 +7,7 @@ import type { CreateAssistantMessageUseCase } from 'src/domain/messages/applicat
 import type { CreateToolResultMessageUseCase } from 'src/domain/messages/application/use-cases/create-tool-result-message/create-tool-result-message.use-case';
 import type { CreateUserMessageUseCase } from 'src/domain/messages/application/use-cases/create-user-message/create-user-message.use-case';
 import type { TrimMessagesForContextUseCase } from 'src/domain/messages/application/use-cases/trim-messages-for-context/trim-messages-for-context.use-case';
-import type { GetInferenceUseCase } from 'src/domain/models/application/use-cases/get-inference/get-inference.use-case';
+
 import type { LanguageModel } from 'src/domain/models/domain/models/language.model';
 import type { PermittedLanguageModel } from 'src/domain/models/domain/permitted-model.entity';
 import type { AddMessageToThreadUseCase } from 'src/domain/threads/application/use-cases/add-message-to-thread/add-message-to-thread.use-case';
@@ -21,8 +21,10 @@ import type { ToolAssemblyService } from '../../services/tool-assembly.service';
 import type { ToolResultCollectorService } from '../../services/tool-result-collector.service';
 import type { MessageCleanupService } from '../../services/message-cleanup.service';
 import type { StreamingInferenceService } from '../../services/streaming-inference.service';
+import type { NonStreamingInferenceService } from '../../services/non-streaming-inference.service';
 import type { SkillActivationService } from 'src/domain/skills/application/services/skill-activation.service';
 import type { AssistantMessage } from 'src/domain/messages/domain/messages/assistant-message.entity';
+import type { Counter } from 'prom-client';
 import { ToolResultMessageContent } from 'src/domain/messages/domain/message-contents/tool-result.message-content.entity';
 import { ToolType } from 'src/domain/tools/domain/value-objects/tool-type.enum';
 import { randomUUID } from 'crypto';
@@ -98,7 +100,6 @@ describe('ExecuteRunUseCase', () => {
       { execute: jest.fn() } as unknown as CreateUserMessageUseCase,
       { execute: jest.fn() } as unknown as CreateAssistantMessageUseCase,
       { execute: jest.fn() } as unknown as CreateToolResultMessageUseCase,
-      { execute: jest.fn() } as unknown as GetInferenceUseCase,
       findThreadUseCase,
       { execute: jest.fn() } as unknown as FindOneAgentUseCase,
       { execute: jest.fn() } as unknown as AddMessageToThreadUseCase,
@@ -115,9 +116,11 @@ describe('ExecuteRunUseCase', () => {
       {
         executeStreamingInference: jest.fn(),
       } as unknown as StreamingInferenceService,
+      { execute: jest.fn() } as unknown as NonStreamingInferenceService,
       {
         activateOnThread: jest.fn(),
       } as unknown as jest.Mocked<SkillActivationService>,
+      { inc: jest.fn() } as unknown as Counter<string>,
     );
   });
 

--- a/ayunis-core-backend/src/domain/runs/runs.module.ts
+++ b/ayunis-core-backend/src/domain/runs/runs.module.ts
@@ -12,6 +12,7 @@ import { ToolAssemblyService } from './application/services/tool-assembly.servic
 import { ToolResultCollectorService } from './application/services/tool-result-collector.service';
 import { MessageCleanupService } from './application/services/message-cleanup.service';
 import { StreamingInferenceService } from './application/services/streaming-inference.service';
+import { NonStreamingInferenceService } from './application/services/non-streaming-inference.service';
 import { CollectUsageAsyncService } from './application/services/collect-usage-async.service';
 import { SubscriptionsModule } from 'src/iam/subscriptions/subscriptions.module';
 import { TrialsModule } from 'src/iam/trials/trials.module';
@@ -49,6 +50,7 @@ import { ChatSettingsModule } from 'src/domain/chat-settings/chat-settings.modul
     ToolResultCollectorService,
     MessageCleanupService,
     StreamingInferenceService,
+    NonStreamingInferenceService,
     CollectUsageAsyncService,
   ],
   exports: [ExecuteRunUseCase, ExecuteRunAndSetTitleUseCase],

--- a/ayunis-core-backend/src/domain/threads/application/use-cases/add-message-to-thread/add-message-to-thread.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/threads/application/use-cases/add-message-to-thread/add-message-to-thread.use-case.spec.ts
@@ -1,0 +1,89 @@
+import type { TestingModule } from '@nestjs/testing';
+import { Test } from '@nestjs/testing';
+import { AddMessageToThreadUseCase } from './add-message-to-thread.use-case';
+import { AddMessageCommand } from './add-message.command';
+import { Thread } from '../../../domain/thread.entity';
+import { randomUUID } from 'crypto';
+import { ContextService } from 'src/common/context/services/context.service';
+import { getToken } from '@willsoto/nestjs-prometheus';
+import { AYUNIS_THREAD_MESSAGE_COUNT } from 'src/metrics/metrics.constants';
+import { AssistantMessage } from 'src/domain/messages/domain/messages/assistant-message.entity';
+
+describe('AddMessageToThreadUseCase', () => {
+  let useCase: AddMessageToThreadUseCase;
+  let mockContextService: Partial<ContextService>;
+  let mockHistogram: { observe: jest.Mock };
+
+  beforeAll(async () => {
+    mockContextService = {
+      get: jest.fn().mockReturnValue(randomUUID()),
+    };
+
+    mockHistogram = { observe: jest.fn() };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AddMessageToThreadUseCase,
+        { provide: ContextService, useValue: mockContextService },
+        {
+          provide: getToken(AYUNIS_THREAD_MESSAGE_COUNT),
+          useValue: mockHistogram,
+        },
+      ],
+    }).compile();
+
+    useCase = module.get<AddMessageToThreadUseCase>(AddMessageToThreadUseCase);
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (mockContextService.get as jest.Mock).mockReturnValue(randomUUID());
+  });
+
+  it('should be defined', () => {
+    expect(useCase).toBeDefined();
+  });
+
+  it('should add a message to the thread and observe the histogram', () => {
+    const thread = new Thread({
+      userId: randomUUID(),
+      messages: [],
+      isAnonymous: false,
+    });
+    const message = new AssistantMessage({
+      threadId: thread.id,
+      content: [],
+    });
+    const command = new AddMessageCommand(thread, message);
+
+    const result = useCase.execute(command);
+
+    expect(result.messages).toContain(message);
+    expect(result.messages).toHaveLength(1);
+    expect(mockHistogram.observe).toHaveBeenCalledWith(
+      expect.objectContaining({ user_id: expect.any(String) }),
+      1,
+    );
+  });
+
+  it('should observe correct message count for thread with existing messages', () => {
+    const existingMessage = new AssistantMessage({
+      threadId: randomUUID(),
+      content: [],
+    });
+    const thread = new Thread({
+      userId: randomUUID(),
+      messages: [existingMessage],
+      isAnonymous: false,
+    });
+    const newMessage = new AssistantMessage({
+      threadId: thread.id,
+      content: [],
+    });
+    const command = new AddMessageCommand(thread, newMessage);
+
+    useCase.execute(command);
+
+    expect(mockHistogram.observe).toHaveBeenCalledWith(expect.any(Object), 2);
+  });
+});

--- a/ayunis-core-backend/src/domain/threads/application/use-cases/add-message-to-thread/add-message-to-thread.use-case.ts
+++ b/ayunis-core-backend/src/domain/threads/application/use-cases/add-message-to-thread/add-message-to-thread.use-case.ts
@@ -1,11 +1,22 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { Histogram } from 'prom-client';
+import { InjectMetric } from '@willsoto/nestjs-prometheus';
 import { Thread } from '../../../domain/thread.entity';
 import { AddMessageCommand } from './add-message.command';
 import { MessageAdditionError } from '../../threads.errors';
+import { ContextService } from 'src/common/context/services/context.service';
+import { AYUNIS_THREAD_MESSAGE_COUNT } from 'src/metrics/metrics.constants';
+import { getUserContextLabels, safeMetric } from 'src/metrics/metrics.utils';
 
 @Injectable()
 export class AddMessageToThreadUseCase {
   private readonly logger = new Logger(AddMessageToThreadUseCase.name);
+
+  constructor(
+    private readonly contextService: ContextService,
+    @InjectMetric(AYUNIS_THREAD_MESSAGE_COUNT)
+    private readonly threadMessageHistogram: Histogram<string>,
+  ) {}
 
   execute(command: AddMessageCommand): Thread {
     this.logger.log('addMessage', {
@@ -14,6 +25,18 @@ export class AddMessageToThreadUseCase {
     });
     try {
       command.thread.messages.push(command.message);
+
+      // Observing on every message addition is intentional: it gives the
+      // distribution of thread sizes at write time. The _sum/_count ratio
+      // yields average thread length across all writes.
+      safeMetric(this.logger, () => {
+        const labels = getUserContextLabels(this.contextService);
+        this.threadMessageHistogram.observe(
+          labels,
+          command.thread.messages.length,
+        );
+      });
+
       return command.thread;
     } catch (error) {
       this.logger.error('Failed to add message to thread', {

--- a/ayunis-core-backend/src/metrics/SUMMARY.md
+++ b/ayunis-core-backend/src/metrics/SUMMARY.md
@@ -6,6 +6,9 @@ This module provides application-level Prometheus metrics for monitoring LLM usa
 **Key files:**
 - `metrics.module.ts` — NestJS module wiring. Registers `PrometheusModule` at the `/metrics` path and applies `MetricsAuthMiddleware` to protect it.
 - `metrics.constants.ts` — Single source of truth for metric names, label names, and the metrics endpoint path.
+- `metrics.utils.ts` — Shared helpers: `getUserContextLabels()` extracts user/org context for metric labels; `safeMetric()` wraps metric operations in try/catch to prevent metric failures from crashing business flows.
+- `classify-inference-error.helper.ts` — Pure classification function that maps inference errors to Prometheus-friendly `error_type` label values (timeout, rate_limit, server_error, etc.).
+- `record-inference-metrics.helper.ts` — Records inference duration histogram and error counter in a single call. Used by both streaming and non-streaming inference paths.
 - `metrics-auth.middleware.ts` — NestMiddleware implementing HTTP Basic Auth for the metrics endpoint. Credentials come from `ConfigService` (`metrics.user` / `metrics.password`). Uses timing-safe comparison to prevent side-channel attacks.
 
 **Configuration:**

--- a/ayunis-core-backend/src/metrics/classify-inference-error.helper.spec.ts
+++ b/ayunis-core-backend/src/metrics/classify-inference-error.helper.spec.ts
@@ -1,0 +1,272 @@
+import { classifyInferenceError } from './classify-inference-error.helper';
+
+describe('classifyInferenceError', () => {
+  describe('timeout errors', () => {
+    it('should classify "timeout" message as timeout', () => {
+      expect(classifyInferenceError(new Error('Request timeout'))).toBe(
+        'timeout',
+      );
+    });
+
+    it('should classify "timed out" message as timeout', () => {
+      expect(classifyInferenceError(new Error('Connection timed out'))).toBe(
+        'timeout',
+      );
+    });
+
+    it('should classify status 408 as timeout', () => {
+      const error = Object.assign(new Error('Request Timeout'), {
+        status: 408,
+      });
+      expect(classifyInferenceError(error)).toBe('timeout');
+    });
+
+    it('should classify status 504 as timeout', () => {
+      const error = Object.assign(new Error('Gateway Timeout'), {
+        status: 504,
+      });
+      expect(classifyInferenceError(error)).toBe('timeout');
+    });
+
+    it('should classify "408" in message as timeout', () => {
+      expect(
+        classifyInferenceError(new Error('HTTP 408 Request Timeout')),
+      ).toBe('timeout');
+    });
+
+    it('should classify "504" in message as timeout', () => {
+      expect(
+        classifyInferenceError(new Error('HTTP 504 Gateway Timeout')),
+      ).toBe('timeout');
+    });
+  });
+
+  describe('rate limit errors', () => {
+    it('should classify "rate limit" message as rate_limit', () => {
+      expect(classifyInferenceError(new Error('Rate limit exceeded'))).toBe(
+        'rate_limit',
+      );
+    });
+
+    it('should classify status 429 as rate_limit', () => {
+      const error = Object.assign(new Error('Too many requests'), {
+        status: 429,
+      });
+      expect(classifyInferenceError(error)).toBe('rate_limit');
+    });
+  });
+
+  describe('server errors', () => {
+    it('should classify "503" in message as server_error', () => {
+      expect(classifyInferenceError(new Error('503 Service Unavailable'))).toBe(
+        'server_error',
+      );
+    });
+
+    it('should classify "502" in message as server_error', () => {
+      expect(classifyInferenceError(new Error('502 Bad Gateway'))).toBe(
+        'server_error',
+      );
+    });
+
+    it('should classify "500" in message as server_error', () => {
+      expect(
+        classifyInferenceError(new Error('500 Internal Server Error')),
+      ).toBe('server_error');
+    });
+
+    it('should classify status 500 as server_error', () => {
+      const error = Object.assign(new Error('Internal Server Error'), {
+        status: 500,
+      });
+      expect(classifyInferenceError(error)).toBe('server_error');
+    });
+
+    it('should classify status 502 as server_error', () => {
+      const error = Object.assign(new Error('Bad Gateway'), { status: 502 });
+      expect(classifyInferenceError(error)).toBe('server_error');
+    });
+
+    it('should classify status 503 as server_error', () => {
+      const error = Object.assign(new Error('Unavailable'), { status: 503 });
+      expect(classifyInferenceError(error)).toBe('server_error');
+    });
+
+    it('should NOT classify message containing "502" as substring in a number', () => {
+      expect(
+        classifyInferenceError(new Error('processed 50200 items')),
+      ).not.toBe('server_error');
+    });
+
+    it('should NOT classify message containing "500" as substring in a number', () => {
+      expect(
+        classifyInferenceError(new Error('processed 50000 items')),
+      ).not.toBe('server_error');
+    });
+  });
+
+  describe('auth errors', () => {
+    it('should classify status 401 as auth_error', () => {
+      const error = Object.assign(new Error('Unauthorized'), { status: 401 });
+      expect(classifyInferenceError(error)).toBe('auth_error');
+    });
+
+    it('should classify status 403 as auth_error', () => {
+      const error = Object.assign(new Error('Forbidden'), { status: 403 });
+      expect(classifyInferenceError(error)).toBe('auth_error');
+    });
+
+    it('should classify "401" in message as auth_error', () => {
+      expect(classifyInferenceError(new Error('HTTP 401 Unauthorized'))).toBe(
+        'auth_error',
+      );
+    });
+
+    it('should classify "403" in message as auth_error', () => {
+      expect(classifyInferenceError(new Error('HTTP 403 Forbidden'))).toBe(
+        'auth_error',
+      );
+    });
+
+    it('should classify code property 401 as auth_error', () => {
+      const error = { code: 401, message: 'Unauthorized' };
+      expect(classifyInferenceError(error)).toBe('auth_error');
+    });
+
+    it('should NOT classify message containing "403" as substring in a number', () => {
+      expect(
+        classifyInferenceError(new Error('token count 14032 exceeds limit')),
+      ).not.toBe('auth_error');
+    });
+
+    it('should NOT classify message containing "401" as substring in a number', () => {
+      expect(
+        classifyInferenceError(new Error('request id 94013 failed')),
+      ).not.toBe('auth_error');
+    });
+  });
+
+  describe('context length errors', () => {
+    it('should classify "context length" message as context_length', () => {
+      expect(
+        classifyInferenceError(
+          new Error("This model's maximum context length is 4096 tokens"),
+        ),
+      ).toBe('context_length');
+    });
+
+    it('should classify "context_length" message as context_length', () => {
+      expect(classifyInferenceError(new Error('context_length_exceeded'))).toBe(
+        'context_length',
+      );
+    });
+
+    it('should classify "too many tokens" as context_length', () => {
+      expect(
+        classifyInferenceError(new Error('Too many tokens in request')),
+      ).toBe('context_length');
+    });
+
+    it('should classify "maximum context" as context_length', () => {
+      expect(
+        classifyInferenceError(new Error('Exceeded maximum context window')),
+      ).toBe('context_length');
+    });
+  });
+
+  describe('content policy errors', () => {
+    it('should classify "content policy" message as content_policy', () => {
+      expect(
+        classifyInferenceError(new Error('Content policy violation')),
+      ).toBe('content_policy');
+    });
+
+    it('should classify "content_policy" message as content_policy', () => {
+      expect(
+        classifyInferenceError(new Error('content_policy_violation')),
+      ).toBe('content_policy');
+    });
+
+    it('should classify "content filter" as content_policy', () => {
+      expect(
+        classifyInferenceError(new Error('Blocked by content filter')),
+      ).toBe('content_policy');
+    });
+
+    it('should classify "content moderation" as content_policy', () => {
+      expect(
+        classifyInferenceError(new Error('Flagged by content moderation')),
+      ).toBe('content_policy');
+    });
+  });
+
+  describe('connection errors', () => {
+    it('should classify ECONNREFUSED as connection_error', () => {
+      expect(
+        classifyInferenceError(new Error('connect ECONNREFUSED 127.0.0.1')),
+      ).toBe('connection_error');
+    });
+
+    it('should classify ECONNRESET as connection_error', () => {
+      expect(classifyInferenceError(new Error('read ECONNRESET'))).toBe(
+        'connection_error',
+      );
+    });
+  });
+
+  describe('unknown errors', () => {
+    it('should return unknown for non-Error values', () => {
+      expect(classifyInferenceError('string error')).toBe('unknown');
+    });
+
+    it('should return unknown for null', () => {
+      expect(classifyInferenceError(null)).toBe('unknown');
+    });
+
+    it('should return unknown for undefined', () => {
+      expect(classifyInferenceError(undefined)).toBe('unknown');
+    });
+
+    it('should return unknown for unrecognized error messages', () => {
+      expect(classifyInferenceError(new Error('Something went wrong'))).toBe(
+        'unknown',
+      );
+    });
+  });
+
+  describe('structured error objects with status/code', () => {
+    it('should prioritize status code over message content', () => {
+      const error = Object.assign(new Error('Request timeout'), {
+        status: 401,
+      });
+      expect(classifyInferenceError(error)).toBe('auth_error');
+    });
+
+    it('should handle plain objects with status property', () => {
+      expect(classifyInferenceError({ status: 429 })).toBe('rate_limit');
+    });
+
+    it('should handle plain objects with code property', () => {
+      expect(classifyInferenceError({ code: 503 })).toBe('server_error');
+    });
+
+    it('should classify plain object with message property via message rules', () => {
+      expect(
+        classifyInferenceError({
+          status: 418,
+          message: 'rate limit exceeded',
+        }),
+      ).toBe('rate_limit');
+    });
+
+    it('should classify plain object with message but no status code', () => {
+      expect(classifyInferenceError({ message: 'Connection timed out' })).toBe(
+        'timeout',
+      );
+    });
+
+    it('should return unknown for plain object without message property', () => {
+      expect(classifyInferenceError({ foo: 'bar' })).toBe('unknown');
+    });
+  });
+});

--- a/ayunis-core-backend/src/metrics/classify-inference-error.helper.ts
+++ b/ayunis-core-backend/src/metrics/classify-inference-error.helper.ts
@@ -1,0 +1,113 @@
+/**
+ * Known inference error types used as Prometheus `error_type` label values.
+ */
+export type InferenceErrorType =
+  | 'timeout'
+  | 'rate_limit'
+  | 'server_error'
+  | 'auth_error'
+  | 'context_length'
+  | 'content_policy'
+  | 'connection_error'
+  | 'unknown';
+
+/**
+ * Extracts a numeric status code from a structured error object.
+ * Provider SDKs (OpenAI, Anthropic) attach `status` or `code` properties.
+ */
+function extractStatusCode(error: unknown): number | undefined {
+  if (typeof error !== 'object' || error === null) return undefined;
+  const record = error as Record<string, unknown>;
+  if (typeof record['status'] === 'number') return record['status'];
+  if (typeof record['code'] === 'number') return record['code'];
+  return undefined;
+}
+
+interface StatusRule {
+  test: (status: number) => boolean;
+  category: InferenceErrorType;
+}
+
+const STATUS_RULES: StatusRule[] = [
+  { test: (s) => s === 401 || s === 403, category: 'auth_error' },
+  { test: (s) => s === 408 || s === 504, category: 'timeout' },
+  { test: (s) => s === 429, category: 'rate_limit' },
+  {
+    test: (s) => s === 500 || s === 502 || s === 503,
+    category: 'server_error',
+  },
+];
+
+interface MessageRule {
+  test: (msg: string) => boolean;
+  category: InferenceErrorType;
+}
+
+const MESSAGE_RULES: MessageRule[] = [
+  {
+    test: (m) => m.includes('timeout') || m.includes('timed out'),
+    category: 'timeout',
+  },
+  {
+    test: (m) => m.includes('rate') && m.includes('limit'),
+    category: 'rate_limit',
+  },
+  {
+    test: (m) => /\b500\b/.test(m) || /\b502\b/.test(m) || /\b503\b/.test(m),
+    category: 'server_error',
+  },
+  { test: (m) => /\b408\b/.test(m) || /\b504\b/.test(m), category: 'timeout' },
+  {
+    test: (m) => /\b401\b/.test(m) || /\b403\b/.test(m),
+    category: 'auth_error',
+  },
+  {
+    test: (m) =>
+      m.includes('context length') ||
+      m.includes('context_length') ||
+      m.includes('too many tokens') ||
+      m.includes('maximum context'),
+    category: 'context_length',
+  },
+  {
+    test: (m) =>
+      m.includes('content policy') ||
+      m.includes('content_policy') ||
+      m.includes('content filter') ||
+      m.includes('content moderation'),
+    category: 'content_policy',
+  },
+  {
+    test: (m) => m.includes('econnrefused') || m.includes('econnreset'),
+    category: 'connection_error',
+  },
+];
+
+/**
+ * Extracts a message string from a structured error object.
+ * Handles both Error instances and plain objects with a `message` property.
+ */
+function extractMessage(error: unknown): string | undefined {
+  if (error instanceof Error) return error.message;
+  if (typeof error !== 'object' || error === null) return undefined;
+  if (!('message' in error)) return undefined;
+  const msg = (error as Record<string, unknown>)['message'];
+  return typeof msg === 'string' ? msg : undefined;
+}
+
+/**
+ * Classifies an inference error into a Prometheus-friendly error_type label.
+ */
+export function classifyInferenceError(error: unknown): InferenceErrorType {
+  const status = extractStatusCode(error);
+  if (status !== undefined) {
+    const statusMatch = STATUS_RULES.find((r) => r.test(status));
+    if (statusMatch) return statusMatch.category;
+  }
+
+  const rawMessage = extractMessage(error);
+  if (rawMessage === undefined) return 'unknown';
+  const message = rawMessage.toLowerCase();
+
+  return MESSAGE_RULES.find((r) => r.test(message))?.category ?? 'unknown';
+}

--- a/ayunis-core-backend/src/metrics/metrics.constants.ts
+++ b/ayunis-core-backend/src/metrics/metrics.constants.ts
@@ -26,3 +26,4 @@ export const LABEL_PROVIDER = 'provider';
 export const LABEL_DIRECTION = 'direction';
 export const LABEL_ROLE = 'role';
 export const LABEL_ERROR_TYPE = 'error_type';
+export const LABEL_STREAMING = 'streaming';

--- a/ayunis-core-backend/src/metrics/metrics.module.ts
+++ b/ayunis-core-backend/src/metrics/metrics.module.ts
@@ -19,6 +19,7 @@ import {
   LABEL_DIRECTION,
   LABEL_ROLE,
   LABEL_ERROR_TYPE,
+  LABEL_STREAMING,
 } from './metrics.constants';
 import { MetricsAuthMiddleware } from './metrics-auth.middleware';
 
@@ -37,14 +38,14 @@ const tokensCounter = makeCounterProvider({
 const inferenceDurationHistogram = makeHistogramProvider({
   name: AYUNIS_INFERENCE_DURATION_SECONDS,
   help: 'Duration of LLM inference calls in seconds',
-  labelNames: [LABEL_MODEL, LABEL_PROVIDER],
+  labelNames: [LABEL_MODEL, LABEL_PROVIDER, LABEL_STREAMING],
   buckets: [0.1, 0.5, 1, 2, 5, 10, 30, 60, 120],
 });
 
 const inferenceErrorsCounter = makeCounterProvider({
   name: AYUNIS_INFERENCE_ERRORS_TOTAL,
   help: 'Total number of LLM inference errors',
-  labelNames: [LABEL_MODEL, LABEL_PROVIDER, LABEL_ERROR_TYPE],
+  labelNames: [LABEL_MODEL, LABEL_PROVIDER, LABEL_ERROR_TYPE, LABEL_STREAMING],
 });
 
 const messagesCounter = makeCounterProvider({

--- a/ayunis-core-backend/src/metrics/metrics.utils.spec.ts
+++ b/ayunis-core-backend/src/metrics/metrics.utils.spec.ts
@@ -1,0 +1,55 @@
+import { Logger } from '@nestjs/common';
+import { safeMetric, getUserContextLabels } from './metrics.utils';
+import type { ContextService } from 'src/common/context/services/context.service';
+
+describe('safeMetric', () => {
+  const logger = new Logger('TestLogger');
+
+  beforeEach(() => {
+    jest.spyOn(logger, 'warn').mockImplementation();
+  });
+
+  it('should execute the metric function', () => {
+    const fn = jest.fn();
+    safeMetric(logger, fn);
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('should swallow errors and log a warning', () => {
+    const fn = jest.fn().mockImplementation(() => {
+      throw new Error('metric boom');
+    });
+    expect(() => safeMetric(logger, fn)).not.toThrow();
+    expect(logger.warn).toHaveBeenCalledWith('Metric recording failed', {
+      error: expect.any(Error),
+    });
+  });
+});
+
+describe('getUserContextLabels', () => {
+  it('should return user_id and org_id from context', () => {
+    const contextService = {
+      get: jest.fn((key: string) => {
+        if (key === 'userId') return 'user-123';
+        if (key === 'orgId') return 'org-456';
+        return undefined;
+      }),
+    } as unknown as ContextService;
+
+    expect(getUserContextLabels(contextService)).toEqual({
+      user_id: 'user-123',
+      org_id: 'org-456',
+    });
+  });
+
+  it('should fall back to unknown when context is unavailable', () => {
+    const contextService = {
+      get: jest.fn().mockReturnValue(undefined),
+    } as unknown as ContextService;
+
+    expect(getUserContextLabels(contextService)).toEqual({
+      user_id: 'unknown',
+      org_id: 'unknown',
+    });
+  });
+});

--- a/ayunis-core-backend/src/metrics/metrics.utils.ts
+++ b/ayunis-core-backend/src/metrics/metrics.utils.ts
@@ -1,0 +1,31 @@
+import type { Logger } from '@nestjs/common';
+import type { ContextService } from 'src/common/context/services/context.service';
+
+/**
+ * Extracts common metric labels from the request context.
+ * Falls back to 'unknown' when context values are unavailable
+ * (e.g., in background jobs or during context propagation failures).
+ */
+export function getUserContextLabels(contextService: ContextService): {
+  user_id: string;
+  org_id: string;
+} {
+  return {
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- undefined at runtime when context not propagated
+    user_id: contextService.get('userId') ?? 'unknown',
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- undefined at runtime when context not propagated
+    org_id: contextService.get('orgId') ?? 'unknown',
+  };
+}
+
+/**
+ * Wraps a metric operation in a try/catch so that metric failures
+ * never crash the main business flow. Logs a warning on failure.
+ */
+export function safeMetric(logger: Logger, fn: () => void): void {
+  try {
+    fn();
+  } catch (error) {
+    logger.warn('Metric recording failed', { error: error as Error });
+  }
+}

--- a/ayunis-core-backend/src/metrics/record-inference-metrics.helper.spec.ts
+++ b/ayunis-core-backend/src/metrics/record-inference-metrics.helper.spec.ts
@@ -1,0 +1,73 @@
+import { Logger } from '@nestjs/common';
+import type { RecordInferenceMetricsOptions } from './record-inference-metrics.helper';
+import { recordInferenceMetrics } from './record-inference-metrics.helper';
+
+describe('recordInferenceMetrics', () => {
+  const logger = new Logger('TestLogger');
+  let histogram: { observe: jest.Mock };
+  let errorCounter: { inc: jest.Mock };
+
+  beforeEach(() => {
+    histogram = { observe: jest.fn() };
+    errorCounter = { inc: jest.fn() };
+    jest.spyOn(logger, 'warn').mockImplementation();
+  });
+
+  function makeOpts(
+    overrides?: Partial<RecordInferenceMetricsOptions>,
+  ): RecordInferenceMetricsOptions {
+    return {
+      histogram: histogram as never,
+      errorCounter: errorCounter as never,
+      logger,
+      model: 'gpt-4',
+      provider: 'openai',
+      streaming: 'false',
+      ...overrides,
+    };
+  }
+
+  it('should observe duration on the histogram', () => {
+    recordInferenceMetrics(makeOpts(), 1500);
+    expect(histogram.observe).toHaveBeenCalledWith(
+      { model: 'gpt-4', provider: 'openai', streaming: 'false' },
+      1.5,
+    );
+    expect(errorCounter.inc).not.toHaveBeenCalled();
+  });
+
+  it('should increment error counter when error is provided', () => {
+    const error = Object.assign(new Error('timeout'), { status: 429 });
+    recordInferenceMetrics(makeOpts(), 2000, error);
+    expect(errorCounter.inc).toHaveBeenCalledWith({
+      model: 'gpt-4',
+      provider: 'openai',
+      error_type: 'rate_limit',
+      streaming: 'false',
+    });
+  });
+
+  it('should pass streaming string label through', () => {
+    recordInferenceMetrics(makeOpts({ streaming: 'true' }), 500);
+    expect(histogram.observe).toHaveBeenCalledWith(
+      expect.objectContaining({ streaming: 'true' }),
+      0.5,
+    );
+  });
+
+  it('should not throw when histogram.observe fails', () => {
+    histogram.observe.mockImplementation(() => {
+      throw new Error('prom broken');
+    });
+    expect(() => recordInferenceMetrics(makeOpts(), 100)).not.toThrow();
+  });
+
+  it('should not throw when error counter fails', () => {
+    errorCounter.inc.mockImplementation(() => {
+      throw new Error('prom broken');
+    });
+    expect(() =>
+      recordInferenceMetrics(makeOpts(), 100, new Error('some error')),
+    ).not.toThrow();
+  });
+});

--- a/ayunis-core-backend/src/metrics/record-inference-metrics.helper.ts
+++ b/ayunis-core-backend/src/metrics/record-inference-metrics.helper.ts
@@ -1,0 +1,45 @@
+import type { Logger } from '@nestjs/common';
+import type { Counter, Histogram } from 'prom-client';
+import { classifyInferenceError } from './classify-inference-error.helper';
+import { safeMetric } from './metrics.utils';
+
+export interface RecordInferenceMetricsOptions {
+  histogram: Histogram<string>;
+  errorCounter: Counter<string>;
+  logger: Logger;
+  model: string;
+  provider: string;
+  streaming: 'true' | 'false';
+}
+
+/**
+ * Records inference duration and (optionally) error classification metrics.
+ * Designed to be called from a `finally` block after inference completes.
+ */
+export function recordInferenceMetrics(
+  opts: RecordInferenceMetricsOptions,
+  durationMs: number,
+  error?: unknown,
+): void {
+  safeMetric(opts.logger, () => {
+    opts.histogram.observe(
+      {
+        model: opts.model,
+        provider: opts.provider,
+        streaming: opts.streaming,
+      },
+      durationMs / 1000,
+    );
+  });
+
+  if (error) {
+    safeMetric(opts.logger, () => {
+      opts.errorCounter.inc({
+        model: opts.model,
+        provider: opts.provider,
+        error_type: classifyInferenceError(error),
+        streaming: opts.streaming,
+      });
+    });
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches core run execution and messaging/inference paths by adding new DI dependencies and side-effect metric recording; failures are guarded via `safeMetric`, but misconfigured metric providers/labels could still impact runtime wiring.
> 
> **Overview**
> Adds **Prometheus metrics instrumentation** across key domain flows: message creation/saving now increments `AYUNIS_MESSAGES_TOTAL` with user/org context labels, and adding a message to a thread records `AYUNIS_THREAD_MESSAGE_COUNT` as a histogram observation.
> 
> Refactors run execution to increment a new **DAU-style** `AYUNIS_USER_ACTIVITY_TOTAL` counter at the start of `ExecuteRunUseCase`, and routes non-streaming inference through a new `NonStreamingInferenceService` that records duration and classified errors; streaming inference is similarly instrumented, adding a new `streaming` label to inference duration/error metrics.
> 
> Introduces shared metrics utilities (`safeMetric`, `getUserContextLabels`), inference error classification (`classifyInferenceError`), and a `recordInferenceMetrics` helper, plus corresponding unit tests and updates to metrics module label definitions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 046c44672800ce057ec91e9d0e454874b1ad4d19. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->