### PR TITLE
wip(AYC-107): add department field to user entity and migration

### DIFF
--- a/ayunis-core-backend/src/db/migrations/1773675804016-AddDepartmentToUsers.ts
+++ b/ayunis-core-backend/src/db/migrations/1773675804016-AddDepartmentToUsers.ts
@@ -1,0 +1,15 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddDepartmentToUsers1773675804016 implements MigrationInterface {
+  name = 'AddDepartmentToUsers1773675804016';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "users" ADD "department" character varying`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "users" DROP COLUMN "department"`);
+  }
+}

--- a/ayunis-core-backend/src/iam/users/application/use-cases/create-admin-user/create-admin-user.command.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/create-admin-user/create-admin-user.command.ts
@@ -7,6 +7,7 @@ export class CreateAdminUserCommand {
   public readonly name: string;
   public readonly emailVerified: boolean;
   public readonly hasAcceptedMarketing: boolean;
+  public readonly department?: string;
 
   constructor({
     email,
@@ -15,6 +16,7 @@ export class CreateAdminUserCommand {
     name,
     emailVerified,
     hasAcceptedMarketing,
+    department,
   }: {
     email: string;
     password: string;
@@ -22,6 +24,7 @@ export class CreateAdminUserCommand {
     name: string;
     emailVerified: boolean;
     hasAcceptedMarketing: boolean;
+    department?: string;
   }) {
     this.email = email;
     this.password = password;
@@ -29,5 +32,6 @@ export class CreateAdminUserCommand {
     this.name = name;
     this.emailVerified = emailVerified;
     this.hasAcceptedMarketing = hasAcceptedMarketing;
+    this.department = department;
   }
 }

--- a/ayunis-core-backend/src/iam/users/application/use-cases/create-admin-user/create-admin-user.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/create-admin-user/create-admin-user.use-case.spec.ts
@@ -80,6 +80,42 @@ describe('CreateAdminUserUseCase', () => {
     expect(mockCreateUserUseCase.execute).toHaveBeenCalled();
   });
 
+  it('should pass department from command to create-user use case', async () => {
+    const command = new CreateAdminUserCommand({
+      email: 'admin@example.com',
+      password: 'password123',
+      orgId: 'org-id' as UUID,
+      name: 'Admin User',
+      emailVerified: false,
+      hasAcceptedMarketing: false,
+      department: 'other:Wasserwerk',
+    });
+    const mockUser = new User({
+      id: 'user-id' as UUID,
+      email: 'admin@example.com',
+      emailVerified: false,
+      passwordHash: 'hashedPassword',
+      role: UserRole.ADMIN,
+      orgId: 'org-id' as UUID,
+      name: 'Admin User',
+      hasAcceptedMarketing: false,
+      department: 'other:Wasserwerk',
+    });
+
+    jest.spyOn(mockUsersRepository, 'findOneByEmail').mockResolvedValue(null);
+    jest
+      .spyOn(mockHashTextUseCase, 'execute')
+      .mockResolvedValue('hashedPassword');
+    jest.spyOn(mockCreateUserUseCase, 'execute').mockResolvedValue(mockUser);
+
+    const result = await useCase.execute(command);
+
+    expect(result.department).toBe('other:Wasserwerk');
+    expect(mockCreateUserUseCase.execute).toHaveBeenCalledWith(
+      expect.objectContaining({ department: 'other:Wasserwerk' }),
+    );
+  });
+
   it('should throw UserAlreadyExistsError when user exists', async () => {
     const command = new CreateAdminUserCommand({
       email: 'admin@example.com',

--- a/ayunis-core-backend/src/iam/users/application/use-cases/create-admin-user/create-admin-user.use-case.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/create-admin-user/create-admin-user.use-case.ts
@@ -25,6 +25,7 @@ export class CreateAdminUserUseCase {
       role: UserRole.ADMIN,
       emailVerified: command.emailVerified,
       hasAcceptedMarketing: command.hasAcceptedMarketing,
+      department: command.department,
     });
 
     return this.createUserUseCase.execute(createUserCommand);

--- a/ayunis-core-backend/src/iam/users/application/use-cases/create-regular-user/create-regular-user.command.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/create-regular-user/create-regular-user.command.ts
@@ -7,6 +7,7 @@ export class CreateRegularUserCommand {
   public readonly name: string;
   public readonly emailVerified: boolean;
   public readonly hasAcceptedMarketing: boolean;
+  public readonly department?: string;
 
   constructor(params: {
     email: string;
@@ -15,6 +16,7 @@ export class CreateRegularUserCommand {
     name: string;
     emailVerified: boolean;
     hasAcceptedMarketing: boolean;
+    department?: string;
   }) {
     this.email = params.email;
     this.password = params.password;
@@ -22,5 +24,6 @@ export class CreateRegularUserCommand {
     this.name = params.name;
     this.emailVerified = params.emailVerified;
     this.hasAcceptedMarketing = params.hasAcceptedMarketing;
+    this.department = params.department;
   }
 }

--- a/ayunis-core-backend/src/iam/users/application/use-cases/create-regular-user/create-regular-user.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/create-regular-user/create-regular-user.use-case.spec.ts
@@ -80,6 +80,42 @@ describe('CreateRegularUserUseCase', () => {
     expect(mockCreateUserUseCase.execute).toHaveBeenCalled();
   });
 
+  it('should pass department from command to create-user use case', async () => {
+    const command = new CreateRegularUserCommand({
+      email: 'test@example.com',
+      password: 'password123',
+      orgId: 'org-id' as UUID,
+      name: 'Regular User',
+      emailVerified: false,
+      hasAcceptedMarketing: false,
+      department: 'jugendamt',
+    });
+    const mockUser = new User({
+      id: 'user-id' as UUID,
+      email: 'test@example.com',
+      emailVerified: false,
+      passwordHash: 'hashedPassword',
+      role: UserRole.USER,
+      orgId: 'org-id' as UUID,
+      name: 'Regular User',
+      hasAcceptedMarketing: false,
+      department: 'jugendamt',
+    });
+
+    jest.spyOn(mockUsersRepository, 'findOneByEmail').mockResolvedValue(null);
+    jest
+      .spyOn(mockHashTextUseCase, 'execute')
+      .mockResolvedValue('hashedPassword');
+    jest.spyOn(mockCreateUserUseCase, 'execute').mockResolvedValue(mockUser);
+
+    const result = await useCase.execute(command);
+
+    expect(result.department).toBe('jugendamt');
+    expect(mockCreateUserUseCase.execute).toHaveBeenCalledWith(
+      expect.objectContaining({ department: 'jugendamt' }),
+    );
+  });
+
   it('should throw UserAlreadyExistsError if user exists', async () => {
     const command = new CreateRegularUserCommand({
       email: 'test@example.com',

--- a/ayunis-core-backend/src/iam/users/application/use-cases/create-regular-user/create-regular-user.use-case.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/create-regular-user/create-regular-user.use-case.ts
@@ -26,6 +26,7 @@ export class CreateRegularUserUseCase {
       role: UserRole.USER,
       emailVerified: command.emailVerified,
       hasAcceptedMarketing: command.hasAcceptedMarketing,
+      department: command.department,
     });
 
     return this.createUserUseCase.execute(createUserCommand);

--- a/ayunis-core-backend/src/iam/users/application/use-cases/create-user/create-user.command.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/create-user/create-user.command.ts
@@ -9,6 +9,7 @@ export class CreateUserCommand {
   public readonly role: UserRole;
   public readonly emailVerified: boolean;
   public readonly hasAcceptedMarketing: boolean;
+  public readonly department?: string;
 
   constructor({
     email,
@@ -18,6 +19,7 @@ export class CreateUserCommand {
     role,
     emailVerified,
     hasAcceptedMarketing,
+    department,
   }: {
     email: string;
     password: string;
@@ -26,6 +28,7 @@ export class CreateUserCommand {
     role: UserRole;
     emailVerified: boolean;
     hasAcceptedMarketing: boolean;
+    department?: string;
   }) {
     this.email = email;
     this.password = password;
@@ -34,5 +37,6 @@ export class CreateUserCommand {
     this.role = role;
     this.emailVerified = emailVerified;
     this.hasAcceptedMarketing = hasAcceptedMarketing;
+    this.department = department;
   }
 }

--- a/ayunis-core-backend/src/iam/users/application/use-cases/create-user/create-user.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/create-user/create-user.use-case.spec.ts
@@ -131,6 +131,26 @@ describe('CreateUserUseCase', () => {
     await new Promise(process.nextTick);
   });
 
+  it('should pass department from command to the created user entity', async () => {
+    const commandWithDepartment = new CreateUserCommand({
+      email: 'maria.garcia@ayunis.de',
+      password: 'Sicher3sPasswort!',
+      orgId,
+      name: 'Maria Garcia',
+      role: UserRole.USER,
+      emailVerified: false,
+      hasAcceptedMarketing: true,
+      department: 'bauamt',
+    });
+
+    const result = await useCase.execute(commandWithDepartment);
+
+    expect(result.department).toBe('bauamt');
+    expect(usersRepository.create).toHaveBeenCalledWith(
+      expect.objectContaining({ department: 'bauamt' }),
+    );
+  });
+
   it('should not emit UserCreatedEvent when repository create fails', async () => {
     usersRepository.create.mockRejectedValue(new Error('Database error'));
 

--- a/ayunis-core-backend/src/iam/users/application/use-cases/create-user/create-user.use-case.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/create-user/create-user.use-case.ts
@@ -85,6 +85,7 @@ export class CreateUserUseCase {
         role: command.role,
         name: command.name,
         hasAcceptedMarketing: command.hasAcceptedMarketing,
+        department: command.department,
       });
 
       const createdUser = await this.usersRepository.create(user);

--- a/ayunis-core-backend/src/iam/users/domain/department.constants.spec.ts
+++ b/ayunis-core-backend/src/iam/users/domain/department.constants.spec.ts
@@ -1,0 +1,30 @@
+import { isValidDepartment } from './department.constants';
+
+describe('isValidDepartment', () => {
+  it.each([
+    'hauptamt',
+    'kaemmerei',
+    'ordnungsamt',
+    'bauamt',
+    'it',
+    'pressestelle',
+    'other',
+  ])('should accept known department key "%s"', (key) => {
+    expect(isValidDepartment(key)).toBe(true);
+  });
+
+  it('should accept other:<text> pattern', () => {
+    expect(isValidDepartment('other:Wasserwerk')).toBe(true);
+    expect(isValidDepartment('other:Stadtwerke GmbH')).toBe(true);
+  });
+
+  it('should reject other: with empty text', () => {
+    expect(isValidDepartment('other:')).toBe(false);
+  });
+
+  it('should reject unknown department keys', () => {
+    expect(isValidDepartment('unknown')).toBe(false);
+    expect(isValidDepartment('')).toBe(false);
+    expect(isValidDepartment('HAUPTAMT')).toBe(false);
+  });
+});

--- a/ayunis-core-backend/src/iam/users/domain/department.constants.ts
+++ b/ayunis-core-backend/src/iam/users/domain/department.constants.ts
@@ -1,0 +1,34 @@
+export const DEPARTMENT_KEYS = [
+  'hauptamt',
+  'kaemmerei',
+  'ordnungsamt',
+  'bauamt',
+  'sozialamt',
+  'jugendamt',
+  'standesamt',
+  'einwohnermeldeamt',
+  'schulamt',
+  'kulturamt',
+  'umweltamt',
+  'tiefbauamt',
+  'hochbauamt',
+  'personalamt',
+  'rechtsamt',
+  'gesundheitsamt',
+  'liegenschaftsamt',
+  'it',
+  'pressestelle',
+  'other',
+] as const;
+
+export type DepartmentKey = (typeof DEPARTMENT_KEYS)[number];
+
+const OTHER_PREFIX = 'other:';
+const departmentKeySet: ReadonlySet<string> = new Set(DEPARTMENT_KEYS);
+
+export function isValidDepartment(value: string): boolean {
+  return (
+    departmentKeySet.has(value) ||
+    (value.startsWith(OTHER_PREFIX) && value.length > OTHER_PREFIX.length)
+  );
+}

--- a/ayunis-core-backend/src/iam/users/domain/user.entity.ts
+++ b/ayunis-core-backend/src/iam/users/domain/user.entity.ts
@@ -14,6 +14,7 @@ export class User {
   public orgId: UUID;
   public name: string;
   public hasAcceptedMarketing: boolean;
+  public department?: string;
   public createdAt: Date;
   public updatedAt: Date;
 
@@ -28,6 +29,7 @@ export class User {
     org?: Org;
     name: string;
     hasAcceptedMarketing: boolean;
+    department?: string;
     createdAt?: Date;
     updatedAt?: Date;
   }) {
@@ -40,6 +42,7 @@ export class User {
     this.orgId = params.orgId;
     this.name = params.name;
     this.hasAcceptedMarketing = params.hasAcceptedMarketing;
+    this.department = params.department;
     this.createdAt = params.createdAt ?? new Date();
     this.updatedAt = params.updatedAt ?? new Date();
   }

--- a/ayunis-core-backend/src/iam/users/infrastructure/repositories/local/mappers/user.mapper.ts
+++ b/ayunis-core-backend/src/iam/users/infrastructure/repositories/local/mappers/user.mapper.ts
@@ -13,6 +13,7 @@ export class UserMapper {
       passwordHash: entity.passwordHash,
       name: entity.name,
       hasAcceptedMarketing: entity.hasAcceptedMarketing,
+      department: entity.department,
       createdAt: entity.createdAt,
       updatedAt: entity.updatedAt,
     });
@@ -29,6 +30,7 @@ export class UserMapper {
     entity.passwordHash = domain.passwordHash;
     entity.name = domain.name;
     entity.hasAcceptedMarketing = domain.hasAcceptedMarketing;
+    entity.department = domain.department;
     entity.updatedAt = domain.updatedAt;
     entity.createdAt = domain.createdAt;
     return entity;

--- a/ayunis-core-backend/src/iam/users/infrastructure/repositories/local/schema/user.record.ts
+++ b/ayunis-core-backend/src/iam/users/infrastructure/repositories/local/schema/user.record.ts
@@ -39,4 +39,7 @@ export class UserRecord extends BaseRecord {
 
   @Column({ default: false })
   hasAcceptedMarketing: boolean;
+
+  @Column({ nullable: true })
+  department?: string;
 }

--- a/ayunis-core-backend/src/iam/users/presenters/http/dtos/user-response.dto.ts
+++ b/ayunis-core-backend/src/iam/users/presenters/http/dtos/user-response.dto.ts
@@ -38,6 +38,14 @@ export class UserResponseDto {
   orgId: UUID;
 
   @ApiProperty({
+    description: 'Department the user belongs to',
+    example: 'hauptamt',
+    required: false,
+    nullable: true,
+  })
+  department?: string;
+
+  @ApiProperty({
     description: 'Date when the user was created',
     example: '2024-01-15T10:30:00Z',
     type: Date,

--- a/ayunis-core-backend/src/iam/users/presenters/http/mappers/user-response-dto.mapper.ts
+++ b/ayunis-core-backend/src/iam/users/presenters/http/mappers/user-response-dto.mapper.ts
@@ -16,6 +16,7 @@ export class UserResponseDtoMapper {
       email: user.email,
       role: user.role,
       orgId: user.orgId,
+      department: user.department,
       createdAt: user.createdAt,
     };
   }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces a schema change and propagates a new optional `department` attribute through user creation, persistence, and HTTP responses; risk is mainly around migration rollout and downstream consumers expecting the new field.
> 
> **Overview**
> Adds an optional `department` field to users end-to-end.
> 
> This PR introduces a TypeORM migration to add the nullable `users.department` column, threads `department` through `CreateAdminUserCommand`/`CreateRegularUserCommand` into `CreateUserUseCase`, persists it via the `User` entity + TypeORM `UserRecord`/`UserMapper`, and exposes it in `UserResponseDto`/mapper. It also adds `DEPARTMENT_KEYS` + `isValidDepartment` helper (with tests) and extends/create-user tests to ensure `department` is passed through correctly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 67f5273dae124edfce216c3d22de0526e203b785. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->