### PR TITLE
fix(AYC-000): skip jwt auth for metrics endpoint

### DIFF
--- a/ayunis-core-backend/src/iam/authentication/application/guards/jwt-auth.guard.ts
+++ b/ayunis-core-backend/src/iam/authentication/application/guards/jwt-auth.guard.ts
@@ -2,7 +2,6 @@ import { ExecutionContext, Injectable, Logger } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
 import { AuthGuard } from '@nestjs/passport';
 import { IS_PUBLIC_KEY } from 'src/common/guards/public.guard';
-import { METRICS_PATH } from 'src/metrics/metrics.constants';
 import { Request, Response } from 'express';
 import { RefreshTokenUseCase } from '../use-cases/refresh-token/refresh-token.use-case';
 import { RefreshTokenCommand } from '../use-cases/refresh-token/refresh-token.command';
@@ -22,12 +21,6 @@ export class JwtAuthGuard extends AuthGuard('jwt') {
   }
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
-    // Skip JWT auth for the metrics endpoint (protected by its own basic-auth middleware)
-    const request = context.switchToHttp().getRequest<Request>();
-    if (request.path === METRICS_PATH) {
-      return true;
-    }
-
     // Check if route is public
     const isPublic = this.reflector.getAllAndOverride<boolean>(IS_PUBLIC_KEY, [
       context.getHandler(),
@@ -48,6 +41,7 @@ export class JwtAuthGuard extends AuthGuard('jwt') {
     }
 
     // Access token validation failed, try refresh token
+    const request = context.switchToHttp().getRequest<Request>();
     const response = context.switchToHttp().getResponse<Response>();
 
     const refreshTokenName = this.configService.get<string>(

--- a/ayunis-core-backend/src/iam/authentication/application/guards/jwt-auth.guard.ts
+++ b/ayunis-core-backend/src/iam/authentication/application/guards/jwt-auth.guard.ts
@@ -2,6 +2,7 @@ import { ExecutionContext, Injectable, Logger } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
 import { AuthGuard } from '@nestjs/passport';
 import { IS_PUBLIC_KEY } from 'src/common/guards/public.guard';
+import { METRICS_PATH } from 'src/metrics/metrics.constants';
 import { Request, Response } from 'express';
 import { RefreshTokenUseCase } from '../use-cases/refresh-token/refresh-token.use-case';
 import { RefreshTokenCommand } from '../use-cases/refresh-token/refresh-token.command';
@@ -21,6 +22,12 @@ export class JwtAuthGuard extends AuthGuard('jwt') {
   }
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
+    // Skip JWT auth for the metrics endpoint (protected by its own basic-auth middleware)
+    const request = context.switchToHttp().getRequest<Request>();
+    if (request.path === METRICS_PATH) {
+      return true;
+    }
+
     // Check if route is public
     const isPublic = this.reflector.getAllAndOverride<boolean>(IS_PUBLIC_KEY, [
       context.getHandler(),
@@ -41,7 +48,6 @@ export class JwtAuthGuard extends AuthGuard('jwt') {
     }
 
     // Access token validation failed, try refresh token
-    const request = context.switchToHttp().getRequest<Request>();
     const response = context.switchToHttp().getResponse<Response>();
 
     const refreshTokenName = this.configService.get<string>(

--- a/ayunis-core-backend/src/metrics/SUMMARY.md
+++ b/ayunis-core-backend/src/metrics/SUMMARY.md
@@ -4,7 +4,9 @@ Exposes Prometheus metrics at `/metrics` with optional basic auth protection.
 This module provides application-level Prometheus metrics for monitoring LLM usage, inference performance, message throughput, and user activity. It is a global module — metric providers (counters, histograms) are exported and can be injected into any other module.
 
 **Key files:**
-- `metrics.module.ts` — NestJS module wiring. Registers `PrometheusModule` at the `/metrics` path and applies `MetricsAuthMiddleware` to protect it.
+
+- `metrics.module.ts` — NestJS module wiring. Registers `PrometheusModule` at the `/metrics` path with a custom controller and applies `MetricsAuthMiddleware` to protect it.
+- `metrics.controller.ts` — Custom `PrometheusController` subclass decorated with `@Public()` so all global guards (JWT, EmailConfirm, Roles, Subscription, RateLimit) skip this endpoint. Actual protection is handled by `MetricsAuthMiddleware`.
 - `metrics.constants.ts` — Single source of truth for metric names, label names, and the metrics endpoint path.
 - `metrics.utils.ts` — Shared helpers: `getUserContextLabels()` extracts user/org context for metric labels; `safeMetric()` wraps metric operations in try/catch to prevent metric failures from crashing business flows.
 - `classify-inference-error.helper.ts` — Pure classification function that maps inference errors to Prometheus-friendly `error_type` label values (timeout, rate_limit, server_error, etc.).
@@ -12,6 +14,7 @@ This module provides application-level Prometheus metrics for monitoring LLM usa
 - `metrics-auth.middleware.ts` — NestMiddleware implementing HTTP Basic Auth for the metrics endpoint. Credentials come from `ConfigService` (`metrics.user` / `metrics.password`). Uses timing-safe comparison to prevent side-channel attacks.
 
 **Configuration:**
+
 - `AYUNIS_METRICS_USER` / `AYUNIS_METRICS_PASSWORD` — When both are set, the `/metrics` endpoint requires Basic Auth. When neither is set, the endpoint is open (with a warning log). Setting only one is treated as a misconfiguration — all requests are rejected until both are provided.
 
 **Cardinality note:** The `user_id` label is included on several metrics. This is acceptable for municipal deployments (hundreds of users) but should be revisited if user count grows significantly. See the comment in `metrics.constants.ts`.

--- a/ayunis-core-backend/src/metrics/metrics.controller.ts
+++ b/ayunis-core-backend/src/metrics/metrics.controller.ts
@@ -1,0 +1,19 @@
+import { Controller, Get, Res } from '@nestjs/common';
+import { PrometheusController } from '@willsoto/nestjs-prometheus';
+import { Response } from 'express';
+import { Public } from 'src/common/guards/public.guard';
+
+/**
+ * Custom metrics controller that extends the default PrometheusController.
+ * Decorated with @Public() so all global guards (JWT, EmailConfirm, Roles,
+ * Subscription, RateLimit) skip this endpoint. Actual protection is handled
+ * by MetricsAuthMiddleware (basic-auth).
+ */
+@Public()
+@Controller()
+export class MetricsController extends PrometheusController {
+  @Get()
+  async index(@Res({ passthrough: true }) response: Response) {
+    return super.index(response);
+  }
+}

--- a/ayunis-core-backend/src/metrics/metrics.module.ts
+++ b/ayunis-core-backend/src/metrics/metrics.module.ts
@@ -22,6 +22,7 @@ import {
   LABEL_STREAMING,
 } from './metrics.constants';
 import { MetricsAuthMiddleware } from './metrics-auth.middleware';
+import { MetricsController } from './metrics.controller';
 
 const tokensCounter = makeCounterProvider({
   name: AYUNIS_TOKENS_TOTAL,
@@ -82,6 +83,7 @@ const metricProviders = [
     PrometheusModule.register({
       path: METRICS_PATH,
       defaultMetrics: { enabled: true },
+      controller: MetricsController,
     }),
   ],
   providers: metricProviders,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes request-auth behavior for the `/metrics` endpoint by skipping global guards and relying solely on Basic Auth middleware; misconfiguration could unintentionally expose metrics or block scraping.
> 
> **Overview**
> Updates the metrics endpoint to **bypass all global NestJS guards** by registering a custom `PrometheusController` subclass (`MetricsController`) decorated with `@Public()`.
> 
> `PrometheusModule.register` is updated to use this controller so `/metrics` is no longer subject to JWT/roles/subscription/rate-limit guards, while `MetricsAuthMiddleware` remains the sole protection mechanism. Documentation in `metrics/SUMMARY.md` is updated to reflect this behavior and the `AYUNIS_METRICS_USER/PASSWORD` config expectations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0886198f5fea6d6430c034a3495bdfafc76c1cae. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->