### PR TITLE
wip(AYC-77): add platform config module with credits-per-euro

### DIFF
--- a/ayunis-core-backend/src/db/migrations/1773098611477-AddCreditsConsumedToUsage.ts
+++ b/ayunis-core-backend/src/db/migrations/1773098611477-AddCreditsConsumedToUsage.ts
@@ -1,14 +1,19 @@
-import { MigrationInterface, QueryRunner } from "typeorm";
+import type { MigrationInterface, QueryRunner } from 'typeorm';
 
-export class AddCreditsConsumedToUsage1773098611477 implements MigrationInterface {
-    name = 'AddCreditsConsumedToUsage1773098611477'
+export class AddCreditsConsumedToUsage1773098611477
+  implements MigrationInterface
+{
+  name = 'AddCreditsConsumedToUsage1773098611477';
 
-    public async up(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.query(`ALTER TABLE "usage" ADD "creditsConsumed" numeric(16,6)`);
-    }
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "usage" ADD "creditsConsumed" numeric(16,6)`,
+    );
+  }
 
-    public async down(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.query(`ALTER TABLE "usage" DROP COLUMN "creditsConsumed"`);
-    }
-
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "usage" DROP COLUMN "creditsConsumed"`,
+    );
+  }
 }

--- a/ayunis-core-backend/src/db/migrations/1773099444636-CreatePlatformConfigTable.ts
+++ b/ayunis-core-backend/src/db/migrations/1773099444636-CreatePlatformConfigTable.ts
@@ -1,0 +1,14 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class CreatePlatformConfigTable1773099444636 implements MigrationInterface {
+    name = 'CreatePlatformConfigTable1773099444636'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`CREATE TABLE "platform_config" ("key" character varying NOT NULL, "value" character varying NOT NULL, CONSTRAINT "PK_e288d39f7103fdc2a057f96b62e" PRIMARY KEY ("key"))`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`DROP TABLE "platform_config"`);
+    }
+
+}

--- a/ayunis-core-backend/src/iam/iam.module.ts
+++ b/ayunis-core-backend/src/iam/iam.module.ts
@@ -15,6 +15,7 @@ import { TrialsModule } from './trials/trials.module';
 import { LegalAcceptancesModule } from './legal-acceptances/legal-acceptances.module';
 import { QuotasModule } from './quotas/quotas.module';
 import { TeamsModule } from './teams/teams.module';
+import { PlatformConfigModule } from './platform-config/platform-config.module';
 
 @Module({})
 export class IamModule {
@@ -36,6 +37,7 @@ export class IamModule {
         LegalAcceptancesModule,
         QuotasModule,
         TeamsModule,
+        PlatformConfigModule,
       ],
       exports: [
         AuthenticationModule,
@@ -49,6 +51,7 @@ export class IamModule {
         LegalAcceptancesModule,
         QuotasModule,
         TeamsModule,
+        PlatformConfigModule,
       ],
     };
   }

--- a/ayunis-core-backend/src/iam/platform-config/application/platform-config.errors.ts
+++ b/ayunis-core-backend/src/iam/platform-config/application/platform-config.errors.ts
@@ -1,0 +1,28 @@
+import { ApplicationError } from '../../../common/errors/base.error';
+
+export enum PlatformConfigErrorCode {
+  CONFIG_NOT_FOUND = 'PLATFORM_CONFIG_NOT_FOUND',
+  INVALID_VALUE = 'PLATFORM_CONFIG_INVALID_VALUE',
+}
+
+export class PlatformConfigNotFoundError extends ApplicationError {
+  constructor(key: string) {
+    super(
+      `Platform config '${key}' is not set`,
+      PlatformConfigErrorCode.CONFIG_NOT_FOUND,
+      404,
+      { key },
+    );
+  }
+}
+
+export class PlatformConfigInvalidValueError extends ApplicationError {
+  constructor(key: string, reason: string) {
+    super(
+      `Invalid value for platform config '${key}': ${reason}`,
+      PlatformConfigErrorCode.INVALID_VALUE,
+      400,
+      { key, reason },
+    );
+  }
+}

--- a/ayunis-core-backend/src/iam/platform-config/application/ports/platform-config.repository.ts
+++ b/ayunis-core-backend/src/iam/platform-config/application/ports/platform-config.repository.ts
@@ -1,0 +1,7 @@
+import type { PlatformConfigKey } from '../../domain/platform-config-keys.enum';
+import type { PlatformConfig } from '../../domain/platform-config.entity';
+
+export abstract class PlatformConfigRepositoryPort {
+  abstract get(key: PlatformConfigKey): Promise<PlatformConfig | null>;
+  abstract set(key: PlatformConfigKey, value: string): Promise<void>;
+}

