### PR TITLE
wip(AYC-105): add super admin management backend endpoints

### DIFF
--- a/ayunis-core-backend/package-lock.json
+++ b/ayunis-core-backend/package-lock.json
@@ -7130,7 +7130,7 @@
     },
     "node_modules/@swc/core": {
       "version": "1.11.21",
-      "dev": true,
+      "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -7172,7 +7172,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -7189,7 +7188,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -7206,7 +7204,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -7221,7 +7218,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -7236,7 +7232,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -7253,7 +7248,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -7270,7 +7264,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -7287,7 +7280,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -7304,7 +7296,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -7321,7 +7312,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -7333,7 +7323,7 @@
     },
     "node_modules/@swc/counter": {
       "version": "0.1.3",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0"
     },
     "node_modules/@swc/jest": {
@@ -7356,7 +7346,7 @@
     },
     "node_modules/@swc/types": {
       "version": "0.1.21",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@swc/counter": "^0.1.3"

--- a/ayunis-core-backend/src/db/migrations/1772627745700-MigrateAgentsAndPromptsToSkills.ts
+++ b/ayunis-core-backend/src/db/migrations/1772627745700-MigrateAgentsAndPromptsToSkills.ts
@@ -1,6 +1,8 @@
 import type { MigrationInterface, QueryRunner } from 'typeorm';
 
-export class MigrateAgentsAndPromptsToSkills1772627745700 implements MigrationInterface {
+export class MigrateAgentsAndPromptsToSkills1772627745700
+  implements MigrationInterface
+{
   name = 'MigrateAgentsAndPromptsToSkills1772627745700';
 
   public async up(queryRunner: QueryRunner): Promise<void> {

--- a/ayunis-core-backend/src/domain/skill-templates/application/use-cases/delete-skill-template/delete-skill-template.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/application/use-cases/delete-skill-template/delete-skill-template.use-case.spec.ts
@@ -5,7 +5,6 @@ import type { UUID } from 'crypto';
 import { DeleteSkillTemplateUseCase } from './delete-skill-template.use-case';
 import { DeleteSkillTemplateCommand } from './delete-skill-template.command';
 import { SkillTemplateRepository } from '../../ports/skill-template.repository';
-import { SkillTemplate } from '../../../domain/skill-template.entity';
 import { AlwaysOnSkillTemplate } from '../../../domain/always-on-skill-template.entity';
 import { SkillTemplateNotFoundError } from '../../skill-templates.errors';
 

--- a/ayunis-core-backend/src/domain/skill-templates/application/use-cases/find-active-always-on-templates/find-active-always-on-templates.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/application/use-cases/find-active-always-on-templates/find-active-always-on-templates.use-case.spec.ts
@@ -1,7 +1,7 @@
 import { FindActiveAlwaysOnTemplatesUseCase } from './find-active-always-on-templates.use-case';
 import { FindActiveAlwaysOnTemplatesQuery } from './find-active-always-on-templates.query';
 import type { SkillTemplateRepository } from '../../ports/skill-template.repository';
-import { SkillTemplate } from '../../../domain/skill-template.entity';
+import type { SkillTemplate } from '../../../domain/skill-template.entity';
 import { AlwaysOnSkillTemplate } from '../../../domain/always-on-skill-template.entity';
 import { DistributionMode } from '../../../domain/distribution-mode.enum';
 import { randomUUID } from 'crypto';

--- a/ayunis-core-backend/src/domain/skill-templates/application/use-cases/find-active-pre-created-templates/find-active-pre-created-templates.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/application/use-cases/find-active-pre-created-templates/find-active-pre-created-templates.use-case.spec.ts
@@ -1,7 +1,7 @@
 import { FindActivePreCreatedTemplatesUseCase } from './find-active-pre-created-templates.use-case';
 import { FindActivePreCreatedTemplatesQuery } from './find-active-pre-created-templates.query';
 import type { SkillTemplateRepository } from '../../ports/skill-template.repository';
-import { SkillTemplate } from '../../../domain/skill-template.entity';
+import type { SkillTemplate } from '../../../domain/skill-template.entity';
 import { PreCreatedCopySkillTemplate } from '../../../domain/pre-created-copy-skill-template.entity';
 import { DistributionMode } from '../../../domain/distribution-mode.enum';
 import { randomUUID } from 'crypto';

--- a/ayunis-core-backend/src/domain/skill-templates/application/use-cases/find-one-skill-template/find-one-skill-template.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/application/use-cases/find-one-skill-template/find-one-skill-template.use-case.spec.ts
@@ -5,7 +5,6 @@ import type { UUID } from 'crypto';
 import { FindOneSkillTemplateUseCase } from './find-one-skill-template.use-case';
 import { FindOneSkillTemplateQuery } from './find-one-skill-template.query';
 import { SkillTemplateRepository } from '../../ports/skill-template.repository';
-import { SkillTemplate } from '../../../domain/skill-template.entity';
 import { AlwaysOnSkillTemplate } from '../../../domain/always-on-skill-template.entity';
 import { SkillTemplateNotFoundError } from '../../skill-templates.errors';
 

--- a/ayunis-core-backend/src/iam/users/application/ports/users.repository.ts
+++ b/ayunis-core-backend/src/iam/users/application/ports/users.repository.ts
@@ -1,6 +1,7 @@
 import type { User } from '../../domain/user.entity';
 import type { UUID } from 'crypto';
 import type { Paginated } from 'src/common/pagination/paginated.entity';
+import type { SystemRole } from '../../domain/value-objects/system-role.enum';
 
 export interface UsersPagination {
   limit: number;
@@ -15,6 +16,7 @@ export abstract class UsersRepository {
   abstract findOneById(id: UUID): Promise<User | null>;
   abstract findOneByEmail(email: string): Promise<User | null>;
   abstract findManyByEmails(emails: string[]): Promise<User[]>;
+  abstract findManyBySystemRole(role: SystemRole): Promise<User[]>;
   abstract findManyByOrgId(
     orgId: UUID,
     pagination: UsersPagination,

--- a/ayunis-core-backend/src/iam/users/application/use-cases/demote-from-super-admin/demote-from-super-admin.command.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/demote-from-super-admin/demote-from-super-admin.command.ts
@@ -1,0 +1,11 @@
+import type { UUID } from 'crypto';
+
+export class DemoteFromSuperAdminCommand {
+  public readonly userId: UUID;
+  public readonly requestingUserId: UUID;
+
+  constructor(params: { userId: UUID; requestingUserId: UUID }) {
+    this.userId = params.userId;
+    this.requestingUserId = params.requestingUserId;
+  }
+}

--- a/ayunis-core-backend/src/iam/users/application/use-cases/demote-from-super-admin/demote-from-super-admin.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/demote-from-super-admin/demote-from-super-admin.use-case.spec.ts
@@ -1,0 +1,173 @@
+import type { TestingModule } from '@nestjs/testing';
+import { Test } from '@nestjs/testing';
+
+// Mock the Transactional decorator
+jest.mock('@nestjs-cls/transactional', () => ({
+  Transactional:
+    () =>
+    (_target: unknown, _propertyName: string, descriptor: PropertyDescriptor) =>
+      descriptor,
+}));
+
+import { DemoteFromSuperAdminUseCase } from './demote-from-super-admin.use-case';
+import { DemoteFromSuperAdminCommand } from './demote-from-super-admin.command';
+import { UsersRepository } from '../../ports/users.repository';
+import { User } from '../../../domain/user.entity';
+import { UserRole } from '../../../domain/value-objects/role.object';
+import { SystemRole } from '../../../domain/value-objects/system-role.enum';
+import type { UUID } from 'crypto';
+import {
+  UserNotFoundError,
+  UserNotSuperAdminError,
+  UserSelfDemotionNotAllowedError,
+  UserLastSuperAdminError,
+} from '../../users.errors';
+
+describe('DemoteFromSuperAdminUseCase', () => {
+  let useCase: DemoteFromSuperAdminUseCase;
+  let mockUsersRepository: Partial<UsersRepository>;
+
+  beforeAll(async () => {
+    mockUsersRepository = {
+      findOneById: jest.fn(),
+      findManyBySystemRole: jest.fn(),
+      update: jest.fn(),
+    };
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        DemoteFromSuperAdminUseCase,
+        { provide: UsersRepository, useValue: mockUsersRepository },
+      ],
+    }).compile();
+
+    useCase = module.get<DemoteFromSuperAdminUseCase>(
+      DemoteFromSuperAdminUseCase,
+    );
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should demote user from super admin', async () => {
+    const command = new DemoteFromSuperAdminCommand({
+      userId: 'target-user-id' as UUID,
+      requestingUserId: 'requesting-user-id' as UUID,
+    });
+    const mockUser = new User({
+      id: 'target-user-id' as UUID,
+      email: 'test@example.com',
+      emailVerified: true,
+      passwordHash: 'hash',
+      role: UserRole.USER,
+      systemRole: SystemRole.SUPER_ADMIN,
+      orgId: 'org-id' as UUID,
+      name: 'Test User',
+      hasAcceptedMarketing: false,
+    });
+
+    const anotherAdmin = new User({
+      id: 'other-admin-id' as UUID,
+      email: 'other@example.com',
+      emailVerified: true,
+      passwordHash: 'hash',
+      role: UserRole.USER,
+      systemRole: SystemRole.SUPER_ADMIN,
+      orgId: 'org-id' as UUID,
+      name: 'Other Admin',
+      hasAcceptedMarketing: false,
+    });
+
+    jest.spyOn(mockUsersRepository, 'findOneById').mockResolvedValue(mockUser);
+    jest
+      .spyOn(mockUsersRepository, 'findManyBySystemRole')
+      .mockResolvedValue([mockUser, anotherAdmin]);
+    jest.spyOn(mockUsersRepository, 'update').mockResolvedValue(mockUser);
+
+    await useCase.execute(command);
+
+    expect(mockUsersRepository.findOneById).toHaveBeenCalledWith(
+      'target-user-id',
+    );
+    expect(mockUser.systemRole).toBe(SystemRole.CUSTOMER);
+    expect(mockUsersRepository.update).toHaveBeenCalledWith(mockUser);
+  });
+
+  it('should throw UserSelfDemotionNotAllowedError on self-demotion', async () => {
+    const command = new DemoteFromSuperAdminCommand({
+      userId: 'same-user-id' as UUID,
+      requestingUserId: 'same-user-id' as UUID,
+    });
+
+    await expect(useCase.execute(command)).rejects.toThrow(
+      UserSelfDemotionNotAllowedError,
+    );
+    expect(mockUsersRepository.findOneById).not.toHaveBeenCalled();
+    expect(mockUsersRepository.update).not.toHaveBeenCalled();
+  });
+
+  it('should throw UserNotSuperAdminError when user is not a super admin', async () => {
+    const command = new DemoteFromSuperAdminCommand({
+      userId: 'target-user-id' as UUID,
+      requestingUserId: 'requesting-user-id' as UUID,
+    });
+    const mockUser = new User({
+      id: 'target-user-id' as UUID,
+      email: 'regular@example.com',
+      emailVerified: true,
+      passwordHash: 'hash',
+      role: UserRole.USER,
+      systemRole: SystemRole.CUSTOMER,
+      orgId: 'org-id' as UUID,
+      name: 'Regular User',
+      hasAcceptedMarketing: false,
+    });
+
+    jest.spyOn(mockUsersRepository, 'findOneById').mockResolvedValue(mockUser);
+
+    await expect(useCase.execute(command)).rejects.toThrow(
+      UserNotSuperAdminError,
+    );
+    expect(mockUsersRepository.update).not.toHaveBeenCalled();
+  });
+
+  it('should throw UserLastSuperAdminError when demoting the last super admin', async () => {
+    const command = new DemoteFromSuperAdminCommand({
+      userId: 'target-user-id' as UUID,
+      requestingUserId: 'requesting-user-id' as UUID,
+    });
+    const mockUser = new User({
+      id: 'target-user-id' as UUID,
+      email: 'admin@example.com',
+      emailVerified: true,
+      passwordHash: 'hash',
+      role: UserRole.USER,
+      systemRole: SystemRole.SUPER_ADMIN,
+      orgId: 'org-id' as UUID,
+      name: 'Last Admin',
+      hasAcceptedMarketing: false,
+    });
+
+    jest.spyOn(mockUsersRepository, 'findOneById').mockResolvedValue(mockUser);
+    jest
+      .spyOn(mockUsersRepository, 'findManyBySystemRole')
+      .mockResolvedValue([mockUser]);
+
+    await expect(useCase.execute(command)).rejects.toThrow(
+      UserLastSuperAdminError,
+    );
+    expect(mockUsersRepository.update).not.toHaveBeenCalled();
+  });
+
+  it('should throw UserNotFoundError when user not found', async () => {
+    const command = new DemoteFromSuperAdminCommand({
+      userId: 'nonexistent-id' as UUID,
+      requestingUserId: 'requesting-user-id' as UUID,
+    });
+
+    jest.spyOn(mockUsersRepository, 'findOneById').mockResolvedValue(null);
+
+    await expect(useCase.execute(command)).rejects.toThrow(UserNotFoundError);
+    expect(mockUsersRepository.update).not.toHaveBeenCalled();
+  });
+});

--- a/ayunis-core-backend/src/iam/users/application/use-cases/demote-from-super-admin/demote-from-super-admin.use-case.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/demote-from-super-admin/demote-from-super-admin.use-case.ts
@@ -1,0 +1,61 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Transactional } from '@nestjs-cls/transactional';
+import { UsersRepository } from '../../ports/users.repository';
+import { DemoteFromSuperAdminCommand } from './demote-from-super-admin.command';
+import { SystemRole } from '../../../domain/value-objects/system-role.enum';
+import {
+  UserNotFoundError,
+  UserNotSuperAdminError,
+  UserUnexpectedError,
+  UserSelfDemotionNotAllowedError,
+  UserLastSuperAdminError,
+} from '../../users.errors';
+import { ApplicationError } from 'src/common/errors/base.error';
+
+@Injectable()
+export class DemoteFromSuperAdminUseCase {
+  private readonly logger = new Logger(DemoteFromSuperAdminUseCase.name);
+
+  constructor(private readonly usersRepository: UsersRepository) {}
+
+  @Transactional()
+  async execute(command: DemoteFromSuperAdminCommand): Promise<void> {
+    this.logger.log('execute', {
+      userId: command.userId,
+      requestingUserId: command.requestingUserId,
+    });
+
+    try {
+      if (command.userId === command.requestingUserId) {
+        throw new UserSelfDemotionNotAllowedError();
+      }
+
+      const user = await this.usersRepository.findOneById(command.userId);
+      if (!user) {
+        throw new UserNotFoundError(command.userId);
+      }
+
+      if (user.systemRole !== SystemRole.SUPER_ADMIN) {
+        throw new UserNotSuperAdminError(command.userId);
+      }
+
+      const superAdmins = await this.usersRepository.findManyBySystemRole(
+        SystemRole.SUPER_ADMIN,
+      );
+      if (superAdmins.length <= 1) {
+        throw new UserLastSuperAdminError();
+      }
+
+      user.systemRole = SystemRole.CUSTOMER;
+      await this.usersRepository.update(user);
+    } catch (error) {
+      if (error instanceof ApplicationError) {
+        throw error;
+      }
+      this.logger.error('Error demoting user from super admin', {
+        error: error instanceof Error ? error.message : 'Unknown error',
+      });
+      throw new UserUnexpectedError(error as Error);
+    }
+  }
+}

--- a/ayunis-core-backend/src/iam/users/application/use-cases/find-super-admins/find-super-admins.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/find-super-admins/find-super-admins.use-case.spec.ts
@@ -1,0 +1,89 @@
+import type { TestingModule } from '@nestjs/testing';
+import { Test } from '@nestjs/testing';
+import { FindSuperAdminsUseCase } from './find-super-admins.use-case';
+import { UsersRepository } from '../../ports/users.repository';
+import { User } from '../../../domain/user.entity';
+import { UserRole } from '../../../domain/value-objects/role.object';
+import { SystemRole } from '../../../domain/value-objects/system-role.enum';
+import type { UUID } from 'crypto';
+import { UserUnexpectedError } from '../../users.errors';
+
+describe('FindSuperAdminsUseCase', () => {
+  let useCase: FindSuperAdminsUseCase;
+  let mockUsersRepository: Partial<UsersRepository>;
+
+  beforeAll(async () => {
+    mockUsersRepository = {
+      findManyBySystemRole: jest.fn(),
+    };
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        FindSuperAdminsUseCase,
+        { provide: UsersRepository, useValue: mockUsersRepository },
+      ],
+    }).compile();
+
+    useCase = module.get<FindSuperAdminsUseCase>(FindSuperAdminsUseCase);
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return all super admin users', async () => {
+    const superAdmin1 = new User({
+      id: 'admin-1-id' as UUID,
+      email: 'admin1@example.com',
+      emailVerified: true,
+      passwordHash: 'hash',
+      role: UserRole.USER,
+      systemRole: SystemRole.SUPER_ADMIN,
+      orgId: 'org-1-id' as UUID,
+      name: 'Admin One',
+      hasAcceptedMarketing: false,
+    });
+    const superAdmin2 = new User({
+      id: 'admin-2-id' as UUID,
+      email: 'admin2@example.com',
+      emailVerified: true,
+      passwordHash: 'hash',
+      role: UserRole.ADMIN,
+      systemRole: SystemRole.SUPER_ADMIN,
+      orgId: 'org-2-id' as UUID,
+      name: 'Admin Two',
+      hasAcceptedMarketing: true,
+    });
+
+    jest
+      .spyOn(mockUsersRepository, 'findManyBySystemRole')
+      .mockResolvedValue([superAdmin1, superAdmin2]);
+
+    const result = await useCase.execute();
+
+    expect(mockUsersRepository.findManyBySystemRole).toHaveBeenCalledWith(
+      SystemRole.SUPER_ADMIN,
+    );
+    expect(result).toEqual([superAdmin1, superAdmin2]);
+  });
+
+  it('should return an empty array when no super admins exist', async () => {
+    jest
+      .spyOn(mockUsersRepository, 'findManyBySystemRole')
+      .mockResolvedValue([]);
+
+    const result = await useCase.execute();
+
+    expect(mockUsersRepository.findManyBySystemRole).toHaveBeenCalledWith(
+      SystemRole.SUPER_ADMIN,
+    );
+    expect(result).toEqual([]);
+  });
+
+  it('should throw UserUnexpectedError when repository throws', async () => {
+    jest
+      .spyOn(mockUsersRepository, 'findManyBySystemRole')
+      .mockRejectedValue(new Error('Database connection failed'));
+
+    await expect(useCase.execute()).rejects.toThrow(UserUnexpectedError);
+  });
+});

