### PR TITLE
fix(AYC-000): prevent AI from overwriting user edits to artifacts

### DIFF
--- a/ayunis-core-backend/src/domain/artifacts/application/artifacts.errors.ts
+++ b/ayunis-core-backend/src/domain/artifacts/application/artifacts.errors.ts
@@ -8,6 +8,7 @@ export enum ArtifactErrorCode {
   ARTIFACT_NOT_FOUND = 'ARTIFACT_NOT_FOUND',
   ARTIFACT_VERSION_NOT_FOUND = 'ARTIFACT_VERSION_NOT_FOUND',
   ARTIFACT_VERSION_CONFLICT = 'ARTIFACT_VERSION_CONFLICT',
+  ARTIFACT_EXPECTED_VERSION_MISMATCH = 'ARTIFACT_EXPECTED_VERSION_MISMATCH',
   ARTIFACT_CONTENT_TOO_LARGE = 'ARTIFACT_CONTENT_TOO_LARGE',
   ARTIFACT_EDIT_NOT_FOUND = 'ARTIFACT_EDIT_NOT_FOUND',
   ARTIFACT_EDIT_AMBIGUOUS = 'ARTIFACT_EDIT_AMBIGUOUS',
@@ -58,6 +59,24 @@ export class ArtifactVersionConflictError extends ArtifactError {
       ArtifactErrorCode.ARTIFACT_VERSION_CONFLICT,
       409,
       { artifactId, ...metadata },
+    );
+  }
+}
+
+export class ArtifactExpectedVersionMismatchError extends ArtifactError {
+  constructor(
+    artifactId: string,
+    expectedVersion: number,
+    actualVersion: number,
+    metadata?: ErrorMetadata,
+  ) {
+    super(
+      `Version conflict: you expected version ${expectedVersion} but the document is at version ${actualVersion}. ` +
+        `The document has been edited since you last saw it. ` +
+        `Use read_document to get the current content and version, then retry your edit.`,
+      ArtifactErrorCode.ARTIFACT_EXPECTED_VERSION_MISMATCH,
+      409,
+      { artifactId, expectedVersion, actualVersion, ...metadata },
     );
   }
 }

--- a/ayunis-core-backend/src/domain/artifacts/application/use-cases/apply-edits-to-artifact/apply-edits-to-artifact.command.ts
+++ b/ayunis-core-backend/src/domain/artifacts/application/use-cases/apply-edits-to-artifact/apply-edits-to-artifact.command.ts
@@ -10,14 +10,17 @@ export class ApplyEditsToArtifactCommand {
   readonly artifactId: UUID;
   readonly edits: ArtifactEdit[];
   readonly authorType: AuthorType;
+  readonly expectedVersionNumber?: number;
 
   constructor(params: {
     artifactId: UUID;
     edits: ArtifactEdit[];
     authorType: AuthorType;
+    expectedVersionNumber?: number;
   }) {
     this.artifactId = params.artifactId;
     this.edits = params.edits;
     this.authorType = params.authorType;
+    this.expectedVersionNumber = params.expectedVersionNumber;
   }
 }

--- a/ayunis-core-backend/src/domain/artifacts/application/use-cases/apply-edits-to-artifact/apply-edits-to-artifact.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/artifacts/application/use-cases/apply-edits-to-artifact/apply-edits-to-artifact.use-case.spec.ts
@@ -9,6 +9,7 @@ import {
   ArtifactContentTooLargeError,
   ArtifactEditAmbiguousError,
   ArtifactEditNotFoundError,
+  ArtifactExpectedVersionMismatchError,
   ArtifactNotFoundError,
   ARTIFACT_MAX_CONTENT_LENGTH,
 } from '../../artifacts.errors';
