### PR TITLE
wip(AYC-101): add letterhead CRUD use cases, HTTP controller, and app module wiring

### DIFF
--- a/ayunis-core-backend/package-lock.json
+++ b/ayunis-core-backend/package-lock.json
@@ -55,6 +55,7 @@
         "passport": "^0.7.0",
         "passport-jwt": "^4.0.1",
         "passport-local": "^1.0.0",
+        "pdf-lib": "^1.17.1",
         "pdf-parse": "^1.1.1",
         "pg": "^8.18.0",
         "prom-client": "^15.1.3",
@@ -6179,6 +6180,24 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@pdf-lib/standard-fonts": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@pdf-lib/standard-fonts/-/standard-fonts-1.0.0.tgz",
+      "integrity": "sha512-hU30BK9IUN/su0Mn9VdlVKsWBS6GyhVfqjwl1FjZN4TxP6cCw0jP2w7V3Hf5uX7M0AZJ16vey9yE0ny7Sa59ZA==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^1.0.6"
+      }
+    },
+    "node_modules/@pdf-lib/upng": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@pdf-lib/upng/-/upng-1.0.1.tgz",
+      "integrity": "sha512-dQK2FUMQtowVP00mtIksrlZhdFXQZPC+taih1q4CvPZ5vqdxR/LKBaFg0oAfzd1GlHZXXSPdQfzQnt+ViGvEIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^1.0.10"
+      }
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
@@ -20316,6 +20335,24 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz",
       "integrity": "sha512-KG8UEiEVkR3wGEb4m5yZkVCzigAD+cVEJck2CzYZO37ZGJfctvVptVO192MwrtPhzONn6go8ylnOdMhKqi4nfg=="
