### PR TITLE
wip(AYC-103): add skill slug utilities and refactor system prompt builder and activate skill tool to use slugified skill names

### DIFF
--- a/ayunis-core-backend/src/common/util/skill-slug.spec.ts
+++ b/ayunis-core-backend/src/common/util/skill-slug.spec.ts
@@ -1,0 +1,135 @@
+import {
+  slugify,
+  buildSkillSlug,
+  parseSkillSlug,
+  buildSlugMap,
+  SlugCollisionError,
+  SYSTEM_PREFIX,
+  USER_PREFIX,
+} from './skill-slug';
+
+describe('skill-slug', () => {
+  describe('slugify', () => {
+    it('should produce lowercase hyphenated strings', () => {
+      expect(slugify('German Administrative Law')).toBe(
+        'german-administrative-law',
+      );
+    });
+
+    it('should strip leading and trailing hyphens', () => {
+      expect(slugify('  Hello World  ')).toBe('hello-world');
+    });
+
+    it('should replace special characters with hyphens', () => {
+      expect(slugify('QA & Testing (v2)')).toBe('qa-testing-v2');
+    });
+
+    it('should collapse multiple separators into one hyphen', () => {
+      expect(slugify('foo---bar')).toBe('foo-bar');
+    });
+
+    it('should transliterate German umlauts to ASCII equivalents (DIN 5007-2)', () => {
+      expect(slugify('Bürgerbüro Anfragen')).toBe('buergerbuero-anfragen');
+    });
+
+    it('should distinguish umlauts from base vowels', () => {
+      expect(slugify('Bürger')).toBe('buerger');
+      expect(slugify('Burger')).toBe('burger');
+    });
+
+    it('should transliterate uppercase umlauts', () => {
+      expect(slugify('Über Öffentliche Ämter')).toBe(
+        'ueber-oeffentliche-aemter',
+      );
+    });
+
+    it('should replace German ß with ss', () => {
+      expect(slugify('Straßenverkehr')).toBe('strassenverkehr');
+    });
+
+    it('should throw on empty input', () => {
+      expect(() => slugify('')).toThrow('slugify produced an empty slug');
+    });
+
+    it('should throw on special-char-only input', () => {
+      expect(() => slugify('!!!')).toThrow('slugify produced an empty slug');
+    });
+  });
+
+  describe('buildSkillSlug', () => {
+    it('should prefix with system__', () => {
+      expect(buildSkillSlug(SYSTEM_PREFIX, 'Data Privacy')).toBe(
+        'system__data-privacy',
+      );
+    });
+
+    it('should prefix with user__', () => {
+      expect(buildSkillSlug(USER_PREFIX, 'Data Analysis')).toBe(
+        'user__data-analysis',
+      );
+    });
+  });
+
+  describe('parseSkillSlug', () => {
+    it('should split system__ prefix correctly', () => {
+      const result = parseSkillSlug('system__data-privacy');
+      expect(result).toEqual({ prefix: 'system', slug: 'data-privacy' });
+    });
+
+    it('should split user__ prefix correctly', () => {
+      const result = parseSkillSlug('user__data-analysis');
+      expect(result).toEqual({ prefix: 'user', slug: 'data-analysis' });
+    });
+
+    it('should throw on missing prefix', () => {
+      expect(() => parseSkillSlug('data-analysis')).toThrow(
+        'Invalid skill slug: missing prefix',
+      );
+    });
+
+    it('should throw on invalid prefix', () => {
+      expect(() => parseSkillSlug('admin__some-skill')).toThrow(
+        'Invalid skill slug: missing prefix',
+      );
+    });
+
+    it('should throw on empty slug after prefix', () => {
+      expect(() => parseSkillSlug('system__')).toThrow(
+        'Invalid skill slug: empty slug after prefix',
+      );
+      expect(() => parseSkillSlug('user__')).toThrow(
+        'Invalid skill slug: empty slug after prefix',
+      );
+    });
+  });
+
+  describe('buildSlugMap', () => {
+    it('should build a map from slug to original name', () => {
+      const map = buildSlugMap([
+        { name: 'Data Privacy', prefix: SYSTEM_PREFIX },
+        { name: 'Budget Analysis', prefix: USER_PREFIX },
+      ]);
+
+      expect(map.get('system__data-privacy')).toBe('Data Privacy');
+      expect(map.get('user__budget-analysis')).toBe('Budget Analysis');
+    });
+
+    it('should throw SlugCollisionError when two different names produce the same slug', () => {
+      expect(() =>
+        buildSlugMap([
+          { name: 'Foo Bar', prefix: SYSTEM_PREFIX },
+          { name: 'foo-bar', prefix: SYSTEM_PREFIX },
+        ]),
+      ).toThrow(SlugCollisionError);
+    });
+
+    it('should allow duplicate entries with the same name', () => {
+      const map = buildSlugMap([
+        { name: 'Data Privacy', prefix: SYSTEM_PREFIX },
+        { name: 'Data Privacy', prefix: SYSTEM_PREFIX },
+      ]);
+
+      expect(map.size).toBe(1);
+    });
+  });
+});

