### PR TITLE
wip(AYC-103): add always-on injection and pre-created copy distribution

### DIFF
--- a/ayunis-core-backend/src/domain/runs/application/services/system-prompt-builder.service.spec.ts
+++ b/ayunis-core-backend/src/domain/runs/application/services/system-prompt-builder.service.spec.ts
@@ -161,4 +161,62 @@ describe('SystemPromptBuilderService', () => {
       );
     });
   });
+
+  describe('always-on instructions section', () => {
+    it('should include always_on_instructions section when instructions are provided', () => {
+      const result = service.build({
+        tools: [],
+        currentTime: new Date('2026-01-15T10:00:00Z'),
+        alwaysOnInstructions: [
+          'Always be polite and professional.',
+          'Never share personal data across conversations.',
+        ],
+      });
+
+      expect(result).toContain('<always_on_instructions>');
+      expect(result).toContain('Always be polite and professional.');
+      expect(result).toContain(
+        'Never share personal data across conversations.',
+      );
+      expect(result).toContain('</always_on_instructions>');
+    });
+
+    it('should not include always_on_instructions section when no instructions are provided', () => {
+      const result = service.build({
+        tools: [],
+        currentTime: new Date('2026-01-15T10:00:00Z'),
+      });
+
+      expect(result).not.toContain('<always_on_instructions>');
+    });
+
+    it('should not include always_on_instructions section when instructions array is empty', () => {
+      const result = service.build({
+        tools: [],
+        currentTime: new Date('2026-01-15T10:00:00Z'),
+        alwaysOnInstructions: [],
+      });
+
+      expect(result).not.toContain('<always_on_instructions>');
+    });
+
+    it('should place always_on_instructions before agent_instructions', () => {
+      const agent = {
+        instructions: 'Agent-level instructions here',
+      } as any;
+
+      const result = service.build({
+        agent,
+        tools: [],
+        currentTime: new Date('2026-01-15T10:00:00Z'),
+        alwaysOnInstructions: ['Platform-level instructions here'],
+      });
+
+      const alwaysOnPos = result.indexOf('<always_on_instructions>');
+      const agentPos = result.indexOf('<agent_instructions>');
+      expect(alwaysOnPos).toBeGreaterThan(-1);
+      expect(agentPos).toBeGreaterThan(-1);
+      expect(alwaysOnPos).toBeLessThan(agentPos);
+    });
+  });
 });

--- a/ayunis-core-backend/src/domain/runs/application/services/system-prompt-builder.service.ts
+++ b/ayunis-core-backend/src/domain/runs/application/services/system-prompt-builder.service.ts
@@ -14,7 +14,6 @@ import {
 } from 'src/domain/sources/domain/sources/data-source.entity';
 import { Skill } from 'src/domain/skills/domain/skill.entity';
 import type { KnowledgeBaseSummary } from 'src/domain/knowledge-bases/domain/knowledge-base-summary';
-
 export interface SystemPromptBuildParams {
   agent?: Agent;
   tools: Tool[];
@@ -22,6 +21,7 @@ export interface SystemPromptBuildParams {
   sources?: Source[];
   skills?: Skill[];
   knowledgeBases?: KnowledgeBaseSummary[];
+  alwaysOnInstructions?: string[];
   userSystemPrompt?: string;
 }
 
@@ -32,28 +32,26 @@ export class SystemPromptBuilderService {
       agent,
       tools,
       currentTime,
-      sources,
-      skills,
-      knowledgeBases,
+      sources = [],
+      skills = [],
+      knowledgeBases = [],
+      alwaysOnInstructions = [],
       userSystemPrompt,
     } = params;
 
     const sections = [
       this.buildPreamble(currentTime),
       this.buildBehaviorInstructions(),
+      this.buildAlwaysOnInstructionsSection(alwaysOnInstructions),
       this.buildToolUsageSection(tools),
-      this.buildSkillsSection(skills ?? []),
-      this.buildFilesSection(sources ?? []),
-      this.buildKnowledgeBasesSection(knowledgeBases ?? []),
+      this.buildSkillsSection(skills),
+      this.buildFilesSection(sources),
+      this.buildKnowledgeBasesSection(knowledgeBases),
       this.buildDataHandlingSection(),
       this.buildResponseGuidelines(),
       this.buildPlatformSection(),
-      agent?.instructions
-        ? this.buildAgentInstructionsSection(agent.instructions)
-        : '',
-      userSystemPrompt
-        ? this.buildUserInstructionsSection(userSystemPrompt)
-        : '',
+      this.buildOptionalAgentInstructions(agent),
+      this.buildOptionalUserInstructions(userSystemPrompt),
       'You are now ready to assist the user.',
     ];
 
@@ -218,6 +216,30 @@ For technical questions about the platform, configuration, or deployment, users 
       .join('\n\n');
 
     return toolSections;
+  }
+
+  private buildAlwaysOnInstructionsSection(instructions: string[]): string {
+    if (instructions.length === 0) {
+      return '';
+    }
+
+    const entries = instructions.join('\n\n');
+
+    return `<always_on_instructions>\n${entries}\n</always_on_instructions>`;
+  }
+
+  private buildOptionalAgentInstructions(agent?: Agent): string {
+    return agent?.instructions
+      ? this.buildAgentInstructionsSection(agent.instructions)
+      : '';
+  }
+
+  private buildOptionalUserInstructions(
+    userSystemPrompt?: string,
+  ): string {
+    return userSystemPrompt
+      ? this.buildUserInstructionsSection(userSystemPrompt)
+      : '';
   }
 
   private buildAgentInstructionsSection(instructions: string): string {

--- a/ayunis-core-backend/src/domain/runs/application/services/tool-assembly.service.ts
+++ b/ayunis-core-backend/src/domain/runs/application/services/tool-assembly.service.ts
@@ -21,6 +21,8 @@ import { GetUserSystemPromptUseCase } from 'src/domain/chat-settings/application
 import { GetMcpIntegrationsByIdsUseCase } from 'src/domain/mcp/application/use-cases/get-mcp-integrations-by-ids/get-mcp-integrations-by-ids.use-case';
 import { GetMcpIntegrationsByIdsQuery } from 'src/domain/mcp/application/use-cases/get-mcp-integrations-by-ids/get-mcp-integrations-by-ids.query';
 import { MarketplaceMcpIntegration } from 'src/domain/mcp/domain/integrations/marketplace-mcp-integration.entity';
+import { FindActiveAlwaysOnTemplatesUseCase } from 'src/domain/skill-templates/application/use-cases/find-active-always-on-templates/find-active-always-on-templates.use-case';
+import { FindActiveAlwaysOnTemplatesQuery } from 'src/domain/skill-templates/application/use-cases/find-active-always-on-templates/find-active-always-on-templates.query';
 import { featuresConfig } from 'src/config/features.config';
 
 @Injectable()
@@ -35,6 +37,7 @@ export class ToolAssemblyService {
     private readonly findActiveSkillsUseCase: FindActiveSkillsUseCase,
     private readonly getUserSystemPromptUseCase: GetUserSystemPromptUseCase,
     private readonly getMcpIntegrationsByIdsUseCase: GetMcpIntegrationsByIdsUseCase,
+    private readonly findActiveAlwaysOnTemplatesUseCase: FindActiveAlwaysOnTemplatesUseCase,
     @Inject(featuresConfig.KEY)
     private readonly features: ConfigType<typeof featuresConfig>,
   ) {}
@@ -69,6 +72,20 @@ export class ToolAssemblyService {
       await this.getUserSystemPromptUseCase.execute();
     const userSystemPrompt = userSystemPromptEntity?.systemPrompt ?? undefined;
 
+    // Fetch active always-on skill templates (cached, 60s TTL)
+    let alwaysOnInstructions: string[] = [];
+    try {
+      const templates = await this.findActiveAlwaysOnTemplatesUseCase.execute(
+        new FindActiveAlwaysOnTemplatesQuery(),
+      );
+      alwaysOnInstructions = templates.map((t) => t.instructions);
+    } catch (error) {
+      this.logger.error(
+        'Failed to fetch always-on templates, continuing without them',
+        { error: error instanceof Error ? error.message : 'Unknown error' },
+      );
+    }
+
     const instructions = this.systemPromptBuilderService.build({
       agent,
       tools,
@@ -79,6 +96,7 @@ export class ToolAssemblyService {
       skills: canUseTools && this.features.skillsEnabled ? activeSkills : [],
 
       knowledgeBases: canUseTools ? (thread.knowledgeBases ?? []) : [],
+      alwaysOnInstructions,
       userSystemPrompt,
     });
 

--- a/ayunis-core-backend/src/domain/runs/runs.module.ts
+++ b/ayunis-core-backend/src/domain/runs/runs.module.ts
@@ -22,6 +22,7 @@ import { AnonymizationModule } from 'src/common/anonymization/anonymization.modu
 import { UsageModule } from 'src/domain/usage/usage.module';
 import { QuotasModule } from 'src/iam/quotas/quotas.module';
 import { SkillsModule } from 'src/domain/skills/skills.module';
+import { SkillTemplatesModule } from 'src/domain/skill-templates/skill-templates.module';
 import { ChatSettingsModule } from 'src/domain/chat-settings/chat-settings.module';
 
 @Module({
@@ -39,6 +40,7 @@ import { ChatSettingsModule } from 'src/domain/chat-settings/chat-settings.modul
     UsageModule,
     QuotasModule,
     SkillsModule,
+    SkillTemplatesModule,
     ChatSettingsModule,
   ],
   controllers: [RunsController],

--- a/ayunis-core-backend/src/domain/skill-templates/SUMMARY.md
+++ b/ayunis-core-backend/src/domain/skill-templates/SUMMARY.md
@@ -24,12 +24,18 @@ skill-templates/
 ├── application/
 │   ├── ports/skill-template.repository.ts # Abstract repository interface
 │   ├── skill-templates.errors.ts          # Domain errors
+│   ├── listeners/
+│   │   └── user-created.listener.ts       # Listens for UserCreatedEvent, installs pre-created templates
+│   ├── services/
+│   │   └── skill-template-installation.service.ts  # Installs pre-created template copies for a user
 │   └── use-cases/
 │       ├── create-skill-template/         # CreateSkillTemplateUseCase + command
 │       ├── update-skill-template/         # UpdateSkillTemplateUseCase + command
 │       ├── delete-skill-template/         # DeleteSkillTemplateUseCase + command
 │       ├── find-all-skill-templates/      # FindAllSkillTemplatesUseCase + query
-│       └── find-one-skill-template/       # FindOneSkillTemplateUseCase + query
+│       ├── find-one-skill-template/       # FindOneSkillTemplateUseCase + query
+│       ├── find-active-always-on-templates/   # FindActiveAlwaysOnTemplatesUseCase + query
+│       └── find-active-pre-created-templates/ # FindActivePreCreatedTemplatesUseCase + query
 ├── infrastructure/
 │   └── persistence/local/
 │       ├── schema/skill-template.record.ts        # TypeORM entity
@@ -50,6 +56,7 @@ skill-templates/
 ## Exports
 
 - `FindAllSkillTemplatesUseCase` — exported for consumers that need to list all templates (e.g., marketplace skill installation flow).
+- `FindActiveAlwaysOnTemplatesUseCase` — exported for consumers that need always-on templates (e.g., chat module injecting always-on skills).
 
 ## Design Decisions
 
@@ -58,4 +65,5 @@ Name validation reuses the same pattern as the Skills module (Unicode letters, n
 ## Dependencies
 
 - `iam/authorization` — decorators for route protection (`SystemRoles`)
-- `iam/users` — `SystemRole` enum used in controller authorization
+- `iam/users` — `SystemRole` enum used in controller authorization; `UserCreatedEvent` consumed by listener
+- `skills` — `CreateSkillWithUniqueNameUseCase` used by `SkillTemplateInstallationService` to create skill copies with automatic name deduplication

--- a/ayunis-core-backend/src/domain/skill-templates/application/listeners/user-created.listener.spec.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/application/listeners/user-created.listener.spec.ts
@@ -1,0 +1,39 @@
+import { SkillTemplateUserCreatedListener } from './user-created.listener';
+import type { SkillTemplateInstallationService } from '../services/skill-template-installation.service';
+import { UserCreatedEvent } from 'src/iam/users/application/events/user-created.event';
+import { randomUUID } from 'crypto';
+
+describe('SkillTemplateUserCreatedListener', () => {
+  let listener: SkillTemplateUserCreatedListener;
+  let installationService: jest.Mocked<SkillTemplateInstallationService>;
+
+  beforeEach(() => {
+    installationService = {
+      installAllPreCreatedForUser: jest.fn().mockResolvedValue(2),
+    } as unknown as jest.Mocked<SkillTemplateInstallationService>;
+
+    listener = new SkillTemplateUserCreatedListener(installationService);
+  });
+
+  it('should call installAllPreCreatedForUser with the user ID', async () => {
+    const userId = randomUUID();
+    const orgId = randomUUID();
+    const event = new UserCreatedEvent(userId, orgId);
+
+    await listener.handleUserCreated(event);
+
+    expect(
+      installationService.installAllPreCreatedForUser,
+    ).toHaveBeenCalledWith(userId);
+  });
+
+  it('should not throw when installation service fails', async () => {
+    installationService.installAllPreCreatedForUser.mockRejectedValue(
+      new Error('Unexpected error'),
+    );
+
+    const event = new UserCreatedEvent(randomUUID(), randomUUID());
+
+    await expect(listener.handleUserCreated(event)).resolves.toBeUndefined();
+  });
+});

--- a/ayunis-core-backend/src/domain/skill-templates/application/listeners/user-created.listener.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/application/listeners/user-created.listener.ts
@@ -1,0 +1,39 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { OnEvent } from '@nestjs/event-emitter';
+import { UserCreatedEvent } from 'src/iam/users/application/events/user-created.event';
+import { SkillTemplateInstallationService } from '../services/skill-template-installation.service';
+
+@Injectable()
+export class SkillTemplateUserCreatedListener {
+  private readonly logger = new Logger(SkillTemplateUserCreatedListener.name);
+
+  constructor(
+    private readonly skillTemplateInstallationService: SkillTemplateInstallationService,
+  ) {}
+
+  @OnEvent(UserCreatedEvent.EVENT_NAME)
+  async handleUserCreated(event: UserCreatedEvent): Promise<void> {
+    try {
+      this.logger.log('Installing pre-created skill templates for new user', {
+        userId: event.userId,
+        orgId: event.orgId,
+      });
+
+      const successCount =
+        await this.skillTemplateInstallationService.installAllPreCreatedForUser(
+          event.userId,
+        );
+
+      this.logger.log('Pre-created skill template installation complete', {
+        userId: event.userId,
+        count: successCount,
+      });
+    } catch (error) {
+      this.logger.error('Failed to install pre-created skill templates', {
+        userId: event.userId,
+        orgId: event.orgId,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      });
+    }
+  }
+}

--- a/ayunis-core-backend/src/domain/skill-templates/application/services/skill-template-installation.service.spec.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/application/services/skill-template-installation.service.spec.ts
@@ -1,0 +1,104 @@
+import { SkillTemplateInstallationService } from './skill-template-installation.service';
+import type { FindActivePreCreatedTemplatesUseCase } from '../use-cases/find-active-pre-created-templates/find-active-pre-created-templates.use-case';
+import type { CreateSkillWithUniqueNameUseCase } from 'src/domain/skills/application/use-cases/create-skill-with-unique-name/create-skill-with-unique-name.use-case';
+import type { CreateSkillWithUniqueNameCommand } from 'src/domain/skills/application/use-cases/create-skill-with-unique-name/create-skill-with-unique-name.command';
+import { SkillTemplate } from '../../domain/skill-template.entity';
+import { DistributionMode } from '../../domain/distribution-mode.enum';
+import { Skill } from 'src/domain/skills/domain/skill.entity';
+import { randomUUID } from 'crypto';
+
+describe('SkillTemplateInstallationService', () => {
+  let service: SkillTemplateInstallationService;
+  let findActivePreCreatedTemplatesUseCase: jest.Mocked<FindActivePreCreatedTemplatesUseCase>;
+  let createSkillWithUniqueNameUseCase: jest.Mocked<CreateSkillWithUniqueNameUseCase>;
+
+  const userId = randomUUID();
+
+  const mockTemplates: SkillTemplate[] = [
+    new SkillTemplate({
+      id: randomUUID(),
+      name: 'Template A',
+      shortDescription: 'Description A',
+      instructions: 'Instructions A',
+      distributionMode: DistributionMode.PRE_CREATED_COPY,
+      isActive: true,
+    }),
+    new SkillTemplate({
+      id: randomUUID(),
+      name: 'Template B',
+      shortDescription: 'Description B',
+      instructions: 'Instructions B',
+      distributionMode: DistributionMode.PRE_CREATED_COPY,
+      isActive: true,
+    }),
+  ];
+
+  beforeEach(() => {
+    findActivePreCreatedTemplatesUseCase = {
+      execute: jest.fn().mockResolvedValue(mockTemplates),
+    } as unknown as jest.Mocked<FindActivePreCreatedTemplatesUseCase>;
+
+    createSkillWithUniqueNameUseCase = {
+      execute: jest
+        .fn()
+        .mockImplementation((command: CreateSkillWithUniqueNameCommand) =>
+          Promise.resolve(
+            new Skill({
+              name: command.name,
+              shortDescription: command.shortDescription,
+              instructions: command.instructions,
+              userId: command.userId,
+            }),
+          ),
+        ),
+    } as unknown as jest.Mocked<CreateSkillWithUniqueNameUseCase>;
+
+    service = new SkillTemplateInstallationService(
+      findActivePreCreatedTemplatesUseCase,
+      createSkillWithUniqueNameUseCase,
+    );
+  });
+
+  it('should install all pre-created templates for a user', async () => {
+    const count = await service.installAllPreCreatedForUser(userId);
+
+    expect(count).toBe(2);
+    expect(createSkillWithUniqueNameUseCase.execute).toHaveBeenCalledTimes(2);
+    expect(createSkillWithUniqueNameUseCase.execute).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'Template A',
+        shortDescription: 'Description A',
+        instructions: 'Instructions A',
+        userId,
+      }),
+    );
+    expect(createSkillWithUniqueNameUseCase.execute).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'Template B',
+        shortDescription: 'Description B',
+        instructions: 'Instructions B',
+        userId,
+      }),
+    );
+  });
+
+  it('should return 0 when no templates exist', async () => {
+    findActivePreCreatedTemplatesUseCase.execute.mockResolvedValue([]);
+
+    const count = await service.installAllPreCreatedForUser(userId);
+
+    expect(count).toBe(0);
+    expect(createSkillWithUniqueNameUseCase.execute).not.toHaveBeenCalled();
+  });
+
+  it('should continue on individual template failure', async () => {
+    createSkillWithUniqueNameUseCase.execute.mockRejectedValueOnce(
+      new Error('DB error'),
+    );
+
+    const count = await service.installAllPreCreatedForUser(userId);
+
+    expect(count).toBe(1);
+    expect(createSkillWithUniqueNameUseCase.execute).toHaveBeenCalledTimes(2);
+  });
+});

