### PR TITLE
fix(AYC-000): show helpful error for URLs pointing to PDFs

### DIFF
--- a/ayunis-core-backend/src/domain/retrievers/url-retrievers/application/url-retriever.errors.ts
+++ b/ayunis-core-backend/src/domain/retrievers/url-retrievers/application/url-retriever.errors.ts
@@ -4,6 +4,7 @@ import {
   NotFoundException,
   InternalServerErrorException,
   RequestTimeoutException,
+  UnprocessableEntityException,
 } from '@nestjs/common';
 
 /**
@@ -15,6 +16,7 @@ export enum UrlRetrieverErrorCode {
   TIMEOUT = 'TIMEOUT',
   HTTP_ERROR = 'HTTP_ERROR',
   PARSING_ERROR = 'PARSING_ERROR',
+  UNSUPPORTED_CONTENT_TYPE = 'UNSUPPORTED_CONTENT_TYPE',
 }
 
 /**
@@ -43,6 +45,12 @@ export abstract class UrlRetrieverError extends ApplicationError {
         });
       case 408:
         return new RequestTimeoutException({
+          code: this.code,
+          message: this.message,
+          ...(this.metadata && { metadata: this.metadata }),
+        });
+      case 422:
+        return new UnprocessableEntityException({
           code: this.code,
           message: this.message,
           ...(this.metadata && { metadata: this.metadata }),
@@ -109,5 +117,17 @@ export class UrlRetrieverParsingError extends UrlRetrieverError {
       metadata,
     );
     this.name = 'UrlRetrieverParsingError';
+  }
+}
+
+export class UrlRetrieverUnsupportedContentTypeError extends UrlRetrieverError {
+  constructor(url: string, contentType: string, metadata?: ErrorMetadata) {
+    super(
+      `Unsupported content type '${contentType}' for URL '${url}'`,
+      UrlRetrieverErrorCode.UNSUPPORTED_CONTENT_TYPE,
+      422,
+      metadata,
+    );
+    this.name = 'UrlRetrieverUnsupportedContentTypeError';
   }
 }

--- a/ayunis-core-backend/src/domain/retrievers/url-retrievers/infrastructure/cheerio.url-retriever.ts
+++ b/ayunis-core-backend/src/domain/retrievers/url-retrievers/infrastructure/cheerio.url-retriever.ts
@@ -11,6 +11,7 @@ import {
   UrlRetrieverTimeoutError,
   UrlRetrieverHttpError,
   UrlRetrieverParsingError,
+  UrlRetrieverUnsupportedContentTypeError,
   UrlRetrieverError,
 } from '../application/url-retriever.errors';
 
@@ -21,95 +22,98 @@ export class CheerioUrlRetrieverHandler extends UrlRetrieverHandler {
 
   constructor(private readonly configService: ConfigService) {
     super();
-    this.defaultTimeout = this.configService.get<number>('url.timeout') || 5000;
+    this.defaultTimeout = this.configService.get<number>('url.timeout') ?? 5000;
   }
 
   async retrieveUrl(input: UrlRetrieverInput): Promise<UrlRetrieverResult> {
     try {
-      this.logger.debug(`Retrieving URL: ${input.url} with Cheerio handler`);
-
-      // Create AbortController for timeout handling
-      const timeout = (input.options?.timeout as number) || this.defaultTimeout;
-      const controller = new AbortController();
-      const timeoutId = setTimeout(() => controller.abort(), timeout);
-
-      try {
-        // Make the HTTP request with fetch
-        const response = await fetch(input.url, {
-          signal: controller.signal,
-          headers: {
-            'User-Agent': 'Ayunis/1.0',
-          },
-        });
-
-        // Clear the timeout
-        clearTimeout(timeoutId);
-
-        if (!response.ok) {
-          throw new UrlRetrieverHttpError(input.url, response.status, {
-            statusText: response.statusText,
-          });
-        }
-
-        // Get HTML content
-        const html = await response.text();
-
-        try {
-          // Extract text content from HTML using cheerio
-          const $ = cheerio.load(html);
-
-          // Remove script and style elements that contain non-readable content
-          $('script, style, meta, link').remove();
-
-          // Get the text content
-          const textContent = $('body').text();
-
-          // Clean up the text (remove extra whitespace)
-          const cleanedText = textContent.replace(/\s+/g, ' ').trim();
-
-          // Get the website title
-          const websiteTitle = $('title').text();
-
-          return new UrlRetrieverResult(cleanedText, input.url, websiteTitle);
-        } catch (error) {
-          throw new UrlRetrieverParsingError(
-            input.url,
-            error instanceof Error ? error.message : 'Unknown error',
-            {
-              error: error instanceof Error ? error.stack : 'Unknown error',
-            },
-          );
-        }
-      } catch (error) {
-        // Clear the timeout if not already cleared
-        clearTimeout(timeoutId);
-
-        if (error instanceof Error && error.name === 'AbortError') {
-          throw new UrlRetrieverTimeoutError(input.url, timeout, {
-            originalError:
-              error instanceof Error ? error.message : 'Unknown error',
-          });
-        }
-        throw error; // Re-throw for the outer catch block
-      }
+      return await this.fetchAndParse(input);
     } catch (error) {
-      // Log the error with appropriate details
-      this.logger.error(
-        `HTTP URL retrieval failed: ${error instanceof Error ? error.message : 'Unknown error'}`,
-        error instanceof Error ? error.stack : 'Unknown error',
-      );
+      return this.handleTopLevelError(error);
+    }
+  }
 
-      // If error is already one of our domain errors, rethrow it
-      if (error instanceof UrlRetrieverError) {
-        throw error;
+  private async fetchAndParse(
+    input: UrlRetrieverInput,
+  ): Promise<UrlRetrieverResult> {
+    this.logger.debug(`Retrieving URL: ${input.url} with Cheerio handler`);
+
+    const timeout =
+      (input.options?.timeout as number | undefined) ?? this.defaultTimeout;
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), timeout);
+
+    try {
+      const response = await fetch(input.url, {
+        signal: controller.signal,
+        headers: { 'User-Agent': 'Ayunis/1.0' },
+      });
+      clearTimeout(timeoutId);
+
+      this.validateResponse(response, input.url);
+
+      return this.parseHtml(await response.text(), input.url);
+    } catch (error) {
+      clearTimeout(timeoutId);
+
+      if (error instanceof Error && error.name === 'AbortError') {
+        throw new UrlRetrieverTimeoutError(input.url, timeout, {
+          originalError: error.message,
+        });
       }
+      throw error;
+    }
+  }
 
-      // Otherwise wrap in a generic retrieval error
-      throw new UrlRetrieverRetrievalError(`Failed to retrieve URL with HTTP`, {
-        url: input.url,
-        error: error instanceof Error ? error.message : 'Unknown error',
-        stack: error instanceof Error ? error.stack : 'Unknown error',
+  private validateResponse(response: Response, url: string): void {
+    if (!response.ok) {
+      throw new UrlRetrieverHttpError(url, response.status, {
+        statusText: response.statusText,
       });
     }
+
+    const contentType =
+      response.headers.get('content-type')?.toLowerCase() ?? '';
+    if (contentType && !contentType.includes('text/html')) {
+      throw new UrlRetrieverUnsupportedContentTypeError(
+        url,
+        contentType.split(';')[0].trim(),
+      );
+    }
+  }
+
+  private parseHtml(html: string, url: string): UrlRetrieverResult {
+    try {
+      const $ = cheerio.load(html);
+      $('script, style, meta, link').remove();
+
+      const textContent = $('body').text();
+      const cleanedText = textContent.replace(/\s+/g, ' ').trim();
+      const websiteTitle = $('title').text();
+
+      return new UrlRetrieverResult(cleanedText, url, websiteTitle);
+    } catch (error) {
+      throw new UrlRetrieverParsingError(
+        url,
+        error instanceof Error ? error.message : 'Unknown error',
+        { error: error instanceof Error ? error.stack : 'Unknown error' },
+      );
+    }
+  }
+
+  private handleTopLevelError(error: unknown): never {
+    this.logger.error(
+      `HTTP URL retrieval failed: ${error instanceof Error ? error.message : 'Unknown error'}`,
+      error instanceof Error ? error.stack : 'Unknown error',
+    );
+
+    if (error instanceof UrlRetrieverError) {
+      throw error;
+    }
+
+    throw new UrlRetrieverRetrievalError('Failed to retrieve URL with HTTP', {
+      error: error instanceof Error ? error.message : 'Unknown error',
+      stack: error instanceof Error ? error.stack : 'Unknown error',
+    });
   }
 }

--- a/ayunis-core-backend/src/domain/retrievers/url-retrievers/infrastructure/cheerio.url-retriever.ts
+++ b/ayunis-core-backend/src/domain/retrievers/url-retrievers/infrastructure/cheerio.url-retriever.ts
@@ -74,7 +74,11 @@ export class CheerioUrlRetrieverHandler extends UrlRetrieverHandler {
 
     const contentType =
       response.headers.get('content-type')?.toLowerCase() ?? '';
-    if (contentType && !contentType.includes('text/html')) {
+    if (
+      contentType &&
+      !contentType.includes('text/html') &&
+      !contentType.includes('xhtml')
+    ) {
       throw new UrlRetrieverUnsupportedContentTypeError(
         url,
         contentType.split(';')[0].trim(),

--- a/ayunis-core-backend/src/domain/retrievers/url-retrievers/infrastructure/cheerio.url-retriever.ts
+++ b/ayunis-core-backend/src/domain/retrievers/url-retrievers/infrastructure/cheerio.url-retriever.ts
@@ -29,7 +29,7 @@ export class CheerioUrlRetrieverHandler extends UrlRetrieverHandler {
     try {
       return await this.fetchAndParse(input);
     } catch (error) {
-      return this.handleTopLevelError(error);
+      return this.handleTopLevelError(error, input.url);
     }
   }
 
@@ -101,7 +101,7 @@ export class CheerioUrlRetrieverHandler extends UrlRetrieverHandler {
     }
   }
 
-  private handleTopLevelError(error: unknown): never {
+  private handleTopLevelError(error: unknown, url: string): never {
     this.logger.error(
       `HTTP URL retrieval failed: ${error instanceof Error ? error.message : 'Unknown error'}`,
       error instanceof Error ? error.stack : 'Unknown error',
@@ -112,6 +112,7 @@ export class CheerioUrlRetrieverHandler extends UrlRetrieverHandler {
     }
 
     throw new UrlRetrieverRetrievalError('Failed to retrieve URL with HTTP', {
+      url,
       error: error instanceof Error ? error.message : 'Unknown error',
       stack: error instanceof Error ? error.stack : 'Unknown error',
     });

--- a/ayunis-core-frontend/src/pages/knowledge-base/api/useAddUrl.ts
+++ b/ayunis-core-frontend/src/pages/knowledge-base/api/useAddUrl.ts
@@ -21,10 +21,14 @@ export function useAddUrl(knowledgeBaseId: string) {
         showSuccess(t('detail.documents.addUrlSuccess'));
       },
       onError: (error: unknown) => {
-        const errorData = extractErrorData(error);
-        if (errorData.code === 'UNSUPPORTED_CONTENT_TYPE') {
-          showError(t('detail.documents.addUrlUnsupportedContentType'));
-        } else {
+        try {
+          const errorData = extractErrorData(error);
+          if (errorData.code === 'UNSUPPORTED_CONTENT_TYPE') {
+            showError(t('detail.documents.addUrlUnsupportedContentType'));
+          } else {
+            showError(t('detail.documents.addUrlError'));
+          }
+        } catch {
           showError(t('detail.documents.addUrlError'));
         }
       },

--- a/ayunis-core-frontend/src/pages/knowledge-base/api/useAddUrl.ts
+++ b/ayunis-core-frontend/src/pages/knowledge-base/api/useAddUrl.ts
@@ -5,6 +5,7 @@ import {
   useKnowledgeBasesControllerAddUrl,
   getKnowledgeBasesControllerListDocumentsQueryKey,
 } from '@/shared/api/generated/ayunisCoreAPI';
+import extractErrorData from '@/shared/api/extract-error-data';
 
 export function useAddUrl(knowledgeBaseId: string) {
   const { t } = useTranslation('knowledge-bases');
@@ -19,8 +20,13 @@ export function useAddUrl(knowledgeBaseId: string) {
         });
         showSuccess(t('detail.documents.addUrlSuccess'));
       },
-      onError: () => {
-        showError(t('detail.documents.addUrlError'));
+      onError: (error: unknown) => {
+        const errorData = extractErrorData(error);
+        if (errorData.code === 'UNSUPPORTED_CONTENT_TYPE') {
+          showError(t('detail.documents.addUrlUnsupportedContentType'));
+        } else {
+          showError(t('detail.documents.addUrlError'));
+        }
       },
     },
   });

--- a/ayunis-core-frontend/src/shared/locales/de/knowledge-bases.json
+++ b/ayunis-core-frontend/src/shared/locales/de/knowledge-bases.json
@@ -150,6 +150,7 @@
       "urlLabel": "Website-URL",
       "addUrlSuccess": "URL erfolgreich hinzugefügt! Der Website-Inhalt wird verarbeitet.",
       "addUrlError": "URL konnte nicht hinzugefügt werden. Bitte überprüfen Sie die URL und versuchen Sie es erneut.",
+      "addUrlUnsupportedContentType": "Diese URL verweist auf eine Datei (z. B. PDF) statt auf eine Website. Bitte laden Sie die Datei herunter und laden Sie sie direkt hoch.",
       "removeSuccess": "Dokument erfolgreich entfernt!",
       "removeError": "Dokument konnte nicht entfernt werden. Bitte versuchen Sie es erneut.",
       "urlDialogCancel": "Abbrechen"

--- a/ayunis-core-frontend/src/shared/locales/en/knowledge-bases.json
+++ b/ayunis-core-frontend/src/shared/locales/en/knowledge-bases.json
@@ -150,6 +150,7 @@
       "urlLabel": "Website URL",
       "addUrlSuccess": "URL added successfully! The website content is being processed.",
       "addUrlError": "Failed to add URL. Please check the URL and try again.",
+      "addUrlUnsupportedContentType": "This URL points to a file (e.g. PDF) instead of a website. Please download the file and upload it directly.",
       "removeSuccess": "Document removed successfully!",
       "removeError": "Failed to remove document. Please try again.",
       "urlDialogCancel": "Cancel"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes URL ingestion behavior by validating `content-type` and returning a new 422 domain error, which may cause previously accepted URLs (e.g. PDFs) to fail and impacts API/client error handling.
> 
> **Overview**
> Improves URL-to-document ingestion by detecting non-HTML responses during URL retrieval and failing fast with a new domain error `UNSUPPORTED_CONTENT_TYPE` mapped to HTTP 422.
> 
> Refactors the Cheerio URL retriever to separate fetch/validation/parse logic and to consistently handle timeouts and top-level wrapping errors. The frontend now inspects backend error codes when adding a URL and shows a dedicated, localized message when the URL points to a file (e.g. PDF) rather than a webpage.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b16999a334f3f29a8ecb44793ba8ac29b73c4370. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->