### PR TITLE
fix(AYC-000): return 422 for url retrieval failures instead of 500

### DIFF
--- a/ayunis-core-backend/src/domain/retrievers/url-retrievers/application/url-retriever.errors.ts
+++ b/ayunis-core-backend/src/domain/retrievers/url-retrievers/application/url-retriever.errors.ts
@@ -67,7 +67,7 @@ export abstract class UrlRetrieverError extends ApplicationError {
 
 export class UrlRetrieverRetrievalError extends UrlRetrieverError {
   constructor(message: string, metadata?: ErrorMetadata) {
-    super(message, UrlRetrieverErrorCode.RETRIEVAL_FAILED, 500, metadata);
+    super(message, UrlRetrieverErrorCode.RETRIEVAL_FAILED, 422, metadata);
     this.name = 'UrlRetrieverRetrievalError';
   }
 }
@@ -101,7 +101,7 @@ export class UrlRetrieverHttpError extends UrlRetrieverError {
     super(
       `HTTP error when retrieving '${url}': ${statusCode}`,
       UrlRetrieverErrorCode.HTTP_ERROR,
-      500,
+      422,
       metadata,
     );
     this.name = 'UrlRetrieverHttpError';
@@ -113,7 +113,7 @@ export class UrlRetrieverParsingError extends UrlRetrieverError {
     super(
       `Failed to parse content from '${url}': ${message}`,
       UrlRetrieverErrorCode.PARSING_ERROR,
-      500,
+      422,
       metadata,
     );
     this.name = 'UrlRetrieverParsingError';

--- a/ayunis-core-frontend/src/pages/knowledge-base/api/useAddUrl.ts
+++ b/ayunis-core-frontend/src/pages/knowledge-base/api/useAddUrl.ts
@@ -25,6 +25,8 @@ export function useAddUrl(knowledgeBaseId: string) {
           const errorData = extractErrorData(error);
           if (errorData.code === 'UNSUPPORTED_CONTENT_TYPE') {
             showError(t('detail.documents.addUrlUnsupportedContentType'));
+          } else if (errorData.code === 'RETRIEVAL_FAILED') {
+            showError(t('detail.documents.addUrlRetrievalFailed'));
           } else {
             showError(t('detail.documents.addUrlError'));
           }

--- a/ayunis-core-frontend/src/shared/locales/de/knowledge-bases.json
+++ b/ayunis-core-frontend/src/shared/locales/de/knowledge-bases.json
@@ -150,6 +150,7 @@
       "urlLabel": "Website-URL",
       "addUrlSuccess": "URL erfolgreich hinzugefügt! Der Website-Inhalt wird verarbeitet.",
       "addUrlError": "URL konnte nicht hinzugefügt werden. Bitte überprüfen Sie die URL und versuchen Sie es erneut.",
+      "addUrlRetrievalFailed": "Die Website konnte nicht erreicht werden. Bitte überprüfen Sie, ob die URL korrekt ist und die Website erreichbar ist.",
       "addUrlUnsupportedContentType": "Diese URL verweist auf eine Datei (z. B. PDF) statt auf eine Website. Bitte laden Sie die Datei herunter und laden Sie sie direkt hoch.",
       "removeSuccess": "Dokument erfolgreich entfernt!",
       "removeError": "Dokument konnte nicht entfernt werden. Bitte versuchen Sie es erneut.",

--- a/ayunis-core-frontend/src/shared/locales/en/knowledge-bases.json
+++ b/ayunis-core-frontend/src/shared/locales/en/knowledge-bases.json
@@ -150,6 +150,7 @@
       "urlLabel": "Website URL",
       "addUrlSuccess": "URL added successfully! The website content is being processed.",
       "addUrlError": "Failed to add URL. Please check the URL and try again.",
+      "addUrlRetrievalFailed": "The website could not be reached. Please check that the URL is correct and the website is accessible.",
       "addUrlUnsupportedContentType": "This URL points to a file (e.g. PDF) instead of a website. Please download the file and upload it directly.",
       "removeSuccess": "Document removed successfully!",
       "removeError": "Failed to remove document. Please try again.",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: this only changes HTTP status codes for URL retrieval failures and adds corresponding frontend messaging; main risk is unintended client/monitoring reliance on the previous 500 responses.
> 
> **Overview**
> **URL import failures are now treated as client-processable errors instead of server errors.** The backend changes `UrlRetrieverRetrievalError`, `UrlRetrieverHttpError`, and `UrlRetrieverParsingError` to return `422 Unprocessable Entity` (instead of `500`), mapping them through `UnprocessableEntityException`.
> 
> On the frontend, the knowledge base “Add URL” flow adds a dedicated toast for `RETRIEVAL_FAILED` and introduces new `en`/`de` i18n strings for the message.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4e54da592ea0af7373a126fa947812ee59c99b3f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->