### PR TITLE
wip(AYC-102): add personalized system prompt endpoint and frontend hook

### DIFF
--- a/ayunis-core-backend/package-lock.json
+++ b/ayunis-core-backend/package-lock.json
@@ -7130,7 +7130,7 @@
     },
     "node_modules/@swc/core": {
       "version": "1.11.21",
-      "devOptional": true,
+      "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -7172,6 +7172,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -7188,6 +7189,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -7204,6 +7206,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -7218,6 +7221,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -7232,6 +7236,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -7248,6 +7253,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -7264,6 +7270,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -7280,6 +7287,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -7296,6 +7304,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -7312,6 +7321,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -7323,7 +7333,7 @@
     },
     "node_modules/@swc/counter": {
       "version": "0.1.3",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/@swc/jest": {
@@ -7346,7 +7356,7 @@
     },
     "node_modules/@swc/types": {
       "version": "0.1.21",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@swc/counter": "^0.1.3"

--- a/ayunis-core-backend/package-lock.json
+++ b/ayunis-core-backend/package-lock.json
@@ -7130,7 +7130,7 @@
     },
     "node_modules/@swc/core": {
       "version": "1.11.21",
-      "dev": true,
+      "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -7172,7 +7172,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -7189,7 +7188,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -7206,7 +7204,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -7221,7 +7218,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -7236,7 +7232,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -7253,7 +7248,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -7270,7 +7264,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -7287,7 +7280,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -7304,7 +7296,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -7321,7 +7312,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -7333,7 +7323,7 @@
     },
     "node_modules/@swc/counter": {
       "version": "0.1.3",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0"
     },
     "node_modules/@swc/jest": {
@@ -7356,7 +7346,7 @@
     },
     "node_modules/@swc/types": {
       "version": "0.1.21",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@swc/counter": "^0.1.3"

--- a/ayunis-core-backend/src/domain/chat-settings/SUMMARY.md
+++ b/ayunis-core-backend/src/domain/chat-settings/SUMMARY.md
@@ -15,6 +15,7 @@ Per-user chat configuration. Currently contains the **user system prompt** featu
 - **`GetUserSystemPromptUseCase`** — Retrieves the user's system prompt (returns `null` if not set)
 - **`UpsertUserSystemPromptUseCase`** — Creates or replaces the user's system prompt
 - **`DeleteUserSystemPromptUseCase`** — Deletes the user's system prompt (idempotent)
+- **`GeneratePersonalizedSystemPromptUseCase`** — Generates a personalized system prompt and welcome message via LLM inference based on user preferences, then upserts the generated system prompt
 
 ## Infrastructure
 
@@ -26,11 +27,12 @@ Per-user chat configuration. Currently contains the **user system prompt** featu
 
 Controller: `ChatSettingsController` — base path `/chat-settings`, tag `Chat Settings`
 
-| Method | Path                          | Description                    |
-| ------ | ----------------------------- | ------------------------------ |
-| GET    | `/chat-settings/system-prompt` | Get user's system prompt       |
-| PUT    | `/chat-settings/system-prompt` | Set/update user's system prompt |
-| DELETE | `/chat-settings/system-prompt` | Delete user's system prompt    |
+| Method | Path                                                  | Description                                      |
+| ------ | ----------------------------------------------------- | ------------------------------------------------ |
+| GET    | `/chat-settings/system-prompt`                        | Get user's system prompt                         |
+| PUT    | `/chat-settings/system-prompt`                        | Set/update user's system prompt                  |
+| DELETE | `/chat-settings/system-prompt`                        | Delete user's system prompt                      |
+| POST   | `/chat-settings/generate-personalized-system-prompt`  | Generate and save a personalized system prompt   |
 
 ## Exports
 

--- a/ayunis-core-backend/src/domain/chat-settings/application/chat-settings.errors.ts
+++ b/ayunis-core-backend/src/domain/chat-settings/application/chat-settings.errors.ts
@@ -4,6 +4,7 @@ import { ApplicationError } from '../../../common/errors/base.error';
 export enum ChatSettingsErrorCode {
   USER_SYSTEM_PROMPT_NOT_FOUND = 'USER_SYSTEM_PROMPT_NOT_FOUND',
   UNEXPECTED_CHAT_SETTINGS_ERROR = 'UNEXPECTED_CHAT_SETTINGS_ERROR',
+  PERSONALIZED_SYSTEM_PROMPT_GENERATION_ERROR = 'PERSONALIZED_SYSTEM_PROMPT_GENERATION_ERROR',
 }
 
 export class ChatSettingsError extends ApplicationError {}
@@ -30,5 +31,18 @@ export class UnexpectedChatSettingsError extends ChatSettingsError {
         error,
       },
     );
+  }
+}
+
+export class PersonalizedSystemPromptGenerationError extends ChatSettingsError {
+  constructor(cause?: Error) {
+    super(
+      'Failed to generate personalized system prompt',
+      ChatSettingsErrorCode.PERSONALIZED_SYSTEM_PROMPT_GENERATION_ERROR,
+      500,
+    );
+    if (cause) {
+      this.cause = cause;
+    }
   }
 }

--- a/ayunis-core-backend/src/domain/chat-settings/application/use-cases/generate-personalized-system-prompt/generate-personalized-system-prompt.command.ts
+++ b/ayunis-core-backend/src/domain/chat-settings/application/use-cases/generate-personalized-system-prompt/generate-personalized-system-prompt.command.ts
@@ -1,0 +1,15 @@
+export class GeneratePersonalizedSystemPromptCommand {
+  public readonly preferredName: string;
+  public readonly communicationStyle?: string;
+  public readonly workContext?: string;
+
+  constructor(params: {
+    preferredName: string;
+    communicationStyle?: string;
+    workContext?: string;
+  }) {
+    this.preferredName = params.preferredName;
+    this.communicationStyle = params.communicationStyle;
+    this.workContext = params.workContext;
+  }
+}

