### PR TITLE
wip(AYC-101): add letterheads domain module and migration

### DIFF
--- a/ayunis-core-backend/src/db/migrations/1773697364898-CreateLetterheadsTable.ts
+++ b/ayunis-core-backend/src/db/migrations/1773697364898-CreateLetterheadsTable.ts
@@ -1,0 +1,39 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateLetterheadsTable1773697364898 implements MigrationInterface {
+  name = 'CreateLetterheadsTable1773697364898';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE "letterheads" (
+        "id" character varying NOT NULL,
+        "createdAt" TIMESTAMP NOT NULL DEFAULT now(),
+        "updatedAt" TIMESTAMP NOT NULL DEFAULT now(),
+        "orgId" character varying NOT NULL,
+        "name" character varying(255) NOT NULL,
+        "description" character varying(1000),
+        "firstPageStoragePath" character varying NOT NULL,
+        "continuationPageStoragePath" character varying,
+        "firstPageMargins" text NOT NULL,
+        "continuationPageMargins" text NOT NULL,
+        CONSTRAINT "PK_5c311a586c089dc4f93c852cdc1" PRIMARY KEY ("id")
+      )`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_ed5c8c0b59525d6ee217b5e271" ON "letterheads" ("orgId")`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "letterheads" ADD CONSTRAINT "FK_letterheads_orgId_orgs" FOREIGN KEY ("orgId") REFERENCES "orgs"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "letterheads" DROP CONSTRAINT "FK_letterheads_orgId_orgs"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_ed5c8c0b59525d6ee217b5e271"`,
+    );
+    await queryRunner.query(`DROP TABLE "letterheads"`);
+  }
+}

--- a/ayunis-core-backend/src/domain/artifacts/application/use-cases/update-artifact/update-artifact.command.ts
+++ b/ayunis-core-backend/src/domain/artifacts/application/use-cases/update-artifact/update-artifact.command.ts
@@ -6,16 +6,19 @@ export class UpdateArtifactCommand {
   readonly content: string;
   readonly authorType: AuthorType;
   readonly expectedVersionNumber?: number;
+  readonly letterheadId?: UUID | null;
 
   constructor(params: {
     artifactId: UUID;
     content: string;
     authorType: AuthorType;
     expectedVersionNumber?: number;
+    letterheadId?: UUID | null;
   }) {
     this.artifactId = params.artifactId;
     this.content = params.content;
     this.authorType = params.authorType;
     this.expectedVersionNumber = params.expectedVersionNumber;
+    this.letterheadId = params.letterheadId;
   }
 }

--- a/ayunis-core-backend/src/domain/letterheads/SUMMARY.md
+++ b/ayunis-core-backend/src/domain/letterheads/SUMMARY.md
@@ -1,0 +1,50 @@
+# Letterheads Module
+
+## Purpose
+
+Manages organization-scoped letterhead templates (PDF backgrounds) used for official document generation. Each letterhead defines a first-page PDF and optional continuation-page PDF, along with validated page margins for content placement.
+
+## Domain Concepts
+
+- **Letterhead** — A named letterhead template belonging to an organization. Stores storage paths for first-page and optional continuation-page PDFs, plus validated page margins for each.
+- **PageMargins** — Value object representing top/bottom/left/right margins in millimeters. Validated on construction to be non-negative finite numbers.
+
+## Architecture
+
+```text
+letterheads/
+├── domain/
+│   ├── letterhead.entity.ts
+│   ├── letterhead.errors.ts
+│   └── value-objects/
+│       └── page-margins.ts
+├── application/
+│   ├── letterheads.errors.ts
+│   ├── ports/
+│   │   └── letterheads-repository.port.ts
+│   └── use-cases/
+├── infrastructure/
+│   └── persistence/local/
+│       ├── schema/
+│       │   └── letterhead.record.ts
+│       ├── mappers/
+│       │   └── letterhead.mapper.ts
+│       ├── local-letterheads.repository.ts
+│       └── local-letterheads-repository.module.ts
+├── presenters/http/
+└── letterheads.module.ts
+```
+
+## Dependencies
+
+None — standalone module.
+
+## Ports
+
+- **LetterheadsRepository** — CRUD for letterhead entities (find by org, find by ID, save, delete)
+
+## Key Behaviors
+
+- Page margins are validated (non-negative, finite) when a `Letterhead` entity is constructed
+- Delete throws `LetterheadNotFoundError` if no matching record exists
+- Each letterhead is scoped to an organization via `orgId`

