### PR TITLE
fix: put agent filter behind  agent feature toggle

### DIFF
--- a/ayunis-core-frontend/src/pages/chats/ui/ChatsFilters.tsx
+++ b/ayunis-core-frontend/src/pages/chats/ui/ChatsFilters.tsx
@@ -13,6 +13,7 @@ import { Search } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { useState, useEffect, useRef, useMemo } from 'react';
 import type { Agent } from '../model/types';
+import { useIsAgentsEnabled } from '@/features/feature-toggles/useIsFeatureEnabled';
 
 interface ChatsFiltersProps {
   agents: Agent[];
@@ -30,6 +31,7 @@ export default function ChatsFilters({
   const navigate = useNavigate();
   const [searchValue, setSearchValue] = useState(search ?? '');
   const searchInputRef = useRef<HTMLInputElement>(null);
+  const isAgentsEnabled = useIsAgentsEnabled();
 
   // Separate agents into personal (owned) and shared, sorted alphabetically
   const { personalAgents, sharedAgents } = useMemo(() => {
@@ -101,44 +103,46 @@ export default function ChatsFilters({
           className="pl-10"
         />
       </div>
-      <Select value={agentId ?? 'all'} onValueChange={handleAgentChange}>
-        <SelectTrigger className="w-[200px]">
-          <SelectValue placeholder={t('filters.agentFilterLabel')} />
-        </SelectTrigger>
-        <SelectContent>
-          <SelectItem value="all">{t('filters.agentFilterAll')}</SelectItem>
-          {agents.length > 0 && (
-            <>
-              {/* Personal Agents Group */}
-              {personalAgents.length > 0 && (
-                <SelectGroup>
-                  {sharedAgents.length > 0 && (
-                    <SelectLabel>{tAgents('tabs.personal')}</SelectLabel>
-                  )}
-                  {personalAgents.map((agent) => (
-                    <SelectItem key={agent.id} value={agent.id}>
-                      {agent.name}
-                    </SelectItem>
-                  ))}
-                </SelectGroup>
-              )}
-              {/* Shared Agents Group */}
-              {sharedAgents.length > 0 && (
-                <SelectGroup>
-                  {personalAgents.length > 0 && (
-                    <SelectLabel>{tAgents('tabs.shared')}</SelectLabel>
-                  )}
-                  {sharedAgents.map((agent) => (
-                    <SelectItem key={agent.id} value={agent.id}>
-                      {agent.name}
-                    </SelectItem>
-                  ))}
-                </SelectGroup>
-              )}
-            </>
-          )}
-        </SelectContent>
-      </Select>
+      {isAgentsEnabled && (
+        <Select value={agentId ?? 'all'} onValueChange={handleAgentChange}>
+          <SelectTrigger className="w-[200px]">
+            <SelectValue placeholder={t('filters.agentFilterLabel')} />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">{t('filters.agentFilterAll')}</SelectItem>
+            {agents.length > 0 && (
+              <>
+                {/* Personal Agents Group */}
+                {personalAgents.length > 0 && (
+                  <SelectGroup>
+                    {sharedAgents.length > 0 && (
+                      <SelectLabel>{tAgents('tabs.personal')}</SelectLabel>
+                    )}
+                    {personalAgents.map((agent) => (
+                      <SelectItem key={agent.id} value={agent.id}>
+                        {agent.name}
+                      </SelectItem>
+                    ))}
+                  </SelectGroup>
+                )}
+                {/* Shared Agents Group */}
+                {sharedAgents.length > 0 && (
+                  <SelectGroup>
+                    {personalAgents.length > 0 && (
+                      <SelectLabel>{tAgents('tabs.shared')}</SelectLabel>
+                    )}
+                    {sharedAgents.map((agent) => (
+                      <SelectItem key={agent.id} value={agent.id}>
+                        {agent.name}
+                      </SelectItem>
+                    ))}
+                  </SelectGroup>
+                )}
+              </>
+            )}
+          </SelectContent>
+        </Select>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
Conditionally render the agent filter on the `/chats` page to hide it when the agents feature is disabled.

---
[Slack Thread](https://locaboo.slack.com/archives/C0375HX2C4S/p1772200844965569?thread_ts=1772200844.965569&cid=C0375HX2C4S)

<p><a href="https://cursor.com/agents/bc-a3651fc0-6879-508c-a4cf-f93cf27b7a62"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a3651fc0-6879-508c-a4cf-f93cf27b7a62"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that conditionally hides the agent filter when `agentsEnabled` is off; no data/model logic changes.
> 
> **Overview**
> Adds an `agentsEnabled` feature-toggle check (`useIsAgentsEnabled`) to `ChatsFilters` so the agent `Select` dropdown on `/chats` only renders when the agents feature is enabled.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 52632532e4bddaf944df3eb4c76c5eac5259af1c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->