### PR TITLE
fix(AYC-000): strip unsupported json schema formats for openai function calling

### DIFF
--- a/ayunis-core-backend/src/domain/models/infrastructure/util/normalize-schema-for-openai.spec.ts
+++ b/ayunis-core-backend/src/domain/models/infrastructure/util/normalize-schema-for-openai.spec.ts
@@ -232,6 +232,104 @@ describe('normalizeSchemaForOpenAI', () => {
     });
   });
 
+  describe('format stripping', () => {
+    it('should strip unsupported format values like uri', () => {
+      const schema = {
+        type: 'object',
+        properties: {
+          page_url: { type: 'string', format: 'uri', description: 'A URL' },
+        },
+      };
+
+      const result = normalizeSchemaForOpenAI(schema);
+
+      expect(result).toEqual({
+        type: 'object',
+        additionalProperties: false,
+        required: ['page_url'],
+        properties: {
+          page_url: { type: 'string', description: 'A URL' },
+        },
+      });
+    });
+
+    it('should preserve supported format values', () => {
+      const schema = {
+        type: 'object',
+        properties: {
+          email: { type: 'string', format: 'email' },
+          created: { type: 'string', format: 'date-time' },
+          id: { type: 'string', format: 'uuid' },
+          birthday: { type: 'string', format: 'date' },
+        },
+      };
+
+      const result = normalizeSchemaForOpenAI(schema);
+      const props = result!.properties as Record<
+        string,
+        Record<string, unknown>
+      >;
+
+      expect(props.email.format).toBe('email');
+      expect(props.created.format).toBe('date-time');
+      expect(props.id.format).toBe('uuid');
+      expect(props.birthday.format).toBe('date');
+    });
+
+    it('should strip unsupported formats from nested properties', () => {
+      const schema = {
+        type: 'object',
+        properties: {
+          config: {
+            type: 'object',
+            properties: {
+              email: { type: 'string', format: 'email' },
+              website: { type: 'string', format: 'uri' },
+            },
+          },
+        },
+      };
+
+      const result = normalizeSchemaForOpenAI(schema);
+      const config = (
+        result!.properties as Record<string, Record<string, unknown>>
+      ).config;
+      const nested = config.properties as Record<
+        string,
+        Record<string, unknown>
+      >;
+
+      expect(nested.email.format).toBe('email');
+      expect(nested.website).not.toHaveProperty('format');
+    });
+
+    it('should strip unsupported formats from array item properties', () => {
+      const schema = {
+        type: 'object',
+        properties: {
+          links: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                href: { type: 'string', format: 'uri' },
+              },
+            },
+          },
+        },
+      };
+
+      const result = normalizeSchemaForOpenAI(schema);
+
+      const links = (
+        result!.properties as Record<string, Record<string, unknown>>
+      ).links;
+      const items = links.items as Record<string, unknown>;
+      const props = items.properties as Record<string, Record<string, unknown>>;
+      expect(props.href).not.toHaveProperty('format');
+    });
+  });
+
   describe('edge cases', () => {
     it('should handle schema without properties', () => {
       const schema = {

--- a/ayunis-core-backend/src/domain/models/infrastructure/util/normalize-schema-for-openai.ts
+++ b/ayunis-core-backend/src/domain/models/infrastructure/util/normalize-schema-for-openai.ts
@@ -1,4 +1,24 @@
 /**
+ * OpenAI only supports a subset of JSON Schema `format` values.
+ * MCP servers often include unsupported formats (e.g. "uri", "uri-reference"),
+ * which cause 400 errors from the OpenAI API. We strip any format not in the
+ * supported set.
+ *
+ * @see https://platform.openai.com/docs/guides/structured-outputs#supported-schemas
+ */
+const OPENAI_SUPPORTED_FORMATS = new Set([
+  'date-time',
+  'time',
+  'date',
+  'duration',
+  'email',
+  'hostname',
+  'ipv4',
+  'ipv6',
+  'uuid',
+]);
+
+/**
  * Recursively normalizes a JSON schema for OpenAI's strict mode.
  * OpenAI's strict mode requires:
  * 1. `additionalProperties: false` on all object schemas
@@ -13,6 +33,14 @@ export function normalizeSchemaForOpenAI(
   if (!schema) return undefined;
 
   const normalized = { ...schema };
+
+  // Strip unsupported JSON Schema format values (e.g. "uri") that OpenAI rejects
+  if (
+    typeof normalized.format === 'string' &&
+    !OPENAI_SUPPORTED_FORMATS.has(normalized.format)
+  ) {
+    delete normalized.format;
+  }
 
   normalizeObjectType(normalized);
   normalizeProperties(normalized);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: small, localized change to schema normalization that only removes `format` values OpenAI rejects, backed by targeted tests.
> 
> **Overview**
> Prevents OpenAI structured output/tool-calling 400s by stripping unsupported JSON Schema `format` values (e.g. `uri`) during `normalizeSchemaForOpenAI`, while preserving OpenAI-supported formats.
> 
> Adds a supported-format allowlist and expands unit coverage to ensure stripping works at the top level, in nested objects, and inside array item schemas.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d736f1815a46c04c1160b21c54c312fc445c13c4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->