### PR TITLE
fix(AYC-000): prevent orphaned tool_use in message cleanup and context trimming

### DIFF
--- a/ayunis-core-backend/package-lock.json
+++ b/ayunis-core-backend/package-lock.json
@@ -7011,7 +7011,7 @@
       "version": "1.15.11",
       "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.15.11.tgz",
       "integrity": "sha512-iLmLTodbYxU39HhMPaMUooPwO/zqJWvsqkrXv1ZI38rMb048p6N7qtAtTp37sw9NzSrvH6oli8EdDygo09IZ/w==",
-      "devOptional": true,
+      "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -7053,6 +7053,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -7069,6 +7070,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -7085,6 +7087,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -7101,6 +7104,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -7117,6 +7121,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -7133,6 +7138,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -7149,6 +7155,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -7165,6 +7172,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -7181,6 +7189,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -7197,6 +7206,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -7210,7 +7220,7 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
       "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/@swc/jest": {
@@ -7235,7 +7245,7 @@
       "version": "0.1.25",
       "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.25.tgz",
       "integrity": "sha512-iAoY/qRhNH8a/hBvm3zKj9qQ4oc2+3w1unPJa2XvTK3XjeLXtzcCingVPw/9e5mn1+0yPqxcBGp9Jf0pkfMb1g==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@swc/counter": "^0.1.3"

--- a/ayunis-core-backend/src/domain/messages/application/use-cases/trim-messages-for-context/trim-messages-for-context.use-case.ts
+++ b/ayunis-core-backend/src/domain/messages/application/use-cases/trim-messages-for-context/trim-messages-for-context.use-case.ts
@@ -4,6 +4,8 @@ import { CountTokensCommand } from 'src/common/token-counter/application/use-cas
 import { TokenCounterType } from 'src/common/token-counter/application/ports/token-counter.handler.port';
 import { Message } from '../../../domain/message.entity';
 import { MessageRole } from '../../../domain/value-objects/message-role.object';
+import { AssistantMessage } from '../../../domain/messages/assistant-message.entity';
+import { ToolUseMessageContent } from '../../../domain/message-contents/tool-use.message-content.entity';
 import { TrimMessagesForContextCommand } from './trim-messages-for-context.command';
 import { extractTextFromMessage } from '../../utils/message-text-extractor.util';
 
@@ -50,8 +52,12 @@ export class TrimMessagesForContextUseCase {
       }
     }
 
