### PR TITLE
wip(AYC-99): add KB shares migration, skill originSkillId, and KB cleanup on skill share revocation

### DIFF
--- a/ayunis-core-backend/src/db/migrations/1772201046597-AddKnowledgeBaseShares.ts
+++ b/ayunis-core-backend/src/db/migrations/1772201046597-AddKnowledgeBaseShares.ts
@@ -1,0 +1,23 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddKnowledgeBaseShares1772201046597 implements MigrationInterface {
+  name = 'AddKnowledgeBaseShares1772201046597';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "shares" ADD "knowledge_base_id" character varying`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "shares" ADD CONSTRAINT "FK_9d58e41ed733832c1feaf146a62" FOREIGN KEY ("knowledge_base_id") REFERENCES "knowledge_bases"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "shares" DROP CONSTRAINT "FK_9d58e41ed733832c1feaf146a62"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "shares" DROP COLUMN "knowledge_base_id"`,
+    );
+  }
+}

--- a/ayunis-core-backend/src/domain/shares/application/services/share-scope-resolver.service.spec.ts
+++ b/ayunis-core-backend/src/domain/shares/application/services/share-scope-resolver.service.spec.ts
@@ -1,0 +1,112 @@
+import type { TestingModule } from '@nestjs/testing';
+import { Test } from '@nestjs/testing';
+import { ShareScopeResolverService } from './share-scope-resolver.service';
+import { FindAllUserIdsByOrgIdUseCase } from 'src/iam/users/application/use-cases/find-all-user-ids-by-org-id/find-all-user-ids-by-org-id.use-case';
+import { FindAllUserIdsByTeamIdUseCase } from 'src/iam/teams/application/use-cases/find-all-user-ids-by-team-id/find-all-user-ids-by-team-id.use-case';
+import { ShareScopeType } from '../../domain/value-objects/share-scope-type.enum';
+import { randomUUID } from 'crypto';
+
+describe('ShareScopeResolverService', () => {
+  let service: ShareScopeResolverService;
+  let findAllUserIdsByOrgId: { execute: jest.Mock };
+  let findAllUserIdsByTeamId: { execute: jest.Mock };
+
+  beforeAll(async () => {
+    findAllUserIdsByOrgId = {
+      execute: jest.fn().mockResolvedValue([]),
+    };
+
+    findAllUserIdsByTeamId = {
+      execute: jest.fn().mockResolvedValue([]),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ShareScopeResolverService,
+        {
+          provide: FindAllUserIdsByOrgIdUseCase,
+          useValue: findAllUserIdsByOrgId,
+        },
+        {
+          provide: FindAllUserIdsByTeamIdUseCase,
+          useValue: findAllUserIdsByTeamId,
+        },
+      ],
+    }).compile();
+
+    service = module.get<ShareScopeResolverService>(ShareScopeResolverService);
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return empty set when no scopes are provided', async () => {
+    const result = await service.resolveUserIds([]);
+
+    expect(result).toEqual(new Set());
+  });
+
+  it('should resolve user IDs from an org scope', async () => {
+    const orgId = randomUUID();
+    const userId1 = randomUUID();
+    const userId2 = randomUUID();
+
+    findAllUserIdsByOrgId.execute.mockResolvedValue([userId1, userId2]);
+
+    const result = await service.resolveUserIds([
+      { scopeType: ShareScopeType.ORG, scopeId: orgId },
+    ]);
+
+    expect(findAllUserIdsByOrgId.execute).toHaveBeenCalledWith({ orgId });
+    expect(result).toEqual(new Set([userId1, userId2]));
+  });
+
+  it('should resolve user IDs from a team scope', async () => {
+    const teamId = randomUUID();
+    const userId1 = randomUUID();
+
+    findAllUserIdsByTeamId.execute.mockResolvedValue([userId1]);
+
+    const result = await service.resolveUserIds([
+      { scopeType: ShareScopeType.TEAM, scopeId: teamId },
+    ]);
+
+    expect(findAllUserIdsByTeamId.execute).toHaveBeenCalledWith({ teamId });
+    expect(result).toEqual(new Set([userId1]));
+  });
+
+  it('should merge user IDs from multiple scopes without duplicates', async () => {
+    const orgId = randomUUID();
+    const teamId = randomUUID();
+    const sharedUserId = randomUUID();
+    const orgOnlyUserId = randomUUID();
+    const teamOnlyUserId = randomUUID();
+
+    findAllUserIdsByOrgId.execute.mockResolvedValue([
+      sharedUserId,
+      orgOnlyUserId,
+    ]);
+    findAllUserIdsByTeamId.execute.mockResolvedValue([
+      sharedUserId,
+      teamOnlyUserId,
+    ]);
+
+    const result = await service.resolveUserIds([
+      { scopeType: ShareScopeType.ORG, scopeId: orgId },
+      { scopeType: ShareScopeType.TEAM, scopeId: teamId },
+    ]);
+
+    expect(result).toEqual(
+      new Set([sharedUserId, orgOnlyUserId, teamOnlyUserId]),
+    );
+  });
+
+  it('should return empty array for unknown scope type', async () => {
+    const result = await service.resolveUserIds([
+      { scopeType: 'UNKNOWN' as ShareScopeType, scopeId: randomUUID() },
+    ]);
+
+    expect(result).toEqual(new Set());
+  });
+});

