### PR TITLE
feat(AYC-000): add help button to new chat page

### DIFF
--- a/ayunis-core-frontend/src/pages/new-chat/ui/NewChatPage.tsx
+++ b/ayunis-core-frontend/src/pages/new-chat/ui/NewChatPage.tsx
@@ -4,6 +4,7 @@ import { useInitiateChat } from '../api/useInitiateChat';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import ContentAreaHeader from '@/widgets/content-area-header/ui/ContentAreaHeader';
+import { HelpLink } from '@/shared/ui/help-link/HelpLink';
 import { showError } from '@/shared/lib/toast';
 import { generateUUID } from '@/shared/lib/uuid';
 import type { AgentResponseDto } from '@/shared/api';
@@ -139,7 +140,12 @@ export default function NewChatPage({
 
   return (
     <NewChatPageLayout
-      header={<ContentAreaHeader title={t('newChat.newChat')} />}
+      header={
+        <ContentAreaHeader
+          title={t('newChat.newChat')}
+          action={<HelpLink path="" />}
+        />
+      }
     >
       <div className="text-center">
         <h1 className="text-2xl font-bold">{greeting}</h1>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk UI-only change that adds a Help Center link to the `NewChatPage` header; no changes to chat initiation or data handling.
> 
> **Overview**
> Adds a `HelpLink` action to the `ContentAreaHeader` on `NewChatPage`, exposing a Help Center link (opens in a new tab) directly from the new chat screen.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f8b63c9e214a29b065ed59b37b935647c7141692. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->