### PR TITLE
feat(AYC-000): add own/shared tabs to skills page and remove active badge

### DIFF
--- a/ayunis-core-frontend/src/pages/skills/ui/SkillCard.tsx
+++ b/ayunis-core-frontend/src/pages/skills/ui/SkillCard.tsx
@@ -75,12 +75,6 @@ export default function SkillCard({ skill }: Readonly<SkillCardProps>) {
               {t('shared.badge')}
             </Badge>
           )}
-          <Badge
-            variant={skill.isActive ? 'default' : 'secondary'}
-            className="ml-2 text-xs"
-          >
-            {skill.isActive ? t('badge.active') : t('badge.inactive')}
-          </Badge>
         </ItemTitle>
         <ItemDescription>{skill.shortDescription}</ItemDescription>
       </ItemContent>

--- a/ayunis-core-frontend/src/pages/skills/ui/SkillsPage.tsx
+++ b/ayunis-core-frontend/src/pages/skills/ui/SkillsPage.tsx
@@ -8,6 +8,13 @@ import SkillsEmptyState from './SkillsEmptyState';
 import FullScreenMessageLayout from '@/layouts/full-screen-message-layout/ui/FullScreenMessageLayout';
 import { useTranslation } from 'react-i18next';
 import { HelpLink } from '@/shared/ui/help-link/HelpLink';
+import {
+  Tabs,
+  TabsList,
+  TabsTrigger,
+  TabsContent,
+} from '@/shared/ui/shadcn/tabs';
+import { EmptyState } from '@/widgets/empty-state';
 
 interface SkillsPageProps {
   skills: Skill[];
@@ -16,8 +23,13 @@ interface SkillsPageProps {
 export default function SkillsPage({ skills }: Readonly<SkillsPageProps>) {
   const { t } = useTranslation('skills');
 
-  // Sort skills by name
-  const sortedSkills = [...skills].sort((a, b) => a.name.localeCompare(b.name));
+  const personalSkills = skills
+    .filter((skill) => !skill.isShared)
+    .sort((a, b) => a.name.localeCompare(b.name));
+
+  const sharedSkills = skills
+    .filter((skill) => skill.isShared)
+    .sort((a, b) => a.name.localeCompare(b.name));
 
   const headerAction = (
     <div className="flex gap-2">
@@ -48,11 +60,46 @@ export default function SkillsPage({ skills }: Readonly<SkillsPageProps>) {
           <ContentAreaHeader title={t('page.title')} action={headerAction} />
         }
         contentArea={
-          <div className="space-y-3">
-            {sortedSkills.map((skill) => (
-              <SkillCard key={skill.id} skill={skill} />
-            ))}
-          </div>
+          <Tabs defaultValue="personal" className="w-full">
+            <TabsList>
+              <TabsTrigger value="personal">{t('tabs.personal')}</TabsTrigger>
+              <TabsTrigger value="shared">{t('tabs.shared')}</TabsTrigger>
+            </TabsList>
+            <TabsContent value="personal" className="mt-4">
+              {personalSkills.length === 0 ? (
+                <EmptyState
+                  title={t('emptyState.personal.title')}
+                  description={t('emptyState.personal.description')}
+                  action={
+                    <CreateSkillDialog
+                      buttonText={t('createDialog.buttonTextFirst')}
+                      showIcon={true}
+                    />
+                  }
+                />
+              ) : (
+                <div className="space-y-3">
+                  {personalSkills.map((skill) => (
+                    <SkillCard key={skill.id} skill={skill} />
+                  ))}
+                </div>
+              )}
+            </TabsContent>
+            <TabsContent value="shared" className="mt-4">
+              {sharedSkills.length === 0 ? (
+                <EmptyState
+                  title={t('emptyState.shared.title')}
+                  description={t('emptyState.shared.description')}
+                />
+              ) : (
+                <div className="space-y-3">
+                  {sharedSkills.map((skill) => (
+                    <SkillCard key={skill.id} skill={skill} />
+                  ))}
+                </div>
+              )}
+            </TabsContent>
+          </Tabs>
         }
       />
     </AppLayout>

--- a/ayunis-core-frontend/src/shared/locales/de/skills.json
+++ b/ayunis-core-frontend/src/shared/locales/de/skills.json
@@ -5,9 +5,21 @@
   "page": {
     "title": "Fähigkeiten"
   },
+  "tabs": {
+    "personal": "Eigene Fähigkeiten",
+    "shared": "Geteilte Fähigkeiten"
+  },
   "emptyState": {
     "title": "Noch keine Fähigkeiten",
-    "description": "Erstellen Sie Ihre erste Fähigkeit. Fähigkeiten sind wiederverwendbare Wissens- und Integrationsbündel, die bei Bedarf während Gesprächen aktiviert werden können."
+    "description": "Erstellen Sie Ihre erste Fähigkeit. Fähigkeiten sind wiederverwendbare Wissens- und Integrationsbündel, die bei Bedarf während Gesprächen aktiviert werden können.",
+    "personal": {
+      "title": "Noch keine eigenen Fähigkeiten",
+      "description": "Erstellen Sie Ihre erste Fähigkeit. Fähigkeiten sind wiederverwendbare Wissens- und Integrationsbündel, die bei Bedarf während Gesprächen aktiviert werden können."
+    },
+    "shared": {
+      "title": "Noch keine geteilten Fähigkeiten",
+      "description": "Fähigkeiten, die von anderen Mitgliedern Ihrer Organisation mit Ihnen geteilt werden, erscheinen hier."
+    }
   },
   "badge": {
     "active": "Aktiv",

--- a/ayunis-core-frontend/src/shared/locales/en/skills.json
+++ b/ayunis-core-frontend/src/shared/locales/en/skills.json
@@ -5,9 +5,21 @@
   "page": {
     "title": "My Skills"
   },
+  "tabs": {
+    "personal": "Own Skills",
+    "shared": "Shared Skills"
+  },
   "emptyState": {
     "title": "No skills yet",
-    "description": "Get started by creating your first skill. Skills are reusable knowledge and integration bundles that can be activated on-demand during conversations."
+    "description": "Get started by creating your first skill. Skills are reusable knowledge and integration bundles that can be activated on-demand during conversations.",
+    "personal": {
+      "title": "No own skills yet",
+      "description": "Create your first skill. Skills are reusable knowledge and integration bundles that can be activated on-demand during conversations."
+    },
+    "shared": {
+      "title": "No shared skills yet",
+      "description": "Skills shared with you by other members of your organization will appear here."
+    }
   },
   "badge": {
     "active": "Active",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk UI-only changes: skills list rendering is reorganized into tabs and empty-state messaging is updated, with no backend/API or permission logic changes.
> 
> **Overview**
> Adds **Own/Shared tabs** to `SkillsPage`, splitting the list into `personalSkills` and `sharedSkills` (both sorted by name) and showing tab-specific empty states (including a “create first skill” CTA for the personal tab).
> 
> Simplifies `SkillCard` by removing the active/inactive status badge, relying on the existing label + switch; updates `en`/`de` `skills.json` with new tab labels and tab-specific empty-state copy.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4e2f41dd7ec98cecbd50ac83b5317959786918a9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->