### PR TITLE
wip(letterheads): Hide letterheads behind feature toggle (AYC-101)

### DIFF
--- a/ayunis-core-backend/src/app/presenters/http/app.controller.ts
+++ b/ayunis-core-backend/src/app/presenters/http/app.controller.ts
@@ -64,6 +64,7 @@ export class AppController {
     return {
       agentsEnabled: this.features.agentsEnabled,
       knowledgeBasesEnabled: this.features.knowledgeBasesEnabled,
+      letterheadsEnabled: this.features.letterheadsEnabled,
       promptsEnabled: this.features.promptsEnabled,
       skillsEnabled: this.features.skillsEnabled,
     };

--- a/ayunis-core-backend/src/app/presenters/http/dto/feature-toggles-response.dto.ts
+++ b/ayunis-core-backend/src/app/presenters/http/dto/feature-toggles-response.dto.ts
@@ -14,6 +14,12 @@ export class FeatureTogglesResponseDto {
   knowledgeBasesEnabled: boolean;
 
   @ApiProperty({
+    description: 'Whether the letterheads feature is enabled',
+    example: false,
+  })
+  letterheadsEnabled: boolean;
+
+  @ApiProperty({
     description: 'Whether the prompts feature is enabled',
     example: true,
   })

--- a/ayunis-core-backend/src/config/features.config.ts
+++ b/ayunis-core-backend/src/config/features.config.ts
@@ -3,6 +3,7 @@ import { registerAs } from '@nestjs/config';
 export enum FeatureFlag {
   Agents = 'agentsEnabled',
   KnowledgeBases = 'knowledgeBasesEnabled',
+  Letterheads = 'letterheadsEnabled',
   Prompts = 'promptsEnabled',
   Skills = 'skillsEnabled',
 }
@@ -27,6 +28,10 @@ export const featuresConfig = registerAs(
     knowledgeBasesEnabled: parseBooleanWithDefault(
       process.env.FEATURE_KNOWLEDGE_BASES_ENABLED,
       true,
+    ),
+    letterheadsEnabled: parseBooleanWithDefault(
+      process.env.FEATURE_LETTERHEADS_ENABLED,
+      false,
     ),
     promptsEnabled: parseBooleanWithDefault(
       process.env.FEATURE_PROMPTS_ENABLED,

--- a/ayunis-core-frontend/src/app/routes/_authenticated/admin-settings.letterheads.$id.tsx
+++ b/ayunis-core-frontend/src/app/routes/_authenticated/admin-settings.letterheads.$id.tsx
@@ -1,8 +1,10 @@
-import { createFileRoute } from '@tanstack/react-router';
+import { createFileRoute, redirect } from '@tanstack/react-router';
 import { LetterheadDetailPage } from '@/pages/admin-settings/letterhead-detail';
 import {
   letterheadsControllerFindOne,
   getLetterheadsControllerFindOneQueryKey,
+  appControllerFeatureToggles,
+  getAppControllerFeatureTogglesQueryKey,
 } from '@/shared/api/generated/ayunisCoreAPI';
 
 export const Route = createFileRoute(
@@ -10,6 +12,13 @@ export const Route = createFileRoute(
 )({
   component: RouteComponent,
   loader: async ({ params: { id }, context: { queryClient } }) => {
+    const featureToggles = await queryClient.fetchQuery({
+      queryKey: getAppControllerFeatureTogglesQueryKey(),
+      queryFn: () => appControllerFeatureToggles(),
+    });
+    if (!featureToggles.letterheadsEnabled) {
+      throw redirect({ to: '/admin-settings' });
+    }
     const letterhead = await queryClient.fetchQuery({
       queryKey: getLetterheadsControllerFindOneQueryKey(id),
       queryFn: () => letterheadsControllerFindOne(id),

--- a/ayunis-core-frontend/src/app/routes/_authenticated/admin-settings.letterheads.index.tsx
+++ b/ayunis-core-frontend/src/app/routes/_authenticated/admin-settings.letterheads.index.tsx
@@ -1,8 +1,21 @@
-import { createFileRoute } from '@tanstack/react-router';
+import { createFileRoute, redirect } from '@tanstack/react-router';
 import { LetterheadsSettingsPage } from '@/pages/admin-settings/letterheads-settings';
+import {
+  appControllerFeatureToggles,
+  getAppControllerFeatureTogglesQueryKey,
+} from '@/shared/api/generated/ayunisCoreAPI';
 
 export const Route = createFileRoute(
   '/_authenticated/admin-settings/letterheads/',
 )({
   component: LetterheadsSettingsPage,
+  loader: async ({ context: { queryClient } }) => {
+    const featureToggles = await queryClient.fetchQuery({
+      queryKey: getAppControllerFeatureTogglesQueryKey(),
+      queryFn: () => appControllerFeatureToggles(),
+    });
+    if (!featureToggles.letterheadsEnabled) {
+      throw redirect({ to: '/admin-settings' });
+    }
+  },
 });

--- a/ayunis-core-frontend/src/features/feature-toggles/index.ts
+++ b/ayunis-core-frontend/src/features/feature-toggles/index.ts
@@ -3,6 +3,7 @@ export {
   useIsFeatureEnabled,
   useIsAgentsEnabled,
   useIsKnowledgeBasesEnabled,
+  useIsLetterheadsEnabled,
   useIsPromptsEnabled,
   useIsSkillsEnabled,
 } from './useIsFeatureEnabled';

--- a/ayunis-core-frontend/src/features/feature-toggles/useFeatureToggles.ts
+++ b/ayunis-core-frontend/src/features/feature-toggles/useFeatureToggles.ts
@@ -7,6 +7,7 @@ export function useFeatureToggles(): FeatureTogglesResponseDto {
   return {
     agentsEnabled: data?.agentsEnabled ?? true,
     knowledgeBasesEnabled: data?.knowledgeBasesEnabled ?? true,
+    letterheadsEnabled: data?.letterheadsEnabled ?? false,
     promptsEnabled: data?.promptsEnabled ?? true,
     skillsEnabled: data?.skillsEnabled ?? false,
   };

--- a/ayunis-core-frontend/src/features/feature-toggles/useIsFeatureEnabled.ts
+++ b/ayunis-core-frontend/src/features/feature-toggles/useIsFeatureEnabled.ts
@@ -20,6 +20,10 @@ export function useIsKnowledgeBasesEnabled(): boolean {
   return useIsFeatureEnabled('knowledgeBasesEnabled');
 }
 
+export function useIsLetterheadsEnabled(): boolean {
+  return useIsFeatureEnabled('letterheadsEnabled');
+}
+
 export function useIsSkillsEnabled(): boolean {
   return useIsFeatureEnabled('skillsEnabled');
 }

--- a/ayunis-core-frontend/src/pages/admin-settings/admin-settings-layout/ui/AdminSettingsSidebar.tsx
+++ b/ayunis-core-frontend/src/pages/admin-settings/admin-settings-layout/ui/AdminSettingsSidebar.tsx
@@ -16,6 +16,7 @@ import {
   SettingsSidebarWidget,
   type SidebarMenuItem,
 } from '@/widgets/settings-sidebar/ui/SettingsSidebarWidget';
+import { useIsLetterheadsEnabled } from '@/features/feature-toggles';
 
 export function AdminSettingsSidebar() {
   const { t } = useTranslation('admin-settings-layout');
@@ -24,6 +25,7 @@ export function AdminSettingsSidebar() {
   const isUsageBased =
     subscriptionData?.subscriptionType ===
     ActiveSubscriptionResponseDtoSubscriptionType.USAGE_BASED;
+  const isLetterheadsEnabled = useIsLetterheadsEnabled();
 
   const menuItems: SidebarMenuItem[] = [
     {
@@ -51,11 +53,15 @@ export function AdminSettingsSidebar() {
       icon: <Shield />,
       label: t('layout.security'),
     },
-    {
-      to: '/admin-settings/letterheads',
-      icon: <FileText />,
-      label: t('layout.letterheads'),
-    },
+    ...(isLetterheadsEnabled
+      ? [
+          {
+            to: '/admin-settings/letterheads' as const,
+            icon: <FileText />,
+            label: t('layout.letterheads'),
+          },
+        ]
+      : []),
   ];
 
   if (isUsageBased) {

--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
@@ -17,6 +17,8 @@ export interface FeatureTogglesResponseDto {
   agentsEnabled: boolean;
   /** Whether the standalone knowledge bases feature is enabled */
   knowledgeBasesEnabled: boolean;
+  /** Whether the letterheads feature is enabled */
+  letterheadsEnabled: boolean;
   /** Whether the prompts feature is enabled */
   promptsEnabled: boolean;
   /** Whether the skills feature is enabled */

--- a/ayunis-core-frontend/src/shared/api/openapi-schema.json
+++ b/ayunis-core-frontend/src/shared/api/openapi-schema.json
@@ -18,7 +18,9 @@
           }
         },
         "summary": "Check if the deployment is running in a cloud environment",
-        "tags": ["app"]
+        "tags": [
+          "app"
+        ]
       }
     },
     "/health": {
@@ -31,7 +33,9 @@
           }
         },
         "summary": "Check if the deployment is healthy",
-        "tags": ["app"]
+        "tags": [
+          "app"
+        ]
       }
     },
     "/feature-toggles": {
@@ -51,7 +55,9 @@
           }
         },
         "summary": "Get the current feature toggle states",
-        "tags": ["app"]
+        "tags": [
+          "app"
+        ]
       }
     },
     "/models/available": {
@@ -77,7 +83,9 @@
           }
         },
         "summary": "Get all available models",
-        "tags": ["models"]
+        "tags": [
+          "models"
+        ]
       }
     },
     "/models/providers": {
@@ -100,7 +108,9 @@
           }
         },
         "summary": "Get all available model providers with their info",
-        "tags": ["models"]
+        "tags": [
+          "models"
+        ]
       }
     },
     "/models/permitted": {
@@ -129,7 +139,9 @@
           }
         },
         "summary": "Create a permitted model",
-        "tags": ["models"]
+        "tags": [
+          "models"
+        ]
       }
     },
     "/models/permitted/{id}": {
@@ -154,7 +166,9 @@
           }
         },
         "summary": "Delete a permitted model",
-        "tags": ["models"]
+        "tags": [
+          "models"
+        ]
       },
       "patch": {
         "operationId": "ModelsController_updatePermittedModel",
@@ -197,7 +211,9 @@
           }
         },
         "summary": "Update a permitted model",
-        "tags": ["models"]
+        "tags": [
+          "models"
+        ]
       }
     },
     "/models/permitted/language-models": {
@@ -224,7 +240,9 @@
           }
         },
         "summary": "Get effective permitted language models for the current user",
-        "tags": ["models"]
+        "tags": [
+          "models"
+        ]
       }
     },
     "/models/permitted/language-models/org": {
@@ -251,7 +269,9 @@
           }
         },
         "summary": "Get org-level permitted language models (admin view)",
-        "tags": ["models"]
+        "tags": [
+          "models"
+        ]
       }
     },
     "/models/default": {
@@ -275,7 +295,9 @@
           }
         },
         "summary": "Get the effective default model for the user",
-        "tags": ["models"]
+        "tags": [
+          "models"
+        ]
       }
     },
     "/models/org/default": {
@@ -299,7 +321,9 @@
           }
         },
         "summary": "Get the organization default model",
-        "tags": ["models"]
+        "tags": [
+          "models"
+        ]
       },
       "put": {
         "description": "Sets the specified permitted model as the organization default. If a default already exists, it will be updated to the new model.",
@@ -334,7 +358,9 @@
           }
         },
         "summary": "Set or update the organization default model",
-        "tags": ["models"]
+        "tags": [
+          "models"
+        ]
       }
     },
     "/models/user/default": {
@@ -358,7 +384,9 @@
           }
         },
         "summary": "Get the user-specific default model",
-        "tags": ["models"]
+        "tags": [
+          "models"
+        ]
       },
       "put": {
         "description": "Sets the specified permitted model as the user default. If a default already exists, it will be updated to the new model.",
@@ -393,7 +421,9 @@
           }
         },
         "summary": "Set or update the user default model",
-        "tags": ["models"]
+        "tags": [
+          "models"
+        ]
       },
       "delete": {
         "operationId": "ModelsController_deleteUserDefaultModel",
@@ -407,7 +437,9 @@
           }
         },
         "summary": "Delete the user default model",
-        "tags": ["models"]
+        "tags": [
+          "models"
+        ]
       }
     },
     "/models/provider/{provider}": {
@@ -443,7 +475,9 @@
           }
         },
         "summary": "Get model provider information",
-        "tags": ["models"]
+        "tags": [
+          "models"
+        ]
       }
     },
     "/models/embedding/enabled": {
@@ -466,7 +500,9 @@
           }
         },
         "summary": "Check if an embedding model is enabled for this org",
-        "tags": ["models"]
+        "tags": [
+          "models"
+        ]
       }
     },
     "/teams/{teamId}/permitted-models": {
@@ -501,7 +537,9 @@
           }
         },
         "summary": "List a team's permitted language models",
-        "tags": ["team-permitted-models"]
+        "tags": [
+          "team-permitted-models"
+        ]
       },
       "post": {
         "description": "Creates a team-scoped permitted model. The model must already be permitted at the organization level.",
@@ -548,7 +586,9 @@
           }
         },
         "summary": "Add a permitted model to a team",
-        "tags": ["team-permitted-models"]
+        "tags": [
+          "team-permitted-models"
+        ]
       }
     },
     "/teams/{teamId}/permitted-models/{id}": {
@@ -581,7 +621,9 @@
           }
         },
         "summary": "Remove a permitted model from a team",
-        "tags": ["team-permitted-models"]
+        "tags": [
+          "team-permitted-models"
+        ]
       }
     },
     "/teams/{teamId}/permitted-models/default": {
@@ -624,7 +666,9 @@
           }
         },
         "summary": "Set the team's default model",
-        "tags": ["team-permitted-models"]
+        "tags": [
+          "team-permitted-models"
+        ]
       }
     },
     "/super-admin/models/{orgId}/available": {
@@ -666,7 +710,9 @@
           }
         },
         "summary": "Get all available models",
-        "tags": ["Super Admin Models"]
+        "tags": [
+          "Super Admin Models"
+        ]
       }
     },
     "/super-admin/models/{orgId}/default-model": {
@@ -721,7 +767,9 @@
           }
         },
         "summary": "Set or update the organization default model",
-        "tags": ["Super Admin Models"]
+        "tags": [
+          "Super Admin Models"
+        ]
       }
     },
     "/super-admin/models/{orgId}/permitted-models": {
@@ -770,7 +818,9 @@
           }
         },
         "summary": "Get all permitted models for a specific organization",
-        "tags": ["Super Admin Models"]
+        "tags": [
+          "Super Admin Models"
+        ]
       },
       "post": {
         "description": "Create a new permitted model for the specified organization. This endpoint is only accessible to super admins.",
@@ -816,7 +866,9 @@
           }
         },
         "summary": "Create a permitted model for a specific organization",
-        "tags": ["Super Admin Models"]
+        "tags": [
+          "Super Admin Models"
+        ]
       }
     },
     "/super-admin/models/{orgId}/permitted-models/{id}": {
@@ -865,7 +917,9 @@
           }
         },
         "summary": "Delete a permitted model for a specific organization",
-        "tags": ["Super Admin Models"]
+        "tags": [
+          "Super Admin Models"
+        ]
       },
       "patch": {
         "description": "Update the settings of a permitted model for the specified organization. This endpoint is only accessible to super admins.",
@@ -936,7 +990,9 @@
           }
         },
         "summary": "Update a permitted model for a specific organization",
