### PR TITLE
fix(chat): preserve display-only tool_use messages from cleanup deletion (AYC-000)

### DIFF
--- a/ayunis-core-backend/src/domain/runs/SUMMARY.md
+++ b/ayunis-core-backend/src/domain/runs/SUMMARY.md
@@ -12,7 +12,7 @@ The runs module is the central orchestrator for AI conversation execution. The `
 - **StreamingInferenceService** — Executes streaming inference, accumulates response chunks into partial `AssistantMessage` updates, and persists the final result. Handles usage collection from streaming chunks.
 - **CollectUsageAsyncService** — Collects usage data asynchronously (fire-and-forget). Errors are logged but don't block the main flow.
 - **CreditBudgetGuardService** — Orchestrates a pre-run credit-budget check by combining `GetMonthlyCreditLimitUseCase` (from subscriptions) and `GetMonthlyCreditUsageUseCase` (from usage). Throws `CreditBudgetExceededError` when the organization's monthly credit limit is reached. Lives in the runs module because it is the run execution flow that needs this cross-domain decision.
-- **MessageCleanupService** — Ensures threads end with a valid assistant message after a run completes or is interrupted by deleting trailing non-assistant messages and assistant messages with orphaned `tool_use` content (tool calls without corresponding tool results).
+- **MessageCleanupService** — Cleans up threads after a failed or interrupted run by deleting trailing non-assistant messages and assistant messages with orphaned `tool_use` content (tool calls without corresponding tool results). Only called on the error path — successful runs leave the thread in a valid state by design.
 - **SystemPromptBuilderService** — Builds system prompts from agent configuration, thread context, and active skills. Accepts `SkillEntry[]` (slug + description) instead of `Skill[]` — the slug is used as the skill name in the prompt.
 
 ### Helpers

--- a/ayunis-core-backend/src/domain/runs/application/services/message-cleanup.service.ts
+++ b/ayunis-core-backend/src/domain/runs/application/services/message-cleanup.service.ts
@@ -10,9 +10,13 @@ import { FindThreadUseCase } from 'src/domain/threads/application/use-cases/find
 import { FindThreadQuery } from 'src/domain/threads/application/use-cases/find-thread/find-thread.query';
 
 /**
- * Ensures threads end with an assistant message after a run completes or is interrupted.
- * Deletes trailing non-assistant messages (e.g., tool results) that would leave the
- * conversation in an inconsistent state.
+ * Cleans up threads after a failed or interrupted run.
+ * Deletes trailing non-assistant messages (e.g., tool results) and orphaned
+ * tool_use assistant messages that would leave the conversation in an
+ * inconsistent state for providers requiring tool_use → tool_result pairing.
+ *
+ * Only called on the error path — successful runs leave the thread in a
+ * valid state by design.
  */
 @Injectable()
 export class MessageCleanupService {
@@ -24,15 +28,10 @@ export class MessageCleanupService {
   ) {}
 
   /**
-   * Ensures the thread ends with an assistant message by deleting any trailing messages
-   * that come after the specified saved assistant message. This is critical when the stream
-   * is interrupted - we need to delete any trailing non-assistant messages (like tool results)
-   * to maintain conversation integrity.
+   * Ensures the thread ends with a clean assistant message (no tool_use)
+   * by deleting trailing non-assistant messages and orphaned tool_use messages.
    */
-  async cleanupTrailingNonAssistantMessages(
-    threadId: UUID,
-    savedMessageId: UUID | null,
-  ): Promise<void> {
+  async cleanupTrailingNonAssistantMessages(threadId: UUID): Promise<void> {
     try {
       const { thread: updatedThread } = await this.findThreadUseCase.execute(
         new FindThreadQuery(threadId),
@@ -44,79 +43,13 @@ export class MessageCleanupService {
         return;
       }
 
-      if (savedMessageId) {
-        await this.cleanupAfterSavedMessage(
-          threadId,
-          threadMessages,
-          savedMessageId,
-        );
-      } else {
-        await this.deleteMessagesUntilAssistant(threadId, threadMessages);
-      }
+      await this.deleteMessagesUntilAssistant(threadId, threadMessages);
     } catch (error) {
       this.logger.error('Error during message cleanup', {
         threadId,
         error: error as Error,
       });
       // Don't throw - we want to gracefully handle cleanup failures
-    }
-  }
-
-  private async cleanupAfterSavedMessage(
-    threadId: UUID,
-    threadMessages: Message[],
-    savedMessageId: UUID,
-  ): Promise<void> {
-    const savedMessageIndex = threadMessages.findIndex(
-      (m) => m.id === savedMessageId,
-    );
-
-    if (savedMessageIndex === -1) {
-      this.logger.warn('Saved assistant message not found in thread', {
-        threadId,
-        assistantMessageId: savedMessageId,
-      });
-      await this.deleteMessagesUntilAssistant(threadId, threadMessages);
-      return;
-    }
-
-    const savedMessage = threadMessages[savedMessageIndex];
-    const messagesAfterAssistant = threadMessages.slice(savedMessageIndex + 1);
-
-    // First, delete any trailing messages after the saved assistant message
-    if (messagesAfterAssistant.length > 0) {
-      this.logger.log(
-        'Found messages after saved assistant message, cleaning up',
-        {
-          threadId,
-          assistantMessageId: savedMessageId,
-          messagesAfterCount: messagesAfterAssistant.length,
-        },
-      );
-      await this.deleteTrailingMessages(threadId, messagesAfterAssistant);
-    }
-
-    // Check if the saved assistant message has orphaned tool_use content.
-    // This can happen when:
-    // - There were no trailing messages but the run was interrupted after
-    //   saving tool_use but before tool execution
-    // - Trailing messages (including tool_results) were just deleted above
-    // In either case, tool_use without tool_result corrupts the conversation.
-    if (this.hasToolUseContent(savedMessage)) {
-      this.logger.log(
-        'Saved assistant message has orphaned tool_use, deleting',
-        { threadId, assistantMessageId: savedMessageId },
-      );
-      const remaining = threadMessages.slice(0, savedMessageIndex);
-      await this.deleteMessagesUntilAssistant(threadId, [
-        ...remaining,
-        savedMessage,
-      ]);
-    } else if (messagesAfterAssistant.length === 0) {
-      this.logger.debug('Thread correctly ends with assistant message', {
-        threadId,
-        lastMessageId: savedMessageId,
-      });
     }
   }
 

--- a/ayunis-core-backend/src/domain/runs/application/use-cases/execute-run/execute-run.use-case.ts
+++ b/ayunis-core-backend/src/domain/runs/application/use-cases/execute-run/execute-run.use-case.ts
@@ -181,6 +181,7 @@ export class ExecuteRunUseCase {
   ): AsyncGenerator<Message, void, void> {
     this.logger.log('orchestrateRun', { threadId: params.thread.id });
     const iterations = 20;
+    let succeeded = false;
     try {
       for (let i = 0; i < iterations; i++) {
         this.logger.debug('iteration', i);
@@ -206,6 +207,7 @@ export class ExecuteRunUseCase {
           throw new RunMaxIterationsReachedError(iterations);
         }
       }
+      succeeded = true;
     } catch (error) {
       if (error instanceof ApplicationError) throw error;
       this.logger.error('Run execution failed', { error: error as Error });
@@ -214,10 +216,17 @@ export class ExecuteRunUseCase {
         { originalError: error as Error },
       );
     } finally {
-      await this.messageCleanupService.cleanupTrailingNonAssistantMessages(
-        params.thread.id,
-        null,
-      );
+      // Clean up orphaned messages only on failure/interruption.
+      // On the success path the orchestration loop already leaves the
+      // thread in a valid state — running cleanup there risks deleting
+      // intentional terminal messages (e.g., display-only tool_use).
+      // Using finally (not catch) so cleanup also runs when the generator
+      // is early-returned via .return() on client disconnect.
+      if (!succeeded) {
+        await this.messageCleanupService.cleanupTrailingNonAssistantMessages(
+          params.thread.id,
+        );
+      }
     }
   }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes when post-run cleanup deletes messages, which can affect thread history correctness if the success/failure detection is wrong or new edge cases occur (e.g., early generator termination). Scope is limited to run orchestration cleanup behavior.
> 
> **Overview**
> Prevents post-run cleanup from running on successful runs, so terminal *display-only* `tool_use` assistant messages aren’t accidentally deleted.
> 
> `ExecuteRunUseCase.orchestrateRun` now tracks success and only calls `MessageCleanupService.cleanupTrailingNonAssistantMessages` on failure/interruption (still in `finally` to cover client disconnects). `MessageCleanupService` is simplified to always clean from the end of the thread (removing the prior `savedMessageId`-based path), deleting trailing non-assistant messages and orphaned `tool_use` assistant messages.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e4411472ef72622764de6fcfad168a226e49b30c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->