@@ -213,6 +214,66 @@ describe('ApplyEditsToArtifactUseCase', () => {
       await expect(useCase.execute(command)).rejects.toThrow(
         ArtifactContentTooLargeError,
       );
+    });
+
+    it('should throw ArtifactExpectedVersionMismatchError when expected version does not match', async () => {
+      const advancedArtifact = new Artifact({
+        id: mockArtifactId,
+        threadId: mockThreadId,
+        userId: mockUserId,
+        title: 'Test Document',
+        currentVersionNumber: 5,
+        versions: [
+          new ArtifactVersion({
+            artifactId: mockArtifactId,
+            versionNumber: 5,
+            content: '<p>User-edited content</p>',
+            authorType: AuthorType.USER,
+            authorId: mockUserId,
+          }),
+        ],
+      });
+
+      artifactsRepository.findByIdWithVersions.mockResolvedValue(
+        advancedArtifact,
+      );
+
+      const command = new ApplyEditsToArtifactCommand({
+        artifactId: mockArtifactId,
+        edits: [{ oldText: 'Hello', newText: 'Hi' }],
+        authorType: AuthorType.ASSISTANT,
+        expectedVersionNumber: 1,
+      });
+
+      await expect(useCase.execute(command)).rejects.toThrow(
+        ArtifactExpectedVersionMismatchError,
+      );
+    });
+
+    it('should succeed when expected version matches current version', async () => {
+      const originalContent = '<p>Hello world</p>';
+      const mockArtifact = createArtifactWithVersions(originalContent);
+
+      const mockVersion = new ArtifactVersion({
+        artifactId: mockArtifactId,
+        versionNumber: 2,
+        content: '<p>Hello universe</p>',
+        authorType: AuthorType.ASSISTANT,
+        authorId: null,
+      });
+
+      artifactsRepository.findByIdWithVersions.mockResolvedValue(mockArtifact);
+      updateArtifactUseCase.execute.mockResolvedValue(mockVersion);
+
+      const command = new ApplyEditsToArtifactCommand({
+        artifactId: mockArtifactId,
+        edits: [{ oldText: 'world', newText: 'universe' }],
+        authorType: AuthorType.ASSISTANT,
+        expectedVersionNumber: 1,
+      });
+
+      const result = await useCase.execute(command);
+      expect(result).toBe(mockVersion);
     });
 
     it('should throw ArtifactNotFoundError when artifact does not exist', async () => {

--- a/ayunis-core-backend/src/domain/artifacts/application/use-cases/apply-edits-to-artifact/apply-edits-to-artifact.use-case.ts
+++ b/ayunis-core-backend/src/domain/artifacts/application/use-cases/apply-edits-to-artifact/apply-edits-to-artifact.use-case.ts
@@ -5,6 +5,7 @@ import {
   ArtifactContentTooLargeError,
   ArtifactEditAmbiguousError,
   ArtifactEditNotFoundError,
+  ArtifactExpectedVersionMismatchError,
   ArtifactNotFoundError,
   ArtifactVersionNotFoundError,
   UnexpectedArtifactError,
@@ -50,6 +51,17 @@ export class ApplyEditsToArtifactUseCase {
         throw new ArtifactNotFoundError(command.artifactId);
       }
 
+      if (
+        command.expectedVersionNumber !== undefined &&
+        command.expectedVersionNumber !== artifact.currentVersionNumber
+      ) {
+        throw new ArtifactExpectedVersionMismatchError(
+          command.artifactId,
+          command.expectedVersionNumber,
+          artifact.currentVersionNumber,
+        );
+      }
+
       // Find current version content
       const currentVersion = artifact.versions.find(
         (v) => v.versionNumber === artifact.currentVersionNumber,
@@ -61,44 +73,7 @@ export class ApplyEditsToArtifactUseCase {
         );
       }
 
-      let content = currentVersion.content;
-
-      // Apply edits sequentially
-      for (let i = 0; i < command.edits.length; i++) {
-        const edit = command.edits[i];
-        const { oldText, newText } = edit;
-
-        // Guard against empty oldText which would cause infinite loop in findOccurrences
-        if (oldText.length === 0) {
-          throw new ArtifactEditNotFoundError(i + 1, oldText);
-        }
-
-        // Find occurrences of oldText
-        const occurrences = this.findOccurrences(content, oldText);
-
-        if (occurrences.length === 0) {
-          throw new ArtifactEditNotFoundError(i + 1, oldText);
-        }
-
-        if (occurrences.length > 1) {
-          throw new ArtifactEditAmbiguousError(i + 1, oldText);
-        }
-
-        // Apply the edit
-        const index = occurrences[0];
-        content =
-          content.substring(0, index) +
-          newText +
-          content.substring(index + oldText.length);
-      }
-
-      // Check content length after edits
-      if (content.length > ARTIFACT_MAX_CONTENT_LENGTH) {
-        throw new ArtifactContentTooLargeError(
-          content.length,
-          ARTIFACT_MAX_CONTENT_LENGTH,
-        );
-      }
+      const content = this.applyEdits(currentVersion.content, command.edits);
 
       // Sanitize and save using UpdateArtifactUseCase
       const updateCommand = new UpdateArtifactCommand({
@@ -121,6 +96,45 @@ export class ApplyEditsToArtifactUseCase {
         error instanceof Error ? error.message : 'Unknown error',
       );
     }
+  }
+
+  private applyEdits(
+    originalContent: string,
+    edits: ApplyEditsToArtifactCommand['edits'],
+  ): string {
+    let content = originalContent;
+
+    for (let i = 0; i < edits.length; i++) {
+      const { oldText, newText } = edits[i];
+
+      if (oldText.length === 0) {
+        throw new ArtifactEditNotFoundError(i + 1, oldText);
+      }
+
+      const occurrences = this.findOccurrences(content, oldText);
+
+      if (occurrences.length === 0) {
+        throw new ArtifactEditNotFoundError(i + 1, oldText);
+      }
+      if (occurrences.length > 1) {
+        throw new ArtifactEditAmbiguousError(i + 1, oldText);
+      }
+
+      const index = occurrences[0];
+      content =
+        content.substring(0, index) +
+        newText +
+        content.substring(index + oldText.length);
+    }
+
+    if (content.length > ARTIFACT_MAX_CONTENT_LENGTH) {
+      throw new ArtifactContentTooLargeError(
+        content.length,
+        ARTIFACT_MAX_CONTENT_LENGTH,
+      );
+    }
+
+    return content;
   }
 
   private findOccurrences(content: string, searchText: string): number[] {

--- a/ayunis-core-backend/src/domain/artifacts/application/use-cases/update-artifact/update-artifact.command.ts
+++ b/ayunis-core-backend/src/domain/artifacts/application/use-cases/update-artifact/update-artifact.command.ts
@@ -5,14 +5,17 @@ export class UpdateArtifactCommand {
   readonly artifactId: UUID;
   readonly content: string;
   readonly authorType: AuthorType;
+  readonly expectedVersionNumber?: number;
 
   constructor(params: {
     artifactId: UUID;
     content: string;
     authorType: AuthorType;
+    expectedVersionNumber?: number;
   }) {
     this.artifactId = params.artifactId;
     this.content = params.content;
     this.authorType = params.authorType;
+    this.expectedVersionNumber = params.expectedVersionNumber;
   }
 }

--- a/ayunis-core-backend/src/domain/artifacts/application/use-cases/update-artifact/update-artifact.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/artifacts/application/use-cases/update-artifact/update-artifact.use-case.spec.ts
@@ -8,6 +8,7 @@ import { UpdateArtifactCommand } from './update-artifact.command';
 import { ArtifactsRepository } from '../../ports/artifacts-repository.port';
 import {
   ArtifactContentTooLargeError,
+  ArtifactExpectedVersionMismatchError,
   ArtifactNotFoundError,
   ArtifactVersionConflictError,
   ARTIFACT_MAX_CONTENT_LENGTH,
@@ -315,6 +316,82 @@ describe('UpdateArtifactUseCase', () => {
     await expect(useCaseNoAuth.execute(command)).rejects.toThrow(
       UnauthorizedAccessError,
     );
+  });
+
+  describe('expected version check', () => {
+    it('should throw ArtifactExpectedVersionMismatchError when expected version does not match', async () => {
+      const existingArtifact = new Artifact({
+        id: mockArtifactId,
+        threadId: mockThreadId,
+        userId: mockUserId,
+        title: 'User-Edited Report',
+        currentVersionNumber: 5,
+      });
+
+      artifactsRepository.findById.mockResolvedValue(existingArtifact);
+
+      const command = new UpdateArtifactCommand({
+        artifactId: mockArtifactId,
+        content: '<p>Stale content</p>',
+        authorType: AuthorType.ASSISTANT,
+        expectedVersionNumber: 3,
+      });
+
+      await expect(useCase.execute(command)).rejects.toThrow(
+        ArtifactExpectedVersionMismatchError,
+      );
+    });
+
+    it('should succeed when expected version matches current version', async () => {
+      const existingArtifact = new Artifact({
+        id: mockArtifactId,
+        threadId: mockThreadId,
+        userId: mockUserId,
+        title: 'Current Report',
+        currentVersionNumber: 3,
+      });
+
+      artifactsRepository.findById.mockResolvedValue(existingArtifact);
+      artifactsRepository.addVersionAndUpdateCurrent.mockImplementation(
+        async (version) => version,
+      );
+
+      const command = new UpdateArtifactCommand({
+        artifactId: mockArtifactId,
+        content: '<p>Updated content</p>',
+        authorType: AuthorType.ASSISTANT,
+        expectedVersionNumber: 3,
+      });
+
+      const result = await useCase.execute(command);
+
+      expect(result.versionNumber).toBe(4);
+    });
+
+    it('should skip version check when expectedVersionNumber is not provided', async () => {
+      const existingArtifact = new Artifact({
+        id: mockArtifactId,
+        threadId: mockThreadId,
+        userId: mockUserId,
+        title: 'No Version Check Report',
+        currentVersionNumber: 5,
+      });
+
+      artifactsRepository.findById.mockResolvedValue(existingArtifact);
+      artifactsRepository.addVersionAndUpdateCurrent.mockImplementation(
+        async (version) => version,
+      );
+
+      const command = new UpdateArtifactCommand({
+        artifactId: mockArtifactId,
+        content: '<p>Content without version check</p>',
+        authorType: AuthorType.USER,
+      });
+
+      const result = await useCase.execute(command);
+
+      expect(result.versionNumber).toBe(6);
+    });
   });
 
   describe('retry on version conflict', () => {

--- a/ayunis-core-backend/src/domain/artifacts/application/use-cases/update-artifact/update-artifact.use-case.ts
+++ b/ayunis-core-backend/src/domain/artifacts/application/use-cases/update-artifact/update-artifact.use-case.ts
@@ -3,6 +3,7 @@ import { ArtifactsRepository } from '../../ports/artifacts-repository.port';
 import { UpdateArtifactCommand } from './update-artifact.command';
 import {
   ArtifactContentTooLargeError,
+  ArtifactExpectedVersionMismatchError,
   ArtifactNotFoundError,
   UnexpectedArtifactError,
   ARTIFACT_MAX_CONTENT_LENGTH,
@@ -53,6 +54,17 @@ export class UpdateArtifactUseCase {
           );
           if (!artifact) {
             throw new ArtifactNotFoundError(command.artifactId);
+          }
+
+          if (
+            command.expectedVersionNumber !== undefined &&
+            command.expectedVersionNumber !== artifact.currentVersionNumber
+          ) {
+            throw new ArtifactExpectedVersionMismatchError(
+              command.artifactId,
+              command.expectedVersionNumber,
+              artifact.currentVersionNumber,
+            );
           }
 
           return new ArtifactVersion({

--- a/ayunis-core-backend/src/domain/runs/application/services/tool-assembly.service.ts
+++ b/ayunis-core-backend/src/domain/runs/application/services/tool-assembly.service.ts
@@ -35,6 +35,9 @@ import {
 import type { SkillTemplate } from 'src/domain/skill-templates/domain/skill-template.entity';
 import { FindArtifactsByThreadUseCase } from 'src/domain/artifacts/application/use-cases/find-artifacts-by-thread/find-artifacts-by-thread.use-case';
 import { FindArtifactsByThreadQuery } from 'src/domain/artifacts/application/use-cases/find-artifacts-by-thread/find-artifacts-by-thread.query';
+import { FindArtifactWithVersionsUseCase } from 'src/domain/artifacts/application/use-cases/find-artifact-with-versions/find-artifact-with-versions.use-case';
+import { FindArtifactWithVersionsQuery } from 'src/domain/artifacts/application/use-cases/find-artifact-with-versions/find-artifact-with-versions.query';
+import { AuthorType } from 'src/domain/artifacts/domain/value-objects/author-type.enum';
 
 @Injectable()
 export class ToolAssemblyService {
@@ -52,6 +55,7 @@ export class ToolAssemblyService {
     @Inject(featuresConfig.KEY)
     private readonly features: ConfigType<typeof featuresConfig>,
     private readonly findArtifactsByThreadUseCase: FindArtifactsByThreadUseCase,
+    private readonly findArtifactWithVersionsUseCase: FindArtifactWithVersionsUseCase,
   ) {}
 
   async findActiveSkills(): Promise<Skill[]> {
@@ -460,27 +464,35 @@ export class ToolAssemblyService {
       new FindArtifactsByThreadQuery({ threadId: thread.id }),
     );
 
-    const artifactLines = threadArtifacts.map(
-      (a) => '- ' + a.id + ': "' + a.title + '"',
-    );
-    const artifactSuffix =
+    const artifactLines: string[] = [];
+    for (const a of threadArtifacts) {
+      const full = await this.findArtifactWithVersionsUseCase.execute(
+        new FindArtifactWithVersionsQuery({ artifactId: a.id }),
+      );
+      const cur = full.versions.find(
+        (v) => v.versionNumber === full.currentVersionNumber,
+      );
+      const warn =
+        cur?.authorType === AuthorType.USER
+          ? ' (⚠ user-edited — use read_document before editing)'
+          : '';
+      artifactLines.push(`- ${a.id}: "${a.title}"${warn}`);
+    }
+
+    const suffix =
       artifactLines.length > 0
         ? `\n\nAvailable documents in this conversation:\n${artifactLines.join('\n')}`
         : '';
 
-    const toolTypes = [ToolType.UPDATE_DOCUMENT, ToolType.EDIT_DOCUMENT];
+    const toolTypes = [ToolType.UPDATE_DOCUMENT, ToolType.EDIT_DOCUMENT, ToolType.READ_DOCUMENT];
     const tools: Tool[] = [];
-
     for (const type of toolTypes) {
-      const tool = await this.assembleToolsUseCase.execute(
-        new AssembleToolCommand({ type }),
-      );
-      if (artifactSuffix) {
-        tool.descriptionLong = `${tool.descriptionLong ?? tool.description}${artifactSuffix}`;
+      const tool = await this.assembleToolsUseCase.execute(new AssembleToolCommand({ type }));
+      if (suffix) {
+        tool.descriptionLong = `${tool.descriptionLong ?? tool.description}${suffix}`;
       }
       tools.push(tool);
     }
-
     return tools;
   }
 }

--- a/ayunis-core-backend/src/domain/tools/application/handlers/create-document-tool.handler.spec.ts
+++ b/ayunis-core-backend/src/domain/tools/application/handlers/create-document-tool.handler.spec.ts
@@ -96,6 +96,7 @@ describe('CreateDocumentToolHandler', () => {
 
     expect(result).toContain(mockArtifactId);
     expect(result).toContain('Document created successfully');
+    expect(result).toContain('version: 1');
   });
 
   it('should throw ToolExecutionFailedError when CreateArtifactUseCase fails', async () => {

--- a/ayunis-core-backend/src/domain/tools/application/handlers/create-document-tool.handler.ts
+++ b/ayunis-core-backend/src/domain/tools/application/handlers/create-document-tool.handler.ts
@@ -37,7 +37,7 @@ export class CreateDocumentToolHandler extends ToolExecutionHandler {
         }),
       );
 
-      return `Document created successfully. Artifact ID: ${artifact.id}`;
+      return `Document created successfully. Artifact ID: ${artifact.id}, version: ${artifact.currentVersionNumber}`;
     } catch (error) {
       if (error instanceof ToolExecutionFailedError) {
         throw error;

--- a/ayunis-core-backend/src/domain/tools/application/handlers/edit-document-tool.handler.ts
+++ b/ayunis-core-backend/src/domain/tools/application/handlers/edit-document-tool.handler.ts
@@ -12,6 +12,7 @@ import { UUID } from 'crypto';
 import {
   ArtifactEditAmbiguousError,
   ArtifactEditNotFoundError,
+  ArtifactExpectedVersionMismatchError,
 } from 'src/domain/artifacts/application/artifacts.errors';
 
 @Injectable()
@@ -40,23 +41,32 @@ export class EditDocumentToolHandler extends ToolExecutionHandler {
         newText: edit.new_text,
       }));
 
-      await this.applyEditsToArtifactUseCase.execute(
+      const version = await this.applyEditsToArtifactUseCase.execute(
         new ApplyEditsToArtifactCommand({
           artifactId: validatedInput.artifact_id as UUID,
           edits: edits,
           authorType: AuthorType.ASSISTANT,
+          expectedVersionNumber: validatedInput.expected_version,
         }),
       );
 
       const editCount = edits.length;
       const editWord = editCount === 1 ? 'edit' : 'edits';
-      return `Document edited successfully. Applied ${editCount} ${editWord} to artifact ID: ${validatedInput.artifact_id}`;
+      return `Document edited successfully. Applied ${editCount} ${editWord} to artifact ID: ${validatedInput.artifact_id}, version: ${version.versionNumber}`;
     } catch (error) {
       if (error instanceof ToolExecutionFailedError) {
         throw error;
       }
 
-      // Map artifact edit errors to tool execution errors that can be retried by the LLM
+      // Map artifact errors to tool execution errors that can be retried by the LLM
+      if (error instanceof ArtifactExpectedVersionMismatchError) {
+        throw new ToolExecutionFailedError({
+          toolName: tool.name,
+          message: error.message,
+          exposeToLLM: true,
+        });
+      }
+
       if (
         error instanceof ArtifactEditNotFoundError ||
         error instanceof ArtifactEditAmbiguousError

--- a/ayunis-core-backend/src/domain/tools/application/handlers/read-document-tool.handler.spec.ts
+++ b/ayunis-core-backend/src/domain/tools/application/handlers/read-document-tool.handler.spec.ts
@@ -1,0 +1,138 @@
+import type { TestingModule } from '@nestjs/testing';
+import { Test } from '@nestjs/testing';
+import { Logger } from '@nestjs/common';
+import { randomUUID } from 'crypto';
+import { ReadDocumentToolHandler } from './read-document-tool.handler';
+import { FindArtifactWithVersionsUseCase } from 'src/domain/artifacts/application/use-cases/find-artifact-with-versions/find-artifact-with-versions.use-case';
+import { ReadDocumentTool } from '../../domain/tools/read-document-tool.entity';
+import { Artifact } from 'src/domain/artifacts/domain/artifact.entity';
+import { ArtifactVersion } from 'src/domain/artifacts/domain/artifact-version.entity';
+import { AuthorType } from 'src/domain/artifacts/domain/value-objects/author-type.enum';
+import { ToolExecutionFailedError } from '../tools.errors';
+
+describe('ReadDocumentToolHandler', () => {
+  let handler: ReadDocumentToolHandler;
+  let mockFindArtifactUseCase: jest.Mocked<FindArtifactWithVersionsUseCase>;
+
+  const mockThreadId = randomUUID();
+  const mockOrgId = randomUUID();
+  const mockArtifactId = randomUUID();
+  const mockUserId = randomUUID();
+
+  beforeEach(async () => {
+    mockFindArtifactUseCase = {
+      execute: jest.fn(),
+    } as unknown as jest.Mocked<FindArtifactWithVersionsUseCase>;
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ReadDocumentToolHandler,
+        {
+          provide: FindArtifactWithVersionsUseCase,
+          useValue: mockFindArtifactUseCase,
+        },
+      ],
+    }).compile();
+
+    handler = module.get<ReadDocumentToolHandler>(ReadDocumentToolHandler);
+
+    jest.spyOn(Logger.prototype, 'log').mockImplementation();
+    jest.spyOn(Logger.prototype, 'error').mockImplementation();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  function createMockArtifact(
+    versionNumber: number,
+    content: string,
+  ): Artifact {
+    const version = new ArtifactVersion({
+      id: randomUUID(),
+      artifactId: mockArtifactId,
+      versionNumber,
+      content,
+      authorType: AuthorType.USER,
+      authorId: mockUserId,
+    });
+
+    return new Artifact({
+      id: mockArtifactId,
+      threadId: mockThreadId,
+      userId: mockUserId,
+      title: 'Municipal Budget Report 2026',
+      currentVersionNumber: versionNumber,
+      versions: [version],
+    });
+  }
+
+  it('should return document content with title and version number', async () => {
+    const artifact = createMockArtifact(
+      3,
+      '<h1>Budget Report</h1><p>Total: €5.2M</p>',
+    );
+    mockFindArtifactUseCase.execute.mockResolvedValue(artifact);
+
+    const tool = new ReadDocumentTool();
+    const input = { artifact_id: mockArtifactId };
+
+    const result = await handler.execute({
+      tool,
+      input,
+      context: { threadId: mockThreadId, orgId: mockOrgId },
+    });
+
+    expect(result).toContain('Municipal Budget Report 2026');
+    expect(result).toContain('version: 3');
+    expect(result).toContain('<h1>Budget Report</h1><p>Total: €5.2M</p>');
+  });
+
+  it('should call FindArtifactWithVersionsUseCase with the correct artifact ID', async () => {
+    const artifact = createMockArtifact(1, '<p>Content</p>');
+    mockFindArtifactUseCase.execute.mockResolvedValue(artifact);
+
+    const tool = new ReadDocumentTool();
+    const input = { artifact_id: mockArtifactId };
+
+    await handler.execute({
+      tool,
+      input,
+      context: { threadId: mockThreadId, orgId: mockOrgId },
+    });
+
+    expect(mockFindArtifactUseCase.execute).toHaveBeenCalledTimes(1);
+    const query = mockFindArtifactUseCase.execute.mock.calls[0][0];
+    expect(query.artifactId).toBe(mockArtifactId);
+  });
+
+  it('should throw ToolExecutionFailedError when use case fails', async () => {
+    mockFindArtifactUseCase.execute.mockRejectedValue(
+      new Error('Artifact not found'),
+    );
+
+    const tool = new ReadDocumentTool();
+    const input = { artifact_id: mockArtifactId };
+
+    await expect(
+      handler.execute({
+        tool,
+        input,
+        context: { threadId: mockThreadId, orgId: mockOrgId },
+      }),
+    ).rejects.toThrow(ToolExecutionFailedError);
+  });
+
+  it('should throw ToolExecutionFailedError when input validation fails', async () => {
+    const tool = new ReadDocumentTool();
+    const input = {};
+
+    await expect(
+      handler.execute({
+        tool,
+        input,
+        context: { threadId: mockThreadId, orgId: mockOrgId },
+      }),
+    ).rejects.toThrow(ToolExecutionFailedError);
+  });
+});

--- a/ayunis-core-backend/src/domain/tools/application/handlers/read-document-tool.handler.ts
+++ b/ayunis-core-backend/src/domain/tools/application/handlers/read-document-tool.handler.ts
@@ -1,0 +1,65 @@
+import { Injectable, Logger } from '@nestjs/common';
+import {
+  ToolExecutionContext,
+  ToolExecutionHandler,
+} from '../ports/execution.handler';
+import { ReadDocumentTool } from '../../domain/tools/read-document-tool.entity';
+import { ToolExecutionFailedError } from '../tools.errors';
+import { FindArtifactWithVersionsUseCase } from 'src/domain/artifacts/application/use-cases/find-artifact-with-versions/find-artifact-with-versions.use-case';
+import { FindArtifactWithVersionsQuery } from 'src/domain/artifacts/application/use-cases/find-artifact-with-versions/find-artifact-with-versions.query';
+import { UUID } from 'crypto';
+
+@Injectable()
+export class ReadDocumentToolHandler extends ToolExecutionHandler {
+  private readonly logger = new Logger(ReadDocumentToolHandler.name);
+
+  constructor(
+    private readonly findArtifactWithVersionsUseCase: FindArtifactWithVersionsUseCase,
+  ) {
+    super();
+  }
+
+  async execute(params: {
+    tool: ReadDocumentTool;
+    input: Record<string, unknown>;
+    context: ToolExecutionContext;
+  }): Promise<string> {
+    const { tool, input } = params;
+    this.logger.log('Executing read_document tool');
+
+    try {
+      const validatedInput = tool.validateParams(input);
+
+      const artifact = await this.findArtifactWithVersionsUseCase.execute(
+        new FindArtifactWithVersionsQuery({
+          artifactId: validatedInput.artifact_id as UUID,
+        }),
+      );
+
+      const currentVersion = artifact.versions.find(
+        (v) => v.versionNumber === artifact.currentVersionNumber,
+      );
+
+      if (!currentVersion) {
+        throw new Error(
+          `Current version ${artifact.currentVersionNumber} not found for artifact ${artifact.id}`,
+        );
+      }
+
+      return (
+        `Document: "${artifact.title}" (version: ${artifact.currentVersionNumber})\n\n` +
+        currentVersion.content
+      );
+    } catch (error) {
+      if (error instanceof ToolExecutionFailedError) {
+        throw error;
+      }
+      this.logger.error('Failed to execute read_document tool', error);
+      throw new ToolExecutionFailedError({
+        toolName: tool.name,
+        message: error instanceof Error ? error.message : 'Unknown error',
+        exposeToLLM: true,
+      });
+    }
+  }
+}

--- a/ayunis-core-backend/src/domain/tools/application/handlers/update-document-tool.handler.spec.ts
+++ b/ayunis-core-backend/src/domain/tools/application/handlers/update-document-tool.handler.spec.ts
@@ -8,6 +8,7 @@ import { UpdateDocumentTool } from '../../domain/tools/update-document-tool.enti
 import { ArtifactVersion } from 'src/domain/artifacts/domain/artifact-version.entity';
 import { AuthorType } from 'src/domain/artifacts/domain/value-objects/author-type.enum';
 import { ToolExecutionFailedError } from '../tools.errors';
+import { ArtifactExpectedVersionMismatchError } from 'src/domain/artifacts/application/artifacts.errors';
 
 describe('UpdateDocumentToolHandler', () => {
   let handler: UpdateDocumentToolHandler;
@@ -53,7 +54,7 @@ describe('UpdateDocumentToolHandler', () => {
     });
   }
 
-  it('should call UpdateArtifactUseCase with correct artifactId, content, and authorType', async () => {
+  it('should call UpdateArtifactUseCase with correct artifactId, content, authorType, and expectedVersionNumber', async () => {
     const version = createMockVersion();
     mockUpdateArtifactUseCase.execute.mockResolvedValue(version);
 
@@ -61,6 +62,7 @@ describe('UpdateDocumentToolHandler', () => {
     const input = {
       artifact_id: mockArtifactId,
       content: '<h1>Updated Budget Report</h1><p>Revised figures</p>',
+      expected_version: 1,
     };
 
     await handler.execute({
@@ -76,9 +78,10 @@ describe('UpdateDocumentToolHandler', () => {
       '<h1>Updated Budget Report</h1><p>Revised figures</p>',
     );
     expect(command.authorType).toBe(AuthorType.ASSISTANT);
+    expect(command.expectedVersionNumber).toBe(1);
   });
 
-  it('should return a success message containing the artifact ID', async () => {
+  it('should return a success message containing the artifact ID and version number', async () => {
     const version = createMockVersion();
     mockUpdateArtifactUseCase.execute.mockResolvedValue(version);
 
@@ -86,6 +89,7 @@ describe('UpdateDocumentToolHandler', () => {
     const input = {
       artifact_id: mockArtifactId,
       content: '<h1>Updated Report</h1>',
+      expected_version: 1,
     };
 
     const result = await handler.execute({
@@ -96,6 +100,7 @@ describe('UpdateDocumentToolHandler', () => {
 
     expect(result).toContain(mockArtifactId);
     expect(result).toContain('Document updated successfully');
+    expect(result).toContain('version: 2');
   });
 
   it('should throw ToolExecutionFailedError when UpdateArtifactUseCase fails', async () => {
@@ -107,6 +112,7 @@ describe('UpdateDocumentToolHandler', () => {
     const input = {
       artifact_id: mockArtifactId,
       content: '<h1>Will Fail</h1>',
+      expected_version: 1,
     };
 
     await expect(
@@ -116,6 +122,40 @@ describe('UpdateDocumentToolHandler', () => {
         context: { threadId: mockThreadId, orgId: mockOrgId },
       }),
     ).rejects.toThrow(ToolExecutionFailedError);
+  });
+
+  it('should throw ToolExecutionFailedError with exposeToLLM when version mismatch occurs', async () => {
+    mockUpdateArtifactUseCase.execute.mockRejectedValue(
+      new ArtifactExpectedVersionMismatchError(mockArtifactId, 1, 3),
+    );
+
+    const tool = new UpdateDocumentTool();
+    const input = {
+      artifact_id: mockArtifactId,
+      content: '<h1>Stale Update</h1>',
+      expected_version: 1,
+    };
+
+    await expect(
+      handler.execute({
+        tool,
+        input,
+        context: { threadId: mockThreadId, orgId: mockOrgId },
+      }),
+    ).rejects.toThrow(ToolExecutionFailedError);
+
+    try {
+      await handler.execute({
+        tool,
+        input,
+        context: { threadId: mockThreadId, orgId: mockOrgId },
+      });
+    } catch (error) {
+      expect(error).toBeInstanceOf(ToolExecutionFailedError);
+      expect((error as ToolExecutionFailedError).message).toContain(
+        'read_document',
+      );
+    }
   });
 
   it('should throw ToolExecutionFailedError when input validation fails', async () => {

--- a/ayunis-core-backend/src/domain/tools/application/handlers/update-document-tool.handler.ts
+++ b/ayunis-core-backend/src/domain/tools/application/handlers/update-document-tool.handler.ts
@@ -8,6 +8,7 @@ import { ToolExecutionFailedError } from '../tools.errors';
 import { UpdateArtifactUseCase } from 'src/domain/artifacts/application/use-cases/update-artifact/update-artifact.use-case';
 import { UpdateArtifactCommand } from 'src/domain/artifacts/application/use-cases/update-artifact/update-artifact.command';
 import { AuthorType } from 'src/domain/artifacts/domain/value-objects/author-type.enum';
+import { ArtifactExpectedVersionMismatchError } from 'src/domain/artifacts/application/artifacts.errors';
 import { UUID } from 'crypto';
 
 @Injectable()
@@ -29,19 +30,29 @@ export class UpdateDocumentToolHandler extends ToolExecutionHandler {
     try {
       const validatedInput = tool.validateParams(input);
 
-      await this.updateArtifactUseCase.execute(
+      const version = await this.updateArtifactUseCase.execute(
         new UpdateArtifactCommand({
           artifactId: validatedInput.artifact_id as UUID,
           content: validatedInput.content,
           authorType: AuthorType.ASSISTANT,
+          expectedVersionNumber: validatedInput.expected_version,
         }),
       );
 
-      return `Document updated successfully. Artifact ID: ${validatedInput.artifact_id}`;
+      return `Document updated successfully. Artifact ID: ${validatedInput.artifact_id}, version: ${version.versionNumber}`;
     } catch (error) {
       if (error instanceof ToolExecutionFailedError) {
         throw error;
       }
+
+      if (error instanceof ArtifactExpectedVersionMismatchError) {
+        throw new ToolExecutionFailedError({
+          toolName: tool.name,
+          message: error.message,
+          exposeToLLM: true,
+        });
+      }
+
       this.logger.error('Failed to execute update_document tool', error);
       throw new ToolExecutionFailedError({
         toolName: tool.name,

--- a/ayunis-core-backend/src/domain/tools/application/tool-handler.registry.ts
+++ b/ayunis-core-backend/src/domain/tools/application/tool-handler.registry.ts
@@ -32,78 +32,63 @@ import { UpdateDocumentToolHandler } from './handlers/update-document-tool.handl
 import { UpdateDocumentTool } from '../domain/tools/update-document-tool.entity';
 import { EditDocumentToolHandler } from './handlers/edit-document-tool.handler';
 import { EditDocumentTool } from '../domain/tools/edit-document-tool.entity';
+import { ReadDocumentToolHandler } from './handlers/read-document-tool.handler';
+import { ReadDocumentTool } from '../domain/tools/read-document-tool.entity';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- constructor types vary; used only as Map keys for instanceof matching
+type ToolConstructor = abstract new (...args: any[]) => Tool;
 
 @Injectable()
 export class ToolHandlerRegistry {
   private readonly logger = new Logger(ToolHandlerRegistry.name);
+  private readonly handlers: [ToolConstructor, ToolExecutionHandler][];
 
   constructor(
-    private readonly httpToolHandler: HttpToolHandler,
-    private readonly sourceQueryToolHandler: SourceQueryToolHandler,
-    private readonly sourceGetTextToolHandler: SourceGetTextToolHandler,
-    private readonly internetSearchToolHandler: InternetSearchToolHandler,
-    private readonly websiteContentToolHandler: WebsiteContentToolHandler,
-    private readonly codeExecutionToolHandler: CodeExecutionToolHandler,
-    private readonly mcpIntegrationToolHandler: McpIntegrationToolHandler,
-    private readonly mcpIntegrationResourceHandler: McpIntegrationResourceHandler,
-    private readonly productKnowledgeToolHandler: ProductKnowledgeToolHandler,
-    private readonly activateSkillToolHandler: ActivateSkillToolHandler,
-    private readonly knowledgeQueryToolHandler: KnowledgeQueryToolHandler,
-    private readonly knowledgeGetTextToolHandler: KnowledgeGetTextToolHandler,
-    private readonly createDocumentToolHandler: CreateDocumentToolHandler,
-    private readonly updateDocumentToolHandler: UpdateDocumentToolHandler,
-    private readonly editDocumentToolHandler: EditDocumentToolHandler,
-  ) {}
+    httpToolHandler: HttpToolHandler,
+    sourceQueryToolHandler: SourceQueryToolHandler,
+    sourceGetTextToolHandler: SourceGetTextToolHandler,
+    internetSearchToolHandler: InternetSearchToolHandler,
+    websiteContentToolHandler: WebsiteContentToolHandler,
+    codeExecutionToolHandler: CodeExecutionToolHandler,
+    mcpIntegrationToolHandler: McpIntegrationToolHandler,
+    mcpIntegrationResourceHandler: McpIntegrationResourceHandler,
+    productKnowledgeToolHandler: ProductKnowledgeToolHandler,
+    activateSkillToolHandler: ActivateSkillToolHandler,
+    knowledgeQueryToolHandler: KnowledgeQueryToolHandler,
+    knowledgeGetTextToolHandler: KnowledgeGetTextToolHandler,
+    createDocumentToolHandler: CreateDocumentToolHandler,
+    updateDocumentToolHandler: UpdateDocumentToolHandler,
+    editDocumentToolHandler: EditDocumentToolHandler,
+    readDocumentToolHandler: ReadDocumentToolHandler,
+  ) {
+    this.handlers = [
+      [HttpTool, httpToolHandler],
+      [SourceQueryTool, sourceQueryToolHandler],
+      [SourceGetTextTool, sourceGetTextToolHandler],
+      [InternetSearchTool, internetSearchToolHandler],
+      [WebsiteContentTool, websiteContentToolHandler],
+      [CodeExecutionTool, codeExecutionToolHandler],
+      [McpIntegrationTool, mcpIntegrationToolHandler],
+      [McpIntegrationResource, mcpIntegrationResourceHandler],
+      [ProductKnowledgeTool, productKnowledgeToolHandler],
+      [ActivateSkillTool, activateSkillToolHandler],
+      [KnowledgeQueryTool, knowledgeQueryToolHandler],
+      [KnowledgeGetTextTool, knowledgeGetTextToolHandler],
+      [CreateDocumentTool, createDocumentToolHandler],
+      [UpdateDocumentTool, updateDocumentToolHandler],
+      [EditDocumentTool, editDocumentToolHandler],
+      [ReadDocumentTool, readDocumentToolHandler],
+    ];
+  }
 
   getHandler(tool: Tool): ToolExecutionHandler {
     this.logger.log(`Getting handler for tool: ${tool.name}`);
-    if (tool instanceof HttpTool) {
-      return this.httpToolHandler;
+
+    const entry = this.handlers.find(([ctor]) => tool instanceof ctor);
+    if (entry) {
+      return entry[1];
     }
-    if (tool instanceof SourceQueryTool) {
-      return this.sourceQueryToolHandler;
-    }
-    if (tool instanceof SourceGetTextTool) {
-      return this.sourceGetTextToolHandler;
-    }
-    if (tool instanceof InternetSearchTool) {
-      return this.internetSearchToolHandler;
-    }
-    if (tool instanceof WebsiteContentTool) {
-      return this.websiteContentToolHandler;
-    }
-    if (tool instanceof CodeExecutionTool) {
-      return this.codeExecutionToolHandler;
-    }
-    if (tool instanceof McpIntegrationTool) {
-      return this.mcpIntegrationToolHandler;
-    }
-    if (tool instanceof McpIntegrationResource) {
-      return this.mcpIntegrationResourceHandler;
-    }
-    if (tool instanceof ProductKnowledgeTool) {
-      return this.productKnowledgeToolHandler;
-    }
-    if (tool instanceof ActivateSkillTool) {
-      return this.activateSkillToolHandler;
-    }
-    if (tool instanceof KnowledgeQueryTool) {
-      return this.knowledgeQueryToolHandler;
-    }
-    if (tool instanceof KnowledgeGetTextTool) {
-      return this.knowledgeGetTextToolHandler;
-    }
-    if (tool instanceof CreateDocumentTool) {
-      return this.createDocumentToolHandler;
-    }
-    if (tool instanceof UpdateDocumentTool) {
-      return this.updateDocumentToolHandler;
-    }
-    if (tool instanceof EditDocumentTool) {
-      return this.editDocumentToolHandler;
-    }
-    throw new ToolHandlerNotFoundError({
-      toolType: tool.name,
-    });
+
+    throw new ToolHandlerNotFoundError({ toolType: tool.name });
   }
 }

--- a/ayunis-core-backend/src/domain/tools/application/tool.factory.spec.ts
+++ b/ayunis-core-backend/src/domain/tools/application/tool.factory.spec.ts
@@ -150,7 +150,7 @@ describe('ToolFactory', () => {
       expect(types).toContain(ToolType.UPDATE_DOCUMENT);
       expect(types).toContain(ToolType.EDIT_DOCUMENT);
 
-      expect(types.length).toBe(22);
+      expect(types.length).toBe(23);
     });
   });
 });

--- a/ayunis-core-backend/src/domain/tools/application/tool.factory.ts
+++ b/ayunis-core-backend/src/domain/tools/application/tool.factory.ts
@@ -32,6 +32,7 @@ import type { KnowledgeBaseSummary } from 'src/domain/knowledge-bases/domain/kno
 import { CreateDocumentTool } from '../domain/tools/create-document-tool.entity';
 import { UpdateDocumentTool } from '../domain/tools/update-document-tool.entity';
 import { EditDocumentTool } from '../domain/tools/edit-document-tool.entity';
+import { ReadDocumentTool } from '../domain/tools/read-document-tool.entity';
 
 type ToolCreator = (params: { config?: ToolConfig; context?: unknown }) => Tool;
 
@@ -48,6 +49,7 @@ const SIMPLE_TOOLS: Record<string, () => Tool> = {
   [ToolType.CREATE_DOCUMENT]: () => new CreateDocumentTool(),
   [ToolType.UPDATE_DOCUMENT]: () => new UpdateDocumentTool(),
   [ToolType.EDIT_DOCUMENT]: () => new EditDocumentTool(),
+  [ToolType.READ_DOCUMENT]: () => new ReadDocumentTool(),
 };
 
 @Injectable()

--- a/ayunis-core-backend/src/domain/tools/domain/tools/edit-document-tool.entity.spec.ts
+++ b/ayunis-core-backend/src/domain/tools/domain/tools/edit-document-tool.entity.spec.ts
@@ -18,17 +18,19 @@ describe('EditDocumentTool', () => {
     expect(tool.isExecutable).toBe(true);
   });
 
-  it('should include a descriptionLong explaining edit vs update', () => {
+  it('should include a descriptionLong explaining edit vs update and mentioning expected_version', () => {
     expect(tool.descriptionLong).toBeDefined();
     expect(tool.descriptionLong).toContain('edit_document');
     expect(tool.descriptionLong).toContain('update_document');
     expect(tool.descriptionLong).toContain('search-and-replace');
+    expect(tool.descriptionLong).toContain('expected_version');
   });
 
   describe('validateParams', () => {
-    it('should accept valid parameters with artifact_id and edits', () => {
+    it('should accept valid parameters with artifact_id, expected_version, and edits', () => {
       const params = {
         artifact_id: '550e8400-e29b-41d4-a716-446655440000',
+        expected_version: 2,
         edits: [
           { old_text: 'Hello', new_text: 'Hi' },
           { old_text: 'world', new_text: 'universe' },
@@ -38,6 +40,7 @@ describe('EditDocumentTool', () => {
       const result = tool.validateParams(params);
 
       expect(result.artifact_id).toBe('550e8400-e29b-41d4-a716-446655440000');
+      expect(result.expected_version).toBe(2);
       expect(result.edits).toHaveLength(2);
       expect(result.edits[0]).toEqual({ old_text: 'Hello', new_text: 'Hi' });
       expect(result.edits[1]).toEqual({
@@ -57,6 +60,16 @@ describe('EditDocumentTool', () => {
     it('should reject parameters missing edits', () => {
       const params = {
         artifact_id: '550e8400-e29b-41d4-a716-446655440000',
+        expected_version: 1,
+      };
+
+      expect(() => tool.validateParams(params)).toThrow();
+    });
+
+    it('should reject parameters missing expected_version', () => {
+      const params = {
+        artifact_id: '550e8400-e29b-41d4-a716-446655440000',
+        edits: [{ old_text: 'test', new_text: 'replacement' }],
       };
 
       expect(() => tool.validateParams(params)).toThrow();
@@ -65,6 +78,7 @@ describe('EditDocumentTool', () => {
     it('should reject empty edits array', () => {
       const params = {
         artifact_id: '550e8400-e29b-41d4-a716-446655440000',
+        expected_version: 1,
         edits: [],
       };
 
@@ -74,6 +88,7 @@ describe('EditDocumentTool', () => {
     it('should reject edits with empty old_text', () => {
       const params = {
         artifact_id: '550e8400-e29b-41d4-a716-446655440000',
+        expected_version: 1,
         edits: [{ old_text: '', new_text: 'replacement' }],
       };
 
@@ -83,6 +98,7 @@ describe('EditDocumentTool', () => {
     it('should reject edits missing old_text', () => {
       const params = {
         artifact_id: '550e8400-e29b-41d4-a716-446655440000',
+        expected_version: 1,
         edits: [{ new_text: 'replacement' }],
       };
 
@@ -92,6 +108,7 @@ describe('EditDocumentTool', () => {
     it('should reject edits missing new_text', () => {
       const params = {
         artifact_id: '550e8400-e29b-41d4-a716-446655440000',
+        expected_version: 1,
         edits: [{ old_text: 'test' }],
       };
 
@@ -101,6 +118,7 @@ describe('EditDocumentTool', () => {
     it('should reject additional properties on edits', () => {
       const params = {
         artifact_id: '550e8400-e29b-41d4-a716-446655440000',
+        expected_version: 1,
         edits: [
           {
             old_text: 'test',
@@ -116,6 +134,7 @@ describe('EditDocumentTool', () => {
     it('should reject additional properties on main object', () => {
       const params = {
         artifact_id: '550e8400-e29b-41d4-a716-446655440000',
+        expected_version: 1,
         edits: [{ old_text: 'test', new_text: 'replacement' }],
         extra: 'not allowed',
       };
@@ -126,6 +145,7 @@ describe('EditDocumentTool', () => {
     it('should accept empty new_text (deletion)', () => {
       const params = {
         artifact_id: '550e8400-e29b-41d4-a716-446655440000',
+        expected_version: 1,
         edits: [{ old_text: 'delete this', new_text: '' }],
       };
 

--- a/ayunis-core-backend/src/domain/tools/domain/tools/edit-document-tool.entity.ts
+++ b/ayunis-core-backend/src/domain/tools/domain/tools/edit-document-tool.entity.ts
@@ -10,6 +10,11 @@ const editDocumentToolParameters = {
       type: 'string' as const,
       description: 'The UUID of the existing artifact (document) to edit',
     },
+    expected_version: {
+      type: 'integer' as const,
+      description:
+        'The version number you expect the document to be at. Pass the version from your last create/update/edit result, or from read_document. The operation will fail if the document has been modified since.',
+    },
     edits: {
       type: 'array' as const,
       description: 'Array of search-and-replace edits to apply sequentially',
@@ -34,7 +39,7 @@ const editDocumentToolParameters = {
       maxItems: 50,
     },
   },
-  required: ['artifact_id', 'edits'],
+  required: ['artifact_id', 'expected_version', 'edits'],
   additionalProperties: false,
 } as const satisfies JSONSchema;
 
@@ -53,7 +58,9 @@ export class EditDocumentTool extends DisplayableTool {
         'This tool applies search-and-replace edits sequentially to the current document content. ' +
         'Each old_text must match exactly one location in the document - include enough surrounding context to make it unambiguous. ' +
         'The old_text must match the exact HTML source (tags, whitespace, etc.). ' +
-        'For full rewrites or major restructuring, use update_document instead.',
+        'For full rewrites or major restructuring, use update_document instead. ' +
+        'You must pass expected_version with the version number from your last tool result or from read_document. ' +
+        'If the document was modified by the user since then, the operation will fail — use read_document to get the current content first.',
       parameters: editDocumentToolParameters,
       type: ToolType.EDIT_DOCUMENT,
     });

--- a/ayunis-core-backend/src/domain/tools/domain/tools/read-document-tool.entity.spec.ts
+++ b/ayunis-core-backend/src/domain/tools/domain/tools/read-document-tool.entity.spec.ts
@@ -1,0 +1,50 @@
+import { ReadDocumentTool } from './read-document-tool.entity';
+import { ToolType } from '../value-objects/tool-type.enum';
+
+describe('ReadDocumentTool', () => {
+  let tool: ReadDocumentTool;
+
+  beforeEach(() => {
+    tool = new ReadDocumentTool();
+  });
+
+  it('should have the correct tool type and name', () => {
+    expect(tool.type).toBe(ToolType.READ_DOCUMENT);
+    expect(tool.name).toBe('read_document');
+  });
+
+  it('should include a descriptionLong explaining when to use it', () => {
+    expect(tool.descriptionLong).toBeDefined();
+    expect(tool.descriptionLong).toContain('read_document');
+    expect(tool.descriptionLong).toContain('expected_version');
+  });
+
+  describe('validateParams', () => {
+    it('should accept valid parameters with artifact_id', () => {
+      const params = {
+        artifact_id: '550e8400-e29b-41d4-a716-446655440000',
+      };
+
+      const result = tool.validateParams(params);
+
+      expect(result.artifact_id).toBe('550e8400-e29b-41d4-a716-446655440000');
+    });
+
+    it('should reject parameters missing artifact_id', () => {
+      expect(() => tool.validateParams({})).toThrow();
+    });
+
+    it('should reject additional properties', () => {
+      const params = {
+        artifact_id: '550e8400-e29b-41d4-a716-446655440000',
+        extra: 'not allowed',
+      };
+
+      expect(() => tool.validateParams(params)).toThrow();
+    });
+  });
+
+  it('should not return PII', () => {
+    expect(tool.returnsPii).toBe(false);
+  });
+});

--- a/ayunis-core-backend/src/domain/tools/domain/tools/read-document-tool.entity.ts
+++ b/ayunis-core-backend/src/domain/tools/domain/tools/read-document-tool.entity.ts
@@ -1,0 +1,48 @@
+import { createAjv } from 'src/common/validators/ajv.factory';
+import { ToolType } from '../value-objects/tool-type.enum';
+import type { FromSchema, JSONSchema } from 'json-schema-to-ts';
+import { Tool } from '../tool.entity';
+
+const readDocumentToolParameters = {
+  type: 'object' as const,
+  properties: {
+    artifact_id: {
+      type: 'string' as const,
+      description: 'The UUID of the artifact (document) to read',
+    },
+  },
+  required: ['artifact_id'],
+  additionalProperties: false,
+} as const satisfies JSONSchema;
+
+type ReadDocumentToolParameters = FromSchema<typeof readDocumentToolParameters>;
+
+export class ReadDocumentTool extends Tool {
+  constructor() {
+    super({
+      name: ToolType.READ_DOCUMENT,
+      description:
+        'Read the current content of an existing document. Use this before editing a document that the user may have modified.',
+      descriptionLong:
+        'Use read_document to retrieve the current content and version of a document. ' +
+        'Always read a document before editing it when the document list indicates the user has made changes. ' +
+        'The response includes the current version number — pass it as expected_version when calling update_document or edit_document.',
+      parameters: readDocumentToolParameters,
+      type: ToolType.READ_DOCUMENT,
+    });
+  }
+
+  validateParams(params: Record<string, unknown>): ReadDocumentToolParameters {
+    const ajv = createAjv();
+    const validate = ajv.compile(this.parameters);
+    const valid = validate(params);
+    if (!valid) {
+      throw new Error(JSON.stringify(validate.errors));
+    }
+    return params as ReadDocumentToolParameters;
+  }
+
+  get returnsPii(): boolean {
+    return false;
+  }
+}

--- a/ayunis-core-backend/src/domain/tools/domain/tools/update-document-tool.entity.spec.ts
+++ b/ayunis-core-backend/src/domain/tools/domain/tools/update-document-tool.entity.spec.ts
@@ -18,17 +18,19 @@ describe('UpdateDocumentTool', () => {
     expect(tool.isExecutable).toBe(true);
   });
 
-  it('should include a descriptionLong distinguishing create vs update', () => {
+  it('should include a descriptionLong distinguishing create vs update and mentioning expected_version', () => {
     expect(tool.descriptionLong).toBeDefined();
     expect(tool.descriptionLong).toContain('create_document');
     expect(tool.descriptionLong).toContain('update_document');
+    expect(tool.descriptionLong).toContain('expected_version');
   });
 
   describe('validateParams', () => {
-    it('should accept valid parameters with artifact_id and content', () => {
+    it('should accept valid parameters with artifact_id, content, and expected_version', () => {
       const params = {
         artifact_id: '550e8400-e29b-41d4-a716-446655440000',
         content: '<h1>Updated Report</h1><p>Revised findings...</p>',
+        expected_version: 3,
       };
 
       const result = tool.validateParams(params);
@@ -37,6 +39,7 @@ describe('UpdateDocumentTool', () => {
       expect(result.content).toBe(
         '<h1>Updated Report</h1><p>Revised findings...</p>',
       );
+      expect(result.expected_version).toBe(3);
     });
 
     it('should reject parameters missing artifact_id', () => {
@@ -50,6 +53,16 @@ describe('UpdateDocumentTool', () => {
     it('should reject parameters missing content', () => {
       const params = {
         artifact_id: '550e8400-e29b-41d4-a716-446655440000',
+        expected_version: 1,
+      };
+
+      expect(() => tool.validateParams(params)).toThrow();
+    });
+
+    it('should reject parameters missing expected_version', () => {
+      const params = {
+        artifact_id: '550e8400-e29b-41d4-a716-446655440000',
+        content: '<p>Content</p>',
       };
 
       expect(() => tool.validateParams(params)).toThrow();
@@ -63,6 +76,7 @@ describe('UpdateDocumentTool', () => {
       const params = {
         artifact_id: '550e8400-e29b-41d4-a716-446655440000',
         content: '<p>Content</p>',
+        expected_version: 1,
         title: 'not allowed here',
       };
 

--- a/ayunis-core-backend/src/domain/tools/domain/tools/update-document-tool.entity.ts
+++ b/ayunis-core-backend/src/domain/tools/domain/tools/update-document-tool.entity.ts
@@ -15,8 +15,13 @@ const updateDocumentToolParameters = {
       description:
         'The full updated HTML content of the document. Provide the complete document content, not just the changes.',
     },
+    expected_version: {
+      type: 'integer' as const,
+      description:
+        'The version number you expect the document to be at. Pass the version from your last create/update/edit result, or from read_document. The operation will fail if the document has been modified since.',
+    },
   },
-  required: ['artifact_id', 'content'],
+  required: ['artifact_id', 'content', 'expected_version'],
   additionalProperties: false,
 } as const satisfies JSONSchema;
 
@@ -37,7 +42,9 @@ export class UpdateDocumentTool extends DisplayableTool {
         'Use create_document instead when the user wants a brand new document. ' +
         'Always provide the full updated content, not a partial diff. ' +
         'For targeted changes (fixing typos, updating a section, inserting a paragraph), prefer edit_document instead — ' +
-        'it is more efficient and less error-prone for small edits.',
+        'it is more efficient and less error-prone for small edits. ' +
+        'You must pass expected_version with the version number from your last tool result or from read_document. ' +
+        'If the document was modified by the user since then, the operation will fail — use read_document to get the current content first.',
       parameters: updateDocumentToolParameters,
       type: ToolType.UPDATE_DOCUMENT,
     });

--- a/ayunis-core-backend/src/domain/tools/domain/value-objects/tool-type.enum.ts
+++ b/ayunis-core-backend/src/domain/tools/domain/value-objects/tool-type.enum.ts
@@ -22,4 +22,5 @@ export enum ToolType {
   CREATE_DOCUMENT = 'create_document',
   UPDATE_DOCUMENT = 'update_document',
   EDIT_DOCUMENT = 'edit_document',
+  READ_DOCUMENT = 'read_document',
 }

--- a/ayunis-core-backend/src/domain/tools/tools.module.ts
+++ b/ayunis-core-backend/src/domain/tools/tools.module.ts
@@ -29,6 +29,7 @@ import { KnowledgeGetTextToolHandler } from './application/handlers/knowledge-ge
 import { CreateDocumentToolHandler } from './application/handlers/create-document-tool.handler';
 import { UpdateDocumentToolHandler } from './application/handlers/update-document-tool.handler';
 import { EditDocumentToolHandler } from './application/handlers/edit-document-tool.handler';
+import { ReadDocumentToolHandler } from './application/handlers/read-document-tool.handler';
 import { SkillsModule } from '../skills/skills.module';
 import { KnowledgeBasesModule } from '../knowledge-bases/knowledge-bases.module';
 import { SkillTemplatesModule } from '../skill-templates/skill-templates.module';
@@ -68,6 +69,7 @@ import { ArtifactsModule } from '../artifacts/artifacts.module';
     CreateDocumentToolHandler,
     UpdateDocumentToolHandler,
     EditDocumentToolHandler,
+    ReadDocumentToolHandler,
     {
       provide: ProductKnowledgePort,
       useClass: ProductKnowledgeAdapter,

--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
@@ -1938,6 +1938,7 @@ export const ToolAssignmentDtoType = {
   create_document: 'create_document',
   update_document: 'update_document',
   edit_document: 'edit_document',
+  read_document: 'read_document',
 } as const;
 
 export interface ToolAssignmentDto {
@@ -1992,6 +1993,7 @@ export const ToolResponseDtoType = {
   create_document: 'create_document',
   update_document: 'update_document',
   edit_document: 'edit_document',
+  read_document: 'read_document',
 } as const;
 
 export interface ToolResponseDto {

--- a/ayunis-core-frontend/src/shared/api/openapi-schema.json
+++ b/ayunis-core-frontend/src/shared/api/openapi-schema.json
@@ -18,7 +18,9 @@
           }
         },
         "summary": "Check if the deployment is running in a cloud environment",
-        "tags": ["app"]
+        "tags": [
+          "app"
+        ]
       }
     },
     "/health": {
@@ -31,7 +33,9 @@
           }
         },
         "summary": "Check if the deployment is healthy",
-        "tags": ["app"]
+        "tags": [
+          "app"
+        ]
       }
     },
     "/feature-toggles": {
@@ -51,7 +55,9 @@
           }
         },
         "summary": "Get the current feature toggle states",
-        "tags": ["app"]
+        "tags": [
+          "app"
+        ]
       }
     },
     "/models/available": {
@@ -77,7 +83,9 @@
           }
         },
         "summary": "Get all available models",
-        "tags": ["models"]
+        "tags": [
+          "models"
+        ]
       }
     },
     "/models/providers": {
@@ -100,7 +108,9 @@
           }
         },
         "summary": "Get all available model providers with their info",
-        "tags": ["models"]
+        "tags": [
+          "models"
+        ]
       }
     },
     "/models/permitted": {
@@ -129,7 +139,9 @@
           }
         },
         "summary": "Create a permitted model",
-        "tags": ["models"]
+        "tags": [
+          "models"
+        ]
       }
     },
     "/models/permitted/{id}": {
@@ -154,7 +166,9 @@
           }
         },
         "summary": "Delete a permitted model",
-        "tags": ["models"]
+        "tags": [
+          "models"
+        ]
       },
       "patch": {
         "operationId": "ModelsController_updatePermittedModel",
@@ -197,7 +211,9 @@
           }
         },
         "summary": "Update a permitted model",
-        "tags": ["models"]
+        "tags": [
+          "models"
+        ]
       }
     },
     "/models/permitted/language-models": {
@@ -224,7 +240,9 @@
           }
         },
         "summary": "Get effective permitted language models for the current user",
-        "tags": ["models"]
+        "tags": [
+          "models"
+        ]
       }
     },
     "/models/permitted/language-models/org": {
@@ -251,7 +269,9 @@
           }
         },
         "summary": "Get org-level permitted language models (admin view)",
-        "tags": ["models"]
+        "tags": [
+          "models"
+        ]
       }
     },
     "/models/default": {
@@ -275,7 +295,9 @@
           }
         },
         "summary": "Get the effective default model for the user",
-        "tags": ["models"]
+        "tags": [
+          "models"
+        ]
       }
     },
     "/models/org/default": {
@@ -299,7 +321,9 @@
           }
         },
         "summary": "Get the organization default model",
-        "tags": ["models"]
+        "tags": [
+          "models"
+        ]
       },
       "put": {
         "description": "Sets the specified permitted model as the organization default. If a default already exists, it will be updated to the new model.",
@@ -334,7 +358,9 @@
           }
         },
         "summary": "Set or update the organization default model",
-        "tags": ["models"]
+        "tags": [
+          "models"
+        ]
       }
     },
     "/models/user/default": {
@@ -358,7 +384,9 @@
           }
         },
         "summary": "Get the user-specific default model",
-        "tags": ["models"]
+        "tags": [
+          "models"
+        ]
       },
       "put": {
         "description": "Sets the specified permitted model as the user default. If a default already exists, it will be updated to the new model.",
@@ -393,7 +421,9 @@
           }
         },
         "summary": "Set or update the user default model",
-        "tags": ["models"]
+        "tags": [
+          "models"
+        ]
       },
       "delete": {
         "operationId": "ModelsController_deleteUserDefaultModel",
@@ -407,7 +437,9 @@
           }
         },
         "summary": "Delete the user default model",
-        "tags": ["models"]
+        "tags": [
+          "models"
+        ]
       }
     },
     "/models/provider/{provider}": {
@@ -443,7 +475,9 @@
           }
         },
         "summary": "Get model provider information",
-        "tags": ["models"]
+        "tags": [
+          "models"
+        ]
       }
     },
     "/models/embedding/enabled": {
@@ -466,7 +500,9 @@
           }
         },
         "summary": "Check if an embedding model is enabled for this org",
-        "tags": ["models"]
+        "tags": [
+          "models"
+        ]
       }
     },
     "/teams/{teamId}/permitted-models": {
@@ -501,7 +537,9 @@
           }
         },
         "summary": "List a team's permitted language models",
-        "tags": ["team-permitted-models"]
+        "tags": [
+          "team-permitted-models"
+        ]
       },
       "post": {
         "description": "Creates a team-scoped permitted model. The model must already be permitted at the organization level.",
@@ -548,7 +586,9 @@
           }
         },
         "summary": "Add a permitted model to a team",
-        "tags": ["team-permitted-models"]
+        "tags": [
+          "team-permitted-models"
+        ]
       }
     },
     "/teams/{teamId}/permitted-models/{id}": {
@@ -581,7 +621,9 @@
           }
         },
         "summary": "Remove a permitted model from a team",
-        "tags": ["team-permitted-models"]
+        "tags": [
+          "team-permitted-models"
+        ]
       }
     },
     "/teams/{teamId}/permitted-models/default": {
@@ -624,7 +666,9 @@
           }
         },
         "summary": "Set the team's default model",
-        "tags": ["team-permitted-models"]
+        "tags": [
+          "team-permitted-models"
+        ]
       }
     },
     "/super-admin/models/{orgId}/available": {
@@ -666,7 +710,9 @@
           }
         },
         "summary": "Get all available models",
-        "tags": ["Super Admin Models"]
+        "tags": [
+          "Super Admin Models"
+        ]
       }
     },
     "/super-admin/models/{orgId}/default-model": {
@@ -721,7 +767,9 @@
           }
         },
         "summary": "Set or update the organization default model",
-        "tags": ["Super Admin Models"]
+        "tags": [
+          "Super Admin Models"
+        ]
       }
     },
     "/super-admin/models/{orgId}/permitted-models": {
@@ -770,7 +818,9 @@
           }
         },
         "summary": "Get all permitted models for a specific organization",
-        "tags": ["Super Admin Models"]
+        "tags": [
+          "Super Admin Models"
+        ]
       },
       "post": {
         "description": "Create a new permitted model for the specified organization. This endpoint is only accessible to super admins.",
@@ -816,7 +866,9 @@
           }
         },
         "summary": "Create a permitted model for a specific organization",
-        "tags": ["Super Admin Models"]
+        "tags": [
+          "Super Admin Models"
+        ]
       }
     },
     "/super-admin/models/{orgId}/permitted-models/{id}": {
@@ -865,7 +917,9 @@
           }
         },
         "summary": "Delete a permitted model for a specific organization",
-        "tags": ["Super Admin Models"]
+        "tags": [
+          "Super Admin Models"
+        ]
       },
       "patch": {
         "description": "Update the settings of a permitted model for the specified organization. This endpoint is only accessible to super admins.",
@@ -936,7 +990,9 @@
           }
         },
         "summary": "Update a permitted model for a specific organization",
-        "tags": ["Super Admin Models"]
+        "tags": [
+          "Super Admin Models"
+        ]
       }
     },
     "/super-admin/models/catalog": {
@@ -973,7 +1029,9 @@
           }
         },
         "summary": "Get all models in the catalog",
-        "tags": ["Super Admin Models"]
+        "tags": [
+          "Super Admin Models"
+        ]
       }
     },
     "/super-admin/models/catalog/{id}": {
@@ -1022,7 +1080,9 @@
           }
         },
         "summary": "Get a model by ID from the catalog",
-        "tags": ["Super Admin Models"]
+        "tags": [
+          "Super Admin Models"
+        ]
       },
       "delete": {
         "description": "Remove a model (language or embedding) from the master catalog. This endpoint is only accessible to super admins.",
@@ -1055,7 +1115,9 @@
           }
         },
         "summary": "Delete a model from the catalog",
-        "tags": ["Super Admin Models"]
+        "tags": [
+          "Super Admin Models"
+        ]
       }
     },
     "/super-admin/models/catalog/language": {
@@ -1098,7 +1160,9 @@
           }
         },
         "summary": "Create a new language model in the catalog",
-        "tags": ["Super Admin Models"]
+        "tags": [
+          "Super Admin Models"
+        ]
       }
     },
     "/super-admin/models/catalog/language/{id}": {
@@ -1153,7 +1217,9 @@
           }
         },
         "summary": "Update a language model in the catalog",
-        "tags": ["Super Admin Models"]
+        "tags": [
+          "Super Admin Models"
+        ]
       }
     },
     "/super-admin/models/catalog/embedding": {
@@ -1196,7 +1262,9 @@
           }
         },
         "summary": "Create a new embedding model in the catalog",
-        "tags": ["Super Admin Models"]
+        "tags": [
+          "Super Admin Models"
+        ]
       }
     },
     "/super-admin/models/catalog/embedding/{id}": {
@@ -1251,7 +1319,9 @@
           }
         },
         "summary": "Update an embedding model in the catalog",