-        "tags": ["Super Admin Models"]
+        "tags": [
+          "Super Admin Models"
+        ]
       }
     },
     "/super-admin/models/catalog": {
@@ -973,7 +1029,9 @@
           }
         },
         "summary": "Get all models in the catalog",
-        "tags": ["Super Admin Models"]
+        "tags": [
+          "Super Admin Models"
+        ]
       }
     },
     "/super-admin/models/catalog/{id}": {
@@ -1022,7 +1080,9 @@
           }
         },
         "summary": "Get a model by ID from the catalog",
-        "tags": ["Super Admin Models"]
+        "tags": [
+          "Super Admin Models"
+        ]
       },
       "delete": {
         "description": "Remove a model (language or embedding) from the master catalog. This endpoint is only accessible to super admins.",
@@ -1055,7 +1115,9 @@
           }
         },
         "summary": "Delete a model from the catalog",
-        "tags": ["Super Admin Models"]
+        "tags": [
+          "Super Admin Models"
+        ]
       }
     },
     "/super-admin/models/catalog/language": {
@@ -1098,7 +1160,9 @@
           }
         },
         "summary": "Create a new language model in the catalog",
-        "tags": ["Super Admin Models"]
+        "tags": [
+          "Super Admin Models"
+        ]
       }
     },
     "/super-admin/models/catalog/language/{id}": {
@@ -1153,7 +1217,9 @@
           }
         },
         "summary": "Update a language model in the catalog",
-        "tags": ["Super Admin Models"]
+        "tags": [
+          "Super Admin Models"
+        ]
       }
     },
     "/super-admin/models/catalog/embedding": {
@@ -1196,7 +1262,9 @@
           }
         },
         "summary": "Create a new embedding model in the catalog",
-        "tags": ["Super Admin Models"]
+        "tags": [
+          "Super Admin Models"
+        ]
       }
     },
     "/super-admin/models/catalog/embedding/{id}": {
@@ -1251,7 +1319,9 @@
           }
         },
         "summary": "Update an embedding model in the catalog",
-        "tags": ["Super Admin Models"]
+        "tags": [
+          "Super Admin Models"
+        ]
       }
     },
     "/super-admin/orgs": {
@@ -1289,7 +1359,9 @@
           }
         },
         "summary": "Create a new organization",
-        "tags": ["Super Admin Orgs"]
+        "tags": [
+          "Super Admin Orgs"
+        ]
       },
       "get": {
         "description": "Retrieve paginated organizations in the system. Only accessible to users with the super admin system role.",
@@ -1344,7 +1416,9 @@
           }
         },
         "summary": "List all organizations",
-        "tags": ["Super Admin Orgs"]
+        "tags": [
+          "Super Admin Orgs"
+        ]
       }
     },
     "/super-admin/orgs/{id}": {
@@ -1378,7 +1452,9 @@
           }
         },
         "summary": "Get an organization by ID",
-        "tags": ["Super Admin Orgs"]
+        "tags": [
+          "Super Admin Orgs"
+        ]
       }
     },
     "/users": {
@@ -1438,7 +1514,9 @@
           }
         },
         "summary": "Get users in current organization",
-        "tags": ["Users"]
+        "tags": [
+          "Users"
+        ]
       }
     },
     "/users/{id}/role": {
@@ -1494,7 +1572,9 @@
           }
         },
         "summary": "Update user role",
-        "tags": ["Users"]
+        "tags": [
+          "Users"
+        ]
       }
     },
     "/users/name": {
@@ -1538,7 +1618,9 @@
           }
         },
         "summary": "Update user name",
-        "tags": ["Users"]
+        "tags": [
+          "Users"
+        ]
       }
     },
     "/users/password": {
@@ -1572,7 +1654,9 @@
           }
         },
         "summary": "Update user password",
-        "tags": ["Users"]
+        "tags": [
+          "Users"
+        ]
       }
     },
     "/users/confirm-email": {
@@ -1606,7 +1690,9 @@
           }
         },
         "summary": "Confirm user email",
-        "tags": ["Users"]
+        "tags": [
+          "Users"
+        ]
       }
     },
     "/users/resend-confirmation": {
@@ -1637,7 +1723,9 @@
           }
         },
         "summary": "Resend email confirmation",
-        "tags": ["Users"]
+        "tags": [
+          "Users"
+        ]
       }
     },
     "/users/{id}": {
@@ -1672,7 +1760,9 @@
           }
         },
         "summary": "Delete a user",
-        "tags": ["Users"]
+        "tags": [
+          "Users"
+        ]
       }
     },
     "/users/{id}/trigger-password-reset": {
@@ -1703,7 +1793,9 @@
           }
         },
         "summary": "Trigger password reset for a user",
-        "tags": ["Users"]
+        "tags": [
+          "Users"
+        ]
       }
     },
     "/users/forgot-password": {
@@ -1734,7 +1826,9 @@
           }
         },
         "summary": "Trigger password reset",
-        "tags": ["Users"]
+        "tags": [
+          "Users"
+        ]
       }
     },
     "/users/reset-password": {
@@ -1768,7 +1862,9 @@
           }
         },
         "summary": "Reset password with token",
-        "tags": ["Users"]
+        "tags": [
+          "Users"
+        ]
       }
     },
     "/users/validate-reset-token": {
@@ -1812,7 +1908,9 @@
           }
         },
         "summary": "Validate password reset token",
-        "tags": ["Users"]
+        "tags": [
+          "Users"
+        ]
       }
     },
     "/super-admin/users/{orgId}": {
@@ -1886,7 +1984,9 @@
           }
         },
         "summary": "Get users by organization ID",
-        "tags": ["Super Admin Users"]
+        "tags": [
+          "Super Admin Users"
+        ]
       }
     },
     "/super-admin/users/{userId}": {
@@ -1921,12 +2021,14 @@
           }
         },
         "summary": "Delete a user",
-        "tags": ["Super Admin Users"]
+        "tags": [
+          "Super Admin Users"
+        ]
       }
     },
     "/super-admin/users/{userId}/trigger-password-reset": {
       "post": {
-        "description": "Send a password reset email to the specified user. This endpoint is only accessible to super admins.",
+        "description": "Send a password reset email to the specified user and return the reset URL. This endpoint is only accessible to super admins.",
         "operationId": "SuperAdminUsersController_triggerPasswordReset",
         "parameters": [
           {
@@ -1942,8 +2044,15 @@
           }
         ],
         "responses": {
-          "204": {
-            "description": "Password reset email sent successfully"
+          "200": {
+            "description": "Password reset email sent successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TriggerPasswordResetResponseDto"
+                }
+              }
+            }
           },
           "401": {
             "description": "User not authenticated or not authorized as super admin"
@@ -1956,7 +2065,9 @@
           }
         },
         "summary": "Trigger password reset for a user",
-        "tags": ["Super Admin Users"]
+        "tags": [
+          "Super Admin Users"
+        ]
       }
     },
     "/super-admin/users/{orgId}/create": {
@@ -2012,7 +2123,9 @@
           }
         },
         "summary": "Create a new user in an organization",
-        "tags": ["Super Admin Users"]
+        "tags": [
+          "Super Admin Users"
+        ]
       }
     },
     "/super-admin/super-admins": {
@@ -2039,7 +2152,9 @@
           }
         },
         "summary": "List all super admins",
-        "tags": ["Super Admin Management"]
+        "tags": [
+          "Super Admin Management"
+        ]
       },
       "post": {
         "description": "Promote an existing user to super admin by email address. Idempotent if user is already a super admin.",
@@ -2075,7 +2190,9 @@
           }
         },
         "summary": "Promote a user to super admin",
-        "tags": ["Super Admin Management"]
+        "tags": [
+          "Super Admin Management"
+        ]
       }
     },
     "/super-admin/super-admins/{userId}": {
@@ -2116,7 +2233,9 @@
           }
         },
         "summary": "Remove super admin status from a user",
-        "tags": ["Super Admin Management"]
+        "tags": [
+          "Super Admin Management"
+        ]
       }
     },
     "/invites": {
@@ -2153,7 +2272,9 @@
           }
         },
         "summary": "Create a new invite",
-        "tags": ["invites"]
+        "tags": [
+          "invites"
+        ]
       },
       "get": {
         "description": "Retrieve paginated invites with optional search",
@@ -2208,7 +2329,9 @@
           }
         },
         "summary": "Get all invites for current user's organization",
-        "tags": ["invites"]
+        "tags": [
+          "invites"
+        ]
       }
     },
     "/invites/bulk": {
@@ -2245,7 +2368,9 @@
           }
         },
         "summary": "Create multiple invites in bulk",
-        "tags": ["invites"]
+        "tags": [
+          "invites"
+        ]
       }
     },
     "/invites/{token}": {
@@ -2283,7 +2408,9 @@
           }
         },
         "summary": "Get a single invite by token",
-        "tags": ["invites"]
+        "tags": [
+          "invites"
+        ]
       }
     },
     "/invites/accept": {
@@ -2323,7 +2450,9 @@
           }
         },
         "summary": "Accept an invite",
-        "tags": ["invites"]
+        "tags": [
+          "invites"
+        ]
       }
     },
     "/invites/{id}/resend": {
@@ -2364,7 +2493,9 @@
           }
         },
         "summary": "Resend an expired invite",
-        "tags": ["invites"]
+        "tags": [
+          "invites"
+        ]
       }
     },
     "/invites/all": {
@@ -2391,7 +2522,9 @@
           }
         },
         "summary": "Delete all pending invites",
-        "tags": ["invites"]
+        "tags": [
+          "invites"
+        ]
       }
     },
     "/invites/{id}": {
@@ -2425,7 +2558,9 @@
           }
         },
         "summary": "Delete an invite",
-        "tags": ["invites"]
+        "tags": [
+          "invites"
+        ]
       }
     },
     "/subscriptions/active": {
@@ -2448,7 +2583,9 @@
           }
         },
         "summary": "Check if the current organization has an active subscription",
-        "tags": ["subscriptions"]
+        "tags": [
+          "subscriptions"
+        ]
       }
     },
     "/subscriptions/price": {
@@ -2474,7 +2611,9 @@
           }
         },
         "summary": "Get the current price per seat monthly",
-        "tags": ["subscriptions"]
+        "tags": [
+          "subscriptions"
+        ]
       }
     },
     "/super-admin/subscriptions/{orgId}": {
@@ -2513,7 +2652,9 @@
           }
         },
         "summary": "Get subscription details for a specific organization",
-        "tags": ["Super Admin Subscriptions"]
+        "tags": [
+          "Super Admin Subscriptions"
+        ]
       },
       "post": {
         "description": "Create a new subscription for the specified organization. This endpoint is only accessible to super admins.",
@@ -2566,7 +2707,9 @@
           }
         },
         "summary": "Create a new subscription for a specific organization",
-        "tags": ["Super Admin Subscriptions"]
+        "tags": [
+          "Super Admin Subscriptions"
+        ]
       },
       "delete": {
         "description": "Cancel the subscription for the specified organization. This endpoint is only accessible to super admins.",
@@ -2602,7 +2745,9 @@
           }
         },
         "summary": "Cancel the subscription for a specific organization",
-        "tags": ["Super Admin Subscriptions"]
+        "tags": [
+          "Super Admin Subscriptions"
+        ]
       }
     },
     "/super-admin/subscriptions/{orgId}/seats": {
@@ -2650,7 +2795,9 @@
           }
         },
         "summary": "Update the number of seats for a specific organization",
-        "tags": ["Super Admin Subscriptions"]
+        "tags": [
+          "Super Admin Subscriptions"
+        ]
       }
     },
     "/super-admin/subscriptions/{orgId}/billing-info": {
@@ -2698,7 +2845,9 @@
           }
         },
         "summary": "Update the billing information for a specific organization",
-        "tags": ["Super Admin Subscriptions"]
+        "tags": [
+          "Super Admin Subscriptions"
+        ]
       }
     },
     "/super-admin/subscriptions/{orgId}/uncancel": {
@@ -2736,7 +2885,9 @@
           }
         },
         "summary": "Uncancel the subscription for a specific organization",
-        "tags": ["Super Admin Subscriptions"]
+        "tags": [
+          "Super Admin Subscriptions"
+        ]
       }
     },
     "/teams": {
@@ -2768,7 +2919,9 @@
           }
         },
         "summary": "List all teams for the current organization",
-        "tags": ["teams"]
+        "tags": [
+          "teams"
+        ]
       },
       "post": {
         "operationId": "TeamsController_createTeam",
@@ -2811,7 +2964,9 @@
           }
         },
         "summary": "Create a new team for the current organization",
-        "tags": ["teams"]
+        "tags": [
+          "teams"
+        ]
       }
     },
     "/teams/me": {
@@ -2840,7 +2995,9 @@
           }
         },
         "summary": "List teams the current user is a member of",
-        "tags": ["teams"]
+        "tags": [
+          "teams"
+        ]
       }
     },
     "/teams/{id}": {
@@ -2881,7 +3038,9 @@
           }
         },
         "summary": "Get a team by ID",
-        "tags": ["teams"]
+        "tags": [
+          "teams"
+        ]
       },
       "patch": {
         "operationId": "TeamsController_updateTeam",
@@ -2936,7 +3095,9 @@
           }
         },
         "summary": "Update a team in the current organization",
-        "tags": ["teams"]
+        "tags": [
+          "teams"
+        ]
       },
       "delete": {
         "operationId": "TeamsController_deleteTeam",
@@ -2968,7 +3129,9 @@
           }
         },
         "summary": "Delete a team from the current organization",
-        "tags": ["teams"]
+        "tags": [
+          "teams"
+        ]
       }
     },
     "/teams/{id}/members": {
@@ -3031,7 +3194,9 @@
           }
         },
         "summary": "List members of a team",
-        "tags": ["teams"]
+        "tags": [
+          "teams"
+        ]
       },
       "post": {
         "operationId": "TeamsController_addTeamMember",
@@ -3086,7 +3251,9 @@
           }
         },
         "summary": "Add a user to a team",
-        "tags": ["teams"]
+        "tags": [
+          "teams"
+        ]
       }
     },
     "/teams/{id}/members/{userId}": {
@@ -3128,7 +3295,9 @@
           }
         },
         "summary": "Remove a user from a team",
-        "tags": ["teams"]
+        "tags": [
+          "teams"
+        ]
       }
     },
     "/storage/upload": {
@@ -3142,7 +3311,9 @@
             "multipart/form-data": {
               "schema": {
                 "type": "object",
-                "required": ["file"],
+                "required": [
+                  "file"
+                ],
                 "properties": {
                   "file": {
                     "type": "string",
@@ -3170,7 +3341,9 @@
           }
         },
         "summary": "Upload a file to object storage",
-        "tags": ["storage"]
+        "tags": [
+          "storage"
+        ]
       }
     },
     "/storage/{objectName}": {
@@ -3192,7 +3365,9 @@
             "description": ""
           }
         },
-        "tags": ["storage"]
+        "tags": [
+          "storage"
+        ]
       },
       "delete": {
         "operationId": "StorageController_deleteFile",
@@ -3212,7 +3387,9 @@
             "description": ""
           }
         },
-        "tags": ["storage"]
+        "tags": [
+          "storage"
+        ]
       }
     },
     "/storage/url/{objectName}": {
@@ -3234,7 +3411,9 @@
             "description": ""
           }
         },
-        "tags": ["storage"]
+        "tags": [
+          "storage"
+        ]
       }
     },
     "/retrievers/url": {
@@ -3257,7 +3436,9 @@
           }
         },
         "summary": "Retrieve content from a URL",
-        "tags": ["retrievers"]
+        "tags": [
+          "retrievers"
+        ]
       }
     },
     "/threads": {
@@ -3293,7 +3474,9 @@
           }
         },
         "summary": "Create a new thread",