--- a/ayunis-core-backend/src/domain/letterheads/application/letterheads.errors.ts
+++ b/ayunis-core-backend/src/domain/letterheads/application/letterheads.errors.ts
@@ -1,0 +1,54 @@
+import type { ErrorMetadata } from '../../../common/errors/base.error';
+import { ApplicationError } from '../../../common/errors/base.error';
+
+export { InvalidPageMarginsError } from '../domain/letterhead.errors';
+
+export enum LetterheadErrorCode {
+  LETTERHEAD_NOT_FOUND = 'LETTERHEAD_NOT_FOUND',
+  LETTERHEAD_INVALID_PDF = 'LETTERHEAD_INVALID_PDF',
+  LETTERHEAD_ORG_MISMATCH = 'LETTERHEAD_ORG_MISMATCH',
+}
+
+export abstract class LetterheadError extends ApplicationError {
+  constructor(
+    message: string,
+    code: LetterheadErrorCode,
+    statusCode: number = 400,
+    metadata?: ErrorMetadata,
+  ) {
+    super(message, code, statusCode, metadata);
+  }
+}
+
+export class LetterheadNotFoundError extends LetterheadError {
+  constructor(letterheadId: string, metadata?: ErrorMetadata) {
+    super(
+      `Letterhead with ID '${letterheadId}' not found`,
+      LetterheadErrorCode.LETTERHEAD_NOT_FOUND,
+      404,
+      { letterheadId, ...metadata },
+    );
+  }
+}
+
+export class LetterheadInvalidPdfError extends LetterheadError {
+  constructor(reason: string, metadata?: ErrorMetadata) {
+    super(
+      `Invalid letterhead PDF: ${reason}`,
+      LetterheadErrorCode.LETTERHEAD_INVALID_PDF,
+      400,
+      metadata,
+    );
+  }
+}
+
+export class LetterheadOrgMismatchError extends LetterheadError {
+  constructor(letterheadId: string, metadata?: ErrorMetadata) {
+    super(
+      `Letterhead '${letterheadId}' does not belong to the current organization`,
+      LetterheadErrorCode.LETTERHEAD_ORG_MISMATCH,
+      403,
+      { letterheadId, ...metadata },
+    );
+  }
+}

--- a/ayunis-core-backend/src/domain/letterheads/application/ports/letterheads-repository.port.ts
+++ b/ayunis-core-backend/src/domain/letterheads/application/ports/letterheads-repository.port.ts
@@ -1,0 +1,9 @@
+import type { UUID } from 'crypto';
+import type { Letterhead } from '../../domain/letterhead.entity';
+
+export abstract class LetterheadsRepository {
+  abstract findAllByOrgId(orgId: UUID): Promise<Letterhead[]>;
+  abstract findById(orgId: UUID, id: UUID): Promise<Letterhead | null>;
+  abstract save(letterhead: Letterhead): Promise<Letterhead>;
+  abstract delete(orgId: UUID, id: UUID): Promise<void>;
+}

--- a/ayunis-core-backend/src/domain/letterheads/domain/letterhead.entity.ts
+++ b/ayunis-core-backend/src/domain/letterheads/domain/letterhead.entity.ts
@@ -1,0 +1,44 @@
+import type { UUID } from 'crypto';
+import { randomUUID } from 'crypto';
+import type { PageMargins } from './value-objects/page-margins';
+import { createPageMargins } from './value-objects/page-margins';
+
+export class Letterhead {
+  public readonly id: UUID;
+  public readonly orgId: UUID;
+  public readonly name: string;
+  public readonly description: string | null;
+  public readonly firstPageStoragePath: string;
+  public readonly continuationPageStoragePath: string | null;
+  public readonly firstPageMargins: PageMargins;
+  public readonly continuationPageMargins: PageMargins;
+  public readonly createdAt: Date;
+  public readonly updatedAt: Date;
+
+  constructor(params: {
+    id?: UUID;
+    orgId: UUID;
+    name: string;
+    description?: string | null;
+    firstPageStoragePath: string;
+    continuationPageStoragePath?: string | null;
+    firstPageMargins: PageMargins;
+    continuationPageMargins: PageMargins;
+    createdAt?: Date;
+    updatedAt?: Date;
+  }) {
+    this.id = params.id ?? randomUUID();
+    this.orgId = params.orgId;
+    this.name = params.name;
+    this.description = params.description ?? null;
+    this.firstPageStoragePath = params.firstPageStoragePath;
+    this.continuationPageStoragePath =
+      params.continuationPageStoragePath ?? null;
+    this.firstPageMargins = createPageMargins(params.firstPageMargins);
+    this.continuationPageMargins = createPageMargins(
+      params.continuationPageMargins,
+    );
+    this.createdAt = params.createdAt ?? new Date();
+    this.updatedAt = params.updatedAt ?? new Date();
+  }
+}

