### PR TITLE
wip(AYC-77): add scope-aware repository methods and effective model resolution use case

### DIFF
--- a/ayunis-core-backend/src/domain/models/application/ports/permitted-models.repository.ts
+++ b/ayunis-core-backend/src/domain/models/application/ports/permitted-models.repository.ts
@@ -28,6 +28,10 @@ export abstract class PermittedModelsRepository {
   abstract findOrgDefaultLanguage(
     orgId: UUID,
   ): Promise<PermittedLanguageModel | null>;
+  abstract findTeamDefaultLanguage(
+    teamId: UUID,
+    orgId: UUID,
+  ): Promise<PermittedLanguageModel | null>;
   abstract findOne(params: FindOneParams): Promise<PermittedModel | null>;
   abstract findOneLanguage(
     params: FindOneParams,
@@ -36,11 +40,20 @@ export abstract class PermittedModelsRepository {
     orgId: UUID,
   ): Promise<PermittedEmbeddingModel | null>;
   abstract findManyLanguage(orgId: UUID): Promise<PermittedLanguageModel[]>;
+  abstract findManyLanguageByTeam(
+    teamId: UUID,
+    orgId: UUID,
+  ): Promise<PermittedLanguageModel[]>;
   abstract create(permittedModel: PermittedModel): Promise<PermittedModel>;
   abstract delete(params: { id: UUID; orgId: UUID }): Promise<void>;
+  abstract deleteTeamScopedByOrgAndModelId(
+    orgId: UUID,
+    modelId: UUID,
+  ): Promise<void>;
   abstract setAsDefault(params: {
     id: UUID;
     orgId: UUID;
+    teamId?: UUID;
   }): Promise<PermittedLanguageModel>;
   abstract update(permittedModel: PermittedModel): Promise<PermittedModel>;
   abstract findAllByCatalogModelId(

--- a/ayunis-core-backend/src/domain/models/application/use-cases/get-effective-language-models/get-effective-language-models.query.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/get-effective-language-models/get-effective-language-models.query.ts
@@ -1,0 +1,5 @@
+import type { UUID } from 'crypto';
+
+export class GetEffectiveLanguageModelsQuery {
+  constructor(public readonly orgId: UUID) {}
+}

--- a/ayunis-core-backend/src/domain/models/application/use-cases/get-effective-language-models/get-effective-language-models.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/get-effective-language-models/get-effective-language-models.use-case.spec.ts
@@ -1,0 +1,292 @@
+import type { TestingModule } from '@nestjs/testing';
+import { Test } from '@nestjs/testing';
+import { GetEffectiveLanguageModelsUseCase } from './get-effective-language-models.use-case';
+import { GetEffectiveLanguageModelsQuery } from './get-effective-language-models.query';
+import { PermittedModelsRepository } from '../../ports/permitted-models.repository';
+import { ListMyTeamsUseCase } from 'src/iam/teams/application/use-cases/list-my-teams/list-my-teams.use-case';
+import { Team } from 'src/iam/teams/domain/team.entity';
+import { PermittedLanguageModel } from 'src/domain/models/domain/permitted-model.entity';
+import { LanguageModel } from 'src/domain/models/domain/models/language.model';
+import { ModelProvider } from 'src/domain/models/domain/value-objects/model-provider.enum';
+import { PermittedModelScope } from 'src/domain/models/domain/value-objects/permitted-model-scope.enum';
+import { ContextService } from 'src/common/context/services/context.service';
+import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
+import { SystemRole } from 'src/iam/users/domain/value-objects/system-role.enum';
+import type { UUID } from 'crypto';
+
+describe('GetEffectiveLanguageModelsUseCase', () => {
+  let useCase: GetEffectiveLanguageModelsUseCase;
+  let permittedModelsRepository: jest.Mocked<PermittedModelsRepository>;
+  let listMyTeamsUseCase: jest.Mocked<ListMyTeamsUseCase>;
+  let contextService: jest.Mocked<ContextService>;
+
+  const userId = '11111111-1111-1111-1111-111111111111' as UUID;
+  const orgId = '22222222-2222-2222-2222-222222222222' as UUID;
+  const teamAId = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa' as UUID;
+  const teamBId = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb' as UUID;
+
+  function makeLanguageModel(name: string, id?: UUID): LanguageModel {
+    return new LanguageModel({
+      id: id ?? (`${name}-0000-0000-0000-000000000000` as UUID),
+      name,
+      displayName: name,
+      provider: ModelProvider.OPENAI,
+      canStream: true,
+      isReasoning: false,
+      isArchived: false,
+      canUseTools: true,
+      canVision: false,
+    });
+  }
+
+  function makePermittedLanguageModel(
+    model: LanguageModel,
+    scope: PermittedModelScope = PermittedModelScope.ORG,
+    scopeId: UUID | null = null,
+  ): PermittedLanguageModel {
+    return new PermittedLanguageModel({
+      model,
+      orgId,
+      scope,
+      scopeId,
+    });
+  }
+
+  function makeTeam(
+    id: UUID,
+    teamOrgId: UUID,
+    modelOverrideEnabled: boolean,
+  ): Team {
+    return new Team({
+      id,
+      name: `team-${id}`,
+      orgId: teamOrgId,
+      modelOverrideEnabled,
+    });
+  }
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        GetEffectiveLanguageModelsUseCase,
+        {
+          provide: PermittedModelsRepository,
+          useValue: {
+            findManyLanguage: jest.fn(),
+            findManyLanguageByTeam: jest.fn(),
+          },
+        },
+        {
+          provide: ListMyTeamsUseCase,
+          useValue: {
+            execute: jest.fn(),
+          },
+        },
+        {
+          provide: ContextService,
+          useValue: {
+            get: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    useCase = module.get(GetEffectiveLanguageModelsUseCase);
+    permittedModelsRepository = module.get(PermittedModelsRepository);
+    listMyTeamsUseCase = module.get(ListMyTeamsUseCase);
+    contextService = module.get(ContextService);
+
+    // Default: user belongs to the org
+    contextService.get.mockImplementation((key) => {
+      if (key === 'userId') return userId;
+      if (key === 'orgId') return orgId;
+      if (key === 'systemRole') return SystemRole.CUSTOMER;
+      return undefined;
+    });
+  });
+
+  it('should throw UnauthorizedAccessError when user does not belong to org', async () => {
+    const otherOrgId = '99999999-9999-9999-9999-999999999999' as UUID;
+    contextService.get.mockImplementation((key) => {
+      if (key === 'userId') return userId;
+      if (key === 'orgId') return otherOrgId;
+      if (key === 'systemRole') return SystemRole.CUSTOMER;
+      return undefined;
+    });
+
+    await expect(
+      useCase.execute(new GetEffectiveLanguageModelsQuery(orgId)),
+    ).rejects.toThrow(UnauthorizedAccessError);
+  });
+
+  it('should allow super admin to access any org', async () => {
+    const otherOrgId = '99999999-9999-9999-9999-999999999999' as UUID;
+    contextService.get.mockImplementation((key) => {
+      if (key === 'userId') return userId;
+      if (key === 'orgId') return otherOrgId;
+      if (key === 'systemRole') return SystemRole.SUPER_ADMIN;
+      return undefined;
+    });
+
+    const gpt4 = makeLanguageModel('gpt-4');
+    const orgModels = [makePermittedLanguageModel(gpt4)];
+
+    listMyTeamsUseCase.execute.mockResolvedValue([]);
+    permittedModelsRepository.findManyLanguage.mockResolvedValue(orgModels);
+
+    const result = await useCase.execute(
+      new GetEffectiveLanguageModelsQuery(orgId),
+    );
+
+    expect(result).toEqual(orgModels);
+  });
+
+  it('should return org models when user has no teams', async () => {
+    const gpt4 = makeLanguageModel('gpt-4');
+    const orgModels = [makePermittedLanguageModel(gpt4)];
+
+    listMyTeamsUseCase.execute.mockResolvedValue([]);
+    permittedModelsRepository.findManyLanguage.mockResolvedValue(orgModels);
+
+    const result = await useCase.execute(
+      new GetEffectiveLanguageModelsQuery(orgId),
+    );
+
+    expect(result).toEqual(orgModels);
+    expect(permittedModelsRepository.findManyLanguage).toHaveBeenCalledWith(
+      orgId,
+    );
+    expect(
+      permittedModelsRepository.findManyLanguageByTeam,
+    ).not.toHaveBeenCalled();
+  });
+
+  it('should return org models when user is only in non-override teams', async () => {
+    const gpt4 = makeLanguageModel('gpt-4');
+    const orgModels = [makePermittedLanguageModel(gpt4)];
+
+    listMyTeamsUseCase.execute.mockResolvedValue([
+      makeTeam(teamAId, orgId, false),
+      makeTeam(teamBId, orgId, false),
+    ]);
+    permittedModelsRepository.findManyLanguage.mockResolvedValue(orgModels);
+
+    const result = await useCase.execute(
+      new GetEffectiveLanguageModelsQuery(orgId),
+    );
+
+    expect(result).toEqual(orgModels);
+    expect(permittedModelsRepository.findManyLanguage).toHaveBeenCalledWith(
+      orgId,
+    );
+  });
+
+  it('should return team models when user is in one override team', async () => {
+    const gpt4 = makeLanguageModel('gpt-4');
+    const teamModels = [
+      makePermittedLanguageModel(gpt4, PermittedModelScope.TEAM, teamAId),
+    ];
+
+    listMyTeamsUseCase.execute.mockResolvedValue([
+      makeTeam(teamAId, orgId, true),
+    ]);
+    permittedModelsRepository.findManyLanguageByTeam.mockResolvedValue(
+      teamModels,
+    );
+
+    const result = await useCase.execute(
+      new GetEffectiveLanguageModelsQuery(orgId),
+    );
+
+    expect(result).toEqual(teamModels);
+    expect(
+      permittedModelsRepository.findManyLanguageByTeam,
+    ).toHaveBeenCalledWith(teamAId, orgId);
+    expect(permittedModelsRepository.findManyLanguage).not.toHaveBeenCalled();
+  });
+
+  it('should return union of models from two override teams', async () => {
+    const gpt4 = makeLanguageModel('gpt-4');
+    const claude = makeLanguageModel('claude-3-sonnet');
+    const mistral = makeLanguageModel('mistral-large');
+
+    const teamAModels = [
+      makePermittedLanguageModel(gpt4, PermittedModelScope.TEAM, teamAId),
+      makePermittedLanguageModel(claude, PermittedModelScope.TEAM, teamAId),
+    ];
+    const teamBModels = [
+      makePermittedLanguageModel(claude, PermittedModelScope.TEAM, teamBId),
+      makePermittedLanguageModel(mistral, PermittedModelScope.TEAM, teamBId),
+    ];
+
+    listMyTeamsUseCase.execute.mockResolvedValue([
+      makeTeam(teamAId, orgId, true),
+      makeTeam(teamBId, orgId, true),
+    ]);
+    permittedModelsRepository.findManyLanguageByTeam
+      .mockResolvedValueOnce(teamAModels)
+      .mockResolvedValueOnce(teamBModels);
+
+    const result = await useCase.execute(
+      new GetEffectiveLanguageModelsQuery(orgId),
+    );
+
+    // Union: gpt-4 (from A), claude (from A, deduped), mistral (from B)
+    expect(result).toHaveLength(3);
+    const modelNames = result.map((m) => m.model.name);
+    expect(modelNames).toContain('gpt-4');
+    expect(modelNames).toContain('claude-3-sonnet');
+    expect(modelNames).toContain('mistral-large');
+  });
+
+  it('should use only override team models when user is in both override and non-override teams', async () => {
+    const gpt4 = makeLanguageModel('gpt-4');
+    const teamModels = [
+      makePermittedLanguageModel(gpt4, PermittedModelScope.TEAM, teamAId),
+    ];
+
+    listMyTeamsUseCase.execute.mockResolvedValue([
+      makeTeam(teamAId, orgId, true),
+      makeTeam(teamBId, orgId, false),
+    ]);
+    permittedModelsRepository.findManyLanguageByTeam.mockResolvedValue(
+      teamModels,
+    );
+
+    const result = await useCase.execute(
+      new GetEffectiveLanguageModelsQuery(orgId),
+    );
+
+    expect(result).toEqual(teamModels);
+    expect(
+      permittedModelsRepository.findManyLanguageByTeam,
+    ).toHaveBeenCalledWith(teamAId, orgId);
+    expect(
+      permittedModelsRepository.findManyLanguageByTeam,
+    ).not.toHaveBeenCalledWith(teamBId, orgId);
+    expect(permittedModelsRepository.findManyLanguage).not.toHaveBeenCalled();
+  });
+
+  it('should fall back to org models when override teams have zero configured models', async () => {
+    const gpt4 = makeLanguageModel('gpt-4');
+    const orgModels = [makePermittedLanguageModel(gpt4)];
+
+    listMyTeamsUseCase.execute.mockResolvedValue([
+      makeTeam(teamAId, orgId, true),
+    ]);
+    permittedModelsRepository.findManyLanguageByTeam.mockResolvedValue([]);
+    permittedModelsRepository.findManyLanguage.mockResolvedValue(orgModels);
+
+    const result = await useCase.execute(
+      new GetEffectiveLanguageModelsQuery(orgId),
+    );
+
+    expect(result).toEqual(orgModels);
+    expect(
+      permittedModelsRepository.findManyLanguageByTeam,
+    ).toHaveBeenCalledWith(teamAId, orgId);
+    expect(permittedModelsRepository.findManyLanguage).toHaveBeenCalledWith(
+      orgId,
+    );
+  });
+});

--- a/ayunis-core-backend/src/domain/models/application/use-cases/get-effective-language-models/get-effective-language-models.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/get-effective-language-models/get-effective-language-models.use-case.ts
@@ -1,0 +1,115 @@
+import { Injectable, Logger } from '@nestjs/common';
+import type { UUID } from 'crypto';
+import { ApplicationError } from 'src/common/errors/base.error';
+import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
+import { ContextService } from 'src/common/context/services/context.service';
+import { PermittedLanguageModel } from 'src/domain/models/domain/permitted-model.entity';
+import { PermittedModelsRepository } from '../../ports/permitted-models.repository';
+import { UnexpectedModelError } from '../../models.errors';
+import { ListMyTeamsUseCase } from 'src/iam/teams/application/use-cases/list-my-teams/list-my-teams.use-case';
+import { GetEffectiveLanguageModelsQuery } from './get-effective-language-models.query';
+import { SystemRole } from 'src/iam/users/domain/value-objects/system-role.enum';
+
+@Injectable()
+export class GetEffectiveLanguageModelsUseCase {
+  private readonly logger = new Logger(GetEffectiveLanguageModelsUseCase.name);
+
+  constructor(
+    private readonly permittedModelsRepository: PermittedModelsRepository,
+    private readonly listMyTeamsUseCase: ListMyTeamsUseCase,
+    private readonly contextService: ContextService,
+  ) {}
+
+  async execute(
+    query: GetEffectiveLanguageModelsQuery,
+  ): Promise<PermittedLanguageModel[]> {
+    const userId = this.contextService.get('userId');
+    if (!userId) {
+      throw new UnauthorizedAccessError({ reason: 'Missing user context' });
+    }
+
+    this.logger.log('Resolving effective language models', {
+      userId,
+      orgId: query.orgId,
+    });
+
+    try {
+      const orgId = this.contextService.get('orgId');
+      const systemRole = this.contextService.get('systemRole');
+      const isSuperAdmin = systemRole === SystemRole.SUPER_ADMIN;
+      const isFromOrg = orgId === query.orgId;
+      if (!isFromOrg && !isSuperAdmin) {
+        throw new UnauthorizedAccessError();
+      }
+
+      const allTeams = await this.listMyTeamsUseCase.execute();
+      const orgTeams = allTeams.filter((team) => team.orgId === query.orgId);
+      const overrideTeams = orgTeams.filter(
+        (team) => team.modelOverrideEnabled,
+      );
+
+      if (overrideTeams.length === 0) {
+        this.logger.debug(
+          'No override teams found, returning org-level models',
+          {
+            userId,
+            orgId: query.orgId,
+          },
+        );
+        return this.permittedModelsRepository.findManyLanguage(query.orgId);
+      }
+
+      const merged = await this.mergeTeamModels(
+        overrideTeams.map((t) => t.id),
+        query.orgId,
+      );
+
+      if (merged.length === 0) {
+        this.logger.debug(
+          'Override teams have no configured models, falling back to org-level models',
+          { userId, orgId: query.orgId },
+        );
+        return this.permittedModelsRepository.findManyLanguage(query.orgId);
+      }
+
+      return merged;
+    } catch (error) {
+      if (error instanceof ApplicationError) {
+        throw error;
+      }
+      this.logger.error('Error resolving effective language models', {
+        userId,
+        orgId: query.orgId,
+        error: error instanceof Error ? error : new Error('Unknown error'),
+      });
+      throw new UnexpectedModelError(error as Error);
+    }
+  }
+
+  private async mergeTeamModels(
+    teamIds: UUID[],
+    orgId: UUID,
+  ): Promise<PermittedLanguageModel[]> {
+    const teamModelArrays = await Promise.all(
+      teamIds.map((teamId) =>
+        this.permittedModelsRepository.findManyLanguageByTeam(teamId, orgId),
+      ),
+    );
+
+    const modelsByModelId = new Map<UUID, PermittedLanguageModel>();
+    for (const teamModels of teamModelArrays) {
+      for (const model of teamModels) {
+        if (!modelsByModelId.has(model.model.id)) {
+          modelsByModelId.set(model.model.id, model);
+        }
+      }
+    }
+
+    this.logger.debug('Merged team models', {
+      teamIds,
+      modelCount: modelsByModelId.size,
+    });
+
+    return Array.from(modelsByModelId.values());
+  }
+}

--- a/ayunis-core-backend/src/domain/models/infrastructure/persistence/local-permitted-models/local-permitted-models.repository.ts
+++ b/ayunis-core-backend/src/domain/models/infrastructure/persistence/local-permitted-models/local-permitted-models.repository.ts
@@ -9,11 +9,12 @@ import {
   PermittedLanguageModel,
   PermittedModel,
 } from 'src/domain/models/domain/permitted-model.entity';
-import { Repository } from 'typeorm';
+import { FindOptionsWhere, Repository } from 'typeorm';
 import { PermittedModelRecord } from './schema/permitted-model.record';
 import { UUID } from 'crypto';
 import { PermittedModelMapper } from './mappers/permitted-model.mapper';
 import { ModelProvider } from 'src/domain/models/domain/value-objects/model-provider.enum';
+import { PermittedModelScope } from 'src/domain/models/domain/value-objects/permitted-model-scope.enum';
 import {
   EmbeddingModelRecord,
   LanguageModelRecord,
@@ -42,6 +43,7 @@ export class LocalPermittedModelsRepository extends PermittedModelsRepository {
     const permittedModels = await this.permittedModelRepository.find({
       where: {
         orgId,
+        scope: PermittedModelScope.ORG,
         model: { provider: filter?.provider, id: filter?.modelId },
       },
       relations: {
@@ -63,6 +65,7 @@ export class LocalPermittedModelsRepository extends PermittedModelsRepository {
       where: {
         orgId,
         isDefault: true,
+        scope: PermittedModelScope.ORG,
         model: { isArchived: false },
       },
       relations: {
@@ -83,6 +86,34 @@ export class LocalPermittedModelsRepository extends PermittedModelsRepository {
     ) as PermittedLanguageModel;
   }
 
+  async findTeamDefaultLanguage(
+    teamId: UUID,
+    orgId: UUID,
+  ): Promise<PermittedLanguageModel | null> {
+    this.logger.log('findTeamDefaultLanguage', { teamId, orgId });
+    const permittedModel = await this.permittedModelRepository.findOne({
+      where: {
+        scopeId: teamId,
+        orgId,
+        isDefault: true,
+        scope: PermittedModelScope.TEAM,
+        model: { isArchived: false },
+      },
+      relations: {
+        model: true,
+      },
+    });
+    if (
+      !permittedModel ||
+      !(permittedModel.model instanceof LanguageModelRecord)
+    ) {
+      return null;
+    }
+    return this.permittedModelMapper.toDomain(
+      permittedModel,
+    ) as PermittedLanguageModel;
+  }
+
   async findOne(params: FindOneParams): Promise<PermittedModel | null> {
     const where =
       'id' in params
@@ -90,6 +121,7 @@ export class LocalPermittedModelsRepository extends PermittedModelsRepository {
         : {
             model: { name: params.name, provider: params.provider },
             ...(params.orgId && { orgId: params.orgId }),
+            scope: PermittedModelScope.ORG,
           };
     const permittedModel = await this.permittedModelRepository.findOne({
       where,
@@ -120,6 +152,7 @@ export class LocalPermittedModelsRepository extends PermittedModelsRepository {
               isArchived: false,
             },
             ...(params.orgId && { orgId: params.orgId }),
+            scope: PermittedModelScope.ORG,
           };
     const permittedModel = await this.permittedModelRepository.findOne({
       where,
@@ -143,6 +176,7 @@ export class LocalPermittedModelsRepository extends PermittedModelsRepository {
     const permittedModels = await this.permittedModelRepository.find({
       where: {
         orgId,
+        scope: PermittedModelScope.ORG,
         model: { isArchived: false },
       },
       relations: {
@@ -174,6 +208,31 @@ export class LocalPermittedModelsRepository extends PermittedModelsRepository {
     const permittedModels = await this.permittedModelRepository.find({
       where: {
         orgId,
+        scope: PermittedModelScope.ORG,
+        model: { isArchived: false },
+      },
+      relations: {
+        model: true,
+      },
+    });
+    return permittedModels
+      .filter(
+        (permittedModel) => permittedModel.model instanceof LanguageModelRecord,
+      )
+      .map((permittedModel) =>
+        this.permittedModelMapper.toDomain(permittedModel),
+      ) as PermittedLanguageModel[];
+  }
+
+  async findManyLanguageByTeam(
+    teamId: UUID,
+    orgId: UUID,
+  ): Promise<PermittedLanguageModel[]> {
+    const permittedModels = await this.permittedModelRepository.find({
+      where: {
+        scopeId: teamId,
+        orgId,
+        scope: PermittedModelScope.TEAM,
         model: { isArchived: false },
       },
       relations: {
@@ -235,29 +294,47 @@ export class LocalPermittedModelsRepository extends PermittedModelsRepository {
     }
   }
 
+  async deleteTeamScopedByOrgAndModelId(
+    orgId: UUID,
+    modelId: UUID,
+  ): Promise<void> {
+    this.logger.log('deleteTeamScopedByOrgAndModelId', { orgId, modelId });
+    const result = await this.permittedModelRepository.delete({
+      orgId,
+      modelId,
+      scope: PermittedModelScope.TEAM,
+    });
+    this.logger.debug('Deleted team-scoped permitted models', {
+      orgId,
+      modelId,
+      affected: result.affected,
+    });
+  }
+
   async setAsDefault(params: {
     id: UUID;
     orgId: UUID;
+    teamId?: UUID;
   }): Promise<PermittedLanguageModel> {
     this.logger.log('setAsDefault', {
       id: params.id,
       orgId: params.orgId,
+      teamId: params.teamId,
     });
+
+    const unsetWhere = this.buildUnsetDefaultWhere(params);
+    const setWhere = this.buildSetDefaultWhere(params);
 
     // Start a transaction to ensure consistency
     return await this.permittedModelRepository.manager.transaction(
       async (manager) => {
-        // Unset any existing default for this organization
-        await manager.update(
-          PermittedModelRecord,
-          { orgId: params.orgId, isDefault: true },
-          { isDefault: false },
-        );
+        await manager.update(PermittedModelRecord, unsetWhere, {
+          isDefault: false,
+        });
 
-        // Then set the specified model as default
         const updateResult = await manager.update(
           PermittedModelRecord,
-          { id: params.id, orgId: params.orgId },
+          setWhere,
           { isDefault: true },
         );
 
@@ -267,7 +344,6 @@ export class LocalPermittedModelsRepository extends PermittedModelsRepository {
           );
         }
 
-        // Fetch and return the updated model
         const updatedModel = await manager.findOne(PermittedModelRecord, {
           where: { id: params.id, orgId: params.orgId },
           relations: ['model'],
@@ -282,6 +358,7 @@ export class LocalPermittedModelsRepository extends PermittedModelsRepository {
         this.logger.debug('Model set as default', {
           id: params.id,
           orgId: params.orgId,
+          teamId: params.teamId,
           modelName: updatedModel.model.name,
           modelProvider: updatedModel.model.provider,
         });
@@ -335,6 +412,43 @@ export class LocalPermittedModelsRepository extends PermittedModelsRepository {
     });
 
     return permittedModels.map((pm) => this.permittedModelMapper.toDomain(pm));
+  }
+
+  private buildUnsetDefaultWhere(params: {
+    orgId: UUID;
+    teamId?: UUID;
+  }): FindOptionsWhere<PermittedModelRecord> {
+    return params.teamId
+      ? {
+          orgId: params.orgId,
+          scopeId: params.teamId,
+          scope: PermittedModelScope.TEAM,
+          isDefault: true,
+        }
+      : {
+          orgId: params.orgId,
+          scope: PermittedModelScope.ORG,
+          isDefault: true,
+        };
+  }
+
+  private buildSetDefaultWhere(params: {
+    id: UUID;
+    orgId: UUID;
+    teamId?: UUID;
+  }): FindOptionsWhere<PermittedModelRecord> {
+    return params.teamId
+      ? {
+          id: params.id,
+          orgId: params.orgId,
+          scopeId: params.teamId,
+          scope: PermittedModelScope.TEAM,
+        }
+      : {
+          id: params.id,
+          orgId: params.orgId,
+          scope: PermittedModelScope.ORG,
+        };
   }
 
   async unsetDefaultsByCatalogModelId(catalogModelId: UUID): Promise<void> {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces new scope-aware querying and default-setting paths for permitted models, which can change which language models users see and which defaults are stored. Risk is moderate due to new team/org scoping logic and delete/update behavior on persisted model records.
> 
> **Overview**
> Adds **team-scoped permitted language model support** to the `PermittedModelsRepository` (team default lookup, team-scoped language listing, and bulk delete of team-scoped entries by org+model).
> 
> Implements `GetEffectiveLanguageModelsUseCase` to resolve the *effective* language model list for a user: it authorizes org access (with super-admin bypass), then prefers the union of models from the user’s `modelOverrideEnabled` teams (deduped by model id) and falls back to org-scoped models when no override teams or no team models exist (covered by new unit tests).
> 
> Updates `LocalPermittedModelsRepository` queries to be **scope-aware** (org methods now filter `scope=ORG`), adds team-scoped query methods, and extends `setAsDefault` to optionally set/unset defaults within a team scope via helper-built `where` clauses.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cc3ab2b425491b15313c50170d9016d089a247ec. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->