### PR TITLE
fix(AYC-000): pass defaultActive and defaultPinned when creating pre-created skill templates

### DIFF
--- a/ayunis-core-backend/src/domain/skill-templates/application/use-cases/create-skill-template/create-skill-template.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/application/use-cases/create-skill-template/create-skill-template.use-case.spec.ts
@@ -91,6 +91,28 @@ describe('CreateSkillTemplateUseCase', () => {
     expect(result.distributionMode).toBe(DistributionMode.PRE_CREATED_COPY);
   });
 
+  it('should pass defaultActive and defaultPinned to pre-created copy templates', async () => {
+    const command = new CreateSkillTemplateCommand({
+      name: 'Preconfigured Template',
+      shortDescription: 'A preconfigured template',
+      instructions: 'Instructions here.',
+      distributionMode: DistributionMode.PRE_CREATED_COPY,
+      isActive: true,
+      defaultActive: true,
+      defaultPinned: true,
+    });
+
+    repository.findByName.mockResolvedValue(null);
+    repository.create.mockImplementation(async (t) => t);
+
+    const result = await useCase.execute(command);
+
+    expect(result).toBeInstanceOf(PreCreatedCopySkillTemplate);
+    const preCreated = result as PreCreatedCopySkillTemplate;
+    expect(preCreated.defaultActive).toBe(true);
+    expect(preCreated.defaultPinned).toBe(true);
+  });
+
   it('should reject creation when name already exists', async () => {
     const command = new CreateSkillTemplateCommand({
       name: 'Legal Guidelines',

--- a/ayunis-core-backend/src/domain/skill-templates/application/use-cases/create-skill-template/create-skill-template.use-case.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/application/use-cases/create-skill-template/create-skill-template.use-case.ts
@@ -40,7 +40,11 @@ export class CreateSkillTemplateUseCase {
       const skillTemplate: SkillTemplate =
         command.distributionMode === DistributionMode.ALWAYS_ON
           ? new AlwaysOnSkillTemplate(baseParams)
-          : new PreCreatedCopySkillTemplate(baseParams);
+          : new PreCreatedCopySkillTemplate({
+              ...baseParams,
+              defaultActive: command.defaultActive,
+              defaultPinned: command.defaultPinned,
+            });
 
       return await this.skillTemplateRepository.create(skillTemplate);
     } catch (error) {

--- a/ayunis-core-backend/src/domain/skill-templates/application/use-cases/update-skill-template/update-skill-template.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/application/use-cases/update-skill-template/update-skill-template.use-case.spec.ts
@@ -101,6 +101,59 @@ describe('UpdateSkillTemplateUseCase', () => {
     expect(result.isActive).toBe(false);
   });
 
+  it('should pass defaultActive and defaultPinned when updating a pre-created copy template', async () => {
+    const existing = new PreCreatedCopySkillTemplate({
+      id: mockId,
+      name: 'Template',
+      shortDescription: 'Description',
+      instructions: 'Instructions.',
+      defaultActive: false,
+      defaultPinned: false,
+    });
+
+    const command = new UpdateSkillTemplateCommand({
+      skillTemplateId: mockId,
+      defaultActive: true,
+      defaultPinned: true,
+    });
+
+    repository.findOne.mockResolvedValue(existing);
+    repository.update.mockImplementation(async (t) => t);
+
+    const result = await useCase.execute(command);
+
+    expect(result).toBeInstanceOf(PreCreatedCopySkillTemplate);
+    const preCreated = result as PreCreatedCopySkillTemplate;
+    expect(preCreated.defaultActive).toBe(true);
+    expect(preCreated.defaultPinned).toBe(true);
+  });
+
+  it('should preserve existing defaultActive and defaultPinned when not provided in update', async () => {
+    const existing = new PreCreatedCopySkillTemplate({
+      id: mockId,
+      name: 'Template',
+      shortDescription: 'Description',
+      instructions: 'Instructions.',
+      defaultActive: true,
+      defaultPinned: true,
+    });
+
+    const command = new UpdateSkillTemplateCommand({
+      skillTemplateId: mockId,
+      shortDescription: 'Updated description',
+    });
+
+    repository.findOne.mockResolvedValue(existing);
+    repository.update.mockImplementation(async (t) => t);
+
+    const result = await useCase.execute(command);
+
+    expect(result).toBeInstanceOf(PreCreatedCopySkillTemplate);
+    const preCreated = result as PreCreatedCopySkillTemplate;
+    expect(preCreated.defaultActive).toBe(true);
+    expect(preCreated.defaultPinned).toBe(true);
+  });
+
   it('should check name uniqueness when name changes', async () => {
     const existing = new AlwaysOnSkillTemplate({
       id: mockId,

--- a/ayunis-core-backend/src/domain/skill-templates/application/use-cases/update-skill-template/update-skill-template.use-case.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/application/use-cases/update-skill-template/update-skill-template.use-case.ts
@@ -57,7 +57,19 @@ export class UpdateSkillTemplateUseCase {
       const updated: SkillTemplate =
         distributionMode === DistributionMode.ALWAYS_ON
           ? new AlwaysOnSkillTemplate(baseParams)
-          : new PreCreatedCopySkillTemplate(baseParams);
+          : new PreCreatedCopySkillTemplate({
+              ...baseParams,
+              defaultActive:
+                command.defaultActive ??
+                (existing instanceof PreCreatedCopySkillTemplate
+                  ? existing.defaultActive
+                  : false),
+              defaultPinned:
+                command.defaultPinned ??
+                (existing instanceof PreCreatedCopySkillTemplate
+                  ? existing.defaultPinned
+                  : false),
+            });
 
       return await this.skillTemplateRepository.update(updated);
     } catch (error) {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small, well-tested change to creation/update mapping for `PreCreatedCopySkillTemplate`; main risk is altering persisted defaults for new/updated templates in this distribution mode.
> 
> **Overview**
> Fixes `CreateSkillTemplateUseCase` and `UpdateSkillTemplateUseCase` to propagate `defaultActive` and `defaultPinned` into `PreCreatedCopySkillTemplate` instances.
> 
> Updates now *preserve existing* default values when the fields aren’t provided, and new unit tests cover both create and update behavior for these defaults.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f09cbb235444d326d037fac4e0be8ad8a446461f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->