### PR TITLE
fix(sources): do not bypass error handling on ingestion (AYC-000)

### DIFF
--- a/ayunis-core-backend/src/domain/rag/indexers/application/use-cases/ingest-bulk-content/ingest-bulk-content.use-case.ts
+++ b/ayunis-core-backend/src/domain/rag/indexers/application/use-cases/ingest-bulk-content/ingest-bulk-content.use-case.ts
@@ -13,7 +13,7 @@ export class IngestBulkContentUseCase {
   async execute(command: IngestBulkContentCommand): Promise<void> {
     try {
       const index = this.indexRegistry.get(command.type);
-      return index.ingestBulk({
+      return await index.ingestBulk({
         orgId: command.orgId,
         entries: command.entries.map((entry) => ({
           indexEntry: new IndexEntry({


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: a single-line change ensures `ingestBulk` is awaited so async failures are caught and wrapped consistently; behavior change is limited to error propagation timing.
> 
> **Overview**
> Ensures `IngestBulkContentUseCase.execute` **awaits** `index.ingestBulk(...)` instead of returning the promise directly, so ingestion errors are reliably handled by the surrounding `try/catch` and surfaced as the expected application/index errors.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5708b0621934f2dc31f94a02c34e3ef3f6946c03. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->