--- a/ayunis-core-backend/src/common/util/skill-slug.ts
+++ b/ayunis-core-backend/src/common/util/skill-slug.ts
@@ -1,0 +1,97 @@
+export const SYSTEM_PREFIX = 'system';
+export const USER_PREFIX = 'user';
+
+const SLUG_SEPARATOR = '__';
+
+export type SkillPrefix = typeof SYSTEM_PREFIX | typeof USER_PREFIX;
+
+export interface SkillEntry {
+  slug: string;
+  description: string;
+}
+
+export function slugify(name: string): string {
+  const result = name
+    .replace(/ä/g, 'ae')
+    .replace(/Ä/g, 'Ae')
+    .replace(/ö/g, 'oe')
+    .replace(/Ö/g, 'Oe')
+    .replace(/ü/g, 'ue')
+    .replace(/Ü/g, 'Ue')
+    .replace(/ß/g, 'ss')
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]/g, '-')
+    .replace(/-{2,}/g, '-')
+    .replace(/^-/, '')
+    .replace(/-$/, '');
+
+  if (result === '') {
+    throw new Error(`slugify produced an empty slug for input: "${name}"`);
+  }
+
+  return result;
+}
+
+export function buildSkillSlug(prefix: SkillPrefix, name: string): string {
+  return `${prefix}${SLUG_SEPARATOR}${slugify(name)}`;
+}
+
+export interface ParsedSkillSlug {
+  prefix: SkillPrefix;
+  slug: string;
+}
+
+export function parseSkillSlug(slug: string): ParsedSkillSlug {
+  const systemFull = `${SYSTEM_PREFIX}${SLUG_SEPARATOR}`;
+  const userFull = `${USER_PREFIX}${SLUG_SEPARATOR}`;
+
+  let prefix: SkillPrefix | undefined;
+  let remainder: string | undefined;
+
+  if (slug.startsWith(systemFull)) {
+    prefix = SYSTEM_PREFIX;
+    remainder = slug.slice(systemFull.length);
+  } else if (slug.startsWith(userFull)) {
+    prefix = USER_PREFIX;
+    remainder = slug.slice(userFull.length);
+  }
+
+  if (prefix === undefined || remainder === undefined) {
+    throw new Error(`Invalid skill slug: missing prefix in "${slug}"`);
+  }
+
+  if (remainder === '') {
+    throw new Error(`Invalid skill slug: empty slug after prefix in "${slug}"`);
+  }
+
+  return { prefix, slug: remainder };
+}
+
+export class SlugCollisionError extends Error {
+  constructor(slug: string, existingName: string, newName: string) {
+    super(
+      `Slug collision: "${existingName}" and "${newName}" both produce slug "${slug}"`,
+    );
+    this.name = 'SlugCollisionError';
+  }
+}
+
+export function buildSlugMap(
+  entries: { name: string; prefix: SkillPrefix }[],
+): Map<string, string> {
+  const slugToName = new Map<string, string>();
+
+  for (const entry of entries) {
+    const slug = buildSkillSlug(entry.prefix, entry.name);
+    const existing = slugToName.get(slug);
+    if (existing !== undefined && existing !== entry.name) {
+      throw new SlugCollisionError(slug, existing, entry.name);
+    }
+    slugToName.set(slug, entry.name);
+  }
+
+  return slugToName;
+}

--- a/ayunis-core-backend/src/domain/runs/application/services/system-prompt-builder.service.spec.ts
+++ b/ayunis-core-backend/src/domain/runs/application/services/system-prompt-builder.service.spec.ts
@@ -1,6 +1,5 @@
+import type { SkillEntry } from 'src/common/util/skill-slug';
 import { SystemPromptBuilderService } from './system-prompt-builder.service';
