### PR TITLE
wip(AYC-103): wire defaultActive/defaultPinned through skill creation and installation

### DIFF
--- a/ayunis-core-backend/src/domain/skill-templates/application/services/skill-template-installation.service.spec.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/application/services/skill-template-installation.service.spec.ts
@@ -2,7 +2,7 @@ import { SkillTemplateInstallationService } from './skill-template-installation.
 import type { FindActivePreCreatedTemplatesUseCase } from '../use-cases/find-active-pre-created-templates/find-active-pre-created-templates.use-case';
 import type { CreateSkillWithUniqueNameUseCase } from 'src/domain/skills/application/use-cases/create-skill-with-unique-name/create-skill-with-unique-name.use-case';
 import type { CreateSkillWithUniqueNameCommand } from 'src/domain/skills/application/use-cases/create-skill-with-unique-name/create-skill-with-unique-name.command';
-import { SkillTemplate } from '../../domain/skill-template.entity';
+
 import { PreCreatedCopySkillTemplate } from '../../domain/pre-created-copy-skill-template.entity';
 import { Skill } from 'src/domain/skills/domain/skill.entity';
 import { randomUUID } from 'crypto';
@@ -14,13 +14,15 @@ describe('SkillTemplateInstallationService', () => {
 
   const userId = randomUUID();
 
-  const mockTemplates: SkillTemplate[] = [
+  const mockTemplates: PreCreatedCopySkillTemplate[] = [
     new PreCreatedCopySkillTemplate({
       id: randomUUID(),
       name: 'Template A',
       shortDescription: 'Description A',
       instructions: 'Instructions A',
       isActive: true,
+      defaultActive: true,
+      defaultPinned: true,
     }),
     new PreCreatedCopySkillTemplate({
       id: randomUUID(),
@@ -28,6 +30,8 @@ describe('SkillTemplateInstallationService', () => {
       shortDescription: 'Description B',
       instructions: 'Instructions B',
       isActive: true,
+      defaultActive: false,
+      defaultPinned: false,
     }),
   ];
 
@@ -68,6 +72,8 @@ describe('SkillTemplateInstallationService', () => {
         shortDescription: 'Description A',
         instructions: 'Instructions A',
         userId,
+        isActive: true,
+        isPinned: true,
       }),
     );
     expect(createSkillWithUniqueNameUseCase.execute).toHaveBeenCalledWith(
@@ -76,6 +82,56 @@ describe('SkillTemplateInstallationService', () => {
         shortDescription: 'Description B',
         instructions: 'Instructions B',
         userId,
+        isActive: false,
+        isPinned: false,
+      }),
+    );
+  });
+
+  it('should forward defaultActive and defaultPinned from template', async () => {
+    const templateWithDefaults = new PreCreatedCopySkillTemplate({
+      id: randomUUID(),
+      name: 'Active and Pinned',
+      shortDescription: 'Both true',
+      instructions: 'Instructions',
+      isActive: true,
+      defaultActive: true,
+      defaultPinned: true,
+    });
+
+    findActivePreCreatedTemplatesUseCase.execute.mockResolvedValue([
+      templateWithDefaults,
+    ]);
+
+    await service.installAllPreCreatedForUser(userId);
+
+    expect(createSkillWithUniqueNameUseCase.execute).toHaveBeenCalledWith(
+      expect.objectContaining({
+        isActive: true,
+        isPinned: true,
+      }),
+    );
+  });
+
+  it('should treat undefined defaults as false', async () => {
+    const templateNoDefaults = new PreCreatedCopySkillTemplate({
+      id: randomUUID(),
+      name: 'No Defaults',
+      shortDescription: 'No defaults set',
+      instructions: 'Instructions',
+      isActive: true,
+    });
+
+    findActivePreCreatedTemplatesUseCase.execute.mockResolvedValue([
+      templateNoDefaults,
+    ]);
+
+    await service.installAllPreCreatedForUser(userId);
+
+    expect(createSkillWithUniqueNameUseCase.execute).toHaveBeenCalledWith(
+      expect.objectContaining({
+        isActive: false,
+        isPinned: false,
       }),
     );
   });

--- a/ayunis-core-backend/src/domain/skill-templates/application/services/skill-template-installation.service.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/application/services/skill-template-installation.service.ts
@@ -33,13 +33,18 @@ export class SkillTemplateInstallationService {
             shortDescription: template.shortDescription,
             instructions: template.instructions,
             userId,
+            isActive: template.defaultActive,
+            isPinned: template.defaultPinned,
           }),
         );
 
