### PR TITLE
fix(AYC-000): restore optional chaining on azure streaming chunk delta

### DIFF
--- a/ayunis-core-backend/src/domain/models/infrastructure/stream-inference/base-openai-chat.stream-inference.ts
+++ b/ayunis-core-backend/src/domain/models/infrastructure/stream-inference/base-openai-chat.stream-inference.ts
@@ -12,9 +12,7 @@ import { ThinkingContentParser } from 'src/common/util/thinking-content-parser';
 import { OpenAIChatMessageConverter } from '../converters/openai-chat-message.converter';
 
 @Injectable()
-export class BaseOpenAIChatStreamInferenceHandler
-  implements StreamInferenceHandler
-{
+export class BaseOpenAIChatStreamInferenceHandler implements StreamInferenceHandler {
   private readonly logger = new Logger(
     BaseOpenAIChatStreamInferenceHandler.name,
   );
@@ -102,22 +100,27 @@ export class BaseOpenAIChatStreamInferenceHandler
   private convertChunk = (
     chunk: OpenAI.ChatCompletionChunk,
   ): StreamInferenceResponseChunk => {
-    const delta = chunk.choices[0]?.delta;
-    const textContent = delta.content ?? null;
+    // Azure may send chunks with empty choices (e.g. content filter results).
+    // Guard against undefined delta to avoid runtime TypeError.
+    const choice = chunk.choices[0] as
+      | OpenAI.ChatCompletionChunk.Choice
+      | undefined;
+    const delta = choice?.delta;
+    const textContent = delta?.content ?? null;
 
     // Parse thinking content from text
     const { thinkingDelta, textContentDelta } = textContent
       ? this.thinkingParser.parse(textContent)
       : { thinkingDelta: null, textContentDelta: null };
 
-    const finishReason = chunk.choices[0]?.finish_reason ?? null;
+    const finishReason = choice?.finish_reason ?? null;
     const usage = chunk.usage;
 
     return new StreamInferenceResponseChunk({
       thinkingDelta,
       textContentDelta,
       toolCallsDelta:
-        delta.tool_calls?.map(
+        delta?.tool_calls?.map(
           (toolCall) =>
             new StreamInferenceResponseChunkToolCall({
               index: toolCall.index,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: a small defensive change to streaming chunk parsing to avoid runtime errors when Azure returns chunks without `choices`; behavior should remain the same for normal OpenAI chunks.
> 
> **Overview**
> Hardens `BaseOpenAIChatStreamInferenceHandler` streaming parsing by handling Azure/OpenAI chat completion chunks that may arrive with **empty `choices`** (e.g., content filter events).
> 
> `convertChunk` now safely optional-chains `delta`/`finish_reason`/`tool_calls` off an optionally-present first choice, preventing `TypeError` crashes during streaming while keeping emitted deltas/usage logic unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 65b95df911e3d28cb45f0f95dddc84234233584c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->