### PR TITLE
fix(AYC-000): preserve chat scroll position when opening artifact editor

### DIFF
--- a/ayunis-core-frontend/src/layouts/chat-interface-layout/ui/ChatInterfaceLayout.tsx
+++ b/ayunis-core-frontend/src/layouts/chat-interface-layout/ui/ChatInterfaceLayout.tsx
@@ -44,19 +44,21 @@ export const ChatInterfaceLayout: React.FC<ChatInterfaceLayoutProps> = ({
     </div>
   );
 
-  if (!sidePanel) {
-    return <div className="absolute inset-0">{chatPane}</div>;
-  }
-
+  // Always render the PanelGroup so the chat pane's scroll container is never
+  // unmounted/remounted when the side panel opens or closes.
   return (
     <PanelGroup orientation="horizontal" className="absolute inset-0">
-      <Panel defaultSize={50} minSize={30}>
+      <Panel defaultSize={sidePanel ? 50 : 100} minSize={30}>
         {chatPane}
       </Panel>
-      <PanelResizeHandle className="w-1 bg-border hover:bg-primary/20 transition-colors" />
-      <Panel defaultSize={50} minSize={30}>
-        {sidePanel}
-      </Panel>
+      {sidePanel && (
+        <>
+          <PanelResizeHandle className="w-1 bg-border hover:bg-primary/20 transition-colors" />
+          <Panel defaultSize={50} minSize={30}>
+            {sidePanel}
+          </Panel>
+        </>
+      )}
     </PanelGroup>
   );
 };


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk UI layout change that keeps the chat scroll container mounted; main risk is minor layout/regression around panel sizing/resizing when the side panel appears.
> 
> **Overview**
> **Prevents chat scroll resets when toggling the artifact/side panel.** `ChatInterfaceLayout` now always renders the `react-resizable-panels` `PanelGroup` and dynamically sets the chat panel to `100%` width when no `sidePanel` is present.
> 
> The resize handle and side panel `Panel` are rendered only when `sidePanel` exists, avoiding unmount/remount of the chat pane’s scroll container when opening/closing the panel.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9684f34d363b4f373ec3a59f5dcceadca6af54a6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->