--- a/ayunis-core-backend/src/iam/platform-config/application/use-cases/get-credits-per-euro/get-credits-per-euro.query.ts
+++ b/ayunis-core-backend/src/iam/platform-config/application/use-cases/get-credits-per-euro/get-credits-per-euro.query.ts
@@ -1,0 +1,1 @@
+export class GetCreditsPerEuroQuery {}

--- a/ayunis-core-backend/src/iam/platform-config/application/use-cases/get-credits-per-euro/get-credits-per-euro.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/platform-config/application/use-cases/get-credits-per-euro/get-credits-per-euro.use-case.spec.ts
@@ -1,0 +1,72 @@
+import { GetCreditsPerEuroUseCase } from './get-credits-per-euro.use-case';
+import type { PlatformConfigRepositoryPort } from '../../ports/platform-config.repository';
+import { PlatformConfig } from '../../../domain/platform-config.entity';
+import {
+  PlatformConfigInvalidValueError,
+  PlatformConfigNotFoundError,
+} from '../../platform-config.errors';
+import { PlatformConfigKey } from '../../../domain/platform-config-keys.enum';
+
+describe('GetCreditsPerEuroUseCase', () => {
+  let useCase: GetCreditsPerEuroUseCase;
+  let repository: jest.Mocked<PlatformConfigRepositoryPort>;
+
+  beforeEach(() => {
+    repository = {
+      get: jest.fn(),
+      set: jest.fn(),
+    } as jest.Mocked<PlatformConfigRepositoryPort>;
+
+    useCase = new GetCreditsPerEuroUseCase(repository);
+  });
+
+  it('should return the credits-per-euro value from the repository', async () => {
+    repository.get.mockResolvedValue(
+      new PlatformConfig({
+        key: PlatformConfigKey.CREDITS_PER_EURO,
+        value: '1000',
+      }),
+    );
+
+    const result = await useCase.execute();
+
+    expect(result).toBe(1000);
+    expect(repository.get).toHaveBeenCalledWith(
+      PlatformConfigKey.CREDITS_PER_EURO,
+    );
+  });
+
+  it('should return a decimal credits-per-euro value correctly', async () => {
+    repository.get.mockResolvedValue(
+      new PlatformConfig({
+        key: PlatformConfigKey.CREDITS_PER_EURO,
+        value: '1500.5',
+      }),
+    );
+
+    const result = await useCase.execute();
+
+    expect(result).toBe(1500.5);
+  });
+
+  it('should throw PlatformConfigNotFoundError when credits-per-euro is not configured', async () => {
+    repository.get.mockResolvedValue(null);
+
+    await expect(useCase.execute()).rejects.toThrow(
+      PlatformConfigNotFoundError,
+    );
+  });
+
+  it('should throw PlatformConfigInvalidValueError when stored value is corrupted', async () => {
+    repository.get.mockResolvedValue(
+      new PlatformConfig({
+        key: PlatformConfigKey.CREDITS_PER_EURO,
+        value: 'abc',
+      }),
+    );
+
+    await expect(useCase.execute()).rejects.toThrow(
+      PlatformConfigInvalidValueError,
+    );
+  });
+});

--- a/ayunis-core-backend/src/iam/platform-config/application/use-cases/get-credits-per-euro/get-credits-per-euro.use-case.ts
+++ b/ayunis-core-backend/src/iam/platform-config/application/use-cases/get-credits-per-euro/get-credits-per-euro.use-case.ts
@@ -1,0 +1,35 @@
+import { Injectable } from '@nestjs/common';
+import { PlatformConfigRepositoryPort } from '../../ports/platform-config.repository';
+import { PlatformConfigKey } from '../../../domain/platform-config-keys.enum';
+import {
+  PlatformConfigInvalidValueError,
+  PlatformConfigNotFoundError,
+} from '../../platform-config.errors';
+
+@Injectable()
+export class GetCreditsPerEuroUseCase {
+  constructor(
+    private readonly configRepository: PlatformConfigRepositoryPort,
+  ) {}
+
+  async execute(): Promise<number> {
+    const config = await this.configRepository.get(
+      PlatformConfigKey.CREDITS_PER_EURO,
+    );
+
+    if (!config) {
+      throw new PlatformConfigNotFoundError(PlatformConfigKey.CREDITS_PER_EURO);
+    }
+
+    const result = parseFloat(config.value);
+
+    if (!Number.isFinite(result)) {
+      throw new PlatformConfigInvalidValueError(
+        PlatformConfigKey.CREDITS_PER_EURO,
+        'stored value is not a valid number',
+      );
+    }
+
+    return result;
+  }
+}