--- a/ayunis-core-backend/src/domain/shares/application/services/share-scope-resolver.service.ts
+++ b/ayunis-core-backend/src/domain/shares/application/services/share-scope-resolver.service.ts
@@ -1,0 +1,51 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { UUID } from 'crypto';
+import { ShareScopeType } from '../../domain/value-objects/share-scope-type.enum';
+import { RemainingShareScope } from '../events/share-deleted.event';
+import { FindAllUserIdsByOrgIdUseCase } from 'src/iam/users/application/use-cases/find-all-user-ids-by-org-id/find-all-user-ids-by-org-id.use-case';
+import { FindAllUserIdsByOrgIdQuery } from 'src/iam/users/application/use-cases/find-all-user-ids-by-org-id/find-all-user-ids-by-org-id.query';
+import { FindAllUserIdsByTeamIdUseCase } from 'src/iam/teams/application/use-cases/find-all-user-ids-by-team-id/find-all-user-ids-by-team-id.use-case';
+import { FindAllUserIdsByTeamIdQuery } from 'src/iam/teams/application/use-cases/find-all-user-ids-by-team-id/find-all-user-ids-by-team-id.query';
+
+@Injectable()
+export class ShareScopeResolverService {
+  private readonly logger = new Logger(ShareScopeResolverService.name);
+
+  constructor(
+    private readonly findAllUserIdsByOrgId: FindAllUserIdsByOrgIdUseCase,
+    private readonly findAllUserIdsByTeamId: FindAllUserIdsByTeamIdUseCase,
+  ) {}
+
+  async resolveUserIds(scopes: RemainingShareScope[]): Promise<Set<UUID>> {
+    const userIds = new Set<UUID>();
+
+    for (const scope of scopes) {
+      const ids = await this.resolveScopeUserIds(scope);
+      for (const id of ids) {
+        userIds.add(id);
+      }
+    }
+
+    return userIds;
+  }
+
+  private async resolveScopeUserIds(
+    scope: RemainingShareScope,
+  ): Promise<UUID[]> {
+    switch (scope.scopeType) {
+      case ShareScopeType.ORG:
+        return this.findAllUserIdsByOrgId.execute(
+          new FindAllUserIdsByOrgIdQuery(scope.scopeId),
+        );
+      case ShareScopeType.TEAM:
+        return this.findAllUserIdsByTeamId.execute(
+          new FindAllUserIdsByTeamIdQuery(scope.scopeId),
+        );
+      default:
+        this.logger.warn('Unknown scope type', {
+          scopeType: scope.scopeType,
+        });
+        return [];
+    }
+  }
+}

--- a/ayunis-core-backend/src/domain/shares/shares.module.ts
+++ b/ayunis-core-backend/src/domain/shares/shares.module.ts
@@ -20,6 +20,9 @@ import { GetSharesUseCase } from './application/use-cases/get-shares/get-shares.
 import { FindSharesByScopeUseCase } from './application/use-cases/find-shares-by-scope/find-shares-by-scope.use-case';
 import { FindShareByEntityUseCase } from './application/use-cases/find-share-by-entity/find-share-by-entity.use-case';
 