-        "tags": ["Super Admin Models"]
+        "tags": [
+          "Super Admin Models"
+        ]
       }
     },
     "/super-admin/orgs": {
@@ -1289,7 +1359,9 @@
           }
         },
         "summary": "Create a new organization",
-        "tags": ["Super Admin Orgs"]
+        "tags": [
+          "Super Admin Orgs"
+        ]
       },
       "get": {
         "description": "Retrieve paginated organizations in the system. Only accessible to users with the super admin system role.",
@@ -1344,7 +1416,9 @@
           }
         },
         "summary": "List all organizations",
-        "tags": ["Super Admin Orgs"]
+        "tags": [
+          "Super Admin Orgs"
+        ]
       }
     },
     "/super-admin/orgs/{id}": {
@@ -1378,7 +1452,9 @@
           }
         },
         "summary": "Get an organization by ID",
-        "tags": ["Super Admin Orgs"]
+        "tags": [
+          "Super Admin Orgs"
+        ]
       }
     },
     "/users": {
@@ -1438,7 +1514,9 @@
           }
         },
         "summary": "Get users in current organization",
-        "tags": ["Users"]
+        "tags": [
+          "Users"
+        ]
       }
     },
     "/users/{id}/role": {
@@ -1494,7 +1572,9 @@
           }
         },
         "summary": "Update user role",
