### PR TITLE
feat(AYC-103): add super admin skill templates frontend page

### DIFF
--- a/ayunis-core-frontend/src/app/routeTree.gen.ts
+++ b/ayunis-core-frontend/src/app/routeTree.gen.ts
@@ -42,6 +42,7 @@ import { Route as AuthenticatedAdminSettingsIntegrationsImport } from './routes/
 import { Route as onboardingPasswordResetImport } from './routes/(onboarding)/password.reset'
 import { Route as onboardingPasswordForgotImport } from './routes/(onboarding)/password.forgot'
 import { Route as AuthenticatedSuperAdminSettingsUsageIndexImport } from './routes/_authenticated/super-admin-settings.usage.index'
+import { Route as AuthenticatedSuperAdminSettingsSkillsIndexImport } from './routes/_authenticated/super-admin-settings.skills.index'
 import { Route as AuthenticatedSuperAdminSettingsOrgsIndexImport } from './routes/_authenticated/super-admin-settings.orgs.index'
 import { Route as AuthenticatedSuperAdminSettingsModelsCatalogIndexImport } from './routes/_authenticated/super-admin-settings.models-catalog.index'
 import { Route as AuthenticatedAdminSettingsTeamsIndexImport } from './routes/_authenticated/admin-settings.teams.index'
@@ -247,6 +248,13 @@ const AuthenticatedSuperAdminSettingsUsageIndexRoute =
   AuthenticatedSuperAdminSettingsUsageIndexImport.update({
     id: '/super-admin-settings/usage/',
     path: '/super-admin-settings/usage/',
+    getParentRoute: () => AuthenticatedRoute,
+  } as any)
+
+const AuthenticatedSuperAdminSettingsSkillsIndexRoute =
+  AuthenticatedSuperAdminSettingsSkillsIndexImport.update({
+    id: '/super-admin-settings/skills/',
+    path: '/super-admin-settings/skills/',
     getParentRoute: () => AuthenticatedRoute,
   } as any)
 
@@ -534,6 +542,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedSuperAdminSettingsOrgsIndexImport
       parentRoute: typeof AuthenticatedImport
     }
