### PR TITLE
wip(AYC-103): add skill template CRUD use cases and super admin controller

### DIFF
--- a/ayunis-core-backend/src/domain/skill-templates/SUMMARY.md
+++ b/ayunis-core-backend/src/domain/skill-templates/SUMMARY.md
@@ -23,22 +23,39 @@ skill-templates/
 │   └── distribution-mode.enum.ts          # ALWAYS_ON, PRE_CREATED_COPY
 ├── application/
 │   ├── ports/skill-template.repository.ts # Abstract repository interface
-│   └── skill-templates.errors.ts          # Domain errors
+│   ├── skill-templates.errors.ts          # Domain errors
+│   └── use-cases/
+│       ├── create-skill-template/         # CreateSkillTemplateUseCase + command
+│       ├── update-skill-template/         # UpdateSkillTemplateUseCase + command
+│       ├── delete-skill-template/         # DeleteSkillTemplateUseCase + command
+│       ├── find-all-skill-templates/      # FindAllSkillTemplatesUseCase + query
+│       └── find-one-skill-template/       # FindOneSkillTemplateUseCase + query
 ├── infrastructure/
 │   └── persistence/local/
 │       ├── schema/skill-template.record.ts        # TypeORM entity
 │       ├── mappers/skill-template.mapper.ts       # Domain ↔ Record conversion
 │       ├── local-skill-template.repository.ts     # PostgreSQL repository
 │       └── local-skill-template-repository.module.ts
