### PR TITLE
feat(admin-settings): add hint about team-specific model restrictions on models page

### DIFF
--- a/ayunis-core-frontend/src/pages/admin-settings/model-settings/ui/ModelSettingsPage.tsx
+++ b/ayunis-core-frontend/src/pages/admin-settings/model-settings/ui/ModelSettingsPage.tsx
@@ -1,9 +1,12 @@
 import { Card, CardContent } from '@/shared/ui/shadcn/card';
+import { Alert, AlertTitle, AlertDescription } from '@/shared/ui/shadcn/alert';
+import { Info } from 'lucide-react';
+import { Link } from '@tanstack/react-router';
 import ModelTypeCard from './ModelTypeCard';
 import { OrgDefaultModelCard } from './OrgDefaultModelCard';
 import SettingsLayout from '../../admin-settings-layout';
 import { HelpLink } from '@/shared/ui/help-link/HelpLink';
-import { useTranslation } from 'react-i18next';
+import { Trans, useTranslation } from 'react-i18next';
 import { useModelsWithConfig } from '../api';
 
 export default function ModelSettingsPage() {
@@ -23,6 +26,24 @@ export default function ModelSettingsPage() {
       title={tLayout('layout.models')}
     >
       <div className="space-y-4">
+        <Alert>
+          <Info className="h-4 w-4" />
+          <AlertTitle>{t('models.teamHint.title')}</AlertTitle>
+          <AlertDescription>
+            <Trans
+              i18nKey="models.teamHint.description"
+              ns="admin-settings-models"
+              components={{
+                teamsLink: (
+                  <Link
+                    to="/admin-settings/teams"
+                    className="font-medium underline underline-offset-4 hover:text-primary"
+                  />
+                ),
+              }}
+            />
+          </AlertDescription>
+        </Alert>
         <OrgDefaultModelCard
           models={languageModels}
           isLoading={modelsLoading}

--- a/ayunis-core-frontend/src/shared/locales/de/admin-settings-models.json
+++ b/ayunis-core-frontend/src/shared/locales/de/admin-settings-models.json
@@ -1,5 +1,9 @@
 {
   "models": {
+    "teamHint": {
+      "title": "Team-spezifische Modellbeschränkungen",
+      "description": "Sie können einschränken, welche Modelle für bestimmte Teams verfügbar sind, in den <teamsLink>Team-Einstellungen</teamsLink>."
+    },
     "loading": "Modelle werden geladen...",
     "noModelsAvailable": "Keine Modelle verfügbar. Bitte überprüfen Sie Ihre Konfiguration.",
     "noModelsForProvider": "Keine Modelle für diesen Provider verfügbar.",

--- a/ayunis-core-frontend/src/shared/locales/de/admin-settings-models.json
+++ b/ayunis-core-frontend/src/shared/locales/de/admin-settings-models.json
@@ -2,7 +2,7 @@
   "models": {
     "teamHint": {
       "title": "Team-spezifische Modellbeschränkungen",
-      "description": "Sie können einschränken, welche Modelle für bestimmte Teams verfügbar sind, in den <teamsLink>Team-Einstellungen</teamsLink>."
+      "description": "Sie können in den <teamsLink>Team-Einstellungen</teamsLink> einschränken, welche Modelle für bestimmte Teams verfügbar sind."
     },
     "loading": "Modelle werden geladen...",
     "noModelsAvailable": "Keine Modelle verfügbar. Bitte überprüfen Sie Ihre Konfiguration.",

--- a/ayunis-core-frontend/src/shared/locales/en/admin-settings-models.json
+++ b/ayunis-core-frontend/src/shared/locales/en/admin-settings-models.json
@@ -1,5 +1,9 @@
 {
   "models": {
+    "teamHint": {
+      "title": "Team-specific model restrictions",
+      "description": "You can restrict which models are available to specific teams in the <teamsLink>Teams settings</teamsLink>."
+    },
     "loading": "Loading models...",
     "noModelsAvailable": "No models available. Please check your configuration.",
     "noModelsForProvider": "No models available for this provider.",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Added a static hint/info alert on the `/admin-settings/models` page to inform admins that they can restrict model selection for specific teams on the teams settings page.

## Changes

- **`ModelSettingsPage.tsx`**: Added an `Alert` component at the top of the page with an info icon, title, and description that includes a link to the teams settings page
- **English translations** (`admin-settings-models.json`): Added `teamHint.title` and `teamHint.description` translations
- **German translations** (`admin-settings-models.json`): Added `teamHint.title` and `teamHint.description` translations

## Screenshot

The hint appears at the top of the models settings page and looks like:

```
┌────────────────────────────────────────────────────────────┐
│ ℹ️ Team-specific model restrictions                        │
│   You can restrict which models are available to specific  │
│   teams in the Teams settings.                             │
└────────────────────────────────────────────────────────────┘
```

The "Teams settings" text is a clickable link that navigates to `/admin-settings/teams`.

## Testing

- TypeScript compiles successfully
- No lint errors in the modified files
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://locaboo.slack.com/archives/C0375HX2C4S/p1773766946052609?thread_ts=1773766946.052609&cid=C0375HX2C4S)

<div><a href="https://cursor.com/agents/bc-ab32545d-f1e7-54f9-afce-e5bb0c2cc4f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ab32545d-f1e7-54f9-afce-e5bb0c2cc4f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

