### PR TITLE
fix(AYC-000): auto-reload on stale chunk load errors after deployment

### DIFF
--- a/ayunis-core-frontend/src/main.tsx
+++ b/ayunis-core-frontend/src/main.tsx
@@ -4,11 +4,19 @@ applyDomPatch(); // Must be called before React renders
 import { initSentry } from '@/shared/lib/sentry';
 initSentry();
 
+import {
+  attemptChunkReload,
+  clearChunkReloadFlag,
+} from '@/shared/lib/chunk-reload-guard';
+
+// Clear the reload flag on successful load to allow future reloads if needed
+clearChunkReloadFlag();
+
 // Auto-reload when Vite chunk imports fail after a deployment
 // (users with stale index.html try to load chunks that no longer exist)
 window.addEventListener('vite:preloadError', (event) => {
   event.preventDefault();
-  window.location.reload();
+  attemptChunkReload();
 });
 
 import { StrictMode } from 'react';
@@ -58,8 +66,7 @@ const router = createRouter({
   defaultPreloadStaleTime: 0,
   defaultErrorComponent: ({ error }) => {
     // Auto-reload on chunk load errors (stale deployment)
-    if (isChunkLoadError(error)) {
-      window.location.reload();
+    if (isChunkLoadError(error) && attemptChunkReload()) {
       return null;
     }
 

--- a/ayunis-core-frontend/src/main.tsx
+++ b/ayunis-core-frontend/src/main.tsx
@@ -4,12 +4,21 @@ applyDomPatch(); // Must be called before React renders
 import { initSentry } from '@/shared/lib/sentry';
 initSentry();
 
+// Auto-reload when Vite chunk imports fail after a deployment
+// (users with stale index.html try to load chunks that no longer exist)
+window.addEventListener('vite:preloadError', (event) => {
+  event.preventDefault();
+  window.location.reload();
+});
+
 import { StrictMode } from 'react';
 import ReactDOM from 'react-dom/client';
 import { RouterProvider, createRouter } from '@tanstack/react-router';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import RootLayout from './layouts/root-layout';
 import { ErrorBoundary } from '@/shared/ui/error-boundary';
+import { ErrorFallback } from '@/shared/ui/error-boundary/ErrorFallback';
+import { isChunkLoadError } from '@/shared/lib/is-chunk-load-error';
 
 // Import the generated route tree
 import { routeTree } from './app/routeTree.gen.ts';
@@ -47,6 +56,15 @@ const router = createRouter({
   scrollRestoration: true,
   defaultStructuralSharing: true,
   defaultPreloadStaleTime: 0,
+  defaultErrorComponent: ({ error }) => {
+    // Auto-reload on chunk load errors (stale deployment)
+    if (isChunkLoadError(error)) {
+      window.location.reload();
+      return null;
+    }
+
+    return <ErrorFallback onReset={() => window.location.reload()} />;
+  },
 });
 
 // Register the router instance for type safety

--- a/ayunis-core-frontend/src/shared/lib/chunk-reload-guard.ts
+++ b/ayunis-core-frontend/src/shared/lib/chunk-reload-guard.ts
@@ -1,0 +1,35 @@
+const CHUNK_RELOAD_KEY = 'chunk-reload-attempted';
+
+/**
+ * Attempts to reload the page to recover from a chunk load error,
+ * but only once per session to prevent infinite reload loops.
+ *
+ * @returns `true` if a reload was triggered, `false` if a reload
+ *          was already attempted (caller should show error UI instead).
+ */
+export function attemptChunkReload(): boolean {
+  try {
+    if (sessionStorage.getItem(CHUNK_RELOAD_KEY)) {
+      return false;
+    }
+    sessionStorage.setItem(CHUNK_RELOAD_KEY, 'true');
+    window.location.reload();
+    return true;
+  } catch {
+    // sessionStorage may be unavailable (private browsing, etc.)
+    // Fall back to showing error UI rather than risking a loop
+    return false;
+  }
+}
+
+/**
+ * Clears the chunk reload flag. Call this after a successful page load
+ * to allow future reloads if needed.
+ */
+export function clearChunkReloadFlag(): void {
+  try {
+    sessionStorage.removeItem(CHUNK_RELOAD_KEY);
+  } catch {
+    // Ignore errors if sessionStorage is unavailable
+  }
+}

--- a/ayunis-core-frontend/src/shared/lib/is-chunk-load-error.ts
+++ b/ayunis-core-frontend/src/shared/lib/is-chunk-load-error.ts
@@ -1,0 +1,22 @@
+/**
+ * Detects chunk/module load failures caused by stale deployments.
+ *
+ * After a new deployment, users with cached HTML may try to import
+ * JS chunks that no longer exist (different content hashes). This
+ * manifests as dynamic import errors or "loading chunk failed" errors.
+ */
+export function isChunkLoadError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+
+  const message = error.message.toLowerCase();
+
+  return (
+    // Vite / native dynamic import
+    message.includes('failed to fetch dynamically imported module') ||
+    // Webpack-style (in case of migration)
+    message.includes('loading chunk') ||
+    message.includes('loading css chunk') ||
+    // Generic network failures during chunk fetch
+    (error.name === 'TypeError' && message.includes('failed to fetch'))
+  );
+}

--- a/ayunis-core-frontend/src/shared/ui/error-boundary/ErrorBoundary.tsx
+++ b/ayunis-core-frontend/src/shared/ui/error-boundary/ErrorBoundary.tsx
@@ -2,6 +2,7 @@ import { Component, type ReactNode } from 'react';
 import { ErrorFallback } from './ErrorFallback';
 import { Sentry } from '@/shared/lib/sentry';
 import { isChunkLoadError } from '@/shared/lib/is-chunk-load-error';
+import { attemptChunkReload } from '@/shared/lib/chunk-reload-guard';
 
 interface Props {
   children: ReactNode;
@@ -25,8 +26,7 @@ export class ErrorBoundary extends Component<Props, State> {
 
   componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
     // Auto-reload on stale chunk errors instead of showing error UI
-    if (isChunkLoadError(error)) {
-      window.location.reload();
+    if (isChunkLoadError(error) && attemptChunkReload()) {
       return;
     }
 

--- a/ayunis-core-frontend/src/shared/ui/error-boundary/ErrorBoundary.tsx
+++ b/ayunis-core-frontend/src/shared/ui/error-boundary/ErrorBoundary.tsx
@@ -1,6 +1,7 @@
 import { Component, type ReactNode } from 'react';
 import { ErrorFallback } from './ErrorFallback';
 import { Sentry } from '@/shared/lib/sentry';
+import { isChunkLoadError } from '@/shared/lib/is-chunk-load-error';
 
 interface Props {
   children: ReactNode;
@@ -23,6 +24,12 @@ export class ErrorBoundary extends Component<Props, State> {
   }
 
   componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
+    // Auto-reload on stale chunk errors instead of showing error UI
+    if (isChunkLoadError(error)) {
+      window.location.reload();
+      return;
+    }
+
     console.error('ErrorBoundary caught an error:', error, errorInfo);
     Sentry.captureException(error, {
       extra: { componentStack: errorInfo.componentStack },


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds automatic full-page reload behavior on detected chunk/dynamic import failures, which could cause unexpected reload loops if errors are misclassified. Changes touch global app bootstrap and router/error-boundary handling paths.
> 
> **Overview**
> Improves resilience to post-deployment stale asset issues by **automatically reloading the page** when Vite preload/dynamic import chunk loads fail.
> 
> Adds `vite:preloadError` handling in `main.tsx`, introduces `isChunkLoadError` for detecting chunk/module fetch failures, and wires this into both TanStack Router’s `defaultErrorComponent` and the app `ErrorBoundary` to reload instead of rendering the error UI (otherwise showing `ErrorFallback` with a reload reset option).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 01859d6b80fc0906c165c78e851da24ed0ab57dd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->