+// Services
+import { ShareScopeResolverService } from './application/services/share-scope-resolver.service';
+
 // Factories
 import { ShareAuthorizationFactory } from './application/factories/share-authorization.factory';
 
@@ -29,6 +32,7 @@ import { ShareDtoMapper } from './presenters/http/mappers/share-dto.mapper';
 // Presenters
 import { SharesController } from './presenters/http/shares.controller';
 import { TeamsModule } from 'src/iam/teams/teams.module';
+import { UsersModule } from 'src/iam/users/users.module';
 
 @Module({
   imports: [
@@ -39,6 +43,7 @@ import { TeamsModule } from 'src/iam/teams/teams.module';
       KnowledgeBaseShareRecord,
     ]),
     forwardRef(() => TeamsModule), // For CheckUserTeamMembershipUseCase, ListMyTeamsUseCase, GetTeamUseCase
+    UsersModule, // For ShareScopeResolverService
   ],
   providers: [
     // Repository
@@ -58,6 +63,9 @@ import { TeamsModule } from 'src/iam/teams/teams.module';
     FindSharesByScopeUseCase,
     FindShareByEntityUseCase,
 
+    // Services
+    ShareScopeResolverService,
+
     // Factories
     ShareAuthorizationFactory,
 
@@ -70,6 +78,7 @@ import { TeamsModule } from 'src/iam/teams/teams.module';
     DeleteShareUseCase,
     FindSharesByScopeUseCase,
     FindShareByEntityUseCase,
+    ShareScopeResolverService,
   ],
 })
 export class SharesModule {}

--- a/ayunis-core-backend/src/domain/skills/application/listeners/share-deleted.listener.ts
+++ b/ayunis-core-backend/src/domain/skills/application/listeners/share-deleted.listener.ts
@@ -1,14 +1,8 @@
 import { Inject, Injectable, Logger } from '@nestjs/common';
 import { OnEvent } from '@nestjs/event-emitter';
-import { UUID } from 'crypto';
 import { ShareDeletedEvent } from 'src/domain/shares/application/events/share-deleted.event';
 import { SharedEntityType } from 'src/domain/shares/domain/value-objects/shared-entity-type.enum';
-import { ShareScopeType } from 'src/domain/shares/domain/value-objects/share-scope-type.enum';
-import { FindAllUserIdsByOrgIdUseCase } from 'src/iam/users/application/use-cases/find-all-user-ids-by-org-id/find-all-user-ids-by-org-id.use-case';
-import { FindAllUserIdsByOrgIdQuery } from 'src/iam/users/application/use-cases/find-all-user-ids-by-org-id/find-all-user-ids-by-org-id.query';
-import { FindAllUserIdsByTeamIdUseCase } from 'src/iam/teams/application/use-cases/find-all-user-ids-by-team-id/find-all-user-ids-by-team-id.use-case';
-import { FindAllUserIdsByTeamIdQuery } from 'src/iam/teams/application/use-cases/find-all-user-ids-by-team-id/find-all-user-ids-by-team-id.query';
-import { RemainingShareScope } from 'src/domain/shares/application/events/share-deleted.event';
+import { ShareScopeResolverService } from 'src/domain/shares/application/services/share-scope-resolver.service';
 import { SkillRepository } from '../ports/skill.repository';
 
 @Injectable()