-        "tags": ["Users"]
+        "tags": [
+          "Users"
+        ]
       }
     },
     "/users/name": {
@@ -1538,7 +1618,9 @@
           }
         },
         "summary": "Update user name",
-        "tags": ["Users"]
+        "tags": [
+          "Users"
+        ]
       }
     },
     "/users/password": {
@@ -1572,7 +1654,9 @@
           }
         },
         "summary": "Update user password",
-        "tags": ["Users"]
+        "tags": [
+          "Users"
+        ]
       }
     },
     "/users/confirm-email": {
@@ -1606,7 +1690,9 @@
           }
         },
         "summary": "Confirm user email",
-        "tags": ["Users"]
+        "tags": [
+          "Users"
+        ]
       }
     },
     "/users/resend-confirmation": {
@@ -1637,7 +1723,9 @@
           }
         },
         "summary": "Resend email confirmation",
-        "tags": ["Users"]
+        "tags": [
+          "Users"
+        ]
       }
     },
     "/users/{id}": {
@@ -1672,7 +1760,9 @@
           }
         },
         "summary": "Delete a user",
-        "tags": ["Users"]
+        "tags": [
+          "Users"
+        ]
       }
     },
     "/users/{id}/trigger-password-reset": {
@@ -1703,7 +1793,9 @@
           }
         },
         "summary": "Trigger password reset for a user",
-        "tags": ["Users"]
+        "tags": [
+          "Users"
+        ]
       }
     },
     "/users/forgot-password": {
@@ -1734,7 +1826,9 @@
           }
         },
         "summary": "Trigger password reset",
-        "tags": ["Users"]
+        "tags": [
+          "Users"
+        ]
       }
     },
     "/users/reset-password": {
@@ -1768,7 +1862,9 @@
           }
         },
         "summary": "Reset password with token",
-        "tags": ["Users"]
+        "tags": [
+          "Users"
+        ]
       }
     },
     "/users/validate-reset-token": {
@@ -1812,7 +1908,9 @@
           }
         },
         "summary": "Validate password reset token",
-        "tags": ["Users"]
+        "tags": [
+          "Users"
+        ]
       }
     },
     "/super-admin/users/{orgId}": {
@@ -1886,7 +1984,9 @@
           }
         },
         "summary": "Get users by organization ID",
-        "tags": ["Super Admin Users"]
+        "tags": [
+          "Super Admin Users"
+        ]
       }
     },
     "/super-admin/users/{userId}": {
@@ -1921,7 +2021,9 @@
           }
         },
         "summary": "Delete a user",
-        "tags": ["Super Admin Users"]
+        "tags": [
+          "Super Admin Users"
+        ]
       }
     },
     "/super-admin/users/{userId}/trigger-password-reset": {
@@ -1956,7 +2058,9 @@
           }
         },
         "summary": "Trigger password reset for a user",
-        "tags": ["Super Admin Users"]
+        "tags": [
+          "Super Admin Users"
+        ]
       }
     },
     "/super-admin/users/{orgId}/create": {
@@ -2012,7 +2116,9 @@
           }
         },
         "summary": "Create a new user in an organization",
-        "tags": ["Super Admin Users"]
+        "tags": [
+          "Super Admin Users"
+        ]
       }
     },
     "/super-admin/super-admins": {
@@ -2039,7 +2145,9 @@
           }
         },
         "summary": "List all super admins",
-        "tags": ["Super Admin Management"]
+        "tags": [
+          "Super Admin Management"
+        ]
       },
       "post": {
         "description": "Promote an existing user to super admin by email address. Idempotent if user is already a super admin.",
@@ -2075,7 +2183,9 @@
           }
         },
         "summary": "Promote a user to super admin",
-        "tags": ["Super Admin Management"]
+        "tags": [
+          "Super Admin Management"
+        ]
       }
     },
     "/super-admin/super-admins/{userId}": {
@@ -2116,7 +2226,9 @@
           }
         },
         "summary": "Remove super admin status from a user",
-        "tags": ["Super Admin Management"]
+        "tags": [
+          "Super Admin Management"
+        ]
       }
     },
     "/invites": {
@@ -2153,7 +2265,9 @@
           }
         },
         "summary": "Create a new invite",
-        "tags": ["invites"]
+        "tags": [
+          "invites"
+        ]
       },
       "get": {
         "description": "Retrieve paginated invites with optional search",
@@ -2208,7 +2322,9 @@
           }
         },
         "summary": "Get all invites for current user's organization",
-        "tags": ["invites"]
+        "tags": [
+          "invites"
+        ]
       }
     },
     "/invites/bulk": {
@@ -2245,7 +2361,9 @@
           }
         },
         "summary": "Create multiple invites in bulk",
-        "tags": ["invites"]
+        "tags": [
+          "invites"
+        ]
       }
     },
     "/invites/{token}": {
@@ -2283,7 +2401,9 @@
           }
         },
         "summary": "Get a single invite by token",
-        "tags": ["invites"]
+        "tags": [
+          "invites"
+        ]
       }
     },
     "/invites/accept": {
@@ -2323,7 +2443,9 @@
           }
         },
         "summary": "Accept an invite",
-        "tags": ["invites"]
+        "tags": [
+          "invites"
+        ]
       }
     },
     "/invites/{id}/resend": {
@@ -2364,7 +2486,9 @@
           }
         },
         "summary": "Resend an expired invite",
-        "tags": ["invites"]
+        "tags": [
+          "invites"
+        ]
       }
     },
     "/invites/all": {
@@ -2391,7 +2515,9 @@
           }
         },
         "summary": "Delete all pending invites",
-        "tags": ["invites"]
+        "tags": [
+          "invites"
+        ]
       }
     },
     "/invites/{id}": {
@@ -2425,7 +2551,9 @@
           }
         },
         "summary": "Delete an invite",
-        "tags": ["invites"]
+        "tags": [
+          "invites"
+        ]
       }
     },
     "/subscriptions/active": {
@@ -2448,7 +2576,9 @@
           }
         },
         "summary": "Check if the current organization has an active subscription",
-        "tags": ["subscriptions"]
+        "tags": [
+          "subscriptions"
+        ]
       }
     },
     "/subscriptions/price": {
@@ -2474,7 +2604,9 @@
           }
         },
         "summary": "Get the current price per seat monthly",
-        "tags": ["subscriptions"]
+        "tags": [
+          "subscriptions"
+        ]
       }
     },
     "/super-admin/subscriptions/{orgId}": {
@@ -2513,7 +2645,9 @@
           }
         },
         "summary": "Get subscription details for a specific organization",
-        "tags": ["Super Admin Subscriptions"]
+        "tags": [
+          "Super Admin Subscriptions"
+        ]
       },
       "post": {
         "description": "Create a new subscription for the specified organization. This endpoint is only accessible to super admins.",
@@ -2566,7 +2700,9 @@
           }
         },
         "summary": "Create a new subscription for a specific organization",
-        "tags": ["Super Admin Subscriptions"]
+        "tags": [
+          "Super Admin Subscriptions"
+        ]
       },
       "delete": {
         "description": "Cancel the subscription for the specified organization. This endpoint is only accessible to super admins.",
@@ -2602,7 +2738,9 @@
           }
         },
         "summary": "Cancel the subscription for a specific organization",
-        "tags": ["Super Admin Subscriptions"]
+        "tags": [
+          "Super Admin Subscriptions"
+        ]
       }
     },
     "/super-admin/subscriptions/{orgId}/seats": {
@@ -2650,7 +2788,9 @@
           }
         },
         "summary": "Update the number of seats for a specific organization",
-        "tags": ["Super Admin Subscriptions"]
+        "tags": [
+          "Super Admin Subscriptions"
+        ]
       }
     },
     "/super-admin/subscriptions/{orgId}/billing-info": {
@@ -2698,7 +2838,9 @@
           }
         },
         "summary": "Update the billing information for a specific organization",
-        "tags": ["Super Admin Subscriptions"]
+        "tags": [
+          "Super Admin Subscriptions"
+        ]
       }
     },
     "/super-admin/subscriptions/{orgId}/uncancel": {
@@ -2736,7 +2878,9 @@
           }
         },
         "summary": "Uncancel the subscription for a specific organization",
-        "tags": ["Super Admin Subscriptions"]
+        "tags": [
+          "Super Admin Subscriptions"
+        ]
       }
     },
     "/teams": {
@@ -2768,7 +2912,9 @@
           }
         },
         "summary": "List all teams for the current organization",
-        "tags": ["teams"]
+        "tags": [
+          "teams"
+        ]
       },
       "post": {
         "operationId": "TeamsController_createTeam",
@@ -2811,7 +2957,9 @@
           }
         },
         "summary": "Create a new team for the current organization",
-        "tags": ["teams"]
+        "tags": [
+          "teams"
+        ]
       }
     },
     "/teams/me": {
@@ -2840,7 +2988,9 @@
           }
         },
         "summary": "List teams the current user is a member of",
-        "tags": ["teams"]
+        "tags": [
+          "teams"
+        ]
       }
     },
     "/teams/{id}": {
@@ -2881,7 +3031,9 @@
           }
         },
         "summary": "Get a team by ID",
-        "tags": ["teams"]
+        "tags": [
+          "teams"
+        ]
       },
       "patch": {
         "operationId": "TeamsController_updateTeam",
@@ -2936,7 +3088,9 @@
           }
         },
         "summary": "Update a team in the current organization",
-        "tags": ["teams"]
+        "tags": [
+          "teams"
+        ]
       },
       "delete": {
         "operationId": "TeamsController_deleteTeam",
@@ -2968,7 +3122,9 @@
           }
         },
         "summary": "Delete a team from the current organization",
-        "tags": ["teams"]
+        "tags": [
+          "teams"
+        ]
       }
     },
     "/teams/{id}/members": {
@@ -3031,7 +3187,9 @@
           }
         },
         "summary": "List members of a team",
-        "tags": ["teams"]
+        "tags": [
+          "teams"
+        ]
       },
       "post": {
         "operationId": "TeamsController_addTeamMember",
@@ -3086,7 +3244,9 @@
           }
         },
         "summary": "Add a user to a team",
-        "tags": ["teams"]
+        "tags": [
+          "teams"
+        ]
       }
     },
     "/teams/{id}/members/{userId}": {
@@ -3128,7 +3288,9 @@
           }
         },
         "summary": "Remove a user from a team",
-        "tags": ["teams"]
+        "tags": [
+          "teams"
+        ]
       }
     },
     "/storage/upload": {
@@ -3142,7 +3304,9 @@
             "multipart/form-data": {
               "schema": {
                 "type": "object",
-                "required": ["file"],
+                "required": [
+                  "file"
+                ],
                 "properties": {
                   "file": {
                     "type": "string",
@@ -3170,7 +3334,9 @@
           }
         },
         "summary": "Upload a file to object storage",
-        "tags": ["storage"]
+        "tags": [
+          "storage"
+        ]
       }
     },
     "/storage/{objectName}": {
@@ -3192,7 +3358,9 @@
             "description": ""
           }
         },
-        "tags": ["storage"]
+        "tags": [
+          "storage"
+        ]
       },
       "delete": {
         "operationId": "StorageController_deleteFile",
@@ -3212,7 +3380,9 @@
             "description": ""
           }
         },
-        "tags": ["storage"]
+        "tags": [
+          "storage"
+        ]
       }
     },
     "/storage/url/{objectName}": {
@@ -3234,7 +3404,9 @@
             "description": ""
           }
         },
-        "tags": ["storage"]
+        "tags": [
+          "storage"
+        ]
       }
     },
     "/retrievers/url": {
@@ -3257,7 +3429,9 @@
           }
         },
         "summary": "Retrieve content from a URL",
-        "tags": ["retrievers"]
+        "tags": [
+          "retrievers"
+        ]
       }
     },
     "/threads": {
@@ -3293,7 +3467,9 @@
           }
         },
         "summary": "Create a new thread",
-        "tags": ["threads"]
+        "tags": [
+          "threads"
+        ]
       },
       "get": {
         "operationId": "ThreadsController_findAll",
@@ -3352,7 +3528,9 @@
           }
         },
         "summary": "Get all threads for the current user",
-        "tags": ["threads"]
+        "tags": [
+          "threads"
+        ]
       }
     },
     "/threads/{id}": {
@@ -3389,7 +3567,9 @@
           }
         },
         "summary": "Get a thread by ID",
-        "tags": ["threads"]
+        "tags": [
+          "threads"
+        ]
       },
       "delete": {
         "operationId": "ThreadsController_delete",
@@ -3417,7 +3597,9 @@
           }
         },
         "summary": "Delete a thread",
-        "tags": ["threads"]
+        "tags": [
+          "threads"
+        ]
       }
     },
     "/threads/{id}/title": {
@@ -3460,7 +3642,9 @@
           }
         },
         "summary": "Update a thread title",
-        "tags": ["threads"]
+        "tags": [
+          "threads"
+        ]
       }
     },
     "/threads/{id}/sources": {
@@ -3510,7 +3694,9 @@
           }
         },
         "summary": "Get all sources for a thread",
-        "tags": ["threads"]
+        "tags": [
+          "threads"
+        ]
       }
     },
     "/threads/{id}/sources/file": {
@@ -3549,7 +3735,9 @@
                     "description": "A description of the file source"
                   }
                 },
-                "required": ["file"]
+                "required": [
+                  "file"
+                ]
               }
             }
           }
@@ -3560,7 +3748,9 @@
           }
         },
         "summary": "Add a file source to a thread",
-        "tags": ["threads"]
+        "tags": [
+          "threads"
+        ]
       }
     },
     "/threads/{id}/sources/{sourceId}": {
@@ -3597,7 +3787,9 @@
           }
         },
         "summary": "Remove a source from a thread",
-        "tags": ["threads"]
+        "tags": [
+          "threads"
+        ]
       }
     },
     "/threads/{id}/sources/{sourceId}/download": {
@@ -3645,7 +3837,9 @@
           }
         },
         "summary": "Download a data source as CSV",
-        "tags": ["threads"]
+        "tags": [
+          "threads"
+        ]
       }
     },
     "/threads/{id}/knowledge-bases/{knowledgeBaseId}": {
@@ -3682,7 +3876,9 @@
           }
         },
         "summary": "Add a knowledge base to a thread",
-        "tags": ["threads"]
+        "tags": [
+          "threads"
+        ]
       },
       "delete": {
         "operationId": "ThreadKnowledgeBasesController_removeKnowledgeBase",
@@ -3717,7 +3913,9 @@
           }
         },
         "summary": "Remove a knowledge base from a thread",
-        "tags": ["threads"]
+        "tags": [
+          "threads"
+        ]
       }
     },
     "/agents": {
@@ -3753,7 +3951,9 @@
           }
         },
         "summary": "Create a new agent",
-        "tags": ["agents"]
+        "tags": [
+          "agents"
+        ]
       },
       "get": {
         "operationId": "AgentsController_findAll",
@@ -3777,7 +3977,9 @@
           }
         },
         "summary": "Get all agents for the current user",
