### PR TITLE
feat(AYC-77): add month filter and total credits to admin user usage table

### DIFF
--- a/ayunis-core-backend/src/domain/usage/application/ports/usage.repository.ts
+++ b/ayunis-core-backend/src/domain/usage/application/ports/usage.repository.ts
@@ -23,6 +23,11 @@ export {
   GlobalUserUsageItem,
 };
 
+export interface UserUsageResult {
+  users: Paginated<UserUsageItem>;
+  totalCredits: number;
+}
+
 export abstract class UsageRepository {
   abstract save(usage: Usage): Promise<void>;
   abstract saveBatch(usages: Usage[]): Promise<void>;
@@ -47,9 +52,7 @@ export abstract class UsageRepository {
   abstract getModelDistribution(
     query: GetModelDistributionQuery,
   ): Promise<ModelDistribution[]>;
-  abstract getUserUsage(
-    query: GetUserUsageQuery,
-  ): Promise<Paginated<UserUsageItem>>;
+  abstract getUserUsage(query: GetUserUsageQuery): Promise<UserUsageResult>;
   abstract getUsageStats(query: GetUsageStatsQuery): Promise<UsageStats>;
   abstract getUsageCount(
     organizationId: UUID,

--- a/ayunis-core-backend/src/domain/usage/application/use-cases/get-user-usage/get-user-usage.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/usage/application/use-cases/get-user-usage/get-user-usage.use-case.spec.ts
@@ -9,8 +9,16 @@ import {
 } from '../../usage.errors';
 import { Paginated } from 'src/common/pagination';
 import { UserUsageItem } from '../../../domain/user-usage-item.entity';
+import type { UserUsageResult } from '../../ports/usage.repository';
 import type { UUID } from 'crypto';
 import { UsageConstants } from '../../../domain/value-objects/usage.constants';
+
+function mockUserUsageResult(
+  users: Paginated<UserUsageItem>,
+  totalCredits = 0,
+): UserUsageResult {
+  return { users, totalCredits };
+}
 
 describe('GetUserUsageUseCase', () => {
   let useCase: GetUserUsageUseCase;
@@ -44,35 +52,39 @@ describe('GetUserUsageUseCase', () => {
     it('should return user usage data', async () => {
       const userId = 'user-id' as UUID;
 
-      const mockUserUsage = new Paginated<UserUsageItem>({
-        data: [
-          new UserUsageItem({
-            userId,
-            userName: 'Test User',
-            userEmail: 'test@example.com',
-            credits: 100,
-            requests: 5,
-            lastActivity: new Date(),
-            isActive: true,
-          }),
-        ],
-        limit: 50,
-        offset: 0,
-        total: 1,
-      });
+      const mockResult = mockUserUsageResult(
+        new Paginated<UserUsageItem>({
+          data: [
+            new UserUsageItem({
+              userId,
+              userName: 'Test User',
+              userEmail: 'test@example.com',
+              credits: 100,
+              requests: 5,
+              lastActivity: new Date(),
+              isActive: true,
+            }),
+          ],
+          limit: 50,
+          offset: 0,
+          total: 1,
+        }),
+        100,
+      );
 
       jest
         .spyOn(mockUsageRepository, 'getUserUsage')
-        .mockResolvedValue(mockUserUsage);
+        .mockResolvedValue(mockResult);
 
       const query = new GetUserUsageQuery({ organizationId: orgId });
 
       const result = await useCase.execute(query);
 
       expect(result).toBeDefined();
-      expect(result.data).toHaveLength(1);
-      expect(result.data[0].userId).toBe(userId);
-      expect(result.data[0].isActive).toBe(true);
+      expect(result.users.data).toHaveLength(1);
+      expect(result.users.data[0].userId).toBe(userId);
+      expect(result.users.data[0].isActive).toBe(true);
+      expect(result.totalCredits).toBe(100);
     });
   });
 
@@ -152,14 +164,18 @@ describe('GetUserUsageUseCase', () => {
         endDate,
       });
 
-      jest.spyOn(mockUsageRepository, 'getUserUsage').mockResolvedValue(
-        new Paginated<UserUsageItem>({
-          data: [],
-          limit: 50,
-          offset: 0,
-          total: 0,
-        }),
-      );
+      jest
+        .spyOn(mockUsageRepository, 'getUserUsage')
+        .mockResolvedValue(
+          mockUserUsageResult(
+            new Paginated<UserUsageItem>({
+              data: [],
+              limit: 50,
+              offset: 0,
+              total: 0,
+            }),
+          ),
+        );
 
       await expect(useCase.execute(query)).resolves.toBeDefined();
     });
@@ -221,14 +237,18 @@ describe('GetUserUsageUseCase', () => {
         offset: 0,
       });
 
-      jest.spyOn(mockUsageRepository, 'getUserUsage').mockResolvedValue(
-        new Paginated<UserUsageItem>({
-          data: [],
-          limit: 50,
-          offset: 0,
-          total: 0,
-        }),
-      );
+      jest
+        .spyOn(mockUsageRepository, 'getUserUsage')
+        .mockResolvedValue(
+          mockUserUsageResult(
+            new Paginated<UserUsageItem>({
+              data: [],
+              limit: 50,
+              offset: 0,
+              total: 0,
+            }),
+          ),
+        );
 
       await expect(useCase.execute(query)).resolves.toBeDefined();
     });
@@ -265,14 +285,18 @@ describe('GetUserUsageUseCase', () => {
         sortOrder: 'desc',
       });
 
-      jest.spyOn(mockUsageRepository, 'getUserUsage').mockResolvedValue(
-        new Paginated<UserUsageItem>({
-          data: [],
-          limit: 50,
-          offset: 0,
-          total: 0,
-        }),
-      );
+      jest
+        .spyOn(mockUsageRepository, 'getUserUsage')
+        .mockResolvedValue(
+          mockUserUsageResult(
+            new Paginated<UserUsageItem>({
+              data: [],
+              limit: 50,
+              offset: 0,
+              total: 0,
+            }),
+          ),
+        );
 
       await expect(useCase.execute(query)).resolves.toBeDefined();
     });