@@ -18,8 +12,7 @@ export class ShareDeletedListener {
   constructor(
     @Inject(SkillRepository)
     private readonly skillRepository: SkillRepository,
-    private readonly findAllUserIdsByOrgId: FindAllUserIdsByOrgIdUseCase,
-    private readonly findAllUserIdsByTeamId: FindAllUserIdsByTeamIdUseCase,
+    private readonly shareScopeResolver: ShareScopeResolverService,
   ) {}
 
   @OnEvent(ShareDeletedEvent.EVENT_NAME)
@@ -42,47 +35,14 @@ export class ShareDeletedListener {
       return;
     }
 
-    const retainUserIds = await this.resolveUserIds(event.remainingScopes);
+    const retainUserIds = await this.shareScopeResolver.resolveUserIds(
+      event.remainingScopes,
+    );
 
     await this.skillRepository.deactivateUsersNotInSet(
       event.entityId,
       event.ownerId,
       retainUserIds,
     );
-  }
-
-  private async resolveUserIds(
-    scopes: RemainingShareScope[],
-  ): Promise<Set<UUID>> {
-    const userIds = new Set<UUID>();
-
-    for (const scope of scopes) {
-      const ids = await this.resolveScopeUserIds(scope);
-      for (const id of ids) {
-        userIds.add(id);
-      }
-    }
-
-    return userIds;
-  }
-
-  private async resolveScopeUserIds(
-    scope: RemainingShareScope,
-  ): Promise<UUID[]> {
-    switch (scope.scopeType) {
-      case ShareScopeType.ORG:
-        return this.findAllUserIdsByOrgId.execute(
-          new FindAllUserIdsByOrgIdQuery(scope.scopeId),
-        );
-      case ShareScopeType.TEAM:
-        return this.findAllUserIdsByTeamId.execute(
-          new FindAllUserIdsByTeamIdQuery(scope.scopeId),
-        );
-      default:
-        this.logger.warn('Unknown scope type', {
-          scopeType: scope.scopeType,
-        });
-        return [];
-    }
   }
 }

--- a/ayunis-core-backend/src/domain/skills/application/services/skill-activation.service.spec.ts
+++ b/ayunis-core-backend/src/domain/skills/application/services/skill-activation.service.spec.ts
@@ -220,7 +220,7 @@ describe('SkillActivationService', () => {
       );
     });
 