--- a/ayunis-core-backend/src/domain/skill-templates/application/services/skill-template-installation.service.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/application/services/skill-template-installation.service.ts
@@ -1,0 +1,59 @@
+import { Injectable, Logger } from '@nestjs/common';
+import type { UUID } from 'crypto';
+import { CreateSkillWithUniqueNameUseCase } from 'src/domain/skills/application/use-cases/create-skill-with-unique-name/create-skill-with-unique-name.use-case';
+import { CreateSkillWithUniqueNameCommand } from 'src/domain/skills/application/use-cases/create-skill-with-unique-name/create-skill-with-unique-name.command';
+import { FindActivePreCreatedTemplatesUseCase } from '../use-cases/find-active-pre-created-templates/find-active-pre-created-templates.use-case';
+import { FindActivePreCreatedTemplatesQuery } from '../use-cases/find-active-pre-created-templates/find-active-pre-created-templates.query';
+
+@Injectable()
+export class SkillTemplateInstallationService {
+  private readonly logger = new Logger(SkillTemplateInstallationService.name);
+
+  constructor(
+    private readonly findActivePreCreatedTemplatesUseCase: FindActivePreCreatedTemplatesUseCase,
+    private readonly createSkillWithUniqueNameUseCase: CreateSkillWithUniqueNameUseCase,
+  ) {}
+
+  async installAllPreCreatedForUser(userId: UUID): Promise<number> {
+    const templates = await this.findActivePreCreatedTemplatesUseCase.execute(
+      new FindActivePreCreatedTemplatesQuery(),
+    );
+
+    if (templates.length === 0) {
+      this.logger.debug('No active pre-created skill templates found');
+      return 0;
+    }
+
+    let successCount = 0;
+    for (const template of templates) {
+      try {
+        const created = await this.createSkillWithUniqueNameUseCase.execute(
+          new CreateSkillWithUniqueNameCommand({
+            name: template.name,
+            shortDescription: template.shortDescription,
+            instructions: template.instructions,
+            userId,
+          }),
+        );
+
+        this.logger.debug(
+          'Pre-created skill template installed and activated',
+          { templateId: template.id, skillId: created.id, userId },
+        );
+        successCount++;
+      } catch (error) {
+        this.logger.error(
+          'Failed to install individual pre-created skill template',
+          {
+            templateId: template.id,
+            templateName: template.name,
+            userId,
+            error: error instanceof Error ? error.message : 'Unknown error',
+          },
+        );
+      }
+    }
+
+    return successCount;
+  }
+}

--- a/ayunis-core-backend/src/domain/skill-templates/application/use-cases/find-active-always-on-templates/find-active-always-on-templates.query.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/application/use-cases/find-active-always-on-templates/find-active-always-on-templates.query.ts
@@ -1,0 +1,1 @@
+export class FindActiveAlwaysOnTemplatesQuery {}

--- a/ayunis-core-backend/src/domain/skill-templates/application/use-cases/find-active-always-on-templates/find-active-always-on-templates.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/application/use-cases/find-active-always-on-templates/find-active-always-on-templates.use-case.spec.ts
@@ -1,0 +1,70 @@
+import { FindActiveAlwaysOnTemplatesUseCase } from './find-active-always-on-templates.use-case';
+import { FindActiveAlwaysOnTemplatesQuery } from './find-active-always-on-templates.query';
+import type { SkillTemplateRepository } from '../../ports/skill-template.repository';
+import { SkillTemplate } from '../../../domain/skill-template.entity';
+import { DistributionMode } from '../../../domain/distribution-mode.enum';
+import { randomUUID } from 'crypto';
+
+describe('FindActiveAlwaysOnTemplatesUseCase', () => {
+  let useCase: FindActiveAlwaysOnTemplatesUseCase;
+  let repository: jest.Mocked<SkillTemplateRepository>;
+
+  const mockTemplates: SkillTemplate[] = [
+    new SkillTemplate({
+      id: randomUUID(),
+      name: 'Global Policy',
+      shortDescription: 'Global policy instructions',
+      instructions: 'Always follow these rules...',
+      distributionMode: DistributionMode.ALWAYS_ON,
+      isActive: true,
+    }),
+  ];
+
+  beforeEach(() => {
+    repository = {
+      findActiveByMode: jest.fn().mockResolvedValue(mockTemplates),
+      create: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
+      findOne: jest.fn(),
+      findAll: jest.fn(),
+      findByName: jest.fn(),
+    } as unknown as jest.Mocked<SkillTemplateRepository>;
+
+    useCase = new FindActiveAlwaysOnTemplatesUseCase(repository);
+  });
+
+  it('should return active always-on templates from repository', async () => {
+    const result = await useCase.execute(
+      new FindActiveAlwaysOnTemplatesQuery(),
+    );
+
+    expect(result).toEqual(mockTemplates);
+    expect(repository.findActiveByMode).toHaveBeenCalledWith(
+      DistributionMode.ALWAYS_ON,
+    );
+  });
+
+  it('should cache results and not call repository on subsequent calls', async () => {
+    await useCase.execute(new FindActiveAlwaysOnTemplatesQuery());
+    await useCase.execute(new FindActiveAlwaysOnTemplatesQuery());
+
+    expect(repository.findActiveByMode).toHaveBeenCalledTimes(1);
+  });
+
+  it('should refresh cache after clearCache is called', async () => {
+    await useCase.execute(new FindActiveAlwaysOnTemplatesQuery());
+    useCase.clearCache();
+    await useCase.execute(new FindActiveAlwaysOnTemplatesQuery());
+
+    expect(repository.findActiveByMode).toHaveBeenCalledTimes(2);
+  });
+
+  it('should throw UnexpectedSkillTemplateError on repository failure', async () => {
+    repository.findActiveByMode.mockRejectedValue(new Error('DB error'));
+
+    await expect(
+      useCase.execute(new FindActiveAlwaysOnTemplatesQuery()),
+    ).rejects.toThrow('Unexpected error occurred');
+  });
+});

