### PR TITLE
wip(AYC-103): refactor skill templates into polymorphic STI hierarchy

### DIFF
--- a/ayunis-core-backend/src/domain/skill-templates/SUMMARY.md
+++ b/ayunis-core-backend/src/domain/skill-templates/SUMMARY.md
@@ -19,8 +19,10 @@ Skill templates are admin-managed blueprints for skills that can be distributed 
 skill-templates/
 ├── SUMMARY.md
 ├── domain/
-│   ├── skill-template.entity.ts           # Domain entity with name validation
-│   └── distribution-mode.enum.ts          # ALWAYS_ON, PRE_CREATED_COPY
+│   ├── skill-template.entity.ts                    # Abstract base domain entity with name validation
+│   ├── always-on-skill-template.entity.ts           # AlwaysOnSkillTemplate (ALWAYS_ON mode)
+│   ├── pre-created-copy-skill-template.entity.ts    # PreCreatedCopySkillTemplate (PRE_CREATED_COPY mode)
+│   └── distribution-mode.enum.ts                    # ALWAYS_ON, PRE_CREATED_COPY
 ├── application/
 │   ├── ports/skill-template.repository.ts # Abstract repository interface
 │   ├── skill-templates.errors.ts          # Domain errors
@@ -39,7 +41,10 @@ skill-templates/
 │       └── find-active-pre-created-templates/ # FindActivePreCreatedTemplatesUseCase + query
 ├── infrastructure/
 │   └── persistence/local/
-│       ├── schema/skill-template.record.ts        # TypeORM entity
+│       ├── schema/
+│       │   ├── skill-template.record.ts                    # Abstract base TypeORM entity (STI parent)
+│       │   ├── always-on-skill-template.record.ts           # AlwaysOnSkillTemplateRecord (child entity)
+│       │   └── pre-created-copy-skill-template.record.ts    # PreCreatedCopySkillTemplateRecord (child entity)
 │       ├── mappers/skill-template.mapper.ts       # Domain ↔ Record conversion
 │       ├── local-skill-template.repository.ts     # PostgreSQL repository
 │       └── local-skill-template-repository.module.ts
@@ -63,6 +68,8 @@ skill-templates/
 ## Design Decisions
 
 Name validation reuses the same pattern as the Skills module (Unicode letters, numbers, emojis, hyphens, spaces; no consecutive spaces).
+
+The persistence layer uses TypeORM Single Table Inheritance (STI) with `distributionMode` as the discriminator column. Child entity repositories (`AlwaysOnSkillTemplateRecord`, `PreCreatedCopySkillTemplateRecord`) are used for mode-specific queries.
 
 ## Dependencies
 

--- a/ayunis-core-backend/src/domain/skill-templates/application/services/skill-template-installation.service.spec.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/application/services/skill-template-installation.service.spec.ts
@@ -3,7 +3,7 @@ import type { FindActivePreCreatedTemplatesUseCase } from '../use-cases/find-act
 import type { CreateSkillWithUniqueNameUseCase } from 'src/domain/skills/application/use-cases/create-skill-with-unique-name/create-skill-with-unique-name.use-case';
 import type { CreateSkillWithUniqueNameCommand } from 'src/domain/skills/application/use-cases/create-skill-with-unique-name/create-skill-with-unique-name.command';
 import { SkillTemplate } from '../../domain/skill-template.entity';
-import { DistributionMode } from '../../domain/distribution-mode.enum';
+import { PreCreatedCopySkillTemplate } from '../../domain/pre-created-copy-skill-template.entity';
 import { Skill } from 'src/domain/skills/domain/skill.entity';
 import { randomUUID } from 'crypto';
 
