### PR TITLE
wip(AYC-77): wire TeamMembershipPort adapter and update default model fallback chain

### DIFF
--- a/ayunis-core-backend/src/domain/models/application/use-cases/get-default-model/get-default-model.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/get-default-model/get-default-model.use-case.spec.ts
@@ -1,0 +1,360 @@
+import type { TestingModule } from '@nestjs/testing';
+import { Test } from '@nestjs/testing';
+import { GetDefaultModelUseCase } from './get-default-model.use-case';
+import { GetDefaultModelQuery } from './get-default-model.query';
+import { PermittedModelsRepository } from '../../ports/permitted-models.repository';
+import { UserDefaultModelsRepository } from '../../ports/user-default-models.repository';
+import { GetEffectiveLanguageModelsUseCase } from '../get-effective-language-models/get-effective-language-models.use-case';
+import { PermittedLanguageModel } from 'src/domain/models/domain/permitted-model.entity';
+import { LanguageModel } from 'src/domain/models/domain/models/language.model';
+import { ModelProvider } from 'src/domain/models/domain/value-objects/model-provider.enum';
+import { PermittedModelScope } from 'src/domain/models/domain/value-objects/permitted-model-scope.enum';
+import { DefaultModelNotFoundError } from '../../models.errors';
+import type { UUID } from 'crypto';
+
+describe('GetDefaultModelUseCase', () => {
+  let useCase: GetDefaultModelUseCase;
+  let permittedModelsRepository: jest.Mocked<PermittedModelsRepository>;
+  let userDefaultModelsRepository: jest.Mocked<UserDefaultModelsRepository>;
+  let getEffectiveLanguageModelsUseCase: jest.Mocked<GetEffectiveLanguageModelsUseCase>;
+
+  const userId = '11111111-1111-1111-1111-111111111111' as UUID;
+  const orgId = '22222222-2222-2222-2222-222222222222' as UUID;
+  const teamAId = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa' as UUID;
+  const teamBId = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb' as UUID;
+
+  function makeLanguageModel(name: string, id?: UUID): LanguageModel {
+    return new LanguageModel({
+      id: id ?? (`${name}-0000-0000-0000-000000000000` as UUID),
+      name,
+      displayName: name,
+      provider: ModelProvider.OPENAI,
+      canStream: true,
+      isReasoning: false,
+      isArchived: false,
+      canUseTools: true,
+      canVision: false,
+    });
+  }
+
+  function makePermittedLanguageModel(
+    model: LanguageModel,
+    overrides?: {
+      id?: UUID;
+      scope?: PermittedModelScope;
+      scopeId?: UUID | null;
+      isDefault?: boolean;
+    },
+  ): PermittedLanguageModel {
+    return new PermittedLanguageModel({
+      id: overrides?.id,
+      model,
+      orgId,
+      scope: overrides?.scope ?? PermittedModelScope.ORG,
+      scopeId: overrides?.scopeId ?? null,
+      isDefault: overrides?.isDefault ?? false,
+    });
+  }
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        GetDefaultModelUseCase,
+        {
+          provide: PermittedModelsRepository,
+          useValue: {
+            findOrgDefaultLanguage: jest.fn(),
+            findTeamDefaultLanguage: jest.fn(),
+          },
+        },
+        {
+          provide: UserDefaultModelsRepository,
+          useValue: {
+            findByUserId: jest.fn(),
+          },
+        },
+        {
+          provide: GetEffectiveLanguageModelsUseCase,
+          useValue: {
+            execute: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    useCase = module.get(GetDefaultModelUseCase);
+    permittedModelsRepository = module.get(PermittedModelsRepository);
+    userDefaultModelsRepository = module.get(UserDefaultModelsRepository);
+    getEffectiveLanguageModelsUseCase = module.get(
+      GetEffectiveLanguageModelsUseCase,
+    );
+
+    // Default: no user default
+    userDefaultModelsRepository.findByUserId.mockResolvedValue(null);
+    permittedModelsRepository.findOrgDefaultLanguage.mockResolvedValue(null);
+  });
+
+  it('should return user default when it is in the effective set', async () => {
+    const gpt4 = makeLanguageModel('gpt-4');
+    const userDefault = makePermittedLanguageModel(gpt4);
+    const effectiveModels = [userDefault];
+
+    getEffectiveLanguageModelsUseCase.execute.mockResolvedValue({
+      models: effectiveModels,
+      overrideTeamIds: [],
+    });
+    userDefaultModelsRepository.findByUserId.mockResolvedValue(userDefault);
+
+    const result = await useCase.execute(
+      new GetDefaultModelQuery({ orgId, userId }),
+    );
+
+    expect(result).toBe(userDefault);
+  });
+
+  it('should skip user default when it is NOT in the effective set', async () => {
+    const gpt4 = makeLanguageModel('gpt-4');
+    const claude = makeLanguageModel('claude-3-sonnet');
+
+    const userDefault = makePermittedLanguageModel(gpt4);
+    const effectiveModels = [makePermittedLanguageModel(claude)];
+
+    getEffectiveLanguageModelsUseCase.execute.mockResolvedValue({
+      models: effectiveModels,
+      overrideTeamIds: [],
+    });
+    userDefaultModelsRepository.findByUserId.mockResolvedValue(userDefault);
+
+    const result = await useCase.execute(
+      new GetDefaultModelQuery({ orgId, userId }),
+    );
+
+    // Should fall through to first available (claude)
+    expect(result.model.name).toBe('claude-3-sonnet');
+  });
+
+  it('should return team default from override teams', async () => {
+    const gpt4 = makeLanguageModel('gpt-4');
+    const claude = makeLanguageModel('claude-3-sonnet');
+
+    const teamDefault = makePermittedLanguageModel(claude, {
+      scope: PermittedModelScope.TEAM,
+      scopeId: teamAId,
+      isDefault: true,
+    });
+    const effectiveModels = [
+      makePermittedLanguageModel(gpt4, {
+        scope: PermittedModelScope.TEAM,
+        scopeId: teamAId,
+      }),
+      makePermittedLanguageModel(claude, {
+        scope: PermittedModelScope.TEAM,
+        scopeId: teamAId,
+      }),
+    ];
+
+    getEffectiveLanguageModelsUseCase.execute.mockResolvedValue({
+      models: effectiveModels,
+      overrideTeamIds: [teamAId],
+    });
+    userDefaultModelsRepository.findByUserId.mockResolvedValue(null);
+    permittedModelsRepository.findTeamDefaultLanguage.mockResolvedValue(
+      teamDefault,
+    );
+
+    const result = await useCase.execute(
+      new GetDefaultModelQuery({ orgId, userId }),
+    );
+
+    expect(result.model.name).toBe('claude-3-sonnet');
+  });
+
+  it('should pick alphabetically first team default across multiple override teams', async () => {
+    const gpt4 = makeLanguageModel('gpt-4');
+    const claude = makeLanguageModel('claude-3-sonnet');
+
+    const teamADefault = makePermittedLanguageModel(gpt4, {
+      scope: PermittedModelScope.TEAM,
+      scopeId: teamAId,
+      isDefault: true,
+    });
+    const teamBDefault = makePermittedLanguageModel(claude, {
+      scope: PermittedModelScope.TEAM,
+      scopeId: teamBId,
+      isDefault: true,
+    });
+    const effectiveModels = [
+      makePermittedLanguageModel(gpt4, {
+        scope: PermittedModelScope.TEAM,
+        scopeId: teamAId,
+      }),
+      makePermittedLanguageModel(claude, {
+        scope: PermittedModelScope.TEAM,
+        scopeId: teamBId,
+      }),
+    ];
+
+    getEffectiveLanguageModelsUseCase.execute.mockResolvedValue({
+      models: effectiveModels,
+      overrideTeamIds: [teamAId, teamBId],
+    });
+    permittedModelsRepository.findTeamDefaultLanguage
+      .mockResolvedValueOnce(teamADefault) // team A default: gpt-4
+      .mockResolvedValueOnce(teamBDefault); // team B default: claude-3-sonnet
+
+    const result = await useCase.execute(
+      new GetDefaultModelQuery({ orgId, userId }),
+    );
+
+    // claude-3-sonnet < gpt-4 alphabetically
+    expect(result.model.name).toBe('claude-3-sonnet');
+  });
+
+  it('should return org default when in effective set and no user/team defaults', async () => {
+    const gpt4 = makeLanguageModel('gpt-4');
+    const orgDefault = makePermittedLanguageModel(gpt4, { isDefault: true });
+    const effectiveModels = [orgDefault];
+
+    getEffectiveLanguageModelsUseCase.execute.mockResolvedValue({
+      models: effectiveModels,
+      overrideTeamIds: [],
+    });
+    permittedModelsRepository.findOrgDefaultLanguage.mockResolvedValue(
+      orgDefault,
+    );
+
+    const result = await useCase.execute(
+      new GetDefaultModelQuery({ orgId, userId }),
+    );
+
+    expect(result).toBe(orgDefault);
+  });
+
+  it('should skip org default when NOT in effective set', async () => {
+    const gpt4 = makeLanguageModel('gpt-4');
+    const claude = makeLanguageModel('claude-3-sonnet');
+
+    const orgDefault = makePermittedLanguageModel(gpt4, { isDefault: true });
+    const effectiveModels = [makePermittedLanguageModel(claude)];
+
+    getEffectiveLanguageModelsUseCase.execute.mockResolvedValue({
+      models: effectiveModels,
+      overrideTeamIds: [],
+    });
+    permittedModelsRepository.findOrgDefaultLanguage.mockResolvedValue(
+      orgDefault,
+    );
+
+    const result = await useCase.execute(
+      new GetDefaultModelQuery({ orgId, userId }),
+    );
+
+    expect(result.model.name).toBe('claude-3-sonnet');
+  });
+
+  it('should return first available alphabetically when no defaults match', async () => {
+    const gpt4 = makeLanguageModel('gpt-4');
+    const claude = makeLanguageModel('claude-3-sonnet');
+    const mistral = makeLanguageModel('mistral-large');
+
+    const effectiveModels = [
+      makePermittedLanguageModel(mistral),
+      makePermittedLanguageModel(gpt4),
+      makePermittedLanguageModel(claude),
+    ];
+
+    getEffectiveLanguageModelsUseCase.execute.mockResolvedValue({
+      models: effectiveModels,
+      overrideTeamIds: [],
+    });
+
+    const result = await useCase.execute(
+      new GetDefaultModelQuery({ orgId, userId }),
+    );
+
+    expect(result.model.name).toBe('claude-3-sonnet');
+  });
+
+  it('should throw DefaultModelNotFoundError when no models available', async () => {
+    getEffectiveLanguageModelsUseCase.execute.mockResolvedValue({
+      models: [],
+      overrideTeamIds: [],
+    });
+
+    await expect(
+      useCase.execute(new GetDefaultModelQuery({ orgId, userId })),
+    ).rejects.toThrow(DefaultModelNotFoundError);
+  });
+
+  it('should skip blacklisted models using catalog model ID', async () => {
+    const gpt4 = makeLanguageModel('gpt-4');
+    const claude = makeLanguageModel('claude-3-sonnet');
+    const gpt4Permitted = makePermittedLanguageModel(gpt4);
+    const claudePermitted = makePermittedLanguageModel(claude);
+
+    const effectiveModels = [gpt4Permitted, claudePermitted];
+
+    getEffectiveLanguageModelsUseCase.execute.mockResolvedValue({
+      models: effectiveModels,
+      overrideTeamIds: [],
+    });
+
+    const result = await useCase.execute(
+      new GetDefaultModelQuery({
+        orgId,
+        userId,
+        blacklistedModelIds: [claudePermitted.model.id],
+      }),
+    );
+
+    expect(result.model.name).toBe('gpt-4');
+  });
+
+  it('should work without userId (no user/team default steps)', async () => {
+    const gpt4 = makeLanguageModel('gpt-4');
+    const orgDefault = makePermittedLanguageModel(gpt4, { isDefault: true });
+
+    getEffectiveLanguageModelsUseCase.execute.mockResolvedValue({
+      models: [orgDefault],
+      overrideTeamIds: [],
+    });
+    permittedModelsRepository.findOrgDefaultLanguage.mockResolvedValue(
+      orgDefault,
+    );
+
+    const result = await useCase.execute(new GetDefaultModelQuery({ orgId }));
+
+    expect(result).toBe(orgDefault);
+    expect(userDefaultModelsRepository.findByUserId).not.toHaveBeenCalled();
+  });
+
+  it('should not query team defaults when overrideTeamIds is empty', async () => {
+    const gpt4 = makeLanguageModel('gpt-4');
+    const effectiveModels = [makePermittedLanguageModel(gpt4)];
+
+    getEffectiveLanguageModelsUseCase.execute.mockResolvedValue({
+      models: effectiveModels,
+      overrideTeamIds: [],
+    });
+
+    await useCase.execute(new GetDefaultModelQuery({ orgId, userId }));
+
+    expect(
+      permittedModelsRepository.findTeamDefaultLanguage,
+    ).not.toHaveBeenCalled();
+  });
+
+  it('should pass userId to GetEffectiveLanguageModelsUseCase', async () => {
+    const gpt4 = makeLanguageModel('gpt-4');
+    getEffectiveLanguageModelsUseCase.execute.mockResolvedValue({
+      models: [makePermittedLanguageModel(gpt4)],
+      overrideTeamIds: [],
+    });
+
+    await useCase.execute(new GetDefaultModelQuery({ orgId, userId }));
+
+    expect(getEffectiveLanguageModelsUseCase.execute).toHaveBeenCalledWith(
+      expect.objectContaining({ orgId, userId }),
+    );
+  });
+});

--- a/ayunis-core-backend/src/domain/models/application/use-cases/get-default-model/get-default-model.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/get-default-model/get-default-model.use-case.ts
@@ -1,8 +1,11 @@
 import { Injectable, Logger } from '@nestjs/common';
+import type { UUID } from 'crypto';
 import { GetDefaultModelQuery } from './get-default-model.query';
 import { PermittedLanguageModel } from 'src/domain/models/domain/permitted-model.entity';
 import { PermittedModelsRepository } from '../../ports/permitted-models.repository';
 import { UserDefaultModelsRepository } from '../../ports/user-default-models.repository';
+import { GetEffectiveLanguageModelsUseCase } from '../get-effective-language-models/get-effective-language-models.use-case';
+import { GetEffectiveLanguageModelsQuery } from '../get-effective-language-models/get-effective-language-models.query';
 import { DefaultModelNotFoundError, ModelError } from '../../models.errors';
 
 @Injectable()
