### PR TITLE
fix(AYC-000): allow parentheses in skill names

### DIFF
--- a/ayunis-core-backend/src/domain/skill-templates/domain/skill-template.entity.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/domain/skill-template.entity.ts
@@ -3,21 +3,21 @@ import { randomUUID } from 'crypto';
 import type { DistributionMode } from './distribution-mode.enum';
 
 /**
- * Valid skill template names: Unicode letters, numbers, emojis, hyphens, and spaces.
- * Must start and end with a letter, number, or emoji.
- * No consecutive spaces. Min length 1.
+ * Valid skill template names: Unicode letters, numbers, emojis, hyphens,
+ * parentheses, and spaces. Must start and end with a letter, number, emoji,
+ * or closing parenthesis. No consecutive spaces. Min length 1.
  *
  * Reuses the same pattern as Skill entity.
  */
 const SKILL_TEMPLATE_NAME_PATTERN =
-  /^[\p{L}\p{N}\p{Emoji_Presentation}]([\p{L}\p{N}\p{Emoji_Presentation} -]*[\p{L}\p{N}\p{Emoji_Presentation}])?$/u;
+  /^[\p{L}\p{N}\p{Emoji_Presentation}]([\p{L}\p{N}\p{Emoji_Presentation} ()-]*[\p{L}\p{N}\p{Emoji_Presentation})])?$/u;
 const CONSECUTIVE_SPACES = / {2}/;
 
 export class InvalidSkillTemplateNameError extends Error {
   constructor(name: string) {
     super(
-      `Invalid skill template name "${name}". Names must contain only letters, numbers, emojis, hyphens, and spaces, ` +
-        `must start and end with a letter, number, or emoji, and must not contain consecutive spaces.`,
+      `Invalid skill template name "${name}". Names must contain only letters, numbers, emojis, hyphens, parentheses, and spaces, ` +
+        `must start and end with a letter, number, emoji, or closing parenthesis, and must not contain consecutive spaces.`,
     );
     this.name = 'InvalidSkillTemplateNameError';
   }

--- a/ayunis-core-backend/src/domain/skill-templates/presenters/http/dto/create-skill-template.dto.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/presenters/http/dto/create-skill-template.dto.ts
@@ -14,7 +14,7 @@ import { DistributionMode } from '../../../domain/distribution-mode.enum';
 export class CreateSkillTemplateDto {
   @ApiProperty({
     description:
-      'The name of the skill template. Only letters, numbers, emojis, hyphens, and spaces allowed. Must start and end with a letter, number, or emoji.',
+      'The name of the skill template. Only letters, numbers, emojis, hyphens, parentheses, and spaces allowed. Must start and end with a letter, number, emoji, or closing parenthesis.',
     example: 'Legal Guidelines',
     minLength: 1,
     maxLength: 255,
@@ -23,10 +23,10 @@ export class CreateSkillTemplateDto {
   @IsNotEmpty()
   @Length(1, 255)
   @Matches(
-    /^[\p{L}\p{N}\p{Emoji_Presentation}]([\p{L}\p{N}\p{Emoji_Presentation} -]*[\p{L}\p{N}\p{Emoji_Presentation}])?$/u,
+    /^[\p{L}\p{N}\p{Emoji_Presentation}]([\p{L}\p{N}\p{Emoji_Presentation} ()-]*[\p{L}\p{N}\p{Emoji_Presentation})])?$/u,
     {
       message:
-        'Name must contain only letters, numbers, emojis, hyphens, and spaces, and must start and end with a letter, number, or emoji',
+        'Name must contain only letters, numbers, emojis, hyphens, parentheses, and spaces, and must start and end with a letter, number, emoji, or closing parenthesis',
     },
   )
   @Matches(/^(?!.* {2})/, {

--- a/ayunis-core-backend/src/domain/skill-templates/presenters/http/dto/update-skill-template.dto.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/presenters/http/dto/update-skill-template.dto.ts
@@ -14,7 +14,7 @@ import { DistributionMode } from '../../../domain/distribution-mode.enum';
 export class UpdateSkillTemplateDto {
   @ApiPropertyOptional({
     description:
-      'The name of the skill template. Only letters, numbers, emojis, hyphens, and spaces allowed. Must start and end with a letter, number, or emoji.',
+      'The name of the skill template. Only letters, numbers, emojis, hyphens, parentheses, and spaces allowed. Must start and end with a letter, number, emoji, or closing parenthesis.',
     example: 'Legal Guidelines',
     minLength: 1,
     maxLength: 255,
@@ -23,10 +23,10 @@ export class UpdateSkillTemplateDto {
   @IsNotEmpty()
   @Length(1, 255)
   @Matches(
-    /^[\p{L}\p{N}\p{Emoji_Presentation}]([\p{L}\p{N}\p{Emoji_Presentation} -]*[\p{L}\p{N}\p{Emoji_Presentation}])?$/u,
+    /^[\p{L}\p{N}\p{Emoji_Presentation}]([\p{L}\p{N}\p{Emoji_Presentation} ()-]*[\p{L}\p{N}\p{Emoji_Presentation})])?$/u,
     {
       message:
-        'Name must contain only letters, numbers, emojis, hyphens, and spaces, and must start and end with a letter, number, or emoji',
+        'Name must contain only letters, numbers, emojis, hyphens, parentheses, and spaces, and must start and end with a letter, number, emoji, or closing parenthesis',
     },
   )
   @Matches(/^(?!.* {2})/, {

--- a/ayunis-core-backend/src/domain/skills/domain/skill.entity.ts
+++ b/ayunis-core-backend/src/domain/skills/domain/skill.entity.ts
@@ -2,22 +2,22 @@ import type { UUID } from 'crypto';
 import { randomUUID } from 'crypto';
 
 /**
- * Valid skill names: Unicode letters, numbers, emojis, hyphens, and spaces.
- * Must start and end with a letter, number, or emoji.
- * No consecutive spaces. Min length 1.
+ * Valid skill names: Unicode letters, numbers, emojis, hyphens, parentheses,
+ * and spaces. Must start and end with a letter, number, emoji, or closing
+ * parenthesis. No consecutive spaces. Min length 1.
  *
  * Uses \p{Emoji_Presentation} for visible emojis only — excludes invisible
  * components like ZWJ (U+200D) and variation selectors (U+FE0E/FE0F).
  */
 const SKILL_NAME_PATTERN =
-  /^[\p{L}\p{N}\p{Emoji_Presentation}]([\p{L}\p{N}\p{Emoji_Presentation} -]*[\p{L}\p{N}\p{Emoji_Presentation}])?$/u;
+  /^[\p{L}\p{N}\p{Emoji_Presentation}]([\p{L}\p{N}\p{Emoji_Presentation} ()-]*[\p{L}\p{N}\p{Emoji_Presentation})])?$/u;
 const CONSECUTIVE_SPACES = / {2}/;
 
 export class InvalidSkillNameError extends Error {
   constructor(name: string) {
     super(
-      `Invalid skill name "${name}". Names must contain only letters, numbers, emojis, hyphens, and spaces, ` +
-        `must start and end with a letter, number, or emoji, and must not contain consecutive spaces.`,
+      `Invalid skill name "${name}". Names must contain only letters, numbers, emojis, hyphens, parentheses, and spaces, ` +
+        `must start and end with a letter, number, emoji, or closing parenthesis, and must not contain consecutive spaces.`,
     );
     this.name = 'InvalidSkillNameError';
   }

--- a/ayunis-core-backend/src/domain/skills/presenters/http/dto/base-skill.dto.ts
+++ b/ayunis-core-backend/src/domain/skills/presenters/http/dto/base-skill.dto.ts
@@ -4,7 +4,7 @@ import { IsString, IsNotEmpty, Length, Matches } from 'class-validator';
 export class BaseSkillDto {
   @ApiProperty({
     description:
-      'The name of the skill (must be unique per user). Only letters, numbers, emojis, hyphens, and spaces allowed. Must start and end with a letter, number, or emoji.',
+      'The name of the skill (must be unique per user). Only letters, numbers, emojis, hyphens, parentheses, and spaces allowed. Must start and end with a letter, number, emoji, or closing parenthesis.',
     example: 'Legal Research',
     minLength: 1,
     maxLength: 255,
@@ -13,10 +13,10 @@ export class BaseSkillDto {
   @IsNotEmpty()
   @Length(1, 255)
   @Matches(
-    /^[\p{L}\p{N}\p{Emoji_Presentation}]([\p{L}\p{N}\p{Emoji_Presentation} -]*[\p{L}\p{N}\p{Emoji_Presentation}])?$/u,
+    /^[\p{L}\p{N}\p{Emoji_Presentation}]([\p{L}\p{N}\p{Emoji_Presentation} ()-]*[\p{L}\p{N}\p{Emoji_Presentation})])?$/u,
     {
       message:
-        'Name must contain only letters, numbers, emojis, hyphens, and spaces, and must start and end with a letter, number, or emoji',
+        'Name must contain only letters, numbers, emojis, hyphens, parentheses, and spaces, and must start and end with a letter, number, emoji, or closing parenthesis',
     },
   )
   @Matches(/^(?!.* {2})/, {

--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
@@ -2571,7 +2571,7 @@ export interface SkillResponseDto {
 
 export interface CreateSkillDto {
   /**
-   * The name of the skill (must be unique per user). Only letters, numbers, emojis, hyphens, and spaces allowed. Must start and end with a letter, number, or emoji.
+   * The name of the skill (must be unique per user). Only letters, numbers, emojis, hyphens, parentheses, and spaces allowed. Must start and end with a letter, number, emoji, or closing parenthesis.
    * @minLength 1
    * @maxLength 255
    */
@@ -2586,7 +2586,7 @@ export interface CreateSkillDto {
 
 export interface UpdateSkillDto {
   /**
-   * The name of the skill (must be unique per user). Only letters, numbers, emojis, hyphens, and spaces allowed. Must start and end with a letter, number, or emoji.
+   * The name of the skill (must be unique per user). Only letters, numbers, emojis, hyphens, parentheses, and spaces allowed. Must start and end with a letter, number, emoji, or closing parenthesis.
    * @minLength 1
    * @maxLength 255
    */
@@ -3039,89 +3039,6 @@ export interface GlobalUserUsageResponseDto {
   data: GlobalUserUsageDto[];
 }
 
-export interface UserSystemPromptResponseDto {
-  /**
-   * The custom system prompt for the user, or null if not set
-   * @nullable
-   */
-  systemPrompt: string | null;
-}
-
-export interface UpsertUserSystemPromptDto {
-  /**
-   * The custom system prompt for the user
-   * @maxLength 10000
-   */
-  systemPrompt: string;
-}
-
-export interface GeneratePersonalizedSystemPromptDto {
-  /**
-   * The preferred name of the user
-   * @maxLength 200
-   */
-  preferredName: string;
-  /**
-   * The preferred communication style
-   * @maxLength 500
-   */
-  communicationStyle?: string;
-  /**
-   * The work context of the user
-   * @maxLength 1000
-   */
-  workContext?: string;
-}
-
-export interface GeneratePersonalizedSystemPromptResponseDto {
-  /** The generated personalized system prompt */
-  systemPrompt: string;
-  /** A personalized welcome message for the user */
-  welcomeMessage: string;
-}
-
-export interface CreatePromptDto {
-  /**
-   * The title of the prompt
-   * @minLength 1
-   * @maxLength 255
-   */
-  title: string;
-  /** The content of the prompt */
-  content: string;
-}
-
-export interface PromptResponseDto {
-  /** The unique identifier of the prompt */
-  id: string;
-  /** The title of the prompt */
-  title: string;
-  /** The content of the prompt */
-  content: string;
-  /** The unique identifier of the user who owns this prompt */
-  userId: string;
-  /** The date and time when the prompt was created */
-  createdAt: string;
-  /** The date and time when the prompt was last updated */
-  updatedAt: string;
-}
-
-export interface UpdatePromptDto {
-  /**
-   * The title of the prompt
-   * @minLength 1
-   * @maxLength 255
-   */
-  title: string;
-  /** The content of the prompt */
-  content: string;
-}
-
-export interface TranscriptionResponseDto {
-  /** The transcribed text from the audio file */
-  text: string;
-}
-
 /**
  * The distribution mode of the skill template
  */
@@ -3136,7 +3053,7 @@ export const CreateSkillTemplateDtoDistributionMode = {
 
 export interface CreateSkillTemplateDto {
   /**
-   * The name of the skill template. Only letters, numbers, emojis, hyphens, and spaces allowed. Must start and end with a letter, number, or emoji.
+   * The name of the skill template. Only letters, numbers, emojis, hyphens, parentheses, and spaces allowed. Must start and end with a letter, number, emoji, or closing parenthesis.
    * @minLength 1
    * @maxLength 255
    */
@@ -3196,7 +3113,7 @@ export const UpdateSkillTemplateDtoDistributionMode = {
 
 export interface UpdateSkillTemplateDto {
   /**
-   * The name of the skill template. Only letters, numbers, emojis, hyphens, and spaces allowed. Must start and end with a letter, number, or emoji.
+   * The name of the skill template. Only letters, numbers, emojis, hyphens, parentheses, and spaces allowed. Must start and end with a letter, number, emoji, or closing parenthesis.
    * @minLength 1
    * @maxLength 255
    */
@@ -3225,6 +3142,31 @@ export interface UpsertUserSystemPromptDto {
    * @maxLength 10000
    */
   systemPrompt: string;
+}
+
+export interface GeneratePersonalizedSystemPromptDto {
+  /**
+   * The preferred name of the user
+   * @maxLength 200
+   */
+  preferredName: string;
+  /**
+   * The preferred communication style
+   * @maxLength 500
+   */
+  communicationStyle?: string;
+  /**
+   * The work context of the user
+   * @maxLength 1000
+   */
+  workContext?: string;
+}
+
+export interface GeneratePersonalizedSystemPromptResponseDto {
+  /** The generated personalized system prompt */
+  systemPrompt: string;
+  /** A personalized welcome message for the user */
+  welcomeMessage: string;
 }
 
 export interface CreatePromptDto {

--- a/ayunis-core-frontend/src/shared/api/openapi-schema.json
+++ b/ayunis-core-frontend/src/shared/api/openapi-schema.json
@@ -12132,7 +12132,7 @@
         "properties": {
           "name": {
             "type": "string",
-            "description": "The name of the skill (must be unique per user). Only letters, numbers, emojis, hyphens, and spaces allowed. Must start and end with a letter, number, or emoji.",
+            "description": "The name of the skill (must be unique per user). Only letters, numbers, emojis, hyphens, parentheses, and spaces allowed. Must start and end with a letter, number, emoji, or closing parenthesis.",
             "example": "Legal Research",
             "minLength": 1,
             "maxLength": 255
@@ -12164,7 +12164,7 @@
         "properties": {
           "name": {
             "type": "string",
-            "description": "The name of the skill (must be unique per user). Only letters, numbers, emojis, hyphens, and spaces allowed. Must start and end with a letter, number, or emoji.",
+            "description": "The name of the skill (must be unique per user). Only letters, numbers, emojis, hyphens, parentheses, and spaces allowed. Must start and end with a letter, number, emoji, or closing parenthesis.",
             "example": "Legal Research",
             "minLength": 1,
             "maxLength": 255
@@ -13023,187 +13023,12 @@
           "data"
         ]
       },
-      "UserSystemPromptResponseDto": {
-        "type": "object",
-        "properties": {
-          "systemPrompt": {
-            "type": "string",
-            "description": "The custom system prompt for the user, or null if not set",
-            "example": "Always respond in bullet points. I work in the finance department.",
-            "nullable": true
-          }
-        },
-        "required": [
-          "systemPrompt"
-        ]
-      },
-      "UpsertUserSystemPromptDto": {
-        "type": "object",
-        "properties": {
-          "systemPrompt": {
-            "type": "string",
-            "description": "The custom system prompt for the user",
-            "example": "Always respond in bullet points. I work in the finance department.",
-            "maxLength": 10000
-          }
-        },
-        "required": [
-          "systemPrompt"
-        ]
-      },
-      "GeneratePersonalizedSystemPromptDto": {
-        "type": "object",
-        "properties": {
-          "preferredName": {
-            "type": "string",
-            "description": "The preferred name of the user",
-            "example": "Maria",
-            "maxLength": 200
-          },
-          "communicationStyle": {
-            "type": "string",
-            "description": "The preferred communication style",
-            "example": "Locker & kurz",
-            "maxLength": 500
-          },
-          "workContext": {
-            "type": "string",
-            "description": "The work context of the user",
-            "example": "Bescheide im Sozialamt, Protokolle für den Gemeinderat",
-            "maxLength": 1000
-          }
-        },
-        "required": [
-          "preferredName"
-        ]
-      },
-      "GeneratePersonalizedSystemPromptResponseDto": {
-        "type": "object",
-        "properties": {
-          "systemPrompt": {
-            "type": "string",
-            "description": "The generated personalized system prompt",
-            "example": "Hallo Maria! Ich kommuniziere locker und kurz mit dir. Ich helfe dir bei allen Fragen rund um deine Arbeit im Sozialamt."
-          },
-          "welcomeMessage": {
-            "type": "string",
-            "description": "A personalized welcome message for the user",
-            "example": "Willkommen, Maria! Schön, dass du da bist. Wie kann ich dir heute helfen?"
-          }
-        },
-        "required": [
-          "systemPrompt",
-          "welcomeMessage"
-        ]
-      },
-      "CreatePromptDto": {
-        "type": "object",
-        "properties": {
-          "title": {
-            "type": "string",
-            "description": "The title of the prompt",
-            "example": "Project Planning Assistant",
-            "minLength": 1,
-            "maxLength": 255
-          },
-          "content": {
-            "type": "string",
-            "description": "The content of the prompt",
-            "example": "You are a helpful assistant that helps with project planning. Please provide detailed step-by-step guidance for managing projects effectively."
-          }
-        },
-        "required": [
-          "title",
-          "content"
-        ]
-      },
-      "PromptResponseDto": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string",
-            "description": "The unique identifier of the prompt",
-            "example": "123e4567-e89b-12d3-a456-426614174000",
-            "format": "uuid"
-          },
-          "title": {
-            "type": "string",
-            "description": "The title of the prompt",
-            "example": "Project Planning Assistant"
-          },
-          "content": {
-            "type": "string",
-            "description": "The content of the prompt",
-            "example": "You are a helpful assistant that helps with project planning. Please provide detailed step-by-step guidance for managing projects effectively."
-          },
-          "userId": {
-            "type": "string",
-            "description": "The unique identifier of the user who owns this prompt",
-            "example": "123e4567-e89b-12d3-a456-426614174000",
-            "format": "uuid"
-          },
-          "createdAt": {
-            "type": "string",
-            "description": "The date and time when the prompt was created",
-            "example": "2023-12-01T10:00:00.000Z",
-            "format": "date-time"
-          },
-          "updatedAt": {
-            "type": "string",
-            "description": "The date and time when the prompt was last updated",
-            "example": "2023-12-01T10:00:00.000Z",
-            "format": "date-time"
-          }
-        },
-        "required": [
-          "id",
-          "title",
-          "content",
-          "userId",
-          "createdAt",
-          "updatedAt"
-        ]
-      },
-      "UpdatePromptDto": {
-        "type": "object",
-        "properties": {
-          "title": {
-            "type": "string",
-            "description": "The title of the prompt",
-            "example": "Updated Project Planning Assistant",
-            "minLength": 1,
-            "maxLength": 255
-          },
-          "content": {
-            "type": "string",
-            "description": "The content of the prompt",
-            "example": "You are an expert project planning assistant. Provide comprehensive guidance for project management, including risk assessment and timeline optimization."
-          }
-        },
-        "required": [
-          "title",
-          "content"
-        ]
-      },
-      "TranscriptionResponseDto": {
-        "type": "object",
-        "properties": {
-          "text": {
-            "type": "string",
-            "description": "The transcribed text from the audio file",
-            "example": "Hello, this is a test transcription."
-          }
-        },
-        "required": [
-          "text"
-        ]
-      },
       "CreateSkillTemplateDto": {
         "type": "object",
         "properties": {
           "name": {
             "type": "string",
-            "description": "The name of the skill template. Only letters, numbers, emojis, hyphens, and spaces allowed. Must start and end with a letter, number, or emoji.",
+            "description": "The name of the skill template. Only letters, numbers, emojis, hyphens, parentheses, and spaces allowed. Must start and end with a letter, number, emoji, or closing parenthesis.",
             "example": "Legal Guidelines",
             "minLength": 1,
             "maxLength": 255
@@ -13305,7 +13130,7 @@
         "properties": {
           "name": {
             "type": "string",
-            "description": "The name of the skill template. Only letters, numbers, emojis, hyphens, and spaces allowed. Must start and end with a letter, number, or emoji.",
+            "description": "The name of the skill template. Only letters, numbers, emojis, hyphens, parentheses, and spaces allowed. Must start and end with a letter, number, emoji, or closing parenthesis.",
             "example": "Legal Guidelines",
             "minLength": 1,
             "maxLength": 255
@@ -13362,6 +13187,51 @@
         },
         "required": [
           "systemPrompt"
+        ]
+      },
+      "GeneratePersonalizedSystemPromptDto": {
+        "type": "object",
+        "properties": {
+          "preferredName": {
+            "type": "string",
+            "description": "The preferred name of the user",
+            "example": "Maria",
+            "maxLength": 200
+          },
+          "communicationStyle": {
+            "type": "string",
+            "description": "The preferred communication style",
+            "example": "Locker & kurz",
+            "maxLength": 500
+          },
+          "workContext": {
+            "type": "string",
+            "description": "The work context of the user",
+            "example": "Bescheide im Sozialamt, Protokolle für den Gemeinderat",
+            "maxLength": 1000
+          }
+        },
+        "required": [
+          "preferredName"
+        ]
+      },
+      "GeneratePersonalizedSystemPromptResponseDto": {
+        "type": "object",
+        "properties": {
+          "systemPrompt": {
+            "type": "string",
+            "description": "The generated personalized system prompt",
+            "example": "Hallo Maria! Ich kommuniziere locker und kurz mit dir. Ich helfe dir bei allen Fragen rund um deine Arbeit im Sozialamt."
+          },
+          "welcomeMessage": {
+            "type": "string",
+            "description": "A personalized welcome message for the user",
+            "example": "Willkommen, Maria! Schön, dass du da bist. Wie kann ich dir heute helfen?"
+          }
+        },
+        "required": [
+          "systemPrompt",
+          "welcomeMessage"
         ]
       },
       "CreatePromptDto": {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk validation/doc change: it expands allowed characters for skill and skill-template names and updates generated API schema/docs accordingly, with minimal behavioral impact beyond name acceptance.
> 
> **Overview**
> Allows parentheses in **skill** and **skill template** names by updating the shared name validation regex in the domain entities and corresponding HTTP DTO `@Matches` validators (including updated error/help text).
> 
> Regenerates/updates the frontend OpenAPI artifacts (`ayunisCoreAPI.schemas.ts`, `openapi-schema.json`) so the documented constraints for `Create/UpdateSkillDto` and `Create/UpdateSkillTemplateDto` reflect the new naming rules.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aeacc08e5612b68b35cf5e3aa6a6f6fd3988ca63. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->