### PR TITLE
fix(AYC-000): add SSE heartbeat to prevent stream disconnects during long LLM pauses

### DIFF
--- a/ayunis-core-backend/src/domain/runs/presenters/http/runs.controller.ts
+++ b/ayunis-core-backend/src/domain/runs/presenters/http/runs.controller.ts
@@ -397,6 +397,17 @@ export class RunsController {
       // Listen for client disconnect
       params.response.on('close', disconnectHandler);
 
+      // Send periodic heartbeat comments to keep the connection alive
+      // through proxies (e.g. nginx proxy_read_timeout) and prevent
+      // the browser from treating the connection as dead during long
+      // pauses in the LLM stream (tool call generation, thinking, etc.).
+      // SSE comments (lines starting with ':') are ignored by clients.
+      const heartbeatInterval = setInterval(() => {
+        if (!connection.disconnected) {
+          params.response.write(': heartbeat\n\n');
+        }
+      }, 15_000);
+
       try {
         for await (const event of eventGenerator) {
           // Check if client disconnected before writing
@@ -430,6 +441,7 @@ export class RunsController {
           this.writeSSEEvent(params.response, eventId, responseDto);
         }
       } finally {
+        clearInterval(heartbeatInterval);
         // Clean up disconnect listener
         params.response.off('close', disconnectHandler);
       }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: adds a periodic SSE comment heartbeat and cleans it up on stream termination, with minimal impact on run execution logic beyond extra writes/timer management.
> 
> **Overview**
> Adds a 15s SSE *heartbeat comment* in `RunsController.executeRunAndStream` to keep long-running `text/event-stream` connections alive during LLM pauses and proxy timeouts.
> 
> Ensures the timer is cleared and the disconnect listener is removed in the `finally` cleanup path to avoid leaking intervals after the stream completes or the client disconnects.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6be1439e80b5b07c91d081512576b4bed52a0072. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->