### PR TITLE
fix(AYC-000): resolve frontend lint errors and warnings

### DIFF
--- a/ayunis-core-frontend/src/pages/admin-settings/integrations-settings/ui/edit-integration-dialog.tsx
+++ b/ayunis-core-frontend/src/pages/admin-settings/integrations-settings/ui/edit-integration-dialog.tsx
@@ -45,6 +45,53 @@ function getEditableOrgFields(
   );
 }
 
+function buildMarketplacePayload(
+  payload: UpdateIntegrationFormData,
+  editableFields: MarketplaceIntegrationConfigFieldDto[],
+  configFormValues: Record<string, string>,
+  currentOrgValues: Record<string, string>,
+): void {
+  const orgConfigValues: Record<string, string> = {};
+  let hasConfigChanges = false;
+
+  for (const field of editableFields) {
+    const value = configFormValues[field.key] ?? '';
+    if (field.type === 'secret') {
+      if (value.trim()) {
+        orgConfigValues[field.key] = value;
+        hasConfigChanges = true;
+      }
+    } else {
+      orgConfigValues[field.key] = value;
+      if (value !== (currentOrgValues[field.key] ?? '')) {
+        hasConfigChanges = true;
+      }
+    }
+  }
+
+  if (hasConfigChanges) {
+    payload.orgConfigValues = orgConfigValues;
+  }
+}
+
+function buildCustomPayload(
+  payload: UpdateIntegrationFormData,
+  data: UpdateIntegrationFormData,
+  integration: McpIntegration,
+): void {
+  const trimmedCredentials = data.credentials?.trim();
+  if (trimmedCredentials) {
+    payload.credentials = trimmedCredentials;
+  }
+
+  if (integration.authMethod === 'CUSTOM_HEADER') {
+    const trimmedHeaderName = data.authHeaderName?.trim();
+    if (trimmedHeaderName && trimmedHeaderName !== integration.authHeaderName) {
+      payload.authHeaderName = trimmedHeaderName;
+    }
+  }
+}
+
 export function EditIntegrationDialog({
   integration,
   open,
@@ -111,44 +158,14 @@ export function EditIntegrationDialog({
     }
 
     if (isMarketplace) {
-      // Build orgConfigValues: include non-secret fields always, secret fields only if non-empty
-      const orgConfigValues: Record<string, string> = {};
-      let hasConfigChanges = false;
-
-      for (const field of editableFields) {
-        const value = configFormValues[field.key] ?? '';
-        if (field.type === 'secret') {
-          // Only include if the admin entered a new value
-          if (value.trim()) {
-            orgConfigValues[field.key] = value;
-            hasConfigChanges = true;
-          }
-        } else {
-          orgConfigValues[field.key] = value;
-          if (value !== (currentOrgValues[field.key] ?? '')) {
-            hasConfigChanges = true;
-          }
-        }
-      }
-
-      if (hasConfigChanges) {
-        payload.orgConfigValues = orgConfigValues;
-      }
+      buildMarketplacePayload(
+        payload,
+        editableFields,
+        configFormValues,
+        currentOrgValues,
+      );
     } else {
-      const trimmedCredentials = data.credentials?.trim();
-      if (trimmedCredentials) {
-        payload.credentials = trimmedCredentials;
-      }
-
-      if (integration.authMethod === 'CUSTOM_HEADER') {
-        const trimmedHeaderName = data.authHeaderName?.trim();
-        if (
-          trimmedHeaderName &&
-          trimmedHeaderName !== integration.authHeaderName
-        ) {
-          payload.authHeaderName = trimmedHeaderName;
-        }
-      }
+      buildCustomPayload(payload, data, integration);
     }
 
     if (Object.keys(payload).length === 0) {

--- a/ayunis-core-frontend/src/pages/admin-settings/integrations-settings/ui/integration-card.tsx
+++ b/ayunis-core-frontend/src/pages/admin-settings/integrations-settings/ui/integration-card.tsx
@@ -113,9 +113,9 @@ export function IntegrationCard({
 
 function IntegrationDescription({
   integration,
-}: {
+}: Readonly<{
   integration: McpIntegration;
-}) {
+}>) {
   if (integration.type === 'marketplace') {
     return <>{integration.marketplaceIdentifier ?? ''}</>;
   }

--- a/ayunis-core-frontend/src/pages/admin-settings/integrations-settings/ui/user-config-dialog.tsx
+++ b/ayunis-core-frontend/src/pages/admin-settings/integrations-settings/ui/user-config-dialog.tsx
@@ -17,9 +17,9 @@ import type { MarketplaceIntegrationConfigFieldDto } from '@/shared/api/generate
 import { SECRET_MASK } from '@/shared/constants/secret-mask';
 
 interface UserConfigDialogProps {
-  integration: McpIntegration | null;
-  open: boolean;
-  onOpenChange: (open: boolean) => void;
+  readonly integration: McpIntegration | null;
+  readonly open: boolean;
+  readonly onOpenChange: (open: boolean) => void;
 }
 
 export function UserConfigDialog({
@@ -54,10 +54,10 @@ export function UserConfigDialog({
 function UserConfigForm({
   integration,
   onClose,
-}: {
+}: Readonly<{
   integration: McpIntegration;
   onClose: () => void;
-}) {
+}>) {
   const { t } = useTranslation('admin-settings-integrations');
   const { userConfig, isLoadingUserConfig } = useGetUserConfig(integration.id);
   const { setUserConfig, isSaving } = useSetUserConfig(integration.id, onClose);
@@ -75,7 +75,7 @@ function UserConfigForm({
     return <UserConfigLoadingSkeleton />;
   }
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = (e: React.SyntheticEvent) => {
     e.preventDefault();
     setUserConfig(formValues);
   };

--- a/ayunis-core-frontend/src/pages/admin-settings/team-detail/ui/AddTeamMemberDialog.tsx
+++ b/ayunis-core-frontend/src/pages/admin-settings/team-detail/ui/AddTeamMemberDialog.tsx
@@ -73,7 +73,7 @@ export function AddTeamMemberDialog({
         label: `${user.name} (${user.email})`,
       })) ?? [];
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = (e: React.SyntheticEvent) => {
     e.preventDefault();
     if (selectedUser) {
       addTeamMember(selectedUser.value);

--- a/ayunis-core-frontend/src/pages/chat/ui/chat-widgets/CreateDocumentWidget.tsx
+++ b/ayunis-core-frontend/src/pages/chat/ui/chat-widgets/CreateDocumentWidget.tsx
@@ -1,14 +1,36 @@
+import type { ReactNode } from 'react';
+import type { TFunction } from 'i18next';
 import type { ToolUseMessageContent } from '../../model/openapi';
 import { useTranslation } from 'react-i18next';
 import { Check } from 'lucide-react';
 import { useThreadArtifacts } from '../../api/useThreadArtifacts';
 import { DocumentWidgetCard } from './DocumentWidgetCard';
 
+// eslint-disable-next-line sonarjs/function-return-type -- intentional: returns JSX or string, both valid ReactNode
+function getCreateStatusLabel(
+  artifactId: string | null,
+  isStreaming: boolean,
+  t: TFunction<'chat'>,
+): ReactNode {
+  if (artifactId) {
+    return (
+      <span className="flex items-center gap-1">
+        <Check className="size-3" />
+        {t('chat.tools.create_document.created')}
+      </span>
+    );
+  }
+  if (isStreaming) {
+    return t('chat.tools.create_document.generating');
+  }
+  return t('chat.tools.create_document.title');
+}
+
 interface CreateDocumentWidgetProps {
-  content: ToolUseMessageContent;
-  isStreaming?: boolean;
-  threadId: string;
-  onOpenArtifact?: (artifactId: string) => void;
+  readonly content: ToolUseMessageContent;
+  readonly isStreaming?: boolean;
+  readonly threadId: string;
+  readonly onOpenArtifact?: (artifactId: string) => void;
 }
 
 export default function CreateDocumentWidget({
@@ -19,6 +41,7 @@ export default function CreateDocumentWidget({
 }: CreateDocumentWidgetProps) {
   const { t } = useTranslation('chat');
 
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- content.params may be undefined during streaming even if typed as required
   const params = (content.params || {}) as {
     title?: string;
     content?: string;
@@ -42,22 +65,14 @@ export default function CreateDocumentWidget({
     }
   };
 
-  const statusLabel = artifactId ? (
-    <span className="flex items-center gap-1">
-      <Check className="size-3" />
-      {t('chat.tools.create_document.created')}
-    </span>
-  ) : isStreaming ? (
-    t('chat.tools.create_document.generating')
-  ) : (
-    t('chat.tools.create_document.title')
-  );
+  const statusLabel = getCreateStatusLabel(artifactId, isStreaming, t);
 
   return (
     <DocumentWidgetCard
       contentKey={content.name}
       contentId={content.id}
       isStreaming={isStreaming}
+      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- empty string during streaming should fall back to translation
       title={params.title || t('chat.tools.create_document.title')}
       statusLabel={statusLabel}
       buttonLabel={t('chat.tools.create_document.openInEditor')}

--- a/ayunis-core-frontend/src/pages/chat/ui/chat-widgets/DocumentWidgetCard.tsx
+++ b/ayunis-core-frontend/src/pages/chat/ui/chat-widgets/DocumentWidgetCard.tsx
@@ -4,14 +4,14 @@ import { FileText, ExternalLink } from 'lucide-react';
 import type { ReactNode } from 'react';
 
 interface DocumentWidgetCardProps {
-  contentKey: string;
-  contentId: string;
-  isStreaming?: boolean;
-  title: string;
-  statusLabel: ReactNode;
-  buttonLabel: string;
-  artifactId: string | null;
-  onOpen: () => void;
+  readonly contentKey: string;
+  readonly contentId: string;
+  readonly isStreaming?: boolean;
+  readonly title: string;
+  readonly statusLabel: ReactNode;
+  readonly buttonLabel: string;
+  readonly artifactId: string | null;
+  readonly onOpen: () => void;
 }
 
 export function DocumentWidgetCard({

--- a/ayunis-core-frontend/src/pages/chat/ui/chat-widgets/EditDocumentWidget.tsx
+++ b/ayunis-core-frontend/src/pages/chat/ui/chat-widgets/EditDocumentWidget.tsx
@@ -16,7 +16,8 @@ export default function EditDocumentWidget({
 }: EditDocumentWidgetProps) {
   const { t } = useTranslation('chat');
 
-  const params = content.params as {
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- content.params may be undefined during streaming even if typed as required
+  const params = (content.params || {}) as {
     artifact_id?: string;
     edits?: unknown[];
   };

--- a/ayunis-core-frontend/src/pages/chat/ui/chat-widgets/UpdateDocumentWidget.tsx
+++ b/ayunis-core-frontend/src/pages/chat/ui/chat-widgets/UpdateDocumentWidget.tsx
@@ -1,12 +1,34 @@
+import type { ReactNode } from 'react';
+import type { TFunction } from 'i18next';
 import type { ToolUseMessageContent } from '../../model/openapi';
 import { useTranslation } from 'react-i18next';
 import { Check } from 'lucide-react';
 import { DocumentWidgetCard } from './DocumentWidgetCard';
 
+// eslint-disable-next-line sonarjs/function-return-type -- intentional: returns JSX or string, both valid ReactNode
+function getUpdateStatusLabel(
+  artifactId: string,
+  isStreaming: boolean,
+  t: TFunction<'chat'>,
+): ReactNode {
+  if (!isStreaming && artifactId) {
+    return (
+      <span className="flex items-center gap-1">
+        <Check className="size-3" />
+        {t('chat.tools.update_document.updated')}
+      </span>
+    );
+  }
+  if (isStreaming) {
+    return t('chat.tools.update_document.generating');
+  }
+  return t('chat.tools.update_document.title');
+}
+
 interface UpdateDocumentWidgetProps {
-  content: ToolUseMessageContent;
-  isStreaming?: boolean;
-  onOpenArtifact?: (artifactId: string) => void;
+  readonly content: ToolUseMessageContent;
+  readonly isStreaming?: boolean;
+  readonly onOpenArtifact?: (artifactId: string) => void;
 }
 
 export default function UpdateDocumentWidget({
@@ -16,12 +38,13 @@ export default function UpdateDocumentWidget({
 }: UpdateDocumentWidgetProps) {
   const { t } = useTranslation('chat');
 
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- content.params may be undefined during streaming even if typed as required
   const params = (content.params || {}) as {
     artifact_id?: string;
     content?: string;
   };
 
-  const artifactId = params.artifact_id || '';
+  const artifactId = params.artifact_id ?? '';
 
   const handleOpen = () => {
     if (artifactId && onOpenArtifact) {
@@ -29,17 +52,7 @@ export default function UpdateDocumentWidget({
     }
   };
 
-  const statusLabel =
-    !isStreaming && artifactId ? (
-      <span className="flex items-center gap-1">
-        <Check className="size-3" />
-        {t('chat.tools.update_document.updated')}
-      </span>
-    ) : isStreaming ? (
-      t('chat.tools.update_document.generating')
-    ) : (
-      t('chat.tools.update_document.title')
-    );
+  const statusLabel = getUpdateStatusLabel(artifactId, isStreaming, t);
 
   return (
     <DocumentWidgetCard

--- a/ayunis-core-frontend/src/pages/super-admin-settings/orgs/ui/CreateOrgDialog.tsx
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/orgs/ui/CreateOrgDialog.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, type FormEvent } from 'react';
+import { useState, useCallback, type SyntheticEvent } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button } from '@/shared/ui/shadcn/button';
 import {
@@ -32,7 +32,7 @@ export default function CreateOrgDialog() {
     onSuccessCallback: handleClose,
   });
 
-  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+  const handleSubmit = (event: SyntheticEvent) => {
     event.preventDefault();
     if (!name.trim()) {
       return;

--- a/ayunis-core-frontend/src/shared/locales/de/chat.json
+++ b/ayunis-core-frontend/src/shared/locales/de/chat.json
@@ -41,6 +41,7 @@
       "activate_skill": "Fähigkeit aktivieren",
       "knowledge_query": "Wissen abrufen",
       "knowledge_get_text": "Wissen abrufen",
+      "read_document": "Dokument lesen",
       "product_knowledge": "Produktwissen durchsuchen",
       "send_email": {
         "subject": "Betreff",

--- a/ayunis-core-frontend/src/shared/locales/en/chat.json
+++ b/ayunis-core-frontend/src/shared/locales/en/chat.json
@@ -41,6 +41,7 @@
       "activate_skill": "Activate skill",
       "knowledge_query": "Search knowledge base",
       "knowledge_get_text": "Read knowledge base document",
+      "read_document": "Read document",
       "product_knowledge": "Search product knowledge",
       "send_email": {
         "subject": "Subject",

--- a/ayunis-core-frontend/src/shared/ui/config-field-input/ConfigFieldInput.tsx
+++ b/ayunis-core-frontend/src/shared/ui/config-field-input/ConfigFieldInput.tsx
@@ -4,14 +4,14 @@ import { Label } from '@/shared/ui/shadcn/label';
 import type { MarketplaceIntegrationConfigFieldDto } from '@/shared/api/generated/ayunisCoreAPI.schemas';
 
 interface ConfigFieldInputProps {
-  field: MarketplaceIntegrationConfigFieldDto;
-  value: string;
-  onChange: (value: string) => void;
-  disabled: boolean;
+  readonly field: MarketplaceIntegrationConfigFieldDto;
+  readonly value: string;
+  readonly onChange: (value: string) => void;
+  readonly disabled: boolean;
   /** Override placeholder for secret fields (e.g. "Leave blank to keep existing") */
-  secretPlaceholder?: string;
+  readonly secretPlaceholder?: string;
   /** Prefix for the input id attribute (default: "config-field") */
-  idPrefix?: string;
+  readonly idPrefix?: string;
 }
 
 export function ConfigFieldInput({

--- a/ayunis-core-frontend/src/widgets/artifact-editor/ui/EditorToolbar.tsx
+++ b/ayunis-core-frontend/src/widgets/artifact-editor/ui/EditorToolbar.tsx
@@ -20,7 +20,7 @@ import { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
 interface EditorToolbarProps {
-  editor: Editor | null;
+  readonly editor: Editor | null;
 }
 
 interface ToolbarItem {
@@ -37,12 +37,12 @@ function ToolbarButton({
   isActive,
   icon: Icon,
   title,
-}: {
+}: Readonly<{
   onClick: () => void;
   isActive: boolean;
   icon: React.ComponentType<{ className?: string }>;
   title: string;
-}) {
+}>) {
   return (
     <Button
       type="button"

--- a/ayunis-core-frontend/src/widgets/artifact-editor/ui/ExportButtons.tsx
+++ b/ayunis-core-frontend/src/widgets/artifact-editor/ui/ExportButtons.tsx
@@ -3,8 +3,8 @@ import { FileDown } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 
 interface ExportButtonsProps {
-  onExport: (format: 'docx' | 'pdf') => void;
-  isExporting?: boolean;
+  readonly onExport: (format: 'docx' | 'pdf') => void;
+  readonly isExporting?: boolean;
 }
 
 export function ExportButtons({ onExport, isExporting }: ExportButtonsProps) {

--- a/ayunis-core-frontend/src/widgets/artifact-editor/ui/VersionHistory.tsx
+++ b/ayunis-core-frontend/src/widgets/artifact-editor/ui/VersionHistory.tsx
@@ -5,9 +5,9 @@ import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 interface VersionHistoryProps {
-  versions: ArtifactVersionResponseDto[];
-  currentVersionNumber: number;
-  onRevert: (versionNumber: number) => void;
+  readonly versions: ArtifactVersionResponseDto[];
+  readonly currentVersionNumber: number;
+  readonly onRevert: (versionNumber: number) => void;
 }
 
 function formatTimestamp(iso: string): string {

--- a/ayunis-core-frontend/src/widgets/create-entity-dialog/ui/CreateEntityDialog.tsx
+++ b/ayunis-core-frontend/src/widgets/create-entity-dialog/ui/CreateEntityDialog.tsx
@@ -15,7 +15,7 @@ interface CreateEntityDialogProps {
   isOpen: boolean;
   onOpenChange: (open: boolean) => void;
   onCancel: () => void;
-  onSubmit: (e: React.FormEvent<HTMLFormElement>) => void;
+  onSubmit: (e: React.SyntheticEvent<HTMLFormElement>) => void;
   isLoading: boolean;
   translations: {
     buttonText: string;

--- a/ayunis-core-frontend/src/widgets/rename-thread-dialog/ui/RenameThreadDialog.tsx
+++ b/ayunis-core-frontend/src/widgets/rename-thread-dialog/ui/RenameThreadDialog.tsx
@@ -55,7 +55,7 @@ export function RenameThreadDialog({
     }
   }, [open, currentTitle]);
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = (e: React.SyntheticEvent) => {
     e.preventDefault();
     const trimmedTitle = title.trim();
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Primarily type/lint cleanups and small refactors; minimal behavioral change aside from safer handling of missing `content.params` during chat streaming.
> 
> **Overview**
> **Resolves frontend lint/type warnings** across multiple components by making props `Readonly`, standardizing form submit handlers to `React.SyntheticEvent`, and extracting repeated logic into small helpers.
> 
> **Improves chat widget robustness during streaming** by safely defaulting `content.params` to `{}` and refactoring create/update document status label rendering into dedicated functions.
> 
> Adds a missing chat tool translation label for `read_document` in `en` and `de` locales, and refactors integration update payload construction into `buildMarketplacePayload`/`buildCustomPayload` helpers without changing the payload rules.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3932ed9b4415ca76313c885f72153a8134292473. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->