### PR TITLE
feat: open markdown links in new window with target=_blank

### DIFF
--- a/ayunis-core-frontend/src/widgets/markdown/ui/Markdown.tsx
+++ b/ayunis-core-frontend/src/widgets/markdown/ui/Markdown.tsx
@@ -19,6 +19,11 @@ interface TableComponentProps {
   children?: ReactNode;
 }
 
+interface AnchorComponentProps {
+  href?: string;
+  children?: ReactNode;
+}
+
 function Markdown({ children, className = '' }: Readonly<MarkdownProps>) {
   return (
     <div
@@ -85,6 +90,11 @@ function Markdown({ children, className = '' }: Readonly<MarkdownProps>) {
           ),
           td: ({ children }: TableComponentProps) => (
             <td className="px-2 py-2 text-foreground">{children}</td>
+          ),
+          a: ({ href, children }: AnchorComponentProps) => (
+            <a href={href} target="_blank" rel="noopener noreferrer">
+              {children}
+            </a>
           ),
         }}
       >


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When users click links rendered in chat markdown (e.g. documents or URLs returned by Ayunis Core), the browser navigates away from the app, replacing the current view. This PR makes all markdown links open in a **new browser tab** instead.

## Changes

- **`ayunis-core-frontend/src/widgets/markdown/ui/Markdown.tsx`**: Added a custom `a` component to the `ReactMarkdown` `components` prop that sets `target="_blank"` and `rel="noopener noreferrer"` on every rendered link.

## Context

From Slack (#product-improvements): "Wenn man sich über Ayunis Core Dokumente oder Links suchen lässt und diese dann klickt, wird Ayunis Core mit dem Inhalt des jeweiligen Dokuments ersetzt. Hier wäre es sinnvoller, dass neben Ayunis Core ein neues Fenster geöffnet wird."

## Testing

- Open a chat conversation where the assistant returns markdown links
- Click any link — it should open in a new browser tab
- The Ayunis Core window should remain open and unchanged
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://locaboo.slack.com/archives/C0375HX2C4S/p1774244913244539?thread_ts=1774244913.244539&cid=C0375HX2C4S)

<div><a href="https://cursor.com/agents/bc-a93d6e10-a683-5c2f-b88b-2355c79c9d6f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a93d6e10-a683-5c2f-b88b-2355c79c9d6f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

