### PR TITLE
fix(AYC-000): map transient mistral api errors to service busy/timeout responses

### DIFF
--- a/ayunis-core-backend/src/domain/retrievers/file-retrievers/infrastructure/adapters/mistral-file-retriever.handler.spec.ts
+++ b/ayunis-core-backend/src/domain/retrievers/file-retrievers/infrastructure/adapters/mistral-file-retriever.handler.spec.ts
@@ -1,0 +1,157 @@
+import { Test } from '@nestjs/testing';
+import type { TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { MistralFileRetrieverHandler } from './mistral-file-retriever.handler';
+import {
+  FileRetrieverUnexpectedError,
+  ServiceBusyError,
+  ServiceTimeoutError,
+} from '../../application/file-retriever.errors';
+import { MistralError } from '@mistralai/mistralai/models/errors';
+import { File } from '../../domain/file.entity';
+
+// Mock the Mistral SDK
+jest.mock('@mistralai/mistralai', () => ({
+  Mistral: jest.fn().mockImplementation(() => ({
+    files: {
+      upload: jest.fn(),
+      getSignedUrl: jest.fn(),
+      delete: jest.fn(),
+    },
+    ocr: {
+      process: jest.fn(),
+    },
+  })),
+}));
+
+// Mock retryWithBackoff to execute fn directly (no retries in tests)
+jest.mock('src/common/util/retryWithBackoff', () => ({
+  __esModule: true,
+  default: ({ fn }: { fn: () => Promise<unknown> }) => fn(),
+}));
+
+function createMistralError(statusCode: number, body: string): MistralError {
+  const response = {
+    status: statusCode,
+    headers: new Headers({ 'content-type': 'application/json' }),
+    url: 'https://api.mistral.ai/v1/ocr',
+  } as unknown as Response;
+  const request = {} as Request;
+  const error = new MistralError(`API error: ${statusCode}`, {
+    response,
+    request,
+    body,
+  });
+  return error;
+}
+
+describe('MistralFileRetrieverHandler', () => {
+  let handler: MistralFileRetrieverHandler;
+  let mockClient: {
+    files: {
+      upload: jest.Mock;
+      getSignedUrl: jest.Mock;
+      delete: jest.Mock;
+    };
+    ocr: { process: jest.Mock };
+  };
+
+  const testFile = new File(
+    Buffer.from('fake pdf content'),
+    'test-document.pdf',
+    'application/pdf',
+  );
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        MistralFileRetrieverHandler,
+        {
+          provide: ConfigService,
+          useValue: {
+            get: jest.fn().mockReturnValue('test-api-key'),
+          },
+        },
+      ],
+    }).compile();
+
+    handler = module.get(MistralFileRetrieverHandler);
+    // Access the mocked client created by the constructor
+    mockClient = (handler as unknown as { client: typeof mockClient }).client;
+  });
+
+  describe('transient upstream error handling', () => {
+    beforeEach(() => {
+      // Setup upload and signedUrl to succeed — error on OCR process
+      mockClient.files.upload.mockResolvedValue({ id: 'file-123' });
+      mockClient.files.getSignedUrl.mockResolvedValue({
+        url: 'https://signed.url',
+      });
+      mockClient.files.delete.mockResolvedValue(undefined);
+    });
+
+    it('should throw ServiceBusyError when Mistral returns 502', async () => {
+      const mistralError = createMistralError(
+        502,
+        '{"message":"An invalid response was received from the upstream server"}',
+      );
+      mockClient.ocr.process.mockRejectedValue(mistralError);
+
+      await expect(handler.processFile(testFile)).rejects.toThrow(
+        ServiceBusyError,
+      );
+    });
+
+    it('should throw ServiceBusyError when Mistral returns 503', async () => {
+      const mistralError = createMistralError(
+        503,
+        '{"message":"Service temporarily unavailable"}',
+      );
+      mockClient.ocr.process.mockRejectedValue(mistralError);
+
+      await expect(handler.processFile(testFile)).rejects.toThrow(
+        ServiceBusyError,
+      );
+    });
+
+    it('should throw ServiceTimeoutError when Mistral returns 504', async () => {
+      const mistralError = createMistralError(
+        504,
+        '{"message":"Gateway timeout"}',
+      );
+      mockClient.ocr.process.mockRejectedValue(mistralError);
+
+      await expect(handler.processFile(testFile)).rejects.toThrow(
+        ServiceTimeoutError,
+      );
+    });
+
+    it('should throw FileRetrieverUnexpectedError for non-transient Mistral errors', async () => {
+      const mistralError = createMistralError(400, '{"message":"Bad request"}');
+      mockClient.ocr.process.mockRejectedValue(mistralError);
+
+      await expect(handler.processFile(testFile)).rejects.toThrow(
+        FileRetrieverUnexpectedError,
+      );
+    });
+
+    it('should throw FileRetrieverUnexpectedError for non-Mistral errors', async () => {
+      mockClient.ocr.process.mockRejectedValue(
+        new Error('Network connection lost'),
+      );
+
+      await expect(handler.processFile(testFile)).rejects.toThrow(
+        FileRetrieverUnexpectedError,
+      );
+    });
+
+    it('should throw ServiceBusyError when file upload returns 502', async () => {
+      const mistralError = createMistralError(502, '{"message":"Bad gateway"}');
+      mockClient.files.upload.mockRejectedValue(mistralError);
+
+      await expect(handler.processFile(testFile)).rejects.toThrow(
+        ServiceBusyError,
+      );
+    });
+  });
+});

