### PR TITLE
fix(AYC-103): address QA findings for skill templates

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -46,6 +46,7 @@ ayunis-core/
 | [shares](ayunis-core-backend/src/domain/shares/SUMMARY.md) | Sharing | Organization-wide resource sharing |
 | [transcriptions](ayunis-core-backend/src/domain/transcriptions/SUMMARY.md) | Voice | Audio transcription service |
 | [usage](ayunis-core-backend/src/domain/usage/SUMMARY.md) | Metering | Token and credit usage tracking |
+| [skill-templates](ayunis-core-backend/src/domain/skill-templates/SUMMARY.md) | Blueprints | Admin-managed skill templates with distribution modes |
 
 ### IAM Modules — Identity & Access Management
 

--- a/ayunis-core-backend/src/app/app.module.ts
+++ b/ayunis-core-backend/src/app/app.module.ts
@@ -24,6 +24,7 @@ import { UsageModule } from '../domain/usage/usage.module';
 import { TranscriptionsModule } from '../domain/transcriptions/transcriptions.module';
 import { ChatSettingsModule } from '../domain/chat-settings/chat-settings.module';
 import { KnowledgeBasesModule } from '../domain/knowledge-bases/knowledge-bases.module';
+import { SkillTemplatesModule } from '../domain/skill-templates/skill-templates.module';
 import { IamModule } from '../iam/iam.module';
 
 import { modelsConfig } from '../config/models.config';
@@ -138,6 +139,7 @@ import { MetricsModule } from '../metrics/metrics.module';
     TranscriptionsModule,
     ChatSettingsModule,
     KnowledgeBasesModule,
+    SkillTemplatesModule,
     IamModule.register({
       authProvider:
         // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- env var may be undefined at runtime despite type cast

--- a/ayunis-core-backend/src/db/migrations/1772657109813-CreateSkillTemplatesTable.ts
+++ b/ayunis-core-backend/src/db/migrations/1772657109813-CreateSkillTemplatesTable.ts
@@ -1,0 +1,23 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateSkillTemplatesTable1772657109813
+  implements MigrationInterface
+{
+  name = 'CreateSkillTemplatesTable1772657109813';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TYPE "public"."skill_templates_distributionmode_enum" AS ENUM('always_on', 'pre_created_copy')`,
+    );
+    await queryRunner.query(
+      `CREATE TABLE "skill_templates" ("id" character varying NOT NULL, "createdAt" TIMESTAMP NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP NOT NULL DEFAULT now(), "name" character varying NOT NULL, "shortDescription" character varying NOT NULL, "instructions" text NOT NULL, "distributionMode" "public"."skill_templates_distributionmode_enum" NOT NULL, "isActive" boolean NOT NULL DEFAULT false, CONSTRAINT "UQ_8c7147d8348fe8dd497b386eb40" UNIQUE ("name"), CONSTRAINT "PK_019dd6ccb411ca3d71d28d18da2" PRIMARY KEY ("id"))`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE "skill_templates"`);
+    await queryRunner.query(
+      `DROP TYPE "public"."skill_templates_distributionmode_enum"`,
+    );
+  }
+}

--- a/ayunis-core-backend/src/domain/skill-templates/SUMMARY.md
+++ b/ayunis-core-backend/src/domain/skill-templates/SUMMARY.md
@@ -1,0 +1,44 @@
+# Skill Templates Module
+
+## Purpose
+
+Skill templates are admin-managed blueprints for skills that can be distributed to users. They define the name, instructions, and distribution mode for skills that are automatically installed for users based on the distribution strategy.
+
+## Key Concepts
+
+- **Skill Template**: A blueprint with a name, short description, instructions, distribution mode, and active flag.
+- **Distribution Mode**: Controls how templates are distributed to users. Defined in `DistributionMode` enum:
+  - `ALWAYS_ON` — the skill is always active for every user and cannot be removed.
+  - `PRE_CREATED_COPY` — a personal copy of the skill is pre-created for each user, who can then modify or delete it.
+- **Active flag**: Only active templates are eligible for distribution. Inactive templates are drafts or retired.
+- **Name uniqueness**: Template names must be globally unique (enforced by DB unique constraint). Duplicate names raise `DuplicateSkillTemplateNameError`.
+
+## Structure
+
+```text
+skill-templates/
+├── SUMMARY.md
+├── domain/
+│   ├── skill-template.entity.ts           # Domain entity with name validation
+│   └── distribution-mode.enum.ts          # ALWAYS_ON, PRE_CREATED_COPY
+├── application/
+│   ├── ports/skill-template.repository.ts # Abstract repository interface
+│   └── skill-templates.errors.ts          # Domain errors
+├── infrastructure/
+│   └── persistence/local/
+│       ├── schema/skill-template.record.ts        # TypeORM entity
+│       ├── mappers/skill-template.mapper.ts       # Domain ↔ Record conversion
+│       ├── local-skill-template.repository.ts     # PostgreSQL repository
+│       └── local-skill-template-repository.module.ts
+└── skill-templates.module.ts              # NestJS wiring
+```
+
+## Design Decisions
+
+The module currently exports nothing — there are no use cases or controllers yet. The `SkillTemplateRepository` port is registered internally but not exported. Use cases will be added and exported in subsequent steps, allowing consumers (e.g., the marketplace skill installation flow) to interact with templates.
+
+Name validation reuses the same pattern as the Skills module (Unicode letters, numbers, emojis, hyphens, spaces; no consecutive spaces).
+
+## Dependencies
+
+None — this is a leaf module with no cross-module imports.