-        "tags": ["agents"]
+        "tags": [
+          "agents"
+        ]
       }
     },
     "/agents/{id}": {
@@ -3814,7 +4016,9 @@
           }
         },
         "summary": "Get an agent by ID",
-        "tags": ["agents"]
+        "tags": [
+          "agents"
+        ]
       },
       "put": {
         "operationId": "AgentsController_update",
@@ -3862,7 +4066,9 @@
           }
         },
         "summary": "Update an agent",
-        "tags": ["agents"]
+        "tags": [
+          "agents"
+        ]
       },
       "delete": {
         "operationId": "AgentsController_delete",
@@ -3890,7 +4096,9 @@
           }
         },
         "summary": "Delete an agent",
-        "tags": ["agents"]
+        "tags": [
+          "agents"
+        ]
       }
     },
     "/agents/{id}/sources": {
@@ -3930,7 +4138,9 @@
           }
         },
         "summary": "Get all sources for an agent",
-        "tags": ["agents"]
+        "tags": [
+          "agents"
+        ]
       }
     },
     "/agents/{id}/sources/file": {
@@ -3961,7 +4171,9 @@
                     "description": "The file to upload"
                   }
                 },
-                "required": ["file"]
+                "required": [
+                  "file"
+                ]
               }
             }
           }
@@ -3981,7 +4193,9 @@
           }
         },
         "summary": "Add a file source to an agent",
-        "tags": ["agents"]
+        "tags": [
+          "agents"
+        ]
       }
     },
     "/agents/{id}/sources/{sourceAssignmentId}": {
@@ -4018,7 +4232,9 @@
           }
         },
         "summary": "Remove a source from an agent",
-        "tags": ["agents"]
+        "tags": [
+          "agents"
+        ]
       }
     },
     "/agents/{agentId}/mcp-integrations/{integrationId}": {
@@ -4071,7 +4287,9 @@
           }
         },
         "summary": "Assign MCP integration to agent",
-        "tags": ["agents"]
+        "tags": [
+          "agents"
+        ]
       },
       "delete": {
         "operationId": "AgentMcpIntegrationsController_unassignMcpIntegration",
@@ -4113,7 +4331,9 @@
           }
         },
         "summary": "Unassign MCP integration from agent",
-        "tags": ["agents"]
+        "tags": [
+          "agents"
+        ]
       }
     },
     "/agents/{agentId}/mcp-integrations": {
@@ -4150,7 +4370,9 @@
           }
         },
         "summary": "List MCP integrations assigned to agent",
-        "tags": ["agents"]
+        "tags": [
+          "agents"
+        ]
       }
     },
     "/shares": {
@@ -4193,7 +4415,9 @@
           }
         },
         "summary": "Create a share for an agent",
-        "tags": ["shares"]
+        "tags": [
+          "shares"
+        ]
       },
       "get": {
         "operationId": "SharesController_getShares",
@@ -4214,7 +4438,12 @@
             "in": "query",
             "description": "Type of the entity",
             "schema": {
-              "enum": ["agent", "prompt", "skill", "knowledge_base"],
+              "enum": [
+                "agent",
+                "prompt",
+                "skill",
+                "knowledge_base"
+              ],
               "type": "string"
             }
           }
@@ -4244,7 +4473,9 @@
           }
         },
         "summary": "Get shares for an entity",
-        "tags": ["shares"]
+        "tags": [
+          "shares"
+        ]
       }
     },
     "/shares/skills": {
@@ -4284,7 +4515,9 @@
           }
         },
         "summary": "Create a share for a skill",
-        "tags": ["shares"]
+        "tags": [
+          "shares"
+        ]
       }
     },
     "/shares/knowledge-bases": {
@@ -4324,7 +4557,9 @@
           }
         },
         "summary": "Create a share for a knowledge base",
-        "tags": ["shares"]
+        "tags": [
+          "shares"
+        ]
       }
     },
     "/shares/{id}": {
@@ -4357,7 +4592,9 @@
           }
         },
         "summary": "Delete a share",
-        "tags": ["shares"]
+        "tags": [
+          "shares"
+        ]
       }
     },
     "/mcp-integrations/predefined": {
@@ -4393,7 +4630,9 @@
           }
         },
         "summary": "Create a new predefined MCP integration",
-        "tags": ["mcp-integrations"]
+        "tags": [
+          "mcp-integrations"
+        ]
       }
     },
     "/mcp-integrations/custom": {
@@ -4426,7 +4665,9 @@
           }
         },
         "summary": "Create a new custom MCP integration",
-        "tags": ["mcp-integrations"]
+        "tags": [
+          "mcp-integrations"
+        ]
       }
     },
     "/mcp-integrations": {
@@ -4449,7 +4690,9 @@
           }
         },
         "summary": "List all MCP integrations for organization",
-        "tags": ["mcp-integrations"]
+        "tags": [
+          "mcp-integrations"
+        ]
       }
     },
     "/mcp-integrations/predefined/available": {
@@ -4472,7 +4715,9 @@
           }
         },
         "summary": "List available predefined MCP integration configurations",
-        "tags": ["mcp-integrations"]
+        "tags": [
+          "mcp-integrations"
+        ]
       }
     },
     "/mcp-integrations/available": {
@@ -4495,7 +4740,9 @@
           }
         },
         "summary": "List all available (enabled) MCP integrations for organization",
-        "tags": ["mcp-integrations"]
+        "tags": [
+          "mcp-integrations"
+        ]
       }
     },
     "/mcp-integrations/{id}": {
@@ -4528,7 +4775,9 @@
           }
         },
         "summary": "Get MCP integration by ID",
-        "tags": ["mcp-integrations"]
+        "tags": [
+          "mcp-integrations"
+        ]
       },
       "patch": {
         "operationId": "McpIntegrationsController_update",
@@ -4572,7 +4821,9 @@
           }
         },
         "summary": "Update MCP integration",
-        "tags": ["mcp-integrations"]
+        "tags": [
+          "mcp-integrations"
+        ]
       },
       "delete": {
         "operationId": "McpIntegrationsController_delete",
@@ -4596,7 +4847,9 @@
           }
         },
         "summary": "Delete MCP integration",
-        "tags": ["mcp-integrations"]
+        "tags": [
+          "mcp-integrations"
+        ]
       }
     },
     "/mcp-integrations/{id}/enable": {
@@ -4629,7 +4882,9 @@
           }
         },
         "summary": "Enable MCP integration",
-        "tags": ["mcp-integrations"]
+        "tags": [
+          "mcp-integrations"
+        ]
       }
     },
     "/mcp-integrations/{id}/disable": {
@@ -4662,7 +4917,9 @@
           }
         },
         "summary": "Disable MCP integration",
-        "tags": ["mcp-integrations"]
+        "tags": [
+          "mcp-integrations"
+        ]
       }
     },
     "/mcp-integrations/install-from-marketplace": {
@@ -4698,7 +4955,9 @@
           }
         },
         "summary": "Install an MCP integration from the marketplace",
-        "tags": ["mcp-integrations"]
+        "tags": [
+          "mcp-integrations"
+        ]
       }
     },
     "/mcp-integrations/{id}/user-config": {
@@ -4728,7 +4987,9 @@
           }
         },
         "summary": "Get current user config for a marketplace MCP integration",
-        "tags": ["mcp-integrations"]
+        "tags": [
+          "mcp-integrations"
+        ]
       },
       "patch": {
         "operationId": "McpIntegrationsController_setUserConfig",
@@ -4772,7 +5033,9 @@
           }
         },
         "summary": "Set current user config for a marketplace MCP integration",
-        "tags": ["mcp-integrations"]
+        "tags": [
+          "mcp-integrations"
+        ]
       }
     },
     "/mcp-integrations/{id}/validate": {
@@ -4805,7 +5068,9 @@
           }
         },
         "summary": "Validate MCP integration connection",
-        "tags": ["mcp-integrations"]
+        "tags": [
+          "mcp-integrations"
+        ]
       }
     },
     "/marketplace/skills/{identifier}": {
@@ -4838,7 +5103,9 @@
           }
         },
         "summary": "Preview a marketplace skill before installation",
-        "tags": ["marketplace"]
+        "tags": [
+          "marketplace"
+        ]
       }
     },
     "/marketplace/integrations/{identifier}": {
@@ -4871,7 +5138,9 @@
           }
         },
         "summary": "Preview a marketplace integration before installation",
-        "tags": ["marketplace"]
+        "tags": [
+          "marketplace"
+        ]
       }
     },
     "/knowledge-bases": {
@@ -4904,7 +5173,9 @@
           }
         },
         "summary": "Create a new knowledge base",
-        "tags": ["knowledge-bases"]
+        "tags": [
+          "knowledge-bases"
+        ]
       },
       "get": {
         "operationId": "KnowledgeBasesController_findAll",
@@ -4922,7 +5193,9 @@
           }
         },
         "summary": "List all knowledge bases for the current user",
-        "tags": ["knowledge-bases"]
+        "tags": [
+          "knowledge-bases"
+        ]
       }
     },
     "/knowledge-bases/{id}": {
@@ -4956,7 +5229,9 @@
           }
         },
         "summary": "Get a knowledge base by ID",
-        "tags": ["knowledge-bases"]
+        "tags": [
+          "knowledge-bases"
+        ]
       },
       "patch": {
         "operationId": "KnowledgeBasesController_update",
@@ -5001,7 +5276,9 @@
           }
         },
         "summary": "Update a knowledge base",
-        "tags": ["knowledge-bases"]
+        "tags": [
+          "knowledge-bases"
+        ]
       },
       "delete": {
         "operationId": "KnowledgeBasesController_delete",
@@ -5026,7 +5303,9 @@
           }
         },
         "summary": "Delete a knowledge base",
-        "tags": ["knowledge-bases"]
+        "tags": [
+          "knowledge-bases"
+        ]
       }
     },
     "/knowledge-bases/{id}/documents": {
@@ -5060,7 +5339,9 @@
           }
         },
         "summary": "List all documents in a knowledge base",
-        "tags": ["knowledge-bases"]
+        "tags": [
+          "knowledge-bases"
+        ]
       },
       "post": {
         "operationId": "KnowledgeBasesController_addDocument",
@@ -5089,7 +5370,9 @@
                     "description": "The file to upload (PDF, DOCX, PPTX, TXT)"
                   }
                 },
-                "required": ["file"]
+                "required": [
+                  "file"
+                ]
               }
             }
           }
@@ -5110,7 +5393,9 @@
           }
         },
         "summary": "Add a document to a knowledge base",
-        "tags": ["knowledge-bases"]
+        "tags": [
+          "knowledge-bases"
+        ]
       }
     },
     "/knowledge-bases/{id}/urls": {
@@ -5154,7 +5439,9 @@
           }
         },
         "summary": "Add a URL source to a knowledge base",
-        "tags": ["knowledge-bases"]
+        "tags": [
+          "knowledge-bases"
+        ]
       }
     },
     "/knowledge-bases/{id}/documents/{documentId}": {
@@ -5191,7 +5478,9 @@
           }
         },
         "summary": "Remove a document from a knowledge base",
-        "tags": ["knowledge-bases"]
+        "tags": [
+          "knowledge-bases"
+        ]
       }
     },
     "/skills/install-from-marketplace": {
@@ -5224,7 +5513,9 @@
           }
         },
         "summary": "Install a skill from the marketplace",
-        "tags": ["skills"]
+        "tags": [
+          "skills"
+        ]
       }
     },
     "/skills": {
@@ -5260,7 +5551,9 @@
           }
         },
         "summary": "Create a new skill",
-        "tags": ["skills"]
+        "tags": [
+          "skills"
+        ]
       },
       "get": {
         "operationId": "SkillsController_findAll",
@@ -5281,7 +5574,9 @@
           }
         },
         "summary": "Get all skills for the current user",
-        "tags": ["skills"]
+        "tags": [
+          "skills"
+        ]
       }
     },
     "/skills/{id}": {
@@ -5315,7 +5610,9 @@
           }
         },
         "summary": "Get a skill by ID",
-        "tags": ["skills"]
+        "tags": [
+          "skills"
+        ]
       },
       "put": {
         "operationId": "SkillsController_update",
@@ -5363,7 +5660,9 @@
           }
         },
         "summary": "Update a skill",
-        "tags": ["skills"]
+        "tags": [
+          "skills"
+        ]
       },
       "delete": {
         "operationId": "SkillsController_delete",
@@ -5388,7 +5687,9 @@
           }
         },
         "summary": "Delete a skill",
-        "tags": ["skills"]
+        "tags": [
+          "skills"
+        ]
       }
     },
     "/skills/{id}/toggle-active": {
@@ -5422,7 +5723,9 @@
           }
         },
         "summary": "Toggle skill active/inactive status",
-        "tags": ["skills"]
+        "tags": [
+          "skills"
+        ]
       }
     },
     "/skills/{id}/toggle-pinned": {
@@ -5459,7 +5762,9 @@
           }
         },
         "summary": "Toggle skill pinned/unpinned status",
-        "tags": ["skills"]
+        "tags": [
+          "skills"
+        ]
       }
     },
     "/skills/{id}/sources": {
@@ -5496,7 +5801,9 @@
           }
         },
         "summary": "Get all sources for a skill",
-        "tags": ["skills"]
+        "tags": [
+          "skills"
+        ]
       }
     },
     "/skills/{id}/sources/file": {
@@ -5527,7 +5834,9 @@
                     "description": "The file to upload"
                   }
                 },
-                "required": ["file"]
+                "required": [
+                  "file"
+                ]
               }
             }
           }
@@ -5551,7 +5860,9 @@
           }
         },
         "summary": "Add a file source to a skill",
-        "tags": ["skills"]
+        "tags": [
+          "skills"
+        ]
       }
     },
     "/skills/{id}/sources/{sourceId}": {
@@ -5588,7 +5899,9 @@
           }
         },
         "summary": "Remove a source from a skill",
-        "tags": ["skills"]
+        "tags": [
+          "skills"
+        ]
       }
     },
     "/skills/{skillId}/mcp-integrations/{integrationId}": {
@@ -5635,7 +5948,9 @@
           }
         },
         "summary": "Assign MCP integration to skill",
-        "tags": ["skills"]
+        "tags": [
+          "skills"
+        ]
       },
       "delete": {
         "operationId": "SkillMcpIntegrationsController_unassignMcpIntegration",
@@ -5677,7 +5992,9 @@
           }
         },
         "summary": "Unassign MCP integration from skill",
-        "tags": ["skills"]
+        "tags": [
+          "skills"
+        ]
       }
     },
     "/skills/{skillId}/mcp-integrations": {
@@ -5714,7 +6031,9 @@
           }
         },
         "summary": "List MCP integrations assigned to skill",
-        "tags": ["skills"]
+        "tags": [
+          "skills"
+        ]
       }
     },
     "/skills/{skillId}/knowledge-bases/{knowledgeBaseId}": {
@@ -5761,7 +6080,9 @@
           }
         },
         "summary": "Assign knowledge base to skill",
-        "tags": ["skills"]
+        "tags": [
+          "skills"
+        ]
       },
       "delete": {
         "operationId": "SkillKnowledgeBasesController_unassignKnowledgeBase",
@@ -5803,7 +6124,9 @@
           }
         },
         "summary": "Unassign knowledge base from skill",
-        "tags": ["skills"]
+        "tags": [
+          "skills"
+        ]
       }
     },
     "/skills/{skillId}/knowledge-bases": {
@@ -5840,7 +6163,9 @@
           }
         },
         "summary": "List knowledge bases assigned to skill",
-        "tags": ["skills"]
+        "tags": [
+          "skills"
+        ]
       }
     },
     "/super-admin/skill-templates": {
@@ -5880,7 +6205,9 @@
           }
         },
         "summary": "Create a new skill template",
-        "tags": ["Super Admin Skill Templates"]
+        "tags": [
+          "Super Admin Skill Templates"
+        ]
       },
       "get": {
         "description": "Retrieve all skill templates. Only accessible to super admins.",
@@ -5908,7 +6235,9 @@
           }
         },
         "summary": "Get all skill templates",
-        "tags": ["Super Admin Skill Templates"]
+        "tags": [
+          "Super Admin Skill Templates"
+        ]
       }
     },
     "/super-admin/skill-templates/{id}": {
@@ -5949,7 +6278,9 @@
           }
         },
         "summary": "Get a skill template by ID",
-        "tags": ["Super Admin Skill Templates"]
+        "tags": [
+          "Super Admin Skill Templates"
+        ]
       },
       "patch": {
         "description": "Partially update an existing skill template. Only accessible to super admins.",
@@ -6001,7 +6332,9 @@
           }
         },
         "summary": "Update a skill template",
-        "tags": ["Super Admin Skill Templates"]
+        "tags": [
+          "Super Admin Skill Templates"
+        ]
       },
       "delete": {
         "description": "Delete a skill template. Only accessible to super admins.",
@@ -6033,7 +6366,9 @@
           }
         },
         "summary": "Delete a skill template",
-        "tags": ["Super Admin Skill Templates"]
+        "tags": [
+          "Super Admin Skill Templates"
+        ]
       }
     },
     "/artifacts": {
@@ -6066,7 +6401,9 @@
           }
         },
         "summary": "Create a new artifact (document)",
-        "tags": ["artifacts"]
+        "tags": [
+          "artifacts"
+        ]
       }
     },
     "/artifacts/{id}": {
@@ -6110,7 +6447,9 @@
           }
         },
         "summary": "Update an artifact (add a new version)",
-        "tags": ["artifacts"]
+        "tags": [
+          "artifacts"
+        ]
       },
       "get": {
         "operationId": "ArtifactsController_findOne",
@@ -6142,7 +6481,9 @@
           }
         },
         "summary": "Get an artifact by ID with all versions",
-        "tags": ["artifacts"]
+        "tags": [
+          "artifacts"
+        ]
       }
     },
     "/artifacts/thread/{threadId}": {
@@ -6176,7 +6517,9 @@
           }
         },
         "summary": "Get all artifacts for a thread",
-        "tags": ["artifacts"]
+        "tags": [
+          "artifacts"
+        ]
       }
     },
     "/artifacts/{id}/revert": {
@@ -6220,7 +6563,9 @@
           }
         },
         "summary": "Revert an artifact to a specific version",
-        "tags": ["artifacts"]
+        "tags": [
+          "artifacts"
+        ]
       }
     },
     "/artifacts/{id}/export": {
@@ -6243,7 +6588,10 @@
             "in": "query",
             "description": "Export format",
             "schema": {
-              "enum": ["docx", "pdf"],
+              "enum": [
+                "docx",
+                "pdf"
+              ],
               "type": "string"
             }
           }
@@ -6265,7 +6613,9 @@
           }
         },
         "summary": "Export an artifact as DOCX or PDF",
-        "tags": ["artifacts"]
+        "tags": [
+          "artifacts"
+        ]
       }
     },
     "/runs/send-message": {
@@ -6279,7 +6629,9 @@
             "multipart/form-data": {
               "schema": {
                 "type": "object",
-                "required": ["threadId"],
+                "required": [
+                  "threadId"
+                ],
                 "properties": {
                   "threadId": {
                     "type": "string",
@@ -6386,7 +6738,9 @@
           }
         },
         "summary": "Send a message with optional images and receive streaming response",
-        "tags": ["runs"]
+        "tags": [
+          "runs"
+        ]
       }
     },
     "/super-admin/trials": {
@@ -6424,7 +6778,9 @@
           }
         },
         "summary": "Create a new trial",
-        "tags": ["Super Admin Trials"]
+        "tags": [
+          "Super Admin Trials"
+        ]
       }
     },
     "/super-admin/trials/{orgId}": {
@@ -6461,7 +6817,9 @@
           }
         },
         "summary": "Get a trial by organization ID",
-        "tags": ["Super Admin Trials"]
+        "tags": [
+          "Super Admin Trials"
+        ]
       },
       "put": {
         "description": "Update a trial for an organization. Can update maxMessages and/or messagesSent. Only accessible to users with the super admin system role.",
@@ -6507,7 +6865,9 @@
           }
         },
         "summary": "Update a trial",
-        "tags": ["Super Admin Trials"]
+        "tags": [
+          "Super Admin Trials"
+        ]
       }
     },
     "/usage/config": {
@@ -6528,7 +6888,9 @@
           }
         },
         "summary": "Get usage dashboard configuration",
-        "tags": ["Admin Usage"]
+        "tags": [
+          "Admin Usage"
+        ]
       }
     },
     "/usage/credits": {
@@ -6549,7 +6911,9 @@
           }
         },
         "summary": "Get credit usage for the current month",
-        "tags": ["Admin Usage"]
+        "tags": [
+          "Admin Usage"
+        ]
       }
     },
     "/usage/users": {
@@ -6613,7 +6977,12 @@
             "in": "query",
             "description": "Field to sort users by. Defaults to tokens.",
             "schema": {
-              "enum": ["tokens", "requests", "lastActivity", "userName"],
+              "enum": [
+                "tokens",
+                "requests",
+                "lastActivity",
+                "userName"
+              ],
               "type": "string"
             }
           },
