### PR TITLE
fix(AYC-000): preserve newlines on message clipboard copy

### DIFF
--- a/ayunis-core-frontend/src/pages/chat/ui/ChatMessage.tsx
+++ b/ayunis-core-frontend/src/pages/chat/ui/ChatMessage.tsx
@@ -72,7 +72,7 @@ function CopyMessageButton({
     const textParts: string[] = [];
     copyableElements.forEach((element) => {
       htmlParts.push(element.innerHTML);
-      textParts.push(element.textContent || '');
+      textParts.push((element as HTMLElement).innerText || '');
     });
 
     const html = htmlParts.join('<br><br>');


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk UI-only change that adjusts clipboard text extraction to better match rendered content; potential impact is limited to how whitespace/newlines are copied.
> 
> **Overview**
> Fixes assistant message clipboard copying to preserve rendered line breaks by using `innerText` instead of `textContent` when building the `text/plain` payload in `ChatMessage.tsx`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 69829eaf85cfea89a2251dc516011818f96bea55. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->