### PR TITLE
fix(sources): lazy load sources to avoid out of memory errors (AYC-000)

### DIFF
--- a/ayunis-core-backend/.dependency-cruiser-known-violations.json
+++ b/ayunis-core-backend/.dependency-cruiser-known-violations.json
@@ -1,1 +1,137 @@
-[]
+[
+  {
+    "type": "dependency",
+    "from": "src/domain/agents/application/strategies/agent-share-authorization.strategy.ts",
+    "to": "src/domain/shares/application/ports/share-authorization-strategy.port.ts",
+    "rule": {
+      "severity": "error",
+      "name": "no-cross-module-port-imports"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "src/domain/agents/application/use-cases/assign-mcp-integration-to-agent/assign-mcp-integration-to-agent.use-case.ts",
+    "to": "src/domain/mcp/application/ports/mcp-integrations.repository.port.ts",
+    "rule": {
+      "severity": "error",
+      "name": "no-cross-module-port-imports"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "src/domain/chat-settings/application/use-cases/generate-personalized-system-prompt/generate-personalized-system-prompt.use-case.ts",
+    "to": "src/domain/models/application/ports/inference.handler.ts",
+    "rule": {
+      "severity": "error",
+      "name": "no-cross-module-port-imports"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "src/domain/knowledge-bases/application/listeners/share-deleted.listener.ts",
+    "to": "src/domain/shares/application/ports/shares-repository.port.ts",
+    "rule": {
+      "severity": "error",
+      "name": "no-cross-module-port-imports"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "src/domain/knowledge-bases/application/listeners/share-deleted.listener.ts",
+    "to": "src/domain/skills/application/ports/skill.repository.ts",
+    "rule": {
+      "severity": "error",
+      "name": "no-cross-module-port-imports"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "src/domain/knowledge-bases/application/strategies/knowledge-base-share-authorization.strategy.ts",
+    "to": "src/domain/shares/application/ports/share-authorization-strategy.port.ts",
+    "rule": {
+      "severity": "error",
+      "name": "no-cross-module-port-imports"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "src/domain/messages/application/use-cases/cleanup-orphaned-images/cleanup-orphaned-images.use-case.ts",
+    "to": "src/domain/storage/application/ports/object-storage.port.ts",
+    "rule": {
+      "severity": "error",
+      "name": "no-cross-module-port-imports"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "src/domain/runs/application/services/non-streaming-inference.service.ts",
+    "to": "src/domain/models/application/ports/inference.handler.ts",
+    "rule": {
+      "severity": "error",
+      "name": "no-cross-module-port-imports"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "src/domain/runs/application/services/streaming-inference.service.ts",
+    "to": "src/domain/models/application/ports/stream-inference.handler.ts",
+    "rule": {
+      "severity": "error",
+      "name": "no-cross-module-port-imports"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "src/domain/skills/application/services/marketplace-skill-installation.service.ts",
+    "to": "src/domain/marketplace/application/ports/marketplace-client.port.ts",
+    "rule": {
+      "severity": "error",
+      "name": "no-cross-module-port-imports"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "src/domain/skills/application/strategies/skill-share-authorization.strategy.ts",
+    "to": "src/domain/shares/application/ports/share-authorization-strategy.port.ts",
+    "rule": {
+      "severity": "error",
+      "name": "no-cross-module-port-imports"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "src/domain/skills/application/use-cases/assign-mcp-integration-to-skill/assign-mcp-integration-to-skill.use-case.ts",
+    "to": "src/domain/mcp/application/ports/mcp-integrations.repository.port.ts",
+    "rule": {
+      "severity": "error",
+      "name": "no-cross-module-port-imports"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "src/domain/threads/application/use-cases/add-knowledge-base-to-thread/add-knowledge-base-to-thread.use-case.ts",
+    "to": "src/domain/knowledge-bases/application/ports/knowledge-base.repository.ts",
+    "rule": {
+      "severity": "error",
+      "name": "no-cross-module-port-imports"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "src/domain/threads/application/use-cases/delete-thread/delete-thread.use-case.ts",
+    "to": "src/domain/messages/application/ports/messages.repository.ts",
+    "rule": {
+      "severity": "error",
+      "name": "no-cross-module-port-imports"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "src/iam/invites/application/use-cases/create-bulk-invites/create-bulk-invites.use-case.ts",
+    "to": "src/iam/users/application/ports/users.repository.ts",
+    "rule": {
+      "severity": "error",
+      "name": "no-cross-module-port-imports"
+    }
+  }
+]

--- a/ayunis-core-backend/.dependency-cruiser.cjs
+++ b/ayunis-core-backend/.dependency-cruiser.cjs
@@ -70,6 +70,26 @@ module.exports = {
     },
 
     // ═══════════════════════════════════════════════════════════════════════════
+    // CROSS-MODULE BOUNDARY — Use cases, not ports
+    // Module A may import use cases from module B, but NOT B's ports.
+    // Ports are internal contracts between a module's application and
+    // infrastructure layers.
+    // ═══════════════════════════════════════════════════════════════════════════
+    {
+      name: 'no-cross-module-port-imports',
+      comment:
+        'Modules must not import ports from other modules — use exported use cases instead',
+      severity: 'error',
+      from: {
+        path: '^src/(domain|iam)/([^/]+)/',
+      },
+      to: {
+        path: '^src/(domain|iam)/[^/]+/application/ports/',
+        pathNot: '^src/$1/$2/application/ports/',
+      },
+    },
+
+    // ═══════════════════════════════════════════════════════════════════════════
     // PORTS — Abstract interfaces for INFRASTRUCTURE (repos, external APIs)
     // Ports define contracts that infrastructure adapters implement.
     // Cross-module communication goes through USE CASES, not ports.

--- a/ayunis-core-backend/src/db/migrations/1774290326817-AddSourceMetadataToSourceRecords.ts
+++ b/ayunis-core-backend/src/db/migrations/1774290326817-AddSourceMetadataToSourceRecords.ts
@@ -1,0 +1,64 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddSourceMetadataToSourceRecords1774290326817 implements MigrationInterface {
+  name = 'AddSourceMetadataToSourceRecords1774290326817';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Add new enum types
+    await queryRunner.query(
+      `CREATE TYPE "public"."sources_texttype_enum" AS ENUM('file', 'web')`,
+    );
+    await queryRunner.query(
+      `CREATE TYPE "public"."sources_filetype_enum" AS ENUM('pdf', 'docx', 'pptx', 'txt')`,
+    );
+    await queryRunner.query(
+      `CREATE TYPE "public"."sources_datatype_enum" AS ENUM('csv')`,
+    );
+
+    // Add columns to sources table
+    await queryRunner.query(
+      `ALTER TABLE "sources" ADD "textType" "public"."sources_texttype_enum"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "sources" ADD "fileType" "public"."sources_filetype_enum"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "sources" ADD "url" character varying`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "sources" ADD "dataType" "public"."sources_datatype_enum"`,
+    );
+
+    // Backfill from text_source_details_record
+    await queryRunner.query(`
+      UPDATE sources s
+      SET "textType" = d."textType"::"public"."sources_texttype_enum",
+          "fileType" = CASE
+            WHEN d."fileType" IS NOT NULL
+            THEN d."fileType"::"public"."sources_filetype_enum"
+            ELSE NULL
+          END,
+          "url" = d."url"
+      FROM text_source_details_record d
+      WHERE d."sourceId" = s.id
+    `);
+
+    // Backfill from data_source_details_record
+    await queryRunner.query(`
+      UPDATE sources s
+      SET "dataType" = d."dataType"::"public"."sources_datatype_enum"
+      FROM data_source_details_record d
+      WHERE d."sourceId" = s.id
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "sources" DROP COLUMN "dataType"`);
+    await queryRunner.query(`DROP TYPE "public"."sources_datatype_enum"`);
+    await queryRunner.query(`ALTER TABLE "sources" DROP COLUMN "url"`);
+    await queryRunner.query(`ALTER TABLE "sources" DROP COLUMN "fileType"`);
+    await queryRunner.query(`DROP TYPE "public"."sources_filetype_enum"`);
+    await queryRunner.query(`ALTER TABLE "sources" DROP COLUMN "textType"`);
+    await queryRunner.query(`DROP TYPE "public"."sources_texttype_enum"`);
+  }
+}

--- a/ayunis-core-backend/src/domain/agents/application/use-cases/remove-source-from-agent/remove-source-from-agent.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/agents/application/use-cases/remove-source-from-agent/remove-source-from-agent.use-case.spec.ts
@@ -13,7 +13,6 @@ import { RemoveSourceFromAgentUseCase } from './remove-source-from-agent.use-cas
 import { RemoveSourceFromAgentCommand } from './remove-source-from-agent.command';
 import { AgentRepository } from '../../ports/agent.repository';
 import { ContextService } from 'src/common/context/services/context.service';
-import { GetTextSourceByIdUseCase } from 'src/domain/sources/application/use-cases/get-text-source-by-id/get-text-source-by-id.use-case';
 import { DeleteSourceUseCase } from 'src/domain/sources/application/use-cases/delete-source/delete-source.use-case';
 import { Agent } from '../../../domain/agent.entity';
 import { AgentSourceAssignment } from '../../../domain/agent-source-assignment.entity';
@@ -35,7 +34,6 @@ describe('RemoveSourceFromAgentUseCase', () => {
   let useCase: RemoveSourceFromAgentUseCase;
   let agentRepository: jest.Mocked<AgentRepository>;
   let contextService: jest.Mocked<ContextService>;
-  let getSourceByIdUseCase: jest.Mocked<GetTextSourceByIdUseCase>;
   let deleteSourceUseCase: jest.Mocked<DeleteSourceUseCase>;
 
   const mockUserId = randomUUID();
@@ -57,10 +55,6 @@ describe('RemoveSourceFromAgentUseCase', () => {
       get: jest.fn(),
     };
 
-    const mockGetSourceByIdUseCase = {
-      execute: jest.fn(),
-    };
-
     const mockDeleteSourceUseCase = {
       execute: jest.fn(),
     };
@@ -70,10 +64,6 @@ describe('RemoveSourceFromAgentUseCase', () => {
         RemoveSourceFromAgentUseCase,
         { provide: AgentRepository, useValue: mockAgentRepository },
         { provide: ContextService, useValue: mockContextService },
-        {
-          provide: GetTextSourceByIdUseCase,
-          useValue: mockGetSourceByIdUseCase,
-        },
         { provide: DeleteSourceUseCase, useValue: mockDeleteSourceUseCase },
       ],
     }).compile();
@@ -83,7 +73,6 @@ describe('RemoveSourceFromAgentUseCase', () => {
     );
     agentRepository = module.get(AgentRepository);
     contextService = module.get(ContextService);
-    getSourceByIdUseCase = module.get(GetTextSourceByIdUseCase);
     deleteSourceUseCase = module.get(DeleteSourceUseCase);
 
     // Mock logger
@@ -144,7 +133,6 @@ describe('RemoveSourceFromAgentUseCase', () => {
       });
 
       const mockAgent = createMockAgent();
-      const mockSource = mockAgent.sourceAssignments[0].source;
       const updatedAgent = new Agent({
         ...mockAgent,
         sourceAssignments: [],
@@ -152,7 +140,6 @@ describe('RemoveSourceFromAgentUseCase', () => {
 
       contextService.get.mockReturnValue(mockUserId);
       agentRepository.findOne.mockResolvedValue(mockAgent);
-      getSourceByIdUseCase.execute.mockResolvedValue(mockSource);
       deleteSourceUseCase.execute.mockResolvedValue(undefined);
       agentRepository.update.mockResolvedValue(updatedAgent);
 
@@ -165,14 +152,9 @@ describe('RemoveSourceFromAgentUseCase', () => {
         mockAgentId,
         mockUserId,
       );
-      expect(getSourceByIdUseCase.execute).toHaveBeenCalledWith(
-        expect.objectContaining({
-          id: mockSourceId,
-        }),
-      );
       expect(deleteSourceUseCase.execute).toHaveBeenCalledWith(
         expect.objectContaining({
-          source: mockSource,
+          sourceId: mockSourceId,
         }),
       );
       expect(agentRepository.update).toHaveBeenCalledWith(
@@ -219,7 +201,6 @@ describe('RemoveSourceFromAgentUseCase', () => {
         mockAgentId,
         mockUserId,
       );
-      expect(getSourceByIdUseCase.execute).not.toHaveBeenCalled();
       expect(deleteSourceUseCase.execute).not.toHaveBeenCalled();
       expect(agentRepository.update).not.toHaveBeenCalled();
     });
@@ -244,7 +225,6 @@ describe('RemoveSourceFromAgentUseCase', () => {
         mockAgentId,
         mockUserId,
       );
-      expect(getSourceByIdUseCase.execute).not.toHaveBeenCalled();
       expect(deleteSourceUseCase.execute).not.toHaveBeenCalled();
       expect(agentRepository.update).not.toHaveBeenCalled();
     });
@@ -289,9 +269,6 @@ describe('RemoveSourceFromAgentUseCase', () => {
 
       contextService.get.mockReturnValue(mockUserId);
       agentRepository.findOne.mockResolvedValue(agentWithMultipleSources);
-      getSourceByIdUseCase.execute.mockResolvedValue(
-        mockAgent.sourceAssignments[0].source,
-      );
       deleteSourceUseCase.execute.mockResolvedValue(undefined);
       agentRepository.update.mockResolvedValue(updatedAgent);
 
@@ -331,32 +308,6 @@ describe('RemoveSourceFromAgentUseCase', () => {
       );
     });
 
-    it('should throw UnexpectedAgentError when getSourceById fails', async () => {
-      // Arrange
-      const command = new RemoveSourceFromAgentCommand({
-        agentId: mockAgentId,
-        sourceAssignmentId: mockSourceAssignmentId,
-      });
-
-      const mockAgent = createMockAgent();
-      const sourceError = new Error('Source not found');
-
-      contextService.get.mockReturnValue(mockUserId);
-      agentRepository.findOne.mockResolvedValue(mockAgent);
-      getSourceByIdUseCase.execute.mockRejectedValue(sourceError);
-
-      // Act & Assert
-      await expect(useCase.execute(command)).rejects.toThrow(
-        UnexpectedAgentError,
-      );
-      expect(Logger.prototype.error).toHaveBeenCalledWith(
-        'Error removing source from agent',
-        expect.objectContaining({
-          error: sourceError,
-        }),
-      );
-    });
-
     it('should throw UnexpectedAgentError when deleteSource fails', async () => {
       // Arrange
       const command = new RemoveSourceFromAgentCommand({
@@ -365,12 +316,10 @@ describe('RemoveSourceFromAgentUseCase', () => {
       });
 
       const mockAgent = createMockAgent();
-      const mockSource = mockAgent.sourceAssignments[0].source;
       const deleteError = new Error('Delete operation failed');
 
       contextService.get.mockReturnValue(mockUserId);
       agentRepository.findOne.mockResolvedValue(mockAgent);
-      getSourceByIdUseCase.execute.mockResolvedValue(mockSource);
       deleteSourceUseCase.execute.mockRejectedValue(deleteError);
 
       // Act & Assert
@@ -412,7 +361,6 @@ describe('RemoveSourceFromAgentUseCase', () => {
       });
 
       const mockAgent = createMockAgent();
-      const mockSource = mockAgent.sourceAssignments[0].source;
       const updatedAgent = new Agent({
         ...mockAgent,
         sourceAssignments: [],
@@ -420,7 +368,6 @@ describe('RemoveSourceFromAgentUseCase', () => {
 
       contextService.get.mockReturnValue(mockUserId);
       agentRepository.findOne.mockResolvedValue(mockAgent);
-      getSourceByIdUseCase.execute.mockResolvedValue(mockSource);
       deleteSourceUseCase.execute.mockResolvedValue(undefined);
       agentRepository.update.mockResolvedValue(updatedAgent);
 

--- a/ayunis-core-backend/src/domain/agents/application/use-cases/remove-source-from-agent/remove-source-from-agent.use-case.ts
+++ b/ayunis-core-backend/src/domain/agents/application/use-cases/remove-source-from-agent/remove-source-from-agent.use-case.ts
@@ -7,8 +7,6 @@ import { AgentNotFoundError, UnexpectedAgentError } from '../../agents.errors';
 import { Agent } from 'src/domain/agents/domain/agent.entity';
 import { DeleteSourceUseCase } from 'src/domain/sources/application/use-cases/delete-source/delete-source.use-case';
 import { DeleteSourceCommand } from 'src/domain/sources/application/use-cases/delete-source/delete-source.command';
-import { GetTextSourceByIdUseCase } from 'src/domain/sources/application/use-cases/get-text-source-by-id/get-text-source-by-id.use-case';
-import { GetTextSourceByIdQuery } from 'src/domain/sources/application/use-cases/get-text-source-by-id/get-text-source-by-id.query';
 import { Transactional } from '@nestjs-cls/transactional';
 
 @Injectable()
@@ -18,7 +16,6 @@ export class RemoveSourceFromAgentUseCase {
   constructor(
     private readonly agentRepository: AgentRepository,
     private readonly contextService: ContextService,
-    private readonly getSourceByIdUseCase: GetTextSourceByIdUseCase,
     private readonly deleteSourceUseCase: DeleteSourceUseCase,
   ) {}
 
@@ -53,11 +50,9 @@ export class RemoveSourceFromAgentUseCase {
         sourceAssignments: updatedSourceAssignments,
       });
 
-      const source = await this.getSourceByIdUseCase.execute(
-        new GetTextSourceByIdQuery(sourceAssignment.source.id),
+      await this.deleteSourceUseCase.execute(
+        new DeleteSourceCommand(sourceAssignment.source.id),
       );
-
-      await this.deleteSourceUseCase.execute(new DeleteSourceCommand(source));
 
       await this.agentRepository.update(updatedAgent);
     } catch (error) {

--- a/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/add-document-to-knowledge-base/add-document-to-knowledge-base.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/add-document-to-knowledge-base/add-document-to-knowledge-base.use-case.spec.ts
@@ -69,8 +69,6 @@ describe('AddDocumentToKnowledgeBaseUseCase', () => {
       fileType: FileType.PDF,
       name: 'Protokoll_März_2025.pdf',
       type: TextType.FILE,
-      text: 'Protokoll Inhalt...',
-      contentChunks: [],
     });
     mockCreateTextSourceUseCase.execute.mockResolvedValue(
       createdSource as never,

--- a/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/add-url-to-knowledge-base/add-url-to-knowledge-base.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/add-url-to-knowledge-base/add-url-to-knowledge-base.use-case.spec.ts
@@ -72,8 +72,6 @@ describe('AddUrlToKnowledgeBaseUseCase', () => {
       url: 'https://example.com/stadtrat',
       name: 'example.com/stadtrat',
       type: TextType.WEB,
-      text: 'Webseite Inhalt...',
-      contentChunks: [],
     });
     mockCreateTextSourceUseCase.execute.mockResolvedValue(
       createdSource as never,

--- a/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/delete-knowledge-base/delete-knowledge-base.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/delete-knowledge-base/delete-knowledge-base.use-case.spec.ts
@@ -12,8 +12,8 @@ jest.mock('@nestjs-cls/transactional', () => ({
 import { DeleteKnowledgeBaseUseCase } from './delete-knowledge-base.use-case';
 import { DeleteKnowledgeBaseCommand } from './delete-knowledge-base.command';
 import { KnowledgeBaseRepository } from '../../ports/knowledge-base.repository';
-import { SourceRepository } from 'src/domain/sources/application/ports/source.repository';
 import { DeleteSourcesUseCase } from 'src/domain/sources/application/use-cases/delete-sources/delete-sources.use-case';
+import { GetSourcesByKnowledgeBaseIdUseCase } from 'src/domain/sources/application/use-cases/get-sources-by-knowledge-base-id/get-sources-by-knowledge-base-id.use-case';
 import { DeleteSourcesCommand } from 'src/domain/sources/application/use-cases/delete-sources/delete-sources.command';
 import { KnowledgeBase } from '../../../domain/knowledge-base.entity';
 import {
@@ -27,9 +27,7 @@ import type { UUID } from 'crypto';
 describe('DeleteKnowledgeBaseUseCase', () => {
   let useCase: DeleteKnowledgeBaseUseCase;
   let mockKbRepository: jest.Mocked<KnowledgeBaseRepository>;
-  let mockSourceRepository: jest.Mocked<
-    Pick<SourceRepository, 'findByKnowledgeBaseId'>
-  >;
+  let mockGetSourcesByKbId: jest.Mocked<GetSourcesByKnowledgeBaseIdUseCase>;
   let mockDeleteSourcesUseCase: jest.Mocked<
     Pick<DeleteSourcesUseCase, 'execute'>
   >;
@@ -50,9 +48,9 @@ describe('DeleteKnowledgeBaseUseCase', () => {
       findSourceByIdAndKnowledgeBaseId: jest.fn(),
     } as jest.Mocked<KnowledgeBaseRepository>;
 
-    mockSourceRepository = {
-      findByKnowledgeBaseId: jest.fn(),
-    };
+    mockGetSourcesByKbId = {
+      execute: jest.fn(),
+    } as unknown as jest.Mocked<GetSourcesByKnowledgeBaseIdUseCase>;
 
     mockDeleteSourcesUseCase = {
       execute: jest.fn(),
@@ -62,7 +60,10 @@ describe('DeleteKnowledgeBaseUseCase', () => {
       providers: [
         DeleteKnowledgeBaseUseCase,
         { provide: KnowledgeBaseRepository, useValue: mockKbRepository },
-        { provide: SourceRepository, useValue: mockSourceRepository },
+        {
+          provide: GetSourcesByKnowledgeBaseIdUseCase,
+          useValue: mockGetSourcesByKbId,
+        },
         { provide: DeleteSourcesUseCase, useValue: mockDeleteSourcesUseCase },
       ],
     }).compile();
@@ -84,21 +85,17 @@ describe('DeleteKnowledgeBaseUseCase', () => {
         url: 'https://gemeinde-musterstadt.de/protokoll-01.pdf',
         name: 'Protokoll Januar',
         type: TextType.WEB,
-        text: 'Protokoll-Inhalt',
-        contentChunks: [],
       }),
       new UrlSource({
         id: '55555555-5555-5555-5555-555555555555' as UUID,
         url: 'https://gemeinde-musterstadt.de/protokoll-02.pdf',
         name: 'Protokoll Februar',
         type: TextType.WEB,
-        text: 'Protokoll-Inhalt',
-        contentChunks: [],
       }),
     ];
 
     mockKbRepository.findById.mockResolvedValue(existing);
-    mockSourceRepository.findByKnowledgeBaseId.mockResolvedValue(sources);
+    mockGetSourcesByKbId.execute.mockResolvedValue(sources);
     mockDeleteSourcesUseCase.execute.mockResolvedValue(undefined);
     mockKbRepository.delete.mockResolvedValue(undefined);
 
@@ -106,11 +103,11 @@ describe('DeleteKnowledgeBaseUseCase', () => {
       new DeleteKnowledgeBaseCommand({ knowledgeBaseId, userId }),
     );
 
-    expect(mockSourceRepository.findByKnowledgeBaseId).toHaveBeenCalledWith(
-      knowledgeBaseId,
+    expect(mockGetSourcesByKbId.execute).toHaveBeenCalledWith(
+      expect.objectContaining({ knowledgeBaseId }),
     );
     expect(mockDeleteSourcesUseCase.execute).toHaveBeenCalledWith(
-      new DeleteSourcesCommand(sources),
+      new DeleteSourcesCommand(sources.map((s) => s.id)),
     );
     expect(mockKbRepository.delete).toHaveBeenCalledWith(existing);
   });
@@ -124,7 +121,7 @@ describe('DeleteKnowledgeBaseUseCase', () => {
     });
 
     mockKbRepository.findById.mockResolvedValue(existing);
-    mockSourceRepository.findByKnowledgeBaseId.mockResolvedValue([]);
+    mockGetSourcesByKbId.execute.mockResolvedValue([]);
     mockDeleteSourcesUseCase.execute.mockResolvedValue(undefined);
     mockKbRepository.delete.mockResolvedValue(undefined);
 
@@ -147,7 +144,7 @@ describe('DeleteKnowledgeBaseUseCase', () => {
       ),
     ).rejects.toThrow(KnowledgeBaseNotFoundError);
 
-    expect(mockSourceRepository.findByKnowledgeBaseId).not.toHaveBeenCalled();
+    expect(mockGetSourcesByKbId.execute).not.toHaveBeenCalled();
     expect(mockDeleteSourcesUseCase.execute).not.toHaveBeenCalled();
     expect(mockKbRepository.delete).not.toHaveBeenCalled();
   });
@@ -169,7 +166,7 @@ describe('DeleteKnowledgeBaseUseCase', () => {
       ),
     ).rejects.toThrow(KnowledgeBaseNotFoundError);
 
-    expect(mockSourceRepository.findByKnowledgeBaseId).not.toHaveBeenCalled();
+    expect(mockGetSourcesByKbId.execute).not.toHaveBeenCalled();
     expect(mockDeleteSourcesUseCase.execute).not.toHaveBeenCalled();
     expect(mockKbRepository.delete).not.toHaveBeenCalled();
   });
@@ -183,7 +180,7 @@ describe('DeleteKnowledgeBaseUseCase', () => {
     });
 
     mockKbRepository.findById.mockResolvedValue(existing);
-    mockSourceRepository.findByKnowledgeBaseId.mockResolvedValue([]);
+    mockGetSourcesByKbId.execute.mockResolvedValue([]);
 
     const callOrder: string[] = [];
     mockDeleteSourcesUseCase.execute.mockImplementation(async () => {

--- a/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/delete-knowledge-base/delete-knowledge-base.use-case.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/delete-knowledge-base/delete-knowledge-base.use-case.ts
@@ -1,9 +1,10 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { Transactional } from '@nestjs-cls/transactional';
 import { KnowledgeBaseRepository } from '../../ports/knowledge-base.repository';
-import { SourceRepository } from 'src/domain/sources/application/ports/source.repository';
 import { DeleteSourcesUseCase } from 'src/domain/sources/application/use-cases/delete-sources/delete-sources.use-case';
 import { DeleteSourcesCommand } from 'src/domain/sources/application/use-cases/delete-sources/delete-sources.command';
+import { GetSourcesByKnowledgeBaseIdUseCase } from 'src/domain/sources/application/use-cases/get-sources-by-knowledge-base-id/get-sources-by-knowledge-base-id.use-case';
+import { GetSourcesByKnowledgeBaseIdQuery } from 'src/domain/sources/application/use-cases/get-sources-by-knowledge-base-id/get-sources-by-knowledge-base-id.query';
 import { DeleteKnowledgeBaseCommand } from './delete-knowledge-base.command';
 import {
   KnowledgeBaseNotFoundError,
@@ -17,7 +18,7 @@ export class DeleteKnowledgeBaseUseCase {
 
   constructor(
     private readonly knowledgeBaseRepository: KnowledgeBaseRepository,
-    private readonly sourceRepository: SourceRepository,
+    private readonly getSourcesByKnowledgeBaseIdUseCase: GetSourcesByKnowledgeBaseIdUseCase,
     private readonly deleteSourcesUseCase: DeleteSourcesUseCase,
   ) {}
 
@@ -36,11 +37,12 @@ export class DeleteKnowledgeBaseUseCase {
         throw new KnowledgeBaseNotFoundError(command.knowledgeBaseId);
       }
 
-      const sources = await this.sourceRepository.findByKnowledgeBaseId(
-        command.knowledgeBaseId,
+      const sources = await this.getSourcesByKnowledgeBaseIdUseCase.execute(
+        new GetSourcesByKnowledgeBaseIdQuery(command.knowledgeBaseId),
       );
+      const sourceIds = sources.map((s) => s.id);
       await this.deleteSourcesUseCase.execute(
-        new DeleteSourcesCommand(sources),
+        new DeleteSourcesCommand(sourceIds),
       );
 
       await this.knowledgeBaseRepository.delete(existing);

--- a/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/get-knowledge-base-document-text/get-knowledge-base-document-text.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/get-knowledge-base-document-text/get-knowledge-base-document-text.use-case.spec.ts
@@ -68,8 +68,6 @@ describe('GetKnowledgeBaseDocumentTextUseCase', () => {
     const source = new FileSource({
       id: documentId,
       name: 'building-codes.pdf',
-      text: 'Building code regulations...',
-      contentChunks: [],
       type: TextType.FILE,
       fileType: FileType.PDF,
     });
@@ -143,8 +141,6 @@ describe('GetKnowledgeBaseDocumentTextUseCase', () => {
     const source = new FileSource({
       id: documentId,
       name: 'shared-building-codes.pdf',
-      text: 'Shared building code regulations...',
-      contentChunks: [],
       type: TextType.FILE,
       fileType: FileType.PDF,
     });

--- a/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/list-knowledge-base-documents/list-knowledge-base-documents.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/list-knowledge-base-documents/list-knowledge-base-documents.use-case.spec.ts
@@ -52,8 +52,6 @@ describe('ListKnowledgeBaseDocumentsUseCase', () => {
       url: 'https://stadt.de/protokoll',
       name: 'Protokoll März 2025',
       type: TextType.WEB,
-      text: 'Inhalt',
-      contentChunks: [],
     });
     mockRepository.findSourcesByKnowledgeBaseId.mockResolvedValue([source]);
 

--- a/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/query-knowledge-base/query-knowledge-base.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/query-knowledge-base/query-knowledge-base.use-case.spec.ts
@@ -15,11 +15,13 @@ import { FileSource } from 'src/domain/sources/domain/sources/text-source.entity
 import { FileType, TextType } from 'src/domain/sources/domain/source-type.enum';
 import { ContextService } from 'src/common/context/services/context.service';
 import { KnowledgeBaseAccessService } from '../../services/knowledge-base-access.service';
+import { FindContentChunksByIdsUseCase } from 'src/domain/sources/application/use-cases/find-content-chunks-by-ids/find-content-chunks-by-ids.use-case';
 import type { UUID } from 'crypto';
 
 describe('QueryKnowledgeBaseUseCase', () => {
   let useCase: QueryKnowledgeBaseUseCase;
   let mockKbRepo: jest.Mocked<KnowledgeBaseRepository>;
+  let mockFindChunks: jest.Mocked<FindContentChunksByIdsUseCase>;
   let mockSearchContent: jest.Mocked<SearchContentUseCase>;
   let mockContextService: Partial<ContextService>;
   let mockAccessService: jest.Mocked<KnowledgeBaseAccessService>;
@@ -42,6 +44,10 @@ describe('QueryKnowledgeBaseUseCase', () => {
       findSourceByIdAndKnowledgeBaseId: jest.fn(),
     } as jest.Mocked<KnowledgeBaseRepository>;
 
+    mockFindChunks = {
+      execute: jest.fn(),
+    } as unknown as jest.Mocked<FindContentChunksByIdsUseCase>;
+
     mockSearchContent = {
       execute: jest.fn(),
       executeMulti: jest.fn(),
@@ -62,6 +68,7 @@ describe('QueryKnowledgeBaseUseCase', () => {
       providers: [
         QueryKnowledgeBaseUseCase,
         { provide: KnowledgeBaseRepository, useValue: mockKbRepo },
+        { provide: FindContentChunksByIdsUseCase, useValue: mockFindChunks },
         { provide: SearchContentUseCase, useValue: mockSearchContent },
         { provide: ContextService, useValue: mockContextService },
         {
@@ -93,8 +100,6 @@ describe('QueryKnowledgeBaseUseCase', () => {
       name: 'Haushaltssatzung_2025.pdf',
       fileType: FileType.PDF,
       type: TextType.FILE,
-      text: 'full text...',
-      contentChunks: [chunk],
     });
 
     const indexEntry = new IndexEntry({
@@ -105,6 +110,9 @@ describe('QueryKnowledgeBaseUseCase', () => {
     mockAccessService.findAccessibleKnowledgeBase.mockResolvedValue(kb);
     mockKbRepo.findSourcesByKnowledgeBaseId.mockResolvedValue([source]);
     mockSearchContent.executeMulti.mockResolvedValue([indexEntry]);
+    mockFindChunks.execute.mockResolvedValue([
+      { chunk, sourceId, sourceName: 'Haushaltssatzung_2025.pdf' },
+    ]);
 
     const query = new QueryKnowledgeBaseQuery({
       knowledgeBaseId: kbId,
@@ -125,9 +133,12 @@ describe('QueryKnowledgeBaseUseCase', () => {
         query: 'Grundsteuer',
       }),
     );
+    expect(mockFindChunks.execute).toHaveBeenCalledWith(
+      expect.objectContaining({ chunkIds: [chunkId] }),
+    );
   });
 
-  it('should look up sources from pre-loaded map instead of fetching individually', async () => {
+  it('should fetch chunks by ID instead of loading full sources', async () => {
     const kb = new KnowledgeBase({
       id: kbId,
       name: 'Stadtratsprotokolle',
@@ -146,8 +157,6 @@ describe('QueryKnowledgeBaseUseCase', () => {
       name: 'Bebauungsplan_42.pdf',
       fileType: FileType.PDF,
       type: TextType.FILE,
-      text: 'full text...',
-      contentChunks: [chunk],
     });
 
     const indexEntry = new IndexEntry({
@@ -158,6 +167,9 @@ describe('QueryKnowledgeBaseUseCase', () => {
     mockAccessService.findAccessibleKnowledgeBase.mockResolvedValue(kb);
     mockKbRepo.findSourcesByKnowledgeBaseId.mockResolvedValue([source]);
     mockSearchContent.executeMulti.mockResolvedValue([indexEntry]);
+    mockFindChunks.execute.mockResolvedValue([
+      { chunk, sourceId, sourceName: 'Bebauungsplan_42.pdf' },
+    ]);
 
     const query = new QueryKnowledgeBaseQuery({
       knowledgeBaseId: kbId,
@@ -274,7 +286,7 @@ describe('QueryKnowledgeBaseUseCase', () => {
     );
   });
 
-  it('should skip index entries where source content chunk is not found', async () => {
+  it('should skip index entries where chunk is not found in DB', async () => {
     const kb = new KnowledgeBase({
       id: kbId,
       name: 'Stadtratsprotokolle',
@@ -287,8 +299,6 @@ describe('QueryKnowledgeBaseUseCase', () => {
       name: 'Protokoll.pdf',
       fileType: FileType.PDF,
       type: TextType.FILE,
-      text: 'text...',
-      contentChunks: [],
     });
 
     const indexEntry = new IndexEntry({
@@ -299,6 +309,8 @@ describe('QueryKnowledgeBaseUseCase', () => {
     mockAccessService.findAccessibleKnowledgeBase.mockResolvedValue(kb);
     mockKbRepo.findSourcesByKnowledgeBaseId.mockResolvedValue([source]);
     mockSearchContent.executeMulti.mockResolvedValue([indexEntry]);
+    // Chunk not found in DB
+    mockFindChunks.execute.mockResolvedValue([]);
 
     const query = new QueryKnowledgeBaseQuery({
       knowledgeBaseId: kbId,

--- a/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/query-knowledge-base/query-knowledge-base.use-case.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/query-knowledge-base/query-knowledge-base.use-case.ts
@@ -8,13 +8,12 @@ import {
 import { SearchContentUseCase } from 'src/domain/rag/indexers/application/use-cases/search-content/search-content.use-case';
 import { SearchMultiContentQuery } from 'src/domain/rag/indexers/application/use-cases/search-content/search-content.query';
 import { IndexType } from 'src/domain/rag/indexers/domain/value-objects/index-type.enum';
-import { TextSource } from 'src/domain/sources/domain/sources/text-source.entity';
 import type { TextSourceContentChunk } from 'src/domain/sources/domain/source-content-chunk.entity';
-import type { UUID } from 'crypto';
-import type { Source } from 'src/domain/sources/domain/source.entity';
 import { ContextService } from 'src/common/context/services/context.service';
 import { ApplicationError } from 'src/common/errors/base.error';
 import { KnowledgeBaseAccessService } from '../../services/knowledge-base-access.service';
+import { FindContentChunksByIdsUseCase } from 'src/domain/sources/application/use-cases/find-content-chunks-by-ids/find-content-chunks-by-ids.use-case';
+import { FindContentChunksByIdsQuery } from 'src/domain/sources/application/use-cases/find-content-chunks-by-ids/find-content-chunks-by-ids.query';
 
 export interface KnowledgeBaseQueryResult {
   chunk: TextSourceContentChunk;
@@ -28,6 +27,7 @@ export class QueryKnowledgeBaseUseCase {
 
   constructor(
     private readonly knowledgeBaseRepository: KnowledgeBaseRepository,
+    private readonly findContentChunksByIdsUseCase: FindContentChunksByIdsUseCase,
     private readonly searchContentUseCase: SearchContentUseCase,
     private readonly contextService: ContextService,
     private readonly knowledgeBaseAccessService: KnowledgeBaseAccessService,
@@ -69,8 +69,7 @@ export class QueryKnowledgeBaseUseCase {
       throw new KnowledgeBaseNotFoundError(query.knowledgeBaseId);
     }
 
-    // Sources are loaded with content chunks in a single query via TypeORM
-    // eager loading: SourceRecord → TextSourceDetailsRecord → contentChunks.
+    // Sources are now metadata-only (no text or chunks loaded)
     const sources =
       await this.knowledgeBaseRepository.findSourcesByKnowledgeBaseId(
         query.knowledgeBaseId,
@@ -80,7 +79,6 @@ export class QueryKnowledgeBaseUseCase {
       return [];
     }
 
-    const sourceMap = this.buildSourceMap(sources);
     const documentIds = sources.map((source) => source.id);
 
     const indexEntries = await this.searchContentUseCase.executeMulti(
@@ -93,23 +91,29 @@ export class QueryKnowledgeBaseUseCase {
       }),
     );
 
+    if (indexEntries.length === 0) {
+      return [];
+    }
+
+    // Fetch only the matched chunks by ID (single query)
+    const chunkIds = indexEntries.map((entry) => entry.relatedChunkId);
+    const chunkResults = await this.findContentChunksByIdsUseCase.execute(
+      new FindContentChunksByIdsQuery(chunkIds),
+    );
+
+    // Build a lookup map for quick access
+    const chunkMap = new Map(chunkResults.map((r) => [r.chunk.id, r]));
+
     const results: KnowledgeBaseQueryResult[] = [];
 
     for (const entry of indexEntries) {
-      const source = sourceMap.get(entry.relatedDocumentId);
-
-      if (source && source instanceof TextSource) {
-        const chunk = source.contentChunks.find(
-          (c) => c.id === entry.relatedChunkId,
-        );
-
-        if (chunk) {
-          results.push({
-            chunk,
-            sourceName: source.name,
-            sourceId: source.id,
-          });
-        }
+      const match = chunkMap.get(entry.relatedChunkId);
+      if (match) {
+        results.push({
+          chunk: match.chunk,
+          sourceName: match.sourceName,
+          sourceId: match.sourceId,
+        });
       }
     }
 
@@ -118,13 +122,5 @@ export class QueryKnowledgeBaseUseCase {
     );
 
     return results;
-  }
-
-  private buildSourceMap(sources: Source[]): Map<UUID, Source> {
-    const map = new Map<UUID, Source>();
-    for (const source of sources) {
-      map.set(source.id, source);
-    }
-    return map;
   }
 }

--- a/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/remove-document-from-knowledge-base/remove-document-from-knowledge-base.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/remove-document-from-knowledge-base/remove-document-from-knowledge-base.use-case.spec.ts
@@ -74,8 +74,6 @@ describe('RemoveDocumentFromKnowledgeBaseUseCase', () => {
       url: 'https://stadt.de/protokoll',
       name: 'Protokoll März 2025',
       type: TextType.WEB,
-      text: 'Protokoll Inhalt',
-      contentChunks: [],
     });
     mockRepository.findSourceByIdAndKnowledgeBaseId.mockResolvedValue(source);
     mockDeleteSourceUseCase.execute.mockResolvedValue(undefined);

--- a/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/remove-document-from-knowledge-base/remove-document-from-knowledge-base.use-case.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/remove-document-from-knowledge-base/remove-document-from-knowledge-base.use-case.ts
@@ -51,7 +51,9 @@ export class RemoveDocumentFromKnowledgeBaseUseCase {
         );
       }
 
-      await this.deleteSourceUseCase.execute(new DeleteSourceCommand(source));
+      await this.deleteSourceUseCase.execute(
+        new DeleteSourceCommand(command.documentId),
+      );
     } catch (error) {
       if (error instanceof ApplicationError) {
         throw error;

--- a/ayunis-core-backend/src/domain/models/application/use-cases/delete-permitted-model/delete-permitted-model.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/delete-permitted-model/delete-permitted-model.use-case.ts
@@ -183,15 +183,15 @@ export class DeletePermittedModelUseCase {
       new FindAllThreadsByOrgWithSourcesQuery(orgId),
     );
 
-    // Collect all sources from all threads
-    const sources = threads
-      .flatMap((t) => t.sourceAssignments?.map((sa) => sa.source) ?? [])
+    // Collect all source IDs from all threads
+    const sourceIds = threads
+      .flatMap((t) => t.sourceAssignments?.map((sa) => sa.source.id) ?? [])
       .filter(Boolean);
 
     // Batch delete RAG index + sources (2 queries total)
-    if (sources.length > 0) {
+    if (sourceIds.length > 0) {
       await this.deleteSourcesUseCase.execute(
-        new DeleteSourcesCommand(sources),
+        new DeleteSourcesCommand(sourceIds),
       );
     }
 

--- a/ayunis-core-backend/src/domain/skills/application/services/skill-activation.service.spec.ts
+++ b/ayunis-core-backend/src/domain/skills/application/services/skill-activation.service.spec.ts
@@ -58,8 +58,6 @@ describe('SkillActivationService', () => {
     new UrlSource({
       id,
       url: `https://example.com/doc-${id}`,
-      contentChunks: [],
-      text: 'Sample document content.',
       name: `Source ${id}`,
       type: TextType.WEB,
     });

--- a/ayunis-core-backend/src/domain/skills/application/use-cases/list-skill-sources/list-skill-sources.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/skills/application/use-cases/list-skill-sources/list-skill-sources.use-case.spec.ts
@@ -112,8 +112,6 @@ describe('ListSkillSourcesUseCase', () => {
       name,
       type: TextType.FILE,
       fileType: FileType.PDF,
-      text: 'test content',
-      contentChunks: [],
     });
   };
 

--- a/ayunis-core-backend/src/domain/skills/application/use-cases/remove-source-from-skill/remove-source-from-skill.use-case.ts
+++ b/ayunis-core-backend/src/domain/skills/application/use-cases/remove-source-from-skill/remove-source-from-skill.use-case.ts
@@ -8,8 +8,6 @@ import { Skill } from '../../../domain/skill.entity';
 import { ApplicationError } from 'src/common/errors/base.error';
 import { DeleteSourceUseCase } from 'src/domain/sources/application/use-cases/delete-source/delete-source.use-case';
 import { DeleteSourceCommand } from 'src/domain/sources/application/use-cases/delete-source/delete-source.command';
-import { GetTextSourceByIdUseCase } from 'src/domain/sources/application/use-cases/get-text-source-by-id/get-text-source-by-id.use-case';
-import { GetTextSourceByIdQuery } from 'src/domain/sources/application/use-cases/get-text-source-by-id/get-text-source-by-id.query';
 
 @Injectable()
 export class RemoveSourceFromSkillUseCase {
@@ -18,7 +16,6 @@ export class RemoveSourceFromSkillUseCase {
   constructor(
     private readonly skillRepository: SkillRepository,
     private readonly contextService: ContextService,
-    private readonly getSourceByIdUseCase: GetTextSourceByIdUseCase,
     private readonly deleteSourceUseCase: DeleteSourceUseCase,
   ) {}
 
@@ -48,11 +45,9 @@ export class RemoveSourceFromSkillUseCase {
         sourceIds: skill.sourceIds.filter((id) => id !== command.sourceId),
       });
 
-      const source = await this.getSourceByIdUseCase.execute(
-        new GetTextSourceByIdQuery(command.sourceId),
+      await this.deleteSourceUseCase.execute(
+        new DeleteSourceCommand(command.sourceId),
       );
-
-      await this.deleteSourceUseCase.execute(new DeleteSourceCommand(source));
       await this.skillRepository.update(updatedSkill);
     } catch (error) {
       if (

--- a/ayunis-core-backend/src/domain/sources/application/ports/source.repository.ts
+++ b/ayunis-core-backend/src/domain/sources/application/ports/source.repository.ts
@@ -2,12 +2,27 @@ import type { UUID } from 'crypto';
 import type { TextSource } from '../../domain/sources/text-source.entity';
 import type { DataSource } from '../../domain/sources/data-source.entity';
 import type { Source } from '../../domain/source.entity';
+import type { TextSourceContentChunk } from '../../domain/source-content-chunk.entity';
 
 export abstract class SourceRepository {
   abstract findById(id: UUID): Promise<TextSource | DataSource | null>;
   abstract findByIds(ids: UUID[]): Promise<Source[]>;
   abstract findByKnowledgeBaseId(knowledgeBaseId: UUID): Promise<Source[]>;
+  abstract saveTextSource(
+    source: TextSource,
+    content: { text: string; chunks: TextSourceContentChunk[] },
+  ): Promise<TextSource>;
   abstract save(source: Source): Promise<Source>;
-  abstract delete(source: Source): Promise<void>;
+  abstract extractTextLines(
+    sourceId: UUID,
+    startLine: number,
+    endLine: number,
+  ): Promise<{ totalLines: number; text: string } | null>;
+  abstract findContentChunksByIds(
+    chunkIds: UUID[],
+  ): Promise<
+    { chunk: TextSourceContentChunk; sourceId: UUID; sourceName: string }[]
+  >;
+  abstract delete(sourceId: UUID): Promise<void>;
   abstract deleteMany(sourceIds: UUID[]): Promise<void>;
 }

--- a/ayunis-core-backend/src/domain/sources/application/use-cases/create-text-source/create-text-source.use-case.ts
+++ b/ayunis-core-backend/src/domain/sources/application/use-cases/create-text-source/create-text-source.use-case.ts
@@ -37,6 +37,12 @@ import { MIME_TYPES } from 'src/common/util/file-type';
 /** Max concurrent embedding API calls per source ingestion to avoid rate limits */
 const EMBEDDING_CONCURRENCY = 20;
 
+interface TextSourceWithContent {
+  source: TextSource;
+  text: string;
+  chunks: TextSourceContentChunk[];
+}
+
 @Injectable()
 export class CreateTextSourceUseCase {
   private readonly logger = new Logger(CreateTextSourceUseCase.name);
@@ -61,18 +67,25 @@ export class CreateTextSourceUseCase {
       if (!orgId) {
         throw new UnauthorizedException('User not authenticated');
       }
-      let source: TextSource;
+      let result: TextSourceWithContent;
       if (command instanceof CreateFileSourceCommand) {
-        source = await this.createFileSource(command);
+        result = await this.createFileSource(command);
       } else if (command instanceof CreateUrlSourceCommand) {
-        source = await this.createUrlSource(command);
+        result = await this.createUrlSource(command);
       } else {
         throw new InvalidSourceTypeError(command.constructor.name);
       }
-      this.logger.debug('Saving source', { sourceId: source.id });
-      await this.sourceRepository.save(source);
-      await this.indexSourceContentChunks({ source, orgId });
-      return source;
+      this.logger.debug('Saving source', { sourceId: result.source.id });
+      const saved = await this.sourceRepository.saveTextSource(result.source, {
+        text: result.text,
+        chunks: result.chunks,
+      });
+      await this.indexSourceContentChunks({
+        sourceId: saved.id,
+        chunks: result.chunks,
+        orgId,
+      });
+      return saved;
     } catch (error) {
       if (error instanceof ApplicationError) throw error;
       this.logger.error('Error creating text source', {
@@ -86,7 +99,7 @@ export class CreateTextSourceUseCase {
 
   private async createFileSource(
     command: CreateFileSourceCommand,
-  ): Promise<FileSource> {
+  ): Promise<TextSourceWithContent> {
     const fileRetrieverResult = await this.retrieveFileContentUseCase.execute(
       new RetrieveFileContentCommand({
         fileData: command.fileData,
@@ -95,36 +108,37 @@ export class CreateTextSourceUseCase {
       }),
     );
     const text = fileRetrieverResult.pages.map((page) => page.text).join('\n');
-    const contentChunks = this.getChunksFromText(text, {
+    const chunks = this.getChunksFromText(text, {
       fileName: command.fileName,
     });
 
-    return new FileSource({
+    const source = new FileSource({
       fileType: this.getFileType(command.fileType),
       name: command.fileName,
-      text,
-      contentChunks,
       type: TextType.FILE,
     });
+
+    return { source, text, chunks };
   }
 
   private async createUrlSource(
     command: CreateUrlSourceCommand,
-  ): Promise<UrlSource> {
+  ): Promise<TextSourceWithContent> {
     const urlRetrieverResult = await this.retrieveUrlUseCase.execute(
       new RetrieveUrlCommand(command.url),
     );
 
-    const sourceContents = this.getChunksFromText(urlRetrieverResult.content, {
+    const chunks = this.getChunksFromText(urlRetrieverResult.content, {
       url: command.url,
     });
-    return new UrlSource({
-      contentChunks: sourceContents,
-      text: urlRetrieverResult.content,
+
+    const source = new UrlSource({
       name: urlRetrieverResult.websiteTitle,
       type: TextType.WEB,
       url: command.url,
     });
+
+    return { source, text: urlRetrieverResult.content, chunks };
   }
 
   private getFileType(mimeType: string): FileType {
@@ -164,8 +178,6 @@ export class CreateTextSourceUseCase {
     );
 
     for (const contentBlock of contentBlocks.chunks) {
-      // Create source content for each content block
-      // Merge source metadata (fileName, URL) with splitter metadata (index, line numbers)
       const chunk = new TextSourceContentChunk({
         content: contentBlock.text,
         meta: {
@@ -187,15 +199,16 @@ export class CreateTextSourceUseCase {
    * Concurrency is capped to avoid hitting embedding API rate limits.
    */
   private async indexSourceContentChunks(params: {
-    source: TextSource;
+    sourceId: UUID;
+    chunks: TextSourceContentChunk[];
     orgId: UUID;
   }): Promise<void> {
-    this.logger.debug(`Indexing content for source: ${params.source.id}`);
+    this.logger.debug(`Indexing content for source: ${params.sourceId}`);
 
     // Step 1: Delete any existing index entries for this source ONCE
     // (handles re-upload/re-index scenarios, no-op for new sources)
     await this.deleteContentUseCase.execute(
-      new DeleteContentCommand({ documentId: params.source.id }),
+      new DeleteContentCommand({ documentId: params.sourceId }),
     );
 
     // Step 2: Ingest all chunks with bounded concurrency
@@ -203,11 +216,11 @@ export class CreateTextSourceUseCase {
     const { default: pLimit } = await import('p-limit');
     const limit = pLimit(EMBEDDING_CONCURRENCY);
     await Promise.all(
-      params.source.contentChunks.map((chunk) =>
+      params.chunks.map((chunk) =>
         limit(async () => {
           const ingestCommand = new IngestContentCommand({
             orgId: params.orgId,
-            documentId: params.source.id,
+            documentId: params.sourceId,
             chunkId: chunk.id,
             content: chunk.content,
             type: IndexType.PARENT_CHILD,
@@ -219,7 +232,7 @@ export class CreateTextSourceUseCase {
     );
 
     this.logger.debug(
-      `Successfully indexed ${params.source.contentChunks.length} content blocks for source: ${params.source.id}`,
+      `Successfully indexed ${params.chunks.length} content blocks for source: ${params.sourceId}`,
     );
   }
 }

--- a/ayunis-core-backend/src/domain/sources/application/use-cases/delete-source/delete-source.command.ts
+++ b/ayunis-core-backend/src/domain/sources/application/use-cases/delete-source/delete-source.command.ts
@@ -1,5 +1,5 @@
-import type { Source } from 'src/domain/sources/domain/source.entity';
+import type { UUID } from 'crypto';
 
 export class DeleteSourceCommand {
-  constructor(public readonly source: Source) {}
+  constructor(public readonly sourceId: UUID) {}
 }

--- a/ayunis-core-backend/src/domain/sources/application/use-cases/delete-source/delete-source.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/sources/application/use-cases/delete-source/delete-source.use-case.spec.ts
@@ -13,8 +13,6 @@ import { DeleteSourceCommand } from './delete-source.command';
 import { DeleteContentUseCase } from 'src/domain/rag/indexers/application/use-cases/delete-content/delete-content.use-case';
 import { SourceRepository } from '../../ports/source.repository';
 import { randomUUID } from 'crypto';
-import { TextType } from 'src/domain/sources/domain/source-type.enum';
-import { UrlSource } from 'src/domain/sources/domain/sources/text-source.entity';
 import { UnexpectedSourceError } from '../../sources.errors';
 
 describe('DeleteSourceUseCase', () => {
@@ -51,23 +49,15 @@ describe('DeleteSourceUseCase', () => {
   });
 
   it('should wrap repository errors into UnexpectedSourceError', async () => {
-    const mockSource = new UrlSource({
-      id: randomUUID(),
-      url: 'https://example.com',
-      name: 'Example URL',
-      type: TextType.WEB,
-      text: 'Example text',
-      contentChunks: [],
-    });
-
+    const sourceId = randomUUID();
     const error = new Error('Repository error');
 
     (mockSourceRepository.delete as jest.Mock).mockRejectedValue(error);
 
     await expect(
-      useCase.execute(new DeleteSourceCommand(mockSource)),
+      useCase.execute(new DeleteSourceCommand(sourceId)),
     ).rejects.toBeInstanceOf(UnexpectedSourceError);
 
-    expect(mockSourceRepository.delete).toHaveBeenCalledWith(mockSource);
+    expect(mockSourceRepository.delete).toHaveBeenCalledWith(sourceId);
   });
 });

--- a/ayunis-core-backend/src/domain/sources/application/use-cases/delete-source/delete-source.use-case.ts
+++ b/ayunis-core-backend/src/domain/sources/application/use-cases/delete-source/delete-source.use-case.ts
@@ -18,18 +18,18 @@ export class DeleteSourceUseCase {
 
   @Transactional()
   async execute(command: DeleteSourceCommand): Promise<void> {
-    this.logger.debug(`Deleting source: ${command.source.id}`);
+    this.logger.debug(`Deleting source: ${command.sourceId}`);
     try {
       // Delete indexed content first
       const deleteContentCommand = new DeleteContentCommand({
-        documentId: command.source.id,
+        documentId: command.sourceId,
       });
 
       await this.deleteContentUseCase.execute(deleteContentCommand);
-      await this.sourceRepository.delete(command.source);
+      await this.sourceRepository.delete(command.sourceId);
 
       this.logger.debug(
-        `Successfully deleted source and indexed content: ${command.source.id}`,
+        `Successfully deleted source and indexed content: ${command.sourceId}`,
       );
     } catch (error) {
       if (error instanceof ApplicationError) {

--- a/ayunis-core-backend/src/domain/sources/application/use-cases/delete-sources/delete-sources.command.ts
+++ b/ayunis-core-backend/src/domain/sources/application/use-cases/delete-sources/delete-sources.command.ts
@@ -1,5 +1,5 @@
-import type { Source } from '../../../domain/source.entity';
+import type { UUID } from 'crypto';
 
 export class DeleteSourcesCommand {
-  constructor(public readonly sources: Source[]) {}
+  constructor(public readonly sourceIds: UUID[]) {}
 }

--- a/ayunis-core-backend/src/domain/sources/application/use-cases/delete-sources/delete-sources.use-case.ts
+++ b/ayunis-core-backend/src/domain/sources/application/use-cases/delete-sources/delete-sources.use-case.ts
@@ -17,25 +17,23 @@ export class DeleteSourcesUseCase {
 
   @Transactional()
   async execute(command: DeleteSourcesCommand): Promise<void> {
-    if (command.sources.length === 0) {
+    if (command.sourceIds.length === 0) {
       return;
     }
 
-    this.logger.debug(`Deleting ${command.sources.length} sources`);
+    this.logger.debug(`Deleting ${command.sourceIds.length} sources`);
     try {
-      const sourceIds = command.sources.map((s) => s.id);
-
       // Batch delete indexed content from all indices
       const indices = this.indexRegistry.getAll();
       for (const index of indices) {
-        await index.deleteMany(sourceIds);
+        await index.deleteMany(command.sourceIds);
       }
 
       // Batch delete sources
-      await this.sourceRepository.deleteMany(sourceIds);
+      await this.sourceRepository.deleteMany(command.sourceIds);
 
       this.logger.debug(
-        `Successfully deleted ${command.sources.length} sources and their indexed content`,
+        `Successfully deleted ${command.sourceIds.length} sources and their indexed content`,
       );
     } catch (error) {
       if (error instanceof ApplicationError) {

--- a/ayunis-core-backend/src/domain/sources/application/use-cases/extract-text-lines/extract-text-lines.query.ts
+++ b/ayunis-core-backend/src/domain/sources/application/use-cases/extract-text-lines/extract-text-lines.query.ts
@@ -1,0 +1,13 @@
+import type { UUID } from 'crypto';
+
+export class ExtractTextLinesQuery {
+  public readonly sourceId: UUID;
+  public readonly startLine: number;
+  public readonly endLine: number;
+
+  constructor(params: { sourceId: UUID; startLine: number; endLine: number }) {
+    this.sourceId = params.sourceId;
+    this.startLine = params.startLine;
+    this.endLine = params.endLine;
+  }
+}

--- a/ayunis-core-backend/src/domain/sources/application/use-cases/extract-text-lines/extract-text-lines.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/sources/application/use-cases/extract-text-lines/extract-text-lines.use-case.spec.ts
@@ -1,0 +1,85 @@
+import type { TestingModule } from '@nestjs/testing';
+import { Test } from '@nestjs/testing';
+import { ExtractTextLinesUseCase } from './extract-text-lines.use-case';
+import { ExtractTextLinesQuery } from './extract-text-lines.query';
+import { SourceRepository } from '../../ports/source.repository';
+import { randomUUID } from 'crypto';
+import { UnexpectedSourceError } from '../../sources.errors';
+
+describe('ExtractTextLinesUseCase', () => {
+  let useCase: ExtractTextLinesUseCase;
+  let mockSourceRepository: Partial<SourceRepository>;
+
+  beforeAll(async () => {
+    mockSourceRepository = {
+      extractTextLines: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ExtractTextLinesUseCase,
+        {
+          provide: SourceRepository,
+          useValue: mockSourceRepository,
+        },
+      ],
+    }).compile();
+
+    useCase = module.get<ExtractTextLinesUseCase>(ExtractTextLinesUseCase);
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return extracted text lines with total line count', async () => {
+    const sourceId = randomUUID();
+    const expected = {
+      totalLines: 150,
+      text: 'Article 1: General Provisions\nArticle 2: Definitions',
+    };
+
+    (mockSourceRepository.extractTextLines as jest.Mock).mockResolvedValue(
+      expected,
+    );
+
+    const result = await useCase.execute(
+      new ExtractTextLinesQuery({ sourceId, startLine: 1, endLine: 50 }),
+    );
+
+    expect(result).toEqual(expected);
+    expect(mockSourceRepository.extractTextLines).toHaveBeenCalledWith(
+      sourceId,
+      1,
+      50,
+    );
+  });
+
+  it('should return null when source text is not found', async () => {
+    const sourceId = randomUUID();
+
+    (mockSourceRepository.extractTextLines as jest.Mock).mockResolvedValue(
+      null,
+    );
+
+    const result = await useCase.execute(
+      new ExtractTextLinesQuery({ sourceId, startLine: 1, endLine: 100 }),
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it('should wrap unexpected errors in UnexpectedSourceError', async () => {
+    const sourceId = randomUUID();
+
+    (mockSourceRepository.extractTextLines as jest.Mock).mockRejectedValue(
+      new Error('Database connection lost'),
+    );
+
+    await expect(
+      useCase.execute(
+        new ExtractTextLinesQuery({ sourceId, startLine: 1, endLine: 50 }),
+      ),
+    ).rejects.toThrow(UnexpectedSourceError);
+  });
+});

--- a/ayunis-core-backend/src/domain/sources/application/use-cases/extract-text-lines/extract-text-lines.use-case.ts
+++ b/ayunis-core-backend/src/domain/sources/application/use-cases/extract-text-lines/extract-text-lines.use-case.ts
@@ -1,0 +1,43 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ApplicationError } from 'src/common/errors/base.error';
+import { SourceRepository } from '../../ports/source.repository';
+import { UnexpectedSourceError } from '../../sources.errors';
+import { ExtractTextLinesQuery } from './extract-text-lines.query';
+
+export interface ExtractTextLinesResult {
+  totalLines: number;
+  text: string;
+}
+
+@Injectable()
+export class ExtractTextLinesUseCase {
+  private readonly logger = new Logger(ExtractTextLinesUseCase.name);
+
+  constructor(private readonly sourceRepository: SourceRepository) {}
+
+  async execute(
+    query: ExtractTextLinesQuery,
+  ): Promise<ExtractTextLinesResult | null> {
+    this.logger.log('Extracting text lines', {
+      sourceId: query.sourceId,
+      startLine: query.startLine,
+      endLine: query.endLine,
+    });
+
+    try {
+      return await this.sourceRepository.extractTextLines(
+        query.sourceId,
+        query.startLine,
+        query.endLine,
+      );
+    } catch (error) {
+      if (error instanceof ApplicationError) throw error;
+      this.logger.error('Error extracting text lines', {
+        error: error as Error,
+      });
+      throw new UnexpectedSourceError(
+        error instanceof Error ? error.message : 'Unknown error',
+      );
+    }
+  }
+}

--- a/ayunis-core-backend/src/domain/sources/application/use-cases/find-content-chunks-by-ids/find-content-chunks-by-ids.query.ts
+++ b/ayunis-core-backend/src/domain/sources/application/use-cases/find-content-chunks-by-ids/find-content-chunks-by-ids.query.ts
@@ -1,0 +1,5 @@
+import type { UUID } from 'crypto';
+
+export class FindContentChunksByIdsQuery {
+  constructor(public readonly chunkIds: UUID[]) {}
+}

--- a/ayunis-core-backend/src/domain/sources/application/use-cases/find-content-chunks-by-ids/find-content-chunks-by-ids.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/sources/application/use-cases/find-content-chunks-by-ids/find-content-chunks-by-ids.use-case.spec.ts
@@ -1,0 +1,85 @@
+import type { TestingModule } from '@nestjs/testing';
+import { Test } from '@nestjs/testing';
+import { FindContentChunksByIdsUseCase } from './find-content-chunks-by-ids.use-case';
+import { FindContentChunksByIdsQuery } from './find-content-chunks-by-ids.query';
+import { SourceRepository } from '../../ports/source.repository';
+import { randomUUID } from 'crypto';
+import { TextSourceContentChunk } from '../../../domain/source-content-chunk.entity';
+import { UnexpectedSourceError } from '../../sources.errors';
+import type { UUID } from 'crypto';
+
+describe('FindContentChunksByIdsUseCase', () => {
+  let useCase: FindContentChunksByIdsUseCase;
+  let mockSourceRepository: Partial<SourceRepository>;
+
+  beforeAll(async () => {
+    mockSourceRepository = {
+      findContentChunksByIds: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        FindContentChunksByIdsUseCase,
+        {
+          provide: SourceRepository,
+          useValue: mockSourceRepository,
+        },
+      ],
+    }).compile();
+
+    useCase = module.get<FindContentChunksByIdsUseCase>(
+      FindContentChunksByIdsUseCase,
+    );
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return content chunks with source metadata', async () => {
+    const chunkId = randomUUID();
+    const sourceId = randomUUID();
+    const chunk = new TextSourceContentChunk({
+      id: chunkId,
+      content: 'Municipal zoning regulation section 4.2',
+      meta: { lineStart: 1, lineEnd: 10 },
+    });
+    const expected = [
+      { chunk, sourceId, sourceName: 'Zoning Regulations 2025.pdf' },
+    ];
+
+    (
+      mockSourceRepository.findContentChunksByIds as jest.Mock
+    ).mockResolvedValue(expected);
+
+    const result = await useCase.execute(
+      new FindContentChunksByIdsQuery([chunkId]),
+    );
+
+    expect(result).toEqual(expected);
+    expect(mockSourceRepository.findContentChunksByIds).toHaveBeenCalledWith([
+      chunkId,
+    ]);
+  });
+
+  it('should return empty array when no chunk IDs provided', async () => {
+    const result = await useCase.execute(
+      new FindContentChunksByIdsQuery([] as UUID[]),
+    );
+
+    expect(result).toEqual([]);
+    expect(mockSourceRepository.findContentChunksByIds).not.toHaveBeenCalled();
+  });
+
+  it('should wrap unexpected errors in UnexpectedSourceError', async () => {
+    const chunkId = randomUUID();
+
+    (
+      mockSourceRepository.findContentChunksByIds as jest.Mock
+    ).mockRejectedValue(new Error('Database connection lost'));
+
+    await expect(
+      useCase.execute(new FindContentChunksByIdsQuery([chunkId])),
+    ).rejects.toThrow(UnexpectedSourceError);
+  });
+});

--- a/ayunis-core-backend/src/domain/sources/application/use-cases/find-content-chunks-by-ids/find-content-chunks-by-ids.use-case.ts
+++ b/ayunis-core-backend/src/domain/sources/application/use-cases/find-content-chunks-by-ids/find-content-chunks-by-ids.use-case.ts
@@ -1,0 +1,44 @@
+import { Injectable, Logger } from '@nestjs/common';
+import type { UUID } from 'crypto';
+import { ApplicationError } from 'src/common/errors/base.error';
+import type { TextSourceContentChunk } from '../../../domain/source-content-chunk.entity';
+import { SourceRepository } from '../../ports/source.repository';
+import { UnexpectedSourceError } from '../../sources.errors';
+import { FindContentChunksByIdsQuery } from './find-content-chunks-by-ids.query';
+
+export interface ContentChunkWithSource {
+  chunk: TextSourceContentChunk;
+  sourceId: UUID;
+  sourceName: string;
+}
+
+@Injectable()
+export class FindContentChunksByIdsUseCase {
+  private readonly logger = new Logger(FindContentChunksByIdsUseCase.name);
+
+  constructor(private readonly sourceRepository: SourceRepository) {}
+
+  async execute(
+    query: FindContentChunksByIdsQuery,
+  ): Promise<ContentChunkWithSource[]> {
+    this.logger.log('Finding content chunks by IDs', {
+      count: query.chunkIds.length,
+    });
+
+    try {
+      if (query.chunkIds.length === 0) {
+        return [];
+      }
+
+      return await this.sourceRepository.findContentChunksByIds(query.chunkIds);
+    } catch (error) {
+      if (error instanceof ApplicationError) throw error;
+      this.logger.error('Error finding content chunks by IDs', {
+        error: error as Error,
+      });
+      throw new UnexpectedSourceError(
+        error instanceof Error ? error.message : 'Unknown error',
+      );
+    }
+  }
+}

--- a/ayunis-core-backend/src/domain/sources/application/use-cases/get-sources-by-ids/get-sources-by-ids.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/sources/application/use-cases/get-sources-by-ids/get-sources-by-ids.use-case.spec.ts
@@ -28,7 +28,10 @@ describe('GetSourcesByIdsUseCase', () => {
       findById: jest.fn(),
       findByIds: jest.fn(),
       findByKnowledgeBaseId: jest.fn(),
+      saveTextSource: jest.fn(),
       save: jest.fn(),
+      extractTextLines: jest.fn(),
+      findContentChunksByIds: jest.fn(),
       delete: jest.fn(),
       deleteMany: jest.fn(),
     } as jest.Mocked<SourceRepository>;

--- a/ayunis-core-backend/src/domain/sources/application/use-cases/get-sources-by-knowledge-base-id/get-sources-by-knowledge-base-id.query.ts
+++ b/ayunis-core-backend/src/domain/sources/application/use-cases/get-sources-by-knowledge-base-id/get-sources-by-knowledge-base-id.query.ts
@@ -1,0 +1,5 @@
+import type { UUID } from 'crypto';
+
+export class GetSourcesByKnowledgeBaseIdQuery {
+  constructor(public readonly knowledgeBaseId: UUID) {}
+}

--- a/ayunis-core-backend/src/domain/sources/application/use-cases/get-sources-by-knowledge-base-id/get-sources-by-knowledge-base-id.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/sources/application/use-cases/get-sources-by-knowledge-base-id/get-sources-by-knowledge-base-id.use-case.spec.ts
@@ -1,0 +1,84 @@
+import type { TestingModule } from '@nestjs/testing';
+import { Test } from '@nestjs/testing';
+import { GetSourcesByKnowledgeBaseIdUseCase } from './get-sources-by-knowledge-base-id.use-case';
+import { GetSourcesByKnowledgeBaseIdQuery } from './get-sources-by-knowledge-base-id.query';
+import { SourceRepository } from '../../ports/source.repository';
+import { randomUUID } from 'crypto';
+import { UnexpectedSourceError } from '../../sources.errors';
+import type { Source } from '../../../domain/source.entity';
+
+describe('GetSourcesByKnowledgeBaseIdUseCase', () => {
+  let useCase: GetSourcesByKnowledgeBaseIdUseCase;
+  let mockSourceRepository: Partial<SourceRepository>;
+
+  beforeAll(async () => {
+    mockSourceRepository = {
+      findByKnowledgeBaseId: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        GetSourcesByKnowledgeBaseIdUseCase,
+        {
+          provide: SourceRepository,
+          useValue: mockSourceRepository,
+        },
+      ],
+    }).compile();
+
+    useCase = module.get<GetSourcesByKnowledgeBaseIdUseCase>(
+      GetSourcesByKnowledgeBaseIdUseCase,
+    );
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return sources belonging to the knowledge base', async () => {
+    const knowledgeBaseId = randomUUID();
+    const sourceId = randomUUID();
+    const mockSources = [
+      { id: sourceId, name: 'Haushaltssatzung_2025.pdf' },
+    ] as Source[];
+
+    (mockSourceRepository.findByKnowledgeBaseId as jest.Mock).mockResolvedValue(
+      mockSources,
+    );
+
+    const result = await useCase.execute(
+      new GetSourcesByKnowledgeBaseIdQuery(knowledgeBaseId),
+    );
+
+    expect(result).toEqual(mockSources);
+    expect(mockSourceRepository.findByKnowledgeBaseId).toHaveBeenCalledWith(
+      knowledgeBaseId,
+    );
+  });
+
+  it('should return empty array when knowledge base has no sources', async () => {
+    const knowledgeBaseId = randomUUID();
+
+    (mockSourceRepository.findByKnowledgeBaseId as jest.Mock).mockResolvedValue(
+      [],
+    );
+
+    const result = await useCase.execute(
+      new GetSourcesByKnowledgeBaseIdQuery(knowledgeBaseId),
+    );
+
+    expect(result).toEqual([]);
+  });
+
+  it('should wrap unexpected errors in UnexpectedSourceError', async () => {
+    const knowledgeBaseId = randomUUID();
+
+    (mockSourceRepository.findByKnowledgeBaseId as jest.Mock).mockRejectedValue(
+      new Error('Database connection lost'),
+    );
+
+    await expect(
+      useCase.execute(new GetSourcesByKnowledgeBaseIdQuery(knowledgeBaseId)),
+    ).rejects.toThrow(UnexpectedSourceError);
+  });
+});

--- a/ayunis-core-backend/src/domain/sources/application/use-cases/get-sources-by-knowledge-base-id/get-sources-by-knowledge-base-id.use-case.ts
+++ b/ayunis-core-backend/src/domain/sources/application/use-cases/get-sources-by-knowledge-base-id/get-sources-by-knowledge-base-id.use-case.ts
@@ -1,0 +1,33 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ApplicationError } from 'src/common/errors/base.error';
+import type { Source } from '../../../domain/source.entity';
+import { SourceRepository } from '../../ports/source.repository';
+import { UnexpectedSourceError } from '../../sources.errors';
+import { GetSourcesByKnowledgeBaseIdQuery } from './get-sources-by-knowledge-base-id.query';
+
+@Injectable()
+export class GetSourcesByKnowledgeBaseIdUseCase {
+  private readonly logger = new Logger(GetSourcesByKnowledgeBaseIdUseCase.name);
+
+  constructor(private readonly sourceRepository: SourceRepository) {}
+
+  async execute(query: GetSourcesByKnowledgeBaseIdQuery): Promise<Source[]> {
+    this.logger.log('Finding sources by knowledge base ID', {
+      knowledgeBaseId: query.knowledgeBaseId,
+    });
+
+    try {
+      return await this.sourceRepository.findByKnowledgeBaseId(
+        query.knowledgeBaseId,
+      );
+    } catch (error) {
+      if (error instanceof ApplicationError) throw error;
+      this.logger.error('Error finding sources by knowledge base ID', {
+        error: error as Error,
+      });
+      throw new UnexpectedSourceError(
+        error instanceof Error ? error.message : 'Unknown error',
+      );
+    }
+  }
+}

--- a/ayunis-core-backend/src/domain/sources/application/use-cases/query-text-source/query-text-source.use-case.ts
+++ b/ayunis-core-backend/src/domain/sources/application/use-cases/query-text-source/query-text-source.use-case.ts
@@ -4,8 +4,7 @@ import { QueryTextSourceCommand } from './query-text-source.command';
 import { SearchContentUseCase } from 'src/domain/rag/indexers/application/use-cases/search-content/search-content.use-case';
 import { SearchContentQuery } from 'src/domain/rag/indexers/application/use-cases/search-content/search-content.query';
 import { IndexType } from 'src/domain/rag/indexers/domain/value-objects/index-type.enum';
-import { TextSourceContentChunk } from 'src/domain/sources/domain/source-content-chunk.entity';
-import { TextSource } from 'src/domain/sources/domain/sources/text-source.entity';
+import type { TextSourceContentChunk } from 'src/domain/sources/domain/source-content-chunk.entity';
 
 @Injectable()
 export class QueryTextSourceUseCase {
@@ -46,40 +45,20 @@ export class QueryTextSourceUseCase {
         `Found ${indexEntries.length} index entries for query: "${command.query}" in source: ${command.filter.sourceId}`,
       );
 
-      // Fetch the actual source content for each index entry
-      const sourceContentMatches: TextSourceContentChunk[] = [];
-
-      for (const indexEntry of indexEntries) {
-        // Get the source first to access its content
-        const source = await this.sourceRepository.findById(
-          indexEntry.relatedDocumentId,
-        );
-
-        if (source && source instanceof TextSource && source.contentChunks) {
-          // Find the specific content chunk by ID
-          const sourceContent = source.contentChunks.find(
-            (content) => content.id === indexEntry.relatedChunkId,
-          );
-
-          if (sourceContent) {
-            sourceContentMatches.push(sourceContent);
-          } else {
-            this.logger.warn(
-              `Source content with ID ${indexEntry.relatedChunkId} not found in source ${indexEntry.relatedDocumentId}`,
-            );
-          }
-        } else {
-          this.logger.warn(
-            `Source with ID ${indexEntry.relatedDocumentId} not found or has no content`,
-          );
-        }
+      if (indexEntries.length === 0) {
+        return [];
       }
 
+      // Fetch all matched chunks in a single query
+      const chunkIds = indexEntries.map((entry) => entry.relatedChunkId);
+      const chunkResults =
+        await this.sourceRepository.findContentChunksByIds(chunkIds);
+
       this.logger.debug(
-        `Successfully matched ${sourceContentMatches.length} source content items for query: "${command.query}" in source: ${command.filter.sourceId}`,
+        `Successfully matched ${chunkResults.length} source content items for query: "${command.query}" in source: ${command.filter.sourceId}`,
       );
 
-      return sourceContentMatches;
+      return chunkResults.map((r) => r.chunk);
     } catch (error) {
       this.logger.error(
         `Error during vector search for query "${command.query}":`,

--- a/ayunis-core-backend/src/domain/sources/domain/sources/text-source.entity.ts
+++ b/ayunis-core-backend/src/domain/sources/domain/sources/text-source.entity.ts
@@ -2,29 +2,22 @@ import type { UUID } from 'crypto';
 import { Source } from '../source.entity';
 import type { FileType } from '../source-type.enum';
 import { SourceType, TextType } from '../source-type.enum';
-import type { TextSourceContentChunk } from '../source-content-chunk.entity';
 import type { SourceCreator } from '../source-creator.enum';
 
 export abstract class TextSource extends Source {
-  contentChunks: TextSourceContentChunk[];
   textType: TextType;
-  text: string;
 
   constructor(params: {
     id?: UUID;
     name: string;
     type: TextType;
-    text: string;
-    contentChunks: TextSourceContentChunk[];
     knowledgeBaseId?: UUID | null;
     createdBy?: SourceCreator;
     createdAt?: Date;
     updatedAt?: Date;
   }) {
     super({ ...params, type: SourceType.TEXT });
-    this.text = params.text;
     this.textType = params.type;
-    this.contentChunks = params.contentChunks;
   }
 }
 
@@ -36,8 +29,6 @@ export class FileSource extends TextSource {
     fileType: FileType;
     name: string;
     type: TextType;
-    text: string;
-    contentChunks: TextSourceContentChunk[];
     knowledgeBaseId?: UUID | null;
     createdBy?: SourceCreator;
     createdAt?: Date;
@@ -54,8 +45,6 @@ export class UrlSource extends TextSource {
   constructor(params: {
     id?: UUID;
     url: string;
-    contentChunks: TextSourceContentChunk[];
-    text: string;
     name: string;
     type: TextType;
     knowledgeBaseId?: UUID | null;

--- a/ayunis-core-backend/src/domain/sources/infrastructure/persistence/local/local-source.repository.ts
+++ b/ayunis-core-backend/src/domain/sources/infrastructure/persistence/local/local-source.repository.ts
@@ -1,6 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { In, Repository } from 'typeorm';
+import { Repository } from 'typeorm';
 import { UUID } from 'crypto';
 import { TextSource } from '../../../domain/sources/text-source.entity';
 import { DataSource } from '../../../domain/sources/data-source.entity';
@@ -15,6 +15,8 @@ import {
 import { DataSourceDetailsRecord } from './schema/data-source-details.record';
 import { Source } from 'src/domain/sources/domain/source.entity';
 import { SourceContentChunkRecord } from './schema/source-content-chunk.record';
+import type { TextSourceContentChunk } from 'src/domain/sources/domain/source-content-chunk.entity';
+import { SourceContentChunkMapper } from './mappers/source-content-chunk.mapper';
 
 @Injectable()
 export class LocalSourceRepository extends SourceRepository {
@@ -30,6 +32,7 @@ export class LocalSourceRepository extends SourceRepository {
     @InjectRepository(SourceContentChunkRecord)
     private readonly sourceContentChunkRepository: Repository<SourceContentChunkRecord>,
     private readonly mapper: SourceMapper,
+    private readonly chunkMapper: SourceContentChunkMapper,
   ) {
     super();
   }
@@ -45,16 +48,12 @@ export class LocalSourceRepository extends SourceRepository {
     if (record instanceof TextSourceRecord) {
       const textSourceDetails = await this.textSourceDetailsRepository.findOne({
         where: { source: { id } },
-        relations: {
-          contentChunks: true,
-        },
       });
       if (!textSourceDetails) {
         return null;
       }
       record.textSourceDetails = textSourceDetails;
-      const source = this.mapper.toDomain(record);
-      return source;
+      return this.mapper.toDomain(record);
     }
     if (record instanceof DataSourceRecord) {
       const dataSourceDetails = await this.dataSourceDetailsRepository.findOne({
@@ -64,8 +63,7 @@ export class LocalSourceRepository extends SourceRepository {
         return null;
       }
       record.dataSourceDetails = dataSourceDetails;
-      const source = this.mapper.toDomain(record);
-      return source;
+      return this.mapper.toDomain(record);
     }
 
     return null;
@@ -76,44 +74,62 @@ export class LocalSourceRepository extends SourceRepository {
     if (ids.length === 0) {
       return [];
     }
-    const records = await this.sourceRepository.find({
-      where: { id: In(ids) },
-    });
+    const records = await this.sourceRepository
+      .createQueryBuilder('source')
+      .leftJoinAndSelect(
+        'source.dataSourceDetails',
+        'dataSourceDetails',
+        'source.type = :dataType',
+        { dataType: 'data' },
+      )
+      .where('source.id IN (:...ids)', { ids })
+      .getMany();
     return records.map((record) => this.mapper.toDomain(record));
   }
 
   async findByKnowledgeBaseId(knowledgeBaseId: UUID): Promise<Source[]> {
     this.logger.log('findByKnowledgeBaseId', { knowledgeBaseId });
-    const records = await this.sourceRepository.find({
-      where: { knowledgeBaseId },
-    });
+    const records = await this.sourceRepository
+      .createQueryBuilder('source')
+      .leftJoinAndSelect(
+        'source.dataSourceDetails',
+        'dataSourceDetails',
+        'source.type = :dataType',
+        { dataType: 'data' },
+      )
+      .where('source.knowledgeBaseId = :knowledgeBaseId', { knowledgeBaseId })
+      .getMany();
     return records.map((record) => this.mapper.toDomain(record));
   }
 
-  async save(source: TextSource): Promise<TextSource>;
+  async saveTextSource(
+    source: TextSource,
+    content: { text: string; chunks: TextSourceContentChunk[] },
+  ): Promise<TextSource> {
+    this.logger.log('saveTextSource', { sourceId: source.id });
+    const {
+      source: sourceRecord,
+      details,
+      contentChunks,
+    } = this.mapper.toTextSourceRecord(source, content);
+    this.logger.debug('Saving text source record', {
+      sourceId: sourceRecord.id,
+      chunksCount: contentChunks.length,
+    });
+    const savedSource = await this.sourceRepository.save(sourceRecord);
+    this.logger.debug('Saved source record with id', { id: savedSource.id });
+    const savedDetails = await this.textSourceDetailsRepository.save(details);
+    const savedContentChunks =
+      await this.sourceContentChunkRepository.save(contentChunks);
+    savedSource.textSourceDetails = savedDetails;
+    savedDetails.contentChunks = savedContentChunks;
+    return this.mapper.toDomain(savedSource as TextSourceRecord);
+  }
+
   async save(source: DataSource): Promise<DataSource>;
   async save(source: Source): Promise<Source>;
   async save(source: Source): Promise<Source> {
     this.logger.log('save', { sourceId: source.id });
-    if (source instanceof TextSource) {
-      const {
-        source: sourceRecord,
-        details,
-        contentChunks,
-      } = this.mapper.toRecord(source);
-      this.logger.debug('Saving source record', {
-        sourceId: sourceRecord.id,
-        chunksCount: contentChunks.length,
-      });
-      const savedSource = await this.sourceRepository.save(sourceRecord);
-      this.logger.debug('Saved source record with id', { id: savedSource.id });
-      const savedDetails = await this.textSourceDetailsRepository.save(details);
-      const savedContentChunks =
-        await this.sourceContentChunkRepository.save(contentChunks);
-      savedSource.textSourceDetails = savedDetails;
-      savedDetails.contentChunks = savedContentChunks;
-      return this.mapper.toDomain(savedSource);
-    }
     if (source instanceof DataSource) {
       const { source: sourceRecord, details } = this.mapper.toRecord(source);
       sourceRecord.dataSourceDetails = details;
@@ -123,13 +139,67 @@ export class LocalSourceRepository extends SourceRepository {
       savedSource.dataSourceDetails = savedDetails;
       return this.mapper.toDomain(savedSource);
     }
-    throw new Error('Invalid source type');
+    throw new Error('Use saveTextSource for TextSource entities');
   }
 
-  async delete(source: Source): Promise<void> {
-    this.logger.log('delete', { sourceId: source.id });
-    const { source: record } = this.mapper.toRecord(source);
-    await this.sourceRepository.remove(record);
+  async extractTextLines(
+    sourceId: UUID,
+    startLine: number,
+    endLine: number,
+  ): Promise<{ totalLines: number; text: string } | null> {
+    this.logger.log('extractTextLines', { sourceId, startLine, endLine });
+    const result: { totalLines: string; text: string }[] =
+      await this.textSourceDetailsRepository.query(
+        `SELECT
+          array_length(string_to_array(text, E'\\n'), 1) AS "totalLines",
+          array_to_string(
+            (string_to_array(text, E'\\n'))[$1:$2],
+            E'\\n'
+          ) AS "text"
+        FROM text_source_details_record
+        WHERE "sourceId" = $3`,
+        [startLine, endLine, sourceId],
+      );
+    if (result.length === 0) {
+      return null;
+    }
+    return {
+      totalLines: parseInt(result[0].totalLines, 10),
+      text: result[0].text,
+    };
+  }
+
+  async findContentChunksByIds(
+    chunkIds: UUID[],
+  ): Promise<
+    { chunk: TextSourceContentChunk; sourceId: UUID; sourceName: string }[]
+  > {
+    this.logger.log('findContentChunksByIds', { count: chunkIds.length });
+    if (chunkIds.length === 0) {
+      return [];
+    }
+    const records = await this.sourceContentChunkRepository
+      .createQueryBuilder('chunk')
+      .innerJoinAndSelect('chunk.source', 'details')
+      .innerJoin('details.source', 'source')
+      .addSelect(['source.id', 'source.name'])
+      .where('chunk.id IN (:...ids)', { ids: chunkIds })
+      .getMany();
+
+    return records.map((record) => ({
+      chunk: this.chunkMapper.toDomain(record),
+      sourceId: record.source.source.id,
+      sourceName: record.source.source.name,
+    }));
+  }
+
+  async delete(sourceId: UUID): Promise<void> {
+    this.logger.log('delete', { sourceId });
+    await this.sourceRepository
+      .createQueryBuilder()
+      .delete()
+      .where('id = :id', { id: sourceId })
+      .execute();
   }
 
   async deleteMany(sourceIds: UUID[]): Promise<void> {

--- a/ayunis-core-backend/src/domain/sources/infrastructure/persistence/local/mappers/source.mapper.spec.ts
+++ b/ayunis-core-backend/src/domain/sources/infrastructure/persistence/local/mappers/source.mapper.spec.ts
@@ -2,9 +2,24 @@ import { randomUUID } from 'crypto';
 import { SourceMapper } from './source.mapper';
 import type { SourceContentChunkMapper } from './source-content-chunk.mapper';
 import { CSVDataSource } from 'src/domain/sources/domain/sources/data-source.entity';
+import {
+  FileSource,
+  UrlSource,
+} from 'src/domain/sources/domain/sources/text-source.entity';
 import { SourceCreator } from 'src/domain/sources/domain/source-creator.enum';
-import { DataSourceRecord } from '../schema/source.record';
+import {
+  DataType,
+  FileType,
+  TextType,
+} from 'src/domain/sources/domain/source-type.enum';
+import { DataSourceRecord, TextSourceRecord } from '../schema/source.record';
 import { CSVDataSourceDetailsRecord } from '../schema/data-source-details.record';
+import {
+  FileSourceDetailsRecord,
+  UrlSourceDetailsRecord,
+} from '../schema/text-source-details.record';
+import { TextSourceContentChunk } from 'src/domain/sources/domain/source-content-chunk.entity';
+import { SourceContentChunkRecord } from '../schema/source-content-chunk.record';
 
 describe('SourceMapper', () => {
   let mapper: SourceMapper;
@@ -13,7 +28,7 @@ describe('SourceMapper', () => {
   beforeEach(() => {
     mockContentChunkMapper = {
       toDomain: jest.fn(),
-      toRecord: jest.fn(),
+      toRecord: jest.fn().mockReturnValue(new SourceContentChunkRecord()),
     };
     mapper = new SourceMapper(
       mockContentChunkMapper as SourceContentChunkMapper,
@@ -27,6 +42,7 @@ describe('SourceMapper', () => {
         record.id = randomUUID();
         record.name = 'Test CSV';
         record.createdBy = SourceCreator.USER;
+        record.dataType = DataType.CSV;
         record.createdAt = new Date();
         record.updatedAt = new Date();
 
@@ -45,6 +61,7 @@ describe('SourceMapper', () => {
         record.id = randomUUID();
         record.name = 'Test CSV';
         record.createdBy = SourceCreator.LLM;
+        record.dataType = DataType.CSV;
         record.createdAt = new Date();
         record.updatedAt = new Date();
 
@@ -63,6 +80,7 @@ describe('SourceMapper', () => {
         record.id = randomUUID();
         record.name = 'Test CSV';
         record.createdBy = SourceCreator.SYSTEM;
+        record.dataType = DataType.CSV;
         record.createdAt = new Date();
         record.updatedAt = new Date();
 
@@ -119,6 +137,123 @@ describe('SourceMapper', () => {
         expect(record).toBeInstanceOf(DataSourceRecord);
         expect(record.createdBy).toBe(SourceCreator.SYSTEM);
       });
+    });
+  });
+
+  describe('TextSource toDomain', () => {
+    it('should map FileSource from record columns without loading details', () => {
+      const record = new TextSourceRecord();
+      record.id = randomUUID();
+      record.name = 'Test File';
+      record.createdBy = SourceCreator.USER;
+      record.knowledgeBaseId = null;
+      record.textType = TextType.FILE;
+      record.fileType = FileType.PDF;
+      record.url = null;
+      record.createdAt = new Date();
+      record.updatedAt = new Date();
+      // textSourceDetails intentionally NOT set
+
+      const domain = mapper.toDomain(record);
+
+      expect(domain).toBeInstanceOf(FileSource);
+      expect(domain.name).toBe('Test File');
+      expect((domain as FileSource).fileType).toBe(FileType.PDF);
+      expect('text' in domain).toBe(false);
+      expect('contentChunks' in domain).toBe(false);
+    });
+
+    it('should map UrlSource from record columns without loading details', () => {
+      const record = new TextSourceRecord();
+      record.id = randomUUID();
+      record.name = 'Test URL';
+      record.createdBy = SourceCreator.USER;
+      record.knowledgeBaseId = null;
+      record.textType = TextType.WEB;
+      record.fileType = null;
+      record.url = 'https://example.com';
+      record.createdAt = new Date();
+      record.updatedAt = new Date();
+      // textSourceDetails intentionally NOT set
+
+      const domain = mapper.toDomain(record);
+
+      expect(domain).toBeInstanceOf(UrlSource);
+      expect(domain.name).toBe('Test URL');
+      expect((domain as UrlSource).url).toBe('https://example.com');
+      expect('text' in domain).toBe(false);
+      expect('contentChunks' in domain).toBe(false);
+    });
+  });
+
+  describe('toTextSourceRecord', () => {
+    it('should create records for FileSource with content', () => {
+      const source = new FileSource({
+        id: randomUUID(),
+        fileType: FileType.PDF,
+        name: 'Test File',
+        type: TextType.FILE,
+        createdBy: SourceCreator.USER,
+      });
+
+      const chunks = [
+        new TextSourceContentChunk({
+          content: 'chunk 1',
+          meta: { page: 1 },
+        }),
+      ];
+
+      const result = mapper.toTextSourceRecord(source, {
+        text: 'full text',
+        chunks,
+      });
+
+      expect(result.source).toBeInstanceOf(TextSourceRecord);
+      expect(result.source.id).toBe(source.id);
+      expect(result.source.textType).toBe(TextType.FILE);
+      expect(result.source.fileType).toBe(FileType.PDF);
+      expect(result.source.url).toBeNull();
+      expect(result.details).toBeInstanceOf(FileSourceDetailsRecord);
+      expect(result.details.text).toBe('full text');
+      expect(result.contentChunks).toHaveLength(1);
+      expect(mockContentChunkMapper.toRecord).toHaveBeenCalledWith(
+        result.details,
+        chunks[0],
+      );
+    });
+
+    it('should create records for UrlSource with content', () => {
+      const source = new UrlSource({
+        id: randomUUID(),
+        url: 'https://example.com',
+        name: 'Test URL',
+        type: TextType.WEB,
+        createdBy: SourceCreator.USER,
+      });
+
+      const chunks = [
+        new TextSourceContentChunk({
+          content: 'chunk 1',
+          meta: {},
+        }),
+        new TextSourceContentChunk({
+          content: 'chunk 2',
+          meta: {},
+        }),
+      ];
+
+      const result = mapper.toTextSourceRecord(source, {
+        text: 'full url text',
+        chunks,
+      });
+
+      expect(result.source).toBeInstanceOf(TextSourceRecord);
+      expect(result.source.textType).toBe(TextType.WEB);
+      expect(result.source.fileType).toBeNull();
+      expect(result.source.url).toBe('https://example.com');
+      expect(result.details).toBeInstanceOf(UrlSourceDetailsRecord);
+      expect(result.details.text).toBe('full url text');
+      expect(result.contentChunks).toHaveLength(2);
     });
   });
 });

--- a/ayunis-core-backend/src/domain/sources/infrastructure/persistence/local/mappers/source.mapper.ts
+++ b/ayunis-core-backend/src/domain/sources/infrastructure/persistence/local/mappers/source.mapper.ts
@@ -26,6 +26,7 @@ import {
 } from '../schema/source.record';
 import { TextType } from 'src/domain/sources/domain/source-type.enum';
 import { SourceContentChunkRecord } from '../schema/source-content-chunk.record';
+import type { TextSourceContentChunk } from 'src/domain/sources/domain/source-content-chunk.entity';
 
 @Injectable()
 export class SourceMapper {
@@ -48,60 +49,68 @@ export class SourceMapper {
     throw new Error(`Invalid source type`);
   }
 
-  private mapContentChunks(
-    details: TextSourceDetailsRecord,
-  ): ReturnType<SourceContentChunkMapper['toDomain']>[] {
-    return (details.contentChunks ?? []).map((c) =>
-      this.sourceContentChunkMapper.toDomain(c),
-    );
-  }
-
   private textSourceToDomain(record: TextSourceRecord): TextSource {
-    if (record.textSourceDetails instanceof FileSourceDetailsRecord) {
-      return new FileSource({
-        id: record.id,
-        fileType: record.textSourceDetails.fileType,
-        name: record.name,
-        type: TextType.FILE,
-        text: record.textSourceDetails.text,
-        contentChunks: this.mapContentChunks(record.textSourceDetails),
-        knowledgeBaseId: record.knowledgeBaseId,
-        createdAt: record.createdAt,
-        updatedAt: record.updatedAt,
-        createdBy: record.createdBy,
-      });
+    switch (record.textType) {
+      case TextType.FILE:
+        return new FileSource({
+          id: record.id,
+          fileType: record.fileType!,
+          name: record.name,
+          type: TextType.FILE,
+          knowledgeBaseId: record.knowledgeBaseId,
+          createdAt: record.createdAt,
+          updatedAt: record.updatedAt,
+          createdBy: record.createdBy,
+        });
+      case TextType.WEB:
+        return new UrlSource({
+          id: record.id,
+          url: record.url!,
+          name: record.name,
+          type: TextType.WEB,
+          knowledgeBaseId: record.knowledgeBaseId,
+          createdAt: record.createdAt,
+          updatedAt: record.updatedAt,
+          createdBy: record.createdBy,
+        });
+      default:
+        throw new Error(`Invalid source type: ${String(record.textType)}`);
     }
-    if (record.textSourceDetails instanceof UrlSourceDetailsRecord) {
-      return new UrlSource({
-        id: record.id,
-        url: record.textSourceDetails.url,
-        name: record.name,
-        type: TextType.WEB,
-        text: record.textSourceDetails.text,
-        contentChunks: this.mapContentChunks(record.textSourceDetails),
-        knowledgeBaseId: record.knowledgeBaseId,
-        createdAt: record.createdAt,
-        updatedAt: record.updatedAt,
-        createdBy: record.createdBy,
-      });
-    }
-
-    throw new Error(`Invalid source type`);
   }
 
   private dataSourceToDomain(record: DataSourceRecord): DataSource {
-    if (record.dataSourceDetails instanceof CSVDataSourceDetailsRecord) {
-      return new CSVDataSource({
-        id: record.id,
-        data: record.dataSourceDetails.data,
-        name: record.name,
-        knowledgeBaseId: record.knowledgeBaseId,
-        createdBy: record.createdBy,
-        createdAt: record.createdAt,
-        updatedAt: record.updatedAt,
-      });
+    const details = record.dataSourceDetails as CSVDataSourceDetailsRecord;
+    return new CSVDataSource({
+      id: record.id,
+      data: details.data,
+      name: record.name,
+      knowledgeBaseId: record.knowledgeBaseId,
+      createdBy: record.createdBy,
+      createdAt: record.createdAt,
+      updatedAt: record.updatedAt,
+    });
+  }
+
+  /**
+   * Create records for a TextSource with its content (text + chunks).
+   * Used by the save path where content is provided alongside the entity.
+   */
+  toTextSourceRecord(
+    source: TextSource,
+    content: { text: string; chunks: TextSourceContentChunk[] },
+  ): {
+    source: TextSourceRecord;
+    details: TextSourceDetailsRecord;
+    contentChunks: SourceContentChunkRecord[];
+  } {
+    if (source instanceof FileSource) {
+      return this.fileSourceToRecord(source, content);
     }
-    throw new Error('not implemented');
+    if (source instanceof UrlSource) {
+      return this.urlSourceToRecord(source, content);
+    }
+
+    throw new Error('Invalid text source type');
   }
 
   /**
@@ -110,11 +119,6 @@ export class SourceMapper {
    * It seems that because we initialize the IDs in the domain layer,
    * TypeORM is unable to properly set the IDs in the records during cascading.
    */
-  toRecord(source: TextSource): {
-    source: TextSourceRecord;
-    details: TextSourceDetailsRecord;
-    contentChunks: SourceContentChunkRecord[];
-  };
   toRecord(source: DataSource): {
     source: DataSourceRecord;
     details: DataSourceDetailsRecord;
@@ -125,11 +129,8 @@ export class SourceMapper {
   toRecord(source: Source): {
     source: SourceRecord;
   } {
-    if (source instanceof FileSource) {
-      return this.fileSourceToRecord(source);
-    }
-    if (source instanceof UrlSource) {
-      return this.urlSourceToRecord(source);
+    if (source instanceof FileSource || source instanceof UrlSource) {
+      return { source: this.createTextSourceRecord(source) };
     }
     if (source instanceof CSVDataSource) {
       return this.dataSourceToRecord(source);
@@ -144,6 +145,9 @@ export class SourceMapper {
     record.name = source.name;
     record.createdBy = source.createdBy;
     record.knowledgeBaseId = source.knowledgeBaseId;
+    record.textType = source.textType;
+    record.fileType = source instanceof FileSource ? source.fileType : null;
+    record.url = source instanceof UrlSource ? source.url : null;
     record.createdAt = source.createdAt;
     record.updatedAt = source.updatedAt;
     return record;
@@ -152,20 +156,23 @@ export class SourceMapper {
   private buildTextSourceResult<T extends TextSourceDetailsRecord>(
     record: TextSourceRecord,
     details: T,
-    source: TextSource,
+    chunks: TextSourceContentChunk[],
   ): {
     source: TextSourceRecord;
     details: T;
     contentChunks: SourceContentChunkRecord[];
   } {
-    const contentChunks = source.contentChunks.map((c) =>
+    const contentChunks = chunks.map((c) =>
       this.sourceContentChunkMapper.toRecord(details, c),
     );
     record.textSourceDetails = details;
     return { source: record, details, contentChunks };
   }
 
-  private fileSourceToRecord(source: FileSource): {
+  private fileSourceToRecord(
+    source: FileSource,
+    content: { text: string; chunks: TextSourceContentChunk[] },
+  ): {
     source: TextSourceRecord;
     details: FileSourceDetailsRecord;
     contentChunks: SourceContentChunkRecord[];
@@ -176,14 +183,17 @@ export class SourceMapper {
     details.id = source.id;
     details.fileType = source.fileType;
     details.source = record;
-    details.text = source.text;
+    details.text = content.text;
     details.createdAt = source.createdAt;
     details.updatedAt = source.updatedAt;
 
-    return this.buildTextSourceResult(record, details, source);
+    return this.buildTextSourceResult(record, details, content.chunks);
   }
 
-  private urlSourceToRecord(source: UrlSource): {
+  private urlSourceToRecord(
+    source: UrlSource,
+    content: { text: string; chunks: TextSourceContentChunk[] },
+  ): {
     source: TextSourceRecord;
     details: UrlSourceDetailsRecord;
     contentChunks: SourceContentChunkRecord[];
@@ -193,12 +203,12 @@ export class SourceMapper {
     const details = new UrlSourceDetailsRecord();
     details.id = source.id;
     details.url = source.url;
-    details.text = source.text;
+    details.text = content.text;
     details.source = record;
     details.createdAt = source.createdAt;
     details.updatedAt = source.updatedAt;
 
-    return this.buildTextSourceResult(record, details, source);
+    return this.buildTextSourceResult(record, details, content.chunks);
   }
 
   private dataSourceToRecord(source: CSVDataSource): {
@@ -210,6 +220,7 @@ export class SourceMapper {
     record.name = source.name;
     record.createdBy = source.createdBy;
     record.knowledgeBaseId = source.knowledgeBaseId;
+    record.dataType = source.dataType;
     record.createdAt = source.createdAt;
     record.updatedAt = source.updatedAt;
 

--- a/ayunis-core-backend/src/domain/sources/infrastructure/persistence/local/schema/source.record.ts
+++ b/ayunis-core-backend/src/domain/sources/infrastructure/persistence/local/schema/source.record.ts
@@ -9,7 +9,12 @@ import {
 } from 'typeorm';
 import type { UUID } from 'crypto';
 import { BaseRecord } from '../../../../../../common/db/base-record';
-import { SourceType } from '../../../../domain/source-type.enum';
+import {
+  DataType,
+  FileType,
+  SourceType,
+  TextType,
+} from '../../../../domain/source-type.enum';
 import { SourceCreator } from '../../../../domain/source-creator.enum';
 import { TextSourceDetailsRecord } from './text-source-details.record';
 import { DataSourceDetailsRecord } from './data-source-details.record';
@@ -41,18 +46,28 @@ export abstract class SourceRecord extends BaseRecord {
 
 @ChildEntity(SourceType.TEXT)
 export class TextSourceRecord extends SourceRecord {
+  @Column({ type: 'enum', enum: TextType })
+  textType: TextType;
+
+  @Column({ type: 'enum', enum: FileType, nullable: true })
+  fileType: FileType | null;
+
+  @Column({ type: 'varchar', nullable: true })
+  url: string | null;
+
   @OneToOne(() => TextSourceDetailsRecord, (details) => details.source, {
     cascade: true,
-    eager: true,
   })
   textSourceDetails: TextSourceDetailsRecord;
 }
 
 @ChildEntity(SourceType.DATA)
 export class DataSourceRecord extends SourceRecord {
+  @Column({ type: 'enum', enum: DataType })
+  dataType: DataType;
+
   @OneToOne(() => DataSourceDetailsRecord, (details) => details.source, {
     cascade: true,
-    eager: true,
   })
   dataSourceDetails: DataSourceDetailsRecord;
 }

--- a/ayunis-core-backend/src/domain/sources/infrastructure/persistence/local/schema/text-source-details.record.ts
+++ b/ayunis-core-backend/src/domain/sources/infrastructure/persistence/local/schema/text-source-details.record.ts
@@ -24,7 +24,6 @@ export abstract class TextSourceDetailsRecord extends BaseRecord {
 
   @OneToMany(() => SourceContentChunkRecord, (content) => content.source, {
     cascade: true,
-    eager: true,
   })
   contentChunks?: SourceContentChunkRecord[];
 }

--- a/ayunis-core-backend/src/domain/sources/sources.module.ts
+++ b/ayunis-core-backend/src/domain/sources/sources.module.ts
@@ -13,6 +13,9 @@ import { CreateTextSourceUseCase } from './application/use-cases/create-text-sou
 import { QueryTextSourceUseCase } from './application/use-cases/query-text-source/query-text-source.use-case';
 import { CreateDataSourceUseCase } from './application/use-cases/create-data-source/create-data-source.use-case';
 import { GetSourcesByIdsUseCase } from './application/use-cases/get-sources-by-ids/get-sources-by-ids.use-case';
+import { FindContentChunksByIdsUseCase } from './application/use-cases/find-content-chunks-by-ids/find-content-chunks-by-ids.use-case';
+import { ExtractTextLinesUseCase } from './application/use-cases/extract-text-lines/extract-text-lines.use-case';
+import { GetSourcesByKnowledgeBaseIdUseCase } from './application/use-cases/get-sources-by-knowledge-base-id/get-sources-by-knowledge-base-id.use-case';
 
 @Module({
   imports: [
@@ -30,6 +33,9 @@ import { GetSourcesByIdsUseCase } from './application/use-cases/get-sources-by-i
     CreateDataSourceUseCase,
     GetSourcesByIdsUseCase,
     QueryTextSourceUseCase,
+    FindContentChunksByIdsUseCase,
+    ExtractTextLinesUseCase,
+    GetSourcesByKnowledgeBaseIdUseCase,
   ],
   exports: [
     LocalSourceRepositoryModule,
@@ -41,6 +47,9 @@ import { GetSourcesByIdsUseCase } from './application/use-cases/get-sources-by-i
     CreateDataSourceUseCase,
     GetSourcesByIdsUseCase,
     QueryTextSourceUseCase,
+    FindContentChunksByIdsUseCase,
+    ExtractTextLinesUseCase,
+    GetSourcesByKnowledgeBaseIdUseCase,
   ],
 })
 export class SourcesModule {}

--- a/ayunis-core-backend/src/domain/threads/application/use-cases/remove-source-from-thread/remove-source-from-thread.use-case.ts
+++ b/ayunis-core-backend/src/domain/threads/application/use-cases/remove-source-from-thread/remove-source-from-thread.use-case.ts
@@ -35,7 +35,7 @@ export class RemoveSourceFromThreadUseCase {
       }
 
       await this.deleteSourceUseCase.execute(
-        new DeleteSourceCommand(assignmentToRemove.source),
+        new DeleteSourceCommand(assignmentToRemove.source.id),
       );
     } catch (error) {
       if (error instanceof ApplicationError) {

--- a/ayunis-core-backend/src/domain/tools/application/handlers/knowledge-get-text-tool.handler.spec.ts
+++ b/ayunis-core-backend/src/domain/tools/application/handlers/knowledge-get-text-tool.handler.spec.ts
@@ -10,6 +10,7 @@ import { FileType, TextType } from 'src/domain/sources/domain/source-type.enum';
 import { ContextService } from 'src/common/context/services/context.service';
 import toolsConfig from 'src/config/tools.config';
 import { KnowledgeBaseNotFoundError } from 'src/domain/knowledge-bases/application/knowledge-bases.errors';
+import { ExtractTextLinesUseCase } from 'src/domain/sources/application/use-cases/extract-text-lines/extract-text-lines.use-case';
 
 function createMockTool(knowledgeBaseId: string, documentId: string) {
   return {
@@ -26,6 +27,7 @@ function createMockTool(knowledgeBaseId: string, documentId: string) {
 describe('KnowledgeGetTextToolHandler', () => {
   let handler: KnowledgeGetTextToolHandler;
   let mockGetDocTextUseCase: jest.Mocked<GetKnowledgeBaseDocumentTextUseCase>;
+  let mockExtractTextLines: jest.Mocked<ExtractTextLinesUseCase>;
   let mockContextService: jest.Mocked<ContextService>;
 
   const mockKbId = randomUUID();
@@ -39,6 +41,10 @@ describe('KnowledgeGetTextToolHandler', () => {
       execute: jest.fn(),
     } as unknown as jest.Mocked<GetKnowledgeBaseDocumentTextUseCase>;
 
+    mockExtractTextLines = {
+      execute: jest.fn(),
+    } as unknown as jest.Mocked<ExtractTextLinesUseCase>;
+
     mockContextService = {
       get: jest.fn().mockReturnValue(mockUserId),
     } as unknown as jest.Mocked<ContextService>;
@@ -49,6 +55,10 @@ describe('KnowledgeGetTextToolHandler', () => {
         {
           provide: GetKnowledgeBaseDocumentTextUseCase,
           useValue: mockGetDocTextUseCase,
+        },
+        {
+          provide: ExtractTextLinesUseCase,
+          useValue: mockExtractTextLines,
         },
         {
           provide: ContextService,
@@ -77,13 +87,15 @@ describe('KnowledgeGetTextToolHandler', () => {
     const mockSource = new FileSource({
       id: mockDocId,
       name: 'policy-document.pdf',
-      text: 'Line 1\nLine 2\nLine 3',
-      contentChunks: [],
       type: TextType.FILE,
       fileType: FileType.PDF,
     });
 
     mockGetDocTextUseCase.execute.mockResolvedValue(mockSource);
+    mockExtractTextLines.execute.mockResolvedValue({
+      totalLines: 3,
+      text: 'Line 1\nLine 2\nLine 3',
+    });
 
     const tool = createMockTool(mockKbId, mockDocId);
     const result = await handler.execute({
@@ -98,6 +110,13 @@ describe('KnowledgeGetTextToolHandler', () => {
     expect(parsed.documentName).toBe('policy-document.pdf');
     expect(parsed.totalLines).toBe(3);
     expect(parsed.text).toBe('Line 1\nLine 2\nLine 3');
+    expect(mockExtractTextLines.execute).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sourceId: mockDocId,
+        startLine: 1,
+        endLine: 100,
+      }),
+    );
   });
 
   it('should throw when knowledge base is not found', async () => {
@@ -159,13 +178,15 @@ describe('KnowledgeGetTextToolHandler', () => {
     const mockSource = new FileSource({
       id: mockDocId,
       name: 'empty-doc.pdf',
-      text: '',
-      contentChunks: [],
       type: TextType.FILE,
       fileType: FileType.PDF,
     });
 
     mockGetDocTextUseCase.execute.mockResolvedValue(mockSource);
+    mockExtractTextLines.execute.mockResolvedValue({
+      totalLines: 0,
+      text: '',
+    });
 
     const tool = createMockTool(mockKbId, mockDocId);
     const result = await handler.execute({

--- a/ayunis-core-backend/src/domain/tools/application/handlers/knowledge-get-text-tool.handler.ts
+++ b/ayunis-core-backend/src/domain/tools/application/handlers/knowledge-get-text-tool.handler.ts
@@ -12,11 +12,16 @@ import {
 import { TextSource } from 'src/domain/sources/domain/sources/text-source.entity';
 import { ContextService } from 'src/common/context/services/context.service';
 import toolsConfig from 'src/config/tools.config';
-import { extractTextByLineRange } from '../utils/text-extraction.utils';
+import { validateTextExtraction } from '../utils/text-extraction.utils';
 import {
   KnowledgeBaseNotFoundError,
   DocumentNotInKnowledgeBaseError,
 } from 'src/domain/knowledge-bases/application/knowledge-bases.errors';
+import { ExtractTextLinesUseCase } from 'src/domain/sources/application/use-cases/extract-text-lines/extract-text-lines.use-case';
+import { ExtractTextLinesQuery } from 'src/domain/sources/application/use-cases/extract-text-lines/extract-text-lines.query';
+
+/** PostgreSQL max int for "read to end" when endLine is -1 */
+const MAX_END_LINE = 2147483647;
 
 interface KnowledgeGetTextResult {
   knowledgeBaseId: string;
@@ -36,6 +41,7 @@ export class KnowledgeGetTextToolHandler extends ToolExecutionHandler {
 
   constructor(
     private readonly getDocumentTextUseCase: GetKnowledgeBaseDocumentTextUseCase,
+    private readonly extractTextLinesUseCase: ExtractTextLinesUseCase,
     private readonly contextService: ContextService,
     @Inject(toolsConfig.KEY)
     private readonly config: ConfigType<typeof toolsConfig>,
@@ -72,6 +78,7 @@ export class KnowledgeGetTextToolHandler extends ToolExecutionHandler {
         });
       }
 
+      // Ownership check — returns metadata-only Source
       const source = await this.getDocumentTextUseCase.execute(
         new GetKnowledgeBaseDocumentTextQuery({
           knowledgeBaseId: knowledgeBaseId as UUID,
@@ -89,10 +96,27 @@ export class KnowledgeGetTextToolHandler extends ToolExecutionHandler {
         });
       }
 
-      const text = source.text || '';
-      const extraction = extractTextByLineRange({
+      // Extract text lines at DB level
+      const dbEndLine = endLine === -1 ? MAX_END_LINE : endLine;
+      const dbResult = await this.extractTextLinesUseCase.execute(
+        new ExtractTextLinesQuery({
+          sourceId: source.id,
+          startLine,
+          endLine: dbEndLine,
+        }),
+      );
+
+      if (!dbResult) {
+        throw new ToolExecutionFailedError({
+          toolName: tool.name,
+          message: `Document text not found for "${source.name}"`,
+          exposeToLLM: true,
+        });
+      }
+
+      const extraction = validateTextExtraction({
         toolName: tool.name,
-        text,
+        dbResult,
         startLine,
         endLine,
         maxLines,

--- a/ayunis-core-backend/src/domain/tools/application/handlers/source-get-text-tool.handler.ts
+++ b/ayunis-core-backend/src/domain/tools/application/handlers/source-get-text-tool.handler.ts
@@ -11,7 +11,12 @@ import {
 } from '../ports/execution.handler';
 import { TextSource } from 'src/domain/sources/domain/sources/text-source.entity';
 import toolsConfig from 'src/config/tools.config';
-import { extractTextByLineRange } from '../utils/text-extraction.utils';
+import { validateTextExtraction } from '../utils/text-extraction.utils';
+import { ExtractTextLinesUseCase } from 'src/domain/sources/application/use-cases/extract-text-lines/extract-text-lines.use-case';
+import { ExtractTextLinesQuery } from 'src/domain/sources/application/use-cases/extract-text-lines/extract-text-lines.query';
+
+/** PostgreSQL max int for "read to end" when endLine is -1 */
+const MAX_END_LINE = 2147483647;
 
 interface SourceGetTextResult {
   sourceId: string;
@@ -30,6 +35,7 @@ export class SourceGetTextToolHandler extends ToolExecutionHandler {
 
   constructor(
     private readonly getSourceByIdUseCase: GetTextSourceByIdUseCase,
+    private readonly extractTextLinesUseCase: ExtractTextLinesUseCase,
     @Inject(toolsConfig.KEY)
     private readonly config: ConfigType<typeof toolsConfig>,
   ) {
@@ -49,6 +55,7 @@ export class SourceGetTextToolHandler extends ToolExecutionHandler {
       const { sourceId, startLine = 1, endLine = -1 } = validatedInput;
       const { maxLines, maxChars } = this.config.sourceGetText;
 
+      // Load metadata-only source for type check and name
       const source = await this.getSourceByIdUseCase.execute(
         new GetTextSourceByIdQuery(sourceId as UUID),
       );
@@ -61,10 +68,27 @@ export class SourceGetTextToolHandler extends ToolExecutionHandler {
         });
       }
 
-      const text = source.text || '';
-      const extraction = extractTextByLineRange({
+      // Extract text lines at DB level
+      const dbEndLine = endLine === -1 ? MAX_END_LINE : endLine;
+      const dbResult = await this.extractTextLinesUseCase.execute(
+        new ExtractTextLinesQuery({
+          sourceId: source.id,
+          startLine,
+          endLine: dbEndLine,
+        }),
+      );
+
+      if (!dbResult) {
+        throw new ToolExecutionFailedError({
+          toolName: tool.name,
+          message: `Source text not found for "${source.name}"`,
+          exposeToLLM: true,
+        });
+      }
+
+      const extraction = validateTextExtraction({
         toolName: tool.name,
-        text,
+        dbResult,
         startLine,
         endLine,
         maxLines,

--- a/ayunis-core-backend/src/domain/tools/application/handlers/source-query-tool.handler.spec.ts
+++ b/ayunis-core-backend/src/domain/tools/application/handlers/source-query-tool.handler.spec.ts
@@ -68,8 +68,6 @@ describe('SourceQueryToolHandler', () => {
       const mockSource = new FileSource({
         id: mockSourceId,
         name: 'test-file.pdf',
-        text: 'Test content',
-        contentChunks: [],
         type: TextType.FILE,
         fileType: FileType.PDF,
       });
@@ -135,8 +133,6 @@ describe('SourceQueryToolHandler', () => {
       const mockSource = new FileSource({
         id: mockSourceId,
         name: 'Example Website',
-        text: 'Test content',
-        contentChunks: [],
         type: TextType.FILE,
         fileType: FileType.PDF,
       });
@@ -181,8 +177,6 @@ describe('SourceQueryToolHandler', () => {
       const mockSource = new FileSource({
         id: mockSourceId,
         name: 'old-file.pdf',
-        text: 'Test content',
-        contentChunks: [],
         type: TextType.FILE,
         fileType: FileType.PDF,
       });
@@ -225,8 +219,6 @@ describe('SourceQueryToolHandler', () => {
       const mockSource = new FileSource({
         id: mockSourceId,
         name: 'test.pdf',
-        text: 'Test content',
-        contentChunks: [],
         type: TextType.FILE,
         fileType: FileType.PDF,
       });
@@ -266,8 +258,6 @@ describe('SourceQueryToolHandler', () => {
       const mockSource = new FileSource({
         id: mockSourceId,
         name: 'test.pdf',
-        text: 'Test content',
-        contentChunks: [],
         type: TextType.FILE,
         fileType: FileType.PDF,
       });

--- a/ayunis-core-backend/src/domain/tools/application/utils/text-extraction.utils.spec.ts
+++ b/ayunis-core-backend/src/domain/tools/application/utils/text-extraction.utils.spec.ts
@@ -1,4 +1,7 @@
-import { extractTextByLineRange } from './text-extraction.utils';
+import {
+  extractTextByLineRange,
+  validateTextExtraction,
+} from './text-extraction.utils';
 import { ToolExecutionFailedError } from '../tools.errors';
 
 describe('extractTextByLineRange', () => {
@@ -71,10 +74,13 @@ describe('extractTextByLineRange', () => {
   });
 
   it('should throw when requested line count exceeds maxLines', () => {
+    const text = Array.from({ length: 600 }, (_, i) => `Line ${i + 1}`).join(
+      '\n',
+    );
     expect(() =>
       extractTextByLineRange({
         ...defaultParams,
-        text: Array.from({ length: 600 }, (_, i) => `Line ${i + 1}`).join('\n'),
+        text,
         startLine: 1,
         endLine: 550,
         maxLines: 500,
@@ -106,5 +112,101 @@ describe('extractTextByLineRange', () => {
     expect(result.extractedText).toBe('Line 2\nLine 3\nLine 4');
     expect(result.effectiveStartLine).toBe(2);
     expect(result.effectiveEndLine).toBe(4);
+  });
+});
+
+describe('validateTextExtraction', () => {
+  const defaultParams = {
+    toolName: 'test_tool',
+    maxLines: 500,
+    maxChars: 50000,
+  };
+
+  it('should validate pre-sliced text from DB', () => {
+    const result = validateTextExtraction({
+      ...defaultParams,
+      dbResult: { totalLines: 10, text: 'Line 2\nLine 3\nLine 4' },
+      startLine: 2,
+      endLine: 4,
+    });
+
+    expect(result.totalLines).toBe(10);
+    expect(result.effectiveStartLine).toBe(2);
+    expect(result.effectiveEndLine).toBe(4);
+    expect(result.extractedText).toBe('Line 2\nLine 3\nLine 4');
+    expect(result.isEmpty).toBe(false);
+  });
+
+  it('should return empty result when totalLines is 0', () => {
+    const result = validateTextExtraction({
+      ...defaultParams,
+      dbResult: { totalLines: 0, text: '' },
+      startLine: 1,
+      endLine: -1,
+    });
+
+    expect(result.isEmpty).toBe(true);
+    expect(result.totalLines).toBe(0);
+  });
+
+  it('should clamp endLine to totalLines', () => {
+    const result = validateTextExtraction({
+      ...defaultParams,
+      dbResult: {
+        totalLines: 5,
+        text: 'Line 1\nLine 2\nLine 3\nLine 4\nLine 5',
+      },
+      startLine: 1,
+      endLine: 100,
+    });
+
+    expect(result.effectiveEndLine).toBe(5);
+  });
+
+  it('should resolve endLine -1 to totalLines', () => {
+    const result = validateTextExtraction({
+      ...defaultParams,
+      dbResult: { totalLines: 3, text: 'Line 1\nLine 2\nLine 3' },
+      startLine: 1,
+      endLine: -1,
+    });
+
+    expect(result.effectiveEndLine).toBe(3);
+  });
+
+  it('should throw when startLine exceeds totalLines', () => {
+    expect(() =>
+      validateTextExtraction({
+        ...defaultParams,
+        dbResult: { totalLines: 5, text: '' },
+        startLine: 10,
+        endLine: 15,
+      }),
+    ).toThrow(ToolExecutionFailedError);
+  });
+
+  it('should throw when line count exceeds maxLines', () => {
+    expect(() =>
+      validateTextExtraction({
+        ...defaultParams,
+        dbResult: { totalLines: 600, text: 'lots of text' },
+        startLine: 1,
+        endLine: 550,
+        maxLines: 500,
+      }),
+    ).toThrow(ToolExecutionFailedError);
+  });
+
+  it('should throw when text exceeds maxChars', () => {
+    const longText = 'A'.repeat(200);
+    expect(() =>
+      validateTextExtraction({
+        ...defaultParams,
+        dbResult: { totalLines: 3, text: longText },
+        startLine: 1,
+        endLine: 3,
+        maxChars: 100,
+      }),
+    ).toThrow(ToolExecutionFailedError);
   });
 });

--- a/ayunis-core-backend/src/domain/tools/application/utils/text-extraction.utils.ts
+++ b/ayunis-core-backend/src/domain/tools/application/utils/text-extraction.utils.ts
@@ -9,7 +9,7 @@ interface TextExtractionParams {
   maxChars: number;
 }
 
-interface TextExtractionResult {
+export interface TextExtractionResult {
   totalLines: number;
   effectiveStartLine: number;
   effectiveEndLine: number;
@@ -85,6 +85,10 @@ function validateCharLimit(
   }
 }
 
+/**
+ * Extract text by line range from a full text string.
+ * Used when the full text is available in memory.
+ */
 export function extractTextByLineRange(
   params: TextExtractionParams,
 ): TextExtractionResult {
@@ -121,6 +125,51 @@ export function extractTextByLineRange(
     effectiveStartLine: effectiveStart,
     effectiveEndLine: effectiveEnd,
     extractedText,
+    isEmpty: false,
+  };
+}
+
+/**
+ * Validate text extracted by the DB (pre-sliced).
+ * Used after `sourceRepository.extractTextLines()` returns { totalLines, text }.
+ */
+export function validateTextExtraction(params: {
+  toolName: string;
+  dbResult: { totalLines: number; text: string };
+  startLine: number;
+  endLine: number;
+  maxLines: number;
+  maxChars: number;
+}): TextExtractionResult {
+  const { toolName, dbResult, startLine, endLine, maxLines, maxChars } = params;
+  const { totalLines, text } = dbResult;
+
+  if (totalLines === 0 || (text === '' && totalLines <= 1)) {
+    return { ...EMPTY_RESULT, totalLines };
+  }
+
+  const { effectiveStart, effectiveEnd } = clampLineRange(
+    startLine,
+    endLine,
+    totalLines,
+  );
+  const lineCount = effectiveEnd - effectiveStart + 1;
+
+  validateLineRange({
+    toolName,
+    startLine,
+    effectiveEnd,
+    totalLines,
+    maxLines,
+  });
+
+  validateCharLimit(toolName, text, lineCount, maxChars);
+
+  return {
+    totalLines,
+    effectiveStartLine: effectiveStart,
+    effectiveEndLine: effectiveEnd,
+    extractedText: text,
     isEmpty: false,
   };
 }

--- a/ayunis-core-frontend/src/app/routeTree.gen.ts
+++ b/ayunis-core-frontend/src/app/routeTree.gen.ts
@@ -8,883 +8,647 @@
 // You should NOT make any changes in this file as it will be overwritten.
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
-import { Route as rootRouteImport } from './routes/__root'
-import { Route as AuthenticatedRouteImport } from './routes/_authenticated'
-import { Route as IndexRouteImport } from './routes/index'
-import { Route as AuthenticatedInstallRouteImport } from './routes/_authenticated/install'
-import { Route as onboardingRegisterRouteImport } from './routes/(onboarding)/register'
-import { Route as onboardingLoginRouteImport } from './routes/(onboarding)/login'
-import { Route as onboardingIpBlockedRouteImport } from './routes/(onboarding)/ip-blocked'
-import { Route as onboardingEmailConfirmRouteImport } from './routes/(onboarding)/email-confirm'
-import { Route as onboardingConfirmEmailRouteImport } from './routes/(onboarding)/confirm-email'
-import { Route as onboardingAcceptInviteRouteImport } from './routes/(onboarding)/accept-invite'
-import { Route as AuthenticatedSuperAdminSettingsIndexRouteImport } from './routes/_authenticated/super-admin-settings.index'
-import { Route as AuthenticatedSkillsIndexRouteImport } from './routes/_authenticated/skills.index'
-import { Route as AuthenticatedSettingsIndexRouteImport } from './routes/_authenticated/settings.index'
-import { Route as AuthenticatedPromptsIndexRouteImport } from './routes/_authenticated/prompts.index'
-import { Route as AuthenticatedKnowledgeBasesIndexRouteImport } from './routes/_authenticated/knowledge-bases.index'
-import { Route as AuthenticatedChatsIndexRouteImport } from './routes/_authenticated/chats.index'
-import { Route as AuthenticatedChatIndexRouteImport } from './routes/_authenticated/chat.index'
-import { Route as AuthenticatedAgentsIndexRouteImport } from './routes/_authenticated/agents.index'
-import { Route as AuthenticatedAdminSettingsIndexRouteImport } from './routes/_authenticated/admin-settings.index'
-import { Route as AuthenticatedSkillsIdRouteImport } from './routes/_authenticated/skills.$id'
-import { Route as AuthenticatedSettingsGeneralRouteImport } from './routes/_authenticated/settings.general'
-import { Route as AuthenticatedSettingsChatRouteImport } from './routes/_authenticated/settings.chat'
-import { Route as AuthenticatedSettingsAccountRouteImport } from './routes/_authenticated/settings.account'
-import { Route as AuthenticatedKnowledgeBasesIdRouteImport } from './routes/_authenticated/knowledge-bases.$id'
-import { Route as AuthenticatedChatsThreadIdRouteImport } from './routes/_authenticated/chats.$threadId'
-import { Route as AuthenticatedAgentsIdRouteImport } from './routes/_authenticated/agents.$id'
-import { Route as AuthenticatedAdminSettingsUsersRouteImport } from './routes/_authenticated/admin-settings.users'
-import { Route as AuthenticatedAdminSettingsUsageRouteImport } from './routes/_authenticated/admin-settings.usage'
-import { Route as AuthenticatedAdminSettingsSecurityRouteImport } from './routes/_authenticated/admin-settings.security'
-import { Route as AuthenticatedAdminSettingsModelsRouteImport } from './routes/_authenticated/admin-settings.models'
-import { Route as AuthenticatedAdminSettingsIntegrationsRouteImport } from './routes/_authenticated/admin-settings.integrations'
-import { Route as onboardingPasswordResetRouteImport } from './routes/(onboarding)/password.reset'
-import { Route as onboardingPasswordForgotRouteImport } from './routes/(onboarding)/password.forgot'
-import { Route as AuthenticatedSuperAdminSettingsUsageIndexRouteImport } from './routes/_authenticated/super-admin-settings.usage.index'
-import { Route as AuthenticatedSuperAdminSettingsSuperAdminsIndexRouteImport } from './routes/_authenticated/super-admin-settings.super-admins.index'
-import { Route as AuthenticatedSuperAdminSettingsSkillsIndexRouteImport } from './routes/_authenticated/super-admin-settings.skills.index'
-import { Route as AuthenticatedSuperAdminSettingsPlatformConfigIndexRouteImport } from './routes/_authenticated/super-admin-settings.platform-config.index'
-import { Route as AuthenticatedSuperAdminSettingsOrgsIndexRouteImport } from './routes/_authenticated/super-admin-settings.orgs.index'
-import { Route as AuthenticatedSuperAdminSettingsModelsCatalogIndexRouteImport } from './routes/_authenticated/super-admin-settings.models-catalog.index'
-import { Route as AuthenticatedAdminSettingsTeamsIndexRouteImport } from './routes/_authenticated/admin-settings.teams.index'
-import { Route as AuthenticatedAdminSettingsLetterheadsIndexRouteImport } from './routes/_authenticated/admin-settings.letterheads.index'
-import { Route as AuthenticatedSuperAdminSettingsOrgsIdRouteImport } from './routes/_authenticated/super-admin-settings.orgs.$id'
-import { Route as AuthenticatedAdminSettingsTeamsIdRouteImport } from './routes/_authenticated/admin-settings.teams.$id'
-import { Route as AuthenticatedAdminSettingsLetterheadsIdRouteImport } from './routes/_authenticated/admin-settings.letterheads.$id'
+// Import Routes
 
-const AuthenticatedRoute = AuthenticatedRouteImport.update({
+import { Route as rootRoute } from './routes/__root'
+import { Route as AuthenticatedImport } from './routes/_authenticated'
+import { Route as IndexImport } from './routes/index'
+import { Route as AuthenticatedInstallImport } from './routes/_authenticated/install'
+import { Route as onboardingRegisterImport } from './routes/(onboarding)/register'
+import { Route as onboardingLoginImport } from './routes/(onboarding)/login'
+import { Route as onboardingIpBlockedImport } from './routes/(onboarding)/ip-blocked'
+import { Route as onboardingEmailConfirmImport } from './routes/(onboarding)/email-confirm'
+import { Route as onboardingConfirmEmailImport } from './routes/(onboarding)/confirm-email'
+import { Route as onboardingAcceptInviteImport } from './routes/(onboarding)/accept-invite'
+import { Route as AuthenticatedSuperAdminSettingsIndexImport } from './routes/_authenticated/super-admin-settings.index'
+import { Route as AuthenticatedSkillsIndexImport } from './routes/_authenticated/skills.index'
+import { Route as AuthenticatedSettingsIndexImport } from './routes/_authenticated/settings.index'
+import { Route as AuthenticatedPromptsIndexImport } from './routes/_authenticated/prompts.index'
+import { Route as AuthenticatedKnowledgeBasesIndexImport } from './routes/_authenticated/knowledge-bases.index'
+import { Route as AuthenticatedChatsIndexImport } from './routes/_authenticated/chats.index'
+import { Route as AuthenticatedChatIndexImport } from './routes/_authenticated/chat.index'
+import { Route as AuthenticatedAgentsIndexImport } from './routes/_authenticated/agents.index'
+import { Route as AuthenticatedAdminSettingsIndexImport } from './routes/_authenticated/admin-settings.index'
+import { Route as AuthenticatedSkillsIdImport } from './routes/_authenticated/skills.$id'
+import { Route as AuthenticatedSettingsGeneralImport } from './routes/_authenticated/settings.general'
+import { Route as AuthenticatedSettingsChatImport } from './routes/_authenticated/settings.chat'
+import { Route as AuthenticatedSettingsAccountImport } from './routes/_authenticated/settings.account'
+import { Route as AuthenticatedKnowledgeBasesIdImport } from './routes/_authenticated/knowledge-bases.$id'
+import { Route as AuthenticatedChatsThreadIdImport } from './routes/_authenticated/chats.$threadId'
+import { Route as AuthenticatedAgentsIdImport } from './routes/_authenticated/agents.$id'
+import { Route as AuthenticatedAdminSettingsUsersImport } from './routes/_authenticated/admin-settings.users'
+import { Route as AuthenticatedAdminSettingsUsageImport } from './routes/_authenticated/admin-settings.usage'
+import { Route as AuthenticatedAdminSettingsSecurityImport } from './routes/_authenticated/admin-settings.security'
+import { Route as AuthenticatedAdminSettingsModelsImport } from './routes/_authenticated/admin-settings.models'
+import { Route as AuthenticatedAdminSettingsIntegrationsImport } from './routes/_authenticated/admin-settings.integrations'
+import { Route as onboardingPasswordResetImport } from './routes/(onboarding)/password.reset'
+import { Route as onboardingPasswordForgotImport } from './routes/(onboarding)/password.forgot'
+import { Route as AuthenticatedSuperAdminSettingsUsageIndexImport } from './routes/_authenticated/super-admin-settings.usage.index'
+import { Route as AuthenticatedSuperAdminSettingsSuperAdminsIndexImport } from './routes/_authenticated/super-admin-settings.super-admins.index'
+import { Route as AuthenticatedSuperAdminSettingsSkillsIndexImport } from './routes/_authenticated/super-admin-settings.skills.index'
+import { Route as AuthenticatedSuperAdminSettingsPlatformConfigIndexImport } from './routes/_authenticated/super-admin-settings.platform-config.index'
+import { Route as AuthenticatedSuperAdminSettingsOrgsIndexImport } from './routes/_authenticated/super-admin-settings.orgs.index'
+import { Route as AuthenticatedSuperAdminSettingsModelsCatalogIndexImport } from './routes/_authenticated/super-admin-settings.models-catalog.index'
+import { Route as AuthenticatedAdminSettingsTeamsIndexImport } from './routes/_authenticated/admin-settings.teams.index'
+import { Route as AuthenticatedAdminSettingsLetterheadsIndexImport } from './routes/_authenticated/admin-settings.letterheads.index'
+import { Route as AuthenticatedSuperAdminSettingsOrgsIdImport } from './routes/_authenticated/super-admin-settings.orgs.$id'
+import { Route as AuthenticatedAdminSettingsTeamsIdImport } from './routes/_authenticated/admin-settings.teams.$id'
+import { Route as AuthenticatedAdminSettingsLetterheadsIdImport } from './routes/_authenticated/admin-settings.letterheads.$id'
+
+// Create/Update Routes
+
+const AuthenticatedRoute = AuthenticatedImport.update({
   id: '/_authenticated',
-  getParentRoute: () => rootRouteImport,
+  getParentRoute: () => rootRoute,
 } as any)
-const IndexRoute = IndexRouteImport.update({
+
+const IndexRoute = IndexImport.update({
   id: '/',
   path: '/',
-  getParentRoute: () => rootRouteImport,
+  getParentRoute: () => rootRoute,
 } as any)
-const AuthenticatedInstallRoute = AuthenticatedInstallRouteImport.update({
+
+const AuthenticatedInstallRoute = AuthenticatedInstallImport.update({
   id: '/install',
   path: '/install',
   getParentRoute: () => AuthenticatedRoute,
 } as any)
-const onboardingRegisterRoute = onboardingRegisterRouteImport.update({
+
+const onboardingRegisterRoute = onboardingRegisterImport.update({
   id: '/(onboarding)/register',
   path: '/register',
-  getParentRoute: () => rootRouteImport,
+  getParentRoute: () => rootRoute,
 } as any)
-const onboardingLoginRoute = onboardingLoginRouteImport.update({
+
+const onboardingLoginRoute = onboardingLoginImport.update({
   id: '/(onboarding)/login',
   path: '/login',
-  getParentRoute: () => rootRouteImport,
+  getParentRoute: () => rootRoute,
 } as any)
-const onboardingIpBlockedRoute = onboardingIpBlockedRouteImport.update({
+
+const onboardingIpBlockedRoute = onboardingIpBlockedImport.update({
   id: '/(onboarding)/ip-blocked',
   path: '/ip-blocked',
-  getParentRoute: () => rootRouteImport,
+  getParentRoute: () => rootRoute,
 } as any)
-const onboardingEmailConfirmRoute = onboardingEmailConfirmRouteImport.update({
+
+const onboardingEmailConfirmRoute = onboardingEmailConfirmImport.update({
   id: '/(onboarding)/email-confirm',
   path: '/email-confirm',
-  getParentRoute: () => rootRouteImport,
+  getParentRoute: () => rootRoute,
 } as any)
-const onboardingConfirmEmailRoute = onboardingConfirmEmailRouteImport.update({
+
+const onboardingConfirmEmailRoute = onboardingConfirmEmailImport.update({
   id: '/(onboarding)/confirm-email',
   path: '/confirm-email',
-  getParentRoute: () => rootRouteImport,
+  getParentRoute: () => rootRoute,
 } as any)
-const onboardingAcceptInviteRoute = onboardingAcceptInviteRouteImport.update({
+
+const onboardingAcceptInviteRoute = onboardingAcceptInviteImport.update({
   id: '/(onboarding)/accept-invite',
   path: '/accept-invite',
-  getParentRoute: () => rootRouteImport,
+  getParentRoute: () => rootRoute,
 } as any)
+
 const AuthenticatedSuperAdminSettingsIndexRoute =
-  AuthenticatedSuperAdminSettingsIndexRouteImport.update({
+  AuthenticatedSuperAdminSettingsIndexImport.update({
     id: '/super-admin-settings/',
     path: '/super-admin-settings/',
     getParentRoute: () => AuthenticatedRoute,
   } as any)
-const AuthenticatedSkillsIndexRoute =
-  AuthenticatedSkillsIndexRouteImport.update({
-    id: '/skills/',
-    path: '/skills/',
-    getParentRoute: () => AuthenticatedRoute,
-  } as any)
-const AuthenticatedSettingsIndexRoute =
-  AuthenticatedSettingsIndexRouteImport.update({
+
+const AuthenticatedSkillsIndexRoute = AuthenticatedSkillsIndexImport.update({
+  id: '/skills/',
+  path: '/skills/',
+  getParentRoute: () => AuthenticatedRoute,
+} as any)
+
+const AuthenticatedSettingsIndexRoute = AuthenticatedSettingsIndexImport.update(
+  {
     id: '/settings/',
     path: '/settings/',
     getParentRoute: () => AuthenticatedRoute,
-  } as any)
-const AuthenticatedPromptsIndexRoute =
-  AuthenticatedPromptsIndexRouteImport.update({
-    id: '/prompts/',
-    path: '/prompts/',
-    getParentRoute: () => AuthenticatedRoute,
-  } as any)
+  } as any,
+)
+
+const AuthenticatedPromptsIndexRoute = AuthenticatedPromptsIndexImport.update({
+  id: '/prompts/',
+  path: '/prompts/',
+  getParentRoute: () => AuthenticatedRoute,
+} as any)
+
 const AuthenticatedKnowledgeBasesIndexRoute =
-  AuthenticatedKnowledgeBasesIndexRouteImport.update({
+  AuthenticatedKnowledgeBasesIndexImport.update({
     id: '/knowledge-bases/',
     path: '/knowledge-bases/',
     getParentRoute: () => AuthenticatedRoute,
   } as any)
-const AuthenticatedChatsIndexRoute = AuthenticatedChatsIndexRouteImport.update({
+
+const AuthenticatedChatsIndexRoute = AuthenticatedChatsIndexImport.update({
   id: '/chats/',
   path: '/chats/',
   getParentRoute: () => AuthenticatedRoute,
 } as any)
-const AuthenticatedChatIndexRoute = AuthenticatedChatIndexRouteImport.update({
+
+const AuthenticatedChatIndexRoute = AuthenticatedChatIndexImport.update({
   id: '/chat/',
   path: '/chat/',
   getParentRoute: () => AuthenticatedRoute,
 } as any)
-const AuthenticatedAgentsIndexRoute =
-  AuthenticatedAgentsIndexRouteImport.update({
-    id: '/agents/',
-    path: '/agents/',
-    getParentRoute: () => AuthenticatedRoute,
-  } as any)
+
+const AuthenticatedAgentsIndexRoute = AuthenticatedAgentsIndexImport.update({
+  id: '/agents/',
+  path: '/agents/',
+  getParentRoute: () => AuthenticatedRoute,
+} as any)
+
 const AuthenticatedAdminSettingsIndexRoute =
-  AuthenticatedAdminSettingsIndexRouteImport.update({
+  AuthenticatedAdminSettingsIndexImport.update({
     id: '/admin-settings/',
     path: '/admin-settings/',
     getParentRoute: () => AuthenticatedRoute,
   } as any)
-const AuthenticatedSkillsIdRoute = AuthenticatedSkillsIdRouteImport.update({
+
+const AuthenticatedSkillsIdRoute = AuthenticatedSkillsIdImport.update({
   id: '/skills/$id',
   path: '/skills/$id',
   getParentRoute: () => AuthenticatedRoute,
 } as any)
+
 const AuthenticatedSettingsGeneralRoute =
-  AuthenticatedSettingsGeneralRouteImport.update({
+  AuthenticatedSettingsGeneralImport.update({
     id: '/settings/general',
     path: '/settings/general',
     getParentRoute: () => AuthenticatedRoute,
   } as any)
-const AuthenticatedSettingsChatRoute =
-  AuthenticatedSettingsChatRouteImport.update({
-    id: '/settings/chat',
-    path: '/settings/chat',
-    getParentRoute: () => AuthenticatedRoute,
-  } as any)
+
+const AuthenticatedSettingsChatRoute = AuthenticatedSettingsChatImport.update({
+  id: '/settings/chat',
+  path: '/settings/chat',
+  getParentRoute: () => AuthenticatedRoute,
+} as any)
+
 const AuthenticatedSettingsAccountRoute =
-  AuthenticatedSettingsAccountRouteImport.update({
+  AuthenticatedSettingsAccountImport.update({
     id: '/settings/account',
     path: '/settings/account',
     getParentRoute: () => AuthenticatedRoute,
   } as any)
+
 const AuthenticatedKnowledgeBasesIdRoute =
-  AuthenticatedKnowledgeBasesIdRouteImport.update({
+  AuthenticatedKnowledgeBasesIdImport.update({
     id: '/knowledge-bases/$id',
     path: '/knowledge-bases/$id',
     getParentRoute: () => AuthenticatedRoute,
   } as any)
-const AuthenticatedChatsThreadIdRoute =
-  AuthenticatedChatsThreadIdRouteImport.update({
+
+const AuthenticatedChatsThreadIdRoute = AuthenticatedChatsThreadIdImport.update(
+  {
     id: '/chats/$threadId',
     path: '/chats/$threadId',
     getParentRoute: () => AuthenticatedRoute,
-  } as any)
-const AuthenticatedAgentsIdRoute = AuthenticatedAgentsIdRouteImport.update({
+  } as any,
+)
+
+const AuthenticatedAgentsIdRoute = AuthenticatedAgentsIdImport.update({
   id: '/agents/$id',
   path: '/agents/$id',
   getParentRoute: () => AuthenticatedRoute,
 } as any)
+
 const AuthenticatedAdminSettingsUsersRoute =
-  AuthenticatedAdminSettingsUsersRouteImport.update({
+  AuthenticatedAdminSettingsUsersImport.update({
     id: '/admin-settings/users',
     path: '/admin-settings/users',
     getParentRoute: () => AuthenticatedRoute,
   } as any)
+
 const AuthenticatedAdminSettingsUsageRoute =
-  AuthenticatedAdminSettingsUsageRouteImport.update({
+  AuthenticatedAdminSettingsUsageImport.update({
     id: '/admin-settings/usage',
     path: '/admin-settings/usage',
     getParentRoute: () => AuthenticatedRoute,
   } as any)
+
 const AuthenticatedAdminSettingsSecurityRoute =
-  AuthenticatedAdminSettingsSecurityRouteImport.update({
+  AuthenticatedAdminSettingsSecurityImport.update({
     id: '/admin-settings/security',
     path: '/admin-settings/security',
     getParentRoute: () => AuthenticatedRoute,
   } as any)
+
 const AuthenticatedAdminSettingsModelsRoute =
-  AuthenticatedAdminSettingsModelsRouteImport.update({
+  AuthenticatedAdminSettingsModelsImport.update({
     id: '/admin-settings/models',
     path: '/admin-settings/models',
     getParentRoute: () => AuthenticatedRoute,
   } as any)
+
 const AuthenticatedAdminSettingsIntegrationsRoute =
-  AuthenticatedAdminSettingsIntegrationsRouteImport.update({
+  AuthenticatedAdminSettingsIntegrationsImport.update({
     id: '/admin-settings/integrations',
     path: '/admin-settings/integrations',
     getParentRoute: () => AuthenticatedRoute,
   } as any)
-const onboardingPasswordResetRoute = onboardingPasswordResetRouteImport.update({
+
+const onboardingPasswordResetRoute = onboardingPasswordResetImport.update({
   id: '/(onboarding)/password/reset',
   path: '/password/reset',
-  getParentRoute: () => rootRouteImport,
+  getParentRoute: () => rootRoute,
 } as any)
-const onboardingPasswordForgotRoute =
-  onboardingPasswordForgotRouteImport.update({
-    id: '/(onboarding)/password/forgot',
-    path: '/password/forgot',
-    getParentRoute: () => rootRouteImport,
-  } as any)
+
+const onboardingPasswordForgotRoute = onboardingPasswordForgotImport.update({
+  id: '/(onboarding)/password/forgot',
+  path: '/password/forgot',
+  getParentRoute: () => rootRoute,
+} as any)
+
 const AuthenticatedSuperAdminSettingsUsageIndexRoute =
-  AuthenticatedSuperAdminSettingsUsageIndexRouteImport.update({
+  AuthenticatedSuperAdminSettingsUsageIndexImport.update({
     id: '/super-admin-settings/usage/',
     path: '/super-admin-settings/usage/',
     getParentRoute: () => AuthenticatedRoute,
   } as any)
+
 const AuthenticatedSuperAdminSettingsSuperAdminsIndexRoute =
-  AuthenticatedSuperAdminSettingsSuperAdminsIndexRouteImport.update({
+  AuthenticatedSuperAdminSettingsSuperAdminsIndexImport.update({
     id: '/super-admin-settings/super-admins/',
     path: '/super-admin-settings/super-admins/',
     getParentRoute: () => AuthenticatedRoute,
   } as any)
+
 const AuthenticatedSuperAdminSettingsSkillsIndexRoute =
-  AuthenticatedSuperAdminSettingsSkillsIndexRouteImport.update({
+  AuthenticatedSuperAdminSettingsSkillsIndexImport.update({
     id: '/super-admin-settings/skills/',
     path: '/super-admin-settings/skills/',
     getParentRoute: () => AuthenticatedRoute,
   } as any)
+
 const AuthenticatedSuperAdminSettingsPlatformConfigIndexRoute =
-  AuthenticatedSuperAdminSettingsPlatformConfigIndexRouteImport.update({
+  AuthenticatedSuperAdminSettingsPlatformConfigIndexImport.update({
     id: '/super-admin-settings/platform-config/',
     path: '/super-admin-settings/platform-config/',
     getParentRoute: () => AuthenticatedRoute,
   } as any)
+
 const AuthenticatedSuperAdminSettingsOrgsIndexRoute =
-  AuthenticatedSuperAdminSettingsOrgsIndexRouteImport.update({
+  AuthenticatedSuperAdminSettingsOrgsIndexImport.update({
     id: '/super-admin-settings/orgs/',
     path: '/super-admin-settings/orgs/',
     getParentRoute: () => AuthenticatedRoute,
   } as any)
+
 const AuthenticatedSuperAdminSettingsModelsCatalogIndexRoute =
-  AuthenticatedSuperAdminSettingsModelsCatalogIndexRouteImport.update({
+  AuthenticatedSuperAdminSettingsModelsCatalogIndexImport.update({
     id: '/super-admin-settings/models-catalog/',
     path: '/super-admin-settings/models-catalog/',
     getParentRoute: () => AuthenticatedRoute,
   } as any)
+
 const AuthenticatedAdminSettingsTeamsIndexRoute =
-  AuthenticatedAdminSettingsTeamsIndexRouteImport.update({
+  AuthenticatedAdminSettingsTeamsIndexImport.update({
     id: '/admin-settings/teams/',
     path: '/admin-settings/teams/',
     getParentRoute: () => AuthenticatedRoute,
   } as any)
+
 const AuthenticatedAdminSettingsLetterheadsIndexRoute =
-  AuthenticatedAdminSettingsLetterheadsIndexRouteImport.update({
+  AuthenticatedAdminSettingsLetterheadsIndexImport.update({
     id: '/admin-settings/letterheads/',
     path: '/admin-settings/letterheads/',
     getParentRoute: () => AuthenticatedRoute,
   } as any)
+
 const AuthenticatedSuperAdminSettingsOrgsIdRoute =
-  AuthenticatedSuperAdminSettingsOrgsIdRouteImport.update({
+  AuthenticatedSuperAdminSettingsOrgsIdImport.update({
     id: '/super-admin-settings/orgs/$id',
     path: '/super-admin-settings/orgs/$id',
     getParentRoute: () => AuthenticatedRoute,
   } as any)
+
 const AuthenticatedAdminSettingsTeamsIdRoute =
-  AuthenticatedAdminSettingsTeamsIdRouteImport.update({
+  AuthenticatedAdminSettingsTeamsIdImport.update({
     id: '/admin-settings/teams/$id',
     path: '/admin-settings/teams/$id',
     getParentRoute: () => AuthenticatedRoute,
   } as any)
+
 const AuthenticatedAdminSettingsLetterheadsIdRoute =
-  AuthenticatedAdminSettingsLetterheadsIdRouteImport.update({
+  AuthenticatedAdminSettingsLetterheadsIdImport.update({
     id: '/admin-settings/letterheads/$id',
     path: '/admin-settings/letterheads/$id',
     getParentRoute: () => AuthenticatedRoute,
   } as any)
 
-export interface FileRoutesByFullPath {
-  '/': typeof IndexRoute
-  '/accept-invite': typeof onboardingAcceptInviteRoute
-  '/confirm-email': typeof onboardingConfirmEmailRoute
-  '/email-confirm': typeof onboardingEmailConfirmRoute
-  '/ip-blocked': typeof onboardingIpBlockedRoute
-  '/login': typeof onboardingLoginRoute
-  '/register': typeof onboardingRegisterRoute
-  '/install': typeof AuthenticatedInstallRoute
-  '/password/forgot': typeof onboardingPasswordForgotRoute
-  '/password/reset': typeof onboardingPasswordResetRoute
-  '/admin-settings/integrations': typeof AuthenticatedAdminSettingsIntegrationsRoute
-  '/admin-settings/models': typeof AuthenticatedAdminSettingsModelsRoute
-  '/admin-settings/security': typeof AuthenticatedAdminSettingsSecurityRoute
-  '/admin-settings/usage': typeof AuthenticatedAdminSettingsUsageRoute
-  '/admin-settings/users': typeof AuthenticatedAdminSettingsUsersRoute
-  '/agents/$id': typeof AuthenticatedAgentsIdRoute
-  '/chats/$threadId': typeof AuthenticatedChatsThreadIdRoute
-  '/knowledge-bases/$id': typeof AuthenticatedKnowledgeBasesIdRoute
-  '/settings/account': typeof AuthenticatedSettingsAccountRoute
-  '/settings/chat': typeof AuthenticatedSettingsChatRoute
-  '/settings/general': typeof AuthenticatedSettingsGeneralRoute
-  '/skills/$id': typeof AuthenticatedSkillsIdRoute
-  '/admin-settings/': typeof AuthenticatedAdminSettingsIndexRoute
-  '/agents/': typeof AuthenticatedAgentsIndexRoute
-  '/chat/': typeof AuthenticatedChatIndexRoute
-  '/chats/': typeof AuthenticatedChatsIndexRoute
-  '/knowledge-bases/': typeof AuthenticatedKnowledgeBasesIndexRoute
-  '/prompts/': typeof AuthenticatedPromptsIndexRoute
-  '/settings/': typeof AuthenticatedSettingsIndexRoute
-  '/skills/': typeof AuthenticatedSkillsIndexRoute
-  '/super-admin-settings/': typeof AuthenticatedSuperAdminSettingsIndexRoute
-  '/admin-settings/letterheads/$id': typeof AuthenticatedAdminSettingsLetterheadsIdRoute
-  '/admin-settings/teams/$id': typeof AuthenticatedAdminSettingsTeamsIdRoute
-  '/super-admin-settings/orgs/$id': typeof AuthenticatedSuperAdminSettingsOrgsIdRoute
-  '/admin-settings/letterheads/': typeof AuthenticatedAdminSettingsLetterheadsIndexRoute
-  '/admin-settings/teams/': typeof AuthenticatedAdminSettingsTeamsIndexRoute
-  '/super-admin-settings/models-catalog/': typeof AuthenticatedSuperAdminSettingsModelsCatalogIndexRoute
-  '/super-admin-settings/orgs/': typeof AuthenticatedSuperAdminSettingsOrgsIndexRoute
-  '/super-admin-settings/platform-config/': typeof AuthenticatedSuperAdminSettingsPlatformConfigIndexRoute
-  '/super-admin-settings/skills/': typeof AuthenticatedSuperAdminSettingsSkillsIndexRoute
-  '/super-admin-settings/super-admins/': typeof AuthenticatedSuperAdminSettingsSuperAdminsIndexRoute
-  '/super-admin-settings/usage/': typeof AuthenticatedSuperAdminSettingsUsageIndexRoute
-}
-export interface FileRoutesByTo {
-  '/': typeof IndexRoute
-  '/accept-invite': typeof onboardingAcceptInviteRoute
-  '/confirm-email': typeof onboardingConfirmEmailRoute
-  '/email-confirm': typeof onboardingEmailConfirmRoute
-  '/ip-blocked': typeof onboardingIpBlockedRoute
-  '/login': typeof onboardingLoginRoute
-  '/register': typeof onboardingRegisterRoute
-  '/install': typeof AuthenticatedInstallRoute
-  '/password/forgot': typeof onboardingPasswordForgotRoute
-  '/password/reset': typeof onboardingPasswordResetRoute
-  '/admin-settings/integrations': typeof AuthenticatedAdminSettingsIntegrationsRoute
-  '/admin-settings/models': typeof AuthenticatedAdminSettingsModelsRoute
-  '/admin-settings/security': typeof AuthenticatedAdminSettingsSecurityRoute
-  '/admin-settings/usage': typeof AuthenticatedAdminSettingsUsageRoute
-  '/admin-settings/users': typeof AuthenticatedAdminSettingsUsersRoute
-  '/agents/$id': typeof AuthenticatedAgentsIdRoute
-  '/chats/$threadId': typeof AuthenticatedChatsThreadIdRoute
-  '/knowledge-bases/$id': typeof AuthenticatedKnowledgeBasesIdRoute
-  '/settings/account': typeof AuthenticatedSettingsAccountRoute
-  '/settings/chat': typeof AuthenticatedSettingsChatRoute
-  '/settings/general': typeof AuthenticatedSettingsGeneralRoute
-  '/skills/$id': typeof AuthenticatedSkillsIdRoute
-  '/admin-settings': typeof AuthenticatedAdminSettingsIndexRoute
-  '/agents': typeof AuthenticatedAgentsIndexRoute
-  '/chat': typeof AuthenticatedChatIndexRoute
-  '/chats': typeof AuthenticatedChatsIndexRoute
-  '/knowledge-bases': typeof AuthenticatedKnowledgeBasesIndexRoute
-  '/prompts': typeof AuthenticatedPromptsIndexRoute
-  '/settings': typeof AuthenticatedSettingsIndexRoute
-  '/skills': typeof AuthenticatedSkillsIndexRoute
-  '/super-admin-settings': typeof AuthenticatedSuperAdminSettingsIndexRoute
-  '/admin-settings/letterheads/$id': typeof AuthenticatedAdminSettingsLetterheadsIdRoute
-  '/admin-settings/teams/$id': typeof AuthenticatedAdminSettingsTeamsIdRoute
-  '/super-admin-settings/orgs/$id': typeof AuthenticatedSuperAdminSettingsOrgsIdRoute
-  '/admin-settings/letterheads': typeof AuthenticatedAdminSettingsLetterheadsIndexRoute
-  '/admin-settings/teams': typeof AuthenticatedAdminSettingsTeamsIndexRoute
-  '/super-admin-settings/models-catalog': typeof AuthenticatedSuperAdminSettingsModelsCatalogIndexRoute
-  '/super-admin-settings/orgs': typeof AuthenticatedSuperAdminSettingsOrgsIndexRoute
-  '/super-admin-settings/platform-config': typeof AuthenticatedSuperAdminSettingsPlatformConfigIndexRoute
-  '/super-admin-settings/skills': typeof AuthenticatedSuperAdminSettingsSkillsIndexRoute
-  '/super-admin-settings/super-admins': typeof AuthenticatedSuperAdminSettingsSuperAdminsIndexRoute
-  '/super-admin-settings/usage': typeof AuthenticatedSuperAdminSettingsUsageIndexRoute
-}
-export interface FileRoutesById {
-  __root__: typeof rootRouteImport
-  '/': typeof IndexRoute
-  '/_authenticated': typeof AuthenticatedRouteWithChildren
-  '/(onboarding)/accept-invite': typeof onboardingAcceptInviteRoute
-  '/(onboarding)/confirm-email': typeof onboardingConfirmEmailRoute
-  '/(onboarding)/email-confirm': typeof onboardingEmailConfirmRoute
-  '/(onboarding)/ip-blocked': typeof onboardingIpBlockedRoute
-  '/(onboarding)/login': typeof onboardingLoginRoute
-  '/(onboarding)/register': typeof onboardingRegisterRoute
-  '/_authenticated/install': typeof AuthenticatedInstallRoute
-  '/(onboarding)/password/forgot': typeof onboardingPasswordForgotRoute
-  '/(onboarding)/password/reset': typeof onboardingPasswordResetRoute
-  '/_authenticated/admin-settings/integrations': typeof AuthenticatedAdminSettingsIntegrationsRoute
-  '/_authenticated/admin-settings/models': typeof AuthenticatedAdminSettingsModelsRoute
-  '/_authenticated/admin-settings/security': typeof AuthenticatedAdminSettingsSecurityRoute
-  '/_authenticated/admin-settings/usage': typeof AuthenticatedAdminSettingsUsageRoute
-  '/_authenticated/admin-settings/users': typeof AuthenticatedAdminSettingsUsersRoute
-  '/_authenticated/agents/$id': typeof AuthenticatedAgentsIdRoute
-  '/_authenticated/chats/$threadId': typeof AuthenticatedChatsThreadIdRoute
-  '/_authenticated/knowledge-bases/$id': typeof AuthenticatedKnowledgeBasesIdRoute
-  '/_authenticated/settings/account': typeof AuthenticatedSettingsAccountRoute
-  '/_authenticated/settings/chat': typeof AuthenticatedSettingsChatRoute
-  '/_authenticated/settings/general': typeof AuthenticatedSettingsGeneralRoute
-  '/_authenticated/skills/$id': typeof AuthenticatedSkillsIdRoute
-  '/_authenticated/admin-settings/': typeof AuthenticatedAdminSettingsIndexRoute
-  '/_authenticated/agents/': typeof AuthenticatedAgentsIndexRoute
-  '/_authenticated/chat/': typeof AuthenticatedChatIndexRoute
-  '/_authenticated/chats/': typeof AuthenticatedChatsIndexRoute
-  '/_authenticated/knowledge-bases/': typeof AuthenticatedKnowledgeBasesIndexRoute
-  '/_authenticated/prompts/': typeof AuthenticatedPromptsIndexRoute
-  '/_authenticated/settings/': typeof AuthenticatedSettingsIndexRoute
-  '/_authenticated/skills/': typeof AuthenticatedSkillsIndexRoute
-  '/_authenticated/super-admin-settings/': typeof AuthenticatedSuperAdminSettingsIndexRoute
-  '/_authenticated/admin-settings/letterheads/$id': typeof AuthenticatedAdminSettingsLetterheadsIdRoute
-  '/_authenticated/admin-settings/teams/$id': typeof AuthenticatedAdminSettingsTeamsIdRoute
-  '/_authenticated/super-admin-settings/orgs/$id': typeof AuthenticatedSuperAdminSettingsOrgsIdRoute
-  '/_authenticated/admin-settings/letterheads/': typeof AuthenticatedAdminSettingsLetterheadsIndexRoute
-  '/_authenticated/admin-settings/teams/': typeof AuthenticatedAdminSettingsTeamsIndexRoute
-  '/_authenticated/super-admin-settings/models-catalog/': typeof AuthenticatedSuperAdminSettingsModelsCatalogIndexRoute
-  '/_authenticated/super-admin-settings/orgs/': typeof AuthenticatedSuperAdminSettingsOrgsIndexRoute
-  '/_authenticated/super-admin-settings/platform-config/': typeof AuthenticatedSuperAdminSettingsPlatformConfigIndexRoute
-  '/_authenticated/super-admin-settings/skills/': typeof AuthenticatedSuperAdminSettingsSkillsIndexRoute
-  '/_authenticated/super-admin-settings/super-admins/': typeof AuthenticatedSuperAdminSettingsSuperAdminsIndexRoute
-  '/_authenticated/super-admin-settings/usage/': typeof AuthenticatedSuperAdminSettingsUsageIndexRoute
-}
-export interface FileRouteTypes {
-  fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths:
-    | '/'
-    | '/accept-invite'
-    | '/confirm-email'
-    | '/email-confirm'
-    | '/ip-blocked'
-    | '/login'
-    | '/register'
-    | '/install'
-    | '/password/forgot'
-    | '/password/reset'
-    | '/admin-settings/integrations'
-    | '/admin-settings/models'
-    | '/admin-settings/security'
-    | '/admin-settings/usage'
-    | '/admin-settings/users'
-    | '/agents/$id'
-    | '/chats/$threadId'
-    | '/knowledge-bases/$id'
-    | '/settings/account'
-    | '/settings/chat'
-    | '/settings/general'
-    | '/skills/$id'
-    | '/admin-settings/'
-    | '/agents/'
-    | '/chat/'
-    | '/chats/'
-    | '/knowledge-bases/'
-    | '/prompts/'
-    | '/settings/'
-    | '/skills/'
-    | '/super-admin-settings/'
-    | '/admin-settings/letterheads/$id'
-    | '/admin-settings/teams/$id'
-    | '/super-admin-settings/orgs/$id'
-    | '/admin-settings/letterheads/'
-    | '/admin-settings/teams/'
-    | '/super-admin-settings/models-catalog/'
-    | '/super-admin-settings/orgs/'
-    | '/super-admin-settings/platform-config/'
-    | '/super-admin-settings/skills/'
-    | '/super-admin-settings/super-admins/'
-    | '/super-admin-settings/usage/'
-  fileRoutesByTo: FileRoutesByTo
-  to:
-    | '/'
-    | '/accept-invite'
-    | '/confirm-email'
-    | '/email-confirm'
-    | '/ip-blocked'
-    | '/login'
-    | '/register'
-    | '/install'
-    | '/password/forgot'
-    | '/password/reset'
-    | '/admin-settings/integrations'
-    | '/admin-settings/models'
-    | '/admin-settings/security'
-    | '/admin-settings/usage'
-    | '/admin-settings/users'
-    | '/agents/$id'
-    | '/chats/$threadId'
-    | '/knowledge-bases/$id'
-    | '/settings/account'
-    | '/settings/chat'
-    | '/settings/general'
-    | '/skills/$id'
-    | '/admin-settings'
-    | '/agents'
-    | '/chat'
-    | '/chats'
-    | '/knowledge-bases'
-    | '/prompts'
-    | '/settings'
-    | '/skills'
-    | '/super-admin-settings'
-    | '/admin-settings/letterheads/$id'
-    | '/admin-settings/teams/$id'
-    | '/super-admin-settings/orgs/$id'
-    | '/admin-settings/letterheads'
-    | '/admin-settings/teams'
-    | '/super-admin-settings/models-catalog'
-    | '/super-admin-settings/orgs'
-    | '/super-admin-settings/platform-config'
-    | '/super-admin-settings/skills'
-    | '/super-admin-settings/super-admins'
-    | '/super-admin-settings/usage'
-  id:
-    | '__root__'
-    | '/'
-    | '/_authenticated'
-    | '/(onboarding)/accept-invite'
-    | '/(onboarding)/confirm-email'
-    | '/(onboarding)/email-confirm'
-    | '/(onboarding)/ip-blocked'
-    | '/(onboarding)/login'
-    | '/(onboarding)/register'
-    | '/_authenticated/install'
-    | '/(onboarding)/password/forgot'
-    | '/(onboarding)/password/reset'
-    | '/_authenticated/admin-settings/integrations'
-    | '/_authenticated/admin-settings/models'
-    | '/_authenticated/admin-settings/security'
-    | '/_authenticated/admin-settings/usage'
-    | '/_authenticated/admin-settings/users'
-    | '/_authenticated/agents/$id'
-    | '/_authenticated/chats/$threadId'
-    | '/_authenticated/knowledge-bases/$id'
-    | '/_authenticated/settings/account'
-    | '/_authenticated/settings/chat'
-    | '/_authenticated/settings/general'
-    | '/_authenticated/skills/$id'
-    | '/_authenticated/admin-settings/'
-    | '/_authenticated/agents/'
-    | '/_authenticated/chat/'
-    | '/_authenticated/chats/'
-    | '/_authenticated/knowledge-bases/'
-    | '/_authenticated/prompts/'
-    | '/_authenticated/settings/'
-    | '/_authenticated/skills/'
-    | '/_authenticated/super-admin-settings/'
-    | '/_authenticated/admin-settings/letterheads/$id'
-    | '/_authenticated/admin-settings/teams/$id'
-    | '/_authenticated/super-admin-settings/orgs/$id'
-    | '/_authenticated/admin-settings/letterheads/'
-    | '/_authenticated/admin-settings/teams/'
-    | '/_authenticated/super-admin-settings/models-catalog/'
-    | '/_authenticated/super-admin-settings/orgs/'
-    | '/_authenticated/super-admin-settings/platform-config/'
-    | '/_authenticated/super-admin-settings/skills/'
-    | '/_authenticated/super-admin-settings/super-admins/'
-    | '/_authenticated/super-admin-settings/usage/'
-  fileRoutesById: FileRoutesById
-}
-export interface RootRouteChildren {
-  IndexRoute: typeof IndexRoute
-  AuthenticatedRoute: typeof AuthenticatedRouteWithChildren
-  onboardingAcceptInviteRoute: typeof onboardingAcceptInviteRoute
-  onboardingConfirmEmailRoute: typeof onboardingConfirmEmailRoute
-  onboardingEmailConfirmRoute: typeof onboardingEmailConfirmRoute
-  onboardingIpBlockedRoute: typeof onboardingIpBlockedRoute
-  onboardingLoginRoute: typeof onboardingLoginRoute
-  onboardingRegisterRoute: typeof onboardingRegisterRoute
-  onboardingPasswordForgotRoute: typeof onboardingPasswordForgotRoute
-  onboardingPasswordResetRoute: typeof onboardingPasswordResetRoute
-}
+// Populate the FileRoutesByPath interface
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
-    '/_authenticated': {
-      id: '/_authenticated'
-      path: ''
-      fullPath: '/'
-      preLoaderRoute: typeof AuthenticatedRouteImport
-      parentRoute: typeof rootRouteImport
-    }
     '/': {
       id: '/'
       path: '/'
       fullPath: '/'
-      preLoaderRoute: typeof IndexRouteImport
-      parentRoute: typeof rootRouteImport
+      preLoaderRoute: typeof IndexImport
+      parentRoute: typeof rootRoute
     }
-    '/_authenticated/install': {
-      id: '/_authenticated/install'
-      path: '/install'
-      fullPath: '/install'
-      preLoaderRoute: typeof AuthenticatedInstallRouteImport
-      parentRoute: typeof AuthenticatedRoute
-    }
-    '/(onboarding)/register': {
-      id: '/(onboarding)/register'
-      path: '/register'
-      fullPath: '/register'
-      preLoaderRoute: typeof onboardingRegisterRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/(onboarding)/login': {
-      id: '/(onboarding)/login'
-      path: '/login'
-      fullPath: '/login'
-      preLoaderRoute: typeof onboardingLoginRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/(onboarding)/ip-blocked': {
-      id: '/(onboarding)/ip-blocked'
-      path: '/ip-blocked'
-      fullPath: '/ip-blocked'
-      preLoaderRoute: typeof onboardingIpBlockedRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/(onboarding)/email-confirm': {
-      id: '/(onboarding)/email-confirm'
-      path: '/email-confirm'
-      fullPath: '/email-confirm'
-      preLoaderRoute: typeof onboardingEmailConfirmRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/(onboarding)/confirm-email': {
-      id: '/(onboarding)/confirm-email'
-      path: '/confirm-email'
-      fullPath: '/confirm-email'
-      preLoaderRoute: typeof onboardingConfirmEmailRouteImport
-      parentRoute: typeof rootRouteImport
+    '/_authenticated': {
+      id: '/_authenticated'
+      path: ''
+      fullPath: ''
+      preLoaderRoute: typeof AuthenticatedImport
+      parentRoute: typeof rootRoute
     }
     '/(onboarding)/accept-invite': {
       id: '/(onboarding)/accept-invite'
       path: '/accept-invite'
       fullPath: '/accept-invite'
-      preLoaderRoute: typeof onboardingAcceptInviteRouteImport
-      parentRoute: typeof rootRouteImport
+      preLoaderRoute: typeof onboardingAcceptInviteImport
+      parentRoute: typeof rootRoute
     }
-    '/_authenticated/super-admin-settings/': {
-      id: '/_authenticated/super-admin-settings/'
-      path: '/super-admin-settings'
-      fullPath: '/super-admin-settings/'
-      preLoaderRoute: typeof AuthenticatedSuperAdminSettingsIndexRouteImport
-      parentRoute: typeof AuthenticatedRoute
+    '/(onboarding)/confirm-email': {
+      id: '/(onboarding)/confirm-email'
+      path: '/confirm-email'
+      fullPath: '/confirm-email'
+      preLoaderRoute: typeof onboardingConfirmEmailImport
+      parentRoute: typeof rootRoute
     }
-    '/_authenticated/skills/': {
-      id: '/_authenticated/skills/'
-      path: '/skills'
-      fullPath: '/skills/'
-      preLoaderRoute: typeof AuthenticatedSkillsIndexRouteImport
-      parentRoute: typeof AuthenticatedRoute
+    '/(onboarding)/email-confirm': {
+      id: '/(onboarding)/email-confirm'
+      path: '/email-confirm'
+      fullPath: '/email-confirm'
+      preLoaderRoute: typeof onboardingEmailConfirmImport
+      parentRoute: typeof rootRoute
     }
-    '/_authenticated/settings/': {
-      id: '/_authenticated/settings/'
-      path: '/settings'
-      fullPath: '/settings/'
-      preLoaderRoute: typeof AuthenticatedSettingsIndexRouteImport
-      parentRoute: typeof AuthenticatedRoute
+    '/(onboarding)/ip-blocked': {
+      id: '/(onboarding)/ip-blocked'
+      path: '/ip-blocked'
+      fullPath: '/ip-blocked'
+      preLoaderRoute: typeof onboardingIpBlockedImport
+      parentRoute: typeof rootRoute
     }
-    '/_authenticated/prompts/': {
-      id: '/_authenticated/prompts/'
-      path: '/prompts'
-      fullPath: '/prompts/'
-      preLoaderRoute: typeof AuthenticatedPromptsIndexRouteImport
-      parentRoute: typeof AuthenticatedRoute
+    '/(onboarding)/login': {
+      id: '/(onboarding)/login'
+      path: '/login'
+      fullPath: '/login'
+      preLoaderRoute: typeof onboardingLoginImport
+      parentRoute: typeof rootRoute
     }
-    '/_authenticated/knowledge-bases/': {
-      id: '/_authenticated/knowledge-bases/'
-      path: '/knowledge-bases'
-      fullPath: '/knowledge-bases/'
-      preLoaderRoute: typeof AuthenticatedKnowledgeBasesIndexRouteImport
-      parentRoute: typeof AuthenticatedRoute
+    '/(onboarding)/register': {
+      id: '/(onboarding)/register'
+      path: '/register'
+      fullPath: '/register'
+      preLoaderRoute: typeof onboardingRegisterImport
+      parentRoute: typeof rootRoute
     }
-    '/_authenticated/chats/': {
-      id: '/_authenticated/chats/'
-      path: '/chats'
-      fullPath: '/chats/'
-      preLoaderRoute: typeof AuthenticatedChatsIndexRouteImport
-      parentRoute: typeof AuthenticatedRoute
-    }
-    '/_authenticated/chat/': {
-      id: '/_authenticated/chat/'
-      path: '/chat'
-      fullPath: '/chat/'
-      preLoaderRoute: typeof AuthenticatedChatIndexRouteImport
-      parentRoute: typeof AuthenticatedRoute
-    }
-    '/_authenticated/agents/': {
-      id: '/_authenticated/agents/'
-      path: '/agents'
-      fullPath: '/agents/'
-      preLoaderRoute: typeof AuthenticatedAgentsIndexRouteImport
-      parentRoute: typeof AuthenticatedRoute
-    }
-    '/_authenticated/admin-settings/': {
-      id: '/_authenticated/admin-settings/'
-      path: '/admin-settings'
-      fullPath: '/admin-settings/'
-      preLoaderRoute: typeof AuthenticatedAdminSettingsIndexRouteImport
-      parentRoute: typeof AuthenticatedRoute
-    }
-    '/_authenticated/skills/$id': {
-      id: '/_authenticated/skills/$id'
-      path: '/skills/$id'
-      fullPath: '/skills/$id'
-      preLoaderRoute: typeof AuthenticatedSkillsIdRouteImport
-      parentRoute: typeof AuthenticatedRoute
-    }
-    '/_authenticated/settings/general': {
-      id: '/_authenticated/settings/general'
-      path: '/settings/general'
-      fullPath: '/settings/general'
-      preLoaderRoute: typeof AuthenticatedSettingsGeneralRouteImport
-      parentRoute: typeof AuthenticatedRoute
-    }
-    '/_authenticated/settings/chat': {
-      id: '/_authenticated/settings/chat'
-      path: '/settings/chat'
-      fullPath: '/settings/chat'
-      preLoaderRoute: typeof AuthenticatedSettingsChatRouteImport
-      parentRoute: typeof AuthenticatedRoute
-    }
-    '/_authenticated/settings/account': {
-      id: '/_authenticated/settings/account'
-      path: '/settings/account'
-      fullPath: '/settings/account'
-      preLoaderRoute: typeof AuthenticatedSettingsAccountRouteImport
-      parentRoute: typeof AuthenticatedRoute
-    }
-    '/_authenticated/knowledge-bases/$id': {
-      id: '/_authenticated/knowledge-bases/$id'
-      path: '/knowledge-bases/$id'
-      fullPath: '/knowledge-bases/$id'
-      preLoaderRoute: typeof AuthenticatedKnowledgeBasesIdRouteImport
-      parentRoute: typeof AuthenticatedRoute
-    }
-    '/_authenticated/chats/$threadId': {
-      id: '/_authenticated/chats/$threadId'
-      path: '/chats/$threadId'
-      fullPath: '/chats/$threadId'
-      preLoaderRoute: typeof AuthenticatedChatsThreadIdRouteImport
-      parentRoute: typeof AuthenticatedRoute
-    }
-    '/_authenticated/agents/$id': {
-      id: '/_authenticated/agents/$id'
-      path: '/agents/$id'
-      fullPath: '/agents/$id'
-      preLoaderRoute: typeof AuthenticatedAgentsIdRouteImport
-      parentRoute: typeof AuthenticatedRoute
-    }
-    '/_authenticated/admin-settings/users': {
-      id: '/_authenticated/admin-settings/users'
-      path: '/admin-settings/users'
-      fullPath: '/admin-settings/users'
-      preLoaderRoute: typeof AuthenticatedAdminSettingsUsersRouteImport
-      parentRoute: typeof AuthenticatedRoute
-    }
-    '/_authenticated/admin-settings/usage': {
-      id: '/_authenticated/admin-settings/usage'
-      path: '/admin-settings/usage'
-      fullPath: '/admin-settings/usage'
-      preLoaderRoute: typeof AuthenticatedAdminSettingsUsageRouteImport
-      parentRoute: typeof AuthenticatedRoute
-    }
-    '/_authenticated/admin-settings/security': {
-      id: '/_authenticated/admin-settings/security'
-      path: '/admin-settings/security'
-      fullPath: '/admin-settings/security'
-      preLoaderRoute: typeof AuthenticatedAdminSettingsSecurityRouteImport
-      parentRoute: typeof AuthenticatedRoute
-    }
-    '/_authenticated/admin-settings/models': {
-      id: '/_authenticated/admin-settings/models'
-      path: '/admin-settings/models'
-      fullPath: '/admin-settings/models'
-      preLoaderRoute: typeof AuthenticatedAdminSettingsModelsRouteImport
-      parentRoute: typeof AuthenticatedRoute
-    }
-    '/_authenticated/admin-settings/integrations': {
-      id: '/_authenticated/admin-settings/integrations'
-      path: '/admin-settings/integrations'
-      fullPath: '/admin-settings/integrations'
-      preLoaderRoute: typeof AuthenticatedAdminSettingsIntegrationsRouteImport
-      parentRoute: typeof AuthenticatedRoute
-    }
-    '/(onboarding)/password/reset': {
-      id: '/(onboarding)/password/reset'
-      path: '/password/reset'
-      fullPath: '/password/reset'
-      preLoaderRoute: typeof onboardingPasswordResetRouteImport
-      parentRoute: typeof rootRouteImport
+    '/_authenticated/install': {
+      id: '/_authenticated/install'
+      path: '/install'
+      fullPath: '/install'
+      preLoaderRoute: typeof AuthenticatedInstallImport
+      parentRoute: typeof AuthenticatedImport
     }
     '/(onboarding)/password/forgot': {
       id: '/(onboarding)/password/forgot'
       path: '/password/forgot'
       fullPath: '/password/forgot'
-      preLoaderRoute: typeof onboardingPasswordForgotRouteImport
-      parentRoute: typeof rootRouteImport
+      preLoaderRoute: typeof onboardingPasswordForgotImport
+      parentRoute: typeof rootRoute
     }
-    '/_authenticated/super-admin-settings/usage/': {
-      id: '/_authenticated/super-admin-settings/usage/'
-      path: '/super-admin-settings/usage'
-      fullPath: '/super-admin-settings/usage/'
-      preLoaderRoute: typeof AuthenticatedSuperAdminSettingsUsageIndexRouteImport
-      parentRoute: typeof AuthenticatedRoute
+    '/(onboarding)/password/reset': {
+      id: '/(onboarding)/password/reset'
+      path: '/password/reset'
+      fullPath: '/password/reset'
+      preLoaderRoute: typeof onboardingPasswordResetImport
+      parentRoute: typeof rootRoute
     }
-    '/_authenticated/super-admin-settings/super-admins/': {
-      id: '/_authenticated/super-admin-settings/super-admins/'
-      path: '/super-admin-settings/super-admins'
-      fullPath: '/super-admin-settings/super-admins/'
-      preLoaderRoute: typeof AuthenticatedSuperAdminSettingsSuperAdminsIndexRouteImport
-      parentRoute: typeof AuthenticatedRoute
+    '/_authenticated/admin-settings/integrations': {
+      id: '/_authenticated/admin-settings/integrations'
+      path: '/admin-settings/integrations'
+      fullPath: '/admin-settings/integrations'
+      preLoaderRoute: typeof AuthenticatedAdminSettingsIntegrationsImport
+      parentRoute: typeof AuthenticatedImport
     }
-    '/_authenticated/super-admin-settings/skills/': {
-      id: '/_authenticated/super-admin-settings/skills/'
-      path: '/super-admin-settings/skills'
-      fullPath: '/super-admin-settings/skills/'
-      preLoaderRoute: typeof AuthenticatedSuperAdminSettingsSkillsIndexRouteImport
-      parentRoute: typeof AuthenticatedRoute
+    '/_authenticated/admin-settings/models': {
+      id: '/_authenticated/admin-settings/models'
+      path: '/admin-settings/models'
+      fullPath: '/admin-settings/models'
+      preLoaderRoute: typeof AuthenticatedAdminSettingsModelsImport
+      parentRoute: typeof AuthenticatedImport
     }
-    '/_authenticated/super-admin-settings/platform-config/': {
-      id: '/_authenticated/super-admin-settings/platform-config/'
-      path: '/super-admin-settings/platform-config'
-      fullPath: '/super-admin-settings/platform-config/'
-      preLoaderRoute: typeof AuthenticatedSuperAdminSettingsPlatformConfigIndexRouteImport
-      parentRoute: typeof AuthenticatedRoute
+    '/_authenticated/admin-settings/security': {
+      id: '/_authenticated/admin-settings/security'
+      path: '/admin-settings/security'
+      fullPath: '/admin-settings/security'
+      preLoaderRoute: typeof AuthenticatedAdminSettingsSecurityImport
+      parentRoute: typeof AuthenticatedImport
     }
-    '/_authenticated/super-admin-settings/orgs/': {
-      id: '/_authenticated/super-admin-settings/orgs/'
-      path: '/super-admin-settings/orgs'
-      fullPath: '/super-admin-settings/orgs/'
-      preLoaderRoute: typeof AuthenticatedSuperAdminSettingsOrgsIndexRouteImport
-      parentRoute: typeof AuthenticatedRoute
+    '/_authenticated/admin-settings/usage': {
+      id: '/_authenticated/admin-settings/usage'
+      path: '/admin-settings/usage'
+      fullPath: '/admin-settings/usage'
+      preLoaderRoute: typeof AuthenticatedAdminSettingsUsageImport
+      parentRoute: typeof AuthenticatedImport
     }
-    '/_authenticated/super-admin-settings/models-catalog/': {
-      id: '/_authenticated/super-admin-settings/models-catalog/'
-      path: '/super-admin-settings/models-catalog'
-      fullPath: '/super-admin-settings/models-catalog/'
-      preLoaderRoute: typeof AuthenticatedSuperAdminSettingsModelsCatalogIndexRouteImport
-      parentRoute: typeof AuthenticatedRoute
+    '/_authenticated/admin-settings/users': {
+      id: '/_authenticated/admin-settings/users'
+      path: '/admin-settings/users'
+      fullPath: '/admin-settings/users'
+      preLoaderRoute: typeof AuthenticatedAdminSettingsUsersImport
+      parentRoute: typeof AuthenticatedImport
     }
-    '/_authenticated/admin-settings/teams/': {
-      id: '/_authenticated/admin-settings/teams/'
-      path: '/admin-settings/teams'
-      fullPath: '/admin-settings/teams/'
-      preLoaderRoute: typeof AuthenticatedAdminSettingsTeamsIndexRouteImport
-      parentRoute: typeof AuthenticatedRoute
+    '/_authenticated/agents/$id': {
+      id: '/_authenticated/agents/$id'
+      path: '/agents/$id'
+      fullPath: '/agents/$id'
+      preLoaderRoute: typeof AuthenticatedAgentsIdImport
+      parentRoute: typeof AuthenticatedImport
     }
-    '/_authenticated/admin-settings/letterheads/': {
-      id: '/_authenticated/admin-settings/letterheads/'
-      path: '/admin-settings/letterheads'
-      fullPath: '/admin-settings/letterheads/'
-      preLoaderRoute: typeof AuthenticatedAdminSettingsLetterheadsIndexRouteImport
-      parentRoute: typeof AuthenticatedRoute
+    '/_authenticated/chats/$threadId': {
+      id: '/_authenticated/chats/$threadId'
+      path: '/chats/$threadId'
+      fullPath: '/chats/$threadId'
+      preLoaderRoute: typeof AuthenticatedChatsThreadIdImport
+      parentRoute: typeof AuthenticatedImport
     }
-    '/_authenticated/super-admin-settings/orgs/$id': {
-      id: '/_authenticated/super-admin-settings/orgs/$id'
-      path: '/super-admin-settings/orgs/$id'
-      fullPath: '/super-admin-settings/orgs/$id'
-      preLoaderRoute: typeof AuthenticatedSuperAdminSettingsOrgsIdRouteImport
-      parentRoute: typeof AuthenticatedRoute
+    '/_authenticated/knowledge-bases/$id': {
+      id: '/_authenticated/knowledge-bases/$id'
+      path: '/knowledge-bases/$id'
+      fullPath: '/knowledge-bases/$id'
+      preLoaderRoute: typeof AuthenticatedKnowledgeBasesIdImport
+      parentRoute: typeof AuthenticatedImport
     }
-    '/_authenticated/admin-settings/teams/$id': {
-      id: '/_authenticated/admin-settings/teams/$id'
-      path: '/admin-settings/teams/$id'
-      fullPath: '/admin-settings/teams/$id'
-      preLoaderRoute: typeof AuthenticatedAdminSettingsTeamsIdRouteImport
-      parentRoute: typeof AuthenticatedRoute
+    '/_authenticated/settings/account': {
+      id: '/_authenticated/settings/account'
+      path: '/settings/account'
+      fullPath: '/settings/account'
+      preLoaderRoute: typeof AuthenticatedSettingsAccountImport
+      parentRoute: typeof AuthenticatedImport
+    }
+    '/_authenticated/settings/chat': {
+      id: '/_authenticated/settings/chat'
+      path: '/settings/chat'
+      fullPath: '/settings/chat'
+      preLoaderRoute: typeof AuthenticatedSettingsChatImport
+      parentRoute: typeof AuthenticatedImport
+    }
+    '/_authenticated/settings/general': {
+      id: '/_authenticated/settings/general'
+      path: '/settings/general'
+      fullPath: '/settings/general'
+      preLoaderRoute: typeof AuthenticatedSettingsGeneralImport
+      parentRoute: typeof AuthenticatedImport
+    }
+    '/_authenticated/skills/$id': {
+      id: '/_authenticated/skills/$id'
+      path: '/skills/$id'
+      fullPath: '/skills/$id'
+      preLoaderRoute: typeof AuthenticatedSkillsIdImport
+      parentRoute: typeof AuthenticatedImport
+    }
+    '/_authenticated/admin-settings/': {
+      id: '/_authenticated/admin-settings/'
+      path: '/admin-settings'
+      fullPath: '/admin-settings'
+      preLoaderRoute: typeof AuthenticatedAdminSettingsIndexImport
+      parentRoute: typeof AuthenticatedImport
+    }
+    '/_authenticated/agents/': {
+      id: '/_authenticated/agents/'
+      path: '/agents'
+      fullPath: '/agents'
+      preLoaderRoute: typeof AuthenticatedAgentsIndexImport
+      parentRoute: typeof AuthenticatedImport
+    }
+    '/_authenticated/chat/': {
+      id: '/_authenticated/chat/'
+      path: '/chat'
+      fullPath: '/chat'
+      preLoaderRoute: typeof AuthenticatedChatIndexImport
+      parentRoute: typeof AuthenticatedImport
+    }
+    '/_authenticated/chats/': {
+      id: '/_authenticated/chats/'
+      path: '/chats'
+      fullPath: '/chats'
+      preLoaderRoute: typeof AuthenticatedChatsIndexImport
+      parentRoute: typeof AuthenticatedImport
+    }
+    '/_authenticated/knowledge-bases/': {
+      id: '/_authenticated/knowledge-bases/'
+      path: '/knowledge-bases'
+      fullPath: '/knowledge-bases'
+      preLoaderRoute: typeof AuthenticatedKnowledgeBasesIndexImport
+      parentRoute: typeof AuthenticatedImport
+    }
+    '/_authenticated/prompts/': {
+      id: '/_authenticated/prompts/'
+      path: '/prompts'
+      fullPath: '/prompts'
+      preLoaderRoute: typeof AuthenticatedPromptsIndexImport
+      parentRoute: typeof AuthenticatedImport
+    }
+    '/_authenticated/settings/': {
+      id: '/_authenticated/settings/'
+      path: '/settings'
+      fullPath: '/settings'
+      preLoaderRoute: typeof AuthenticatedSettingsIndexImport
+      parentRoute: typeof AuthenticatedImport
+    }
+    '/_authenticated/skills/': {
+      id: '/_authenticated/skills/'
+      path: '/skills'
+      fullPath: '/skills'
+      preLoaderRoute: typeof AuthenticatedSkillsIndexImport
+      parentRoute: typeof AuthenticatedImport
+    }
+    '/_authenticated/super-admin-settings/': {
+      id: '/_authenticated/super-admin-settings/'
+      path: '/super-admin-settings'
+      fullPath: '/super-admin-settings'
+      preLoaderRoute: typeof AuthenticatedSuperAdminSettingsIndexImport
+      parentRoute: typeof AuthenticatedImport
     }
     '/_authenticated/admin-settings/letterheads/$id': {
       id: '/_authenticated/admin-settings/letterheads/$id'
       path: '/admin-settings/letterheads/$id'
       fullPath: '/admin-settings/letterheads/$id'
-      preLoaderRoute: typeof AuthenticatedAdminSettingsLetterheadsIdRouteImport
-      parentRoute: typeof AuthenticatedRoute
+      preLoaderRoute: typeof AuthenticatedAdminSettingsLetterheadsIdImport
+      parentRoute: typeof AuthenticatedImport
+    }
+    '/_authenticated/admin-settings/teams/$id': {
+      id: '/_authenticated/admin-settings/teams/$id'
+      path: '/admin-settings/teams/$id'
+      fullPath: '/admin-settings/teams/$id'
+      preLoaderRoute: typeof AuthenticatedAdminSettingsTeamsIdImport
+      parentRoute: typeof AuthenticatedImport
+    }
+    '/_authenticated/super-admin-settings/orgs/$id': {
+      id: '/_authenticated/super-admin-settings/orgs/$id'
+      path: '/super-admin-settings/orgs/$id'
+      fullPath: '/super-admin-settings/orgs/$id'
+      preLoaderRoute: typeof AuthenticatedSuperAdminSettingsOrgsIdImport
+      parentRoute: typeof AuthenticatedImport
+    }
+    '/_authenticated/admin-settings/letterheads/': {
+      id: '/_authenticated/admin-settings/letterheads/'
+      path: '/admin-settings/letterheads'
+      fullPath: '/admin-settings/letterheads'
+      preLoaderRoute: typeof AuthenticatedAdminSettingsLetterheadsIndexImport
+      parentRoute: typeof AuthenticatedImport
+    }
+    '/_authenticated/admin-settings/teams/': {
+      id: '/_authenticated/admin-settings/teams/'
+      path: '/admin-settings/teams'
+      fullPath: '/admin-settings/teams'
+      preLoaderRoute: typeof AuthenticatedAdminSettingsTeamsIndexImport
+      parentRoute: typeof AuthenticatedImport
+    }
+    '/_authenticated/super-admin-settings/models-catalog/': {
+      id: '/_authenticated/super-admin-settings/models-catalog/'
+      path: '/super-admin-settings/models-catalog'
+      fullPath: '/super-admin-settings/models-catalog'
+      preLoaderRoute: typeof AuthenticatedSuperAdminSettingsModelsCatalogIndexImport
+      parentRoute: typeof AuthenticatedImport
+    }
+    '/_authenticated/super-admin-settings/orgs/': {
+      id: '/_authenticated/super-admin-settings/orgs/'
+      path: '/super-admin-settings/orgs'
+      fullPath: '/super-admin-settings/orgs'
+      preLoaderRoute: typeof AuthenticatedSuperAdminSettingsOrgsIndexImport
+      parentRoute: typeof AuthenticatedImport
+    }
+    '/_authenticated/super-admin-settings/platform-config/': {
+      id: '/_authenticated/super-admin-settings/platform-config/'
+      path: '/super-admin-settings/platform-config'
+      fullPath: '/super-admin-settings/platform-config'
+      preLoaderRoute: typeof AuthenticatedSuperAdminSettingsPlatformConfigIndexImport
+      parentRoute: typeof AuthenticatedImport
+    }
+    '/_authenticated/super-admin-settings/skills/': {
+      id: '/_authenticated/super-admin-settings/skills/'
+      path: '/super-admin-settings/skills'
+      fullPath: '/super-admin-settings/skills'
+      preLoaderRoute: typeof AuthenticatedSuperAdminSettingsSkillsIndexImport
+      parentRoute: typeof AuthenticatedImport
+    }
+    '/_authenticated/super-admin-settings/super-admins/': {
+      id: '/_authenticated/super-admin-settings/super-admins/'
+      path: '/super-admin-settings/super-admins'
+      fullPath: '/super-admin-settings/super-admins'
+      preLoaderRoute: typeof AuthenticatedSuperAdminSettingsSuperAdminsIndexImport
+      parentRoute: typeof AuthenticatedImport
+    }
+    '/_authenticated/super-admin-settings/usage/': {
+      id: '/_authenticated/super-admin-settings/usage/'
+      path: '/super-admin-settings/usage'
+      fullPath: '/super-admin-settings/usage'
+      preLoaderRoute: typeof AuthenticatedSuperAdminSettingsUsageIndexImport
+      parentRoute: typeof AuthenticatedImport
     }
   }
 }
+
+// Create and export the route tree
 
 interface AuthenticatedRouteChildren {
   AuthenticatedInstallRoute: typeof AuthenticatedInstallRoute
@@ -976,6 +740,297 @@ const AuthenticatedRouteWithChildren = AuthenticatedRoute._addFileChildren(
   AuthenticatedRouteChildren,
 )
 
+export interface FileRoutesByFullPath {
+  '/': typeof IndexRoute
+  '': typeof AuthenticatedRouteWithChildren
+  '/accept-invite': typeof onboardingAcceptInviteRoute
+  '/confirm-email': typeof onboardingConfirmEmailRoute
+  '/email-confirm': typeof onboardingEmailConfirmRoute
+  '/ip-blocked': typeof onboardingIpBlockedRoute
+  '/login': typeof onboardingLoginRoute
+  '/register': typeof onboardingRegisterRoute
+  '/install': typeof AuthenticatedInstallRoute
+  '/password/forgot': typeof onboardingPasswordForgotRoute
+  '/password/reset': typeof onboardingPasswordResetRoute
+  '/admin-settings/integrations': typeof AuthenticatedAdminSettingsIntegrationsRoute
+  '/admin-settings/models': typeof AuthenticatedAdminSettingsModelsRoute
+  '/admin-settings/security': typeof AuthenticatedAdminSettingsSecurityRoute
+  '/admin-settings/usage': typeof AuthenticatedAdminSettingsUsageRoute
+  '/admin-settings/users': typeof AuthenticatedAdminSettingsUsersRoute
+  '/agents/$id': typeof AuthenticatedAgentsIdRoute
+  '/chats/$threadId': typeof AuthenticatedChatsThreadIdRoute
+  '/knowledge-bases/$id': typeof AuthenticatedKnowledgeBasesIdRoute
+  '/settings/account': typeof AuthenticatedSettingsAccountRoute
+  '/settings/chat': typeof AuthenticatedSettingsChatRoute
+  '/settings/general': typeof AuthenticatedSettingsGeneralRoute
+  '/skills/$id': typeof AuthenticatedSkillsIdRoute
+  '/admin-settings': typeof AuthenticatedAdminSettingsIndexRoute
+  '/agents': typeof AuthenticatedAgentsIndexRoute
+  '/chat': typeof AuthenticatedChatIndexRoute
+  '/chats': typeof AuthenticatedChatsIndexRoute
+  '/knowledge-bases': typeof AuthenticatedKnowledgeBasesIndexRoute
+  '/prompts': typeof AuthenticatedPromptsIndexRoute
+  '/settings': typeof AuthenticatedSettingsIndexRoute
+  '/skills': typeof AuthenticatedSkillsIndexRoute
+  '/super-admin-settings': typeof AuthenticatedSuperAdminSettingsIndexRoute
+  '/admin-settings/letterheads/$id': typeof AuthenticatedAdminSettingsLetterheadsIdRoute
+  '/admin-settings/teams/$id': typeof AuthenticatedAdminSettingsTeamsIdRoute
+  '/super-admin-settings/orgs/$id': typeof AuthenticatedSuperAdminSettingsOrgsIdRoute
+  '/admin-settings/letterheads': typeof AuthenticatedAdminSettingsLetterheadsIndexRoute
+  '/admin-settings/teams': typeof AuthenticatedAdminSettingsTeamsIndexRoute
+  '/super-admin-settings/models-catalog': typeof AuthenticatedSuperAdminSettingsModelsCatalogIndexRoute
+  '/super-admin-settings/orgs': typeof AuthenticatedSuperAdminSettingsOrgsIndexRoute
+  '/super-admin-settings/platform-config': typeof AuthenticatedSuperAdminSettingsPlatformConfigIndexRoute
+  '/super-admin-settings/skills': typeof AuthenticatedSuperAdminSettingsSkillsIndexRoute
+  '/super-admin-settings/super-admins': typeof AuthenticatedSuperAdminSettingsSuperAdminsIndexRoute
+  '/super-admin-settings/usage': typeof AuthenticatedSuperAdminSettingsUsageIndexRoute
+}
+
+export interface FileRoutesByTo {
+  '/': typeof IndexRoute
+  '': typeof AuthenticatedRouteWithChildren
+  '/accept-invite': typeof onboardingAcceptInviteRoute
+  '/confirm-email': typeof onboardingConfirmEmailRoute
+  '/email-confirm': typeof onboardingEmailConfirmRoute
+  '/ip-blocked': typeof onboardingIpBlockedRoute
+  '/login': typeof onboardingLoginRoute
+  '/register': typeof onboardingRegisterRoute
+  '/install': typeof AuthenticatedInstallRoute
+  '/password/forgot': typeof onboardingPasswordForgotRoute
+  '/password/reset': typeof onboardingPasswordResetRoute
+  '/admin-settings/integrations': typeof AuthenticatedAdminSettingsIntegrationsRoute
+  '/admin-settings/models': typeof AuthenticatedAdminSettingsModelsRoute
+  '/admin-settings/security': typeof AuthenticatedAdminSettingsSecurityRoute
+  '/admin-settings/usage': typeof AuthenticatedAdminSettingsUsageRoute
+  '/admin-settings/users': typeof AuthenticatedAdminSettingsUsersRoute
+  '/agents/$id': typeof AuthenticatedAgentsIdRoute
+  '/chats/$threadId': typeof AuthenticatedChatsThreadIdRoute
+  '/knowledge-bases/$id': typeof AuthenticatedKnowledgeBasesIdRoute
+  '/settings/account': typeof AuthenticatedSettingsAccountRoute
+  '/settings/chat': typeof AuthenticatedSettingsChatRoute
+  '/settings/general': typeof AuthenticatedSettingsGeneralRoute
+  '/skills/$id': typeof AuthenticatedSkillsIdRoute
+  '/admin-settings': typeof AuthenticatedAdminSettingsIndexRoute
+  '/agents': typeof AuthenticatedAgentsIndexRoute
+  '/chat': typeof AuthenticatedChatIndexRoute
+  '/chats': typeof AuthenticatedChatsIndexRoute
+  '/knowledge-bases': typeof AuthenticatedKnowledgeBasesIndexRoute
+  '/prompts': typeof AuthenticatedPromptsIndexRoute
+  '/settings': typeof AuthenticatedSettingsIndexRoute
+  '/skills': typeof AuthenticatedSkillsIndexRoute
+  '/super-admin-settings': typeof AuthenticatedSuperAdminSettingsIndexRoute
+  '/admin-settings/letterheads/$id': typeof AuthenticatedAdminSettingsLetterheadsIdRoute
+  '/admin-settings/teams/$id': typeof AuthenticatedAdminSettingsTeamsIdRoute
+  '/super-admin-settings/orgs/$id': typeof AuthenticatedSuperAdminSettingsOrgsIdRoute
+  '/admin-settings/letterheads': typeof AuthenticatedAdminSettingsLetterheadsIndexRoute
+  '/admin-settings/teams': typeof AuthenticatedAdminSettingsTeamsIndexRoute
+  '/super-admin-settings/models-catalog': typeof AuthenticatedSuperAdminSettingsModelsCatalogIndexRoute
+  '/super-admin-settings/orgs': typeof AuthenticatedSuperAdminSettingsOrgsIndexRoute
+  '/super-admin-settings/platform-config': typeof AuthenticatedSuperAdminSettingsPlatformConfigIndexRoute
+  '/super-admin-settings/skills': typeof AuthenticatedSuperAdminSettingsSkillsIndexRoute
+  '/super-admin-settings/super-admins': typeof AuthenticatedSuperAdminSettingsSuperAdminsIndexRoute
+  '/super-admin-settings/usage': typeof AuthenticatedSuperAdminSettingsUsageIndexRoute
+}
+
+export interface FileRoutesById {
+  __root__: typeof rootRoute
+  '/': typeof IndexRoute
+  '/_authenticated': typeof AuthenticatedRouteWithChildren
+  '/(onboarding)/accept-invite': typeof onboardingAcceptInviteRoute
+  '/(onboarding)/confirm-email': typeof onboardingConfirmEmailRoute
+  '/(onboarding)/email-confirm': typeof onboardingEmailConfirmRoute
+  '/(onboarding)/ip-blocked': typeof onboardingIpBlockedRoute
+  '/(onboarding)/login': typeof onboardingLoginRoute
+  '/(onboarding)/register': typeof onboardingRegisterRoute
+  '/_authenticated/install': typeof AuthenticatedInstallRoute
+  '/(onboarding)/password/forgot': typeof onboardingPasswordForgotRoute
+  '/(onboarding)/password/reset': typeof onboardingPasswordResetRoute
+  '/_authenticated/admin-settings/integrations': typeof AuthenticatedAdminSettingsIntegrationsRoute
+  '/_authenticated/admin-settings/models': typeof AuthenticatedAdminSettingsModelsRoute
+  '/_authenticated/admin-settings/security': typeof AuthenticatedAdminSettingsSecurityRoute
+  '/_authenticated/admin-settings/usage': typeof AuthenticatedAdminSettingsUsageRoute
+  '/_authenticated/admin-settings/users': typeof AuthenticatedAdminSettingsUsersRoute
+  '/_authenticated/agents/$id': typeof AuthenticatedAgentsIdRoute
+  '/_authenticated/chats/$threadId': typeof AuthenticatedChatsThreadIdRoute
+  '/_authenticated/knowledge-bases/$id': typeof AuthenticatedKnowledgeBasesIdRoute
+  '/_authenticated/settings/account': typeof AuthenticatedSettingsAccountRoute
+  '/_authenticated/settings/chat': typeof AuthenticatedSettingsChatRoute
+  '/_authenticated/settings/general': typeof AuthenticatedSettingsGeneralRoute
+  '/_authenticated/skills/$id': typeof AuthenticatedSkillsIdRoute
+  '/_authenticated/admin-settings/': typeof AuthenticatedAdminSettingsIndexRoute
+  '/_authenticated/agents/': typeof AuthenticatedAgentsIndexRoute
+  '/_authenticated/chat/': typeof AuthenticatedChatIndexRoute
+  '/_authenticated/chats/': typeof AuthenticatedChatsIndexRoute
+  '/_authenticated/knowledge-bases/': typeof AuthenticatedKnowledgeBasesIndexRoute
+  '/_authenticated/prompts/': typeof AuthenticatedPromptsIndexRoute
+  '/_authenticated/settings/': typeof AuthenticatedSettingsIndexRoute
+  '/_authenticated/skills/': typeof AuthenticatedSkillsIndexRoute
+  '/_authenticated/super-admin-settings/': typeof AuthenticatedSuperAdminSettingsIndexRoute
+  '/_authenticated/admin-settings/letterheads/$id': typeof AuthenticatedAdminSettingsLetterheadsIdRoute
+  '/_authenticated/admin-settings/teams/$id': typeof AuthenticatedAdminSettingsTeamsIdRoute
+  '/_authenticated/super-admin-settings/orgs/$id': typeof AuthenticatedSuperAdminSettingsOrgsIdRoute
+  '/_authenticated/admin-settings/letterheads/': typeof AuthenticatedAdminSettingsLetterheadsIndexRoute
+  '/_authenticated/admin-settings/teams/': typeof AuthenticatedAdminSettingsTeamsIndexRoute
+  '/_authenticated/super-admin-settings/models-catalog/': typeof AuthenticatedSuperAdminSettingsModelsCatalogIndexRoute
+  '/_authenticated/super-admin-settings/orgs/': typeof AuthenticatedSuperAdminSettingsOrgsIndexRoute
+  '/_authenticated/super-admin-settings/platform-config/': typeof AuthenticatedSuperAdminSettingsPlatformConfigIndexRoute
+  '/_authenticated/super-admin-settings/skills/': typeof AuthenticatedSuperAdminSettingsSkillsIndexRoute
+  '/_authenticated/super-admin-settings/super-admins/': typeof AuthenticatedSuperAdminSettingsSuperAdminsIndexRoute
+  '/_authenticated/super-admin-settings/usage/': typeof AuthenticatedSuperAdminSettingsUsageIndexRoute
+}
+
+export interface FileRouteTypes {
+  fileRoutesByFullPath: FileRoutesByFullPath
+  fullPaths:
+    | '/'
+    | ''
+    | '/accept-invite'
+    | '/confirm-email'
+    | '/email-confirm'
+    | '/ip-blocked'
+    | '/login'
+    | '/register'
+    | '/install'
+    | '/password/forgot'
+    | '/password/reset'
+    | '/admin-settings/integrations'
+    | '/admin-settings/models'
+    | '/admin-settings/security'
+    | '/admin-settings/usage'
+    | '/admin-settings/users'
+    | '/agents/$id'
+    | '/chats/$threadId'
+    | '/knowledge-bases/$id'
+    | '/settings/account'
+    | '/settings/chat'
+    | '/settings/general'
+    | '/skills/$id'
+    | '/admin-settings'
+    | '/agents'
+    | '/chat'
+    | '/chats'
+    | '/knowledge-bases'
+    | '/prompts'
+    | '/settings'
+    | '/skills'
+    | '/super-admin-settings'
+    | '/admin-settings/letterheads/$id'
+    | '/admin-settings/teams/$id'
+    | '/super-admin-settings/orgs/$id'
+    | '/admin-settings/letterheads'
+    | '/admin-settings/teams'
+    | '/super-admin-settings/models-catalog'
+    | '/super-admin-settings/orgs'
+    | '/super-admin-settings/platform-config'
+    | '/super-admin-settings/skills'
+    | '/super-admin-settings/super-admins'
+    | '/super-admin-settings/usage'
+  fileRoutesByTo: FileRoutesByTo
+  to:
+    | '/'
+    | ''
+    | '/accept-invite'
+    | '/confirm-email'
+    | '/email-confirm'
+    | '/ip-blocked'
+    | '/login'
+    | '/register'
+    | '/install'
+    | '/password/forgot'
+    | '/password/reset'
+    | '/admin-settings/integrations'
+    | '/admin-settings/models'
+    | '/admin-settings/security'
+    | '/admin-settings/usage'
+    | '/admin-settings/users'
+    | '/agents/$id'
+    | '/chats/$threadId'
+    | '/knowledge-bases/$id'
+    | '/settings/account'
+    | '/settings/chat'
+    | '/settings/general'
+    | '/skills/$id'
+    | '/admin-settings'
+    | '/agents'
+    | '/chat'
+    | '/chats'
+    | '/knowledge-bases'
+    | '/prompts'
+    | '/settings'
+    | '/skills'
+    | '/super-admin-settings'
+    | '/admin-settings/letterheads/$id'
+    | '/admin-settings/teams/$id'
+    | '/super-admin-settings/orgs/$id'
+    | '/admin-settings/letterheads'
+    | '/admin-settings/teams'
+    | '/super-admin-settings/models-catalog'
+    | '/super-admin-settings/orgs'
+    | '/super-admin-settings/platform-config'
+    | '/super-admin-settings/skills'
+    | '/super-admin-settings/super-admins'
+    | '/super-admin-settings/usage'
+  id:
+    | '__root__'
+    | '/'
+    | '/_authenticated'
+    | '/(onboarding)/accept-invite'
+    | '/(onboarding)/confirm-email'
+    | '/(onboarding)/email-confirm'
+    | '/(onboarding)/ip-blocked'
+    | '/(onboarding)/login'
+    | '/(onboarding)/register'
+    | '/_authenticated/install'
+    | '/(onboarding)/password/forgot'
+    | '/(onboarding)/password/reset'
+    | '/_authenticated/admin-settings/integrations'
+    | '/_authenticated/admin-settings/models'
+    | '/_authenticated/admin-settings/security'
+    | '/_authenticated/admin-settings/usage'
+    | '/_authenticated/admin-settings/users'
+    | '/_authenticated/agents/$id'
+    | '/_authenticated/chats/$threadId'
+    | '/_authenticated/knowledge-bases/$id'
+    | '/_authenticated/settings/account'
+    | '/_authenticated/settings/chat'
+    | '/_authenticated/settings/general'
+    | '/_authenticated/skills/$id'
+    | '/_authenticated/admin-settings/'
+    | '/_authenticated/agents/'
+    | '/_authenticated/chat/'
+    | '/_authenticated/chats/'
+    | '/_authenticated/knowledge-bases/'
+    | '/_authenticated/prompts/'
+    | '/_authenticated/settings/'
+    | '/_authenticated/skills/'
+    | '/_authenticated/super-admin-settings/'
+    | '/_authenticated/admin-settings/letterheads/$id'
+    | '/_authenticated/admin-settings/teams/$id'
+    | '/_authenticated/super-admin-settings/orgs/$id'
+    | '/_authenticated/admin-settings/letterheads/'
+    | '/_authenticated/admin-settings/teams/'
+    | '/_authenticated/super-admin-settings/models-catalog/'
+    | '/_authenticated/super-admin-settings/orgs/'
+    | '/_authenticated/super-admin-settings/platform-config/'
+    | '/_authenticated/super-admin-settings/skills/'
+    | '/_authenticated/super-admin-settings/super-admins/'
+    | '/_authenticated/super-admin-settings/usage/'
+  fileRoutesById: FileRoutesById
+}
+
+export interface RootRouteChildren {
+  IndexRoute: typeof IndexRoute
+  AuthenticatedRoute: typeof AuthenticatedRouteWithChildren
+  onboardingAcceptInviteRoute: typeof onboardingAcceptInviteRoute
+  onboardingConfirmEmailRoute: typeof onboardingConfirmEmailRoute
+  onboardingEmailConfirmRoute: typeof onboardingEmailConfirmRoute
+  onboardingIpBlockedRoute: typeof onboardingIpBlockedRoute
+  onboardingLoginRoute: typeof onboardingLoginRoute
+  onboardingRegisterRoute: typeof onboardingRegisterRoute
+  onboardingPasswordForgotRoute: typeof onboardingPasswordForgotRoute
+  onboardingPasswordResetRoute: typeof onboardingPasswordResetRoute
+}
+
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   AuthenticatedRoute: AuthenticatedRouteWithChildren,
@@ -988,6 +1043,226 @@ const rootRouteChildren: RootRouteChildren = {
   onboardingPasswordForgotRoute: onboardingPasswordForgotRoute,
   onboardingPasswordResetRoute: onboardingPasswordResetRoute,
 }
-export const routeTree = rootRouteImport
+
+export const routeTree = rootRoute
   ._addFileChildren(rootRouteChildren)
   ._addFileTypes<FileRouteTypes>()
+
+/* ROUTE_MANIFEST_START
+{
+  "routes": {
+    "__root__": {
+      "filePath": "__root.tsx",
+      "children": [
+        "/",
+        "/_authenticated",
+        "/(onboarding)/accept-invite",
+        "/(onboarding)/confirm-email",
+        "/(onboarding)/email-confirm",
+        "/(onboarding)/ip-blocked",
+        "/(onboarding)/login",
+        "/(onboarding)/register",
+        "/(onboarding)/password/forgot",
+        "/(onboarding)/password/reset"
+      ]
+    },
+    "/": {
+      "filePath": "index.tsx"
+    },
+    "/_authenticated": {
+      "filePath": "_authenticated.tsx",
+      "children": [
+        "/_authenticated/install",
+        "/_authenticated/admin-settings/integrations",
+        "/_authenticated/admin-settings/models",
+        "/_authenticated/admin-settings/security",
+        "/_authenticated/admin-settings/usage",
+        "/_authenticated/admin-settings/users",
+        "/_authenticated/agents/$id",
+        "/_authenticated/chats/$threadId",
+        "/_authenticated/knowledge-bases/$id",
+        "/_authenticated/settings/account",
+        "/_authenticated/settings/chat",
+        "/_authenticated/settings/general",
+        "/_authenticated/skills/$id",
+        "/_authenticated/admin-settings/",
+        "/_authenticated/agents/",
+        "/_authenticated/chat/",
+        "/_authenticated/chats/",
+        "/_authenticated/knowledge-bases/",
+        "/_authenticated/prompts/",
+        "/_authenticated/settings/",
+        "/_authenticated/skills/",
+        "/_authenticated/super-admin-settings/",
+        "/_authenticated/admin-settings/letterheads/$id",
+        "/_authenticated/admin-settings/teams/$id",
+        "/_authenticated/super-admin-settings/orgs/$id",
+        "/_authenticated/admin-settings/letterheads/",
+        "/_authenticated/admin-settings/teams/",
+        "/_authenticated/super-admin-settings/models-catalog/",
+        "/_authenticated/super-admin-settings/orgs/",
+        "/_authenticated/super-admin-settings/platform-config/",
+        "/_authenticated/super-admin-settings/skills/",
+        "/_authenticated/super-admin-settings/super-admins/",
+        "/_authenticated/super-admin-settings/usage/"
+      ]
+    },
+    "/(onboarding)/accept-invite": {
+      "filePath": "(onboarding)/accept-invite.tsx"
+    },
+    "/(onboarding)/confirm-email": {
+      "filePath": "(onboarding)/confirm-email.tsx"
+    },
+    "/(onboarding)/email-confirm": {
+      "filePath": "(onboarding)/email-confirm.tsx"
+    },
+    "/(onboarding)/ip-blocked": {
+      "filePath": "(onboarding)/ip-blocked.tsx"
+    },
+    "/(onboarding)/login": {
+      "filePath": "(onboarding)/login.tsx"
+    },
+    "/(onboarding)/register": {
+      "filePath": "(onboarding)/register.tsx"
+    },
+    "/_authenticated/install": {
+      "filePath": "_authenticated/install.tsx",
+      "parent": "/_authenticated"
+    },
+    "/(onboarding)/password/forgot": {
+      "filePath": "(onboarding)/password.forgot.tsx"
+    },
+    "/(onboarding)/password/reset": {
+      "filePath": "(onboarding)/password.reset.tsx"
+    },
+    "/_authenticated/admin-settings/integrations": {
+      "filePath": "_authenticated/admin-settings.integrations.tsx",
+      "parent": "/_authenticated"
+    },
+    "/_authenticated/admin-settings/models": {
+      "filePath": "_authenticated/admin-settings.models.tsx",
+      "parent": "/_authenticated"
+    },
+    "/_authenticated/admin-settings/security": {
+      "filePath": "_authenticated/admin-settings.security.tsx",
+      "parent": "/_authenticated"
+    },
+    "/_authenticated/admin-settings/usage": {
+      "filePath": "_authenticated/admin-settings.usage.tsx",
+      "parent": "/_authenticated"
+    },
+    "/_authenticated/admin-settings/users": {
+      "filePath": "_authenticated/admin-settings.users.tsx",
+      "parent": "/_authenticated"
+    },
+    "/_authenticated/agents/$id": {
+      "filePath": "_authenticated/agents.$id.tsx",
+      "parent": "/_authenticated"
+    },
+    "/_authenticated/chats/$threadId": {
+      "filePath": "_authenticated/chats.$threadId.tsx",
+      "parent": "/_authenticated"
+    },
+    "/_authenticated/knowledge-bases/$id": {
+      "filePath": "_authenticated/knowledge-bases.$id.tsx",
+      "parent": "/_authenticated"
+    },
+    "/_authenticated/settings/account": {
+      "filePath": "_authenticated/settings.account.tsx",
+      "parent": "/_authenticated"
+    },
+    "/_authenticated/settings/chat": {
+      "filePath": "_authenticated/settings.chat.tsx",
+      "parent": "/_authenticated"
+    },
+    "/_authenticated/settings/general": {
+      "filePath": "_authenticated/settings.general.tsx",
+      "parent": "/_authenticated"
+    },
+    "/_authenticated/skills/$id": {
+      "filePath": "_authenticated/skills.$id.tsx",
+      "parent": "/_authenticated"
+    },
+    "/_authenticated/admin-settings/": {
+      "filePath": "_authenticated/admin-settings.index.tsx",
+      "parent": "/_authenticated"
+    },
+    "/_authenticated/agents/": {
+      "filePath": "_authenticated/agents.index.tsx",
+      "parent": "/_authenticated"
+    },
+    "/_authenticated/chat/": {
+      "filePath": "_authenticated/chat.index.tsx",
+      "parent": "/_authenticated"
+    },
+    "/_authenticated/chats/": {
+      "filePath": "_authenticated/chats.index.tsx",
+      "parent": "/_authenticated"
+    },
+    "/_authenticated/knowledge-bases/": {
+      "filePath": "_authenticated/knowledge-bases.index.tsx",
+      "parent": "/_authenticated"
+    },
+    "/_authenticated/prompts/": {
+      "filePath": "_authenticated/prompts.index.tsx",
+      "parent": "/_authenticated"
+    },
+    "/_authenticated/settings/": {
+      "filePath": "_authenticated/settings.index.ts",
+      "parent": "/_authenticated"
+    },
+    "/_authenticated/skills/": {
+      "filePath": "_authenticated/skills.index.tsx",
+      "parent": "/_authenticated"
+    },
+    "/_authenticated/super-admin-settings/": {
+      "filePath": "_authenticated/super-admin-settings.index.tsx",
+      "parent": "/_authenticated"
+    },
+    "/_authenticated/admin-settings/letterheads/$id": {
+      "filePath": "_authenticated/admin-settings.letterheads.$id.tsx",
+      "parent": "/_authenticated"
+    },
+    "/_authenticated/admin-settings/teams/$id": {
+      "filePath": "_authenticated/admin-settings.teams.$id.tsx",
+      "parent": "/_authenticated"
+    },
+    "/_authenticated/super-admin-settings/orgs/$id": {
+      "filePath": "_authenticated/super-admin-settings.orgs.$id.tsx",
+      "parent": "/_authenticated"
+    },
+    "/_authenticated/admin-settings/letterheads/": {
+      "filePath": "_authenticated/admin-settings.letterheads.index.tsx",
+      "parent": "/_authenticated"
+    },
+    "/_authenticated/admin-settings/teams/": {
+      "filePath": "_authenticated/admin-settings.teams.index.tsx",
+      "parent": "/_authenticated"
+    },
+    "/_authenticated/super-admin-settings/models-catalog/": {
+      "filePath": "_authenticated/super-admin-settings.models-catalog.index.tsx",
+      "parent": "/_authenticated"
+    },
+    "/_authenticated/super-admin-settings/orgs/": {
+      "filePath": "_authenticated/super-admin-settings.orgs.index.tsx",
+      "parent": "/_authenticated"
+    },
+    "/_authenticated/super-admin-settings/platform-config/": {
+      "filePath": "_authenticated/super-admin-settings.platform-config.index.tsx",
+      "parent": "/_authenticated"
+    },
+    "/_authenticated/super-admin-settings/skills/": {
+      "filePath": "_authenticated/super-admin-settings.skills.index.tsx",
+      "parent": "/_authenticated"
+    },
+    "/_authenticated/super-admin-settings/super-admins/": {
+      "filePath": "_authenticated/super-admin-settings.super-admins.index.tsx",
+      "parent": "/_authenticated"
+    },
+    "/_authenticated/super-admin-settings/usage/": {
+      "filePath": "_authenticated/super-admin-settings.usage.index.tsx",
+      "parent": "/_authenticated"
+    }
+  }
+}
+ROUTE_MANIFEST_END */


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches persistence + migration for the `sources` table and changes multiple deletion/query paths to operate on IDs and DB-level chunk/text fetches, which could affect data integrity and runtime behavior if mappings or queries are wrong. Primary risk is around migration/backfill correctness and any codepaths that previously relied on eagerly-loaded `text`/`contentChunks` now being absent.
> 
> **Overview**
> **Refactors text source persistence to avoid loading full text/chunks into memory.** `TextSource` domain entities are now *metadata-only* (no `text`/`contentChunks`), with a migration adding `textType`/`fileType`/`url`/`dataType` columns on `sources` and backfilling them from detail tables.
> 
> Source creation now saves text + chunks via `SourceRepository.saveTextSource(...)` and indexes chunks using the returned IDs, while querying switches to targeted DB reads: knowledge base and per-source vector search fetch matched chunks via `findContentChunksByIds`, and the get-text tools read line ranges via a new `ExtractTextLinesUseCase` (DB-sliced text + validation).
> 
> Deletion flows are simplified to pass `sourceId` arrays (not full entities) through `DeleteSourceCommand`/`DeleteSourcesCommand`, updating agent/skill/thread/knowledge-base/model cleanup paths accordingly. Also adds a Dependency Cruiser rule blocking cross-module imports of other modules’ `application/ports`, with a known-violations list to track existing breaches.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ea10b2e94efe4e89c5490c5a3fd356570d08feeb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->