@@ -12,83 +15,82 @@ export class GetDefaultModelUseCase {
   constructor(
     private readonly permittedModelsRepository: PermittedModelsRepository,
     private readonly userDefaultModelsRepository: UserDefaultModelsRepository,
+    private readonly getEffectiveLanguageModelsUseCase: GetEffectiveLanguageModelsUseCase,
   ) {}
 
   async execute(query: GetDefaultModelQuery): Promise<PermittedLanguageModel> {
-    this.logger.log('execute', {
-      query,
-    });
+    this.logger.log('execute', { query });
 
     try {
-      // Step 1: Check if user has a specific default model (if userId is provided)
-      if (query.userId) {
-        this.logger.debug('Checking for user-specific default model', {
-          userId: query.userId,
-        });
-
-        const userDefaultModel =
-          await this.userDefaultModelsRepository.findByUserId(query.userId);
-
-        if (userDefaultModel) {
-          this.logger.debug('User default model found', {
-            userId: query.userId,
-            modelId: userDefaultModel.id,
-          });
-          return userDefaultModel;
-        }
-
-        this.logger.debug(
-          'No user default model found, falling back to org default',
-          {
-            userId: query.userId,
-          },
+      const { models: effectiveModels, overrideTeamIds } =
+        await this.getEffectiveLanguageModelsUseCase.execute(
+          new GetEffectiveLanguageModelsQuery(query.orgId, query.userId),
         );
+
+      const effectiveModelIds = new Set(effectiveModels.map((m) => m.model.id));
+
+      const isInEffectiveSet = (model: PermittedLanguageModel): boolean =>
+        effectiveModelIds.has(model.model.id) &&
+        !query.blacklistedModelIds?.includes(model.model.id);
+
+      // Step 1: User default
+      if (query.userId) {
+        const userDefault = await this.userDefaultModelsRepository.findByUserId(
+          query.userId,
+        );
+
+        if (userDefault && isInEffectiveSet(userDefault)) {
+          this.logger.debug('Using user default model', {
+            userId: query.userId,
+            modelId: userDefault.id,
+          });
+          return userDefault;
+        }
       }
 
-      // Step 2: Check for organization default model
-      this.logger.debug('Checking for organization default model', {
-        orgId: query.orgId,
-      });
+      // Step 2: Team defaults (from override teams)
+      if (query.userId && overrideTeamIds.length > 0) {
+        const teamDefault = await this.resolveTeamDefault(
+          overrideTeamIds,
+          query.orgId,
+          effectiveModelIds,
+          query.blacklistedModelIds,
+        );
+        if (teamDefault) {
+          this.logger.debug('Using team default model', {
+            modelId: teamDefault.id,
+          });
+          return teamDefault;
+        }
+      }
 
-      const defaultModel =
+      // Step 3: Org default
+      const orgDefault =
         await this.permittedModelsRepository.findOrgDefaultLanguage(
           query.orgId,
         );
-
-      if (defaultModel) {
-        this.logger.debug('Organization default model found', {
+      if (orgDefault && isInEffectiveSet(orgDefault)) {
+        this.logger.debug('Using org default model', {
           orgId: query.orgId,
-          modelId: defaultModel.id,
+          modelId: orgDefault.id,
         });
-        return defaultModel;
+        return orgDefault;
       }
 
-      // Step 3: Fall back to first available model in the organization
-      this.logger.debug(
-        'No org default model found, falling back to first available model',
-        {
-          orgId: query.orgId,
-        },
+      // Step 4: First available from effective set, alphabetically
+      const sorted = [...effectiveModels].sort((a, b) =>
+        a.model.name.localeCompare(b.model.name),
       );
 
-      const availableModels =
-        await this.permittedModelsRepository.findManyLanguage(query.orgId);
-
-      let index = 0;
-      while (index < availableModels.length) {
-        const model = availableModels[index];
-        if (query.blacklistedModelIds?.includes(model.id)) {
-          index++;
-          continue;
+      for (const model of sorted) {
+        if (!query.blacklistedModelIds?.includes(model.model.id)) {
+          this.logger.debug('Using first available model alphabetically', {
+            modelId: model.id,
+          });
+          return model;
         }
-        return model;
       }
 
-      // Step 4: No models available at all
-      this.logger.error('No models available for organization', {
-        orgId: query.orgId,
-        userId: query.userId,
-      });
       throw new DefaultModelNotFoundError(query.orgId);
     } catch (error) {
       if (error instanceof ModelError) {
@@ -101,5 +103,29 @@ export class GetDefaultModelUseCase {
       });
       throw error;
     }
+  }
+
+  private async resolveTeamDefault(
+    overrideTeamIds: UUID[],
+    orgId: UUID,
+    effectiveModelIds: Set<UUID>,
+    blacklistedModelIds?: UUID[],
+  ): Promise<PermittedLanguageModel | null> {
+    const teamDefaults = await Promise.all(
+      overrideTeamIds.map((teamId) =>
+        this.permittedModelsRepository.findTeamDefaultLanguage(teamId, orgId),
+      ),
+    );
+
+    const validDefaults = teamDefaults
+      .filter(
+        (model): model is PermittedLanguageModel =>
+          model !== null &&
+          effectiveModelIds.has(model.model.id) &&
+          !blacklistedModelIds?.includes(model.model.id),
+      )
+      .sort((a, b) => a.model.name.localeCompare(b.model.name));
+
+    return validDefaults[0] ?? null;
   }
 }

--- a/ayunis-core-backend/src/domain/models/application/use-cases/get-effective-language-models/effective-language-models-result.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/get-effective-language-models/effective-language-models-result.ts
@@ -1,0 +1,7 @@
+import type { UUID } from 'crypto';
+import type { PermittedLanguageModel } from 'src/domain/models/domain/permitted-model.entity';
+
+export interface EffectiveLanguageModelsResult {
+  models: PermittedLanguageModel[];
+  overrideTeamIds: UUID[];
+}

--- a/ayunis-core-backend/src/domain/models/application/use-cases/get-effective-language-models/get-effective-language-models.query.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/get-effective-language-models/get-effective-language-models.query.ts
@@ -1,5 +1,8 @@
 import type { UUID } from 'crypto';
 
 export class GetEffectiveLanguageModelsQuery {
-  constructor(public readonly orgId: UUID) {}
+  constructor(
+    public readonly orgId: UUID,
+    public readonly userId?: UUID,
+  ) {}
 }

--- a/ayunis-core-backend/src/domain/models/application/use-cases/get-effective-language-models/get-effective-language-models.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/get-effective-language-models/get-effective-language-models.use-case.spec.ts
@@ -3,7 +3,7 @@ import { Test } from '@nestjs/testing';
 import { GetEffectiveLanguageModelsUseCase } from './get-effective-language-models.use-case';
 import { GetEffectiveLanguageModelsQuery } from './get-effective-language-models.query';
 import { PermittedModelsRepository } from '../../ports/permitted-models.repository';
-import { ListMyTeamsUseCase } from 'src/iam/teams/application/use-cases/list-my-teams/list-my-teams.use-case';
+import { FindTeamsByUserIdUseCase } from 'src/iam/teams/application/use-cases/find-teams-by-user-id/find-teams-by-user-id.use-case';
 import { Team } from 'src/iam/teams/domain/team.entity';
 import { PermittedLanguageModel } from 'src/domain/models/domain/permitted-model.entity';
 import { LanguageModel } from 'src/domain/models/domain/models/language.model';
@@ -17,7 +17,7 @@ import type { UUID } from 'crypto';
 describe('GetEffectiveLanguageModelsUseCase', () => {
   let useCase: GetEffectiveLanguageModelsUseCase;
   let permittedModelsRepository: jest.Mocked<PermittedModelsRepository>;
-  let listMyTeamsUseCase: jest.Mocked<ListMyTeamsUseCase>;
+  let findTeamsByUserIdUseCase: jest.Mocked<FindTeamsByUserIdUseCase>;
   let contextService: jest.Mocked<ContextService>;
 
   const userId = '11111111-1111-1111-1111-111111111111' as UUID;
@@ -77,7 +77,7 @@ describe('GetEffectiveLanguageModelsUseCase', () => {
           },
         },
         {
-          provide: ListMyTeamsUseCase,
+          provide: FindTeamsByUserIdUseCase,
           useValue: {
             execute: jest.fn(),
           },
@@ -93,7 +93,7 @@ describe('GetEffectiveLanguageModelsUseCase', () => {
 
     useCase = module.get(GetEffectiveLanguageModelsUseCase);
     permittedModelsRepository = module.get(PermittedModelsRepository);
-    listMyTeamsUseCase = module.get(ListMyTeamsUseCase);
+    findTeamsByUserIdUseCase = module.get(FindTeamsByUserIdUseCase);
     contextService = module.get(ContextService);
 
     // Default: user belongs to the org
@@ -115,7 +115,7 @@ describe('GetEffectiveLanguageModelsUseCase', () => {
     });
 
     await expect(
-      useCase.execute(new GetEffectiveLanguageModelsQuery(orgId)),
+      useCase.execute(new GetEffectiveLanguageModelsQuery(orgId, userId)),
     ).rejects.toThrow(UnauthorizedAccessError);
   });
 
@@ -131,28 +131,30 @@ describe('GetEffectiveLanguageModelsUseCase', () => {
     const gpt4 = makeLanguageModel('gpt-4');
     const orgModels = [makePermittedLanguageModel(gpt4)];
 
-    listMyTeamsUseCase.execute.mockResolvedValue([]);
+    findTeamsByUserIdUseCase.execute.mockResolvedValue([]);
     permittedModelsRepository.findManyLanguage.mockResolvedValue(orgModels);
 
     const result = await useCase.execute(
-      new GetEffectiveLanguageModelsQuery(orgId),
+      new GetEffectiveLanguageModelsQuery(orgId, userId),
     );
 
-    expect(result).toEqual(orgModels);
+    expect(result.models).toEqual(orgModels);
+    expect(result.overrideTeamIds).toEqual([]);
   });
 
   it('should return org models when user has no teams', async () => {
     const gpt4 = makeLanguageModel('gpt-4');
     const orgModels = [makePermittedLanguageModel(gpt4)];
 
-    listMyTeamsUseCase.execute.mockResolvedValue([]);
+    findTeamsByUserIdUseCase.execute.mockResolvedValue([]);
     permittedModelsRepository.findManyLanguage.mockResolvedValue(orgModels);
 
     const result = await useCase.execute(
-      new GetEffectiveLanguageModelsQuery(orgId),
+      new GetEffectiveLanguageModelsQuery(orgId, userId),
     );
 
-    expect(result).toEqual(orgModels);
+    expect(result.models).toEqual(orgModels);
+    expect(result.overrideTeamIds).toEqual([]);
     expect(permittedModelsRepository.findManyLanguage).toHaveBeenCalledWith(
       orgId,
     );
@@ -165,17 +167,18 @@ describe('GetEffectiveLanguageModelsUseCase', () => {
     const gpt4 = makeLanguageModel('gpt-4');
     const orgModels = [makePermittedLanguageModel(gpt4)];
 
-    listMyTeamsUseCase.execute.mockResolvedValue([
+    findTeamsByUserIdUseCase.execute.mockResolvedValue([
       makeTeam(teamAId, orgId, false),
       makeTeam(teamBId, orgId, false),
     ]);
     permittedModelsRepository.findManyLanguage.mockResolvedValue(orgModels);
 
     const result = await useCase.execute(
-      new GetEffectiveLanguageModelsQuery(orgId),
+      new GetEffectiveLanguageModelsQuery(orgId, userId),
     );
 
-    expect(result).toEqual(orgModels);
+    expect(result.models).toEqual(orgModels);
+    expect(result.overrideTeamIds).toEqual([]);
     expect(permittedModelsRepository.findManyLanguage).toHaveBeenCalledWith(
       orgId,
     );
@@ -187,7 +190,7 @@ describe('GetEffectiveLanguageModelsUseCase', () => {
       makePermittedLanguageModel(gpt4, PermittedModelScope.TEAM, teamAId),
     ];
 
-    listMyTeamsUseCase.execute.mockResolvedValue([
+    findTeamsByUserIdUseCase.execute.mockResolvedValue([
       makeTeam(teamAId, orgId, true),
     ]);
     permittedModelsRepository.findManyLanguageByTeam.mockResolvedValue(
@@ -195,10 +198,11 @@ describe('GetEffectiveLanguageModelsUseCase', () => {
     );
 
     const result = await useCase.execute(
-      new GetEffectiveLanguageModelsQuery(orgId),
+      new GetEffectiveLanguageModelsQuery(orgId, userId),
     );
 
-    expect(result).toEqual(teamModels);
+    expect(result.models).toEqual(teamModels);
+    expect(result.overrideTeamIds).toEqual([teamAId]);
     expect(
       permittedModelsRepository.findManyLanguageByTeam,
     ).toHaveBeenCalledWith(teamAId, orgId);
@@ -219,7 +223,7 @@ describe('GetEffectiveLanguageModelsUseCase', () => {
       makePermittedLanguageModel(mistral, PermittedModelScope.TEAM, teamBId),
     ];
 
-    listMyTeamsUseCase.execute.mockResolvedValue([
+    findTeamsByUserIdUseCase.execute.mockResolvedValue([
       makeTeam(teamAId, orgId, true),
       makeTeam(teamBId, orgId, true),
     ]);
@@ -228,15 +232,15 @@ describe('GetEffectiveLanguageModelsUseCase', () => {
       .mockResolvedValueOnce(teamBModels);
 
     const result = await useCase.execute(
-      new GetEffectiveLanguageModelsQuery(orgId),
+      new GetEffectiveLanguageModelsQuery(orgId, userId),
     );
 
-    // Union: gpt-4 (from A), claude (from A, deduped), mistral (from B)
-    expect(result).toHaveLength(3);
-    const modelNames = result.map((m) => m.model.name);
+    expect(result.models).toHaveLength(3);
+    const modelNames = result.models.map((m) => m.model.name);
     expect(modelNames).toContain('gpt-4');
     expect(modelNames).toContain('claude-3-sonnet');
     expect(modelNames).toContain('mistral-large');
+    expect(result.overrideTeamIds).toEqual([teamAId, teamBId]);
   });
 
   it('should use only override team models when user is in both override and non-override teams', async () => {
@@ -245,7 +249,7 @@ describe('GetEffectiveLanguageModelsUseCase', () => {
       makePermittedLanguageModel(gpt4, PermittedModelScope.TEAM, teamAId),
     ];
 
-    listMyTeamsUseCase.execute.mockResolvedValue([
+    findTeamsByUserIdUseCase.execute.mockResolvedValue([
       makeTeam(teamAId, orgId, true),
       makeTeam(teamBId, orgId, false),
     ]);
@@ -254,10 +258,11 @@ describe('GetEffectiveLanguageModelsUseCase', () => {
     );
 
     const result = await useCase.execute(
-      new GetEffectiveLanguageModelsQuery(orgId),
+      new GetEffectiveLanguageModelsQuery(orgId, userId),
     );
 
-    expect(result).toEqual(teamModels);
+    expect(result.models).toEqual(teamModels);
+    expect(result.overrideTeamIds).toEqual([teamAId]);
     expect(
       permittedModelsRepository.findManyLanguageByTeam,
     ).toHaveBeenCalledWith(teamAId, orgId);
@@ -271,22 +276,55 @@ describe('GetEffectiveLanguageModelsUseCase', () => {
     const gpt4 = makeLanguageModel('gpt-4');
     const orgModels = [makePermittedLanguageModel(gpt4)];
 
-    listMyTeamsUseCase.execute.mockResolvedValue([
+    findTeamsByUserIdUseCase.execute.mockResolvedValue([
       makeTeam(teamAId, orgId, true),
     ]);
     permittedModelsRepository.findManyLanguageByTeam.mockResolvedValue([]);
     permittedModelsRepository.findManyLanguage.mockResolvedValue(orgModels);
 
     const result = await useCase.execute(
-      new GetEffectiveLanguageModelsQuery(orgId),
+      new GetEffectiveLanguageModelsQuery(orgId, userId),
     );
 
-    expect(result).toEqual(orgModels);
+    expect(result.models).toEqual(orgModels);
+    expect(result.overrideTeamIds).toEqual([]);
     expect(
       permittedModelsRepository.findManyLanguageByTeam,
     ).toHaveBeenCalledWith(teamAId, orgId);
     expect(permittedModelsRepository.findManyLanguage).toHaveBeenCalledWith(
       orgId,
+    );
+  });
+
+  it('should return org models with empty overrideTeamIds when no userId provided', async () => {
+    const gpt4 = makeLanguageModel('gpt-4');
+    const orgModels = [makePermittedLanguageModel(gpt4)];
+
+    permittedModelsRepository.findManyLanguage.mockResolvedValue(orgModels);
+
+    const result = await useCase.execute(
+      new GetEffectiveLanguageModelsQuery(orgId),
+    );
+
+    expect(result.models).toEqual(orgModels);
+    expect(result.overrideTeamIds).toEqual([]);
+    expect(findTeamsByUserIdUseCase.execute).not.toHaveBeenCalled();
+  });
+
+  it('should use explicit userId for team membership lookup', async () => {
+    const otherUserId = '33333333-3333-3333-3333-333333333333' as UUID;
+    const gpt4 = makeLanguageModel('gpt-4');
+    const orgModels = [makePermittedLanguageModel(gpt4)];
+
+    findTeamsByUserIdUseCase.execute.mockResolvedValue([]);
+    permittedModelsRepository.findManyLanguage.mockResolvedValue(orgModels);
+
+    await useCase.execute(
+      new GetEffectiveLanguageModelsQuery(orgId, otherUserId),
+    );
+
+    expect(findTeamsByUserIdUseCase.execute).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: otherUserId }),
     );
   });
 });

--- a/ayunis-core-backend/src/domain/models/application/use-cases/get-effective-language-models/get-effective-language-models.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/get-effective-language-models/get-effective-language-models.use-case.ts
@@ -6,9 +6,11 @@ import { ContextService } from 'src/common/context/services/context.service';
 import { PermittedLanguageModel } from 'src/domain/models/domain/permitted-model.entity';
 import { PermittedModelsRepository } from '../../ports/permitted-models.repository';
 import { UnexpectedModelError } from '../../models.errors';
-import { ListMyTeamsUseCase } from 'src/iam/teams/application/use-cases/list-my-teams/list-my-teams.use-case';
+import { FindTeamsByUserIdUseCase } from 'src/iam/teams/application/use-cases/find-teams-by-user-id/find-teams-by-user-id.use-case';
+import { FindTeamsByUserIdQuery } from 'src/iam/teams/application/use-cases/find-teams-by-user-id/find-teams-by-user-id.query';
 import { GetEffectiveLanguageModelsQuery } from './get-effective-language-models.query';
 import { SystemRole } from 'src/iam/users/domain/value-objects/system-role.enum';
+import type { EffectiveLanguageModelsResult } from './effective-language-models-result';
 
 @Injectable()
 export class GetEffectiveLanguageModelsUseCase {
@@ -16,74 +18,88 @@ export class GetEffectiveLanguageModelsUseCase {
 
   constructor(
     private readonly permittedModelsRepository: PermittedModelsRepository,
-    private readonly listMyTeamsUseCase: ListMyTeamsUseCase,
+    private readonly findTeamsByUserIdUseCase: FindTeamsByUserIdUseCase,
     private readonly contextService: ContextService,
   ) {}
 
   async execute(
     query: GetEffectiveLanguageModelsQuery,
-  ): Promise<PermittedLanguageModel[]> {
-    const userId = this.contextService.get('userId');
-    if (!userId) {
-      throw new UnauthorizedAccessError({ reason: 'Missing user context' });
-    }
-
+  ): Promise<EffectiveLanguageModelsResult> {
     this.logger.log('Resolving effective language models', {
-      userId,
+      userId: query.userId,
       orgId: query.orgId,
     });
 
     try {
-      const orgId = this.contextService.get('orgId');
-      const systemRole = this.contextService.get('systemRole');
-      const isSuperAdmin = systemRole === SystemRole.SUPER_ADMIN;
-      const isFromOrg = orgId === query.orgId;
-      if (!isFromOrg && !isSuperAdmin) {
-        throw new UnauthorizedAccessError();
+      this.validateOrgAccess(query.orgId);
+
+      if (!query.userId) {
+        return this.buildOrgFallback(query.orgId);
       }
 
-      const allTeams = await this.listMyTeamsUseCase.execute();
-      const orgTeams = allTeams.filter((team) => team.orgId === query.orgId);
-      const overrideTeams = orgTeams.filter(
-        (team) => team.modelOverrideEnabled,
-      );
-
-      if (overrideTeams.length === 0) {
-        this.logger.debug(
-          'No override teams found, returning org-level models',
-          {
-            userId,
-            orgId: query.orgId,
-          },
-        );
-        return this.permittedModelsRepository.findManyLanguage(query.orgId);
-      }
-
-      const merged = await this.mergeTeamModels(
-        overrideTeams.map((t) => t.id),
-        query.orgId,
-      );
-
-      if (merged.length === 0) {
-        this.logger.debug(
-          'Override teams have no configured models, falling back to org-level models',
-          { userId, orgId: query.orgId },
-        );
-        return this.permittedModelsRepository.findManyLanguage(query.orgId);
-      }
-
-      return merged;
+      return this.resolveForUser(query.userId, query.orgId);
     } catch (error) {
       if (error instanceof ApplicationError) {
         throw error;
       }
       this.logger.error('Error resolving effective language models', {
-        userId,
+        userId: query.userId,
         orgId: query.orgId,
         error: error instanceof Error ? error : new Error('Unknown error'),
       });
       throw new UnexpectedModelError(error as Error);
     }
+  }
+
+  private validateOrgAccess(queryOrgId: UUID): void {
+    const orgId = this.contextService.get('orgId');
+    const systemRole = this.contextService.get('systemRole');
+    const isSuperAdmin = systemRole === SystemRole.SUPER_ADMIN;
+    const isFromOrg = orgId === queryOrgId;
+    if (!isFromOrg && !isSuperAdmin) {
+      throw new UnauthorizedAccessError();
+    }
+  }
+
+  private async resolveForUser(
+    userId: UUID,
+    orgId: UUID,
+  ): Promise<EffectiveLanguageModelsResult> {
+    const allTeams = await this.findTeamsByUserIdUseCase.execute(
+      new FindTeamsByUserIdQuery(userId),
+    );
+    const orgTeams = allTeams.filter((team) => team.orgId === orgId);
+    const overrideTeams = orgTeams.filter(
+      (team) => team.modelOverrideEnabled,
+    );
+    const overrideTeamIds = overrideTeams.map((t) => t.id);
+
+    if (overrideTeams.length === 0) {
+      this.logger.debug('No override teams found, returning org-level models', {
+        userId,
+        orgId,
+      });
+      return this.buildOrgFallback(orgId);
+    }
+
+    const merged = await this.mergeTeamModels(overrideTeamIds, orgId);
+
+    if (merged.length === 0) {
+      this.logger.debug(
+        'Override teams have no configured models, falling back to org-level models',
+        { userId, orgId },
+      );
+      return this.buildOrgFallback(orgId);
+    }
+
+    return { models: merged, overrideTeamIds };
+  }
+
+  private async buildOrgFallback(
+    orgId: UUID,
+  ): Promise<EffectiveLanguageModelsResult> {
+    const models = await this.permittedModelsRepository.findManyLanguage(orgId);
+    return { models, overrideTeamIds: [] };
   }
 
   private async mergeTeamModels(

--- a/ayunis-core-backend/src/domain/models/models.module.ts
+++ b/ayunis-core-backend/src/domain/models/models.module.ts
@@ -77,6 +77,8 @@ import { StackitStreamInferenceHandler } from './infrastructure/stream-inference
 import { ScalewayInferenceHandler } from './infrastructure/inference/scaleway.inference';
 import { ScalewayStreamInferenceHandler } from './infrastructure/stream-inference/scaleway.stream-inference';
 import { ConfigService } from '@nestjs/config';
+import { TeamsModule } from 'src/iam/teams/teams.module';
+import { GetEffectiveLanguageModelsUseCase } from './application/use-cases/get-effective-language-models/get-effective-language-models.use-case';
 import { StorageModule } from '../storage/storage.module';
 import { MessagesModule } from '../messages/messages.module';
 import { OpenAIResponsesMessageConverter } from './infrastructure/converters/openai-responses-message.converter';
@@ -90,6 +92,7 @@ import { MistralMessageConverter } from './infrastructure/converters/mistral-mes
     LocalModelsRepositoryModule,
     OrgsModule,
     UsersModule,
+    TeamsModule,
     StorageModule,
     forwardRef(() => MessagesModule), // ImageContentService for inference handlers
     forwardRef(() => SourcesModule), // Sources → Retrievers → FileRetrievers → Models (circular)
@@ -241,6 +244,7 @@ import { MistralMessageConverter } from './infrastructure/converters/mistral-mes
       ],
     },
     // Use Cases
+    GetEffectiveLanguageModelsUseCase,
     CreatePermittedModelUseCase,
     DeletePermittedModelUseCase,
     UpdatePermittedModelUseCase,
@@ -287,6 +291,7 @@ import { MistralMessageConverter } from './infrastructure/converters/mistral-mes
     GetPermittedModelsUseCase,
     IsModelPermittedUseCase,
     GetDefaultModelUseCase,
+    GetEffectiveLanguageModelsUseCase,
     // Use Cases
     GetInferenceUseCase,
     StreamInferenceUseCase,

--- a/ayunis-core-backend/src/iam/teams/application/use-cases/find-teams-by-user-id/find-teams-by-user-id.query.ts
+++ b/ayunis-core-backend/src/iam/teams/application/use-cases/find-teams-by-user-id/find-teams-by-user-id.query.ts
@@ -1,0 +1,5 @@
+import type { UUID } from 'crypto';
+
+export class FindTeamsByUserIdQuery {
+  constructor(public readonly userId: UUID) {}
+}

--- a/ayunis-core-backend/src/iam/teams/application/use-cases/find-teams-by-user-id/find-teams-by-user-id.use-case.ts
+++ b/ayunis-core-backend/src/iam/teams/application/use-cases/find-teams-by-user-id/find-teams-by-user-id.use-case.ts
@@ -1,0 +1,30 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { TeamsRepository } from '../../ports/teams.repository';
+import { Team } from '../../../domain/team.entity';
+import { FindTeamsByUserIdQuery } from './find-teams-by-user-id.query';
+import { UnexpectedTeamError } from '../../teams.errors';
+import { ApplicationError } from 'src/common/errors/base.error';
+
+@Injectable()
+export class FindTeamsByUserIdUseCase {
+  private readonly logger = new Logger(FindTeamsByUserIdUseCase.name);
+
+  constructor(private readonly teamsRepository: TeamsRepository) {}
+
+  async execute(query: FindTeamsByUserIdQuery): Promise<Team[]> {
+    this.logger.log('execute', { userId: query.userId });
+
+    try {
+      return await this.teamsRepository.findByUserId(query.userId);
+    } catch (error) {
+      if (error instanceof ApplicationError) {
+        throw error;
+      }
+      this.logger.error('Failed to find teams by user ID', {
+        error: error instanceof Error ? error.message : 'Unknown error',
+        userId: query.userId,
+      });
+      throw new UnexpectedTeamError(error);
+    }
+  }
+}

--- a/ayunis-core-backend/src/iam/teams/teams.module.ts
+++ b/ayunis-core-backend/src/iam/teams/teams.module.ts
@@ -20,6 +20,7 @@ import { AddTeamMemberUseCase } from './application/use-cases/add-team-member/ad
 import { RemoveTeamMemberUseCase } from './application/use-cases/remove-team-member/remove-team-member.use-case';
 import { CheckUserTeamMembershipUseCase } from './application/use-cases/check-user-team-membership/check-user-team-membership.use-case';
 import { FindAllUserIdsByTeamIdUseCase } from './application/use-cases/find-all-user-ids-by-team-id/find-all-user-ids-by-team-id.use-case';
+import { FindTeamsByUserIdUseCase } from './application/use-cases/find-teams-by-user-id/find-teams-by-user-id.use-case';
 
 import { TeamsController } from './presenters/http/teams.controller';
 import { TeamDtoMapper } from './presenters/http/mappers/team-dto.mapper';
@@ -57,6 +58,7 @@ import { UsersModule } from '../users/users.module';
     RemoveTeamMemberUseCase,
     CheckUserTeamMembershipUseCase,
     FindAllUserIdsByTeamIdUseCase,
+    FindTeamsByUserIdUseCase,
     // Mappers
     TeamDtoMapper,
     TeamMemberDtoMapper,
@@ -73,6 +75,7 @@ import { UsersModule } from '../users/users.module';
     RemoveTeamMemberUseCase,
     CheckUserTeamMembershipUseCase,
     FindAllUserIdsByTeamIdUseCase,
+    FindTeamsByUserIdUseCase,
   ],
 })
 export class TeamsModule {}

--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
@@ -1220,6 +1220,79 @@ export interface UpdateBillingInfoDto {
 
 export interface UpdateSeatsDto { [key: string]: unknown }
 
+export interface CreateTeamDto {
+  /** The name of the team */
+  name: string;
+}
+
+export interface UpdateTeamDto {
+  /** The new name of the team */
+  name: string;
+  /** Whether model access override is enabled for this team */
+  modelOverrideEnabled?: boolean;
+}
+
+export interface TeamResponseDto {
+  /** The unique identifier of the team */
+  id: string;
+  /** The name of the team */
+  name: string;
+  /** The organization ID the team belongs to */
+  orgId: string;
+  /** The date and time when the team was created */
+  createdAt: string;
+  /** The date and time when the team was last updated */
+  updatedAt: string;
+  /** Whether model access override is enabled for this team */
+  modelOverrideEnabled: boolean;
+}
+
+/**
+ * The role of the team member in the organization
+ */
+export type TeamMemberResponseDtoUserRole = typeof TeamMemberResponseDtoUserRole[keyof typeof TeamMemberResponseDtoUserRole];
+
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const TeamMemberResponseDtoUserRole = {
+  admin: 'admin',
+  user: 'user',
+} as const;
+
+export interface TeamMemberResponseDto {
+  /** The unique identifier of the team member */
+  id: string;
+  /** The user ID of the team member */
+  userId: string;
+  /** The name of the team member */
+  userName: string;
+  /** The email of the team member */
+  userEmail: string;
+  /** The role of the team member in the organization */
+  userRole: TeamMemberResponseDtoUserRole;
+  /** The date when the user joined the team */
+  joinedAt: string;
+}
+
+export interface PaginatedTeamMembersResponseDto {
+  /** Array of team members for the current page */
+  data: TeamMemberResponseDto[];
+  /** Pagination metadata */
+  pagination: PaginationDto;
+}
+
+export interface AddTeamMemberDto {
+  /** The user ID to add to the team */
+  userId: string;
+}
+
+export interface ListTeamMembersQueryDto {
+  /** Maximum number of items per page */
+  limit?: number;
+  /** Number of items to skip */
+  offset?: number;
+}
+
 export interface UploadFileResponseDto {
   /** Name of the uploaded object */
   objectName: string;
@@ -2174,79 +2247,6 @@ export interface CreateKnowledgeBaseShareDto {
   knowledgeBaseId: string;
   /** ID of the team to share with (if not provided, shares with entire organization) */
   teamId?: string;
-}
-
-export interface CreateTeamDto {
-  /** The name of the team */
-  name: string;
-}
-
-export interface UpdateTeamDto {
-  /** The new name of the team */
-  name: string;
-  /** Whether model access override is enabled for this team */
-  modelOverrideEnabled?: boolean;
-}
-
-export interface TeamResponseDto {
-  /** The unique identifier of the team */
-  id: string;
-  /** The name of the team */
-  name: string;
-  /** The organization ID the team belongs to */
-  orgId: string;
-  /** The date and time when the team was created */
-  createdAt: string;
-  /** The date and time when the team was last updated */
-  updatedAt: string;
-  /** Whether model access override is enabled for this team */
-  modelOverrideEnabled: boolean;
-}
-
-/**
- * The role of the team member in the organization
- */
-export type TeamMemberResponseDtoUserRole = typeof TeamMemberResponseDtoUserRole[keyof typeof TeamMemberResponseDtoUserRole];
-
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const TeamMemberResponseDtoUserRole = {
-  admin: 'admin',
-  user: 'user',
-} as const;
-
-export interface TeamMemberResponseDto {
-  /** The unique identifier of the team member */
-  id: string;
-  /** The user ID of the team member */
-  userId: string;
-  /** The name of the team member */
-  userName: string;
-  /** The email of the team member */
-  userEmail: string;
-  /** The role of the team member in the organization */
-  userRole: TeamMemberResponseDtoUserRole;
-  /** The date when the user joined the team */
-  joinedAt: string;
-}
-
-export interface PaginatedTeamMembersResponseDto {
-  /** Array of team members for the current page */
-  data: TeamMemberResponseDto[];
-  /** Pagination metadata */
-  pagination: PaginationDto;
-}
-
-export interface AddTeamMemberDto {
-  /** The user ID to add to the team */
-  userId: string;
-}
-
-export interface ListTeamMembersQueryDto {
-  /** Maximum number of items per page */
-  limit?: number;
-  /** Number of items to skip */
-  offset?: number;
 }
 
 /**
@@ -3673,6 +3673,17 @@ limit?: number;
 offset?: number;
 };
 
+export type TeamsControllerListTeamMembersParams = {
+/**
+ * Maximum number of items per page
+ */
+limit?: number;
+/**
+ * Number of items to skip
+ */
+offset?: number;
+};
+
 export type StorageControllerUploadFileBody = {
   /** The file to upload */
   file: Blob;
@@ -3734,17 +3745,6 @@ export const SharesControllerGetSharesEntityType = {
   skill: 'skill',
   knowledge_base: 'knowledge_base',
 } as const;
-
-export type TeamsControllerListTeamMembersParams = {
-/**
- * Maximum number of items per page
- */
-limit?: number;
-/**
- * Number of items to skip
- */
-offset?: number;
-};
 
 export type KnowledgeBasesControllerAddDocumentBody = {
   /** The file to upload (PDF, DOCX, PPTX, TXT) */

--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.ts
@@ -5303,6 +5303,707 @@ export const useSuperAdminSubscriptionsControllerUncancelSubscription = <TError 
     }
     
 /**
+ * @summary List all teams for the current organization
+ */
+export const teamsControllerListTeams = (
+    
+ signal?: AbortSignal
+) => {
+      
+      
+      return customAxiosInstance<TeamResponseDto[]>(
+      {url: `/teams`, method: 'GET', signal
+    },
+      );
+    }
+  
+
+
+
+export const getTeamsControllerListTeamsQueryKey = () => {
+    return [
+    `/teams`
+    ] as const;
+    }
+
+    
+export const getTeamsControllerListTeamsQueryOptions = <TData = Awaited<ReturnType<typeof teamsControllerListTeams>>, TError = void>( options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof teamsControllerListTeams>>, TError, TData>>, }
+) => {
+
+const {query: queryOptions} = options ?? {};
+
+  const queryKey =  queryOptions?.queryKey ?? getTeamsControllerListTeamsQueryKey();
+
+  
+
+    const queryFn: QueryFunction<Awaited<ReturnType<typeof teamsControllerListTeams>>> = ({ signal }) => teamsControllerListTeams(signal);
+
+      
+
+      
+
+   return  { queryKey, queryFn, ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof teamsControllerListTeams>>, TError, TData> & { queryKey: DataTag<QueryKey, TData, TError> }
+}
+
+export type TeamsControllerListTeamsQueryResult = NonNullable<Awaited<ReturnType<typeof teamsControllerListTeams>>>
+export type TeamsControllerListTeamsQueryError = void
+
+
+export function useTeamsControllerListTeams<TData = Awaited<ReturnType<typeof teamsControllerListTeams>>, TError = void>(
+  options: { query:Partial<UseQueryOptions<Awaited<ReturnType<typeof teamsControllerListTeams>>, TError, TData>> & Pick<
+        DefinedInitialDataOptions<
+          Awaited<ReturnType<typeof teamsControllerListTeams>>,
+          TError,
+          Awaited<ReturnType<typeof teamsControllerListTeams>>
+        > , 'initialData'
+      >, }
+ , queryClient?: QueryClient
+  ):  DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useTeamsControllerListTeams<TData = Awaited<ReturnType<typeof teamsControllerListTeams>>, TError = void>(
+  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof teamsControllerListTeams>>, TError, TData>> & Pick<
+        UndefinedInitialDataOptions<
+          Awaited<ReturnType<typeof teamsControllerListTeams>>,
+          TError,
+          Awaited<ReturnType<typeof teamsControllerListTeams>>
+        > , 'initialData'
+      >, }
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useTeamsControllerListTeams<TData = Awaited<ReturnType<typeof teamsControllerListTeams>>, TError = void>(
+  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof teamsControllerListTeams>>, TError, TData>>, }
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+/**
+ * @summary List all teams for the current organization
+ */
+
+export function useTeamsControllerListTeams<TData = Awaited<ReturnType<typeof teamsControllerListTeams>>, TError = void>(
+  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof teamsControllerListTeams>>, TError, TData>>, }
+ , queryClient?: QueryClient 
+ ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
+
+  const queryOptions = getTeamsControllerListTeamsQueryOptions(options)
+
+  const query = useQuery(queryOptions, queryClient) as  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+
+  query.queryKey = queryOptions.queryKey ;
+
+  return query;
+}
+
+
+
+
+
+/**
+ * @summary Create a new team for the current organization
+ */
+export const teamsControllerCreateTeam = (
+    createTeamDto: CreateTeamDto,
+ signal?: AbortSignal
+) => {
+      
+      
+      return customAxiosInstance<TeamResponseDto>(
+      {url: `/teams`, method: 'POST',
+      headers: {'Content-Type': 'application/json', },
+      data: createTeamDto, signal
+    },
+      );
+    }
+  
+
+
+export const getTeamsControllerCreateTeamMutationOptions = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof teamsControllerCreateTeam>>, TError,{data: CreateTeamDto}, TContext>, }
+): UseMutationOptions<Awaited<ReturnType<typeof teamsControllerCreateTeam>>, TError,{data: CreateTeamDto}, TContext> => {
+
+const mutationKey = ['teamsControllerCreateTeam'];
+const {mutation: mutationOptions} = options ?
+      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
+      options
+      : {...options, mutation: {...options.mutation, mutationKey}}
+      : {mutation: { mutationKey, }};
+
+      
+
+
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof teamsControllerCreateTeam>>, {data: CreateTeamDto}> = (props) => {
+          const {data} = props ?? {};
+
+          return  teamsControllerCreateTeam(data,)
+        }
+
+        
+
+
+  return  { mutationFn, ...mutationOptions }}
+
+    export type TeamsControllerCreateTeamMutationResult = NonNullable<Awaited<ReturnType<typeof teamsControllerCreateTeam>>>
+    export type TeamsControllerCreateTeamMutationBody = CreateTeamDto
+    export type TeamsControllerCreateTeamMutationError = void
+
+    /**
+ * @summary Create a new team for the current organization
+ */
+export const useTeamsControllerCreateTeam = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof teamsControllerCreateTeam>>, TError,{data: CreateTeamDto}, TContext>, }
+ , queryClient?: QueryClient): UseMutationResult<
+        Awaited<ReturnType<typeof teamsControllerCreateTeam>>,
+        TError,
+        {data: CreateTeamDto},
+        TContext
+      > => {
+
+      const mutationOptions = getTeamsControllerCreateTeamMutationOptions(options);
+
+      return useMutation(mutationOptions, queryClient);
+    }
+    
+/**
+ * @summary List teams the current user is a member of
+ */
+export const teamsControllerListMyTeams = (
+    
+ signal?: AbortSignal
+) => {
+      
+      
+      return customAxiosInstance<TeamResponseDto[]>(
+      {url: `/teams/me`, method: 'GET', signal
+    },
+      );
+    }
+  
+
+
+
+export const getTeamsControllerListMyTeamsQueryKey = () => {
+    return [
+    `/teams/me`
+    ] as const;
+    }
+
+    
+export const getTeamsControllerListMyTeamsQueryOptions = <TData = Awaited<ReturnType<typeof teamsControllerListMyTeams>>, TError = void>( options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof teamsControllerListMyTeams>>, TError, TData>>, }
+) => {
+
+const {query: queryOptions} = options ?? {};
+
+  const queryKey =  queryOptions?.queryKey ?? getTeamsControllerListMyTeamsQueryKey();
+
+  
+
+    const queryFn: QueryFunction<Awaited<ReturnType<typeof teamsControllerListMyTeams>>> = ({ signal }) => teamsControllerListMyTeams(signal);
+
+      
+
+      
+
+   return  { queryKey, queryFn, ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof teamsControllerListMyTeams>>, TError, TData> & { queryKey: DataTag<QueryKey, TData, TError> }
+}
+
+export type TeamsControllerListMyTeamsQueryResult = NonNullable<Awaited<ReturnType<typeof teamsControllerListMyTeams>>>
+export type TeamsControllerListMyTeamsQueryError = void
+
+
+export function useTeamsControllerListMyTeams<TData = Awaited<ReturnType<typeof teamsControllerListMyTeams>>, TError = void>(
+  options: { query:Partial<UseQueryOptions<Awaited<ReturnType<typeof teamsControllerListMyTeams>>, TError, TData>> & Pick<
+        DefinedInitialDataOptions<
+          Awaited<ReturnType<typeof teamsControllerListMyTeams>>,
+          TError,
+          Awaited<ReturnType<typeof teamsControllerListMyTeams>>
+        > , 'initialData'
+      >, }
+ , queryClient?: QueryClient
+  ):  DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useTeamsControllerListMyTeams<TData = Awaited<ReturnType<typeof teamsControllerListMyTeams>>, TError = void>(
+  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof teamsControllerListMyTeams>>, TError, TData>> & Pick<
+        UndefinedInitialDataOptions<
+          Awaited<ReturnType<typeof teamsControllerListMyTeams>>,
+          TError,
+          Awaited<ReturnType<typeof teamsControllerListMyTeams>>
+        > , 'initialData'
+      >, }
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useTeamsControllerListMyTeams<TData = Awaited<ReturnType<typeof teamsControllerListMyTeams>>, TError = void>(
+  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof teamsControllerListMyTeams>>, TError, TData>>, }
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+/**
+ * @summary List teams the current user is a member of
+ */
+
+export function useTeamsControllerListMyTeams<TData = Awaited<ReturnType<typeof teamsControllerListMyTeams>>, TError = void>(
+  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof teamsControllerListMyTeams>>, TError, TData>>, }
+ , queryClient?: QueryClient 
+ ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
+
+  const queryOptions = getTeamsControllerListMyTeamsQueryOptions(options)
+
+  const query = useQuery(queryOptions, queryClient) as  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+
+  query.queryKey = queryOptions.queryKey ;
+
+  return query;
+}
+
+
+
+
+
+/**
+ * @summary Get a team by ID
+ */
+export const teamsControllerGetTeam = (
+    id: string,
+ signal?: AbortSignal
+) => {
+      
+      
+      return customAxiosInstance<TeamResponseDto>(
+      {url: `/teams/${id}`, method: 'GET', signal
+    },
+      );
+    }
+  
+
+
+
+export const getTeamsControllerGetTeamQueryKey = (id?: string,) => {
+    return [
+    `/teams/${id}`
+    ] as const;
+    }
+
+    
+export const getTeamsControllerGetTeamQueryOptions = <TData = Awaited<ReturnType<typeof teamsControllerGetTeam>>, TError = void>(id: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof teamsControllerGetTeam>>, TError, TData>>, }
+) => {
+
+const {query: queryOptions} = options ?? {};
+
+  const queryKey =  queryOptions?.queryKey ?? getTeamsControllerGetTeamQueryKey(id);
+
+  
+
+    const queryFn: QueryFunction<Awaited<ReturnType<typeof teamsControllerGetTeam>>> = ({ signal }) => teamsControllerGetTeam(id, signal);
+
+      
+
+      
+
+   return  { queryKey, queryFn, enabled: !!(id), ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof teamsControllerGetTeam>>, TError, TData> & { queryKey: DataTag<QueryKey, TData, TError> }
+}
+
+export type TeamsControllerGetTeamQueryResult = NonNullable<Awaited<ReturnType<typeof teamsControllerGetTeam>>>
+export type TeamsControllerGetTeamQueryError = void
+
+
+export function useTeamsControllerGetTeam<TData = Awaited<ReturnType<typeof teamsControllerGetTeam>>, TError = void>(
+ id: string, options: { query:Partial<UseQueryOptions<Awaited<ReturnType<typeof teamsControllerGetTeam>>, TError, TData>> & Pick<
+        DefinedInitialDataOptions<
+          Awaited<ReturnType<typeof teamsControllerGetTeam>>,
+          TError,
+          Awaited<ReturnType<typeof teamsControllerGetTeam>>
+        > , 'initialData'
+      >, }
+ , queryClient?: QueryClient
+  ):  DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useTeamsControllerGetTeam<TData = Awaited<ReturnType<typeof teamsControllerGetTeam>>, TError = void>(
+ id: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof teamsControllerGetTeam>>, TError, TData>> & Pick<
+        UndefinedInitialDataOptions<
+          Awaited<ReturnType<typeof teamsControllerGetTeam>>,
+          TError,
+          Awaited<ReturnType<typeof teamsControllerGetTeam>>
+        > , 'initialData'
+      >, }
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useTeamsControllerGetTeam<TData = Awaited<ReturnType<typeof teamsControllerGetTeam>>, TError = void>(
+ id: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof teamsControllerGetTeam>>, TError, TData>>, }
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+/**
+ * @summary Get a team by ID
+ */
+
+export function useTeamsControllerGetTeam<TData = Awaited<ReturnType<typeof teamsControllerGetTeam>>, TError = void>(
+ id: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof teamsControllerGetTeam>>, TError, TData>>, }
+ , queryClient?: QueryClient 
+ ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
+
+  const queryOptions = getTeamsControllerGetTeamQueryOptions(id,options)
+
+  const query = useQuery(queryOptions, queryClient) as  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+
+  query.queryKey = queryOptions.queryKey ;
+
+  return query;
+}
+
+
+
+
+
+/**
+ * @summary Update a team in the current organization
+ */
+export const teamsControllerUpdateTeam = (
+    id: string,
+    updateTeamDto: UpdateTeamDto,
+ ) => {
+      
+      
+      return customAxiosInstance<TeamResponseDto>(
+      {url: `/teams/${id}`, method: 'PATCH',
+      headers: {'Content-Type': 'application/json', },
+      data: updateTeamDto
+    },
+      );
+    }
+  
+
+
+export const getTeamsControllerUpdateTeamMutationOptions = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof teamsControllerUpdateTeam>>, TError,{id: string;data: UpdateTeamDto}, TContext>, }
+): UseMutationOptions<Awaited<ReturnType<typeof teamsControllerUpdateTeam>>, TError,{id: string;data: UpdateTeamDto}, TContext> => {
+
+const mutationKey = ['teamsControllerUpdateTeam'];
+const {mutation: mutationOptions} = options ?
+      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
+      options
+      : {...options, mutation: {...options.mutation, mutationKey}}
+      : {mutation: { mutationKey, }};
+
+      
+
+
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof teamsControllerUpdateTeam>>, {id: string;data: UpdateTeamDto}> = (props) => {
+          const {id,data} = props ?? {};
+
+          return  teamsControllerUpdateTeam(id,data,)
+        }
+
+        
+
+
+  return  { mutationFn, ...mutationOptions }}
+
+    export type TeamsControllerUpdateTeamMutationResult = NonNullable<Awaited<ReturnType<typeof teamsControllerUpdateTeam>>>
+    export type TeamsControllerUpdateTeamMutationBody = UpdateTeamDto
+    export type TeamsControllerUpdateTeamMutationError = void
+
+    /**
+ * @summary Update a team in the current organization
+ */
+export const useTeamsControllerUpdateTeam = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof teamsControllerUpdateTeam>>, TError,{id: string;data: UpdateTeamDto}, TContext>, }
+ , queryClient?: QueryClient): UseMutationResult<
+        Awaited<ReturnType<typeof teamsControllerUpdateTeam>>,
+        TError,
+        {id: string;data: UpdateTeamDto},
+        TContext
+      > => {
+
+      const mutationOptions = getTeamsControllerUpdateTeamMutationOptions(options);
+
+      return useMutation(mutationOptions, queryClient);
+    }
+    
+/**
+ * @summary Delete a team from the current organization
+ */
+export const teamsControllerDeleteTeam = (
+    id: string,
+ ) => {
+      
+      
+      return customAxiosInstance<void>(
+      {url: `/teams/${id}`, method: 'DELETE'
+    },
+      );
+    }
+  
+
+
+export const getTeamsControllerDeleteTeamMutationOptions = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof teamsControllerDeleteTeam>>, TError,{id: string}, TContext>, }
+): UseMutationOptions<Awaited<ReturnType<typeof teamsControllerDeleteTeam>>, TError,{id: string}, TContext> => {
+
+const mutationKey = ['teamsControllerDeleteTeam'];
+const {mutation: mutationOptions} = options ?
+      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
+      options
+      : {...options, mutation: {...options.mutation, mutationKey}}
+      : {mutation: { mutationKey, }};
+
+      
+
+
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof teamsControllerDeleteTeam>>, {id: string}> = (props) => {
+          const {id} = props ?? {};
+
+          return  teamsControllerDeleteTeam(id,)
+        }
+
+        
+
+
+  return  { mutationFn, ...mutationOptions }}
+
+    export type TeamsControllerDeleteTeamMutationResult = NonNullable<Awaited<ReturnType<typeof teamsControllerDeleteTeam>>>
+    
+    export type TeamsControllerDeleteTeamMutationError = void
+
+    /**
+ * @summary Delete a team from the current organization
+ */
+export const useTeamsControllerDeleteTeam = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof teamsControllerDeleteTeam>>, TError,{id: string}, TContext>, }
+ , queryClient?: QueryClient): UseMutationResult<
+        Awaited<ReturnType<typeof teamsControllerDeleteTeam>>,
+        TError,
+        {id: string},
+        TContext
+      > => {
+
+      const mutationOptions = getTeamsControllerDeleteTeamMutationOptions(options);
+
+      return useMutation(mutationOptions, queryClient);
+    }
+    
+/**
+ * @summary List members of a team
+ */
+export const teamsControllerListTeamMembers = (
+    id: string,
+    params?: TeamsControllerListTeamMembersParams,
+ signal?: AbortSignal
+) => {
+      
+      
+      return customAxiosInstance<PaginatedTeamMembersResponseDto>(
+      {url: `/teams/${id}/members`, method: 'GET',
+        params, signal
+    },
+      );
+    }
+  
+
+
+
+export const getTeamsControllerListTeamMembersQueryKey = (id?: string,
+    params?: TeamsControllerListTeamMembersParams,) => {
+    return [
+    `/teams/${id}/members`, ...(params ? [params]: [])
+    ] as const;
+    }
+
+    
+export const getTeamsControllerListTeamMembersQueryOptions = <TData = Awaited<ReturnType<typeof teamsControllerListTeamMembers>>, TError = void>(id: string,
+    params?: TeamsControllerListTeamMembersParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof teamsControllerListTeamMembers>>, TError, TData>>, }
+) => {
+
+const {query: queryOptions} = options ?? {};
+
+  const queryKey =  queryOptions?.queryKey ?? getTeamsControllerListTeamMembersQueryKey(id,params);
+
+  
+
+    const queryFn: QueryFunction<Awaited<ReturnType<typeof teamsControllerListTeamMembers>>> = ({ signal }) => teamsControllerListTeamMembers(id,params, signal);
+
+      
+
+      
+
+   return  { queryKey, queryFn, enabled: !!(id), ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof teamsControllerListTeamMembers>>, TError, TData> & { queryKey: DataTag<QueryKey, TData, TError> }
+}
+
+export type TeamsControllerListTeamMembersQueryResult = NonNullable<Awaited<ReturnType<typeof teamsControllerListTeamMembers>>>
+export type TeamsControllerListTeamMembersQueryError = void
+
+
+export function useTeamsControllerListTeamMembers<TData = Awaited<ReturnType<typeof teamsControllerListTeamMembers>>, TError = void>(
+ id: string,
+    params: undefined |  TeamsControllerListTeamMembersParams, options: { query:Partial<UseQueryOptions<Awaited<ReturnType<typeof teamsControllerListTeamMembers>>, TError, TData>> & Pick<
+        DefinedInitialDataOptions<
+          Awaited<ReturnType<typeof teamsControllerListTeamMembers>>,
+          TError,
+          Awaited<ReturnType<typeof teamsControllerListTeamMembers>>
+        > , 'initialData'
+      >, }
+ , queryClient?: QueryClient
+  ):  DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useTeamsControllerListTeamMembers<TData = Awaited<ReturnType<typeof teamsControllerListTeamMembers>>, TError = void>(
+ id: string,
+    params?: TeamsControllerListTeamMembersParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof teamsControllerListTeamMembers>>, TError, TData>> & Pick<
+        UndefinedInitialDataOptions<
+          Awaited<ReturnType<typeof teamsControllerListTeamMembers>>,
+          TError,
+          Awaited<ReturnType<typeof teamsControllerListTeamMembers>>
+        > , 'initialData'
+      >, }
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useTeamsControllerListTeamMembers<TData = Awaited<ReturnType<typeof teamsControllerListTeamMembers>>, TError = void>(
+ id: string,
+    params?: TeamsControllerListTeamMembersParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof teamsControllerListTeamMembers>>, TError, TData>>, }
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+/**
+ * @summary List members of a team
+ */
+
+export function useTeamsControllerListTeamMembers<TData = Awaited<ReturnType<typeof teamsControllerListTeamMembers>>, TError = void>(
+ id: string,
+    params?: TeamsControllerListTeamMembersParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof teamsControllerListTeamMembers>>, TError, TData>>, }
+ , queryClient?: QueryClient 
+ ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
+
+  const queryOptions = getTeamsControllerListTeamMembersQueryOptions(id,params,options)
+
+  const query = useQuery(queryOptions, queryClient) as  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+
+  query.queryKey = queryOptions.queryKey ;
+
+  return query;
+}
+
+
+
+
+
+/**
+ * @summary Add a user to a team
+ */
+export const teamsControllerAddTeamMember = (
+    id: string,
+    addTeamMemberDto: AddTeamMemberDto,
+ signal?: AbortSignal
+) => {
+      
+      
+      return customAxiosInstance<TeamMemberResponseDto>(
+      {url: `/teams/${id}/members`, method: 'POST',
+      headers: {'Content-Type': 'application/json', },
+      data: addTeamMemberDto, signal
+    },
+      );
+    }
+  
+
+
+export const getTeamsControllerAddTeamMemberMutationOptions = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof teamsControllerAddTeamMember>>, TError,{id: string;data: AddTeamMemberDto}, TContext>, }
+): UseMutationOptions<Awaited<ReturnType<typeof teamsControllerAddTeamMember>>, TError,{id: string;data: AddTeamMemberDto}, TContext> => {
+
+const mutationKey = ['teamsControllerAddTeamMember'];
+const {mutation: mutationOptions} = options ?
+      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
+      options
+      : {...options, mutation: {...options.mutation, mutationKey}}
+      : {mutation: { mutationKey, }};
+
+      
+
+
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof teamsControllerAddTeamMember>>, {id: string;data: AddTeamMemberDto}> = (props) => {
+          const {id,data} = props ?? {};
+
+          return  teamsControllerAddTeamMember(id,data,)
+        }
+
+        
+
+
+  return  { mutationFn, ...mutationOptions }}
+
+    export type TeamsControllerAddTeamMemberMutationResult = NonNullable<Awaited<ReturnType<typeof teamsControllerAddTeamMember>>>
+    export type TeamsControllerAddTeamMemberMutationBody = AddTeamMemberDto
+    export type TeamsControllerAddTeamMemberMutationError = void
+
+    /**
+ * @summary Add a user to a team
+ */
+export const useTeamsControllerAddTeamMember = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof teamsControllerAddTeamMember>>, TError,{id: string;data: AddTeamMemberDto}, TContext>, }
+ , queryClient?: QueryClient): UseMutationResult<
+        Awaited<ReturnType<typeof teamsControllerAddTeamMember>>,
+        TError,
+        {id: string;data: AddTeamMemberDto},
+        TContext
+      > => {
+
+      const mutationOptions = getTeamsControllerAddTeamMemberMutationOptions(options);
+
+      return useMutation(mutationOptions, queryClient);
+    }
+    
+/**
+ * @summary Remove a user from a team
+ */
+export const teamsControllerRemoveTeamMember = (
+    id: string,
+    userId: string,
+ ) => {
+      
+      
+      return customAxiosInstance<void>(
+      {url: `/teams/${id}/members/${userId}`, method: 'DELETE'
+    },
+      );
+    }
+  
+
+
+export const getTeamsControllerRemoveTeamMemberMutationOptions = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof teamsControllerRemoveTeamMember>>, TError,{id: string;userId: string}, TContext>, }
+): UseMutationOptions<Awaited<ReturnType<typeof teamsControllerRemoveTeamMember>>, TError,{id: string;userId: string}, TContext> => {
+
+const mutationKey = ['teamsControllerRemoveTeamMember'];
+const {mutation: mutationOptions} = options ?
+      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
+      options
+      : {...options, mutation: {...options.mutation, mutationKey}}
+      : {mutation: { mutationKey, }};
+
+      
+
+
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof teamsControllerRemoveTeamMember>>, {id: string;userId: string}> = (props) => {
+          const {id,userId} = props ?? {};
+
+          return  teamsControllerRemoveTeamMember(id,userId,)
+        }
+
+        
+
+
+  return  { mutationFn, ...mutationOptions }}
+
+    export type TeamsControllerRemoveTeamMemberMutationResult = NonNullable<Awaited<ReturnType<typeof teamsControllerRemoveTeamMember>>>
+    
+    export type TeamsControllerRemoveTeamMemberMutationError = void
+
+    /**
+ * @summary Remove a user from a team
+ */
+export const useTeamsControllerRemoveTeamMember = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof teamsControllerRemoveTeamMember>>, TError,{id: string;userId: string}, TContext>, }
+ , queryClient?: QueryClient): UseMutationResult<
+        Awaited<ReturnType<typeof teamsControllerRemoveTeamMember>>,
+        TError,
+        {id: string;userId: string},
+        TContext
+      > => {
+
+      const mutationOptions = getTeamsControllerRemoveTeamMemberMutationOptions(options);
+
+      return useMutation(mutationOptions, queryClient);
+    }
+    
+/**
  * Generic file upload endpoint. Stores the file with optional metadata. Validation (file types, sizes) should be handled by consuming modules.
  * @summary Upload a file to object storage
  */
@@ -7671,707 +8372,6 @@ export const useSharesControllerDeleteShare = <TError = void,
       > => {
 
       const mutationOptions = getSharesControllerDeleteShareMutationOptions(options);
-
-      return useMutation(mutationOptions, queryClient);
-    }
-    
-/**
- * @summary List all teams for the current organization
- */
-export const teamsControllerListTeams = (
-    
- signal?: AbortSignal
-) => {
-      
-      
-      return customAxiosInstance<TeamResponseDto[]>(
-      {url: `/teams`, method: 'GET', signal
-    },
-      );
-    }
-  
-
-
-
-export const getTeamsControllerListTeamsQueryKey = () => {
-    return [
-    `/teams`
-    ] as const;
-    }
-
-    
-export const getTeamsControllerListTeamsQueryOptions = <TData = Awaited<ReturnType<typeof teamsControllerListTeams>>, TError = void>( options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof teamsControllerListTeams>>, TError, TData>>, }
-) => {
-
-const {query: queryOptions} = options ?? {};
-
-  const queryKey =  queryOptions?.queryKey ?? getTeamsControllerListTeamsQueryKey();
-
-  
-
-    const queryFn: QueryFunction<Awaited<ReturnType<typeof teamsControllerListTeams>>> = ({ signal }) => teamsControllerListTeams(signal);
-
-      
-
-      
-
-   return  { queryKey, queryFn, ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof teamsControllerListTeams>>, TError, TData> & { queryKey: DataTag<QueryKey, TData, TError> }
-}
-
-export type TeamsControllerListTeamsQueryResult = NonNullable<Awaited<ReturnType<typeof teamsControllerListTeams>>>
-export type TeamsControllerListTeamsQueryError = void
-
-
-export function useTeamsControllerListTeams<TData = Awaited<ReturnType<typeof teamsControllerListTeams>>, TError = void>(
-  options: { query:Partial<UseQueryOptions<Awaited<ReturnType<typeof teamsControllerListTeams>>, TError, TData>> & Pick<
-        DefinedInitialDataOptions<
-          Awaited<ReturnType<typeof teamsControllerListTeams>>,
-          TError,
-          Awaited<ReturnType<typeof teamsControllerListTeams>>
-        > , 'initialData'
-      >, }
- , queryClient?: QueryClient
-  ):  DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
-export function useTeamsControllerListTeams<TData = Awaited<ReturnType<typeof teamsControllerListTeams>>, TError = void>(
-  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof teamsControllerListTeams>>, TError, TData>> & Pick<
-        UndefinedInitialDataOptions<
-          Awaited<ReturnType<typeof teamsControllerListTeams>>,
-          TError,
-          Awaited<ReturnType<typeof teamsControllerListTeams>>
-        > , 'initialData'
-      >, }
- , queryClient?: QueryClient
-  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
-export function useTeamsControllerListTeams<TData = Awaited<ReturnType<typeof teamsControllerListTeams>>, TError = void>(
-  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof teamsControllerListTeams>>, TError, TData>>, }
- , queryClient?: QueryClient
-  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
-/**
- * @summary List all teams for the current organization
- */
-
-export function useTeamsControllerListTeams<TData = Awaited<ReturnType<typeof teamsControllerListTeams>>, TError = void>(
-  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof teamsControllerListTeams>>, TError, TData>>, }
- , queryClient?: QueryClient 
- ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
-
-  const queryOptions = getTeamsControllerListTeamsQueryOptions(options)
-
-  const query = useQuery(queryOptions, queryClient) as  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
-
-  query.queryKey = queryOptions.queryKey ;
-
-  return query;
-}
-
-
-
-
-
-/**
- * @summary Create a new team for the current organization
- */
-export const teamsControllerCreateTeam = (
-    createTeamDto: CreateTeamDto,
- signal?: AbortSignal
-) => {
-      
-      
-      return customAxiosInstance<TeamResponseDto>(
-      {url: `/teams`, method: 'POST',
-      headers: {'Content-Type': 'application/json', },
-      data: createTeamDto, signal
-    },
-      );
-    }
-  
-
-
-export const getTeamsControllerCreateTeamMutationOptions = <TError = void,
-    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof teamsControllerCreateTeam>>, TError,{data: CreateTeamDto}, TContext>, }
-): UseMutationOptions<Awaited<ReturnType<typeof teamsControllerCreateTeam>>, TError,{data: CreateTeamDto}, TContext> => {
-
-const mutationKey = ['teamsControllerCreateTeam'];
-const {mutation: mutationOptions} = options ?
-      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
-      options
-      : {...options, mutation: {...options.mutation, mutationKey}}
-      : {mutation: { mutationKey, }};
-
-      
-
-
-      const mutationFn: MutationFunction<Awaited<ReturnType<typeof teamsControllerCreateTeam>>, {data: CreateTeamDto}> = (props) => {
-          const {data} = props ?? {};
-
-          return  teamsControllerCreateTeam(data,)
-        }
-
-        
-
-
-  return  { mutationFn, ...mutationOptions }}
-
-    export type TeamsControllerCreateTeamMutationResult = NonNullable<Awaited<ReturnType<typeof teamsControllerCreateTeam>>>
-    export type TeamsControllerCreateTeamMutationBody = CreateTeamDto
-    export type TeamsControllerCreateTeamMutationError = void
-
-    /**
- * @summary Create a new team for the current organization
- */
-export const useTeamsControllerCreateTeam = <TError = void,
-    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof teamsControllerCreateTeam>>, TError,{data: CreateTeamDto}, TContext>, }
- , queryClient?: QueryClient): UseMutationResult<
-        Awaited<ReturnType<typeof teamsControllerCreateTeam>>,
-        TError,
-        {data: CreateTeamDto},
-        TContext
-      > => {
-
-      const mutationOptions = getTeamsControllerCreateTeamMutationOptions(options);
-
-      return useMutation(mutationOptions, queryClient);
-    }
-    
-/**
- * @summary List teams the current user is a member of
- */
-export const teamsControllerListMyTeams = (
-    
- signal?: AbortSignal
-) => {
-      
-      
-      return customAxiosInstance<TeamResponseDto[]>(
-      {url: `/teams/me`, method: 'GET', signal
-    },
-      );
-    }
-  
-
-
-
-export const getTeamsControllerListMyTeamsQueryKey = () => {
-    return [
-    `/teams/me`
-    ] as const;
-    }
-
-    
-export const getTeamsControllerListMyTeamsQueryOptions = <TData = Awaited<ReturnType<typeof teamsControllerListMyTeams>>, TError = void>( options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof teamsControllerListMyTeams>>, TError, TData>>, }
-) => {
-
-const {query: queryOptions} = options ?? {};
-
-  const queryKey =  queryOptions?.queryKey ?? getTeamsControllerListMyTeamsQueryKey();
-
-  
-
-    const queryFn: QueryFunction<Awaited<ReturnType<typeof teamsControllerListMyTeams>>> = ({ signal }) => teamsControllerListMyTeams(signal);
-
-      
-
-      
-
-   return  { queryKey, queryFn, ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof teamsControllerListMyTeams>>, TError, TData> & { queryKey: DataTag<QueryKey, TData, TError> }
-}
-
-export type TeamsControllerListMyTeamsQueryResult = NonNullable<Awaited<ReturnType<typeof teamsControllerListMyTeams>>>
-export type TeamsControllerListMyTeamsQueryError = void
-
-
-export function useTeamsControllerListMyTeams<TData = Awaited<ReturnType<typeof teamsControllerListMyTeams>>, TError = void>(
-  options: { query:Partial<UseQueryOptions<Awaited<ReturnType<typeof teamsControllerListMyTeams>>, TError, TData>> & Pick<
-        DefinedInitialDataOptions<
-          Awaited<ReturnType<typeof teamsControllerListMyTeams>>,
-          TError,
-          Awaited<ReturnType<typeof teamsControllerListMyTeams>>
-        > , 'initialData'
-      >, }
- , queryClient?: QueryClient
-  ):  DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
-export function useTeamsControllerListMyTeams<TData = Awaited<ReturnType<typeof teamsControllerListMyTeams>>, TError = void>(
-  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof teamsControllerListMyTeams>>, TError, TData>> & Pick<
-        UndefinedInitialDataOptions<
-          Awaited<ReturnType<typeof teamsControllerListMyTeams>>,
-          TError,
-          Awaited<ReturnType<typeof teamsControllerListMyTeams>>
-        > , 'initialData'
-      >, }
- , queryClient?: QueryClient
-  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
-export function useTeamsControllerListMyTeams<TData = Awaited<ReturnType<typeof teamsControllerListMyTeams>>, TError = void>(
-  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof teamsControllerListMyTeams>>, TError, TData>>, }
- , queryClient?: QueryClient
-  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
-/**
- * @summary List teams the current user is a member of
- */
-
-export function useTeamsControllerListMyTeams<TData = Awaited<ReturnType<typeof teamsControllerListMyTeams>>, TError = void>(
-  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof teamsControllerListMyTeams>>, TError, TData>>, }
- , queryClient?: QueryClient 
- ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
-
-  const queryOptions = getTeamsControllerListMyTeamsQueryOptions(options)
-
-  const query = useQuery(queryOptions, queryClient) as  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
-
-  query.queryKey = queryOptions.queryKey ;
-
-  return query;
-}
-
-
-
-
-
-/**
- * @summary Get a team by ID
- */
-export const teamsControllerGetTeam = (
-    id: string,
- signal?: AbortSignal
-) => {
-      
-      
-      return customAxiosInstance<TeamResponseDto>(
-      {url: `/teams/${id}`, method: 'GET', signal
-    },
-      );
-    }
-  
-
-
-
-export const getTeamsControllerGetTeamQueryKey = (id?: string,) => {
-    return [
-    `/teams/${id}`
-    ] as const;
-    }
-
-    
-export const getTeamsControllerGetTeamQueryOptions = <TData = Awaited<ReturnType<typeof teamsControllerGetTeam>>, TError = void>(id: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof teamsControllerGetTeam>>, TError, TData>>, }
-) => {
-
-const {query: queryOptions} = options ?? {};
-
-  const queryKey =  queryOptions?.queryKey ?? getTeamsControllerGetTeamQueryKey(id);
-
-  
-
-    const queryFn: QueryFunction<Awaited<ReturnType<typeof teamsControllerGetTeam>>> = ({ signal }) => teamsControllerGetTeam(id, signal);
-
-      
-
-      
-
-   return  { queryKey, queryFn, enabled: !!(id), ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof teamsControllerGetTeam>>, TError, TData> & { queryKey: DataTag<QueryKey, TData, TError> }
-}
-
-export type TeamsControllerGetTeamQueryResult = NonNullable<Awaited<ReturnType<typeof teamsControllerGetTeam>>>
-export type TeamsControllerGetTeamQueryError = void
-
-
-export function useTeamsControllerGetTeam<TData = Awaited<ReturnType<typeof teamsControllerGetTeam>>, TError = void>(
- id: string, options: { query:Partial<UseQueryOptions<Awaited<ReturnType<typeof teamsControllerGetTeam>>, TError, TData>> & Pick<
-        DefinedInitialDataOptions<
-          Awaited<ReturnType<typeof teamsControllerGetTeam>>,
-          TError,
-          Awaited<ReturnType<typeof teamsControllerGetTeam>>
-        > , 'initialData'
-      >, }
- , queryClient?: QueryClient
-  ):  DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
-export function useTeamsControllerGetTeam<TData = Awaited<ReturnType<typeof teamsControllerGetTeam>>, TError = void>(
- id: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof teamsControllerGetTeam>>, TError, TData>> & Pick<
-        UndefinedInitialDataOptions<
-          Awaited<ReturnType<typeof teamsControllerGetTeam>>,
-          TError,
-          Awaited<ReturnType<typeof teamsControllerGetTeam>>
-        > , 'initialData'
-      >, }
- , queryClient?: QueryClient
-  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
-export function useTeamsControllerGetTeam<TData = Awaited<ReturnType<typeof teamsControllerGetTeam>>, TError = void>(
- id: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof teamsControllerGetTeam>>, TError, TData>>, }
- , queryClient?: QueryClient
-  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
-/**
- * @summary Get a team by ID
- */
-
-export function useTeamsControllerGetTeam<TData = Awaited<ReturnType<typeof teamsControllerGetTeam>>, TError = void>(
- id: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof teamsControllerGetTeam>>, TError, TData>>, }
- , queryClient?: QueryClient 
- ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
-
-  const queryOptions = getTeamsControllerGetTeamQueryOptions(id,options)
-
-  const query = useQuery(queryOptions, queryClient) as  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
-
-  query.queryKey = queryOptions.queryKey ;
-
-  return query;
-}
-
-
-
-
-
-/**
- * @summary Update a team in the current organization
- */
-export const teamsControllerUpdateTeam = (
-    id: string,
-    updateTeamDto: UpdateTeamDto,
- ) => {
-      
-      
-      return customAxiosInstance<TeamResponseDto>(
-      {url: `/teams/${id}`, method: 'PATCH',
-      headers: {'Content-Type': 'application/json', },
-      data: updateTeamDto
-    },
-      );
-    }
-  
-
-
-export const getTeamsControllerUpdateTeamMutationOptions = <TError = void,
-    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof teamsControllerUpdateTeam>>, TError,{id: string;data: UpdateTeamDto}, TContext>, }
-): UseMutationOptions<Awaited<ReturnType<typeof teamsControllerUpdateTeam>>, TError,{id: string;data: UpdateTeamDto}, TContext> => {
-
-const mutationKey = ['teamsControllerUpdateTeam'];
-const {mutation: mutationOptions} = options ?
-      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
-      options
-      : {...options, mutation: {...options.mutation, mutationKey}}
-      : {mutation: { mutationKey, }};
-
-      
-
-
-      const mutationFn: MutationFunction<Awaited<ReturnType<typeof teamsControllerUpdateTeam>>, {id: string;data: UpdateTeamDto}> = (props) => {
-          const {id,data} = props ?? {};
-
-          return  teamsControllerUpdateTeam(id,data,)
-        }
-
-        
-
-
-  return  { mutationFn, ...mutationOptions }}
-
-    export type TeamsControllerUpdateTeamMutationResult = NonNullable<Awaited<ReturnType<typeof teamsControllerUpdateTeam>>>
-    export type TeamsControllerUpdateTeamMutationBody = UpdateTeamDto
-    export type TeamsControllerUpdateTeamMutationError = void
-
-    /**
- * @summary Update a team in the current organization
- */
-export const useTeamsControllerUpdateTeam = <TError = void,
-    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof teamsControllerUpdateTeam>>, TError,{id: string;data: UpdateTeamDto}, TContext>, }
- , queryClient?: QueryClient): UseMutationResult<
-        Awaited<ReturnType<typeof teamsControllerUpdateTeam>>,
-        TError,
-        {id: string;data: UpdateTeamDto},
-        TContext
-      > => {
-
-      const mutationOptions = getTeamsControllerUpdateTeamMutationOptions(options);
-
-      return useMutation(mutationOptions, queryClient);
-    }
-    
-/**
- * @summary Delete a team from the current organization
- */
-export const teamsControllerDeleteTeam = (
-    id: string,
- ) => {
-      
-      
-      return customAxiosInstance<void>(
-      {url: `/teams/${id}`, method: 'DELETE'
-    },
-      );
-    }
-  
-
-
-export const getTeamsControllerDeleteTeamMutationOptions = <TError = void,
-    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof teamsControllerDeleteTeam>>, TError,{id: string}, TContext>, }
-): UseMutationOptions<Awaited<ReturnType<typeof teamsControllerDeleteTeam>>, TError,{id: string}, TContext> => {
-
-const mutationKey = ['teamsControllerDeleteTeam'];
-const {mutation: mutationOptions} = options ?
-      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
-      options
-      : {...options, mutation: {...options.mutation, mutationKey}}
-      : {mutation: { mutationKey, }};
-
-      
-
-
-      const mutationFn: MutationFunction<Awaited<ReturnType<typeof teamsControllerDeleteTeam>>, {id: string}> = (props) => {
-          const {id} = props ?? {};
-
-          return  teamsControllerDeleteTeam(id,)
-        }
-
-        
-
-
-  return  { mutationFn, ...mutationOptions }}
-
-    export type TeamsControllerDeleteTeamMutationResult = NonNullable<Awaited<ReturnType<typeof teamsControllerDeleteTeam>>>
-    
-    export type TeamsControllerDeleteTeamMutationError = void
-
-    /**
- * @summary Delete a team from the current organization
- */
-export const useTeamsControllerDeleteTeam = <TError = void,
-    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof teamsControllerDeleteTeam>>, TError,{id: string}, TContext>, }
- , queryClient?: QueryClient): UseMutationResult<
-        Awaited<ReturnType<typeof teamsControllerDeleteTeam>>,
-        TError,
-        {id: string},
-        TContext
-      > => {
-
-      const mutationOptions = getTeamsControllerDeleteTeamMutationOptions(options);
-
-      return useMutation(mutationOptions, queryClient);
-    }
-    
-/**
- * @summary List members of a team
- */
-export const teamsControllerListTeamMembers = (
-    id: string,
-    params?: TeamsControllerListTeamMembersParams,
- signal?: AbortSignal
-) => {
-      
-      
-      return customAxiosInstance<PaginatedTeamMembersResponseDto>(
-      {url: `/teams/${id}/members`, method: 'GET',
-        params, signal
-    },
-      );
-    }
-  
-
-
-
-export const getTeamsControllerListTeamMembersQueryKey = (id?: string,
-    params?: TeamsControllerListTeamMembersParams,) => {
-    return [
-    `/teams/${id}/members`, ...(params ? [params]: [])
-    ] as const;
-    }
-
-    
-export const getTeamsControllerListTeamMembersQueryOptions = <TData = Awaited<ReturnType<typeof teamsControllerListTeamMembers>>, TError = void>(id: string,
-    params?: TeamsControllerListTeamMembersParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof teamsControllerListTeamMembers>>, TError, TData>>, }
-) => {
-
-const {query: queryOptions} = options ?? {};
-
-  const queryKey =  queryOptions?.queryKey ?? getTeamsControllerListTeamMembersQueryKey(id,params);
-
-  
-
-    const queryFn: QueryFunction<Awaited<ReturnType<typeof teamsControllerListTeamMembers>>> = ({ signal }) => teamsControllerListTeamMembers(id,params, signal);
-
-      
-
-      
-
-   return  { queryKey, queryFn, enabled: !!(id), ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof teamsControllerListTeamMembers>>, TError, TData> & { queryKey: DataTag<QueryKey, TData, TError> }
-}
-
-export type TeamsControllerListTeamMembersQueryResult = NonNullable<Awaited<ReturnType<typeof teamsControllerListTeamMembers>>>
-export type TeamsControllerListTeamMembersQueryError = void
-
-
-export function useTeamsControllerListTeamMembers<TData = Awaited<ReturnType<typeof teamsControllerListTeamMembers>>, TError = void>(
- id: string,
-    params: undefined |  TeamsControllerListTeamMembersParams, options: { query:Partial<UseQueryOptions<Awaited<ReturnType<typeof teamsControllerListTeamMembers>>, TError, TData>> & Pick<
-        DefinedInitialDataOptions<
-          Awaited<ReturnType<typeof teamsControllerListTeamMembers>>,
-          TError,
-          Awaited<ReturnType<typeof teamsControllerListTeamMembers>>
-        > , 'initialData'
-      >, }
- , queryClient?: QueryClient
-  ):  DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
-export function useTeamsControllerListTeamMembers<TData = Awaited<ReturnType<typeof teamsControllerListTeamMembers>>, TError = void>(
- id: string,
-    params?: TeamsControllerListTeamMembersParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof teamsControllerListTeamMembers>>, TError, TData>> & Pick<
-        UndefinedInitialDataOptions<
-          Awaited<ReturnType<typeof teamsControllerListTeamMembers>>,
-          TError,
-          Awaited<ReturnType<typeof teamsControllerListTeamMembers>>
-        > , 'initialData'
-      >, }
- , queryClient?: QueryClient
-  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
-export function useTeamsControllerListTeamMembers<TData = Awaited<ReturnType<typeof teamsControllerListTeamMembers>>, TError = void>(
- id: string,
-    params?: TeamsControllerListTeamMembersParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof teamsControllerListTeamMembers>>, TError, TData>>, }
- , queryClient?: QueryClient
-  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
-/**
- * @summary List members of a team
- */
-
-export function useTeamsControllerListTeamMembers<TData = Awaited<ReturnType<typeof teamsControllerListTeamMembers>>, TError = void>(
- id: string,
-    params?: TeamsControllerListTeamMembersParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof teamsControllerListTeamMembers>>, TError, TData>>, }
- , queryClient?: QueryClient 
- ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
-
-  const queryOptions = getTeamsControllerListTeamMembersQueryOptions(id,params,options)
-
-  const query = useQuery(queryOptions, queryClient) as  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
-
-  query.queryKey = queryOptions.queryKey ;
-
-  return query;
-}
-
-
-
-
-
-/**
- * @summary Add a user to a team
- */
-export const teamsControllerAddTeamMember = (
-    id: string,
-    addTeamMemberDto: AddTeamMemberDto,
- signal?: AbortSignal
-) => {
-      
-      
-      return customAxiosInstance<TeamMemberResponseDto>(
-      {url: `/teams/${id}/members`, method: 'POST',
-      headers: {'Content-Type': 'application/json', },
-      data: addTeamMemberDto, signal
-    },
-      );
-    }
-  
-
-
-export const getTeamsControllerAddTeamMemberMutationOptions = <TError = void,
-    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof teamsControllerAddTeamMember>>, TError,{id: string;data: AddTeamMemberDto}, TContext>, }
-): UseMutationOptions<Awaited<ReturnType<typeof teamsControllerAddTeamMember>>, TError,{id: string;data: AddTeamMemberDto}, TContext> => {
-
-const mutationKey = ['teamsControllerAddTeamMember'];
-const {mutation: mutationOptions} = options ?
-      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
-      options
-      : {...options, mutation: {...options.mutation, mutationKey}}
-      : {mutation: { mutationKey, }};
-
-      
-
-
-      const mutationFn: MutationFunction<Awaited<ReturnType<typeof teamsControllerAddTeamMember>>, {id: string;data: AddTeamMemberDto}> = (props) => {
-          const {id,data} = props ?? {};
-
-          return  teamsControllerAddTeamMember(id,data,)
-        }
-
-        
-
-
-  return  { mutationFn, ...mutationOptions }}
-
-    export type TeamsControllerAddTeamMemberMutationResult = NonNullable<Awaited<ReturnType<typeof teamsControllerAddTeamMember>>>
-    export type TeamsControllerAddTeamMemberMutationBody = AddTeamMemberDto
-    export type TeamsControllerAddTeamMemberMutationError = void
-
-    /**
- * @summary Add a user to a team
- */
-export const useTeamsControllerAddTeamMember = <TError = void,
-    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof teamsControllerAddTeamMember>>, TError,{id: string;data: AddTeamMemberDto}, TContext>, }
- , queryClient?: QueryClient): UseMutationResult<
-        Awaited<ReturnType<typeof teamsControllerAddTeamMember>>,
-        TError,
-        {id: string;data: AddTeamMemberDto},
-        TContext
-      > => {
-
-      const mutationOptions = getTeamsControllerAddTeamMemberMutationOptions(options);
-
-      return useMutation(mutationOptions, queryClient);
-    }
-    
-/**
- * @summary Remove a user from a team
- */
-export const teamsControllerRemoveTeamMember = (
-    id: string,
-    userId: string,
- ) => {
-      
-      
-      return customAxiosInstance<void>(
-      {url: `/teams/${id}/members/${userId}`, method: 'DELETE'
-    },
-      );
-    }
-  
-
-
-export const getTeamsControllerRemoveTeamMemberMutationOptions = <TError = void,
-    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof teamsControllerRemoveTeamMember>>, TError,{id: string;userId: string}, TContext>, }
-): UseMutationOptions<Awaited<ReturnType<typeof teamsControllerRemoveTeamMember>>, TError,{id: string;userId: string}, TContext> => {
-
-const mutationKey = ['teamsControllerRemoveTeamMember'];
-const {mutation: mutationOptions} = options ?
-      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
-      options
-      : {...options, mutation: {...options.mutation, mutationKey}}
-      : {mutation: { mutationKey, }};
-
-      
-
-
-      const mutationFn: MutationFunction<Awaited<ReturnType<typeof teamsControllerRemoveTeamMember>>, {id: string;userId: string}> = (props) => {
-          const {id,userId} = props ?? {};
-
-          return  teamsControllerRemoveTeamMember(id,userId,)
-        }
-
-        
-
-
-  return  { mutationFn, ...mutationOptions }}
-
-    export type TeamsControllerRemoveTeamMemberMutationResult = NonNullable<Awaited<ReturnType<typeof teamsControllerRemoveTeamMember>>>
-    
-    export type TeamsControllerRemoveTeamMemberMutationError = void
-
-    /**
- * @summary Remove a user from a team
- */
-export const useTeamsControllerRemoveTeamMember = <TError = void,
-    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof teamsControllerRemoveTeamMember>>, TError,{id: string;userId: string}, TContext>, }
- , queryClient?: QueryClient): UseMutationResult<
-        Awaited<ReturnType<typeof teamsControllerRemoveTeamMember>>,
-        TError,
-        {id: string;userId: string},
-        TContext
-      > => {
-
-      const mutationOptions = getTeamsControllerRemoveTeamMemberMutationOptions(options);
 
       return useMutation(mutationOptions, queryClient);
     }