--- a/ayunis-core-backend/src/domain/chat-settings/application/use-cases/generate-personalized-system-prompt/generate-personalized-system-prompt.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/chat-settings/application/use-cases/generate-personalized-system-prompt/generate-personalized-system-prompt.use-case.spec.ts
@@ -1,0 +1,314 @@
+import { GeneratePersonalizedSystemPromptUseCase } from './generate-personalized-system-prompt.use-case';
+import { GeneratePersonalizedSystemPromptCommand } from './generate-personalized-system-prompt.command';
+import { PersonalizedSystemPromptGenerationError } from '../../chat-settings.errors';
+import { TextMessageContent } from 'src/domain/messages/domain/message-contents/text-message-content.entity';
+import {
+  DefaultModelNotFoundError,
+  InferenceFailedError,
+} from 'src/domain/models/application/models.errors';
+import { randomUUID } from 'crypto';
+import { UserSystemPrompt } from '../../../domain/user-system-prompt.entity';
+import type { GetInferenceUseCase } from 'src/domain/models/application/use-cases/get-inference/get-inference.use-case';
+import type { GetDefaultModelUseCase } from 'src/domain/models/application/use-cases/get-default-model/get-default-model.use-case';
+import type { UpsertUserSystemPromptUseCase } from '../upsert-user-system-prompt/upsert-user-system-prompt.use-case';
+import type { ContextService } from 'src/common/context/services/context.service';
+import type { PermittedLanguageModel } from 'src/domain/models/domain/permitted-model.entity';
+import type { LanguageModel } from 'src/domain/models/domain/models/language.model';
+import type { InferenceResponse } from 'src/domain/models/application/ports/inference.handler';
+
+const userId = randomUUID();
+const orgId = randomUUID();
+
+const mockLanguageModel = {
+  id: randomUUID(),
+  name: 'gpt-4',
+  provider: 'openai',
+} as unknown as LanguageModel;
+
+const mockPermittedModel = {
+  id: randomUUID(),
+  model: mockLanguageModel,
+  orgId,
+  isDefault: true,
+} as unknown as PermittedLanguageModel;
+
+function createMockInferenceResponse(text: string): InferenceResponse {
+  return {
+    content: [new TextMessageContent(text)],
+    meta: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+  } as InferenceResponse;
+}
+
+describe('GeneratePersonalizedSystemPromptUseCase', () => {
+  let useCase: GeneratePersonalizedSystemPromptUseCase;
+  let getInferenceUseCase: jest.Mocked<Pick<GetInferenceUseCase, 'execute'>>;
+  let getDefaultModelUseCase: jest.Mocked<
+    Pick<GetDefaultModelUseCase, 'execute'>
+  >;
+  let upsertUserSystemPromptUseCase: jest.Mocked<
+    Pick<UpsertUserSystemPromptUseCase, 'execute'>
+  >;
+  let contextService: { get: jest.Mock };
+
+  beforeEach(() => {
+    getInferenceUseCase = {
+      execute: jest.fn(),
+    };
+
+    getDefaultModelUseCase = {
+      execute: jest.fn(),
+    };
+
+    upsertUserSystemPromptUseCase = {
+      execute: jest.fn(),
+    };
+
+    contextService = {
+      get: jest.fn().mockImplementation((key: string) => {
+        if (key === 'userId') return userId;
+        if (key === 'orgId') return orgId;
+        return undefined;
+      }),
+    };
+
+    useCase = new GeneratePersonalizedSystemPromptUseCase(
+      getInferenceUseCase as unknown as GetInferenceUseCase,
+      getDefaultModelUseCase as unknown as GetDefaultModelUseCase,
+      upsertUserSystemPromptUseCase as unknown as UpsertUserSystemPromptUseCase,
+      contextService as unknown as ContextService,
+    );
+  });
+
+  it('should generate system prompt and welcome message when all fields are provided', async () => {
+    const generatedSystemPrompt =
+      'Hallo Maria! Ich kommuniziere locker und direkt mit dir und unterstütze dich bei deiner Arbeit im Sozialamt.';
+    const generatedWelcome =
+      'Willkommen, Maria! Schön, dass du da bist – wie kann ich dir heute helfen?';
+
+    getDefaultModelUseCase.execute.mockResolvedValue(mockPermittedModel);
+    getInferenceUseCase.execute
+      .mockResolvedValueOnce(createMockInferenceResponse(generatedSystemPrompt))
+      .mockResolvedValueOnce(createMockInferenceResponse(generatedWelcome));
+
+    const result = await useCase.execute(
+      new GeneratePersonalizedSystemPromptCommand({
+        preferredName: 'Maria',
+        communicationStyle: 'Locker & kurz',
+        workContext: 'Bescheide im Sozialamt',
+      }),
+    );
+
+    expect(result.systemPrompt).toBe(generatedSystemPrompt);
+    expect(result.welcomeMessage).toBe(generatedWelcome);
+    expect(getInferenceUseCase.execute).toHaveBeenCalledTimes(2);
+    expect(upsertUserSystemPromptUseCase.execute).toHaveBeenCalledTimes(1);
+  });
+
+  it('should generate meaningful prompt when only name is provided', async () => {
+    const generatedSystemPrompt =
+      'Hi Thomas! I will communicate in a friendly and helpful manner.';
+    const generatedWelcome = 'Welcome, Thomas! How can I help you today?';
+
+    getDefaultModelUseCase.execute.mockResolvedValue(mockPermittedModel);
+    getInferenceUseCase.execute
+      .mockResolvedValueOnce(createMockInferenceResponse(generatedSystemPrompt))
+      .mockResolvedValueOnce(createMockInferenceResponse(generatedWelcome));
+
+    const result = await useCase.execute(
+      new GeneratePersonalizedSystemPromptCommand({
+        preferredName: 'Thomas',
+      }),
+    );
+
+    expect(result.systemPrompt).toBe(generatedSystemPrompt);
+    expect(result.welcomeMessage).toBe(generatedWelcome);
+    expect(getInferenceUseCase.execute).toHaveBeenCalledTimes(2);
+    expect(upsertUserSystemPromptUseCase.execute).toHaveBeenCalledTimes(1);
+  });
+
+  it('should throw InferenceFailedError when inference fails', async () => {
+    getDefaultModelUseCase.execute.mockResolvedValue(mockPermittedModel);
+    getInferenceUseCase.execute.mockRejectedValue(
+      new InferenceFailedError('Model unavailable'),
+    );
+
+    await expect(
+      useCase.execute(
+        new GeneratePersonalizedSystemPromptCommand({
+          preferredName: 'Anna',
+          communicationStyle: 'Professionell & ausführlich',
+        }),
+      ),
+    ).rejects.toThrow(InferenceFailedError);
+  });
+
+  it('should throw DefaultModelNotFoundError when no default model exists', async () => {
+    getDefaultModelUseCase.execute.mockRejectedValue(
+      new DefaultModelNotFoundError(orgId),
+    );
+
+    await expect(
+      useCase.execute(
+        new GeneratePersonalizedSystemPromptCommand({
+          preferredName: 'Klaus',
+        }),
+      ),
+    ).rejects.toThrow(DefaultModelNotFoundError);
+  });
+
+  it('should upsert the generated system prompt', async () => {
+    const generatedSystemPrompt = 'Personalized prompt for Lisa.';
+    const generatedWelcome = 'Welcome, Lisa!';
+
+    getDefaultModelUseCase.execute.mockResolvedValue(mockPermittedModel);
+    getInferenceUseCase.execute
+      .mockResolvedValueOnce(createMockInferenceResponse(generatedSystemPrompt))
+      .mockResolvedValueOnce(createMockInferenceResponse(generatedWelcome));
+
+    await useCase.execute(
+      new GeneratePersonalizedSystemPromptCommand({
+        preferredName: 'Lisa',
+      }),
+    );
+
+    expect(upsertUserSystemPromptUseCase.execute).toHaveBeenCalledWith(
+      expect.objectContaining({ systemPrompt: generatedSystemPrompt }),
+    );
+  });
+
+  it('should return empty welcome message when welcome generation fails', async () => {
+    const generatedSystemPrompt = 'Personalized prompt for Eva.';
+
+    getDefaultModelUseCase.execute.mockResolvedValue(mockPermittedModel);
+    getInferenceUseCase.execute
+      .mockResolvedValueOnce(createMockInferenceResponse(generatedSystemPrompt))
+      .mockRejectedValueOnce(new Error('Welcome generation failed'));
+
+    const result = await useCase.execute(
+      new GeneratePersonalizedSystemPromptCommand({
+        preferredName: 'Eva',
+      }),
+    );
+
+    expect(result.systemPrompt).toBe(generatedSystemPrompt);
+    expect(result.welcomeMessage).toBe('');
+    expect(upsertUserSystemPromptUseCase.execute).toHaveBeenCalledWith(
+      expect.objectContaining({ systemPrompt: generatedSystemPrompt }),
+    );
+  });
+
+  it('should upsert system prompt before generating welcome message', async () => {
+    const generatedSystemPrompt = 'Prompt for order check.';
+    const callOrder: string[] = [];
+
+    getDefaultModelUseCase.execute.mockResolvedValue(mockPermittedModel);
+    upsertUserSystemPromptUseCase.execute.mockImplementation(async () => {
+      callOrder.push('upsert');
+      return new UserSystemPrompt({
+        userId,
+        systemPrompt: generatedSystemPrompt,
+      });
+    });
+    getInferenceUseCase.execute
+      .mockImplementationOnce(async () => {
+        callOrder.push('inference:systemPrompt');
+        return createMockInferenceResponse(generatedSystemPrompt);
+      })
+      .mockImplementationOnce(async () => {
+        callOrder.push('inference:welcome');
+        return createMockInferenceResponse('Welcome!');
+      });
+
+    await useCase.execute(
+      new GeneratePersonalizedSystemPromptCommand({
+        preferredName: 'Test',
+      }),
+    );
+
+    expect(callOrder).toEqual([
+      'inference:systemPrompt',
+      'upsert',
+      'inference:welcome',
+    ]);
+  });
+
+  it('should throw PersonalizedSystemPromptGenerationError with generic message for unknown errors', async () => {
+    getDefaultModelUseCase.execute.mockResolvedValue(mockPermittedModel);
+    getInferenceUseCase.execute.mockRejectedValue(
+      new Error('Internal SDK error at host:3000'),
+    );
+
+    await expect(
+      useCase.execute(
+        new GeneratePersonalizedSystemPromptCommand({
+          preferredName: 'Max',
+        }),
+      ),
+    ).rejects.toThrow(PersonalizedSystemPromptGenerationError);
+
+    await expect(
+      useCase.execute(
+        new GeneratePersonalizedSystemPromptCommand({
+          preferredName: 'Max',
+        }),
+      ),
+    ).rejects.toThrow('Failed to generate personalized system prompt');
+  });
+
+  it('should throw PersonalizedSystemPromptGenerationError when generated system prompt is empty', async () => {
+    getDefaultModelUseCase.execute.mockResolvedValue(mockPermittedModel);
+    getInferenceUseCase.execute.mockResolvedValueOnce(
+      createMockInferenceResponse('   '),
+    );
+
+    await expect(
+      useCase.execute(
+        new GeneratePersonalizedSystemPromptCommand({
+          preferredName: 'Lena',
+        }),
+      ),
+    ).rejects.toThrow(PersonalizedSystemPromptGenerationError);
+
+    expect(upsertUserSystemPromptUseCase.execute).not.toHaveBeenCalled();
+  });
+
+  it('should throw PersonalizedSystemPromptGenerationError when upsert fails', async () => {
+    const generatedSystemPrompt = 'Personalized prompt for Jan.';
+
+    getDefaultModelUseCase.execute.mockResolvedValue(mockPermittedModel);
+    getInferenceUseCase.execute.mockResolvedValueOnce(
+      createMockInferenceResponse(generatedSystemPrompt),
+    );
+    upsertUserSystemPromptUseCase.execute.mockRejectedValue(
+      new Error('Database connection lost'),
+    );
+
+    await expect(
+      useCase.execute(
+        new GeneratePersonalizedSystemPromptCommand({
+          preferredName: 'Jan',
+        }),
+      ),
+    ).rejects.toThrow(PersonalizedSystemPromptGenerationError);
+  });
+
+  it('should preserve error cause when wrapping unknown errors', async () => {
+    const originalError = new Error('Something broke');
+    getDefaultModelUseCase.execute.mockResolvedValue(mockPermittedModel);
+    getInferenceUseCase.execute.mockRejectedValue(originalError);
+
+    try {
+      await useCase.execute(
+        new GeneratePersonalizedSystemPromptCommand({
+          preferredName: 'Test',
+        }),
+      );
+      fail('Expected error to be thrown');
+    } catch (error) {
+      expect(error).toBeInstanceOf(PersonalizedSystemPromptGenerationError);
+      expect((error as PersonalizedSystemPromptGenerationError).cause).toBe(
+        originalError,
+      );
+    }
+  });
+});

