### PR TITLE
wip(AYC-101): add letterheadId to artifact entity, record, commands, DTOs, and migration

### DIFF
--- a/ayunis-core-backend/src/db/migrations/1773706000224-AddLetterheadIdToArtifacts.ts
+++ b/ayunis-core-backend/src/db/migrations/1773706000224-AddLetterheadIdToArtifacts.ts
@@ -1,0 +1,18 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddLetterheadIdToArtifacts1773706000224 implements MigrationInterface {
+    name = 'AddLetterheadIdToArtifacts1773706000224'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "artifacts" ADD "letterheadId" character varying`);
+        await queryRunner.query(`CREATE INDEX "IDX_ab4dde61f4eb04ba072c26a5a2" ON "artifacts" ("letterheadId") `);
+        await queryRunner.query(`ALTER TABLE "artifacts" ADD CONSTRAINT "FK_ab4dde61f4eb04ba072c26a5a2c" FOREIGN KEY ("letterheadId") REFERENCES "letterheads"("id") ON DELETE SET NULL ON UPDATE NO ACTION`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "artifacts" DROP CONSTRAINT "FK_ab4dde61f4eb04ba072c26a5a2c"`);
+        await queryRunner.query(`DROP INDEX "public"."IDX_ab4dde61f4eb04ba072c26a5a2"`);
+        await queryRunner.query(`ALTER TABLE "artifacts" DROP COLUMN "letterheadId"`);
+    }
+
+}

--- a/ayunis-core-backend/src/domain/artifacts/SUMMARY.md
+++ b/ayunis-core-backend/src/domain/artifacts/SUMMARY.md
@@ -56,6 +56,7 @@ artifacts/
 ## Dependencies
 
 - **ThreadsModule** — Imported for thread ownership validation when creating artifacts
+- **LetterheadsModule** — Imported for letterhead validation when creating or updating artifacts
 
 ## Ports
 

--- a/ayunis-core-backend/src/domain/artifacts/application/helpers/add-version-with-retry.ts
+++ b/ayunis-core-backend/src/domain/artifacts/application/helpers/add-version-with-retry.ts
@@ -1,4 +1,5 @@
 import type { Logger } from '@nestjs/common';
+import type { UUID } from 'crypto';
 import type { ArtifactsRepository } from '../ports/artifacts-repository.port';
 import type { ArtifactVersion } from '../../domain/artifact-version.entity';
 import { ArtifactVersionConflictError } from '../artifacts.errors';
