### PR TITLE
fix(AYC-000): scope chart download to chart area only

### DIFF
--- a/ayunis-core-frontend/src/widgets/charts/lib/useDownloadChartImage.ts
+++ b/ayunis-core-frontend/src/widgets/charts/lib/useDownloadChartImage.ts
@@ -15,12 +15,6 @@ export function useDownloadChartImage(title?: string) {
       const dataUrl = await toPng(node, {
         backgroundColor: '#ffffff',
         pixelRatio: 2,
-        filter: (domNode) => {
-          if (domNode instanceof Element) {
-            return !domNode.hasAttribute('data-exclude-from-export');
-          }
-          return true;
-        },
       });
 
       const link = document.createElement('a');

--- a/ayunis-core-frontend/src/widgets/charts/ui/ChartCard.tsx
+++ b/ayunis-core-frontend/src/widgets/charts/ui/ChartCard.tsx
@@ -48,10 +48,10 @@ export function ChartCard({
   }, [xCount, threshold, perPointPx]);
 
   return (
-    <Card className={cn('my-2', className)} ref={chartRef}>
+    <Card className={cn('my-2', className)}>
       <CardHeader>
         {title && <CardTitle>{title}</CardTitle>}
-        <CardAction data-exclude-from-export>
+        <CardAction>
           <Button
             variant="ghost"
             size="icon-sm"
@@ -69,13 +69,15 @@ export function ChartCard({
       </CardHeader>
 
       <CardContent className="overflow-auto">
-        <ChartContainer
-          className="min-h-[300px] max-h-[400px]"
-          style={dynamicWidth ? { width: dynamicWidth } : undefined}
-          config={config}
-        >
-          {children}
-        </ChartContainer>
+        <div ref={chartRef}>
+          <ChartContainer
+            className="min-h-[300px] max-h-[400px]"
+            style={dynamicWidth ? { width: dynamicWidth } : undefined}
+            config={config}
+          >
+            {children}
+          </ChartContainer>
+        </div>
       </CardContent>
 
       {insight?.trim() && (


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk UI change that only alters which DOM subtree is captured for chart image export; no data or security-sensitive logic touched.
> 
> **Overview**
> Chart image download now captures only the rendered chart area by moving `chartRef` from the full `Card` to a wrapper around `ChartContainer`.
> 
> Removes the `data-exclude-from-export` mechanism and the `html-to-image` `filter` option, since non-chart UI is no longer inside the captured node.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b61ec0699c8dcfc931fa849f4fdf41be266c8901. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->