### PR TITLE
feat(letterheads): Allow letterheads for pdf exports of documents (AYC-101)

### DIFF
--- a/ayunis-core-backend/src/db/migrations/1773706000224-AddLetterheadIdToArtifacts.ts
+++ b/ayunis-core-backend/src/db/migrations/1773706000224-AddLetterheadIdToArtifacts.ts
@@ -1,18 +1,29 @@
-import { MigrationInterface, QueryRunner } from "typeorm";
+import type { MigrationInterface, QueryRunner } from 'typeorm';
 
 export class AddLetterheadIdToArtifacts1773706000224 implements MigrationInterface {
-    name = 'AddLetterheadIdToArtifacts1773706000224'
+  name = 'AddLetterheadIdToArtifacts1773706000224';
 
-    public async up(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.query(`ALTER TABLE "artifacts" ADD "letterheadId" character varying`);
-        await queryRunner.query(`CREATE INDEX "IDX_ab4dde61f4eb04ba072c26a5a2" ON "artifacts" ("letterheadId") `);
-        await queryRunner.query(`ALTER TABLE "artifacts" ADD CONSTRAINT "FK_ab4dde61f4eb04ba072c26a5a2c" FOREIGN KEY ("letterheadId") REFERENCES "letterheads"("id") ON DELETE SET NULL ON UPDATE NO ACTION`);
-    }
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "artifacts" ADD "letterheadId" character varying`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_ab4dde61f4eb04ba072c26a5a2" ON "artifacts" ("letterheadId") `,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "artifacts" ADD CONSTRAINT "FK_ab4dde61f4eb04ba072c26a5a2c" FOREIGN KEY ("letterheadId") REFERENCES "letterheads"("id") ON DELETE SET NULL ON UPDATE NO ACTION`,
+    );
+  }
 
-    public async down(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.query(`ALTER TABLE "artifacts" DROP CONSTRAINT "FK_ab4dde61f4eb04ba072c26a5a2c"`);
-        await queryRunner.query(`DROP INDEX "public"."IDX_ab4dde61f4eb04ba072c26a5a2"`);
-        await queryRunner.query(`ALTER TABLE "artifacts" DROP COLUMN "letterheadId"`);
-    }
-
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "artifacts" DROP CONSTRAINT "FK_ab4dde61f4eb04ba072c26a5a2c"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_ab4dde61f4eb04ba072c26a5a2"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "artifacts" DROP COLUMN "letterheadId"`,
+    );
+  }
 }