--- a/ayunis-core-backend/src/domain/skill-templates/application/use-cases/find-active-always-on-templates/find-active-always-on-templates.use-case.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/application/use-cases/find-active-always-on-templates/find-active-always-on-templates.use-case.ts
@@ -1,0 +1,51 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { SkillTemplateRepository } from '../../ports/skill-template.repository';
+import { SkillTemplate } from '../../../domain/skill-template.entity';
+import { DistributionMode } from '../../../domain/distribution-mode.enum';
+import { FindActiveAlwaysOnTemplatesQuery } from './find-active-always-on-templates.query';
+import { UnexpectedSkillTemplateError } from '../../skill-templates.errors';
+import { ApplicationError } from 'src/common/errors/base.error';
+
+const CACHE_TTL_MS = 60_000;
+
+@Injectable()
+export class FindActiveAlwaysOnTemplatesUseCase {
+  private readonly logger = new Logger(FindActiveAlwaysOnTemplatesUseCase.name);
+  private cachedTemplates: SkillTemplate[] | null = null;
+  private cacheExpiresAt = 0;
+
+  constructor(
+    private readonly skillTemplateRepository: SkillTemplateRepository,
+  ) {}
+
+  async execute(
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    _query: FindActiveAlwaysOnTemplatesQuery,
+  ): Promise<SkillTemplate[]> {
+    const now = Date.now();
+    if (this.cachedTemplates !== null && now < this.cacheExpiresAt) {
+      return this.cachedTemplates;
+    }
+
+    try {
+      const templates = await this.skillTemplateRepository.findActiveByMode(
+        DistributionMode.ALWAYS_ON,
+      );
+      this.cachedTemplates = templates;
+      this.cacheExpiresAt = now + CACHE_TTL_MS;
+      return templates;
+    } catch (error) {
+      if (error instanceof ApplicationError) throw error;
+      this.logger.error('Error finding active always-on templates', {
+        error: error as Error,
+      });
+      throw new UnexpectedSkillTemplateError(error);
+    }
+  }
+
+  /** Clears the in-memory cache (useful for testing). */
+  clearCache(): void {
+    this.cachedTemplates = null;
+    this.cacheExpiresAt = 0;
+  }
+}

--- a/ayunis-core-backend/src/domain/skill-templates/application/use-cases/find-active-pre-created-templates/find-active-pre-created-templates.query.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/application/use-cases/find-active-pre-created-templates/find-active-pre-created-templates.query.ts
@@ -1,0 +1,1 @@
+export class FindActivePreCreatedTemplatesQuery {}

--- a/ayunis-core-backend/src/domain/skill-templates/application/use-cases/find-active-pre-created-templates/find-active-pre-created-templates.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/application/use-cases/find-active-pre-created-templates/find-active-pre-created-templates.use-case.spec.ts
@@ -1,0 +1,68 @@
+import { FindActivePreCreatedTemplatesUseCase } from './find-active-pre-created-templates.use-case';
+import { FindActivePreCreatedTemplatesQuery } from './find-active-pre-created-templates.query';
+import type { SkillTemplateRepository } from '../../ports/skill-template.repository';
+import { SkillTemplate } from '../../../domain/skill-template.entity';
+import { DistributionMode } from '../../../domain/distribution-mode.enum';
+import { randomUUID } from 'crypto';
+
+describe('FindActivePreCreatedTemplatesUseCase', () => {
+  let useCase: FindActivePreCreatedTemplatesUseCase;
+  let repository: jest.Mocked<SkillTemplateRepository>;
+
+  const mockTemplates: SkillTemplate[] = [
+    new SkillTemplate({
+      id: randomUUID(),
+      name: 'Starter Skill',
+      shortDescription: 'A pre-created starter skill',
+      instructions: 'Follow these starter instructions...',
+      distributionMode: DistributionMode.PRE_CREATED_COPY,
+      isActive: true,
+    }),
+  ];
+
+  beforeEach(() => {
+    repository = {
+      findActiveByMode: jest.fn().mockResolvedValue(mockTemplates),
+      create: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
+      findOne: jest.fn(),
+      findAll: jest.fn(),
+      findByName: jest.fn(),
+    } as unknown as jest.Mocked<SkillTemplateRepository>;
+
+    useCase = new FindActivePreCreatedTemplatesUseCase(repository);
+  });
+
+  it('should return active pre-created templates from repository', async () => {
+    const result = await useCase.execute(
+      new FindActivePreCreatedTemplatesQuery(),
+    );
+
+    expect(result).toEqual(mockTemplates);
+    expect(repository.findActiveByMode).toHaveBeenCalledWith(
+      DistributionMode.PRE_CREATED_COPY,
+    );
+  });
+
+  it('should return empty array when no templates exist', async () => {
+    repository.findActiveByMode.mockResolvedValue([]);
+
+    const result = await useCase.execute(
+      new FindActivePreCreatedTemplatesQuery(),
+    );
+
+    expect(result).toEqual([]);
+    expect(repository.findActiveByMode).toHaveBeenCalledWith(
+      DistributionMode.PRE_CREATED_COPY,
+    );
+  });
+
+  it('should throw UnexpectedSkillTemplateError on repository failure', async () => {
+    repository.findActiveByMode.mockRejectedValue(new Error('DB error'));
+
+    await expect(
+      useCase.execute(new FindActivePreCreatedTemplatesQuery()),
+    ).rejects.toThrow('Unexpected error occurred');
+  });
+});

--- a/ayunis-core-backend/src/domain/skill-templates/application/use-cases/find-active-pre-created-templates/find-active-pre-created-templates.use-case.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/application/use-cases/find-active-pre-created-templates/find-active-pre-created-templates.use-case.ts
@@ -1,0 +1,36 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { SkillTemplateRepository } from '../../ports/skill-template.repository';
+import { SkillTemplate } from '../../../domain/skill-template.entity';
+import { DistributionMode } from '../../../domain/distribution-mode.enum';
+import { FindActivePreCreatedTemplatesQuery } from './find-active-pre-created-templates.query';
+import { UnexpectedSkillTemplateError } from '../../skill-templates.errors';
+import { ApplicationError } from 'src/common/errors/base.error';
+
+@Injectable()
+export class FindActivePreCreatedTemplatesUseCase {
+  private readonly logger = new Logger(
+    FindActivePreCreatedTemplatesUseCase.name,
+  );
+
+  constructor(
+    private readonly skillTemplateRepository: SkillTemplateRepository,
+  ) {}
+
+  async execute(
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    _query: FindActivePreCreatedTemplatesQuery,
+  ): Promise<SkillTemplate[]> {
+    this.logger.log('Finding active pre-created copy templates');
+    try {
+      return await this.skillTemplateRepository.findActiveByMode(
+        DistributionMode.PRE_CREATED_COPY,
+      );
+    } catch (error) {
+      if (error instanceof ApplicationError) throw error;
+      this.logger.error('Error finding active pre-created templates', {
+        error: error as Error,
+      });
+      throw new UnexpectedSkillTemplateError(error);
+    }
+  }
+}

--- a/ayunis-core-backend/src/domain/skill-templates/skill-templates.module.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/skill-templates.module.ts
@@ -1,4 +1,5 @@
 import { Module } from '@nestjs/common';
+import { SkillsModule } from 'src/domain/skills/skills.module';
 import { LocalSkillTemplateRepositoryModule } from './infrastructure/persistence/local/local-skill-template-repository.module';
 import { LocalSkillTemplateRepository } from './infrastructure/persistence/local/local-skill-template.repository';
 import { SkillTemplateRepository } from './application/ports/skill-template.repository';
@@ -7,11 +8,15 @@ import { UpdateSkillTemplateUseCase } from './application/use-cases/update-skill
 import { DeleteSkillTemplateUseCase } from './application/use-cases/delete-skill-template/delete-skill-template.use-case';
 import { FindAllSkillTemplatesUseCase } from './application/use-cases/find-all-skill-templates/find-all-skill-templates.use-case';
 import { FindOneSkillTemplateUseCase } from './application/use-cases/find-one-skill-template/find-one-skill-template.use-case';
