### PR TITLE
wip(AYC-101): add PDF letterhead compositing and wire into export

### DIFF
--- a/ayunis-core-backend/src/domain/artifacts/application/ports/document-export.port.ts
+++ b/ayunis-core-backend/src/domain/artifacts/application/ports/document-export.port.ts
@@ -1,4 +1,24 @@
+export interface LetterheadConfig {
+  firstPagePdf: Buffer;
+  continuationPagePdf?: Buffer;
+  firstPageMargins: {
+    top: number;
+    bottom: number;
+    left: number;
+    right: number;
+  };
+  continuationPageMargins: {
+    top: number;
+    bottom: number;
+    left: number;
+    right: number;
+  };
+}
+
 export abstract class DocumentExportPort {
   abstract exportToDocx(html: string): Promise<Buffer>;
-  abstract exportToPdf(html: string): Promise<Buffer>;
+  abstract exportToPdf(
+    html: string,
+    letterhead?: LetterheadConfig,
+  ): Promise<Buffer>;
 }

--- a/ayunis-core-backend/src/domain/artifacts/application/use-cases/export-artifact/export-artifact.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/artifacts/application/use-cases/export-artifact/export-artifact.use-case.spec.ts
@@ -1,6 +1,7 @@
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import { Logger } from '@nestjs/common';
+import { Readable } from 'stream';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
 import type { UUID } from 'crypto';
 import { ExportArtifactUseCase } from './export-artifact.use-case';
@@ -12,15 +13,31 @@ import { Artifact } from '../../../domain/artifact.entity';
 import { ArtifactVersion } from '../../../domain/artifact-version.entity';
 import { AuthorType } from '../../../domain/value-objects/author-type.enum';
 import { ContextService } from 'src/common/context/services/context.service';