--- a/ayunis-core-backend/src/domain/letterheads/domain/letterhead.errors.ts
+++ b/ayunis-core-backend/src/domain/letterheads/domain/letterhead.errors.ts
@@ -1,0 +1,17 @@
+import type { ErrorMetadata } from '../../../common/errors/base.error';
+import { ApplicationError } from '../../../common/errors/base.error';
+
+export enum LetterheadDomainErrorCode {
+  LETTERHEAD_INVALID_PAGE_MARGINS = 'LETTERHEAD_INVALID_PAGE_MARGINS',
+}
+
+export class InvalidPageMarginsError extends ApplicationError {
+  constructor(field: string, value: number, metadata?: ErrorMetadata) {
+    super(
+      `Invalid page margin: '${field}' must be a non-negative finite number, got ${value}`,
+      LetterheadDomainErrorCode.LETTERHEAD_INVALID_PAGE_MARGINS,
+      400,
+      { field, value, ...metadata },
+    );
+  }
+}

--- a/ayunis-core-backend/src/domain/letterheads/domain/value-objects/page-margins.spec.ts
+++ b/ayunis-core-backend/src/domain/letterheads/domain/value-objects/page-margins.spec.ts
@@ -1,0 +1,68 @@
+import { createPageMargins } from './page-margins';
+import { InvalidPageMarginsError } from '../letterhead.errors';
+
+describe('createPageMargins', () => {
+  it('should create valid page margins with positive values', () => {
+    const margins = createPageMargins({
+      top: 55,
+      bottom: 20,
+      left: 15,
+      right: 15,
+    });
+
+    expect(margins).toEqual({ top: 55, bottom: 20, left: 15, right: 15 });
+  });
+
+  it('should accept zero margins', () => {
+    const margins = createPageMargins({
+      top: 0,
+      bottom: 0,
+      left: 0,
+      right: 0,
+    });
+
+    expect(margins).toEqual({ top: 0, bottom: 0, left: 0, right: 0 });
+  });
+
+  it('should reject negative top margin', () => {
+    expect(() =>
+      createPageMargins({ top: -1, bottom: 20, left: 15, right: 15 }),
+    ).toThrow(InvalidPageMarginsError);
+  });
+
+  it('should reject negative bottom margin', () => {
+    expect(() =>
+      createPageMargins({ top: 55, bottom: -5, left: 15, right: 15 }),
+    ).toThrow(InvalidPageMarginsError);
+  });
+
+  it('should reject negative left margin', () => {
+    expect(() =>
+      createPageMargins({ top: 55, bottom: 20, left: -10, right: 15 }),
+    ).toThrow(InvalidPageMarginsError);
+  });
+
+  it('should reject negative right margin', () => {
+    expect(() =>
+      createPageMargins({ top: 55, bottom: 20, left: 15, right: -3 }),
+    ).toThrow(InvalidPageMarginsError);
+  });
+
+  it('should reject Infinity', () => {
+    expect(() =>
+      createPageMargins({ top: Infinity, bottom: 20, left: 15, right: 15 }),
+    ).toThrow(InvalidPageMarginsError);
+  });
+
+  it('should reject NaN', () => {
+    expect(() =>
+      createPageMargins({ top: 55, bottom: NaN, left: 15, right: 15 }),
+    ).toThrow(InvalidPageMarginsError);
+  });
+
+  it('should include field name and value in error message', () => {
+    expect(() =>
+      createPageMargins({ top: -7, bottom: 20, left: 15, right: 15 }),
+    ).toThrow("'top' must be a non-negative finite number, got -7");
+  });
+});

