### PR TITLE
wip(AYC-103): add migration and update application layer for polymorphic STI

### DIFF
--- a/ayunis-core-backend/src/db/migrations/1772717984846-AddDefaultActiveAndPinnedToSkillTemplates.ts
+++ b/ayunis-core-backend/src/db/migrations/1772717984846-AddDefaultActiveAndPinnedToSkillTemplates.ts
@@ -1,0 +1,40 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddDefaultActiveAndPinnedToSkillTemplates1772717984846
+  implements MigrationInterface
+{
+  name = 'AddDefaultActiveAndPinnedToSkillTemplates1772717984846';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "skill_templates" ADD "defaultActive" boolean`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "skill_templates" ADD "defaultPinned" boolean`,
+    );
+    await queryRunner.query(
+      `UPDATE "skill_templates" SET "defaultActive" = false, "defaultPinned" = false WHERE "distributionMode" = 'pre_created_copy' AND "defaultActive" IS NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "skill_templates" ALTER COLUMN "distributionMode" TYPE character varying USING "distributionMode"::text`,
+    );
+    await queryRunner.query(
+      `DROP TYPE IF EXISTS "public"."skill_templates_distributionmode_enum"`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TYPE "public"."skill_templates_distributionmode_enum" AS ENUM('always_on', 'pre_created_copy')`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "skill_templates" ALTER COLUMN "distributionMode" TYPE "public"."skill_templates_distributionmode_enum" USING "distributionMode"::"public"."skill_templates_distributionmode_enum"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "skill_templates" DROP COLUMN "defaultPinned"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "skill_templates" DROP COLUMN "defaultActive"`,
+    );
+  }
+}