@@ -6623,7 +6992,10 @@
             "in": "query",
             "description": "Sort order (ascending or descending). Defaults to desc.",
             "schema": {
-              "enum": ["asc", "desc"],
+              "enum": [
+                "asc",
+                "desc"
+              ],
               "type": "string"
             }
           }
@@ -6641,7 +7013,9 @@
           }
         },
         "summary": "Get usage statistics by user",
-        "tags": ["Admin Usage"]
+        "tags": [
+          "Admin Usage"
+        ]
       }
     },
     "/super-admin/usage/{orgId}/config": {
@@ -6671,7 +7045,9 @@
           }
         },
         "summary": "Get usage dashboard configuration for an organization",
-        "tags": ["Super Admin Usage"]
+        "tags": [
+          "Super Admin Usage"
+        ]
       }
     },
     "/super-admin/usage/{orgId}/credits": {
@@ -6703,7 +7079,9 @@
           }
         },
         "summary": "Get credit usage for an organization",
-        "tags": ["Super Admin Usage"]
+        "tags": [
+          "Super Admin Usage"
+        ]
       }
     },
     "/super-admin/usage/{orgId}/stats": {
@@ -6750,7 +7128,9 @@
           }
         },
         "summary": "Get overall usage statistics for an organization",
-        "tags": ["Super Admin Usage"]
+        "tags": [
+          "Super Admin Usage"
+        ]
       }
     },
     "/super-admin/usage/{orgId}/models": {
@@ -6813,7 +7193,9 @@
           }
         },
         "summary": "Get usage distribution by model for an organization",
-        "tags": ["Super Admin Usage"]
+        "tags": [
+          "Super Admin Usage"
+        ]
       }
     },
     "/super-admin/usage/{orgId}/providers": {
@@ -6884,7 +7266,9 @@
           }
         },
         "summary": "Get usage statistics by provider for an organization",
-        "tags": ["Super Admin Usage"]
+        "tags": [
+          "Super Admin Usage"
+        ]
       }
     },
     "/super-admin/usage/{orgId}/providers/chart": {
@@ -6947,7 +7331,9 @@
           }
         },
         "summary": "Get provider usage time series for an organization (chart-ready)",
-        "tags": ["Super Admin Usage"]
+        "tags": [
+          "Super Admin Usage"
+        ]
       }
     },
     "/super-admin/usage/{orgId}/users": {
@@ -7009,7 +7395,12 @@
             "required": false,
             "in": "query",
             "schema": {
-              "enum": ["tokens", "requests", "lastActivity", "userName"],
+              "enum": [
+                "tokens",
+                "requests",
+                "lastActivity",
+                "userName"
+              ],
               "type": "string"
             }
           },
@@ -7018,7 +7409,10 @@
             "required": false,
             "in": "query",
             "schema": {
-              "enum": ["asc", "desc"],
+              "enum": [
+                "asc",
+                "desc"
+              ],
               "type": "string"
             }
           }
@@ -7036,7 +7430,9 @@
           }
         },
         "summary": "Get usage statistics by user for an organization",
-        "tags": ["Super Admin Usage"]
+        "tags": [
+          "Super Admin Usage"
+        ]
       }
     },
     "/super-admin/global-usage/providers/chart": {
@@ -7089,7 +7485,9 @@
           }
         },
         "summary": "Get global provider usage time series across all organizations (chart-ready)",
-        "tags": ["Super Admin Global Usage"]
+        "tags": [
+          "Super Admin Global Usage"
+        ]
       }
     },
     "/super-admin/global-usage/models": {
@@ -7134,7 +7532,9 @@
           }
         },
         "summary": "Get global model distribution across all organizations",
-        "tags": ["Super Admin Global Usage"]
+        "tags": [
+          "Super Admin Global Usage"
+        ]
       }
     },
     "/super-admin/global-usage/users": {
@@ -7171,7 +7571,9 @@
           }
         },
         "summary": "Get top 20 users by token usage across all organizations",
-        "tags": ["Super Admin Global Usage"]
+        "tags": [
+          "Super Admin Global Usage"
+        ]
       }
     },
     "/super-admin/platform-config/credits-per-euro": {
@@ -7201,7 +7603,9 @@
           }
         },
         "summary": "Get the current credits-per-euro configuration",
-        "tags": ["Super Admin Platform Config"]
+        "tags": [
+          "Super Admin Platform Config"
+        ]
       },
       "put": {
         "description": "Update the global credits-per-euro value used for credit calculations. Super admin only.",
@@ -7232,7 +7636,9 @@
           }
         },
         "summary": "Set the credits-per-euro configuration",
-        "tags": ["Super Admin Platform Config"]
+        "tags": [
+          "Super Admin Platform Config"
+        ]
       }
     },
     "/chat-settings/system-prompt": {
@@ -7253,7 +7659,9 @@
           }
         },
         "summary": "Get the user system prompt",
-        "tags": ["Chat Settings"]
+        "tags": [
+          "Chat Settings"
+        ]
       },
       "put": {
         "description": "Creates or replaces the custom system prompt for the authenticated user.",
@@ -7285,7 +7693,9 @@
           }
         },
         "summary": "Set or update the user system prompt",
-        "tags": ["Chat Settings"]
+        "tags": [
+          "Chat Settings"
+        ]
       },
       "delete": {
         "description": "Deletes the custom system prompt for the authenticated user.",
@@ -7297,7 +7707,9 @@
           }
         },
         "summary": "Delete the user system prompt",
-        "tags": ["Chat Settings"]
+        "tags": [
+          "Chat Settings"
+        ]
       }
     },
     "/chat-settings/generate-personalized-system-prompt": {
@@ -7337,7 +7749,9 @@
           }
         },
         "summary": "Generate a personalized system prompt",
-        "tags": ["Chat Settings"]
+        "tags": [
+          "Chat Settings"
+        ]
       }
     },
     "/prompts": {
@@ -7373,7 +7787,9 @@
           }
         },
         "summary": "Create a new prompt",
-        "tags": ["prompts"]
+        "tags": [
+          "prompts"
+        ]
       },
       "get": {
         "operationId": "PromptsController_findAll",
@@ -7397,7 +7813,9 @@
           }
         },
         "summary": "Get all prompts for the current user",
-        "tags": ["prompts"]
+        "tags": [
+          "prompts"
+        ]
       }
     },
     "/prompts/{id}": {
@@ -7434,7 +7852,9 @@
           }
         },
         "summary": "Get a prompt by ID",
-        "tags": ["prompts"]
+        "tags": [
+          "prompts"
+        ]
       },
       "put": {
         "operationId": "PromptsController_update",
@@ -7482,7 +7902,9 @@
           }
         },
         "summary": "Update a prompt",
-        "tags": ["prompts"]
+        "tags": [
+          "prompts"
+        ]
       },
       "delete": {
         "operationId": "PromptsController_delete",
@@ -7510,7 +7932,9 @@
           }
         },
         "summary": "Delete a prompt",
-        "tags": ["prompts"]
+        "tags": [
+          "prompts"
+        ]
       }
     },
     "/transcriptions": {
@@ -7524,7 +7948,9 @@
             "multipart/form-data": {
               "schema": {
                 "type": "object",
-                "required": ["file"],
+                "required": [
+                  "file"
+                ],
                 "properties": {
                   "file": {
                     "type": "string",
@@ -7568,7 +7994,9 @@
           }
         ],
         "summary": "Transcribe audio file to text",
-        "tags": ["transcriptions"]
+        "tags": [
+          "transcriptions"
+        ]
       }
     },
     "/auth/login": {
@@ -7620,7 +8048,9 @@
           }
         },
         "summary": "User login",
-        "tags": ["Authentication"]
+        "tags": [
+          "Authentication"
+        ]
       }
     },
     "/auth/register": {
@@ -7672,7 +8102,9 @@
           }
         },
         "summary": "User registration",
-        "tags": ["Authentication"]
+        "tags": [
+          "Authentication"
+        ]
       }
     },
     "/auth/refresh": {
@@ -7718,7 +8150,9 @@
           }
         ],
         "summary": "Refresh authentication tokens",
-        "tags": ["Authentication"]
+        "tags": [
+          "Authentication"
+        ]
       }
     },
     "/auth/me": {
@@ -7759,7 +8193,9 @@
           }
         },
         "summary": "Get current user information",
-        "tags": ["Authentication"]
+        "tags": [
+          "Authentication"
+        ]
       }
     },
     "/auth/logout": {
@@ -7780,7 +8216,9 @@
           }
         },
         "summary": "User logout",
-        "tags": ["Authentication"]
+        "tags": [
+          "Authentication"
+        ]
       }
     }
   },
@@ -7813,7 +8251,10 @@
             "example": false
           }
         },
-        "required": ["isCloud", "isRegistrationDisabled"]
+        "required": [
+          "isCloud",
+          "isRegistrationDisabled"
+        ]
       },
       "FeatureTogglesResponseDto": {
         "type": "object",
@@ -7963,12 +8404,22 @@
           },
           "hostedIn": {
             "type": "string",
-            "enum": ["DE", "EU", "US", "SELF_HOSTED", "AYUNIS"],
+            "enum": [
+              "DE",
+              "EU",
+              "US",
+              "SELF_HOSTED",
+              "AYUNIS"
+            ],
             "description": "The location where the provider hosts their services",
             "example": "US"
           }
         },
-        "required": ["provider", "displayName", "hostedIn"]
+        "required": [
+          "provider",
+          "displayName",
+          "hostedIn"
+        ]
       },
       "CreatePermittedModelDto": {
         "type": "object",
@@ -7985,7 +8436,9 @@
             "default": false
           }
         },
-        "required": ["modelId"]
+        "required": [
+          "modelId"
+        ]
       },
       "UpdatePermittedModelDto": {
         "type": "object",
@@ -7996,7 +8449,9 @@
             "example": true
           }
         },
-        "required": ["anonymousOnly"]
+        "required": [
+          "anonymousOnly"
+        ]
       },
       "PermittedLanguageModelResponseDto": {
         "type": "object",
@@ -8045,7 +8500,9 @@
           },
           "type": {
             "type": "string",
-            "enum": ["language"],
+            "enum": [
+              "language"
+            ],
             "description": "The type of the model (always language)"
           },
           "canStream": {
@@ -8098,7 +8555,9 @@
             ]
           }
         },
-        "required": ["permittedLanguageModel"]
+        "required": [
+          "permittedLanguageModel"
+        ]
       },
       "SetUserDefaultModelDto": {
         "type": "object",
@@ -8109,7 +8568,9 @@
             "example": "123e4567-e89b-12d3-a456-426614174000"
           }
         },
-        "required": ["permittedModelId"]
+        "required": [
+          "permittedModelId"
+        ]
       },
       "SetOrgDefaultModelDto": {
         "type": "object",
@@ -8120,7 +8581,9 @@
             "example": "123e4567-e89b-12d3-a456-426614174000"
           }
         },
-        "required": ["permittedModelId"]
+        "required": [
+          "permittedModelId"
+        ]
       },
       "EmbeddingModelEnabledResponseDto": {
         "type": "object",
@@ -8131,7 +8594,9 @@
             "example": true
           }
         },
-        "required": ["isEmbeddingModelEnabled"]
+        "required": [
+          "isEmbeddingModelEnabled"
+        ]
       },
       "CreateTeamPermittedModelDto": {
         "type": "object",
@@ -8148,7 +8613,9 @@
             "default": false
           }
         },
-        "required": ["modelId"]
+        "required": [
+          "modelId"
+        ]
       },
       "SetTeamDefaultModelDto": {
         "type": "object",
@@ -8159,7 +8626,9 @@
             "example": "123e4567-e89b-12d3-a456-426614174000"
           }
         },
-        "required": ["permittedModelId"]
+        "required": [
+          "permittedModelId"
+        ]
       },
       "PermittedEmbeddingModelResponseDto": {
         "type": "object",
@@ -8204,7 +8673,9 @@
           },
           "type": {
             "type": "string",
-            "enum": ["embedding"],
+            "enum": [
+              "embedding"
+            ],
             "description": "The type of the model (always embedding)"
           },
           "dimensions": {
@@ -8421,7 +8892,11 @@
           "dimensions": {
             "type": "number",
             "description": "The dimensions of the embedding",
-            "enum": [1024, 1536, 2560],
+            "enum": [
+              1024,
+              1536,
+              2560
+            ],
             "example": 1536
           },
           "isArchived": {
@@ -8485,7 +8960,11 @@
           "dimensions": {
             "type": "number",
             "description": "The dimensions of the embedding",
-            "enum": [1024, 1536, 2560],
+            "enum": [
+              1024,
+              1536,
+              2560
+            ],
             "example": 1536
           },
           "isArchived": {
@@ -8554,7 +9033,9 @@
           },
           "type": {
             "type": "string",
-            "enum": ["language"],
+            "enum": [
+              "language"
+            ],
             "description": "The type of the model (always language)"
           },
           "isArchived": {
@@ -8658,7 +9139,9 @@
           },
           "type": {
             "type": "string",
-            "enum": ["embedding"],
+            "enum": [
+              "embedding"
+            ],
             "description": "The type of the model (always embedding)"
           },
           "isArchived": {
@@ -8721,7 +9204,9 @@
             "example": "Acme Corporation"
           }
         },
-        "required": ["name"]
+        "required": [
+          "name"
+        ]
       },
       "SuperAdminOrgResponseDto": {
         "type": "object",
@@ -8744,7 +9229,11 @@
             "example": "2024-01-15T10:30:00Z"
           }
         },
-        "required": ["id", "name", "createdAt"]
+        "required": [
+          "id",
+          "name",
+          "createdAt"
+        ]
       },
       "PaginationDto": {
         "type": "object",
@@ -8765,7 +9254,10 @@
             "example": 150
           }
         },
-        "required": ["limit", "offset"]
+        "required": [
+          "limit",
+          "offset"
+        ]
       },
       "SuperAdminOrgListResponseDto": {
         "type": "object",
@@ -8786,7 +9278,10 @@
             ]
           }
         },
-        "required": ["data", "pagination"]
+        "required": [
+          "data",
+          "pagination"
+        ]
       },
       "UserResponseDto": {
         "type": "object",
@@ -8810,7 +9305,10 @@
           "role": {
             "type": "string",
             "description": "User role",
-            "enum": ["admin", "user"],
+            "enum": [
+              "admin",
+              "user"
+            ],
             "example": "user"
           },
           "orgId": {
@@ -8832,7 +9330,14 @@
             "example": "2024-01-15T10:30:00Z"
           }
         },
-        "required": ["id", "name", "email", "role", "orgId", "createdAt"]
+        "required": [
+          "id",
+          "name",
+          "email",
+          "role",
+          "orgId",
+          "createdAt"
+        ]
       },
       "PaginatedUsersListResponseDto": {
         "type": "object",
@@ -8853,7 +9358,10 @@
             ]
           }
         },
-        "required": ["data", "pagination"]
+        "required": [
+          "data",
+          "pagination"
+        ]
       },
       "UpdateUserRoleDto": {
         "type": "object",
@@ -8861,11 +9369,16 @@
           "role": {
             "type": "string",
             "description": "New role for the user",
-            "enum": ["admin", "user"],
+            "enum": [
+              "admin",
+              "user"
+            ],
             "example": "admin"
           }
         },
-        "required": ["role"]
+        "required": [
+          "role"
+        ]
       },
       "UpdateUserNameDto": {
         "type": "object",
@@ -8878,7 +9391,9 @@
             "maxLength": 100
           }
         },
-        "required": ["name"]
+        "required": [
+          "name"
+        ]
       },
       "UpdatePasswordDto": {
         "type": "object",
@@ -8917,7 +9432,9 @@
             "example": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
           }
         },
-        "required": ["token"]
+        "required": [
+          "token"
+        ]
       },
       "ResendEmailConfirmationDto": {
         "type": "object",
@@ -8929,7 +9446,9 @@
             "format": "email"
           }
         },
-        "required": ["email"]
+        "required": [
+          "email"
+        ]
       },
       "ForgotPasswordDto": {
         "type": "object",
@@ -8940,7 +9459,9 @@
             "example": "user@example.com"
           }
         },
-        "required": ["email"]
+        "required": [
+          "email"
+        ]
       },
       "ResetPasswordDto": {
         "type": "object",
@@ -8963,7 +9484,11 @@
             "minLength": 8
           }
         },
-        "required": ["resetToken", "newPassword", "newPasswordConfirmation"]
+        "required": [
+          "resetToken",
+          "newPassword",
+          "newPasswordConfirmation"
+        ]
       },
       "CreateUserDto": {
         "type": "object",
@@ -8981,7 +9506,10 @@
           "role": {
             "type": "string",
             "description": "Role for the user",
-            "enum": ["admin", "user"],
+            "enum": [
+              "admin",
+              "user"
+            ],
             "example": "user"
           },
           "sendPasswordResetEmail": {
@@ -8990,7 +9518,12 @@
             "example": true
           }
         },
-        "required": ["email", "name", "role", "sendPasswordResetEmail"]
+        "required": [
+          "email",
+          "name",
+          "role",
+          "sendPasswordResetEmail"
+        ]
       },
       "SuperAdminUserResponseDto": {
         "type": "object",
@@ -9014,7 +9547,10 @@
           "role": {
             "type": "string",
             "description": "User role",
-            "enum": ["admin", "user"],
+            "enum": [
+              "admin",
+              "user"
+            ],
             "example": "user"
           },
           "orgId": {
@@ -9038,7 +9574,10 @@
           "systemRole": {
             "type": "string",
             "description": "System-level role of the user",
-            "enum": ["customer", "super_admin"],
+            "enum": [
+              "customer",
+              "super_admin"
+            ],
             "example": "super_admin"
           }
         },
@@ -9061,7 +9600,9 @@
             "example": "user@example.com"
           }
         },
-        "required": ["email"]
+        "required": [
+          "email"
+        ]
       },
       "CreateInviteDto": {
         "type": "object",
@@ -9074,11 +9615,17 @@
           "role": {
             "type": "string",
             "description": "Role to assign to the invited user",
-            "enum": ["admin", "user"],
+            "enum": [
+              "admin",
+              "user"
+            ],
             "example": "user"
           }
         },
-        "required": ["email", "role"]
+        "required": [
+          "email",
+          "role"
+        ]
       },
       "CreateInviteResponseDto": {
         "type": "object",
@@ -9090,7 +9637,9 @@
             "nullable": true
           }
         },
-        "required": ["url"]
+        "required": [
+          "url"
+        ]
       },
       "CreateBulkInviteItemDto": {
         "type": "object",
@@ -9103,11 +9652,17 @@
           "role": {
             "type": "string",
             "description": "Role to assign to the invited user",
-            "enum": ["admin", "user"],
+            "enum": [
+              "admin",
+              "user"
+            ],
             "example": "user"
           }
         },
-        "required": ["email", "role"]
+        "required": [
+          "email",
+          "role"
+        ]
       },
       "CreateBulkInvitesDto": {
         "type": "object",
@@ -9122,7 +9677,9 @@
             }
           }
         },
-        "required": ["invites"]
+        "required": [
+          "invites"
+        ]
       },
       "BulkInviteResultDto": {
         "type": "object",
@@ -9135,7 +9692,10 @@
           "role": {
             "type": "string",
             "description": "Role assigned to the invited user",
-            "enum": ["admin", "user"],
+            "enum": [
+              "admin",
+              "user"
+            ],
             "example": "user"
           },
           "success": {
@@ -9197,7 +9757,12 @@
             }
           }
         },
-        "required": ["totalCount", "successCount", "failureCount", "results"]
+        "required": [
+          "totalCount",
+          "successCount",
+          "failureCount",
+          "results"
+        ]
       },
       "InviteResponseDto": {
         "type": "object",
@@ -9216,13 +9781,20 @@
           "role": {
             "type": "string",
             "description": "Role assigned to the invited user",
-            "enum": ["admin", "user"],
+            "enum": [
+              "admin",
+              "user"
+            ],
             "example": "user"
           },
           "status": {
             "type": "string",
             "description": "Current status of the invite",
-            "enum": ["pending", "accepted", "expired"],
+            "enum": [
+              "pending",
+              "accepted",
+              "expired"
+            ],
             "example": "pending"
           },
           "sentDate": {
@@ -9244,7 +9816,14 @@
             "example": "2023-12-02T15:30:00Z"
           }
         },
-        "required": ["id", "email", "role", "status", "sentDate", "expiresAt"]
+        "required": [
+          "id",
+          "email",
+          "role",
+          "status",
+          "sentDate",
+          "expiresAt"
+        ]
       },
       "PaginatedInvitesListResponseDto": {
         "type": "object",
@@ -9265,7 +9844,10 @@
             ]
           }
         },
-        "required": ["data", "pagination"]
+        "required": [
+          "data",
+          "pagination"
+        ]
       },
       "InviteDetailResponseDto": {
         "type": "object",
@@ -9284,13 +9866,20 @@
           "role": {
             "type": "string",
             "description": "Role assigned to the invited user",
-            "enum": ["admin", "user"],
+            "enum": [
+              "admin",
+              "user"
+            ],
             "example": "user"
           },
           "status": {
             "type": "string",
             "description": "Current status of the invite",
-            "enum": ["pending", "accepted", "expired"],
+            "enum": [
+              "pending",
+              "accepted",
+              "expired"
+            ],
             "example": "pending"
           },
           "sentDate": {
@@ -9384,7 +9973,11 @@
             "format": "uuid"
           }
         },