--- a/ayunis-core-backend/src/domain/letterheads/domain/value-objects/page-margins.ts
+++ b/ayunis-core-backend/src/domain/letterheads/domain/value-objects/page-margins.ts
@@ -1,0 +1,41 @@
+import { InvalidPageMarginsError } from '../letterhead.errors';
+
+/**
+ * Margins for a page type (first page or continuation pages), in millimeters.
+ */
+export interface PageMargins {
+  /** Top margin in mm */
+  top: number;
+  /** Bottom margin in mm */
+  bottom: number;
+  /** Left margin in mm */
+  left: number;
+  /** Right margin in mm */
+  right: number;
+}
+
+const MARGIN_KEYS: ReadonlyArray<keyof PageMargins> = [
+  'top',
+  'bottom',
+  'left',
+  'right',
+];
+
+/**
+ * Creates a validated PageMargins object.
+ * All margins must be non-negative finite numbers.
+ */
+export function createPageMargins(input: PageMargins): PageMargins {
+  for (const key of MARGIN_KEYS) {
+    const value = input[key];
+    if (!Number.isFinite(value) || value < 0) {
+      throw new InvalidPageMarginsError(key, value);
+    }
+  }
+  return {
+    top: input.top,
+    bottom: input.bottom,
+    left: input.left,
+    right: input.right,
+  };
+}

--- a/ayunis-core-backend/src/domain/letterheads/infrastructure/persistence/local/local-letterheads-repository.module.ts
+++ b/ayunis-core-backend/src/domain/letterheads/infrastructure/persistence/local/local-letterheads-repository.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { LetterheadRecord } from './schema/letterhead.record';
+import { LocalLetterheadsRepository } from './local-letterheads.repository';
+import { LetterheadMapper } from './mappers/letterhead.mapper';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([LetterheadRecord])],
+  providers: [LocalLetterheadsRepository, LetterheadMapper],
+  exports: [LocalLetterheadsRepository],
+})
+export class LocalLetterheadsRepositoryModule {}

--- a/ayunis-core-backend/src/domain/letterheads/infrastructure/persistence/local/local-letterheads.repository.ts
+++ b/ayunis-core-backend/src/domain/letterheads/infrastructure/persistence/local/local-letterheads.repository.ts
@@ -1,0 +1,50 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import type { UUID } from 'crypto';
+
+import { LetterheadsRepository } from '../../../application/ports/letterheads-repository.port';
+import { LetterheadNotFoundError } from '../../../application/letterheads.errors';
+import { Letterhead } from '../../../domain/letterhead.entity';
+import { LetterheadRecord } from './schema/letterhead.record';
+import { LetterheadMapper } from './mappers/letterhead.mapper';
+
+@Injectable()
+export class LocalLetterheadsRepository extends LetterheadsRepository {
+  private readonly logger = new Logger(LocalLetterheadsRepository.name);
+
+  constructor(
+    @InjectRepository(LetterheadRecord)
+    private readonly repo: Repository<LetterheadRecord>,
+    private readonly mapper: LetterheadMapper,
+  ) {
+    super();
+  }
+
+  async findAllByOrgId(orgId: UUID): Promise<Letterhead[]> {
+    const records = await this.repo.find({
+      where: { orgId },
+      order: { createdAt: 'ASC' },
+    });
+    return records.map((r) => this.mapper.toDomain(r));
+  }
+
+  async findById(orgId: UUID, id: UUID): Promise<Letterhead | null> {
+    const record = await this.repo.findOne({ where: { orgId, id } });
+    return record ? this.mapper.toDomain(record) : null;
+  }
+
+  async save(letterhead: Letterhead): Promise<Letterhead> {
+    this.logger.log(`Saving letterhead ${letterhead.id}`);
+    const record = this.mapper.toRecord(letterhead);
+    const saved = await this.repo.save(record);
+    return this.mapper.toDomain(saved);
+  }
+
+  async delete(orgId: UUID, id: UUID): Promise<void> {
+    const result = await this.repo.delete({ orgId, id });
+    if (!result.affected) {
+      throw new LetterheadNotFoundError(id);
+    }
+  }
+}