--- a/ayunis-core-backend/src/domain/chat-settings/application/use-cases/generate-personalized-system-prompt/generate-personalized-system-prompt.use-case.ts
+++ b/ayunis-core-backend/src/domain/chat-settings/application/use-cases/generate-personalized-system-prompt/generate-personalized-system-prompt.use-case.ts
@@ -1,0 +1,198 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { GeneratePersonalizedSystemPromptCommand } from './generate-personalized-system-prompt.command';
+import { GetInferenceUseCase } from 'src/domain/models/application/use-cases/get-inference/get-inference.use-case';
+import { GetInferenceCommand } from 'src/domain/models/application/use-cases/get-inference/get-inference.command';
+import { GetDefaultModelUseCase } from 'src/domain/models/application/use-cases/get-default-model/get-default-model.use-case';
+import { GetDefaultModelQuery } from 'src/domain/models/application/use-cases/get-default-model/get-default-model.query';
+import { UpsertUserSystemPromptUseCase } from '../upsert-user-system-prompt/upsert-user-system-prompt.use-case';
+import { UpsertUserSystemPromptCommand } from '../upsert-user-system-prompt/upsert-user-system-prompt.command';
+import { ContextService } from 'src/common/context/services/context.service';
+import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
+import { PersonalizedSystemPromptGenerationError } from '../../chat-settings.errors';
+import { UserMessage } from 'src/domain/messages/domain/messages/user-message.entity';
+import { TextMessageContent } from 'src/domain/messages/domain/message-contents/text-message-content.entity';
+import { ModelToolChoice } from 'src/domain/models/domain/value-objects/model-tool-choice.enum';
+import { ApplicationError } from 'src/common/errors/base.error';
+import { InferenceResponse } from 'src/domain/models/application/ports/inference.handler';
+import type { LanguageModel } from 'src/domain/models/domain/models/language.model';
+import type { UUID } from 'crypto';
+
+/**
+ * Synthetic thread ID used for one-shot inference calls that are not part of
+ * a real conversation thread.  The nil UUID signals that no persisted thread
+ * is involved.
+ */
+const SYNTHETIC_THREAD_ID = '00000000-0000-0000-0000-000000000000' as UUID;
+
+export interface GeneratePersonalizedSystemPromptResult {
+  systemPrompt: string;
+  welcomeMessage: string;
+}
+
+@Injectable()
+export class GeneratePersonalizedSystemPromptUseCase {
+  private readonly logger = new Logger(
+    GeneratePersonalizedSystemPromptUseCase.name,
+  );
+
+  constructor(
+    private readonly getInferenceUseCase: GetInferenceUseCase,
+    private readonly getDefaultModelUseCase: GetDefaultModelUseCase,
+    private readonly upsertUserSystemPromptUseCase: UpsertUserSystemPromptUseCase,
+    private readonly contextService: ContextService,
+  ) {}
+
+  async execute(
+    command: GeneratePersonalizedSystemPromptCommand,
+  ): Promise<GeneratePersonalizedSystemPromptResult> {
+    const userId = this.contextService.get('userId');
+    if (!userId) {
+      throw new UnauthorizedAccessError();
+    }
+
+    const orgId = this.contextService.get('orgId');
+    if (!orgId) {
+      throw new UnauthorizedAccessError();
+    }
+
+    this.logger.log('execute', { userId });
+
+    try {
+      const permittedModel = await this.getDefaultModelUseCase.execute(
+        new GetDefaultModelQuery({ orgId, userId }),
+      );
+
+      const systemPrompt = await this.generateSystemPrompt(
+        command,
+        permittedModel.model,
+      );
+
+      if (!systemPrompt) {
+        throw new PersonalizedSystemPromptGenerationError();
+      }
+
+      await this.upsertUserSystemPromptUseCase.execute(
+        new UpsertUserSystemPromptCommand(systemPrompt),
+      );
+
+      const welcomeMessage = await this.generateWelcomeMessageSafe(
+        systemPrompt,
+        command.preferredName,
+        permittedModel.model,
+      );
+
+      return { systemPrompt, welcomeMessage };
+    } catch (error) {
+      if (error instanceof ApplicationError) throw error;
+      this.logger.error('Failed to generate personalized system prompt', {
+        userId,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      });
+      throw new PersonalizedSystemPromptGenerationError(
+        error instanceof Error ? error : undefined,
+      );
+    }
+  }
+
+  private async generateSystemPrompt(
+    command: GeneratePersonalizedSystemPromptCommand,
+    model: LanguageModel,
+  ): Promise<string> {
+    const userInput = this.buildUserInputSummary(command);
+
+    const prompt = `You are a system prompt generator. Based on the user's preferences below, generate a personalized system prompt (2-4 sentences). The system prompt should personalize the AI assistant's tone and communication style without restricting what topics the user can ask about. Write the system prompt in the SAME LANGUAGE as the user's input.
+
+User preferences:
+${userInput}
+
+Generate ONLY the system prompt text, nothing else.`;
+
+    const response = await this.callInference(prompt, model);
+    return this.extractTextFromResponse(response);
+  }
+
+  private async generateWelcomeMessage(
+    systemPrompt: string,
+    preferredName: string,
+    model: LanguageModel,
+  ): Promise<string> {
+    const prompt = `Based on the following system prompt and the user's name, generate a short, warm welcome message (1-2 sentences). Write the welcome message in the SAME LANGUAGE as the system prompt. Address the user by their name.
+
+System prompt: "${systemPrompt}"
+User's name: "${preferredName}"
+
+Generate ONLY the welcome message text, nothing else.`;
+
+    const response = await this.callInference(prompt, model);
+    return this.extractTextFromResponse(response);
+  }
+
+  /**
+   * Generates a welcome message, returning an empty string on failure so
+   * the already-persisted system prompt is not lost.
+   */
+  private async generateWelcomeMessageSafe(
+    systemPrompt: string,
+    preferredName: string,
+    model: LanguageModel,
+  ): Promise<string> {
+    try {
+      return await this.generateWelcomeMessage(
+        systemPrompt,
+        preferredName,
+        model,
+      );
+    } catch (error) {
+      this.logger.warn('Welcome message generation failed, using fallback', {
+        error: error instanceof Error ? error.message : 'Unknown error',
+      });
+      return '';
+    }
+  }
+
+  private async callInference(
+    prompt: string,
+    model: LanguageModel,
+  ): Promise<InferenceResponse> {
+    return this.getInferenceUseCase.execute(
+      new GetInferenceCommand({
+        model,
+        messages: [
+          new UserMessage({
+            threadId: SYNTHETIC_THREAD_ID,
+            content: [new TextMessageContent(prompt)],
+          }),
+        ],
+        tools: [],
+        toolChoice: ModelToolChoice.AUTO,
+      }),
+    );
+  }
+
+  private extractTextFromResponse(response: InferenceResponse): string {
+    const textContent = response.content.find(
+      (c): c is TextMessageContent => c instanceof TextMessageContent,
+    );
+    if (!textContent) {
+      throw new PersonalizedSystemPromptGenerationError();
+    }
+
+    return textContent.text.trim();
+  }
+
+  private buildUserInputSummary(
+    command: GeneratePersonalizedSystemPromptCommand,
+  ): string {
+    const parts = [`Name: ${command.preferredName}`];
+
+    if (command.communicationStyle) {
+      parts.push(`Communication style: ${command.communicationStyle}`);
+    }
+
+    if (command.workContext) {
+      parts.push(`Work context: ${command.workContext}`);
+    }
+
+    return parts.join('\n');
+  }
+}

