### PR TITLE
wip(AYC-99): thread KB assignment provenance — record, entity, migration

### DIFF
--- a/ayunis-core-backend/src/db/migrations/1772197660397-CreateThreadKnowledgeBaseAssignments.ts
+++ b/ayunis-core-backend/src/db/migrations/1772197660397-CreateThreadKnowledgeBaseAssignments.ts
@@ -1,0 +1,90 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateThreadKnowledgeBaseAssignments1772197660397
+  implements MigrationInterface
+{
+  name = 'CreateThreadKnowledgeBaseAssignments1772197660397';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE "thread_knowledge_base_assignments" (
+        "id" character varying NOT NULL,
+        "createdAt" TIMESTAMP NOT NULL DEFAULT now(),
+        "updatedAt" TIMESTAMP NOT NULL DEFAULT now(),
+        "threadId" character varying NOT NULL,
+        "knowledgeBaseId" character varying NOT NULL,
+        "originSkillId" uuid,
+        CONSTRAINT "PK_29730caa763bf0e1413e9f87538" PRIMARY KEY ("id")
+      )`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_d835f5fd7b2f9e332cddcf8909" ON "thread_knowledge_base_assignments" ("threadId")`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_19c8f433e210393b5793b8ade7" ON "thread_knowledge_base_assignments" ("knowledgeBaseId")`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_5684625fb82bb130a0b1215733" ON "thread_knowledge_base_assignments" ("originSkillId")`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "thread_knowledge_base_assignments" ADD CONSTRAINT "FK_d835f5fd7b2f9e332cddcf89096" FOREIGN KEY ("threadId") REFERENCES "threads"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "thread_knowledge_base_assignments" ADD CONSTRAINT "FK_19c8f433e210393b5793b8ade73" FOREIGN KEY ("knowledgeBaseId") REFERENCES "knowledge_bases"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+
+    // Migrate existing data from join table
+    await queryRunner.query(
+      `INSERT INTO "thread_knowledge_base_assignments" ("id", "threadId", "knowledgeBaseId", "originSkillId", "createdAt", "updatedAt")
+       SELECT gen_random_uuid()::varchar, "threadsId", "knowledgeBasesId", NULL, NOW(), NOW()
+       FROM "thread_knowledge_bases"`,
+    );
+
+    // Drop old join table
+    await queryRunner.query(`DROP TABLE "thread_knowledge_bases"`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    // Recreate old join table
+    await queryRunner.query(
+      `CREATE TABLE "thread_knowledge_bases" (
+        "threadsId" character varying NOT NULL,
+        "knowledgeBasesId" character varying NOT NULL,
+        CONSTRAINT "PK_thread_knowledge_bases" PRIMARY KEY ("threadsId", "knowledgeBasesId")
+      )`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_thread_knowledge_bases_threadsId" ON "thread_knowledge_bases" ("threadsId")`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_thread_knowledge_bases_knowledgeBasesId" ON "thread_knowledge_bases" ("knowledgeBasesId")`,
+    );
+
+    // Migrate data back (lose originSkillId)
+    await queryRunner.query(
+      `INSERT INTO "thread_knowledge_bases" ("threadsId", "knowledgeBasesId")
+       SELECT DISTINCT "threadId", "knowledgeBaseId"
+       FROM "thread_knowledge_base_assignments"`,
+    );
+
+    // Drop new table
+    await queryRunner.query(
+      `ALTER TABLE "thread_knowledge_base_assignments" DROP CONSTRAINT "FK_19c8f433e210393b5793b8ade73"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "thread_knowledge_base_assignments" DROP CONSTRAINT "FK_d835f5fd7b2f9e332cddcf89096"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_5684625fb82bb130a0b1215733"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_19c8f433e210393b5793b8ade7"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_d835f5fd7b2f9e332cddcf8909"`,
+    );
+    await queryRunner.query(
+      `DROP TABLE "thread_knowledge_base_assignments"`,
+    );
+  }
+}

--- a/ayunis-core-backend/src/domain/threads/domain/thread-knowledge-base-assignment.entity.ts
+++ b/ayunis-core-backend/src/domain/threads/domain/thread-knowledge-base-assignment.entity.ts
@@ -1,0 +1,25 @@
+import type { UUID } from 'crypto';
+import { randomUUID } from 'crypto';
+import type { KnowledgeBaseSummary } from 'src/domain/knowledge-bases/domain/knowledge-base-summary';
+
+export class KnowledgeBaseAssignment {
+  public readonly id: UUID;
+  public readonly knowledgeBase: KnowledgeBaseSummary;
+  public readonly originSkillId?: UUID;
+  public readonly createdAt: Date;
+  public readonly updatedAt: Date;
+
+  constructor(params: {
+    id?: UUID;
+    knowledgeBase: KnowledgeBaseSummary;
+    originSkillId?: UUID;
+    createdAt?: Date;
+    updatedAt?: Date;
+  }) {
+    this.id = params.id ?? randomUUID();
+    this.knowledgeBase = params.knowledgeBase;
+    this.originSkillId = params.originSkillId;
+    this.createdAt = params.createdAt ?? new Date();
+    this.updatedAt = params.updatedAt ?? new Date();
+  }
+}

--- a/ayunis-core-backend/src/domain/threads/infrastructure/persistence/local/local-threads-repository.module.ts
+++ b/ayunis-core-backend/src/domain/threads/infrastructure/persistence/local/local-threads-repository.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { ThreadRecord } from './schema/thread.record';
 import { ThreadSourceAssignmentRecord } from './schema/thread-source-assignment.record';