-        this.logger.debug(
-          'Pre-created skill template installed and activated',
-          { templateId: template.id, skillId: created.id, userId },
-        );
+        this.logger.debug('Pre-created skill template installed', {
+          templateId: template.id,
+          skillId: created.id,
+          userId,
+          isActive: template.defaultActive,
+          isPinned: template.defaultPinned,
+        });
         successCount++;
       } catch (error) {
         this.logger.error(

--- a/ayunis-core-backend/src/domain/skill-templates/application/use-cases/find-active-pre-created-templates/find-active-pre-created-templates.use-case.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/application/use-cases/find-active-pre-created-templates/find-active-pre-created-templates.use-case.ts
@@ -1,6 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { SkillTemplateRepository } from '../../ports/skill-template.repository';
-import { SkillTemplate } from '../../../domain/skill-template.entity';
+import { PreCreatedCopySkillTemplate } from '../../../domain/pre-created-copy-skill-template.entity';
 import { DistributionMode } from '../../../domain/distribution-mode.enum';
 import { FindActivePreCreatedTemplatesQuery } from './find-active-pre-created-templates.query';
 import { UnexpectedSkillTemplateError } from '../../skill-templates.errors';
@@ -19,12 +19,15 @@ export class FindActivePreCreatedTemplatesUseCase {
   async execute(
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     _query: FindActivePreCreatedTemplatesQuery,
-  ): Promise<SkillTemplate[]> {
+  ): Promise<PreCreatedCopySkillTemplate[]> {
     this.logger.log('Finding active pre-created copy templates');
     try {
-      return await this.skillTemplateRepository.findActiveByMode(
+      // Safe cast: the repository uses TypeORM STI which hydrates the correct
+      // subclass based on the discriminator column, so findActiveByMode(PRE_CREATED_COPY)
+      // always returns PreCreatedCopySkillTemplate instances.
+      return (await this.skillTemplateRepository.findActiveByMode(
         DistributionMode.PRE_CREATED_COPY,
-      );
+      )) as PreCreatedCopySkillTemplate[];
     } catch (error) {
       if (error instanceof ApplicationError) throw error;
       this.logger.error('Error finding active pre-created templates', {

--- a/ayunis-core-backend/src/domain/skills/application/ports/skill.repository.ts
+++ b/ayunis-core-backend/src/domain/skills/application/ports/skill.repository.ts
@@ -26,6 +26,7 @@ export abstract class SkillRepository {
     retainUserIds: Set<UUID>,
   ): Promise<void>;
   abstract findByIds(ids: UUID[]): Promise<Skill[]>;
+  abstract pinSkill(skillId: UUID, userId: UUID): Promise<void>;
   abstract toggleSkillPinned(skillId: UUID, userId: UUID): Promise<boolean>;
   abstract isSkillPinned(skillId: UUID, userId: UUID): Promise<boolean>;
   abstract getPinnedSkillIds(userId: UUID): Promise<Set<UUID>>;

--- a/ayunis-core-backend/src/domain/skills/application/use-cases/create-skill-with-unique-name/create-skill-with-unique-name.command.ts
+++ b/ayunis-core-backend/src/domain/skills/application/use-cases/create-skill-with-unique-name/create-skill-with-unique-name.command.ts
@@ -6,6 +6,8 @@ export class CreateSkillWithUniqueNameCommand {
   public readonly instructions: string;
   public readonly marketplaceIdentifier: string | null;
   public readonly userId: UUID;
+  public readonly isActive: boolean;
+  public readonly isPinned: boolean;
 
   constructor(params: {
     name: string;
@@ -13,11 +15,15 @@ export class CreateSkillWithUniqueNameCommand {
     instructions: string;
     marketplaceIdentifier?: string | null;
     userId: UUID;
+    isActive?: boolean;
+    isPinned?: boolean;
   }) {
     this.name = params.name;
     this.shortDescription = params.shortDescription;
     this.instructions = params.instructions;
     this.marketplaceIdentifier = params.marketplaceIdentifier ?? null;
     this.userId = params.userId;
+    this.isActive = params.isActive ?? true;
+    this.isPinned = params.isPinned ?? false;
   }
 }

--- a/ayunis-core-backend/src/domain/skills/application/use-cases/create-skill-with-unique-name/create-skill-with-unique-name.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/skills/application/use-cases/create-skill-with-unique-name/create-skill-with-unique-name.use-case.spec.ts
@@ -18,6 +18,7 @@ describe('CreateSkillWithUniqueNameUseCase', () => {
         .fn()
         .mockImplementation((skill: Skill) => Promise.resolve(skill)),
       activateSkill: jest.fn().mockResolvedValue(undefined),
+      pinSkill: jest.fn().mockResolvedValue(undefined),
       findByNameAndOwner: jest.fn().mockResolvedValue(null),
     } as unknown as jest.Mocked<SkillRepository>;
 
@@ -103,67 +104,70 @@ describe('CreateSkillWithUniqueNameUseCase', () => {
     expect(result.name).toBe('Translator 4');
   });
 
-  it('should truncate base name when suffix would exceed 100-char limit', async () => {
-    const longName = 'A'.repeat(100);
-    skillRepository.findByNameAndOwner.mockImplementation((name: string) =>
-      Promise.resolve(
-        name === longName
-          ? new Skill({
-              name,
-              shortDescription: 'existing',
-              instructions: 'existing',
-              userId,
-            })
-          : null,
-      ),
+  it('should not activate the skill when isActive is false', async () => {
+    const command = new CreateSkillWithUniqueNameCommand({
+      name: 'Inactive Skill',
+      shortDescription: 'Not active',
+      instructions: 'Instructions',
+      userId,
+      isActive: false,
+    });
+
+    await useCase.execute(command);
+
+    expect(skillRepository.create).toHaveBeenCalledTimes(1);
+    expect(skillRepository.activateSkill).not.toHaveBeenCalled();
+  });
+
+  it('should call pinSkill when isPinned is true', async () => {
+    const command = new CreateSkillWithUniqueNameCommand({
+      name: 'Pinned Skill',
+      shortDescription: 'Pinned',
+      instructions: 'Instructions',
+      userId,
+      isPinned: true,
+    });
+
+    const result = await useCase.execute(command);
+
+    expect(skillRepository.activateSkill).toHaveBeenCalledWith(
+      result.id,
+      userId,
     );
-
-    const command = new CreateSkillWithUniqueNameCommand({
-      name: longName,
-      shortDescription: 'Test',
-      instructions: 'Test',
-      userId,
-    });
-
-    const result = await useCase.execute(command);
-
-    expect(result.name.length).toBeLessThanOrEqual(100);
-    expect(result.name).toMatch(/ 2$/);
+    expect(skillRepository.pinSkill).toHaveBeenCalledWith(result.id, userId);
   });
 
-  it('should truncate base name to 100 characters even when no collision exists', async () => {
-    const longName = 'B'.repeat(120);
-
+  it('should force activation when isPinned is true and isActive is false', async () => {
     const command = new CreateSkillWithUniqueNameCommand({
-      name: longName,
-      shortDescription: 'Test',
-      instructions: 'Test',
+      name: 'Pinned But Not Active',
+      shortDescription: 'Pinned without explicit activation',
+      instructions: 'Instructions',
       userId,
+      isActive: false,
+      isPinned: true,
     });
 
     const result = await useCase.execute(command);
 
-    expect(result.name.length).toBe(100);
-    expect(result.name).toBe('B'.repeat(100));
+    expect(skillRepository.activateSkill).toHaveBeenCalledWith(
+      result.id,
+      userId,
+    );
+    expect(skillRepository.pinSkill).toHaveBeenCalledWith(result.id, userId);
   });
 
-  it('should truncate codepoint-safely when no collision exists', async () => {
-    // Each emoji is multiple UTF-16 code units but one codepoint
-    const emoji = '😀';
-    const longName = emoji.repeat(60); // 60 emoji × 2 UTF-16 chars = 120 chars
-
+  it('should not call pinSkill by default', async () => {
     const command = new CreateSkillWithUniqueNameCommand({
-      name: longName,
-      shortDescription: 'Test',
-      instructions: 'Test',
+      name: 'Default Skill',
+      shortDescription: 'Default',
+      instructions: 'Instructions',
       userId,
     });
 
-    const result = await useCase.execute(command);
+    await useCase.execute(command);
 
-    expect(result.name.length).toBeLessThanOrEqual(100);
-    // Should not split an emoji in half
-    expect([...result.name].every((cp) => cp === emoji)).toBe(true);
+    expect(skillRepository.activateSkill).toHaveBeenCalled();
+    expect(skillRepository.pinSkill).not.toHaveBeenCalled();
   });
 
   it('should throw when unique name cannot be resolved after max attempts', async () => {

--- a/ayunis-core-backend/src/domain/skills/application/use-cases/create-skill-with-unique-name/create-skill-with-unique-name.use-case.ts
+++ b/ayunis-core-backend/src/domain/skills/application/use-cases/create-skill-with-unique-name/create-skill-with-unique-name.use-case.ts
@@ -1,15 +1,10 @@
 import { Inject, Injectable, Logger } from '@nestjs/common';
 import { SkillRepository } from '../../ports/skill.repository';
 import { CreateSkillWithUniqueNameCommand } from './create-skill-with-unique-name.command';
-import { Skill, InvalidSkillNameError } from '../../../domain/skill.entity';
-import {
-  SkillNameResolutionError,
-  UnexpectedSkillError,
-} from '../../skills.errors';
-import { ApplicationError } from 'src/common/errors/base.error';
+import { Skill } from '../../../domain/skill.entity';
+import { SkillNameResolutionError } from '../../skills.errors';
 import type { UUID } from 'crypto';
 
-const MAX_NAME_LENGTH = 100;
 const MAX_NAME_RESOLUTION_ATTEMPTS = 100;
 
 @Injectable()
@@ -27,53 +22,44 @@ export class CreateSkillWithUniqueNameUseCase {
       userId: command.userId,
     });
 
-    try {
-      const name = await this.resolveUniqueName(command.name, command.userId);
+    const name = await this.resolveUniqueName(command.name, command.userId);
 
-      const skill = new Skill({
-        name,
-        shortDescription: command.shortDescription,
-        instructions: command.instructions,
-        marketplaceIdentifier: command.marketplaceIdentifier,
-        userId: command.userId,
-      });
+    const skill = new Skill({
+      name,
+      shortDescription: command.shortDescription,
+      instructions: command.instructions,
+      marketplaceIdentifier: command.marketplaceIdentifier,
+      userId: command.userId,
+    });
 
-      const created = await this.skillRepository.create(skill);
+    const created = await this.skillRepository.create(skill);
+
+    const shouldActivate = command.isActive || command.isPinned;
+
+    if (shouldActivate) {
       await this.skillRepository.activateSkill(created.id, command.userId);
-
-      this.logger.debug('Skill created and activated', {
-        skillId: created.id,
-        name: created.name,
-        userId: command.userId,
-      });
-
-      return created;
-    } catch (error) {
-      if (
-        error instanceof ApplicationError ||
-        error instanceof InvalidSkillNameError
-      )
-        throw error;
-      this.logger.error('Error creating skill with unique name', {
-        error: error as Error,
-      });
-      throw new UnexpectedSkillError(error);
     }
+
+    if (command.isPinned) {
+      await this.skillRepository.pinSkill(created.id, command.userId);
+    }
+
+    this.logger.debug('Skill created', {
+      skillId: created.id,
+      name: created.name,
+      userId: command.userId,
+      isActive: command.isActive,
+      isPinned: command.isPinned,
+    });
+
+    return created;
   }
 
   private async resolveUniqueName(
     baseName: string,
     userId: UUID,
   ): Promise<string> {
-    const baseCodePoints = [...baseName];
-    let truncatedBase = '';
-    for (const cp of baseCodePoints) {
-      if (truncatedBase.length + cp.length > MAX_NAME_LENGTH) break;
-      truncatedBase += cp;
-    }
-    truncatedBase = truncatedBase.trimEnd();
-
-    let name = truncatedBase;
+    let name = baseName;
     let suffix = 2;
     while (await this.skillRepository.findByNameAndOwner(name, userId)) {
       if (suffix > MAX_NAME_RESOLUTION_ATTEMPTS) {
@@ -82,16 +68,7 @@ export class CreateSkillWithUniqueNameUseCase {
           MAX_NAME_RESOLUTION_ATTEMPTS,
         );
       }
-      const suffixStr = ` ${suffix}`;
-      const codePoints = [...truncatedBase];
-      let truncated = '';
-      for (const cp of codePoints) {
-        if (truncated.length + cp.length + suffixStr.length > MAX_NAME_LENGTH)
-          break;
-        truncated += cp;
-      }
-      truncated = truncated.trimEnd();
-      name = `${truncated}${suffixStr}`;
+      name = `${baseName} ${suffix}`;
       suffix++;
     }
     return name;

--- a/ayunis-core-backend/src/domain/skills/application/use-cases/list-skill-mcp-integrations/list-skill-mcp-integrations.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/skills/application/use-cases/list-skill-mcp-integrations/list-skill-mcp-integrations.use-case.spec.ts
@@ -46,6 +46,7 @@ describe('ListSkillMcpIntegrationsUseCase', () => {
       findByIds: jest.fn(),
       toggleSkillPinned: jest.fn(),
       isSkillPinned: jest.fn(),
+      pinSkill: jest.fn(),
       getPinnedSkillIds: jest.fn(),
       findSkillsByKnowledgeBaseAndOwners: jest.fn(),
       removeKnowledgeBaseFromSkills: jest.fn(),

--- a/ayunis-core-backend/src/domain/skills/application/use-cases/list-skill-sources/list-skill-sources.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/skills/application/use-cases/list-skill-sources/list-skill-sources.use-case.spec.ts
@@ -44,6 +44,7 @@ describe('ListSkillSourcesUseCase', () => {
       findByIds: jest.fn(),
       toggleSkillPinned: jest.fn(),
       isSkillPinned: jest.fn(),
+      pinSkill: jest.fn(),
       getPinnedSkillIds: jest.fn(),
       findSkillsByKnowledgeBaseAndOwners: jest.fn(),
       removeKnowledgeBaseFromSkills: jest.fn(),

--- a/ayunis-core-backend/src/domain/skills/infrastructure/persistence/local/local-skill.repository.spec.ts
+++ b/ayunis-core-backend/src/domain/skills/infrastructure/persistence/local/local-skill.repository.spec.ts
@@ -63,6 +63,36 @@ describe('LocalSkillRepository', () => {
     );
   });
 
+  describe('pinSkill', () => {
+    it('should set isPinned to true on the activation record', async () => {
+      const mockExecute = jest.fn().mockResolvedValue({ affected: 1 });
+      mockManager.createQueryBuilder.mockReturnValue({
+        update: jest.fn().mockReturnThis(),
+        set: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        execute: mockExecute,
+      });
+
+      await repository.pinSkill(skillId, userId);
+
+      expect(mockManager.createQueryBuilder).toHaveBeenCalled();
+    });
+
+    it('should throw SkillNotActiveError when no activation record exists', async () => {
+      const mockExecute = jest.fn().mockResolvedValue({ affected: 0 });
+      mockManager.createQueryBuilder.mockReturnValue({
+        update: jest.fn().mockReturnThis(),
+        set: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        execute: mockExecute,
+      });
+
+      await expect(repository.pinSkill(skillId, userId)).rejects.toThrow(
+        SkillNotActiveError,
+      );
+    });
+  });
+
   describe('toggleSkillPinned', () => {
     it('should toggle isPinned and return new value using RETURNING clause', async () => {
       mockManager.query.mockResolvedValue([{ isPinned: true }]);

--- a/ayunis-core-backend/src/domain/skills/infrastructure/persistence/local/local-skill.repository.ts
+++ b/ayunis-core-backend/src/domain/skills/infrastructure/persistence/local/local-skill.repository.ts
@@ -350,6 +350,25 @@ export class LocalSkillRepository implements SkillRepository {
     return new Set(activations.map((a) => a.skillId));
   }
 
+  async pinSkill(skillId: UUID, userId: UUID): Promise<void> {
+    this.logger.log('pinSkill', { skillId, userId });
+
+    const manager = this.getManager();
+    const result = await manager
+      .createQueryBuilder()
+      .update(SkillActivationRecord)
+      .set({ isPinned: true })
+      .where('"skillId" = :skillId AND "userId" = :userId', {
+        skillId,
+        userId,
+      })
+      .execute();
+
+    if (result.affected === 0) {
+      throw new SkillNotActiveError(skillId);
+    }
+  }
+
   async toggleSkillPinned(skillId: UUID, userId: UUID): Promise<boolean> {
     this.logger.log('toggleSkillPinned', { skillId, userId });
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes skill creation semantics (conditional activation, new pin-on-create path) and simplifies unique-name resolution by removing length truncation, which could surface new runtime/DB constraint errors. Adds a new repository write (`pinSkill`) that depends on activation records existing and may affect existing flows if assumptions are wrong.
> 
> **Overview**
> Pre-created skill template installation now forwards each template’s `defaultActive`/`defaultPinned` flags into skill creation, and the pre-created template query is typed to return `PreCreatedCopySkillTemplate` instances.
> 
> Skill creation (`CreateSkillWithUniqueNameUseCase`) now supports creating skills *inactive* and/or *pinned*: activation is skipped when `isActive` is false, pinning uses a new `SkillRepository.pinSkill` method, and pinning forces activation to ensure an activation row exists. Unique-name collision handling was simplified to always append `" <n>"` without the prior 100-char truncation logic, and logging/tests were updated accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7e0fbf184e6e9b70cfd025a599e0254eeeb9b815. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->