--- a/ayunis-core-frontend/src/shared/api/openapi-schema.json
+++ b/ayunis-core-frontend/src/shared/api/openapi-schema.json
@@ -2687,6 +2687,416 @@
         ]
       }
     },
+    "/teams": {
+      "get": {
+        "operationId": "TeamsController_listTeams",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved teams",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/TeamResponseDto"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "User is not authenticated"
+          },
+          "403": {
+            "description": "User is not authorized to view teams"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "summary": "List all teams for the current organization",
+        "tags": [
+          "teams"
+        ]
+      },
+      "post": {
+        "operationId": "TeamsController_createTeam",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateTeamDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Successfully created team",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TeamResponseDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid team data provided"
+          },
+          "401": {
+            "description": "User is not authenticated"
+          },
+          "403": {
+            "description": "User is not authorized to create teams"
+          },
+          "409": {
+            "description": "Team with this name already exists in the organization"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "summary": "Create a new team for the current organization",
+        "tags": [
+          "teams"
+        ]
+      }
+    },
+    "/teams/me": {
+      "get": {
+        "operationId": "TeamsController_listMyTeams",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved user teams",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/TeamResponseDto"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "User is not authenticated"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "summary": "List teams the current user is a member of",
+        "tags": [
+          "teams"
+        ]
+      }
+    },
+    "/teams/{id}": {
+      "get": {
+        "operationId": "TeamsController_getTeam",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved team",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TeamResponseDto"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "User is not authenticated"
+          },
+          "403": {
+            "description": "User is not authorized to view teams"
+          },
+          "404": {
+            "description": "Team not found"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "summary": "Get a team by ID",
+        "tags": [
+          "teams"
+        ]
+      },
+      "patch": {
+        "operationId": "TeamsController_updateTeam",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateTeamDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successfully updated team",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TeamResponseDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid team data provided"
+          },
+          "401": {
+            "description": "User is not authenticated"
+          },
+          "403": {
+            "description": "User is not authorized to update teams"
+          },
+          "404": {
+            "description": "Team not found"
+          },
+          "409": {
+            "description": "Team with this name already exists in the organization"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "summary": "Update a team in the current organization",
+        "tags": [
+          "teams"
+        ]
+      },
+      "delete": {
+        "operationId": "TeamsController_deleteTeam",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Team successfully deleted"
+          },
+          "401": {
+            "description": "User is not authenticated"
+          },
+          "403": {
+            "description": "User is not authorized to delete teams"
+          },
+          "404": {
+            "description": "Team not found"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "summary": "Delete a team from the current organization",
+        "tags": [
+          "teams"
+        ]
+      }
+    },
+    "/teams/{id}/members": {
+      "get": {
+        "operationId": "TeamsController_listTeamMembers",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "required": false,
+            "in": "query",
+            "description": "Maximum number of items per page",
+            "schema": {
+              "default": 50,
+              "example": 50,
+              "type": "number"
+            }
+          },
+          {
+            "name": "offset",
+            "required": false,
+            "in": "query",
+            "description": "Number of items to skip",
+            "schema": {
+              "default": 0,
+              "example": 0,
+              "type": "number"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved team members",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedTeamMembersResponseDto"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "User is not authenticated"
+          },
+          "403": {
+            "description": "User is not authorized to view team members"
+          },
+          "404": {
+            "description": "Team not found"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "summary": "List members of a team",
+        "tags": [
+          "teams"
+        ]
+      },
+      "post": {
+        "operationId": "TeamsController_addTeamMember",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AddTeamMemberDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Successfully added user to team",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TeamMemberResponseDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid data provided or user not in same organization"
+          },
+          "401": {
+            "description": "User is not authenticated"
+          },
+          "403": {
+            "description": "User is not authorized to add team members"
+          },
+          "404": {
+            "description": "Team or user not found"
+          },
+          "409": {
+            "description": "User is already a member of the team"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "summary": "Add a user to a team",
+        "tags": [
+          "teams"
+        ]
+      }
+    },
+    "/teams/{id}/members/{userId}": {
+      "delete": {
+        "operationId": "TeamsController_removeTeamMember",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "userId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "User successfully removed from team"
+          },
+          "401": {
+            "description": "User is not authenticated"
+          },
+          "403": {
+            "description": "User is not authorized to remove team members"
+          },
+          "404": {
+            "description": "Team not found or user is not a member of the team"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "summary": "Remove a user from a team",
+        "tags": [
+          "teams"
+        ]
+      }
+    },
     "/storage/upload": {
       "post": {
         "description": "Generic file upload endpoint. Stores the file with optional metadata. Validation (file types, sizes) should be handled by consuming modules.",
@@ -3988,416 +4398,6 @@
         "summary": "Delete a share",
         "tags": [
           "shares"
-        ]
-      }
-    },
-    "/teams": {
-      "get": {
-        "operationId": "TeamsController_listTeams",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "description": "Successfully retrieved teams",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/TeamResponseDto"
-                  }
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "User is not authenticated"
-          },
-          "403": {
-            "description": "User is not authorized to view teams"
-          },
-          "500": {
-            "description": "Internal server error"
-          }
-        },
-        "summary": "List all teams for the current organization",
-        "tags": [
-          "teams"
-        ]
-      },
-      "post": {
-        "operationId": "TeamsController_createTeam",
-        "parameters": [],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/CreateTeamDto"
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "Successfully created team",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/TeamResponseDto"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Invalid team data provided"
-          },
-          "401": {
-            "description": "User is not authenticated"
-          },
-          "403": {
-            "description": "User is not authorized to create teams"
-          },
-          "409": {
-            "description": "Team with this name already exists in the organization"
-          },
-          "500": {
-            "description": "Internal server error"
-          }
-        },
-        "summary": "Create a new team for the current organization",
-        "tags": [
-          "teams"
-        ]
-      }
-    },
-    "/teams/me": {
-      "get": {
-        "operationId": "TeamsController_listMyTeams",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "description": "Successfully retrieved user teams",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/TeamResponseDto"
-                  }
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "User is not authenticated"
-          },
-          "500": {
-            "description": "Internal server error"
-          }
-        },
-        "summary": "List teams the current user is a member of",
-        "tags": [
-          "teams"
-        ]
-      }
-    },
-    "/teams/{id}": {
-      "get": {
-        "operationId": "TeamsController_getTeam",
-        "parameters": [
-          {
-            "name": "id",
-            "required": true,
-            "in": "path",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successfully retrieved team",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/TeamResponseDto"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "User is not authenticated"
-          },
-          "403": {
-            "description": "User is not authorized to view teams"
-          },
-          "404": {
-            "description": "Team not found"
-          },
-          "500": {
-            "description": "Internal server error"
-          }
-        },
-        "summary": "Get a team by ID",
-        "tags": [
-          "teams"
-        ]
-      },
-      "patch": {
-        "operationId": "TeamsController_updateTeam",
-        "parameters": [
-          {
-            "name": "id",
-            "required": true,
-            "in": "path",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/UpdateTeamDto"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successfully updated team",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/TeamResponseDto"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Invalid team data provided"
-          },
-          "401": {
-            "description": "User is not authenticated"
-          },
-          "403": {
-            "description": "User is not authorized to update teams"
-          },
-          "404": {
-            "description": "Team not found"
-          },
-          "409": {
-            "description": "Team with this name already exists in the organization"
-          },
-          "500": {
-            "description": "Internal server error"
-          }
-        },
-        "summary": "Update a team in the current organization",
-        "tags": [
-          "teams"
-        ]
-      },
-      "delete": {
-        "operationId": "TeamsController_deleteTeam",
-        "parameters": [
-          {
-            "name": "id",
-            "required": true,
-            "in": "path",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "Team successfully deleted"
-          },
-          "401": {
-            "description": "User is not authenticated"
-          },
-          "403": {
-            "description": "User is not authorized to delete teams"
-          },
-          "404": {
-            "description": "Team not found"
-          },
-          "500": {
-            "description": "Internal server error"
-          }
-        },
-        "summary": "Delete a team from the current organization",
-        "tags": [
-          "teams"
-        ]
-      }
-    },
-    "/teams/{id}/members": {
-      "get": {
-        "operationId": "TeamsController_listTeamMembers",
-        "parameters": [
-          {
-            "name": "id",
-            "required": true,
-            "in": "path",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "limit",
-            "required": false,
-            "in": "query",
-            "description": "Maximum number of items per page",
-            "schema": {
-              "default": 50,
-              "example": 50,
-              "type": "number"
-            }
-          },
-          {
-            "name": "offset",
-            "required": false,
-            "in": "query",
-            "description": "Number of items to skip",
-            "schema": {
-              "default": 0,
-              "example": 0,
-              "type": "number"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successfully retrieved team members",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PaginatedTeamMembersResponseDto"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "User is not authenticated"
-          },
-          "403": {
-            "description": "User is not authorized to view team members"
-          },
-          "404": {
-            "description": "Team not found"
-          },
-          "500": {
-            "description": "Internal server error"
-          }
-        },
-        "summary": "List members of a team",
-        "tags": [
-          "teams"
-        ]
-      },
-      "post": {
-        "operationId": "TeamsController_addTeamMember",
-        "parameters": [
-          {
-            "name": "id",
-            "required": true,
-            "in": "path",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/AddTeamMemberDto"
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "Successfully added user to team",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/TeamMemberResponseDto"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Invalid data provided or user not in same organization"
-          },
-          "401": {
-            "description": "User is not authenticated"
-          },
-          "403": {
-            "description": "User is not authorized to add team members"
-          },
-          "404": {
-            "description": "Team or user not found"
-          },
-          "409": {
-            "description": "User is already a member of the team"
-          },
-          "500": {
-            "description": "Internal server error"
-          }
-        },
-        "summary": "Add a user to a team",
-        "tags": [
-          "teams"
-        ]
-      }
-    },
-    "/teams/{id}/members/{userId}": {
-      "delete": {
-        "operationId": "TeamsController_removeTeamMember",
-        "parameters": [
-          {
-            "name": "id",
-            "required": true,
-            "in": "path",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "userId",
-            "required": true,
-            "in": "path",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "User successfully removed from team"
-          },
-          "401": {
-            "description": "User is not authenticated"
-          },
-          "403": {
-            "description": "User is not authorized to remove team members"
-          },
-          "404": {
-            "description": "Team not found or user is not a member of the team"
-          },
-          "500": {
-            "description": "Internal server error"
-          }
-        },
-        "summary": "Remove a user from a team",
-        "tags": [
-          "teams"
         ]
       }
     },
@@ -10053,6 +10053,184 @@
         "type": "object",
         "properties": {}
       },
