### PR TITLE
feat(AYC-105): add super admins management page with list, promote, and demote

### DIFF
--- a/ayunis-core-backend/.nsprc
+++ b/ayunis-core-backend/.nsprc
@@ -1,10 +1,6 @@
 {
-  "1113331": {
+  "1113567": {
     "active": true,
-    "notes": "fast-xml-parser DoS via DOCTYPE entity expansion — only affects minio which parses XML from our own MinIO server, not untrusted input. Waiting for minio to upgrade to fast-xml-parser v5."
-  },
-  "1113407": {
-    "active": true,
-    "notes": "fast-xml-parser entity encoding bypass via regex injection — only affects minio which parses XML from our own MinIO server, not untrusted input. Waiting for minio to upgrade to fast-xml-parser v5."
+    "notes": "fast-xml-parser entity encoding bypass via regex injection in DOCTYPE entity names — only affects minio which parses XML from our own MinIO server, not untrusted input. Waiting for minio to upgrade to fast-xml-parser v5."
   }
 }

--- a/ayunis-core-frontend/src/app/routeTree.gen.ts
+++ b/ayunis-core-frontend/src/app/routeTree.gen.ts
@@ -42,6 +42,7 @@ import { Route as AuthenticatedAdminSettingsIntegrationsImport } from './routes/
 import { Route as onboardingPasswordResetImport } from './routes/(onboarding)/password.reset'
 import { Route as onboardingPasswordForgotImport } from './routes/(onboarding)/password.forgot'
 import { Route as AuthenticatedSuperAdminSettingsUsageIndexImport } from './routes/_authenticated/super-admin-settings.usage.index'
+import { Route as AuthenticatedSuperAdminSettingsSuperAdminsIndexImport } from './routes/_authenticated/super-admin-settings.super-admins.index'
 import { Route as AuthenticatedSuperAdminSettingsSkillsIndexImport } from './routes/_authenticated/super-admin-settings.skills.index'
 import { Route as AuthenticatedSuperAdminSettingsOrgsIndexImport } from './routes/_authenticated/super-admin-settings.orgs.index'
 import { Route as AuthenticatedSuperAdminSettingsModelsCatalogIndexImport } from './routes/_authenticated/super-admin-settings.models-catalog.index'
@@ -248,6 +249,13 @@ const AuthenticatedSuperAdminSettingsUsageIndexRoute =
   AuthenticatedSuperAdminSettingsUsageIndexImport.update({
     id: '/super-admin-settings/usage/',
     path: '/super-admin-settings/usage/',
+    getParentRoute: () => AuthenticatedRoute,
+  } as any)
+
+const AuthenticatedSuperAdminSettingsSuperAdminsIndexRoute =
+  AuthenticatedSuperAdminSettingsSuperAdminsIndexImport.update({
+    id: '/super-admin-settings/super-admins/',
+    path: '/super-admin-settings/super-admins/',
     getParentRoute: () => AuthenticatedRoute,
   } as any)
 
@@ -549,6 +557,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedSuperAdminSettingsSkillsIndexImport
       parentRoute: typeof AuthenticatedImport
     }