+    },
+    "node_modules/pdf-lib": {
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/pdf-lib/-/pdf-lib-1.17.1.tgz",
+      "integrity": "sha512-V/mpyJAoTsN4cnP31vc0wfNA1+p20evqqnap0KLoRUN0Yk/p3wN52DOEsL4oBFcLdb76hlpKPtzJIgo67j/XLw==",
+      "license": "MIT",
+      "dependencies": {
+        "@pdf-lib/standard-fonts": "^1.0.0",
+        "@pdf-lib/upng": "^1.0.1",
+        "pako": "^1.0.11",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/pdf-lib/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
     },
     "node_modules/pdf-parse": {
       "version": "1.1.4",

--- a/ayunis-core-backend/package.json
+++ b/ayunis-core-backend/package.json
@@ -90,6 +90,7 @@
     "passport": "^0.7.0",
     "passport-jwt": "^4.0.1",
     "passport-local": "^1.0.0",
+    "pdf-lib": "^1.17.1",
     "pdf-parse": "^1.1.1",
     "pg": "^8.18.0",
     "prom-client": "^15.1.3",

--- a/ayunis-core-backend/src/app/app.module.ts
+++ b/ayunis-core-backend/src/app/app.module.ts
@@ -27,6 +27,7 @@ import { ChatSettingsModule } from '../domain/chat-settings/chat-settings.module
 import { KnowledgeBasesModule } from '../domain/knowledge-bases/knowledge-bases.module';
 import { SkillTemplatesModule } from '../domain/skill-templates/skill-templates.module';
 import { ArtifactsModule } from '../domain/artifacts/artifacts.module';
+import { LetterheadsModule } from '../domain/letterheads/letterheads.module';
 import { IamModule } from '../iam/iam.module';
 
 import { modelsConfig } from '../config/models.config';
@@ -145,6 +146,7 @@ import { MetricsModule } from '../metrics/metrics.module';
     KnowledgeBasesModule,
     SkillTemplatesModule,
     ArtifactsModule,
+    LetterheadsModule,
     IamModule.register({
       authProvider:
         // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- env var may be undefined at runtime despite type cast

--- a/ayunis-core-backend/src/domain/letterheads/SUMMARY.md
+++ b/ayunis-core-backend/src/domain/letterheads/SUMMARY.md
@@ -22,7 +22,14 @@ letterheads/
 │   ├── letterheads.errors.ts
 │   ├── ports/
 │   │   └── letterheads-repository.port.ts
+│   ├── services/
+│   │   └── letterhead-pdf.service.ts   # Shared PDF validation & storage path builder
 │   └── use-cases/
+│       ├── create-letterhead/
+│       ├── delete-letterhead/
+│       ├── find-all-letterheads/
+│       ├── find-letterhead/
+│       └── update-letterhead/
 ├── infrastructure/
 │   └── persistence/local/
 │       ├── schema/
@@ -32,12 +39,20 @@ letterheads/
 │       ├── local-letterheads.repository.ts
 │       └── local-letterheads-repository.module.ts
 ├── presenters/http/
+│   ├── letterheads.controller.ts
+│   ├── dtos/
+│   │   ├── create-letterhead.dto.ts
+│   │   ├── update-letterhead.dto.ts
+│   │   ├── letterhead-response.dto.ts
+│   │   └── page-margins.dto.ts
+│   └── mappers/
+│       └── letterhead-dto.mapper.ts
 └── letterheads.module.ts
 ```
 
 ## Dependencies
 
-None — standalone module.
+- **StorageModule** — File storage for letterhead PDF uploads
 
 ## Ports
 

--- a/ayunis-core-backend/src/domain/letterheads/application/letterheads.errors.ts
+++ b/ayunis-core-backend/src/domain/letterheads/application/letterheads.errors.ts
@@ -7,6 +7,7 @@ export enum LetterheadErrorCode {
   LETTERHEAD_NOT_FOUND = 'LETTERHEAD_NOT_FOUND',
   LETTERHEAD_INVALID_PDF = 'LETTERHEAD_INVALID_PDF',
   LETTERHEAD_ORG_MISMATCH = 'LETTERHEAD_ORG_MISMATCH',
+  UNEXPECTED_LETTERHEAD_ERROR = 'UNEXPECTED_LETTERHEAD_ERROR',
 }
 
 export abstract class LetterheadError extends ApplicationError {
@@ -49,6 +50,17 @@ export class LetterheadOrgMismatchError extends LetterheadError {
       LetterheadErrorCode.LETTERHEAD_ORG_MISMATCH,
       403,
       { letterheadId, ...metadata },
+    );
+  }
+}
+
+export class UnexpectedLetterheadError extends LetterheadError {
+  constructor(message: string, metadata?: ErrorMetadata) {
+    super(
+      message,
+      LetterheadErrorCode.UNEXPECTED_LETTERHEAD_ERROR,
+      500,
+      metadata,
     );
   }
 }

--- a/ayunis-core-backend/src/domain/letterheads/application/services/letterhead-pdf.service.spec.ts
+++ b/ayunis-core-backend/src/domain/letterheads/application/services/letterhead-pdf.service.spec.ts
@@ -1,0 +1,66 @@
+import type { UUID } from 'crypto';
+import { PDFDocument } from 'pdf-lib';
+import { LetterheadPdfService } from './letterhead-pdf.service';
+import { LetterheadInvalidPdfError } from '../letterheads.errors';
+
+async function createSinglePagePdf(): Promise<Buffer> {
+  const doc = await PDFDocument.create();
+  doc.addPage();
+  const bytes = await doc.save();
+  return Buffer.from(bytes);
+}
+
+async function createMultiPagePdf(pages: number): Promise<Buffer> {
+  const doc = await PDFDocument.create();
+  for (let i = 0; i < pages; i++) {
+    doc.addPage();
+  }
+  const bytes = await doc.save();
+  return Buffer.from(bytes);
+}
+
+describe('LetterheadPdfService', () => {
+  let service: LetterheadPdfService;
+
+  beforeEach(() => {
+    service = new LetterheadPdfService();
+  });
+
+  describe('validateSinglePagePdf', () => {
+    it('should accept a valid single-page PDF', async () => {
+      const pdf = await createSinglePagePdf();
+      await expect(
+        service.validateSinglePagePdf(pdf, 'first page'),
+      ).resolves.toBeUndefined();
+    });
+
+    it('should reject a multi-page PDF', async () => {
+      const pdf = await createMultiPagePdf(3);
+      await expect(
+        service.validateSinglePagePdf(pdf, 'first page'),
+      ).rejects.toThrow(LetterheadInvalidPdfError);
+    });
+
+    it('should reject an invalid buffer', async () => {
+      const buffer = Buffer.from('not a pdf');
+      await expect(
+        service.validateSinglePagePdf(buffer, 'first page'),
+      ).rejects.toThrow(LetterheadInvalidPdfError);
+    });
+  });
+
+  describe('buildStoragePath', () => {
+    it('should build a correct org-scoped storage path', () => {
+      const orgId = '123e4567-e89b-12d3-a456-426614174000' as UUID;
+      const letterheadId = '223e4567-e89b-12d3-a456-426614174000' as UUID;
+
+      const path = service.buildStoragePath(
+        orgId,
+        letterheadId,
+        'first-page.pdf',
+      );
+
+      expect(path).toBe(`letterheads/${orgId}/${letterheadId}/first-page.pdf`);
+    });
+  });
+});

--- a/ayunis-core-backend/src/domain/letterheads/application/services/letterhead-pdf.service.ts
+++ b/ayunis-core-backend/src/domain/letterheads/application/services/letterhead-pdf.service.ts
@@ -1,0 +1,28 @@
+import { Injectable } from '@nestjs/common';
+import type { UUID } from 'crypto';
+import { PDFDocument } from 'pdf-lib';
+import { LetterheadInvalidPdfError } from '../letterheads.errors';
+
+@Injectable()
+export class LetterheadPdfService {
+  async validateSinglePagePdf(buffer: Buffer, label: string): Promise<void> {
+    try {
+      const pdfDoc = await PDFDocument.load(buffer);
+      const pageCount = pdfDoc.getPageCount();
+      if (pageCount !== 1) {
+        throw new LetterheadInvalidPdfError(
+          `${label} PDF must be exactly 1 page, got ${pageCount}`,
+        );
+      }
+    } catch (error) {
+      if (error instanceof LetterheadInvalidPdfError) {
+        throw error;
+      }
+      throw new LetterheadInvalidPdfError(`${label} is not a valid PDF file`);
+    }
+  }
+
+  buildStoragePath(orgId: UUID, letterheadId: UUID, fileName: string): string {
+    return `letterheads/${orgId}/${letterheadId}/${fileName}`;
+  }
+}

--- a/ayunis-core-backend/src/domain/letterheads/application/use-cases/create-letterhead/create-letterhead.command.ts
+++ b/ayunis-core-backend/src/domain/letterheads/application/use-cases/create-letterhead/create-letterhead.command.ts
@@ -1,0 +1,26 @@
+import type { PageMargins } from '../../../domain/value-objects/page-margins';
+
+export class CreateLetterheadCommand {
+  readonly name: string;
+  readonly description: string | null;
+  readonly firstPagePdfBuffer: Buffer;
+  readonly continuationPagePdfBuffer: Buffer | null;
+  readonly firstPageMargins: PageMargins;
+  readonly continuationPageMargins: PageMargins;
+
+  constructor(params: {
+    name: string;
+    description?: string | null;
+    firstPagePdfBuffer: Buffer;
+    continuationPagePdfBuffer?: Buffer | null;
+    firstPageMargins: PageMargins;
+    continuationPageMargins: PageMargins;
+  }) {
+    this.name = params.name;
+    this.description = params.description ?? null;
+    this.firstPagePdfBuffer = params.firstPagePdfBuffer;
+    this.continuationPagePdfBuffer = params.continuationPagePdfBuffer ?? null;
+    this.firstPageMargins = params.firstPageMargins;
+    this.continuationPageMargins = params.continuationPageMargins;
+  }
+}

--- a/ayunis-core-backend/src/domain/letterheads/application/use-cases/create-letterhead/create-letterhead.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/letterheads/application/use-cases/create-letterhead/create-letterhead.use-case.spec.ts
@@ -1,0 +1,251 @@
+import type { TestingModule } from '@nestjs/testing';
+import { Test } from '@nestjs/testing';
+import { Logger } from '@nestjs/common';
+import type { UUID } from 'crypto';
+import { PDFDocument } from 'pdf-lib';
+import { CreateLetterheadUseCase } from './create-letterhead.use-case';
+import { CreateLetterheadCommand } from './create-letterhead.command';
+import { LetterheadsRepository } from '../../ports/letterheads-repository.port';
+import { LetterheadPdfService } from '../../services/letterhead-pdf.service';
+import { ContextService } from 'src/common/context/services/context.service';
+import { UploadObjectUseCase } from 'src/domain/storage/application/use-cases/upload-object/upload-object.use-case';
+import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
+import { LetterheadInvalidPdfError } from '../../letterheads.errors';
+
+async function createSinglePagePdf(): Promise<Buffer> {
+  const doc = await PDFDocument.create();
+  doc.addPage();
+  const bytes = await doc.save();
+  return Buffer.from(bytes);
+}
+
+async function createMultiPagePdf(pages: number): Promise<Buffer> {
+  const doc = await PDFDocument.create();
+  for (let i = 0; i < pages; i++) {
+    doc.addPage();
+  }
+  const bytes = await doc.save();
+  return Buffer.from(bytes);
+}
+
+describe('CreateLetterheadUseCase', () => {
+  let useCase: CreateLetterheadUseCase;
+  let letterheadsRepository: jest.Mocked<LetterheadsRepository>;
+  let uploadObjectUseCase: jest.Mocked<UploadObjectUseCase>;
+
+  const mockOrgId = '123e4567-e89b-12d3-a456-426614174000' as UUID;
+
+  beforeEach(async () => {
+    const mockRepository = {
+      findAllByOrgId: jest.fn(),
+      findById: jest.fn(),
+      save: jest.fn(),
+      delete: jest.fn(),
+    };
+
+    const mockContextService = {
+      get: jest.fn((key: string) => {
+        if (key === 'orgId') return mockOrgId;
+        return undefined;
+      }),
+    } as unknown as jest.Mocked<ContextService>;
+
+    const mockUploadObjectUseCase = {
+      execute: jest.fn().mockResolvedValue({
+        objectName: 'test',
+        size: 1024,
+        etag: 'abc',
+      }),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        CreateLetterheadUseCase,
+        LetterheadPdfService,
+        { provide: LetterheadsRepository, useValue: mockRepository },
+        { provide: ContextService, useValue: mockContextService },
+        { provide: UploadObjectUseCase, useValue: mockUploadObjectUseCase },
+      ],
+    }).compile();
+
+    useCase = module.get(CreateLetterheadUseCase);
+    letterheadsRepository = module.get(LetterheadsRepository);
+    uploadObjectUseCase = module.get(UploadObjectUseCase);
+
+    letterheadsRepository.save.mockImplementation(async (l) => l);
+
+    jest.spyOn(Logger.prototype, 'log').mockImplementation();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should create a letterhead with first-page PDF only', async () => {
+    const pdfBuffer = await createSinglePagePdf();
+
+    const command = new CreateLetterheadCommand({
+      name: 'Stadtverwaltung Musterstadt',
+      description: 'Offizielles Briefpapier der Stadt',
+      firstPagePdfBuffer: pdfBuffer,
+      firstPageMargins: { top: 55, bottom: 20, left: 25, right: 15 },
+      continuationPageMargins: { top: 20, bottom: 20, left: 25, right: 15 },
+    });
+
+    const result = await useCase.execute(command);
+
+    expect(result.name).toBe('Stadtverwaltung Musterstadt');
+    expect(result.description).toBe('Offizielles Briefpapier der Stadt');
+    expect(result.orgId).toBe(mockOrgId);
+    expect(result.firstPageStoragePath).toContain('letterheads/');
+    expect(result.firstPageStoragePath).toContain('first-page.pdf');
+    expect(result.continuationPageStoragePath).toBeNull();
+    expect(uploadObjectUseCase.execute).toHaveBeenCalledTimes(1);
+  });
+
+  it('should create a letterhead with both first-page and continuation PDFs', async () => {
+    const firstPagePdf = await createSinglePagePdf();
+    const continuationPdf = await createSinglePagePdf();
+
+    const command = new CreateLetterheadCommand({
+      name: 'Amt für Finanzen',
+      firstPagePdfBuffer: firstPagePdf,
+      continuationPagePdfBuffer: continuationPdf,
+      firstPageMargins: { top: 60, bottom: 25, left: 20, right: 20 },
+      continuationPageMargins: { top: 15, bottom: 25, left: 20, right: 20 },
+    });
+
+    const result = await useCase.execute(command);
+
+    expect(result.continuationPageStoragePath).toContain('continuation.pdf');
+    expect(uploadObjectUseCase.execute).toHaveBeenCalledTimes(2);
+  });
+
+  it('should reject a multi-page first-page PDF', async () => {
+    const multiPagePdf = await createMultiPagePdf(3);
+
+    const command = new CreateLetterheadCommand({
+      name: 'Invalid Letterhead',
+      firstPagePdfBuffer: multiPagePdf,
+      firstPageMargins: { top: 20, bottom: 20, left: 20, right: 20 },
+      continuationPageMargins: { top: 20, bottom: 20, left: 20, right: 20 },
+    });
+
+    await expect(useCase.execute(command)).rejects.toThrow(
+      LetterheadInvalidPdfError,
+    );
+    expect(letterheadsRepository.save).not.toHaveBeenCalled();
+  });
+
+  it('should reject a multi-page continuation PDF', async () => {
+    const firstPagePdf = await createSinglePagePdf();
+    const multiPageContinuation = await createMultiPagePdf(2);
+
+    const command = new CreateLetterheadCommand({
+      name: 'Invalid Continuation',
+      firstPagePdfBuffer: firstPagePdf,
+      continuationPagePdfBuffer: multiPageContinuation,
+      firstPageMargins: { top: 20, bottom: 20, left: 20, right: 20 },
+      continuationPageMargins: { top: 20, bottom: 20, left: 20, right: 20 },
+    });
+
+    await expect(useCase.execute(command)).rejects.toThrow(
+      LetterheadInvalidPdfError,
+    );
+    expect(letterheadsRepository.save).not.toHaveBeenCalled();
+  });
+
+  it('should reject an invalid PDF buffer', async () => {
+    const invalidBuffer = Buffer.from('not a pdf');
+
+    const command = new CreateLetterheadCommand({
+      name: 'Corrupted File',
+      firstPagePdfBuffer: invalidBuffer,
+      firstPageMargins: { top: 20, bottom: 20, left: 20, right: 20 },
+      continuationPageMargins: { top: 20, bottom: 20, left: 20, right: 20 },
+    });
+
+    await expect(useCase.execute(command)).rejects.toThrow(
+      LetterheadInvalidPdfError,
+    );
+  });
+
+  it('should throw UnauthorizedAccessError when orgId is missing', async () => {
+    const mockContextService = {
+      get: jest.fn(() => undefined),
+    } as unknown as jest.Mocked<ContextService>;
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        CreateLetterheadUseCase,
+        LetterheadPdfService,
+        { provide: LetterheadsRepository, useValue: letterheadsRepository },
+        { provide: ContextService, useValue: mockContextService },
+        { provide: UploadObjectUseCase, useValue: uploadObjectUseCase },
+      ],
+    }).compile();
+
+    const useCaseNoOrg = module.get(CreateLetterheadUseCase);
+    const pdfBuffer = await createSinglePagePdf();
+
+    const command = new CreateLetterheadCommand({
+      name: 'No Org',
+      firstPagePdfBuffer: pdfBuffer,
+      firstPageMargins: { top: 20, bottom: 20, left: 20, right: 20 },
+      continuationPageMargins: { top: 20, bottom: 20, left: 20, right: 20 },
+    });
+
+    await expect(useCaseNoOrg.execute(command)).rejects.toThrow(
+      UnauthorizedAccessError,
+    );
+  });
+
+  it('should set description to null when not provided', async () => {
+    const pdfBuffer = await createSinglePagePdf();
+
+    const command = new CreateLetterheadCommand({
+      name: 'Minimal Letterhead',
+      firstPagePdfBuffer: pdfBuffer,
+      firstPageMargins: { top: 20, bottom: 20, left: 20, right: 20 },
+      continuationPageMargins: { top: 20, bottom: 20, left: 20, right: 20 },
+    });
+
+    const result = await useCase.execute(command);
+
+    expect(result.description).toBeNull();
+  });
+
+  it('should store files under the correct org-scoped path', async () => {
+    const pdfBuffer = await createSinglePagePdf();
+
+    const command = new CreateLetterheadCommand({
+      name: 'Path Test',
+      firstPagePdfBuffer: pdfBuffer,
+      firstPageMargins: { top: 20, bottom: 20, left: 20, right: 20 },
+      continuationPageMargins: { top: 20, bottom: 20, left: 20, right: 20 },
+    });
+
+    const result = await useCase.execute(command);
+
+    expect(result.firstPageStoragePath).toMatch(
+      new RegExp(`^letterheads/${mockOrgId}/[\\w-]+/first-page\\.pdf$`),
+    );
+  });
+
+  it('should construct the entity only once with valid storage paths', async () => {
+    const pdfBuffer = await createSinglePagePdf();
+
+    const command = new CreateLetterheadCommand({
+      name: 'Single Construction',
+      firstPagePdfBuffer: pdfBuffer,
+      firstPageMargins: { top: 20, bottom: 20, left: 20, right: 20 },
+      continuationPageMargins: { top: 20, bottom: 20, left: 20, right: 20 },
+    });
+
+    const result = await useCase.execute(command);
+
+    // The entity should have a valid storage path, not an empty string
+    expect(result.firstPageStoragePath).not.toBe('');
+    expect(result.firstPageStoragePath).toContain('first-page.pdf');
+  });
+});

--- a/ayunis-core-backend/src/domain/letterheads/application/use-cases/create-letterhead/create-letterhead.use-case.ts
+++ b/ayunis-core-backend/src/domain/letterheads/application/use-cases/create-letterhead/create-letterhead.use-case.ts
@@ -1,0 +1,97 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { randomUUID } from 'crypto';
+import { ContextService } from 'src/common/context/services/context.service';
+import { ApplicationError } from 'src/common/errors/base.error';
+import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
+import { UploadObjectUseCase } from 'src/domain/storage/application/use-cases/upload-object/upload-object.use-case';
+import { UploadObjectCommand } from 'src/domain/storage/application/use-cases/upload-object/upload-object.command';
+import { LetterheadsRepository } from '../../ports/letterheads-repository.port';
+import { UnexpectedLetterheadError } from '../../letterheads.errors';
+import { Letterhead } from '../../../domain/letterhead.entity';
+import { LetterheadPdfService } from '../../services/letterhead-pdf.service';
+import { CreateLetterheadCommand } from './create-letterhead.command';
+
+@Injectable()
+export class CreateLetterheadUseCase {
+  private readonly logger = new Logger(CreateLetterheadUseCase.name);
+
+  constructor(
+    private readonly letterheadsRepository: LetterheadsRepository,
+    private readonly contextService: ContextService,
+    private readonly uploadObjectUseCase: UploadObjectUseCase,
+    private readonly letterheadPdfService: LetterheadPdfService,
+  ) {}
+
+  async execute(command: CreateLetterheadCommand): Promise<Letterhead> {
+    this.logger.log('Creating letterhead', { name: command.name });
+
+    try {
+      const orgId = this.contextService.get('orgId');
+      if (!orgId) {
+        throw new UnauthorizedAccessError();
+      }
+
+      await this.letterheadPdfService.validateSinglePagePdf(
+        command.firstPagePdfBuffer,
+        'first page',
+      );
+
+      if (command.continuationPagePdfBuffer) {
+        await this.letterheadPdfService.validateSinglePagePdf(
+          command.continuationPagePdfBuffer,
+          'continuation page',
+        );
+      }
+
+      const letterheadId = randomUUID();
+
+      const firstPagePath = this.letterheadPdfService.buildStoragePath(
+        orgId,
+        letterheadId,
+        'first-page.pdf',
+      );
+
+      await this.uploadObjectUseCase.execute(
+        new UploadObjectCommand(firstPagePath, command.firstPagePdfBuffer),
+      );
+
+      let continuationPagePath: string | null = null;
+      if (command.continuationPagePdfBuffer) {
+        continuationPagePath = this.letterheadPdfService.buildStoragePath(
+          orgId,
+          letterheadId,
+          'continuation.pdf',
+        );
+        await this.uploadObjectUseCase.execute(
+          new UploadObjectCommand(
+            continuationPagePath,
+            command.continuationPagePdfBuffer,
+          ),
+        );
+      }
+
+      const letterhead = new Letterhead({
+        id: letterheadId,
+        orgId,
+        name: command.name,
+        description: command.description,
+        firstPageStoragePath: firstPagePath,
+        continuationPageStoragePath: continuationPagePath,
+        firstPageMargins: command.firstPageMargins,
+        continuationPageMargins: command.continuationPageMargins,
+      });
+
+      return await this.letterheadsRepository.save(letterhead);
+    } catch (error) {
+      if (error instanceof ApplicationError) {
+        throw error;
+      }
+      this.logger.error('Error creating letterhead', {
+        error: error as Error,
+      });
+      throw new UnexpectedLetterheadError('Error creating letterhead', {
+        error: error as Error,
+      });
+    }
+  }
+}

--- a/ayunis-core-backend/src/domain/letterheads/application/use-cases/delete-letterhead/delete-letterhead.command.ts
+++ b/ayunis-core-backend/src/domain/letterheads/application/use-cases/delete-letterhead/delete-letterhead.command.ts
@@ -1,0 +1,9 @@
+import type { UUID } from 'crypto';
+
+export class DeleteLetterheadCommand {
+  readonly letterheadId: UUID;
+
+  constructor(params: { letterheadId: UUID }) {
+    this.letterheadId = params.letterheadId;
+  }
+}

--- a/ayunis-core-backend/src/domain/letterheads/application/use-cases/delete-letterhead/delete-letterhead.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/letterheads/application/use-cases/delete-letterhead/delete-letterhead.use-case.spec.ts
@@ -1,0 +1,170 @@
+import type { TestingModule } from '@nestjs/testing';
+import { Test } from '@nestjs/testing';
+import { Logger } from '@nestjs/common';
+import type { UUID } from 'crypto';
+import { DeleteLetterheadUseCase } from './delete-letterhead.use-case';
+import { DeleteLetterheadCommand } from './delete-letterhead.command';
+import { LetterheadsRepository } from '../../ports/letterheads-repository.port';
+import { ContextService } from 'src/common/context/services/context.service';
+import { DeleteObjectUseCase } from 'src/domain/storage/application/use-cases/delete-object/delete-object.use-case';
+import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
+import { LetterheadNotFoundError } from '../../letterheads.errors';
+import { Letterhead } from '../../../domain/letterhead.entity';
+
+describe('DeleteLetterheadUseCase', () => {
+  let useCase: DeleteLetterheadUseCase;
+  let letterheadsRepository: jest.Mocked<LetterheadsRepository>;
+  let deleteObjectUseCase: jest.Mocked<DeleteObjectUseCase>;
+
+  const mockOrgId = '123e4567-e89b-12d3-a456-426614174000' as UUID;
+  const mockLetterheadId = '223e4567-e89b-12d3-a456-426614174000' as UUID;
+
+  beforeEach(async () => {
+    const mockRepository = {
+      findAllByOrgId: jest.fn(),
+      findById: jest.fn(),
+      save: jest.fn(),
+      delete: jest.fn(),
+    };
+
+    const mockContextService = {
+      get: jest.fn((key: string) => {
+        if (key === 'orgId') return mockOrgId;
+        return undefined;
+      }),
+    } as unknown as jest.Mocked<ContextService>;
+
+    const mockDeleteObjectUseCase = {
+      execute: jest.fn().mockResolvedValue(undefined),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        DeleteLetterheadUseCase,
+        { provide: LetterheadsRepository, useValue: mockRepository },
+        { provide: ContextService, useValue: mockContextService },
+        { provide: DeleteObjectUseCase, useValue: mockDeleteObjectUseCase },
+      ],
+    }).compile();
+
+    useCase = module.get(DeleteLetterheadUseCase);
+    letterheadsRepository = module.get(LetterheadsRepository);
+    deleteObjectUseCase = module.get(DeleteObjectUseCase);
+
+    jest.spyOn(Logger.prototype, 'log').mockImplementation();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should delete a letterhead and its first-page file from storage', async () => {
+    const letterhead = new Letterhead({
+      id: mockLetterheadId,
+      orgId: mockOrgId,
+      name: 'Stadtverwaltung Briefpapier',
+      firstPageStoragePath: `letterheads/${mockOrgId}/${mockLetterheadId}/first-page.pdf`,
+      continuationPageStoragePath: null,
+      firstPageMargins: { top: 55, bottom: 20, left: 25, right: 15 },
+      continuationPageMargins: { top: 20, bottom: 20, left: 25, right: 15 },
+    });
+    letterheadsRepository.findById.mockResolvedValue(letterhead);
+
+    await useCase.execute(
+      new DeleteLetterheadCommand({ letterheadId: mockLetterheadId }),
+    );
+
+    expect(deleteObjectUseCase.execute).toHaveBeenCalledTimes(1);
+    expect(deleteObjectUseCase.execute).toHaveBeenCalledWith(
+      expect.objectContaining({
+        objectName: `letterheads/${mockOrgId}/${mockLetterheadId}/first-page.pdf`,
+      }),
+    );
+    expect(letterheadsRepository.delete).toHaveBeenCalledWith(
+      mockOrgId,
+      mockLetterheadId,
+    );
+  });
+
+  it('should delete both files when continuation page exists', async () => {
+    const letterhead = new Letterhead({
+      id: mockLetterheadId,
+      orgId: mockOrgId,
+      name: 'With Continuation',
+      firstPageStoragePath: `letterheads/${mockOrgId}/${mockLetterheadId}/first-page.pdf`,
+      continuationPageStoragePath: `letterheads/${mockOrgId}/${mockLetterheadId}/continuation.pdf`,
+      firstPageMargins: { top: 55, bottom: 20, left: 25, right: 15 },
+      continuationPageMargins: { top: 20, bottom: 20, left: 25, right: 15 },
+    });
+    letterheadsRepository.findById.mockResolvedValue(letterhead);
+
+    await useCase.execute(
+      new DeleteLetterheadCommand({ letterheadId: mockLetterheadId }),
+    );
+
+    expect(deleteObjectUseCase.execute).toHaveBeenCalledTimes(2);
+  });
+
+  it('should throw LetterheadNotFoundError when letterhead does not exist', async () => {
+    letterheadsRepository.findById.mockResolvedValue(null);
+
+    await expect(
+      useCase.execute(
+        new DeleteLetterheadCommand({ letterheadId: mockLetterheadId }),
+      ),
+    ).rejects.toThrow(LetterheadNotFoundError);
+
+    expect(deleteObjectUseCase.execute).not.toHaveBeenCalled();
+    expect(letterheadsRepository.delete).not.toHaveBeenCalled();
+  });
+
+  it('should throw UnauthorizedAccessError when orgId is missing', async () => {
+    const mockContextService = {
+      get: jest.fn(() => undefined),
+    } as unknown as jest.Mocked<ContextService>;
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        DeleteLetterheadUseCase,
+        { provide: LetterheadsRepository, useValue: letterheadsRepository },
+        { provide: ContextService, useValue: mockContextService },
+        { provide: DeleteObjectUseCase, useValue: deleteObjectUseCase },
+      ],
+    }).compile();
+
+    const useCaseNoOrg = module.get(DeleteLetterheadUseCase);
+
+    await expect(
+      useCaseNoOrg.execute(
+        new DeleteLetterheadCommand({ letterheadId: mockLetterheadId }),
+      ),
+    ).rejects.toThrow(UnauthorizedAccessError);
+  });
+
+  it('should delete the database record before storage files', async () => {
+    const callOrder: string[] = [];
+
+    const letterhead = new Letterhead({
+      id: mockLetterheadId,
+      orgId: mockOrgId,
+      name: 'Order Test',
+      firstPageStoragePath: `letterheads/${mockOrgId}/${mockLetterheadId}/first-page.pdf`,
+      firstPageMargins: { top: 20, bottom: 20, left: 20, right: 20 },
+      continuationPageMargins: { top: 20, bottom: 20, left: 20, right: 20 },
+    });
+    letterheadsRepository.findById.mockResolvedValue(letterhead);
+
+    deleteObjectUseCase.execute.mockImplementation(async () => {
+      callOrder.push('deleteObject');
+    });
+    letterheadsRepository.delete.mockImplementation(async () => {
+      callOrder.push('deleteRecord');
+    });
+
+    await useCase.execute(
+      new DeleteLetterheadCommand({ letterheadId: mockLetterheadId }),
+    );
+
+    expect(callOrder).toEqual(['deleteRecord', 'deleteObject']);
+  });
+});

--- a/ayunis-core-backend/src/domain/letterheads/application/use-cases/delete-letterhead/delete-letterhead.use-case.ts
+++ b/ayunis-core-backend/src/domain/letterheads/application/use-cases/delete-letterhead/delete-letterhead.use-case.ts
@@ -1,0 +1,68 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ContextService } from 'src/common/context/services/context.service';
+import { ApplicationError } from 'src/common/errors/base.error';
+import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
+import { DeleteObjectUseCase } from 'src/domain/storage/application/use-cases/delete-object/delete-object.use-case';
+import { DeleteObjectCommand } from 'src/domain/storage/application/use-cases/delete-object/delete-object.command';
+import { LetterheadsRepository } from '../../ports/letterheads-repository.port';
+import {
+  LetterheadNotFoundError,
+  UnexpectedLetterheadError,
+} from '../../letterheads.errors';
+import { DeleteLetterheadCommand } from './delete-letterhead.command';
+
+@Injectable()
+export class DeleteLetterheadUseCase {
+  private readonly logger = new Logger(DeleteLetterheadUseCase.name);
+
+  constructor(
+    private readonly letterheadsRepository: LetterheadsRepository,
+    private readonly contextService: ContextService,
+    private readonly deleteObjectUseCase: DeleteObjectUseCase,
+  ) {}
+
+  async execute(command: DeleteLetterheadCommand): Promise<void> {
+    this.logger.log('Deleting letterhead', {
+      letterheadId: command.letterheadId,
+    });
+
+    try {
+      const orgId = this.contextService.get('orgId');
+      if (!orgId) {
+        throw new UnauthorizedAccessError();
+      }
+
+      const letterhead = await this.letterheadsRepository.findById(
+        orgId,
+        command.letterheadId,
+      );
+      if (!letterhead) {
+        throw new LetterheadNotFoundError(command.letterheadId);
+      }
+
+      // Delete DB record first — orphaned storage files are benign,
+      // but a DB record pointing to deleted storage paths causes runtime errors.
+      await this.letterheadsRepository.delete(orgId, command.letterheadId);
+
+      await this.deleteObjectUseCase.execute(
+        new DeleteObjectCommand(letterhead.firstPageStoragePath),
+      );
+
+      if (letterhead.continuationPageStoragePath) {
+        await this.deleteObjectUseCase.execute(
+          new DeleteObjectCommand(letterhead.continuationPageStoragePath),
+        );
+      }
+    } catch (error) {
+      if (error instanceof ApplicationError) {
+        throw error;
+      }
+      this.logger.error('Error deleting letterhead', {
+        error: error as Error,
+      });
+      throw new UnexpectedLetterheadError('Error deleting letterhead', {
+        error: error as Error,
+      });
+    }
+  }
+}

--- a/ayunis-core-backend/src/domain/letterheads/application/use-cases/find-all-letterheads/find-all-letterheads.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/letterheads/application/use-cases/find-all-letterheads/find-all-letterheads.use-case.spec.ts
@@ -1,0 +1,106 @@
+import type { TestingModule } from '@nestjs/testing';
+import { Test } from '@nestjs/testing';
+import { Logger } from '@nestjs/common';
+import type { UUID } from 'crypto';
+import { FindAllLetterheadsUseCase } from './find-all-letterheads.use-case';
+import { LetterheadsRepository } from '../../ports/letterheads-repository.port';
+import { ContextService } from 'src/common/context/services/context.service';
+import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
+import { Letterhead } from '../../../domain/letterhead.entity';
+
+describe('FindAllLetterheadsUseCase', () => {
+  let useCase: FindAllLetterheadsUseCase;
+  let letterheadsRepository: jest.Mocked<LetterheadsRepository>;
+
+  const mockOrgId = '123e4567-e89b-12d3-a456-426614174000' as UUID;
+
+  beforeEach(async () => {
+    const mockRepository = {
+      findAllByOrgId: jest.fn(),
+      findById: jest.fn(),
+      save: jest.fn(),
+      delete: jest.fn(),
+    };
+
+    const mockContextService = {
+      get: jest.fn((key: string) => {
+        if (key === 'orgId') return mockOrgId;
+        return undefined;
+      }),
+    } as unknown as jest.Mocked<ContextService>;
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        FindAllLetterheadsUseCase,
+        { provide: LetterheadsRepository, useValue: mockRepository },
+        { provide: ContextService, useValue: mockContextService },
+      ],
+    }).compile();
+
+    useCase = module.get(FindAllLetterheadsUseCase);
+    letterheadsRepository = module.get(LetterheadsRepository);
+
+    jest.spyOn(Logger.prototype, 'log').mockImplementation();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return all letterheads for the current organization', async () => {
+    const letterheads = [
+      new Letterhead({
+        orgId: mockOrgId,
+        name: 'Stadtverwaltung Briefpapier',
+        firstPageStoragePath: 'letterheads/org/1/first-page.pdf',
+        firstPageMargins: { top: 55, bottom: 20, left: 25, right: 15 },
+        continuationPageMargins: { top: 20, bottom: 20, left: 25, right: 15 },
+      }),
+      new Letterhead({
+        orgId: mockOrgId,
+        name: 'Amt für Bildung',
+        firstPageStoragePath: 'letterheads/org/2/first-page.pdf',
+        firstPageMargins: { top: 40, bottom: 20, left: 20, right: 20 },
+        continuationPageMargins: { top: 15, bottom: 20, left: 20, right: 20 },
+      }),
+    ];
+    letterheadsRepository.findAllByOrgId.mockResolvedValue(letterheads);
+
+    const result = await useCase.execute();
+
+    expect(result).toHaveLength(2);
+    expect(result[0].name).toBe('Stadtverwaltung Briefpapier');
+    expect(result[1].name).toBe('Amt für Bildung');
+    expect(letterheadsRepository.findAllByOrgId).toHaveBeenCalledWith(
+      mockOrgId,
+    );
+  });
+
+  it('should return empty array when no letterheads exist', async () => {
+    letterheadsRepository.findAllByOrgId.mockResolvedValue([]);
+
+    const result = await useCase.execute();
+
+    expect(result).toHaveLength(0);
+  });
+
+  it('should throw UnauthorizedAccessError when orgId is missing', async () => {
+    const mockContextService = {
+      get: jest.fn(() => undefined),
+    } as unknown as jest.Mocked<ContextService>;
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        FindAllLetterheadsUseCase,
+        { provide: LetterheadsRepository, useValue: letterheadsRepository },
+        { provide: ContextService, useValue: mockContextService },
+      ],
+    }).compile();
+
+    const useCaseNoOrg = module.get(FindAllLetterheadsUseCase);
+
+    await expect(useCaseNoOrg.execute()).rejects.toThrow(
+      UnauthorizedAccessError,
+    );
+  });
+});

--- a/ayunis-core-backend/src/domain/letterheads/application/use-cases/find-all-letterheads/find-all-letterheads.use-case.ts
+++ b/ayunis-core-backend/src/domain/letterheads/application/use-cases/find-all-letterheads/find-all-letterheads.use-case.ts
@@ -1,0 +1,40 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ContextService } from 'src/common/context/services/context.service';
+import { ApplicationError } from 'src/common/errors/base.error';
+import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
+import { LetterheadsRepository } from '../../ports/letterheads-repository.port';
+import { UnexpectedLetterheadError } from '../../letterheads.errors';
+import { Letterhead } from '../../../domain/letterhead.entity';
+
+@Injectable()
+export class FindAllLetterheadsUseCase {
+  private readonly logger = new Logger(FindAllLetterheadsUseCase.name);
+
+  constructor(
+    private readonly letterheadsRepository: LetterheadsRepository,
+    private readonly contextService: ContextService,
+  ) {}
+
+  async execute(): Promise<Letterhead[]> {
+    this.logger.log('Finding all letterheads');
+
+    try {
+      const orgId = this.contextService.get('orgId');
+      if (!orgId) {
+        throw new UnauthorizedAccessError();
+      }
+
+      return await this.letterheadsRepository.findAllByOrgId(orgId);
+    } catch (error) {
+      if (error instanceof ApplicationError) {
+        throw error;
+      }
+      this.logger.error('Error finding all letterheads', {
+        error: error as Error,
+      });
+      throw new UnexpectedLetterheadError('Error finding all letterheads', {
+        error: error as Error,
+      });
+    }
+  }
+}

--- a/ayunis-core-backend/src/domain/letterheads/application/use-cases/find-letterhead/find-letterhead.query.ts
+++ b/ayunis-core-backend/src/domain/letterheads/application/use-cases/find-letterhead/find-letterhead.query.ts
@@ -1,0 +1,9 @@
+import type { UUID } from 'crypto';
+
+export class FindLetterheadQuery {
+  readonly letterheadId: UUID;
+
+  constructor(params: { letterheadId: UUID }) {
+    this.letterheadId = params.letterheadId;
+  }
+}

--- a/ayunis-core-backend/src/domain/letterheads/application/use-cases/find-letterhead/find-letterhead.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/letterheads/application/use-cases/find-letterhead/find-letterhead.use-case.spec.ts
@@ -1,0 +1,108 @@
+import type { TestingModule } from '@nestjs/testing';
+import { Test } from '@nestjs/testing';
+import { Logger } from '@nestjs/common';
+import type { UUID } from 'crypto';
+import { FindLetterheadUseCase } from './find-letterhead.use-case';
+import { FindLetterheadQuery } from './find-letterhead.query';
+import { LetterheadsRepository } from '../../ports/letterheads-repository.port';
+import { ContextService } from 'src/common/context/services/context.service';
+import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
+import { LetterheadNotFoundError } from '../../letterheads.errors';
+import { Letterhead } from '../../../domain/letterhead.entity';
+
+describe('FindLetterheadUseCase', () => {
+  let useCase: FindLetterheadUseCase;
+  let letterheadsRepository: jest.Mocked<LetterheadsRepository>;
+
+  const mockOrgId = '123e4567-e89b-12d3-a456-426614174000' as UUID;
+  const mockLetterheadId = '223e4567-e89b-12d3-a456-426614174000' as UUID;
+
+  beforeEach(async () => {
+    const mockRepository = {
+      findAllByOrgId: jest.fn(),
+      findById: jest.fn(),
+      save: jest.fn(),
+      delete: jest.fn(),
+    };
+
+    const mockContextService = {
+      get: jest.fn((key: string) => {
+        if (key === 'orgId') return mockOrgId;
+        return undefined;
+      }),
+    } as unknown as jest.Mocked<ContextService>;
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        FindLetterheadUseCase,
+        { provide: LetterheadsRepository, useValue: mockRepository },
+        { provide: ContextService, useValue: mockContextService },
+      ],
+    }).compile();
+
+    useCase = module.get(FindLetterheadUseCase);
+    letterheadsRepository = module.get(LetterheadsRepository);
+
+    jest.spyOn(Logger.prototype, 'log').mockImplementation();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return a letterhead when found by ID and org', async () => {
+    const letterhead = new Letterhead({
+      id: mockLetterheadId,
+      orgId: mockOrgId,
+      name: 'Stadtverwaltung Briefpapier',
+      description: 'Offizielles Briefpapier',
+      firstPageStoragePath: 'letterheads/org/id/first-page.pdf',
+      firstPageMargins: { top: 55, bottom: 20, left: 25, right: 15 },
+      continuationPageMargins: { top: 20, bottom: 20, left: 25, right: 15 },
+    });
+    letterheadsRepository.findById.mockResolvedValue(letterhead);
+
+    const result = await useCase.execute(
+      new FindLetterheadQuery({ letterheadId: mockLetterheadId }),
+    );
+
+    expect(result.id).toBe(mockLetterheadId);
+    expect(result.name).toBe('Stadtverwaltung Briefpapier');
+    expect(letterheadsRepository.findById).toHaveBeenCalledWith(
+      mockOrgId,
+      mockLetterheadId,
+    );
+  });
+
+  it('should throw LetterheadNotFoundError when letterhead does not exist', async () => {
+    letterheadsRepository.findById.mockResolvedValue(null);
+
+    await expect(
+      useCase.execute(
+        new FindLetterheadQuery({ letterheadId: mockLetterheadId }),
+      ),
+    ).rejects.toThrow(LetterheadNotFoundError);
+  });
+
+  it('should throw UnauthorizedAccessError when orgId is missing', async () => {
+    const mockContextService = {
+      get: jest.fn(() => undefined),
+    } as unknown as jest.Mocked<ContextService>;
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        FindLetterheadUseCase,
+        { provide: LetterheadsRepository, useValue: letterheadsRepository },
+        { provide: ContextService, useValue: mockContextService },
+      ],
+    }).compile();
+
+    const useCaseNoOrg = module.get(FindLetterheadUseCase);
+
+    await expect(
+      useCaseNoOrg.execute(
+        new FindLetterheadQuery({ letterheadId: mockLetterheadId }),
+      ),
+    ).rejects.toThrow(UnauthorizedAccessError);
+  });
+});

--- a/ayunis-core-backend/src/domain/letterheads/application/use-cases/find-letterhead/find-letterhead.use-case.ts
+++ b/ayunis-core-backend/src/domain/letterheads/application/use-cases/find-letterhead/find-letterhead.use-case.ts
@@ -1,0 +1,55 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ContextService } from 'src/common/context/services/context.service';
+import { ApplicationError } from 'src/common/errors/base.error';
+import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
+import { LetterheadsRepository } from '../../ports/letterheads-repository.port';
+import { Letterhead } from '../../../domain/letterhead.entity';
+import {
+  LetterheadNotFoundError,
+  UnexpectedLetterheadError,
+} from '../../letterheads.errors';
+import { FindLetterheadQuery } from './find-letterhead.query';
+
+@Injectable()
+export class FindLetterheadUseCase {
+  private readonly logger = new Logger(FindLetterheadUseCase.name);
+
+  constructor(
+    private readonly letterheadsRepository: LetterheadsRepository,
+    private readonly contextService: ContextService,
+  ) {}
+
+  async execute(query: FindLetterheadQuery): Promise<Letterhead> {
+    this.logger.log('Finding letterhead', {
+      letterheadId: query.letterheadId,
+    });
+
+    try {
+      const orgId = this.contextService.get('orgId');
+      if (!orgId) {
+        throw new UnauthorizedAccessError();
+      }
+
+      const letterhead = await this.letterheadsRepository.findById(
+        orgId,
+        query.letterheadId,
+      );
+
+      if (!letterhead) {
+        throw new LetterheadNotFoundError(query.letterheadId);
+      }
+
+      return letterhead;
+    } catch (error) {
+      if (error instanceof ApplicationError) {
+        throw error;
+      }
+      this.logger.error('Error finding letterhead', {
+        error: error as Error,
+      });
+      throw new UnexpectedLetterheadError('Error finding letterhead', {
+        error: error as Error,
+      });
+    }
+  }
+}

--- a/ayunis-core-backend/src/domain/letterheads/application/use-cases/update-letterhead/update-letterhead.command.ts
+++ b/ayunis-core-backend/src/domain/letterheads/application/use-cases/update-letterhead/update-letterhead.command.ts
@@ -1,0 +1,33 @@
+import type { UUID } from 'crypto';
+import type { PageMargins } from '../../../domain/value-objects/page-margins';
+
+export class UpdateLetterheadCommand {
+  readonly letterheadId: UUID;
+  readonly name?: string;
+  readonly description?: string | null;
+  readonly firstPagePdfBuffer?: Buffer;
+  readonly continuationPagePdfBuffer?: Buffer;
+  readonly removeContinuationPage: boolean;
+  readonly firstPageMargins?: PageMargins;
+  readonly continuationPageMargins?: PageMargins;
+
+  constructor(params: {
+    letterheadId: UUID;
+    name?: string;
+    description?: string | null;
+    firstPagePdfBuffer?: Buffer;
+    continuationPagePdfBuffer?: Buffer;
+    removeContinuationPage?: boolean;
+    firstPageMargins?: PageMargins;
+    continuationPageMargins?: PageMargins;
+  }) {
+    this.letterheadId = params.letterheadId;
+    this.name = params.name;
+    this.description = params.description;
+    this.firstPagePdfBuffer = params.firstPagePdfBuffer;
+    this.continuationPagePdfBuffer = params.continuationPagePdfBuffer;
+    this.removeContinuationPage = params.removeContinuationPage ?? false;
+    this.firstPageMargins = params.firstPageMargins;
+    this.continuationPageMargins = params.continuationPageMargins;
+  }
+}

--- a/ayunis-core-backend/src/domain/letterheads/application/use-cases/update-letterhead/update-letterhead.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/letterheads/application/use-cases/update-letterhead/update-letterhead.use-case.spec.ts
@@ -1,0 +1,269 @@
+import type { TestingModule } from '@nestjs/testing';
+import { Test } from '@nestjs/testing';
+import { Logger } from '@nestjs/common';
+import type { UUID } from 'crypto';
+import { PDFDocument } from 'pdf-lib';
+import { UpdateLetterheadUseCase } from './update-letterhead.use-case';
+import { UpdateLetterheadCommand } from './update-letterhead.command';
+import { LetterheadsRepository } from '../../ports/letterheads-repository.port';
+import { LetterheadPdfService } from '../../services/letterhead-pdf.service';
+import { ContextService } from 'src/common/context/services/context.service';
+import { UploadObjectUseCase } from 'src/domain/storage/application/use-cases/upload-object/upload-object.use-case';
+import { DeleteObjectUseCase } from 'src/domain/storage/application/use-cases/delete-object/delete-object.use-case';
+import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
+import {
+  LetterheadNotFoundError,
+  LetterheadInvalidPdfError,
+} from '../../letterheads.errors';
+import { Letterhead } from '../../../domain/letterhead.entity';
+
+async function createSinglePagePdf(): Promise<Buffer> {
+  const doc = await PDFDocument.create();
+  doc.addPage();
+  const bytes = await doc.save();
+  return Buffer.from(bytes);
+}
+
+async function createMultiPagePdf(pages: number): Promise<Buffer> {
+  const doc = await PDFDocument.create();
+  for (let i = 0; i < pages; i++) {
+    doc.addPage();
+  }
+  const bytes = await doc.save();
+  return Buffer.from(bytes);
+}
+
+describe('UpdateLetterheadUseCase', () => {
+  let useCase: UpdateLetterheadUseCase;
+  let letterheadsRepository: jest.Mocked<LetterheadsRepository>;
+  let uploadObjectUseCase: jest.Mocked<UploadObjectUseCase>;
+  let deleteObjectUseCase: jest.Mocked<DeleteObjectUseCase>;
+
+  const mockOrgId = '123e4567-e89b-12d3-a456-426614174000' as UUID;
+  const mockLetterheadId = '223e4567-e89b-12d3-a456-426614174000' as UUID;
+
+  const existingLetterhead = new Letterhead({
+    id: mockLetterheadId,
+    orgId: mockOrgId,
+    name: 'Original Name',
+    description: 'Original Description',
+    firstPageStoragePath: `letterheads/${mockOrgId}/${mockLetterheadId}/first-page.pdf`,
+    continuationPageStoragePath: null,
+    firstPageMargins: { top: 55, bottom: 20, left: 25, right: 15 },
+    continuationPageMargins: { top: 20, bottom: 20, left: 25, right: 15 },
+  });
+
+  beforeEach(async () => {
+    const mockRepository = {
+      findAllByOrgId: jest.fn(),
+      findById: jest.fn().mockResolvedValue(existingLetterhead),
+      save: jest.fn(),
+      delete: jest.fn(),
+    };
+
+    const mockContextService = {
+      get: jest.fn((key: string) => {
+        if (key === 'orgId') return mockOrgId;
+        return undefined;
+      }),
+    } as unknown as jest.Mocked<ContextService>;
+
+    const mockUploadObjectUseCase = {
+      execute: jest.fn().mockResolvedValue({
+        objectName: 'test',
+        size: 1024,
+        etag: 'abc',
+      }),
+    };
+
+    const mockDeleteObjectUseCase = {
+      execute: jest.fn().mockResolvedValue(undefined),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        UpdateLetterheadUseCase,
+        LetterheadPdfService,
+        { provide: LetterheadsRepository, useValue: mockRepository },
+        { provide: ContextService, useValue: mockContextService },
+        { provide: UploadObjectUseCase, useValue: mockUploadObjectUseCase },
+        { provide: DeleteObjectUseCase, useValue: mockDeleteObjectUseCase },
+      ],
+    }).compile();
+
+    useCase = module.get(UpdateLetterheadUseCase);
+    letterheadsRepository = module.get(LetterheadsRepository);
+    uploadObjectUseCase = module.get(UploadObjectUseCase);
+    deleteObjectUseCase = module.get(DeleteObjectUseCase);
+
+    letterheadsRepository.save.mockImplementation(async (l) => l);
+
+    jest.spyOn(Logger.prototype, 'log').mockImplementation();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should update name and description without uploading files', async () => {
+    const command = new UpdateLetterheadCommand({
+      letterheadId: mockLetterheadId,
+      name: 'Updated Briefpapier',
+      description: 'Neues Design 2026',
+    });
+
+    const result = await useCase.execute(command);
+
+    expect(result.name).toBe('Updated Briefpapier');
+    expect(result.description).toBe('Neues Design 2026');
+    expect(result.firstPageStoragePath).toBe(
+      existingLetterhead.firstPageStoragePath,
+    );
+    expect(uploadObjectUseCase.execute).not.toHaveBeenCalled();
+  });
+
+  it('should update margins without replacing PDF files', async () => {
+    const command = new UpdateLetterheadCommand({
+      letterheadId: mockLetterheadId,
+      firstPageMargins: { top: 70, bottom: 25, left: 30, right: 20 },
+    });
+
+    const result = await useCase.execute(command);
+
+    expect(result.firstPageMargins).toEqual({
+      top: 70,
+      bottom: 25,
+      left: 30,
+      right: 20,
+    });
+    expect(result.continuationPageMargins).toEqual(
+      existingLetterhead.continuationPageMargins,
+    );
+  });
+
+  it('should replace the first-page PDF when a new buffer is provided', async () => {
+    const newPdf = await createSinglePagePdf();
+
+    const command = new UpdateLetterheadCommand({
+      letterheadId: mockLetterheadId,
+      firstPagePdfBuffer: newPdf,
+    });
+
+    const result = await useCase.execute(command);
+
+    expect(result.firstPageStoragePath).toContain('first-page.pdf');
+    expect(uploadObjectUseCase.execute).toHaveBeenCalledTimes(1);
+  });
+
+  it('should add a continuation PDF when provided', async () => {
+    const continuationPdf = await createSinglePagePdf();
+
+    const command = new UpdateLetterheadCommand({
+      letterheadId: mockLetterheadId,
+      continuationPagePdfBuffer: continuationPdf,
+    });
+
+    const result = await useCase.execute(command);
+
+    expect(result.continuationPageStoragePath).toContain('continuation.pdf');
+    expect(uploadObjectUseCase.execute).toHaveBeenCalledTimes(1);
+  });
+
+  it('should clear continuation PDF and delete storage file when removeContinuationPage is true', async () => {
+    const continuationPath = `letterheads/${mockOrgId}/${mockLetterheadId}/continuation.pdf`;
+    const withContinuation = new Letterhead({
+      ...existingLetterhead,
+      continuationPageStoragePath: continuationPath,
+    });
+    letterheadsRepository.findById.mockResolvedValue(withContinuation);
+
+    const command = new UpdateLetterheadCommand({
+      letterheadId: mockLetterheadId,
+      removeContinuationPage: true,
+    });
+
+    const result = await useCase.execute(command);
+
+    expect(result.continuationPageStoragePath).toBeNull();
+    expect(deleteObjectUseCase.execute).toHaveBeenCalledWith(
+      expect.objectContaining({ objectName: continuationPath }),
+    );
+  });
+
+  it('should not call deleteObject when removeContinuationPage is true but no file exists', async () => {
+    const command = new UpdateLetterheadCommand({
+      letterheadId: mockLetterheadId,
+      removeContinuationPage: true,
+    });
+
+    const result = await useCase.execute(command);
+
+    expect(result.continuationPageStoragePath).toBeNull();
+    expect(deleteObjectUseCase.execute).not.toHaveBeenCalled();
+  });
+
+  it('should reject a multi-page first-page PDF replacement', async () => {
+    const multiPagePdf = await createMultiPagePdf(2);
+
+    const command = new UpdateLetterheadCommand({
+      letterheadId: mockLetterheadId,
+      firstPagePdfBuffer: multiPagePdf,
+    });
+
+    await expect(useCase.execute(command)).rejects.toThrow(
+      LetterheadInvalidPdfError,
+    );
+  });
+
+  it('should throw LetterheadNotFoundError when letterhead does not exist', async () => {
+    letterheadsRepository.findById.mockResolvedValue(null);
+
+    const command = new UpdateLetterheadCommand({
+      letterheadId: mockLetterheadId,
+      name: 'Does Not Exist',
+    });
+
+    await expect(useCase.execute(command)).rejects.toThrow(
+      LetterheadNotFoundError,
+    );
+  });
+
+  it('should throw UnauthorizedAccessError when orgId is missing', async () => {
+    const mockContextService = {
+      get: jest.fn(() => undefined),
+    } as unknown as jest.Mocked<ContextService>;
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        UpdateLetterheadUseCase,
+        LetterheadPdfService,
+        { provide: LetterheadsRepository, useValue: letterheadsRepository },
+        { provide: ContextService, useValue: mockContextService },
+        { provide: UploadObjectUseCase, useValue: uploadObjectUseCase },
+        { provide: DeleteObjectUseCase, useValue: deleteObjectUseCase },
+      ],
+    }).compile();
+
+    const useCaseNoOrg = module.get(UpdateLetterheadUseCase);
+
+    const command = new UpdateLetterheadCommand({
+      letterheadId: mockLetterheadId,
+      name: 'No Org',
+    });
+
+    await expect(useCaseNoOrg.execute(command)).rejects.toThrow(
+      UnauthorizedAccessError,
+    );
+  });
+
+  it('should allow setting description to null explicitly', async () => {
+    const command = new UpdateLetterheadCommand({
+      letterheadId: mockLetterheadId,
+      description: null,
+    });
+
+    const result = await useCase.execute(command);
+
+    expect(result.description).toBeNull();
+  });
+});

--- a/ayunis-core-backend/src/domain/letterheads/application/use-cases/update-letterhead/update-letterhead.use-case.ts
+++ b/ayunis-core-backend/src/domain/letterheads/application/use-cases/update-letterhead/update-letterhead.use-case.ts
@@ -1,0 +1,125 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ContextService } from 'src/common/context/services/context.service';
+import { ApplicationError } from 'src/common/errors/base.error';
+import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
+import { UploadObjectUseCase } from 'src/domain/storage/application/use-cases/upload-object/upload-object.use-case';
+import { UploadObjectCommand } from 'src/domain/storage/application/use-cases/upload-object/upload-object.command';
+import { DeleteObjectUseCase } from 'src/domain/storage/application/use-cases/delete-object/delete-object.use-case';
+import { DeleteObjectCommand } from 'src/domain/storage/application/use-cases/delete-object/delete-object.command';
+import { LetterheadsRepository } from '../../ports/letterheads-repository.port';
+import { Letterhead } from '../../../domain/letterhead.entity';
+import {
+  LetterheadNotFoundError,
+  UnexpectedLetterheadError,
+} from '../../letterheads.errors';
+import { LetterheadPdfService } from '../../services/letterhead-pdf.service';
+import { UpdateLetterheadCommand } from './update-letterhead.command';
+
+@Injectable()
+export class UpdateLetterheadUseCase {
+  private readonly logger = new Logger(UpdateLetterheadUseCase.name);
+
+  constructor(
+    private readonly letterheadsRepository: LetterheadsRepository,
+    private readonly contextService: ContextService,
+    private readonly uploadObjectUseCase: UploadObjectUseCase,
+    private readonly deleteObjectUseCase: DeleteObjectUseCase,
+    private readonly letterheadPdfService: LetterheadPdfService,
+  ) {}
+
+  async execute(command: UpdateLetterheadCommand): Promise<Letterhead> {
+    this.logger.log('Updating letterhead', {
+      letterheadId: command.letterheadId,
+    });
+
+    try {
+      const orgId = this.contextService.get('orgId');
+      if (!orgId) {
+        throw new UnauthorizedAccessError();
+      }
+
+      const existing = await this.letterheadsRepository.findById(
+        orgId,
+        command.letterheadId,
+      );
+      if (!existing) {
+        throw new LetterheadNotFoundError(command.letterheadId);
+      }
+
+      let firstPageStoragePath = existing.firstPageStoragePath;
+      if (command.firstPagePdfBuffer) {
+        await this.letterheadPdfService.validateSinglePagePdf(
+          command.firstPagePdfBuffer,
+          'first page',
+        );
+        firstPageStoragePath = this.letterheadPdfService.buildStoragePath(
+          orgId,
+          existing.id,
+          'first-page.pdf',
+        );
+        await this.uploadObjectUseCase.execute(
+          new UploadObjectCommand(
+            firstPageStoragePath,
+            command.firstPagePdfBuffer,
+          ),
+        );
+      }
+
+      let continuationPageStoragePath = existing.continuationPageStoragePath;
+      if (command.continuationPagePdfBuffer) {
+        await this.letterheadPdfService.validateSinglePagePdf(
+          command.continuationPagePdfBuffer,
+          'continuation page',
+        );
+        continuationPageStoragePath =
+          this.letterheadPdfService.buildStoragePath(
+            orgId,
+            existing.id,
+            'continuation.pdf',
+          );
+        await this.uploadObjectUseCase.execute(
+          new UploadObjectCommand(
+            continuationPageStoragePath,
+            command.continuationPagePdfBuffer,
+          ),
+        );
+      } else if (command.removeContinuationPage) {
+        if (existing.continuationPageStoragePath) {
+          await this.deleteObjectUseCase.execute(
+            new DeleteObjectCommand(existing.continuationPageStoragePath),
+          );
+        }
+        continuationPageStoragePath = null;
+      }
+
+      const updated = new Letterhead({
+        id: existing.id,
+        orgId: existing.orgId,
+        name: command.name ?? existing.name,
+        description:
+          command.description !== undefined
+            ? command.description
+            : existing.description,
+        firstPageStoragePath,
+        continuationPageStoragePath,
+        firstPageMargins: command.firstPageMargins ?? existing.firstPageMargins,
+        continuationPageMargins:
+          command.continuationPageMargins ?? existing.continuationPageMargins,
+        createdAt: existing.createdAt,
+        updatedAt: new Date(),
+      });
+
+      return await this.letterheadsRepository.save(updated);
+    } catch (error) {
+      if (error instanceof ApplicationError) {
+        throw error;
+      }
+      this.logger.error('Error updating letterhead', {
+        error: error as Error,
+      });
+      throw new UnexpectedLetterheadError('Error updating letterhead', {
+        error: error as Error,
+      });
+    }
+  }
+}

--- a/ayunis-core-backend/src/domain/letterheads/letterheads.module.ts
+++ b/ayunis-core-backend/src/domain/letterheads/letterheads.module.ts
@@ -2,15 +2,39 @@ import { Module } from '@nestjs/common';
 import { LetterheadsRepository } from './application/ports/letterheads-repository.port';
 import { LocalLetterheadsRepositoryModule } from './infrastructure/persistence/local/local-letterheads-repository.module';
 import { LocalLetterheadsRepository } from './infrastructure/persistence/local/local-letterheads.repository';
+import { StorageModule } from '../storage/storage.module';
+import { LetterheadPdfService } from './application/services/letterhead-pdf.service';
+import { CreateLetterheadUseCase } from './application/use-cases/create-letterhead/create-letterhead.use-case';
+import { FindAllLetterheadsUseCase } from './application/use-cases/find-all-letterheads/find-all-letterheads.use-case';
+import { FindLetterheadUseCase } from './application/use-cases/find-letterhead/find-letterhead.use-case';
+import { UpdateLetterheadUseCase } from './application/use-cases/update-letterhead/update-letterhead.use-case';
+import { DeleteLetterheadUseCase } from './application/use-cases/delete-letterhead/delete-letterhead.use-case';
+import { LetterheadsController } from './presenters/http/letterheads.controller';
+import { LetterheadDtoMapper } from './presenters/http/mappers/letterhead-dto.mapper';
 
 @Module({
-  imports: [LocalLetterheadsRepositoryModule],
+  imports: [LocalLetterheadsRepositoryModule, StorageModule],
+  controllers: [LetterheadsController],
   providers: [
     {
       provide: LetterheadsRepository,
       useExisting: LocalLetterheadsRepository,
     },
+    LetterheadPdfService,
+    CreateLetterheadUseCase,
+    FindAllLetterheadsUseCase,
+    FindLetterheadUseCase,
+    UpdateLetterheadUseCase,
+    DeleteLetterheadUseCase,
+    LetterheadDtoMapper,
   ],
-  exports: [LetterheadsRepository],
+  exports: [
+    LetterheadsRepository,
+    CreateLetterheadUseCase,
+    FindAllLetterheadsUseCase,
+    FindLetterheadUseCase,
+    UpdateLetterheadUseCase,
+    DeleteLetterheadUseCase,
+  ],
 })
 export class LetterheadsModule {}

--- a/ayunis-core-backend/src/domain/letterheads/presenters/http/dtos/create-letterhead.dto.ts
+++ b/ayunis-core-backend/src/domain/letterheads/presenters/http/dtos/create-letterhead.dto.ts
@@ -1,0 +1,40 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsNotEmpty, IsOptional, IsString, MaxLength } from 'class-validator';
+
+export class CreateLetterheadDto {
+  @ApiProperty({
+    description: 'Name of the letterhead',
+    example: 'Stadtverwaltung Musterstadt',
+  })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(200)
+  name: string;
+
+  @ApiPropertyOptional({
+    description: 'Description of the letterhead (used by AI for context)',
+    example: 'Offizielles Briefpapier der Stadtverwaltung',
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(1000)
+  description?: string;
+
+  // Margins arrive as JSON strings in multipart requests.
+  // Structural validation is handled by parseMargins() in the controller.
+  @ApiProperty({
+    type: String,
+    description: 'JSON string of { top, bottom, left, right } margins in mm',
+  })
+  @IsString()
+  @IsNotEmpty()
+  firstPageMargins: string;
+
+  @ApiProperty({
+    type: String,
+    description: 'JSON string of { top, bottom, left, right } margins in mm',
+  })
+  @IsString()
+  @IsNotEmpty()
+  continuationPageMargins: string;
+}

--- a/ayunis-core-backend/src/domain/letterheads/presenters/http/dtos/letterhead-response.dto.ts
+++ b/ayunis-core-backend/src/domain/letterheads/presenters/http/dtos/letterhead-response.dto.ts
@@ -1,0 +1,53 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { PageMarginsDto } from './page-margins.dto';
+
+export class LetterheadResponseDto {
+  @ApiProperty({
+    description: 'Unique identifier of the letterhead',
+    example: '123e4567-e89b-12d3-a456-426614174000',
+  })
+  id: string;
+
+  @ApiProperty({
+    description: 'Name of the letterhead',
+    example: 'Stadtverwaltung Musterstadt',
+  })
+  name: string;
+
+  @ApiPropertyOptional({
+    type: String,
+    description: 'Description of the letterhead',
+    example: 'Offizielles Briefpapier der Stadtverwaltung',
+    nullable: true,
+  })
+  description: string | null;
+
+  @ApiProperty({
+    description: 'Margins for the first page in mm',
+    type: PageMarginsDto,
+  })
+  firstPageMargins: PageMarginsDto;
+
+  @ApiProperty({
+    description: 'Margins for continuation pages in mm',
+    type: PageMarginsDto,
+  })
+  continuationPageMargins: PageMarginsDto;
+
+  @ApiProperty({
+    description: 'Whether a continuation page PDF is configured',
+  })
+  hasContinuationPage: boolean;
+
+  @ApiProperty({
+    description: 'When the letterhead was created',
+    example: '2026-01-15T10:00:00.000Z',
+  })
+  createdAt: string;
+
+  @ApiProperty({
+    description: 'When the letterhead was last updated',
+    example: '2026-01-15T10:30:00.000Z',
+  })
+  updatedAt: string;
+}

--- a/ayunis-core-backend/src/domain/letterheads/presenters/http/dtos/page-margins.dto.ts
+++ b/ayunis-core-backend/src/domain/letterheads/presenters/http/dtos/page-margins.dto.ts
@@ -1,0 +1,24 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNumber, Min } from 'class-validator';
+
+export class PageMarginsDto {
+  @ApiProperty({ description: 'Top margin in mm', example: 55 })
+  @IsNumber()
+  @Min(0)
+  top: number;
+
+  @ApiProperty({ description: 'Bottom margin in mm', example: 20 })
+  @IsNumber()
+  @Min(0)
+  bottom: number;
+
+  @ApiProperty({ description: 'Left margin in mm', example: 25 })
+  @IsNumber()
+  @Min(0)
+  left: number;
+
+  @ApiProperty({ description: 'Right margin in mm', example: 15 })
+  @IsNumber()
+  @Min(0)
+  right: number;
+}

--- a/ayunis-core-backend/src/domain/letterheads/presenters/http/dtos/update-letterhead.dto.ts
+++ b/ayunis-core-backend/src/domain/letterheads/presenters/http/dtos/update-letterhead.dto.ts
@@ -1,0 +1,46 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsOptional, IsString, MaxLength } from 'class-validator';
+
+export class UpdateLetterheadDto {
+  @ApiPropertyOptional({
+    description: 'Name of the letterhead',
+    example: 'Stadtverwaltung Musterstadt — Neues Design',
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(200)
+  name?: string;
+
+  @ApiPropertyOptional({
+    description: 'Description of the letterhead',
+    example: 'Überarbeitetes Briefpapier 2026',
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(1000)
+  description?: string;
+
+  // Margins arrive as JSON strings in multipart requests.
+  // Validation is handled by parseMargins() in the controller.
+  @ApiPropertyOptional({
+    type: String,
+    description: 'JSON string of { top, bottom, left, right } margins in mm',
+  })
+  @IsOptional()
+  firstPageMargins?: string;
+
+  @ApiPropertyOptional({
+    type: String,
+    description: 'JSON string of { top, bottom, left, right } margins in mm',
+  })
+  @IsOptional()
+  continuationPageMargins?: string;
+
+  @ApiPropertyOptional({
+    type: String,
+    description:
+      'Set to "true" to remove the continuation page PDF. Ignored if a new continuationPagePdf file is uploaded.',
+  })
+  @IsOptional()
+  removeContinuationPage?: string;
+}

--- a/ayunis-core-backend/src/domain/letterheads/presenters/http/letterheads.controller.ts
+++ b/ayunis-core-backend/src/domain/letterheads/presenters/http/letterheads.controller.ts
@@ -1,0 +1,273 @@
+import {
+  Controller,
+  Post,
+  Get,
+  Patch,
+  Delete,
+  Param,
+  Body,
+  ParseUUIDPipe,
+  Logger,
+  UseInterceptors,
+  UploadedFiles,
+  BadRequestException,
+  HttpCode,
+  HttpStatus,
+} from '@nestjs/common';
+import { FileFieldsInterceptor } from '@nestjs/platform-express';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiParam,
+  ApiConsumes,
+} from '@nestjs/swagger';
+import type { UUID } from 'crypto';
+import { Roles } from 'src/iam/authorization/application/decorators/roles.decorator';
+import { UserRole } from 'src/iam/users/domain/value-objects/role.object';
+import { CreateLetterheadUseCase } from '../../application/use-cases/create-letterhead/create-letterhead.use-case';
+import { FindAllLetterheadsUseCase } from '../../application/use-cases/find-all-letterheads/find-all-letterheads.use-case';
+import { FindLetterheadUseCase } from '../../application/use-cases/find-letterhead/find-letterhead.use-case';
+import { UpdateLetterheadUseCase } from '../../application/use-cases/update-letterhead/update-letterhead.use-case';
+import { DeleteLetterheadUseCase } from '../../application/use-cases/delete-letterhead/delete-letterhead.use-case';
+import { CreateLetterheadCommand } from '../../application/use-cases/create-letterhead/create-letterhead.command';
+import { FindLetterheadQuery } from '../../application/use-cases/find-letterhead/find-letterhead.query';
+import { UpdateLetterheadCommand } from '../../application/use-cases/update-letterhead/update-letterhead.command';
+import { DeleteLetterheadCommand } from '../../application/use-cases/delete-letterhead/delete-letterhead.command';
+import { CreateLetterheadDto } from './dtos/create-letterhead.dto';
+import { UpdateLetterheadDto } from './dtos/update-letterhead.dto';
+import { LetterheadResponseDto } from './dtos/letterhead-response.dto';
+import { LetterheadDtoMapper } from './mappers/letterhead-dto.mapper';
+import type { PageMargins } from '../../domain/value-objects/page-margins';
+
+const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5 MB
+
+interface UploadedFileFields {
+  firstPagePdf?: Express.Multer.File[];
+  continuationPagePdf?: Express.Multer.File[];
+}
+
+interface MarginsInput {
+  top?: unknown;
+  bottom?: unknown;
+  left?: unknown;
+  right?: unknown;
+}
+
+const MARGIN_KEYS: ReadonlyArray<keyof PageMargins> = [
+  'top',
+  'bottom',
+  'left',
+  'right',
+];
+
+function parseMargins(value: unknown, label: string): PageMargins {
+  if (!value) {
+    return { top: 20, bottom: 20, left: 20, right: 20 };
+  }
+
+  let parsed: MarginsInput;
+  try {
+    parsed =
+      typeof value === 'string'
+        ? (JSON.parse(value) as MarginsInput)
+        : (value as MarginsInput);
+  } catch {
+    throw new BadRequestException(
+      `Invalid ${label}: must be a JSON object with top, bottom, left, right`,
+    );
+  }
+
+  const margins: Record<string, number> = {};
+  for (const key of MARGIN_KEYS) {
+    const num = Number(parsed[key]);
+    if (!Number.isFinite(num) || num < 0) {
+      throw new BadRequestException(
+        `Invalid ${label}: '${key}' must be a finite non-negative number, got '${String(parsed[key])}'`,
+      );
+    }
+    margins[key] = num;
+  }
+
+  return margins as unknown as PageMargins;
+}
+
+@ApiTags('letterheads')
+@Controller('letterheads')
+export class LetterheadsController {
+  private readonly logger = new Logger(LetterheadsController.name);
+
+  constructor(
+    private readonly createLetterheadUseCase: CreateLetterheadUseCase,
+    private readonly findAllLetterheadsUseCase: FindAllLetterheadsUseCase,
+    private readonly findLetterheadUseCase: FindLetterheadUseCase,
+    private readonly updateLetterheadUseCase: UpdateLetterheadUseCase,
+    private readonly deleteLetterheadUseCase: DeleteLetterheadUseCase,
+    private readonly letterheadDtoMapper: LetterheadDtoMapper,
+  ) {}
+
+  @Post()
+  @Roles(UserRole.ADMIN)
+  @UseInterceptors(
+    FileFieldsInterceptor(
+      [
+        { name: 'firstPagePdf', maxCount: 1 },
+        { name: 'continuationPagePdf', maxCount: 1 },
+      ],
+      { limits: { fileSize: MAX_FILE_SIZE } },
+    ),
+  )
+  @ApiOperation({ summary: 'Create a new letterhead' })
+  @ApiConsumes('multipart/form-data')
+  @ApiResponse({
+    status: 201,
+    description: 'The letterhead has been created',
+    type: LetterheadResponseDto,
+  })
+  @ApiResponse({ status: 400, description: 'Invalid input data' })
+  async create(
+    @Body() dto: CreateLetterheadDto,
+    @UploadedFiles() files: UploadedFileFields,
+  ): Promise<LetterheadResponseDto> {
+    this.logger.log('create', { name: dto.name });
+
+    const firstPageFile = files?.firstPagePdf?.[0];
+    if (!firstPageFile) {
+      throw new BadRequestException('First page PDF file is required');
+    }
+
+    const firstPageMargins = parseMargins(
+      dto.firstPageMargins,
+      'firstPageMargins',
+    );
+    const continuationPageMargins = parseMargins(
+      dto.continuationPageMargins,
+      'continuationPageMargins',
+    );
+
+    const letterhead = await this.createLetterheadUseCase.execute(
+      new CreateLetterheadCommand({
+        name: dto.name,
+        description: dto.description,
+        firstPagePdfBuffer: firstPageFile.buffer,
+        continuationPagePdfBuffer:
+          files?.continuationPagePdf?.[0]?.buffer ?? null,
+        firstPageMargins,
+        continuationPageMargins,
+      }),
+    );
+    return this.letterheadDtoMapper.toDto(letterhead);
+  }
+
+  @Get()
+  @ApiOperation({ summary: 'List all letterheads for the current org' })
+  @ApiResponse({
+    status: 200,
+    description: 'List of letterheads',
+    type: [LetterheadResponseDto],
+  })
+  async findAll(): Promise<LetterheadResponseDto[]> {
+    this.logger.log('findAll');
+    const letterheads = await this.findAllLetterheadsUseCase.execute();
+    return letterheads.map((l) => this.letterheadDtoMapper.toDto(l));
+  }
+
+  @Get(':id')
+  @ApiOperation({ summary: 'Get a letterhead by ID' })
+  @ApiParam({
+    name: 'id',
+    description: 'The UUID of the letterhead',
+    type: 'string',
+    format: 'uuid',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'The letterhead',
+    type: LetterheadResponseDto,
+  })
+  @ApiResponse({ status: 404, description: 'Letterhead not found' })
+  async findOne(
+    @Param('id', ParseUUIDPipe) id: UUID,
+  ): Promise<LetterheadResponseDto> {
+    this.logger.log('findOne', { id });
+    const letterhead = await this.findLetterheadUseCase.execute(
+      new FindLetterheadQuery({ letterheadId: id }),
+    );
+    return this.letterheadDtoMapper.toDto(letterhead);
+  }
+
+  @Patch(':id')
+  @Roles(UserRole.ADMIN)
+  @UseInterceptors(
+    FileFieldsInterceptor(
+      [
+        { name: 'firstPagePdf', maxCount: 1 },
+        { name: 'continuationPagePdf', maxCount: 1 },
+      ],
+      { limits: { fileSize: MAX_FILE_SIZE } },
+    ),
+  )
+  @ApiOperation({ summary: 'Update a letterhead' })
+  @ApiConsumes('multipart/form-data')
+  @ApiParam({
+    name: 'id',
+    description: 'The UUID of the letterhead',
+    type: 'string',
+    format: 'uuid',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'The updated letterhead',
+    type: LetterheadResponseDto,
+  })
+  @ApiResponse({ status: 404, description: 'Letterhead not found' })
+  async update(
+    @Param('id', ParseUUIDPipe) id: UUID,
+    @Body() dto: UpdateLetterheadDto,
+    @UploadedFiles() files: UploadedFileFields,
+  ): Promise<LetterheadResponseDto> {
+    this.logger.log('update', { id });
+
+    const firstPageMargins = dto.firstPageMargins
+      ? parseMargins(dto.firstPageMargins, 'firstPageMargins')
+      : undefined;
+    const continuationPageMargins = dto.continuationPageMargins
+      ? parseMargins(dto.continuationPageMargins, 'continuationPageMargins')
+      : undefined;
+
+    const removeContinuationPage = dto.removeContinuationPage === 'true';
+
+    const letterhead = await this.updateLetterheadUseCase.execute(
+      new UpdateLetterheadCommand({
+        letterheadId: id,
+        name: dto.name,
+        description: dto.description,
+        firstPagePdfBuffer: files?.firstPagePdf?.[0]?.buffer,
+        continuationPagePdfBuffer: files?.continuationPagePdf?.[0]?.buffer,
+        removeContinuationPage,
+        firstPageMargins,
+        continuationPageMargins,
+      }),
+    );
+    return this.letterheadDtoMapper.toDto(letterhead);
+  }
+
+  @Delete(':id')
+  @Roles(UserRole.ADMIN)
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({ summary: 'Delete a letterhead' })
+  @ApiParam({
+    name: 'id',
+    description: 'The UUID of the letterhead',
+    type: 'string',
+    format: 'uuid',
+  })
+  @ApiResponse({ status: 204, description: 'Letterhead deleted' })
+  @ApiResponse({ status: 404, description: 'Letterhead not found' })
+  async remove(@Param('id', ParseUUIDPipe) id: UUID): Promise<void> {
+    this.logger.log('delete', { id });
+    await this.deleteLetterheadUseCase.execute(
+      new DeleteLetterheadCommand({ letterheadId: id }),
+    );
+  }
+}

--- a/ayunis-core-backend/src/domain/letterheads/presenters/http/mappers/letterhead-dto.mapper.ts
+++ b/ayunis-core-backend/src/domain/letterheads/presenters/http/mappers/letterhead-dto.mapper.ts
@@ -1,0 +1,19 @@
+import { Injectable } from '@nestjs/common';
+import { Letterhead } from '../../../domain/letterhead.entity';
+import { LetterheadResponseDto } from '../dtos/letterhead-response.dto';
+
+@Injectable()
+export class LetterheadDtoMapper {
+  toDto(letterhead: Letterhead): LetterheadResponseDto {
+    const dto = new LetterheadResponseDto();
+    dto.id = letterhead.id;
+    dto.name = letterhead.name;
+    dto.description = letterhead.description;
+    dto.firstPageMargins = { ...letterhead.firstPageMargins };
+    dto.continuationPageMargins = { ...letterhead.continuationPageMargins };
+    dto.hasContinuationPage = letterhead.continuationPageStoragePath !== null;
+    dto.createdAt = letterhead.createdAt.toISOString();
+    dto.updatedAt = letterhead.updatedAt.toISOString();
+    return dto;
+  }
+}

--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
@@ -3577,6 +3577,63 @@ export interface TranscriptionResponseDto {
   text: string;
 }
 
+export interface CreateLetterheadDto {
+  /** Name of the letterhead */
+  name: string;
+  /** Description of the letterhead (used by AI for context) */
+  description?: string;
+  /** JSON string of { top, bottom, left, right } margins in mm */
+  firstPageMargins: string;
+  /** JSON string of { top, bottom, left, right } margins in mm */
+  continuationPageMargins: string;
+}
+
+export interface PageMarginsDto {
+  /** Top margin in mm */
+  top: number;
+  /** Bottom margin in mm */
+  bottom: number;
+  /** Left margin in mm */
+  left: number;
+  /** Right margin in mm */
+  right: number;
+}
+
+export interface LetterheadResponseDto {
+  /** Unique identifier of the letterhead */
+  id: string;
+  /** Name of the letterhead */
+  name: string;
+  /**
+   * Description of the letterhead
+   * @nullable
+   */
+  description?: string | null;
+  /** Margins for the first page in mm */
+  firstPageMargins: PageMarginsDto;
+  /** Margins for continuation pages in mm */
+  continuationPageMargins: PageMarginsDto;
+  /** Whether a continuation page PDF is configured */
+  hasContinuationPage: boolean;
+  /** When the letterhead was created */
+  createdAt: string;
+  /** When the letterhead was last updated */
+  updatedAt: string;
+}
+
+export interface UpdateLetterheadDto {
+  /** Name of the letterhead */
+  name?: string;
+  /** Description of the letterhead */
+  description?: string;
+  /** JSON string of { top, bottom, left, right } margins in mm */
+  firstPageMargins?: string;
+  /** JSON string of { top, bottom, left, right } margins in mm */
+  continuationPageMargins?: string;
+  /** Set to "true" to remove the continuation page PDF. Ignored if a new continuationPagePdf file is uploaded. */
+  removeContinuationPage?: string;
+}
+
 export interface LoginDto {
   /** Email address for authentication */
   email: string;

--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.ts
@@ -49,6 +49,7 @@ import type {
   CreateKnowledgeBaseDto,
   CreateKnowledgeBaseShareDto,
   CreateLanguageModelRequestDto,
+  CreateLetterheadDto,
   CreateOrgRequestDto,
   CreatePermittedModelDto,
   CreatePredefinedIntegrationDto,
@@ -87,6 +88,7 @@ import type {
   KnowledgeBaseResponseDto,
   KnowledgeBasesControllerAddDocumentBody,
   LanguageModelResponseDto,
+  LetterheadResponseDto,
   LoginDto,
   MarketplaceIntegrationResponseDto,
   MarketplaceSkillResponseDto,
@@ -162,6 +164,7 @@ import type {
   UpdateIpAllowlistRequestDto,
   UpdateKnowledgeBaseDto,
   UpdateLanguageModelRequestDto,
+  UpdateLetterheadDto,
   UpdateMcpIntegrationDto,
   UpdatePasswordDto,
   UpdatePermittedModelDto,
@@ -15218,6 +15221,407 @@ export const useTranscriptionsControllerTranscribe = <TError = void,
       > => {
 
       const mutationOptions = getTranscriptionsControllerTranscribeMutationOptions(options);
+
+      return useMutation(mutationOptions, queryClient);
+    }
+    
+/**
+ * @summary Create a new letterhead
+ */
+export const letterheadsControllerCreate = (
+    createLetterheadDto: CreateLetterheadDto,
+ signal?: AbortSignal
+) => {
+      
+      const formData = new FormData();
+formData.append(`name`, createLetterheadDto.name)
+if(createLetterheadDto.description !== undefined) {
+ formData.append(`description`, createLetterheadDto.description)
+ }
+formData.append(`firstPageMargins`, createLetterheadDto.firstPageMargins)
+formData.append(`continuationPageMargins`, createLetterheadDto.continuationPageMargins)
+
+      return customAxiosInstance<LetterheadResponseDto>(
+      {url: `/letterheads`, method: 'POST',
+      headers: {'Content-Type': 'multipart/form-data', },
+       data: formData, signal
+    },
+      );
+    }
+  
+
+
+export const getLetterheadsControllerCreateMutationOptions = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof letterheadsControllerCreate>>, TError,{data: CreateLetterheadDto}, TContext>, }
+): UseMutationOptions<Awaited<ReturnType<typeof letterheadsControllerCreate>>, TError,{data: CreateLetterheadDto}, TContext> => {
+
+const mutationKey = ['letterheadsControllerCreate'];
+const {mutation: mutationOptions} = options ?
+      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
+      options
+      : {...options, mutation: {...options.mutation, mutationKey}}
+      : {mutation: { mutationKey, }};
+
+      
+
+
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof letterheadsControllerCreate>>, {data: CreateLetterheadDto}> = (props) => {
+          const {data} = props ?? {};
+
+          return  letterheadsControllerCreate(data,)
+        }
+
+        
+
+
+  return  { mutationFn, ...mutationOptions }}
+
+    export type LetterheadsControllerCreateMutationResult = NonNullable<Awaited<ReturnType<typeof letterheadsControllerCreate>>>
+    export type LetterheadsControllerCreateMutationBody = CreateLetterheadDto
+    export type LetterheadsControllerCreateMutationError = void
+
+    /**
+ * @summary Create a new letterhead
+ */
+export const useLetterheadsControllerCreate = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof letterheadsControllerCreate>>, TError,{data: CreateLetterheadDto}, TContext>, }
+ , queryClient?: QueryClient): UseMutationResult<
+        Awaited<ReturnType<typeof letterheadsControllerCreate>>,
+        TError,
+        {data: CreateLetterheadDto},
+        TContext
+      > => {
+
+      const mutationOptions = getLetterheadsControllerCreateMutationOptions(options);
+
+      return useMutation(mutationOptions, queryClient);
+    }
+    
+/**
+ * @summary List all letterheads for the current org
+ */
+export const letterheadsControllerFindAll = (
+    
+ signal?: AbortSignal
+) => {
+      
+      
+      return customAxiosInstance<LetterheadResponseDto[]>(
+      {url: `/letterheads`, method: 'GET', signal
+    },
+      );
+    }
+  
+
+
+
+export const getLetterheadsControllerFindAllQueryKey = () => {
+    return [
+    `/letterheads`
+    ] as const;
+    }
+
+    
+export const getLetterheadsControllerFindAllQueryOptions = <TData = Awaited<ReturnType<typeof letterheadsControllerFindAll>>, TError = unknown>( options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof letterheadsControllerFindAll>>, TError, TData>>, }
+) => {
+
+const {query: queryOptions} = options ?? {};
+
+  const queryKey =  queryOptions?.queryKey ?? getLetterheadsControllerFindAllQueryKey();
+
+  
+
+    const queryFn: QueryFunction<Awaited<ReturnType<typeof letterheadsControllerFindAll>>> = ({ signal }) => letterheadsControllerFindAll(signal);
+
+      
+
+      
+
+   return  { queryKey, queryFn, ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof letterheadsControllerFindAll>>, TError, TData> & { queryKey: DataTag<QueryKey, TData, TError> }
+}
+
+export type LetterheadsControllerFindAllQueryResult = NonNullable<Awaited<ReturnType<typeof letterheadsControllerFindAll>>>
+export type LetterheadsControllerFindAllQueryError = unknown
+
+
+export function useLetterheadsControllerFindAll<TData = Awaited<ReturnType<typeof letterheadsControllerFindAll>>, TError = unknown>(
+  options: { query:Partial<UseQueryOptions<Awaited<ReturnType<typeof letterheadsControllerFindAll>>, TError, TData>> & Pick<
+        DefinedInitialDataOptions<
+          Awaited<ReturnType<typeof letterheadsControllerFindAll>>,
+          TError,
+          Awaited<ReturnType<typeof letterheadsControllerFindAll>>
+        > , 'initialData'
+      >, }
+ , queryClient?: QueryClient
+  ):  DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useLetterheadsControllerFindAll<TData = Awaited<ReturnType<typeof letterheadsControllerFindAll>>, TError = unknown>(
+  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof letterheadsControllerFindAll>>, TError, TData>> & Pick<
+        UndefinedInitialDataOptions<
+          Awaited<ReturnType<typeof letterheadsControllerFindAll>>,
+          TError,
+          Awaited<ReturnType<typeof letterheadsControllerFindAll>>
+        > , 'initialData'
+      >, }
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useLetterheadsControllerFindAll<TData = Awaited<ReturnType<typeof letterheadsControllerFindAll>>, TError = unknown>(
+  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof letterheadsControllerFindAll>>, TError, TData>>, }
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+/**
+ * @summary List all letterheads for the current org
+ */
+
+export function useLetterheadsControllerFindAll<TData = Awaited<ReturnType<typeof letterheadsControllerFindAll>>, TError = unknown>(
+  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof letterheadsControllerFindAll>>, TError, TData>>, }
+ , queryClient?: QueryClient 
+ ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
+
+  const queryOptions = getLetterheadsControllerFindAllQueryOptions(options)
+
+  const query = useQuery(queryOptions, queryClient) as  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+
+  query.queryKey = queryOptions.queryKey ;
+
+  return query;
+}
+
+
+
+
+
+/**
+ * @summary Get a letterhead by ID
+ */
+export const letterheadsControllerFindOne = (
+    id: string,
+ signal?: AbortSignal
+) => {
+      
+      
+      return customAxiosInstance<LetterheadResponseDto>(
+      {url: `/letterheads/${id}`, method: 'GET', signal
+    },
+      );
+    }
+  
+
+
+
+export const getLetterheadsControllerFindOneQueryKey = (id?: string,) => {
+    return [
+    `/letterheads/${id}`
+    ] as const;
+    }
+
+    
+export const getLetterheadsControllerFindOneQueryOptions = <TData = Awaited<ReturnType<typeof letterheadsControllerFindOne>>, TError = void>(id: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof letterheadsControllerFindOne>>, TError, TData>>, }
+) => {
+
+const {query: queryOptions} = options ?? {};
+
+  const queryKey =  queryOptions?.queryKey ?? getLetterheadsControllerFindOneQueryKey(id);
+
+  
+
+    const queryFn: QueryFunction<Awaited<ReturnType<typeof letterheadsControllerFindOne>>> = ({ signal }) => letterheadsControllerFindOne(id, signal);
+
+      
+
+      
+
+   return  { queryKey, queryFn, enabled: !!(id), ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof letterheadsControllerFindOne>>, TError, TData> & { queryKey: DataTag<QueryKey, TData, TError> }
+}
+
+export type LetterheadsControllerFindOneQueryResult = NonNullable<Awaited<ReturnType<typeof letterheadsControllerFindOne>>>
+export type LetterheadsControllerFindOneQueryError = void
+
+
+export function useLetterheadsControllerFindOne<TData = Awaited<ReturnType<typeof letterheadsControllerFindOne>>, TError = void>(
+ id: string, options: { query:Partial<UseQueryOptions<Awaited<ReturnType<typeof letterheadsControllerFindOne>>, TError, TData>> & Pick<
+        DefinedInitialDataOptions<
+          Awaited<ReturnType<typeof letterheadsControllerFindOne>>,
+          TError,
+          Awaited<ReturnType<typeof letterheadsControllerFindOne>>
+        > , 'initialData'
+      >, }
+ , queryClient?: QueryClient
+  ):  DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useLetterheadsControllerFindOne<TData = Awaited<ReturnType<typeof letterheadsControllerFindOne>>, TError = void>(
+ id: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof letterheadsControllerFindOne>>, TError, TData>> & Pick<
+        UndefinedInitialDataOptions<
+          Awaited<ReturnType<typeof letterheadsControllerFindOne>>,
+          TError,
+          Awaited<ReturnType<typeof letterheadsControllerFindOne>>
+        > , 'initialData'
+      >, }
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useLetterheadsControllerFindOne<TData = Awaited<ReturnType<typeof letterheadsControllerFindOne>>, TError = void>(
+ id: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof letterheadsControllerFindOne>>, TError, TData>>, }
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+/**
+ * @summary Get a letterhead by ID
+ */
+
+export function useLetterheadsControllerFindOne<TData = Awaited<ReturnType<typeof letterheadsControllerFindOne>>, TError = void>(
+ id: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof letterheadsControllerFindOne>>, TError, TData>>, }
+ , queryClient?: QueryClient 
+ ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
+
+  const queryOptions = getLetterheadsControllerFindOneQueryOptions(id,options)
+
+  const query = useQuery(queryOptions, queryClient) as  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+
+  query.queryKey = queryOptions.queryKey ;
+
+  return query;
+}
+
+
+
+
+
+/**
+ * @summary Update a letterhead
+ */
+export const letterheadsControllerUpdate = (
+    id: string,
+    updateLetterheadDto: UpdateLetterheadDto,
+ ) => {
+      
+      const formData = new FormData();
+if(updateLetterheadDto.name !== undefined) {
+ formData.append(`name`, updateLetterheadDto.name)
+ }
+if(updateLetterheadDto.description !== undefined) {
+ formData.append(`description`, updateLetterheadDto.description)
+ }
+if(updateLetterheadDto.firstPageMargins !== undefined) {
+ formData.append(`firstPageMargins`, updateLetterheadDto.firstPageMargins)
+ }
+if(updateLetterheadDto.continuationPageMargins !== undefined) {
+ formData.append(`continuationPageMargins`, updateLetterheadDto.continuationPageMargins)
+ }
+if(updateLetterheadDto.removeContinuationPage !== undefined) {
+ formData.append(`removeContinuationPage`, updateLetterheadDto.removeContinuationPage)
+ }
+
+      return customAxiosInstance<LetterheadResponseDto>(
+      {url: `/letterheads/${id}`, method: 'PATCH',
+      headers: {'Content-Type': 'multipart/form-data', },
+       data: formData
+    },
+      );
+    }
+  
+
+
+export const getLetterheadsControllerUpdateMutationOptions = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof letterheadsControllerUpdate>>, TError,{id: string;data: UpdateLetterheadDto}, TContext>, }
+): UseMutationOptions<Awaited<ReturnType<typeof letterheadsControllerUpdate>>, TError,{id: string;data: UpdateLetterheadDto}, TContext> => {
+
+const mutationKey = ['letterheadsControllerUpdate'];
+const {mutation: mutationOptions} = options ?
+      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
+      options
+      : {...options, mutation: {...options.mutation, mutationKey}}
+      : {mutation: { mutationKey, }};
+
+      
+
+
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof letterheadsControllerUpdate>>, {id: string;data: UpdateLetterheadDto}> = (props) => {
+          const {id,data} = props ?? {};
+
+          return  letterheadsControllerUpdate(id,data,)
+        }
+
+        
+
+
+  return  { mutationFn, ...mutationOptions }}
+
+    export type LetterheadsControllerUpdateMutationResult = NonNullable<Awaited<ReturnType<typeof letterheadsControllerUpdate>>>
+    export type LetterheadsControllerUpdateMutationBody = UpdateLetterheadDto
+    export type LetterheadsControllerUpdateMutationError = void
+
+    /**
+ * @summary Update a letterhead
+ */
+export const useLetterheadsControllerUpdate = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof letterheadsControllerUpdate>>, TError,{id: string;data: UpdateLetterheadDto}, TContext>, }
+ , queryClient?: QueryClient): UseMutationResult<
+        Awaited<ReturnType<typeof letterheadsControllerUpdate>>,
+        TError,
+        {id: string;data: UpdateLetterheadDto},
+        TContext
+      > => {
+
+      const mutationOptions = getLetterheadsControllerUpdateMutationOptions(options);
+
+      return useMutation(mutationOptions, queryClient);
+    }
+    
+/**
+ * @summary Delete a letterhead
+ */
+export const letterheadsControllerRemove = (
+    id: string,
+ ) => {
+      
+      
+      return customAxiosInstance<void>(
+      {url: `/letterheads/${id}`, method: 'DELETE'
+    },
+      );
+    }
+  
+
+
+export const getLetterheadsControllerRemoveMutationOptions = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof letterheadsControllerRemove>>, TError,{id: string}, TContext>, }
+): UseMutationOptions<Awaited<ReturnType<typeof letterheadsControllerRemove>>, TError,{id: string}, TContext> => {
+
+const mutationKey = ['letterheadsControllerRemove'];
+const {mutation: mutationOptions} = options ?
+      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
+      options
+      : {...options, mutation: {...options.mutation, mutationKey}}
+      : {mutation: { mutationKey, }};
+
+      
+
+
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof letterheadsControllerRemove>>, {id: string}> = (props) => {
+          const {id} = props ?? {};
+
+          return  letterheadsControllerRemove(id,)
+        }
+
+        
+
+
+  return  { mutationFn, ...mutationOptions }}
+
+    export type LetterheadsControllerRemoveMutationResult = NonNullable<Awaited<ReturnType<typeof letterheadsControllerRemove>>>
+    
+    export type LetterheadsControllerRemoveMutationError = void
+
+    /**
+ * @summary Delete a letterhead
+ */
+export const useLetterheadsControllerRemove = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof letterheadsControllerRemove>>, TError,{id: string}, TContext>, }
+ , queryClient?: QueryClient): UseMutationResult<
+        Awaited<ReturnType<typeof letterheadsControllerRemove>>,
+        TError,
+        {id: string},
+        TContext
+      > => {
+
+      const mutationOptions = getLetterheadsControllerRemoveMutationOptions(options);
 
       return useMutation(mutationOptions, queryClient);
     }

--- a/ayunis-core-frontend/src/shared/api/openapi-schema.json
+++ b/ayunis-core-frontend/src/shared/api/openapi-schema.json
@@ -7999,6 +7999,171 @@
         ]
       }
     },
+    "/letterheads": {
+      "post": {
+        "operationId": "LetterheadsController_create",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateLetterheadDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "The letterhead has been created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LetterheadResponseDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid input data"
+          }
+        },
+        "summary": "Create a new letterhead",
+        "tags": [
+          "letterheads"
+        ]
+      },
+      "get": {
+        "operationId": "LetterheadsController_findAll",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "List of letterheads",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/LetterheadResponseDto"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "summary": "List all letterheads for the current org",
+        "tags": [
+          "letterheads"
+        ]
+      }
+    },
+    "/letterheads/{id}": {
+      "get": {
+        "operationId": "LetterheadsController_findOne",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "description": "The UUID of the letterhead",
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The letterhead",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LetterheadResponseDto"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Letterhead not found"
+          }
+        },
+        "summary": "Get a letterhead by ID",
+        "tags": [
+          "letterheads"
+        ]
+      },
+      "patch": {
+        "operationId": "LetterheadsController_update",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "description": "The UUID of the letterhead",
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateLetterheadDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The updated letterhead",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LetterheadResponseDto"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Letterhead not found"
+          }
+        },
+        "summary": "Update a letterhead",
+        "tags": [
+          "letterheads"
+        ]
+      },
+      "delete": {
+        "operationId": "LetterheadsController_remove",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "description": "The UUID of the letterhead",
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Letterhead deleted"
+          },
+          "404": {
+            "description": "Letterhead not found"
+          }
+        },
+        "summary": "Delete a letterhead",
+        "tags": [
+          "letterheads"
+        ]
+      }
+    },
     "/auth/login": {
       "post": {
         "description": "Authenticate user with email and password. Sets authentication cookies on successful login.",
@@ -14445,6 +14610,152 @@
         "required": [
           "text"
         ]
+      },
+      "CreateLetterheadDto": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Name of the letterhead",
+            "example": "Stadtverwaltung Musterstadt"
+          },
+          "description": {
+            "type": "string",
+            "description": "Description of the letterhead (used by AI for context)",
+            "example": "Offizielles Briefpapier der Stadtverwaltung"
+          },
+          "firstPageMargins": {
+            "type": "string",
+            "description": "JSON string of { top, bottom, left, right } margins in mm"
+          },
+          "continuationPageMargins": {
+            "type": "string",
+            "description": "JSON string of { top, bottom, left, right } margins in mm"
+          }
+        },
+        "required": [
+          "name",
+          "firstPageMargins",
+          "continuationPageMargins"
+        ]
+      },
+      "PageMarginsDto": {
+        "type": "object",
+        "properties": {
+          "top": {
+            "type": "number",
+            "description": "Top margin in mm",
+            "example": 55
+          },
+          "bottom": {
+            "type": "number",
+            "description": "Bottom margin in mm",
+            "example": 20
+          },
+          "left": {
+            "type": "number",
+            "description": "Left margin in mm",
+            "example": 25
+          },
+          "right": {
+            "type": "number",
+            "description": "Right margin in mm",
+            "example": 15
+          }
+        },
+        "required": [
+          "top",
+          "bottom",
+          "left",
+          "right"
+        ]
+      },
+      "LetterheadResponseDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Unique identifier of the letterhead",
+            "example": "123e4567-e89b-12d3-a456-426614174000"
+          },
+          "name": {
+            "type": "string",
+            "description": "Name of the letterhead",
+            "example": "Stadtverwaltung Musterstadt"
+          },
+          "description": {
+            "type": "string",
+            "description": "Description of the letterhead",
+            "example": "Offizielles Briefpapier der Stadtverwaltung",
+            "nullable": true
+          },
+          "firstPageMargins": {
+            "description": "Margins for the first page in mm",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PageMarginsDto"
+              }
+            ]
+          },
+          "continuationPageMargins": {
+            "description": "Margins for continuation pages in mm",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PageMarginsDto"
+              }
+            ]
+          },
+          "hasContinuationPage": {
+            "type": "boolean",
+            "description": "Whether a continuation page PDF is configured"
+          },
+          "createdAt": {
+            "type": "string",
+            "description": "When the letterhead was created",
+            "example": "2026-01-15T10:00:00.000Z"
+          },
+          "updatedAt": {
+            "type": "string",
+            "description": "When the letterhead was last updated",
+            "example": "2026-01-15T10:30:00.000Z"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "firstPageMargins",
+          "continuationPageMargins",
+          "hasContinuationPage",
+          "createdAt",
+          "updatedAt"
+        ]
+      },
+      "UpdateLetterheadDto": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Name of the letterhead",
+            "example": "Stadtverwaltung Musterstadt — Neues Design"
+          },
+          "description": {
+            "type": "string",
+            "description": "Description of the letterhead",
+            "example": "Überarbeitetes Briefpapier 2026"
+          },
+          "firstPageMargins": {
+            "type": "string",
+            "description": "JSON string of { top, bottom, left, right } margins in mm"
+          },
+          "continuationPageMargins": {
+            "type": "string",
+            "description": "JSON string of { top, bottom, left, right } margins in mm"
+          },
+          "removeContinuationPage": {
+            "type": "string",
+            "description": "Set to \"true\" to remove the continuation page PDF. Ignored if a new continuationPagePdf file is uploaded."
+          }
+        }
       },
       "LoginDto": {
         "type": "object",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces new org-scoped CRUD endpoints that upload/delete PDF files in storage, so mistakes could create orphaned objects or inconsistent DB/storage state. Changes are well-tested but touch request parsing (multipart + JSON margins) and error handling paths.
> 
> **Overview**
> Adds a new **Letterheads CRUD API** (`POST/GET/PATCH/DELETE /letterheads`) wired into `AppModule`, including multipart PDF upload support (5MB limit), admin-only write operations, and DTO mapping to a `LetterheadResponseDto`.
> 
> Implements create/update/delete use-cases that **validate uploaded PDFs are exactly one page** (via new `LetterheadPdfService` using `pdf-lib`), store files under `letterheads/{orgId}/{letterheadId}/...`, and coordinate storage uploads/deletes with repository persistence; adds `UnexpectedLetterheadError` for consistent 500s.
> 
> Updates the frontend generated OpenAPI client/types to include the new `letterheads` endpoints and schemas.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2cc0da45a2994f09f94123ea3b007d6525869caf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->