### PR TITLE
feat(AYC-106): add security settings page with IP allow list management

### DIFF
--- a/ayunis-core-frontend/src/app/routeTree.gen.ts
+++ b/ayunis-core-frontend/src/app/routeTree.gen.ts
@@ -16,6 +16,7 @@ import { Route as IndexImport } from './routes/index'
 import { Route as AuthenticatedInstallImport } from './routes/_authenticated/install'
 import { Route as onboardingRegisterImport } from './routes/(onboarding)/register'
 import { Route as onboardingLoginImport } from './routes/(onboarding)/login'
+import { Route as onboardingIpBlockedImport } from './routes/(onboarding)/ip-blocked'
 import { Route as onboardingEmailConfirmImport } from './routes/(onboarding)/email-confirm'
 import { Route as onboardingConfirmEmailImport } from './routes/(onboarding)/confirm-email'
 import { Route as onboardingAcceptInviteImport } from './routes/(onboarding)/accept-invite'
@@ -37,6 +38,7 @@ import { Route as AuthenticatedChatsThreadIdImport } from './routes/_authenticat
 import { Route as AuthenticatedAgentsIdImport } from './routes/_authenticated/agents.$id'
 import { Route as AuthenticatedAdminSettingsUsersImport } from './routes/_authenticated/admin-settings.users'
 import { Route as AuthenticatedAdminSettingsUsageImport } from './routes/_authenticated/admin-settings.usage'
+import { Route as AuthenticatedAdminSettingsSecurityImport } from './routes/_authenticated/admin-settings.security'
 import { Route as AuthenticatedAdminSettingsModelsImport } from './routes/_authenticated/admin-settings.models'
 import { Route as AuthenticatedAdminSettingsIntegrationsImport } from './routes/_authenticated/admin-settings.integrations'
 import { Route as onboardingPasswordResetImport } from './routes/(onboarding)/password.reset'
@@ -79,6 +81,12 @@ const onboardingRegisterRoute = onboardingRegisterImport.update({
 const onboardingLoginRoute = onboardingLoginImport.update({
   id: '/(onboarding)/login',
   path: '/login',
+  getParentRoute: () => rootRoute,
+} as any)
+
+const onboardingIpBlockedRoute = onboardingIpBlockedImport.update({
+  id: '/(onboarding)/ip-blocked',
+  path: '/ip-blocked',
   getParentRoute: () => rootRoute,
 } as any)
 
@@ -220,6 +228,13 @@ const AuthenticatedAdminSettingsUsageRoute =
     getParentRoute: () => AuthenticatedRoute,
   } as any)
 