--- a/ayunis-core-backend/src/iam/platform-config/application/use-cases/set-credits-per-euro/set-credits-per-euro.command.ts
+++ b/ayunis-core-backend/src/iam/platform-config/application/use-cases/set-credits-per-euro/set-credits-per-euro.command.ts
@@ -1,0 +1,7 @@
+export class SetCreditsPerEuroCommand {
+  readonly creditsPerEuro: number;
+
+  constructor(params: { creditsPerEuro: number }) {
+    this.creditsPerEuro = params.creditsPerEuro;
+  }
+}

--- a/ayunis-core-backend/src/iam/platform-config/application/use-cases/set-credits-per-euro/set-credits-per-euro.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/platform-config/application/use-cases/set-credits-per-euro/set-credits-per-euro.use-case.spec.ts
@@ -1,0 +1,79 @@
+import { SetCreditsPerEuroUseCase } from './set-credits-per-euro.use-case';
+import { SetCreditsPerEuroCommand } from './set-credits-per-euro.command';
+import type { PlatformConfigRepositoryPort } from '../../ports/platform-config.repository';
+import { PlatformConfigInvalidValueError } from '../../platform-config.errors';
+import { PlatformConfigKey } from '../../../domain/platform-config-keys.enum';
+
+describe('SetCreditsPerEuroUseCase', () => {
+  let useCase: SetCreditsPerEuroUseCase;
+  let repository: jest.Mocked<PlatformConfigRepositoryPort>;
+
+  beforeEach(() => {
+    repository = {
+      get: jest.fn(),
+      set: jest.fn(),
+    } as jest.Mocked<PlatformConfigRepositoryPort>;
+
+    useCase = new SetCreditsPerEuroUseCase(repository);
+  });
+
+  it('should store the credits-per-euro value in the repository', async () => {
+    repository.set.mockResolvedValue(undefined);
+
+    const command = new SetCreditsPerEuroCommand({ creditsPerEuro: 1000 });
+    await useCase.execute(command);
+
+    expect(repository.set).toHaveBeenCalledWith(
+      PlatformConfigKey.CREDITS_PER_EURO,
+      '1000',
+    );
+  });
+
+  it('should store a decimal credits-per-euro value', async () => {
+    repository.set.mockResolvedValue(undefined);
+
+    const command = new SetCreditsPerEuroCommand({ creditsPerEuro: 1500.75 });
+    await useCase.execute(command);
+
+    expect(repository.set).toHaveBeenCalledWith(
+      PlatformConfigKey.CREDITS_PER_EURO,
+      '1500.75',
+    );
+  });
+
+  it('should reject credits-per-euro value of zero', async () => {
+    const command = new SetCreditsPerEuroCommand({ creditsPerEuro: 0 });
+
+    await expect(useCase.execute(command)).rejects.toThrow(
+      PlatformConfigInvalidValueError,
+    );
+    expect(repository.set).not.toHaveBeenCalled();
+  });
+
+  it('should reject negative credits-per-euro value', async () => {
+    const command = new SetCreditsPerEuroCommand({ creditsPerEuro: -50 });
+
+    await expect(useCase.execute(command)).rejects.toThrow(
+      PlatformConfigInvalidValueError,
+    );
+    expect(repository.set).not.toHaveBeenCalled();
+  });
+
+  it('should reject NaN credits-per-euro value', async () => {
+    const command = new SetCreditsPerEuroCommand({ creditsPerEuro: NaN });
+
+    await expect(useCase.execute(command)).rejects.toThrow(
+      PlatformConfigInvalidValueError,
+    );
+    expect(repository.set).not.toHaveBeenCalled();
+  });
+
+  it('should reject Infinity credits-per-euro value', async () => {
+    const command = new SetCreditsPerEuroCommand({ creditsPerEuro: Infinity });
+
+    await expect(useCase.execute(command)).rejects.toThrow(
+      PlatformConfigInvalidValueError,
+    );
+    expect(repository.set).not.toHaveBeenCalled();
+  });
+});

