### PR TITLE
wip(AYC-99): frontend KB sharing — API client, sharing tab, shared badges, read-only controls

### DIFF
--- a/ayunis-core-backend/src/domain/knowledge-bases/application/services/knowledge-base-access.service.spec.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/application/services/knowledge-base-access.service.spec.ts
@@ -160,7 +160,7 @@ describe('KnowledgeBaseAccessService', () => {
       const kb = makeKb();
       knowledgeBaseRepository.findById.mockResolvedValue(kb);
 
-      const result = await service.findOneAccessible(kbId, userId);
+      const result = await service.findOneAccessible(kbId);
 
       expect(result.knowledgeBase).toBe(kb);
       expect(result.isShared).toBe(false);
@@ -172,7 +172,7 @@ describe('KnowledgeBaseAccessService', () => {
       knowledgeBaseRepository.findById.mockResolvedValue(sharedKb);
       findShareByEntityUseCase.execute.mockResolvedValue({} as never);
 
-      const result = await service.findOneAccessible(kbId, userId);
+      const result = await service.findOneAccessible(kbId);
 
       expect(result.knowledgeBase).toBe(sharedKb);
       expect(result.isShared).toBe(true);
@@ -181,7 +181,7 @@ describe('KnowledgeBaseAccessService', () => {
     it('should throw KnowledgeBaseNotFoundError when KB does not exist', async () => {
       knowledgeBaseRepository.findById.mockResolvedValue(null);
 
-      await expect(service.findOneAccessible(kbId, userId)).rejects.toThrow(
+      await expect(service.findOneAccessible(kbId)).rejects.toThrow(
         KnowledgeBaseNotFoundError,
       );
     });
@@ -191,7 +191,7 @@ describe('KnowledgeBaseAccessService', () => {
       knowledgeBaseRepository.findById.mockResolvedValue(otherKb);
       findShareByEntityUseCase.execute.mockResolvedValue(null);
 
-      await expect(service.findOneAccessible(kbId, userId)).rejects.toThrow(
+      await expect(service.findOneAccessible(kbId)).rejects.toThrow(
         KnowledgeBaseNotFoundError,
       );
     });
@@ -199,7 +199,7 @@ describe('KnowledgeBaseAccessService', () => {
     it('should throw UnauthorizedAccessError when no user in context', async () => {
       contextService.get.mockReturnValue(undefined);
 
-      await expect(service.findOneAccessible(kbId, userId)).rejects.toThrow(
+      await expect(service.findOneAccessible(kbId)).rejects.toThrow(
         UnauthorizedAccessError,
       );
     });
@@ -208,7 +208,7 @@ describe('KnowledgeBaseAccessService', () => {
       const kb = makeKb();
       knowledgeBaseRepository.findById.mockResolvedValue(kb);
 
-      await service.findOneAccessible(kbId, userId);
+      await service.findOneAccessible(kbId);
 
       expect(knowledgeBaseRepository.findById).toHaveBeenCalledTimes(1);
     });

--- a/ayunis-core-backend/src/domain/knowledge-bases/application/services/knowledge-base-access.service.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/application/services/knowledge-base-access.service.ts
@@ -62,10 +62,9 @@ export class KnowledgeBaseAccessService {
    */
   async findOneAccessible(
     id: UUID,
-    userId: UUID,
   ): Promise<KnowledgeBaseWithShareStatus> {
-    const contextUserId = this.contextService.get('userId');
-    if (!contextUserId) {
+    const userId = this.contextService.get('userId');
+    if (!userId) {
       throw new UnauthorizedAccessError();
     }
 

--- a/ayunis-core-backend/src/domain/knowledge-bases/presenters/http/knowledge-bases.controller.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/presenters/http/knowledge-bases.controller.ts
@@ -158,13 +158,12 @@ export class KnowledgeBasesController {
   })
   @ApiResponse({ status: 404, description: 'Knowledge base not found' })
   async findOne(
-    @CurrentUser(UserProperty.ID) userId: UUID,
     @Param('id', ParseUUIDPipe) id: UUID,
   ): Promise<KnowledgeBaseResponseDto> {
-    this.logger.log('findOne', { id, userId });
+    this.logger.log('findOne', { id });
 
     const { knowledgeBase, isShared } =
-      await this.knowledgeBaseAccessService.findOneAccessible(id, userId);
+      await this.knowledgeBaseAccessService.findOneAccessible(id);
 
     return this.knowledgeBaseDtoMapper.toDto(knowledgeBase, isShared);
   }

--- a/ayunis-core-frontend/src/app/routes/_authenticated/knowledge-bases.$id.tsx
+++ b/ayunis-core-frontend/src/app/routes/_authenticated/knowledge-bases.$id.tsx
@@ -4,9 +4,19 @@ import {
   getKnowledgeBasesControllerFindOneQueryKey,
   appControllerFeatureToggles,
   getAppControllerFeatureTogglesQueryKey,
+  sharesControllerGetShares,
+  getSharesControllerGetSharesQueryKey,
+  teamsControllerListMyTeams,
+  getTeamsControllerListMyTeamsQueryKey,
 } from '@/shared/api/generated/ayunisCoreAPI';
+import { CreateKnowledgeBaseShareDtoEntityType } from '@/shared/api/generated/ayunisCoreAPI.schemas';
 import { createFileRoute, redirect } from '@tanstack/react-router';
 import { KnowledgeBasePage } from '@/pages/knowledge-base';
+import { z } from 'zod';
+
+const searchSchema = z.object({
+  tab: z.enum(['config', 'share']).optional(),
+});
 
 const knowledgeBaseQueryOptions = (id: string) =>
   queryOptions({
@@ -14,8 +24,28 @@ const knowledgeBaseQueryOptions = (id: string) =>
     queryFn: () => knowledgeBasesControllerFindOne(id),
   });
 
+const sharesQueryOptions = (knowledgeBaseId: string) =>
+  queryOptions({
+    queryKey: getSharesControllerGetSharesQueryKey({
+      entityId: knowledgeBaseId,
+      entityType: CreateKnowledgeBaseShareDtoEntityType.knowledge_base,
+    }),
+    queryFn: () =>
+      sharesControllerGetShares({
+        entityId: knowledgeBaseId,
+        entityType: CreateKnowledgeBaseShareDtoEntityType.knowledge_base,
+      }),
+  });
+
+const userTeamsQueryOptions = () =>
+  queryOptions({
+    queryKey: getTeamsControllerListMyTeamsQueryKey(),
+    queryFn: () => teamsControllerListMyTeams(),
+  });
+
 export const Route = createFileRoute('/_authenticated/knowledge-bases/$id')({
   component: RouteComponent,
+  validateSearch: searchSchema,
   loader: async ({ context: { queryClient }, params: { id } }) => {
     const featureToggles = await queryClient.fetchQuery({
       queryKey: getAppControllerFeatureTogglesQueryKey(),
@@ -27,11 +57,26 @@ export const Route = createFileRoute('/_authenticated/knowledge-bases/$id')({
     const knowledgeBase = await queryClient.fetchQuery(
       knowledgeBaseQueryOptions(id),
     );
-    return { knowledgeBase };
+    // Only query shares and user teams if the user owns the KB (not shared)
+    const shares = knowledgeBase.isShared
+      ? []
+      : await queryClient.fetchQuery(sharesQueryOptions(id));
+    const userTeams = knowledgeBase.isShared
+      ? []
+      : await queryClient.fetchQuery(userTeamsQueryOptions());
+    return { knowledgeBase, shares, userTeams };
   },
 });
 
 function RouteComponent() {
-  const { knowledgeBase } = Route.useLoaderData();
-  return <KnowledgeBasePage knowledgeBase={knowledgeBase} />;
+  const { knowledgeBase, shares, userTeams } = Route.useLoaderData();
+  const { tab } = Route.useSearch();
+  return (
+    <KnowledgeBasePage
+      knowledgeBase={knowledgeBase}
+      shares={shares}
+      userTeams={userTeams}
+      initialTab={tab}
+    />
+  );
 }

--- a/ayunis-core-frontend/src/pages/knowledge-base/ui/KnowledgeBaseDocumentsCard.tsx
+++ b/ayunis-core-frontend/src/pages/knowledge-base/ui/KnowledgeBaseDocumentsCard.tsx
@@ -10,15 +10,7 @@ import {
 import { Button } from '@/shared/ui/shadcn/button';
 import { Input } from '@/shared/ui/shadcn/input';
 import { Label } from '@/shared/ui/shadcn/label';
-import {
-  Item,
-  ItemMedia,
-  ItemContent,
-  ItemTitle,
-  ItemActions,
-  ItemGroup,
-  ItemSeparator,
-} from '@/shared/ui/shadcn/item';
+import { Badge } from '@/shared/ui/shadcn/badge';
 import {
   Dialog,
   DialogContent,
@@ -54,8 +46,10 @@ function isValidUrl(value: string): boolean {
 
 export default function KnowledgeBaseDocumentsCard({
   knowledgeBaseId,
+  disabled = false,
 }: Readonly<{
   knowledgeBaseId: string;
+  disabled?: boolean;
 }>) {
   const { t } = useTranslation('knowledge-bases');
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -99,47 +93,49 @@ export default function KnowledgeBaseDocumentsCard({
       <CardHeader>
         <CardTitle>{t('detail.documents.title')}</CardTitle>
         <CardDescription>{t('detail.documents.description')}</CardDescription>
-        <CardAction>
-          <input
-            ref={fileInputRef}
-            type="file"
-            accept={ACCEPTED_FILE_TYPES}
-            onChange={handleFileChange}
-            className="hidden"
-          />
-          <div className="flex gap-2">
-            <HelpLink
-              path="knowledge-collections/create-and-upload/"
-              variant="icon"
+        {!disabled && (
+          <CardAction>
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept={ACCEPTED_FILE_TYPES}
+              onChange={handleFileChange}
+              className="hidden"
             />
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => setUrlDialogOpen(true)}
-              disabled={isAddingUrl}
-            >
-              {isAddingUrl ? (
-                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-              ) : (
-                <Globe className="mr-2 h-4 w-4" />
-              )}
-              {t('detail.documents.addUrl')}
-            </Button>
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => fileInputRef.current?.click()}
-              disabled={isUploading}
-            >
-              {isUploading ? (
-                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-              ) : (
-                <Upload className="mr-2 h-4 w-4" />
-              )}
-              {t('detail.documents.upload')}
-            </Button>
-          </div>
-        </CardAction>
+            <div className="flex gap-2">
+              <HelpLink
+                path="knowledge-collections/create-and-upload/"
+                variant="icon"
+              />
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setUrlDialogOpen(true)}
+                disabled={isAddingUrl}
+              >
+                {isAddingUrl ? (
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                ) : (
+                  <Globe className="mr-2 h-4 w-4" />
+                )}
+                {t('detail.documents.addUrl')}
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => fileInputRef.current?.click()}
+                disabled={isUploading}
+              >
+                {isUploading ? (
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                ) : (
+                  <Upload className="mr-2 h-4 w-4" />
+                )}
+                {t('detail.documents.upload')}
+              </Button>
+            </div>
+          </CardAction>
+        )}
       </CardHeader>
       <CardContent>
         <DocumentsContent
@@ -148,6 +144,7 @@ export default function KnowledgeBaseDocumentsCard({
           removeDocument={removeDocument}
           isRemoving={isRemoving}
           emptyText={t('detail.documents.empty')}
+          disabled={disabled}
         />
       </CardContent>
       <AddUrlDialog
@@ -169,12 +166,14 @@ function DocumentsContent({
   removeDocument,
   isRemoving,
   emptyText,
+  disabled = false,
 }: Readonly<{
   isLoading: boolean;
   documents: KnowledgeBaseDocumentResponseDto[];
   removeDocument: (id: string) => void;
   isRemoving: boolean;
   emptyText: string;
+  disabled?: boolean;
 }>) {
   if (isLoading) {
     return (
@@ -191,17 +190,17 @@ function DocumentsContent({
     );
   }
   return (
-    <ItemGroup>
-      {documents.map((doc, index) => (
+    <div className="flex flex-wrap gap-2">
+      {documents.map((doc) => (
         <DocumentItem
           key={doc.id}
           doc={doc}
           removeDocument={removeDocument}
           isRemoving={isRemoving}
-          showSeparator={index < documents.length - 1}
+          disabled={disabled}
         />
       ))}
-    </ItemGroup>
+    </div>
   );
 }
 
@@ -209,42 +208,37 @@ function DocumentItem({
   doc,
   removeDocument,
   isRemoving,
-  showSeparator,
+  disabled = false,
 }: Readonly<{
   doc: KnowledgeBaseDocumentResponseDto;
   removeDocument: (id: string) => void;
   isRemoving: boolean;
-  showSeparator: boolean;
+  disabled?: boolean;
 }>) {
   const isWeb = doc.textType === KnowledgeBaseDocumentResponseDtoTextType.web;
   const Icon = isWeb ? Globe : FileText;
 
   return (
-    <>
-      <Item size="sm">
-        <ItemMedia>
-          <Icon className="h-4 w-4 text-muted-foreground" />
-        </ItemMedia>
-        <ItemContent>
-          <ItemTitle title={isWeb ? (doc.url ?? undefined) : undefined}>
-            {doc.name}
-          </ItemTitle>
-        </ItemContent>
-        <ItemActions>
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon"
-            onClick={() => removeDocument(doc.id)}
-            disabled={isRemoving}
-            className="h-7 w-7"
-          >
-            <X className="h-4 w-4" />
-          </Button>
-        </ItemActions>
-      </Item>
-      {showSeparator && <ItemSeparator />}
-    </>
+    <Badge
+      variant="secondary"
+      className="flex items-center gap-1.5 py-1.5 px-3"
+      title={isWeb ? (doc.url ?? undefined) : undefined}
+    >
+      <Icon className="h-3.5 w-3.5 shrink-0" />
+      <span className="max-w-[200px] truncate">{doc.name}</span>
+      {!disabled && (
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          onClick={() => removeDocument(doc.id)}
+          disabled={isRemoving}
+          className="ml-1 h-5 w-5 rounded-full"
+        >
+          <X className="h-3 w-3" />
+        </Button>
+      )}
+    </Badge>
   );
 }
 

--- a/ayunis-core-frontend/src/pages/knowledge-base/ui/KnowledgeBasePage.tsx
+++ b/ayunis-core-frontend/src/pages/knowledge-base/ui/KnowledgeBasePage.tsx
@@ -1,29 +1,66 @@
 import AppLayout from '@/layouts/app-layout';
-import type { KnowledgeBaseResponseDto } from '@/shared/api/generated/ayunisCoreAPI.schemas';
+import type {
+  KnowledgeBaseResponseDto,
+  ShareResponseDto,
+  TeamResponseDto,
+} from '@/shared/api/generated/ayunisCoreAPI.schemas';
 import ContentAreaHeader from '@/widgets/content-area-header/ui/ContentAreaHeader';
 import ContentAreaLayout from '@/layouts/content-area-layout/ui/ContentAreaLayout';
+import { SharesTab } from '@/widgets/shares-tab';
+import {
+  Tabs,
+  TabsList,
+  TabsTrigger,
+  TabsContent,
+} from '@/shared/ui/shadcn/tabs';
+import { Badge } from '@/shared/ui/shadcn/badge';
 import { Button } from '@/shared/ui/shadcn/button';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/shared/ui/shadcn/tooltip';
 import { Trash2 } from 'lucide-react';
 import { useConfirmation } from '@/widgets/confirmation-modal';
 import { useTranslation } from 'react-i18next';
 import { useDeleteKnowledgeBase } from '@/pages/knowledge-bases/api/useDeleteKnowledgeBase';
-import { useNavigate } from '@tanstack/react-router';
+import { useNavigate, useParams } from '@tanstack/react-router';
 import { useCallback } from 'react';
 import KnowledgeBasePropertiesCard from './KnowledgeBasePropertiesCard';
 import KnowledgeBaseDocumentsCard from './KnowledgeBaseDocumentsCard';
 
 export function KnowledgeBasePage({
   knowledgeBase,
+  shares,
+  userTeams,
+  initialTab = 'config',
 }: Readonly<{
   knowledgeBase: KnowledgeBaseResponseDto;
+  shares: ShareResponseDto[];
+  userTeams: TeamResponseDto[];
+  initialTab?: 'config' | 'share';
 }>) {
   const { t } = useTranslation('knowledge-bases');
   const navigate = useNavigate();
+  const { id } = useParams({
+    from: '/_authenticated/knowledge-bases/$id',
+  });
   const navigateToList = useCallback(() => {
     void navigate({ to: '/knowledge-bases' });
   }, [navigate]);
   const deleteKnowledgeBase = useDeleteKnowledgeBase(navigateToList);
   const { confirm } = useConfirmation();
+
+  const handleTabChange = useCallback(
+    (value: string) => {
+      void navigate({
+        to: '/knowledge-bases/$id',
+        params: { id },
+        search: value === 'config' ? {} : { tab: value as 'share' },
+      });
+    },
+    [navigate, id],
+  );
 
   function handleDelete() {
     confirm({
@@ -40,29 +77,80 @@ export function KnowledgeBasePage({
     });
   }
 
+  const isReadOnly = knowledgeBase.isShared;
+
+  const configContent = (
+    <div className="grid gap-4">
+      <KnowledgeBasePropertiesCard
+        knowledgeBase={knowledgeBase}
+        disabled={isReadOnly}
+      />
+      <KnowledgeBaseDocumentsCard
+        knowledgeBaseId={knowledgeBase.id}
+        disabled={isReadOnly}
+      />
+    </div>
+  );
+
   return (
     <AppLayout>
       <ContentAreaLayout
         contentHeader={
           <ContentAreaHeader
             title={knowledgeBase.name}
+            badge={
+              isReadOnly ? (
+                <Badge variant="secondary">{t('shared.badge')}</Badge>
+              ) : undefined
+            }
             action={
-              <Button
-                variant="ghost"
-                size="icon"
-                onClick={handleDelete}
-                disabled={deleteKnowledgeBase.isPending}
-              >
-                <Trash2 className="h-4 w-4" />
-              </Button>
+              !isReadOnly ? (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      onClick={handleDelete}
+                      disabled={deleteKnowledgeBase.isPending}
+                      aria-label={t('detail.deleteLabel')}
+                    >
+                      <Trash2 className="h-4 w-4" />
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>{t('detail.deleteLabel')}</TooltipContent>
+                </Tooltip>
+              ) : undefined
             }
           />
         }
         contentArea={
-          <div className="grid gap-4">
-            <KnowledgeBasePropertiesCard knowledgeBase={knowledgeBase} />
-            <KnowledgeBaseDocumentsCard knowledgeBaseId={knowledgeBase.id} />
-          </div>
+          isReadOnly ? (
+            configContent
+          ) : (
+            <Tabs
+              value={initialTab}
+              onValueChange={handleTabChange}
+              className="w-full"
+            >
+              <TabsList>
+                <TabsTrigger value="config">
+                  {t('tabs.configuration')}
+                </TabsTrigger>
+                <TabsTrigger value="share">{t('tabs.shares')}</TabsTrigger>
+              </TabsList>
+              <TabsContent value="config" className="mt-4">
+                {configContent}
+              </TabsContent>
+              <TabsContent value="share" className="mt-4">
+                <SharesTab
+                  entityType="knowledge_base"
+                  entityId={knowledgeBase.id}
+                  shares={shares}
+                  userTeams={userTeams}
+                />
+              </TabsContent>
+            </Tabs>
+          )
         }
       />
     </AppLayout>

--- a/ayunis-core-frontend/src/pages/knowledge-base/ui/KnowledgeBasePropertiesCard.tsx
+++ b/ayunis-core-frontend/src/pages/knowledge-base/ui/KnowledgeBasePropertiesCard.tsx
@@ -23,8 +23,10 @@ import { NameField } from '@/widgets/entity-form-fields';
 
 export default function KnowledgeBasePropertiesCard({
   knowledgeBase,
+  disabled = false,
 }: Readonly<{
   knowledgeBase: KnowledgeBaseResponseDto;
+  disabled?: boolean;
 }>) {
   const { t } = useTranslation('knowledge-bases');
   const { form, onSubmit, isLoading } = useUpdateKnowledgeBase({
@@ -48,6 +50,7 @@ export default function KnowledgeBasePropertiesCard({
               name="name"
               translationNamespace="knowledge-bases"
               translationPrefix="detail.properties"
+              disabled={disabled}
             />
             <FormField
               control={form.control}
@@ -63,6 +66,7 @@ export default function KnowledgeBasePropertiesCard({
                         'detail.properties.form.descriptionPlaceholder',
                       )}
                       className="min-h-[80px] max-h-[200px]"
+                      disabled={disabled}
                       {...field}
                     />
                   </FormControl>
@@ -73,11 +77,13 @@ export default function KnowledgeBasePropertiesCard({
                 </FormItem>
               )}
             />
-            <Button type="submit" disabled={isLoading}>
-              {isLoading
-                ? t('detail.properties.buttons.saving')
-                : t('detail.properties.buttons.save')}
-            </Button>
+            {!disabled && (
+              <Button type="submit" disabled={isLoading}>
+                {isLoading
+                  ? t('detail.properties.buttons.saving')
+                  : t('detail.properties.buttons.save')}
+              </Button>
+            )}
           </form>
         </Form>
       </CardContent>

--- a/ayunis-core-frontend/src/pages/knowledge-bases/ui/KnowledgeBaseCard.tsx
+++ b/ayunis-core-frontend/src/pages/knowledge-bases/ui/KnowledgeBaseCard.tsx
@@ -1,4 +1,5 @@
 import { Button } from '@/shared/ui/shadcn/button';
+import { Badge } from '@/shared/ui/shadcn/badge';
 import { Trash2 } from 'lucide-react';
 import { useDeleteKnowledgeBase } from '../api/useDeleteKnowledgeBase';
 import { useConfirmation } from '@/widgets/confirmation-modal';
@@ -40,6 +41,8 @@ export default function KnowledgeBaseCard({
     });
   }
 
+  const isShared = knowledgeBase.isShared;
+
   return (
     <Item
       variant="outline"
@@ -54,24 +57,31 @@ export default function KnowledgeBaseCard({
       <ItemContent>
         <ItemTitle>
           <span>{knowledgeBase.name}</span>
+          {isShared && (
+            <Badge variant="secondary" className="ml-2 text-xs">
+              {t('shared.badge')}
+            </Badge>
+          )}
         </ItemTitle>
         {knowledgeBase.description && (
           <ItemDescription>{knowledgeBase.description}</ItemDescription>
         )}
       </ItemContent>
-      <ItemActions>
-        <Button
-          variant="ghost"
-          size="icon"
-          onClick={(e) => {
-            e.stopPropagation();
-            handleDelete();
-          }}
-          disabled={deleteKnowledgeBase.isPending}
-        >
-          <Trash2 className="h-4 w-4" />
-        </Button>
-      </ItemActions>
+      {!isShared && (
+        <ItemActions>
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={(e) => {
+              e.stopPropagation();
+              handleDelete();
+            }}
+            disabled={deleteKnowledgeBase.isPending}
+          >
+            <Trash2 className="h-4 w-4" />
+          </Button>
+        </ItemActions>
+      )}
     </Item>
   );
 }

--- a/ayunis-core-frontend/src/shared/locales/de/knowledge-bases.json
+++ b/ayunis-core-frontend/src/shared/locales/de/knowledge-bases.json
@@ -2,6 +2,58 @@
   "page": {
     "title": "Meine Wissenssammlungen"
   },
+  "shared": {
+    "badge": "Freigegeben"
+  },
+  "tabs": {
+    "configuration": "Konfiguration",
+    "shares": "Freigaben"
+  },
+  "shares": {
+    "org": {
+      "title": "Freigabe für Organisation",
+      "descriptionOn": "Diese Wissenssammlung ist für alle Nutzer Ihrer Organisation freigegeben",
+      "descriptionOff": "Diese Wissenssammlung ist aktuell nicht für Nutzer Ihrer Organisation freigegeben"
+    },
+    "teams": {
+      "title": "Teams",
+      "description": "Mit Teammitgliedern teilen",
+      "create": {
+        "title": "Wissenssammlung mit Team teilen",
+        "description": "Dadurch wird die Wissenssammlung für alle Mitglieder von {{teamName}} verfügbar",
+        "confirm": "Teilen",
+        "cancel": "Abbrechen"
+      },
+      "delete": {
+        "title": "Team-Freigabe entfernen",
+        "description": "Der Zugriff für alle Mitglieder von {{teamName}} wird entfernt",
+        "confirm": "Entfernen",
+        "cancel": "Abbrechen"
+      }
+    },
+    "create": {
+      "button": "Wissenssammlung teilen",
+      "title": "Wissenssammlung mit Organisation teilen",
+      "description": "Dadurch wird die Wissenssammlung für alle Mitglieder Ihrer Organisation verfügbar",
+      "confirm": "Teilen",
+      "cancel": "Abbrechen"
+    },
+    "delete": {
+      "tooltip": "Freigabe entfernen",
+      "title": "Freigabe entfernen",
+      "description": "Der Zugriff für alle Mitglieder Ihrer Organisation wird entfernt",
+      "confirm": "Entfernen",
+      "cancel": "Abbrechen"
+    },
+    "success": {
+      "created": "Wissenssammlung erfolgreich geteilt",
+      "deleted": "Freigabe erfolgreich entfernt"
+    },
+    "error": {
+      "create": "Fehler beim Teilen der Wissenssammlung",
+      "delete": "Fehler beim Entfernen der Freigabe"
+    }
+  },
   "emptyState": {
     "title": "Noch keine Wissenssammlungen",
     "description": "Erstellen Sie Ihre erste Wissenssammlung. Laden Sie Dokumente hoch und nutzen Sie sie in Ihren Chats als Kontext für die KI."
@@ -63,6 +115,7 @@
     "validation": {
       "nameRequired": "Name ist erforderlich"
     },
+    "deleteLabel": "Löschen",
     "confirmDelete": {
       "title": "Wissenssammlung löschen",
       "description": "Sind Sie sicher, dass Sie \"{{title}}\" löschen möchten? Alle zugehörigen Dokumente werden ebenfalls gelöscht. Diese Aktion kann nicht rückgängig gemacht werden.",

--- a/ayunis-core-frontend/src/shared/locales/en/knowledge-bases.json
+++ b/ayunis-core-frontend/src/shared/locales/en/knowledge-bases.json
@@ -2,6 +2,58 @@
   "page": {
     "title": "My Knowledge Bases"
   },
+  "shared": {
+    "badge": "Shared"
+  },
+  "tabs": {
+    "configuration": "Configuration",
+    "shares": "Share"
+  },
+  "shares": {
+    "org": {
+      "title": "Share with organisation",
+      "descriptionOn": "This knowledge base is shared with all users of your organisation",
+      "descriptionOff": "This knowledge base is not shared with all users of your organisation"
+    },
+    "teams": {
+      "title": "Teams",
+      "description": "Share with team members",
+      "create": {
+        "title": "Share Knowledge Base with Team",
+        "description": "This will make the knowledge base available to all members of {{teamName}}",
+        "confirm": "Share",
+        "cancel": "Cancel"
+      },
+      "delete": {
+        "title": "Remove Team Share",
+        "description": "This will remove access to the knowledge base for all members of {{teamName}}",
+        "confirm": "Remove",
+        "cancel": "Cancel"
+      }
+    },
+    "create": {
+      "button": "Share Knowledge Base",
+      "title": "Share Knowledge Base with Organization",
+      "description": "This will make the knowledge base available to all members of your organization",
+      "confirm": "Share",
+      "cancel": "Cancel"
+    },
+    "delete": {
+      "tooltip": "Remove share",
+      "title": "Remove Share",
+      "description": "This will remove access to the knowledge base for all members of your organization",
+      "confirm": "Remove",
+      "cancel": "Cancel"
+    },
+    "success": {
+      "created": "Knowledge base shared successfully",
+      "deleted": "Share removed successfully"
+    },
+    "error": {
+      "create": "Failed to share knowledge base",
+      "delete": "Failed to remove share"
+    }
+  },
   "emptyState": {
     "title": "No knowledge bases yet",
     "description": "Create your first knowledge base. Upload documents and use them in your chats as context for the AI."
@@ -63,6 +115,7 @@
     "validation": {
       "nameRequired": "Name is required"
     },
+    "deleteLabel": "Delete",
     "confirmDelete": {
       "title": "Delete Knowledge Base",
       "description": "Are you sure you want to delete \"{{title}}\"? All associated documents will also be deleted. This action cannot be undone.",

--- a/ayunis-core-frontend/src/widgets/shares-tab/api/useDeleteShare.ts
+++ b/ayunis-core-frontend/src/widgets/shares-tab/api/useDeleteShare.ts
@@ -4,25 +4,33 @@ import {
   useSharesControllerDeleteShare,
   getSharesControllerGetSharesQueryKey,
 } from '@/shared/api/generated/ayunisCoreAPI';
-import {
-  CreateAgentShareDtoEntityType,
-  CreateSkillShareDtoEntityType,
-} from '@/shared/api/generated/ayunisCoreAPI.schemas';
+import { SharesControllerGetSharesEntityType } from '@/shared/api/generated/ayunisCoreAPI.schemas';
 import { useRouter } from '@tanstack/react-router';
 import { useTranslation } from 'react-i18next';
 
-type EntityType = 'agent' | 'skill';
+type EntityType = 'agent' | 'skill' | 'knowledge_base';
+
+const translationNsMap: Record<EntityType, string> = {
+  agent: 'agent',
+  skill: 'skill',
+  knowledge_base: 'knowledge-bases',
+};
+
+const sharesEntityTypeMap: Record<
+  EntityType,
+  SharesControllerGetSharesEntityType
+> = {
+  agent: SharesControllerGetSharesEntityType.agent,
+  skill: SharesControllerGetSharesEntityType.skill,
+  knowledge_base: SharesControllerGetSharesEntityType.knowledge_base,
+};
 
 export function useDeleteShare(entityType: EntityType, entityId: string) {
   const queryClient = useQueryClient();
   const router = useRouter();
-  const translationNs = entityType === 'agent' ? 'agent' : 'skill';
-  const { t } = useTranslation(translationNs);
+  const { t } = useTranslation(translationNsMap[entityType]);
 
-  const sharesEntityType =
-    entityType === 'agent'
-      ? CreateAgentShareDtoEntityType.agent
-      : CreateSkillShareDtoEntityType.skill;
+  const sharesEntityType = sharesEntityTypeMap[entityType];
 
   const mutation = useSharesControllerDeleteShare({
     mutation: {

--- a/ayunis-core-frontend/src/widgets/shares-tab/ui/SharesTab.tsx
+++ b/ayunis-core-frontend/src/widgets/shares-tab/ui/SharesTab.tsx
@@ -16,7 +16,7 @@ import {
   ItemActions,
 } from '@/shared/ui/shadcn/item';
 
-type EntityType = 'agent' | 'skill';
+type EntityType = 'agent' | 'skill' | 'knowledge_base';
 
 interface SharesTabProps {
   entityType: EntityType;
@@ -31,7 +31,12 @@ export default function SharesTab({
   shares,
   userTeams,
 }: Readonly<SharesTabProps>) {
-  const translationNs = entityType === 'agent' ? 'agent' : 'skill';
+  const translationNsMap: Record<EntityType, string> = {
+    agent: 'agent',
+    skill: 'skill',
+    knowledge_base: 'knowledge-bases',
+  };
+  const translationNs = translationNsMap[entityType];
   const { t } = useTranslation(translationNs);
   const { confirm } = useConfirmation();
   const { createShare, isCreating } = useCreateShare(entityType, entityId);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces knowledge-base sharing management and read-only behavior for shared KBs, plus a backend access-signature change that could affect authorization if context is misconfigured. Main risk is incorrect share/ownership detection leading to unintended access or blocked edits.
> 
> **Overview**
> Adds a *Knowledge Base sharing* experience in the frontend: the KB detail page now supports a `share` tab (URL-driven), preloads shares + user teams for owned KBs, and shows a "Shared" badge plus read-only UI (no delete, no edits, no document add/remove) when viewing a shared KB.
> 
> Extends the reusable `SharesTab` and share create/delete hooks to support `knowledge_base` entity shares, and adds the required i18n strings. On the backend, `KnowledgeBaseAccessService.findOneAccessible` no longer accepts an explicit `userId` and instead reads it from request context; the KB `findOne` controller and related tests are updated accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 040b1f23e5428eeb2a52a7b7cbb21b59d9e2dbb5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->