-        "tags": ["threads"]
+        "tags": [
+          "threads"
+        ]
       },
       "get": {
         "operationId": "ThreadsController_findAll",
@@ -3352,7 +3535,9 @@
           }
         },
         "summary": "Get all threads for the current user",
-        "tags": ["threads"]
+        "tags": [
+          "threads"
+        ]
       }
     },
     "/threads/{id}": {
@@ -3389,7 +3574,9 @@
           }
         },
         "summary": "Get a thread by ID",
-        "tags": ["threads"]
+        "tags": [
+          "threads"
+        ]
       },
       "delete": {
         "operationId": "ThreadsController_delete",
@@ -3417,7 +3604,9 @@
           }
         },
         "summary": "Delete a thread",
-        "tags": ["threads"]
+        "tags": [
+          "threads"
+        ]
       }
     },
     "/threads/{id}/title": {
@@ -3460,7 +3649,9 @@
           }
         },
         "summary": "Update a thread title",
-        "tags": ["threads"]
+        "tags": [
+          "threads"
+        ]
       }
     },
     "/threads/{id}/sources": {
@@ -3510,7 +3701,9 @@
           }
         },
         "summary": "Get all sources for a thread",
-        "tags": ["threads"]
+        "tags": [
+          "threads"
+        ]
       }
     },
     "/threads/{id}/sources/file": {
@@ -3549,7 +3742,9 @@
                     "description": "A description of the file source"
                   }
                 },
-                "required": ["file"]
+                "required": [
+                  "file"
+                ]
               }
             }
           }
@@ -3560,7 +3755,9 @@
           }
         },
         "summary": "Add a file source to a thread",
-        "tags": ["threads"]
+        "tags": [
+          "threads"
+        ]
       }
     },
     "/threads/{id}/sources/{sourceId}": {
@@ -3597,7 +3794,9 @@
           }
         },
         "summary": "Remove a source from a thread",
-        "tags": ["threads"]
+        "tags": [
+          "threads"
+        ]
       }
     },
     "/threads/{id}/sources/{sourceId}/download": {
@@ -3645,7 +3844,9 @@
           }
         },
         "summary": "Download a data source as CSV",
-        "tags": ["threads"]
+        "tags": [
+          "threads"
+        ]
       }
     },
     "/threads/{id}/knowledge-bases/{knowledgeBaseId}": {
@@ -3682,7 +3883,9 @@
           }
         },
         "summary": "Add a knowledge base to a thread",
-        "tags": ["threads"]
+        "tags": [
+          "threads"
+        ]
       },
       "delete": {
         "operationId": "ThreadKnowledgeBasesController_removeKnowledgeBase",
@@ -3717,7 +3920,9 @@
           }
         },
         "summary": "Remove a knowledge base from a thread",
-        "tags": ["threads"]
+        "tags": [
+          "threads"
+        ]
       }
     },
     "/agents": {
@@ -3753,7 +3958,9 @@
           }
         },
         "summary": "Create a new agent",
-        "tags": ["agents"]
+        "tags": [
+          "agents"
+        ]
       },
       "get": {
         "operationId": "AgentsController_findAll",
@@ -3777,7 +3984,9 @@
           }
         },
         "summary": "Get all agents for the current user",
-        "tags": ["agents"]
+        "tags": [
+          "agents"
+        ]
       }
     },
     "/agents/{id}": {
@@ -3814,7 +4023,9 @@
           }
         },
         "summary": "Get an agent by ID",
-        "tags": ["agents"]
+        "tags": [
+          "agents"
+        ]
       },
       "put": {
         "operationId": "AgentsController_update",
@@ -3862,7 +4073,9 @@
           }
         },
         "summary": "Update an agent",
-        "tags": ["agents"]
+        "tags": [
+          "agents"
+        ]
       },
       "delete": {
         "operationId": "AgentsController_delete",
@@ -3890,7 +4103,9 @@
           }
         },
         "summary": "Delete an agent",
-        "tags": ["agents"]
+        "tags": [
+          "agents"
+        ]
       }
     },
     "/agents/{id}/sources": {
@@ -3930,7 +4145,9 @@
           }
         },
         "summary": "Get all sources for an agent",
-        "tags": ["agents"]
+        "tags": [
+          "agents"
+        ]
       }
     },
     "/agents/{id}/sources/file": {
@@ -3961,7 +4178,9 @@
                     "description": "The file to upload"
                   }
                 },
-                "required": ["file"]
+                "required": [
+                  "file"
+                ]
               }
             }
           }
@@ -3981,7 +4200,9 @@
           }
         },
         "summary": "Add a file source to an agent",
-        "tags": ["agents"]
+        "tags": [
+          "agents"
+        ]
       }
     },
     "/agents/{id}/sources/{sourceAssignmentId}": {
@@ -4018,7 +4239,9 @@
           }
         },
         "summary": "Remove a source from an agent",
-        "tags": ["agents"]
+        "tags": [
+          "agents"
+        ]
       }
     },
     "/agents/{agentId}/mcp-integrations/{integrationId}": {
@@ -4071,7 +4294,9 @@
           }
         },
         "summary": "Assign MCP integration to agent",
-        "tags": ["agents"]
+        "tags": [
+          "agents"
+        ]
       },
       "delete": {
         "operationId": "AgentMcpIntegrationsController_unassignMcpIntegration",
@@ -4113,7 +4338,9 @@
           }
         },
         "summary": "Unassign MCP integration from agent",
-        "tags": ["agents"]
+        "tags": [
+          "agents"
+        ]
       }
     },
     "/agents/{agentId}/mcp-integrations": {
@@ -4150,7 +4377,9 @@
           }
         },
         "summary": "List MCP integrations assigned to agent",
-        "tags": ["agents"]
+        "tags": [
+          "agents"
+        ]
       }
     },
     "/shares": {
@@ -4193,7 +4422,9 @@
           }
         },
         "summary": "Create a share for an agent",
-        "tags": ["shares"]
+        "tags": [
+          "shares"
+        ]
       },
       "get": {
         "operationId": "SharesController_getShares",
@@ -4214,7 +4445,12 @@
             "in": "query",
             "description": "Type of the entity",
             "schema": {
-              "enum": ["agent", "prompt", "skill", "knowledge_base"],
+              "enum": [
+                "agent",
+                "prompt",
+                "skill",
+                "knowledge_base"
+              ],
               "type": "string"
             }
           }
@@ -4244,7 +4480,9 @@
           }
         },
         "summary": "Get shares for an entity",
-        "tags": ["shares"]
+        "tags": [
+          "shares"
+        ]
       }
     },
     "/shares/skills": {
@@ -4284,7 +4522,9 @@
           }
         },
         "summary": "Create a share for a skill",
-        "tags": ["shares"]
+        "tags": [
+          "shares"
+        ]
       }
     },
     "/shares/knowledge-bases": {
@@ -4324,7 +4564,9 @@
           }
         },
         "summary": "Create a share for a knowledge base",
-        "tags": ["shares"]
+        "tags": [
+          "shares"
+        ]
       }
     },
     "/shares/{id}": {
@@ -4357,7 +4599,9 @@
           }
         },
         "summary": "Delete a share",
-        "tags": ["shares"]
+        "tags": [
+          "shares"
+        ]
       }
     },
     "/mcp-integrations/predefined": {
@@ -4393,7 +4637,9 @@
           }
         },
         "summary": "Create a new predefined MCP integration",
-        "tags": ["mcp-integrations"]
+        "tags": [
+          "mcp-integrations"
+        ]
       }
     },
     "/mcp-integrations/custom": {
@@ -4426,7 +4672,9 @@
           }
         },
         "summary": "Create a new custom MCP integration",
-        "tags": ["mcp-integrations"]
+        "tags": [
+          "mcp-integrations"
+        ]
       }
     },
     "/mcp-integrations": {
@@ -4449,7 +4697,9 @@
           }
         },
         "summary": "List all MCP integrations for organization",
-        "tags": ["mcp-integrations"]
+        "tags": [
+          "mcp-integrations"
+        ]
       }
     },
     "/mcp-integrations/predefined/available": {
@@ -4472,7 +4722,9 @@
           }
         },
         "summary": "List available predefined MCP integration configurations",
-        "tags": ["mcp-integrations"]
+        "tags": [
+          "mcp-integrations"
+        ]
       }
     },
     "/mcp-integrations/available": {
@@ -4495,7 +4747,9 @@
           }
         },
         "summary": "List all available (enabled) MCP integrations for organization",
-        "tags": ["mcp-integrations"]
+        "tags": [
+          "mcp-integrations"
+        ]
       }
     },
     "/mcp-integrations/{id}": {
@@ -4528,7 +4782,9 @@
           }
         },
         "summary": "Get MCP integration by ID",
-        "tags": ["mcp-integrations"]
+        "tags": [
+          "mcp-integrations"
+        ]
       },
       "patch": {
         "operationId": "McpIntegrationsController_update",
@@ -4572,7 +4828,9 @@
           }
         },
         "summary": "Update MCP integration",
-        "tags": ["mcp-integrations"]
+        "tags": [
+          "mcp-integrations"
+        ]
       },
       "delete": {
         "operationId": "McpIntegrationsController_delete",
@@ -4596,7 +4854,9 @@
           }
         },
         "summary": "Delete MCP integration",
-        "tags": ["mcp-integrations"]
+        "tags": [
+          "mcp-integrations"
+        ]
       }
     },
     "/mcp-integrations/{id}/enable": {
@@ -4629,7 +4889,9 @@
           }
         },
         "summary": "Enable MCP integration",
-        "tags": ["mcp-integrations"]
+        "tags": [
+          "mcp-integrations"
+        ]
       }
     },
     "/mcp-integrations/{id}/disable": {
@@ -4662,7 +4924,9 @@
           }
         },
         "summary": "Disable MCP integration",
-        "tags": ["mcp-integrations"]
+        "tags": [
+          "mcp-integrations"
+        ]
       }
     },
     "/mcp-integrations/install-from-marketplace": {
@@ -4698,7 +4962,9 @@
           }
         },
         "summary": "Install an MCP integration from the marketplace",
-        "tags": ["mcp-integrations"]
+        "tags": [
+          "mcp-integrations"
+        ]
       }
     },
     "/mcp-integrations/{id}/user-config": {
@@ -4728,7 +4994,9 @@
           }
         },
         "summary": "Get current user config for a marketplace MCP integration",
-        "tags": ["mcp-integrations"]
+        "tags": [
+          "mcp-integrations"
+        ]
       },
       "patch": {
         "operationId": "McpIntegrationsController_setUserConfig",
@@ -4772,7 +5040,9 @@
           }
         },
         "summary": "Set current user config for a marketplace MCP integration",
-        "tags": ["mcp-integrations"]
+        "tags": [
+          "mcp-integrations"
+        ]
       }
     },
     "/mcp-integrations/{id}/validate": {
@@ -4805,7 +5075,9 @@
           }
         },
         "summary": "Validate MCP integration connection",
-        "tags": ["mcp-integrations"]
+        "tags": [
+          "mcp-integrations"
+        ]
       }
     },
     "/marketplace/skills/{identifier}": {
@@ -4838,7 +5110,9 @@
           }
         },
         "summary": "Preview a marketplace skill before installation",
-        "tags": ["marketplace"]
+        "tags": [
+          "marketplace"
+        ]
       }
     },
     "/marketplace/integrations/{identifier}": {
@@ -4871,7 +5145,9 @@
           }
         },
         "summary": "Preview a marketplace integration before installation",
-        "tags": ["marketplace"]
+        "tags": [
+          "marketplace"
+        ]
       }
     },
     "/knowledge-bases": {
@@ -4904,7 +5180,9 @@
           }
         },
         "summary": "Create a new knowledge base",
-        "tags": ["knowledge-bases"]
+        "tags": [
+          "knowledge-bases"
+        ]
       },
       "get": {
         "operationId": "KnowledgeBasesController_findAll",
@@ -4922,7 +5200,9 @@
           }
         },
         "summary": "List all knowledge bases for the current user",
-        "tags": ["knowledge-bases"]
+        "tags": [
+          "knowledge-bases"
+        ]
       }
     },
     "/knowledge-bases/{id}": {
@@ -4956,7 +5236,9 @@
           }
         },
         "summary": "Get a knowledge base by ID",
-        "tags": ["knowledge-bases"]
+        "tags": [
+          "knowledge-bases"
+        ]
       },
       "patch": {
         "operationId": "KnowledgeBasesController_update",
@@ -5001,7 +5283,9 @@
           }
         },
         "summary": "Update a knowledge base",
-        "tags": ["knowledge-bases"]
+        "tags": [
+          "knowledge-bases"
+        ]
       },
       "delete": {
         "operationId": "KnowledgeBasesController_delete",
@@ -5026,7 +5310,9 @@
           }
         },
         "summary": "Delete a knowledge base",
-        "tags": ["knowledge-bases"]
+        "tags": [
+          "knowledge-bases"
+        ]
       }
     },
     "/knowledge-bases/{id}/documents": {
@@ -5060,7 +5346,9 @@
           }
         },
         "summary": "List all documents in a knowledge base",
-        "tags": ["knowledge-bases"]
+        "tags": [
+          "knowledge-bases"
+        ]
       },
       "post": {
         "operationId": "KnowledgeBasesController_addDocument",
@@ -5089,7 +5377,9 @@
                     "description": "The file to upload (PDF, DOCX, PPTX, TXT)"
                   }
                 },
-                "required": ["file"]
+                "required": [
+                  "file"
+                ]
               }
             }
           }
@@ -5110,7 +5400,9 @@
           }
         },
         "summary": "Add a document to a knowledge base",
-        "tags": ["knowledge-bases"]
+        "tags": [
+          "knowledge-bases"
+        ]
       }
     },
     "/knowledge-bases/{id}/urls": {
@@ -5154,7 +5446,9 @@
           }
         },
         "summary": "Add a URL source to a knowledge base",
-        "tags": ["knowledge-bases"]
+        "tags": [
+          "knowledge-bases"
+        ]
       }
     },
     "/knowledge-bases/{id}/documents/{documentId}": {
@@ -5191,7 +5485,9 @@
           }
         },
         "summary": "Remove a document from a knowledge base",
-        "tags": ["knowledge-bases"]
+        "tags": [
+          "knowledge-bases"
+        ]
       }
     },
     "/skills/install-from-marketplace": {
@@ -5224,7 +5520,9 @@
           }
         },
         "summary": "Install a skill from the marketplace",
-        "tags": ["skills"]
+        "tags": [
+          "skills"
+        ]
       }
     },
     "/skills": {
@@ -5260,7 +5558,9 @@
           }
         },
         "summary": "Create a new skill",
-        "tags": ["skills"]
+        "tags": [
+          "skills"
+        ]
       },
       "get": {
         "operationId": "SkillsController_findAll",
@@ -5281,7 +5581,9 @@
           }
         },
         "summary": "Get all skills for the current user",
-        "tags": ["skills"]
+        "tags": [
+          "skills"
+        ]
       }
     },
     "/skills/{id}": {
@@ -5315,7 +5617,9 @@
           }
         },
         "summary": "Get a skill by ID",
-        "tags": ["skills"]
+        "tags": [
+          "skills"
+        ]
       },
       "put": {
         "operationId": "SkillsController_update",
@@ -5363,7 +5667,9 @@
           }
         },
         "summary": "Update a skill",
-        "tags": ["skills"]
+        "tags": [
+          "skills"
+        ]
       },
       "delete": {
         "operationId": "SkillsController_delete",
@@ -5388,7 +5694,9 @@
           }
         },
         "summary": "Delete a skill",
