### PR TITLE
fix(AYC-000): hide greeting when personalization card is active

### DIFF
--- a/ayunis-core-frontend/src/pages/new-chat/ui/NewChatPage.tsx
+++ b/ayunis-core-frontend/src/pages/new-chat/ui/NewChatPage.tsx
@@ -163,9 +163,6 @@ export default function NewChatPage({
       <NewChatPageLayout
         header={<ContentAreaHeader title={t('newChat.newChat')} />}
       >
-        <div className="text-center">
-          <h1 className="text-2xl font-bold">{greeting}</h1>
-        </div>
         <PersonalizationCard
           onSkip={skip}
           isSkipping={isSkipping}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk UI-only change that removes a heading in a specific conditional render path; no data flow or business logic is affected.
> 
> **Overview**
> When the new-chat flow shows the `PersonalizationCard` (i.e., before a system prompt exists), the page no longer renders the time-based greeting header above it.
> 
> The greeting remains shown on the normal new chat page once personalization is complete.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 140d49be3ebdf661767dc7d4d708bb55c7abc91a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->