-        "required": ["inviteId", "email", "orgId"]
+        "required": [
+          "inviteId",
+          "email",
+          "orgId"
+        ]
       },
       "DeleteAllPendingInvitesResponseDto": {
         "type": "object",
@@ -9394,7 +9987,9 @@
             "description": "Number of invites deleted"
           }
         },
-        "required": ["deletedCount"]
+        "required": [
+          "deletedCount"
+        ]
       },
       "ActiveSubscriptionResponseDto": {
         "type": "object",
@@ -9405,7 +10000,9 @@
             "example": true
           }
         },
-        "required": ["hasActiveSubscription"]
+        "required": [
+          "hasActiveSubscription"
+        ]
       },
       "PriceResponseDto": {
         "type": "object",
@@ -9416,7 +10013,9 @@
             "example": 29.99
           }
         },
-        "required": ["pricePerSeatMonthly"]
+        "required": [
+          "pricePerSeatMonthly"
+        ]
       },
       "SubscriptionBillingInfoResponseDto": {
         "type": "object",
@@ -9501,7 +10100,10 @@
           "type": {
             "type": "string",
             "description": "Subscription type",
-            "enum": ["SEAT_BASED", "USAGE_BASED"],
+            "enum": [
+              "SEAT_BASED",
+              "USAGE_BASED"
+            ],
             "example": "SEAT_BASED"
           },
           "noOfSeats": {
@@ -9517,7 +10119,10 @@
           "renewalCycle": {
             "type": "string",
             "description": "Renewal cycle of the subscription (seat-based only)",
-            "enum": ["monthly", "yearly"],
+            "enum": [
+              "monthly",
+              "yearly"
+            ],
             "example": "monthly"
           },
           "renewalCycleAnchor": {
@@ -9616,7 +10221,10 @@
           "type": {
             "type": "string",
             "description": "Subscription type. Defaults to SEAT_BASED if not specified.",
-            "enum": ["SEAT_BASED", "USAGE_BASED"],
+            "enum": [
+              "SEAT_BASED",
+              "USAGE_BASED"
+            ],
             "example": "SEAT_BASED",
             "default": "SEAT_BASED"
           },
@@ -9709,7 +10317,9 @@
             "example": "Engineering"
           }
         },
-        "required": ["name"]
+        "required": [
+          "name"
+        ]
       },
       "UpdateTeamDto": {
         "type": "object",
@@ -9725,7 +10335,9 @@
             "example": false
           }
         },
-        "required": ["name"]
+        "required": [
+          "name"
+        ]
       },
       "TeamResponseDto": {
         "type": "object",
@@ -9798,7 +10410,10 @@
           "userRole": {
             "type": "string",
             "description": "The role of the team member in the organization",
-            "enum": ["admin", "user"],
+            "enum": [
+              "admin",
+              "user"
+            ],
             "example": "user"
           },
           "joinedAt": {
@@ -9836,7 +10451,10 @@
             ]
           }
         },
-        "required": ["data", "pagination"]
+        "required": [
+          "data",
+          "pagination"
+        ]
       },
       "AddTeamMemberDto": {
         "type": "object",
@@ -9847,7 +10465,9 @@
             "example": "550e8400-e29b-41d4-a716-446655440001"
           }
         },
-        "required": ["userId"]
+        "required": [
+          "userId"
+        ]
       },
       "ListTeamMembersQueryDto": {
         "type": "object",
@@ -9896,7 +10516,11 @@
             "example": "2024-01-01T00:00:00.000Z"
           }
         },
-        "required": ["objectName", "size", "etag"]
+        "required": [
+          "objectName",
+          "size",
+          "etag"
+        ]
       },
       "RetrieveUrlDto": {
         "type": "object",
@@ -9907,7 +10531,9 @@
             "example": "https://example.com/article"
           }
         },
-        "required": ["url"]
+        "required": [
+          "url"
+        ]
       },
       "CreateThreadDto": {
         "type": "object",
@@ -9954,7 +10580,9 @@
             "type": "string",
             "description": "Role of the message sender",
             "example": "user",
-            "enum": ["user"]
+            "enum": [
+              "user"
+            ]
           },
           "content": {
             "type": "array",
@@ -9971,7 +10599,13 @@
             }
           }
         },
-        "required": ["id", "threadId", "createdAt", "role", "content"]
+        "required": [
+          "id",
+          "threadId",
+          "createdAt",
+          "role",
+          "content"
+        ]
       },
       "SystemMessageResponseDto": {
         "type": "object",
@@ -9995,7 +10629,9 @@
             "type": "string",
             "description": "Role of the message sender",
             "example": "system",
-            "enum": ["system"]
+            "enum": [
+              "system"
+            ]
           },
           "content": {
             "type": "array",
@@ -10005,7 +10641,13 @@
             }
           }
         },
-        "required": ["id", "threadId", "createdAt", "role", "content"]
+        "required": [
+          "id",
+          "threadId",
+          "createdAt",
+          "role",
+          "content"
+        ]
       },
       "AssistantMessageResponseDto": {
         "type": "object",
@@ -10029,7 +10671,9 @@
             "type": "string",
             "description": "Role of the message sender",
             "example": "assistant",
-            "enum": ["assistant"]
+            "enum": [
+              "assistant"
+            ]
           },
           "content": {
             "type": "array",
@@ -10049,7 +10693,13 @@
             }
           }
         },
-        "required": ["id", "threadId", "createdAt", "role", "content"]
+        "required": [
+          "id",
+          "threadId",
+          "createdAt",
+          "role",
+          "content"
+        ]
       },
       "ToolResultMessageResponseDto": {
         "type": "object",
@@ -10073,7 +10723,9 @@
             "type": "string",
             "description": "Role of the message sender",
             "example": "tool",
-            "enum": ["tool"]
+            "enum": [
+              "tool"
+            ]
           },
           "content": {
             "type": "array",
@@ -10083,7 +10735,13 @@
             }
           }
         },
-        "required": ["id", "threadId", "createdAt", "role", "content"]
+        "required": [
+          "id",
+          "threadId",
+          "createdAt",
+          "role",
+          "content"
+        ]
       },
       "TextMessageContentResponseDto": {
         "type": "object",
@@ -10092,7 +10750,13 @@
             "type": "string",
             "description": "Type of the message content",
             "example": "text",
-            "enum": ["text", "tool_use", "tool_result", "thinking", "image"]
+            "enum": [
+              "text",
+              "tool_use",
+              "tool_result",
+              "thinking",
+              "image"
+            ]
           },
           "text": {
             "type": "string",
@@ -10105,7 +10769,10 @@
             "example": false
           }
         },
-        "required": ["type", "text"]
+        "required": [
+          "type",
+          "text"
+        ]
       },
       "ToolUseIntegrationDto": {
         "type": "object",
@@ -10127,7 +10794,10 @@
             "nullable": true
           }
         },
-        "required": ["id", "name"]
+        "required": [
+          "id",
+          "name"
+        ]
       },
       "ToolUseMessageContentResponseDto": {
         "type": "object",
@@ -10136,7 +10806,13 @@
             "type": "string",
             "description": "Type of the message content",
             "example": "text",
-            "enum": ["text", "tool_use", "tool_result", "thinking", "image"]
+            "enum": [
+              "text",
+              "tool_use",
+              "tool_result",
+              "thinking",
+              "image"
+            ]
           },
           "id": {
             "type": "string",
@@ -10165,7 +10841,12 @@
             ]
           }
         },
-        "required": ["type", "id", "name", "params"]
+        "required": [
+          "type",
+          "id",
+          "name",
+          "params"
+        ]
       },
       "ToolResultMessageContentResponseDto": {
         "type": "object",
@@ -10174,7 +10855,13 @@
             "type": "string",
             "description": "Type of the message content",
             "example": "text",
-            "enum": ["text", "tool_use", "tool_result", "thinking", "image"]
+            "enum": [
+              "text",
+              "tool_use",
+              "tool_result",
+              "thinking",
+              "image"
+            ]
           },
           "toolId": {
             "type": "string",
@@ -10192,7 +10879,12 @@
             "example": "The current temperature in New York is 22°C with partly cloudy skies."
           }
         },
-        "required": ["type", "toolId", "toolName", "result"]
+        "required": [
+          "type",
+          "toolId",
+          "toolName",
+          "result"
+        ]
       },
       "ThinkingMessageContentResponseDto": {
         "type": "object",
@@ -10201,7 +10893,13 @@
             "type": "string",
             "description": "Type of the message content",
             "example": "text",
-            "enum": ["text", "tool_use", "tool_result", "thinking", "image"]
+            "enum": [
+              "text",
+              "tool_use",
+              "tool_result",
+              "thinking",
+              "image"
+            ]
           },
           "thinking": {
             "type": "string",
@@ -10209,7 +10907,10 @@
             "example": "I am thinking about the best way to help you."
           }
         },
-        "required": ["type", "thinking"]
+        "required": [
+          "type",
+          "thinking"
+        ]
       },
       "ImageMessageContentResponseDto": {
         "type": "object",
@@ -10218,7 +10919,13 @@
             "type": "string",
             "description": "Type of the message content",
             "example": "text",
-            "enum": ["text", "tool_use", "tool_result", "thinking", "image"]
+            "enum": [
+              "text",
+              "tool_use",
+              "tool_result",
+              "thinking",
+              "image"
+            ]
           },
           "imageUrl": {
             "type": "string",
@@ -10231,7 +10938,10 @@
             "example": "Screenshot of the reported issue"
           }
         },
-        "required": ["type", "imageUrl"]
+        "required": [
+          "type",
+          "imageUrl"
+        ]
       },
       "ModelResponseDto": {
         "type": "object",
@@ -10295,12 +11005,19 @@
           "type": {
             "type": "string",
             "description": "Type of source",
-            "enum": ["text", "data"]
+            "enum": [
+              "text",
+              "data"
+            ]
           },
           "createdBy": {
             "type": "string",
             "description": "Creator of the source",
-            "enum": ["user", "llm", "system"]
+            "enum": [
+              "user",
+              "llm",
+              "system"
+            ]
           },
           "createdAt": {
             "type": "string",
@@ -10339,12 +11056,19 @@
           "type": {
             "type": "string",
             "description": "Type of source",
-            "enum": ["text", "data"]
+            "enum": [
+              "text",
+              "data"
+            ]
           },
           "createdBy": {
             "type": "string",
             "description": "Creator of the source",
-            "enum": ["user", "llm", "system"]
+            "enum": [
+              "user",
+              "llm",
+              "system"
+            ]
           },
           "createdAt": {
             "type": "string",
@@ -10357,12 +11081,20 @@
           "textType": {
             "type": "string",
             "description": "Type of text",
-            "enum": ["file", "web"]
+            "enum": [
+              "file",
+              "web"
+            ]
           },
           "fileType": {
             "type": "string",
             "description": "Type of file",
-            "enum": ["pdf", "docx", "pptx", "txt"]
+            "enum": [
+              "pdf",
+              "docx",
+              "pptx",
+              "txt"
+            ]
           }
         },
         "required": [
@@ -10395,12 +11127,19 @@
           "type": {
             "type": "string",
             "description": "Type of source",
-            "enum": ["text", "data"]
+            "enum": [
+              "text",
+              "data"
+            ]
           },
           "createdBy": {
             "type": "string",
             "description": "Creator of the source",
-            "enum": ["user", "llm", "system"]
+            "enum": [
+              "user",
+              "llm",
+              "system"
+            ]
           },
           "createdAt": {
             "type": "string",
@@ -10413,7 +11152,10 @@
           "textType": {
             "type": "string",
             "description": "Type of text",
-            "enum": ["file", "web"]
+            "enum": [
+              "file",
+              "web"
+            ]
           },
           "url": {
             "type": "string",
@@ -10450,12 +11192,19 @@
           "type": {
             "type": "string",
             "description": "Type of source",
-            "enum": ["text", "data"]
+            "enum": [
+              "text",
+              "data"
+            ]
           },
           "createdBy": {
             "type": "string",
             "description": "Creator of the source",
-            "enum": ["user", "llm", "system"]
+            "enum": [
+              "user",
+              "llm",
+              "system"
+            ]
           },
           "createdAt": {
             "type": "string",
@@ -10468,7 +11217,9 @@
           "dataType": {
             "type": "string",
             "description": "Type of data",
-            "enum": ["csv"]
+            "enum": [
+              "csv"
+            ]
           },
           "data": {
             "type": "object",
@@ -10521,7 +11272,10 @@
             "example": "Municipal Zoning Guidelines"
           }
         },
-        "required": ["id", "name"]
+        "required": [
+          "id",
+          "name"
+        ]
       },
       "GetThreadResponseDto": {
         "type": "object",
@@ -10649,7 +11403,12 @@
             "example": false
           }
         },
-        "required": ["id", "createdAt", "updatedAt", "isAnonymous"]
+        "required": [
+          "id",
+          "createdAt",
+          "updatedAt",
+          "isAnonymous"
+        ]
       },
       "GetThreadsResponseDto": {
         "type": "object",
@@ -10670,7 +11429,10 @@
             ]
           }
         },
-        "required": ["data", "pagination"]
+        "required": [
+          "data",
+          "pagination"
+        ]
       },
       "UpdateThreadTitleDto": {
         "type": "object",
@@ -10683,7 +11445,9 @@
             "maxLength": 200
           }
         },
-        "required": ["title"]
+        "required": [
+          "title"
+        ]
       },
       "ToolAssignmentDto": {
         "type": "object",
@@ -10714,7 +11478,8 @@
               "knowledge_get_text",
               "create_document",
               "update_document",
-              "edit_document"
+              "edit_document",
+              "read_document"
             ]
           },
           "toolConfigId": {
@@ -10724,7 +11489,9 @@
             "format": "uuid"
           }
         },
-        "required": ["type"]
+        "required": [
+          "type"
+        ]
       },
       "CreateAgentDto": {
         "type": "object",
@@ -10755,7 +11522,12 @@
             }
           }
         },
-        "required": ["name", "instructions", "modelId", "toolAssignments"]
+        "required": [
+          "name",
+          "instructions",
+          "modelId",
+          "toolAssignments"
+        ]
       },
       "ToolResponseDto": {
         "type": "object",
@@ -10786,11 +11558,14 @@
               "knowledge_get_text",
               "create_document",
               "update_document",
-              "edit_document"
+              "edit_document",
+              "read_document"
             ]
           }
         },
-        "required": ["type"]
+        "required": [
+          "type"
+        ]
       },
       "AgentSourceResponseDto": {
         "type": "object",
@@ -10816,10 +11591,18 @@
             "type": "string",
             "description": "The type of source",
             "example": "file",
-            "enum": ["file", "url"]
+            "enum": [
+              "file",
+              "url"
+            ]
           }
         },
-        "required": ["id", "sourceId", "name", "type"]
+        "required": [
+          "id",
+          "sourceId",
+          "name",
+          "type"
+        ]
       },
       "AgentResponseDto": {
         "type": "object",
@@ -10933,7 +11716,11 @@
             "format": "uuid"
           }
         },
-        "required": ["name", "instructions", "modelId"]
+        "required": [
+          "name",
+          "instructions",
+          "modelId"
+        ]
       },
       "McpIntegrationResponseDto": {
         "type": "object",
@@ -10951,7 +11738,11 @@
           "type": {
             "type": "string",
             "description": "Type of integration",
-            "enum": ["predefined", "custom", "marketplace"],
+            "enum": [
+              "predefined",
+              "custom",
+              "marketplace"
+            ],
             "example": "predefined"
           },
           "slug": {
@@ -10977,7 +11768,12 @@
           "authMethod": {
             "type": "string",
             "description": "Authentication method used",
-            "enum": ["NO_AUTH", "BEARER_TOKEN", "CUSTOM_HEADER", "OAUTH"],
+            "enum": [
+              "NO_AUTH",
+              "BEARER_TOKEN",
+              "CUSTOM_HEADER",
+              "OAUTH"
+            ],
             "example": "BEARER_TOKEN"
           },
           "authHeaderName": {
@@ -10993,7 +11789,12 @@
           "connectionStatus": {
             "type": "string",
             "description": "Connection status of the integration",
-            "enum": ["connected", "disconnected", "error", "unknown"],
+            "enum": [
+              "connected",
+              "disconnected",
+              "error",
+              "unknown"
+            ],
             "example": "connected"
           },
           "lastConnectionError": {
@@ -11076,7 +11877,12 @@
           "entityType": {
             "type": "string",
             "description": "Type of entity being shared",
-            "enum": ["agent", "prompt", "skill", "knowledge_base"]
+            "enum": [
+              "agent",
+              "prompt",
+              "skill",
+              "knowledge_base"
+            ]
           },
           "agentId": {
             "type": "string",
@@ -11089,7 +11895,10 @@
             "format": "uuid"
           }
         },
-        "required": ["entityType", "agentId"]
+        "required": [
+          "entityType",
+          "agentId"
+        ]
       },
       "ShareResponseDto": {
         "type": "object",
@@ -11102,7 +11911,12 @@
           "entityType": {
             "type": "string",
             "description": "Type of entity being shared",
-            "enum": ["agent", "prompt", "skill", "knowledge_base"]
+            "enum": [
+              "agent",
+              "prompt",
+              "skill",
+              "knowledge_base"
+            ]
           },
           "entityId": {
             "type": "string",
@@ -11112,7 +11926,10 @@
           "scopeType": {
             "type": "string",
             "description": "Type of share scope (organization, user, or team)",
-            "enum": ["org", "team"]
+            "enum": [
+              "org",
+              "team"
+            ]
           },
           "ownerId": {
             "type": "string",
@@ -11155,7 +11972,12 @@
           "entityType": {
             "type": "string",
             "description": "Type of entity being shared",
-            "enum": ["agent", "prompt", "skill", "knowledge_base"]
+            "enum": [
+              "agent",
+              "prompt",
+              "skill",
+              "knowledge_base"
+            ]
           },
           "skillId": {
             "type": "string",
@@ -11168,7 +11990,10 @@
             "format": "uuid"
           }
         },
-        "required": ["entityType", "skillId"]
+        "required": [
+          "entityType",
+          "skillId"
+        ]
       },
       "CreateKnowledgeBaseShareDto": {
         "type": "object",
@@ -11176,7 +12001,12 @@
           "entityType": {
             "type": "string",
             "description": "Type of entity being shared",
-            "enum": ["agent", "prompt", "skill", "knowledge_base"]
+            "enum": [
+              "agent",
+              "prompt",
+              "skill",
+              "knowledge_base"
+            ]
           },
           "knowledgeBaseId": {
             "type": "string",
@@ -11189,7 +12019,10 @@
             "format": "uuid"
           }
         },
-        "required": ["entityType", "knowledgeBaseId"]
+        "required": [
+          "entityType",
+          "knowledgeBaseId"
+        ]
       },
       "ConfigValueDto": {
         "type": "object",
@@ -11197,7 +12030,11 @@
           "name": {
             "type": "string",
             "description": "The name/type of the credential field",
-            "enum": ["token", "clientId", "clientSecret"],
+            "enum": [
+              "token",
+              "clientId",
+              "clientSecret"
+            ],
             "example": "token"
           },
           "value": {
@@ -11206,7 +12043,10 @@
             "example": "sk_test_123abc"
           }
         },
-        "required": ["name", "value"]
+        "required": [
+          "name",
+          "value"
+        ]
       },
       "CreatePredefinedIntegrationDto": {
         "type": "object",
@@ -11215,7 +12055,11 @@
             "type": "string",
             "description": "The predefined integration slug",
             "example": "TEST",
-            "enum": ["TEST", "LOCABOO", "LEGAL_CODES"]
+            "enum": [
+              "TEST",
+              "LOCABOO",
+              "LEGAL_CODES"
+            ]
           },
           "configValues": {
             "description": "List of config values for credential fields",
@@ -11237,7 +12081,10 @@
             "default": true
           }
         },
-        "required": ["slug", "configValues"]
+        "required": [
+          "slug",
+          "configValues"
+        ]
       },
       "CreateCustomIntegrationDto": {
         "type": "object",
@@ -11257,7 +12104,12 @@
           "authMethod": {
             "type": "string",
             "description": "Authentication method for the MCP server",
-            "enum": ["NO_AUTH", "BEARER_TOKEN", "CUSTOM_HEADER", "OAUTH"],
+            "enum": [
+              "NO_AUTH",
+              "BEARER_TOKEN",
+              "CUSTOM_HEADER",
+              "OAUTH"
+            ],
             "example": "CUSTOM_HEADER",
             "nullable": true
           },
@@ -11278,7 +12130,10 @@
             "default": true
           }
         },
-        "required": ["name", "serverUrl"]
+        "required": [
+          "name",
+          "serverUrl"
+        ]
       },
       "CredentialFieldDto": {
         "type": "object",
@@ -11291,7 +12146,11 @@
           "type": {
             "type": "string",
             "description": "Input type (text or password)",
-            "enum": ["token", "clientId", "clientSecret"],
+            "enum": [
+              "token",
+              "clientId",
+              "clientSecret"
+            ],
             "example": "token"
           },
           "required": {
@@ -11305,7 +12164,11 @@
             "example": "Your Locaboo 3 API token will be used to authenticate with Locaboo 4"
           }
         },