--- a/ayunis-core-backend/src/domain/artifacts/application/use-cases/create-artifact/create-artifact.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/artifacts/application/use-cases/create-artifact/create-artifact.use-case.spec.ts
@@ -112,8 +112,7 @@ describe('CreateArtifactUseCase', () => {
   });
 
   it('should create an artifact with letterheadId when provided', async () => {
-    const mockLetterheadId =
-      '423e4567-e89b-12d3-a456-426614174000' as UUID;
+    const mockLetterheadId = '423e4567-e89b-12d3-a456-426614174000' as UUID;
 
     const command = new CreateArtifactCommand({
       threadId: mockThreadId,
@@ -361,8 +360,7 @@ describe('CreateArtifactUseCase', () => {
   });
 
   it('should validate letterheadId belongs to org when provided', async () => {
-    const mockLetterheadId =
-      '423e4567-e89b-12d3-a456-426614174000' as UUID;
+    const mockLetterheadId = '423e4567-e89b-12d3-a456-426614174000' as UUID;
 
     const command = new CreateArtifactCommand({
       threadId: mockThreadId,
@@ -385,8 +383,7 @@ describe('CreateArtifactUseCase', () => {
   });
 
   it('should throw LetterheadNotFoundError when letterheadId does not belong to org', async () => {
-    const crossOrgLetterheadId =
-      '523e4567-e89b-12d3-a456-426614174000' as UUID;
+    const crossOrgLetterheadId = '523e4567-e89b-12d3-a456-426614174000' as UUID;
 
     findLetterheadUseCase.execute.mockRejectedValue(
       new LetterheadNotFoundError(crossOrgLetterheadId),

--- a/ayunis-core-backend/src/domain/artifacts/infrastructure/export/pdf-letterhead-compositor.spec.ts
+++ b/ayunis-core-backend/src/domain/artifacts/infrastructure/export/pdf-letterhead-compositor.spec.ts
@@ -59,14 +59,22 @@ describe('PdfLetterheadCompositor', () => {
     expect(outputDoc.getPageCount()).toBe(3);
   });
 
-  it('should copy continuation pages as-is when no continuation background is provided', async () => {
-    const contentPdf = await createMultiPagePdf(2);
+  it('should use first-page background for continuation pages when no continuation background is provided', async () => {
+    const contentPdf = await createMultiPagePdf(3);
     const firstPagePdf = await createSinglePagePdf('First BG');
 
     const result = await compositor.composite(contentPdf, firstPagePdf);
 
     const outputDoc = await PDFDocument.load(result);
-    expect(outputDoc.getPageCount()).toBe(2);
+    expect(outputDoc.getPageCount()).toBe(3);
+
+    // All pages should have the same dimensions (background was applied)
+    for (let i = 0; i < 3; i++) {
+      const page = outputDoc.getPage(i);
+      const { width, height } = page.getSize();
+      expect(width).toBeCloseTo(595.28, 1);
+      expect(height).toBeCloseTo(841.89, 1);
+    }
   });
 
   it('should produce a valid PDF buffer', async () => {

--- a/ayunis-core-backend/src/domain/artifacts/infrastructure/export/pdf-letterhead-compositor.ts
+++ b/ayunis-core-backend/src/domain/artifacts/infrastructure/export/pdf-letterhead-compositor.ts
@@ -43,22 +43,18 @@ export class PdfLetterheadCompositor {
 
     for (let i = 0; i < contentPageCount; i++) {
       const isFirstPage = i === 0;
-      const embeddedBg = isFirstPage ? embeddedFirstBg : embeddedContinuationBg;
+      const embeddedBg = isFirstPage
+        ? embeddedFirstBg
+        : (embeddedContinuationBg ?? embeddedFirstBg);
 
-      if (embeddedBg) {
-        const contentPage = contentDoc.getPage(i);
-        const { width, height } = contentPage.getSize();
+      const contentPage = contentDoc.getPage(i);
+      const { width, height } = contentPage.getSize();
 
-        const outputPage = outputDoc.addPage([width, height]);
-        outputPage.drawPage(embeddedBg, { x: 0, y: 0, width, height });
+      const outputPage = outputDoc.addPage([width, height]);
+      outputPage.drawPage(embeddedBg, { x: 0, y: 0, width, height });
 
-        const [embeddedContent] = await outputDoc.embedPdf(contentDoc, [i]);
-        outputPage.drawPage(embeddedContent, { x: 0, y: 0, width, height });
-      } else {
-        // No background for this page type — copy content page as-is
-        const [copiedPage] = await outputDoc.copyPages(contentDoc, [i]);
-        outputDoc.addPage(copiedPage);
-      }
+      const [embeddedContent] = await outputDoc.embedPdf(contentDoc, [i]);
+      outputPage.drawPage(embeddedContent, { x: 0, y: 0, width, height });
     }
 
     const outputBytes = await outputDoc.save();

--- a/ayunis-core-backend/src/domain/models/application/use-cases/create-team-permitted-model/create-team-permitted-model.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/create-team-permitted-model/create-team-permitted-model.use-case.spec.ts
@@ -65,9 +65,11 @@ describe('CreateTeamPermittedModelUseCase', () => {
     } as unknown as jest.Mocked<ModelsRepository>;
 
     getTeamUseCase = {
-      execute: jest.fn().mockResolvedValue(
-        new Team({ name: 'test-team', orgId, modelOverrideEnabled: false }),
-      ),
+      execute: jest
+        .fn()
+        .mockResolvedValue(
+          new Team({ name: 'test-team', orgId, modelOverrideEnabled: false }),
+        ),
     } as unknown as jest.Mocked<GetTeamUseCase>;
 
     contextService = {

--- a/ayunis-core-backend/src/domain/models/application/use-cases/delete-team-permitted-model/delete-team-permitted-model.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/delete-team-permitted-model/delete-team-permitted-model.use-case.spec.ts
@@ -51,9 +51,11 @@ describe('DeleteTeamPermittedModelUseCase', () => {
     } as unknown as jest.Mocked<PermittedModelsRepository>;
 
     getTeamUseCase = {
-      execute: jest.fn().mockResolvedValue(
-        new Team({ name: 'test-team', orgId, modelOverrideEnabled: false }),
-      ),
+      execute: jest
+        .fn()
+        .mockResolvedValue(
+          new Team({ name: 'test-team', orgId, modelOverrideEnabled: false }),
+        ),
     } as unknown as jest.Mocked<GetTeamUseCase>;
 
     contextService = {

--- a/ayunis-core-backend/src/domain/models/application/use-cases/get-effective-language-models/get-effective-language-models.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/get-effective-language-models/get-effective-language-models.use-case.ts
@@ -69,9 +69,7 @@ export class GetEffectiveLanguageModelsUseCase {
       new FindTeamsByUserIdQuery(userId),
     );
     const orgTeams = allTeams.filter((team) => team.orgId === orgId);
-    const overrideTeams = orgTeams.filter(
-      (team) => team.modelOverrideEnabled,
-    );
+    const overrideTeams = orgTeams.filter((team) => team.modelOverrideEnabled);
     const overrideTeamIds = overrideTeams.map((t) => t.id);
 
     if (overrideTeams.length === 0) {

--- a/ayunis-core-backend/src/domain/models/application/use-cases/get-team-permitted-models/get-team-permitted-models.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/get-team-permitted-models/get-team-permitted-models.use-case.spec.ts
@@ -33,9 +33,11 @@ describe('GetTeamPermittedModelsUseCase', () => {
     } as unknown as jest.Mocked<PermittedModelsRepository>;
 
     getTeamUseCase = {
-      execute: jest.fn().mockResolvedValue(
-        new Team({ name: 'test-team', orgId, modelOverrideEnabled: false }),
-      ),
+      execute: jest
+        .fn()
+        .mockResolvedValue(
+          new Team({ name: 'test-team', orgId, modelOverrideEnabled: false }),
+        ),
     } as unknown as jest.Mocked<GetTeamUseCase>;
 
     contextService = {

--- a/ayunis-core-backend/src/domain/models/application/use-cases/set-team-default-model/set-team-default-model.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/set-team-default-model/set-team-default-model.use-case.spec.ts
@@ -62,9 +62,11 @@ describe('SetTeamDefaultModelUseCase', () => {
     } as unknown as jest.Mocked<PermittedModelsRepository>;
 
     getTeamUseCase = {
-      execute: jest.fn().mockResolvedValue(
-        new Team({ name: 'test-team', orgId, modelOverrideEnabled: false }),
-      ),
+      execute: jest
+        .fn()
+        .mockResolvedValue(
+          new Team({ name: 'test-team', orgId, modelOverrideEnabled: false }),
+        ),
     } as unknown as jest.Mocked<GetTeamUseCase>;
 
     contextService = {

--- a/ayunis-core-backend/src/domain/rag/embeddings/infrastructure/handler/mistral-embeddings.handler.ts
+++ b/ayunis-core-backend/src/domain/rag/embeddings/infrastructure/handler/mistral-embeddings.handler.ts
@@ -46,7 +46,7 @@ export class MistralEmbeddingsHandler extends EmbeddingsHandler {
           this.logger.warn(
             'Retrying Mistral embeddings after transient error',
             {
-              statusCode: (error as SDKError).statusCode,
+              statusCode: error.statusCode,
               message: error.message,
             },
           );

--- a/ayunis-core-backend/src/domain/transcriptions/infrastructure/mistral-transcription.service.ts
+++ b/ayunis-core-backend/src/domain/transcriptions/infrastructure/mistral-transcription.service.ts
@@ -64,7 +64,7 @@ export class MistralTranscriptionService extends TranscriptionPort {
             this.logger.warn(
               'Retrying Mistral transcription after transient error',
               {
-                statusCode: (error as SDKError).statusCode,
+                statusCode: error.statusCode,
                 message: error.message,
               },
             );

--- a/ayunis-core-backend/src/domain/usage/application/use-cases/get-user-usage/get-user-usage.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/usage/application/use-cases/get-user-usage/get-user-usage.use-case.spec.ts
@@ -164,18 +164,16 @@ describe('GetUserUsageUseCase', () => {
         endDate,
       });
 
-      jest
-        .spyOn(mockUsageRepository, 'getUserUsage')
-        .mockResolvedValue(
-          mockUserUsageResult(
-            new Paginated<UserUsageItem>({
-              data: [],
-              limit: 50,
-              offset: 0,
-              total: 0,
-            }),
-          ),
-        );
+      jest.spyOn(mockUsageRepository, 'getUserUsage').mockResolvedValue(
+        mockUserUsageResult(
+          new Paginated<UserUsageItem>({
+            data: [],
+            limit: 50,
+            offset: 0,
+            total: 0,
+          }),
+        ),
+      );
 
       await expect(useCase.execute(query)).resolves.toBeDefined();
     });
@@ -237,18 +235,16 @@ describe('GetUserUsageUseCase', () => {
         offset: 0,
       });
 
-      jest
-        .spyOn(mockUsageRepository, 'getUserUsage')
-        .mockResolvedValue(
-          mockUserUsageResult(
-            new Paginated<UserUsageItem>({
-              data: [],
-              limit: 50,
-              offset: 0,
-              total: 0,
-            }),
-          ),
-        );
+      jest.spyOn(mockUsageRepository, 'getUserUsage').mockResolvedValue(
+        mockUserUsageResult(
+          new Paginated<UserUsageItem>({
+            data: [],
+            limit: 50,
+            offset: 0,
+            total: 0,
+          }),
+        ),
+      );
 
       await expect(useCase.execute(query)).resolves.toBeDefined();
     });
@@ -285,18 +281,16 @@ describe('GetUserUsageUseCase', () => {
         sortOrder: 'desc',
       });
 
-      jest
-        .spyOn(mockUsageRepository, 'getUserUsage')
-        .mockResolvedValue(
-          mockUserUsageResult(
-            new Paginated<UserUsageItem>({
-              data: [],
-              limit: 50,
-              offset: 0,
-              total: 0,
-            }),
-          ),
-        );
+      jest.spyOn(mockUsageRepository, 'getUserUsage').mockResolvedValue(
+        mockUserUsageResult(
+          new Paginated<UserUsageItem>({
+            data: [],
+            limit: 50,
+            offset: 0,
+            total: 0,
+          }),
+        ),
+      );
 
       await expect(useCase.execute(query)).resolves.toBeDefined();
     });

--- a/ayunis-core-frontend/src/pages/admin-settings/letterhead-detail/ui/LetterheadDetailPage.tsx
+++ b/ayunis-core-frontend/src/pages/admin-settings/letterhead-detail/ui/LetterheadDetailPage.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { Button } from '@/shared/ui/shadcn/button';
 import { Input } from '@/shared/ui/shadcn/input';
 import { Label } from '@/shared/ui/shadcn/label';
-import { Checkbox } from '@/shared/ui/shadcn/checkbox';
+import { Switch } from '@/shared/ui/shadcn/switch';
 import {
   Card,
   CardContent,
@@ -38,6 +38,9 @@ export function LetterheadDetailPage({
   );
 
   const [firstPagePdf, setFirstPagePdf] = useState<File | null>(null);
+  const [useDifferentFollowingPages, setUseDifferentFollowingPages] = useState(
+    letterhead.hasContinuationPage,
+  );
   const [continuationPagePdf, setContinuationPagePdf] = useState<File | null>(
     null,
   );
@@ -46,7 +49,6 @@ export function LetterheadDetailPage({
   );
   const [continuationPageMargins, setContinuationPageMargins] =
     useState<PageMargins>(initialMargins.continuationPage);
-  const [removeContinuation, setRemoveContinuation] = useState(false);
 
   const { updateLetterhead, isUpdating } = useUpdateLetterhead();
 
@@ -61,17 +63,24 @@ export function LetterheadDetailPage({
     },
   });
 
+  const shouldRemoveContinuation =
+    !useDifferentFollowingPages && letterhead.hasContinuationPage;
+
   const onSubmit = (data: LetterheadFormFields) => {
     updateLetterhead({
       id: letterhead.id,
       name: data.name,
       description: data.description,
       firstPagePdf: firstPagePdf ?? undefined,
-      continuationPagePdf: continuationPagePdf ?? undefined,
+      continuationPagePdf:
+        useDifferentFollowingPages && continuationPagePdf
+          ? continuationPagePdf
+          : undefined,
       firstPageMargins,
-      continuationPageMargins,
-      removeContinuationPage:
-        removeContinuation && !continuationPagePdf ? true : undefined,
+      continuationPageMargins: useDifferentFollowingPages
+        ? continuationPageMargins
+        : firstPageMargins,
+      removeContinuationPage: shouldRemoveContinuation || undefined,
     });
   };
 
@@ -82,7 +91,7 @@ export function LetterheadDetailPage({
   const continuationPageSource: PdfSource = getContinuationPageSource(
     continuationPagePdf,
     letterhead,
-    removeContinuation,
+    !useDifferentFollowingPages,
   );
 
   return (
@@ -154,39 +163,45 @@ export function LetterheadDetailPage({
 
         <Card>
           <CardHeader>
-            <CardTitle>{t('letterheads.detail.continuationPage')}</CardTitle>
+            <CardTitle>{t('letterheads.detail.followingPages')}</CardTitle>
           </CardHeader>
           <CardContent className="space-y-4">
-            <div className="grid gap-2">
-              <Label>
-                {t('letterheads.createDialog.continuationPagePdfLabel')}
-              </Label>
-              <Input
-                type="file"
-                accept="application/pdf"
-                onChange={(e) =>
-                  setContinuationPagePdf(e.target.files?.[0] ?? null)
-                }
+            <div className="flex items-center gap-2">
+              <Switch
+                id="use-different-following"
+                checked={useDifferentFollowingPages}
+                onCheckedChange={setUseDifferentFollowingPages}
               />
-              {letterhead.hasContinuationPage && (
-                <label className="flex items-center gap-2 text-sm text-muted-foreground">
-                  <Checkbox
-                    checked={removeContinuation}
-                    onCheckedChange={(checked) =>
-                      setRemoveContinuation(checked === true)
-                    }
-                  />
-                  {t('letterheads.editDialog.removeContinuationPage')}
-                </label>
-              )}
+              <Label htmlFor="use-different-following">
+                {t('letterheads.editDialog.useDifferentFollowingPages')}
+              </Label>
             </div>
 
-            <MarginEditor
-              pdfSource={continuationPageSource}
-              margins={continuationPageMargins}
-              onMarginsChange={setContinuationPageMargins}
-              label={t('letterheads.createDialog.continuationPageMarginsLabel')}
-            />
+            {useDifferentFollowingPages && (
+              <>
+                <div className="grid gap-2">
+                  <Label>
+                    {t('letterheads.createDialog.followingPagesPdfLabel')}
+                  </Label>
+                  <Input
+                    type="file"
+                    accept="application/pdf"
+                    onChange={(e) =>
+                      setContinuationPagePdf(e.target.files?.[0] ?? null)
+                    }
+                  />
+                </div>
+
+                <MarginEditor
+                  pdfSource={continuationPageSource}
+                  margins={continuationPageMargins}
+                  onMarginsChange={setContinuationPageMargins}
+                  label={t(
+                    'letterheads.createDialog.followingPagesMarginsLabel',
+                  )}
+                />
+              </>
+            )}
           </CardContent>
         </Card>
 

--- a/ayunis-core-frontend/src/pages/admin-settings/letterheads-settings/ui/LetterheadFormDialog.tsx
+++ b/ayunis-core-frontend/src/pages/admin-settings/letterheads-settings/ui/LetterheadFormDialog.tsx
@@ -21,6 +21,7 @@ import {
 import { Button } from '@/shared/ui/shadcn/button';
 import { Input } from '@/shared/ui/shadcn/input';
 import { Label } from '@/shared/ui/shadcn/label';
+import { Switch } from '@/shared/ui/shadcn/switch';
 import { MarginEditor } from '@/widgets/margin-editor';
 import { useCreateLetterhead } from '../api/useCreateLetterhead';
 import type { PageMargins } from '../model/types';
@@ -64,6 +65,8 @@ function LetterheadFormContent({
   t,
 }: Readonly<LetterheadFormContentProps>) {
   const [firstPagePdf, setFirstPagePdf] = useState<File | null>(null);
+  const [useDifferentFollowingPages, setUseDifferentFollowingPages] =
+    useState(false);
   const [continuationPagePdf, setContinuationPagePdf] = useState<File | null>(
     null,
   );
@@ -83,6 +86,7 @@ function LetterheadFormContent({
   const resetForm = () => {
     form.reset();
     setFirstPagePdf(null);
+    setUseDifferentFollowingPages(false);
     setContinuationPagePdf(null);
     setFirstPageMargins(DEFAULT_MARGINS);
     setContinuationPageMargins(DEFAULT_MARGINS);
@@ -101,9 +105,14 @@ function LetterheadFormContent({
       name: data.name,
       description: data.description,
       firstPagePdf,
-      continuationPagePdf: continuationPagePdf ?? undefined,
+      continuationPagePdf:
+        useDifferentFollowingPages && continuationPagePdf
+          ? continuationPagePdf
+          : undefined,
       firstPageMargins,
-      continuationPageMargins,
+      continuationPageMargins: useDifferentFollowingPages
+        ? continuationPageMargins
+        : firstPageMargins,
     });
   };
 
@@ -181,28 +190,47 @@ function LetterheadFormContent({
               label={t('letterheads.createDialog.firstPageMarginsLabel')}
             />
 
-            {/* Continuation Page PDF */}
-            <div className="grid gap-2">
-              <Label>
-                {t('letterheads.createDialog.continuationPagePdfLabel')}
-              </Label>
-              <Input
-                type="file"
-                accept="application/pdf"
+            {/* Toggle: different letterhead for following pages */}
+            <div className="flex items-center gap-2">
+              <Switch
+                id="use-different-following"
+                checked={useDifferentFollowingPages}
+                onCheckedChange={setUseDifferentFollowingPages}
                 disabled={isCreating}
-                onChange={(e) =>
-                  setContinuationPagePdf(e.target.files?.[0] ?? null)
-                }
               />
+              <Label htmlFor="use-different-following">
+                {t('letterheads.createDialog.useDifferentFollowingPages')}
+              </Label>
             </div>
 
-            {/* Continuation Page Margins */}
-            <MarginEditor
-              pdfSource={continuationPagePdf}
-              margins={continuationPageMargins}
-              onMarginsChange={setContinuationPageMargins}
-              label={t('letterheads.createDialog.continuationPageMarginsLabel')}
-            />
+            {useDifferentFollowingPages && (
+              <>
+                {/* Following Pages PDF */}
+                <div className="grid gap-2">
+                  <Label>
+                    {t('letterheads.createDialog.followingPagesPdfLabel')}
+                  </Label>
+                  <Input
+                    type="file"
+                    accept="application/pdf"
+                    disabled={isCreating}
+                    onChange={(e) =>
+                      setContinuationPagePdf(e.target.files?.[0] ?? null)
+                    }
+                  />
+                </div>
+
+                {/* Following Pages Margins */}
+                <MarginEditor
+                  pdfSource={continuationPagePdf}
+                  margins={continuationPageMargins}
+                  onMarginsChange={setContinuationPageMargins}
+                  label={t(
+                    'letterheads.createDialog.followingPagesMarginsLabel',
+                  )}
+                />
+              </>
+            )}
           </div>
           <DialogFooter>
             <Button

--- a/ayunis-core-frontend/src/shared/locales/de/admin-settings-letterheads.json
+++ b/ayunis-core-frontend/src/shared/locales/de/admin-settings-letterheads.json
@@ -6,25 +6,26 @@
     "noDescription": "Keine Beschreibung",
     "detail": {
       "general": "Allgemein",
-      "firstPage": "Erste Seite",
-      "continuationPage": "Folgeseite"
+      "firstPage": "Briefpapier",
+      "followingPages": "Folgeseiten"
     },
     "createDialog": {
       "title": "Briefpapier erstellen",
-      "description": "Laden Sie PDF-Dateien für die erste Seite und optional für Folgeseiten hoch.",
+      "description": "Laden Sie ein PDF als Briefpapier-Hintergrund hoch. Optional können Sie ein separates PDF für Folgeseiten hochladen — andernfalls wird das Briefpapier der ersten Seite für alle Seiten verwendet.",
       "nameLabel": "Name",
       "namePlaceholder": "z.B. Offizielles Briefpapier",
       "nameRequired": "Name ist erforderlich",
       "descriptionLabel": "Beschreibung",
       "descriptionPlaceholder": "Beschreibung für die KI (optional)",
-      "firstPagePdfLabel": "Erste Seite (PDF)",
-      "continuationPagePdfLabel": "Folgeseite (PDF, optional)",
+      "firstPagePdfLabel": "Briefpapier (PDF)",
+      "followingPagesPdfLabel": "Folgeseiten (PDF)",
       "firstPageMarginsLabel": "Seitenränder erste Seite (mm)",
-      "continuationPageMarginsLabel": "Seitenränder Folgeseiten (mm)",
+      "followingPagesMarginsLabel": "Seitenränder Folgeseiten (mm)",
       "top": "Oben",
       "bottom": "Unten",
       "left": "Links",
       "right": "Rechts",
+      "useDifferentFollowingPages": "Anderes Briefpapier für Folgeseiten verwenden",
       "cancel": "Abbrechen",
       "create": "Erstellen",
       "creating": "Wird erstellt…",
@@ -44,7 +45,8 @@
       "error": "Fehler beim Aktualisieren des Briefpapiers.",
       "invalidPdf": "Bitte laden Sie eine gültige PDF-Datei hoch.",
       "invalidPageMargins": "Bitte geben Sie gültige nicht-negative Seitenränder ein.",
-      "removeContinuationPage": "Folgeseite entfernen"
+      "removeContinuationPage": "Folgeseiten-Briefpapier entfernen",
+      "useDifferentFollowingPages": "Anderes Briefpapier für Folgeseiten verwenden"
     },
     "deleteDialog": {
       "title": "Briefpapier löschen",

--- a/ayunis-core-frontend/src/shared/locales/en/admin-settings-letterheads.json
+++ b/ayunis-core-frontend/src/shared/locales/en/admin-settings-letterheads.json
@@ -6,25 +6,26 @@
     "noDescription": "No description",
     "detail": {
       "general": "General",
-      "firstPage": "First Page",
-      "continuationPage": "Continuation Page"
+      "firstPage": "Letterhead",
+      "followingPages": "Following Pages"
     },
     "createDialog": {
       "title": "Create Letterhead",
-      "description": "Upload PDF files for the first page and optionally for continuation pages.",
+      "description": "Upload a PDF to use as letterhead background. Optionally, upload a separate PDF for following pages — if omitted, the first page letterhead is used for all pages.",
       "nameLabel": "Name",
       "namePlaceholder": "e.g. Official Letterhead",
       "nameRequired": "Name is required",
       "descriptionLabel": "Description",
       "descriptionPlaceholder": "Description for AI (optional)",
-      "firstPagePdfLabel": "First Page (PDF)",
-      "continuationPagePdfLabel": "Continuation Page (PDF, optional)",
+      "firstPagePdfLabel": "Letterhead (PDF)",
+      "followingPagesPdfLabel": "Following Pages (PDF)",
       "firstPageMarginsLabel": "First Page Margins (mm)",
-      "continuationPageMarginsLabel": "Continuation Page Margins (mm)",
+      "followingPagesMarginsLabel": "Following Pages Margins (mm)",
       "top": "Top",
       "bottom": "Bottom",
       "left": "Left",
       "right": "Right",
+      "useDifferentFollowingPages": "Use different letterhead for following pages",
       "cancel": "Cancel",
       "create": "Create",
       "creating": "Creating…",
@@ -44,7 +45,8 @@
       "error": "Failed to update letterhead.",
       "invalidPdf": "Please upload a valid PDF file.",
       "invalidPageMargins": "Please enter valid non-negative page margins.",
-      "removeContinuationPage": "Remove continuation page"
+      "removeContinuationPage": "Remove following pages letterhead",
+      "useDifferentFollowingPages": "Use different letterhead for following pages"
     },
     "deleteDialog": {
       "title": "Delete Letterhead",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches persistence and PDF export rendering: artifacts gain a new `letterheadId` FK and PDF composition behavior changes for multi-page exports, which could affect existing document exports if assumptions about continuation backgrounds/margins were relied on.
> 
> **Overview**
> **Letterhead handling is simplified so a single uploaded letterhead can apply to all PDF pages by default.** Backend `PdfLetterheadCompositor` now always applies a background to every page, falling back to the first-page letterhead when no continuation PDF is provided (with updated tests).
> 
> **Admin letterhead create/edit UI now uses a switch to optionally enable a separate “Following Pages” PDF/margins.** When disabled, following pages reuse the first-page margins and any existing continuation letterhead can be removed; copy and labels were updated in `en`/`de` locales.
> 
> Also includes minor spec/formatting cleanups and safer Mistral retry logging by using `error.statusCode` directly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bb14bac284414770804e33efb672788e53415cc5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->