--- a/ayunis-core-backend/src/domain/chat-settings/chat-settings.module.ts
+++ b/ayunis-core-backend/src/domain/chat-settings/chat-settings.module.ts
@@ -4,14 +4,17 @@ import { LocalUserSystemPromptsRepositoryModule } from './infrastructure/persist
 import { GetUserSystemPromptUseCase } from './application/use-cases/get-user-system-prompt/get-user-system-prompt.use-case';
 import { UpsertUserSystemPromptUseCase } from './application/use-cases/upsert-user-system-prompt/upsert-user-system-prompt.use-case';
 import { DeleteUserSystemPromptUseCase } from './application/use-cases/delete-user-system-prompt/delete-user-system-prompt.use-case';
+import { GeneratePersonalizedSystemPromptUseCase } from './application/use-cases/generate-personalized-system-prompt/generate-personalized-system-prompt.use-case';
+import { ModelsModule } from '../models/models.module';
 
 @Module({
-  imports: [LocalUserSystemPromptsRepositoryModule],
+  imports: [LocalUserSystemPromptsRepositoryModule, ModelsModule],
   controllers: [ChatSettingsController],
   providers: [
     GetUserSystemPromptUseCase,
     UpsertUserSystemPromptUseCase,
     DeleteUserSystemPromptUseCase,
+    GeneratePersonalizedSystemPromptUseCase,
   ],
   exports: [GetUserSystemPromptUseCase],
 })