-        "tags": ["skills"]
+        "tags": [
+          "skills"
+        ]
       }
     },
     "/skills/{id}/toggle-active": {
@@ -5422,7 +5730,9 @@
           }
         },
         "summary": "Toggle skill active/inactive status",
-        "tags": ["skills"]
+        "tags": [
+          "skills"
+        ]
       }
     },
     "/skills/{id}/toggle-pinned": {
@@ -5459,7 +5769,9 @@
           }
         },
         "summary": "Toggle skill pinned/unpinned status",
-        "tags": ["skills"]
+        "tags": [
+          "skills"
+        ]
       }
     },
     "/skills/{id}/sources": {
@@ -5496,7 +5808,9 @@
           }
         },
         "summary": "Get all sources for a skill",
-        "tags": ["skills"]
+        "tags": [
+          "skills"
+        ]
       }
     },
     "/skills/{id}/sources/file": {
@@ -5527,7 +5841,9 @@
                     "description": "The file to upload"
                   }
                 },
-                "required": ["file"]
+                "required": [
+                  "file"
+                ]
               }
             }
           }
@@ -5551,7 +5867,9 @@
           }
         },
         "summary": "Add a file source to a skill",
-        "tags": ["skills"]
+        "tags": [
+          "skills"
+        ]
       }
     },
     "/skills/{id}/sources/{sourceId}": {
@@ -5588,7 +5906,9 @@
           }
         },
         "summary": "Remove a source from a skill",
-        "tags": ["skills"]
+        "tags": [
+          "skills"
+        ]
       }
     },
     "/skills/{skillId}/mcp-integrations/{integrationId}": {
@@ -5635,7 +5955,9 @@
           }
         },
         "summary": "Assign MCP integration to skill",
-        "tags": ["skills"]
+        "tags": [
+          "skills"
+        ]
       },
       "delete": {
         "operationId": "SkillMcpIntegrationsController_unassignMcpIntegration",
@@ -5677,7 +5999,9 @@
           }
         },
         "summary": "Unassign MCP integration from skill",
-        "tags": ["skills"]
+        "tags": [
+          "skills"
+        ]
       }
     },
     "/skills/{skillId}/mcp-integrations": {
@@ -5714,7 +6038,9 @@
           }
         },
         "summary": "List MCP integrations assigned to skill",
-        "tags": ["skills"]
+        "tags": [
+          "skills"
+        ]
       }
     },
     "/skills/{skillId}/knowledge-bases/{knowledgeBaseId}": {
@@ -5761,7 +6087,9 @@
           }
         },
         "summary": "Assign knowledge base to skill",
-        "tags": ["skills"]
+        "tags": [
+          "skills"
+        ]
       },
       "delete": {
         "operationId": "SkillKnowledgeBasesController_unassignKnowledgeBase",
@@ -5803,7 +6131,9 @@
           }
         },
         "summary": "Unassign knowledge base from skill",
-        "tags": ["skills"]
+        "tags": [
+          "skills"
+        ]
       }
     },
     "/skills/{skillId}/knowledge-bases": {
@@ -5840,7 +6170,9 @@
           }
         },
         "summary": "List knowledge bases assigned to skill",
-        "tags": ["skills"]
+        "tags": [
+          "skills"
+        ]
       }
     },
     "/super-admin/skill-templates": {
@@ -5880,7 +6212,9 @@
           }
         },
         "summary": "Create a new skill template",
-        "tags": ["Super Admin Skill Templates"]
+        "tags": [
+          "Super Admin Skill Templates"
+        ]
       },
       "get": {
         "description": "Retrieve all skill templates. Only accessible to super admins.",
@@ -5908,7 +6242,9 @@
           }
         },
         "summary": "Get all skill templates",
-        "tags": ["Super Admin Skill Templates"]
+        "tags": [
+          "Super Admin Skill Templates"
+        ]
       }
     },
     "/super-admin/skill-templates/{id}": {
@@ -5949,7 +6285,9 @@
           }
         },
         "summary": "Get a skill template by ID",
-        "tags": ["Super Admin Skill Templates"]
+        "tags": [
+          "Super Admin Skill Templates"
+        ]
       },
       "patch": {
         "description": "Partially update an existing skill template. Only accessible to super admins.",
@@ -6001,7 +6339,9 @@
           }
         },
         "summary": "Update a skill template",
-        "tags": ["Super Admin Skill Templates"]
+        "tags": [
+          "Super Admin Skill Templates"
+        ]
       },
       "delete": {
         "description": "Delete a skill template. Only accessible to super admins.",
@@ -6033,7 +6373,9 @@
           }
         },
         "summary": "Delete a skill template",
-        "tags": ["Super Admin Skill Templates"]
+        "tags": [
+          "Super Admin Skill Templates"
+        ]
       }
     },
     "/artifacts": {
@@ -6066,7 +6408,9 @@
           }
         },
         "summary": "Create a new artifact (document)",
-        "tags": ["artifacts"]
+        "tags": [
+          "artifacts"
+        ]
       }
     },
     "/artifacts/{id}": {
@@ -6113,7 +6457,9 @@
           }
         },
         "summary": "Update an artifact (add a new version)",
-        "tags": ["artifacts"]
+        "tags": [
+          "artifacts"
+        ]
       },
       "get": {
         "operationId": "ArtifactsController_findOne",
@@ -6145,7 +6491,9 @@
           }
         },
         "summary": "Get an artifact by ID with all versions",
-        "tags": ["artifacts"]
+        "tags": [
+          "artifacts"
+        ]
       }
     },
     "/artifacts/thread/{threadId}": {
@@ -6179,7 +6527,9 @@
           }
         },
         "summary": "Get all artifacts for a thread",
-        "tags": ["artifacts"]
+        "tags": [
+          "artifacts"
+        ]
       }
     },
     "/artifacts/{id}/revert": {
@@ -6223,7 +6573,9 @@
           }
         },
         "summary": "Revert an artifact to a specific version",
-        "tags": ["artifacts"]
+        "tags": [
+          "artifacts"
+        ]
       }
     },
     "/artifacts/{id}/export": {
@@ -6246,7 +6598,10 @@
             "in": "query",
             "description": "Export format",
             "schema": {
-              "enum": ["docx", "pdf"],
+              "enum": [
+                "docx",
+                "pdf"
+              ],
               "type": "string"
             }
           }
@@ -6268,7 +6623,9 @@
           }
         },
         "summary": "Export an artifact as DOCX or PDF",
-        "tags": ["artifacts"]
+        "tags": [
+          "artifacts"
+        ]
       }
     },
     "/letterheads": {
@@ -6301,7 +6658,9 @@
           }
         },
         "summary": "Create a new letterhead",
-        "tags": ["letterheads"]
+        "tags": [
+          "letterheads"
+        ]
       },
       "get": {
         "operationId": "LetterheadsController_findAll",
@@ -6322,7 +6681,9 @@
           }
         },
         "summary": "List all letterheads for the current org",
-        "tags": ["letterheads"]
+        "tags": [
+          "letterheads"
+        ]
       }
     },
     "/letterheads/{id}": {
@@ -6356,7 +6717,9 @@
           }
         },
         "summary": "Get a letterhead by ID",
-        "tags": ["letterheads"]
+        "tags": [
+          "letterheads"
+        ]
       },
       "patch": {
         "operationId": "LetterheadsController_update",
@@ -6398,7 +6761,9 @@
           }
         },
         "summary": "Update a letterhead",
-        "tags": ["letterheads"]
+        "tags": [
+          "letterheads"
+        ]
       },
       "delete": {
         "operationId": "LetterheadsController_remove",
@@ -6423,7 +6788,9 @@
           }
         },
         "summary": "Delete a letterhead",
-        "tags": ["letterheads"]
+        "tags": [
+          "letterheads"
+        ]
       }
     },
     "/letterheads/{id}/first-page-pdf": {
@@ -6450,7 +6817,9 @@
           }
         },
         "summary": "Download the first-page PDF of a letterhead",
-        "tags": ["letterheads"]
+        "tags": [
+          "letterheads"
+        ]
       }
     },
     "/letterheads/{id}/continuation-page-pdf": {
@@ -6477,7 +6846,9 @@
           }
         },
         "summary": "Download the continuation-page PDF of a letterhead",
-        "tags": ["letterheads"]
+        "tags": [
+          "letterheads"
+        ]
       }
     },
     "/runs/send-message": {
@@ -6491,7 +6862,9 @@
             "multipart/form-data": {
               "schema": {
                 "type": "object",
-                "required": ["threadId"],
+                "required": [
+                  "threadId"
+                ],
                 "properties": {
                   "threadId": {
                     "type": "string",
@@ -6598,7 +6971,9 @@
           }
         },
         "summary": "Send a message with optional images and receive streaming response",
-        "tags": ["runs"]
+        "tags": [
+          "runs"
+        ]
       }
     },
     "/super-admin/trials": {
@@ -6636,7 +7011,9 @@
           }
         },
         "summary": "Create a new trial",
-        "tags": ["Super Admin Trials"]
+        "tags": [
+          "Super Admin Trials"
+        ]
       }
     },
     "/super-admin/trials/{orgId}": {
@@ -6673,7 +7050,9 @@
           }
         },
         "summary": "Get a trial by organization ID",
-        "tags": ["Super Admin Trials"]
+        "tags": [
+          "Super Admin Trials"
+        ]
       },
       "put": {
         "description": "Update a trial for an organization. Can update maxMessages and/or messagesSent. Only accessible to users with the super admin system role.",
@@ -6719,7 +7098,9 @@
           }
         },
         "summary": "Update a trial",
-        "tags": ["Super Admin Trials"]
+        "tags": [
+          "Super Admin Trials"
+        ]
       }
     },
     "/usage/config": {
@@ -6740,7 +7121,9 @@
           }
         },
         "summary": "Get usage dashboard configuration",
-        "tags": ["Admin Usage"]
+        "tags": [
+          "Admin Usage"
+        ]
       }
     },
     "/usage/credits": {
@@ -6761,7 +7144,9 @@
           }
         },
         "summary": "Get credit usage for the current month",
-        "tags": ["Admin Usage"]
+        "tags": [
+          "Admin Usage"
+        ]
       }
     },
     "/usage/users": {
@@ -6825,7 +7210,12 @@
             "in": "query",
             "description": "Field to sort users by. Defaults to credits.",
             "schema": {
-              "enum": ["credits", "requests", "lastActivity", "userName"],
+              "enum": [
+                "credits",
+                "requests",
+                "lastActivity",
+                "userName"
+              ],
               "type": "string"
             }
           },
@@ -6835,7 +7225,10 @@
             "in": "query",
             "description": "Sort order (ascending or descending). Defaults to desc.",
             "schema": {
-              "enum": ["asc", "desc"],
+              "enum": [
+                "asc",
+                "desc"
+              ],
               "type": "string"
             }
           }
@@ -6853,7 +7246,9 @@
           }
         },
         "summary": "Get usage statistics by user",
-        "tags": ["Admin Usage"]
+        "tags": [
+          "Admin Usage"
+        ]
       }
     },
     "/super-admin/usage/{orgId}/config": {
@@ -6883,7 +7278,9 @@
           }
         },
         "summary": "Get usage dashboard configuration for an organization",
-        "tags": ["Super Admin Usage"]
+        "tags": [
+          "Super Admin Usage"
+        ]
       }
     },
     "/super-admin/usage/{orgId}/credits": {
@@ -6915,7 +7312,9 @@
           }
         },
         "summary": "Get credit usage for an organization",
-        "tags": ["Super Admin Usage"]
+        "tags": [
+          "Super Admin Usage"
+        ]
       }
     },
     "/super-admin/usage/{orgId}/stats": {
@@ -6962,7 +7361,9 @@
           }
         },
         "summary": "Get overall usage statistics for an organization",
-        "tags": ["Super Admin Usage"]
+        "tags": [
+          "Super Admin Usage"
+        ]
       }
     },
     "/super-admin/usage/{orgId}/models": {
@@ -7025,7 +7426,9 @@
           }
         },
         "summary": "Get usage distribution by model for an organization",
-        "tags": ["Super Admin Usage"]
+        "tags": [
+          "Super Admin Usage"
+        ]
       }
     },
     "/super-admin/usage/{orgId}/providers": {
@@ -7096,7 +7499,9 @@
           }
         },
         "summary": "Get usage statistics by provider for an organization",
-        "tags": ["Super Admin Usage"]
+        "tags": [
+          "Super Admin Usage"
+        ]
       }
     },
     "/super-admin/usage/{orgId}/providers/chart": {
@@ -7159,7 +7564,9 @@
           }
         },
         "summary": "Get provider usage time series for an organization (chart-ready)",
-        "tags": ["Super Admin Usage"]
+        "tags": [
+          "Super Admin Usage"
+        ]
       }
     },
     "/super-admin/usage/{orgId}/users": {
@@ -7221,7 +7628,12 @@
             "required": false,
             "in": "query",
             "schema": {
-              "enum": ["credits", "requests", "lastActivity", "userName"],
+              "enum": [
+                "credits",
+                "requests",
+                "lastActivity",
+                "userName"
+              ],
               "type": "string"
             }
           },
@@ -7230,7 +7642,10 @@
             "required": false,
             "in": "query",
             "schema": {
-              "enum": ["asc", "desc"],
+              "enum": [
+                "asc",
+                "desc"
+              ],
               "type": "string"
             }
           }
@@ -7248,7 +7663,9 @@
           }
         },
         "summary": "Get usage statistics by user for an organization",
-        "tags": ["Super Admin Usage"]
+        "tags": [
+          "Super Admin Usage"
+        ]
       }
     },
     "/super-admin/global-usage/providers/chart": {
@@ -7301,7 +7718,9 @@
           }
         },
         "summary": "Get global provider usage time series across all organizations (chart-ready)",
-        "tags": ["Super Admin Global Usage"]
+        "tags": [
+          "Super Admin Global Usage"
+        ]
       }
     },
     "/super-admin/global-usage/models": {
@@ -7346,7 +7765,9 @@
           }
         },
         "summary": "Get global model distribution across all organizations",
-        "tags": ["Super Admin Global Usage"]
+        "tags": [
+          "Super Admin Global Usage"
+        ]
       }
     },
     "/super-admin/global-usage/users": {
@@ -7383,7 +7804,9 @@
           }
         },
         "summary": "Get top 20 users by token usage across all organizations",
-        "tags": ["Super Admin Global Usage"]
+        "tags": [
+          "Super Admin Global Usage"
+        ]
       }
     },
     "/super-admin/platform-config/credits-per-euro": {
@@ -7413,7 +7836,9 @@
           }
         },
         "summary": "Get the current credits-per-euro configuration",
-        "tags": ["Super Admin Platform Config"]
+        "tags": [
+          "Super Admin Platform Config"
+        ]
       },
       "put": {
         "description": "Update the global credits-per-euro value used for credit calculations. Super admin only.",
@@ -7444,7 +7869,9 @@
           }
         },
         "summary": "Set the credits-per-euro configuration",
-        "tags": ["Super Admin Platform Config"]
+        "tags": [
+          "Super Admin Platform Config"
+        ]
       }
     },
     "/chat-settings/system-prompt": {
@@ -7465,7 +7892,9 @@
           }
         },
         "summary": "Get the user system prompt",
-        "tags": ["Chat Settings"]
+        "tags": [
+          "Chat Settings"
+        ]
       },
       "put": {
         "description": "Creates or replaces the custom system prompt for the authenticated user.",
@@ -7497,7 +7926,9 @@
           }
         },
         "summary": "Set or update the user system prompt",
-        "tags": ["Chat Settings"]
+        "tags": [
+          "Chat Settings"
+        ]
       },
       "delete": {
         "description": "Deletes the custom system prompt for the authenticated user.",
@@ -7509,7 +7940,9 @@
           }
         },
         "summary": "Delete the user system prompt",