--- a/ayunis-core-backend/src/iam/users/application/use-cases/find-super-admins/find-super-admins.use-case.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/find-super-admins/find-super-admins.use-case.ts
@@ -1,0 +1,26 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { UsersRepository } from '../../ports/users.repository';
+import { User } from '../../../domain/user.entity';
+import { SystemRole } from '../../../domain/value-objects/system-role.enum';
+import { UserUnexpectedError } from '../../users.errors';
+
+@Injectable()
+export class FindSuperAdminsUseCase {
+  private readonly logger = new Logger(FindSuperAdminsUseCase.name);
+
+  constructor(private readonly usersRepository: UsersRepository) {}
+
+  async execute(): Promise<User[]> {
+    this.logger.log('execute');
+    try {
+      return await this.usersRepository.findManyBySystemRole(
+        SystemRole.SUPER_ADMIN,
+      );
+    } catch (error) {
+      this.logger.error('Error finding super admins', {
+        error: error instanceof Error ? error.message : 'Unknown error',
+      });
+      throw new UserUnexpectedError(error as Error);
+    }
+  }
+}

--- a/ayunis-core-backend/src/iam/users/application/use-cases/promote-to-super-admin/promote-to-super-admin.command.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/promote-to-super-admin/promote-to-super-admin.command.ts
@@ -1,0 +1,7 @@
+export class PromoteToSuperAdminCommand {
+  public readonly email: string;
+
+  constructor(params: { email: string }) {
+    this.email = params.email;
+  }
+}

