### PR TITLE
wip(AYC-101): add letterhead_id to document tools and inject into tool descriptions

### DIFF
--- a/ayunis-core-backend/src/domain/runs/application/services/tool-assembly.service.spec.ts
+++ b/ayunis-core-backend/src/domain/runs/application/services/tool-assembly.service.spec.ts
@@ -1,0 +1,86 @@
+import { randomUUID } from 'crypto';
+import type { UUID } from 'crypto';
+import { Letterhead } from 'src/domain/letterheads/domain/letterhead.entity';
+
+/**
+ * Tests for the letterhead suffix logic in ToolAssemblyService.
+ * We test the private `buildLetterheadSuffix` via a minimal instance
+ * constructed with null dependencies — only the pure helper is called.
+ */
+describe('ToolAssemblyService — letterhead suffix', () => {
+  let service: any;
+
+  beforeEach(async () => {
+    // Dynamically import to avoid eager resolution of all NestJS decorators
+    const mod = await import('./tool-assembly.service');
+    // Create a bare instance — we only call pure private helpers, no DI needed
+    service = new (mod.ToolAssemblyService as any)(
+      ...Array<null>(12).fill(null),
+    );
+  });
+
+  const mockOrgId = randomUUID();
+
+  function createLetterhead(overrides?: {
+    name?: string;
+    description?: string | null;
+    id?: UUID;
+  }): Letterhead {
+    return new Letterhead({
+      id: overrides?.id ?? randomUUID(),
+      orgId: mockOrgId,
+      name: overrides?.name ?? 'Stadt Musterstadt',
+      description:
+        overrides?.description !== undefined
+          ? overrides.description
+          : 'Offizielles Briefpapier',
+      firstPageStoragePath: `letterheads/${mockOrgId}/first.pdf`,
+      firstPageMargins: { top: 55, bottom: 20, left: 20, right: 20 },
+      continuationPageMargins: { top: 20, bottom: 20, left: 20, right: 20 },
+    });
+  }
+
+  it('should return empty string when no letterheads exist', () => {
+    const result = service.buildLetterheadSuffix([]);
+    expect(result).toBe('');
+  });
+
+  it('should include letterhead name and description in suffix', () => {
+    const letterhead = createLetterhead({
+      name: 'Gemeinde Testdorf',
+      description: 'Für formelle Schreiben',
+    });
+
+    const result = service.buildLetterheadSuffix([letterhead]);
+
+    expect(result).toContain('Gemeinde Testdorf');
+    expect(result).toContain('Für formelle Schreiben');
+    expect(result).toContain(letterhead.id);
+    expect(result).toContain('letterhead_id');
+  });
+
+  it('should handle letterhead without description', () => {
+    const letterhead = createLetterhead({
+      name: 'Einfaches Briefpapier',
+      description: null,
+    });
+
+    const result = service.buildLetterheadSuffix([letterhead]);
+
+    expect(result).toContain('Einfaches Briefpapier');
+    expect(result).not.toContain(' — ');
+  });
+
+  it('should list multiple letterheads', () => {
+    const letterheads = [
+      createLetterhead({ name: 'Briefpapier A' }),
+      createLetterhead({ name: 'Briefpapier B' }),
+    ];
+
+    const result = service.buildLetterheadSuffix(letterheads);
+
+    expect(result).toContain('Briefpapier A');
+    expect(result).toContain('Briefpapier B');
+    expect(result).toContain('Available letterheads (Briefpapier)');
+  });
+});

--- a/ayunis-core-backend/src/domain/runs/application/services/tool-assembly.service.ts
+++ b/ayunis-core-backend/src/domain/runs/application/services/tool-assembly.service.ts
@@ -38,6 +38,8 @@ import { FindArtifactsByThreadQuery } from 'src/domain/artifacts/application/use
 import { FindArtifactWithVersionsUseCase } from 'src/domain/artifacts/application/use-cases/find-artifact-with-versions/find-artifact-with-versions.use-case';
 import { FindArtifactWithVersionsQuery } from 'src/domain/artifacts/application/use-cases/find-artifact-with-versions/find-artifact-with-versions.query';
 import { AuthorType } from 'src/domain/artifacts/domain/value-objects/author-type.enum';