--- a/ayunis-core-backend/src/domain/chat-settings/presenters/http/chat-settings.controller.ts
+++ b/ayunis-core-backend/src/domain/chat-settings/presenters/http/chat-settings.controller.ts
@@ -2,9 +2,9 @@ import {
   Controller,
   Get,
   Put,
+  Post,
   Delete,
   Body,
-  Logger,
   HttpCode,
   HttpStatus,
 } from '@nestjs/common';
@@ -13,18 +13,21 @@ import { GetUserSystemPromptUseCase } from '../../application/use-cases/get-user
 import { UpsertUserSystemPromptUseCase } from '../../application/use-cases/upsert-user-system-prompt/upsert-user-system-prompt.use-case';
 import { UpsertUserSystemPromptCommand } from '../../application/use-cases/upsert-user-system-prompt/upsert-user-system-prompt.command';
 import { DeleteUserSystemPromptUseCase } from '../../application/use-cases/delete-user-system-prompt/delete-user-system-prompt.use-case';
+import { GeneratePersonalizedSystemPromptUseCase } from '../../application/use-cases/generate-personalized-system-prompt/generate-personalized-system-prompt.use-case';
+import { GeneratePersonalizedSystemPromptCommand } from '../../application/use-cases/generate-personalized-system-prompt/generate-personalized-system-prompt.command';
 import { UpsertUserSystemPromptDto } from './dtos/upsert-user-system-prompt.dto';
 import { UserSystemPromptResponseDto } from './dtos/user-system-prompt-response.dto';
