### PR TITLE
fix(AYC-000): relax skill name validation and surface errors as 400

### DIFF
--- a/ayunis-core-backend/src/domain/skill-templates/domain/skill-template.entity.spec.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/domain/skill-template.entity.spec.ts
@@ -63,7 +63,9 @@ describe('SkillTemplate', () => {
         distributionMode: DistributionMode.PRE_CREATED_COPY,
       });
 
-      expect(template.distributionMode).toBe(DistributionMode.PRE_CREATED_COPY);
+      expect(template.distributionMode).toBe(
+        DistributionMode.PRE_CREATED_COPY,
+      );
     });
   });
 
@@ -89,6 +91,32 @@ describe('SkillTemplate', () => {
       expect(template.name).toBe('A');
     });
 
+    it('should accept names with special characters like &, ?, /', () => {
+      expect(
+        new SkillTemplate({ ...validParams, name: 'Q&A Helper' }).name,
+      ).toBe('Q&A Helper');
+      expect(
+        new SkillTemplate({ ...validParams, name: "What's New?" }).name,
+      ).toBe("What's New?");
+      expect(
+        new SkillTemplate({ ...validParams, name: 'Legal/Tax' }).name,
+      ).toBe('Legal/Tax');
+    });
+
+    it('should accept names with underscores', () => {
+      const template = new SkillTemplate({
+        ...validParams,
+        name: 'my_template',
+      });
+      expect(template.name).toBe('my_template');
+    });
+
+    it('should accept names longer than 100 characters (max enforced at DTO layer)', () => {
+      const name = 'A'.repeat(150);
+      const template = new SkillTemplate({ ...validParams, name });
+      expect(template.name).toBe(name);
+    });
+
     it('should reject names with consecutive spaces', () => {
       expect(
         () => new SkillTemplate({ ...validParams, name: 'Bad  Name' }),
@@ -97,6 +125,12 @@ describe('SkillTemplate', () => {
 
     it('should reject empty names', () => {
       expect(() => new SkillTemplate({ ...validParams, name: '' })).toThrow(
+        InvalidSkillTemplateNameError,
+      );
+    });
+
+    it('should reject whitespace-only names', () => {
+      expect(() => new SkillTemplate({ ...validParams, name: '   ' })).toThrow(
         InvalidSkillTemplateNameError,
       );
     });
@@ -111,6 +145,20 @@ describe('SkillTemplate', () => {
       expect(
         () => new SkillTemplate({ ...validParams, name: 'Trailing ' }),
       ).toThrow(InvalidSkillTemplateNameError);
+    });
+
+    it('should reject names with control characters', () => {
+      expect(
+        () => new SkillTemplate({ ...validParams, name: 'Test\u0000Name' }),
+      ).toThrow(InvalidSkillTemplateNameError);
+    });
+
+    it('should accept names with ZWJ emoji sequences', () => {
+      const template = new SkillTemplate({
+        ...validParams,
+        name: '👩‍💻 Coding',
+      });
+      expect(template.name).toBe('👩‍💻 Coding');
     });
   });
 });

--- a/ayunis-core-backend/src/domain/skill-templates/domain/skill-template.entity.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/domain/skill-template.entity.ts
@@ -3,21 +3,19 @@ import { randomUUID } from 'crypto';
 import type { DistributionMode } from './distribution-mode.enum';
 
 /**
- * Valid skill template names: Unicode letters, numbers, emojis, hyphens,
- * parentheses, and spaces. Must start and end with a letter, number, emoji,
- * or closing parenthesis. No consecutive spaces. Min length 1.
- *
- * Reuses the same pattern as Skill entity.
+ * Valid skill template names: any printable characters (no control characters).
+ * Must not be empty, must not start or end with whitespace, must not
+ * contain consecutive spaces. Max length is enforced at the DTO layer.
  */
-const SKILL_TEMPLATE_NAME_PATTERN =
-  /^[\p{L}\p{N}\p{Emoji_Presentation}]([\p{L}\p{N}\p{Emoji_Presentation} ()-]*[\p{L}\p{N}\p{Emoji_Presentation})])?$/u;
 const CONSECUTIVE_SPACES = / {2}/;
