### PR TITLE
wip(AYC-77): add creditsConsumed to usage entity and migration

### DIFF
--- a/ayunis-core-backend/src/db/migrations/1773098611477-AddCreditsConsumedToUsage.ts
+++ b/ayunis-core-backend/src/db/migrations/1773098611477-AddCreditsConsumedToUsage.ts
@@ -1,0 +1,14 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddCreditsConsumedToUsage1773098611477 implements MigrationInterface {
+    name = 'AddCreditsConsumedToUsage1773098611477'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "usage" ADD "creditsConsumed" numeric(16,6)`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "usage" DROP COLUMN "creditsConsumed"`);
+    }
+
+}

--- a/ayunis-core-backend/src/domain/usage/domain/usage.entity.ts
+++ b/ayunis-core-backend/src/domain/usage/domain/usage.entity.ts
@@ -20,6 +20,7 @@ export class Usage {
   public readonly totalTokens: number;
   public readonly cost?: number;
   public readonly currency?: Currency;
+  public readonly creditsConsumed?: number;
   public readonly requestId: UUID;
   public readonly createdAt: Date;
 
@@ -34,6 +35,7 @@ export class Usage {
     totalTokens: number;
     cost?: number;
     currency?: Currency;
+    creditsConsumed?: number;
     requestId: UUID;
     createdAt?: Date;
   }) {
@@ -47,6 +49,7 @@ export class Usage {
     this.totalTokens = params.totalTokens;
     this.cost = params.cost;
     this.currency = params.currency;
+    this.creditsConsumed = params.creditsConsumed;
     this.requestId = params.requestId;
     this.createdAt = params.createdAt ?? new Date();
   }

--- a/ayunis-core-backend/src/domain/usage/infrastructure/persistence/local-usage/mappers/usage.mapper.ts
+++ b/ayunis-core-backend/src/domain/usage/infrastructure/persistence/local-usage/mappers/usage.mapper.ts
@@ -16,6 +16,7 @@ export class UsageMapper {
     record.totalTokens = usage.totalTokens;
     record.cost = usage.cost ?? null;
     record.currency = usage.currency ?? null;
+    record.creditsConsumed = usage.creditsConsumed ?? null;
     record.requestId = usage.requestId;
     record.createdAt = usage.createdAt;
     return record;
@@ -33,6 +34,7 @@ export class UsageMapper {
       totalTokens: record.totalTokens,
       cost: record.cost ?? undefined,
       currency: record.currency ?? undefined,
+      creditsConsumed: record.creditsConsumed ?? undefined,
       requestId: record.requestId,
       createdAt: record.createdAt,
     });

--- a/ayunis-core-backend/src/domain/usage/infrastructure/persistence/local-usage/schema/usage.record.ts
+++ b/ayunis-core-backend/src/domain/usage/infrastructure/persistence/local-usage/schema/usage.record.ts
@@ -7,6 +7,12 @@ import { ModelRecord } from '../../../../../models/infrastructure/persistence/lo
 import { ModelProvider } from '../../../../../models/domain/value-objects/model-provider.enum';
 import { Currency } from '../../../../../models/domain/value-objects/currency.enum';
 
+const decimalTransformer = {
+  to: (value?: number | null) => value,
+  from: (value?: string | null) =>
+    value === null || value === undefined ? null : Number(value),
+};
+
 @Entity('usage')
 @Index(['organizationId', 'createdAt'])
 @Index(['userId', 'createdAt'])
@@ -47,7 +53,12 @@ export class UsageRecord extends BaseRecord {
   @Column('integer')
   totalTokens: number;
 
-  @Column('decimal', { precision: 10, scale: 6, nullable: true })
+  @Column('decimal', {
+    precision: 10,
+    scale: 6,
+    nullable: true,
+    transformer: decimalTransformer,
+  })
   cost: number | null;
 
   @Column({
@@ -56,6 +67,14 @@ export class UsageRecord extends BaseRecord {
     nullable: true,
   })
   currency: Currency | null;
+
+  @Column('decimal', {
+    precision: 16,
+    scale: 6,
+    nullable: true,
+    transformer: decimalTransformer,
+  })
+  creditsConsumed: number | null;
 
   @Column('uuid')
   requestId: UUID;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a nullable numeric field to the `usage` table and changes ORM mapping/transformers for decimal columns, which can affect persisted values and type conversions at runtime but is limited in scope.
> 
> **Overview**
> Adds support for tracking *credits consumed* on usage entries by introducing a nullable `creditsConsumed` field end-to-end.
> 
> Includes a new TypeORM migration to add/drop the `creditsConsumed` numeric column on the `usage` table, extends the `Usage` domain entity and `UsageMapper` to read/write it, and updates the TypeORM `UsageRecord` schema to store `creditsConsumed` (and now `cost`) as decimal columns with a transformer that converts DB strings to `number`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5e6577a0bcd564629e1db45841c64236a4d0da82. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->