### PR TITLE
wip(AYC-77): drop USD currency, fix subscription create

### DIFF
--- a/ayunis-core-backend/src/db/fixtures/minimal.fixture.ts
+++ b/ayunis-core-backend/src/db/fixtures/minimal.fixture.ts
@@ -3,8 +3,6 @@ import { UserRole } from 'src/iam/users/domain/value-objects/role.object';
 import { SystemRole } from 'src/iam/users/domain/value-objects/system-role.enum';
 import { RenewalCycle } from 'src/iam/subscriptions/domain/value-objects/renewal-cycle.enum';
 import { EmbeddingDimensions } from 'src/domain/models/domain/value-objects/embedding-dimensions.enum';
-import { Currency } from 'src/domain/models/domain/value-objects/currency.enum';
-
 /**
  * Minimal fixture for development and E2E testing
  * Contains: 2 orgs (seat-based + usage-based), admin users, models, subscriptions
@@ -49,7 +47,6 @@ export const minimalFixture = {
     canVision: true,
     inputTokenCost: 3,
     outputTokenCost: 15,
-    currency: Currency.EUR,
   },
 
   embeddingModel: {

--- a/ayunis-core-backend/src/db/migrations/1773331092929-RemoveCurrencyColumns.ts
+++ b/ayunis-core-backend/src/db/migrations/1773331092929-RemoveCurrencyColumns.ts
@@ -1,0 +1,27 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class RemoveCurrencyColumns1773331092929 implements MigrationInterface {
+  name = 'RemoveCurrencyColumns1773331092929';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "models" DROP COLUMN "currency"`);
+    await queryRunner.query(`DROP TYPE "public"."models_currency_enum"`);
+    await queryRunner.query(`ALTER TABLE "usage" DROP COLUMN "currency"`);
+    await queryRunner.query(`DROP TYPE "public"."usage_currency_enum"`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TYPE "public"."usage_currency_enum" AS ENUM('EUR', 'USD')`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "usage" ADD "currency" "public"."usage_currency_enum"`,
+    );
+    await queryRunner.query(
+      `CREATE TYPE "public"."models_currency_enum" AS ENUM('EUR', 'USD')`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "models" ADD "currency" "public"."models_currency_enum"`,
+    );
+  }
+}

--- a/ayunis-core-backend/src/domain/models/application/use-cases/create-embedding-model/create-embedding-model.command.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/create-embedding-model/create-embedding-model.command.ts
@@ -1,6 +1,5 @@
 import type { ModelProvider } from 'src/domain/models/domain/value-objects/model-provider.enum';
 import type { EmbeddingDimensions } from 'src/domain/models/domain/value-objects/embedding-dimensions.enum';
-import type { Currency } from 'src/domain/models/domain/value-objects/currency.enum';
 
 export class CreateEmbeddingModelCommand {
   name: string;
@@ -10,7 +9,6 @@ export class CreateEmbeddingModelCommand {
   dimensions: EmbeddingDimensions;
   inputTokenCost?: number;
   outputTokenCost?: number;
-  currency?: Currency;
 
   constructor(params: {
     name: string;
@@ -20,7 +18,6 @@ export class CreateEmbeddingModelCommand {
     dimensions: EmbeddingDimensions;
     inputTokenCost?: number;
     outputTokenCost?: number;
-    currency?: Currency;
   }) {
     this.name = params.name;
     this.provider = params.provider;
@@ -29,6 +26,5 @@ export class CreateEmbeddingModelCommand {
     this.dimensions = params.dimensions;
     this.inputTokenCost = params.inputTokenCost;
     this.outputTokenCost = params.outputTokenCost;
-    this.currency = params.currency;
   }
 }

--- a/ayunis-core-backend/src/domain/models/application/use-cases/create-embedding-model/create-embedding-model.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/create-embedding-model/create-embedding-model.use-case.ts
@@ -52,7 +52,6 @@ export class CreateEmbeddingModelUseCase {
         dimensions: command.dimensions,
         inputTokenCost: command.inputTokenCost,
         outputTokenCost: command.outputTokenCost,
-        currency: command.currency,
       });
       await this.modelsRepository.save(model);
       return model;

--- a/ayunis-core-backend/src/domain/models/application/use-cases/create-language-model/create-language-model.command.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/create-language-model/create-language-model.command.ts
@@ -1,5 +1,4 @@
 import type { ModelProvider } from 'src/domain/models/domain/value-objects/model-provider.enum';
-import type { Currency } from 'src/domain/models/domain/value-objects/currency.enum';
 
 export class CreateLanguageModelCommand {
   name: string;
@@ -12,7 +11,6 @@ export class CreateLanguageModelCommand {
   isArchived: boolean;
   inputTokenCost?: number;
   outputTokenCost?: number;
-  currency?: Currency;
 
   constructor(params: {
     name: string;
@@ -25,7 +23,6 @@ export class CreateLanguageModelCommand {
     isArchived: boolean;
     inputTokenCost?: number;
     outputTokenCost?: number;
-    currency?: Currency;
   }) {
     this.name = params.name;
     this.provider = params.provider;
@@ -37,6 +34,5 @@ export class CreateLanguageModelCommand {
     this.isArchived = params.isArchived;
     this.inputTokenCost = params.inputTokenCost;
     this.outputTokenCost = params.outputTokenCost;
-    this.currency = params.currency;
   }
 }

--- a/ayunis-core-backend/src/domain/models/application/use-cases/create-language-model/create-language-model.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/create-language-model/create-language-model.use-case.ts
@@ -35,7 +35,6 @@ export class CreateLanguageModelUseCase {
         isArchived: command.isArchived,
         inputTokenCost: command.inputTokenCost,
         outputTokenCost: command.outputTokenCost,
-        currency: command.currency,
       });
       await this.modelsRepository.save(model);
       return model;

--- a/ayunis-core-backend/src/domain/models/application/use-cases/update-embedding-model/update-embedding-model.command.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/update-embedding-model/update-embedding-model.command.ts
@@ -1,6 +1,5 @@
 import type { UUID } from 'crypto';
 import type { ModelProvider } from 'src/domain/models/domain/value-objects/model-provider.enum';
-import type { Currency } from 'src/domain/models/domain/value-objects/currency.enum';
 
 export class UpdateEmbeddingModelCommand {
   id: UUID;
@@ -11,7 +10,6 @@ export class UpdateEmbeddingModelCommand {
   dimensions: number;
   inputTokenCost?: number;
   outputTokenCost?: number;
-  currency?: Currency;
 
   constructor(params: {
     id: UUID;
@@ -22,7 +20,6 @@ export class UpdateEmbeddingModelCommand {
     dimensions: number;
     inputTokenCost?: number;
     outputTokenCost?: number;
-    currency?: Currency;
   }) {
     this.id = params.id;
     this.name = params.name;
@@ -32,6 +29,5 @@ export class UpdateEmbeddingModelCommand {
     this.dimensions = params.dimensions;
     this.inputTokenCost = params.inputTokenCost;
     this.outputTokenCost = params.outputTokenCost;
-    this.currency = params.currency;
   }
 }

--- a/ayunis-core-backend/src/domain/models/application/use-cases/update-embedding-model/update-embedding-model.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/update-embedding-model/update-embedding-model.use-case.ts
@@ -41,7 +41,6 @@ export class UpdateEmbeddingModelUseCase {
         dimensions: command.dimensions,
         inputTokenCost: command.inputTokenCost,
         outputTokenCost: command.outputTokenCost,
-        currency: command.currency,
       });
       await this.modelsRepository.save(model);
 

--- a/ayunis-core-backend/src/domain/models/application/use-cases/update-language-model/update-language-model.command.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/update-language-model/update-language-model.command.ts
@@ -1,6 +1,5 @@
 import type { UUID } from 'crypto';
 import type { ModelProvider } from 'src/domain/models/domain/value-objects/model-provider.enum';
-import type { Currency } from 'src/domain/models/domain/value-objects/currency.enum';
 
 export class UpdateLanguageModelCommand {
   id: UUID;
@@ -14,7 +13,6 @@ export class UpdateLanguageModelCommand {
   canVision: boolean;
   inputTokenCost?: number;
   outputTokenCost?: number;
-  currency?: Currency;
 
   constructor(params: {
     id: UUID;
@@ -28,7 +26,6 @@ export class UpdateLanguageModelCommand {
     canVision: boolean;
     inputTokenCost?: number;
     outputTokenCost?: number;
-    currency?: Currency;
   }) {
     this.id = params.id;
     this.name = params.name;
@@ -41,6 +38,5 @@ export class UpdateLanguageModelCommand {
     this.canVision = params.canVision;
     this.inputTokenCost = params.inputTokenCost;
     this.outputTokenCost = params.outputTokenCost;
-    this.currency = params.currency;
   }
 }

--- a/ayunis-core-backend/src/domain/models/application/use-cases/update-language-model/update-language-model.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/update-language-model/update-language-model.use-case.ts
@@ -44,7 +44,6 @@ export class UpdateLanguageModelUseCase {
         canVision: command.canVision,
         inputTokenCost: command.inputTokenCost,
         outputTokenCost: command.outputTokenCost,
-        currency: command.currency,
       });
       await this.modelsRepository.save(model);
 

--- a/ayunis-core-backend/src/domain/models/domain/models/embedding.model.ts
+++ b/ayunis-core-backend/src/domain/models/domain/models/embedding.model.ts
@@ -3,13 +3,13 @@ import { Model } from '../model.entity';
 import { ModelType } from '../value-objects/model-type.enum';
 import type { UUID } from 'crypto';
 import type { EmbeddingDimensions } from '../value-objects/embedding-dimensions.enum';
-import type { Currency } from '../value-objects/currency.enum';
 
 export class EmbeddingModel extends Model {
   public readonly dimensions: EmbeddingDimensions;
+  /** Cost per million input tokens in EUR */
   public readonly inputTokenCost?: number;
+  /** Cost per million output tokens in EUR */
   public readonly outputTokenCost?: number;
-  public readonly currency?: Currency;
 
   constructor(params: {
     id?: UUID;
@@ -22,12 +22,10 @@ export class EmbeddingModel extends Model {
     dimensions: EmbeddingDimensions;
     inputTokenCost?: number;
     outputTokenCost?: number;
-    currency?: Currency;
   }) {
     super({ ...params, type: ModelType.EMBEDDING });
     this.dimensions = params.dimensions;
     this.inputTokenCost = params.inputTokenCost;
     this.outputTokenCost = params.outputTokenCost;
-    this.currency = params.currency;
   }
 }

--- a/ayunis-core-backend/src/domain/models/domain/models/language.model.ts
+++ b/ayunis-core-backend/src/domain/models/domain/models/language.model.ts
@@ -2,16 +2,16 @@ import type { ModelProvider } from '../value-objects/model-provider.enum';
 import { Model } from '../model.entity';
 import { ModelType } from '../value-objects/model-type.enum';
 import type { UUID } from 'crypto';
-import type { Currency } from '../value-objects/currency.enum';
 
 export class LanguageModel extends Model {
   public readonly canStream: boolean;
   public readonly canUseTools: boolean;
   public readonly isReasoning: boolean;
   public readonly canVision: boolean;
+  /** Cost per million input tokens in EUR */
   public readonly inputTokenCost?: number;
+  /** Cost per million output tokens in EUR */
   public readonly outputTokenCost?: number;
-  public readonly currency?: Currency;
 
   constructor(params: {
     id?: UUID;
@@ -27,7 +27,6 @@ export class LanguageModel extends Model {
     isArchived: boolean;
     inputTokenCost?: number;
     outputTokenCost?: number;
-    currency?: Currency;
   }) {
     super({ ...params, type: ModelType.LANGUAGE });
     this.canStream = params.canStream;
@@ -36,6 +35,5 @@ export class LanguageModel extends Model {
     this.canVision = params.canVision;
     this.inputTokenCost = params.inputTokenCost;
     this.outputTokenCost = params.outputTokenCost;
-    this.currency = params.currency;
   }
 }

--- a/ayunis-core-backend/src/domain/models/domain/value-objects/currency.enum.ts
+++ b/ayunis-core-backend/src/domain/models/domain/value-objects/currency.enum.ts
@@ -1,4 +1,0 @@
-export enum Currency {
-  EUR = 'EUR',
-  USD = 'USD',
-}

--- a/ayunis-core-backend/src/domain/models/infrastructure/persistence/local-models/mappers/model.mapper.ts
+++ b/ayunis-core-backend/src/domain/models/infrastructure/persistence/local-models/mappers/model.mapper.ts
@@ -27,7 +27,6 @@ export class ModelMapper {
         updatedAt: record.updatedAt,
         inputTokenCost: record.inputTokenCost,
         outputTokenCost: record.outputTokenCost,
-        currency: record.currency,
       });
     }
 
@@ -43,7 +42,6 @@ export class ModelMapper {
         updatedAt: record.updatedAt,
         inputTokenCost: record.inputTokenCost,
         outputTokenCost: record.outputTokenCost,
-        currency: record.currency,
       });
     }
 
@@ -66,7 +64,6 @@ export class ModelMapper {
       record.updatedAt = domain.updatedAt;
       record.inputTokenCost = domain.inputTokenCost;
       record.outputTokenCost = domain.outputTokenCost;
-      record.currency = domain.currency;
       return record;
     }
 
@@ -82,7 +79,6 @@ export class ModelMapper {
       record.updatedAt = domain.updatedAt;
       record.inputTokenCost = domain.inputTokenCost;
       record.outputTokenCost = domain.outputTokenCost;
-      record.currency = domain.currency;
       return record;
     }
 

--- a/ayunis-core-backend/src/domain/models/infrastructure/persistence/local-models/schema/model.record.ts
+++ b/ayunis-core-backend/src/domain/models/infrastructure/persistence/local-models/schema/model.record.ts
@@ -3,7 +3,6 @@ import { BaseRecord } from '../../../../../../common/db/base-record';
 import { ModelProvider } from '../../../../domain/value-objects/model-provider.enum';
 import { EmbeddingDimensions } from '../../../../domain/value-objects/embedding-dimensions.enum';
 import { Column, Entity, Index, TableInheritance, ChildEntity } from 'typeorm';
-import { Currency } from '../../../../domain/value-objects/currency.enum';
 
 const tokenCostColumnOptions = {
   type: 'decimal' as const,
@@ -70,13 +69,6 @@ export class LanguageModelRecord extends ModelRecord {
 
   @Column(tokenCostColumnOptions)
   outputTokenCost?: number;
-
-  @Column({
-    type: 'enum',
-    enum: Currency,
-    nullable: true,
-  })
-  currency?: Currency;
 }
 
 @ChildEntity(ModelType.EMBEDDING)
@@ -91,11 +83,4 @@ export class EmbeddingModelRecord extends ModelRecord {
 
   @Column(tokenCostColumnOptions)
   outputTokenCost?: number;
-
-  @Column({
-    type: 'enum',
-    enum: Currency,
-    nullable: true,
-  })
-  currency?: Currency;
 }

--- a/ayunis-core-backend/src/domain/models/presenters/http/dto/base-embedding-model-request.dto.ts
+++ b/ayunis-core-backend/src/domain/models/presenters/http/dto/base-embedding-model-request.dto.ts
@@ -10,14 +10,9 @@ import {
 } from 'class-validator';
 import { ModelProvider } from 'src/domain/models/domain/value-objects/model-provider.enum';
 import { EmbeddingDimensions } from 'src/domain/models/domain/value-objects/embedding-dimensions.enum';
-import { Currency } from 'src/domain/models/domain/value-objects/currency.enum';
 
 function hasAnyCostField(o: BaseEmbeddingModelRequestDto): boolean {
-  return (
-    o.inputTokenCost !== undefined ||
-    o.outputTokenCost !== undefined ||
-    o.currency !== undefined
-  );
+  return o.inputTokenCost !== undefined || o.outputTokenCost !== undefined;
 }
 
 export abstract class BaseEmbeddingModelRequestDto {
@@ -61,7 +56,7 @@ export abstract class BaseEmbeddingModelRequestDto {
   isArchived: boolean;
 
   @ApiPropertyOptional({
-    description: 'Cost per million input tokens (in the specified currency)',
+    description: 'Cost per million input tokens in EUR',
     example: 0.13,
     minimum: 0,
   })
@@ -71,7 +66,7 @@ export abstract class BaseEmbeddingModelRequestDto {
   inputTokenCost?: number;
 
   @ApiPropertyOptional({
-    description: 'Cost per million output tokens (in the specified currency)',
+    description: 'Cost per million output tokens in EUR',
     example: 0,
     minimum: 0,
   })
@@ -79,13 +74,4 @@ export abstract class BaseEmbeddingModelRequestDto {
   @IsNumber()
   @Min(0)
   outputTokenCost?: number;
-
-  @ApiPropertyOptional({
-    description: 'Currency for token costs',
-    enum: Currency,
-    example: Currency.EUR,
-  })
-  @ValidateIf((o: BaseEmbeddingModelRequestDto) => hasAnyCostField(o))
-  @IsEnum(Currency)
-  currency?: Currency;
 }

--- a/ayunis-core-backend/src/domain/models/presenters/http/dto/base-language-model-request.dto.ts
+++ b/ayunis-core-backend/src/domain/models/presenters/http/dto/base-language-model-request.dto.ts
@@ -9,14 +9,9 @@ import {
   ValidateIf,
 } from 'class-validator';
 import { ModelProvider } from 'src/domain/models/domain/value-objects/model-provider.enum';
-import { Currency } from 'src/domain/models/domain/value-objects/currency.enum';
 
 function hasAnyCostField(o: BaseLanguageModelRequestDto): boolean {
-  return (
-    o.inputTokenCost !== undefined ||
-    o.outputTokenCost !== undefined ||
-    o.currency !== undefined
-  );
+  return o.inputTokenCost !== undefined || o.outputTokenCost !== undefined;
 }
 
 export abstract class BaseLanguageModelRequestDto {
@@ -80,7 +75,7 @@ export abstract class BaseLanguageModelRequestDto {
   isArchived: boolean;
 
   @ApiPropertyOptional({
-    description: 'Cost per million input tokens (in the specified currency)',
+    description: 'Cost per million input tokens in EUR',
     example: 3,
     minimum: 0,
   })
@@ -90,7 +85,7 @@ export abstract class BaseLanguageModelRequestDto {
   inputTokenCost?: number;
 
   @ApiPropertyOptional({
-    description: 'Cost per million output tokens (in the specified currency)',
+    description: 'Cost per million output tokens in EUR',
     example: 15,
     minimum: 0,
   })
@@ -98,13 +93,4 @@ export abstract class BaseLanguageModelRequestDto {
   @IsNumber()
   @Min(0)
   outputTokenCost?: number;
-
-  @ApiPropertyOptional({
-    description: 'Currency for token costs',
-    enum: Currency,
-    example: Currency.EUR,
-  })
-  @ValidateIf((o: BaseLanguageModelRequestDto) => hasAnyCostField(o))
-  @IsEnum(Currency)
-  currency?: Currency;
 }

--- a/ayunis-core-backend/src/domain/models/presenters/http/dto/embedding-model-response.dto.ts
+++ b/ayunis-core-backend/src/domain/models/presenters/http/dto/embedding-model-response.dto.ts
@@ -3,7 +3,6 @@ import { UUID } from 'crypto';
 import { ModelProvider } from 'src/domain/models/domain/value-objects/model-provider.enum';
 import { ModelType } from 'src/domain/models/domain/value-objects/model-type.enum';
 import { EmbeddingDimensions } from 'src/domain/models/domain/value-objects/embedding-dimensions.enum';
-import { Currency } from 'src/domain/models/domain/value-objects/currency.enum';
 
 export class EmbeddingModelResponseDto {
   @ApiProperty({
@@ -74,23 +73,15 @@ export class EmbeddingModelResponseDto {
 
   @ApiPropertyOptional({
     type: 'number',
-    description: 'Cost per million input tokens',
+    description: 'Cost per million input tokens in EUR',
     example: 0.13,
   })
   inputTokenCost?: number;
 
   @ApiPropertyOptional({
     type: 'number',
-    description: 'Cost per million output tokens',
+    description: 'Cost per million output tokens in EUR',
     example: 0,
   })
   outputTokenCost?: number;
-
-  @ApiPropertyOptional({
-    type: 'string',
-    enum: Currency,
-    description: 'Currency for token costs',
-    example: Currency.EUR,
-  })
-  currency?: Currency;
 }

--- a/ayunis-core-backend/src/domain/models/presenters/http/dto/language-model-response.dto.ts
+++ b/ayunis-core-backend/src/domain/models/presenters/http/dto/language-model-response.dto.ts
@@ -2,7 +2,6 @@ import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { UUID } from 'crypto';
 import { ModelProvider } from 'src/domain/models/domain/value-objects/model-provider.enum';
 import { ModelType } from 'src/domain/models/domain/value-objects/model-type.enum';
-import { Currency } from 'src/domain/models/domain/value-objects/currency.enum';
 
 export class LanguageModelResponseDto {
   @ApiProperty({
@@ -93,23 +92,15 @@ export class LanguageModelResponseDto {
 
   @ApiPropertyOptional({
     type: 'number',
-    description: 'Cost per million input tokens',
+    description: 'Cost per million input tokens in EUR',
     example: 3,
   })
   inputTokenCost?: number;
 
   @ApiPropertyOptional({
     type: 'number',
-    description: 'Cost per million output tokens',
+    description: 'Cost per million output tokens in EUR',
     example: 15,
   })
   outputTokenCost?: number;
-
-  @ApiPropertyOptional({
-    type: 'string',
-    enum: Currency,
-    description: 'Currency for token costs',
-    example: Currency.EUR,
-  })
-  currency?: Currency;
 }

--- a/ayunis-core-backend/src/domain/models/presenters/http/mappers/catalog-model-response-dto.mapper.ts
+++ b/ayunis-core-backend/src/domain/models/presenters/http/mappers/catalog-model-response-dto.mapper.ts
@@ -25,7 +25,6 @@ export class CatalogModelResponseDtoMapper {
       updatedAt: model.updatedAt,
       inputTokenCost: model.inputTokenCost,
       outputTokenCost: model.outputTokenCost,
-      currency: model.currency,
     };
   }
 
@@ -42,7 +41,6 @@ export class CatalogModelResponseDtoMapper {
       updatedAt: model.updatedAt,
       inputTokenCost: model.inputTokenCost,
       outputTokenCost: model.outputTokenCost,
-      currency: model.currency,
     };
   }
 

--- a/ayunis-core-backend/src/domain/models/presenters/http/mappers/model-response-dto.mapper.ts
+++ b/ayunis-core-backend/src/domain/models/presenters/http/mappers/model-response-dto.mapper.ts
@@ -31,7 +31,7 @@ export class ModelResponseDtoMapper {
       isReasoning: permittedModel.model.isReasoning,
       canVision: permittedModel.model.canVision,
       anonymousOnly: permittedModel.anonymousOnly,
-      // Note: Cost fields (inputTokenCost, outputTokenCost, currency) are intentionally
+      // Note: Cost fields (inputTokenCost, outputTokenCost) are intentionally
       // not exposed to users. They are tracked internally for usage analytics only.
     };
   }
@@ -52,7 +52,7 @@ export class ModelResponseDtoMapper {
       type: ModelType.EMBEDDING,
       isArchived: permittedModel.model.isArchived,
       dimensions: permittedModel.model.dimensions,
-      // Note: Cost fields (inputTokenCost, outputTokenCost, currency) are intentionally
+      // Note: Cost fields (inputTokenCost, outputTokenCost) are intentionally
       // not exposed to users. They are tracked internally for usage analytics only.
     };
   }

--- a/ayunis-core-backend/src/domain/models/presenters/http/super-admin-catalog-models.controller.ts
+++ b/ayunis-core-backend/src/domain/models/presenters/http/super-admin-catalog-models.controller.ts
@@ -246,7 +246,6 @@ export class SuperAdminCatalogModelsController {
       isArchived: dto.isArchived,
       inputTokenCost: dto.inputTokenCost,
       outputTokenCost: dto.outputTokenCost,
-      currency: dto.currency,
     });
 
     const model = await this.createLanguageModelUseCase.execute(command);
@@ -309,7 +308,6 @@ export class SuperAdminCatalogModelsController {
       isArchived: dto.isArchived,
       inputTokenCost: dto.inputTokenCost,
       outputTokenCost: dto.outputTokenCost,
-      currency: dto.currency,
     });
 
     const model = await this.updateLanguageModelUseCase.execute(command);
@@ -363,7 +361,6 @@ export class SuperAdminCatalogModelsController {
       isArchived: dto.isArchived,
       inputTokenCost: dto.inputTokenCost,
       outputTokenCost: dto.outputTokenCost,
-      currency: dto.currency,
     });
 
     const model = await this.createEmbeddingModelUseCase.execute(command);
@@ -423,7 +420,6 @@ export class SuperAdminCatalogModelsController {
       isArchived: dto.isArchived,
       inputTokenCost: dto.inputTokenCost,
       outputTokenCost: dto.outputTokenCost,
-      currency: dto.currency,
     });
 
     const model = await this.updateEmbeddingModelUseCase.execute(command);

--- a/ayunis-core-backend/src/domain/threads/application/use-cases/delete-thread/delete-thread.use-case.ts
+++ b/ayunis-core-backend/src/domain/threads/application/use-cases/delete-thread/delete-thread.use-case.ts
@@ -50,10 +50,13 @@ export class DeleteThreadUseCase {
 
       if (!thread) {
         // Idempotent delete: treat already-deleted threads as success
-        this.logger.warn('Thread already deleted or not found, treating as success', {
-          threadId: command.id,
-          userId,
-        });
+        this.logger.warn(
+          'Thread already deleted or not found, treating as success',
+          {
+            threadId: command.id,
+            userId,
+          },
+        );
         return;
       }
 

--- a/ayunis-core-backend/src/domain/usage/application/use-cases/collect-usage/collect-usage.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/usage/application/use-cases/collect-usage/collect-usage.use-case.spec.ts
@@ -9,7 +9,6 @@ import {
   UnexpectedUsageError,
 } from '../../usage.errors';
 import { ModelProvider } from '../../../../models/domain/value-objects/model-provider.enum';
-import { Currency } from '../../../../models/domain/value-objects/currency.enum';
 import type { UUID } from 'crypto';
 import { LanguageModel } from '../../../../models/domain/models/language.model';
 import type { Usage } from '../../../domain/usage.entity';
@@ -94,7 +93,7 @@ describe('CollectUsageUseCase', () => {
   });
 
   describe('successful usage collection', () => {
-    it('should collect usage successfully in cloud mode', async () => {
+    it('should collect usage successfully when model has no cost info', async () => {
       const model = createMockModel();
       const command = new CollectUsageCommand({
         model,
@@ -115,17 +114,15 @@ describe('CollectUsageUseCase', () => {
           outputTokens: 50,
           totalTokens: 150,
           cost: undefined,
-          currency: undefined,
           requestId,
         }),
       );
     });
 
-    it('should collect usage with cost', async () => {
+    it('should collect usage with cost in EUR', async () => {
       const model = createMockModel({
         inputTokenCost: 1,
         outputTokenCost: 2,
-        currency: Currency.EUR,
       });
 
       const command = new CollectUsageCommand({
@@ -146,16 +143,14 @@ describe('CollectUsageUseCase', () => {
           outputTokens: 500,
           totalTokens: 1500,
           cost: expect.any(Number) as number,
-          currency: Currency.EUR,
         }),
       );
     });
 
-    it('should calculate cost correctly', async () => {
+    it('should calculate cost correctly in EUR', async () => {
       const model = createMockModel({
         inputTokenCost: 1,
         outputTokenCost: 2,
-        currency: Currency.EUR,
       });
 
       const command = new CollectUsageCommand({
@@ -179,14 +174,12 @@ describe('CollectUsageUseCase', () => {
       // outputCost = (1000/1_000_000) * 2 = 0.002
       // totalCost = 0.004
       expect(saveCall.cost).toBeCloseTo(0.004, 6);
-      expect(saveCall.currency).toBe(Currency.EUR);
     });
 
     it('should calculate and store small costs correctly', async () => {
       const model = createMockModel({
         inputTokenCost: 0.0001,
         outputTokenCost: 0.0001,
-        currency: Currency.EUR,
       });
 
       const command = new CollectUsageCommand({
@@ -210,7 +203,6 @@ describe('CollectUsageUseCase', () => {
       // outputCost = (50/1_000_000) * 0.0001 = 0.000000005
       // totalCost = 0.000000015
       expect(saveCall.cost).toBeCloseTo(0.000000015, 10);
-      expect(saveCall.currency).toBe(Currency.EUR);
     });
 
     it('should return undefined cost if model has no cost info', async () => {
@@ -237,14 +229,12 @@ describe('CollectUsageUseCase', () => {
         throw new Error('save was not called');
       }
       expect(saveCall.cost).toBeUndefined();
-      expect(saveCall.currency).toBeUndefined();
     });
 
-    it('should return undefined cost if model has costs but no currency', async () => {
+    it('should return undefined cost if only input cost is set', async () => {
       const model = createMockModel({
         inputTokenCost: 1,
-        outputTokenCost: 2,
-        currency: undefined,
+        outputTokenCost: undefined,
       });
 
       const command = new CollectUsageCommand({
@@ -264,9 +254,7 @@ describe('CollectUsageUseCase', () => {
       if (!saveCall) {
         throw new Error('save was not called');
       }
-      // Cost should be undefined because currency is missing
       expect(saveCall.cost).toBeUndefined();
-      expect(saveCall.currency).toBeUndefined();
     });
   });
 
@@ -400,7 +388,7 @@ describe('CollectUsageUseCase', () => {
       );
     });
 
-    it('should handle cost calculation gracefully when model has no cost info (per million tokens)', async () => {
+    it('should handle cost calculation gracefully when model has no cost info', async () => {
       const model = createMockModel({
         inputTokenCost: undefined,
         outputTokenCost: undefined,
@@ -419,7 +407,6 @@ describe('CollectUsageUseCase', () => {
       expect(mockUsageRepository.save).toHaveBeenCalledWith(
         expect.objectContaining({
           cost: undefined,
-          currency: undefined,
         }),
       );
     });
@@ -432,7 +419,6 @@ describe('CollectUsageUseCase', () => {
       const model = createMockModel({
         inputTokenCost: 1,
         outputTokenCost: 2,
-        currency: Currency.EUR,
       });
 
       const command = new CollectUsageCommand({
@@ -493,7 +479,6 @@ describe('CollectUsageUseCase', () => {
       const model = createMockModel({
         inputTokenCost: 1,
         outputTokenCost: 2,
-        currency: Currency.EUR,
       });
 
       const command = new CollectUsageCommand({

--- a/ayunis-core-backend/src/domain/usage/application/use-cases/collect-usage/collect-usage.use-case.ts
+++ b/ayunis-core-backend/src/domain/usage/application/use-cases/collect-usage/collect-usage.use-case.ts
@@ -10,7 +10,6 @@ import {
 } from '../../usage.errors';
 import { ApplicationError } from '../../../../../common/errors/base.error';
 import { ContextService } from '../../../../../common/context/services/context.service';
-import { Currency } from '../../../../models/domain/value-objects/currency.enum';
 import { GetCreditsPerEuroUseCase } from '../../../../../iam/platform-config/application/use-cases/get-credits-per-euro/get-credits-per-euro.use-case';
 import { PlatformConfigNotFoundError } from '../../../../../iam/platform-config/application/platform-config.errors';
 
@@ -50,7 +49,7 @@ export class CollectUsageUseCase {
     try {
       this.validateCommand(command);
 
-      const { cost, currency } = this.calculateCost(command);
+      const cost = this.calculateCost(command);
       const creditsConsumed = await this.calculateCredits(cost);
 
       const usage = new Usage({
@@ -62,7 +61,6 @@ export class CollectUsageUseCase {
         outputTokens: command.outputTokens,
         totalTokens: command.totalTokens,
         cost,
-        currency,
         creditsConsumed,
         requestId: command.requestId ?? randomUUID(),
       });
@@ -136,25 +134,24 @@ export class CollectUsageUseCase {
     }
   }
 
-  private calculateCost(command: CollectUsageCommand): {
-    cost?: number;
-    currency?: Currency;
-  } {
+  /**
+   * Calculates cost in EUR based on the model's per-million-token pricing.
+   * Returns undefined if the model has no cost information configured.
+   */
+  private calculateCost(command: CollectUsageCommand): number | undefined {
     const model = command.model;
 
     if (
       model.inputTokenCost === undefined ||
-      model.outputTokenCost === undefined ||
-      model.currency === undefined
+      model.outputTokenCost === undefined
     ) {
       this.logger.debug('No cost information available for model', {
         modelId: model.id,
         hasInputCost: model.inputTokenCost !== undefined,
         hasOutputCost: model.outputTokenCost !== undefined,
-        hasCurrency: model.currency !== undefined,
       });
 
-      return { cost: undefined, currency: undefined };
+      return undefined;
     }
 
     const inputCost = (command.inputTokens / 1_000_000) * model.inputTokenCost;
@@ -162,7 +159,7 @@ export class CollectUsageUseCase {
       (command.outputTokens / 1_000_000) * model.outputTokenCost;
     const totalCost = inputCost + outputCost;
 
-    this.logger.debug('Cost calculated for usage', {
+    this.logger.debug('Cost calculated for usage (EUR)', {
       modelId: model.id,
       inputTokens: command.inputTokens,
       outputTokens: command.outputTokens,
@@ -171,12 +168,8 @@ export class CollectUsageUseCase {
       inputCost,
       outputCost,
       totalCost,
-      currency: model.currency,
     });
 
-    return {
-      cost: totalCost,
-      currency: model.currency,
-    };
+    return totalCost;
   }
 }

--- a/ayunis-core-backend/src/domain/usage/domain/usage.entity.ts
+++ b/ayunis-core-backend/src/domain/usage/domain/usage.entity.ts
@@ -1,7 +1,6 @@
 import type { UUID } from 'crypto';
 import { randomUUID } from 'crypto';
 import type { ModelProvider } from '../../models/domain/value-objects/model-provider.enum';
-import type { Currency } from '../../models/domain/value-objects/currency.enum';
 
 export class Usage {
   public readonly id: UUID;
@@ -18,8 +17,8 @@ export class Usage {
   public readonly inputTokens: number;
   public readonly outputTokens: number;
   public readonly totalTokens: number;
+  /** Cost in EUR */
   public readonly cost?: number;
-  public readonly currency?: Currency;
   public readonly creditsConsumed?: number;
   public readonly requestId: UUID;
   public readonly createdAt: Date;
@@ -34,7 +33,6 @@ export class Usage {
     outputTokens: number;
     totalTokens: number;
     cost?: number;
-    currency?: Currency;
     creditsConsumed?: number;
     requestId: UUID;
     createdAt?: Date;
@@ -48,7 +46,6 @@ export class Usage {
     this.outputTokens = params.outputTokens;
     this.totalTokens = params.totalTokens;
     this.cost = params.cost;
-    this.currency = params.currency;
     this.creditsConsumed = params.creditsConsumed;
     this.requestId = params.requestId;
     this.createdAt = params.createdAt ?? new Date();

--- a/ayunis-core-backend/src/domain/usage/infrastructure/persistence/local-usage/mappers/usage.mapper.ts
+++ b/ayunis-core-backend/src/domain/usage/infrastructure/persistence/local-usage/mappers/usage.mapper.ts
@@ -15,7 +15,6 @@ export class UsageMapper {
     record.outputTokens = usage.outputTokens;
     record.totalTokens = usage.totalTokens;
     record.cost = usage.cost ?? null;
-    record.currency = usage.currency ?? null;
     record.creditsConsumed = usage.creditsConsumed ?? null;
     record.requestId = usage.requestId;
     record.createdAt = usage.createdAt;
@@ -33,7 +32,6 @@ export class UsageMapper {
       outputTokens: record.outputTokens,
       totalTokens: record.totalTokens,
       cost: record.cost ?? undefined,
-      currency: record.currency ?? undefined,
       creditsConsumed: record.creditsConsumed ?? undefined,
       requestId: record.requestId,
       createdAt: record.createdAt,

--- a/ayunis-core-backend/src/domain/usage/infrastructure/persistence/local-usage/schema/usage.record.ts
+++ b/ayunis-core-backend/src/domain/usage/infrastructure/persistence/local-usage/schema/usage.record.ts
@@ -5,7 +5,6 @@ import { UserRecord } from '../../../../../../iam/users/infrastructure/repositor
 import { OrgRecord } from '../../../../../../iam/orgs/infrastructure/repositories/local/schema/org.record';
 import { ModelRecord } from '../../../../../models/infrastructure/persistence/local-models/schema/model.record';
 import { ModelProvider } from '../../../../../models/domain/value-objects/model-provider.enum';
-import { Currency } from '../../../../../models/domain/value-objects/currency.enum';
 
 const decimalTransformer = {
   to: (value?: number | null) => value,
@@ -13,6 +12,9 @@ const decimalTransformer = {
     value === null || value === undefined ? null : Number(value),
 };
 
+/**
+ * All costs are stored in EUR.
+ */
 @Entity('usage')
 @Index(['organizationId', 'createdAt'])
 @Index(['userId', 'createdAt'])
@@ -53,6 +55,7 @@ export class UsageRecord extends BaseRecord {
   @Column('integer')
   totalTokens: number;
 
+  /** Cost in EUR */
   @Column('decimal', {
     precision: 10,
     scale: 6,
@@ -60,13 +63,6 @@ export class UsageRecord extends BaseRecord {
     transformer: decimalTransformer,
   })
   cost: number | null;
-
-  @Column({
-    type: 'enum',
-    enum: Currency,
-    nullable: true,
-  })
-  currency: Currency | null;
 
   @Column('decimal', {
     precision: 16,

--- a/ayunis-core-backend/src/iam/subscriptions/infrastructure/persistence/local/local-subscriptions.repository.ts
+++ b/ayunis-core-backend/src/iam/subscriptions/infrastructure/persistence/local/local-subscriptions.repository.ts
@@ -1,6 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { DataSource, Repository } from 'typeorm';
 import { UUID } from 'crypto';
 import { SubscriptionRepository } from 'src/iam/subscriptions/application/ports/subscription.repository';
 import { Subscription } from 'src/iam/subscriptions/domain/subscription.entity';
@@ -21,6 +21,7 @@ export class LocalSubscriptionsRepository extends SubscriptionRepository {
     private readonly subscriptionBillingInfoRepository: Repository<SubscriptionBillingInfoRecord>,
     private readonly subscriptionMapper: SubscriptionMapper,
     private readonly subscriptionBillingInfoMapper: SubscriptionBillingInfoMapper,
+    private readonly dataSource: DataSource,
   ) {
     super();
   }
@@ -74,7 +75,18 @@ export class LocalSubscriptionsRepository extends SubscriptionRepository {
   async create(subscription: Subscription): Promise<Subscription> {
     try {
       const record = this.subscriptionMapper.toRecord(subscription);
-      await this.subscriptionRepository.save(record);
+
+      // Save subscription and billing info in a transaction to guarantee
+      // the subscription row exists before the billing info FK references it.
+      await this.dataSource.transaction(async (manager) => {
+        const billingInfo = record.billingInfo;
+        record.billingInfo =
+          undefined as unknown as SubscriptionBillingInfoRecord;
+        await manager.save(SubscriptionRecord, record);
+        await manager.save(SubscriptionBillingInfoRecord, billingInfo);
+        record.billingInfo = billingInfo;
+      });
+
       this.logger.log(`Created subscription with id ${subscription.id}`);
       return this.subscriptionMapper.toDomain(record);
     } catch (error) {

--- a/ayunis-core-frontend/src/app/routes/_authenticated/super-admin-settings.models-catalog.index.tsx
+++ b/ayunis-core-frontend/src/app/routes/_authenticated/super-admin-settings.models-catalog.index.tsx
@@ -1,8 +1,8 @@
 import { createFileRoute } from '@tanstack/react-router';
 import ModelsCatalogPage from '@/pages/super-admin-settings/models-catalog';
 import {
-  getSuperAdminModelsControllerGetAllCatalogModelsQueryKey,
-  superAdminModelsControllerGetAllCatalogModels,
+  getSuperAdminCatalogModelsControllerGetAllCatalogModelsQueryKey,
+  superAdminCatalogModelsControllerGetAllCatalogModels,
 } from '@/shared/api';
 
 export const Route = createFileRoute(
@@ -12,8 +12,9 @@ export const Route = createFileRoute(
   loader: async ({ context: { queryClient } }) => {
     return {
       models: await queryClient.fetchQuery({
-        queryKey: getSuperAdminModelsControllerGetAllCatalogModelsQueryKey(),
-        queryFn: () => superAdminModelsControllerGetAllCatalogModels(),
+        queryKey:
+          getSuperAdminCatalogModelsControllerGetAllCatalogModelsQueryKey(),
+        queryFn: () => superAdminCatalogModelsControllerGetAllCatalogModels(),
       }),
     };
   },

--- a/ayunis-core-frontend/src/pages/super-admin-settings/models-catalog/api/useCreateEmbeddingModel.ts
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/models-catalog/api/useCreateEmbeddingModel.ts
@@ -1,8 +1,8 @@
 import { useQueryClient } from '@tanstack/react-query';
 import { showSuccess, showError } from '@/shared/lib/toast';
 import {
-  useSuperAdminModelsControllerCreateEmbeddingModel,
-  getSuperAdminModelsControllerGetAllCatalogModelsQueryKey,
+  useSuperAdminCatalogModelsControllerCreateEmbeddingModel,
+  getSuperAdminCatalogModelsControllerGetAllCatalogModelsQueryKey,
   type CreateEmbeddingModelRequestDto,
 } from '@/shared/api';
 import { useRouter } from '@tanstack/react-router';
@@ -13,11 +13,12 @@ export function useCreateEmbeddingModel(onSuccess?: () => void) {
   const { t } = useTranslation('super-admin-settings-org');
   const queryClient = useQueryClient();
   const router = useRouter();
-  const mutation = useSuperAdminModelsControllerCreateEmbeddingModel({
+  const mutation = useSuperAdminCatalogModelsControllerCreateEmbeddingModel({
     mutation: {
       onSuccess: async () => {
         await queryClient.invalidateQueries({
-          queryKey: getSuperAdminModelsControllerGetAllCatalogModelsQueryKey(),
+          queryKey:
+            getSuperAdminCatalogModelsControllerGetAllCatalogModelsQueryKey(),
         });
         showSuccess(t('models.createSuccess'));
         onSuccess?.();

--- a/ayunis-core-frontend/src/pages/super-admin-settings/models-catalog/api/useCreateLanguageModel.ts
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/models-catalog/api/useCreateLanguageModel.ts
@@ -1,8 +1,8 @@
 import { useQueryClient } from '@tanstack/react-query';
 import { showSuccess, showError } from '@/shared/lib/toast';
 import {
-  useSuperAdminModelsControllerCreateLanguageModel,
-  getSuperAdminModelsControllerGetAllCatalogModelsQueryKey,
+  useSuperAdminCatalogModelsControllerCreateLanguageModel,
+  getSuperAdminCatalogModelsControllerGetAllCatalogModelsQueryKey,
   type CreateLanguageModelRequestDto,
 } from '@/shared/api';
 import { useRouter } from '@tanstack/react-router';
@@ -12,11 +12,12 @@ export function useCreateLanguageModel(onSuccess?: () => void) {
   const { t } = useTranslation('super-admin-settings-org');
   const queryClient = useQueryClient();
   const router = useRouter();
-  const mutation = useSuperAdminModelsControllerCreateLanguageModel({
+  const mutation = useSuperAdminCatalogModelsControllerCreateLanguageModel({
     mutation: {
       onSuccess: async () => {
         await queryClient.invalidateQueries({
-          queryKey: getSuperAdminModelsControllerGetAllCatalogModelsQueryKey(),
+          queryKey:
+            getSuperAdminCatalogModelsControllerGetAllCatalogModelsQueryKey(),
         });
         showSuccess(t('models.createSuccess'));
         onSuccess?.();

--- a/ayunis-core-frontend/src/pages/super-admin-settings/models-catalog/api/useDeleteModel.ts
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/models-catalog/api/useDeleteModel.ts
@@ -1,8 +1,8 @@
 import { useQueryClient } from '@tanstack/react-query';
 import { showSuccess, showError } from '@/shared/lib/toast';
 import {
-  getSuperAdminModelsControllerGetAllCatalogModelsQueryKey,
-  useSuperAdminModelsControllerDeleteCatalogModel,
+  getSuperAdminCatalogModelsControllerGetAllCatalogModelsQueryKey,
+  useSuperAdminCatalogModelsControllerDeleteCatalogModel,
 } from '@/shared/api';
 import { useRouter } from '@tanstack/react-router';
 import { useTranslation } from 'react-i18next';
@@ -12,11 +12,12 @@ export function useDeleteModel() {
   const { t } = useTranslation('super-admin-settings-org');
   const queryClient = useQueryClient();
   const router = useRouter();
-  const mutation = useSuperAdminModelsControllerDeleteCatalogModel({
+  const mutation = useSuperAdminCatalogModelsControllerDeleteCatalogModel({
     mutation: {
       onSuccess: async () => {
         await queryClient.invalidateQueries({
-          queryKey: getSuperAdminModelsControllerGetAllCatalogModelsQueryKey(),
+          queryKey:
+            getSuperAdminCatalogModelsControllerGetAllCatalogModelsQueryKey(),
         });
         showSuccess(t('models.deleteSuccess'));
       },

--- a/ayunis-core-frontend/src/pages/super-admin-settings/models-catalog/api/useUpdateEmbeddingModel.ts
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/models-catalog/api/useUpdateEmbeddingModel.ts
@@ -1,8 +1,8 @@
 import { useQueryClient } from '@tanstack/react-query';
 import { showSuccess, showError } from '@/shared/lib/toast';
 import {
-  useSuperAdminModelsControllerUpdateEmbeddingModel,
-  getSuperAdminModelsControllerGetAllCatalogModelsQueryKey,
+  useSuperAdminCatalogModelsControllerUpdateEmbeddingModel,
+  getSuperAdminCatalogModelsControllerGetAllCatalogModelsQueryKey,
   type UpdateEmbeddingModelRequestDto,
 } from '@/shared/api';
 import { useRouter } from '@tanstack/react-router';
@@ -12,11 +12,12 @@ export function useUpdateEmbeddingModel(onSuccess?: () => void) {
   const { t } = useTranslation('super-admin-settings-org');
   const queryClient = useQueryClient();
   const router = useRouter();
-  const mutation = useSuperAdminModelsControllerUpdateEmbeddingModel({
+  const mutation = useSuperAdminCatalogModelsControllerUpdateEmbeddingModel({
     mutation: {
       onSuccess: async () => {
         await queryClient.invalidateQueries({
-          queryKey: getSuperAdminModelsControllerGetAllCatalogModelsQueryKey(),
+          queryKey:
+            getSuperAdminCatalogModelsControllerGetAllCatalogModelsQueryKey(),
         });
         showSuccess(t('models.updateSuccess'));
         onSuccess?.();

--- a/ayunis-core-frontend/src/pages/super-admin-settings/models-catalog/api/useUpdateLanguageModel.ts
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/models-catalog/api/useUpdateLanguageModel.ts
@@ -1,8 +1,8 @@
 import { useQueryClient } from '@tanstack/react-query';
 import { showSuccess, showError } from '@/shared/lib/toast';
 import {
-  useSuperAdminModelsControllerUpdateLanguageModel,
-  getSuperAdminModelsControllerGetAllCatalogModelsQueryKey,
+  useSuperAdminCatalogModelsControllerUpdateLanguageModel,
+  getSuperAdminCatalogModelsControllerGetAllCatalogModelsQueryKey,
   type UpdateLanguageModelRequestDto,
 } from '@/shared/api';
 import { useRouter } from '@tanstack/react-router';
@@ -12,11 +12,12 @@ export function useUpdateLanguageModel(onSuccess?: () => void) {
   const { t } = useTranslation('super-admin-settings-org');
   const queryClient = useQueryClient();
   const router = useRouter();
-  const mutation = useSuperAdminModelsControllerUpdateLanguageModel({
+  const mutation = useSuperAdminCatalogModelsControllerUpdateLanguageModel({
     mutation: {
       onSuccess: async () => {
         await queryClient.invalidateQueries({
-          queryKey: getSuperAdminModelsControllerGetAllCatalogModelsQueryKey(),
+          queryKey:
+            getSuperAdminCatalogModelsControllerGetAllCatalogModelsQueryKey(),
         });
         showSuccess(t('models.updateSuccess'));
         onSuccess?.();

--- a/ayunis-core-frontend/src/pages/super-admin-settings/models-catalog/model/types.ts
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/models-catalog/model/types.ts
@@ -1,14 +1,12 @@
 import type {
   CreateEmbeddingModelRequestDtoDimensions,
   CreateEmbeddingModelRequestDtoProvider,
-  CreateLanguageModelRequestDtoCurrency,
   CreateLanguageModelRequestDtoProvider,
 } from '@/shared/api';
 
 export interface ModelPricingFormData {
   inputTokenCost?: number;
   outputTokenCost?: number;
-  currency?: CreateLanguageModelRequestDtoCurrency;
 }
 
 export interface LanguageModelFormData extends ModelPricingFormData {

--- a/ayunis-core-frontend/src/pages/super-admin-settings/models-catalog/ui/EditEmbeddingModelDialog.tsx
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/models-catalog/ui/EditEmbeddingModelDialog.tsx
@@ -68,7 +68,6 @@ export function EditEmbeddingModelDialog({
         isArchived: model.isArchived,
         inputTokenCost: model.inputTokenCost,
         outputTokenCost: model.outputTokenCost,
-        currency: model.currency,
       });
     }
   }, [model, open, form]);

--- a/ayunis-core-frontend/src/pages/super-admin-settings/models-catalog/ui/EditLanguageModelDialog.tsx
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/models-catalog/ui/EditLanguageModelDialog.tsx
@@ -53,7 +53,6 @@ export function EditLanguageModelDialog({
         isArchived: model.isArchived,
         inputTokenCost: model.inputTokenCost,
         outputTokenCost: model.outputTokenCost,
-        currency: model.currency,
       });
     }
   }, [model, open, form]);

--- a/ayunis-core-frontend/src/pages/super-admin-settings/models-catalog/ui/ModelItem.tsx
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/models-catalog/ui/ModelItem.tsx
@@ -1,7 +1,7 @@
 import type {
   EmbeddingModelResponseDto,
   LanguageModelResponseDto,
-  SuperAdminModelsControllerGetAllCatalogModels200Item,
+  SuperAdminCatalogModelsControllerGetAllCatalogModels200Item,
 } from '@/shared/api';
 import {
   Item,
@@ -15,19 +15,19 @@ import { Button } from '@/shared/ui/shadcn/button';
 import { Pencil, Trash2 } from 'lucide-react';
 
 function isLanguageModel(
-  model: SuperAdminModelsControllerGetAllCatalogModels200Item,
+  model: SuperAdminCatalogModelsControllerGetAllCatalogModels200Item,
 ): model is LanguageModelResponseDto {
   return model.type === 'language';
 }
 
 function isEmbeddingModel(
-  model: SuperAdminModelsControllerGetAllCatalogModels200Item,
+  model: SuperAdminCatalogModelsControllerGetAllCatalogModels200Item,
 ): model is EmbeddingModelResponseDto {
   return model.type === 'embedding';
 }
 
 interface ModelItemProps {
-  model: SuperAdminModelsControllerGetAllCatalogModels200Item;
+  model: SuperAdminCatalogModelsControllerGetAllCatalogModels200Item;
   onEdit: () => void;
   onDelete: () => void;
   isDeleting: boolean;

--- a/ayunis-core-frontend/src/pages/super-admin-settings/models-catalog/ui/ModelPricingFields.tsx
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/models-catalog/ui/ModelPricingFields.tsx
@@ -7,19 +7,7 @@ import {
   FormMessage,
 } from '@/shared/ui/shadcn/form';
 import { Input } from '@/shared/ui/shadcn/input';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/shared/ui/shadcn/select';
 import type { ModelPricingFormData } from '../model/types';
-import { CreateLanguageModelRequestDtoCurrency } from '@/shared/api/generated/ayunisCoreAPI.schemas';
-
-const CURRENCY_OPTIONS = Object.values(
-  CreateLanguageModelRequestDtoCurrency,
-).map((value) => ({ value, label: value }));
 
 interface ModelPricingFieldsProps<
   T extends FieldValues & ModelPricingFormData,
@@ -33,7 +21,7 @@ export function ModelPricingFields<
 >({ form, disabled }: Readonly<ModelPricingFieldsProps<T>>) {
   return (
     <div className="space-y-4 rounded-md border p-4">
-      <h4 className="text-sm font-medium">Pricing (per million tokens)</h4>
+      <h4 className="text-sm font-medium">Pricing (EUR per million tokens)</h4>
 
       <div className="grid grid-cols-2 gap-4">
         <FormField
@@ -41,7 +29,7 @@ export function ModelPricingFields<
           name={'inputTokenCost' as Path<T>}
           render={({ field }) => (
             <FormItem>
-              <FormLabel>Input Cost</FormLabel>
+              <FormLabel>Input Cost (€)</FormLabel>
               <FormControl>
                 <Input
                   type="number"
@@ -66,7 +54,7 @@ export function ModelPricingFields<
           name={'outputTokenCost' as Path<T>}
           render={({ field }) => (
             <FormItem>
-              <FormLabel>Output Cost</FormLabel>
+              <FormLabel>Output Cost (€)</FormLabel>
               <FormControl>
                 <Input
                   type="number"
@@ -86,35 +74,6 @@ export function ModelPricingFields<
           )}
         />
       </div>
-
-      <FormField
-        control={form.control}
-        name={'currency' as Path<T>}
-        render={({ field }) => (
-          <FormItem>
-            <FormLabel>Currency</FormLabel>
-            <Select
-              onValueChange={field.onChange}
-              value={(field.value as string | undefined) ?? ''}
-              disabled={disabled}
-            >
-              <FormControl>
-                <SelectTrigger>
-                  <SelectValue placeholder="Select currency" />
-                </SelectTrigger>
-              </FormControl>
-              <SelectContent>
-                {CURRENCY_OPTIONS.map((option) => (
-                  <SelectItem key={option.value} value={option.value}>
-                    {option.label}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-            <FormMessage />
-          </FormItem>
-        )}
-      />
     </div>
   );
 }

--- a/ayunis-core-frontend/src/pages/super-admin-settings/models-catalog/ui/ModelsCatalogList.tsx
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/models-catalog/ui/ModelsCatalogList.tsx
@@ -8,7 +8,7 @@ import {
 } from '@/shared/ui/shadcn/card';
 import { ItemGroup, ItemSeparator } from '@/shared/ui/shadcn/item';
 import type {
-  SuperAdminModelsControllerGetAllCatalogModels200Item,
+  SuperAdminCatalogModelsControllerGetAllCatalogModels200Item,
   LanguageModelResponseDto,
   EmbeddingModelResponseDto,
 } from '@/shared/api';
@@ -16,24 +16,24 @@ import { ModelItem } from './ModelItem';
 import { Fragment } from 'react/jsx-runtime';
 
 interface ModelsCatalogListProps {
-  models: SuperAdminModelsControllerGetAllCatalogModels200Item[];
+  models: SuperAdminCatalogModelsControllerGetAllCatalogModels200Item[];
   onEditLanguageModel: (model: LanguageModelResponseDto) => void;
   onEditEmbeddingModel: (model: EmbeddingModelResponseDto) => void;
   onDeleteModel: (
-    model: SuperAdminModelsControllerGetAllCatalogModels200Item,
+    model: SuperAdminCatalogModelsControllerGetAllCatalogModels200Item,
   ) => void;
   isDeleting: boolean;
   isArchivedView?: boolean;
 }
 
 function isLanguageModel(
-  model: SuperAdminModelsControllerGetAllCatalogModels200Item,
+  model: SuperAdminCatalogModelsControllerGetAllCatalogModels200Item,
 ): model is LanguageModelResponseDto {
   return model.type === 'language';
 }
 
 function isEmbeddingModel(
-  model: SuperAdminModelsControllerGetAllCatalogModels200Item,
+  model: SuperAdminCatalogModelsControllerGetAllCatalogModels200Item,
 ): model is EmbeddingModelResponseDto {
   return model.type === 'embedding';
 }

--- a/ayunis-core-frontend/src/pages/super-admin-settings/models-catalog/ui/Page.tsx
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/models-catalog/ui/Page.tsx
@@ -15,7 +15,7 @@ import {
   DropdownMenuTrigger,
 } from '@/shared/ui/shadcn/dropdown-menu';
 import type {
-  SuperAdminModelsControllerGetAllCatalogModels200Item,
+  SuperAdminCatalogModelsControllerGetAllCatalogModels200Item,
   LanguageModelResponseDto,
   EmbeddingModelResponseDto,
 } from '@/shared/api';
@@ -25,7 +25,7 @@ import { useConfirmation } from '@/widgets/confirmation-modal';
 export default function ModelsCatalogPage({
   models,
 }: Readonly<{
-  models: SuperAdminModelsControllerGetAllCatalogModels200Item[];
+  models: SuperAdminCatalogModelsControllerGetAllCatalogModels200Item[];
 }>) {
   const { t } = useTranslation('super-admin-settings-layout');
   const [createLanguageDialogOpen, setCreateLanguageDialogOpen] =
@@ -43,7 +43,7 @@ export default function ModelsCatalogPage({
   const archivedModels = models.filter((m) => m.isArchived);
 
   function handleDeleteModel(
-    model: SuperAdminModelsControllerGetAllCatalogModels200Item,
+    model: SuperAdminCatalogModelsControllerGetAllCatalogModels200Item,
   ) {
     confirm({
       title: 'Delete model',

--- a/ayunis-core-frontend/src/pages/super-admin-settings/org/api/useSuperAdminCreatePermittedModel.ts
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/org/api/useSuperAdminCreatePermittedModel.ts
@@ -1,7 +1,7 @@
 import {
-  useSuperAdminModelsControllerCreatePermittedModel,
+  useSuperAdminPermittedModelsControllerCreatePermittedModel,
   type CreatePermittedModelDto,
-  getSuperAdminModelsControllerGetAvailableModelsQueryKey,
+  getSuperAdminPermittedModelsControllerGetAvailableModelsQueryKey,
 } from '@/shared/api';
 import { useQueryClient } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
@@ -24,10 +24,10 @@ export function useSuperAdminCreatePermittedModel(orgId: string) {
   const router = useRouter();
   const { t } = useTranslation('admin-settings-models');
   const queryKey =
-    getSuperAdminModelsControllerGetAvailableModelsQueryKey(orgId);
+    getSuperAdminPermittedModelsControllerGetAvailableModelsQueryKey(orgId);
 
   const createPermittedModelMutation =
-    useSuperAdminModelsControllerCreatePermittedModel({
+    useSuperAdminPermittedModelsControllerCreatePermittedModel({
       mutation: {
         onMutate: async ({ data }) =>
           prepareOptimisticUpdate(queryClient, queryKey, (models) =>

--- a/ayunis-core-frontend/src/pages/super-admin-settings/org/api/useSuperAdminDeletePermittedModel.ts
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/org/api/useSuperAdminDeletePermittedModel.ts
@@ -1,6 +1,6 @@
 import {
-  useSuperAdminModelsControllerDeletePermittedModel,
-  getSuperAdminModelsControllerGetAvailableModelsQueryKey,
+  useSuperAdminPermittedModelsControllerDeletePermittedModel,
+  getSuperAdminPermittedModelsControllerGetAvailableModelsQueryKey,
 } from '@/shared/api';
 import { useConfirmation } from '@/widgets/confirmation-modal';
 import { useQueryClient } from '@tanstack/react-query';
@@ -22,10 +22,10 @@ export function useSuperAdminDeletePermittedModel(orgId: string) {
   const router = useRouter();
   const { confirm } = useConfirmation();
   const queryKey =
-    getSuperAdminModelsControllerGetAvailableModelsQueryKey(orgId);
+    getSuperAdminPermittedModelsControllerGetAvailableModelsQueryKey(orgId);
 
   const deletePermittedModelMutation =
-    useSuperAdminModelsControllerDeletePermittedModel({
+    useSuperAdminPermittedModelsControllerDeletePermittedModel({
       mutation: {
         onMutate: async ({ id }) =>
           prepareOptimisticUpdate(queryClient, queryKey, (models) =>

--- a/ayunis-core-frontend/src/pages/super-admin-settings/org/api/useSuperAdminManageOrgDefaultModel.ts
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/org/api/useSuperAdminManageOrgDefaultModel.ts
@@ -1,8 +1,8 @@
 import {
-  getSuperAdminModelsControllerGetAvailableModelsQueryKey,
-  getSuperAdminModelsControllerGetPermittedModelsQueryKey,
+  getSuperAdminPermittedModelsControllerGetAvailableModelsQueryKey,
+  getSuperAdminPermittedModelsControllerGetPermittedModelsQueryKey,
   type ModelWithConfigResponseDto,
-  useSuperAdminModelsControllerManageOrgDefaultModel,
+  useSuperAdminPermittedModelsControllerManageOrgDefaultModel,
 } from '@/shared/api';
 import { showError, showSuccess } from '@/shared/lib/toast';
 import { useQueryClient } from '@tanstack/react-query';
@@ -15,11 +15,13 @@ export function useSuperAdminManageOrgDefaultModel(orgId: string) {
   const router = useRouter();
 
   const manageOrgDefaultModelMutation =
-    useSuperAdminModelsControllerManageOrgDefaultModel({
+    useSuperAdminPermittedModelsControllerManageOrgDefaultModel({
       mutation: {
         onMutate: async ({ data }) => {
           const queryKey =
-            getSuperAdminModelsControllerGetAvailableModelsQueryKey(orgId);
+            getSuperAdminPermittedModelsControllerGetAvailableModelsQueryKey(
+              orgId,
+            );
           await queryClient.cancelQueries({ queryKey });
 
           const previousModels =
@@ -59,8 +61,12 @@ export function useSuperAdminManageOrgDefaultModel(orgId: string) {
         },
         onSettled: async () => {
           const queryKeys = [
-            getSuperAdminModelsControllerGetAvailableModelsQueryKey(orgId),
-            getSuperAdminModelsControllerGetPermittedModelsQueryKey(orgId),
+            getSuperAdminPermittedModelsControllerGetAvailableModelsQueryKey(
+              orgId,
+            ),
+            getSuperAdminPermittedModelsControllerGetPermittedModelsQueryKey(
+              orgId,
+            ),
           ];
 
           await Promise.all(

--- a/ayunis-core-frontend/src/pages/super-admin-settings/org/api/useSuperAdminModels.ts
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/org/api/useSuperAdminModels.ts
@@ -1,11 +1,11 @@
-import { useSuperAdminModelsControllerGetAvailableModels } from '@/shared/api';
+import { useSuperAdminPermittedModelsControllerGetAvailableModels } from '@/shared/api';
 
 export function useSuperAdminModels(orgId: string) {
   const {
     data: models = [],
     isLoading,
     error,
-  } = useSuperAdminModelsControllerGetAvailableModels(orgId);
+  } = useSuperAdminPermittedModelsControllerGetAvailableModels(orgId);
 
   return {
     models,

--- a/ayunis-core-frontend/src/pages/super-admin-settings/org/api/useSuperAdminUpdatePermittedModel.ts
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/org/api/useSuperAdminUpdatePermittedModel.ts
@@ -1,6 +1,6 @@
 import {
-  useSuperAdminModelsControllerUpdatePermittedModel,
-  getSuperAdminModelsControllerGetAvailableModelsQueryKey,
+  useSuperAdminPermittedModelsControllerUpdatePermittedModel,
+  getSuperAdminPermittedModelsControllerGetAvailableModelsQueryKey,
 } from '@/shared/api';
 import { useQueryClient } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
@@ -24,10 +24,10 @@ export function useSuperAdminUpdatePermittedModel(orgId: string) {
   const router = useRouter();
   const { t } = useTranslation('admin-settings-models');
   const queryKey =
-    getSuperAdminModelsControllerGetAvailableModelsQueryKey(orgId);
+    getSuperAdminPermittedModelsControllerGetAvailableModelsQueryKey(orgId);
 
   const updatePermittedModelMutation =
-    useSuperAdminModelsControllerUpdatePermittedModel({
+    useSuperAdminPermittedModelsControllerUpdatePermittedModel({
       mutation: {
         onMutate: async ({ id, data }) =>
           prepareOptimisticUpdate(queryClient, queryKey, (models) =>

--- a/ayunis-core-frontend/src/pages/super-admin-settings/org/ui/SuperAdminProviderConsumption.tsx
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/org/ui/SuperAdminProviderConsumption.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import { useSuperAdminProviderUsageChart } from '../api/useSuperAdminProviderUsageChart';
-import { useSuperAdminModelsControllerGetPermittedModels } from '@/shared/api';
+import { useSuperAdminPermittedModelsControllerGetPermittedModels } from '@/shared/api';
 import { ProviderConsumptionWidget } from '@/widgets/provider-consumption-chart';
 
 interface SuperAdminProviderConsumptionProps {
@@ -27,7 +27,7 @@ export function SuperAdminProviderConsumption({
   });
 
   const { data: permittedModels } =
-    useSuperAdminModelsControllerGetPermittedModels(orgId);
+    useSuperAdminPermittedModelsControllerGetPermittedModels(orgId);
 
   const providerDisplayNames = useMemo(() => {
     const map: Record<string, string> = {};

--- a/ayunis-core-frontend/src/pages/super-admin-settings/org/ui/SuperAdminUsageFilters.tsx
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/org/ui/SuperAdminUsageFilters.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import { UsageFiltersWidget } from '@/widgets/usage-filters/ui/UsageFiltersWidget';
-import { useSuperAdminModelsControllerGetPermittedModels } from '@/shared/api';
+import { useSuperAdminPermittedModelsControllerGetPermittedModels } from '@/shared/api';
 
 interface SuperAdminUsageFiltersProps {
   orgId: string;
@@ -22,7 +22,7 @@ export function SuperAdminUsageFilters({
   onModelChange,
 }: Readonly<SuperAdminUsageFiltersProps>) {
   const { data: permittedModels } =
-    useSuperAdminModelsControllerGetPermittedModels(orgId);
+    useSuperAdminPermittedModelsControllerGetPermittedModels(orgId);
 
   const providerOptions = useMemo(() => {
     if (!permittedModels?.length) return [];

--- a/ayunis-core-frontend/src/pages/super-admin-settings/usage/ui/GlobalProviderConsumption.tsx
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/usage/ui/GlobalProviderConsumption.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import { useGlobalProviderUsageChart } from '../api/useGlobalProviderUsageChart';
-import { useSuperAdminModelsControllerGetAllCatalogModels } from '@/shared/api';
+import { useSuperAdminCatalogModelsControllerGetAllCatalogModels } from '@/shared/api';
 import { ProviderConsumptionWidget } from '@/widgets/provider-consumption-chart';
 
 interface GlobalProviderConsumptionProps {
@@ -25,7 +25,7 @@ export function GlobalProviderConsumption({
   });
 
   const { data: catalogModels } =
-    useSuperAdminModelsControllerGetAllCatalogModels();
+    useSuperAdminCatalogModelsControllerGetAllCatalogModels();
 
   const providerDisplayNames = useMemo(() => {
     const map: Record<string, string> = {};

--- a/ayunis-core-frontend/src/pages/super-admin-settings/usage/ui/GlobalUsageFilters.tsx
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/usage/ui/GlobalUsageFilters.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { useSuperAdminModelsControllerGetAllCatalogModels } from '@/shared/api';
+import { useSuperAdminCatalogModelsControllerGetAllCatalogModels } from '@/shared/api';
 import { UsageFiltersWidget } from '@/widgets/usage-filters/ui/UsageFiltersWidget';
 
 interface GlobalUsageFiltersProps {
@@ -20,7 +20,7 @@ export function GlobalUsageFilters({
   onModelChange,
 }: Readonly<GlobalUsageFiltersProps>) {
   const { data: catalogModels } =
-    useSuperAdminModelsControllerGetAllCatalogModels();
+    useSuperAdminCatalogModelsControllerGetAllCatalogModels();
 
   const providerOptions = useMemo(() => {
     if (!catalogModels?.length) return [];

--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
@@ -302,18 +302,6 @@ export const CreateLanguageModelRequestDtoProvider = {
   scaleway: 'scaleway',
 } as const;
 
-/**
- * Currency for token costs
- */
-export type CreateLanguageModelRequestDtoCurrency = typeof CreateLanguageModelRequestDtoCurrency[keyof typeof CreateLanguageModelRequestDtoCurrency];
-
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const CreateLanguageModelRequestDtoCurrency = {
-  EUR: 'EUR',
-  USD: 'USD',
-} as const;
-
 export interface CreateLanguageModelRequestDto {
   /** The name of the model */
   name: string;
@@ -332,17 +320,15 @@ export interface CreateLanguageModelRequestDto {
   /** Whether the model is archived */
   isArchived: boolean;
   /**
-   * Cost per million input tokens (in the specified currency)
+   * Cost per million input tokens in EUR
    * @minimum 0
    */
   inputTokenCost?: number;
   /**
-   * Cost per million output tokens (in the specified currency)
+   * Cost per million output tokens in EUR
    * @minimum 0
    */
   outputTokenCost?: number;
-  /** Currency for token costs */
-  currency?: CreateLanguageModelRequestDtoCurrency;
 }
 
 /**
@@ -367,18 +353,6 @@ export const UpdateLanguageModelRequestDtoProvider = {
   scaleway: 'scaleway',
 } as const;
 
-/**
- * Currency for token costs
- */
-export type UpdateLanguageModelRequestDtoCurrency = typeof UpdateLanguageModelRequestDtoCurrency[keyof typeof UpdateLanguageModelRequestDtoCurrency];
-
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const UpdateLanguageModelRequestDtoCurrency = {
-  EUR: 'EUR',
-  USD: 'USD',
-} as const;
-
 export interface UpdateLanguageModelRequestDto {
   /** The name of the model */
   name: string;
@@ -397,17 +371,15 @@ export interface UpdateLanguageModelRequestDto {
   /** Whether the model is archived */
   isArchived: boolean;
   /**
-   * Cost per million input tokens (in the specified currency)
+   * Cost per million input tokens in EUR
    * @minimum 0
    */
   inputTokenCost?: number;
   /**
-   * Cost per million output tokens (in the specified currency)
+   * Cost per million output tokens in EUR
    * @minimum 0
    */
   outputTokenCost?: number;
-  /** Currency for token costs */
-  currency?: UpdateLanguageModelRequestDtoCurrency;
 }
 
 /**
@@ -445,18 +417,6 @@ export const CreateEmbeddingModelRequestDtoDimensions = {
   NUMBER_2560: 2560,
 } as const;
 
-/**
- * Currency for token costs
- */
-export type CreateEmbeddingModelRequestDtoCurrency = typeof CreateEmbeddingModelRequestDtoCurrency[keyof typeof CreateEmbeddingModelRequestDtoCurrency];
-
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const CreateEmbeddingModelRequestDtoCurrency = {
-  EUR: 'EUR',
-  USD: 'USD',
-} as const;
-
 export interface CreateEmbeddingModelRequestDto {
   /** The name of the model */
   name: string;
@@ -469,17 +429,15 @@ export interface CreateEmbeddingModelRequestDto {
   /** Whether the model is archived */
   isArchived: boolean;
   /**
-   * Cost per million input tokens (in the specified currency)
+   * Cost per million input tokens in EUR
    * @minimum 0
    */
   inputTokenCost?: number;
   /**
-   * Cost per million output tokens (in the specified currency)
+   * Cost per million output tokens in EUR
    * @minimum 0
    */
   outputTokenCost?: number;
-  /** Currency for token costs */
-  currency?: CreateEmbeddingModelRequestDtoCurrency;
 }
 
 /**
@@ -517,18 +475,6 @@ export const UpdateEmbeddingModelRequestDtoDimensions = {
   NUMBER_2560: 2560,
 } as const;
 
-/**
- * Currency for token costs
- */
-export type UpdateEmbeddingModelRequestDtoCurrency = typeof UpdateEmbeddingModelRequestDtoCurrency[keyof typeof UpdateEmbeddingModelRequestDtoCurrency];
-
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const UpdateEmbeddingModelRequestDtoCurrency = {
-  EUR: 'EUR',
-  USD: 'USD',
-} as const;
-
 export interface UpdateEmbeddingModelRequestDto {
   /** The name of the model */
   name: string;
@@ -541,17 +487,15 @@ export interface UpdateEmbeddingModelRequestDto {
   /** Whether the model is archived */
   isArchived: boolean;
   /**
-   * Cost per million input tokens (in the specified currency)
+   * Cost per million input tokens in EUR
    * @minimum 0
    */
   inputTokenCost?: number;
   /**
-   * Cost per million output tokens (in the specified currency)
+   * Cost per million output tokens in EUR
    * @minimum 0
    */
   outputTokenCost?: number;
-  /** Currency for token costs */
-  currency?: UpdateEmbeddingModelRequestDtoCurrency;
 }
 
 /**
@@ -587,18 +531,6 @@ export const LanguageModelResponseDtoType = {
   language: 'language',
 } as const;
 
-/**
- * Currency for token costs
- */
-export type LanguageModelResponseDtoCurrency = typeof LanguageModelResponseDtoCurrency[keyof typeof LanguageModelResponseDtoCurrency];
-
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const LanguageModelResponseDtoCurrency = {
-  EUR: 'EUR',
-  USD: 'USD',
-} as const;
-
 export interface LanguageModelResponseDto {
   /** The unique identifier of the model */
   id: string;
@@ -624,12 +556,10 @@ export interface LanguageModelResponseDto {
   createdAt: string;
   /** The date the model was last updated */
   updatedAt: string;
-  /** Cost per million input tokens */
+  /** Cost per million input tokens in EUR */
   inputTokenCost?: number;
-  /** Cost per million output tokens */
+  /** Cost per million output tokens in EUR */
   outputTokenCost?: number;
-  /** Currency for token costs */
-  currency?: LanguageModelResponseDtoCurrency;
 }
 
 /**
@@ -681,18 +611,6 @@ export const EmbeddingModelResponseDtoDimensions = {
   NUMBER_2560: 2560,
 } as const;
 
-/**
- * Currency for token costs
- */
-export type EmbeddingModelResponseDtoCurrency = typeof EmbeddingModelResponseDtoCurrency[keyof typeof EmbeddingModelResponseDtoCurrency];
-
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const EmbeddingModelResponseDtoCurrency = {
-  EUR: 'EUR',
-  USD: 'USD',
-} as const;
-
 export interface EmbeddingModelResponseDto {
   /** The unique identifier of the model */
   id: string;
@@ -712,12 +630,10 @@ export interface EmbeddingModelResponseDto {
   createdAt: string;
   /** The date the model was last updated */
   updatedAt: string;
-  /** Cost per million input tokens */
+  /** Cost per million input tokens in EUR */
   inputTokenCost?: number;
-  /** Cost per million output tokens */
+  /** Cost per million output tokens in EUR */
   outputTokenCost?: number;
-  /** Currency for token costs */
-  currency?: EmbeddingModelResponseDtoCurrency;
 }
 
 export interface CreateOrgRequestDto {
@@ -3329,6 +3245,33 @@ export interface CreditUsageResponseDto {
   creditsRemaining: number | null;
 }
 
+export interface UserUsageDto {
+  /** User ID */
+  userId: string;
+  /** User name */
+  userName: string;
+  /** User email */
+  userEmail: string;
+  /** Total tokens for this user */
+  tokens: number;
+  /** Total requests for this user */
+  requests: number;
+  /**
+   * Last activity date (null if no activity)
+   * @nullable
+   */
+  lastActivity: string | null;
+  /** Whether the user is considered active */
+  isActive: boolean;
+}
+
+export interface UserUsageResponseDto {
+  /** User usage statistics */
+  data: UserUsageDto[];
+  /** Pagination metadata */
+  pagination: PaginationDto;
+}
+
 export interface UsageStatsResponseDto {
   /** Total tokens consumed across all users and models in the specified period */
   totalTokens: number;
@@ -3340,6 +3283,50 @@ export interface UsageStatsResponseDto {
   totalUsers: number;
   /** List of the most frequently used model names, ordered by usage */
   topModels: string[];
+}
+
+/**
+ * Model provider
+ */
+export type ModelDistributionDtoProvider = typeof ModelDistributionDtoProvider[keyof typeof ModelDistributionDtoProvider];
+
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const ModelDistributionDtoProvider = {
+  openai: 'openai',
+  anthropic: 'anthropic',
+  bedrock: 'bedrock',
+  mistral: 'mistral',
+  ollama: 'ollama',
+  synaforce: 'synaforce',
+  ayunis: 'ayunis',
+  otc: 'otc',
+  azure: 'azure',
+  gemini: 'gemini',
+  stackit: 'stackit',
+  scaleway: 'scaleway',
+} as const;
+
+export interface ModelDistributionDto {
+  /** Model ID */
+  modelId: string;
+  /** Model name */
+  modelName: string;
+  /** Model display name */
+  displayName: string;
+  /** Model provider */
+  provider: ModelDistributionDtoProvider;
+  /** Total tokens for this model */
+  tokens: number;
+  /** Total requests for this model */
+  requests: number;
+  /** Percentage of total usage */
+  percentage: number;
+}
+
+export interface ModelDistributionResponseDto {
+  /** Model distribution statistics */
+  models: ModelDistributionDto[];
 }
 
 export interface TimeSeriesPointDto {
@@ -3416,77 +3403,6 @@ export interface ProviderTimeSeriesRowDto {
 export interface ProviderUsageChartResponseDto {
   /** Aligned time series rows by date with provider token values */
   timeSeries: ProviderTimeSeriesRowDto[];
-}
-
-/**
- * Model provider
- */
-export type ModelDistributionDtoProvider = typeof ModelDistributionDtoProvider[keyof typeof ModelDistributionDtoProvider];
-
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const ModelDistributionDtoProvider = {
-  openai: 'openai',
-  anthropic: 'anthropic',
-  bedrock: 'bedrock',
-  mistral: 'mistral',
-  ollama: 'ollama',
-  synaforce: 'synaforce',
-  ayunis: 'ayunis',
-  otc: 'otc',
-  azure: 'azure',
-  gemini: 'gemini',
-  stackit: 'stackit',
-  scaleway: 'scaleway',
-} as const;
-
-export interface ModelDistributionDto {
-  /** Model ID */
-  modelId: string;
-  /** Model name */
-  modelName: string;
-  /** Model display name */
-  displayName: string;
-  /** Model provider */
-  provider: ModelDistributionDtoProvider;
-  /** Total tokens for this model */
-  tokens: number;
-  /** Total requests for this model */
-  requests: number;
-  /** Percentage of total usage */
-  percentage: number;
-}
-
-export interface ModelDistributionResponseDto {
-  /** Model distribution statistics */
-  models: ModelDistributionDto[];
-}
-
-export interface UserUsageDto {
-  /** User ID */
-  userId: string;
-  /** User name */
-  userName: string;
-  /** User email */
-  userEmail: string;
-  /** Total tokens for this user */
-  tokens: number;
-  /** Total requests for this user */
-  requests: number;
-  /**
-   * Last activity date (null if no activity)
-   * @nullable
-   */
-  lastActivity: string | null;
-  /** Whether the user is considered active */
-  isActive: boolean;
-}
-
-export interface UserUsageResponseDto {
-  /** User usage statistics */
-  data: UserUsageDto[];
-  /** Pagination metadata */
-  pagination: PaginationDto;
 }
 
 export interface GlobalUserUsageDto {
@@ -3674,13 +3590,13 @@ export interface MeResponseDto {
   name: string;
 }
 
-export type SuperAdminModelsControllerGetCatalogModelById200 = LanguageModelResponseDto | EmbeddingModelResponseDto;
+export type SuperAdminPermittedModelsControllerGetPermittedModels200Item = PermittedLanguageModelResponseDto | PermittedEmbeddingModelResponseDto;
 
-export type SuperAdminModelsControllerGetPermittedModels200Item = PermittedLanguageModelResponseDto | PermittedEmbeddingModelResponseDto;
+export type SuperAdminPermittedModelsControllerUpdatePermittedModel200 = PermittedLanguageModelResponseDto | PermittedEmbeddingModelResponseDto;
 
-export type SuperAdminModelsControllerUpdatePermittedModel200 = PermittedLanguageModelResponseDto | PermittedEmbeddingModelResponseDto;
+export type SuperAdminCatalogModelsControllerGetAllCatalogModels200Item = LanguageModelResponseDto | EmbeddingModelResponseDto;
 
-export type SuperAdminModelsControllerGetAllCatalogModels200Item = LanguageModelResponseDto | EmbeddingModelResponseDto;
+export type SuperAdminCatalogModelsControllerGetCatalogModelById200 = LanguageModelResponseDto | EmbeddingModelResponseDto;
 
 export type SuperAdminOrgsControllerGetAllOrgsParams = {
 /**
@@ -3868,72 +3784,6 @@ export type RunsControllerSendMessageBody = {
 };
 
 export type RunsControllerSendMessage200 = RunSessionResponseDto | RunMessageResponseDto | RunErrorResponseDto | RunThreadResponseDto;
-
-export type UsageControllerGetUsageStatsParams = {
-/**
- * Start date in ISO format. If provided, must be used with endDate.
- */
-startDate?: string;
-/**
- * End date in ISO format. If provided, must be used with startDate.
- */
-endDate?: string;
-};
-
-export type UsageControllerGetProviderUsageParams = {
-/**
- * Start date in ISO format
- */
-startDate?: string;
-/**
- * End date in ISO format
- */
-endDate?: string;
-/**
- * Whether to include time series data for trend charts. Defaults to true.
- */
-includeTimeSeries?: boolean;
-/**
- * Filter by provider (e.g., openai, anthropic)
- */
-provider?: string;
-/**
- * Filter by model ID
- */
-modelId?: string;
-};
-
-export type UsageControllerGetProviderUsageChartParams = {
-startDate?: string;
-endDate?: string;
-/**
- * Filter by provider (e.g., openai, anthropic)
- */
-provider?: string;
-/**
- * Filter by model ID
- */
-modelId?: string;
-};
-
-export type UsageControllerGetModelDistributionParams = {
-/**
- * Start date in ISO format
- */
-startDate?: string;
-/**
- * End date in ISO format
- */
-endDate?: string;
-/**
- * Maximum number of models to return. Defaults to 10. Frontend can decide how to handle aggregation if needed.
- */
-maxModels?: number;
-/**
- * Filter by model ID
- */
-modelId?: string;
-};
 
 export type UsageControllerGetUserUsageParams = {
 /**

--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.ts
@@ -125,16 +125,16 @@ import type {
   SubscriptionResponseDto,
   SubscriptionResponseDtoNullable,
   SuccessResponseDto,
+  SuperAdminCatalogModelsControllerGetAllCatalogModels200Item,
+  SuperAdminCatalogModelsControllerGetCatalogModelById200,
   SuperAdminGlobalUsageControllerGetGlobalModelDistributionParams,
   SuperAdminGlobalUsageControllerGetGlobalProviderUsageChartParams,
   SuperAdminGlobalUsageControllerGetGlobalUserUsageParams,
-  SuperAdminModelsControllerGetAllCatalogModels200Item,
-  SuperAdminModelsControllerGetCatalogModelById200,
-  SuperAdminModelsControllerGetPermittedModels200Item,
-  SuperAdminModelsControllerUpdatePermittedModel200,
   SuperAdminOrgListResponseDto,
   SuperAdminOrgResponseDto,
   SuperAdminOrgsControllerGetAllOrgsParams,
+  SuperAdminPermittedModelsControllerGetPermittedModels200Item,
+  SuperAdminPermittedModelsControllerUpdatePermittedModel200,
   SuperAdminTrialResponseDto,
   SuperAdminTrialResponseDtoNullable,
   SuperAdminUsageControllerGetModelDistributionParams,
@@ -173,10 +173,6 @@ import type {
   UploadFileResponseDto,
   UpsertUserSystemPromptDto,
   UsageConfigResponseDto,
-  UsageControllerGetModelDistributionParams,
-  UsageControllerGetProviderUsageChartParams,
-  UsageControllerGetProviderUsageParams,
-  UsageControllerGetUsageStatsParams,
   UsageControllerGetUserUsageParams,
   UsageStatsResponseDto,
   UserConfigResponseDto,
@@ -1609,7 +1605,7 @@ export function useModelsControllerIsEmbeddingModelEnabled<TData = Awaited<Retur
  * Retrieve all available models from the registry with their permitted status for the specified organization. This endpoint is only accessible to super admins.
  * @summary Get all available models
  */
-export const superAdminModelsControllerGetAvailableModels = (
+export const superAdminPermittedModelsControllerGetAvailableModels = (
     orgId: string,
  signal?: AbortSignal
 ) => {
@@ -1624,69 +1620,69 @@ export const superAdminModelsControllerGetAvailableModels = (
 
 
 
-export const getSuperAdminModelsControllerGetAvailableModelsQueryKey = (orgId?: string,) => {
+export const getSuperAdminPermittedModelsControllerGetAvailableModelsQueryKey = (orgId?: string,) => {
     return [
     `/super-admin/models/${orgId}/available`
     ] as const;
     }
 
     
-export const getSuperAdminModelsControllerGetAvailableModelsQueryOptions = <TData = Awaited<ReturnType<typeof superAdminModelsControllerGetAvailableModels>>, TError = void>(orgId: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof superAdminModelsControllerGetAvailableModels>>, TError, TData>>, }
+export const getSuperAdminPermittedModelsControllerGetAvailableModelsQueryOptions = <TData = Awaited<ReturnType<typeof superAdminPermittedModelsControllerGetAvailableModels>>, TError = void>(orgId: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof superAdminPermittedModelsControllerGetAvailableModels>>, TError, TData>>, }
 ) => {
 
 const {query: queryOptions} = options ?? {};
 
-  const queryKey =  queryOptions?.queryKey ?? getSuperAdminModelsControllerGetAvailableModelsQueryKey(orgId);
+  const queryKey =  queryOptions?.queryKey ?? getSuperAdminPermittedModelsControllerGetAvailableModelsQueryKey(orgId);
 
   
 
-    const queryFn: QueryFunction<Awaited<ReturnType<typeof superAdminModelsControllerGetAvailableModels>>> = ({ signal }) => superAdminModelsControllerGetAvailableModels(orgId, signal);
+    const queryFn: QueryFunction<Awaited<ReturnType<typeof superAdminPermittedModelsControllerGetAvailableModels>>> = ({ signal }) => superAdminPermittedModelsControllerGetAvailableModels(orgId, signal);
 
       
 
       
 
-   return  { queryKey, queryFn, enabled: !!(orgId), ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof superAdminModelsControllerGetAvailableModels>>, TError, TData> & { queryKey: DataTag<QueryKey, TData, TError> }
+   return  { queryKey, queryFn, enabled: !!(orgId), ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof superAdminPermittedModelsControllerGetAvailableModels>>, TError, TData> & { queryKey: DataTag<QueryKey, TData, TError> }
 }
 
-export type SuperAdminModelsControllerGetAvailableModelsQueryResult = NonNullable<Awaited<ReturnType<typeof superAdminModelsControllerGetAvailableModels>>>
-export type SuperAdminModelsControllerGetAvailableModelsQueryError = void
+export type SuperAdminPermittedModelsControllerGetAvailableModelsQueryResult = NonNullable<Awaited<ReturnType<typeof superAdminPermittedModelsControllerGetAvailableModels>>>
+export type SuperAdminPermittedModelsControllerGetAvailableModelsQueryError = void
 
 
-export function useSuperAdminModelsControllerGetAvailableModels<TData = Awaited<ReturnType<typeof superAdminModelsControllerGetAvailableModels>>, TError = void>(
- orgId: string, options: { query:Partial<UseQueryOptions<Awaited<ReturnType<typeof superAdminModelsControllerGetAvailableModels>>, TError, TData>> & Pick<
+export function useSuperAdminPermittedModelsControllerGetAvailableModels<TData = Awaited<ReturnType<typeof superAdminPermittedModelsControllerGetAvailableModels>>, TError = void>(
+ orgId: string, options: { query:Partial<UseQueryOptions<Awaited<ReturnType<typeof superAdminPermittedModelsControllerGetAvailableModels>>, TError, TData>> & Pick<
         DefinedInitialDataOptions<
-          Awaited<ReturnType<typeof superAdminModelsControllerGetAvailableModels>>,
+          Awaited<ReturnType<typeof superAdminPermittedModelsControllerGetAvailableModels>>,
           TError,
-          Awaited<ReturnType<typeof superAdminModelsControllerGetAvailableModels>>
+          Awaited<ReturnType<typeof superAdminPermittedModelsControllerGetAvailableModels>>
         > , 'initialData'
       >, }
  , queryClient?: QueryClient
   ):  DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
-export function useSuperAdminModelsControllerGetAvailableModels<TData = Awaited<ReturnType<typeof superAdminModelsControllerGetAvailableModels>>, TError = void>(
- orgId: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof superAdminModelsControllerGetAvailableModels>>, TError, TData>> & Pick<
+export function useSuperAdminPermittedModelsControllerGetAvailableModels<TData = Awaited<ReturnType<typeof superAdminPermittedModelsControllerGetAvailableModels>>, TError = void>(
+ orgId: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof superAdminPermittedModelsControllerGetAvailableModels>>, TError, TData>> & Pick<
         UndefinedInitialDataOptions<
-          Awaited<ReturnType<typeof superAdminModelsControllerGetAvailableModels>>,
+          Awaited<ReturnType<typeof superAdminPermittedModelsControllerGetAvailableModels>>,
           TError,
-          Awaited<ReturnType<typeof superAdminModelsControllerGetAvailableModels>>
+          Awaited<ReturnType<typeof superAdminPermittedModelsControllerGetAvailableModels>>
         > , 'initialData'
       >, }
  , queryClient?: QueryClient
   ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
-export function useSuperAdminModelsControllerGetAvailableModels<TData = Awaited<ReturnType<typeof superAdminModelsControllerGetAvailableModels>>, TError = void>(
- orgId: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof superAdminModelsControllerGetAvailableModels>>, TError, TData>>, }
+export function useSuperAdminPermittedModelsControllerGetAvailableModels<TData = Awaited<ReturnType<typeof superAdminPermittedModelsControllerGetAvailableModels>>, TError = void>(
+ orgId: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof superAdminPermittedModelsControllerGetAvailableModels>>, TError, TData>>, }
  , queryClient?: QueryClient
   ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
 /**
  * @summary Get all available models
  */
 
-export function useSuperAdminModelsControllerGetAvailableModels<TData = Awaited<ReturnType<typeof superAdminModelsControllerGetAvailableModels>>, TError = void>(
- orgId: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof superAdminModelsControllerGetAvailableModels>>, TError, TData>>, }
+export function useSuperAdminPermittedModelsControllerGetAvailableModels<TData = Awaited<ReturnType<typeof superAdminPermittedModelsControllerGetAvailableModels>>, TError = void>(
+ orgId: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof superAdminPermittedModelsControllerGetAvailableModels>>, TError, TData>>, }
  , queryClient?: QueryClient 
  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
 
-  const queryOptions = getSuperAdminModelsControllerGetAvailableModelsQueryOptions(orgId,options)
+  const queryOptions = getSuperAdminPermittedModelsControllerGetAvailableModelsQueryOptions(orgId,options)
 
   const query = useQuery(queryOptions, queryClient) as  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
 
@@ -1703,7 +1699,7 @@ export function useSuperAdminModelsControllerGetAvailableModels<TData = Awaited<
  * Sets the specified permitted model as the organization default. If a default already exists, it will be updated to the new model. This endpoint is only accessible to super admins.
  * @summary Set or update the organization default model
  */
-export const superAdminModelsControllerManageOrgDefaultModel = (
+export const superAdminPermittedModelsControllerManageOrgDefaultModel = (
     orgId: string,
     setOrgDefaultModelDto: SetOrgDefaultModelDto,
  ) => {
@@ -1719,11 +1715,11 @@ export const superAdminModelsControllerManageOrgDefaultModel = (
   
 
 
-export const getSuperAdminModelsControllerManageOrgDefaultModelMutationOptions = <TError = void,
-    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof superAdminModelsControllerManageOrgDefaultModel>>, TError,{orgId: string;data: SetOrgDefaultModelDto}, TContext>, }
-): UseMutationOptions<Awaited<ReturnType<typeof superAdminModelsControllerManageOrgDefaultModel>>, TError,{orgId: string;data: SetOrgDefaultModelDto}, TContext> => {
+export const getSuperAdminPermittedModelsControllerManageOrgDefaultModelMutationOptions = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof superAdminPermittedModelsControllerManageOrgDefaultModel>>, TError,{orgId: string;data: SetOrgDefaultModelDto}, TContext>, }
+): UseMutationOptions<Awaited<ReturnType<typeof superAdminPermittedModelsControllerManageOrgDefaultModel>>, TError,{orgId: string;data: SetOrgDefaultModelDto}, TContext> => {
 
-const mutationKey = ['superAdminModelsControllerManageOrgDefaultModel'];
+const mutationKey = ['superAdminPermittedModelsControllerManageOrgDefaultModel'];
 const {mutation: mutationOptions} = options ?
       options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
       options
@@ -1733,10 +1729,10 @@ const {mutation: mutationOptions} = options ?
       
 
 
-      const mutationFn: MutationFunction<Awaited<ReturnType<typeof superAdminModelsControllerManageOrgDefaultModel>>, {orgId: string;data: SetOrgDefaultModelDto}> = (props) => {
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof superAdminPermittedModelsControllerManageOrgDefaultModel>>, {orgId: string;data: SetOrgDefaultModelDto}> = (props) => {
           const {orgId,data} = props ?? {};
 
-          return  superAdminModelsControllerManageOrgDefaultModel(orgId,data,)
+          return  superAdminPermittedModelsControllerManageOrgDefaultModel(orgId,data,)
         }
 
         
@@ -1744,195 +1740,38 @@ const {mutation: mutationOptions} = options ?
 
   return  { mutationFn, ...mutationOptions }}
 
-    export type SuperAdminModelsControllerManageOrgDefaultModelMutationResult = NonNullable<Awaited<ReturnType<typeof superAdminModelsControllerManageOrgDefaultModel>>>
-    export type SuperAdminModelsControllerManageOrgDefaultModelMutationBody = SetOrgDefaultModelDto
-    export type SuperAdminModelsControllerManageOrgDefaultModelMutationError = void
+    export type SuperAdminPermittedModelsControllerManageOrgDefaultModelMutationResult = NonNullable<Awaited<ReturnType<typeof superAdminPermittedModelsControllerManageOrgDefaultModel>>>
+    export type SuperAdminPermittedModelsControllerManageOrgDefaultModelMutationBody = SetOrgDefaultModelDto
+    export type SuperAdminPermittedModelsControllerManageOrgDefaultModelMutationError = void
 
     /**
  * @summary Set or update the organization default model
  */
-export const useSuperAdminModelsControllerManageOrgDefaultModel = <TError = void,
-    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof superAdminModelsControllerManageOrgDefaultModel>>, TError,{orgId: string;data: SetOrgDefaultModelDto}, TContext>, }
+export const useSuperAdminPermittedModelsControllerManageOrgDefaultModel = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof superAdminPermittedModelsControllerManageOrgDefaultModel>>, TError,{orgId: string;data: SetOrgDefaultModelDto}, TContext>, }
  , queryClient?: QueryClient): UseMutationResult<
-        Awaited<ReturnType<typeof superAdminModelsControllerManageOrgDefaultModel>>,
+        Awaited<ReturnType<typeof superAdminPermittedModelsControllerManageOrgDefaultModel>>,
         TError,
         {orgId: string;data: SetOrgDefaultModelDto},
         TContext
       > => {
 
-      const mutationOptions = getSuperAdminModelsControllerManageOrgDefaultModelMutationOptions(options);
+      const mutationOptions = getSuperAdminPermittedModelsControllerManageOrgDefaultModelMutationOptions(options);
 
       return useMutation(mutationOptions, queryClient);
     }
     
-/**
- * Remove a model (language or embedding) from the master catalog. This endpoint is only accessible to super admins.
- * @summary Delete a model from the catalog
- */
-export const superAdminModelsControllerDeleteCatalogModel = (
-    id: string,
- ) => {
-      
-      
-      return customAxiosInstance<void>(
-      {url: `/super-admin/models/catalog/${id}`, method: 'DELETE'
-    },
-      );
-    }
-  
-
-
-export const getSuperAdminModelsControllerDeleteCatalogModelMutationOptions = <TError = void,
-    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof superAdminModelsControllerDeleteCatalogModel>>, TError,{id: string}, TContext>, }
-): UseMutationOptions<Awaited<ReturnType<typeof superAdminModelsControllerDeleteCatalogModel>>, TError,{id: string}, TContext> => {
-
-const mutationKey = ['superAdminModelsControllerDeleteCatalogModel'];
-const {mutation: mutationOptions} = options ?
-      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
-      options
-      : {...options, mutation: {...options.mutation, mutationKey}}
-      : {mutation: { mutationKey, }};
-
-      
-
-
-      const mutationFn: MutationFunction<Awaited<ReturnType<typeof superAdminModelsControllerDeleteCatalogModel>>, {id: string}> = (props) => {
-          const {id} = props ?? {};
-
-          return  superAdminModelsControllerDeleteCatalogModel(id,)
-        }
-
-        
-
-
-  return  { mutationFn, ...mutationOptions }}
-
-    export type SuperAdminModelsControllerDeleteCatalogModelMutationResult = NonNullable<Awaited<ReturnType<typeof superAdminModelsControllerDeleteCatalogModel>>>
-    
-    export type SuperAdminModelsControllerDeleteCatalogModelMutationError = void
-
-    /**
- * @summary Delete a model from the catalog
- */
-export const useSuperAdminModelsControllerDeleteCatalogModel = <TError = void,
-    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof superAdminModelsControllerDeleteCatalogModel>>, TError,{id: string}, TContext>, }
- , queryClient?: QueryClient): UseMutationResult<
-        Awaited<ReturnType<typeof superAdminModelsControllerDeleteCatalogModel>>,
-        TError,
-        {id: string},
-        TContext
-      > => {
-
-      const mutationOptions = getSuperAdminModelsControllerDeleteCatalogModelMutationOptions(options);
-
-      return useMutation(mutationOptions, queryClient);
-    }
-    
-/**
- * Retrieve a specific model from the master catalog by its ID. This endpoint is only accessible to super admins.
- * @summary Get a model by ID from the catalog
- */
-export const superAdminModelsControllerGetCatalogModelById = (
-    id: string,
- signal?: AbortSignal
-) => {
-      
-      
-      return customAxiosInstance<SuperAdminModelsControllerGetCatalogModelById200>(
-      {url: `/super-admin/models/catalog/${id}`, method: 'GET', signal
-    },
-      );
-    }
-  
-
-
-
-export const getSuperAdminModelsControllerGetCatalogModelByIdQueryKey = (id?: string,) => {
-    return [
-    `/super-admin/models/catalog/${id}`
-    ] as const;
-    }
-
-    
-export const getSuperAdminModelsControllerGetCatalogModelByIdQueryOptions = <TData = Awaited<ReturnType<typeof superAdminModelsControllerGetCatalogModelById>>, TError = void>(id: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof superAdminModelsControllerGetCatalogModelById>>, TError, TData>>, }
-) => {
-
-const {query: queryOptions} = options ?? {};
-
-  const queryKey =  queryOptions?.queryKey ?? getSuperAdminModelsControllerGetCatalogModelByIdQueryKey(id);
-
-  
-
-    const queryFn: QueryFunction<Awaited<ReturnType<typeof superAdminModelsControllerGetCatalogModelById>>> = ({ signal }) => superAdminModelsControllerGetCatalogModelById(id, signal);
-
-      
-
-      
-
-   return  { queryKey, queryFn, enabled: !!(id), ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof superAdminModelsControllerGetCatalogModelById>>, TError, TData> & { queryKey: DataTag<QueryKey, TData, TError> }
-}
-
-export type SuperAdminModelsControllerGetCatalogModelByIdQueryResult = NonNullable<Awaited<ReturnType<typeof superAdminModelsControllerGetCatalogModelById>>>
-export type SuperAdminModelsControllerGetCatalogModelByIdQueryError = void
-
-
-export function useSuperAdminModelsControllerGetCatalogModelById<TData = Awaited<ReturnType<typeof superAdminModelsControllerGetCatalogModelById>>, TError = void>(
- id: string, options: { query:Partial<UseQueryOptions<Awaited<ReturnType<typeof superAdminModelsControllerGetCatalogModelById>>, TError, TData>> & Pick<
-        DefinedInitialDataOptions<
-          Awaited<ReturnType<typeof superAdminModelsControllerGetCatalogModelById>>,
-          TError,
-          Awaited<ReturnType<typeof superAdminModelsControllerGetCatalogModelById>>
-        > , 'initialData'
-      >, }
- , queryClient?: QueryClient
-  ):  DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
-export function useSuperAdminModelsControllerGetCatalogModelById<TData = Awaited<ReturnType<typeof superAdminModelsControllerGetCatalogModelById>>, TError = void>(
- id: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof superAdminModelsControllerGetCatalogModelById>>, TError, TData>> & Pick<
-        UndefinedInitialDataOptions<
-          Awaited<ReturnType<typeof superAdminModelsControllerGetCatalogModelById>>,
-          TError,
-          Awaited<ReturnType<typeof superAdminModelsControllerGetCatalogModelById>>
-        > , 'initialData'
-      >, }
- , queryClient?: QueryClient
-  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
-export function useSuperAdminModelsControllerGetCatalogModelById<TData = Awaited<ReturnType<typeof superAdminModelsControllerGetCatalogModelById>>, TError = void>(
- id: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof superAdminModelsControllerGetCatalogModelById>>, TError, TData>>, }
- , queryClient?: QueryClient
-  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
-/**
- * @summary Get a model by ID from the catalog
- */
-
-export function useSuperAdminModelsControllerGetCatalogModelById<TData = Awaited<ReturnType<typeof superAdminModelsControllerGetCatalogModelById>>, TError = void>(
- id: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof superAdminModelsControllerGetCatalogModelById>>, TError, TData>>, }
- , queryClient?: QueryClient 
- ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
-
-  const queryOptions = getSuperAdminModelsControllerGetCatalogModelByIdQueryOptions(id,options)
-
-  const query = useQuery(queryOptions, queryClient) as  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
-
-  query.queryKey = queryOptions.queryKey ;
-
-  return query;
-}
-
-
-
-
-
 /**
  * Retrieve all permitted models for the specified organization. This endpoint is only accessible to super admins.
  * @summary Get all permitted models for a specific organization
  */
-export const superAdminModelsControllerGetPermittedModels = (
+export const superAdminPermittedModelsControllerGetPermittedModels = (
     orgId: string,
  signal?: AbortSignal
 ) => {
       
       
-      return customAxiosInstance<SuperAdminModelsControllerGetPermittedModels200Item[]>(
+      return customAxiosInstance<SuperAdminPermittedModelsControllerGetPermittedModels200Item[]>(
       {url: `/super-admin/models/${orgId}/permitted-models`, method: 'GET', signal
     },
       );
@@ -1941,69 +1780,69 @@ export const superAdminModelsControllerGetPermittedModels = (
 
 
 
-export const getSuperAdminModelsControllerGetPermittedModelsQueryKey = (orgId?: string,) => {
+export const getSuperAdminPermittedModelsControllerGetPermittedModelsQueryKey = (orgId?: string,) => {
     return [
     `/super-admin/models/${orgId}/permitted-models`
     ] as const;
     }
 
     
-export const getSuperAdminModelsControllerGetPermittedModelsQueryOptions = <TData = Awaited<ReturnType<typeof superAdminModelsControllerGetPermittedModels>>, TError = void>(orgId: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof superAdminModelsControllerGetPermittedModels>>, TError, TData>>, }
+export const getSuperAdminPermittedModelsControllerGetPermittedModelsQueryOptions = <TData = Awaited<ReturnType<typeof superAdminPermittedModelsControllerGetPermittedModels>>, TError = void>(orgId: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof superAdminPermittedModelsControllerGetPermittedModels>>, TError, TData>>, }
 ) => {
 
 const {query: queryOptions} = options ?? {};
 
-  const queryKey =  queryOptions?.queryKey ?? getSuperAdminModelsControllerGetPermittedModelsQueryKey(orgId);
+  const queryKey =  queryOptions?.queryKey ?? getSuperAdminPermittedModelsControllerGetPermittedModelsQueryKey(orgId);
 
   
 
-    const queryFn: QueryFunction<Awaited<ReturnType<typeof superAdminModelsControllerGetPermittedModels>>> = ({ signal }) => superAdminModelsControllerGetPermittedModels(orgId, signal);
+    const queryFn: QueryFunction<Awaited<ReturnType<typeof superAdminPermittedModelsControllerGetPermittedModels>>> = ({ signal }) => superAdminPermittedModelsControllerGetPermittedModels(orgId, signal);
 
       
 
       
 
-   return  { queryKey, queryFn, enabled: !!(orgId), ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof superAdminModelsControllerGetPermittedModels>>, TError, TData> & { queryKey: DataTag<QueryKey, TData, TError> }
+   return  { queryKey, queryFn, enabled: !!(orgId), ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof superAdminPermittedModelsControllerGetPermittedModels>>, TError, TData> & { queryKey: DataTag<QueryKey, TData, TError> }
 }
 
-export type SuperAdminModelsControllerGetPermittedModelsQueryResult = NonNullable<Awaited<ReturnType<typeof superAdminModelsControllerGetPermittedModels>>>
-export type SuperAdminModelsControllerGetPermittedModelsQueryError = void
+export type SuperAdminPermittedModelsControllerGetPermittedModelsQueryResult = NonNullable<Awaited<ReturnType<typeof superAdminPermittedModelsControllerGetPermittedModels>>>
+export type SuperAdminPermittedModelsControllerGetPermittedModelsQueryError = void
 
 
-export function useSuperAdminModelsControllerGetPermittedModels<TData = Awaited<ReturnType<typeof superAdminModelsControllerGetPermittedModels>>, TError = void>(
- orgId: string, options: { query:Partial<UseQueryOptions<Awaited<ReturnType<typeof superAdminModelsControllerGetPermittedModels>>, TError, TData>> & Pick<
+export function useSuperAdminPermittedModelsControllerGetPermittedModels<TData = Awaited<ReturnType<typeof superAdminPermittedModelsControllerGetPermittedModels>>, TError = void>(
+ orgId: string, options: { query:Partial<UseQueryOptions<Awaited<ReturnType<typeof superAdminPermittedModelsControllerGetPermittedModels>>, TError, TData>> & Pick<
         DefinedInitialDataOptions<
-          Awaited<ReturnType<typeof superAdminModelsControllerGetPermittedModels>>,
+          Awaited<ReturnType<typeof superAdminPermittedModelsControllerGetPermittedModels>>,
           TError,
-          Awaited<ReturnType<typeof superAdminModelsControllerGetPermittedModels>>
+          Awaited<ReturnType<typeof superAdminPermittedModelsControllerGetPermittedModels>>
         > , 'initialData'
       >, }
  , queryClient?: QueryClient
   ):  DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
-export function useSuperAdminModelsControllerGetPermittedModels<TData = Awaited<ReturnType<typeof superAdminModelsControllerGetPermittedModels>>, TError = void>(
- orgId: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof superAdminModelsControllerGetPermittedModels>>, TError, TData>> & Pick<
+export function useSuperAdminPermittedModelsControllerGetPermittedModels<TData = Awaited<ReturnType<typeof superAdminPermittedModelsControllerGetPermittedModels>>, TError = void>(
+ orgId: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof superAdminPermittedModelsControllerGetPermittedModels>>, TError, TData>> & Pick<
         UndefinedInitialDataOptions<
-          Awaited<ReturnType<typeof superAdminModelsControllerGetPermittedModels>>,
+          Awaited<ReturnType<typeof superAdminPermittedModelsControllerGetPermittedModels>>,
           TError,
-          Awaited<ReturnType<typeof superAdminModelsControllerGetPermittedModels>>
+          Awaited<ReturnType<typeof superAdminPermittedModelsControllerGetPermittedModels>>
         > , 'initialData'
       >, }
  , queryClient?: QueryClient
   ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
-export function useSuperAdminModelsControllerGetPermittedModels<TData = Awaited<ReturnType<typeof superAdminModelsControllerGetPermittedModels>>, TError = void>(
- orgId: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof superAdminModelsControllerGetPermittedModels>>, TError, TData>>, }
+export function useSuperAdminPermittedModelsControllerGetPermittedModels<TData = Awaited<ReturnType<typeof superAdminPermittedModelsControllerGetPermittedModels>>, TError = void>(
+ orgId: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof superAdminPermittedModelsControllerGetPermittedModels>>, TError, TData>>, }
  , queryClient?: QueryClient
   ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
 /**
  * @summary Get all permitted models for a specific organization
  */
 
-export function useSuperAdminModelsControllerGetPermittedModels<TData = Awaited<ReturnType<typeof superAdminModelsControllerGetPermittedModels>>, TError = void>(
- orgId: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof superAdminModelsControllerGetPermittedModels>>, TError, TData>>, }
+export function useSuperAdminPermittedModelsControllerGetPermittedModels<TData = Awaited<ReturnType<typeof superAdminPermittedModelsControllerGetPermittedModels>>, TError = void>(
+ orgId: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof superAdminPermittedModelsControllerGetPermittedModels>>, TError, TData>>, }
  , queryClient?: QueryClient 
  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
 
-  const queryOptions = getSuperAdminModelsControllerGetPermittedModelsQueryOptions(orgId,options)
+  const queryOptions = getSuperAdminPermittedModelsControllerGetPermittedModelsQueryOptions(orgId,options)
 
   const query = useQuery(queryOptions, queryClient) as  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
 
@@ -2020,7 +1859,7 @@ export function useSuperAdminModelsControllerGetPermittedModels<TData = Awaited<
  * Create a new permitted model for the specified organization. This endpoint is only accessible to super admins.
  * @summary Create a permitted model for a specific organization
  */
-export const superAdminModelsControllerCreatePermittedModel = (
+export const superAdminPermittedModelsControllerCreatePermittedModel = (
     orgId: string,
     createPermittedModelDto: CreatePermittedModelDto,
  signal?: AbortSignal
@@ -2037,11 +1876,11 @@ export const superAdminModelsControllerCreatePermittedModel = (
   
 
 
-export const getSuperAdminModelsControllerCreatePermittedModelMutationOptions = <TError = void,
-    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof superAdminModelsControllerCreatePermittedModel>>, TError,{orgId: string;data: CreatePermittedModelDto}, TContext>, }
-): UseMutationOptions<Awaited<ReturnType<typeof superAdminModelsControllerCreatePermittedModel>>, TError,{orgId: string;data: CreatePermittedModelDto}, TContext> => {
+export const getSuperAdminPermittedModelsControllerCreatePermittedModelMutationOptions = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof superAdminPermittedModelsControllerCreatePermittedModel>>, TError,{orgId: string;data: CreatePermittedModelDto}, TContext>, }
+): UseMutationOptions<Awaited<ReturnType<typeof superAdminPermittedModelsControllerCreatePermittedModel>>, TError,{orgId: string;data: CreatePermittedModelDto}, TContext> => {
 
-const mutationKey = ['superAdminModelsControllerCreatePermittedModel'];
+const mutationKey = ['superAdminPermittedModelsControllerCreatePermittedModel'];
 const {mutation: mutationOptions} = options ?
       options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
       options
@@ -2051,10 +1890,10 @@ const {mutation: mutationOptions} = options ?
       
 
 
-      const mutationFn: MutationFunction<Awaited<ReturnType<typeof superAdminModelsControllerCreatePermittedModel>>, {orgId: string;data: CreatePermittedModelDto}> = (props) => {
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof superAdminPermittedModelsControllerCreatePermittedModel>>, {orgId: string;data: CreatePermittedModelDto}> = (props) => {
           const {orgId,data} = props ?? {};
 
-          return  superAdminModelsControllerCreatePermittedModel(orgId,data,)
+          return  superAdminPermittedModelsControllerCreatePermittedModel(orgId,data,)
         }
 
         
@@ -2062,23 +1901,23 @@ const {mutation: mutationOptions} = options ?
 
   return  { mutationFn, ...mutationOptions }}
 
-    export type SuperAdminModelsControllerCreatePermittedModelMutationResult = NonNullable<Awaited<ReturnType<typeof superAdminModelsControllerCreatePermittedModel>>>
-    export type SuperAdminModelsControllerCreatePermittedModelMutationBody = CreatePermittedModelDto
-    export type SuperAdminModelsControllerCreatePermittedModelMutationError = void
+    export type SuperAdminPermittedModelsControllerCreatePermittedModelMutationResult = NonNullable<Awaited<ReturnType<typeof superAdminPermittedModelsControllerCreatePermittedModel>>>
+    export type SuperAdminPermittedModelsControllerCreatePermittedModelMutationBody = CreatePermittedModelDto
+    export type SuperAdminPermittedModelsControllerCreatePermittedModelMutationError = void
 
     /**
  * @summary Create a permitted model for a specific organization
  */
-export const useSuperAdminModelsControllerCreatePermittedModel = <TError = void,
-    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof superAdminModelsControllerCreatePermittedModel>>, TError,{orgId: string;data: CreatePermittedModelDto}, TContext>, }
+export const useSuperAdminPermittedModelsControllerCreatePermittedModel = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof superAdminPermittedModelsControllerCreatePermittedModel>>, TError,{orgId: string;data: CreatePermittedModelDto}, TContext>, }
  , queryClient?: QueryClient): UseMutationResult<
-        Awaited<ReturnType<typeof superAdminModelsControllerCreatePermittedModel>>,
+        Awaited<ReturnType<typeof superAdminPermittedModelsControllerCreatePermittedModel>>,
         TError,
         {orgId: string;data: CreatePermittedModelDto},
         TContext
       > => {
 
-      const mutationOptions = getSuperAdminModelsControllerCreatePermittedModelMutationOptions(options);
+      const mutationOptions = getSuperAdminPermittedModelsControllerCreatePermittedModelMutationOptions(options);
 
       return useMutation(mutationOptions, queryClient);
     }
@@ -2087,7 +1926,7 @@ export const useSuperAdminModelsControllerCreatePermittedModel = <TError = void,
  * Delete a permitted model for the specified organization. This endpoint is only accessible to super admins.
  * @summary Delete a permitted model for a specific organization
  */
-export const superAdminModelsControllerDeletePermittedModel = (
+export const superAdminPermittedModelsControllerDeletePermittedModel = (
     orgId: string,
     id: string,
  ) => {
@@ -2101,11 +1940,11 @@ export const superAdminModelsControllerDeletePermittedModel = (
   
 
 
-export const getSuperAdminModelsControllerDeletePermittedModelMutationOptions = <TError = void,
-    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof superAdminModelsControllerDeletePermittedModel>>, TError,{orgId: string;id: string}, TContext>, }
-): UseMutationOptions<Awaited<ReturnType<typeof superAdminModelsControllerDeletePermittedModel>>, TError,{orgId: string;id: string}, TContext> => {
+export const getSuperAdminPermittedModelsControllerDeletePermittedModelMutationOptions = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof superAdminPermittedModelsControllerDeletePermittedModel>>, TError,{orgId: string;id: string}, TContext>, }
+): UseMutationOptions<Awaited<ReturnType<typeof superAdminPermittedModelsControllerDeletePermittedModel>>, TError,{orgId: string;id: string}, TContext> => {
 
-const mutationKey = ['superAdminModelsControllerDeletePermittedModel'];
+const mutationKey = ['superAdminPermittedModelsControllerDeletePermittedModel'];
 const {mutation: mutationOptions} = options ?
       options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
       options
@@ -2115,10 +1954,10 @@ const {mutation: mutationOptions} = options ?
       
 
 
-      const mutationFn: MutationFunction<Awaited<ReturnType<typeof superAdminModelsControllerDeletePermittedModel>>, {orgId: string;id: string}> = (props) => {
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof superAdminPermittedModelsControllerDeletePermittedModel>>, {orgId: string;id: string}> = (props) => {
           const {orgId,id} = props ?? {};
 
-          return  superAdminModelsControllerDeletePermittedModel(orgId,id,)
+          return  superAdminPermittedModelsControllerDeletePermittedModel(orgId,id,)
         }
 
         
@@ -2126,23 +1965,23 @@ const {mutation: mutationOptions} = options ?
 
   return  { mutationFn, ...mutationOptions }}
 
-    export type SuperAdminModelsControllerDeletePermittedModelMutationResult = NonNullable<Awaited<ReturnType<typeof superAdminModelsControllerDeletePermittedModel>>>
+    export type SuperAdminPermittedModelsControllerDeletePermittedModelMutationResult = NonNullable<Awaited<ReturnType<typeof superAdminPermittedModelsControllerDeletePermittedModel>>>
     
-    export type SuperAdminModelsControllerDeletePermittedModelMutationError = void
+    export type SuperAdminPermittedModelsControllerDeletePermittedModelMutationError = void
 
     /**
  * @summary Delete a permitted model for a specific organization
  */
-export const useSuperAdminModelsControllerDeletePermittedModel = <TError = void,
-    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof superAdminModelsControllerDeletePermittedModel>>, TError,{orgId: string;id: string}, TContext>, }
+export const useSuperAdminPermittedModelsControllerDeletePermittedModel = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof superAdminPermittedModelsControllerDeletePermittedModel>>, TError,{orgId: string;id: string}, TContext>, }
  , queryClient?: QueryClient): UseMutationResult<
-        Awaited<ReturnType<typeof superAdminModelsControllerDeletePermittedModel>>,
+        Awaited<ReturnType<typeof superAdminPermittedModelsControllerDeletePermittedModel>>,
         TError,
         {orgId: string;id: string},
         TContext
       > => {
 
-      const mutationOptions = getSuperAdminModelsControllerDeletePermittedModelMutationOptions(options);
+      const mutationOptions = getSuperAdminPermittedModelsControllerDeletePermittedModelMutationOptions(options);
 
       return useMutation(mutationOptions, queryClient);
     }
@@ -2151,14 +1990,14 @@ export const useSuperAdminModelsControllerDeletePermittedModel = <TError = void,
  * Update the settings of a permitted model for the specified organization. This endpoint is only accessible to super admins.
  * @summary Update a permitted model for a specific organization
  */
-export const superAdminModelsControllerUpdatePermittedModel = (
+export const superAdminPermittedModelsControllerUpdatePermittedModel = (
     orgId: string,
     id: string,
     updatePermittedModelDto: UpdatePermittedModelDto,
  ) => {
       
       
-      return customAxiosInstance<SuperAdminModelsControllerUpdatePermittedModel200>(
+      return customAxiosInstance<SuperAdminPermittedModelsControllerUpdatePermittedModel200>(
       {url: `/super-admin/models/${orgId}/permitted-models/${id}`, method: 'PATCH',
       headers: {'Content-Type': 'application/json', },
       data: updatePermittedModelDto
@@ -2168,11 +2007,11 @@ export const superAdminModelsControllerUpdatePermittedModel = (
   
 
 
-export const getSuperAdminModelsControllerUpdatePermittedModelMutationOptions = <TError = void,
-    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof superAdminModelsControllerUpdatePermittedModel>>, TError,{orgId: string;id: string;data: UpdatePermittedModelDto}, TContext>, }
-): UseMutationOptions<Awaited<ReturnType<typeof superAdminModelsControllerUpdatePermittedModel>>, TError,{orgId: string;id: string;data: UpdatePermittedModelDto}, TContext> => {
+export const getSuperAdminPermittedModelsControllerUpdatePermittedModelMutationOptions = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof superAdminPermittedModelsControllerUpdatePermittedModel>>, TError,{orgId: string;id: string;data: UpdatePermittedModelDto}, TContext>, }
+): UseMutationOptions<Awaited<ReturnType<typeof superAdminPermittedModelsControllerUpdatePermittedModel>>, TError,{orgId: string;id: string;data: UpdatePermittedModelDto}, TContext> => {
 
-const mutationKey = ['superAdminModelsControllerUpdatePermittedModel'];
+const mutationKey = ['superAdminPermittedModelsControllerUpdatePermittedModel'];
 const {mutation: mutationOptions} = options ?
       options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
       options
@@ -2182,10 +2021,10 @@ const {mutation: mutationOptions} = options ?
       
 
 
-      const mutationFn: MutationFunction<Awaited<ReturnType<typeof superAdminModelsControllerUpdatePermittedModel>>, {orgId: string;id: string;data: UpdatePermittedModelDto}> = (props) => {
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof superAdminPermittedModelsControllerUpdatePermittedModel>>, {orgId: string;id: string;data: UpdatePermittedModelDto}> = (props) => {
           const {orgId,id,data} = props ?? {};
 
-          return  superAdminModelsControllerUpdatePermittedModel(orgId,id,data,)
+          return  superAdminPermittedModelsControllerUpdatePermittedModel(orgId,id,data,)
         }
 
         
@@ -2193,23 +2032,23 @@ const {mutation: mutationOptions} = options ?
 
   return  { mutationFn, ...mutationOptions }}
 
-    export type SuperAdminModelsControllerUpdatePermittedModelMutationResult = NonNullable<Awaited<ReturnType<typeof superAdminModelsControllerUpdatePermittedModel>>>
-    export type SuperAdminModelsControllerUpdatePermittedModelMutationBody = UpdatePermittedModelDto
-    export type SuperAdminModelsControllerUpdatePermittedModelMutationError = void
+    export type SuperAdminPermittedModelsControllerUpdatePermittedModelMutationResult = NonNullable<Awaited<ReturnType<typeof superAdminPermittedModelsControllerUpdatePermittedModel>>>
+    export type SuperAdminPermittedModelsControllerUpdatePermittedModelMutationBody = UpdatePermittedModelDto
+    export type SuperAdminPermittedModelsControllerUpdatePermittedModelMutationError = void
 
     /**
  * @summary Update a permitted model for a specific organization
  */
-export const useSuperAdminModelsControllerUpdatePermittedModel = <TError = void,
-    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof superAdminModelsControllerUpdatePermittedModel>>, TError,{orgId: string;id: string;data: UpdatePermittedModelDto}, TContext>, }
+export const useSuperAdminPermittedModelsControllerUpdatePermittedModel = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof superAdminPermittedModelsControllerUpdatePermittedModel>>, TError,{orgId: string;id: string;data: UpdatePermittedModelDto}, TContext>, }
  , queryClient?: QueryClient): UseMutationResult<
-        Awaited<ReturnType<typeof superAdminModelsControllerUpdatePermittedModel>>,
+        Awaited<ReturnType<typeof superAdminPermittedModelsControllerUpdatePermittedModel>>,
         TError,
         {orgId: string;id: string;data: UpdatePermittedModelDto},
         TContext
       > => {
 
-      const mutationOptions = getSuperAdminModelsControllerUpdatePermittedModelMutationOptions(options);
+      const mutationOptions = getSuperAdminPermittedModelsControllerUpdatePermittedModelMutationOptions(options);
 
       return useMutation(mutationOptions, queryClient);
     }
@@ -2218,13 +2057,13 @@ export const useSuperAdminModelsControllerUpdatePermittedModel = <TError = void,
  * Retrieve all models (language and embedding) from the master catalog. This endpoint is only accessible to super admins.
  * @summary Get all models in the catalog
  */
-export const superAdminModelsControllerGetAllCatalogModels = (
+export const superAdminCatalogModelsControllerGetAllCatalogModels = (
     
  signal?: AbortSignal
 ) => {
       
       
-      return customAxiosInstance<SuperAdminModelsControllerGetAllCatalogModels200Item[]>(
+      return customAxiosInstance<SuperAdminCatalogModelsControllerGetAllCatalogModels200Item[]>(
       {url: `/super-admin/models/catalog`, method: 'GET', signal
     },
       );
@@ -2233,69 +2072,69 @@ export const superAdminModelsControllerGetAllCatalogModels = (
 
 
 
-export const getSuperAdminModelsControllerGetAllCatalogModelsQueryKey = () => {
+export const getSuperAdminCatalogModelsControllerGetAllCatalogModelsQueryKey = () => {
     return [
     `/super-admin/models/catalog`
     ] as const;
     }
 
     
-export const getSuperAdminModelsControllerGetAllCatalogModelsQueryOptions = <TData = Awaited<ReturnType<typeof superAdminModelsControllerGetAllCatalogModels>>, TError = void>( options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof superAdminModelsControllerGetAllCatalogModels>>, TError, TData>>, }
+export const getSuperAdminCatalogModelsControllerGetAllCatalogModelsQueryOptions = <TData = Awaited<ReturnType<typeof superAdminCatalogModelsControllerGetAllCatalogModels>>, TError = void>( options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof superAdminCatalogModelsControllerGetAllCatalogModels>>, TError, TData>>, }
 ) => {
 
 const {query: queryOptions} = options ?? {};
 
-  const queryKey =  queryOptions?.queryKey ?? getSuperAdminModelsControllerGetAllCatalogModelsQueryKey();
+  const queryKey =  queryOptions?.queryKey ?? getSuperAdminCatalogModelsControllerGetAllCatalogModelsQueryKey();
 
   
 
-    const queryFn: QueryFunction<Awaited<ReturnType<typeof superAdminModelsControllerGetAllCatalogModels>>> = ({ signal }) => superAdminModelsControllerGetAllCatalogModels(signal);
+    const queryFn: QueryFunction<Awaited<ReturnType<typeof superAdminCatalogModelsControllerGetAllCatalogModels>>> = ({ signal }) => superAdminCatalogModelsControllerGetAllCatalogModels(signal);
 
       
 
       
 
-   return  { queryKey, queryFn, ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof superAdminModelsControllerGetAllCatalogModels>>, TError, TData> & { queryKey: DataTag<QueryKey, TData, TError> }
+   return  { queryKey, queryFn, ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof superAdminCatalogModelsControllerGetAllCatalogModels>>, TError, TData> & { queryKey: DataTag<QueryKey, TData, TError> }
 }
 
-export type SuperAdminModelsControllerGetAllCatalogModelsQueryResult = NonNullable<Awaited<ReturnType<typeof superAdminModelsControllerGetAllCatalogModels>>>
-export type SuperAdminModelsControllerGetAllCatalogModelsQueryError = void
+export type SuperAdminCatalogModelsControllerGetAllCatalogModelsQueryResult = NonNullable<Awaited<ReturnType<typeof superAdminCatalogModelsControllerGetAllCatalogModels>>>
+export type SuperAdminCatalogModelsControllerGetAllCatalogModelsQueryError = void
 
 
-export function useSuperAdminModelsControllerGetAllCatalogModels<TData = Awaited<ReturnType<typeof superAdminModelsControllerGetAllCatalogModels>>, TError = void>(
-  options: { query:Partial<UseQueryOptions<Awaited<ReturnType<typeof superAdminModelsControllerGetAllCatalogModels>>, TError, TData>> & Pick<
+export function useSuperAdminCatalogModelsControllerGetAllCatalogModels<TData = Awaited<ReturnType<typeof superAdminCatalogModelsControllerGetAllCatalogModels>>, TError = void>(
+  options: { query:Partial<UseQueryOptions<Awaited<ReturnType<typeof superAdminCatalogModelsControllerGetAllCatalogModels>>, TError, TData>> & Pick<
         DefinedInitialDataOptions<
-          Awaited<ReturnType<typeof superAdminModelsControllerGetAllCatalogModels>>,
+          Awaited<ReturnType<typeof superAdminCatalogModelsControllerGetAllCatalogModels>>,
           TError,
-          Awaited<ReturnType<typeof superAdminModelsControllerGetAllCatalogModels>>
+          Awaited<ReturnType<typeof superAdminCatalogModelsControllerGetAllCatalogModels>>
         > , 'initialData'
       >, }
  , queryClient?: QueryClient
   ):  DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
-export function useSuperAdminModelsControllerGetAllCatalogModels<TData = Awaited<ReturnType<typeof superAdminModelsControllerGetAllCatalogModels>>, TError = void>(
-  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof superAdminModelsControllerGetAllCatalogModels>>, TError, TData>> & Pick<
+export function useSuperAdminCatalogModelsControllerGetAllCatalogModels<TData = Awaited<ReturnType<typeof superAdminCatalogModelsControllerGetAllCatalogModels>>, TError = void>(
+  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof superAdminCatalogModelsControllerGetAllCatalogModels>>, TError, TData>> & Pick<
         UndefinedInitialDataOptions<
-          Awaited<ReturnType<typeof superAdminModelsControllerGetAllCatalogModels>>,
+          Awaited<ReturnType<typeof superAdminCatalogModelsControllerGetAllCatalogModels>>,
           TError,
-          Awaited<ReturnType<typeof superAdminModelsControllerGetAllCatalogModels>>
+          Awaited<ReturnType<typeof superAdminCatalogModelsControllerGetAllCatalogModels>>
         > , 'initialData'
       >, }
  , queryClient?: QueryClient
   ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
-export function useSuperAdminModelsControllerGetAllCatalogModels<TData = Awaited<ReturnType<typeof superAdminModelsControllerGetAllCatalogModels>>, TError = void>(
-  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof superAdminModelsControllerGetAllCatalogModels>>, TError, TData>>, }
+export function useSuperAdminCatalogModelsControllerGetAllCatalogModels<TData = Awaited<ReturnType<typeof superAdminCatalogModelsControllerGetAllCatalogModels>>, TError = void>(
+  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof superAdminCatalogModelsControllerGetAllCatalogModels>>, TError, TData>>, }
  , queryClient?: QueryClient
   ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
 /**
  * @summary Get all models in the catalog
  */
 
-export function useSuperAdminModelsControllerGetAllCatalogModels<TData = Awaited<ReturnType<typeof superAdminModelsControllerGetAllCatalogModels>>, TError = void>(
-  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof superAdminModelsControllerGetAllCatalogModels>>, TError, TData>>, }
+export function useSuperAdminCatalogModelsControllerGetAllCatalogModels<TData = Awaited<ReturnType<typeof superAdminCatalogModelsControllerGetAllCatalogModels>>, TError = void>(
+  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof superAdminCatalogModelsControllerGetAllCatalogModels>>, TError, TData>>, }
  , queryClient?: QueryClient 
  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
 
-  const queryOptions = getSuperAdminModelsControllerGetAllCatalogModelsQueryOptions(options)
+  const queryOptions = getSuperAdminCatalogModelsControllerGetAllCatalogModelsQueryOptions(options)
 
   const query = useQuery(queryOptions, queryClient) as  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
 
@@ -2309,10 +2148,167 @@ export function useSuperAdminModelsControllerGetAllCatalogModels<TData = Awaited
 
 
 /**
+ * Retrieve a specific model from the master catalog by its ID. This endpoint is only accessible to super admins.
+ * @summary Get a model by ID from the catalog
+ */
+export const superAdminCatalogModelsControllerGetCatalogModelById = (
+    id: string,
+ signal?: AbortSignal
+) => {
+      
+      
+      return customAxiosInstance<SuperAdminCatalogModelsControllerGetCatalogModelById200>(
+      {url: `/super-admin/models/catalog/${id}`, method: 'GET', signal
+    },
+      );
+    }
+  
+
+
+
+export const getSuperAdminCatalogModelsControllerGetCatalogModelByIdQueryKey = (id?: string,) => {
+    return [
+    `/super-admin/models/catalog/${id}`
+    ] as const;
+    }
+
+    
+export const getSuperAdminCatalogModelsControllerGetCatalogModelByIdQueryOptions = <TData = Awaited<ReturnType<typeof superAdminCatalogModelsControllerGetCatalogModelById>>, TError = void>(id: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof superAdminCatalogModelsControllerGetCatalogModelById>>, TError, TData>>, }
+) => {
+
+const {query: queryOptions} = options ?? {};
+
+  const queryKey =  queryOptions?.queryKey ?? getSuperAdminCatalogModelsControllerGetCatalogModelByIdQueryKey(id);
+
+  
+
+    const queryFn: QueryFunction<Awaited<ReturnType<typeof superAdminCatalogModelsControllerGetCatalogModelById>>> = ({ signal }) => superAdminCatalogModelsControllerGetCatalogModelById(id, signal);
+
+      
+
+      
+
+   return  { queryKey, queryFn, enabled: !!(id), ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof superAdminCatalogModelsControllerGetCatalogModelById>>, TError, TData> & { queryKey: DataTag<QueryKey, TData, TError> }
+}
+
+export type SuperAdminCatalogModelsControllerGetCatalogModelByIdQueryResult = NonNullable<Awaited<ReturnType<typeof superAdminCatalogModelsControllerGetCatalogModelById>>>
+export type SuperAdminCatalogModelsControllerGetCatalogModelByIdQueryError = void
+
+
+export function useSuperAdminCatalogModelsControllerGetCatalogModelById<TData = Awaited<ReturnType<typeof superAdminCatalogModelsControllerGetCatalogModelById>>, TError = void>(
+ id: string, options: { query:Partial<UseQueryOptions<Awaited<ReturnType<typeof superAdminCatalogModelsControllerGetCatalogModelById>>, TError, TData>> & Pick<
+        DefinedInitialDataOptions<
+          Awaited<ReturnType<typeof superAdminCatalogModelsControllerGetCatalogModelById>>,
+          TError,
+          Awaited<ReturnType<typeof superAdminCatalogModelsControllerGetCatalogModelById>>
+        > , 'initialData'
+      >, }
+ , queryClient?: QueryClient
+  ):  DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useSuperAdminCatalogModelsControllerGetCatalogModelById<TData = Awaited<ReturnType<typeof superAdminCatalogModelsControllerGetCatalogModelById>>, TError = void>(
+ id: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof superAdminCatalogModelsControllerGetCatalogModelById>>, TError, TData>> & Pick<
+        UndefinedInitialDataOptions<
+          Awaited<ReturnType<typeof superAdminCatalogModelsControllerGetCatalogModelById>>,
+          TError,
+          Awaited<ReturnType<typeof superAdminCatalogModelsControllerGetCatalogModelById>>
+        > , 'initialData'
+      >, }
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useSuperAdminCatalogModelsControllerGetCatalogModelById<TData = Awaited<ReturnType<typeof superAdminCatalogModelsControllerGetCatalogModelById>>, TError = void>(
+ id: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof superAdminCatalogModelsControllerGetCatalogModelById>>, TError, TData>>, }
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+/**
+ * @summary Get a model by ID from the catalog
+ */
+
+export function useSuperAdminCatalogModelsControllerGetCatalogModelById<TData = Awaited<ReturnType<typeof superAdminCatalogModelsControllerGetCatalogModelById>>, TError = void>(
+ id: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof superAdminCatalogModelsControllerGetCatalogModelById>>, TError, TData>>, }
+ , queryClient?: QueryClient 
+ ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
+
+  const queryOptions = getSuperAdminCatalogModelsControllerGetCatalogModelByIdQueryOptions(id,options)
+
+  const query = useQuery(queryOptions, queryClient) as  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+
+  query.queryKey = queryOptions.queryKey ;
+
+  return query;
+}
+
+
+
+
+
+/**
+ * Remove a model (language or embedding) from the master catalog. This endpoint is only accessible to super admins.
+ * @summary Delete a model from the catalog
+ */
+export const superAdminCatalogModelsControllerDeleteCatalogModel = (
+    id: string,
+ ) => {
+      
+      
+      return customAxiosInstance<void>(
+      {url: `/super-admin/models/catalog/${id}`, method: 'DELETE'
+    },
+      );
+    }
+  
+
+
+export const getSuperAdminCatalogModelsControllerDeleteCatalogModelMutationOptions = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof superAdminCatalogModelsControllerDeleteCatalogModel>>, TError,{id: string}, TContext>, }
+): UseMutationOptions<Awaited<ReturnType<typeof superAdminCatalogModelsControllerDeleteCatalogModel>>, TError,{id: string}, TContext> => {
+
+const mutationKey = ['superAdminCatalogModelsControllerDeleteCatalogModel'];
+const {mutation: mutationOptions} = options ?
+      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
+      options
+      : {...options, mutation: {...options.mutation, mutationKey}}
+      : {mutation: { mutationKey, }};
+
+      
+
+
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof superAdminCatalogModelsControllerDeleteCatalogModel>>, {id: string}> = (props) => {
+          const {id} = props ?? {};
+
+          return  superAdminCatalogModelsControllerDeleteCatalogModel(id,)
+        }
+
+        
+
+
+  return  { mutationFn, ...mutationOptions }}
+
+    export type SuperAdminCatalogModelsControllerDeleteCatalogModelMutationResult = NonNullable<Awaited<ReturnType<typeof superAdminCatalogModelsControllerDeleteCatalogModel>>>
+    
+    export type SuperAdminCatalogModelsControllerDeleteCatalogModelMutationError = void
+
+    /**
+ * @summary Delete a model from the catalog
+ */
+export const useSuperAdminCatalogModelsControllerDeleteCatalogModel = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof superAdminCatalogModelsControllerDeleteCatalogModel>>, TError,{id: string}, TContext>, }
+ , queryClient?: QueryClient): UseMutationResult<
+        Awaited<ReturnType<typeof superAdminCatalogModelsControllerDeleteCatalogModel>>,
+        TError,
+        {id: string},
+        TContext
+      > => {
+
+      const mutationOptions = getSuperAdminCatalogModelsControllerDeleteCatalogModelMutationOptions(options);
+
+      return useMutation(mutationOptions, queryClient);
+    }
+    
+/**
  * Create a new language model in the master catalog. This endpoint is only accessible to super admins.
  * @summary Create a new language model in the catalog
  */
-export const superAdminModelsControllerCreateLanguageModel = (
+export const superAdminCatalogModelsControllerCreateLanguageModel = (
     createLanguageModelRequestDto: CreateLanguageModelRequestDto,
  signal?: AbortSignal
 ) => {
@@ -2328,11 +2324,11 @@ export const superAdminModelsControllerCreateLanguageModel = (
   
 
 
-export const getSuperAdminModelsControllerCreateLanguageModelMutationOptions = <TError = void,
-    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof superAdminModelsControllerCreateLanguageModel>>, TError,{data: CreateLanguageModelRequestDto}, TContext>, }
-): UseMutationOptions<Awaited<ReturnType<typeof superAdminModelsControllerCreateLanguageModel>>, TError,{data: CreateLanguageModelRequestDto}, TContext> => {
+export const getSuperAdminCatalogModelsControllerCreateLanguageModelMutationOptions = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof superAdminCatalogModelsControllerCreateLanguageModel>>, TError,{data: CreateLanguageModelRequestDto}, TContext>, }
+): UseMutationOptions<Awaited<ReturnType<typeof superAdminCatalogModelsControllerCreateLanguageModel>>, TError,{data: CreateLanguageModelRequestDto}, TContext> => {
 
-const mutationKey = ['superAdminModelsControllerCreateLanguageModel'];
+const mutationKey = ['superAdminCatalogModelsControllerCreateLanguageModel'];
 const {mutation: mutationOptions} = options ?
       options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
       options
@@ -2342,10 +2338,10 @@ const {mutation: mutationOptions} = options ?
       
 
 
-      const mutationFn: MutationFunction<Awaited<ReturnType<typeof superAdminModelsControllerCreateLanguageModel>>, {data: CreateLanguageModelRequestDto}> = (props) => {
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof superAdminCatalogModelsControllerCreateLanguageModel>>, {data: CreateLanguageModelRequestDto}> = (props) => {
           const {data} = props ?? {};
 
-          return  superAdminModelsControllerCreateLanguageModel(data,)
+          return  superAdminCatalogModelsControllerCreateLanguageModel(data,)
         }
 
         
@@ -2353,23 +2349,23 @@ const {mutation: mutationOptions} = options ?
 
   return  { mutationFn, ...mutationOptions }}
 
-    export type SuperAdminModelsControllerCreateLanguageModelMutationResult = NonNullable<Awaited<ReturnType<typeof superAdminModelsControllerCreateLanguageModel>>>
-    export type SuperAdminModelsControllerCreateLanguageModelMutationBody = CreateLanguageModelRequestDto
-    export type SuperAdminModelsControllerCreateLanguageModelMutationError = void
+    export type SuperAdminCatalogModelsControllerCreateLanguageModelMutationResult = NonNullable<Awaited<ReturnType<typeof superAdminCatalogModelsControllerCreateLanguageModel>>>
+    export type SuperAdminCatalogModelsControllerCreateLanguageModelMutationBody = CreateLanguageModelRequestDto
+    export type SuperAdminCatalogModelsControllerCreateLanguageModelMutationError = void
 
     /**
  * @summary Create a new language model in the catalog
  */
-export const useSuperAdminModelsControllerCreateLanguageModel = <TError = void,
-    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof superAdminModelsControllerCreateLanguageModel>>, TError,{data: CreateLanguageModelRequestDto}, TContext>, }
+export const useSuperAdminCatalogModelsControllerCreateLanguageModel = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof superAdminCatalogModelsControllerCreateLanguageModel>>, TError,{data: CreateLanguageModelRequestDto}, TContext>, }
  , queryClient?: QueryClient): UseMutationResult<
-        Awaited<ReturnType<typeof superAdminModelsControllerCreateLanguageModel>>,
+        Awaited<ReturnType<typeof superAdminCatalogModelsControllerCreateLanguageModel>>,
         TError,
         {data: CreateLanguageModelRequestDto},
         TContext
       > => {
 
-      const mutationOptions = getSuperAdminModelsControllerCreateLanguageModelMutationOptions(options);
+      const mutationOptions = getSuperAdminCatalogModelsControllerCreateLanguageModelMutationOptions(options);
 
       return useMutation(mutationOptions, queryClient);
     }
@@ -2378,7 +2374,7 @@ export const useSuperAdminModelsControllerCreateLanguageModel = <TError = void,
  * Update an existing language model in the master catalog. This endpoint is only accessible to super admins.
  * @summary Update a language model in the catalog
  */
-export const superAdminModelsControllerUpdateLanguageModel = (
+export const superAdminCatalogModelsControllerUpdateLanguageModel = (
     id: string,
     updateLanguageModelRequestDto: UpdateLanguageModelRequestDto,
  ) => {
@@ -2394,11 +2390,11 @@ export const superAdminModelsControllerUpdateLanguageModel = (
   
 
 
-export const getSuperAdminModelsControllerUpdateLanguageModelMutationOptions = <TError = void,
-    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof superAdminModelsControllerUpdateLanguageModel>>, TError,{id: string;data: UpdateLanguageModelRequestDto}, TContext>, }
-): UseMutationOptions<Awaited<ReturnType<typeof superAdminModelsControllerUpdateLanguageModel>>, TError,{id: string;data: UpdateLanguageModelRequestDto}, TContext> => {
+export const getSuperAdminCatalogModelsControllerUpdateLanguageModelMutationOptions = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof superAdminCatalogModelsControllerUpdateLanguageModel>>, TError,{id: string;data: UpdateLanguageModelRequestDto}, TContext>, }
+): UseMutationOptions<Awaited<ReturnType<typeof superAdminCatalogModelsControllerUpdateLanguageModel>>, TError,{id: string;data: UpdateLanguageModelRequestDto}, TContext> => {
 
-const mutationKey = ['superAdminModelsControllerUpdateLanguageModel'];
+const mutationKey = ['superAdminCatalogModelsControllerUpdateLanguageModel'];
 const {mutation: mutationOptions} = options ?
       options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
       options
@@ -2408,10 +2404,10 @@ const {mutation: mutationOptions} = options ?
       
 
 
-      const mutationFn: MutationFunction<Awaited<ReturnType<typeof superAdminModelsControllerUpdateLanguageModel>>, {id: string;data: UpdateLanguageModelRequestDto}> = (props) => {
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof superAdminCatalogModelsControllerUpdateLanguageModel>>, {id: string;data: UpdateLanguageModelRequestDto}> = (props) => {
           const {id,data} = props ?? {};
 
-          return  superAdminModelsControllerUpdateLanguageModel(id,data,)
+          return  superAdminCatalogModelsControllerUpdateLanguageModel(id,data,)
         }
 
         
@@ -2419,23 +2415,23 @@ const {mutation: mutationOptions} = options ?
 
   return  { mutationFn, ...mutationOptions }}
 
-    export type SuperAdminModelsControllerUpdateLanguageModelMutationResult = NonNullable<Awaited<ReturnType<typeof superAdminModelsControllerUpdateLanguageModel>>>
-    export type SuperAdminModelsControllerUpdateLanguageModelMutationBody = UpdateLanguageModelRequestDto
-    export type SuperAdminModelsControllerUpdateLanguageModelMutationError = void
+    export type SuperAdminCatalogModelsControllerUpdateLanguageModelMutationResult = NonNullable<Awaited<ReturnType<typeof superAdminCatalogModelsControllerUpdateLanguageModel>>>
+    export type SuperAdminCatalogModelsControllerUpdateLanguageModelMutationBody = UpdateLanguageModelRequestDto
+    export type SuperAdminCatalogModelsControllerUpdateLanguageModelMutationError = void
 
     /**
  * @summary Update a language model in the catalog
  */
-export const useSuperAdminModelsControllerUpdateLanguageModel = <TError = void,
-    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof superAdminModelsControllerUpdateLanguageModel>>, TError,{id: string;data: UpdateLanguageModelRequestDto}, TContext>, }
+export const useSuperAdminCatalogModelsControllerUpdateLanguageModel = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof superAdminCatalogModelsControllerUpdateLanguageModel>>, TError,{id: string;data: UpdateLanguageModelRequestDto}, TContext>, }
  , queryClient?: QueryClient): UseMutationResult<
-        Awaited<ReturnType<typeof superAdminModelsControllerUpdateLanguageModel>>,
+        Awaited<ReturnType<typeof superAdminCatalogModelsControllerUpdateLanguageModel>>,
         TError,
         {id: string;data: UpdateLanguageModelRequestDto},
         TContext
       > => {
 
-      const mutationOptions = getSuperAdminModelsControllerUpdateLanguageModelMutationOptions(options);
+      const mutationOptions = getSuperAdminCatalogModelsControllerUpdateLanguageModelMutationOptions(options);
 
       return useMutation(mutationOptions, queryClient);
     }
@@ -2444,7 +2440,7 @@ export const useSuperAdminModelsControllerUpdateLanguageModel = <TError = void,
  * Create a new embedding model in the master catalog. This endpoint is only accessible to super admins.
  * @summary Create a new embedding model in the catalog
  */
-export const superAdminModelsControllerCreateEmbeddingModel = (
+export const superAdminCatalogModelsControllerCreateEmbeddingModel = (
     createEmbeddingModelRequestDto: CreateEmbeddingModelRequestDto,
  signal?: AbortSignal
 ) => {
@@ -2460,11 +2456,11 @@ export const superAdminModelsControllerCreateEmbeddingModel = (
   
 
 
-export const getSuperAdminModelsControllerCreateEmbeddingModelMutationOptions = <TError = void,
-    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof superAdminModelsControllerCreateEmbeddingModel>>, TError,{data: CreateEmbeddingModelRequestDto}, TContext>, }
-): UseMutationOptions<Awaited<ReturnType<typeof superAdminModelsControllerCreateEmbeddingModel>>, TError,{data: CreateEmbeddingModelRequestDto}, TContext> => {
+export const getSuperAdminCatalogModelsControllerCreateEmbeddingModelMutationOptions = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof superAdminCatalogModelsControllerCreateEmbeddingModel>>, TError,{data: CreateEmbeddingModelRequestDto}, TContext>, }
+): UseMutationOptions<Awaited<ReturnType<typeof superAdminCatalogModelsControllerCreateEmbeddingModel>>, TError,{data: CreateEmbeddingModelRequestDto}, TContext> => {
 
-const mutationKey = ['superAdminModelsControllerCreateEmbeddingModel'];
+const mutationKey = ['superAdminCatalogModelsControllerCreateEmbeddingModel'];
 const {mutation: mutationOptions} = options ?
       options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
       options
@@ -2474,10 +2470,10 @@ const {mutation: mutationOptions} = options ?
       
 
 
-      const mutationFn: MutationFunction<Awaited<ReturnType<typeof superAdminModelsControllerCreateEmbeddingModel>>, {data: CreateEmbeddingModelRequestDto}> = (props) => {
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof superAdminCatalogModelsControllerCreateEmbeddingModel>>, {data: CreateEmbeddingModelRequestDto}> = (props) => {
           const {data} = props ?? {};
 
-          return  superAdminModelsControllerCreateEmbeddingModel(data,)
+          return  superAdminCatalogModelsControllerCreateEmbeddingModel(data,)
         }
 
         
@@ -2485,23 +2481,23 @@ const {mutation: mutationOptions} = options ?
 
   return  { mutationFn, ...mutationOptions }}
 
-    export type SuperAdminModelsControllerCreateEmbeddingModelMutationResult = NonNullable<Awaited<ReturnType<typeof superAdminModelsControllerCreateEmbeddingModel>>>
-    export type SuperAdminModelsControllerCreateEmbeddingModelMutationBody = CreateEmbeddingModelRequestDto
-    export type SuperAdminModelsControllerCreateEmbeddingModelMutationError = void
+    export type SuperAdminCatalogModelsControllerCreateEmbeddingModelMutationResult = NonNullable<Awaited<ReturnType<typeof superAdminCatalogModelsControllerCreateEmbeddingModel>>>
+    export type SuperAdminCatalogModelsControllerCreateEmbeddingModelMutationBody = CreateEmbeddingModelRequestDto
+    export type SuperAdminCatalogModelsControllerCreateEmbeddingModelMutationError = void
 
     /**
  * @summary Create a new embedding model in the catalog
  */
-export const useSuperAdminModelsControllerCreateEmbeddingModel = <TError = void,
-    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof superAdminModelsControllerCreateEmbeddingModel>>, TError,{data: CreateEmbeddingModelRequestDto}, TContext>, }
+export const useSuperAdminCatalogModelsControllerCreateEmbeddingModel = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof superAdminCatalogModelsControllerCreateEmbeddingModel>>, TError,{data: CreateEmbeddingModelRequestDto}, TContext>, }
  , queryClient?: QueryClient): UseMutationResult<
-        Awaited<ReturnType<typeof superAdminModelsControllerCreateEmbeddingModel>>,
+        Awaited<ReturnType<typeof superAdminCatalogModelsControllerCreateEmbeddingModel>>,
         TError,
         {data: CreateEmbeddingModelRequestDto},
         TContext
       > => {
 
-      const mutationOptions = getSuperAdminModelsControllerCreateEmbeddingModelMutationOptions(options);
+      const mutationOptions = getSuperAdminCatalogModelsControllerCreateEmbeddingModelMutationOptions(options);
 
       return useMutation(mutationOptions, queryClient);
     }
@@ -2510,7 +2506,7 @@ export const useSuperAdminModelsControllerCreateEmbeddingModel = <TError = void,
  * Update an existing embedding model in the master catalog. This endpoint is only accessible to super admins.
  * @summary Update an embedding model in the catalog
  */
-export const superAdminModelsControllerUpdateEmbeddingModel = (
+export const superAdminCatalogModelsControllerUpdateEmbeddingModel = (
     id: string,
     updateEmbeddingModelRequestDto: UpdateEmbeddingModelRequestDto,
  ) => {
@@ -2526,11 +2522,11 @@ export const superAdminModelsControllerUpdateEmbeddingModel = (
   
 
 
-export const getSuperAdminModelsControllerUpdateEmbeddingModelMutationOptions = <TError = void,
-    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof superAdminModelsControllerUpdateEmbeddingModel>>, TError,{id: string;data: UpdateEmbeddingModelRequestDto}, TContext>, }
-): UseMutationOptions<Awaited<ReturnType<typeof superAdminModelsControllerUpdateEmbeddingModel>>, TError,{id: string;data: UpdateEmbeddingModelRequestDto}, TContext> => {
+export const getSuperAdminCatalogModelsControllerUpdateEmbeddingModelMutationOptions = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof superAdminCatalogModelsControllerUpdateEmbeddingModel>>, TError,{id: string;data: UpdateEmbeddingModelRequestDto}, TContext>, }
+): UseMutationOptions<Awaited<ReturnType<typeof superAdminCatalogModelsControllerUpdateEmbeddingModel>>, TError,{id: string;data: UpdateEmbeddingModelRequestDto}, TContext> => {
 
-const mutationKey = ['superAdminModelsControllerUpdateEmbeddingModel'];
+const mutationKey = ['superAdminCatalogModelsControllerUpdateEmbeddingModel'];
 const {mutation: mutationOptions} = options ?
       options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
       options
@@ -2540,10 +2536,10 @@ const {mutation: mutationOptions} = options ?
       
 
 
-      const mutationFn: MutationFunction<Awaited<ReturnType<typeof superAdminModelsControllerUpdateEmbeddingModel>>, {id: string;data: UpdateEmbeddingModelRequestDto}> = (props) => {
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof superAdminCatalogModelsControllerUpdateEmbeddingModel>>, {id: string;data: UpdateEmbeddingModelRequestDto}> = (props) => {
           const {id,data} = props ?? {};
 
-          return  superAdminModelsControllerUpdateEmbeddingModel(id,data,)
+          return  superAdminCatalogModelsControllerUpdateEmbeddingModel(id,data,)
         }
 
         
@@ -2551,23 +2547,23 @@ const {mutation: mutationOptions} = options ?
 
   return  { mutationFn, ...mutationOptions }}
 
-    export type SuperAdminModelsControllerUpdateEmbeddingModelMutationResult = NonNullable<Awaited<ReturnType<typeof superAdminModelsControllerUpdateEmbeddingModel>>>
-    export type SuperAdminModelsControllerUpdateEmbeddingModelMutationBody = UpdateEmbeddingModelRequestDto
-    export type SuperAdminModelsControllerUpdateEmbeddingModelMutationError = void
+    export type SuperAdminCatalogModelsControllerUpdateEmbeddingModelMutationResult = NonNullable<Awaited<ReturnType<typeof superAdminCatalogModelsControllerUpdateEmbeddingModel>>>
+    export type SuperAdminCatalogModelsControllerUpdateEmbeddingModelMutationBody = UpdateEmbeddingModelRequestDto
+    export type SuperAdminCatalogModelsControllerUpdateEmbeddingModelMutationError = void
 
     /**
  * @summary Update an embedding model in the catalog
  */
-export const useSuperAdminModelsControllerUpdateEmbeddingModel = <TError = void,
-    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof superAdminModelsControllerUpdateEmbeddingModel>>, TError,{id: string;data: UpdateEmbeddingModelRequestDto}, TContext>, }
+export const useSuperAdminCatalogModelsControllerUpdateEmbeddingModel = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof superAdminCatalogModelsControllerUpdateEmbeddingModel>>, TError,{id: string;data: UpdateEmbeddingModelRequestDto}, TContext>, }
  , queryClient?: QueryClient): UseMutationResult<
-        Awaited<ReturnType<typeof superAdminModelsControllerUpdateEmbeddingModel>>,
+        Awaited<ReturnType<typeof superAdminCatalogModelsControllerUpdateEmbeddingModel>>,
         TError,
         {id: string;data: UpdateEmbeddingModelRequestDto},
         TContext
       > => {
 
-      const mutationOptions = getSuperAdminModelsControllerUpdateEmbeddingModelMutationOptions(options);
+      const mutationOptions = getSuperAdminCatalogModelsControllerUpdateEmbeddingModelMutationOptions(options);
 
       return useMutation(mutationOptions, queryClient);
     }
@@ -12861,386 +12857,6 @@ export function useUsageControllerGetCreditUsage<TData = Awaited<ReturnType<type
  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
 
   const queryOptions = getUsageControllerGetCreditUsageQueryOptions(options)
-
-  const query = useQuery(queryOptions, queryClient) as  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
-
-  query.queryKey = queryOptions.queryKey ;
-
-  return query;
-}
-
-
-
-
-
-/**
- * Returns aggregated usage statistics including total tokens, requests, and active users. Dates are optional - if not provided, shows all usage.
- * @summary Get overall usage statistics
- */
-export const usageControllerGetUsageStats = (
-    params?: UsageControllerGetUsageStatsParams,
- signal?: AbortSignal
-) => {
-      
-      
-      return customAxiosInstance<UsageStatsResponseDto>(
-      {url: `/usage/stats`, method: 'GET',
-        params, signal
-    },
-      );
-    }
-  
-
-
-
-export const getUsageControllerGetUsageStatsQueryKey = (params?: UsageControllerGetUsageStatsParams,) => {
-    return [
-    `/usage/stats`, ...(params ? [params]: [])
-    ] as const;
-    }
-
-    
-export const getUsageControllerGetUsageStatsQueryOptions = <TData = Awaited<ReturnType<typeof usageControllerGetUsageStats>>, TError = unknown>(params?: UsageControllerGetUsageStatsParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof usageControllerGetUsageStats>>, TError, TData>>, }
-) => {
-
-const {query: queryOptions} = options ?? {};
-
-  const queryKey =  queryOptions?.queryKey ?? getUsageControllerGetUsageStatsQueryKey(params);
-
-  
-
-    const queryFn: QueryFunction<Awaited<ReturnType<typeof usageControllerGetUsageStats>>> = ({ signal }) => usageControllerGetUsageStats(params, signal);
-
-      
-
-      
-
-   return  { queryKey, queryFn, ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof usageControllerGetUsageStats>>, TError, TData> & { queryKey: DataTag<QueryKey, TData, TError> }
-}
-
-export type UsageControllerGetUsageStatsQueryResult = NonNullable<Awaited<ReturnType<typeof usageControllerGetUsageStats>>>
-export type UsageControllerGetUsageStatsQueryError = unknown
-
-
-export function useUsageControllerGetUsageStats<TData = Awaited<ReturnType<typeof usageControllerGetUsageStats>>, TError = unknown>(
- params: undefined |  UsageControllerGetUsageStatsParams, options: { query:Partial<UseQueryOptions<Awaited<ReturnType<typeof usageControllerGetUsageStats>>, TError, TData>> & Pick<
-        DefinedInitialDataOptions<
-          Awaited<ReturnType<typeof usageControllerGetUsageStats>>,
-          TError,
-          Awaited<ReturnType<typeof usageControllerGetUsageStats>>
-        > , 'initialData'
-      >, }
- , queryClient?: QueryClient
-  ):  DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
-export function useUsageControllerGetUsageStats<TData = Awaited<ReturnType<typeof usageControllerGetUsageStats>>, TError = unknown>(
- params?: UsageControllerGetUsageStatsParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof usageControllerGetUsageStats>>, TError, TData>> & Pick<
-        UndefinedInitialDataOptions<
-          Awaited<ReturnType<typeof usageControllerGetUsageStats>>,
-          TError,
-          Awaited<ReturnType<typeof usageControllerGetUsageStats>>
-        > , 'initialData'
-      >, }
- , queryClient?: QueryClient
-  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
-export function useUsageControllerGetUsageStats<TData = Awaited<ReturnType<typeof usageControllerGetUsageStats>>, TError = unknown>(
- params?: UsageControllerGetUsageStatsParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof usageControllerGetUsageStats>>, TError, TData>>, }
- , queryClient?: QueryClient
-  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
-/**
- * @summary Get overall usage statistics
- */
-
-export function useUsageControllerGetUsageStats<TData = Awaited<ReturnType<typeof usageControllerGetUsageStats>>, TError = unknown>(
- params?: UsageControllerGetUsageStatsParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof usageControllerGetUsageStats>>, TError, TData>>, }
- , queryClient?: QueryClient 
- ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
-
-  const queryOptions = getUsageControllerGetUsageStatsQueryOptions(params,options)
-
-  const query = useQuery(queryOptions, queryClient) as  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
-
-  query.queryKey = queryOptions.queryKey ;
-
-  return query;
-}
-
-
-
-
-
-/**
- * Returns usage statistics grouped by model provider (OpenAI, Anthropic, etc.) with optional time series data for trend analysis. Useful for provider comparison charts. Dates are optional - if not provided, shows all usage.
- * @summary Get usage statistics by provider
- */
-export const usageControllerGetProviderUsage = (
-    params?: UsageControllerGetProviderUsageParams,
- signal?: AbortSignal
-) => {
-      
-      
-      return customAxiosInstance<ProviderUsageResponseDto>(
-      {url: `/usage/providers`, method: 'GET',
-        params, signal
-    },
-      );
-    }
-  
-
-
-
-export const getUsageControllerGetProviderUsageQueryKey = (params?: UsageControllerGetProviderUsageParams,) => {
-    return [
-    `/usage/providers`, ...(params ? [params]: [])
-    ] as const;
-    }
-
-    
-export const getUsageControllerGetProviderUsageQueryOptions = <TData = Awaited<ReturnType<typeof usageControllerGetProviderUsage>>, TError = unknown>(params?: UsageControllerGetProviderUsageParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof usageControllerGetProviderUsage>>, TError, TData>>, }
-) => {
-
-const {query: queryOptions} = options ?? {};
-
-  const queryKey =  queryOptions?.queryKey ?? getUsageControllerGetProviderUsageQueryKey(params);
-
-  
-
-    const queryFn: QueryFunction<Awaited<ReturnType<typeof usageControllerGetProviderUsage>>> = ({ signal }) => usageControllerGetProviderUsage(params, signal);
-
-      
-
-      
-
-   return  { queryKey, queryFn, ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof usageControllerGetProviderUsage>>, TError, TData> & { queryKey: DataTag<QueryKey, TData, TError> }
-}
-
-export type UsageControllerGetProviderUsageQueryResult = NonNullable<Awaited<ReturnType<typeof usageControllerGetProviderUsage>>>
-export type UsageControllerGetProviderUsageQueryError = unknown
-
-
-export function useUsageControllerGetProviderUsage<TData = Awaited<ReturnType<typeof usageControllerGetProviderUsage>>, TError = unknown>(
- params: undefined |  UsageControllerGetProviderUsageParams, options: { query:Partial<UseQueryOptions<Awaited<ReturnType<typeof usageControllerGetProviderUsage>>, TError, TData>> & Pick<
-        DefinedInitialDataOptions<
-          Awaited<ReturnType<typeof usageControllerGetProviderUsage>>,
-          TError,
-          Awaited<ReturnType<typeof usageControllerGetProviderUsage>>
-        > , 'initialData'
-      >, }
- , queryClient?: QueryClient
-  ):  DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
-export function useUsageControllerGetProviderUsage<TData = Awaited<ReturnType<typeof usageControllerGetProviderUsage>>, TError = unknown>(
- params?: UsageControllerGetProviderUsageParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof usageControllerGetProviderUsage>>, TError, TData>> & Pick<
-        UndefinedInitialDataOptions<
-          Awaited<ReturnType<typeof usageControllerGetProviderUsage>>,
-          TError,
-          Awaited<ReturnType<typeof usageControllerGetProviderUsage>>
-        > , 'initialData'
-      >, }
- , queryClient?: QueryClient
-  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
-export function useUsageControllerGetProviderUsage<TData = Awaited<ReturnType<typeof usageControllerGetProviderUsage>>, TError = unknown>(
- params?: UsageControllerGetProviderUsageParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof usageControllerGetProviderUsage>>, TError, TData>>, }
- , queryClient?: QueryClient
-  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
-/**
- * @summary Get usage statistics by provider
- */
-
-export function useUsageControllerGetProviderUsage<TData = Awaited<ReturnType<typeof usageControllerGetProviderUsage>>, TError = unknown>(
- params?: UsageControllerGetProviderUsageParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof usageControllerGetProviderUsage>>, TError, TData>>, }
- , queryClient?: QueryClient 
- ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
-
-  const queryOptions = getUsageControllerGetProviderUsageQueryOptions(params,options)
-
-  const query = useQuery(queryOptions, queryClient) as  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
-
-  query.queryKey = queryOptions.queryKey ;
-
-  return query;
-}
-
-
-
-
-
-/**
- * Returns rows aligned by date with tokens per provider. Shape: { timeSeries: [{ date, values: { [provider]: tokens } }] }
- * @summary Get provider usage time series aligned by date (chart-ready)
- */
-export const usageControllerGetProviderUsageChart = (
-    params?: UsageControllerGetProviderUsageChartParams,
- signal?: AbortSignal
-) => {
-      
-      
-      return customAxiosInstance<ProviderUsageChartResponseDto>(
-      {url: `/usage/providers/chart`, method: 'GET',
-        params, signal
-    },
-      );
-    }
-  
-
-
-
-export const getUsageControllerGetProviderUsageChartQueryKey = (params?: UsageControllerGetProviderUsageChartParams,) => {
-    return [
-    `/usage/providers/chart`, ...(params ? [params]: [])
-    ] as const;
-    }
-
-    
-export const getUsageControllerGetProviderUsageChartQueryOptions = <TData = Awaited<ReturnType<typeof usageControllerGetProviderUsageChart>>, TError = unknown>(params?: UsageControllerGetProviderUsageChartParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof usageControllerGetProviderUsageChart>>, TError, TData>>, }
-) => {
-
-const {query: queryOptions} = options ?? {};
-
-  const queryKey =  queryOptions?.queryKey ?? getUsageControllerGetProviderUsageChartQueryKey(params);
-
-  
-
-    const queryFn: QueryFunction<Awaited<ReturnType<typeof usageControllerGetProviderUsageChart>>> = ({ signal }) => usageControllerGetProviderUsageChart(params, signal);
-
-      
-
-      
-
-   return  { queryKey, queryFn, ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof usageControllerGetProviderUsageChart>>, TError, TData> & { queryKey: DataTag<QueryKey, TData, TError> }
-}
-
-export type UsageControllerGetProviderUsageChartQueryResult = NonNullable<Awaited<ReturnType<typeof usageControllerGetProviderUsageChart>>>
-export type UsageControllerGetProviderUsageChartQueryError = unknown
-
-
-export function useUsageControllerGetProviderUsageChart<TData = Awaited<ReturnType<typeof usageControllerGetProviderUsageChart>>, TError = unknown>(
- params: undefined |  UsageControllerGetProviderUsageChartParams, options: { query:Partial<UseQueryOptions<Awaited<ReturnType<typeof usageControllerGetProviderUsageChart>>, TError, TData>> & Pick<
-        DefinedInitialDataOptions<
-          Awaited<ReturnType<typeof usageControllerGetProviderUsageChart>>,
-          TError,
-          Awaited<ReturnType<typeof usageControllerGetProviderUsageChart>>
-        > , 'initialData'
-      >, }
- , queryClient?: QueryClient
-  ):  DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
-export function useUsageControllerGetProviderUsageChart<TData = Awaited<ReturnType<typeof usageControllerGetProviderUsageChart>>, TError = unknown>(
- params?: UsageControllerGetProviderUsageChartParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof usageControllerGetProviderUsageChart>>, TError, TData>> & Pick<
-        UndefinedInitialDataOptions<
-          Awaited<ReturnType<typeof usageControllerGetProviderUsageChart>>,
-          TError,
-          Awaited<ReturnType<typeof usageControllerGetProviderUsageChart>>
-        > , 'initialData'
-      >, }
- , queryClient?: QueryClient
-  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
-export function useUsageControllerGetProviderUsageChart<TData = Awaited<ReturnType<typeof usageControllerGetProviderUsageChart>>, TError = unknown>(
- params?: UsageControllerGetProviderUsageChartParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof usageControllerGetProviderUsageChart>>, TError, TData>>, }
- , queryClient?: QueryClient
-  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
-/**
- * @summary Get provider usage time series aligned by date (chart-ready)
- */
-
-export function useUsageControllerGetProviderUsageChart<TData = Awaited<ReturnType<typeof usageControllerGetProviderUsageChart>>, TError = unknown>(
- params?: UsageControllerGetProviderUsageChartParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof usageControllerGetProviderUsageChart>>, TError, TData>>, }
- , queryClient?: QueryClient 
- ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
-
-  const queryOptions = getUsageControllerGetProviderUsageChartQueryOptions(params,options)
-
-  const query = useQuery(queryOptions, queryClient) as  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
-
-  query.queryKey = queryOptions.queryKey ;
-
-  return query;
-}
-
-
-
-
-
-/**
- * Returns usage statistics grouped by individual models with percentage distribution. Dates are optional - if not provided, shows all usage.
- * @summary Get usage distribution by model
- */
-export const usageControllerGetModelDistribution = (
-    params?: UsageControllerGetModelDistributionParams,
- signal?: AbortSignal
-) => {
-      
-      
-      return customAxiosInstance<ModelDistributionResponseDto>(
-      {url: `/usage/models`, method: 'GET',
-        params, signal
-    },
-      );
-    }
-  
-
-
-
-export const getUsageControllerGetModelDistributionQueryKey = (params?: UsageControllerGetModelDistributionParams,) => {
-    return [
-    `/usage/models`, ...(params ? [params]: [])
-    ] as const;
-    }
-
-    
-export const getUsageControllerGetModelDistributionQueryOptions = <TData = Awaited<ReturnType<typeof usageControllerGetModelDistribution>>, TError = unknown>(params?: UsageControllerGetModelDistributionParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof usageControllerGetModelDistribution>>, TError, TData>>, }
-) => {
-
-const {query: queryOptions} = options ?? {};
-
-  const queryKey =  queryOptions?.queryKey ?? getUsageControllerGetModelDistributionQueryKey(params);
-
-  
-
-    const queryFn: QueryFunction<Awaited<ReturnType<typeof usageControllerGetModelDistribution>>> = ({ signal }) => usageControllerGetModelDistribution(params, signal);
-
-      
-
-      
-
-   return  { queryKey, queryFn, ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof usageControllerGetModelDistribution>>, TError, TData> & { queryKey: DataTag<QueryKey, TData, TError> }
-}
-
-export type UsageControllerGetModelDistributionQueryResult = NonNullable<Awaited<ReturnType<typeof usageControllerGetModelDistribution>>>
-export type UsageControllerGetModelDistributionQueryError = unknown
-
-
-export function useUsageControllerGetModelDistribution<TData = Awaited<ReturnType<typeof usageControllerGetModelDistribution>>, TError = unknown>(
- params: undefined |  UsageControllerGetModelDistributionParams, options: { query:Partial<UseQueryOptions<Awaited<ReturnType<typeof usageControllerGetModelDistribution>>, TError, TData>> & Pick<
-        DefinedInitialDataOptions<
-          Awaited<ReturnType<typeof usageControllerGetModelDistribution>>,
-          TError,
-          Awaited<ReturnType<typeof usageControllerGetModelDistribution>>
-        > , 'initialData'
-      >, }
- , queryClient?: QueryClient
-  ):  DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
-export function useUsageControllerGetModelDistribution<TData = Awaited<ReturnType<typeof usageControllerGetModelDistribution>>, TError = unknown>(
- params?: UsageControllerGetModelDistributionParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof usageControllerGetModelDistribution>>, TError, TData>> & Pick<
-        UndefinedInitialDataOptions<
-          Awaited<ReturnType<typeof usageControllerGetModelDistribution>>,
-          TError,
-          Awaited<ReturnType<typeof usageControllerGetModelDistribution>>
-        > , 'initialData'
-      >, }
- , queryClient?: QueryClient
-  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
-export function useUsageControllerGetModelDistribution<TData = Awaited<ReturnType<typeof usageControllerGetModelDistribution>>, TError = unknown>(
- params?: UsageControllerGetModelDistributionParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof usageControllerGetModelDistribution>>, TError, TData>>, }
- , queryClient?: QueryClient
-  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
-/**
- * @summary Get usage distribution by model
- */
-
-export function useUsageControllerGetModelDistribution<TData = Awaited<ReturnType<typeof usageControllerGetModelDistribution>>, TError = unknown>(
- params?: UsageControllerGetModelDistributionParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof usageControllerGetModelDistribution>>, TError, TData>>, }
- , queryClient?: QueryClient 
- ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
-
-  const queryOptions = getUsageControllerGetModelDistributionQueryOptions(params,options)
 
   const query = useQuery(queryOptions, queryClient) as  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
 

--- a/ayunis-core-frontend/src/shared/api/openapi-schema.json
+++ b/ayunis-core-frontend/src/shared/api/openapi-schema.json
@@ -10,22 +10,32 @@
             "description": "Cloud deployment status",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/IsCloudResponseDto" }
+                "schema": {
+                  "$ref": "#/components/schemas/IsCloudResponseDto"
+                }
               }
             }
           }
         },
         "summary": "Check if the deployment is running in a cloud environment",
-        "tags": ["app"]
+        "tags": [
+          "app"
+        ]
       }
     },
     "/health": {
       "get": {
         "operationId": "AppController_health",
         "parameters": [],
-        "responses": { "200": { "description": "Health status" } },
+        "responses": {
+          "200": {
+            "description": "Health status"
+          }
+        },
         "summary": "Check if the deployment is healthy",
-        "tags": ["app"]
+        "tags": [
+          "app"
+        ]
       }
     },
     "/feature-toggles": {
@@ -45,7 +55,9 @@
           }
         },
         "summary": "Get the current feature toggle states",
-        "tags": ["app"]
+        "tags": [
+          "app"
+        ]
       }
     },
     "/models/available": {
@@ -66,10 +78,14 @@
               }
             }
           },
-          "500": { "description": "Internal server error" }
+          "500": {
+            "description": "Internal server error"
+          }
         },
         "summary": "Get all available models",
-        "tags": ["models"]
+        "tags": [
+          "models"
+        ]
       }
     },
     "/models/providers": {
@@ -92,7 +108,9 @@
           }
         },
         "summary": "Get all available model providers with their info",
-        "tags": ["models"]
+        "tags": [
+          "models"
+        ]
       }
     },
     "/models/permitted": {
@@ -110,12 +128,20 @@
           }
         },
         "responses": {
-          "200": { "description": "Successfully created a permitted model" },
-          "400": { "description": "Invalid model input" },
-          "500": { "description": "Internal server error" }
+          "200": {
+            "description": "Successfully created a permitted model"
+          },
+          "400": {
+            "description": "Invalid model input"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
         },
         "summary": "Create a permitted model",
-        "tags": ["models"]
+        "tags": [
+          "models"
+        ]
       }
     },
     "/models/permitted/{id}": {
@@ -126,15 +152,23 @@
             "name": "id",
             "required": true,
             "in": "path",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
-          "200": { "description": "Successfully deleted a permitted model" },
-          "401": { "description": "Unauthorized" }
+          "200": {
+            "description": "Successfully deleted a permitted model"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
         },
         "summary": "Delete a permitted model",
-        "tags": ["models"]
+        "tags": [
+          "models"
+        ]
       },
       "patch": {
         "operationId": "ModelsController_updatePermittedModel",
@@ -143,7 +177,9 @@
             "name": "id",
             "required": true,
             "in": "path",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "requestBody": {
@@ -167,11 +203,17 @@
               }
             }
           },
-          "401": { "description": "Unauthorized" },
-          "404": { "description": "Permitted model not found" }
+          "401": {
+            "description": "Unauthorized"
+          },
+          "404": {
+            "description": "Permitted model not found"
+          }
         },
         "summary": "Update a permitted model",
-        "tags": ["models"]
+        "tags": [
+          "models"
+        ]
       }
     },
     "/models/permitted/language-models": {
@@ -192,10 +234,14 @@
               }
             }
           },
-          "500": { "description": "Internal server error" }
+          "500": {
+            "description": "Internal server error"
+          }
         },
         "summary": "Get all permitted language models",
-        "tags": ["models"]
+        "tags": [
+          "models"
+        ]
       }
     },
     "/models/default": {
@@ -214,10 +260,14 @@
               }
             }
           },
-          "500": { "description": "Internal server error" }
+          "500": {
+            "description": "Internal server error"
+          }
         },
         "summary": "Get the effective default model for the user",
-        "tags": ["models"]
+        "tags": [
+          "models"
+        ]
       }
     },
     "/models/org/default": {
@@ -236,10 +286,14 @@
               }
             }
           },
-          "500": { "description": "Internal server error" }
+          "500": {
+            "description": "Internal server error"
+          }
         },
         "summary": "Get the organization default model",
-        "tags": ["models"]
+        "tags": [
+          "models"
+        ]
       },
       "put": {
         "description": "Sets the specified permitted model as the organization default. If a default already exists, it will be updated to the new model.",
@@ -249,7 +303,9 @@
           "required": true,
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/SetOrgDefaultModelDto" }
+              "schema": {
+                "$ref": "#/components/schemas/SetOrgDefaultModelDto"
+              }
             }
           }
         },
@@ -264,11 +320,17 @@
               }
             }
           },
-          "400": { "description": "Invalid request payload" },
-          "404": { "description": "Permitted model not found" }
+          "400": {
+            "description": "Invalid request payload"
+          },
+          "404": {
+            "description": "Permitted model not found"
+          }
         },
         "summary": "Set or update the organization default model",
-        "tags": ["models"]
+        "tags": [
+          "models"
+        ]
       }
     },
     "/models/user/default": {
@@ -287,10 +349,14 @@
               }
             }
           },
-          "500": { "description": "Internal server error" }
+          "500": {
+            "description": "Internal server error"
+          }
         },
         "summary": "Get the user-specific default model",
-        "tags": ["models"]
+        "tags": [
+          "models"
+        ]
       },
       "put": {
         "description": "Sets the specified permitted model as the user default. If a default already exists, it will be updated to the new model.",
@@ -317,11 +383,17 @@
               }
             }
           },
-          "400": { "description": "Invalid request payload" },
-          "404": { "description": "Permitted model not found" }
+          "400": {
+            "description": "Invalid request payload"
+          },
+          "404": {
+            "description": "Permitted model not found"
+          }
         },
         "summary": "Set or update the user default model",
-        "tags": ["models"]
+        "tags": [
+          "models"
+        ]
       },
       "delete": {
         "operationId": "ModelsController_deleteUserDefaultModel",
@@ -330,10 +402,14 @@
           "204": {
             "description": "Successfully deleted the user default model"
           },
-          "404": { "description": "User default model not found" }
+          "404": {
+            "description": "User default model not found"
+          }
         },
         "summary": "Delete the user default model",
-        "tags": ["models"]
+        "tags": [
+          "models"
+        ]
       }
     },
     "/models/provider/{provider}": {
@@ -345,7 +421,9 @@
             "name": "provider",
             "required": true,
             "in": "path",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -359,11 +437,17 @@
               }
             }
           },
-          "404": { "description": "Model provider not found" },
-          "500": { "description": "Internal server error" }
+          "404": {
+            "description": "Model provider not found"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
         },
         "summary": "Get model provider information",
-        "tags": ["models"]
+        "tags": [
+          "models"
+        ]
       }
     },
     "/models/embedding/enabled": {
@@ -381,16 +465,20 @@
               }
             }
           },
-          "500": { "description": "Internal server error" }
+          "500": {
+            "description": "Internal server error"
+          }
         },
         "summary": "Check if an embedding model is enabled for this org",
-        "tags": ["models"]
+        "tags": [
+          "models"
+        ]
       }
     },
     "/super-admin/models/{orgId}/available": {
       "get": {
         "description": "Retrieve all available models from the registry with their permitted status for the specified organization. This endpoint is only accessible to super admins.",
-        "operationId": "SuperAdminModelsController_getAvailableModels",
+        "operationId": "SuperAdminPermittedModelsController_getAvailableModels",
         "parameters": [
           {
             "name": "orgId",
@@ -421,16 +509,20 @@
           "401": {
             "description": "User not authenticated or not authorized as super admin"
           },
-          "500": { "description": "Internal server error" }
+          "500": {
+            "description": "Internal server error"
+          }
         },
         "summary": "Get all available models",
-        "tags": ["Super Admin Models"]
+        "tags": [
+          "Super Admin Models"
+        ]
       }
     },
     "/super-admin/models/{orgId}/default-model": {
       "put": {
         "description": "Sets the specified permitted model as the organization default. If a default already exists, it will be updated to the new model. This endpoint is only accessible to super admins.",
-        "operationId": "SuperAdminModelsController_manageOrgDefaultModel",
+        "operationId": "SuperAdminPermittedModelsController_manageOrgDefaultModel",
         "parameters": [
           {
             "name": "orgId",
@@ -448,7 +540,9 @@
           "required": true,
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/SetOrgDefaultModelDto" }
+              "schema": {
+                "$ref": "#/components/schemas/SetOrgDefaultModelDto"
+              }
             }
           }
         },
@@ -463,89 +557,29 @@
               }
             }
           },
-          "400": { "description": "Invalid model data provided" },
+          "400": {
+            "description": "Invalid model data provided"
+          },
           "401": {
             "description": "User not authenticated or not authorized as super admin"
           },
-          "404": { "description": "Permitted model not found" },
-          "500": { "description": "Internal server error" }
+          "404": {
+            "description": "Permitted model not found"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
         },
         "summary": "Set or update the organization default model",
-        "tags": ["Super Admin Models"]
-      }
-    },
-    "/super-admin/models/catalog/{id}": {
-      "delete": {
-        "description": "Remove a model (language or embedding) from the master catalog. This endpoint is only accessible to super admins.",
-        "operationId": "SuperAdminModelsController_deleteCatalogModel",
-        "parameters": [
-          {
-            "name": "id",
-            "required": true,
-            "in": "path",
-            "description": "Model ID to delete",
-            "schema": {
-              "format": "uuid",
-              "example": "123e4567-e89b-12d3-a456-426614174000",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "204": { "description": "Successfully deleted model" },
-          "401": {
-            "description": "User not authenticated or not authorized as super admin"
-          },
-          "404": { "description": "Model not found" },
-          "500": { "description": "Internal server error" }
-        },
-        "summary": "Delete a model from the catalog",
-        "tags": ["Super Admin Models"]
-      },
-      "get": {
-        "description": "Retrieve a specific model from the master catalog by its ID. This endpoint is only accessible to super admins.",
-        "operationId": "SuperAdminModelsController_getCatalogModelById",
-        "parameters": [
-          {
-            "name": "id",
-            "required": true,
-            "in": "path",
-            "description": "Model ID to retrieve",
-            "schema": {
-              "format": "uuid",
-              "example": "123e4567-e89b-12d3-a456-426614174000",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successfully retrieved model",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "oneOf": [
-                    { "$ref": "#/components/schemas/LanguageModelResponseDto" },
-                    { "$ref": "#/components/schemas/EmbeddingModelResponseDto" }
-                  ]
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "User not authenticated or not authorized as super admin"
-          },
-          "404": { "description": "Model not found" },
-          "500": { "description": "Internal server error" }
-        },
-        "summary": "Get a model by ID from the catalog",
-        "tags": ["Super Admin Models"]
+        "tags": [
+          "Super Admin Models"
+        ]
       }
     },
     "/super-admin/models/{orgId}/permitted-models": {
       "get": {
         "description": "Retrieve all permitted models for the specified organization. This endpoint is only accessible to super admins.",
-        "operationId": "SuperAdminModelsController_getPermittedModels",
+        "operationId": "SuperAdminPermittedModelsController_getPermittedModels",
         "parameters": [
           {
             "name": "orgId",
@@ -583,14 +617,18 @@
           "401": {
             "description": "User not authenticated or not authorized as super admin"
           },
-          "500": { "description": "Internal server error" }
+          "500": {
+            "description": "Internal server error"
+          }
         },
         "summary": "Get all permitted models for a specific organization",
-        "tags": ["Super Admin Models"]
+        "tags": [
+          "Super Admin Models"
+        ]
       },
       "post": {
         "description": "Create a new permitted model for the specified organization. This endpoint is only accessible to super admins.",
-        "operationId": "SuperAdminModelsController_createPermittedModel",
+        "operationId": "SuperAdminPermittedModelsController_createPermittedModel",
         "parameters": [
           {
             "name": "orgId",
@@ -615,24 +653,32 @@
           }
         },
         "responses": {
-          "201": { "description": "Successfully created permitted model" },
-          "400": { "description": "Invalid model data provided" },
+          "201": {
+            "description": "Successfully created permitted model"
+          },
+          "400": {
+            "description": "Invalid model data provided"
+          },
           "401": {
             "description": "User not authenticated or not authorized as super admin"
           },
           "409": {
             "description": "Model already permitted for this organization"
           },
-          "500": { "description": "Internal server error" }
+          "500": {
+            "description": "Internal server error"
+          }
         },
         "summary": "Create a permitted model for a specific organization",
-        "tags": ["Super Admin Models"]
+        "tags": [
+          "Super Admin Models"
+        ]
       }
     },
     "/super-admin/models/{orgId}/permitted-models/{id}": {
       "delete": {
         "description": "Delete a permitted model for the specified organization. This endpoint is only accessible to super admins.",
-        "operationId": "SuperAdminModelsController_deletePermittedModel",
+        "operationId": "SuperAdminPermittedModelsController_deletePermittedModel",
         "parameters": [
           {
             "name": "orgId",
@@ -658,22 +704,30 @@
           }
         ],
         "responses": {
-          "204": { "description": "Successfully deleted permitted model" },
+          "204": {
+            "description": "Successfully deleted permitted model"
+          },
           "400": {
             "description": "Cannot delete the last permitted language model or default model"
           },
           "401": {
             "description": "User not authenticated or not authorized as super admin"
           },
-          "404": { "description": "Permitted model not found" },
-          "500": { "description": "Internal server error" }
+          "404": {
+            "description": "Permitted model not found"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
         },
         "summary": "Delete a permitted model for a specific organization",
-        "tags": ["Super Admin Models"]
+        "tags": [
+          "Super Admin Models"
+        ]
       },
       "patch": {
         "description": "Update the settings of a permitted model for the specified organization. This endpoint is only accessible to super admins.",
-        "operationId": "SuperAdminModelsController_updatePermittedModel",
+        "operationId": "SuperAdminPermittedModelsController_updatePermittedModel",
         "parameters": [
           {
             "name": "orgId",
@@ -726,21 +780,29 @@
               }
             }
           },
-          "400": { "description": "Invalid update data provided" },
+          "400": {
+            "description": "Invalid update data provided"
+          },
           "401": {
             "description": "User not authenticated or not authorized as super admin"
           },
-          "404": { "description": "Permitted model not found" },
-          "500": { "description": "Internal server error" }
+          "404": {
+            "description": "Permitted model not found"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
         },
         "summary": "Update a permitted model for a specific organization",
-        "tags": ["Super Admin Models"]
+        "tags": [
+          "Super Admin Models"
+        ]
       }
     },
     "/super-admin/models/catalog": {
       "get": {
         "description": "Retrieve all models (language and embedding) from the master catalog. This endpoint is only accessible to super admins.",
-        "operationId": "SuperAdminModelsController_getAllCatalogModels",
+        "operationId": "SuperAdminCatalogModelsController_getAllCatalogModels",
         "parameters": [],
         "responses": {
           "200": {
@@ -766,16 +828,106 @@
           "401": {
             "description": "User not authenticated or not authorized as super admin"
           },
-          "500": { "description": "Internal server error" }
+          "500": {
+            "description": "Internal server error"
+          }
         },
         "summary": "Get all models in the catalog",
-        "tags": ["Super Admin Models"]
+        "tags": [
+          "Super Admin Models"
+        ]
+      }
+    },
+    "/super-admin/models/catalog/{id}": {
+      "get": {
+        "description": "Retrieve a specific model from the master catalog by its ID. This endpoint is only accessible to super admins.",
+        "operationId": "SuperAdminCatalogModelsController_getCatalogModelById",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "description": "Model ID to retrieve",
+            "schema": {
+              "format": "uuid",
+              "example": "123e4567-e89b-12d3-a456-426614174000",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved model",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/LanguageModelResponseDto"
+                    },
+                    {
+                      "$ref": "#/components/schemas/EmbeddingModelResponseDto"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "User not authenticated or not authorized as super admin"
+          },
+          "404": {
+            "description": "Model not found"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "summary": "Get a model by ID from the catalog",
+        "tags": [
+          "Super Admin Models"
+        ]
+      },
+      "delete": {
+        "description": "Remove a model (language or embedding) from the master catalog. This endpoint is only accessible to super admins.",
+        "operationId": "SuperAdminCatalogModelsController_deleteCatalogModel",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "description": "Model ID to delete",
+            "schema": {
+              "format": "uuid",
+              "example": "123e4567-e89b-12d3-a456-426614174000",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successfully deleted model"
+          },
+          "401": {
+            "description": "User not authenticated or not authorized as super admin"
+          },
+          "404": {
+            "description": "Model not found"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "summary": "Delete a model from the catalog",
+        "tags": [
+          "Super Admin Models"
+        ]
       }
     },
     "/super-admin/models/catalog/language": {
       "post": {
         "description": "Create a new language model in the master catalog. This endpoint is only accessible to super admins.",
-        "operationId": "SuperAdminModelsController_createLanguageModel",
+        "operationId": "SuperAdminCatalogModelsController_createLanguageModel",
         "parameters": [],
         "requestBody": {
           "required": true,
@@ -798,21 +950,29 @@
               }
             }
           },
-          "400": { "description": "Invalid model data provided" },
+          "400": {
+            "description": "Invalid model data provided"
+          },
           "401": {
             "description": "User not authenticated or not authorized as super admin"
           },
-          "409": { "description": "Model already exists" },
-          "500": { "description": "Internal server error" }
+          "409": {
+            "description": "Model already exists"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
         },
         "summary": "Create a new language model in the catalog",
-        "tags": ["Super Admin Models"]
+        "tags": [
+          "Super Admin Models"
+        ]
       }
     },
     "/super-admin/models/catalog/language/{id}": {
       "patch": {
         "description": "Update an existing language model in the master catalog. This endpoint is only accessible to super admins.",
-        "operationId": "SuperAdminModelsController_updateLanguageModel",
+        "operationId": "SuperAdminCatalogModelsController_updateLanguageModel",
         "parameters": [
           {
             "name": "id",
@@ -847,21 +1007,29 @@
               }
             }
           },
-          "400": { "description": "Invalid model data provided" },
+          "400": {
+            "description": "Invalid model data provided"
+          },
           "401": {
             "description": "User not authenticated or not authorized as super admin"
           },
-          "404": { "description": "Model not found" },
-          "500": { "description": "Internal server error" }
+          "404": {
+            "description": "Model not found"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
         },
         "summary": "Update a language model in the catalog",
-        "tags": ["Super Admin Models"]
+        "tags": [
+          "Super Admin Models"
+        ]
       }
     },
     "/super-admin/models/catalog/embedding": {
       "post": {
         "description": "Create a new embedding model in the master catalog. This endpoint is only accessible to super admins.",
-        "operationId": "SuperAdminModelsController_createEmbeddingModel",
+        "operationId": "SuperAdminCatalogModelsController_createEmbeddingModel",
         "parameters": [],
         "requestBody": {
           "required": true,
@@ -884,21 +1052,29 @@
               }
             }
           },
-          "400": { "description": "Invalid model data provided" },
+          "400": {
+            "description": "Invalid model data provided"
+          },
           "401": {
             "description": "User not authenticated or not authorized as super admin"
           },
-          "409": { "description": "Model already exists" },
-          "500": { "description": "Internal server error" }
+          "409": {
+            "description": "Model already exists"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
         },
         "summary": "Create a new embedding model in the catalog",
-        "tags": ["Super Admin Models"]
+        "tags": [
+          "Super Admin Models"
+        ]
       }
     },
     "/super-admin/models/catalog/embedding/{id}": {
       "patch": {
         "description": "Update an existing embedding model in the master catalog. This endpoint is only accessible to super admins.",
-        "operationId": "SuperAdminModelsController_updateEmbeddingModel",
+        "operationId": "SuperAdminCatalogModelsController_updateEmbeddingModel",
         "parameters": [
           {
             "name": "id",
@@ -933,15 +1109,23 @@
               }
             }
           },
-          "400": { "description": "Invalid model data provided" },
+          "400": {
+            "description": "Invalid model data provided"
+          },
           "401": {
             "description": "User not authenticated or not authorized as super admin"
           },
-          "404": { "description": "Model not found" },
-          "500": { "description": "Internal server error" }
+          "404": {
+            "description": "Model not found"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
         },
         "summary": "Update an embedding model in the catalog",
-        "tags": ["Super Admin Models"]
+        "tags": [
+          "Super Admin Models"
+        ]
       }
     },
     "/super-admin/orgs": {
@@ -954,7 +1138,9 @@
           "description": "Organization information",
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/CreateOrgRequestDto" }
+              "schema": {
+                "$ref": "#/components/schemas/CreateOrgRequestDto"
+              }
             }
           }
         },
@@ -972,10 +1158,14 @@
           "400": {
             "description": "Invalid request format or validation errors."
           },
-          "403": { "description": "The requester is not a super admin." }
+          "403": {
+            "description": "The requester is not a super admin."
+          }
         },
         "summary": "Create a new organization",
-        "tags": ["Super Admin Orgs"]
+        "tags": [
+          "Super Admin Orgs"
+        ]
       },
       "get": {
         "description": "Retrieve paginated organizations in the system. Only accessible to users with the super admin system role.",
@@ -986,21 +1176,32 @@
             "required": false,
             "in": "query",
             "description": "Search organizations by name.",
-            "schema": { "example": "Acme", "type": "string" }
+            "schema": {
+              "example": "Acme",
+              "type": "string"
+            }
           },
           {
             "name": "limit",
             "required": false,
             "in": "query",
             "description": "Maximum number of organizations to return (default: 50).",
-            "schema": { "default": 50, "example": 25, "type": "number" }
+            "schema": {
+              "default": 50,
+              "example": 25,
+              "type": "number"
+            }
           },
           {
             "name": "offset",
             "required": false,
             "in": "query",
             "description": "Number of organizations to skip (default: 0).",
-            "schema": { "default": 0, "example": 0, "type": "number" }
+            "schema": {
+              "default": 0,
+              "example": 0,
+              "type": "number"
+            }
           }
         ],
         "responses": {
@@ -1014,10 +1215,14 @@
               }
             }
           },
-          "403": { "description": "The requester is not a super admin." }
+          "403": {
+            "description": "The requester is not a super admin."
+          }
         },
         "summary": "List all organizations",
-        "tags": ["Super Admin Orgs"]
+        "tags": [
+          "Super Admin Orgs"
+        ]
       }
     },
     "/super-admin/orgs/{id}": {
@@ -1030,7 +1235,9 @@
             "required": true,
             "in": "path",
             "description": "The ID of the organization to retrieve.",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -1044,10 +1251,14 @@
               }
             }
           },
-          "403": { "description": "The requester is not a super admin." }
+          "403": {
+            "description": "The requester is not a super admin."
+          }
         },
         "summary": "Get an organization by ID",
-        "tags": ["Super Admin Orgs"]
+        "tags": [
+          "Super Admin Orgs"
+        ]
       }
     },
     "/users": {
@@ -1060,21 +1271,32 @@
             "required": false,
             "in": "query",
             "description": "Search users by name or email",
-            "schema": { "example": "john", "type": "string" }
+            "schema": {
+              "example": "john",
+              "type": "string"
+            }
           },
           {
             "name": "limit",
             "required": false,
             "in": "query",
             "description": "Maximum number of users to return (default: 25)",
-            "schema": { "default": 25, "example": 25, "type": "number" }
+            "schema": {
+              "default": 25,
+              "example": 25,
+              "type": "number"
+            }
           },
           {
             "name": "offset",
             "required": false,
             "in": "query",
             "description": "Number of users to skip (default: 0)",
-            "schema": { "default": 0, "example": 0, "type": "number" }
+            "schema": {
+              "default": 0,
+              "example": 0,
+              "type": "number"
+            }
           }
         ],
         "responses": {
@@ -1088,13 +1310,17 @@
               }
             }
           },
-          "401": { "description": "User not authenticated" },
+          "401": {
+            "description": "User not authenticated"
+          },
           "500": {
             "description": "Internal server error occurred while retrieving users"
           }
         },
         "summary": "Get users in current organization",
-        "tags": ["Users"]
+        "tags": [
+          "Users"
+        ]
       }
     },
     "/users/{id}/role": {
@@ -1119,7 +1345,9 @@
           "description": "New role information",
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/UpdateUserRoleDto" }
+              "schema": {
+                "$ref": "#/components/schemas/UpdateUserRoleDto"
+              }
             }
           }
         },
@@ -1128,21 +1356,29 @@
             "description": "User role successfully updated",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/UserResponseDto" }
+                "schema": {
+                  "$ref": "#/components/schemas/UserResponseDto"
+                }
               }
             }
           },
-          "400": { "description": "Invalid role value" },
+          "400": {
+            "description": "Invalid role value"
+          },
           "401": {
             "description": "User not authenticated or trying to update own role"
           },
-          "404": { "description": "User not found" },
+          "404": {
+            "description": "User not found"
+          },
           "500": {
             "description": "Internal server error occurred while updating user role"
           }
         },
         "summary": "Update user role",
-        "tags": ["Users"]
+        "tags": [
+          "Users"
+        ]
       }
     },
     "/users/name": {
@@ -1155,7 +1391,9 @@
           "description": "New name information",
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/UpdateUserNameDto" }
+              "schema": {
+                "$ref": "#/components/schemas/UpdateUserNameDto"
+              }
             }
           }
         },
@@ -1164,21 +1402,29 @@
             "description": "User name successfully updated",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/UserResponseDto" }
+                "schema": {
+                  "$ref": "#/components/schemas/UserResponseDto"
+                }
               }
             }
           },
-          "400": { "description": "Invalid name value" },
+          "400": {
+            "description": "Invalid name value"
+          },
           "401": {
             "description": "User not authenticated or not authorized to update this user"
           },
-          "404": { "description": "User not found" },
+          "404": {
+            "description": "User not found"
+          },
           "500": {
             "description": "Internal server error occurred while updating user name"
           }
         },
         "summary": "Update user name",
-        "tags": ["Users"]
+        "tags": [
+          "Users"
+        ]
       }
     },
     "/users/password": {
@@ -1191,12 +1437,16 @@
           "description": "Password update information",
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/UpdatePasswordDto" }
+              "schema": {
+                "$ref": "#/components/schemas/UpdatePasswordDto"
+              }
             }
           }
         },
         "responses": {
-          "204": { "description": "Password successfully updated" },
+          "204": {
+            "description": "Password successfully updated"
+          },
           "400": {
             "description": "Invalid password values or passwords do not match"
           },
@@ -1208,7 +1458,9 @@
           }
         },
         "summary": "Update user password",
-        "tags": ["Users"]
+        "tags": [
+          "Users"
+        ]
       }
     },
     "/users/confirm-email": {
@@ -1221,20 +1473,30 @@
           "description": "Email confirmation token",
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/ConfirmEmailDto" }
+              "schema": {
+                "$ref": "#/components/schemas/ConfirmEmailDto"
+              }
             }
           }
         },
         "responses": {
-          "204": { "description": "Email successfully confirmed" },
-          "400": { "description": "Invalid token or token has expired" },
-          "404": { "description": "User not found" },
+          "204": {
+            "description": "Email successfully confirmed"
+          },
+          "400": {
+            "description": "Invalid token or token has expired"
+          },
+          "404": {
+            "description": "User not found"
+          },
           "500": {
             "description": "Internal server error occurred while confirming email"
           }
         },
         "summary": "Confirm user email",
-        "tags": ["Users"]
+        "tags": [
+          "Users"
+        ]
       }
     },
     "/users/resend-confirmation": {
@@ -1257,13 +1519,17 @@
           "204": {
             "description": "Confirmation email resent (or silently handled)"
           },
-          "400": { "description": "Invalid email format" },
+          "400": {
+            "description": "Invalid email format"
+          },
           "500": {
             "description": "Internal server error occurred while sending email"
           }
         },
         "summary": "Resend email confirmation",
-        "tags": ["Users"]
+        "tags": [
+          "Users"
+        ]
       }
     },
     "/users/{id}": {
@@ -1284,15 +1550,23 @@
           }
         ],
         "responses": {
-          "204": { "description": "User successfully deleted" },
-          "401": { "description": "User not authenticated" },
-          "404": { "description": "User not found" },
+          "204": {
+            "description": "User successfully deleted"
+          },
+          "401": {
+            "description": "User not authenticated"
+          },
+          "404": {
+            "description": "User not found"
+          },
           "500": {
             "description": "Internal server error occurred while deleting user"
           }
         },
         "summary": "Delete a user",
-        "tags": ["Users"]
+        "tags": [
+          "Users"
+        ]
       }
     },
     "/users/{id}/trigger-password-reset": {
@@ -1305,18 +1579,27 @@
             "required": true,
             "in": "path",
             "description": "User ID to send password reset email to",
-            "schema": { "format": "uuid", "type": "string" }
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
         "responses": {
-          "204": { "description": "Password reset email sent successfully" },
+          "204": {
+            "description": "Password reset email sent successfully"
+          },
           "401": {
             "description": "Not authorized to reset this user's password"
           },
-          "404": { "description": "User not found" }
+          "404": {
+            "description": "User not found"
+          }
         },
         "summary": "Trigger password reset for a user",
-        "tags": ["Users"]
+        "tags": [
+          "Users"
+        ]
       }
     },
     "/users/forgot-password": {
@@ -1329,7 +1612,9 @@
           "description": "Email address to send reset link to",
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/ForgotPasswordDto" }
+              "schema": {
+                "$ref": "#/components/schemas/ForgotPasswordDto"
+              }
             }
           }
         },
@@ -1345,7 +1630,9 @@
           }
         },
         "summary": "Trigger password reset",
-        "tags": ["Users"]
+        "tags": [
+          "Users"
+        ]
       }
     },
     "/users/reset-password": {
@@ -1358,22 +1645,30 @@
           "description": "Password reset information including token and new password",
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/ResetPasswordDto" }
+              "schema": {
+                "$ref": "#/components/schemas/ResetPasswordDto"
+              }
             }
           }
         },
         "responses": {
-          "204": { "description": "Password reset successful." },
+          "204": {
+            "description": "Password reset successful."
+          },
           "400": {
             "description": "Invalid request format, validation errors, or password requirements not met"
           },
-          "401": { "description": "Invalid or expired reset token" },
+          "401": {
+            "description": "Invalid or expired reset token"
+          },
           "500": {
             "description": "Internal server error while processing the request"
           }
         },
         "summary": "Reset password with token",
-        "tags": ["Users"]
+        "tags": [
+          "Users"
+        ]
       }
     },
     "/users/validate-reset-token": {
@@ -1400,19 +1695,26 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "valid": { "type": "boolean", "example": true }
+                    "valid": {
+                      "type": "boolean",
+                      "example": true
+                    }
                   }
                 }
               }
             }
           },
-          "401": { "description": "Invalid or expired reset token" },
+          "401": {
+            "description": "Invalid or expired reset token"
+          },
           "500": {
             "description": "Internal server error while processing the request"
           }
         },
         "summary": "Validate password reset token",
-        "tags": ["Users"]
+        "tags": [
+          "Users"
+        ]
       }
     },
     "/super-admin/users/{orgId}": {
@@ -1436,21 +1738,32 @@
             "required": false,
             "in": "query",
             "description": "Search users by name or email",
-            "schema": { "example": "john", "type": "string" }
+            "schema": {
+              "example": "john",
+              "type": "string"
+            }
           },
           {
             "name": "limit",
             "required": false,
             "in": "query",
             "description": "Maximum number of users to return (default: 25)",
-            "schema": { "default": 25, "example": 25, "type": "number" }
+            "schema": {
+              "default": 25,
+              "example": 25,
+              "type": "number"
+            }
           },
           {
             "name": "offset",
             "required": false,
             "in": "query",
             "description": "Number of users to skip (default: 0)",
-            "schema": { "default": 0, "example": 0, "type": "number" }
+            "schema": {
+              "default": 0,
+              "example": 0,
+              "type": "number"
+            }
           }
         ],
         "responses": {
@@ -1467,13 +1780,17 @@
           "401": {
             "description": "User not authenticated or not authorized as super admin"
           },
-          "404": { "description": "Organization not found" },
+          "404": {
+            "description": "Organization not found"
+          },
           "500": {
             "description": "Internal server error occurred while retrieving users"
           }
         },
         "summary": "Get users by organization ID",
-        "tags": ["Super Admin Users"]
+        "tags": [
+          "Super Admin Users"
+        ]
       }
     },
     "/super-admin/users/{userId}": {
@@ -1494,17 +1811,23 @@
           }
         ],
         "responses": {
-          "204": { "description": "User successfully deleted" },
+          "204": {
+            "description": "User successfully deleted"
+          },
           "401": {
             "description": "User not authenticated or not authorized as super admin"
           },
-          "404": { "description": "User not found" },
+          "404": {
+            "description": "User not found"
+          },
           "500": {
             "description": "Internal server error occurred while deleting user"
           }
         },
         "summary": "Delete a user",
-        "tags": ["Super Admin Users"]
+        "tags": [
+          "Super Admin Users"
+        ]
       }
     },
     "/super-admin/users/{userId}/trigger-password-reset": {
@@ -1525,17 +1848,23 @@
           }
         ],
         "responses": {
-          "204": { "description": "Password reset email sent successfully" },
+          "204": {
+            "description": "Password reset email sent successfully"
+          },
           "401": {
             "description": "User not authenticated or not authorized as super admin"
           },
-          "404": { "description": "User not found" },
+          "404": {
+            "description": "User not found"
+          },
           "500": {
             "description": "Internal server error occurred while sending password reset email"
           }
         },
         "summary": "Trigger password reset for a user",
-        "tags": ["Super Admin Users"]
+        "tags": [
+          "Super Admin Users"
+        ]
       }
     },
     "/super-admin/users/{orgId}/create": {
@@ -1560,7 +1889,9 @@
           "description": "User information",
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/CreateUserDto" }
+              "schema": {
+                "$ref": "#/components/schemas/CreateUserDto"
+              }
             }
           }
         },
@@ -1569,7 +1900,9 @@
             "description": "User created successfully",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/UserResponseDto" }
+                "schema": {
+                  "$ref": "#/components/schemas/UserResponseDto"
+                }
               }
             }
           },
@@ -1579,13 +1912,17 @@
           "401": {
             "description": "User not authenticated or not authorized as super admin"
           },
-          "404": { "description": "Organization not found" },
+          "404": {
+            "description": "Organization not found"
+          },
           "500": {
             "description": "Internal server error occurred while creating user"
           }
         },
         "summary": "Create a new user in an organization",
-        "tags": ["Super Admin Users"]
+        "tags": [
+          "Super Admin Users"
+        ]
       }
     },
     "/super-admin/super-admins": {
@@ -1612,7 +1949,9 @@
           }
         },
         "summary": "List all super admins",
-        "tags": ["Super Admin Management"]
+        "tags": [
+          "Super Admin Management"
+        ]
       },
       "post": {
         "description": "Promote an existing user to super admin by email address. Idempotent if user is already a super admin.",
@@ -1643,10 +1982,14 @@
           "401": {
             "description": "User not authenticated or not authorized as super admin"
           },
-          "404": { "description": "User with the given email not found" }
+          "404": {
+            "description": "User with the given email not found"
+          }
         },
         "summary": "Promote a user to super admin",
-        "tags": ["Super Admin Management"]
+        "tags": [
+          "Super Admin Management"
+        ]
       }
     },
     "/super-admin/super-admins/{userId}": {
@@ -1667,17 +2010,29 @@
           }
         ],
         "responses": {
-          "204": { "description": "Super admin status removed" },
+          "204": {
+            "description": "Super admin status removed"
+          },
           "401": {
             "description": "User not authenticated or not authorized as super admin"
           },
-          "403": { "description": "Cannot remove your own super admin status" },
-          "404": { "description": "User not found" },
-          "409": { "description": "Cannot demote the last super admin" },
-          "422": { "description": "User is not a super admin" }
+          "403": {
+            "description": "Cannot remove your own super admin status"
+          },
+          "404": {
+            "description": "User not found"
+          },
+          "409": {
+            "description": "Cannot demote the last super admin"
+          },
+          "422": {
+            "description": "User is not a super admin"
+          }
         },
         "summary": "Remove super admin status from a user",
-        "tags": ["Super Admin Management"]
+        "tags": [
+          "Super Admin Management"
+        ]
       }
     },
     "/invites": {
@@ -1689,7 +2044,9 @@
           "required": true,
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/CreateInviteDto" }
+              "schema": {
+                "$ref": "#/components/schemas/CreateInviteDto"
+              }
             }
           }
         },
@@ -1704,11 +2061,17 @@
               }
             }
           },
-          "400": { "description": "Invalid invite data" },
-          "500": { "description": "Internal server error" }
+          "400": {
+            "description": "Invalid invite data"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
         },
         "summary": "Create a new invite",
-        "tags": ["invites"]
+        "tags": [
+          "invites"
+        ]
       },
       "get": {
         "description": "Retrieve paginated invites with optional search",
@@ -1719,21 +2082,32 @@
             "required": false,
             "in": "query",
             "description": "Search invites by email",
-            "schema": { "example": "john@example.com", "type": "string" }
+            "schema": {
+              "example": "john@example.com",
+              "type": "string"
+            }
           },
           {
             "name": "limit",
             "required": false,
             "in": "query",
             "description": "Maximum number of invites to return (default: 25)",
-            "schema": { "default": 25, "example": 25, "type": "number" }
+            "schema": {
+              "default": 25,
+              "example": 25,
+              "type": "number"
+            }
           },
           {
             "name": "offset",
             "required": false,
             "in": "query",
             "description": "Number of invites to skip (default: 0)",
-            "schema": { "default": 0, "example": 0, "type": "number" }
+            "schema": {
+              "default": 0,
+              "example": 0,
+              "type": "number"
+            }
           }
         ],
         "responses": {
@@ -1747,10 +2121,14 @@
               }
             }
           },
-          "500": { "description": "Internal server error" }
+          "500": {
+            "description": "Internal server error"
+          }
         },
         "summary": "Get all invites for current user's organization",
-        "tags": ["invites"]
+        "tags": [
+          "invites"
+        ]
       }
     },
     "/invites/bulk": {
@@ -1762,7 +2140,9 @@
           "required": true,
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/CreateBulkInvitesDto" }
+              "schema": {
+                "$ref": "#/components/schemas/CreateBulkInvitesDto"
+              }
             }
           }
         },
@@ -1777,11 +2157,17 @@
               }
             }
           },
-          "400": { "description": "Validation failed for one or more invites" },
-          "500": { "description": "Internal server error" }
+          "400": {
+            "description": "Validation failed for one or more invites"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
         },
         "summary": "Create multiple invites in bulk",
-        "tags": ["invites"]
+        "tags": [
+          "invites"
+        ]
       }
     },
     "/invites/{token}": {
@@ -1794,7 +2180,10 @@
             "required": true,
             "in": "path",
             "description": "Token of the invited user",
-            "schema": { "example": "1234567890", "type": "string" }
+            "schema": {
+              "example": "1234567890",
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -1808,11 +2197,17 @@
               }
             }
           },
-          "404": { "description": "Invite not found" },
-          "500": { "description": "Internal server error" }
+          "404": {
+            "description": "Invite not found"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
         },
         "summary": "Get a single invite by token",
-        "tags": ["invites"]
+        "tags": [
+          "invites"
+        ]
       }
     },
     "/invites/accept": {
@@ -1824,7 +2219,9 @@
           "required": true,
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/AcceptInviteDto" }
+              "schema": {
+                "$ref": "#/components/schemas/AcceptInviteDto"
+              }
             }
           }
         },
@@ -1842,11 +2239,17 @@
           "400": {
             "description": "Invalid invite token or invite already accepted/expired"
           },
-          "404": { "description": "Invite not found" },
-          "500": { "description": "Internal server error" }
+          "404": {
+            "description": "Invite not found"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
         },
         "summary": "Accept an invite",
-        "tags": ["invites"]
+        "tags": [
+          "invites"
+        ]
       }
     },
     "/invites/{id}/resend": {
@@ -1859,7 +2262,10 @@
             "required": true,
             "in": "path",
             "description": "The UUID of the expired invite to resend",
-            "schema": { "format": "uuid", "type": "string" }
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -1876,11 +2282,17 @@
           "400": {
             "description": "Invite has not expired yet or invalid data"
           },
-          "404": { "description": "Invite not found" },
-          "500": { "description": "Internal server error" }
+          "404": {
+            "description": "Invite not found"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
         },
         "summary": "Resend an expired invite",
-        "tags": ["invites"]
+        "tags": [
+          "invites"
+        ]
       }
     },
     "/invites/all": {
@@ -1899,11 +2311,17 @@
               }
             }
           },
-          "403": { "description": "Unauthorized - Admin role required" },
-          "500": { "description": "Internal server error" }
+          "403": {
+            "description": "Unauthorized - Admin role required"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
         },
         "summary": "Delete all pending invites",
-        "tags": ["invites"]
+        "tags": [
+          "invites"
+        ]
       }
     },
     "/invites/{id}": {
@@ -1916,17 +2334,30 @@
             "required": true,
             "in": "path",
             "description": "The UUID of the invite to delete",
-            "schema": { "format": "uuid", "type": "string" }
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
         "responses": {
-          "204": { "description": "The invite has been successfully deleted" },
-          "403": { "description": "Unauthorized to delete this invite" },
-          "404": { "description": "Invite not found" },
-          "500": { "description": "Internal server error" }
+          "204": {
+            "description": "The invite has been successfully deleted"
+          },
+          "403": {
+            "description": "Unauthorized to delete this invite"
+          },
+          "404": {
+            "description": "Invite not found"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
         },
         "summary": "Delete an invite",
-        "tags": ["invites"]
+        "tags": [
+          "invites"
+        ]
       }
     },
     "/subscriptions/active": {
@@ -1944,10 +2375,14 @@
               }
             }
           },
-          "500": { "description": "Internal server error" }
+          "500": {
+            "description": "Internal server error"
+          }
         },
         "summary": "Check if the current organization has an active subscription",
-        "tags": ["subscriptions"]
+        "tags": [
+          "subscriptions"
+        ]
       }
     },
     "/subscriptions/price": {
@@ -1959,15 +2394,23 @@
             "description": "Successfully retrieved current price",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/PriceResponseDto" }
+                "schema": {
+                  "$ref": "#/components/schemas/PriceResponseDto"
+                }
               }
             }
           },
-          "404": { "description": "Price not configured" },
-          "500": { "description": "Internal server error" }
+          "404": {
+            "description": "Price not configured"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
         },
         "summary": "Get the current price per seat monthly",
-        "tags": ["subscriptions"]
+        "tags": [
+          "subscriptions"
+        ]
       }
     },
     "/super-admin/subscriptions/{orgId}": {
@@ -2001,10 +2444,14 @@
           "401": {
             "description": "User not authenticated or not authorized as super admin"
           },
-          "500": { "description": "Internal server error" }
+          "500": {
+            "description": "Internal server error"
+          }
         },
         "summary": "Get subscription details for a specific organization",
-        "tags": ["Super Admin Subscriptions"]
+        "tags": [
+          "Super Admin Subscriptions"
+        ]
       },
       "post": {
         "description": "Create a new subscription for the specified organization. This endpoint is only accessible to super admins.",
@@ -2043,17 +2490,23 @@
               }
             }
           },
-          "400": { "description": "Invalid subscription data provided" },
+          "400": {
+            "description": "Invalid subscription data provided"
+          },
           "401": {
             "description": "User not authenticated or not authorized as super admin"
           },
           "409": {
             "description": "Subscription already exists for this organization"
           },
-          "500": { "description": "Internal server error" }
+          "500": {
+            "description": "Internal server error"
+          }
         },
         "summary": "Create a new subscription for a specific organization",
-        "tags": ["Super Admin Subscriptions"]
+        "tags": [
+          "Super Admin Subscriptions"
+        ]
       },
       "delete": {
         "description": "Cancel the subscription for the specified organization. This endpoint is only accessible to super admins.",
@@ -2072,18 +2525,26 @@
           }
         ],
         "responses": {
-          "204": { "description": "Successfully cancelled subscription" },
+          "204": {
+            "description": "Successfully cancelled subscription"
+          },
           "401": {
             "description": "User not authenticated or not authorized as super admin"
           },
           "404": {
             "description": "No subscription found for the organization"
           },
-          "409": { "description": "Subscription is already cancelled" },
-          "500": { "description": "Internal server error" }
+          "409": {
+            "description": "Subscription is already cancelled"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
         },
         "summary": "Cancel the subscription for a specific organization",
-        "tags": ["Super Admin Subscriptions"]
+        "tags": [
+          "Super Admin Subscriptions"
+        ]
       }
     },
     "/super-admin/subscriptions/{orgId}/seats": {
@@ -2107,23 +2568,33 @@
           "required": true,
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/UpdateSeatsDto" }
+              "schema": {
+                "$ref": "#/components/schemas/UpdateSeatsDto"
+              }
             }
           }
         },
         "responses": {
-          "204": { "description": "Successfully updated seats" },
-          "400": { "description": "Invalid seat update data provided" },
+          "204": {
+            "description": "Successfully updated seats"
+          },
+          "400": {
+            "description": "Invalid seat update data provided"
+          },
           "401": {
             "description": "User not authenticated or not authorized as super admin"
           },
           "404": {
             "description": "No subscription found for the organization"
           },
-          "500": { "description": "Internal server error" }
+          "500": {
+            "description": "Internal server error"
+          }
         },
         "summary": "Update the number of seats for a specific organization",
-        "tags": ["Super Admin Subscriptions"]
+        "tags": [
+          "Super Admin Subscriptions"
+        ]
       }
     },
     "/super-admin/subscriptions/{orgId}/billing-info": {
@@ -2147,23 +2618,33 @@
           "required": true,
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/UpdateBillingInfoDto" }
+              "schema": {
+                "$ref": "#/components/schemas/UpdateBillingInfoDto"
+              }
             }
           }
         },
         "responses": {
-          "204": { "description": "Successfully updated billing information" },
-          "400": { "description": "Invalid billing information provided" },
+          "204": {
+            "description": "Successfully updated billing information"
+          },
+          "400": {
+            "description": "Invalid billing information provided"
+          },
           "401": {
             "description": "User not authenticated or not authorized as super admin"
           },
           "404": {
             "description": "No subscription found for the organization"
           },
-          "500": { "description": "Internal server error" }
+          "500": {
+            "description": "Internal server error"
+          }
         },
         "summary": "Update the billing information for a specific organization",
-        "tags": ["Super Admin Subscriptions"]
+        "tags": [
+          "Super Admin Subscriptions"
+        ]
       }
     },
     "/super-admin/subscriptions/{orgId}/uncancel": {
@@ -2184,18 +2665,26 @@
           }
         ],
         "responses": {
-          "204": { "description": "Successfully uncancelled subscription" },
+          "204": {
+            "description": "Successfully uncancelled subscription"
+          },
           "401": {
             "description": "User not authenticated or not authorized as super admin"
           },
           "404": {
             "description": "No subscription found for the organization"
           },
-          "409": { "description": "Subscription is not cancelled" },
-          "500": { "description": "Internal server error" }
+          "409": {
+            "description": "Subscription is not cancelled"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
         },
         "summary": "Uncancel the subscription for a specific organization",
-        "tags": ["Super Admin Subscriptions"]
+        "tags": [
+          "Super Admin Subscriptions"
+        ]
       }
     },
     "/storage/upload": {
@@ -2209,7 +2698,9 @@
             "multipart/form-data": {
               "schema": {
                 "type": "object",
-                "required": ["file"],
+                "required": [
+                  "file"
+                ],
                 "properties": {
                   "file": {
                     "type": "string",
@@ -2232,10 +2723,14 @@
               }
             }
           },
-          "400": { "description": "No file provided or invalid request" }
+          "400": {
+            "description": "No file provided or invalid request"
+          }
         },
         "summary": "Upload a file to object storage",
-        "tags": ["storage"]
+        "tags": [
+          "storage"
+        ]
       }
     },
     "/storage/{objectName}": {
@@ -2247,11 +2742,19 @@
             "required": true,
             "in": "path",
             "description": "Name of the object to retrieve",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           }
         ],
-        "responses": { "200": { "description": "" } },
-        "tags": ["storage"]
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "tags": [
+          "storage"
+        ]
       },
       "delete": {
         "operationId": "StorageController_deleteFile",
@@ -2261,11 +2764,19 @@
             "required": true,
             "in": "path",
             "description": "Name of the object to delete",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           }
         ],
-        "responses": { "200": { "description": "" } },
-        "tags": ["storage"]
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "tags": [
+          "storage"
+        ]
       }
     },
     "/storage/url/{objectName}": {
@@ -2277,11 +2788,19 @@
             "required": true,
             "in": "path",
             "description": "Name of the object to get URL for",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           }
         ],
-        "responses": { "200": { "description": "" } },
-        "tags": ["storage"]
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "tags": [
+          "storage"
+        ]
       }
     },
     "/retrievers/url": {
@@ -2292,7 +2811,9 @@
           "required": true,
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/RetrieveUrlDto" }
+              "schema": {
+                "$ref": "#/components/schemas/RetrieveUrlDto"
+              }
             }
           }
         },
@@ -2302,7 +2823,9 @@
           }
         },
         "summary": "Retrieve content from a URL",
-        "tags": ["retrievers"]
+        "tags": [
+          "retrievers"
+        ]
       }
     },
     "/threads": {
@@ -2313,7 +2836,9 @@
           "required": true,
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/CreateThreadDto" }
+              "schema": {
+                "$ref": "#/components/schemas/CreateThreadDto"
+              }
             }
           }
         },
@@ -2328,11 +2853,17 @@
               }
             }
           },
-          "400": { "description": "Invalid model data" },
-          "500": { "description": "Internal server error" }
+          "400": {
+            "description": "Invalid model data"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
         },
         "summary": "Create a new thread",
-        "tags": ["threads"]
+        "tags": [
+          "threads"
+        ]
       },
       "get": {
         "operationId": "ThreadsController_findAll",
@@ -2342,28 +2873,37 @@
             "required": false,
             "in": "query",
             "description": "Search threads by title",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "agentId",
             "required": false,
             "in": "query",
             "description": "Filter threads by agent ID",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "limit",
             "required": false,
             "in": "query",
             "description": "Maximum number of threads to return (default: 50)",
-            "schema": { "type": "number" }
+            "schema": {
+              "type": "number"
+            }
           },
           {
             "name": "offset",
             "required": false,
             "in": "query",
             "description": "Number of threads to skip (default: 0)",
-            "schema": { "default": 0, "type": "number" }
+            "schema": {
+              "default": 0,
+              "type": "number"
+            }
           }
         ],
         "responses": {
@@ -2377,10 +2917,14 @@
               }
             }
           },
-          "500": { "description": "Internal server error" }
+          "500": {
+            "description": "Internal server error"
+          }
         },
         "summary": "Get all threads for the current user",
-        "tags": ["threads"]
+        "tags": [
+          "threads"
+        ]
       }
     },
     "/threads/{id}": {
@@ -2392,7 +2936,10 @@
             "required": true,
             "in": "path",
             "description": "The UUID of the thread to retrieve",
-            "schema": { "format": "uuid", "type": "string" }
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -2406,11 +2953,17 @@
               }
             }
           },
-          "404": { "description": "Thread not found" },
-          "500": { "description": "Internal server error" }
+          "404": {
+            "description": "Thread not found"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
         },
         "summary": "Get a thread by ID",
-        "tags": ["threads"]
+        "tags": [
+          "threads"
+        ]
       },
       "delete": {
         "operationId": "ThreadsController_delete",
@@ -2420,16 +2973,27 @@
             "required": true,
             "in": "path",
             "description": "The UUID of the thread to delete",
-            "schema": { "format": "uuid", "type": "string" }
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
         "responses": {
-          "204": { "description": "The thread has been successfully deleted" },
-          "404": { "description": "Thread not found" },
-          "500": { "description": "Internal server error" }
+          "204": {
+            "description": "The thread has been successfully deleted"
+          },
+          "404": {
+            "description": "Thread not found"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
         },
         "summary": "Delete a thread",
-        "tags": ["threads"]
+        "tags": [
+          "threads"
+        ]
       }
     },
     "/threads/{id}/title": {
@@ -2441,14 +3005,19 @@
             "required": true,
             "in": "path",
             "description": "The UUID of the thread to update",
-            "schema": { "format": "uuid", "type": "string" }
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/UpdateThreadTitleDto" }
+              "schema": {
+                "$ref": "#/components/schemas/UpdateThreadTitleDto"
+              }
             }
           }
         },
@@ -2456,12 +3025,20 @@
           "204": {
             "description": "The thread title has been successfully updated"
           },
-          "400": { "description": "Invalid title data" },
-          "404": { "description": "Thread not found" },
-          "500": { "description": "Internal server error" }
+          "400": {
+            "description": "Invalid title data"
+          },
+          "404": {
+            "description": "Thread not found"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
         },
         "summary": "Update a thread title",
-        "tags": ["threads"]
+        "tags": [
+          "threads"
+        ]
       }
     },
     "/threads/{id}/sources": {
@@ -2473,7 +3050,10 @@
             "required": true,
             "in": "path",
             "description": "The UUID of the thread",
-            "schema": { "format": "uuid", "type": "string" }
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -2485,8 +3065,12 @@
                   "type": "array",
                   "items": {
                     "oneOf": [
-                      { "$ref": "#/components/schemas/FileSourceResponseDto" },
-                      { "$ref": "#/components/schemas/UrlSourceResponseDto" },
+                      {
+                        "$ref": "#/components/schemas/FileSourceResponseDto"
+                      },
+                      {
+                        "$ref": "#/components/schemas/UrlSourceResponseDto"
+                      },
                       {
                         "$ref": "#/components/schemas/CSVDataSourceResponseDto"
                       }
@@ -2496,11 +3080,17 @@
               }
             }
           },
-          "404": { "description": "Thread not found" },
-          "500": { "description": "Internal server error" }
+          "404": {
+            "description": "Thread not found"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
         },
         "summary": "Get all sources for a thread",
-        "tags": ["threads"]
+        "tags": [
+          "threads"
+        ]
       }
     },
     "/threads/{id}/sources/file": {
@@ -2512,7 +3102,10 @@
             "required": true,
             "in": "path",
             "description": "The UUID of the thread",
-            "schema": { "format": "uuid", "type": "string" }
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
         "requestBody": {
@@ -2536,7 +3129,9 @@
                     "description": "A description of the file source"
                   }
                 },
-                "required": ["file"]
+                "required": [
+                  "file"
+                ]
               }
             }
           }
@@ -2547,7 +3142,9 @@
           }
         },
         "summary": "Add a file source to a thread",
-        "tags": ["threads"]
+        "tags": [
+          "threads"
+        ]
       }
     },
     "/threads/{id}/sources/{sourceId}": {
@@ -2559,24 +3156,34 @@
             "required": true,
             "in": "path",
             "description": "The UUID of the thread",
-            "schema": { "format": "uuid", "type": "string" }
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
           },
           {
             "name": "sourceId",
             "required": true,
             "in": "path",
             "description": "The UUID of the source to remove",
-            "schema": { "format": "uuid", "type": "string" }
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
         "responses": {
           "204": {
             "description": "The source has been successfully removed from the thread"
           },
-          "404": { "description": "Thread or source not found" }
+          "404": {
+            "description": "Thread or source not found"
+          }
         },
         "summary": "Remove a source from a thread",
-        "tags": ["threads"]
+        "tags": [
+          "threads"
+        ]
       }
     },
     "/threads/{id}/sources/{sourceId}/download": {
@@ -2588,28 +3195,45 @@
             "required": true,
             "in": "path",
             "description": "The UUID of the thread",
-            "schema": { "format": "uuid", "type": "string" }
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
           },
           {
             "name": "sourceId",
             "required": true,
             "in": "path",
             "description": "The UUID of the source to download",
-            "schema": { "format": "uuid", "type": "string" }
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
         "responses": {
           "200": {
             "description": "Returns the source as a CSV file",
             "content": {
-              "text/csv": { "schema": { "type": "string", "format": "binary" } }
+              "text/csv": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
             }
           },
-          "400": { "description": "Source is not a CSV data source" },
-          "404": { "description": "Thread or source not found" }
+          "400": {
+            "description": "Source is not a CSV data source"
+          },
+          "404": {
+            "description": "Thread or source not found"
+          }
         },
         "summary": "Download a data source as CSV",
-        "tags": ["threads"]
+        "tags": [
+          "threads"
+        ]
       }
     },
     "/threads/{id}/knowledge-bases/{knowledgeBaseId}": {
@@ -2621,24 +3245,34 @@
             "required": true,
             "in": "path",
             "description": "The UUID of the thread",
-            "schema": { "format": "uuid", "type": "string" }
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
           },
           {
             "name": "knowledgeBaseId",
             "required": true,
             "in": "path",
             "description": "The UUID of the knowledge base to add",
-            "schema": { "format": "uuid", "type": "string" }
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
         "responses": {
           "204": {
             "description": "The knowledge base has been successfully added to the thread"
           },
-          "404": { "description": "Thread or knowledge base not found" }
+          "404": {
+            "description": "Thread or knowledge base not found"
+          }
         },
         "summary": "Add a knowledge base to a thread",
-        "tags": ["threads"]
+        "tags": [
+          "threads"
+        ]
       },
       "delete": {
         "operationId": "ThreadKnowledgeBasesController_removeKnowledgeBase",
@@ -2648,24 +3282,34 @@
             "required": true,
             "in": "path",
             "description": "The UUID of the thread",
-            "schema": { "format": "uuid", "type": "string" }
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
           },
           {
             "name": "knowledgeBaseId",
             "required": true,
             "in": "path",
             "description": "The UUID of the knowledge base to remove",
-            "schema": { "format": "uuid", "type": "string" }
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
         "responses": {
           "204": {
             "description": "The knowledge base has been successfully removed from the thread"
           },
-          "404": { "description": "Thread not found" }
+          "404": {
+            "description": "Thread not found"
+          }
         },
         "summary": "Remove a knowledge base from a thread",
-        "tags": ["threads"]
+        "tags": [
+          "threads"
+        ]
       }
     },
     "/agents": {
@@ -2676,7 +3320,9 @@
           "required": true,
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/CreateAgentDto" }
+              "schema": {
+                "$ref": "#/components/schemas/CreateAgentDto"
+              }
             }
           }
         },
@@ -2685,15 +3331,23 @@
             "description": "The agent has been successfully created",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/AgentResponseDto" }
+                "schema": {
+                  "$ref": "#/components/schemas/AgentResponseDto"
+                }
               }
             }
           },
-          "400": { "description": "Invalid agent data" },
-          "500": { "description": "Internal server error" }
+          "400": {
+            "description": "Invalid agent data"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
         },
         "summary": "Create a new agent",
-        "tags": ["agents"]
+        "tags": [
+          "agents"
+        ]
       },
       "get": {
         "operationId": "AgentsController_findAll",
@@ -2705,15 +3359,21 @@
               "application/json": {
                 "schema": {
                   "type": "array",
-                  "items": { "$ref": "#/components/schemas/AgentResponseDto" }
+                  "items": {
+                    "$ref": "#/components/schemas/AgentResponseDto"
+                  }
                 }
               }
             }
           },
-          "500": { "description": "Internal server error" }
+          "500": {
+            "description": "Internal server error"
+          }
         },
         "summary": "Get all agents for the current user",
-        "tags": ["agents"]
+        "tags": [
+          "agents"
+        ]
       }
     },
     "/agents/{id}": {
@@ -2725,7 +3385,10 @@
             "required": true,
             "in": "path",
             "description": "The UUID of the agent to retrieve",
-            "schema": { "format": "uuid", "type": "string" }
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -2733,15 +3396,23 @@
             "description": "Returns the agent with the specified ID",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/AgentResponseDto" }
+                "schema": {
+                  "$ref": "#/components/schemas/AgentResponseDto"
+                }
               }
             }
           },
-          "404": { "description": "Agent not found" },
-          "500": { "description": "Internal server error" }
+          "404": {
+            "description": "Agent not found"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
         },
         "summary": "Get an agent by ID",
-        "tags": ["agents"]
+        "tags": [
+          "agents"
+        ]
       },
       "put": {
         "operationId": "AgentsController_update",
@@ -2751,14 +3422,19 @@
             "required": true,
             "in": "path",
             "description": "The UUID of the agent to update",
-            "schema": { "format": "uuid", "type": "string" }
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/UpdateAgentDto" }
+              "schema": {
+                "$ref": "#/components/schemas/UpdateAgentDto"
+              }
             }
           }
         },
@@ -2767,16 +3443,26 @@
             "description": "The agent has been successfully updated",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/AgentResponseDto" }
+                "schema": {
+                  "$ref": "#/components/schemas/AgentResponseDto"
+                }
               }
             }
           },
-          "400": { "description": "Invalid agent data" },
-          "404": { "description": "Agent not found" },
-          "500": { "description": "Internal server error" }
+          "400": {
+            "description": "Invalid agent data"
+          },
+          "404": {
+            "description": "Agent not found"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
         },
         "summary": "Update an agent",
-        "tags": ["agents"]
+        "tags": [
+          "agents"
+        ]
       },
       "delete": {
         "operationId": "AgentsController_delete",
@@ -2786,16 +3472,27 @@
             "required": true,
             "in": "path",
             "description": "The UUID of the agent to delete",
-            "schema": { "format": "uuid", "type": "string" }
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
         "responses": {
-          "204": { "description": "The agent has been successfully deleted" },
-          "404": { "description": "Agent not found" },
-          "500": { "description": "Internal server error" }
+          "204": {
+            "description": "The agent has been successfully deleted"
+          },
+          "404": {
+            "description": "Agent not found"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
         },
         "summary": "Delete an agent",
-        "tags": ["agents"]
+        "tags": [
+          "agents"
+        ]
       }
     },
     "/agents/{id}/sources": {
@@ -2807,7 +3504,10 @@
             "required": true,
             "in": "path",
             "description": "The UUID of the agent",
-            "schema": { "format": "uuid", "type": "string" }
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -2824,11 +3524,17 @@
               }
             }
           },
-          "404": { "description": "Agent not found" },
-          "500": { "description": "Internal server error" }
+          "404": {
+            "description": "Agent not found"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
         },
         "summary": "Get all sources for an agent",
-        "tags": ["agents"]
+        "tags": [
+          "agents"
+        ]
       }
     },
     "/agents/{id}/sources/file": {
@@ -2840,7 +3546,10 @@
             "required": true,
             "in": "path",
             "description": "The UUID of the agent",
-            "schema": { "format": "uuid", "type": "string" }
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
         "requestBody": {
@@ -2856,7 +3565,9 @@
                     "description": "The file to upload"
                   }
                 },
-                "required": ["file"]
+                "required": [
+                  "file"
+                ]
               }
             }
           }
@@ -2868,11 +3579,17 @@
           "400": {
             "description": "Invalid or unsupported file type. Supported types: PDF, DOCX, PPTX, TXT, CSV, XLSX, XLS"
           },
-          "404": { "description": "Agent not found" },
-          "500": { "description": "Internal server error" }
+          "404": {
+            "description": "Agent not found"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
         },
         "summary": "Add a file source to an agent",
-        "tags": ["agents"]
+        "tags": [
+          "agents"
+        ]
       }
     },
     "/agents/{id}/sources/{sourceAssignmentId}": {
@@ -2884,24 +3601,34 @@
             "required": true,
             "in": "path",
             "description": "The UUID of the agent",
-            "schema": { "format": "uuid", "type": "string" }
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
           },
           {
             "name": "sourceAssignmentId",
             "required": true,
             "in": "path",
             "description": "The UUID of the source assignment to remove",
-            "schema": { "format": "uuid", "type": "string" }
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
         "responses": {
           "204": {
             "description": "The source has been successfully removed from the agent"
           },
-          "404": { "description": "Agent or source assignment not found" }
+          "404": {
+            "description": "Agent or source assignment not found"
+          }
         },
         "summary": "Remove a source from an agent",
-        "tags": ["agents"]
+        "tags": [
+          "agents"
+        ]
       }
     },
     "/agents/{agentId}/mcp-integrations/{integrationId}": {
@@ -2913,14 +3640,20 @@
             "required": true,
             "in": "path",
             "description": "The UUID of the agent",
-            "schema": { "format": "uuid", "type": "string" }
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
           },
           {
             "name": "integrationId",
             "required": true,
             "in": "path",
             "description": "The UUID of the MCP integration to assign",
-            "schema": { "format": "uuid", "type": "string" }
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -2928,19 +3661,29 @@
             "description": "The MCP integration has been successfully assigned",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/AgentResponseDto" }
+                "schema": {
+                  "$ref": "#/components/schemas/AgentResponseDto"
+                }
               }
             }
           },
-          "400": { "description": "Integration disabled" },
+          "400": {
+            "description": "Integration disabled"
+          },
           "403": {
             "description": "Integration belongs to different organization"
           },
-          "404": { "description": "Agent or integration not found" },
-          "409": { "description": "Integration already assigned" }
+          "404": {
+            "description": "Agent or integration not found"
+          },
+          "409": {
+            "description": "Integration already assigned"
+          }
         },
         "summary": "Assign MCP integration to agent",
-        "tags": ["agents"]
+        "tags": [
+          "agents"
+        ]
       },
       "delete": {
         "operationId": "AgentMcpIntegrationsController_unassignMcpIntegration",
@@ -2950,14 +3693,20 @@
             "required": true,
             "in": "path",
             "description": "The UUID of the agent",
-            "schema": { "format": "uuid", "type": "string" }
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
           },
           {
             "name": "integrationId",
             "required": true,
             "in": "path",
             "description": "The UUID of the MCP integration to unassign",
-            "schema": { "format": "uuid", "type": "string" }
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -2965,7 +3714,9 @@
             "description": "The MCP integration has been successfully unassigned",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/AgentResponseDto" }
+                "schema": {
+                  "$ref": "#/components/schemas/AgentResponseDto"
+                }
               }
             }
           },
@@ -2974,7 +3725,9 @@
           }
         },
         "summary": "Unassign MCP integration from agent",
-        "tags": ["agents"]
+        "tags": [
+          "agents"
+        ]
       }
     },
     "/agents/{agentId}/mcp-integrations": {
@@ -2986,7 +3739,10 @@
             "required": true,
             "in": "path",
             "description": "The UUID of the agent",
-            "schema": { "format": "uuid", "type": "string" }
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -3003,10 +3759,14 @@
               }
             }
           },
-          "404": { "description": "Agent not found" }
+          "404": {
+            "description": "Agent not found"
+          }
         },
         "summary": "List MCP integrations assigned to agent",
-        "tags": ["agents"]
+        "tags": [
+          "agents"
+        ]
       }
     },
     "/shares": {
@@ -3018,7 +3778,9 @@
           "description": "Share creation data",
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/CreateAgentShareDto" }
+              "schema": {
+                "$ref": "#/components/schemas/CreateAgentShareDto"
+              }
             }
           }
         },
@@ -3027,17 +3789,29 @@
             "description": "Share created successfully",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ShareResponseDto" }
+                "schema": {
+                  "$ref": "#/components/schemas/ShareResponseDto"
+                }
               }
             }
           },
-          "400": { "description": "Invalid request data" },
-          "401": { "description": "User not authenticated" },
-          "403": { "description": "User cannot create share for this entity" },
-          "500": { "description": "Internal server error" }
+          "400": {
+            "description": "Invalid request data"
+          },
+          "401": {
+            "description": "User not authenticated"
+          },
+          "403": {
+            "description": "User cannot create share for this entity"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
         },
         "summary": "Create a share for an agent",
-        "tags": ["shares"]
+        "tags": [
+          "shares"
+        ]
       },
       "get": {
         "operationId": "SharesController_getShares",
@@ -3047,7 +3821,10 @@
             "required": true,
             "in": "query",
             "description": "ID of the entity to get shares for",
-            "schema": { "format": "uuid", "type": "string" }
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
           },
           {
             "name": "entityType",
@@ -3055,7 +3832,12 @@
             "in": "query",
             "description": "Type of the entity",
             "schema": {
-              "enum": ["agent", "prompt", "skill", "knowledge_base"],
+              "enum": [
+                "agent",
+                "prompt",
+                "skill",
+                "knowledge_base"
+              ],
               "type": "string"
             }
           }
@@ -3067,17 +3849,27 @@
               "application/json": {
                 "schema": {
                   "type": "array",
-                  "items": { "$ref": "#/components/schemas/ShareResponseDto" }
+                  "items": {
+                    "$ref": "#/components/schemas/ShareResponseDto"
+                  }
                 }
               }
             }
           },
-          "401": { "description": "User not authenticated" },
-          "403": { "description": "User cannot view shares for this entity" },
-          "500": { "description": "Internal server error" }
+          "401": {
+            "description": "User not authenticated"
+          },
+          "403": {
+            "description": "User cannot view shares for this entity"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
         },
         "summary": "Get shares for an entity",
-        "tags": ["shares"]
+        "tags": [
+          "shares"
+        ]
       }
     },
     "/shares/skills": {
@@ -3089,7 +3881,9 @@
           "description": "Skill share creation data",
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/CreateSkillShareDto" }
+              "schema": {
+                "$ref": "#/components/schemas/CreateSkillShareDto"
+              }
             }
           }
         },
@@ -3098,16 +3892,26 @@
             "description": "Share created successfully",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ShareResponseDto" }
+                "schema": {
+                  "$ref": "#/components/schemas/ShareResponseDto"
+                }
               }
             }
           },
-          "400": { "description": "Invalid request data" },
-          "401": { "description": "User not authenticated" },
-          "403": { "description": "User cannot create share for this skill" }
+          "400": {
+            "description": "Invalid request data"
+          },
+          "401": {
+            "description": "User not authenticated"
+          },
+          "403": {
+            "description": "User cannot create share for this skill"
+          }
         },
         "summary": "Create a share for a skill",
-        "tags": ["shares"]
+        "tags": [
+          "shares"
+        ]
       }
     },
     "/shares/knowledge-bases": {
@@ -3130,18 +3934,26 @@
             "description": "Share created successfully",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ShareResponseDto" }
+                "schema": {
+                  "$ref": "#/components/schemas/ShareResponseDto"
+                }
               }
             }
           },
-          "400": { "description": "Invalid request data" },
-          "401": { "description": "User not authenticated" },
+          "400": {
+            "description": "Invalid request data"
+          },
+          "401": {
+            "description": "User not authenticated"
+          },
           "403": {
             "description": "User cannot create share for this knowledge base"
           }
         },
         "summary": "Create a share for a knowledge base",
-        "tags": ["shares"]
+        "tags": [
+          "shares"
+        ]
       }
     },
     "/shares/{id}": {
@@ -3153,17 +3965,30 @@
             "required": true,
             "in": "path",
             "description": "The UUID of the share to delete",
-            "schema": { "format": "uuid", "type": "string" }
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
         "responses": {
-          "204": { "description": "The share has been successfully deleted" },
-          "401": { "description": "Unauthorized" },
-          "404": { "description": "Share not found" },
-          "500": { "description": "Internal server error" }
+          "204": {
+            "description": "The share has been successfully deleted"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "404": {
+            "description": "Share not found"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
         },
         "summary": "Delete a share",
-        "tags": ["shares"]
+        "tags": [
+          "shares"
+        ]
       }
     },
     "/teams": {
@@ -3177,17 +4002,27 @@
               "application/json": {
                 "schema": {
                   "type": "array",
-                  "items": { "$ref": "#/components/schemas/TeamResponseDto" }
+                  "items": {
+                    "$ref": "#/components/schemas/TeamResponseDto"
+                  }
                 }
               }
             }
           },
-          "401": { "description": "User is not authenticated" },
-          "403": { "description": "User is not authorized to view teams" },
-          "500": { "description": "Internal server error" }
+          "401": {
+            "description": "User is not authenticated"
+          },
+          "403": {
+            "description": "User is not authorized to view teams"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
         },
         "summary": "List all teams for the current organization",
-        "tags": ["teams"]
+        "tags": [
+          "teams"
+        ]
       },
       "post": {
         "operationId": "TeamsController_createTeam",
@@ -3196,7 +4031,9 @@
           "required": true,
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/CreateTeamDto" }
+              "schema": {
+                "$ref": "#/components/schemas/CreateTeamDto"
+              }
             }
           }
         },
@@ -3205,20 +4042,32 @@
             "description": "Successfully created team",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/TeamResponseDto" }
+                "schema": {
+                  "$ref": "#/components/schemas/TeamResponseDto"
+                }
               }
             }
           },
-          "400": { "description": "Invalid team data provided" },
-          "401": { "description": "User is not authenticated" },
-          "403": { "description": "User is not authorized to create teams" },
+          "400": {
+            "description": "Invalid team data provided"
+          },
+          "401": {
+            "description": "User is not authenticated"
+          },
+          "403": {
+            "description": "User is not authorized to create teams"
+          },
           "409": {
             "description": "Team with this name already exists in the organization"
           },
-          "500": { "description": "Internal server error" }
+          "500": {
+            "description": "Internal server error"
+          }
         },
         "summary": "Create a new team for the current organization",
-        "tags": ["teams"]
+        "tags": [
+          "teams"
+        ]
       }
     },
     "/teams/me": {
@@ -3232,16 +4081,24 @@
               "application/json": {
                 "schema": {
                   "type": "array",
-                  "items": { "$ref": "#/components/schemas/TeamResponseDto" }
+                  "items": {
+                    "$ref": "#/components/schemas/TeamResponseDto"
+                  }
                 }
               }
             }
           },
-          "401": { "description": "User is not authenticated" },
-          "500": { "description": "Internal server error" }
+          "401": {
+            "description": "User is not authenticated"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
         },
         "summary": "List teams the current user is a member of",
-        "tags": ["teams"]
+        "tags": [
+          "teams"
+        ]
       }
     },
     "/teams/{id}": {
@@ -3252,7 +4109,9 @@
             "name": "id",
             "required": true,
             "in": "path",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -3260,17 +4119,29 @@
             "description": "Successfully retrieved team",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/TeamResponseDto" }
+                "schema": {
+                  "$ref": "#/components/schemas/TeamResponseDto"
+                }
               }
             }
           },
-          "401": { "description": "User is not authenticated" },
-          "403": { "description": "User is not authorized to view teams" },
-          "404": { "description": "Team not found" },
-          "500": { "description": "Internal server error" }
+          "401": {
+            "description": "User is not authenticated"
+          },
+          "403": {
+            "description": "User is not authorized to view teams"
+          },
+          "404": {
+            "description": "Team not found"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
         },
         "summary": "Get a team by ID",
-        "tags": ["teams"]
+        "tags": [
+          "teams"
+        ]
       },
       "patch": {
         "operationId": "TeamsController_updateTeam",
@@ -3279,14 +4150,18 @@
             "name": "id",
             "required": true,
             "in": "path",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/UpdateTeamDto" }
+              "schema": {
+                "$ref": "#/components/schemas/UpdateTeamDto"
+              }
             }
           }
         },
@@ -3295,21 +4170,35 @@
             "description": "Successfully updated team",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/TeamResponseDto" }
+                "schema": {
+                  "$ref": "#/components/schemas/TeamResponseDto"
+                }
               }
             }
           },
-          "400": { "description": "Invalid team data provided" },
-          "401": { "description": "User is not authenticated" },
-          "403": { "description": "User is not authorized to update teams" },
-          "404": { "description": "Team not found" },
+          "400": {
+            "description": "Invalid team data provided"
+          },
+          "401": {
+            "description": "User is not authenticated"
+          },
+          "403": {
+            "description": "User is not authorized to update teams"
+          },
+          "404": {
+            "description": "Team not found"
+          },
           "409": {
             "description": "Team with this name already exists in the organization"
           },
-          "500": { "description": "Internal server error" }
+          "500": {
+            "description": "Internal server error"
+          }
         },
         "summary": "Update a team in the current organization",
-        "tags": ["teams"]
+        "tags": [
+          "teams"
+        ]
       },
       "delete": {
         "operationId": "TeamsController_deleteTeam",
@@ -3318,18 +4207,32 @@
             "name": "id",
             "required": true,
             "in": "path",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
-          "204": { "description": "Team successfully deleted" },
-          "401": { "description": "User is not authenticated" },
-          "403": { "description": "User is not authorized to delete teams" },
-          "404": { "description": "Team not found" },
-          "500": { "description": "Internal server error" }
+          "204": {
+            "description": "Team successfully deleted"
+          },
+          "401": {
+            "description": "User is not authenticated"
+          },
+          "403": {
+            "description": "User is not authorized to delete teams"
+          },
+          "404": {
+            "description": "Team not found"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
         },
         "summary": "Delete a team from the current organization",
-        "tags": ["teams"]
+        "tags": [
+          "teams"
+        ]
       }
     },
     "/teams/{id}/members": {
@@ -3340,21 +4243,31 @@
             "name": "id",
             "required": true,
             "in": "path",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "limit",
             "required": false,
             "in": "query",
             "description": "Maximum number of items per page",
-            "schema": { "default": 50, "example": 50, "type": "number" }
+            "schema": {
+              "default": 50,
+              "example": 50,
+              "type": "number"
+            }
           },
           {
             "name": "offset",
             "required": false,
             "in": "query",
             "description": "Number of items to skip",
-            "schema": { "default": 0, "example": 0, "type": "number" }
+            "schema": {
+              "default": 0,
+              "example": 0,
+              "type": "number"
+            }
           }
         ],
         "responses": {
@@ -3368,15 +4281,23 @@
               }
             }
           },
-          "401": { "description": "User is not authenticated" },
+          "401": {
+            "description": "User is not authenticated"
+          },
           "403": {
             "description": "User is not authorized to view team members"
           },
-          "404": { "description": "Team not found" },
-          "500": { "description": "Internal server error" }
+          "404": {
+            "description": "Team not found"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
         },
         "summary": "List members of a team",
-        "tags": ["teams"]
+        "tags": [
+          "teams"
+        ]
       },
       "post": {
         "operationId": "TeamsController_addTeamMember",
@@ -3385,14 +4306,18 @@
             "name": "id",
             "required": true,
             "in": "path",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/AddTeamMemberDto" }
+              "schema": {
+                "$ref": "#/components/schemas/AddTeamMemberDto"
+              }
             }
           }
         },
@@ -3410,16 +4335,26 @@
           "400": {
             "description": "Invalid data provided or user not in same organization"
           },
-          "401": { "description": "User is not authenticated" },
+          "401": {
+            "description": "User is not authenticated"
+          },
           "403": {
             "description": "User is not authorized to add team members"
           },
-          "404": { "description": "Team or user not found" },
-          "409": { "description": "User is already a member of the team" },
-          "500": { "description": "Internal server error" }
+          "404": {
+            "description": "Team or user not found"
+          },
+          "409": {
+            "description": "User is already a member of the team"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
         },
         "summary": "Add a user to a team",
-        "tags": ["teams"]
+        "tags": [
+          "teams"
+        ]
       }
     },
     "/teams/{id}/members/{userId}": {
@@ -3430,28 +4365,40 @@
             "name": "id",
             "required": true,
             "in": "path",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "userId",
             "required": true,
             "in": "path",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
-          "204": { "description": "User successfully removed from team" },
-          "401": { "description": "User is not authenticated" },
+          "204": {
+            "description": "User successfully removed from team"
+          },
+          "401": {
+            "description": "User is not authenticated"
+          },
           "403": {
             "description": "User is not authorized to remove team members"
           },
           "404": {
             "description": "Team not found or user is not a member of the team"
           },
-          "500": { "description": "Internal server error" }
+          "500": {
+            "description": "Internal server error"
+          }
         },
         "summary": "Remove a user from a team",
-        "tags": ["teams"]
+        "tags": [
+          "teams"
+        ]
       }
     },
     "/mcp-integrations/predefined": {
@@ -3479,11 +4426,17 @@
               }
             }
           },
-          "400": { "description": "Invalid slug or missing required fields" },
-          "404": { "description": "Predefined integration slug not found" }
+          "400": {
+            "description": "Invalid slug or missing required fields"
+          },
+          "404": {
+            "description": "Predefined integration slug not found"
+          }
         },
         "summary": "Create a new predefined MCP integration",
-        "tags": ["mcp-integrations"]
+        "tags": [
+          "mcp-integrations"
+        ]
       }
     },
     "/mcp-integrations/custom": {
@@ -3511,10 +4464,14 @@
               }
             }
           },
-          "400": { "description": "Invalid data" }
+          "400": {
+            "description": "Invalid data"
+          }
         },
         "summary": "Create a new custom MCP integration",
-        "tags": ["mcp-integrations"]
+        "tags": [
+          "mcp-integrations"
+        ]
       }
     },
     "/mcp-integrations": {
@@ -3537,7 +4494,9 @@
           }
         },
         "summary": "List all MCP integrations for organization",
-        "tags": ["mcp-integrations"]
+        "tags": [
+          "mcp-integrations"
+        ]
       }
     },
     "/mcp-integrations/predefined/available": {
@@ -3560,7 +4519,9 @@
           }
         },
         "summary": "List available predefined MCP integration configurations",
-        "tags": ["mcp-integrations"]
+        "tags": [
+          "mcp-integrations"
+        ]
       }
     },
     "/mcp-integrations/available": {
@@ -3583,7 +4544,9 @@
           }
         },
         "summary": "List all available (enabled) MCP integrations for organization",
-        "tags": ["mcp-integrations"]
+        "tags": [
+          "mcp-integrations"
+        ]
       }
     },
     "/mcp-integrations/{id}": {
@@ -3594,7 +4557,10 @@
             "name": "id",
             "required": true,
             "in": "path",
-            "schema": { "format": "uuid", "type": "string" }
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -3608,10 +4574,14 @@
               }
             }
           },
-          "404": { "description": "Integration not found" }
+          "404": {
+            "description": "Integration not found"
+          }
         },
         "summary": "Get MCP integration by ID",
-        "tags": ["mcp-integrations"]
+        "tags": [
+          "mcp-integrations"
+        ]
       },
       "patch": {
         "operationId": "McpIntegrationsController_update",
@@ -3620,7 +4590,10 @@
             "name": "id",
             "required": true,
             "in": "path",
-            "schema": { "format": "uuid", "type": "string" }
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
         "requestBody": {
@@ -3644,11 +4617,17 @@
               }
             }
           },
-          "400": { "description": "Invalid data" },
-          "404": { "description": "Integration not found" }
+          "400": {
+            "description": "Invalid data"
+          },
+          "404": {
+            "description": "Integration not found"
+          }
         },
         "summary": "Update MCP integration",
-        "tags": ["mcp-integrations"]
+        "tags": [
+          "mcp-integrations"
+        ]
       },
       "delete": {
         "operationId": "McpIntegrationsController_delete",
@@ -3657,15 +4636,24 @@
             "name": "id",
             "required": true,
             "in": "path",
-            "schema": { "format": "uuid", "type": "string" }
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
         "responses": {
-          "204": { "description": "Integration deleted successfully" },
-          "404": { "description": "Integration not found" }
+          "204": {
+            "description": "Integration deleted successfully"
+          },
+          "404": {
+            "description": "Integration not found"
+          }
         },
         "summary": "Delete MCP integration",
-        "tags": ["mcp-integrations"]
+        "tags": [
+          "mcp-integrations"
+        ]
       }
     },
     "/mcp-integrations/{id}/enable": {
@@ -3676,7 +4664,10 @@
             "name": "id",
             "required": true,
             "in": "path",
-            "schema": { "format": "uuid", "type": "string" }
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -3690,10 +4681,14 @@
               }
             }
           },
-          "404": { "description": "Integration not found" }
+          "404": {
+            "description": "Integration not found"
+          }
         },
         "summary": "Enable MCP integration",
-        "tags": ["mcp-integrations"]
+        "tags": [
+          "mcp-integrations"
+        ]
       }
     },
     "/mcp-integrations/{id}/disable": {
@@ -3704,7 +4699,10 @@
             "name": "id",
             "required": true,
             "in": "path",
-            "schema": { "format": "uuid", "type": "string" }
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -3718,10 +4716,14 @@
               }
             }
           },
-          "404": { "description": "Integration not found" }
+          "404": {
+            "description": "Integration not found"
+          }
         },
         "summary": "Disable MCP integration",
-        "tags": ["mcp-integrations"]
+        "tags": [
+          "mcp-integrations"
+        ]
       }
     },
     "/mcp-integrations/install-from-marketplace": {
@@ -3752,10 +4754,14 @@
           "400": {
             "description": "Missing required config fields or OAuth not supported"
           },
-          "404": { "description": "Marketplace integration not found" }
+          "404": {
+            "description": "Marketplace integration not found"
+          }
         },
         "summary": "Install an MCP integration from the marketplace",
-        "tags": ["mcp-integrations"]
+        "tags": [
+          "mcp-integrations"
+        ]
       }
     },
     "/mcp-integrations/{id}/user-config": {
@@ -3766,7 +4772,10 @@
             "name": "id",
             "required": true,
             "in": "path",
-            "schema": { "format": "uuid", "type": "string" }
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -3782,7 +4791,9 @@
           }
         },
         "summary": "Get current user config for a marketplace MCP integration",
-        "tags": ["mcp-integrations"]
+        "tags": [
+          "mcp-integrations"
+        ]
       },
       "patch": {
         "operationId": "McpIntegrationsController_setUserConfig",
@@ -3791,14 +4802,19 @@
             "name": "id",
             "required": true,
             "in": "path",
-            "schema": { "format": "uuid", "type": "string" }
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/SetUserConfigDto" }
+              "schema": {
+                "$ref": "#/components/schemas/SetUserConfigDto"
+              }
             }
           }
         },
@@ -3813,11 +4829,17 @@
               }
             }
           },
-          "400": { "description": "Integration has no user fields" },
-          "404": { "description": "Integration not found" }
+          "400": {
+            "description": "Integration has no user fields"
+          },
+          "404": {
+            "description": "Integration not found"
+          }
         },
         "summary": "Set current user config for a marketplace MCP integration",
-        "tags": ["mcp-integrations"]
+        "tags": [
+          "mcp-integrations"
+        ]
       }
     },
     "/mcp-integrations/{id}/validate": {
@@ -3828,7 +4850,10 @@
             "name": "id",
             "required": true,
             "in": "path",
-            "schema": { "format": "uuid", "type": "string" }
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -3842,10 +4867,14 @@
               }
             }
           },
-          "404": { "description": "Integration not found" }
+          "404": {
+            "description": "Integration not found"
+          }
         },
         "summary": "Validate MCP integration connection",
-        "tags": ["mcp-integrations"]
+        "tags": [
+          "mcp-integrations"
+        ]
       }
     },
     "/marketplace/skills/{identifier}": {
@@ -3857,7 +4886,9 @@
             "required": true,
             "in": "path",
             "description": "The unique identifier slug of the marketplace skill",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -3871,10 +4902,14 @@
               }
             }
           },
-          "404": { "description": "Marketplace skill not found" }
+          "404": {
+            "description": "Marketplace skill not found"
+          }
         },
         "summary": "Preview a marketplace skill before installation",
-        "tags": ["marketplace"]
+        "tags": [
+          "marketplace"
+        ]
       }
     },
     "/marketplace/integrations/{identifier}": {
@@ -3886,7 +4921,9 @@
             "required": true,
             "in": "path",
             "description": "The unique identifier slug of the marketplace integration",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -3900,10 +4937,14 @@
               }
             }
           },
-          "404": { "description": "Marketplace integration not found" }
+          "404": {
+            "description": "Marketplace integration not found"
+          }
         },
         "summary": "Preview a marketplace integration before installation",
-        "tags": ["marketplace"]
+        "tags": [
+          "marketplace"
+        ]
       }
     },
     "/knowledge-bases": {
@@ -3931,10 +4972,14 @@
               }
             }
           },
-          "400": { "description": "Invalid input data" }
+          "400": {
+            "description": "Invalid input data"
+          }
         },
         "summary": "Create a new knowledge base",
-        "tags": ["knowledge-bases"]
+        "tags": [
+          "knowledge-bases"
+        ]
       },
       "get": {
         "operationId": "KnowledgeBasesController_findAll",
@@ -3952,7 +4997,9 @@
           }
         },
         "summary": "List all knowledge bases for the current user",
-        "tags": ["knowledge-bases"]
+        "tags": [
+          "knowledge-bases"
+        ]
       }
     },
     "/knowledge-bases/{id}": {
@@ -3964,7 +5011,10 @@
             "required": true,
             "in": "path",
             "description": "The UUID of the knowledge base",
-            "schema": { "format": "uuid", "type": "string" }
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -3978,10 +5028,14 @@
               }
             }
           },
-          "404": { "description": "Knowledge base not found" }
+          "404": {
+            "description": "Knowledge base not found"
+          }
         },
         "summary": "Get a knowledge base by ID",
-        "tags": ["knowledge-bases"]
+        "tags": [
+          "knowledge-bases"
+        ]
       },
       "patch": {
         "operationId": "KnowledgeBasesController_update",
@@ -3991,7 +5045,10 @@
             "required": true,
             "in": "path",
             "description": "The UUID of the knowledge base to update",
-            "schema": { "format": "uuid", "type": "string" }
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
         "requestBody": {
@@ -4015,11 +5072,17 @@
               }
             }
           },
-          "400": { "description": "Invalid input data" },
-          "404": { "description": "Knowledge base not found" }
+          "400": {
+            "description": "Invalid input data"
+          },
+          "404": {
+            "description": "Knowledge base not found"
+          }
         },
         "summary": "Update a knowledge base",
-        "tags": ["knowledge-bases"]
+        "tags": [
+          "knowledge-bases"
+        ]
       },
       "delete": {
         "operationId": "KnowledgeBasesController_delete",
@@ -4029,17 +5092,24 @@
             "required": true,
             "in": "path",
             "description": "The UUID of the knowledge base to delete",
-            "schema": { "format": "uuid", "type": "string" }
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
         "responses": {
           "204": {
             "description": "The knowledge base has been successfully deleted"
           },
-          "404": { "description": "Knowledge base not found" }
+          "404": {
+            "description": "Knowledge base not found"
+          }
         },
         "summary": "Delete a knowledge base",
-        "tags": ["knowledge-bases"]
+        "tags": [
+          "knowledge-bases"
+        ]
       }
     },
     "/knowledge-bases/{id}/documents": {
@@ -4051,7 +5121,10 @@
             "required": true,
             "in": "path",
             "description": "The UUID of the knowledge base",
-            "schema": { "format": "uuid", "type": "string" }
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -4065,10 +5138,14 @@
               }
             }
           },
-          "404": { "description": "Knowledge base not found" }
+          "404": {
+            "description": "Knowledge base not found"
+          }
         },
         "summary": "List all documents in a knowledge base",
-        "tags": ["knowledge-bases"]
+        "tags": [
+          "knowledge-bases"
+        ]
       },
       "post": {
         "operationId": "KnowledgeBasesController_addDocument",
@@ -4078,7 +5155,10 @@
             "required": true,
             "in": "path",
             "description": "The UUID of the knowledge base",
-            "schema": { "format": "uuid", "type": "string" }
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
         "requestBody": {
@@ -4094,7 +5174,9 @@
                     "description": "The file to upload (PDF, DOCX, PPTX, TXT)"
                   }
                 },
-                "required": ["file"]
+                "required": [
+                  "file"
+                ]
               }
             }
           }
@@ -4110,10 +5192,14 @@
               }
             }
           },
-          "404": { "description": "Knowledge base not found" }
+          "404": {
+            "description": "Knowledge base not found"
+          }
         },
         "summary": "Add a document to a knowledge base",
-        "tags": ["knowledge-bases"]
+        "tags": [
+          "knowledge-bases"
+        ]
       }
     },
     "/knowledge-bases/{id}/urls": {
@@ -4125,7 +5211,10 @@
             "required": true,
             "in": "path",
             "description": "The UUID of the knowledge base",
-            "schema": { "format": "uuid", "type": "string" }
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
         "requestBody": {
@@ -4149,10 +5238,14 @@
               }
             }
           },
-          "404": { "description": "Knowledge base not found" }
+          "404": {
+            "description": "Knowledge base not found"
+          }
         },
         "summary": "Add a URL source to a knowledge base",
-        "tags": ["knowledge-bases"]
+        "tags": [
+          "knowledge-bases"
+        ]
       }
     },
     "/knowledge-bases/{id}/documents/{documentId}": {
@@ -4164,24 +5257,34 @@
             "required": true,
             "in": "path",
             "description": "The UUID of the knowledge base",
-            "schema": { "format": "uuid", "type": "string" }
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
           },
           {
             "name": "documentId",
             "required": true,
             "in": "path",
             "description": "The UUID of the document to remove",
-            "schema": { "format": "uuid", "type": "string" }
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
         "responses": {
           "204": {
             "description": "The document has been removed from the knowledge base"
           },
-          "404": { "description": "Knowledge base or document not found" }
+          "404": {
+            "description": "Knowledge base or document not found"
+          }
         },
         "summary": "Remove a document from a knowledge base",
-        "tags": ["knowledge-bases"]
+        "tags": [
+          "knowledge-bases"
+        ]
       }
     },
     "/skills/install-from-marketplace": {
@@ -4203,14 +5306,20 @@
             "description": "The skill has been successfully installed from the marketplace",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/SkillResponseDto" }
+                "schema": {
+                  "$ref": "#/components/schemas/SkillResponseDto"
+                }
               }
             }
           },
-          "404": { "description": "Marketplace skill not found" }
+          "404": {
+            "description": "Marketplace skill not found"
+          }
         },
         "summary": "Install a skill from the marketplace",
-        "tags": ["skills"]
+        "tags": [
+          "skills"
+        ]
       }
     },
     "/skills": {
@@ -4221,7 +5330,9 @@
           "required": true,
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/CreateSkillDto" }
+              "schema": {
+                "$ref": "#/components/schemas/CreateSkillDto"
+              }
             }
           }
         },
@@ -4230,15 +5341,23 @@
             "description": "The skill has been successfully created",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/SkillResponseDto" }
+                "schema": {
+                  "$ref": "#/components/schemas/SkillResponseDto"
+                }
               }
             }
           },
-          "400": { "description": "Invalid skill data" },
-          "409": { "description": "A skill with this name already exists" }
+          "400": {
+            "description": "Invalid skill data"
+          },
+          "409": {
+            "description": "A skill with this name already exists"
+          }
         },
         "summary": "Create a new skill",
-        "tags": ["skills"]
+        "tags": [
+          "skills"
+        ]
       },
       "get": {
         "operationId": "SkillsController_findAll",
@@ -4250,14 +5369,18 @@
               "application/json": {
                 "schema": {
                   "type": "array",
-                  "items": { "$ref": "#/components/schemas/SkillResponseDto" }
+                  "items": {
+                    "$ref": "#/components/schemas/SkillResponseDto"
+                  }
                 }
               }
             }
           }
         },
         "summary": "Get all skills for the current user",
-        "tags": ["skills"]
+        "tags": [
+          "skills"
+        ]
       }
     },
     "/skills/{id}": {
@@ -4269,7 +5392,10 @@
             "required": true,
             "in": "path",
             "description": "The UUID of the skill to retrieve",
-            "schema": { "format": "uuid", "type": "string" }
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -4277,14 +5403,20 @@
             "description": "Returns the skill with the specified ID",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/SkillResponseDto" }
+                "schema": {
+                  "$ref": "#/components/schemas/SkillResponseDto"
+                }
               }
             }
           },
-          "404": { "description": "Skill not found" }
+          "404": {
+            "description": "Skill not found"
+          }
         },
         "summary": "Get a skill by ID",
-        "tags": ["skills"]
+        "tags": [
+          "skills"
+        ]
       },
       "put": {
         "operationId": "SkillsController_update",
@@ -4294,14 +5426,19 @@
             "required": true,
             "in": "path",
             "description": "The UUID of the skill to update",
-            "schema": { "format": "uuid", "type": "string" }
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/UpdateSkillDto" }
+              "schema": {
+                "$ref": "#/components/schemas/UpdateSkillDto"
+              }
             }
           }
         },
@@ -4310,16 +5447,26 @@
             "description": "The skill has been successfully updated",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/SkillResponseDto" }
+                "schema": {
+                  "$ref": "#/components/schemas/SkillResponseDto"
+                }
               }
             }
           },
-          "400": { "description": "Invalid skill data" },
-          "404": { "description": "Skill not found" },
-          "409": { "description": "A skill with this name already exists" }
+          "400": {
+            "description": "Invalid skill data"
+          },
+          "404": {
+            "description": "Skill not found"
+          },
+          "409": {
+            "description": "A skill with this name already exists"
+          }
         },
         "summary": "Update a skill",
-        "tags": ["skills"]
+        "tags": [
+          "skills"
+        ]
       },
       "delete": {
         "operationId": "SkillsController_delete",
@@ -4329,15 +5476,24 @@
             "required": true,
             "in": "path",
             "description": "The UUID of the skill to delete",
-            "schema": { "format": "uuid", "type": "string" }
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
         "responses": {
-          "204": { "description": "The skill has been successfully deleted" },
-          "404": { "description": "Skill not found" }
+          "204": {
+            "description": "The skill has been successfully deleted"
+          },
+          "404": {
+            "description": "Skill not found"
+          }
         },
         "summary": "Delete a skill",
-        "tags": ["skills"]
+        "tags": [
+          "skills"
+        ]
       }
     },
     "/skills/{id}/toggle-active": {
@@ -4349,7 +5505,10 @@
             "required": true,
             "in": "path",
             "description": "The UUID of the skill to toggle",
-            "schema": { "format": "uuid", "type": "string" }
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -4357,14 +5516,20 @@
             "description": "The skill active status has been toggled",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/SkillResponseDto" }
+                "schema": {
+                  "$ref": "#/components/schemas/SkillResponseDto"
+                }
               }
             }
           },
-          "404": { "description": "Skill not found" }
+          "404": {
+            "description": "Skill not found"
+          }
         },
         "summary": "Toggle skill active/inactive status",
-        "tags": ["skills"]
+        "tags": [
+          "skills"
+        ]
       }
     },
     "/skills/{id}/toggle-pinned": {
@@ -4376,7 +5541,10 @@
             "required": true,
             "in": "path",
             "description": "The UUID of the skill to toggle pinned status",
-            "schema": { "format": "uuid", "type": "string" }
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -4384,15 +5552,23 @@
             "description": "The skill pinned status has been toggled",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/SkillResponseDto" }
+                "schema": {
+                  "$ref": "#/components/schemas/SkillResponseDto"
+                }
               }
             }
           },
-          "400": { "description": "Skill is not active" },
-          "404": { "description": "Skill not found" }
+          "400": {
+            "description": "Skill is not active"
+          },
+          "404": {
+            "description": "Skill not found"
+          }
         },
         "summary": "Toggle skill pinned/unpinned status",
-        "tags": ["skills"]
+        "tags": [
+          "skills"
+        ]
       }
     },
     "/skills/{id}/sources": {
@@ -4404,7 +5580,10 @@
             "required": true,
             "in": "path",
             "description": "The UUID of the skill",
-            "schema": { "format": "uuid", "type": "string" }
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -4421,10 +5600,14 @@
               }
             }
           },
-          "404": { "description": "Skill not found" }
+          "404": {
+            "description": "Skill not found"
+          }
         },
         "summary": "Get all sources for a skill",
-        "tags": ["skills"]
+        "tags": [
+          "skills"
+        ]
       }
     },
     "/skills/{id}/sources/file": {
@@ -4436,7 +5619,10 @@
             "required": true,
             "in": "path",
             "description": "The UUID of the skill",
-            "schema": { "format": "uuid", "type": "string" }
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
         "requestBody": {
@@ -4452,7 +5638,9 @@
                     "description": "The file to upload"
                   }
                 },
-                "required": ["file"]
+                "required": [
+                  "file"
+                ]
               }
             }
           }
@@ -4462,15 +5650,23 @@
             "description": "The file source has been successfully added to the skill",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/SkillResponseDto" }
+                "schema": {
+                  "$ref": "#/components/schemas/SkillResponseDto"
+                }
               }
             }
           },
-          "400": { "description": "Invalid or unsupported file type" },
-          "404": { "description": "Skill not found" }
+          "400": {
+            "description": "Invalid or unsupported file type"
+          },
+          "404": {
+            "description": "Skill not found"
+          }
         },
         "summary": "Add a file source to a skill",
-        "tags": ["skills"]
+        "tags": [
+          "skills"
+        ]
       }
     },
     "/skills/{id}/sources/{sourceId}": {
@@ -4482,24 +5678,34 @@
             "required": true,
             "in": "path",
             "description": "The UUID of the skill",
-            "schema": { "format": "uuid", "type": "string" }
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
           },
           {
             "name": "sourceId",
             "required": true,
             "in": "path",
             "description": "The UUID of the source to remove",
-            "schema": { "format": "uuid", "type": "string" }
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
         "responses": {
           "204": {
             "description": "The source has been successfully removed from the skill"
           },
-          "404": { "description": "Skill or source not found" }
+          "404": {
+            "description": "Skill or source not found"
+          }
         },
         "summary": "Remove a source from a skill",
-        "tags": ["skills"]
+        "tags": [
+          "skills"
+        ]
       }
     },
     "/skills/{skillId}/mcp-integrations/{integrationId}": {
@@ -4511,14 +5717,20 @@
             "required": true,
             "in": "path",
             "description": "The UUID of the skill",
-            "schema": { "format": "uuid", "type": "string" }
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
           },
           {
             "name": "integrationId",
             "required": true,
             "in": "path",
             "description": "The UUID of the MCP integration to assign",
-            "schema": { "format": "uuid", "type": "string" }
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -4526,15 +5738,23 @@
             "description": "The MCP integration has been successfully assigned",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/SkillResponseDto" }
+                "schema": {
+                  "$ref": "#/components/schemas/SkillResponseDto"
+                }
               }
             }
           },
-          "404": { "description": "Skill or integration not found" },
-          "409": { "description": "Integration already assigned" }
+          "404": {
+            "description": "Skill or integration not found"
+          },
+          "409": {
+            "description": "Integration already assigned"
+          }
         },
         "summary": "Assign MCP integration to skill",
-        "tags": ["skills"]
+        "tags": [
+          "skills"
+        ]
       },
       "delete": {
         "operationId": "SkillMcpIntegrationsController_unassignMcpIntegration",
@@ -4544,14 +5764,20 @@
             "required": true,
             "in": "path",
             "description": "The UUID of the skill",
-            "schema": { "format": "uuid", "type": "string" }
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
           },
           {
             "name": "integrationId",
             "required": true,
             "in": "path",
             "description": "The UUID of the MCP integration to unassign",
-            "schema": { "format": "uuid", "type": "string" }
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -4559,7 +5785,9 @@
             "description": "The MCP integration has been successfully unassigned",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/SkillResponseDto" }
+                "schema": {
+                  "$ref": "#/components/schemas/SkillResponseDto"
+                }
               }
             }
           },
@@ -4568,7 +5796,9 @@
           }
         },
         "summary": "Unassign MCP integration from skill",
-        "tags": ["skills"]
+        "tags": [
+          "skills"
+        ]
       }
     },
     "/skills/{skillId}/mcp-integrations": {
@@ -4580,7 +5810,10 @@
             "required": true,
             "in": "path",
             "description": "The UUID of the skill",
-            "schema": { "format": "uuid", "type": "string" }
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -4597,10 +5830,14 @@
               }
             }
           },
-          "404": { "description": "Skill not found" }
+          "404": {
+            "description": "Skill not found"
+          }
         },
         "summary": "List MCP integrations assigned to skill",
-        "tags": ["skills"]
+        "tags": [
+          "skills"
+        ]
       }
     },
     "/skills/{skillId}/knowledge-bases/{knowledgeBaseId}": {
@@ -4612,14 +5849,20 @@
             "required": true,
             "in": "path",
             "description": "The UUID of the skill",
-            "schema": { "format": "uuid", "type": "string" }
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
           },
           {
             "name": "knowledgeBaseId",
             "required": true,
             "in": "path",
             "description": "The UUID of the knowledge base to assign",
-            "schema": { "format": "uuid", "type": "string" }
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -4627,15 +5870,23 @@
             "description": "The knowledge base has been successfully assigned",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/SkillResponseDto" }
+                "schema": {
+                  "$ref": "#/components/schemas/SkillResponseDto"
+                }
               }
             }
           },
-          "404": { "description": "Skill or knowledge base not found" },
-          "409": { "description": "Knowledge base already assigned" }
+          "404": {
+            "description": "Skill or knowledge base not found"
+          },
+          "409": {
+            "description": "Knowledge base already assigned"
+          }
         },
         "summary": "Assign knowledge base to skill",
-        "tags": ["skills"]
+        "tags": [
+          "skills"
+        ]
       },
       "delete": {
         "operationId": "SkillKnowledgeBasesController_unassignKnowledgeBase",
@@ -4645,14 +5896,20 @@
             "required": true,
             "in": "path",
             "description": "The UUID of the skill",
-            "schema": { "format": "uuid", "type": "string" }
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
           },
           {
             "name": "knowledgeBaseId",
             "required": true,
             "in": "path",
             "description": "The UUID of the knowledge base to unassign",
-            "schema": { "format": "uuid", "type": "string" }
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -4660,7 +5917,9 @@
             "description": "The knowledge base has been successfully unassigned",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/SkillResponseDto" }
+                "schema": {
+                  "$ref": "#/components/schemas/SkillResponseDto"
+                }
               }
             }
           },
@@ -4669,7 +5928,9 @@
           }
         },
         "summary": "Unassign knowledge base from skill",
-        "tags": ["skills"]
+        "tags": [
+          "skills"
+        ]
       }
     },
     "/skills/{skillId}/knowledge-bases": {
@@ -4681,7 +5942,10 @@
             "required": true,
             "in": "path",
             "description": "The UUID of the skill",
-            "schema": { "format": "uuid", "type": "string" }
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -4698,10 +5962,14 @@
               }
             }
           },
-          "404": { "description": "Skill not found" }
+          "404": {
+            "description": "Skill not found"
+          }
         },
         "summary": "List knowledge bases assigned to skill",
-        "tags": ["skills"]
+        "tags": [
+          "skills"
+        ]
       }
     },
     "/super-admin/skill-templates": {
@@ -4736,10 +6004,14 @@
           "409": {
             "description": "Skill template with this name already exists"
           },
-          "500": { "description": "Internal server error" }
+          "500": {
+            "description": "Internal server error"
+          }
         },
         "summary": "Create a new skill template",
-        "tags": ["Super Admin Skill Templates"]
+        "tags": [
+          "Super Admin Skill Templates"
+        ]
       },
       "get": {
         "description": "Retrieve all skill templates. Only accessible to super admins.",
@@ -4762,10 +6034,14 @@
           "401": {
             "description": "User not authenticated or not authorized as super admin"
           },
-          "500": { "description": "Internal server error" }
+          "500": {
+            "description": "Internal server error"
+          }
         },
         "summary": "Get all skill templates",
-        "tags": ["Super Admin Skill Templates"]
+        "tags": [
+          "Super Admin Skill Templates"
+        ]
       }
     },
     "/super-admin/skill-templates/{id}": {
@@ -4778,7 +6054,10 @@
             "required": true,
             "in": "path",
             "description": "Skill template ID",
-            "schema": { "format": "uuid", "type": "string" }
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -4795,11 +6074,17 @@
           "401": {
             "description": "User not authenticated or not authorized as super admin"
           },
-          "404": { "description": "Skill template not found" },
-          "500": { "description": "Internal server error" }
+          "404": {
+            "description": "Skill template not found"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
         },
         "summary": "Get a skill template by ID",
-        "tags": ["Super Admin Skill Templates"]
+        "tags": [
+          "Super Admin Skill Templates"
+        ]
       },
       "patch": {
         "description": "Partially update an existing skill template. Only accessible to super admins.",
@@ -4810,7 +6095,10 @@
             "required": true,
             "in": "path",
             "description": "Skill template ID",
-            "schema": { "format": "uuid", "type": "string" }
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
         "requestBody": {
@@ -4837,14 +6125,20 @@
           "401": {
             "description": "User not authenticated or not authorized as super admin"
           },
-          "404": { "description": "Skill template not found" },
+          "404": {
+            "description": "Skill template not found"
+          },
           "409": {
             "description": "Skill template with this name already exists"
           },
-          "500": { "description": "Internal server error" }
+          "500": {
+            "description": "Internal server error"
+          }
         },
         "summary": "Update a skill template",
-        "tags": ["Super Admin Skill Templates"]
+        "tags": [
+          "Super Admin Skill Templates"
+        ]
       },
       "delete": {
         "description": "Delete a skill template. Only accessible to super admins.",
@@ -4855,19 +6149,30 @@
             "required": true,
             "in": "path",
             "description": "Skill template ID",
-            "schema": { "format": "uuid", "type": "string" }
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
         "responses": {
-          "204": { "description": "Successfully deleted skill template" },
+          "204": {
+            "description": "Successfully deleted skill template"
+          },
           "401": {
             "description": "User not authenticated or not authorized as super admin"
           },
-          "404": { "description": "Skill template not found" },
-          "500": { "description": "Internal server error" }
+          "404": {
+            "description": "Skill template not found"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
         },
         "summary": "Delete a skill template",
-        "tags": ["Super Admin Skill Templates"]
+        "tags": [
+          "Super Admin Skill Templates"
+        ]
       }
     },
     "/artifacts": {
@@ -4878,7 +6183,9 @@
           "required": true,
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/CreateArtifactDto" }
+              "schema": {
+                "$ref": "#/components/schemas/CreateArtifactDto"
+              }
             }
           }
         },
@@ -4887,14 +6194,20 @@
             "description": "The artifact has been created",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ArtifactResponseDto" }
+                "schema": {
+                  "$ref": "#/components/schemas/ArtifactResponseDto"
+                }
               }
             }
           },
-          "400": { "description": "Invalid input data" }
+          "400": {
+            "description": "Invalid input data"
+          }
         },
         "summary": "Create a new artifact (document)",
-        "tags": ["artifacts"]
+        "tags": [
+          "artifacts"
+        ]
       }
     },
     "/artifacts/{id}": {
@@ -4906,14 +6219,19 @@
             "required": true,
             "in": "path",
             "description": "The UUID of the artifact",
-            "schema": { "format": "uuid", "type": "string" }
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/UpdateArtifactDto" }
+              "schema": {
+                "$ref": "#/components/schemas/UpdateArtifactDto"
+              }
             }
           }
         },
@@ -4928,10 +6246,14 @@
               }
             }
           },
-          "404": { "description": "Artifact not found" }
+          "404": {
+            "description": "Artifact not found"
+          }
         },
         "summary": "Update an artifact (add a new version)",
-        "tags": ["artifacts"]
+        "tags": [
+          "artifacts"
+        ]
       },
       "get": {
         "operationId": "ArtifactsController_findOne",
@@ -4941,7 +6263,10 @@
             "required": true,
             "in": "path",
             "description": "The UUID of the artifact",
-            "schema": { "format": "uuid", "type": "string" }
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -4949,14 +6274,20 @@
             "description": "The artifact with all versions",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ArtifactResponseDto" }
+                "schema": {
+                  "$ref": "#/components/schemas/ArtifactResponseDto"
+                }
               }
             }
           },
-          "404": { "description": "Artifact not found" }
+          "404": {
+            "description": "Artifact not found"
+          }
         },
         "summary": "Get an artifact by ID with all versions",
-        "tags": ["artifacts"]
+        "tags": [
+          "artifacts"
+        ]
       }
     },
     "/artifacts/thread/{threadId}": {
@@ -4968,7 +6299,10 @@
             "required": true,
             "in": "path",
             "description": "The UUID of the thread",
-            "schema": { "format": "uuid", "type": "string" }
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -4987,7 +6321,9 @@
           }
         },
         "summary": "Get all artifacts for a thread",
-        "tags": ["artifacts"]
+        "tags": [
+          "artifacts"
+        ]
       }
     },
     "/artifacts/{id}/revert": {
@@ -4999,14 +6335,19 @@
             "required": true,
             "in": "path",
             "description": "The UUID of the artifact",
-            "schema": { "format": "uuid", "type": "string" }
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/RevertArtifactDto" }
+              "schema": {
+                "$ref": "#/components/schemas/RevertArtifactDto"
+              }
             }
           }
         },
@@ -5021,10 +6362,14 @@
               }
             }
           },
-          "404": { "description": "Artifact or version not found" }
+          "404": {
+            "description": "Artifact or version not found"
+          }
         },
         "summary": "Revert an artifact to a specific version",
-        "tags": ["artifacts"]
+        "tags": [
+          "artifacts"
+        ]
       }
     },
     "/artifacts/{id}/export": {
@@ -5036,14 +6381,23 @@
             "required": true,
             "in": "path",
             "description": "The UUID of the artifact",
-            "schema": { "format": "uuid", "type": "string" }
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
           },
           {
             "name": "format",
             "required": true,
             "in": "query",
             "description": "Export format",
-            "schema": { "enum": ["docx", "pdf"], "type": "string" }
+            "schema": {
+              "enum": [
+                "docx",
+                "pdf"
+              ],
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -5051,14 +6405,21 @@
             "description": "The exported file",
             "content": {
               "application/octet-stream": {
-                "schema": { "type": "string", "format": "binary" }
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
               }
             }
           },
-          "404": { "description": "Artifact not found" }
+          "404": {
+            "description": "Artifact not found"
+          }
         },
         "summary": "Export an artifact as DOCX or PDF",
-        "tags": ["artifacts"]
+        "tags": [
+          "artifacts"
+        ]
       }
     },
     "/runs/send-message": {
@@ -5072,16 +6433,24 @@
             "multipart/form-data": {
               "schema": {
                 "type": "object",
-                "required": ["threadId"],
+                "required": [
+                  "threadId"
+                ],
                 "properties": {
-                  "threadId": { "type": "string", "format": "uuid" },
+                  "threadId": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
                   "text": {
                     "type": "string",
                     "description": "Message text (optional if images provided)"
                   },
                   "images": {
                     "type": "array",
-                    "items": { "type": "string", "format": "binary" },
+                    "items": {
+                      "type": "string",
+                      "format": "binary"
+                    },
                     "description": "Image files to attach (max 10, max 10MB each, 50MB total)"
                   },
                   "imageAltTexts": {
@@ -5097,7 +6466,10 @@
                     "format": "uuid",
                     "description": "Skill ID to activate for this message"
                   },
-                  "streaming": { "type": "boolean", "default": true }
+                  "streaming": {
+                    "type": "boolean",
+                    "default": true
+                  }
                 }
               }
             }
@@ -5110,10 +6482,18 @@
               "text/event-stream": {
                 "schema": {
                   "oneOf": [
-                    { "$ref": "#/components/schemas/RunSessionResponseDto" },
-                    { "$ref": "#/components/schemas/RunMessageResponseDto" },
-                    { "$ref": "#/components/schemas/RunErrorResponseDto" },
-                    { "$ref": "#/components/schemas/RunThreadResponseDto" }
+                    {
+                      "$ref": "#/components/schemas/RunSessionResponseDto"
+                    },
+                    {
+                      "$ref": "#/components/schemas/RunMessageResponseDto"
+                    },
+                    {
+                      "$ref": "#/components/schemas/RunErrorResponseDto"
+                    },
+                    {
+                      "$ref": "#/components/schemas/RunThreadResponseDto"
+                    }
                   ],
                   "discriminator": {
                     "propertyName": "type",
@@ -5130,24 +6510,41 @@
             "headers": {
               "Content-Type": {
                 "description": "Content type for server-sent events",
-                "schema": { "type": "string", "example": "text/event-stream" }
+                "schema": {
+                  "type": "string",
+                  "example": "text/event-stream"
+                }
               },
               "Cache-Control": {
                 "description": "Cache control header",
-                "schema": { "type": "string", "example": "no-cache" }
+                "schema": {
+                  "type": "string",
+                  "example": "no-cache"
+                }
               },
               "Connection": {
                 "description": "Connection type",
-                "schema": { "type": "string", "example": "keep-alive" }
+                "schema": {
+                  "type": "string",
+                  "example": "keep-alive"
+                }
               }
             }
           },
-          "400": { "description": "Invalid request payload" },
-          "403": { "description": "Subscription required" },
-          "500": { "description": "Internal server error" }
+          "400": {
+            "description": "Invalid request payload"
+          },
+          "403": {
+            "description": "Subscription required"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
         },
         "summary": "Send a message with optional images and receive streaming response",
-        "tags": ["runs"]
+        "tags": [
+          "runs"
+        ]
       }
     },
     "/super-admin/trials": {
@@ -5160,7 +6557,9 @@
           "description": "Trial information",
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/CreateTrialRequestDto" }
+              "schema": {
+                "$ref": "#/components/schemas/CreateTrialRequestDto"
+              }
             }
           }
         },
@@ -5178,10 +6577,14 @@
           "400": {
             "description": "Invalid request format or validation errors."
           },
-          "403": { "description": "The requester is not a super admin." }
+          "403": {
+            "description": "The requester is not a super admin."
+          }
         },
         "summary": "Create a new trial",
-        "tags": ["Super Admin Trials"]
+        "tags": [
+          "Super Admin Trials"
+        ]
       }
     },
     "/super-admin/trials/{orgId}": {
@@ -5194,7 +6597,9 @@
             "required": true,
             "in": "path",
             "description": "The organization ID of the trial to retrieve.",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -5208,11 +6613,17 @@
               }
             }
           },
-          "400": { "description": "Trial not found for the organization." },
-          "403": { "description": "The requester is not a super admin." }
+          "400": {
+            "description": "Trial not found for the organization."
+          },
+          "403": {
+            "description": "The requester is not a super admin."
+          }
         },
         "summary": "Get a trial by organization ID",
-        "tags": ["Super Admin Trials"]
+        "tags": [
+          "Super Admin Trials"
+        ]
       },
       "put": {
         "description": "Update a trial for an organization. Can update maxMessages and/or messagesSent. Only accessible to users with the super admin system role.",
@@ -5223,7 +6634,9 @@
             "required": true,
             "in": "path",
             "description": "The organization ID of the trial to update.",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "requestBody": {
@@ -5231,7 +6644,9 @@
           "description": "Trial update information",
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/UpdateTrialRequestDto" }
+              "schema": {
+                "$ref": "#/components/schemas/UpdateTrialRequestDto"
+              }
             }
           }
         },
@@ -5249,10 +6664,14 @@
           "400": {
             "description": "Invalid request format or validation errors."
           },
-          "403": { "description": "The requester is not a super admin." }
+          "403": {
+            "description": "The requester is not a super admin."
+          }
         },
         "summary": "Update a trial",
-        "tags": ["Super Admin Trials"]
+        "tags": [
+          "Super Admin Trials"
+        ]
       }
     },
     "/usage/config": {
@@ -5273,7 +6692,9 @@
           }
         },
         "summary": "Get usage dashboard configuration",
-        "tags": ["Admin Usage"]
+        "tags": [
+          "Admin Usage"
+        ]
       }
     },
     "/usage/credits": {
@@ -5294,225 +6715,9 @@
           }
         },
         "summary": "Get credit usage for the current month",
-        "tags": ["Admin Usage"]
-      }
-    },
-    "/usage/stats": {
-      "get": {
-        "description": "Returns aggregated usage statistics including total tokens, requests, and active users. Dates are optional - if not provided, shows all usage.",
-        "operationId": "UsageController_getUsageStats",
-        "parameters": [
-          {
-            "name": "startDate",
-            "required": false,
-            "in": "query",
-            "description": "Start date in ISO format. If provided, must be used with endDate.",
-            "schema": {
-              "example": "2024-01-01T00:00:00.000Z",
-              "type": "string"
-            }
-          },
-          {
-            "name": "endDate",
-            "required": false,
-            "in": "query",
-            "description": "End date in ISO format. If provided, must be used with startDate.",
-            "schema": {
-              "example": "2024-01-31T23:59:59.999Z",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Usage statistics retrieved successfully.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/UsageStatsResponseDto"
-                }
-              }
-            }
-          }
-        },
-        "summary": "Get overall usage statistics",
-        "tags": ["Admin Usage"]
-      }
-    },
-    "/usage/providers": {
-      "get": {
-        "description": "Returns usage statistics grouped by model provider (OpenAI, Anthropic, etc.) with optional time series data for trend analysis. Useful for provider comparison charts. Dates are optional - if not provided, shows all usage.",
-        "operationId": "UsageController_getProviderUsage",
-        "parameters": [
-          {
-            "name": "startDate",
-            "required": false,
-            "in": "query",
-            "description": "Start date in ISO format",
-            "schema": {
-              "example": "2024-01-01T00:00:00.000Z",
-              "type": "string"
-            }
-          },
-          {
-            "name": "endDate",
-            "required": false,
-            "in": "query",
-            "description": "End date in ISO format",
-            "schema": {
-              "example": "2024-01-31T23:59:59.999Z",
-              "type": "string"
-            }
-          },
-          {
-            "name": "includeTimeSeries",
-            "required": false,
-            "in": "query",
-            "description": "Whether to include time series data for trend charts. Defaults to true.",
-            "schema": { "example": true, "type": "boolean" }
-          },
-          {
-            "name": "provider",
-            "required": false,
-            "in": "query",
-            "description": "Filter by provider (e.g., openai, anthropic)",
-            "schema": { "example": "openai", "type": "string" }
-          },
-          {
-            "name": "modelId",
-            "required": false,
-            "in": "query",
-            "description": "Filter by model ID",
-            "schema": {
-              "example": "123e4567-e89b-12d3-a456-426614174000",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Provider usage statistics retrieved successfully. Includes percentage distribution and optional time series data.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProviderUsageResponseDto"
-                }
-              }
-            }
-          }
-        },
-        "summary": "Get usage statistics by provider",
-        "tags": ["Admin Usage"]
-      }
-    },
-    "/usage/providers/chart": {
-      "get": {
-        "description": "Returns rows aligned by date with tokens per provider. Shape: { timeSeries: [{ date, values: { [provider]: tokens } }] }",
-        "operationId": "UsageController_getProviderUsageChart",
-        "parameters": [
-          {
-            "name": "startDate",
-            "required": false,
-            "in": "query",
-            "schema": { "type": "string" }
-          },
-          {
-            "name": "endDate",
-            "required": false,
-            "in": "query",
-            "schema": { "type": "string" }
-          },
-          {
-            "name": "provider",
-            "required": false,
-            "in": "query",
-            "description": "Filter by provider (e.g., openai, anthropic)",
-            "schema": { "example": "openai", "type": "string" }
-          },
-          {
-            "name": "modelId",
-            "required": false,
-            "in": "query",
-            "description": "Filter by model ID",
-            "schema": {
-              "example": "123e4567-e89b-12d3-a456-426614174000",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Chart-ready provider time series",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProviderUsageChartResponseDto"
-                }
-              }
-            }
-          }
-        },
-        "summary": "Get provider usage time series aligned by date (chart-ready)",
-        "tags": ["Admin Usage"]
-      }
-    },
-    "/usage/models": {
-      "get": {
-        "description": "Returns usage statistics grouped by individual models with percentage distribution. Dates are optional - if not provided, shows all usage.",
-        "operationId": "UsageController_getModelDistribution",
-        "parameters": [
-          {
-            "name": "startDate",
-            "required": false,
-            "in": "query",
-            "description": "Start date in ISO format",
-            "schema": {
-              "example": "2024-01-01T00:00:00.000Z",
-              "type": "string"
-            }
-          },
-          {
-            "name": "endDate",
-            "required": false,
-            "in": "query",
-            "description": "End date in ISO format",
-            "schema": {
-              "example": "2024-01-31T23:59:59.999Z",
-              "type": "string"
-            }
-          },
-          {
-            "name": "maxModels",
-            "required": false,
-            "in": "query",
-            "description": "Maximum number of models to return. Defaults to 10. Frontend can decide how to handle aggregation if needed.",
-            "schema": { "example": 10, "type": "number" }
-          },
-          {
-            "name": "modelId",
-            "required": false,
-            "in": "query",
-            "description": "Filter by model ID",
-            "schema": {
-              "example": "123e4567-e89b-12d3-a456-426614174000",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Model usage distribution retrieved successfully.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ModelDistributionResponseDto"
-                }
-              }
-            }
-          }
-        },
-        "summary": "Get usage distribution by model",
-        "tags": ["Admin Usage"]
+        "tags": [
+          "Admin Usage"
+        ]
       }
     },
     "/usage/users": {
@@ -5545,21 +6750,30 @@
             "required": false,
             "in": "query",
             "description": "Number of users per page (1-1000). Defaults to 50.",
-            "schema": { "example": 50, "type": "number" }
+            "schema": {
+              "example": 50,
+              "type": "number"
+            }
           },
           {
             "name": "offset",
             "required": false,
             "in": "query",
             "description": "Number of users to skip for pagination. Defaults to 0.",
-            "schema": { "example": 0, "type": "number" }
+            "schema": {
+              "example": 0,
+              "type": "number"
+            }
           },
           {
             "name": "search",
             "required": false,
             "in": "query",
             "description": "Search term to filter users by name or email",
-            "schema": { "example": "john.doe", "type": "string" }
+            "schema": {
+              "example": "john.doe",
+              "type": "string"
+            }
           },
           {
             "name": "sortBy",
@@ -5567,7 +6781,12 @@
             "in": "query",
             "description": "Field to sort users by. Defaults to tokens.",
             "schema": {
-              "enum": ["tokens", "requests", "lastActivity", "userName"],
+              "enum": [
+                "tokens",
+                "requests",
+                "lastActivity",
+                "userName"
+              ],
               "type": "string"
             }
           },
@@ -5576,7 +6795,13 @@
             "required": false,
             "in": "query",
             "description": "Sort order (ascending or descending). Defaults to desc.",
-            "schema": { "enum": ["asc", "desc"], "type": "string" }
+            "schema": {
+              "enum": [
+                "asc",
+                "desc"
+              ],
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -5592,7 +6817,9 @@
           }
         },
         "summary": "Get usage statistics by user",
-        "tags": ["Admin Usage"]
+        "tags": [
+          "Admin Usage"
+        ]
       }
     },
     "/super-admin/usage/{orgId}/config": {
@@ -5604,7 +6831,9 @@
             "required": true,
             "in": "path",
             "description": "Organization ID",
-            "schema": { "format": "uuid" }
+            "schema": {
+              "format": "uuid"
+            }
           }
         ],
         "responses": {
@@ -5620,7 +6849,9 @@
           }
         },
         "summary": "Get usage dashboard configuration for an organization",
-        "tags": ["Super Admin Usage"]
+        "tags": [
+          "Super Admin Usage"
+        ]
       }
     },
     "/super-admin/usage/{orgId}/credits": {
@@ -5633,7 +6864,10 @@
             "required": true,
             "in": "path",
             "description": "Organization ID",
-            "schema": { "format": "uuid", "type": "string" }
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -5649,7 +6883,9 @@
           }
         },
         "summary": "Get credit usage for an organization",
-        "tags": ["Super Admin Usage"]
+        "tags": [
+          "Super Admin Usage"
+        ]
       }
     },
     "/super-admin/usage/{orgId}/stats": {
@@ -5661,19 +6897,26 @@
             "required": true,
             "in": "path",
             "description": "Organization ID",
-            "schema": { "format": "uuid", "type": "string" }
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
           },
           {
             "name": "startDate",
             "required": false,
             "in": "query",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "endDate",
             "required": false,
             "in": "query",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -5689,7 +6932,9 @@
           }
         },
         "summary": "Get overall usage statistics for an organization",
-        "tags": ["Super Admin Usage"]
+        "tags": [
+          "Super Admin Usage"
+        ]
       }
     },
     "/super-admin/usage/{orgId}/models": {
@@ -5701,31 +6946,42 @@
             "required": true,
             "in": "path",
             "description": "Organization ID",
-            "schema": { "format": "uuid", "type": "string" }
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
           },
           {
             "name": "startDate",
             "required": false,
             "in": "query",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "endDate",
             "required": false,
             "in": "query",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "maxModels",
             "required": false,
             "in": "query",
-            "schema": { "type": "number" }
+            "schema": {
+              "type": "number"
+            }
           },
           {
             "name": "modelId",
             "required": false,
             "in": "query",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -5741,7 +6997,9 @@
           }
         },
         "summary": "Get usage distribution by model for an organization",
-        "tags": ["Super Admin Usage"]
+        "tags": [
+          "Super Admin Usage"
+        ]
       }
     },
     "/super-admin/usage/{orgId}/providers": {
@@ -5753,37 +7011,50 @@
             "required": true,
             "in": "path",
             "description": "Organization ID",
-            "schema": { "format": "uuid", "type": "string" }
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
           },
           {
             "name": "startDate",
             "required": false,
             "in": "query",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "endDate",
             "required": false,
             "in": "query",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "includeTimeSeries",
             "required": false,
             "in": "query",
-            "schema": { "type": "boolean" }
+            "schema": {
+              "type": "boolean"
+            }
           },
           {
             "name": "provider",
             "required": false,
             "in": "query",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "modelId",
             "required": false,
             "in": "query",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -5799,7 +7070,9 @@
           }
         },
         "summary": "Get usage statistics by provider for an organization",
-        "tags": ["Super Admin Usage"]
+        "tags": [
+          "Super Admin Usage"
+        ]
       }
     },
     "/super-admin/usage/{orgId}/providers/chart": {
@@ -5811,31 +7084,42 @@
             "required": true,
             "in": "path",
             "description": "Organization ID",
-            "schema": { "format": "uuid", "type": "string" }
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
           },
           {
             "name": "startDate",
             "required": false,
             "in": "query",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "endDate",
             "required": false,
             "in": "query",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "provider",
             "required": false,
             "in": "query",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "modelId",
             "required": false,
             "in": "query",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -5851,7 +7135,9 @@
           }
         },
         "summary": "Get provider usage time series for an organization (chart-ready)",
-        "tags": ["Super Admin Usage"]
+        "tags": [
+          "Super Admin Usage"
+        ]
       }
     },
     "/super-admin/usage/{orgId}/users": {
@@ -5863,44 +7149,62 @@
             "required": true,
             "in": "path",
             "description": "Organization ID",
-            "schema": { "format": "uuid", "type": "string" }
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
           },
           {
             "name": "startDate",
             "required": false,
             "in": "query",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "endDate",
             "required": false,
             "in": "query",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "limit",
             "required": false,
             "in": "query",
-            "schema": { "type": "number" }
+            "schema": {
+              "type": "number"
+            }
           },
           {
             "name": "offset",
             "required": false,
             "in": "query",
-            "schema": { "type": "number" }
+            "schema": {
+              "type": "number"
+            }
           },
           {
             "name": "search",
             "required": false,
             "in": "query",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "sortBy",
             "required": false,
             "in": "query",
             "schema": {
-              "enum": ["tokens", "requests", "lastActivity", "userName"],
+              "enum": [
+                "tokens",
+                "requests",
+                "lastActivity",
+                "userName"
+              ],
               "type": "string"
             }
           },
@@ -5908,7 +7212,13 @@
             "name": "sortOrder",
             "required": false,
             "in": "query",
-            "schema": { "enum": ["asc", "desc"], "type": "string" }
+            "schema": {
+              "enum": [
+                "asc",
+                "desc"
+              ],
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -5924,7 +7234,9 @@
           }
         },
         "summary": "Get usage statistics by user for an organization",
-        "tags": ["Super Admin Usage"]
+        "tags": [
+          "Super Admin Usage"
+        ]
       }
     },
     "/super-admin/global-usage/providers/chart": {
@@ -5935,25 +7247,33 @@
             "name": "startDate",
             "required": false,
             "in": "query",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "endDate",
             "required": false,
             "in": "query",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "provider",
             "required": false,
             "in": "query",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "modelId",
             "required": false,
             "in": "query",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -5969,7 +7289,9 @@
           }
         },
         "summary": "Get global provider usage time series across all organizations (chart-ready)",
-        "tags": ["Super Admin Global Usage"]
+        "tags": [
+          "Super Admin Global Usage"
+        ]
       }
     },
     "/super-admin/global-usage/models": {
@@ -5980,19 +7302,25 @@
             "name": "startDate",
             "required": false,
             "in": "query",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "endDate",
             "required": false,
             "in": "query",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "modelId",
             "required": false,
             "in": "query",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -6008,7 +7336,9 @@
           }
         },
         "summary": "Get global model distribution across all organizations",
-        "tags": ["Super Admin Global Usage"]
+        "tags": [
+          "Super Admin Global Usage"
+        ]
       }
     },
     "/super-admin/global-usage/users": {
@@ -6019,13 +7349,17 @@
             "name": "startDate",
             "required": false,
             "in": "query",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "endDate",
             "required": false,
             "in": "query",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -6041,7 +7375,9 @@
           }
         },
         "summary": "Get top 20 users by token usage across all organizations",
-        "tags": ["Super Admin Global Usage"]
+        "tags": [
+          "Super Admin Global Usage"
+        ]
       }
     },
     "/super-admin/platform-config/credits-per-euro": {
@@ -6066,10 +7402,14 @@
           "404": {
             "description": "Credits-per-euro value has not been configured"
           },
-          "500": { "description": "Internal server error" }
+          "500": {
+            "description": "Internal server error"
+          }
         },
         "summary": "Get the current credits-per-euro configuration",
-        "tags": ["Super Admin Platform Config"]
+        "tags": [
+          "Super Admin Platform Config"
+        ]
       },
       "put": {
         "description": "Update the global credits-per-euro value used for credit calculations. Super admin only.",
@@ -6095,10 +7435,14 @@
           "401": {
             "description": "User not authenticated or not authorized as super admin"
           },
-          "500": { "description": "Internal server error" }
+          "500": {
+            "description": "Internal server error"
+          }
         },
         "summary": "Set the credits-per-euro configuration",
-        "tags": ["Super Admin Platform Config"]
+        "tags": [
+          "Super Admin Platform Config"
+        ]
       }
     },
     "/chat-settings/system-prompt": {
@@ -6119,7 +7463,9 @@
           }
         },
         "summary": "Get the user system prompt",
-        "tags": ["Chat Settings"]
+        "tags": [
+          "Chat Settings"
+        ]
       },
       "put": {
         "description": "Creates or replaces the custom system prompt for the authenticated user.",
@@ -6146,10 +7492,14 @@
               }
             }
           },
-          "400": { "description": "Invalid request payload" }
+          "400": {
+            "description": "Invalid request payload"
+          }
         },
         "summary": "Set or update the user system prompt",
-        "tags": ["Chat Settings"]
+        "tags": [
+          "Chat Settings"
+        ]
       },
       "delete": {
         "description": "Deletes the custom system prompt for the authenticated user.",
@@ -6161,7 +7511,9 @@
           }
         },
         "summary": "Delete the user system prompt",
-        "tags": ["Chat Settings"]
+        "tags": [
+          "Chat Settings"
+        ]
       }
     },
     "/chat-settings/generate-personalized-system-prompt": {
@@ -6190,14 +7542,20 @@
               }
             }
           },
-          "400": { "description": "Invalid request payload" },
+          "400": {
+            "description": "Invalid request payload"
+          },
           "422": {
             "description": "No default model configured for the organization"
           },
-          "500": { "description": "Inference failure during prompt generation" }
+          "500": {
+            "description": "Inference failure during prompt generation"
+          }
         },
         "summary": "Generate a personalized system prompt",
-        "tags": ["Chat Settings"]
+        "tags": [
+          "Chat Settings"
+        ]
       }
     },
     "/prompts": {
@@ -6208,7 +7566,9 @@
           "required": true,
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/CreatePromptDto" }
+              "schema": {
+                "$ref": "#/components/schemas/CreatePromptDto"
+              }
             }
           }
         },
@@ -6217,15 +7577,23 @@
             "description": "The prompt has been successfully created",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/PromptResponseDto" }
+                "schema": {
+                  "$ref": "#/components/schemas/PromptResponseDto"
+                }
               }
             }
           },
-          "400": { "description": "Invalid prompt data" },
-          "500": { "description": "Internal server error" }
+          "400": {
+            "description": "Invalid prompt data"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
         },
         "summary": "Create a new prompt",
-        "tags": ["prompts"]
+        "tags": [
+          "prompts"
+        ]
       },
       "get": {
         "operationId": "PromptsController_findAll",
@@ -6237,15 +7605,21 @@
               "application/json": {
                 "schema": {
                   "type": "array",
-                  "items": { "$ref": "#/components/schemas/PromptResponseDto" }
+                  "items": {
+                    "$ref": "#/components/schemas/PromptResponseDto"
+                  }
                 }
               }
             }
           },
-          "500": { "description": "Internal server error" }
+          "500": {
+            "description": "Internal server error"
+          }
         },
         "summary": "Get all prompts for the current user",
-        "tags": ["prompts"]
+        "tags": [
+          "prompts"
+        ]
       }
     },
     "/prompts/{id}": {
@@ -6257,7 +7631,10 @@
             "required": true,
             "in": "path",
             "description": "The UUID of the prompt to retrieve",
-            "schema": { "format": "uuid", "type": "string" }
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -6265,15 +7642,23 @@
             "description": "Returns the prompt with the specified ID",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/PromptResponseDto" }
+                "schema": {
+                  "$ref": "#/components/schemas/PromptResponseDto"
+                }
               }
             }
           },
-          "404": { "description": "Prompt not found" },
-          "500": { "description": "Internal server error" }
+          "404": {
+            "description": "Prompt not found"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
         },
         "summary": "Get a prompt by ID",
-        "tags": ["prompts"]
+        "tags": [
+          "prompts"
+        ]
       },
       "put": {
         "operationId": "PromptsController_update",
@@ -6283,14 +7668,19 @@
             "required": true,
             "in": "path",
             "description": "The UUID of the prompt to update",
-            "schema": { "format": "uuid", "type": "string" }
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/UpdatePromptDto" }
+              "schema": {
+                "$ref": "#/components/schemas/UpdatePromptDto"
+              }
             }
           }
         },
@@ -6299,16 +7689,26 @@
             "description": "The prompt has been successfully updated",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/PromptResponseDto" }
+                "schema": {
+                  "$ref": "#/components/schemas/PromptResponseDto"
+                }
               }
             }
           },
-          "400": { "description": "Invalid prompt data" },
-          "404": { "description": "Prompt not found" },
-          "500": { "description": "Internal server error" }
+          "400": {
+            "description": "Invalid prompt data"
+          },
+          "404": {
+            "description": "Prompt not found"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
         },
         "summary": "Update a prompt",
-        "tags": ["prompts"]
+        "tags": [
+          "prompts"
+        ]
       },
       "delete": {
         "operationId": "PromptsController_delete",
@@ -6318,16 +7718,27 @@
             "required": true,
             "in": "path",
             "description": "The UUID of the prompt to delete",
-            "schema": { "format": "uuid", "type": "string" }
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
           }
         ],
         "responses": {
-          "204": { "description": "The prompt has been successfully deleted" },
-          "404": { "description": "Prompt not found" },
-          "500": { "description": "Internal server error" }
+          "204": {
+            "description": "The prompt has been successfully deleted"
+          },
+          "404": {
+            "description": "Prompt not found"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
         },
         "summary": "Delete a prompt",
-        "tags": ["prompts"]
+        "tags": [
+          "prompts"
+        ]
       }
     },
     "/transcriptions": {
@@ -6341,7 +7752,9 @@
             "multipart/form-data": {
               "schema": {
                 "type": "object",
-                "required": ["file"],
+                "required": [
+                  "file"
+                ],
                 "properties": {
                   "file": {
                     "type": "string",
@@ -6372,12 +7785,22 @@
           "400": {
             "description": "Invalid request or unsupported audio format"
           },
-          "401": { "description": "Unauthorized" },
-          "500": { "description": "Transcription failed" }
+          "401": {
+            "description": "Unauthorized"
+          },
+          "500": {
+            "description": "Transcription failed"
+          }
         },
-        "security": [{ "bearer": [] }],
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
         "summary": "Transcribe audio file to text",
-        "tags": ["transcriptions"]
+        "tags": [
+          "transcriptions"
+        ]
       }
     },
     "/auth/login": {
@@ -6390,7 +7813,9 @@
           "description": "User credentials for authentication",
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/LoginDto" }
+              "schema": {
+                "$ref": "#/components/schemas/LoginDto"
+              }
             }
           }
         },
@@ -6399,7 +7824,9 @@
             "description": "Login successful. Authentication cookies are set.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/SuccessResponseDto" }
+                "schema": {
+                  "$ref": "#/components/schemas/SuccessResponseDto"
+                }
               }
             }
           },
@@ -6407,7 +7834,9 @@
             "description": "Invalid request format",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponseDto" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponseDto"
+                }
               }
             }
           },
@@ -6415,13 +7844,17 @@
             "description": "Invalid credentials",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponseDto" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponseDto"
+                }
               }
             }
           }
         },
         "summary": "User login",
-        "tags": ["Authentication"]
+        "tags": [
+          "Authentication"
+        ]
       }
     },
     "/auth/register": {
@@ -6434,7 +7867,9 @@
           "description": "User registration information",
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/RegisterDto" }
+              "schema": {
+                "$ref": "#/components/schemas/RegisterDto"
+              }
             }
           }
         },
@@ -6443,7 +7878,9 @@
             "description": "Registration successful. User is automatically logged in and authentication cookies are set.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/SuccessResponseDto" }
+                "schema": {
+                  "$ref": "#/components/schemas/SuccessResponseDto"
+                }
               }
             }
           },
@@ -6451,7 +7888,9 @@
             "description": "Invalid request format or validation errors",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponseDto" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponseDto"
+                }
               }
             }
           },
@@ -6459,13 +7898,17 @@
             "description": "User with this email already exists",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponseDto" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponseDto"
+                }
               }
             }
           }
         },
         "summary": "User registration",
-        "tags": ["Authentication"]
+        "tags": [
+          "Authentication"
+        ]
       }
     },
     "/auth/refresh": {
@@ -6478,7 +7921,9 @@
             "description": "Token refresh successful. New authentication cookies are set.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/SuccessResponseDto" }
+                "schema": {
+                  "$ref": "#/components/schemas/SuccessResponseDto"
+                }
               }
             }
           },
@@ -6486,7 +7931,9 @@
             "description": "Invalid or expired refresh token",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponseDto" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponseDto"
+                }
               }
             }
           },
@@ -6494,14 +7941,22 @@
             "description": "Authentication configuration error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponseDto" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponseDto"
+                }
               }
             }
           }
         },
-        "security": [{ "refreshToken": [] }],
+        "security": [
+          {
+            "refreshToken": []
+          }
+        ],
         "summary": "Refresh authentication tokens",
-        "tags": ["Authentication"]
+        "tags": [
+          "Authentication"
+        ]
       }
     },
     "/auth/me": {
@@ -6514,7 +7969,9 @@
             "description": "User information retrieved successfully. If tokens were refreshed, new cookies are set.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/MeResponseDto" }
+                "schema": {
+                  "$ref": "#/components/schemas/MeResponseDto"
+                }
               }
             }
           },
@@ -6522,7 +7979,9 @@
             "description": "Not authenticated - no valid tokens found",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponseDto" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponseDto"
+                }
               }
             }
           },
@@ -6530,13 +7989,17 @@
             "description": "Authentication configuration error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponseDto" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponseDto"
+                }
               }
             }
           }
         },
         "summary": "Get current user information",
-        "tags": ["Authentication"]
+        "tags": [
+          "Authentication"
+        ]
       }
     },
     "/auth/logout": {
@@ -6549,13 +8012,17 @@
             "description": "Logout successful. Authentication cookies are cleared.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/SuccessResponseDto" }
+                "schema": {
+                  "$ref": "#/components/schemas/SuccessResponseDto"
+                }
               }
             }
           }
         },
         "summary": "User logout",
-        "tags": ["Authentication"]
+        "tags": [
+          "Authentication"
+        ]
       }
     }
   },
@@ -6565,7 +8032,12 @@
     "version": "1.0",
     "contact": {}
   },
-  "tags": [{ "name": "ayunis", "description": "" }],
+  "tags": [
+    {
+      "name": "ayunis",
+      "description": ""
+    }
+  ],
   "servers": [],
   "components": {
     "schemas": {
@@ -6583,7 +8055,10 @@
             "example": false
           }
         },
-        "required": ["isCloud", "isRegistrationDisabled"]
+        "required": [
+          "isCloud",
+          "isRegistrationDisabled"
+        ]
       },
       "FeatureTogglesResponseDto": {
         "type": "object",
@@ -6619,13 +8094,19 @@
       "ModelWithConfigResponseDto": {
         "type": "object",
         "properties": {
-          "modelId": { "type": "string", "description": "The id of the model" },
+          "modelId": {
+            "type": "string",
+            "description": "The id of the model"
+          },
           "permittedModelId": {
             "type": "string",
             "description": "The id of the model. Null if the model is not permitted.",
             "nullable": true
           },
-          "name": { "type": "string", "description": "The name of the model" },
+          "name": {
+            "type": "string",
+            "description": "The name of the model"
+          },
           "provider": {
             "type": "string",
             "enum": [
@@ -6727,12 +8208,22 @@
           },
           "hostedIn": {
             "type": "string",
-            "enum": ["DE", "EU", "US", "SELF_HOSTED", "AYUNIS"],
+            "enum": [
+              "DE",
+              "EU",
+              "US",
+              "SELF_HOSTED",
+              "AYUNIS"
+            ],
             "description": "The location where the provider hosts their services",
             "example": "US"
           }
         },
-        "required": ["provider", "displayName", "hostedIn"]
+        "required": [
+          "provider",
+          "displayName",
+          "hostedIn"
+        ]
       },
       "CreatePermittedModelDto": {
         "type": "object",
@@ -6749,7 +8240,9 @@
             "default": false
           }
         },
-        "required": ["modelId"]
+        "required": [
+          "modelId"
+        ]
       },
       "UpdatePermittedModelDto": {
         "type": "object",
@@ -6760,7 +8253,9 @@
             "example": true
           }
         },
-        "required": ["anonymousOnly"]
+        "required": [
+          "anonymousOnly"
+        ]
       },
       "PermittedLanguageModelResponseDto": {
         "type": "object",
@@ -6769,7 +8264,10 @@
             "type": "string",
             "description": "The id of the permitted model"
           },
-          "name": { "type": "string", "description": "The name of the model" },
+          "name": {
+            "type": "string",
+            "description": "The name of the model"
+          },
           "provider": {
             "type": "string",
             "enum": [
@@ -6798,7 +8296,9 @@
           },
           "type": {
             "type": "string",
-            "enum": ["language"],
+            "enum": [
+              "language"
+            ],
             "description": "The type of the model (always language)"
           },
           "isArchived": {
@@ -6849,7 +8349,9 @@
             ]
           }
         },
-        "required": ["permittedLanguageModel"]
+        "required": [
+          "permittedLanguageModel"
+        ]
       },
       "SetUserDefaultModelDto": {
         "type": "object",
@@ -6860,7 +8362,9 @@
             "example": "123e4567-e89b-12d3-a456-426614174000"
           }
         },
-        "required": ["permittedModelId"]
+        "required": [
+          "permittedModelId"
+        ]
       },
       "SetOrgDefaultModelDto": {
         "type": "object",
@@ -6871,7 +8375,9 @@
             "example": "123e4567-e89b-12d3-a456-426614174000"
           }
         },
-        "required": ["permittedModelId"]
+        "required": [
+          "permittedModelId"
+        ]
       },
       "EmbeddingModelEnabledResponseDto": {
         "type": "object",
@@ -6882,7 +8388,9 @@
             "example": true
           }
         },
-        "required": ["isEmbeddingModelEnabled"]
+        "required": [
+          "isEmbeddingModelEnabled"
+        ]
       },
       "PermittedEmbeddingModelResponseDto": {
         "type": "object",
@@ -6891,7 +8399,10 @@
             "type": "string",
             "description": "The id of the permitted model"
           },
-          "name": { "type": "string", "description": "The name of the model" },
+          "name": {
+            "type": "string",
+            "description": "The name of the model"
+          },
           "provider": {
             "type": "string",
             "enum": [
@@ -6920,7 +8431,9 @@
           },
           "type": {
             "type": "string",
-            "enum": ["embedding"],
+            "enum": [
+              "embedding"
+            ],
             "description": "The type of the model (always embedding)"
           },
           "isArchived": {
@@ -7003,21 +8516,15 @@
           },
           "inputTokenCost": {
             "type": "number",
-            "description": "Cost per million input tokens (in the specified currency)",
+            "description": "Cost per million input tokens in EUR",
             "example": 3,
             "minimum": 0
           },
           "outputTokenCost": {
             "type": "number",
-            "description": "Cost per million output tokens (in the specified currency)",
+            "description": "Cost per million output tokens in EUR",
             "example": 15,
             "minimum": 0
-          },
-          "currency": {
-            "type": "string",
-            "description": "Currency for token costs",
-            "enum": ["EUR", "USD"],
-            "example": "EUR"
           }
         },
         "required": [
@@ -7090,21 +8597,15 @@
           },
           "inputTokenCost": {
             "type": "number",
-            "description": "Cost per million input tokens (in the specified currency)",
+            "description": "Cost per million input tokens in EUR",
             "example": 3,
             "minimum": 0
           },
           "outputTokenCost": {
             "type": "number",
-            "description": "Cost per million output tokens (in the specified currency)",
+            "description": "Cost per million output tokens in EUR",
             "example": 15,
             "minimum": 0
-          },
-          "currency": {
-            "type": "string",
-            "description": "Currency for token costs",
-            "enum": ["EUR", "USD"],
-            "example": "EUR"
           }
         },
         "required": [
@@ -7153,7 +8654,11 @@
           "dimensions": {
             "type": "number",
             "description": "The dimensions of the embedding",
-            "enum": [1024, 1536, 2560],
+            "enum": [
+              1024,
+              1536,
+              2560
+            ],
             "example": 1536
           },
           "isArchived": {
@@ -7163,21 +8668,15 @@
           },
           "inputTokenCost": {
             "type": "number",
-            "description": "Cost per million input tokens (in the specified currency)",
+            "description": "Cost per million input tokens in EUR",
             "example": 0.13,
             "minimum": 0
           },
           "outputTokenCost": {
             "type": "number",
-            "description": "Cost per million output tokens (in the specified currency)",
+            "description": "Cost per million output tokens in EUR",
             "example": 0,
             "minimum": 0
-          },
-          "currency": {
-            "type": "string",
-            "description": "Currency for token costs",
-            "enum": ["EUR", "USD"],
-            "example": "EUR"
           }
         },
         "required": [
@@ -7223,7 +8722,11 @@
           "dimensions": {
             "type": "number",
             "description": "The dimensions of the embedding",
-            "enum": [1024, 1536, 2560],
+            "enum": [
+              1024,
+              1536,
+              2560
+            ],
             "example": 1536
           },
           "isArchived": {
@@ -7233,21 +8736,15 @@
           },
           "inputTokenCost": {
             "type": "number",
-            "description": "Cost per million input tokens (in the specified currency)",
+            "description": "Cost per million input tokens in EUR",
             "example": 0.13,
             "minimum": 0
           },
           "outputTokenCost": {
             "type": "number",
-            "description": "Cost per million output tokens (in the specified currency)",
+            "description": "Cost per million output tokens in EUR",
             "example": 0,
             "minimum": 0
-          },
-          "currency": {
-            "type": "string",
-            "description": "Currency for token costs",
-            "enum": ["EUR", "USD"],
-            "example": "EUR"
           }
         },
         "required": [
@@ -7298,7 +8795,9 @@
           },
           "type": {
             "type": "string",
-            "enum": ["language"],
+            "enum": [
+              "language"
+            ],
             "description": "The type of the model (always language)"
           },
           "isArchived": {
@@ -7338,19 +8837,13 @@
           },
           "inputTokenCost": {
             "type": "number",
-            "description": "Cost per million input tokens",
+            "description": "Cost per million input tokens in EUR",
             "example": 3
           },
           "outputTokenCost": {
             "type": "number",
-            "description": "Cost per million output tokens",
+            "description": "Cost per million output tokens in EUR",
             "example": 15
-          },
-          "currency": {
-            "type": "string",
-            "enum": ["EUR", "USD"],
-            "description": "Currency for token costs",
-            "example": "EUR"
           }
         },
         "required": [
@@ -7408,7 +8901,9 @@
           },
           "type": {
             "type": "string",
-            "enum": ["embedding"],
+            "enum": [
+              "embedding"
+            ],
             "description": "The type of the model (always embedding)"
           },
           "isArchived": {
@@ -7441,19 +8936,13 @@
           },
           "inputTokenCost": {
             "type": "number",
-            "description": "Cost per million input tokens",
+            "description": "Cost per million input tokens in EUR",
             "example": 0.13
           },
           "outputTokenCost": {
             "type": "number",
-            "description": "Cost per million output tokens",
+            "description": "Cost per million output tokens in EUR",
             "example": 0
-          },
-          "currency": {
-            "type": "string",
-            "enum": ["EUR", "USD"],
-            "description": "Currency for token costs",
-            "example": "EUR"
           }
         },
         "required": [
@@ -7477,7 +8966,9 @@
             "example": "Acme Corporation"
           }
         },
-        "required": ["name"]
+        "required": [
+          "name"
+        ]
       },
       "SuperAdminOrgResponseDto": {
         "type": "object",
@@ -7500,7 +8991,11 @@
             "example": "2024-01-15T10:30:00Z"
           }
         },
-        "required": ["id", "name", "createdAt"]
+        "required": [
+          "id",
+          "name",
+          "createdAt"
+        ]
       },
       "PaginationDto": {
         "type": "object",
@@ -7521,7 +9016,10 @@
             "example": 150
           }
         },
-        "required": ["limit", "offset"]
+        "required": [
+          "limit",
+          "offset"
+        ]
       },
       "SuperAdminOrgListResponseDto": {
         "type": "object",
@@ -7529,14 +9027,23 @@
           "data": {
             "description": "Array of organizations for the current page",
             "type": "array",
-            "items": { "$ref": "#/components/schemas/SuperAdminOrgResponseDto" }
+            "items": {
+              "$ref": "#/components/schemas/SuperAdminOrgResponseDto"
+            }
           },
           "pagination": {
             "description": "Pagination metadata",
-            "allOf": [{ "$ref": "#/components/schemas/PaginationDto" }]
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PaginationDto"
+              }
+            ]
           }
         },
-        "required": ["data", "pagination"]
+        "required": [
+          "data",
+          "pagination"
+        ]
       },
       "UserResponseDto": {
         "type": "object",
@@ -7560,7 +9067,10 @@
           "role": {
             "type": "string",
             "description": "User role",
-            "enum": ["admin", "user"],
+            "enum": [
+              "admin",
+              "user"
+            ],
             "example": "user"
           },
           "orgId": {
@@ -7576,7 +9086,14 @@
             "example": "2024-01-15T10:30:00Z"
           }
         },
-        "required": ["id", "name", "email", "role", "orgId", "createdAt"]
+        "required": [
+          "id",
+          "name",
+          "email",
+          "role",
+          "orgId",
+          "createdAt"
+        ]
       },
       "PaginatedUsersListResponseDto": {
         "type": "object",
@@ -7584,14 +9101,23 @@
           "data": {
             "description": "Array of users for the current page",
             "type": "array",
-            "items": { "$ref": "#/components/schemas/UserResponseDto" }
+            "items": {
+              "$ref": "#/components/schemas/UserResponseDto"
+            }
           },
           "pagination": {
             "description": "Pagination metadata",
-            "allOf": [{ "$ref": "#/components/schemas/PaginationDto" }]
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PaginationDto"
+              }
+            ]
           }
         },
-        "required": ["data", "pagination"]
+        "required": [
+          "data",
+          "pagination"
+        ]
       },
       "UpdateUserRoleDto": {
         "type": "object",
@@ -7599,11 +9125,16 @@
           "role": {
             "type": "string",
             "description": "New role for the user",
-            "enum": ["admin", "user"],
+            "enum": [
+              "admin",
+              "user"
+            ],
             "example": "admin"
           }
         },
-        "required": ["role"]
+        "required": [
+          "role"
+        ]
       },
       "UpdateUserNameDto": {
         "type": "object",
@@ -7616,7 +9147,9 @@
             "maxLength": 100
           }
         },
-        "required": ["name"]
+        "required": [
+          "name"
+        ]
       },
       "UpdatePasswordDto": {
         "type": "object",
@@ -7655,7 +9188,9 @@
             "example": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
           }
         },
-        "required": ["token"]
+        "required": [
+          "token"
+        ]
       },
       "ResendEmailConfirmationDto": {
         "type": "object",
@@ -7667,7 +9202,9 @@
             "format": "email"
           }
         },
-        "required": ["email"]
+        "required": [
+          "email"
+        ]
       },
       "ForgotPasswordDto": {
         "type": "object",
@@ -7678,7 +9215,9 @@
             "example": "user@example.com"
           }
         },
-        "required": ["email"]
+        "required": [
+          "email"
+        ]
       },
       "ResetPasswordDto": {
         "type": "object",
@@ -7701,7 +9240,11 @@
             "minLength": 8
           }
         },
-        "required": ["resetToken", "newPassword", "newPasswordConfirmation"]
+        "required": [
+          "resetToken",
+          "newPassword",
+          "newPasswordConfirmation"
+        ]
       },
       "CreateUserDto": {
         "type": "object",
@@ -7719,7 +9262,10 @@
           "role": {
             "type": "string",
             "description": "Role for the user",
-            "enum": ["admin", "user"],
+            "enum": [
+              "admin",
+              "user"
+            ],
             "example": "user"
           },
           "sendPasswordResetEmail": {
@@ -7728,7 +9274,12 @@
             "example": true
           }
         },
-        "required": ["email", "name", "role", "sendPasswordResetEmail"]
+        "required": [
+          "email",
+          "name",
+          "role",
+          "sendPasswordResetEmail"
+        ]
       },
       "SuperAdminUserResponseDto": {
         "type": "object",
@@ -7752,7 +9303,10 @@
           "role": {
             "type": "string",
             "description": "User role",
-            "enum": ["admin", "user"],
+            "enum": [
+              "admin",
+              "user"
+            ],
             "example": "user"
           },
           "orgId": {
@@ -7770,7 +9324,10 @@
           "systemRole": {
             "type": "string",
             "description": "System-level role of the user",
-            "enum": ["customer", "super_admin"],
+            "enum": [
+              "customer",
+              "super_admin"
+            ],
             "example": "super_admin"
           }
         },
@@ -7793,7 +9350,9 @@
             "example": "user@example.com"
           }
         },
-        "required": ["email"]
+        "required": [
+          "email"
+        ]
       },
       "CreateInviteDto": {
         "type": "object",
@@ -7806,11 +9365,17 @@
           "role": {
             "type": "string",
             "description": "Role to assign to the invited user",
-            "enum": ["admin", "user"],
+            "enum": [
+              "admin",
+              "user"
+            ],
             "example": "user"
           }
         },
-        "required": ["email", "role"]
+        "required": [
+          "email",
+          "role"
+        ]
       },
       "CreateInviteResponseDto": {
         "type": "object",
@@ -7822,7 +9387,9 @@
             "nullable": true
           }
         },
-        "required": ["url"]
+        "required": [
+          "url"
+        ]
       },
       "CreateBulkInviteItemDto": {
         "type": "object",
@@ -7835,11 +9402,17 @@
           "role": {
             "type": "string",
             "description": "Role to assign to the invited user",
-            "enum": ["admin", "user"],
+            "enum": [
+              "admin",
+              "user"
+            ],
             "example": "user"
           }
         },
-        "required": ["email", "role"]
+        "required": [
+          "email",
+          "role"
+        ]
       },
       "CreateBulkInvitesDto": {
         "type": "object",
@@ -7849,10 +9422,14 @@
             "maxItems": 500,
             "minItems": 1,
             "type": "array",
-            "items": { "$ref": "#/components/schemas/CreateBulkInviteItemDto" }
+            "items": {
+              "$ref": "#/components/schemas/CreateBulkInviteItemDto"
+            }
           }
         },
-        "required": ["invites"]
+        "required": [
+          "invites"
+        ]
       },
       "BulkInviteResultDto": {
         "type": "object",
@@ -7865,7 +9442,10 @@
           "role": {
             "type": "string",
             "description": "Role assigned to the invited user",
-            "enum": ["admin", "user"],
+            "enum": [
+              "admin",
+              "user"
+            ],
             "example": "user"
           },
           "success": {
@@ -7922,10 +9502,17 @@
           "results": {
             "description": "Individual results for each invite",
             "type": "array",
-            "items": { "$ref": "#/components/schemas/BulkInviteResultDto" }
+            "items": {
+              "$ref": "#/components/schemas/BulkInviteResultDto"
+            }
           }
         },
-        "required": ["totalCount", "successCount", "failureCount", "results"]
+        "required": [
+          "totalCount",
+          "successCount",
+          "failureCount",
+          "results"
+        ]
       },
       "InviteResponseDto": {
         "type": "object",
@@ -7944,13 +9531,20 @@
           "role": {
             "type": "string",
             "description": "Role assigned to the invited user",
-            "enum": ["admin", "user"],
+            "enum": [
+              "admin",
+              "user"
+            ],
             "example": "user"
           },
           "status": {
             "type": "string",
             "description": "Current status of the invite",
-            "enum": ["pending", "accepted", "expired"],
+            "enum": [
+              "pending",
+              "accepted",
+              "expired"
+            ],
             "example": "pending"
           },
           "sentDate": {
@@ -7972,7 +9566,14 @@
             "example": "2023-12-02T15:30:00Z"
           }
         },
-        "required": ["id", "email", "role", "status", "sentDate", "expiresAt"]
+        "required": [
+          "id",
+          "email",
+          "role",
+          "status",
+          "sentDate",
+          "expiresAt"
+        ]
       },
       "PaginatedInvitesListResponseDto": {
         "type": "object",
@@ -7980,14 +9581,23 @@
           "data": {
             "description": "Array of invites for the current page",
             "type": "array",
-            "items": { "$ref": "#/components/schemas/InviteResponseDto" }
+            "items": {
+              "$ref": "#/components/schemas/InviteResponseDto"
+            }
           },
           "pagination": {
             "description": "Pagination metadata",
-            "allOf": [{ "$ref": "#/components/schemas/PaginationDto" }]
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PaginationDto"
+              }
+            ]
           }
         },
-        "required": ["data", "pagination"]
+        "required": [
+          "data",
+          "pagination"
+        ]
       },
       "InviteDetailResponseDto": {
         "type": "object",
@@ -8006,13 +9616,20 @@
           "role": {
             "type": "string",
             "description": "Role assigned to the invited user",
-            "enum": ["admin", "user"],
+            "enum": [
+              "admin",
+              "user"
+            ],
             "example": "user"
           },
           "status": {
             "type": "string",
             "description": "Current status of the invite",
-            "enum": ["pending", "accepted", "expired"],
+            "enum": [
+              "pending",
+              "accepted",
+              "expired"
+            ],
             "example": "pending"
           },
           "sentDate": {
@@ -8101,7 +9718,11 @@
             "format": "uuid"
           }
         },
-        "required": ["inviteId", "email", "orgId"]
+        "required": [
+          "inviteId",
+          "email",
+          "orgId"
+        ]
       },
       "DeleteAllPendingInvitesResponseDto": {
         "type": "object",
@@ -8111,7 +9732,9 @@
             "description": "Number of invites deleted"
           }
         },
-        "required": ["deletedCount"]
+        "required": [
+          "deletedCount"
+        ]
       },
       "ActiveSubscriptionResponseDto": {
         "type": "object",
@@ -8122,7 +9745,9 @@
             "example": true
           }
         },
-        "required": ["hasActiveSubscription"]
+        "required": [
+          "hasActiveSubscription"
+        ]
       },
       "PriceResponseDto": {
         "type": "object",
@@ -8133,7 +9758,9 @@
             "example": 29.99
           }
         },
-        "required": ["pricePerSeatMonthly"]
+        "required": [
+          "pricePerSeatMonthly"
+        ]
       },
       "SubscriptionBillingInfoResponseDto": {
         "type": "object",
@@ -8218,7 +9845,10 @@
           "type": {
             "type": "string",
             "description": "Subscription type",
-            "enum": ["SEAT_BASED", "USAGE_BASED"],
+            "enum": [
+              "SEAT_BASED",
+              "USAGE_BASED"
+            ],
             "example": "SEAT_BASED"
           },
           "noOfSeats": {
@@ -8234,7 +9864,10 @@
           "renewalCycle": {
             "type": "string",
             "description": "Renewal cycle of the subscription (seat-based only)",
-            "enum": ["monthly", "yearly"],
+            "enum": [
+              "monthly",
+              "yearly"
+            ],
             "example": "monthly"
           },
           "renewalCycleAnchor": {
@@ -8285,7 +9918,9 @@
           "subscription": {
             "description": "Subscription",
             "allOf": [
-              { "$ref": "#/components/schemas/SubscriptionResponseDto" }
+              {
+                "$ref": "#/components/schemas/SubscriptionResponseDto"
+              }
             ]
           }
         }
@@ -8331,7 +9966,10 @@
           "type": {
             "type": "string",
             "description": "Subscription type. Defaults to SEAT_BASED if not specified.",
-            "enum": ["SEAT_BASED", "USAGE_BASED"],
+            "enum": [
+              "SEAT_BASED",
+              "USAGE_BASED"
+            ],
             "example": "SEAT_BASED",
             "default": "SEAT_BASED"
           },
@@ -8411,7 +10049,10 @@
           "country"
         ]
       },
-      "UpdateSeatsDto": { "type": "object", "properties": {} },
+      "UpdateSeatsDto": {
+        "type": "object",
+        "properties": {}
+      },
       "UploadFileResponseDto": {
         "type": "object",
         "properties": {
@@ -8442,7 +10083,11 @@
             "example": "2024-01-01T00:00:00.000Z"
           }
         },
-        "required": ["objectName", "size", "etag"]
+        "required": [
+          "objectName",
+          "size",
+          "etag"
+        ]
       },
       "RetrieveUrlDto": {
         "type": "object",
@@ -8453,7 +10098,9 @@
             "example": "https://example.com/article"
           }
         },
-        "required": ["url"]
+        "required": [
+          "url"
+        ]
       },
       "CreateThreadDto": {
         "type": "object",
@@ -8500,7 +10147,9 @@
             "type": "string",
             "description": "Role of the message sender",
             "example": "user",
-            "enum": ["user"]
+            "enum": [
+              "user"
+            ]
           },
           "content": {
             "type": "array",
@@ -8517,7 +10166,13 @@
             }
           }
         },
-        "required": ["id", "threadId", "createdAt", "role", "content"]
+        "required": [
+          "id",
+          "threadId",
+          "createdAt",
+          "role",
+          "content"
+        ]
       },
       "SystemMessageResponseDto": {
         "type": "object",
@@ -8541,7 +10196,9 @@
             "type": "string",
             "description": "Role of the message sender",
             "example": "system",
-            "enum": ["system"]
+            "enum": [
+              "system"
+            ]
           },
           "content": {
             "type": "array",
@@ -8551,7 +10208,13 @@
             }
           }
         },
-        "required": ["id", "threadId", "createdAt", "role", "content"]
+        "required": [
+          "id",
+          "threadId",
+          "createdAt",
+          "role",
+          "content"
+        ]
       },
       "AssistantMessageResponseDto": {
         "type": "object",
@@ -8575,7 +10238,9 @@
             "type": "string",
             "description": "Role of the message sender",
             "example": "assistant",
-            "enum": ["assistant"]
+            "enum": [
+              "assistant"
+            ]
           },
           "content": {
             "type": "array",
@@ -8595,7 +10260,13 @@
             }
           }
         },
-        "required": ["id", "threadId", "createdAt", "role", "content"]
+        "required": [
+          "id",
+          "threadId",
+          "createdAt",
+          "role",
+          "content"
+        ]
       },
       "ToolResultMessageResponseDto": {
         "type": "object",
@@ -8619,7 +10290,9 @@
             "type": "string",
             "description": "Role of the message sender",
             "example": "tool",
-            "enum": ["tool"]
+            "enum": [
+              "tool"
+            ]
           },
           "content": {
             "type": "array",
@@ -8629,7 +10302,13 @@
             }
           }
         },
-        "required": ["id", "threadId", "createdAt", "role", "content"]
+        "required": [
+          "id",
+          "threadId",
+          "createdAt",
+          "role",
+          "content"
+        ]
       },
       "TextMessageContentResponseDto": {
         "type": "object",
@@ -8638,7 +10317,13 @@
             "type": "string",
             "description": "Type of the message content",
             "example": "text",
-            "enum": ["text", "tool_use", "tool_result", "thinking", "image"]
+            "enum": [
+              "text",
+              "tool_use",
+              "tool_result",
+              "thinking",
+              "image"
+            ]
           },
           "text": {
             "type": "string",
@@ -8651,7 +10336,10 @@
             "example": false
           }
         },
-        "required": ["type", "text"]
+        "required": [
+          "type",
+          "text"
+        ]
       },
       "ToolUseIntegrationDto": {
         "type": "object",
@@ -8673,7 +10361,10 @@
             "nullable": true
           }
         },
-        "required": ["id", "name"]
+        "required": [
+          "id",
+          "name"
+        ]
       },
       "ToolUseMessageContentResponseDto": {
         "type": "object",
@@ -8682,7 +10373,13 @@
             "type": "string",
             "description": "Type of the message content",
             "example": "text",
-            "enum": ["text", "tool_use", "tool_result", "thinking", "image"]
+            "enum": [
+              "text",
+              "tool_use",
+              "tool_result",
+              "thinking",
+              "image"
+            ]
           },
           "id": {
             "type": "string",
@@ -8697,14 +10394,26 @@
           "params": {
             "type": "object",
             "description": "Parameters passed to the tool",
-            "example": { "location": "New York", "unit": "celsius" }
+            "example": {
+              "location": "New York",
+              "unit": "celsius"
+            }
           },
           "integration": {
             "description": "Integration metadata if this tool belongs to a marketplace integration",
-            "allOf": [{ "$ref": "#/components/schemas/ToolUseIntegrationDto" }]
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ToolUseIntegrationDto"
+              }
+            ]
           }
         },
-        "required": ["type", "id", "name", "params"]
+        "required": [
+          "type",
+          "id",
+          "name",
+          "params"
+        ]
       },
       "ToolResultMessageContentResponseDto": {
         "type": "object",
@@ -8713,7 +10422,13 @@
             "type": "string",
             "description": "Type of the message content",
             "example": "text",
-            "enum": ["text", "tool_use", "tool_result", "thinking", "image"]
+            "enum": [
+              "text",
+              "tool_use",
+              "tool_result",
+              "thinking",
+              "image"
+            ]
           },
           "toolId": {
             "type": "string",
@@ -8731,7 +10446,12 @@
             "example": "The current temperature in New York is 22°C with partly cloudy skies."
           }
         },
-        "required": ["type", "toolId", "toolName", "result"]
+        "required": [
+          "type",
+          "toolId",
+          "toolName",
+          "result"
+        ]
       },
       "ThinkingMessageContentResponseDto": {
         "type": "object",
@@ -8740,7 +10460,13 @@
             "type": "string",
             "description": "Type of the message content",
             "example": "text",
-            "enum": ["text", "tool_use", "tool_result", "thinking", "image"]
+            "enum": [
+              "text",
+              "tool_use",
+              "tool_result",
+              "thinking",
+              "image"
+            ]
           },
           "thinking": {
             "type": "string",
@@ -8748,7 +10474,10 @@
             "example": "I am thinking about the best way to help you."
           }
         },
-        "required": ["type", "thinking"]
+        "required": [
+          "type",
+          "thinking"
+        ]
       },
       "ImageMessageContentResponseDto": {
         "type": "object",
@@ -8757,7 +10486,13 @@
             "type": "string",
             "description": "Type of the message content",
             "example": "text",
-            "enum": ["text", "tool_use", "tool_result", "thinking", "image"]
+            "enum": [
+              "text",
+              "tool_use",
+              "tool_result",
+              "thinking",
+              "image"
+            ]
           },
           "imageUrl": {
             "type": "string",
@@ -8770,7 +10505,10 @@
             "example": "Screenshot of the reported issue"
           }
         },
-        "required": ["type", "imageUrl"]
+        "required": [
+          "type",
+          "imageUrl"
+        ]
       },
       "ModelResponseDto": {
         "type": "object",
@@ -8827,16 +10565,26 @@
             "type": "string",
             "description": "Thread ID this source belongs to"
           },
-          "name": { "type": "string", "description": "Name of the source" },
+          "name": {
+            "type": "string",
+            "description": "Name of the source"
+          },
           "type": {
             "type": "string",
             "description": "Type of source",
-            "enum": ["text", "data"]
+            "enum": [
+              "text",
+              "data"
+            ]
           },
           "createdBy": {
             "type": "string",
             "description": "Creator of the source",
-            "enum": ["user", "llm", "system"]
+            "enum": [
+              "user",
+              "llm",
+              "system"
+            ]
           },
           "createdAt": {
             "type": "string",
@@ -8868,16 +10616,26 @@
             "type": "string",
             "description": "Thread ID this source belongs to"
           },
-          "name": { "type": "string", "description": "Name of the source" },
+          "name": {
+            "type": "string",
+            "description": "Name of the source"
+          },
           "type": {
             "type": "string",
             "description": "Type of source",
-            "enum": ["text", "data"]
+            "enum": [
+              "text",
+              "data"
+            ]
           },
           "createdBy": {
             "type": "string",
             "description": "Creator of the source",
-            "enum": ["user", "llm", "system"]
+            "enum": [
+              "user",
+              "llm",
+              "system"
+            ]
           },
           "createdAt": {
             "type": "string",
@@ -8890,12 +10648,20 @@
           "textType": {
             "type": "string",
             "description": "Type of text",
-            "enum": ["file", "web"]
+            "enum": [
+              "file",
+              "web"
+            ]
           },
           "fileType": {
             "type": "string",
             "description": "Type of file",
-            "enum": ["pdf", "docx", "pptx", "txt"]
+            "enum": [
+              "pdf",
+              "docx",
+              "pptx",
+              "txt"
+            ]
           }
         },
         "required": [
@@ -8921,16 +10687,26 @@
             "type": "string",
             "description": "Thread ID this source belongs to"
           },
-          "name": { "type": "string", "description": "Name of the source" },
+          "name": {
+            "type": "string",
+            "description": "Name of the source"
+          },
           "type": {
             "type": "string",
             "description": "Type of source",
-            "enum": ["text", "data"]
+            "enum": [
+              "text",
+              "data"
+            ]
           },
           "createdBy": {
             "type": "string",
             "description": "Creator of the source",
-            "enum": ["user", "llm", "system"]
+            "enum": [
+              "user",
+              "llm",
+              "system"
+            ]
           },
           "createdAt": {
             "type": "string",
@@ -8943,9 +10719,15 @@
           "textType": {
             "type": "string",
             "description": "Type of text",
-            "enum": ["file", "web"]
+            "enum": [
+              "file",
+              "web"
+            ]
           },
-          "url": { "type": "string", "description": "URL of the source" }
+          "url": {
+            "type": "string",
+            "description": "URL of the source"
+          }
         },
         "required": [
           "id",
@@ -8970,16 +10752,26 @@
             "type": "string",
             "description": "Thread ID this source belongs to"
           },
-          "name": { "type": "string", "description": "Name of the source" },
+          "name": {
+            "type": "string",
+            "description": "Name of the source"
+          },
           "type": {
             "type": "string",
             "description": "Type of source",
-            "enum": ["text", "data"]
+            "enum": [
+              "text",
+              "data"
+            ]
           },
           "createdBy": {
             "type": "string",
             "description": "Creator of the source",
-            "enum": ["user", "llm", "system"]
+            "enum": [
+              "user",
+              "llm",
+              "system"
+            ]
           },
           "createdAt": {
             "type": "string",
@@ -8992,7 +10784,9 @@
           "dataType": {
             "type": "string",
             "description": "Type of data",
-            "enum": ["csv"]
+            "enum": [
+              "csv"
+            ]
           },
           "data": {
             "type": "object",
@@ -9001,12 +10795,19 @@
             "properties": {
               "headers": {
                 "type": "array",
-                "items": { "type": "string" },
+                "items": {
+                  "type": "string"
+                },
                 "description": "Column headers"
               },
               "rows": {
                 "type": "array",
-                "items": { "type": "array", "items": { "type": "string" } },
+                "items": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
                 "description": "Data rows"
               }
             }
@@ -9038,7 +10839,10 @@
             "example": "Municipal Zoning Guidelines"
           }
         },
-        "required": ["id", "name"]
+        "required": [
+          "id",
+          "name"
+        ]
       },
       "GetThreadResponseDto": {
         "type": "object",
@@ -9073,17 +10877,27 @@
             "description": "Array of messages in the thread (role-specific types)",
             "items": {
               "oneOf": [
-                { "$ref": "#/components/schemas/UserMessageResponseDto" },
-                { "$ref": "#/components/schemas/SystemMessageResponseDto" },
-                { "$ref": "#/components/schemas/AssistantMessageResponseDto" },
-                { "$ref": "#/components/schemas/ToolResultMessageResponseDto" }
+                {
+                  "$ref": "#/components/schemas/UserMessageResponseDto"
+                },
+                {
+                  "$ref": "#/components/schemas/SystemMessageResponseDto"
+                },
+                {
+                  "$ref": "#/components/schemas/AssistantMessageResponseDto"
+                },
+                {
+                  "$ref": "#/components/schemas/ToolResultMessageResponseDto"
+                }
               ]
             }
           },
           "sources": {
             "type": "array",
             "description": "Array of sources in the thread",
-            "items": { "$ref": "#/components/schemas/SourceResponseDto" }
+            "items": {
+              "$ref": "#/components/schemas/SourceResponseDto"
+            }
           },
           "createdAt": {
             "type": "string",
@@ -9156,7 +10970,12 @@
             "example": false
           }
         },
-        "required": ["id", "createdAt", "updatedAt", "isAnonymous"]
+        "required": [
+          "id",
+          "createdAt",
+          "updatedAt",
+          "isAnonymous"
+        ]
       },
       "GetThreadsResponseDto": {
         "type": "object",
@@ -9170,10 +10989,17 @@
           },
           "pagination": {
             "description": "Pagination metadata",
-            "allOf": [{ "$ref": "#/components/schemas/PaginationDto" }]
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PaginationDto"
+              }
+            ]
           }
         },
-        "required": ["data", "pagination"]
+        "required": [
+          "data",
+          "pagination"
+        ]
       },
       "UpdateThreadTitleDto": {
         "type": "object",
@@ -9186,7 +11012,9 @@
             "maxLength": 200
           }
         },
-        "required": ["title"]
+        "required": [
+          "title"
+        ]
       },
       "ToolAssignmentDto": {
         "type": "object",
@@ -9227,7 +11055,9 @@
             "format": "uuid"
           }
         },
-        "required": ["type"]
+        "required": [
+          "type"
+        ]
       },
       "CreateAgentDto": {
         "type": "object",
@@ -9253,10 +11083,17 @@
           "toolAssignments": {
             "description": "The tools to assign to the agent",
             "type": "array",
-            "items": { "$ref": "#/components/schemas/ToolAssignmentDto" }
+            "items": {
+              "$ref": "#/components/schemas/ToolAssignmentDto"
+            }
           }
         },
-        "required": ["name", "instructions", "modelId", "toolAssignments"]
+        "required": [
+          "name",
+          "instructions",
+          "modelId",
+          "toolAssignments"
+        ]
       },
       "ToolResponseDto": {
         "type": "object",
@@ -9291,7 +11128,9 @@
             ]
           }
         },
-        "required": ["type"]
+        "required": [
+          "type"
+        ]
       },
       "AgentSourceResponseDto": {
         "type": "object",
@@ -9317,10 +11156,18 @@
             "type": "string",
             "description": "The type of source",
             "example": "file",
-            "enum": ["file", "url"]
+            "enum": [
+              "file",
+              "url"
+            ]
           }
         },
-        "required": ["id", "sourceId", "name", "type"]
+        "required": [
+          "id",
+          "sourceId",
+          "name",
+          "type"
+        ]
       },
       "AgentResponseDto": {
         "type": "object",
@@ -9366,17 +11213,25 @@
               "name": "gpt-4",
               "provider": "openai"
             },
-            "allOf": [{ "$ref": "#/components/schemas/ModelResponseDto" }]
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ModelResponseDto"
+              }
+            ]
           },
           "tools": {
             "description": "The tools assigned to this agent",
             "type": "array",
-            "items": { "$ref": "#/components/schemas/ToolResponseDto" }
+            "items": {
+              "$ref": "#/components/schemas/ToolResponseDto"
+            }
           },
           "sources": {
             "description": "The sources assigned to this agent",
             "type": "array",
-            "items": { "$ref": "#/components/schemas/AgentSourceResponseDto" }
+            "items": {
+              "$ref": "#/components/schemas/AgentSourceResponseDto"
+            }
           },
           "isShared": {
             "type": "boolean",
@@ -9426,7 +11281,11 @@
             "format": "uuid"
           }
         },
-        "required": ["name", "instructions", "modelId"]
+        "required": [
+          "name",
+          "instructions",
+          "modelId"
+        ]
       },
       "McpIntegrationResponseDto": {
         "type": "object",
@@ -9444,7 +11303,11 @@
           "type": {
             "type": "string",
             "description": "Type of integration",
-            "enum": ["predefined", "custom", "marketplace"],
+            "enum": [
+              "predefined",
+              "custom",
+              "marketplace"
+            ],
             "example": "predefined"
           },
           "slug": {
@@ -9470,7 +11333,12 @@
           "authMethod": {
             "type": "string",
             "description": "Authentication method used",
-            "enum": ["NO_AUTH", "BEARER_TOKEN", "CUSTOM_HEADER", "OAUTH"],
+            "enum": [
+              "NO_AUTH",
+              "BEARER_TOKEN",
+              "CUSTOM_HEADER",
+              "OAUTH"
+            ],
             "example": "BEARER_TOKEN"
           },
           "authHeaderName": {
@@ -9486,7 +11354,12 @@
           "connectionStatus": {
             "type": "string",
             "description": "Connection status of the integration",
-            "enum": ["connected", "disconnected", "error", "unknown"],
+            "enum": [
+              "connected",
+              "disconnected",
+              "error",
+              "unknown"
+            ],
             "example": "connected"
           },
           "lastConnectionError": {
@@ -9569,7 +11442,12 @@
           "entityType": {
             "type": "string",
             "description": "Type of entity being shared",
-            "enum": ["agent", "prompt", "skill", "knowledge_base"]
+            "enum": [
+              "agent",
+              "prompt",
+              "skill",
+              "knowledge_base"
+            ]
           },
           "agentId": {
             "type": "string",
@@ -9582,7 +11460,10 @@
             "format": "uuid"
           }
         },
-        "required": ["entityType", "agentId"]
+        "required": [
+          "entityType",
+          "agentId"
+        ]
       },
       "ShareResponseDto": {
         "type": "object",
@@ -9595,7 +11476,12 @@
           "entityType": {
             "type": "string",
             "description": "Type of entity being shared",
-            "enum": ["agent", "prompt", "skill", "knowledge_base"]
+            "enum": [
+              "agent",
+              "prompt",
+              "skill",
+              "knowledge_base"
+            ]
           },
           "entityId": {
             "type": "string",
@@ -9605,7 +11491,10 @@
           "scopeType": {
             "type": "string",
             "description": "Type of share scope (organization, user, or team)",
-            "enum": ["org", "team"]
+            "enum": [
+              "org",
+              "team"
+            ]
           },
           "ownerId": {
             "type": "string",
@@ -9648,7 +11537,12 @@
           "entityType": {
             "type": "string",
             "description": "Type of entity being shared",
-            "enum": ["agent", "prompt", "skill", "knowledge_base"]
+            "enum": [
+              "agent",
+              "prompt",
+              "skill",
+              "knowledge_base"
+            ]
           },
           "skillId": {
             "type": "string",
@@ -9661,7 +11555,10 @@
             "format": "uuid"
           }
         },
-        "required": ["entityType", "skillId"]
+        "required": [
+          "entityType",
+          "skillId"
+        ]
       },
       "CreateKnowledgeBaseShareDto": {
         "type": "object",
@@ -9669,7 +11566,12 @@
           "entityType": {
             "type": "string",
             "description": "Type of entity being shared",
-            "enum": ["agent", "prompt", "skill", "knowledge_base"]
+            "enum": [
+              "agent",
+              "prompt",
+              "skill",
+              "knowledge_base"
+            ]
           },
           "knowledgeBaseId": {
             "type": "string",
@@ -9682,7 +11584,10 @@
             "format": "uuid"
           }
         },
-        "required": ["entityType", "knowledgeBaseId"]
+        "required": [
+          "entityType",
+          "knowledgeBaseId"
+        ]
       },
       "CreateTeamDto": {
         "type": "object",
@@ -9693,7 +11598,9 @@
             "example": "Engineering"
           }
         },
-        "required": ["name"]
+        "required": [
+          "name"
+        ]
       },
       "UpdateTeamDto": {
         "type": "object",
@@ -9704,7 +11611,9 @@
             "example": "Engineering"
           }
         },
-        "required": ["name"]
+        "required": [
+          "name"
+        ]
       },
       "TeamResponseDto": {
         "type": "object",
@@ -9737,7 +11646,13 @@
             "example": "2024-01-15T10:30:00.000Z"
           }
         },
-        "required": ["id", "name", "orgId", "createdAt", "updatedAt"]
+        "required": [
+          "id",
+          "name",
+          "orgId",
+          "createdAt",
+          "updatedAt"
+        ]
       },
       "TeamMemberResponseDto": {
         "type": "object",
@@ -9765,7 +11680,10 @@
           "userRole": {
             "type": "string",
             "description": "The role of the team member in the organization",
-            "enum": ["admin", "user"],
+            "enum": [
+              "admin",
+              "user"
+            ],
             "example": "user"
           },
           "joinedAt": {
@@ -9790,14 +11708,23 @@
           "data": {
             "description": "Array of team members for the current page",
             "type": "array",
-            "items": { "$ref": "#/components/schemas/TeamMemberResponseDto" }
+            "items": {
+              "$ref": "#/components/schemas/TeamMemberResponseDto"
+            }
           },
           "pagination": {
             "description": "Pagination metadata",
-            "allOf": [{ "$ref": "#/components/schemas/PaginationDto" }]
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PaginationDto"
+              }
+            ]
           }
         },
-        "required": ["data", "pagination"]
+        "required": [
+          "data",
+          "pagination"
+        ]
       },
       "AddTeamMemberDto": {
         "type": "object",
@@ -9808,7 +11735,9 @@
             "example": "550e8400-e29b-41d4-a716-446655440001"
           }
         },
-        "required": ["userId"]
+        "required": [
+          "userId"
+        ]
       },
       "ListTeamMembersQueryDto": {
         "type": "object",
@@ -9833,7 +11762,11 @@
           "name": {
             "type": "string",
             "description": "The name/type of the credential field",
-            "enum": ["token", "clientId", "clientSecret"],
+            "enum": [
+              "token",
+              "clientId",
+              "clientSecret"
+            ],
             "example": "token"
           },
           "value": {
@@ -9842,7 +11775,10 @@
             "example": "sk_test_123abc"
           }
         },
-        "required": ["name", "value"]
+        "required": [
+          "name",
+          "value"
+        ]
       },
       "CreatePredefinedIntegrationDto": {
         "type": "object",
@@ -9851,13 +11787,24 @@
             "type": "string",
             "description": "The predefined integration slug",
             "example": "TEST",
-            "enum": ["TEST", "LOCABOO", "LEGAL_CODES"]
+            "enum": [
+              "TEST",
+              "LOCABOO",
+              "LEGAL_CODES"
+            ]
           },
           "configValues": {
             "description": "List of config values for credential fields",
-            "example": [{ "name": "token", "value": "sk_test_123abc" }],
+            "example": [
+              {
+                "name": "token",
+                "value": "sk_test_123abc"
+              }
+            ],
             "type": "array",
-            "items": { "$ref": "#/components/schemas/ConfigValueDto" }
+            "items": {
+              "$ref": "#/components/schemas/ConfigValueDto"
+            }
           },
           "returnsPii": {
             "type": "boolean",
@@ -9866,7 +11813,10 @@
             "default": true
           }
         },
-        "required": ["slug", "configValues"]
+        "required": [
+          "slug",
+          "configValues"
+        ]
       },
       "CreateCustomIntegrationDto": {
         "type": "object",
@@ -9886,7 +11836,12 @@
           "authMethod": {
             "type": "string",
             "description": "Authentication method for the MCP server",
-            "enum": ["NO_AUTH", "BEARER_TOKEN", "CUSTOM_HEADER", "OAUTH"],
+            "enum": [
+              "NO_AUTH",
+              "BEARER_TOKEN",
+              "CUSTOM_HEADER",
+              "OAUTH"
+            ],
             "example": "CUSTOM_HEADER",
             "nullable": true
           },
@@ -9907,7 +11862,10 @@
             "default": true
           }
         },
-        "required": ["name", "serverUrl"]
+        "required": [
+          "name",
+          "serverUrl"
+        ]
       },
       "CredentialFieldDto": {
         "type": "object",
@@ -9920,7 +11878,11 @@
           "type": {
             "type": "string",
             "description": "Input type (text or password)",
-            "enum": ["token", "clientId", "clientSecret"],
+            "enum": [
+              "token",
+              "clientId",
+              "clientSecret"
+            ],
             "example": "token"
           },
           "required": {
@@ -9934,7 +11896,11 @@
             "example": "Your Locaboo 3 API token will be used to authenticate with Locaboo 4"
           }
         },
-        "required": ["label", "type", "required"]
+        "required": [
+          "label",
+          "type",
+          "required"
+        ]
       },
       "PredefinedConfigResponseDto": {
         "type": "object",
@@ -9957,7 +11923,12 @@
           "authType": {
             "type": "string",
             "description": "Authentication method for this integration",
-            "enum": ["NO_AUTH", "BEARER_TOKEN", "API_KEY", "OAUTH"],
+            "enum": [
+              "NO_AUTH",
+              "BEARER_TOKEN",
+              "API_KEY",
+              "OAUTH"
+            ],
             "example": "BEARER_TOKEN"
           },
           "authHeaderName": {
@@ -9968,10 +11939,17 @@
           "credentialFields": {
             "description": "Credential fields required for this integration",
             "type": "array",
-            "items": { "$ref": "#/components/schemas/CredentialFieldDto" }
+            "items": {
+              "$ref": "#/components/schemas/CredentialFieldDto"
+            }
           }
         },
-        "required": ["slug", "displayName", "description", "authType"]
+        "required": [
+          "slug",
+          "displayName",
+          "description",
+          "authType"
+        ]
       },
       "UpdateMcpIntegrationDto": {
         "type": "object",
@@ -10001,7 +11979,9 @@
           "orgConfigValues": {
             "type": "object",
             "description": "Org-level config values for marketplace integrations. For secret fields, omit or send empty string to keep the existing value.",
-            "example": { "endpointUrl": "https://example.com/api" }
+            "example": {
+              "endpointUrl": "https://example.com/api"
+            }
           }
         }
       },
@@ -10016,8 +11996,12 @@
           "orgConfigValues": {
             "type": "object",
             "description": "Organization-level configuration values (key-value pairs matching config schema orgFields)",
-            "example": { "oparlEndpointUrl": "https://rim.ekom21.de/oparl/v1" },
-            "additionalProperties": { "type": "string" }
+            "example": {
+              "oparlEndpointUrl": "https://rim.ekom21.de/oparl/v1"
+            },
+            "additionalProperties": {
+              "type": "string"
+            }
           },
           "returnsPii": {
             "type": "boolean",
@@ -10025,7 +12009,10 @@
             "example": false
           }
         },
-        "required": ["identifier", "orgConfigValues"]
+        "required": [
+          "identifier",
+          "orgConfigValues"
+        ]
       },
       "UserConfigResponseDto": {
         "type": "object",
@@ -10038,11 +12025,18 @@
           "configValues": {
             "type": "object",
             "description": "Configuration values with secret values masked (keys present, values replaced with \"••••••\")",
-            "example": { "personalToken": "••••••" },
-            "additionalProperties": { "type": "string" }
+            "example": {
+              "personalToken": "••••••"
+            },
+            "additionalProperties": {
+              "type": "string"
+            }
           }
         },
-        "required": ["hasConfig", "configValues"]
+        "required": [
+          "hasConfig",
+          "configValues"
+        ]
       },
       "SetUserConfigDto": {
         "type": "object",
@@ -10050,11 +12044,17 @@
           "configValues": {
             "type": "object",
             "description": "User-level configuration values (key-value pairs matching config schema userFields)",
-            "example": { "personalToken": "my-personal-access-token" },
-            "additionalProperties": { "type": "string" }
+            "example": {
+              "personalToken": "my-personal-access-token"
+            },
+            "additionalProperties": {
+              "type": "string"
+            }
           }
         },
-        "required": ["configValues"]
+        "required": [
+          "configValues"
+        ]
       },
       "ValidationResponseDto": {
         "type": "object",
@@ -10067,7 +12067,11 @@
           "capabilities": {
             "type": "object",
             "description": "Discovered capabilities from the MCP server",
-            "example": { "tools": 5, "resources": 3, "prompts": 2 }
+            "example": {
+              "tools": 5,
+              "resources": 3,
+              "prompts": 2
+            }
           },
           "error": {
             "type": "string",
@@ -10075,17 +12079,26 @@
             "example": "Connection timeout"
           }
         },
-        "required": ["valid", "capabilities"]
+        "required": [
+          "valid",
+          "capabilities"
+        ]
       },
       "MarketplaceSkillResponseDto": {
         "type": "object",
         "properties": {
-          "id": { "type": "string", "description": "Skill UUID" },
+          "id": {
+            "type": "string",
+            "description": "Skill UUID"
+          },
           "identifier": {
             "type": "string",
             "description": "Unique identifier (slug)"
           },
-          "name": { "type": "string", "description": "Display name" },
+          "name": {
+            "type": "string",
+            "description": "Display name"
+          },
           "shortDescription": {
             "type": "string",
             "description": "Short description for marketplace display"
@@ -10157,7 +12170,11 @@
           "type": {
             "type": "string",
             "description": "Field type",
-            "enum": ["text", "url", "secret"]
+            "enum": [
+              "text",
+              "url",
+              "secret"
+            ]
           },
           "headerName": {
             "type": "string",
@@ -10184,7 +12201,12 @@
             "nullable": true
           }
         },
-        "required": ["key", "label", "type", "required"]
+        "required": [
+          "key",
+          "label",
+          "type",
+          "required"
+        ]
       },
       "MarketplaceIntegrationConfigSchemaDto": {
         "type": "object",
@@ -10208,17 +12230,27 @@
             }
           }
         },
-        "required": ["authType", "orgFields", "userFields"]
+        "required": [
+          "authType",
+          "orgFields",
+          "userFields"
+        ]
       },
       "MarketplaceIntegrationResponseDto": {
         "type": "object",
         "properties": {
-          "id": { "type": "string", "description": "Integration UUID" },
+          "id": {
+            "type": "string",
+            "description": "Integration UUID"
+          },
           "identifier": {
             "type": "string",
             "description": "Unique identifier (slug)"
           },
-          "name": { "type": "string", "description": "Display name" },
+          "name": {
+            "type": "string",
+            "description": "Display name"
+          },
           "shortDescription": {
             "type": "string",
             "description": "Short description for marketplace display"
@@ -10242,7 +12274,10 @@
             "description": "Category UUID from the marketplace",
             "nullable": true
           },
-          "serverUrl": { "type": "string", "description": "MCP server URL" },
+          "serverUrl": {
+            "type": "string",
+            "description": "MCP server URL"
+          },
           "configSchema": {
             "description": "Configuration schema (authType, orgFields, userFields, oauth)",
             "allOf": [
@@ -10314,7 +12349,9 @@
             "maxLength": 2000
           }
         },
-        "required": ["name"]
+        "required": [
+          "name"
+        ]
       },
       "KnowledgeBaseResponseDto": {
         "type": "object",
@@ -10353,7 +12390,13 @@
             "example": false
           }
         },
-        "required": ["id", "name", "description", "createdAt", "updatedAt"]
+        "required": [
+          "id",
+          "name",
+          "description",
+          "createdAt",
+          "updatedAt"
+        ]
       },
       "KnowledgeBaseListResponseDto": {
         "type": "object",
@@ -10361,10 +12404,14 @@
           "data": {
             "description": "The list of knowledge bases",
             "type": "array",
-            "items": { "$ref": "#/components/schemas/KnowledgeBaseResponseDto" }
+            "items": {
+              "$ref": "#/components/schemas/KnowledgeBaseResponseDto"
+            }
           }
         },
-        "required": ["data"]
+        "required": [
+          "data"
+        ]
       },
       "UpdateKnowledgeBaseDto": {
         "type": "object",
@@ -10401,13 +12448,20 @@
           "type": {
             "type": "string",
             "description": "The type of the source",
-            "enum": ["text", "data"],
+            "enum": [
+              "text",
+              "data"
+            ],
             "example": "text"
           },
           "createdBy": {
             "type": "string",
             "description": "Who created the source",
-            "enum": ["user", "llm", "system"],
+            "enum": [
+              "user",
+              "llm",
+              "system"
+            ],
             "example": "user"
           },
           "createdAt": {
@@ -10425,7 +12479,10 @@
           "textType": {
             "type": "string",
             "description": "The text source subtype (e.g. file, web)",
-            "enum": ["file", "web"],
+            "enum": [
+              "file",
+              "web"
+            ],
             "example": "web"
           },
           "url": {
@@ -10454,7 +12511,9 @@
             }
           }
         },
-        "required": ["data"]
+        "required": [
+          "data"
+        ]
       },
       "AddUrlToKnowledgeBaseDto": {
         "type": "object",
@@ -10465,7 +12524,9 @@
             "example": "https://example.com/page"
           }
         },
-        "required": ["url"]
+        "required": [
+          "url"
+        ]
       },
       "InstallSkillFromMarketplaceDto": {
         "type": "object",
@@ -10476,7 +12537,9 @@
             "example": "meeting-summarizer"
           }
         },
-        "required": ["identifier"]
+        "required": [
+          "identifier"
+        ]
       },
       "SkillResponseDto": {
         "type": "object",
@@ -10582,7 +12645,11 @@
             "example": true
           }
         },
-        "required": ["name", "shortDescription", "instructions"]
+        "required": [
+          "name",
+          "shortDescription",
+          "instructions"
+        ]
       },
       "UpdateSkillDto": {
         "type": "object",
@@ -10605,7 +12672,11 @@
             "example": "You are a legal research assistant. When activated, search through the attached legal databases..."
           }
         },
-        "required": ["name", "shortDescription", "instructions"]
+        "required": [
+          "name",
+          "shortDescription",
+          "instructions"
+        ]
       },
       "SkillSourceResponseDto": {
         "type": "object",
@@ -10627,7 +12698,11 @@
             "example": "file"
           }
         },
-        "required": ["id", "name", "type"]
+        "required": [
+          "id",
+          "name",
+          "type"
+        ]
       },
       "CreateSkillTemplateDto": {
         "type": "object",
@@ -10652,7 +12727,10 @@
           "distributionMode": {
             "type": "string",
             "description": "The distribution mode of the skill template",
-            "enum": ["always_on", "pre_created_copy"],
+            "enum": [
+              "always_on",
+              "pre_created_copy"
+            ],
             "example": "always_on"
           },
           "isActive": {
@@ -10704,7 +12782,10 @@
           },
           "distributionMode": {
             "type": "string",
-            "enum": ["always_on", "pre_created_copy"],
+            "enum": [
+              "always_on",
+              "pre_created_copy"
+            ],
             "description": "The distribution mode of the skill template",
             "example": "always_on"
           },
@@ -10772,7 +12853,10 @@
           "distributionMode": {
             "type": "string",
             "description": "The distribution mode of the skill template",
-            "enum": ["always_on", "pre_created_copy"],
+            "enum": [
+              "always_on",
+              "pre_created_copy"
+            ],
             "example": "always_on"
           },
           "isActive": {
@@ -10814,11 +12898,19 @@
           "authorType": {
             "type": "string",
             "description": "Who authored this version",
-            "enum": ["USER", "ASSISTANT"],
+            "enum": [
+              "USER",
+              "ASSISTANT"
+            ],
             "example": "ASSISTANT"
           }
         },
-        "required": ["title", "content", "threadId", "authorType"]
+        "required": [
+          "title",
+          "content",
+          "threadId",
+          "authorType"
+        ]
       },
       "ArtifactVersionResponseDto": {
         "type": "object",
@@ -10846,7 +12938,10 @@
           "authorType": {
             "type": "string",
             "description": "Who authored this version",
-            "enum": ["USER", "ASSISTANT"],
+            "enum": [
+              "USER",
+              "ASSISTANT"
+            ],
             "example": "ASSISTANT"
           },
           "authorId": {
@@ -10937,11 +13032,17 @@
           "authorType": {
             "type": "string",
             "description": "Who authored this version",
-            "enum": ["USER", "ASSISTANT"],
+            "enum": [
+              "USER",
+              "ASSISTANT"
+            ],
             "example": "USER"
           }
         },
-        "required": ["content", "authorType"]
+        "required": [
+          "content",
+          "authorType"
+        ]
       },
       "RevertArtifactDto": {
         "type": "object",
@@ -10952,7 +13053,9 @@
             "example": 1
           }
         },
-        "required": ["versionNumber"]
+        "required": [
+          "versionNumber"
+        ]
       },
       "MessageContentResponseDto": {
         "type": "object",
@@ -10961,10 +13064,18 @@
             "type": "string",
             "description": "Type of the message content",
             "example": "text",
-            "enum": ["text", "tool_use", "tool_result", "thinking", "image"]
+            "enum": [
+              "text",
+              "tool_use",
+              "tool_result",
+              "thinking",
+              "image"
+            ]
           }
         },
-        "required": ["type"]
+        "required": [
+          "type"
+        ]
       },
       "RunSessionResponseDto": {
         "type": "object",
@@ -10973,7 +13084,9 @@
             "type": "string",
             "description": "Response type identifier",
             "example": "session",
-            "enum": ["session"]
+            "enum": [
+              "session"
+            ]
           },
           "success": {
             "type": "boolean",
@@ -10996,7 +13109,11 @@
             "example": "2024-01-01T12:00:00.000Z"
           }
         },
-        "required": ["type", "threadId", "timestamp"]
+        "required": [
+          "type",
+          "threadId",
+          "timestamp"
+        ]
       },
       "RunMessageResponseDto": {
         "type": "object",
@@ -11005,15 +13122,25 @@
             "type": "string",
             "description": "Response type identifier",
             "example": "message",
-            "enum": ["message"]
+            "enum": [
+              "message"
+            ]
           },
           "message": {
             "description": "The message data",
             "oneOf": [
-              { "$ref": "#/components/schemas/UserMessageResponseDto" },
-              { "$ref": "#/components/schemas/AssistantMessageResponseDto" },
-              { "$ref": "#/components/schemas/ToolResultMessageResponseDto" },
-              { "$ref": "#/components/schemas/SystemMessageResponseDto" }
+              {
+                "$ref": "#/components/schemas/UserMessageResponseDto"
+              },
+              {
+                "$ref": "#/components/schemas/AssistantMessageResponseDto"
+              },
+              {
+                "$ref": "#/components/schemas/ToolResultMessageResponseDto"
+              },
+              {
+                "$ref": "#/components/schemas/SystemMessageResponseDto"
+              }
             ]
           },
           "threadId": {
@@ -11027,7 +13154,12 @@
             "example": "2024-01-01T12:00:00.000Z"
           }
         },
-        "required": ["type", "message", "threadId", "timestamp"]
+        "required": [
+          "type",
+          "message",
+          "threadId",
+          "timestamp"
+        ]
       },
       "RunErrorResponseDto": {
         "type": "object",
@@ -11036,7 +13168,9 @@
             "type": "string",
             "description": "Response type identifier",
             "example": "error",
-            "enum": ["error"]
+            "enum": [
+              "error"
+            ]
           },
           "message": {
             "type": "string",
@@ -11061,10 +13195,17 @@
           "details": {
             "type": "object",
             "description": "Optional additional error details",
-            "example": { "originalError": "Network timeout" }
+            "example": {
+              "originalError": "Network timeout"
+            }
           }
         },
-        "required": ["type", "message", "threadId", "timestamp"]
+        "required": [
+          "type",
+          "message",
+          "threadId",
+          "timestamp"
+        ]
       },
       "RunThreadResponseDto": {
         "type": "object",
@@ -11073,7 +13214,9 @@
             "type": "string",
             "description": "Response type identifier",
             "example": "thread",
-            "enum": ["thread"]
+            "enum": [
+              "thread"
+            ]
           },
           "threadId": {
             "type": "string",
@@ -11084,7 +13227,9 @@
             "type": "string",
             "description": "Type of thread update",
             "example": "title_updated",
-            "enum": ["title_updated"]
+            "enum": [
+              "title_updated"
+            ]
           },
           "title": {
             "type": "string",
@@ -11097,7 +13242,13 @@
             "example": "2024-01-01T12:00:00.000Z"
           }
         },
-        "required": ["type", "threadId", "updateType", "title", "timestamp"]
+        "required": [
+          "type",
+          "threadId",
+          "updateType",
+          "title",
+          "timestamp"
+        ]
       },
       "TextInput": {
         "type": "object",
@@ -11105,7 +13256,9 @@
           "type": {
             "type": "string",
             "description": "The type of input",
-            "enum": ["text"],
+            "enum": [
+              "text"
+            ],
             "example": "text"
           },
           "text": {
@@ -11114,7 +13267,10 @@
             "example": "What is the weather forecast for New York tomorrow?"
           }
         },
-        "required": ["type", "text"]
+        "required": [
+          "type",
+          "text"
+        ]
       },
       "ToolResultInput": {
         "type": "object",
@@ -11122,7 +13278,9 @@
           "type": {
             "type": "string",
             "description": "The type of input",
-            "enum": ["tool_result"],
+            "enum": [
+              "tool_result"
+            ],
             "example": "tool_result"
           },
           "toolId": {
@@ -11141,7 +13299,12 @@
             "example": "{\"location\":\"New York\",\"forecast\":\"Partly cloudy with a high of 75°F and a low of 60°F\",\"precipitation\":\"20%\"}"
           }
         },
-        "required": ["type", "toolId", "toolName", "result"]
+        "required": [
+          "type",
+          "toolId",
+          "toolName",
+          "result"
+        ]
       },
       "SendMessageDto": {
         "type": "object",
@@ -11159,12 +13322,22 @@
           "imageAltTexts": {
             "type": "array",
             "description": "JSON array of alt texts matching the order of uploaded images",
-            "items": { "type": "string" }
+            "items": {
+              "type": "string"
+            }
           },
           "toolResult": {
             "description": "Tool result input (for tool_result type only)",
-            "oneOf": [{ "$ref": "#/components/schemas/ToolResultInput" }],
-            "allOf": [{ "$ref": "#/components/schemas/ToolResultInput" }]
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/ToolResultInput"
+              }
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ToolResultInput"
+              }
+            ]
           },
           "skillId": {
             "type": "string",
@@ -11178,7 +13351,9 @@
             "default": true
           }
         },
-        "required": ["threadId"]
+        "required": [
+          "threadId"
+        ]
       },
       "SuperAdminTrialResponseDto": {
         "type": "object",
@@ -11235,7 +13410,9 @@
           "trial": {
             "description": "Trial",
             "allOf": [
-              { "$ref": "#/components/schemas/SuperAdminTrialResponseDto" }
+              {
+                "$ref": "#/components/schemas/SuperAdminTrialResponseDto"
+              }
             ]
           }
         }
@@ -11256,7 +13433,10 @@
             "minimum": 1
           }
         },
-        "required": ["orgId", "maxMessages"]
+        "required": [
+          "orgId",
+          "maxMessages"
+        ]
       },
       "UpdateTrialRequestDto": {
         "type": "object",
@@ -11284,7 +13464,9 @@
             "example": true
           }
         },
-        "required": ["isSelfHosted"]
+        "required": [
+          "isSelfHosted"
+        ]
       },
       "CreditUsageResponseDto": {
         "type": "object",
@@ -11307,7 +13489,79 @@
             "nullable": true
           }
         },
-        "required": ["monthlyCredits", "creditsUsed", "creditsRemaining"]
+        "required": [
+          "monthlyCredits",
+          "creditsUsed",
+          "creditsRemaining"
+        ]
+      },
+      "UserUsageDto": {
+        "type": "object",
+        "properties": {
+          "userId": {
+            "type": "string",
+            "description": "User ID"
+          },
+          "userName": {
+            "type": "string",
+            "description": "User name"
+          },
+          "userEmail": {
+            "type": "string",
+            "description": "User email"
+          },
+          "tokens": {
+            "type": "number",
+            "description": "Total tokens for this user"
+          },
+          "requests": {
+            "type": "number",
+            "description": "Total requests for this user"
+          },
+          "lastActivity": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Last activity date (null if no activity)",
+            "nullable": true
+          },
+          "isActive": {
+            "type": "boolean",
+            "description": "Whether the user is considered active"
+          }
+        },
+        "required": [
+          "userId",
+          "userName",
+          "userEmail",
+          "tokens",
+          "requests",
+          "lastActivity",
+          "isActive"
+        ]
+      },
+      "UserUsageResponseDto": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "description": "User usage statistics",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/UserUsageDto"
+            }
+          },
+          "pagination": {
+            "description": "Pagination metadata",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PaginationDto"
+              }
+            ]
+          }
+        },
+        "required": [
+          "data",
+          "pagination"
+        ]
       },
       "UsageStatsResponseDto": {
         "type": "object",
@@ -11334,9 +13588,15 @@
           },
           "topModels": {
             "description": "List of the most frequently used model names, ordered by usage",
-            "example": ["gpt-4", "claude-3-sonnet", "gpt-3.5-turbo"],
+            "example": [
+              "gpt-4",
+              "claude-3-sonnet",
+              "gpt-3.5-turbo"
+            ],
             "type": "array",
-            "items": { "type": "string" }
+            "items": {
+              "type": "string"
+            }
           }
         },
         "required": [
@@ -11347,134 +13607,17 @@
           "topModels"
         ]
       },
-      "TimeSeriesPointDto": {
-        "type": "object",
-        "properties": {
-          "date": {
-            "format": "date-time",
-            "type": "string",
-            "description": "Date of the data point"
-          },
-          "tokens": {
-            "type": "number",
-            "description": "Number of tokens at this point"
-          },
-          "requests": {
-            "type": "number",
-            "description": "Number of requests at this point"
-          }
-        },
-        "required": ["date", "tokens", "requests"]
-      },
-      "ProviderUsageDto": {
-        "type": "object",
-        "properties": {
-          "provider": {
-            "type": "string",
-            "enum": [
-              "openai",
-              "anthropic",
-              "bedrock",
-              "mistral",
-              "ollama",
-              "synaforce",
-              "ayunis",
-              "otc",
-              "azure",
-              "gemini",
-              "stackit",
-              "scaleway"
-            ],
-            "description": "Model provider"
-          },
-          "tokens": {
-            "type": "number",
-            "description": "Total tokens for this provider"
-          },
-          "requests": {
-            "type": "number",
-            "description": "Total requests for this provider"
-          },
-          "percentage": {
-            "type": "number",
-            "description": "Percentage of total usage"
-          },
-          "timeSeriesData": {
-            "description": "Time series data for this provider",
-            "type": "array",
-            "items": { "$ref": "#/components/schemas/TimeSeriesPointDto" }
-          }
-        },
-        "required": [
-          "provider",
-          "tokens",
-          "requests",
-          "percentage",
-          "timeSeriesData"
-        ]
-      },
-      "ProviderUsageResponseDto": {
-        "type": "object",
-        "properties": {
-          "providers": {
-            "description": "Provider usage statistics",
-            "type": "array",
-            "items": { "$ref": "#/components/schemas/ProviderUsageDto" }
-          }
-        },
-        "required": ["providers"]
-      },
-      "ProviderValuesDto": {
-        "type": "object",
-        "properties": {
-          "openai": { "type": "number", "description": "Tokens for OpenAI" },
-          "anthropic": {
-            "type": "number",
-            "description": "Tokens for Anthropic"
-          },
-          "mistral": { "type": "number", "description": "Tokens for Mistral" },
-          "ollama": { "type": "number", "description": "Tokens for Ollama" },
-          "synaforce": {
-            "type": "number",
-            "description": "Tokens for Synaforce"
-          },
-          "ayunis": {
-            "type": "number",
-            "description": "Tokens for Ayunis (internal)"
-          }
-        }
-      },
-      "ProviderTimeSeriesRowDto": {
-        "type": "object",
-        "properties": {
-          "date": {
-            "type": "string",
-            "description": "Date of the data point",
-            "format": "date-time"
-          },
-          "values": {
-            "description": "Tokens per provider for this date",
-            "allOf": [{ "$ref": "#/components/schemas/ProviderValuesDto" }]
-          }
-        },
-        "required": ["date", "values"]
-      },
-      "ProviderUsageChartResponseDto": {
-        "type": "object",
-        "properties": {
-          "timeSeries": {
-            "description": "Aligned time series rows by date with provider token values",
-            "type": "array",
-            "items": { "$ref": "#/components/schemas/ProviderTimeSeriesRowDto" }
-          }
-        },
-        "required": ["timeSeries"]
-      },
       "ModelDistributionDto": {
         "type": "object",
         "properties": {
-          "modelId": { "type": "string", "description": "Model ID" },
-          "modelName": { "type": "string", "description": "Model name" },
+          "modelId": {
+            "type": "string",
+            "description": "Model ID"
+          },
+          "modelName": {
+            "type": "string",
+            "description": "Model name"
+          },
           "displayName": {
             "type": "string",
             "description": "Model display name"
@@ -11526,67 +13669,183 @@
           "models": {
             "description": "Model distribution statistics",
             "type": "array",
-            "items": { "$ref": "#/components/schemas/ModelDistributionDto" }
-          }
-        },
-        "required": ["models"]
-      },
-      "UserUsageDto": {
-        "type": "object",
-        "properties": {
-          "userId": { "type": "string", "description": "User ID" },
-          "userName": { "type": "string", "description": "User name" },
-          "userEmail": { "type": "string", "description": "User email" },
-          "tokens": {
-            "type": "number",
-            "description": "Total tokens for this user"
-          },
-          "requests": {
-            "type": "number",
-            "description": "Total requests for this user"
-          },
-          "lastActivity": {
-            "type": "string",
-            "format": "date-time",
-            "description": "Last activity date (null if no activity)",
-            "nullable": true
-          },
-          "isActive": {
-            "type": "boolean",
-            "description": "Whether the user is considered active"
+            "items": {
+              "$ref": "#/components/schemas/ModelDistributionDto"
+            }
           }
         },
         "required": [
-          "userId",
-          "userName",
-          "userEmail",
-          "tokens",
-          "requests",
-          "lastActivity",
-          "isActive"
+          "models"
         ]
       },
-      "UserUsageResponseDto": {
+      "TimeSeriesPointDto": {
         "type": "object",
         "properties": {
-          "data": {
-            "description": "User usage statistics",
-            "type": "array",
-            "items": { "$ref": "#/components/schemas/UserUsageDto" }
+          "date": {
+            "format": "date-time",
+            "type": "string",
+            "description": "Date of the data point"
           },
-          "pagination": {
-            "description": "Pagination metadata",
-            "allOf": [{ "$ref": "#/components/schemas/PaginationDto" }]
+          "tokens": {
+            "type": "number",
+            "description": "Number of tokens at this point"
+          },
+          "requests": {
+            "type": "number",
+            "description": "Number of requests at this point"
           }
         },
-        "required": ["data", "pagination"]
+        "required": [
+          "date",
+          "tokens",
+          "requests"
+        ]
+      },
+      "ProviderUsageDto": {
+        "type": "object",
+        "properties": {
+          "provider": {
+            "type": "string",
+            "enum": [
+              "openai",
+              "anthropic",
+              "bedrock",
+              "mistral",
+              "ollama",
+              "synaforce",
+              "ayunis",
+              "otc",
+              "azure",
+              "gemini",
+              "stackit",
+              "scaleway"
+            ],
+            "description": "Model provider"
+          },
+          "tokens": {
+            "type": "number",
+            "description": "Total tokens for this provider"
+          },
+          "requests": {
+            "type": "number",
+            "description": "Total requests for this provider"
+          },
+          "percentage": {
+            "type": "number",
+            "description": "Percentage of total usage"
+          },
+          "timeSeriesData": {
+            "description": "Time series data for this provider",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TimeSeriesPointDto"
+            }
+          }
+        },
+        "required": [
+          "provider",
+          "tokens",
+          "requests",
+          "percentage",
+          "timeSeriesData"
+        ]
+      },
+      "ProviderUsageResponseDto": {
+        "type": "object",
+        "properties": {
+          "providers": {
+            "description": "Provider usage statistics",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ProviderUsageDto"
+            }
+          }
+        },
+        "required": [
+          "providers"
+        ]
+      },
+      "ProviderValuesDto": {
+        "type": "object",
+        "properties": {
+          "openai": {
+            "type": "number",
+            "description": "Tokens for OpenAI"
+          },
+          "anthropic": {
+            "type": "number",
+            "description": "Tokens for Anthropic"
+          },
+          "mistral": {
+            "type": "number",
+            "description": "Tokens for Mistral"
+          },
+          "ollama": {
+            "type": "number",
+            "description": "Tokens for Ollama"
+          },
+          "synaforce": {
+            "type": "number",
+            "description": "Tokens for Synaforce"
+          },
+          "ayunis": {
+            "type": "number",
+            "description": "Tokens for Ayunis (internal)"
+          }
+        }
+      },
+      "ProviderTimeSeriesRowDto": {
+        "type": "object",
+        "properties": {
+          "date": {
+            "type": "string",
+            "description": "Date of the data point",
+            "format": "date-time"
+          },
+          "values": {
+            "description": "Tokens per provider for this date",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ProviderValuesDto"
+              }
+            ]
+          }
+        },
+        "required": [
+          "date",
+          "values"
+        ]
+      },
+      "ProviderUsageChartResponseDto": {
+        "type": "object",
+        "properties": {
+          "timeSeries": {
+            "description": "Aligned time series rows by date with provider token values",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ProviderTimeSeriesRowDto"
+            }
+          }
+        },
+        "required": [
+          "timeSeries"
+        ]
       },
       "GlobalUserUsageDto": {
         "type": "object",
         "properties": {
-          "userId": { "type": "string", "description": "User ID" },
-          "userName": { "type": "string", "description": "User name" },
-          "userEmail": { "type": "string", "description": "User email" },
+          "userId": {
+            "type": "string",
+            "description": "User ID"
+          },
+          "userName": {
+            "type": "string",
+            "description": "User name"
+          },
+          "userEmail": {
+            "type": "string",
+            "description": "User email"
+          },
           "tokens": {
             "type": "number",
             "description": "Total tokens for this user"
@@ -11627,10 +13886,14 @@
           "data": {
             "description": "Top users by token usage across all organizations",
             "type": "array",
-            "items": { "$ref": "#/components/schemas/GlobalUserUsageDto" }
+            "items": {
+              "$ref": "#/components/schemas/GlobalUserUsageDto"
+            }
           }
         },
-        "required": ["data"]
+        "required": [
+          "data"
+        ]
       },
       "CreditsPerEuroResponseDto": {
         "type": "object",
@@ -11641,7 +13904,9 @@
             "example": 1000
           }
         },
-        "required": ["creditsPerEuro"]
+        "required": [
+          "creditsPerEuro"
+        ]
       },
       "SetCreditsPerEuroRequestDto": {
         "type": "object",
@@ -11652,7 +13917,9 @@
             "example": 1000
           }
         },
-        "required": ["creditsPerEuro"]
+        "required": [
+          "creditsPerEuro"
+        ]
       },
       "UserSystemPromptResponseDto": {
         "type": "object",
@@ -11664,7 +13931,9 @@
             "nullable": true
           }
         },
-        "required": ["systemPrompt"]
+        "required": [
+          "systemPrompt"
+        ]
       },
       "UpsertUserSystemPromptDto": {
         "type": "object",
@@ -11676,7 +13945,9 @@
             "maxLength": 10000
           }
         },
-        "required": ["systemPrompt"]
+        "required": [
+          "systemPrompt"
+        ]
       },
       "GeneratePersonalizedSystemPromptDto": {
         "type": "object",
@@ -11700,7 +13971,9 @@
             "maxLength": 1000
           }
         },
-        "required": ["preferredName"]
+        "required": [
+          "preferredName"
+        ]
       },
       "GeneratePersonalizedSystemPromptResponseDto": {
         "type": "object",
@@ -11716,7 +13989,10 @@
             "example": "Willkommen, Maria! Schön, dass du da bist. Wie kann ich dir heute helfen?"
           }
         },
-        "required": ["systemPrompt", "welcomeMessage"]
+        "required": [
+          "systemPrompt",
+          "welcomeMessage"
+        ]
       },
       "CreatePromptDto": {
         "type": "object",
@@ -11734,7 +14010,10 @@
             "example": "You are a helpful assistant that helps with project planning. Please provide detailed step-by-step guidance for managing projects effectively."
           }
         },
-        "required": ["title", "content"]
+        "required": [
+          "title",
+          "content"
+        ]
       },
       "PromptResponseDto": {
         "type": "object",
@@ -11799,7 +14078,10 @@
             "example": "You are an expert project planning assistant. Provide comprehensive guidance for project management, including risk assessment and timeline optimization."
           }
         },
-        "required": ["title", "content"]
+        "required": [
+          "title",
+          "content"
+        ]
       },
       "TranscriptionResponseDto": {
         "type": "object",
@@ -11810,7 +14092,9 @@
             "example": "Hello, this is a test transcription."
           }
         },
-        "required": ["text"]
+        "required": [
+          "text"
+        ]
       },
       "LoginDto": {
         "type": "object",
@@ -11826,7 +14110,10 @@
             "example": "password123"
           }
         },
-        "required": ["email", "password"]
+        "required": [
+          "email",
+          "password"
+        ]
       },
       "SuccessResponseDto": {
         "type": "object",
@@ -11837,7 +14124,9 @@
             "example": true
           }
         },
-        "required": ["success"]
+        "required": [
+          "success"
+        ]
       },
       "ErrorResponseDto": {
         "type": "object",
@@ -11848,7 +14137,9 @@
             "example": "Authentication failed"
           }
         },
-        "required": ["message"]
+        "required": [
+          "message"
+        ]
       },
       "RegisterDto": {
         "type": "object",
@@ -11898,13 +14189,19 @@
           "role": {
             "type": "string",
             "description": "User role",
-            "enum": ["admin", "user"],
+            "enum": [
+              "admin",
+              "user"
+            ],
             "example": "user"
           },
           "systemRole": {
             "type": "string",
             "description": "User system role",
-            "enum": ["customer", "super_admin"],
+            "enum": [
+              "customer",
+              "super_admin"
+            ],
             "example": "super_admin"
           },
           "name": {
@@ -11913,7 +14210,12 @@
             "example": "John Doe"
           }
         },
-        "required": ["email", "role", "systemRole", "name"]
+        "required": [
+          "email",
+          "role",
+          "systemRole",
+          "name"
+        ]
       }
     }
   }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Drops `currency` from the data model and database for both `models` and `usage`, so deployments must run the migration and ensure any downstream code no longer expects the column. Also changes subscription creation persistence to a transaction, which could affect write behavior under failure/retry scenarios.
> 
> **Overview**
> **Removes currency support and standardizes token pricing/usage costs to EUR.** This drops the `Currency` enum, removes `currency` fields from model/usage domain objects, DTOs, mappers, fixtures, and updates cost calculation to return a EUR-only `cost` value.
> 
> Adds a DB migration (`RemoveCurrencyColumns...`) that drops `currency` columns and their Postgres enum types from `models` and `usage`.
> 
> Improves subscription creation reliability by saving subscription + billing info inside a single TypeORM transaction, and updates the frontend to use renamed generated API clients (`SuperAdminCatalogModelsController` / `SuperAdminPermittedModelsController`) plus removes the currency selector from the models catalog pricing UI.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a5ac170f9a1ab2e1cddee522f0ccfe1ad6c3c98e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->