### PR TITLE
fix(AYC-000): resolve skill slug to original name before activation lookup

### DIFF
--- a/ayunis-core-backend/src/domain/tools/application/handlers/activate-skill-tool.handler.spec.ts
+++ b/ayunis-core-backend/src/domain/tools/application/handlers/activate-skill-tool.handler.spec.ts
@@ -68,10 +68,11 @@ describe('ActivateSkillToolHandler', () => {
     });
   }
 
-  function createMockTool(skillName: string) {
+  function createMockTool(slug: string, resolvedName?: string) {
     return {
       name: 'activate_skill',
-      validateParams: jest.fn().mockReturnValue({ skill_slug: skillName }),
+      validateParams: jest.fn().mockReturnValue({ skill_slug: slug }),
+      resolveOriginalName: jest.fn().mockReturnValue(resolvedName),
     } as unknown as ActivateSkillTool;
   }
 
@@ -108,7 +109,9 @@ describe('ActivateSkillToolHandler', () => {
   });
 
   it('should throw ToolExecutionFailedError when skill is not found', async () => {
-    mockFindSkillByName.execute.mockResolvedValue(null as any);
+    mockFindSkillByName.execute.mockRejectedValue(
+      new Error('Skill with ID Nonexistent Skill not found'),
+    );
     const tool = createMockTool('Nonexistent Skill');
 
     await expect(
@@ -147,6 +150,42 @@ describe('ActivateSkillToolHandler', () => {
     });
 
     expect(result).toBe(instructions);
+  });
+
+  it('should resolve slug to original name before looking up the skill', async () => {
+    const skill = createMockSkill({ name: 'Buchungsanfragen bearbeiten' });
+    const thread = new Thread({
+      userId: randomUUID(),
+      messages: [],
+    });
+
+    mockFindSkillByName.execute.mockResolvedValue(skill);
+    mockFindThread.execute.mockResolvedValue({
+      thread,
+      isLongChat: false,
+    });
+    mockSkillActivationService.activateOnThread.mockResolvedValue({
+      instructions: 'Handle booking requests.',
+      skillName: 'Buchungsanfragen bearbeiten',
+    });
+
+    const tool = createMockTool(
+      'user__buchungsanfragen-bearbeiten',
+      'Buchungsanfragen bearbeiten',
+    );
+
+    await handler.execute({
+      tool,
+      input: { skill_slug: 'user__buchungsanfragen-bearbeiten' },
+      context: { threadId: mockThreadId, orgId: randomUUID() },
+    });
+
+    expect(tool.resolveOriginalName).toHaveBeenCalledWith(
+      'user__buchungsanfragen-bearbeiten',
+    );
+    expect(mockFindSkillByName.execute).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'Buchungsanfragen bearbeiten' }),
+    );
   });
 
   it('should wrap unexpected errors from SkillActivationService as ToolExecutionFailedError', async () => {

--- a/ayunis-core-backend/src/domain/tools/application/handlers/activate-skill-tool.handler.ts
+++ b/ayunis-core-backend/src/domain/tools/application/handlers/activate-skill-tool.handler.ts
@@ -35,19 +35,15 @@ export class ActivateSkillToolHandler extends ToolExecutionHandler {
     try {
       const validatedInput = tool.validateParams(input);
 
-      // Find the skill by name
-      const skill = await this.findSkillByNameUseCase.execute(
-        new FindSkillByNameQuery(validatedInput.skill_slug),
-      );
+      // Resolve slug back to original skill name
+      const skillName =
+        tool.resolveOriginalName(validatedInput.skill_slug) ??
+        validatedInput.skill_slug;
 
-      if (!skill) {
-        this.logger.error('Skill not found', validatedInput.skill_slug);
-        throw new ToolExecutionFailedError({
-          toolName: tool.name,
-          message: `Skill "${validatedInput.skill_slug}" not found`,
-          exposeToLLM: true,
-        });
-      }
+      // Find the skill by name (throws SkillNotFoundError if missing)
+      const skill = await this.findSkillByNameUseCase.execute(
+        new FindSkillByNameQuery(skillName),
+      );
 
       // Get the thread
       const threadResult = await this.findThreadUseCase.execute(


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the skill-activation lookup path to translate slugs to names and relies on thrown errors from `FindSkillByNameUseCase`, which could affect activation behavior and error propagation at runtime.
> 
> **Overview**
> `ActivateSkillToolHandler` now translates the incoming `skill_slug` back to the original skill name via `tool.resolveOriginalName(...)` before calling `FindSkillByNameUseCase`, enabling activation when tools emit slug identifiers rather than display names.
> 
> The handler no longer performs a `null`-check for missing skills (it assumes `FindSkillByNameUseCase` throws), and the spec updates mocks accordingly and adds coverage to ensure slug-to-name resolution happens before lookup.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 529e322d0444ca5683feb5f1b8c84d2f6fe9b2f9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->