--- a/ayunis-core-backend/src/iam/users/application/use-cases/promote-to-super-admin/promote-to-super-admin.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/promote-to-super-admin/promote-to-super-admin.use-case.spec.ts
@@ -1,0 +1,114 @@
+import type { TestingModule } from '@nestjs/testing';
+import { Test } from '@nestjs/testing';
+
+// Mock the Transactional decorator
+jest.mock('@nestjs-cls/transactional', () => ({
+  Transactional:
+    () =>
+    (_target: unknown, _propertyName: string, descriptor: PropertyDescriptor) =>
+      descriptor,
+}));
+
+import { PromoteToSuperAdminUseCase } from './promote-to-super-admin.use-case';
+import { PromoteToSuperAdminCommand } from './promote-to-super-admin.command';
+import { UsersRepository } from '../../ports/users.repository';
+import { User } from '../../../domain/user.entity';
+import { UserRole } from '../../../domain/value-objects/role.object';
+import { SystemRole } from '../../../domain/value-objects/system-role.enum';
+import type { UUID } from 'crypto';
+import { UserNotFoundError } from '../../users.errors';
+
+describe('PromoteToSuperAdminUseCase', () => {
+  let useCase: PromoteToSuperAdminUseCase;
+  let mockUsersRepository: Partial<UsersRepository>;
+
+  beforeAll(async () => {
+    mockUsersRepository = {
+      findOneByEmail: jest.fn(),
+      update: jest.fn(),
+    };
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        PromoteToSuperAdminUseCase,
+        { provide: UsersRepository, useValue: mockUsersRepository },
+      ],
+    }).compile();
+
+    useCase = module.get<PromoteToSuperAdminUseCase>(
+      PromoteToSuperAdminUseCase,
+    );
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should promote user to super admin', async () => {
+    const command = new PromoteToSuperAdminCommand({
+      email: 'test@example.com',
+    });
+    const mockUser = new User({
+      id: 'user-id' as UUID,
+      email: 'test@example.com',
+      emailVerified: true,
+      passwordHash: 'hash',
+      role: UserRole.USER,
+      systemRole: SystemRole.CUSTOMER,
+      orgId: 'org-id' as UUID,
+      name: 'Test User',
+      hasAcceptedMarketing: false,
+    });
+
+    jest
+      .spyOn(mockUsersRepository, 'findOneByEmail')
+      .mockResolvedValue(mockUser);
+    jest.spyOn(mockUsersRepository, 'update').mockResolvedValue(mockUser);
+
+    const result = await useCase.execute(command);
+
+    expect(mockUsersRepository.findOneByEmail).toHaveBeenCalledWith(
+      'test@example.com',
+    );
+    expect(mockUser.systemRole).toBe(SystemRole.SUPER_ADMIN);
+    expect(mockUsersRepository.update).toHaveBeenCalledWith(mockUser);
+    expect(result).toBe(mockUser);
+  });
+
+  it('should throw UserNotFoundError when user not found', async () => {
+    const command = new PromoteToSuperAdminCommand({
+      email: 'notfound@example.com',
+    });
+
+    jest.spyOn(mockUsersRepository, 'findOneByEmail').mockResolvedValue(null);
+
+    await expect(useCase.execute(command)).rejects.toThrow(UserNotFoundError);
+    expect(mockUsersRepository.update).not.toHaveBeenCalled();
+  });
+
+  it('should return early without DB write when user is already super admin', async () => {
+    const command = new PromoteToSuperAdminCommand({
+      email: 'admin@example.com',
+    });
+    const mockUser = new User({
+      id: 'user-id' as UUID,
+      email: 'admin@example.com',
+      emailVerified: true,
+      passwordHash: 'hash',
+      role: UserRole.USER,
+      systemRole: SystemRole.SUPER_ADMIN,
+      orgId: 'org-id' as UUID,
+      name: 'Admin User',
+      hasAcceptedMarketing: false,
+    });
+
+    jest
+      .spyOn(mockUsersRepository, 'findOneByEmail')
+      .mockResolvedValue(mockUser);
+
+    const result = await useCase.execute(command);
+
+    expect(mockUser.systemRole).toBe(SystemRole.SUPER_ADMIN);
+    expect(mockUsersRepository.update).not.toHaveBeenCalled();
+    expect(result).toBe(mockUser);
+  });
+});

