### PR TITLE
ci(AYC-000): speed up deploys with docker cache, build-before-down, and health polling

### DIFF
--- a/.github/workflows/deploy-production-manual.yml
+++ b/.github/workflows/deploy-production-manual.yml
@@ -36,10 +36,13 @@ jobs:
               git checkout -f "$RELEASE_TAG"
               git reset --hard "origin/$RELEASE_TAG"
             fi
+            # Build with cache while old containers still serve traffic
+            docker compose build
+            # Quick swap — downtime is only the restart
             docker compose down
-            # Clean up old images and build cache before building new ones
-            docker image prune -af
-            docker builder prune -af
-            docker compose up -d --build
-            sleep 60
+            docker compose up -d
+            # Wait for app to be healthy (up to 120s)
+            timeout 120 bash -c 'until docker compose ps app --format json | grep -q "(healthy)"; do sleep 5; done'
             docker compose ps
+            # Clean up dangling images to reclaim disk space
+            docker image prune -f

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -26,10 +26,13 @@ jobs:
             cd /home/ayunis/apps/ayunis-core
             git fetch origin main
             git reset --hard origin/main
+            # Build with cache while old containers still serve traffic
+            docker compose build
+            # Quick swap — downtime is only the restart
             docker compose down
-            # Clean up old images and build cache before building new ones
-            docker image prune -af
-            docker builder prune -af
-            docker compose up -d --build
-            sleep 60
+            docker compose up -d
+            # Wait for app to be healthy (up to 120s)
+            timeout 120 bash -c 'until docker compose ps app --format json | grep -q "(healthy)"; do sleep 5; done'
             docker compose ps
+            # Clean up dangling images to reclaim disk space
+            docker image prune -f

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -48,10 +48,16 @@ jobs:
             cd /home/ayunis/apps/ayunis-core
             git fetch --all --tags
             git checkout -f "$RELEASE_TAG"
+            # Build with cache while old containers still serve traffic
+            docker compose build
+            # Quick swap — downtime is only the restart
             docker compose down
-            docker compose up -d --build
-            sleep 60
+            docker compose up -d
+            # Wait for app to be healthy (up to 120s)
+            timeout 120 bash -c 'until docker compose ps app --format json | grep -q "(healthy)"; do sleep 5; done'
             docker compose ps
+            # Clean up dangling images to reclaim disk space
+            docker image prune -f
 
   deploy-production:
     needs: [release-please, deploy-internal]
@@ -76,10 +82,16 @@ jobs:
             cd /home/ayunis/apps/ayunis-core
             git fetch --all --tags
             git checkout -f "$RELEASE_TAG"
+            # Build with cache while old containers still serve traffic
+            docker compose build
+            # Quick swap — downtime is only the restart
             docker compose down
-            docker compose up -d --build
-            sleep 60
+            docker compose up -d
+            # Wait for app to be healthy (up to 120s)
+            timeout 120 bash -c 'until docker compose ps app --format json | grep -q "(healthy)"; do sleep 5; done'
             docker compose ps
+            # Clean up dangling images to reclaim disk space
+            docker image prune -f
 
   notify-slack:
     name: Notify Slack


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes production/staging deployment automation (build/swap/health-wait), so a mis-detected health state or compose behavior change could impact deploy reliability. Scope is limited to GitHub Actions workflow scripts.
> 
> **Overview**
> **Deployment workflows now build before shutdown and verify health.** Staging, production (manual), and `release-please` deploy jobs run `docker compose build` while the old stack is still up, then do a quick `down`/`up -d` swap.
> 
> Replaces the fixed sleep and `up --build` with a 120s health poll for the `app` container, and switches aggressive image/builder pruning to a lighter `docker image prune -f` after deploy.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 69811fb648212642bfb300883232ab0680bc8da0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->