-        "tags": ["Chat Settings"]
+        "tags": [
+          "Chat Settings"
+        ]
       }
     },
     "/chat-settings/generate-personalized-system-prompt": {
@@ -7549,7 +7982,9 @@
           }
         },
         "summary": "Generate a personalized system prompt",
-        "tags": ["Chat Settings"]
+        "tags": [
+          "Chat Settings"
+        ]
       }
     },
     "/prompts": {
@@ -7585,7 +8020,9 @@
           }
         },
         "summary": "Create a new prompt",
-        "tags": ["prompts"]
+        "tags": [
+          "prompts"
+        ]
       },
       "get": {
         "operationId": "PromptsController_findAll",
@@ -7609,7 +8046,9 @@
           }
         },
         "summary": "Get all prompts for the current user",
-        "tags": ["prompts"]
+        "tags": [
+          "prompts"
+        ]
       }
     },
     "/prompts/{id}": {
@@ -7646,7 +8085,9 @@
           }
         },
         "summary": "Get a prompt by ID",
-        "tags": ["prompts"]
+        "tags": [
+          "prompts"
+        ]
       },
       "put": {
         "operationId": "PromptsController_update",
@@ -7694,7 +8135,9 @@
           }
         },
         "summary": "Update a prompt",
-        "tags": ["prompts"]
+        "tags": [
+          "prompts"
+        ]
       },
       "delete": {
         "operationId": "PromptsController_delete",
@@ -7722,7 +8165,9 @@
           }
         },
         "summary": "Delete a prompt",
-        "tags": ["prompts"]
+        "tags": [
+          "prompts"
+        ]
       }
     },
     "/transcriptions": {
@@ -7736,7 +8181,9 @@
             "multipart/form-data": {
               "schema": {
                 "type": "object",
-                "required": ["file"],
+                "required": [
+                  "file"
+                ],
                 "properties": {
                   "file": {
                     "type": "string",
@@ -7780,7 +8227,9 @@
           }
         ],
         "summary": "Transcribe audio file to text",
-        "tags": ["transcriptions"]
+        "tags": [
+          "transcriptions"
+        ]
       }
     },
     "/auth/login": {
@@ -7832,7 +8281,9 @@
           }
         },
         "summary": "User login",
-        "tags": ["Authentication"]
+        "tags": [
+          "Authentication"
+        ]
       }
     },
     "/auth/register": {
@@ -7884,7 +8335,9 @@
           }
         },
         "summary": "User registration",
-        "tags": ["Authentication"]
+        "tags": [
+          "Authentication"
+        ]
       }
     },
     "/auth/refresh": {
@@ -7930,7 +8383,9 @@
           }
         ],
         "summary": "Refresh authentication tokens",
-        "tags": ["Authentication"]
+        "tags": [
+          "Authentication"
+        ]
       }
     },
     "/auth/me": {
@@ -7971,7 +8426,9 @@
           }
         },
         "summary": "Get current user information",
-        "tags": ["Authentication"]
+        "tags": [
+          "Authentication"
+        ]
       }
     },
     "/auth/logout": {
@@ -7992,7 +8449,9 @@
           }
         },
         "summary": "User logout",
-        "tags": ["Authentication"]
+        "tags": [
+          "Authentication"
+        ]
       }
     },
     "/ip-allowlist": {
@@ -8012,7 +8471,9 @@
           }
         },
         "summary": "Get the IP allow list for the current org",
-        "tags": ["ip-allowlist"]
+        "tags": [
+          "ip-allowlist"
+        ]
       },
       "put": {
         "operationId": "IpAllowlistController_update",
@@ -8043,7 +8504,9 @@
           }
         },
         "summary": "Replace the IP allow list for the current org",
-        "tags": ["ip-allowlist"]
+        "tags": [
+          "ip-allowlist"
+        ]
       },
       "delete": {
         "operationId": "IpAllowlistController_remove",
@@ -8054,7 +8517,9 @@
           }
         },
         "summary": "Remove the IP allow list (disable IP restriction)",
-        "tags": ["ip-allowlist"]
+        "tags": [
+          "ip-allowlist"
+        ]
       }
     }
   },
@@ -8087,7 +8552,10 @@
             "example": false
           }
         },
-        "required": ["isCloud", "isRegistrationDisabled"]
+        "required": [
+          "isCloud",
+          "isRegistrationDisabled"
+        ]
       },
       "FeatureTogglesResponseDto": {
         "type": "object",
@@ -8101,6 +8569,11 @@
             "type": "boolean",
             "description": "Whether the standalone knowledge bases feature is enabled",
             "example": true
+          },
+          "letterheadsEnabled": {
+            "type": "boolean",
+            "description": "Whether the letterheads feature is enabled",
+            "example": false
           },
           "promptsEnabled": {
             "type": "boolean",
@@ -8116,6 +8589,7 @@
         "required": [
           "agentsEnabled",
           "knowledgeBasesEnabled",
+          "letterheadsEnabled",
           "promptsEnabled",
           "skillsEnabled"
         ]
@@ -8237,12 +8711,22 @@
           },
           "hostedIn": {
             "type": "string",
-            "enum": ["DE", "EU", "US", "SELF_HOSTED", "AYUNIS"],
+            "enum": [
+              "DE",
+              "EU",
+              "US",
+              "SELF_HOSTED",
+              "AYUNIS"
+            ],
             "description": "The location where the provider hosts their services",
             "example": "US"
           }
         },
-        "required": ["provider", "displayName", "hostedIn"]
+        "required": [
+          "provider",
+          "displayName",
+          "hostedIn"
+        ]
       },
       "CreatePermittedModelDto": {
         "type": "object",
@@ -8259,7 +8743,9 @@
             "default": false
           }
         },
-        "required": ["modelId"]
+        "required": [
+          "modelId"
+        ]
       },
       "UpdatePermittedModelDto": {
         "type": "object",
@@ -8270,7 +8756,9 @@
             "example": true
           }
         },
-        "required": ["anonymousOnly"]
+        "required": [
+          "anonymousOnly"
+        ]
       },
       "PermittedLanguageModelResponseDto": {
         "type": "object",
@@ -8319,7 +8807,9 @@
           },
           "type": {
             "type": "string",
-            "enum": ["language"],
+            "enum": [
+              "language"
+            ],
             "description": "The type of the model (always language)"
           },
           "canStream": {
@@ -8372,7 +8862,9 @@
             ]
           }
         },
-        "required": ["permittedLanguageModel"]
+        "required": [
+          "permittedLanguageModel"
+        ]
       },
       "SetUserDefaultModelDto": {
         "type": "object",
@@ -8383,7 +8875,9 @@
             "example": "123e4567-e89b-12d3-a456-426614174000"
           }
         },
-        "required": ["permittedModelId"]
+        "required": [
+          "permittedModelId"
+        ]
       },
       "SetOrgDefaultModelDto": {
         "type": "object",
@@ -8394,7 +8888,9 @@
             "example": "123e4567-e89b-12d3-a456-426614174000"
           }
         },
-        "required": ["permittedModelId"]
+        "required": [
+          "permittedModelId"
+        ]
       },
       "EmbeddingModelEnabledResponseDto": {
         "type": "object",
@@ -8405,7 +8901,9 @@
             "example": true
           }
         },
-        "required": ["isEmbeddingModelEnabled"]
+        "required": [
+          "isEmbeddingModelEnabled"
+        ]
       },
       "CreateTeamPermittedModelDto": {
         "type": "object",
@@ -8422,7 +8920,9 @@
             "default": false
           }
         },
-        "required": ["modelId"]
+        "required": [
+          "modelId"
+        ]
       },
       "SetTeamDefaultModelDto": {
         "type": "object",
@@ -8433,7 +8933,9 @@
             "example": "123e4567-e89b-12d3-a456-426614174000"
           }
         },
-        "required": ["permittedModelId"]
+        "required": [
+          "permittedModelId"
+        ]
       },
       "PermittedEmbeddingModelResponseDto": {
         "type": "object",
@@ -8478,7 +8980,9 @@
           },
           "type": {
             "type": "string",
-            "enum": ["embedding"],
+            "enum": [
+              "embedding"
+            ],
             "description": "The type of the model (always embedding)"
           },
           "dimensions": {
@@ -8695,7 +9199,11 @@
           "dimensions": {
             "type": "number",
             "description": "The dimensions of the embedding",
-            "enum": [1024, 1536, 2560],
+            "enum": [
+              1024,
+              1536,
+              2560
+            ],
             "example": 1536
           },
           "isArchived": {
@@ -8759,7 +9267,11 @@
           "dimensions": {
             "type": "number",
             "description": "The dimensions of the embedding",
-            "enum": [1024, 1536, 2560],
+            "enum": [
+              1024,
+              1536,
+              2560
+            ],
             "example": 1536
           },
           "isArchived": {
@@ -8828,7 +9340,9 @@
           },
           "type": {
             "type": "string",
-            "enum": ["language"],
+            "enum": [
+              "language"
+            ],
             "description": "The type of the model (always language)"
           },
           "isArchived": {
@@ -8932,7 +9446,9 @@
           },
           "type": {
             "type": "string",
-            "enum": ["embedding"],
+            "enum": [
+              "embedding"
+            ],
             "description": "The type of the model (always embedding)"
           },
           "isArchived": {
@@ -8995,7 +9511,9 @@
             "example": "Acme Corporation"
           }
         },
-        "required": ["name"]
+        "required": [
+          "name"
+        ]
       },
       "SuperAdminOrgResponseDto": {
         "type": "object",
@@ -9018,7 +9536,11 @@
             "example": "2024-01-15T10:30:00Z"
           }
         },
-        "required": ["id", "name", "createdAt"]
+        "required": [
+          "id",
+          "name",
+          "createdAt"
+        ]
       },
       "PaginationDto": {
         "type": "object",
@@ -9039,7 +9561,10 @@
             "example": 150
           }
         },
-        "required": ["limit", "offset"]
+        "required": [
+          "limit",
+          "offset"
+        ]
       },
       "SuperAdminOrgListResponseDto": {
         "type": "object",
@@ -9060,7 +9585,10 @@
             ]
           }
         },
-        "required": ["data", "pagination"]
+        "required": [
+          "data",
+          "pagination"
+        ]
       },
       "UserResponseDto": {
         "type": "object",
@@ -9084,7 +9612,10 @@
           "role": {
             "type": "string",
             "description": "User role",
-            "enum": ["admin", "user"],
+            "enum": [
+              "admin",
+              "user"
+            ],
             "example": "user"
           },
           "orgId": {
@@ -9106,7 +9637,14 @@
             "example": "2024-01-15T10:30:00Z"
           }
         },
-        "required": ["id", "name", "email", "role", "orgId", "createdAt"]
+        "required": [
+          "id",
+          "name",
+          "email",
+          "role",
+          "orgId",
+          "createdAt"
+        ]
       },
       "PaginatedUsersListResponseDto": {
         "type": "object",
@@ -9127,7 +9665,10 @@
             ]
           }
         },
-        "required": ["data", "pagination"]
+        "required": [
+          "data",
+          "pagination"
+        ]
       },
       "UpdateUserRoleDto": {
         "type": "object",
@@ -9135,11 +9676,16 @@
           "role": {
             "type": "string",
             "description": "New role for the user",
-            "enum": ["admin", "user"],
+            "enum": [
+              "admin",
+              "user"
+            ],
             "example": "admin"
           }
         },
-        "required": ["role"]
+        "required": [
+          "role"
+        ]
       },
       "UpdateUserNameDto": {
         "type": "object",
@@ -9152,7 +9698,9 @@
             "maxLength": 100
           }
         },
-        "required": ["name"]
+        "required": [
+          "name"
+        ]
       },
       "UpdatePasswordDto": {
         "type": "object",
@@ -9191,7 +9739,9 @@
             "example": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
           }
         },
-        "required": ["token"]
+        "required": [
+          "token"
+        ]
       },
       "ResendEmailConfirmationDto": {
         "type": "object",
@@ -9203,7 +9753,9 @@
             "format": "email"
           }
         },
-        "required": ["email"]
+        "required": [
+          "email"
+        ]
       },
       "ForgotPasswordDto": {
         "type": "object",
@@ -9214,7 +9766,9 @@
             "example": "user@example.com"
           }
         },
-        "required": ["email"]
+        "required": [
+          "email"
+        ]
       },
       "ResetPasswordDto": {
         "type": "object",
@@ -9237,7 +9791,24 @@
             "minLength": 8
           }
         },
-        "required": ["resetToken", "newPassword", "newPasswordConfirmation"]
+        "required": [
+          "resetToken",
+          "newPassword",
+          "newPasswordConfirmation"
+        ]
+      },
+      "TriggerPasswordResetResponseDto": {
+        "type": "object",
+        "properties": {
+          "resetUrl": {
+            "type": "string",
+            "description": "The password reset URL sent to the user",
+            "example": "https://app.ayunis.de/password/reset?token=eyJhbGci..."
+          }
+        },
+        "required": [
+          "resetUrl"
+        ]
       },
       "CreateUserDto": {
         "type": "object",
@@ -9255,7 +9826,10 @@
           "role": {
             "type": "string",
             "description": "Role for the user",
-            "enum": ["admin", "user"],
+            "enum": [
+              "admin",
+              "user"
+            ],
             "example": "user"
           },
           "sendPasswordResetEmail": {
@@ -9264,7 +9838,12 @@
             "example": true
           }
         },
-        "required": ["email", "name", "role", "sendPasswordResetEmail"]
+        "required": [
+          "email",
+          "name",
+          "role",
+          "sendPasswordResetEmail"
+        ]
       },
       "SuperAdminUserResponseDto": {
         "type": "object",
@@ -9288,7 +9867,10 @@
           "role": {
             "type": "string",
             "description": "User role",
-            "enum": ["admin", "user"],
+            "enum": [
+              "admin",
+              "user"
+            ],
             "example": "user"
           },
           "orgId": {
@@ -9312,7 +9894,10 @@
           "systemRole": {
             "type": "string",
             "description": "System-level role of the user",
-            "enum": ["customer", "super_admin"],
+            "enum": [
+              "customer",
+              "super_admin"
+            ],
             "example": "super_admin"
           }
         },
@@ -9335,7 +9920,9 @@
             "example": "user@example.com"
           }
         },
-        "required": ["email"]
+        "required": [
+          "email"
+        ]
       },
       "CreateInviteDto": {
         "type": "object",
@@ -9348,11 +9935,17 @@
           "role": {
             "type": "string",
             "description": "Role to assign to the invited user",
-            "enum": ["admin", "user"],
+            "enum": [
+              "admin",
+              "user"
+            ],
             "example": "user"
           }
         },
-        "required": ["email", "role"]
+        "required": [
+          "email",
+          "role"
+        ]
       },
       "CreateInviteResponseDto": {
         "type": "object",
@@ -9364,7 +9957,9 @@
             "nullable": true
           }
         },
-        "required": ["url"]
+        "required": [
+          "url"
+        ]
       },
       "CreateBulkInviteItemDto": {
         "type": "object",
@@ -9377,11 +9972,17 @@
           "role": {
             "type": "string",
             "description": "Role to assign to the invited user",
-            "enum": ["admin", "user"],
+            "enum": [
+              "admin",
+              "user"
+            ],
             "example": "user"
           }
         },
-        "required": ["email", "role"]
+        "required": [
+          "email",
+          "role"
+        ]
       },
       "CreateBulkInvitesDto": {
         "type": "object",
@@ -9396,7 +9997,9 @@
             }
           }
         },