--- a/ayunis-core-backend/src/iam/platform-config/application/use-cases/set-credits-per-euro/set-credits-per-euro.use-case.ts
+++ b/ayunis-core-backend/src/iam/platform-config/application/use-cases/set-credits-per-euro/set-credits-per-euro.use-case.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@nestjs/common';
+import { PlatformConfigRepositoryPort } from '../../ports/platform-config.repository';
+import { PlatformConfigKey } from '../../../domain/platform-config-keys.enum';
+import { PlatformConfigInvalidValueError } from '../../platform-config.errors';
+import { SetCreditsPerEuroCommand } from './set-credits-per-euro.command';
+
+@Injectable()
+export class SetCreditsPerEuroUseCase {
+  constructor(
+    private readonly configRepository: PlatformConfigRepositoryPort,
+  ) {}
+
+  async execute(command: SetCreditsPerEuroCommand): Promise<void> {
+    if (!Number.isFinite(command.creditsPerEuro) || command.creditsPerEuro <= 0) {
+      throw new PlatformConfigInvalidValueError(
+        PlatformConfigKey.CREDITS_PER_EURO,
+        'must be greater than 0',
+      );
+    }
+
+    await this.configRepository.set(
+      PlatformConfigKey.CREDITS_PER_EURO,
+      command.creditsPerEuro.toString(),
+    );
+  }
+}

--- a/ayunis-core-backend/src/iam/platform-config/domain/platform-config-keys.enum.ts
+++ b/ayunis-core-backend/src/iam/platform-config/domain/platform-config-keys.enum.ts
@@ -1,0 +1,3 @@
+export enum PlatformConfigKey {
+  CREDITS_PER_EURO = 'CREDITS_PER_EURO',
+}

--- a/ayunis-core-backend/src/iam/platform-config/domain/platform-config.entity.ts
+++ b/ayunis-core-backend/src/iam/platform-config/domain/platform-config.entity.ts
@@ -1,0 +1,14 @@
+export interface PlatformConfigParams {
+  key: string;
+  value: string;
+}
+
+export class PlatformConfig {
+  public readonly key: string;
+  public readonly value: string;
+
+  constructor(params: PlatformConfigParams) {
+    this.key = params.key;
+    this.value = params.value;
+  }
+}

--- a/ayunis-core-backend/src/iam/platform-config/infrastructure/persistence/postgres/platform-config.repository.ts
+++ b/ayunis-core-backend/src/iam/platform-config/infrastructure/persistence/postgres/platform-config.repository.ts
@@ -1,0 +1,31 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { PlatformConfigRepositoryPort } from '../../../application/ports/platform-config.repository';
+import type { PlatformConfigKey } from '../../../domain/platform-config-keys.enum';
+import { PlatformConfig } from '../../../domain/platform-config.entity';
+import { PlatformConfigRecord } from './schema/platform-config.record';
+
+@Injectable()
+export class PlatformConfigRepository extends PlatformConfigRepositoryPort {
+  constructor(
+    @InjectRepository(PlatformConfigRecord)
+    private readonly repository: Repository<PlatformConfigRecord>,
+  ) {
+    super();
+  }
+
+  async get(key: PlatformConfigKey): Promise<PlatformConfig | null> {
+    const record = await this.repository.findOne({ where: { key } });
+
+    if (!record) {
+      return null;
+    }
+
+    return new PlatformConfig({ key: record.key, value: record.value });
+  }
+
+  async set(key: PlatformConfigKey, value: string): Promise<void> {
+    await this.repository.upsert({ key, value }, ['key']);
+  }
+}

--- a/ayunis-core-backend/src/iam/platform-config/infrastructure/persistence/postgres/schema/platform-config.record.ts
+++ b/ayunis-core-backend/src/iam/platform-config/infrastructure/persistence/postgres/schema/platform-config.record.ts
@@ -1,0 +1,10 @@
+import { Entity, Column, PrimaryColumn } from 'typeorm';
+
+@Entity('platform_config')
+export class PlatformConfigRecord {
+  @PrimaryColumn({ type: 'varchar' })
+  key: string;
+
+  @Column({ type: 'varchar' })
+  value: string;
+}