+import { FindActiveAlwaysOnTemplatesUseCase } from './application/use-cases/find-active-always-on-templates/find-active-always-on-templates.use-case';
+import { FindActivePreCreatedTemplatesUseCase } from './application/use-cases/find-active-pre-created-templates/find-active-pre-created-templates.use-case';
+import { SkillTemplateInstallationService } from './application/services/skill-template-installation.service';
+import { SkillTemplateUserCreatedListener } from './application/listeners/user-created.listener';
 import { SuperAdminSkillTemplatesController } from './presenters/http/super-admin-skill-templates.controller';
 import { SkillTemplateResponseMapper } from './presenters/http/mappers/skill-template-response.mapper';
 
 @Module({
-  imports: [LocalSkillTemplateRepositoryModule],
+  imports: [LocalSkillTemplateRepositoryModule, SkillsModule],
   controllers: [SuperAdminSkillTemplatesController],
   providers: [
     {
@@ -23,8 +28,12 @@ import { SkillTemplateResponseMapper } from './presenters/http/mappers/skill-tem
     DeleteSkillTemplateUseCase,
     FindAllSkillTemplatesUseCase,
     FindOneSkillTemplateUseCase,
+    FindActiveAlwaysOnTemplatesUseCase,
+    FindActivePreCreatedTemplatesUseCase,
+    SkillTemplateInstallationService,
+    SkillTemplateUserCreatedListener,
     SkillTemplateResponseMapper,
   ],
-  exports: [FindAllSkillTemplatesUseCase],
+  exports: [FindAllSkillTemplatesUseCase, FindActiveAlwaysOnTemplatesUseCase],
 })
 export class SkillTemplatesModule {}

--- a/ayunis-core-backend/src/domain/skills/application/services/marketplace-skill-installation.service.spec.ts
+++ b/ayunis-core-backend/src/domain/skills/application/services/marketplace-skill-installation.service.spec.ts
@@ -1,7 +1,7 @@
 import { MarketplaceSkillInstallationService } from './marketplace-skill-installation.service';
 import type { GetMarketplaceSkillUseCase } from 'src/domain/marketplace/application/use-cases/get-marketplace-skill/get-marketplace-skill.use-case';
 import type { MarketplaceClient } from 'src/domain/marketplace/application/ports/marketplace-client.port';
-import type { SkillRepository } from '../ports/skill.repository';
+import type { CreateSkillWithUniqueNameUseCase } from '../use-cases/create-skill-with-unique-name/create-skill-with-unique-name.use-case';
 import type {
   SkillListResponseDto,
   SkillResponseDto,
@@ -9,6 +9,7 @@ import type {
 import { Skill } from '../../domain/skill.entity';
 import type { UUID } from 'crypto';
 import { MarketplaceSkillNotFoundError } from 'src/domain/marketplace/application/marketplace.errors';
+import { CreateSkillWithUniqueNameCommand } from '../use-cases/create-skill-with-unique-name/create-skill-with-unique-name.command';
 
 const USER_ID = '550e8400-e29b-41d4-a716-446655440000' as UUID;
 
@@ -27,7 +28,7 @@ const marketplaceSkill: SkillResponseDto = {
 describe('MarketplaceSkillInstallationService', () => {
   let service: MarketplaceSkillInstallationService;
   let getMarketplaceSkillUseCase: jest.Mocked<GetMarketplaceSkillUseCase>;
-  let skillRepository: jest.Mocked<SkillRepository>;
+  let createSkillWithUniqueNameUseCase: jest.Mocked<CreateSkillWithUniqueNameUseCase>;
   let marketplaceClient: jest.Mocked<MarketplaceClient>;
 
   beforeEach(() => {
@@ -35,11 +36,9 @@ describe('MarketplaceSkillInstallationService', () => {
       execute: jest.fn(),
     } as unknown as jest.Mocked<GetMarketplaceSkillUseCase>;
 
-    skillRepository = {
-      create: jest.fn(),
-      findByNameAndOwner: jest.fn(),
-      activateSkill: jest.fn(),
-    } as unknown as jest.Mocked<SkillRepository>;
+    createSkillWithUniqueNameUseCase = {
+      execute: jest.fn(),
+    } as unknown as jest.Mocked<CreateSkillWithUniqueNameUseCase>;
 
     marketplaceClient = {
       getPreInstalledSkills: jest.fn(),
@@ -49,15 +48,23 @@ describe('MarketplaceSkillInstallationService', () => {
 
     service = new MarketplaceSkillInstallationService(
       getMarketplaceSkillUseCase,
-      skillRepository,
+      createSkillWithUniqueNameUseCase,
       marketplaceClient,
     );
   });
 
-  it('should install a marketplace skill, create it, and activate it', async () => {
+  it('should fetch marketplace skill and delegate creation to CreateSkillWithUniqueNameUseCase', async () => {
+    const createdSkill = new Skill({
+      name: 'Meeting Summarizer',
+      shortDescription: 'Summarize meetings and extract action items',
+      instructions:
+        'You are a meeting summarization assistant. Analyze meeting notes.',
+      marketplaceIdentifier: 'meeting-summarizer',
+      userId: USER_ID,
+    });
+
     getMarketplaceSkillUseCase.execute.mockResolvedValue(marketplaceSkill);
-    skillRepository.findByNameAndOwner.mockResolvedValue(null);
-    skillRepository.create.mockImplementation(async (skill: Skill) => skill);
+    createSkillWithUniqueNameUseCase.execute.mockResolvedValue(createdSkill);
 
     const result = await service.installFromMarketplace(
       'meeting-summarizer',
@@ -73,45 +80,15 @@ describe('MarketplaceSkillInstallationService', () => {
     );
     expect(result.marketplaceIdentifier).toBe('meeting-summarizer');
     expect(result.userId).toBe(USER_ID);
-    expect(skillRepository.create).toHaveBeenCalledWith(
-      expect.objectContaining({ name: 'Meeting Summarizer' }),
-    );
-    expect(skillRepository.activateSkill).toHaveBeenCalledWith(
-      result.id,
-      USER_ID,
-    );
-  });
-
-  it('should append a numeric suffix when the name already exists', async () => {
-    getMarketplaceSkillUseCase.execute.mockResolvedValue(marketplaceSkill);
-
-    const existingSkill = new Skill({
-      name: 'Meeting Summarizer',
-      shortDescription: 'Existing',
-      instructions: 'Existing instructions',
-      userId: USER_ID,
-    });
-
-    skillRepository.findByNameAndOwner
-      .mockResolvedValueOnce(existingSkill) // "Meeting Summarizer" taken
-      .mockResolvedValueOnce(null); // "Meeting Summarizer 2" available
-
-    skillRepository.create.mockImplementation(async (skill: Skill) => skill);
-
-    const result = await service.installFromMarketplace(
-      'meeting-summarizer',
-      USER_ID,
-    );
-
-    expect(result.name).toBe('Meeting Summarizer 2');
-    expect(skillRepository.findByNameAndOwner).toHaveBeenCalledTimes(2);
-    expect(skillRepository.findByNameAndOwner).toHaveBeenCalledWith(
-      'Meeting Summarizer',
-      USER_ID,
-    );
-    expect(skillRepository.findByNameAndOwner).toHaveBeenCalledWith(
-      'Meeting Summarizer 2',
-      USER_ID,
+    expect(createSkillWithUniqueNameUseCase.execute).toHaveBeenCalledWith(
+      new CreateSkillWithUniqueNameCommand({
+        name: 'Meeting Summarizer',
+        shortDescription: 'Summarize meetings and extract action items',
+        instructions:
+          'You are a meeting summarization assistant. Analyze meeting notes.',
+        marketplaceIdentifier: 'meeting-summarizer',
+        userId: USER_ID,
+      }),
     );
   });
 
@@ -124,41 +101,18 @@ describe('MarketplaceSkillInstallationService', () => {
       service.installFromMarketplace('nonexistent-skill', USER_ID),
     ).rejects.toThrow(MarketplaceSkillNotFoundError);
 
-    expect(skillRepository.create).not.toHaveBeenCalled();
+    expect(createSkillWithUniqueNameUseCase.execute).not.toHaveBeenCalled();
   });
 
-  it('should propagate repository create failure', async () => {
+  it('should propagate creation failure from CreateSkillWithUniqueNameUseCase', async () => {
     getMarketplaceSkillUseCase.execute.mockResolvedValue(marketplaceSkill);
-    skillRepository.findByNameAndOwner.mockResolvedValue(null);
-    skillRepository.create.mockRejectedValue(
+    createSkillWithUniqueNameUseCase.execute.mockRejectedValue(
       new Error('Unique constraint violation'),
     );
 
     await expect(
       service.installFromMarketplace('meeting-summarizer', USER_ID),
     ).rejects.toThrow('Unique constraint violation');
-
-    expect(skillRepository.activateSkill).not.toHaveBeenCalled();
-  });
-
-  it('should throw after exceeding maximum name resolution attempts', async () => {
-    getMarketplaceSkillUseCase.execute.mockResolvedValue(marketplaceSkill);
-
-    const existingSkill = new Skill({
-      name: 'Meeting Summarizer',
-      shortDescription: 'Existing',
-      instructions: 'Existing instructions',
-      userId: USER_ID,
-    });
-
-    // All names taken — returns existing skill every time
-    skillRepository.findByNameAndOwner.mockResolvedValue(existingSkill);
-
-    await expect(
-      service.installFromMarketplace('meeting-summarizer', USER_ID),
-    ).rejects.toThrow(/Could not resolve unique name/);
-
-    expect(skillRepository.create).not.toHaveBeenCalled();
   });
 
   describe('installAllPreInstalled', () => {
@@ -180,8 +134,16 @@ describe('MarketplaceSkillInstallationService', () => {
         identifier: query.identifier,
         name: query.identifier,
       }));
-      skillRepository.findByNameAndOwner.mockResolvedValue(null);
-      skillRepository.create.mockImplementation(async (skill: Skill) => skill);
+      createSkillWithUniqueNameUseCase.execute.mockImplementation(
+        async (command) =>
+          new Skill({
+            name: command.name,
+            shortDescription: command.shortDescription,
+            instructions: command.instructions,
+            marketplaceIdentifier: command.marketplaceIdentifier,
+            userId: command.userId,
+          }),
+      );
     };
 
     it('should install all pre-installed skills and return success count', async () => {
@@ -221,8 +183,16 @@ describe('MarketplaceSkillInstallationService', () => {
           identifier: 'working-skill',
           name: 'Working Skill',
         });
-      skillRepository.findByNameAndOwner.mockResolvedValue(null);
-      skillRepository.create.mockImplementation(async (skill: Skill) => skill);
+      createSkillWithUniqueNameUseCase.execute.mockImplementation(
+        async (command) =>
+          new Skill({
+            name: command.name,
+            shortDescription: command.shortDescription,
+            instructions: command.instructions,
+            marketplaceIdentifier: command.marketplaceIdentifier,
+            userId: command.userId,
+          }),
+      );
 
       const count = await service.installAllPreInstalled(USER_ID);
 

--- a/ayunis-core-backend/src/domain/skills/application/services/marketplace-skill-installation.service.ts
+++ b/ayunis-core-backend/src/domain/skills/application/services/marketplace-skill-installation.service.ts
@@ -1,12 +1,11 @@
-import { Inject, Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { UUID } from 'crypto';
 import { GetMarketplaceSkillUseCase } from 'src/domain/marketplace/application/use-cases/get-marketplace-skill/get-marketplace-skill.use-case';
 import { GetMarketplaceSkillQuery } from 'src/domain/marketplace/application/use-cases/get-marketplace-skill/get-marketplace-skill.query';
 import { MarketplaceClient } from 'src/domain/marketplace/application/ports/marketplace-client.port';
-import { SkillRepository } from '../ports/skill.repository';
+import { CreateSkillWithUniqueNameUseCase } from '../use-cases/create-skill-with-unique-name/create-skill-with-unique-name.use-case';
+import { CreateSkillWithUniqueNameCommand } from '../use-cases/create-skill-with-unique-name/create-skill-with-unique-name.command';
 import { Skill } from '../../domain/skill.entity';
-
-const MAX_NAME_RESOLUTION_ATTEMPTS = 100;
 
 @Injectable()
 export class MarketplaceSkillInstallationService {
@@ -16,8 +15,7 @@ export class MarketplaceSkillInstallationService {
 
   constructor(
     private readonly getMarketplaceSkillUseCase: GetMarketplaceSkillUseCase,
-    @Inject(SkillRepository)
-    private readonly skillRepository: SkillRepository,
+    private readonly createSkillWithUniqueNameUseCase: CreateSkillWithUniqueNameUseCase,
     private readonly marketplaceClient: MarketplaceClient,
   ) {}
 
@@ -74,37 +72,14 @@ export class MarketplaceSkillInstallationService {
       new GetMarketplaceSkillQuery(identifier),
     );
 
-    const name = await this.resolveUniqueName(marketplaceSkill.name, userId);
-
-    const skill = new Skill({
-      name,
-      shortDescription: marketplaceSkill.shortDescription,
-      instructions: marketplaceSkill.instructions,
-      marketplaceIdentifier: marketplaceSkill.identifier,
-      userId,
-    });
-
-    const created = await this.skillRepository.create(skill);
-    await this.skillRepository.activateSkill(created.id, userId);
-
-    return created;
-  }
-
-  private async resolveUniqueName(
-    baseName: string,
-    userId: UUID,
-  ): Promise<string> {
-    let name = baseName;
-    let suffix = 2;
-    while (await this.skillRepository.findByNameAndOwner(name, userId)) {
-      if (suffix > MAX_NAME_RESOLUTION_ATTEMPTS) {
-        throw new Error(
-          `Could not resolve unique name for "${baseName}" after ${MAX_NAME_RESOLUTION_ATTEMPTS} attempts`,
-        );
-      }
-      name = `${baseName} ${suffix}`;
-      suffix++;
-    }
-    return name;
+    return this.createSkillWithUniqueNameUseCase.execute(
+      new CreateSkillWithUniqueNameCommand({
+        name: marketplaceSkill.name,
+        shortDescription: marketplaceSkill.shortDescription,
+        instructions: marketplaceSkill.instructions,
+        marketplaceIdentifier: marketplaceSkill.identifier,
+        userId,
+      }),
+    );
   }
 }

--- a/ayunis-core-backend/src/domain/skills/application/skills.errors.ts
+++ b/ayunis-core-backend/src/domain/skills/application/skills.errors.ts
@@ -19,6 +19,7 @@ export enum SkillErrorCode {
   EMPTY_FILE_DATA = 'EMPTY_FILE_DATA',
   MARKETPLACE_INSTALL_FAILED = 'MARKETPLACE_INSTALL_FAILED',
   SKILL_NOT_ACTIVE = 'SKILL_NOT_ACTIVE',
+  SKILL_NAME_RESOLUTION_FAILED = 'SKILL_NAME_RESOLUTION_FAILED',
   UNEXPECTED_SKILL_ERROR = 'UNEXPECTED_SKILL_ERROR',
 }
 
@@ -220,6 +221,17 @@ export class SkillNotActiveError extends SkillError {
       SkillErrorCode.SKILL_NOT_ACTIVE,
       400,
       metadata,
+    );
+  }
+}
+
+export class SkillNameResolutionError extends SkillError {
+  constructor(baseName: string, maxAttempts: number, metadata?: ErrorMetadata) {
+    super(
+      `Could not resolve unique name for "${baseName}" after ${maxAttempts} attempts`,
+      SkillErrorCode.SKILL_NAME_RESOLUTION_FAILED,
+      409,
+      { baseName, maxAttempts, ...metadata },
     );
   }
 }

--- a/ayunis-core-backend/src/domain/skills/application/use-cases/create-skill-with-unique-name/create-skill-with-unique-name.command.ts
+++ b/ayunis-core-backend/src/domain/skills/application/use-cases/create-skill-with-unique-name/create-skill-with-unique-name.command.ts
@@ -1,0 +1,23 @@
+import type { UUID } from 'crypto';
+
+export class CreateSkillWithUniqueNameCommand {
+  public readonly name: string;
+  public readonly shortDescription: string;
+  public readonly instructions: string;
+  public readonly marketplaceIdentifier: string | null;
+  public readonly userId: UUID;
+
+  constructor(params: {
+    name: string;
+    shortDescription: string;
+    instructions: string;
+    marketplaceIdentifier?: string | null;
+    userId: UUID;
+  }) {
+    this.name = params.name;
+    this.shortDescription = params.shortDescription;
+    this.instructions = params.instructions;
+    this.marketplaceIdentifier = params.marketplaceIdentifier ?? null;
+    this.userId = params.userId;
+  }
+}

--- a/ayunis-core-backend/src/domain/skills/application/use-cases/create-skill-with-unique-name/create-skill-with-unique-name.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/skills/application/use-cases/create-skill-with-unique-name/create-skill-with-unique-name.use-case.spec.ts
@@ -1,0 +1,127 @@
+import { CreateSkillWithUniqueNameUseCase } from './create-skill-with-unique-name.use-case';
+import { CreateSkillWithUniqueNameCommand } from './create-skill-with-unique-name.command';
+import type { SkillRepository } from '../../ports/skill.repository';
+import { Skill } from '../../../domain/skill.entity';
+import { SkillNameResolutionError } from '../../skills.errors';
+import { randomUUID } from 'crypto';
+import type { UUID } from 'crypto';
+
+describe('CreateSkillWithUniqueNameUseCase', () => {
+  let useCase: CreateSkillWithUniqueNameUseCase;
+  let skillRepository: jest.Mocked<SkillRepository>;
+
+  const userId = randomUUID();
+
+  beforeEach(() => {
+    skillRepository = {
+      create: jest
+        .fn()
+        .mockImplementation((skill: Skill) => Promise.resolve(skill)),
+      activateSkill: jest.fn().mockResolvedValue(undefined),
+      findByNameAndOwner: jest.fn().mockResolvedValue(null),
+    } as unknown as jest.Mocked<SkillRepository>;
+
+    useCase = new CreateSkillWithUniqueNameUseCase(skillRepository);
+  });
+
+  it('should create and activate a skill with the given name when no collision exists', async () => {
+    const command = new CreateSkillWithUniqueNameCommand({
+      name: 'Summarizer',
+      shortDescription: 'Summarizes documents',
+      instructions: 'You are a summarizer assistant',
+      userId,
+    });
+
+    const result = await useCase.execute(command);
+
+    expect(result.name).toBe('Summarizer');
+    expect(result.shortDescription).toBe('Summarizes documents');
+    expect(result.instructions).toBe('You are a summarizer assistant');
+    expect(result.userId).toBe(userId);
+    expect(skillRepository.create).toHaveBeenCalledTimes(1);
+    expect(skillRepository.activateSkill).toHaveBeenCalledWith(
+      result.id,
+      userId,
+    );
+  });
+
+  it('should append a numeric suffix when the name already exists', async () => {
+    skillRepository.findByNameAndOwner.mockImplementation(
+      (name: string, ownerId: UUID) =>
+        Promise.resolve(
+          name === 'Summarizer'
+            ? new Skill({
+                name: 'Summarizer',
+                shortDescription: 'existing',
+                instructions: 'existing',
+                userId: ownerId,
+              })
+            : null,
+        ),
+    );
+
+    const command = new CreateSkillWithUniqueNameCommand({
+      name: 'Summarizer',
+      shortDescription: 'Summarizes documents',
+      instructions: 'You are a summarizer assistant',
+      userId,
+    });
+
+    const result = await useCase.execute(command);
+
+    expect(result.name).toBe('Summarizer 2');
+  });
+
+  it('should increment suffix until a unique name is found', async () => {
+    const existingNames = new Set([
+      'Translator',
+      'Translator 2',
+      'Translator 3',
+    ]);
+    skillRepository.findByNameAndOwner.mockImplementation((name: string) =>
+      Promise.resolve(
+        existingNames.has(name)
+          ? new Skill({
+              name,
+              shortDescription: 'existing',
+              instructions: 'existing',
+              userId,
+            })
+          : null,
+      ),
+    );
+
+    const command = new CreateSkillWithUniqueNameCommand({
+      name: 'Translator',
+      shortDescription: 'Translates text',
+      instructions: 'You are a translator',
+      userId,
+    });
+
+    const result = await useCase.execute(command);
+
+    expect(result.name).toBe('Translator 4');
+  });
+
+  it('should throw when unique name cannot be resolved after max attempts', async () => {
+    skillRepository.findByNameAndOwner.mockResolvedValue(
+      new Skill({
+        name: 'Collider',
+        shortDescription: 'existing',
+        instructions: 'existing',
+        userId,
+      }),
+    );
+
+    const command = new CreateSkillWithUniqueNameCommand({
+      name: 'Collider',
+      shortDescription: 'Always collides',
+      instructions: 'This will fail',
+      userId,
+    });
+
+    await expect(useCase.execute(command)).rejects.toThrow(
+      SkillNameResolutionError,
+    );
+  });
+});

--- a/ayunis-core-backend/src/domain/skills/application/use-cases/create-skill-with-unique-name/create-skill-with-unique-name.use-case.ts
+++ b/ayunis-core-backend/src/domain/skills/application/use-cases/create-skill-with-unique-name/create-skill-with-unique-name.use-case.ts
@@ -1,0 +1,65 @@
+import { Inject, Injectable, Logger } from '@nestjs/common';
+import { SkillRepository } from '../../ports/skill.repository';
+import { CreateSkillWithUniqueNameCommand } from './create-skill-with-unique-name.command';
+import { Skill } from '../../../domain/skill.entity';
+import { SkillNameResolutionError } from '../../skills.errors';
+import type { UUID } from 'crypto';
+
+const MAX_NAME_RESOLUTION_ATTEMPTS = 100;
+
+@Injectable()
+export class CreateSkillWithUniqueNameUseCase {
+  private readonly logger = new Logger(CreateSkillWithUniqueNameUseCase.name);
+
+  constructor(
+    @Inject(SkillRepository)
+    private readonly skillRepository: SkillRepository,
+  ) {}
+
+  async execute(command: CreateSkillWithUniqueNameCommand): Promise<Skill> {
+    this.logger.log('Creating skill with unique name resolution', {
+      baseName: command.name,
+      userId: command.userId,
+    });
+
+    const name = await this.resolveUniqueName(command.name, command.userId);
+
+    const skill = new Skill({
+      name,
+      shortDescription: command.shortDescription,
+      instructions: command.instructions,
+      marketplaceIdentifier: command.marketplaceIdentifier,
+      userId: command.userId,
+    });
+
+    const created = await this.skillRepository.create(skill);
+    await this.skillRepository.activateSkill(created.id, command.userId);
+
+    this.logger.debug('Skill created and activated', {
+      skillId: created.id,
+      name: created.name,
+      userId: command.userId,
+    });
+
+    return created;
+  }
+
+  private async resolveUniqueName(
+    baseName: string,
+    userId: UUID,
+  ): Promise<string> {
+    let name = baseName;
+    let suffix = 2;
+    while (await this.skillRepository.findByNameAndOwner(name, userId)) {
+      if (suffix > MAX_NAME_RESOLUTION_ATTEMPTS) {
+        throw new SkillNameResolutionError(
+          baseName,
+          MAX_NAME_RESOLUTION_ATTEMPTS,
+        );
+      }
+      name = `${baseName} ${suffix}`;
+      suffix++;
+    }
+    return name;
+  }
+}

--- a/ayunis-core-backend/src/domain/skills/skills.module.ts
+++ b/ayunis-core-backend/src/domain/skills/skills.module.ts
@@ -32,6 +32,7 @@ import { UnassignKnowledgeBaseFromSkillUseCase } from './application/use-cases/u
 import { ListSkillKnowledgeBasesUseCase } from './application/use-cases/list-skill-knowledge-bases/list-skill-knowledge-bases.use-case';
 import { FindSkillByNameUseCase } from './application/use-cases/find-skill-by-name/find-skill-by-name.use-case';
 import { InstallSkillFromMarketplaceUseCase } from './application/use-cases/install-skill-from-marketplace/install-skill-from-marketplace.use-case';
+import { CreateSkillWithUniqueNameUseCase } from './application/use-cases/create-skill-with-unique-name/create-skill-with-unique-name.use-case';
 
 // Services
 import { MarketplaceSkillInstallationService } from './application/services/marketplace-skill-installation.service';
@@ -111,6 +112,7 @@ import { KnowledgeBaseDtoMapper } from '../knowledge-bases/presenters/http/mappe
     ListSkillKnowledgeBasesUseCase,
     FindSkillByNameUseCase,
     InstallSkillFromMarketplaceUseCase,
+    CreateSkillWithUniqueNameUseCase,
 
     // Services
     MarketplaceSkillInstallationService,
@@ -146,6 +148,7 @@ import { KnowledgeBaseDtoMapper } from '../knowledge-bases/presenters/http/mappe
     SkillActivationService,
     SkillShareAuthorizationStrategy,
     getShareAuthStrategyToken(SharedEntityType.SKILL),
+    CreateSkillWithUniqueNameUseCase,
   ],
 })
 export class SkillsModule {}

--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
@@ -3211,6 +3211,64 @@ export interface UpdateSkillTemplateDto {
   isActive?: boolean;
 }
 
+export interface UserSystemPromptResponseDto {
+  /**
+   * The custom system prompt for the user, or null if not set
+   * @nullable
+   */
+  systemPrompt: string | null;
+}
+
+export interface UpsertUserSystemPromptDto {
+  /**
+   * The custom system prompt for the user
+   * @maxLength 10000
+   */
+  systemPrompt: string;
+}
+
+export interface CreatePromptDto {
+  /**
+   * The title of the prompt
+   * @minLength 1
+   * @maxLength 255
+   */
+  title: string;
+  /** The content of the prompt */
+  content: string;
+}
+
+export interface PromptResponseDto {
+  /** The unique identifier of the prompt */
+  id: string;
+  /** The title of the prompt */
+  title: string;
+  /** The content of the prompt */
+  content: string;
+  /** The unique identifier of the user who owns this prompt */
+  userId: string;
+  /** The date and time when the prompt was created */
+  createdAt: string;
+  /** The date and time when the prompt was last updated */
+  updatedAt: string;
+}
+
+export interface UpdatePromptDto {
+  /**
+   * The title of the prompt
+   * @minLength 1
+   * @maxLength 255
+   */
+  title: string;
+  /** The content of the prompt */
+  content: string;
+}
+
+export interface TranscriptionResponseDto {
+  /** The transcribed text from the audio file */
+  text: string;
+}
+
 export interface LoginDto {
   /** Email address for authentication */
   email: string;

--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.ts
@@ -12968,6 +12968,389 @@ export function useSuperAdminGlobalUsageControllerGetGlobalUserUsage<TData = Awa
 
 
 /**
+ * Create a new skill template. Only accessible to super admins.
+ * @summary Create a new skill template
+ */
+export const superAdminSkillTemplatesControllerCreate = (
+    createSkillTemplateDto: CreateSkillTemplateDto,
+ signal?: AbortSignal
+) => {
+      
+      
+      return customAxiosInstance<SkillTemplateResponseDto>(
+      {url: `/super-admin/skill-templates`, method: 'POST',
+      headers: {'Content-Type': 'application/json', },
+      data: createSkillTemplateDto, signal
+    },
+      );
+    }
+  
+
+
+export const getSuperAdminSkillTemplatesControllerCreateMutationOptions = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof superAdminSkillTemplatesControllerCreate>>, TError,{data: CreateSkillTemplateDto}, TContext>, }
+): UseMutationOptions<Awaited<ReturnType<typeof superAdminSkillTemplatesControllerCreate>>, TError,{data: CreateSkillTemplateDto}, TContext> => {
+
+const mutationKey = ['superAdminSkillTemplatesControllerCreate'];
+const {mutation: mutationOptions} = options ?
+      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
+      options
+      : {...options, mutation: {...options.mutation, mutationKey}}
+      : {mutation: { mutationKey, }};
+
+      
+
+
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof superAdminSkillTemplatesControllerCreate>>, {data: CreateSkillTemplateDto}> = (props) => {
+          const {data} = props ?? {};
+
+          return  superAdminSkillTemplatesControllerCreate(data,)
+        }
+
+        
+
+
+  return  { mutationFn, ...mutationOptions }}
+
+    export type SuperAdminSkillTemplatesControllerCreateMutationResult = NonNullable<Awaited<ReturnType<typeof superAdminSkillTemplatesControllerCreate>>>
+    export type SuperAdminSkillTemplatesControllerCreateMutationBody = CreateSkillTemplateDto
+    export type SuperAdminSkillTemplatesControllerCreateMutationError = void
+
+    /**
+ * @summary Create a new skill template
+ */
+export const useSuperAdminSkillTemplatesControllerCreate = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof superAdminSkillTemplatesControllerCreate>>, TError,{data: CreateSkillTemplateDto}, TContext>, }
+ , queryClient?: QueryClient): UseMutationResult<
+        Awaited<ReturnType<typeof superAdminSkillTemplatesControllerCreate>>,
+        TError,
+        {data: CreateSkillTemplateDto},
+        TContext
+      > => {
+
+      const mutationOptions = getSuperAdminSkillTemplatesControllerCreateMutationOptions(options);
+
+      return useMutation(mutationOptions, queryClient);
+    }
+    
+/**
+ * Retrieve all skill templates. Only accessible to super admins.
+ * @summary Get all skill templates
+ */
+export const superAdminSkillTemplatesControllerFindAll = (
+    
+ signal?: AbortSignal
+) => {
+      
+      
+      return customAxiosInstance<SkillTemplateResponseDto[]>(
+      {url: `/super-admin/skill-templates`, method: 'GET', signal
+    },
+      );
+    }
+  
+
+
+
+export const getSuperAdminSkillTemplatesControllerFindAllQueryKey = () => {
+    return [
+    `/super-admin/skill-templates`
+    ] as const;
+    }
+
+    
+export const getSuperAdminSkillTemplatesControllerFindAllQueryOptions = <TData = Awaited<ReturnType<typeof superAdminSkillTemplatesControllerFindAll>>, TError = void>( options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof superAdminSkillTemplatesControllerFindAll>>, TError, TData>>, }
+) => {
+
+const {query: queryOptions} = options ?? {};
+
+  const queryKey =  queryOptions?.queryKey ?? getSuperAdminSkillTemplatesControllerFindAllQueryKey();
+
+  
+
+    const queryFn: QueryFunction<Awaited<ReturnType<typeof superAdminSkillTemplatesControllerFindAll>>> = ({ signal }) => superAdminSkillTemplatesControllerFindAll(signal);
+
+      
+
+      
+
+   return  { queryKey, queryFn, ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof superAdminSkillTemplatesControllerFindAll>>, TError, TData> & { queryKey: DataTag<QueryKey, TData, TError> }
+}
+
+export type SuperAdminSkillTemplatesControllerFindAllQueryResult = NonNullable<Awaited<ReturnType<typeof superAdminSkillTemplatesControllerFindAll>>>
+export type SuperAdminSkillTemplatesControllerFindAllQueryError = void
+
+
+export function useSuperAdminSkillTemplatesControllerFindAll<TData = Awaited<ReturnType<typeof superAdminSkillTemplatesControllerFindAll>>, TError = void>(
+  options: { query:Partial<UseQueryOptions<Awaited<ReturnType<typeof superAdminSkillTemplatesControllerFindAll>>, TError, TData>> & Pick<
+        DefinedInitialDataOptions<
+          Awaited<ReturnType<typeof superAdminSkillTemplatesControllerFindAll>>,
+          TError,
+          Awaited<ReturnType<typeof superAdminSkillTemplatesControllerFindAll>>
+        > , 'initialData'
+      >, }
+ , queryClient?: QueryClient
+  ):  DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useSuperAdminSkillTemplatesControllerFindAll<TData = Awaited<ReturnType<typeof superAdminSkillTemplatesControllerFindAll>>, TError = void>(
+  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof superAdminSkillTemplatesControllerFindAll>>, TError, TData>> & Pick<
+        UndefinedInitialDataOptions<
+          Awaited<ReturnType<typeof superAdminSkillTemplatesControllerFindAll>>,
+          TError,
+          Awaited<ReturnType<typeof superAdminSkillTemplatesControllerFindAll>>
+        > , 'initialData'
+      >, }
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useSuperAdminSkillTemplatesControllerFindAll<TData = Awaited<ReturnType<typeof superAdminSkillTemplatesControllerFindAll>>, TError = void>(
+  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof superAdminSkillTemplatesControllerFindAll>>, TError, TData>>, }
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+/**
+ * @summary Get all skill templates
+ */
+
+export function useSuperAdminSkillTemplatesControllerFindAll<TData = Awaited<ReturnType<typeof superAdminSkillTemplatesControllerFindAll>>, TError = void>(
+  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof superAdminSkillTemplatesControllerFindAll>>, TError, TData>>, }
+ , queryClient?: QueryClient 
+ ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
+
+  const queryOptions = getSuperAdminSkillTemplatesControllerFindAllQueryOptions(options)
+
+  const query = useQuery(queryOptions, queryClient) as  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+
+  query.queryKey = queryOptions.queryKey ;
+
+  return query;
+}
+
+
+
+
+
+/**
+ * Retrieve a specific skill template by its ID. Only accessible to super admins.
+ * @summary Get a skill template by ID
+ */
+export const superAdminSkillTemplatesControllerFindOne = (
+    id: string,
+ signal?: AbortSignal
+) => {
+      
+      
+      return customAxiosInstance<SkillTemplateResponseDto>(
+      {url: `/super-admin/skill-templates/${id}`, method: 'GET', signal
+    },
+      );
+    }
+  
+
+
+
+export const getSuperAdminSkillTemplatesControllerFindOneQueryKey = (id?: string,) => {
+    return [
+    `/super-admin/skill-templates/${id}`
+    ] as const;
+    }
+
+    
+export const getSuperAdminSkillTemplatesControllerFindOneQueryOptions = <TData = Awaited<ReturnType<typeof superAdminSkillTemplatesControllerFindOne>>, TError = void>(id: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof superAdminSkillTemplatesControllerFindOne>>, TError, TData>>, }
+) => {
+
+const {query: queryOptions} = options ?? {};
+
+  const queryKey =  queryOptions?.queryKey ?? getSuperAdminSkillTemplatesControllerFindOneQueryKey(id);
+
+  
+
+    const queryFn: QueryFunction<Awaited<ReturnType<typeof superAdminSkillTemplatesControllerFindOne>>> = ({ signal }) => superAdminSkillTemplatesControllerFindOne(id, signal);
+
+      
+
+      
+
+   return  { queryKey, queryFn, enabled: !!(id), ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof superAdminSkillTemplatesControllerFindOne>>, TError, TData> & { queryKey: DataTag<QueryKey, TData, TError> }
+}
+
+export type SuperAdminSkillTemplatesControllerFindOneQueryResult = NonNullable<Awaited<ReturnType<typeof superAdminSkillTemplatesControllerFindOne>>>
+export type SuperAdminSkillTemplatesControllerFindOneQueryError = void
+
+
+export function useSuperAdminSkillTemplatesControllerFindOne<TData = Awaited<ReturnType<typeof superAdminSkillTemplatesControllerFindOne>>, TError = void>(
+ id: string, options: { query:Partial<UseQueryOptions<Awaited<ReturnType<typeof superAdminSkillTemplatesControllerFindOne>>, TError, TData>> & Pick<
+        DefinedInitialDataOptions<
+          Awaited<ReturnType<typeof superAdminSkillTemplatesControllerFindOne>>,
+          TError,
+          Awaited<ReturnType<typeof superAdminSkillTemplatesControllerFindOne>>
+        > , 'initialData'
+      >, }
+ , queryClient?: QueryClient
+  ):  DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useSuperAdminSkillTemplatesControllerFindOne<TData = Awaited<ReturnType<typeof superAdminSkillTemplatesControllerFindOne>>, TError = void>(
+ id: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof superAdminSkillTemplatesControllerFindOne>>, TError, TData>> & Pick<
+        UndefinedInitialDataOptions<
+          Awaited<ReturnType<typeof superAdminSkillTemplatesControllerFindOne>>,
+          TError,
+          Awaited<ReturnType<typeof superAdminSkillTemplatesControllerFindOne>>
+        > , 'initialData'
+      >, }
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useSuperAdminSkillTemplatesControllerFindOne<TData = Awaited<ReturnType<typeof superAdminSkillTemplatesControllerFindOne>>, TError = void>(
+ id: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof superAdminSkillTemplatesControllerFindOne>>, TError, TData>>, }
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+/**
+ * @summary Get a skill template by ID
+ */
+
+export function useSuperAdminSkillTemplatesControllerFindOne<TData = Awaited<ReturnType<typeof superAdminSkillTemplatesControllerFindOne>>, TError = void>(
+ id: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof superAdminSkillTemplatesControllerFindOne>>, TError, TData>>, }
+ , queryClient?: QueryClient 
+ ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
+
+  const queryOptions = getSuperAdminSkillTemplatesControllerFindOneQueryOptions(id,options)
+
+  const query = useQuery(queryOptions, queryClient) as  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+
+  query.queryKey = queryOptions.queryKey ;
+
+  return query;
+}
+
+
+
+
+
+/**
+ * Partially update an existing skill template. Only accessible to super admins.
+ * @summary Update a skill template
+ */
+export const superAdminSkillTemplatesControllerUpdate = (
+    id: string,
+    updateSkillTemplateDto: UpdateSkillTemplateDto,
+ ) => {
+      
+      
+      return customAxiosInstance<SkillTemplateResponseDto>(
+      {url: `/super-admin/skill-templates/${id}`, method: 'PATCH',
+      headers: {'Content-Type': 'application/json', },
+      data: updateSkillTemplateDto
+    },
+      );
+    }
+  
+
+
+export const getSuperAdminSkillTemplatesControllerUpdateMutationOptions = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof superAdminSkillTemplatesControllerUpdate>>, TError,{id: string;data: UpdateSkillTemplateDto}, TContext>, }
+): UseMutationOptions<Awaited<ReturnType<typeof superAdminSkillTemplatesControllerUpdate>>, TError,{id: string;data: UpdateSkillTemplateDto}, TContext> => {
+
+const mutationKey = ['superAdminSkillTemplatesControllerUpdate'];
+const {mutation: mutationOptions} = options ?
+      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
+      options
+      : {...options, mutation: {...options.mutation, mutationKey}}
+      : {mutation: { mutationKey, }};
+
+      
+
+
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof superAdminSkillTemplatesControllerUpdate>>, {id: string;data: UpdateSkillTemplateDto}> = (props) => {
+          const {id,data} = props ?? {};
+
+          return  superAdminSkillTemplatesControllerUpdate(id,data,)
+        }
+
+        
+
+
+  return  { mutationFn, ...mutationOptions }}
+
+    export type SuperAdminSkillTemplatesControllerUpdateMutationResult = NonNullable<Awaited<ReturnType<typeof superAdminSkillTemplatesControllerUpdate>>>
+    export type SuperAdminSkillTemplatesControllerUpdateMutationBody = UpdateSkillTemplateDto
+    export type SuperAdminSkillTemplatesControllerUpdateMutationError = void
+
+    /**
+ * @summary Update a skill template
+ */
+export const useSuperAdminSkillTemplatesControllerUpdate = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof superAdminSkillTemplatesControllerUpdate>>, TError,{id: string;data: UpdateSkillTemplateDto}, TContext>, }
+ , queryClient?: QueryClient): UseMutationResult<
+        Awaited<ReturnType<typeof superAdminSkillTemplatesControllerUpdate>>,
+        TError,
+        {id: string;data: UpdateSkillTemplateDto},
+        TContext
+      > => {
+
+      const mutationOptions = getSuperAdminSkillTemplatesControllerUpdateMutationOptions(options);
+
+      return useMutation(mutationOptions, queryClient);
+    }
+    
+/**
+ * Delete a skill template. Only accessible to super admins.
+ * @summary Delete a skill template
+ */
+export const superAdminSkillTemplatesControllerDelete = (
+    id: string,
+ ) => {
+      
+      
+      return customAxiosInstance<void>(
+      {url: `/super-admin/skill-templates/${id}`, method: 'DELETE'
+    },
+      );
+    }
+  
+
+
+export const getSuperAdminSkillTemplatesControllerDeleteMutationOptions = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof superAdminSkillTemplatesControllerDelete>>, TError,{id: string}, TContext>, }
+): UseMutationOptions<Awaited<ReturnType<typeof superAdminSkillTemplatesControllerDelete>>, TError,{id: string}, TContext> => {
+
+const mutationKey = ['superAdminSkillTemplatesControllerDelete'];
+const {mutation: mutationOptions} = options ?
+      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
+      options
+      : {...options, mutation: {...options.mutation, mutationKey}}
+      : {mutation: { mutationKey, }};
+
+      
+
+
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof superAdminSkillTemplatesControllerDelete>>, {id: string}> = (props) => {
+          const {id} = props ?? {};
+
+          return  superAdminSkillTemplatesControllerDelete(id,)
+        }
+
+        
+
+
+  return  { mutationFn, ...mutationOptions }}
+
+    export type SuperAdminSkillTemplatesControllerDeleteMutationResult = NonNullable<Awaited<ReturnType<typeof superAdminSkillTemplatesControllerDelete>>>
+    
+    export type SuperAdminSkillTemplatesControllerDeleteMutationError = void
+
+    /**
+ * @summary Delete a skill template
+ */
+export const useSuperAdminSkillTemplatesControllerDelete = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof superAdminSkillTemplatesControllerDelete>>, TError,{id: string}, TContext>, }
+ , queryClient?: QueryClient): UseMutationResult<
+        Awaited<ReturnType<typeof superAdminSkillTemplatesControllerDelete>>,
+        TError,
+        {id: string},
+        TContext
+      > => {
+
+      const mutationOptions = getSuperAdminSkillTemplatesControllerDeleteMutationOptions(options);
+
+      return useMutation(mutationOptions, queryClient);
+    }
+    
+/**
  * Returns the custom system prompt for the authenticated user, or null if not set.
  * @summary Get the user system prompt
  */
@@ -13700,389 +14083,6 @@ export const useTranscriptionsControllerTranscribe = <TError = void,
       > => {
 
       const mutationOptions = getTranscriptionsControllerTranscribeMutationOptions(options);
-
-      return useMutation(mutationOptions, queryClient);
-    }
-    
-/**
- * Create a new skill template. Only accessible to super admins.
- * @summary Create a new skill template
- */
-export const superAdminSkillTemplatesControllerCreate = (
-    createSkillTemplateDto: CreateSkillTemplateDto,
- signal?: AbortSignal
-) => {
-      
-      
-      return customAxiosInstance<SkillTemplateResponseDto>(
-      {url: `/super-admin/skill-templates`, method: 'POST',
-      headers: {'Content-Type': 'application/json', },
-      data: createSkillTemplateDto, signal
-    },
-      );
-    }
-  
-
-
-export const getSuperAdminSkillTemplatesControllerCreateMutationOptions = <TError = void,
-    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof superAdminSkillTemplatesControllerCreate>>, TError,{data: CreateSkillTemplateDto}, TContext>, }
-): UseMutationOptions<Awaited<ReturnType<typeof superAdminSkillTemplatesControllerCreate>>, TError,{data: CreateSkillTemplateDto}, TContext> => {
-
-const mutationKey = ['superAdminSkillTemplatesControllerCreate'];
-const {mutation: mutationOptions} = options ?
-      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
-      options
-      : {...options, mutation: {...options.mutation, mutationKey}}
-      : {mutation: { mutationKey, }};
-
-      
-
-
-      const mutationFn: MutationFunction<Awaited<ReturnType<typeof superAdminSkillTemplatesControllerCreate>>, {data: CreateSkillTemplateDto}> = (props) => {
-          const {data} = props ?? {};
-
-          return  superAdminSkillTemplatesControllerCreate(data,)
-        }
-
-        
-
-
-  return  { mutationFn, ...mutationOptions }}
-
-    export type SuperAdminSkillTemplatesControllerCreateMutationResult = NonNullable<Awaited<ReturnType<typeof superAdminSkillTemplatesControllerCreate>>>
-    export type SuperAdminSkillTemplatesControllerCreateMutationBody = CreateSkillTemplateDto
-    export type SuperAdminSkillTemplatesControllerCreateMutationError = void
-
-    /**
- * @summary Create a new skill template
- */
-export const useSuperAdminSkillTemplatesControllerCreate = <TError = void,
-    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof superAdminSkillTemplatesControllerCreate>>, TError,{data: CreateSkillTemplateDto}, TContext>, }
- , queryClient?: QueryClient): UseMutationResult<
-        Awaited<ReturnType<typeof superAdminSkillTemplatesControllerCreate>>,
-        TError,
-        {data: CreateSkillTemplateDto},
-        TContext
-      > => {
-
-      const mutationOptions = getSuperAdminSkillTemplatesControllerCreateMutationOptions(options);
-
-      return useMutation(mutationOptions, queryClient);
-    }
-    
-/**
- * Retrieve all skill templates. Only accessible to super admins.
- * @summary Get all skill templates
- */
-export const superAdminSkillTemplatesControllerFindAll = (
-    
- signal?: AbortSignal
-) => {
-      
-      
-      return customAxiosInstance<SkillTemplateResponseDto[]>(
-      {url: `/super-admin/skill-templates`, method: 'GET', signal
-    },
-      );
-    }
-  
-
-
-
-export const getSuperAdminSkillTemplatesControllerFindAllQueryKey = () => {
-    return [
-    `/super-admin/skill-templates`
-    ] as const;
-    }
-
-    
-export const getSuperAdminSkillTemplatesControllerFindAllQueryOptions = <TData = Awaited<ReturnType<typeof superAdminSkillTemplatesControllerFindAll>>, TError = void>( options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof superAdminSkillTemplatesControllerFindAll>>, TError, TData>>, }
-) => {
-
-const {query: queryOptions} = options ?? {};
-
-  const queryKey =  queryOptions?.queryKey ?? getSuperAdminSkillTemplatesControllerFindAllQueryKey();
-
-  
-
-    const queryFn: QueryFunction<Awaited<ReturnType<typeof superAdminSkillTemplatesControllerFindAll>>> = ({ signal }) => superAdminSkillTemplatesControllerFindAll(signal);
-
-      
-
-      
-
-   return  { queryKey, queryFn, ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof superAdminSkillTemplatesControllerFindAll>>, TError, TData> & { queryKey: DataTag<QueryKey, TData, TError> }
-}
-
-export type SuperAdminSkillTemplatesControllerFindAllQueryResult = NonNullable<Awaited<ReturnType<typeof superAdminSkillTemplatesControllerFindAll>>>
-export type SuperAdminSkillTemplatesControllerFindAllQueryError = void
-
-
-export function useSuperAdminSkillTemplatesControllerFindAll<TData = Awaited<ReturnType<typeof superAdminSkillTemplatesControllerFindAll>>, TError = void>(
-  options: { query:Partial<UseQueryOptions<Awaited<ReturnType<typeof superAdminSkillTemplatesControllerFindAll>>, TError, TData>> & Pick<
-        DefinedInitialDataOptions<
-          Awaited<ReturnType<typeof superAdminSkillTemplatesControllerFindAll>>,
-          TError,
-          Awaited<ReturnType<typeof superAdminSkillTemplatesControllerFindAll>>
-        > , 'initialData'
-      >, }
- , queryClient?: QueryClient
-  ):  DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
-export function useSuperAdminSkillTemplatesControllerFindAll<TData = Awaited<ReturnType<typeof superAdminSkillTemplatesControllerFindAll>>, TError = void>(
-  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof superAdminSkillTemplatesControllerFindAll>>, TError, TData>> & Pick<
-        UndefinedInitialDataOptions<
-          Awaited<ReturnType<typeof superAdminSkillTemplatesControllerFindAll>>,
-          TError,
-          Awaited<ReturnType<typeof superAdminSkillTemplatesControllerFindAll>>
-        > , 'initialData'
-      >, }
- , queryClient?: QueryClient
-  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
-export function useSuperAdminSkillTemplatesControllerFindAll<TData = Awaited<ReturnType<typeof superAdminSkillTemplatesControllerFindAll>>, TError = void>(
-  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof superAdminSkillTemplatesControllerFindAll>>, TError, TData>>, }
- , queryClient?: QueryClient
-  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
-/**
- * @summary Get all skill templates
- */
-
-export function useSuperAdminSkillTemplatesControllerFindAll<TData = Awaited<ReturnType<typeof superAdminSkillTemplatesControllerFindAll>>, TError = void>(
-  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof superAdminSkillTemplatesControllerFindAll>>, TError, TData>>, }
- , queryClient?: QueryClient 
- ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
-
-  const queryOptions = getSuperAdminSkillTemplatesControllerFindAllQueryOptions(options)
-
-  const query = useQuery(queryOptions, queryClient) as  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
-
-  query.queryKey = queryOptions.queryKey ;
-
-  return query;
-}
-
-
-
-
-
-/**
- * Retrieve a specific skill template by its ID. Only accessible to super admins.
- * @summary Get a skill template by ID
- */
-export const superAdminSkillTemplatesControllerFindOne = (
-    id: string,
- signal?: AbortSignal
-) => {
-      
-      
-      return customAxiosInstance<SkillTemplateResponseDto>(
-      {url: `/super-admin/skill-templates/${id}`, method: 'GET', signal
-    },
-      );
-    }
-  
-
-
-
-export const getSuperAdminSkillTemplatesControllerFindOneQueryKey = (id?: string,) => {
-    return [
-    `/super-admin/skill-templates/${id}`
-    ] as const;
-    }
-
-    
-export const getSuperAdminSkillTemplatesControllerFindOneQueryOptions = <TData = Awaited<ReturnType<typeof superAdminSkillTemplatesControllerFindOne>>, TError = void>(id: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof superAdminSkillTemplatesControllerFindOne>>, TError, TData>>, }
-) => {
-
-const {query: queryOptions} = options ?? {};
-
-  const queryKey =  queryOptions?.queryKey ?? getSuperAdminSkillTemplatesControllerFindOneQueryKey(id);
-
-  
-
-    const queryFn: QueryFunction<Awaited<ReturnType<typeof superAdminSkillTemplatesControllerFindOne>>> = ({ signal }) => superAdminSkillTemplatesControllerFindOne(id, signal);
-
-      
-
-      
-
-   return  { queryKey, queryFn, enabled: !!(id), ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof superAdminSkillTemplatesControllerFindOne>>, TError, TData> & { queryKey: DataTag<QueryKey, TData, TError> }
-}
-
-export type SuperAdminSkillTemplatesControllerFindOneQueryResult = NonNullable<Awaited<ReturnType<typeof superAdminSkillTemplatesControllerFindOne>>>
-export type SuperAdminSkillTemplatesControllerFindOneQueryError = void
-
-
-export function useSuperAdminSkillTemplatesControllerFindOne<TData = Awaited<ReturnType<typeof superAdminSkillTemplatesControllerFindOne>>, TError = void>(
- id: string, options: { query:Partial<UseQueryOptions<Awaited<ReturnType<typeof superAdminSkillTemplatesControllerFindOne>>, TError, TData>> & Pick<
-        DefinedInitialDataOptions<
-          Awaited<ReturnType<typeof superAdminSkillTemplatesControllerFindOne>>,
-          TError,
-          Awaited<ReturnType<typeof superAdminSkillTemplatesControllerFindOne>>
-        > , 'initialData'
-      >, }
- , queryClient?: QueryClient
-  ):  DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
-export function useSuperAdminSkillTemplatesControllerFindOne<TData = Awaited<ReturnType<typeof superAdminSkillTemplatesControllerFindOne>>, TError = void>(
- id: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof superAdminSkillTemplatesControllerFindOne>>, TError, TData>> & Pick<
-        UndefinedInitialDataOptions<
-          Awaited<ReturnType<typeof superAdminSkillTemplatesControllerFindOne>>,
-          TError,
-          Awaited<ReturnType<typeof superAdminSkillTemplatesControllerFindOne>>
-        > , 'initialData'
-      >, }
- , queryClient?: QueryClient
-  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
-export function useSuperAdminSkillTemplatesControllerFindOne<TData = Awaited<ReturnType<typeof superAdminSkillTemplatesControllerFindOne>>, TError = void>(
- id: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof superAdminSkillTemplatesControllerFindOne>>, TError, TData>>, }
- , queryClient?: QueryClient
-  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
-/**
- * @summary Get a skill template by ID
- */
-
-export function useSuperAdminSkillTemplatesControllerFindOne<TData = Awaited<ReturnType<typeof superAdminSkillTemplatesControllerFindOne>>, TError = void>(
- id: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof superAdminSkillTemplatesControllerFindOne>>, TError, TData>>, }
- , queryClient?: QueryClient 
- ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
-
-  const queryOptions = getSuperAdminSkillTemplatesControllerFindOneQueryOptions(id,options)
-
-  const query = useQuery(queryOptions, queryClient) as  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
-
-  query.queryKey = queryOptions.queryKey ;
-
-  return query;
-}
-
-
-
-
-
-/**
- * Partially update an existing skill template. Only accessible to super admins.
- * @summary Update a skill template
- */
-export const superAdminSkillTemplatesControllerUpdate = (
-    id: string,
-    updateSkillTemplateDto: UpdateSkillTemplateDto,
- ) => {
-      
-      
-      return customAxiosInstance<SkillTemplateResponseDto>(
-      {url: `/super-admin/skill-templates/${id}`, method: 'PATCH',
-      headers: {'Content-Type': 'application/json', },
-      data: updateSkillTemplateDto
-    },
-      );
-    }
-  
-
-
-export const getSuperAdminSkillTemplatesControllerUpdateMutationOptions = <TError = void,
-    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof superAdminSkillTemplatesControllerUpdate>>, TError,{id: string;data: UpdateSkillTemplateDto}, TContext>, }
-): UseMutationOptions<Awaited<ReturnType<typeof superAdminSkillTemplatesControllerUpdate>>, TError,{id: string;data: UpdateSkillTemplateDto}, TContext> => {
-
-const mutationKey = ['superAdminSkillTemplatesControllerUpdate'];
-const {mutation: mutationOptions} = options ?
-      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
-      options
-      : {...options, mutation: {...options.mutation, mutationKey}}
-      : {mutation: { mutationKey, }};
-
-      
-
-
-      const mutationFn: MutationFunction<Awaited<ReturnType<typeof superAdminSkillTemplatesControllerUpdate>>, {id: string;data: UpdateSkillTemplateDto}> = (props) => {
-          const {id,data} = props ?? {};
-
-          return  superAdminSkillTemplatesControllerUpdate(id,data,)
-        }
-
-        
-
-
-  return  { mutationFn, ...mutationOptions }}
-
-    export type SuperAdminSkillTemplatesControllerUpdateMutationResult = NonNullable<Awaited<ReturnType<typeof superAdminSkillTemplatesControllerUpdate>>>
-    export type SuperAdminSkillTemplatesControllerUpdateMutationBody = UpdateSkillTemplateDto
-    export type SuperAdminSkillTemplatesControllerUpdateMutationError = void
-
-    /**
- * @summary Update a skill template
- */
-export const useSuperAdminSkillTemplatesControllerUpdate = <TError = void,
-    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof superAdminSkillTemplatesControllerUpdate>>, TError,{id: string;data: UpdateSkillTemplateDto}, TContext>, }
- , queryClient?: QueryClient): UseMutationResult<
-        Awaited<ReturnType<typeof superAdminSkillTemplatesControllerUpdate>>,
-        TError,
-        {id: string;data: UpdateSkillTemplateDto},
-        TContext
-      > => {
-
-      const mutationOptions = getSuperAdminSkillTemplatesControllerUpdateMutationOptions(options);
-
-      return useMutation(mutationOptions, queryClient);
-    }
-    
-/**
- * Delete a skill template. Only accessible to super admins.
- * @summary Delete a skill template
- */
-export const superAdminSkillTemplatesControllerDelete = (
-    id: string,
- ) => {
-      
-      
-      return customAxiosInstance<void>(
-      {url: `/super-admin/skill-templates/${id}`, method: 'DELETE'
-    },
-      );
-    }
-  
-
-
-export const getSuperAdminSkillTemplatesControllerDeleteMutationOptions = <TError = void,
-    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof superAdminSkillTemplatesControllerDelete>>, TError,{id: string}, TContext>, }
-): UseMutationOptions<Awaited<ReturnType<typeof superAdminSkillTemplatesControllerDelete>>, TError,{id: string}, TContext> => {
-
-const mutationKey = ['superAdminSkillTemplatesControllerDelete'];
-const {mutation: mutationOptions} = options ?
-      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
-      options
-      : {...options, mutation: {...options.mutation, mutationKey}}
-      : {mutation: { mutationKey, }};
-
-      
-
-
-      const mutationFn: MutationFunction<Awaited<ReturnType<typeof superAdminSkillTemplatesControllerDelete>>, {id: string}> = (props) => {
-          const {id} = props ?? {};
-
-          return  superAdminSkillTemplatesControllerDelete(id,)
-        }
-
-        
-
-
-  return  { mutationFn, ...mutationOptions }}
-
-    export type SuperAdminSkillTemplatesControllerDeleteMutationResult = NonNullable<Awaited<ReturnType<typeof superAdminSkillTemplatesControllerDelete>>>
-    
-    export type SuperAdminSkillTemplatesControllerDeleteMutationError = void
-
-    /**
- * @summary Delete a skill template
- */
-export const useSuperAdminSkillTemplatesControllerDelete = <TError = void,
-    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof superAdminSkillTemplatesControllerDelete>>, TError,{id: string}, TContext>, }
- , queryClient?: QueryClient): UseMutationResult<
-        Awaited<ReturnType<typeof superAdminSkillTemplatesControllerDelete>>,
-        TError,
-        {id: string},
-        TContext
-      > => {
-
-      const mutationOptions = getSuperAdminSkillTemplatesControllerDeleteMutationOptions(options);
 
       return useMutation(mutationOptions, queryClient);
     }

