### PR TITLE
feat(AYC-000): add tool usage prometheus metric

### DIFF
--- a/ayunis-core-backend/src/domain/runs/application/services/tool-result-collector.service.spec.ts
+++ b/ayunis-core-backend/src/domain/runs/application/services/tool-result-collector.service.spec.ts
@@ -1,3 +1,4 @@
+import type { Counter } from 'prom-client';
 import { AnonymizationFailedError } from 'src/common/anonymization/application/anonymization.errors';
 import type { AnonymizeTextUseCase } from 'src/common/anonymization/application/use-cases/anonymize-text/anonymize-text.use-case';
 import { RunAnonymizationUnavailableError } from '../runs.errors';
@@ -7,6 +8,7 @@ import type { Thread } from 'src/domain/threads/domain/thread.entity';
 import type { Tool } from 'src/domain/tools/domain/tool.entity';
 import type { ExecuteToolUseCase } from 'src/domain/tools/application/use-cases/execute-tool/execute-tool.use-case';
 import type { CheckToolCapabilitiesUseCase } from 'src/domain/tools/application/use-cases/check-tool-capabilities/check-tool-capabilities.use-case';
+import type { ContextService } from 'src/common/context/services/context.service';
 import { ToolResultCollectorService } from './tool-result-collector.service';
 import { randomUUID } from 'crypto';
 