--- a/ayunis-core-backend/src/iam/platform-config/platform-config.module.ts
+++ b/ayunis-core-backend/src/iam/platform-config/platform-config.module.ts
@@ -1,0 +1,23 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { PlatformConfigRecord } from './infrastructure/persistence/postgres/schema/platform-config.record';
+import { PlatformConfigRepositoryPort } from './application/ports/platform-config.repository';
+import { PlatformConfigRepository } from './infrastructure/persistence/postgres/platform-config.repository';
+import { GetCreditsPerEuroUseCase } from './application/use-cases/get-credits-per-euro/get-credits-per-euro.use-case';
+import { SetCreditsPerEuroUseCase } from './application/use-cases/set-credits-per-euro/set-credits-per-euro.use-case';
+import { SuperAdminPlatformConfigController } from './presenters/http/super-admin-platform-config.controller';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([PlatformConfigRecord])],
+  controllers: [SuperAdminPlatformConfigController],
+  providers: [
+    {
+      provide: PlatformConfigRepositoryPort,
+      useClass: PlatformConfigRepository,
+    },
+    GetCreditsPerEuroUseCase,
+    SetCreditsPerEuroUseCase,
+  ],
+  exports: [GetCreditsPerEuroUseCase],
+})
+export class PlatformConfigModule {}

--- a/ayunis-core-backend/src/iam/platform-config/presenters/http/dto/credits-per-euro-response.dto.ts
+++ b/ayunis-core-backend/src/iam/platform-config/presenters/http/dto/credits-per-euro-response.dto.ts
@@ -1,0 +1,10 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class CreditsPerEuroResponseDto {
+  @ApiProperty({
+    description: 'Number of credits per euro of token cost',
+    example: 1000,
+    type: Number,
+  })
+  creditsPerEuro: number;
+}

--- a/ayunis-core-backend/src/iam/platform-config/presenters/http/dto/set-credits-per-euro-request.dto.ts
+++ b/ayunis-core-backend/src/iam/platform-config/presenters/http/dto/set-credits-per-euro-request.dto.ts
@@ -1,0 +1,13 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNumber, IsPositive } from 'class-validator';
+
+export class SetCreditsPerEuroRequestDto {
+  @ApiProperty({
+    description: 'Number of credits per euro of token cost. Must be positive.',
+    example: 1000,
+    type: Number,
+  })
+  @IsNumber()
+  @IsPositive()
+  creditsPerEuro: number;
+}

--- a/ayunis-core-backend/src/iam/platform-config/presenters/http/super-admin-platform-config.controller.ts
+++ b/ayunis-core-backend/src/iam/platform-config/presenters/http/super-admin-platform-config.controller.ts
@@ -1,0 +1,95 @@
+import {
+  Controller,
+  Get,
+  Put,
+  Body,
+  Logger,
+  HttpCode,
+  HttpStatus,
+} from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiUnauthorizedResponse,
+  ApiInternalServerErrorResponse,
+} from '@nestjs/swagger';
+import { SystemRoles } from 'src/iam/authorization/application/decorators/system-roles.decorator';
+import { SystemRole } from 'src/iam/users/domain/value-objects/system-role.enum';
+import { GetCreditsPerEuroUseCase } from '../../application/use-cases/get-credits-per-euro/get-credits-per-euro.use-case';
+import { SetCreditsPerEuroUseCase } from '../../application/use-cases/set-credits-per-euro/set-credits-per-euro.use-case';
+import { SetCreditsPerEuroCommand } from '../../application/use-cases/set-credits-per-euro/set-credits-per-euro.command';
+import { CreditsPerEuroResponseDto } from './dto/credits-per-euro-response.dto';
+import { SetCreditsPerEuroRequestDto } from './dto/set-credits-per-euro-request.dto';
+
+@ApiTags('Super Admin Platform Config')
+@Controller('super-admin/platform-config')
+@SystemRoles(SystemRole.SUPER_ADMIN)
+export class SuperAdminPlatformConfigController {
+  private readonly logger = new Logger(SuperAdminPlatformConfigController.name);
+
+  constructor(
+    private readonly getCreditsPerEuroUseCase: GetCreditsPerEuroUseCase,
+    private readonly setCreditsPerEuroUseCase: SetCreditsPerEuroUseCase,
+  ) {}
+
+  @Get('credits-per-euro')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Get the current credits-per-euro configuration',
+    description:
+      'Retrieve the global credits-per-euro value used for credit calculations. Super admin only.',
+  })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'Successfully retrieved credits-per-euro value',
+    type: CreditsPerEuroResponseDto,
+  })
+  @ApiResponse({
+    status: HttpStatus.NOT_FOUND,
+    description: 'Credits-per-euro value has not been configured',
+  })
+  @ApiUnauthorizedResponse({
+    description: 'User not authenticated or not authorized as super admin',
+  })
+  @ApiInternalServerErrorResponse({
+    description: 'Internal server error',
+  })
+  async getCreditsPerEuro(): Promise<CreditsPerEuroResponseDto> {
+    this.logger.log('Getting credits-per-euro configuration');
+    const creditsPerEuro = await this.getCreditsPerEuroUseCase.execute();
+    return { creditsPerEuro };
+  }
+
+  @Put('credits-per-euro')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({
+    summary: 'Set the credits-per-euro configuration',
+    description:
+      'Update the global credits-per-euro value used for credit calculations. Super admin only.',
+  })
+  @ApiResponse({
+    status: HttpStatus.NO_CONTENT,
+    description: 'Successfully updated credits-per-euro value',
+  })
+  @ApiResponse({
+    status: HttpStatus.BAD_REQUEST,
+    description: 'Invalid value provided (must be positive number)',
+  })
+  @ApiUnauthorizedResponse({
+    description: 'User not authenticated or not authorized as super admin',
+  })
+  @ApiInternalServerErrorResponse({
+    description: 'Internal server error',
+  })
+  async setCreditsPerEuro(
+    @Body() dto: SetCreditsPerEuroRequestDto,
+  ): Promise<void> {
+    this.logger.log(`Setting credits-per-euro to ${dto.creditsPerEuro}`);
+    const command = new SetCreditsPerEuroCommand({
+      creditsPerEuro: dto.creditsPerEuro,
+    });
+    await this.setCreditsPerEuroUseCase.execute(command);
+    this.logger.log('Successfully updated credits-per-euro configuration');
+  }
+}

