### PR TITLE
feat(AYC-99): make knowledge bases shareable

### DIFF
--- a/ayunis-core-backend/src/domain/knowledge-bases/application/listeners/share-deleted.listener.spec.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/application/listeners/share-deleted.listener.spec.ts
@@ -33,11 +33,7 @@ function createSkillShare(skillId: UUID, ownerId: UUID, orgId: UUID) {
   });
 }
 
-function createTeamSkillShare(
-  skillId: UUID,
-  ownerId: UUID,
-  teamId: UUID,
-) {
+function createTeamSkillShare(skillId: UUID, ownerId: UUID, teamId: UUID) {
   return new SkillShare({
     skillId,
     ownerId,
@@ -235,6 +231,7 @@ describe('KnowledgeBaseShareDeletedListener', () => {
 
     const kbCall = removeKbAssignments.execute.mock.calls[0][0];
     expect(kbCall.skillId).toBe(skillId);
+    expect(kbCall.knowledgeBaseId).toBe(kbId);
     // Should include skill owner + share recipients (minus owner)
     expect(kbCall.userIds).toContain(lostUserId); // skill owner
     expect(kbCall.userIds).toContain(skillShareRecipient);
@@ -362,6 +359,7 @@ describe('KnowledgeBaseShareDeletedListener', () => {
 
     const kbCall = removeKbAssignments.execute.mock.calls[0][0];
     expect(kbCall.skillId).toBe(skillId);
+    expect(kbCall.knowledgeBaseId).toBe(kbId);
     expect(kbCall.userIds).toContain(lostUserId);
     expect(kbCall.userIds).toContain(teamMember);
   });

--- a/ayunis-core-backend/src/domain/knowledge-bases/application/listeners/share-deleted.listener.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/application/listeners/share-deleted.listener.ts
@@ -74,11 +74,12 @@ export class KnowledgeBaseShareDeletedListener {
     // For each affected skill that is itself shared, clean up thread KB
     // assignments that originated from that skill (for ALL users, since the
     // KB is no longer accessible through the skill)
-    await this.cascadeToSharedSkillThreads(affectedSkills);
+    await this.cascadeToSharedSkillThreads(affectedSkills, event.entityId);
   }
 
   private async cascadeToSharedSkillThreads(
     affectedSkills: Skill[],
+    knowledgeBaseId: UUID,
   ): Promise<void> {
     for (const skill of affectedSkills) {
       const skillShares = await this.sharesRepository.findByEntityIdAndType(
@@ -103,6 +104,7 @@ export class KnowledgeBaseShareDeletedListener {
         new RemoveKnowledgeBaseAssignmentsByOriginSkillCommand(
           skill.id,
           allUserIds,
+          knowledgeBaseId,
         ),
       );
 

--- a/ayunis-core-backend/src/domain/threads/application/ports/threads.repository.ts
+++ b/ayunis-core-backend/src/domain/threads/application/ports/threads.repository.ts
@@ -79,6 +79,7 @@ export abstract class ThreadsRepository {
   abstract removeKnowledgeBaseAssignmentsByOriginSkill(params: {
     originSkillId: UUID;
     userIds: UUID[];
+    knowledgeBaseId?: UUID;
   }): Promise<void>;
   abstract removeDirectKnowledgeBaseAssignments(params: {
     knowledgeBaseId: UUID;

--- a/ayunis-core-backend/src/domain/threads/application/use-cases/remove-knowledge-base-assignments-by-origin-skill/remove-knowledge-base-assignments-by-origin-skill.command.ts
+++ b/ayunis-core-backend/src/domain/threads/application/use-cases/remove-knowledge-base-assignments-by-origin-skill/remove-knowledge-base-assignments-by-origin-skill.command.ts
@@ -4,5 +4,6 @@ export class RemoveKnowledgeBaseAssignmentsByOriginSkillCommand {
   constructor(
     public readonly skillId: UUID,
     public readonly userIds: UUID[],
+    public readonly knowledgeBaseId?: UUID,
   ) {}
 }

--- a/ayunis-core-backend/src/domain/threads/application/use-cases/remove-knowledge-base-assignments-by-origin-skill/remove-knowledge-base-assignments-by-origin-skill.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/threads/application/use-cases/remove-knowledge-base-assignments-by-origin-skill/remove-knowledge-base-assignments-by-origin-skill.use-case.spec.ts
@@ -47,6 +47,28 @@ describe('RemoveKnowledgeBaseAssignmentsByOriginSkillUseCase', () => {
     ).toHaveBeenCalledWith({
       originSkillId: skillId,
       userIds,
+      knowledgeBaseId: undefined,
+    });
+  });
+
+  it('should pass knowledgeBaseId to repository when provided', async () => {
+    const skillId = randomUUID();
+    const userIds = [randomUUID()];
+    const knowledgeBaseId = randomUUID();
+    const command = new RemoveKnowledgeBaseAssignmentsByOriginSkillCommand(
+      skillId,
+      userIds,
+      knowledgeBaseId,
+    );
+
+    await useCase.execute(command);
+
+    expect(
+      threadsRepository.removeKnowledgeBaseAssignmentsByOriginSkill,
+    ).toHaveBeenCalledWith({
+      originSkillId: skillId,
+      userIds,
+      knowledgeBaseId,
     });
   });
 

--- a/ayunis-core-backend/src/domain/threads/application/use-cases/remove-knowledge-base-assignments-by-origin-skill/remove-knowledge-base-assignments-by-origin-skill.use-case.ts
+++ b/ayunis-core-backend/src/domain/threads/application/use-cases/remove-knowledge-base-assignments-by-origin-skill/remove-knowledge-base-assignments-by-origin-skill.use-case.ts
@@ -16,6 +16,7 @@ export class RemoveKnowledgeBaseAssignmentsByOriginSkillUseCase {
     this.logger.log('execute', {
       skillId: command.skillId,
       userCount: command.userIds.length,
+      knowledgeBaseId: command.knowledgeBaseId,
     });
 
     if (command.userIds.length === 0) {
@@ -25,6 +26,7 @@ export class RemoveKnowledgeBaseAssignmentsByOriginSkillUseCase {
     await this.threadsRepository.removeKnowledgeBaseAssignmentsByOriginSkill({
       originSkillId: command.skillId,
       userIds: command.userIds,
+      knowledgeBaseId: command.knowledgeBaseId,
     });
   }
 }

--- a/ayunis-core-backend/src/domain/threads/infrastructure/persistence/local/local-threads.repository.ts
+++ b/ayunis-core-backend/src/domain/threads/infrastructure/persistence/local/local-threads.repository.ts
@@ -453,33 +453,44 @@ export class LocalThreadsRepository extends ThreadsRepository {
   async removeKnowledgeBaseAssignmentsByOriginSkill(params: {
     originSkillId: UUID;
     userIds: UUID[];
+    knowledgeBaseId?: UUID;
   }): Promise<void> {
     this.logger.log('removeKnowledgeBaseAssignmentsByOriginSkill', {
       originSkillId: params.originSkillId,
       userCount: params.userIds.length,
+      knowledgeBaseId: params.knowledgeBaseId,
     });
 
     if (params.userIds.length === 0) {
       return;
     }
 
+    const subQuery = this.threadKbAssignmentRepository
+      .createQueryBuilder('tkba')
+      .select('tkba.id')
+      .innerJoin('tkba.thread', 'thread')
+      .where('tkba.originSkillId = :originSkillId')
+      .andWhere('thread.userId IN (:...userIds)');
+
+    if (params.knowledgeBaseId) {
+      subQuery.andWhere('tkba.knowledgeBaseId = :knowledgeBaseId');
+    }
+
+    const queryParams: Record<string, unknown> = {
+      originSkillId: params.originSkillId,
+      userIds: params.userIds,
+    };
+
+    if (params.knowledgeBaseId) {
+      queryParams.knowledgeBaseId = params.knowledgeBaseId;
+    }
+
     await this.threadKbAssignmentRepository
       .createQueryBuilder('tkba')
       .delete()
       .from(ThreadKnowledgeBaseAssignmentRecord)
-      .where(
-        `id IN (${this.threadKbAssignmentRepository
-          .createQueryBuilder('tkba')
-          .select('tkba.id')
-          .innerJoin('tkba.thread', 'thread')
-          .where('tkba.originSkillId = :originSkillId')
-          .andWhere('thread.userId IN (:...userIds)')
-          .getQuery()})`,
-      )
-      .setParameters({
-        originSkillId: params.originSkillId,
-        userIds: params.userIds,
-      })
+      .where(`id IN (${subQuery.getQuery()})`)
+      .setParameters(queryParams)
       .execute();
   }
 

--- a/ayunis-core-frontend/src/pages/knowledge-bases/ui/KnowledgeBasesPage.tsx
+++ b/ayunis-core-frontend/src/pages/knowledge-bases/ui/KnowledgeBasesPage.tsx
@@ -8,6 +8,13 @@ import FullScreenMessageLayout from '@/layouts/full-screen-message-layout/ui/Ful
 import type { KnowledgeBase } from '../model/openapi';
 import { useTranslation } from 'react-i18next';
 import { HelpLink } from '@/shared/ui/help-link/HelpLink';
+import {
+  Tabs,
+  TabsList,
+  TabsTrigger,
+  TabsContent,
+} from '@/shared/ui/shadcn/tabs';
+import { EmptyState } from '@/widgets/empty-state';
 
 interface KnowledgeBasesPageProps {
   knowledgeBases: KnowledgeBase[];
@@ -17,6 +24,14 @@ export default function KnowledgeBasesPage({
   knowledgeBases,
 }: Readonly<KnowledgeBasesPageProps>) {
   const { t } = useTranslation('knowledge-bases');
+
+  const personalKnowledgeBases = knowledgeBases
+    .filter((kb) => !kb.isShared)
+    .sort((a, b) => a.name.localeCompare(b.name));
+
+  const sharedKnowledgeBases = knowledgeBases
+    .filter((kb) => kb.isShared)
+    .sort((a, b) => a.name.localeCompare(b.name));
 
   const headerAction = (
     <div className="flex gap-2">
@@ -39,10 +54,6 @@ export default function KnowledgeBasesPage({
     );
   }
 
-  const sortedKnowledgeBases = [...knowledgeBases].sort((a, b) =>
-    a.name.localeCompare(b.name),
-  );
-
   return (
     <AppLayout>
       <ContentAreaLayout
@@ -50,11 +61,46 @@ export default function KnowledgeBasesPage({
           <ContentAreaHeader title={t('page.title')} action={headerAction} />
         }
         contentArea={
-          <div className="space-y-3">
-            {sortedKnowledgeBases.map((kb) => (
-              <KnowledgeBaseCard key={kb.id} knowledgeBase={kb} />
-            ))}
-          </div>
+          <Tabs defaultValue="personal" className="w-full">
+            <TabsList>
+              <TabsTrigger value="personal">{t('tabs.personal')}</TabsTrigger>
+              <TabsTrigger value="shared">{t('tabs.shared')}</TabsTrigger>
+            </TabsList>
+            <TabsContent value="personal" className="mt-4">
+              {personalKnowledgeBases.length === 0 ? (
+                <EmptyState
+                  title={t('emptyState.personal.title')}
+                  description={t('emptyState.personal.description')}
+                  action={
+                    <CreateKnowledgeBaseDialog
+                      buttonText={t('createDialog.buttonTextFirst')}
+                      showIcon={true}
+                    />
+                  }
+                />
+              ) : (
+                <div className="space-y-3">
+                  {personalKnowledgeBases.map((kb) => (
+                    <KnowledgeBaseCard key={kb.id} knowledgeBase={kb} />
+                  ))}
+                </div>
+              )}
+            </TabsContent>
+            <TabsContent value="shared" className="mt-4">
+              {sharedKnowledgeBases.length === 0 ? (
+                <EmptyState
+                  title={t('emptyState.shared.title')}
+                  description={t('emptyState.shared.description')}
+                />
+              ) : (
+                <div className="space-y-3">
+                  {sharedKnowledgeBases.map((kb) => (
+                    <KnowledgeBaseCard key={kb.id} knowledgeBase={kb} />
+                  ))}
+                </div>
+              )}
+            </TabsContent>
+          </Tabs>
         }
       />
     </AppLayout>

--- a/ayunis-core-frontend/src/pages/skill/ui/SkillKnowledgeBasesCard.tsx
+++ b/ayunis-core-frontend/src/pages/skill/ui/SkillKnowledgeBasesCard.tsx
@@ -20,6 +20,7 @@ import {
   ItemTitle,
 } from '@/shared/ui/shadcn/item';
 import { Button } from '@/shared/ui/shadcn/button';
+import { Badge } from '@/shared/ui/shadcn/badge';
 import { cn } from '@/shared/lib/shadcn/utils';
 import {
   useSkillKnowledgeBasesQueries,
@@ -138,7 +139,14 @@ export default function SkillKnowledgeBasesCard({
                   )}
                 >
                   <ItemContent>
-                    <ItemTitle>{knowledgeBase.name}</ItemTitle>
+                    <ItemTitle>
+                      {knowledgeBase.name}
+                      {knowledgeBase.isShared && (
+                        <Badge variant="secondary" className="ml-2 text-xs">
+                          {t('knowledgeBases.sharedBadge')}
+                        </Badge>
+                      )}
+                    </ItemTitle>
                     {knowledgeBase.description && (
                       <ItemDescription>
                         {knowledgeBase.description}

--- a/ayunis-core-frontend/src/shared/locales/de/common.json
+++ b/ayunis-core-frontend/src/shared/locales/de/common.json
@@ -65,6 +65,7 @@
     "knowledgeBasesLoadError": "Fehler beim Laden der Wissenssammlungen",
     "knowledgeBasesEmptyState": "Noch keine Wissenssammlung erstellt",
     "knowledgeBasesAllAttached": "Alle Wissenssammlungen bereits angehängt",
+    "shared": "Freigegeben",
     "createKnowledgeBase": "Wissenssammlung erstellen",
     "noEmbeddingModelEnabled": "Um Dokumente hochzuladen, muss ein Embedding-Modell aktiviert sein.",
     "modelChangeDisabledTooltip": "Das Modell kann nicht geändert werden, wenn ein Agent ausgewählt ist.",

--- a/ayunis-core-frontend/src/shared/locales/de/knowledge-bases.json
+++ b/ayunis-core-frontend/src/shared/locales/de/knowledge-bases.json
@@ -7,7 +7,9 @@
   },
   "tabs": {
     "configuration": "Konfiguration",
-    "shares": "Freigaben"
+    "shares": "Freigaben",
+    "personal": "Eigene Wissenssammlungen",
+    "shared": "Geteilte Wissenssammlungen"
   },
   "shares": {
     "org": {
@@ -56,7 +58,15 @@
   },
   "emptyState": {
     "title": "Noch keine Wissenssammlungen",
-    "description": "Erstellen Sie Ihre erste Wissenssammlung. Laden Sie Dokumente hoch und nutzen Sie sie in Ihren Chats als Kontext für die KI."
+    "description": "Erstellen Sie Ihre erste Wissenssammlung. Laden Sie Dokumente hoch und nutzen Sie sie in Ihren Chats als Kontext für die KI.",
+    "personal": {
+      "title": "Noch keine eigenen Wissenssammlungen",
+      "description": "Erstellen Sie Ihre erste Wissenssammlung. Laden Sie Dokumente hoch und verwenden Sie sie als Kontext für die KI in Ihren Chats."
+    },
+    "shared": {
+      "title": "Noch keine geteilten Wissenssammlungen",
+      "description": "Wissenssammlungen, die von anderen Mitgliedern Ihrer Organisation mit Ihnen geteilt werden, erscheinen hier."
+    }
   },
   "card": {
     "confirmDelete": {

--- a/ayunis-core-frontend/src/shared/locales/de/skill.json
+++ b/ayunis-core-frontend/src/shared/locales/de/skill.json
@@ -88,6 +88,7 @@
     "title": "Wissenssammlungen",
     "description": "Gemeinsame Wissenssammlungen mit dieser Fähigkeit verbinden",
     "toggleAriaLabel": "{{name}} Wissenssammlung umschalten",
+    "sharedBadge": "Freigegeben",
     "retryButton": "Erneut versuchen",
     "success": {
       "assigned": "Wissenssammlung verbunden",

--- a/ayunis-core-frontend/src/shared/locales/en/common.json
+++ b/ayunis-core-frontend/src/shared/locales/en/common.json
@@ -65,6 +65,7 @@
     "knowledgeBasesLoadError": "Error loading knowledge bases",
     "knowledgeBasesEmptyState": "No knowledge bases created yet",
     "knowledgeBasesAllAttached": "All knowledge bases already attached",
+    "shared": "Shared",
     "createKnowledgeBase": "Create knowledge base",
     "noEmbeddingModelEnabled": "To upload documents, an embedding model must be enabled.",
     "modelChangeDisabledTooltip": "The model cannot be changed when an agent is selected.",

--- a/ayunis-core-frontend/src/shared/locales/en/knowledge-bases.json
+++ b/ayunis-core-frontend/src/shared/locales/en/knowledge-bases.json
@@ -7,7 +7,9 @@
   },
   "tabs": {
     "configuration": "Configuration",
-    "shares": "Share"
+    "shares": "Share",
+    "personal": "Own Knowledge Bases",
+    "shared": "Shared Knowledge Bases"
   },
   "shares": {
     "org": {
@@ -56,7 +58,15 @@
   },
   "emptyState": {
     "title": "No knowledge bases yet",
-    "description": "Create your first knowledge base. Upload documents and use them in your chats as context for the AI."
+    "description": "Create your first knowledge base. Upload documents and use them in your chats as context for the AI.",
+    "personal": {
+      "title": "No own knowledge bases yet",
+      "description": "Create your first knowledge base. Upload documents and use them in your chats as context for the AI."
+    },
+    "shared": {
+      "title": "No shared knowledge bases yet",
+      "description": "Knowledge bases shared with you by other members of your organization will appear here."
+    }
   },
   "card": {
     "confirmDelete": {

--- a/ayunis-core-frontend/src/shared/locales/en/skill.json
+++ b/ayunis-core-frontend/src/shared/locales/en/skill.json
@@ -88,6 +88,7 @@
     "title": "Knowledge Bases",
     "description": "Connect shared knowledge bases to this skill",
     "toggleAriaLabel": "Toggle {{name}} knowledge base",
+    "sharedBadge": "Shared",
     "retryButton": "Retry",
     "success": {
       "assigned": "Knowledge base connected",

--- a/ayunis-core-frontend/src/widgets/chat-input/ui/PlusButton.tsx
+++ b/ayunis-core-frontend/src/widgets/chat-input/ui/PlusButton.tsx
@@ -14,6 +14,7 @@ import {
   TooltipTrigger,
   TooltipContent,
 } from '@/shared/ui/shadcn/tooltip';
+import { Badge } from '@/shared/ui/shadcn/badge';
 import { BookOpen, Brain, FileText, Image, Loader2, Plus } from 'lucide-react';
 import { Input } from '@/shared/ui/shadcn/input';
 import { useRef } from 'react';
@@ -237,6 +238,11 @@ export default function PlusButton({
                           }
                         >
                           {kb.name}
+                          {kb.isShared && (
+                            <Badge variant="secondary" className="ml-2 text-xs">
+                              {t('chatInput.shared')}
+                            </Badge>
+                          )}
                         </DropdownMenuItem>
                       ))
                     : null}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches thread-assignment deletion logic and underlying DB query construction; a mistake could delete the wrong assignments or leave stale ones after share revocation.
> 
> **Overview**
> **Backend:** When a knowledge base share is deleted, the cascade cleanup now passes the specific `knowledgeBaseId` into `RemoveKnowledgeBaseAssignmentsByOriginSkill`, and the threads repository can optionally filter deletions by that KB (instead of removing all KB assignments for the origin skill). Specs were updated to assert the KB id is propagated.
> 
> **Frontend:** The Knowledge Bases page is split into *Personal* vs *Shared* tabs with dedicated empty states, and shared knowledge bases are now labeled with a "Shared" badge in the skill KB list and the chat input KB dropdown (with updated EN/DE translations).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9a6caccac5ad7ebebd63eabfc6889ae041e3e403. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->