-        "required": ["invites"]
+        "required": [
+          "invites"
+        ]
       },
       "BulkInviteResultDto": {
         "type": "object",
@@ -9409,7 +10012,10 @@
           "role": {
             "type": "string",
             "description": "Role assigned to the invited user",
-            "enum": ["admin", "user"],
+            "enum": [
+              "admin",
+              "user"
+            ],
             "example": "user"
           },
           "success": {
@@ -9471,7 +10077,12 @@
             }
           }
         },
-        "required": ["totalCount", "successCount", "failureCount", "results"]
+        "required": [
+          "totalCount",
+          "successCount",
+          "failureCount",
+          "results"
+        ]
       },
       "InviteResponseDto": {
         "type": "object",
@@ -9490,13 +10101,20 @@
           "role": {
             "type": "string",
             "description": "Role assigned to the invited user",
-            "enum": ["admin", "user"],
+            "enum": [
+              "admin",
+              "user"
+            ],
             "example": "user"
           },
           "status": {
             "type": "string",
             "description": "Current status of the invite",
-            "enum": ["pending", "accepted", "expired"],
+            "enum": [
+              "pending",
+              "accepted",
+              "expired"
+            ],
             "example": "pending"
           },
           "sentDate": {
@@ -9518,7 +10136,14 @@
             "example": "2023-12-02T15:30:00Z"
           }
         },
-        "required": ["id", "email", "role", "status", "sentDate", "expiresAt"]
+        "required": [
+          "id",
+          "email",
+          "role",
+          "status",
+          "sentDate",
+          "expiresAt"
+        ]
       },
       "PaginatedInvitesListResponseDto": {
         "type": "object",
@@ -9539,7 +10164,10 @@
             ]
           }
         },
-        "required": ["data", "pagination"]
+        "required": [
+          "data",
+          "pagination"
+        ]
       },
       "InviteDetailResponseDto": {
         "type": "object",
@@ -9558,13 +10186,20 @@
           "role": {
             "type": "string",
             "description": "Role assigned to the invited user",
-            "enum": ["admin", "user"],
+            "enum": [
+              "admin",
+              "user"
+            ],
             "example": "user"
           },
           "status": {
             "type": "string",
             "description": "Current status of the invite",
-            "enum": ["pending", "accepted", "expired"],
+            "enum": [
+              "pending",
+              "accepted",
+              "expired"
+            ],
             "example": "pending"
           },
           "sentDate": {
@@ -9658,7 +10293,11 @@
             "format": "uuid"
           }
         },
-        "required": ["inviteId", "email", "orgId"]
+        "required": [
+          "inviteId",
+          "email",
+          "orgId"
+        ]
       },
       "DeleteAllPendingInvitesResponseDto": {
         "type": "object",
@@ -9668,7 +10307,9 @@
             "description": "Number of invites deleted"
           }
         },
-        "required": ["deletedCount"]
+        "required": [
+          "deletedCount"
+        ]
       },
       "ActiveSubscriptionResponseDto": {
         "type": "object",
@@ -9681,12 +10322,18 @@
           "subscriptionType": {
             "type": "string",
             "description": "Type of the active subscription. Null when there is no active subscription or on self-hosted deployments.",
-            "enum": ["SEAT_BASED", "USAGE_BASED"],
+            "enum": [
+              "SEAT_BASED",
+              "USAGE_BASED"
+            ],
             "example": "SEAT_BASED",
             "nullable": true
           }
         },
-        "required": ["hasActiveSubscription", "subscriptionType"]
+        "required": [
+          "hasActiveSubscription",
+          "subscriptionType"
+        ]
       },
       "PriceResponseDto": {
         "type": "object",
@@ -9697,7 +10344,9 @@
             "example": 29.99
           }
         },
-        "required": ["pricePerSeatMonthly"]
+        "required": [
+          "pricePerSeatMonthly"
+        ]
       },
       "SubscriptionBillingInfoResponseDto": {
         "type": "object",
@@ -9782,7 +10431,10 @@
           "type": {
             "type": "string",
             "description": "Subscription type",
-            "enum": ["SEAT_BASED", "USAGE_BASED"],
+            "enum": [
+              "SEAT_BASED",
+              "USAGE_BASED"
+            ],
             "example": "SEAT_BASED"
           },
           "noOfSeats": {
@@ -9798,7 +10450,10 @@
           "renewalCycle": {
             "type": "string",
             "description": "Renewal cycle of the subscription (seat-based only)",
-            "enum": ["monthly", "yearly"],
+            "enum": [
+              "monthly",
+              "yearly"
+            ],
             "example": "monthly"
           },
           "renewalCycleAnchor": {
@@ -9897,7 +10552,10 @@
           "type": {
             "type": "string",
             "description": "Subscription type. Defaults to SEAT_BASED if not specified.",
-            "enum": ["SEAT_BASED", "USAGE_BASED"],
+            "enum": [
+              "SEAT_BASED",
+              "USAGE_BASED"
+            ],
             "example": "SEAT_BASED",
             "default": "SEAT_BASED"
           },
@@ -9990,7 +10648,9 @@
             "example": "Engineering"
           }
         },
-        "required": ["name"]
+        "required": [
+          "name"
+        ]
       },
       "UpdateTeamDto": {
         "type": "object",
@@ -10006,7 +10666,9 @@
             "example": false
           }
         },
-        "required": ["name"]
+        "required": [
+          "name"
+        ]
       },
       "TeamResponseDto": {
         "type": "object",
@@ -10079,7 +10741,10 @@
           "userRole": {
             "type": "string",
             "description": "The role of the team member in the organization",
-            "enum": ["admin", "user"],
+            "enum": [
+              "admin",
+              "user"
+            ],
             "example": "user"
           },
           "joinedAt": {
@@ -10117,7 +10782,10 @@
             ]
           }
         },
-        "required": ["data", "pagination"]
+        "required": [
+          "data",
+          "pagination"
+        ]
       },
       "AddTeamMemberDto": {
         "type": "object",
@@ -10128,7 +10796,9 @@
             "example": "550e8400-e29b-41d4-a716-446655440001"
           }
         },
-        "required": ["userId"]
+        "required": [
+          "userId"
+        ]
       },
       "ListTeamMembersQueryDto": {
         "type": "object",
@@ -10177,7 +10847,11 @@
             "example": "2024-01-01T00:00:00.000Z"
           }
         },
-        "required": ["objectName", "size", "etag"]
+        "required": [
+          "objectName",
+          "size",
+          "etag"
+        ]
       },
       "RetrieveUrlDto": {
         "type": "object",
@@ -10188,7 +10862,9 @@
             "example": "https://example.com/article"
           }
         },
-        "required": ["url"]
+        "required": [
+          "url"
+        ]
       },
       "CreateThreadDto": {
         "type": "object",
@@ -10235,7 +10911,9 @@
             "type": "string",
             "description": "Role of the message sender",
             "example": "user",
-            "enum": ["user"]
+            "enum": [
+              "user"
+            ]
           },
           "content": {
             "type": "array",
@@ -10252,7 +10930,13 @@
             }
           }
         },
-        "required": ["id", "threadId", "createdAt", "role", "content"]
+        "required": [
+          "id",
+          "threadId",
+          "createdAt",
+          "role",
+          "content"
+        ]
       },
       "SystemMessageResponseDto": {
         "type": "object",
@@ -10276,7 +10960,9 @@
             "type": "string",
             "description": "Role of the message sender",
             "example": "system",
-            "enum": ["system"]
+            "enum": [
+              "system"
+            ]
           },
           "content": {
             "type": "array",
@@ -10286,7 +10972,13 @@
             }
           }
         },
-        "required": ["id", "threadId", "createdAt", "role", "content"]
+        "required": [
+          "id",
+          "threadId",
+          "createdAt",
+          "role",
+          "content"
+        ]
       },
       "AssistantMessageResponseDto": {
         "type": "object",
@@ -10310,7 +11002,9 @@
             "type": "string",
             "description": "Role of the message sender",
             "example": "assistant",
-            "enum": ["assistant"]
+            "enum": [
+              "assistant"
+            ]
           },
           "content": {
             "type": "array",
@@ -10330,7 +11024,13 @@
             }
           }
         },
-        "required": ["id", "threadId", "createdAt", "role", "content"]
+        "required": [
+          "id",
+          "threadId",
+          "createdAt",
+          "role",
+          "content"
+        ]
       },
       "ToolResultMessageResponseDto": {
         "type": "object",
@@ -10354,7 +11054,9 @@
             "type": "string",
             "description": "Role of the message sender",
             "example": "tool",
-            "enum": ["tool"]
+            "enum": [
+              "tool"
+            ]
           },
           "content": {
             "type": "array",
@@ -10364,7 +11066,13 @@
             }
           }
         },
-        "required": ["id", "threadId", "createdAt", "role", "content"]
+        "required": [
+          "id",
+          "threadId",
+          "createdAt",
+          "role",
+          "content"
+        ]
       },
       "TextMessageContentResponseDto": {
         "type": "object",
@@ -10373,7 +11081,13 @@
             "type": "string",
             "description": "Type of the message content",
             "example": "text",
-            "enum": ["text", "tool_use", "tool_result", "thinking", "image"]
+            "enum": [
+              "text",
+              "tool_use",
+              "tool_result",
+              "thinking",
+              "image"
+            ]
           },
           "text": {
             "type": "string",
@@ -10386,7 +11100,10 @@
             "example": false
           }
         },
-        "required": ["type", "text"]
+        "required": [
+          "type",
+          "text"
+        ]
       },
       "ToolUseIntegrationDto": {
         "type": "object",
@@ -10408,7 +11125,10 @@
             "nullable": true
           }
         },
-        "required": ["id", "name"]
+        "required": [
+          "id",
+          "name"
+        ]
       },
       "ToolUseMessageContentResponseDto": {
         "type": "object",
@@ -10417,7 +11137,13 @@
             "type": "string",
             "description": "Type of the message content",
             "example": "text",
-            "enum": ["text", "tool_use", "tool_result", "thinking", "image"]
+            "enum": [
+              "text",
+              "tool_use",
+              "tool_result",
+              "thinking",
+              "image"
+            ]
           },
           "id": {
             "type": "string",
@@ -10446,7 +11172,12 @@
             ]
           }
         },
-        "required": ["type", "id", "name", "params"]
+        "required": [
+          "type",
+          "id",
+          "name",
+          "params"
+        ]
       },
       "ToolResultMessageContentResponseDto": {
         "type": "object",
@@ -10455,7 +11186,13 @@
             "type": "string",
             "description": "Type of the message content",
             "example": "text",
-            "enum": ["text", "tool_use", "tool_result", "thinking", "image"]
+            "enum": [
+              "text",
+              "tool_use",
+              "tool_result",
+              "thinking",
+              "image"
+            ]
           },
           "toolId": {
             "type": "string",
@@ -10473,7 +11210,12 @@
             "example": "The current temperature in New York is 22°C with partly cloudy skies."
           }
         },
-        "required": ["type", "toolId", "toolName", "result"]
+        "required": [
+          "type",
+          "toolId",
+          "toolName",
+          "result"
+        ]
       },
       "ThinkingMessageContentResponseDto": {
         "type": "object",
@@ -10482,7 +11224,13 @@
             "type": "string",
             "description": "Type of the message content",
             "example": "text",
-            "enum": ["text", "tool_use", "tool_result", "thinking", "image"]
+            "enum": [
+              "text",
+              "tool_use",
+              "tool_result",
+              "thinking",
+              "image"
+            ]
           },
           "thinking": {
             "type": "string",
@@ -10490,7 +11238,10 @@
             "example": "I am thinking about the best way to help you."
           }
         },
-        "required": ["type", "thinking"]
+        "required": [
+          "type",
+          "thinking"
+        ]
       },
       "ImageMessageContentResponseDto": {
         "type": "object",
@@ -10499,7 +11250,13 @@
             "type": "string",
             "description": "Type of the message content",
             "example": "text",
-            "enum": ["text", "tool_use", "tool_result", "thinking", "image"]
+            "enum": [
+              "text",
+              "tool_use",
+              "tool_result",
+              "thinking",
+              "image"
+            ]
           },
           "imageUrl": {
             "type": "string",
@@ -10512,7 +11269,10 @@
             "example": "Screenshot of the reported issue"
           }
         },
-        "required": ["type", "imageUrl"]
+        "required": [
+          "type",
+          "imageUrl"
+        ]
       },
       "ModelResponseDto": {
         "type": "object",
@@ -10576,12 +11336,19 @@
           "type": {
             "type": "string",
             "description": "Type of source",
-            "enum": ["text", "data"]
+            "enum": [
+              "text",
+              "data"
+            ]
           },
           "createdBy": {
             "type": "string",
             "description": "Creator of the source",
-            "enum": ["user", "llm", "system"]
+            "enum": [
+              "user",
+              "llm",
+              "system"
+            ]
           },
           "createdAt": {
             "type": "string",
@@ -10620,12 +11387,19 @@
           "type": {
             "type": "string",
             "description": "Type of source",
-            "enum": ["text", "data"]
+            "enum": [
+              "text",
+              "data"
+            ]
           },
           "createdBy": {
             "type": "string",
             "description": "Creator of the source",
-            "enum": ["user", "llm", "system"]
+            "enum": [
+              "user",
+              "llm",
+              "system"
+            ]
           },
           "createdAt": {
             "type": "string",
@@ -10638,12 +11412,20 @@
           "textType": {
             "type": "string",
             "description": "Type of text",
-            "enum": ["file", "web"]
+            "enum": [
+              "file",
+              "web"
+            ]
           },
           "fileType": {
             "type": "string",
             "description": "Type of file",
-            "enum": ["pdf", "docx", "pptx", "txt"]
+            "enum": [
+              "pdf",
+              "docx",
+              "pptx",
+              "txt"
+            ]
           }
         },
         "required": [
@@ -10676,12 +11458,19 @@
           "type": {
             "type": "string",
             "description": "Type of source",
-            "enum": ["text", "data"]
+            "enum": [
+              "text",
+              "data"
+            ]
           },
           "createdBy": {
             "type": "string",
             "description": "Creator of the source",
-            "enum": ["user", "llm", "system"]
+            "enum": [
+              "user",
+              "llm",
+              "system"
+            ]
           },
           "createdAt": {
             "type": "string",
@@ -10694,7 +11483,10 @@
           "textType": {
             "type": "string",
             "description": "Type of text",
-            "enum": ["file", "web"]
+            "enum": [
+              "file",
+              "web"
+            ]
           },
           "url": {
             "type": "string",
@@ -10731,12 +11523,19 @@
           "type": {
             "type": "string",
             "description": "Type of source",
-            "enum": ["text", "data"]
+            "enum": [
+              "text",
+              "data"
+            ]
           },
           "createdBy": {
             "type": "string",
             "description": "Creator of the source",
-            "enum": ["user", "llm", "system"]
+            "enum": [
+              "user",
+              "llm",
+              "system"
+            ]
           },
           "createdAt": {
             "type": "string",
@@ -10749,7 +11548,9 @@
           "dataType": {
             "type": "string",
             "description": "Type of data",
-            "enum": ["csv"]
+            "enum": [
+              "csv"
+            ]
           },
           "data": {
             "type": "object",
@@ -10802,7 +11603,10 @@
             "example": "Municipal Zoning Guidelines"
           }
         },
-        "required": ["id", "name"]
+        "required": [
+          "id",
+          "name"
+        ]
       },
       "GetThreadResponseDto": {
         "type": "object",
@@ -10930,7 +11734,12 @@
             "example": false
           }
         },
-        "required": ["id", "createdAt", "updatedAt", "isAnonymous"]
+        "required": [
+          "id",
+          "createdAt",
+          "updatedAt",
+          "isAnonymous"
+        ]
       },
       "GetThreadsResponseDto": {
         "type": "object",
@@ -10951,7 +11760,10 @@
             ]
           }
         },