--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
@@ -3517,6 +3517,16 @@ export interface MeResponseDto {
   name: string;
 }
 
+export interface CreditsPerEuroResponseDto {
+  /** Number of credits per euro of token cost */
+  creditsPerEuro: number;
+}
+
+export interface SetCreditsPerEuroRequestDto {
+  /** Number of credits per euro of token cost. Must be positive. */
+  creditsPerEuro: number;
+}
+
 export type SuperAdminModelsControllerGetCatalogModelById200 = LanguageModelResponseDto | EmbeddingModelResponseDto;
 
 export type SuperAdminModelsControllerGetPermittedModels200Item = PermittedLanguageModelResponseDto | PermittedEmbeddingModelResponseDto;

--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.ts
@@ -61,6 +61,7 @@ import type {
   CreateThreadDto,
   CreateTrialRequestDto,
   CreateUserDto,
+  CreditsPerEuroResponseDto,
   DeleteAllPendingInvitesResponseDto,
   EmbeddingModelEnabledResponseDto,
   EmbeddingModelResponseDto,
@@ -109,6 +110,7 @@ import type {
   RevertArtifactDto,
   RunsControllerSendMessage200,
   RunsControllerSendMessageBody,
+  SetCreditsPerEuroRequestDto,
   SetOrgDefaultModelDto,
   SetUserConfigDto,
   SetUserDefaultModelDto,
@@ -15218,6 +15220,165 @@ export const useAuthenticationControllerLogout = <TError = unknown,
       > => {
 
       const mutationOptions = getAuthenticationControllerLogoutMutationOptions(options);
+
+      return useMutation(mutationOptions, queryClient);
+    }
+    
+/**
+ * Retrieve the global credits-per-euro value used for credit calculations. Super admin only.
+ * @summary Get the current credits-per-euro configuration
+ */
+export const superAdminPlatformConfigControllerGetCreditsPerEuro = (
+    
+ signal?: AbortSignal
+) => {
+      
+      
+      return customAxiosInstance<CreditsPerEuroResponseDto>(
+      {url: `/super-admin/platform-config/credits-per-euro`, method: 'GET', signal
+    },
+      );
+    }
+  
+
+
+
+export const getSuperAdminPlatformConfigControllerGetCreditsPerEuroQueryKey = () => {
+    return [
+    `/super-admin/platform-config/credits-per-euro`
+    ] as const;
+    }
+
+    
+export const getSuperAdminPlatformConfigControllerGetCreditsPerEuroQueryOptions = <TData = Awaited<ReturnType<typeof superAdminPlatformConfigControllerGetCreditsPerEuro>>, TError = void>( options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof superAdminPlatformConfigControllerGetCreditsPerEuro>>, TError, TData>>, }
+) => {
+
+const {query: queryOptions} = options ?? {};
+
+  const queryKey =  queryOptions?.queryKey ?? getSuperAdminPlatformConfigControllerGetCreditsPerEuroQueryKey();
+
+  
+
+    const queryFn: QueryFunction<Awaited<ReturnType<typeof superAdminPlatformConfigControllerGetCreditsPerEuro>>> = ({ signal }) => superAdminPlatformConfigControllerGetCreditsPerEuro(signal);
+
+      
+
+      
+
+   return  { queryKey, queryFn, ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof superAdminPlatformConfigControllerGetCreditsPerEuro>>, TError, TData> & { queryKey: DataTag<QueryKey, TData, TError> }
+}
+
+export type SuperAdminPlatformConfigControllerGetCreditsPerEuroQueryResult = NonNullable<Awaited<ReturnType<typeof superAdminPlatformConfigControllerGetCreditsPerEuro>>>
+export type SuperAdminPlatformConfigControllerGetCreditsPerEuroQueryError = void
+
+
+export function useSuperAdminPlatformConfigControllerGetCreditsPerEuro<TData = Awaited<ReturnType<typeof superAdminPlatformConfigControllerGetCreditsPerEuro>>, TError = void>(
+  options: { query:Partial<UseQueryOptions<Awaited<ReturnType<typeof superAdminPlatformConfigControllerGetCreditsPerEuro>>, TError, TData>> & Pick<
+        DefinedInitialDataOptions<
+          Awaited<ReturnType<typeof superAdminPlatformConfigControllerGetCreditsPerEuro>>,
+          TError,
+          Awaited<ReturnType<typeof superAdminPlatformConfigControllerGetCreditsPerEuro>>
+        > , 'initialData'
+      >, }
+ , queryClient?: QueryClient
+  ):  DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useSuperAdminPlatformConfigControllerGetCreditsPerEuro<TData = Awaited<ReturnType<typeof superAdminPlatformConfigControllerGetCreditsPerEuro>>, TError = void>(
+  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof superAdminPlatformConfigControllerGetCreditsPerEuro>>, TError, TData>> & Pick<
+        UndefinedInitialDataOptions<
+          Awaited<ReturnType<typeof superAdminPlatformConfigControllerGetCreditsPerEuro>>,
+          TError,
+          Awaited<ReturnType<typeof superAdminPlatformConfigControllerGetCreditsPerEuro>>
+        > , 'initialData'
+      >, }
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useSuperAdminPlatformConfigControllerGetCreditsPerEuro<TData = Awaited<ReturnType<typeof superAdminPlatformConfigControllerGetCreditsPerEuro>>, TError = void>(
+  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof superAdminPlatformConfigControllerGetCreditsPerEuro>>, TError, TData>>, }
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+/**
+ * @summary Get the current credits-per-euro configuration
+ */
+
+export function useSuperAdminPlatformConfigControllerGetCreditsPerEuro<TData = Awaited<ReturnType<typeof superAdminPlatformConfigControllerGetCreditsPerEuro>>, TError = void>(
+  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof superAdminPlatformConfigControllerGetCreditsPerEuro>>, TError, TData>>, }
+ , queryClient?: QueryClient 
+ ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
+
+  const queryOptions = getSuperAdminPlatformConfigControllerGetCreditsPerEuroQueryOptions(options)
+
+  const query = useQuery(queryOptions, queryClient) as  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+
+  query.queryKey = queryOptions.queryKey ;
+
+  return query;
+}
+
+
+
+
+
+/**
+ * Update the global credits-per-euro value used for credit calculations. Super admin only.
+ * @summary Set the credits-per-euro configuration
+ */
+export const superAdminPlatformConfigControllerSetCreditsPerEuro = (
+    setCreditsPerEuroRequestDto: SetCreditsPerEuroRequestDto,
+ ) => {
+      
+      
+      return customAxiosInstance<void>(
+      {url: `/super-admin/platform-config/credits-per-euro`, method: 'PUT',
+      headers: {'Content-Type': 'application/json', },
+      data: setCreditsPerEuroRequestDto
+    },
+      );
+    }
+  
+
+
+export const getSuperAdminPlatformConfigControllerSetCreditsPerEuroMutationOptions = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof superAdminPlatformConfigControllerSetCreditsPerEuro>>, TError,{data: SetCreditsPerEuroRequestDto}, TContext>, }
+): UseMutationOptions<Awaited<ReturnType<typeof superAdminPlatformConfigControllerSetCreditsPerEuro>>, TError,{data: SetCreditsPerEuroRequestDto}, TContext> => {
+
+const mutationKey = ['superAdminPlatformConfigControllerSetCreditsPerEuro'];
+const {mutation: mutationOptions} = options ?
+      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
+      options
+      : {...options, mutation: {...options.mutation, mutationKey}}
+      : {mutation: { mutationKey, }};
+
+      
+
+
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof superAdminPlatformConfigControllerSetCreditsPerEuro>>, {data: SetCreditsPerEuroRequestDto}> = (props) => {
+          const {data} = props ?? {};
+
+          return  superAdminPlatformConfigControllerSetCreditsPerEuro(data,)
+        }
+
+        
+
+
+  return  { mutationFn, ...mutationOptions }}
+
+    export type SuperAdminPlatformConfigControllerSetCreditsPerEuroMutationResult = NonNullable<Awaited<ReturnType<typeof superAdminPlatformConfigControllerSetCreditsPerEuro>>>
+    export type SuperAdminPlatformConfigControllerSetCreditsPerEuroMutationBody = SetCreditsPerEuroRequestDto
+    export type SuperAdminPlatformConfigControllerSetCreditsPerEuroMutationError = void
+
+    /**
+ * @summary Set the credits-per-euro configuration
+ */
+export const useSuperAdminPlatformConfigControllerSetCreditsPerEuro = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof superAdminPlatformConfigControllerSetCreditsPerEuro>>, TError,{data: SetCreditsPerEuroRequestDto}, TContext>, }
+ , queryClient?: QueryClient): UseMutationResult<
+        Awaited<ReturnType<typeof superAdminPlatformConfigControllerSetCreditsPerEuro>>,
+        TError,
+        {data: SetCreditsPerEuroRequestDto},
+        TContext
+      > => {
+
+      const mutationOptions = getSuperAdminPlatformConfigControllerSetCreditsPerEuroMutationOptions(options);
 
       return useMutation(mutationOptions, queryClient);
     }

