### PR TITLE
fix(AYC-000): only add 5xx errors to sentry

### DIFF
--- a/ayunis-core-backend/src/common/filters/application-error.filter.ts
+++ b/ayunis-core-backend/src/common/filters/application-error.filter.ts
@@ -46,6 +46,13 @@ export class ApplicationErrorFilter implements ExceptionFilter {
   }
 
   private captureToSentry(exception: ApplicationError, request: Request) {
+    // Only report server errors (5xx) to Sentry.
+    // 4xx errors are expected client errors (bad input, auth failures, etc.)
+    // and are already captured in structured logs.
+    if (exception.statusCode < 500) {
+      return;
+    }
+
     Sentry.withScope((scope) => {
       // Add user context from CLS store
       const cls = ClsServiceManager.getClsService<MyClsStore>();


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk change limited to error reporting behavior; it reduces Sentry noise by skipping expected 4xx errors, with minimal impact beyond observability.
> 
> **Overview**
> Updates `ApplicationErrorFilter` so `captureToSentry` **only reports 5xx** `ApplicationError`s to Sentry, returning early for any `statusCode < 500`.
> 
> This prevents expected client-side failures (4xx) from being captured as Sentry exceptions while keeping the existing structured HTTP responses unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7ceee2a302257631a33d5bb539b9b1bbc7bbe5c3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->