### PR TITLE
fix(AYC-000): add retry with backoff to mistral embeddings handler

### DIFF
--- a/ayunis-core-backend/src/domain/rag/embeddings/infrastructure/handler/mistral-embeddings.handler.ts
+++ b/ayunis-core-backend/src/domain/rag/embeddings/infrastructure/handler/mistral-embeddings.handler.ts
@@ -2,10 +2,12 @@ import { Injectable, Logger } from '@nestjs/common';
 import { EmbeddingsHandler } from '../../application/ports/embeddings.handler';
 import { Embedding } from '../../domain/embedding.entity';
 import { Mistral } from '@mistralai/mistralai';
+import { SDKError } from '@mistralai/mistralai/models/errors';
 import { ConfigService } from '@nestjs/config';
 import { EmbeddingModel } from '../../domain/embedding-model.entity';
 import { EmbeddingsProvider } from '../../domain/embeddings-provider.enum';
 import { NoEmbeddingsReturnedError } from '../../application/embeddings.errors';
+import retryWithBackoff from 'src/common/util/retryWithBackoff';
 
 @Injectable()
 export class MistralEmbeddingsHandler extends EmbeddingsHandler {
@@ -28,9 +30,25 @@ export class MistralEmbeddingsHandler extends EmbeddingsHandler {
       model: model.name,
       input: input.length,
     });
-    const embeddingsBatchResponse = await this.mistral.embeddings.create({
-      model: model.name,
-      inputs: input,
+    const embeddingsBatchResponse = await retryWithBackoff({
+      fn: () =>
+        this.mistral.embeddings.create({
+          model: model.name,
+          inputs: input,
+        }),
+      maxRetries: 3,
+      delay: 2000,
+      retryIfError: (error: Error) => {
+        const isTransient =
+          error instanceof SDKError && error.statusCode >= 500;
+        if (isTransient) {
+          this.logger.warn('Retrying Mistral embeddings after transient error', {
+            statusCode: (error as SDKError).statusCode,
+            message: error.message,
+          });
+        }
+        return isTransient;
+      },
     });
 
     return embeddingsBatchResponse.data.map((data) => {

--- a/ayunis-core-backend/src/domain/rag/embeddings/infrastructure/handler/mistral-embeddings.handler.ts
+++ b/ayunis-core-backend/src/domain/rag/embeddings/infrastructure/handler/mistral-embeddings.handler.ts
@@ -40,12 +40,16 @@ export class MistralEmbeddingsHandler extends EmbeddingsHandler {
       delay: 2000,
       retryIfError: (error: Error) => {
         const isTransient =
-          error instanceof SDKError && error.statusCode >= 500;
+          error instanceof SDKError &&
+          (error.statusCode >= 500 || error.statusCode === 429);
         if (isTransient) {
-          this.logger.warn('Retrying Mistral embeddings after transient error', {
-            statusCode: (error as SDKError).statusCode,
-            message: error.message,
-          });
+          this.logger.warn(
+            'Retrying Mistral embeddings after transient error',
+            {
+              statusCode: (error as SDKError).statusCode,
+              message: error.message,
+            },
+          );
         }
         return isTransient;
       },


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds retry/backoff around an external embeddings API call, which can change latency and increase request volume during outages or rate limiting. Scoped to transient `SDKError` 429/5xx responses with capped retries, so blast radius is limited.
> 
> **Overview**
> Improves resilience of Mistral embeddings generation by wrapping `mistral.embeddings.create` in `retryWithBackoff`.
> 
> Retries are limited (3 max) with exponential backoff starting at 2s and only trigger for transient `SDKError` cases (HTTP 429 or 5xx), with a warning log emitted on each retry; all other errors continue to fail fast.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a310603c390227d4dc3c7a4776e3f383fbe29079. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->