--- a/ayunis-core-frontend/src/shared/api/openapi-schema.json
+++ b/ayunis-core-frontend/src/shared/api/openapi-schema.json
@@ -8144,6 +8144,71 @@
           "Authentication"
         ]
       }
+    },
+    "/super-admin/platform-config/credits-per-euro": {
+      "get": {
+        "description": "Retrieve the global credits-per-euro value used for credit calculations. Super admin only.",
+        "operationId": "SuperAdminPlatformConfigController_getCreditsPerEuro",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved credits-per-euro value",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreditsPerEuroResponseDto"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "User not authenticated or not authorized as super admin"
+          },
+          "404": {
+            "description": "Credits-per-euro value has not been configured"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "summary": "Get the current credits-per-euro configuration",
+        "tags": [
+          "Super Admin Platform Config"
+        ]
+      },
+      "put": {
+        "description": "Update the global credits-per-euro value used for credit calculations. Super admin only.",
+        "operationId": "SuperAdminPlatformConfigController_setCreditsPerEuro",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetCreditsPerEuroRequestDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "description": "Successfully updated credits-per-euro value"
+          },
+          "400": {
+            "description": "Invalid value provided (must be positive number)"
+          },
+          "401": {
+            "description": "User not authenticated or not authorized as super admin"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "summary": "Set the credits-per-euro configuration",
+        "tags": [
+          "Super Admin Platform Config"
+        ]
+      }
     }
   },
   "info": {
@@ -14214,6 +14279,32 @@
           "role",
           "systemRole",
           "name"
+        ]
+      },
+      "CreditsPerEuroResponseDto": {
+        "type": "object",
+        "properties": {
+          "creditsPerEuro": {
+            "type": "number",
+            "description": "Number of credits per euro of token cost",
+            "example": 1000
+          }
+        },
+        "required": [
+          "creditsPerEuro"
+        ]
+      },
+      "SetCreditsPerEuroRequestDto": {
+        "type": "object",
+        "properties": {
+          "creditsPerEuro": {
+            "type": "number",
+            "description": "Number of credits per euro of token cost. Must be positive.",
+            "example": 1000
+          }
+        },
+        "required": [
+          "creditsPerEuro"
         ]
       }
     }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds new database tables/migrations and a super-admin-only API for mutating global configuration, which could impact billing/credit calculations if misconfigured. Risk is limited by role-gating and input validation but still touches core pricing parameters.
> 
> **Overview**
> Introduces a new **platform configuration** capability persisted in Postgres via the new `platform_config` table, plus a `PlatformConfigModule` wired into `IamModule`.
> 
> Adds super-admin endpoints `GET`/`PUT /super-admin/platform-config/credits-per-euro` backed by `GetCreditsPerEuroUseCase`/`SetCreditsPerEuroUseCase`, including validation and explicit `404`/`400` application errors.
> 
> Separately adds a `creditsConsumed` column to the `usage` table, and updates the frontend’s generated OpenAPI client/schema to include the new platform-config endpoints and DTOs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8c9091cddb4ebbe5d6aa4e8dfddafc51bed99781. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->