### PR TITLE
wip(AYC-77): add subscription polymorphism migration and usage-based creation

### DIFF
--- a/ayunis-core-backend/src/db/migrations/1773096734098-AddSubscriptionPolymorphism.ts
+++ b/ayunis-core-backend/src/db/migrations/1773096734098-AddSubscriptionPolymorphism.ts
@@ -1,0 +1,80 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddSubscriptionPolymorphism1773096734098
+  implements MigrationInterface
+{
+  name = 'AddSubscriptionPolymorphism1773096734098';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "subscriptions" ADD "monthlyCredits" numeric(16,2)`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "subscriptions" ADD "type" character varying NOT NULL DEFAULT 'SEAT_BASED'`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "subscriptions" ALTER COLUMN "type" DROP DEFAULT`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "subscriptions" ALTER COLUMN "noOfSeats" DROP NOT NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "subscriptions" ALTER COLUMN "pricePerSeat" DROP NOT NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "subscriptions" ALTER COLUMN "renewalCycle" TYPE character varying USING "renewalCycle"::character varying`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "subscriptions" ALTER COLUMN "renewalCycle" DROP NOT NULL`,
+    );
+    await queryRunner.query(
+      `DROP TYPE IF EXISTS "public"."subscriptions_renewalcycle_enum"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "subscriptions" ALTER COLUMN "renewalCycleAnchor" DROP NOT NULL`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_7fc69c933b26749eee02d108bb" ON "subscriptions" ("type") `,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_7fc69c933b26749eee02d108bb"`,
+    );
+    await queryRunner.query(
+      `DELETE FROM "subscriptions" WHERE "type" = 'USAGE_BASED'`,
+    );
+    await queryRunner.query(
+      `UPDATE "subscriptions" SET "renewalCycleAnchor" = NOW() WHERE "renewalCycleAnchor" IS NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "subscriptions" ALTER COLUMN "renewalCycleAnchor" SET NOT NULL`,
+    );
+    await queryRunner.query(
+      `CREATE TYPE "public"."subscriptions_renewalcycle_enum" AS ENUM('monthly', 'yearly')`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "subscriptions" ALTER COLUMN "renewalCycle" TYPE "public"."subscriptions_renewalcycle_enum" USING "renewalCycle"::"public"."subscriptions_renewalcycle_enum"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "subscriptions" ALTER COLUMN "renewalCycle" SET NOT NULL`,
+    );
+    await queryRunner.query(
+      `UPDATE "subscriptions" SET "noOfSeats" = 1 WHERE "noOfSeats" IS NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "subscriptions" ALTER COLUMN "noOfSeats" SET NOT NULL`,
+    );
+    await queryRunner.query(
+      `UPDATE "subscriptions" SET "pricePerSeat" = 0 WHERE "pricePerSeat" IS NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "subscriptions" ALTER COLUMN "pricePerSeat" SET NOT NULL`,
+    );
+    await queryRunner.query(`ALTER TABLE "subscriptions" DROP COLUMN "type"`);
+    await queryRunner.query(
+      `ALTER TABLE "subscriptions" DROP COLUMN "monthlyCredits"`,
+    );
+  }
+}

--- a/ayunis-core-backend/src/iam/subscriptions/application/use-cases/create-subscription/create-subscription.command.ts
+++ b/ayunis-core-backend/src/iam/subscriptions/application/use-cases/create-subscription/create-subscription.command.ts
@@ -1,9 +1,12 @@
 import type { UUID } from 'crypto';
+import { SubscriptionType } from '../../../domain/value-objects/subscription-type.enum';
 
 export class CreateSubscriptionCommand {
   public readonly orgId: UUID;
   public readonly requestingUserId: UUID;
-  public readonly noOfSeats: number;
+  public readonly type: SubscriptionType;
+  public readonly noOfSeats?: number;
+  public readonly monthlyCredits?: number;
   public readonly companyName: string;
   public readonly subText?: string;
   public readonly street: string;
@@ -16,7 +19,9 @@ export class CreateSubscriptionCommand {
   constructor(params: {
     orgId: UUID;
     requestingUserId: UUID;
+    type?: SubscriptionType;
     noOfSeats?: number;
+    monthlyCredits?: number;
     companyName: string;
     subText?: string;
     street: string;
@@ -28,7 +33,9 @@ export class CreateSubscriptionCommand {
   }) {
     this.orgId = params.orgId;
     this.requestingUserId = params.requestingUserId;
-    this.noOfSeats = params.noOfSeats ?? 1;
+    this.type = params.type ?? SubscriptionType.SEAT_BASED;
+    this.noOfSeats = params.noOfSeats;
+    this.monthlyCredits = params.monthlyCredits;
     this.companyName = params.companyName;
     this.subText = params.subText;
     this.street = params.street;

--- a/ayunis-core-backend/src/iam/subscriptions/application/use-cases/create-subscription/create-subscription.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/subscriptions/application/use-cases/create-subscription/create-subscription.use-case.spec.ts
@@ -1,0 +1,288 @@
+import type { TestingModule } from '@nestjs/testing';
+import { Test } from '@nestjs/testing';
+import { Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { randomUUID } from 'crypto';
+import { CreateSubscriptionUseCase } from './create-subscription.use-case';
+import { CreateSubscriptionCommand } from './create-subscription.command';
+import { SubscriptionRepository } from '../../ports/subscription.repository';
+import { HasActiveSubscriptionUseCase } from '../has-active-subscription/has-active-subscription.use-case';
+import { GetInvitesByOrgUseCase } from 'src/iam/invites/application/use-cases/get-invites-by-org/get-invites-by-org.use-case';
+import { FindUsersByOrgIdUseCase } from 'src/iam/users/application/use-cases/find-users-by-org-id/find-users-by-org-id.use-case';
+import { SendWebhookUseCase } from 'src/common/webhooks/application/use-cases/send-webhook/send-webhook.use-case';
+import { ContextService } from 'src/common/context/services/context.service';
+import { SeatBasedSubscription } from 'src/iam/subscriptions/domain/seat-based-subscription.entity';
+import { UsageBasedSubscription } from 'src/iam/subscriptions/domain/usage-based-subscription.entity';
+import { SubscriptionType } from 'src/iam/subscriptions/domain/value-objects/subscription-type.enum';
+import { SystemRole } from 'src/iam/users/domain/value-objects/system-role.enum';
+import { UserRole } from 'src/iam/users/domain/value-objects/role.object';
+import { Paginated } from 'src/common/pagination/paginated.entity';
+import {
+  SubscriptionAlreadyExistsError,
+  InvalidSubscriptionDataError,
+  TooManyUsedSeatsError,
+} from '../../subscription.errors';
+import type { Subscription } from 'src/iam/subscriptions/domain/subscription.entity';
+
+describe('CreateSubscriptionUseCase', () => {
+  let useCase: CreateSubscriptionUseCase;
+  let subscriptionRepository: jest.Mocked<SubscriptionRepository>;
+  let hasActiveSubscriptionUseCase: jest.Mocked<HasActiveSubscriptionUseCase>;
+  let getInvitesByOrgUseCase: jest.Mocked<GetInvitesByOrgUseCase>;
+  let findUsersByOrgIdUseCase: jest.Mocked<FindUsersByOrgIdUseCase>;
+  let configService: jest.Mocked<ConfigService>;
+  let contextService: jest.Mocked<ContextService>;
+
+  const orgId = randomUUID();
+  const requestingUserId = randomUUID();
+
+  const baseBillingParams = {
+    companyName: 'Gemeinde Musterstadt',
+    street: 'Hauptstraße',
+    houseNumber: '1',
+    postalCode: '12345',
+    city: 'Musterstadt',
+    country: 'DE',
+  };
+
+  beforeAll(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        CreateSubscriptionUseCase,
+        {
+          provide: SubscriptionRepository,
+          useValue: {
+            create: jest.fn((sub: Subscription) => Promise.resolve(sub)),
+          },
+        },
+        {
+          provide: HasActiveSubscriptionUseCase,
+          useValue: { execute: jest.fn() },
+        },
+        {
+          provide: GetInvitesByOrgUseCase,
+          useValue: { execute: jest.fn() },
+        },
+        {
+          provide: FindUsersByOrgIdUseCase,
+          useValue: { execute: jest.fn() },
+        },
+        {
+          provide: SendWebhookUseCase,
+          useValue: { execute: jest.fn().mockResolvedValue(undefined) },
+        },
+        {
+          provide: ConfigService,
+          useValue: { get: jest.fn() },
+        },
+        {
+          provide: ContextService,
+          useValue: { get: jest.fn() },
+        },
+      ],
+    }).compile();
+
+    useCase = module.get(CreateSubscriptionUseCase);
+    subscriptionRepository = module.get(SubscriptionRepository);
+    hasActiveSubscriptionUseCase = module.get(HasActiveSubscriptionUseCase);
+    getInvitesByOrgUseCase = module.get(GetInvitesByOrgUseCase);
+    findUsersByOrgIdUseCase = module.get(FindUsersByOrgIdUseCase);
+    configService = module.get(ConfigService);
+    contextService = module.get(ContextService);
+
+    jest.spyOn(Logger.prototype, 'log').mockImplementation();
+    jest.spyOn(Logger.prototype, 'debug').mockImplementation();
+    jest.spyOn(Logger.prototype, 'warn').mockImplementation();
+    jest.spyOn(Logger.prototype, 'error').mockImplementation();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  function setupSuperAdminContext(): void {
+    contextService.get.mockImplementation(((key: string) => {
+      if (key === 'systemRole') return SystemRole.SUPER_ADMIN;
+      if (key === 'role') return UserRole.USER;
+      if (key === 'orgId') return randomUUID();
+      return undefined;
+    }) as never);
+  }
+
+  function mockNoActiveSubscription(): void {
+    hasActiveSubscriptionUseCase.execute.mockResolvedValue(false);
+  }
+
+  function mockInvitesAndUsers(openInvites: number, userCount: number): void {
+    getInvitesByOrgUseCase.execute.mockResolvedValue(
+      new Paginated({
+        data: [],
+        limit: 1000,
+        offset: 0,
+        total: openInvites,
+      }),
+    );
+    findUsersByOrgIdUseCase.execute.mockResolvedValue(
+      new Paginated({
+        data: [],
+        limit: 1000,
+        offset: 0,
+        total: userCount,
+      }),
+    );
+  }
+
+  describe('usage-based subscription creation', () => {
+    it('should create a UsageBasedSubscription when type is USAGE_BASED', async () => {
+      setupSuperAdminContext();
+      mockNoActiveSubscription();
+
+      const command = new CreateSubscriptionCommand({
+        orgId,
+        requestingUserId,
+        type: SubscriptionType.USAGE_BASED,
+        monthlyCredits: 500,
+        ...baseBillingParams,
+      });
+
+      const result = await useCase.execute(command);
+
+      expect(result).toBeInstanceOf(UsageBasedSubscription);
+      expect((result as UsageBasedSubscription).monthlyCredits).toBe(500);
+      expect(result.orgId).toBe(orgId);
+      expect(subscriptionRepository.create).toHaveBeenCalledWith(
+        expect.any(UsageBasedSubscription),
+      );
+    });
+
+    it('should reject usage-based subscription with monthlyCredits <= 0', async () => {
+      setupSuperAdminContext();
+      mockNoActiveSubscription();
+
+      const command = new CreateSubscriptionCommand({
+        orgId,
+        requestingUserId,
+        type: SubscriptionType.USAGE_BASED,
+        monthlyCredits: 0,
+        ...baseBillingParams,
+      });
+
+      await expect(useCase.execute(command)).rejects.toThrow(
+        InvalidSubscriptionDataError,
+      );
+    });
+
+    it('should reject usage-based subscription without monthlyCredits', async () => {
+      setupSuperAdminContext();
+      mockNoActiveSubscription();
+
+      const command = new CreateSubscriptionCommand({
+        orgId,
+        requestingUserId,
+        type: SubscriptionType.USAGE_BASED,
+        ...baseBillingParams,
+      });
+
+      await expect(useCase.execute(command)).rejects.toThrow(
+        InvalidSubscriptionDataError,
+      );
+    });
+
+    it('should not query invites or users for usage-based subscription', async () => {
+      setupSuperAdminContext();
+      mockNoActiveSubscription();
+
+      const command = new CreateSubscriptionCommand({
+        orgId,
+        requestingUserId,
+        type: SubscriptionType.USAGE_BASED,
+        monthlyCredits: 1000,
+        ...baseBillingParams,
+      });
+
+      await useCase.execute(command);
+
+      expect(getInvitesByOrgUseCase.execute).not.toHaveBeenCalled();
+      expect(findUsersByOrgIdUseCase.execute).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('seat-based subscription creation', () => {
+    it('should create a SeatBasedSubscription when type is SEAT_BASED', async () => {
+      setupSuperAdminContext();
+      mockNoActiveSubscription();
+      mockInvitesAndUsers(0, 1);
+      configService.get.mockReturnValue(99.99);
+
+      const command = new CreateSubscriptionCommand({
+        orgId,
+        requestingUserId,
+        type: SubscriptionType.SEAT_BASED,
+        noOfSeats: 5,
+        ...baseBillingParams,
+      });
+
+      const result = await useCase.execute(command);
+
+      expect(result).toBeInstanceOf(SeatBasedSubscription);
+      expect((result as SeatBasedSubscription).noOfSeats).toBe(5);
+      expect((result as SeatBasedSubscription).pricePerSeat).toBe(99.99);
+    });
+
+    it('should default to SEAT_BASED when type is not specified', async () => {
+      setupSuperAdminContext();
+      mockNoActiveSubscription();
+      mockInvitesAndUsers(0, 1);
+      configService.get.mockReturnValue(99.99);
+
+      const command = new CreateSubscriptionCommand({
+        orgId,
+        requestingUserId,
+        noOfSeats: 3,
+        ...baseBillingParams,
+      });
+
+      const result = await useCase.execute(command);
+
+      expect(result).toBeInstanceOf(SeatBasedSubscription);
+    });
+
+    it('should reject seat-based subscription when users plus open invites exceed noOfSeats', async () => {
+      setupSuperAdminContext();
+      mockNoActiveSubscription();
+      mockInvitesAndUsers(3, 4);
+      configService.get.mockReturnValue(99.99);
+
+      const command = new CreateSubscriptionCommand({
+        orgId,
+        requestingUserId,
+        type: SubscriptionType.SEAT_BASED,
+        noOfSeats: 5,
+        ...baseBillingParams,
+      });
+
+      await expect(useCase.execute(command)).rejects.toThrow(
+        TooManyUsedSeatsError,
+      );
+    });
+  });
+
+  describe('common validation', () => {
+    it('should reject creation when subscription already exists', async () => {
+      setupSuperAdminContext();
+      hasActiveSubscriptionUseCase.execute.mockResolvedValue(true);
+
+      const command = new CreateSubscriptionCommand({
+        orgId,
+        requestingUserId,
+        type: SubscriptionType.USAGE_BASED,
+        monthlyCredits: 500,
+        ...baseBillingParams,
+      });
+
+      await expect(useCase.execute(command)).rejects.toThrow(
+        SubscriptionAlreadyExistsError,
+      );
+    });
+  });
+});

--- a/ayunis-core-backend/src/iam/subscriptions/application/use-cases/create-subscription/create-subscription.use-case.ts
+++ b/ayunis-core-backend/src/iam/subscriptions/application/use-cases/create-subscription/create-subscription.use-case.ts
@@ -3,6 +3,8 @@ import { CreateSubscriptionCommand } from './create-subscription.command';
 import { SubscriptionRepository } from '../../ports/subscription.repository';
 import { Subscription } from 'src/iam/subscriptions/domain/subscription.entity';
 import { SeatBasedSubscription } from 'src/iam/subscriptions/domain/seat-based-subscription.entity';
+import { UsageBasedSubscription } from 'src/iam/subscriptions/domain/usage-based-subscription.entity';
+import { SubscriptionType } from 'src/iam/subscriptions/domain/value-objects/subscription-type.enum';
 import { ConfigService } from '@nestjs/config';
 import { RenewalCycle } from 'src/iam/subscriptions/domain/value-objects/renewal-cycle.enum';
 import {
@@ -15,6 +17,7 @@ import { SubscriptionBillingInfo } from 'src/iam/subscriptions/domain/subscripti
 import { HasActiveSubscriptionQuery } from '../has-active-subscription/has-active-subscription.query';
 import { HasActiveSubscriptionUseCase } from '../has-active-subscription/has-active-subscription.use-case';
 import { ApplicationError } from 'src/common/errors/base.error';
+import type { User } from 'src/iam/users/domain/user.entity';
 import { GetInvitesByOrgQuery } from 'src/iam/invites/application/use-cases/get-invites-by-org/get-invites-by-org.query';
 import { FindUsersByOrgIdQuery } from 'src/iam/users/application/use-cases/find-users-by-org-id/find-users-by-org-id.query';
 import { GetInvitesByOrgUseCase } from 'src/iam/invites/application/use-cases/get-invites-by-org/get-invites-by-org.use-case';
@@ -47,99 +50,23 @@ export class CreateSubscriptionUseCase {
         command.requestingUserId,
         command.orgId,
       );
-      this.logger.log('Creating subscription', {
-        orgId: command.orgId,
-        requestingUserId: command.requestingUserId,
-        renewalCycle: RenewalCycle.YEARLY,
-        noOfSeats: command.noOfSeats,
-      });
-      this.logger.debug('Checking if subscription already exists');
-      const hasActiveSubscription =
-        await this.hasActiveSubscriptionUseCase.execute(
-          new HasActiveSubscriptionQuery(command.orgId),
-        );
-      if (hasActiveSubscription) {
-        this.logger.warn('Subscription already exists for organization', {
-          orgId: command.orgId,
-        });
-        throw new SubscriptionAlreadyExistsError(command.orgId);
-      }
-      if (command.noOfSeats <= 0) {
-        this.logger.warn('Invalid number of seats provided', {
-          noOfSeats: command.noOfSeats,
-        });
-        throw new InvalidSubscriptionDataError(
-          'Number of seats must be greater than 0',
-        );
-      }
 
-      const [invitesResult, usersResult] = await Promise.all([
-        this.getInvitesByOrgUseCase.execute(
-          new GetInvitesByOrgQuery({
-            orgId: command.orgId,
-            requestingUserId: command.requestingUserId,
-            onlyOpen: true,
-          }),
-        ),
-        this.findUsersByOrgIdUseCase.execute(
-          new FindUsersByOrgIdQuery({
-            orgId: command.orgId,
-            pagination: { limit: 1000, offset: 0 },
-          }),
-        ),
-      ]);
-      const openInvitesCount = invitesResult.total ?? invitesResult.data.length;
-      if (
-        openInvitesCount + (usersResult.total ?? usersResult.data.length) >
-        command.noOfSeats
-      ) {
-        this.logger.warn('Too many used seats', {
-          orgId: command.orgId,
-          openInvites: openInvitesCount,
-        });
-        throw new TooManyUsedSeatsError({
-          orgId: command.orgId,
-          openInvites: openInvitesCount,
-        });
-      }
+      await this.ensureNoActiveSubscription(command.orgId);
 
-      const pricePerSeat = this.configService.get<number>(
-        'subscriptions.pricePerSeatYearly',
-      );
-
-      if (!pricePerSeat) {
-        this.logger.error('Price per seat not configured', {});
-        throw new InvalidSubscriptionDataError('Price per seat not configured');
-      }
-
-      this.logger.debug('Creating subscription entity');
-      const subscription = new SeatBasedSubscription({
-        orgId: command.orgId,
-        noOfSeats: command.noOfSeats,
-        renewalCycle: RenewalCycle.YEARLY,
-        pricePerSeat,
-        renewalCycleAnchor: new Date(),
-        billingInfo: new SubscriptionBillingInfo({
-          companyName: command.companyName,
-          subText: command.subText,
-          street: command.street,
-          houseNumber: command.houseNumber,
-          postalCode: command.postalCode,
-          city: command.city,
-          country: command.country,
-          vatNumber: command.vatNumber,
-        }),
-      });
+      const subscription =
+        command.type === SubscriptionType.USAGE_BASED
+          ? this.createUsageBasedSubscription(command)
+          : await this.createSeatBasedSubscription(command);
 
       const createdSubscription =
         await this.subscriptionRepository.create(subscription);
+
       this.logger.debug('Subscription created successfully', {
         subscriptionId: createdSubscription.id,
         orgId: command.orgId,
-        noOfSeats: command.noOfSeats,
+        type: command.type,
       });
 
-      // Send webhook asynchronously (don't block the main operation)
       void this.sendWebhookUseCase.execute(
         new SendWebhookCommand(
           new SubscriptionCreatedWebhookEvent(
@@ -151,7 +78,6 @@ export class CreateSubscriptionUseCase {
       return createdSubscription;
     } catch (error) {
       if (error instanceof ApplicationError) {
-        // Already logged and properly typed error, just rethrow
         throw error;
       }
       this.logger.error('Subscription creation failed', {
@@ -164,5 +90,131 @@ export class CreateSubscriptionUseCase {
         { error: error as Error },
       );
     }
+  }
+
+  private async ensureNoActiveSubscription(
+    orgId: Subscription['orgId'],
+  ): Promise<void> {
+    const hasActiveSubscription =
+      await this.hasActiveSubscriptionUseCase.execute(
+        new HasActiveSubscriptionQuery(orgId),
+      );
+    if (hasActiveSubscription) {
+      this.logger.warn('Subscription already exists for organization', {
+        orgId,
+      });
+      throw new SubscriptionAlreadyExistsError(orgId);
+    }
+  }
+
+  private createUsageBasedSubscription(
+    command: CreateSubscriptionCommand,
+  ): UsageBasedSubscription {
+    if (!command.monthlyCredits || command.monthlyCredits <= 0) {
+      throw new InvalidSubscriptionDataError(
+        'Monthly credits must be greater than 0 for usage-based subscriptions',
+      );
+    }
+
+    this.logger.log('Creating usage-based subscription', {
+      orgId: command.orgId,
+      monthlyCredits: command.monthlyCredits,
+    });
+
+    return new UsageBasedSubscription({
+      orgId: command.orgId,
+      monthlyCredits: command.monthlyCredits,
+      billingInfo: this.buildBillingInfo(command),
+    });
+  }
+
+  private async createSeatBasedSubscription(
+    command: CreateSubscriptionCommand,
+  ): Promise<SeatBasedSubscription> {
+    const noOfSeats = command.noOfSeats ?? 1;
+
+    this.logger.log('Creating seat-based subscription', {
+      orgId: command.orgId,
+      noOfSeats,
+    });
+
+    if (noOfSeats <= 0) {
+      throw new InvalidSubscriptionDataError(
+        'Number of seats must be greater than 0',
+      );
+    }
+
+    await this.validateSeatCount(
+      command.orgId,
+      command.requestingUserId,
+      noOfSeats,
+    );
+
+    const pricePerSeat = this.configService.get<number>(
+      'subscriptions.pricePerSeatYearly',
+    );
+    if (!pricePerSeat) {
+      throw new InvalidSubscriptionDataError('Price per seat not configured');
+    }
+
+    return new SeatBasedSubscription({
+      orgId: command.orgId,
+      noOfSeats,
+      renewalCycle: RenewalCycle.YEARLY,
+      pricePerSeat,
+      renewalCycleAnchor: new Date(),
+      billingInfo: this.buildBillingInfo(command),
+    });
+  }
+
+  private async validateSeatCount(
+    orgId: Subscription['orgId'],
+    requestingUserId: User['id'],
+    noOfSeats: number,
+  ): Promise<void> {
+    const [invitesResult, usersResult] = await Promise.all([
+      this.getInvitesByOrgUseCase.execute(
+        new GetInvitesByOrgQuery({
+          orgId,
+          requestingUserId,
+          onlyOpen: true,
+        }),
+      ),
+      this.findUsersByOrgIdUseCase.execute(
+        new FindUsersByOrgIdQuery({
+          orgId,
+          pagination: { limit: 1000, offset: 0 },
+        }),
+      ),
+    ]);
+    const openInvitesCount = invitesResult.total ?? invitesResult.data.length;
+    if (
+      openInvitesCount + (usersResult.total ?? usersResult.data.length) >
+      noOfSeats
+    ) {
+      this.logger.warn('Too many used seats', {
+        orgId,
+        openInvites: openInvitesCount,
+      });
+      throw new TooManyUsedSeatsError({
+        orgId,
+        openInvites: openInvitesCount,
+      });
+    }
+  }
+
+  private buildBillingInfo(
+    command: CreateSubscriptionCommand,
+  ): SubscriptionBillingInfo {
+    return new SubscriptionBillingInfo({
+      companyName: command.companyName,
+      subText: command.subText,
+      street: command.street,
+      houseNumber: command.houseNumber,
+      postalCode: command.postalCode,
+      city: command.city,
+      country: command.country,
+      vatNumber: command.vatNumber,
+    });
   }
 }

--- a/ayunis-core-backend/src/iam/subscriptions/application/use-cases/uncancel-subscription/uncancel-subscription.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/subscriptions/application/use-cases/uncancel-subscription/uncancel-subscription.use-case.spec.ts
@@ -2,7 +2,6 @@ import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import { Logger } from '@nestjs/common';
 import { randomUUID } from 'crypto';
-import type { UUID } from 'crypto';
 import { UncancelSubscriptionUseCase } from './uncancel-subscription.use-case';
 import { UncancelSubscriptionCommand } from './uncancel-subscription.command';
 import { SubscriptionRepository } from '../../ports/subscription.repository';
@@ -20,8 +19,8 @@ import { ContextService } from 'src/common/context/services/context.service';
 import { SystemRole } from 'src/iam/users/domain/value-objects/system-role.enum';
 import { UserRole } from 'src/iam/users/domain/value-objects/role.object';
 
-const mockOrgId = randomUUID() as UUID;
-const mockUserId = randomUUID() as UUID;
+const mockOrgId = randomUUID();
+const mockUserId = randomUUID();
 
 function createBillingInfo(): SubscriptionBillingInfo {
   return new SubscriptionBillingInfo({

--- a/ayunis-core-backend/src/iam/subscriptions/presenters/http/dto/create-subscription-request.dto.ts
+++ b/ayunis-core-backend/src/iam/subscriptions/presenters/http/dto/create-subscription-request.dto.ts
@@ -1,18 +1,53 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import { IsNumber, IsOptional, IsString, Min } from 'class-validator';
+import {
+  IsEnum,
+  IsNumber,
+  IsOptional,
+  IsString,
+  Min,
+  ValidateIf,
+} from 'class-validator';
 import { BillingInfoFieldsDto } from './billing-info-fields.dto';
+import { SubscriptionType } from '../../../domain/value-objects/subscription-type.enum';
 
 export class CreateSubscriptionRequestDto extends BillingInfoFieldsDto {
+  @ApiPropertyOptional({
+    description: 'Subscription type. Defaults to SEAT_BASED if not specified.',
+    enum: SubscriptionType,
+    example: SubscriptionType.SEAT_BASED,
+    default: SubscriptionType.SEAT_BASED,
+  })
+  @IsOptional()
+  @IsEnum(SubscriptionType)
+  type?: SubscriptionType;
+
   @ApiPropertyOptional({
     description: 'Number of seats for the subscription (seat-based only)',
     example: 10,
     minimum: 1,
     default: 1,
   })
+  @ValidateIf(
+    (o: CreateSubscriptionRequestDto) =>
+      !o.type || o.type === SubscriptionType.SEAT_BASED,
+  )
   @IsOptional()
   @IsNumber()
   @Min(1)
   noOfSeats?: number;
+
+  @ApiPropertyOptional({
+    description: 'Monthly credit budget (usage-based only)',
+    example: 1000,
+    minimum: 1,
+  })
+  @ValidateIf(
+    (o: CreateSubscriptionRequestDto) =>
+      o.type === SubscriptionType.USAGE_BASED,
+  )
+  @IsNumber()
+  @Min(1)
+  monthlyCredits?: number;
 
   @ApiProperty({
     description: 'Sub text for the subscription',

--- a/ayunis-core-backend/src/iam/subscriptions/presenters/http/super-admin-subscriptions.controller.ts
+++ b/ayunis-core-backend/src/iam/subscriptions/presenters/http/super-admin-subscriptions.controller.ts
@@ -176,7 +176,9 @@ export class SuperAdminSubscriptionsController {
     const command = new CreateSubscriptionCommand({
       orgId,
       requestingUserId: userId,
+      type: createSubscriptionDto.type,
       noOfSeats: createSubscriptionDto.noOfSeats,
+      monthlyCredits: createSubscriptionDto.monthlyCredits,
       companyName: createSubscriptionDto.companyName,
       subText: createSubscriptionDto.subText,
       street: createSubscriptionDto.street,

--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
@@ -1110,6 +1110,18 @@ export interface SubscriptionResponseDtoNullable {
   subscription?: SubscriptionResponseDto;
 }
 
+/**
+ * Subscription type. Defaults to SEAT_BASED if not specified.
+ */
+export type CreateSubscriptionRequestDtoType = typeof CreateSubscriptionRequestDtoType[keyof typeof CreateSubscriptionRequestDtoType];
+
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const CreateSubscriptionRequestDtoType = {
+  SEAT_BASED: 'SEAT_BASED',
+  USAGE_BASED: 'USAGE_BASED',
+} as const;
+
 export interface CreateSubscriptionRequestDto {
   /** Company name for the subscription */
   companyName: string;
@@ -1125,11 +1137,18 @@ export interface CreateSubscriptionRequestDto {
   country: string;
   /** VAT number for the subscription */
   vatNumber?: string;
+  /** Subscription type. Defaults to SEAT_BASED if not specified. */
+  type?: CreateSubscriptionRequestDtoType;
   /**
    * Number of seats for the subscription (seat-based only)
    * @minimum 1
    */
   noOfSeats?: number;
+  /**
+   * Monthly credit budget (usage-based only)
+   * @minimum 1
+   */
+  monthlyCredits?: number;
   /** Sub text for the subscription */
   subText?: string;
 }

--- a/ayunis-core-frontend/src/shared/api/openapi-schema.json
+++ b/ayunis-core-frontend/src/shared/api/openapi-schema.json
@@ -10015,12 +10015,28 @@
             "description": "VAT number for the subscription",
             "example": "1234567890"
           },
+          "type": {
+            "type": "string",
+            "description": "Subscription type. Defaults to SEAT_BASED if not specified.",
+            "enum": [
+              "SEAT_BASED",
+              "USAGE_BASED"
+            ],
+            "example": "SEAT_BASED",
+            "default": "SEAT_BASED"
+          },
           "noOfSeats": {
             "type": "number",
             "description": "Number of seats for the subscription (seat-based only)",
             "example": 10,
             "minimum": 1,
             "default": 1
+          },
+          "monthlyCredits": {
+            "type": "number",
+            "description": "Monthly credit budget (usage-based only)",
+            "example": 1000,
+            "minimum": 1
           },
           "subText": {
             "type": "string",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces a schema migration that changes required/nullable constraints and drops the `renewalCycle` enum type, which can affect existing data and rollback behavior. Also changes subscription creation flow to branch by `type`, adding new validation paths that impact billing/seat enforcement logic.
> 
> **Overview**
> Adds polymorphic subscription support by migrating `subscriptions` to include a `type` discriminator and `monthlyCredits`, while relaxing seat-based-only columns (`noOfSeats`, `pricePerSeat`, `renewalCycle`, `renewalCycleAnchor`) to be nullable and indexing `type`.
> 
> Updates subscription creation to accept `type` (default `SEAT_BASED`) and create either `SeatBasedSubscription` (with existing seat-count validation) or `UsageBasedSubscription` (requires `monthlyCredits` and skips seat/invite/user checks), and wires the new fields through the super-admin HTTP DTO/controller and regenerated frontend OpenAPI client types. Adds unit tests covering both creation paths and validations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bd9e72365a3432fbff5791b360c7884420a04466. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->