### PR TITLE
wip(AYC-77): add team detail models tab with override toggle

### DIFF
--- a/ayunis-core-backend/src/domain/agents/application/use-cases/replace-model-with-user-default/replace-model-with-user-default.command.ts
+++ b/ayunis-core-backend/src/domain/agents/application/use-cases/replace-model-with-user-default/replace-model-with-user-default.command.ts
@@ -1,5 +1,8 @@
 import type { UUID } from 'crypto';
 
 export class ReplaceModelWithUserDefaultCommand {
-  constructor(public readonly oldPermittedModelId: UUID) {}
+  constructor(
+    public readonly oldPermittedModelId: UUID,
+    public readonly catalogModelId: UUID,
+  ) {}
 }

--- a/ayunis-core-backend/src/domain/agents/application/use-cases/replace-model-with-user-default/replace-model-with-user-default.use-case.ts
+++ b/ayunis-core-backend/src/domain/agents/application/use-cases/replace-model-with-user-default/replace-model-with-user-default.use-case.ts
@@ -48,7 +48,7 @@ export class ReplaceModelWithUserDefaultUseCase {
           new GetDefaultModelQuery({
             orgId: agent.model.orgId,
             userId: agent.userId,
-            blacklistedModelIds: [command.oldPermittedModelId],
+            blacklistedModelIds: [command.catalogModelId],
           }),
         );
 

--- a/ayunis-core-backend/src/domain/models/application/use-cases/delete-permitted-model/delete-permitted-model.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/delete-permitted-model/delete-permitted-model.use-case.ts
@@ -148,6 +148,7 @@ export class DeletePermittedModelUseCase {
       new ReplaceModelWithUserDefaultCommand({
         orgId,
         oldPermittedModelId: model.id,
+        catalogModelId: model.model.id,
       }),
     );
 
