### PR TITLE
wip(AYC-99): update thread repo, mapper and use cases for kb assignment provenance

### DIFF
--- a/ayunis-core-backend/package-lock.json
+++ b/ayunis-core-backend/package-lock.json
@@ -7130,7 +7130,7 @@
     },
     "node_modules/@swc/core": {
       "version": "1.11.21",
-      "devOptional": true,
+      "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -7172,6 +7172,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -7188,6 +7189,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -7204,6 +7206,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -7218,6 +7221,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -7232,6 +7236,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -7248,6 +7253,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -7264,6 +7270,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -7280,6 +7287,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -7296,6 +7304,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -7312,6 +7321,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -7323,7 +7333,7 @@
     },
     "node_modules/@swc/counter": {
       "version": "0.1.3",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/@swc/jest": {
@@ -7346,7 +7356,7 @@
     },
     "node_modules/@swc/types": {
       "version": "0.1.21",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@swc/counter": "^0.1.3"

--- a/ayunis-core-backend/src/db/migrations/1772197660397-CreateThreadKnowledgeBaseAssignments.ts
+++ b/ayunis-core-backend/src/db/migrations/1772197660397-CreateThreadKnowledgeBaseAssignments.ts
@@ -1,4 +1,4 @@
-import { MigrationInterface, QueryRunner } from 'typeorm';
+import type { MigrationInterface, QueryRunner } from 'typeorm';
 
 export class CreateThreadKnowledgeBaseAssignments1772197660397
   implements MigrationInterface
@@ -83,8 +83,6 @@ export class CreateThreadKnowledgeBaseAssignments1772197660397
     await queryRunner.query(
       `DROP INDEX "public"."IDX_d835f5fd7b2f9e332cddcf8909"`,
     );
-    await queryRunner.query(
-      `DROP TABLE "thread_knowledge_base_assignments"`,
-    );
+    await queryRunner.query(`DROP TABLE "thread_knowledge_base_assignments"`);
   }
 }

