### PR TITLE
fix(sources): bulk create embeddings (AYC-000)

### DIFF
--- a/ayunis-core-backend/src/db/fixtures/minimal.fixture.ts
+++ b/ayunis-core-backend/src/db/fixtures/minimal.fixture.ts
@@ -50,10 +50,10 @@ export const minimalFixture = {
   },
 
   embeddingModel: {
-    name: 'text-embedding-3-large',
-    displayName: 'Text Embedding 3 Large',
-    provider: ModelProvider.OPENAI,
-    dimensions: EmbeddingDimensions.DIMENSION_1536,
+    name: 'mistral-embed',
+    displayName: 'Mistral Embed',
+    provider: ModelProvider.MISTRAL,
+    dimensions: EmbeddingDimensions.DIMENSION_1024,
   },
 
   subscription: {
@@ -94,9 +94,9 @@ export const minimalFixture = {
       anonymousOnly: false,
     },
     {
-      // Embedding model (not default)
+      // Embedding model as default
       modelKey: 'embeddingModel',
-      isDefault: false,
+      isDefault: true,
       anonymousOnly: false,
     },
   ],

--- a/ayunis-core-backend/src/domain/rag/indexers/application/ports/indexer.ts
+++ b/ayunis-core-backend/src/domain/rag/indexers/application/ports/indexer.ts
@@ -25,8 +25,14 @@ export interface IngestInput {
   content: string;
 }
 
+export interface IngestBulkInput {
+  orgId: UUID;
+  entries: { indexEntry: IndexEntry; content: string }[];
+}
+
 export abstract class IndexerPort {
   abstract ingest(input: IngestInput): Promise<void>;
+  abstract ingestBulk(input: IngestBulkInput): Promise<void>;
   abstract search(input: SearchInput): Promise<IndexEntry[]>;
   abstract searchMulti(input: SearchMultiInput): Promise<IndexEntry[]>;
   abstract delete(documentId: UUID): Promise<void>;

--- a/ayunis-core-backend/src/domain/rag/indexers/application/use-cases/ingest-bulk-content/ingest-bulk-content.command.ts
+++ b/ayunis-core-backend/src/domain/rag/indexers/application/use-cases/ingest-bulk-content/ingest-bulk-content.command.ts
@@ -1,0 +1,24 @@
+import type { UUID } from 'crypto';
+import type { IndexType } from '../../../domain/value-objects/index-type.enum';
+
+export interface IngestBulkContentEntry {
+  documentId: UUID;
+  chunkId: UUID;
+  content: string;
+}
+
+export class IngestBulkContentCommand {
+  orgId: UUID;
+  entries: IngestBulkContentEntry[];
+  type: IndexType;
+
+  constructor(params: {
+    orgId: UUID;
+    entries: IngestBulkContentEntry[];
+    type: IndexType;
+  }) {
+    this.orgId = params.orgId;
+    this.entries = params.entries;
+    this.type = params.type;
+  }
+}

--- a/ayunis-core-backend/src/domain/rag/indexers/application/use-cases/ingest-bulk-content/ingest-bulk-content.use-case.ts
+++ b/ayunis-core-backend/src/domain/rag/indexers/application/use-cases/ingest-bulk-content/ingest-bulk-content.use-case.ts
@@ -1,0 +1,34 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { IndexRegistry } from '../../indexer.registry';
+import { IngestBulkContentCommand } from './ingest-bulk-content.command';
+import { IndexEntry } from 'src/domain/rag/indexers/domain/index-entry.entity';
+import { UnexpectedIndexError } from '../../indexer.errors';
+import { ApplicationError } from 'src/common/errors/base.error';
+
+@Injectable()
+export class IngestBulkContentUseCase {
+  private readonly logger = new Logger(IngestBulkContentUseCase.name);
+  constructor(private readonly indexRegistry: IndexRegistry) {}
+
+  async execute(command: IngestBulkContentCommand): Promise<void> {
+    try {
+      const index = this.indexRegistry.get(command.type);
+      return index.ingestBulk({
+        orgId: command.orgId,
+        entries: command.entries.map((entry) => ({
+          indexEntry: new IndexEntry({
+            relatedDocumentId: entry.documentId,
+            relatedChunkId: entry.chunkId,
+          }),
+          content: entry.content,
+        })),
+      });
+    } catch (error) {
+      if (error instanceof ApplicationError) {
+        throw error;
+      }
+      this.logger.error(error);
+      throw new UnexpectedIndexError(error as Error);
+    }
+  }
+}

--- a/ayunis-core-backend/src/domain/rag/indexers/application/use-cases/search-content/search-content.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/rag/indexers/application/use-cases/search-content/search-content.use-case.spec.ts
@@ -24,6 +24,7 @@ describe('SearchContentUseCase', () => {
       search: jest.fn(),
       searchMulti: jest.fn(),
       ingest: jest.fn(),
+      ingestBulk: jest.fn(),
       delete: jest.fn(),
       deleteMany: jest.fn(),
     } as jest.Mocked<IndexerPort>;

--- a/ayunis-core-backend/src/domain/rag/indexers/indexers.module.ts
+++ b/ayunis-core-backend/src/domain/rag/indexers/indexers.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 import { ParentChildIndexerModule } from './infrastructure/adapters/parent-child-index/parent-child-indexer.module';
 import { IngestContentUseCase } from './application/use-cases/ingest-content/ingest-content.use-case';
+import { IngestBulkContentUseCase } from './application/use-cases/ingest-bulk-content/ingest-bulk-content.use-case';
 import { SearchContentUseCase } from './application/use-cases/search-content/search-content.use-case';
 import { DeleteContentUseCase } from './application/use-cases/delete-content/delete-content.use-case';
 import { IndexRegistry } from './application/indexer.registry';
@@ -20,12 +21,14 @@ import { IndexType } from './domain/value-objects/index-type.enum';
       inject: [ParentChildIndexerAdapter],
     },
     IngestContentUseCase,
+    IngestBulkContentUseCase,
     SearchContentUseCase,
     DeleteContentUseCase,
   ],
   exports: [
     IndexRegistry,
     IngestContentUseCase,
+    IngestBulkContentUseCase,
     SearchContentUseCase,
     DeleteContentUseCase,
   ],

--- a/ayunis-core-backend/src/domain/rag/indexers/infrastructure/adapters/parent-child-index/application/parent-child-indexer.adapter.ts
+++ b/ayunis-core-backend/src/domain/rag/indexers/infrastructure/adapters/parent-child-index/application/parent-child-indexer.adapter.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import type {
   IngestInput,
+  IngestBulkInput,
   SearchInput,
   SearchMultiInput,
 } from 'src/domain/rag/indexers/application/ports/indexer';
@@ -8,6 +9,8 @@ import { IndexerPort } from 'src/domain/rag/indexers/application/ports/indexer';
 import type { IndexEntry } from 'src/domain/rag/indexers/domain/index-entry.entity';
 import { IngestContentUseCase } from './use-cases/ingest-content/ingest-content.use-case';
 import { IngestContentCommand } from './use-cases/ingest-content/ingest-content.command';
+import { IngestBulkContentUseCase } from './use-cases/ingest-bulk-content/ingest-bulk-content.use-case';
+import { IngestBulkContentCommand } from './use-cases/ingest-bulk-content/ingest-bulk-content.command';
 import { SearchContentUseCase } from './use-cases/search-content/search-content.use-case';
 import type { UUID } from 'crypto';
 import { DeleteContentUseCase } from './use-cases/delete-content/delete-content.use-case';
@@ -19,6 +22,7 @@ import { DeleteContentsCommand } from './use-cases/delete-contents/delete-conten
 export class ParentChildIndexerAdapter extends IndexerPort {
   constructor(
     private readonly ingestContentUseCase: IngestContentUseCase,
+    private readonly ingestBulkContentUseCase: IngestBulkContentUseCase,
     private readonly searchContentUseCase: SearchContentUseCase,
     private readonly deleteContentUseCase: DeleteContentUseCase,
     private readonly deleteContentsUseCase: DeleteContentsUseCase,
@@ -32,6 +36,18 @@ export class ParentChildIndexerAdapter extends IndexerPort {
         orgId: params.orgId,
         indexEntry: params.indexEntry,
         content: params.content,
+      }),
+    );
+  }
+
+  async ingestBulk(params: IngestBulkInput): Promise<void> {
+    await this.ingestBulkContentUseCase.execute(
+      new IngestBulkContentCommand({
+        orgId: params.orgId,
+        entries: params.entries.map((entry) => ({
+          indexEntry: entry.indexEntry,
+          content: entry.content,
+        })),
       }),
     );
   }

--- a/ayunis-core-backend/src/domain/rag/indexers/infrastructure/adapters/parent-child-index/application/ports/parent-child-indexer-repository.port.ts
+++ b/ayunis-core-backend/src/domain/rag/indexers/infrastructure/adapters/parent-child-index/application/ports/parent-child-indexer-repository.port.ts
@@ -5,6 +5,7 @@ import { UUID } from 'crypto';
 @Injectable()
 export abstract class ParentChildIndexerRepositoryPort {
   abstract save(input: ParentChunk): Promise<void>;
+  abstract saveMany(inputs: ParentChunk[]): Promise<void>;
   abstract delete(relatedDocumentId: UUID): Promise<void>;
   abstract deleteMany(relatedDocumentIds: UUID[]): Promise<void>;
   abstract find(

--- a/ayunis-core-backend/src/domain/rag/indexers/infrastructure/adapters/parent-child-index/application/use-cases/ingest-bulk-content/ingest-bulk-content.command.ts
+++ b/ayunis-core-backend/src/domain/rag/indexers/infrastructure/adapters/parent-child-index/application/use-cases/ingest-bulk-content/ingest-bulk-content.command.ts
@@ -1,0 +1,17 @@
+import type { UUID } from 'crypto';
+import type { IndexEntry } from 'src/domain/rag/indexers/domain/index-entry.entity';
+
+export interface IngestBulkEntry {
+  indexEntry: IndexEntry;
+  content: string;
+}
+
+export class IngestBulkContentCommand {
+  orgId: UUID;
+  entries: IngestBulkEntry[];
+
+  constructor(params: { orgId: UUID; entries: IngestBulkEntry[] }) {
+    this.orgId = params.orgId;
+    this.entries = params.entries;
+  }
+}

--- a/ayunis-core-backend/src/domain/rag/indexers/infrastructure/adapters/parent-child-index/application/use-cases/ingest-bulk-content/ingest-bulk-content.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/rag/indexers/infrastructure/adapters/parent-child-index/application/use-cases/ingest-bulk-content/ingest-bulk-content.use-case.spec.ts
@@ -1,0 +1,292 @@
+import type { TestingModule } from '@nestjs/testing';
+import { Test } from '@nestjs/testing';
+import { IngestBulkContentUseCase } from './ingest-bulk-content.use-case';
+import { IngestBulkContentCommand } from './ingest-bulk-content.command';
+import { ParentChildIndexerRepositoryPort } from '../../ports/parent-child-indexer-repository.port';
+import { SplitTextUseCase } from 'src/domain/rag/splitters/application/use-cases/split-text/split-text.use-case';
+import { EmbedTextUseCase } from 'src/domain/rag/embeddings/application/use-cases/embed-text/embed-text.use-case';
+import { GetPermittedEmbeddingModelUseCase } from 'src/domain/models/application/use-cases/get-permitted-embedding-model/get-permitted-embedding-model.use-case';
+import { IndexEntry } from 'src/domain/rag/indexers/domain/index-entry.entity';
+import {
+  SplitResult,
+  TextChunk,
+} from 'src/domain/rag/splitters/domain/split-result.entity';
+import { Embedding } from 'src/domain/rag/embeddings/domain/embedding.entity';
+import { EmbeddingModel } from 'src/domain/models/domain/models/embedding.model';
+import { PermittedEmbeddingModel } from 'src/domain/models/domain/permitted-model.entity';
+import { ModelProvider } from 'src/domain/models/domain/value-objects/model-provider.enum';
+import { EmbeddingDimensions } from 'src/domain/models/domain/value-objects/embedding-dimensions.enum';
+import type { UUID } from 'crypto';
+
+const ORG_ID = '11111111-1111-1111-1111-111111111111' as UUID;
+const DOC_ID = '22222222-2222-2222-2222-222222222222' as UUID;
+const CHUNK_ID_1 = '33333333-3333-3333-3333-333333333333' as UUID;
+const CHUNK_ID_2 = '44444444-4444-4444-4444-444444444444' as UUID;
+
+const EMBEDDING_MODEL = new EmbeddingModel({
+  name: 'mistral-embed',
+  provider: ModelProvider.MISTRAL,
+  displayName: 'Mistral Embed',
+  isArchived: false,
+  dimensions: EmbeddingDimensions.DIMENSION_1024,
+});
+
+const PERMITTED_MODEL = new PermittedEmbeddingModel({
+  model: EMBEDDING_MODEL,
+  orgId: ORG_ID,
+});
+
+describe('IngestBulkContentUseCase', () => {
+  let useCase: IngestBulkContentUseCase;
+  let mockRepo: jest.Mocked<ParentChildIndexerRepositoryPort>;
+  let mockSplitter: jest.Mocked<SplitTextUseCase>;
+  let mockEmbedder: jest.Mocked<EmbedTextUseCase>;
+  let mockGetModel: jest.Mocked<GetPermittedEmbeddingModelUseCase>;
+
+  beforeEach(async () => {
+    mockRepo = {
+      save: jest.fn(),
+      saveMany: jest.fn(),
+      delete: jest.fn(),
+      deleteMany: jest.fn(),
+      find: jest.fn(),
+      findByDocumentIds: jest.fn(),
+    } as jest.Mocked<ParentChildIndexerRepositoryPort>;
+
+    mockSplitter = {
+      execute: jest.fn(),
+    } as unknown as jest.Mocked<SplitTextUseCase>;
+
+    mockEmbedder = {
+      execute: jest.fn(),
+    } as unknown as jest.Mocked<EmbedTextUseCase>;
+
+    mockGetModel = {
+      execute: jest.fn(),
+    } as unknown as jest.Mocked<GetPermittedEmbeddingModelUseCase>;
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        IngestBulkContentUseCase,
+        { provide: ParentChildIndexerRepositoryPort, useValue: mockRepo },
+        { provide: SplitTextUseCase, useValue: mockSplitter },
+        { provide: EmbedTextUseCase, useValue: mockEmbedder },
+        {
+          provide: GetPermittedEmbeddingModelUseCase,
+          useValue: mockGetModel,
+        },
+      ],
+    }).compile();
+
+    useCase = module.get(IngestBulkContentUseCase);
+  });
+
+  it('should resolve the embedding model exactly once for multiple entries', async () => {
+    mockGetModel.execute.mockResolvedValue(PERMITTED_MODEL);
+    mockSplitter.execute.mockReturnValue(
+      new SplitResult([new TextChunk('child text', { index: 0 })], {}),
+    );
+    mockEmbedder.execute.mockResolvedValue([
+      new Embedding([0.1, 0.2], 'child text', EMBEDDING_MODEL),
+      new Embedding([0.3, 0.4], 'child text', EMBEDDING_MODEL),
+    ]);
+
+    const command = new IngestBulkContentCommand({
+      orgId: ORG_ID,
+      entries: [
+        {
+          indexEntry: new IndexEntry({
+            relatedDocumentId: DOC_ID,
+            relatedChunkId: CHUNK_ID_1,
+          }),
+          content: 'Bebauungsplan Gewerbegebiet Abschnitt A',
+        },
+        {
+          indexEntry: new IndexEntry({
+            relatedDocumentId: DOC_ID,
+            relatedChunkId: CHUNK_ID_2,
+          }),
+          content: 'Bebauungsplan Gewerbegebiet Abschnitt B',
+        },
+      ],
+    });
+
+    await useCase.execute(command);
+
+    expect(mockGetModel.execute).toHaveBeenCalledTimes(1);
+  });
+
+  it('should batch all child texts into a single embedding API call', async () => {
+    mockGetModel.execute.mockResolvedValue(PERMITTED_MODEL);
+
+    // Each source chunk splits into 2 child chunks
+    mockSplitter.execute
+      .mockReturnValueOnce(
+        new SplitResult(
+          [
+            new TextChunk('Kind-Abschnitt 1a', { index: 0 }),
+            new TextChunk('Kind-Abschnitt 1b', { index: 1 }),
+          ],
+          {},
+        ),
+      )
+      .mockReturnValueOnce(
+        new SplitResult(
+          [
+            new TextChunk('Kind-Abschnitt 2a', { index: 0 }),
+            new TextChunk('Kind-Abschnitt 2b', { index: 1 }),
+          ],
+          {},
+        ),
+      );
+
+    mockEmbedder.execute.mockResolvedValue([
+      new Embedding([0.1], 'Kind-Abschnitt 1a', EMBEDDING_MODEL),
+      new Embedding([0.2], 'Kind-Abschnitt 1b', EMBEDDING_MODEL),
+      new Embedding([0.3], 'Kind-Abschnitt 2a', EMBEDDING_MODEL),
+      new Embedding([0.4], 'Kind-Abschnitt 2b', EMBEDDING_MODEL),
+    ]);
+
+    const command = new IngestBulkContentCommand({
+      orgId: ORG_ID,
+      entries: [
+        {
+          indexEntry: new IndexEntry({
+            relatedDocumentId: DOC_ID,
+            relatedChunkId: CHUNK_ID_1,
+          }),
+          content: 'Eltern-Abschnitt 1 mit detaillierten Textinhalten',
+        },
+        {
+          indexEntry: new IndexEntry({
+            relatedDocumentId: DOC_ID,
+            relatedChunkId: CHUNK_ID_2,
+          }),
+          content: 'Eltern-Abschnitt 2 mit weiteren Textinhalten',
+        },
+      ],
+    });
+
+    await useCase.execute(command);
+
+    // All 4 child texts should be embedded in a single API call
+    expect(mockEmbedder.execute).toHaveBeenCalledTimes(1);
+    expect(mockEmbedder.execute).toHaveBeenCalledWith(
+      expect.objectContaining({
+        texts: [
+          'Kind-Abschnitt 1a',
+          'Kind-Abschnitt 1b',
+          'Kind-Abschnitt 2a',
+          'Kind-Abschnitt 2b',
+        ],
+        model: EMBEDDING_MODEL,
+      }),
+    );
+  });
+
+  it('should save all parent chunks in a single bulk operation', async () => {
+    mockGetModel.execute.mockResolvedValue(PERMITTED_MODEL);
+    mockSplitter.execute.mockReturnValue(
+      new SplitResult([new TextChunk('Kind-Text', { index: 0 })], {}),
+    );
+    mockEmbedder.execute.mockResolvedValue([
+      new Embedding([0.1], 'Kind-Text', EMBEDDING_MODEL),
+      new Embedding([0.2], 'Kind-Text', EMBEDDING_MODEL),
+    ]);
+
+    const command = new IngestBulkContentCommand({
+      orgId: ORG_ID,
+      entries: [
+        {
+          indexEntry: new IndexEntry({
+            relatedDocumentId: DOC_ID,
+            relatedChunkId: CHUNK_ID_1,
+          }),
+          content: 'Grundstücksverkehrsgenehmigung Abschnitt A',
+        },
+        {
+          indexEntry: new IndexEntry({
+            relatedDocumentId: DOC_ID,
+            relatedChunkId: CHUNK_ID_2,
+          }),
+          content: 'Grundstücksverkehrsgenehmigung Abschnitt B',
+        },
+      ],
+    });
+
+    await useCase.execute(command);
+
+    expect(mockRepo.saveMany).toHaveBeenCalledTimes(1);
+    const savedChunks = mockRepo.saveMany.mock.calls[0][0];
+    expect(savedChunks).toHaveLength(2);
+    expect(savedChunks[0].relatedChunkId).toBe(CHUNK_ID_1);
+    expect(savedChunks[1].relatedChunkId).toBe(CHUNK_ID_2);
+  });
+
+  it('should correctly map embeddings back to their parent chunks', async () => {
+    mockGetModel.execute.mockResolvedValue(PERMITTED_MODEL);
+
+    // Entry 1 → 2 children, Entry 2 → 1 child
+    mockSplitter.execute
+      .mockReturnValueOnce(
+        new SplitResult(
+          [
+            new TextChunk('A1', { index: 0 }),
+            new TextChunk('A2', { index: 1 }),
+          ],
+          {},
+        ),
+      )
+      .mockReturnValueOnce(
+        new SplitResult([new TextChunk('B1', { index: 0 })], {}),
+      );
+
+    mockEmbedder.execute.mockResolvedValue([
+      new Embedding([1.0], 'A1', EMBEDDING_MODEL),
+      new Embedding([2.0], 'A2', EMBEDDING_MODEL),
+      new Embedding([3.0], 'B1', EMBEDDING_MODEL),
+    ]);
+
+    const command = new IngestBulkContentCommand({
+      orgId: ORG_ID,
+      entries: [
+        {
+          indexEntry: new IndexEntry({
+            relatedDocumentId: DOC_ID,
+            relatedChunkId: CHUNK_ID_1,
+          }),
+          content: 'Erster Elternblock mit Ratsbeschluss',
+        },
+        {
+          indexEntry: new IndexEntry({
+            relatedDocumentId: DOC_ID,
+            relatedChunkId: CHUNK_ID_2,
+          }),
+          content: 'Zweiter Elternblock mit Satzung',
+        },
+      ],
+    });
+
+    await useCase.execute(command);
+
+    const savedChunks = mockRepo.saveMany.mock.calls[0][0];
+    expect(savedChunks[0].children).toHaveLength(2);
+    expect(savedChunks[0].children[0].embedding).toEqual([1.0]);
+    expect(savedChunks[0].children[1].embedding).toEqual([2.0]);
+    expect(savedChunks[1].children).toHaveLength(1);
+    expect(savedChunks[1].children[0].embedding).toEqual([3.0]);
+  });
+
+  it('should do nothing when entries array is empty', async () => {
+    const command = new IngestBulkContentCommand({
+      orgId: ORG_ID,
+      entries: [],
+    });
+
+    await useCase.execute(command);
+
+    expect(mockGetModel.execute).not.toHaveBeenCalled();
+    expect(mockEmbedder.execute).not.toHaveBeenCalled();
+    expect(mockRepo.saveMany).not.toHaveBeenCalled();
+  });
+});