+import { GeneratePersonalizedSystemPromptDto } from './dtos/generate-personalized-system-prompt.dto';
+import { GeneratePersonalizedSystemPromptResponseDto } from './dtos/generate-personalized-system-prompt-response.dto';
 
 @ApiTags('Chat Settings')
 @Controller('chat-settings')
 export class ChatSettingsController {
-  private readonly logger = new Logger(ChatSettingsController.name);
-
   constructor(
     private readonly getUserSystemPromptUseCase: GetUserSystemPromptUseCase,
     private readonly upsertUserSystemPromptUseCase: UpsertUserSystemPromptUseCase,
     private readonly deleteUserSystemPromptUseCase: DeleteUserSystemPromptUseCase,
+    private readonly generatePersonalizedSystemPromptUseCase: GeneratePersonalizedSystemPromptUseCase,
   ) {}
 
   @Get('system-prompt')
@@ -85,5 +88,49 @@ export class ChatSettingsController {
   })
   async deleteSystemPrompt(): Promise<void> {
     await this.deleteUserSystemPromptUseCase.execute();
+  }
+
+  @Post('generate-personalized-system-prompt')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Generate a personalized system prompt',
+    description:
+      'Generates a personalized system prompt and welcome message based on user preferences, then saves the system prompt.',
+  })
+  @ApiBody({ type: GeneratePersonalizedSystemPromptDto })
+  @ApiResponse({
+    status: 200,
+    description:
+      'Successfully generated and saved the personalized system prompt',
+    type: GeneratePersonalizedSystemPromptResponseDto,
+  })
+  @ApiResponse({
+    status: 400,
+    description: 'Invalid request payload',
+  })
+  @ApiResponse({
+    status: 422,
+    description: 'No default model configured for the organization',
+  })
+  @ApiResponse({
+    status: 500,
+    description: 'Inference failure during prompt generation',
+  })
+  async generatePersonalizedSystemPrompt(
+    @Body() dto: GeneratePersonalizedSystemPromptDto,
+  ): Promise<GeneratePersonalizedSystemPromptResponseDto> {
+    const command = new GeneratePersonalizedSystemPromptCommand({
+      preferredName: dto.preferredName,
+      communicationStyle: dto.communicationStyle,
+      workContext: dto.workContext,
+    });
+
+    const result =
+      await this.generatePersonalizedSystemPromptUseCase.execute(command);
+
+    return {
+      systemPrompt: result.systemPrompt,
+      welcomeMessage: result.welcomeMessage,
+    };
   }
 }

--- a/ayunis-core-backend/src/domain/chat-settings/presenters/http/dtos/generate-personalized-system-prompt-response.dto.ts
+++ b/ayunis-core-backend/src/domain/chat-settings/presenters/http/dtos/generate-personalized-system-prompt-response.dto.ts
@@ -1,0 +1,17 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class GeneratePersonalizedSystemPromptResponseDto {
+  @ApiProperty({
+    description: 'The generated personalized system prompt',
+    example:
+      'Hallo Maria! Ich kommuniziere locker und kurz mit dir. Ich helfe dir bei allen Fragen rund um deine Arbeit im Sozialamt.',
+  })
+  systemPrompt: string;
+
+  @ApiProperty({
+    description: 'A personalized welcome message for the user',
+    example:
+      'Willkommen, Maria! Schön, dass du da bist. Wie kann ich dir heute helfen?',
+  })
+  welcomeMessage: string;
+}

--- a/ayunis-core-backend/src/domain/chat-settings/presenters/http/dtos/generate-personalized-system-prompt.dto.ts
+++ b/ayunis-core-backend/src/domain/chat-settings/presenters/http/dtos/generate-personalized-system-prompt.dto.ts
@@ -1,0 +1,36 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsOptional, IsString, MaxLength } from 'class-validator';
+
+export class GeneratePersonalizedSystemPromptDto {
+  @ApiProperty({
+    description: 'The preferred name of the user',
+    example: 'Maria',
+    maxLength: 200,
+  })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(200)
+  preferredName: string;
+
+  @ApiProperty({
+    description: 'The preferred communication style',
+    example: 'Locker & kurz',
+    maxLength: 500,
+    required: false,
+  })
+  @IsString()
+  @IsOptional()
+  @MaxLength(500)
+  communicationStyle?: string;
+
+  @ApiProperty({
+    description: 'The work context of the user',
+    example: 'Bescheide im Sozialamt, Protokolle für den Gemeinderat',
+    maxLength: 1000,
+    required: false,
+  })
+  @IsString()
+  @IsOptional()
+  @MaxLength(1000)
+  workContext?: string;
+}

--- a/ayunis-core-backend/src/domain/models/application/models.errors.ts
+++ b/ayunis-core-backend/src/domain/models/application/models.errors.ts
@@ -83,7 +83,7 @@ export class DefaultModelNotFoundError extends ModelError {
     super(
       `Default model not found for org '${orgId}'`,
       ModelErrorCode.NO_DEFAULT_MODEL_FOUND,
-      404,
+      422,
       metadata,
     );
   }