+const CONTROL_CHARS = /\p{Cc}/u;
 
 export class InvalidSkillTemplateNameError extends Error {
   constructor(name: string) {
     super(
-      `Invalid skill template name "${name}". Names must contain only letters, numbers, emojis, hyphens, parentheses, and spaces, ` +
-        `must start and end with a letter, number, emoji, or closing parenthesis, and must not contain consecutive spaces.`,
+      `Invalid skill template name "${name}". Names must not be empty, ` +
+        `must not start or end with whitespace, must not contain consecutive spaces, ` +
+        `and must not contain control characters.`,
     );
     this.name = 'InvalidSkillTemplateNameError';
   }
@@ -25,8 +23,10 @@ export class InvalidSkillTemplateNameError extends Error {
 
 function validateSkillTemplateName(name: string): void {
   if (
-    !SKILL_TEMPLATE_NAME_PATTERN.test(name) ||
-    CONSECUTIVE_SPACES.test(name)
+    name.length === 0 ||
+    name !== name.trim() ||
+    CONSECUTIVE_SPACES.test(name) ||
+    CONTROL_CHARS.test(name)
   ) {
     throw new InvalidSkillTemplateNameError(name);
   }

--- a/ayunis-core-backend/src/domain/skill-templates/presenters/http/dto/create-skill-template.dto.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/presenters/http/dto/create-skill-template.dto.ts
@@ -14,23 +14,22 @@ import { DistributionMode } from '../../../domain/distribution-mode.enum';
 export class CreateSkillTemplateDto {
   @ApiProperty({
     description:
-      'The name of the skill template. Only letters, numbers, emojis, hyphens, parentheses, and spaces allowed. Must start and end with a letter, number, emoji, or closing parenthesis.',
+      'The name of the skill template. No leading/trailing whitespace, no consecutive spaces, no control characters. Max 100 characters.',
     example: 'Legal Guidelines',
     minLength: 1,
-    maxLength: 255,
+    maxLength: 100,
   })
   @IsString()
   @IsNotEmpty()
-  @Length(1, 255)
-  @Matches(
-    /^[\p{L}\p{N}\p{Emoji_Presentation}]([\p{L}\p{N}\p{Emoji_Presentation} ()-]*[\p{L}\p{N}\p{Emoji_Presentation})])?$/u,
-    {
-      message:
-        'Name must contain only letters, numbers, emojis, hyphens, parentheses, and spaces, and must start and end with a letter, number, emoji, or closing parenthesis',
-    },
-  )
+  @Length(1, 100)
+  @Matches(/^\S.*\S$|^\S$/, {
+    message: 'Name must not start or end with whitespace',
+  })
   @Matches(/^(?!.* {2})/, {
     message: 'Name must not contain consecutive spaces',
+  })
+  @Matches(/^[^\p{Cc}]*$/u, {
+    message: 'Name must not contain control characters',
   })
   name: string;
 

--- a/ayunis-core-backend/src/domain/skill-templates/presenters/http/dto/update-skill-template.dto.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/presenters/http/dto/update-skill-template.dto.ts
@@ -14,23 +14,22 @@ import { DistributionMode } from '../../../domain/distribution-mode.enum';
 export class UpdateSkillTemplateDto {
   @ApiPropertyOptional({
     description:
-      'The name of the skill template. Only letters, numbers, emojis, hyphens, parentheses, and spaces allowed. Must start and end with a letter, number, emoji, or closing parenthesis.',
+      'The name of the skill template. No leading/trailing whitespace, no consecutive spaces, no control characters. Max 100 characters.',
     example: 'Legal Guidelines',
     minLength: 1,
-    maxLength: 255,
+    maxLength: 100,
   })
   @IsString()
   @IsNotEmpty()
-  @Length(1, 255)
-  @Matches(
-    /^[\p{L}\p{N}\p{Emoji_Presentation}]([\p{L}\p{N}\p{Emoji_Presentation} ()-]*[\p{L}\p{N}\p{Emoji_Presentation})])?$/u,
-    {
-      message:
-        'Name must contain only letters, numbers, emojis, hyphens, parentheses, and spaces, and must start and end with a letter, number, emoji, or closing parenthesis',
-    },
-  )
+  @Length(1, 100)
+  @Matches(/^\S.*\S$|^\S$/, {
+    message: 'Name must not start or end with whitespace',
+  })
   @Matches(/^(?!.* {2})/, {
     message: 'Name must not contain consecutive spaces',
+  })
+  @Matches(/^[^\p{Cc}]*$/u, {
+    message: 'Name must not contain control characters',
   })
   @IsOptional()
   name?: string;

--- a/ayunis-core-backend/src/domain/skills/application/use-cases/create-skill-with-unique-name/create-skill-with-unique-name.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/skills/application/use-cases/create-skill-with-unique-name/create-skill-with-unique-name.use-case.spec.ts
@@ -103,6 +103,69 @@ describe('CreateSkillWithUniqueNameUseCase', () => {
     expect(result.name).toBe('Translator 4');
   });
 
+  it('should truncate base name when suffix would exceed 100-char limit', async () => {
+    const longName = 'A'.repeat(100);
+    skillRepository.findByNameAndOwner.mockImplementation((name: string) =>
+      Promise.resolve(
+        name === longName
+          ? new Skill({
+              name,
+              shortDescription: 'existing',
+              instructions: 'existing',
+              userId,
+            })
+          : null,
+      ),
+    );
+
+    const command = new CreateSkillWithUniqueNameCommand({
+      name: longName,
+      shortDescription: 'Test',
+      instructions: 'Test',
+      userId,
+    });
+
+    const result = await useCase.execute(command);
+
+    expect(result.name.length).toBeLessThanOrEqual(100);
+    expect(result.name).toMatch(/ 2$/);
+  });
+
+  it('should truncate base name to 100 characters even when no collision exists', async () => {
+    const longName = 'B'.repeat(120);
+
+    const command = new CreateSkillWithUniqueNameCommand({
+      name: longName,
+      shortDescription: 'Test',
+      instructions: 'Test',
+      userId,
+    });
+
+    const result = await useCase.execute(command);
+
+    expect(result.name.length).toBe(100);
+    expect(result.name).toBe('B'.repeat(100));
+  });
+
+  it('should truncate codepoint-safely when no collision exists', async () => {
+    // Each emoji is multiple UTF-16 code units but one codepoint
+    const emoji = '😀';
+    const longName = emoji.repeat(60); // 60 emoji × 2 UTF-16 chars = 120 chars
+
+    const command = new CreateSkillWithUniqueNameCommand({
+      name: longName,
+      shortDescription: 'Test',
+      instructions: 'Test',
+      userId,
+    });
+
+    const result = await useCase.execute(command);
+
+    expect(result.name.length).toBeLessThanOrEqual(100);
+    // Should not split an emoji in half
+    expect([...result.name].every((cp) => cp === emoji)).toBe(true);
+  });
+
   it('should throw when unique name cannot be resolved after max attempts', async () => {
     skillRepository.findByNameAndOwner.mockResolvedValue(
       new Skill({

--- a/ayunis-core-backend/src/domain/skills/application/use-cases/create-skill-with-unique-name/create-skill-with-unique-name.use-case.ts
+++ b/ayunis-core-backend/src/domain/skills/application/use-cases/create-skill-with-unique-name/create-skill-with-unique-name.use-case.ts
@@ -1,10 +1,15 @@
 import { Inject, Injectable, Logger } from '@nestjs/common';
 import { SkillRepository } from '../../ports/skill.repository';
 import { CreateSkillWithUniqueNameCommand } from './create-skill-with-unique-name.command';
-import { Skill } from '../../../domain/skill.entity';
-import { SkillNameResolutionError } from '../../skills.errors';
+import { Skill, InvalidSkillNameError } from '../../../domain/skill.entity';
+import {
+  SkillNameResolutionError,
+  UnexpectedSkillError,
+} from '../../skills.errors';
+import { ApplicationError } from 'src/common/errors/base.error';
 import type { UUID } from 'crypto';
 
+const MAX_NAME_LENGTH = 100;
 const MAX_NAME_RESOLUTION_ATTEMPTS = 100;
 
 @Injectable()
@@ -22,33 +27,53 @@ export class CreateSkillWithUniqueNameUseCase {
       userId: command.userId,
     });
 
-    const name = await this.resolveUniqueName(command.name, command.userId);
+    try {
+      const name = await this.resolveUniqueName(command.name, command.userId);
 
-    const skill = new Skill({
-      name,
-      shortDescription: command.shortDescription,
-      instructions: command.instructions,
-      marketplaceIdentifier: command.marketplaceIdentifier,
-      userId: command.userId,
-    });
+      const skill = new Skill({
+        name,
+        shortDescription: command.shortDescription,
+        instructions: command.instructions,
+        marketplaceIdentifier: command.marketplaceIdentifier,
+        userId: command.userId,
+      });
 
-    const created = await this.skillRepository.create(skill);
-    await this.skillRepository.activateSkill(created.id, command.userId);
+      const created = await this.skillRepository.create(skill);
+      await this.skillRepository.activateSkill(created.id, command.userId);
 
-    this.logger.debug('Skill created and activated', {
-      skillId: created.id,
-      name: created.name,
-      userId: command.userId,
-    });
+      this.logger.debug('Skill created and activated', {
+        skillId: created.id,
+        name: created.name,
+        userId: command.userId,
+      });
 
-    return created;
+      return created;
+    } catch (error) {
+      if (
+        error instanceof ApplicationError ||
+        error instanceof InvalidSkillNameError
+      )
+        throw error;
+      this.logger.error('Error creating skill with unique name', {
+        error: error as Error,
+      });
+      throw new UnexpectedSkillError(error);
+    }
   }
 
   private async resolveUniqueName(
     baseName: string,
     userId: UUID,
   ): Promise<string> {
-    let name = baseName;
+    const baseCodePoints = [...baseName];
+    let truncatedBase = '';
+    for (const cp of baseCodePoints) {
+      if (truncatedBase.length + cp.length > MAX_NAME_LENGTH) break;
+      truncatedBase += cp;
+    }
+    truncatedBase = truncatedBase.trimEnd();
+
+    let name = truncatedBase;
     let suffix = 2;
     while (await this.skillRepository.findByNameAndOwner(name, userId)) {
       if (suffix > MAX_NAME_RESOLUTION_ATTEMPTS) {
@@ -57,7 +82,16 @@ export class CreateSkillWithUniqueNameUseCase {
           MAX_NAME_RESOLUTION_ATTEMPTS,
         );
       }
-      name = `${baseName} ${suffix}`;
+      const suffixStr = ` ${suffix}`;
+      const codePoints = [...truncatedBase];
+      let truncated = '';
+      for (const cp of codePoints) {
+        if (truncated.length + cp.length + suffixStr.length > MAX_NAME_LENGTH)
+          break;
+        truncated += cp;
+      }
+      truncated = truncated.trimEnd();
+      name = `${truncated}${suffixStr}`;
       suffix++;
     }
     return name;

--- a/ayunis-core-backend/src/domain/skills/application/use-cases/create-skill/create-skill.use-case.ts
+++ b/ayunis-core-backend/src/domain/skills/application/use-cases/create-skill/create-skill.use-case.ts
@@ -9,6 +9,7 @@ import {
   UnexpectedSkillError,
 } from '../../skills.errors';
 import { ApplicationError } from 'src/common/errors/base.error';
+import { InvalidSkillNameError } from '../../../domain/skill.entity';
 
 @Injectable()
 export class CreateSkillUseCase {
@@ -51,7 +52,11 @@ export class CreateSkillUseCase {
 
       return created;
     } catch (error) {
-      if (error instanceof ApplicationError) throw error;
+      if (
+        error instanceof ApplicationError ||
+        error instanceof InvalidSkillNameError
+      )
+        throw error;
       this.logger.error('Error creating skill', { error: error as Error });
       throw new UnexpectedSkillError(error);
     }

--- a/ayunis-core-backend/src/domain/skills/application/use-cases/update-skill/update-skill.use-case.ts
+++ b/ayunis-core-backend/src/domain/skills/application/use-cases/update-skill/update-skill.use-case.ts
@@ -11,6 +11,7 @@ import {
   UnexpectedSkillError,
 } from '../../skills.errors';
 import { ApplicationError } from 'src/common/errors/base.error';
+import { InvalidSkillNameError } from '../../../domain/skill.entity';
 
 @Injectable()
 export class UpdateSkillUseCase {
@@ -64,7 +65,11 @@ export class UpdateSkillUseCase {
 
       return this.skillRepository.update(updatedSkill);
     } catch (error) {
-      if (error instanceof ApplicationError) throw error;
+      if (
+        error instanceof ApplicationError ||
+        error instanceof InvalidSkillNameError
+      )
+        throw error;
       this.logger.error('Error updating skill', { error: error as Error });
       throw new UnexpectedSkillError(error);
     }

--- a/ayunis-core-backend/src/domain/skills/domain/skill.entity.spec.ts
+++ b/ayunis-core-backend/src/domain/skills/domain/skill.entity.spec.ts
@@ -104,6 +104,29 @@ describe('Skill Entity', () => {
       expect(skill.name).toBe('My-Custom-Skill');
     });
 
+    it('should accept names with special characters like &, ?, /', () => {
+      expect(new Skill({ ...validParams, name: 'Q&A Helper' }).name).toBe(
+        'Q&A Helper',
+      );
+      expect(new Skill({ ...validParams, name: "What's New?" }).name).toBe(
+        "What's New?",
+      );
+      expect(new Skill({ ...validParams, name: 'Legal/Tax' }).name).toBe(
+        'Legal/Tax',
+      );
+    });
+
+    it('should accept names with underscores', () => {
+      const skill = new Skill({ ...validParams, name: 'my_skill' });
+      expect(skill.name).toBe('my_skill');
+    });
+
+    it('should accept names longer than 100 characters (max enforced at DTO layer)', () => {
+      const name = 'A'.repeat(150);
+      const skill = new Skill({ ...validParams, name });
+      expect(skill.name).toBe(name);
+    });
+
     it('should reject names with leading spaces', () => {
       expect(
         () => new Skill({ ...validParams, name: ' Legal Research' }),
@@ -116,30 +139,6 @@ describe('Skill Entity', () => {
       ).toThrow(InvalidSkillNameError);
     });
 
-    it('should reject names with leading hyphens', () => {
-      expect(() => new Skill({ ...validParams, name: '-Research' })).toThrow(
-        InvalidSkillNameError,
-      );
-    });
-
-    it('should reject names with trailing hyphens', () => {
-      expect(() => new Skill({ ...validParams, name: 'Research-' })).toThrow(
-        InvalidSkillNameError,
-      );
-    });
-
-    it('should reject names with special characters', () => {
-      expect(
-        () => new Skill({ ...validParams, name: 'Legal/Research' }),
-      ).toThrow(InvalidSkillNameError);
-    });
-
-    it('should reject names with underscores', () => {
-      expect(
-        () => new Skill({ ...validParams, name: 'Legal_Research' }),
-      ).toThrow(InvalidSkillNameError);
-    });
-
     it('should reject names with consecutive spaces', () => {
       expect(
         () => new Skill({ ...validParams, name: 'Legal  Research' }),
@@ -148,6 +147,12 @@ describe('Skill Entity', () => {
 
     it('should reject empty names', () => {
       expect(() => new Skill({ ...validParams, name: '' })).toThrow(
+        InvalidSkillNameError,
+      );
+    });
+
+    it('should reject whitespace-only names', () => {
+      expect(() => new Skill({ ...validParams, name: '   ' })).toThrow(
         InvalidSkillNameError,
       );
     });
@@ -172,18 +177,15 @@ describe('Skill Entity', () => {
       expect(skill.name).toBe('📚');
     });
 
-    it('should reject names with invisible emoji components', () => {
-      // ZWJ (U+200D) should not be allowed
+    it('should reject names with control characters', () => {
       expect(
-        () => new Skill({ ...validParams, name: 'Test\u200DSkill' }),
+        () => new Skill({ ...validParams, name: 'Test\u0000Skill' }),
       ).toThrow(InvalidSkillNameError);
     });
 
-    it('should reject names ending with variation selector', () => {
-      // Variation selector (U+FE0F) should not be allowed
-      expect(() => new Skill({ ...validParams, name: 'Test\uFE0F' })).toThrow(
-        InvalidSkillNameError,
-      );
+    it('should accept names with ZWJ emoji sequences', () => {
+      const skill = new Skill({ ...validParams, name: '👩‍💻 Coding' });
+      expect(skill.name).toBe('👩‍💻 Coding');
     });
   });
 });

--- a/ayunis-core-backend/src/domain/skills/domain/skill.entity.ts
+++ b/ayunis-core-backend/src/domain/skills/domain/skill.entity.ts
@@ -2,29 +2,31 @@ import type { UUID } from 'crypto';
 import { randomUUID } from 'crypto';
 
 /**
- * Valid skill names: Unicode letters, numbers, emojis, hyphens, parentheses,
- * and spaces. Must start and end with a letter, number, emoji, or closing
- * parenthesis. No consecutive spaces. Min length 1.
- *
- * Uses \p{Emoji_Presentation} for visible emojis only — excludes invisible
- * components like ZWJ (U+200D) and variation selectors (U+FE0E/FE0F).
+ * Valid skill names: any printable characters (no control characters).
+ * Must not be empty, must not start or end with whitespace, must not
+ * contain consecutive spaces. Max length is enforced at the DTO layer.
  */
-const SKILL_NAME_PATTERN =
-  /^[\p{L}\p{N}\p{Emoji_Presentation}]([\p{L}\p{N}\p{Emoji_Presentation} ()-]*[\p{L}\p{N}\p{Emoji_Presentation})])?$/u;
 const CONSECUTIVE_SPACES = / {2}/;
+const CONTROL_CHARS = /\p{Cc}/u;
 
 export class InvalidSkillNameError extends Error {
   constructor(name: string) {
     super(
-      `Invalid skill name "${name}". Names must contain only letters, numbers, emojis, hyphens, parentheses, and spaces, ` +
-        `must start and end with a letter, number, emoji, or closing parenthesis, and must not contain consecutive spaces.`,
+      `Invalid skill name "${name}". Names must not be empty, ` +
+        `must not start or end with whitespace, must not contain consecutive spaces, ` +
+        `and must not contain control characters.`,
     );
     this.name = 'InvalidSkillNameError';
   }
 }
 
 function validateSkillName(name: string): void {
-  if (!SKILL_NAME_PATTERN.test(name) || CONSECUTIVE_SPACES.test(name)) {
+  if (
+    name.length === 0 ||
+    name !== name.trim() ||
+    CONSECUTIVE_SPACES.test(name) ||
+    CONTROL_CHARS.test(name)
+  ) {
     throw new InvalidSkillNameError(name);
   }
 }

--- a/ayunis-core-backend/src/domain/skills/presenters/http/dto/base-skill.dto.ts
+++ b/ayunis-core-backend/src/domain/skills/presenters/http/dto/base-skill.dto.ts
@@ -4,23 +4,22 @@ import { IsString, IsNotEmpty, Length, Matches } from 'class-validator';
 export class BaseSkillDto {
   @ApiProperty({
     description:
-      'The name of the skill (must be unique per user). Only letters, numbers, emojis, hyphens, parentheses, and spaces allowed. Must start and end with a letter, number, emoji, or closing parenthesis.',
+      'The name of the skill (must be unique per user). No leading/trailing whitespace, no consecutive spaces, no control characters. Max 100 characters.',
     example: 'Legal Research',
     minLength: 1,
-    maxLength: 255,
+    maxLength: 100,
   })
   @IsString()
   @IsNotEmpty()
-  @Length(1, 255)
-  @Matches(
-    /^[\p{L}\p{N}\p{Emoji_Presentation}]([\p{L}\p{N}\p{Emoji_Presentation} ()-]*[\p{L}\p{N}\p{Emoji_Presentation})])?$/u,
-    {
-      message:
-        'Name must contain only letters, numbers, emojis, hyphens, parentheses, and spaces, and must start and end with a letter, number, emoji, or closing parenthesis',
-    },
-  )
+  @Length(1, 100)
+  @Matches(/^\S.*\S$|^\S$/, {
+    message: 'Name must not start or end with whitespace',
+  })
   @Matches(/^(?!.* {2})/, {
     message: 'Name must not contain consecutive spaces',
+  })
+  @Matches(/^[^\p{Cc}]*$/u, {
+    message: 'Name must not contain control characters',
   })
   name: string;
 

--- a/ayunis-core-backend/src/domain/skills/presenters/http/skills.controller.ts
+++ b/ayunis-core-backend/src/domain/skills/presenters/http/skills.controller.ts
@@ -1,4 +1,5 @@
 import {
+  BadRequestException,
   Controller,
   Post,
   Get,
@@ -54,6 +55,7 @@ import { UpdateSkillDto } from './dto/update-skill.dto';
 import { InstallSkillFromMarketplaceDto } from './dto/install-skill-from-marketplace.dto';
 import { SkillResponseDto } from './dto/skill-response.dto';
 import { SkillDtoMapper } from './mappers/skill.mapper';
+import { InvalidSkillNameError } from '../../domain/skill.entity';
 import { RequireFeature } from 'src/common/guards/feature.guard';
 import { FeatureFlag } from 'src/config/features.config';
 
@@ -130,20 +132,27 @@ export class SkillsController {
 
     this.logger.log('create', { userId, name: dto.name });
 
-    const skill = await this.createSkillUseCase.execute(
-      new CreateSkillCommand({
-        name: dto.name,
-        shortDescription: dto.shortDescription,
-        instructions: dto.instructions,
-        isActive,
-      }),
-    );
+    try {
+      const skill = await this.createSkillUseCase.execute(
+        new CreateSkillCommand({
+          name: dto.name,
+          shortDescription: dto.shortDescription,
+          instructions: dto.instructions,
+          isActive,
+        }),
+      );
 
-    return this.skillDtoMapper.toDto(skill, {
-      isActive,
-      isShared: false,
-      isPinned: false,
-    });
+      return this.skillDtoMapper.toDto(skill, {
+        isActive,
+        isShared: false,
+        isPinned: false,
+      });
+    } catch (error) {
+      if (error instanceof InvalidSkillNameError) {
+        throw new BadRequestException(error.message);
+      }
+      throw error;
+    }
   }
 
   @Get()
@@ -230,18 +239,25 @@ export class SkillsController {
   ): Promise<SkillResponseDto> {
     this.logger.log('update', { id, userId, name: dto.name });
 
-    const skill = await this.updateSkillUseCase.execute(
-      new UpdateSkillCommand({
-        skillId: id,
-        name: dto.name,
-        shortDescription: dto.shortDescription,
-        instructions: dto.instructions,
-      }),
-    );
+    try {
+      const skill = await this.updateSkillUseCase.execute(
+        new UpdateSkillCommand({
+          skillId: id,
+          name: dto.name,
+          shortDescription: dto.shortDescription,
+          instructions: dto.instructions,
+        }),
+      );
 
-    const context = await this.skillAccessService.resolveUserContext(id);
+      const context = await this.skillAccessService.resolveUserContext(id);
 
-    return this.skillDtoMapper.toDto(skill, context);
+      return this.skillDtoMapper.toDto(skill, context);
+    } catch (error) {
+      if (error instanceof InvalidSkillNameError) {
+        throw new BadRequestException(error.message);
+      }
+      throw error;
+    }
   }
 
   @Delete(':id')

--- a/ayunis-core-frontend/src/pages/skill/api/useUpdateSkill.ts
+++ b/ayunis-core-frontend/src/pages/skill/api/useUpdateSkill.ts
@@ -28,7 +28,7 @@ export function useUpdateSkill({ skill }: UseUpdateSkillProps) {
   const router = useRouter();
 
   const updateSkillSchema = z.object({
-    name: z.string().min(1, t('properties.validation.nameRequired')).max(255),
+    name: z.string().min(1, t('properties.validation.nameRequired')).max(100),
     shortDescription: z
       .string()
       .min(1, t('properties.validation.shortDescriptionRequired')),

--- a/ayunis-core-frontend/src/pages/skills/api/useCreateSkill.ts
+++ b/ayunis-core-frontend/src/pages/skills/api/useCreateSkill.ts
@@ -23,7 +23,7 @@ export function useCreateSkill() {
   const router = useRouter();
 
   const createSkillSchema = z.object({
-    name: z.string().min(1, t('createDialog.validation.nameRequired')),
+    name: z.string().min(1, t('createDialog.validation.nameRequired')).max(100),
     shortDescription: z
       .string()
       .min(1, t('createDialog.validation.shortDescriptionRequired')),

--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
@@ -2572,9 +2572,9 @@ export interface SkillResponseDto {
 
 export interface CreateSkillDto {
   /**
-   * The name of the skill (must be unique per user). Only letters, numbers, emojis, hyphens, parentheses, and spaces allowed. Must start and end with a letter, number, emoji, or closing parenthesis.
+   * The name of the skill (must be unique per user). No leading/trailing whitespace, no consecutive spaces, no control characters. Max 100 characters.
    * @minLength 1
-   * @maxLength 255
+   * @maxLength 100
    */
   name: string;
   /** A short description of the skill (shown in system prompt for LLM to decide activation) */
@@ -2587,9 +2587,9 @@ export interface CreateSkillDto {
 
 export interface UpdateSkillDto {
   /**
-   * The name of the skill (must be unique per user). Only letters, numbers, emojis, hyphens, parentheses, and spaces allowed. Must start and end with a letter, number, emoji, or closing parenthesis.
+   * The name of the skill (must be unique per user). No leading/trailing whitespace, no consecutive spaces, no control characters. Max 100 characters.
    * @minLength 1
-   * @maxLength 255
+   * @maxLength 100
    */
   name: string;
   /** A short description of the skill (shown in system prompt for LLM to decide activation) */
@@ -3054,9 +3054,9 @@ export const CreateSkillTemplateDtoDistributionMode = {
 
 export interface CreateSkillTemplateDto {
   /**
-   * The name of the skill template. Only letters, numbers, emojis, hyphens, parentheses, and spaces allowed. Must start and end with a letter, number, emoji, or closing parenthesis.
+   * The name of the skill template. No leading/trailing whitespace, no consecutive spaces, no control characters. Max 100 characters.
    * @minLength 1
-   * @maxLength 255
+   * @maxLength 100
    */
   name: string;
   /** A short description of the skill template */
@@ -3114,9 +3114,9 @@ export const UpdateSkillTemplateDtoDistributionMode = {
 
 export interface UpdateSkillTemplateDto {
   /**
-   * The name of the skill template. Only letters, numbers, emojis, hyphens, parentheses, and spaces allowed. Must start and end with a letter, number, emoji, or closing parenthesis.
+   * The name of the skill template. No leading/trailing whitespace, no consecutive spaces, no control characters. Max 100 characters.
    * @minLength 1
-   * @maxLength 255
+   * @maxLength 100
    */
   name?: string;
   /** A short description of the skill template */

--- a/ayunis-core-frontend/src/shared/api/openapi-schema.json
+++ b/ayunis-core-frontend/src/shared/api/openapi-schema.json
@@ -12133,10 +12133,10 @@
         "properties": {
           "name": {
             "type": "string",
-            "description": "The name of the skill (must be unique per user). Only letters, numbers, emojis, hyphens, parentheses, and spaces allowed. Must start and end with a letter, number, emoji, or closing parenthesis.",
+            "description": "The name of the skill (must be unique per user). No leading/trailing whitespace, no consecutive spaces, no control characters. Max 100 characters.",
             "example": "Legal Research",
             "minLength": 1,
-            "maxLength": 255
+            "maxLength": 100
           },
           "shortDescription": {
             "type": "string",
@@ -12165,10 +12165,10 @@
         "properties": {
           "name": {
             "type": "string",
-            "description": "The name of the skill (must be unique per user). Only letters, numbers, emojis, hyphens, parentheses, and spaces allowed. Must start and end with a letter, number, emoji, or closing parenthesis.",
+            "description": "The name of the skill (must be unique per user). No leading/trailing whitespace, no consecutive spaces, no control characters. Max 100 characters.",
             "example": "Legal Research",
             "minLength": 1,
-            "maxLength": 255
+            "maxLength": 100
           },
           "shortDescription": {
             "type": "string",
@@ -13029,10 +13029,10 @@
         "properties": {
           "name": {
             "type": "string",
-            "description": "The name of the skill template. Only letters, numbers, emojis, hyphens, parentheses, and spaces allowed. Must start and end with a letter, number, emoji, or closing parenthesis.",
+            "description": "The name of the skill template. No leading/trailing whitespace, no consecutive spaces, no control characters. Max 100 characters.",
             "example": "Legal Guidelines",
             "minLength": 1,
-            "maxLength": 255
+            "maxLength": 100
           },
           "shortDescription": {
             "type": "string",
@@ -13131,10 +13131,10 @@
         "properties": {
           "name": {
             "type": "string",
-            "description": "The name of the skill template. Only letters, numbers, emojis, hyphens, parentheses, and spaces allowed. Must start and end with a letter, number, emoji, or closing parenthesis.",
+            "description": "The name of the skill template. No leading/trailing whitespace, no consecutive spaces, no control characters. Max 100 characters.",
             "example": "Legal Guidelines",
             "minLength": 1,
-            "maxLength": 255
+            "maxLength": 100
           },
           "shortDescription": {
             "type": "string",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes validation rules and max length for skill/skill-template names across domain entities, DTOs, and frontend forms, which can affect existing clients and persisted data expectations. Also updates unique-name resolution logic (including codepoint-safe truncation) that could change generated names in collision cases.
> 
> **Overview**
> **Relaxes skill and skill-template name validation** by replacing the strict character whitelist regex with a simpler rule set: non-empty, no leading/trailing whitespace, no consecutive spaces, and no Unicode control characters (domain entities + DTO validation).
> 
> **Standardizes name length to 100 characters** at the DTO/OpenAPI/Frontend form layer (previously 255), while keeping domain entities tolerant of longer names.
> 
> **Hardens skill creation flows**: `CreateSkillWithUniqueNameUseCase` now truncates names (codepoint-safe) to fit the 100-char limit and trims appropriately when adding numeric suffixes; new tests cover long names and emoji truncation. Invalid skill names are now surfaced as `400 Bad Request` from `SkillsController`, and use-cases rethrow `InvalidSkillNameError` instead of wrapping it as unexpected.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5c7fbdb7a8554f2c493269ae5abea9ecdb905ac6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->