--- a/ayunis-core-backend/src/domain/rag/indexers/infrastructure/adapters/parent-child-index/application/use-cases/ingest-bulk-content/ingest-bulk-content.use-case.ts
+++ b/ayunis-core-backend/src/domain/rag/indexers/infrastructure/adapters/parent-child-index/application/use-cases/ingest-bulk-content/ingest-bulk-content.use-case.ts
@@ -1,0 +1,150 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ParentChildIndexerRepositoryPort } from '../../ports/parent-child-indexer-repository.port';
+import { ParentChunk } from '../../../domain/parent-chunk.entity';
+import { SplitTextUseCase } from 'src/domain/rag/splitters/application/use-cases/split-text/split-text.use-case';
+import { SplitTextCommand } from 'src/domain/rag/splitters/application/use-cases/split-text/split-text.command';
+import { SplitterType } from 'src/domain/rag/splitters/domain/splitter-type.enum';
+import { ChildChunk } from '../../../domain/child-chunk.entity';
+import { EmbedTextUseCase } from 'src/domain/rag/embeddings/application/use-cases/embed-text/embed-text.use-case';
+import { EmbedTextCommand } from 'src/domain/rag/embeddings/application/use-cases/embed-text/embed-text.command';
+import { GetPermittedEmbeddingModelUseCase } from 'src/domain/models/application/use-cases/get-permitted-embedding-model/get-permitted-embedding-model.use-case';
+import { GetPermittedEmbeddingModelQuery } from 'src/domain/models/application/use-cases/get-permitted-embedding-model/get-permitted-embedding-model.query';
+import { IngestBulkContentCommand } from './ingest-bulk-content.command';
+import type { UUID } from 'crypto';
+import { randomUUID } from 'crypto';
+import type { EmbeddingModel } from 'src/domain/rag/embeddings/domain/embedding-model.entity';
+
+/**
+ * Maximum number of texts to send in a single embedding API call.
+ *
+ * Child chunks are up to ~1000 chars (~250 tokens) each, so this batch size
+ * yields ~16k tokens per request — well within all provider limits:
+ *   - Mistral: error 3210 "Too many tokens" at ~256 × 1000-char chunks;
+ *     64 chunks (~16k tokens) is safe with headroom.
+ *   - OpenAI: max 300k total tokens per request — 64 chunks is far below.
+ *   - Ollama: no documented limit.
+ */
+const EMBEDDING_BATCH_SIZE = 64;
+
+@Injectable()
+export class IngestBulkContentUseCase {
+  private readonly logger = new Logger(IngestBulkContentUseCase.name);
+  constructor(
+    private readonly parentChildIndexerRepository: ParentChildIndexerRepositoryPort,
+    private readonly splitTextUseCase: SplitTextUseCase,
+    private readonly embedTextUseCase: EmbedTextUseCase,
+    private readonly getPermittedEmbeddingModelUseCase: GetPermittedEmbeddingModelUseCase,
+  ) {}
+
+  async execute(command: IngestBulkContentCommand): Promise<void> {
+    if (command.entries.length === 0) return;
+
+    this.logger.debug(
+      `Bulk ingesting ${command.entries.length} entries for org ${command.orgId}`,
+    );
+
+    // 1. Resolve embedding model ONCE for the entire batch
+    const permittedModel = await this.getPermittedEmbeddingModelUseCase.execute(
+      new GetPermittedEmbeddingModelQuery({ orgId: command.orgId }),
+    );
+
+    // 2. Split all entries into child chunks, tracking parent ownership
+    const parentPlans = this.buildParentPlans(command);
+
+    // 3. Collect all child texts into a flat list for batched embedding
+    const allChildTexts = parentPlans.flatMap((plan) => plan.childTexts);
+
+    this.logger.debug(
+      `Split ${command.entries.length} entries into ` +
+        `${parentPlans.length} parent chunks with ${allChildTexts.length} child texts total`,
+    );
+
+    // 4. Embed all child texts in batches
+    const allEmbeddings = await this.embedInBatches(
+      allChildTexts,
+      permittedModel.model,
+      command.orgId,
+    );
+
+    // 5. Reassemble parent chunks with their embeddings
+    const parentChunks = this.assembleParentChunks(parentPlans, allEmbeddings);
+
+    // 6. Bulk save all parent chunks
+    await this.parentChildIndexerRepository.saveMany(parentChunks);
+
+    this.logger.debug(
+      `Bulk ingested ${parentChunks.length} parent chunks ` +
+        `with ${allChildTexts.length} child embeddings`,
+    );
+  }
+
+  private buildParentPlans(command: IngestBulkContentCommand): ParentPlan[] {
+    return command.entries.map((entry) => {
+      const splitResult = this.splitTextUseCase.execute(
+        new SplitTextCommand(entry.content, SplitterType.RECURSIVE),
+      );
+      const parentId = randomUUID();
+      return {
+        parentId,
+        relatedDocumentId: entry.indexEntry.relatedDocumentId,
+        relatedChunkId: entry.indexEntry.relatedChunkId,
+        content: entry.content,
+        childTexts: splitResult.chunks.map((chunk) => chunk.text),
+      };
+    });
+  }
+
+  private async embedInBatches(
+    texts: string[],
+    model: EmbeddingModel,
+    orgId: UUID,
+  ): Promise<number[][]> {
+    if (texts.length === 0) return [];
+
+    const allVectors: number[][] = [];
+
+    for (let i = 0; i < texts.length; i += EMBEDDING_BATCH_SIZE) {
+      const batch = texts.slice(i, i + EMBEDDING_BATCH_SIZE);
+      const embeddings = await this.embedTextUseCase.execute(
+        new EmbedTextCommand({ texts: batch, model, orgId }),
+      );
+      for (const embedding of embeddings) {
+        allVectors.push(embedding.vector);
+      }
+    }
+
+    return allVectors;
+  }
+
+  private assembleParentChunks(
+    plans: ParentPlan[],
+    allEmbeddings: number[][],
+  ): ParentChunk[] {
+    let embeddingOffset = 0;
+    return plans.map((plan) => {
+      const childChunks = plan.childTexts.map(() => {
+        const chunk = new ChildChunk({
+          embedding: allEmbeddings[embeddingOffset],
+          parentId: plan.parentId,
+        });
+        embeddingOffset++;
+        return chunk;
+      });
+      return new ParentChunk({
+        id: plan.parentId,
+        relatedDocumentId: plan.relatedDocumentId,
+        relatedChunkId: plan.relatedChunkId,
+        content: plan.content,
+        children: childChunks,
+      });
+    });
+  }
+}
+
+interface ParentPlan {
+  parentId: UUID;
+  relatedDocumentId: UUID;
+  relatedChunkId: UUID;
+  content: string;
+  childTexts: string[];
+}

--- a/ayunis-core-backend/src/domain/rag/indexers/infrastructure/adapters/parent-child-index/parent-child-index.repository.ts
+++ b/ayunis-core-backend/src/domain/rag/indexers/infrastructure/adapters/parent-child-index/parent-child-index.repository.ts
@@ -31,6 +31,14 @@ export class ParentChildIndexerRepository extends ParentChildIndexerRepositoryPo
     await this.parentChunkRepository.save(parentChunkRecord);
   }
 