-        "required": ["data", "pagination"]
+        "required": [
+          "data",
+          "pagination"
+        ]
       },
       "UpdateThreadTitleDto": {
         "type": "object",
@@ -10964,7 +11776,9 @@
             "maxLength": 200
           }
         },
-        "required": ["title"]
+        "required": [
+          "title"
+        ]
       },
       "ToolAssignmentDto": {
         "type": "object",
@@ -11005,7 +11819,9 @@
             "format": "uuid"
           }
         },
-        "required": ["type"]
+        "required": [
+          "type"
+        ]
       },
       "CreateAgentDto": {
         "type": "object",
@@ -11036,7 +11852,12 @@
             }
           }
         },
-        "required": ["name", "instructions", "modelId", "toolAssignments"]
+        "required": [
+          "name",
+          "instructions",
+          "modelId",
+          "toolAssignments"
+        ]
       },
       "ToolResponseDto": {
         "type": "object",
@@ -11071,7 +11892,9 @@
             ]
           }
         },
-        "required": ["type"]
+        "required": [
+          "type"
+        ]
       },
       "AgentSourceResponseDto": {
         "type": "object",
@@ -11097,10 +11920,18 @@
             "type": "string",
             "description": "The type of source",
             "example": "file",
-            "enum": ["file", "url"]
+            "enum": [
+              "file",
+              "url"
+            ]
           }
         },
-        "required": ["id", "sourceId", "name", "type"]
+        "required": [
+          "id",
+          "sourceId",
+          "name",
+          "type"
+        ]
       },
       "AgentResponseDto": {
         "type": "object",
@@ -11214,7 +12045,11 @@
             "format": "uuid"
           }
         },
-        "required": ["name", "instructions", "modelId"]
+        "required": [
+          "name",
+          "instructions",
+          "modelId"
+        ]
       },
       "McpIntegrationResponseDto": {
         "type": "object",
@@ -11232,7 +12067,11 @@
           "type": {
             "type": "string",
             "description": "Type of integration",
-            "enum": ["predefined", "custom", "marketplace"],
+            "enum": [
+              "predefined",
+              "custom",
+              "marketplace"
+            ],
             "example": "predefined"
           },
           "slug": {
@@ -11258,7 +12097,12 @@
           "authMethod": {
             "type": "string",
             "description": "Authentication method used",
-            "enum": ["NO_AUTH", "BEARER_TOKEN", "CUSTOM_HEADER", "OAUTH"],
+            "enum": [
+              "NO_AUTH",
+              "BEARER_TOKEN",
+              "CUSTOM_HEADER",
+              "OAUTH"
+            ],
             "example": "BEARER_TOKEN"
           },
           "authHeaderName": {
@@ -11274,7 +12118,12 @@
           "connectionStatus": {
             "type": "string",
             "description": "Connection status of the integration",
-            "enum": ["connected", "disconnected", "error", "unknown"],
+            "enum": [
+              "connected",
+              "disconnected",
+              "error",
+              "unknown"
+            ],
             "example": "connected"
           },
           "lastConnectionError": {
@@ -11357,7 +12206,12 @@
           "entityType": {
             "type": "string",
             "description": "Type of entity being shared",
-            "enum": ["agent", "prompt", "skill", "knowledge_base"]
+            "enum": [
+              "agent",
+              "prompt",
+              "skill",
+              "knowledge_base"
+            ]
           },
           "agentId": {
             "type": "string",
@@ -11370,7 +12224,10 @@
             "format": "uuid"
           }
         },
-        "required": ["entityType", "agentId"]
+        "required": [
+          "entityType",
+          "agentId"
+        ]
       },
       "ShareResponseDto": {
         "type": "object",
@@ -11383,7 +12240,12 @@
           "entityType": {
             "type": "string",
             "description": "Type of entity being shared",
-            "enum": ["agent", "prompt", "skill", "knowledge_base"]
+            "enum": [
+              "agent",
+              "prompt",
+              "skill",
+              "knowledge_base"
+            ]
           },
           "entityId": {
             "type": "string",
@@ -11393,7 +12255,10 @@
           "scopeType": {
             "type": "string",
             "description": "Type of share scope (organization, user, or team)",
-            "enum": ["org", "team"]
+            "enum": [
+              "org",
+              "team"
+            ]
           },
           "ownerId": {
             "type": "string",
@@ -11436,7 +12301,12 @@
           "entityType": {
             "type": "string",
             "description": "Type of entity being shared",
-            "enum": ["agent", "prompt", "skill", "knowledge_base"]
+            "enum": [
+              "agent",
+              "prompt",
+              "skill",
+              "knowledge_base"
+            ]
           },
           "skillId": {
             "type": "string",
@@ -11449,7 +12319,10 @@
             "format": "uuid"
           }
         },
-        "required": ["entityType", "skillId"]
+        "required": [
+          "entityType",
+          "skillId"
+        ]
       },
       "CreateKnowledgeBaseShareDto": {
         "type": "object",
@@ -11457,7 +12330,12 @@
           "entityType": {
             "type": "string",
             "description": "Type of entity being shared",
-            "enum": ["agent", "prompt", "skill", "knowledge_base"]
+            "enum": [
+              "agent",
+              "prompt",
+              "skill",
+              "knowledge_base"
+            ]
           },
           "knowledgeBaseId": {
             "type": "string",
@@ -11470,7 +12348,10 @@
             "format": "uuid"
           }
         },
-        "required": ["entityType", "knowledgeBaseId"]
+        "required": [
+          "entityType",
+          "knowledgeBaseId"
+        ]
       },
       "ConfigValueDto": {
         "type": "object",
@@ -11478,7 +12359,11 @@
           "name": {
             "type": "string",
             "description": "The name/type of the credential field",
-            "enum": ["token", "clientId", "clientSecret"],
+            "enum": [
+              "token",
+              "clientId",
+              "clientSecret"
+            ],
             "example": "token"
           },
           "value": {
@@ -11487,7 +12372,10 @@
             "example": "sk_test_123abc"
           }
         },
-        "required": ["name", "value"]
+        "required": [
+          "name",
+          "value"
+        ]
       },
       "CreatePredefinedIntegrationDto": {
         "type": "object",
@@ -11496,7 +12384,11 @@
             "type": "string",
             "description": "The predefined integration slug",
             "example": "TEST",
-            "enum": ["TEST", "LOCABOO", "LEGAL_CODES"]
+            "enum": [
+              "TEST",
+              "LOCABOO",
+              "LEGAL_CODES"
+            ]
           },
           "configValues": {
             "description": "List of config values for credential fields",
@@ -11518,7 +12410,10 @@
             "default": true
           }
         },
-        "required": ["slug", "configValues"]
+        "required": [
+          "slug",
+          "configValues"
+        ]
       },
       "CreateCustomIntegrationDto": {
         "type": "object",
@@ -11538,7 +12433,12 @@
           "authMethod": {
             "type": "string",
             "description": "Authentication method for the MCP server",
-            "enum": ["NO_AUTH", "BEARER_TOKEN", "CUSTOM_HEADER", "OAUTH"],
+            "enum": [
+              "NO_AUTH",
+              "BEARER_TOKEN",
+              "CUSTOM_HEADER",
+              "OAUTH"
+            ],
             "example": "CUSTOM_HEADER",
             "nullable": true
           },
@@ -11559,7 +12459,10 @@
             "default": true
           }
         },
-        "required": ["name", "serverUrl"]
+        "required": [
+          "name",
+          "serverUrl"
+        ]
       },
       "CredentialFieldDto": {
         "type": "object",
@@ -11572,7 +12475,11 @@
           "type": {
             "type": "string",
             "description": "Input type (text or password)",
-            "enum": ["token", "clientId", "clientSecret"],
+            "enum": [
+              "token",
+              "clientId",
+              "clientSecret"
+            ],
             "example": "token"
           },
           "required": {
@@ -11586,7 +12493,11 @@
             "example": "Your Locaboo 3 API token will be used to authenticate with Locaboo 4"
           }
         },
-        "required": ["label", "type", "required"]
+        "required": [
+          "label",
+          "type",
+          "required"
+        ]
       },
       "PredefinedConfigResponseDto": {
         "type": "object",
@@ -11609,7 +12520,12 @@
           "authType": {
             "type": "string",
             "description": "Authentication method for this integration",
-            "enum": ["NO_AUTH", "BEARER_TOKEN", "API_KEY", "OAUTH"],
+            "enum": [
+              "NO_AUTH",
+              "BEARER_TOKEN",
+              "API_KEY",
+              "OAUTH"
+            ],
             "example": "BEARER_TOKEN"
           },
           "authHeaderName": {
@@ -11625,7 +12541,12 @@
             }
           }
         },
-        "required": ["slug", "displayName", "description", "authType"]
+        "required": [
+          "slug",
+          "displayName",
+          "description",
+          "authType"
+        ]
       },
       "UpdateMcpIntegrationDto": {
         "type": "object",
@@ -11685,7 +12606,10 @@
             "example": false
           }
         },
-        "required": ["identifier", "orgConfigValues"]
+        "required": [
+          "identifier",
+          "orgConfigValues"
+        ]
       },
       "UserConfigResponseDto": {
         "type": "object",
@@ -11706,7 +12630,10 @@
             }
           }
         },
-        "required": ["hasConfig", "configValues"]
+        "required": [
+          "hasConfig",
+          "configValues"
+        ]
       },
       "SetUserConfigDto": {
         "type": "object",
@@ -11722,7 +12649,9 @@
             }
           }
         },
-        "required": ["configValues"]
+        "required": [
+          "configValues"
+        ]
       },
       "ValidationResponseDto": {
         "type": "object",
@@ -11747,7 +12676,10 @@
             "example": "Connection timeout"
           }
         },
-        "required": ["valid", "capabilities"]
+        "required": [
+          "valid",
+          "capabilities"
+        ]
       },
       "MarketplaceSkillResponseDto": {
         "type": "object",
@@ -11835,7 +12767,11 @@
           "type": {
             "type": "string",
             "description": "Field type",
-            "enum": ["text", "url", "secret"]
+            "enum": [
+              "text",
+              "url",
+              "secret"
+            ]
           },
           "headerName": {
             "type": "string",
@@ -11862,7 +12798,12 @@
             "nullable": true
           }
         },
-        "required": ["key", "label", "type", "required"]
+        "required": [
+          "key",
+          "label",
+          "type",
+          "required"
+        ]
       },
       "MarketplaceIntegrationConfigSchemaDto": {
         "type": "object",
@@ -11886,7 +12827,11 @@
             }
           }
         },
-        "required": ["authType", "orgFields", "userFields"]
+        "required": [
+          "authType",
+          "orgFields",
+          "userFields"
+        ]
       },
       "MarketplaceIntegrationResponseDto": {
         "type": "object",
@@ -12001,7 +12946,9 @@
             "maxLength": 2000
           }
         },
-        "required": ["name"]
+        "required": [
+          "name"
+        ]
       },
       "KnowledgeBaseResponseDto": {
         "type": "object",
@@ -12040,7 +12987,13 @@
             "example": false
           }
         },
-        "required": ["id", "name", "description", "createdAt", "updatedAt"]
+        "required": [
+          "id",
+          "name",
+          "description",
+          "createdAt",
+          "updatedAt"
+        ]
       },
       "KnowledgeBaseListResponseDto": {
         "type": "object",
@@ -12053,7 +13006,9 @@
             }
           }
         },
-        "required": ["data"]
+        "required": [
+          "data"
+        ]
       },
       "UpdateKnowledgeBaseDto": {
         "type": "object",
@@ -12090,13 +13045,20 @@
           "type": {
             "type": "string",
             "description": "The type of the source",
-            "enum": ["text", "data"],
+            "enum": [
+              "text",
+              "data"
+            ],
             "example": "text"
           },
           "createdBy": {
             "type": "string",
             "description": "Who created the source",
-            "enum": ["user", "llm", "system"],
+            "enum": [
+              "user",
+              "llm",
+              "system"
+            ],
             "example": "user"
           },
           "createdAt": {
@@ -12114,7 +13076,10 @@
           "textType": {
             "type": "string",
             "description": "The text source subtype (e.g. file, web)",
-            "enum": ["file", "web"],
+            "enum": [
+              "file",
+              "web"
+            ],
             "example": "web"
           },
           "url": {
@@ -12143,7 +13108,9 @@
             }
           }
         },
-        "required": ["data"]
+        "required": [
+          "data"
+        ]
       },
       "AddUrlToKnowledgeBaseDto": {
         "type": "object",
@@ -12154,7 +13121,9 @@
             "example": "https://example.com/page"
           }
         },
-        "required": ["url"]
+        "required": [
+          "url"
+        ]
       },
       "InstallSkillFromMarketplaceDto": {
         "type": "object",
@@ -12165,7 +13134,9 @@
             "example": "meeting-summarizer"
           }
         },
-        "required": ["identifier"]
+        "required": [
+          "identifier"
+        ]
       },
       "SkillResponseDto": {
         "type": "object",
@@ -12271,7 +13242,11 @@
             "example": true
           }
         },
-        "required": ["name", "shortDescription", "instructions"]
+        "required": [
+          "name",
+          "shortDescription",
+          "instructions"
+        ]
       },
       "UpdateSkillDto": {
         "type": "object",
@@ -12294,7 +13269,11 @@
             "example": "You are a legal research assistant. When activated, search through the attached legal databases..."
           }
         },
-        "required": ["name", "shortDescription", "instructions"]
+        "required": [
+          "name",
+          "shortDescription",
+          "instructions"
+        ]
       },
       "SkillSourceResponseDto": {
         "type": "object",
@@ -12316,7 +13295,11 @@
             "example": "file"
           }
         },
-        "required": ["id", "name", "type"]
+        "required": [
+          "id",
+          "name",
+          "type"
+        ]
       },
       "CreateSkillTemplateDto": {
         "type": "object",
@@ -12341,7 +13324,10 @@
           "distributionMode": {
             "type": "string",
             "description": "The distribution mode of the skill template",
-            "enum": ["always_on", "pre_created_copy"],
+            "enum": [
+              "always_on",
+              "pre_created_copy"
+            ],
             "example": "always_on"
           },
           "isActive": {
@@ -12393,7 +13379,10 @@
           },
           "distributionMode": {
             "type": "string",
-            "enum": ["always_on", "pre_created_copy"],
+            "enum": [
+              "always_on",
+              "pre_created_copy"
+            ],
             "description": "The distribution mode of the skill template",
             "example": "always_on"
           },
@@ -12461,7 +13450,10 @@
           "distributionMode": {
             "type": "string",
             "description": "The distribution mode of the skill template",
-            "enum": ["always_on", "pre_created_copy"],
+            "enum": [
+              "always_on",
+              "pre_created_copy"
+            ],
             "example": "always_on"
           },
           "isActive": {
@@ -12503,7 +13495,10 @@
           "authorType": {
             "type": "string",
             "description": "Who authored this version",
-            "enum": ["USER", "ASSISTANT"],
+            "enum": [
+              "USER",
+              "ASSISTANT"
+            ],
             "example": "ASSISTANT"
           },
           "letterheadId": {
@@ -12513,7 +13508,12 @@
             "format": "uuid"
           }
         },
-        "required": ["title", "content", "threadId", "authorType"]
+        "required": [
+          "title",
+          "content",
+          "threadId",
+          "authorType"
+        ]
       },
       "ArtifactVersionResponseDto": {
         "type": "object",
@@ -12541,7 +13541,10 @@
           "authorType": {
             "type": "string",
             "description": "Who authored this version",
-            "enum": ["USER", "ASSISTANT"],
+            "enum": [
+              "USER",
+              "ASSISTANT"
+            ],
             "example": "ASSISTANT"
           },
           "authorId": {
@@ -12639,7 +13642,10 @@
           "authorType": {
             "type": "string",
             "description": "Who authored this version. Required when content is provided.",
-            "enum": ["USER", "ASSISTANT"],
+            "enum": [
+              "USER",
+              "ASSISTANT"
+            ],
             "example": "USER"
           },
           "letterheadId": {
@@ -12660,7 +13666,9 @@
             "example": 1
           }
         },
-        "required": ["versionNumber"]
+        "required": [
+          "versionNumber"
+        ]
       },
       "CreateLetterheadDto": {
         "type": "object",
@@ -12684,7 +13692,11 @@
             "description": "JSON string of { top, bottom, left, right } margins in mm"
           }
         },
