### PR TITLE
fix: german user role translation

### DIFF
--- a/ayunis-core-frontend/src/pages/admin-settings/users-settings/ui/InvitesSection.tsx
+++ b/ayunis-core-frontend/src/pages/admin-settings/users-settings/ui/InvitesSection.tsx
@@ -118,7 +118,11 @@ export default function InvitesSection({
               {invites.map((invite) => (
                 <TableRow key={invite.id}>
                   <TableCell className="font-medium">{invite.email}</TableCell>
-                  <TableCell className="capitalize">{invite.role}</TableCell>
+                  <TableCell>
+                    {invite.role === 'admin'
+                      ? t('users.admin')
+                      : t('users.user')}
+                  </TableCell>
                   <TableCell>
                     {(() => {
                       const statusColorMap: Record<string, string> = {

--- a/ayunis-core-frontend/src/pages/admin-settings/users-settings/ui/UsersSection.tsx
+++ b/ayunis-core-frontend/src/pages/admin-settings/users-settings/ui/UsersSection.tsx
@@ -145,7 +145,9 @@ export default function UsersSection({
               <TableRow key={user.id}>
                 <TableCell className="font-medium">{user.name}</TableCell>
                 <TableCell>{user.email}</TableCell>
-                <TableCell className="capitalize">{user.role}</TableCell>
+                <TableCell>
+                  {user.role === 'admin' ? t('users.admin') : t('users.user')}
+                </TableCell>
                 <TableCell>
                   <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800">
                     {t('users.active')}


### PR DESCRIPTION
Fixes German translation for user roles on admin user management pages.

The admin user management pages were displaying raw English role values ("User", "Admin") instead of their German translations ("Benutzer", "Administrator"). This PR updates `InvitesSection.tsx` and `UsersSection.tsx` to use the existing translation keys for roles.

---
[Slack Thread](https://locaboo.slack.com/archives/C0375HX2C4S/p1772200771173659?thread_ts=1772200771.173659&cid=C0375HX2C4S)

<p><a href="https://cursor.com/agents/bc-b90b041d-d0f1-5746-8ea0-7d07e91ca002"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b90b041d-d0f1-5746-8ea0-7d07e91ca002"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that only affects how roles are rendered in the admin users/invites tables via existing i18n keys.
> 
> **Overview**
> Fixes role labels on the admin user management pages to use translations instead of rendering raw role strings.
> 
> `InvitesSection` and `UsersSection` now map `admin`/`user` roles to `t('users.admin')` / `t('users.user')` when displaying the role column.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9d2cff6fc3ea54173b5b29c6a3e1158aaf20aecc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->