### PR TITLE
feat(AYC-77): show usage tab for usage-based subscriptions instead of non-cloud only

### DIFF
--- a/ayunis-core-backend/src/iam/authorization/application/guards/subscription.guard.ts
+++ b/ayunis-core-backend/src/iam/authorization/application/guards/subscription.guard.ts
@@ -48,6 +48,7 @@ export class SubscriptionGuard implements CanActivate {
       .getRequest<RequestWithSubscriptionContext>();
     const user = request.user;
 
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- defensive guard for runtime safety
     if (!user) {
       this.logger.warn('User not found in request context');
       return false;
@@ -59,7 +60,7 @@ export class SubscriptionGuard implements CanActivate {
     });
 
     try {
-      const hasActiveSubscription =
+      const { hasActiveSubscription } =
         await this.hasActiveSubscriptionUseCase.execute(
           new HasActiveSubscriptionQuery(user.orgId),
         );
@@ -87,6 +88,7 @@ export class SubscriptionGuard implements CanActivate {
         new GetTrialQuery(user.orgId),
       );
 
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- defensive guard for runtime safety
       if (!trial) {
         this.logger.warn('Access denied: no trial found', {
           orgId: user.orgId,

--- a/ayunis-core-backend/src/iam/subscriptions/application/use-cases/create-subscription/create-subscription.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/subscriptions/application/use-cases/create-subscription/create-subscription.use-case.spec.ts
@@ -110,7 +110,10 @@ describe('CreateSubscriptionUseCase', () => {
   }
 
   function mockNoActiveSubscription(): void {
-    hasActiveSubscriptionUseCase.execute.mockResolvedValue(false);
+    hasActiveSubscriptionUseCase.execute.mockResolvedValue({
+      hasActiveSubscription: false,
+      subscriptionType: null,
+    });
   }
 
   function mockInvitesAndUsers(openInvites: number, userCount: number): void {
@@ -270,7 +273,10 @@ describe('CreateSubscriptionUseCase', () => {
   describe('common validation', () => {
     it('should reject creation when subscription already exists', async () => {
       setupSuperAdminContext();
-      hasActiveSubscriptionUseCase.execute.mockResolvedValue(true);
+      hasActiveSubscriptionUseCase.execute.mockResolvedValue({
+        hasActiveSubscription: true,
+        subscriptionType: SubscriptionType.SEAT_BASED,
+      });
 
       const command = new CreateSubscriptionCommand({
         orgId,

--- a/ayunis-core-backend/src/iam/subscriptions/application/use-cases/create-subscription/create-subscription.use-case.ts
+++ b/ayunis-core-backend/src/iam/subscriptions/application/use-cases/create-subscription/create-subscription.use-case.ts
@@ -95,7 +95,7 @@ export class CreateSubscriptionUseCase {
   private async ensureNoActiveSubscription(
     orgId: Subscription['orgId'],
   ): Promise<void> {
-    const hasActiveSubscription =
+    const { hasActiveSubscription } =
       await this.hasActiveSubscriptionUseCase.execute(
         new HasActiveSubscriptionQuery(orgId),
       );

--- a/ayunis-core-backend/src/iam/subscriptions/application/use-cases/has-active-subscription/has-active-subscription.result.ts
+++ b/ayunis-core-backend/src/iam/subscriptions/application/use-cases/has-active-subscription/has-active-subscription.result.ts
@@ -1,0 +1,6 @@
+import type { SubscriptionType } from 'src/iam/subscriptions/domain/value-objects/subscription-type.enum';
+
+export interface HasActiveSubscriptionResult {
+  hasActiveSubscription: boolean;
+  subscriptionType: SubscriptionType | null;
+}

--- a/ayunis-core-backend/src/iam/subscriptions/application/use-cases/has-active-subscription/has-active-subscription.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/subscriptions/application/use-cases/has-active-subscription/has-active-subscription.use-case.spec.ts
@@ -60,7 +60,7 @@ describe('HasActiveSubscriptionUseCase', () => {
   });
 
   describe('execute', () => {
-    it('should return true for self-hosted instances', async () => {
+    it('should return true with null type for self-hosted instances', async () => {
       // Arrange
       const query = new HasActiveSubscriptionQuery(mockOrgId);
       configService.get.mockReturnValue(true);
@@ -69,7 +69,10 @@ describe('HasActiveSubscriptionUseCase', () => {
       const result = await useCase.execute(query);
 
       // Assert
-      expect(result).toBe(true);
+      expect(result).toEqual({
+        hasActiveSubscription: true,
+        subscriptionType: null,
+      });
       expect(configService.get).toHaveBeenCalledWith('app.isSelfHosted');
       expect(subscriptionRepository.findByOrgId).not.toHaveBeenCalled();
     });
@@ -84,20 +87,23 @@ describe('HasActiveSubscriptionUseCase', () => {
       const result = await useCase.execute(query);
 
       // Assert
-      expect(result).toBe(false);
+      expect(result).toEqual({
+        hasActiveSubscription: false,
+        subscriptionType: null,
+      });
       expect(subscriptionRepository.findByOrgId).toHaveBeenCalledWith(
         mockOrgId,
       );
     });
 
-    it('should return true when at least one active subscription exists', async () => {
+    it('should return true with subscription type when active subscription exists', async () => {
       // Arrange
       const query = new HasActiveSubscriptionQuery(mockOrgId);
       configService.get.mockReturnValue(false);
 
       const mockSubscriptions = [
-        { id: '1', orgId: mockOrgId } as any,
-        { id: '2', orgId: mockOrgId } as any,
+        { id: '1', orgId: mockOrgId, type: 'USAGE_BASED' } as any,
+        { id: '2', orgId: mockOrgId, type: 'SEAT_BASED' } as any,
       ];
 
       subscriptionRepository.findByOrgId.mockResolvedValue(
@@ -109,7 +115,10 @@ describe('HasActiveSubscriptionUseCase', () => {
       const result = await useCase.execute(query);
 
       // Assert
-      expect(result).toBe(true);
+      expect(result).toEqual({
+        hasActiveSubscription: true,
+        subscriptionType: 'USAGE_BASED',
+      });
       expect(subscriptionRepository.findByOrgId).toHaveBeenCalledWith(
         mockOrgId,
       );
@@ -135,7 +144,10 @@ describe('HasActiveSubscriptionUseCase', () => {
       const result = await useCase.execute(query);
 
       // Assert
-      expect(result).toBe(false);
+      expect(result).toEqual({
+        hasActiveSubscription: false,
+        subscriptionType: null,
+      });
       expect(subscriptionRepository.findByOrgId).toHaveBeenCalledWith(
         mockOrgId,
       );

--- a/ayunis-core-backend/src/iam/subscriptions/application/use-cases/has-active-subscription/has-active-subscription.use-case.ts
+++ b/ayunis-core-backend/src/iam/subscriptions/application/use-cases/has-active-subscription/has-active-subscription.use-case.ts
@@ -1,5 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { HasActiveSubscriptionQuery } from './has-active-subscription.query';
+import { HasActiveSubscriptionResult } from './has-active-subscription.result';
 import { SubscriptionRepository } from '../../ports/subscription.repository';
 import { ConfigService } from '@nestjs/config';
 import { isActive } from '../../util/is-active';
@@ -14,13 +15,15 @@ export class HasActiveSubscriptionUseCase {
     private readonly configService: ConfigService,
   ) {}
 
-  async execute(query: HasActiveSubscriptionQuery): Promise<boolean> {
+  async execute(
+    query: HasActiveSubscriptionQuery,
+  ): Promise<HasActiveSubscriptionResult> {
     // Self-hosted instances are not required to have an active subscription
     // This is used in the subscription guard to allow access to the subscription endpoint
     // And as a separate endpoint for the frontend to display "get a subscription" hints
     const isSelfHosted = this.configService.get<boolean>('app.isSelfHosted');
     if (isSelfHosted) {
-      return true;
+      return { hasActiveSubscription: true, subscriptionType: null };
     }
 
     this.logger.log('Checking active subscription', {
@@ -36,16 +39,19 @@ export class HasActiveSubscriptionUseCase {
         this.logger.debug('No subscription found for organization', {
           orgId: query.orgId,
         });
-        return false;
+        return { hasActiveSubscription: false, subscriptionType: null };
       }
 
       for (const subscription of subscriptions) {
         if (isActive(subscription)) {
-          return true;
+          return {
+            hasActiveSubscription: true,
+            subscriptionType: subscription.type,
+          };
         }
       }
 
-      return false;
+      return { hasActiveSubscription: false, subscriptionType: null };
     } catch (error) {
       if (error instanceof ApplicationError) {
         throw error;

--- a/ayunis-core-backend/src/iam/subscriptions/presenters/http/dto/active-subscription-response.dto.ts
+++ b/ayunis-core-backend/src/iam/subscriptions/presenters/http/dto/active-subscription-response.dto.ts
@@ -1,4 +1,4 @@
-import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { ApiProperty } from '@nestjs/swagger';
 import { SubscriptionType } from '../../../domain/value-objects/subscription-type.enum';
 
 export class ActiveSubscriptionResponseDto {
@@ -8,11 +8,12 @@ export class ActiveSubscriptionResponseDto {
   })
   hasActiveSubscription: boolean;
 
-  @ApiPropertyOptional({
+  @ApiProperty({
     description:
       'Type of the active subscription. Null when there is no active subscription or on self-hosted deployments.',
     enum: SubscriptionType,
     example: SubscriptionType.SEAT_BASED,
+    nullable: true,
   })
-  subscriptionType?: SubscriptionType | null;
+  subscriptionType: SubscriptionType | null;
 }

--- a/ayunis-core-backend/src/iam/subscriptions/presenters/http/dto/active-subscription-response.dto.ts
+++ b/ayunis-core-backend/src/iam/subscriptions/presenters/http/dto/active-subscription-response.dto.ts
@@ -1,4 +1,5 @@
-import { ApiProperty } from '@nestjs/swagger';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { SubscriptionType } from '../../../domain/value-objects/subscription-type.enum';
 
 export class ActiveSubscriptionResponseDto {
   @ApiProperty({
@@ -6,4 +7,12 @@ export class ActiveSubscriptionResponseDto {
     example: true,
   })
   hasActiveSubscription: boolean;
+
+  @ApiPropertyOptional({
+    description:
+      'Type of the active subscription. Null when there is no active subscription or on self-hosted deployments.',
+    enum: SubscriptionType,
+    example: SubscriptionType.SEAT_BASED,
+  })
+  subscriptionType?: SubscriptionType | null;
 }

--- a/ayunis-core-backend/src/iam/subscriptions/presenters/http/subscriptions.controller.ts
+++ b/ayunis-core-backend/src/iam/subscriptions/presenters/http/subscriptions.controller.ts
@@ -49,14 +49,16 @@ export class SubscriptionsController {
     this.logger.log(`Checking active subscription for org ${orgId}`);
 
     const query = new HasActiveSubscriptionQuery(orgId);
-    const hasActiveSubscription =
-      await this.hasActiveSubscriptionUseCase.execute(query);
+    const result = await this.hasActiveSubscriptionUseCase.execute(query);
 
     this.logger.log(
-      `Active subscription check result for org ${orgId}: ${hasActiveSubscription}`,
+      `Active subscription check result for org ${orgId}: ${result.hasActiveSubscription}`,
     );
 
-    return { hasActiveSubscription };
+    return {
+      hasActiveSubscription: result.hasActiveSubscription,
+      subscriptionType: result.subscriptionType,
+    };
   }
 
   @Get('price')

--- a/ayunis-core-frontend/src/app/routes/_authenticated/admin-settings.usage.tsx
+++ b/ayunis-core-frontend/src/app/routes/_authenticated/admin-settings.usage.tsx
@@ -1,15 +1,20 @@
 import { createFileRoute, redirect } from '@tanstack/react-router';
 import {
   getUsageControllerGetUsageConfigQueryOptions,
-  appControllerIsCloud,
+  subscriptionsControllerHasActiveSubscription,
 } from '@/shared/api/generated/ayunisCoreAPI';
+import { ActiveSubscriptionResponseDtoSubscriptionType } from '@/shared/api/generated/ayunisCoreAPI.schemas';
 import UsageSettingsPage from '@/pages/admin-settings/usage-settings';
 
 export const Route = createFileRoute('/_authenticated/admin-settings/usage')({
   component: RouteComponent,
   beforeLoad: async () => {
-    const { isCloud } = await appControllerIsCloud();
-    if (isCloud) {
+    const { subscriptionType } =
+      await subscriptionsControllerHasActiveSubscription();
+    if (
+      subscriptionType !==
+      ActiveSubscriptionResponseDtoSubscriptionType.USAGE_BASED
+    ) {
       throw redirect({ to: '/admin-settings/users' });
     }
   },

--- a/ayunis-core-frontend/src/pages/admin-settings/admin-settings-layout/ui/AdminSettingsSidebar.tsx
+++ b/ayunis-core-frontend/src/pages/admin-settings/admin-settings-layout/ui/AdminSettingsSidebar.tsx
@@ -1,6 +1,9 @@
 import { User, Users, Brain, Plug, BarChart3, Shield } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
-import { useAppControllerIsCloud } from '@/shared/api';
+import {
+  ActiveSubscriptionResponseDtoSubscriptionType,
+  useSubscriptionsControllerHasActiveSubscription,
+} from '@/shared/api';
 import {
   SettingsSidebarWidget,
   type SidebarMenuItem,
@@ -8,8 +11,11 @@ import {
 
 export function AdminSettingsSidebar() {
   const { t } = useTranslation('admin-settings-layout');
-  const { data: appConfig } = useAppControllerIsCloud();
-  const isCloud = appConfig?.isCloud ?? false;
+  const { data: subscriptionData } =
+    useSubscriptionsControllerHasActiveSubscription();
+  const isUsageBased =
+    subscriptionData?.subscriptionType ===
+    ActiveSubscriptionResponseDtoSubscriptionType.USAGE_BASED;
 
   const menuItems: SidebarMenuItem[] = [
     {
@@ -39,7 +45,7 @@ export function AdminSettingsSidebar() {
     },
   ];
 
-  if (!isCloud) {
+  if (isUsageBased) {
     menuItems.push({
       to: '/admin-settings/usage',
       icon: <BarChart3 />,

--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
@@ -1093,8 +1093,9 @@ export interface DeleteAllPendingInvitesResponseDto {
 
 /**
  * Type of the active subscription. Null when there is no active subscription or on self-hosted deployments.
+ * @nullable
  */
-export type ActiveSubscriptionResponseDtoSubscriptionType = typeof ActiveSubscriptionResponseDtoSubscriptionType[keyof typeof ActiveSubscriptionResponseDtoSubscriptionType];
+export type ActiveSubscriptionResponseDtoSubscriptionType = typeof ActiveSubscriptionResponseDtoSubscriptionType[keyof typeof ActiveSubscriptionResponseDtoSubscriptionType] | null;
 
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
@@ -1106,8 +1107,11 @@ export const ActiveSubscriptionResponseDtoSubscriptionType = {
 export interface ActiveSubscriptionResponseDto {
   /** Whether the organization has an active subscription */
   hasActiveSubscription: boolean;
-  /** Type of the active subscription. Null when there is no active subscription or on self-hosted deployments. */
-  subscriptionType?: ActiveSubscriptionResponseDtoSubscriptionType;
+  /**
+   * Type of the active subscription. Null when there is no active subscription or on self-hosted deployments.
+   * @nullable
+   */
+  subscriptionType: ActiveSubscriptionResponseDtoSubscriptionType;
 }
 
 export interface PriceResponseDto {

--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
@@ -1091,9 +1091,23 @@ export interface DeleteAllPendingInvitesResponseDto {
   deletedCount: number;
 }
 
+/**
+ * Type of the active subscription. Null when there is no active subscription or on self-hosted deployments.
+ */
+export type ActiveSubscriptionResponseDtoSubscriptionType = typeof ActiveSubscriptionResponseDtoSubscriptionType[keyof typeof ActiveSubscriptionResponseDtoSubscriptionType];
+
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const ActiveSubscriptionResponseDtoSubscriptionType = {
+  SEAT_BASED: 'SEAT_BASED',
+  USAGE_BASED: 'USAGE_BASED',
+} as const;
+
 export interface ActiveSubscriptionResponseDto {
   /** Whether the organization has an active subscription */
   hasActiveSubscription: boolean;
+  /** Type of the active subscription. Null when there is no active subscription or on self-hosted deployments. */
+  subscriptionType?: ActiveSubscriptionResponseDtoSubscriptionType;
 }
 
 export interface PriceResponseDto {

--- a/ayunis-core-frontend/src/shared/api/openapi-schema.json
+++ b/ayunis-core-frontend/src/shared/api/openapi-schema.json
@@ -10074,11 +10074,13 @@
               "SEAT_BASED",
               "USAGE_BASED"
             ],
-            "example": "SEAT_BASED"
+            "example": "SEAT_BASED",
+            "nullable": true
           }
         },
         "required": [
-          "hasActiveSubscription"
+          "hasActiveSubscription",
+          "subscriptionType"
         ]
       },
       "PriceResponseDto": {

--- a/ayunis-core-frontend/src/shared/api/openapi-schema.json
+++ b/ayunis-core-frontend/src/shared/api/openapi-schema.json
@@ -10066,6 +10066,15 @@
             "type": "boolean",
             "description": "Whether the organization has an active subscription",
             "example": true
+          },
+          "subscriptionType": {
+            "type": "string",
+            "description": "Type of the active subscription. Null when there is no active subscription or on self-hosted deployments.",
+            "enum": [
+              "SEAT_BASED",
+              "USAGE_BASED"
+            ],
+            "example": "SEAT_BASED"
           }
         },
         "required": [


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the `HasActiveSubscriptionUseCase` return type and the `GET /subscriptions/active` response contract, requiring all consumers (including frontend and tests) to handle the new `subscriptionType` field.
> 
> **Overview**
> The `has active subscription` flow now returns a structured result `{ hasActiveSubscription, subscriptionType }` instead of a boolean, and `GET /subscriptions/active` exposes this new `subscriptionType` (nullable, including for self-hosted). Callers such as `SubscriptionGuard` and subscription creation validation were updated accordingly, with tests adjusted to mock/expect the new shape.
> 
> On the frontend, the admin *Usage* route and sidebar visibility are now gated on `subscriptionType === USAGE_BASED` rather than the prior *non-cloud* check, and the generated OpenAPI schema/types were updated to include `subscriptionType`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ac967a20c0a3b288b1688299215a8b5c42ff6614. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->