--- a/ayunis-core-backend/src/iam/users/application/use-cases/promote-to-super-admin/promote-to-super-admin.use-case.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/promote-to-super-admin/promote-to-super-admin.use-case.ts
@@ -1,0 +1,43 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Transactional } from '@nestjs-cls/transactional';
+import { UsersRepository } from '../../ports/users.repository';
+import { PromoteToSuperAdminCommand } from './promote-to-super-admin.command';
+import { User } from '../../../domain/user.entity';
+import { SystemRole } from '../../../domain/value-objects/system-role.enum';
+import { UserNotFoundError, UserUnexpectedError } from '../../users.errors';
+import { ApplicationError } from 'src/common/errors/base.error';
+
+@Injectable()
+export class PromoteToSuperAdminUseCase {
+  private readonly logger = new Logger(PromoteToSuperAdminUseCase.name);
+
+  constructor(private readonly usersRepository: UsersRepository) {}
+
+  @Transactional()
+  async execute(command: PromoteToSuperAdminCommand): Promise<User> {
+    this.logger.log('execute');
+
+    try {
+      const user = await this.usersRepository.findOneByEmail(command.email);
+      if (!user) {
+        throw new UserNotFoundError(command.email);
+      }
+
+      if (user.systemRole === SystemRole.SUPER_ADMIN) {
+        return user;
+      }
+
+      user.systemRole = SystemRole.SUPER_ADMIN;
+
+      return await this.usersRepository.update(user);
+    } catch (error) {
+      if (error instanceof ApplicationError) {
+        throw error;
+      }
+      this.logger.error('Error promoting user to super admin', {
+        error: error instanceof Error ? error.message : 'Unknown error',
+      });
+      throw new UserUnexpectedError(error as Error);
+    }
+  }
+}

