### PR TITLE
fix(AYC-000): skip orphaned agents and prompts in skills migration

### DIFF
--- a/ayunis-core-backend/src/db/migrations/1772627745700-MigrateAgentsAndPromptsToSkills.ts
+++ b/ayunis-core-backend/src/db/migrations/1772627745700-MigrateAgentsAndPromptsToSkills.ts
@@ -32,7 +32,9 @@ export class MigrateAgentsAndPromptsToSkills1772627745700 implements MigrationIn
         new_id TEXT;
         suffix INT;
       BEGIN
-        FOR r IN SELECT "id", "name", "instructions", "userId", "createdAt", "updatedAt" FROM "agents"
+        FOR r IN SELECT a."id", a."name", a."instructions", a."userId", a."createdAt", a."updatedAt"
+                 FROM "agents" a
+                 JOIN "users" u ON u."id" = a."userId"
         LOOP
           -- Sanitize: replace characters that are not alphanumeric, spaces, or hyphens
           sanitized := regexp_replace(r."name", '[^[:alnum:] -]', '-', 'g');
@@ -128,7 +130,9 @@ export class MigrateAgentsAndPromptsToSkills1772627745700 implements MigrationIn
         new_id TEXT;
         suffix INT;
       BEGIN
-        FOR r IN SELECT "id", "title", "content", "userId", "createdAt", "updatedAt" FROM "prompts"
+        FOR r IN SELECT p."id", p."title", p."content", p."userId", p."createdAt", p."updatedAt"
+                 FROM "prompts" p
+                 JOIN "users" u ON u."id" = p."userId"
         LOOP
           -- Sanitize: replace characters that are not alphanumeric, spaces, or hyphens
           sanitized := regexp_replace(r."title", '[^[:alnum:] -]', '-', 'g');


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes data migration behavior in a TypeORM/SQL migration and may leave some legacy rows unmigrated if their `userId` is invalid, but reduces the chance of migration failures due to broken references.
> 
> **Overview**
> **Skips orphaned data during the agents/prompts → skills migration.** The migration now only iterates agents and prompts that have a matching row in `users` (via an inner join), preventing skills from being created for records whose `userId` no longer exists.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 81c36ab5d895239f234f7ffae9517168655c842f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->