-    // Ensure the first message is a user message
-    const trimmedMessages = this.ensureFirstMessageIsUser(selectedMessages);
+    // Ensure the first message is a user message and no tool_use is orphaned
+    const withoutOrphanedToolUse =
+      this.removeLeadingOrphanedToolPairs(selectedMessages);
+    const trimmedMessages = this.ensureFirstMessageIsUser(
+      withoutOrphanedToolUse,
+    );
 
     this.logger.log('execute completed', {
       originalCount: command.messages.length,
@@ -75,6 +81,36 @@ export class TrimMessagesForContextUseCase {
     return this.countTokensUseCase.execute(
       new CountTokensCommand(text, counterType),
     );
+  }
+
+  /**
+   * After trimming, the first messages might be orphaned tool_result or
+   * assistant(tool_use) blocks whose counterpart was trimmed away.
+   * Drop leading messages until we reach a message that doesn't depend
+   * on a missing predecessor.
+   */
+  private removeLeadingOrphanedToolPairs(messages: Message[]): Message[] {
+    let startIndex = 0;
+    while (startIndex < messages.length) {
+      const msg = messages[startIndex];
+      // A tool_result without a preceding tool_use — skip it
+      if (msg.role === MessageRole.TOOL) {
+        startIndex++;
+        continue;
+      }
+      // An assistant message with tool_use followed by no tool_result — skip it
+      if (
+        msg instanceof AssistantMessage &&
+        msg.content.some((c) => c instanceof ToolUseMessageContent) &&
+        (startIndex + 1 >= messages.length ||
+          messages[startIndex + 1].role !== MessageRole.TOOL)
+      ) {
+        startIndex++;
+        continue;
+      }
+      break;
+    }
+    return startIndex > 0 ? messages.slice(startIndex) : messages;
   }
 
   private ensureFirstMessageIsUser(messages: Message[]): Message[] {

--- a/ayunis-core-backend/src/domain/messages/application/use-cases/trim-messages-for-context/trim-messages-for-context.use-case.ts
+++ b/ayunis-core-backend/src/domain/messages/application/use-cases/trim-messages-for-context/trim-messages-for-context.use-case.ts
@@ -4,8 +4,6 @@ import { CountTokensCommand } from 'src/common/token-counter/application/use-cas
 import { TokenCounterType } from 'src/common/token-counter/application/ports/token-counter.handler.port';
 import { Message } from '../../../domain/message.entity';
 import { MessageRole } from '../../../domain/value-objects/message-role.object';
-import { AssistantMessage } from '../../../domain/messages/assistant-message.entity';
-import { ToolUseMessageContent } from '../../../domain/message-contents/tool-use.message-content.entity';
 import { TrimMessagesForContextCommand } from './trim-messages-for-context.command';
 import { extractTextFromMessage } from '../../utils/message-text-extractor.util';
 
@@ -52,12 +50,8 @@ export class TrimMessagesForContextUseCase {
       }
     }
 
-    // Ensure the first message is a user message and no tool_use is orphaned
-    const withoutOrphanedToolUse =
-      this.removeLeadingOrphanedToolPairs(selectedMessages);
-    const trimmedMessages = this.ensureFirstMessageIsUser(
-      withoutOrphanedToolUse,
-    );
+    // Ensure the first message is a user message
+    const trimmedMessages = this.ensureFirstMessageIsUser(selectedMessages);
 
     this.logger.log('execute completed', {
       originalCount: command.messages.length,
@@ -81,36 +75,6 @@ export class TrimMessagesForContextUseCase {
     return this.countTokensUseCase.execute(
       new CountTokensCommand(text, counterType),
     );
-  }
-
-  /**
-   * After trimming, the first messages might be orphaned tool_result or
-   * assistant(tool_use) blocks whose counterpart was trimmed away.
-   * Drop leading messages until we reach a message that doesn't depend
-   * on a missing predecessor.
-   */
-  private removeLeadingOrphanedToolPairs(messages: Message[]): Message[] {
-    let startIndex = 0;
-    while (startIndex < messages.length) {
-      const msg = messages[startIndex];
-      // A tool_result without a preceding tool_use — skip it
-      if (msg.role === MessageRole.TOOL) {
-        startIndex++;
-        continue;
-      }
-      // An assistant message with tool_use followed by no tool_result — skip it
-      if (
-        msg instanceof AssistantMessage &&
-        msg.content.some((c) => c instanceof ToolUseMessageContent) &&
-        (startIndex + 1 >= messages.length ||
-          messages[startIndex + 1].role !== MessageRole.TOOL)
-      ) {
-        startIndex++;
-        continue;
-      }
-      break;
-    }
-    return startIndex > 0 ? messages.slice(startIndex) : messages;
   }
 
   private ensureFirstMessageIsUser(messages: Message[]): Message[] {

--- a/ayunis-core-backend/src/domain/runs/SUMMARY.md
+++ b/ayunis-core-backend/src/domain/runs/SUMMARY.md
@@ -12,7 +12,7 @@ The runs module is the central orchestrator for AI conversation execution. The `
 - **StreamingInferenceService** — Executes streaming inference, accumulates response chunks into partial `AssistantMessage` updates, and persists the final result. Handles usage collection from streaming chunks.
 - **CollectUsageAsyncService** — Collects usage data asynchronously (fire-and-forget). Errors are logged but don't block the main flow.
 - **CreditBudgetGuardService** — Orchestrates a pre-run credit-budget check by combining `GetMonthlyCreditLimitUseCase` (from subscriptions) and `GetMonthlyCreditUsageUseCase` (from usage). Throws `CreditBudgetExceededError` when the organization's monthly credit limit is reached. Lives in the runs module because it is the run execution flow that needs this cross-domain decision.
-- **MessageCleanupService** — Ensures threads end with an assistant message after a run completes or is interrupted by deleting trailing non-assistant messages.
+- **MessageCleanupService** — Ensures threads end with a valid assistant message after a run completes or is interrupted by deleting trailing non-assistant messages and assistant messages with orphaned `tool_use` content (tool calls without corresponding tool results).
 - **SystemPromptBuilderService** — Builds system prompts from agent configuration, thread context, and active skills. Accepts `SkillEntry[]` (slug + description) instead of `Skill[]` — the slug is used as the skill name in the prompt.
 
 ### Helpers

--- a/ayunis-core-backend/src/domain/runs/application/services/message-cleanup.service.ts
+++ b/ayunis-core-backend/src/domain/runs/application/services/message-cleanup.service.ts
@@ -84,10 +84,26 @@ export class MessageCleanupService {
     const messagesAfterAssistant = threadMessages.slice(savedMessageIndex + 1);
 
     if (messagesAfterAssistant.length === 0) {
-      this.logger.debug('Thread correctly ends with assistant message', {
-        threadId,
-        lastMessageId: savedMessageId,
-      });
+      // Even when no trailing messages exist, the saved assistant message
+      // may contain tool_use content without a corresponding tool_result
+      // (e.g., run interrupted after saving tool_use but before tool execution).
+      // This orphaned tool_use must be cleaned up.
+      if (this.hasToolUseContent(savedMessage)) {
+        this.logger.log(
+          'Saved assistant message has orphaned tool_use (no trailing messages), deleting',
+          { threadId, assistantMessageId: savedMessageId },
+        );
+        const remaining = threadMessages.slice(0, savedMessageIndex);
+        await this.deleteMessagesUntilAssistant(threadId, [
+          ...remaining,
+          savedMessage,
+        ]);
+      } else {
+        this.logger.debug('Thread correctly ends with assistant message', {
+          threadId,
+          lastMessageId: savedMessageId,
+        });
+      }
     } else {
       this.logger.log(
         'Found messages after saved assistant message, cleaning up',

--- a/ayunis-core-backend/src/domain/runs/application/services/message-cleanup.service.ts
+++ b/ayunis-core-backend/src/domain/runs/application/services/message-cleanup.service.ts
@@ -2,6 +2,8 @@ import { Injectable, Logger } from '@nestjs/common';
 import { UUID } from 'crypto';
 import { Message } from 'src/domain/messages/domain/message.entity';
 import { MessageRole } from 'src/domain/messages/domain/value-objects/message-role.object';
+import { AssistantMessage } from 'src/domain/messages/domain/messages/assistant-message.entity';
+import { ToolUseMessageContent } from 'src/domain/messages/domain/message-contents/tool-use.message-content.entity';
 import { DeleteMessageUseCase } from 'src/domain/messages/application/use-cases/delete-message/delete-message.use-case';
 import { DeleteMessageCommand } from 'src/domain/messages/application/use-cases/delete-message/delete-message.command';
 import { FindThreadUseCase } from 'src/domain/threads/application/use-cases/find-thread/find-thread.use-case';
@@ -78,6 +80,7 @@ export class MessageCleanupService {
       return;
     }
 
+    const savedMessage = threadMessages[savedMessageIndex];
     const messagesAfterAssistant = threadMessages.slice(savedMessageIndex + 1);
 
     if (messagesAfterAssistant.length === 0) {
@@ -95,11 +98,31 @@ export class MessageCleanupService {
         },
       );
       await this.deleteTrailingMessages(threadId, messagesAfterAssistant);
+
+      // If the saved assistant message contains tool_use content, its
+      // tool_results were just deleted — leaving it would corrupt the
+      // conversation (tool_use without tool_result). Delete it too and
+      // continue cleanup from there.
+      if (this.hasToolUseContent(savedMessage)) {
+        this.logger.log(
+          'Saved assistant message has orphaned tool_use, deleting',
+          { threadId, assistantMessageId: savedMessageId },
+        );
+        const remaining = threadMessages.slice(0, savedMessageIndex);
+        await this.deleteMessagesUntilAssistant(threadId, [
+          ...remaining,
+          savedMessage,
+        ]);
+      }
     }
   }
 
   /**
-   * Deletes messages from the end of the thread until an assistant message is found.
+   * Deletes messages from the end of the thread until a "clean" assistant
+   * message is found — one that does NOT contain tool_use content.
+   * An assistant message with tool_use but no corresponding tool_result
+   * would leave the conversation in an invalid state for providers like
+   * Anthropic that require tool_use → tool_result pairing.
    */
   async deleteMessagesUntilAssistant(
     threadId: UUID,
@@ -110,13 +133,23 @@ export class MessageCleanupService {
       const messagesToDelete: Message[] = [];
       for (let i = threadMessages.length - 1; i >= 0; i--) {
         const message = threadMessages[i];
-        if (message.role === MessageRole.ASSISTANT) {
+        if (
+          message.role === MessageRole.ASSISTANT &&
+          !this.hasToolUseContent(message)
+        ) {
           break;
         }
         messagesToDelete.push(message);
       }
       await this.deleteTrailingMessages(threadId, messagesToDelete);
     }
+  }
+
+  private hasToolUseContent(message: Message): boolean {
+    return (
+      message instanceof AssistantMessage &&
+      message.content.some((c) => c instanceof ToolUseMessageContent)
+    );
   }
 
   async deleteTrailingMessages(

--- a/ayunis-core-backend/src/domain/runs/application/services/message-cleanup.service.ts
+++ b/ayunis-core-backend/src/domain/runs/application/services/message-cleanup.service.ts
@@ -129,7 +129,10 @@ export class MessageCleanupService {
     threadMessages: Message[],
   ): Promise<void> {
     const lastMessage = threadMessages[threadMessages.length - 1];
-    if (lastMessage.role !== MessageRole.ASSISTANT) {
+    if (
+      lastMessage.role !== MessageRole.ASSISTANT ||
+      this.hasToolUseContent(lastMessage)
+    ) {
       const messagesToDelete: Message[] = [];
       for (let i = threadMessages.length - 1; i >= 0; i--) {
         const message = threadMessages[i];

--- a/ayunis-core-backend/src/domain/runs/application/services/message-cleanup.service.ts
+++ b/ayunis-core-backend/src/domain/runs/application/services/message-cleanup.service.ts
@@ -83,28 +83,8 @@ export class MessageCleanupService {
     const savedMessage = threadMessages[savedMessageIndex];
     const messagesAfterAssistant = threadMessages.slice(savedMessageIndex + 1);
 
-    if (messagesAfterAssistant.length === 0) {
-      // Even when no trailing messages exist, the saved assistant message
-      // may contain tool_use content without a corresponding tool_result
-      // (e.g., run interrupted after saving tool_use but before tool execution).
-      // This orphaned tool_use must be cleaned up.
-      if (this.hasToolUseContent(savedMessage)) {
-        this.logger.log(
-          'Saved assistant message has orphaned tool_use (no trailing messages), deleting',
-          { threadId, assistantMessageId: savedMessageId },
-        );
-        const remaining = threadMessages.slice(0, savedMessageIndex);
-        await this.deleteMessagesUntilAssistant(threadId, [
-          ...remaining,
-          savedMessage,
-        ]);
-      } else {
-        this.logger.debug('Thread correctly ends with assistant message', {
-          threadId,
-          lastMessageId: savedMessageId,
-        });
-      }
-    } else {
+    // First, delete any trailing messages after the saved assistant message
+    if (messagesAfterAssistant.length > 0) {
       this.logger.log(
         'Found messages after saved assistant message, cleaning up',
         {
@@ -114,22 +94,29 @@ export class MessageCleanupService {
         },
       );
       await this.deleteTrailingMessages(threadId, messagesAfterAssistant);
+    }
 
-      // If the saved assistant message contains tool_use content, its
-      // tool_results were just deleted — leaving it would corrupt the
-      // conversation (tool_use without tool_result). Delete it too and
-      // continue cleanup from there.
-      if (this.hasToolUseContent(savedMessage)) {
-        this.logger.log(
-          'Saved assistant message has orphaned tool_use, deleting',
-          { threadId, assistantMessageId: savedMessageId },
-        );
-        const remaining = threadMessages.slice(0, savedMessageIndex);
-        await this.deleteMessagesUntilAssistant(threadId, [
-          ...remaining,
-          savedMessage,
-        ]);
-      }
+    // Check if the saved assistant message has orphaned tool_use content.
+    // This can happen when:
+    // - There were no trailing messages but the run was interrupted after
+    //   saving tool_use but before tool execution
+    // - Trailing messages (including tool_results) were just deleted above
+    // In either case, tool_use without tool_result corrupts the conversation.
+    if (this.hasToolUseContent(savedMessage)) {
+      this.logger.log(
+        'Saved assistant message has orphaned tool_use, deleting',
+        { threadId, assistantMessageId: savedMessageId },
+      );
+      const remaining = threadMessages.slice(0, savedMessageIndex);
+      await this.deleteMessagesUntilAssistant(threadId, [
+        ...remaining,
+        savedMessage,
+      ]);
+    } else if (messagesAfterAssistant.length === 0) {
+      this.logger.debug('Thread correctly ends with assistant message', {
+        threadId,
+        lastMessageId: savedMessageId,
+      });
     }
   }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes message cleanup deletion criteria and may remove additional assistant messages if tool calls are present, which could impact conversation history if detection is wrong. Also adjusts `package-lock.json` metadata for `@swc/*` dev dependencies, with low runtime risk but potential install/CI differences.
> 
> **Overview**
> Prevents conversations from ending in an invalid state by extending `MessageCleanupService` to treat assistant messages containing `tool_use` as *not safe terminal messages* and deleting them (and any trailing messages) until a clean assistant message remains.
> 
> Updates runs module docs to reflect the new cleanup behavior, and tweaks `package-lock.json` so `@swc/core` and platform-specific `@swc/*` packages are marked as `dev` dependencies instead of `devOptional`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bec48935c23494453e8d76b8ec9e288645e3a7b7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->