### PR TITLE
feat(AYC-77): restrict models for teams

### DIFF
--- a/ayunis-core-backend/src/domain/models/presenters/http/dto/permitted-language-model-response.dto.ts
+++ b/ayunis-core-backend/src/domain/models/presenters/http/dto/permitted-language-model-response.dto.ts
@@ -37,6 +37,12 @@ export class PermittedLanguageModelResponseDto extends BasePermittedModelRespons
 
   @ApiProperty({
     type: 'boolean',
+    description: 'Whether this is the default model',
+  })
+  isDefault: boolean;
+
+  @ApiProperty({
+    type: 'boolean',
     description: 'Whether this model enforces anonymous mode',
   })
   anonymousOnly: boolean;

--- a/ayunis-core-backend/src/domain/models/presenters/http/mappers/model-response-dto.mapper.ts
+++ b/ayunis-core-backend/src/domain/models/presenters/http/mappers/model-response-dto.mapper.ts
@@ -31,6 +31,7 @@ export class ModelResponseDtoMapper {
       canStream: permittedModel.model.canStream,
       isReasoning: permittedModel.model.isReasoning,
       canVision: permittedModel.model.canVision,
+      isDefault: permittedModel.isDefault,
       anonymousOnly: permittedModel.anonymousOnly,
       // Note: Cost fields (inputTokenCost, outputTokenCost) are intentionally
       // not exposed to users. They are tracked internally for usage analytics only.

--- a/ayunis-core-frontend/src/pages/admin-settings/team-detail/api/useSetTeamDefaultModel.ts
+++ b/ayunis-core-frontend/src/pages/admin-settings/team-detail/api/useSetTeamDefaultModel.ts
@@ -15,8 +15,17 @@ export function useSetTeamDefaultModel(teamId: string) {
       onSuccess: () => {
         showSuccess(t('models.defaultModel.success'));
       },
-      onError: () => {
-        showError(t('models.defaultModel.error'));
+      onError: (error: unknown) => {
+        const errorObj = error as { response?: { data?: { code?: string } } };
+        const errorCode = errorObj.response?.data?.code;
+
+        if (errorCode === 'MODEL_NOT_FOUND') {
+          showError(t('models.defaultModel.modelNotFound'));
+        } else if (errorCode === 'MODEL_INVALID') {
+          showError(t('models.defaultModel.modelInvalid'));
+        } else {
+          showError(t('models.defaultModel.error'));
+        }
       },
       onSettled: () => {
         void queryClient.invalidateQueries({

--- a/ayunis-core-frontend/src/pages/admin-settings/team-detail/api/useSetTeamDefaultModel.ts
+++ b/ayunis-core-frontend/src/pages/admin-settings/team-detail/api/useSetTeamDefaultModel.ts
@@ -1,0 +1,40 @@
+import { useQueryClient } from '@tanstack/react-query';
+import { useTranslation } from 'react-i18next';
+import {
+  useTeamPermittedModelsControllerSetTeamDefaultModel,
+  getTeamPermittedModelsControllerListTeamPermittedModelsQueryKey,
+} from '@/shared/api/generated/ayunisCoreAPI';
+import { showError, showSuccess } from '@/shared/lib/toast';
+
+export function useSetTeamDefaultModel(teamId: string) {
+  const { t } = useTranslation('admin-settings-teams');
+  const queryClient = useQueryClient();
+
+  const mutation = useTeamPermittedModelsControllerSetTeamDefaultModel({
+    mutation: {
+      onSuccess: () => {
+        showSuccess(t('models.defaultModel.success'));
+      },
+      onError: () => {
+        showError(t('models.defaultModel.error'));
+      },
+      onSettled: () => {
+        void queryClient.invalidateQueries({
+          queryKey:
+            getTeamPermittedModelsControllerListTeamPermittedModelsQueryKey(
+              teamId,
+            ),
+        });
+      },
+    },
+  });
+
+  function setTeamDefaultModel(permittedModelId: string) {
+    mutation.mutate({ teamId, data: { permittedModelId } });
+  }
+
+  return {
+    setTeamDefaultModel,
+    isSetting: mutation.isPending,
+  };
+}

--- a/ayunis-core-frontend/src/pages/admin-settings/team-detail/ui/TeamDefaultModelCard.tsx
+++ b/ayunis-core-frontend/src/pages/admin-settings/team-detail/ui/TeamDefaultModelCard.tsx
@@ -1,0 +1,28 @@
+import type { ModelWithConfigResponseDto } from '@/shared/api';
+import { OrgDefaultModelCardWidget } from '@/widgets/org-default-model-card/ui/OrgDefaultModelCardWidget';
+import { useSetTeamDefaultModel } from '../api/useSetTeamDefaultModel';
+
+interface TeamDefaultModelCardProps {
+  readonly teamId: string;
+  readonly models: ModelWithConfigResponseDto[];
+  readonly isLoading: boolean;
+}
+
+export function TeamDefaultModelCard({
+  teamId,
+  models,
+  isLoading,
+}: TeamDefaultModelCardProps) {
+  const { setTeamDefaultModel, isSetting } = useSetTeamDefaultModel(teamId);
+
+  return (
+    <OrgDefaultModelCardWidget
+      models={models}
+      isLoading={isLoading}
+      isSaving={isSetting}
+      onDefaultModelChange={setTeamDefaultModel}
+      selectId="team-default-model-select"
+      translationNamespace="admin-settings-teams"
+    />
+  );
+}

--- a/ayunis-core-frontend/src/pages/admin-settings/team-detail/ui/TeamModelsTab.tsx
+++ b/ayunis-core-frontend/src/pages/admin-settings/team-detail/ui/TeamModelsTab.tsx
@@ -21,6 +21,7 @@ import { useTeamPermittedModels } from '../api/useTeamPermittedModels';
 import { useCreateTeamPermittedModel } from '../api/useCreateTeamPermittedModel';
 import { useDeleteTeamPermittedModel } from '../api/useDeleteTeamPermittedModel';
 import { useToggleModelOverride } from '../api/useToggleModelOverride';
+import { TeamDefaultModelCard } from './TeamDefaultModelCard';
 
 interface TeamModelsTabProps {
   readonly teamId: string;
@@ -45,7 +46,8 @@ export function TeamModelsTab({
     teamName,
   );
   const { models: orgModels } = useModelsWithConfig();
-  const { models: teamPermittedModels } = useTeamPermittedModels(teamId);
+  const { models: teamPermittedModels, isLoading: isLoadingTeamModels } =
+    useTeamPermittedModels(teamId);
   const { createTeamPermittedModel, isCreating } =
     useCreateTeamPermittedModel(teamId);
   const { deleteTeamPermittedModel, isDeleting } =
@@ -66,6 +68,7 @@ export function TeamModelsTab({
       return {
         ...model,
         isPermitted: permittedModelIds.has(model.modelId),
+        isDefault: teamModel?.isDefault ?? false,
         permittedModelId: teamModel?.id ?? null,
         anonymousOnly: teamModel?.anonymousOnly ?? null,
       };
@@ -109,11 +112,18 @@ export function TeamModelsTab({
       </Card>
 
       {effectiveOverrideEnabled ? (
-        <ModelTypeCard
-          type="language"
-          models={modelsForCard}
-          actions={actions}
-        />
+        <>
+          <ModelTypeCard
+            type="language"
+            models={modelsForCard}
+            actions={actions}
+          />
+          <TeamDefaultModelCard
+            teamId={teamId}
+            models={modelsForCard}
+            isLoading={isLoadingTeamModels}
+          />
+        </>
       ) : (
         <Card>
           <CardContent className="py-6">

--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
@@ -194,6 +194,8 @@ export interface PermittedLanguageModelResponseDto {
   isReasoning: boolean;
   /** Whether the model supports vision (image processing) */
   canVision: boolean;
+  /** Whether this is the default model */
+  isDefault: boolean;
   /** Whether this model enforces anonymous mode */
   anonymousOnly: boolean;
 }

--- a/ayunis-core-frontend/src/shared/api/openapi-schema.json
+++ b/ayunis-core-frontend/src/shared/api/openapi-schema.json
@@ -8517,6 +8517,10 @@
             "type": "boolean",
             "description": "Whether the model supports vision (image processing)"
           },
+          "isDefault": {
+            "type": "boolean",
+            "description": "Whether this is the default model"
+          },
           "anonymousOnly": {
             "type": "boolean",
             "description": "Whether this model enforces anonymous mode"
@@ -8534,6 +8538,7 @@
           "canStream",
           "isReasoning",
           "canVision",
+          "isDefault",
           "anonymousOnly"
         ]
       },

--- a/ayunis-core-frontend/src/shared/locales/de/admin-settings-teams.json
+++ b/ayunis-core-frontend/src/shared/locales/de/admin-settings-teams.json
@@ -110,5 +110,18 @@
       "error": "Mitglied konnte nicht entfernt werden",
       "notFound": "Mitglied nicht gefunden"
     }
+  },
+  "models": {
+    "defaultModel": {
+      "title": "Team-Standardmodell",
+      "description": "Wählen Sie das Standardmodell für die Mitglieder dieses Teams.",
+      "label": "Standardmodell",
+      "helper": "Teammitglieder starten mit diesem Modell, sofern sie kein anderes auswählen.",
+      "placeholder": "Standardmodell auswählen",
+      "loading": "Modelle werden geladen...",
+      "empty": "Aktivieren Sie mindestens ein Modell, um ein Standardmodell festzulegen.",
+      "success": "Team-Standardmodell aktualisiert",
+      "error": "Team-Standardmodell konnte nicht festgelegt werden"
+    }
   }
 }

--- a/ayunis-core-frontend/src/shared/locales/de/admin-settings-teams.json
+++ b/ayunis-core-frontend/src/shared/locales/de/admin-settings-teams.json
@@ -121,7 +121,9 @@
       "loading": "Modelle werden geladen...",
       "empty": "Aktivieren Sie mindestens ein Modell, um ein Standardmodell festzulegen.",
       "success": "Team-Standardmodell aktualisiert",
-      "error": "Team-Standardmodell konnte nicht festgelegt werden"
+      "error": "Team-Standardmodell konnte nicht festgelegt werden",
+      "modelNotFound": "Modell nicht gefunden",
+      "modelInvalid": "Dieses Modell kann nicht als Standard für das Team festgelegt werden"
     }
   }
 }

--- a/ayunis-core-frontend/src/shared/locales/en/admin-settings-teams.json
+++ b/ayunis-core-frontend/src/shared/locales/en/admin-settings-teams.json
@@ -110,5 +110,18 @@
       "error": "Failed to remove member",
       "notFound": "Member not found"
     }
+  },
+  "models": {
+    "defaultModel": {
+      "title": "Team default model",
+      "description": "Choose which permitted model should be used as the default for this team's members.",
+      "label": "Default model",
+      "helper": "Team members will start with this model unless they select a different one.",
+      "placeholder": "Select a default model",
+      "loading": "Loading models...",
+      "empty": "Enable at least one model to set a default.",
+      "success": "Team default model updated",
+      "error": "Failed to set team default model"
+    }
   }
 }

--- a/ayunis-core-frontend/src/shared/locales/en/admin-settings-teams.json
+++ b/ayunis-core-frontend/src/shared/locales/en/admin-settings-teams.json
@@ -121,7 +121,9 @@
       "loading": "Loading models...",
       "empty": "Enable at least one model to set a default.",
       "success": "Team default model updated",
-      "error": "Failed to set team default model"
+      "error": "Failed to set team default model",
+      "modelNotFound": "Model not found",
+      "modelInvalid": "This model cannot be set as default for the team"
     }
   }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces a new `isDefault` field on permitted language model API responses and wires it into the admin UI to set a team’s default model, which changes API contracts and could affect clients relying on the old schema.
> 
> **Overview**
> Adds team-level default language model support by exposing `isDefault` on `PermittedLanguageModelResponseDto` (and mapping it from the domain entity), updating the generated OpenAPI/TypeScript schemas accordingly.
> 
> Updates the team admin settings UI to show a *Team default model* selector (reusing `OrgDefaultModelCardWidget`) and adds a `useSetTeamDefaultModel` mutation that calls `PUT /teams/{teamId}/permitted-models/default`, handles specific API error codes, and refreshes the team permitted-models query.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 227d1552c150c163be3e212529efc83205817a64. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->