+import { FindLetterheadUseCase } from 'src/domain/letterheads/application/use-cases/find-letterhead/find-letterhead.use-case';
+import { DownloadObjectUseCase } from 'src/domain/storage/application/use-cases/download-object/download-object.use-case';
+import { DownloadObjectCommand } from 'src/domain/storage/application/use-cases/download-object/download-object.command';
+import { Letterhead } from 'src/domain/letterheads/domain/letterhead.entity';
+import { LetterheadNotFoundError } from 'src/domain/letterheads/application/letterheads.errors';
+
+function createBufferStream(buf: Buffer): NodeJS.ReadableStream {
+  const readable = new Readable();
+  readable.push(buf);
+  readable.push(null);
+  return readable;
+}
 
 describe('ExportArtifactUseCase', () => {
   let useCase: ExportArtifactUseCase;
   let artifactsRepository: jest.Mocked<ArtifactsRepository>;
   let documentExportPort: jest.Mocked<DocumentExportPort>;
+  let findLetterheadUseCase: jest.Mocked<FindLetterheadUseCase>;
+  let downloadObjectUseCase: jest.Mocked<DownloadObjectUseCase>;
 
   const mockUserId = '123e4567-e89b-12d3-a456-426614174000' as UUID;
+  const mockOrgId = '423e4567-e89b-12d3-a456-426614174000' as UUID;
   const mockArtifactId = '323e4567-e89b-12d3-a456-426614174000' as UUID;
   const mockThreadId = '223e4567-e89b-12d3-a456-426614174000' as UUID;
+  const mockLetterheadId = '523e4567-e89b-12d3-a456-426614174000' as UUID;
 
   beforeEach(async () => {
     const mockRepository = {
@@ -41,9 +58,18 @@ describe('ExportArtifactUseCase', () => {
     const mockContextService = {
       get: jest.fn((key: string) => {
         if (key === 'userId') return mockUserId;
+        if (key === 'orgId') return mockOrgId;
         return undefined;
       }),
     } as unknown as jest.Mocked<ContextService>;
+
+    const mockFindLetterhead = {
+      execute: jest.fn(),
+    };
+
+    const mockDownloadObject = {
+      execute: jest.fn(),
+    };
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -51,19 +77,58 @@ describe('ExportArtifactUseCase', () => {
         { provide: ArtifactsRepository, useValue: mockRepository },
         { provide: DocumentExportPort, useValue: mockExportPort },
         { provide: ContextService, useValue: mockContextService },
+        { provide: FindLetterheadUseCase, useValue: mockFindLetterhead },
+        { provide: DownloadObjectUseCase, useValue: mockDownloadObject },
       ],
     }).compile();
 
     useCase = module.get<ExportArtifactUseCase>(ExportArtifactUseCase);
     artifactsRepository = module.get(ArtifactsRepository);
     documentExportPort = module.get(DocumentExportPort);
+    findLetterheadUseCase = module.get(FindLetterheadUseCase);
+    downloadObjectUseCase = module.get(DownloadObjectUseCase);
 
     jest.spyOn(Logger.prototype, 'log').mockImplementation();
+    jest.spyOn(Logger.prototype, 'warn').mockImplementation();
   });
 
   afterEach(() => {
     jest.clearAllMocks();
   });
+
+  function createArtifact(overrides?: {
+    title?: string;
+    letterheadId?: UUID | null;
+  }): Artifact {
+    return new Artifact({
+      id: mockArtifactId,
+      threadId: mockThreadId,
+      userId: mockUserId,
+      title: overrides?.title ?? 'Council Meeting Notes',
+      letterheadId: overrides?.letterheadId ?? null,
+      currentVersionNumber: 1,
+      versions: [
+        new ArtifactVersion({
+          artifactId: mockArtifactId,
+          versionNumber: 1,
+          content: '<p>Meeting notes content</p>',
+          authorType: AuthorType.ASSISTANT,
+        }),
+      ],
+    });
+  }
+
+  function createLetterhead(): Letterhead {
+    return new Letterhead({
+      id: mockLetterheadId,
+      orgId: mockOrgId,
+      name: 'Stadtbriefpapier',
+      firstPageStoragePath: 'letterheads/org1/lh1/first-page.pdf',
+      continuationPageStoragePath: 'letterheads/org1/lh1/continuation.pdf',
+      firstPageMargins: { top: 55, right: 15, bottom: 20, left: 15 },
+      continuationPageMargins: { top: 20, right: 15, bottom: 20, left: 15 },
+    });
+  }
 
   it('should export the current version as DOCX', async () => {
     const artifact = new Artifact({
@@ -112,23 +177,8 @@ describe('ExportArtifactUseCase', () => {
     );
   });
 
-  it('should export the current version as PDF', async () => {
-    const artifact = new Artifact({
-      id: mockArtifactId,
-      threadId: mockThreadId,
-      userId: mockUserId,
-      title: 'Council Meeting Notes',
-      currentVersionNumber: 1,
-      versions: [
-        new ArtifactVersion({
-          artifactId: mockArtifactId,
-          versionNumber: 1,
-          content: '<p>Meeting notes content</p>',
-          authorType: AuthorType.ASSISTANT,
-        }),
-      ],
-    });
-
+  it('should export the current version as PDF without letterhead', async () => {
+    const artifact = createArtifact();
     const pdfBuffer = Buffer.from('fake-pdf-content');
     artifactsRepository.findByIdWithVersions.mockResolvedValue(artifact);
     documentExportPort.exportToPdf.mockResolvedValue(pdfBuffer);
@@ -145,7 +195,121 @@ describe('ExportArtifactUseCase', () => {
     expect(result.mimeType).toBe('application/pdf');
     expect(documentExportPort.exportToPdf).toHaveBeenCalledWith(
       '<p>Meeting notes content</p>',
+      undefined,
     );
+  });
+
+  it('should export PDF with letterhead when artifact has letterheadId', async () => {
+    const artifact = createArtifact({ letterheadId: mockLetterheadId });
+    const letterhead = createLetterhead();
+    const pdfBuffer = Buffer.from('fake-composited-pdf');
+    const firstPageBuf = Buffer.from('%PDF-first');
+    const contPageBuf = Buffer.from('%PDF-continuation');
+
+    artifactsRepository.findByIdWithVersions.mockResolvedValue(artifact);
+    findLetterheadUseCase.execute.mockResolvedValue(letterhead);
+    downloadObjectUseCase.execute
+      .mockResolvedValueOnce(createBufferStream(firstPageBuf))
+      .mockResolvedValueOnce(createBufferStream(contPageBuf));
+    documentExportPort.exportToPdf.mockResolvedValue(pdfBuffer);
+
+    const command = new ExportArtifactCommand({
+      artifactId: mockArtifactId,
+      format: 'pdf',
+    });
+
+    const result = await useCase.execute(command);
+
+    expect(result.buffer).toBe(pdfBuffer);
+    expect(findLetterheadUseCase.execute).toHaveBeenCalledWith(
+      expect.objectContaining({ letterheadId: mockLetterheadId }),
+    );
+    expect(downloadObjectUseCase.execute).toHaveBeenCalledTimes(2);
+    expect(downloadObjectUseCase.execute).toHaveBeenCalledWith(
+      new DownloadObjectCommand('letterheads/org1/lh1/first-page.pdf'),
+    );
+    expect(downloadObjectUseCase.execute).toHaveBeenCalledWith(
+      new DownloadObjectCommand('letterheads/org1/lh1/continuation.pdf'),
+    );
+    expect(documentExportPort.exportToPdf).toHaveBeenCalledWith(
+      '<p>Meeting notes content</p>',
+      expect.objectContaining({
+        firstPagePdf: firstPageBuf,
+        continuationPagePdf: contPageBuf,
+        firstPageMargins: { top: 55, right: 15, bottom: 20, left: 15 },
+        continuationPageMargins: { top: 20, right: 15, bottom: 20, left: 15 },
+      }),
+    );
+  });
+
+  it('should export PDF without letterhead when letterhead is not found', async () => {
+    const artifact = createArtifact({ letterheadId: mockLetterheadId });
+    const pdfBuffer = Buffer.from('fake-pdf');
+
+    artifactsRepository.findByIdWithVersions.mockResolvedValue(artifact);
+    findLetterheadUseCase.execute.mockRejectedValue(
+      new LetterheadNotFoundError(mockLetterheadId),
+    );
+    documentExportPort.exportToPdf.mockResolvedValue(pdfBuffer);
+
+    const command = new ExportArtifactCommand({
+      artifactId: mockArtifactId,
+      format: 'pdf',
+    });
+
+    const result = await useCase.execute(command);
+
+    expect(result.buffer).toBe(pdfBuffer);
+    expect(documentExportPort.exportToPdf).toHaveBeenCalledWith(
+      '<p>Meeting notes content</p>',
+      undefined,
+    );
+    expect(downloadObjectUseCase.execute).not.toHaveBeenCalled();
+  });
+
+  it('should gracefully degrade when letterhead PDF download fails', async () => {
+    const artifact = createArtifact({ letterheadId: mockLetterheadId });
+    const letterhead = createLetterhead();
+    const pdfBuffer = Buffer.from('fake-pdf-no-letterhead');
+
+    artifactsRepository.findByIdWithVersions.mockResolvedValue(artifact);
+    findLetterheadUseCase.execute.mockResolvedValue(letterhead);
+    downloadObjectUseCase.execute.mockRejectedValue(
+      new Error('Object not found in storage'),
+    );
+    documentExportPort.exportToPdf.mockResolvedValue(pdfBuffer);
+
+    const command = new ExportArtifactCommand({
+      artifactId: mockArtifactId,
+      format: 'pdf',
+    });
+
+    const result = await useCase.execute(command);
+
+    expect(result.buffer).toBe(pdfBuffer);
+    expect(documentExportPort.exportToPdf).toHaveBeenCalledWith(
+      '<p>Meeting notes content</p>',
+      undefined,
+    );
+  });
+
+  it('should export DOCX ignoring letterhead even when artifact has letterheadId', async () => {
+    const artifact = createArtifact({ letterheadId: mockLetterheadId });
+    const docxBuffer = Buffer.from('fake-docx');
+
+    artifactsRepository.findByIdWithVersions.mockResolvedValue(artifact);
+    documentExportPort.exportToDocx.mockResolvedValue(docxBuffer);
+
+    const command = new ExportArtifactCommand({
+      artifactId: mockArtifactId,
+      format: 'docx',
+    });
+
+    const result = await useCase.execute(command);
+
+    expect(result.buffer).toBe(docxBuffer);
+    expect(findLetterheadUseCase.execute).not.toHaveBeenCalled();
+    expect(downloadObjectUseCase.execute).not.toHaveBeenCalled();
   });
 
   it('should throw ArtifactNotFoundError when artifact does not exist', async () => {
@@ -162,21 +326,7 @@ describe('ExportArtifactUseCase', () => {
   });
 
   it('should sanitize special characters from the file name', async () => {
-    const artifact = new Artifact({
-      id: mockArtifactId,
-      threadId: mockThreadId,
-      userId: mockUserId,
-      title: 'Report <2026> "Final"',
-      currentVersionNumber: 1,
-      versions: [
-        new ArtifactVersion({
-          artifactId: mockArtifactId,
-          versionNumber: 1,
-          content: '<p>Content</p>',
-          authorType: AuthorType.ASSISTANT,
-        }),
-      ],
-    });
+    const artifact = createArtifact({ title: 'Report <2026> "Final"' });
 
     artifactsRepository.findByIdWithVersions.mockResolvedValue(artifact);
     documentExportPort.exportToPdf.mockResolvedValue(
@@ -196,21 +346,7 @@ describe('ExportArtifactUseCase', () => {
   });
 
   it('should fallback to "artifact" when title has only non-ASCII characters', async () => {
-    const artifact = new Artifact({
-      id: mockArtifactId,
-      threadId: mockThreadId,
-      userId: mockUserId,
-      title: 'Бюджетний звіт',
-      currentVersionNumber: 1,
-      versions: [
-        new ArtifactVersion({
-          artifactId: mockArtifactId,
-          versionNumber: 1,
-          content: '<p>Зміст</p>',
-          authorType: AuthorType.ASSISTANT,
-        }),
-      ],
-    });
+    const artifact = createArtifact({ title: 'Бюджетний звіт' });
 
     artifactsRepository.findByIdWithVersions.mockResolvedValue(artifact);
     documentExportPort.exportToPdf.mockResolvedValue(
@@ -238,6 +374,8 @@ describe('ExportArtifactUseCase', () => {
         { provide: ArtifactsRepository, useValue: artifactsRepository },
         { provide: DocumentExportPort, useValue: documentExportPort },
         { provide: ContextService, useValue: mockContextService },
+        { provide: FindLetterheadUseCase, useValue: findLetterheadUseCase },
+        { provide: DownloadObjectUseCase, useValue: downloadObjectUseCase },
       ],
     }).compile();
 
@@ -252,6 +390,44 @@ describe('ExportArtifactUseCase', () => {
 
     await expect(useCaseNoAuth.execute(command)).rejects.toThrow(
       UnauthorizedAccessError,
+    );
+  });
+
+  it('should export PDF with letterhead without continuation page when not set', async () => {
+    const artifact = createArtifact({ letterheadId: mockLetterheadId });
+    const letterhead = new Letterhead({
+      id: mockLetterheadId,
+      orgId: mockOrgId,
+      name: 'Simple Letterhead',
+      firstPageStoragePath: 'letterheads/org1/lh2/first-page.pdf',
+      continuationPageStoragePath: null,
+      firstPageMargins: { top: 40, right: 20, bottom: 20, left: 20 },
+      continuationPageMargins: { top: 20, right: 20, bottom: 20, left: 20 },
+    });
+    const firstPageBuf = Buffer.from('%PDF-first-only');
+    const pdfBuffer = Buffer.from('fake-pdf');
+
+    artifactsRepository.findByIdWithVersions.mockResolvedValue(artifact);
+    findLetterheadUseCase.execute.mockResolvedValue(letterhead);
+    downloadObjectUseCase.execute.mockResolvedValueOnce(
+      createBufferStream(firstPageBuf),
+    );
+    documentExportPort.exportToPdf.mockResolvedValue(pdfBuffer);
+
+    const command = new ExportArtifactCommand({
+      artifactId: mockArtifactId,
+      format: 'pdf',
+    });
+
+    await useCase.execute(command);
+
+    expect(downloadObjectUseCase.execute).toHaveBeenCalledTimes(1);
+    expect(documentExportPort.exportToPdf).toHaveBeenCalledWith(
+      '<p>Meeting notes content</p>',
+      expect.objectContaining({
+        firstPagePdf: firstPageBuf,
+        continuationPagePdf: undefined,
+      }),
     );
   });
 });

--- a/ayunis-core-backend/src/domain/artifacts/application/use-cases/export-artifact/export-artifact.use-case.ts
+++ b/ayunis-core-backend/src/domain/artifacts/application/use-cases/export-artifact/export-artifact.use-case.ts
@@ -1,6 +1,10 @@
+import type { UUID } from 'crypto';
 import { Injectable, Logger } from '@nestjs/common';
 import { ArtifactsRepository } from '../../ports/artifacts-repository.port';
-import { DocumentExportPort } from '../../ports/document-export.port';
+import {
+  DocumentExportPort,
+  LetterheadConfig,
+} from '../../ports/document-export.port';
 import { ExportArtifactCommand } from './export-artifact.command';
 import {
   ArtifactNotFoundError,
@@ -10,6 +14,11 @@ import {
 import { ContextService } from 'src/common/context/services/context.service';
 import { ApplicationError } from 'src/common/errors/base.error';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
+import { FindLetterheadUseCase } from 'src/domain/letterheads/application/use-cases/find-letterhead/find-letterhead.use-case';
+import { FindLetterheadQuery } from 'src/domain/letterheads/application/use-cases/find-letterhead/find-letterhead.query';
+import { DownloadObjectUseCase } from 'src/domain/storage/application/use-cases/download-object/download-object.use-case';
+import { DownloadObjectCommand } from 'src/domain/storage/application/use-cases/download-object/download-object.command';
+import type { Letterhead } from 'src/domain/letterheads/domain/letterhead.entity';
 
 export interface ExportResult {
   buffer: Buffer;
@@ -25,6 +34,8 @@ export class ExportArtifactUseCase {
     private readonly artifactsRepository: ArtifactsRepository,
     private readonly documentExportPort: DocumentExportPort,
     private readonly contextService: ContextService,
+    private readonly findLetterheadUseCase: FindLetterheadUseCase,
+    private readonly downloadObjectUseCase: DownloadObjectUseCase,
   ) {}
 
   async execute(command: ExportArtifactCommand): Promise<ExportResult> {
@@ -72,8 +83,11 @@ export class ExportArtifactUseCase {
         };
       }
 
+      const letterheadConfig = await this.resolveLetterhead(artifact);
+
       const buffer = await this.documentExportPort.exportToPdf(
         currentVersion.content,
+        letterheadConfig,
       );
       return {
         buffer,
@@ -93,5 +107,60 @@ export class ExportArtifactUseCase {
         error instanceof Error ? error.message : 'Unknown error',
       );
     }
+  }
+
+  private async resolveLetterhead(artifact: {
+    letterheadId: UUID | null;
+  }): Promise<LetterheadConfig | undefined> {
+    if (!artifact.letterheadId) {
+      return undefined;
+    }
+
+    try {
+      const letterhead = await this.findLetterheadUseCase.execute(
+        new FindLetterheadQuery({ letterheadId: artifact.letterheadId }),
+      );
+      return await this.downloadLetterheadPdfs(letterhead);
+    } catch (error) {
+      const reason = error instanceof Error ? error.message : 'Unknown error';
+      this.logger.warn(
+        `Failed to resolve letterhead ${artifact.letterheadId}, exporting without background: ${reason}`,
+      );
+      return undefined;
+    }
+  }
+
+  private async downloadLetterheadPdfs(
+    letterhead: Letterhead,
+  ): Promise<LetterheadConfig> {
+    const firstPagePdf = await this.downloadPdf(
+      letterhead.firstPageStoragePath,
+    );
+
+    const continuationPagePdf = letterhead.continuationPageStoragePath
+      ? await this.downloadPdf(letterhead.continuationPageStoragePath)
+      : undefined;
+
+    return {
+      firstPagePdf,
+      continuationPagePdf,
+      firstPageMargins: letterhead.firstPageMargins,
+      continuationPageMargins: letterhead.continuationPageMargins,
+    };
+  }
+
+  private async downloadPdf(storagePath: string): Promise<Buffer> {
+    const stream = await this.downloadObjectUseCase.execute(
+      new DownloadObjectCommand(storagePath),
+    );
+    return this.streamToBuffer(stream);
+  }
+
+  private async streamToBuffer(stream: NodeJS.ReadableStream): Promise<Buffer> {
+    const chunks: Buffer[] = [];
+    for await (const chunk of stream) {
+      chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+    }
+    return Buffer.concat(chunks);
   }
 }

--- a/ayunis-core-backend/src/domain/artifacts/application/use-cases/export-artifact/export-artifact.use-case.ts
+++ b/ayunis-core-backend/src/domain/artifacts/application/use-cases/export-artifact/export-artifact.use-case.ts
@@ -85,10 +85,22 @@ export class ExportArtifactUseCase {
 
       const letterheadConfig = await this.resolveLetterhead(artifact);
 
-      const buffer = await this.documentExportPort.exportToPdf(
-        currentVersion.content,
-        letterheadConfig,
-      );
+      let buffer: Buffer;
+      try {
+        buffer = await this.documentExportPort.exportToPdf(
+          currentVersion.content,
+          letterheadConfig,
+        );
+      } catch (error) {
+        if (!letterheadConfig) throw error;
+        const reason = error instanceof Error ? error.message : 'Unknown error';
+        this.logger.warn(
+          `Letterhead compositing failed, exporting without letterhead: ${reason}`,
+        );
+        buffer = await this.documentExportPort.exportToPdf(
+          currentVersion.content,
+        );
+      }
       return {
         buffer,
         fileName: `${safeTitle}.pdf`,
@@ -133,13 +145,12 @@ export class ExportArtifactUseCase {
   private async downloadLetterheadPdfs(
     letterhead: Letterhead,
   ): Promise<LetterheadConfig> {
-    const firstPagePdf = await this.downloadPdf(
-      letterhead.firstPageStoragePath,
-    );
-
-    const continuationPagePdf = letterhead.continuationPageStoragePath
-      ? await this.downloadPdf(letterhead.continuationPageStoragePath)
-      : undefined;
+    const [firstPagePdf, continuationPagePdf] = await Promise.all([
+      this.downloadPdf(letterhead.firstPageStoragePath),
+      letterhead.continuationPageStoragePath
+        ? this.downloadPdf(letterhead.continuationPageStoragePath)
+        : undefined,
+    ]);
 
     return {
       firstPagePdf,

--- a/ayunis-core-backend/src/domain/artifacts/artifacts.module.ts
+++ b/ayunis-core-backend/src/domain/artifacts/artifacts.module.ts
@@ -5,9 +5,11 @@ import { DocumentExportPort } from './application/ports/document-export.port';
 import { LocalArtifactsRepositoryModule } from './infrastructure/persistence/local/local-artifacts-repository.module';
 import { LocalArtifactsRepository } from './infrastructure/persistence/local/local-artifacts.repository';
 import { HtmlDocumentExportService } from './infrastructure/export/html-document-export.service';
+import { PdfLetterheadCompositor } from './infrastructure/export/pdf-letterhead-compositor';
 import { ArtifactDtoMapper } from './presenters/http/mappers/artifact-dto.mapper';
 import { ThreadsModule } from 'src/domain/threads/threads.module';
 import { LetterheadsModule } from 'src/domain/letterheads/letterheads.module';
+import { StorageModule } from 'src/domain/storage/storage.module';
 
 // Use cases
 import { CreateArtifactUseCase } from './application/use-cases/create-artifact/create-artifact.use-case';
@@ -23,6 +25,7 @@ import { ApplyEditsToArtifactUseCase } from './application/use-cases/apply-edits
     LocalArtifactsRepositoryModule,
     forwardRef(() => ThreadsModule),
     LetterheadsModule,
+    StorageModule,
   ],
   controllers: [ArtifactsController],
   providers: [
@@ -42,6 +45,8 @@ import { ApplyEditsToArtifactUseCase } from './application/use-cases/apply-edits
     FindArtifactWithVersionsUseCase,
     RevertArtifactUseCase,
     ExportArtifactUseCase,
+    // Infrastructure
+    PdfLetterheadCompositor,
     // Mappers
     ArtifactDtoMapper,
   ],

--- a/ayunis-core-backend/src/domain/artifacts/infrastructure/export/html-document-export.service.spec.ts
+++ b/ayunis-core-backend/src/domain/artifacts/infrastructure/export/html-document-export.service.spec.ts
@@ -1,4 +1,6 @@
 import { HtmlDocumentExportService } from './html-document-export.service';
+import type { PdfLetterheadCompositor } from './pdf-letterhead-compositor';
+import type { LetterheadConfig } from '../../application/ports/document-export.port';
 
 // ---------------------------------------------------------------------------
 // Puppeteer mock — avoids launching a real browser in unit tests
@@ -26,6 +28,7 @@ jest.mock('puppeteer-core', () => ({
 
 describe('HtmlDocumentExportService', () => {
   let service: HtmlDocumentExportService;
+  let compositor: jest.Mocked<PdfLetterheadCompositor>;
 
   const sampleHtml = `
     <h1>Test Document</h1>
@@ -41,7 +44,10 @@ describe('HtmlDocumentExportService', () => {
   `;
 
   beforeAll(() => {
-    service = new HtmlDocumentExportService();
+    compositor = {
+      composite: jest.fn().mockResolvedValue(Buffer.from('%PDF-composited')),
+    } as unknown as jest.Mocked<PdfLetterheadCompositor>;
+    service = new HtmlDocumentExportService(compositor);
   });
 
   afterAll(async () => {
@@ -51,6 +57,7 @@ describe('HtmlDocumentExportService', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockBrowser.connected = true;
+    compositor.composite.mockResolvedValue(Buffer.from('%PDF-composited'));
   });
 
   describe('exportToDocx', () => {
@@ -160,7 +167,7 @@ describe('HtmlDocumentExportService', () => {
       );
     });
 
-    it('should generate A4 PDF with correct margins', async () => {
+    it('should generate A4 PDF with correct margins when no letterhead', async () => {
       await service.exportToPdf('<p>Hello</p>');
 
       expect(mockPage.pdf).toHaveBeenCalledWith({
@@ -191,6 +198,71 @@ describe('HtmlDocumentExportService', () => {
       await service.exportToPdf('<p>After reconnect</p>');
 
       expect(mockLaunch).toHaveBeenCalled();
+    });
+
+    describe('with letterhead', () => {
+      const letterheadConfig: LetterheadConfig = {
+        firstPagePdf: Buffer.from('%PDF-first-bg'),
+        continuationPagePdf: Buffer.from('%PDF-cont-bg'),
+        firstPageMargins: { top: 55, right: 15, bottom: 20, left: 15 },
+        continuationPageMargins: { top: 20, right: 15, bottom: 20, left: 15 },
+      };
+
+      it('should set zero margins in Puppeteer when letterhead is provided', async () => {
+        await service.exportToPdf('<p>Hello</p>', letterheadConfig);
+
+        expect(mockPage.pdf).toHaveBeenCalledWith({
+          format: 'A4',
+          margin: {
+            top: '0mm',
+            right: '0mm',
+            bottom: '0mm',
+            left: '0mm',
+          },
+          preferCSSPageSize: true,
+          printBackground: true,
+        });
+      });
+
+      it('should inject @page CSS rules with letterhead margins', async () => {
+        await service.exportToPdf('<p>Hello</p>', letterheadConfig);
+
+        const htmlArg = mockPage.setContent.mock.calls[0][0] as string;
+        expect(htmlArg).toContain('@page :first');
+        expect(htmlArg).toContain('55mm');
+        expect(htmlArg).toContain('15mm');
+        expect(htmlArg).toContain(
+          '@page {\n    margin: 20mm 15mm 20mm 15mm;\n  }',
+        );
+      });
+
+      it('should call compositor with content PDF and background PDFs', async () => {
+        await service.exportToPdf('<p>Hello</p>', letterheadConfig);
+
+        expect(compositor.composite).toHaveBeenCalledWith(
+          FAKE_PDF,
+          letterheadConfig.firstPagePdf,
+          letterheadConfig.continuationPagePdf,
+        );
+      });
+
+      it('should return the composited PDF buffer', async () => {
+        const compositedPdf = Buffer.from('%PDF-composited-result');
+        compositor.composite.mockResolvedValue(compositedPdf);
+
+        const result = await service.exportToPdf(
+          '<p>Hello</p>',
+          letterheadConfig,
+        );
+
+        expect(result).toBe(compositedPdf);
+      });
+
+      it('should not call compositor when no letterhead is provided', async () => {
+        await service.exportToPdf('<p>Hello</p>');
+
+        expect(compositor.composite).not.toHaveBeenCalled();
+      });
     });
   });
 });

--- a/ayunis-core-backend/src/domain/artifacts/infrastructure/export/html-document-export.service.ts
+++ b/ayunis-core-backend/src/domain/artifacts/infrastructure/export/html-document-export.service.ts
@@ -1,6 +1,10 @@
 import { Injectable, Logger, OnModuleDestroy } from '@nestjs/common';
-import { DocumentExportPort } from '../../application/ports/document-export.port';
+import {
+  DocumentExportPort,
+  LetterheadConfig,
+} from '../../application/ports/document-export.port';
 import { convertHtmlToDocx } from './html-to-docx-converter';
+import { PdfLetterheadCompositor } from './pdf-letterhead-compositor';
 import puppeteer, { Browser } from 'puppeteer-core';
 import { existsSync } from 'fs';
 import { sanitizeHtmlContent } from '../../application/helpers/sanitize-html-content';
@@ -50,6 +54,10 @@ export class HtmlDocumentExportService
   private browser: Browser | null = null;
   private launchPromise: Promise<void> | null = null;
 
+  constructor(
+    private readonly pdfLetterheadCompositor: PdfLetterheadCompositor,
+  ) {}
+
   async onModuleDestroy(): Promise<void> {
     await this.closeBrowser();
   }
@@ -61,26 +69,60 @@ export class HtmlDocumentExportService
     return convertHtmlToDocx(sanitized);
   }
 
-  async exportToPdf(html: string): Promise<Buffer> {
+  async exportToPdf(
+    html: string,
+    letterhead?: LetterheadConfig,
+  ): Promise<Buffer> {
     this.logger.log('Exporting HTML to PDF');
 
-    const wrappedHtml = this.wrapHtmlForPdf(html);
+    const wrappedHtml = this.wrapHtmlForPdf(html, letterhead);
     const browser = await this.getBrowser();
     const page = await browser.newPage();
 
     try {
       await page.setContent(wrappedHtml, { waitUntil: 'networkidle0' });
 
-      const pdfBuffer = await page.pdf({
-        format: 'A4',
-        margin: { top: '20mm', right: '20mm', bottom: '20mm', left: '20mm' },
-        printBackground: true,
-      });
+      const pdfOptions = letterhead
+        ? this.buildLetterheadPdfOptions()
+        : this.buildDefaultPdfOptions();
 
-      return Buffer.from(pdfBuffer);
+      const pdfBuffer = await page.pdf(pdfOptions);
+      const contentPdf = Buffer.from(pdfBuffer);
+
+      if (!letterhead) {
+        return contentPdf;
+      }
+
+      return this.pdfLetterheadCompositor.composite(
+        contentPdf,
+        letterhead.firstPagePdf,
+        letterhead.continuationPagePdf,
+      );
     } finally {
       await page.close();
     }
+  }
+
+  private buildDefaultPdfOptions() {
+    return {
+      format: 'A4' as const,
+      margin: { top: '20mm', right: '20mm', bottom: '20mm', left: '20mm' },
+      printBackground: true,
+    };
+  }
+
+  /**
+   * When using letterhead, margins are set via CSS @page rules
+   * so Chromium handles text reflow correctly per page type.
+   * Puppeteer margin is set to 0 — the CSS controls it.
+   */
+  private buildLetterheadPdfOptions() {
+    return {
+      format: 'A4' as const,
+      margin: { top: '0mm', right: '0mm', bottom: '0mm', left: '0mm' },
+      preferCSSPageSize: true,
+      printBackground: true,
+    };
   }
 
   private async getBrowser(): Promise<Browser> {
@@ -139,15 +181,33 @@ export class HtmlDocumentExportService
     }
   }
 
-  private wrapHtmlForPdf(unsafeHtml: string): string {
+  private wrapHtmlForPdf(
+    unsafeHtml: string,
+    letterhead?: LetterheadConfig,
+  ): string {
     const html = sanitizeHtmlContent(unsafeHtml);
+    const marginCss = letterhead ? this.buildMarginCss(letterhead) : '';
+
     return `<!DOCTYPE html>
 <html>
 <head>
   <meta charset="utf-8">
-  <style>${PDF_CSS}</style>
+  <style>${PDF_CSS}${marginCss}</style>
 </head>
 <body>${html}</body>
 </html>`;
+  }
+
+  private buildMarginCss(letterhead: LetterheadConfig): string {
+    const { continuationPageMargins: cont, firstPageMargins: first } =
+      letterhead;
+
+    return `
+  @page {
+    margin: ${cont.top}mm ${cont.right}mm ${cont.bottom}mm ${cont.left}mm;
+  }
+  @page :first {
+    margin: ${first.top}mm ${first.right}mm ${first.bottom}mm ${first.left}mm;
+  }`;
   }
 }

--- a/ayunis-core-backend/src/domain/artifacts/infrastructure/export/pdf-letterhead-compositor.spec.ts
+++ b/ayunis-core-backend/src/domain/artifacts/infrastructure/export/pdf-letterhead-compositor.spec.ts
@@ -1,0 +1,100 @@
+import { PDFDocument, rgb } from 'pdf-lib';
+import { PdfLetterheadCompositor } from './pdf-letterhead-compositor';
+
+async function createSinglePagePdf(label: string): Promise<Buffer> {
+  const doc = await PDFDocument.create();
+  const page = doc.addPage([595.28, 841.89]); // A4
+  page.drawText(label, { x: 50, y: 750, size: 14, color: rgb(0, 0, 0) });
+  return Buffer.from(await doc.save());
+}
+
+async function createMultiPagePdf(pageCount: number): Promise<Buffer> {
+  const doc = await PDFDocument.create();
+  for (let i = 0; i < pageCount; i++) {
+    const page = doc.addPage([595.28, 841.89]);
+    page.drawText(`Content page ${i + 1}`, {
+      x: 50,
+      y: 400,
+      size: 12,
+      color: rgb(0, 0, 0),
+    });
+  }
+  return Buffer.from(await doc.save());
+}
+
+describe('PdfLetterheadCompositor', () => {
+  let compositor: PdfLetterheadCompositor;
+
+  beforeEach(() => {
+    compositor = new PdfLetterheadCompositor();
+  });
+
+  it('should composite a single-page content PDF with first-page background', async () => {
+    const contentPdf = await createSinglePagePdf('Content');
+    const firstPagePdf = await createSinglePagePdf('Background');
+
+    const result = await compositor.composite(contentPdf, firstPagePdf);
+
+    const outputDoc = await PDFDocument.load(result);
+    expect(outputDoc.getPageCount()).toBe(1);
+
+    const page = outputDoc.getPage(0);
+    const { width, height } = page.getSize();
+    expect(width).toBeCloseTo(595.28, 1);
+    expect(height).toBeCloseTo(841.89, 1);
+  });
+
+  it('should composite multi-page content with first and continuation backgrounds', async () => {
+    const contentPdf = await createMultiPagePdf(3);
+    const firstPagePdf = await createSinglePagePdf('First BG');
+    const continuationPagePdf = await createSinglePagePdf('Continuation BG');
+
+    const result = await compositor.composite(
+      contentPdf,
+      firstPagePdf,
+      continuationPagePdf,
+    );
+
+    const outputDoc = await PDFDocument.load(result);
+    expect(outputDoc.getPageCount()).toBe(3);
+  });
+
+  it('should copy continuation pages as-is when no continuation background is provided', async () => {
+    const contentPdf = await createMultiPagePdf(2);
+    const firstPagePdf = await createSinglePagePdf('First BG');
+
+    const result = await compositor.composite(contentPdf, firstPagePdf);
+
+    const outputDoc = await PDFDocument.load(result);
+    expect(outputDoc.getPageCount()).toBe(2);
+  });
+
+  it('should produce a valid PDF buffer', async () => {
+    const contentPdf = await createSinglePagePdf('Content');
+    const firstPagePdf = await createSinglePagePdf('Background');
+
+    const result = await compositor.composite(contentPdf, firstPagePdf);
+
+    expect(result).toBeInstanceOf(Buffer);
+    expect(result.subarray(0, 5).toString('ascii')).toBe('%PDF-');
+  });
+
+  it('should preserve page dimensions from content PDF', async () => {
+    const doc = await PDFDocument.create();
+    const customWidth = 400;
+    const customHeight = 600;
+    const page = doc.addPage([customWidth, customHeight]);
+    page.drawText('Custom size', { x: 10, y: 300, size: 10 });
+    const contentPdf = Buffer.from(await doc.save());
+
+    const firstPagePdf = await createSinglePagePdf('BG');
+
+    const result = await compositor.composite(contentPdf, firstPagePdf);
+
+    const outputDoc = await PDFDocument.load(result);
+    const outputPage = outputDoc.getPage(0);
+    const { width, height } = outputPage.getSize();
+    expect(width).toBeCloseTo(customWidth, 1);
+    expect(height).toBeCloseTo(customHeight, 1);
+  });
+});

--- a/ayunis-core-backend/src/domain/artifacts/infrastructure/export/pdf-letterhead-compositor.ts
+++ b/ayunis-core-backend/src/domain/artifacts/infrastructure/export/pdf-letterhead-compositor.ts
@@ -1,0 +1,70 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { PDFDocument } from 'pdf-lib';
+
+/**
+ * Composites content PDF pages onto letterhead background PDFs.
+ *
+ * For each content page, the corresponding background page is placed first,
+ * then the content page is overlaid on top. Page 1 uses the first-page
+ * background; pages 2+ use the continuation-page background (if provided).
+ */
+@Injectable()
+export class PdfLetterheadCompositor {
+  private readonly logger = new Logger(PdfLetterheadCompositor.name);
+
+  /**
+   * Composite content pages onto letterhead backgrounds.
+   *
+   * @param contentPdf   The rendered content PDF buffer
+   * @param firstPagePdf Single-page PDF used as background for page 1
+   * @param continuationPagePdf Optional single-page PDF for pages 2+
+   * @returns Composited PDF buffer
+   */
+  async composite(
+    contentPdf: Buffer,
+    firstPagePdf: Buffer,
+    continuationPagePdf?: Buffer,
+  ): Promise<Buffer> {
+    this.logger.log('Compositing PDF with letterhead background');
+
+    const contentDoc = await PDFDocument.load(contentPdf);
+    const firstBgDoc = await PDFDocument.load(firstPagePdf);
+    const continuationBgDoc = continuationPagePdf
+      ? await PDFDocument.load(continuationPagePdf)
+      : null;
+
+    const outputDoc = await PDFDocument.create();
+    const contentPageCount = contentDoc.getPageCount();
+
+    const [embeddedFirstBg] = await outputDoc.embedPdf(firstBgDoc, [0]);
+    const embeddedContinuationBg = continuationBgDoc
+      ? (await outputDoc.embedPdf(continuationBgDoc, [0]))[0]
+      : null;
+
+    for (let i = 0; i < contentPageCount; i++) {
+      const isFirstPage = i === 0;
+      const embeddedBg = isFirstPage ? embeddedFirstBg : embeddedContinuationBg;
+
+      if (embeddedBg) {
+        const contentPage = contentDoc.getPage(i);
+        const { width, height } = contentPage.getSize();
+
+        const outputPage = outputDoc.addPage([width, height]);
+        outputPage.drawPage(embeddedBg, { x: 0, y: 0, width, height });
+
+        const [embeddedContent] = await outputDoc.embedPdf(contentDoc, [i]);
+        outputPage.drawPage(embeddedContent, { x: 0, y: 0, width, height });
+      } else {
+        // No background for this page type — copy content page as-is
+        const [copiedPage] = await outputDoc.copyPages(contentDoc, [i]);
+        outputDoc.addPage(copiedPage);
+      }
+    }
+
+    const outputBytes = await outputDoc.save();
+    this.logger.log(
+      `Composited ${contentPageCount} page(s) with letterhead background`,
+    );
+    return Buffer.from(outputBytes);
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches the PDF export pipeline by adding storage-backed letterhead retrieval, CSS margin handling, and post-processing PDF compositing; failures are handled via fallback but could still impact export correctness/performance.
> 
> **Overview**
> Adds optional *letterhead-aware* PDF export for artifacts: when an artifact has a `letterheadId`, the export flow now fetches the letterhead, downloads its background PDF(s) from storage, and passes them (plus per-page margins) into `DocumentExportPort.exportToPdf`.
> 
> Updates the HTML→PDF exporter to render with CSS `@page` margins (zero Puppeteer margins) and then composite the rendered content PDF over the letterhead background(s) via a new `PdfLetterheadCompositor` (using `pdf-lib`). Export gracefully falls back to non-letterhead PDFs if letterhead resolution/download/compositing fails, and tests/modules are expanded to cover these scenarios (including optional continuation pages).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5cdb91ba389e26ac2015e5676235b3c22a159aff. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->