-        "required": ["label", "type", "required"]
+        "required": [
+          "label",
+          "type",
+          "required"
+        ]
       },
       "PredefinedConfigResponseDto": {
         "type": "object",
@@ -11328,7 +12191,12 @@
           "authType": {
             "type": "string",
             "description": "Authentication method for this integration",
-            "enum": ["NO_AUTH", "BEARER_TOKEN", "API_KEY", "OAUTH"],
+            "enum": [
+              "NO_AUTH",
+              "BEARER_TOKEN",
+              "API_KEY",
+              "OAUTH"
+            ],
             "example": "BEARER_TOKEN"
           },
           "authHeaderName": {
@@ -11344,7 +12212,12 @@
             }
           }
         },
-        "required": ["slug", "displayName", "description", "authType"]
+        "required": [
+          "slug",
+          "displayName",
+          "description",
+          "authType"
+        ]
       },
       "UpdateMcpIntegrationDto": {
         "type": "object",
@@ -11404,7 +12277,10 @@
             "example": false
           }
         },
-        "required": ["identifier", "orgConfigValues"]
+        "required": [
+          "identifier",
+          "orgConfigValues"
+        ]
       },
       "UserConfigResponseDto": {
         "type": "object",
@@ -11425,7 +12301,10 @@
             }
           }
         },
-        "required": ["hasConfig", "configValues"]
+        "required": [
+          "hasConfig",
+          "configValues"
+        ]
       },
       "SetUserConfigDto": {
         "type": "object",
@@ -11441,7 +12320,9 @@
             }
           }
         },
-        "required": ["configValues"]
+        "required": [
+          "configValues"
+        ]
       },
       "ValidationResponseDto": {
         "type": "object",
@@ -11466,7 +12347,10 @@
             "example": "Connection timeout"
           }
         },
-        "required": ["valid", "capabilities"]
+        "required": [
+          "valid",
+          "capabilities"
+        ]
       },
       "MarketplaceSkillResponseDto": {
         "type": "object",
@@ -11554,7 +12438,11 @@
           "type": {
             "type": "string",
             "description": "Field type",
-            "enum": ["text", "url", "secret"]
+            "enum": [
+              "text",
+              "url",
+              "secret"
+            ]
           },
           "headerName": {
             "type": "string",
@@ -11581,7 +12469,12 @@
             "nullable": true
           }
         },
-        "required": ["key", "label", "type", "required"]
+        "required": [
+          "key",
+          "label",
+          "type",
+          "required"
+        ]
       },
       "MarketplaceIntegrationConfigSchemaDto": {
         "type": "object",
@@ -11605,7 +12498,11 @@
             }
           }
         },
-        "required": ["authType", "orgFields", "userFields"]
+        "required": [
+          "authType",
+          "orgFields",
+          "userFields"
+        ]
       },
       "MarketplaceIntegrationResponseDto": {
         "type": "object",
@@ -11720,7 +12617,9 @@
             "maxLength": 2000
           }
         },
-        "required": ["name"]
+        "required": [
+          "name"
+        ]
       },
       "KnowledgeBaseResponseDto": {
         "type": "object",
@@ -11759,7 +12658,13 @@
             "example": false
           }
         },
-        "required": ["id", "name", "description", "createdAt", "updatedAt"]
+        "required": [
+          "id",
+          "name",
+          "description",
+          "createdAt",
+          "updatedAt"
+        ]
       },
       "KnowledgeBaseListResponseDto": {
         "type": "object",
@@ -11772,7 +12677,9 @@
             }
           }
         },
-        "required": ["data"]
+        "required": [
+          "data"
+        ]
       },
       "UpdateKnowledgeBaseDto": {
         "type": "object",
@@ -11809,13 +12716,20 @@
           "type": {
             "type": "string",
             "description": "The type of the source",
-            "enum": ["text", "data"],
+            "enum": [
+              "text",
+              "data"
+            ],
             "example": "text"
           },
           "createdBy": {
             "type": "string",
             "description": "Who created the source",
-            "enum": ["user", "llm", "system"],
+            "enum": [
+              "user",
+              "llm",
+              "system"
+            ],
             "example": "user"
           },
           "createdAt": {
@@ -11833,7 +12747,10 @@
           "textType": {
             "type": "string",
             "description": "The text source subtype (e.g. file, web)",
-            "enum": ["file", "web"],
+            "enum": [
+              "file",
+              "web"
+            ],
             "example": "web"
           },
           "url": {
@@ -11862,7 +12779,9 @@
             }
           }
         },
-        "required": ["data"]
+        "required": [
+          "data"
+        ]
       },
       "AddUrlToKnowledgeBaseDto": {
         "type": "object",
@@ -11873,7 +12792,9 @@
             "example": "https://example.com/page"
           }
         },
-        "required": ["url"]
+        "required": [
+          "url"
+        ]
       },
       "InstallSkillFromMarketplaceDto": {
         "type": "object",
@@ -11884,7 +12805,9 @@
             "example": "meeting-summarizer"
           }
         },
-        "required": ["identifier"]
+        "required": [
+          "identifier"
+        ]
       },
       "SkillResponseDto": {
         "type": "object",
@@ -11990,7 +12913,11 @@
             "example": true
           }
         },
-        "required": ["name", "shortDescription", "instructions"]
+        "required": [
+          "name",
+          "shortDescription",
+          "instructions"
+        ]
       },
       "UpdateSkillDto": {
         "type": "object",
@@ -12013,7 +12940,11 @@
             "example": "You are a legal research assistant. When activated, search through the attached legal databases..."
           }
         },
-        "required": ["name", "shortDescription", "instructions"]
+        "required": [
+          "name",
+          "shortDescription",
+          "instructions"
+        ]
       },
       "SkillSourceResponseDto": {
         "type": "object",
@@ -12035,7 +12966,11 @@
             "example": "file"
           }
         },
-        "required": ["id", "name", "type"]
+        "required": [
+          "id",
+          "name",
+          "type"
+        ]
       },
       "CreateSkillTemplateDto": {
         "type": "object",
@@ -12060,7 +12995,10 @@
           "distributionMode": {
             "type": "string",
             "description": "The distribution mode of the skill template",
-            "enum": ["always_on", "pre_created_copy"],
+            "enum": [
+              "always_on",
+              "pre_created_copy"
+            ],
             "example": "always_on"
           },
           "isActive": {
@@ -12112,7 +13050,10 @@
           },
           "distributionMode": {
             "type": "string",
-            "enum": ["always_on", "pre_created_copy"],
+            "enum": [
+              "always_on",
+              "pre_created_copy"
+            ],
             "description": "The distribution mode of the skill template",
             "example": "always_on"
           },
@@ -12180,7 +13121,10 @@
           "distributionMode": {
             "type": "string",
             "description": "The distribution mode of the skill template",
-            "enum": ["always_on", "pre_created_copy"],
+            "enum": [
+              "always_on",
+              "pre_created_copy"
+            ],
             "example": "always_on"
           },
           "isActive": {
@@ -12222,11 +13166,19 @@
           "authorType": {
             "type": "string",
             "description": "Who authored this version",
-            "enum": ["USER", "ASSISTANT"],
+            "enum": [
+              "USER",
+              "ASSISTANT"
+            ],
             "example": "ASSISTANT"
           }
         },
-        "required": ["title", "content", "threadId", "authorType"]
+        "required": [
+          "title",
+          "content",
+          "threadId",
+          "authorType"
+        ]
       },
       "ArtifactVersionResponseDto": {
         "type": "object",
@@ -12254,7 +13206,10 @@
           "authorType": {
             "type": "string",
             "description": "Who authored this version",
-            "enum": ["USER", "ASSISTANT"],
+            "enum": [
+              "USER",
+              "ASSISTANT"
+            ],
             "example": "ASSISTANT"
           },
           "authorId": {
@@ -12345,11 +13300,17 @@
           "authorType": {
             "type": "string",
             "description": "Who authored this version",
-            "enum": ["USER", "ASSISTANT"],
+            "enum": [
+              "USER",
+              "ASSISTANT"
+            ],
             "example": "USER"
           }
         },
-        "required": ["content", "authorType"]
+        "required": [
+          "content",
+          "authorType"
+        ]
       },
       "RevertArtifactDto": {
         "type": "object",
@@ -12360,7 +13321,9 @@
             "example": 1
           }
         },
-        "required": ["versionNumber"]
+        "required": [
+          "versionNumber"
+        ]
       },
       "MessageContentResponseDto": {
         "type": "object",
@@ -12369,10 +13332,18 @@
             "type": "string",
             "description": "Type of the message content",
             "example": "text",
-            "enum": ["text", "tool_use", "tool_result", "thinking", "image"]
+            "enum": [
+              "text",
+              "tool_use",
+              "tool_result",
+              "thinking",
+              "image"
+            ]
           }
         },
-        "required": ["type"]
+        "required": [
+          "type"
+        ]
       },
       "RunSessionResponseDto": {
         "type": "object",
@@ -12381,7 +13352,9 @@
             "type": "string",
             "description": "Response type identifier",
             "example": "session",
-            "enum": ["session"]
+            "enum": [
+              "session"
+            ]
           },
           "success": {
             "type": "boolean",
@@ -12404,7 +13377,11 @@
             "example": "2024-01-01T12:00:00.000Z"
           }
         },
-        "required": ["type", "threadId", "timestamp"]
+        "required": [
+          "type",
+          "threadId",
+          "timestamp"
+        ]
       },
       "RunMessageResponseDto": {
         "type": "object",
@@ -12413,7 +13390,9 @@
             "type": "string",
             "description": "Response type identifier",
             "example": "message",
-            "enum": ["message"]
+            "enum": [
+              "message"
+            ]
           },
           "message": {
             "description": "The message data",
@@ -12443,7 +13422,12 @@
             "example": "2024-01-01T12:00:00.000Z"
           }
         },
-        "required": ["type", "message", "threadId", "timestamp"]
+        "required": [
+          "type",
+          "message",
+          "threadId",
+          "timestamp"
+        ]
       },
       "RunErrorResponseDto": {
         "type": "object",
@@ -12452,7 +13436,9 @@
             "type": "string",
             "description": "Response type identifier",
             "example": "error",
-            "enum": ["error"]
+            "enum": [
+              "error"
+            ]
           },
           "message": {
             "type": "string",
@@ -12482,7 +13468,12 @@
             }
           }
         },
-        "required": ["type", "message", "threadId", "timestamp"]
+        "required": [
+          "type",
+          "message",
+          "threadId",
+          "timestamp"
+        ]
       },
       "RunThreadResponseDto": {
         "type": "object",
@@ -12491,7 +13482,9 @@
             "type": "string",
             "description": "Response type identifier",
             "example": "thread",
-            "enum": ["thread"]
+            "enum": [
+              "thread"
+            ]
           },
           "threadId": {
             "type": "string",
@@ -12502,7 +13495,9 @@
             "type": "string",
             "description": "Type of thread update",
             "example": "title_updated",
-            "enum": ["title_updated"]
+            "enum": [
+              "title_updated"
+            ]
           },
           "title": {
             "type": "string",
@@ -12515,7 +13510,13 @@
             "example": "2024-01-01T12:00:00.000Z"
           }
         },
-        "required": ["type", "threadId", "updateType", "title", "timestamp"]
+        "required": [
+          "type",
+          "threadId",
+          "updateType",
+          "title",
+          "timestamp"
+        ]
       },
       "TextInput": {
         "type": "object",
@@ -12523,7 +13524,9 @@
           "type": {
             "type": "string",
             "description": "The type of input",
-            "enum": ["text"],
+            "enum": [
+              "text"
+            ],
             "example": "text"
           },
           "text": {
@@ -12532,7 +13535,10 @@
             "example": "What is the weather forecast for New York tomorrow?"
           }
         },
-        "required": ["type", "text"]
+        "required": [
+          "type",
+          "text"
+        ]
       },
       "ToolResultInput": {
         "type": "object",
@@ -12540,7 +13546,9 @@
           "type": {
             "type": "string",
             "description": "The type of input",
-            "enum": ["tool_result"],
+            "enum": [
+              "tool_result"
+            ],
             "example": "tool_result"
           },
           "toolId": {
@@ -12559,7 +13567,12 @@
             "example": "{\"location\":\"New York\",\"forecast\":\"Partly cloudy with a high of 75°F and a low of 60°F\",\"precipitation\":\"20%\"}"
           }
         },
-        "required": ["type", "toolId", "toolName", "result"]
+        "required": [
+          "type",
+          "toolId",
+          "toolName",
+          "result"
+        ]
       },
       "SendMessageDto": {
         "type": "object",
@@ -12606,7 +13619,9 @@
             "default": true
           }
         },
-        "required": ["threadId"]
+        "required": [
+          "threadId"
+        ]
       },
       "SuperAdminTrialResponseDto": {
         "type": "object",
@@ -12686,7 +13701,10 @@
             "minimum": 1
           }
         },
-        "required": ["orgId", "maxMessages"]
+        "required": [
+          "orgId",
+          "maxMessages"
+        ]
       },
       "UpdateTrialRequestDto": {
         "type": "object",
@@ -12714,7 +13732,9 @@
             "example": true
           }
         },
-        "required": ["isSelfHosted"]
+        "required": [
+          "isSelfHosted"
+        ]
       },
       "CreditUsageResponseDto": {
         "type": "object",
@@ -12737,7 +13757,11 @@
             "nullable": true
           }
         },
-        "required": ["monthlyCredits", "creditsUsed", "creditsRemaining"]
+        "required": [
+          "monthlyCredits",
+          "creditsUsed",
+          "creditsRemaining"
+        ]
       },
       "UserUsageDto": {
         "type": "object",
@@ -12802,7 +13826,10 @@
             ]
           }
         },
-        "required": ["data", "pagination"]
+        "required": [
+          "data",
+          "pagination"
+        ]
       },
       "UsageStatsResponseDto": {
         "type": "object",
@@ -12829,7 +13856,11 @@
           },
           "topModels": {
             "description": "List of the most frequently used model names, ordered by usage",
-            "example": ["gpt-4", "claude-3-sonnet", "gpt-3.5-turbo"],
+            "example": [
+              "gpt-4",
+              "claude-3-sonnet",
+              "gpt-3.5-turbo"
+            ],
             "type": "array",
             "items": {
               "type": "string"
@@ -12911,7 +13942,9 @@
             }
           }
         },
-        "required": ["models"]
+        "required": [
+          "models"
+        ]
       },
       "TimeSeriesPointDto": {
         "type": "object",
@@ -12930,7 +13963,11 @@
             "description": "Number of requests at this point"
           }
         },
-        "required": ["date", "tokens", "requests"]
+        "required": [
+          "date",
+          "tokens",
+          "requests"
+        ]
       },
       "ProviderUsageDto": {
         "type": "object",
@@ -12992,7 +14029,9 @@
             }
           }
         },
-        "required": ["providers"]
+        "required": [
+          "providers"
+        ]
       },
       "ProviderValuesDto": {
         "type": "object",
@@ -13040,7 +14079,10 @@
             ]
           }
         },
-        "required": ["date", "values"]
+        "required": [
+          "date",
+          "values"
+        ]
       },
       "ProviderUsageChartResponseDto": {
         "type": "object",
@@ -13053,7 +14095,9 @@
             }
           }
         },
-        "required": ["timeSeries"]
+        "required": [
+          "timeSeries"
+        ]
       },
       "GlobalUserUsageDto": {
         "type": "object",
@@ -13115,7 +14159,9 @@
             }
           }
         },
-        "required": ["data"]
+        "required": [
+          "data"
+        ]
       },
       "CreditsPerEuroResponseDto": {
         "type": "object",
@@ -13126,7 +14172,9 @@
             "example": 1000
           }
         },
-        "required": ["creditsPerEuro"]
+        "required": [
+          "creditsPerEuro"
+        ]
       },
       "SetCreditsPerEuroRequestDto": {
         "type": "object",
@@ -13137,7 +14185,9 @@
             "example": 1000
           }
         },
-        "required": ["creditsPerEuro"]
+        "required": [
+          "creditsPerEuro"
+        ]
       },
       "UserSystemPromptResponseDto": {
         "type": "object",
@@ -13149,7 +14199,9 @@
             "nullable": true
           }
         },
-        "required": ["systemPrompt"]
+        "required": [
+          "systemPrompt"
+        ]
       },
       "UpsertUserSystemPromptDto": {
         "type": "object",
@@ -13161,7 +14213,9 @@
             "maxLength": 10000
           }
         },
-        "required": ["systemPrompt"]
+        "required": [
+          "systemPrompt"
+        ]
       },
       "GeneratePersonalizedSystemPromptDto": {
         "type": "object",
@@ -13185,7 +14239,9 @@
             "maxLength": 1000
           }
         },
-        "required": ["preferredName"]
+        "required": [
+          "preferredName"
+        ]
       },
       "GeneratePersonalizedSystemPromptResponseDto": {
         "type": "object",
@@ -13201,7 +14257,10 @@
             "example": "Willkommen, Maria! Schön, dass du da bist. Wie kann ich dir heute helfen?"
           }
         },
-        "required": ["systemPrompt", "welcomeMessage"]
+        "required": [
+          "systemPrompt",
+          "welcomeMessage"
+        ]
       },
       "CreatePromptDto": {
         "type": "object",
@@ -13219,7 +14278,10 @@
             "example": "You are a helpful assistant that helps with project planning. Please provide detailed step-by-step guidance for managing projects effectively."
           }
         },
-        "required": ["title", "content"]
+        "required": [
+          "title",
+          "content"
+        ]
       },
       "PromptResponseDto": {
         "type": "object",
@@ -13284,7 +14346,10 @@
             "example": "You are an expert project planning assistant. Provide comprehensive guidance for project management, including risk assessment and timeline optimization."
           }
         },
-        "required": ["title", "content"]
+        "required": [
+          "title",
+          "content"
+        ]
       },
       "TranscriptionResponseDto": {
         "type": "object",
@@ -13295,7 +14360,9 @@
             "example": "Hello, this is a test transcription."
           }
         },
-        "required": ["text"]
+        "required": [
+          "text"
+        ]
       },
       "LoginDto": {
         "type": "object",
@@ -13311,7 +14378,10 @@
             "example": "password123"
           }
         },
-        "required": ["email", "password"]
+        "required": [
+          "email",
+          "password"
+        ]
       },
       "SuccessResponseDto": {
         "type": "object",
@@ -13322,7 +14392,9 @@
             "example": true
           }
         },
-        "required": ["success"]
+        "required": [
+          "success"
+        ]
       },
       "ErrorResponseDto": {
         "type": "object",
@@ -13333,7 +14405,9 @@
             "example": "Authentication failed"
           }
         },
-        "required": ["message"]
+        "required": [
+          "message"
+        ]
       },
       "RegisterDto": {
         "type": "object",
@@ -13388,13 +14462,19 @@
           "role": {
             "type": "string",
             "description": "User role",
-            "enum": ["admin", "user"],
+            "enum": [
+              "admin",
+              "user"
+            ],
             "example": "user"
           },
           "systemRole": {
             "type": "string",
             "description": "User system role",
-            "enum": ["customer", "super_admin"],
+            "enum": [
+              "customer",
+              "super_admin"
+            ],
             "example": "super_admin"
           },
           "name": {
@@ -13403,7 +14483,12 @@
             "example": "John Doe"
           }
         },
-        "required": ["email", "role", "systemRole", "name"]
+        "required": [
+          "email",
+          "role",
+          "systemRole",
+          "name"
+        ]
       }
     }
   }


### PR DESCRIPTION
- Add read_document tool so AI can read current artifact content and version
- Add expected_version param to update_document and edit_document tools
- Add ArtifactExpectedVersionMismatchError with version conflict check in use cases
- Include version number in all document tool results (create, update, edit, read)
- Show user-edit warning in tool descriptions when last author is USER
- Register read_document in tool factory, handler registry, and module
- Refactor tool-handler registry to use array lookup instead of instanceof chain

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces optimistic concurrency checks (`expected_version`) across document update/edit flows and adds a new `read_document` tool; mismatches now hard-fail with 409, which can break existing tool callers if they don’t supply versions or handle the new error.
> 
> **Overview**
> Prevents the assistant from overwriting user changes by adding an **optimistic version check** to artifact updates/edits: `UpdateArtifactCommand` and `ApplyEditsToArtifactCommand` accept `expectedVersionNumber`, and the corresponding use cases throw the new `ArtifactExpectedVersionMismatchError` (409) when the current version has advanced.
> 
> Updates document tools to support this workflow: `update_document` and `edit_document` now require an `expected_version` parameter, tool handlers pass it through and surface version-mismatch errors to the LLM, and tool success messages now include the resulting `version` (also added to `create_document`).
> 
> Adds a new **`read_document` tool** (entity, handler, tests, registrations) to fetch current document content + version, and enhances tool assembly to include `read_document` alongside edit tools and to annotate the document list when the current version was user-authored. Also refactors `ToolHandlerRegistry` from an `instanceof` chain to a constructor→handler lookup table.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7f3726424ad79ef3d0677e9e479ef9368a2b6007. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->