+    '/_authenticated/super-admin-settings/super-admins/': {
+      id: '/_authenticated/super-admin-settings/super-admins/'
+      path: '/super-admin-settings/super-admins'
+      fullPath: '/super-admin-settings/super-admins'
+      preLoaderRoute: typeof AuthenticatedSuperAdminSettingsSuperAdminsIndexImport
+      parentRoute: typeof AuthenticatedImport
+    }
     '/_authenticated/super-admin-settings/usage/': {
       id: '/_authenticated/super-admin-settings/usage/'
       path: '/super-admin-settings/usage'
@@ -589,6 +604,7 @@ interface AuthenticatedRouteChildren {
   AuthenticatedSuperAdminSettingsModelsCatalogIndexRoute: typeof AuthenticatedSuperAdminSettingsModelsCatalogIndexRoute
   AuthenticatedSuperAdminSettingsOrgsIndexRoute: typeof AuthenticatedSuperAdminSettingsOrgsIndexRoute
   AuthenticatedSuperAdminSettingsSkillsIndexRoute: typeof AuthenticatedSuperAdminSettingsSkillsIndexRoute
+  AuthenticatedSuperAdminSettingsSuperAdminsIndexRoute: typeof AuthenticatedSuperAdminSettingsSuperAdminsIndexRoute
   AuthenticatedSuperAdminSettingsUsageIndexRoute: typeof AuthenticatedSuperAdminSettingsUsageIndexRoute
 }
 
@@ -628,6 +644,8 @@ const AuthenticatedRouteChildren: AuthenticatedRouteChildren = {
     AuthenticatedSuperAdminSettingsOrgsIndexRoute,
   AuthenticatedSuperAdminSettingsSkillsIndexRoute:
     AuthenticatedSuperAdminSettingsSkillsIndexRoute,
+  AuthenticatedSuperAdminSettingsSuperAdminsIndexRoute:
+    AuthenticatedSuperAdminSettingsSuperAdminsIndexRoute,
   AuthenticatedSuperAdminSettingsUsageIndexRoute:
     AuthenticatedSuperAdminSettingsUsageIndexRoute,
 }
@@ -673,6 +691,7 @@ export interface FileRoutesByFullPath {
   '/super-admin-settings/models-catalog': typeof AuthenticatedSuperAdminSettingsModelsCatalogIndexRoute
   '/super-admin-settings/orgs': typeof AuthenticatedSuperAdminSettingsOrgsIndexRoute
   '/super-admin-settings/skills': typeof AuthenticatedSuperAdminSettingsSkillsIndexRoute
+  '/super-admin-settings/super-admins': typeof AuthenticatedSuperAdminSettingsSuperAdminsIndexRoute
   '/super-admin-settings/usage': typeof AuthenticatedSuperAdminSettingsUsageIndexRoute
 }
 
@@ -713,6 +732,7 @@ export interface FileRoutesByTo {
   '/super-admin-settings/models-catalog': typeof AuthenticatedSuperAdminSettingsModelsCatalogIndexRoute
   '/super-admin-settings/orgs': typeof AuthenticatedSuperAdminSettingsOrgsIndexRoute
   '/super-admin-settings/skills': typeof AuthenticatedSuperAdminSettingsSkillsIndexRoute
+  '/super-admin-settings/super-admins': typeof AuthenticatedSuperAdminSettingsSuperAdminsIndexRoute
   '/super-admin-settings/usage': typeof AuthenticatedSuperAdminSettingsUsageIndexRoute
 }
 
@@ -754,6 +774,7 @@ export interface FileRoutesById {
   '/_authenticated/super-admin-settings/models-catalog/': typeof AuthenticatedSuperAdminSettingsModelsCatalogIndexRoute
   '/_authenticated/super-admin-settings/orgs/': typeof AuthenticatedSuperAdminSettingsOrgsIndexRoute
   '/_authenticated/super-admin-settings/skills/': typeof AuthenticatedSuperAdminSettingsSkillsIndexRoute
+  '/_authenticated/super-admin-settings/super-admins/': typeof AuthenticatedSuperAdminSettingsSuperAdminsIndexRoute
   '/_authenticated/super-admin-settings/usage/': typeof AuthenticatedSuperAdminSettingsUsageIndexRoute
 }
 
@@ -796,6 +817,7 @@ export interface FileRouteTypes {
     | '/super-admin-settings/models-catalog'
     | '/super-admin-settings/orgs'
     | '/super-admin-settings/skills'
+    | '/super-admin-settings/super-admins'
     | '/super-admin-settings/usage'
   fileRoutesByTo: FileRoutesByTo
   to:
@@ -835,6 +857,7 @@ export interface FileRouteTypes {
     | '/super-admin-settings/models-catalog'
     | '/super-admin-settings/orgs'
     | '/super-admin-settings/skills'
+    | '/super-admin-settings/super-admins'
     | '/super-admin-settings/usage'
   id:
     | '__root__'
@@ -874,6 +897,7 @@ export interface FileRouteTypes {
     | '/_authenticated/super-admin-settings/models-catalog/'
     | '/_authenticated/super-admin-settings/orgs/'
     | '/_authenticated/super-admin-settings/skills/'
+    | '/_authenticated/super-admin-settings/super-admins/'
     | '/_authenticated/super-admin-settings/usage/'
   fileRoutesById: FileRoutesById
 }
@@ -956,6 +980,7 @@ export const routeTree = rootRoute
         "/_authenticated/super-admin-settings/models-catalog/",
         "/_authenticated/super-admin-settings/orgs/",
         "/_authenticated/super-admin-settings/skills/",
+        "/_authenticated/super-admin-settings/super-admins/",
         "/_authenticated/super-admin-settings/usage/"
       ]
     },
@@ -1086,6 +1111,10 @@ export const routeTree = rootRoute
     },
     "/_authenticated/super-admin-settings/skills/": {
       "filePath": "_authenticated/super-admin-settings.skills.index.tsx",
+      "parent": "/_authenticated"
+    },
+    "/_authenticated/super-admin-settings/super-admins/": {
+      "filePath": "_authenticated/super-admin-settings.super-admins.index.tsx",
       "parent": "/_authenticated"
     },
     "/_authenticated/super-admin-settings/usage/": {

--- a/ayunis-core-frontend/src/app/routes/_authenticated/super-admin-settings.super-admins.index.tsx
+++ b/ayunis-core-frontend/src/app/routes/_authenticated/super-admin-settings.super-admins.index.tsx
@@ -1,0 +1,24 @@
+import { createFileRoute } from '@tanstack/react-router';
+import SuperAdminSuperAdminsPage from '@/pages/super-admin-settings/super-admins';
+import {
+  getSuperAdminManagementControllerListSuperAdminsQueryKey,
+  superAdminManagementControllerListSuperAdmins,
+} from '@/shared/api';
+
+export const Route = createFileRoute(
+  '/_authenticated/super-admin-settings/super-admins/',
+)({
+  component: RouteComponent,
+  loader: async ({ context: { queryClient } }) => {
+    const superAdmins = await queryClient.fetchQuery({
+      queryKey: getSuperAdminManagementControllerListSuperAdminsQueryKey(),
+      queryFn: () => superAdminManagementControllerListSuperAdmins(),
+    });
+    return { superAdmins };
+  },
+});
+
+function RouteComponent() {
+  const { superAdmins } = Route.useLoaderData();
+  return <SuperAdminSuperAdminsPage superAdmins={superAdmins} />;
+}

--- a/ayunis-core-frontend/src/i18n.ts
+++ b/ayunis-core-frontend/src/i18n.ts
@@ -48,6 +48,8 @@ import enKnowledgeBases from './shared/locales/en/knowledge-bases.json';
 import deKnowledgeBases from './shared/locales/de/knowledge-bases.json';
 import enSuperAdminSettingsSkills from './shared/locales/en/super-admin-settings-skills.json';
 import deSuperAdminSettingsSkills from './shared/locales/de/super-admin-settings-skills.json';
+import enSuperAdminSettingsSuperAdmins from './shared/locales/en/super-admin-settings-super-admins.json';
+import deSuperAdminSettingsSuperAdmins from './shared/locales/de/super-admin-settings-super-admins.json';
 
 const resources = {
   en: {
@@ -74,6 +76,7 @@ const resources = {
     skill: enSkill,
     'knowledge-bases': enKnowledgeBases,
     'super-admin-settings-skills': enSuperAdminSettingsSkills,
+    'super-admin-settings-super-admins': enSuperAdminSettingsSuperAdmins,
   },
   de: {
     auth: deAuth,
@@ -99,6 +102,7 @@ const resources = {
     skill: deSkill,
     'knowledge-bases': deKnowledgeBases,
     'super-admin-settings-skills': deSuperAdminSettingsSkills,
+    'super-admin-settings-super-admins': deSuperAdminSettingsSuperAdmins,
   },
 };
 

--- a/ayunis-core-frontend/src/pages/super-admin-settings/super-admin-settings-layout/ui/SuperAdminSettingsSidebar.tsx
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/super-admin-settings-layout/ui/SuperAdminSettingsSidebar.tsx
@@ -1,4 +1,10 @@
-import { Building2, Brain, BarChart3, Sparkles } from 'lucide-react';
+import {
+  Building2,
+  Brain,
+  BarChart3,
+  Sparkles,
+  ShieldCheck,
+} from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import {
   SettingsSidebarWidget,
@@ -28,6 +34,11 @@ export function SuperAdminSettingsSidebar() {
       to: '/super-admin-settings/skills',
       icon: <Sparkles />,
       label: t('layout.skills'),
+    },
+    {
+      to: '/super-admin-settings/super-admins',
+      icon: <ShieldCheck />,
+      label: t('layout.superAdmins'),
     },
   ];
 

--- a/ayunis-core-frontend/src/pages/super-admin-settings/super-admins/api/useAddSuperAdmin.ts
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/super-admins/api/useAddSuperAdmin.ts
@@ -1,0 +1,61 @@
+import {
+  useSuperAdminManagementControllerPromoteToSuperAdmin,
+  getSuperAdminManagementControllerListSuperAdminsQueryKey,
+  type PromoteToSuperAdminDto,
+} from '@/shared/api';
+import { useQueryClient } from '@tanstack/react-query';
+import { useRouter } from '@tanstack/react-router';
+import { useTranslation } from 'react-i18next';
+import { showError, showSuccess } from '@/shared/lib/toast';
+import extractErrorData from '@/shared/api/extract-error-data';
+
+interface UseAddSuperAdminOptions {
+  onSuccessCallback?: () => void;
+}
+
+const ADD_ERROR_MAP: Record<string, string> = {
+  USER_NOT_FOUND: 'addSuperAdmin.errorNotFound',
+};
+
+export function useAddSuperAdmin(options?: UseAddSuperAdminOptions) {
+  const { t } = useTranslation('super-admin-settings-super-admins');
+  const queryClient = useQueryClient();
+  const router = useRouter();
+
+  const mutation = useSuperAdminManagementControllerPromoteToSuperAdmin({
+    mutation: {
+      onSuccess: () => {
+        showSuccess(t('addSuperAdmin.success'));
+        options?.onSuccessCallback?.();
+      },
+      onError: (error: unknown) => {
+        try {
+          const { code } = extractErrorData(error);
+          const mappedKey = ADD_ERROR_MAP[code];
+          if (mappedKey) {
+            showError(t(mappedKey));
+          } else {
+            showError(t('addSuperAdmin.error'));
+          }
+        } catch {
+          showError(t('addSuperAdmin.error'));
+        }
+      },
+      onSettled: async () => {
+        await queryClient.invalidateQueries({
+          queryKey: getSuperAdminManagementControllerListSuperAdminsQueryKey(),
+        });
+        await router.invalidate();
+      },
+    },
+  });
+
+  function addSuperAdmin(data: PromoteToSuperAdminDto) {
+    mutation.mutate({ data });
+  }
+
+  return {
+    addSuperAdmin,
+    isAdding: mutation.isPending,
+  };
+}

--- a/ayunis-core-frontend/src/pages/super-admin-settings/super-admins/api/useRemoveSuperAdmin.ts
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/super-admins/api/useRemoveSuperAdmin.ts
@@ -1,0 +1,58 @@
+import {
+  useSuperAdminManagementControllerDemoteFromSuperAdmin,
+  getSuperAdminManagementControllerListSuperAdminsQueryKey,
+} from '@/shared/api';
+import { useQueryClient } from '@tanstack/react-query';
+import { useRouter } from '@tanstack/react-router';
+import { useTranslation } from 'react-i18next';
+import { showError, showSuccess } from '@/shared/lib/toast';
+import extractErrorData from '@/shared/api/extract-error-data';
+
+const REMOVE_ERROR_MAP: Record<string, string> = {
+  USER_SELF_DEMOTION_NOT_ALLOWED: 'removeSuperAdmin.errorSelfDemotion',
+  USER_LAST_SUPER_ADMIN: 'removeSuperAdmin.errorLastAdmin',
+  USER_NOT_SUPER_ADMIN: 'removeSuperAdmin.errorNotSuperAdmin',
+  USER_NOT_FOUND: 'removeSuperAdmin.errorNotFound',
+};
+
+export function useRemoveSuperAdmin() {
+  const { t } = useTranslation('super-admin-settings-super-admins');
+  const queryClient = useQueryClient();
+  const router = useRouter();
+
+  const mutation = useSuperAdminManagementControllerDemoteFromSuperAdmin({
+    mutation: {
+      onSuccess: () => {
+        showSuccess(t('removeSuperAdmin.success'));
+      },
+      onError: (error: unknown) => {
+        try {
+          const { code } = extractErrorData(error);
+          const mappedKey = REMOVE_ERROR_MAP[code];
+          if (mappedKey) {
+            showError(t(mappedKey));
+          } else {
+            showError(t('removeSuperAdmin.error'));
+          }
+        } catch {
+          showError(t('removeSuperAdmin.error'));
+        }
+      },
+      onSettled: async () => {
+        await queryClient.invalidateQueries({
+          queryKey: getSuperAdminManagementControllerListSuperAdminsQueryKey(),
+        });
+        await router.invalidate();
+      },
+    },
+  });
+
+  function removeSuperAdmin(userId: string) {
+    mutation.mutate({ userId });
+  }
+
+  return {
+    removeSuperAdmin,
+    isRemoving: mutation.isPending,
+  };
+}

--- a/ayunis-core-frontend/src/pages/super-admin-settings/super-admins/index.ts
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/super-admins/index.ts
@@ -1,0 +1,3 @@
+import SuperAdminSuperAdminsPage from './ui/Page';
+
+export default SuperAdminSuperAdminsPage;

--- a/ayunis-core-frontend/src/pages/super-admin-settings/super-admins/ui/AddSuperAdminDialog.tsx
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/super-admins/ui/AddSuperAdminDialog.tsx
@@ -1,0 +1,115 @@
+import { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { useTranslation } from 'react-i18next';
+import { Button } from '@/shared/ui/shadcn/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/shared/ui/shadcn/dialog';
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/shared/ui/shadcn/form';
+import { Input } from '@/shared/ui/shadcn/input';
+import { useAddSuperAdmin } from '../api/useAddSuperAdmin';
+
+interface AddSuperAdminFormData {
+  email: string;
+}
+
+export default function AddSuperAdminDialog() {
+  const { t } = useTranslation('super-admin-settings-super-admins');
+  const [isOpen, setIsOpen] = useState(false);
+
+  const form = useForm<AddSuperAdminFormData>({
+    defaultValues: { email: '' },
+  });
+
+  const { addSuperAdmin, isAdding: isLoading } = useAddSuperAdmin({
+    onSuccessCallback: () => {
+      setIsOpen(false);
+      form.reset();
+    },
+  });
+
+  function onSubmit(data: AddSuperAdminFormData) {
+    addSuperAdmin({ email: data.email.trim() });
+  }
+
+  function handleOpenChange(open: boolean) {
+    if (!open && !isLoading) {
+      form.reset();
+    }
+    setIsOpen(open);
+  }
+
+  return (
+    <Dialog open={isOpen} onOpenChange={handleOpenChange}>
+      <DialogTrigger asChild>
+        <Button size="sm">{t('actions.addSuperAdmin')}</Button>
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-[480px]">
+        <DialogHeader>
+          <DialogTitle>{t('dialog.title')}</DialogTitle>
+          <DialogDescription>{t('dialog.description')}</DialogDescription>
+        </DialogHeader>
+        <Form {...form}>
+          <form
+            onSubmit={(e) => {
+              void form.handleSubmit(onSubmit)(e);
+            }}
+            className="space-y-4"
+          >
+            <FormField
+              control={form.control}
+              name="email"
+              rules={{
+                required: t('dialog.emailRequired'),
+                pattern: {
+                  value: /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/i,
+                  message: t('dialog.emailInvalid'),
+                },
+              }}
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>{t('dialog.emailLabel')}</FormLabel>
+                  <FormControl>
+                    <Input
+                      type="email"
+                      placeholder={t('dialog.emailPlaceholder')}
+                      {...field}
+                      disabled={isLoading}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <DialogFooter>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => handleOpenChange(false)}
+                disabled={isLoading}
+              >
+                {t('dialog.cancel')}
+              </Button>
+              <Button type="submit" disabled={isLoading}>
+                {isLoading ? t('dialog.adding') : t('dialog.add')}
+              </Button>
+            </DialogFooter>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/ayunis-core-frontend/src/pages/super-admin-settings/super-admins/ui/Page.tsx
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/super-admins/ui/Page.tsx
@@ -1,0 +1,24 @@
+import { useTranslation } from 'react-i18next';
+import SuperAdminSettingsLayout from '../../super-admin-settings-layout';
+import AddSuperAdminDialog from './AddSuperAdminDialog';
+import SuperAdminsTable from './SuperAdminsTable';
+import type { SuperAdminUserResponseDto } from '@/shared/api';
+
+interface SuperAdminSuperAdminsPageProps {
+  superAdmins: SuperAdminUserResponseDto[];
+}
+
+export default function SuperAdminSuperAdminsPage({
+  superAdmins,
+}: Readonly<SuperAdminSuperAdminsPageProps>) {
+  const { t } = useTranslation('super-admin-settings-layout');
+
+  return (
+    <SuperAdminSettingsLayout
+      pageTitle={t('layout.superAdmins')}
+      action={<AddSuperAdminDialog />}
+    >
+      <SuperAdminsTable superAdmins={superAdmins} />
+    </SuperAdminSettingsLayout>
+  );
+}

--- a/ayunis-core-frontend/src/pages/super-admin-settings/super-admins/ui/SuperAdminsTable.tsx
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/super-admins/ui/SuperAdminsTable.tsx
@@ -1,0 +1,99 @@
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/shared/ui/shadcn/card';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/shared/ui/shadcn/table';
+import { Button } from '@/shared/ui/shadcn/button';
+import { useTranslation } from 'react-i18next';
+import type { SuperAdminUserResponseDto } from '@/shared/api';
+import { useAuthenticationControllerMe } from '@/shared/api';
+import { useRemoveSuperAdmin } from '../api/useRemoveSuperAdmin';
+import { useConfirmation } from '@/widgets/confirmation-modal';
+
+interface SuperAdminsTableProps {
+  superAdmins: SuperAdminUserResponseDto[];
+}
+
+export default function SuperAdminsTable({
+  superAdmins,
+}: Readonly<SuperAdminsTableProps>) {
+  const { t } = useTranslation('super-admin-settings-super-admins');
+  const { removeSuperAdmin, isRemoving } = useRemoveSuperAdmin();
+  const { confirm } = useConfirmation();
+  const { data: currentUser } = useAuthenticationControllerMe();
+
+  const handleRemove = (user: SuperAdminUserResponseDto) => {
+    confirm({
+      title: t('confirmRemove.title'),
+      description: t('confirmRemove.description', { name: user.name }),
+      confirmText: t('confirmRemove.confirmText'),
+      cancelText: t('confirmRemove.cancelText'),
+      variant: 'destructive',
+      onConfirm: () => {
+        removeSuperAdmin(user.id);
+      },
+    });
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{t('header.title')}</CardTitle>
+        <CardDescription>{t('header.description')}</CardDescription>
+      </CardHeader>
+      <CardContent>
+        {superAdmins.length === 0 ? (
+          <div className="flex flex-col items-center justify-center space-y-2 py-10 text-center">
+            <h3 className="text-lg font-semibold">{t('empty.title')}</h3>
+            <p className="text-sm text-muted-foreground max-w-sm">
+              {t('empty.description')}
+            </p>
+          </div>
+        ) : (
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>{t('table.name')}</TableHead>
+                <TableHead>{t('table.email')}</TableHead>
+                <TableHead className="w-[100px]" />
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {superAdmins.map((user) => (
+                <TableRow key={user.id}>
+                  <TableCell className="font-medium">{user.name}</TableCell>
+                  <TableCell>{user.email}</TableCell>
+                  <TableCell>
+                    {currentUser &&
+                      user.email.toLowerCase() !==
+                        currentUser.email.toLowerCase() && (
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          className="text-destructive"
+                          disabled={isRemoving}
+                          onClick={() => handleRemove(user)}
+                        >
+                          {t('actions.remove')}
+                        </Button>
+                      )}
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
@@ -750,6 +750,52 @@ export interface CreateUserDto {
 }
 
 /**
+ * User role
+ */
+export type SuperAdminUserResponseDtoRole = typeof SuperAdminUserResponseDtoRole[keyof typeof SuperAdminUserResponseDtoRole];
+
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const SuperAdminUserResponseDtoRole = {
+  admin: 'admin',
+  user: 'user',
+} as const;
+
+/**
+ * System-level role of the user
+ */
+export type SuperAdminUserResponseDtoSystemRole = typeof SuperAdminUserResponseDtoSystemRole[keyof typeof SuperAdminUserResponseDtoSystemRole];
+
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const SuperAdminUserResponseDtoSystemRole = {
+  customer: 'customer',
+  super_admin: 'super_admin',
+} as const;
+
+export interface SuperAdminUserResponseDto {
+  /** User unique identifier */
+  id: string;
+  /** User name */
+  name: string;
+  /** User email address */
+  email: string;
+  /** User role */
+  role: SuperAdminUserResponseDtoRole;
+  /** Organization ID the user belongs to */
+  orgId: string;
+  /** Date when the user was created */
+  createdAt: string;
+  /** System-level role of the user */
+  systemRole: SuperAdminUserResponseDtoSystemRole;
+}
+
+export interface PromoteToSuperAdminDto {
+  /** Email address of the user to promote to super admin */
+  email: string;
+}
+
+/**
  * Role to assign to the invited user
  */
 export type CreateInviteDtoRole = typeof CreateInviteDtoRole[keyof typeof CreateInviteDtoRole];

--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.ts
@@ -94,6 +94,7 @@ import type {
   PermittedLanguageModelResponseDtoNullable,
   PredefinedConfigResponseDto,
   PriceResponseDto,
+  PromoteToSuperAdminDto,
   PromptResponseDto,
   ProviderUsageChartResponseDto,
   ProviderUsageResponseDto,
@@ -133,6 +134,7 @@ import type {
   SuperAdminUsageDataControllerGetProviderUsageChartParams,
   SuperAdminUsageDataControllerGetProviderUsageParams,
   SuperAdminUsageDataControllerGetUserUsageParams,
+  SuperAdminUserResponseDto,
   SuperAdminUsersControllerGetUsersByOrgIdParams,
   TeamMemberResponseDto,
   TeamResponseDto,
@@ -3885,6 +3887,229 @@ export const useSuperAdminUsersControllerCreateUser = <TError = void,
       > => {
 
       const mutationOptions = getSuperAdminUsersControllerCreateUserMutationOptions(options);
+
+      return useMutation(mutationOptions, queryClient);
+    }
+    
+/**
+ * Retrieve all users with super admin status. Only accessible to super admins.
+ * @summary List all super admins
+ */
+export const superAdminManagementControllerListSuperAdmins = (
+    
+ signal?: AbortSignal
+) => {
+      
+      
+      return customAxiosInstance<SuperAdminUserResponseDto[]>(
+      {url: `/super-admin/super-admins`, method: 'GET', signal
+    },
+      );
+    }
+  
+
+
+
+export const getSuperAdminManagementControllerListSuperAdminsQueryKey = () => {
+    return [
+    `/super-admin/super-admins`
+    ] as const;
+    }
+
+    
+export const getSuperAdminManagementControllerListSuperAdminsQueryOptions = <TData = Awaited<ReturnType<typeof superAdminManagementControllerListSuperAdmins>>, TError = void>( options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof superAdminManagementControllerListSuperAdmins>>, TError, TData>>, }
+) => {
+
+const {query: queryOptions} = options ?? {};
+
+  const queryKey =  queryOptions?.queryKey ?? getSuperAdminManagementControllerListSuperAdminsQueryKey();
+
+  
+
+    const queryFn: QueryFunction<Awaited<ReturnType<typeof superAdminManagementControllerListSuperAdmins>>> = ({ signal }) => superAdminManagementControllerListSuperAdmins(signal);
+
+      
+
+      
+
+   return  { queryKey, queryFn, ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof superAdminManagementControllerListSuperAdmins>>, TError, TData> & { queryKey: DataTag<QueryKey, TData, TError> }
+}
+
+export type SuperAdminManagementControllerListSuperAdminsQueryResult = NonNullable<Awaited<ReturnType<typeof superAdminManagementControllerListSuperAdmins>>>
+export type SuperAdminManagementControllerListSuperAdminsQueryError = void
+
+
+export function useSuperAdminManagementControllerListSuperAdmins<TData = Awaited<ReturnType<typeof superAdminManagementControllerListSuperAdmins>>, TError = void>(
+  options: { query:Partial<UseQueryOptions<Awaited<ReturnType<typeof superAdminManagementControllerListSuperAdmins>>, TError, TData>> & Pick<
+        DefinedInitialDataOptions<
+          Awaited<ReturnType<typeof superAdminManagementControllerListSuperAdmins>>,
+          TError,
+          Awaited<ReturnType<typeof superAdminManagementControllerListSuperAdmins>>
+        > , 'initialData'
+      >, }
+ , queryClient?: QueryClient
+  ):  DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useSuperAdminManagementControllerListSuperAdmins<TData = Awaited<ReturnType<typeof superAdminManagementControllerListSuperAdmins>>, TError = void>(
+  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof superAdminManagementControllerListSuperAdmins>>, TError, TData>> & Pick<
+        UndefinedInitialDataOptions<
+          Awaited<ReturnType<typeof superAdminManagementControllerListSuperAdmins>>,
+          TError,
+          Awaited<ReturnType<typeof superAdminManagementControllerListSuperAdmins>>
+        > , 'initialData'
+      >, }
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useSuperAdminManagementControllerListSuperAdmins<TData = Awaited<ReturnType<typeof superAdminManagementControllerListSuperAdmins>>, TError = void>(
+  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof superAdminManagementControllerListSuperAdmins>>, TError, TData>>, }
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+/**
+ * @summary List all super admins
+ */
+
+export function useSuperAdminManagementControllerListSuperAdmins<TData = Awaited<ReturnType<typeof superAdminManagementControllerListSuperAdmins>>, TError = void>(
+  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof superAdminManagementControllerListSuperAdmins>>, TError, TData>>, }
+ , queryClient?: QueryClient 
+ ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
+
+  const queryOptions = getSuperAdminManagementControllerListSuperAdminsQueryOptions(options)
+
+  const query = useQuery(queryOptions, queryClient) as  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+
+  query.queryKey = queryOptions.queryKey ;
+
+  return query;
+}
+
+
+
+
+
+/**
+ * Promote an existing user to super admin by email address. Idempotent if user is already a super admin.
+ * @summary Promote a user to super admin
+ */
+export const superAdminManagementControllerPromoteToSuperAdmin = (
+    promoteToSuperAdminDto: PromoteToSuperAdminDto,
+ signal?: AbortSignal
+) => {
+      
+      
+      return customAxiosInstance<SuperAdminUserResponseDto>(
+      {url: `/super-admin/super-admins`, method: 'POST',
+      headers: {'Content-Type': 'application/json', },
+      data: promoteToSuperAdminDto, signal
+    },
+      );
+    }
+  
+
+
+export const getSuperAdminManagementControllerPromoteToSuperAdminMutationOptions = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof superAdminManagementControllerPromoteToSuperAdmin>>, TError,{data: PromoteToSuperAdminDto}, TContext>, }
+): UseMutationOptions<Awaited<ReturnType<typeof superAdminManagementControllerPromoteToSuperAdmin>>, TError,{data: PromoteToSuperAdminDto}, TContext> => {
+
+const mutationKey = ['superAdminManagementControllerPromoteToSuperAdmin'];
+const {mutation: mutationOptions} = options ?
+      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
+      options
+      : {...options, mutation: {...options.mutation, mutationKey}}
+      : {mutation: { mutationKey, }};
+
+      
+
+
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof superAdminManagementControllerPromoteToSuperAdmin>>, {data: PromoteToSuperAdminDto}> = (props) => {
+          const {data} = props ?? {};
+
+          return  superAdminManagementControllerPromoteToSuperAdmin(data,)
+        }
+
+        
+
+
+  return  { mutationFn, ...mutationOptions }}
+
+    export type SuperAdminManagementControllerPromoteToSuperAdminMutationResult = NonNullable<Awaited<ReturnType<typeof superAdminManagementControllerPromoteToSuperAdmin>>>
+    export type SuperAdminManagementControllerPromoteToSuperAdminMutationBody = PromoteToSuperAdminDto
+    export type SuperAdminManagementControllerPromoteToSuperAdminMutationError = void
+
+    /**
+ * @summary Promote a user to super admin
+ */
+export const useSuperAdminManagementControllerPromoteToSuperAdmin = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof superAdminManagementControllerPromoteToSuperAdmin>>, TError,{data: PromoteToSuperAdminDto}, TContext>, }
+ , queryClient?: QueryClient): UseMutationResult<
+        Awaited<ReturnType<typeof superAdminManagementControllerPromoteToSuperAdmin>>,
+        TError,
+        {data: PromoteToSuperAdminDto},
+        TContext
+      > => {
+
+      const mutationOptions = getSuperAdminManagementControllerPromoteToSuperAdminMutationOptions(options);
+
+      return useMutation(mutationOptions, queryClient);
+    }
+    
+/**
+ * Demote a user from super admin to customer. Cannot demote yourself.
+ * @summary Remove super admin status from a user
+ */
+export const superAdminManagementControllerDemoteFromSuperAdmin = (
+    userId: string,
+ ) => {
+      
+      
+      return customAxiosInstance<void>(
+      {url: `/super-admin/super-admins/${userId}`, method: 'DELETE'
+    },
+      );
+    }
+  
+
+
+export const getSuperAdminManagementControllerDemoteFromSuperAdminMutationOptions = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof superAdminManagementControllerDemoteFromSuperAdmin>>, TError,{userId: string}, TContext>, }
+): UseMutationOptions<Awaited<ReturnType<typeof superAdminManagementControllerDemoteFromSuperAdmin>>, TError,{userId: string}, TContext> => {
+
+const mutationKey = ['superAdminManagementControllerDemoteFromSuperAdmin'];
+const {mutation: mutationOptions} = options ?
+      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
+      options
+      : {...options, mutation: {...options.mutation, mutationKey}}
+      : {mutation: { mutationKey, }};
+
+      
+
+
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof superAdminManagementControllerDemoteFromSuperAdmin>>, {userId: string}> = (props) => {
+          const {userId} = props ?? {};
+
+          return  superAdminManagementControllerDemoteFromSuperAdmin(userId,)
+        }
+
+        
+
+
+  return  { mutationFn, ...mutationOptions }}
+
+    export type SuperAdminManagementControllerDemoteFromSuperAdminMutationResult = NonNullable<Awaited<ReturnType<typeof superAdminManagementControllerDemoteFromSuperAdmin>>>
+    
+    export type SuperAdminManagementControllerDemoteFromSuperAdminMutationError = void
+
+    /**
+ * @summary Remove super admin status from a user
+ */
+export const useSuperAdminManagementControllerDemoteFromSuperAdmin = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof superAdminManagementControllerDemoteFromSuperAdmin>>, TError,{userId: string}, TContext>, }
+ , queryClient?: QueryClient): UseMutationResult<
+        Awaited<ReturnType<typeof superAdminManagementControllerDemoteFromSuperAdmin>>,
+        TError,
+        {userId: string},
+        TContext
+      > => {
+
+      const mutationOptions = getSuperAdminManagementControllerDemoteFromSuperAdminMutationOptions(options);
 
       return useMutation(mutationOptions, queryClient);
     }

--- a/ayunis-core-frontend/src/shared/api/openapi-schema.json
+++ b/ayunis-core-frontend/src/shared/api/openapi-schema.json
@@ -1925,6 +1925,116 @@
         ]
       }
     },
+    "/super-admin/super-admins": {
+      "get": {
+        "description": "Retrieve all users with super admin status. Only accessible to super admins.",
+        "operationId": "SuperAdminManagementController_listSuperAdmins",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "List of super admins",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/SuperAdminUserResponseDto"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "User not authenticated or not authorized as super admin"
+          }
+        },
+        "summary": "List all super admins",
+        "tags": [
+          "Super Admin Management"
+        ]
+      },
+      "post": {
+        "description": "Promote an existing user to super admin by email address. Idempotent if user is already a super admin.",
+        "operationId": "SuperAdminManagementController_promoteToSuperAdmin",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "description": "Email of the user to promote",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PromoteToSuperAdminDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "User promoted to super admin (or already a super admin)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SuperAdminUserResponseDto"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "User not authenticated or not authorized as super admin"
+          },
+          "404": {
+            "description": "User with the given email not found"
+          }
+        },
+        "summary": "Promote a user to super admin",
+        "tags": [
+          "Super Admin Management"
+        ]
+      }
+    },
+    "/super-admin/super-admins/{userId}": {
+      "delete": {
+        "description": "Demote a user from super admin to customer. Cannot demote yourself.",
+        "operationId": "SuperAdminManagementController_demoteFromSuperAdmin",
+        "parameters": [
+          {
+            "name": "userId",
+            "required": true,
+            "in": "path",
+            "description": "User ID to demote",
+            "schema": {
+              "format": "uuid",
+              "example": "123e4567-e89b-12d3-a456-426614174000",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Super admin status removed"
+          },
+          "401": {
+            "description": "User not authenticated or not authorized as super admin"
+          },
+          "403": {
+            "description": "Cannot remove your own super admin status"
+          },
+          "404": {
+            "description": "User not found"
+          },
+          "409": {
+            "description": "Cannot demote the last super admin"
+          },
+          "422": {
+            "description": "User is not a super admin"
+          }
+        },
+        "summary": "Remove super admin status from a user",
+        "tags": [
+          "Super Admin Management"
+        ]
+      }
+    },
     "/invites": {
       "post": {
         "description": "Send an invitation to a user to join an organization with a specific role",
@@ -8974,6 +9084,79 @@
           "name",
           "role",
           "sendPasswordResetEmail"
+        ]
+      },
+      "SuperAdminUserResponseDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "User unique identifier",
+            "example": "123e4567-e89b-12d3-a456-426614174000",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string",
+            "description": "User name",
+            "example": "John Doe"
+          },
+          "email": {
+            "type": "string",
+            "description": "User email address",
+            "example": "john.doe@example.com"
+          },
+          "role": {
+            "type": "string",
+            "description": "User role",
+            "enum": [
+              "admin",
+              "user"
+            ],
+            "example": "user"
+          },
+          "orgId": {
+            "type": "string",
+            "description": "Organization ID the user belongs to",
+            "example": "123e4567-e89b-12d3-a456-426614174001",
+            "format": "uuid"
+          },
+          "createdAt": {
+            "format": "date-time",
+            "type": "string",
+            "description": "Date when the user was created",
+            "example": "2024-01-15T10:30:00Z"
+          },
+          "systemRole": {
+            "type": "string",
+            "description": "System-level role of the user",
+            "enum": [
+              "customer",
+              "super_admin"
+            ],
+            "example": "super_admin"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "email",
+          "role",
+          "orgId",
+          "createdAt",
+          "systemRole"
+        ]
+      },
+      "PromoteToSuperAdminDto": {
+        "type": "object",
+        "properties": {
+          "email": {
+            "type": "string",
+            "description": "Email address of the user to promote to super admin",
+            "example": "user@example.com"
+          }
+        },
+        "required": [
+          "email"
         ]
       },
       "CreateInviteDto": {

--- a/ayunis-core-frontend/src/shared/locales/de/super-admin-settings-layout.json
+++ b/ayunis-core-frontend/src/shared/locales/de/super-admin-settings-layout.json
@@ -7,6 +7,7 @@
     "orgs": "Organisationen",
     "modelsCatalog": "Model-Katalog",
     "usage": "Nutzung",
-    "skills": "Skill-Vorlagen"
+    "skills": "Skill-Vorlagen",
+    "superAdmins": "Super-Admins"
   }
 }

