### PR TITLE
wip(AYC-99): update knowledge base endpoints for shared access

### DIFF
--- a/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/list-knowledge-base-documents/list-knowledge-base-documents.query.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/list-knowledge-base-documents/list-knowledge-base-documents.query.ts
@@ -1,8 +1,5 @@
 import type { UUID } from 'crypto';
 
 export class ListKnowledgeBaseDocumentsQuery {
-  constructor(
-    public readonly knowledgeBaseId: UUID,
-    public readonly userId: UUID,
-  ) {}
+  constructor(public readonly knowledgeBaseId: UUID) {}
 }

--- a/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/list-knowledge-base-documents/list-knowledge-base-documents.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/list-knowledge-base-documents/list-knowledge-base-documents.use-case.spec.ts
@@ -57,7 +57,7 @@ describe('ListKnowledgeBaseDocumentsUseCase', () => {
     });
     mockRepository.findSourcesByKnowledgeBaseId.mockResolvedValue([source]);
 
-    const query = new ListKnowledgeBaseDocumentsQuery(knowledgeBaseId, userId);
+    const query = new ListKnowledgeBaseDocumentsQuery(knowledgeBaseId);
 
     const result = await useCase.execute(query);
 
@@ -78,24 +78,17 @@ describe('ListKnowledgeBaseDocumentsUseCase', () => {
     mockRepository.findById.mockResolvedValue(knowledgeBase);
     mockRepository.findSourcesByKnowledgeBaseId.mockResolvedValue([]);
 
-    const query = new ListKnowledgeBaseDocumentsQuery(knowledgeBaseId, userId);
+    const query = new ListKnowledgeBaseDocumentsQuery(knowledgeBaseId);
 
     const result = await useCase.execute(query);
 
     expect(result).toHaveLength(0);
   });
 
