### PR TITLE
fix(AYC-000): fix repo name for docs update

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -181,5 +181,5 @@ jobs:
         uses: peter-evans/repository-dispatch@v3
         with:
           token: ${{ secrets.DOCS_REPO_PAT }}
-          repository: ayunis/ayunis-core-docs
+          repository: ayunis-core/ayunis-core-docs
           event-type: release-published


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk workflow-only change that just updates the target repository for the docs dispatch event; main risk is misrouting or failing the docs update trigger if the repo name is still incorrect.
> 
> **Overview**
> Fixes the release workflow’s docs-update trigger by updating the `repository-dispatch` target from `ayunis/ayunis-core-docs` to `ayunis-core/ayunis-core-docs`, so the `release-published` event is sent to the correct docs repository after production deploy.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bd0435edfa1b95838c2c7653270f3070d30fb59d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->