### PR TITLE
fix(AYC-91): execute hybrid displayable+executable tools before exiting run loop

### DIFF
--- a/ayunis-core-backend/src/domain/runs/application/services/tool-result-collector.service.spec.ts
+++ b/ayunis-core-backend/src/domain/runs/application/services/tool-result-collector.service.spec.ts
@@ -214,7 +214,7 @@ describe('ToolResultCollectorService', () => {
   });
 
   describe('exitLoopAfterAgentResponse', () => {
-    it('should return true when response contains a hybrid displayable+executable tool', () => {
+    it('should return false when response contains a hybrid displayable+executable tool', () => {
       const tool = new MockTool('create_document', ToolType.CREATE_DOCUMENT);
       const toolUseContent = makeToolUseContent('tu-4', 'create_document');
 
@@ -225,6 +225,25 @@ describe('ToolResultCollectorService', () => {
       checkToolCapabilitiesUseCase.execute.mockReturnValue({
         isDisplayable: true,
         isExecutable: true,
+      });
+
+      const result = service.exitLoopAfterAgentResponse(message, [tool]);
+
+      // Hybrid tools need backend execution, so the loop must continue
+      expect(result).toBe(false);
+    });
+
+    it('should return true when response contains a display-only tool', () => {
+      const tool = new MockTool('chart_tool', ToolType.ACTIVATE_SKILL);
+      const toolUseContent = makeToolUseContent('tu-5', 'chart_tool');
+
+      const message = {
+        content: [toolUseContent],
+      } as unknown as AssistantMessage;
+
+      checkToolCapabilitiesUseCase.execute.mockReturnValue({
+        isDisplayable: true,
+        isExecutable: false,
       });
 
       const result = service.exitLoopAfterAgentResponse(message, [tool]);

--- a/ayunis-core-backend/src/domain/runs/application/services/tool-result-collector.service.ts
+++ b/ayunis-core-backend/src/domain/runs/application/services/tool-result-collector.service.ts
@@ -60,73 +60,111 @@ export class ToolResultCollectorService {
     const toolResultMessageContent: ToolResultMessageContent[] = [];
 
     for (const content of toolUseMessageContent) {
-      const tool = tools.find((tool) => tool.name === content.name);
-      if (!tool) {
-        toolResultMessageContent.push(
-          new ToolResultMessageContent(
-            content.id,
-            content.name,
-            `A tool with the name ${content.name} was not found. Only use tools that are available in your given list of tools.`,
-          ),
-        );
-        continue;
-      }
-
-      safeMetric(this.logger, () => {
-        const labels = getUserContextLabels(this.contextService);
-        this.toolUsesCounter.inc({
-          ...labels,
-          tool_name: content.name,
-        });
-      });
-
-      try {
-        const capabilities = this.checkToolCapabilitiesUseCase.execute(
-          new CheckToolCapabilitiesQuery(tool),
-        );
-
-        if (capabilities.isDisplayable && capabilities.isExecutable) {
-          // Hybrid tool: execute for side effects, then return displayable result
-          const executionResult = await this.executeBackendTool(
-            tool,
-            content,
-            orgId,
-            thread.id,
-            isAnonymous,
-          );
-          if (executionResult.succeeded) {
-            toolResultMessageContent.push(
-              this.handleDisplayableTool(content, input),
-            );
-          } else {
-            toolResultMessageContent.push(executionResult.content);
-          }
-        } else if (capabilities.isDisplayable) {
-          toolResultMessageContent.push(
-            this.handleDisplayableTool(content, input),
-          );
-        } else if (capabilities.isExecutable) {
-          const executionResult = await this.executeBackendTool(
-            tool,
-            content,
-            orgId,
-            thread.id,
-            isAnonymous,
-          );
-          toolResultMessageContent.push(executionResult.content);
-        }
-      } catch (error) {
-        if (error instanceof ApplicationError) {
-          throw error;
-        }
-        this.logger.error(`Error processing tool ${content.name}`, error);
-        throw new RunToolExecutionFailedError(content.name, {
-          error: error as Error,
-        });
-      }
+      const result = await this.processToolUse(
+        content,
+        tools,
+        input,
+        orgId,
+        thread.id,
+        isAnonymous,
+      );
+      toolResultMessageContent.push(result);
     }
 
     return toolResultMessageContent;
+  }
+
+  private async processToolUse(
+    content: ToolUseMessageContent,
+    tools: Tool[],
+    input: RunToolResultInput | null,
+    orgId: UUID,
+    threadId: UUID,
+    isAnonymous: boolean,
+  ): Promise<ToolResultMessageContent> {
+    const tool = tools.find((t) => t.name === content.name);
+    if (!tool) {
+      return new ToolResultMessageContent(
+        content.id,
+        content.name,
+        `A tool with the name ${content.name} was not found. Only use tools that are available in your given list of tools.`,
+      );
+    }
+
+    safeMetric(this.logger, () => {
+      const labels = getUserContextLabels(this.contextService);
+      this.toolUsesCounter.inc({
+        ...labels,
+        tool_name: content.name,
+      });
+    });
+
+    try {
+      const capabilities = this.checkToolCapabilitiesUseCase.execute(
+        new CheckToolCapabilitiesQuery(tool),
+      );
+
+      if (capabilities.isDisplayable && capabilities.isExecutable) {
+        return await this.processHybridTool(
+          tool,
+          content,
+          input,
+          orgId,
+          threadId,
+          isAnonymous,
+        );
+      }
+
+      if (capabilities.isDisplayable) {
+        return this.handleDisplayableTool(content, input);
+      }
+
+      if (capabilities.isExecutable) {
+        const executionResult = await this.executeBackendTool(
+          tool,
+          content,
+          orgId,
+          threadId,
+          isAnonymous,
+        );
+        return executionResult.content;
+      }
+
+      return new ToolResultMessageContent(
+        content.id,
+        content.name,
+        `Tool ${content.name} has no executable or displayable capability.`,
+      );
+    } catch (error) {
+      if (error instanceof ApplicationError) {
+        throw error;
+      }
+      this.logger.error(`Error processing tool ${content.name}`, error);
+      throw new RunToolExecutionFailedError(content.name, {
+        error: error as Error,
+      });
+    }
+  }
+
+  private async processHybridTool(
+    tool: Tool,
+    content: ToolUseMessageContent,
+    input: RunToolResultInput | null,
+    orgId: UUID,
+    threadId: UUID,
+    isAnonymous: boolean,
+  ): Promise<ToolResultMessageContent> {
+    const executionResult = await this.executeBackendTool(
+      tool,
+      content,
+      orgId,
+      threadId,
+      isAnonymous,
+    );
+    if (executionResult.succeeded) {
+      return this.handleDisplayableTool(content, input);
+    }
+    return executionResult.content;
   }
 
   exitLoopAfterAgentResponse(
@@ -139,7 +177,7 @@ export class ToolResultCollectorService {
     if (responseDoesNotContainToolCalls) return true;
 
     try {
-      const responseContainsDisplayTool = agentResponseMessage.content
+      const responseContainsDisplayOnlyTool = agentResponseMessage.content
         .filter((content) => content instanceof ToolUseMessageContent)
         .some((content) => {
           const tool = tools.find((tool) => tool.name === content.name);
@@ -150,11 +188,13 @@ export class ToolResultCollectorService {
             return false;
           }
 
-          return this.checkToolCapabilitiesUseCase.execute(
+          const capabilities = this.checkToolCapabilitiesUseCase.execute(
             new CheckToolCapabilitiesQuery(tool),
-          ).isDisplayable;
+          );
+          // Only exit the loop for display-only tools (not hybrid tools that also need execution)
+          return capabilities.isDisplayable && !capabilities.isExecutable;
         });
-      if (responseContainsDisplayTool) return true;
+      if (responseContainsDisplayOnlyTool) return true;
     } catch (error) {
       this.logger.error('Error checking for display tools', error);
     }

--- a/ayunis-core-frontend/src/pages/chat/api/useMessageSend.ts
+++ b/ayunis-core-frontend/src/pages/chat/api/useMessageSend.ts
@@ -12,6 +12,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import {
   getThreadsControllerFindAllQueryKey,
   getThreadsControllerFindOneQueryKey,
+  getArtifactsControllerFindByThreadQueryKey,
 } from '@/shared/api/generated/ayunisCoreAPI';
 
 export interface PendingImage {
@@ -234,6 +235,7 @@ export function useMessageSend(params: UseMessageSendParams) {
           [
             getThreadsControllerFindOneQueryKey(params.threadId),
             getThreadsControllerFindAllQueryKey(),
+            getArtifactsControllerFindByThreadQueryKey(params.threadId),
           ].forEach((queryKey) => {
             void queryClient.invalidateQueries({
               queryKey,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the run-loop termination criteria and tool-result processing for hybrid (displayable+executable) tools, which can affect run execution flow and side effects. Also updates frontend cache invalidation to refresh artifacts after sending messages.
> 
> **Overview**
> Ensures **hybrid tools (displayable+executable)** are executed on the backend before the run loop can terminate, and only exits early for *display-only* tools by updating `exitLoopAfterAgentResponse`.
> 
> Refactors backend tool result collection by extracting per-tool handling into `processToolUse`/`processHybridTool`, preserving execution-error propagation to the LLM and adding an explicit fallback when a tool has no capabilities; tests are updated to cover the new hybrid vs display-only loop-exit behavior.
> 
> On the frontend, `useMessageSend` now also invalidates the artifacts-by-thread query after a successful send so UI refreshes generated artifacts.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e443ef6854336c2745e0cc838016c5729453916b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->