--- a/ayunis-core-backend/src/domain/skill-templates/application/ports/skill-template.repository.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/application/ports/skill-template.repository.ts
@@ -1,0 +1,13 @@
+import type { UUID } from 'crypto';
+import type { SkillTemplate } from '../../domain/skill-template.entity';
+import type { DistributionMode } from '../../domain/distribution-mode.enum';
+
+export abstract class SkillTemplateRepository {
+  abstract create(skillTemplate: SkillTemplate): Promise<SkillTemplate>;
+  abstract update(skillTemplate: SkillTemplate): Promise<SkillTemplate>;
+  abstract delete(id: UUID): Promise<void>;
+  abstract findOne(id: UUID): Promise<SkillTemplate | null>;
+  abstract findAll(): Promise<SkillTemplate[]>;
+  abstract findByName(name: string): Promise<SkillTemplate | null>;
+  abstract findActiveByMode(mode: DistributionMode): Promise<SkillTemplate[]>;
+}

--- a/ayunis-core-backend/src/domain/skill-templates/application/skill-templates.errors.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/application/skill-templates.errors.ts
@@ -1,0 +1,52 @@
+import type { ErrorMetadata } from '../../../common/errors/base.error';
+import { ApplicationError } from '../../../common/errors/base.error';
+
+export enum SkillTemplateErrorCode {
+  SKILL_TEMPLATE_NOT_FOUND = 'SKILL_TEMPLATE_NOT_FOUND',
+  DUPLICATE_SKILL_TEMPLATE_NAME = 'DUPLICATE_SKILL_TEMPLATE_NAME',
+  UNEXPECTED_SKILL_TEMPLATE_ERROR = 'UNEXPECTED_SKILL_TEMPLATE_ERROR',
+}
+
+export abstract class SkillTemplateError extends ApplicationError {
+  constructor(
+    message: string,
+    code: SkillTemplateErrorCode,
+    statusCode: number = 400,
+    metadata?: ErrorMetadata,
+  ) {
+    super(message, code, statusCode, metadata);
+  }
+}
+
+export class SkillTemplateNotFoundError extends SkillTemplateError {
+  constructor(skillTemplateId: string, metadata?: ErrorMetadata) {
+    super(
+      `Skill template with ID ${skillTemplateId} not found`,
+      SkillTemplateErrorCode.SKILL_TEMPLATE_NOT_FOUND,
+      404,
+      metadata,
+    );
+  }
+}
+
+export class DuplicateSkillTemplateNameError extends SkillTemplateError {
+  constructor(name: string, metadata?: ErrorMetadata) {
+    super(
+      `A skill template with the name "${name}" already exists`,
+      SkillTemplateErrorCode.DUPLICATE_SKILL_TEMPLATE_NAME,
+      409,
+      metadata,
+    );
+  }
+}
+
+export class UnexpectedSkillTemplateError extends SkillTemplateError {
+  constructor(error: unknown) {
+    super(
+      'Unexpected error occurred',
+      SkillTemplateErrorCode.UNEXPECTED_SKILL_TEMPLATE_ERROR,
+      500,
+      { error },
+    );
+  }
+}

--- a/ayunis-core-backend/src/domain/skill-templates/domain/distribution-mode.enum.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/domain/distribution-mode.enum.ts
@@ -1,0 +1,4 @@
+export enum DistributionMode {
+  ALWAYS_ON = 'always_on',
+  PRE_CREATED_COPY = 'pre_created_copy',
+}