@@ -15,15 +16,19 @@ export async function addVersionWithRetry(params: {
   repository: ArtifactsRepository;
   logger: Logger;
   artifactId: string;
-  buildVersion: () => Promise<ArtifactVersion>;
+  buildVersion: () => Promise<{
+    version: ArtifactVersion;
+    expectedCurrentVersionNumber: number;
+    letterheadId?: UUID | null;
+  }>;
 }): Promise<ArtifactVersion> {
   const { repository, logger, artifactId } = params;
 
   for (let attempt = 1; attempt <= MAX_VERSION_RETRIES; attempt++) {
-    const version = await params.buildVersion();
+    const updateParams = await params.buildVersion();
 
     try {
-      return await repository.addVersionAndUpdateCurrent(version);
+      return await repository.addVersionAndUpdateArtifact(updateParams);
     } catch (error) {
       if (
         error instanceof ArtifactVersionConflictError &&
@@ -31,7 +36,7 @@ export async function addVersionWithRetry(params: {
       ) {
         logger.warn(`Version conflict on attempt ${attempt}, retrying`, {
           artifactId,
-          versionNumber: version.versionNumber,
+          versionNumber: updateParams.version.versionNumber,
         });
         continue;
       }

--- a/ayunis-core-backend/src/domain/artifacts/application/ports/artifacts-repository.port.ts
+++ b/ayunis-core-backend/src/domain/artifacts/application/ports/artifacts-repository.port.ts
@@ -16,14 +16,17 @@ export abstract class ArtifactsRepository {
     versionNumber: number,
   ): Promise<void>;
   /**
-   * Atomically adds a version and updates the artifact's current version number.
+   * Atomically adds a version and updates the artifact row.
    * Each call runs in its own transaction so that a unique-constraint failure
    * does not poison the caller's transaction context.
    *
-   * @throws ArtifactVersionConflictError when the version number already exists.
+   * @throws ArtifactVersionConflictError when the version number already exists
+   * or when the artifact was concurrently modified.
    */
-  abstract addVersionAndUpdateCurrent(
-    version: ArtifactVersion,
-  ): Promise<ArtifactVersion>;
+  abstract addVersionAndUpdateArtifact(params: {
+    version: ArtifactVersion;
+    expectedCurrentVersionNumber: number;
+    letterheadId?: UUID | null;
+  }): Promise<ArtifactVersion>;
   abstract delete(id: UUID): Promise<void>;
 }

--- a/ayunis-core-backend/src/domain/artifacts/application/use-cases/apply-edits-to-artifact/apply-edits-to-artifact.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/artifacts/application/use-cases/apply-edits-to-artifact/apply-edits-to-artifact.use-case.spec.ts
@@ -36,7 +36,7 @@ describe('ApplyEditsToArtifactUseCase', () => {
       findByIdWithVersions: jest.fn(),
       addVersion: jest.fn(),
       updateCurrentVersionNumber: jest.fn(),
-      addVersionAndUpdateCurrent: jest.fn(),
+      addVersionAndUpdateArtifact: jest.fn(),
       delete: jest.fn(),
     };
 

--- a/ayunis-core-backend/src/domain/artifacts/application/use-cases/create-artifact/create-artifact.command.ts
+++ b/ayunis-core-backend/src/domain/artifacts/application/use-cases/create-artifact/create-artifact.command.ts
@@ -6,16 +6,19 @@ export class CreateArtifactCommand {
   readonly title: string;
   readonly content: string;
   readonly authorType: AuthorType;
+  readonly letterheadId?: UUID;
 
   constructor(params: {
     threadId: UUID;
     title: string;
     content: string;
     authorType: AuthorType;
+    letterheadId?: UUID;
   }) {
     this.threadId = params.threadId;
     this.title = params.title;
     this.content = params.content;
     this.authorType = params.authorType;
+    this.letterheadId = params.letterheadId;
   }
 }

--- a/ayunis-core-backend/src/domain/artifacts/application/use-cases/create-artifact/create-artifact.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/artifacts/application/use-cases/create-artifact/create-artifact.use-case.spec.ts
@@ -16,6 +16,8 @@ import { AuthorType } from '../../../domain/value-objects/author-type.enum';
 import { ContextService } from 'src/common/context/services/context.service';
 import { FindThreadUseCase } from 'src/domain/threads/application/use-cases/find-thread/find-thread.use-case';
 import { ThreadNotFoundError } from 'src/domain/threads/application/threads.errors';
+import { FindLetterheadUseCase } from 'src/domain/letterheads/application/use-cases/find-letterhead/find-letterhead.use-case';
+import { LetterheadNotFoundError } from 'src/domain/letterheads/application/letterheads.errors';
 import {
   ArtifactContentTooLargeError,
   ARTIFACT_MAX_CONTENT_LENGTH,
@@ -25,6 +27,7 @@ describe('CreateArtifactUseCase', () => {
   let useCase: CreateArtifactUseCase;
   let artifactsRepository: jest.Mocked<ArtifactsRepository>;
   let findThreadUseCase: jest.Mocked<FindThreadUseCase>;
+  let findLetterheadUseCase: jest.Mocked<FindLetterheadUseCase>;
 
   const mockUserId = '123e4567-e89b-12d3-a456-426614174000' as UUID;
   const mockThreadId = '223e4567-e89b-12d3-a456-426614174000' as UUID;
@@ -51,18 +54,27 @@ describe('CreateArtifactUseCase', () => {
       execute: jest.fn().mockResolvedValue({ thread: {}, isLongChat: false }),
     };
 
+    const mockFindLetterheadUseCase = {
+      execute: jest.fn().mockResolvedValue({}),
+    };
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         CreateArtifactUseCase,
         { provide: ArtifactsRepository, useValue: mockRepository },
         { provide: ContextService, useValue: mockContextService },
         { provide: FindThreadUseCase, useValue: mockFindThreadUseCase },
+        {
+          provide: FindLetterheadUseCase,
+          useValue: mockFindLetterheadUseCase,
+        },
       ],
     }).compile();
 
     useCase = module.get<CreateArtifactUseCase>(CreateArtifactUseCase);
     artifactsRepository = module.get(ArtifactsRepository);
     findThreadUseCase = module.get(FindThreadUseCase);
+    findLetterheadUseCase = module.get(FindLetterheadUseCase);
 
     jest.spyOn(Logger.prototype, 'log').mockImplementation();
   });
@@ -89,6 +101,7 @@ describe('CreateArtifactUseCase', () => {
     expect(result.title).toBe('Quarterly Budget Report');
     expect(result.threadId).toBe(mockThreadId);
     expect(result.userId).toBe(mockUserId);
+    expect(result.letterheadId).toBeNull();
     expect(result.currentVersionNumber).toBe(1);
     expect(result.versions).toHaveLength(1);
     expect(result.versions[0].versionNumber).toBe(1);
@@ -96,6 +109,28 @@ describe('CreateArtifactUseCase', () => {
       '<h1>Budget Report</h1><p>Q1 2026 expenses...</p>',
     );
     expect(result.versions[0].authorType).toBe(AuthorType.ASSISTANT);
+  });
+
+  it('should create an artifact with letterheadId when provided', async () => {
+    const mockLetterheadId =
+      '423e4567-e89b-12d3-a456-426614174000' as UUID;
+
+    const command = new CreateArtifactCommand({
+      threadId: mockThreadId,
+      title: 'Official Letter',
+      content: '<p>Dear Sir or Madam...</p>',
+      authorType: AuthorType.ASSISTANT,
+      letterheadId: mockLetterheadId,
+    });
+
+    artifactsRepository.create.mockImplementation(async (artifact) => artifact);
+    artifactsRepository.addVersion.mockImplementation(
+      async (version) => version,
+    );
+
+    const result = await useCase.execute(command);
+
+    expect(result.letterheadId).toBe(mockLetterheadId);
   });
 
   it('should set authorId to userId when author type is USER', async () => {
@@ -145,6 +180,10 @@ describe('CreateArtifactUseCase', () => {
         { provide: ArtifactsRepository, useValue: artifactsRepository },
         { provide: ContextService, useValue: mockContextService },
         { provide: FindThreadUseCase, useValue: findThreadUseCase },
+        {
+          provide: FindLetterheadUseCase,
+          useValue: findLetterheadUseCase,
+        },
       ],
     }).compile();
 
@@ -319,6 +358,70 @@ describe('CreateArtifactUseCase', () => {
     const result = await useCase.execute(command);
 
     expect(result.title).toBe('Maximum Size Document');
+  });
+
+  it('should validate letterheadId belongs to org when provided', async () => {
+    const mockLetterheadId =
+      '423e4567-e89b-12d3-a456-426614174000' as UUID;
+
+    const command = new CreateArtifactCommand({
+      threadId: mockThreadId,
+      title: 'Letter with Letterhead',
+      content: '<p>Official content</p>',
+      authorType: AuthorType.ASSISTANT,
+      letterheadId: mockLetterheadId,
+    });
+
+    artifactsRepository.create.mockImplementation(async (artifact) => artifact);
+    artifactsRepository.addVersion.mockImplementation(
+      async (version) => version,
+    );
+
+    await useCase.execute(command);
+
+    expect(findLetterheadUseCase.execute).toHaveBeenCalledWith(
+      expect.objectContaining({ letterheadId: mockLetterheadId }),
+    );
+  });
+
+  it('should throw LetterheadNotFoundError when letterheadId does not belong to org', async () => {
+    const crossOrgLetterheadId =
+      '523e4567-e89b-12d3-a456-426614174000' as UUID;
+
+    findLetterheadUseCase.execute.mockRejectedValue(
+      new LetterheadNotFoundError(crossOrgLetterheadId),
+    );
+
+    const command = new CreateArtifactCommand({
+      threadId: mockThreadId,
+      title: 'Cross-Org Letterhead Attempt',
+      content: '<p>Should not be created</p>',
+      authorType: AuthorType.ASSISTANT,
+      letterheadId: crossOrgLetterheadId,
+    });
+
+    await expect(useCase.execute(command)).rejects.toThrow(
+      LetterheadNotFoundError,
+    );
+    expect(artifactsRepository.create).not.toHaveBeenCalled();
+  });
+
+  it('should not validate letterheadId when not provided', async () => {
+    const command = new CreateArtifactCommand({
+      threadId: mockThreadId,
+      title: 'No Letterhead Document',
+      content: '<p>Content without letterhead</p>',
+      authorType: AuthorType.ASSISTANT,
+    });
+
+    artifactsRepository.create.mockImplementation(async (artifact) => artifact);
+    artifactsRepository.addVersion.mockImplementation(
+      async (version) => version,
+    );
+
+    await useCase.execute(command);
+
+    expect(findLetterheadUseCase.execute).not.toHaveBeenCalled();
   });
 
   it('should persist the artifact before adding the version', async () => {

--- a/ayunis-core-backend/src/domain/artifacts/application/use-cases/create-artifact/create-artifact.use-case.ts
+++ b/ayunis-core-backend/src/domain/artifacts/application/use-cases/create-artifact/create-artifact.use-case.ts
@@ -9,6 +9,8 @@ import { ContextService } from 'src/common/context/services/context.service';
 import { sanitizeHtmlContent } from '../../helpers/sanitize-html-content';
 import { FindThreadUseCase } from 'src/domain/threads/application/use-cases/find-thread/find-thread.use-case';
 import { FindThreadQuery } from 'src/domain/threads/application/use-cases/find-thread/find-thread.query';
+import { FindLetterheadUseCase } from 'src/domain/letterheads/application/use-cases/find-letterhead/find-letterhead.use-case';
+import { FindLetterheadQuery } from 'src/domain/letterheads/application/use-cases/find-letterhead/find-letterhead.query';
 import {
   ArtifactContentTooLargeError,
   UnexpectedArtifactError,
@@ -25,6 +27,7 @@ export class CreateArtifactUseCase {
     private readonly artifactsRepository: ArtifactsRepository,
     private readonly contextService: ContextService,
     private readonly findThreadUseCase: FindThreadUseCase,
+    private readonly findLetterheadUseCase: FindLetterheadUseCase,
   ) {}
 
   @Transactional()
@@ -48,10 +51,17 @@ export class CreateArtifactUseCase {
         new FindThreadQuery(command.threadId),
       );
 
+      if (command.letterheadId) {
+        await this.findLetterheadUseCase.execute(
+          new FindLetterheadQuery({ letterheadId: command.letterheadId }),
+        );
+      }
+
       const artifact = new Artifact({
         threadId: command.threadId,
         userId,
         title: command.title,
+        letterheadId: command.letterheadId ?? null,
         currentVersionNumber: 1,
       });
 

--- a/ayunis-core-backend/src/domain/artifacts/application/use-cases/revert-artifact/revert-artifact.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/artifacts/application/use-cases/revert-artifact/revert-artifact.use-case.spec.ts
@@ -52,7 +52,7 @@ describe('RevertArtifactUseCase', () => {
       findByIdWithVersions: jest.fn(),
       addVersion: jest.fn(),
       updateCurrentVersionNumber: jest.fn(),
-      addVersionAndUpdateCurrent: jest.fn(),
+      addVersionAndUpdateArtifact: jest.fn(),
       delete: jest.fn(),
     };
 
@@ -109,8 +109,8 @@ describe('RevertArtifactUseCase', () => {
     });
 
     artifactsRepository.findByIdWithVersions.mockResolvedValue(artifact);
-    artifactsRepository.addVersionAndUpdateCurrent.mockImplementation(
-      async (version) => version,
+    artifactsRepository.addVersionAndUpdateArtifact.mockImplementation(
+      async ({ version }) => version,
     );
 
     const command = new RevertArtifactCommand({
@@ -130,7 +130,7 @@ describe('RevertArtifactUseCase', () => {
     );
   });
 
-  it('should call addVersionAndUpdateCurrent with the reverted version', async () => {
+  it('should call addVersionAndUpdateArtifact with the reverted version', async () => {
     const versions = [
       new ArtifactVersion({
         artifactId: mockArtifactId,
@@ -157,8 +157,8 @@ describe('RevertArtifactUseCase', () => {
     });
 
     artifactsRepository.findByIdWithVersions.mockResolvedValue(artifact);
-    artifactsRepository.addVersionAndUpdateCurrent.mockImplementation(
-      async (version) => version,
+    artifactsRepository.addVersionAndUpdateArtifact.mockImplementation(
+      async ({ version }) => version,
     );
 
     const command = new RevertArtifactCommand({
@@ -169,12 +169,14 @@ describe('RevertArtifactUseCase', () => {
     await useCase.execute(command);
 
     expect(
-      artifactsRepository.addVersionAndUpdateCurrent,
+      artifactsRepository.addVersionAndUpdateArtifact,
     ).toHaveBeenCalledTimes(1);
-    const passedVersion =
-      artifactsRepository.addVersionAndUpdateCurrent.mock.calls[0][0];
-    expect(passedVersion.artifactId).toBe(mockArtifactId);
-    expect(passedVersion.versionNumber).toBe(3);
+    const passedParams =
+      artifactsRepository.addVersionAndUpdateArtifact.mock.calls[0][0];
+    expect(passedParams.version.artifactId).toBe(mockArtifactId);
+    expect(passedParams.version.versionNumber).toBe(3);
+    expect(passedParams.expectedCurrentVersionNumber).toBe(2);
+    expect(passedParams.letterheadId).toBeUndefined();
   });
 
   it('should throw ArtifactNotFoundError when artifact does not exist', async () => {
@@ -248,8 +250,8 @@ describe('RevertArtifactUseCase', () => {
     });
 
     artifactsRepository.findByIdWithVersions.mockResolvedValue(artifact);
-    artifactsRepository.addVersionAndUpdateCurrent.mockImplementation(
-      async (version) => version,
+    artifactsRepository.addVersionAndUpdateArtifact.mockImplementation(
+      async ({ version }) => version,
     );
 
     const command = new RevertArtifactCommand({
@@ -292,7 +294,7 @@ describe('RevertArtifactUseCase', () => {
   });
 
   describe('retry on version conflict', () => {
-    it('should retry and succeed when addVersionAndUpdateCurrent fails once with conflict', async () => {
+    it('should retry and succeed when addVersionAndUpdateArtifact fails once with conflict', async () => {
       const artifactV2 = new Artifact({
         id: mockArtifactId,
         threadId: mockThreadId,
@@ -324,9 +326,9 @@ describe('RevertArtifactUseCase', () => {
         .mockResolvedValueOnce(artifactV2)
         .mockResolvedValueOnce(artifactV3);
 
-      artifactsRepository.addVersionAndUpdateCurrent
+      artifactsRepository.addVersionAndUpdateArtifact
         .mockRejectedValueOnce(new ArtifactVersionConflictError(mockArtifactId))
-        .mockImplementationOnce(async (version) => version);
+        .mockImplementationOnce(async ({ version }) => version);
 
       const command = new RevertArtifactCommand({
         artifactId: mockArtifactId,
@@ -339,7 +341,7 @@ describe('RevertArtifactUseCase', () => {
       expect(result.content).toBe('<p>Original municipal plan</p>');
       expect(artifactsRepository.findByIdWithVersions).toHaveBeenCalledTimes(2);
       expect(
-        artifactsRepository.addVersionAndUpdateCurrent,
+        artifactsRepository.addVersionAndUpdateArtifact,
       ).toHaveBeenCalledTimes(2);
     });
 
@@ -354,7 +356,7 @@ describe('RevertArtifactUseCase', () => {
       });
 
       artifactsRepository.findByIdWithVersions.mockResolvedValue(artifact);
-      artifactsRepository.addVersionAndUpdateCurrent.mockRejectedValue(
+      artifactsRepository.addVersionAndUpdateArtifact.mockRejectedValue(
         new ArtifactVersionConflictError(mockArtifactId),
       );
 
@@ -369,7 +371,7 @@ describe('RevertArtifactUseCase', () => {
 
       expect(artifactsRepository.findByIdWithVersions).toHaveBeenCalledTimes(3);
       expect(
-        artifactsRepository.addVersionAndUpdateCurrent,
+        artifactsRepository.addVersionAndUpdateArtifact,
       ).toHaveBeenCalledTimes(3);
     });
 
@@ -384,7 +386,7 @@ describe('RevertArtifactUseCase', () => {
       });
 
       artifactsRepository.findByIdWithVersions.mockResolvedValue(artifact);
-      artifactsRepository.addVersionAndUpdateCurrent.mockRejectedValue(
+      artifactsRepository.addVersionAndUpdateArtifact.mockRejectedValue(
         new Error('Connection refused'),
       );
 
@@ -399,7 +401,7 @@ describe('RevertArtifactUseCase', () => {
 
       expect(artifactsRepository.findByIdWithVersions).toHaveBeenCalledTimes(1);
       expect(
-        artifactsRepository.addVersionAndUpdateCurrent,
+        artifactsRepository.addVersionAndUpdateArtifact,
       ).toHaveBeenCalledTimes(1);
     });
   });

--- a/ayunis-core-backend/src/domain/artifacts/application/use-cases/revert-artifact/revert-artifact.use-case.ts
+++ b/ayunis-core-backend/src/domain/artifacts/application/use-cases/revert-artifact/revert-artifact.use-case.ts
@@ -58,13 +58,16 @@ export class RevertArtifactUseCase {
             );
           }
 
-          return new ArtifactVersion({
-            artifactId: artifact.id,
-            versionNumber: artifact.currentVersionNumber + 1,
-            content: sanitizeHtmlContent(targetVersion.content),
-            authorType: AuthorType.USER,
-            authorId: userId,
-          });
+          return {
+            expectedCurrentVersionNumber: artifact.currentVersionNumber,
+            version: new ArtifactVersion({
+              artifactId: artifact.id,
+              versionNumber: artifact.currentVersionNumber + 1,
+              content: sanitizeHtmlContent(targetVersion.content),
+              authorType: AuthorType.USER,
+              authorId: userId,
+            }),
+          };
         },
       });
     } catch (error) {

--- a/ayunis-core-backend/src/domain/artifacts/application/use-cases/update-artifact/update-artifact.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/artifacts/application/use-cases/update-artifact/update-artifact.use-case.spec.ts
@@ -16,10 +16,13 @@ import {
 import { Artifact } from '../../../domain/artifact.entity';
 import { AuthorType } from '../../../domain/value-objects/author-type.enum';
 import { ContextService } from 'src/common/context/services/context.service';
+import { FindLetterheadUseCase } from 'src/domain/letterheads/application/use-cases/find-letterhead/find-letterhead.use-case';
+import { LetterheadNotFoundError } from 'src/domain/letterheads/application/letterheads.errors';
 
 describe('UpdateArtifactUseCase', () => {
   let useCase: UpdateArtifactUseCase;
   let artifactsRepository: jest.Mocked<ArtifactsRepository>;
+  let findLetterheadUseCase: jest.Mocked<FindLetterheadUseCase>;
 
   const mockUserId = '123e4567-e89b-12d3-a456-426614174000' as UUID;
   const mockArtifactId = '323e4567-e89b-12d3-a456-426614174000' as UUID;
@@ -33,7 +36,7 @@ describe('UpdateArtifactUseCase', () => {
       findByIdWithVersions: jest.fn(),
       addVersion: jest.fn(),
       updateCurrentVersionNumber: jest.fn(),
-      addVersionAndUpdateCurrent: jest.fn(),
+      addVersionAndUpdateArtifact: jest.fn(),
       delete: jest.fn(),
     };
 
@@ -44,16 +47,25 @@ describe('UpdateArtifactUseCase', () => {
       }),
     } as unknown as jest.Mocked<ContextService>;
 
+    const mockFindLetterheadUseCase = {
+      execute: jest.fn().mockResolvedValue({}),
+    };
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         UpdateArtifactUseCase,
         { provide: ArtifactsRepository, useValue: mockRepository },
         { provide: ContextService, useValue: mockContextService },
+        {
+          provide: FindLetterheadUseCase,
+          useValue: mockFindLetterheadUseCase,
+        },
       ],
     }).compile();
 
     useCase = module.get<UpdateArtifactUseCase>(UpdateArtifactUseCase);
     artifactsRepository = module.get(ArtifactsRepository);
+    findLetterheadUseCase = module.get(FindLetterheadUseCase);
 
     jest.spyOn(Logger.prototype, 'log').mockImplementation();
     jest.spyOn(Logger.prototype, 'warn').mockImplementation();
@@ -73,8 +85,8 @@ describe('UpdateArtifactUseCase', () => {
     });
 
     artifactsRepository.findById.mockResolvedValue(existingArtifact);
-    artifactsRepository.addVersionAndUpdateCurrent.mockImplementation(
-      async (version) => version,
+    artifactsRepository.addVersionAndUpdateArtifact.mockImplementation(
+      async ({ version }) => version,
     );
 
     const command = new UpdateArtifactCommand({
@@ -97,7 +109,7 @@ describe('UpdateArtifactUseCase', () => {
     );
   });
 
-  it('should call addVersionAndUpdateCurrent with the new version', async () => {
+  it('should call addVersionAndUpdateArtifact with the new version', async () => {
     const existingArtifact = new Artifact({
       id: mockArtifactId,
       threadId: mockThreadId,
@@ -107,8 +119,8 @@ describe('UpdateArtifactUseCase', () => {
     });
 
     artifactsRepository.findById.mockResolvedValue(existingArtifact);
-    artifactsRepository.addVersionAndUpdateCurrent.mockImplementation(
-      async (version) => version,
+    artifactsRepository.addVersionAndUpdateArtifact.mockImplementation(
+      async ({ version }) => version,
     );
 
     const command = new UpdateArtifactCommand({
@@ -120,12 +132,14 @@ describe('UpdateArtifactUseCase', () => {
     await useCase.execute(command);
 
     expect(
-      artifactsRepository.addVersionAndUpdateCurrent,
+      artifactsRepository.addVersionAndUpdateArtifact,
     ).toHaveBeenCalledTimes(1);
-    const passedVersion =
-      artifactsRepository.addVersionAndUpdateCurrent.mock.calls[0][0];
-    expect(passedVersion.artifactId).toBe(mockArtifactId);
-    expect(passedVersion.versionNumber).toBe(2);
+    const passedParams =
+      artifactsRepository.addVersionAndUpdateArtifact.mock.calls[0][0];
+    expect(passedParams.version.artifactId).toBe(mockArtifactId);
+    expect(passedParams.version.versionNumber).toBe(2);
+    expect(passedParams.expectedCurrentVersionNumber).toBe(1);
+    expect(passedParams.letterheadId).toBeUndefined();
   });
 
   it('should throw ArtifactNotFoundError when artifact does not exist', async () => {
@@ -152,8 +166,8 @@ describe('UpdateArtifactUseCase', () => {
     });
 
     artifactsRepository.findById.mockResolvedValue(existingArtifact);
-    artifactsRepository.addVersionAndUpdateCurrent.mockImplementation(
-      async (version) => version,
+    artifactsRepository.addVersionAndUpdateArtifact.mockImplementation(
+      async ({ version }) => version,
     );
 
     const command = new UpdateArtifactCommand({
@@ -177,8 +191,8 @@ describe('UpdateArtifactUseCase', () => {
     });
 
     artifactsRepository.findById.mockResolvedValue(existingArtifact);
-    artifactsRepository.addVersionAndUpdateCurrent.mockImplementation(
-      async (version) => version,
+    artifactsRepository.addVersionAndUpdateArtifact.mockImplementation(
+      async ({ version }) => version,
     );
 
     const command = new UpdateArtifactCommand({
@@ -203,8 +217,8 @@ describe('UpdateArtifactUseCase', () => {
     });
 
     artifactsRepository.findById.mockResolvedValue(existingArtifact);
-    artifactsRepository.addVersionAndUpdateCurrent.mockImplementation(
-      async (version) => version,
+    artifactsRepository.addVersionAndUpdateArtifact.mockImplementation(
+      async ({ version }) => version,
     );
 
     const command = new UpdateArtifactCommand({
@@ -229,8 +243,8 @@ describe('UpdateArtifactUseCase', () => {
     });
 
     artifactsRepository.findById.mockResolvedValue(existingArtifact);
-    artifactsRepository.addVersionAndUpdateCurrent.mockImplementation(
-      async (version) => version,
+    artifactsRepository.addVersionAndUpdateArtifact.mockImplementation(
+      async ({ version }) => version,
     );
 
     const safeContent =
@@ -275,8 +289,8 @@ describe('UpdateArtifactUseCase', () => {
     });
 
     artifactsRepository.findById.mockResolvedValue(existingArtifact);
-    artifactsRepository.addVersionAndUpdateCurrent.mockImplementation(
-      async (version) => version,
+    artifactsRepository.addVersionAndUpdateArtifact.mockImplementation(
+      async ({ version }) => version,
     );
 
     const command = new UpdateArtifactCommand({
@@ -290,6 +304,111 @@ describe('UpdateArtifactUseCase', () => {
     expect(result.versionNumber).toBe(2);
   });
 
+  it('should pass letterheadId to the atomic artifact update when provided in command', async () => {
+    const mockLetterheadId = '423e4567-e89b-12d3-a456-426614174000' as UUID;
+
+    const existingArtifact = new Artifact({
+      id: mockArtifactId,
+      threadId: mockThreadId,
+      userId: mockUserId,
+      title: 'Official Letter',
+      currentVersionNumber: 1,
+    });
+
+    artifactsRepository.findById.mockResolvedValue(existingArtifact);
+    artifactsRepository.addVersionAndUpdateArtifact.mockImplementation(
+      async ({ version }) => version,
+    );
+
+    const command = new UpdateArtifactCommand({
+      artifactId: mockArtifactId,
+      content: '<p>Updated content</p>',
+      authorType: AuthorType.USER,
+      letterheadId: mockLetterheadId,
+    });
+
+    await useCase.execute(command);
+
+    expect(
+      artifactsRepository.addVersionAndUpdateArtifact,
+    ).toHaveBeenCalledWith(
+      expect.objectContaining({
+        expectedCurrentVersionNumber: 1,
+        letterheadId: mockLetterheadId,
+        version: expect.objectContaining({
+          artifactId: mockArtifactId,
+          versionNumber: 2,
+        }),
+      }),
+    );
+  });
+
+  it('should leave letterheadId unchanged when not provided in command', async () => {
+    const existingArtifact = new Artifact({
+      id: mockArtifactId,
+      threadId: mockThreadId,
+      userId: mockUserId,
+      title: 'Regular Document',
+      currentVersionNumber: 1,
+    });
+
+    artifactsRepository.findById.mockResolvedValue(existingArtifact);
+    artifactsRepository.addVersionAndUpdateArtifact.mockImplementation(
+      async ({ version }) => version,
+    );
+
+    const command = new UpdateArtifactCommand({
+      artifactId: mockArtifactId,
+      content: '<p>Updated content</p>',
+      authorType: AuthorType.USER,
+    });
+
+    await useCase.execute(command);
+
+    expect(
+      artifactsRepository.addVersionAndUpdateArtifact,
+    ).toHaveBeenCalledWith(
+      expect.objectContaining({
+        expectedCurrentVersionNumber: 1,
+        letterheadId: undefined,
+      }),
+    );
+  });
+
+  it('should pass letterheadId as null to remove letterhead atomically', async () => {
+    const existingArtifact = new Artifact({
+      id: mockArtifactId,
+      threadId: mockThreadId,
+      userId: mockUserId,
+      title: 'Letter with letterhead',
+      letterheadId: '423e4567-e89b-12d3-a456-426614174000' as UUID,
+      currentVersionNumber: 1,
+    });
+
+    artifactsRepository.findById.mockResolvedValue(existingArtifact);
+    artifactsRepository.addVersionAndUpdateArtifact.mockImplementation(
+      async ({ version }) => version,
+    );
+
+    const command = new UpdateArtifactCommand({
+      artifactId: mockArtifactId,
+      content: '<p>Content without letterhead</p>',
+      authorType: AuthorType.USER,
+      letterheadId: null,
+    });
+
+    await useCase.execute(command);
+
+    expect(
+      artifactsRepository.addVersionAndUpdateArtifact,
+    ).toHaveBeenCalledWith(
+      expect.objectContaining({
+        expectedCurrentVersionNumber: 1,
+        letterheadId: null,
+      }),
+    );
+  });
+
   it('should throw UnauthorizedAccessError when user is not authenticated', async () => {
     const mockContextService = {
       get: jest.fn(() => undefined),
@@ -300,6 +419,10 @@ describe('UpdateArtifactUseCase', () => {
         UpdateArtifactUseCase,
         { provide: ArtifactsRepository, useValue: artifactsRepository },
         { provide: ContextService, useValue: mockContextService },
+        {
+          provide: FindLetterheadUseCase,
+          useValue: findLetterheadUseCase,
+        },
       ],
     }).compile();
 
@@ -352,8 +475,8 @@ describe('UpdateArtifactUseCase', () => {
       });
 
       artifactsRepository.findById.mockResolvedValue(existingArtifact);
-      artifactsRepository.addVersionAndUpdateCurrent.mockImplementation(
-        async (version) => version,
+      artifactsRepository.addVersionAndUpdateArtifact.mockImplementation(
+        async ({ version }) => version,
       );
 
       const command = new UpdateArtifactCommand({
@@ -378,8 +501,8 @@ describe('UpdateArtifactUseCase', () => {
       });
 
       artifactsRepository.findById.mockResolvedValue(existingArtifact);
-      artifactsRepository.addVersionAndUpdateCurrent.mockImplementation(
-        async (version) => version,
+      artifactsRepository.addVersionAndUpdateArtifact.mockImplementation(
+        async ({ version }) => version,
       );
 
       const command = new UpdateArtifactCommand({
@@ -394,8 +517,80 @@ describe('UpdateArtifactUseCase', () => {
     });
   });
 
+  it('should not call the atomic artifact update when artifact is not found', async () => {
+    const mockLetterheadId = '423e4567-e89b-12d3-a456-426614174000' as UUID;
+
+    artifactsRepository.findById.mockResolvedValue(null);
+
+    const command = new UpdateArtifactCommand({
+      artifactId: mockArtifactId,
+      content: '<p>Unauthorized letterhead change</p>',
+      authorType: AuthorType.USER,
+      letterheadId: mockLetterheadId,
+    });
+
+    await expect(useCase.execute(command)).rejects.toThrow(
+      ArtifactNotFoundError,
+    );
+    expect(
+      artifactsRepository.addVersionAndUpdateArtifact,
+    ).not.toHaveBeenCalled();
+  });
+
+  it('should throw LetterheadNotFoundError when letterheadId does not belong to org before atomic update', async () => {
+    const crossOrgLetterheadId = '523e4567-e89b-12d3-a456-426614174000' as UUID;
+
+    findLetterheadUseCase.execute.mockRejectedValue(
+      new LetterheadNotFoundError(crossOrgLetterheadId),
+    );
+
+    const command = new UpdateArtifactCommand({
+      artifactId: mockArtifactId,
+      content: '<p>Cross-org letterhead attempt</p>',
+      authorType: AuthorType.USER,
+      letterheadId: crossOrgLetterheadId,
+    });
+
+    await expect(useCase.execute(command)).rejects.toThrow(
+      LetterheadNotFoundError,
+    );
+    expect(
+      artifactsRepository.addVersionAndUpdateArtifact,
+    ).not.toHaveBeenCalled();
+  });
+
+  it('should validate letterheadId belongs to org before updating', async () => {
+    const mockLetterheadId = '423e4567-e89b-12d3-a456-426614174000' as UUID;
+
+    const existingArtifact = new Artifact({
+      id: mockArtifactId,
+      threadId: mockThreadId,
+      userId: mockUserId,
+      title: 'Official Letter',
+      currentVersionNumber: 1,
+    });
+
+    artifactsRepository.findById.mockResolvedValue(existingArtifact);
+    artifactsRepository.addVersionAndUpdateArtifact.mockImplementation(
+      async ({ version }) => version,
+    );
+
+    const command = new UpdateArtifactCommand({
+      artifactId: mockArtifactId,
+      content: '<p>Content with valid letterhead</p>',
+      authorType: AuthorType.USER,
+      letterheadId: mockLetterheadId,
+    });
+
+    await useCase.execute(command);
+
+    expect(findLetterheadUseCase.execute).toHaveBeenCalledWith(
+      expect.objectContaining({ letterheadId: mockLetterheadId }),
+    );
+  });
+
   describe('retry on version conflict', () => {
-    it('should retry and succeed when addVersionAndUpdateCurrent fails once with conflict', async () => {
+    it('should retry and succeed when addVersionAndUpdateArtifact fails once with conflict', async () => {
       const artifactV2 = new Artifact({
         id: mockArtifactId,
         threadId: mockThreadId,
@@ -416,9 +611,9 @@ describe('UpdateArtifactUseCase', () => {
         .mockResolvedValueOnce(artifactV2)
         .mockResolvedValueOnce(artifactV3);
 
-      artifactsRepository.addVersionAndUpdateCurrent
+      artifactsRepository.addVersionAndUpdateArtifact
         .mockRejectedValueOnce(new ArtifactVersionConflictError(mockArtifactId))
-        .mockImplementationOnce(async (version) => version);
+        .mockImplementationOnce(async ({ version }) => version);
 
       const command = new UpdateArtifactCommand({
         artifactId: mockArtifactId,
@@ -431,7 +626,7 @@ describe('UpdateArtifactUseCase', () => {
       expect(result.versionNumber).toBe(4);
       expect(artifactsRepository.findById).toHaveBeenCalledTimes(2);
       expect(
-        artifactsRepository.addVersionAndUpdateCurrent,
+        artifactsRepository.addVersionAndUpdateArtifact,
       ).toHaveBeenCalledTimes(2);
     });
 
@@ -445,7 +640,7 @@ describe('UpdateArtifactUseCase', () => {
       });
 
       artifactsRepository.findById.mockResolvedValue(artifact);
-      artifactsRepository.addVersionAndUpdateCurrent.mockRejectedValue(
+      artifactsRepository.addVersionAndUpdateArtifact.mockRejectedValue(
         new ArtifactVersionConflictError(mockArtifactId),
       );
 
@@ -461,7 +656,7 @@ describe('UpdateArtifactUseCase', () => {
 
       expect(artifactsRepository.findById).toHaveBeenCalledTimes(3);
       expect(
-        artifactsRepository.addVersionAndUpdateCurrent,
+        artifactsRepository.addVersionAndUpdateArtifact,
       ).toHaveBeenCalledTimes(3);
     });
 
@@ -475,7 +670,7 @@ describe('UpdateArtifactUseCase', () => {
       });
 
       artifactsRepository.findById.mockResolvedValue(artifact);
-      artifactsRepository.addVersionAndUpdateCurrent.mockRejectedValue(
+      artifactsRepository.addVersionAndUpdateArtifact.mockRejectedValue(
         new Error('Connection refused'),
       );
 
@@ -491,7 +686,7 @@ describe('UpdateArtifactUseCase', () => {
 
       expect(artifactsRepository.findById).toHaveBeenCalledTimes(1);
       expect(
-        artifactsRepository.addVersionAndUpdateCurrent,
+        artifactsRepository.addVersionAndUpdateArtifact,
       ).toHaveBeenCalledTimes(1);
     });
   });

--- a/ayunis-core-backend/src/domain/artifacts/application/use-cases/update-artifact/update-artifact.use-case.ts
+++ b/ayunis-core-backend/src/domain/artifacts/application/use-cases/update-artifact/update-artifact.use-case.ts
@@ -15,6 +15,8 @@ import { sanitizeHtmlContent } from '../../helpers/sanitize-html-content';
 import { ApplicationError } from 'src/common/errors/base.error';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
 import { addVersionWithRetry } from '../../helpers/add-version-with-retry';
+import { FindLetterheadUseCase } from 'src/domain/letterheads/application/use-cases/find-letterhead/find-letterhead.use-case';
+import { FindLetterheadQuery } from 'src/domain/letterheads/application/use-cases/find-letterhead/find-letterhead.query';
 
 @Injectable()
 export class UpdateArtifactUseCase {
@@ -23,6 +25,7 @@ export class UpdateArtifactUseCase {
   constructor(
     private readonly artifactsRepository: ArtifactsRepository,
     private readonly contextService: ContextService,
+    private readonly findLetterheadUseCase: FindLetterheadUseCase,
   ) {}
 
   async execute(command: UpdateArtifactCommand): Promise<ArtifactVersion> {
@@ -38,6 +41,12 @@ export class UpdateArtifactUseCase {
         throw new ArtifactContentTooLargeError(
           command.content.length,
           ARTIFACT_MAX_CONTENT_LENGTH,
+        );
+      }
+
+      if (command.letterheadId) {
+        await this.findLetterheadUseCase.execute(
+          new FindLetterheadQuery({ letterheadId: command.letterheadId }),
         );
       }
 
@@ -67,13 +76,17 @@ export class UpdateArtifactUseCase {
             );
           }
 
-          return new ArtifactVersion({
-            artifactId: artifact.id,
-            versionNumber: artifact.currentVersionNumber + 1,
-            content: sanitizedContent,
-            authorType: command.authorType,
-            authorId: command.authorType === AuthorType.USER ? userId : null,
-          });
+          return {
+            expectedCurrentVersionNumber: artifact.currentVersionNumber,
+            letterheadId: command.letterheadId,
+            version: new ArtifactVersion({
+              artifactId: artifact.id,
+              versionNumber: artifact.currentVersionNumber + 1,
+              content: sanitizedContent,
+              authorType: command.authorType,
+              authorId: command.authorType === AuthorType.USER ? userId : null,
+            }),
+          };
         },
       });
     } catch (error) {

--- a/ayunis-core-backend/src/domain/artifacts/artifacts.module.ts
+++ b/ayunis-core-backend/src/domain/artifacts/artifacts.module.ts
@@ -7,6 +7,7 @@ import { LocalArtifactsRepository } from './infrastructure/persistence/local/loc
 import { HtmlDocumentExportService } from './infrastructure/export/html-document-export.service';
 import { ArtifactDtoMapper } from './presenters/http/mappers/artifact-dto.mapper';
 import { ThreadsModule } from 'src/domain/threads/threads.module';
+import { LetterheadsModule } from 'src/domain/letterheads/letterheads.module';
 
 // Use cases
 import { CreateArtifactUseCase } from './application/use-cases/create-artifact/create-artifact.use-case';
@@ -18,7 +19,11 @@ import { ExportArtifactUseCase } from './application/use-cases/export-artifact/e
 import { ApplyEditsToArtifactUseCase } from './application/use-cases/apply-edits-to-artifact/apply-edits-to-artifact.use-case';
 
 @Module({
-  imports: [LocalArtifactsRepositoryModule, forwardRef(() => ThreadsModule)],
+  imports: [
+    LocalArtifactsRepositoryModule,
+    forwardRef(() => ThreadsModule),
+    LetterheadsModule,
+  ],
   controllers: [ArtifactsController],
   providers: [
     {

--- a/ayunis-core-backend/src/domain/artifacts/domain/artifact.entity.ts
+++ b/ayunis-core-backend/src/domain/artifacts/domain/artifact.entity.ts
@@ -7,6 +7,7 @@ export class Artifact {
   public readonly threadId: UUID;
   public readonly userId: UUID;
   public readonly title: string;
+  public readonly letterheadId: UUID | null;
   public readonly currentVersionNumber: number;
   public readonly versions: ArtifactVersion[];
   public readonly createdAt: Date;
@@ -17,6 +18,7 @@ export class Artifact {
     threadId: UUID;
     userId: UUID;
     title: string;
+    letterheadId?: UUID | null;
     currentVersionNumber?: number;
     versions?: ArtifactVersion[];
     createdAt?: Date;
@@ -26,6 +28,7 @@ export class Artifact {
     this.threadId = params.threadId;
     this.userId = params.userId;
     this.title = params.title;
+    this.letterheadId = params.letterheadId ?? null;
     this.currentVersionNumber = params.currentVersionNumber ?? 1;
     this.versions = params.versions ?? [];
     this.createdAt = params.createdAt ?? new Date();

--- a/ayunis-core-backend/src/domain/artifacts/infrastructure/persistence/local/local-artifacts.repository.ts
+++ b/ayunis-core-backend/src/domain/artifacts/infrastructure/persistence/local/local-artifacts.repository.ts
@@ -81,12 +81,18 @@ export class LocalArtifactsRepository extends ArtifactsRepository {
   }
 
   @Transactional()
-  async addVersionAndUpdateCurrent(
-    version: ArtifactVersion,
-  ): Promise<ArtifactVersion> {
-    this.logger.log('addVersionAndUpdateCurrent', {
+  async addVersionAndUpdateArtifact(params: {
+    version: ArtifactVersion;
+    expectedCurrentVersionNumber: number;
+    letterheadId?: UUID | null;
+  }): Promise<ArtifactVersion> {
+    const { version, expectedCurrentVersionNumber, letterheadId } = params;
+
+    this.logger.log('addVersionAndUpdateArtifact', {
       artifactId: version.artifactId,
       versionNumber: version.versionNumber,
+      expectedCurrentVersionNumber,
+      shouldUpdateLetterhead: letterheadId !== undefined,
     });
 
     try {
@@ -94,10 +100,33 @@ export class LocalArtifactsRepository extends ArtifactsRepository {
       const saved = await this.versionRepo.save(record);
       const createdVersion = this.versionMapper.toDomain(saved);
 
-      await this.artifactRepo.update(
-        { id: version.artifactId },
-        { currentVersionNumber: version.versionNumber },
-      );
+      const result =
+        letterheadId === undefined
+          ? await this.artifactRepo.update(
+              {
+                id: version.artifactId,
+                currentVersionNumber: expectedCurrentVersionNumber,
+              },
+              {
+                currentVersionNumber: version.versionNumber,
+                updatedAt: new Date(),
+              },
+            )
+          : await this.artifactRepo.update(
+              {
+                id: version.artifactId,
+                currentVersionNumber: expectedCurrentVersionNumber,
+              },
+              {
+                currentVersionNumber: version.versionNumber,
+                letterheadId,
+                updatedAt: new Date(),
+              },
+            );
+
+      if (result.affected !== 1) {
+        throw new ArtifactVersionConflictError(version.artifactId);
+      }
 
       return createdVersion;
     } catch (error) {

--- a/ayunis-core-backend/src/domain/artifacts/infrastructure/persistence/local/mappers/artifact.mapper.spec.ts
+++ b/ayunis-core-backend/src/domain/artifacts/infrastructure/persistence/local/mappers/artifact.mapper.spec.ts
@@ -20,6 +20,7 @@ describe('ArtifactMapper', () => {
   const artifactId = randomUUID();
   const threadId = randomUUID();
   const userId = randomUUID();
+  const letterheadId = randomUUID();
 
   describe('toDomain', () => {
     it('should map a record without versions to a domain entity', () => {
@@ -28,6 +29,7 @@ describe('ArtifactMapper', () => {
       record.threadId = threadId;
       record.userId = userId;
       record.title = 'Budget Report Q1 2026';
+      record.letterheadId = null;
       record.currentVersionNumber = 3;
       record.createdAt = now;
       record.updatedAt = now;
@@ -39,9 +41,26 @@ describe('ArtifactMapper', () => {
       expect(domain.threadId).toBe(threadId);
       expect(domain.userId).toBe(userId);
       expect(domain.title).toBe('Budget Report Q1 2026');
+      expect(domain.letterheadId).toBeNull();
       expect(domain.currentVersionNumber).toBe(3);
       expect(domain.createdAt).toBe(now);
       expect(domain.updatedAt).toBe(now);
+    });
+
+    it('should map a record with letterheadId to a domain entity', () => {
+      const record = new ArtifactRecord();
+      record.id = artifactId;
+      record.threadId = threadId;
+      record.userId = userId;
+      record.title = 'Official Letter';
+      record.letterheadId = letterheadId;
+      record.currentVersionNumber = 1;
+      record.createdAt = now;
+      record.updatedAt = now;
+
+      const domain = mapper.toDomain(record);
+
+      expect(domain.letterheadId).toBe(letterheadId);
     });
 
     it('should map a record with versions to a domain entity', () => {
@@ -59,6 +78,7 @@ describe('ArtifactMapper', () => {
       record.threadId = threadId;
       record.userId = userId;
       record.title = 'Budget Report Q1 2026';
+      record.letterheadId = null;
       record.currentVersionNumber = 1;
       record.versions = [versionRecord];
       record.createdAt = now;
@@ -91,7 +111,25 @@ describe('ArtifactMapper', () => {
       expect(record.threadId).toBe(threadId);
       expect(record.userId).toBe(userId);
       expect(record.title).toBe('Budget Report Q1 2026');
+      expect(record.letterheadId).toBeNull();
       expect(record.currentVersionNumber).toBe(2);
+    });
+
+    it('should map a domain entity with letterheadId to a record', () => {
+      const domain = new Artifact({
+        id: artifactId,
+        threadId,
+        userId,
+        title: 'Official Letter',
+        letterheadId,
+        currentVersionNumber: 1,
+        createdAt: now,
+        updatedAt: now,
+      });
+
+      const record = mapper.toRecord(domain);
+
+      expect(record.letterheadId).toBe(letterheadId);
     });
   });
 
@@ -111,6 +149,7 @@ describe('ArtifactMapper', () => {
         threadId,
         userId,
         title: 'Project Plan Document',
+        letterheadId,
         currentVersionNumber: 1,
         versions: [version],
         createdAt: now,
@@ -130,6 +169,7 @@ describe('ArtifactMapper', () => {
       expect(reconstructed.threadId).toBe(original.threadId);
       expect(reconstructed.userId).toBe(original.userId);
       expect(reconstructed.title).toBe(original.title);
+      expect(reconstructed.letterheadId).toBe(original.letterheadId);
       expect(reconstructed.currentVersionNumber).toBe(
         original.currentVersionNumber,
       );

--- a/ayunis-core-backend/src/domain/artifacts/infrastructure/persistence/local/mappers/artifact.mapper.ts
+++ b/ayunis-core-backend/src/domain/artifacts/infrastructure/persistence/local/mappers/artifact.mapper.ts
@@ -13,6 +13,7 @@ export class ArtifactMapper {
       threadId: record.threadId,
       userId: record.userId,
       title: record.title,
+      letterheadId: record.letterheadId,
       currentVersionNumber: record.currentVersionNumber,
       versions: record.versions?.map((v) => this.versionMapper.toDomain(v)),
       createdAt: record.createdAt,
@@ -26,6 +27,7 @@ export class ArtifactMapper {
     record.threadId = domain.threadId;
     record.userId = domain.userId;
     record.title = domain.title;
+    record.letterheadId = domain.letterheadId;
     record.currentVersionNumber = domain.currentVersionNumber;
     record.versions = domain.versions?.map((v) =>
       this.versionMapper.toRecord(v),

--- a/ayunis-core-backend/src/domain/artifacts/infrastructure/persistence/local/schema/artifact.record.ts
+++ b/ayunis-core-backend/src/domain/artifacts/infrastructure/persistence/local/schema/artifact.record.ts
@@ -3,6 +3,7 @@ import { UUID } from 'crypto';
 import { BaseRecord } from '../../../../../../common/db/base-record';
 import { ArtifactVersionRecord } from './artifact-version.record';
 import { ThreadRecord } from '../../../../../threads/infrastructure/persistence/local/schema/thread.record';
+import { LetterheadRecord } from '../../../../../letterheads/infrastructure/persistence/local/schema/letterhead.record';
 
 @Entity({ name: 'artifacts' })
 export class ArtifactRecord extends BaseRecord {
@@ -19,6 +20,13 @@ export class ArtifactRecord extends BaseRecord {
 
   @Column()
   title: string;
+
+  @Column({ nullable: true })
+  @Index()
+  letterheadId: UUID | null;
+
+  @ManyToOne(() => LetterheadRecord, { onDelete: 'SET NULL', nullable: true })
+  letterhead: LetterheadRecord | null;
 
   @Column({ default: 1 })
   currentVersionNumber: number;

--- a/ayunis-core-backend/src/domain/artifacts/presenters/http/artifacts.controller.ts
+++ b/ayunis-core-backend/src/domain/artifacts/presenters/http/artifacts.controller.ts
@@ -76,6 +76,7 @@ export class ArtifactsController {
         title: dto.title,
         content: dto.content,
         authorType: dto.authorType,
+        letterheadId: dto.letterheadId,
       }),
     );
     return this.artifactDtoMapper.toDto(artifact);
@@ -105,6 +106,7 @@ export class ArtifactsController {
         artifactId: id,
         content: dto.content,
         authorType: dto.authorType,
+        letterheadId: dto.letterheadId,
       }),
     );
     return this.artifactDtoMapper.toVersionDto(version);

--- a/ayunis-core-backend/src/domain/artifacts/presenters/http/dtos/artifact-response.dto.ts
+++ b/ayunis-core-backend/src/domain/artifacts/presenters/http/dtos/artifact-response.dto.ts
@@ -72,6 +72,15 @@ export class ArtifactResponseDto {
   })
   title: string;
 
+  @ApiPropertyOptional({
+    description: 'The letterhead applied to this artifact',
+    type: 'string',
+    format: 'uuid',
+    example: '123e4567-e89b-12d3-a456-426614174000',
+    nullable: true,
+  })
+  letterheadId: string | null;
+
   @ApiProperty({
     description: 'Current version number',
     example: 3,

--- a/ayunis-core-backend/src/domain/artifacts/presenters/http/dtos/create-artifact.dto.ts
+++ b/ayunis-core-backend/src/domain/artifacts/presenters/http/dtos/create-artifact.dto.ts
@@ -1,7 +1,8 @@
-import { ApiProperty } from '@nestjs/swagger';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import {
   IsEnum,
   IsNotEmpty,
+  IsOptional,
   IsString,
   IsUUID,
   MaxLength,
@@ -45,4 +46,14 @@ export class CreateArtifactDto {
   })
   @IsEnum(AuthorType)
   authorType: AuthorType;
+
+  @ApiPropertyOptional({
+    description: 'Optional letterhead to apply to this artifact',
+    example: '123e4567-e89b-12d3-a456-426614174000',
+    type: 'string',
+    format: 'uuid',
+  })
+  @IsUUID()
+  @IsOptional()
+  letterheadId?: UUID;
 }

--- a/ayunis-core-backend/src/domain/artifacts/presenters/http/dtos/update-artifact.dto.ts
+++ b/ayunis-core-backend/src/domain/artifacts/presenters/http/dtos/update-artifact.dto.ts
@@ -1,5 +1,14 @@
-import { ApiProperty } from '@nestjs/swagger';
-import { IsEnum, IsNotEmpty, IsString, MaxLength } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  IsEnum,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  IsUUID,
+  MaxLength,
+  ValidateIf,
+} from 'class-validator';
+import type { UUID } from 'crypto';
 import { AuthorType } from '../../../domain/value-objects/author-type.enum';
 import { ARTIFACT_MAX_CONTENT_LENGTH } from '../../../application/artifacts.errors';
 
@@ -20,4 +29,17 @@ export class UpdateArtifactDto {
   })
   @IsEnum(AuthorType)
   authorType: AuthorType;
+
+  @ApiPropertyOptional({
+    description:
+      'Optional letterhead to apply to this artifact (null to remove)',
+    example: '123e4567-e89b-12d3-a456-426614174000',
+    type: 'string',
+    format: 'uuid',
+    nullable: true,
+  })
+  @ValidateIf((o: UpdateArtifactDto) => o.letterheadId !== null)
+  @IsUUID()
+  @IsOptional()
+  letterheadId?: UUID | null;
 }

--- a/ayunis-core-backend/src/domain/artifacts/presenters/http/mappers/artifact-dto.mapper.ts
+++ b/ayunis-core-backend/src/domain/artifacts/presenters/http/mappers/artifact-dto.mapper.ts
@@ -14,6 +14,7 @@ export class ArtifactDtoMapper {
     dto.threadId = artifact.threadId;
     dto.userId = artifact.userId;
     dto.title = artifact.title;
+    dto.letterheadId = artifact.letterheadId;
     dto.currentVersionNumber = artifact.currentVersionNumber;
     dto.createdAt = artifact.createdAt.toISOString();
     dto.updatedAt = artifact.updatedAt.toISOString();

--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
@@ -2951,6 +2951,8 @@ export interface CreateArtifactDto {
   threadId: string;
   /** Who authored this version */
   authorType: CreateArtifactDtoAuthorType;
+  /** Optional letterhead to apply to this artifact */
+  letterheadId?: string;
 }
 
 /**
@@ -3000,6 +3002,11 @@ export interface ArtifactResponseDto {
   userId: string;
   /** Title of the document */
   title: string;
+  /**
+   * The letterhead applied to this artifact
+   * @nullable
+   */
+  letterheadId?: string | null;
   /** Current version number */
   currentVersionNumber: number;
   /** All versions of this artifact (included when fetching by ID) */
@@ -3027,11 +3034,73 @@ export interface UpdateArtifactDto {
   content: string;
   /** Who authored this version */
   authorType: UpdateArtifactDtoAuthorType;
+  /**
+   * Optional letterhead to apply to this artifact (null to remove)
+   * @nullable
+   */
+  letterheadId?: string | null;
 }
 
 export interface RevertArtifactDto {
   /** The version number to revert to */
   versionNumber: number;
+}
+
+export interface CreateLetterheadDto {
+  /** Name of the letterhead */
+  name: string;
+  /** Description of the letterhead (used by AI for context) */
+  description?: string;
+  /** JSON string of { top, bottom, left, right } margins in mm */
+  firstPageMargins: string;
+  /** JSON string of { top, bottom, left, right } margins in mm */
+  continuationPageMargins: string;
+}
+
+export interface PageMarginsDto {
+  /** Top margin in mm */
+  top: number;
+  /** Bottom margin in mm */
+  bottom: number;
+  /** Left margin in mm */
+  left: number;
+  /** Right margin in mm */
+  right: number;
+}
+
+export interface LetterheadResponseDto {
+  /** Unique identifier of the letterhead */
+  id: string;
+  /** Name of the letterhead */
+  name: string;
+  /**
+   * Description of the letterhead
+   * @nullable
+   */
+  description?: string | null;
+  /** Margins for the first page in mm */
+  firstPageMargins: PageMarginsDto;
+  /** Margins for continuation pages in mm */
+  continuationPageMargins: PageMarginsDto;
+  /** Whether a continuation page PDF is configured */
+  hasContinuationPage: boolean;
+  /** When the letterhead was created */
+  createdAt: string;
+  /** When the letterhead was last updated */
+  updatedAt: string;
+}
+
+export interface UpdateLetterheadDto {
+  /** Name of the letterhead */
+  name?: string;
+  /** Description of the letterhead */
+  description?: string;
+  /** JSON string of { top, bottom, left, right } margins in mm */
+  firstPageMargins?: string;
+  /** JSON string of { top, bottom, left, right } margins in mm */
+  continuationPageMargins?: string;
+  /** Set to "true" to remove the continuation page PDF. Ignored if a new continuationPagePdf file is uploaded. */
+  removeContinuationPage?: string;
 }
 
 /**
@@ -3575,63 +3644,6 @@ export interface UpdatePromptDto {
 export interface TranscriptionResponseDto {
   /** The transcribed text from the audio file */
   text: string;
-}
-
-export interface CreateLetterheadDto {
-  /** Name of the letterhead */
-  name: string;
-  /** Description of the letterhead (used by AI for context) */
-  description?: string;
-  /** JSON string of { top, bottom, left, right } margins in mm */
-  firstPageMargins: string;
-  /** JSON string of { top, bottom, left, right } margins in mm */
-  continuationPageMargins: string;
-}
-
-export interface PageMarginsDto {
-  /** Top margin in mm */
-  top: number;
-  /** Bottom margin in mm */
-  bottom: number;
-  /** Left margin in mm */
-  left: number;
-  /** Right margin in mm */
-  right: number;
-}
-
-export interface LetterheadResponseDto {
-  /** Unique identifier of the letterhead */
-  id: string;
-  /** Name of the letterhead */
-  name: string;
-  /**
-   * Description of the letterhead
-   * @nullable
-   */
-  description?: string | null;
-  /** Margins for the first page in mm */
-  firstPageMargins: PageMarginsDto;
-  /** Margins for continuation pages in mm */
-  continuationPageMargins: PageMarginsDto;
-  /** Whether a continuation page PDF is configured */
-  hasContinuationPage: boolean;
-  /** When the letterhead was created */
-  createdAt: string;
-  /** When the letterhead was last updated */
-  updatedAt: string;
-}
-
-export interface UpdateLetterheadDto {
-  /** Name of the letterhead */
-  name?: string;
-  /** Description of the letterhead */
-  description?: string;
-  /** JSON string of { top, bottom, left, right } margins in mm */
-  firstPageMargins?: string;
-  /** JSON string of { top, bottom, left, right } margins in mm */
-  continuationPageMargins?: string;
-  /** Set to "true" to remove the continuation page PDF. Ignored if a new continuationPagePdf file is uploaded. */
-  removeContinuationPage?: string;
 }
 
 export interface LoginDto {

--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.ts
@@ -12761,6 +12761,407 @@ export function useArtifactsControllerExport<TData = Awaited<ReturnType<typeof a
 
 
 /**
+ * @summary Create a new letterhead
+ */
+export const letterheadsControllerCreate = (
+    createLetterheadDto: CreateLetterheadDto,
+ signal?: AbortSignal
+) => {
+      
+      const formData = new FormData();
+formData.append(`name`, createLetterheadDto.name)
+if(createLetterheadDto.description !== undefined) {
+ formData.append(`description`, createLetterheadDto.description)
+ }
+formData.append(`firstPageMargins`, createLetterheadDto.firstPageMargins)
+formData.append(`continuationPageMargins`, createLetterheadDto.continuationPageMargins)
+
+      return customAxiosInstance<LetterheadResponseDto>(
+      {url: `/letterheads`, method: 'POST',
+      headers: {'Content-Type': 'multipart/form-data', },
+       data: formData, signal
+    },
+      );
+    }
+  
+
+
+export const getLetterheadsControllerCreateMutationOptions = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof letterheadsControllerCreate>>, TError,{data: CreateLetterheadDto}, TContext>, }
+): UseMutationOptions<Awaited<ReturnType<typeof letterheadsControllerCreate>>, TError,{data: CreateLetterheadDto}, TContext> => {
+
+const mutationKey = ['letterheadsControllerCreate'];
+const {mutation: mutationOptions} = options ?
+      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
+      options
+      : {...options, mutation: {...options.mutation, mutationKey}}
+      : {mutation: { mutationKey, }};
+
+      
+
+
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof letterheadsControllerCreate>>, {data: CreateLetterheadDto}> = (props) => {
+          const {data} = props ?? {};
+
+          return  letterheadsControllerCreate(data,)
+        }
+
+        
+
+
+  return  { mutationFn, ...mutationOptions }}
+
+    export type LetterheadsControllerCreateMutationResult = NonNullable<Awaited<ReturnType<typeof letterheadsControllerCreate>>>
+    export type LetterheadsControllerCreateMutationBody = CreateLetterheadDto
+    export type LetterheadsControllerCreateMutationError = void
+
+    /**
+ * @summary Create a new letterhead
+ */
+export const useLetterheadsControllerCreate = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof letterheadsControllerCreate>>, TError,{data: CreateLetterheadDto}, TContext>, }
+ , queryClient?: QueryClient): UseMutationResult<
+        Awaited<ReturnType<typeof letterheadsControllerCreate>>,
+        TError,
+        {data: CreateLetterheadDto},
+        TContext
+      > => {
+
+      const mutationOptions = getLetterheadsControllerCreateMutationOptions(options);
+
+      return useMutation(mutationOptions, queryClient);
+    }
+    
+/**
+ * @summary List all letterheads for the current org
+ */
+export const letterheadsControllerFindAll = (
+    
+ signal?: AbortSignal
+) => {
+      
+      
+      return customAxiosInstance<LetterheadResponseDto[]>(
+      {url: `/letterheads`, method: 'GET', signal
+    },
+      );
+    }
+  
+
+
+
+export const getLetterheadsControllerFindAllQueryKey = () => {
+    return [
+    `/letterheads`
+    ] as const;
+    }
+
+    
+export const getLetterheadsControllerFindAllQueryOptions = <TData = Awaited<ReturnType<typeof letterheadsControllerFindAll>>, TError = unknown>( options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof letterheadsControllerFindAll>>, TError, TData>>, }
+) => {
+
+const {query: queryOptions} = options ?? {};
+
+  const queryKey =  queryOptions?.queryKey ?? getLetterheadsControllerFindAllQueryKey();
+
+  
+
+    const queryFn: QueryFunction<Awaited<ReturnType<typeof letterheadsControllerFindAll>>> = ({ signal }) => letterheadsControllerFindAll(signal);
+
+      
+
+      
+
+   return  { queryKey, queryFn, ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof letterheadsControllerFindAll>>, TError, TData> & { queryKey: DataTag<QueryKey, TData, TError> }
+}
+
+export type LetterheadsControllerFindAllQueryResult = NonNullable<Awaited<ReturnType<typeof letterheadsControllerFindAll>>>
+export type LetterheadsControllerFindAllQueryError = unknown
+
+
+export function useLetterheadsControllerFindAll<TData = Awaited<ReturnType<typeof letterheadsControllerFindAll>>, TError = unknown>(
+  options: { query:Partial<UseQueryOptions<Awaited<ReturnType<typeof letterheadsControllerFindAll>>, TError, TData>> & Pick<
+        DefinedInitialDataOptions<
+          Awaited<ReturnType<typeof letterheadsControllerFindAll>>,
+          TError,
+          Awaited<ReturnType<typeof letterheadsControllerFindAll>>
+        > , 'initialData'
+      >, }
+ , queryClient?: QueryClient
+  ):  DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useLetterheadsControllerFindAll<TData = Awaited<ReturnType<typeof letterheadsControllerFindAll>>, TError = unknown>(
+  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof letterheadsControllerFindAll>>, TError, TData>> & Pick<
+        UndefinedInitialDataOptions<
+          Awaited<ReturnType<typeof letterheadsControllerFindAll>>,
+          TError,
+          Awaited<ReturnType<typeof letterheadsControllerFindAll>>
+        > , 'initialData'
+      >, }
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useLetterheadsControllerFindAll<TData = Awaited<ReturnType<typeof letterheadsControllerFindAll>>, TError = unknown>(
+  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof letterheadsControllerFindAll>>, TError, TData>>, }
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+/**
+ * @summary List all letterheads for the current org
+ */
+
+export function useLetterheadsControllerFindAll<TData = Awaited<ReturnType<typeof letterheadsControllerFindAll>>, TError = unknown>(
+  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof letterheadsControllerFindAll>>, TError, TData>>, }
+ , queryClient?: QueryClient 
+ ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
+
+  const queryOptions = getLetterheadsControllerFindAllQueryOptions(options)
+
+  const query = useQuery(queryOptions, queryClient) as  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+
+  query.queryKey = queryOptions.queryKey ;
+
+  return query;
+}
+
+
+
+
+
+/**
+ * @summary Get a letterhead by ID
+ */
+export const letterheadsControllerFindOne = (
+    id: string,
+ signal?: AbortSignal
+) => {
+      
+      
+      return customAxiosInstance<LetterheadResponseDto>(
+      {url: `/letterheads/${id}`, method: 'GET', signal
+    },
+      );
+    }
+  
+
+
+
+export const getLetterheadsControllerFindOneQueryKey = (id?: string,) => {
+    return [
+    `/letterheads/${id}`
+    ] as const;
+    }
+
+    
+export const getLetterheadsControllerFindOneQueryOptions = <TData = Awaited<ReturnType<typeof letterheadsControllerFindOne>>, TError = void>(id: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof letterheadsControllerFindOne>>, TError, TData>>, }
+) => {
+
+const {query: queryOptions} = options ?? {};
+
+  const queryKey =  queryOptions?.queryKey ?? getLetterheadsControllerFindOneQueryKey(id);
+
+  
+
+    const queryFn: QueryFunction<Awaited<ReturnType<typeof letterheadsControllerFindOne>>> = ({ signal }) => letterheadsControllerFindOne(id, signal);
+
+      
+
+      
+
+   return  { queryKey, queryFn, enabled: !!(id), ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof letterheadsControllerFindOne>>, TError, TData> & { queryKey: DataTag<QueryKey, TData, TError> }
+}
+
+export type LetterheadsControllerFindOneQueryResult = NonNullable<Awaited<ReturnType<typeof letterheadsControllerFindOne>>>
+export type LetterheadsControllerFindOneQueryError = void
+
+
+export function useLetterheadsControllerFindOne<TData = Awaited<ReturnType<typeof letterheadsControllerFindOne>>, TError = void>(
+ id: string, options: { query:Partial<UseQueryOptions<Awaited<ReturnType<typeof letterheadsControllerFindOne>>, TError, TData>> & Pick<
+        DefinedInitialDataOptions<
+          Awaited<ReturnType<typeof letterheadsControllerFindOne>>,
+          TError,
+          Awaited<ReturnType<typeof letterheadsControllerFindOne>>
+        > , 'initialData'
+      >, }
+ , queryClient?: QueryClient
+  ):  DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useLetterheadsControllerFindOne<TData = Awaited<ReturnType<typeof letterheadsControllerFindOne>>, TError = void>(
+ id: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof letterheadsControllerFindOne>>, TError, TData>> & Pick<
+        UndefinedInitialDataOptions<
+          Awaited<ReturnType<typeof letterheadsControllerFindOne>>,
+          TError,
+          Awaited<ReturnType<typeof letterheadsControllerFindOne>>
+        > , 'initialData'
+      >, }
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useLetterheadsControllerFindOne<TData = Awaited<ReturnType<typeof letterheadsControllerFindOne>>, TError = void>(
+ id: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof letterheadsControllerFindOne>>, TError, TData>>, }
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+/**
+ * @summary Get a letterhead by ID
+ */
+
+export function useLetterheadsControllerFindOne<TData = Awaited<ReturnType<typeof letterheadsControllerFindOne>>, TError = void>(
+ id: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof letterheadsControllerFindOne>>, TError, TData>>, }
+ , queryClient?: QueryClient 
+ ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
+
+  const queryOptions = getLetterheadsControllerFindOneQueryOptions(id,options)
+
+  const query = useQuery(queryOptions, queryClient) as  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+
+  query.queryKey = queryOptions.queryKey ;
+
+  return query;
+}
+
+
+
+
+
+/**
+ * @summary Update a letterhead
+ */
+export const letterheadsControllerUpdate = (
+    id: string,
+    updateLetterheadDto: UpdateLetterheadDto,
+ ) => {
+      
+      const formData = new FormData();
+if(updateLetterheadDto.name !== undefined) {
+ formData.append(`name`, updateLetterheadDto.name)
+ }
+if(updateLetterheadDto.description !== undefined) {
+ formData.append(`description`, updateLetterheadDto.description)
+ }
+if(updateLetterheadDto.firstPageMargins !== undefined) {
+ formData.append(`firstPageMargins`, updateLetterheadDto.firstPageMargins)
+ }
+if(updateLetterheadDto.continuationPageMargins !== undefined) {
+ formData.append(`continuationPageMargins`, updateLetterheadDto.continuationPageMargins)
+ }
+if(updateLetterheadDto.removeContinuationPage !== undefined) {
+ formData.append(`removeContinuationPage`, updateLetterheadDto.removeContinuationPage)
+ }
+
+      return customAxiosInstance<LetterheadResponseDto>(
+      {url: `/letterheads/${id}`, method: 'PATCH',
+      headers: {'Content-Type': 'multipart/form-data', },
+       data: formData
+    },
+      );
+    }
+  
+
+
+export const getLetterheadsControllerUpdateMutationOptions = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof letterheadsControllerUpdate>>, TError,{id: string;data: UpdateLetterheadDto}, TContext>, }
+): UseMutationOptions<Awaited<ReturnType<typeof letterheadsControllerUpdate>>, TError,{id: string;data: UpdateLetterheadDto}, TContext> => {
+
+const mutationKey = ['letterheadsControllerUpdate'];
+const {mutation: mutationOptions} = options ?
+      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
+      options
+      : {...options, mutation: {...options.mutation, mutationKey}}
+      : {mutation: { mutationKey, }};
+
+      
+
+
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof letterheadsControllerUpdate>>, {id: string;data: UpdateLetterheadDto}> = (props) => {
+          const {id,data} = props ?? {};
+
+          return  letterheadsControllerUpdate(id,data,)
+        }
+
+        
+
+
+  return  { mutationFn, ...mutationOptions }}
+
+    export type LetterheadsControllerUpdateMutationResult = NonNullable<Awaited<ReturnType<typeof letterheadsControllerUpdate>>>
+    export type LetterheadsControllerUpdateMutationBody = UpdateLetterheadDto
+    export type LetterheadsControllerUpdateMutationError = void
+
+    /**
+ * @summary Update a letterhead
+ */
+export const useLetterheadsControllerUpdate = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof letterheadsControllerUpdate>>, TError,{id: string;data: UpdateLetterheadDto}, TContext>, }
+ , queryClient?: QueryClient): UseMutationResult<
+        Awaited<ReturnType<typeof letterheadsControllerUpdate>>,
+        TError,
+        {id: string;data: UpdateLetterheadDto},
+        TContext
+      > => {
+
+      const mutationOptions = getLetterheadsControllerUpdateMutationOptions(options);
+
+      return useMutation(mutationOptions, queryClient);
+    }
+    
+/**
+ * @summary Delete a letterhead
+ */
+export const letterheadsControllerRemove = (
+    id: string,
+ ) => {
+      
+      
+      return customAxiosInstance<void>(
+      {url: `/letterheads/${id}`, method: 'DELETE'
+    },
+      );
+    }
+  
+
+
+export const getLetterheadsControllerRemoveMutationOptions = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof letterheadsControllerRemove>>, TError,{id: string}, TContext>, }
+): UseMutationOptions<Awaited<ReturnType<typeof letterheadsControllerRemove>>, TError,{id: string}, TContext> => {
+
+const mutationKey = ['letterheadsControllerRemove'];
+const {mutation: mutationOptions} = options ?
+      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
+      options
+      : {...options, mutation: {...options.mutation, mutationKey}}
+      : {mutation: { mutationKey, }};
+
+      
+
+
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof letterheadsControllerRemove>>, {id: string}> = (props) => {
+          const {id} = props ?? {};
+
+          return  letterheadsControllerRemove(id,)
+        }
+
+        
+
+
+  return  { mutationFn, ...mutationOptions }}
+
+    export type LetterheadsControllerRemoveMutationResult = NonNullable<Awaited<ReturnType<typeof letterheadsControllerRemove>>>
+    
+    export type LetterheadsControllerRemoveMutationError = void
+
+    /**
+ * @summary Delete a letterhead
+ */
+export const useLetterheadsControllerRemove = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof letterheadsControllerRemove>>, TError,{id: string}, TContext>, }
+ , queryClient?: QueryClient): UseMutationResult<
+        Awaited<ReturnType<typeof letterheadsControllerRemove>>,
+        TError,
+        {id: string},
+        TContext
+      > => {
+
+      const mutationOptions = getLetterheadsControllerRemoveMutationOptions(options);
+
+      return useMutation(mutationOptions, queryClient);
+    }
+    
+/**
  * Sends a user message (with optional image attachments) and returns a server-sent events stream with the AI response. Images are processed transactionally with the message.
  * @summary Send a message with optional images and receive streaming response
  */
@@ -15221,407 +15622,6 @@ export const useTranscriptionsControllerTranscribe = <TError = void,
       > => {
 
       const mutationOptions = getTranscriptionsControllerTranscribeMutationOptions(options);
-
-      return useMutation(mutationOptions, queryClient);
-    }
-    
-/**
- * @summary Create a new letterhead
- */
-export const letterheadsControllerCreate = (
-    createLetterheadDto: CreateLetterheadDto,
- signal?: AbortSignal
-) => {
-      
-      const formData = new FormData();
-formData.append(`name`, createLetterheadDto.name)
-if(createLetterheadDto.description !== undefined) {
- formData.append(`description`, createLetterheadDto.description)
- }
-formData.append(`firstPageMargins`, createLetterheadDto.firstPageMargins)
-formData.append(`continuationPageMargins`, createLetterheadDto.continuationPageMargins)
-
-      return customAxiosInstance<LetterheadResponseDto>(
-      {url: `/letterheads`, method: 'POST',
-      headers: {'Content-Type': 'multipart/form-data', },
-       data: formData, signal
-    },
-      );
-    }
-  
-
-
-export const getLetterheadsControllerCreateMutationOptions = <TError = void,
-    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof letterheadsControllerCreate>>, TError,{data: CreateLetterheadDto}, TContext>, }
-): UseMutationOptions<Awaited<ReturnType<typeof letterheadsControllerCreate>>, TError,{data: CreateLetterheadDto}, TContext> => {
-
-const mutationKey = ['letterheadsControllerCreate'];
-const {mutation: mutationOptions} = options ?
-      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
-      options
-      : {...options, mutation: {...options.mutation, mutationKey}}
-      : {mutation: { mutationKey, }};
-
-      
-
-
-      const mutationFn: MutationFunction<Awaited<ReturnType<typeof letterheadsControllerCreate>>, {data: CreateLetterheadDto}> = (props) => {
-          const {data} = props ?? {};
-
-          return  letterheadsControllerCreate(data,)
-        }
-
-        
-
-
-  return  { mutationFn, ...mutationOptions }}
-
-    export type LetterheadsControllerCreateMutationResult = NonNullable<Awaited<ReturnType<typeof letterheadsControllerCreate>>>
-    export type LetterheadsControllerCreateMutationBody = CreateLetterheadDto
-    export type LetterheadsControllerCreateMutationError = void
-
-    /**
- * @summary Create a new letterhead
- */
-export const useLetterheadsControllerCreate = <TError = void,
-    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof letterheadsControllerCreate>>, TError,{data: CreateLetterheadDto}, TContext>, }
- , queryClient?: QueryClient): UseMutationResult<
-        Awaited<ReturnType<typeof letterheadsControllerCreate>>,
-        TError,
-        {data: CreateLetterheadDto},
-        TContext
-      > => {
-
-      const mutationOptions = getLetterheadsControllerCreateMutationOptions(options);
-
-      return useMutation(mutationOptions, queryClient);
-    }
-    
-/**
- * @summary List all letterheads for the current org
- */
-export const letterheadsControllerFindAll = (
-    
- signal?: AbortSignal
-) => {
-      
-      
-      return customAxiosInstance<LetterheadResponseDto[]>(
-      {url: `/letterheads`, method: 'GET', signal
-    },
-      );
-    }
-  
-
-
-
-export const getLetterheadsControllerFindAllQueryKey = () => {
-    return [
-    `/letterheads`
-    ] as const;
-    }
-
-    
-export const getLetterheadsControllerFindAllQueryOptions = <TData = Awaited<ReturnType<typeof letterheadsControllerFindAll>>, TError = unknown>( options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof letterheadsControllerFindAll>>, TError, TData>>, }
-) => {
-
-const {query: queryOptions} = options ?? {};
-
-  const queryKey =  queryOptions?.queryKey ?? getLetterheadsControllerFindAllQueryKey();
-
-  
-
-    const queryFn: QueryFunction<Awaited<ReturnType<typeof letterheadsControllerFindAll>>> = ({ signal }) => letterheadsControllerFindAll(signal);
-
-      
-
-      
-
-   return  { queryKey, queryFn, ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof letterheadsControllerFindAll>>, TError, TData> & { queryKey: DataTag<QueryKey, TData, TError> }
-}
-
-export type LetterheadsControllerFindAllQueryResult = NonNullable<Awaited<ReturnType<typeof letterheadsControllerFindAll>>>
-export type LetterheadsControllerFindAllQueryError = unknown
-
-
-export function useLetterheadsControllerFindAll<TData = Awaited<ReturnType<typeof letterheadsControllerFindAll>>, TError = unknown>(
-  options: { query:Partial<UseQueryOptions<Awaited<ReturnType<typeof letterheadsControllerFindAll>>, TError, TData>> & Pick<
-        DefinedInitialDataOptions<
-          Awaited<ReturnType<typeof letterheadsControllerFindAll>>,
-          TError,
-          Awaited<ReturnType<typeof letterheadsControllerFindAll>>
-        > , 'initialData'
-      >, }
- , queryClient?: QueryClient
-  ):  DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
-export function useLetterheadsControllerFindAll<TData = Awaited<ReturnType<typeof letterheadsControllerFindAll>>, TError = unknown>(
-  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof letterheadsControllerFindAll>>, TError, TData>> & Pick<
-        UndefinedInitialDataOptions<
-          Awaited<ReturnType<typeof letterheadsControllerFindAll>>,
-          TError,
-          Awaited<ReturnType<typeof letterheadsControllerFindAll>>
-        > , 'initialData'
-      >, }
- , queryClient?: QueryClient
-  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
-export function useLetterheadsControllerFindAll<TData = Awaited<ReturnType<typeof letterheadsControllerFindAll>>, TError = unknown>(
-  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof letterheadsControllerFindAll>>, TError, TData>>, }
- , queryClient?: QueryClient
-  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
-/**
- * @summary List all letterheads for the current org
- */
-
-export function useLetterheadsControllerFindAll<TData = Awaited<ReturnType<typeof letterheadsControllerFindAll>>, TError = unknown>(
-  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof letterheadsControllerFindAll>>, TError, TData>>, }
- , queryClient?: QueryClient 
- ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
-
-  const queryOptions = getLetterheadsControllerFindAllQueryOptions(options)
-
-  const query = useQuery(queryOptions, queryClient) as  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
-
-  query.queryKey = queryOptions.queryKey ;
-
-  return query;
-}
-
-
-
-
-
-/**
- * @summary Get a letterhead by ID
- */
-export const letterheadsControllerFindOne = (
-    id: string,
- signal?: AbortSignal
-) => {
-      
-      
-      return customAxiosInstance<LetterheadResponseDto>(
-      {url: `/letterheads/${id}`, method: 'GET', signal
-    },
-      );
-    }
-  
-
-
-
-export const getLetterheadsControllerFindOneQueryKey = (id?: string,) => {
-    return [
-    `/letterheads/${id}`
-    ] as const;
-    }
-
-    
-export const getLetterheadsControllerFindOneQueryOptions = <TData = Awaited<ReturnType<typeof letterheadsControllerFindOne>>, TError = void>(id: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof letterheadsControllerFindOne>>, TError, TData>>, }
-) => {
-
-const {query: queryOptions} = options ?? {};
-
-  const queryKey =  queryOptions?.queryKey ?? getLetterheadsControllerFindOneQueryKey(id);
-
-  
-
-    const queryFn: QueryFunction<Awaited<ReturnType<typeof letterheadsControllerFindOne>>> = ({ signal }) => letterheadsControllerFindOne(id, signal);
-
-      
-
-      
-
-   return  { queryKey, queryFn, enabled: !!(id), ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof letterheadsControllerFindOne>>, TError, TData> & { queryKey: DataTag<QueryKey, TData, TError> }
-}
-
-export type LetterheadsControllerFindOneQueryResult = NonNullable<Awaited<ReturnType<typeof letterheadsControllerFindOne>>>
-export type LetterheadsControllerFindOneQueryError = void
-
-
-export function useLetterheadsControllerFindOne<TData = Awaited<ReturnType<typeof letterheadsControllerFindOne>>, TError = void>(
- id: string, options: { query:Partial<UseQueryOptions<Awaited<ReturnType<typeof letterheadsControllerFindOne>>, TError, TData>> & Pick<
-        DefinedInitialDataOptions<
-          Awaited<ReturnType<typeof letterheadsControllerFindOne>>,
-          TError,
-          Awaited<ReturnType<typeof letterheadsControllerFindOne>>
-        > , 'initialData'
-      >, }
- , queryClient?: QueryClient
-  ):  DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
-export function useLetterheadsControllerFindOne<TData = Awaited<ReturnType<typeof letterheadsControllerFindOne>>, TError = void>(
- id: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof letterheadsControllerFindOne>>, TError, TData>> & Pick<
-        UndefinedInitialDataOptions<
-          Awaited<ReturnType<typeof letterheadsControllerFindOne>>,
-          TError,
-          Awaited<ReturnType<typeof letterheadsControllerFindOne>>
-        > , 'initialData'
-      >, }
- , queryClient?: QueryClient
-  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
-export function useLetterheadsControllerFindOne<TData = Awaited<ReturnType<typeof letterheadsControllerFindOne>>, TError = void>(
- id: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof letterheadsControllerFindOne>>, TError, TData>>, }
- , queryClient?: QueryClient
-  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
-/**
- * @summary Get a letterhead by ID
- */
-
-export function useLetterheadsControllerFindOne<TData = Awaited<ReturnType<typeof letterheadsControllerFindOne>>, TError = void>(
- id: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof letterheadsControllerFindOne>>, TError, TData>>, }
- , queryClient?: QueryClient 
- ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
-
-  const queryOptions = getLetterheadsControllerFindOneQueryOptions(id,options)
-
-  const query = useQuery(queryOptions, queryClient) as  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
-
-  query.queryKey = queryOptions.queryKey ;
-
-  return query;
-}
-
-
-
-
-
-/**
- * @summary Update a letterhead
- */
-export const letterheadsControllerUpdate = (
-    id: string,
-    updateLetterheadDto: UpdateLetterheadDto,
- ) => {
-      
-      const formData = new FormData();
-if(updateLetterheadDto.name !== undefined) {
- formData.append(`name`, updateLetterheadDto.name)
- }
-if(updateLetterheadDto.description !== undefined) {
- formData.append(`description`, updateLetterheadDto.description)
- }
-if(updateLetterheadDto.firstPageMargins !== undefined) {
- formData.append(`firstPageMargins`, updateLetterheadDto.firstPageMargins)
- }
-if(updateLetterheadDto.continuationPageMargins !== undefined) {
- formData.append(`continuationPageMargins`, updateLetterheadDto.continuationPageMargins)
- }
-if(updateLetterheadDto.removeContinuationPage !== undefined) {
- formData.append(`removeContinuationPage`, updateLetterheadDto.removeContinuationPage)
- }
-
-      return customAxiosInstance<LetterheadResponseDto>(
-      {url: `/letterheads/${id}`, method: 'PATCH',
-      headers: {'Content-Type': 'multipart/form-data', },
-       data: formData
-    },
-      );
-    }
-  
-
-
-export const getLetterheadsControllerUpdateMutationOptions = <TError = void,
-    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof letterheadsControllerUpdate>>, TError,{id: string;data: UpdateLetterheadDto}, TContext>, }
-): UseMutationOptions<Awaited<ReturnType<typeof letterheadsControllerUpdate>>, TError,{id: string;data: UpdateLetterheadDto}, TContext> => {
-
-const mutationKey = ['letterheadsControllerUpdate'];
-const {mutation: mutationOptions} = options ?
-      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
-      options
-      : {...options, mutation: {...options.mutation, mutationKey}}
-      : {mutation: { mutationKey, }};
-
-      
-
-
-      const mutationFn: MutationFunction<Awaited<ReturnType<typeof letterheadsControllerUpdate>>, {id: string;data: UpdateLetterheadDto}> = (props) => {
-          const {id,data} = props ?? {};
-
-          return  letterheadsControllerUpdate(id,data,)
-        }
-
-        
-
-
-  return  { mutationFn, ...mutationOptions }}
-
-    export type LetterheadsControllerUpdateMutationResult = NonNullable<Awaited<ReturnType<typeof letterheadsControllerUpdate>>>
-    export type LetterheadsControllerUpdateMutationBody = UpdateLetterheadDto
-    export type LetterheadsControllerUpdateMutationError = void
-
-    /**
- * @summary Update a letterhead
- */
-export const useLetterheadsControllerUpdate = <TError = void,
-    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof letterheadsControllerUpdate>>, TError,{id: string;data: UpdateLetterheadDto}, TContext>, }
- , queryClient?: QueryClient): UseMutationResult<
-        Awaited<ReturnType<typeof letterheadsControllerUpdate>>,
-        TError,
-        {id: string;data: UpdateLetterheadDto},
-        TContext
-      > => {
-
-      const mutationOptions = getLetterheadsControllerUpdateMutationOptions(options);
-
-      return useMutation(mutationOptions, queryClient);
-    }
-    
-/**
- * @summary Delete a letterhead
- */
-export const letterheadsControllerRemove = (
-    id: string,
- ) => {
-      
-      
-      return customAxiosInstance<void>(
-      {url: `/letterheads/${id}`, method: 'DELETE'
-    },
-      );
-    }
-  
-
-
-export const getLetterheadsControllerRemoveMutationOptions = <TError = void,
-    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof letterheadsControllerRemove>>, TError,{id: string}, TContext>, }
-): UseMutationOptions<Awaited<ReturnType<typeof letterheadsControllerRemove>>, TError,{id: string}, TContext> => {
-
-const mutationKey = ['letterheadsControllerRemove'];
-const {mutation: mutationOptions} = options ?
-      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
-      options
-      : {...options, mutation: {...options.mutation, mutationKey}}
-      : {mutation: { mutationKey, }};
-
-      
-
-
-      const mutationFn: MutationFunction<Awaited<ReturnType<typeof letterheadsControllerRemove>>, {id: string}> = (props) => {
-          const {id} = props ?? {};
-
-          return  letterheadsControllerRemove(id,)
-        }
-
-        
-
-
-  return  { mutationFn, ...mutationOptions }}
-
-    export type LetterheadsControllerRemoveMutationResult = NonNullable<Awaited<ReturnType<typeof letterheadsControllerRemove>>>
-    
-    export type LetterheadsControllerRemoveMutationError = void
-
-    /**
- * @summary Delete a letterhead
- */
-export const useLetterheadsControllerRemove = <TError = void,
-    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof letterheadsControllerRemove>>, TError,{id: string}, TContext>, }
- , queryClient?: QueryClient): UseMutationResult<
-        Awaited<ReturnType<typeof letterheadsControllerRemove>>,
-        TError,
-        {id: string},
-        TContext
-      > => {
-
-      const mutationOptions = getLetterheadsControllerRemoveMutationOptions(options);
 
       return useMutation(mutationOptions, queryClient);
     }

--- a/ayunis-core-frontend/src/shared/api/openapi-schema.json
+++ b/ayunis-core-frontend/src/shared/api/openapi-schema.json
@@ -6618,6 +6618,171 @@
         ]
       }
     },
+    "/letterheads": {
+      "post": {
+        "operationId": "LetterheadsController_create",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateLetterheadDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "The letterhead has been created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LetterheadResponseDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid input data"
+          }
+        },
+        "summary": "Create a new letterhead",
+        "tags": [
+          "letterheads"
+        ]
+      },
+      "get": {
+        "operationId": "LetterheadsController_findAll",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "List of letterheads",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/LetterheadResponseDto"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "summary": "List all letterheads for the current org",
+        "tags": [
+          "letterheads"
+        ]
+      }
+    },
+    "/letterheads/{id}": {
+      "get": {
+        "operationId": "LetterheadsController_findOne",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "description": "The UUID of the letterhead",
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The letterhead",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LetterheadResponseDto"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Letterhead not found"
+          }
+        },
+        "summary": "Get a letterhead by ID",
+        "tags": [
+          "letterheads"
+        ]
+      },
+      "patch": {
+        "operationId": "LetterheadsController_update",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "description": "The UUID of the letterhead",
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateLetterheadDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The updated letterhead",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LetterheadResponseDto"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Letterhead not found"
+          }
+        },
+        "summary": "Update a letterhead",
+        "tags": [
+          "letterheads"
+        ]
+      },
+      "delete": {
+        "operationId": "LetterheadsController_remove",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "description": "The UUID of the letterhead",
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Letterhead deleted"
+          },
+          "404": {
+            "description": "Letterhead not found"
+          }
+        },
+        "summary": "Delete a letterhead",
+        "tags": [
+          "letterheads"
+        ]
+      }
+    },
     "/runs/send-message": {
       "post": {
         "description": "Sends a user message (with optional image attachments) and returns a server-sent events stream with the AI response. Images are processed transactionally with the message.",
@@ -7996,171 +8161,6 @@
         "summary": "Transcribe audio file to text",
         "tags": [
           "transcriptions"
-        ]
-      }
-    },
-    "/letterheads": {
-      "post": {
-        "operationId": "LetterheadsController_create",
-        "parameters": [],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "multipart/form-data": {
-              "schema": {
-                "$ref": "#/components/schemas/CreateLetterheadDto"
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "The letterhead has been created",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/LetterheadResponseDto"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Invalid input data"
-          }
-        },
-        "summary": "Create a new letterhead",
-        "tags": [
-          "letterheads"
-        ]
-      },
-      "get": {
-        "operationId": "LetterheadsController_findAll",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "description": "List of letterheads",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/LetterheadResponseDto"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "summary": "List all letterheads for the current org",
-        "tags": [
-          "letterheads"
-        ]
-      }
-    },
-    "/letterheads/{id}": {
-      "get": {
-        "operationId": "LetterheadsController_findOne",
-        "parameters": [
-          {
-            "name": "id",
-            "required": true,
-            "in": "path",
-            "description": "The UUID of the letterhead",
-            "schema": {
-              "format": "uuid",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "The letterhead",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/LetterheadResponseDto"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Letterhead not found"
-          }
-        },
-        "summary": "Get a letterhead by ID",
-        "tags": [
-          "letterheads"
-        ]
-      },
-      "patch": {
-        "operationId": "LetterheadsController_update",
-        "parameters": [
-          {
-            "name": "id",
-            "required": true,
-            "in": "path",
-            "description": "The UUID of the letterhead",
-            "schema": {
-              "format": "uuid",
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "multipart/form-data": {
-              "schema": {
-                "$ref": "#/components/schemas/UpdateLetterheadDto"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "The updated letterhead",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/LetterheadResponseDto"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Letterhead not found"
-          }
-        },
-        "summary": "Update a letterhead",
-        "tags": [
-          "letterheads"
-        ]
-      },
-      "delete": {
-        "operationId": "LetterheadsController_remove",
-        "parameters": [
-          {
-            "name": "id",
-            "required": true,
-            "in": "path",
-            "description": "The UUID of the letterhead",
-            "schema": {
-              "format": "uuid",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "Letterhead deleted"
-          },
-          "404": {
-            "description": "Letterhead not found"
-          }
-        },
-        "summary": "Delete a letterhead",
-        "tags": [
-          "letterheads"
         ]
       }
     },
@@ -13413,6 +13413,12 @@
               "ASSISTANT"
             ],
             "example": "ASSISTANT"
+          },
+          "letterheadId": {
+            "type": "string",
+            "description": "Optional letterhead to apply to this artifact",
+            "example": "123e4567-e89b-12d3-a456-426614174000",
+            "format": "uuid"
           }
         },
         "required": [
@@ -13498,6 +13504,13 @@
             "description": "Title of the document",
             "example": "Meeting Notes Q1 2026"
           },
+          "letterheadId": {
+            "type": "string",
+            "description": "The letterhead applied to this artifact",
+            "format": "uuid",
+            "example": "123e4567-e89b-12d3-a456-426614174000",
+            "nullable": true
+          },
           "currentVersionNumber": {
             "type": "number",
             "description": "Current version number",
@@ -13547,6 +13560,13 @@
               "ASSISTANT"
             ],
             "example": "USER"
+          },
+          "letterheadId": {
+            "type": "string",
+            "description": "Optional letterhead to apply to this artifact (null to remove)",
+            "example": "123e4567-e89b-12d3-a456-426614174000",
+            "format": "uuid",
+            "nullable": true
           }
         },
         "required": [
@@ -13566,6 +13586,152 @@
         "required": [
           "versionNumber"
         ]
+      },
+      "CreateLetterheadDto": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Name of the letterhead",
+            "example": "Stadtverwaltung Musterstadt"
+          },
+          "description": {
+            "type": "string",
+            "description": "Description of the letterhead (used by AI for context)",
+            "example": "Offizielles Briefpapier der Stadtverwaltung"
+          },
+          "firstPageMargins": {
+            "type": "string",
+            "description": "JSON string of { top, bottom, left, right } margins in mm"
+          },
+          "continuationPageMargins": {
+            "type": "string",
+            "description": "JSON string of { top, bottom, left, right } margins in mm"
+          }
+        },
+        "required": [
+          "name",
+          "firstPageMargins",
+          "continuationPageMargins"
+        ]
+      },
+      "PageMarginsDto": {
+        "type": "object",
+        "properties": {
+          "top": {
+            "type": "number",
+            "description": "Top margin in mm",
+            "example": 55
+          },
+          "bottom": {
+            "type": "number",
+            "description": "Bottom margin in mm",
+            "example": 20
+          },
+          "left": {
+            "type": "number",
+            "description": "Left margin in mm",
+            "example": 25
+          },
+          "right": {
+            "type": "number",
+            "description": "Right margin in mm",
+            "example": 15
+          }
+        },
+        "required": [
+          "top",
+          "bottom",
+          "left",
+          "right"
+        ]
+      },
+      "LetterheadResponseDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Unique identifier of the letterhead",
+            "example": "123e4567-e89b-12d3-a456-426614174000"
+          },
+          "name": {
+            "type": "string",
+            "description": "Name of the letterhead",
+            "example": "Stadtverwaltung Musterstadt"
+          },
+          "description": {
+            "type": "string",
+            "description": "Description of the letterhead",
+            "example": "Offizielles Briefpapier der Stadtverwaltung",
+            "nullable": true
+          },
+          "firstPageMargins": {
+            "description": "Margins for the first page in mm",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PageMarginsDto"
+              }
+            ]
+          },
+          "continuationPageMargins": {
+            "description": "Margins for continuation pages in mm",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PageMarginsDto"
+              }
+            ]
+          },
+          "hasContinuationPage": {
+            "type": "boolean",
+            "description": "Whether a continuation page PDF is configured"
+          },
+          "createdAt": {
+            "type": "string",
+            "description": "When the letterhead was created",
+            "example": "2026-01-15T10:00:00.000Z"
+          },
+          "updatedAt": {
+            "type": "string",
+            "description": "When the letterhead was last updated",
+            "example": "2026-01-15T10:30:00.000Z"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "firstPageMargins",
+          "continuationPageMargins",
+          "hasContinuationPage",
+          "createdAt",
+          "updatedAt"
+        ]
+      },
+      "UpdateLetterheadDto": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Name of the letterhead",
+            "example": "Stadtverwaltung Musterstadt — Neues Design"
+          },
+          "description": {
+            "type": "string",
+            "description": "Description of the letterhead",
+            "example": "Überarbeitetes Briefpapier 2026"
+          },
+          "firstPageMargins": {
+            "type": "string",
+            "description": "JSON string of { top, bottom, left, right } margins in mm"
+          },
+          "continuationPageMargins": {
+            "type": "string",
+            "description": "JSON string of { top, bottom, left, right } margins in mm"
+          },
+          "removeContinuationPage": {
+            "type": "string",
+            "description": "Set to \"true\" to remove the continuation page PDF. Ignored if a new continuationPagePdf file is uploaded."
+          }
+        }
       },
       "MessageContentResponseDto": {
         "type": "object",
@@ -14610,152 +14776,6 @@
         "required": [
           "text"
         ]
-      },
-      "CreateLetterheadDto": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string",
-            "description": "Name of the letterhead",
-            "example": "Stadtverwaltung Musterstadt"
-          },
-          "description": {
-            "type": "string",
-            "description": "Description of the letterhead (used by AI for context)",
-            "example": "Offizielles Briefpapier der Stadtverwaltung"
-          },
-          "firstPageMargins": {
-            "type": "string",
-            "description": "JSON string of { top, bottom, left, right } margins in mm"
-          },
-          "continuationPageMargins": {
-            "type": "string",
-            "description": "JSON string of { top, bottom, left, right } margins in mm"
-          }
-        },
-        "required": [
-          "name",
-          "firstPageMargins",
-          "continuationPageMargins"
-        ]
-      },
-      "PageMarginsDto": {
-        "type": "object",
-        "properties": {
-          "top": {
-            "type": "number",
-            "description": "Top margin in mm",
-            "example": 55
-          },
-          "bottom": {
-            "type": "number",
-            "description": "Bottom margin in mm",
-            "example": 20
-          },
-          "left": {
-            "type": "number",
-            "description": "Left margin in mm",
-            "example": 25
-          },
-          "right": {
-            "type": "number",
-            "description": "Right margin in mm",
-            "example": 15
-          }
-        },
-        "required": [
-          "top",
-          "bottom",
-          "left",
-          "right"
-        ]
-      },
-      "LetterheadResponseDto": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string",
-            "description": "Unique identifier of the letterhead",
-            "example": "123e4567-e89b-12d3-a456-426614174000"
-          },
-          "name": {
-            "type": "string",
-            "description": "Name of the letterhead",
-            "example": "Stadtverwaltung Musterstadt"
-          },
-          "description": {
-            "type": "string",
-            "description": "Description of the letterhead",
-            "example": "Offizielles Briefpapier der Stadtverwaltung",
-            "nullable": true
-          },
-          "firstPageMargins": {
-            "description": "Margins for the first page in mm",
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/PageMarginsDto"
-              }
-            ]
-          },
-          "continuationPageMargins": {
-            "description": "Margins for continuation pages in mm",
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/PageMarginsDto"
-              }
-            ]
-          },
-          "hasContinuationPage": {
-            "type": "boolean",
-            "description": "Whether a continuation page PDF is configured"
-          },
-          "createdAt": {
-            "type": "string",
-            "description": "When the letterhead was created",
-            "example": "2026-01-15T10:00:00.000Z"
-          },
-          "updatedAt": {
-            "type": "string",
-            "description": "When the letterhead was last updated",
-            "example": "2026-01-15T10:30:00.000Z"
-          }
-        },
-        "required": [
-          "id",
-          "name",
-          "firstPageMargins",
-          "continuationPageMargins",
-          "hasContinuationPage",
-          "createdAt",
-          "updatedAt"
-        ]
-      },
-      "UpdateLetterheadDto": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string",
-            "description": "Name of the letterhead",
-            "example": "Stadtverwaltung Musterstadt — Neues Design"
-          },
-          "description": {
-            "type": "string",
-            "description": "Description of the letterhead",
-            "example": "Überarbeitetes Briefpapier 2026"
-          },
-          "firstPageMargins": {
-            "type": "string",
-            "description": "JSON string of { top, bottom, left, right } margins in mm"
-          },
-          "continuationPageMargins": {
-            "type": "string",
-            "description": "JSON string of { top, bottom, left, right } margins in mm"
-          },
-          "removeContinuationPage": {
-            "type": "string",
-            "description": "Set to \"true\" to remove the continuation page PDF. Ignored if a new continuationPagePdf file is uploaded."
-          }
-        }
       },
       "LoginDto": {
         "type": "object",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new nullable FK column and API surface for `letterheadId`, plus changes the version-write path to also update the artifact row with optimistic concurrency; issues here could cause update conflicts or unexpected letterhead changes under concurrent writes.
> 
> **Overview**
> Artifacts now support an optional `letterheadId` linked to `letterheads`: a migration adds the nullable FK+index, the domain/DB mappers and response DTOs expose it, and create/update endpoints accept it (including `null` to remove on update).
> 
> Artifact updates/reverts switch to a new repository method `addVersionAndUpdateArtifact` that *atomically* inserts the new version and updates the artifact row (optionally updating `letterheadId`) using an `expectedCurrentVersionNumber` check; `addVersionWithRetry` and related tests are updated accordingly, and artifacts creation/update validates provided `letterheadId` via `FindLetterheadUseCase`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e5a43d75d7d873b62670507426c59991b7c9e25f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->