+const AuthenticatedAdminSettingsSecurityRoute =
+  AuthenticatedAdminSettingsSecurityImport.update({
+    id: '/admin-settings/security',
+    path: '/admin-settings/security',
+    getParentRoute: () => AuthenticatedRoute,
+  } as any)
+
 const AuthenticatedAdminSettingsModelsRoute =
   AuthenticatedAdminSettingsModelsImport.update({
     id: '/admin-settings/models',
@@ -348,6 +363,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof onboardingEmailConfirmImport
       parentRoute: typeof rootRoute
     }
+    '/(onboarding)/ip-blocked': {
+      id: '/(onboarding)/ip-blocked'
+      path: '/ip-blocked'
+      fullPath: '/ip-blocked'
+      preLoaderRoute: typeof onboardingIpBlockedImport
+      parentRoute: typeof rootRoute
+    }
     '/(onboarding)/login': {
       id: '/(onboarding)/login'
       path: '/login'
@@ -395,6 +417,13 @@ declare module '@tanstack/react-router' {
       path: '/admin-settings/models'
       fullPath: '/admin-settings/models'
       preLoaderRoute: typeof AuthenticatedAdminSettingsModelsImport
+      parentRoute: typeof AuthenticatedImport
+    }
+    '/_authenticated/admin-settings/security': {
+      id: '/_authenticated/admin-settings/security'
+      path: '/admin-settings/security'
+      fullPath: '/admin-settings/security'
+      preLoaderRoute: typeof AuthenticatedAdminSettingsSecurityImport
       parentRoute: typeof AuthenticatedImport
     }
     '/_authenticated/admin-settings/usage': {
@@ -595,6 +624,7 @@ interface AuthenticatedRouteChildren {
   AuthenticatedInstallRoute: typeof AuthenticatedInstallRoute
   AuthenticatedAdminSettingsIntegrationsRoute: typeof AuthenticatedAdminSettingsIntegrationsRoute
   AuthenticatedAdminSettingsModelsRoute: typeof AuthenticatedAdminSettingsModelsRoute
+  AuthenticatedAdminSettingsSecurityRoute: typeof AuthenticatedAdminSettingsSecurityRoute
   AuthenticatedAdminSettingsUsageRoute: typeof AuthenticatedAdminSettingsUsageRoute
   AuthenticatedAdminSettingsUsersRoute: typeof AuthenticatedAdminSettingsUsersRoute
   AuthenticatedAgentsIdRoute: typeof AuthenticatedAgentsIdRoute
@@ -629,6 +659,8 @@ const AuthenticatedRouteChildren: AuthenticatedRouteChildren = {
   AuthenticatedAdminSettingsIntegrationsRoute:
     AuthenticatedAdminSettingsIntegrationsRoute,
   AuthenticatedAdminSettingsModelsRoute: AuthenticatedAdminSettingsModelsRoute,
+  AuthenticatedAdminSettingsSecurityRoute:
+    AuthenticatedAdminSettingsSecurityRoute,
   AuthenticatedAdminSettingsUsageRoute: AuthenticatedAdminSettingsUsageRoute,
   AuthenticatedAdminSettingsUsersRoute: AuthenticatedAdminSettingsUsersRoute,
   AuthenticatedAgentsIdRoute: AuthenticatedAgentsIdRoute,
@@ -678,6 +710,7 @@ export interface FileRoutesByFullPath {
   '/accept-invite': typeof onboardingAcceptInviteRoute
   '/confirm-email': typeof onboardingConfirmEmailRoute
   '/email-confirm': typeof onboardingEmailConfirmRoute
+  '/ip-blocked': typeof onboardingIpBlockedRoute
   '/login': typeof onboardingLoginRoute
   '/register': typeof onboardingRegisterRoute
   '/install': typeof AuthenticatedInstallRoute
@@ -685,6 +718,7 @@ export interface FileRoutesByFullPath {
   '/password/reset': typeof onboardingPasswordResetRoute
   '/admin-settings/integrations': typeof AuthenticatedAdminSettingsIntegrationsRoute
   '/admin-settings/models': typeof AuthenticatedAdminSettingsModelsRoute
+  '/admin-settings/security': typeof AuthenticatedAdminSettingsSecurityRoute
   '/admin-settings/usage': typeof AuthenticatedAdminSettingsUsageRoute
   '/admin-settings/users': typeof AuthenticatedAdminSettingsUsersRoute
   '/agents/$id': typeof AuthenticatedAgentsIdRoute
@@ -720,6 +754,7 @@ export interface FileRoutesByTo {
   '/accept-invite': typeof onboardingAcceptInviteRoute
   '/confirm-email': typeof onboardingConfirmEmailRoute
   '/email-confirm': typeof onboardingEmailConfirmRoute
+  '/ip-blocked': typeof onboardingIpBlockedRoute
   '/login': typeof onboardingLoginRoute
   '/register': typeof onboardingRegisterRoute
   '/install': typeof AuthenticatedInstallRoute
@@ -727,6 +762,7 @@ export interface FileRoutesByTo {
   '/password/reset': typeof onboardingPasswordResetRoute
   '/admin-settings/integrations': typeof AuthenticatedAdminSettingsIntegrationsRoute
   '/admin-settings/models': typeof AuthenticatedAdminSettingsModelsRoute
+  '/admin-settings/security': typeof AuthenticatedAdminSettingsSecurityRoute
   '/admin-settings/usage': typeof AuthenticatedAdminSettingsUsageRoute
   '/admin-settings/users': typeof AuthenticatedAdminSettingsUsersRoute
   '/agents/$id': typeof AuthenticatedAgentsIdRoute
@@ -763,6 +799,7 @@ export interface FileRoutesById {
   '/(onboarding)/accept-invite': typeof onboardingAcceptInviteRoute
   '/(onboarding)/confirm-email': typeof onboardingConfirmEmailRoute
   '/(onboarding)/email-confirm': typeof onboardingEmailConfirmRoute
+  '/(onboarding)/ip-blocked': typeof onboardingIpBlockedRoute
   '/(onboarding)/login': typeof onboardingLoginRoute
   '/(onboarding)/register': typeof onboardingRegisterRoute
   '/_authenticated/install': typeof AuthenticatedInstallRoute
@@ -770,6 +807,7 @@ export interface FileRoutesById {
   '/(onboarding)/password/reset': typeof onboardingPasswordResetRoute
   '/_authenticated/admin-settings/integrations': typeof AuthenticatedAdminSettingsIntegrationsRoute
   '/_authenticated/admin-settings/models': typeof AuthenticatedAdminSettingsModelsRoute
+  '/_authenticated/admin-settings/security': typeof AuthenticatedAdminSettingsSecurityRoute
   '/_authenticated/admin-settings/usage': typeof AuthenticatedAdminSettingsUsageRoute
   '/_authenticated/admin-settings/users': typeof AuthenticatedAdminSettingsUsersRoute
   '/_authenticated/agents/$id': typeof AuthenticatedAgentsIdRoute
@@ -807,6 +845,7 @@ export interface FileRouteTypes {
     | '/accept-invite'
     | '/confirm-email'
     | '/email-confirm'
+    | '/ip-blocked'
     | '/login'
     | '/register'
     | '/install'
@@ -814,6 +853,7 @@ export interface FileRouteTypes {
     | '/password/reset'
     | '/admin-settings/integrations'
     | '/admin-settings/models'
+    | '/admin-settings/security'
     | '/admin-settings/usage'
     | '/admin-settings/users'
     | '/agents/$id'
@@ -848,6 +888,7 @@ export interface FileRouteTypes {
     | '/accept-invite'
     | '/confirm-email'
     | '/email-confirm'
+    | '/ip-blocked'
     | '/login'
     | '/register'
     | '/install'
@@ -855,6 +896,7 @@ export interface FileRouteTypes {
     | '/password/reset'
     | '/admin-settings/integrations'
     | '/admin-settings/models'
+    | '/admin-settings/security'
     | '/admin-settings/usage'
     | '/admin-settings/users'
     | '/agents/$id'
@@ -889,6 +931,7 @@ export interface FileRouteTypes {
     | '/(onboarding)/accept-invite'
     | '/(onboarding)/confirm-email'
     | '/(onboarding)/email-confirm'
+    | '/(onboarding)/ip-blocked'
     | '/(onboarding)/login'
     | '/(onboarding)/register'
     | '/_authenticated/install'
@@ -896,6 +939,7 @@ export interface FileRouteTypes {
     | '/(onboarding)/password/reset'
     | '/_authenticated/admin-settings/integrations'
     | '/_authenticated/admin-settings/models'
+    | '/_authenticated/admin-settings/security'
     | '/_authenticated/admin-settings/usage'
     | '/_authenticated/admin-settings/users'
     | '/_authenticated/agents/$id'
@@ -932,6 +976,7 @@ export interface RootRouteChildren {
   onboardingAcceptInviteRoute: typeof onboardingAcceptInviteRoute
   onboardingConfirmEmailRoute: typeof onboardingConfirmEmailRoute
   onboardingEmailConfirmRoute: typeof onboardingEmailConfirmRoute
+  onboardingIpBlockedRoute: typeof onboardingIpBlockedRoute
   onboardingLoginRoute: typeof onboardingLoginRoute
   onboardingRegisterRoute: typeof onboardingRegisterRoute
   onboardingPasswordForgotRoute: typeof onboardingPasswordForgotRoute
@@ -944,6 +989,7 @@ const rootRouteChildren: RootRouteChildren = {
   onboardingAcceptInviteRoute: onboardingAcceptInviteRoute,
   onboardingConfirmEmailRoute: onboardingConfirmEmailRoute,
   onboardingEmailConfirmRoute: onboardingEmailConfirmRoute,
+  onboardingIpBlockedRoute: onboardingIpBlockedRoute,
   onboardingLoginRoute: onboardingLoginRoute,
   onboardingRegisterRoute: onboardingRegisterRoute,
   onboardingPasswordForgotRoute: onboardingPasswordForgotRoute,
@@ -965,6 +1011,7 @@ export const routeTree = rootRoute
         "/(onboarding)/accept-invite",
         "/(onboarding)/confirm-email",
         "/(onboarding)/email-confirm",
+        "/(onboarding)/ip-blocked",
         "/(onboarding)/login",
         "/(onboarding)/register",
         "/(onboarding)/password/forgot",
@@ -980,6 +1027,7 @@ export const routeTree = rootRoute
         "/_authenticated/install",
         "/_authenticated/admin-settings/integrations",
         "/_authenticated/admin-settings/models",
+        "/_authenticated/admin-settings/security",
         "/_authenticated/admin-settings/usage",
         "/_authenticated/admin-settings/users",
         "/_authenticated/agents/$id",
@@ -1018,6 +1066,9 @@ export const routeTree = rootRoute
     "/(onboarding)/email-confirm": {
       "filePath": "(onboarding)/email-confirm.tsx"
     },
+    "/(onboarding)/ip-blocked": {
+      "filePath": "(onboarding)/ip-blocked.tsx"
+    },
     "/(onboarding)/login": {
       "filePath": "(onboarding)/login.tsx"
     },
@@ -1040,6 +1091,10 @@ export const routeTree = rootRoute
     },
     "/_authenticated/admin-settings/models": {
       "filePath": "_authenticated/admin-settings.models.tsx",
+      "parent": "/_authenticated"
+    },
+    "/_authenticated/admin-settings/security": {
+      "filePath": "_authenticated/admin-settings.security.tsx",
       "parent": "/_authenticated"
     },
     "/_authenticated/admin-settings/usage": {

--- a/ayunis-core-frontend/src/app/routes/(onboarding)/ip-blocked.tsx
+++ b/ayunis-core-frontend/src/app/routes/(onboarding)/ip-blocked.tsx
@@ -1,0 +1,6 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { IpBlockedPage } from '@/pages/auth/ip-blocked';
+
+export const Route = createFileRoute('/(onboarding)/ip-blocked')({
+  component: IpBlockedPage,
+});

--- a/ayunis-core-frontend/src/app/routes/_authenticated.tsx
+++ b/ayunis-core-frontend/src/app/routes/_authenticated.tsx
@@ -34,6 +34,11 @@ export const Route = createFileRoute('/_authenticated')({
     } catch (error) {
       try {
         const { code } = extractErrorData(error);
+        if (code === 'IP_NOT_ALLOWED') {
+          throw redirect({
+            to: '/ip-blocked',
+          });
+        }
         if (code === 'EMAIL_NOT_VERIFIED') {
           throw redirect({
             to: '/email-confirm',

--- a/ayunis-core-frontend/src/app/routes/_authenticated/admin-settings.security.tsx
+++ b/ayunis-core-frontend/src/app/routes/_authenticated/admin-settings.security.tsx
@@ -1,0 +1,12 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { SecuritySettingsPage } from '@/pages/admin-settings/security-settings';
+
+export const Route = createFileRoute('/_authenticated/admin-settings/security')(
+  {
+    component: RouteComponent,
+  },
+);
+
+function RouteComponent() {
+  return <SecuritySettingsPage />;
+}

--- a/ayunis-core-frontend/src/i18n.ts
+++ b/ayunis-core-frontend/src/i18n.ts
@@ -54,6 +54,8 @@ import enArtifacts from './shared/locales/en/artifacts.json';
 import deArtifacts from './shared/locales/de/artifacts.json';
 import enSuperAdminSettingsPlatformConfig from './shared/locales/en/super-admin-settings-platform-config.json';
 import deSuperAdminSettingsPlatformConfig from './shared/locales/de/super-admin-settings-platform-config.json';
+import enAdminSettingsSecurity from './shared/locales/en/admin-settings-security.json';
+import deAdminSettingsSecurity from './shared/locales/de/admin-settings-security.json';
 
 const resources = {
   en: {
@@ -83,6 +85,7 @@ const resources = {
     'super-admin-settings-super-admins': enSuperAdminSettingsSuperAdmins,
     artifacts: enArtifacts,
     'super-admin-settings-platform-config': enSuperAdminSettingsPlatformConfig,
+    'admin-settings-security': enAdminSettingsSecurity,
   },
   de: {
     auth: deAuth,
@@ -111,6 +114,7 @@ const resources = {
     'super-admin-settings-super-admins': deSuperAdminSettingsSuperAdmins,
     artifacts: deArtifacts,
     'super-admin-settings-platform-config': deSuperAdminSettingsPlatformConfig,
+    'admin-settings-security': deAdminSettingsSecurity,
   },
 };
 

--- a/ayunis-core-frontend/src/pages/admin-settings/admin-settings-layout/ui/AdminSettingsSidebar.tsx
+++ b/ayunis-core-frontend/src/pages/admin-settings/admin-settings-layout/ui/AdminSettingsSidebar.tsx
@@ -1,4 +1,4 @@
-import { User, Users, Brain, Plug, BarChart3 } from 'lucide-react';
+import { User, Users, Brain, Plug, BarChart3, Shield } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { useAppControllerIsCloud } from '@/shared/api';
 import {
@@ -31,6 +31,11 @@ export function AdminSettingsSidebar() {
       to: '/admin-settings/integrations',
       icon: <Plug />,
       label: t('layout.integrations'),
+    },
+    {
+      to: '/admin-settings/security',
+      icon: <Shield />,
+      label: t('layout.security'),
     },
   ];
 

--- a/ayunis-core-frontend/src/pages/admin-settings/security-settings/index.ts
+++ b/ayunis-core-frontend/src/pages/admin-settings/security-settings/index.ts
@@ -1,0 +1,1 @@
+export { SecuritySettingsPage } from './ui/SecuritySettingsPage';

--- a/ayunis-core-frontend/src/pages/admin-settings/security-settings/lib/validate-cidr.spec.ts
+++ b/ayunis-core-frontend/src/pages/admin-settings/security-settings/lib/validate-cidr.spec.ts
@@ -1,0 +1,167 @@
+/* eslint-disable sonarjs/no-hardcoded-ip -- test fixtures require hardcoded IPs */
+import { describe, it, expect } from 'vitest';
+import { isValidCidrOrIp } from './validate-cidr';
+
+describe('isValidCidrOrIp', () => {
+  describe('valid IPv4 CIDR', () => {
+    it('should accept a standard IPv4 CIDR', () => {
+      expect(isValidCidrOrIp('192.168.1.0/24')).toBe(true);
+    });
+
+    it('should accept a single-host /32 CIDR', () => {
+      expect(isValidCidrOrIp('10.0.0.1/32')).toBe(true);
+    });
+
+    it('should accept a broad /8 CIDR', () => {
+      expect(isValidCidrOrIp('10.0.0.0/8')).toBe(true);
+    });
+
+    it('should accept /0 CIDR', () => {
+      expect(isValidCidrOrIp('0.0.0.0/0')).toBe(true);
+    });
+  });
+
+  describe('valid IPv6 CIDR', () => {
+    it('should accept a standard IPv6 CIDR', () => {
+      expect(isValidCidrOrIp('2001:db8::/32')).toBe(true);
+    });
+
+    it('should accept a /128 prefix', () => {
+      expect(isValidCidrOrIp('2001:db8::1/128')).toBe(true);
+    });
+
+    it('should accept a full IPv6 address with CIDR', () => {
+      expect(
+        isValidCidrOrIp('2001:0db8:0000:0000:0000:0000:0000:0001/64'),
+      ).toBe(true);
+    });
+
+    it('should accept /0 prefix', () => {
+      expect(isValidCidrOrIp('::/0')).toBe(true);
+    });
+  });
+
+  describe('single IPv4 address', () => {
+    it('should accept a single IPv4 address', () => {
+      expect(isValidCidrOrIp('192.168.1.1')).toBe(true);
+    });
+
+    it('should accept 0.0.0.0', () => {
+      expect(isValidCidrOrIp('0.0.0.0')).toBe(true);
+    });
+
+    it('should accept 255.255.255.255', () => {
+      expect(isValidCidrOrIp('255.255.255.255')).toBe(true);
+    });
+  });
+
+  describe('single IPv6 address', () => {
+    it('should accept ::1 (loopback)', () => {
+      expect(isValidCidrOrIp('::1')).toBe(true);
+    });
+
+    it('should accept :: (all zeros)', () => {
+      expect(isValidCidrOrIp('::')).toBe(true);
+    });
+
+    it('should accept a full IPv6 address', () => {
+      expect(isValidCidrOrIp('2001:0db8:0000:0000:0000:0000:0000:0001')).toBe(
+        true,
+      );
+    });
+
+    it('should accept a compressed IPv6 address', () => {
+      expect(isValidCidrOrIp('fe80::1')).toBe(true);
+    });
+  });
+
+  describe('invalid CIDRs', () => {
+    it('should reject an IPv4 octet > 255', () => {
+      expect(isValidCidrOrIp('999.999.999.999/24')).toBe(false);
+    });
+
+    it('should reject a negative prefix', () => {
+      expect(isValidCidrOrIp('192.168.1.0/-1')).toBe(false);
+    });
+
+    it('should reject an IPv4 prefix > 32', () => {
+      expect(isValidCidrOrIp('192.168.1.0/33')).toBe(false);
+    });
+
+    it('should reject an IPv6 prefix > 128', () => {
+      expect(isValidCidrOrIp('2001:db8::/129')).toBe(false);
+    });
+
+    it('should reject a non-numeric prefix', () => {
+      expect(isValidCidrOrIp('192.168.1.0/abc')).toBe(false);
+    });
+
+    it('should reject a floating-point prefix', () => {
+      expect(isValidCidrOrIp('192.168.1.0/24.5')).toBe(false);
+    });
+  });
+
+  describe('malformed input', () => {
+    it('should reject an empty string', () => {
+      expect(isValidCidrOrIp('')).toBe(false);
+    });
+
+    it('should reject multiple slashes', () => {
+      expect(isValidCidrOrIp('192.168.1.0/24/16')).toBe(false);
+    });
+
+    it('should reject trailing slash without prefix', () => {
+      expect(isValidCidrOrIp('192.168.1.0/')).toBe(false);
+    });
+
+    it('should reject IPv6 trailing slash without prefix', () => {
+      expect(isValidCidrOrIp('2001:db8::/')).toBe(false);
+    });
+
+    it('should reject whitespace-only prefix', () => {
+      expect(isValidCidrOrIp('10.0.0.1/ ')).toBe(false);
+    });
+
+    it('should reject prefix with leading whitespace', () => {
+      expect(isValidCidrOrIp('10.0.0.1/ 24')).toBe(false);
+    });
+
+    it('should reject prefix with trailing whitespace', () => {
+      expect(isValidCidrOrIp('10.0.0.1/24 ')).toBe(false);
+    });
+
+    it('should reject tab character in prefix', () => {
+      expect(isValidCidrOrIp('10.0.0.1/\t8')).toBe(false);
+    });
+
+    it('should reject random text', () => {
+      expect(isValidCidrOrIp('not-an-ip')).toBe(false);
+    });
+  });
+
+  describe('IPv6 edge cases', () => {
+    it('should reject structurally invalid IPv6 with too many colons', () => {
+      expect(isValidCidrOrIp(':::::::::/64')).toBe(false);
+    });
+
+    it('should reject IPv6 with multiple :: groups', () => {
+      expect(isValidCidrOrIp('2001::db8::1/64')).toBe(false);
+    });
+
+    it('should reject IPv6 with too many groups', () => {
+      expect(isValidCidrOrIp('1:2:3:4:5:6:7:8:9/64')).toBe(false);
+    });
+
+    it('should reject IPv6 group with invalid hex', () => {
+      expect(isValidCidrOrIp('gggg::/32')).toBe(false);
+    });
+
+    it('should reject IPv6 group with more than 4 hex digits', () => {
+      expect(isValidCidrOrIp('12345::/32')).toBe(false);
+    });
+
+    it('should reject single IPv6 with multiple :: groups', () => {
+      expect(isValidCidrOrIp('2001::db8::1')).toBe(false);
+    });
+  });
+});

--- a/ayunis-core-frontend/src/pages/admin-settings/security-settings/lib/validate-cidr.ts
+++ b/ayunis-core-frontend/src/pages/admin-settings/security-settings/lib/validate-cidr.ts
@@ -1,0 +1,83 @@
+const IPV4_CIDR_REGEX =
+  /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})\/(\d{1,2})$/;
+const SINGLE_IPV4_REGEX = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/;
+
+function isValidIpv4Cidr(cidr: string): boolean {
+  const match = IPV4_CIDR_REGEX.exec(cidr);
+  if (!match) return false;
+  const octets = [match[1], match[2], match[3], match[4]];
+  if (octets.some((o) => Number(o) > 255)) return false;
+  const prefix = Number(match[5]);
+  return prefix >= 0 && prefix <= 32;
+}
+
+function isValidSingleIpv4(ip: string): boolean {
+  const match = SINGLE_IPV4_REGEX.exec(ip);
+  if (!match) return false;
+  const octets = [match[1], match[2], match[3], match[4]];
+  return !octets.some((o) => Number(o) > 255);
+}
+
+/**
+ * Validates an IPv6 address string (without prefix).
+ * Handles full form, compressed (::), and mixed formats.
+ */
+function isValidIpv6Address(address: string): boolean {
+  if (address.length === 0) return false;
+
+  // Check for multiple consecutive :: (only one allowed)
+  const doubleColonCount = address.split('::').length - 1;
+  if (doubleColonCount > 1) return false;
+
+  const groups = address.split(':');
+  const hasDoubleColon = doubleColonCount === 1;
+
+  if (hasDoubleColon) {
+    // With ::, we can have fewer than 8 groups
+    // Split on :: to get left and right parts
+    const parts = address.split('::');
+    const left = parts[0] === '' ? [] : parts[0].split(':');
+    const right = parts[1] === '' ? [] : parts[1].split(':');
+    const totalGroups = left.length + right.length;
+    if (totalGroups > 7) return false;
+    const allGroups = [...left, ...right];
+    return allGroups.every((g) => /^[0-9a-fA-F]{1,4}$/.test(g));
+  }
+
+  // Without ::, must have exactly 8 groups
+  if (groups.length !== 8) return false;
+  return groups.every((g) => /^[0-9a-fA-F]{1,4}$/.test(g));
+}
+
+function isValidIpv6Cidr(cidr: string): boolean {
+  const slashIndex = cidr.lastIndexOf('/');
+  if (slashIndex === -1) return false;
+
+  const address = cidr.substring(0, slashIndex);
+  const prefixStr = cidr.substring(slashIndex + 1);
+
+  if (!/^\d{1,3}$/.test(prefixStr)) return false;
+  const prefix = Number(prefixStr);
+  if (prefix < 0 || prefix > 128) return false;
+
+  return isValidIpv6Address(address);
+}
+
+function isValidSingleIpv6(ip: string): boolean {
+  // Must not contain a slash (that would be CIDR notation)
+  if (ip.includes('/')) return false;
+  return isValidIpv6Address(ip);
+}
+
+/**
+ * Validates a CIDR string (IPv4 or IPv6).
+ * Also accepts single IPv4/IPv6 addresses (treated as /32 or /128 by the backend).
+ */
+export function isValidCidrOrIp(cidr: string): boolean {
+  return (
+    isValidIpv4Cidr(cidr) ||
+    isValidIpv6Cidr(cidr) ||
+    isValidSingleIpv4(cidr) ||
+    isValidSingleIpv6(cidr)
+  );
+}

--- a/ayunis-core-frontend/src/pages/admin-settings/security-settings/ui/RemoveRestrictionsDialog.tsx
+++ b/ayunis-core-frontend/src/pages/admin-settings/security-settings/ui/RemoveRestrictionsDialog.tsx
@@ -1,0 +1,59 @@
+import { useTranslation } from 'react-i18next';
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/shared/ui/shadcn/alert-dialog';
+import { Button } from '@/shared/ui/shadcn/button';
+
+interface RemoveRestrictionsDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onConfirm: () => void;
+  isRemoving: boolean;
+}
+
+export function RemoveRestrictionsDialog({
+  open,
+  onOpenChange,
+  onConfirm,
+  isRemoving,
+}: Readonly<RemoveRestrictionsDialogProps>) {
+  const { t } = useTranslation('admin-settings-security');
+
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>
+            {t('ipAllowlist.removeConfirmTitle')}
+          </AlertDialogTitle>
+          <AlertDialogDescription>
+            {t('ipAllowlist.removeConfirmDescription')}
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <Button
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={isRemoving}
+          >
+            {t('ipAllowlist.removeConfirmCancel')}
+          </Button>
+          <Button
+            variant="destructive"
+            onClick={onConfirm}
+            disabled={isRemoving}
+          >
+            {isRemoving
+              ? t('ipAllowlist.removing')
+              : t('ipAllowlist.removeConfirmConfirm')}
+          </Button>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/ayunis-core-frontend/src/pages/admin-settings/security-settings/ui/SecuritySettingsPage.tsx
+++ b/ayunis-core-frontend/src/pages/admin-settings/security-settings/ui/SecuritySettingsPage.tsx
@@ -1,0 +1,244 @@
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useQueryClient } from '@tanstack/react-query';
+import SettingsLayout from '../../admin-settings-layout';
+import { Button } from '@/shared/ui/shadcn/button';
+import { Textarea } from '@/shared/ui/shadcn/textarea';
+import { Label } from '@/shared/ui/shadcn/label';
+import {
+  useIpAllowlistControllerGet,
+  useIpAllowlistControllerUpdate,
+  useIpAllowlistControllerRemove,
+  getIpAllowlistControllerGetQueryKey,
+} from '@/shared/api';
+import extractErrorData from '@/shared/api/extract-error-data';
+import { showSuccess, showError } from '@/shared/lib/toast';
+import { isValidCidrOrIp } from '../lib/validate-cidr';
+import { RemoveRestrictionsDialog } from './RemoveRestrictionsDialog';
+import { AlertCircle, Info, Loader2 } from 'lucide-react';
+import { Alert, AlertDescription } from '@/shared/ui/shadcn/alert';
+
+export function SecuritySettingsPage() {
+  const { t: tLayout } = useTranslation('admin-settings-layout');
+  const { t } = useTranslation('admin-settings-security');
+  const queryClient = useQueryClient();
+
+  const { data, isLoading, isError, refetch } = useIpAllowlistControllerGet();
+  const cidrsFromServer = data?.cidrs ?? [];
+
+  const [cidrsText, setCidrsText] = useState<string | null>(null);
+  const [validationError, setValidationError] = useState<string | null>(null);
+  const [removeDialogOpen, setRemoveDialogOpen] = useState(false);
+
+  const displayText =
+    cidrsText !== null ? cidrsText : cidrsFromServer.join('\n');
+
+  const updateMutation = useIpAllowlistControllerUpdate();
+  const removeMutation = useIpAllowlistControllerRemove();
+  const isMutating = updateMutation.isPending || removeMutation.isPending;
+
+  const hasExistingRestrictions = cidrsFromServer.length > 0;
+  const isDirty = cidrsText !== null;
+
+  function parseCidrs(text: string): string[] {
+    return text
+      .split('\n')
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0);
+  }
+
+  function handleSave() {
+    const lines = parseCidrs(displayText);
+
+    if (lines.length === 0) {
+      if (hasExistingRestrictions) {
+        setRemoveDialogOpen(true);
+      }
+      return;
+    }
+
+    const invalidLine = findFirstInvalidCidr(lines);
+    if (invalidLine) {
+      setValidationError(invalidLine);
+      return;
+    }
+    setValidationError(null);
+
+    updateMutation.mutate(
+      { data: { cidrs: lines } },
+      {
+        onSuccess: () => {
+          showSuccess(t('ipAllowlist.saveSuccess'));
+          setCidrsText(null);
+          void queryClient.invalidateQueries({
+            queryKey: getIpAllowlistControllerGetQueryKey(),
+          });
+        },
+        onError: (error) => {
+          handleMutationError(error, 'save');
+        },
+      },
+    );
+  }
+
+  function findFirstInvalidCidr(lines: string[]): string | null {
+    for (let i = 0; i < lines.length; i++) {
+      if (!isValidCidrOrIp(lines[i])) {
+        return t('ipAllowlist.invalidCidr', {
+          line: i + 1,
+          value: lines[i],
+        });
+      }
+    }
+    return null;
+  }
+
+  function handleMutationError(error: unknown, operation: 'save' | 'remove') {
+    try {
+      const { code } = extractErrorData(error);
+      if (code === 'ADMIN_LOCKOUT') {
+        showError(t('ipAllowlist.lockoutError'));
+      } else {
+        showError(
+          t(
+            operation === 'save'
+              ? 'ipAllowlist.saveError'
+              : 'ipAllowlist.removeError',
+          ),
+        );
+      }
+    } catch {
+      showError(
+        t(
+          operation === 'save'
+            ? 'ipAllowlist.saveError'
+            : 'ipAllowlist.removeError',
+        ),
+      );
+    }
+  }
+
+  function handleRemoveConfirm() {
+    removeMutation.mutate(undefined, {
+      onSuccess: () => {
+        showSuccess(t('ipAllowlist.removeSuccess'));
+        setCidrsText(null);
+        setRemoveDialogOpen(false);
+        void queryClient.invalidateQueries({
+          queryKey: getIpAllowlistControllerGetQueryKey(),
+        });
+      },
+      onError: (error) => {
+        handleMutationError(error, 'remove');
+        setRemoveDialogOpen(false);
+      },
+    });
+  }
+
+  if (isLoading) {
+    return (
+      <SettingsLayout title={tLayout('layout.security')}>
+        <div className="flex items-center justify-center py-12">
+          <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+        </div>
+      </SettingsLayout>
+    );
+  }
+
+  if (isError) {
+    return (
+      <SettingsLayout title={tLayout('layout.security')}>
+        <Alert variant="destructive">
+          <AlertCircle className="h-4 w-4" />
+          <AlertDescription>
+            {t('ipAllowlist.loadError')}
+            <Button
+              variant="link"
+              className="ml-2 h-auto p-0"
+              onClick={() => void refetch()}
+            >
+              {t('ipAllowlist.retry')}
+            </Button>
+          </AlertDescription>
+        </Alert>
+      </SettingsLayout>
+    );
+  }
+
+  return (
+    <SettingsLayout title={tLayout('layout.security')}>
+      <div className="space-y-6">
+        <div>
+          <h3 className="text-lg font-medium">{t('ipAllowlist.heading')}</h3>
+          <p className="text-sm text-muted-foreground">
+            {t('ipAllowlist.description')}
+          </p>
+        </div>
+
+        {!hasExistingRestrictions && !isDirty && (
+          <Alert>
+            <Info className="h-4 w-4" />
+            <AlertDescription>
+              {t('ipAllowlist.noRestrictions')}
+            </AlertDescription>
+          </Alert>
+        )}
+
+        <div className="space-y-2">
+          <Label htmlFor="cidrs-textarea">{t('ipAllowlist.cidrsLabel')}</Label>
+          <Textarea
+            id="cidrs-textarea"
+            placeholder={t('ipAllowlist.cidrsPlaceholder')}
+            value={displayText}
+            onChange={(e) => {
+              setCidrsText(e.target.value);
+              setValidationError(null);
+            }}
+            rows={8}
+            className="font-mono text-sm"
+          />
+          {validationError && (
+            <div className="flex items-center gap-2 text-sm text-destructive">
+              <AlertCircle className="h-4 w-4 shrink-0" />
+              <span>{validationError}</span>
+            </div>
+          )}
+        </div>
+
+        <Alert variant="default">
+          <Info className="h-4 w-4" />
+          <AlertDescription>
+            {t('ipAllowlist.propagationNote')}
+          </AlertDescription>
+        </Alert>
+
+        <div className="flex gap-3">
+          <Button onClick={handleSave} disabled={isMutating}>
+            {updateMutation.isPending
+              ? t('ipAllowlist.saving')
+              : t('ipAllowlist.saveButton')}
+          </Button>
+
+          {hasExistingRestrictions && (
+            <Button
+              variant="destructive"
+              onClick={() => setRemoveDialogOpen(true)}
+              disabled={isMutating}
+            >
+              {removeMutation.isPending
+                ? t('ipAllowlist.removing')
+                : t('ipAllowlist.removeButton')}
+            </Button>
+          )}
+        </div>
+      </div>
+
+      <RemoveRestrictionsDialog
+        open={removeDialogOpen}
+        onOpenChange={setRemoveDialogOpen}
+        onConfirm={handleRemoveConfirm}
+        isRemoving={isMutating}
+      />
+    </SettingsLayout>
+  );
+}

--- a/ayunis-core-frontend/src/pages/auth/ip-blocked/index.ts
+++ b/ayunis-core-frontend/src/pages/auth/ip-blocked/index.ts
@@ -1,0 +1,1 @@
+export { IpBlockedPage } from './ui/IpBlockedPage';

--- a/ayunis-core-frontend/src/pages/auth/ip-blocked/ui/IpBlockedPage.tsx
+++ b/ayunis-core-frontend/src/pages/auth/ip-blocked/ui/IpBlockedPage.tsx
@@ -1,0 +1,25 @@
+import { useTranslation } from 'react-i18next';
+import { Link } from '@tanstack/react-router';
+import { ShieldAlert } from 'lucide-react';
+import { Button } from '@/shared/ui/shadcn/button';
+import OnboardingLayout from '@/layouts/onboarding-layout';
+
+export function IpBlockedPage() {
+  const { t } = useTranslation('auth');
+
+  return (
+    <OnboardingLayout
+      title={t('ipBlocked.title')}
+      description={t('ipBlocked.description')}
+    >
+      <div className="flex flex-col items-center space-y-6 text-center">
+        <div className="flex justify-center">
+          <ShieldAlert className="h-16 w-16 text-destructive" />
+        </div>
+        <Button asChild variant="outline">
+          <Link to="/login">{t('ipBlocked.backToLogin')}</Link>
+        </Button>
+      </div>
+    </OnboardingLayout>
+  );
+}

--- a/ayunis-core-frontend/src/pages/auth/login/api/useLogin.ts
+++ b/ayunis-core-frontend/src/pages/auth/login/api/useLogin.ts
@@ -43,10 +43,12 @@ export function useLogin({ redirect }: { redirect?: string }) {
           void navigate({ to: redirect || '/chat' });
         },
         onError: (error) => {
-          console.error('Login failed:', error);
           try {
             const { status, code } = extractErrorData(error);
-            if (status === 401 || status === 403) {
+            if (code === 'IP_NOT_ALLOWED') {
+              void navigate({ to: '/ip-blocked' });
+              return;
+            } else if (status === 401 || status === 403) {
               showError(t('login.error.invalidCredentials'));
             } else if (code === 'RATE_LIMIT_EXCEEDED') {
               showError(t('login.error.rateLimitExceeded'));

--- a/ayunis-core-frontend/src/shared/locales/de/admin-settings-layout.json
+++ b/ayunis-core-frontend/src/shared/locales/de/admin-settings-layout.json
@@ -8,6 +8,7 @@
     "teams": "Teams",
     "models": "Modelle",
     "integrations": "Integrationen",
-    "usage": "Nutzung"
+    "usage": "Nutzung",
+    "security": "Sicherheit"
   }
 }

--- a/ayunis-core-frontend/src/shared/locales/de/admin-settings-security.json
+++ b/ayunis-core-frontend/src/shared/locales/de/admin-settings-security.json
@@ -1,0 +1,26 @@
+{
+  "ipAllowlist": {
+    "heading": "IP-Zulassungsliste",
+    "description": "Beschränken Sie den Zugriff auf Ihre Organisation nach IP-Adresse. Nur Benutzer, die sich von den angegebenen CIDR-Bereichen aus verbinden, können die Anwendung nutzen. Lassen Sie das Feld leer, um alle IPs zuzulassen.",
+    "cidrsLabel": "Erlaubte CIDR-Bereiche",
+    "cidrsPlaceholder": "Geben Sie einen CIDR-Bereich pro Zeile ein, z.B.\n192.168.1.0/24\n10.0.0.0/8\n2001:db8::/32",
+    "saveButton": "Speichern",
+    "saving": "Speichern...",
+    "removeButton": "Alle Einschränkungen entfernen",
+    "removing": "Entfernen...",
+    "removeConfirmTitle": "IP-Einschränkungen entfernen",
+    "removeConfirmDescription": "Sind Sie sicher, dass Sie alle IP-Einschränkungen entfernen möchten? Alle Benutzer können dann von jeder IP-Adresse auf die Anwendung zugreifen.",
+    "removeConfirmCancel": "Abbrechen",
+    "removeConfirmConfirm": "Einschränkungen entfernen",
+    "saveSuccess": "IP-Zulassungsliste erfolgreich aktualisiert.",
+    "removeSuccess": "IP-Einschränkungen erfolgreich entfernt.",
+    "saveError": "Fehler beim Aktualisieren der IP-Zulassungsliste.",
+    "removeError": "Fehler beim Entfernen der IP-Einschränkungen.",
+    "lockoutError": "Diese Änderung würde Sie aussperren. Stellen Sie sicher, dass Ihre aktuelle IP-Adresse in den erlaubten Bereichen enthalten ist.",
+    "invalidCidr": "Ungültiger CIDR-Bereich in Zeile {{line}}: \"{{value}}\"",
+    "propagationNote": "Änderungen können bis zu 60 Sekunden dauern, bis sie auf allen Diensten wirksam werden.",
+    "noRestrictions": "Derzeit sind keine IP-Einschränkungen konfiguriert. Alle IP-Adressen sind erlaubt.",
+    "loadError": "Fehler beim Laden der IP-Zulassungslisten-Einstellungen.",
+    "retry": "Erneut versuchen"
+  }
+}

--- a/ayunis-core-frontend/src/shared/locales/de/auth.json
+++ b/ayunis-core-frontend/src/shared/locales/de/auth.json
@@ -193,6 +193,11 @@
       "requestNewLink": "Neuen Reset-Link anfordern"
     }
   },
+  "ipBlocked": {
+    "title": "Zugriff verweigert",
+    "description": "Ihre IP-Adresse ist nicht berechtigt, auf diese Anwendung zuzugreifen. Kontaktieren Sie den Administrator Ihrer Organisation, um die IP-Zulassungsliste zu aktualisieren.",
+    "backToLogin": "Zurück zur Anmeldung"
+  },
   "onboardingLayout": {
     "imprint": "Impressum",
     "privacy": "Datenschutz",

--- a/ayunis-core-frontend/src/shared/locales/en/admin-settings-layout.json
+++ b/ayunis-core-frontend/src/shared/locales/en/admin-settings-layout.json
@@ -8,6 +8,7 @@
     "teams": "Teams",
     "models": "Models",
     "integrations": "Integrations",
-    "usage": "Usage"
+    "usage": "Usage",
+    "security": "Security"
   }
 }

--- a/ayunis-core-frontend/src/shared/locales/en/admin-settings-security.json
+++ b/ayunis-core-frontend/src/shared/locales/en/admin-settings-security.json
@@ -1,0 +1,26 @@
+{
+  "ipAllowlist": {
+    "heading": "IP Allow List",
+    "description": "Restrict access to your organization by IP address. Only users connecting from the specified CIDR ranges will be able to use the application. Leave empty to allow all IPs.",
+    "cidrsLabel": "Allowed CIDR Ranges",
+    "cidrsPlaceholder": "Enter one CIDR range per line, e.g.\n192.168.1.0/24\n10.0.0.0/8\n2001:db8::/32",
+    "saveButton": "Save",
+    "saving": "Saving...",
+    "removeButton": "Remove All Restrictions",
+    "removing": "Removing...",
+    "removeConfirmTitle": "Remove IP Restrictions",
+    "removeConfirmDescription": "Are you sure you want to remove all IP restrictions? All users will be able to access the application from any IP address.",
+    "removeConfirmCancel": "Cancel",
+    "removeConfirmConfirm": "Remove Restrictions",
+    "saveSuccess": "IP allow list updated successfully.",
+    "removeSuccess": "IP restrictions removed successfully.",
+    "saveError": "Failed to update IP allow list.",
+    "removeError": "Failed to remove IP restrictions.",
+    "lockoutError": "This change would lock you out. Make sure your current IP address is included in the allowed ranges.",
+    "invalidCidr": "Invalid CIDR range on line {{line}}: \"{{value}}\"",
+    "propagationNote": "Changes may take up to 60 seconds to take effect across all services.",
+    "noRestrictions": "No IP restrictions are currently configured. All IP addresses are allowed.",
+    "loadError": "Failed to load IP allow list settings.",
+    "retry": "Retry"
+  }
+}

--- a/ayunis-core-frontend/src/shared/locales/en/auth.json
+++ b/ayunis-core-frontend/src/shared/locales/en/auth.json
@@ -192,6 +192,11 @@
       "requestNewLink": "Request New Reset Link"
     }
   },
+  "ipBlocked": {
+    "title": "Access Denied",
+    "description": "Your IP address is not allowed to access this application. Contact your organization administrator to update the IP allow list.",
+    "backToLogin": "Back to login"
+  },
   "onboardingLayout": {
     "imprint": "Imprint",
     "privacy": "Privacy Policy",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds new organization IP allowlist management UI and changes auth/login routing based on backend error codes, which can affect user access flows if miswired or misvalidated.
> 
> **Overview**
> Adds a new **Admin Settings → Security** page at `/admin-settings/security` for managing an organization IP allow list, including client-side CIDR/IP validation, save/remove actions (with a confirmation dialog), and localized copy.
> 
> Introduces an onboarding `/ip-blocked` route and updates both the authenticated `beforeLoad` guard and login error handling to redirect users to this page when the backend returns `IP_NOT_ALLOWED`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c98d377c92ca07fa781788230c0eaf67815a54d5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->