### PR TITLE
wip(AYC-107): thread department through registration and invite accept flows

### DIFF
--- a/ayunis-core-backend/src/db/migrations/1773675804016-AddDepartmentToUsers.ts
+++ b/ayunis-core-backend/src/db/migrations/1773675804016-AddDepartmentToUsers.ts
@@ -1,4 +1,4 @@
-import { MigrationInterface, QueryRunner } from 'typeorm';
+import type { MigrationInterface, QueryRunner } from 'typeorm';
 
 export class AddDepartmentToUsers1773675804016 implements MigrationInterface {
   name = 'AddDepartmentToUsers1773675804016';

--- a/ayunis-core-backend/src/iam/authentication/application/use-cases/register-user/register-user.command.ts
+++ b/ayunis-core-backend/src/iam/authentication/application/use-cases/register-user/register-user.command.ts
@@ -4,6 +4,7 @@ export class RegisterUserCommand {
   public readonly password: string;
   public readonly orgName: string;
   public readonly hasAcceptedMarketing: boolean;
+  public readonly department?: string;
 
   constructor({
     userName,
@@ -11,17 +12,20 @@ export class RegisterUserCommand {
     password,
     orgName,
     hasAcceptedMarketing,
+    department,
   }: {
     userName: string;
     email: string;
     password: string;
     orgName: string;
     hasAcceptedMarketing: boolean;
+    department?: string;
   }) {
     this.userName = userName;
     this.email = email;
     this.password = password;
     this.orgName = orgName;
     this.hasAcceptedMarketing = hasAcceptedMarketing;
+    this.department = department;
   }
 }

--- a/ayunis-core-backend/src/iam/authentication/application/use-cases/register-user/register-user.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/authentication/application/use-cases/register-user/register-user.use-case.spec.ts
@@ -139,6 +139,40 @@ describe('RegisterUserUseCase', () => {
     );
   });
 
+  it('should pass department to create-admin-user command', async () => {
+    const command = new RegisterUserCommand({
+      userName: 'test',
+      email: 'dept@example.com',
+      password: 'validPassword123',
+      orgName: 'Test Org',
+      hasAcceptedMarketing: false,
+      department: 'bauamt',
+    });
+    const mockOrg = new Org({ id: 'org-id' as UUID, name: 'Test Org' });
+    const mockUser = new User({
+      id: 'user-id' as UUID,
+      email: 'dept@example.com',
+      emailVerified: false,
+      passwordHash: 'hashedPassword',
+      role: UserRole.ADMIN,
+      orgId: 'org-id' as UUID,
+      name: 'test',
+      hasAcceptedMarketing: false,
+    });
+
+    jest.spyOn(mockIsValidPasswordUseCase, 'execute').mockResolvedValue(true);
+    jest.spyOn(mockCreateOrgUseCase, 'execute').mockResolvedValue(mockOrg);
+    jest
+      .spyOn(mockCreateAdminUserUseCase, 'execute')
+      .mockResolvedValue(mockUser);
+
+    await useCase.execute(command);
+
+    expect(mockCreateAdminUserUseCase.execute).toHaveBeenCalledWith(
+      expect.objectContaining({ department: 'bauamt' }),
+    );
+  });
+
   it('should throw InvalidPasswordError for invalid password', async () => {
     const command = new RegisterUserCommand({
       userName: 'test',

--- a/ayunis-core-backend/src/iam/authentication/application/use-cases/register-user/register-user.use-case.ts
+++ b/ayunis-core-backend/src/iam/authentication/application/use-cases/register-user/register-user.use-case.ts
@@ -107,6 +107,7 @@ export class RegisterUserUseCase {
           name: command.userName,
           emailVerified: shouldConfirmEmail ? false : true,
           hasAcceptedMarketing: command.hasAcceptedMarketing,
+          department: command.department,
         }),
       );
 

--- a/ayunis-core-backend/src/iam/authentication/presenters/http/authentication.controller.ts
+++ b/ayunis-core-backend/src/iam/authentication/presenters/http/authentication.controller.ts
@@ -130,6 +130,7 @@ export class AuthenticationController {
         password: body.password,
         orgName: body.orgName,
         hasAcceptedMarketing: body.marketingAcceptance,
+        department: body.department,
       }),
     );
     const tokens = await this.loginUseCase.execute(new LoginCommand(user));

--- a/ayunis-core-backend/src/iam/authentication/presenters/http/dtos/register.dto.ts
+++ b/ayunis-core-backend/src/iam/authentication/presenters/http/dtos/register.dto.ts
@@ -1,5 +1,12 @@
-import { IsEmail, IsNotEmpty } from 'class-validator';
-import { ApiProperty } from '@nestjs/swagger';
+import {
+  IsEmail,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  MaxLength,
+} from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsValidDepartment } from '../../../../users/domain/is-valid-department.validator';
 
 export class RegisterDto {
   @ApiProperty({
@@ -36,4 +43,14 @@ export class RegisterDto {
     example: true,
   })
   marketingAcceptance: boolean;
+
+  @ApiPropertyOptional({
+    description: 'Department within the municipality',
+    example: 'hauptamt',
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(100)
+  @IsValidDepartment()
+  department?: string;
 }

--- a/ayunis-core-backend/src/iam/invites/application/use-cases/accept-invite/accept-invite.command.ts
+++ b/ayunis-core-backend/src/iam/invites/application/use-cases/accept-invite/accept-invite.command.ts
@@ -3,16 +3,19 @@ export class AcceptInviteCommand {
   public readonly userName: string;
   public readonly password: string;
   public readonly hasAcceptedMarketing: boolean;
+  public readonly department?: string;
 
   constructor(params: {
     inviteToken: string;
     userName: string;
     password: string;
     hasAcceptedMarketing: boolean;
+    department?: string;
   }) {
     this.inviteToken = params.inviteToken;
     this.userName = params.userName;
     this.password = params.password;
     this.hasAcceptedMarketing = params.hasAcceptedMarketing;
+    this.department = params.department;
   }
 }

--- a/ayunis-core-backend/src/iam/invites/application/use-cases/accept-invite/accept-invite.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/invites/application/use-cases/accept-invite/accept-invite.use-case.spec.ts
@@ -1,0 +1,136 @@
+import type { TestingModule } from '@nestjs/testing';
+import { Test } from '@nestjs/testing';
+import { AcceptInviteUseCase } from './accept-invite.use-case';
+import { AcceptInviteCommand } from './accept-invite.command';
+import { InvitesRepository } from '../../ports/invites.repository';
+import { InviteJwtService } from '../../services/invite-jwt.service';
+import { CreateRegularUserUseCase } from 'src/iam/users/application/use-cases/create-regular-user/create-regular-user.use-case';
+import { CreateAdminUserUseCase } from 'src/iam/users/application/use-cases/create-admin-user/create-admin-user.use-case';
+import { IsValidPasswordUseCase } from 'src/iam/users/application/use-cases/is-valid-password/is-valid-password.use-case';
+import { FindUserByEmailUseCase } from 'src/iam/users/application/use-cases/find-user-by-email/find-user-by-email.use-case';
+import { Invite } from '../../../domain/invite.entity';
+import { UserRole } from 'src/iam/users/domain/value-objects/role.object';
+import type { UUID } from 'crypto';
+
+describe('AcceptInviteUseCase', () => {
+  let useCase: AcceptInviteUseCase;
+  let mockInvitesRepository: Partial<InvitesRepository>;
+  let mockInviteJwtService: Partial<InviteJwtService>;
+  let mockCreateRegularUserUseCase: Partial<CreateRegularUserUseCase>;
+  let mockCreateAdminUserUseCase: Partial<CreateAdminUserUseCase>;
+  let mockIsValidPasswordUseCase: Partial<IsValidPasswordUseCase>;
+  let mockFindUserByEmailUseCase: Partial<FindUserByEmailUseCase>;
+
+  const inviteId = 'invite-id' as UUID;
+  const orgId = 'org-id' as UUID;
+
+  beforeAll(async () => {
+    mockInvitesRepository = {
+      findOne: jest.fn(),
+      accept: jest.fn(),
+    };
+    mockInviteJwtService = {
+      verifyInviteToken: jest.fn(),
+    };
+    mockCreateRegularUserUseCase = { execute: jest.fn() };
+    mockCreateAdminUserUseCase = { execute: jest.fn() };
+    mockIsValidPasswordUseCase = { execute: jest.fn() };
+    mockFindUserByEmailUseCase = { execute: jest.fn() };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AcceptInviteUseCase,
+        { provide: InvitesRepository, useValue: mockInvitesRepository },
+        { provide: InviteJwtService, useValue: mockInviteJwtService },
+        {
+          provide: CreateRegularUserUseCase,
+          useValue: mockCreateRegularUserUseCase,
+        },
+        {
+          provide: CreateAdminUserUseCase,
+          useValue: mockCreateAdminUserUseCase,
+        },
+        {
+          provide: IsValidPasswordUseCase,
+          useValue: mockIsValidPasswordUseCase,
+        },
+        {
+          provide: FindUserByEmailUseCase,
+          useValue: mockFindUserByEmailUseCase,
+        },
+      ],
+    }).compile();
+
+    useCase = module.get<AcceptInviteUseCase>(AcceptInviteUseCase);
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should pass department to create-regular-user command', async () => {
+    const invite = new Invite({
+      id: inviteId,
+      email: 'user@example.com',
+      orgId,
+      role: UserRole.USER,
+      expiresAt: new Date(Date.now() + 86_400_000),
+    });
+
+    jest
+      .spyOn(mockInviteJwtService, 'verifyInviteToken')
+      .mockReturnValue({ inviteId });
+    jest.spyOn(mockInvitesRepository, 'findOne').mockResolvedValue(invite);
+    jest
+      .spyOn(mockFindUserByEmailUseCase, 'execute')
+      .mockResolvedValue(null as never);
+    jest.spyOn(mockIsValidPasswordUseCase, 'execute').mockResolvedValue(true);
+
+    const command = new AcceptInviteCommand({
+      inviteToken: 'valid-token',
+      userName: 'Jane Doe',
+      password: 'securePass123',
+      hasAcceptedMarketing: false,
+      department: 'jugendamt',
+    });
+
+    await useCase.execute(command);
+
+    expect(mockCreateRegularUserUseCase.execute).toHaveBeenCalledWith(
+      expect.objectContaining({ department: 'jugendamt' }),
+    );
+  });
+
+  it('should pass department to create-admin-user command', async () => {
+    const invite = new Invite({
+      id: inviteId,
+      email: 'admin@example.com',
+      orgId,
+      role: UserRole.ADMIN,
+      expiresAt: new Date(Date.now() + 86_400_000),
+    });
+
+    jest
+      .spyOn(mockInviteJwtService, 'verifyInviteToken')
+      .mockReturnValue({ inviteId });
+    jest.spyOn(mockInvitesRepository, 'findOne').mockResolvedValue(invite);
+    jest
+      .spyOn(mockFindUserByEmailUseCase, 'execute')
+      .mockResolvedValue(null as never);
+    jest.spyOn(mockIsValidPasswordUseCase, 'execute').mockResolvedValue(true);
+
+    const command = new AcceptInviteCommand({
+      inviteToken: 'valid-token',
+      userName: 'Admin User',
+      password: 'securePass123',
+      hasAcceptedMarketing: true,
+      department: 'other:Wasserwerk',
+    });
+
+    await useCase.execute(command);
+
+    expect(mockCreateAdminUserUseCase.execute).toHaveBeenCalledWith(
+      expect.objectContaining({ department: 'other:Wasserwerk' }),
+    );
+  });
+});

