### PR TITLE
wip(AYC-77): add team model override data model and migration

### DIFF
--- a/ayunis-core-backend/src/db/migrations/1773647075277-AddTeamModelOverrides.ts
+++ b/ayunis-core-backend/src/db/migrations/1773647075277-AddTeamModelOverrides.ts
@@ -1,0 +1,75 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddTeamModelOverrides1773647075277 implements MigrationInterface {
+  name = 'AddTeamModelOverrides1773647075277';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "teams" ADD "model_override_enabled" boolean NOT NULL DEFAULT false`,
+    );
+    await queryRunner.query(
+      `CREATE TYPE "public"."permitted_models_scope_enum" AS ENUM('org', 'team')`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "permitted_models" ADD "scope" "public"."permitted_models_scope_enum" NOT NULL DEFAULT 'org'`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "permitted_models" ADD "scope_id" character varying`,
+    );
+
+    // Deduplicate existing rows on (orgId, modelId) before creating the unique index
+    await queryRunner.query(`
+      DELETE FROM "permitted_models"
+      WHERE "id" IN (
+        SELECT "id" FROM (
+          SELECT "id", ROW_NUMBER() OVER (PARTITION BY "orgId", "modelId" ORDER BY "createdAt" ASC) AS rn
+          FROM "permitted_models"
+          WHERE "scope" = 'org'
+        ) sub
+        WHERE sub.rn > 1
+      )
+    `);
+
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX "IDX_605f8ca2a5a7123c96c2f145a2" ON "permitted_models" ("scope_id", "modelId") WHERE "scope" = 'team'`,
+    );
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX "IDX_e0b6fc73ea7f071066257a9c4d" ON "permitted_models" ("orgId", "modelId") WHERE "scope" = 'org'`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "permitted_models" ADD CONSTRAINT "FK_b6d0e7d1fa9fa0c343b75152f94" FOREIGN KEY ("scope_id") REFERENCES "teams"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "permitted_models" ADD CONSTRAINT "CHK_permitted_models_scope_team" CHECK (("scope" = 'org' AND "scope_id" IS NULL) OR ("scope" = 'team' AND "scope_id" IS NOT NULL))`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    // Delete team-scoped rows first to avoid duplicate (orgId, modelId) after columns are dropped
+    await queryRunner.query(
+      `DELETE FROM "permitted_models" WHERE "scope" = 'team'`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "permitted_models" DROP CONSTRAINT "CHK_permitted_models_scope_team"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "permitted_models" DROP CONSTRAINT "FK_b6d0e7d1fa9fa0c343b75152f94"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_e0b6fc73ea7f071066257a9c4d"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_605f8ca2a5a7123c96c2f145a2"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "permitted_models" DROP COLUMN "scope_id"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "permitted_models" DROP COLUMN "scope"`,
+    );
+    await queryRunner.query(`DROP TYPE "public"."permitted_models_scope_enum"`);
+    await queryRunner.query(
+      `ALTER TABLE "teams" DROP COLUMN "model_override_enabled"`,
+    );
+  }
+}

--- a/ayunis-core-backend/src/domain/models/domain/permitted-model.entity.ts
+++ b/ayunis-core-backend/src/domain/models/domain/permitted-model.entity.ts
@@ -3,6 +3,7 @@ import { randomUUID } from 'crypto';
 import type { Model } from './model.entity';
 import type { LanguageModel } from './models/language.model';
 import type { EmbeddingModel } from './models/embedding.model';
+import { PermittedModelScope } from './value-objects/permitted-model-scope.enum';
 
 export class PermittedModel {
   public readonly id: UUID;
@@ -10,6 +11,8 @@ export class PermittedModel {
   public readonly orgId: UUID;
   public readonly isDefault: boolean;
   public readonly anonymousOnly: boolean;
+  public readonly scope: PermittedModelScope;
+  public readonly scopeId: UUID | null;
   public readonly createdAt: Date;
   public readonly updatedAt: Date;
 
@@ -19,6 +22,8 @@ export class PermittedModel {
     orgId: UUID;
     isDefault?: boolean;
     anonymousOnly?: boolean;
+    scope?: PermittedModelScope;
+    scopeId?: UUID | null;
     createdAt?: Date;
     updatedAt?: Date;
   }) {
@@ -27,6 +32,16 @@ export class PermittedModel {
     this.orgId = params.orgId;
     this.isDefault = params.isDefault ?? false;
     this.anonymousOnly = params.anonymousOnly ?? false;
+    this.scope = params.scope ?? PermittedModelScope.ORG;
+    this.scopeId = params.scopeId ?? null;
+
+    if (this.scope === PermittedModelScope.TEAM && this.scopeId === null) {
+      throw new Error('scopeId is required when scope is TEAM');
+    }
+    if (this.scope === PermittedModelScope.ORG && this.scopeId !== null) {
+      throw new Error('scopeId must be null when scope is ORG');
+    }
+
     this.createdAt = params.createdAt ?? new Date();
     this.updatedAt = params.updatedAt ?? new Date();
   }
@@ -40,6 +55,8 @@ export class PermittedLanguageModel extends PermittedModel {
     orgId: UUID;
     isDefault?: boolean;
     anonymousOnly?: boolean;
+    scope?: PermittedModelScope;
+    scopeId?: UUID | null;
     createdAt?: Date;
     updatedAt?: Date;
   }) {
@@ -56,6 +73,8 @@ export class PermittedEmbeddingModel extends PermittedModel {
     orgId: UUID;
     isDefault?: boolean;
     anonymousOnly?: boolean;
+    scope?: PermittedModelScope;
+    scopeId?: UUID | null;
     createdAt?: Date;
     updatedAt?: Date;
   }) {

--- a/ayunis-core-backend/src/domain/models/domain/value-objects/permitted-model-scope.enum.ts
+++ b/ayunis-core-backend/src/domain/models/domain/value-objects/permitted-model-scope.enum.ts
@@ -1,0 +1,4 @@
+export enum PermittedModelScope {
+  ORG = 'org',
+  TEAM = 'team',
+}

--- a/ayunis-core-backend/src/domain/models/infrastructure/persistence/local-permitted-models/mappers/permitted-model.mapper.ts
+++ b/ayunis-core-backend/src/domain/models/infrastructure/persistence/local-permitted-models/mappers/permitted-model.mapper.ts
@@ -25,6 +25,8 @@ export class PermittedModelMapper {
         orgId: record.orgId,
         isDefault: record.isDefault,
         anonymousOnly: record.anonymousOnly,
+        scope: record.scope,
+        scopeId: record.scopeId,
         createdAt: record.createdAt,
         updatedAt: record.updatedAt,
       });
@@ -36,6 +38,8 @@ export class PermittedModelMapper {
         orgId: record.orgId,
         isDefault: record.isDefault,
         anonymousOnly: record.anonymousOnly,
+        scope: record.scope,
+        scopeId: record.scopeId,
         createdAt: record.createdAt,
         updatedAt: record.updatedAt,
       });
@@ -51,6 +55,8 @@ export class PermittedModelMapper {
     record.orgId = domain.orgId;
     record.isDefault = domain.isDefault;
     record.anonymousOnly = domain.anonymousOnly;
+    record.scope = domain.scope;
+    record.scopeId = domain.scopeId;
     record.createdAt = domain.createdAt;
     record.updatedAt = domain.updatedAt;
     return record;

--- a/ayunis-core-backend/src/domain/models/infrastructure/persistence/local-permitted-models/schema/permitted-model.record.ts
+++ b/ayunis-core-backend/src/domain/models/infrastructure/persistence/local-permitted-models/schema/permitted-model.record.ts
@@ -2,10 +2,14 @@ import { UUID } from 'crypto';
 import { BaseRecord } from '../../../../../../common/db/base-record';
 import { Org } from '../../../../../../iam/orgs/domain/org.entity';
 import { OrgRecord } from '../../../../../../iam/orgs/infrastructure/repositories/local/schema/org.record';
-import { Column, Entity, ManyToOne } from 'typeorm';
+import { Column, Entity, Index, JoinColumn, ManyToOne } from 'typeorm';
 import { ModelRecord } from '../../local-models/schema/model.record';
+import { TeamRecord } from '../../../../../../iam/teams/infrastructure/repositories/local/schema/team.record';
+import { PermittedModelScope } from '../../../../domain/value-objects/permitted-model-scope.enum';
 
 @Entity({ name: 'permitted_models' })
+@Index(['orgId', 'modelId'], { unique: true, where: `"scope" = 'org'` })
+@Index(['scopeId', 'modelId'], { unique: true, where: `"scope" = 'team'` })
 export class PermittedModelRecord extends BaseRecord {
   @Column({ nullable: false })
   orgId: UUID;
@@ -25,4 +29,18 @@ export class PermittedModelRecord extends BaseRecord {
 
   @Column({ nullable: false, default: false })
   anonymousOnly: boolean;
+
+  @Column({
+    type: 'enum',
+    enum: PermittedModelScope,
+    default: PermittedModelScope.ORG,
+  })
+  scope: PermittedModelScope;
+
+  @Column({ name: 'scope_id', nullable: true })
+  scopeId: UUID | null;
+
+  @ManyToOne(() => TeamRecord, { nullable: true, onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'scope_id' })
+  team: TeamRecord | null;
 }

--- a/ayunis-core-backend/src/iam/teams/application/use-cases/update-team/update-team.command.ts
+++ b/ayunis-core-backend/src/iam/teams/application/use-cases/update-team/update-team.command.ts
@@ -4,5 +4,6 @@ export class UpdateTeamCommand {
   constructor(
     public readonly teamId: UUID,
     public readonly name: string,
+    public readonly modelOverrideEnabled?: boolean,
   ) {}
 }

--- a/ayunis-core-backend/src/iam/teams/application/use-cases/update-team/update-team.use-case.ts
+++ b/ayunis-core-backend/src/iam/teams/application/use-cases/update-team/update-team.use-case.ts
@@ -74,6 +74,9 @@ export class UpdateTeamUseCase {
       });
 
       team.name = trimmedName;
+      if (command.modelOverrideEnabled !== undefined) {
+        team.modelOverrideEnabled = command.modelOverrideEnabled;
+      }
       team.updatedAt = new Date();
 
       const updatedTeam = await this.teamsRepository.update(team);

--- a/ayunis-core-backend/src/iam/teams/domain/team.entity.ts
+++ b/ayunis-core-backend/src/iam/teams/domain/team.entity.ts
@@ -5,6 +5,7 @@ export class Team {
   public id: UUID;
   public name: string;
   public orgId: UUID;
+  public modelOverrideEnabled: boolean;
   public createdAt: Date;
   public updatedAt: Date;
 
@@ -12,12 +13,14 @@ export class Team {
     id?: UUID;
     name: string;
     orgId: UUID;
+    modelOverrideEnabled?: boolean;
     createdAt?: Date;
     updatedAt?: Date;
   }) {
     this.id = params.id ?? randomUUID();
     this.name = params.name;
     this.orgId = params.orgId;
+    this.modelOverrideEnabled = params.modelOverrideEnabled ?? false;
     this.createdAt = params.createdAt ?? new Date();
     this.updatedAt = params.updatedAt ?? new Date();
   }

--- a/ayunis-core-backend/src/iam/teams/infrastructure/repositories/local/mappers/team.mapper.ts
+++ b/ayunis-core-backend/src/iam/teams/infrastructure/repositories/local/mappers/team.mapper.ts
@@ -7,6 +7,7 @@ export class TeamMapper {
       id: record.id,
       name: record.name,
       orgId: record.orgId,
+      modelOverrideEnabled: record.modelOverrideEnabled,
       createdAt: record.createdAt,
       updatedAt: record.updatedAt,
     });
@@ -17,6 +18,7 @@ export class TeamMapper {
     record.id = domain.id;
     record.name = domain.name;
     record.orgId = domain.orgId;
+    record.modelOverrideEnabled = domain.modelOverrideEnabled;
     record.createdAt = domain.createdAt;
     record.updatedAt = domain.updatedAt;
     return record;

--- a/ayunis-core-backend/src/iam/teams/infrastructure/repositories/local/schema/team.record.ts
+++ b/ayunis-core-backend/src/iam/teams/infrastructure/repositories/local/schema/team.record.ts
@@ -15,4 +15,7 @@ export class TeamRecord extends BaseRecord {
   @ManyToOne(() => OrgRecord, { onDelete: 'CASCADE' })
   @JoinColumn({ name: 'org_id' })
   org: OrgRecord;
+
+  @Column({ name: 'model_override_enabled', default: false })
+  modelOverrideEnabled: boolean;
 }

--- a/ayunis-core-backend/src/iam/teams/presenters/http/dtos/team-response.dto.ts
+++ b/ayunis-core-backend/src/iam/teams/presenters/http/dtos/team-response.dto.ts
@@ -31,4 +31,10 @@ export class TeamResponseDto {
     example: '2024-01-15T10:30:00.000Z',
   })
   updatedAt: Date;
+
+  @ApiProperty({
+    description: 'Whether model access override is enabled for this team',
+    example: false,
+  })
+  modelOverrideEnabled: boolean;
 }

--- a/ayunis-core-backend/src/iam/teams/presenters/http/dtos/update-team.dto.ts
+++ b/ayunis-core-backend/src/iam/teams/presenters/http/dtos/update-team.dto.ts
@@ -1,5 +1,12 @@
-import { ApiProperty } from '@nestjs/swagger';
-import { IsString, IsNotEmpty, MaxLength, MinLength } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  IsString,
+  IsNotEmpty,
+  MaxLength,
+  MinLength,
+  IsOptional,
+  IsBoolean,
+} from 'class-validator';
 
 export class UpdateTeamDto {
   @ApiProperty({
@@ -11,4 +18,12 @@ export class UpdateTeamDto {
   @MinLength(1)
   @MaxLength(100)
   name: string;
+
+  @ApiPropertyOptional({
+    description: 'Whether model access override is enabled for this team',
+    example: false,
+  })
+  @IsOptional()
+  @IsBoolean()
+  modelOverrideEnabled?: boolean;
 }

--- a/ayunis-core-backend/src/iam/teams/presenters/http/mappers/team-dto.mapper.ts
+++ b/ayunis-core-backend/src/iam/teams/presenters/http/mappers/team-dto.mapper.ts
@@ -11,6 +11,7 @@ export class TeamDtoMapper {
       orgId: team.orgId,
       createdAt: team.createdAt,
       updatedAt: team.updatedAt,
+      modelOverrideEnabled: team.modelOverrideEnabled,
     };
   }
 

--- a/ayunis-core-backend/src/iam/teams/presenters/http/teams.controller.ts
+++ b/ayunis-core-backend/src/iam/teams/presenters/http/teams.controller.ts
@@ -259,9 +259,15 @@ export class TeamsController {
     @Param('id', ParseUUIDPipe) id: UUID,
     @Body() updateTeamDto: UpdateTeamDto,
   ): Promise<TeamResponseDto> {
-    this.logger.log(`Updating team ${id} with name: ${updateTeamDto.name}`);
+    this.logger.log(
+      `Updating team ${id} with name: ${updateTeamDto.name}, modelOverrideEnabled: ${updateTeamDto.modelOverrideEnabled}`,
+    );
 
-    const command = new UpdateTeamCommand(id, updateTeamDto.name);
+    const command = new UpdateTeamCommand(
+      id,
+      updateTeamDto.name,
+      updateTeamDto.modelOverrideEnabled,
+    );
     const team = await this.updateTeamUseCase.execute(command);
 
     this.logger.log(`Successfully updated team with id: ${team.id}`);

--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
@@ -2184,6 +2184,8 @@ export interface CreateTeamDto {
 export interface UpdateTeamDto {
   /** The new name of the team */
   name: string;
+  /** Whether model access override is enabled for this team */
+  modelOverrideEnabled?: boolean;
 }
 
 export interface TeamResponseDto {
@@ -2197,6 +2199,8 @@ export interface TeamResponseDto {
   createdAt: string;
   /** The date and time when the team was last updated */
   updatedAt: string;
+  /** Whether model access override is enabled for this team */
+  modelOverrideEnabled: boolean;
 }
 
 /**

--- a/ayunis-core-frontend/src/shared/api/openapi-schema.json
+++ b/ayunis-core-frontend/src/shared/api/openapi-schema.json
@@ -11609,6 +11609,11 @@
             "type": "string",
             "description": "The new name of the team",
             "example": "Engineering"
+          },
+          "modelOverrideEnabled": {
+            "type": "boolean",
+            "description": "Whether model access override is enabled for this team",
+            "example": false
           }
         },
         "required": [
@@ -11644,6 +11649,11 @@
             "type": "string",
             "description": "The date and time when the team was last updated",
             "example": "2024-01-15T10:30:00.000Z"
+          },
+          "modelOverrideEnabled": {
+            "type": "boolean",
+            "description": "Whether model access override is enabled for this team",
+            "example": false
           }
         },
         "required": [
@@ -11651,7 +11661,8 @@
           "name",
           "orgId",
           "createdAt",
-          "updatedAt"
+          "updatedAt",
+          "modelOverrideEnabled"
         ]
       },
       "TeamMemberResponseDto": {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces a schema migration that reshapes `permitted_models` with new scope/uniqueness constraints and deletes duplicate rows, which can affect existing data and requires careful rollout/rollback. API surface changes are small but coupled to the new DB fields (`modelOverrideEnabled`).
> 
> **Overview**
> Adds **team-level model override support** to the data model.
> 
> Introduces a migration that adds `teams.model_override_enabled` and extends `permitted_models` with `scope` (`org`/`team`) and `scope_id`, plus partial unique indexes, a FK to `teams`, and a check constraint; the migration also deduplicates existing org-scoped rows before enforcing uniqueness.
> 
> Updates backend domain/entities/mappers to carry `PermittedModel.scope/scopeId` (with invariant checks) and exposes `modelOverrideEnabled` through the teams update flow (`UpdateTeamDto`/command/use-case/controller response). Frontend generated OpenAPI schemas are updated to include the new field on `UpdateTeamDto` and `TeamResponseDto`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d7a033fbc9cc9a86938ae9254a216627cbc94f8d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->