@@ -158,7 +159,7 @@ export class DeletePermittedModelUseCase {
     // Replace the model in all agents that use it
     // This will fall back to the user's default model or org default model
     await this.replaceModelWithUserDefaultUseCaseAgents.execute(
-      new ReplaceModelWithUserDefaultCommandAgents(model.id),
+      new ReplaceModelWithUserDefaultCommandAgents(model.id, model.model.id),
     );
 
     // Cascade: remove team-scoped permitted models referencing the same catalog model

--- a/ayunis-core-backend/src/domain/models/presenters/http/dto/base-permitted-model-response.dto.ts
+++ b/ayunis-core-backend/src/domain/models/presenters/http/dto/base-permitted-model-response.dto.ts
@@ -1,0 +1,42 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { UUID } from 'crypto';
+import { ModelProvider } from 'src/domain/models/domain/value-objects/model-provider.enum';
+
+export abstract class BasePermittedModelResponseDto {
+  @ApiProperty({
+    type: 'string',
+    description: 'The id of the permitted model',
+  })
+  id: UUID;
+
+  @ApiProperty({
+    type: 'string',
+    description: 'The name of the model',
+  })
+  name: string;
+
+  @ApiProperty({
+    type: 'string',
+    enum: Object.values(ModelProvider),
+    description: 'The provider of the model',
+  })
+  provider: ModelProvider;
+
+  @ApiProperty({
+    type: 'string',
+    description: 'The display name of the provider',
+  })
+  providerDisplayName: string;
+
+  @ApiProperty({
+    type: 'string',
+    description: 'The display name of the model',
+  })
+  displayName: string;
+
+  @ApiProperty({
+    type: 'boolean',
+    description: 'Whether the model is archived',
+  })
+  isArchived: boolean;
+}

--- a/ayunis-core-backend/src/domain/models/presenters/http/dto/permitted-embedding-model-response.dto.ts
+++ b/ayunis-core-backend/src/domain/models/presenters/http/dto/permitted-embedding-model-response.dto.ts
@@ -1,52 +1,14 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { UUID } from 'crypto';
-import { ModelProvider } from 'src/domain/models/domain/value-objects/model-provider.enum';
 import { ModelType } from 'src/domain/models/domain/value-objects/model-type.enum';
+import { BasePermittedModelResponseDto } from './base-permitted-model-response.dto';
 
-export class PermittedEmbeddingModelResponseDto {
-  @ApiProperty({
-    type: 'string',
-    description: 'The id of the permitted model',
-  })
-  id: UUID;
-
-  @ApiProperty({
-    type: 'string',
-    description: 'The name of the model',
-  })
-  name: string;
-
-  @ApiProperty({
-    type: 'string',
-    enum: Object.values(ModelProvider),
-    description: 'The provider of the model',
-  })
-  provider: ModelProvider;
-
-  @ApiProperty({
-    type: 'string',
-    description: 'The display name of the provider',
-  })
-  providerDisplayName: string;
-
-  @ApiProperty({
-    type: 'string',
-    description: 'The display name of the model',
-  })
-  displayName: string;
-
+export class PermittedEmbeddingModelResponseDto extends BasePermittedModelResponseDto {
   @ApiProperty({
     type: 'string',
     enum: [ModelType.EMBEDDING],
     description: 'The type of the model (always embedding)',
   })
   type: ModelType.EMBEDDING;
-
-  @ApiProperty({
-    type: 'boolean',
-    description: 'Whether the model is archived',
-  })
-  isArchived: boolean;
 
   @ApiProperty({
     type: 'number',

--- a/ayunis-core-backend/src/domain/models/presenters/http/dto/permitted-language-model-response.dto.ts
+++ b/ayunis-core-backend/src/domain/models/presenters/http/dto/permitted-language-model-response.dto.ts
@@ -1,39 +1,14 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { UUID } from 'crypto';
-import { ModelProvider } from 'src/domain/models/domain/value-objects/model-provider.enum';
 import { ModelType } from 'src/domain/models/domain/value-objects/model-type.enum';
+import { BasePermittedModelResponseDto } from './base-permitted-model-response.dto';
 
-export class PermittedLanguageModelResponseDto {
+export class PermittedLanguageModelResponseDto extends BasePermittedModelResponseDto {
   @ApiProperty({
     type: 'string',
-    description: 'The id of the permitted model',
+    description: 'The catalog model UUID',
   })
-  id: UUID;
-
-  @ApiProperty({
-    type: 'string',
-    description: 'The name of the model',
-  })
-  name: string;
-
-  @ApiProperty({
-    type: 'string',
-    enum: Object.values(ModelProvider),
-    description: 'The provider of the model',
-  })
-  provider: ModelProvider;
-
-  @ApiProperty({
-    type: 'string',
-    description: 'The display name of the provider',
-  })
-  providerDisplayName: string;
-
-  @ApiProperty({
-    type: 'string',
-    description: 'The display name of the model',
-  })
-  displayName: string;
+  modelId: UUID;
 
   @ApiProperty({
     type: 'string',
@@ -41,12 +16,6 @@ export class PermittedLanguageModelResponseDto {
     description: 'The type of the model (always language)',
   })
   type: ModelType.LANGUAGE;
-
-  @ApiProperty({
-    type: 'boolean',
-    description: 'Whether the model is archived',
-  })
-  isArchived: boolean;
 
   @ApiProperty({
     type: 'boolean',

--- a/ayunis-core-backend/src/domain/models/presenters/http/mappers/model-response-dto.mapper.ts
+++ b/ayunis-core-backend/src/domain/models/presenters/http/mappers/model-response-dto.mapper.ts
@@ -21,6 +21,7 @@ export class ModelResponseDtoMapper {
 
     return {
       id: permittedModel.id,
+      modelId: permittedModel.model.id,
       name: permittedModel.model.name,
       provider: permittedModel.model.provider,
       providerDisplayName: providerInfo.displayName,

--- a/ayunis-core-backend/src/domain/threads/application/use-cases/replace-model-with-user-default/replace-model-with-user-default.command.ts
+++ b/ayunis-core-backend/src/domain/threads/application/use-cases/replace-model-with-user-default/replace-model-with-user-default.command.ts
@@ -3,14 +3,17 @@ import type { UUID } from 'crypto';
 export class ReplaceModelWithUserDefaultCommand {
   orgId: UUID;
   oldPermittedModelId?: UUID;
+  catalogModelId?: UUID;
   oldAgentId?: UUID;
   constructor(params: {
     orgId: UUID;
     oldPermittedModelId?: UUID;
+    catalogModelId?: UUID;
     oldAgentId?: UUID;
   }) {
     this.orgId = params.orgId;
     this.oldPermittedModelId = params.oldPermittedModelId;
+    this.catalogModelId = params.catalogModelId;
     this.oldAgentId = params.oldAgentId;
   }
 }

--- a/ayunis-core-backend/src/domain/threads/application/use-cases/replace-model-with-user-default/replace-model-with-user-default.use-case.ts
+++ b/ayunis-core-backend/src/domain/threads/application/use-cases/replace-model-with-user-default/replace-model-with-user-default.use-case.ts
@@ -39,8 +39,8 @@ export class ReplaceModelWithUserDefaultUseCase {
           new GetDefaultModelQuery({
             orgId: command.orgId,
             userId: thread.userId,
-            blacklistedModelIds: command.oldPermittedModelId
-              ? [command.oldPermittedModelId]
+            blacklistedModelIds: command.catalogModelId
+              ? [command.catalogModelId]
               : [],
           }),
         );

--- a/ayunis-core-frontend/src/app/routes/_authenticated/admin-settings.teams.$id.tsx
+++ b/ayunis-core-frontend/src/app/routes/_authenticated/admin-settings.teams.$id.tsx
@@ -5,6 +5,8 @@ import {
   getTeamsControllerGetTeamQueryKey,
   teamsControllerListTeamMembers,
   getTeamsControllerListTeamMembersQueryKey,
+  teamPermittedModelsControllerListTeamPermittedModels,
+  getTeamPermittedModelsControllerListTeamPermittedModelsQueryKey,
 } from '@/shared/api/generated/ayunisCoreAPI';
 
 export const Route = createFileRoute(
@@ -12,6 +14,12 @@ export const Route = createFileRoute(
 )({
   component: RouteComponent,
   loader: async ({ context: { queryClient }, params: { id } }) => {
+    void queryClient.prefetchQuery({
+      queryKey:
+        getTeamPermittedModelsControllerListTeamPermittedModelsQueryKey(id),
+      queryFn: () => teamPermittedModelsControllerListTeamPermittedModels(id),
+    });
+
     const [team, membersResponse] = await Promise.all([
       queryClient.fetchQuery({
         queryKey: getTeamsControllerGetTeamQueryKey(id),

--- a/ayunis-core-frontend/src/pages/admin-settings/team-detail/api/useCreateTeamPermittedModel.ts
+++ b/ayunis-core-frontend/src/pages/admin-settings/team-detail/api/useCreateTeamPermittedModel.ts
@@ -15,8 +15,19 @@ export function useCreateTeamPermittedModel(teamId: string) {
       onSuccess: () => {
         showSuccess(t('teamDetail.models.enableSuccess'));
       },
-      onError: () => {
-        showError(t('teamDetail.models.enableError'));
+      onError: (error: unknown) => {
+        const errorObj = error as { response?: { data?: { code?: string } } };
+        const errorCode = errorObj.response?.data?.code;
+
+        if (errorCode === 'DUPLICATE_TEAM_PERMITTED_MODEL') {
+          showError(t('teamDetail.models.enableAlreadyEnabled'));
+        } else if (errorCode === 'MODEL_NOT_FOUND') {
+          showError(t('teamDetail.models.enableModelNotFound'));
+        } else if (errorCode === 'MODEL_INVALID') {
+          showError(t('teamDetail.models.enableModelInvalid'));
+        } else {
+          showError(t('teamDetail.models.enableError'));
+        }
       },
       onSettled: () => {
         void queryClient.invalidateQueries({

--- a/ayunis-core-frontend/src/pages/admin-settings/team-detail/api/useCreateTeamPermittedModel.ts
+++ b/ayunis-core-frontend/src/pages/admin-settings/team-detail/api/useCreateTeamPermittedModel.ts
@@ -1,0 +1,40 @@
+import { useQueryClient } from '@tanstack/react-query';
+import { useTranslation } from 'react-i18next';
+import {
+  useTeamPermittedModelsControllerCreateTeamPermittedModel,
+  getTeamPermittedModelsControllerListTeamPermittedModelsQueryKey,
+} from '@/shared/api/generated/ayunisCoreAPI';
+import { showError, showSuccess } from '@/shared/lib/toast';
+
+export function useCreateTeamPermittedModel(teamId: string) {
+  const { t } = useTranslation('admin-settings-teams');
+  const queryClient = useQueryClient();
+
+  const mutation = useTeamPermittedModelsControllerCreateTeamPermittedModel({
+    mutation: {
+      onSuccess: () => {
+        showSuccess(t('teamDetail.models.enableSuccess'));
+      },
+      onError: () => {
+        showError(t('teamDetail.models.enableError'));
+      },
+      onSettled: () => {
+        void queryClient.invalidateQueries({
+          queryKey:
+            getTeamPermittedModelsControllerListTeamPermittedModelsQueryKey(
+              teamId,
+            ),
+        });
+      },
+    },
+  });
+
+  function createTeamPermittedModel(modelId: string) {
+    mutation.mutate({ teamId, data: { modelId } });
+  }
+
+  return {
+    createTeamPermittedModel,
+    isCreating: mutation.isPending,
+  };
+}

--- a/ayunis-core-frontend/src/pages/admin-settings/team-detail/api/useDeleteTeamPermittedModel.ts
+++ b/ayunis-core-frontend/src/pages/admin-settings/team-detail/api/useDeleteTeamPermittedModel.ts
@@ -1,0 +1,40 @@
+import { useQueryClient } from '@tanstack/react-query';
+import { useTranslation } from 'react-i18next';
+import {
+  useTeamPermittedModelsControllerDeleteTeamPermittedModel,
+  getTeamPermittedModelsControllerListTeamPermittedModelsQueryKey,
+} from '@/shared/api/generated/ayunisCoreAPI';
+import { showError, showSuccess } from '@/shared/lib/toast';
+
+export function useDeleteTeamPermittedModel(teamId: string) {
+  const { t } = useTranslation('admin-settings-teams');
+  const queryClient = useQueryClient();
+
+  const mutation = useTeamPermittedModelsControllerDeleteTeamPermittedModel({
+    mutation: {
+      onSuccess: () => {
+        showSuccess(t('teamDetail.models.disableSuccess'));
+      },
+      onError: () => {
+        showError(t('teamDetail.models.disableError'));
+      },
+      onSettled: () => {
+        void queryClient.invalidateQueries({
+          queryKey:
+            getTeamPermittedModelsControllerListTeamPermittedModelsQueryKey(
+              teamId,
+            ),
+        });
+      },
+    },
+  });
+
+  function deleteTeamPermittedModel(permittedModelId: string) {
+    mutation.mutate({ teamId, id: permittedModelId });
+  }
+
+  return {
+    deleteTeamPermittedModel,
+    isDeleting: mutation.isPending,
+  };
+}

--- a/ayunis-core-frontend/src/pages/admin-settings/team-detail/api/useDeleteTeamPermittedModel.ts
+++ b/ayunis-core-frontend/src/pages/admin-settings/team-detail/api/useDeleteTeamPermittedModel.ts
@@ -15,8 +15,17 @@ export function useDeleteTeamPermittedModel(teamId: string) {
       onSuccess: () => {
         showSuccess(t('teamDetail.models.disableSuccess'));
       },
-      onError: () => {
-        showError(t('teamDetail.models.disableError'));
+      onError: (error: unknown) => {
+        const errorObj = error as { response?: { data?: { code?: string } } };
+        const errorCode = errorObj.response?.data?.code;
+
+        if (errorCode === 'MODEL_NOT_FOUND') {
+          showError(t('teamDetail.models.disableModelNotFound'));
+        } else if (errorCode === 'MODEL_INVALID') {
+          showError(t('teamDetail.models.disableModelInvalid'));
+        } else {
+          showError(t('teamDetail.models.disableError'));
+        }
       },
       onSettled: () => {
         void queryClient.invalidateQueries({

--- a/ayunis-core-frontend/src/pages/admin-settings/team-detail/api/useTeamPermittedModels.ts
+++ b/ayunis-core-frontend/src/pages/admin-settings/team-detail/api/useTeamPermittedModels.ts
@@ -1,0 +1,8 @@
+import { useTeamPermittedModelsControllerListTeamPermittedModels } from '@/shared/api/generated/ayunisCoreAPI';
+
+export function useTeamPermittedModels(teamId: string) {
+  const { data: models = [], isLoading } =
+    useTeamPermittedModelsControllerListTeamPermittedModels(teamId);
+
+  return { models, isLoading };
+}

--- a/ayunis-core-frontend/src/pages/admin-settings/team-detail/api/useToggleModelOverride.ts
+++ b/ayunis-core-frontend/src/pages/admin-settings/team-detail/api/useToggleModelOverride.ts
@@ -35,11 +35,19 @@ export function useToggleModelOverride(teamId: string, teamName: string) {
       onSuccess: () => {
         showSuccess(t('teamDetail.models.overrideToggleSuccess'));
       },
-      onError: (_error, _variables, context) => {
+      onError: (error: unknown, _variables, context) => {
         if (context?.previous) {
           queryClient.setQueryData<TeamResponseDto>(queryKey, context.previous);
         }
-        showError(t('teamDetail.models.overrideToggleError'));
+
+        const errorObj = error as { response?: { data?: { code?: string } } };
+        const errorCode = errorObj.response?.data?.code;
+
+        if (errorCode === 'TEAM_NOT_FOUND') {
+          showError(t('teamDetail.models.overrideToggleNotFound'));
+        } else {
+          showError(t('teamDetail.models.overrideToggleError'));
+        }
       },
       onSettled: () => {
         void queryClient.invalidateQueries({ queryKey });

--- a/ayunis-core-frontend/src/pages/admin-settings/team-detail/api/useToggleModelOverride.ts
+++ b/ayunis-core-frontend/src/pages/admin-settings/team-detail/api/useToggleModelOverride.ts
@@ -1,0 +1,65 @@
+import { useQueryClient } from '@tanstack/react-query';
+import { useRouter } from '@tanstack/react-router';
+import { useTranslation } from 'react-i18next';
+import {
+  useTeamsControllerUpdateTeam,
+  getTeamsControllerGetTeamQueryKey,
+} from '@/shared/api/generated/ayunisCoreAPI';
+import type { TeamResponseDto } from '@/shared/api/generated/ayunisCoreAPI.schemas';
+import { showError, showSuccess } from '@/shared/lib/toast';
+
+export function useToggleModelOverride(teamId: string, teamName: string) {
+  const { t } = useTranslation('admin-settings-teams');
+  const queryClient = useQueryClient();
+  const router = useRouter();
+
+  const queryKey = getTeamsControllerGetTeamQueryKey(teamId);
+
+  const mutation = useTeamsControllerUpdateTeam({
+    mutation: {
+      onMutate: async (variables) => {
+        await queryClient.cancelQueries({ queryKey });
+        const previous = queryClient.getQueryData<TeamResponseDto>(queryKey);
+
+        if (previous) {
+          queryClient.setQueryData<TeamResponseDto>(queryKey, {
+            ...previous,
+            modelOverrideEnabled:
+              variables.data.modelOverrideEnabled ??
+              previous.modelOverrideEnabled,
+          });
+        }
+
+        return { previous };
+      },
+      onSuccess: () => {
+        showSuccess(t('teamDetail.models.overrideToggleSuccess'));
+      },
+      onError: (_error, _variables, context) => {
+        if (context?.previous) {
+          queryClient.setQueryData<TeamResponseDto>(queryKey, context.previous);
+        }
+        showError(t('teamDetail.models.overrideToggleError'));
+      },
+      onSettled: () => {
+        void queryClient.invalidateQueries({ queryKey });
+        void router.invalidate();
+      },
+    },
+  });
+
+  function toggleModelOverride(enabled: boolean) {
+    const cached = queryClient.getQueryData<TeamResponseDto>(queryKey);
+    const currentName = cached?.name ?? teamName;
+
+    mutation.mutate({
+      id: teamId,
+      data: { name: currentName, modelOverrideEnabled: enabled },
+    });
+  }
+
+  return {
+    toggleModelOverride,
+    isToggling: mutation.isPending,
+  };
+}

--- a/ayunis-core-frontend/src/pages/admin-settings/team-detail/model/types.ts
+++ b/ayunis-core-frontend/src/pages/admin-settings/team-detail/model/types.ts
@@ -2,8 +2,10 @@ import type {
   TeamResponseDto,
   TeamMemberResponseDto,
   PaginatedTeamMembersResponseDto,
+  PermittedLanguageModelResponseDto,
 } from '@/shared/api/generated/ayunisCoreAPI.schemas';
 
 export type TeamDetail = TeamResponseDto;
 export type TeamMember = TeamMemberResponseDto;
 export type PaginatedTeamMembers = PaginatedTeamMembersResponseDto;
+export type TeamPermittedModel = PermittedLanguageModelResponseDto;

--- a/ayunis-core-frontend/src/pages/admin-settings/team-detail/ui/TeamDetailPage.tsx
+++ b/ayunis-core-frontend/src/pages/admin-settings/team-detail/ui/TeamDetailPage.tsx
@@ -7,8 +7,15 @@ import {
   CardHeader,
   CardTitle,
 } from '@/shared/ui/shadcn/card';
+import {
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+} from '@/shared/ui/shadcn/tabs';
 import { TeamMembersList } from './TeamMembersList';
 import { AddTeamMemberDialog } from './AddTeamMemberDialog';
+import { TeamModelsTab } from './TeamModelsTab';
 import SettingsLayout from '../../admin-settings-layout';
 import type { TeamDetail, PaginatedTeamMembers } from '../model/types';
 
@@ -23,23 +30,49 @@ export function TeamDetailPage({
 }: Readonly<TeamDetailPageProps>) {
   const { t } = useTranslation('admin-settings-teams');
   const [addMemberDialogOpen, setAddMemberDialogOpen] = useState(false);
+  const [activeTab, setActiveTab] = useState('members');
 
-  const headerActions = (
-    <Button size="sm" onClick={() => setAddMemberDialogOpen(true)}>
-      {t('teamDetail.addMember.button')}
-    </Button>
-  );
+  const headerActions =
+    activeTab === 'members' ? (
+      <Button size="sm" onClick={() => setAddMemberDialogOpen(true)}>
+        {t('teamDetail.addMember.button')}
+      </Button>
+    ) : null;
 
   return (
     <SettingsLayout action={headerActions} title={team.name}>
-      <Card>
-        <CardHeader>
-          <CardTitle>{t('teamDetail.members.title')}</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <TeamMembersList teamId={team.id} members={membersResponse.data} />
-        </CardContent>
-      </Card>
+      <Tabs value={activeTab} onValueChange={setActiveTab}>
+        <TabsList>
+          <TabsTrigger value="members">
+            {t('teamDetail.tabs.members')}
+          </TabsTrigger>
+          <TabsTrigger value="models">
+            {t('teamDetail.tabs.models')}
+          </TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="members">
+          <Card>
+            <CardHeader>
+              <CardTitle>{t('teamDetail.members.title')}</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <TeamMembersList
+                teamId={team.id}
+                members={membersResponse.data}
+              />
+            </CardContent>
+          </Card>
+        </TabsContent>
+
+        <TabsContent value="models">
+          <TeamModelsTab
+            teamId={team.id}
+            teamName={team.name}
+            modelOverrideEnabled={team.modelOverrideEnabled}
+          />
+        </TabsContent>
+      </Tabs>
 
       <AddTeamMemberDialog
         teamId={team.id}

--- a/ayunis-core-frontend/src/pages/admin-settings/team-detail/ui/TeamModelsTab.tsx
+++ b/ayunis-core-frontend/src/pages/admin-settings/team-detail/ui/TeamModelsTab.tsx
@@ -1,0 +1,128 @@
+import { useQueryClient } from '@tanstack/react-query';
+import { useTranslation } from 'react-i18next';
+import { Switch } from '@/shared/ui/shadcn/switch';
+import { Label } from '@/shared/ui/shadcn/label';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/shared/ui/shadcn/card';
+import { useModelsWithConfig } from '@/features/models';
+import { ModelTypeCard } from '@/widgets/model-type-card';
+import type { ModelActions } from '@/widgets/model-type-card';
+import type {
+  ModelWithConfigResponseDto,
+  TeamResponseDto,
+} from '@/shared/api/generated/ayunisCoreAPI.schemas';
+import { getTeamsControllerGetTeamQueryKey } from '@/shared/api/generated/ayunisCoreAPI';
+import { useTeamPermittedModels } from '../api/useTeamPermittedModels';
+import { useCreateTeamPermittedModel } from '../api/useCreateTeamPermittedModel';
+import { useDeleteTeamPermittedModel } from '../api/useDeleteTeamPermittedModel';
+import { useToggleModelOverride } from '../api/useToggleModelOverride';
+
+interface TeamModelsTabProps {
+  readonly teamId: string;
+  readonly teamName: string;
+  readonly modelOverrideEnabled: boolean;
+}
+
+export function TeamModelsTab({
+  teamId,
+  teamName,
+  modelOverrideEnabled,
+}: TeamModelsTabProps) {
+  const queryClient = useQueryClient();
+  const cachedTeam = queryClient.getQueryData<TeamResponseDto>(
+    getTeamsControllerGetTeamQueryKey(teamId),
+  );
+  const effectiveOverrideEnabled =
+    cachedTeam?.modelOverrideEnabled ?? modelOverrideEnabled;
+  const { t } = useTranslation('admin-settings-teams');
+  const { toggleModelOverride, isToggling } = useToggleModelOverride(
+    teamId,
+    teamName,
+  );
+  const { models: orgModels } = useModelsWithConfig();
+  const { models: teamPermittedModels } = useTeamPermittedModels(teamId);
+  const { createTeamPermittedModel, isCreating } =
+    useCreateTeamPermittedModel(teamId);
+  const { deleteTeamPermittedModel, isDeleting } =
+    useDeleteTeamPermittedModel(teamId);
+
+  const permittedModelIds = new Set(teamPermittedModels.map((m) => m.modelId));
+  const permittedModelByModelId = new Map(
+    teamPermittedModels.map((m) => [m.modelId, m]),
+  );
+
+  const orgLanguageModels = orgModels.filter(
+    (m) => !m.isEmbedding && m.isPermitted,
+  );
+
+  const modelsForCard: ModelWithConfigResponseDto[] = orgLanguageModels.map(
+    (model) => {
+      const teamModel = permittedModelByModelId.get(model.modelId);
+      return {
+        ...model,
+        isPermitted: permittedModelIds.has(model.modelId),
+        permittedModelId: teamModel?.id ?? null,
+        anonymousOnly: teamModel?.anonymousOnly ?? null,
+      };
+    },
+  );
+
+  const actions: ModelActions = {
+    enableModel: (model: ModelWithConfigResponseDto) => {
+      createTeamPermittedModel(model.modelId);
+    },
+    deletePermittedModel: (permittedModelId: string) => {
+      deleteTeamPermittedModel(permittedModelId);
+    },
+    updatePermittedModel: undefined,
+    isEnabling: isCreating,
+    isDisabling: isDeleting,
+  };
+
+  return (
+    <div className="space-y-4">
+      <Card>
+        <CardHeader>
+          <CardTitle>{t('teamDetail.models.overrideTitle')}</CardTitle>
+          <CardDescription>
+            {t('teamDetail.models.overrideDescription')}
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="flex items-center gap-3">
+            <Switch
+              id="model-override-toggle"
+              checked={effectiveOverrideEnabled}
+              disabled={isToggling}
+              onCheckedChange={toggleModelOverride}
+            />
+            <Label htmlFor="model-override-toggle">
+              {t('teamDetail.models.overrideLabel')}
+            </Label>
+          </div>
+        </CardContent>
+      </Card>
+
+      {effectiveOverrideEnabled ? (
+        <ModelTypeCard
+          type="language"
+          models={modelsForCard}
+          actions={actions}
+        />
+      ) : (
+        <Card>
+          <CardContent className="py-6">
+            <p className="text-muted-foreground text-center">
+              {t('teamDetail.models.overrideDisabledMessage')}
+            </p>
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
@@ -182,10 +182,12 @@ export interface PermittedLanguageModelResponseDto {
   providerDisplayName: string;
   /** The display name of the model */
   displayName: string;
-  /** The type of the model (always language) */
-  type: PermittedLanguageModelResponseDtoType;
   /** Whether the model is archived */
   isArchived: boolean;
+  /** The catalog model UUID */
+  modelId: string;
+  /** The type of the model (always language) */
+  type: PermittedLanguageModelResponseDtoType;
   /** Whether the model can stream */
   canStream: boolean;
   /** Whether the model can reason */
@@ -281,10 +283,10 @@ export interface PermittedEmbeddingModelResponseDto {
   providerDisplayName: string;
   /** The display name of the model */
   displayName: string;
-  /** The type of the model (always embedding) */
-  type: PermittedEmbeddingModelResponseDtoType;
   /** Whether the model is archived */
   isArchived: boolean;
+  /** The type of the model (always embedding) */
+  type: PermittedEmbeddingModelResponseDtoType;
   /**
    * The number of dimensions for embeddings
    * @nullable

--- a/ayunis-core-frontend/src/shared/api/openapi-schema.json
+++ b/ayunis-core-frontend/src/shared/api/openapi-schema.json
@@ -8490,16 +8490,20 @@
             "type": "string",
             "description": "The display name of the model"
           },
+          "isArchived": {
+            "type": "boolean",
+            "description": "Whether the model is archived"
+          },
+          "modelId": {
+            "type": "string",
+            "description": "The catalog model UUID"
+          },
           "type": {
             "type": "string",
             "enum": [
               "language"
             ],
             "description": "The type of the model (always language)"
-          },
-          "isArchived": {
-            "type": "boolean",
-            "description": "Whether the model is archived"
           },
           "canStream": {
             "type": "boolean",
@@ -8524,8 +8528,9 @@
           "provider",
           "providerDisplayName",
           "displayName",
-          "type",
           "isArchived",
+          "modelId",
+          "type",
           "canStream",
           "isReasoning",
           "canVision",
@@ -8657,16 +8662,16 @@
             "type": "string",
             "description": "The display name of the model"
           },
+          "isArchived": {
+            "type": "boolean",
+            "description": "Whether the model is archived"
+          },
           "type": {
             "type": "string",
             "enum": [
               "embedding"
             ],
             "description": "The type of the model (always embedding)"
-          },
-          "isArchived": {
-            "type": "boolean",
-            "description": "Whether the model is archived"
           },
           "dimensions": {
             "type": "number",
@@ -8680,8 +8685,8 @@
           "provider",
           "providerDisplayName",
           "displayName",
-          "type",
           "isArchived",
+          "type",
           "dimensions"
         ]
       },

--- a/ayunis-core-frontend/src/shared/locales/de/admin-settings-teams.json
+++ b/ayunis-core-frontend/src/shared/locales/de/admin-settings-teams.json
@@ -90,10 +90,16 @@
       "overrideDisabledMessage": "Dieses Team verwendet die Modelleinstellungen der Organisation. Aktivieren Sie die Überschreibung, um einzuschränken, auf welche Modelle dieses Team zugreifen kann.",
       "overrideToggleSuccess": "Modellüberschreibung aktualisiert",
       "overrideToggleError": "Modellüberschreibung konnte nicht aktualisiert werden",
+      "overrideToggleNotFound": "Team nicht gefunden",
       "enableSuccess": "Modell für Team aktiviert",
       "enableError": "Modell konnte nicht für Team aktiviert werden",
+      "enableAlreadyEnabled": "Dieses Modell ist bereits für das Team aktiviert",
+      "enableModelNotFound": "Modell nicht gefunden",
+      "enableModelInvalid": "Dieses Modell kann nicht für das Team aktiviert werden",
       "disableSuccess": "Modell für Team deaktiviert",
-      "disableError": "Modell konnte nicht für Team deaktiviert werden"
+      "disableError": "Modell konnte nicht für Team deaktiviert werden",
+      "disableModelNotFound": "Modell nicht gefunden",
+      "disableModelInvalid": "Dieses Modell kann nicht für das Team deaktiviert werden"
     },
     "removeMember": {
       "confirmTitle": "Mitglied entfernen",

--- a/ayunis-core-frontend/src/shared/locales/de/admin-settings-teams.json
+++ b/ayunis-core-frontend/src/shared/locales/de/admin-settings-teams.json
@@ -79,6 +79,22 @@
       "notInSameOrg": "Benutzer muss in derselben Organisation sein",
       "userNotFound": "Benutzer nicht gefunden"
     },
+    "tabs": {
+      "members": "Mitglieder",
+      "models": "Modelle"
+    },
+    "models": {
+      "overrideTitle": "Modellzugriff überschreiben",
+      "overrideDescription": "Wenn aktiviert, sehen die Mitglieder dieses Teams nur die unten ausgewählten Modelle anstelle der Standard-Modelle der Organisation.",
+      "overrideLabel": "Modellzugriff überschreiben",
+      "overrideDisabledMessage": "Dieses Team verwendet die Modelleinstellungen der Organisation. Aktivieren Sie die Überschreibung, um einzuschränken, auf welche Modelle dieses Team zugreifen kann.",
+      "overrideToggleSuccess": "Modellüberschreibung aktualisiert",
+      "overrideToggleError": "Modellüberschreibung konnte nicht aktualisiert werden",
+      "enableSuccess": "Modell für Team aktiviert",
+      "enableError": "Modell konnte nicht für Team aktiviert werden",
+      "disableSuccess": "Modell für Team deaktiviert",
+      "disableError": "Modell konnte nicht für Team deaktiviert werden"
+    },
     "removeMember": {
       "confirmTitle": "Mitglied entfernen",
       "confirmDescription": "Sind Sie sicher, dass Sie dieses Mitglied aus dem Team entfernen möchten?",

--- a/ayunis-core-frontend/src/shared/locales/en/admin-settings-teams.json
+++ b/ayunis-core-frontend/src/shared/locales/en/admin-settings-teams.json
@@ -90,10 +90,16 @@
       "overrideDisabledMessage": "This team uses the organization's model settings. Enable the override to restrict which models this team can access.",
       "overrideToggleSuccess": "Model override setting updated",
       "overrideToggleError": "Failed to update model override setting",
+      "overrideToggleNotFound": "Team not found",
       "enableSuccess": "Model enabled for team",
       "enableError": "Failed to enable model for team",
+      "enableAlreadyEnabled": "This model is already enabled for the team",
+      "enableModelNotFound": "Model not found",
+      "enableModelInvalid": "This model cannot be enabled for the team",
       "disableSuccess": "Model disabled for team",
-      "disableError": "Failed to disable model for team"
+      "disableError": "Failed to disable model for team",
+      "disableModelNotFound": "Model not found",
+      "disableModelInvalid": "This model cannot be disabled for the team"
     },
     "removeMember": {
       "confirmTitle": "Remove Member",

--- a/ayunis-core-frontend/src/shared/locales/en/admin-settings-teams.json
+++ b/ayunis-core-frontend/src/shared/locales/en/admin-settings-teams.json
@@ -79,6 +79,22 @@
       "notInSameOrg": "User must be in the same organization",
       "userNotFound": "User not found"
     },
+    "tabs": {
+      "members": "Members",
+      "models": "Models"
+    },
+    "models": {
+      "overrideTitle": "Model Access Override",
+      "overrideDescription": "When enabled, this team's members will only see the models you select below instead of the organization's default model set.",
+      "overrideLabel": "Override model access",
+      "overrideDisabledMessage": "This team uses the organization's model settings. Enable the override to restrict which models this team can access.",
+      "overrideToggleSuccess": "Model override setting updated",
+      "overrideToggleError": "Failed to update model override setting",
+      "enableSuccess": "Model enabled for team",
+      "enableError": "Failed to enable model for team",
+      "disableSuccess": "Model disabled for team",
+      "disableError": "Failed to disable model for team"
+    },
     "removeMember": {
       "confirmTitle": "Remove Member",
       "confirmDescription": "Are you sure you want to remove this member from the team?",

--- a/ayunis-core-frontend/src/widgets/model-type-card/ModelTypeCard.tsx
+++ b/ayunis-core-frontend/src/widgets/model-type-card/ModelTypeCard.tsx
@@ -21,12 +21,13 @@ import { getFlagByProvider } from '@/shared/lib/getFlagByProvider';
 
 export interface ModelActions {
   readonly deletePermittedModel: (permittedModelId: string) => void;
-  readonly updatePermittedModel: (params: {
+  readonly updatePermittedModel?: (params: {
     permittedModelId: string;
     anonymousOnly: boolean;
   }) => void;
   readonly enableModel: (model: ModelWithConfigResponseDto) => void;
   readonly isEnabling: boolean;
+  readonly isDisabling?: boolean;
 }
 
 interface ModelTypeCardProps {
@@ -71,6 +72,7 @@ export default function ModelTypeCard({
     updatePermittedModel,
     enableModel,
     isEnabling,
+    isDisabling,
   } = actions;
 
   const title =
@@ -100,7 +102,7 @@ export default function ModelTypeCard({
     model: ModelWithConfigResponseDto,
     anonymousOnly: boolean,
   ) {
-    if (!model.permittedModelId) return;
+    if (!model.permittedModelId || !updatePermittedModel) return;
     updatePermittedModel({
       permittedModelId: model.permittedModelId,
       anonymousOnly,
@@ -165,7 +167,7 @@ export default function ModelTypeCard({
                     </ItemTitle>
                   </ItemContent>
                   <ItemActions>
-                    {model.isPermitted && (
+                    {model.isPermitted && updatePermittedModel && (
                       <div className="flex items-center gap-2">
                         <Label
                           htmlFor={`${modelKey}-anonymous`}
@@ -192,7 +194,7 @@ export default function ModelTypeCard({
                       </Label>
                       <Switch
                         id={modelKey}
-                        disabled={isEnabling}
+                        disabled={isEnabling || isDisabling}
                         checked={model.isPermitted}
                         onCheckedChange={(isPermitted) =>
                           handleModelToggle(model, isPermitted)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk due to API contract changes (`PermittedLanguageModelResponseDto` now includes `modelId`) and adjusted model-replacement behavior that affects threads/agents when permitted models are deleted.
> 
> **Overview**
> Adds a new **Team “Models” tab** in admin settings that lets admins toggle `modelOverrideEnabled` and enable/disable which org language models a team can access, including query prefetching, create/delete mutations, and localized UI copy.
> 
> Updates the permitted-model API shape by introducing `BasePermittedModelResponseDto` and adding `modelId` (catalog model UUID) to `PermittedLanguageModelResponseDto`, updating the DTO mapper and regenerated OpenAPI client types.
> 
> Fixes model replacement during permitted-model deletion by passing/using a `catalogModelId` for default-model blacklisting in both thread and agent `ReplaceModelWithUserDefault*` use cases, and makes `ModelTypeCard` actions more flexible by allowing `updatePermittedModel`/disable state to be optional.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bfa07a11ff8eaa718c751105ac2354bde9df51af. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->