### PR TITLE
feat(AYC-104): enable txt file upload as text source

### DIFF
--- a/ayunis-core-backend/src/common/util/file-type.spec.ts
+++ b/ayunis-core-backend/src/common/util/file-type.spec.ts
@@ -123,9 +123,33 @@ describe('detectFileType', () => {
     });
   });
 
+  describe('TXT detection', () => {
+    it('returns "txt" when MIME type is text/plain and extension is .txt', () => {
+      expect(detectFileType(MIME_TYPES.TXT, 'notes.txt')).toBe('txt');
+    });
+
+    it('returns "txt" when extension is .txt but MIME type is application/octet-stream', () => {
+      expect(detectFileType('application/octet-stream', 'notes.txt')).toBe(
+        'txt',
+      );
+    });
+
+    it('returns "unknown" when MIME type is text/plain but extension is not .txt', () => {
+      expect(detectFileType(MIME_TYPES.TXT, 'notes.log')).toBe('unknown');
+    });
+
+    it('returns "txt" when extension is .TXT (case insensitive)', () => {
+      expect(detectFileType('application/octet-stream', 'NOTES.TXT')).toBe(
+        'txt',
+      );
+    });
+  });
+
   describe('Unknown handling', () => {
     it('returns "unknown" for unsupported MIME types and extensions', () => {
-      expect(detectFileType('text/plain', 'file.txt')).toBe('unknown');
+      expect(detectFileType('application/x-something', 'file.bin')).toBe(
+        'unknown',
+      );
     });
 
     it('returns "unknown" for image files', () => {

--- a/ayunis-core-backend/src/common/util/file-type.ts
+++ b/ayunis-core-backend/src/common/util/file-type.ts
@@ -19,6 +19,9 @@ export const MIME_TYPES = {
 
   // CSV
   CSV: 'text/csv',
+
+  // Plain text
+  TXT: 'text/plain',
 } as const;
 
 /**
@@ -31,6 +34,7 @@ export const FILE_EXTENSIONS = {
   XLSX: '.xlsx',
   XLS: '.xls',
   CSV: '.csv',
+  TXT: '.txt',
 } as const;
 
 export type DetectedFileType =
@@ -40,6 +44,7 @@ export type DetectedFileType =
   | 'xlsx'
   | 'xls'
   | 'csv'
+  | 'txt'
   | 'unknown';
 
 /** Lookup: MIME type → detected file type */
@@ -50,6 +55,7 @@ const MIME_TO_FILE_TYPE: Record<string, DetectedFileType> = {
   [MIME_TYPES.XLSX]: 'xlsx',
   [MIME_TYPES.CSV]: 'csv',
   // Note: MIME_TYPES.XLS is intentionally excluded — XLS MIME can also indicate CSV files
+  // Note: MIME_TYPES.TXT is intentionally excluded — text/plain is too broad (matches .md, .log, .json, etc.)
 };
 
 /** Lookup: file extension → detected file type */
@@ -60,6 +66,7 @@ const EXT_TO_FILE_TYPE: Record<string, DetectedFileType> = {
   [FILE_EXTENSIONS.XLSX]: 'xlsx',
   [FILE_EXTENSIONS.XLS]: 'xls',
   [FILE_EXTENSIONS.CSV]: 'csv',
+  [FILE_EXTENSIONS.TXT]: 'txt',
 };
 
 /**
@@ -82,6 +89,13 @@ export function detectFileType(
 
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- lookup returns undefined for unknown keys at runtime
   return MIME_TO_FILE_TYPE[mimetype] ?? EXT_TO_FILE_TYPE[ext] ?? 'unknown';
+}
+
+/**
+ * Check if the file type is a plain text file (TXT)
+ */
+export function isPlainTextFile(fileType: DetectedFileType): boolean {
+  return fileType === 'txt';
 }
 
 /**
@@ -126,6 +140,8 @@ export function getCanonicalMimeType(
       return MIME_TYPES.XLS;
     case 'csv':
       return MIME_TYPES.CSV;
+    case 'txt':
+      return MIME_TYPES.TXT;
     case 'unknown':
       return null;
   }

--- a/ayunis-core-backend/src/domain/agents/presenters/http/agents.controller.ts
+++ b/ayunis-core-backend/src/domain/agents/presenters/http/agents.controller.ts
@@ -314,7 +314,7 @@ export class AgentsController {
   @ApiResponse({
     status: 400,
     description:
-      'Invalid or unsupported file type. Supported types: PDF, DOCX, PPTX, CSV, XLSX, XLS',
+      'Invalid or unsupported file type. Supported types: PDF, DOCX, PPTX, TXT, CSV, XLSX, XLS',
   })
   @ApiResponse({ status: 500, description: 'Internal server error' })
   @UseInterceptors(
@@ -370,6 +370,7 @@ export class AgentsController {
             'PDF',
             'DOCX',
             'PPTX',
+            'TXT',
             'CSV',
             'XLSX',
             'XLS',

--- a/ayunis-core-backend/src/domain/knowledge-bases/presenters/http/knowledge-bases.controller.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/presenters/http/knowledge-bases.controller.ts
@@ -38,6 +38,7 @@ import {
 import {
   detectFileType,
   isDocumentFile,
+  isPlainTextFile,
   getCanonicalMimeType,
 } from 'src/common/util/file-type';
 
@@ -282,7 +283,7 @@ export class KnowledgeBasesController {
         file: {
           type: 'string',
           format: 'binary',
-          description: 'The file to upload (PDF, DOCX, PPTX)',
+          description: 'The file to upload (PDF, DOCX, PPTX, TXT)',
         },
       },
       required: ['file'],
@@ -332,10 +333,10 @@ export class KnowledgeBasesController {
     });
 
     const detectedType = detectFileType(file.mimetype, file.originalname);
-    if (!isDocumentFile(detectedType)) {
+    if (!isDocumentFile(detectedType) && !isPlainTextFile(detectedType)) {
       await this.cleanupTempFile(file.path);
       throw new BadRequestException(
-        `Unsupported file type: ${file.originalname}. Knowledge bases only support PDF, DOCX, and PPTX files.`,
+        `Unsupported file type: ${file.originalname}. Knowledge bases only support PDF, DOCX, PPTX, and TXT files.`,
       );
     }
 

--- a/ayunis-core-backend/src/domain/retrievers/file-retrievers/application/use-cases/retrieve-file-content/retrieve-file-content.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/retrievers/file-retrievers/application/use-cases/retrieve-file-content/retrieve-file-content.use-case.spec.ts
@@ -57,6 +57,45 @@ describe('ProcessFileUseCase', () => {
     expect(useCase).toBeDefined();
   });
 
+  it('should return UTF-8 text content directly for TXT files', async () => {
+    const textContent = 'Hello, this is plain text content.\nLine two.';
+    const command = new RetrieveFileContentCommand({
+      fileData: Buffer.from(textContent, 'utf8'),
+      fileName: 'notes.txt',
+      fileType: 'text/plain',
+    });
+
+    const result = await useCase.execute(command);
+
+    expect(result).toBeInstanceOf(FileRetrieverResult);
+    expect(result.pages).toHaveLength(1);
+    expect(result.pages[0]).toBeInstanceOf(FileRetrieverPage);
+    expect(result.pages[0].text).toBe(textContent);
+    expect(result.pages[0].number).toBe(1);
+    expect(mockHandler.processFile).not.toHaveBeenCalled();
+  });
+
+  it('should strip UTF-8 BOM from TXT files', async () => {
+    const textContent = 'Hello, BOM test content.';
+    const bomBuffer = Buffer.concat([
+      Buffer.from([0xef, 0xbb, 0xbf]),
+      Buffer.from(textContent, 'utf8'),
+    ]);
+    const command = new RetrieveFileContentCommand({
+      fileData: bomBuffer,
+      fileName: 'bom-file.txt',
+      fileType: 'text/plain',
+    });
+
+    const result = await useCase.execute(command);
+
+    expect(result).toBeInstanceOf(FileRetrieverResult);
+    expect(result.pages).toHaveLength(1);
+    expect(result.pages[0].text).toBe(textContent);
+    expect(result.pages[0].text).not.toMatch(/^\uFEFF/);
+    expect(mockHandler.processFile).not.toHaveBeenCalled();
+  });
+
   it('should process file successfully', async () => {
     const command = new RetrieveFileContentCommand({
       fileData: Buffer.from('test file content'),

--- a/ayunis-core-backend/src/domain/retrievers/file-retrievers/application/use-cases/retrieve-file-content/retrieve-file-content.use-case.ts
+++ b/ayunis-core-backend/src/domain/retrievers/file-retrievers/application/use-cases/retrieve-file-content/retrieve-file-content.use-case.ts
@@ -5,7 +5,10 @@ import {
   UnauthorizedException,
 } from '@nestjs/common';
 import { ConfigType } from '@nestjs/config';
-import { FileRetrieverResult } from '../../../domain/file-retriever-result.entity';
+import {
+  FileRetrieverPage,
+  FileRetrieverResult,
+} from '../../../domain/file-retriever-result.entity';
 import { RetrieveFileContentCommand } from './retrieve-file-content.command';
 import { FileRetrieverRegistry } from '../../file-retriever-handler.registry';
 import { File } from '../../../domain/file.entity';
@@ -58,6 +61,10 @@ export class RetrieveFileContentUseCase {
             FileRetrieverType.NPM_PDF_PARSE,
           );
         }
+      } else if (fileType === 'txt') {
+        // TXT: Read directly as UTF-8, no external service needed
+        const text = command.fileData.toString('utf8').replace(/^\uFEFF/, '');
+        return new FileRetrieverResult([new FileRetrieverPage(text, 1)]);
       } else if (fileType === 'docx' || fileType === 'pptx') {
         // DOCX/PPTX: Require Docling
         if (this.config.docling.serviceUrl) {

--- a/ayunis-core-backend/src/domain/skills/presenters/http/skill-sources.controller.ts
+++ b/ayunis-core-backend/src/domain/skills/presenters/http/skill-sources.controller.ts
@@ -58,6 +58,7 @@ import {
   detectFileType,
   getCanonicalMimeType,
   isDocumentFile,
+  isPlainTextFile,
   isSpreadsheetFile,
   isCSVFile,
 } from 'src/common/util/file-type';
@@ -239,7 +240,7 @@ export class SkillSourcesController {
     const sources: Source[] = [];
     const detectedType = detectFileType(file.mimetype, file.originalname);
 
-    if (isDocumentFile(detectedType)) {
+    if (isDocumentFile(detectedType) || isPlainTextFile(detectedType)) {
       const source = await this.createDocumentSource(file, detectedType);
       sources.push(source);
     } else if (isCSVFile(detectedType)) {
@@ -251,7 +252,7 @@ export class SkillSourcesController {
     } else {
       throw new UnsupportedFileTypeError(
         detectedType === 'unknown' ? file.originalname : detectedType,
-        ['PDF', 'DOCX', 'PPTX', 'CSV', 'XLSX', 'XLS'],
+        ['PDF', 'DOCX', 'PPTX', 'TXT', 'CSV', 'XLSX', 'XLS'],
       );
     }
 
@@ -270,7 +271,12 @@ export class SkillSourcesController {
     detectedType: DetectedFileType,
   ): Promise<Source> {
     const fileData = fs.readFileSync(file.path);
-    const canonicalMimeType = getCanonicalMimeType(detectedType)!;
+    const canonicalMimeType = getCanonicalMimeType(detectedType);
+    if (!canonicalMimeType) {
+      throw new Error(
+        `Unable to determine MIME type for detected file type: ${detectedType}`,
+      );
+    }
 
     return this.createTextSourceUseCase.execute(
       new CreateFileSourceCommand({

--- a/ayunis-core-backend/src/domain/sources/application/file-source-creator.ts
+++ b/ayunis-core-backend/src/domain/sources/application/file-source-creator.ts
@@ -7,6 +7,7 @@ import {
   detectFileType,
   getCanonicalMimeType,
   isDocumentFile,
+  isPlainTextFile,
   isSpreadsheetFile,
   isCSVFile,
 } from 'src/common/util/file-type';
@@ -26,7 +27,7 @@ export async function createSourcesFromFile(
 ): Promise<Source[]> {
   const detectedType = detectFileType(file.mimetype, file.originalname);
 
-  if (isDocumentFile(detectedType)) {
+  if (isDocumentFile(detectedType) || isPlainTextFile(detectedType)) {
     return [await createDocumentSource(file, detectedType, deps)];
   }
 

--- a/ayunis-core-backend/src/domain/sources/application/use-cases/create-text-source/create-text-source.use-case.ts
+++ b/ayunis-core-backend/src/domain/sources/application/use-cases/create-text-source/create-text-source.use-case.ts
@@ -132,11 +132,13 @@ export class CreateTextSourceUseCase {
         return FileType.DOCX;
       case MIME_TYPES.PPTX:
         return FileType.PPTX;
+      case MIME_TYPES.TXT:
+        return FileType.TXT;
       default:
         // This is a programming error - caller should validate/route file types before calling this use case
         throw new Error(
           `CreateTextSourceUseCase received unsupported file type: ${mimeType}. ` +
-            `This use case only handles PDF, DOCX, and PPTX. Spreadsheets should be routed to CreateDataSourceUseCase.`,
+            `This use case only handles PDF, DOCX, PPTX, and TXT. Spreadsheets should be routed to CreateDataSourceUseCase.`,
         );
     }
   }

--- a/ayunis-core-backend/src/domain/sources/domain/source-type.enum.ts
+++ b/ayunis-core-backend/src/domain/sources/domain/source-type.enum.ts
@@ -12,6 +12,7 @@ export enum FileType {
   PDF = 'pdf',
   DOCX = 'docx',
   PPTX = 'pptx',
+  TXT = 'txt',
 }
 
 export enum DataType {

--- a/ayunis-core-backend/src/domain/threads/presenters/http/threads.controller.ts
+++ b/ayunis-core-backend/src/domain/threads/presenters/http/threads.controller.ts
@@ -379,6 +379,7 @@ export class ThreadsController {
             'PDF',
             'DOCX',
             'PPTX',
+            'TXT',
             'CSV',
             'XLSX',
             'XLS',

--- a/ayunis-core-frontend/src/pages/knowledge-base/ui/KnowledgeBaseDocumentsCard.tsx
+++ b/ayunis-core-frontend/src/pages/knowledge-base/ui/KnowledgeBaseDocumentsCard.tsx
@@ -41,7 +41,7 @@ import {
   useRemoveDocument,
 } from '../api';
 
-const ACCEPTED_FILE_TYPES = '.pdf,.docx';
+const ACCEPTED_FILE_TYPES = '.pdf,.docx,.pptx,.txt';
 
 function isValidUrl(value: string): boolean {
   try {

--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
@@ -1461,6 +1461,7 @@ export const FileSourceResponseDtoFileType = {
   pdf: 'pdf',
   docx: 'docx',
   pptx: 'pptx',
+  txt: 'txt',
 } as const;
 
 export interface FileSourceResponseDto {
@@ -3428,7 +3429,7 @@ offset?: number;
 };
 
 export type KnowledgeBasesControllerAddDocumentBody = {
-  /** The file to upload (PDF, DOCX, PPTX) */
+  /** The file to upload (PDF, DOCX, PPTX, TXT) */
   file: Blob;
 };
 

--- a/ayunis-core-frontend/src/shared/api/openapi-schema.json
+++ b/ayunis-core-frontend/src/shared/api/openapi-schema.json
@@ -3467,7 +3467,7 @@
             "description": "The file source has been successfully added to the agent"
           },
           "400": {
-            "description": "Invalid or unsupported file type. Supported types: PDF, DOCX, PPTX, CSV, XLSX, XLS"
+            "description": "Invalid or unsupported file type. Supported types: PDF, DOCX, PPTX, TXT, CSV, XLSX, XLS"
           },
           "404": {
             "description": "Agent not found"
@@ -5018,7 +5018,7 @@
                   "file": {
                     "type": "string",
                     "format": "binary",
-                    "description": "The file to upload (PDF, DOCX, PPTX)"
+                    "description": "The file to upload (PDF, DOCX, PPTX, TXT)"
                   }
                 },
                 "required": [
@@ -10211,7 +10211,8 @@
             "enum": [
               "pdf",
               "docx",
-              "pptx"
+              "pptx",
+              "txt"
             ]
           }
         },

--- a/ayunis-core-frontend/src/widgets/chat-input/ui/ChatInput.tsx
+++ b/ayunis-core-frontend/src/widgets/chat-input/ui/ChatInput.tsx
@@ -157,6 +157,7 @@ const ChatInput = forwardRef<ChatInputRef, ChatInputProps>(
         '.xls',
         '.docx',
         '.pptx',
+        '.txt',
       ],
     });
 