@@ -15,20 +15,18 @@ describe('SkillTemplateInstallationService', () => {
   const userId = randomUUID();
 
   const mockTemplates: SkillTemplate[] = [
-    new SkillTemplate({
+    new PreCreatedCopySkillTemplate({
       id: randomUUID(),
       name: 'Template A',
       shortDescription: 'Description A',
       instructions: 'Instructions A',
-      distributionMode: DistributionMode.PRE_CREATED_COPY,
       isActive: true,
     }),
-    new SkillTemplate({
+    new PreCreatedCopySkillTemplate({
       id: randomUUID(),
       name: 'Template B',
       shortDescription: 'Description B',
       instructions: 'Instructions B',
-      distributionMode: DistributionMode.PRE_CREATED_COPY,
       isActive: true,
     }),
   ];

--- a/ayunis-core-backend/src/domain/skill-templates/application/use-cases/create-skill-template/create-skill-template.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/application/use-cases/create-skill-template/create-skill-template.use-case.spec.ts
@@ -5,6 +5,8 @@ import { CreateSkillTemplateUseCase } from './create-skill-template.use-case';
 import { CreateSkillTemplateCommand } from './create-skill-template.command';
 import { SkillTemplateRepository } from '../../ports/skill-template.repository';
 import { SkillTemplate } from '../../../domain/skill-template.entity';
+import { AlwaysOnSkillTemplate } from '../../../domain/always-on-skill-template.entity';
+import { PreCreatedCopySkillTemplate } from '../../../domain/pre-created-copy-skill-template.entity';
 import { DistributionMode } from '../../../domain/distribution-mode.enum';
 import { InvalidSkillTemplateNameError } from '../../../domain/skill-template.entity';
 import { DuplicateSkillTemplateNameError } from '../../skill-templates.errors';
@@ -47,11 +49,10 @@ describe('CreateSkillTemplateUseCase', () => {
       distributionMode: DistributionMode.ALWAYS_ON,
     });
 
-    const expectedTemplate = new SkillTemplate({
+    const expectedTemplate = new AlwaysOnSkillTemplate({
       name: command.name,
       shortDescription: command.shortDescription,
       instructions: command.instructions,
-      distributionMode: command.distributionMode,
     });
 
     repository.findByName.mockResolvedValue(null);
@@ -74,11 +75,10 @@ describe('CreateSkillTemplateUseCase', () => {
       isActive: true,
     });
 
-    const expectedTemplate = new SkillTemplate({
+    const expectedTemplate = new PreCreatedCopySkillTemplate({
       name: command.name,
       shortDescription: command.shortDescription,
       instructions: command.instructions,
-      distributionMode: command.distributionMode,
       isActive: true,
     });
 
@@ -99,11 +99,10 @@ describe('CreateSkillTemplateUseCase', () => {
       distributionMode: DistributionMode.ALWAYS_ON,
     });
 
-    const existingTemplate = new SkillTemplate({
+    const existingTemplate = new AlwaysOnSkillTemplate({
       name: 'Legal Guidelines',
       shortDescription: 'Existing template',
       instructions: 'Existing instructions.',
-      distributionMode: DistributionMode.ALWAYS_ON,
     });
 
     repository.findByName.mockResolvedValue(existingTemplate);

--- a/ayunis-core-backend/src/domain/skill-templates/application/use-cases/create-skill-template/create-skill-template.use-case.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/application/use-cases/create-skill-template/create-skill-template.use-case.ts
@@ -2,6 +2,9 @@ import { Injectable, Logger } from '@nestjs/common';
 import { SkillTemplateRepository } from '../../ports/skill-template.repository';
 import { CreateSkillTemplateCommand } from './create-skill-template.command';
 import { SkillTemplate } from '../../../domain/skill-template.entity';
+import { AlwaysOnSkillTemplate } from '../../../domain/always-on-skill-template.entity';
+import { PreCreatedCopySkillTemplate } from '../../../domain/pre-created-copy-skill-template.entity';
+import { DistributionMode } from '../../../domain/distribution-mode.enum';
 import {
   DuplicateSkillTemplateNameError,
   UnexpectedSkillTemplateError,
@@ -27,13 +30,17 @@ export class CreateSkillTemplateUseCase {
         throw new DuplicateSkillTemplateNameError(command.name);
       }
 
-      const skillTemplate = new SkillTemplate({
+      const baseParams = {
         name: command.name,
         shortDescription: command.shortDescription,
         instructions: command.instructions,
-        distributionMode: command.distributionMode,
         isActive: command.isActive,
-      });
+      };
+
+      const skillTemplate: SkillTemplate =
+        command.distributionMode === DistributionMode.ALWAYS_ON
+          ? new AlwaysOnSkillTemplate(baseParams)
+          : new PreCreatedCopySkillTemplate(baseParams);
 
       return await this.skillTemplateRepository.create(skillTemplate);
     } catch (error) {

--- a/ayunis-core-backend/src/domain/skill-templates/application/use-cases/delete-skill-template/delete-skill-template.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/application/use-cases/delete-skill-template/delete-skill-template.use-case.spec.ts
@@ -6,7 +6,7 @@ import { DeleteSkillTemplateUseCase } from './delete-skill-template.use-case';
 import { DeleteSkillTemplateCommand } from './delete-skill-template.command';
 import { SkillTemplateRepository } from '../../ports/skill-template.repository';
 import { SkillTemplate } from '../../../domain/skill-template.entity';
-import { DistributionMode } from '../../../domain/distribution-mode.enum';
+import { AlwaysOnSkillTemplate } from '../../../domain/always-on-skill-template.entity';
 import { SkillTemplateNotFoundError } from '../../skill-templates.errors';
 
 describe('DeleteSkillTemplateUseCase', () => {
@@ -42,12 +42,11 @@ describe('DeleteSkillTemplateUseCase', () => {
   });
 
   it('should delete a skill template successfully', async () => {
-    const existing = new SkillTemplate({
+    const existing = new AlwaysOnSkillTemplate({
       id: mockId,
       name: 'Legal Guidelines',
       shortDescription: 'Description',
       instructions: 'Instructions.',
-      distributionMode: DistributionMode.ALWAYS_ON,
     });
 
     repository.findOne.mockResolvedValue(existing);

--- a/ayunis-core-backend/src/domain/skill-templates/application/use-cases/find-active-always-on-templates/find-active-always-on-templates.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/application/use-cases/find-active-always-on-templates/find-active-always-on-templates.use-case.spec.ts
@@ -2,6 +2,7 @@ import { FindActiveAlwaysOnTemplatesUseCase } from './find-active-always-on-temp
 import { FindActiveAlwaysOnTemplatesQuery } from './find-active-always-on-templates.query';
 import type { SkillTemplateRepository } from '../../ports/skill-template.repository';
 import { SkillTemplate } from '../../../domain/skill-template.entity';
+import { AlwaysOnSkillTemplate } from '../../../domain/always-on-skill-template.entity';
 import { DistributionMode } from '../../../domain/distribution-mode.enum';
 import { randomUUID } from 'crypto';
 
@@ -10,12 +11,11 @@ describe('FindActiveAlwaysOnTemplatesUseCase', () => {
   let repository: jest.Mocked<SkillTemplateRepository>;
 
   const mockTemplates: SkillTemplate[] = [
-    new SkillTemplate({
+    new AlwaysOnSkillTemplate({
       id: randomUUID(),
       name: 'Global Policy',
       shortDescription: 'Global policy instructions',
       instructions: 'Always follow these rules...',
-      distributionMode: DistributionMode.ALWAYS_ON,
       isActive: true,
     }),
   ];

--- a/ayunis-core-backend/src/domain/skill-templates/application/use-cases/find-active-pre-created-templates/find-active-pre-created-templates.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/application/use-cases/find-active-pre-created-templates/find-active-pre-created-templates.use-case.spec.ts
@@ -2,6 +2,7 @@ import { FindActivePreCreatedTemplatesUseCase } from './find-active-pre-created-
 import { FindActivePreCreatedTemplatesQuery } from './find-active-pre-created-templates.query';
 import type { SkillTemplateRepository } from '../../ports/skill-template.repository';
 import { SkillTemplate } from '../../../domain/skill-template.entity';
+import { PreCreatedCopySkillTemplate } from '../../../domain/pre-created-copy-skill-template.entity';
 import { DistributionMode } from '../../../domain/distribution-mode.enum';
 import { randomUUID } from 'crypto';
 
@@ -10,12 +11,11 @@ describe('FindActivePreCreatedTemplatesUseCase', () => {
   let repository: jest.Mocked<SkillTemplateRepository>;
 
   const mockTemplates: SkillTemplate[] = [
-    new SkillTemplate({
+    new PreCreatedCopySkillTemplate({
       id: randomUUID(),
       name: 'Starter Skill',
       shortDescription: 'A pre-created starter skill',
       instructions: 'Follow these starter instructions...',
-      distributionMode: DistributionMode.PRE_CREATED_COPY,
       isActive: true,
     }),
   ];

--- a/ayunis-core-backend/src/domain/skill-templates/application/use-cases/find-all-skill-templates/find-all-skill-templates.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/application/use-cases/find-all-skill-templates/find-all-skill-templates.use-case.spec.ts
@@ -4,8 +4,8 @@ import { Logger } from '@nestjs/common';
 import { FindAllSkillTemplatesUseCase } from './find-all-skill-templates.use-case';
 import { FindAllSkillTemplatesQuery } from './find-all-skill-templates.query';
 import { SkillTemplateRepository } from '../../ports/skill-template.repository';
-import { SkillTemplate } from '../../../domain/skill-template.entity';
-import { DistributionMode } from '../../../domain/distribution-mode.enum';
+import { AlwaysOnSkillTemplate } from '../../../domain/always-on-skill-template.entity';
+import { PreCreatedCopySkillTemplate } from '../../../domain/pre-created-copy-skill-template.entity';
 
 describe('FindAllSkillTemplatesUseCase', () => {
   let useCase: FindAllSkillTemplatesUseCase;
@@ -38,17 +38,15 @@ describe('FindAllSkillTemplatesUseCase', () => {
 
   it('should return all skill templates', async () => {
     const templates = [
-      new SkillTemplate({
+      new AlwaysOnSkillTemplate({
         name: 'Template 1',
         shortDescription: 'First',
         instructions: 'Instructions 1.',
-        distributionMode: DistributionMode.ALWAYS_ON,
       }),
-      new SkillTemplate({
+      new PreCreatedCopySkillTemplate({
         name: 'Template 2',
         shortDescription: 'Second',
         instructions: 'Instructions 2.',
-        distributionMode: DistributionMode.PRE_CREATED_COPY,
         isActive: true,
       }),
     ];

--- a/ayunis-core-backend/src/domain/skill-templates/application/use-cases/find-always-on-template-by-name/find-always-on-template-by-name.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/application/use-cases/find-always-on-template-by-name/find-always-on-template-by-name.use-case.spec.ts
@@ -4,28 +4,26 @@ import type { UUID } from 'crypto';
 import { FindAlwaysOnTemplateByNameUseCase } from './find-always-on-template-by-name.use-case';
 import { FindAlwaysOnTemplateByNameQuery } from './find-always-on-template-by-name.query';
 import { FindActiveAlwaysOnTemplatesUseCase } from '../find-active-always-on-templates/find-active-always-on-templates.use-case';
-import { SkillTemplate } from '../../../domain/skill-template.entity';
-import { DistributionMode } from '../../../domain/distribution-mode.enum';
+import { AlwaysOnSkillTemplate } from '../../../domain/always-on-skill-template.entity';
+import { PreCreatedCopySkillTemplate } from '../../../domain/pre-created-copy-skill-template.entity';
 
 describe('FindAlwaysOnTemplateByNameUseCase', () => {
   let useCase: FindAlwaysOnTemplateByNameUseCase;
   let findActiveAlwaysOnTemplates: jest.Mocked<FindActiveAlwaysOnTemplatesUseCase>;
 
-  const alwaysOnTemplate = new SkillTemplate({
+  const alwaysOnTemplate = new AlwaysOnSkillTemplate({
     id: '123e4567-e89b-12d3-a456-426614174001' as UUID,
     name: 'German Administrative Law',
     shortDescription: 'German admin law guidelines',
     instructions: 'Follow German administrative law...',
-    distributionMode: DistributionMode.ALWAYS_ON,
     isActive: true,
   });
 
-  const preCreatedTemplate = new SkillTemplate({
+  const preCreatedTemplate = new PreCreatedCopySkillTemplate({
     id: '123e4567-e89b-12d3-a456-426614174002' as UUID,
     name: 'Data Analysis',
     shortDescription: 'Data analysis helper',
     instructions: 'Analyze data...',
-    distributionMode: DistributionMode.PRE_CREATED_COPY,
     isActive: true,
   });
 

--- a/ayunis-core-backend/src/domain/skill-templates/application/use-cases/find-one-skill-template/find-one-skill-template.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/application/use-cases/find-one-skill-template/find-one-skill-template.use-case.spec.ts
@@ -6,7 +6,7 @@ import { FindOneSkillTemplateUseCase } from './find-one-skill-template.use-case'
 import { FindOneSkillTemplateQuery } from './find-one-skill-template.query';
 import { SkillTemplateRepository } from '../../ports/skill-template.repository';
 import { SkillTemplate } from '../../../domain/skill-template.entity';
-import { DistributionMode } from '../../../domain/distribution-mode.enum';
+import { AlwaysOnSkillTemplate } from '../../../domain/always-on-skill-template.entity';
 import { SkillTemplateNotFoundError } from '../../skill-templates.errors';
 
 describe('FindOneSkillTemplateUseCase', () => {
@@ -41,12 +41,11 @@ describe('FindOneSkillTemplateUseCase', () => {
   });
 
   it('should return a skill template by ID', async () => {
-    const template = new SkillTemplate({
+    const template = new AlwaysOnSkillTemplate({
       id: mockId,
       name: 'Legal Guidelines',
       shortDescription: 'Description',
       instructions: 'Instructions.',
-      distributionMode: DistributionMode.ALWAYS_ON,
     });
 
     repository.findOne.mockResolvedValue(template);

--- a/ayunis-core-backend/src/domain/skill-templates/application/use-cases/update-skill-template/update-skill-template.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/application/use-cases/update-skill-template/update-skill-template.use-case.spec.ts
@@ -5,7 +5,8 @@ import type { UUID } from 'crypto';
 import { UpdateSkillTemplateUseCase } from './update-skill-template.use-case';
 import { UpdateSkillTemplateCommand } from './update-skill-template.command';
 import { SkillTemplateRepository } from '../../ports/skill-template.repository';
-import { SkillTemplate } from '../../../domain/skill-template.entity';
+import { AlwaysOnSkillTemplate } from '../../../domain/always-on-skill-template.entity';
+import { PreCreatedCopySkillTemplate } from '../../../domain/pre-created-copy-skill-template.entity';
 import { DistributionMode } from '../../../domain/distribution-mode.enum';
 import { InvalidSkillTemplateNameError } from '../../../domain/skill-template.entity';
 import {
@@ -47,12 +48,11 @@ describe('UpdateSkillTemplateUseCase', () => {
   });
 
   it('should update a skill template with all fields provided', async () => {
-    const existing = new SkillTemplate({
+    const existing = new AlwaysOnSkillTemplate({
       id: mockId,
       name: 'Legal Guidelines',
       shortDescription: 'Original description',
       instructions: 'Original instructions.',
-      distributionMode: DistributionMode.ALWAYS_ON,
     });
 
     const command = new UpdateSkillTemplateCommand({
@@ -76,12 +76,11 @@ describe('UpdateSkillTemplateUseCase', () => {
   });
 
   it('should merge with existing values when only partial fields provided', async () => {
-    const existing = new SkillTemplate({
+    const existing = new AlwaysOnSkillTemplate({
       id: mockId,
       name: 'Legal Guidelines',
       shortDescription: 'Original description',
       instructions: 'Original instructions.',
-      distributionMode: DistributionMode.ALWAYS_ON,
       isActive: false,
     });
 
@@ -103,12 +102,11 @@ describe('UpdateSkillTemplateUseCase', () => {
   });
 
   it('should check name uniqueness when name changes', async () => {
-    const existing = new SkillTemplate({
+    const existing = new AlwaysOnSkillTemplate({
       id: mockId,
       name: 'Old Name',
       shortDescription: 'Description',
       instructions: 'Instructions.',
-      distributionMode: DistributionMode.ALWAYS_ON,
     });
 
     const command = new UpdateSkillTemplateCommand({
@@ -127,19 +125,17 @@ describe('UpdateSkillTemplateUseCase', () => {
   });
 
   it('should reject update when new name already exists', async () => {
-    const existing = new SkillTemplate({
+    const existing = new AlwaysOnSkillTemplate({
       id: mockId,
       name: 'Old Name',
       shortDescription: 'Description',
       instructions: 'Instructions.',
-      distributionMode: DistributionMode.ALWAYS_ON,
     });
 
-    const duplicate = new SkillTemplate({
+    const duplicate = new PreCreatedCopySkillTemplate({
       name: 'Taken Name',
       shortDescription: 'Other',
       instructions: 'Other.',
-      distributionMode: DistributionMode.PRE_CREATED_COPY,
     });
 
     const command = new UpdateSkillTemplateCommand({
@@ -170,12 +166,11 @@ describe('UpdateSkillTemplateUseCase', () => {
   });
 
   it('should rethrow InvalidSkillTemplateNameError for invalid names', async () => {
-    const existing = new SkillTemplate({
+    const existing = new AlwaysOnSkillTemplate({
       id: mockId,
       name: 'Legal Guidelines',
       shortDescription: 'Description',
       instructions: 'Instructions.',
-      distributionMode: DistributionMode.ALWAYS_ON,
     });
 
     const command = new UpdateSkillTemplateCommand({

--- a/ayunis-core-backend/src/domain/skill-templates/application/use-cases/update-skill-template/update-skill-template.use-case.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/application/use-cases/update-skill-template/update-skill-template.use-case.ts
@@ -2,6 +2,9 @@ import { Injectable, Logger } from '@nestjs/common';
 import { SkillTemplateRepository } from '../../ports/skill-template.repository';
 import { UpdateSkillTemplateCommand } from './update-skill-template.command';
 import { SkillTemplate } from '../../../domain/skill-template.entity';
+import { AlwaysOnSkillTemplate } from '../../../domain/always-on-skill-template.entity';
+import { PreCreatedCopySkillTemplate } from '../../../domain/pre-created-copy-skill-template.entity';
+import { DistributionMode } from '../../../domain/distribution-mode.enum';
 import {
   DuplicateSkillTemplateNameError,
   SkillTemplateNotFoundError,
@@ -39,16 +42,22 @@ export class UpdateSkillTemplateUseCase {
         }
       }
 
-      const updated = new SkillTemplate({
+      const distributionMode =
+        command.distributionMode ?? existing.distributionMode;
+      const baseParams = {
         id: existing.id,
         name,
         shortDescription: command.shortDescription ?? existing.shortDescription,
         instructions: command.instructions ?? existing.instructions,
-        distributionMode: command.distributionMode ?? existing.distributionMode,
         isActive: command.isActive ?? existing.isActive,
         createdAt: existing.createdAt,
         updatedAt: new Date(),
-      });
+      };
+
+      const updated: SkillTemplate =
+        distributionMode === DistributionMode.ALWAYS_ON
+          ? new AlwaysOnSkillTemplate(baseParams)
+          : new PreCreatedCopySkillTemplate(baseParams);
 
       return await this.skillTemplateRepository.update(updated);
     } catch (error) {

--- a/ayunis-core-backend/src/domain/skill-templates/domain/always-on-skill-template.entity.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/domain/always-on-skill-template.entity.ts
@@ -1,0 +1,19 @@
+import type { UUID } from 'crypto';
+import { DistributionMode } from './distribution-mode.enum';
+import { SkillTemplate } from './skill-template.entity';
+
+export class AlwaysOnSkillTemplate extends SkillTemplate {
+  public readonly distributionMode = DistributionMode.ALWAYS_ON;
+
+  constructor(params: {
+    id?: UUID;
+    name: string;
+    shortDescription: string;
+    instructions: string;
+    isActive?: boolean;
+    createdAt?: Date;
+    updatedAt?: Date;
+  }) {
+    super(params);
+  }
+}

--- a/ayunis-core-backend/src/domain/skill-templates/domain/pre-created-copy-skill-template.entity.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/domain/pre-created-copy-skill-template.entity.ts
@@ -1,0 +1,25 @@
+import type { UUID } from 'crypto';
+import { DistributionMode } from './distribution-mode.enum';
+import { SkillTemplate } from './skill-template.entity';
+
+export class PreCreatedCopySkillTemplate extends SkillTemplate {
+  public readonly distributionMode = DistributionMode.PRE_CREATED_COPY;
+  public readonly defaultActive: boolean;
+  public readonly defaultPinned: boolean;
+
+  constructor(params: {
+    id?: UUID;
+    name: string;
+    shortDescription: string;
+    instructions: string;
+    isActive?: boolean;
+    defaultActive?: boolean;
+    defaultPinned?: boolean;
+    createdAt?: Date;
+    updatedAt?: Date;
+  }) {
+    super(params);
+    this.defaultActive = params.defaultActive ?? false;
+    this.defaultPinned = params.defaultPinned ?? false;
+  }
+}

--- a/ayunis-core-backend/src/domain/skill-templates/domain/skill-template.entity.spec.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/domain/skill-template.entity.spec.ts
@@ -1,164 +1,158 @@
-import {
-  SkillTemplate,
-  InvalidSkillTemplateNameError,
-} from './skill-template.entity';
+import { InvalidSkillTemplateNameError } from './skill-template.entity';
+import { AlwaysOnSkillTemplate } from './always-on-skill-template.entity';
+import { PreCreatedCopySkillTemplate } from './pre-created-copy-skill-template.entity';
 import { DistributionMode } from './distribution-mode.enum';
 import type { UUID } from 'crypto';
 
-describe('SkillTemplate', () => {
+describe('AlwaysOnSkillTemplate', () => {
   const validParams = {
     name: 'Datenschutz-Hinweis',
     shortDescription: 'Weist auf Datenschutzrichtlinien hin',
     instructions: 'Du musst immer auf den Datenschutz achten.',
-    distributionMode: DistributionMode.ALWAYS_ON,
   };
 
-  describe('construction', () => {
-    it('should create a skill template with valid parameters', () => {
-      const template = new SkillTemplate(validParams);
+  it('should always have distributionMode ALWAYS_ON', () => {
+    const template = new AlwaysOnSkillTemplate(validParams);
 
-      expect(template.id).toBeDefined();
-      expect(template.name).toBe('Datenschutz-Hinweis');
-      expect(template.shortDescription).toBe(
-        'Weist auf Datenschutzrichtlinien hin',
-      );
-      expect(template.instructions).toBe(
-        'Du musst immer auf den Datenschutz achten.',
-      );
-      expect(template.distributionMode).toBe(DistributionMode.ALWAYS_ON);
-      expect(template.isActive).toBe(false);
-      expect(template.createdAt).toBeInstanceOf(Date);
-      expect(template.updatedAt).toBeInstanceOf(Date);
-    });
-
-    it('should use provided id when given', () => {
-      const id = '550e8400-e29b-41d4-a716-446655440000' as UUID;
-      const template = new SkillTemplate({ ...validParams, id });
-
-      expect(template.id).toBe(id);
-    });
-
-    it('should use provided isActive value', () => {
-      const template = new SkillTemplate({ ...validParams, isActive: true });
-
-      expect(template.isActive).toBe(true);
-    });
-
-    it('should use provided dates', () => {
-      const createdAt = new Date('2026-01-15');
-      const updatedAt = new Date('2026-02-20');
-      const template = new SkillTemplate({
-        ...validParams,
-        createdAt,
-        updatedAt,
-      });
-
-      expect(template.createdAt).toEqual(createdAt);
-      expect(template.updatedAt).toEqual(updatedAt);
-    });
-
-    it('should accept pre_created_copy distribution mode', () => {
-      const template = new SkillTemplate({
-        ...validParams,
-        distributionMode: DistributionMode.PRE_CREATED_COPY,
-      });
-
-      expect(template.distributionMode).toBe(
-        DistributionMode.PRE_CREATED_COPY,
-      );
-    });
+    expect(template.distributionMode).toBe(DistributionMode.ALWAYS_ON);
   });
 
-  describe('name validation', () => {
-    it('should accept names with letters and spaces', () => {
-      const template = new SkillTemplate({
-        ...validParams,
-        name: 'Legal Research Assistant',
-      });
-      expect(template.name).toBe('Legal Research Assistant');
+  it('should create with valid parameters and defaults', () => {
+    const template = new AlwaysOnSkillTemplate(validParams);
+
+    expect(template.id).toBeDefined();
+    expect(template.name).toBe('Datenschutz-Hinweis');
+    expect(template.shortDescription).toBe(
+      'Weist auf Datenschutzrichtlinien hin',
+    );
+    expect(template.instructions).toBe(
+      'Du musst immer auf den Datenschutz achten.',
+    );
+    expect(template.isActive).toBe(false);
+    expect(template.createdAt).toBeInstanceOf(Date);
+    expect(template.updatedAt).toBeInstanceOf(Date);
+  });
+
+  it('should use provided id when given', () => {
+    const id = '550e8400-e29b-41d4-a716-446655440000' as UUID;
+    const template = new AlwaysOnSkillTemplate({ ...validParams, id });
+
+    expect(template.id).toBe(id);
+  });
+
+  it('should use provided isActive value', () => {
+    const template = new AlwaysOnSkillTemplate({
+      ...validParams,
+      isActive: true,
     });
 
-    it('should accept names with hyphens', () => {
-      const template = new SkillTemplate({
-        ...validParams,
-        name: 'DSGVO-Konform',
-      });
-      expect(template.name).toBe('DSGVO-Konform');
+    expect(template.isActive).toBe(true);
+  });
+
+  it('should use provided dates', () => {
+    const createdAt = new Date('2026-01-15');
+    const updatedAt = new Date('2026-02-20');
+    const template = new AlwaysOnSkillTemplate({
+      ...validParams,
+      createdAt,
+      updatedAt,
     });
 
-    it('should accept single character names', () => {
-      const template = new SkillTemplate({ ...validParams, name: 'A' });
-      expect(template.name).toBe('A');
+    expect(template.createdAt).toEqual(createdAt);
+    expect(template.updatedAt).toEqual(updatedAt);
+  });
+});
+
+describe('PreCreatedCopySkillTemplate', () => {
+  const validParams = {
+    name: 'Willkommens-Skill',
+    shortDescription: 'Begrüßt neue Nutzer',
+    instructions: 'Begrüße den Nutzer freundlich.',
+  };
+
+  it('should always have distributionMode PRE_CREATED_COPY', () => {
+    const template = new PreCreatedCopySkillTemplate(validParams);
+
+    expect(template.distributionMode).toBe(DistributionMode.PRE_CREATED_COPY);
+  });
+
+  it('should default defaultActive and defaultPinned to false', () => {
+    const template = new PreCreatedCopySkillTemplate(validParams);
+
+    expect(template.defaultActive).toBe(false);
+    expect(template.defaultPinned).toBe(false);
+  });
+
+  it('should accept explicit defaultActive and defaultPinned values', () => {
+    const template = new PreCreatedCopySkillTemplate({
+      ...validParams,
+      defaultActive: true,
+      defaultPinned: true,
     });
 
-    it('should accept names with special characters like &, ?, /', () => {
-      expect(
-        new SkillTemplate({ ...validParams, name: 'Q&A Helper' }).name,
-      ).toBe('Q&A Helper');
-      expect(
-        new SkillTemplate({ ...validParams, name: "What's New?" }).name,
-      ).toBe("What's New?");
-      expect(
-        new SkillTemplate({ ...validParams, name: 'Legal/Tax' }).name,
-      ).toBe('Legal/Tax');
-    });
+    expect(template.defaultActive).toBe(true);
+    expect(template.defaultPinned).toBe(true);
+  });
 
-    it('should accept names with underscores', () => {
-      const template = new SkillTemplate({
-        ...validParams,
-        name: 'my_template',
-      });
-      expect(template.name).toBe('my_template');
-    });
+  it('should create with valid parameters and defaults', () => {
+    const template = new PreCreatedCopySkillTemplate(validParams);
 
-    it('should accept names longer than 100 characters (max enforced at DTO layer)', () => {
-      const name = 'A'.repeat(150);
-      const template = new SkillTemplate({ ...validParams, name });
-      expect(template.name).toBe(name);
-    });
+    expect(template.id).toBeDefined();
+    expect(template.name).toBe('Willkommens-Skill');
+    expect(template.isActive).toBe(false);
+    expect(template.createdAt).toBeInstanceOf(Date);
+    expect(template.updatedAt).toBeInstanceOf(Date);
+  });
+});
 
-    it('should reject names with consecutive spaces', () => {
-      expect(
-        () => new SkillTemplate({ ...validParams, name: 'Bad  Name' }),
-      ).toThrow(InvalidSkillTemplateNameError);
-    });
+describe('Name validation', () => {
+  const alwaysOnParams = {
+    name: 'Valid',
+    shortDescription: 'desc',
+    instructions: 'instr',
+  };
 
-    it('should reject empty names', () => {
-      expect(() => new SkillTemplate({ ...validParams, name: '' })).toThrow(
-        InvalidSkillTemplateNameError,
-      );
+  it('should accept names with letters and spaces on AlwaysOnSkillTemplate', () => {
+    const template = new AlwaysOnSkillTemplate({
+      ...alwaysOnParams,
+      name: 'Legal Research Assistant',
     });
+    expect(template.name).toBe('Legal Research Assistant');
+  });
 
-    it('should reject whitespace-only names', () => {
-      expect(() => new SkillTemplate({ ...validParams, name: '   ' })).toThrow(
-        InvalidSkillTemplateNameError,
-      );
+  it('should accept names with hyphens on PreCreatedCopySkillTemplate', () => {
+    const template = new PreCreatedCopySkillTemplate({
+      ...alwaysOnParams,
+      name: 'DSGVO-Konform',
     });
+    expect(template.name).toBe('DSGVO-Konform');
+  });
 
-    it('should reject names starting with a space', () => {
-      expect(
-        () => new SkillTemplate({ ...validParams, name: ' Leading' }),
-      ).toThrow(InvalidSkillTemplateNameError);
-    });
+  it('should reject names with consecutive spaces', () => {
+    expect(
+      () => new AlwaysOnSkillTemplate({ ...alwaysOnParams, name: 'Bad  Name' }),
+    ).toThrow(InvalidSkillTemplateNameError);
+  });
 
-    it('should reject names ending with a space', () => {
-      expect(
-        () => new SkillTemplate({ ...validParams, name: 'Trailing ' }),
-      ).toThrow(InvalidSkillTemplateNameError);
-    });
+  it('should reject empty names', () => {
+    expect(
+      () => new PreCreatedCopySkillTemplate({ ...alwaysOnParams, name: '' }),
+    ).toThrow(InvalidSkillTemplateNameError);
+  });
 
-    it('should reject names with control characters', () => {
-      expect(
-        () => new SkillTemplate({ ...validParams, name: 'Test\u0000Name' }),
-      ).toThrow(InvalidSkillTemplateNameError);
-    });
+  it('should reject names starting with a space', () => {
+    expect(
+      () => new AlwaysOnSkillTemplate({ ...alwaysOnParams, name: ' Leading' }),
+    ).toThrow(InvalidSkillTemplateNameError);
+  });
 
-    it('should accept names with ZWJ emoji sequences', () => {
-      const template = new SkillTemplate({
-        ...validParams,
-        name: '👩‍💻 Coding',
-      });
-      expect(template.name).toBe('👩‍💻 Coding');
-    });
+  it('should reject names ending with a space', () => {
+    expect(
+      () =>
+        new PreCreatedCopySkillTemplate({
+          ...alwaysOnParams,
+          name: 'Trailing ',
+        }),
+    ).toThrow(InvalidSkillTemplateNameError);
   });
 });

--- a/ayunis-core-backend/src/domain/skill-templates/domain/skill-template.entity.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/domain/skill-template.entity.ts
@@ -32,22 +32,21 @@ function validateSkillTemplateName(name: string): void {
   }
 }
 
-export class SkillTemplate {
+export abstract class SkillTemplate {
   public readonly id: UUID;
   public readonly name: string;
   public readonly shortDescription: string;
   public readonly instructions: string;
-  public readonly distributionMode: DistributionMode;
+  public abstract readonly distributionMode: DistributionMode;
   public readonly isActive: boolean;
   public readonly createdAt: Date;
   public readonly updatedAt: Date;
 
-  constructor(params: {
+  protected constructor(params: {
     id?: UUID;
     name: string;
     shortDescription: string;
     instructions: string;
-    distributionMode: DistributionMode;
     isActive?: boolean;
     createdAt?: Date;
     updatedAt?: Date;
@@ -57,7 +56,6 @@ export class SkillTemplate {
     this.name = params.name;
     this.shortDescription = params.shortDescription;
     this.instructions = params.instructions;
-    this.distributionMode = params.distributionMode;
     this.isActive = params.isActive ?? false;
     this.createdAt = params.createdAt ?? new Date();
     this.updatedAt = params.updatedAt ?? new Date();

--- a/ayunis-core-backend/src/domain/skill-templates/infrastructure/persistence/local/local-skill-template-repository.module.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/infrastructure/persistence/local/local-skill-template-repository.module.ts
@@ -2,10 +2,18 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { LocalSkillTemplateRepository } from './local-skill-template.repository';
 import { SkillTemplateRecord } from './schema/skill-template.record';
+import { AlwaysOnSkillTemplateRecord } from './schema/always-on-skill-template.record';
+import { PreCreatedCopySkillTemplateRecord } from './schema/pre-created-copy-skill-template.record';
 import { SkillTemplateMapper } from './mappers/skill-template.mapper';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([SkillTemplateRecord])],
+  imports: [
+    TypeOrmModule.forFeature([
+      SkillTemplateRecord,
+      AlwaysOnSkillTemplateRecord,
+      PreCreatedCopySkillTemplateRecord,
+    ]),
+  ],
   providers: [SkillTemplateMapper, LocalSkillTemplateRepository],
   exports: [LocalSkillTemplateRepository],
 })

--- a/ayunis-core-backend/src/domain/skill-templates/infrastructure/persistence/local/local-skill-template.repository.spec.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/infrastructure/persistence/local/local-skill-template.repository.spec.ts
@@ -1,37 +1,77 @@
-import type { Repository } from 'typeorm';
+import type { ObjectLiteral, Repository } from 'typeorm';
 import { QueryFailedError } from 'typeorm';
 import { randomUUID } from 'crypto';
 
 import { LocalSkillTemplateRepository } from './local-skill-template.repository';
-import { SkillTemplateRecord } from './schema/skill-template.record';
+import type { SkillTemplateRecord } from './schema/skill-template.record';
+import { AlwaysOnSkillTemplateRecord } from './schema/always-on-skill-template.record';
+import { PreCreatedCopySkillTemplateRecord } from './schema/pre-created-copy-skill-template.record';
 import { SkillTemplateMapper } from './mappers/skill-template.mapper';
-import { SkillTemplate } from '../../../domain/skill-template.entity';
+import { AlwaysOnSkillTemplate } from '../../../domain/always-on-skill-template.entity';
+import { PreCreatedCopySkillTemplate } from '../../../domain/pre-created-copy-skill-template.entity';
 import { DistributionMode } from '../../../domain/distribution-mode.enum';
 import {
   DuplicateSkillTemplateNameError,
   SkillTemplateNotFoundError,
 } from '../../../application/skill-templates.errors';
 
-function buildSkillTemplate(overrides?: Partial<SkillTemplate>): SkillTemplate {
-  return new SkillTemplate({
+function buildAlwaysOnTemplate(
+  overrides?: Partial<{
+    name: string;
+    isActive: boolean;
+  }>,
+): AlwaysOnSkillTemplate {
+  return new AlwaysOnSkillTemplate({
     id: randomUUID(),
-    name: 'Bürgerservice Vorlage',
+    name: overrides?.name ?? 'Bürgerservice Vorlage',
     shortDescription: 'Vorlage für Bürgerservice-Skills',
     instructions: 'Beantworte Fragen zum Bürgerservice.',
-    distributionMode: DistributionMode.PRE_CREATED_COPY,
-    isActive: true,
-    ...overrides,
+    isActive: overrides?.isActive ?? true,
   });
 }
 
-function buildRecord(template: SkillTemplate): SkillTemplateRecord {
-  const record = new SkillTemplateRecord();
+function buildPreCreatedTemplate(
+  overrides?: Partial<{
+    name: string;
+    isActive: boolean;
+  }>,
+): PreCreatedCopySkillTemplate {
+  return new PreCreatedCopySkillTemplate({
+    id: randomUUID(),
+    name: overrides?.name ?? 'Willkommens-Vorlage',
+    shortDescription: 'Begrüßt neue Nutzer',
+    instructions: 'Begrüße den Nutzer freundlich.',
+    isActive: overrides?.isActive ?? true,
+    defaultActive: true,
+    defaultPinned: false,
+  });
+}
+
+function buildAlwaysOnRecord(
+  template: AlwaysOnSkillTemplate,
+): AlwaysOnSkillTemplateRecord {
+  const record = new AlwaysOnSkillTemplateRecord();
   record.id = template.id;
   record.name = template.name;
   record.shortDescription = template.shortDescription;
   record.instructions = template.instructions;
-  record.distributionMode = template.distributionMode;
   record.isActive = template.isActive;
+  record.createdAt = template.createdAt;
+  record.updatedAt = template.updatedAt;
+  return record;
+}
+
+function buildPreCreatedRecord(
+  template: PreCreatedCopySkillTemplate,
+): PreCreatedCopySkillTemplateRecord {
+  const record = new PreCreatedCopySkillTemplateRecord();
+  record.id = template.id;
+  record.name = template.name;
+  record.shortDescription = template.shortDescription;
+  record.instructions = template.instructions;
+  record.isActive = template.isActive;
+  record.defaultActive = template.defaultActive;
+  record.defaultPinned = template.defaultPinned;
   record.createdAt = template.createdAt;
   record.updatedAt = template.updatedAt;
   return record;
@@ -43,29 +83,44 @@ function createPgUniqueViolation(): QueryFailedError {
   return error;
 }
 
+function createMockRepo<T extends ObjectLiteral>(): jest.Mocked<Repository<T>> {
+  return {
+    save: jest.fn(),
+    findOne: jest.fn(),
+    find: jest.fn(),
+    delete: jest.fn(),
+    update: jest.fn(),
+  } as unknown as jest.Mocked<Repository<T>>;
+}
+
 describe('LocalSkillTemplateRepository', () => {
   let repo: LocalSkillTemplateRepository;
   let mockTypeOrmRepo: jest.Mocked<Repository<SkillTemplateRecord>>;
+  let mockAlwaysOnRepo: jest.Mocked<Repository<AlwaysOnSkillTemplateRecord>>;
+  let mockPreCreatedRepo: jest.Mocked<
+    Repository<PreCreatedCopySkillTemplateRecord>
+  >;
   let mapper: SkillTemplateMapper;
 
   beforeEach(() => {
     mapper = new SkillTemplateMapper();
 
-    mockTypeOrmRepo = {
-      save: jest.fn(),
-      findOne: jest.fn(),
-      find: jest.fn(),
-      delete: jest.fn(),
-      update: jest.fn(),
-    } as unknown as jest.Mocked<Repository<SkillTemplateRecord>>;
+    mockTypeOrmRepo = createMockRepo<SkillTemplateRecord>();
+    mockAlwaysOnRepo = createMockRepo<AlwaysOnSkillTemplateRecord>();
+    mockPreCreatedRepo = createMockRepo<PreCreatedCopySkillTemplateRecord>();
 
-    repo = new LocalSkillTemplateRepository(mockTypeOrmRepo, mapper);
+    repo = new LocalSkillTemplateRepository(
+      mockTypeOrmRepo,
+      mockAlwaysOnRepo,
+      mockPreCreatedRepo,
+      mapper,
+    );
   });
 
   describe('create', () => {
     it('should save and return the created skill template', async () => {
-      const template = buildSkillTemplate();
-      const record = buildRecord(template);
+      const template = buildPreCreatedTemplate();
+      const record = buildPreCreatedRecord(template);
       mockTypeOrmRepo.save.mockResolvedValue(record);
 
       const result = await repo.create(template);
@@ -76,7 +131,7 @@ describe('LocalSkillTemplateRepository', () => {
     });
 
     it('should throw DuplicateSkillTemplateNameError on unique violation', async () => {
-      const template = buildSkillTemplate();
+      const template = buildPreCreatedTemplate();
       mockTypeOrmRepo.save.mockRejectedValue(createPgUniqueViolation());
 
       await expect(repo.create(template)).rejects.toThrow(
@@ -85,7 +140,7 @@ describe('LocalSkillTemplateRepository', () => {
     });
 
     it('should rethrow non-unique-violation errors', async () => {
-      const template = buildSkillTemplate();
+      const template = buildPreCreatedTemplate();
       const dbError = new Error('connection lost');
       mockTypeOrmRepo.save.mockRejectedValue(dbError);
 
@@ -95,7 +150,7 @@ describe('LocalSkillTemplateRepository', () => {
 
   describe('update', () => {
     it('should throw SkillTemplateNotFoundError when template does not exist', async () => {
-      const template = buildSkillTemplate();
+      const template = buildAlwaysOnTemplate();
       mockTypeOrmRepo.findOne.mockResolvedValue(null);
 
       await expect(repo.update(template)).rejects.toThrow(
@@ -105,8 +160,8 @@ describe('LocalSkillTemplateRepository', () => {
     });
 
     it('should save and return the updated skill template', async () => {
-      const template = buildSkillTemplate();
-      const record = buildRecord(template);
+      const template = buildAlwaysOnTemplate();
+      const record = buildAlwaysOnRecord(template);
       mockTypeOrmRepo.findOne.mockResolvedValue(record);
       mockTypeOrmRepo.save.mockResolvedValue(record);
 
@@ -117,8 +172,8 @@ describe('LocalSkillTemplateRepository', () => {
     });
 
     it('should throw DuplicateSkillTemplateNameError when renaming to existing name', async () => {
-      const template = buildSkillTemplate({ name: 'Duplicate Name' });
-      const existingRecord = buildRecord(template);
+      const template = buildAlwaysOnTemplate({ name: 'Duplicate Name' });
+      const existingRecord = buildAlwaysOnRecord(template);
       mockTypeOrmRepo.findOne.mockResolvedValue(existingRecord);
       mockTypeOrmRepo.save.mockRejectedValue(createPgUniqueViolation());
 
@@ -154,8 +209,8 @@ describe('LocalSkillTemplateRepository', () => {
     });
 
     it('should return the domain entity when found', async () => {
-      const template = buildSkillTemplate();
-      const record = buildRecord(template);
+      const template = buildAlwaysOnTemplate();
+      const record = buildAlwaysOnRecord(template);
       mockTypeOrmRepo.findOne.mockResolvedValue(record);
 
       const result = await repo.findOne(template.id);
@@ -167,11 +222,11 @@ describe('LocalSkillTemplateRepository', () => {
 
   describe('findAll', () => {
     it('should return all templates ordered by createdAt descending', async () => {
-      const older = buildSkillTemplate({ name: 'Ältere Vorlage' });
-      const newer = buildSkillTemplate({ name: 'Neuere Vorlage' });
+      const older = buildAlwaysOnTemplate({ name: 'Ältere Vorlage' });
+      const newer = buildPreCreatedTemplate({ name: 'Neuere Vorlage' });
       mockTypeOrmRepo.find.mockResolvedValue([
-        buildRecord(newer),
-        buildRecord(older),
+        buildPreCreatedRecord(newer),
+        buildAlwaysOnRecord(older),
       ]);
 
       const result = await repo.findAll();
@@ -195,8 +250,8 @@ describe('LocalSkillTemplateRepository', () => {
 
   describe('findByName', () => {
     it('should return the template when found by name', async () => {
-      const template = buildSkillTemplate({ name: 'Meldewesen Vorlage' });
-      const record = buildRecord(template);
+      const template = buildAlwaysOnTemplate({ name: 'Meldewesen Vorlage' });
+      const record = buildAlwaysOnRecord(template);
       mockTypeOrmRepo.findOne.mockResolvedValue(record);
 
       const result = await repo.findByName('Meldewesen Vorlage');
@@ -218,13 +273,14 @@ describe('LocalSkillTemplateRepository', () => {
   });
 
   describe('findActiveByMode', () => {
-    it('should return only active templates with the specified distribution mode', async () => {
-      const activeAlwaysOn = buildSkillTemplate({
+    it('should query the always-on child repository for ALWAYS_ON mode', async () => {
+      const activeAlwaysOn = buildAlwaysOnTemplate({
         name: 'Immer Aktiv',
-        distributionMode: DistributionMode.ALWAYS_ON,
         isActive: true,
       });
-      mockTypeOrmRepo.find.mockResolvedValue([buildRecord(activeAlwaysOn)]);
+      mockAlwaysOnRepo.find.mockResolvedValue([
+        buildAlwaysOnRecord(activeAlwaysOn),
+      ]);
 
       const result = await repo.findActiveByMode(DistributionMode.ALWAYS_ON);
 
@@ -232,35 +288,39 @@ describe('LocalSkillTemplateRepository', () => {
       expect(result[0].name).toBe('Immer Aktiv');
       expect(result[0].isActive).toBe(true);
       expect(result[0].distributionMode).toBe(DistributionMode.ALWAYS_ON);
-      expect(mockTypeOrmRepo.find).toHaveBeenCalledWith({
-        where: { isActive: true, distributionMode: DistributionMode.ALWAYS_ON },
+      expect(mockAlwaysOnRepo.find).toHaveBeenCalledWith({
+        where: { isActive: true },
         order: { createdAt: 'ASC' },
       });
     });
 
-    it('should return empty array when no active templates match the mode', async () => {
-      mockTypeOrmRepo.find.mockResolvedValue([]);
+    it('should query the pre-created child repository for PRE_CREATED_COPY mode', async () => {
+      const preCreated = buildPreCreatedTemplate({
+        name: 'Vorkonfiguriert',
+        isActive: true,
+      });
+      mockPreCreatedRepo.find.mockResolvedValue([
+        buildPreCreatedRecord(preCreated),
+      ]);
 
       const result = await repo.findActiveByMode(
         DistributionMode.PRE_CREATED_COPY,
       );
 
-      expect(result).toEqual([]);
+      expect(result).toHaveLength(1);
+      expect(result[0].name).toBe('Vorkonfiguriert');
+      expect(mockPreCreatedRepo.find).toHaveBeenCalledWith({
+        where: { isActive: true },
+        order: { createdAt: 'ASC' },
+      });
     });
 
-    it('should not return inactive templates', async () => {
-      // The repository queries with isActive: true, so inactive records
-      // are filtered at the database level. Mock returns empty to verify
-      // the correct query is issued.
-      mockTypeOrmRepo.find.mockResolvedValue([]);
+    it('should return empty array when no active templates match the mode', async () => {
+      mockAlwaysOnRepo.find.mockResolvedValue([]);
 
-      await repo.findActiveByMode(DistributionMode.ALWAYS_ON);
+      const result = await repo.findActiveByMode(DistributionMode.ALWAYS_ON);
 
-      expect(mockTypeOrmRepo.find).toHaveBeenCalledWith(
-        expect.objectContaining({
-          where: expect.objectContaining({ isActive: true }),
-        }),
-      );
+      expect(result).toEqual([]);
     });
   });
 });

--- a/ayunis-core-backend/src/domain/skill-templates/infrastructure/persistence/local/local-skill-template.repository.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/infrastructure/persistence/local/local-skill-template.repository.ts
@@ -6,6 +6,8 @@ import type { UUID } from 'crypto';
 import { SkillTemplateRepository } from '../../../application/ports/skill-template.repository';
 import { SkillTemplate } from '../../../domain/skill-template.entity';
 import { SkillTemplateRecord } from './schema/skill-template.record';
+import { AlwaysOnSkillTemplateRecord } from './schema/always-on-skill-template.record';
+import { PreCreatedCopySkillTemplateRecord } from './schema/pre-created-copy-skill-template.record';
 import { SkillTemplateMapper } from './mappers/skill-template.mapper';
 import { DistributionMode } from '../../../domain/distribution-mode.enum';
 import {
@@ -18,12 +20,25 @@ const PG_UNIQUE_VIOLATION = '23505';
 @Injectable()
 export class LocalSkillTemplateRepository implements SkillTemplateRepository {
   private readonly logger = new Logger(LocalSkillTemplateRepository.name);
+  private readonly childRepos: Record<
+    DistributionMode,
+    Repository<SkillTemplateRecord>
+  >;
 
   constructor(
     @InjectRepository(SkillTemplateRecord)
     private readonly repository: Repository<SkillTemplateRecord>,
+    @InjectRepository(AlwaysOnSkillTemplateRecord)
+    alwaysOnRepository: Repository<AlwaysOnSkillTemplateRecord>,
+    @InjectRepository(PreCreatedCopySkillTemplateRecord)
+    preCreatedCopyRepository: Repository<PreCreatedCopySkillTemplateRecord>,
     private readonly mapper: SkillTemplateMapper,
-  ) {}
+  ) {
+    this.childRepos = {
+      [DistributionMode.ALWAYS_ON]: alwaysOnRepository,
+      [DistributionMode.PRE_CREATED_COPY]: preCreatedCopyRepository,
+    };
+  }
 
   async create(skillTemplate: SkillTemplate): Promise<SkillTemplate> {
     this.logger.log('create', { name: skillTemplate.name });
@@ -80,8 +95,9 @@ export class LocalSkillTemplateRepository implements SkillTemplateRepository {
 
   async findActiveByMode(mode: DistributionMode): Promise<SkillTemplate[]> {
     this.logger.log('findActiveByMode', { mode });
-    const records = await this.repository.find({
-      where: { isActive: true, distributionMode: mode },
+    const childRepo = this.childRepos[mode];
+    const records = await childRepo.find({
+      where: { isActive: true },
       order: { createdAt: 'ASC' },
     });
     return records.map((r) => this.mapper.toDomain(r));

--- a/ayunis-core-backend/src/domain/skill-templates/infrastructure/persistence/local/mappers/skill-template.mapper.spec.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/infrastructure/persistence/local/mappers/skill-template.mapper.spec.ts
@@ -1,7 +1,11 @@
-import { SkillTemplate } from '../../../../domain/skill-template.entity';
-import { SkillTemplateRecord } from '../schema/skill-template.record';
-import { SkillTemplateMapper } from './skill-template.mapper';
+import { AlwaysOnSkillTemplate } from '../../../../domain/always-on-skill-template.entity';
+import { PreCreatedCopySkillTemplate } from '../../../../domain/pre-created-copy-skill-template.entity';
+import type { SkillTemplate } from '../../../../domain/skill-template.entity';
 import { DistributionMode } from '../../../../domain/distribution-mode.enum';
+import type { SkillTemplateRecord } from '../schema/skill-template.record';
+import { AlwaysOnSkillTemplateRecord } from '../schema/always-on-skill-template.record';
+import { PreCreatedCopySkillTemplateRecord } from '../schema/pre-created-copy-skill-template.record';
+import { SkillTemplateMapper } from './skill-template.mapper';
 import type { UUID } from 'crypto';
 
 describe('SkillTemplateMapper', () => {
@@ -14,20 +18,20 @@ describe('SkillTemplateMapper', () => {
   });
 
   describe('toDomain', () => {
-    it('should map a SkillTemplateRecord to SkillTemplate domain entity', () => {
-      const record = new SkillTemplateRecord();
+    it('should map an AlwaysOnSkillTemplateRecord to AlwaysOnSkillTemplate', () => {
+      const record = new AlwaysOnSkillTemplateRecord();
       record.id = mockId;
       record.name = 'Datenschutz-Richtlinie';
       record.shortDescription = 'Stellt Datenschutzkonformität sicher';
       record.instructions =
         'Achte bei allen Antworten auf den Datenschutz und die DSGVO.';
-      record.distributionMode = DistributionMode.ALWAYS_ON;
       record.isActive = true;
       record.createdAt = new Date('2026-01-01');
       record.updatedAt = new Date('2026-01-02');
 
       const domain = mapper.toDomain(record);
 
+      expect(domain).toBeInstanceOf(AlwaysOnSkillTemplate);
       expect(domain.id).toBe(mockId);
       expect(domain.name).toBe('Datenschutz-Richtlinie');
       expect(domain.shortDescription).toBe(
@@ -42,76 +46,166 @@ describe('SkillTemplateMapper', () => {
       expect(domain.updatedAt).toEqual(new Date('2026-01-02'));
     });
 
-    it('should map a record with pre_created_copy mode', () => {
-      const record = new SkillTemplateRecord();
+    it('should map a PreCreatedCopySkillTemplateRecord to PreCreatedCopySkillTemplate', () => {
+      const record = new PreCreatedCopySkillTemplateRecord();
       record.id = mockId;
       record.name = 'Willkommens-Skill';
       record.shortDescription = 'Begrüßt neue Nutzer';
       record.instructions = 'Begrüße den Nutzer freundlich.';
-      record.distributionMode = DistributionMode.PRE_CREATED_COPY;
       record.isActive = false;
+      record.defaultActive = true;
+      record.defaultPinned = true;
       record.createdAt = new Date('2026-03-01');
       record.updatedAt = new Date('2026-03-01');
 
       const domain = mapper.toDomain(record);
 
+      expect(domain).toBeInstanceOf(PreCreatedCopySkillTemplate);
       expect(domain.distributionMode).toBe(DistributionMode.PRE_CREATED_COPY);
       expect(domain.isActive).toBe(false);
+      expect((domain as PreCreatedCopySkillTemplate).defaultActive).toBe(true);
+      expect((domain as PreCreatedCopySkillTemplate).defaultPinned).toBe(true);
+    });
+
+    it('should treat null defaultActive/defaultPinned as false', () => {
+      const record = new PreCreatedCopySkillTemplateRecord();
+      record.id = mockId;
+      record.name = 'Null-Defaults';
+      record.shortDescription = 'Has null defaults';
+      record.instructions = 'Test instructions.';
+      record.isActive = false;
+      record.defaultActive = null;
+      record.defaultPinned = null;
+      record.createdAt = new Date('2026-03-01');
+      record.updatedAt = new Date('2026-03-01');
+
+      const domain = mapper.toDomain(record) as PreCreatedCopySkillTemplate;
+
+      expect(domain.defaultActive).toBe(false);
+      expect(domain.defaultPinned).toBe(false);
+    });
+
+    it('should throw for unknown record type', () => {
+      const record = {
+        constructor: { name: 'UnknownRecord' },
+      } as SkillTemplateRecord;
+
+      expect(() => mapper.toDomain(record)).toThrow(
+        'Unknown skill template record type: UnknownRecord',
+      );
     });
   });
 
   describe('toRecord', () => {
-    it('should map a SkillTemplate domain entity to SkillTemplateRecord', () => {
-      const domain = new SkillTemplate({
+    it('should map an AlwaysOnSkillTemplate to AlwaysOnSkillTemplateRecord', () => {
+      const domain = new AlwaysOnSkillTemplate({
         id: mockId,
         name: 'Datenschutz-Richtlinie',
         shortDescription: 'Stellt Datenschutzkonformität sicher',
         instructions:
           'Achte bei allen Antworten auf den Datenschutz und die DSGVO.',
-        distributionMode: DistributionMode.ALWAYS_ON,
         isActive: true,
       });
 
       const record = mapper.toRecord(domain);
 
+      expect(record).toBeInstanceOf(AlwaysOnSkillTemplateRecord);
       expect(record.id).toBe(mockId);
       expect(record.name).toBe('Datenschutz-Richtlinie');
-      expect(record.shortDescription).toBe(
-        'Stellt Datenschutzkonformität sicher',
-      );
-      expect(record.instructions).toBe(
-        'Achte bei allen Antworten auf den Datenschutz und die DSGVO.',
-      );
-      expect(record.distributionMode).toBe(DistributionMode.ALWAYS_ON);
       expect(record.isActive).toBe(true);
+    });
+
+    it('should map a PreCreatedCopySkillTemplate to PreCreatedCopySkillTemplateRecord', () => {
+      const domain = new PreCreatedCopySkillTemplate({
+        id: mockId,
+        name: 'Willkommens-Skill',
+        shortDescription: 'Begrüßt neue Nutzer',
+        instructions: 'Begrüße den Nutzer freundlich.',
+        isActive: true,
+        defaultActive: true,
+        defaultPinned: true,
+      });
+
+      const record = mapper.toRecord(domain);
+
+      expect(record).toBeInstanceOf(PreCreatedCopySkillTemplateRecord);
+      expect(record.id).toBe(mockId);
+      expect(record.name).toBe('Willkommens-Skill');
+      expect(record.isActive).toBe(true);
+      expect((record as PreCreatedCopySkillTemplateRecord).defaultActive).toBe(
+        true,
+      );
+      expect((record as PreCreatedCopySkillTemplateRecord).defaultPinned).toBe(
+        true,
+      );
+    });
+
+    it('should throw for unknown domain type', () => {
+      const domain = {
+        constructor: { name: 'UnknownEntity' },
+      } as unknown as SkillTemplate;
+
+      expect(() => mapper.toRecord(domain)).toThrow(
+        'Unknown skill template type: UnknownEntity',
+      );
     });
   });
 
   describe('round-trip', () => {
-    it('should preserve all fields through domain → record → domain', () => {
-      const original = new SkillTemplate({
+    it('should preserve all fields through AlwaysOnSkillTemplate → record → domain', () => {
+      const original = new AlwaysOnSkillTemplate({
         id: mockId,
         name: 'Verwaltungs-Assistent',
         shortDescription: 'Unterstützt bei Verwaltungsaufgaben',
         instructions: 'Hilf bei kommunalen Verwaltungsaufgaben.',
-        distributionMode: DistributionMode.PRE_CREATED_COPY,
         isActive: true,
         createdAt: new Date('2026-02-15'),
         updatedAt: new Date('2026-02-20'),
       });
 
       const record = mapper.toRecord(original);
-      // Simulate DB returning timestamps
       record.createdAt = original.createdAt;
       record.updatedAt = original.updatedAt;
       const restored = mapper.toDomain(record);
 
+      expect(restored).toBeInstanceOf(AlwaysOnSkillTemplate);
       expect(restored.id).toBe(original.id);
       expect(restored.name).toBe(original.name);
       expect(restored.shortDescription).toBe(original.shortDescription);
       expect(restored.instructions).toBe(original.instructions);
       expect(restored.distributionMode).toBe(original.distributionMode);
       expect(restored.isActive).toBe(original.isActive);
+      expect(restored.createdAt).toEqual(original.createdAt);
+      expect(restored.updatedAt).toEqual(original.updatedAt);
+    });
+
+    it('should preserve all fields through PreCreatedCopySkillTemplate → record → domain', () => {
+      const original = new PreCreatedCopySkillTemplate({
+        id: mockId,
+        name: 'Begrüßungs-Skill',
+        shortDescription: 'Begrüßt Nutzer',
+        instructions: 'Begrüße den Nutzer.',
+        isActive: true,
+        defaultActive: true,
+        defaultPinned: false,
+        createdAt: new Date('2026-02-15'),
+        updatedAt: new Date('2026-02-20'),
+      });
+
+      const record = mapper.toRecord(original);
+      record.createdAt = original.createdAt;
+      record.updatedAt = original.updatedAt;
+      const restored = mapper.toDomain(record) as PreCreatedCopySkillTemplate;
+
+      expect(restored).toBeInstanceOf(PreCreatedCopySkillTemplate);
+      expect(restored.id).toBe(original.id);
+      expect(restored.name).toBe(original.name);
+      expect(restored.shortDescription).toBe(original.shortDescription);
+      expect(restored.instructions).toBe(original.instructions);
+      expect(restored.distributionMode).toBe(original.distributionMode);
+      expect(restored.isActive).toBe(original.isActive);
+      expect(restored.defaultActive).toBe(original.defaultActive);
+      expect(restored.defaultPinned).toBe(original.defaultPinned);
       expect(restored.createdAt).toEqual(original.createdAt);
       expect(restored.updatedAt).toEqual(original.updatedAt);
     });

--- a/ayunis-core-backend/src/domain/skill-templates/infrastructure/persistence/local/mappers/skill-template.mapper.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/infrastructure/persistence/local/mappers/skill-template.mapper.ts
@@ -1,30 +1,69 @@
 import { Injectable } from '@nestjs/common';
 import { SkillTemplate } from '../../../../domain/skill-template.entity';
+import { AlwaysOnSkillTemplate } from '../../../../domain/always-on-skill-template.entity';
+import { PreCreatedCopySkillTemplate } from '../../../../domain/pre-created-copy-skill-template.entity';
 import { SkillTemplateRecord } from '../schema/skill-template.record';
+import { AlwaysOnSkillTemplateRecord } from '../schema/always-on-skill-template.record';
+import { PreCreatedCopySkillTemplateRecord } from '../schema/pre-created-copy-skill-template.record';
 
 @Injectable()
 export class SkillTemplateMapper {
   toDomain(record: SkillTemplateRecord): SkillTemplate {
-    return new SkillTemplate({
+    if (record instanceof PreCreatedCopySkillTemplateRecord) {
+      return new PreCreatedCopySkillTemplate({
+        ...this.sharedRecordFields(record),
+        defaultActive: record.defaultActive ?? false,
+        defaultPinned: record.defaultPinned ?? false,
+      });
+    }
+
+    if (record instanceof AlwaysOnSkillTemplateRecord) {
+      return new AlwaysOnSkillTemplate(this.sharedRecordFields(record));
+    }
+
+    throw new Error(
+      'Unknown skill template record type: ' + record.constructor.name,
+    );
+  }
+
+  toRecord(domain: SkillTemplate): SkillTemplateRecord {
+    if (domain instanceof PreCreatedCopySkillTemplate) {
+      const record = new PreCreatedCopySkillTemplateRecord();
+      this.assignSharedRecordFields(record, domain);
+      record.defaultActive = domain.defaultActive;
+      record.defaultPinned = domain.defaultPinned;
+      return record;
+    }
+
+    if (domain instanceof AlwaysOnSkillTemplate) {
+      const record = new AlwaysOnSkillTemplateRecord();
+      this.assignSharedRecordFields(record, domain);
+      return record;
+    }
+
+    throw new Error('Unknown skill template type: ' + domain.constructor.name);
+  }
+
+  private sharedRecordFields(record: SkillTemplateRecord) {
+    return {
       id: record.id,
       name: record.name,
       shortDescription: record.shortDescription,
       instructions: record.instructions,
-      distributionMode: record.distributionMode,
       isActive: record.isActive,
       createdAt: record.createdAt,
       updatedAt: record.updatedAt,
-    });
+    };
   }
 
-  toRecord(domain: SkillTemplate): SkillTemplateRecord {
-    const record = new SkillTemplateRecord();
+  private assignSharedRecordFields(
+    record: SkillTemplateRecord,
+    domain: SkillTemplate,
+  ): void {
     record.id = domain.id;
     record.name = domain.name;
     record.shortDescription = domain.shortDescription;
     record.instructions = domain.instructions;
-    record.distributionMode = domain.distributionMode;
     record.isActive = domain.isActive;
-    return record;
   }
 }

--- a/ayunis-core-backend/src/domain/skill-templates/infrastructure/persistence/local/schema/always-on-skill-template.record.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/infrastructure/persistence/local/schema/always-on-skill-template.record.ts
@@ -1,0 +1,6 @@
+import { ChildEntity } from 'typeorm';
+import { SkillTemplateRecord } from './skill-template.record';
+import { DistributionMode } from '../../../../domain/distribution-mode.enum';
+
+@ChildEntity(DistributionMode.ALWAYS_ON)
+export class AlwaysOnSkillTemplateRecord extends SkillTemplateRecord {}

--- a/ayunis-core-backend/src/domain/skill-templates/infrastructure/persistence/local/schema/pre-created-copy-skill-template.record.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/infrastructure/persistence/local/schema/pre-created-copy-skill-template.record.ts
@@ -1,0 +1,12 @@
+import { ChildEntity, Column } from 'typeorm';
+import { SkillTemplateRecord } from './skill-template.record';
+import { DistributionMode } from '../../../../domain/distribution-mode.enum';
+
+@ChildEntity(DistributionMode.PRE_CREATED_COPY)
+export class PreCreatedCopySkillTemplateRecord extends SkillTemplateRecord {
+  @Column({ nullable: true })
+  defaultActive: boolean | null;
+
+  @Column({ nullable: true })
+  defaultPinned: boolean | null;
+}

--- a/ayunis-core-backend/src/domain/skill-templates/infrastructure/persistence/local/schema/skill-template.record.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/infrastructure/persistence/local/schema/skill-template.record.ts
@@ -1,9 +1,9 @@
-import { Column, Entity } from 'typeorm';
+import { Column, Entity, TableInheritance } from 'typeorm';
 import { BaseRecord } from '../../../../../../common/db/base-record';
-import { DistributionMode } from '../../../../domain/distribution-mode.enum';
 
 @Entity({ name: 'skill_templates' })
-export class SkillTemplateRecord extends BaseRecord {
+@TableInheritance({ column: { type: 'varchar', name: 'distributionMode' } })
+export abstract class SkillTemplateRecord extends BaseRecord {
   @Column({ nullable: false, unique: true })
   name: string;
 
@@ -12,13 +12,6 @@ export class SkillTemplateRecord extends BaseRecord {
 
   @Column({ nullable: false, type: 'text' })
   instructions: string;
-
-  @Column({
-    type: 'enum',
-    enum: DistributionMode,
-    nullable: false,
-  })
-  distributionMode: DistributionMode;
 
   @Column({ nullable: false, default: false })
   isActive: boolean;

--- a/ayunis-core-backend/src/domain/tools/application/handlers/activate-skill-tool.handler.spec.ts
+++ b/ayunis-core-backend/src/domain/tools/application/handlers/activate-skill-tool.handler.spec.ts
@@ -9,8 +9,7 @@ import { SkillActivationService } from 'src/domain/skills/application/services/s
 import { FindAlwaysOnTemplateByNameUseCase } from 'src/domain/skill-templates/application/use-cases/find-always-on-template-by-name/find-always-on-template-by-name.use-case';
 import { ActivateSkillTool } from '../../domain/tools/activate-skill-tool.entity';
 import { Skill } from 'src/domain/skills/domain/skill.entity';
-import { SkillTemplate } from 'src/domain/skill-templates/domain/skill-template.entity';
-import { DistributionMode } from 'src/domain/skill-templates/domain/distribution-mode.enum';
+import { AlwaysOnSkillTemplate } from 'src/domain/skill-templates/domain/always-on-skill-template.entity';
 import { Thread } from 'src/domain/threads/domain/thread.entity';
 import { ToolExecutionFailedError } from '../tools.errors';
 
@@ -80,13 +79,12 @@ describe('ActivateSkillToolHandler', () => {
   }
 
   function createMockTemplate(
-    overrides?: Partial<ConstructorParameters<typeof SkillTemplate>[0]>,
+    overrides?: Partial<ConstructorParameters<typeof AlwaysOnSkillTemplate>[0]>,
   ) {
-    return new SkillTemplate({
+    return new AlwaysOnSkillTemplate({
       name: 'German Administrative Law',
       shortDescription: 'Administrative law guidance',
       instructions: 'You are a German administrative law expert.',
-      distributionMode: DistributionMode.ALWAYS_ON,
       isActive: true,
       ...overrides,
     });


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> High risk because it changes TypeORM persistence mapping for `skill_templates` (STI + child entities/repositories) and introduces new persisted fields (`defaultActive`, `defaultPinned`), which can break runtime queries if DB schema/migrations don’t match.
> 
> **Overview**
> **Skill templates are refactored from a single concrete entity into a polymorphic hierarchy**: `SkillTemplate` becomes abstract, with new `AlwaysOnSkillTemplate` and `PreCreatedCopySkillTemplate` subclasses (the latter adds `defaultActive`/`defaultPinned` defaults).
> 
> **Persistence is switched to TypeORM Single Table Inheritance** using `distributionMode` as the discriminator, adding child record entities and updating `SkillTemplateMapper` + `LocalSkillTemplateRepository.findActiveByMode` to query via mode-specific repositories rather than filtering on the base table.
> 
> Use cases/tests are updated to construct the correct subtype in `CreateSkillTemplateUseCase`/`UpdateSkillTemplateUseCase`, and downstream tests (e.g. `activate_skill` tool handler) are adjusted to use the new always-on template type.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit caf34cec6cb00965b652476d75217b5dadf91684. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->