### PR TITLE
fix(AYC-000): improve prompt to avoid content warning flag from ms azure

### DIFF
--- a/ayunis-core-backend/src/domain/chat-settings/application/use-cases/generate-personalized-system-prompt/generate-personalized-system-prompt.use-case.ts
+++ b/ayunis-core-backend/src/domain/chat-settings/application/use-cases/generate-personalized-system-prompt/generate-personalized-system-prompt.use-case.ts
@@ -100,14 +100,19 @@ export class GeneratePersonalizedSystemPromptUseCase {
   ): Promise<string> {
     const userInput = this.buildUserInputSummary(command);
 
-    const prompt = `Based on the user's preferences below, write personalized instructions for an AI assistant (2-4 sentences). The instructions should define the assistant's tone and communication style without restricting what topics the user can ask about. Write the instructions in the SAME LANGUAGE as the user's input.
+    const instructions =
+      'You are a helpful configuration assistant for a municipal workplace AI tool. ' +
+      'Your task is to write personalized instructions (2-4 sentences) that define ' +
+      "the assistant's tone and communication style based on user preferences. " +
+      'Do not restrict what topics the user can ask about. ' +
+      'Write the instructions in the SAME LANGUAGE as the user input. ' +
+      'Generate ONLY the instruction text, nothing else.';
 
-User preferences:
-${userInput}
-
-Generate ONLY the instruction text, nothing else.`;
-
-    const response = await this.callInference(prompt, model);
+    const response = await this.callInference(
+      `My preferences:\n${userInput}`,
+      model,
+      instructions,
+    );
     return this.extractTextFromResponse(response);
   }
 
@@ -116,14 +121,19 @@ Generate ONLY the instruction text, nothing else.`;
     preferredName: string,
     model: LanguageModel,
   ): Promise<string> {
-    const prompt = `Based on the following assistant instructions and the user's name, generate a short, warm welcome message (1-2 sentences). Write the welcome message in the SAME LANGUAGE as the instructions. Address the user by their name.
+    const instructions =
+      'You are a helpful configuration assistant for a municipal workplace AI tool. ' +
+      'Your task is to generate a short, warm welcome message (1-2 sentences) ' +
+      'based on assistant instructions and a user name. ' +
+      'Write the welcome message in the SAME LANGUAGE as the instructions. ' +
+      'Address the user by their name. ' +
+      'Generate ONLY the welcome message text, nothing else.';
 
-Assistant instructions: "${systemPrompt}"
-User's name: "${preferredName}"
+    const userMessage =
+      `Assistant instructions: "${systemPrompt}"\n` +
+      `User's name: "${preferredName}"`;
 
-Generate ONLY the welcome message text, nothing else.`;
-
-    const response = await this.callInference(prompt, model);
+    const response = await this.callInference(userMessage, model, instructions);
     return this.extractTextFromResponse(response);
   }
 
@@ -153,6 +163,7 @@ Generate ONLY the welcome message text, nothing else.`;
   private async callInference(
     prompt: string,
     model: LanguageModel,
+    instructions?: string,
   ): Promise<InferenceResponse> {
     return this.getInferenceUseCase.execute(
       new GetInferenceCommand({
@@ -165,6 +176,7 @@ Generate ONLY the welcome message text, nothing else.`;
         ],
         tools: [],
         toolChoice: ModelToolChoice.AUTO,
+        instructions,
       }),
     );
   }

--- a/ayunis-core-backend/src/domain/models/application/ports/inference.handler.ts
+++ b/ayunis-core-backend/src/domain/models/application/ports/inference.handler.ts
@@ -9,7 +9,7 @@ import type { Model } from '../../domain/model.entity';
 export class InferenceInput {
   public readonly model: Model;
   public readonly messages: Message[];
-  public readonly systemPrompt: string;
+  public readonly systemPrompt?: string;
   public readonly tools: Tool[];
   public readonly toolChoice?: ModelToolChoice;
   public readonly orgId: string;
@@ -17,16 +17,17 @@ export class InferenceInput {
   constructor(params: {
     model: Model;
     messages: Message[];
+    systemPrompt?: string;
     tools: Tool[];
     toolChoice: ModelToolChoice;
     orgId: string;
   }) {
     this.model = params.model;
     this.messages = params.messages;
+    this.systemPrompt = params.systemPrompt;
     this.tools = params.tools;
     // only set toolChoice if tools are provided
-    this.toolChoice =
-      params.tools && params.tools.length > 0 ? params.toolChoice : undefined;
+    this.toolChoice = params.tools.length > 0 ? params.toolChoice : undefined;
     this.orgId = params.orgId;
   }
 }

--- a/ayunis-core-backend/src/domain/models/application/use-cases/get-inference/get-inference.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/get-inference/get-inference.use-case.ts
@@ -38,6 +38,7 @@ export class GetInferenceUseCase {
           new InferenceInput({
             model: command.model,
             messages: command.messages,
+            systemPrompt: command.instructions,
             tools: command.tools,
             toolChoice: command.toolChoice,
             orgId,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes how prompts are packaged and routed through the shared inference layer (`InferenceInput.systemPrompt`), which can affect model behavior across providers if any handler assumes the field is always present.
> 
> **Overview**
> Updates personalized system prompt and welcome message generation to separate *system-level instructions* from the user message, sending preferences/name as the user content while passing the new guidance via `GetInferenceCommand.instructions`.
> 
> Plumbs this through the inference pipeline by mapping `instructions` to `InferenceInput.systemPrompt`, and makes `systemPrompt` optional in `InferenceInput` (plus a small `toolChoice` conditional simplification).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f69f318584cf497201704954d7fa86dc5f7b5fbd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->