+  async saveMany(parentChunks: ParentChunk[]) {
+    if (parentChunks.length === 0) return;
+    const records = parentChunks.map((chunk) =>
+      this.parentChildIndexerMapper.toParentChunkRecord(chunk),
+    );
+    await this.parentChunkRepository.save(records);
+  }
+
   async delete(relatedDocumentId: UUID) {
     const parentChunks = await this.parentChunkRepository.find({
       where: { relatedDocumentId },

--- a/ayunis-core-backend/src/domain/rag/indexers/infrastructure/adapters/parent-child-index/parent-child-indexer.module.ts
+++ b/ayunis-core-backend/src/domain/rag/indexers/infrastructure/adapters/parent-child-index/parent-child-indexer.module.ts
@@ -15,6 +15,7 @@ import { ParentChildIndexerRepositoryPort } from './application/ports/parent-chi
 
 // Use Cases
 import { IngestContentUseCase } from './application/use-cases/ingest-content/ingest-content.use-case';
+import { IngestBulkContentUseCase } from './application/use-cases/ingest-bulk-content/ingest-bulk-content.use-case';
 import { SearchContentUseCase } from './application/use-cases/search-content/search-content.use-case';
 import { DeleteContentUseCase } from './application/use-cases/delete-content/delete-content.use-case';
 import { DeleteContentsUseCase } from './application/use-cases/delete-contents/delete-contents.use-case';
@@ -46,6 +47,7 @@ import { ModelsModule } from 'src/domain/models/models.module';
 
     // Use Cases
     IngestContentUseCase,
+    IngestBulkContentUseCase,
     SearchContentUseCase,
     DeleteContentUseCase,
     DeleteContentsUseCase,
@@ -56,6 +58,7 @@ import { ModelsModule } from 'src/domain/models/models.module';
   exports: [
     ParentChildIndexerAdapter,
     IngestContentUseCase,
+    IngestBulkContentUseCase,
     SearchContentUseCase,
     DeleteContentUseCase,
     DeleteContentsUseCase,

--- a/ayunis-core-backend/src/domain/sources/application/use-cases/create-text-source/create-text-source.use-case.ts
+++ b/ayunis-core-backend/src/domain/sources/application/use-cases/create-text-source/create-text-source.use-case.ts
@@ -22,9 +22,9 @@ import { RetrieveUrlUseCase } from 'src/domain/retrievers/url-retrievers/applica
 import { IndexType } from 'src/domain/rag/indexers/domain/value-objects/index-type.enum';
 import { TextSourceContentChunk } from 'src/domain/sources/domain/source-content-chunk.entity';
 import { UUID } from 'crypto';
-import { IngestContentCommand } from 'src/domain/rag/indexers/application/use-cases/ingest-content/ingest-content.command';
+import { IngestBulkContentCommand } from 'src/domain/rag/indexers/application/use-cases/ingest-bulk-content/ingest-bulk-content.command';
 import { SplitTextUseCase } from 'src/domain/rag/splitters/application/use-cases/split-text/split-text.use-case';
-import { IngestContentUseCase } from 'src/domain/rag/indexers/application/use-cases/ingest-content/ingest-content.use-case';
+import { IngestBulkContentUseCase } from 'src/domain/rag/indexers/application/use-cases/ingest-bulk-content/ingest-bulk-content.use-case';
 import { DeleteContentUseCase } from 'src/domain/rag/indexers/application/use-cases/delete-content/delete-content.use-case';
 import { DeleteContentCommand } from 'src/domain/rag/indexers/application/use-cases/delete-content/delete-content.command';
 import { SplitTextCommand } from 'src/domain/rag/splitters/application/use-cases/split-text/split-text.command';
@@ -33,9 +33,6 @@ import { SourceRepository } from '../../ports/source.repository';
 import { RetrieveFileContentCommand } from 'src/domain/retrievers/file-retrievers/application/use-cases/retrieve-file-content/retrieve-file-content.command';
 import { RetrieveFileContentUseCase } from 'src/domain/retrievers/file-retrievers/application/use-cases/retrieve-file-content/retrieve-file-content.use-case';
 import { MIME_TYPES } from 'src/common/util/file-type';
-
-/** Max concurrent embedding API calls per source ingestion to avoid rate limits */
-const EMBEDDING_CONCURRENCY = 20;
 
 interface TextSourceWithContent {
   source: TextSource;
@@ -52,7 +49,7 @@ export class CreateTextSourceUseCase {
     private readonly contextService: ContextService,
     private readonly retrieveFileContentUseCase: RetrieveFileContentUseCase,
     private readonly splitTextUseCase: SplitTextUseCase,
-    private readonly ingestContentUseCase: IngestContentUseCase,
+    private readonly ingestBulkContentUseCase: IngestBulkContentUseCase,
     private readonly deleteContentUseCase: DeleteContentUseCase,
     private readonly sourceRepository: SourceRepository,
   ) {}
@@ -194,9 +191,10 @@ export class CreateTextSourceUseCase {
 
   /**
    * Index source content using the indexers module.
-   * Uses delete-once-then-parallel-ingest pattern to avoid race conditions
-   * while maintaining performance for parallel chunk processing.
-   * Concurrency is capped to avoid hitting embedding API rate limits.
+   * Uses bulk ingestion to minimize embedding API calls and DB round-trips:
+   * - Embedding model is resolved once (not per chunk)
+   * - All child chunk texts are embedded in batched API calls
+   * - All parent chunks are saved in a single DB write
    */
   private async indexSourceContentChunks(params: {
     sourceId: UUID;
@@ -205,30 +203,23 @@ export class CreateTextSourceUseCase {
   }): Promise<void> {
     this.logger.debug(`Indexing content for source: ${params.sourceId}`);
 
-    // Step 1: Delete any existing index entries for this source ONCE
+    // Step 1: Delete any existing index entries for this source
     // (handles re-upload/re-index scenarios, no-op for new sources)
     await this.deleteContentUseCase.execute(
       new DeleteContentCommand({ documentId: params.sourceId }),
     );
 
-    // Step 2: Ingest all chunks with bounded concurrency
-    // Safe because deletion is handled above, not in the ingest use case
-    const { default: pLimit } = await import('p-limit');
-    const limit = pLimit(EMBEDDING_CONCURRENCY);
-    await Promise.all(
-      params.chunks.map((chunk) =>
-        limit(async () => {
-          const ingestCommand = new IngestContentCommand({
-            orgId: params.orgId,
-            documentId: params.sourceId,
-            chunkId: chunk.id,
-            content: chunk.content,
-            type: IndexType.PARENT_CHILD,
-          });
-
-          await this.ingestContentUseCase.execute(ingestCommand);
-        }),
-      ),
+    // Step 2: Bulk ingest all chunks in one operation
+    await this.ingestBulkContentUseCase.execute(
+      new IngestBulkContentCommand({
+        orgId: params.orgId,
+        entries: params.chunks.map((chunk) => ({
+          documentId: params.sourceId,
+          chunkId: chunk.id,
+          content: chunk.content,
+        })),
+        type: IndexType.PARENT_CHILD,
+      }),
     );
 
     this.logger.debug(

--- a/ayunis-core-frontend/src/app/routeTree.gen.ts
+++ b/ayunis-core-frontend/src/app/routeTree.gen.ts
@@ -8,647 +8,883 @@
 // You should NOT make any changes in this file as it will be overwritten.
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
-// Import Routes
+import { Route as rootRouteImport } from './routes/__root'
+import { Route as AuthenticatedRouteImport } from './routes/_authenticated'
+import { Route as IndexRouteImport } from './routes/index'
+import { Route as AuthenticatedInstallRouteImport } from './routes/_authenticated/install'
+import { Route as onboardingRegisterRouteImport } from './routes/(onboarding)/register'
+import { Route as onboardingLoginRouteImport } from './routes/(onboarding)/login'
+import { Route as onboardingIpBlockedRouteImport } from './routes/(onboarding)/ip-blocked'
+import { Route as onboardingEmailConfirmRouteImport } from './routes/(onboarding)/email-confirm'
+import { Route as onboardingConfirmEmailRouteImport } from './routes/(onboarding)/confirm-email'
+import { Route as onboardingAcceptInviteRouteImport } from './routes/(onboarding)/accept-invite'
+import { Route as AuthenticatedSuperAdminSettingsIndexRouteImport } from './routes/_authenticated/super-admin-settings.index'
+import { Route as AuthenticatedSkillsIndexRouteImport } from './routes/_authenticated/skills.index'
+import { Route as AuthenticatedSettingsIndexRouteImport } from './routes/_authenticated/settings.index'
+import { Route as AuthenticatedPromptsIndexRouteImport } from './routes/_authenticated/prompts.index'
+import { Route as AuthenticatedKnowledgeBasesIndexRouteImport } from './routes/_authenticated/knowledge-bases.index'
+import { Route as AuthenticatedChatsIndexRouteImport } from './routes/_authenticated/chats.index'
+import { Route as AuthenticatedChatIndexRouteImport } from './routes/_authenticated/chat.index'
+import { Route as AuthenticatedAgentsIndexRouteImport } from './routes/_authenticated/agents.index'
+import { Route as AuthenticatedAdminSettingsIndexRouteImport } from './routes/_authenticated/admin-settings.index'
+import { Route as AuthenticatedSkillsIdRouteImport } from './routes/_authenticated/skills.$id'
+import { Route as AuthenticatedSettingsGeneralRouteImport } from './routes/_authenticated/settings.general'
+import { Route as AuthenticatedSettingsChatRouteImport } from './routes/_authenticated/settings.chat'
+import { Route as AuthenticatedSettingsAccountRouteImport } from './routes/_authenticated/settings.account'
+import { Route as AuthenticatedKnowledgeBasesIdRouteImport } from './routes/_authenticated/knowledge-bases.$id'
+import { Route as AuthenticatedChatsThreadIdRouteImport } from './routes/_authenticated/chats.$threadId'
+import { Route as AuthenticatedAgentsIdRouteImport } from './routes/_authenticated/agents.$id'
+import { Route as AuthenticatedAdminSettingsUsersRouteImport } from './routes/_authenticated/admin-settings.users'
+import { Route as AuthenticatedAdminSettingsUsageRouteImport } from './routes/_authenticated/admin-settings.usage'
+import { Route as AuthenticatedAdminSettingsSecurityRouteImport } from './routes/_authenticated/admin-settings.security'
+import { Route as AuthenticatedAdminSettingsModelsRouteImport } from './routes/_authenticated/admin-settings.models'
+import { Route as AuthenticatedAdminSettingsIntegrationsRouteImport } from './routes/_authenticated/admin-settings.integrations'
+import { Route as onboardingPasswordResetRouteImport } from './routes/(onboarding)/password.reset'
+import { Route as onboardingPasswordForgotRouteImport } from './routes/(onboarding)/password.forgot'
+import { Route as AuthenticatedSuperAdminSettingsUsageIndexRouteImport } from './routes/_authenticated/super-admin-settings.usage.index'
+import { Route as AuthenticatedSuperAdminSettingsSuperAdminsIndexRouteImport } from './routes/_authenticated/super-admin-settings.super-admins.index'
+import { Route as AuthenticatedSuperAdminSettingsSkillsIndexRouteImport } from './routes/_authenticated/super-admin-settings.skills.index'
+import { Route as AuthenticatedSuperAdminSettingsPlatformConfigIndexRouteImport } from './routes/_authenticated/super-admin-settings.platform-config.index'
+import { Route as AuthenticatedSuperAdminSettingsOrgsIndexRouteImport } from './routes/_authenticated/super-admin-settings.orgs.index'
+import { Route as AuthenticatedSuperAdminSettingsModelsCatalogIndexRouteImport } from './routes/_authenticated/super-admin-settings.models-catalog.index'
+import { Route as AuthenticatedAdminSettingsTeamsIndexRouteImport } from './routes/_authenticated/admin-settings.teams.index'
+import { Route as AuthenticatedAdminSettingsLetterheadsIndexRouteImport } from './routes/_authenticated/admin-settings.letterheads.index'
+import { Route as AuthenticatedSuperAdminSettingsOrgsIdRouteImport } from './routes/_authenticated/super-admin-settings.orgs.$id'
+import { Route as AuthenticatedAdminSettingsTeamsIdRouteImport } from './routes/_authenticated/admin-settings.teams.$id'
+import { Route as AuthenticatedAdminSettingsLetterheadsIdRouteImport } from './routes/_authenticated/admin-settings.letterheads.$id'
 
-import { Route as rootRoute } from './routes/__root'
-import { Route as AuthenticatedImport } from './routes/_authenticated'
-import { Route as IndexImport } from './routes/index'
-import { Route as AuthenticatedInstallImport } from './routes/_authenticated/install'
-import { Route as onboardingRegisterImport } from './routes/(onboarding)/register'
-import { Route as onboardingLoginImport } from './routes/(onboarding)/login'
-import { Route as onboardingIpBlockedImport } from './routes/(onboarding)/ip-blocked'
-import { Route as onboardingEmailConfirmImport } from './routes/(onboarding)/email-confirm'
-import { Route as onboardingConfirmEmailImport } from './routes/(onboarding)/confirm-email'
-import { Route as onboardingAcceptInviteImport } from './routes/(onboarding)/accept-invite'
-import { Route as AuthenticatedSuperAdminSettingsIndexImport } from './routes/_authenticated/super-admin-settings.index'
-import { Route as AuthenticatedSkillsIndexImport } from './routes/_authenticated/skills.index'
-import { Route as AuthenticatedSettingsIndexImport } from './routes/_authenticated/settings.index'
-import { Route as AuthenticatedPromptsIndexImport } from './routes/_authenticated/prompts.index'
-import { Route as AuthenticatedKnowledgeBasesIndexImport } from './routes/_authenticated/knowledge-bases.index'
-import { Route as AuthenticatedChatsIndexImport } from './routes/_authenticated/chats.index'
-import { Route as AuthenticatedChatIndexImport } from './routes/_authenticated/chat.index'
-import { Route as AuthenticatedAgentsIndexImport } from './routes/_authenticated/agents.index'
-import { Route as AuthenticatedAdminSettingsIndexImport } from './routes/_authenticated/admin-settings.index'
-import { Route as AuthenticatedSkillsIdImport } from './routes/_authenticated/skills.$id'
-import { Route as AuthenticatedSettingsGeneralImport } from './routes/_authenticated/settings.general'
-import { Route as AuthenticatedSettingsChatImport } from './routes/_authenticated/settings.chat'
-import { Route as AuthenticatedSettingsAccountImport } from './routes/_authenticated/settings.account'
-import { Route as AuthenticatedKnowledgeBasesIdImport } from './routes/_authenticated/knowledge-bases.$id'
-import { Route as AuthenticatedChatsThreadIdImport } from './routes/_authenticated/chats.$threadId'
-import { Route as AuthenticatedAgentsIdImport } from './routes/_authenticated/agents.$id'
-import { Route as AuthenticatedAdminSettingsUsersImport } from './routes/_authenticated/admin-settings.users'
-import { Route as AuthenticatedAdminSettingsUsageImport } from './routes/_authenticated/admin-settings.usage'
-import { Route as AuthenticatedAdminSettingsSecurityImport } from './routes/_authenticated/admin-settings.security'
-import { Route as AuthenticatedAdminSettingsModelsImport } from './routes/_authenticated/admin-settings.models'
-import { Route as AuthenticatedAdminSettingsIntegrationsImport } from './routes/_authenticated/admin-settings.integrations'
-import { Route as onboardingPasswordResetImport } from './routes/(onboarding)/password.reset'
-import { Route as onboardingPasswordForgotImport } from './routes/(onboarding)/password.forgot'
-import { Route as AuthenticatedSuperAdminSettingsUsageIndexImport } from './routes/_authenticated/super-admin-settings.usage.index'
-import { Route as AuthenticatedSuperAdminSettingsSuperAdminsIndexImport } from './routes/_authenticated/super-admin-settings.super-admins.index'
-import { Route as AuthenticatedSuperAdminSettingsSkillsIndexImport } from './routes/_authenticated/super-admin-settings.skills.index'
-import { Route as AuthenticatedSuperAdminSettingsPlatformConfigIndexImport } from './routes/_authenticated/super-admin-settings.platform-config.index'
-import { Route as AuthenticatedSuperAdminSettingsOrgsIndexImport } from './routes/_authenticated/super-admin-settings.orgs.index'
-import { Route as AuthenticatedSuperAdminSettingsModelsCatalogIndexImport } from './routes/_authenticated/super-admin-settings.models-catalog.index'
-import { Route as AuthenticatedAdminSettingsTeamsIndexImport } from './routes/_authenticated/admin-settings.teams.index'
-import { Route as AuthenticatedAdminSettingsLetterheadsIndexImport } from './routes/_authenticated/admin-settings.letterheads.index'
-import { Route as AuthenticatedSuperAdminSettingsOrgsIdImport } from './routes/_authenticated/super-admin-settings.orgs.$id'
-import { Route as AuthenticatedAdminSettingsTeamsIdImport } from './routes/_authenticated/admin-settings.teams.$id'
-import { Route as AuthenticatedAdminSettingsLetterheadsIdImport } from './routes/_authenticated/admin-settings.letterheads.$id'
-
-// Create/Update Routes
-
-const AuthenticatedRoute = AuthenticatedImport.update({
+const AuthenticatedRoute = AuthenticatedRouteImport.update({
   id: '/_authenticated',
-  getParentRoute: () => rootRoute,
+  getParentRoute: () => rootRouteImport,
 } as any)
-
-const IndexRoute = IndexImport.update({
+const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
-  getParentRoute: () => rootRoute,
+  getParentRoute: () => rootRouteImport,
 } as any)
-
-const AuthenticatedInstallRoute = AuthenticatedInstallImport.update({
+const AuthenticatedInstallRoute = AuthenticatedInstallRouteImport.update({
   id: '/install',
   path: '/install',
   getParentRoute: () => AuthenticatedRoute,
 } as any)
-
-const onboardingRegisterRoute = onboardingRegisterImport.update({
+const onboardingRegisterRoute = onboardingRegisterRouteImport.update({
   id: '/(onboarding)/register',
   path: '/register',
-  getParentRoute: () => rootRoute,
+  getParentRoute: () => rootRouteImport,
 } as any)
-
-const onboardingLoginRoute = onboardingLoginImport.update({
+const onboardingLoginRoute = onboardingLoginRouteImport.update({
   id: '/(onboarding)/login',
   path: '/login',
-  getParentRoute: () => rootRoute,
+  getParentRoute: () => rootRouteImport,
 } as any)
-
-const onboardingIpBlockedRoute = onboardingIpBlockedImport.update({
+const onboardingIpBlockedRoute = onboardingIpBlockedRouteImport.update({
   id: '/(onboarding)/ip-blocked',
   path: '/ip-blocked',
-  getParentRoute: () => rootRoute,
+  getParentRoute: () => rootRouteImport,
 } as any)
-
-const onboardingEmailConfirmRoute = onboardingEmailConfirmImport.update({
+const onboardingEmailConfirmRoute = onboardingEmailConfirmRouteImport.update({
   id: '/(onboarding)/email-confirm',
   path: '/email-confirm',
-  getParentRoute: () => rootRoute,
+  getParentRoute: () => rootRouteImport,
 } as any)
-
-const onboardingConfirmEmailRoute = onboardingConfirmEmailImport.update({
+const onboardingConfirmEmailRoute = onboardingConfirmEmailRouteImport.update({
   id: '/(onboarding)/confirm-email',
   path: '/confirm-email',
-  getParentRoute: () => rootRoute,
+  getParentRoute: () => rootRouteImport,
 } as any)
-
-const onboardingAcceptInviteRoute = onboardingAcceptInviteImport.update({
+const onboardingAcceptInviteRoute = onboardingAcceptInviteRouteImport.update({
   id: '/(onboarding)/accept-invite',
   path: '/accept-invite',
-  getParentRoute: () => rootRoute,
+  getParentRoute: () => rootRouteImport,
 } as any)
-
 const AuthenticatedSuperAdminSettingsIndexRoute =
-  AuthenticatedSuperAdminSettingsIndexImport.update({
+  AuthenticatedSuperAdminSettingsIndexRouteImport.update({
     id: '/super-admin-settings/',
     path: '/super-admin-settings/',
     getParentRoute: () => AuthenticatedRoute,
   } as any)
-
-const AuthenticatedSkillsIndexRoute = AuthenticatedSkillsIndexImport.update({
-  id: '/skills/',
-  path: '/skills/',
-  getParentRoute: () => AuthenticatedRoute,
-} as any)
-
-const AuthenticatedSettingsIndexRoute = AuthenticatedSettingsIndexImport.update(
-  {
+const AuthenticatedSkillsIndexRoute =
+  AuthenticatedSkillsIndexRouteImport.update({
+    id: '/skills/',
+    path: '/skills/',
+    getParentRoute: () => AuthenticatedRoute,
+  } as any)
+const AuthenticatedSettingsIndexRoute =
+  AuthenticatedSettingsIndexRouteImport.update({
     id: '/settings/',
     path: '/settings/',
     getParentRoute: () => AuthenticatedRoute,
-  } as any,
-)
-
-const AuthenticatedPromptsIndexRoute = AuthenticatedPromptsIndexImport.update({
-  id: '/prompts/',
-  path: '/prompts/',
-  getParentRoute: () => AuthenticatedRoute,
-} as any)
-
+  } as any)
+const AuthenticatedPromptsIndexRoute =
+  AuthenticatedPromptsIndexRouteImport.update({
+    id: '/prompts/',
+    path: '/prompts/',
+    getParentRoute: () => AuthenticatedRoute,
+  } as any)
 const AuthenticatedKnowledgeBasesIndexRoute =
-  AuthenticatedKnowledgeBasesIndexImport.update({
+  AuthenticatedKnowledgeBasesIndexRouteImport.update({
     id: '/knowledge-bases/',
     path: '/knowledge-bases/',
     getParentRoute: () => AuthenticatedRoute,
   } as any)
-
-const AuthenticatedChatsIndexRoute = AuthenticatedChatsIndexImport.update({
+const AuthenticatedChatsIndexRoute = AuthenticatedChatsIndexRouteImport.update({
   id: '/chats/',
   path: '/chats/',
   getParentRoute: () => AuthenticatedRoute,
 } as any)
-
-const AuthenticatedChatIndexRoute = AuthenticatedChatIndexImport.update({
+const AuthenticatedChatIndexRoute = AuthenticatedChatIndexRouteImport.update({
   id: '/chat/',
   path: '/chat/',
   getParentRoute: () => AuthenticatedRoute,
 } as any)
-
-const AuthenticatedAgentsIndexRoute = AuthenticatedAgentsIndexImport.update({
-  id: '/agents/',
-  path: '/agents/',
-  getParentRoute: () => AuthenticatedRoute,
-} as any)
-
+const AuthenticatedAgentsIndexRoute =
+  AuthenticatedAgentsIndexRouteImport.update({
+    id: '/agents/',
+    path: '/agents/',
+    getParentRoute: () => AuthenticatedRoute,
+  } as any)
 const AuthenticatedAdminSettingsIndexRoute =
-  AuthenticatedAdminSettingsIndexImport.update({
+  AuthenticatedAdminSettingsIndexRouteImport.update({
     id: '/admin-settings/',
     path: '/admin-settings/',
     getParentRoute: () => AuthenticatedRoute,
   } as any)
-
-const AuthenticatedSkillsIdRoute = AuthenticatedSkillsIdImport.update({
+const AuthenticatedSkillsIdRoute = AuthenticatedSkillsIdRouteImport.update({
   id: '/skills/$id',
   path: '/skills/$id',
   getParentRoute: () => AuthenticatedRoute,
 } as any)
-
 const AuthenticatedSettingsGeneralRoute =
-  AuthenticatedSettingsGeneralImport.update({
+  AuthenticatedSettingsGeneralRouteImport.update({
     id: '/settings/general',
     path: '/settings/general',
     getParentRoute: () => AuthenticatedRoute,
   } as any)
-
-const AuthenticatedSettingsChatRoute = AuthenticatedSettingsChatImport.update({
-  id: '/settings/chat',
-  path: '/settings/chat',
-  getParentRoute: () => AuthenticatedRoute,
-} as any)
-
+const AuthenticatedSettingsChatRoute =
+  AuthenticatedSettingsChatRouteImport.update({
+    id: '/settings/chat',
+    path: '/settings/chat',
+    getParentRoute: () => AuthenticatedRoute,
+  } as any)
 const AuthenticatedSettingsAccountRoute =
-  AuthenticatedSettingsAccountImport.update({
+  AuthenticatedSettingsAccountRouteImport.update({
     id: '/settings/account',
     path: '/settings/account',
     getParentRoute: () => AuthenticatedRoute,
   } as any)
-
 const AuthenticatedKnowledgeBasesIdRoute =
-  AuthenticatedKnowledgeBasesIdImport.update({
+  AuthenticatedKnowledgeBasesIdRouteImport.update({
     id: '/knowledge-bases/$id',
     path: '/knowledge-bases/$id',
     getParentRoute: () => AuthenticatedRoute,
   } as any)
-
-const AuthenticatedChatsThreadIdRoute = AuthenticatedChatsThreadIdImport.update(
-  {
+const AuthenticatedChatsThreadIdRoute =
+  AuthenticatedChatsThreadIdRouteImport.update({
     id: '/chats/$threadId',
     path: '/chats/$threadId',
     getParentRoute: () => AuthenticatedRoute,
-  } as any,
-)
-
-const AuthenticatedAgentsIdRoute = AuthenticatedAgentsIdImport.update({
+  } as any)
+const AuthenticatedAgentsIdRoute = AuthenticatedAgentsIdRouteImport.update({
   id: '/agents/$id',
   path: '/agents/$id',
   getParentRoute: () => AuthenticatedRoute,
 } as any)
-
 const AuthenticatedAdminSettingsUsersRoute =
-  AuthenticatedAdminSettingsUsersImport.update({
+  AuthenticatedAdminSettingsUsersRouteImport.update({
     id: '/admin-settings/users',
     path: '/admin-settings/users',
     getParentRoute: () => AuthenticatedRoute,
   } as any)
-
 const AuthenticatedAdminSettingsUsageRoute =
-  AuthenticatedAdminSettingsUsageImport.update({
+  AuthenticatedAdminSettingsUsageRouteImport.update({
     id: '/admin-settings/usage',
     path: '/admin-settings/usage',
     getParentRoute: () => AuthenticatedRoute,
   } as any)
-
 const AuthenticatedAdminSettingsSecurityRoute =
-  AuthenticatedAdminSettingsSecurityImport.update({
+  AuthenticatedAdminSettingsSecurityRouteImport.update({
     id: '/admin-settings/security',
     path: '/admin-settings/security',
     getParentRoute: () => AuthenticatedRoute,
   } as any)
-
 const AuthenticatedAdminSettingsModelsRoute =
-  AuthenticatedAdminSettingsModelsImport.update({
+  AuthenticatedAdminSettingsModelsRouteImport.update({
     id: '/admin-settings/models',
     path: '/admin-settings/models',
     getParentRoute: () => AuthenticatedRoute,
   } as any)
-
 const AuthenticatedAdminSettingsIntegrationsRoute =
-  AuthenticatedAdminSettingsIntegrationsImport.update({
+  AuthenticatedAdminSettingsIntegrationsRouteImport.update({
     id: '/admin-settings/integrations',
     path: '/admin-settings/integrations',
     getParentRoute: () => AuthenticatedRoute,
   } as any)
-
-const onboardingPasswordResetRoute = onboardingPasswordResetImport.update({
+const onboardingPasswordResetRoute = onboardingPasswordResetRouteImport.update({
   id: '/(onboarding)/password/reset',
   path: '/password/reset',
-  getParentRoute: () => rootRoute,
+  getParentRoute: () => rootRouteImport,
 } as any)
-
-const onboardingPasswordForgotRoute = onboardingPasswordForgotImport.update({
-  id: '/(onboarding)/password/forgot',
-  path: '/password/forgot',
-  getParentRoute: () => rootRoute,
-} as any)
-
+const onboardingPasswordForgotRoute =
+  onboardingPasswordForgotRouteImport.update({
+    id: '/(onboarding)/password/forgot',
+    path: '/password/forgot',
+    getParentRoute: () => rootRouteImport,
+  } as any)
 const AuthenticatedSuperAdminSettingsUsageIndexRoute =
-  AuthenticatedSuperAdminSettingsUsageIndexImport.update({
+  AuthenticatedSuperAdminSettingsUsageIndexRouteImport.update({
     id: '/super-admin-settings/usage/',
     path: '/super-admin-settings/usage/',
     getParentRoute: () => AuthenticatedRoute,
   } as any)
-
 const AuthenticatedSuperAdminSettingsSuperAdminsIndexRoute =
-  AuthenticatedSuperAdminSettingsSuperAdminsIndexImport.update({
+  AuthenticatedSuperAdminSettingsSuperAdminsIndexRouteImport.update({
     id: '/super-admin-settings/super-admins/',
     path: '/super-admin-settings/super-admins/',
     getParentRoute: () => AuthenticatedRoute,
   } as any)
-
 const AuthenticatedSuperAdminSettingsSkillsIndexRoute =
-  AuthenticatedSuperAdminSettingsSkillsIndexImport.update({
+  AuthenticatedSuperAdminSettingsSkillsIndexRouteImport.update({
     id: '/super-admin-settings/skills/',
     path: '/super-admin-settings/skills/',
     getParentRoute: () => AuthenticatedRoute,
   } as any)
-
 const AuthenticatedSuperAdminSettingsPlatformConfigIndexRoute =
-  AuthenticatedSuperAdminSettingsPlatformConfigIndexImport.update({
+  AuthenticatedSuperAdminSettingsPlatformConfigIndexRouteImport.update({
     id: '/super-admin-settings/platform-config/',
     path: '/super-admin-settings/platform-config/',
     getParentRoute: () => AuthenticatedRoute,
   } as any)
-
 const AuthenticatedSuperAdminSettingsOrgsIndexRoute =
-  AuthenticatedSuperAdminSettingsOrgsIndexImport.update({
+  AuthenticatedSuperAdminSettingsOrgsIndexRouteImport.update({
     id: '/super-admin-settings/orgs/',
     path: '/super-admin-settings/orgs/',
     getParentRoute: () => AuthenticatedRoute,
   } as any)
-
 const AuthenticatedSuperAdminSettingsModelsCatalogIndexRoute =
-  AuthenticatedSuperAdminSettingsModelsCatalogIndexImport.update({
+  AuthenticatedSuperAdminSettingsModelsCatalogIndexRouteImport.update({
     id: '/super-admin-settings/models-catalog/',
     path: '/super-admin-settings/models-catalog/',
     getParentRoute: () => AuthenticatedRoute,
   } as any)
-
 const AuthenticatedAdminSettingsTeamsIndexRoute =
-  AuthenticatedAdminSettingsTeamsIndexImport.update({
+  AuthenticatedAdminSettingsTeamsIndexRouteImport.update({
     id: '/admin-settings/teams/',
     path: '/admin-settings/teams/',
     getParentRoute: () => AuthenticatedRoute,
   } as any)
-
 const AuthenticatedAdminSettingsLetterheadsIndexRoute =
-  AuthenticatedAdminSettingsLetterheadsIndexImport.update({
+  AuthenticatedAdminSettingsLetterheadsIndexRouteImport.update({
     id: '/admin-settings/letterheads/',
     path: '/admin-settings/letterheads/',
     getParentRoute: () => AuthenticatedRoute,
   } as any)
-
 const AuthenticatedSuperAdminSettingsOrgsIdRoute =
-  AuthenticatedSuperAdminSettingsOrgsIdImport.update({
+  AuthenticatedSuperAdminSettingsOrgsIdRouteImport.update({
     id: '/super-admin-settings/orgs/$id',
     path: '/super-admin-settings/orgs/$id',
     getParentRoute: () => AuthenticatedRoute,
   } as any)
-
 const AuthenticatedAdminSettingsTeamsIdRoute =
-  AuthenticatedAdminSettingsTeamsIdImport.update({
+  AuthenticatedAdminSettingsTeamsIdRouteImport.update({
     id: '/admin-settings/teams/$id',
     path: '/admin-settings/teams/$id',
     getParentRoute: () => AuthenticatedRoute,
   } as any)
-
 const AuthenticatedAdminSettingsLetterheadsIdRoute =
-  AuthenticatedAdminSettingsLetterheadsIdImport.update({
+  AuthenticatedAdminSettingsLetterheadsIdRouteImport.update({
     id: '/admin-settings/letterheads/$id',
     path: '/admin-settings/letterheads/$id',
     getParentRoute: () => AuthenticatedRoute,
   } as any)
 
-// Populate the FileRoutesByPath interface
+export interface FileRoutesByFullPath {
+  '/': typeof IndexRoute
+  '/accept-invite': typeof onboardingAcceptInviteRoute
+  '/confirm-email': typeof onboardingConfirmEmailRoute
+  '/email-confirm': typeof onboardingEmailConfirmRoute
+  '/ip-blocked': typeof onboardingIpBlockedRoute
+  '/login': typeof onboardingLoginRoute
+  '/register': typeof onboardingRegisterRoute
+  '/install': typeof AuthenticatedInstallRoute
+  '/password/forgot': typeof onboardingPasswordForgotRoute
+  '/password/reset': typeof onboardingPasswordResetRoute
+  '/admin-settings/integrations': typeof AuthenticatedAdminSettingsIntegrationsRoute
+  '/admin-settings/models': typeof AuthenticatedAdminSettingsModelsRoute
+  '/admin-settings/security': typeof AuthenticatedAdminSettingsSecurityRoute
+  '/admin-settings/usage': typeof AuthenticatedAdminSettingsUsageRoute
+  '/admin-settings/users': typeof AuthenticatedAdminSettingsUsersRoute
+  '/agents/$id': typeof AuthenticatedAgentsIdRoute
+  '/chats/$threadId': typeof AuthenticatedChatsThreadIdRoute
+  '/knowledge-bases/$id': typeof AuthenticatedKnowledgeBasesIdRoute
+  '/settings/account': typeof AuthenticatedSettingsAccountRoute
+  '/settings/chat': typeof AuthenticatedSettingsChatRoute
+  '/settings/general': typeof AuthenticatedSettingsGeneralRoute
+  '/skills/$id': typeof AuthenticatedSkillsIdRoute
+  '/admin-settings/': typeof AuthenticatedAdminSettingsIndexRoute
+  '/agents/': typeof AuthenticatedAgentsIndexRoute
+  '/chat/': typeof AuthenticatedChatIndexRoute
+  '/chats/': typeof AuthenticatedChatsIndexRoute
+  '/knowledge-bases/': typeof AuthenticatedKnowledgeBasesIndexRoute
+  '/prompts/': typeof AuthenticatedPromptsIndexRoute
+  '/settings/': typeof AuthenticatedSettingsIndexRoute
+  '/skills/': typeof AuthenticatedSkillsIndexRoute
+  '/super-admin-settings/': typeof AuthenticatedSuperAdminSettingsIndexRoute
+  '/admin-settings/letterheads/$id': typeof AuthenticatedAdminSettingsLetterheadsIdRoute
+  '/admin-settings/teams/$id': typeof AuthenticatedAdminSettingsTeamsIdRoute
+  '/super-admin-settings/orgs/$id': typeof AuthenticatedSuperAdminSettingsOrgsIdRoute
+  '/admin-settings/letterheads/': typeof AuthenticatedAdminSettingsLetterheadsIndexRoute
+  '/admin-settings/teams/': typeof AuthenticatedAdminSettingsTeamsIndexRoute
+  '/super-admin-settings/models-catalog/': typeof AuthenticatedSuperAdminSettingsModelsCatalogIndexRoute
+  '/super-admin-settings/orgs/': typeof AuthenticatedSuperAdminSettingsOrgsIndexRoute
+  '/super-admin-settings/platform-config/': typeof AuthenticatedSuperAdminSettingsPlatformConfigIndexRoute
+  '/super-admin-settings/skills/': typeof AuthenticatedSuperAdminSettingsSkillsIndexRoute
+  '/super-admin-settings/super-admins/': typeof AuthenticatedSuperAdminSettingsSuperAdminsIndexRoute
+  '/super-admin-settings/usage/': typeof AuthenticatedSuperAdminSettingsUsageIndexRoute
+}
+export interface FileRoutesByTo {
+  '/': typeof IndexRoute
+  '/accept-invite': typeof onboardingAcceptInviteRoute
+  '/confirm-email': typeof onboardingConfirmEmailRoute
+  '/email-confirm': typeof onboardingEmailConfirmRoute
+  '/ip-blocked': typeof onboardingIpBlockedRoute
+  '/login': typeof onboardingLoginRoute
+  '/register': typeof onboardingRegisterRoute
+  '/install': typeof AuthenticatedInstallRoute
+  '/password/forgot': typeof onboardingPasswordForgotRoute
+  '/password/reset': typeof onboardingPasswordResetRoute
+  '/admin-settings/integrations': typeof AuthenticatedAdminSettingsIntegrationsRoute
+  '/admin-settings/models': typeof AuthenticatedAdminSettingsModelsRoute
+  '/admin-settings/security': typeof AuthenticatedAdminSettingsSecurityRoute
+  '/admin-settings/usage': typeof AuthenticatedAdminSettingsUsageRoute
+  '/admin-settings/users': typeof AuthenticatedAdminSettingsUsersRoute
+  '/agents/$id': typeof AuthenticatedAgentsIdRoute
+  '/chats/$threadId': typeof AuthenticatedChatsThreadIdRoute
+  '/knowledge-bases/$id': typeof AuthenticatedKnowledgeBasesIdRoute
+  '/settings/account': typeof AuthenticatedSettingsAccountRoute
+  '/settings/chat': typeof AuthenticatedSettingsChatRoute
+  '/settings/general': typeof AuthenticatedSettingsGeneralRoute
+  '/skills/$id': typeof AuthenticatedSkillsIdRoute
+  '/admin-settings': typeof AuthenticatedAdminSettingsIndexRoute
+  '/agents': typeof AuthenticatedAgentsIndexRoute
+  '/chat': typeof AuthenticatedChatIndexRoute
+  '/chats': typeof AuthenticatedChatsIndexRoute
+  '/knowledge-bases': typeof AuthenticatedKnowledgeBasesIndexRoute
+  '/prompts': typeof AuthenticatedPromptsIndexRoute
+  '/settings': typeof AuthenticatedSettingsIndexRoute
+  '/skills': typeof AuthenticatedSkillsIndexRoute
+  '/super-admin-settings': typeof AuthenticatedSuperAdminSettingsIndexRoute
+  '/admin-settings/letterheads/$id': typeof AuthenticatedAdminSettingsLetterheadsIdRoute
+  '/admin-settings/teams/$id': typeof AuthenticatedAdminSettingsTeamsIdRoute
+  '/super-admin-settings/orgs/$id': typeof AuthenticatedSuperAdminSettingsOrgsIdRoute
+  '/admin-settings/letterheads': typeof AuthenticatedAdminSettingsLetterheadsIndexRoute
+  '/admin-settings/teams': typeof AuthenticatedAdminSettingsTeamsIndexRoute
+  '/super-admin-settings/models-catalog': typeof AuthenticatedSuperAdminSettingsModelsCatalogIndexRoute
+  '/super-admin-settings/orgs': typeof AuthenticatedSuperAdminSettingsOrgsIndexRoute
+  '/super-admin-settings/platform-config': typeof AuthenticatedSuperAdminSettingsPlatformConfigIndexRoute
+  '/super-admin-settings/skills': typeof AuthenticatedSuperAdminSettingsSkillsIndexRoute
+  '/super-admin-settings/super-admins': typeof AuthenticatedSuperAdminSettingsSuperAdminsIndexRoute
+  '/super-admin-settings/usage': typeof AuthenticatedSuperAdminSettingsUsageIndexRoute
+}
+export interface FileRoutesById {
+  __root__: typeof rootRouteImport
+  '/': typeof IndexRoute
+  '/_authenticated': typeof AuthenticatedRouteWithChildren
+  '/(onboarding)/accept-invite': typeof onboardingAcceptInviteRoute
+  '/(onboarding)/confirm-email': typeof onboardingConfirmEmailRoute
+  '/(onboarding)/email-confirm': typeof onboardingEmailConfirmRoute
+  '/(onboarding)/ip-blocked': typeof onboardingIpBlockedRoute
+  '/(onboarding)/login': typeof onboardingLoginRoute
+  '/(onboarding)/register': typeof onboardingRegisterRoute
+  '/_authenticated/install': typeof AuthenticatedInstallRoute
+  '/(onboarding)/password/forgot': typeof onboardingPasswordForgotRoute
+  '/(onboarding)/password/reset': typeof onboardingPasswordResetRoute
+  '/_authenticated/admin-settings/integrations': typeof AuthenticatedAdminSettingsIntegrationsRoute
+  '/_authenticated/admin-settings/models': typeof AuthenticatedAdminSettingsModelsRoute
+  '/_authenticated/admin-settings/security': typeof AuthenticatedAdminSettingsSecurityRoute
+  '/_authenticated/admin-settings/usage': typeof AuthenticatedAdminSettingsUsageRoute
+  '/_authenticated/admin-settings/users': typeof AuthenticatedAdminSettingsUsersRoute
+  '/_authenticated/agents/$id': typeof AuthenticatedAgentsIdRoute
+  '/_authenticated/chats/$threadId': typeof AuthenticatedChatsThreadIdRoute
+  '/_authenticated/knowledge-bases/$id': typeof AuthenticatedKnowledgeBasesIdRoute
+  '/_authenticated/settings/account': typeof AuthenticatedSettingsAccountRoute
+  '/_authenticated/settings/chat': typeof AuthenticatedSettingsChatRoute
+  '/_authenticated/settings/general': typeof AuthenticatedSettingsGeneralRoute
+  '/_authenticated/skills/$id': typeof AuthenticatedSkillsIdRoute
+  '/_authenticated/admin-settings/': typeof AuthenticatedAdminSettingsIndexRoute
+  '/_authenticated/agents/': typeof AuthenticatedAgentsIndexRoute
+  '/_authenticated/chat/': typeof AuthenticatedChatIndexRoute
+  '/_authenticated/chats/': typeof AuthenticatedChatsIndexRoute
+  '/_authenticated/knowledge-bases/': typeof AuthenticatedKnowledgeBasesIndexRoute
+  '/_authenticated/prompts/': typeof AuthenticatedPromptsIndexRoute
+  '/_authenticated/settings/': typeof AuthenticatedSettingsIndexRoute
+  '/_authenticated/skills/': typeof AuthenticatedSkillsIndexRoute
+  '/_authenticated/super-admin-settings/': typeof AuthenticatedSuperAdminSettingsIndexRoute
+  '/_authenticated/admin-settings/letterheads/$id': typeof AuthenticatedAdminSettingsLetterheadsIdRoute
+  '/_authenticated/admin-settings/teams/$id': typeof AuthenticatedAdminSettingsTeamsIdRoute
+  '/_authenticated/super-admin-settings/orgs/$id': typeof AuthenticatedSuperAdminSettingsOrgsIdRoute
+  '/_authenticated/admin-settings/letterheads/': typeof AuthenticatedAdminSettingsLetterheadsIndexRoute
+  '/_authenticated/admin-settings/teams/': typeof AuthenticatedAdminSettingsTeamsIndexRoute
+  '/_authenticated/super-admin-settings/models-catalog/': typeof AuthenticatedSuperAdminSettingsModelsCatalogIndexRoute
+  '/_authenticated/super-admin-settings/orgs/': typeof AuthenticatedSuperAdminSettingsOrgsIndexRoute
+  '/_authenticated/super-admin-settings/platform-config/': typeof AuthenticatedSuperAdminSettingsPlatformConfigIndexRoute
+  '/_authenticated/super-admin-settings/skills/': typeof AuthenticatedSuperAdminSettingsSkillsIndexRoute
+  '/_authenticated/super-admin-settings/super-admins/': typeof AuthenticatedSuperAdminSettingsSuperAdminsIndexRoute
+  '/_authenticated/super-admin-settings/usage/': typeof AuthenticatedSuperAdminSettingsUsageIndexRoute
+}
+export interface FileRouteTypes {
+  fileRoutesByFullPath: FileRoutesByFullPath
+  fullPaths:
+    | '/'
+    | '/accept-invite'
+    | '/confirm-email'
+    | '/email-confirm'
+    | '/ip-blocked'
+    | '/login'
+    | '/register'
+    | '/install'
+    | '/password/forgot'
+    | '/password/reset'
+    | '/admin-settings/integrations'
+    | '/admin-settings/models'
+    | '/admin-settings/security'
+    | '/admin-settings/usage'
+    | '/admin-settings/users'
+    | '/agents/$id'
+    | '/chats/$threadId'
+    | '/knowledge-bases/$id'
+    | '/settings/account'
+    | '/settings/chat'
+    | '/settings/general'
+    | '/skills/$id'
+    | '/admin-settings/'
+    | '/agents/'
+    | '/chat/'
+    | '/chats/'
+    | '/knowledge-bases/'
+    | '/prompts/'
+    | '/settings/'
+    | '/skills/'
+    | '/super-admin-settings/'
+    | '/admin-settings/letterheads/$id'
+    | '/admin-settings/teams/$id'
+    | '/super-admin-settings/orgs/$id'
+    | '/admin-settings/letterheads/'
+    | '/admin-settings/teams/'
+    | '/super-admin-settings/models-catalog/'
+    | '/super-admin-settings/orgs/'
+    | '/super-admin-settings/platform-config/'
+    | '/super-admin-settings/skills/'
+    | '/super-admin-settings/super-admins/'
+    | '/super-admin-settings/usage/'
+  fileRoutesByTo: FileRoutesByTo
+  to:
+    | '/'
+    | '/accept-invite'
+    | '/confirm-email'
+    | '/email-confirm'
+    | '/ip-blocked'
+    | '/login'
+    | '/register'
+    | '/install'
+    | '/password/forgot'
+    | '/password/reset'
+    | '/admin-settings/integrations'
+    | '/admin-settings/models'
+    | '/admin-settings/security'
+    | '/admin-settings/usage'
+    | '/admin-settings/users'
+    | '/agents/$id'
+    | '/chats/$threadId'
+    | '/knowledge-bases/$id'
+    | '/settings/account'
+    | '/settings/chat'
+    | '/settings/general'
+    | '/skills/$id'
+    | '/admin-settings'
+    | '/agents'
+    | '/chat'
+    | '/chats'
+    | '/knowledge-bases'
+    | '/prompts'
+    | '/settings'
+    | '/skills'
+    | '/super-admin-settings'
+    | '/admin-settings/letterheads/$id'
+    | '/admin-settings/teams/$id'
+    | '/super-admin-settings/orgs/$id'
+    | '/admin-settings/letterheads'
+    | '/admin-settings/teams'
+    | '/super-admin-settings/models-catalog'
+    | '/super-admin-settings/orgs'
+    | '/super-admin-settings/platform-config'
+    | '/super-admin-settings/skills'
+    | '/super-admin-settings/super-admins'
+    | '/super-admin-settings/usage'
+  id:
+    | '__root__'
+    | '/'
+    | '/_authenticated'
+    | '/(onboarding)/accept-invite'
+    | '/(onboarding)/confirm-email'
+    | '/(onboarding)/email-confirm'
+    | '/(onboarding)/ip-blocked'
+    | '/(onboarding)/login'
+    | '/(onboarding)/register'
+    | '/_authenticated/install'
+    | '/(onboarding)/password/forgot'
+    | '/(onboarding)/password/reset'
+    | '/_authenticated/admin-settings/integrations'
+    | '/_authenticated/admin-settings/models'
+    | '/_authenticated/admin-settings/security'
+    | '/_authenticated/admin-settings/usage'
+    | '/_authenticated/admin-settings/users'
+    | '/_authenticated/agents/$id'
+    | '/_authenticated/chats/$threadId'
+    | '/_authenticated/knowledge-bases/$id'
+    | '/_authenticated/settings/account'
+    | '/_authenticated/settings/chat'
+    | '/_authenticated/settings/general'
+    | '/_authenticated/skills/$id'
+    | '/_authenticated/admin-settings/'
+    | '/_authenticated/agents/'
+    | '/_authenticated/chat/'
+    | '/_authenticated/chats/'
+    | '/_authenticated/knowledge-bases/'
+    | '/_authenticated/prompts/'
+    | '/_authenticated/settings/'
+    | '/_authenticated/skills/'
+    | '/_authenticated/super-admin-settings/'
+    | '/_authenticated/admin-settings/letterheads/$id'
+    | '/_authenticated/admin-settings/teams/$id'
+    | '/_authenticated/super-admin-settings/orgs/$id'
+    | '/_authenticated/admin-settings/letterheads/'
+    | '/_authenticated/admin-settings/teams/'
+    | '/_authenticated/super-admin-settings/models-catalog/'
+    | '/_authenticated/super-admin-settings/orgs/'
+    | '/_authenticated/super-admin-settings/platform-config/'
+    | '/_authenticated/super-admin-settings/skills/'
+    | '/_authenticated/super-admin-settings/super-admins/'
+    | '/_authenticated/super-admin-settings/usage/'
+  fileRoutesById: FileRoutesById
+}
+export interface RootRouteChildren {
+  IndexRoute: typeof IndexRoute
+  AuthenticatedRoute: typeof AuthenticatedRouteWithChildren
+  onboardingAcceptInviteRoute: typeof onboardingAcceptInviteRoute
+  onboardingConfirmEmailRoute: typeof onboardingConfirmEmailRoute
+  onboardingEmailConfirmRoute: typeof onboardingEmailConfirmRoute
+  onboardingIpBlockedRoute: typeof onboardingIpBlockedRoute
+  onboardingLoginRoute: typeof onboardingLoginRoute
+  onboardingRegisterRoute: typeof onboardingRegisterRoute
+  onboardingPasswordForgotRoute: typeof onboardingPasswordForgotRoute
+  onboardingPasswordResetRoute: typeof onboardingPasswordResetRoute
+}
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/_authenticated': {
+      id: '/_authenticated'
+      path: ''
+      fullPath: '/'
+      preLoaderRoute: typeof AuthenticatedRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/': {
       id: '/'
       path: '/'
       fullPath: '/'
-      preLoaderRoute: typeof IndexImport
-      parentRoute: typeof rootRoute
-    }
-    '/_authenticated': {
-      id: '/_authenticated'
-      path: ''
-      fullPath: ''
-      preLoaderRoute: typeof AuthenticatedImport
-      parentRoute: typeof rootRoute
-    }
-    '/(onboarding)/accept-invite': {
-      id: '/(onboarding)/accept-invite'
-      path: '/accept-invite'
-      fullPath: '/accept-invite'
-      preLoaderRoute: typeof onboardingAcceptInviteImport
-      parentRoute: typeof rootRoute
-    }
-    '/(onboarding)/confirm-email': {
-      id: '/(onboarding)/confirm-email'
-      path: '/confirm-email'
-      fullPath: '/confirm-email'
-      preLoaderRoute: typeof onboardingConfirmEmailImport
-      parentRoute: typeof rootRoute
-    }
-    '/(onboarding)/email-confirm': {
-      id: '/(onboarding)/email-confirm'
-      path: '/email-confirm'
-      fullPath: '/email-confirm'
-      preLoaderRoute: typeof onboardingEmailConfirmImport
-      parentRoute: typeof rootRoute
-    }
-    '/(onboarding)/ip-blocked': {
-      id: '/(onboarding)/ip-blocked'
-      path: '/ip-blocked'
-      fullPath: '/ip-blocked'
-      preLoaderRoute: typeof onboardingIpBlockedImport
-      parentRoute: typeof rootRoute
-    }
-    '/(onboarding)/login': {
-      id: '/(onboarding)/login'
-      path: '/login'
-      fullPath: '/login'
-      preLoaderRoute: typeof onboardingLoginImport
-      parentRoute: typeof rootRoute
-    }
-    '/(onboarding)/register': {
-      id: '/(onboarding)/register'
-      path: '/register'
-      fullPath: '/register'
-      preLoaderRoute: typeof onboardingRegisterImport
-      parentRoute: typeof rootRoute
+      preLoaderRoute: typeof IndexRouteImport
+      parentRoute: typeof rootRouteImport
     }
     '/_authenticated/install': {
       id: '/_authenticated/install'
       path: '/install'
       fullPath: '/install'
-      preLoaderRoute: typeof AuthenticatedInstallImport
-      parentRoute: typeof AuthenticatedImport
+      preLoaderRoute: typeof AuthenticatedInstallRouteImport
+      parentRoute: typeof AuthenticatedRoute
     }
-    '/(onboarding)/password/forgot': {
-      id: '/(onboarding)/password/forgot'
-      path: '/password/forgot'
-      fullPath: '/password/forgot'
-      preLoaderRoute: typeof onboardingPasswordForgotImport
-      parentRoute: typeof rootRoute
+    '/(onboarding)/register': {
+      id: '/(onboarding)/register'
+      path: '/register'
+      fullPath: '/register'
+      preLoaderRoute: typeof onboardingRegisterRouteImport
+      parentRoute: typeof rootRouteImport
     }
-    '/(onboarding)/password/reset': {
-      id: '/(onboarding)/password/reset'
-      path: '/password/reset'
-      fullPath: '/password/reset'
-      preLoaderRoute: typeof onboardingPasswordResetImport
-      parentRoute: typeof rootRoute
+    '/(onboarding)/login': {
+      id: '/(onboarding)/login'
+      path: '/login'
+      fullPath: '/login'
+      preLoaderRoute: typeof onboardingLoginRouteImport
+      parentRoute: typeof rootRouteImport
     }
-    '/_authenticated/admin-settings/integrations': {
-      id: '/_authenticated/admin-settings/integrations'
-      path: '/admin-settings/integrations'
-      fullPath: '/admin-settings/integrations'
-      preLoaderRoute: typeof AuthenticatedAdminSettingsIntegrationsImport
-      parentRoute: typeof AuthenticatedImport
+    '/(onboarding)/ip-blocked': {
+      id: '/(onboarding)/ip-blocked'
+      path: '/ip-blocked'
+      fullPath: '/ip-blocked'
+      preLoaderRoute: typeof onboardingIpBlockedRouteImport
+      parentRoute: typeof rootRouteImport
     }
-    '/_authenticated/admin-settings/models': {
-      id: '/_authenticated/admin-settings/models'
-      path: '/admin-settings/models'
-      fullPath: '/admin-settings/models'
-      preLoaderRoute: typeof AuthenticatedAdminSettingsModelsImport
-      parentRoute: typeof AuthenticatedImport
+    '/(onboarding)/email-confirm': {
+      id: '/(onboarding)/email-confirm'
+      path: '/email-confirm'
+      fullPath: '/email-confirm'
+      preLoaderRoute: typeof onboardingEmailConfirmRouteImport
+      parentRoute: typeof rootRouteImport
     }
-    '/_authenticated/admin-settings/security': {
-      id: '/_authenticated/admin-settings/security'
-      path: '/admin-settings/security'
-      fullPath: '/admin-settings/security'
-      preLoaderRoute: typeof AuthenticatedAdminSettingsSecurityImport
-      parentRoute: typeof AuthenticatedImport
+    '/(onboarding)/confirm-email': {
+      id: '/(onboarding)/confirm-email'
+      path: '/confirm-email'
+      fullPath: '/confirm-email'
+      preLoaderRoute: typeof onboardingConfirmEmailRouteImport
+      parentRoute: typeof rootRouteImport
     }
-    '/_authenticated/admin-settings/usage': {
-      id: '/_authenticated/admin-settings/usage'
-      path: '/admin-settings/usage'
-      fullPath: '/admin-settings/usage'
-      preLoaderRoute: typeof AuthenticatedAdminSettingsUsageImport
-      parentRoute: typeof AuthenticatedImport
+    '/(onboarding)/accept-invite': {
+      id: '/(onboarding)/accept-invite'
+      path: '/accept-invite'
+      fullPath: '/accept-invite'
+      preLoaderRoute: typeof onboardingAcceptInviteRouteImport
+      parentRoute: typeof rootRouteImport
     }
-    '/_authenticated/admin-settings/users': {
-      id: '/_authenticated/admin-settings/users'
-      path: '/admin-settings/users'
-      fullPath: '/admin-settings/users'
-      preLoaderRoute: typeof AuthenticatedAdminSettingsUsersImport
-      parentRoute: typeof AuthenticatedImport
+    '/_authenticated/super-admin-settings/': {
+      id: '/_authenticated/super-admin-settings/'
+      path: '/super-admin-settings'
+      fullPath: '/super-admin-settings/'
+      preLoaderRoute: typeof AuthenticatedSuperAdminSettingsIndexRouteImport
+      parentRoute: typeof AuthenticatedRoute
     }
-    '/_authenticated/agents/$id': {
-      id: '/_authenticated/agents/$id'
-      path: '/agents/$id'
-      fullPath: '/agents/$id'
-      preLoaderRoute: typeof AuthenticatedAgentsIdImport
-      parentRoute: typeof AuthenticatedImport
+    '/_authenticated/skills/': {
+      id: '/_authenticated/skills/'
+      path: '/skills'
+      fullPath: '/skills/'
+      preLoaderRoute: typeof AuthenticatedSkillsIndexRouteImport
+      parentRoute: typeof AuthenticatedRoute
     }
-    '/_authenticated/chats/$threadId': {
-      id: '/_authenticated/chats/$threadId'
-      path: '/chats/$threadId'
-      fullPath: '/chats/$threadId'
-      preLoaderRoute: typeof AuthenticatedChatsThreadIdImport
-      parentRoute: typeof AuthenticatedImport
+    '/_authenticated/settings/': {
+      id: '/_authenticated/settings/'
+      path: '/settings'
+      fullPath: '/settings/'
+      preLoaderRoute: typeof AuthenticatedSettingsIndexRouteImport
+      parentRoute: typeof AuthenticatedRoute
     }
-    '/_authenticated/knowledge-bases/$id': {
-      id: '/_authenticated/knowledge-bases/$id'
-      path: '/knowledge-bases/$id'
-      fullPath: '/knowledge-bases/$id'
-      preLoaderRoute: typeof AuthenticatedKnowledgeBasesIdImport
-      parentRoute: typeof AuthenticatedImport
+    '/_authenticated/prompts/': {
+      id: '/_authenticated/prompts/'
+      path: '/prompts'
+      fullPath: '/prompts/'
+      preLoaderRoute: typeof AuthenticatedPromptsIndexRouteImport
+      parentRoute: typeof AuthenticatedRoute
     }
-    '/_authenticated/settings/account': {
-      id: '/_authenticated/settings/account'
-      path: '/settings/account'
-      fullPath: '/settings/account'
-      preLoaderRoute: typeof AuthenticatedSettingsAccountImport
-      parentRoute: typeof AuthenticatedImport
+    '/_authenticated/knowledge-bases/': {
+      id: '/_authenticated/knowledge-bases/'
+      path: '/knowledge-bases'
+      fullPath: '/knowledge-bases/'
+      preLoaderRoute: typeof AuthenticatedKnowledgeBasesIndexRouteImport
+      parentRoute: typeof AuthenticatedRoute
     }
-    '/_authenticated/settings/chat': {
-      id: '/_authenticated/settings/chat'
-      path: '/settings/chat'
-      fullPath: '/settings/chat'
-      preLoaderRoute: typeof AuthenticatedSettingsChatImport
-      parentRoute: typeof AuthenticatedImport
+    '/_authenticated/chats/': {
+      id: '/_authenticated/chats/'
+      path: '/chats'
+      fullPath: '/chats/'
+      preLoaderRoute: typeof AuthenticatedChatsIndexRouteImport
+      parentRoute: typeof AuthenticatedRoute
     }
-    '/_authenticated/settings/general': {
-      id: '/_authenticated/settings/general'
-      path: '/settings/general'
-      fullPath: '/settings/general'
-      preLoaderRoute: typeof AuthenticatedSettingsGeneralImport
-      parentRoute: typeof AuthenticatedImport
+    '/_authenticated/chat/': {
+      id: '/_authenticated/chat/'
+      path: '/chat'
+      fullPath: '/chat/'
+      preLoaderRoute: typeof AuthenticatedChatIndexRouteImport
+      parentRoute: typeof AuthenticatedRoute
+    }
+    '/_authenticated/agents/': {
+      id: '/_authenticated/agents/'
+      path: '/agents'
+      fullPath: '/agents/'
+      preLoaderRoute: typeof AuthenticatedAgentsIndexRouteImport
+      parentRoute: typeof AuthenticatedRoute
+    }
+    '/_authenticated/admin-settings/': {
+      id: '/_authenticated/admin-settings/'
+      path: '/admin-settings'
+      fullPath: '/admin-settings/'
+      preLoaderRoute: typeof AuthenticatedAdminSettingsIndexRouteImport
+      parentRoute: typeof AuthenticatedRoute
     }
     '/_authenticated/skills/$id': {
       id: '/_authenticated/skills/$id'
       path: '/skills/$id'
       fullPath: '/skills/$id'
-      preLoaderRoute: typeof AuthenticatedSkillsIdImport
-      parentRoute: typeof AuthenticatedImport
+      preLoaderRoute: typeof AuthenticatedSkillsIdRouteImport
+      parentRoute: typeof AuthenticatedRoute
     }
-    '/_authenticated/admin-settings/': {
-      id: '/_authenticated/admin-settings/'
-      path: '/admin-settings'
-      fullPath: '/admin-settings'
-      preLoaderRoute: typeof AuthenticatedAdminSettingsIndexImport
-      parentRoute: typeof AuthenticatedImport
+    '/_authenticated/settings/general': {
+      id: '/_authenticated/settings/general'
+      path: '/settings/general'
+      fullPath: '/settings/general'
+      preLoaderRoute: typeof AuthenticatedSettingsGeneralRouteImport
+      parentRoute: typeof AuthenticatedRoute
     }
-    '/_authenticated/agents/': {
-      id: '/_authenticated/agents/'
-      path: '/agents'
-      fullPath: '/agents'
-      preLoaderRoute: typeof AuthenticatedAgentsIndexImport
-      parentRoute: typeof AuthenticatedImport
+    '/_authenticated/settings/chat': {
+      id: '/_authenticated/settings/chat'
+      path: '/settings/chat'
+      fullPath: '/settings/chat'
+      preLoaderRoute: typeof AuthenticatedSettingsChatRouteImport
+      parentRoute: typeof AuthenticatedRoute
     }
-    '/_authenticated/chat/': {
-      id: '/_authenticated/chat/'
-      path: '/chat'
-      fullPath: '/chat'
-      preLoaderRoute: typeof AuthenticatedChatIndexImport
-      parentRoute: typeof AuthenticatedImport
+    '/_authenticated/settings/account': {
+      id: '/_authenticated/settings/account'
+      path: '/settings/account'
+      fullPath: '/settings/account'
+      preLoaderRoute: typeof AuthenticatedSettingsAccountRouteImport
+      parentRoute: typeof AuthenticatedRoute
     }
-    '/_authenticated/chats/': {
-      id: '/_authenticated/chats/'
-      path: '/chats'
-      fullPath: '/chats'
-      preLoaderRoute: typeof AuthenticatedChatsIndexImport
-      parentRoute: typeof AuthenticatedImport
+    '/_authenticated/knowledge-bases/$id': {
+      id: '/_authenticated/knowledge-bases/$id'
+      path: '/knowledge-bases/$id'
+      fullPath: '/knowledge-bases/$id'
+      preLoaderRoute: typeof AuthenticatedKnowledgeBasesIdRouteImport
+      parentRoute: typeof AuthenticatedRoute
     }
-    '/_authenticated/knowledge-bases/': {
-      id: '/_authenticated/knowledge-bases/'
-      path: '/knowledge-bases'
-      fullPath: '/knowledge-bases'
-      preLoaderRoute: typeof AuthenticatedKnowledgeBasesIndexImport
-      parentRoute: typeof AuthenticatedImport
+    '/_authenticated/chats/$threadId': {
+      id: '/_authenticated/chats/$threadId'
+      path: '/chats/$threadId'
+      fullPath: '/chats/$threadId'
+      preLoaderRoute: typeof AuthenticatedChatsThreadIdRouteImport
+      parentRoute: typeof AuthenticatedRoute
     }
-    '/_authenticated/prompts/': {
-      id: '/_authenticated/prompts/'
-      path: '/prompts'
-      fullPath: '/prompts'
-      preLoaderRoute: typeof AuthenticatedPromptsIndexImport
-      parentRoute: typeof AuthenticatedImport
+    '/_authenticated/agents/$id': {
+      id: '/_authenticated/agents/$id'
+      path: '/agents/$id'
+      fullPath: '/agents/$id'
+      preLoaderRoute: typeof AuthenticatedAgentsIdRouteImport
+      parentRoute: typeof AuthenticatedRoute
     }
-    '/_authenticated/settings/': {
-      id: '/_authenticated/settings/'
-      path: '/settings'
-      fullPath: '/settings'
-      preLoaderRoute: typeof AuthenticatedSettingsIndexImport
-      parentRoute: typeof AuthenticatedImport
+    '/_authenticated/admin-settings/users': {
+      id: '/_authenticated/admin-settings/users'
+      path: '/admin-settings/users'
+      fullPath: '/admin-settings/users'
+      preLoaderRoute: typeof AuthenticatedAdminSettingsUsersRouteImport
+      parentRoute: typeof AuthenticatedRoute
     }
-    '/_authenticated/skills/': {
-      id: '/_authenticated/skills/'
-      path: '/skills'
-      fullPath: '/skills'
-      preLoaderRoute: typeof AuthenticatedSkillsIndexImport
-      parentRoute: typeof AuthenticatedImport
+    '/_authenticated/admin-settings/usage': {
+      id: '/_authenticated/admin-settings/usage'
+      path: '/admin-settings/usage'
+      fullPath: '/admin-settings/usage'
+      preLoaderRoute: typeof AuthenticatedAdminSettingsUsageRouteImport
+      parentRoute: typeof AuthenticatedRoute
     }
-    '/_authenticated/super-admin-settings/': {
-      id: '/_authenticated/super-admin-settings/'
-      path: '/super-admin-settings'
-      fullPath: '/super-admin-settings'
-      preLoaderRoute: typeof AuthenticatedSuperAdminSettingsIndexImport
-      parentRoute: typeof AuthenticatedImport
+    '/_authenticated/admin-settings/security': {
+      id: '/_authenticated/admin-settings/security'
+      path: '/admin-settings/security'
+      fullPath: '/admin-settings/security'
+      preLoaderRoute: typeof AuthenticatedAdminSettingsSecurityRouteImport
+      parentRoute: typeof AuthenticatedRoute
     }
-    '/_authenticated/admin-settings/letterheads/$id': {
-      id: '/_authenticated/admin-settings/letterheads/$id'
-      path: '/admin-settings/letterheads/$id'
-      fullPath: '/admin-settings/letterheads/$id'
-      preLoaderRoute: typeof AuthenticatedAdminSettingsLetterheadsIdImport
-      parentRoute: typeof AuthenticatedImport
+    '/_authenticated/admin-settings/models': {
+      id: '/_authenticated/admin-settings/models'
+      path: '/admin-settings/models'
+      fullPath: '/admin-settings/models'
+      preLoaderRoute: typeof AuthenticatedAdminSettingsModelsRouteImport
+      parentRoute: typeof AuthenticatedRoute
     }
-    '/_authenticated/admin-settings/teams/$id': {
-      id: '/_authenticated/admin-settings/teams/$id'
-      path: '/admin-settings/teams/$id'
-      fullPath: '/admin-settings/teams/$id'
-      preLoaderRoute: typeof AuthenticatedAdminSettingsTeamsIdImport
-      parentRoute: typeof AuthenticatedImport
+    '/_authenticated/admin-settings/integrations': {
+      id: '/_authenticated/admin-settings/integrations'
+      path: '/admin-settings/integrations'
+      fullPath: '/admin-settings/integrations'
+      preLoaderRoute: typeof AuthenticatedAdminSettingsIntegrationsRouteImport
+      parentRoute: typeof AuthenticatedRoute
+    }
+    '/(onboarding)/password/reset': {
+      id: '/(onboarding)/password/reset'
+      path: '/password/reset'
+      fullPath: '/password/reset'
+      preLoaderRoute: typeof onboardingPasswordResetRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/(onboarding)/password/forgot': {
+      id: '/(onboarding)/password/forgot'
+      path: '/password/forgot'
+      fullPath: '/password/forgot'
+      preLoaderRoute: typeof onboardingPasswordForgotRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/_authenticated/super-admin-settings/usage/': {
+      id: '/_authenticated/super-admin-settings/usage/'
+      path: '/super-admin-settings/usage'
+      fullPath: '/super-admin-settings/usage/'
+      preLoaderRoute: typeof AuthenticatedSuperAdminSettingsUsageIndexRouteImport
+      parentRoute: typeof AuthenticatedRoute
+    }
+    '/_authenticated/super-admin-settings/super-admins/': {
+      id: '/_authenticated/super-admin-settings/super-admins/'
+      path: '/super-admin-settings/super-admins'
+      fullPath: '/super-admin-settings/super-admins/'
+      preLoaderRoute: typeof AuthenticatedSuperAdminSettingsSuperAdminsIndexRouteImport
+      parentRoute: typeof AuthenticatedRoute
+    }
+    '/_authenticated/super-admin-settings/skills/': {
+      id: '/_authenticated/super-admin-settings/skills/'
+      path: '/super-admin-settings/skills'
+      fullPath: '/super-admin-settings/skills/'
+      preLoaderRoute: typeof AuthenticatedSuperAdminSettingsSkillsIndexRouteImport
+      parentRoute: typeof AuthenticatedRoute
+    }
+    '/_authenticated/super-admin-settings/platform-config/': {
+      id: '/_authenticated/super-admin-settings/platform-config/'
+      path: '/super-admin-settings/platform-config'
+      fullPath: '/super-admin-settings/platform-config/'
+      preLoaderRoute: typeof AuthenticatedSuperAdminSettingsPlatformConfigIndexRouteImport
+      parentRoute: typeof AuthenticatedRoute
+    }
+    '/_authenticated/super-admin-settings/orgs/': {
+      id: '/_authenticated/super-admin-settings/orgs/'
+      path: '/super-admin-settings/orgs'
+      fullPath: '/super-admin-settings/orgs/'
+      preLoaderRoute: typeof AuthenticatedSuperAdminSettingsOrgsIndexRouteImport
+      parentRoute: typeof AuthenticatedRoute
+    }
+    '/_authenticated/super-admin-settings/models-catalog/': {
+      id: '/_authenticated/super-admin-settings/models-catalog/'
+      path: '/super-admin-settings/models-catalog'
+      fullPath: '/super-admin-settings/models-catalog/'
+      preLoaderRoute: typeof AuthenticatedSuperAdminSettingsModelsCatalogIndexRouteImport
+      parentRoute: typeof AuthenticatedRoute
+    }
+    '/_authenticated/admin-settings/teams/': {
+      id: '/_authenticated/admin-settings/teams/'
+      path: '/admin-settings/teams'
+      fullPath: '/admin-settings/teams/'
+      preLoaderRoute: typeof AuthenticatedAdminSettingsTeamsIndexRouteImport
+      parentRoute: typeof AuthenticatedRoute
+    }
+    '/_authenticated/admin-settings/letterheads/': {
+      id: '/_authenticated/admin-settings/letterheads/'
+      path: '/admin-settings/letterheads'
+      fullPath: '/admin-settings/letterheads/'
+      preLoaderRoute: typeof AuthenticatedAdminSettingsLetterheadsIndexRouteImport
+      parentRoute: typeof AuthenticatedRoute
     }
     '/_authenticated/super-admin-settings/orgs/$id': {
       id: '/_authenticated/super-admin-settings/orgs/$id'
       path: '/super-admin-settings/orgs/$id'
       fullPath: '/super-admin-settings/orgs/$id'
-      preLoaderRoute: typeof AuthenticatedSuperAdminSettingsOrgsIdImport
-      parentRoute: typeof AuthenticatedImport
+      preLoaderRoute: typeof AuthenticatedSuperAdminSettingsOrgsIdRouteImport
+      parentRoute: typeof AuthenticatedRoute
     }
-    '/_authenticated/admin-settings/letterheads/': {
-      id: '/_authenticated/admin-settings/letterheads/'
-      path: '/admin-settings/letterheads'
-      fullPath: '/admin-settings/letterheads'
-      preLoaderRoute: typeof AuthenticatedAdminSettingsLetterheadsIndexImport
-      parentRoute: typeof AuthenticatedImport
+    '/_authenticated/admin-settings/teams/$id': {
+      id: '/_authenticated/admin-settings/teams/$id'
+      path: '/admin-settings/teams/$id'
+      fullPath: '/admin-settings/teams/$id'
+      preLoaderRoute: typeof AuthenticatedAdminSettingsTeamsIdRouteImport
+      parentRoute: typeof AuthenticatedRoute
     }
-    '/_authenticated/admin-settings/teams/': {
-      id: '/_authenticated/admin-settings/teams/'
-      path: '/admin-settings/teams'
-      fullPath: '/admin-settings/teams'
-      preLoaderRoute: typeof AuthenticatedAdminSettingsTeamsIndexImport
-      parentRoute: typeof AuthenticatedImport
-    }
-    '/_authenticated/super-admin-settings/models-catalog/': {
-      id: '/_authenticated/super-admin-settings/models-catalog/'
-      path: '/super-admin-settings/models-catalog'
-      fullPath: '/super-admin-settings/models-catalog'
-      preLoaderRoute: typeof AuthenticatedSuperAdminSettingsModelsCatalogIndexImport
-      parentRoute: typeof AuthenticatedImport
-    }
-    '/_authenticated/super-admin-settings/orgs/': {
-      id: '/_authenticated/super-admin-settings/orgs/'
-      path: '/super-admin-settings/orgs'
-      fullPath: '/super-admin-settings/orgs'
-      preLoaderRoute: typeof AuthenticatedSuperAdminSettingsOrgsIndexImport
-      parentRoute: typeof AuthenticatedImport
-    }
-    '/_authenticated/super-admin-settings/platform-config/': {
-      id: '/_authenticated/super-admin-settings/platform-config/'
-      path: '/super-admin-settings/platform-config'
-      fullPath: '/super-admin-settings/platform-config'
-      preLoaderRoute: typeof AuthenticatedSuperAdminSettingsPlatformConfigIndexImport
-      parentRoute: typeof AuthenticatedImport
-    }
-    '/_authenticated/super-admin-settings/skills/': {
-      id: '/_authenticated/super-admin-settings/skills/'
-      path: '/super-admin-settings/skills'
-      fullPath: '/super-admin-settings/skills'
-      preLoaderRoute: typeof AuthenticatedSuperAdminSettingsSkillsIndexImport
-      parentRoute: typeof AuthenticatedImport
-    }
-    '/_authenticated/super-admin-settings/super-admins/': {
-      id: '/_authenticated/super-admin-settings/super-admins/'
-      path: '/super-admin-settings/super-admins'
-      fullPath: '/super-admin-settings/super-admins'
-      preLoaderRoute: typeof AuthenticatedSuperAdminSettingsSuperAdminsIndexImport
-      parentRoute: typeof AuthenticatedImport
-    }
-    '/_authenticated/super-admin-settings/usage/': {
-      id: '/_authenticated/super-admin-settings/usage/'
-      path: '/super-admin-settings/usage'
-      fullPath: '/super-admin-settings/usage'
-      preLoaderRoute: typeof AuthenticatedSuperAdminSettingsUsageIndexImport
-      parentRoute: typeof AuthenticatedImport
+    '/_authenticated/admin-settings/letterheads/$id': {
+      id: '/_authenticated/admin-settings/letterheads/$id'
+      path: '/admin-settings/letterheads/$id'
+      fullPath: '/admin-settings/letterheads/$id'
+      preLoaderRoute: typeof AuthenticatedAdminSettingsLetterheadsIdRouteImport
+      parentRoute: typeof AuthenticatedRoute
     }
   }
 }
-
-// Create and export the route tree
 
 interface AuthenticatedRouteChildren {
   AuthenticatedInstallRoute: typeof AuthenticatedInstallRoute
@@ -740,297 +976,6 @@ const AuthenticatedRouteWithChildren = AuthenticatedRoute._addFileChildren(
   AuthenticatedRouteChildren,
 )
 
-export interface FileRoutesByFullPath {
-  '/': typeof IndexRoute
-  '': typeof AuthenticatedRouteWithChildren
-  '/accept-invite': typeof onboardingAcceptInviteRoute
-  '/confirm-email': typeof onboardingConfirmEmailRoute
-  '/email-confirm': typeof onboardingEmailConfirmRoute
-  '/ip-blocked': typeof onboardingIpBlockedRoute
-  '/login': typeof onboardingLoginRoute
-  '/register': typeof onboardingRegisterRoute
-  '/install': typeof AuthenticatedInstallRoute
-  '/password/forgot': typeof onboardingPasswordForgotRoute
-  '/password/reset': typeof onboardingPasswordResetRoute
-  '/admin-settings/integrations': typeof AuthenticatedAdminSettingsIntegrationsRoute
-  '/admin-settings/models': typeof AuthenticatedAdminSettingsModelsRoute
-  '/admin-settings/security': typeof AuthenticatedAdminSettingsSecurityRoute
-  '/admin-settings/usage': typeof AuthenticatedAdminSettingsUsageRoute
-  '/admin-settings/users': typeof AuthenticatedAdminSettingsUsersRoute
-  '/agents/$id': typeof AuthenticatedAgentsIdRoute
-  '/chats/$threadId': typeof AuthenticatedChatsThreadIdRoute
-  '/knowledge-bases/$id': typeof AuthenticatedKnowledgeBasesIdRoute
-  '/settings/account': typeof AuthenticatedSettingsAccountRoute
-  '/settings/chat': typeof AuthenticatedSettingsChatRoute
-  '/settings/general': typeof AuthenticatedSettingsGeneralRoute
-  '/skills/$id': typeof AuthenticatedSkillsIdRoute
-  '/admin-settings': typeof AuthenticatedAdminSettingsIndexRoute
-  '/agents': typeof AuthenticatedAgentsIndexRoute
-  '/chat': typeof AuthenticatedChatIndexRoute
-  '/chats': typeof AuthenticatedChatsIndexRoute
-  '/knowledge-bases': typeof AuthenticatedKnowledgeBasesIndexRoute
-  '/prompts': typeof AuthenticatedPromptsIndexRoute
-  '/settings': typeof AuthenticatedSettingsIndexRoute
-  '/skills': typeof AuthenticatedSkillsIndexRoute
-  '/super-admin-settings': typeof AuthenticatedSuperAdminSettingsIndexRoute
-  '/admin-settings/letterheads/$id': typeof AuthenticatedAdminSettingsLetterheadsIdRoute
-  '/admin-settings/teams/$id': typeof AuthenticatedAdminSettingsTeamsIdRoute
-  '/super-admin-settings/orgs/$id': typeof AuthenticatedSuperAdminSettingsOrgsIdRoute
-  '/admin-settings/letterheads': typeof AuthenticatedAdminSettingsLetterheadsIndexRoute
-  '/admin-settings/teams': typeof AuthenticatedAdminSettingsTeamsIndexRoute
-  '/super-admin-settings/models-catalog': typeof AuthenticatedSuperAdminSettingsModelsCatalogIndexRoute
-  '/super-admin-settings/orgs': typeof AuthenticatedSuperAdminSettingsOrgsIndexRoute
-  '/super-admin-settings/platform-config': typeof AuthenticatedSuperAdminSettingsPlatformConfigIndexRoute
-  '/super-admin-settings/skills': typeof AuthenticatedSuperAdminSettingsSkillsIndexRoute
-  '/super-admin-settings/super-admins': typeof AuthenticatedSuperAdminSettingsSuperAdminsIndexRoute
-  '/super-admin-settings/usage': typeof AuthenticatedSuperAdminSettingsUsageIndexRoute
-}
-
-export interface FileRoutesByTo {
-  '/': typeof IndexRoute
-  '': typeof AuthenticatedRouteWithChildren
-  '/accept-invite': typeof onboardingAcceptInviteRoute
-  '/confirm-email': typeof onboardingConfirmEmailRoute
-  '/email-confirm': typeof onboardingEmailConfirmRoute
-  '/ip-blocked': typeof onboardingIpBlockedRoute
-  '/login': typeof onboardingLoginRoute
-  '/register': typeof onboardingRegisterRoute
-  '/install': typeof AuthenticatedInstallRoute
-  '/password/forgot': typeof onboardingPasswordForgotRoute
-  '/password/reset': typeof onboardingPasswordResetRoute
-  '/admin-settings/integrations': typeof AuthenticatedAdminSettingsIntegrationsRoute
-  '/admin-settings/models': typeof AuthenticatedAdminSettingsModelsRoute
-  '/admin-settings/security': typeof AuthenticatedAdminSettingsSecurityRoute
-  '/admin-settings/usage': typeof AuthenticatedAdminSettingsUsageRoute
-  '/admin-settings/users': typeof AuthenticatedAdminSettingsUsersRoute
-  '/agents/$id': typeof AuthenticatedAgentsIdRoute
-  '/chats/$threadId': typeof AuthenticatedChatsThreadIdRoute
-  '/knowledge-bases/$id': typeof AuthenticatedKnowledgeBasesIdRoute
-  '/settings/account': typeof AuthenticatedSettingsAccountRoute
-  '/settings/chat': typeof AuthenticatedSettingsChatRoute
-  '/settings/general': typeof AuthenticatedSettingsGeneralRoute
-  '/skills/$id': typeof AuthenticatedSkillsIdRoute
-  '/admin-settings': typeof AuthenticatedAdminSettingsIndexRoute
-  '/agents': typeof AuthenticatedAgentsIndexRoute
-  '/chat': typeof AuthenticatedChatIndexRoute
-  '/chats': typeof AuthenticatedChatsIndexRoute
-  '/knowledge-bases': typeof AuthenticatedKnowledgeBasesIndexRoute
-  '/prompts': typeof AuthenticatedPromptsIndexRoute
-  '/settings': typeof AuthenticatedSettingsIndexRoute
-  '/skills': typeof AuthenticatedSkillsIndexRoute
-  '/super-admin-settings': typeof AuthenticatedSuperAdminSettingsIndexRoute
-  '/admin-settings/letterheads/$id': typeof AuthenticatedAdminSettingsLetterheadsIdRoute
-  '/admin-settings/teams/$id': typeof AuthenticatedAdminSettingsTeamsIdRoute
-  '/super-admin-settings/orgs/$id': typeof AuthenticatedSuperAdminSettingsOrgsIdRoute
-  '/admin-settings/letterheads': typeof AuthenticatedAdminSettingsLetterheadsIndexRoute
-  '/admin-settings/teams': typeof AuthenticatedAdminSettingsTeamsIndexRoute
-  '/super-admin-settings/models-catalog': typeof AuthenticatedSuperAdminSettingsModelsCatalogIndexRoute
-  '/super-admin-settings/orgs': typeof AuthenticatedSuperAdminSettingsOrgsIndexRoute
-  '/super-admin-settings/platform-config': typeof AuthenticatedSuperAdminSettingsPlatformConfigIndexRoute
-  '/super-admin-settings/skills': typeof AuthenticatedSuperAdminSettingsSkillsIndexRoute
-  '/super-admin-settings/super-admins': typeof AuthenticatedSuperAdminSettingsSuperAdminsIndexRoute
-  '/super-admin-settings/usage': typeof AuthenticatedSuperAdminSettingsUsageIndexRoute
-}
-
-export interface FileRoutesById {
-  __root__: typeof rootRoute
-  '/': typeof IndexRoute
-  '/_authenticated': typeof AuthenticatedRouteWithChildren
-  '/(onboarding)/accept-invite': typeof onboardingAcceptInviteRoute
-  '/(onboarding)/confirm-email': typeof onboardingConfirmEmailRoute
-  '/(onboarding)/email-confirm': typeof onboardingEmailConfirmRoute
-  '/(onboarding)/ip-blocked': typeof onboardingIpBlockedRoute
-  '/(onboarding)/login': typeof onboardingLoginRoute
-  '/(onboarding)/register': typeof onboardingRegisterRoute
-  '/_authenticated/install': typeof AuthenticatedInstallRoute
-  '/(onboarding)/password/forgot': typeof onboardingPasswordForgotRoute
-  '/(onboarding)/password/reset': typeof onboardingPasswordResetRoute
-  '/_authenticated/admin-settings/integrations': typeof AuthenticatedAdminSettingsIntegrationsRoute
-  '/_authenticated/admin-settings/models': typeof AuthenticatedAdminSettingsModelsRoute
-  '/_authenticated/admin-settings/security': typeof AuthenticatedAdminSettingsSecurityRoute
-  '/_authenticated/admin-settings/usage': typeof AuthenticatedAdminSettingsUsageRoute
-  '/_authenticated/admin-settings/users': typeof AuthenticatedAdminSettingsUsersRoute
-  '/_authenticated/agents/$id': typeof AuthenticatedAgentsIdRoute
-  '/_authenticated/chats/$threadId': typeof AuthenticatedChatsThreadIdRoute
-  '/_authenticated/knowledge-bases/$id': typeof AuthenticatedKnowledgeBasesIdRoute
-  '/_authenticated/settings/account': typeof AuthenticatedSettingsAccountRoute
-  '/_authenticated/settings/chat': typeof AuthenticatedSettingsChatRoute
-  '/_authenticated/settings/general': typeof AuthenticatedSettingsGeneralRoute
-  '/_authenticated/skills/$id': typeof AuthenticatedSkillsIdRoute
-  '/_authenticated/admin-settings/': typeof AuthenticatedAdminSettingsIndexRoute
-  '/_authenticated/agents/': typeof AuthenticatedAgentsIndexRoute
-  '/_authenticated/chat/': typeof AuthenticatedChatIndexRoute
-  '/_authenticated/chats/': typeof AuthenticatedChatsIndexRoute
-  '/_authenticated/knowledge-bases/': typeof AuthenticatedKnowledgeBasesIndexRoute
-  '/_authenticated/prompts/': typeof AuthenticatedPromptsIndexRoute
-  '/_authenticated/settings/': typeof AuthenticatedSettingsIndexRoute
-  '/_authenticated/skills/': typeof AuthenticatedSkillsIndexRoute
-  '/_authenticated/super-admin-settings/': typeof AuthenticatedSuperAdminSettingsIndexRoute
-  '/_authenticated/admin-settings/letterheads/$id': typeof AuthenticatedAdminSettingsLetterheadsIdRoute
-  '/_authenticated/admin-settings/teams/$id': typeof AuthenticatedAdminSettingsTeamsIdRoute
-  '/_authenticated/super-admin-settings/orgs/$id': typeof AuthenticatedSuperAdminSettingsOrgsIdRoute
-  '/_authenticated/admin-settings/letterheads/': typeof AuthenticatedAdminSettingsLetterheadsIndexRoute
-  '/_authenticated/admin-settings/teams/': typeof AuthenticatedAdminSettingsTeamsIndexRoute
-  '/_authenticated/super-admin-settings/models-catalog/': typeof AuthenticatedSuperAdminSettingsModelsCatalogIndexRoute
-  '/_authenticated/super-admin-settings/orgs/': typeof AuthenticatedSuperAdminSettingsOrgsIndexRoute
-  '/_authenticated/super-admin-settings/platform-config/': typeof AuthenticatedSuperAdminSettingsPlatformConfigIndexRoute
-  '/_authenticated/super-admin-settings/skills/': typeof AuthenticatedSuperAdminSettingsSkillsIndexRoute
-  '/_authenticated/super-admin-settings/super-admins/': typeof AuthenticatedSuperAdminSettingsSuperAdminsIndexRoute
-  '/_authenticated/super-admin-settings/usage/': typeof AuthenticatedSuperAdminSettingsUsageIndexRoute
-}
-
-export interface FileRouteTypes {
-  fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths:
-    | '/'
-    | ''
-    | '/accept-invite'
-    | '/confirm-email'
-    | '/email-confirm'
-    | '/ip-blocked'
-    | '/login'
-    | '/register'
-    | '/install'
-    | '/password/forgot'
-    | '/password/reset'
-    | '/admin-settings/integrations'
-    | '/admin-settings/models'
-    | '/admin-settings/security'
-    | '/admin-settings/usage'
-    | '/admin-settings/users'
-    | '/agents/$id'
-    | '/chats/$threadId'
-    | '/knowledge-bases/$id'
-    | '/settings/account'
-    | '/settings/chat'
-    | '/settings/general'
-    | '/skills/$id'
-    | '/admin-settings'
-    | '/agents'
-    | '/chat'
-    | '/chats'
-    | '/knowledge-bases'
-    | '/prompts'
-    | '/settings'
-    | '/skills'
-    | '/super-admin-settings'
-    | '/admin-settings/letterheads/$id'
-    | '/admin-settings/teams/$id'
-    | '/super-admin-settings/orgs/$id'
-    | '/admin-settings/letterheads'
-    | '/admin-settings/teams'
-    | '/super-admin-settings/models-catalog'
-    | '/super-admin-settings/orgs'
-    | '/super-admin-settings/platform-config'
-    | '/super-admin-settings/skills'
-    | '/super-admin-settings/super-admins'
-    | '/super-admin-settings/usage'
-  fileRoutesByTo: FileRoutesByTo
-  to:
-    | '/'
-    | ''
-    | '/accept-invite'
-    | '/confirm-email'
-    | '/email-confirm'
-    | '/ip-blocked'
-    | '/login'
-    | '/register'
-    | '/install'
-    | '/password/forgot'
-    | '/password/reset'
-    | '/admin-settings/integrations'
-    | '/admin-settings/models'
-    | '/admin-settings/security'
-    | '/admin-settings/usage'
-    | '/admin-settings/users'
-    | '/agents/$id'
-    | '/chats/$threadId'
-    | '/knowledge-bases/$id'
-    | '/settings/account'
-    | '/settings/chat'
-    | '/settings/general'
-    | '/skills/$id'
-    | '/admin-settings'
-    | '/agents'
-    | '/chat'
-    | '/chats'
-    | '/knowledge-bases'
-    | '/prompts'
-    | '/settings'
-    | '/skills'
-    | '/super-admin-settings'
-    | '/admin-settings/letterheads/$id'
-    | '/admin-settings/teams/$id'
-    | '/super-admin-settings/orgs/$id'
-    | '/admin-settings/letterheads'
-    | '/admin-settings/teams'
-    | '/super-admin-settings/models-catalog'
-    | '/super-admin-settings/orgs'
-    | '/super-admin-settings/platform-config'
-    | '/super-admin-settings/skills'
-    | '/super-admin-settings/super-admins'
-    | '/super-admin-settings/usage'
-  id:
-    | '__root__'
-    | '/'
-    | '/_authenticated'
-    | '/(onboarding)/accept-invite'
-    | '/(onboarding)/confirm-email'
-    | '/(onboarding)/email-confirm'
-    | '/(onboarding)/ip-blocked'
-    | '/(onboarding)/login'
-    | '/(onboarding)/register'
-    | '/_authenticated/install'
-    | '/(onboarding)/password/forgot'
-    | '/(onboarding)/password/reset'
-    | '/_authenticated/admin-settings/integrations'
-    | '/_authenticated/admin-settings/models'
-    | '/_authenticated/admin-settings/security'
-    | '/_authenticated/admin-settings/usage'
-    | '/_authenticated/admin-settings/users'
-    | '/_authenticated/agents/$id'
-    | '/_authenticated/chats/$threadId'
-    | '/_authenticated/knowledge-bases/$id'
-    | '/_authenticated/settings/account'
-    | '/_authenticated/settings/chat'
-    | '/_authenticated/settings/general'
-    | '/_authenticated/skills/$id'
-    | '/_authenticated/admin-settings/'
-    | '/_authenticated/agents/'
-    | '/_authenticated/chat/'
-    | '/_authenticated/chats/'
-    | '/_authenticated/knowledge-bases/'
-    | '/_authenticated/prompts/'
-    | '/_authenticated/settings/'
-    | '/_authenticated/skills/'
-    | '/_authenticated/super-admin-settings/'
-    | '/_authenticated/admin-settings/letterheads/$id'
-    | '/_authenticated/admin-settings/teams/$id'
-    | '/_authenticated/super-admin-settings/orgs/$id'
-    | '/_authenticated/admin-settings/letterheads/'
-    | '/_authenticated/admin-settings/teams/'
-    | '/_authenticated/super-admin-settings/models-catalog/'
-    | '/_authenticated/super-admin-settings/orgs/'
-    | '/_authenticated/super-admin-settings/platform-config/'
-    | '/_authenticated/super-admin-settings/skills/'
-    | '/_authenticated/super-admin-settings/super-admins/'
-    | '/_authenticated/super-admin-settings/usage/'
-  fileRoutesById: FileRoutesById
-}
-
-export interface RootRouteChildren {
-  IndexRoute: typeof IndexRoute
-  AuthenticatedRoute: typeof AuthenticatedRouteWithChildren
-  onboardingAcceptInviteRoute: typeof onboardingAcceptInviteRoute
-  onboardingConfirmEmailRoute: typeof onboardingConfirmEmailRoute
-  onboardingEmailConfirmRoute: typeof onboardingEmailConfirmRoute
-  onboardingIpBlockedRoute: typeof onboardingIpBlockedRoute
-  onboardingLoginRoute: typeof onboardingLoginRoute
-  onboardingRegisterRoute: typeof onboardingRegisterRoute
-  onboardingPasswordForgotRoute: typeof onboardingPasswordForgotRoute
-  onboardingPasswordResetRoute: typeof onboardingPasswordResetRoute
-}
-
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   AuthenticatedRoute: AuthenticatedRouteWithChildren,
@@ -1043,226 +988,6 @@ const rootRouteChildren: RootRouteChildren = {
   onboardingPasswordForgotRoute: onboardingPasswordForgotRoute,
   onboardingPasswordResetRoute: onboardingPasswordResetRoute,
 }
-
-export const routeTree = rootRoute
+export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)
   ._addFileTypes<FileRouteTypes>()
-
-/* ROUTE_MANIFEST_START
-{
-  "routes": {
-    "__root__": {
-      "filePath": "__root.tsx",
-      "children": [
-        "/",
-        "/_authenticated",
-        "/(onboarding)/accept-invite",
-        "/(onboarding)/confirm-email",
-        "/(onboarding)/email-confirm",
-        "/(onboarding)/ip-blocked",
-        "/(onboarding)/login",
-        "/(onboarding)/register",
-        "/(onboarding)/password/forgot",
-        "/(onboarding)/password/reset"
-      ]
-    },
-    "/": {
-      "filePath": "index.tsx"
-    },
-    "/_authenticated": {
-      "filePath": "_authenticated.tsx",
-      "children": [
-        "/_authenticated/install",
-        "/_authenticated/admin-settings/integrations",
-        "/_authenticated/admin-settings/models",
-        "/_authenticated/admin-settings/security",
-        "/_authenticated/admin-settings/usage",
-        "/_authenticated/admin-settings/users",
-        "/_authenticated/agents/$id",
-        "/_authenticated/chats/$threadId",
-        "/_authenticated/knowledge-bases/$id",
-        "/_authenticated/settings/account",
-        "/_authenticated/settings/chat",
-        "/_authenticated/settings/general",
-        "/_authenticated/skills/$id",
-        "/_authenticated/admin-settings/",
-        "/_authenticated/agents/",
-        "/_authenticated/chat/",
-        "/_authenticated/chats/",
-        "/_authenticated/knowledge-bases/",
-        "/_authenticated/prompts/",
-        "/_authenticated/settings/",
-        "/_authenticated/skills/",
-        "/_authenticated/super-admin-settings/",
-        "/_authenticated/admin-settings/letterheads/$id",
-        "/_authenticated/admin-settings/teams/$id",
-        "/_authenticated/super-admin-settings/orgs/$id",
-        "/_authenticated/admin-settings/letterheads/",
-        "/_authenticated/admin-settings/teams/",
-        "/_authenticated/super-admin-settings/models-catalog/",
-        "/_authenticated/super-admin-settings/orgs/",
-        "/_authenticated/super-admin-settings/platform-config/",
-        "/_authenticated/super-admin-settings/skills/",
-        "/_authenticated/super-admin-settings/super-admins/",
-        "/_authenticated/super-admin-settings/usage/"
-      ]
-    },
-    "/(onboarding)/accept-invite": {
-      "filePath": "(onboarding)/accept-invite.tsx"
-    },
-    "/(onboarding)/confirm-email": {
-      "filePath": "(onboarding)/confirm-email.tsx"
-    },
-    "/(onboarding)/email-confirm": {
-      "filePath": "(onboarding)/email-confirm.tsx"
-    },
-    "/(onboarding)/ip-blocked": {
-      "filePath": "(onboarding)/ip-blocked.tsx"
-    },
-    "/(onboarding)/login": {
-      "filePath": "(onboarding)/login.tsx"
-    },
-    "/(onboarding)/register": {
-      "filePath": "(onboarding)/register.tsx"
-    },
-    "/_authenticated/install": {
-      "filePath": "_authenticated/install.tsx",
-      "parent": "/_authenticated"
-    },
-    "/(onboarding)/password/forgot": {
-      "filePath": "(onboarding)/password.forgot.tsx"
-    },
-    "/(onboarding)/password/reset": {
-      "filePath": "(onboarding)/password.reset.tsx"
-    },
-    "/_authenticated/admin-settings/integrations": {
-      "filePath": "_authenticated/admin-settings.integrations.tsx",
-      "parent": "/_authenticated"
-    },
-    "/_authenticated/admin-settings/models": {
-      "filePath": "_authenticated/admin-settings.models.tsx",
-      "parent": "/_authenticated"
-    },
-    "/_authenticated/admin-settings/security": {
-      "filePath": "_authenticated/admin-settings.security.tsx",
-      "parent": "/_authenticated"
-    },
-    "/_authenticated/admin-settings/usage": {
-      "filePath": "_authenticated/admin-settings.usage.tsx",
-      "parent": "/_authenticated"
-    },
-    "/_authenticated/admin-settings/users": {
-      "filePath": "_authenticated/admin-settings.users.tsx",
-      "parent": "/_authenticated"
-    },
-    "/_authenticated/agents/$id": {
-      "filePath": "_authenticated/agents.$id.tsx",
-      "parent": "/_authenticated"
-    },
-    "/_authenticated/chats/$threadId": {
-      "filePath": "_authenticated/chats.$threadId.tsx",
-      "parent": "/_authenticated"
-    },
-    "/_authenticated/knowledge-bases/$id": {
-      "filePath": "_authenticated/knowledge-bases.$id.tsx",
-      "parent": "/_authenticated"
-    },
-    "/_authenticated/settings/account": {
-      "filePath": "_authenticated/settings.account.tsx",
-      "parent": "/_authenticated"
-    },
-    "/_authenticated/settings/chat": {
-      "filePath": "_authenticated/settings.chat.tsx",
-      "parent": "/_authenticated"
-    },
-    "/_authenticated/settings/general": {
-      "filePath": "_authenticated/settings.general.tsx",
-      "parent": "/_authenticated"
-    },
-    "/_authenticated/skills/$id": {
-      "filePath": "_authenticated/skills.$id.tsx",
-      "parent": "/_authenticated"
-    },
-    "/_authenticated/admin-settings/": {
-      "filePath": "_authenticated/admin-settings.index.tsx",
-      "parent": "/_authenticated"
-    },
-    "/_authenticated/agents/": {
-      "filePath": "_authenticated/agents.index.tsx",
-      "parent": "/_authenticated"
-    },
-    "/_authenticated/chat/": {
-      "filePath": "_authenticated/chat.index.tsx",
-      "parent": "/_authenticated"
-    },
-    "/_authenticated/chats/": {
-      "filePath": "_authenticated/chats.index.tsx",
-      "parent": "/_authenticated"
-    },
-    "/_authenticated/knowledge-bases/": {
-      "filePath": "_authenticated/knowledge-bases.index.tsx",
-      "parent": "/_authenticated"
-    },
-    "/_authenticated/prompts/": {
-      "filePath": "_authenticated/prompts.index.tsx",
-      "parent": "/_authenticated"
-    },
-    "/_authenticated/settings/": {
-      "filePath": "_authenticated/settings.index.ts",
-      "parent": "/_authenticated"
-    },
-    "/_authenticated/skills/": {
-      "filePath": "_authenticated/skills.index.tsx",
-      "parent": "/_authenticated"
-    },
-    "/_authenticated/super-admin-settings/": {
-      "filePath": "_authenticated/super-admin-settings.index.tsx",
-      "parent": "/_authenticated"
-    },
-    "/_authenticated/admin-settings/letterheads/$id": {
-      "filePath": "_authenticated/admin-settings.letterheads.$id.tsx",
-      "parent": "/_authenticated"
-    },
-    "/_authenticated/admin-settings/teams/$id": {
-      "filePath": "_authenticated/admin-settings.teams.$id.tsx",
-      "parent": "/_authenticated"
-    },
-    "/_authenticated/super-admin-settings/orgs/$id": {
-      "filePath": "_authenticated/super-admin-settings.orgs.$id.tsx",
-      "parent": "/_authenticated"
-    },
-    "/_authenticated/admin-settings/letterheads/": {
-      "filePath": "_authenticated/admin-settings.letterheads.index.tsx",
-      "parent": "/_authenticated"
-    },
-    "/_authenticated/admin-settings/teams/": {
-      "filePath": "_authenticated/admin-settings.teams.index.tsx",
-      "parent": "/_authenticated"
-    },
-    "/_authenticated/super-admin-settings/models-catalog/": {
-      "filePath": "_authenticated/super-admin-settings.models-catalog.index.tsx",
-      "parent": "/_authenticated"
-    },
-    "/_authenticated/super-admin-settings/orgs/": {
-      "filePath": "_authenticated/super-admin-settings.orgs.index.tsx",
-      "parent": "/_authenticated"
-    },
-    "/_authenticated/super-admin-settings/platform-config/": {
-      "filePath": "_authenticated/super-admin-settings.platform-config.index.tsx",
-      "parent": "/_authenticated"
-    },
-    "/_authenticated/super-admin-settings/skills/": {
-      "filePath": "_authenticated/super-admin-settings.skills.index.tsx",
-      "parent": "/_authenticated"
-    },
-    "/_authenticated/super-admin-settings/super-admins/": {
-      "filePath": "_authenticated/super-admin-settings.super-admins.index.tsx",
-      "parent": "/_authenticated"
-    },
-    "/_authenticated/super-admin-settings/usage/": {
-      "filePath": "_authenticated/super-admin-settings.usage.index.tsx",
-      "parent": "/_authenticated"
-    }
-  }
-}
-ROUTE_MANIFEST_END */


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the RAG ingestion pipeline to use a new bulk-ingest API that batches embedding requests and performs bulk DB writes, which could affect indexing correctness/performance. Also switches the default embedding model/dimensions in fixtures, which may impact tests and dev environments.
> 
> **Overview**
> **Adds bulk ingestion for RAG indexing.** Introduces `IndexerPort.ingestBulk` plus a new application-level `IngestBulkContentUseCase` that delegates bulk indexing to the selected indexer.
> 
> **Parent-child indexer now batches embeddings and writes.** Adds a parent-child bulk ingest use case that resolves the embedding model once, splits all inputs, embeds child texts in fixed-size batches, reassembles parent/child chunks, and persists via a new repository `saveMany` method; `CreateTextSourceUseCase` switches from per-chunk concurrent ingest to this bulk flow.
> 
> **Config/test updates.** Minimal fixture changes the default embedding model to Mistral (`mistral-embed`, 1024 dims) and marks it default; tests/mocks are updated accordingly, and the frontend `routeTree.gen.ts` is regenerated (no functional app logic changes).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ee59d51a2f04c97dfabee108e387edb60d534da1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->