--- a/ayunis-core-backend/src/iam/users/application/use-cases/update-user-role/update-user-role.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/update-user-role/update-user-role.use-case.spec.ts
@@ -107,7 +107,7 @@ describe('UpdateUserRoleUseCase', () => {
 
     await expect(useCase.execute(command)).rejects.toThrow(UserUnexpectedError);
     await expect(useCase.execute(command)).rejects.toThrow(
-      'An unexpected error occurred while updating user role',
+      'An unexpected error occurred',
     );
     expect(mockUsersRepository.findOneById).toHaveBeenCalledWith('user-id');
     expect(mockUsersRepository.update).toHaveBeenCalledWith(mockUser);

--- a/ayunis-core-backend/src/iam/users/application/use-cases/validate-password-reset-token/validate-password-reset-token.use-case.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/validate-password-reset-token/validate-password-reset-token.use-case.ts
@@ -3,7 +3,7 @@ import { ValidatePasswordResetTokenQuery } from './validate-password-reset-token
 import { PasswordResetJwtService } from '../../services/password-reset-jwt.service';
 import { InvalidTokenError } from 'src/iam/authentication/application/authentication.errors';
 import { ApplicationError } from 'src/common/errors/base.error';
-import { UnexpectedUserError } from '../../users.errors';
+import { UserUnexpectedError } from '../../users.errors';
 
 @Injectable()
 export class ValidatePasswordResetTokenUseCase {
@@ -23,7 +23,7 @@ export class ValidatePasswordResetTokenUseCase {
       if (error instanceof InvalidTokenError) return false;
       if (error instanceof ApplicationError) throw error;
       this.logger.error('Error validating password');
-      throw new UnexpectedUserError(error as Error);
+      throw new UserUnexpectedError(error as Error);
     }
   }
 }

--- a/ayunis-core-backend/src/iam/users/application/use-cases/validate-user/validate-user.use-case.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/validate-user/validate-user.use-case.ts
@@ -29,7 +29,7 @@ export class ValidateUserUseCase {
         this.logger.warn('User not found during validation', {
           email: query.email,
         });
-        throw new UserNotFoundError('User not found');
+        throw new UserNotFoundError('unknown');
       }
 
       this.logger.debug('Validating password', { userId: user.id });

--- a/ayunis-core-backend/src/iam/users/application/users.errors.ts
+++ b/ayunis-core-backend/src/iam/users/application/users.errors.ts
@@ -14,9 +14,11 @@ export enum UserErrorCode {
   USER_EMAIL_MISMATCH = 'USER_EMAIL_MISMATCH',
   INVALID_EMAIL_CONFIRMATION_TOKEN = 'INVALID_EMAIL_CONFIRMATION_TOKEN',
   EMAIL_ALREADY_VERIFIED = 'EMAIL_ALREADY_VERIFIED',
-  UNEXPECTED_USER_ERROR = 'UNEXPECTED_USER_ERROR',
   PASSWORD_RESET_EMAIL_SENDING_FAILED = 'PASSWORD_RESET_EMAIL_SENDING_FAILED',
   USER_EMAIL_PROVIDER_BLACKLISTED = 'USER_EMAIL_PROVIDER_BLACKLISTED',
+  USER_NOT_SUPER_ADMIN = 'USER_NOT_SUPER_ADMIN',
+  USER_SELF_DEMOTION_NOT_ALLOWED = 'USER_SELF_DEMOTION_NOT_ALLOWED',
+  USER_LAST_SUPER_ADMIN = 'USER_LAST_SUPER_ADMIN',
 }
 
 /**
@@ -34,9 +36,11 @@ export abstract class UserError extends ApplicationError {
 }
 
 export class UserUnexpectedError extends UserError {
-  constructor(error: Error, metadata?: ErrorMetadata) {
+  constructor(error: Error, context?: string, metadata?: ErrorMetadata) {
     super(
-      'An unexpected error occurred while updating user role',
+      context
+        ? `An unexpected error occurred: ${context}`
+        : 'An unexpected error occurred',
       UserErrorCode.USER_UNEXPECTED_ERROR,
       500,
       {
@@ -51,9 +55,9 @@ export class UserUnexpectedError extends UserError {
  * Error thrown when a user is not found
  */
 export class UserNotFoundError extends UserError {
-  constructor(userId: string, metadata?: ErrorMetadata) {
+  constructor(identifier: string, metadata?: ErrorMetadata) {
     super(
-      `User with ID '${userId}' not found`,
+      `User '${identifier}' not found`,
       UserErrorCode.USER_NOT_FOUND,
       404,
       metadata,
@@ -170,15 +174,34 @@ export class PasswordResetEmailSendingFailedError extends UserError {
   }
 }
 
-/**
- * Error thrown when an unexpected error occurs
- */
-export class UnexpectedUserError extends UserError {
-  constructor(error: Error, metadata?: ErrorMetadata) {
+export class UserNotSuperAdminError extends UserError {
+  constructor(userId: string, metadata?: ErrorMetadata) {
     super(
-      `Unexpected user error: ${error.message}`,
-      UserErrorCode.UNEXPECTED_USER_ERROR,
-      500,
+      `User '${userId}' is not a super admin`,
+      UserErrorCode.USER_NOT_SUPER_ADMIN,
+      422,
+      metadata,
+    );
+  }
+}
+
+export class UserSelfDemotionNotAllowedError extends UserError {
+  constructor(metadata?: ErrorMetadata) {
+    super(
+      'Cannot remove your own super admin status',
+      UserErrorCode.USER_SELF_DEMOTION_NOT_ALLOWED,
+      403,
+      metadata,
+    );
+  }
+}
+
+export class UserLastSuperAdminError extends UserError {
+  constructor(metadata?: ErrorMetadata) {
+    super(
+      'Cannot demote the last super admin',
+      UserErrorCode.USER_LAST_SUPER_ADMIN,
+      409,
       metadata,
     );
   }

--- a/ayunis-core-backend/src/iam/users/infrastructure/repositories/local/local-users.repository.ts
+++ b/ayunis-core-backend/src/iam/users/infrastructure/repositories/local/local-users.repository.ts
@@ -5,6 +5,7 @@ import {
   UsersFilters,
 } from 'src/iam/users/application/ports/users.repository';
 import { User } from 'src/iam/users/domain/user.entity';
+import type { SystemRole } from 'src/iam/users/domain/value-objects/system-role.enum';
 import { UUID } from 'crypto';
 import { Repository, ILike } from 'typeorm';
 import { UserRecord } from './schema/user.record';
@@ -69,6 +70,17 @@ export class LocalUsersRepository extends UsersRepository {
     this.logger.debug('Found users by emails', {
       requestedCount: emails.length,
       foundCount: userRecords.length,
+    });
+
+    return userRecords.map((record) => UserMapper.toDomain(record));
+  }
+
+  async findManyBySystemRole(role: SystemRole): Promise<User[]> {
+    this.logger.log('findManyBySystemRole', { role });
+
+    const userRecords = await this.userRepository.find({
+      where: { systemRole: role },
+      order: { createdAt: 'DESC' },
     });
 
     return userRecords.map((record) => UserMapper.toDomain(record));
@@ -157,7 +169,7 @@ export class LocalUsersRepository extends UsersRepository {
       this.logger.warn('Attempted to update non-existent user', {
         userId: user.id,
       });
-      throw new UserNotFoundError(`User with ID ${user.id} not found`);
+      throw new UserNotFoundError(user.id);
     }
 
     const userEntity = UserMapper.toEntity(user);
@@ -177,7 +189,7 @@ export class LocalUsersRepository extends UsersRepository {
       this.logger.warn('Attempted to delete non-existent user', {
         userId: id,
       });
-      throw new UserNotFoundError(`User with ID ${id} not found`);
+      throw new UserNotFoundError(id);
     }
 
     await this.userRepository.delete(id);
@@ -190,7 +202,7 @@ export class LocalUsersRepository extends UsersRepository {
     const user = await this.findOneByEmail(email);
     if (!user) {
       this.logger.warn('User not found during validation', { email });
-      throw new UserNotFoundError(`User with email ${email} not found`);
+      throw new UserNotFoundError(email);
     }
 
     // In a real implementation, this would validate the password hash

--- a/ayunis-core-backend/src/iam/users/presenters/http/dtos/promote-to-super-admin.dto.ts
+++ b/ayunis-core-backend/src/iam/users/presenters/http/dtos/promote-to-super-admin.dto.ts
@@ -1,0 +1,12 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsEmail, IsNotEmpty } from 'class-validator';
+
+export class PromoteToSuperAdminDto {
+  @ApiProperty({
+    description: 'Email address of the user to promote to super admin',
+    example: 'user@example.com',
+  })
+  @IsEmail()
+  @IsNotEmpty()
+  email: string;
+}

--- a/ayunis-core-backend/src/iam/users/presenters/http/dtos/super-admin-user-response.dto.ts
+++ b/ayunis-core-backend/src/iam/users/presenters/http/dtos/super-admin-user-response.dto.ts
@@ -1,0 +1,12 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { UserResponseDto } from './user-response.dto';
+import { SystemRole } from '../../../domain/value-objects/system-role.enum';
+
+export class SuperAdminUserResponseDto extends UserResponseDto {
+  @ApiProperty({
+    description: 'System-level role of the user',
+    enum: SystemRole,
+    example: SystemRole.SUPER_ADMIN,
+  })
+  systemRole: SystemRole;
+}

--- a/ayunis-core-backend/src/iam/users/presenters/http/mappers/super-admin-user-response-dto.mapper.ts
+++ b/ayunis-core-backend/src/iam/users/presenters/http/mappers/super-admin-user-response-dto.mapper.ts
@@ -1,0 +1,16 @@
+import { Injectable } from '@nestjs/common';
+import { SuperAdminUserResponseDto } from '../dtos/super-admin-user-response.dto';
+import { UserResponseDtoMapper } from './user-response-dto.mapper';
+import { User } from '../../../domain/user.entity';
+
+@Injectable()
+export class SuperAdminUserResponseDtoMapper {
+  constructor(private readonly userResponseDtoMapper: UserResponseDtoMapper) {}
+
+  toDto(user: User): SuperAdminUserResponseDto {
+    return {
+      ...this.userResponseDtoMapper.toDto(user),
+      systemRole: user.systemRole,
+    };
+  }
+}

--- a/ayunis-core-backend/src/iam/users/presenters/http/super-admin-management.controller.ts
+++ b/ayunis-core-backend/src/iam/users/presenters/http/super-admin-management.controller.ts
@@ -1,0 +1,157 @@
+import {
+  Controller,
+  Get,
+  Delete,
+  Post,
+  Logger,
+  Param,
+  Body,
+  HttpCode,
+  HttpStatus,
+  ParseUUIDPipe,
+} from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiParam,
+  ApiBody,
+  ApiUnauthorizedResponse,
+  ApiNotFoundResponse,
+  ApiForbiddenResponse,
+  ApiConflictResponse,
+  ApiUnprocessableEntityResponse,
+} from '@nestjs/swagger';
+import { FindSuperAdminsUseCase } from '../../application/use-cases/find-super-admins/find-super-admins.use-case';
+import { PromoteToSuperAdminUseCase } from '../../application/use-cases/promote-to-super-admin/promote-to-super-admin.use-case';
+import { PromoteToSuperAdminCommand } from '../../application/use-cases/promote-to-super-admin/promote-to-super-admin.command';
+import { DemoteFromSuperAdminUseCase } from '../../application/use-cases/demote-from-super-admin/demote-from-super-admin.use-case';
+import { DemoteFromSuperAdminCommand } from '../../application/use-cases/demote-from-super-admin/demote-from-super-admin.command';
+import { SuperAdminUserResponseDtoMapper } from './mappers/super-admin-user-response-dto.mapper';
+import { SuperAdminUserResponseDto } from './dtos/super-admin-user-response.dto';
+import { PromoteToSuperAdminDto } from './dtos/promote-to-super-admin.dto';
+import { UUID } from 'crypto';
+import { SystemRoles } from 'src/iam/authorization/application/decorators/system-roles.decorator';
+import { SystemRole } from 'src/iam/users/domain/value-objects/system-role.enum';
+import {
+  CurrentUser,
+  UserProperty,
+} from 'src/iam/authentication/application/decorators/current-user.decorator';
+
+@ApiTags('Super Admin Management')
+@Controller('super-admin/super-admins')
+@SystemRoles(SystemRole.SUPER_ADMIN)
+export class SuperAdminManagementController {
+  private readonly logger = new Logger(SuperAdminManagementController.name);
+
+  constructor(
+    private readonly findSuperAdminsUseCase: FindSuperAdminsUseCase,
+    private readonly promoteToSuperAdminUseCase: PromoteToSuperAdminUseCase,
+    private readonly demoteFromSuperAdminUseCase: DemoteFromSuperAdminUseCase,
+    private readonly superAdminUserResponseDtoMapper: SuperAdminUserResponseDtoMapper,
+  ) {}
+
+  @Get()
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'List all super admins',
+    description:
+      'Retrieve all users with super admin status. Only accessible to super admins.',
+  })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'List of super admins',
+    type: [SuperAdminUserResponseDto],
+  })
+  @ApiUnauthorizedResponse({
+    description: 'User not authenticated or not authorized as super admin',
+  })
+  async listSuperAdmins(): Promise<SuperAdminUserResponseDto[]> {
+    this.logger.log('listSuperAdmins');
+
+    const superAdmins = await this.findSuperAdminsUseCase.execute();
+
+    return superAdmins.map((user) =>
+      this.superAdminUserResponseDtoMapper.toDto(user),
+    );
+  }
+
+  @Post()
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Promote a user to super admin',
+    description:
+      'Promote an existing user to super admin by email address. Idempotent if user is already a super admin.',
+  })
+  @ApiBody({
+    type: PromoteToSuperAdminDto,
+    description: 'Email of the user to promote',
+  })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'User promoted to super admin (or already a super admin)',
+    type: SuperAdminUserResponseDto,
+  })
+  @ApiNotFoundResponse({
+    description: 'User with the given email not found',
+  })
+  @ApiUnauthorizedResponse({
+    description: 'User not authenticated or not authorized as super admin',
+  })
+  async promoteToSuperAdmin(
+    @Body() dto: PromoteToSuperAdminDto,
+  ): Promise<SuperAdminUserResponseDto> {
+    this.logger.log('promoteToSuperAdmin');
+
+    const user = await this.promoteToSuperAdminUseCase.execute(
+      new PromoteToSuperAdminCommand({ email: dto.email }),
+    );
+
+    return this.superAdminUserResponseDtoMapper.toDto(user);
+  }
+
+  @Delete(':userId')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({
+    summary: 'Remove super admin status from a user',
+    description:
+      'Demote a user from super admin to customer. Cannot demote yourself.',
+  })
+  @ApiParam({
+    name: 'userId',
+    description: 'User ID to demote',
+    format: 'uuid',
+    example: '123e4567-e89b-12d3-a456-426614174000',
+  })
+  @ApiResponse({
+    status: HttpStatus.NO_CONTENT,
+    description: 'Super admin status removed',
+  })
+  @ApiNotFoundResponse({
+    description: 'User not found',
+  })
+  @ApiForbiddenResponse({
+    description: 'Cannot remove your own super admin status',
+  })
+  @ApiUnprocessableEntityResponse({
+    description: 'User is not a super admin',
+  })
+  @ApiConflictResponse({
+    description: 'Cannot demote the last super admin',
+  })
+  @ApiUnauthorizedResponse({
+    description: 'User not authenticated or not authorized as super admin',
+  })
+  async demoteFromSuperAdmin(
+    @Param('userId', ParseUUIDPipe) userId: UUID,
+    @CurrentUser(UserProperty.ID) requestingUserId: UUID,
+  ): Promise<void> {
+    this.logger.log(
+      `demoteFromSuperAdmin userId=${userId} requestingUserId=${requestingUserId}`,
+    );
+
+    await this.demoteFromSuperAdminUseCase.execute(
+      new DemoteFromSuperAdminCommand({ userId, requestingUserId }),
+    );
+  }
+}