--- a/ayunis-core-backend/src/domain/skill-templates/application/use-cases/create-skill-template/create-skill-template.command.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/application/use-cases/create-skill-template/create-skill-template.command.ts
@@ -6,6 +6,8 @@ export class CreateSkillTemplateCommand {
   public readonly instructions: string;
   public readonly distributionMode: DistributionMode;
   public readonly isActive?: boolean;
+  public readonly defaultActive?: boolean;
+  public readonly defaultPinned?: boolean;
 
   constructor(params: {
     name: string;
@@ -13,11 +15,15 @@ export class CreateSkillTemplateCommand {
     instructions: string;
     distributionMode: DistributionMode;
     isActive?: boolean;
+    defaultActive?: boolean;
+    defaultPinned?: boolean;
   }) {
     this.name = params.name;
     this.shortDescription = params.shortDescription;
     this.instructions = params.instructions;
     this.distributionMode = params.distributionMode;
     this.isActive = params.isActive;
+    this.defaultActive = params.defaultActive;
+    this.defaultPinned = params.defaultPinned;
   }
 }

--- a/ayunis-core-backend/src/domain/skill-templates/application/use-cases/update-skill-template/update-skill-template.command.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/application/use-cases/update-skill-template/update-skill-template.command.ts
@@ -8,6 +8,8 @@ export class UpdateSkillTemplateCommand {
   public readonly instructions?: string;
   public readonly distributionMode?: DistributionMode;
   public readonly isActive?: boolean;
+  public readonly defaultActive?: boolean;
+  public readonly defaultPinned?: boolean;
 
   constructor(params: {
     skillTemplateId: UUID;
@@ -16,6 +18,8 @@ export class UpdateSkillTemplateCommand {
     instructions?: string;
     distributionMode?: DistributionMode;
     isActive?: boolean;
+    defaultActive?: boolean;
+    defaultPinned?: boolean;
   }) {
     this.skillTemplateId = params.skillTemplateId;
     this.name = params.name;
@@ -23,5 +27,7 @@ export class UpdateSkillTemplateCommand {
     this.instructions = params.instructions;
     this.distributionMode = params.distributionMode;
     this.isActive = params.isActive;
+    this.defaultActive = params.defaultActive;
+    this.defaultPinned = params.defaultPinned;
   }
 }

--- a/ayunis-core-backend/src/domain/skill-templates/infrastructure/persistence/local/mappers/skill-template.mapper.spec.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/infrastructure/persistence/local/mappers/skill-template.mapper.spec.ts
@@ -115,6 +115,21 @@ describe('SkillTemplateMapper', () => {
       expect(record.isActive).toBe(true);
     });
 
+    it('should null out defaultActive and defaultPinned for AlwaysOnSkillTemplate records', () => {
+      const domain = new AlwaysOnSkillTemplate({
+        id: mockId,
+        name: 'Sicherheits-Richtlinie',
+        shortDescription: 'Sicherheitsanweisungen',
+        instructions: 'Befolge die Sicherheitsrichtlinien.',
+        isActive: true,
+      });
+
+      const record = mapper.toRecord(domain);
+
+      expect(record.defaultActive).toBeNull();
+      expect(record.defaultPinned).toBeNull();
+    });
+
     it('should map a PreCreatedCopySkillTemplate to PreCreatedCopySkillTemplateRecord', () => {
       const domain = new PreCreatedCopySkillTemplate({
         id: mockId,

--- a/ayunis-core-backend/src/domain/skill-templates/infrastructure/persistence/local/mappers/skill-template.mapper.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/infrastructure/persistence/local/mappers/skill-template.mapper.ts
@@ -38,6 +38,8 @@ export class SkillTemplateMapper {
     if (domain instanceof AlwaysOnSkillTemplate) {
       const record = new AlwaysOnSkillTemplateRecord();
       this.assignSharedRecordFields(record, domain);
+      record.defaultActive = null;
+      record.defaultPinned = null;
       return record;
     }
 

--- a/ayunis-core-backend/src/domain/skill-templates/infrastructure/persistence/local/schema/pre-created-copy-skill-template.record.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/infrastructure/persistence/local/schema/pre-created-copy-skill-template.record.ts
@@ -1,12 +1,6 @@
-import { ChildEntity, Column } from 'typeorm';
+import { ChildEntity } from 'typeorm';
 import { SkillTemplateRecord } from './skill-template.record';
 import { DistributionMode } from '../../../../domain/distribution-mode.enum';
 
 @ChildEntity(DistributionMode.PRE_CREATED_COPY)
-export class PreCreatedCopySkillTemplateRecord extends SkillTemplateRecord {
-  @Column({ nullable: true })
-  defaultActive: boolean | null;
-
-  @Column({ nullable: true })
-  defaultPinned: boolean | null;
-}
+export class PreCreatedCopySkillTemplateRecord extends SkillTemplateRecord {}

--- a/ayunis-core-backend/src/domain/skill-templates/infrastructure/persistence/local/schema/skill-template.record.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/infrastructure/persistence/local/schema/skill-template.record.ts
@@ -15,4 +15,12 @@ export abstract class SkillTemplateRecord extends BaseRecord {
 
   @Column({ nullable: false, default: false })
   isActive: boolean;
+
+  // STI: owned by PreCreatedCopy, null for other subtypes — on base record so TypeORM includes them in UPDATE for all child entities
+  @Column({ type: 'boolean', nullable: true })
+  defaultActive: boolean | null;
+
+  // STI: owned by PreCreatedCopy, null for other subtypes — on base record so TypeORM includes them in UPDATE for all child entities
+  @Column({ type: 'boolean', nullable: true })
+  defaultPinned: boolean | null;
 }

--- a/ayunis-core-backend/src/domain/skill-templates/presenters/http/dto/create-skill-template.dto.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/presenters/http/dto/create-skill-template.dto.ts
@@ -66,4 +66,22 @@ export class CreateSkillTemplateDto {
   @IsBoolean()
   @IsOptional()
   isActive?: boolean;
+
+  @ApiPropertyOptional({
+    description:
+      'Whether copied skills should be active by default (only for pre_created_copy mode, defaults to false)',
+    example: false,
+  })
+  @IsBoolean()
+  @IsOptional()
+  defaultActive?: boolean;
+
+  @ApiPropertyOptional({
+    description:
+      'Whether copied skills should be pinned by default (only for pre_created_copy mode, defaults to false)',
+    example: false,
+  })
+  @IsBoolean()
+  @IsOptional()
+  defaultPinned?: boolean;
 }

--- a/ayunis-core-backend/src/domain/skill-templates/presenters/http/dto/skill-template-response.dto.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/presenters/http/dto/skill-template-response.dto.ts
@@ -48,6 +48,24 @@ export class SkillTemplateResponseDto {
   isActive: boolean;
 
   @ApiProperty({
+    type: 'boolean',
+    nullable: true,
+    description:
+      'Whether copied skills are active by default (null for always_on templates)',
+    example: null,
+  })
+  defaultActive: boolean | null;
+
+  @ApiProperty({
+    type: 'boolean',
+    nullable: true,
+    description:
+      'Whether copied skills are pinned by default (null for always_on templates)',
+    example: null,
+  })
+  defaultPinned: boolean | null;
+
+  @ApiProperty({
     type: 'string',
     format: 'date-time',
     description: 'The date the skill template was created',

--- a/ayunis-core-backend/src/domain/skill-templates/presenters/http/dto/update-skill-template.dto.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/presenters/http/dto/update-skill-template.dto.ts
@@ -70,4 +70,22 @@ export class UpdateSkillTemplateDto {
   @IsBoolean()
   @IsOptional()
   isActive?: boolean;
+
+  @ApiPropertyOptional({
+    description:
+      'Whether copied skills should be active by default (only for pre_created_copy mode)',
+    example: false,
+  })
+  @IsBoolean()
+  @IsOptional()
+  defaultActive?: boolean;
+
+  @ApiPropertyOptional({
+    description:
+      'Whether copied skills should be pinned by default (only for pre_created_copy mode)',
+    example: false,
+  })
+  @IsBoolean()
+  @IsOptional()
+  defaultPinned?: boolean;
 }

--- a/ayunis-core-backend/src/domain/skill-templates/presenters/http/mappers/skill-template-response.mapper.spec.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/presenters/http/mappers/skill-template-response.mapper.spec.ts
@@ -1,0 +1,119 @@
+import type { UUID } from 'crypto';
+import { SkillTemplateResponseMapper } from './skill-template-response.mapper';
+import { AlwaysOnSkillTemplate } from '../../../domain/always-on-skill-template.entity';
+import { PreCreatedCopySkillTemplate } from '../../../domain/pre-created-copy-skill-template.entity';
+import { DistributionMode } from '../../../domain/distribution-mode.enum';
+
+describe('SkillTemplateResponseMapper', () => {
+  const mapper = new SkillTemplateResponseMapper();
+
+  const mockId = '123e4567-e89b-12d3-a456-426614174000' as UUID;
+  const createdAt = new Date('2026-01-15T10:00:00Z');
+  const updatedAt = new Date('2026-02-20T14:30:00Z');
+
+  describe('toDto', () => {
+    it('should map AlwaysOnSkillTemplate with defaultActive and defaultPinned as null', () => {
+      const entity = new AlwaysOnSkillTemplate({
+        id: mockId,
+        name: 'Security Policy',
+        shortDescription: 'Enforce security best practices',
+        instructions: 'Always validate user input before processing.',
+        isActive: true,
+        createdAt,
+        updatedAt,
+      });
+
+      const dto = mapper.toDto(entity);
+
+      expect(dto.id).toBe(mockId);
+      expect(dto.name).toBe('Security Policy');
+      expect(dto.shortDescription).toBe('Enforce security best practices');
+      expect(dto.instructions).toBe(
+        'Always validate user input before processing.',
+      );
+      expect(dto.distributionMode).toBe(DistributionMode.ALWAYS_ON);
+      expect(dto.isActive).toBe(true);
+      expect(dto.defaultActive).toBeNull();
+      expect(dto.defaultPinned).toBeNull();
+      expect(dto.createdAt).toBe(createdAt);
+      expect(dto.updatedAt).toBe(updatedAt);
+    });
+
+    it('should map PreCreatedCopySkillTemplate with actual defaultActive and defaultPinned values', () => {
+      const entity = new PreCreatedCopySkillTemplate({
+        id: mockId,
+        name: 'Legal Guidelines',
+        shortDescription: 'Legal compliance instructions',
+        instructions: 'Follow legal guidelines when responding.',
+        isActive: false,
+        defaultActive: true,
+        defaultPinned: true,
+        createdAt,
+        updatedAt,
+      });
+
+      const dto = mapper.toDto(entity);
+
+      expect(dto.id).toBe(mockId);
+      expect(dto.name).toBe('Legal Guidelines');
+      expect(dto.shortDescription).toBe('Legal compliance instructions');
+      expect(dto.instructions).toBe('Follow legal guidelines when responding.');
+      expect(dto.distributionMode).toBe(DistributionMode.PRE_CREATED_COPY);
+      expect(dto.isActive).toBe(false);
+      expect(dto.defaultActive).toBe(true);
+      expect(dto.defaultPinned).toBe(true);
+      expect(dto.createdAt).toBe(createdAt);
+      expect(dto.updatedAt).toBe(updatedAt);
+    });
+
+    it('should map PreCreatedCopySkillTemplate with false defaults', () => {
+      const entity = new PreCreatedCopySkillTemplate({
+        id: mockId,
+        name: 'Onboarding Helper',
+        shortDescription: 'Help new users get started',
+        instructions: 'Guide users through the onboarding process.',
+        defaultActive: false,
+        defaultPinned: false,
+        createdAt,
+        updatedAt,
+      });
+
+      const dto = mapper.toDto(entity);
+
+      expect(dto.defaultActive).toBe(false);
+      expect(dto.defaultPinned).toBe(false);
+    });
+  });
+
+  describe('toDtoArray', () => {
+    it('should map an array of mixed template types', () => {
+      const alwaysOn = new AlwaysOnSkillTemplate({
+        id: mockId,
+        name: 'Security Policy',
+        shortDescription: 'Security instructions',
+        instructions: 'Be secure.',
+        createdAt,
+        updatedAt,
+      });
+
+      const preCreated = new PreCreatedCopySkillTemplate({
+        id: '223e4567-e89b-12d3-a456-426614174001' as UUID,
+        name: 'Legal Guidelines',
+        shortDescription: 'Legal instructions',
+        instructions: 'Be legal.',
+        defaultActive: true,
+        defaultPinned: false,
+        createdAt,
+        updatedAt,
+      });
+
+      const dtos = mapper.toDtoArray([alwaysOn, preCreated]);
+
+      expect(dtos).toHaveLength(2);
+      expect(dtos[0].defaultActive).toBeNull();
+      expect(dtos[0].defaultPinned).toBeNull();
+      expect(dtos[1].defaultActive).toBe(true);
+      expect(dtos[1].defaultPinned).toBe(false);
+    });
+  });
+});

--- a/ayunis-core-backend/src/domain/skill-templates/presenters/http/mappers/skill-template-response.mapper.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/presenters/http/mappers/skill-template-response.mapper.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import type { SkillTemplate } from '../../../domain/skill-template.entity';
+import { PreCreatedCopySkillTemplate } from '../../../domain/pre-created-copy-skill-template.entity';
 import { SkillTemplateResponseDto } from '../dto/skill-template-response.dto';
 
 @Injectable()
@@ -14,6 +15,15 @@ export class SkillTemplateResponseMapper {
     dto.isActive = entity.isActive;
     dto.createdAt = entity.createdAt;
     dto.updatedAt = entity.updatedAt;
+
+    if (entity instanceof PreCreatedCopySkillTemplate) {
+      dto.defaultActive = entity.defaultActive;
+      dto.defaultPinned = entity.defaultPinned;
+    } else {
+      dto.defaultActive = null;
+      dto.defaultPinned = null;
+    }
+
     return dto;
   }
 

--- a/ayunis-core-backend/src/domain/skill-templates/presenters/http/super-admin-skill-templates.controller.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/presenters/http/super-admin-skill-templates.controller.ts
@@ -91,6 +91,8 @@ export class SuperAdminSkillTemplatesController {
         instructions: dto.instructions,
         distributionMode: dto.distributionMode,
         isActive: dto.isActive,
+        defaultActive: dto.defaultActive,
+        defaultPinned: dto.defaultPinned,
       });
 
       const template = await this.createSkillTemplateUseCase.execute(command);
@@ -219,6 +221,8 @@ export class SuperAdminSkillTemplatesController {
         instructions: dto.instructions,
         distributionMode: dto.distributionMode,
         isActive: dto.isActive,
+        defaultActive: dto.defaultActive,
+        defaultPinned: dto.defaultPinned,
       });
 
       const template = await this.updateSkillTemplateUseCase.execute(command);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces a DB migration and changes the skill-templates API contract, which can impact existing data and TypeORM STI persistence behavior. Risk is mainly around schema rollout/backfill and ensuring updates don’t inadvertently overwrite nullable subtype fields.
> 
> **Overview**
> **Adds two new optional defaults for copied skills.** `defaultActive` and `defaultPinned` are now accepted on create/update requests and returned in responses (as `null` for `always_on` templates).
> 
> **Updates persistence/schema for STI.** A migration adds the two columns to `skill_templates`, backfills `false` for existing `pre_created_copy` rows, and changes `distributionMode` from a Postgres enum to `varchar` (dropping the enum type). TypeORM records move these columns onto the base `SkillTemplateRecord` so updates include them for all subtypes, and mappers/tests ensure `always_on` records explicitly persist `null` while `pre_created_copy` maps actual values.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d576e6cc2a772857e3943ffdf21dc2d3728dd8d6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->