### PR TITLE
wip(AYC-106): add ip allowlist guard with cache invalidation

### DIFF
--- a/ayunis-core-backend/src/iam/authorization/authorization.module.ts
+++ b/ayunis-core-backend/src/iam/authorization/authorization.module.ts
@@ -7,10 +7,16 @@ import { SubscriptionsModule } from '../subscriptions/subscriptions.module';
 import { TrialsModule } from '../trials/trials.module';
 import { EmailConfirmGuard } from './application/guards/email-confirm.guard';
 import { SystemRolesGuard } from './application/guards/system-roles.guard';
+import { IpAllowlistModule } from '../ip-allowlist/ip-allowlist.module';
+import { IpAllowlistGuard } from '../ip-allowlist/application/guards/ip-allowlist.guard';
 
 @Module({
-  imports: [SubscriptionsModule, TrialsModule],
+  imports: [SubscriptionsModule, TrialsModule, IpAllowlistModule],
   providers: [
+    {
+      provide: APP_GUARD,
+      useExisting: IpAllowlistGuard,
+    },
     {
       provide: APP_GUARD,
       useClass: EmailConfirmGuard,

--- a/ayunis-core-backend/src/iam/ip-allowlist/application/guards/ip-allowlist.guard.spec.ts
+++ b/ayunis-core-backend/src/iam/ip-allowlist/application/guards/ip-allowlist.guard.spec.ts
@@ -1,0 +1,243 @@
+/* eslint-disable sonarjs/no-hardcoded-ip -- test fixtures require hardcoded IPs */
+import type { ExecutionContext } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { IpAllowlistGuard } from './ip-allowlist.guard';
+import type { IpAllowlistRepository } from '../ports/ip-allowlist.repository';
+import { IpAllowlist } from '../../domain/ip-allowlist.entity';
+import { IpNotAllowedError } from '../ip-allowlist.errors';
+import type { UUID } from 'crypto';
+import type { ActiveUser } from 'src/iam/authentication/domain/active-user.entity';
+
+function createMockContext(overrides: {
+  isPublic?: boolean;
+  user?: Partial<ActiveUser>;
+  ip?: string | null;
+}): { context: ExecutionContext; reflector: Reflector } {
+  const reflector = new Reflector();
+  jest
+    .spyOn(reflector, 'getAllAndOverride')
+    .mockReturnValue(overrides.isPublic ?? false);
+
+  const request = {
+    user: overrides.user,
+    headers: overrides.ip ? { 'x-forwarded-for': overrides.ip } : {},
+    socket: { remoteAddress: overrides.ip ?? undefined },
+    ip: overrides.ip ?? undefined,
+  };
+
+  const context = {
+    getHandler: jest.fn(),
+    getClass: jest.fn(),
+    switchToHttp: () => ({
+      getRequest: () => request,
+    }),
+  } as unknown as ExecutionContext;
+
+  return { context, reflector };
+}
+
+describe('IpAllowlistGuard', () => {
+  let repository: jest.Mocked<IpAllowlistRepository>;
+
+  const orgId = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890' as UUID;
+
+  const activeUser: Partial<ActiveUser> = {
+    id: '11111111-2222-3333-4444-555555555555' as UUID,
+    orgId,
+    email: 'admin@example.gov',
+  };
+
+  beforeEach(() => {
+    repository = {
+      findByOrgId: jest.fn(),
+      upsert: jest.fn(),
+      deleteByOrgId: jest.fn(),
+    } as jest.Mocked<IpAllowlistRepository>;
+
+    repository.findByOrgId.mockResolvedValue(null);
+  });
+
+  it('should allow access on public routes without checking the allow list', async () => {
+    const { context, reflector: mockReflector } = createMockContext({
+      isPublic: true,
+    });
+    const publicGuard = new IpAllowlistGuard(mockReflector, repository);
+
+    const result = await publicGuard.canActivate(context);
+
+    expect(result).toBe(true);
+    expect(repository.findByOrgId).not.toHaveBeenCalled();
+  });
+
+  it('should allow access when no user is present on the request', async () => {
+    const { context, reflector: mockReflector } = createMockContext({
+      user: undefined,
+      ip: '192.168.1.50',
+    });
+    const noUserGuard = new IpAllowlistGuard(mockReflector, repository);
+
+    const result = await noUserGuard.canActivate(context);
+
+    expect(result).toBe(true);
+    expect(repository.findByOrgId).not.toHaveBeenCalled();
+  });
+
+  it('should allow access when no allow list exists for the org', async () => {
+    repository.findByOrgId.mockResolvedValue(null);
+    const { context, reflector: mockReflector } = createMockContext({
+      user: activeUser,
+      ip: '192.168.1.50',
+    });
+    const g = new IpAllowlistGuard(mockReflector, repository);
+
+    const result = await g.canActivate(context);
+
+    expect(result).toBe(true);
+  });
+
+  it('should allow access when the client IP is within an allowed CIDR range', async () => {
+    repository.findByOrgId.mockResolvedValue(
+      new IpAllowlist({ orgId, cidrs: ['192.168.1.0/24'] }),
+    );
+    const { context, reflector: mockReflector } = createMockContext({
+      user: activeUser,
+      ip: '192.168.1.50',
+    });
+    const g = new IpAllowlistGuard(mockReflector, repository);
+
+    const result = await g.canActivate(context);
+
+    expect(result).toBe(true);
+  });
+
+  it('should throw IpNotAllowedError when the client IP is outside all allowed CIDR ranges', async () => {
+    repository.findByOrgId.mockResolvedValue(
+      new IpAllowlist({ orgId, cidrs: ['10.0.0.0/8'] }),
+    );
+    const { context, reflector: mockReflector } = createMockContext({
+      user: activeUser,
+      ip: '192.168.1.50',
+    });
+    const g = new IpAllowlistGuard(mockReflector, repository);
+
+    await expect(g.canActivate(context)).rejects.toThrow(IpNotAllowedError);
+  });
+
+  it('should throw IpNotAllowedError when the client IP cannot be determined', async () => {
+    repository.findByOrgId.mockResolvedValue(
+      new IpAllowlist({ orgId, cidrs: ['10.0.0.0/8'] }),
+    );
+    const { context, reflector: mockReflector } = createMockContext({
+      user: activeUser,
+      ip: null,
+    });
+    const g = new IpAllowlistGuard(mockReflector, repository);
+
+    await expect(g.canActivate(context)).rejects.toThrow(IpNotAllowedError);
+  });
+
+  it('should use cached CIDRs on subsequent requests for the same org', async () => {
+    repository.findByOrgId.mockResolvedValue(
+      new IpAllowlist({ orgId, cidrs: ['192.168.1.0/24'] }),
+    );
+    const { context, reflector: mockReflector } = createMockContext({
+      user: activeUser,
+      ip: '192.168.1.50',
+    });
+    const g = new IpAllowlistGuard(mockReflector, repository);
+
+    await g.canActivate(context);
+    await g.canActivate(context);
+
+    expect(repository.findByOrgId).toHaveBeenCalledTimes(1);
+  });
+
+  it('should fetch from the repository after cache is invalidated', async () => {
+    repository.findByOrgId.mockResolvedValue(
+      new IpAllowlist({ orgId, cidrs: ['192.168.1.0/24'] }),
+    );
+    const { context, reflector: mockReflector } = createMockContext({
+      user: activeUser,
+      ip: '192.168.1.50',
+    });
+    const g = new IpAllowlistGuard(mockReflector, repository);
+
+    await g.canActivate(context);
+    expect(repository.findByOrgId).toHaveBeenCalledTimes(1);
+
+    g.invalidateCache(orgId);
+
+    await g.canActivate(context);
+    expect(repository.findByOrgId).toHaveBeenCalledTimes(2);
+  });
+
+  it('should re-fetch from the repository after cache TTL expires', async () => {
+    jest.useFakeTimers();
+    try {
+      repository.findByOrgId.mockResolvedValue(
+        new IpAllowlist({ orgId, cidrs: ['192.168.1.0/24'] }),
+      );
+      const { context, reflector: mockReflector } = createMockContext({
+        user: activeUser,
+        ip: '192.168.1.50',
+      });
+      const g = new IpAllowlistGuard(mockReflector, repository);
+
+      await g.canActivate(context);
+      expect(repository.findByOrgId).toHaveBeenCalledTimes(1);
+
+      // Advance time past the 60s TTL
+      jest.advanceTimersByTime(60_000);
+
+      await g.canActivate(context);
+      expect(repository.findByOrgId).toHaveBeenCalledTimes(2);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('should fail open (allow request) when the repository throws', async () => {
+    repository.findByOrgId.mockRejectedValue(new Error('DB connection lost'));
+    const { context, reflector: mockReflector } = createMockContext({
+      user: activeUser,
+      ip: '192.168.1.50',
+    });
+    const g = new IpAllowlistGuard(mockReflector, repository);
+
+    const result = await g.canActivate(context);
+
+    expect(result).toBe(true);
+  });
+
+  it('should not cache the result when the repository throws', async () => {
+    repository.findByOrgId
+      .mockRejectedValueOnce(new Error('DB connection lost'))
+      .mockResolvedValueOnce(new IpAllowlist({ orgId, cidrs: ['10.0.0.0/8'] }));
+    const { context, reflector: mockReflector } = createMockContext({
+      user: activeUser,
+      ip: '192.168.1.50',
+    });
+    const g = new IpAllowlistGuard(mockReflector, repository);
+
+    // First call fails open
+    await g.canActivate(context);
+
+    // Second call should hit the repository again (no stale cache from error)
+    await expect(g.canActivate(context)).rejects.toThrow(IpNotAllowedError);
+    expect(repository.findByOrgId).toHaveBeenCalledTimes(2);
+  });
+
+  it('should cache the absence of an allow list to avoid repeated DB queries', async () => {
+    repository.findByOrgId.mockResolvedValue(null);
+    const { context, reflector: mockReflector } = createMockContext({
+      user: activeUser,
+      ip: '192.168.1.50',
+    });
+    const g = new IpAllowlistGuard(mockReflector, repository);
+
+    await g.canActivate(context);
+    await g.canActivate(context);
+
+    expect(repository.findByOrgId).toHaveBeenCalledTimes(1);
+  });
+});

--- a/ayunis-core-backend/src/iam/ip-allowlist/application/guards/ip-allowlist.guard.ts
+++ b/ayunis-core-backend/src/iam/ip-allowlist/application/guards/ip-allowlist.guard.ts
@@ -1,0 +1,109 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  Injectable,
+  Logger,
+} from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import type { Request } from 'express';
+import type { UUID } from 'crypto';
+
+import { IS_PUBLIC_KEY } from 'src/common/guards/public.guard';
+import { getClientIp } from 'src/common/util/ip.util';
+import { isIpInCidrs } from '../../domain/cidr.util';
+import { IpAllowlistRepository } from '../ports/ip-allowlist.repository';
+import { IpNotAllowedError } from '../ip-allowlist.errors';
+import { IpAllowlistCachePort } from '../ports/ip-allowlist-cache.port';
+import type { ActiveUser } from 'src/iam/authentication/domain/active-user.entity';
+
+interface CacheEntry {
+  cidrs: string[] | null;
+  expiresAt: number;
+}
+
+const CACHE_TTL_MS = 60_000;
+
+@Injectable()
+export class IpAllowlistGuard
+  extends IpAllowlistCachePort
+  implements CanActivate
+{
+  private readonly logger = new Logger(IpAllowlistGuard.name);
+  private readonly cache = new Map<UUID, CacheEntry>();
+
+  constructor(
+    private readonly reflector: Reflector,
+    private readonly repository: IpAllowlistRepository,
+  ) {
+    super();
+  }
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const isPublic = this.reflector.getAllAndOverride<boolean>(IS_PUBLIC_KEY, [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+
+    if (isPublic) {
+      return true;
+    }
+
+    const request = context.switchToHttp().getRequest<Request>();
+    const user = request.user as ActiveUser | undefined;
+
+    if (!user) {
+      return true;
+    }
+
+    const orgId = user.orgId;
+    const cidrs = await this.getCidrs(orgId);
+
+    if (!cidrs || cidrs.length === 0) {
+      return true;
+    }
+
+    const clientIp = getClientIp(request);
+
+    if (!clientIp) {
+      this.logger.warn(
+        `Could not determine client IP for user ${user.id} in org ${orgId}`,
+      );
+      throw new IpNotAllowedError();
+    }
+
+    if (isIpInCidrs(clientIp, cidrs)) {
+      return true;
+    }
+
+    throw new IpNotAllowedError();
+  }
+
+  invalidateCache(orgId: UUID): void {
+    this.cache.delete(orgId);
+  }
+
+  private async getCidrs(orgId: UUID): Promise<string[] | null> {
+    const now = Date.now();
+    const cached = this.cache.get(orgId);
+
+    if (cached && cached.expiresAt > now) {
+      return cached.cidrs;
+    }
+
+    try {
+      const entity = await this.repository.findByOrgId(orgId);
+      const cidrs = entity?.cidrs ?? null;
+
+      this.cache.set(orgId, { cidrs, expiresAt: now + CACHE_TTL_MS });
+
+      return cidrs;
+    } catch (error: unknown) {
+      this.logger.warn(
+        `Failed to fetch IP allowlist for org ${orgId}, failing open: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+      return null;
+    }
+  }
+}

--- a/ayunis-core-backend/src/iam/ip-allowlist/application/ports/ip-allowlist-cache.port.ts
+++ b/ayunis-core-backend/src/iam/ip-allowlist/application/ports/ip-allowlist-cache.port.ts
@@ -1,0 +1,5 @@
+import type { UUID } from 'crypto';
+
+export abstract class IpAllowlistCachePort {
+  abstract invalidateCache(orgId: UUID): void;
+}

--- a/ayunis-core-backend/src/iam/ip-allowlist/application/use-cases/delete-ip-allowlist/delete-ip-allowlist.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/ip-allowlist/application/use-cases/delete-ip-allowlist/delete-ip-allowlist.use-case.spec.ts
@@ -1,12 +1,14 @@
 import { DeleteIpAllowlistUseCase } from './delete-ip-allowlist.use-case';
 import { DeleteIpAllowlistCommand } from './delete-ip-allowlist.command';
 import type { IpAllowlistRepository } from '../../ports/ip-allowlist.repository';
+import type { IpAllowlistCachePort } from '../../ports/ip-allowlist-cache.port';
 import { UnexpectedIpAllowlistError } from '../../ip-allowlist.errors';
 import type { UUID } from 'crypto';
 
 describe('DeleteIpAllowlistUseCase', () => {
   let useCase: DeleteIpAllowlistUseCase;
   let repository: jest.Mocked<IpAllowlistRepository>;
+  let guard: jest.Mocked<IpAllowlistCachePort>;
 
   const orgId = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890' as UUID;
 
@@ -17,7 +19,11 @@ describe('DeleteIpAllowlistUseCase', () => {
       deleteByOrgId: jest.fn(),
     } as jest.Mocked<IpAllowlistRepository>;
 
-    useCase = new DeleteIpAllowlistUseCase(repository);
+    guard = {
+      invalidateCache: jest.fn(),
+    };
+
+    useCase = new DeleteIpAllowlistUseCase(repository, guard);
   });
 
   it('should delete the allow list for the given org', async () => {
@@ -33,6 +39,12 @@ describe('DeleteIpAllowlistUseCase', () => {
     await expect(
       useCase.execute(new DeleteIpAllowlistCommand(orgId)),
     ).resolves.not.toThrow();
+  });
+
+  it('should invalidate the guard cache after deleting the allow list', async () => {
+    await useCase.execute(new DeleteIpAllowlistCommand(orgId));
+
+    expect(guard.invalidateCache).toHaveBeenCalledWith(orgId);
   });
 
   it('should throw UnexpectedIpAllowlistError when repository throws unexpected error', async () => {

--- a/ayunis-core-backend/src/iam/ip-allowlist/application/use-cases/delete-ip-allowlist/delete-ip-allowlist.use-case.ts
+++ b/ayunis-core-backend/src/iam/ip-allowlist/application/use-cases/delete-ip-allowlist/delete-ip-allowlist.use-case.ts
@@ -1,6 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { ApplicationError } from 'src/common/errors/base.error';
 import { IpAllowlistRepository } from '../../ports/ip-allowlist.repository';
+import { IpAllowlistCachePort } from '../../ports/ip-allowlist-cache.port';
 import { UnexpectedIpAllowlistError } from '../../ip-allowlist.errors';
 import type { DeleteIpAllowlistCommand } from './delete-ip-allowlist.command';
 
@@ -8,13 +9,17 @@ import type { DeleteIpAllowlistCommand } from './delete-ip-allowlist.command';
 export class DeleteIpAllowlistUseCase {
   private readonly logger = new Logger(DeleteIpAllowlistUseCase.name);
 
-  constructor(private readonly repository: IpAllowlistRepository) {}
+  constructor(
+    private readonly repository: IpAllowlistRepository,
+    private readonly ipAllowlistCache: IpAllowlistCachePort,
+  ) {}
 
   async execute(command: DeleteIpAllowlistCommand): Promise<void> {
     this.logger.debug('Deleting IP allowlist', { orgId: command.orgId });
 
     try {
       await this.repository.deleteByOrgId(command.orgId);
+      this.ipAllowlistCache.invalidateCache(command.orgId);
     } catch (error) {
       if (error instanceof ApplicationError) throw error;
 

--- a/ayunis-core-backend/src/iam/ip-allowlist/application/use-cases/update-ip-allowlist/update-ip-allowlist.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/ip-allowlist/application/use-cases/update-ip-allowlist/update-ip-allowlist.use-case.spec.ts
@@ -8,11 +8,13 @@ import {
   InvalidCidrApplicationError,
   UnexpectedIpAllowlistError,
 } from '../../ip-allowlist.errors';
+import type { IpAllowlistCachePort } from '../../ports/ip-allowlist-cache.port';
 import type { UUID } from 'crypto';
 
 describe('UpdateIpAllowlistUseCase', () => {
   let useCase: UpdateIpAllowlistUseCase;
   let repository: jest.Mocked<IpAllowlistRepository>;
+  let guard: jest.Mocked<IpAllowlistCachePort>;
 
   const orgId = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890' as UUID;
   const adminIp = '192.168.1.50';
@@ -24,10 +26,14 @@ describe('UpdateIpAllowlistUseCase', () => {
       deleteByOrgId: jest.fn(),
     } as jest.Mocked<IpAllowlistRepository>;
 
+    guard = {
+      invalidateCache: jest.fn(),
+    };
+
     repository.upsert.mockImplementation(async (entity) => entity);
     repository.findByOrgId.mockResolvedValue(null);
 
-    useCase = new UpdateIpAllowlistUseCase(repository);
+    useCase = new UpdateIpAllowlistUseCase(repository, guard);
   });
 
   it('should save valid CIDRs when admin IP is within the new allow list', async () => {
@@ -153,6 +159,29 @@ describe('UpdateIpAllowlistUseCase', () => {
 
     await expect(useCase.execute(command)).rejects.toThrow(AdminLockoutError);
     expect(repository.upsert).not.toHaveBeenCalled();
+  });
+
+  it('should invalidate the guard cache after a successful upsert', async () => {
+    const command = new UpdateIpAllowlistCommand(
+      orgId,
+      ['192.168.1.0/24'],
+      adminIp,
+    );
+
+    await useCase.execute(command);
+
+    expect(guard.invalidateCache).toHaveBeenCalledWith(orgId);
+  });
+
+  it('should not invalidate the guard cache when validation fails', async () => {
+    const command = new UpdateIpAllowlistCommand(
+      orgId,
+      ['not-a-cidr'],
+      adminIp,
+    );
+
+    await expect(useCase.execute(command)).rejects.toThrow();
+    expect(guard.invalidateCache).not.toHaveBeenCalled();
   });
 
   it('should throw UnexpectedIpAllowlistError when repository throws unexpected error', async () => {

--- a/ayunis-core-backend/src/iam/ip-allowlist/application/use-cases/update-ip-allowlist/update-ip-allowlist.use-case.ts
+++ b/ayunis-core-backend/src/iam/ip-allowlist/application/use-cases/update-ip-allowlist/update-ip-allowlist.use-case.ts
@@ -1,6 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { ApplicationError } from 'src/common/errors/base.error';
 import { IpAllowlistRepository } from '../../ports/ip-allowlist.repository';
+import { IpAllowlistCachePort } from '../../ports/ip-allowlist-cache.port';
 import {
   AdminLockoutError,
   InvalidCidrApplicationError,
@@ -18,7 +19,10 @@ import { isIpInCidrs } from '../../../domain/cidr.util';
 export class UpdateIpAllowlistUseCase {
   private readonly logger = new Logger(UpdateIpAllowlistUseCase.name);
 
-  constructor(private readonly repository: IpAllowlistRepository) {}
+  constructor(
+    private readonly repository: IpAllowlistRepository,
+    private readonly ipAllowlistCache: IpAllowlistCachePort,
+  ) {}
 
   async execute(command: UpdateIpAllowlistCommand): Promise<IpAllowlist> {
     this.logger.debug('Updating IP allowlist', {
@@ -52,7 +56,10 @@ export class UpdateIpAllowlistUseCase {
         throw new AdminLockoutError({ clientIp: command.clientIp });
       }
 
-      return await this.repository.upsert(entity);
+      const result = await this.repository.upsert(entity);
+      this.ipAllowlistCache.invalidateCache(command.orgId);
+
+      return result;
     } catch (error) {
       if (error instanceof ApplicationError) throw error;
 

--- a/ayunis-core-backend/src/iam/ip-allowlist/ip-allowlist.module.ts
+++ b/ayunis-core-backend/src/iam/ip-allowlist/ip-allowlist.module.ts
@@ -9,6 +9,8 @@ import { GetIpAllowlistUseCase } from './application/use-cases/get-ip-allowlist/
 import { UpdateIpAllowlistUseCase } from './application/use-cases/update-ip-allowlist/update-ip-allowlist.use-case';
 import { DeleteIpAllowlistUseCase } from './application/use-cases/delete-ip-allowlist/delete-ip-allowlist.use-case';
 
+import { IpAllowlistGuard } from './application/guards/ip-allowlist.guard';
+import { IpAllowlistCachePort } from './application/ports/ip-allowlist-cache.port';
 import { IpAllowlistController } from './presenters/http/ip-allowlist.controller';
 
 @Module({
@@ -22,11 +24,17 @@ import { IpAllowlistController } from './presenters/http/ip-allowlist.controller
     GetIpAllowlistUseCase,
     UpdateIpAllowlistUseCase,
     DeleteIpAllowlistUseCase,
+    IpAllowlistGuard,
+    {
+      provide: IpAllowlistCachePort,
+      useExisting: IpAllowlistGuard,
+    },
   ],
   exports: [
     GetIpAllowlistUseCase,
     UpdateIpAllowlistUseCase,
     DeleteIpAllowlistUseCase,
+    IpAllowlistGuard,
   ],
 })
 export class IpAllowlistModule {}

--- a/ayunis-core-frontend/src/shared/api/openapi-schema.json
+++ b/ayunis-core-frontend/src/shared/api/openapi-schema.json
@@ -8267,7 +8267,7 @@
             }
           },
           "400": {
-            "description": "Invalid CIDR"
+            "description": "Invalid CIDR or admin lockout (requesting IP not in new allowlist)"
           }
         },
         "summary": "Replace the IP allow list for the current org",

--- a/ayunis-core-frontend/src/shared/constants/department.ts
+++ b/ayunis-core-frontend/src/shared/constants/department.ts
@@ -1,6 +1,6 @@
 /**
- * Selectable department keys.
- * The frontend owns this list — the backend accepts any string.
+ * Selectable department keys — mirrors the backend `department.constants.ts`.
+ * Do NOT duplicate freely — the backend is the single source of truth.
  */
 export const DEPARTMENT_KEYS = [
   'hauptamt',


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new globally-applied authorization guard that can deny requests based on client IP, which could impact access if IP detection or allowlist configuration is wrong. Caching and fail-open behavior reduce DB load but introduce freshness/consistency concerns addressed via explicit invalidation.
> 
> **Overview**
> Adds an org-scoped **IP allowlist enforcement** layer by registering `IpAllowlistGuard` as an `APP_GUARD` in `AuthorizationModule`.
> 
> The new guard loads per-org CIDR allowlists from the repository, checks the request’s client IP, and **denies with `IpNotAllowedError`** when outside the configured ranges; lookups are cached in-memory with a 60s TTL and cache invalidation support.
> 
> `UpdateIpAllowlistUseCase` and `DeleteIpAllowlistUseCase` now invalidate the guard cache after successful upsert/delete via a new `IpAllowlistCachePort`, and tests are added/updated to cover cache behavior, TTL, invalidation, and fail-open on repository errors. Frontend OpenAPI text is tweaked to clarify 400s can include admin lockout, and `DEPARTMENT_KEYS` comments are updated to note backend as source of truth.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e00e6a2a56a5f9113af591afb69f53b57ac1efc3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->