### PR TITLE
fix(AYC-000): make mistral file cleanup best-effort in file retriever

### DIFF
--- a/ayunis-core-backend/src/domain/retrievers/file-retrievers/infrastructure/adapters/mistral-file-retriever.handler.ts
+++ b/ayunis-core-backend/src/domain/retrievers/file-retrievers/infrastructure/adapters/mistral-file-retriever.handler.ts
@@ -68,9 +68,9 @@ export class MistralFileRetrieverHandler extends FileRetrieverHandler {
           `Mistral OCR signed URL retrieval failed: ${error instanceof Error ? error.message : 'Unknown error'}`,
           error instanceof Error ? error.stack : 'Unknown error',
         );
-        await this.client.files.delete({
-          fileId: uploaded_pdf.id,
-        });
+        await this.client.files
+          .delete({ fileId: uploaded_pdf.id })
+          .catch(() => undefined);
         throw error;
       });
 
@@ -92,12 +92,15 @@ export class MistralFileRetrieverHandler extends FileRetrieverHandler {
           `Mistral OCR processing failed: ${error instanceof Error ? error.message : 'Unknown error'}`,
           error instanceof Error ? error.stack : 'Unknown error',
         );
-        await this.client.files.delete({
-          fileId: uploaded_pdf.id,
-        });
+        await this.client.files
+          .delete({ fileId: uploaded_pdf.id })
+          .catch(() => undefined);
         throw error;
       });
 
+      // Best-effort cleanup — don't fail the operation if the file
+      // was already auto-deleted by Mistral (404) or is temporarily
+      // unreachable (5xx). The OCR result is already obtained.
       await retryWithBackoff({
         fn: () =>
           this.client.files.delete({
@@ -105,6 +108,11 @@ export class MistralFileRetrieverHandler extends FileRetrieverHandler {
           }),
         maxRetries: 3,
         delay: 1000,
+      }).catch((error) => {
+        this.logger.warn('Failed to delete file from Mistral (best-effort)', {
+          fileId: uploaded_pdf.id,
+          error: error instanceof Error ? error.message : 'Unknown error',
+        });
       });
 
       // Parse the response


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to error-handling and cleanup around external Mistral file deletion, reducing the chance of failing successful OCR due to transient/404 delete errors.
> 
> **Overview**
> Makes Mistral uploaded-file cleanup **best-effort** in `MistralFileRetrieverHandler`.
> 
> When signed URL retrieval or OCR processing fails, the handler now ignores errors from `client.files.delete()` so the original failure is preserved. After a successful OCR call, deletion is retried but any final delete failure is swallowed and logged as a warning, preventing successful OCR results from failing due to 404/5xx cleanup issues.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 82a463a05f5cc6027be1b651177c6573abc002f5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->