### PR TITLE
feat(AYC-102): add personalization card and wire into new chat page

### DIFF
--- a/ayunis-core-backend/package-lock.json
+++ b/ayunis-core-backend/package-lock.json
@@ -7130,7 +7130,7 @@
     },
     "node_modules/@swc/core": {
       "version": "1.11.21",
-      "dev": true,
+      "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -7172,7 +7172,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -7189,7 +7188,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -7206,7 +7204,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -7221,7 +7218,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -7236,7 +7232,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -7253,7 +7248,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -7270,7 +7264,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -7287,7 +7280,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -7304,7 +7296,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -7321,7 +7312,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -7333,7 +7323,7 @@
     },
     "node_modules/@swc/counter": {
       "version": "0.1.3",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0"
     },
     "node_modules/@swc/jest": {
@@ -7356,7 +7346,7 @@
     },
     "node_modules/@swc/types": {
       "version": "0.1.21",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@swc/counter": "^0.1.3"

--- a/ayunis-core-frontend/src/app/routes/_authenticated/chat.index.tsx
+++ b/ayunis-core-frontend/src/app/routes/_authenticated/chat.index.tsx
@@ -13,6 +13,8 @@ import {
   agentsControllerFindAll,
   appControllerFeatureToggles,
   getAppControllerFeatureTogglesQueryKey,
+  chatSettingsControllerGetSystemPrompt,
+  getChatSettingsControllerGetSystemPromptQueryKey,
 } from '@/shared/api';
 import extractErrorData from '@/shared/api/extract-error-data';
 import { z } from 'zod';
@@ -85,6 +87,11 @@ export const Route = createFileRoute('/_authenticated/chat/')({
     const agents = featureToggles.agentsEnabled
       ? await queryClient.fetchQuery(queryAgentsOptions())
       : [];
+    // Await system prompt status so PersonalizationCard doesn't flash
+    await queryClient.prefetchQuery({
+      queryKey: getChatSettingsControllerGetSystemPromptQueryKey(),
+      queryFn: () => chatSettingsControllerGetSystemPrompt(),
+    });
     return {
       selectedModelId,
       selectedAgentId,

--- a/ayunis-core-frontend/src/pages/new-chat/api/useGeneratePersonalizedSystemPrompt.ts
+++ b/ayunis-core-frontend/src/pages/new-chat/api/useGeneratePersonalizedSystemPrompt.ts
@@ -1,25 +1,26 @@
-import {
-  useChatSettingsControllerGeneratePersonalizedSystemPrompt,
-  getChatSettingsControllerGetSystemPromptQueryKey,
-} from '@/shared/api/generated/ayunisCoreAPI';
+import { useChatSettingsControllerGeneratePersonalizedSystemPrompt } from '@/shared/api/generated/ayunisCoreAPI';
 import type {
   GeneratePersonalizedSystemPromptDto,
   GeneratePersonalizedSystemPromptResponseDto,
 } from '@/shared/api/generated/ayunisCoreAPI.schemas';
-import { useQueryClient } from '@tanstack/react-query';
-import { useRouter } from '@tanstack/react-router';
 import { useTranslation } from 'react-i18next';
 import { showSuccess, showError } from '@/shared/lib/toast';
 import extractErrorData from '@/shared/api/extract-error-data';
 
+/**
+ * Unlike other mutation hooks, this hook intentionally does NOT invalidate the
+ * query cache on success. The caller needs to display a success screen with the
+ * welcome message before the parent component re-renders — if we invalidated
+ * here, the `useUserSystemPromptStatus` query would flip `hasSystemPrompt` to
+ * true, causing `NewChatPage` to unmount the `PersonalizationCard` before the
+ * user sees the welcome message (Bugbot unmount race). Cache invalidation is
+ * deferred to the caller's `onComplete` callback instead.
+ */
 export function useGeneratePersonalizedSystemPrompt(options?: {
   onSuccess?: (data: GeneratePersonalizedSystemPromptResponseDto) => void;
   onError?: (error: unknown) => void;
 }) {
   const { t } = useTranslation('chat');
-  const queryClient = useQueryClient();
-  const router = useRouter();
-  const queryKey = getChatSettingsControllerGetSystemPromptQueryKey();
 
   const mutation = useChatSettingsControllerGeneratePersonalizedSystemPrompt({
     mutation: {
@@ -39,10 +40,6 @@ export function useGeneratePersonalizedSystemPrompt(options?: {
         }
         showError(message);
         options?.onError?.(error);
-      },
-      onSettled: async () => {
-        await queryClient.invalidateQueries({ queryKey });
-        await router.invalidate();
       },
     },
   });

--- a/ayunis-core-frontend/src/pages/new-chat/api/useSkipPersonalization.ts
+++ b/ayunis-core-frontend/src/pages/new-chat/api/useSkipPersonalization.ts
@@ -1,0 +1,41 @@
+import {
+  useChatSettingsControllerUpsertSystemPrompt,
+  getChatSettingsControllerGetSystemPromptQueryKey,
+} from '@/shared/api/generated/ayunisCoreAPI';
+import { useQueryClient } from '@tanstack/react-query';
+import { useRouter } from '@tanstack/react-router';
+import { useTranslation } from 'react-i18next';
+import { showError } from '@/shared/lib/toast';
+
+/**
+ * Cross-stack contract: the backend stores this as a real system prompt value.
+ * `useUserSystemPromptStatus` treats any non-null value as "has prompt",
+ * so this sentinel means "user explicitly skipped personalization."
+ */
+const SKIP_SENTINEL = '-';
+
+export function useSkipPersonalization(onSuccess?: () => void) {
+  const { t } = useTranslation('chat');
+  const queryClient = useQueryClient();
+  const router = useRouter();
+  const queryKey = getChatSettingsControllerGetSystemPromptQueryKey();
+
+  const mutation = useChatSettingsControllerUpsertSystemPrompt({
+    mutation: {
+      onSuccess,
+      onError: () => {
+        showError(t('newChat.personalization.skipError'));
+      },
+      onSettled: async () => {
+        await queryClient.invalidateQueries({ queryKey });
+        await router.invalidate();
+      },
+    },
+  });
+
+  function skip() {
+    mutation.mutate({ data: { systemPrompt: SKIP_SENTINEL } });
+  }
+
+  return { skip, isSkipping: mutation.isPending };
+}

--- a/ayunis-core-frontend/src/pages/new-chat/api/useUserSystemPromptStatus.ts
+++ b/ayunis-core-frontend/src/pages/new-chat/api/useUserSystemPromptStatus.ts
@@ -1,0 +1,13 @@
+import { useChatSettingsControllerGetSystemPrompt } from '@/shared/api/generated/ayunisCoreAPI';
+
+export function useUserSystemPromptStatus() {
+  const { data, isLoading, isError } =
+    useChatSettingsControllerGetSystemPrompt();
+
+  return {
+    hasSystemPrompt:
+      data?.systemPrompt !== null && data?.systemPrompt !== undefined,
+    isLoading,
+    isError,
+  };
+}

--- a/ayunis-core-frontend/src/pages/new-chat/ui/NewChatPage.tsx
+++ b/ayunis-core-frontend/src/pages/new-chat/ui/NewChatPage.tsx
@@ -1,7 +1,7 @@
 import NewChatPageLayout from './NewChatPageLayout';
 import ChatInput from '@/widgets/chat-input';
 import { useInitiateChat } from '../api/useInitiateChat';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import ContentAreaHeader from '@/widgets/content-area-header/ui/ContentAreaHeader';
 import { showError } from '@/shared/lib/toast';
@@ -13,6 +13,12 @@ import { useTimeBasedGreeting } from '../model/useTimeBasedGreeting';
 import { useChatContext } from '@/shared/contexts/chat/useChatContext';
 import type { KnowledgeBaseSummary } from '@/shared/contexts/chat/chatContext';
 import { PinnedSkills } from './PinnedSkills';
+import { PersonalizationCard } from './PersonalizationCard';
+import { useUserSystemPromptStatus } from '../api/useUserSystemPromptStatus';
+import { useSkipPersonalization } from '../api/useSkipPersonalization';
+import { useQueryClient } from '@tanstack/react-query';
+import { getChatSettingsControllerGetSystemPromptQueryKey } from '@/shared/api/generated/ayunisCoreAPI';
+import { useRouter } from '@tanstack/react-router';
 
 interface NewChatPageProps {
   prefilledPrompt?: string;
@@ -35,6 +41,20 @@ export default function NewChatPage({
   const greeting = useTimeBasedGreeting();
   const { setPendingImages, setPendingKnowledgeBases, setPendingSkillId } =
     useChatContext();
+  const {
+    hasSystemPrompt,
+    isLoading: isSystemPromptLoading,
+    isError: isSystemPromptError,
+  } = useUserSystemPromptStatus();
+  const { skip, isSkipping } = useSkipPersonalization();
+
+  useEffect(() => {
+    if (isSystemPromptError) {
+      showError(t('newChat.systemPromptLoadError'));
+    }
+  }, [isSystemPromptError, t]);
+  const queryClient = useQueryClient();
+  const router = useRouter();
   const [modelId, setModelId] = useState(selectedModelId);
   const [agentId, setAgentId] = useState(selectedAgentId);
   const [isAnonymous, setIsAnonymous] = useState(false);
@@ -135,6 +155,27 @@ export default function NewChatPage({
     setPendingSkillId(skillId);
 
     initiateChat(message, modelId, agentId, sources, isAnonymous);
+  }
+
+  if (!isSystemPromptLoading && !isSystemPromptError && !hasSystemPrompt) {
+    return (
+      <NewChatPageLayout
+        header={<ContentAreaHeader title={t('newChat.newChat')} />}
+      >
+        <div className="text-center">
+          <h1 className="text-2xl font-bold">{greeting}</h1>
+        </div>
+        <PersonalizationCard
+          onSkip={skip}
+          isSkipping={isSkipping}
+          onComplete={async () => {
+            const queryKey = getChatSettingsControllerGetSystemPromptQueryKey();
+            await queryClient.invalidateQueries({ queryKey });
+            await router.invalidate();
+          }}
+        />
+      </NewChatPageLayout>
+    );
   }
 
   return (

--- a/ayunis-core-frontend/src/pages/new-chat/ui/PersonalizationCard.tsx
+++ b/ayunis-core-frontend/src/pages/new-chat/ui/PersonalizationCard.tsx
@@ -1,0 +1,220 @@
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Loader2, Sparkles } from 'lucide-react';
+import { AlertCircle } from 'lucide-react';
+import { Button } from '@/shared/ui/shadcn/button';
+import { Card, CardContent, CardFooter } from '@/shared/ui/shadcn/card';
+import { Alert, AlertTitle, AlertDescription } from '@/shared/ui/shadcn/alert';
+import { useGeneratePersonalizedSystemPrompt } from '../api/useGeneratePersonalizedSystemPrompt';
+import {
+  PersonalizationStepper,
+  PERSONALIZATION_TOTAL_STEPS,
+} from './personalization/PersonalizationStepper';
+import { PersonalizationStepName } from './personalization/PersonalizationStepName';
+import {
+  PersonalizationStepStyle,
+  STYLE_OPTIONS,
+} from './personalization/PersonalizationStepStyle';
+import { PersonalizationStepContext } from './personalization/PersonalizationStepContext';
+
+type CardState =
+  | { type: 'wizard'; step: number }
+  | { type: 'loading' }
+  | { type: 'error' }
+  | { type: 'success'; welcomeMessage: string };
+
+interface PersonalizationCardProps {
+  onSkip: () => void;
+  isSkipping: boolean;
+  onComplete: () => void | Promise<void>;
+}
+
+export function PersonalizationCard({
+  onSkip,
+  isSkipping,
+  onComplete,
+}: Readonly<PersonalizationCardProps>) {
+  const { t } = useTranslation('chat');
+
+  const [name, setName] = useState('');
+  const [selectedStyle, setSelectedStyle] = useState('');
+  const [customStyle, setCustomStyle] = useState('');
+  const [workContext, setWorkContext] = useState('');
+  const [cardState, setCardState] = useState<CardState>({
+    type: 'wizard',
+    step: 1,
+  });
+
+  const { generate, isGenerating } = useGeneratePersonalizedSystemPrompt({
+    onSuccess: (data) => {
+      setCardState({ type: 'success', welcomeMessage: data.welcomeMessage });
+    },
+    onError: () => {
+      setCardState({ type: 'error' });
+    },
+  });
+
+  function buildCommunicationStyle(): string | undefined {
+    const parts: string[] = [];
+    if (selectedStyle) {
+      const option = STYLE_OPTIONS.find((o) => o.key === selectedStyle);
+      const label = option ? t(option.i18nKey) : selectedStyle;
+      parts.push(label);
+    }
+    if (customStyle.trim()) parts.push(customStyle.trim());
+    return parts.length > 0 ? parts.join('. ') : undefined;
+  }
+
+  function handleSubmit() {
+    setCardState({ type: 'loading' });
+    generate({
+      preferredName: name.trim(),
+      communicationStyle: buildCommunicationStyle(),
+      workContext: workContext.trim() || undefined,
+    });
+  }
+
+  function handleRetry() {
+    setCardState({ type: 'wizard', step: PERSONALIZATION_TOTAL_STEPS });
+  }
+
+  const isNameValid = name.trim().length > 0;
+  const isStyleValid = selectedStyle.length > 0;
+  const isBusy = isSkipping || isGenerating;
+
+  if (cardState.type === 'loading') {
+    return <LoadingState message={t('newChat.personalization.generating')} />;
+  }
+
+  if (cardState.type === 'error') {
+    return (
+      <ErrorState
+        message={t('newChat.personalization.errorMessage')}
+        onRetry={handleRetry}
+      />
+    );
+  }
+
+  if (cardState.type === 'success') {
+    return (
+      <SuccessState
+        welcomeMessage={cardState.welcomeMessage}
+        onGetStarted={onComplete}
+      />
+    );
+  }
+
+  const { step } = cardState;
+
+  return (
+    <Card className="w-full max-w-lg mx-auto">
+      <CardContent className="flex flex-col gap-6">
+        <PersonalizationStepper currentStep={step} />
+        {step === 1 && (
+          <PersonalizationStepName name={name} onNameChange={setName} />
+        )}
+        {step === 2 && (
+          <PersonalizationStepStyle
+            selectedStyle={selectedStyle}
+            onStyleChange={setSelectedStyle}
+            customStyle={customStyle}
+            onCustomStyleChange={setCustomStyle}
+          />
+        )}
+        {step === 3 && (
+          <PersonalizationStepContext
+            context={workContext}
+            onContextChange={setWorkContext}
+          />
+        )}
+      </CardContent>
+      <CardFooter className="flex justify-between">
+        <Button variant="ghost" size="sm" onClick={onSkip} disabled={isBusy}>
+          {t('newChat.personalization.skip')}
+        </Button>
+        <div className="flex gap-2">
+          {step > 1 && (
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setCardState({ type: 'wizard', step: step - 1 })}
+            >
+              {t('newChat.personalization.back')}
+            </Button>
+          )}
+          {step < PERSONALIZATION_TOTAL_STEPS && (
+            <Button
+              size="sm"
+              disabled={
+                (step === 1 && !isNameValid) || (step === 2 && !isStyleValid)
+              }
+              onClick={() => setCardState({ type: 'wizard', step: step + 1 })}
+            >
+              {t('newChat.personalization.next')}
+            </Button>
+          )}
+          {step === PERSONALIZATION_TOTAL_STEPS && (
+            <Button size="sm" onClick={handleSubmit} disabled={isBusy}>
+              <Sparkles className="h-4 w-4" />
+              {t('newChat.personalization.submit')}
+            </Button>
+          )}
+        </div>
+      </CardFooter>
+    </Card>
+  );
+}
+
+function LoadingState({ message }: Readonly<{ message: string }>) {
+  return (
+    <Card className="w-full max-w-lg mx-auto">
+      <CardContent className="flex flex-col items-center gap-4 py-8">
+        <Loader2 className="h-8 w-8 animate-spin text-primary" />
+        <p className="text-sm text-muted-foreground">{message}</p>
+      </CardContent>
+    </Card>
+  );
+}
+
+function ErrorState({
+  message,
+  onRetry,
+}: Readonly<{ message: string; onRetry: () => void }>) {
+  const { t } = useTranslation('chat');
+  return (
+    <Card className="w-full max-w-lg mx-auto">
+      <CardContent className="flex flex-col items-center gap-4 py-8">
+        <Alert variant="destructive">
+          <AlertCircle className="h-4 w-4" />
+          <AlertTitle>{t('newChat.personalization.errorTitle')}</AlertTitle>
+          <AlertDescription>{message}</AlertDescription>
+        </Alert>
+        <Button variant="outline" size="sm" onClick={onRetry}>
+          {t('newChat.personalization.retry')}
+        </Button>
+      </CardContent>
+    </Card>
+  );
+}
+
+function SuccessState({
+  welcomeMessage,
+  onGetStarted,
+}: Readonly<{
+  welcomeMessage: string;
+  onGetStarted: () => void | Promise<void>;
+}>) {
+  const { t } = useTranslation('chat');
+  return (
+    <Card className="w-full max-w-lg mx-auto">
+      <CardContent className="flex flex-col items-center gap-4 py-8">
+        <p className="text-center text-sm">{welcomeMessage}</p>
+      </CardContent>
+      <CardFooter className="flex justify-center">
+        <Button onClick={() => void onGetStarted()}>
+          {t('newChat.personalization.getStarted')}
+        </Button>
+      </CardFooter>
+    </Card>
+  );
+}

--- a/ayunis-core-frontend/src/pages/new-chat/ui/personalization/PersonalizationStepContext.tsx
+++ b/ayunis-core-frontend/src/pages/new-chat/ui/personalization/PersonalizationStepContext.tsx
@@ -1,0 +1,42 @@
+import { useTranslation } from 'react-i18next';
+import { Textarea } from '@/shared/ui/shadcn/textarea';
+import { Label } from '@/shared/ui/shadcn/label';
+
+interface PersonalizationStepContextProps {
+  context: string;
+  onContextChange: (context: string) => void;
+}
+
+export function PersonalizationStepContext({
+  context,
+  onContextChange,
+}: Readonly<PersonalizationStepContextProps>) {
+  const { t } = useTranslation('chat');
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="text-center">
+        <h2 className="text-lg font-semibold">
+          {t('newChat.personalization.contextTitle')}
+        </h2>
+        <p className="text-sm text-muted-foreground">
+          {t('newChat.personalization.contextDescription')}
+        </p>
+      </div>
+      <div className="flex flex-col gap-2">
+        <Label htmlFor="personalization-context">
+          {t('newChat.personalization.contextLabel')}
+        </Label>
+        <Textarea
+          id="personalization-context"
+          value={context}
+          onChange={(e) => onContextChange(e.target.value)}
+          placeholder={t('newChat.personalization.contextPlaceholder')}
+          maxLength={1000}
+          rows={3}
+          autoFocus
+        />
+      </div>
+    </div>
+  );
+}

--- a/ayunis-core-frontend/src/pages/new-chat/ui/personalization/PersonalizationStepName.tsx
+++ b/ayunis-core-frontend/src/pages/new-chat/ui/personalization/PersonalizationStepName.tsx
@@ -1,0 +1,41 @@
+import { useTranslation } from 'react-i18next';
+import { Input } from '@/shared/ui/shadcn/input';
+import { Label } from '@/shared/ui/shadcn/label';
+
+interface PersonalizationStepNameProps {
+  name: string;
+  onNameChange: (name: string) => void;
+}
+
+export function PersonalizationStepName({
+  name,
+  onNameChange,
+}: Readonly<PersonalizationStepNameProps>) {
+  const { t } = useTranslation('chat');
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="text-center">
+        <h2 className="text-lg font-semibold">
+          {t('newChat.personalization.nameTitle')}
+        </h2>
+        <p className="text-sm text-muted-foreground">
+          {t('newChat.personalization.nameDescription')}
+        </p>
+      </div>
+      <div className="flex flex-col gap-2">
+        <Label htmlFor="personalization-name">
+          {t('newChat.personalization.nameLabel')}
+        </Label>
+        <Input
+          id="personalization-name"
+          value={name}
+          onChange={(e) => onNameChange(e.target.value)}
+          placeholder={t('newChat.personalization.namePlaceholder')}
+          maxLength={200}
+          autoFocus
+        />
+      </div>
+    </div>
+  );
+}

--- a/ayunis-core-frontend/src/pages/new-chat/ui/personalization/PersonalizationStepStyle.tsx
+++ b/ayunis-core-frontend/src/pages/new-chat/ui/personalization/PersonalizationStepStyle.tsx
@@ -1,0 +1,73 @@
+import { useTranslation } from 'react-i18next';
+import { Button } from '@/shared/ui/shadcn/button';
+import { Textarea } from '@/shared/ui/shadcn/textarea';
+import { Label } from '@/shared/ui/shadcn/label';
+import { cn } from '@/shared/lib/shadcn/utils';
+
+export const STYLE_OPTIONS = [
+  { key: 'casual', i18nKey: 'newChat.personalization.styleCasual' },
+  {
+    key: 'professional',
+    i18nKey: 'newChat.personalization.styleProfessional',
+  },
+  { key: 'factual', i18nKey: 'newChat.personalization.styleFactual' },
+] as const;
+
+interface PersonalizationStepStyleProps {
+  selectedStyle: string;
+  onStyleChange: (style: string) => void;
+  customStyle: string;
+  onCustomStyleChange: (customStyle: string) => void;
+}
+
+export function PersonalizationStepStyle({
+  selectedStyle,
+  onStyleChange,
+  customStyle,
+  onCustomStyleChange,
+}: Readonly<PersonalizationStepStyleProps>) {
+  const { t } = useTranslation('chat');
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="text-center">
+        <h2 className="text-lg font-semibold">
+          {t('newChat.personalization.styleTitle')}
+        </h2>
+        <p className="text-sm text-muted-foreground">
+          {t('newChat.personalization.styleDescription')}
+        </p>
+      </div>
+      <div className="flex flex-wrap justify-center gap-2">
+        {STYLE_OPTIONS.map((option) => (
+          <Button
+            key={option.key}
+            type="button"
+            variant={selectedStyle === option.key ? 'default' : 'outline'}
+            size="sm"
+            className={cn(
+              'rounded-full',
+              selectedStyle === option.key && 'ring-2 ring-primary/30',
+            )}
+            onClick={() => onStyleChange(option.key)}
+          >
+            {t(option.i18nKey)}
+          </Button>
+        ))}
+      </div>
+      <div className="flex flex-col gap-2">
+        <Label htmlFor="personalization-custom-style">
+          {t('newChat.personalization.styleCustomLabel')}
+        </Label>
+        <Textarea
+          id="personalization-custom-style"
+          value={customStyle}
+          onChange={(e) => onCustomStyleChange(e.target.value)}
+          placeholder={t('newChat.personalization.styleCustomPlaceholder')}
+          maxLength={500}
+          rows={2}
+        />
+      </div>
+    </div>
+  );
+}

--- a/ayunis-core-frontend/src/pages/new-chat/ui/personalization/PersonalizationStepper.tsx
+++ b/ayunis-core-frontend/src/pages/new-chat/ui/personalization/PersonalizationStepper.tsx
@@ -1,0 +1,70 @@
+import { useTranslation } from 'react-i18next';
+import { Check } from 'lucide-react';
+import { cn } from '@/shared/lib/shadcn/utils';
+
+interface PersonalizationStepperProps {
+  currentStep: number;
+}
+
+const STEP_LABEL_KEYS = [
+  'newChat.personalization.stepperName',
+  'newChat.personalization.stepperStyle',
+  'newChat.personalization.stepperContext',
+] as const;
+
+export const PERSONALIZATION_TOTAL_STEPS = STEP_LABEL_KEYS.length;
+
+export function PersonalizationStepper({
+  currentStep,
+}: Readonly<PersonalizationStepperProps>) {
+  const totalSteps = STEP_LABEL_KEYS.length;
+  const { t } = useTranslation('chat');
+
+  return (
+    <div className="flex items-center justify-center gap-0">
+      {Array.from({ length: totalSteps }, (_, i) => {
+        const stepNumber = i + 1;
+        const isCompleted = stepNumber < currentStep;
+        const isCurrent = stepNumber === currentStep;
+
+        return (
+          <div key={stepNumber} className="flex items-center">
+            <div className="flex flex-col items-center gap-1">
+              <div
+                className={cn(
+                  'flex h-8 w-8 items-center justify-center rounded-full border-2 text-sm font-medium transition-colors',
+                  isCompleted &&
+                    'border-primary bg-primary text-primary-foreground',
+                  isCurrent && 'border-primary text-primary',
+                  !isCompleted &&
+                    !isCurrent &&
+                    'border-muted-foreground/30 text-muted-foreground/50',
+                )}
+              >
+                {isCompleted ? <Check className="h-4 w-4" /> : stepNumber}
+              </div>
+              <span
+                className={cn(
+                  'text-xs',
+                  isCurrent
+                    ? 'font-medium text-foreground'
+                    : 'text-muted-foreground',
+                )}
+              >
+                {t(STEP_LABEL_KEYS[i])}
+              </span>
+            </div>
+            {stepNumber < totalSteps && (
+              <div
+                className={cn(
+                  'mx-2 mb-5 h-0.5 w-12',
+                  isCompleted ? 'bg-primary' : 'bg-muted-foreground/20',
+                )}
+              />
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/ayunis-core-frontend/src/shared/locales/de/chat.json
+++ b/ayunis-core-frontend/src/shared/locales/de/chat.json
@@ -98,6 +98,37 @@
     "upgradeToProError": "Sie müssen ein Pro-Abonnement haben, um diese Funktion zu verwenden.",
     "personalizedPromptSuccess": "Personalisierter System-Prompt erstellt",
     "personalizedPromptError": "Personalisierter System-Prompt konnte nicht erstellt werden",
-    "noDefaultModelError": "Kein Standardmodell konfiguriert. Bitte wenden Sie sich an Ihren Administrator."
+    "systemPromptLoadError": "Personalisierungsstatus konnte nicht geladen werden. Die Personalisierung wurde möglicherweise übersprungen.",
+    "noDefaultModelError": "Kein Standardmodell konfiguriert. Bitte wenden Sie sich an Ihren Administrator.",
+    "personalization": {
+      "stepperName": "Name",
+      "stepperStyle": "Stil",
+      "stepperContext": "Kontext",
+      "nameTitle": "Wie möchtest du genannt werden?",
+      "nameDescription": "Damit ich dich persönlich ansprechen kann.",
+      "nameLabel": "Dein Name",
+      "namePlaceholder": "z.B. Anna, Herr Müller ...",
+      "styleTitle": "Wie soll ich kommunizieren?",
+      "styleDescription": "Wähle den Stil, der am besten zu dir passt.",
+      "styleCasual": "Locker & kurz",
+      "styleProfessional": "Professionell & ausführlich",
+      "styleFactual": "Sachlich & präzise",
+      "styleCustomLabel": "Eigene Ergänzung (optional)",
+      "styleCustomPlaceholder": "z.B. bitte immer in Stichpunkten antworten ...",
+      "contextTitle": "In welchem Bereich arbeitest du?",
+      "contextDescription": "Das hilft mir, passendere Antworten zu geben.",
+      "contextLabel": "Arbeitskontext",
+      "contextPlaceholder": "z.B. Bescheide im Sozialamt, Protokolle für den Gemeinderat ...",
+      "next": "Weiter",
+      "back": "Zurück",
+      "skip": "Später einrichten",
+      "submit": "Personalisierung starten",
+      "generating": "Dein persönlicher Assistent wird eingerichtet ...",
+      "errorMessage": "Leider ist ein Fehler aufgetreten. Bitte versuche es erneut.",
+      "errorTitle": "Fehler",
+      "skipError": "Personalisierung konnte nicht übersprungen werden. Bitte versuche es erneut.",
+      "retry": "Erneut versuchen",
+      "getStarted": "Los geht's"
+    }
   }
 }

--- a/ayunis-core-frontend/src/shared/locales/en/chat.json
+++ b/ayunis-core-frontend/src/shared/locales/en/chat.json
@@ -98,6 +98,37 @@
     "upgradeToProError": "You need to upgrade to a paid plan to use this feature.",
     "personalizedPromptSuccess": "Personalized system prompt generated",
     "personalizedPromptError": "Failed to generate personalized system prompt",
-    "noDefaultModelError": "No default model configured. Please contact your administrator."
+    "systemPromptLoadError": "Could not load personalization status. Personalization may have been skipped.",
+    "noDefaultModelError": "No default model configured. Please contact your administrator.",
+    "personalization": {
+      "stepperName": "Name",
+      "stepperStyle": "Style",
+      "stepperContext": "Context",
+      "nameTitle": "What should I call you?",
+      "nameDescription": "So I can address you personally.",
+      "nameLabel": "Your name",
+      "namePlaceholder": "e.g. Anna, Mr. Smith ...",
+      "styleTitle": "How should I communicate?",
+      "styleDescription": "Pick the style that suits you best.",
+      "styleCasual": "Casual & brief",
+      "styleProfessional": "Professional & detailed",
+      "styleFactual": "Factual & precise",
+      "styleCustomLabel": "Custom addition (optional)",
+      "styleCustomPlaceholder": "e.g. always reply in bullet points ...",
+      "contextTitle": "What area do you work in?",
+      "contextDescription": "This helps me give more relevant answers.",
+      "contextLabel": "Work context",
+      "contextPlaceholder": "e.g. social welfare notices, city council minutes ...",
+      "next": "Next",
+      "back": "Back",
+      "skip": "Set up later",
+      "submit": "Start personalization",
+      "generating": "Setting up your personal assistant ...",
+      "errorMessage": "Something went wrong. Please try again.",
+      "errorTitle": "Error",
+      "skipError": "Could not skip personalization. Please try again.",
+      "retry": "Try again",
+      "getStarted": "Get started"
+    }
   }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces a new conditional onboarding flow on `NewChatPage` and changes query prefetch/invalidation behavior, which could affect navigation and cache consistency if the system-prompt state isn’t handled correctly. Also tweaks `package-lock.json` dependency flags which could impact installs/builds in some environments.
> 
> **Overview**
> **New chat now gates on system-prompt personalization.** If the user has no system prompt, `NewChatPage` renders a new multi-step `PersonalizationCard` (name/style/context), supports *skip* via a sentinel system prompt, and shows loading/error/success states with a welcome message.
> 
> **Query behavior is adjusted to avoid UI race/flashing.** The chat route loader prefetches `chatSettingsControllerGetSystemPrompt`, and `useGeneratePersonalizedSystemPrompt` no longer invalidates the system-prompt query/router on settle; invalidation is deferred to the card’s `onComplete` callback.
> 
> Adds new i18n strings for the personalization UI (EN/DE) and updates backend `package-lock.json` to mark `@swc/core`/related packages as `devOptional` instead of `dev`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9f91a1f234044133aa2c584100ec831611538ec5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->