+├── presenters/http/
+│   ├── super-admin-skill-templates.controller.ts  # CRUD controller (super-admin only)
+│   ├── dto/
+│   │   ├── create-skill-template.dto.ts           # Create request DTO
+│   │   ├── update-skill-template.dto.ts           # Update request DTO
+│   │   └── skill-template-response.dto.ts         # Response DTO
+│   └── mappers/
+│       └── skill-template-response.mapper.ts      # Domain → Response DTO mapper
 └── skill-templates.module.ts              # NestJS wiring
 ```
 
-## Design Decisions
+## Exports
 
-The module currently exports nothing — there are no use cases or controllers yet. The `SkillTemplateRepository` port is registered internally but not exported. Use cases will be added and exported in subsequent steps, allowing consumers (e.g., the marketplace skill installation flow) to interact with templates.
+- `FindAllSkillTemplatesUseCase` — exported for consumers that need to list all templates (e.g., marketplace skill installation flow).
+
+## Design Decisions
 
 Name validation reuses the same pattern as the Skills module (Unicode letters, numbers, emojis, hyphens, spaces; no consecutive spaces).
 
 ## Dependencies
 
-None — this is a leaf module with no cross-module imports.
+- `iam/authorization` — decorators for route protection (`SystemRoles`)
+- `iam/users` — `SystemRole` enum used in controller authorization

--- a/ayunis-core-backend/src/domain/skill-templates/application/use-cases/create-skill-template/create-skill-template.command.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/application/use-cases/create-skill-template/create-skill-template.command.ts
@@ -1,0 +1,23 @@
+import type { DistributionMode } from '../../../domain/distribution-mode.enum';
+
+export class CreateSkillTemplateCommand {
+  public readonly name: string;
+  public readonly shortDescription: string;
+  public readonly instructions: string;
+  public readonly distributionMode: DistributionMode;
+  public readonly isActive?: boolean;
+
+  constructor(params: {
+    name: string;
+    shortDescription: string;
+    instructions: string;
+    distributionMode: DistributionMode;
+    isActive?: boolean;
+  }) {
+    this.name = params.name;
+    this.shortDescription = params.shortDescription;
+    this.instructions = params.instructions;
+    this.distributionMode = params.distributionMode;
+    this.isActive = params.isActive;
+  }
+}

--- a/ayunis-core-backend/src/domain/skill-templates/application/use-cases/create-skill-template/create-skill-template.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/application/use-cases/create-skill-template/create-skill-template.use-case.spec.ts
@@ -1,0 +1,132 @@
+import type { TestingModule } from '@nestjs/testing';
+import { Test } from '@nestjs/testing';
+import { Logger } from '@nestjs/common';
+import { CreateSkillTemplateUseCase } from './create-skill-template.use-case';
+import { CreateSkillTemplateCommand } from './create-skill-template.command';
+import { SkillTemplateRepository } from '../../ports/skill-template.repository';
+import { SkillTemplate } from '../../../domain/skill-template.entity';
+import { DistributionMode } from '../../../domain/distribution-mode.enum';
+import { InvalidSkillTemplateNameError } from '../../../domain/skill-template.entity';
+import { DuplicateSkillTemplateNameError } from '../../skill-templates.errors';
+
+describe('CreateSkillTemplateUseCase', () => {
+  let useCase: CreateSkillTemplateUseCase;
+  let repository: jest.Mocked<SkillTemplateRepository>;
+
+  beforeAll(async () => {
+    const mockRepository = {
+      create: jest.fn(),
+      findByName: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        CreateSkillTemplateUseCase,
+        { provide: SkillTemplateRepository, useValue: mockRepository },
+      ],
+    }).compile();
+
+    useCase = module.get<CreateSkillTemplateUseCase>(
+      CreateSkillTemplateUseCase,
+    );
+    repository = module.get(SkillTemplateRepository);
+
+    jest.spyOn(Logger.prototype, 'log').mockImplementation();
+    jest.spyOn(Logger.prototype, 'error').mockImplementation();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should create a skill template successfully', async () => {
+    const command = new CreateSkillTemplateCommand({
+      name: 'Legal Guidelines',
+      shortDescription: 'Legal compliance instructions',
+      instructions: 'Always follow legal guidelines when responding.',
+      distributionMode: DistributionMode.ALWAYS_ON,
+    });
+
+    const expectedTemplate = new SkillTemplate({
+      name: command.name,
+      shortDescription: command.shortDescription,
+      instructions: command.instructions,
+      distributionMode: command.distributionMode,
+    });
+
+    repository.findByName.mockResolvedValue(null);
+    repository.create.mockResolvedValue(expectedTemplate);
+
+    const result = await useCase.execute(command);
+
+    expect(repository.findByName).toHaveBeenCalledWith('Legal Guidelines');
+    expect(repository.create).toHaveBeenCalledWith(expect.any(SkillTemplate));
+    expect(result.name).toBe('Legal Guidelines');
+    expect(result.distributionMode).toBe(DistributionMode.ALWAYS_ON);
+  });
+
+  it('should create a skill template with isActive flag', async () => {
+    const command = new CreateSkillTemplateCommand({
+      name: 'Active Template',
+      shortDescription: 'An active template',
+      instructions: 'Instructions here.',
+      distributionMode: DistributionMode.PRE_CREATED_COPY,
+      isActive: true,
+    });
+
+    const expectedTemplate = new SkillTemplate({
+      name: command.name,
+      shortDescription: command.shortDescription,
+      instructions: command.instructions,
+      distributionMode: command.distributionMode,
+      isActive: true,
+    });
+
+    repository.findByName.mockResolvedValue(null);
+    repository.create.mockResolvedValue(expectedTemplate);
+
+    const result = await useCase.execute(command);
+
+    expect(result.isActive).toBe(true);
+    expect(result.distributionMode).toBe(DistributionMode.PRE_CREATED_COPY);
+  });
+
+  it('should reject creation when name already exists', async () => {
+    const command = new CreateSkillTemplateCommand({
+      name: 'Legal Guidelines',
+      shortDescription: 'Duplicate name',
+      instructions: 'Some instructions.',
+      distributionMode: DistributionMode.ALWAYS_ON,
+    });
+
+    const existingTemplate = new SkillTemplate({
+      name: 'Legal Guidelines',
+      shortDescription: 'Existing template',
+      instructions: 'Existing instructions.',
+      distributionMode: DistributionMode.ALWAYS_ON,
+    });
+
+    repository.findByName.mockResolvedValue(existingTemplate);
+
+    await expect(useCase.execute(command)).rejects.toThrow(
+      DuplicateSkillTemplateNameError,
+    );
+    expect(repository.create).not.toHaveBeenCalled();
+  });
+
+  it('should rethrow InvalidSkillTemplateNameError for invalid names', async () => {
+    const command = new CreateSkillTemplateCommand({
+      name: '  invalid  name  ',
+      shortDescription: 'Description',
+      instructions: 'Instructions.',
+      distributionMode: DistributionMode.ALWAYS_ON,
+    });
+
+    repository.findByName.mockResolvedValue(null);
+
+    await expect(useCase.execute(command)).rejects.toThrow(
+      InvalidSkillTemplateNameError,
+    );
+    expect(repository.create).not.toHaveBeenCalled();
+  });
+});

--- a/ayunis-core-backend/src/domain/skill-templates/application/use-cases/create-skill-template/create-skill-template.use-case.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/application/use-cases/create-skill-template/create-skill-template.use-case.ts
@@ -1,0 +1,51 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { SkillTemplateRepository } from '../../ports/skill-template.repository';
+import { CreateSkillTemplateCommand } from './create-skill-template.command';
+import { SkillTemplate } from '../../../domain/skill-template.entity';
+import {
+  DuplicateSkillTemplateNameError,
+  UnexpectedSkillTemplateError,
+} from '../../skill-templates.errors';
+import { InvalidSkillTemplateNameError } from '../../../domain/skill-template.entity';
+import { ApplicationError } from 'src/common/errors/base.error';
+
+@Injectable()
+export class CreateSkillTemplateUseCase {
+  private readonly logger = new Logger(CreateSkillTemplateUseCase.name);
+
+  constructor(
+    private readonly skillTemplateRepository: SkillTemplateRepository,
+  ) {}
+
+  async execute(command: CreateSkillTemplateCommand): Promise<SkillTemplate> {
+    this.logger.log('Creating skill template', { name: command.name });
+    try {
+      const existing = await this.skillTemplateRepository.findByName(
+        command.name,
+      );
+      if (existing) {
+        throw new DuplicateSkillTemplateNameError(command.name);
+      }
+
+      const skillTemplate = new SkillTemplate({
+        name: command.name,
+        shortDescription: command.shortDescription,
+        instructions: command.instructions,
+        distributionMode: command.distributionMode,
+        isActive: command.isActive,
+      });
+
+      return await this.skillTemplateRepository.create(skillTemplate);
+    } catch (error) {
+      if (
+        error instanceof ApplicationError ||
+        error instanceof InvalidSkillTemplateNameError
+      )
+        throw error;
+      this.logger.error('Error creating skill template', {
+        error: error as Error,
+      });
+      throw new UnexpectedSkillTemplateError(error);
+    }
+  }
+}

--- a/ayunis-core-backend/src/domain/skill-templates/application/use-cases/delete-skill-template/delete-skill-template.command.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/application/use-cases/delete-skill-template/delete-skill-template.command.ts
@@ -1,0 +1,9 @@
+import type { UUID } from 'crypto';
+
+export class DeleteSkillTemplateCommand {
+  public readonly skillTemplateId: UUID;
+
+  constructor(params: { skillTemplateId: UUID }) {
+    this.skillTemplateId = params.skillTemplateId;
+  }
+}

--- a/ayunis-core-backend/src/domain/skill-templates/application/use-cases/delete-skill-template/delete-skill-template.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/application/use-cases/delete-skill-template/delete-skill-template.use-case.spec.ts
@@ -1,0 +1,75 @@
+import type { TestingModule } from '@nestjs/testing';
+import { Test } from '@nestjs/testing';
+import { Logger } from '@nestjs/common';
+import type { UUID } from 'crypto';
+import { DeleteSkillTemplateUseCase } from './delete-skill-template.use-case';
+import { DeleteSkillTemplateCommand } from './delete-skill-template.command';
+import { SkillTemplateRepository } from '../../ports/skill-template.repository';
+import { SkillTemplate } from '../../../domain/skill-template.entity';
+import { DistributionMode } from '../../../domain/distribution-mode.enum';
+import { SkillTemplateNotFoundError } from '../../skill-templates.errors';
+
+describe('DeleteSkillTemplateUseCase', () => {
+  let useCase: DeleteSkillTemplateUseCase;
+  let repository: jest.Mocked<SkillTemplateRepository>;
+
+  const mockId = '123e4567-e89b-12d3-a456-426614174000' as UUID;
+
+  beforeAll(async () => {
+    const mockRepository = {
+      findOne: jest.fn(),
+      delete: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        DeleteSkillTemplateUseCase,
+        { provide: SkillTemplateRepository, useValue: mockRepository },
+      ],
+    }).compile();
+
+    useCase = module.get<DeleteSkillTemplateUseCase>(
+      DeleteSkillTemplateUseCase,
+    );
+    repository = module.get(SkillTemplateRepository);
+
+    jest.spyOn(Logger.prototype, 'log').mockImplementation();
+    jest.spyOn(Logger.prototype, 'error').mockImplementation();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should delete a skill template successfully', async () => {
+    const existing = new SkillTemplate({
+      id: mockId,
+      name: 'Legal Guidelines',
+      shortDescription: 'Description',
+      instructions: 'Instructions.',
+      distributionMode: DistributionMode.ALWAYS_ON,
+    });
+
+    repository.findOne.mockResolvedValue(existing);
+    repository.delete.mockResolvedValue(undefined);
+
+    await useCase.execute(
+      new DeleteSkillTemplateCommand({ skillTemplateId: mockId }),
+    );
+
+    expect(repository.findOne).toHaveBeenCalledWith(mockId);
+    expect(repository.delete).toHaveBeenCalledWith(mockId);
+  });
+
+  it('should throw not found when template does not exist', async () => {
+    repository.findOne.mockResolvedValue(null);
+
+    await expect(
+      useCase.execute(
+        new DeleteSkillTemplateCommand({ skillTemplateId: mockId }),
+      ),
+    ).rejects.toThrow(SkillTemplateNotFoundError);
+
+    expect(repository.delete).not.toHaveBeenCalled();
+  });
+});

--- a/ayunis-core-backend/src/domain/skill-templates/application/use-cases/delete-skill-template/delete-skill-template.use-case.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/application/use-cases/delete-skill-template/delete-skill-template.use-case.ts
@@ -1,0 +1,39 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { SkillTemplateRepository } from '../../ports/skill-template.repository';
+import { DeleteSkillTemplateCommand } from './delete-skill-template.command';
+import {
+  SkillTemplateNotFoundError,
+  UnexpectedSkillTemplateError,
+} from '../../skill-templates.errors';
+import { ApplicationError } from 'src/common/errors/base.error';
+
+@Injectable()
+export class DeleteSkillTemplateUseCase {
+  private readonly logger = new Logger(DeleteSkillTemplateUseCase.name);
+
+  constructor(
+    private readonly skillTemplateRepository: SkillTemplateRepository,
+  ) {}
+
+  async execute(command: DeleteSkillTemplateCommand): Promise<void> {
+    this.logger.log('Deleting skill template', {
+      skillTemplateId: command.skillTemplateId,
+    });
+    try {
+      const existing = await this.skillTemplateRepository.findOne(
+        command.skillTemplateId,
+      );
+      if (!existing) {
+        throw new SkillTemplateNotFoundError(command.skillTemplateId);
+      }
+
+      await this.skillTemplateRepository.delete(command.skillTemplateId);
+    } catch (error) {
+      if (error instanceof ApplicationError) throw error;
+      this.logger.error('Error deleting skill template', {
+        error: error as Error,
+      });
+      throw new UnexpectedSkillTemplateError(error);
+    }
+  }
+}

--- a/ayunis-core-backend/src/domain/skill-templates/application/use-cases/find-all-skill-templates/find-all-skill-templates.query.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/application/use-cases/find-all-skill-templates/find-all-skill-templates.query.ts
@@ -1,0 +1,5 @@
+/**
+ * Query for finding all skill templates.
+ * No parameters needed — this is a platform-level query.
+ */
+export class FindAllSkillTemplatesQuery {}

--- a/ayunis-core-backend/src/domain/skill-templates/application/use-cases/find-all-skill-templates/find-all-skill-templates.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/application/use-cases/find-all-skill-templates/find-all-skill-templates.use-case.spec.ts
@@ -1,0 +1,73 @@
+import type { TestingModule } from '@nestjs/testing';
+import { Test } from '@nestjs/testing';
+import { Logger } from '@nestjs/common';
+import { FindAllSkillTemplatesUseCase } from './find-all-skill-templates.use-case';
+import { FindAllSkillTemplatesQuery } from './find-all-skill-templates.query';
+import { SkillTemplateRepository } from '../../ports/skill-template.repository';
+import { SkillTemplate } from '../../../domain/skill-template.entity';
+import { DistributionMode } from '../../../domain/distribution-mode.enum';
+
+describe('FindAllSkillTemplatesUseCase', () => {
+  let useCase: FindAllSkillTemplatesUseCase;
+  let repository: jest.Mocked<SkillTemplateRepository>;
+
+  beforeAll(async () => {
+    const mockRepository = {
+      findAll: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        FindAllSkillTemplatesUseCase,
+        { provide: SkillTemplateRepository, useValue: mockRepository },
+      ],
+    }).compile();
+
+    useCase = module.get<FindAllSkillTemplatesUseCase>(
+      FindAllSkillTemplatesUseCase,
+    );
+    repository = module.get(SkillTemplateRepository);
+
+    jest.spyOn(Logger.prototype, 'log').mockImplementation();
+    jest.spyOn(Logger.prototype, 'error').mockImplementation();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return all skill templates', async () => {
+    const templates = [
+      new SkillTemplate({
+        name: 'Template 1',
+        shortDescription: 'First',
+        instructions: 'Instructions 1.',
+        distributionMode: DistributionMode.ALWAYS_ON,
+      }),
+      new SkillTemplate({
+        name: 'Template 2',
+        shortDescription: 'Second',
+        instructions: 'Instructions 2.',
+        distributionMode: DistributionMode.PRE_CREATED_COPY,
+        isActive: true,
+      }),
+    ];
+
+    repository.findAll.mockResolvedValue(templates);
+
+    const result = await useCase.execute(new FindAllSkillTemplatesQuery());
+
+    expect(repository.findAll).toHaveBeenCalled();
+    expect(result).toHaveLength(2);
+    expect(result[0].name).toBe('Template 1');
+    expect(result[1].name).toBe('Template 2');
+  });
+
+  it('should return empty array when no templates exist', async () => {
+    repository.findAll.mockResolvedValue([]);
+
+    const result = await useCase.execute(new FindAllSkillTemplatesQuery());
+
+    expect(result).toHaveLength(0);
+  });
+});

--- a/ayunis-core-backend/src/domain/skill-templates/application/use-cases/find-all-skill-templates/find-all-skill-templates.use-case.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/application/use-cases/find-all-skill-templates/find-all-skill-templates.use-case.ts
@@ -1,0 +1,29 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { SkillTemplateRepository } from '../../ports/skill-template.repository';
+import { SkillTemplate } from '../../../domain/skill-template.entity';
+import { FindAllSkillTemplatesQuery } from './find-all-skill-templates.query';
+import { UnexpectedSkillTemplateError } from '../../skill-templates.errors';
+import { ApplicationError } from 'src/common/errors/base.error';
+
+@Injectable()
+export class FindAllSkillTemplatesUseCase {
+  private readonly logger = new Logger(FindAllSkillTemplatesUseCase.name);
+
+  constructor(
+    private readonly skillTemplateRepository: SkillTemplateRepository,
+  ) {}
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  async execute(_query: FindAllSkillTemplatesQuery): Promise<SkillTemplate[]> {
+    this.logger.log('Finding all skill templates');
+    try {
+      return await this.skillTemplateRepository.findAll();
+    } catch (error) {
+      if (error instanceof ApplicationError) throw error;
+      this.logger.error('Error finding all skill templates', {
+        error: error as Error,
+      });
+      throw new UnexpectedSkillTemplateError(error);
+    }
+  }
+}

--- a/ayunis-core-backend/src/domain/skill-templates/application/use-cases/find-one-skill-template/find-one-skill-template.query.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/application/use-cases/find-one-skill-template/find-one-skill-template.query.ts
@@ -1,0 +1,5 @@
+import type { UUID } from 'crypto';
+
+export class FindOneSkillTemplateQuery {
+  constructor(public readonly id: UUID) {}
+}

--- a/ayunis-core-backend/src/domain/skill-templates/application/use-cases/find-one-skill-template/find-one-skill-template.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/application/use-cases/find-one-skill-template/find-one-skill-template.use-case.spec.ts
@@ -1,0 +1,67 @@
+import type { TestingModule } from '@nestjs/testing';
+import { Test } from '@nestjs/testing';
+import { Logger } from '@nestjs/common';
+import type { UUID } from 'crypto';
+import { FindOneSkillTemplateUseCase } from './find-one-skill-template.use-case';
+import { FindOneSkillTemplateQuery } from './find-one-skill-template.query';
+import { SkillTemplateRepository } from '../../ports/skill-template.repository';
+import { SkillTemplate } from '../../../domain/skill-template.entity';
+import { DistributionMode } from '../../../domain/distribution-mode.enum';
+import { SkillTemplateNotFoundError } from '../../skill-templates.errors';
+
+describe('FindOneSkillTemplateUseCase', () => {
+  let useCase: FindOneSkillTemplateUseCase;
+  let repository: jest.Mocked<SkillTemplateRepository>;
+
+  const mockId = '123e4567-e89b-12d3-a456-426614174000' as UUID;
+
+  beforeAll(async () => {
+    const mockRepository = {
+      findOne: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        FindOneSkillTemplateUseCase,
+        { provide: SkillTemplateRepository, useValue: mockRepository },
+      ],
+    }).compile();
+
+    useCase = module.get<FindOneSkillTemplateUseCase>(
+      FindOneSkillTemplateUseCase,
+    );
+    repository = module.get(SkillTemplateRepository);
+
+    jest.spyOn(Logger.prototype, 'log').mockImplementation();
+    jest.spyOn(Logger.prototype, 'error').mockImplementation();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return a skill template by ID', async () => {
+    const template = new SkillTemplate({
+      id: mockId,
+      name: 'Legal Guidelines',
+      shortDescription: 'Description',
+      instructions: 'Instructions.',
+      distributionMode: DistributionMode.ALWAYS_ON,
+    });
+
+    repository.findOne.mockResolvedValue(template);
+
+    const result = await useCase.execute(new FindOneSkillTemplateQuery(mockId));
+
+    expect(repository.findOne).toHaveBeenCalledWith(mockId);
+    expect(result.name).toBe('Legal Guidelines');
+  });
+
+  it('should throw not found when template does not exist', async () => {
+    repository.findOne.mockResolvedValue(null);
+
+    await expect(
+      useCase.execute(new FindOneSkillTemplateQuery(mockId)),
+    ).rejects.toThrow(SkillTemplateNotFoundError);
+  });
+});

--- a/ayunis-core-backend/src/domain/skill-templates/application/use-cases/find-one-skill-template/find-one-skill-template.use-case.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/application/use-cases/find-one-skill-template/find-one-skill-template.use-case.ts
@@ -1,0 +1,37 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { SkillTemplateRepository } from '../../ports/skill-template.repository';
+import { FindOneSkillTemplateQuery } from './find-one-skill-template.query';
+import { SkillTemplate } from '../../../domain/skill-template.entity';
+import {
+  SkillTemplateNotFoundError,
+  UnexpectedSkillTemplateError,
+} from '../../skill-templates.errors';
+import { ApplicationError } from 'src/common/errors/base.error';
+
+@Injectable()
+export class FindOneSkillTemplateUseCase {
+  private readonly logger = new Logger(FindOneSkillTemplateUseCase.name);
+
+  constructor(
+    private readonly skillTemplateRepository: SkillTemplateRepository,
+  ) {}
+
+  async execute(query: FindOneSkillTemplateQuery): Promise<SkillTemplate> {
+    this.logger.log('Finding skill template', { id: query.id });
+    try {
+      const skillTemplate = await this.skillTemplateRepository.findOne(
+        query.id,
+      );
+      if (!skillTemplate) {
+        throw new SkillTemplateNotFoundError(query.id);
+      }
+      return skillTemplate;
+    } catch (error) {
+      if (error instanceof ApplicationError) throw error;
+      this.logger.error('Error finding skill template', {
+        error: error as Error,
+      });
+      throw new UnexpectedSkillTemplateError(error);
+    }
+  }
+}

--- a/ayunis-core-backend/src/domain/skill-templates/application/use-cases/update-skill-template/update-skill-template.command.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/application/use-cases/update-skill-template/update-skill-template.command.ts
@@ -1,0 +1,27 @@
+import type { UUID } from 'crypto';
+import type { DistributionMode } from '../../../domain/distribution-mode.enum';
+
+export class UpdateSkillTemplateCommand {
+  public readonly skillTemplateId: UUID;
+  public readonly name?: string;
+  public readonly shortDescription?: string;
+  public readonly instructions?: string;
+  public readonly distributionMode?: DistributionMode;
+  public readonly isActive?: boolean;
+
+  constructor(params: {
+    skillTemplateId: UUID;
+    name?: string;
+    shortDescription?: string;
+    instructions?: string;
+    distributionMode?: DistributionMode;
+    isActive?: boolean;
+  }) {
+    this.skillTemplateId = params.skillTemplateId;
+    this.name = params.name;
+    this.shortDescription = params.shortDescription;
+    this.instructions = params.instructions;
+    this.distributionMode = params.distributionMode;
+    this.isActive = params.isActive;
+  }
+}

--- a/ayunis-core-backend/src/domain/skill-templates/application/use-cases/update-skill-template/update-skill-template.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/application/use-cases/update-skill-template/update-skill-template.use-case.spec.ts
@@ -1,0 +1,194 @@
+import type { TestingModule } from '@nestjs/testing';
+import { Test } from '@nestjs/testing';
+import { Logger } from '@nestjs/common';
+import type { UUID } from 'crypto';
+import { UpdateSkillTemplateUseCase } from './update-skill-template.use-case';
+import { UpdateSkillTemplateCommand } from './update-skill-template.command';
+import { SkillTemplateRepository } from '../../ports/skill-template.repository';
+import { SkillTemplate } from '../../../domain/skill-template.entity';
+import { DistributionMode } from '../../../domain/distribution-mode.enum';
+import { InvalidSkillTemplateNameError } from '../../../domain/skill-template.entity';
+import {
+  DuplicateSkillTemplateNameError,
+  SkillTemplateNotFoundError,
+} from '../../skill-templates.errors';
+
+describe('UpdateSkillTemplateUseCase', () => {
+  let useCase: UpdateSkillTemplateUseCase;
+  let repository: jest.Mocked<SkillTemplateRepository>;
+
+  const mockId = '123e4567-e89b-12d3-a456-426614174000' as UUID;
+
+  beforeAll(async () => {
+    const mockRepository = {
+      findOne: jest.fn(),
+      findByName: jest.fn(),
+      update: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        UpdateSkillTemplateUseCase,
+        { provide: SkillTemplateRepository, useValue: mockRepository },
+      ],
+    }).compile();
+
+    useCase = module.get<UpdateSkillTemplateUseCase>(
+      UpdateSkillTemplateUseCase,
+    );
+    repository = module.get(SkillTemplateRepository);
+
+    jest.spyOn(Logger.prototype, 'log').mockImplementation();
+    jest.spyOn(Logger.prototype, 'error').mockImplementation();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should update a skill template with all fields provided', async () => {
+    const existing = new SkillTemplate({
+      id: mockId,
+      name: 'Legal Guidelines',
+      shortDescription: 'Original description',
+      instructions: 'Original instructions.',
+      distributionMode: DistributionMode.ALWAYS_ON,
+    });
+
+    const command = new UpdateSkillTemplateCommand({
+      skillTemplateId: mockId,
+      name: 'Legal Guidelines',
+      shortDescription: 'Updated description',
+      instructions: 'Updated instructions.',
+      distributionMode: DistributionMode.ALWAYS_ON,
+      isActive: true,
+    });
+
+    repository.findOne.mockResolvedValue(existing);
+    repository.update.mockImplementation(async (t) => t);
+
+    const result = await useCase.execute(command);
+
+    expect(repository.findOne).toHaveBeenCalledWith(mockId);
+    expect(repository.findByName).not.toHaveBeenCalled();
+    expect(result.shortDescription).toBe('Updated description');
+    expect(result.isActive).toBe(true);
+  });
+
+  it('should merge with existing values when only partial fields provided', async () => {
+    const existing = new SkillTemplate({
+      id: mockId,
+      name: 'Legal Guidelines',
+      shortDescription: 'Original description',
+      instructions: 'Original instructions.',
+      distributionMode: DistributionMode.ALWAYS_ON,
+      isActive: false,
+    });
+
+    const command = new UpdateSkillTemplateCommand({
+      skillTemplateId: mockId,
+      shortDescription: 'Updated description',
+    });
+
+    repository.findOne.mockResolvedValue(existing);
+    repository.update.mockImplementation(async (t) => t);
+
+    const result = await useCase.execute(command);
+
+    expect(result.name).toBe('Legal Guidelines');
+    expect(result.shortDescription).toBe('Updated description');
+    expect(result.instructions).toBe('Original instructions.');
+    expect(result.distributionMode).toBe(DistributionMode.ALWAYS_ON);
+    expect(result.isActive).toBe(false);
+  });
+
+  it('should check name uniqueness when name changes', async () => {
+    const existing = new SkillTemplate({
+      id: mockId,
+      name: 'Old Name',
+      shortDescription: 'Description',
+      instructions: 'Instructions.',
+      distributionMode: DistributionMode.ALWAYS_ON,
+    });
+
+    const command = new UpdateSkillTemplateCommand({
+      skillTemplateId: mockId,
+      name: 'New Name',
+    });
+
+    repository.findOne.mockResolvedValue(existing);
+    repository.findByName.mockResolvedValue(null);
+    repository.update.mockImplementation(async (t) => t);
+
+    const result = await useCase.execute(command);
+
+    expect(repository.findByName).toHaveBeenCalledWith('New Name');
+    expect(result.name).toBe('New Name');
+  });
+
+  it('should reject update when new name already exists', async () => {
+    const existing = new SkillTemplate({
+      id: mockId,
+      name: 'Old Name',
+      shortDescription: 'Description',
+      instructions: 'Instructions.',
+      distributionMode: DistributionMode.ALWAYS_ON,
+    });
+
+    const duplicate = new SkillTemplate({
+      name: 'Taken Name',
+      shortDescription: 'Other',
+      instructions: 'Other.',
+      distributionMode: DistributionMode.PRE_CREATED_COPY,
+    });
+
+    const command = new UpdateSkillTemplateCommand({
+      skillTemplateId: mockId,
+      name: 'Taken Name',
+    });
+
+    repository.findOne.mockResolvedValue(existing);
+    repository.findByName.mockResolvedValue(duplicate);
+
+    await expect(useCase.execute(command)).rejects.toThrow(
+      DuplicateSkillTemplateNameError,
+    );
+    expect(repository.update).not.toHaveBeenCalled();
+  });
+
+  it('should throw not found when template does not exist', async () => {
+    const command = new UpdateSkillTemplateCommand({
+      skillTemplateId: mockId,
+      name: 'Name',
+    });
+
+    repository.findOne.mockResolvedValue(null);
+
+    await expect(useCase.execute(command)).rejects.toThrow(
+      SkillTemplateNotFoundError,
+    );
+  });
+
+  it('should rethrow InvalidSkillTemplateNameError for invalid names', async () => {
+    const existing = new SkillTemplate({
+      id: mockId,
+      name: 'Legal Guidelines',
+      shortDescription: 'Description',
+      instructions: 'Instructions.',
+      distributionMode: DistributionMode.ALWAYS_ON,
+    });
+
+    const command = new UpdateSkillTemplateCommand({
+      skillTemplateId: mockId,
+      name: '  invalid  name  ',
+    });
+
+    repository.findOne.mockResolvedValue(existing);
+    repository.findByName.mockResolvedValue(null);
+
+    await expect(useCase.execute(command)).rejects.toThrow(
+      InvalidSkillTemplateNameError,
+    );
+    expect(repository.update).not.toHaveBeenCalled();
+  });
+});

--- a/ayunis-core-backend/src/domain/skill-templates/application/use-cases/update-skill-template/update-skill-template.use-case.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/application/use-cases/update-skill-template/update-skill-template.use-case.ts
@@ -1,0 +1,66 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { SkillTemplateRepository } from '../../ports/skill-template.repository';
+import { UpdateSkillTemplateCommand } from './update-skill-template.command';
+import { SkillTemplate } from '../../../domain/skill-template.entity';
+import {
+  DuplicateSkillTemplateNameError,
+  SkillTemplateNotFoundError,
+  UnexpectedSkillTemplateError,
+} from '../../skill-templates.errors';
+import { InvalidSkillTemplateNameError } from '../../../domain/skill-template.entity';
+import { ApplicationError } from 'src/common/errors/base.error';
+
+@Injectable()
+export class UpdateSkillTemplateUseCase {
+  private readonly logger = new Logger(UpdateSkillTemplateUseCase.name);
+
+  constructor(
+    private readonly skillTemplateRepository: SkillTemplateRepository,
+  ) {}
+
+  async execute(command: UpdateSkillTemplateCommand): Promise<SkillTemplate> {
+    this.logger.log('Updating skill template', {
+      skillTemplateId: command.skillTemplateId,
+    });
+    try {
+      const existing = await this.skillTemplateRepository.findOne(
+        command.skillTemplateId,
+      );
+      if (!existing) {
+        throw new SkillTemplateNotFoundError(command.skillTemplateId);
+      }
+
+      const name = command.name ?? existing.name;
+
+      if (name !== existing.name) {
+        const duplicate = await this.skillTemplateRepository.findByName(name);
+        if (duplicate) {
+          throw new DuplicateSkillTemplateNameError(name);
+        }
+      }
+
+      const updated = new SkillTemplate({
+        id: existing.id,
+        name,
+        shortDescription: command.shortDescription ?? existing.shortDescription,
+        instructions: command.instructions ?? existing.instructions,
+        distributionMode: command.distributionMode ?? existing.distributionMode,
+        isActive: command.isActive ?? existing.isActive,
+        createdAt: existing.createdAt,
+        updatedAt: new Date(),
+      });
+
+      return await this.skillTemplateRepository.update(updated);
+    } catch (error) {
+      if (
+        error instanceof ApplicationError ||
+        error instanceof InvalidSkillTemplateNameError
+      )
+        throw error;
+      this.logger.error('Error updating skill template', {
+        error: error as Error,
+      });
+      throw new UnexpectedSkillTemplateError(error);
+    }
+  }
+}

--- a/ayunis-core-backend/src/domain/skill-templates/presenters/http/dto/create-skill-template.dto.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/presenters/http/dto/create-skill-template.dto.ts
@@ -1,0 +1,70 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  IsString,
+  IsNotEmpty,
+  IsEnum,
+  IsBoolean,
+  IsOptional,
+  Length,
+  Matches,
+  MaxLength,
+} from 'class-validator';
+import { DistributionMode } from '../../../domain/distribution-mode.enum';
+
+export class CreateSkillTemplateDto {
+  @ApiProperty({
+    description:
+      'The name of the skill template. Only letters, numbers, emojis, hyphens, and spaces allowed. Must start and end with a letter, number, or emoji.',
+    example: 'Legal Guidelines',
+    minLength: 1,
+    maxLength: 255,
+  })
+  @IsString()
+  @IsNotEmpty()
+  @Length(1, 255)
+  @Matches(
+    /^[\p{L}\p{N}\p{Emoji_Presentation}]([\p{L}\p{N}\p{Emoji_Presentation} -]*[\p{L}\p{N}\p{Emoji_Presentation}])?$/u,
+    {
+      message:
+        'Name must contain only letters, numbers, emojis, hyphens, and spaces, and must start and end with a letter, number, or emoji',
+    },
+  )
+  @Matches(/^(?!.* {2})/, {
+    message: 'Name must not contain consecutive spaces',
+  })
+  name: string;
+
+  @ApiProperty({
+    description: 'A short description of the skill template',
+    example: 'Legal compliance instructions for all responses',
+  })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(500)
+  shortDescription: string;
+
+  @ApiProperty({
+    description: 'The instructions for the skill template',
+    example: 'Always follow legal guidelines when responding to user queries.',
+  })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(10000)
+  instructions: string;
+
+  @ApiProperty({
+    description: 'The distribution mode of the skill template',
+    enum: DistributionMode,
+    example: DistributionMode.ALWAYS_ON,
+  })
+  @IsEnum(DistributionMode)
+  distributionMode: DistributionMode;
+
+  @ApiPropertyOptional({
+    description: 'Whether the skill template is active (defaults to false)',
+    example: false,
+  })
+  @IsBoolean()
+  @IsOptional()
+  isActive?: boolean;
+}

--- a/ayunis-core-backend/src/domain/skill-templates/presenters/http/dto/skill-template-response.dto.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/presenters/http/dto/skill-template-response.dto.ts
@@ -1,0 +1,63 @@
+import { ApiProperty } from '@nestjs/swagger';
+import type { UUID } from 'crypto';
+import { DistributionMode } from '../../../domain/distribution-mode.enum';
+
+export class SkillTemplateResponseDto {
+  @ApiProperty({
+    type: 'string',
+    format: 'uuid',
+    description: 'The unique identifier of the skill template',
+    example: '123e4567-e89b-12d3-a456-426614174000',
+  })
+  id: UUID;
+
+  @ApiProperty({
+    type: 'string',
+    description: 'The name of the skill template',
+    example: 'Legal Guidelines',
+  })
+  name: string;
+
+  @ApiProperty({
+    type: 'string',
+    description: 'A short description of the skill template',
+    example: 'Legal compliance instructions for all responses',
+  })
+  shortDescription: string;
+
+  @ApiProperty({
+    type: 'string',
+    description: 'The instructions for the skill template',
+    example: 'Always follow legal guidelines when responding to user queries.',
+  })
+  instructions: string;
+
+  @ApiProperty({
+    type: 'string',
+    enum: Object.values(DistributionMode),
+    description: 'The distribution mode of the skill template',
+    example: DistributionMode.ALWAYS_ON,
+  })
+  distributionMode: DistributionMode;
+
+  @ApiProperty({
+    type: 'boolean',
+    description: 'Whether the skill template is active',
+    example: false,
+  })
+  isActive: boolean;
+
+  @ApiProperty({
+    type: 'string',
+    format: 'date-time',
+    description: 'The date the skill template was created',
+  })
+  createdAt: Date;
+
+  @ApiProperty({
+    type: 'string',
+    format: 'date-time',
+    description: 'The date the skill template was last updated',
+  })
+  updatedAt: Date;
+}

--- a/ayunis-core-backend/src/domain/skill-templates/presenters/http/dto/update-skill-template.dto.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/presenters/http/dto/update-skill-template.dto.ts
@@ -1,0 +1,74 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  IsString,
+  IsNotEmpty,
+  IsEnum,
+  IsBoolean,
+  IsOptional,
+  Length,
+  Matches,
+  MaxLength,
+} from 'class-validator';
+import { DistributionMode } from '../../../domain/distribution-mode.enum';
+
+export class UpdateSkillTemplateDto {
+  @ApiPropertyOptional({
+    description:
+      'The name of the skill template. Only letters, numbers, emojis, hyphens, and spaces allowed. Must start and end with a letter, number, or emoji.',
+    example: 'Legal Guidelines',
+    minLength: 1,
+    maxLength: 255,
+  })
+  @IsString()
+  @IsNotEmpty()
+  @Length(1, 255)
+  @Matches(
+    /^[\p{L}\p{N}\p{Emoji_Presentation}]([\p{L}\p{N}\p{Emoji_Presentation} -]*[\p{L}\p{N}\p{Emoji_Presentation}])?$/u,
+    {
+      message:
+        'Name must contain only letters, numbers, emojis, hyphens, and spaces, and must start and end with a letter, number, or emoji',
+    },
+  )
+  @Matches(/^(?!.* {2})/, {
+    message: 'Name must not contain consecutive spaces',
+  })
+  @IsOptional()
+  name?: string;
+
+  @ApiPropertyOptional({
+    description: 'A short description of the skill template',
+    example: 'Legal compliance instructions for all responses',
+  })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(500)
+  @IsOptional()
+  shortDescription?: string;
+
+  @ApiPropertyOptional({
+    description: 'The instructions for the skill template',
+    example: 'Always follow legal guidelines when responding to user queries.',
+  })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(10000)
+  @IsOptional()
+  instructions?: string;
+
+  @ApiPropertyOptional({
+    description: 'The distribution mode of the skill template',
+    enum: DistributionMode,
+    example: DistributionMode.ALWAYS_ON,
+  })
+  @IsEnum(DistributionMode)
+  @IsOptional()
+  distributionMode?: DistributionMode;
+
+  @ApiPropertyOptional({
+    description: 'Whether the skill template is active',
+    example: true,
+  })
+  @IsBoolean()
+  @IsOptional()
+  isActive?: boolean;
+}

--- a/ayunis-core-backend/src/domain/skill-templates/presenters/http/mappers/skill-template-response.mapper.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/presenters/http/mappers/skill-template-response.mapper.ts
@@ -1,0 +1,23 @@
+import { Injectable } from '@nestjs/common';
+import type { SkillTemplate } from '../../../domain/skill-template.entity';
+import { SkillTemplateResponseDto } from '../dto/skill-template-response.dto';
+
+@Injectable()
+export class SkillTemplateResponseMapper {
+  toDto(entity: SkillTemplate): SkillTemplateResponseDto {
+    const dto = new SkillTemplateResponseDto();
+    dto.id = entity.id;
+    dto.name = entity.name;
+    dto.shortDescription = entity.shortDescription;
+    dto.instructions = entity.instructions;
+    dto.distributionMode = entity.distributionMode;
+    dto.isActive = entity.isActive;
+    dto.createdAt = entity.createdAt;
+    dto.updatedAt = entity.updatedAt;
+    return dto;
+  }
+
+  toDtoArray(entities: SkillTemplate[]): SkillTemplateResponseDto[] {
+    return entities.map((entity) => this.toDto(entity));
+  }
+}

--- a/ayunis-core-backend/src/domain/skill-templates/presenters/http/super-admin-skill-templates.controller.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/presenters/http/super-admin-skill-templates.controller.ts
@@ -1,0 +1,270 @@
+import {
+  BadRequestException,
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Logger,
+  Param,
+  ParseUUIDPipe,
+  Patch,
+  Post,
+} from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiParam,
+  ApiBody,
+  ApiCreatedResponse,
+  ApiOkResponse,
+  ApiResponse,
+  ApiUnauthorizedResponse,
+  ApiInternalServerErrorResponse,
+} from '@nestjs/swagger';
+import type { UUID } from 'crypto';
+import { SystemRoles } from 'src/iam/authorization/application/decorators/system-roles.decorator';
+import { SystemRole } from 'src/iam/users/domain/value-objects/system-role.enum';
+import { CreateSkillTemplateUseCase } from '../../application/use-cases/create-skill-template/create-skill-template.use-case';
+import { CreateSkillTemplateCommand } from '../../application/use-cases/create-skill-template/create-skill-template.command';
+import { UpdateSkillTemplateUseCase } from '../../application/use-cases/update-skill-template/update-skill-template.use-case';
+import { UpdateSkillTemplateCommand } from '../../application/use-cases/update-skill-template/update-skill-template.command';
+import { DeleteSkillTemplateUseCase } from '../../application/use-cases/delete-skill-template/delete-skill-template.use-case';
+import { DeleteSkillTemplateCommand } from '../../application/use-cases/delete-skill-template/delete-skill-template.command';
+import { FindAllSkillTemplatesUseCase } from '../../application/use-cases/find-all-skill-templates/find-all-skill-templates.use-case';
+import { FindOneSkillTemplateUseCase } from '../../application/use-cases/find-one-skill-template/find-one-skill-template.use-case';
+import { FindAllSkillTemplatesQuery } from '../../application/use-cases/find-all-skill-templates/find-all-skill-templates.query';
+import { FindOneSkillTemplateQuery } from '../../application/use-cases/find-one-skill-template/find-one-skill-template.query';
+import { InvalidSkillTemplateNameError } from '../../domain/skill-template.entity';
+import { CreateSkillTemplateDto } from './dto/create-skill-template.dto';
+import { UpdateSkillTemplateDto } from './dto/update-skill-template.dto';
+import { SkillTemplateResponseDto } from './dto/skill-template-response.dto';
+import { SkillTemplateResponseMapper } from './mappers/skill-template-response.mapper';
+
+@ApiTags('Super Admin Skill Templates')
+@Controller('super-admin/skill-templates')
+@SystemRoles(SystemRole.SUPER_ADMIN)
+export class SuperAdminSkillTemplatesController {
+  private readonly logger = new Logger(SuperAdminSkillTemplatesController.name);
+
+  constructor(
+    private readonly createSkillTemplateUseCase: CreateSkillTemplateUseCase,
+    private readonly updateSkillTemplateUseCase: UpdateSkillTemplateUseCase,
+    private readonly deleteSkillTemplateUseCase: DeleteSkillTemplateUseCase,
+    private readonly findAllSkillTemplatesUseCase: FindAllSkillTemplatesUseCase,
+    private readonly findOneSkillTemplateUseCase: FindOneSkillTemplateUseCase,
+    private readonly responseMapper: SkillTemplateResponseMapper,
+  ) {}
+
+  @Post()
+  @HttpCode(HttpStatus.CREATED)
+  @ApiOperation({
+    summary: 'Create a new skill template',
+    description:
+      'Create a new skill template. Only accessible to super admins.',
+  })
+  @ApiBody({ type: CreateSkillTemplateDto })
+  @ApiCreatedResponse({
+    description: 'Successfully created skill template',
+    type: SkillTemplateResponseDto,
+  })
+  @ApiResponse({
+    status: HttpStatus.CONFLICT,
+    description: 'Skill template with this name already exists',
+  })
+  @ApiUnauthorizedResponse({
+    description: 'User not authenticated or not authorized as super admin',
+  })
+  @ApiInternalServerErrorResponse({
+    description: 'Internal server error',
+  })
+  async create(
+    @Body() dto: CreateSkillTemplateDto,
+  ): Promise<SkillTemplateResponseDto> {
+    this.logger.log(`Creating skill template: ${dto.name}`);
+
+    try {
+      const command = new CreateSkillTemplateCommand({
+        name: dto.name,
+        shortDescription: dto.shortDescription,
+        instructions: dto.instructions,
+        distributionMode: dto.distributionMode,
+        isActive: dto.isActive,
+      });
+
+      const template = await this.createSkillTemplateUseCase.execute(command);
+
+      this.logger.log(`Successfully created skill template ${template.id}`);
+      return this.responseMapper.toDto(template);
+    } catch (error) {
+      if (error instanceof InvalidSkillTemplateNameError) {
+        throw new BadRequestException(error.message);
+      }
+      throw error;
+    }
+  }
+
+  @Get()
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Get all skill templates',
+    description:
+      'Retrieve all skill templates. Only accessible to super admins.',
+  })
+  @ApiOkResponse({
+    description: 'Successfully retrieved skill templates',
+    type: [SkillTemplateResponseDto],
+  })
+  @ApiUnauthorizedResponse({
+    description: 'User not authenticated or not authorized as super admin',
+  })
+  @ApiInternalServerErrorResponse({
+    description: 'Internal server error',
+  })
+  async findAll(): Promise<SkillTemplateResponseDto[]> {
+    this.logger.log('Finding all skill templates');
+
+    const templates = await this.findAllSkillTemplatesUseCase.execute(
+      new FindAllSkillTemplatesQuery(),
+    );
+
+    this.logger.log(
+      `Successfully retrieved ${templates.length} skill templates`,
+    );
+    return this.responseMapper.toDtoArray(templates);
+  }
+
+  @Get(':id')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Get a skill template by ID',
+    description:
+      'Retrieve a specific skill template by its ID. Only accessible to super admins.',
+  })
+  @ApiParam({
+    name: 'id',
+    description: 'Skill template ID',
+    format: 'uuid',
+  })
+  @ApiOkResponse({
+    description: 'Successfully retrieved skill template',
+    type: SkillTemplateResponseDto,
+  })
+  @ApiResponse({
+    status: HttpStatus.NOT_FOUND,
+    description: 'Skill template not found',
+  })
+  @ApiUnauthorizedResponse({
+    description: 'User not authenticated or not authorized as super admin',
+  })
+  @ApiInternalServerErrorResponse({
+    description: 'Internal server error',
+  })
+  async findOne(
+    @Param('id', ParseUUIDPipe) id: UUID,
+  ): Promise<SkillTemplateResponseDto> {
+    this.logger.log(`Finding skill template ${id}`);
+
+    const template = await this.findOneSkillTemplateUseCase.execute(
+      new FindOneSkillTemplateQuery(id),
+    );
+
+    this.logger.log(`Successfully retrieved skill template ${id}`);
+    return this.responseMapper.toDto(template);
+  }
+
+  @Patch(':id')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Update a skill template',
+    description:
+      'Partially update an existing skill template. Only accessible to super admins.',
+  })
+  @ApiParam({
+    name: 'id',
+    description: 'Skill template ID',
+    format: 'uuid',
+  })
+  @ApiBody({ type: UpdateSkillTemplateDto })
+  @ApiOkResponse({
+    description: 'Successfully updated skill template',
+    type: SkillTemplateResponseDto,
+  })
+  @ApiResponse({
+    status: HttpStatus.NOT_FOUND,
+    description: 'Skill template not found',
+  })
+  @ApiResponse({
+    status: HttpStatus.CONFLICT,
+    description: 'Skill template with this name already exists',
+  })
+  @ApiUnauthorizedResponse({
+    description: 'User not authenticated or not authorized as super admin',
+  })
+  @ApiInternalServerErrorResponse({
+    description: 'Internal server error',
+  })
+  async update(
+    @Param('id', ParseUUIDPipe) id: UUID,
+    @Body() dto: UpdateSkillTemplateDto,
+  ): Promise<SkillTemplateResponseDto> {
+    this.logger.log(`Updating skill template ${id}`);
+
+    try {
+      const command = new UpdateSkillTemplateCommand({
+        skillTemplateId: id,
+        name: dto.name,
+        shortDescription: dto.shortDescription,
+        instructions: dto.instructions,
+        distributionMode: dto.distributionMode,
+        isActive: dto.isActive,
+      });
+
+      const template = await this.updateSkillTemplateUseCase.execute(command);
+
+      this.logger.log(`Successfully updated skill template ${id}`);
+      return this.responseMapper.toDto(template);
+    } catch (error) {
+      if (error instanceof InvalidSkillTemplateNameError) {
+        throw new BadRequestException(error.message);
+      }
+      throw error;
+    }
+  }
+
+  @Delete(':id')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({
+    summary: 'Delete a skill template',
+    description: 'Delete a skill template. Only accessible to super admins.',
+  })
+  @ApiParam({
+    name: 'id',
+    description: 'Skill template ID',
+    format: 'uuid',
+  })
+  @ApiResponse({
+    status: HttpStatus.NO_CONTENT,
+    description: 'Successfully deleted skill template',
+  })
+  @ApiResponse({
+    status: HttpStatus.NOT_FOUND,
+    description: 'Skill template not found',
+  })
+  @ApiUnauthorizedResponse({
+    description: 'User not authenticated or not authorized as super admin',
+  })
+  @ApiInternalServerErrorResponse({
+    description: 'Internal server error',
+  })
+  async delete(@Param('id', ParseUUIDPipe) id: UUID): Promise<void> {
+    this.logger.log(`Deleting skill template ${id}`);
+
+    await this.deleteSkillTemplateUseCase.execute(
+      new DeleteSkillTemplateCommand({ skillTemplateId: id }),
+    );
+
+    this.logger.log(`Successfully deleted skill template ${id}`);
+  }
+}

--- a/ayunis-core-backend/src/domain/skill-templates/skill-templates.module.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/skill-templates.module.ts
@@ -2,15 +2,29 @@ import { Module } from '@nestjs/common';
 import { LocalSkillTemplateRepositoryModule } from './infrastructure/persistence/local/local-skill-template-repository.module';
 import { LocalSkillTemplateRepository } from './infrastructure/persistence/local/local-skill-template.repository';
 import { SkillTemplateRepository } from './application/ports/skill-template.repository';
+import { CreateSkillTemplateUseCase } from './application/use-cases/create-skill-template/create-skill-template.use-case';
+import { UpdateSkillTemplateUseCase } from './application/use-cases/update-skill-template/update-skill-template.use-case';
+import { DeleteSkillTemplateUseCase } from './application/use-cases/delete-skill-template/delete-skill-template.use-case';
+import { FindAllSkillTemplatesUseCase } from './application/use-cases/find-all-skill-templates/find-all-skill-templates.use-case';
+import { FindOneSkillTemplateUseCase } from './application/use-cases/find-one-skill-template/find-one-skill-template.use-case';
+import { SuperAdminSkillTemplatesController } from './presenters/http/super-admin-skill-templates.controller';
+import { SkillTemplateResponseMapper } from './presenters/http/mappers/skill-template-response.mapper';
 
 @Module({
   imports: [LocalSkillTemplateRepositoryModule],
+  controllers: [SuperAdminSkillTemplatesController],
   providers: [
     {
       provide: SkillTemplateRepository,
       useExisting: LocalSkillTemplateRepository,
     },
+    CreateSkillTemplateUseCase,
+    UpdateSkillTemplateUseCase,
+    DeleteSkillTemplateUseCase,
+    FindAllSkillTemplatesUseCase,
+    FindOneSkillTemplateUseCase,
+    SkillTemplateResponseMapper,
   ],
-  exports: [],
+  exports: [FindAllSkillTemplatesUseCase],
 })
 export class SkillTemplatesModule {}

--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
@@ -3122,6 +3122,95 @@ export interface TranscriptionResponseDto {
   text: string;
 }
 
+/**
+ * The distribution mode of the skill template
+ */
+export type CreateSkillTemplateDtoDistributionMode = typeof CreateSkillTemplateDtoDistributionMode[keyof typeof CreateSkillTemplateDtoDistributionMode];
+
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const CreateSkillTemplateDtoDistributionMode = {
+  always_on: 'always_on',
+  pre_created_copy: 'pre_created_copy',
+} as const;
+
+export interface CreateSkillTemplateDto {
+  /**
+   * The name of the skill template. Only letters, numbers, emojis, hyphens, and spaces allowed. Must start and end with a letter, number, or emoji.
+   * @minLength 1
+   * @maxLength 255
+   */
+  name: string;
+  /** A short description of the skill template */
+  shortDescription: string;
+  /** The instructions for the skill template */
+  instructions: string;
+  /** The distribution mode of the skill template */
+  distributionMode: CreateSkillTemplateDtoDistributionMode;
+  /** Whether the skill template is active (defaults to false) */
+  isActive?: boolean;
+}
+
+/**
+ * The distribution mode of the skill template
+ */
+export type SkillTemplateResponseDtoDistributionMode = typeof SkillTemplateResponseDtoDistributionMode[keyof typeof SkillTemplateResponseDtoDistributionMode];
+
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const SkillTemplateResponseDtoDistributionMode = {
+  always_on: 'always_on',
+  pre_created_copy: 'pre_created_copy',
+} as const;
+
+export interface SkillTemplateResponseDto {
+  /** The unique identifier of the skill template */
+  id: string;
+  /** The name of the skill template */
+  name: string;
+  /** A short description of the skill template */
+  shortDescription: string;
+  /** The instructions for the skill template */
+  instructions: string;
+  /** The distribution mode of the skill template */
+  distributionMode: SkillTemplateResponseDtoDistributionMode;
+  /** Whether the skill template is active */
+  isActive: boolean;
+  /** The date the skill template was created */
+  createdAt: string;
+  /** The date the skill template was last updated */
+  updatedAt: string;
+}
+
+/**
+ * The distribution mode of the skill template
+ */
+export type UpdateSkillTemplateDtoDistributionMode = typeof UpdateSkillTemplateDtoDistributionMode[keyof typeof UpdateSkillTemplateDtoDistributionMode];
+
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const UpdateSkillTemplateDtoDistributionMode = {
+  always_on: 'always_on',
+  pre_created_copy: 'pre_created_copy',
+} as const;
+
+export interface UpdateSkillTemplateDto {
+  /**
+   * The name of the skill template. Only letters, numbers, emojis, hyphens, and spaces allowed. Must start and end with a letter, number, or emoji.
+   * @minLength 1
+   * @maxLength 255
+   */
+  name?: string;
+  /** A short description of the skill template */
+  shortDescription?: string;
+  /** The instructions for the skill template */
+  instructions?: string;
+  /** The distribution mode of the skill template */
+  distributionMode?: UpdateSkillTemplateDtoDistributionMode;
+  /** Whether the skill template is active */
+  isActive?: boolean;
+}
+
 export interface LoginDto {
   /** Email address for authentication */
   email: string;

--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.ts
@@ -50,6 +50,7 @@ import type {
   CreatePromptDto,
   CreateSkillDto,
   CreateSkillShareDto,
+  CreateSkillTemplateDto,
   CreateSubscriptionRequestDto,
   CreateTeamDto,
   CreateThreadDto,
@@ -109,6 +110,7 @@ import type {
   SkillResponseDto,
   SkillSourceResponseDto,
   SkillSourcesControllerAddFileSourceBody,
+  SkillTemplateResponseDto,
   StorageControllerUploadFileBody,
   SubscriptionResponseDto,
   SubscriptionResponseDtoNullable,
@@ -150,6 +152,7 @@ import type {
   UpdatePromptDto,
   UpdateSeatsDto,
   UpdateSkillDto,
+  UpdateSkillTemplateDto,
   UpdateTeamDto,
   UpdateThreadTitleDto,
   UpdateTrialRequestDto,
@@ -13697,6 +13700,389 @@ export const useTranscriptionsControllerTranscribe = <TError = void,
       > => {
 
       const mutationOptions = getTranscriptionsControllerTranscribeMutationOptions(options);
+
+      return useMutation(mutationOptions, queryClient);
+    }
+    
+/**
+ * Create a new skill template. Only accessible to super admins.
+ * @summary Create a new skill template
+ */
+export const superAdminSkillTemplatesControllerCreate = (
+    createSkillTemplateDto: CreateSkillTemplateDto,
+ signal?: AbortSignal
+) => {
+      
+      
+      return customAxiosInstance<SkillTemplateResponseDto>(
+      {url: `/super-admin/skill-templates`, method: 'POST',
+      headers: {'Content-Type': 'application/json', },
+      data: createSkillTemplateDto, signal
+    },
+      );
+    }
+  
+
+
+export const getSuperAdminSkillTemplatesControllerCreateMutationOptions = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof superAdminSkillTemplatesControllerCreate>>, TError,{data: CreateSkillTemplateDto}, TContext>, }
+): UseMutationOptions<Awaited<ReturnType<typeof superAdminSkillTemplatesControllerCreate>>, TError,{data: CreateSkillTemplateDto}, TContext> => {
+
+const mutationKey = ['superAdminSkillTemplatesControllerCreate'];
+const {mutation: mutationOptions} = options ?
+      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
+      options
+      : {...options, mutation: {...options.mutation, mutationKey}}
+      : {mutation: { mutationKey, }};
+
+      
+
+
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof superAdminSkillTemplatesControllerCreate>>, {data: CreateSkillTemplateDto}> = (props) => {
+          const {data} = props ?? {};
+
+          return  superAdminSkillTemplatesControllerCreate(data,)
+        }
+
+        
+
+
+  return  { mutationFn, ...mutationOptions }}
+
+    export type SuperAdminSkillTemplatesControllerCreateMutationResult = NonNullable<Awaited<ReturnType<typeof superAdminSkillTemplatesControllerCreate>>>
+    export type SuperAdminSkillTemplatesControllerCreateMutationBody = CreateSkillTemplateDto
+    export type SuperAdminSkillTemplatesControllerCreateMutationError = void
+
+    /**
+ * @summary Create a new skill template
+ */
+export const useSuperAdminSkillTemplatesControllerCreate = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof superAdminSkillTemplatesControllerCreate>>, TError,{data: CreateSkillTemplateDto}, TContext>, }
+ , queryClient?: QueryClient): UseMutationResult<
+        Awaited<ReturnType<typeof superAdminSkillTemplatesControllerCreate>>,
+        TError,
+        {data: CreateSkillTemplateDto},
+        TContext
+      > => {
+
+      const mutationOptions = getSuperAdminSkillTemplatesControllerCreateMutationOptions(options);
+
+      return useMutation(mutationOptions, queryClient);
+    }
+    
+/**
+ * Retrieve all skill templates. Only accessible to super admins.
+ * @summary Get all skill templates
+ */
+export const superAdminSkillTemplatesControllerFindAll = (
+    
+ signal?: AbortSignal
+) => {
+      
+      
+      return customAxiosInstance<SkillTemplateResponseDto[]>(
+      {url: `/super-admin/skill-templates`, method: 'GET', signal
+    },
+      );
+    }
+  
+
+
+
+export const getSuperAdminSkillTemplatesControllerFindAllQueryKey = () => {
+    return [
+    `/super-admin/skill-templates`
+    ] as const;
+    }
+
+    
+export const getSuperAdminSkillTemplatesControllerFindAllQueryOptions = <TData = Awaited<ReturnType<typeof superAdminSkillTemplatesControllerFindAll>>, TError = void>( options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof superAdminSkillTemplatesControllerFindAll>>, TError, TData>>, }
+) => {
+
+const {query: queryOptions} = options ?? {};
+
+  const queryKey =  queryOptions?.queryKey ?? getSuperAdminSkillTemplatesControllerFindAllQueryKey();
+
+  
+
+    const queryFn: QueryFunction<Awaited<ReturnType<typeof superAdminSkillTemplatesControllerFindAll>>> = ({ signal }) => superAdminSkillTemplatesControllerFindAll(signal);
+
+      
+
+      
+
+   return  { queryKey, queryFn, ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof superAdminSkillTemplatesControllerFindAll>>, TError, TData> & { queryKey: DataTag<QueryKey, TData, TError> }
+}
+
+export type SuperAdminSkillTemplatesControllerFindAllQueryResult = NonNullable<Awaited<ReturnType<typeof superAdminSkillTemplatesControllerFindAll>>>
+export type SuperAdminSkillTemplatesControllerFindAllQueryError = void
+
+
+export function useSuperAdminSkillTemplatesControllerFindAll<TData = Awaited<ReturnType<typeof superAdminSkillTemplatesControllerFindAll>>, TError = void>(
+  options: { query:Partial<UseQueryOptions<Awaited<ReturnType<typeof superAdminSkillTemplatesControllerFindAll>>, TError, TData>> & Pick<
+        DefinedInitialDataOptions<
+          Awaited<ReturnType<typeof superAdminSkillTemplatesControllerFindAll>>,
+          TError,
+          Awaited<ReturnType<typeof superAdminSkillTemplatesControllerFindAll>>
+        > , 'initialData'
+      >, }
+ , queryClient?: QueryClient
+  ):  DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useSuperAdminSkillTemplatesControllerFindAll<TData = Awaited<ReturnType<typeof superAdminSkillTemplatesControllerFindAll>>, TError = void>(
+  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof superAdminSkillTemplatesControllerFindAll>>, TError, TData>> & Pick<
+        UndefinedInitialDataOptions<
+          Awaited<ReturnType<typeof superAdminSkillTemplatesControllerFindAll>>,
+          TError,
+          Awaited<ReturnType<typeof superAdminSkillTemplatesControllerFindAll>>
+        > , 'initialData'
+      >, }
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useSuperAdminSkillTemplatesControllerFindAll<TData = Awaited<ReturnType<typeof superAdminSkillTemplatesControllerFindAll>>, TError = void>(
+  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof superAdminSkillTemplatesControllerFindAll>>, TError, TData>>, }
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+/**
+ * @summary Get all skill templates
+ */
+
+export function useSuperAdminSkillTemplatesControllerFindAll<TData = Awaited<ReturnType<typeof superAdminSkillTemplatesControllerFindAll>>, TError = void>(
+  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof superAdminSkillTemplatesControllerFindAll>>, TError, TData>>, }
+ , queryClient?: QueryClient 
+ ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
+
+  const queryOptions = getSuperAdminSkillTemplatesControllerFindAllQueryOptions(options)
+
+  const query = useQuery(queryOptions, queryClient) as  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+
+  query.queryKey = queryOptions.queryKey ;
+
+  return query;
+}
+
+
+
+
+
+/**
+ * Retrieve a specific skill template by its ID. Only accessible to super admins.
+ * @summary Get a skill template by ID
+ */
+export const superAdminSkillTemplatesControllerFindOne = (
+    id: string,
+ signal?: AbortSignal
+) => {
+      
+      
+      return customAxiosInstance<SkillTemplateResponseDto>(
+      {url: `/super-admin/skill-templates/${id}`, method: 'GET', signal
+    },
+      );
+    }
+  
+
+
+
+export const getSuperAdminSkillTemplatesControllerFindOneQueryKey = (id?: string,) => {
+    return [
+    `/super-admin/skill-templates/${id}`
+    ] as const;
+    }
+
+    
+export const getSuperAdminSkillTemplatesControllerFindOneQueryOptions = <TData = Awaited<ReturnType<typeof superAdminSkillTemplatesControllerFindOne>>, TError = void>(id: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof superAdminSkillTemplatesControllerFindOne>>, TError, TData>>, }
+) => {
+
+const {query: queryOptions} = options ?? {};
+
+  const queryKey =  queryOptions?.queryKey ?? getSuperAdminSkillTemplatesControllerFindOneQueryKey(id);
+
+  
+
+    const queryFn: QueryFunction<Awaited<ReturnType<typeof superAdminSkillTemplatesControllerFindOne>>> = ({ signal }) => superAdminSkillTemplatesControllerFindOne(id, signal);
+
+      
+
+      
+
+   return  { queryKey, queryFn, enabled: !!(id), ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof superAdminSkillTemplatesControllerFindOne>>, TError, TData> & { queryKey: DataTag<QueryKey, TData, TError> }
+}
+
+export type SuperAdminSkillTemplatesControllerFindOneQueryResult = NonNullable<Awaited<ReturnType<typeof superAdminSkillTemplatesControllerFindOne>>>
+export type SuperAdminSkillTemplatesControllerFindOneQueryError = void
+
+
+export function useSuperAdminSkillTemplatesControllerFindOne<TData = Awaited<ReturnType<typeof superAdminSkillTemplatesControllerFindOne>>, TError = void>(
+ id: string, options: { query:Partial<UseQueryOptions<Awaited<ReturnType<typeof superAdminSkillTemplatesControllerFindOne>>, TError, TData>> & Pick<
+        DefinedInitialDataOptions<
+          Awaited<ReturnType<typeof superAdminSkillTemplatesControllerFindOne>>,
+          TError,
+          Awaited<ReturnType<typeof superAdminSkillTemplatesControllerFindOne>>
+        > , 'initialData'
+      >, }
+ , queryClient?: QueryClient
+  ):  DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useSuperAdminSkillTemplatesControllerFindOne<TData = Awaited<ReturnType<typeof superAdminSkillTemplatesControllerFindOne>>, TError = void>(
+ id: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof superAdminSkillTemplatesControllerFindOne>>, TError, TData>> & Pick<
+        UndefinedInitialDataOptions<
+          Awaited<ReturnType<typeof superAdminSkillTemplatesControllerFindOne>>,
+          TError,
+          Awaited<ReturnType<typeof superAdminSkillTemplatesControllerFindOne>>
+        > , 'initialData'
+      >, }
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useSuperAdminSkillTemplatesControllerFindOne<TData = Awaited<ReturnType<typeof superAdminSkillTemplatesControllerFindOne>>, TError = void>(
+ id: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof superAdminSkillTemplatesControllerFindOne>>, TError, TData>>, }
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+/**
+ * @summary Get a skill template by ID
+ */
+
+export function useSuperAdminSkillTemplatesControllerFindOne<TData = Awaited<ReturnType<typeof superAdminSkillTemplatesControllerFindOne>>, TError = void>(
+ id: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof superAdminSkillTemplatesControllerFindOne>>, TError, TData>>, }
+ , queryClient?: QueryClient 
+ ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
+
+  const queryOptions = getSuperAdminSkillTemplatesControllerFindOneQueryOptions(id,options)
+
+  const query = useQuery(queryOptions, queryClient) as  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+
+  query.queryKey = queryOptions.queryKey ;
+
+  return query;
+}
+
+
+
+
+
+/**
+ * Partially update an existing skill template. Only accessible to super admins.
+ * @summary Update a skill template
+ */
+export const superAdminSkillTemplatesControllerUpdate = (
+    id: string,
+    updateSkillTemplateDto: UpdateSkillTemplateDto,
+ ) => {
+      
+      
+      return customAxiosInstance<SkillTemplateResponseDto>(
+      {url: `/super-admin/skill-templates/${id}`, method: 'PATCH',
+      headers: {'Content-Type': 'application/json', },
+      data: updateSkillTemplateDto
+    },
+      );
+    }
+  
+
+
+export const getSuperAdminSkillTemplatesControllerUpdateMutationOptions = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof superAdminSkillTemplatesControllerUpdate>>, TError,{id: string;data: UpdateSkillTemplateDto}, TContext>, }
+): UseMutationOptions<Awaited<ReturnType<typeof superAdminSkillTemplatesControllerUpdate>>, TError,{id: string;data: UpdateSkillTemplateDto}, TContext> => {
+
+const mutationKey = ['superAdminSkillTemplatesControllerUpdate'];
+const {mutation: mutationOptions} = options ?
+      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
+      options
+      : {...options, mutation: {...options.mutation, mutationKey}}
+      : {mutation: { mutationKey, }};
+
+      
+
+
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof superAdminSkillTemplatesControllerUpdate>>, {id: string;data: UpdateSkillTemplateDto}> = (props) => {
+          const {id,data} = props ?? {};
+
+          return  superAdminSkillTemplatesControllerUpdate(id,data,)
+        }
+
+        
+
+
+  return  { mutationFn, ...mutationOptions }}
+
+    export type SuperAdminSkillTemplatesControllerUpdateMutationResult = NonNullable<Awaited<ReturnType<typeof superAdminSkillTemplatesControllerUpdate>>>
+    export type SuperAdminSkillTemplatesControllerUpdateMutationBody = UpdateSkillTemplateDto
+    export type SuperAdminSkillTemplatesControllerUpdateMutationError = void
+
+    /**
+ * @summary Update a skill template
+ */
+export const useSuperAdminSkillTemplatesControllerUpdate = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof superAdminSkillTemplatesControllerUpdate>>, TError,{id: string;data: UpdateSkillTemplateDto}, TContext>, }
+ , queryClient?: QueryClient): UseMutationResult<
+        Awaited<ReturnType<typeof superAdminSkillTemplatesControllerUpdate>>,
+        TError,
+        {id: string;data: UpdateSkillTemplateDto},
+        TContext
+      > => {
+
+      const mutationOptions = getSuperAdminSkillTemplatesControllerUpdateMutationOptions(options);
+
+      return useMutation(mutationOptions, queryClient);
+    }
+    
+/**
+ * Delete a skill template. Only accessible to super admins.
+ * @summary Delete a skill template
+ */
+export const superAdminSkillTemplatesControllerDelete = (
+    id: string,
+ ) => {
+      
+      
+      return customAxiosInstance<void>(
+      {url: `/super-admin/skill-templates/${id}`, method: 'DELETE'
+    },
+      );
+    }
+  
+
+
+export const getSuperAdminSkillTemplatesControllerDeleteMutationOptions = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof superAdminSkillTemplatesControllerDelete>>, TError,{id: string}, TContext>, }
+): UseMutationOptions<Awaited<ReturnType<typeof superAdminSkillTemplatesControllerDelete>>, TError,{id: string}, TContext> => {
+
+const mutationKey = ['superAdminSkillTemplatesControllerDelete'];
+const {mutation: mutationOptions} = options ?
+      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
+      options
+      : {...options, mutation: {...options.mutation, mutationKey}}
+      : {mutation: { mutationKey, }};
+
+      
+
+
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof superAdminSkillTemplatesControllerDelete>>, {id: string}> = (props) => {
+          const {id} = props ?? {};
+
+          return  superAdminSkillTemplatesControllerDelete(id,)
+        }
+
+        
+
+
+  return  { mutationFn, ...mutationOptions }}
+
+    export type SuperAdminSkillTemplatesControllerDeleteMutationResult = NonNullable<Awaited<ReturnType<typeof superAdminSkillTemplatesControllerDelete>>>
+    
+    export type SuperAdminSkillTemplatesControllerDeleteMutationError = void
+
+    /**
+ * @summary Delete a skill template
+ */
+export const useSuperAdminSkillTemplatesControllerDelete = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof superAdminSkillTemplatesControllerDelete>>, TError,{id: string}, TContext>, }
+ , queryClient?: QueryClient): UseMutationResult<
+        Awaited<ReturnType<typeof superAdminSkillTemplatesControllerDelete>>,
+        TError,
+        {id: string},
+        TContext
+      > => {
+
+      const mutationOptions = getSuperAdminSkillTemplatesControllerDeleteMutationOptions(options);
 
       return useMutation(mutationOptions, queryClient);
     }

--- a/ayunis-core-frontend/src/shared/api/openapi-schema.json
+++ b/ayunis-core-frontend/src/shared/api/openapi-schema.json
@@ -7320,6 +7320,209 @@
         ]
       }
     },
+    "/super-admin/skill-templates": {
+      "post": {
+        "description": "Create a new skill template. Only accessible to super admins.",
+        "operationId": "SuperAdminSkillTemplatesController_create",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateSkillTemplateDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Successfully created skill template",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SkillTemplateResponseDto"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "User not authenticated or not authorized as super admin"
+          },
+          "409": {
+            "description": "Skill template with this name already exists"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "summary": "Create a new skill template",
+        "tags": [
+          "Super Admin Skill Templates"
+        ]
+      },
+      "get": {
+        "description": "Retrieve all skill templates. Only accessible to super admins.",
+        "operationId": "SuperAdminSkillTemplatesController_findAll",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved skill templates",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/SkillTemplateResponseDto"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "User not authenticated or not authorized as super admin"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "summary": "Get all skill templates",
+        "tags": [
+          "Super Admin Skill Templates"
+        ]
+      }
+    },
+    "/super-admin/skill-templates/{id}": {
+      "get": {
+        "description": "Retrieve a specific skill template by its ID. Only accessible to super admins.",
+        "operationId": "SuperAdminSkillTemplatesController_findOne",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "description": "Skill template ID",
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved skill template",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SkillTemplateResponseDto"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "User not authenticated or not authorized as super admin"
+          },
+          "404": {
+            "description": "Skill template not found"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "summary": "Get a skill template by ID",
+        "tags": [
+          "Super Admin Skill Templates"
+        ]
+      },
+      "patch": {
+        "description": "Partially update an existing skill template. Only accessible to super admins.",
+        "operationId": "SuperAdminSkillTemplatesController_update",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "description": "Skill template ID",
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateSkillTemplateDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successfully updated skill template",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SkillTemplateResponseDto"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "User not authenticated or not authorized as super admin"
+          },
+          "404": {
+            "description": "Skill template not found"
+          },
+          "409": {
+            "description": "Skill template with this name already exists"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "summary": "Update a skill template",
+        "tags": [
+          "Super Admin Skill Templates"
+        ]
+      },
+      "delete": {
+        "description": "Delete a skill template. Only accessible to super admins.",
+        "operationId": "SuperAdminSkillTemplatesController_delete",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "description": "Skill template ID",
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successfully deleted skill template"
+          },
+          "401": {
+            "description": "User not authenticated or not authorized as super admin"
+          },
+          "404": {
+            "description": "Skill template not found"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "summary": "Delete a skill template",
+        "tags": [
+          "Super Admin Skill Templates"
+        ]
+      }
+    },
     "/auth/login": {
       "post": {
         "description": "Authenticate user with email and password. Sets authentication cookies on successful login.",
@@ -12994,6 +13197,144 @@
         "required": [
           "text"
         ]
+      },
+      "CreateSkillTemplateDto": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "The name of the skill template. Only letters, numbers, emojis, hyphens, and spaces allowed. Must start and end with a letter, number, or emoji.",
+            "example": "Legal Guidelines",
+            "minLength": 1,
+            "maxLength": 255
+          },
+          "shortDescription": {
+            "type": "string",
+            "description": "A short description of the skill template",
+            "example": "Legal compliance instructions for all responses"
+          },
+          "instructions": {
+            "type": "string",
+            "description": "The instructions for the skill template",
+            "example": "Always follow legal guidelines when responding to user queries."
+          },
+          "distributionMode": {
+            "type": "string",
+            "description": "The distribution mode of the skill template",
+            "enum": [
+              "always_on",
+              "pre_created_copy"
+            ],
+            "example": "always_on"
+          },
+          "isActive": {
+            "type": "boolean",
+            "description": "Whether the skill template is active (defaults to false)",
+            "example": false
+          }
+        },
+        "required": [
+          "name",
+          "shortDescription",
+          "instructions",
+          "distributionMode"
+        ]
+      },
+      "SkillTemplateResponseDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "The unique identifier of the skill template",
+            "example": "123e4567-e89b-12d3-a456-426614174000"
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of the skill template",
+            "example": "Legal Guidelines"
+          },
+          "shortDescription": {
+            "type": "string",
+            "description": "A short description of the skill template",
+            "example": "Legal compliance instructions for all responses"
+          },
+          "instructions": {
+            "type": "string",
+            "description": "The instructions for the skill template",
+            "example": "Always follow legal guidelines when responding to user queries."
+          },
+          "distributionMode": {
+            "type": "string",
+            "enum": [
+              "always_on",
+              "pre_created_copy"
+            ],
+            "description": "The distribution mode of the skill template",
+            "example": "always_on"
+          },
+          "isActive": {
+            "type": "boolean",
+            "description": "Whether the skill template is active",
+            "example": false
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "The date the skill template was created"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "The date the skill template was last updated"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "shortDescription",
+          "instructions",
+          "distributionMode",
+          "isActive",
+          "createdAt",
+          "updatedAt"
+        ]
+      },
+      "UpdateSkillTemplateDto": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "The name of the skill template. Only letters, numbers, emojis, hyphens, and spaces allowed. Must start and end with a letter, number, or emoji.",
+            "example": "Legal Guidelines",
+            "minLength": 1,
+            "maxLength": 255
+          },
+          "shortDescription": {
+            "type": "string",
+            "description": "A short description of the skill template",
+            "example": "Legal compliance instructions for all responses"
+          },
+          "instructions": {
+            "type": "string",
+            "description": "The instructions for the skill template",
+            "example": "Always follow legal guidelines when responding to user queries."
+          },
+          "distributionMode": {
+            "type": "string",
+            "description": "The distribution mode of the skill template",
+            "enum": [
+              "always_on",
+              "pre_created_copy"
+            ],
+            "example": "always_on"
+          },
+          "isActive": {
+            "type": "boolean",
+            "description": "Whether the skill template is active",
+            "example": true
+          }
+        }
       },
       "LoginDto": {
         "type": "object",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds new super-admin-only CRUD endpoints that write to the skill templates store, so issues could impact template data integrity and access control despite role protection.
> 
> **Overview**
> Introduces full CRUD support for skill templates by adding application-layer use cases (create/update/delete/find-all/find-one) with domain validation, duplicate-name checks, and consistent error wrapping.
> 
> Exposes this functionality via a new super-admin-only REST controller (`/super-admin/skill-templates`) with request/response DTOs, mapping, and Swagger documentation, and wires everything into `SkillTemplatesModule` (exporting `FindAllSkillTemplatesUseCase` for other modules).
> 
> Updates the generated frontend OpenAPI schema and API client/types to include the new skill-template endpoints and DTOs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1c1e678ac5f81ccb67211b06687cbfab61054e2c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->