### PR TITLE
wip(AYC-106): add ip-allowlist infrastructure, controller, and module wiring

### DIFF
--- a/ayunis-core-backend/src/common/util/ip.util.spec.ts
+++ b/ayunis-core-backend/src/common/util/ip.util.spec.ts
@@ -92,6 +92,15 @@ describe('getClientIp', () => {
     expect(getClientIp(request)).toBe('172.16.0.5');
   });
 
+  it('should fall through when x-forwarded-for has an empty first entry', () => {
+    const request = createMockRequest({
+      'x-forwarded-for': ',10.0.0.1',
+      'x-real-ip': '172.16.0.5',
+    });
+
+    expect(getClientIp(request)).toBe('172.16.0.5');
+  });
+
   it('should trim whitespace from x-forwarded-for IPs', () => {
     const request = createMockRequest({
       'x-forwarded-for': '  203.0.113.50  , 70.41.3.18',

--- a/ayunis-core-backend/src/common/util/ip.util.ts
+++ b/ayunis-core-backend/src/common/util/ip.util.ts
@@ -13,7 +13,10 @@ export function getClientIp(request: Request): string | null {
   const forwardedFor = request.headers['x-forwarded-for'];
   if (forwardedFor) {
     const ips = Array.isArray(forwardedFor) ? forwardedFor[0] : forwardedFor;
-    return ips.split(',')[0].trim();
+    const firstIp = ips.split(',')[0].trim();
+    if (firstIp) {
+      return firstIp;
+    }
   }
 
   const realIp = request.headers['x-real-ip'];

--- a/ayunis-core-backend/src/db/migrations/1773679166381-CreateIpAllowlistsTable.ts
+++ b/ayunis-core-backend/src/db/migrations/1773679166381-CreateIpAllowlistsTable.ts
@@ -1,0 +1,21 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateIpAllowlistsTable1773679166381 implements MigrationInterface {
+  name = 'CreateIpAllowlistsTable1773679166381';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE "ip_allowlists" ("id" character varying NOT NULL, "createdAt" TIMESTAMP NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP NOT NULL DEFAULT now(), "orgId" character varying NOT NULL, "cidrs" text array NOT NULL, CONSTRAINT "UQ_cad8648bacddda154a2ad01050a" UNIQUE ("orgId"), CONSTRAINT "PK_75b3501315ecd2c3ce0d253ea51" PRIMARY KEY ("id"))`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "ip_allowlists" ADD CONSTRAINT "FK_cad8648bacddda154a2ad01050a" FOREIGN KEY ("orgId") REFERENCES "orgs"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "ip_allowlists" DROP CONSTRAINT "FK_cad8648bacddda154a2ad01050a"`,
+    );
+    await queryRunner.query(`DROP TABLE "ip_allowlists"`);
+  }
+}

--- a/ayunis-core-backend/src/iam/iam.module.ts
+++ b/ayunis-core-backend/src/iam/iam.module.ts
@@ -16,6 +16,7 @@ import { LegalAcceptancesModule } from './legal-acceptances/legal-acceptances.mo
 import { QuotasModule } from './quotas/quotas.module';
 import { TeamsModule } from './teams/teams.module';
 import { PlatformConfigModule } from './platform-config/platform-config.module';
+import { IpAllowlistModule } from './ip-allowlist/ip-allowlist.module';
 
 @Module({})
 export class IamModule {
@@ -38,6 +39,7 @@ export class IamModule {
         QuotasModule,
         TeamsModule,
         PlatformConfigModule,
+        IpAllowlistModule,
       ],
       exports: [
         AuthenticationModule,
@@ -52,6 +54,7 @@ export class IamModule {
         QuotasModule,
         TeamsModule,
         PlatformConfigModule,
+        IpAllowlistModule,
       ],
     };
   }

--- a/ayunis-core-backend/src/iam/ip-allowlist/application/ip-allowlist.errors.ts
+++ b/ayunis-core-backend/src/iam/ip-allowlist/application/ip-allowlist.errors.ts
@@ -4,6 +4,7 @@ import { ApplicationError } from '../../../common/errors/base.error';
 export enum IpAllowlistErrorCode {
   IP_NOT_ALLOWED = 'IP_NOT_ALLOWED',
   ADMIN_LOCKOUT = 'ADMIN_LOCKOUT',
+  INVALID_CIDR = 'INVALID_CIDR',
   UNEXPECTED_ERROR = 'UNEXPECTED_ERROR',
 }
 
@@ -26,6 +27,12 @@ export class AdminLockoutError extends ApplicationError {
       400,
       metadata,
     );
+  }
+}
+
+export class InvalidCidrApplicationError extends ApplicationError {
+  constructor(message: string, metadata?: ErrorMetadata) {
+    super(message, IpAllowlistErrorCode.INVALID_CIDR, 400, metadata);
   }
 }
 

--- a/ayunis-core-backend/src/iam/ip-allowlist/application/use-cases/update-ip-allowlist/update-ip-allowlist.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/ip-allowlist/application/use-cases/update-ip-allowlist/update-ip-allowlist.use-case.spec.ts
@@ -5,9 +5,9 @@ import type { IpAllowlistRepository } from '../../ports/ip-allowlist.repository'
 import { IpAllowlist } from '../../../domain/ip-allowlist.entity';
 import {
   AdminLockoutError,
+  InvalidCidrApplicationError,
   UnexpectedIpAllowlistError,
 } from '../../ip-allowlist.errors';
-import { InvalidCidrError } from '../../../domain/ip-allowlist.errors';
 import type { UUID } from 'crypto';
 
 describe('UpdateIpAllowlistUseCase', () => {
@@ -103,28 +103,20 @@ describe('UpdateIpAllowlistUseCase', () => {
     expect(repository.upsert).not.toHaveBeenCalled();
   });
 
-  it('should delete the allow list when given an empty CIDR array', async () => {
-    const command = new UpdateIpAllowlistCommand(orgId, [], adminIp);
-
-    const result = await useCase.execute(command);
-
-    expect(result).toBeNull();
-    expect(repository.deleteByOrgId).toHaveBeenCalledWith(orgId);
-    expect(repository.upsert).not.toHaveBeenCalled();
-  });
-
-  it('should throw InvalidCidrError when a CIDR is malformed', async () => {
+  it('should throw InvalidCidrApplicationError when a CIDR is malformed', async () => {
     const command = new UpdateIpAllowlistCommand(
       orgId,
       ['192.168.1.0/24', 'not-a-cidr'],
       adminIp,
     );
 
-    await expect(useCase.execute(command)).rejects.toThrow(InvalidCidrError);
+    await expect(useCase.execute(command)).rejects.toThrow(
+      InvalidCidrApplicationError,
+    );
     expect(repository.upsert).not.toHaveBeenCalled();
   });
 
-  it('should throw InvalidCidrError before AdminLockoutError for invalid CIDRs', async () => {
+  it('should throw InvalidCidrApplicationError before AdminLockoutError for invalid CIDRs', async () => {
     const command = new UpdateIpAllowlistCommand(
       orgId,
       ['not-a-cidr'],
@@ -132,7 +124,9 @@ describe('UpdateIpAllowlistUseCase', () => {
     );
 
     // Even though the admin IP can't match, validation should fail first
-    await expect(useCase.execute(command)).rejects.toThrow(InvalidCidrError);
+    await expect(useCase.execute(command)).rejects.toThrow(
+      InvalidCidrApplicationError,
+    );
     expect(repository.upsert).not.toHaveBeenCalled();
   });
 

--- a/ayunis-core-backend/src/iam/ip-allowlist/application/use-cases/update-ip-allowlist/update-ip-allowlist.use-case.ts
+++ b/ayunis-core-backend/src/iam/ip-allowlist/application/use-cases/update-ip-allowlist/update-ip-allowlist.use-case.ts
@@ -3,9 +3,13 @@ import { ApplicationError } from 'src/common/errors/base.error';
 import { IpAllowlistRepository } from '../../ports/ip-allowlist.repository';
 import {
   AdminLockoutError,
+  InvalidCidrApplicationError,
   UnexpectedIpAllowlistError,
 } from '../../ip-allowlist.errors';
-import { InvalidCidrError } from '../../../domain/ip-allowlist.errors';
+import {
+  EmptyCidrsError,
+  InvalidCidrError,
+} from '../../../domain/ip-allowlist.errors';
 import type { UpdateIpAllowlistCommand } from './update-ip-allowlist.command';
 import { IpAllowlist } from '../../../domain/ip-allowlist.entity';
 import { isIpInCidrs } from '../../../domain/cidr.util';
@@ -16,29 +20,33 @@ export class UpdateIpAllowlistUseCase {
 
   constructor(private readonly repository: IpAllowlistRepository) {}
 
-  async execute(
-    command: UpdateIpAllowlistCommand,
-  ): Promise<IpAllowlist | null> {
+  async execute(command: UpdateIpAllowlistCommand): Promise<IpAllowlist> {
     this.logger.debug('Updating IP allowlist', {
       orgId: command.orgId,
       cidrCount: command.cidrs.length,
     });
 
     try {
-      if (command.cidrs.length === 0) {
-        await this.repository.deleteByOrgId(command.orgId);
-        return null;
-      }
-
       // Validate CIDRs before lockout check so malformed input
       // produces InvalidCidrError, not AdminLockoutError.
       const existing = await this.repository.findByOrgId(command.orgId);
-      const entity = new IpAllowlist({
-        id: existing?.id,
-        orgId: command.orgId,
-        cidrs: command.cidrs,
-        createdAt: existing?.createdAt,
-      });
+      let entity: IpAllowlist;
+      try {
+        entity = new IpAllowlist({
+          id: existing?.id,
+          orgId: command.orgId,
+          cidrs: command.cidrs,
+          createdAt: existing?.createdAt,
+        });
+      } catch (error) {
+        if (
+          error instanceof InvalidCidrError ||
+          error instanceof EmptyCidrsError
+        ) {
+          throw new InvalidCidrApplicationError(error.message);
+        }
+        throw error;
+      }
 
       if (!isIpInCidrs(command.clientIp, command.cidrs)) {
         throw new AdminLockoutError({ clientIp: command.clientIp });
@@ -47,7 +55,6 @@ export class UpdateIpAllowlistUseCase {
       return await this.repository.upsert(entity);
     } catch (error) {
       if (error instanceof ApplicationError) throw error;
-      if (error instanceof InvalidCidrError) throw error;
 
       this.logger.error('Failed to update IP allowlist', {
         error: error instanceof Error ? error.message : 'Unknown error',

--- a/ayunis-core-backend/src/iam/ip-allowlist/domain/ip-allowlist.entity.spec.ts
+++ b/ayunis-core-backend/src/iam/ip-allowlist/domain/ip-allowlist.entity.spec.ts
@@ -1,7 +1,7 @@
 /* eslint-disable sonarjs/no-hardcoded-ip -- test fixtures require hardcoded IPs */
 import type { UUID } from 'crypto';
 import { IpAllowlist } from './ip-allowlist.entity';
-import { InvalidCidrError } from './ip-allowlist.errors';
+import { EmptyCidrsError, InvalidCidrError } from './ip-allowlist.errors';
 
 describe('IpAllowlist', () => {
   const orgId = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890' as UUID;
@@ -68,8 +68,21 @@ describe('IpAllowlist', () => {
     }
   });
 
-  it('should accept an empty CIDR array without throwing', () => {
-    const entity = new IpAllowlist({ orgId, cidrs: [] });
-    expect(entity.cidrs).toEqual([]);
+  it('should throw EmptyCidrsError for an empty CIDR array', () => {
+    expect(() => new IpAllowlist({ orgId, cidrs: [] })).toThrow(
+      EmptyCidrsError,
+    );
+  });
+
+  it('should include a descriptive message for empty CIDR array', () => {
+    try {
+      new IpAllowlist({ orgId, cidrs: [] });
+      fail('Expected EmptyCidrsError');
+    } catch (error) {
+      expect(error).toBeInstanceOf(EmptyCidrsError);
+      expect((error as EmptyCidrsError).message).toBe(
+        'At least one CIDR range is required',
+      );
+    }
   });
 });

--- a/ayunis-core-backend/src/iam/ip-allowlist/domain/ip-allowlist.entity.ts
+++ b/ayunis-core-backend/src/iam/ip-allowlist/domain/ip-allowlist.entity.ts
@@ -1,7 +1,7 @@
 import type { UUID } from 'crypto';
 import { randomUUID } from 'crypto';
 import { isValidCidr } from './cidr.util';
-import { InvalidCidrError } from './ip-allowlist.errors';
+import { EmptyCidrsError, InvalidCidrError } from './ip-allowlist.errors';
 
 export interface IpAllowlistParams {
   id?: UUID;
@@ -29,6 +29,10 @@ export class IpAllowlist {
   }
 
   private validateCidrs(): void {
+    if (this.cidrs.length === 0) {
+      throw new EmptyCidrsError();
+    }
+
     for (const cidr of this.cidrs) {
       if (!isValidCidr(cidr)) {
         throw new InvalidCidrError(cidr);

--- a/ayunis-core-backend/src/iam/ip-allowlist/domain/ip-allowlist.errors.ts
+++ b/ayunis-core-backend/src/iam/ip-allowlist/domain/ip-allowlist.errors.ts
@@ -1,8 +1,19 @@
 export const IP_ALLOWLIST_DOMAIN_ERROR_CODE = {
   INVALID_CIDR: 'INVALID_CIDR',
+  EMPTY_CIDRS: 'EMPTY_CIDRS',
 } as const;
 
 const MAX_CIDR_DISPLAY_LENGTH = 100;
+
+export class EmptyCidrsError extends Error {
+  readonly code: string;
+
+  constructor() {
+    super('At least one CIDR range is required');
+    this.name = 'EmptyCidrsError';
+    this.code = IP_ALLOWLIST_DOMAIN_ERROR_CODE.EMPTY_CIDRS;
+  }
+}
 
 export class InvalidCidrError extends Error {
   readonly code: string;

--- a/ayunis-core-backend/src/iam/ip-allowlist/infrastructure/persistence/postgres/ip-allowlist.repository.ts
+++ b/ayunis-core-backend/src/iam/ip-allowlist/infrastructure/persistence/postgres/ip-allowlist.repository.ts
@@ -1,0 +1,54 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import type { UUID } from 'crypto';
+import { IpAllowlistRepository } from '../../../application/ports/ip-allowlist.repository';
+import { IpAllowlist } from '../../../domain/ip-allowlist.entity';
+import { IpAllowlistRecord } from './schema/ip-allowlist.record';
+import { IpAllowlistMapper } from './mappers/ip-allowlist.mapper';
+
+@Injectable()
+export class PostgresIpAllowlistRepository extends IpAllowlistRepository {
+  private readonly logger = new Logger(PostgresIpAllowlistRepository.name);
+
+  constructor(
+    @InjectRepository(IpAllowlistRecord)
+    private readonly repository: Repository<IpAllowlistRecord>,
+  ) {
+    super();
+  }
+
+  async findByOrgId(orgId: UUID): Promise<IpAllowlist | null> {
+    this.logger.debug('findByOrgId', { orgId });
+
+    const record = await this.repository.findOne({ where: { orgId } });
+    if (!record) {
+      return null;
+    }
+
+    return IpAllowlistMapper.toDomain(record);
+  }
+
+  async upsert(entity: IpAllowlist): Promise<IpAllowlist> {
+    this.logger.debug('upsert', { orgId: entity.orgId });
+
+    const record = IpAllowlistMapper.toRecord(entity);
+
+    await this.repository.upsert(record, ['orgId']);
+
+    // Re-fetch to get accurate DB-managed timestamps
+    const saved = await this.findByOrgId(entity.orgId);
+
+    if (!saved) {
+      throw new Error('Failed to re-fetch ip allowlist after upsert');
+    }
+
+    return saved;
+  }
+
+  async deleteByOrgId(orgId: UUID): Promise<void> {
+    this.logger.debug('deleteByOrgId', { orgId });
+
+    await this.repository.delete({ orgId });
+  }
+}

--- a/ayunis-core-backend/src/iam/ip-allowlist/infrastructure/persistence/postgres/mappers/ip-allowlist.mapper.ts
+++ b/ayunis-core-backend/src/iam/ip-allowlist/infrastructure/persistence/postgres/mappers/ip-allowlist.mapper.ts
@@ -1,0 +1,24 @@
+import { IpAllowlist } from '../../../../domain/ip-allowlist.entity';
+import { IpAllowlistRecord } from '../schema/ip-allowlist.record';
+
+export class IpAllowlistMapper {
+  static toDomain(record: IpAllowlistRecord): IpAllowlist {
+    return new IpAllowlist({
+      id: record.id,
+      orgId: record.orgId,
+      cidrs: record.cidrs,
+      createdAt: record.createdAt,
+      updatedAt: record.updatedAt,
+    });
+  }
+
+  static toRecord(domain: IpAllowlist): IpAllowlistRecord {
+    const record = new IpAllowlistRecord();
+    record.id = domain.id;
+    record.orgId = domain.orgId;
+    record.cidrs = domain.cidrs;
+    record.createdAt = domain.createdAt;
+    record.updatedAt = new Date();
+    return record;
+  }
+}

--- a/ayunis-core-backend/src/iam/ip-allowlist/infrastructure/persistence/postgres/schema/ip-allowlist.record.ts
+++ b/ayunis-core-backend/src/iam/ip-allowlist/infrastructure/persistence/postgres/schema/ip-allowlist.record.ts
@@ -1,0 +1,17 @@
+import { Column, Entity, JoinColumn, OneToOne } from 'typeorm';
+import type { UUID } from 'crypto';
+import { BaseRecord } from '../../../../../../common/db/base-record';
+import { OrgRecord } from '../../../../../orgs/infrastructure/repositories/local/schema/org.record';
+
+@Entity({ name: 'ip_allowlists' })
+export class IpAllowlistRecord extends BaseRecord {
+  @Column({ unique: true })
+  orgId: UUID;
+
+  @Column({ type: 'text', array: true })
+  cidrs: string[];
+
+  @OneToOne(() => OrgRecord, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'orgId' })
+  org: OrgRecord;
+}

--- a/ayunis-core-backend/src/iam/ip-allowlist/ip-allowlist.module.ts
+++ b/ayunis-core-backend/src/iam/ip-allowlist/ip-allowlist.module.ts
@@ -1,0 +1,32 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+
+import { IpAllowlistRecord } from './infrastructure/persistence/postgres/schema/ip-allowlist.record';
+import { IpAllowlistRepository } from './application/ports/ip-allowlist.repository';
+import { PostgresIpAllowlistRepository } from './infrastructure/persistence/postgres/ip-allowlist.repository';
+
+import { GetIpAllowlistUseCase } from './application/use-cases/get-ip-allowlist/get-ip-allowlist.use-case';
+import { UpdateIpAllowlistUseCase } from './application/use-cases/update-ip-allowlist/update-ip-allowlist.use-case';
+import { DeleteIpAllowlistUseCase } from './application/use-cases/delete-ip-allowlist/delete-ip-allowlist.use-case';
+
+import { IpAllowlistController } from './presenters/http/ip-allowlist.controller';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([IpAllowlistRecord])],
+  controllers: [IpAllowlistController],
+  providers: [
+    {
+      provide: IpAllowlistRepository,
+      useClass: PostgresIpAllowlistRepository,
+    },
+    GetIpAllowlistUseCase,
+    UpdateIpAllowlistUseCase,
+    DeleteIpAllowlistUseCase,
+  ],
+  exports: [
+    GetIpAllowlistUseCase,
+    UpdateIpAllowlistUseCase,
+    DeleteIpAllowlistUseCase,
+  ],
+})
+export class IpAllowlistModule {}

--- a/ayunis-core-backend/src/iam/ip-allowlist/presenters/http/dtos/ip-allowlist-response.dto.ts
+++ b/ayunis-core-backend/src/iam/ip-allowlist/presenters/http/dtos/ip-allowlist-response.dto.ts
@@ -1,0 +1,10 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class IpAllowlistResponseDto {
+  @ApiProperty({
+    description: 'List of allowed CIDR ranges',
+    example: ['203.0.113.0/24'],
+    type: [String],
+  })
+  cidrs: string[];
+}

--- a/ayunis-core-backend/src/iam/ip-allowlist/presenters/http/dtos/update-ip-allowlist-request.dto.ts
+++ b/ayunis-core-backend/src/iam/ip-allowlist/presenters/http/dtos/update-ip-allowlist-request.dto.ts
@@ -1,0 +1,26 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Transform } from 'class-transformer';
+import {
+  ArrayMaxSize,
+  ArrayNotEmpty,
+  IsArray,
+  IsString,
+  MaxLength,
+} from 'class-validator';
+
+export class UpdateIpAllowlistRequestDto {
+  @ApiProperty({
+    description: 'List of CIDR ranges to allow (e.g. "192.168.1.0/24")',
+    example: ['203.0.113.0/24'],
+    type: [String],
+  })
+  @Transform(({ value }: { value: string[] }) =>
+    value.map((s: string) => s.trim()),
+  )
+  @IsArray()
+  @ArrayNotEmpty()
+  @ArrayMaxSize(500)
+  @IsString({ each: true })
+  @MaxLength(43, { each: true })
+  cidrs: string[];
+}

--- a/ayunis-core-backend/src/iam/ip-allowlist/presenters/http/ip-allowlist.controller.ts
+++ b/ayunis-core-backend/src/iam/ip-allowlist/presenters/http/ip-allowlist.controller.ts
@@ -1,0 +1,112 @@
+import {
+  BadRequestException,
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Logger,
+  Put,
+  Req,
+} from '@nestjs/common';
+import {
+  ApiExtraModels,
+  ApiOperation,
+  ApiResponse,
+  ApiTags,
+  getSchemaPath,
+} from '@nestjs/swagger';
+import type { Request } from 'express';
+import type { UUID } from 'crypto';
+import {
+  CurrentUser,
+  UserProperty,
+} from '../../../authentication/application/decorators/current-user.decorator';
+import { Roles } from '../../../authorization/application/decorators/roles.decorator';
+import { UserRole } from '../../../users/domain/value-objects/role.object';
+import { GetIpAllowlistUseCase } from '../../application/use-cases/get-ip-allowlist/get-ip-allowlist.use-case';
+import { GetIpAllowlistQuery } from '../../application/use-cases/get-ip-allowlist/get-ip-allowlist.query';
+import { UpdateIpAllowlistUseCase } from '../../application/use-cases/update-ip-allowlist/update-ip-allowlist.use-case';
+import { UpdateIpAllowlistCommand } from '../../application/use-cases/update-ip-allowlist/update-ip-allowlist.command';
+import { DeleteIpAllowlistUseCase } from '../../application/use-cases/delete-ip-allowlist/delete-ip-allowlist.use-case';
+import { DeleteIpAllowlistCommand } from '../../application/use-cases/delete-ip-allowlist/delete-ip-allowlist.command';
+import { UpdateIpAllowlistRequestDto } from './dtos/update-ip-allowlist-request.dto';
+import { IpAllowlistResponseDto } from './dtos/ip-allowlist-response.dto';
+import { getClientIp } from '../../../../common/util/ip.util';
+
+@ApiTags('ip-allowlist')
+@Controller('ip-allowlist')
+@ApiExtraModels(IpAllowlistResponseDto)
+export class IpAllowlistController {
+  private readonly logger = new Logger(IpAllowlistController.name);
+
+  constructor(
+    private readonly getIpAllowlistUseCase: GetIpAllowlistUseCase,
+    private readonly updateIpAllowlistUseCase: UpdateIpAllowlistUseCase,
+    private readonly deleteIpAllowlistUseCase: DeleteIpAllowlistUseCase,
+  ) {}
+
+  @Get()
+  @Roles(UserRole.ADMIN)
+  @ApiOperation({ summary: 'Get the IP allow list for the current org' })
+  @ApiResponse({
+    status: 200,
+    description: 'Current IP allow list (empty array if none)',
+    schema: { $ref: getSchemaPath(IpAllowlistResponseDto) },
+  })
+  async get(
+    @CurrentUser(UserProperty.ORG_ID) orgId: UUID,
+  ): Promise<IpAllowlistResponseDto> {
+    this.logger.log(`Getting IP allow list for org ${orgId}`);
+
+    const query = new GetIpAllowlistQuery(orgId);
+    const allowlist = await this.getIpAllowlistUseCase.execute(query);
+
+    return { cidrs: allowlist?.cidrs ?? [] };
+  }
+
+  @Put()
+  @Roles(UserRole.ADMIN)
+  @ApiOperation({ summary: 'Replace the IP allow list for the current org' })
+  @ApiResponse({
+    status: 200,
+    description: 'Updated IP allow list',
+    schema: { $ref: getSchemaPath(IpAllowlistResponseDto) },
+  })
+  @ApiResponse({
+    status: 400,
+    description:
+      'Invalid CIDR or admin lockout (requesting IP not in new allowlist)',
+  })
+  async update(
+    @CurrentUser(UserProperty.ORG_ID) orgId: UUID,
+    @Body() dto: UpdateIpAllowlistRequestDto,
+    @Req() req: Request,
+  ): Promise<IpAllowlistResponseDto> {
+    this.logger.log(`Updating IP allow list for org ${orgId}`);
+
+    const clientIp = getClientIp(req);
+    if (!clientIp) {
+      throw new BadRequestException('Unable to determine client IP address');
+    }
+
+    const command = new UpdateIpAllowlistCommand(orgId, dto.cidrs, clientIp);
+    const result = await this.updateIpAllowlistUseCase.execute(command);
+    return { cidrs: result.cidrs };
+  }
+
+  @Delete()
+  @Roles(UserRole.ADMIN)
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({
+    summary: 'Remove the IP allow list (disable IP restriction)',
+  })
+  @ApiResponse({ status: 204, description: 'IP allow list removed' })
+  async remove(@CurrentUser(UserProperty.ORG_ID) orgId: UUID): Promise<void> {
+    this.logger.log(`Deleting IP allow list for org ${orgId}`);
+
+    const command = new DeleteIpAllowlistCommand(orgId);
+    await this.deleteIpAllowlistUseCase.execute(command);
+  }
+}

--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
@@ -3624,6 +3624,16 @@ export interface MeResponseDto {
   name: string;
 }
 
+export interface IpAllowlistResponseDto {
+  /** List of allowed CIDR ranges */
+  cidrs: string[];
+}
+
+export interface UpdateIpAllowlistRequestDto {
+  /** List of CIDR ranges to allow (e.g. "192.168.1.0/24") */
+  cidrs: string[];
+}
+
 export type SuperAdminPermittedModelsControllerGetPermittedModels200Item = PermittedLanguageModelResponseDto | PermittedEmbeddingModelResponseDto;
 
 export type SuperAdminPermittedModelsControllerUpdatePermittedModel200 = PermittedLanguageModelResponseDto | PermittedEmbeddingModelResponseDto;

--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.ts
@@ -79,6 +79,7 @@ import type {
   InstallSkillFromMarketplaceDto,
   InviteDetailResponseDto,
   InvitesControllerGetInvitesParams,
+  IpAllowlistResponseDto,
   IsCloudResponseDto,
   KnowledgeBaseDocumentListResponseDto,
   KnowledgeBaseDocumentResponseDto,
@@ -158,6 +159,7 @@ import type {
   UpdateArtifactDto,
   UpdateBillingInfoDto,
   UpdateEmbeddingModelRequestDto,
+  UpdateIpAllowlistRequestDto,
   UpdateKnowledgeBaseDto,
   UpdateLanguageModelRequestDto,
   UpdateMcpIntegrationDto,
@@ -15570,6 +15572,225 @@ export const useAuthenticationControllerLogout = <TError = unknown,
       > => {
 
       const mutationOptions = getAuthenticationControllerLogoutMutationOptions(options);
+
+      return useMutation(mutationOptions, queryClient);
+    }
+    
+/**
+ * @summary Get the IP allow list for the current org
+ */
+export const ipAllowlistControllerGet = (
+    
+ signal?: AbortSignal
+) => {
+      
+      
+      return customAxiosInstance<IpAllowlistResponseDto>(
+      {url: `/ip-allowlist`, method: 'GET', signal
+    },
+      );
+    }
+  
+
+
+
+export const getIpAllowlistControllerGetQueryKey = () => {
+    return [
+    `/ip-allowlist`
+    ] as const;
+    }
+
+    
+export const getIpAllowlistControllerGetQueryOptions = <TData = Awaited<ReturnType<typeof ipAllowlistControllerGet>>, TError = unknown>( options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof ipAllowlistControllerGet>>, TError, TData>>, }
+) => {
+
+const {query: queryOptions} = options ?? {};
+
+  const queryKey =  queryOptions?.queryKey ?? getIpAllowlistControllerGetQueryKey();
+
+  
+
+    const queryFn: QueryFunction<Awaited<ReturnType<typeof ipAllowlistControllerGet>>> = ({ signal }) => ipAllowlistControllerGet(signal);
+
+      
+
+      
+
+   return  { queryKey, queryFn, ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof ipAllowlistControllerGet>>, TError, TData> & { queryKey: DataTag<QueryKey, TData, TError> }
+}
+
+export type IpAllowlistControllerGetQueryResult = NonNullable<Awaited<ReturnType<typeof ipAllowlistControllerGet>>>
+export type IpAllowlistControllerGetQueryError = unknown
+
+
+export function useIpAllowlistControllerGet<TData = Awaited<ReturnType<typeof ipAllowlistControllerGet>>, TError = unknown>(
+  options: { query:Partial<UseQueryOptions<Awaited<ReturnType<typeof ipAllowlistControllerGet>>, TError, TData>> & Pick<
+        DefinedInitialDataOptions<
+          Awaited<ReturnType<typeof ipAllowlistControllerGet>>,
+          TError,
+          Awaited<ReturnType<typeof ipAllowlistControllerGet>>
+        > , 'initialData'
+      >, }
+ , queryClient?: QueryClient
+  ):  DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useIpAllowlistControllerGet<TData = Awaited<ReturnType<typeof ipAllowlistControllerGet>>, TError = unknown>(
+  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof ipAllowlistControllerGet>>, TError, TData>> & Pick<
+        UndefinedInitialDataOptions<
+          Awaited<ReturnType<typeof ipAllowlistControllerGet>>,
+          TError,
+          Awaited<ReturnType<typeof ipAllowlistControllerGet>>
+        > , 'initialData'
+      >, }
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useIpAllowlistControllerGet<TData = Awaited<ReturnType<typeof ipAllowlistControllerGet>>, TError = unknown>(
+  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof ipAllowlistControllerGet>>, TError, TData>>, }
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+/**
+ * @summary Get the IP allow list for the current org
+ */
+
+export function useIpAllowlistControllerGet<TData = Awaited<ReturnType<typeof ipAllowlistControllerGet>>, TError = unknown>(
+  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof ipAllowlistControllerGet>>, TError, TData>>, }
+ , queryClient?: QueryClient 
+ ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
+
+  const queryOptions = getIpAllowlistControllerGetQueryOptions(options)
+
+  const query = useQuery(queryOptions, queryClient) as  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+
+  query.queryKey = queryOptions.queryKey ;
+
+  return query;
+}
+
+
+
+
+
+/**
+ * @summary Replace the IP allow list for the current org
+ */
+export const ipAllowlistControllerUpdate = (
+    updateIpAllowlistRequestDto: UpdateIpAllowlistRequestDto,
+ ) => {
+      
+      
+      return customAxiosInstance<IpAllowlistResponseDto>(
+      {url: `/ip-allowlist`, method: 'PUT',
+      headers: {'Content-Type': 'application/json', },
+      data: updateIpAllowlistRequestDto
+    },
+      );
+    }
+  
+
+
+export const getIpAllowlistControllerUpdateMutationOptions = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof ipAllowlistControllerUpdate>>, TError,{data: UpdateIpAllowlistRequestDto}, TContext>, }
+): UseMutationOptions<Awaited<ReturnType<typeof ipAllowlistControllerUpdate>>, TError,{data: UpdateIpAllowlistRequestDto}, TContext> => {
+
+const mutationKey = ['ipAllowlistControllerUpdate'];
+const {mutation: mutationOptions} = options ?
+      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
+      options
+      : {...options, mutation: {...options.mutation, mutationKey}}
+      : {mutation: { mutationKey, }};
+
+      
+
+
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof ipAllowlistControllerUpdate>>, {data: UpdateIpAllowlistRequestDto}> = (props) => {
+          const {data} = props ?? {};
+
+          return  ipAllowlistControllerUpdate(data,)
+        }
+
+        
+
+
+  return  { mutationFn, ...mutationOptions }}
+
+    export type IpAllowlistControllerUpdateMutationResult = NonNullable<Awaited<ReturnType<typeof ipAllowlistControllerUpdate>>>
+    export type IpAllowlistControllerUpdateMutationBody = UpdateIpAllowlistRequestDto
+    export type IpAllowlistControllerUpdateMutationError = void
+
+    /**
+ * @summary Replace the IP allow list for the current org
+ */
+export const useIpAllowlistControllerUpdate = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof ipAllowlistControllerUpdate>>, TError,{data: UpdateIpAllowlistRequestDto}, TContext>, }
+ , queryClient?: QueryClient): UseMutationResult<
+        Awaited<ReturnType<typeof ipAllowlistControllerUpdate>>,
+        TError,
+        {data: UpdateIpAllowlistRequestDto},
+        TContext
+      > => {
+
+      const mutationOptions = getIpAllowlistControllerUpdateMutationOptions(options);
+
+      return useMutation(mutationOptions, queryClient);
+    }
+    
+/**
+ * @summary Remove the IP allow list (disable IP restriction)
+ */
+export const ipAllowlistControllerRemove = (
+    
+ ) => {
+      
+      
+      return customAxiosInstance<void>(
+      {url: `/ip-allowlist`, method: 'DELETE'
+    },
+      );
+    }
+  
+
+
+export const getIpAllowlistControllerRemoveMutationOptions = <TError = unknown,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof ipAllowlistControllerRemove>>, TError,void, TContext>, }
+): UseMutationOptions<Awaited<ReturnType<typeof ipAllowlistControllerRemove>>, TError,void, TContext> => {
+
+const mutationKey = ['ipAllowlistControllerRemove'];
+const {mutation: mutationOptions} = options ?
+      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
+      options
+      : {...options, mutation: {...options.mutation, mutationKey}}
+      : {mutation: { mutationKey, }};
+
+      
+
+
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof ipAllowlistControllerRemove>>, void> = () => {
+          
+
+          return  ipAllowlistControllerRemove()
+        }
+
+        
+
+
+  return  { mutationFn, ...mutationOptions }}
+
+    export type IpAllowlistControllerRemoveMutationResult = NonNullable<Awaited<ReturnType<typeof ipAllowlistControllerRemove>>>
+    
+    export type IpAllowlistControllerRemoveMutationError = unknown
+
+    /**
+ * @summary Remove the IP allow list (disable IP restriction)
+ */
+export const useIpAllowlistControllerRemove = <TError = unknown,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof ipAllowlistControllerRemove>>, TError,void, TContext>, }
+ , queryClient?: QueryClient): UseMutationResult<
+        Awaited<ReturnType<typeof ipAllowlistControllerRemove>>,
+        TError,
+        void,
+        TContext
+      > => {
+
+      const mutationOptions = getIpAllowlistControllerRemoveMutationOptions(options);
 
       return useMutation(mutationOptions, queryClient);
     }

--- a/ayunis-core-frontend/src/shared/api/openapi-schema.json
+++ b/ayunis-core-frontend/src/shared/api/openapi-schema.json
@@ -8220,6 +8220,74 @@
           "Authentication"
         ]
       }
+    },
+    "/ip-allowlist": {
+      "get": {
+        "operationId": "IpAllowlistController_get",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Current IP allow list (empty array if none)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IpAllowlistResponseDto"
+                }
+              }
+            }
+          }
+        },
+        "summary": "Get the IP allow list for the current org",
+        "tags": [
+          "ip-allowlist"
+        ]
+      },
+      "put": {
+        "operationId": "IpAllowlistController_update",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateIpAllowlistRequestDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated IP allow list",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IpAllowlistResponseDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid CIDR"
+          }
+        },
+        "summary": "Replace the IP allow list for the current org",
+        "tags": [
+          "ip-allowlist"
+        ]
+      },
+      "delete": {
+        "operationId": "IpAllowlistController_remove",
+        "parameters": [],
+        "responses": {
+          "204": {
+            "description": "IP allow list removed"
+          }
+        },
+        "summary": "Remove the IP allow list (disable IP restriction)",
+        "tags": [
+          "ip-allowlist"
+        ]
+      }
     }
   },
   "info": {
@@ -14486,6 +14554,42 @@
           "role",
           "systemRole",
           "name"
+        ]
+      },
+      "IpAllowlistResponseDto": {
+        "type": "object",
+        "properties": {
+          "cidrs": {
+            "description": "List of allowed CIDR ranges",
+            "example": [
+              "203.0.113.0/24"
+            ],
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": [
+          "cidrs"
+        ]
+      },
+      "UpdateIpAllowlistRequestDto": {
+        "type": "object",
+        "properties": {
+          "cidrs": {
+            "description": "List of CIDR ranges to allow (e.g. \"192.168.1.0/24\")",
+            "example": [
+              "203.0.113.0/24"
+            ],
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": [
+          "cidrs"
         ]
       }
     }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds new database-backed IP allowlist endpoints and validation that can affect admin access if misconfigured. Also introduces a schema migration and new error handling paths that should be exercised in staging.
> 
> **Overview**
> Introduces organization-level IP allowlisting with a new `ip_allowlists` table, TypeORM record/mapper, and a Postgres repository wired into IAM via a new `IpAllowlistModule`.
> 
> Adds an admin-only HTTP API at `GET/PUT/DELETE /ip-allowlist` (with DTO validation/normalization) and updates the update use case to enforce **non-empty** CIDR lists and to translate domain CIDR/empty-list validation failures into a consistent `INVALID_CIDR` application error.
> 
> Hardens `getClientIp()` to ignore empty leading entries in `x-forwarded-for` and updates tests; regenerates frontend OpenAPI client types and hooks for the new endpoints.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8a7d1f400a3d08cbf7164e5a60e0e49263c4901f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->