-import { Skill } from 'src/domain/skills/domain/skill.entity';
-import { randomUUID } from 'crypto';
 
 describe('SystemPromptBuilderService', () => {
   let service: SystemPromptBuilderService;
@@ -11,23 +10,15 @@ describe('SystemPromptBuilderService', () => {
 
   describe('skills section', () => {
     it('should include available_skills section when active skills are provided', () => {
-      const skills: Skill[] = [
-        new Skill({
-          id: randomUUID(),
-          name: 'German Administrative Law',
-          shortDescription:
-            'Knowledge about German administrative law procedures',
-          instructions: 'Full instructions here...',
-          userId: randomUUID(),
-        }),
-        new Skill({
-          id: randomUUID(),
-          name: 'Data Analysis',
-          shortDescription:
-            'Analyze datasets and produce statistical summaries',
-          instructions: 'Full data analysis instructions...',
-          userId: randomUUID(),
-        }),
+      const skills: SkillEntry[] = [
+        {
+          slug: 'user__german-administrative-law',
+          description: 'Knowledge about German administrative law procedures',
+        },
+        {
+          slug: 'system__data-analysis',
+          description: 'Analyze datasets and produce statistical summaries',
+        },
       ];
 
       const result = service.build({
@@ -39,11 +30,11 @@ describe('SystemPromptBuilderService', () => {
       expect(result).toContain('<available_skills>');
       expect(result).toContain('</available_skills>');
       expect(result).toContain('<skill>');
-      expect(result).toContain('<name>German Administrative Law</name>');
+      expect(result).toContain('<name>user__german-administrative-law</name>');
       expect(result).toContain(
         '<description>Knowledge about German administrative law procedures</description>',
       );
-      expect(result).toContain('<name>Data Analysis</name>');
+      expect(result).toContain('<name>system__data-analysis</name>');
       expect(result).toContain(
         '<description>Analyze datasets and produce statistical summaries</description>',
       );
@@ -66,6 +57,26 @@ describe('SystemPromptBuilderService', () => {
       });
 
       expect(result).not.toContain('<available_skills>');
+    });
+
+    it('should escape XML characters in skill descriptions', () => {
+      const skills: SkillEntry[] = [
+        {
+          slug: 'user__qa-helper',
+          description: 'Handles <special> "quoted" queries & more',
+        },
+      ];
+
+      const result = service.build({
+        tools: [],
+        currentTime: new Date('2026-01-15T10:00:00Z'),
+        skills,
+      });
+
+      expect(result).toContain('<name>user__qa-helper</name>');
+      expect(result).toContain(
+        '<description>Handles &lt;special&gt; &quot;quoted&quot; queries &amp; more</description>',
+      );
     });
   });
 
@@ -134,89 +145,6 @@ describe('SystemPromptBuilderService', () => {
       const readyPos = result.indexOf('You are now ready to assist the user.');
       expect(userPos).toBeGreaterThan(-1);
       expect(readyPos).toBeGreaterThan(userPos);
-    });
-  });
-
-  describe('skills section (continued)', () => {
-    it('should escape XML characters in skill names and descriptions', () => {
-      const skills: Skill[] = [
-        new Skill({
-          id: randomUUID(),
-          name: 'QA Helper',
-          shortDescription: 'Handles <special> "quoted" queries & more',
-          instructions: 'Instructions...',
-          userId: randomUUID(),
-        }),
-      ];
-
-      const result = service.build({
-        tools: [],
-        currentTime: new Date('2026-01-15T10:00:00Z'),
-        skills,
-      });
-
-      expect(result).toContain('<name>QA Helper</name>');
-      expect(result).toContain(
-        '<description>Handles &lt;special&gt; &quot;quoted&quot; queries &amp; more</description>',
-      );
-    });
-  });
-
-  describe('always-on instructions section', () => {
-    it('should include always_on_instructions section when instructions are provided', () => {
-      const result = service.build({
-        tools: [],
-        currentTime: new Date('2026-01-15T10:00:00Z'),
-        alwaysOnInstructions: [
-          'Always be polite and professional.',
-          'Never share personal data across conversations.',
-        ],
-      });
-
-      expect(result).toContain('<always_on_instructions>');
-      expect(result).toContain('Always be polite and professional.');
-      expect(result).toContain(
-        'Never share personal data across conversations.',
-      );
-      expect(result).toContain('</always_on_instructions>');
-    });
-
-    it('should not include always_on_instructions section when no instructions are provided', () => {
-      const result = service.build({
-        tools: [],
-        currentTime: new Date('2026-01-15T10:00:00Z'),
-      });
-
-      expect(result).not.toContain('<always_on_instructions>');
-    });
-
-    it('should not include always_on_instructions section when instructions array is empty', () => {
-      const result = service.build({
-        tools: [],
-        currentTime: new Date('2026-01-15T10:00:00Z'),
-        alwaysOnInstructions: [],
-      });
-
-      expect(result).not.toContain('<always_on_instructions>');
-    });
-
-    it('should place always_on_instructions before agent_instructions', () => {
-      const agent = {
-        instructions: 'Agent-level instructions here',
-      } as any;
-
-      const result = service.build({
-        agent,
-        tools: [],
-        currentTime: new Date('2026-01-15T10:00:00Z'),
-        alwaysOnInstructions: ['Platform-level instructions here'],
-      });
-
-      const alwaysOnPos = result.indexOf('<always_on_instructions>');
-      const agentPos = result.indexOf('<agent_instructions>');
-      expect(alwaysOnPos).toBeGreaterThan(-1);
-      expect(agentPos).toBeGreaterThan(-1);
-      expect(alwaysOnPos).toBeLessThan(agentPos);
     });
   });
 });

--- a/ayunis-core-backend/src/domain/runs/application/services/system-prompt-builder.service.ts
+++ b/ayunis-core-backend/src/domain/runs/application/services/system-prompt-builder.service.ts
@@ -12,16 +12,16 @@ import {
   DataSource,
   CSVDataSource,
 } from 'src/domain/sources/domain/sources/data-source.entity';
-import { Skill } from 'src/domain/skills/domain/skill.entity';
 import type { KnowledgeBaseSummary } from 'src/domain/knowledge-bases/domain/knowledge-base-summary';
+import type { SkillEntry } from 'src/common/util/skill-slug';
+
 export interface SystemPromptBuildParams {
   agent?: Agent;
   tools: Tool[];
   currentTime: Date;
   sources?: Source[];
-  skills?: Skill[];
+  skills?: SkillEntry[];
   knowledgeBases?: KnowledgeBaseSummary[];
-  alwaysOnInstructions?: string[];
   userSystemPrompt?: string;
 }
 
@@ -35,14 +35,12 @@ export class SystemPromptBuilderService {
       sources = [],
       skills = [],
       knowledgeBases = [],
-      alwaysOnInstructions = [],
       userSystemPrompt,
     } = params;
 
     const sections = [
       this.buildPreamble(currentTime),
       this.buildBehaviorInstructions(),
-      this.buildAlwaysOnInstructionsSection(alwaysOnInstructions),
       this.buildToolUsageSection(tools),
       this.buildSkillsSection(skills),
       this.buildFilesSection(sources),
@@ -50,8 +48,12 @@ export class SystemPromptBuilderService {
       this.buildDataHandlingSection(),
       this.buildResponseGuidelines(),
       this.buildPlatformSection(),
-      this.buildOptionalAgentInstructions(agent),
-      this.buildOptionalUserInstructions(userSystemPrompt),
+      agent?.instructions
+        ? this.buildAgentInstructionsSection(agent.instructions)
+        : '',
+      userSystemPrompt
+        ? this.buildUserInstructionsSection(userSystemPrompt)
+        : '',
       'You are now ready to assist the user.',
     ];
 
@@ -218,30 +220,6 @@ For technical questions about the platform, configuration, or deployment, users 
     return toolSections;
   }
 
-  private buildAlwaysOnInstructionsSection(instructions: string[]): string {
-    if (instructions.length === 0) {
-      return '';
-    }
-
-    const entries = instructions.join('\n\n');
-
-    return `<always_on_instructions>\n${entries}\n</always_on_instructions>`;
-  }
-
-  private buildOptionalAgentInstructions(agent?: Agent): string {
-    return agent?.instructions
-      ? this.buildAgentInstructionsSection(agent.instructions)
-      : '';
-  }
-
-  private buildOptionalUserInstructions(
-    userSystemPrompt?: string,
-  ): string {
-    return userSystemPrompt
-      ? this.buildUserInstructionsSection(userSystemPrompt)
-      : '';
-  }
-
   private buildAgentInstructionsSection(instructions: string): string {
     return `
 <agent_instructions>
@@ -258,7 +236,7 @@ ${userSystemPrompt}
 `;
   }
 
-  private buildSkillsSection(skills: Skill[]): string {
+  private buildSkillsSection(skills: SkillEntry[]): string {
     if (skills.length === 0) {
       return '';
     }
@@ -266,7 +244,7 @@ ${userSystemPrompt}
     const skillEntries = skills
       .map(
         (skill) =>
-          `  <skill>\n    <name>${this.escapeXml(skill.name)}</name>\n    <description>${this.escapeXml(skill.shortDescription)}</description>\n  </skill>`,
+          `  <skill>\n    <name>${this.escapeXml(skill.slug)}</name>\n    <description>${this.escapeXml(skill.description)}</description>\n  </skill>`,
       )
       .join('\n');
 

--- a/ayunis-core-backend/src/domain/runs/application/use-cases/execute-run/execute-run.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/runs/application/use-cases/execute-run/execute-run.use-case.spec.ts
@@ -226,7 +226,7 @@ describe('ExecuteRunUseCase', () => {
             type: 'tool_use',
             toolId: 'tool-1',
             toolName: ToolType.ACTIVATE_SKILL,
-            input: { skill_name: 'Another Skill' },
+            input: { skill_slug: 'Another Skill' },
           },
         ],
       } as unknown as AssistantMessage;

--- a/ayunis-core-backend/src/domain/tools/application/handlers/activate-skill-tool.handler.spec.ts
+++ b/ayunis-core-backend/src/domain/tools/application/handlers/activate-skill-tool.handler.spec.ts
@@ -71,7 +71,7 @@ describe('ActivateSkillToolHandler', () => {
   function createMockTool(skillName: string) {
     return {
       name: 'activate_skill',
-      validateParams: jest.fn().mockReturnValue({ skill_name: skillName }),
+      validateParams: jest.fn().mockReturnValue({ skill_slug: skillName }),
     } as unknown as ActivateSkillTool;
   }
 
@@ -97,7 +97,7 @@ describe('ActivateSkillToolHandler', () => {
 
     await handler.execute({
       tool,
-      input: { skill_name: 'Budget Analysis' },
+      input: { skill_slug: 'Budget Analysis' },
       context: { threadId: mockThreadId, orgId: randomUUID() },
     });
 
@@ -114,7 +114,7 @@ describe('ActivateSkillToolHandler', () => {
     await expect(
       handler.execute({
         tool,
-        input: { skill_name: 'Nonexistent Skill' },
+        input: { skill_slug: 'Nonexistent Skill' },
         context: { threadId: mockThreadId, orgId: randomUUID() },
       }),
     ).rejects.toThrow(ToolExecutionFailedError);
@@ -142,7 +142,7 @@ describe('ActivateSkillToolHandler', () => {
 
     const result = await handler.execute({
       tool,
-      input: { skill_name: 'Budget Analysis' },
+      input: { skill_slug: 'Budget Analysis' },
       context: { threadId: mockThreadId, orgId: randomUUID() },
     });
 
@@ -170,7 +170,7 @@ describe('ActivateSkillToolHandler', () => {
     await expect(
       handler.execute({
         tool,
-        input: { skill_name: 'Budget Analysis' },
+        input: { skill_slug: 'Budget Analysis' },
         context: { threadId: mockThreadId, orgId: randomUUID() },
       }),
     ).rejects.toThrow(ToolExecutionFailedError);

--- a/ayunis-core-backend/src/domain/tools/application/handlers/activate-skill-tool.handler.ts
+++ b/ayunis-core-backend/src/domain/tools/application/handlers/activate-skill-tool.handler.ts
@@ -37,14 +37,14 @@ export class ActivateSkillToolHandler extends ToolExecutionHandler {
 
       // Find the skill by name
       const skill = await this.findSkillByNameUseCase.execute(
-        new FindSkillByNameQuery(validatedInput.skill_name),
+        new FindSkillByNameQuery(validatedInput.skill_slug),
       );
 
       if (!skill) {
-        this.logger.error('Skill not found', validatedInput.skill_name);
+        this.logger.error('Skill not found', validatedInput.skill_slug);
         throw new ToolExecutionFailedError({
           toolName: tool.name,
-          message: `Skill "${validatedInput.skill_name}" not found`,
+          message: `Skill "${validatedInput.skill_slug}" not found`,
           exposeToLLM: true,
         });
       }

--- a/ayunis-core-backend/src/domain/tools/application/tool.factory.spec.ts
+++ b/ayunis-core-backend/src/domain/tools/application/tool.factory.spec.ts
@@ -88,6 +88,15 @@ describe('ToolFactory', () => {
       ).toThrow('Invalid tool type: UNSUPPORTED');
     });
 
+    it('should throw ToolInvalidContextError when activate_skill context is null', () => {
+      expect(() =>
+        factory.createTool({
+          type: ToolType.ACTIVATE_SKILL,
+          context: null,
+        }),
+      ).toThrow('Invalid context for tool');
+    });
+
     it('should throw error for invalid config type', () => {
       const invalidConfig = {
         displayName: 'Test Tool',

--- a/ayunis-core-backend/src/domain/tools/application/tool.factory.ts
+++ b/ayunis-core-backend/src/domain/tools/application/tool.factory.ts
@@ -28,7 +28,6 @@ import { ActivateSkillTool } from '../domain/tools/activate-skill-tool.entity';
 import { CreateSkillTool } from '../domain/tools/create-skill-tool.entity';
 import { KnowledgeQueryTool } from '../domain/tools/knowledge-query-tool.entity';
 import { KnowledgeGetTextTool } from '../domain/tools/knowledge-get-text-tool.entity';
-import { Skill } from 'src/domain/skills/domain/skill.entity';
 import type { KnowledgeBaseSummary } from 'src/domain/knowledge-bases/domain/knowledge-base-summary';
 
 type ToolCreator = (params: { config?: ToolConfig; context?: unknown }) => Tool;
@@ -67,7 +66,7 @@ export class ToolFactory {
         ),
       [ToolType.ACTIVATE_SKILL]: (p) =>
         new ActivateSkillTool(
-          requireArrayContext(p.context, Skill, ToolType.ACTIVATE_SKILL),
+          requireMapContext(p.context, ToolType.ACTIVATE_SKILL),
         ),
       [ToolType.KNOWLEDGE_QUERY]: (p) =>
         new KnowledgeQueryTool(
@@ -110,6 +109,13 @@ export class ToolFactory {
   }
 }
 
+function contextTypeName(context: unknown): string {
+  if (context === null || context === undefined) return 'null';
+  return (
+    (context as { constructor?: { name?: string } }).constructor?.name ?? 'null'
+  );
+}
+
 function requireArrayContext<T>(
   context: unknown,
   itemType: abstract new (...args: never[]) => T,
@@ -124,11 +130,7 @@ function requireArrayContext<T>(
   }
   throw new ToolInvalidContextError({
     toolType,
-    metadata: {
-      contextType:
-        (context as { constructor?: { name?: string } }).constructor?.name ??
-        'null',
-    },
+    metadata: { contextType: contextTypeName(context) },
   });
 }
 
@@ -156,10 +158,19 @@ function requireKnowledgeBaseContext(
   }
   throw new ToolInvalidContextError({
     toolType,
-    metadata: {
-      contextType:
-        (context as { constructor?: { name?: string } }).constructor?.name ??
-        'null',
-    },
+    metadata: { contextType: contextTypeName(context) },
+  });
+}
+
+function requireMapContext(
+  context: unknown,
+  toolType: ToolType,
+): Map<string, string> {
+  if (context instanceof Map) {
+    return context as Map<string, string>;
+  }
+  throw new ToolInvalidContextError({
+    toolType,
+    metadata: { contextType: contextTypeName(context) },
   });
 }

--- a/ayunis-core-backend/src/domain/tools/domain/tools/activate-skill-tool.entity.spec.ts
+++ b/ayunis-core-backend/src/domain/tools/domain/tools/activate-skill-tool.entity.spec.ts
@@ -1,0 +1,39 @@
+import { ActivateSkillTool } from './activate-skill-tool.entity';
+
+describe('ActivateSkillTool', () => {
+  describe('resolveOriginalName', () => {
+    it('should return the original name for a known slug', () => {
+      const slugToName = new Map([
+        ['system__data-privacy', 'Data Privacy'],
+        ['user__budget-analysis', 'Budget Analysis'],
+      ]);
+      const tool = new ActivateSkillTool(slugToName);
+
+      expect(tool.resolveOriginalName('system__data-privacy')).toBe(
+        'Data Privacy',
+      );
+    });
+
+    it('should return undefined for an unknown slug', () => {
+      const slugToName = new Map([['system__data-privacy', 'Data Privacy']]);
+      const tool = new ActivateSkillTool(slugToName);
+
+      expect(
+        tool.resolveOriginalName('system__nonexistent-skill'),
+      ).toBeUndefined();
+    });
+  });
+
+  describe('buildParameters', () => {
+    it('should describe the parameter as a slug identifier', () => {
+      const tool = new ActivateSkillTool(new Map());
+      const params = tool.parameters as Record<string, unknown>;
+      const properties = params.properties as Record<
+        string,
+        Record<string, unknown>
+      >;
+
+      expect(properties.skill_slug.description).toContain('slug');
+    });
+  });
+});

--- a/ayunis-core-backend/src/domain/tools/domain/tools/activate-skill-tool.entity.ts
+++ b/ayunis-core-backend/src/domain/tools/domain/tools/activate-skill-tool.entity.ts
@@ -2,43 +2,49 @@ import type { JSONSchema } from 'json-schema-to-ts';
 import { ToolType } from '../value-objects/tool-type.enum';
 import { createAjv } from 'src/common/validators/ajv.factory';
 import { Tool } from '../tool.entity';
-import type { Skill } from 'src/domain/skills/domain/skill.entity';
 
-function buildParameters(skills: Skill[]): JSONSchema {
+function buildParameters(slugs: string[]): JSONSchema {
   const skillNameProperty: Record<string, unknown> = {
     type: 'string' as const,
-    description: 'The name of the skill to activate',
+    description: 'The slug identifier of the skill to activate',
   };
 
-  if (skills.length > 0) {
-    skillNameProperty.enum = skills.map((s) => s.name);
+  if (slugs.length > 0) {
+    skillNameProperty.enum = slugs;
   }
 
   return {
     type: 'object' as const,
     properties: {
-      skill_name: skillNameProperty,
+      skill_slug: skillNameProperty,
     },
-    required: ['skill_name'],
+    required: ['skill_slug'],
     additionalProperties: false,
   } as const satisfies JSONSchema;
 }
 
 interface ActivateSkillToolParameters {
-  skill_name: string;
+  skill_slug: string;
 }
 
 export class ActivateSkillTool extends Tool {
-  constructor(skills: Skill[] = []) {
+  private readonly slugToName: Map<string, string>;
+
+  constructor(slugToName: Map<string, string> = new Map()) {
     super({
       name: ToolType.ACTIVATE_SKILL,
       description:
         'Activate a skill to inject its knowledge and capabilities into the conversation.',
       descriptionLong:
         "Activate skills when you need specialized knowledge or capabilities that are available as skills. This will inject the skill's instructions and make its knowledge bases and integrations available for use.",
-      parameters: buildParameters(skills),
+      parameters: buildParameters([...slugToName.keys()]),
       type: ToolType.ACTIVATE_SKILL,
     });
+    this.slugToName = slugToName;
+  }
+
+  resolveOriginalName(slug: string): string | undefined {
+    return this.slugToName.get(slug);
   }
 
   validateParams(params: Record<string, unknown>): ActivateSkillToolParameters {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Changes the `activate_skill` tool contract and context type (now `skill_slug` + `Map`), and refactors system-prompt skill rendering to use slugs, which can break tool assembly/callers and LLM tool-call behavior if not updated consistently.
> 
> **Overview**
> Introduces new skill-slug utilities (`slugify`, `buildSkillSlug`/`parseSkillSlug`, `buildSlugMap`) with German transliteration rules and collision detection, plus tests.
> 
> Refactors system prompt generation to accept `SkillEntry` objects and emit `<available_skills>` using `skill.slug`/`skill.description` (with XML escaping), and removes the `alwaysOnInstructions` prompt section/related helpers.
> 
> Updates `activate_skill` to use a `skill_slug` parameter (schema enum derived from known slugs) and a `Map<slug,name>` for reverse lookup, with `ToolFactory` now validating `ACTIVATE_SKILL` context as a `Map` and improving invalid-context error metadata; adjusts handler/specs and adds tool entity tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9e0abed51b38dc4af04593e0953e7101629f07da. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->