--- a/ayunis-core-backend/src/domain/letterheads/infrastructure/persistence/local/mappers/letterhead.mapper.spec.ts
+++ b/ayunis-core-backend/src/domain/letterheads/infrastructure/persistence/local/mappers/letterhead.mapper.spec.ts
@@ -1,0 +1,179 @@
+import { randomUUID } from 'crypto';
+import { LetterheadMapper } from './letterhead.mapper';
+import { Letterhead } from '../../../../domain/letterhead.entity';
+import { LetterheadRecord } from '../schema/letterhead.record';
+import type { PageMargins } from '../../../../domain/value-objects/page-margins';
+
+describe('LetterheadMapper', () => {
+  let mapper: LetterheadMapper;
+
+  beforeEach(() => {
+    mapper = new LetterheadMapper();
+  });
+
+  const now = new Date('2026-02-27T14:00:00.000Z');
+  const letterheadId = randomUUID();
+  const orgId = randomUUID();
+
+  const firstPageMargins: PageMargins = {
+    top: 55,
+    bottom: 20,
+    left: 15,
+    right: 15,
+  };
+
+  const continuationPageMargins: PageMargins = {
+    top: 20,
+    bottom: 20,
+    left: 15,
+    right: 15,
+  };
+
+  describe('toDomain', () => {
+    it('should map a record with all fields to a domain entity', () => {
+      const record = new LetterheadRecord();
+      record.id = letterheadId;
+      record.orgId = orgId;
+      record.name = 'Stadtverwaltung Musterstadt';
+      record.description = 'Offizielles Briefpapier der Stadtverwaltung';
+      record.firstPageStoragePath = `letterheads/${orgId}/${letterheadId}/first-page.pdf`;
+      record.continuationPageStoragePath = `letterheads/${orgId}/${letterheadId}/continuation.pdf`;
+      record.firstPageMargins = firstPageMargins;
+      record.continuationPageMargins = continuationPageMargins;
+      record.createdAt = now;
+      record.updatedAt = now;
+
+      const domain = mapper.toDomain(record);
+
+      expect(domain).toBeInstanceOf(Letterhead);
+      expect(domain.id).toBe(letterheadId);
+      expect(domain.orgId).toBe(orgId);
+      expect(domain.name).toBe('Stadtverwaltung Musterstadt');
+      expect(domain.description).toBe(
+        'Offizielles Briefpapier der Stadtverwaltung',
+      );
+      expect(domain.firstPageStoragePath).toBe(
+        `letterheads/${orgId}/${letterheadId}/first-page.pdf`,
+      );
+      expect(domain.continuationPageStoragePath).toBe(
+        `letterheads/${orgId}/${letterheadId}/continuation.pdf`,
+      );
+      expect(domain.firstPageMargins).toEqual(firstPageMargins);
+      expect(domain.continuationPageMargins).toEqual(continuationPageMargins);
+      expect(domain.createdAt).toBe(now);
+      expect(domain.updatedAt).toBe(now);
+    });
+
+    it('should map a record with nullable fields set to null', () => {
+      const record = new LetterheadRecord();
+      record.id = letterheadId;
+      record.orgId = orgId;
+      record.name = 'Einfaches Briefpapier';
+      record.description = null;
+      record.firstPageStoragePath = `letterheads/${orgId}/${letterheadId}/first-page.pdf`;
+      record.continuationPageStoragePath = null;
+      record.firstPageMargins = firstPageMargins;
+      record.continuationPageMargins = continuationPageMargins;
+      record.createdAt = now;
+      record.updatedAt = now;
+
+      const domain = mapper.toDomain(record);
+
+      expect(domain.description).toBeNull();
+      expect(domain.continuationPageStoragePath).toBeNull();
+    });
+  });
+
+  describe('toRecord', () => {
+    it('should map a domain entity to a record', () => {
+      const domain = new Letterhead({
+        id: letterheadId,
+        orgId,
+        name: 'Stadtverwaltung Musterstadt',
+        description: 'Offizielles Briefpapier der Stadtverwaltung',
+        firstPageStoragePath: `letterheads/${orgId}/${letterheadId}/first-page.pdf`,
+        continuationPageStoragePath: `letterheads/${orgId}/${letterheadId}/continuation.pdf`,
+        firstPageMargins,
+        continuationPageMargins,
+        createdAt: now,
+        updatedAt: now,
+      });
+
+      const record = mapper.toRecord(domain);
+
+      expect(record).toBeInstanceOf(LetterheadRecord);
+      expect(record.id).toBe(letterheadId);
+      expect(record.orgId).toBe(orgId);
+      expect(record.name).toBe('Stadtverwaltung Musterstadt');
+      expect(record.description).toBe(
+        'Offizielles Briefpapier der Stadtverwaltung',
+      );
+      expect(record.firstPageStoragePath).toBe(
+        `letterheads/${orgId}/${letterheadId}/first-page.pdf`,
+      );
+      expect(record.continuationPageStoragePath).toBe(
+        `letterheads/${orgId}/${letterheadId}/continuation.pdf`,
+      );
+      expect(record.firstPageMargins).toEqual(firstPageMargins);
+      expect(record.continuationPageMargins).toEqual(continuationPageMargins);
+      expect(record.createdAt).toBe(now);
+      expect(record.updatedAt).toBe(now);
+    });
+  });
+
+  describe('round-trip', () => {
+    it('should preserve all fields through domain → record → domain', () => {
+      const original = new Letterhead({
+        id: letterheadId,
+        orgId,
+        name: 'Gemeinde Beispieldorf',
+        description: 'Briefpapier für amtliche Schreiben',
+        firstPageStoragePath: `letterheads/${orgId}/${letterheadId}/first-page.pdf`,
+        continuationPageStoragePath: `letterheads/${orgId}/${letterheadId}/continuation.pdf`,
+        firstPageMargins,
+        continuationPageMargins,
+        createdAt: now,
+        updatedAt: now,
+      });
+
+      const record = mapper.toRecord(original);
+      const reconstructed = mapper.toDomain(record);
+
+      expect(reconstructed.id).toBe(original.id);
+      expect(reconstructed.orgId).toBe(original.orgId);
+      expect(reconstructed.name).toBe(original.name);
+      expect(reconstructed.description).toBe(original.description);
+      expect(reconstructed.firstPageStoragePath).toBe(
+        original.firstPageStoragePath,
+      );
+      expect(reconstructed.continuationPageStoragePath).toBe(
+        original.continuationPageStoragePath,
+      );
+      expect(reconstructed.firstPageMargins).toEqual(original.firstPageMargins);
+      expect(reconstructed.continuationPageMargins).toEqual(
+        original.continuationPageMargins,
+      );
+      expect(reconstructed.createdAt).toBe(original.createdAt);
+      expect(reconstructed.updatedAt).toBe(original.updatedAt);
+    });
+
+    it('should preserve null fields through round-trip', () => {
+      const original = new Letterhead({
+        id: letterheadId,
+        orgId,
+        name: 'Minimales Briefpapier',
+        firstPageStoragePath: `letterheads/${orgId}/${letterheadId}/first-page.pdf`,
+        firstPageMargins,
+        continuationPageMargins,
+        createdAt: now,
+        updatedAt: now,
+      });
+
+      const record = mapper.toRecord(original);
+      const reconstructed = mapper.toDomain(record);
+
+      expect(reconstructed.description).toBeNull();
+      expect(reconstructed.continuationPageStoragePath).toBeNull();
+    });
+  });
+});

