### PR TITLE
wip(AYC-99): add KB share authorization strategy and access service

### DIFF
--- a/ayunis-core-backend/src/domain/knowledge-bases/application/services/knowledge-base-access.service.spec.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/application/services/knowledge-base-access.service.spec.ts
@@ -1,0 +1,229 @@
+import type { TestingModule } from '@nestjs/testing';
+import { Test } from '@nestjs/testing';
+import { Logger } from '@nestjs/common';
+import { KnowledgeBaseAccessService } from './knowledge-base-access.service';
+import { KnowledgeBaseRepository } from '../ports/knowledge-base.repository';
+import { FindShareByEntityUseCase } from 'src/domain/shares/application/use-cases/find-share-by-entity/find-share-by-entity.use-case';
+import { FindSharesByScopeUseCase } from 'src/domain/shares/application/use-cases/find-shares-by-scope/find-shares-by-scope.use-case';
+import { ContextService } from 'src/common/context/services/context.service';
+import { KnowledgeBase } from '../../domain/knowledge-base.entity';
+import { KnowledgeBaseNotFoundError } from '../knowledge-bases.errors';
+import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
+import type { Share } from 'src/domain/shares/domain/share.entity';
+import type { UUID } from 'crypto';
+
+describe('KnowledgeBaseAccessService', () => {
+  let service: KnowledgeBaseAccessService;
+  let knowledgeBaseRepository: jest.Mocked<KnowledgeBaseRepository>;
+  let findShareByEntityUseCase: jest.Mocked<FindShareByEntityUseCase>;
+  let findSharesByScopeUseCase: jest.Mocked<FindSharesByScopeUseCase>;
+  let contextService: jest.Mocked<ContextService>;
+
+  const userId = '123e4567-e89b-12d3-a456-426614174000' as UUID;
+  const otherUserId = '223e4567-e89b-12d3-a456-426614174001' as UUID;
+  const orgId = '333e4567-e89b-12d3-a456-426614174002' as UUID;
+  const kbId = '550e8400-e29b-41d4-a716-446655440000' as UUID;
+
+  const makeKb = (id: UUID = kbId, owner: UUID = userId) =>
+    new KnowledgeBase({
+      id,
+      name: 'Test KB',
+      description: 'Test description',
+      orgId,
+      userId: owner,
+    });
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        KnowledgeBaseAccessService,
+        {
+          provide: KnowledgeBaseRepository,
+          useValue: {
+            findById: jest.fn(),
+            findByIds: jest.fn(),
+            findAllByUserId: jest.fn(),
+            save: jest.fn(),
+            delete: jest.fn(),
+            assignSourceToKnowledgeBase: jest.fn(),
+            findSourcesByKnowledgeBaseId: jest.fn(),
+            findSourceByIdAndKnowledgeBaseId: jest.fn(),
+          },
+        },
+        {
+          provide: FindShareByEntityUseCase,
+          useValue: { execute: jest.fn() },
+        },
+        {
+          provide: FindSharesByScopeUseCase,
+          useValue: { execute: jest.fn() },
+        },
+        {
+          provide: ContextService,
+          useValue: {
+            get: jest.fn((key: string) => {
+              if (key === 'userId') return userId;
+              return undefined;
+            }),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get(KnowledgeBaseAccessService);
+    knowledgeBaseRepository = module.get(KnowledgeBaseRepository);
+    findShareByEntityUseCase = module.get(FindShareByEntityUseCase);
+    findSharesByScopeUseCase = module.get(FindSharesByScopeUseCase);
+    contextService = module.get(ContextService);
+
+    jest.spyOn(Logger.prototype, 'log').mockImplementation();
+    jest.spyOn(Logger.prototype, 'debug').mockImplementation();
+    jest.spyOn(Logger.prototype, 'error').mockImplementation();
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  describe('findAccessibleKnowledgeBase', () => {
+    it('should return owned KB without checking shares', async () => {
+      const kb = makeKb();
+      knowledgeBaseRepository.findById.mockResolvedValue(kb);
+
+      const result = await service.findAccessibleKnowledgeBase(kbId);
+
+      expect(result).toBe(kb);
+      expect(findShareByEntityUseCase.execute).not.toHaveBeenCalled();
+    });
+
+    it('should return shared KB when not owned', async () => {
+      const sharedKb = makeKb(kbId, otherUserId);
+      knowledgeBaseRepository.findById
+        .mockResolvedValueOnce(sharedKb) // first call: ownership check
+        .mockResolvedValueOnce(sharedKb); // second call: fetch after share check
+      findShareByEntityUseCase.execute.mockResolvedValue({} as never);
+
+      const result = await service.findAccessibleKnowledgeBase(kbId);
+
+      expect(result).toBe(sharedKb);
+    });
+
+    it('should throw KnowledgeBaseNotFoundError when KB is not owned or shared', async () => {
+      knowledgeBaseRepository.findById.mockResolvedValue(null);
+      findShareByEntityUseCase.execute.mockResolvedValue(null);
+
+      await expect(service.findAccessibleKnowledgeBase(kbId)).rejects.toThrow(
+        KnowledgeBaseNotFoundError,
+      );
+    });
+
+    it('should throw UnauthorizedAccessError when no user in context', async () => {
+      contextService.get.mockReturnValue(undefined);
+
+      await expect(service.findAccessibleKnowledgeBase(kbId)).rejects.toThrow(
+        UnauthorizedAccessError,
+      );
+    });
+  });
+
+  describe('resolveIsShared', () => {
+    it('should return false when user owns the KB', async () => {
+      const kb = makeKb();
+      knowledgeBaseRepository.findById.mockResolvedValue(kb);
+
+      const result = await service.resolveIsShared(kbId, userId);
+
+      expect(result).toBe(false);
+      expect(findShareByEntityUseCase.execute).not.toHaveBeenCalled();
+    });
+
+    it('should return true when KB is shared with user', async () => {
+      const kb = makeKb(kbId, otherUserId);
+      knowledgeBaseRepository.findById.mockResolvedValue(kb);
+      findShareByEntityUseCase.execute.mockResolvedValue({} as never);
+
+      const result = await service.resolveIsShared(kbId, userId);
+
+      expect(result).toBe(true);
+    });
+
+    it('should return false when KB is neither owned nor shared', async () => {
+      knowledgeBaseRepository.findById.mockResolvedValue(null);
+      findShareByEntityUseCase.execute.mockResolvedValue(null);
+
+      const result = await service.resolveIsShared(kbId, userId);
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('findAllAccessible', () => {
+    it('should return owned KBs with isShared=false', async () => {
+      const kb = makeKb();
+      knowledgeBaseRepository.findAllByUserId.mockResolvedValue([kb]);
+      findSharesByScopeUseCase.execute.mockResolvedValue([]);
+
+      const result = await service.findAllAccessible();
+
+      expect(result).toHaveLength(1);
+      expect(result[0].knowledgeBase).toBe(kb);
+      expect(result[0].isShared).toBe(false);
+    });
+
+    it('should return shared KBs with isShared=true', async () => {
+      const sharedKbId = '660e8400-e29b-41d4-a716-446655440001' as UUID;
+      const sharedKb = makeKb(sharedKbId, otherUserId);
+      const share = { entityId: sharedKbId } as Share;
+
+      knowledgeBaseRepository.findAllByUserId.mockResolvedValue([]);
+      findSharesByScopeUseCase.execute.mockResolvedValue([share]);
+      knowledgeBaseRepository.findByIds.mockResolvedValue([sharedKb]);
+
+      const result = await service.findAllAccessible();
+
+      expect(result).toHaveLength(1);
+      expect(result[0].knowledgeBase).toBe(sharedKb);
+      expect(result[0].isShared).toBe(true);
+    });
+
+    it('should deduplicate owned vs shared KBs', async () => {
+      const kb = makeKb();
+      const share = { entityId: kbId } as Share;
+
+      knowledgeBaseRepository.findAllByUserId.mockResolvedValue([kb]);
+      findSharesByScopeUseCase.execute.mockResolvedValue([share]);
+
+      const result = await service.findAllAccessible();
+
+      expect(result).toHaveLength(1);
+      expect(result[0].knowledgeBase).toBe(kb);
+      expect(result[0].isShared).toBe(false);
+      expect(knowledgeBaseRepository.findByIds).not.toHaveBeenCalled();
+    });
+
+    it('should combine owned and shared KBs', async () => {
+      const ownedKb = makeKb();
+      const sharedKbId = '660e8400-e29b-41d4-a716-446655440001' as UUID;
+      const sharedKb = makeKb(sharedKbId, otherUserId);
+      const share = { entityId: sharedKbId } as Share;
+
+      knowledgeBaseRepository.findAllByUserId.mockResolvedValue([ownedKb]);
+      findSharesByScopeUseCase.execute.mockResolvedValue([share]);
+      knowledgeBaseRepository.findByIds.mockResolvedValue([sharedKb]);
+
+      const result = await service.findAllAccessible();
+
+      expect(result).toHaveLength(2);
+      expect(result[0].knowledgeBase).toBe(ownedKb);
+      expect(result[0].isShared).toBe(false);
+      expect(result[1].knowledgeBase).toBe(sharedKb);
+      expect(result[1].isShared).toBe(true);
+    });
+
+    it('should throw UnauthorizedAccessError when no user in context', async () => {
+      contextService.get.mockReturnValue(undefined);
+
+      await expect(service.findAllAccessible()).rejects.toThrow(
+        UnauthorizedAccessError,
+      );
+    });
+  });
+});

--- a/ayunis-core-backend/src/domain/knowledge-bases/application/services/knowledge-base-access.service.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/application/services/knowledge-base-access.service.ts
@@ -1,0 +1,130 @@
+import { Injectable, Logger } from '@nestjs/common';
+import type { UUID } from 'crypto';
+import { KnowledgeBaseRepository } from '../ports/knowledge-base.repository';
+import { FindShareByEntityUseCase } from 'src/domain/shares/application/use-cases/find-share-by-entity/find-share-by-entity.use-case';
+import { FindShareByEntityQuery } from 'src/domain/shares/application/use-cases/find-share-by-entity/find-share-by-entity.query';
+import { FindSharesByScopeUseCase } from 'src/domain/shares/application/use-cases/find-shares-by-scope/find-shares-by-scope.use-case';
+import { FindSharesByScopeQuery } from 'src/domain/shares/application/use-cases/find-shares-by-scope/find-shares-by-scope.query';
+import { SharedEntityType } from 'src/domain/shares/domain/value-objects/shared-entity-type.enum';
+import { ContextService } from 'src/common/context/services/context.service';
+import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
+import { KnowledgeBaseNotFoundError } from '../knowledge-bases.errors';
+import type { KnowledgeBase } from '../../domain/knowledge-base.entity';
+
+export interface KnowledgeBaseWithShareStatus {
+  knowledgeBase: KnowledgeBase;
+  isShared: boolean;
+}
+
+@Injectable()
+export class KnowledgeBaseAccessService {
+  private readonly logger = new Logger(KnowledgeBaseAccessService.name);
+
+  constructor(
+    private readonly knowledgeBaseRepository: KnowledgeBaseRepository,
+    private readonly findShareByEntityUseCase: FindShareByEntityUseCase,
+    private readonly findSharesByScopeUseCase: FindSharesByScopeUseCase,
+    private readonly contextService: ContextService,
+  ) {}
+
+  /**
+   * Finds a knowledge base accessible to the current user (owned or shared).
+   * Throws KnowledgeBaseNotFoundError if the KB doesn't exist or isn't accessible.
+   */
+  async findAccessibleKnowledgeBase(id: UUID): Promise<KnowledgeBase> {
+    const userId = this.contextService.get('userId');
+    if (!userId) {
+      throw new UnauthorizedAccessError();
+    }
+
+    // Try owned KB first
+    const ownedKb = await this.knowledgeBaseRepository.findById(id);
+    if (ownedKb?.userId === userId) {
+      return ownedKb;
+    }
+
+    // If not owned, check if shared with user
+    const share = await this.findShareByEntityUseCase.execute(
+      new FindShareByEntityQuery(SharedEntityType.KNOWLEDGE_BASE, id),
+    );
+
+    if (share && ownedKb) {
+      return ownedKb;
+    }
+
+    throw new KnowledgeBaseNotFoundError(id);
+  }
+
+  /**
+   * Resolves whether a knowledge base is shared with the given user.
+   * Returns false for KB owners, even if the KB has been shared.
+   */
+  async resolveIsShared(kbId: UUID, userId: UUID): Promise<boolean> {
+    const kb = await this.knowledgeBaseRepository.findById(kbId);
+    if (kb?.userId === userId) {
+      return false;
+    }
+
+    const share = await this.findShareByEntityUseCase.execute(
+      new FindShareByEntityQuery(SharedEntityType.KNOWLEDGE_BASE, kbId),
+    );
+    return share !== null;
+  }
+
+  /**
+   * Finds all knowledge bases accessible to the current user (owned + shared).
+   * Returns each KB with an isShared flag.
+   */
+  async findAllAccessible(): Promise<KnowledgeBaseWithShareStatus[]> {
+    const userId = this.contextService.get('userId');
+    if (!userId) {
+      throw new UnauthorizedAccessError();
+    }
+
+    // 1. Fetch owned KBs and shares in parallel
+    const [ownedKbs, shares] = await Promise.all([
+      this.knowledgeBaseRepository.findAllByUserId(userId),
+      this.findSharesByScopeUseCase.execute(
+        new FindSharesByScopeQuery(SharedEntityType.KNOWLEDGE_BASE),
+      ),
+    ]);
+
+    const ownedKbIds = new Set(ownedKbs.map((kb) => kb.id));
+
+    this.logger.debug('Found owned knowledge bases', {
+      count: ownedKbs.length,
+    });
+
+    // 2. Extract shared KB IDs and deduplicate against owned
+    const sharedKbIds = shares
+      .map((s) => s.entityId)
+      .filter((id) => !ownedKbIds.has(id));
+
+    this.logger.debug('Found shared knowledge bases after deduplication', {
+      count: sharedKbIds.length,
+    });
+
+    // 3. Fetch shared KBs
+    const sharedKbs =
+      sharedKbIds.length > 0
+        ? await this.knowledgeBaseRepository.findByIds(sharedKbIds)
+        : [];
+
+    // 4. Combine results with isShared flag
+    const ownedResults: KnowledgeBaseWithShareStatus[] = ownedKbs.map(
+      (knowledgeBase) => ({
+        knowledgeBase,
+        isShared: false,
+      }),
+    );
+
+    const sharedResults: KnowledgeBaseWithShareStatus[] = sharedKbs.map(
+      (knowledgeBase) => ({
+        knowledgeBase,
+        isShared: true,
+      }),
+    );
+
+    return [...ownedResults, ...sharedResults];
+  }
+}

--- a/ayunis-core-backend/src/domain/knowledge-bases/application/strategies/knowledge-base-share-authorization.strategy.spec.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/application/strategies/knowledge-base-share-authorization.strategy.spec.ts
@@ -1,0 +1,146 @@
+import type { TestingModule } from '@nestjs/testing';
+import { Test } from '@nestjs/testing';
+import { KnowledgeBaseShareAuthorizationStrategy } from './knowledge-base-share-authorization.strategy';
+import { KnowledgeBaseRepository } from '../ports/knowledge-base.repository';
+import type { KnowledgeBase } from '../../domain/knowledge-base.entity';
+import { randomUUID } from 'crypto';
+
+describe('KnowledgeBaseShareAuthorizationStrategy', () => {
+  let strategy: KnowledgeBaseShareAuthorizationStrategy;
+  let knowledgeBaseRepository: jest.Mocked<KnowledgeBaseRepository>;
+
+  beforeAll(async () => {
+    const mockKnowledgeBaseRepository = {
+      findById: jest.fn(),
+      findByIds: jest.fn(),
+      findAllByUserId: jest.fn(),
+      save: jest.fn(),
+      delete: jest.fn(),
+      assignSourceToKnowledgeBase: jest.fn(),
+      findSourcesByKnowledgeBaseId: jest.fn(),
+      findSourceByIdAndKnowledgeBaseId: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        KnowledgeBaseShareAuthorizationStrategy,
+        {
+          provide: KnowledgeBaseRepository,
+          useValue: mockKnowledgeBaseRepository,
+        },
+      ],
+    }).compile();
+
+    strategy = module.get<KnowledgeBaseShareAuthorizationStrategy>(
+      KnowledgeBaseShareAuthorizationStrategy,
+    );
+    knowledgeBaseRepository = module.get(KnowledgeBaseRepository);
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('canViewShares', () => {
+    it('should return true when user owns the knowledge base', async () => {
+      const kbId = randomUUID();
+      const userId = randomUUID();
+      const mockKb = { id: kbId, userId } as KnowledgeBase;
+
+      knowledgeBaseRepository.findById.mockResolvedValue(mockKb);
+
+      const result = await strategy.canViewShares(kbId, userId);
+
+      expect(result).toBe(true);
+      expect(knowledgeBaseRepository.findById).toHaveBeenCalledWith(kbId);
+    });
+
+    it('should return false when knowledge base does not exist', async () => {
+      const kbId = randomUUID();
+      const userId = randomUUID();
+
+      knowledgeBaseRepository.findById.mockResolvedValue(null);
+
+      const result = await strategy.canViewShares(kbId, userId);
+
+      expect(result).toBe(false);
+      expect(knowledgeBaseRepository.findById).toHaveBeenCalledWith(kbId);
+    });
+
+    it('should return false when user does not own the knowledge base', async () => {
+      const kbId = randomUUID();
+      const userId = randomUUID();
+      const otherUserId = randomUUID();
+      const mockKb = { id: kbId, userId: otherUserId } as KnowledgeBase;
+
+      knowledgeBaseRepository.findById.mockResolvedValue(mockKb);
+
+      const result = await strategy.canViewShares(kbId, userId);
+
+      expect(result).toBe(false);
+      expect(knowledgeBaseRepository.findById).toHaveBeenCalledWith(kbId);
+    });
+  });
+
+  describe('canCreateShare', () => {
+    it('should return true when user owns the knowledge base', async () => {
+      const kbId = randomUUID();
+      const userId = randomUUID();
+      const mockKb = { id: kbId, userId } as KnowledgeBase;
+
+      knowledgeBaseRepository.findById.mockResolvedValue(mockKb);
+
+      const result = await strategy.canCreateShare(kbId, userId);
+
+      expect(result).toBe(true);
+      expect(knowledgeBaseRepository.findById).toHaveBeenCalledWith(kbId);
+    });
+
+    it('should return false when knowledge base does not exist', async () => {
+      const kbId = randomUUID();
+      const userId = randomUUID();
+
+      knowledgeBaseRepository.findById.mockResolvedValue(null);
+
+      const result = await strategy.canCreateShare(kbId, userId);
+
+      expect(result).toBe(false);
+      expect(knowledgeBaseRepository.findById).toHaveBeenCalledWith(kbId);
+    });
+
+    it('should return false when user does not own the knowledge base', async () => {
+      const kbId = randomUUID();
+      const userId = randomUUID();
+      const otherUserId = randomUUID();
+      const mockKb = { id: kbId, userId: otherUserId } as KnowledgeBase;
+
+      knowledgeBaseRepository.findById.mockResolvedValue(mockKb);
+
+      const result = await strategy.canCreateShare(kbId, userId);
+
+      expect(result).toBe(false);
+      expect(knowledgeBaseRepository.findById).toHaveBeenCalledWith(kbId);
+    });
+  });
+
+  describe('canDeleteShare', () => {
+    it('should always return true since deletion auth is handled at share level', async () => {
+      const shareId = randomUUID();
+      const userId = randomUUID();
+
+      const result = await strategy.canDeleteShare(shareId, userId);
+
+      expect(result).toBe(true);
+      expect(knowledgeBaseRepository.findById).not.toHaveBeenCalled();
+    });
+
+    it('should return true regardless of user or share', async () => {
+      const result1 = await strategy.canDeleteShare(randomUUID(), randomUUID());
+      const result2 = await strategy.canDeleteShare(randomUUID(), randomUUID());
+
+      expect(result1).toBe(true);
+      expect(result2).toBe(true);
+      expect(knowledgeBaseRepository.findById).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/ayunis-core-backend/src/domain/knowledge-bases/application/strategies/knowledge-base-share-authorization.strategy.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/application/strategies/knowledge-base-share-authorization.strategy.ts
@@ -1,0 +1,53 @@
+import { Injectable, Logger } from '@nestjs/common';
+import type { UUID } from 'crypto';
+import { ShareAuthorizationStrategy } from 'src/domain/shares/application/ports/share-authorization-strategy.port';
+import { KnowledgeBaseRepository } from '../ports/knowledge-base.repository';
+
+/**
+ * Knowledge-base-specific implementation of share authorization.
+ * Validates that users can only manage shares for knowledge bases they own.
+ */
+@Injectable()
+export class KnowledgeBaseShareAuthorizationStrategy
+  implements ShareAuthorizationStrategy
+{
+  private readonly logger = new Logger(
+    KnowledgeBaseShareAuthorizationStrategy.name,
+  );
+
+  constructor(
+    private readonly knowledgeBaseRepository: KnowledgeBaseRepository,
+  ) {}
+
+  /**
+   * Check if a user can view shares for a knowledge base.
+   * User must own the knowledge base to view its shares.
+   */
+  async canViewShares(knowledgeBaseId: UUID, userId: UUID): Promise<boolean> {
+    this.logger.log('canViewShares', { knowledgeBaseId, userId });
+
+    const kb = await this.knowledgeBaseRepository.findById(knowledgeBaseId);
+    return kb !== null && kb.userId === userId;
+  }
+
+  /**
+   * Check if a user can create a share for a knowledge base.
+   * User must own the knowledge base to create shares for it.
+   */
+  async canCreateShare(knowledgeBaseId: UUID, userId: UUID): Promise<boolean> {
+    this.logger.log('canCreateShare', { knowledgeBaseId, userId });
+
+    const kb = await this.knowledgeBaseRepository.findById(knowledgeBaseId);
+    return kb !== null && kb.userId === userId;
+  }
+
+  /**
+   * Check if a user can delete a share.
+   * For knowledge base shares, this is handled at the share level by checking ownerId.
+   */
+  canDeleteShare(shareId: UUID, userId: UUID): Promise<boolean> {
+    this.logger.log('canDeleteShare', { shareId, userId });
+
+    return Promise.resolve(true);
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces new access-control paths for knowledge bases by integrating with the shares system; mistakes could incorrectly grant/deny access to shared KBs. Also adds a new module dependency (`forwardRef` to `SharesModule`) that could surface DI/circular-import issues at runtime.
> 
> **Overview**
> **Knowledge base sharing support** is added via a new `KnowledgeBaseShareAuthorizationStrategy` that allows viewing/creating shares only for KB owners (delete auth is deferred to share-level checks).
> 
> A new `KnowledgeBaseAccessService` resolves a single accessible KB (owned-or-shared), computes `isShared`, and lists all accessible KBs by combining owned KBs with shared KBs (deduplicated). The `KnowledgeBasesModule` now `forwardRef` imports `SharesModule` and registers/exports the share-auth strategy token for `SharedEntityType.KNOWLEDGE_BASE`, with accompanying unit tests for both additions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 658cb722e07308535f10efbdcf20c8bba8d3128f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->