-    it('should copy knowledge bases to the thread', async () => {
+    it('should copy knowledge bases to the thread with originSkillId', async () => {
       const thread = makeThread();
       const skill = makeSkill({
         sourceIds: [],
@@ -238,12 +238,14 @@ describe('SkillActivationService', () => {
         expect.objectContaining({
           threadId: thread.id,
           knowledgeBaseId: knowledgeBaseId1,
+          originSkillId: skillId,
         }),
       );
       expect(addKnowledgeBaseToThreadUseCase.execute).toHaveBeenCalledWith(
         expect.objectContaining({
           threadId: thread.id,
           knowledgeBaseId: knowledgeBaseId2,
+          originSkillId: skillId,
         }),
       );
     });

--- a/ayunis-core-backend/src/domain/skills/application/services/skill-activation.service.ts
+++ b/ayunis-core-backend/src/domain/skills/application/services/skill-activation.service.ts
@@ -78,7 +78,11 @@ export class SkillActivationService {
     for (const knowledgeBaseId of skill.knowledgeBaseIds) {
       try {
         await this.addKnowledgeBaseToThreadUseCase.execute(
-          new AddKnowledgeBaseToThreadCommand(thread.id, knowledgeBaseId),
+          new AddKnowledgeBaseToThreadCommand(
+            thread.id,
+            knowledgeBaseId,
+            skill.id,
+          ),
         );
       } catch (error) {
         if (error instanceof KnowledgeBaseNotFoundError) {

--- a/ayunis-core-backend/src/domain/skills/skills.module.ts
+++ b/ayunis-core-backend/src/domain/skills/skills.module.ts
@@ -51,9 +51,6 @@ import { SharedEntityType } from '../shares/domain/value-objects/shared-entity-t
 // Shares
 import { SharesModule } from '../shares/shares.module';
 
-// IAM
-import { UsersModule } from 'src/iam/users/users.module';
-import { TeamsModule } from 'src/iam/teams/teams.module';
 import { ThreadsModule } from '../threads/threads.module';
 
 // Presenters
@@ -79,8 +76,6 @@ import { KnowledgeBaseDtoMapper } from '../knowledge-bases/presenters/http/mappe
     KnowledgeBasesModule,
     MarketplaceModule,
     forwardRef(() => SharesModule),
-    UsersModule,
-    TeamsModule,
     forwardRef(() => ThreadsModule),
   ],
   providers: [

--- a/ayunis-core-backend/src/domain/threads/application/use-cases/find-all-threads/find-all-threads.query.ts
+++ b/ayunis-core-backend/src/domain/threads/application/use-cases/find-all-threads/find-all-threads.query.ts
@@ -10,6 +10,7 @@ export class FindAllThreadsQuery extends PaginatedQuery {
       withMessages?: boolean;
       withAgent?: boolean;
       withModel?: boolean;
+      withKnowledgeBases?: boolean;
     },
     public readonly filters?: {
       search?: string;

--- a/ayunis-core-backend/src/domain/threads/infrastructure/persistence/local/local-threads.repository.ts
+++ b/ayunis-core-backend/src/domain/threads/infrastructure/persistence/local/local-threads.repository.ts
@@ -137,6 +137,16 @@ export class LocalThreadsRepository extends ThreadsRepository {
         'dataSourceDetails',
       );
     }
+    if (options?.withKnowledgeBases) {
+      queryBuilder.leftJoinAndSelect(
+        'thread.knowledgeBaseAssignments',
+        'knowledgeBaseAssignments',
+      );
+      queryBuilder.leftJoinAndSelect(
+        'knowledgeBaseAssignments.knowledgeBase',
+        'knowledgeBase',
+      );
+    }
     if (options?.withModel) {
       queryBuilder.leftJoinAndSelect('thread.model', 'model');
     }

--- a/ayunis-core-backend/src/domain/threads/threads.module.ts
+++ b/ayunis-core-backend/src/domain/threads/threads.module.ts
@@ -36,8 +36,8 @@ import { AgentsModule } from '../agents/agents.module';
 import { KnowledgeBasesModule } from '../knowledge-bases/knowledge-bases.module';
 import { StorageModule } from '../storage/storage.module';
 import { MessagesModule } from '../messages/messages.module';
+import { SharesModule } from '../shares/shares.module';
 import { UsersModule } from 'src/iam/users/users.module';
-import { TeamsModule } from 'src/iam/teams/teams.module';
 
 @Module({
   imports: [
@@ -50,7 +50,7 @@ import { TeamsModule } from 'src/iam/teams/teams.module';
     OrgsModule,
     StorageModule,
     UsersModule,
-    TeamsModule,
+    SharesModule,
   ],
   controllers: [ThreadsController, ThreadKnowledgeBasesController],
   providers: [

--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
@@ -2476,8 +2476,8 @@ export interface KnowledgeBaseResponseDto {
   createdAt: string;
   /** The date and time when the knowledge base was last updated */
   updatedAt: string;
-  /** Whether the knowledge base is shared with the current user (not owned) */
-  isShared: boolean;
+  /** Whether the knowledge base is shared with the current user (not owned). Only present when relevant (e.g., listing user knowledge bases). */
+  isShared?: boolean;
 }
 
 export interface KnowledgeBaseListResponseDto {

--- a/ayunis-core-frontend/src/shared/api/openapi-schema.json
+++ b/ayunis-core-frontend/src/shared/api/openapi-schema.json
@@ -11975,7 +11975,7 @@
           },
           "isShared": {
             "type": "boolean",
-            "description": "Whether the knowledge base is shared with the current user (not owned)",
+            "description": "Whether the knowledge base is shared with the current user (not owned). Only present when relevant (e.g., listing user knowledge bases).",
             "example": false
           }
         },
@@ -11984,8 +11984,7 @@
           "name",
           "description",
           "createdAt",
-          "updatedAt",
-          "isShared"
+          "updatedAt"
         ]
       },
       "KnowledgeBaseListResponseDto": {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Includes a schema migration on `shares` and changes share-revocation cleanup logic for skills/threads, which could affect data retention/visibility if scope resolution or user targeting is wrong. Also adjusts thread retrieval to optionally join knowledge bases and propagates `originSkillId` when copying KBs, impacting downstream cleanup behavior.
> 
> **Overview**
> Adds DB support for knowledge base shares by introducing nullable `shares.knowledge_base_id` with a cascading FK to `knowledge_bases`.
> 
> Introduces `ShareScopeResolverService` (and tests) to resolve retained user IDs from org/team share scopes, and refactors skill/threads `ShareDeletedListener`s to use it; thread cleanup now also removes knowledge base assignments created via the revoked skill (`RemoveKbAssignmentsByOriginSkillUseCase`).
> 
> When activating a skill on a thread, KB assignments are now created with `originSkillId`, and thread listing/query options gain `withKnowledgeBases` support. Frontend OpenAPI types relax `KnowledgeBaseResponseDto.isShared` to be optional.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1d7e74ad15e5f9d4c1f9cf7b98745c9f95bf53e8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->