--- a/ayunis-core-backend/src/domain/letterheads/infrastructure/persistence/local/mappers/letterhead.mapper.ts
+++ b/ayunis-core-backend/src/domain/letterheads/infrastructure/persistence/local/mappers/letterhead.mapper.ts
@@ -1,0 +1,36 @@
+import { Injectable } from '@nestjs/common';
+import { Letterhead } from '../../../../domain/letterhead.entity';
+import { LetterheadRecord } from '../schema/letterhead.record';
+
+@Injectable()
+export class LetterheadMapper {
+  toDomain(record: LetterheadRecord): Letterhead {
+    return new Letterhead({
+      id: record.id,
+      orgId: record.orgId,
+      name: record.name,
+      description: record.description,
+      firstPageStoragePath: record.firstPageStoragePath,
+      continuationPageStoragePath: record.continuationPageStoragePath,
+      firstPageMargins: record.firstPageMargins,
+      continuationPageMargins: record.continuationPageMargins,
+      createdAt: record.createdAt,
+      updatedAt: record.updatedAt,
+    });
+  }
+
+  toRecord(domain: Letterhead): LetterheadRecord {
+    const record = new LetterheadRecord();
+    record.id = domain.id;
+    record.orgId = domain.orgId;
+    record.name = domain.name;
+    record.description = domain.description;
+    record.firstPageStoragePath = domain.firstPageStoragePath;
+    record.continuationPageStoragePath = domain.continuationPageStoragePath;
+    record.firstPageMargins = domain.firstPageMargins;
+    record.continuationPageMargins = domain.continuationPageMargins;
+    record.createdAt = domain.createdAt;
+    record.updatedAt = domain.updatedAt;
+    return record;
+  }
+}