+import { FindAllLetterheadsUseCase } from 'src/domain/letterheads/application/use-cases/find-all-letterheads/find-all-letterheads.use-case';
+import type { Letterhead } from 'src/domain/letterheads/domain/letterhead.entity';
 
 @Injectable()
 export class ToolAssemblyService {
@@ -56,6 +58,7 @@ export class ToolAssemblyService {
     private readonly features: ConfigType<typeof featuresConfig>,
     private readonly findArtifactsByThreadUseCase: FindArtifactsByThreadUseCase,
     private readonly findArtifactWithVersionsUseCase: FindArtifactWithVersionsUseCase,
+    private readonly findAllLetterheadsUseCase: FindAllLetterheadsUseCase,
   ) {}
 
   async findActiveSkills(): Promise<Skill[]> {
@@ -181,86 +184,9 @@ export class ToolAssemblyService {
     const skillsEnabled = this.features.skillsEnabled;
     const tools: Tool[] = [];
 
-    // Collect MCP integration IDs from agent and thread (skill-injected)
-    const mcpIntegrationIds = new Set<UUID>();
-    if (agent) {
-      agent.mcpIntegrationIds.forEach((id) => mcpIntegrationIds.add(id));
-    }
-    thread.mcpIntegrationIds.forEach((id) => mcpIntegrationIds.add(id));
-
-    // Discover MCP capabilities from all integration IDs
-    if (mcpIntegrationIds.size > 0) {
-      const integrationIdList = [...mcpIntegrationIds];
-
-      // Fetch integration entities for metadata (name, logoUrl)
-      const integrations = await this.getMcpIntegrationsByIdsUseCase.execute(
-        new GetMcpIntegrationsByIdsQuery(integrationIdList),
-      );
-      const integrationMetaMap = new Map<
-        UUID,
-        { name: string; logoUrl: string | null }
-      >();
-      for (const integration of integrations) {
-        integrationMetaMap.set(integration.id, {
-          name: integration.name,
-          logoUrl:
-            integration instanceof MarketplaceMcpIntegration
-              ? integration.logoUrl
-              : null,
-        });
-      }
-
-      const mcpResults = await Promise.allSettled(
-        integrationIdList.map((integrationId) =>
-          this.discoverMcpCapabilitiesUseCase.execute(
-            new DiscoverMcpCapabilitiesQuery(integrationId),
-          ),
-        ),
-      );
-
-      // Filter successful results, log and skip failures
-      const mcpCapabilities = mcpResults
-        .map((result, index) => {
-          if (result.status === 'fulfilled') {
-            return result.value;
-          }
-          const failedId = integrationIdList[index];
-          const meta = integrationMetaMap.get(failedId);
-          this.logger.warn(
-            `MCP integration '${meta?.name ?? failedId}' unavailable, skipping`,
-            {
-              integrationId: failedId,
-              error:
-                result.reason instanceof Error
-                  ? result.reason.message
-                  : 'Unknown error',
-            },
-          );
-          return null;
-        })
-        .filter((cap): cap is NonNullable<typeof cap> => cap !== null);
-
-      // Add MCP tools and resources
-      tools.push(
-        ...mcpCapabilities.flatMap((capability) =>
-          capability.tools.map((tool) => {
-            const meta = integrationMetaMap.get(tool.integrationId);
-            return new McpIntegrationTool(
-              tool,
-              capability.returnsPii,
-              meta?.name ?? 'Unknown',
-              meta?.logoUrl ?? null,
-            );
-          }),
-        ),
-        ...mcpCapabilities.flatMap((capability) =>
-          capability.resources.map(
-            (resource) =>
-              new McpIntegrationResource(resource, capability.returnsPii),
-          ),
-        ),
-      );
-    }
+    // Discover and add MCP tools/resources from agent and thread integrations
+    const mcpTools = await this.assembleMcpTools(thread, agent);
+    tools.push(...mcpTools);
 
     if (agent) {
       // Add native tools from the agent (excluding always-available tools)
@@ -295,67 +221,41 @@ export class ToolAssemblyService {
       ),
     );
 
-    // Website content tool is always available
-    tools.push(
-      await this.assembleToolsUseCase.execute(
-        new AssembleToolCommand({
-          type: ToolType.WEBSITE_CONTENT,
-        }),
-      ),
-    );
+    // Always-available tools
+    const alwaysOnTypes = [
+      ToolType.WEBSITE_CONTENT,
+      ToolType.SEND_EMAIL,
+      ToolType.CREATE_CALENDAR_EVENT,
+      ToolType.BAR_CHART,
+      ToolType.LINE_CHART,
+      ToolType.PIE_CHART,
+    ];
+    for (const type of alwaysOnTypes) {
+      tools.push(
+        await this.assembleToolsUseCase.execute(
+          new AssembleToolCommand({ type }),
+        ),
+      );
+    }
 
-    // E-Mail tool is always available
-    tools.push(
-      await this.assembleToolsUseCase.execute(
-        new AssembleToolCommand({
-          type: ToolType.SEND_EMAIL,
-        }),
-      ),
-    );
-
-    // Calendar event tool is always available
-    tools.push(
-      await this.assembleToolsUseCase.execute(
-        new AssembleToolCommand({
-          type: ToolType.CREATE_CALENDAR_EVENT,
-        }),
-      ),
-    );
-
-    // Chart tools are always available
-    tools.push(
-      await this.assembleToolsUseCase.execute(
-        new AssembleToolCommand({
-          type: ToolType.BAR_CHART,
-        }),
-      ),
-    );
-    tools.push(
-      await this.assembleToolsUseCase.execute(
-        new AssembleToolCommand({
-          type: ToolType.LINE_CHART,
-        }),
-      ),
-    );
-    tools.push(
-      await this.assembleToolsUseCase.execute(
-        new AssembleToolCommand({
-          type: ToolType.PIE_CHART,
-        }),
-      ),
-    );
+    // Fetch org letterheads for document tool descriptions
+    const letterheads = await this.fetchLetterheadsSafe();
+    const letterheadSuffix = this.buildLetterheadSuffix(letterheads);
 
     // Document tools are always available
-    tools.push(
-      await this.assembleToolsUseCase.execute(
-        new AssembleToolCommand({
-          type: ToolType.CREATE_DOCUMENT,
-        }),
-      ),
+    const createDocTool = await this.assembleToolsUseCase.execute(
+      new AssembleToolCommand({ type: ToolType.CREATE_DOCUMENT }),
     );
+    if (letterheadSuffix) {
+      createDocTool.descriptionLong = `${createDocTool.descriptionLong ?? createDocTool.description}${letterheadSuffix}`;
+    }
+    tools.push(createDocTool);
 
-    // Document editing tools with artifact context
-    const documentEditTools = await this.assembleDocumentEditTools(thread);
+    // Document editing tools with artifact context + letterhead info
+    const documentEditTools = await this.assembleDocumentEditTools(
+      thread,
+      letterheadSuffix,
+    );
     tools.push(...documentEditTools);
 
     // Create skill tool is available when skills feature is enabled
@@ -391,48 +291,30 @@ export class ToolAssemblyService {
 
     const allTextSources = [...threadTextSources, ...agentTextSources];
 
-    // Source query and source get text tools are available if there are text sources
+    // Source query/get tools — available when there are text sources
     if (allTextSources.length > 0) {
-      tools.push(
-        await this.assembleToolsUseCase.execute(
-          new AssembleToolCommand({
-            type: ToolType.SOURCE_QUERY,
-            context: allTextSources,
-          }),
-        ),
-      );
-
-      tools.push(
-        await this.assembleToolsUseCase.execute(
-          new AssembleToolCommand({
-            type: ToolType.SOURCE_GET_TEXT,
-            context: allTextSources,
-          }),
-        ),
-      );
+      for (const type of [ToolType.SOURCE_QUERY, ToolType.SOURCE_GET_TEXT]) {
+        tools.push(
+          await this.assembleToolsUseCase.execute(
+            new AssembleToolCommand({ type, context: allTextSources }),
+          ),
+        );
+      }
     }
 
-    // Knowledge base tools are available if the thread has knowledge bases
+    // Knowledge base tools — available when the thread has knowledge bases
     const knowledgeBases = thread.getUniqueKnowledgeBases();
-
     if (knowledgeBases.length > 0) {
-      tools.push(
-        await this.assembleToolsUseCase.execute(
-          new AssembleToolCommand({
-            type: ToolType.KNOWLEDGE_QUERY,
-            context: knowledgeBases,
-          }),
-        ),
-      );
-
-      tools.push(
-        await this.assembleToolsUseCase.execute(
-          new AssembleToolCommand({
-            type: ToolType.KNOWLEDGE_GET_TEXT,
-            context: knowledgeBases,
-          }),
-        ),
-      );
+      for (const type of [
+        ToolType.KNOWLEDGE_QUERY,
+        ToolType.KNOWLEDGE_GET_TEXT,
+      ]) {
+        tools.push(
+          await this.assembleToolsUseCase.execute(
+            new AssembleToolCommand({ type, context: knowledgeBases }),
+          ),
+        );
+      }
     }
 
     // Activate skill tool is available if there are activatable skills (user or system) and skills feature is enabled
@@ -450,7 +332,91 @@ export class ToolAssemblyService {
     return tools;
   }
 
-  private async assembleDocumentEditTools(thread: Thread): Promise<Tool[]> {
+  private async assembleMcpTools(
+    thread: Thread,
+    agent: Agent | undefined,
+  ): Promise<Tool[]> {
+    const mcpIntegrationIds = new Set<UUID>();
+    if (agent) {
+      agent.mcpIntegrationIds.forEach((id) => mcpIntegrationIds.add(id));
+    }
+    thread.mcpIntegrationIds.forEach((id) => mcpIntegrationIds.add(id));
+
+    if (mcpIntegrationIds.size === 0) return [];
+
+    const integrationIdList = [...mcpIntegrationIds];
+
+    const integrations = await this.getMcpIntegrationsByIdsUseCase.execute(
+      new GetMcpIntegrationsByIdsQuery(integrationIdList),
+    );
+    const integrationMetaMap = new Map<
+      UUID,
+      { name: string; logoUrl: string | null }
+    >();
+    for (const integration of integrations) {
+      integrationMetaMap.set(integration.id, {
+        name: integration.name,
+        logoUrl:
+          integration instanceof MarketplaceMcpIntegration
+            ? integration.logoUrl
+            : null,
+      });
+    }
+
+    const mcpResults = await Promise.allSettled(
+      integrationIdList.map((integrationId) =>
+        this.discoverMcpCapabilitiesUseCase.execute(
+          new DiscoverMcpCapabilitiesQuery(integrationId),
+        ),
+      ),
+    );
+
+    const mcpCapabilities = mcpResults
+      .map((result, index) => {
+        if (result.status === 'fulfilled') {
+          return result.value;
+        }
+        const failedId = integrationIdList[index];
+        const meta = integrationMetaMap.get(failedId);
+        this.logger.warn(
+          `MCP integration '${meta?.name ?? failedId}' unavailable, skipping`,
+          {
+            integrationId: failedId,
+            error:
+              result.reason instanceof Error
+                ? result.reason.message
+                : 'Unknown error',
+          },
+        );
+        return null;
+      })
+      .filter((cap): cap is NonNullable<typeof cap> => cap !== null);
+
+    return [
+      ...mcpCapabilities.flatMap((capability) =>
+        capability.tools.map((tool) => {
+          const meta = integrationMetaMap.get(tool.integrationId);
+          return new McpIntegrationTool(
+            tool,
+            capability.returnsPii,
+            meta?.name ?? 'Unknown',
+            meta?.logoUrl ?? null,
+          );
+        }),
+      ),
+      ...mcpCapabilities.flatMap((capability) =>
+        capability.resources.map(
+          (resource) =>
+            new McpIntegrationResource(resource, capability.returnsPii),
+        ),
+      ),
+    ];
+  }
+
+  private async assembleDocumentEditTools(
+    thread: Thread,
+    letterheadSuffix: string,
+  ): Promise<Tool[]> {
     const threadArtifacts = await this.findArtifactsByThreadUseCase.execute(
       new FindArtifactsByThreadQuery({ threadId: thread.id }),
     );
@@ -475,15 +441,49 @@ export class ToolAssemblyService {
         ? `\n\nAvailable documents in this conversation:\n${artifactLines.join('\n')}`
         : '';
 
-    const toolTypes = [ToolType.UPDATE_DOCUMENT, ToolType.EDIT_DOCUMENT, ToolType.READ_DOCUMENT];
+    const toolTypes = [
+      ToolType.UPDATE_DOCUMENT,
+      ToolType.EDIT_DOCUMENT,
+      ToolType.READ_DOCUMENT,
+    ];
     const tools: Tool[] = [];
     for (const type of toolTypes) {
-      const tool = await this.assembleToolsUseCase.execute(new AssembleToolCommand({ type }));
-      if (suffix) {
-        tool.descriptionLong = `${tool.descriptionLong ?? tool.description}${suffix}`;
+      const tool = await this.assembleToolsUseCase.execute(
+        new AssembleToolCommand({ type }),
+      );
+      const extra =
+        type === ToolType.UPDATE_DOCUMENT
+          ? `${suffix}${letterheadSuffix}`
+          : suffix;
+      if (extra) {
+        tool.descriptionLong = `${tool.descriptionLong ?? tool.description}${extra}`;
       }
       tools.push(tool);
     }
     return tools;
+  }
+
+  private async fetchLetterheadsSafe(): Promise<Letterhead[]> {
+    try {
+      return await this.findAllLetterheadsUseCase.execute();
+    } catch (error) {
+      this.logger.warn('Failed to fetch letterheads, continuing without them', {
+        error: error instanceof Error ? error.message : 'Unknown error',
+      });
+      return [];
+    }
+  }
+
+  private buildLetterheadSuffix(letterheads: Letterhead[]): string {
+    if (letterheads.length === 0) return '';
+    const lines = letterheads.map((l) => {
+      const desc = l.description ? ` — ${l.description}` : '';
+      return `- ${l.id}: "${l.name}"${desc}`;
+    });
+    return (
+      '\n\nAvailable letterheads (Briefpapier) for this organization:\n' +
+      `${lines.join('\n')}\n` +
+      'When the user asks for an official letter or document that should use a specific letterhead, include the letterhead_id parameter.'
+    );
   }
 }

--- a/ayunis-core-backend/src/domain/runs/runs.module.ts
+++ b/ayunis-core-backend/src/domain/runs/runs.module.ts
@@ -27,6 +27,7 @@ import { SkillsModule } from 'src/domain/skills/skills.module';
 import { SkillTemplatesModule } from 'src/domain/skill-templates/skill-templates.module';
 import { ChatSettingsModule } from 'src/domain/chat-settings/chat-settings.module';
 import { ArtifactsModule } from 'src/domain/artifacts/artifacts.module';
+import { LetterheadsModule } from 'src/domain/letterheads/letterheads.module';
 
 @Module({
   imports: [
@@ -46,6 +47,7 @@ import { ArtifactsModule } from 'src/domain/artifacts/artifacts.module';
     SkillTemplatesModule,
     ChatSettingsModule,
     ArtifactsModule,
+    LetterheadsModule,
   ],
   controllers: [RunsController],
   providers: [

--- a/ayunis-core-backend/src/domain/tools/application/handlers/create-document-tool.handler.spec.ts
+++ b/ayunis-core-backend/src/domain/tools/application/handlers/create-document-tool.handler.spec.ts
@@ -99,6 +99,48 @@ describe('CreateDocumentToolHandler', () => {
     expect(result).toContain('version: 1');
   });
 
+  it('should pass letterheadId to CreateArtifactCommand when letterhead_id is provided', async () => {
+    const artifact = createMockArtifact();
+    mockCreateArtifactUseCase.execute.mockResolvedValue(artifact);
+
+    const letterheadId = randomUUID();
+    const tool = new CreateDocumentTool();
+    const input = {
+      title: 'Official Letter',
+      content: '<h1>Dear Sir</h1><p>Body</p>',
+      letterhead_id: letterheadId,
+    };
+
+    await handler.execute({
+      tool,
+      input,
+      context: { threadId: mockThreadId, orgId: mockOrgId },
+    });
+
+    const command = mockCreateArtifactUseCase.execute.mock.calls[0][0];
+    expect(command.letterheadId).toBe(letterheadId);
+  });
+
+  it('should not pass letterheadId when letterhead_id is not provided', async () => {
+    const artifact = createMockArtifact();
+    mockCreateArtifactUseCase.execute.mockResolvedValue(artifact);
+
+    const tool = new CreateDocumentTool();
+    const input = {
+      title: 'Simple Note',
+      content: '<p>No letterhead</p>',
+    };
+
+    await handler.execute({
+      tool,
+      input,
+      context: { threadId: mockThreadId, orgId: mockOrgId },
+    });
+
+    const command = mockCreateArtifactUseCase.execute.mock.calls[0][0];
+    expect(command.letterheadId).toBeUndefined();
+  });
+
   it('should throw ToolExecutionFailedError when CreateArtifactUseCase fails', async () => {
     mockCreateArtifactUseCase.execute.mockRejectedValue(
       new Error('Database connection lost'),

--- a/ayunis-core-backend/src/domain/tools/application/handlers/create-document-tool.handler.ts
+++ b/ayunis-core-backend/src/domain/tools/application/handlers/create-document-tool.handler.ts
@@ -8,6 +8,7 @@ import { ToolExecutionFailedError } from '../tools.errors';
 import { CreateArtifactUseCase } from 'src/domain/artifacts/application/use-cases/create-artifact/create-artifact.use-case';
 import { CreateArtifactCommand } from 'src/domain/artifacts/application/use-cases/create-artifact/create-artifact.command';
 import { AuthorType } from 'src/domain/artifacts/domain/value-objects/author-type.enum';
+import type { UUID } from 'crypto';
 
 @Injectable()
 export class CreateDocumentToolHandler extends ToolExecutionHandler {
@@ -28,12 +29,17 @@ export class CreateDocumentToolHandler extends ToolExecutionHandler {
     try {
       const validatedInput = tool.validateParams(input);
 
+      const letterheadId = validatedInput.letterhead_id
+        ? (validatedInput.letterhead_id as UUID)
+        : undefined;
+
       const artifact = await this.createArtifactUseCase.execute(
         new CreateArtifactCommand({
           threadId: context.threadId,
           title: validatedInput.title,
           content: validatedInput.content,
           authorType: AuthorType.ASSISTANT,
+          letterheadId,
         }),
       );
 

--- a/ayunis-core-backend/src/domain/tools/application/handlers/update-document-tool.handler.spec.ts
+++ b/ayunis-core-backend/src/domain/tools/application/handlers/update-document-tool.handler.spec.ts
@@ -103,6 +103,50 @@ describe('UpdateDocumentToolHandler', () => {
     expect(result).toContain('version: 2');
   });
 
+  it('should pass letterheadId to UpdateArtifactCommand when letterhead_id is provided', async () => {
+    const version = createMockVersion();
+    mockUpdateArtifactUseCase.execute.mockResolvedValue(version);
+
+    const letterheadId = randomUUID();
+    const tool = new UpdateDocumentTool();
+    const input = {
+      artifact_id: mockArtifactId,
+      content: '<h1>Updated with letterhead</h1>',
+      expected_version: 1,
+      letterhead_id: letterheadId,
+    };
+
+    await handler.execute({
+      tool,
+      input,
+      context: { threadId: mockThreadId, orgId: mockOrgId },
+    });
+
+    const command = mockUpdateArtifactUseCase.execute.mock.calls[0][0];
+    expect(command.letterheadId).toBe(letterheadId);
+  });
+
+  it('should not pass letterheadId when letterhead_id is not provided', async () => {
+    const version = createMockVersion();
+    mockUpdateArtifactUseCase.execute.mockResolvedValue(version);
+
+    const tool = new UpdateDocumentTool();
+    const input = {
+      artifact_id: mockArtifactId,
+      content: '<h1>Updated without letterhead</h1>',
+      expected_version: 1,
+    };
+
+    await handler.execute({
+      tool,
+      input,
+      context: { threadId: mockThreadId, orgId: mockOrgId },
+    });
+
+    const command = mockUpdateArtifactUseCase.execute.mock.calls[0][0];
+    expect(command.letterheadId).toBeUndefined();
+  });
+
   it('should throw ToolExecutionFailedError when UpdateArtifactUseCase fails', async () => {
     mockUpdateArtifactUseCase.execute.mockRejectedValue(
       new Error('Artifact not found'),

--- a/ayunis-core-backend/src/domain/tools/application/handlers/update-document-tool.handler.ts
+++ b/ayunis-core-backend/src/domain/tools/application/handlers/update-document-tool.handler.ts
@@ -30,12 +30,17 @@ export class UpdateDocumentToolHandler extends ToolExecutionHandler {
     try {
       const validatedInput = tool.validateParams(input);
 
+      const letterheadId = validatedInput.letterhead_id
+        ? (validatedInput.letterhead_id as UUID)
+        : undefined;
+
       const version = await this.updateArtifactUseCase.execute(
         new UpdateArtifactCommand({
           artifactId: validatedInput.artifact_id as UUID,
           content: validatedInput.content,
           authorType: AuthorType.ASSISTANT,
           expectedVersionNumber: validatedInput.expected_version,
+          letterheadId,
         }),
       );
 

--- a/ayunis-core-backend/src/domain/tools/domain/tools/create-document-tool.entity.spec.ts
+++ b/ayunis-core-backend/src/domain/tools/domain/tools/create-document-tool.entity.spec.ts
@@ -53,6 +53,31 @@ describe('CreateDocumentTool', () => {
       expect(() => tool.validateParams({})).toThrow();
     });
 
+    it('should accept valid parameters with optional letterhead_id', () => {
+      const params = {
+        title: 'Official Letter',
+        content: '<h1>Dear Sir</h1><p>Body text...</p>',
+        letterhead_id: '550e8400-e29b-41d4-a716-446655440000',
+      };
+
+      const result = tool.validateParams(params);
+
+      expect(result.title).toBe('Official Letter');
+      expect(result.letterhead_id).toBe('550e8400-e29b-41d4-a716-446655440000');
+    });
+
+    it('should accept valid parameters without letterhead_id', () => {
+      const params = {
+        title: 'Casual Note',
+        content: '<p>Just a note</p>',
+      };
+
+      const result = tool.validateParams(params);
+
+      expect(result.title).toBe('Casual Note');
+      expect(result.letterhead_id).toBeUndefined();
+    });
+
     it('should reject additional properties', () => {
       const params = {
         title: 'Doc Title',

--- a/ayunis-core-backend/src/domain/tools/domain/tools/create-document-tool.entity.ts
+++ b/ayunis-core-backend/src/domain/tools/domain/tools/create-document-tool.entity.ts
@@ -15,6 +15,11 @@ const createDocumentToolParameters = {
       description:
         'The full HTML content of the document. Use semantic HTML tags (h1, h2, p, ul, ol, li, strong, em, etc.)',
     },
+    letterhead_id: {
+      type: 'string' as const,
+      description:
+        'Optional UUID of the letterhead (Briefpapier) to apply as background when exporting to PDF. Only include when the user requests a specific letterhead.',
+    },
   },
   required: ['title', 'content'],
   additionalProperties: false,

--- a/ayunis-core-backend/src/domain/tools/domain/tools/update-document-tool.entity.spec.ts
+++ b/ayunis-core-backend/src/domain/tools/domain/tools/update-document-tool.entity.spec.ts
@@ -72,6 +72,31 @@ describe('UpdateDocumentTool', () => {
       expect(() => tool.validateParams({})).toThrow();
     });
 
+    it('should accept valid parameters with optional letterhead_id', () => {
+      const params = {
+        artifact_id: '550e8400-e29b-41d4-a716-446655440000',
+        content: '<h1>Updated Letter</h1><p>New content</p>',
+        letterhead_id: '660e8400-e29b-41d4-a716-446655440000',
+      };
+
+      const result = tool.validateParams(params);
+
+      expect(result.artifact_id).toBe('550e8400-e29b-41d4-a716-446655440000');
+      expect(result.letterhead_id).toBe('660e8400-e29b-41d4-a716-446655440000');
+    });
+
+    it('should accept valid parameters without letterhead_id', () => {
+      const params = {
+        artifact_id: '550e8400-e29b-41d4-a716-446655440000',
+        content: '<p>Updated content</p>',
+      };
+
+      const result = tool.validateParams(params);
+
+      expect(result.artifact_id).toBe('550e8400-e29b-41d4-a716-446655440000');
+      expect(result.letterhead_id).toBeUndefined();
+    });
+
     it('should reject additional properties', () => {
       const params = {
         artifact_id: '550e8400-e29b-41d4-a716-446655440000',

--- a/ayunis-core-backend/src/domain/tools/domain/tools/update-document-tool.entity.ts
+++ b/ayunis-core-backend/src/domain/tools/domain/tools/update-document-tool.entity.ts
@@ -20,6 +20,11 @@ const updateDocumentToolParameters = {
       description:
         'The version number you expect the document to be at. Pass the version from your last create/update/edit result, or from read_document. The operation will fail if the document has been modified since.',
     },
+    letterhead_id: {
+      type: 'string' as const,
+      description:
+        'Optional UUID of the letterhead (Briefpapier) to apply as background when exporting to PDF. Only include when the user requests a specific letterhead.',
+    },
   },
   required: ['artifact_id', 'content', 'expected_version'],
   additionalProperties: false,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes tool assembly/prompting behavior and threads an optional `letterheadId` through document tool handlers, which could affect document generation flows if the new parameter is malformed or the letterhead lookup fails.
> 
> **Overview**
> **Adds optional letterhead selection to document tools.** `create_document` and `update_document` now accept a `letterhead_id` parameter and pass it through to the underlying artifact create/update commands, with new unit tests covering both presence and absence.
> 
> **Surfaces organization letterheads to the LLM via tool descriptions.** `ToolAssemblyService` now fetches available letterheads (fail-open with a warning), appends a formatted "available letterheads" suffix to `create_document` and `update_document` descriptions, and adds tests for the suffix formatting; it also refactors MCP tool discovery into `assembleMcpTools` and consolidates several always-on tool additions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e8cd71727a5668dfe0528e5306046b1609f1105d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->