### PR TITLE
wip(AYC-103): merge always-on templates into slugified skill list

### DIFF
--- a/ayunis-core-backend/src/domain/runs/application/services/tool-assembly.service.ts
+++ b/ayunis-core-backend/src/domain/runs/application/services/tool-assembly.service.ts
@@ -24,6 +24,15 @@ import { MarketplaceMcpIntegration } from 'src/domain/mcp/domain/integrations/ma
 import { FindActiveAlwaysOnTemplatesUseCase } from 'src/domain/skill-templates/application/use-cases/find-active-always-on-templates/find-active-always-on-templates.use-case';
 import { FindActiveAlwaysOnTemplatesQuery } from 'src/domain/skill-templates/application/use-cases/find-active-always-on-templates/find-active-always-on-templates.query';
 import { featuresConfig } from 'src/config/features.config';
+import {
+  buildSkillSlug,
+  SlugCollisionError,
+  SYSTEM_PREFIX,
+  USER_PREFIX,
+  type SkillEntry,
+  type SkillPrefix,
+} from 'src/common/util/skill-slug';
+import type { SkillTemplate } from 'src/domain/skill-templates/domain/skill-template.entity';
 
 @Injectable()
 export class ToolAssemblyService {
@@ -52,8 +61,26 @@ export class ToolAssemblyService {
     activeSkills: Skill[],
     canUseTools: boolean,
   ): Promise<{ tools: Tool[]; instructions: string }> {
+    // Fetch always-on skill templates (cached, 60s TTL)
+    let alwaysOnTemplates: SkillTemplate[] = [];
+    try {
+      alwaysOnTemplates = await this.findActiveAlwaysOnTemplatesUseCase.execute(
+        new FindActiveAlwaysOnTemplatesQuery(),
+      );
+    } catch (error) {
+      this.logger.error(
+        'Failed to fetch always-on templates, continuing without them',
+        { error: error instanceof Error ? error.message : 'Unknown error' },
+      );
+    }
+
+    const { slugMap, skillEntries } = this.buildSkillSlugs(
+      activeSkills,
+      alwaysOnTemplates,
+    );
+
     const tools = canUseTools
-      ? await this.assembleTools(thread, agent, activeSkills)
+      ? await this.assembleTools(thread, agent, activeSkills, slugMap)
       : [];
 
     // Collect all sources from thread and agent for the system prompt
@@ -72,20 +99,6 @@ export class ToolAssemblyService {
       await this.getUserSystemPromptUseCase.execute();
     const userSystemPrompt = userSystemPromptEntity?.systemPrompt ?? undefined;
 
-    // Fetch active always-on skill templates (cached, 60s TTL)
-    let alwaysOnInstructions: string[] = [];
-    try {
-      const templates = await this.findActiveAlwaysOnTemplatesUseCase.execute(
-        new FindActiveAlwaysOnTemplatesQuery(),
-      );
-      alwaysOnInstructions = templates.map((t) => t.instructions);
-    } catch (error) {
-      this.logger.error(
-        'Failed to fetch always-on templates, continuing without them',
-        { error: error instanceof Error ? error.message : 'Unknown error' },
-      );
-    }
-
     const instructions = this.systemPromptBuilderService.build({
       agent,
       tools,
@@ -93,20 +106,70 @@ export class ToolAssemblyService {
       sources: textSources,
       // Only include skills in prompt when tools are enabled and skills feature is on,
       // otherwise the prompt would instruct the model to use activate_skill which isn't available
-      skills: canUseTools && this.features.skillsEnabled ? activeSkills : [],
-
+      skills: canUseTools && this.features.skillsEnabled ? skillEntries : [],
       knowledgeBases: canUseTools ? (thread.knowledgeBases ?? []) : [],
-      alwaysOnInstructions,
       userSystemPrompt,
     });
 
     return { tools, instructions };
   }
 
+  /**
+   * Build slug→name map and skill entries in a single pass.
+   * Errors are handled per-entry so a single problematic skill
+   * (collision or un-slugifiable name) only removes that entry.
+   */
+  private buildSkillSlugs(
+    activeSkills: Skill[],
+    alwaysOnTemplates: SkillTemplate[],
+  ): { slugMap: Map<string, string>; skillEntries: SkillEntry[] } {
+    const slugMap = new Map<string, string>();
+    const skillEntries: SkillEntry[] = [];
+
+    const allInputs: {
+      name: string;
+      prefix: SkillPrefix;
+      description: string;
+    }[] = [
+      ...activeSkills.map((s) => ({
+        name: s.name,
+        prefix: USER_PREFIX as SkillPrefix,
+        description: s.shortDescription,
+      })),
+      ...alwaysOnTemplates.map((t) => ({
+        name: t.name,
+        prefix: SYSTEM_PREFIX as SkillPrefix,
+        description: t.shortDescription,
+      })),
+    ];
+
+    for (const input of allInputs) {
+      try {
+        const slug = buildSkillSlug(input.prefix, input.name);
+        const existing = slugMap.get(slug);
+        if (existing !== undefined && existing !== input.name) {
+          throw new SlugCollisionError(slug, existing, input.name);
+        }
+        slugMap.set(slug, input.name);
+        skillEntries.push({ slug, description: input.description });
+      } catch (error) {
+        const message =
+          error instanceof SlugCollisionError
+            ? `Slug collision, skipping skill "${input.name}"`
+            : `Failed to build slug for skill "${input.name}", skipping`;
+        const detail = error instanceof Error ? error.message : 'Unknown error';
+        this.logger.warn(message, { error: detail });
+      }
+    }
+
+    return { slugMap, skillEntries };
+  }
+
   async assembleTools(
     thread: Thread,
-    agent?: Agent,
-    activeSkills: Skill[] = [],
+    agent: Agent | undefined,
+    activeSkills: Skill[],
+    slugMap: Map<string, string>,
   ): Promise<Tool[]> {
     const skillsEnabled = this.features.skillsEnabled;
     const tools: Tool[] = [];
@@ -360,13 +423,13 @@ export class ToolAssemblyService {
       );
     }
 
-    // Activate skill tool is available if there are active skills and skills feature is enabled
-    if (skillsEnabled && activeSkills.length > 0) {
+    // Activate skill tool is available if there are activatable skills (user or system) and skills feature is enabled
+    if (skillsEnabled && slugMap.size > 0) {
       tools.push(
         await this.assembleToolsUseCase.execute(
           new AssembleToolCommand({
             type: ToolType.ACTIVATE_SKILL,
-            context: activeSkills,
+            context: slugMap,
           }),
         ),
       );

--- a/ayunis-core-backend/src/domain/skill-templates/application/use-cases/find-always-on-template-by-name/find-always-on-template-by-name.query.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/application/use-cases/find-always-on-template-by-name/find-always-on-template-by-name.query.ts
@@ -1,0 +1,3 @@
+export class FindAlwaysOnTemplateByNameQuery {
+  constructor(public readonly name: string) {}
+}

--- a/ayunis-core-backend/src/domain/skill-templates/application/use-cases/find-always-on-template-by-name/find-always-on-template-by-name.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/application/use-cases/find-always-on-template-by-name/find-always-on-template-by-name.use-case.spec.ts
@@ -1,0 +1,95 @@
+import type { TestingModule } from '@nestjs/testing';
+import { Test } from '@nestjs/testing';
+import type { UUID } from 'crypto';
+import { FindAlwaysOnTemplateByNameUseCase } from './find-always-on-template-by-name.use-case';
+import { FindAlwaysOnTemplateByNameQuery } from './find-always-on-template-by-name.query';
+import { FindActiveAlwaysOnTemplatesUseCase } from '../find-active-always-on-templates/find-active-always-on-templates.use-case';
+import { SkillTemplate } from '../../../domain/skill-template.entity';
+import { DistributionMode } from '../../../domain/distribution-mode.enum';
+
+describe('FindAlwaysOnTemplateByNameUseCase', () => {
+  let useCase: FindAlwaysOnTemplateByNameUseCase;
+  let findActiveAlwaysOnTemplates: jest.Mocked<FindActiveAlwaysOnTemplatesUseCase>;
+
+  const alwaysOnTemplate = new SkillTemplate({
+    id: '123e4567-e89b-12d3-a456-426614174001' as UUID,
+    name: 'German Administrative Law',
+    shortDescription: 'German admin law guidelines',
+    instructions: 'Follow German administrative law...',
+    distributionMode: DistributionMode.ALWAYS_ON,
+    isActive: true,
+  });
+
+  const preCreatedTemplate = new SkillTemplate({
+    id: '123e4567-e89b-12d3-a456-426614174002' as UUID,
+    name: 'Data Analysis',
+    shortDescription: 'Data analysis helper',
+    instructions: 'Analyze data...',
+    distributionMode: DistributionMode.PRE_CREATED_COPY,
+    isActive: true,
+  });
+
+  beforeAll(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        FindAlwaysOnTemplateByNameUseCase,
+        {
+          provide: FindActiveAlwaysOnTemplatesUseCase,
+          useValue: { execute: jest.fn() },
+        },
+      ],
+    }).compile();
+
+    useCase = module.get(FindAlwaysOnTemplateByNameUseCase);
+    findActiveAlwaysOnTemplates = module.get(
+      FindActiveAlwaysOnTemplatesUseCase,
+    );
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should find an always-on template by name', async () => {
+    findActiveAlwaysOnTemplates.execute.mockResolvedValue([alwaysOnTemplate]);
+
+    const result = await useCase.execute(
+      new FindAlwaysOnTemplateByNameQuery('German Administrative Law'),
+    );
+
+    expect(result).toBe(alwaysOnTemplate);
+  });
+
+  it('should return null when template name does not match', async () => {
+    findActiveAlwaysOnTemplates.execute.mockResolvedValue([alwaysOnTemplate]);
+
+    const result = await useCase.execute(
+      new FindAlwaysOnTemplateByNameQuery('Nonexistent Skill'),
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it('should return null when no always-on templates exist', async () => {
+    findActiveAlwaysOnTemplates.execute.mockResolvedValue([]);
+
+    const result = await useCase.execute(
+      new FindAlwaysOnTemplateByNameQuery('German Administrative Law'),
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it('should not find templates that are not always-on', async () => {
+    // Return both templates — the use case filters by name, not distribution mode,
+    // but since we search for a pre-created template name that doesn't match any
+    // always-on template, the result should be null
+    findActiveAlwaysOnTemplates.execute.mockResolvedValue([alwaysOnTemplate]);
+
+    const result = await useCase.execute(
+      new FindAlwaysOnTemplateByNameQuery(preCreatedTemplate.name),
+    );
+
+    expect(result).toBeNull();
+  });
+});

--- a/ayunis-core-backend/src/domain/skill-templates/application/use-cases/find-always-on-template-by-name/find-always-on-template-by-name.use-case.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/application/use-cases/find-always-on-template-by-name/find-always-on-template-by-name.use-case.ts
@@ -1,0 +1,22 @@
+import { Injectable } from '@nestjs/common';
+import { FindActiveAlwaysOnTemplatesUseCase } from '../find-active-always-on-templates/find-active-always-on-templates.use-case';
+import { FindActiveAlwaysOnTemplatesQuery } from '../find-active-always-on-templates/find-active-always-on-templates.query';
+import { FindAlwaysOnTemplateByNameQuery } from './find-always-on-template-by-name.query';
+import { SkillTemplate } from '../../../domain/skill-template.entity';
+
+@Injectable()
+export class FindAlwaysOnTemplateByNameUseCase {
+  constructor(
+    private readonly findActiveAlwaysOnTemplatesUseCase: FindActiveAlwaysOnTemplatesUseCase,
+  ) {}
+
+  async execute(
+    query: FindAlwaysOnTemplateByNameQuery,
+  ): Promise<SkillTemplate | null> {
+    const templates = await this.findActiveAlwaysOnTemplatesUseCase.execute(
+      new FindActiveAlwaysOnTemplatesQuery(),
+    );
+
+    return templates.find((t) => t.name === query.name) ?? null;
+  }
+}

--- a/ayunis-core-backend/src/domain/skill-templates/skill-templates.module.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/skill-templates.module.ts
@@ -9,6 +9,7 @@ import { DeleteSkillTemplateUseCase } from './application/use-cases/delete-skill
 import { FindAllSkillTemplatesUseCase } from './application/use-cases/find-all-skill-templates/find-all-skill-templates.use-case';
 import { FindOneSkillTemplateUseCase } from './application/use-cases/find-one-skill-template/find-one-skill-template.use-case';
 import { FindActiveAlwaysOnTemplatesUseCase } from './application/use-cases/find-active-always-on-templates/find-active-always-on-templates.use-case';
+import { FindAlwaysOnTemplateByNameUseCase } from './application/use-cases/find-always-on-template-by-name/find-always-on-template-by-name.use-case';
 import { FindActivePreCreatedTemplatesUseCase } from './application/use-cases/find-active-pre-created-templates/find-active-pre-created-templates.use-case';
 import { SkillTemplateInstallationService } from './application/services/skill-template-installation.service';
 import { SkillTemplateUserCreatedListener } from './application/listeners/user-created.listener';
@@ -29,11 +30,16 @@ import { SkillTemplateResponseMapper } from './presenters/http/mappers/skill-tem
     FindAllSkillTemplatesUseCase,
     FindOneSkillTemplateUseCase,
     FindActiveAlwaysOnTemplatesUseCase,
+    FindAlwaysOnTemplateByNameUseCase,
     FindActivePreCreatedTemplatesUseCase,
     SkillTemplateInstallationService,
     SkillTemplateUserCreatedListener,
     SkillTemplateResponseMapper,
   ],
-  exports: [FindAllSkillTemplatesUseCase, FindActiveAlwaysOnTemplatesUseCase],
+  exports: [
+    FindAllSkillTemplatesUseCase,
+    FindActiveAlwaysOnTemplatesUseCase,
+    FindAlwaysOnTemplateByNameUseCase,
+  ],
 })
 export class SkillTemplatesModule {}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes how skills are surfaced and activated by replacing the `activate_skill` context with a slug→name map that now includes always-on templates, which can affect prompt contents and skill selection at runtime.
> 
> **Overview**
> **Skills are now exposed as a unified, slugified list for activation.** `ToolAssemblyService` fetches always-on skill templates alongside user skills, builds prefixed slugs (`user__*` / `system__*`) with per-entry collision handling, and passes the resulting slug map to the `activate_skill` tool.
> 
> The run system prompt no longer injects always-on template `instructions` directly; instead it lists the merged `SkillEntry` set (slug + description) so the model activates a specific skill via `activate_skill`.
> 
> Adds `FindAlwaysOnTemplateByNameUseCase` (with tests) and wires it into `SkillTemplatesModule` exports for reuse.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 88d6ee3d4716c9608d6590c3570c049454928dd5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->