--- a/ayunis-core-frontend/src/shared/locales/de/super-admin-settings-super-admins.json
+++ b/ayunis-core-frontend/src/shared/locales/de/super-admin-settings-super-admins.json
@@ -1,0 +1,48 @@
+{
+  "header": {
+    "title": "Super-Admins",
+    "description": "Benutzer mit Super-Admin-Zugriff plattformweit verwalten."
+  },
+  "actions": {
+    "addSuperAdmin": "Super-Admin hinzufügen",
+    "remove": "Entfernen"
+  },
+  "dialog": {
+    "title": "Super-Admin hinzufügen",
+    "description": "Geben Sie die E-Mail-Adresse eines bestehenden Benutzers ein, um Super-Admin-Zugriff zu gewähren.",
+    "emailLabel": "E-Mail-Adresse",
+    "emailPlaceholder": "benutzer@beispiel.de",
+    "emailRequired": "E-Mail-Adresse ist erforderlich",
+    "emailInvalid": "Bitte geben Sie eine gültige E-Mail-Adresse ein",
+    "cancel": "Abbrechen",
+    "add": "Super-Admin hinzufügen",
+    "adding": "Wird hinzugefügt..."
+  },
+  "table": {
+    "name": "Name",
+    "email": "E-Mail"
+  },
+  "empty": {
+    "title": "Keine Super-Admins",
+    "description": "Super-Admins, die Sie hinzufügen, werden hier angezeigt."
+  },
+  "addSuperAdmin": {
+    "success": "Benutzer zum Super-Admin befördert",
+    "error": "Super-Admin konnte nicht hinzugefügt werden. Stellen Sie sicher, dass die E-Mail einem bestehenden Benutzer gehört.",
+    "errorNotFound": "Kein Benutzer mit dieser E-Mail-Adresse gefunden."
+  },
+  "confirmRemove": {
+    "title": "Super-Admin entfernen",
+    "description": "Möchten Sie den Super-Admin-Zugriff von {{name}} wirklich entfernen?",
+    "confirmText": "Entfernen",
+    "cancelText": "Abbrechen"
+  },
+  "removeSuperAdmin": {
+    "success": "Super-Admin-Status entfernt",
+    "error": "Super-Admin-Status konnte nicht entfernt werden.",
+    "errorSelfDemotion": "Sie können Ihren eigenen Super-Admin-Status nicht entfernen.",
+    "errorLastAdmin": "Der letzte Super-Admin kann nicht entfernt werden.",
+    "errorNotSuperAdmin": "Dieser Benutzer ist kein Super-Admin.",
+    "errorNotFound": "Benutzer nicht gefunden."
+  }
+}

