### PR TITLE
fix(AYC-000): restore optional chaining on tooltip config lookup

### DIFF
--- a/ayunis-core-frontend/src/shared/ui/shadcn/chart.tsx
+++ b/ayunis-core-frontend/src/shared/ui/shadcn/chart.tsx
@@ -142,7 +142,8 @@ function ChartTooltipContent({
     const itemConfig = getPayloadConfigFromPayload(config, item, key);
     const value =
       !labelKey && typeof label === 'string'
-        ? (config[label].label ?? label)
+        ? // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- label may not exist as a key in config at runtime
+          (config[label]?.label ?? label)
         : itemConfig?.label;
 
     if (labelFormatter) {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk, localized UI change; it only adds a safe optional lookup in tooltip label resolution to prevent runtime errors when `label` isn’t present in the chart config.
> 
> **Overview**
> Fixes `ChartTooltipContent` label resolution by restoring optional chaining when looking up `config[label].label`, preventing a crash when the tooltip `label` string isn’t a key in `config` (and silencing the TS lint false-positive with an inline disable).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e9f980e65bd88aedb665c7292792275c91d18597. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->