### PR TITLE
wip(AYC-108): add document processing status display and polling to knowledge base UI

### DIFF
--- a/ayunis-core-frontend/src/pages/knowledge-base/api/useKnowledgeBaseDocuments.ts
+++ b/ayunis-core-frontend/src/pages/knowledge-base/api/useKnowledgeBaseDocuments.ts
@@ -1,6 +1,20 @@
 import { useKnowledgeBasesControllerListDocuments } from '@/shared/api/generated/ayunisCoreAPI';
+import { KnowledgeBaseDocumentResponseDtoStatus } from '@/shared/api/generated/ayunisCoreAPI.schemas';
+
+const PROCESSING_POLL_INTERVAL = 5000;
 
 export function useKnowledgeBaseDocuments(id: string) {
-  const { data, isLoading } = useKnowledgeBasesControllerListDocuments(id);
+  const { data, isLoading } = useKnowledgeBasesControllerListDocuments(id, {
+    query: {
+      refetchInterval: (query) => {
+        const documents = query.state.data?.data ?? [];
+        const hasProcessing = documents.some(
+          (doc) =>
+            doc.status === KnowledgeBaseDocumentResponseDtoStatus.processing,
+        );
+        return hasProcessing ? PROCESSING_POLL_INTERVAL : false;
+      },
+    },
+  });
   return { documents: data?.data ?? [], isLoading };
 }

--- a/ayunis-core-frontend/src/pages/knowledge-base/ui/KnowledgeBaseDocumentsCard.tsx
+++ b/ayunis-core-frontend/src/pages/knowledge-base/ui/KnowledgeBaseDocumentsCard.tsx
@@ -21,9 +21,15 @@ import {
 } from '@/shared/ui/shadcn/dialog';
 import {
   KnowledgeBaseDocumentResponseDtoTextType,
+  KnowledgeBaseDocumentResponseDtoStatus,
   type KnowledgeBaseDocumentResponseDto,
 } from '@/shared/api/generated/ayunisCoreAPI.schemas';
-import { Upload, X, FileText, Globe, Loader2 } from 'lucide-react';
+import { Upload, X, FileText, Globe, Loader2, AlertCircle } from 'lucide-react';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/shared/ui/shadcn/tooltip';
 import { useTranslation } from 'react-i18next';
 import { HelpLink } from '@/shared/ui/help-link/HelpLink';
 import {
@@ -215,17 +221,41 @@ function DocumentItem({
   isRemoving: boolean;
   disabled?: boolean;
 }>) {
+  const { t } = useTranslation('knowledge-bases');
   const isWeb = doc.textType === KnowledgeBaseDocumentResponseDtoTextType.web;
-  const Icon = isWeb ? Globe : FileText;
+  const isProcessing =
+    doc.status === KnowledgeBaseDocumentResponseDtoStatus.processing;
+  const isFailed = doc.status === KnowledgeBaseDocumentResponseDtoStatus.failed;
 
   return (
     <Badge
-      variant="secondary"
+      variant={isFailed ? 'destructive' : 'secondary'}
       className="flex items-center gap-1.5 py-1.5 px-3"
       title={isWeb ? (doc.url ?? undefined) : undefined}
     >
-      <Icon className="h-3.5 w-3.5 shrink-0" />
+      <DocumentItemIcon
+        isWeb={isWeb}
+        isProcessing={isProcessing}
+        isFailed={isFailed}
+      />
       <span className="max-w-[200px] truncate">{doc.name}</span>
+      {isProcessing && (
+        <span className="text-xs text-muted-foreground">
+          {t('detail.documents.statusProcessing')}
+        </span>
+      )}
+      {isFailed && (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span className="text-xs cursor-help">
+              {t('detail.documents.statusFailed')}
+            </span>
+          </TooltipTrigger>
+          <TooltipContent>
+            {doc.processingError ?? t('detail.documents.retryUpload')}
+          </TooltipContent>
+        </Tooltip>
+      )}
       {!disabled && (
         <Button
           type="button"
@@ -240,6 +270,25 @@ function DocumentItem({
       )}
     </Badge>
   );
+}
+
+function DocumentItemIcon({
+  isWeb,
+  isProcessing,
+  isFailed,
+}: Readonly<{
+  isWeb: boolean;
+  isProcessing: boolean;
+  isFailed: boolean;
+}>) {
+  if (isProcessing) {
+    return <Loader2 className="h-3.5 w-3.5 shrink-0 animate-spin" />;
+  }
+  if (isFailed) {
+    return <AlertCircle className="h-3.5 w-3.5 shrink-0" />;
+  }
+  const Icon = isWeb ? Globe : FileText;
+  return <Icon className="h-3.5 w-3.5 shrink-0" />;
 }
 
 function AddUrlDialog({

--- a/ayunis-core-frontend/src/shared/locales/de/knowledge-bases.json
+++ b/ayunis-core-frontend/src/shared/locales/de/knowledge-bases.json
@@ -152,6 +152,9 @@
       "addUrlError": "URL konnte nicht hinzugefügt werden. Bitte überprüfen Sie die URL und versuchen Sie es erneut.",
       "addUrlRetrievalFailed": "Die Website konnte nicht erreicht werden. Bitte überprüfen Sie, ob die URL korrekt ist und die Website erreichbar ist.",
       "addUrlUnsupportedContentType": "Diese URL verweist auf eine Datei (z. B. PDF) statt auf eine Website. Bitte laden Sie die Datei herunter und laden Sie sie direkt hoch.",
+      "statusProcessing": "Wird verarbeitet…",
+      "statusFailed": "Fehlgeschlagen",
+      "retryUpload": "Entfernen und erneut hochladen",
       "removeSuccess": "Dokument erfolgreich entfernt!",
       "removeError": "Dokument konnte nicht entfernt werden. Bitte versuchen Sie es erneut.",
       "urlDialogCancel": "Abbrechen"

--- a/ayunis-core-frontend/src/shared/locales/en/knowledge-bases.json
+++ b/ayunis-core-frontend/src/shared/locales/en/knowledge-bases.json
@@ -152,6 +152,9 @@
       "addUrlError": "Failed to add URL. Please check the URL and try again.",
       "addUrlRetrievalFailed": "The website could not be reached. Please check that the URL is correct and the website is accessible.",
       "addUrlUnsupportedContentType": "This URL points to a file (e.g. PDF) instead of a website. Please download the file and upload it directly.",
+      "statusProcessing": "Processing…",
+      "statusFailed": "Failed",
+      "retryUpload": "Remove and re-upload",
       "removeSuccess": "Document removed successfully!",
       "removeError": "Failed to remove document. Please try again.",
       "urlDialogCancel": "Cancel"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk UI/data-refresh change; main impact is additional polling traffic while documents are in `processing` and new status rendering that depends on backend status values.
> 
> **Overview**
> Improves the knowledge base documents UI by **polling the document list every 5s while any document is in `processing`**, stopping automatically once processing completes.
> 
> Updates document badges to reflect backend `status`: shows a spinner + “Processing…” label, marks failed items as *destructive* with an error icon and tooltip showing `processingError` (or a “Remove and re-upload” hint), and adds the related i18n strings (EN/DE).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7f098088135807093f20bc69fe6b2ab71fa1f20f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->