+    '/_authenticated/super-admin-settings/skills/': {
+      id: '/_authenticated/super-admin-settings/skills/'
+      path: '/super-admin-settings/skills'
+      fullPath: '/super-admin-settings/skills'
+      preLoaderRoute: typeof AuthenticatedSuperAdminSettingsSkillsIndexImport
+      parentRoute: typeof AuthenticatedImport
+    }
     '/_authenticated/super-admin-settings/usage/': {
       id: '/_authenticated/super-admin-settings/usage/'
       path: '/super-admin-settings/usage'
@@ -573,6 +588,7 @@ interface AuthenticatedRouteChildren {
   AuthenticatedAdminSettingsTeamsIndexRoute: typeof AuthenticatedAdminSettingsTeamsIndexRoute
   AuthenticatedSuperAdminSettingsModelsCatalogIndexRoute: typeof AuthenticatedSuperAdminSettingsModelsCatalogIndexRoute
   AuthenticatedSuperAdminSettingsOrgsIndexRoute: typeof AuthenticatedSuperAdminSettingsOrgsIndexRoute
+  AuthenticatedSuperAdminSettingsSkillsIndexRoute: typeof AuthenticatedSuperAdminSettingsSkillsIndexRoute
   AuthenticatedSuperAdminSettingsUsageIndexRoute: typeof AuthenticatedSuperAdminSettingsUsageIndexRoute
 }
 
@@ -610,6 +626,8 @@ const AuthenticatedRouteChildren: AuthenticatedRouteChildren = {
     AuthenticatedSuperAdminSettingsModelsCatalogIndexRoute,
   AuthenticatedSuperAdminSettingsOrgsIndexRoute:
     AuthenticatedSuperAdminSettingsOrgsIndexRoute,
+  AuthenticatedSuperAdminSettingsSkillsIndexRoute:
+    AuthenticatedSuperAdminSettingsSkillsIndexRoute,
   AuthenticatedSuperAdminSettingsUsageIndexRoute:
     AuthenticatedSuperAdminSettingsUsageIndexRoute,
 }
@@ -654,6 +672,7 @@ export interface FileRoutesByFullPath {
   '/admin-settings/teams': typeof AuthenticatedAdminSettingsTeamsIndexRoute
   '/super-admin-settings/models-catalog': typeof AuthenticatedSuperAdminSettingsModelsCatalogIndexRoute
   '/super-admin-settings/orgs': typeof AuthenticatedSuperAdminSettingsOrgsIndexRoute
+  '/super-admin-settings/skills': typeof AuthenticatedSuperAdminSettingsSkillsIndexRoute
   '/super-admin-settings/usage': typeof AuthenticatedSuperAdminSettingsUsageIndexRoute
 }
 
@@ -693,6 +712,7 @@ export interface FileRoutesByTo {
   '/admin-settings/teams': typeof AuthenticatedAdminSettingsTeamsIndexRoute
   '/super-admin-settings/models-catalog': typeof AuthenticatedSuperAdminSettingsModelsCatalogIndexRoute
   '/super-admin-settings/orgs': typeof AuthenticatedSuperAdminSettingsOrgsIndexRoute
+  '/super-admin-settings/skills': typeof AuthenticatedSuperAdminSettingsSkillsIndexRoute
   '/super-admin-settings/usage': typeof AuthenticatedSuperAdminSettingsUsageIndexRoute
 }
 
@@ -733,6 +753,7 @@ export interface FileRoutesById {
   '/_authenticated/admin-settings/teams/': typeof AuthenticatedAdminSettingsTeamsIndexRoute
   '/_authenticated/super-admin-settings/models-catalog/': typeof AuthenticatedSuperAdminSettingsModelsCatalogIndexRoute
   '/_authenticated/super-admin-settings/orgs/': typeof AuthenticatedSuperAdminSettingsOrgsIndexRoute
+  '/_authenticated/super-admin-settings/skills/': typeof AuthenticatedSuperAdminSettingsSkillsIndexRoute
   '/_authenticated/super-admin-settings/usage/': typeof AuthenticatedSuperAdminSettingsUsageIndexRoute
 }
 
@@ -774,6 +795,7 @@ export interface FileRouteTypes {
     | '/admin-settings/teams'
     | '/super-admin-settings/models-catalog'
     | '/super-admin-settings/orgs'
+    | '/super-admin-settings/skills'
     | '/super-admin-settings/usage'
   fileRoutesByTo: FileRoutesByTo
   to:
@@ -812,6 +834,7 @@ export interface FileRouteTypes {
     | '/admin-settings/teams'
     | '/super-admin-settings/models-catalog'
     | '/super-admin-settings/orgs'
+    | '/super-admin-settings/skills'
     | '/super-admin-settings/usage'
   id:
     | '__root__'
@@ -850,6 +873,7 @@ export interface FileRouteTypes {
     | '/_authenticated/admin-settings/teams/'
     | '/_authenticated/super-admin-settings/models-catalog/'
     | '/_authenticated/super-admin-settings/orgs/'
+    | '/_authenticated/super-admin-settings/skills/'
     | '/_authenticated/super-admin-settings/usage/'
   fileRoutesById: FileRoutesById
 }
@@ -931,6 +955,7 @@ export const routeTree = rootRoute
         "/_authenticated/admin-settings/teams/",
         "/_authenticated/super-admin-settings/models-catalog/",
         "/_authenticated/super-admin-settings/orgs/",
+        "/_authenticated/super-admin-settings/skills/",
         "/_authenticated/super-admin-settings/usage/"
       ]
     },
@@ -1057,6 +1082,10 @@ export const routeTree = rootRoute
     },
     "/_authenticated/super-admin-settings/orgs/": {
       "filePath": "_authenticated/super-admin-settings.orgs.index.tsx",
+      "parent": "/_authenticated"
+    },
+    "/_authenticated/super-admin-settings/skills/": {
+      "filePath": "_authenticated/super-admin-settings.skills.index.tsx",
       "parent": "/_authenticated"
     },
     "/_authenticated/super-admin-settings/usage/": {

--- a/ayunis-core-frontend/src/app/routes/_authenticated/super-admin-settings.skills.index.tsx
+++ b/ayunis-core-frontend/src/app/routes/_authenticated/super-admin-settings.skills.index.tsx
@@ -1,0 +1,25 @@
+import { createFileRoute } from '@tanstack/react-router';
+import SkillTemplatesPage from '@/pages/super-admin-settings/skill-templates';
+import {
+  getSuperAdminSkillTemplatesControllerFindAllQueryKey,
+  superAdminSkillTemplatesControllerFindAll,
+} from '@/shared/api';
+
+export const Route = createFileRoute(
+  '/_authenticated/super-admin-settings/skills/',
+)({
+  component: RouteComponent,
+  loader: async ({ context: { queryClient } }) => {
+    return {
+      skillTemplates: await queryClient.fetchQuery({
+        queryKey: getSuperAdminSkillTemplatesControllerFindAllQueryKey(),
+        queryFn: () => superAdminSkillTemplatesControllerFindAll(),
+      }),
+    };
+  },
+});
+
+function RouteComponent() {
+  const { skillTemplates } = Route.useLoaderData();
+  return <SkillTemplatesPage skillTemplates={skillTemplates} />;
+}

--- a/ayunis-core-frontend/src/i18n.ts
+++ b/ayunis-core-frontend/src/i18n.ts
@@ -46,6 +46,8 @@ import enSkill from './shared/locales/en/skill.json';
 import deSkill from './shared/locales/de/skill.json';
 import enKnowledgeBases from './shared/locales/en/knowledge-bases.json';
 import deKnowledgeBases from './shared/locales/de/knowledge-bases.json';
+import enSuperAdminSettingsSkills from './shared/locales/en/super-admin-settings-skills.json';
+import deSuperAdminSettingsSkills from './shared/locales/de/super-admin-settings-skills.json';
 
 const resources = {
   en: {
@@ -71,6 +73,7 @@ const resources = {
     skills: enSkills,
     skill: enSkill,
     'knowledge-bases': enKnowledgeBases,
+    'super-admin-settings-skills': enSuperAdminSettingsSkills,
   },
   de: {
     auth: deAuth,
@@ -95,6 +98,7 @@ const resources = {
     skills: deSkills,
     skill: deSkill,
     'knowledge-bases': deKnowledgeBases,
+    'super-admin-settings-skills': deSuperAdminSettingsSkills,
   },
 };
 

--- a/ayunis-core-frontend/src/pages/super-admin-settings/skill-templates/api/useCreateSkillTemplate.ts
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/skill-templates/api/useCreateSkillTemplate.ts
@@ -1,0 +1,52 @@
+import { useQueryClient } from '@tanstack/react-query';
+import { showSuccess, showError } from '@/shared/lib/toast';
+import {
+  useSuperAdminSkillTemplatesControllerCreate,
+  getSuperAdminSkillTemplatesControllerFindAllQueryKey,
+  type CreateSkillTemplateDto,
+} from '@/shared/api';
+import { useRouter } from '@tanstack/react-router';
+import { useTranslation } from 'react-i18next';
+import extractErrorData from '@/shared/api/extract-error-data';
+
+export function useCreateSkillTemplate(onSuccess?: () => void) {
+  const { t } = useTranslation('super-admin-settings-skills');
+  const queryClient = useQueryClient();
+  const router = useRouter();
+  const mutation = useSuperAdminSkillTemplatesControllerCreate({
+    mutation: {
+      onSuccess: async () => {
+        await queryClient.invalidateQueries({
+          queryKey: getSuperAdminSkillTemplatesControllerFindAllQueryKey(),
+        });
+        showSuccess(t('toast.createSuccess'));
+        onSuccess?.();
+      },
+      onError: (error: unknown) => {
+        console.error('Create skill template failed:', error);
+        try {
+          const { code } = extractErrorData(error);
+          if (code === 'DUPLICATE_SKILL_TEMPLATE_NAME') {
+            showError(t('toast.duplicateName'));
+          } else {
+            showError(t('toast.createError'));
+          }
+        } catch {
+          showError(t('toast.createError'));
+        }
+      },
+      onSettled: async () => {
+        await router.invalidate();
+      },
+    },
+  });
+
+  function createSkillTemplate(data: CreateSkillTemplateDto) {
+    mutation.mutate({ data });
+  }
+
+  return {
+    createSkillTemplate,
+    isCreating: mutation.isPending,
+  };
+}

--- a/ayunis-core-frontend/src/pages/super-admin-settings/skill-templates/api/useDeleteSkillTemplate.ts
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/skill-templates/api/useDeleteSkillTemplate.ts
@@ -1,0 +1,50 @@
+import { useQueryClient } from '@tanstack/react-query';
+import { showSuccess, showError } from '@/shared/lib/toast';
+import {
+  useSuperAdminSkillTemplatesControllerDelete,
+  getSuperAdminSkillTemplatesControllerFindAllQueryKey,
+} from '@/shared/api';
+import { useRouter } from '@tanstack/react-router';
+import { useTranslation } from 'react-i18next';
+import extractErrorData from '@/shared/api/extract-error-data';
+
+export function useDeleteSkillTemplate() {
+  const { t } = useTranslation('super-admin-settings-skills');
+  const queryClient = useQueryClient();
+  const router = useRouter();
+  const mutation = useSuperAdminSkillTemplatesControllerDelete({
+    mutation: {
+      onSuccess: async () => {
+        await queryClient.invalidateQueries({
+          queryKey: getSuperAdminSkillTemplatesControllerFindAllQueryKey(),
+        });
+        showSuccess(t('toast.deleteSuccess'));
+      },
+      onError: (error: unknown) => {
+        console.error('Delete skill template failed:', error);
+        try {
+          const { code } = extractErrorData(error);
+          if (code === 'SKILL_TEMPLATE_NOT_FOUND') {
+            showError(t('toast.notFound'));
+          } else {
+            showError(t('toast.deleteError'));
+          }
+        } catch {
+          showError(t('toast.deleteError'));
+        }
+      },
+      onSettled: async () => {
+        await router.invalidate();
+      },
+    },
+  });
+
+  function deleteSkillTemplate(id: string) {
+    mutation.mutate({ id });
+  }
+
+  return {
+    deleteSkillTemplate,
+    isDeleting: mutation.isPending,
+  };
+}

--- a/ayunis-core-frontend/src/pages/super-admin-settings/skill-templates/api/useUpdateSkillTemplate.ts
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/skill-templates/api/useUpdateSkillTemplate.ts
@@ -1,0 +1,54 @@
+import { useQueryClient } from '@tanstack/react-query';
+import { showSuccess, showError } from '@/shared/lib/toast';
+import {
+  useSuperAdminSkillTemplatesControllerUpdate,
+  getSuperAdminSkillTemplatesControllerFindAllQueryKey,
+  type UpdateSkillTemplateDto,
+} from '@/shared/api';
+import { useRouter } from '@tanstack/react-router';
+import { useTranslation } from 'react-i18next';
+import extractErrorData from '@/shared/api/extract-error-data';
+
+export function useUpdateSkillTemplate(onSuccess?: () => void) {
+  const { t } = useTranslation('super-admin-settings-skills');
+  const queryClient = useQueryClient();
+  const router = useRouter();
+  const mutation = useSuperAdminSkillTemplatesControllerUpdate({
+    mutation: {
+      onSuccess: async () => {
+        await queryClient.invalidateQueries({
+          queryKey: getSuperAdminSkillTemplatesControllerFindAllQueryKey(),
+        });
+        showSuccess(t('toast.updateSuccess'));
+        onSuccess?.();
+      },
+      onError: (error: unknown) => {
+        console.error('Update skill template failed:', error);
+        try {
+          const { code } = extractErrorData(error);
+          if (code === 'SKILL_TEMPLATE_NOT_FOUND') {
+            showError(t('toast.notFound'));
+          } else if (code === 'DUPLICATE_SKILL_TEMPLATE_NAME') {
+            showError(t('toast.duplicateName'));
+          } else {
+            showError(t('toast.updateError'));
+          }
+        } catch {
+          showError(t('toast.updateError'));
+        }
+      },
+      onSettled: async () => {
+        await router.invalidate();
+      },
+    },
+  });
+
+  function updateSkillTemplate(id: string, data: UpdateSkillTemplateDto) {
+    mutation.mutate({ id, data });
+  }
+
+  return {
+    updateSkillTemplate,
+    isUpdating: mutation.isPending,
+  };
+}

--- a/ayunis-core-frontend/src/pages/super-admin-settings/skill-templates/index.ts
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/skill-templates/index.ts
@@ -1,0 +1,1 @@
+export { default } from './ui/Page';

--- a/ayunis-core-frontend/src/pages/super-admin-settings/skill-templates/ui/CreateSkillTemplateDialog.tsx
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/skill-templates/ui/CreateSkillTemplateDialog.tsx
@@ -1,0 +1,44 @@
+import { useForm } from 'react-hook-form';
+import { useTranslation } from 'react-i18next';
+import { useCreateSkillTemplate } from '../api/useCreateSkillTemplate';
+import { SkillTemplateFormDialog } from './SkillTemplateFormDialog';
+import type { SkillTemplateFormData } from './SkillTemplateFormDialog';
+
+interface CreateSkillTemplateDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function CreateSkillTemplateDialog({
+  open,
+  onOpenChange,
+}: Readonly<CreateSkillTemplateDialogProps>) {
+  const { t } = useTranslation('super-admin-settings-skills');
+  const form = useForm<SkillTemplateFormData>({
+    defaultValues: {
+      name: '',
+      shortDescription: '',
+      instructions: '',
+      distributionMode: 'always_on',
+      isActive: false,
+    },
+  });
+
+  const { createSkillTemplate, isCreating } = useCreateSkillTemplate(() => {
+    onOpenChange(false);
+    form.reset();
+  });
+
+  return (
+    <SkillTemplateFormDialog
+      title={t('form.createTitle')}
+      open={open}
+      onOpenChange={onOpenChange}
+      form={form}
+      onSubmit={createSkillTemplate}
+      isSubmitting={isCreating}
+      submitLabel={t('form.create')}
+      submittingLabel={t('form.creating')}
+    />
+  );
+}

--- a/ayunis-core-frontend/src/pages/super-admin-settings/skill-templates/ui/EditSkillTemplateDialog.tsx
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/skill-templates/ui/EditSkillTemplateDialog.tsx
@@ -1,0 +1,66 @@
+import { useEffect } from 'react';
+import { useForm } from 'react-hook-form';
+import { useTranslation } from 'react-i18next';
+import type { SkillTemplateResponseDto } from '@/shared/api';
+import { useUpdateSkillTemplate } from '../api/useUpdateSkillTemplate';
+import { SkillTemplateFormDialog } from './SkillTemplateFormDialog';
+import type { SkillTemplateFormData } from './SkillTemplateFormDialog';
+
+interface EditSkillTemplateDialogProps {
+  template: SkillTemplateResponseDto | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function EditSkillTemplateDialog({
+  template,
+  open,
+  onOpenChange,
+}: Readonly<EditSkillTemplateDialogProps>) {
+  const { t } = useTranslation('super-admin-settings-skills');
+  const form = useForm<SkillTemplateFormData>({
+    defaultValues: {
+      name: '',
+      shortDescription: '',
+      instructions: '',
+      distributionMode: 'always_on',
+      isActive: false,
+    },
+  });
+
+  useEffect(() => {
+    if (template) {
+      form.reset({
+        name: template.name,
+        shortDescription: template.shortDescription,
+        instructions: template.instructions,
+        distributionMode: template.distributionMode,
+        isActive: template.isActive,
+      });
+    }
+  }, [template, form]);
+
+  const { updateSkillTemplate, isUpdating } = useUpdateSkillTemplate(() => {
+    onOpenChange(false);
+  });
+
+  function handleSubmit(data: SkillTemplateFormData) {
+    if (template) {
+      updateSkillTemplate(template.id, data);
+    }
+  }
+
+  return (
+    <SkillTemplateFormDialog
+      title={t('form.editTitle')}
+      open={open}
+      onOpenChange={onOpenChange}
+      form={form}
+      onSubmit={handleSubmit}
+      isSubmitting={isUpdating}
+      submitLabel={t('form.submit')}
+      submittingLabel={t('form.submitting')}
+      hasContent={!!template}
+    />
+  );
+}

--- a/ayunis-core-frontend/src/pages/super-admin-settings/skill-templates/ui/Page.tsx
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/skill-templates/ui/Page.tsx
@@ -1,0 +1,99 @@
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import type { SkillTemplateResponseDto } from '@/shared/api';
+import SuperAdminSettingsLayout from '../../super-admin-settings-layout';
+import { SkillTemplateItem } from './SkillTemplateItem';
+import { CreateSkillTemplateDialog } from './CreateSkillTemplateDialog';
+import { EditSkillTemplateDialog } from './EditSkillTemplateDialog';
+import { useDeleteSkillTemplate } from '../api/useDeleteSkillTemplate';
+import { useConfirmation } from '@/widgets/confirmation-modal';
+import { Button } from '@/shared/ui/shadcn/button';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/shared/ui/shadcn/card';
+import { ItemGroup, ItemSeparator } from '@/shared/ui/shadcn/item';
+import { Fragment } from 'react/jsx-runtime';
+
+interface SkillTemplatesPageProps {
+  skillTemplates: SkillTemplateResponseDto[];
+}
+
+export default function SkillTemplatesPage({
+  skillTemplates,
+}: Readonly<SkillTemplatesPageProps>) {
+  const { t } = useTranslation('super-admin-settings-skills');
+  const [createDialogOpen, setCreateDialogOpen] = useState(false);
+  const [editTemplate, setEditTemplate] =
+    useState<SkillTemplateResponseDto | null>(null);
+  const { deleteSkillTemplate, isDeleting } = useDeleteSkillTemplate();
+  const { confirm } = useConfirmation();
+
+  function handleDelete(template: SkillTemplateResponseDto) {
+    confirm({
+      title: t('delete.title'),
+      description: t('delete.description', { name: template.name }),
+      confirmText: t('delete.confirm'),
+      cancelText: t('delete.cancel'),
+      variant: 'destructive',
+      onConfirm: () => {
+        deleteSkillTemplate(template.id);
+      },
+    });
+  }
+
+  return (
+    <SuperAdminSettingsLayout
+      pageTitle={t('page.title')}
+      action={
+        <Button size="sm" onClick={() => setCreateDialogOpen(true)}>
+          {t('page.createButton')}
+        </Button>
+      }
+    >
+      <Card>
+        <CardHeader>
+          <CardTitle>{t('page.title')}</CardTitle>
+          <CardDescription>{t('page.description')}</CardDescription>
+        </CardHeader>
+        <CardContent>
+          {skillTemplates.length === 0 ? (
+            <div className="flex flex-col items-center justify-center space-y-2 py-10 text-center">
+              <h3 className="text-lg font-semibold">{t('page.empty')}</h3>
+              <p className="text-sm text-muted-foreground max-w-sm">
+                {t('page.emptyDescription')}
+              </p>
+            </div>
+          ) : (
+            <ItemGroup>
+              {skillTemplates.map((template, index) => (
+                <Fragment key={template.id}>
+                  <SkillTemplateItem
+                    template={template}
+                    onEdit={() => setEditTemplate(template)}
+                    onDelete={() => handleDelete(template)}
+                    isDeleting={isDeleting}
+                  />
+                  {index < skillTemplates.length - 1 && <ItemSeparator />}
+                </Fragment>
+              ))}
+            </ItemGroup>
+          )}
+        </CardContent>
+      </Card>
+
+      <CreateSkillTemplateDialog
+        open={createDialogOpen}
+        onOpenChange={setCreateDialogOpen}
+      />
+      <EditSkillTemplateDialog
+        template={editTemplate}
+        open={!!editTemplate}
+        onOpenChange={(open) => !open && setEditTemplate(null)}
+      />
+    </SuperAdminSettingsLayout>
+  );
+}

--- a/ayunis-core-frontend/src/pages/super-admin-settings/skill-templates/ui/SkillTemplateFormDialog.tsx
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/skill-templates/ui/SkillTemplateFormDialog.tsx
@@ -1,0 +1,216 @@
+import type { UseFormReturn } from 'react-hook-form';
+import { useTranslation } from 'react-i18next';
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/shared/ui/shadcn/dialog';
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/shared/ui/shadcn/form';
+import { Input } from '@/shared/ui/shadcn/input';
+import { Textarea } from '@/shared/ui/shadcn/textarea';
+import { Button } from '@/shared/ui/shadcn/button';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/shared/ui/shadcn/select';
+import { Switch } from '@/shared/ui/shadcn/switch';
+import type { CreateSkillTemplateDtoDistributionMode } from '@/shared/api';
+
+export interface SkillTemplateFormData {
+  name: string;
+  shortDescription: string;
+  instructions: string;
+  distributionMode: CreateSkillTemplateDtoDistributionMode;
+  isActive: boolean;
+}
+
+interface SkillTemplateFormDialogProps {
+  title: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  form: UseFormReturn<SkillTemplateFormData>;
+  onSubmit: (data: SkillTemplateFormData) => void;
+  isSubmitting: boolean;
+  submitLabel: string;
+  submittingLabel: string;
+  hasContent?: boolean;
+}
+
+export function SkillTemplateFormDialog({
+  title,
+  open,
+  onOpenChange,
+  form,
+  onSubmit,
+  isSubmitting,
+  submitLabel,
+  submittingLabel,
+  hasContent = true,
+}: Readonly<SkillTemplateFormDialogProps>) {
+  const { t } = useTranslation('super-admin-settings-skills');
+
+  const handleOpenChange = (newOpen: boolean) => {
+    if (!newOpen && !isSubmitting) {
+      form.reset();
+    }
+    onOpenChange(newOpen);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      {hasContent && (
+        <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-[525px]">
+          <DialogHeader>
+            <DialogTitle>{title}</DialogTitle>
+          </DialogHeader>
+          <Form {...form}>
+            <form
+              onSubmit={(e) => void form.handleSubmit(onSubmit)(e)}
+              className="space-y-4"
+            >
+              <FormField
+                control={form.control}
+                name="name"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>{t('form.name')}</FormLabel>
+                    <FormControl>
+                      <Input
+                        {...field}
+                        placeholder={t('form.namePlaceholder')}
+                        disabled={isSubmitting}
+                        required
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="shortDescription"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>{t('form.shortDescription')}</FormLabel>
+                    <FormControl>
+                      <Input
+                        {...field}
+                        placeholder={t('form.shortDescriptionPlaceholder')}
+                        disabled={isSubmitting}
+                        required
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="instructions"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>{t('form.instructions')}</FormLabel>
+                    <FormControl>
+                      <Textarea
+                        {...field}
+                        placeholder={t('form.instructionsPlaceholder')}
+                        disabled={isSubmitting}
+                        rows={6}
+                        required
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="distributionMode"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>{t('form.distributionMode')}</FormLabel>
+                    <Select
+                      onValueChange={field.onChange}
+                      value={field.value}
+                      disabled={isSubmitting}
+                    >
+                      <FormControl>
+                        <SelectTrigger>
+                          <SelectValue />
+                        </SelectTrigger>
+                      </FormControl>
+                      <SelectContent>
+                        <SelectItem value="always_on">
+                          {t('distributionMode.always_on')}
+                        </SelectItem>
+                        <SelectItem value="pre_created_copy">
+                          {t('distributionMode.pre_created_copy')}
+                        </SelectItem>
+                      </SelectContent>
+                    </Select>
+                    <FormDescription>
+                      {t(`distributionMode.${field.value}_description`)}
+                    </FormDescription>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="isActive"
+                render={({ field }) => (
+                  <FormItem className="flex flex-row items-center justify-between rounded-lg border p-3">
+                    <div className="space-y-0.5">
+                      <FormLabel>{t('form.isActive')}</FormLabel>
+                      <FormDescription>
+                        {t('form.isActiveDescription')}
+                      </FormDescription>
+                    </div>
+                    <FormControl>
+                      <Switch
+                        checked={field.value}
+                        onCheckedChange={field.onChange}
+                        disabled={isSubmitting}
+                      />
+                    </FormControl>
+                  </FormItem>
+                )}
+              />
+
+              <DialogFooter>
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => handleOpenChange(false)}
+                  disabled={isSubmitting}
+                >
+                  {t('form.cancel')}
+                </Button>
+                <Button type="submit" disabled={isSubmitting}>
+                  {isSubmitting ? submittingLabel : submitLabel}
+                </Button>
+              </DialogFooter>
+            </form>
+          </Form>
+        </DialogContent>
+      )}
+    </Dialog>
+  );
+}

--- a/ayunis-core-frontend/src/pages/super-admin-settings/skill-templates/ui/SkillTemplateItem.tsx
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/skill-templates/ui/SkillTemplateItem.tsx
@@ -1,0 +1,66 @@
+import { useTranslation } from 'react-i18next';
+import type { SkillTemplateResponseDto } from '@/shared/api';
+import {
+  Item,
+  ItemContent,
+  ItemDescription,
+  ItemTitle,
+  ItemActions,
+} from '@/shared/ui/shadcn/item';
+import { Badge } from '@/shared/ui/shadcn/badge';
+import { Button } from '@/shared/ui/shadcn/button';
+import { Pencil, Trash2 } from 'lucide-react';
+
+interface SkillTemplateItemProps {
+  template: SkillTemplateResponseDto;
+  onEdit: () => void;
+  onDelete: () => void;
+  isDeleting: boolean;
+}
+
+export function SkillTemplateItem({
+  template,
+  onEdit,
+  onDelete,
+  isDeleting,
+}: Readonly<SkillTemplateItemProps>) {
+  const { t } = useTranslation('super-admin-settings-skills');
+
+  return (
+    <Item>
+      <ItemContent>
+        <ItemTitle>
+          {template.name}
+          <Badge
+            variant={template.isActive ? 'default' : 'secondary'}
+            className="ml-2"
+          >
+            {template.isActive ? t('status.active') : t('status.inactive')}
+          </Badge>
+        </ItemTitle>
+        <ItemDescription>{template.shortDescription}</ItemDescription>
+      </ItemContent>
+      <ItemContent>
+        <div className="flex flex-wrap gap-1.5">
+          <Badge variant="outline">
+            {t(`distributionMode.${template.distributionMode}`)}
+          </Badge>
+        </div>
+      </ItemContent>
+      <ItemActions>
+        <Button variant="ghost" size="icon" onClick={onEdit}>
+          <Pencil className="h-4 w-4" />
+        </Button>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="text-destructive hover:text-destructive"
+          onClick={onDelete}
+          disabled={isDeleting}
+        >
+          <Trash2 className="h-4 w-4" />
+        </Button>
+      </ItemActions>
+    </Item>
+  );
+}

--- a/ayunis-core-frontend/src/pages/super-admin-settings/super-admin-settings-layout/ui/SuperAdminSettingsSidebar.tsx
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/super-admin-settings-layout/ui/SuperAdminSettingsSidebar.tsx
@@ -1,4 +1,4 @@
-import { Building2, Brain, BarChart3 } from 'lucide-react';
+import { Building2, Brain, BarChart3, Sparkles } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import {
   SettingsSidebarWidget,
@@ -23,6 +23,11 @@ export function SuperAdminSettingsSidebar() {
       to: '/super-admin-settings/usage',
       icon: <BarChart3 />,
       label: t('layout.usage'),
+    },
+    {
+      to: '/super-admin-settings/skills',
+      icon: <Sparkles />,
+      label: t('layout.skills'),
     },
   ];
 

--- a/ayunis-core-frontend/src/shared/locales/de/super-admin-settings-layout.json
+++ b/ayunis-core-frontend/src/shared/locales/de/super-admin-settings-layout.json
@@ -6,6 +6,7 @@
     "settings": "Einstellungen",
     "orgs": "Organisationen",
     "modelsCatalog": "Model-Katalog",
-    "usage": "Nutzung"
+    "usage": "Nutzung",
+    "skills": "Skill-Vorlagen"
   }
 }

--- a/ayunis-core-frontend/src/shared/locales/de/super-admin-settings-skills.json
+++ b/ayunis-core-frontend/src/shared/locales/de/super-admin-settings-skills.json
@@ -1,0 +1,53 @@
+{
+  "page": {
+    "title": "Skill-Vorlagen",
+    "description": "Verwalten Sie Skill-Vorlagen, die an alle Benutzer in allen Organisationen verteilt werden.",
+    "empty": "Keine Skill-Vorlagen",
+    "emptyDescription": "Erstellen Sie Ihre erste Skill-Vorlage, um zu beginnen.",
+    "createButton": "Vorlage erstellen"
+  },
+  "form": {
+    "createTitle": "Skill-Vorlage erstellen",
+    "editTitle": "Skill-Vorlage bearbeiten",
+    "name": "Name",
+    "namePlaceholder": "z.B. Kundenservice-Richtlinien",
+    "shortDescription": "Kurzbeschreibung",
+    "shortDescriptionPlaceholder": "Eine kurze Beschreibung dieser Vorlage",
+    "instructions": "Anweisungen",
+    "instructionsPlaceholder": "Geben Sie die Prompt-Anweisungen für diese Skill-Vorlage ein...",
+    "distributionMode": "Verteilungsmodus",
+    "isActive": "Aktiv",
+    "isActiveDescription": "Aktive Vorlagen werden an Benutzer verteilt. Inaktive Vorlagen sind Entwürfe.",
+    "submit": "Speichern",
+    "submitting": "Wird gespeichert...",
+    "create": "Erstellen",
+    "creating": "Wird erstellt...",
+    "cancel": "Abbrechen"
+  },
+  "distributionMode": {
+    "always_on": "Immer aktiv",
+    "pre_created_copy": "Vorkonfigurierte Kopie",
+    "always_on_description": "Anweisungen werden in den System-Prompt jeder Ausführung eingefügt",
+    "pre_created_copy_description": "Wird bei der Kontoerstellung in die Skills jedes neuen Benutzers kopiert"
+  },
+  "status": {
+    "active": "Aktiv",
+    "inactive": "Inaktiv"
+  },
+  "toast": {
+    "createSuccess": "Skill-Vorlage erfolgreich erstellt",
+    "createError": "Skill-Vorlage konnte nicht erstellt werden",
+    "updateSuccess": "Skill-Vorlage erfolgreich aktualisiert",
+    "updateError": "Skill-Vorlage konnte nicht aktualisiert werden",
+    "deleteSuccess": "Skill-Vorlage erfolgreich gelöscht",
+    "deleteError": "Skill-Vorlage konnte nicht gelöscht werden",
+    "duplicateName": "Eine Skill-Vorlage mit diesem Namen existiert bereits",
+    "notFound": "Skill-Vorlage nicht gefunden"
+  },
+  "delete": {
+    "title": "Skill-Vorlage löschen",
+    "description": "Möchten Sie \"{{name}}\" wirklich löschen? Diese Aktion kann nicht rückgängig gemacht werden.",
+    "confirm": "Löschen",
+    "cancel": "Abbrechen"
+  }
+}

--- a/ayunis-core-frontend/src/shared/locales/en/super-admin-settings-layout.json
+++ b/ayunis-core-frontend/src/shared/locales/en/super-admin-settings-layout.json
@@ -6,6 +6,7 @@
     "settings": "Settings",
     "orgs": "Organizations",
     "modelsCatalog": "Models Catalog",
-    "usage": "Usage"
+    "usage": "Usage",
+    "skills": "Skill Templates"
   }
 }

