### PR TITLE
fix(AYC-000): auto-save unsaved editor changes before artifact export

### DIFF
--- a/ayunis-core-frontend/src/pages/chat/api/useUpdateArtifact.ts
+++ b/ayunis-core-frontend/src/pages/chat/api/useUpdateArtifact.ts
@@ -35,6 +35,8 @@ export function useUpdateArtifact({
 
   return {
     updateArtifact: (data: UpdateArtifactDto) => mutation.mutate(data),
+    updateArtifactAsync: (data: UpdateArtifactDto) =>
+      mutation.mutateAsync(data),
     isUpdating: mutation.isPending,
   };
 }

--- a/ayunis-core-frontend/src/pages/chat/hooks/useArtifactActions.ts
+++ b/ayunis-core-frontend/src/pages/chat/hooks/useArtifactActions.ts
@@ -1,0 +1,83 @@
+import { useCallback, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useArtifact } from '../api/useArtifact';
+import { useUpdateArtifact } from '../api/useUpdateArtifact';
+import { useRevertArtifact } from '../api/useRevertArtifact';
+import { useExportArtifact } from '../api/useExportArtifact';
+import { UpdateArtifactDtoAuthorType } from '@/shared/api/generated/ayunisCoreAPI.schemas';
+import type { ArtifactsControllerExportFormat } from '@/shared/api/generated/ayunisCoreAPI.schemas';
+import { showSuccess } from '@/shared/lib/toast';
+
+export function useArtifactActions(threadId: string) {
+  const { t } = useTranslation('chat');
+  const [openArtifactId, setOpenArtifactId] = useState<string | null>(null);
+
+  const { artifact: openArtifact } = useArtifact(openArtifactId);
+
+  const {
+    updateArtifact: saveArtifact,
+    updateArtifactAsync: saveArtifactAsync,
+  } = useUpdateArtifact({
+    artifactId: openArtifactId ?? '',
+    threadId,
+    onSuccess: () => showSuccess(t('chat.artifactSaved')),
+  });
+
+  const { revertArtifact } = useRevertArtifact({
+    artifactId: openArtifactId ?? '',
+    threadId,
+  });
+
+  const { exportArtifact, isExporting } = useExportArtifact({
+    artifactId: openArtifactId ?? '',
+    title: openArtifact?.title ?? 'document',
+  });
+
+  const handleOpenArtifact = useCallback((artifactId: string) => {
+    setOpenArtifactId(artifactId);
+  }, []);
+
+  const handleSaveArtifact = useCallback(
+    (content: string) => {
+      saveArtifact({ content, authorType: UpdateArtifactDtoAuthorType.USER });
+    },
+    [saveArtifact],
+  );
+
+  const handleRevertArtifact = useCallback(
+    (versionNumber: number) => {
+      revertArtifact(versionNumber);
+    },
+    [revertArtifact],
+  );
+
+  const handleExportArtifact = useCallback(
+    (format: 'docx' | 'pdf', unsavedContent?: string) => {
+      const doExport = async () => {
+        if (unsavedContent) {
+          await saveArtifactAsync({
+            content: unsavedContent,
+            authorType: UpdateArtifactDtoAuthorType.USER,
+          });
+        }
+        await exportArtifact(format as ArtifactsControllerExportFormat);
+      };
+      void doExport();
+    },
+    [exportArtifact, saveArtifactAsync],
+  );
+
+  const handleCloseArtifact = useCallback(() => {
+    setOpenArtifactId(null);
+  }, []);
+
+  return {
+    openArtifact,
+    isExporting,
+    handleOpenArtifact,
+    handleSaveArtifact,
+    handleRevertArtifact,
+    handleExportArtifact,
+    handleCloseArtifact,
+  };
+}

--- a/ayunis-core-frontend/src/pages/chat/hooks/usePendingMessage.ts
+++ b/ayunis-core-frontend/src/pages/chat/hooks/usePendingMessage.ts
@@ -1,0 +1,147 @@
+import type { RefObject } from 'react';
+import { useEffect, useRef, useState } from 'react';
+import { AxiosError } from 'axios';
+import { useTranslation } from 'react-i18next';
+import { useChatContext } from '@/shared/contexts/chat/useChatContext';
+import { showError } from '@/shared/lib/toast';
+import type { ChatInputRef } from '@/widgets/chat-input/ui/ChatInput';
+import type { PendingImage } from '../api/useMessageSend';
+
+interface UsePendingMessageParams {
+  sendTextMessage: (params: {
+    text: string;
+    images?: PendingImage[];
+    skillId?: string;
+  }) => Promise<void>;
+  createFileSourceAsync: (params: {
+    file: File;
+    name: string;
+    description: string;
+  }) => unknown;
+  resetCreateFileSourceMutation: () => void;
+  addKnowledgeBaseAsync: (id: string) => Promise<unknown>;
+  chatInputRef: RefObject<ChatInputRef | null>;
+}
+
+export function usePendingMessage({
+  sendTextMessage,
+  createFileSourceAsync,
+  resetCreateFileSourceMutation,
+  addKnowledgeBaseAsync,
+  chatInputRef,
+}: UsePendingMessageParams) {
+  const { t } = useTranslation('chat');
+  const processedPendingMessageRef = useRef<string | null>(null);
+  const [isProcessingPendingSources, setIsProcessingPendingSources] =
+    useState(false);
+
+  const {
+    pendingMessage,
+    setPendingMessage,
+    sources,
+    setSources,
+    pendingImages,
+    setPendingImages,
+    pendingKnowledgeBases,
+    setPendingKnowledgeBases,
+    pendingSkillId,
+    setPendingSkillId,
+  } = useChatContext();
+
+  useEffect(() => {
+    async function uploadPendingSources() {
+      if (sources.length === 0) return;
+      setIsProcessingPendingSources(true);
+      const promises = sources.map((source) =>
+        createFileSourceAsync({
+          file: source.file,
+          name: source.name,
+          description: `File source: ${source.name}`,
+        }),
+      );
+      await Promise.all(promises as Promise<unknown>[]);
+      resetCreateFileSourceMutation();
+    }
+
+    async function attachPendingKnowledgeBases() {
+      if (pendingKnowledgeBases.length === 0) return;
+      const results = await Promise.allSettled(
+        pendingKnowledgeBases.map((kb) => addKnowledgeBaseAsync(kb.id)),
+      );
+      const failed = results.filter((r) => r.status === 'rejected');
+      if (failed.length > 0) {
+        console.error(
+          `Failed to attach ${String(failed.length)} knowledge base(s)`,
+        );
+      }
+    }
+
+    function buildPendingImages(): PendingImage[] | undefined {
+      if (pendingImages.length === 0) return undefined;
+      return pendingImages.map((img) => ({
+        file: img.file,
+        altText: img.altText ?? (img.file.name || 'Pasted image'),
+      }));
+    }
+
+    async function sendPendingMessage() {
+      if (
+        !pendingMessage ||
+        processedPendingMessageRef.current === pendingMessage
+      ) {
+        return;
+      }
+      processedPendingMessageRef.current = pendingMessage;
+      try {
+        await uploadPendingSources();
+        setSources([]);
+        await attachPendingKnowledgeBases();
+        await sendTextMessage({
+          text: pendingMessage,
+          images: buildPendingImages(),
+          skillId: pendingSkillId,
+        });
+      } catch (error) {
+        if (error instanceof AxiosError && error.response?.status === 403) {
+          showError(t('chat.upgradeToProError'));
+        } else {
+          showError(t('chat.errorSendMessage'));
+        }
+        chatInputRef.current?.setMessage(pendingMessage);
+      } finally {
+        setIsProcessingPendingSources(false);
+        setPendingMessage('');
+        setPendingImages([]);
+        setPendingKnowledgeBases([]);
+        setPendingSkillId(undefined);
+      }
+    }
+    void sendPendingMessage();
+  }, [
+    pendingMessage,
+    sendTextMessage,
+    setPendingMessage,
+    sources,
+    createFileSourceAsync,
+    setSources,
+    pendingImages,
+    setPendingImages,
+    pendingKnowledgeBases,
+    setPendingKnowledgeBases,
+    pendingSkillId,
+    setPendingSkillId,
+    addKnowledgeBaseAsync,
+    chatInputRef,
+    t,
+    resetCreateFileSourceMutation,
+  ]);
+
+  return {
+    pendingMessage,
+    sources,
+    pendingImages,
+    pendingKnowledgeBases,
+    pendingSkillId,
+    isProcessingPendingSources,
+  };
+}

--- a/ayunis-core-frontend/src/pages/chat/ui/ChatPage.tsx
+++ b/ayunis-core-frontend/src/pages/chat/ui/ChatPage.tsx
@@ -11,13 +11,12 @@ import ChatInterfaceLayout from '@/layouts/chat-interface-layout/ui/ChatInterfac
 import ChatMessage from '@/pages/chat/ui/ChatMessage';
 import StreamingLoadingIndicator from '@/pages/chat/ui/StreamingLoadingIndicator';
 import ChatInput from '@/widgets/chat-input';
-import { useChatContext } from '@/shared/contexts/chat/useChatContext';
 import { useMessageSend } from '../api/useMessageSend';
 import ChatHeader from './ChatHeader';
 import LongChatWarning from './LongChatWarning';
 import UnavailableAgentWarning from './UnavailableAgentWarning';
 import type { Thread, Message } from '../model/openapi';
-import { showError, showSuccess } from '@/shared/lib/toast';
+import { showError } from '@/shared/lib/toast';
 import config from '@/shared/config';
 
 import { useConfirmation } from '@/widgets/confirmation-modal';
@@ -36,12 +35,8 @@ import { AxiosError } from 'axios';
 import type { ChatInputRef } from '@/widgets/chat-input/ui/ChatInput';
 import { useCreateFileSource } from '@/pages/chat/api/useCreateFileSource';
 import { useDeleteFileSource } from '../api/useDeleteFileSource';
-import { useArtifact } from '../api/useArtifact';
-import { useUpdateArtifact } from '../api/useUpdateArtifact';
-import { useRevertArtifact } from '../api/useRevertArtifact';
-import { useExportArtifact } from '../api/useExportArtifact';
-import { UpdateArtifactDtoAuthorType } from '@/shared/api/generated/ayunisCoreAPI.schemas';
-import type { ArtifactsControllerExportFormat } from '@/shared/api/generated/ayunisCoreAPI.schemas';
+import { useArtifactActions } from '../hooks/useArtifactActions';
+import { usePendingMessage } from '../hooks/usePendingMessage';
 import { useAgents } from '@/features/useAgents';
 import { useIsAgentsEnabled } from '@/features/feature-toggles';
 import { usePermittedModels } from '@/features/usePermittedModels';
@@ -107,78 +102,23 @@ export default function ChatPage({
   ]);
 
   const queryClient = useQueryClient();
-  const processedPendingMessageRef = useRef<string | null>(null);
   const chatInputRef = useRef<ChatInputRef>(null);
 
-  const {
-    pendingMessage,
-    setPendingMessage,
-    sources,
-    setSources,
-    pendingImages,
-    setPendingImages,
-    pendingKnowledgeBases,
-    setPendingKnowledgeBases,
-    pendingSkillId,
-    setPendingSkillId,
-  } = useChatContext();
   const [threadTitle, setThreadTitle] = useState<string | undefined>(
     thread.title,
   );
   const [messages, setMessages] = useState<Message[]>(thread.messages);
   const [isStreaming, setIsStreaming] = useState(false);
-  const [isProcessingPendingSources, setIsProcessingPendingSources] =
-    useState(false);
   const [renameDialogOpen, setRenameDialogOpen] = useState(false);
-  const [openArtifactId, setOpenArtifactId] = useState<string | null>(null);
-
-  // Fetch the open artifact with versions
-  const { artifact: openArtifact } = useArtifact(openArtifactId);
-
-  const { updateArtifact: saveArtifact } = useUpdateArtifact({
-    artifactId: openArtifactId ?? '',
-    threadId: thread.id,
-    onSuccess: () => showSuccess(t('chat.artifactSaved')),
-  });
-
-  const { revertArtifact } = useRevertArtifact({
-    artifactId: openArtifactId ?? '',
-    threadId: thread.id,
-  });
-
-  const { exportArtifact, isExporting } = useExportArtifact({
-    artifactId: openArtifactId ?? '',
-    title: openArtifact?.title ?? 'document',
-  });
-
-  const handleOpenArtifact = useCallback((artifactId: string) => {
-    setOpenArtifactId(artifactId);
-  }, []);
-
-  const handleSaveArtifact = useCallback(
-    (content: string) => {
-      saveArtifact({ content, authorType: UpdateArtifactDtoAuthorType.USER });
-    },
-    [saveArtifact],
-  );
-
-  const handleRevertArtifact = useCallback(
-    (versionNumber: number) => {
-      revertArtifact(versionNumber);
-    },
-    [revertArtifact],
-  );
-
-  const handleExportArtifact = useCallback(
-    (format: 'docx' | 'pdf') => {
-      void exportArtifact(format as ArtifactsControllerExportFormat);
-    },
-    [exportArtifact],
-  );
-
-  const handleCloseArtifact = useCallback(() => {
-    setOpenArtifactId(null);
-  }, []);
+  const {
+    openArtifact,
+    isExporting,
+    handleOpenArtifact,
+    handleSaveArtifact,
+    handleRevertArtifact,
+    handleExportArtifact,
+    handleCloseArtifact,
+  } = useArtifactActions(thread.id);
 
   const sortedMessages = useMemo(() => {
     return [...messages].sort((a, b) => (a.createdAt > b.createdAt ? 1 : -1));
@@ -209,9 +149,6 @@ export default function ChatPage({
   const { addKnowledgeBase, addKnowledgeBaseAsync, removeKnowledgeBase } =
     useKnowledgeBaseAttachment({ threadId: thread.id });
   const { downloadSource } = useDownloadSource(thread);
-
-  const isTotallyCreatingFileSource =
-    isCreatingFileSource || isProcessingPendingSources;
 
   const handleMessage = useCallback((message: RunMessageResponseDtoMessage) => {
     setMessages((prev) => {
@@ -273,6 +210,17 @@ export default function ChatPage({
       setIsStreaming(false);
     },
   });
+
+  const { isProcessingPendingSources } = usePendingMessage({
+    sendTextMessage,
+    createFileSourceAsync,
+    resetCreateFileSourceMutation,
+    addKnowledgeBaseAsync,
+    chatInputRef,
+  });
+
+  const isTotallyCreatingFileSource =
+    isCreatingFileSource || isProcessingPendingSources;
 
   async function handleSend(
     message: string,
@@ -360,95 +308,6 @@ export default function ChatPage({
     setMessages(thread.messages);
     setThreadTitle(thread.title);
   }, [thread]);
-
-  // Send pending message from NewChatPage if it exists
-  useEffect(() => {
-    async function uploadPendingSources() {
-      if (sources.length === 0) return;
-      setIsProcessingPendingSources(true);
-      const promises = sources.map((source) =>
-        createFileSourceAsync({
-          file: source.file,
-          name: source.name,
-          description: `File source: ${source.name}`,
-        }),
-      );
-      await Promise.all(promises as Promise<unknown>[]);
-      resetCreateFileSourceMutation();
-    }
-
-    async function attachPendingKnowledgeBases() {
-      if (pendingKnowledgeBases.length === 0) return;
-      const results = await Promise.allSettled(
-        pendingKnowledgeBases.map((kb) => addKnowledgeBaseAsync(kb.id)),
-      );
-      const failed = results.filter((r) => r.status === 'rejected');
-      if (failed.length > 0) {
-        console.error(
-          `Failed to attach ${String(failed.length)} knowledge base(s)`,
-        );
-      }
-    }
-
-    function buildPendingImages(): PendingImage[] | undefined {
-      if (pendingImages.length === 0) return undefined;
-      return pendingImages.map((img) => ({
-        file: img.file,
-        altText: img.altText ?? (img.file.name || 'Pasted image'),
-      }));
-    }
-
-    async function sendPendingMessage() {
-      if (
-        !pendingMessage ||
-        processedPendingMessageRef.current === pendingMessage
-      ) {
-        return;
-      }
-      processedPendingMessageRef.current = pendingMessage;
-      try {
-        await uploadPendingSources();
-        setSources([]);
-        await attachPendingKnowledgeBases();
-        await sendTextMessage({
-          text: pendingMessage,
-          images: buildPendingImages(),
-          skillId: pendingSkillId,
-        });
-      } catch (error) {
-        if (error instanceof AxiosError && error.response?.status === 403) {
-          showError(t('chat.upgradeToProError'));
-        } else {
-          showError(t('chat.errorSendMessage'));
-        }
-        chatInputRef.current?.setMessage(pendingMessage);
-      } finally {
-        setIsProcessingPendingSources(false);
-        setPendingMessage('');
-        setPendingImages([]);
-        setPendingKnowledgeBases([]);
-        setPendingSkillId(undefined);
-      }
-    }
-    void sendPendingMessage();
-  }, [
-    pendingMessage,
-    sendTextMessage,
-    setPendingMessage,
-    sources,
-    createFileSourceAsync,
-    setSources,
-    pendingImages,
-    setPendingImages,
-    pendingKnowledgeBases,
-    setPendingKnowledgeBases,
-    pendingSkillId,
-    setPendingSkillId,
-    addKnowledgeBaseAsync,
-    chatInputRef,
-    t,
-    resetCreateFileSourceMutation,
-  ]);
 
   const chatHeader = (
     <ChatHeader

--- a/ayunis-core-frontend/src/widgets/artifact-editor/ui/ArtifactEditor.tsx
+++ b/ayunis-core-frontend/src/widgets/artifact-editor/ui/ArtifactEditor.tsx
@@ -14,12 +14,12 @@ import { VersionHistory } from './VersionHistory';
 import { ExportButtons } from './ExportButtons';
 
 interface ArtifactEditorProps {
-  artifact: ArtifactResponseDto;
-  onSave: (content: string) => void;
-  onRevert: (versionNumber: number) => void;
-  onExport: (format: 'docx' | 'pdf') => void;
-  onClose: () => void;
-  isExporting?: boolean;
+  readonly artifact: ArtifactResponseDto;
+  readonly onSave: (content: string) => void;
+  readonly onRevert: (versionNumber: number) => void;
+  readonly onExport: (format: 'docx' | 'pdf', unsavedContent?: string) => void;
+  readonly onClose: () => void;
+  readonly isExporting?: boolean;
 }
 
 export function ArtifactEditor({
@@ -58,7 +58,7 @@ export function ArtifactEditor({
 
   // Update editor content only when the version number actually changes
   useEffect(() => {
-    if (!editor || !currentVersion) return;
+    if (!currentVersion) return;
 
     if (loadedVersionRef.current !== artifact.currentVersionNumber) {
       loadedVersionRef.current = artifact.currentVersionNumber;
@@ -67,9 +67,17 @@ export function ArtifactEditor({
   }, [editor, currentVersion, artifact.currentVersionNumber]);
 
   const handleSave = useCallback(() => {
-    if (!editor) return;
     onSave(editor.getHTML());
   }, [editor, onSave]);
+
+  const handleExport = useCallback(
+    (format: 'docx' | 'pdf') => {
+      const isDirty =
+        currentVersion && editor.getHTML() !== currentVersion.content;
+      onExport(format, isDirty ? editor.getHTML() : undefined);
+    },
+    [editor, currentVersion, onExport],
+  );
 
   return (
     <div className="flex h-full flex-col overflow-hidden border-l">
@@ -79,7 +87,7 @@ export function ArtifactEditor({
           {artifact.title}
         </h3>
         <div className="flex items-center gap-1">
-          <ExportButtons onExport={onExport} isExporting={isExporting} />
+          <ExportButtons onExport={handleExport} isExporting={isExporting} />
           <Button
             variant="default"
             size="sm"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches chat send/export flows by introducing async artifact saves before export and extracting pending-message processing into a hook, which could affect user-facing behavior if edge cases (dirty detection, failed save/export, pending uploads) are missed.
> 
> **Overview**
> **Artifact export now persists unsaved editor changes first.** `ArtifactEditor` detects dirty content on export and passes it up, and `useUpdateArtifact` exposes `updateArtifactAsync` so exports can await a save before downloading.
> 
> **ChatPage logic is refactored into hooks.** New `useArtifactActions` encapsulates open/save/revert/export behavior (including the new save-then-export path), and new `usePendingMessage` moves the “send pending message with uploaded sources/KB attachments” effect out of `ChatPage` while preserving error handling and the `isTotallyCreatingFileSource` state.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e1277af1e5511a3b3f9b639e7fcaf65809e44b9d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->