-  it('should throw KnowledgeBaseNotFoundError when KB does not belong to user', async () => {
-    const otherUserId = '99999999-9999-9999-9999-999999999999' as UUID;
-    const knowledgeBase = new KnowledgeBase({
-      id: knowledgeBaseId,
-      name: 'Anderer Benutzer KB',
-      orgId,
-      userId: otherUserId,
-    });
-    mockRepository.findById.mockResolvedValue(knowledgeBase);
+  it('should throw KnowledgeBaseNotFoundError when KB does not exist', async () => {
+    mockRepository.findById.mockResolvedValue(null);
 
-    const query = new ListKnowledgeBaseDocumentsQuery(knowledgeBaseId, userId);
+    const query = new ListKnowledgeBaseDocumentsQuery(knowledgeBaseId);
 
     await expect(useCase.execute(query)).rejects.toThrow(
       KnowledgeBaseNotFoundError,

--- a/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/list-knowledge-base-documents/list-knowledge-base-documents.use-case.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/list-knowledge-base-documents/list-knowledge-base-documents.use-case.ts
@@ -19,14 +19,13 @@ export class ListKnowledgeBaseDocumentsUseCase {
   async execute(query: ListKnowledgeBaseDocumentsQuery): Promise<Source[]> {
     this.logger.log('Listing knowledge base documents', {
       knowledgeBaseId: query.knowledgeBaseId,
-      userId: query.userId,
     });
 
     try {
       const knowledgeBase = await this.knowledgeBaseRepository.findById(
         query.knowledgeBaseId,
       );
-      if (knowledgeBase?.userId !== query.userId) {
+      if (!knowledgeBase) {
         throw new KnowledgeBaseNotFoundError(query.knowledgeBaseId);
       }
 

--- a/ayunis-core-backend/src/domain/knowledge-bases/presenters/http/dto/knowledge-base-response.dto.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/presenters/http/dto/knowledge-base-response.dto.ts
@@ -37,6 +37,13 @@ export class KnowledgeBaseResponseDto {
     format: 'date-time',
   })
   updatedAt: Date;
+
+  @ApiProperty({
+    description:
+      'Whether the knowledge base is shared with the current user (not owned)',
+    example: false,
+  })
+  isShared: boolean;
 }
 
 export class KnowledgeBaseListResponseDto {

--- a/ayunis-core-backend/src/domain/knowledge-bases/presenters/http/knowledge-bases.controller.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/presenters/http/knowledge-bases.controller.ts
@@ -45,18 +45,15 @@ import {
 import { CreateKnowledgeBaseUseCase } from '../../application/use-cases/create-knowledge-base/create-knowledge-base.use-case';
 import { UpdateKnowledgeBaseUseCase } from '../../application/use-cases/update-knowledge-base/update-knowledge-base.use-case';
 import { DeleteKnowledgeBaseUseCase } from '../../application/use-cases/delete-knowledge-base/delete-knowledge-base.use-case';
-import { FindKnowledgeBaseUseCase } from '../../application/use-cases/find-knowledge-base/find-knowledge-base.use-case';
-import { ListKnowledgeBasesUseCase } from '../../application/use-cases/list-knowledge-bases/list-knowledge-bases.use-case';
 import { AddDocumentToKnowledgeBaseUseCase } from '../../application/use-cases/add-document-to-knowledge-base/add-document-to-knowledge-base.use-case';
 import { AddUrlToKnowledgeBaseUseCase } from '../../application/use-cases/add-url-to-knowledge-base/add-url-to-knowledge-base.use-case';
 import { RemoveDocumentFromKnowledgeBaseUseCase } from '../../application/use-cases/remove-document-from-knowledge-base/remove-document-from-knowledge-base.use-case';
 import { ListKnowledgeBaseDocumentsUseCase } from '../../application/use-cases/list-knowledge-base-documents/list-knowledge-base-documents.use-case';
+import { KnowledgeBaseAccessService } from '../../application/services/knowledge-base-access.service';
 
 import { CreateKnowledgeBaseCommand } from '../../application/use-cases/create-knowledge-base/create-knowledge-base.command';
 import { UpdateKnowledgeBaseCommand } from '../../application/use-cases/update-knowledge-base/update-knowledge-base.command';
 import { DeleteKnowledgeBaseCommand } from '../../application/use-cases/delete-knowledge-base/delete-knowledge-base.command';
-import { FindKnowledgeBaseQuery } from '../../application/use-cases/find-knowledge-base/find-knowledge-base.query';
-import { ListKnowledgeBasesQuery } from '../../application/use-cases/list-knowledge-bases/list-knowledge-bases.query';
 import { AddDocumentToKnowledgeBaseCommand } from '../../application/use-cases/add-document-to-knowledge-base/add-document-to-knowledge-base.command';
 import { AddUrlToKnowledgeBaseCommand } from '../../application/use-cases/add-url-to-knowledge-base/add-url-to-knowledge-base.command';
 import { RemoveDocumentFromKnowledgeBaseCommand } from '../../application/use-cases/remove-document-from-knowledge-base/remove-document-from-knowledge-base.command';
@@ -87,12 +84,11 @@ export class KnowledgeBasesController {
     private readonly createKnowledgeBaseUseCase: CreateKnowledgeBaseUseCase,
     private readonly updateKnowledgeBaseUseCase: UpdateKnowledgeBaseUseCase,
     private readonly deleteKnowledgeBaseUseCase: DeleteKnowledgeBaseUseCase,
-    private readonly findKnowledgeBaseUseCase: FindKnowledgeBaseUseCase,
-    private readonly listKnowledgeBasesUseCase: ListKnowledgeBasesUseCase,
     private readonly addDocumentUseCase: AddDocumentToKnowledgeBaseUseCase,
     private readonly addUrlUseCase: AddUrlToKnowledgeBaseUseCase,
     private readonly removeDocumentUseCase: RemoveDocumentFromKnowledgeBaseUseCase,
     private readonly listDocumentsUseCase: ListKnowledgeBaseDocumentsUseCase,
+    private readonly knowledgeBaseAccessService: KnowledgeBaseAccessService,
     private readonly knowledgeBaseDtoMapper: KnowledgeBaseDtoMapper,
   ) {}
 
@@ -138,12 +134,12 @@ export class KnowledgeBasesController {
   ): Promise<KnowledgeBaseListResponseDto> {
     this.logger.log('findAll', { userId });
 
-    const knowledgeBases = await this.listKnowledgeBasesUseCase.execute(
-      new ListKnowledgeBasesQuery(userId),
-    );
+    const results = await this.knowledgeBaseAccessService.findAllAccessible();
 
     return {
-      data: this.knowledgeBaseDtoMapper.toDtoArray(knowledgeBases),
+      data: results.map((r) =>
+        this.knowledgeBaseDtoMapper.toDto(r.knowledgeBase, r.isShared),
+      ),
     };
   }
 
@@ -167,11 +163,10 @@ export class KnowledgeBasesController {
   ): Promise<KnowledgeBaseResponseDto> {
     this.logger.log('findOne', { id, userId });
 
-    const knowledgeBase = await this.findKnowledgeBaseUseCase.execute(
-      new FindKnowledgeBaseQuery(id, userId),
-    );
+    const { knowledgeBase, isShared } =
+      await this.knowledgeBaseAccessService.findOneAccessible(id, userId);
 
-    return this.knowledgeBaseDtoMapper.toDto(knowledgeBase);
+    return this.knowledgeBaseDtoMapper.toDto(knowledgeBase, isShared);
   }
 
   @Patch(':id')
@@ -256,8 +251,10 @@ export class KnowledgeBasesController {
   ): Promise<KnowledgeBaseDocumentListResponseDto> {
     this.logger.log('listDocuments', { knowledgeBaseId: id, userId });
 
+    await this.knowledgeBaseAccessService.findAccessibleKnowledgeBase(id);
+
     const sources = await this.listDocumentsUseCase.execute(
-      new ListKnowledgeBaseDocumentsQuery(id, userId),
+      new ListKnowledgeBaseDocumentsQuery(id),
     );
 
     return {

--- a/ayunis-core-backend/src/domain/knowledge-bases/presenters/http/mappers/knowledge-base-dto.mapper.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/presenters/http/mappers/knowledge-base-dto.mapper.ts
@@ -10,13 +10,17 @@ import type { KnowledgeBaseDocumentResponseDto } from '../dto/knowledge-base-doc
 
 @Injectable()
 export class KnowledgeBaseDtoMapper {
-  toDto(entity: KnowledgeBase): KnowledgeBaseResponseDto {
+  toDto(
+    entity: KnowledgeBase,
+    isShared: boolean = false,
+  ): KnowledgeBaseResponseDto {
     return {
       id: entity.id,
       name: entity.name,
       description: entity.description,
       createdAt: entity.createdAt,
       updatedAt: entity.updatedAt,
+      isShared,
     };
   }
 

--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
@@ -2476,6 +2476,8 @@ export interface KnowledgeBaseResponseDto {
   createdAt: string;
   /** The date and time when the knowledge base was last updated */
   updatedAt: string;
+  /** Whether the knowledge base is shared with the current user (not owned) */
+  isShared: boolean;
 }
 
 export interface KnowledgeBaseListResponseDto {

--- a/ayunis-core-frontend/src/shared/api/openapi-schema.json
+++ b/ayunis-core-frontend/src/shared/api/openapi-schema.json
@@ -11972,6 +11972,11 @@
             "description": "The date and time when the knowledge base was last updated",
             "example": "2025-01-15T10:00:00.000Z",
             "format": "date-time"
+          },
+          "isShared": {
+            "type": "boolean",
+            "description": "Whether the knowledge base is shared with the current user (not owned)",
+            "example": false
           }
         },
         "required": [
@@ -11979,7 +11984,8 @@
           "name",
           "description",
           "createdAt",
-          "updatedAt"
+          "updatedAt",
+          "isShared"
         ]
       },
       "KnowledgeBaseListResponseDto": {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes request authorization and document-listing access checks by moving ownership validation into `KnowledgeBaseAccessService`, which could cause regressions if share resolution is incorrect. The API contract also changes by making `isShared` a required field in knowledge base responses.
> 
> **Overview**
> Knowledge base `GET /knowledge-bases` and `GET /knowledge-bases/:id` now return an `isShared` flag and use `KnowledgeBaseAccessService` to resolve whether results are owned vs shared, including a new one-pass `findOneAccessible` method.
> 
> Document listing (`GET /knowledge-bases/:id/documents`) now performs an explicit shared/owned access check via `KnowledgeBaseAccessService`, and `ListKnowledgeBaseDocumentsUseCase` no longer enforces per-user ownership (the `userId` is removed from `ListKnowledgeBaseDocumentsQuery`). OpenAPI + generated frontend schemas are updated to include the new `isShared` field, and tests are adjusted/expanded accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0e5869f9cced4a9081c98262052bcef533998002. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->