-        "required": ["name", "firstPageMargins", "continuationPageMargins"]
+        "required": [
+          "name",
+          "firstPageMargins",
+          "continuationPageMargins"
+        ]
       },
       "PageMarginsDto": {
         "type": "object",
@@ -12710,7 +13722,12 @@
             "example": 15
           }
         },
-        "required": ["top", "bottom", "left", "right"]
+        "required": [
+          "top",
+          "bottom",
+          "left",
+          "right"
+        ]
       },
       "LetterheadResponseDto": {
         "type": "object",
@@ -12806,10 +13823,18 @@
             "type": "string",
             "description": "Type of the message content",
             "example": "text",
-            "enum": ["text", "tool_use", "tool_result", "thinking", "image"]
+            "enum": [
+              "text",
+              "tool_use",
+              "tool_result",
+              "thinking",
+              "image"
+            ]
           }
         },
-        "required": ["type"]
+        "required": [
+          "type"
+        ]
       },
       "RunSessionResponseDto": {
         "type": "object",
@@ -12818,7 +13843,9 @@
             "type": "string",
             "description": "Response type identifier",
             "example": "session",
-            "enum": ["session"]
+            "enum": [
+              "session"
+            ]
           },
           "success": {
             "type": "boolean",
@@ -12841,7 +13868,11 @@
             "example": "2024-01-01T12:00:00.000Z"
           }
         },
-        "required": ["type", "threadId", "timestamp"]
+        "required": [
+          "type",
+          "threadId",
+          "timestamp"
+        ]
       },
       "RunMessageResponseDto": {
         "type": "object",
@@ -12850,7 +13881,9 @@
             "type": "string",
             "description": "Response type identifier",
             "example": "message",
-            "enum": ["message"]
+            "enum": [
+              "message"
+            ]
           },
           "message": {
             "description": "The message data",
@@ -12880,7 +13913,12 @@
             "example": "2024-01-01T12:00:00.000Z"
           }
         },
-        "required": ["type", "message", "threadId", "timestamp"]
+        "required": [
+          "type",
+          "message",
+          "threadId",
+          "timestamp"
+        ]
       },
       "RunErrorResponseDto": {
         "type": "object",
@@ -12889,7 +13927,9 @@
             "type": "string",
             "description": "Response type identifier",
             "example": "error",
-            "enum": ["error"]
+            "enum": [
+              "error"
+            ]
           },
           "message": {
             "type": "string",
@@ -12919,7 +13959,12 @@
             }
           }
         },
-        "required": ["type", "message", "threadId", "timestamp"]
+        "required": [
+          "type",
+          "message",
+          "threadId",
+          "timestamp"
+        ]
       },
       "RunThreadResponseDto": {
         "type": "object",
@@ -12928,7 +13973,9 @@
             "type": "string",
             "description": "Response type identifier",
             "example": "thread",
-            "enum": ["thread"]
+            "enum": [
+              "thread"
+            ]
           },
           "threadId": {
             "type": "string",
@@ -12939,7 +13986,9 @@
             "type": "string",
             "description": "Type of thread update",
             "example": "title_updated",
-            "enum": ["title_updated"]
+            "enum": [
+              "title_updated"
+            ]
           },
           "title": {
             "type": "string",
@@ -12952,7 +14001,13 @@
             "example": "2024-01-01T12:00:00.000Z"
           }
         },
-        "required": ["type", "threadId", "updateType", "title", "timestamp"]
+        "required": [
+          "type",
+          "threadId",
+          "updateType",
+          "title",
+          "timestamp"
+        ]
       },
       "TextInput": {
         "type": "object",
@@ -12960,7 +14015,9 @@
           "type": {
             "type": "string",
             "description": "The type of input",
-            "enum": ["text"],
+            "enum": [
+              "text"
+            ],
             "example": "text"
           },
           "text": {
@@ -12969,7 +14026,10 @@
             "example": "What is the weather forecast for New York tomorrow?"
           }
         },
-        "required": ["type", "text"]
+        "required": [
+          "type",
+          "text"
+        ]
       },
       "ToolResultInput": {
         "type": "object",
@@ -12977,7 +14037,9 @@
           "type": {
             "type": "string",
             "description": "The type of input",
-            "enum": ["tool_result"],
+            "enum": [
+              "tool_result"
+            ],
             "example": "tool_result"
           },
           "toolId": {
@@ -12996,7 +14058,12 @@
             "example": "{\"location\":\"New York\",\"forecast\":\"Partly cloudy with a high of 75°F and a low of 60°F\",\"precipitation\":\"20%\"}"
           }
         },
-        "required": ["type", "toolId", "toolName", "result"]
+        "required": [
+          "type",
+          "toolId",
+          "toolName",
+          "result"
+        ]
       },
       "SendMessageDto": {
         "type": "object",
@@ -13043,7 +14110,9 @@
             "default": true
           }
         },
-        "required": ["threadId"]
+        "required": [
+          "threadId"
+        ]
       },
       "SuperAdminTrialResponseDto": {
         "type": "object",
@@ -13123,7 +14192,10 @@
             "minimum": 1
           }
         },
-        "required": ["orgId", "maxMessages"]
+        "required": [
+          "orgId",
+          "maxMessages"
+        ]
       },
       "UpdateTrialRequestDto": {
         "type": "object",
@@ -13151,7 +14223,9 @@
             "example": true
           }
         },
-        "required": ["isSelfHosted"]
+        "required": [
+          "isSelfHosted"
+        ]
       },
       "CreditUsageResponseDto": {
         "type": "object",
@@ -13174,7 +14248,11 @@
             "nullable": true
           }
         },
-        "required": ["monthlyCredits", "creditsUsed", "creditsRemaining"]
+        "required": [
+          "monthlyCredits",
+          "creditsUsed",
+          "creditsRemaining"
+        ]
       },
       "UserUsageDto": {
         "type": "object",
@@ -13243,7 +14321,11 @@
             "description": "Total credits consumed across all users in the filtered period"
           }
         },
-        "required": ["data", "pagination", "totalCredits"]
+        "required": [
+          "data",
+          "pagination",
+          "totalCredits"
+        ]
       },
       "UsageStatsResponseDto": {
         "type": "object",
@@ -13270,7 +14352,11 @@
           },
           "topModels": {
             "description": "List of the most frequently used model names, ordered by usage",
-            "example": ["gpt-4", "claude-3-sonnet", "gpt-3.5-turbo"],
+            "example": [
+              "gpt-4",
+              "claude-3-sonnet",
+              "gpt-3.5-turbo"
+            ],
             "type": "array",
             "items": {
               "type": "string"
@@ -13352,7 +14438,9 @@
             }
           }
         },
-        "required": ["models"]
+        "required": [
+          "models"
+        ]
       },
       "TimeSeriesPointDto": {
         "type": "object",
@@ -13371,7 +14459,11 @@
             "description": "Number of requests at this point"
           }
         },
-        "required": ["date", "tokens", "requests"]
+        "required": [
+          "date",
+          "tokens",
+          "requests"
+        ]
       },
       "ProviderUsageDto": {
         "type": "object",
@@ -13433,7 +14525,9 @@
             }
           }
         },
-        "required": ["providers"]
+        "required": [
+          "providers"
+        ]
       },
       "ProviderValuesDto": {
         "type": "object",
@@ -13481,7 +14575,10 @@
             ]
           }
         },
-        "required": ["date", "values"]
+        "required": [
+          "date",
+          "values"
+        ]
       },
       "ProviderUsageChartResponseDto": {
         "type": "object",
@@ -13494,7 +14591,9 @@
             }
           }
         },
-        "required": ["timeSeries"]
+        "required": [
+          "timeSeries"
+        ]
       },
       "GlobalUserUsageDto": {
         "type": "object",
@@ -13556,7 +14655,9 @@
             }
           }
         },
-        "required": ["data"]
+        "required": [
+          "data"
+        ]
       },
       "CreditsPerEuroResponseDto": {
         "type": "object",
@@ -13567,7 +14668,9 @@
             "example": 1000
           }
         },
-        "required": ["creditsPerEuro"]
+        "required": [
+          "creditsPerEuro"
+        ]
       },
       "SetCreditsPerEuroRequestDto": {
         "type": "object",
@@ -13578,7 +14681,9 @@
             "example": 1000
           }
         },
-        "required": ["creditsPerEuro"]
+        "required": [
+          "creditsPerEuro"
+        ]
       },
       "UserSystemPromptResponseDto": {
         "type": "object",
@@ -13590,7 +14695,9 @@
             "nullable": true
           }
         },
-        "required": ["systemPrompt"]
+        "required": [
+          "systemPrompt"
+        ]
       },
       "UpsertUserSystemPromptDto": {
         "type": "object",
@@ -13602,7 +14709,9 @@
             "maxLength": 10000
           }
         },
-        "required": ["systemPrompt"]
+        "required": [
+          "systemPrompt"
+        ]
       },
       "GeneratePersonalizedSystemPromptDto": {
         "type": "object",
@@ -13626,7 +14735,9 @@
             "maxLength": 1000
           }
         },
-        "required": ["preferredName"]
+        "required": [
+          "preferredName"
+        ]
       },
       "GeneratePersonalizedSystemPromptResponseDto": {
         "type": "object",
@@ -13642,7 +14753,10 @@
             "example": "Willkommen, Maria! Schön, dass du da bist. Wie kann ich dir heute helfen?"
           }
         },
-        "required": ["systemPrompt", "welcomeMessage"]
+        "required": [
+          "systemPrompt",
+          "welcomeMessage"
+        ]
       },
       "CreatePromptDto": {
         "type": "object",
@@ -13660,7 +14774,10 @@
             "example": "You are a helpful assistant that helps with project planning. Please provide detailed step-by-step guidance for managing projects effectively."
           }
         },
-        "required": ["title", "content"]
+        "required": [
+          "title",
+          "content"
+        ]
       },
       "PromptResponseDto": {
         "type": "object",
@@ -13725,7 +14842,10 @@
             "example": "You are an expert project planning assistant. Provide comprehensive guidance for project management, including risk assessment and timeline optimization."
           }
         },
-        "required": ["title", "content"]
+        "required": [
+          "title",
+          "content"
+        ]
       },
       "TranscriptionResponseDto": {
         "type": "object",
@@ -13736,7 +14856,9 @@
             "example": "Hello, this is a test transcription."
           }
         },
-        "required": ["text"]
+        "required": [
+          "text"
+        ]
       },
       "LoginDto": {
         "type": "object",
@@ -13752,7 +14874,10 @@
             "example": "password123"
           }
         },
-        "required": ["email", "password"]
+        "required": [
+          "email",
+          "password"
+        ]
       },
       "SuccessResponseDto": {
         "type": "object",
@@ -13763,7 +14888,9 @@
             "example": true
           }
         },
-        "required": ["success"]
+        "required": [
+          "success"
+        ]
       },
       "ErrorResponseDto": {
         "type": "object",
@@ -13774,7 +14901,9 @@
             "example": "Authentication failed"
           }
         },
-        "required": ["message"]
+        "required": [
+          "message"
+        ]
       },
       "RegisterDto": {
         "type": "object",
@@ -13829,13 +14958,19 @@
           "role": {
             "type": "string",
             "description": "User role",
-            "enum": ["admin", "user"],
+            "enum": [
+              "admin",
+              "user"
+            ],
             "example": "user"
           },
           "systemRole": {
             "type": "string",
             "description": "User system role",
-            "enum": ["customer", "super_admin"],
+            "enum": [
+              "customer",
+              "super_admin"
+            ],
             "example": "super_admin"
           },
           "name": {
@@ -13844,35 +14979,48 @@
             "example": "John Doe"
           }
         },
-        "required": ["email", "role", "systemRole", "name"]
+        "required": [
+          "email",
+          "role",
+          "systemRole",
+          "name"
+        ]
       },
       "IpAllowlistResponseDto": {
         "type": "object",
         "properties": {
           "cidrs": {
             "description": "List of allowed CIDR ranges",
-            "example": ["203.0.113.0/24"],
+            "example": [
+              "203.0.113.0/24"
+            ],
             "type": "array",
             "items": {
               "type": "string"
             }
           }
         },
-        "required": ["cidrs"]
+        "required": [
+          "cidrs"
+        ]
       },
       "UpdateIpAllowlistRequestDto": {
         "type": "object",
         "properties": {
           "cidrs": {
             "description": "List of CIDR ranges to allow (e.g. \"192.168.1.0/24\")",
-            "example": ["203.0.113.0/24"],
+            "example": [
+              "203.0.113.0/24"
+            ],
             "type": "array",
             "items": {
               "type": "string"
             }
           }
         },
-        "required": ["cidrs"]
+        "required": [
+          "cidrs"
+        ]
       }
     }
   }

--- a/ayunis-core-frontend/src/widgets/artifact-editor/ui/ArtifactEditor.tsx
+++ b/ayunis-core-frontend/src/widgets/artifact-editor/ui/ArtifactEditor.tsx
@@ -13,6 +13,7 @@ import { EditorToolbar } from './EditorToolbar';
 import { VersionHistory } from './VersionHistory';
 import { ExportButtons } from './ExportButtons';
 import { LetterheadPicker } from './LetterheadPicker';
+import { useIsLetterheadsEnabled } from '@/features/feature-toggles';
 
 interface ArtifactEditorProps {
   readonly artifact: ArtifactResponseDto;
@@ -34,6 +35,7 @@ export function ArtifactEditor({
   isExporting,
 }: ArtifactEditorProps) {
   const { t } = useTranslation('artifacts');
+  const isLetterheadsEnabled = useIsLetterheadsEnabled();
 
   const currentVersion = artifact.versions?.find(
     (v) => v.versionNumber === artifact.currentVersionNumber,
@@ -91,7 +93,7 @@ export function ArtifactEditor({
         </h3>
         <div className="flex items-center gap-1">
           <ExportButtons onExport={handleExport} isExporting={isExporting} />
-          {onLetterheadChange && (
+          {isLetterheadsEnabled && onLetterheadChange && (
             <LetterheadPicker
               letterheadId={artifact.letterheadId}
               onLetterheadChange={onLetterheadChange}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: adds a new `letterheadsEnabled` flag and uses it to hide/redirect letterheads admin routes and navigation, without changing underlying letterhead behavior or data handling.
> 
> **Overview**
> Adds a new `letterheadsEnabled` feature flag (default `false`) wired from `FEATURE_LETTERHEADS_ENABLED` in backend config and returned from the public `GET /feature-toggles` endpoint.
> 
> Updates the frontend to respect this flag by conditionally rendering the Admin Settings sidebar entry and redirecting away from the letterheads index/detail routes during route loading when the feature is disabled; also extends the shared feature-toggle hooks/types to include `letterheadsEnabled`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 10c98e88edbba220ed1450c94c525e9300e0a00c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->