--- a/ayunis-core-frontend/src/shared/locales/en/super-admin-settings-layout.json
+++ b/ayunis-core-frontend/src/shared/locales/en/super-admin-settings-layout.json
@@ -7,6 +7,7 @@
     "orgs": "Organizations",
     "modelsCatalog": "Models Catalog",
     "usage": "Usage",
-    "skills": "Skill Templates"
+    "skills": "Skill Templates",
+    "superAdmins": "Super Admins"
   }
 }

--- a/ayunis-core-frontend/src/shared/locales/en/super-admin-settings-super-admins.json
+++ b/ayunis-core-frontend/src/shared/locales/en/super-admin-settings-super-admins.json
@@ -1,0 +1,48 @@
+{
+  "header": {
+    "title": "Super Admins",
+    "description": "Manage users with super admin access across the platform."
+  },
+  "actions": {
+    "addSuperAdmin": "Add super admin",
+    "remove": "Remove"
+  },
+  "dialog": {
+    "title": "Add super admin",
+    "description": "Enter the email address of an existing user to grant super admin access.",
+    "emailLabel": "Email address",
+    "emailPlaceholder": "user@example.com",
+    "emailRequired": "Email address is required",
+    "emailInvalid": "Please enter a valid email address",
+    "cancel": "Cancel",
+    "add": "Add super admin",
+    "adding": "Adding..."
+  },
+  "table": {
+    "name": "Name",
+    "email": "Email"
+  },
+  "empty": {
+    "title": "No super admins",
+    "description": "Super admins you add will show up here."
+  },
+  "addSuperAdmin": {
+    "success": "User promoted to super admin",
+    "error": "Failed to add super admin. Make sure the email belongs to an existing user.",
+    "errorNotFound": "No user found with this email address."
+  },
+  "confirmRemove": {
+    "title": "Remove super admin",
+    "description": "Are you sure you want to remove super admin access from {{name}}?",
+    "confirmText": "Remove",
+    "cancelText": "Cancel"
+  },
+  "removeSuperAdmin": {
+    "success": "Super admin status removed",
+    "error": "Failed to remove super admin status.",
+    "errorSelfDemotion": "You cannot remove your own super admin status.",
+    "errorLastAdmin": "Cannot remove the last super admin.",
+    "errorNotSuperAdmin": "This user is not a super admin.",
+    "errorNotFound": "User not found."
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> High risk because it introduces new super-admin promotion/demotion flows and API endpoints that directly affect system-level privileges. Mistakes in authorization, routing exposure, or edge-case handling could enable unintended privilege changes.
> 
> **Overview**
> Adds a new **Super Admins management** section under `Super Admin Settings`, including a new route (`/super-admin-settings/super-admins`) and sidebar navigation entry.
> 
> The page loads and displays the current super admins, provides an *Add super admin* email dialog (promote) and a remove action (demote) with confirmation and translated success/error toasts (including specific backend error-code mappings).
> 
> Updates the generated OpenAPI client/schema to include `GET/POST /super-admin/super-admins` and `DELETE /super-admin/super-admins/{userId}` plus new DTOs, and adjusts `.nsprc` to consolidate/refresh the fast-xml-parser vulnerability ignore entry.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8d11dcbffcf01b6ed3613682c2c481f583803cdf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->