--- a/ayunis-core-frontend/src/shared/api/openapi-schema.json
+++ b/ayunis-core-frontend/src/shared/api/openapi-schema.json
@@ -6962,6 +6962,209 @@
         ]
       }
     },
+    "/super-admin/skill-templates": {
+      "post": {
+        "description": "Create a new skill template. Only accessible to super admins.",
+        "operationId": "SuperAdminSkillTemplatesController_create",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateSkillTemplateDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Successfully created skill template",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SkillTemplateResponseDto"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "User not authenticated or not authorized as super admin"
+          },
+          "409": {
+            "description": "Skill template with this name already exists"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "summary": "Create a new skill template",
+        "tags": [
+          "Super Admin Skill Templates"
+        ]
+      },
+      "get": {
+        "description": "Retrieve all skill templates. Only accessible to super admins.",
+        "operationId": "SuperAdminSkillTemplatesController_findAll",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved skill templates",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/SkillTemplateResponseDto"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "User not authenticated or not authorized as super admin"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "summary": "Get all skill templates",
+        "tags": [
+          "Super Admin Skill Templates"
+        ]
+      }
+    },
+    "/super-admin/skill-templates/{id}": {
+      "get": {
+        "description": "Retrieve a specific skill template by its ID. Only accessible to super admins.",
+        "operationId": "SuperAdminSkillTemplatesController_findOne",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "description": "Skill template ID",
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved skill template",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SkillTemplateResponseDto"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "User not authenticated or not authorized as super admin"
+          },
+          "404": {
+            "description": "Skill template not found"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "summary": "Get a skill template by ID",
+        "tags": [
+          "Super Admin Skill Templates"
+        ]
+      },
+      "patch": {
+        "description": "Partially update an existing skill template. Only accessible to super admins.",
+        "operationId": "SuperAdminSkillTemplatesController_update",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "description": "Skill template ID",
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateSkillTemplateDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successfully updated skill template",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SkillTemplateResponseDto"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "User not authenticated or not authorized as super admin"
+          },
+          "404": {
+            "description": "Skill template not found"
+          },
+          "409": {
+            "description": "Skill template with this name already exists"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "summary": "Update a skill template",
+        "tags": [
+          "Super Admin Skill Templates"
+        ]
+      },
+      "delete": {
+        "description": "Delete a skill template. Only accessible to super admins.",
+        "operationId": "SuperAdminSkillTemplatesController_delete",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "description": "Skill template ID",
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successfully deleted skill template"
+          },
+          "401": {
+            "description": "User not authenticated or not authorized as super admin"
+          },
+          "404": {
+            "description": "Skill template not found"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "summary": "Delete a skill template",
+        "tags": [
+          "Super Admin Skill Templates"
+        ]
+      }
+    },
     "/chat-settings/system-prompt": {
       "get": {
         "description": "Returns the custom system prompt for the authenticated user, or null if not set.",
@@ -7317,209 +7520,6 @@
         "summary": "Transcribe audio file to text",
         "tags": [
           "transcriptions"
-        ]
-      }
-    },
-    "/super-admin/skill-templates": {
-      "post": {
-        "description": "Create a new skill template. Only accessible to super admins.",
-        "operationId": "SuperAdminSkillTemplatesController_create",
-        "parameters": [],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/CreateSkillTemplateDto"
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "Successfully created skill template",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/SkillTemplateResponseDto"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "User not authenticated or not authorized as super admin"
-          },
-          "409": {
-            "description": "Skill template with this name already exists"
-          },
-          "500": {
-            "description": "Internal server error"
-          }
-        },
-        "summary": "Create a new skill template",
-        "tags": [
-          "Super Admin Skill Templates"
-        ]
-      },
-      "get": {
-        "description": "Retrieve all skill templates. Only accessible to super admins.",
-        "operationId": "SuperAdminSkillTemplatesController_findAll",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "description": "Successfully retrieved skill templates",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/SkillTemplateResponseDto"
-                  }
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "User not authenticated or not authorized as super admin"
-          },
-          "500": {
-            "description": "Internal server error"
-          }
-        },
-        "summary": "Get all skill templates",
-        "tags": [
-          "Super Admin Skill Templates"
-        ]
-      }
-    },
-    "/super-admin/skill-templates/{id}": {
-      "get": {
-        "description": "Retrieve a specific skill template by its ID. Only accessible to super admins.",
-        "operationId": "SuperAdminSkillTemplatesController_findOne",
-        "parameters": [
-          {
-            "name": "id",
-            "required": true,
-            "in": "path",
-            "description": "Skill template ID",
-            "schema": {
-              "format": "uuid",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successfully retrieved skill template",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/SkillTemplateResponseDto"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "User not authenticated or not authorized as super admin"
-          },
-          "404": {
-            "description": "Skill template not found"
-          },
-          "500": {
-            "description": "Internal server error"
-          }
-        },
-        "summary": "Get a skill template by ID",
-        "tags": [
-          "Super Admin Skill Templates"
-        ]
-      },
-      "patch": {
-        "description": "Partially update an existing skill template. Only accessible to super admins.",
-        "operationId": "SuperAdminSkillTemplatesController_update",
-        "parameters": [
-          {
-            "name": "id",
-            "required": true,
-            "in": "path",
-            "description": "Skill template ID",
-            "schema": {
-              "format": "uuid",
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/UpdateSkillTemplateDto"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successfully updated skill template",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/SkillTemplateResponseDto"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "User not authenticated or not authorized as super admin"
-          },
-          "404": {
-            "description": "Skill template not found"
-          },
-          "409": {
-            "description": "Skill template with this name already exists"
-          },
-          "500": {
-            "description": "Internal server error"
-          }
-        },
-        "summary": "Update a skill template",
-        "tags": [
-          "Super Admin Skill Templates"
-        ]
-      },
-      "delete": {
-        "description": "Delete a skill template. Only accessible to super admins.",
-        "operationId": "SuperAdminSkillTemplatesController_delete",
-        "parameters": [
-          {
-            "name": "id",
-            "required": true,
-            "in": "path",
-            "description": "Skill template ID",
-            "schema": {
-              "format": "uuid",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "Successfully deleted skill template"
-          },
-          "401": {
-            "description": "User not authenticated or not authorized as super admin"
-          },
-          "404": {
-            "description": "Skill template not found"
-          },
-          "500": {
-            "description": "Internal server error"
-          }
-        },
-        "summary": "Delete a skill template",
-        "tags": [
-          "Super Admin Skill Templates"
         ]
       }
     },
@@ -13335,6 +13335,136 @@
             "example": true
           }
         }
+      },
+      "UserSystemPromptResponseDto": {
+        "type": "object",
+        "properties": {
+          "systemPrompt": {
+            "type": "string",
+            "description": "The custom system prompt for the user, or null if not set",
+            "example": "Always respond in bullet points. I work in the finance department.",
+            "nullable": true
+          }
+        },
+        "required": [
+          "systemPrompt"
+        ]
+      },
+      "UpsertUserSystemPromptDto": {
+        "type": "object",
+        "properties": {
+          "systemPrompt": {
+            "type": "string",
+            "description": "The custom system prompt for the user",
+            "example": "Always respond in bullet points. I work in the finance department.",
+            "maxLength": 10000
+          }
+        },
+        "required": [
+          "systemPrompt"
+        ]
+      },
+      "CreatePromptDto": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string",
+            "description": "The title of the prompt",
+            "example": "Project Planning Assistant",
+            "minLength": 1,
+            "maxLength": 255
+          },
+          "content": {
+            "type": "string",
+            "description": "The content of the prompt",
+            "example": "You are a helpful assistant that helps with project planning. Please provide detailed step-by-step guidance for managing projects effectively."
+          }
+        },
+        "required": [
+          "title",
+          "content"
+        ]
+      },
+      "PromptResponseDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The unique identifier of the prompt",
+            "example": "123e4567-e89b-12d3-a456-426614174000",
+            "format": "uuid"
+          },
+          "title": {
+            "type": "string",
+            "description": "The title of the prompt",
+            "example": "Project Planning Assistant"
+          },
+          "content": {
+            "type": "string",
+            "description": "The content of the prompt",
+            "example": "You are a helpful assistant that helps with project planning. Please provide detailed step-by-step guidance for managing projects effectively."
+          },
+          "userId": {
+            "type": "string",
+            "description": "The unique identifier of the user who owns this prompt",
+            "example": "123e4567-e89b-12d3-a456-426614174000",
+            "format": "uuid"
+          },
+          "createdAt": {
+            "type": "string",
+            "description": "The date and time when the prompt was created",
+            "example": "2023-12-01T10:00:00.000Z",
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "type": "string",
+            "description": "The date and time when the prompt was last updated",
+            "example": "2023-12-01T10:00:00.000Z",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "id",
+          "title",
+          "content",
+          "userId",
+          "createdAt",
+          "updatedAt"
+        ]
+      },
+      "UpdatePromptDto": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string",
+            "description": "The title of the prompt",
+            "example": "Updated Project Planning Assistant",
+            "minLength": 1,
+            "maxLength": 255
+          },
+          "content": {
+            "type": "string",
+            "description": "The content of the prompt",
+            "example": "You are an expert project planning assistant. Provide comprehensive guidance for project management, including risk assessment and timeline optimization."
+          }
+        },
+        "required": [
+          "title",
+          "content"
+        ]
+      },
+      "TranscriptionResponseDto": {
+        "type": "object",
+        "properties": {
+          "text": {
+            "type": "string",
+            "description": "The transcribed text from the audio file",
+            "example": "Hello, this is a test transcription."
+          }
+        },
+        "required": [
+          "text"
+        ]
       },
       "LoginDto": {
         "type": "object",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the system prompt composition and adds automatic skill creation on `UserCreatedEvent`, which can affect model behavior and user provisioning if template data is wrong. Refactors marketplace skill installation to new unique-name creation logic, with potential edge cases around name collisions and activation.
> 
> **Overview**
> Adds support for **platform-wide “always-on” instructions** by fetching active `ALWAYS_ON` skill templates (cached) during run setup and injecting them into the system prompt as a new `<always_on_instructions>` section before agent/user instructions.
> 
> Introduces **pre-created copy distribution** for skill templates: on `UserCreatedEvent`, the system installs all active `PRE_CREATED_COPY` templates as user skills via a new `SkillTemplateInstallationService` (continues on per-template failure). Skill creation/name-collision handling is centralized in a new `CreateSkillWithUniqueNameUseCase`, and `MarketplaceSkillInstallationService` is updated to delegate to it.
> 
> Also updates Nest module wiring to include `SkillTemplatesModule` in runs, exports the always-on templates use case, and refreshes frontend generated OpenAPI/client types accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0e8e7ab0be1a82aa5bc9f084fba595ed9b96c142. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->