--- a/ayunis-core-backend/src/domain/skill-templates/domain/skill-template.entity.spec.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/domain/skill-template.entity.spec.ts
@@ -1,0 +1,116 @@
+import {
+  SkillTemplate,
+  InvalidSkillTemplateNameError,
+} from './skill-template.entity';
+import { DistributionMode } from './distribution-mode.enum';
+import type { UUID } from 'crypto';
+
+describe('SkillTemplate', () => {
+  const validParams = {
+    name: 'Datenschutz-Hinweis',
+    shortDescription: 'Weist auf Datenschutzrichtlinien hin',
+    instructions: 'Du musst immer auf den Datenschutz achten.',
+    distributionMode: DistributionMode.ALWAYS_ON,
+  };
+
+  describe('construction', () => {
+    it('should create a skill template with valid parameters', () => {
+      const template = new SkillTemplate(validParams);
+
+      expect(template.id).toBeDefined();
+      expect(template.name).toBe('Datenschutz-Hinweis');
+      expect(template.shortDescription).toBe(
+        'Weist auf Datenschutzrichtlinien hin',
+      );
+      expect(template.instructions).toBe(
+        'Du musst immer auf den Datenschutz achten.',
+      );
+      expect(template.distributionMode).toBe(DistributionMode.ALWAYS_ON);
+      expect(template.isActive).toBe(false);
+      expect(template.createdAt).toBeInstanceOf(Date);
+      expect(template.updatedAt).toBeInstanceOf(Date);
+    });
+
+    it('should use provided id when given', () => {
+      const id = '550e8400-e29b-41d4-a716-446655440000' as UUID;
+      const template = new SkillTemplate({ ...validParams, id });
+
+      expect(template.id).toBe(id);
+    });
+
+    it('should use provided isActive value', () => {
+      const template = new SkillTemplate({ ...validParams, isActive: true });
+
+      expect(template.isActive).toBe(true);
+    });
+
+    it('should use provided dates', () => {
+      const createdAt = new Date('2026-01-15');
+      const updatedAt = new Date('2026-02-20');
+      const template = new SkillTemplate({
+        ...validParams,
+        createdAt,
+        updatedAt,
+      });
+
+      expect(template.createdAt).toEqual(createdAt);
+      expect(template.updatedAt).toEqual(updatedAt);
+    });
+
+    it('should accept pre_created_copy distribution mode', () => {
+      const template = new SkillTemplate({
+        ...validParams,
+        distributionMode: DistributionMode.PRE_CREATED_COPY,
+      });
+
+      expect(template.distributionMode).toBe(DistributionMode.PRE_CREATED_COPY);
+    });
+  });
+
+  describe('name validation', () => {
+    it('should accept names with letters and spaces', () => {
+      const template = new SkillTemplate({
+        ...validParams,
+        name: 'Legal Research Assistant',
+      });
+      expect(template.name).toBe('Legal Research Assistant');
+    });
+
+    it('should accept names with hyphens', () => {
+      const template = new SkillTemplate({
+        ...validParams,
+        name: 'DSGVO-Konform',
+      });
+      expect(template.name).toBe('DSGVO-Konform');
+    });
+
+    it('should accept single character names', () => {
+      const template = new SkillTemplate({ ...validParams, name: 'A' });
+      expect(template.name).toBe('A');
+    });
+
+    it('should reject names with consecutive spaces', () => {
+      expect(
+        () => new SkillTemplate({ ...validParams, name: 'Bad  Name' }),
+      ).toThrow(InvalidSkillTemplateNameError);
+    });
+
+    it('should reject empty names', () => {
+      expect(() => new SkillTemplate({ ...validParams, name: '' })).toThrow(
+        InvalidSkillTemplateNameError,
+      );
+    });
+
+    it('should reject names starting with a space', () => {
+      expect(
+        () => new SkillTemplate({ ...validParams, name: ' Leading' }),
+      ).toThrow(InvalidSkillTemplateNameError);
+    });
+
+    it('should reject names ending with a space', () => {
+      expect(
+        () => new SkillTemplate({ ...validParams, name: 'Trailing ' }),
+      ).toThrow(InvalidSkillTemplateNameError);
+    });
+  });
+});

--- a/ayunis-core-backend/src/domain/skill-templates/domain/skill-template.entity.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/domain/skill-template.entity.ts
@@ -1,0 +1,65 @@
+import type { UUID } from 'crypto';
+import { randomUUID } from 'crypto';
+import type { DistributionMode } from './distribution-mode.enum';
+
+/**
+ * Valid skill template names: Unicode letters, numbers, emojis, hyphens, and spaces.
+ * Must start and end with a letter, number, or emoji.
+ * No consecutive spaces. Min length 1.
+ *
+ * Reuses the same pattern as Skill entity.
+ */
+const SKILL_TEMPLATE_NAME_PATTERN =
+  /^[\p{L}\p{N}\p{Emoji_Presentation}]([\p{L}\p{N}\p{Emoji_Presentation} -]*[\p{L}\p{N}\p{Emoji_Presentation}])?$/u;
+const CONSECUTIVE_SPACES = / {2}/;
+
+export class InvalidSkillTemplateNameError extends Error {
+  constructor(name: string) {
+    super(
+      `Invalid skill template name "${name}". Names must contain only letters, numbers, emojis, hyphens, and spaces, ` +
+        `must start and end with a letter, number, or emoji, and must not contain consecutive spaces.`,
+    );
+    this.name = 'InvalidSkillTemplateNameError';
+  }
+}
+
+function validateSkillTemplateName(name: string): void {
+  if (
+    !SKILL_TEMPLATE_NAME_PATTERN.test(name) ||
+    CONSECUTIVE_SPACES.test(name)
+  ) {
+    throw new InvalidSkillTemplateNameError(name);
+  }
+}
+
+export class SkillTemplate {
+  public readonly id: UUID;
+  public readonly name: string;
+  public readonly shortDescription: string;
+  public readonly instructions: string;
+  public readonly distributionMode: DistributionMode;
+  public readonly isActive: boolean;
+  public readonly createdAt: Date;
+  public readonly updatedAt: Date;
+
+  constructor(params: {
+    id?: UUID;
+    name: string;
+    shortDescription: string;
+    instructions: string;
+    distributionMode: DistributionMode;
+    isActive?: boolean;
+    createdAt?: Date;
+    updatedAt?: Date;
+  }) {
+    this.id = params.id ?? randomUUID();
+    validateSkillTemplateName(params.name);
+    this.name = params.name;
+    this.shortDescription = params.shortDescription;
+    this.instructions = params.instructions;
+    this.distributionMode = params.distributionMode;
+    this.isActive = params.isActive ?? false;
+    this.createdAt = params.createdAt ?? new Date();
+    this.updatedAt = params.updatedAt ?? new Date();
+  }
+}