@@ -15,6 +17,7 @@ describe('ToolResultCollectorService', () => {
   let executeToolUseCase: jest.Mocked<ExecuteToolUseCase>;
   let checkToolCapabilitiesUseCase: jest.Mocked<CheckToolCapabilitiesUseCase>;
   let anonymizeTextUseCase: jest.Mocked<AnonymizeTextUseCase>;
+  let contextService: jest.Mocked<ContextService>;
 
   const orgId = randomUUID();
   const threadId = randomUUID();
@@ -33,10 +36,20 @@ describe('ToolResultCollectorService', () => {
       execute: jest.fn(),
     } as unknown as jest.Mocked<AnonymizeTextUseCase>;
 
+    contextService = {
+      get: jest.fn().mockReturnValue(randomUUID()),
+    } as unknown as jest.Mocked<ContextService>;
+
+    const toolUsesCounter = {
+      inc: jest.fn(),
+    } as unknown as Counter<string>;
+
     service = new ToolResultCollectorService(
       executeToolUseCase,
       checkToolCapabilitiesUseCase,
       anonymizeTextUseCase,
+      contextService,
+      toolUsesCounter,
     );
   });
 

--- a/ayunis-core-backend/src/domain/runs/application/services/tool-result-collector.service.ts
+++ b/ayunis-core-backend/src/domain/runs/application/services/tool-result-collector.service.ts
@@ -1,4 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { Counter } from 'prom-client';
+import { InjectMetric } from '@willsoto/nestjs-prometheus';
 import { UUID } from 'crypto';
 import { ToolResultMessageContent } from 'src/domain/messages/domain/message-contents/tool-result.message-content.entity';
 import { ToolUseMessageContent } from 'src/domain/messages/domain/message-contents/tool-use.message-content.entity';
@@ -14,6 +16,9 @@ import { ToolExecutionFailedError } from 'src/domain/tools/application/tools.err
 import { AnonymizeTextUseCase } from 'src/common/anonymization/application/use-cases/anonymize-text/anonymize-text.use-case';
 import { AnonymizeTextCommand } from 'src/common/anonymization/application/use-cases/anonymize-text/anonymize-text.command';
 import { ApplicationError } from 'src/common/errors/base.error';
+import { ContextService } from 'src/common/context/services/context.service';
+import { AYUNIS_TOOL_USES_TOTAL } from 'src/metrics/metrics.constants';
+import { getUserContextLabels, safeMetric } from 'src/metrics/metrics.utils';
 import {
   RunAnonymizationUnavailableError,
   RunToolExecutionFailedError,
@@ -30,6 +35,9 @@ export class ToolResultCollectorService {
     private readonly executeToolUseCase: ExecuteToolUseCase,
     private readonly checkToolCapabilitiesUseCase: CheckToolCapabilitiesUseCase,
     private readonly anonymizeTextUseCase: AnonymizeTextUseCase,
+    private readonly contextService: ContextService,
+    @InjectMetric(AYUNIS_TOOL_USES_TOTAL)
+    private readonly toolUsesCounter: Counter<string>,
   ) {}
 
   async collectToolResults(params: {
@@ -63,6 +71,14 @@ export class ToolResultCollectorService {
         );
         continue;
       }
+
+      safeMetric(this.logger, () => {
+        const labels = getUserContextLabels(this.contextService);
+        this.toolUsesCounter.inc({
+          ...labels,
+          tool_name: content.name,
+        });
+      });
 
       try {
         const capabilities = this.checkToolCapabilitiesUseCase.execute(

--- a/ayunis-core-backend/src/metrics/metrics.constants.ts
+++ b/ayunis-core-backend/src/metrics/metrics.constants.ts
@@ -10,6 +10,7 @@ export const AYUNIS_INFERENCE_ERRORS_TOTAL = 'ayunis_inference_errors_total';
 export const AYUNIS_MESSAGES_TOTAL = 'ayunis_messages_total';
 export const AYUNIS_USER_ACTIVITY_TOTAL = 'ayunis_user_activity_total';
 export const AYUNIS_THREAD_MESSAGE_COUNT = 'ayunis_thread_message_count';
+export const AYUNIS_TOOL_USES_TOTAL = 'ayunis_tool_uses_total';
 
 // Shared label names
 //
@@ -27,3 +28,4 @@ export const LABEL_DIRECTION = 'direction';
 export const LABEL_ROLE = 'role';
 export const LABEL_ERROR_TYPE = 'error_type';
 export const LABEL_STREAMING = 'streaming';
+export const LABEL_TOOL_NAME = 'tool_name';

--- a/ayunis-core-backend/src/metrics/metrics.module.ts
+++ b/ayunis-core-backend/src/metrics/metrics.module.ts
@@ -12,6 +12,7 @@ import {
   AYUNIS_MESSAGES_TOTAL,
   AYUNIS_USER_ACTIVITY_TOTAL,
   AYUNIS_THREAD_MESSAGE_COUNT,
+  AYUNIS_TOOL_USES_TOTAL,
   LABEL_USER_ID,
   LABEL_ORG_ID,
   LABEL_MODEL,
@@ -20,6 +21,7 @@ import {
   LABEL_ROLE,
   LABEL_ERROR_TYPE,
   LABEL_STREAMING,
+  LABEL_TOOL_NAME,
 } from './metrics.constants';
 import { MetricsAuthMiddleware } from './metrics-auth.middleware';
 import { MetricsController } from './metrics.controller';
@@ -68,6 +70,12 @@ const threadMessageCountHistogram = makeHistogramProvider({
   buckets: [1, 2, 5, 10, 20, 50, 100, 200],
 });
 
+const toolUsesCounter = makeCounterProvider({
+  name: AYUNIS_TOOL_USES_TOTAL,
+  help: 'Total number of tool invocations',
+  labelNames: [LABEL_USER_ID, LABEL_ORG_ID, LABEL_TOOL_NAME],
+});
+
 const metricProviders = [
   tokensCounter,
   inferenceDurationHistogram,
@@ -75,6 +83,7 @@ const metricProviders = [
   messagesCounter,
   userActivityCounter,
   threadMessageCountHistogram,
+  toolUsesCounter,
 ];
 
 @Global()


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: changes only add metric recording around tool-use processing and are wrapped in `safeMetric` to avoid impacting the main execution path; primary concern is potential label cardinality from `tool_name`.
> 
> **Overview**
> Adds a new Prometheus counter `ayunis_tool_uses_total` (labels: `user_id`, `org_id`, `tool_name`) and registers it in `MetricsModule`.
> 
> `ToolResultCollectorService.collectToolResults` now increments this counter for each resolved tool use using request-context labels from `ContextService`, guarded by `safeMetric`; unit tests are updated to inject the new dependencies.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 91c1e518dffd7e65925a7fecb3128700335d2f76. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->