--- a/ayunis-core-backend/src/iam/invites/application/use-cases/accept-invite/accept-invite.use-case.ts
+++ b/ayunis-core-backend/src/iam/invites/application/use-cases/accept-invite/accept-invite.use-case.ts
@@ -104,6 +104,7 @@ export class AcceptInviteUseCase {
             name: command.userName,
             emailVerified: true,
             hasAcceptedMarketing: command.hasAcceptedMarketing,
+            department: command.department,
           }),
         );
       } else if (invite.role === UserRole.USER) {
@@ -115,6 +116,7 @@ export class AcceptInviteUseCase {
             password: command.password,
             emailVerified: true,
             hasAcceptedMarketing: command.hasAcceptedMarketing,
+            department: command.department,
           }),
         );
       } else {

--- a/ayunis-core-backend/src/iam/invites/presenters/http/dtos/accept-invite.dto.ts
+++ b/ayunis-core-backend/src/iam/invites/presenters/http/dtos/accept-invite.dto.ts
@@ -1,5 +1,6 @@
-import { ApiProperty } from '@nestjs/swagger';
-import { IsBoolean, IsString } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsBoolean, IsOptional, IsString, MaxLength } from 'class-validator';
+import { IsValidDepartment } from '../../../../users/domain/is-valid-department.validator';
 
 export class AcceptInviteDto {
   @ApiProperty({
@@ -29,4 +30,14 @@ export class AcceptInviteDto {
   })
   @IsBoolean()
   hasAcceptedMarketing: boolean;
+
+  @ApiPropertyOptional({
+    description: 'Department within the municipality',
+    example: 'hauptamt',
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(100)
+  @IsValidDepartment()
+  department?: string;
 }

--- a/ayunis-core-backend/src/iam/invites/presenters/http/invites.controller.ts
+++ b/ayunis-core-backend/src/iam/invites/presenters/http/invites.controller.ts
@@ -319,6 +319,7 @@ export class InvitesController {
         userName: acceptInviteDto.userName,
         password: acceptInviteDto.password,
         hasAcceptedMarketing: acceptInviteDto.hasAcceptedMarketing,
+        department: acceptInviteDto.department,
       }),
     );
 

--- a/ayunis-core-backend/src/iam/users/domain/department.constants.spec.ts
+++ b/ayunis-core-backend/src/iam/users/domain/department.constants.spec.ts
@@ -8,7 +8,6 @@ describe('isValidDepartment', () => {
     'bauamt',
     'it',
     'pressestelle',
-    'other',
   ])('should accept known department key "%s"', (key) => {
     expect(isValidDepartment(key)).toBe(true);
   });
@@ -20,6 +19,10 @@ describe('isValidDepartment', () => {
 
   it('should reject other: with empty text', () => {
     expect(isValidDepartment('other:')).toBe(false);
+  });
+
+  it('should reject bare "other" without text suffix', () => {
+    expect(isValidDepartment('other')).toBe(false);
   });
 
   it('should reject unknown department keys', () => {

--- a/ayunis-core-backend/src/iam/users/domain/department.constants.ts
+++ b/ayunis-core-backend/src/iam/users/domain/department.constants.ts
@@ -18,7 +18,6 @@ export const DEPARTMENT_KEYS = [
   'liegenschaftsamt',
   'it',
   'pressestelle',
-  'other',
 ] as const;
 
 export type DepartmentKey = (typeof DEPARTMENT_KEYS)[number];

--- a/ayunis-core-backend/src/iam/users/domain/is-valid-department.validator.spec.ts
+++ b/ayunis-core-backend/src/iam/users/domain/is-valid-department.validator.spec.ts
@@ -1,0 +1,52 @@
+import { validate } from 'class-validator';
+import { IsOptional, IsString } from 'class-validator';
+import { IsValidDepartment } from './is-valid-department.validator';
+
+class TestDto {
+  @IsOptional()
+  @IsString()
+  @IsValidDepartment()
+  department?: string;
+}
+
+describe('IsValidDepartment validator', () => {
+  it('should accept a known department key', async () => {
+    const dto = Object.assign(new TestDto(), { department: 'hauptamt' });
+    const errors = await validate(dto);
+    expect(errors).toHaveLength(0);
+  });
+
+  it('should accept other:<text> pattern', async () => {
+    const dto = Object.assign(new TestDto(), {
+      department: 'other:Wasserwerk',
+    });
+    const errors = await validate(dto);
+    expect(errors).toHaveLength(0);
+  });
+
+  it('should accept undefined (optional)', async () => {
+    const dto = new TestDto();
+    const errors = await validate(dto);
+    expect(errors).toHaveLength(0);
+  });
+
+  it('should reject an arbitrary string', async () => {
+    const dto = Object.assign(new TestDto(), { department: 'random-value' });
+    const errors = await validate(dto);
+    expect(errors).toHaveLength(1);
+    expect(errors[0].property).toBe('department');
+  });
+
+  it('should reject other: with empty text', async () => {
+    const dto = Object.assign(new TestDto(), { department: 'other:' });
+    const errors = await validate(dto);
+    expect(errors).toHaveLength(1);
+  });
+
+  it('should reject bare "other"', async () => {
+    const dto = Object.assign(new TestDto(), { department: 'other' });
+    const errors = await validate(dto);
+    expect(errors).toHaveLength(1);
+    expect(errors[0].property).toBe('department');
+  });
+});

--- a/ayunis-core-backend/src/iam/users/domain/is-valid-department.validator.ts
+++ b/ayunis-core-backend/src/iam/users/domain/is-valid-department.validator.ts
@@ -1,0 +1,29 @@
+import type { ValidationOptions, ValidationArguments } from 'class-validator';
+import { registerDecorator } from 'class-validator';
+import { isValidDepartment } from './department.constants';
+
+/**
+ * Validates that a string is a known department key or matches the `other:<text>` pattern.
+ * Delegates to {@link isValidDepartment}.
+ */
+export function IsValidDepartment(validationOptions?: ValidationOptions) {
+  return function (object: object, propertyName: string) {
+    registerDecorator({
+      name: 'isValidDepartment',
+      target: object.constructor,
+      propertyName: propertyName,
+      options: validationOptions,
+      validator: {
+        validate(value: unknown) {
+          if (typeof value !== 'string') {
+            return false;
+          }
+          return isValidDepartment(value);
+        },
+        defaultMessage(args: ValidationArguments) {
+          return `${args.property} must be a valid department key or match the pattern "other:<text>"`;
+        },
+      },
+    });
+  };
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new optional `department` field that is persisted to the `users` table and threaded through registration/invite acceptance flows; risk is mainly around schema migration and stricter input validation potentially rejecting previously accepted values (e.g., bare `other`).
> 
> **Overview**
> Adds an optional `department` attribute to users, including a DB migration to add the `users.department` column.
> 
> Threads `department` through the HTTP DTOs/controllers into the `RegisterUser` and `AcceptInvite` use-cases, so created admin/regular users receive the field. Introduces a shared `IsValidDepartment` class-validator decorator and tightens department rules to allow known keys or `other:<text>` (explicitly rejecting bare `other`), with new/updated unit tests covering the new behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d3267f9603d8ae2c739cb5ef3f291a61ae14a8a9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->