--- a/ayunis-core-backend/src/iam/users/users.module.ts
+++ b/ayunis-core-backend/src/iam/users/users.module.ts
@@ -31,6 +31,7 @@ import { EmailConfirmationJwtService } from './application/services/email-confir
 // Import controllers and mappers
 import { UserController } from './presenters/http/user.controller';
 import { UserResponseDtoMapper } from './presenters/http/mappers/user-response-dto.mapper';
+import { SuperAdminUserResponseDtoMapper } from './presenters/http/mappers/super-admin-user-response-dto.mapper';
 import { SendConfirmationEmailUseCase } from './application/use-cases/send-confirmation-email/send-confirmation-email.use-case';
 import { TriggerPasswordResetUseCase } from './application/use-cases/trigger-password-reset/trigger-password-reset.use-case';
 import { ResetPasswordUseCase } from './application/use-cases/reset-password/reset-password.use-case';
@@ -43,6 +44,10 @@ import { AdminTriggerPasswordResetUseCase } from './application/use-cases/admin-
 import { WebhooksModule } from 'src/common/webhooks/webhooks.module';
 import { InvitesModule } from '../invites/invites.module';
 import { SuperAdminUsersController } from './presenters/http/super-admin-users.controller';
+import { SuperAdminManagementController } from './presenters/http/super-admin-management.controller';
+import { FindSuperAdminsUseCase } from './application/use-cases/find-super-admins/find-super-admins.use-case';
+import { PromoteToSuperAdminUseCase } from './application/use-cases/promote-to-super-admin/promote-to-super-admin.use-case';
+import { DemoteFromSuperAdminUseCase } from './application/use-cases/demote-from-super-admin/demote-from-super-admin.use-case';
 
 @Module({
   imports: [
@@ -69,7 +74,11 @@ import { SuperAdminUsersController } from './presenters/http/super-admin-users.c
       }),
     }),
   ],