--- a/ayunis-core-frontend/src/shared/locales/en/super-admin-settings-skills.json
+++ b/ayunis-core-frontend/src/shared/locales/en/super-admin-settings-skills.json
@@ -1,0 +1,53 @@
+{
+  "page": {
+    "title": "Skill Templates",
+    "description": "Manage skill templates that are distributed to all users across all organizations.",
+    "empty": "No skill templates",
+    "emptyDescription": "Create your first skill template to get started.",
+    "createButton": "Create Template"
+  },
+  "form": {
+    "createTitle": "Create Skill Template",
+    "editTitle": "Edit Skill Template",
+    "name": "Name",
+    "namePlaceholder": "e.g., Customer Service Guidelines",
+    "shortDescription": "Short Description",
+    "shortDescriptionPlaceholder": "A brief description of what this template does",
+    "instructions": "Instructions",
+    "instructionsPlaceholder": "Enter the prompt instructions for this skill template...",
+    "distributionMode": "Distribution Mode",
+    "isActive": "Active",
+    "isActiveDescription": "Active templates are distributed to users. Inactive templates are drafts.",
+    "submit": "Save",
+    "submitting": "Saving...",
+    "create": "Create",
+    "creating": "Creating...",
+    "cancel": "Cancel"
+  },
+  "distributionMode": {
+    "always_on": "Always On",
+    "pre_created_copy": "Pre-created Copy",
+    "always_on_description": "Instructions injected into every run's system prompt",
+    "pre_created_copy_description": "Cloned into each new user's skills on account creation"
+  },
+  "status": {
+    "active": "Active",
+    "inactive": "Inactive"
+  },
+  "toast": {
+    "createSuccess": "Skill template created successfully",
+    "createError": "Failed to create skill template",
+    "updateSuccess": "Skill template updated successfully",
+    "updateError": "Failed to update skill template",
+    "deleteSuccess": "Skill template deleted successfully",
+    "deleteError": "Failed to delete skill template",
+    "duplicateName": "A skill template with this name already exists",
+    "notFound": "Skill template not found"
+  },
+  "delete": {
+    "title": "Delete Skill Template",
+    "description": "Are you sure you want to delete \"{{name}}\"? This action cannot be undone.",
+    "confirm": "Delete",
+    "cancel": "Cancel"
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds new super-admin CRUD UI and mutations for skill templates, which can affect administrative configuration and depends on correct cache invalidation/error handling. Risk is limited to the super-admin settings surface area and is primarily frontend routing/state management.
> 
> **Overview**
> Adds a new super-admin route `/_authenticated/super-admin-settings/skills/` (surfaced as `/super-admin-settings/skills`) that loads skill templates via React Query and renders a new Skill Templates management page.
> 
> The new page provides list/empty states plus create/edit dialogs and delete confirmation, wiring up `create/update/delete` mutations with cache invalidation, router invalidation, and translated success/error toasts (including specific handling for duplicate-name and not-found errors). Navigation and localization are updated by adding a “Skill Templates” item to the super-admin sidebar and introducing the `super-admin-settings-skills` i18n namespace (EN/DE).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e77243b3d481c13f5dde5f6b156ed808565b6614. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->