+import { ThreadKnowledgeBaseAssignmentRecord } from './schema/thread-knowledge-base-assignment.record';
 import { LocalThreadsRepository } from './local-threads.repository';
 import { LocalMessagesRepositoryModule } from 'src/domain/messages/infrastructure/persistence/local/local-messages-repository.module';
 import { ThreadMapper } from './mappers/thread.mapper';
@@ -12,7 +13,11 @@ import { LocalSourceRepositoryModule } from 'src/domain/sources/infrastructure/p
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([ThreadRecord, ThreadSourceAssignmentRecord]),
+    TypeOrmModule.forFeature([
+      ThreadRecord,
+      ThreadSourceAssignmentRecord,
+      ThreadKnowledgeBaseAssignmentRecord,
+    ]),
     LocalMessagesRepositoryModule,
     LocalPermittedModelsRepositoryModule,
     LocalAgentsRepositoryModule,

--- a/ayunis-core-backend/src/domain/threads/infrastructure/persistence/local/schema/thread-knowledge-base-assignment.record.ts
+++ b/ayunis-core-backend/src/domain/threads/infrastructure/persistence/local/schema/thread-knowledge-base-assignment.record.ts
@@ -1,0 +1,31 @@
+import { Entity, Column, ManyToOne, JoinColumn, Index } from 'typeorm';
+import { UUID } from 'crypto';
+import { ThreadRecord } from './thread.record';
+import { KnowledgeBaseRecord } from '../../../../../knowledge-bases/infrastructure/persistence/local/schema/knowledge-base.record';
+import { BaseRecord } from '../../../../../../common/db/base-record';
+
+@Entity({ name: 'thread_knowledge_base_assignments' })
+export class ThreadKnowledgeBaseAssignmentRecord extends BaseRecord {
+  @Column()
+  @Index()
+  threadId: UUID;
+
+  @ManyToOne(() => ThreadRecord, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'threadId' })
+  thread: ThreadRecord;
+
+  @Column()
+  @Index()
+  knowledgeBaseId: UUID;
+
+  @ManyToOne(() => KnowledgeBaseRecord, {
+    onDelete: 'CASCADE',
+    eager: true,
+  })
+  @JoinColumn({ name: 'knowledgeBaseId' })
+  knowledgeBase: KnowledgeBaseRecord;
+
+  @Column({ type: 'uuid', nullable: true })
+  @Index()
+  originSkillId: UUID | null;
+}

--- a/ayunis-core-backend/src/domain/threads/infrastructure/persistence/local/schema/thread.record.ts
+++ b/ayunis-core-backend/src/domain/threads/infrastructure/persistence/local/schema/thread.record.ts
@@ -1,20 +1,12 @@
 import { UUID } from 'crypto';
 import { MessageRecord } from '../../../../../messages/infrastructure/persistence/local/schema/message.record';
-import {
-  Column,
-  Entity,
-  OneToMany,
-  Index,
-  ManyToOne,
-  ManyToMany,
-  JoinTable,
-} from 'typeorm';
+import { Column, Entity, OneToMany, Index, ManyToOne, ManyToMany, JoinTable } from 'typeorm';
 import { BaseRecord } from '../../../../../../common/db/base-record';
 import { PermittedModelRecord } from '../../../../../models/infrastructure/persistence/local-permitted-models/schema/permitted-model.record';
 import { AgentRecord } from '../../../../../agents/infrastructure/persistence/local/schema/agent.record';
 import { ThreadSourceAssignmentRecord } from './thread-source-assignment.record';
+import { ThreadKnowledgeBaseAssignmentRecord } from './thread-knowledge-base-assignment.record';
 import { McpIntegrationRecord } from '../../../../../mcp/infrastructure/persistence/postgres/schema/mcp-integration.record';
-import { KnowledgeBaseRecord } from '../../../../../knowledge-bases/infrastructure/persistence/local/schema/knowledge-base.record';
 
 @Entity({ name: 'threads' })
 export class ThreadRecord extends BaseRecord {
@@ -58,7 +50,12 @@ export class ThreadRecord extends BaseRecord {
   @JoinTable({ name: 'thread_mcp_integrations' })
   mcpIntegrations?: McpIntegrationRecord[];
 
-  @ManyToMany(() => KnowledgeBaseRecord)
-  @JoinTable({ name: 'thread_knowledge_bases' })
-  knowledgeBases?: KnowledgeBaseRecord[];
+  @OneToMany(
+    () => ThreadKnowledgeBaseAssignmentRecord,
+    (assignment) => assignment.thread,
+    {
+      cascade: true,
+    },
+  )
+  knowledgeBaseAssignments?: ThreadKnowledgeBaseAssignmentRecord[];
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Includes a production DB migration that copies data into a new table and drops the old join table, so mistakes can cause data loss or broken queries. It also changes the ORM relationship shape (ManyToMany → OneToMany assignment records), which can break any code still expecting `knowledgeBases` directly on `ThreadRecord`.
> 
> **Overview**
> **Thread↔Knowledge Base assignments are now modeled as a first-class entity** instead of a bare join table, enabling provenance tracking via `originSkillId`.
> 
> Adds a TypeORM migration that creates `thread_knowledge_base_assignments` (with `id`, timestamps, FKs, and indexes), backfills from `thread_knowledge_bases`, and then drops the old join table (with a `down` migration that recreates it but drops provenance).
> 
> Updates local persistence to introduce `ThreadKnowledgeBaseAssignmentRecord` and switches `ThreadRecord` from `@ManyToMany` `knowledgeBases` to `@OneToMany` `knowledgeBaseAssignments`, registering the new record in `LocalThreadsRepositoryModule`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e4550283c972e7bfd4c12a44f0bf7e651171b437. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->