--- a/ayunis-core-frontend/src/pages/new-chat/api/useGeneratePersonalizedSystemPrompt.ts
+++ b/ayunis-core-frontend/src/pages/new-chat/api/useGeneratePersonalizedSystemPrompt.ts
@@ -1,0 +1,60 @@
+import {
+  useChatSettingsControllerGeneratePersonalizedSystemPrompt,
+  getChatSettingsControllerGetSystemPromptQueryKey,
+} from '@/shared/api/generated/ayunisCoreAPI';
+import type {
+  GeneratePersonalizedSystemPromptDto,
+  GeneratePersonalizedSystemPromptResponseDto,
+} from '@/shared/api/generated/ayunisCoreAPI.schemas';
+import { useQueryClient } from '@tanstack/react-query';
+import { useRouter } from '@tanstack/react-router';
+import { useTranslation } from 'react-i18next';
+import { showSuccess, showError } from '@/shared/lib/toast';
+import extractErrorData from '@/shared/api/extract-error-data';
+
+export function useGeneratePersonalizedSystemPrompt(options?: {
+  onSuccess?: (data: GeneratePersonalizedSystemPromptResponseDto) => void;
+  onError?: (error: unknown) => void;
+}) {
+  const { t } = useTranslation('chat');
+  const queryClient = useQueryClient();
+  const router = useRouter();
+  const queryKey = getChatSettingsControllerGetSystemPromptQueryKey();
+
+  const mutation = useChatSettingsControllerGeneratePersonalizedSystemPrompt({
+    mutation: {
+      onSuccess: (data) => {
+        showSuccess(t('newChat.personalizedPromptSuccess'));
+        options?.onSuccess?.(data);
+      },
+      onError: (error) => {
+        let message = t('newChat.personalizedPromptError');
+        try {
+          const errorData = extractErrorData(error);
+          if (errorData.status === 422) {
+            message = t('newChat.noDefaultModelError');
+          }
+        } catch {
+          // Non-AxiosError (network failure, request cancellation, etc.)
+        }
+        showError(message);
+        options?.onError?.(error);
+      },
+      onSettled: async () => {
+        await queryClient.invalidateQueries({ queryKey });
+        await router.invalidate();
+      },
+    },
+  });
+
+  function generate(answers: GeneratePersonalizedSystemPromptDto) {
+    mutation.mutate({ data: answers });
+  }
+
+  return {
+    generate,
+    isGenerating: mutation.isPending,
+    error: mutation.error,
+    result: mutation.data ?? null,
+  };
+}

--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
@@ -3055,6 +3055,31 @@ export interface UpsertUserSystemPromptDto {
   systemPrompt: string;
 }
 
+export interface GeneratePersonalizedSystemPromptDto {
+  /**
+   * The preferred name of the user
+   * @maxLength 200
+   */
+  preferredName: string;
+  /**
+   * The preferred communication style
+   * @maxLength 500
+   */
+  communicationStyle?: string;
+  /**
+   * The work context of the user
+   * @maxLength 1000
+   */
+  workContext?: string;
+}
+
+export interface GeneratePersonalizedSystemPromptResponseDto {
+  /** The generated personalized system prompt */
+  systemPrompt: string;
+  /** A personalized welcome message for the user */
+  welcomeMessage: string;
+}
+
 export interface CreatePromptDto {
   /**
    * The title of the prompt

--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.ts
@@ -61,6 +61,8 @@ import type {
   ErrorResponseDto,
   FeatureTogglesResponseDto,
   ForgotPasswordDto,
+  GeneratePersonalizedSystemPromptDto,
+  GeneratePersonalizedSystemPromptResponseDto,
   GetThreadResponseDto,
   GetThreadsResponseDto,
   GlobalUserUsageResponseDto,
@@ -13180,6 +13182,72 @@ export const useChatSettingsControllerDeleteSystemPrompt = <TError = unknown,
       > => {
 
       const mutationOptions = getChatSettingsControllerDeleteSystemPromptMutationOptions(options);
+
+      return useMutation(mutationOptions, queryClient);
+    }
+    
+/**
+ * Generates a personalized system prompt and welcome message based on user preferences, then saves the system prompt.
+ * @summary Generate a personalized system prompt
+ */
+export const chatSettingsControllerGeneratePersonalizedSystemPrompt = (
+    generatePersonalizedSystemPromptDto: GeneratePersonalizedSystemPromptDto,
+ signal?: AbortSignal
+) => {
+      
+      
+      return customAxiosInstance<GeneratePersonalizedSystemPromptResponseDto>(
+      {url: `/chat-settings/generate-personalized-system-prompt`, method: 'POST',
+      headers: {'Content-Type': 'application/json', },
+      data: generatePersonalizedSystemPromptDto, signal
+    },
+      );
+    }
+  
+
+
+export const getChatSettingsControllerGeneratePersonalizedSystemPromptMutationOptions = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof chatSettingsControllerGeneratePersonalizedSystemPrompt>>, TError,{data: GeneratePersonalizedSystemPromptDto}, TContext>, }
+): UseMutationOptions<Awaited<ReturnType<typeof chatSettingsControllerGeneratePersonalizedSystemPrompt>>, TError,{data: GeneratePersonalizedSystemPromptDto}, TContext> => {
+
+const mutationKey = ['chatSettingsControllerGeneratePersonalizedSystemPrompt'];
+const {mutation: mutationOptions} = options ?
+      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
+      options
+      : {...options, mutation: {...options.mutation, mutationKey}}
+      : {mutation: { mutationKey, }};
+
+      
+
+
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof chatSettingsControllerGeneratePersonalizedSystemPrompt>>, {data: GeneratePersonalizedSystemPromptDto}> = (props) => {
+          const {data} = props ?? {};
+
+          return  chatSettingsControllerGeneratePersonalizedSystemPrompt(data,)
+        }
+
+        
+
+
+  return  { mutationFn, ...mutationOptions }}
+
+    export type ChatSettingsControllerGeneratePersonalizedSystemPromptMutationResult = NonNullable<Awaited<ReturnType<typeof chatSettingsControllerGeneratePersonalizedSystemPrompt>>>
+    export type ChatSettingsControllerGeneratePersonalizedSystemPromptMutationBody = GeneratePersonalizedSystemPromptDto
+    export type ChatSettingsControllerGeneratePersonalizedSystemPromptMutationError = void
+
+    /**
+ * @summary Generate a personalized system prompt
+ */
+export const useChatSettingsControllerGeneratePersonalizedSystemPrompt = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof chatSettingsControllerGeneratePersonalizedSystemPrompt>>, TError,{data: GeneratePersonalizedSystemPromptDto}, TContext>, }
+ , queryClient?: QueryClient): UseMutationResult<
+        Awaited<ReturnType<typeof chatSettingsControllerGeneratePersonalizedSystemPrompt>>,
+        TError,
+        {data: GeneratePersonalizedSystemPromptDto},
+        TContext
+      > => {
+
+      const mutationOptions = getChatSettingsControllerGeneratePersonalizedSystemPromptMutationOptions(options);
 
       return useMutation(mutationOptions, queryClient);
     }

