### PR TITLE
feat(AYC-000): show skill icon and name in activate skill chat widget

### DIFF
--- a/ayunis-core-frontend/src/pages/chat/lib/slugify.ts
+++ b/ayunis-core-frontend/src/pages/chat/lib/slugify.ts
@@ -1,0 +1,22 @@
+/**
+ * Converts a skill name to its slug form.
+ * Must match the backend slugify logic in src/common/util/skill-slug.ts.
+ */
+export function slugify(name: string): string {
+  return name
+    .replace(/ä/g, 'ae')
+    .replace(/Ä/g, 'Ae')
+    .replace(/ö/g, 'oe')
+    .replace(/Ö/g, 'Oe')
+    .replace(/ü/g, 'ue')
+    .replace(/Ü/g, 'Ue')
+    .replace(/ß/g, 'ss')
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]/g, '-')
+    .replace(/-{2,}/g, '-')
+    .replace(/^-/, '')
+    .replace(/-$/, '');
+}

--- a/ayunis-core-frontend/src/pages/chat/ui/ChatMessage.tsx
+++ b/ayunis-core-frontend/src/pages/chat/ui/ChatMessage.tsx
@@ -30,6 +30,7 @@ import IntegrationToolWidget from './chat-widgets/IntegrationToolWidget';
 import ThinkingBlockWidget from './chat-widgets/ThinkingBlockWidget';
 import CreateCalendarEventWidget from './chat-widgets/CreateCalendarEventWidget';
 import CreateSkillWidget from './chat-widgets/CreateSkillWidget';
+import ActivateSkillWidget from './chat-widgets/ActivateSkillWidget';
 import SkillInstructionWidget from './chat-widgets/SkillInstructionWidget';
 import {
   BarChartWidget,
@@ -66,7 +67,7 @@ function CopyMessageButton({
     const textParts: string[] = [];
     copyableElements.forEach((element) => {
       htmlParts.push(element.innerHTML);
-      textParts.push(element.textContent ?? '');
+      textParts.push(element.textContent || '');
     });
 
     const html = htmlParts.join('<br><br>');
@@ -324,6 +325,18 @@ function renderMessageContent(message: Message, isStreaming?: boolean) {
               return (
                 <CreateSkillWidget
                   key={`create-skill-${index}-${toolUseMessageContent.name.slice(0, 50)}`}
+                  content={toolUseMessageContent}
+                  isStreaming={isStreaming}
+                />
+              );
+            }
+            if (
+              toolUseMessageContent.name ===
+              ToolAssignmentDtoType.activate_skill
+            ) {
+              return (
+                <ActivateSkillWidget
+                  key={`activate-skill-${index}-${toolUseMessageContent.name.slice(0, 50)}`}
                   content={toolUseMessageContent}
                   isStreaming={isStreaming}
                 />

--- a/ayunis-core-frontend/src/pages/chat/ui/chat-widgets/ActivateSkillWidget.tsx
+++ b/ayunis-core-frontend/src/pages/chat/ui/chat-widgets/ActivateSkillWidget.tsx
@@ -1,0 +1,56 @@
+import { Loader2, Sparkles } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { useState } from 'react';
+import type { ToolUseMessageContent } from '../../model/openapi';
+import { slugify } from '../../lib/slugify';
+import AgentActivityHint from '@/widgets/agent-activity-hint/ui/AgentActivityHint';
+import { useSkillsControllerFindAll } from '@/shared/api/generated/ayunisCoreAPI';
+
+function useSkillName(skillSlug: string | undefined): string | undefined {
+  const { data: skills } = useSkillsControllerFindAll();
+
+  if (!skillSlug || !skills) return undefined;
+
+  // Slugs have a prefix like "user__" or "system__" — strip it
+  const bareSlug = skillSlug.replace(/^(user|system)__/, '');
+
+  return skills.find((s) => slugify(s.name) === bareSlug)?.name;
+}
+
+export default function ActivateSkillWidget({
+  content,
+  isStreaming = false,
+}: Readonly<{
+  content: ToolUseMessageContent;
+  isStreaming?: boolean;
+}>) {
+  const { t } = useTranslation('chat');
+  const [open, setOpen] = useState(false);
+
+  const skillSlug = (content.params as { skill_slug?: string } | undefined)
+    ?.skill_slug;
+  const skillName = useSkillName(skillSlug);
+
+  const hasParams =
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- content.params may be undefined during streaming
+    content.params && Object.keys(content.params).length > 0;
+  const isLoadingParams = isStreaming && !hasParams;
+
+  const hint = skillName ?? t('chat.tools.activate_skill');
+
+  return (
+    <AgentActivityHint
+      open={open}
+      onOpenChange={setOpen}
+      icon={
+        isStreaming || isLoadingParams ? (
+          <Loader2 className="h-4 w-4 animate-spin" />
+        ) : (
+          <Sparkles className="h-4 w-4" />
+        )
+      }
+      hint={hint}
+      input={isLoadingParams ? '' : JSON.stringify(content.params, null, 2)}
+    />
+  );
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches core chat message rendering and adds a new `activate_skill` widget that fetches the skills list to resolve slugs, which could affect rendering/performance if the query refetches unexpectedly.
> 
> **Overview**
> Adds support for rendering `ToolAssignmentDtoType.activate_skill` tool calls in chat via a new `ActivateSkillWidget`, showing an `AgentActivityHint` with a spinner while streaming and a resolved skill name when available.
> 
> Introduces a shared `slugify` helper (aligned with backend slug generation) and uses it to map `skill_slug` (after stripping `user__`/`system__` prefixes) to a human-readable skill name by querying `/skills`. Also makes a small robustness tweak in clipboard copy (`textContent || ''`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 361bf82612228fcc7b49a5fc72a5dc8400e12380. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->