### PR TITLE
fix(super-admin): update openapi spec (AYC-000)

### DIFF
--- a/ayunis-core-backend/src/metrics/metrics.constants.ts
+++ b/ayunis-core-backend/src/metrics/metrics.constants.ts
@@ -1,6 +1,5 @@
 // Metric names — single source of truth for all Prometheus metric identifiers.
 // Use these constants everywhere instead of magic strings.
-
 export const METRICS_PATH = '/metrics';
 
 export const AYUNIS_TOKENS_TOTAL = 'ayunis_tokens_total';

--- a/ayunis-core-frontend/src/shared/api/openapi-schema.json
+++ b/ayunis-core-frontend/src/shared/api/openapi-schema.json
@@ -9810,6 +9810,17 @@
           "resetUrl"
         ]
       },
+      "TriggerPasswordResetResponseDto": {
+        "type": "object",
+        "properties": {
+          "resetUrl": {
+            "type": "string",
+            "description": "The password reset URL sent to the user",
+            "example": "https://app.ayunis.de/password/reset?token=eyJhbGci..."
+          }
+        },
+        "required": ["resetUrl"]
+      },
       "CreateUserDto": {
         "type": "object",
         "properties": {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Updates the frontend OpenAPI schema, which can affect generated types/clients; the added duplicate `TriggerPasswordResetResponseDto` entry could also cause spec parsing or codegen issues.
> 
> **Overview**
> Updates the frontend `openapi-schema.json` to (re)introduce a `TriggerPasswordResetResponseDto` schema for password reset triggers.
> 
> Cleans up a minor formatting artifact in backend `metrics.constants.ts` (removes a stray blank line).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 72a88bf001091bd4f113b20535e44e91f6e2b1ef. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->