### PR TITLE
refactor(AYC-103): move STI columns to child record and add generic to findActiveByMode

### DIFF
--- a/ayunis-core-backend/src/domain/skill-templates/application/ports/skill-template.repository.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/application/ports/skill-template.repository.ts
@@ -9,5 +9,7 @@ export abstract class SkillTemplateRepository {
   abstract findOne(id: UUID): Promise<SkillTemplate | null>;
   abstract findAll(): Promise<SkillTemplate[]>;
   abstract findByName(name: string): Promise<SkillTemplate | null>;
-  abstract findActiveByMode(mode: DistributionMode): Promise<SkillTemplate[]>;
+  abstract findActiveByMode<T extends SkillTemplate = SkillTemplate>(
+    mode: DistributionMode,
+  ): Promise<T[]>;
 }

--- a/ayunis-core-backend/src/domain/skill-templates/application/use-cases/find-active-pre-created-templates/find-active-pre-created-templates.use-case.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/application/use-cases/find-active-pre-created-templates/find-active-pre-created-templates.use-case.ts
@@ -22,12 +22,9 @@ export class FindActivePreCreatedTemplatesUseCase {
   ): Promise<PreCreatedCopySkillTemplate[]> {
     this.logger.log('Finding active pre-created copy templates');
     try {
-      // Safe cast: the repository uses TypeORM STI which hydrates the correct
-      // subclass based on the discriminator column, so findActiveByMode(PRE_CREATED_COPY)
-      // always returns PreCreatedCopySkillTemplate instances.
-      return (await this.skillTemplateRepository.findActiveByMode(
+      return await this.skillTemplateRepository.findActiveByMode<PreCreatedCopySkillTemplate>(
         DistributionMode.PRE_CREATED_COPY,
-      )) as PreCreatedCopySkillTemplate[];
+      );
     } catch (error) {
       if (error instanceof ApplicationError) throw error;
       this.logger.error('Error finding active pre-created templates', {

--- a/ayunis-core-backend/src/domain/skill-templates/infrastructure/persistence/local/local-skill-template.repository.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/infrastructure/persistence/local/local-skill-template.repository.ts
@@ -93,14 +93,16 @@ export class LocalSkillTemplateRepository implements SkillTemplateRepository {
     return this.mapper.toDomain(record);
   }
 
-  async findActiveByMode(mode: DistributionMode): Promise<SkillTemplate[]> {
+  async findActiveByMode<T extends SkillTemplate = SkillTemplate>(
+    mode: DistributionMode,
+  ): Promise<T[]> {
     this.logger.log('findActiveByMode', { mode });
     const childRepo = this.childRepos[mode];
     const records = await childRepo.find({
       where: { isActive: true },
       order: { createdAt: 'ASC' },
     });
-    return records.map((r) => this.mapper.toDomain(r));
+    return records.map((r) => this.mapper.toDomain(r) as T);
   }
 
   private async saveOrThrow(

--- a/ayunis-core-backend/src/domain/skill-templates/infrastructure/persistence/local/mappers/skill-template.mapper.spec.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/infrastructure/persistence/local/mappers/skill-template.mapper.spec.ts
@@ -115,7 +115,7 @@ describe('SkillTemplateMapper', () => {
       expect(record.isActive).toBe(true);
     });
 
-    it('should null out defaultActive and defaultPinned for AlwaysOnSkillTemplate records', () => {
+    it('should not set defaultActive or defaultPinned for AlwaysOnSkillTemplate records', () => {
       const domain = new AlwaysOnSkillTemplate({
         id: mockId,
         name: 'Sicherheits-Richtlinie',
@@ -126,8 +126,8 @@ describe('SkillTemplateMapper', () => {
 
       const record = mapper.toRecord(domain);
 
-      expect(record.defaultActive).toBeNull();
-      expect(record.defaultPinned).toBeNull();
+      expect(record).not.toHaveProperty('defaultActive');
+      expect(record).not.toHaveProperty('defaultPinned');
     });
 
     it('should map a PreCreatedCopySkillTemplate to PreCreatedCopySkillTemplateRecord', () => {

--- a/ayunis-core-backend/src/domain/skill-templates/infrastructure/persistence/local/mappers/skill-template.mapper.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/infrastructure/persistence/local/mappers/skill-template.mapper.ts
@@ -38,8 +38,6 @@ export class SkillTemplateMapper {
     if (domain instanceof AlwaysOnSkillTemplate) {
       const record = new AlwaysOnSkillTemplateRecord();
       this.assignSharedRecordFields(record, domain);
-      record.defaultActive = null;
-      record.defaultPinned = null;
       return record;
     }
 

--- a/ayunis-core-backend/src/domain/skill-templates/infrastructure/persistence/local/schema/pre-created-copy-skill-template.record.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/infrastructure/persistence/local/schema/pre-created-copy-skill-template.record.ts
@@ -1,6 +1,12 @@
-import { ChildEntity } from 'typeorm';
+import { ChildEntity, Column } from 'typeorm';
 import { SkillTemplateRecord } from './skill-template.record';
 import { DistributionMode } from '../../../../domain/distribution-mode.enum';
 
 @ChildEntity(DistributionMode.PRE_CREATED_COPY)
-export class PreCreatedCopySkillTemplateRecord extends SkillTemplateRecord {}
+export class PreCreatedCopySkillTemplateRecord extends SkillTemplateRecord {
+  @Column({ type: 'boolean', nullable: true })
+  defaultActive: boolean | null;
+
+  @Column({ type: 'boolean', nullable: true })
+  defaultPinned: boolean | null;
+}

--- a/ayunis-core-backend/src/domain/skill-templates/infrastructure/persistence/local/schema/skill-template.record.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/infrastructure/persistence/local/schema/skill-template.record.ts
@@ -15,12 +15,4 @@ export abstract class SkillTemplateRecord extends BaseRecord {
 
   @Column({ nullable: false, default: false })
   isActive: boolean;
-
-  // STI: owned by PreCreatedCopy, null for other subtypes — on base record so TypeORM includes them in UPDATE for all child entities
-  @Column({ type: 'boolean', nullable: true })
-  defaultActive: boolean | null;
-
-  // STI: owned by PreCreatedCopy, null for other subtypes — on base record so TypeORM includes them in UPDATE for all child entities
-  @Column({ type: 'boolean', nullable: true })
-  defaultPinned: boolean | null;
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches TypeORM STI persistence mapping by relocating `defaultActive`/`defaultPinned` columns to the `PreCreatedCopy` child record, which could affect schema sync/migrations and update behavior. Also changes repository method typing, which is low runtime risk but may surface type mismatches at compile time.
> 
> **Overview**
> **Improves typing of active-template retrieval** by making `SkillTemplateRepository.findActiveByMode` generic, allowing callers to request a specific `SkillTemplate` subtype without unsafe casts (updated in `FindActivePreCreatedTemplatesUseCase`).
> 
> **Refactors TypeORM STI schema/mapping** by moving `defaultActive`/`defaultPinned` column definitions from the base `SkillTemplateRecord` into `PreCreatedCopySkillTemplateRecord`, and updating the mapper/tests so `AlwaysOn` records no longer explicitly write these fields.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0a1abd1ab1fd2d73682af949c67d473caa75477d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->