--- a/ayunis-core-backend/src/domain/usage/application/use-cases/get-user-usage/get-user-usage.use-case.ts
+++ b/ayunis-core-backend/src/domain/usage/application/use-cases/get-user-usage/get-user-usage.use-case.ts
@@ -1,13 +1,15 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { GetUserUsageQuery } from './get-user-usage.query';
-import { UsageRepository, UserUsageItem } from '../../ports/usage.repository';
+import {
+  UsageRepository,
+  type UserUsageResult,
+} from '../../ports/usage.repository';
 import {
   InvalidPaginationError,
   UnexpectedUsageError,
 } from '../../usage.errors';
 import { validateOptionalDateRange } from '../../usage.utils';
 import { UsageConstants } from '../../../domain/value-objects/usage.constants';
-import { Paginated } from 'src/common/pagination';
 import { ApplicationError } from '../../../../../common/errors/base.error';
 
 @Injectable()
@@ -16,7 +18,7 @@ export class GetUserUsageUseCase {
 
   constructor(private readonly usageRepository: UsageRepository) {}
 
-  async execute(query: GetUserUsageQuery): Promise<Paginated<UserUsageItem>> {
+  async execute(query: GetUserUsageQuery): Promise<UserUsageResult> {
     this.validateQuery(query);
 
     try {

--- a/ayunis-core-backend/src/domain/usage/infrastructure/persistence/local-usage/local-usage.repository.ts
+++ b/ayunis-core-backend/src/domain/usage/infrastructure/persistence/local-usage/local-usage.repository.ts
@@ -8,6 +8,7 @@ import {
   UsageRepository,
   ProviderUsage,
   ModelDistribution,
+  type UserUsageResult,
 } from '../../../application/ports/usage.repository';
 import { GetProviderUsageQuery } from '../../../application/use-cases/get-provider-usage/get-provider-usage.query';
 import { GetModelDistributionQuery } from '../../../application/use-cases/get-model-distribution/get-model-distribution.query';
@@ -28,6 +29,7 @@ import { getGlobalProviderTimeSeries } from './queries/get-global-provider-time-
 import { getGlobalModelStats } from './queries/get-global-model-stats.db-query';
 import { getUserUsageRows } from './queries/get-user-usage-rows.db-query';
 import { countUsersForUserUsage } from './queries/count-users-for-user-usage.db-query';
+import { sumCreditsForOrg } from './queries/sum-credits-for-org.db-query';
 import { findUsageRecordsByOrganization } from './queries/find-usage-records-by-organization.db-query';
 import { findUsageRecordsByUser } from './queries/find-usage-records-by-user.db-query';
 import { findUsageRecordsByModel } from './queries/find-usage-records-by-model.db-query';
@@ -161,17 +163,13 @@ export class LocalUsageRepository extends UsageRepository {
     return this.usageQueryMapper.mapModelStatsToDistribution(modelStats).items;
   }
 
-  async getUserUsage(
-    query: GetUserUsageQuery,
-  ): Promise<Paginated<UserUsageItem>> {
+  async getUserUsage(query: GetUserUsageQuery): Promise<UserUsageResult> {
     // Determine sort field and order
     const sortField = this.mapSortFieldForUsers(query.sortBy);
-    const sortOrder = query.sortOrder.toUpperCase() as
-      | 'ASC'
-      | 'DESC';
+    const sortOrder = query.sortOrder.toUpperCase() as 'ASC' | 'DESC';
 
-    // Fetch total count for pagination and rows via query helpers
-    const [total, userStats] = await Promise.all([
+    // Fetch total count, credit sum, and rows in parallel
+    const [total, totalCredits, userStats] = await Promise.all([
       countUsersForUserUsage({
         userRepository: this.userRepository,
         organizationId: query.organizationId,
@@ -179,6 +177,13 @@ export class LocalUsageRepository extends UsageRepository {
         endDate: query.endDate,
         searchTerm: query.searchTerm,
       }),
+
+      sumCreditsForOrg(
+        this.usageRepository,
+        query.organizationId,
+        query.startDate,
+        query.endDate,
+      ),
 
       getUserUsageRows({
         userRepository: this.userRepository,
@@ -207,12 +212,15 @@ export class LocalUsageRepository extends UsageRepository {
       });
     });
 
-    return new Paginated<UserUsageItem>({
-      data: users,
-      limit: query.limit,
-      offset: query.offset,
-      total,
-    });
+    return {
+      users: new Paginated<UserUsageItem>({
+        data: users,
+        limit: query.limit,
+        offset: query.offset,
+        total,
+      }),
+      totalCredits,
+    };
   }
 
   async getUsageStats(query: GetUsageStatsQuery): Promise<UsageStats> {
@@ -365,7 +373,7 @@ export class LocalUsageRepository extends UsageRepository {
     lastActivity?: Date | string | null;
   }): { credits: number; requests: number; lastActivity: Date | null } {
     return {
-      credits: row.credits ? parseFloat(row.credits) : 0,
+      credits: row.credits ? Math.round(parseFloat(row.credits)) : 0,
       requests: row.requests ? parseInt(row.requests, 10) : 0,
       lastActivity: row.lastActivity ? new Date(row.lastActivity) : null,
     };

--- a/ayunis-core-backend/src/domain/usage/infrastructure/persistence/local-usage/queries/count-usages-in-range.db-query.ts
+++ b/ayunis-core-backend/src/domain/usage/infrastructure/persistence/local-usage/queries/count-usages-in-range.db-query.ts
@@ -16,7 +16,7 @@ export async function countUsagesInRange(
     qb.andWhere('usage.createdAt >= :startDate', { startDate });
   }
   if (endDate) {
-    qb.andWhere('usage.createdAt <= :endDate', { endDate });
+    qb.andWhere('usage.createdAt < :endDate', { endDate });
   }
 
   return await qb.getCount();

--- a/ayunis-core-backend/src/domain/usage/infrastructure/persistence/local-usage/queries/count-users-for-user-usage.db-query.ts
+++ b/ayunis-core-backend/src/domain/usage/infrastructure/persistence/local-usage/queries/count-users-for-user-usage.db-query.ts
@@ -26,7 +26,7 @@ export async function countUsersForUserUsage(
     });
   }
   if (params.endDate) {
-    usageSubquery.andWhere('usage.createdAt <= :endDate', {
+    usageSubquery.andWhere('usage.createdAt < :endDate', {
       endDate: params.endDate,
     });
   }

--- a/ayunis-core-backend/src/domain/usage/infrastructure/persistence/local-usage/queries/find-usage-records-by-model.db-query.ts
+++ b/ayunis-core-backend/src/domain/usage/infrastructure/persistence/local-usage/queries/find-usage-records-by-model.db-query.ts
@@ -16,7 +16,7 @@ export async function findUsageRecordsByModel(
     qb.andWhere('usage.createdAt >= :startDate', { startDate });
   }
   if (endDate) {
-    qb.andWhere('usage.createdAt <= :endDate', { endDate });
+    qb.andWhere('usage.createdAt < :endDate', { endDate });
   }
 
   return await qb.orderBy('usage.createdAt', 'DESC').getMany();

--- a/ayunis-core-backend/src/domain/usage/infrastructure/persistence/local-usage/queries/find-usage-records-by-organization.db-query.ts
+++ b/ayunis-core-backend/src/domain/usage/infrastructure/persistence/local-usage/queries/find-usage-records-by-organization.db-query.ts
@@ -16,7 +16,7 @@ export async function findUsageRecordsByOrganization(
     qb.andWhere('usage.createdAt >= :startDate', { startDate });
   }
   if (endDate) {
-    qb.andWhere('usage.createdAt <= :endDate', { endDate });
+    qb.andWhere('usage.createdAt < :endDate', { endDate });
   }
 
   return await qb.orderBy('usage.createdAt', 'DESC').getMany();

--- a/ayunis-core-backend/src/domain/usage/infrastructure/persistence/local-usage/queries/find-usage-records-by-user.db-query.ts
+++ b/ayunis-core-backend/src/domain/usage/infrastructure/persistence/local-usage/queries/find-usage-records-by-user.db-query.ts
@@ -16,7 +16,7 @@ export async function findUsageRecordsByUser(
     qb.andWhere('usage.createdAt >= :startDate', { startDate });
   }
   if (endDate) {
-    qb.andWhere('usage.createdAt <= :endDate', { endDate });
+    qb.andWhere('usage.createdAt < :endDate', { endDate });
   }
 
   return await qb.orderBy('usage.createdAt', 'DESC').getMany();

--- a/ayunis-core-backend/src/domain/usage/infrastructure/persistence/local-usage/queries/get-global-model-stats.db-query.ts
+++ b/ayunis-core-backend/src/domain/usage/infrastructure/persistence/local-usage/queries/get-global-model-stats.db-query.ts
@@ -28,7 +28,7 @@ export async function getGlobalModelStats(
     qb.andWhere('usage.createdAt >= :startDate', { startDate });
   }
   if (endDate) {
-    qb.andWhere('usage.createdAt <= :endDate', { endDate });
+    qb.andWhere('usage.createdAt < :endDate', { endDate });
   }
   if (modelId) {
     qb.andWhere('usage.modelId = :modelId', { modelId });

--- a/ayunis-core-backend/src/domain/usage/infrastructure/persistence/local-usage/queries/get-global-provider-stats.db-query.ts
+++ b/ayunis-core-backend/src/domain/usage/infrastructure/persistence/local-usage/queries/get-global-provider-stats.db-query.ts
@@ -20,7 +20,7 @@ export async function getGlobalProviderStats(
     qb.andWhere('usage.createdAt >= :startDate', { startDate });
   }
   if (endDate) {
-    qb.andWhere('usage.createdAt <= :endDate', { endDate });
+    qb.andWhere('usage.createdAt < :endDate', { endDate });
   }
   if (provider) {
     qb.andWhere('usage.provider = :provider', { provider });

--- a/ayunis-core-backend/src/domain/usage/infrastructure/persistence/local-usage/queries/get-global-provider-time-series.db-query.ts
+++ b/ayunis-core-backend/src/domain/usage/infrastructure/persistence/local-usage/queries/get-global-provider-time-series.db-query.ts
@@ -21,7 +21,7 @@ export async function getGlobalProviderTimeSeries(
     qb.andWhere('usage.createdAt >= :startDate', { startDate });
   }
   if (endDate) {
-    qb.andWhere('usage.createdAt <= :endDate', { endDate });
+    qb.andWhere('usage.createdAt < :endDate', { endDate });
   }
   if (modelId) {
     qb.andWhere('usage.modelId = :modelId', { modelId });

--- a/ayunis-core-backend/src/domain/usage/infrastructure/persistence/local-usage/queries/get-global-user-usage-rows.db-query.ts
+++ b/ayunis-core-backend/src/domain/usage/infrastructure/persistence/local-usage/queries/get-global-user-usage-rows.db-query.ts
@@ -37,7 +37,7 @@ function buildUsageSubquery(
     });
   }
   if (params.endDate) {
-    qb.andWhere('usage.createdAt <= :endDate', {
+    qb.andWhere('usage.createdAt < :endDate', {
       endDate: params.endDate,
     });
   }

--- a/ayunis-core-backend/src/domain/usage/infrastructure/persistence/local-usage/queries/get-model-stats.db-query.ts
+++ b/ayunis-core-backend/src/domain/usage/infrastructure/persistence/local-usage/queries/get-model-stats.db-query.ts
@@ -30,7 +30,7 @@ export async function getModelStats(
     qb.andWhere('usage.createdAt >= :startDate', { startDate });
   }
   if (endDate) {
-    qb.andWhere('usage.createdAt <= :endDate', { endDate });
+    qb.andWhere('usage.createdAt < :endDate', { endDate });
   }
   if (modelId) {
     qb.andWhere('usage.modelId = :modelId', { modelId });

--- a/ayunis-core-backend/src/domain/usage/infrastructure/persistence/local-usage/queries/get-provider-stats.db-query.ts
+++ b/ayunis-core-backend/src/domain/usage/infrastructure/persistence/local-usage/queries/get-provider-stats.db-query.ts
@@ -22,7 +22,7 @@ export async function getProviderStats(
     qb.andWhere('usage.createdAt >= :startDate', { startDate });
   }
   if (endDate) {
-    qb.andWhere('usage.createdAt <= :endDate', { endDate });
+    qb.andWhere('usage.createdAt < :endDate', { endDate });
   }
   if (provider) {
     qb.andWhere('usage.provider = :provider', { provider });

--- a/ayunis-core-backend/src/domain/usage/infrastructure/persistence/local-usage/queries/get-provider-time-series.db-query.ts
+++ b/ayunis-core-backend/src/domain/usage/infrastructure/persistence/local-usage/queries/get-provider-time-series.db-query.ts
@@ -23,7 +23,7 @@ export async function getProviderTimeSeries(
     qb.andWhere('usage.createdAt >= :startDate', { startDate });
   }
   if (endDate) {
-    qb.andWhere('usage.createdAt <= :endDate', { endDate });
+    qb.andWhere('usage.createdAt < :endDate', { endDate });
   }
   if (modelId) {
     qb.andWhere('usage.modelId = :modelId', { modelId });

--- a/ayunis-core-backend/src/domain/usage/infrastructure/persistence/local-usage/queries/get-top-models.db-query.ts
+++ b/ayunis-core-backend/src/domain/usage/infrastructure/persistence/local-usage/queries/get-top-models.db-query.ts
@@ -27,7 +27,7 @@ export async function getTopModels(
     qb.andWhere('usage.createdAt >= :startDate', { startDate });
   }
   if (endDate) {
-    qb.andWhere('usage.createdAt <= :endDate', { endDate });
+    qb.andWhere('usage.createdAt < :endDate', { endDate });
   }
 
   return await qb

--- a/ayunis-core-backend/src/domain/usage/infrastructure/persistence/local-usage/queries/get-usage-aggregate-stats.db-query.ts
+++ b/ayunis-core-backend/src/domain/usage/infrastructure/persistence/local-usage/queries/get-usage-aggregate-stats.db-query.ts
@@ -20,7 +20,7 @@ export async function getUsageAggregateStats(
     qb.andWhere('usage.createdAt >= :startDate', { startDate });
   }
   if (endDate) {
-    qb.andWhere('usage.createdAt <= :endDate', { endDate });
+    qb.andWhere('usage.createdAt < :endDate', { endDate });
   }
 
   const res = await qb.getRawOne<UsageAggregateRow>();

--- a/ayunis-core-backend/src/domain/usage/infrastructure/persistence/local-usage/queries/get-user-usage-rows.db-query.ts
+++ b/ayunis-core-backend/src/domain/usage/infrastructure/persistence/local-usage/queries/get-user-usage-rows.db-query.ts
@@ -26,7 +26,7 @@ export async function getUserUsageRows(
     });
   }
   if (params.endDate) {
-    usageSubquery.andWhere('usage.createdAt <= :endDate', {
+    usageSubquery.andWhere('usage.createdAt < :endDate', {
       endDate: params.endDate,
     });
   }

--- a/ayunis-core-backend/src/domain/usage/infrastructure/persistence/local-usage/queries/sum-credits-for-org.db-query.ts
+++ b/ayunis-core-backend/src/domain/usage/infrastructure/persistence/local-usage/queries/sum-credits-for-org.db-query.ts
@@ -1,0 +1,26 @@
+import type { Repository } from 'typeorm';
+import type { UUID } from 'crypto';
+import type { UsageRecord } from '../schema/usage.record';
+
+export async function sumCreditsForOrg(
+  usageRepository: Repository<UsageRecord>,
+  organizationId: UUID,
+  startDate?: Date,
+  endDate?: Date,
+): Promise<number> {
+  const qb = usageRepository
+    .createQueryBuilder('usage')
+    .select('COALESCE(SUM(usage.creditsConsumed), 0)', 'totalCredits')
+    .where('usage.organizationId = :orgId', { orgId: organizationId });
+
+  if (startDate) {
+    qb.andWhere('usage.createdAt >= :startDate', { startDate });
+  }
+  if (endDate) {
+    qb.andWhere('usage.createdAt <= :endDate', { endDate });
+  }
+
+  const result = await qb.getRawOne<{ totalCredits: string }>();
+
+  return Math.round(parseFloat(result?.totalCredits ?? '0'));
+}

--- a/ayunis-core-backend/src/domain/usage/infrastructure/persistence/local-usage/queries/sum-credits-for-org.db-query.ts
+++ b/ayunis-core-backend/src/domain/usage/infrastructure/persistence/local-usage/queries/sum-credits-for-org.db-query.ts
@@ -17,7 +17,7 @@ export async function sumCreditsForOrg(
     qb.andWhere('usage.createdAt >= :startDate', { startDate });
   }
   if (endDate) {
-    qb.andWhere('usage.createdAt <= :endDate', { endDate });
+    qb.andWhere('usage.createdAt < :endDate', { endDate });
   }
 
   const result = await qb.getRawOne<{ totalCredits: string }>();

--- a/ayunis-core-backend/src/domain/usage/presenters/http/dto/user-usage-response.dto.ts
+++ b/ayunis-core-backend/src/domain/usage/presenters/http/dto/user-usage-response.dto.ts
@@ -10,4 +10,10 @@ export class UserUsageResponseDto {
 
   @ApiProperty({ description: 'Pagination metadata', type: PaginationDto })
   pagination: PaginationDto;
+
+  @ApiProperty({
+    description:
+      'Total credits consumed across all users in the filtered period',
+  })
+  totalCredits: number;
 }

--- a/ayunis-core-backend/src/domain/usage/presenters/http/mappers/usage-response.mapper.ts
+++ b/ayunis-core-backend/src/domain/usage/presenters/http/mappers/usage-response.mapper.ts
@@ -7,8 +7,7 @@ import { UserUsageResponseDtoMapper } from './user-usage-response-dto.mapper';
 import { UsageStats } from '../../../domain/usage-stats.entity';
 import { ProviderUsage } from '../../../domain/provider-usage.entity';
 import { ModelDistribution } from '../../../domain/model-distribution.entity';
-import { UserUsageItem } from '../../../domain/user-usage-item.entity';
-import { Paginated } from 'src/common/pagination';
+import type { UserUsageResult } from '../../../application/ports/usage.repository';
 import { UsageStatsResponseDto } from '../dto/usage-stats-response.dto';
 import { ProviderUsageResponseDto } from '../dto/provider-usage-response.dto';
 import { ProviderUsageChartResponseDto } from '../dto/provider-usage-chart-response.dto';
@@ -45,7 +44,7 @@ export class UsageResponseMapper {
     return this.modelDistributionMapper.toDto(modelDistribution);
   }
 
-  toUserUsageDto(userUsage: Paginated<UserUsageItem>): UserUsageResponseDto {
-    return this.userUsageMapper.toDto(userUsage);
+  toUserUsageDto(result: UserUsageResult): UserUsageResponseDto {
+    return this.userUsageMapper.toDto(result);
   }
 }

--- a/ayunis-core-backend/src/domain/usage/presenters/http/mappers/user-usage-response-dto.mapper.ts
+++ b/ayunis-core-backend/src/domain/usage/presenters/http/mappers/user-usage-response-dto.mapper.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { UserUsageItem } from '../../../domain/user-usage-item.entity';
-import { Paginated } from 'src/common/pagination';
+import type { UserUsageResult } from '../../../application/ports/usage.repository';
 import {
   UserUsageResponseDto,
   UserUsageDto,
@@ -8,14 +8,15 @@ import {
 
 @Injectable()
 export class UserUsageResponseDtoMapper {
-  toDto(userUsageResult: Paginated<UserUsageItem>): UserUsageResponseDto {
+  toDto(result: UserUsageResult): UserUsageResponseDto {
     return {
-      data: userUsageResult.data.map((user) => this.toUserDto(user)),
+      data: result.users.data.map((user) => this.toUserDto(user)),
       pagination: {
-        limit: userUsageResult.limit,
-        offset: userUsageResult.offset,
-        total: userUsageResult.total,
+        limit: result.users.limit,
+        offset: result.users.offset,
+        total: result.users.total,
       },
+      totalCredits: result.totalCredits,
     };
   }
 

--- a/ayunis-core-backend/src/domain/usage/presenters/http/usage-use-cases.facade.ts
+++ b/ayunis-core-backend/src/domain/usage/presenters/http/usage-use-cases.facade.ts
@@ -13,8 +13,7 @@ import { GetUsageStatsQuery } from '../../application/use-cases/get-usage-stats/
 import { UsageStats } from '../../domain/usage-stats.entity';
 import { ProviderUsage } from '../../domain/provider-usage.entity';
 import { ModelDistribution } from '../../domain/model-distribution.entity';
-import { UserUsageItem } from '../../domain/user-usage-item.entity';
-import { Paginated } from 'src/common/pagination';
+import type { UserUsageResult } from '../../application/ports/usage.repository';
 import type { CreditUsage } from '../../domain/credit-usage';
 
 @Injectable()
@@ -37,7 +36,7 @@ export class UsageUseCasesFacade {
     return this.getModelDistributionUseCase.execute(query);
   }
 
-  getUserUsage(query: GetUserUsageQuery): Promise<Paginated<UserUsageItem>> {
+  getUserUsage(query: GetUserUsageQuery): Promise<UserUsageResult> {
     return this.getUserUsageUseCase.execute(query);
   }
 

--- a/ayunis-core-frontend/src/pages/admin-settings/usage-settings/lib/getMonthDateRange.ts
+++ b/ayunis-core-frontend/src/pages/admin-settings/usage-settings/lib/getMonthDateRange.ts
@@ -1,0 +1,12 @@
+/**
+ * Returns the start and end dates for a given calendar month.
+ * Start is midnight on the 1st, end is midnight on the 1st of the next month.
+ */
+export function getMonthDateRange(
+  year: number,
+  month: number,
+): { startDate: Date; endDate: Date } {
+  const startDate = new Date(year, month, 1);
+  const endDate = new Date(year, month + 1, 1);
+  return { startDate, endDate };
+}

--- a/ayunis-core-frontend/src/pages/admin-settings/usage-settings/ui/MonthPicker.tsx
+++ b/ayunis-core-frontend/src/pages/admin-settings/usage-settings/ui/MonthPicker.tsx
@@ -1,0 +1,61 @@
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+import { Button } from '@/shared/ui/shadcn/button';
+import { useTranslation } from 'react-i18next';
+
+interface MonthPickerProps {
+  year: number;
+  month: number; // 0-indexed (0 = January)
+  onMonthChange: (year: number, month: number) => void;
+}
+
+export function MonthPicker({
+  year,
+  month,
+  onMonthChange,
+}: Readonly<MonthPickerProps>) {
+  const { i18n } = useTranslation();
+
+  const label = new Intl.DateTimeFormat(i18n.language, {
+    year: 'numeric',
+    month: 'long',
+  }).format(new Date(year, month, 1));
+
+  const now = new Date();
+  const isCurrentMonth = year === now.getFullYear() && month === now.getMonth();
+
+  const goToPreviousMonth = () => {
+    if (month === 0) {
+      onMonthChange(year - 1, 11);
+    } else {
+      onMonthChange(year, month - 1);
+    }
+  };
+
+  const goToNextMonth = () => {
+    if (isCurrentMonth) return;
+    if (month === 11) {
+      onMonthChange(year + 1, 0);
+    } else {
+      onMonthChange(year, month + 1);
+    }
+  };
+
+  return (
+    <div className="flex items-center gap-2">
+      <Button variant="outline" size="icon" onClick={goToPreviousMonth}>
+        <ChevronLeft className="h-4 w-4" />
+      </Button>
+      <span className="min-w-[10rem] text-center text-sm font-medium">
+        {label}
+      </span>
+      <Button
+        variant="outline"
+        size="icon"
+        onClick={goToNextMonth}
+        disabled={isCurrentMonth}
+      >
+        <ChevronRight className="h-4 w-4" />
+      </Button>
+    </div>
+  );
+}

--- a/ayunis-core-frontend/src/pages/admin-settings/usage-settings/ui/user-usage-table/UserUsageTable.tsx
+++ b/ayunis-core-frontend/src/pages/admin-settings/usage-settings/ui/user-usage-table/UserUsageTable.tsx
@@ -1,50 +1,73 @@
-import { useState, useMemo } from 'react';
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useUserUsage } from '@/pages/admin-settings/usage-settings/api';
 import {
   UserUsageTableWidget,
   DEFAULT_PAGE_SIZE,
 } from '@/widgets/user-usage-table';
+import { MonthPicker } from '../MonthPicker';
+import { getMonthDateRange } from '../../lib/getMonthDateRange';
 
-interface UserUsageTableProps {
-  startDate?: Date;
-  endDate?: Date;
-}
+export function UserUsageTable() {
+  const now = new Date();
+  const [year, setYear] = useState(now.getFullYear());
+  const [month, setMonth] = useState(now.getMonth());
 
-export function UserUsageTable({
-  startDate,
-  endDate,
-}: Readonly<UserUsageTableProps>) {
-  const filterKey = useMemo(
-    () => `${startDate?.toISOString() ?? ''}-${endDate?.toISOString() ?? ''}`,
-    [startDate, endDate],
+  const handleMonthChange = (newYear: number, newMonth: number) => {
+    setYear(newYear);
+    setMonth(newMonth);
+  };
+
+  const { startDate, endDate } = getMonthDateRange(year, month);
+
+  const monthPicker = (
+    <MonthPicker year={year} month={month} onMonthChange={handleMonthChange} />
   );
 
   return (
     <UserUsageTableInner
-      key={filterKey}
+      key={`${year}-${month}`}
       startDate={startDate}
       endDate={endDate}
+      headerAction={monthPicker}
     />
   );
+}
+
+interface UserUsageTableInnerProps {
+  startDate: Date;
+  endDate: Date;
+  headerAction: React.ReactNode;
 }
 
 function UserUsageTableInner({
   startDate,
   endDate,
-}: Readonly<UserUsageTableProps>) {
+  headerAction,
+}: Readonly<UserUsageTableInnerProps>) {
   const [currentPage, setCurrentPage] = useState(0);
   const offset = currentPage * DEFAULT_PAGE_SIZE;
+
+  const { t } = useTranslation('admin-settings-usage');
 
   const {
     data: userUsageResponse,
     isLoading,
     error,
   } = useUserUsage({
-    startDate: startDate?.toISOString(),
-    endDate: endDate?.toISOString(),
+    startDate: startDate.toISOString(),
+    endDate: endDate.toISOString(),
     limit: DEFAULT_PAGE_SIZE,
     offset,
   });
+
+  const totalCredits = userUsageResponse?.totalCredits;
+  const description =
+    totalCredits !== undefined
+      ? t('userUsage.totalCredits', {
+          credits: totalCredits.toLocaleString(),
+        })
+      : undefined;
 
   return (
     <UserUsageTableWidget
@@ -54,6 +77,8 @@ function UserUsageTableInner({
       onPageChange={setCurrentPage}
       isLoading={isLoading}
       error={error}
+      headerAction={headerAction}
+      description={description}
     />
   );
 }

--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
@@ -3320,6 +3320,8 @@ export interface UserUsageResponseDto {
   data: UserUsageDto[];
   /** Pagination metadata */
   pagination: PaginationDto;
+  /** Total credits consumed across all users in the filtered period */
+  totalCredits: number;
 }
 
 export interface UsageStatsResponseDto {

--- a/ayunis-core-frontend/src/shared/api/openapi-schema.json
+++ b/ayunis-core-frontend/src/shared/api/openapi-schema.json
@@ -13901,11 +13901,16 @@
                 "$ref": "#/components/schemas/PaginationDto"
               }
             ]
+          },
+          "totalCredits": {
+            "type": "number",
+            "description": "Total credits consumed across all users in the filtered period"
           }
         },
         "required": [
           "data",
-          "pagination"
+          "pagination",
+          "totalCredits"
         ]
       },
       "UsageStatsResponseDto": {

--- a/ayunis-core-frontend/src/shared/locales/de/admin-settings-usage.json
+++ b/ayunis-core-frontend/src/shared/locales/de/admin-settings-usage.json
@@ -72,6 +72,7 @@
     "status": "Status",
     "active": "aktiv",
     "inactive": "inaktiv",
+    "totalCredits": "Gesamt: {{credits}} Credits",
     "emptyState": "Keine Benutzer entsprechen den ausgewählten Filtern auf dieser Seite. Versuchen Sie, Ihre Filter anzupassen oder zu einer anderen Seite zu navigieren."
   }
 }

--- a/ayunis-core-frontend/src/shared/locales/en/admin-settings-usage.json
+++ b/ayunis-core-frontend/src/shared/locales/en/admin-settings-usage.json
@@ -72,6 +72,7 @@
     "status": "Status",
     "active": "active",
     "inactive": "inactive",
+    "totalCredits": "Total: {{credits}} credits",
     "emptyState": "No users match the selected filters on this page. Try adjusting your filters or navigate to another page."
   }
 }

--- a/ayunis-core-frontend/src/widgets/user-usage-table/ui/UserUsageTableContent.tsx
+++ b/ayunis-core-frontend/src/widgets/user-usage-table/ui/UserUsageTableContent.tsx
@@ -10,6 +10,8 @@ import {
 } from '@/shared/ui/shadcn/table';
 import {
   Card,
+  CardAction,
+  CardDescription,
   CardHeader,
   CardTitle,
   CardContent,
@@ -22,6 +24,8 @@ interface UserUsageTableContentProps {
   currentPage: number;
   totalPages: number;
   onPageChange: (page: number) => void;
+  headerAction?: React.ReactNode;
+  description?: React.ReactNode;
 }
 
 export function UserUsageTableContent({
@@ -29,6 +33,8 @@ export function UserUsageTableContent({
   currentPage,
   totalPages,
   onPageChange,
+  headerAction,
+  description,
 }: Readonly<UserUsageTableContentProps>) {
   const { t } = useTranslation('admin-settings-usage');
 
@@ -36,6 +42,8 @@ export function UserUsageTableContent({
     <Card>
       <CardHeader>
         <CardTitle>{t('userUsage.title')}</CardTitle>
+        {description && <CardDescription>{description}</CardDescription>}
+        {headerAction && <CardAction>{headerAction}</CardAction>}
       </CardHeader>
       <CardContent>
         <Table className="w-[750px]">
@@ -45,7 +53,6 @@ export function UserUsageTableContent({
               <TableHead>{t('userUsage.credits')}</TableHead>
               <TableHead>{t('userUsage.requests')}</TableHead>
               <TableHead>{t('userUsage.lastActive')}</TableHead>
-              <TableHead>{t('userUsage.status')}</TableHead>
             </TableRow>
           </TableHeader>
           <TableBody>
@@ -56,7 +63,7 @@ export function UserUsageTableContent({
             ) : (
               <TableRow>
                 <TableCell
-                  colSpan={5}
+                  colSpan={4}
                   className="text-center py-8 text-muted-foreground"
                 >
                   {t('userUsage.emptyState')}

--- a/ayunis-core-frontend/src/widgets/user-usage-table/ui/UserUsageTableEmpty.tsx
+++ b/ayunis-core-frontend/src/widgets/user-usage-table/ui/UserUsageTableEmpty.tsx
@@ -1,5 +1,7 @@
 import {
   Card,
+  CardAction,
+  CardDescription,
   CardHeader,
   CardTitle,
   CardContent,
@@ -14,13 +16,23 @@ import {
 import { useTranslation } from 'react-i18next';
 import { Users } from 'lucide-react';
 
-export function UserUsageTableEmpty() {
+interface UserUsageTableEmptyProps {
+  headerAction?: React.ReactNode;
+  description?: React.ReactNode;
+}
+
+export function UserUsageTableEmpty({
+  headerAction,
+  description,
+}: Readonly<UserUsageTableEmptyProps>) {
   const { t } = useTranslation('admin-settings-usage');
 
   return (
     <Card>
       <CardHeader>
         <CardTitle>{t('userUsage.title')}</CardTitle>
+        {description && <CardDescription>{description}</CardDescription>}
+        {headerAction && <CardAction>{headerAction}</CardAction>}
       </CardHeader>
       <CardContent>
         <Empty>

--- a/ayunis-core-frontend/src/widgets/user-usage-table/ui/UserUsageTableError.tsx
+++ b/ayunis-core-frontend/src/widgets/user-usage-table/ui/UserUsageTableError.tsx
@@ -1,5 +1,6 @@
 import {
   Card,
+  CardAction,
   CardHeader,
   CardTitle,
   CardDescription,
@@ -17,10 +18,14 @@ import { AlertCircle } from 'lucide-react';
 
 interface UserUsageTableErrorProps {
   error: unknown;
+  headerAction?: React.ReactNode;
+  description?: React.ReactNode;
 }
 
 export function UserUsageTableError({
   error,
+  headerAction,
+  description,
 }: Readonly<UserUsageTableErrorProps>) {
   const { t } = useTranslation('admin-settings-usage');
   const errorMessage =
@@ -30,7 +35,8 @@ export function UserUsageTableError({
     <Card>
       <CardHeader>
         <CardTitle>{t('userUsage.title')}</CardTitle>
-        <CardDescription>{t('userUsage.error')}</CardDescription>
+        <CardDescription>{description ?? t('userUsage.error')}</CardDescription>
+        {headerAction && <CardAction>{headerAction}</CardAction>}
       </CardHeader>
       <CardContent>
         <Empty>

--- a/ayunis-core-frontend/src/widgets/user-usage-table/ui/UserUsageTableLoading.tsx
+++ b/ayunis-core-frontend/src/widgets/user-usage-table/ui/UserUsageTableLoading.tsx
@@ -1,5 +1,7 @@
 import {
   Card,
+  CardAction,
+  CardDescription,
   CardHeader,
   CardTitle,
   CardContent,
@@ -7,13 +9,23 @@ import {
 import { Skeleton } from '@/shared/ui/shadcn/skeleton';
 import { useTranslation } from 'react-i18next';
 
-export function UserUsageTableLoading() {
+interface UserUsageTableLoadingProps {
+  headerAction?: React.ReactNode;
+  description?: React.ReactNode;
+}
+
+export function UserUsageTableLoading({
+  headerAction,
+  description,
+}: Readonly<UserUsageTableLoadingProps>) {
   const { t } = useTranslation('admin-settings-usage');
 
   return (
     <Card>
       <CardHeader>
         <CardTitle>{t('userUsage.title')}</CardTitle>
+        {description && <CardDescription>{description}</CardDescription>}
+        {headerAction && <CardAction>{headerAction}</CardAction>}
       </CardHeader>
       <CardContent>
         <div className="space-y-2">

--- a/ayunis-core-frontend/src/widgets/user-usage-table/ui/UserUsageTableRow.tsx
+++ b/ayunis-core-frontend/src/widgets/user-usage-table/ui/UserUsageTableRow.tsx
@@ -1,7 +1,6 @@
 import type { UserUsageDto } from '@/shared/api/generated/ayunisCoreAPI.schemas';
 import { useTranslation } from 'react-i18next';
 import { TableCell, TableRow } from '@/shared/ui/shadcn/table';
-import { Badge } from '@/shared/ui/shadcn/badge';
 import { formatCompactNumber } from '@/shared/lib/formatCompactNumber';
 import { formatRelativeDate } from '@/shared/lib/format-relative-date';
 
@@ -48,11 +47,6 @@ export function UserUsageTableRow({ user }: Readonly<UserUsageTableRowProps>) {
         ) : (
           <span className="text-sm text-muted-foreground">-</span>
         )}
-      </TableCell>
-      <TableCell>
-        <Badge variant={user.isActive ? 'default' : 'secondary'}>
-          {user.isActive ? t('userUsage.active') : t('userUsage.inactive')}
-        </Badge>
       </TableCell>
     </TableRow>
   );

--- a/ayunis-core-frontend/src/widgets/user-usage-table/ui/UserUsageTableWidget.tsx
+++ b/ayunis-core-frontend/src/widgets/user-usage-table/ui/UserUsageTableWidget.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from 'react';
 import type { UserUsageDto } from '@/shared/api/generated/ayunisCoreAPI.schemas';
 import { UserUsageTableContent } from './UserUsageTableContent';
 import { UserUsageTableLoading } from './UserUsageTableLoading';
@@ -13,6 +14,8 @@ interface UserUsageTableWidgetProps {
   onPageChange: (page: number) => void;
   isLoading: boolean;
   error: unknown;
+  headerAction?: ReactNode;
+  description?: ReactNode;
 }
 
 export function UserUsageTableWidget({
@@ -22,12 +25,33 @@ export function UserUsageTableWidget({
   onPageChange,
   isLoading,
   error,
+  headerAction,
+  description,
 }: Readonly<UserUsageTableWidgetProps>) {
   const totalPages = Math.ceil(total / DEFAULT_PAGE_SIZE);
 
-  if (isLoading) return <UserUsageTableLoading />;
-  if (error) return <UserUsageTableError error={error} />;
-  if (total === 0) return <UserUsageTableEmpty />;
+  if (isLoading)
+    return (
+      <UserUsageTableLoading
+        headerAction={headerAction}
+        description={description}
+      />
+    );
+  if (error)
+    return (
+      <UserUsageTableError
+        error={error}
+        headerAction={headerAction}
+        description={description}
+      />
+    );
+  if (total === 0)
+    return (
+      <UserUsageTableEmpty
+        headerAction={headerAction}
+        description={description}
+      />
+    );
 
   return (
     <UserUsageTableContent
@@ -35,6 +59,8 @@ export function UserUsageTableWidget({
       currentPage={currentPage}
       totalPages={totalPages}
       onPageChange={onPageChange}
+      headerAction={headerAction}
+      description={description}
     />
   );
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the `getUserUsage` API contract and multiple usage aggregation queries (notably making `endDate` exclusive), which can affect reported counts/credits and requires consumers to adapt.
> 
> **Overview**
> Adds `totalCredits` to the user-usage API response by changing `UsageRepository.getUserUsage` to return a new `UserUsageResult` containing both paginated users and an org-wide credit sum (computed via new `sumCreditsForOrg`).
> 
> Updates usage date filtering across the persistence query helpers to treat `endDate` as *exclusive* (`createdAt < endDate`) and rounds credit values when mapping DB rows.
> 
> Frontend admin user-usage table now uses a new month picker to query a calendar-month `[start, nextMonthStart)` range and displays the returned `totalCredits` in the table header; the table UI also removes the per-user active/inactive status column and threads header actions/descriptions through loading/empty/error states.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 15c9ed283fd3f013c4a6a8a51b103b00751b31ef. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->