--- a/ayunis-core-backend/src/domain/knowledge-bases/application/services/knowledge-base-access.service.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/application/services/knowledge-base-access.service.ts
@@ -60,9 +60,7 @@ export class KnowledgeBaseAccessService {
    * its shared status in one pass (single findById call).
    * Throws KnowledgeBaseNotFoundError if the KB doesn't exist or isn't accessible.
    */
-  async findOneAccessible(
-    id: UUID,
-  ): Promise<KnowledgeBaseWithShareStatus> {
+  async findOneAccessible(id: UUID): Promise<KnowledgeBaseWithShareStatus> {
     const userId = this.contextService.get('userId');
     if (!userId) {
       throw new UnauthorizedAccessError();

--- a/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/get-knowledge-base-document-text/get-knowledge-base-document-text.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/get-knowledge-base-document-text/get-knowledge-base-document-text.use-case.spec.ts
@@ -11,10 +11,12 @@ import { KnowledgeBase } from '../../../domain/knowledge-base.entity';
 import { randomUUID } from 'crypto';
 import { FileSource } from 'src/domain/sources/domain/sources/text-source.entity';
 import { FileType, TextType } from 'src/domain/sources/domain/source-type.enum';
+import { KnowledgeBaseAccessService } from '../../services/knowledge-base-access.service';
 
 describe('GetKnowledgeBaseDocumentTextUseCase', () => {
   let useCase: GetKnowledgeBaseDocumentTextUseCase;
   let mockRepository: jest.Mocked<KnowledgeBaseRepository>;
+  let mockAccessService: jest.Mocked<KnowledgeBaseAccessService>;
 
   const orgId = randomUUID();
   const userId = randomUUID();
@@ -27,12 +29,23 @@ describe('GetKnowledgeBaseDocumentTextUseCase', () => {
       findSourceByIdAndKnowledgeBaseId: jest.fn(),
     } as unknown as jest.Mocked<KnowledgeBaseRepository>;
 
+    mockAccessService = {
+      findAccessibleKnowledgeBase: jest.fn(),
+      findOneAccessible: jest.fn(),
+      resolveIsShared: jest.fn(),
+      findAllAccessible: jest.fn(),
+    } as unknown as jest.Mocked<KnowledgeBaseAccessService>;
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         GetKnowledgeBaseDocumentTextUseCase,
         {
           provide: KnowledgeBaseRepository,
           useValue: mockRepository,
+        },
+        {
+          provide: KnowledgeBaseAccessService,
+          useValue: mockAccessService,
         },
       ],
     }).compile();
@@ -44,7 +57,7 @@ describe('GetKnowledgeBaseDocumentTextUseCase', () => {
     jest.clearAllMocks();
   });
 
-  it('should return the source when knowledge base and document exist with correct ownership', async () => {
+  it('should return the source when knowledge base and document exist with correct access', async () => {
     const knowledgeBase = new KnowledgeBase({
       id: knowledgeBaseId,
       name: 'Municipal Policies',
@@ -61,7 +74,9 @@ describe('GetKnowledgeBaseDocumentTextUseCase', () => {
       fileType: FileType.PDF,
     });
 
-    mockRepository.findById.mockResolvedValue(knowledgeBase);
+    mockAccessService.findAccessibleKnowledgeBase.mockResolvedValue(
+      knowledgeBase,
+    );
     mockRepository.findSourceByIdAndKnowledgeBaseId.mockResolvedValue(source);
 
     const result = await useCase.execute(
@@ -74,14 +89,18 @@ describe('GetKnowledgeBaseDocumentTextUseCase', () => {
     );
 
     expect(result).toBe(source);
-    expect(mockRepository.findById).toHaveBeenCalledWith(knowledgeBaseId);
+    expect(mockAccessService.findAccessibleKnowledgeBase).toHaveBeenCalledWith(
+      knowledgeBaseId,
+    );
     expect(
       mockRepository.findSourceByIdAndKnowledgeBaseId,
     ).toHaveBeenCalledWith(documentId, knowledgeBaseId);
   });
 
   it('should throw KnowledgeBaseNotFoundError when knowledge base does not exist', async () => {
-    mockRepository.findById.mockResolvedValue(null);
+    mockAccessService.findAccessibleKnowledgeBase.mockRejectedValue(
+      new KnowledgeBaseNotFoundError(knowledgeBaseId),
+    );
 
     await expect(
       useCase.execute(
@@ -95,16 +114,10 @@ describe('GetKnowledgeBaseDocumentTextUseCase', () => {
     ).rejects.toThrow(KnowledgeBaseNotFoundError);
   });
 
-  it('should throw KnowledgeBaseNotFoundError when userId does not match', async () => {
-    const otherUserId = randomUUID();
-    const knowledgeBase = new KnowledgeBase({
-      id: knowledgeBaseId,
-      name: 'Other User KB',
-      orgId,
-      userId: otherUserId,
-    });
-
-    mockRepository.findById.mockResolvedValue(knowledgeBase);
+  it('should throw KnowledgeBaseNotFoundError when KB is not owned or shared', async () => {
+    mockAccessService.findAccessibleKnowledgeBase.mockRejectedValue(
+      new KnowledgeBaseNotFoundError(knowledgeBaseId),
+    );
 
     await expect(
       useCase.execute(
@@ -116,6 +129,39 @@ describe('GetKnowledgeBaseDocumentTextUseCase', () => {
         }),
       ),
     ).rejects.toThrow(KnowledgeBaseNotFoundError);
+  });
+
+  it('should allow access to a shared knowledge base document', async () => {
+    const otherUserId = randomUUID();
+    const sharedKb = new KnowledgeBase({
+      id: knowledgeBaseId,
+      name: 'Shared Municipal Policies',
+      orgId,
+      userId: otherUserId,
+    });
+
+    const source = new FileSource({
+      id: documentId,
+      name: 'shared-building-codes.pdf',
+      text: 'Shared building code regulations...',
+      contentChunks: [],
+      type: TextType.FILE,
+      fileType: FileType.PDF,
+    });
+
+    mockAccessService.findAccessibleKnowledgeBase.mockResolvedValue(sharedKb);
+    mockRepository.findSourceByIdAndKnowledgeBaseId.mockResolvedValue(source);
+
+    const result = await useCase.execute(
+      new GetKnowledgeBaseDocumentTextQuery({
+        knowledgeBaseId,
+        documentId,
+        orgId,
+        userId,
+      }),
+    );
+
+    expect(result).toBe(source);
   });
 
   it('should throw KnowledgeBaseNotFoundError when orgId does not match', async () => {
@@ -127,7 +173,9 @@ describe('GetKnowledgeBaseDocumentTextUseCase', () => {
       userId,
     });
 
-    mockRepository.findById.mockResolvedValue(knowledgeBase);
+    mockAccessService.findAccessibleKnowledgeBase.mockResolvedValue(
+      knowledgeBase,
+    );
 
     await expect(
       useCase.execute(
@@ -149,7 +197,9 @@ describe('GetKnowledgeBaseDocumentTextUseCase', () => {
       userId,
     });
 
-    mockRepository.findById.mockResolvedValue(knowledgeBase);
+    mockAccessService.findAccessibleKnowledgeBase.mockResolvedValue(
+      knowledgeBase,
+    );
     mockRepository.findSourceByIdAndKnowledgeBaseId.mockResolvedValue(null);
 
     const query = new GetKnowledgeBaseDocumentTextQuery({

--- a/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/get-knowledge-base-document-text/get-knowledge-base-document-text.use-case.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/get-knowledge-base-document-text/get-knowledge-base-document-text.use-case.ts
@@ -6,6 +6,7 @@ import {
   DocumentNotInKnowledgeBaseError,
 } from '../../knowledge-bases.errors';
 import type { Source } from 'src/domain/sources/domain/source.entity';
+import { KnowledgeBaseAccessService } from '../../services/knowledge-base-access.service';
 
 @Injectable()
 export class GetKnowledgeBaseDocumentTextUseCase {
@@ -15,6 +16,7 @@ export class GetKnowledgeBaseDocumentTextUseCase {
 
   constructor(
     private readonly knowledgeBaseRepository: KnowledgeBaseRepository,
+    private readonly knowledgeBaseAccessService: KnowledgeBaseAccessService,
   ) {}
 
   async execute(query: GetKnowledgeBaseDocumentTextQuery): Promise<Source> {
@@ -23,12 +25,10 @@ export class GetKnowledgeBaseDocumentTextUseCase {
       documentId: query.documentId,
     });
 
-    const knowledgeBase = await this.knowledgeBaseRepository.findById(
-      query.knowledgeBaseId,
-    );
-    if (knowledgeBase?.userId !== query.userId) {
-      throw new KnowledgeBaseNotFoundError(query.knowledgeBaseId);
-    }
+    const knowledgeBase =
+      await this.knowledgeBaseAccessService.findAccessibleKnowledgeBase(
+        query.knowledgeBaseId,
+      );
 
     if (knowledgeBase.orgId !== query.orgId) {
       throw new KnowledgeBaseNotFoundError(query.knowledgeBaseId);

--- a/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/query-knowledge-base/query-knowledge-base.use-case.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/query-knowledge-base/query-knowledge-base.use-case.ts
@@ -14,6 +14,7 @@ import type { UUID } from 'crypto';
 import type { Source } from 'src/domain/sources/domain/source.entity';
 import { ContextService } from 'src/common/context/services/context.service';
 import { ApplicationError } from 'src/common/errors/base.error';
+import { KnowledgeBaseAccessService } from '../../services/knowledge-base-access.service';
 
 export interface KnowledgeBaseQueryResult {
   chunk: TextSourceContentChunk;
@@ -29,6 +30,7 @@ export class QueryKnowledgeBaseUseCase {
     private readonly knowledgeBaseRepository: KnowledgeBaseRepository,
     private readonly searchContentUseCase: SearchContentUseCase,
     private readonly contextService: ContextService,
+    private readonly knowledgeBaseAccessService: KnowledgeBaseAccessService,
   ) {}
 
   async execute(
@@ -58,12 +60,10 @@ export class QueryKnowledgeBaseUseCase {
       knowledgeBaseId: query.knowledgeBaseId,
     });
 
-    const knowledgeBase = await this.knowledgeBaseRepository.findById(
-      query.knowledgeBaseId,
-    );
-    if (knowledgeBase?.userId !== query.userId) {
-      throw new KnowledgeBaseNotFoundError(query.knowledgeBaseId);
-    }
+    const knowledgeBase =
+      await this.knowledgeBaseAccessService.findAccessibleKnowledgeBase(
+        query.knowledgeBaseId,
+      );
 
     if (knowledgeBase.orgId !== orgId) {
       throw new KnowledgeBaseNotFoundError(query.knowledgeBaseId);

--- a/ayunis-core-backend/src/domain/knowledge-bases/presenters/http/dto/knowledge-base-response.dto.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/presenters/http/dto/knowledge-base-response.dto.ts
@@ -40,10 +40,11 @@ export class KnowledgeBaseResponseDto {
 
   @ApiProperty({
     description:
-      'Whether the knowledge base is shared with the current user (not owned)',
+      'Whether the knowledge base is shared with the current user (not owned). Only present when relevant (e.g., listing user knowledge bases).',
     example: false,
+    required: false,
   })
-  isShared: boolean;
+  isShared?: boolean;
 }
 
 export class KnowledgeBaseListResponseDto {

--- a/ayunis-core-backend/src/domain/knowledge-bases/presenters/http/mappers/knowledge-base-dto.mapper.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/presenters/http/mappers/knowledge-base-dto.mapper.ts
@@ -10,18 +10,18 @@ import type { KnowledgeBaseDocumentResponseDto } from '../dto/knowledge-base-doc
 
 @Injectable()
 export class KnowledgeBaseDtoMapper {
-  toDto(
-    entity: KnowledgeBase,
-    isShared: boolean = false,
-  ): KnowledgeBaseResponseDto {
-    return {
+  toDto(entity: KnowledgeBase, isShared?: boolean): KnowledgeBaseResponseDto {
+    const dto: KnowledgeBaseResponseDto = {
       id: entity.id,
       name: entity.name,
       description: entity.description,
       createdAt: entity.createdAt,
       updatedAt: entity.updatedAt,
-      isShared,
     };
+    if (isShared !== undefined) {
+      dto.isShared = isShared;
+    }
+    return dto;
   }
 
   toDtoArray(entities: KnowledgeBase[]): KnowledgeBaseResponseDto[] {

--- a/ayunis-core-backend/src/domain/runs/application/services/tool-assembly.service.ts
+++ b/ayunis-core-backend/src/domain/runs/application/services/tool-assembly.service.ts
@@ -33,6 +33,7 @@ import {
   type SkillPrefix,
 } from 'src/common/util/skill-slug';
 import type { SkillTemplate } from 'src/domain/skill-templates/domain/skill-template.entity';
+import type { KnowledgeBaseSummary } from 'src/domain/knowledge-bases/domain/knowledge-base-summary';
 
 @Injectable()
 export class ToolAssemblyService {
@@ -107,7 +108,7 @@ export class ToolAssemblyService {
       // Only include skills in prompt when tools are enabled and skills feature is on,
       // otherwise the prompt would instruct the model to use activate_skill which isn't available
       skills: canUseTools && this.features.skillsEnabled ? skillEntries : [],
-      knowledgeBases: canUseTools ? (thread.knowledgeBases ?? []) : [],
+      knowledgeBases: canUseTools ? this.deduplicateKnowledgeBases(thread) : [],
       userSystemPrompt,
     });
 
@@ -402,13 +403,14 @@ export class ToolAssemblyService {
     }
 
     // Knowledge base tools are available if the thread has knowledge bases
+    const knowledgeBases = this.deduplicateKnowledgeBases(thread);
 
-    if ((thread.knowledgeBases?.length ?? 0) > 0) {
+    if (knowledgeBases.length > 0) {
       tools.push(
         await this.assembleToolsUseCase.execute(
           new AssembleToolCommand({
             type: ToolType.KNOWLEDGE_QUERY,
-            context: thread.knowledgeBases,
+            context: knowledgeBases,
           }),
         ),
       );
@@ -417,7 +419,7 @@ export class ToolAssemblyService {
         await this.assembleToolsUseCase.execute(
           new AssembleToolCommand({
             type: ToolType.KNOWLEDGE_GET_TEXT,
-            context: thread.knowledgeBases,
+            context: knowledgeBases,
           }),
         ),
       );
@@ -436,5 +438,22 @@ export class ToolAssemblyService {
     }
 
     return tools;
+  }
+
+  /**
+   * Deduplicate knowledge bases by knowledgeBaseId.
+   * The same KB can appear multiple times in thread.knowledgeBaseAssignments
+   * when it was assigned by different origin skills.
+   */
+  private deduplicateKnowledgeBases(thread: Thread): KnowledgeBaseSummary[] {
+    const seen = new Set<UUID>();
+    const result: KnowledgeBaseSummary[] = [];
+    for (const assignment of thread.knowledgeBaseAssignments ?? []) {
+      if (!seen.has(assignment.knowledgeBase.id)) {
+        seen.add(assignment.knowledgeBase.id);
+        result.push(assignment.knowledgeBase);
+      }
+    }
+    return result;
   }
 }

--- a/ayunis-core-backend/src/domain/runs/application/services/tool-assembly.service.ts
+++ b/ayunis-core-backend/src/domain/runs/application/services/tool-assembly.service.ts
@@ -33,7 +33,6 @@ import {
   type SkillPrefix,
 } from 'src/common/util/skill-slug';
 import type { SkillTemplate } from 'src/domain/skill-templates/domain/skill-template.entity';
-import type { KnowledgeBaseSummary } from 'src/domain/knowledge-bases/domain/knowledge-base-summary';
 
 @Injectable()
 export class ToolAssemblyService {
@@ -108,7 +107,7 @@ export class ToolAssemblyService {
       // Only include skills in prompt when tools are enabled and skills feature is on,
       // otherwise the prompt would instruct the model to use activate_skill which isn't available
       skills: canUseTools && this.features.skillsEnabled ? skillEntries : [],
-      knowledgeBases: canUseTools ? this.deduplicateKnowledgeBases(thread) : [],
+      knowledgeBases: canUseTools ? thread.getUniqueKnowledgeBases() : [],
       userSystemPrompt,
     });
 
@@ -403,7 +402,7 @@ export class ToolAssemblyService {
     }
 
     // Knowledge base tools are available if the thread has knowledge bases
-    const knowledgeBases = this.deduplicateKnowledgeBases(thread);
+    const knowledgeBases = thread.getUniqueKnowledgeBases();
 
     if (knowledgeBases.length > 0) {
       tools.push(
@@ -438,22 +437,5 @@ export class ToolAssemblyService {
     }
 
     return tools;
-  }
-
-  /**
-   * Deduplicate knowledge bases by knowledgeBaseId.
-   * The same KB can appear multiple times in thread.knowledgeBaseAssignments
-   * when it was assigned by different origin skills.
-   */
-  private deduplicateKnowledgeBases(thread: Thread): KnowledgeBaseSummary[] {
-    const seen = new Set<UUID>();
-    const result: KnowledgeBaseSummary[] = [];
-    for (const assignment of thread.knowledgeBaseAssignments ?? []) {
-      if (!seen.has(assignment.knowledgeBase.id)) {
-        seen.add(assignment.knowledgeBase.id);
-        result.push(assignment.knowledgeBase);
-      }
-    }
-    return result;
   }
 }

--- a/ayunis-core-backend/src/domain/threads/application/ports/threads.repository.ts
+++ b/ayunis-core-backend/src/domain/threads/application/ports/threads.repository.ts
@@ -58,15 +58,30 @@ export abstract class ThreadsRepository {
     userId: UUID;
     mcpIntegrationIds: UUID[];
   }): Promise<void>;
-  abstract updateKnowledgeBases(params: {
+  abstract addKnowledgeBaseAssignment(params: {
     threadId: UUID;
     userId: UUID;
-    knowledgeBaseIds: UUID[];
+    knowledgeBaseId: UUID;
+    originSkillId?: UUID;
+  }): Promise<void>;
+  abstract removeKnowledgeBaseAssignment(params: {
+    threadId: UUID;
+    userId: UUID;
+    knowledgeBaseId: UUID;
+    originSkillId?: UUID;
   }): Promise<void>;
   abstract delete(id: UUID, userId: UUID): Promise<void>;
   abstract findAllByOrgIdWithSources(orgId: UUID): Promise<Thread[]>;
   abstract removeSourceAssignmentsByOriginSkill(params: {
     originSkillId: UUID;
+    userIds: UUID[];
+  }): Promise<void>;
+  abstract removeKnowledgeBaseAssignmentsByOriginSkill(params: {
+    originSkillId: UUID;
+    userIds: UUID[];
+  }): Promise<void>;
+  abstract removeDirectKnowledgeBaseAssignments(params: {
+    knowledgeBaseId: UUID;
     userIds: UUID[];
   }): Promise<void>;
 }

--- a/ayunis-core-backend/src/domain/threads/application/use-cases/add-knowledge-base-to-thread/add-knowledge-base-to-thread.command.ts
+++ b/ayunis-core-backend/src/domain/threads/application/use-cases/add-knowledge-base-to-thread/add-knowledge-base-to-thread.command.ts
@@ -4,5 +4,6 @@ export class AddKnowledgeBaseToThreadCommand {
   constructor(
     public readonly threadId: UUID,
     public readonly knowledgeBaseId: UUID,
+    public readonly originSkillId?: UUID,
   ) {}
 }

--- a/ayunis-core-backend/src/domain/threads/application/use-cases/add-knowledge-base-to-thread/add-knowledge-base-to-thread.use-case.ts
+++ b/ayunis-core-backend/src/domain/threads/application/use-cases/add-knowledge-base-to-thread/add-knowledge-base-to-thread.use-case.ts
@@ -21,6 +21,7 @@ export class AddKnowledgeBaseToThreadUseCase {
     this.logger.log('execute', {
       threadId: command.threadId,
       knowledgeBaseId: command.knowledgeBaseId,
+      originSkillId: command.originSkillId,
     });
 
     const userId = this.contextService.get('userId');
@@ -54,24 +55,22 @@ export class AddKnowledgeBaseToThreadUseCase {
       throw new KnowledgeBaseNotFoundError(command.knowledgeBaseId);
     }
 
-    const currentKbs = thread.knowledgeBases ?? [];
-    const alreadyAssigned = currentKbs.some(
-      (kb) => kb.id === command.knowledgeBaseId,
+    const currentAssignments = thread.knowledgeBaseAssignments ?? [];
+    const alreadyAssigned = currentAssignments.some(
+      (a) =>
+        a.knowledgeBase.id === command.knowledgeBaseId &&
+        a.originSkillId === command.originSkillId,
     );
 
     if (alreadyAssigned) {
       return;
     }
 
-    const updatedIds = [
-      ...currentKbs.map((kb) => kb.id),
-      command.knowledgeBaseId,
-    ];
-
-    await this.threadsRepository.updateKnowledgeBases({
+    await this.threadsRepository.addKnowledgeBaseAssignment({
       threadId: command.threadId,
       userId,
-      knowledgeBaseIds: updatedIds,
+      knowledgeBaseId: command.knowledgeBaseId,
+      originSkillId: command.originSkillId,
     });
   }
 }

--- a/ayunis-core-backend/src/domain/threads/application/use-cases/remove-direct-kb-from-threads/remove-direct-kb-from-threads.command.ts
+++ b/ayunis-core-backend/src/domain/threads/application/use-cases/remove-direct-kb-from-threads/remove-direct-kb-from-threads.command.ts
@@ -1,0 +1,8 @@
+import type { UUID } from 'crypto';
+
+export class RemoveDirectKbFromThreadsCommand {
+  constructor(
+    public readonly knowledgeBaseId: UUID,
+    public readonly userIds: UUID[],
+  ) {}
+}

--- a/ayunis-core-backend/src/domain/threads/application/use-cases/remove-direct-kb-from-threads/remove-direct-kb-from-threads.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/threads/application/use-cases/remove-direct-kb-from-threads/remove-direct-kb-from-threads.use-case.spec.ts
@@ -1,0 +1,63 @@
+import type { TestingModule } from '@nestjs/testing';
+import { Test } from '@nestjs/testing';
+import { Logger } from '@nestjs/common';
+import { randomUUID } from 'crypto';
+import { RemoveDirectKbFromThreadsUseCase } from './remove-direct-kb-from-threads.use-case';
+import { RemoveDirectKbFromThreadsCommand } from './remove-direct-kb-from-threads.command';
+import { ThreadsRepository } from '../../ports/threads.repository';
+
+describe('RemoveDirectKbFromThreadsUseCase', () => {
+  let useCase: RemoveDirectKbFromThreadsUseCase;
+  let threadsRepository: jest.Mocked<ThreadsRepository>;
+
+  beforeAll(async () => {
+    const mockThreadsRepository = {
+      removeDirectKnowledgeBaseAssignments: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        RemoveDirectKbFromThreadsUseCase,
+        { provide: ThreadsRepository, useValue: mockThreadsRepository },
+      ],
+    }).compile();
+
+    useCase = module.get(RemoveDirectKbFromThreadsUseCase);
+    threadsRepository = module.get(ThreadsRepository);
+
+    jest.spyOn(Logger.prototype, 'log').mockImplementation();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should call repository with correct knowledgeBaseId and userIds', async () => {
+    const knowledgeBaseId = randomUUID();
+    const userIds = [randomUUID(), randomUUID()];
+    const command = new RemoveDirectKbFromThreadsCommand(
+      knowledgeBaseId,
+      userIds,
+    );
+
+    await useCase.execute(command);
+
+    expect(
+      threadsRepository.removeDirectKnowledgeBaseAssignments,
+    ).toHaveBeenCalledWith({
+      knowledgeBaseId,
+      userIds,
+    });
+  });
+
+  it('should not call repository when userIds is empty', async () => {
+    const knowledgeBaseId = randomUUID();
+    const command = new RemoveDirectKbFromThreadsCommand(knowledgeBaseId, []);
+
+    await useCase.execute(command);
+
+    expect(
+      threadsRepository.removeDirectKnowledgeBaseAssignments,
+    ).not.toHaveBeenCalled();
+  });
+});

--- a/ayunis-core-backend/src/domain/threads/application/use-cases/remove-direct-kb-from-threads/remove-direct-kb-from-threads.use-case.ts
+++ b/ayunis-core-backend/src/domain/threads/application/use-cases/remove-direct-kb-from-threads/remove-direct-kb-from-threads.use-case.ts
@@ -1,0 +1,26 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ThreadsRepository } from '../../ports/threads.repository';
+import { RemoveDirectKbFromThreadsCommand } from './remove-direct-kb-from-threads.command';
+
+@Injectable()
+export class RemoveDirectKbFromThreadsUseCase {
+  private readonly logger = new Logger(RemoveDirectKbFromThreadsUseCase.name);
+
+  constructor(private readonly threadsRepository: ThreadsRepository) {}
+
+  async execute(command: RemoveDirectKbFromThreadsCommand): Promise<void> {
+    this.logger.log('execute', {
+      knowledgeBaseId: command.knowledgeBaseId,
+      userCount: command.userIds.length,
+    });
+
+    if (command.userIds.length === 0) {
+      return;
+    }
+
+    await this.threadsRepository.removeDirectKnowledgeBaseAssignments({
+      knowledgeBaseId: command.knowledgeBaseId,
+      userIds: command.userIds,
+    });
+  }
+}

--- a/ayunis-core-backend/src/domain/threads/application/use-cases/remove-kb-assignments-by-origin-skill/remove-kb-assignments-by-origin-skill.command.ts
+++ b/ayunis-core-backend/src/domain/threads/application/use-cases/remove-kb-assignments-by-origin-skill/remove-kb-assignments-by-origin-skill.command.ts
@@ -1,0 +1,8 @@
+import type { UUID } from 'crypto';
+
+export class RemoveKbAssignmentsByOriginSkillCommand {
+  constructor(
+    public readonly skillId: UUID,
+    public readonly userIds: UUID[],
+  ) {}
+}

--- a/ayunis-core-backend/src/domain/threads/application/use-cases/remove-kb-assignments-by-origin-skill/remove-kb-assignments-by-origin-skill.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/threads/application/use-cases/remove-kb-assignments-by-origin-skill/remove-kb-assignments-by-origin-skill.use-case.spec.ts
@@ -1,0 +1,63 @@
+import type { TestingModule } from '@nestjs/testing';
+import { Test } from '@nestjs/testing';
+import { Logger } from '@nestjs/common';
+import { randomUUID } from 'crypto';
+import { RemoveKbAssignmentsByOriginSkillUseCase } from './remove-kb-assignments-by-origin-skill.use-case';
+import { RemoveKbAssignmentsByOriginSkillCommand } from './remove-kb-assignments-by-origin-skill.command';
+import { ThreadsRepository } from '../../ports/threads.repository';
+
+describe('RemoveKbAssignmentsByOriginSkillUseCase', () => {
+  let useCase: RemoveKbAssignmentsByOriginSkillUseCase;
+  let threadsRepository: jest.Mocked<ThreadsRepository>;
+
+  beforeAll(async () => {
+    const mockThreadsRepository = {
+      removeKnowledgeBaseAssignmentsByOriginSkill: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        RemoveKbAssignmentsByOriginSkillUseCase,
+        { provide: ThreadsRepository, useValue: mockThreadsRepository },
+      ],
+    }).compile();
+
+    useCase = module.get(RemoveKbAssignmentsByOriginSkillUseCase);
+    threadsRepository = module.get(ThreadsRepository);
+
+    jest.spyOn(Logger.prototype, 'log').mockImplementation();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should call repository with correct skillId and userIds', async () => {
+    const skillId = randomUUID();
+    const userIds = [randomUUID(), randomUUID()];
+    const command = new RemoveKbAssignmentsByOriginSkillCommand(
+      skillId,
+      userIds,
+    );
+
+    await useCase.execute(command);
+
+    expect(
+      threadsRepository.removeKnowledgeBaseAssignmentsByOriginSkill,
+    ).toHaveBeenCalledWith({
+      originSkillId: skillId,
+      userIds,
+    });
+  });
+
+  it('should not call repository when userIds is empty', async () => {
+    const skillId = randomUUID();
+    const command = new RemoveKbAssignmentsByOriginSkillCommand(skillId, []);
+
+    await useCase.execute(command);
+
+    expect(
+      threadsRepository.removeKnowledgeBaseAssignmentsByOriginSkill,
+    ).not.toHaveBeenCalled();
+  });
+});

--- a/ayunis-core-backend/src/domain/threads/application/use-cases/remove-kb-assignments-by-origin-skill/remove-kb-assignments-by-origin-skill.use-case.ts
+++ b/ayunis-core-backend/src/domain/threads/application/use-cases/remove-kb-assignments-by-origin-skill/remove-kb-assignments-by-origin-skill.use-case.ts
@@ -1,0 +1,30 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ThreadsRepository } from '../../ports/threads.repository';
+import { RemoveKbAssignmentsByOriginSkillCommand } from './remove-kb-assignments-by-origin-skill.command';
+
+@Injectable()
+export class RemoveKbAssignmentsByOriginSkillUseCase {
+  private readonly logger = new Logger(
+    RemoveKbAssignmentsByOriginSkillUseCase.name,
+  );
+
+  constructor(private readonly threadsRepository: ThreadsRepository) {}
+
+  async execute(
+    command: RemoveKbAssignmentsByOriginSkillCommand,
+  ): Promise<void> {
+    this.logger.log('execute', {
+      skillId: command.skillId,
+      userCount: command.userIds.length,
+    });
+
+    if (command.userIds.length === 0) {
+      return;
+    }
+
+    await this.threadsRepository.removeKnowledgeBaseAssignmentsByOriginSkill({
+      originSkillId: command.skillId,
+      userIds: command.userIds,
+    });
+  }
+}

--- a/ayunis-core-backend/src/domain/threads/application/use-cases/remove-knowledge-base-from-thread/remove-knowledge-base-from-thread.command.ts
+++ b/ayunis-core-backend/src/domain/threads/application/use-cases/remove-knowledge-base-from-thread/remove-knowledge-base-from-thread.command.ts
@@ -4,5 +4,6 @@ export class RemoveKnowledgeBaseFromThreadCommand {
   constructor(
     public readonly threadId: UUID,
     public readonly knowledgeBaseId: UUID,
+    public readonly originSkillId?: UUID,
   ) {}
 }

--- a/ayunis-core-backend/src/domain/threads/application/use-cases/remove-knowledge-base-from-thread/remove-knowledge-base-from-thread.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/threads/application/use-cases/remove-knowledge-base-from-thread/remove-knowledge-base-from-thread.use-case.spec.ts
@@ -6,6 +6,7 @@ import { RemoveKnowledgeBaseFromThreadCommand } from './remove-knowledge-base-fr
 import { ThreadsRepository } from '../../ports/threads.repository';
 import { ContextService } from 'src/common/context/services/context.service';
 import { Thread } from '../../../domain/thread.entity';
+import { KnowledgeBaseAssignment } from '../../../domain/thread-knowledge-base-assignment.entity';
 import { ThreadNotFoundError } from '../../threads.errors';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
 import type { UUID } from 'crypto';
@@ -23,7 +24,7 @@ describe('RemoveKnowledgeBaseFromThreadUseCase', () => {
   beforeAll(async () => {
     const mockThreadsRepository = {
       findOne: jest.fn(),
-      updateKnowledgeBases: jest.fn(),
+      removeKnowledgeBaseAssignment: jest.fn(),
     };
 
     mockContextService = {
@@ -52,19 +53,28 @@ describe('RemoveKnowledgeBaseFromThreadUseCase', () => {
     jest.clearAllMocks();
   });
 
-  it('should remove a knowledge base from a thread', async () => {
+  it('should remove a direct knowledge base assignment from a thread', async () => {
     const thread = new Thread({
       id: mockThreadId,
       userId: mockUserId,
       messages: [],
-      knowledgeBases: [
-        { id: mockKbId, name: 'Municipal Zoning Guidelines' },
-        { id: mockKbId2, name: 'Building Permits Documentation' },
+      knowledgeBaseAssignments: [
+        new KnowledgeBaseAssignment({
+          knowledgeBase: { id: mockKbId, name: 'Municipal Zoning Guidelines' },
+        }),
+        new KnowledgeBaseAssignment({
+          knowledgeBase: {
+            id: mockKbId2,
+            name: 'Building Permits Documentation',
+          },
+        }),
       ],
     });
 
     threadsRepository.findOne.mockResolvedValue(thread);
-    threadsRepository.updateKnowledgeBases.mockResolvedValue(undefined);
+    threadsRepository.removeKnowledgeBaseAssignment.mockResolvedValue(
+      undefined,
+    );
 
     const command = new RemoveKnowledgeBaseFromThreadCommand(
       mockThreadId,
@@ -73,23 +83,72 @@ describe('RemoveKnowledgeBaseFromThreadUseCase', () => {
 
     await useCase.execute(command);
 
-    expect(threadsRepository.updateKnowledgeBases).toHaveBeenCalledWith({
+    expect(
+      threadsRepository.removeKnowledgeBaseAssignment,
+    ).toHaveBeenCalledWith({
       threadId: mockThreadId,
       userId: mockUserId,
-      knowledgeBaseIds: [mockKbId2],
+      knowledgeBaseId: mockKbId,
+      originSkillId: undefined,
     });
   });
 
-  it('should result in empty array when removing the last knowledge base', async () => {
+  it('should remove only the matching originSkillId assignment', async () => {
+    const mockSkillId = '123e4567-e89b-12d3-a456-426614174050' as UUID;
     const thread = new Thread({
       id: mockThreadId,
       userId: mockUserId,
       messages: [],
-      knowledgeBases: [{ id: mockKbId, name: 'Municipal Zoning Guidelines' }],
+      knowledgeBaseAssignments: [
+        new KnowledgeBaseAssignment({
+          knowledgeBase: { id: mockKbId, name: 'Municipal Zoning Guidelines' },
+        }),
+        new KnowledgeBaseAssignment({
+          knowledgeBase: { id: mockKbId, name: 'Municipal Zoning Guidelines' },
+          originSkillId: mockSkillId,
+        }),
+      ],
     });
 
     threadsRepository.findOne.mockResolvedValue(thread);
-    threadsRepository.updateKnowledgeBases.mockResolvedValue(undefined);
+    threadsRepository.removeKnowledgeBaseAssignment.mockResolvedValue(
+      undefined,
+    );
+
+    const command = new RemoveKnowledgeBaseFromThreadCommand(
+      mockThreadId,
+      mockKbId,
+      mockSkillId,
+    );
+
+    await useCase.execute(command);
+
+    expect(
+      threadsRepository.removeKnowledgeBaseAssignment,
+    ).toHaveBeenCalledWith({
+      threadId: mockThreadId,
+      userId: mockUserId,
+      knowledgeBaseId: mockKbId,
+      originSkillId: mockSkillId,
+    });
+  });
+
+  it('should remove the last knowledge base from a thread', async () => {
+    const thread = new Thread({
+      id: mockThreadId,
+      userId: mockUserId,
+      messages: [],
+      knowledgeBaseAssignments: [
+        new KnowledgeBaseAssignment({
+          knowledgeBase: { id: mockKbId, name: 'Municipal Zoning Guidelines' },
+        }),
+      ],
+    });
+
+    threadsRepository.findOne.mockResolvedValue(thread);
+    threadsRepository.removeKnowledgeBaseAssignment.mockResolvedValue(
+      undefined,
+    );
 
     const command = new RemoveKnowledgeBaseFromThreadCommand(
       mockThreadId,
@@ -98,10 +157,13 @@ describe('RemoveKnowledgeBaseFromThreadUseCase', () => {
 
     await useCase.execute(command);
 
-    expect(threadsRepository.updateKnowledgeBases).toHaveBeenCalledWith({
+    expect(
+      threadsRepository.removeKnowledgeBaseAssignment,
+    ).toHaveBeenCalledWith({
       threadId: mockThreadId,
       userId: mockUserId,
-      knowledgeBaseIds: [],
+      knowledgeBaseId: mockKbId,
+      originSkillId: undefined,
     });
   });
 
@@ -110,7 +172,11 @@ describe('RemoveKnowledgeBaseFromThreadUseCase', () => {
       id: mockThreadId,
       userId: mockUserId,
       messages: [],
-      knowledgeBases: [{ id: mockKbId, name: 'Municipal Zoning Guidelines' }],
+      knowledgeBaseAssignments: [
+        new KnowledgeBaseAssignment({
+          knowledgeBase: { id: mockKbId, name: 'Municipal Zoning Guidelines' },
+        }),
+      ],
     });
 
     threadsRepository.findOne.mockResolvedValue(thread);
@@ -122,7 +188,37 @@ describe('RemoveKnowledgeBaseFromThreadUseCase', () => {
 
     await useCase.execute(command);
 
-    expect(threadsRepository.updateKnowledgeBases).not.toHaveBeenCalled();
+    expect(
+      threadsRepository.removeKnowledgeBaseAssignment,
+    ).not.toHaveBeenCalled();
+  });
+
+  it('should not remove direct assignment when requesting skill-originated removal', async () => {
+    const mockSkillId = '123e4567-e89b-12d3-a456-426614174050' as UUID;
+    const thread = new Thread({
+      id: mockThreadId,
+      userId: mockUserId,
+      messages: [],
+      knowledgeBaseAssignments: [
+        new KnowledgeBaseAssignment({
+          knowledgeBase: { id: mockKbId, name: 'Municipal Zoning Guidelines' },
+        }),
+      ],
+    });
+
+    threadsRepository.findOne.mockResolvedValue(thread);
+
+    const command = new RemoveKnowledgeBaseFromThreadCommand(
+      mockThreadId,
+      mockKbId,
+      mockSkillId,
+    );
+
+    await useCase.execute(command);
+
+    expect(
+      threadsRepository.removeKnowledgeBaseAssignment,
+    ).not.toHaveBeenCalled();
   });
 
   it('should throw ThreadNotFoundError when thread does not exist', async () => {

--- a/ayunis-core-backend/src/domain/threads/application/use-cases/remove-knowledge-base-from-thread/remove-knowledge-base-from-thread.use-case.ts
+++ b/ayunis-core-backend/src/domain/threads/application/use-cases/remove-knowledge-base-from-thread/remove-knowledge-base-from-thread.use-case.ts
@@ -20,6 +20,7 @@ export class RemoveKnowledgeBaseFromThreadUseCase {
     this.logger.log('execute', {
       threadId: command.threadId,
       knowledgeBaseId: command.knowledgeBaseId,
+      originSkillId: command.originSkillId,
     });
 
     const userId = this.contextService.get('userId');
@@ -36,23 +37,22 @@ export class RemoveKnowledgeBaseFromThreadUseCase {
       throw new ThreadNotFoundError(command.threadId, userId);
     }
 
-    const currentKbs = thread.knowledgeBases ?? [];
-    const isAssigned = currentKbs.some(
-      (kb) => kb.id === command.knowledgeBaseId,
+    const currentAssignments = thread.knowledgeBaseAssignments ?? [];
+    const isAssigned = currentAssignments.some(
+      (a) =>
+        a.knowledgeBase.id === command.knowledgeBaseId &&
+        a.originSkillId === command.originSkillId,
     );
 
     if (!isAssigned) {
       return;
     }
 
-    const updatedIds = currentKbs
-      .filter((kb) => kb.id !== command.knowledgeBaseId)
-      .map((kb) => kb.id);
-
-    await this.threadsRepository.updateKnowledgeBases({
+    await this.threadsRepository.removeKnowledgeBaseAssignment({
       threadId: command.threadId,
       userId,
-      knowledgeBaseIds: updatedIds,
+      knowledgeBaseId: command.knowledgeBaseId,
+      originSkillId: command.originSkillId,
     });
   }
 }

--- a/ayunis-core-backend/src/domain/threads/domain/thread.entity.ts
+++ b/ayunis-core-backend/src/domain/threads/domain/thread.entity.ts
@@ -3,9 +3,7 @@ import { randomUUID } from 'crypto';
 import type { Message } from 'src/domain/messages/domain/message.entity';
 import type { PermittedLanguageModel } from 'src/domain/models/domain/permitted-model.entity';
 import type { SourceAssignment } from './thread-source-assignment.entity';
-import type { KnowledgeBaseSummary } from 'src/domain/knowledge-bases/domain/knowledge-base-summary';
-
-export type { KnowledgeBaseSummary };
+import type { KnowledgeBaseAssignment } from './thread-knowledge-base-assignment.entity';
 
 export class Thread {
   id: UUID;
@@ -14,7 +12,7 @@ export class Thread {
   agentId?: UUID;
   sourceAssignments?: SourceAssignment[];
   mcpIntegrationIds: UUID[];
-  knowledgeBases?: KnowledgeBaseSummary[];
+  knowledgeBaseAssignments?: KnowledgeBaseAssignment[];
   title?: string;
   messages: Message[];
   isAnonymous: boolean;
@@ -28,7 +26,7 @@ export class Thread {
     agentId?: UUID;
     sourceAssignments?: SourceAssignment[];
     mcpIntegrationIds?: UUID[];
-    knowledgeBases?: KnowledgeBaseSummary[];
+    knowledgeBaseAssignments?: KnowledgeBaseAssignment[];
     title?: string;
     messages: Message[];
     isAnonymous?: boolean;
@@ -41,7 +39,7 @@ export class Thread {
     this.agentId = params.agentId;
     this.sourceAssignments = params.sourceAssignments;
     this.mcpIntegrationIds = params.mcpIntegrationIds ?? [];
-    this.knowledgeBases = params.knowledgeBases;
+    this.knowledgeBaseAssignments = params.knowledgeBaseAssignments;
     this.title = params.title;
     this.messages = params.messages;
     this.isAnonymous = params.isAnonymous ?? false;

--- a/ayunis-core-backend/src/domain/threads/domain/thread.entity.ts
+++ b/ayunis-core-backend/src/domain/threads/domain/thread.entity.ts
@@ -4,6 +4,7 @@ import type { Message } from 'src/domain/messages/domain/message.entity';
 import type { PermittedLanguageModel } from 'src/domain/models/domain/permitted-model.entity';
 import type { SourceAssignment } from './thread-source-assignment.entity';
 import type { KnowledgeBaseAssignment } from './thread-knowledge-base-assignment.entity';
+import type { KnowledgeBaseSummary } from 'src/domain/knowledge-bases/domain/knowledge-base-summary';
 
 export class Thread {
   id: UUID;
@@ -49,5 +50,22 @@ export class Thread {
 
   getLastMessage(): Message | undefined {
     return this.messages.at(-1);
+  }
+
+  /**
+   * Returns deduplicated knowledge bases by knowledgeBaseId.
+   * The same KB can appear multiple times in knowledgeBaseAssignments
+   * when it was assigned by different origin skills.
+   */
+  getUniqueKnowledgeBases(): KnowledgeBaseSummary[] {
+    const seen = new Set<UUID>();
+    const result: KnowledgeBaseSummary[] = [];
+    for (const assignment of this.knowledgeBaseAssignments ?? []) {
+      if (!seen.has(assignment.knowledgeBase.id)) {
+        seen.add(assignment.knowledgeBase.id);
+        result.push(assignment.knowledgeBase);
+      }
+    }
+    return result;
   }
 }

--- a/ayunis-core-backend/src/domain/threads/infrastructure/persistence/local/local-threads-repository.module.ts
+++ b/ayunis-core-backend/src/domain/threads/infrastructure/persistence/local/local-threads-repository.module.ts
@@ -7,6 +7,7 @@ import { LocalThreadsRepository } from './local-threads.repository';
 import { LocalMessagesRepositoryModule } from 'src/domain/messages/infrastructure/persistence/local/local-messages-repository.module';
 import { ThreadMapper } from './mappers/thread.mapper';
 import { ThreadSourceAssignmentMapper } from './mappers/thread-source-assignment.mapper';
+import { ThreadKnowledgeBaseAssignmentMapper } from './mappers/thread-knowledge-base-assignment.mapper';
 import { LocalPermittedModelsRepositoryModule } from 'src/domain/models/infrastructure/persistence/local-permitted-models/local-permitted-models-repository.module';
 import { LocalAgentsRepositoryModule } from 'src/domain/agents/infrastructure/persistence/local/local-agent-repository.module';
 import { LocalSourceRepositoryModule } from 'src/domain/sources/infrastructure/persistence/local/local-source-repository.module';
@@ -27,7 +28,13 @@ import { LocalSourceRepositoryModule } from 'src/domain/sources/infrastructure/p
     LocalThreadsRepository,
     ThreadMapper,
     ThreadSourceAssignmentMapper,
+    ThreadKnowledgeBaseAssignmentMapper,
   ],
-  exports: [LocalThreadsRepository, ThreadMapper, ThreadSourceAssignmentMapper],
+  exports: [
+    LocalThreadsRepository,
+    ThreadMapper,
+    ThreadSourceAssignmentMapper,
+    ThreadKnowledgeBaseAssignmentMapper,
+  ],
 })
 export class LocalThreadsRepositoryModule {}

--- a/ayunis-core-backend/src/domain/threads/infrastructure/persistence/local/local-threads.repository.ts
+++ b/ayunis-core-backend/src/domain/threads/infrastructure/persistence/local/local-threads.repository.ts
@@ -7,17 +7,17 @@ import {
 } from 'src/domain/threads/application/ports/threads.repository';
 import { Logger, Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { FindOptionsRelations, Repository } from 'typeorm';
+import { FindOptionsRelations, IsNull, Repository } from 'typeorm';
 import { ThreadRecord } from './schema/thread.record';
 import { ThreadMapper } from './mappers/thread.mapper';
-import { UUID } from 'crypto';
+import { UUID, randomUUID } from 'crypto';
 import { ThreadNotFoundError } from 'src/domain/threads/application/threads.errors';
 import { SourceAssignment } from 'src/domain/threads/domain/thread-source-assignment.entity';
 import { ThreadSourceAssignmentMapper } from './mappers/thread-source-assignment.mapper';
 import { ThreadSourceAssignmentRecord } from './schema/thread-source-assignment.record';
+import { ThreadKnowledgeBaseAssignmentRecord } from './schema/thread-knowledge-base-assignment.record';
 import { Paginated } from 'src/common/pagination/paginated.entity';
 import type { McpIntegrationRecord } from 'src/domain/mcp/infrastructure/persistence/postgres/schema/mcp-integration.record';
-import type { KnowledgeBaseRecord } from 'src/domain/knowledge-bases/infrastructure/persistence/local/schema/knowledge-base.record';
 import { ThreadsConstants } from 'src/domain/threads/domain/threads.constants';
 
 @Injectable()
@@ -29,6 +29,8 @@ export class LocalThreadsRepository extends ThreadsRepository {
     private readonly threadRepository: Repository<ThreadRecord>,
     @InjectRepository(ThreadSourceAssignmentRecord)
     private readonly threadSourceAssignmentRepository: Repository<ThreadSourceAssignmentRecord>,
+    @InjectRepository(ThreadKnowledgeBaseAssignmentRecord)
+    private readonly threadKbAssignmentRepository: Repository<ThreadKnowledgeBaseAssignmentRecord>,
     private readonly threadMapper: ThreadMapper,
     private readonly sourceAssignmentMapper: ThreadSourceAssignmentMapper,
   ) {
@@ -46,7 +48,8 @@ export class LocalThreadsRepository extends ThreadsRepository {
         'model',
         'sourceAssignments',
         'sourceAssignments.source',
-        'knowledgeBases',
+        'knowledgeBaseAssignments',
+        'knowledgeBaseAssignments.knowledgeBase',
         'mcpIntegrations',
       ],
       order: {
@@ -74,7 +77,9 @@ export class LocalThreadsRepository extends ThreadsRepository {
         sourceAssignments: {
           source: true,
         },
-        knowledgeBases: true,
+        knowledgeBaseAssignments: {
+          knowledgeBase: true,
+        },
         mcpIntegrations: true,
       },
       order: {
@@ -215,7 +220,9 @@ export class LocalThreadsRepository extends ThreadsRepository {
           }
         : false,
       model: options?.withModel ? true : false,
-      knowledgeBases: options?.withKnowledgeBases ? true : false,
+      knowledgeBaseAssignments: options?.withKnowledgeBases
+        ? { knowledgeBase: true }
+        : false,
       mcpIntegrations: true,
     };
     return relations;
@@ -338,30 +345,60 @@ export class LocalThreadsRepository extends ThreadsRepository {
     await this.threadRepository.save(threadEntity);
   }
 
-  async updateKnowledgeBases(params: {
+  async addKnowledgeBaseAssignment(params: {
     threadId: UUID;
     userId: UUID;
-    knowledgeBaseIds: UUID[];
+    knowledgeBaseId: UUID;
+    originSkillId?: UUID;
   }): Promise<void> {
-    this.logger.log('updateKnowledgeBases', {
+    this.logger.log('addKnowledgeBaseAssignment', {
       threadId: params.threadId,
-      knowledgeBaseIds: params.knowledgeBaseIds,
+      knowledgeBaseId: params.knowledgeBaseId,
+      originSkillId: params.originSkillId,
     });
 
     const threadEntity = await this.threadRepository.findOne({
       where: { id: params.threadId, userId: params.userId },
-      relations: ['knowledgeBases'],
     });
 
     if (!threadEntity) {
       throw new ThreadNotFoundError(params.threadId, params.userId);
     }
 
-    threadEntity.knowledgeBases = params.knowledgeBaseIds.map(
-      (id) => ({ id }) as KnowledgeBaseRecord,
-    );
+    const record = new ThreadKnowledgeBaseAssignmentRecord();
+    record.id = randomUUID();
+    record.threadId = params.threadId;
+    record.knowledgeBaseId = params.knowledgeBaseId;
+    record.originSkillId = params.originSkillId ?? null;
 
-    await this.threadRepository.save(threadEntity);
+    await this.threadKbAssignmentRepository.save(record);
+  }
+
+  async removeKnowledgeBaseAssignment(params: {
+    threadId: UUID;
+    userId: UUID;
+    knowledgeBaseId: UUID;
+    originSkillId?: UUID;
+  }): Promise<void> {
+    this.logger.log('removeKnowledgeBaseAssignment', {
+      threadId: params.threadId,
+      knowledgeBaseId: params.knowledgeBaseId,
+      originSkillId: params.originSkillId,
+    });
+
+    const threadEntity = await this.threadRepository.findOne({
+      where: { id: params.threadId, userId: params.userId },
+    });
+
+    if (!threadEntity) {
+      throw new ThreadNotFoundError(params.threadId, params.userId);
+    }
+
+    await this.threadKbAssignmentRepository.delete({
+      threadId: params.threadId,
+      knowledgeBaseId: params.knowledgeBaseId,
+      originSkillId: params.originSkillId ?? IsNull(),
+    });
   }
 
   async delete(id: UUID, userId: UUID): Promise<void> {
@@ -398,6 +435,75 @@ export class LocalThreadsRepository extends ThreadsRepository {
       )
       .setParameters({
         originSkillId: params.originSkillId,
+        userIds: params.userIds,
+      })
+      .execute();
+  }
+
+  async removeKnowledgeBaseAssignmentsByOriginSkill(params: {
+    originSkillId: UUID;
+    userIds: UUID[];
+  }): Promise<void> {
+    this.logger.log('removeKnowledgeBaseAssignmentsByOriginSkill', {
+      originSkillId: params.originSkillId,
+      userCount: params.userIds.length,
+    });
+
+    if (params.userIds.length === 0) {
+      return;
+    }
+
+    await this.threadKbAssignmentRepository
+      .createQueryBuilder('tkba')
+      .delete()
+      .from(ThreadKnowledgeBaseAssignmentRecord)
+      .where(
+        'id IN ' +
+          this.threadKbAssignmentRepository
+            .createQueryBuilder('tkba')
+            .select('tkba.id')
+            .innerJoin('tkba.thread', 'thread')
+            .where('tkba.originSkillId = :originSkillId')
+            .andWhere('thread.userId IN (:...userIds)')
+            .getQuery(),
+      )
+      .setParameters({
+        originSkillId: params.originSkillId,
+        userIds: params.userIds,
+      })
+      .execute();
+  }
+
+  async removeDirectKnowledgeBaseAssignments(params: {
+    knowledgeBaseId: UUID;
+    userIds: UUID[];
+  }): Promise<void> {
+    this.logger.log('removeDirectKnowledgeBaseAssignments', {
+      knowledgeBaseId: params.knowledgeBaseId,
+      userCount: params.userIds.length,
+    });
+
+    if (params.userIds.length === 0) {
+      return;
+    }
+
+    await this.threadKbAssignmentRepository
+      .createQueryBuilder('tkba')
+      .delete()
+      .from(ThreadKnowledgeBaseAssignmentRecord)
+      .where(
+        'id IN ' +
+          this.threadKbAssignmentRepository
+            .createQueryBuilder('tkba')
+            .select('tkba.id')
+            .innerJoin('tkba.thread', 'thread')
+            .where('tkba.knowledgeBaseId = :knowledgeBaseId')
+            .andWhere('tkba.originSkillId IS NULL')
+            .andWhere('thread.userId IN (:...userIds)')
+            .getQuery(),
+      )
+      .setParameters({
+        knowledgeBaseId: params.knowledgeBaseId,
         userIds: params.userIds,
       })
       .execute();

--- a/ayunis-core-backend/src/domain/threads/infrastructure/persistence/local/mappers/thread-knowledge-base-assignment.mapper.ts
+++ b/ayunis-core-backend/src/domain/threads/infrastructure/persistence/local/mappers/thread-knowledge-base-assignment.mapper.ts
@@ -1,0 +1,40 @@
+import { Injectable } from '@nestjs/common';
+import { UUID } from 'crypto';
+import { KnowledgeBaseAssignment } from '../../../../domain/thread-knowledge-base-assignment.entity';
+import { ThreadKnowledgeBaseAssignmentRecord } from '../schema/thread-knowledge-base-assignment.record';
+import type { KnowledgeBaseRecord } from 'src/domain/knowledge-bases/infrastructure/persistence/local/schema/knowledge-base.record';
+
+@Injectable()
+export class ThreadKnowledgeBaseAssignmentMapper {
+  toDomain(
+    record: ThreadKnowledgeBaseAssignmentRecord,
+  ): KnowledgeBaseAssignment {
+    return new KnowledgeBaseAssignment({
+      id: record.id,
+      knowledgeBase: {
+        id: record.knowledgeBaseId,
+        name: record.knowledgeBase.name,
+      },
+      originSkillId: record.originSkillId ?? undefined,
+      createdAt: record.createdAt,
+      updatedAt: record.updatedAt,
+    });
+  }
+
+  toRecord(
+    domain: KnowledgeBaseAssignment,
+    threadId: UUID,
+  ): ThreadKnowledgeBaseAssignmentRecord {
+    const record = new ThreadKnowledgeBaseAssignmentRecord();
+    record.id = domain.id;
+    record.threadId = threadId;
+    record.knowledgeBaseId = domain.knowledgeBase.id;
+    record.knowledgeBase = {
+      id: domain.knowledgeBase.id,
+    } as KnowledgeBaseRecord;
+    record.originSkillId = domain.originSkillId ?? null;
+    record.createdAt = domain.createdAt;
+    record.updatedAt = domain.updatedAt;
+    return record;
+  }
+}

--- a/ayunis-core-backend/src/domain/threads/infrastructure/persistence/local/schema/thread.record.ts
+++ b/ayunis-core-backend/src/domain/threads/infrastructure/persistence/local/schema/thread.record.ts
@@ -1,6 +1,14 @@
 import { UUID } from 'crypto';
 import { MessageRecord } from '../../../../../messages/infrastructure/persistence/local/schema/message.record';
-import { Column, Entity, OneToMany, Index, ManyToOne, ManyToMany, JoinTable } from 'typeorm';
+import {
+  Column,
+  Entity,
+  OneToMany,
+  Index,
+  ManyToOne,
+  ManyToMany,
+  JoinTable,
+} from 'typeorm';
 import { BaseRecord } from '../../../../../../common/db/base-record';
 import { PermittedModelRecord } from '../../../../../models/infrastructure/persistence/local-permitted-models/schema/permitted-model.record';
 import { AgentRecord } from '../../../../../agents/infrastructure/persistence/local/schema/agent.record';

--- a/ayunis-core-backend/src/domain/threads/presenters/http/mappers/get-thread.mapper.ts
+++ b/ayunis-core-backend/src/domain/threads/presenters/http/mappers/get-thread.mapper.ts
@@ -4,6 +4,7 @@ import { GetThreadResponseDto } from '../dto/get-thread-response.dto';
 import { MessageDtoMapper } from './message.mapper';
 import { SourceDtoMapper } from './source.mapper';
 import { FindThreadResult } from '../../../application/use-cases/find-thread/find-thread.use-case';
+import type { UUID } from 'crypto';
 
 @Injectable()
 export class GetThreadDtoMapper {
@@ -30,14 +31,30 @@ export class GetThreadDtoMapper {
       updatedAt: thread.updatedAt.toISOString(),
       isAnonymous: thread.isAnonymous,
       isLongChat,
-      knowledgeBases: (thread.knowledgeBases ?? []).map((kb) => ({
-        id: kb.id,
-        name: kb.name,
-      })),
+      knowledgeBases: this.deduplicateKnowledgeBases(thread),
     };
   }
 
   toDtoArray(threads: Thread[]): GetThreadResponseDto[] {
     return threads.map((thread) => this.toDto({ thread, isLongChat: false }));
+  }
+
+  /**
+   * Deduplicate knowledge bases by knowledgeBaseId.
+   * The same KB can appear multiple times in thread.knowledgeBaseAssignments
+   * when it was assigned by different origin skills.
+   */
+  private deduplicateKnowledgeBases(
+    thread: Thread,
+  ): { id: UUID; name: string }[] {
+    const seen = new Set<UUID>();
+    const result: { id: UUID; name: string }[] = [];
+    for (const a of thread.knowledgeBaseAssignments ?? []) {
+      if (!seen.has(a.knowledgeBase.id)) {
+        seen.add(a.knowledgeBase.id);
+        result.push({ id: a.knowledgeBase.id, name: a.knowledgeBase.name });
+      }
+    }
+    return result;
   }
 }

--- a/ayunis-core-backend/src/domain/threads/presenters/http/mappers/get-thread.mapper.ts
+++ b/ayunis-core-backend/src/domain/threads/presenters/http/mappers/get-thread.mapper.ts
@@ -4,7 +4,6 @@ import { GetThreadResponseDto } from '../dto/get-thread-response.dto';
 import { MessageDtoMapper } from './message.mapper';
 import { SourceDtoMapper } from './source.mapper';
 import { FindThreadResult } from '../../../application/use-cases/find-thread/find-thread.use-case';
-import type { UUID } from 'crypto';
 
 @Injectable()
 export class GetThreadDtoMapper {
@@ -31,30 +30,11 @@ export class GetThreadDtoMapper {
       updatedAt: thread.updatedAt.toISOString(),
       isAnonymous: thread.isAnonymous,
       isLongChat,
-      knowledgeBases: this.deduplicateKnowledgeBases(thread),
+      knowledgeBases: thread.getUniqueKnowledgeBases(),
     };
   }
 
   toDtoArray(threads: Thread[]): GetThreadResponseDto[] {
     return threads.map((thread) => this.toDto({ thread, isLongChat: false }));
-  }
-
-  /**
-   * Deduplicate knowledge bases by knowledgeBaseId.
-   * The same KB can appear multiple times in thread.knowledgeBaseAssignments
-   * when it was assigned by different origin skills.
-   */
-  private deduplicateKnowledgeBases(
-    thread: Thread,
-  ): { id: UUID; name: string }[] {
-    const seen = new Set<UUID>();
-    const result: { id: UUID; name: string }[] = [];
-    for (const a of thread.knowledgeBaseAssignments ?? []) {
-      if (!seen.has(a.knowledgeBase.id)) {
-        seen.add(a.knowledgeBase.id);
-        result.push({ id: a.knowledgeBase.id, name: a.knowledgeBase.name });
-      }
-    }
-    return result;
   }
 }

--- a/ayunis-core-backend/src/domain/threads/threads.module.ts
+++ b/ayunis-core-backend/src/domain/threads/threads.module.ts
@@ -29,6 +29,8 @@ import { AddMcpIntegrationToThreadUseCase } from './application/use-cases/add-mc
 import { AddKnowledgeBaseToThreadUseCase } from './application/use-cases/add-knowledge-base-to-thread/add-knowledge-base-to-thread.use-case';
 import { RemoveKnowledgeBaseFromThreadUseCase } from './application/use-cases/remove-knowledge-base-from-thread/remove-knowledge-base-from-thread.use-case';
 import { RemoveSkillSourcesFromThreadsUseCase } from './application/use-cases/remove-skill-sources-from-threads/remove-skill-sources-from-threads.use-case';
+import { RemoveKbAssignmentsByOriginSkillUseCase } from './application/use-cases/remove-kb-assignments-by-origin-skill/remove-kb-assignments-by-origin-skill.use-case';
+import { RemoveDirectKbFromThreadsUseCase } from './application/use-cases/remove-direct-kb-from-threads/remove-direct-kb-from-threads.use-case';
 import { ShareDeletedListener } from './application/listeners/share-deleted.listener';
 import { AgentsModule } from '../agents/agents.module';
 import { KnowledgeBasesModule } from '../knowledge-bases/knowledge-bases.module';
@@ -73,6 +75,8 @@ import { TeamsModule } from 'src/iam/teams/teams.module';
     AddKnowledgeBaseToThreadUseCase,
     RemoveKnowledgeBaseFromThreadUseCase,
     RemoveSkillSourcesFromThreadsUseCase,
+    RemoveKbAssignmentsByOriginSkillUseCase,
+    RemoveDirectKbFromThreadsUseCase,
     // Listeners
     ShareDeletedListener,
     // Mappers
@@ -97,6 +101,8 @@ import { TeamsModule } from 'src/iam/teams/teams.module';
     AddKnowledgeBaseToThreadUseCase,
     RemoveKnowledgeBaseFromThreadUseCase,
     RemoveSkillSourcesFromThreadsUseCase,
+    RemoveKbAssignmentsByOriginSkillUseCase,
+    RemoveDirectKbFromThreadsUseCase,
     // Export mappers
     GetThreadDtoMapper,
     GetThreadsDtoMapper,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Moderate risk due to a data migration replacing the thread↔KB join table and widespread repository/use-case changes around thread knowledge base assignment semantics and cleanup.
> 
> **Overview**
> **Adds provenance-aware thread knowledge base assignments.** Replaces the `thread_knowledge_bases` join table with `thread_knowledge_base_assignments` (including `originSkillId`) and migrates existing rows; thread persistence/mappers now read/write `knowledgeBaseAssignments` and expose deduped KBs via `Thread.getUniqueKnowledgeBases()` for tool assembly and thread responses.
> 
> **Updates thread APIs/use-cases to operate on assignment rows.** `ThreadsRepository` switches from `updateKnowledgeBases` to `addKnowledgeBaseAssignment`/`removeKnowledgeBaseAssignment` (origin-skill aware), adds bulk cleanup methods (`removeKnowledgeBaseAssignmentsByOriginSkill`, `removeDirectKnowledgeBaseAssignments`), and introduces corresponding use cases.
> 
> **Aligns KB access and responses.** KB document text + query use cases now rely on `KnowledgeBaseAccessService` to allow access to shared KBs (tests updated), and `KnowledgeBaseResponseDto`/mapper make `isShared` optional/conditionally included.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bef52944514aeb159ea926373f673dbf46d75181. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->