+      "CreateTeamDto": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "The name of the team",
+            "example": "Engineering"
+          }
+        },
+        "required": [
+          "name"
+        ]
+      },
+      "UpdateTeamDto": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "The new name of the team",
+            "example": "Engineering"
+          },
+          "modelOverrideEnabled": {
+            "type": "boolean",
+            "description": "Whether model access override is enabled for this team",
+            "example": false
+          }
+        },
+        "required": [
+          "name"
+        ]
+      },
+      "TeamResponseDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The unique identifier of the team",
+            "example": "550e8400-e29b-41d4-a716-446655440000"
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of the team",
+            "example": "Engineering"
+          },
+          "orgId": {
+            "type": "string",
+            "description": "The organization ID the team belongs to",
+            "example": "550e8400-e29b-41d4-a716-446655440001"
+          },
+          "createdAt": {
+            "format": "date-time",
+            "type": "string",
+            "description": "The date and time when the team was created",
+            "example": "2024-01-15T10:30:00.000Z"
+          },
+          "updatedAt": {
+            "format": "date-time",
+            "type": "string",
+            "description": "The date and time when the team was last updated",
+            "example": "2024-01-15T10:30:00.000Z"
+          },
+          "modelOverrideEnabled": {
+            "type": "boolean",
+            "description": "Whether model access override is enabled for this team",
+            "example": false
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "orgId",
+          "createdAt",
+          "updatedAt",
+          "modelOverrideEnabled"
+        ]
+      },
+      "TeamMemberResponseDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The unique identifier of the team member",
+            "example": "550e8400-e29b-41d4-a716-446655440000"
+          },
+          "userId": {
+            "type": "string",
+            "description": "The user ID of the team member",
+            "example": "550e8400-e29b-41d4-a716-446655440001"
+          },
+          "userName": {
+            "type": "string",
+            "description": "The name of the team member",
+            "example": "John Doe"
+          },
+          "userEmail": {
+            "type": "string",
+            "description": "The email of the team member",
+            "example": "john.doe@example.com"
+          },
+          "userRole": {
+            "type": "string",
+            "description": "The role of the team member in the organization",
+            "enum": [
+              "admin",
+              "user"
+            ],
+            "example": "user"
+          },
+          "joinedAt": {
+            "format": "date-time",
+            "type": "string",
+            "description": "The date when the user joined the team",
+            "example": "2024-01-15T10:30:00.000Z"
+          }
+        },
+        "required": [
+          "id",
+          "userId",
+          "userName",
+          "userEmail",
+          "userRole",
+          "joinedAt"
+        ]
+      },
+      "PaginatedTeamMembersResponseDto": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "description": "Array of team members for the current page",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TeamMemberResponseDto"
+            }
+          },
+          "pagination": {
+            "description": "Pagination metadata",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PaginationDto"
+              }
+            ]
+          }
+        },
+        "required": [
+          "data",
+          "pagination"
+        ]
+      },
+      "AddTeamMemberDto": {
+        "type": "object",
+        "properties": {
+          "userId": {
+            "type": "string",
+            "description": "The user ID to add to the team",
+            "example": "550e8400-e29b-41d4-a716-446655440001"
+          }
+        },
+        "required": [
+          "userId"
+        ]
+      },
+      "ListTeamMembersQueryDto": {
+        "type": "object",
+        "properties": {
+          "limit": {
+            "type": "number",
+            "description": "Maximum number of items per page",
+            "example": 50,
+            "default": 50
+          },
+          "offset": {
+            "type": "number",
+            "description": "Number of items to skip",
+            "example": 0,
+            "default": 0
+          }
+        }
+      },
       "UploadFileResponseDto": {
         "type": "object",
         "properties": {
@@ -11588,184 +11766,6 @@
           "entityType",
           "knowledgeBaseId"
         ]
-      },
-      "CreateTeamDto": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string",
-            "description": "The name of the team",
-            "example": "Engineering"
-          }
-        },
-        "required": [
-          "name"
-        ]
-      },
-      "UpdateTeamDto": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string",
-            "description": "The new name of the team",
-            "example": "Engineering"
-          },
-          "modelOverrideEnabled": {
-            "type": "boolean",
-            "description": "Whether model access override is enabled for this team",
-            "example": false
-          }
-        },
-        "required": [
-          "name"
-        ]
-      },
-      "TeamResponseDto": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string",
-            "description": "The unique identifier of the team",
-            "example": "550e8400-e29b-41d4-a716-446655440000"
-          },
-          "name": {
-            "type": "string",
-            "description": "The name of the team",
-            "example": "Engineering"
-          },
-          "orgId": {
-            "type": "string",
-            "description": "The organization ID the team belongs to",
-            "example": "550e8400-e29b-41d4-a716-446655440001"
-          },
-          "createdAt": {
-            "format": "date-time",
-            "type": "string",
-            "description": "The date and time when the team was created",
-            "example": "2024-01-15T10:30:00.000Z"
-          },
-          "updatedAt": {
-            "format": "date-time",
-            "type": "string",
-            "description": "The date and time when the team was last updated",
-            "example": "2024-01-15T10:30:00.000Z"
-          },
-          "modelOverrideEnabled": {
-            "type": "boolean",
-            "description": "Whether model access override is enabled for this team",
-            "example": false
-          }
-        },
-        "required": [
-          "id",
-          "name",
-          "orgId",
-          "createdAt",
-          "updatedAt",
-          "modelOverrideEnabled"
-        ]
-      },
-      "TeamMemberResponseDto": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string",
-            "description": "The unique identifier of the team member",
-            "example": "550e8400-e29b-41d4-a716-446655440000"
-          },
-          "userId": {
-            "type": "string",
-            "description": "The user ID of the team member",
-            "example": "550e8400-e29b-41d4-a716-446655440001"
-          },
-          "userName": {
-            "type": "string",
-            "description": "The name of the team member",
-            "example": "John Doe"
-          },
-          "userEmail": {
-            "type": "string",
-            "description": "The email of the team member",
-            "example": "john.doe@example.com"
-          },
-          "userRole": {
-            "type": "string",
-            "description": "The role of the team member in the organization",
-            "enum": [
-              "admin",
-              "user"
-            ],
-            "example": "user"
-          },
-          "joinedAt": {
-            "format": "date-time",
-            "type": "string",
-            "description": "The date when the user joined the team",
-            "example": "2024-01-15T10:30:00.000Z"
-          }
-        },
-        "required": [
-          "id",
-          "userId",
-          "userName",
-          "userEmail",
-          "userRole",
-          "joinedAt"
-        ]
-      },
-      "PaginatedTeamMembersResponseDto": {
-        "type": "object",
-        "properties": {
-          "data": {
-            "description": "Array of team members for the current page",
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/TeamMemberResponseDto"
-            }
-          },
-          "pagination": {
-            "description": "Pagination metadata",
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/PaginationDto"
-              }
-            ]
-          }
-        },
-        "required": [
-          "data",
-          "pagination"
-        ]
-      },
-      "AddTeamMemberDto": {
-        "type": "object",
-        "properties": {
-          "userId": {
-            "type": "string",
-            "description": "The user ID to add to the team",
-            "example": "550e8400-e29b-41d4-a716-446655440001"
-          }
-        },
-        "required": [
-          "userId"
-        ]
-      },
-      "ListTeamMembersQueryDto": {
-        "type": "object",
-        "properties": {
-          "limit": {
-            "type": "number",
-            "description": "Maximum number of items per page",
-            "example": 50,
-            "default": 50
-          },
-          "offset": {
-            "type": "number",
-            "description": "Number of items to skip",
-            "example": 0,
-            "default": 0
-          }
-        }
       },
       "ConfigValueDto": {
         "type": "object",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the default-model selection flow to depend on effective model resolution (including team overrides) and introduces a new team-membership lookup use case, which can affect which model is chosen for users in production.
> 
> **Overview**
> **Default model resolution now uses the effective model set (org + team overrides).** `GetDefaultModelUseCase` is refactored to first fetch effective language models via `GetEffectiveLanguageModelsUseCase`, then select a default in order: *user default (if effective)* → *team default(s) from override teams* → *org default (if effective)* → *alphabetically first effective model*, respecting `blacklistedModelIds`.
> 
> **Effective model resolution now returns metadata and supports optional user context.** `GetEffectiveLanguageModelsUseCase` now returns `{ models, overrideTeamIds }`, accepts an optional `userId`, and uses a new `FindTeamsByUserIdUseCase` (added to `TeamsModule`) to determine override teams; when no `userId` is provided it falls back to org models without team lookups.
> 
> Adds comprehensive unit tests for the new default-model fallback chain and updates effective-model tests accordingly, and wires `TeamsModule`/`GetEffectiveLanguageModelsUseCase` into `ModelsModule` DI. Frontend generated API schemas are updated due to regeneration/reordering of team-related DTO typings.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 340d6c4452b54b42fafb7020245d739dcaf9bc9d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->