--- a/ayunis-core-frontend/src/widgets/chat-input/ui/PlusButton.tsx
+++ b/ayunis-core-frontend/src/widgets/chat-input/ui/PlusButton.tsx
@@ -254,7 +254,7 @@ export default function PlusButton({
       <Input
         type="file"
         hidden
-        accept=".pdf,.csv,.xlsx,.xls,.docx,.pptx"
+        accept=".pdf,.csv,.xlsx,.xls,.docx,.pptx,.txt"
         onChange={(e) => handleDocumentChange(e.target.files)}
         ref={documentInputRef}
       />

--- a/ayunis-core-frontend/src/widgets/knowledge-base-card/ui/KnowledgeBaseCard.tsx
+++ b/ayunis-core-frontend/src/widgets/knowledge-base-card/ui/KnowledgeBaseCard.tsx
@@ -118,7 +118,7 @@ export default function KnowledgeBaseCard({
                 type="file"
                 className="hidden"
                 onChange={handleFileChange}
-                accept=".pdf,.docx,.pptx,.csv,.xlsx,.xls"
+                accept=".pdf,.docx,.pptx,.txt,.csv,.xlsx,.xls"
               />
               <TooltipIf
                 condition={!isEnabled}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Expands supported upload types and introduces a new TXT processing path (direct UTF-8 decode), which could affect file validation/encoding handling across multiple upload endpoints.
> 
> **Overview**
> Adds **plain-text (`.txt`) support** end-to-end: file type detection now recognizes `TXT` by extension (and maps canonical MIME to `text/plain`), with a new `isPlainTextFile` helper and updated tests.
> 
> Updates upload/validation flows for agents, threads, skills, and knowledge bases to accept TXT alongside existing document types, and updates OpenAPI/generated frontend schemas and UI `accept` lists accordingly. `RetrieveFileContentUseCase` now short-circuits TXT files by decoding UTF-8 content (stripping a BOM) instead of sending them through external retriever handlers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a85fdaf2a48d84cbc643adcb95660ebb57b12675. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->