### PR TITLE
chore(AYC-000): update chat input placeholder to friendly greeting

### DIFF
--- a/ayunis-core-frontend/src/shared/locales/de/common.json
+++ b/ayunis-core-frontend/src/shared/locales/de/common.json
@@ -38,7 +38,7 @@
     "showMore": "Mehr anzeigen..."
   },
   "chatInput": {
-    "placeholder": "Stellen Sie eine Frage in Ayunis Core...",
+    "placeholder": "Wie kann ich heute helfen?",
     "selectPrompt": "Fügen Sie einen Prompt aus Ihrer Bibliothek hinzu",
     "promptsLoadError": "Fehler beim Laden der Prompts",
     "promptsEmptyState": "Noch kein Prompt erstellt",

--- a/ayunis-core-frontend/src/shared/locales/en/common.json
+++ b/ayunis-core-frontend/src/shared/locales/en/common.json
@@ -38,7 +38,7 @@
     "showMore": "Show more..."
   },
   "chatInput": {
-    "placeholder": "Ask a question in Ayunis Core...",
+    "placeholder": "How can I help today?",
     "selectPrompt": "Add a prompt from your library",
     "promptsLoadError": "Error loading prompts",
     "promptsEmptyState": "No prompts created yet",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk copy-only change limited to localized `chatInput.placeholder` strings; no behavior or data flow changes.
> 
> **Overview**
> Updates the localized `chatInput.placeholder` copy in `en/common.json` and `de/common.json` from a product-specific prompt to a friendlier “How can I help today?” / “Wie kann ich heute helfen?” greeting.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 08b0233917c3cea544921c3228985e24ed8be496. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->