### PR TITLE
fix(AYC-000): use shared error handler for knowledge base document uploads

### DIFF
--- a/ayunis-core-frontend/src/pages/knowledge-base/api/useUploadDocument.ts
+++ b/ayunis-core-frontend/src/pages/knowledge-base/api/useUploadDocument.ts
@@ -1,10 +1,11 @@
 import { useQueryClient } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
-import { showSuccess, showError } from '@/shared/lib/toast';
+import { showSuccess } from '@/shared/lib/toast';
 import {
   useKnowledgeBasesControllerAddDocument,
   getKnowledgeBasesControllerListDocumentsQueryKey,
 } from '@/shared/api/generated/ayunisCoreAPI';
+import handleSourceUploadError from '@/shared/lib/handle-source-upload-error';
 
 export function useUploadDocument(knowledgeBaseId: string) {
   const { t } = useTranslation('knowledge-bases');
@@ -19,8 +20,8 @@ export function useUploadDocument(knowledgeBaseId: string) {
         });
         showSuccess(t('detail.documents.uploadSuccess'));
       },
-      onError: () => {
-        showError(t('detail.documents.uploadError'));
+      onError: (error: unknown) => {
+        handleSourceUploadError(error, t);
       },
     },
   });

--- a/ayunis-core-frontend/src/shared/locales/de/knowledge-bases.json
+++ b/ayunis-core-frontend/src/shared/locales/de/knowledge-bases.json
@@ -156,5 +156,14 @@
       "removeError": "Dokument konnte nicht entfernt werden. Bitte versuchen Sie es erneut.",
       "urlDialogCancel": "Abbrechen"
     }
+  },
+  "sources": {
+    "failedToAdd": "Dokument konnte nicht hochgeladen werden. Bitte versuchen Sie es erneut.",
+    "invalidFileTypeError": "Dieser Dateityp wird derzeit nicht unterstützt.",
+    "fileSourceEmptyDataError": "Die hochgeladene Datei enthält keine verarbeitbaren Daten.",
+    "fileSourceTooLargeError": "Datei ist zu groß. Maximale Dateigröße beträgt 50 MB.",
+    "fileSourceTooManyPagesError": "Das Dokument hat zu viele Seiten zur Verarbeitung.",
+    "fileSourceServiceBusyError": "Der Dokumentenverarbeitungsdienst ist beschäftigt. Bitte versuchen Sie es später erneut.",
+    "fileSourceTimeoutError": "Dokumentenverarbeitung hat das Zeitlimit überschritten. Die Datei ist möglicherweise zu komplex."
   }
 }

--- a/ayunis-core-frontend/src/shared/locales/en/knowledge-bases.json
+++ b/ayunis-core-frontend/src/shared/locales/en/knowledge-bases.json
@@ -156,5 +156,14 @@
       "removeError": "Failed to remove document. Please try again.",
       "urlDialogCancel": "Cancel"
     }
+  },
+  "sources": {
+    "failedToAdd": "Failed to upload document. Please try again.",
+    "invalidFileTypeError": "This file type is currently not supported.",
+    "fileSourceEmptyDataError": "The uploaded file contains no processable data.",
+    "fileSourceTooLargeError": "File is too large. Maximum file size is 50MB.",
+    "fileSourceTooManyPagesError": "Document has too many pages to process.",
+    "fileSourceServiceBusyError": "The document processing service is busy. Please try again later.",
+    "fileSourceTimeoutError": "Document processing timed out. The file may be too complex."
   }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk UI-only change that alters how upload errors are mapped to toast messages. Main risk is missing/incorrect i18n keys or backend error-code mismatches leading to less helpful error feedback.
> 
> **Overview**
> Knowledge base document uploads now route failures through the shared `handleSourceUploadError` helper instead of showing a single generic error toast, enabling specific messages for known backend error codes.
> 
> Adds `knowledge-bases` i18n strings under `sources.*` (EN/DE) to support these more detailed upload error toasts (e.g., unsupported type, too large, timeout, service busy).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit debb084cf529637084a23e4b8f001d0bd44d4656. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->