--- a/ayunis-core-frontend/src/shared/api/openapi-schema.json
+++ b/ayunis-core-frontend/src/shared/api/openapi-schema.json
@@ -7033,6 +7033,48 @@
         ]
       }
     },
+    "/chat-settings/generate-personalized-system-prompt": {
+      "post": {
+        "description": "Generates a personalized system prompt and welcome message based on user preferences, then saves the system prompt.",
+        "operationId": "ChatSettingsController_generatePersonalizedSystemPrompt",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GeneratePersonalizedSystemPromptDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successfully generated and saved the personalized system prompt",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GeneratePersonalizedSystemPromptResponseDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request payload"
+          },
+          "422": {
+            "description": "No default model configured for the organization"
+          },
+          "500": {
+            "description": "Inference failure during prompt generation"
+          }
+        },
+        "summary": "Generate a personalized system prompt",
+        "tags": [
+          "Chat Settings"
+        ]
+      }
+    },
     "/prompts": {
       "post": {
         "operationId": "PromptsController_create",
@@ -12804,6 +12846,51 @@
         },
         "required": [
           "systemPrompt"
+        ]
+      },
+      "GeneratePersonalizedSystemPromptDto": {
+        "type": "object",
+        "properties": {
+          "preferredName": {
+            "type": "string",
+            "description": "The preferred name of the user",
+            "example": "Maria",
+            "maxLength": 200
+          },
+          "communicationStyle": {
+            "type": "string",
+            "description": "The preferred communication style",
+            "example": "Locker & kurz",
+            "maxLength": 500
+          },
+          "workContext": {
+            "type": "string",
+            "description": "The work context of the user",
+            "example": "Bescheide im Sozialamt, Protokolle für den Gemeinderat",
+            "maxLength": 1000
+          }
+        },
+        "required": [
+          "preferredName"
+        ]
+      },
+      "GeneratePersonalizedSystemPromptResponseDto": {
+        "type": "object",
+        "properties": {
+          "systemPrompt": {
+            "type": "string",
+            "description": "The generated personalized system prompt",
+            "example": "Hallo Maria! Ich kommuniziere locker und kurz mit dir. Ich helfe dir bei allen Fragen rund um deine Arbeit im Sozialamt."
+          },
+          "welcomeMessage": {
+            "type": "string",
+            "description": "A personalized welcome message for the user",
+            "example": "Willkommen, Maria! Schön, dass du da bist. Wie kann ich dir heute helfen?"
+          }
+        },
+        "required": [
+          "systemPrompt",
+          "welcomeMessage"
         ]
       },
       "CreatePromptDto": {

--- a/ayunis-core-frontend/src/shared/locales/de/chat.json
+++ b/ayunis-core-frontend/src/shared/locales/de/chat.json
@@ -95,6 +95,9 @@
     "noModelTitle": "Herzlich Willkommen",
     "noModelDescription": "Bevor es losgehen kann, benötigen wir mindestens ein freigeschaltetes Modell. Bitte wenden Sie sich an Ihren Administrator und bitten Sie ihn, mindestens ein Modell zu aktivieren. Wenn Sie Administrator sind, können Sie ein Modell in den Einstellungen konfigurieren.",
     "configureModel": "Modell konfigurieren",
-    "upgradeToProError": "Sie müssen ein Pro-Abonnement haben, um diese Funktion zu verwenden."
+    "upgradeToProError": "Sie müssen ein Pro-Abonnement haben, um diese Funktion zu verwenden.",
+    "personalizedPromptSuccess": "Personalisierter System-Prompt erstellt",
+    "personalizedPromptError": "Personalisierter System-Prompt konnte nicht erstellt werden",
+    "noDefaultModelError": "Kein Standardmodell konfiguriert. Bitte wenden Sie sich an Ihren Administrator."
   }
 }

--- a/ayunis-core-frontend/src/shared/locales/en/chat.json
+++ b/ayunis-core-frontend/src/shared/locales/en/chat.json
@@ -95,6 +95,9 @@
     "noModelTitle": "Welcome",
     "noModelDescription": "Before we can start, we need at least one enabled model. Please contact your administrator and ask them to enable at least one model. If you are an administrator, you can configure a model in the settings.",
     "configureModel": "Configure Model",
-    "upgradeToProError": "You need to upgrade to a paid plan to use this feature."
+    "upgradeToProError": "You need to upgrade to a paid plan to use this feature.",
+    "personalizedPromptSuccess": "Personalized system prompt generated",
+    "personalizedPromptError": "Failed to generate personalized system prompt",
+    "noDefaultModelError": "No default model configured. Please contact your administrator."
   }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new LLM-driven endpoint that selects an org default model, performs inference, and persists user system prompts; failures or model configuration issues can impact chat onboarding and system-prompt persistence. Also updates generated frontend API code and caching behavior, which may affect client error handling.
> 
> **Overview**
> Adds `POST /chat-settings/generate-personalized-system-prompt` to generate a per-user system prompt (and a welcome message) via model inference, then upsert the generated prompt; includes new DTOs, a `GeneratePersonalizedSystemPromptUseCase` (with unit tests), and wires `ChatSettingsModule` to `ModelsModule`.
> 
> Updates the frontend with a new `useGeneratePersonalizedSystemPrompt` mutation hook, regenerated OpenAPI client/schema artifacts, and i18n strings for success/error states (including a specific message when no default model is configured). Also tweaks `package-lock.json` to mark `@swc/*` deps as `devOptional`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0ff20ae683a3ad125973d3c1282e61724f0d0e5a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->