--- a/ayunis-core-backend/src/domain/retrievers/file-retrievers/infrastructure/adapters/mistral-file-retriever.handler.ts
+++ b/ayunis-core-backend/src/domain/retrievers/file-retrievers/infrastructure/adapters/mistral-file-retriever.handler.ts
@@ -7,7 +7,10 @@ import {
 import {
   FileRetrievalFailedError,
   FileRetrieverUnexpectedError,
+  ServiceBusyError,
+  ServiceTimeoutError,
 } from '../../application/file-retriever.errors';
+import { MistralError } from '@mistralai/mistralai/models/errors';
 import { Mistral } from '@mistralai/mistralai';
 import { OCRResponse } from '@mistralai/mistralai/models/components';
 import retryWithBackoff from 'src/common/util/retryWithBackoff';
@@ -122,9 +125,19 @@ export class MistralFileRetrieverHandler extends FileRetrieverHandler {
         `Mistral OCR processing failed: ${error instanceof Error ? error.message : 'Unknown error'}`,
         error instanceof Error ? error.stack : 'Unknown error',
       );
-      throw new FileRetrieverUnexpectedError(error as Error, {
-        model: this.MODEL_NAME,
-      });
+
+      const metadata = { model: this.MODEL_NAME };
+
+      if (error instanceof MistralError) {
+        if (error.statusCode === 502 || error.statusCode === 503) {
+          throw new ServiceBusyError(metadata);
+        }
+        if (error.statusCode === 504) {
+          throw new ServiceTimeoutError(metadata);
+        }
+      }
+
+      throw new FileRetrieverUnexpectedError(error as Error, metadata);
     }
   }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes how Mistral OCR failures are surfaced by mapping specific 5xx responses to `503`/`504`, which can affect client retry behavior and error handling. Scoped to error translation and covered by new unit tests, so overall risk is moderate.
> 
> **Overview**
> Improves Mistral OCR error handling by translating transient Mistral API failures into domain errors: `502`/`503` now throw `ServiceBusyError` and `504` throws `ServiceTimeoutError` (instead of always `FileRetrieverUnexpectedError`), while keeping other errors as unexpected.
> 
> Adds a focused unit test suite for `MistralFileRetrieverHandler` that mocks the Mistral SDK and validates the new status-to-error mappings for both OCR processing and file upload failures.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3d43eace94a8849a03db004827f8bd866d1c6fd3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->