### PR TITLE
feat(sources): process uploads async (AYC-108)

### DIFF
--- a/ayunis-core-frontend/src/pages/knowledge-base/api/useUploadDocument.ts
+++ b/ayunis-core-frontend/src/pages/knowledge-base/api/useUploadDocument.ts
@@ -1,10 +1,11 @@
 import { useQueryClient } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
-import { showSuccess } from '@/shared/lib/toast';
+import { showSuccess, showInfo, showError } from '@/shared/lib/toast';
 import {
   useKnowledgeBasesControllerAddDocument,
   getKnowledgeBasesControllerListDocumentsQueryKey,
 } from '@/shared/api/generated/ayunisCoreAPI';
+import { KnowledgeBaseDocumentResponseDtoStatus } from '@/shared/api/generated/ayunisCoreAPI.schemas';
 import handleSourceUploadError from '@/shared/lib/handle-source-upload-error';
 
 export function useUploadDocument(knowledgeBaseId: string) {
@@ -13,12 +14,20 @@ export function useUploadDocument(knowledgeBaseId: string) {
 
   const mutation = useKnowledgeBasesControllerAddDocument({
     mutation: {
-      onSuccess: () => {
+      onSuccess: (data) => {
         void queryClient.invalidateQueries({
           queryKey:
             getKnowledgeBasesControllerListDocumentsQueryKey(knowledgeBaseId),
         });
-        showSuccess(t('detail.documents.uploadSuccess'));
+        if (data.status === KnowledgeBaseDocumentResponseDtoStatus.processing) {
+          showInfo(t('detail.documents.uploadAccepted'));
+        } else if (
+          data.status === KnowledgeBaseDocumentResponseDtoStatus.failed
+        ) {
+          showError(data.processingError ?? t('detail.documents.statusFailed'));
+        } else {
+          showSuccess(t('detail.documents.uploadSuccess'));
+        }
       },
       onError: (error: unknown) => {
         handleSourceUploadError(error, t);

--- a/ayunis-core-frontend/src/shared/api/openapi-schema.json
+++ b/ayunis-core-frontend/src/shared/api/openapi-schema.json
@@ -5385,8 +5385,8 @@
           }
         },
         "responses": {
-          "201": {
-            "description": "The document has been added to the knowledge base",
+          "202": {
+            "description": "The document has been accepted and is being processed in the background",
             "content": {
               "application/json": {
                 "schema": {

--- a/ayunis-core-frontend/src/shared/lib/toast.ts
+++ b/ayunis-core-frontend/src/shared/lib/toast.ts
@@ -7,3 +7,7 @@ export function showSuccess(message: string) {
 export function showError(message: string) {
   toast.error(message, { position: 'bottom-center', closeButton: true });
 }
+
+export function showInfo(message: string) {
+  toast.info(message, { position: 'bottom-center', closeButton: true });
+}

--- a/ayunis-core-frontend/src/shared/locales/de/knowledge-bases.json
+++ b/ayunis-core-frontend/src/shared/locales/de/knowledge-bases.json
@@ -142,6 +142,7 @@
       "upload": "Hochladen",
       "empty": "Noch keine Dokumente hochgeladen. Laden Sie eine PDF- oder DOCX-Datei hoch, um zu beginnen.",
       "uploadSuccess": "Dokument erfolgreich hochgeladen!",
+      "uploadAccepted": "Dokument hochgeladen — wird im Hintergrund verarbeitet...",
       "uploadError": "Dokument konnte nicht hochgeladen werden. Bitte versuchen Sie es erneut.",
       "addUrl": "URL hinzufügen",
       "urlPlaceholder": "https://beispiel.de",

--- a/ayunis-core-frontend/src/shared/locales/en/knowledge-bases.json
+++ b/ayunis-core-frontend/src/shared/locales/en/knowledge-bases.json
@@ -142,6 +142,7 @@
       "upload": "Upload",
       "empty": "No documents uploaded yet. Upload a PDF or DOCX file to get started.",
       "uploadSuccess": "Document uploaded successfully!",
+      "uploadAccepted": "Document uploaded — processing in the background...",
       "uploadError": "Failed to upload document. Please try again.",
       "addUrl": "Add URL",
       "urlPlaceholder": "https://example.com",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk UI/API-client update that adjusts to a `202 Accepted` response and adds toast messaging based on returned processing status. Main risk is mismatched backend status/DTO values causing incorrect user feedback.
> 
> **Overview**
> Knowledge base document uploads now treat the add-document call as *asynchronous*: the OpenAPI spec switches the success response from `201` to `202`, and the upload hook (`useUploadDocument`) reacts to the returned `status`.
> 
> On upload success, the UI shows **info** when the document is *accepted/processing*, **error** when processing *failed* (including `processingError`), and otherwise the existing **success** toast; an `showInfo` toast helper and new `uploadAccepted` i18n strings (EN/DE) were added.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7a53aa85e587ee55adfcc5ecfb60b3d407cbf6a6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->