-  controllers: [UserController, SuperAdminUsersController],
+  controllers: [
+    UserController,
+    SuperAdminUsersController,
+    SuperAdminManagementController,
+  ],
   providers: [
     {
       provide: UsersRepository,
@@ -102,10 +111,14 @@ import { SuperAdminUsersController } from './presenters/http/super-admin-users.c
     FindUserByEmailUseCase,
     FindAllUserIdsByOrgIdUseCase,
     AdminTriggerPasswordResetUseCase,
+    FindSuperAdminsUseCase,
+    PromoteToSuperAdminUseCase,
+    DemoteFromSuperAdminUseCase,
     // Services
     EmailConfirmationJwtService,
     // Mappers
     UserResponseDtoMapper,
+    SuperAdminUserResponseDtoMapper,
   ],
   exports: [
     CreateAdminUserUseCase,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Adds privilege-management logic (promote/demote `SystemRole.SUPER_ADMIN`) and new HTTP endpoints; mistakes could enable unintended escalation or lock out the last super admin.
> 
> **Overview**
> Introduces **super admin management** via `SuperAdminManagementController` (`GET /super-admin/super-admins`, `POST` promote by email, `DELETE` demote by userId), wired into `UsersModule` and guarded by `@SystemRoles(SystemRole.SUPER_ADMIN)`.
> 
> Adds supporting application logic and persistence: `FindSuperAdminsUseCase`, `PromoteToSuperAdminUseCase` (idempotent), `DemoteFromSuperAdminUseCase` (prevents self-demotion and demoting the last super admin), plus `UsersRepository.findManyBySystemRole` and its `LocalUsersRepository` implementation.
> 
> Refactors user error handling by removing `UnexpectedUserError`, generalizing `UserUnexpectedError`/`UserNotFoundError` messages, and updating affected use cases/tests; includes minor test-only type import cleanups and a `package-lock.json` tweak marking `@swc/*` deps as `devOptional`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e53ddd5f6730659043bd356ec5ea969a7feba051. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->