--- a/ayunis-core-backend/src/domain/skill-templates/infrastructure/persistence/local/local-skill-template-repository.module.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/infrastructure/persistence/local/local-skill-template-repository.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { LocalSkillTemplateRepository } from './local-skill-template.repository';
+import { SkillTemplateRecord } from './schema/skill-template.record';
+import { SkillTemplateMapper } from './mappers/skill-template.mapper';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([SkillTemplateRecord])],
+  providers: [SkillTemplateMapper, LocalSkillTemplateRepository],
+  exports: [LocalSkillTemplateRepository],
+})
+export class LocalSkillTemplateRepositoryModule {}

--- a/ayunis-core-backend/src/domain/skill-templates/infrastructure/persistence/local/local-skill-template.repository.spec.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/infrastructure/persistence/local/local-skill-template.repository.spec.ts
@@ -1,0 +1,266 @@
+import type { Repository } from 'typeorm';
+import { QueryFailedError } from 'typeorm';
+import { randomUUID } from 'crypto';
+
+import { LocalSkillTemplateRepository } from './local-skill-template.repository';
+import { SkillTemplateRecord } from './schema/skill-template.record';
+import { SkillTemplateMapper } from './mappers/skill-template.mapper';
+import { SkillTemplate } from '../../../domain/skill-template.entity';
+import { DistributionMode } from '../../../domain/distribution-mode.enum';
+import {
+  DuplicateSkillTemplateNameError,
+  SkillTemplateNotFoundError,
+} from '../../../application/skill-templates.errors';
+
+function buildSkillTemplate(overrides?: Partial<SkillTemplate>): SkillTemplate {
+  return new SkillTemplate({
+    id: randomUUID(),
+    name: 'Bürgerservice Vorlage',
+    shortDescription: 'Vorlage für Bürgerservice-Skills',
+    instructions: 'Beantworte Fragen zum Bürgerservice.',
+    distributionMode: DistributionMode.PRE_CREATED_COPY,
+    isActive: true,
+    ...overrides,
+  });
+}
+
+function buildRecord(template: SkillTemplate): SkillTemplateRecord {
+  const record = new SkillTemplateRecord();
+  record.id = template.id;
+  record.name = template.name;
+  record.shortDescription = template.shortDescription;
+  record.instructions = template.instructions;
+  record.distributionMode = template.distributionMode;
+  record.isActive = template.isActive;
+  record.createdAt = template.createdAt;
+  record.updatedAt = template.updatedAt;
+  return record;
+}
+
+function createPgUniqueViolation(): QueryFailedError {
+  const error = new QueryFailedError('INSERT', [], new Error('unique'));
+  (error as QueryFailedError & { code?: string }).code = '23505';
+  return error;
+}
+
+describe('LocalSkillTemplateRepository', () => {
+  let repo: LocalSkillTemplateRepository;
+  let mockTypeOrmRepo: jest.Mocked<Repository<SkillTemplateRecord>>;
+  let mapper: SkillTemplateMapper;
+
+  beforeEach(() => {
+    mapper = new SkillTemplateMapper();
+
+    mockTypeOrmRepo = {
+      save: jest.fn(),
+      findOne: jest.fn(),
+      find: jest.fn(),
+      delete: jest.fn(),
+      update: jest.fn(),
+    } as unknown as jest.Mocked<Repository<SkillTemplateRecord>>;
+
+    repo = new LocalSkillTemplateRepository(mockTypeOrmRepo, mapper);
+  });
+
+  describe('create', () => {
+    it('should save and return the created skill template', async () => {
+      const template = buildSkillTemplate();
+      const record = buildRecord(template);
+      mockTypeOrmRepo.save.mockResolvedValue(record);
+
+      const result = await repo.create(template);
+
+      expect(result.id).toBe(template.id);
+      expect(result.name).toBe(template.name);
+      expect(mockTypeOrmRepo.save).toHaveBeenCalledTimes(1);
+    });
+
+    it('should throw DuplicateSkillTemplateNameError on unique violation', async () => {
+      const template = buildSkillTemplate();
+      mockTypeOrmRepo.save.mockRejectedValue(createPgUniqueViolation());
+
+      await expect(repo.create(template)).rejects.toThrow(
+        DuplicateSkillTemplateNameError,
+      );
+    });
+
+    it('should rethrow non-unique-violation errors', async () => {
+      const template = buildSkillTemplate();
+      const dbError = new Error('connection lost');
+      mockTypeOrmRepo.save.mockRejectedValue(dbError);
+
+      await expect(repo.create(template)).rejects.toThrow('connection lost');
+    });
+  });
+
+  describe('update', () => {
+    it('should throw SkillTemplateNotFoundError when template does not exist', async () => {
+      const template = buildSkillTemplate();
+      mockTypeOrmRepo.findOne.mockResolvedValue(null);
+
+      await expect(repo.update(template)).rejects.toThrow(
+        SkillTemplateNotFoundError,
+      );
+      expect(mockTypeOrmRepo.save).not.toHaveBeenCalled();
+    });
+
+    it('should save and return the updated skill template', async () => {
+      const template = buildSkillTemplate();
+      const record = buildRecord(template);
+      mockTypeOrmRepo.findOne.mockResolvedValue(record);
+      mockTypeOrmRepo.save.mockResolvedValue(record);
+
+      const result = await repo.update(template);
+
+      expect(result.id).toBe(template.id);
+      expect(mockTypeOrmRepo.save).toHaveBeenCalledTimes(1);
+    });
+
+    it('should throw DuplicateSkillTemplateNameError when renaming to existing name', async () => {
+      const template = buildSkillTemplate({ name: 'Duplicate Name' });
+      const existingRecord = buildRecord(template);
+      mockTypeOrmRepo.findOne.mockResolvedValue(existingRecord);
+      mockTypeOrmRepo.save.mockRejectedValue(createPgUniqueViolation());
+
+      await expect(repo.update(template)).rejects.toThrow(
+        DuplicateSkillTemplateNameError,
+      );
+    });
+  });
+
+  describe('delete', () => {
+    it('should throw SkillTemplateNotFoundError when template does not exist', async () => {
+      const id = randomUUID();
+      mockTypeOrmRepo.delete.mockResolvedValue({ affected: 0, raw: [] });
+
+      await expect(repo.delete(id)).rejects.toThrow(SkillTemplateNotFoundError);
+    });
+
+    it('should delete without error when template exists', async () => {
+      const id = randomUUID();
+      mockTypeOrmRepo.delete.mockResolvedValue({ affected: 1, raw: [] });
+
+      await expect(repo.delete(id)).resolves.toBeUndefined();
+    });
+  });
+
+  describe('findOne', () => {
+    it('should return null when template does not exist', async () => {
+      mockTypeOrmRepo.findOne.mockResolvedValue(null);
+
+      const result = await repo.findOne(randomUUID());
+
+      expect(result).toBeNull();
+    });
+
+    it('should return the domain entity when found', async () => {
+      const template = buildSkillTemplate();
+      const record = buildRecord(template);
+      mockTypeOrmRepo.findOne.mockResolvedValue(record);
+
+      const result = await repo.findOne(template.id);
+
+      expect(result).not.toBeNull();
+      expect(result!.id).toBe(template.id);
+    });
+  });
+
+  describe('findAll', () => {
+    it('should return all templates ordered by createdAt descending', async () => {
+      const older = buildSkillTemplate({ name: 'Ältere Vorlage' });
+      const newer = buildSkillTemplate({ name: 'Neuere Vorlage' });
+      mockTypeOrmRepo.find.mockResolvedValue([
+        buildRecord(newer),
+        buildRecord(older),
+      ]);
+
+      const result = await repo.findAll();
+
+      expect(result).toHaveLength(2);
+      expect(result[0].name).toBe('Neuere Vorlage');
+      expect(result[1].name).toBe('Ältere Vorlage');
+      expect(mockTypeOrmRepo.find).toHaveBeenCalledWith({
+        order: { createdAt: 'DESC' },
+      });
+    });
+
+    it('should return empty array when no templates exist', async () => {
+      mockTypeOrmRepo.find.mockResolvedValue([]);
+
+      const result = await repo.findAll();
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('findByName', () => {
+    it('should return the template when found by name', async () => {
+      const template = buildSkillTemplate({ name: 'Meldewesen Vorlage' });
+      const record = buildRecord(template);
+      mockTypeOrmRepo.findOne.mockResolvedValue(record);
+
+      const result = await repo.findByName('Meldewesen Vorlage');
+
+      expect(result).not.toBeNull();
+      expect(result!.name).toBe('Meldewesen Vorlage');
+      expect(mockTypeOrmRepo.findOne).toHaveBeenCalledWith({
+        where: { name: 'Meldewesen Vorlage' },
+      });
+    });
+
+    it('should return null when no template matches the name', async () => {
+      mockTypeOrmRepo.findOne.mockResolvedValue(null);
+
+      const result = await repo.findByName('Nicht Vorhanden');
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('findActiveByMode', () => {
+    it('should return only active templates with the specified distribution mode', async () => {
+      const activeAlwaysOn = buildSkillTemplate({
+        name: 'Immer Aktiv',
+        distributionMode: DistributionMode.ALWAYS_ON,
+        isActive: true,
+      });
+      mockTypeOrmRepo.find.mockResolvedValue([buildRecord(activeAlwaysOn)]);
+
+      const result = await repo.findActiveByMode(DistributionMode.ALWAYS_ON);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].name).toBe('Immer Aktiv');
+      expect(result[0].isActive).toBe(true);
+      expect(result[0].distributionMode).toBe(DistributionMode.ALWAYS_ON);
+      expect(mockTypeOrmRepo.find).toHaveBeenCalledWith({
+        where: { isActive: true, distributionMode: DistributionMode.ALWAYS_ON },
+        order: { createdAt: 'ASC' },
+      });
+    });
+
+    it('should return empty array when no active templates match the mode', async () => {
+      mockTypeOrmRepo.find.mockResolvedValue([]);
+
+      const result = await repo.findActiveByMode(
+        DistributionMode.PRE_CREATED_COPY,
+      );
+
+      expect(result).toEqual([]);
+    });
+
+    it('should not return inactive templates', async () => {
+      // The repository queries with isActive: true, so inactive records
+      // are filtered at the database level. Mock returns empty to verify
+      // the correct query is issued.
+      mockTypeOrmRepo.find.mockResolvedValue([]);
+
+      await repo.findActiveByMode(DistributionMode.ALWAYS_ON);
+
+      expect(mockTypeOrmRepo.find).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ isActive: true }),
+        }),
+      );
+    });
+  });
+});

--- a/ayunis-core-backend/src/domain/skill-templates/infrastructure/persistence/local/local-skill-template.repository.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/infrastructure/persistence/local/local-skill-template.repository.ts
@@ -1,0 +1,107 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { QueryFailedError, Repository } from 'typeorm';
+import type { UUID } from 'crypto';
+
+import { SkillTemplateRepository } from '../../../application/ports/skill-template.repository';
+import { SkillTemplate } from '../../../domain/skill-template.entity';
+import { SkillTemplateRecord } from './schema/skill-template.record';
+import { SkillTemplateMapper } from './mappers/skill-template.mapper';
+import { DistributionMode } from '../../../domain/distribution-mode.enum';
+import {
+  DuplicateSkillTemplateNameError,
+  SkillTemplateNotFoundError,
+} from '../../../application/skill-templates.errors';
+
+const PG_UNIQUE_VIOLATION = '23505';
+
+@Injectable()
+export class LocalSkillTemplateRepository implements SkillTemplateRepository {
+  private readonly logger = new Logger(LocalSkillTemplateRepository.name);
+
+  constructor(
+    @InjectRepository(SkillTemplateRecord)
+    private readonly repository: Repository<SkillTemplateRecord>,
+    private readonly mapper: SkillTemplateMapper,
+  ) {}
+
+  async create(skillTemplate: SkillTemplate): Promise<SkillTemplate> {
+    this.logger.log('create', { name: skillTemplate.name });
+    const record = this.mapper.toRecord(skillTemplate);
+    const saved = await this.saveOrThrow(record, skillTemplate.name);
+    return this.mapper.toDomain(saved);
+  }
+
+  async update(skillTemplate: SkillTemplate): Promise<SkillTemplate> {
+    this.logger.log('update', {
+      id: skillTemplate.id,
+      name: skillTemplate.name,
+    });
+    const exists = await this.repository.findOne({
+      where: { id: skillTemplate.id },
+    });
+    if (!exists) {
+      throw new SkillTemplateNotFoundError(skillTemplate.id);
+    }
+    const record = this.mapper.toRecord(skillTemplate);
+    const saved = await this.saveOrThrow(record, skillTemplate.name);
+    return this.mapper.toDomain(saved);
+  }
+
+  async delete(id: UUID): Promise<void> {
+    this.logger.log('delete', { id });
+    const result = await this.repository.delete({ id });
+    if (result.affected === 0) {
+      throw new SkillTemplateNotFoundError(id);
+    }
+  }
+
+  async findOne(id: UUID): Promise<SkillTemplate | null> {
+    this.logger.log('findOne', { id });
+    const record = await this.repository.findOne({ where: { id } });
+    if (!record) return null;
+    return this.mapper.toDomain(record);
+  }
+
+  async findAll(): Promise<SkillTemplate[]> {
+    this.logger.log('findAll');
+    const records = await this.repository.find({
+      order: { createdAt: 'DESC' },
+    });
+    return records.map((r) => this.mapper.toDomain(r));
+  }
+
+  async findByName(name: string): Promise<SkillTemplate | null> {
+    this.logger.log('findByName', { name });
+    const record = await this.repository.findOne({ where: { name } });
+    if (!record) return null;
+    return this.mapper.toDomain(record);
+  }
+
+  async findActiveByMode(mode: DistributionMode): Promise<SkillTemplate[]> {
+    this.logger.log('findActiveByMode', { mode });
+    const records = await this.repository.find({
+      where: { isActive: true, distributionMode: mode },
+      order: { createdAt: 'ASC' },
+    });
+    return records.map((r) => this.mapper.toDomain(r));
+  }
+
+  private async saveOrThrow(
+    record: SkillTemplateRecord,
+    name: string,
+  ): Promise<SkillTemplateRecord> {
+    try {
+      return await this.repository.save(record);
+    } catch (error) {
+      if (
+        error instanceof QueryFailedError &&
+        (error as QueryFailedError & { code?: string }).code ===
+          PG_UNIQUE_VIOLATION
+      ) {
+        throw new DuplicateSkillTemplateNameError(name);
+      }
+      throw error;
+    }
+  }
+}

--- a/ayunis-core-backend/src/domain/skill-templates/infrastructure/persistence/local/mappers/skill-template.mapper.spec.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/infrastructure/persistence/local/mappers/skill-template.mapper.spec.ts
@@ -1,0 +1,119 @@
+import { SkillTemplate } from '../../../../domain/skill-template.entity';
+import { SkillTemplateRecord } from '../schema/skill-template.record';
+import { SkillTemplateMapper } from './skill-template.mapper';
+import { DistributionMode } from '../../../../domain/distribution-mode.enum';
+import type { UUID } from 'crypto';
+
+describe('SkillTemplateMapper', () => {
+  let mapper: SkillTemplateMapper;
+
+  const mockId = '550e8400-e29b-41d4-a716-446655440000' as UUID;
+
+  beforeEach(() => {
+    mapper = new SkillTemplateMapper();
+  });
+
+  describe('toDomain', () => {
+    it('should map a SkillTemplateRecord to SkillTemplate domain entity', () => {
+      const record = new SkillTemplateRecord();
+      record.id = mockId;
+      record.name = 'Datenschutz-Richtlinie';
+      record.shortDescription = 'Stellt Datenschutzkonformität sicher';
+      record.instructions =
+        'Achte bei allen Antworten auf den Datenschutz und die DSGVO.';
+      record.distributionMode = DistributionMode.ALWAYS_ON;
+      record.isActive = true;
+      record.createdAt = new Date('2026-01-01');
+      record.updatedAt = new Date('2026-01-02');
+
+      const domain = mapper.toDomain(record);
+
+      expect(domain.id).toBe(mockId);
+      expect(domain.name).toBe('Datenschutz-Richtlinie');
+      expect(domain.shortDescription).toBe(
+        'Stellt Datenschutzkonformität sicher',
+      );
+      expect(domain.instructions).toBe(
+        'Achte bei allen Antworten auf den Datenschutz und die DSGVO.',
+      );
+      expect(domain.distributionMode).toBe(DistributionMode.ALWAYS_ON);
+      expect(domain.isActive).toBe(true);
+      expect(domain.createdAt).toEqual(new Date('2026-01-01'));
+      expect(domain.updatedAt).toEqual(new Date('2026-01-02'));
+    });
+
+    it('should map a record with pre_created_copy mode', () => {
+      const record = new SkillTemplateRecord();
+      record.id = mockId;
+      record.name = 'Willkommens-Skill';
+      record.shortDescription = 'Begrüßt neue Nutzer';
+      record.instructions = 'Begrüße den Nutzer freundlich.';
+      record.distributionMode = DistributionMode.PRE_CREATED_COPY;
+      record.isActive = false;
+      record.createdAt = new Date('2026-03-01');
+      record.updatedAt = new Date('2026-03-01');
+
+      const domain = mapper.toDomain(record);
+
+      expect(domain.distributionMode).toBe(DistributionMode.PRE_CREATED_COPY);
+      expect(domain.isActive).toBe(false);
+    });
+  });
+
+  describe('toRecord', () => {
+    it('should map a SkillTemplate domain entity to SkillTemplateRecord', () => {
+      const domain = new SkillTemplate({
+        id: mockId,
+        name: 'Datenschutz-Richtlinie',
+        shortDescription: 'Stellt Datenschutzkonformität sicher',
+        instructions:
+          'Achte bei allen Antworten auf den Datenschutz und die DSGVO.',
+        distributionMode: DistributionMode.ALWAYS_ON,
+        isActive: true,
+      });
+
+      const record = mapper.toRecord(domain);
+
+      expect(record.id).toBe(mockId);
+      expect(record.name).toBe('Datenschutz-Richtlinie');
+      expect(record.shortDescription).toBe(
+        'Stellt Datenschutzkonformität sicher',
+      );
+      expect(record.instructions).toBe(
+        'Achte bei allen Antworten auf den Datenschutz und die DSGVO.',
+      );
+      expect(record.distributionMode).toBe(DistributionMode.ALWAYS_ON);
+      expect(record.isActive).toBe(true);
+    });
+  });
+
+  describe('round-trip', () => {
+    it('should preserve all fields through domain → record → domain', () => {
+      const original = new SkillTemplate({
+        id: mockId,
+        name: 'Verwaltungs-Assistent',
+        shortDescription: 'Unterstützt bei Verwaltungsaufgaben',
+        instructions: 'Hilf bei kommunalen Verwaltungsaufgaben.',
+        distributionMode: DistributionMode.PRE_CREATED_COPY,
+        isActive: true,
+        createdAt: new Date('2026-02-15'),
+        updatedAt: new Date('2026-02-20'),
+      });
+
+      const record = mapper.toRecord(original);
+      // Simulate DB returning timestamps
+      record.createdAt = original.createdAt;
+      record.updatedAt = original.updatedAt;
+      const restored = mapper.toDomain(record);
+
+      expect(restored.id).toBe(original.id);
+      expect(restored.name).toBe(original.name);
+      expect(restored.shortDescription).toBe(original.shortDescription);
+      expect(restored.instructions).toBe(original.instructions);
+      expect(restored.distributionMode).toBe(original.distributionMode);
+      expect(restored.isActive).toBe(original.isActive);
+      expect(restored.createdAt).toEqual(original.createdAt);
+      expect(restored.updatedAt).toEqual(original.updatedAt);
+    });
+  });
+});

--- a/ayunis-core-backend/src/domain/skill-templates/infrastructure/persistence/local/mappers/skill-template.mapper.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/infrastructure/persistence/local/mappers/skill-template.mapper.ts
@@ -1,0 +1,30 @@
+import { Injectable } from '@nestjs/common';
+import { SkillTemplate } from '../../../../domain/skill-template.entity';
+import { SkillTemplateRecord } from '../schema/skill-template.record';
+
+@Injectable()
+export class SkillTemplateMapper {
+  toDomain(record: SkillTemplateRecord): SkillTemplate {
+    return new SkillTemplate({
+      id: record.id,
+      name: record.name,
+      shortDescription: record.shortDescription,
+      instructions: record.instructions,
+      distributionMode: record.distributionMode,
+      isActive: record.isActive,
+      createdAt: record.createdAt,
+      updatedAt: record.updatedAt,
+    });
+  }
+
+  toRecord(domain: SkillTemplate): SkillTemplateRecord {
+    const record = new SkillTemplateRecord();
+    record.id = domain.id;
+    record.name = domain.name;
+    record.shortDescription = domain.shortDescription;
+    record.instructions = domain.instructions;
+    record.distributionMode = domain.distributionMode;
+    record.isActive = domain.isActive;
+    return record;
+  }
+}

--- a/ayunis-core-backend/src/domain/skill-templates/infrastructure/persistence/local/schema/skill-template.record.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/infrastructure/persistence/local/schema/skill-template.record.ts
@@ -1,0 +1,25 @@
+import { Column, Entity } from 'typeorm';
+import { BaseRecord } from '../../../../../../common/db/base-record';
+import { DistributionMode } from '../../../../domain/distribution-mode.enum';
+
+@Entity({ name: 'skill_templates' })
+export class SkillTemplateRecord extends BaseRecord {
+  @Column({ nullable: false, unique: true })
+  name: string;
+
+  @Column({ nullable: false })
+  shortDescription: string;
+
+  @Column({ nullable: false, type: 'text' })
+  instructions: string;
+
+  @Column({
+    type: 'enum',
+    enum: DistributionMode,
+    nullable: false,
+  })
+  distributionMode: DistributionMode;
+
+  @Column({ nullable: false, default: false })
+  isActive: boolean;
+}

--- a/ayunis-core-backend/src/domain/skill-templates/skill-templates.module.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/skill-templates.module.ts
@@ -1,0 +1,16 @@
+import { Module } from '@nestjs/common';
+import { LocalSkillTemplateRepositoryModule } from './infrastructure/persistence/local/local-skill-template-repository.module';
+import { LocalSkillTemplateRepository } from './infrastructure/persistence/local/local-skill-template.repository';
+import { SkillTemplateRepository } from './application/ports/skill-template.repository';
+
+@Module({
+  imports: [LocalSkillTemplateRepositoryModule],
+  providers: [
+    {
+      provide: SkillTemplateRepository,
+      useExisting: LocalSkillTemplateRepository,
+    },
+  ],
+  exports: [],
+})
+export class SkillTemplatesModule {}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new persisted domain module plus a database migration (new table + enum), which can impact deployments and data schema. Runtime behavior is otherwise limited since there are no controllers/use cases yet.
> 
> **Overview**
> Adds a new **`skill-templates`** backend domain module for admin-managed skill blueprints, including a `SkillTemplate` entity with name validation and a `DistributionMode` enum.
> 
> Introduces persistence for templates via a TypeORM `SkillTemplateRecord`, mapper, and `LocalSkillTemplateRepository` (CRUD plus `findActiveByMode`), with error mapping for not-found and duplicate-name cases and accompanying unit tests.
> 
> Wires the module into `AppModule` and adds a TypeORM migration creating the `skill_templates` table (unique `name`, `isActive` flag, and `distributionMode` enum).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9e942eec4dd842ad043480b58768dc220e623d81. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->