### PR TITLE
fix(AYC-000): save source assignments directly to avoid TypeORM cascade orphan bug

### DIFF
--- a/ayunis-core-backend/src/domain/threads/infrastructure/persistence/local/local-thread-assignments.repository.ts
+++ b/ayunis-core-backend/src/domain/threads/infrastructure/persistence/local/local-thread-assignments.repository.ts
@@ -56,8 +56,7 @@ export class LocalThreadAssignmentsRepository {
       this.sourceAssignmentMapper.toRecord(assignment, params.threadId),
     );
 
-    threadEntity.sourceAssignments = sourceAssignmentRecords;
-    await this.threadRepository.save(threadEntity);
+    await this.threadSourceAssignmentRepository.save(sourceAssignmentRecords);
   }
 
   async updateMcpIntegrations(params: {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes how thread source assignments are persisted by bypassing `ThreadRecord` cascade saves, which could affect insert/update behavior and orphan cleanup if entity mappings or constraints differ from expectations.
> 
> **Overview**
> Fixes `updateSourceAssignments` so source assignment changes are persisted by saving `ThreadSourceAssignmentRecord` entities directly instead of mutating `threadEntity.sourceAssignments` and saving the parent thread.
> 
> This avoids relying on TypeORM cascade/orphan handling when updating assignments, while keeping the existing explicit delete of removed assignments.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d93aeeb845a5de42ade300441ccfb1ea9be93716. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->