--- a/ayunis-core-backend/src/domain/letterheads/infrastructure/persistence/local/schema/letterhead.record.ts
+++ b/ayunis-core-backend/src/domain/letterheads/infrastructure/persistence/local/schema/letterhead.record.ts
@@ -1,0 +1,29 @@
+import { Column, Entity, Index } from 'typeorm';
+import type { UUID } from 'crypto';
+import { BaseRecord } from '../../../../../../common/db/base-record';
+import type { PageMargins } from '../../../../domain/value-objects/page-margins';
+
+@Entity({ name: 'letterheads' })
+export class LetterheadRecord extends BaseRecord {
+  @Column()
+  @Index()
+  orgId: UUID;
+
+  @Column({ type: 'varchar', length: 255 })
+  name: string;
+
+  @Column({ type: 'varchar', length: 1000, nullable: true })
+  description: string | null;
+
+  @Column({ type: 'varchar' })
+  firstPageStoragePath: string;
+
+  @Column({ type: 'varchar', nullable: true })
+  continuationPageStoragePath: string | null;
+
+  @Column({ type: 'simple-json' })
+  firstPageMargins: PageMargins;
+
+  @Column({ type: 'simple-json' })
+  continuationPageMargins: PageMargins;
+}

--- a/ayunis-core-backend/src/domain/letterheads/letterheads.module.ts
+++ b/ayunis-core-backend/src/domain/letterheads/letterheads.module.ts
@@ -1,0 +1,16 @@
+import { Module } from '@nestjs/common';
+import { LetterheadsRepository } from './application/ports/letterheads-repository.port';
+import { LocalLetterheadsRepositoryModule } from './infrastructure/persistence/local/local-letterheads-repository.module';
+import { LocalLetterheadsRepository } from './infrastructure/persistence/local/local-letterheads.repository';
+
+@Module({
+  imports: [LocalLetterheadsRepositoryModule],
+  providers: [
+    {
+      provide: LetterheadsRepository,
+      useExisting: LocalLetterheadsRepository,
+    },
+  ],
+  exports: [LetterheadsRepository],
+})
+export class LetterheadsModule {}

--- a/ayunis-core-frontend/src/shared/constants/department.ts
+++ b/ayunis-core-frontend/src/shared/constants/department.ts
@@ -1,6 +1,6 @@
 /**
- * Selectable department keys — mirrors the backend `department.constants.ts`.
- * Do NOT duplicate freely — the backend is the single source of truth.
+ * Selectable department keys — the frontend is the single source of truth.
+ * The backend accepts any string; this list drives UI dropdowns only.
  */
 export const DEPARTMENT_KEYS = [
   'hauptamt',


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces a new database table/migration and a new persistence-backed module, which can impact runtime behavior and deployments if the schema or JSON margin storage is mis-specified. Other changes are additive and mostly isolated, with only a small contract extension to `UpdateArtifactCommand`.
> 
> **Overview**
> Adds a new backend `letterheads` domain module including `Letterhead` entity with validated `PageMargins`, application error types, a repository port, and a local TypeORM-backed repository with mapping/tests.
> 
> Introduces a TypeORM migration creating the `letterheads` table (org-scoped, PDF storage paths, and JSON margins) with index/foreign key, and extends `UpdateArtifactCommand` to optionally carry a `letterheadId` for future integration. Updates frontend department constants documentation to reflect the frontend as the source of truth.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 118b299dc4fc1e83488416b446742fb39f09f7c6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->