### PR TITLE
fix(models): handle null cost fields in model update validation (AYC-000)

### DIFF
--- a/ayunis-core-backend/src/common/util/null-to-undefined.ts
+++ b/ayunis-core-backend/src/common/util/null-to-undefined.ts
@@ -1,0 +1,10 @@
+/**
+ * class-transformer `@Transform` helper that converts `null` to `undefined`.
+ *
+ * Use on optional DTO fields whose TypeScript type is `T | undefined`
+ * but where JSON payloads may send `null` (e.g. nullable DB columns
+ * round-tripped through the frontend).
+ */
+export function nullToUndefined({ value }: { value: unknown }): unknown {
+  return value === null ? undefined : value;
+}

--- a/ayunis-core-backend/src/domain/models/presenters/http/dto/base-embedding-model-request.dto.ts
+++ b/ayunis-core-backend/src/domain/models/presenters/http/dto/base-embedding-model-request.dto.ts
@@ -8,8 +8,10 @@ import {
   Min,
   ValidateIf,
 } from 'class-validator';
+import { Transform } from 'class-transformer';
 import { ModelProvider } from 'src/domain/models/domain/value-objects/model-provider.enum';
 import { EmbeddingDimensions } from 'src/domain/models/domain/value-objects/embedding-dimensions.enum';
+import { nullToUndefined } from 'src/common/util/null-to-undefined';
 
 function hasAnyCostField(o: BaseEmbeddingModelRequestDto): boolean {
   return o.inputTokenCost !== undefined || o.outputTokenCost !== undefined;
@@ -60,6 +62,7 @@ export abstract class BaseEmbeddingModelRequestDto {
     example: 0.13,
     minimum: 0,
   })
+  @Transform(nullToUndefined)
   @ValidateIf((o: BaseEmbeddingModelRequestDto) => hasAnyCostField(o))
   @IsNumber()
   @Min(0)
@@ -70,6 +73,7 @@ export abstract class BaseEmbeddingModelRequestDto {
     example: 0,
     minimum: 0,
   })
+  @Transform(nullToUndefined)
   @ValidateIf((o: BaseEmbeddingModelRequestDto) => hasAnyCostField(o))
   @IsNumber()
   @Min(0)

--- a/ayunis-core-backend/src/domain/models/presenters/http/dto/base-language-model-request.dto.ts
+++ b/ayunis-core-backend/src/domain/models/presenters/http/dto/base-language-model-request.dto.ts
@@ -8,7 +8,9 @@ import {
   Min,
   ValidateIf,
 } from 'class-validator';
+import { Transform } from 'class-transformer';
 import { ModelProvider } from 'src/domain/models/domain/value-objects/model-provider.enum';
+import { nullToUndefined } from 'src/common/util/null-to-undefined';
 
 function hasAnyCostField(o: BaseLanguageModelRequestDto): boolean {
   return o.inputTokenCost !== undefined || o.outputTokenCost !== undefined;
@@ -79,6 +81,7 @@ export abstract class BaseLanguageModelRequestDto {
     example: 3,
     minimum: 0,
   })
+  @Transform(nullToUndefined)
   @ValidateIf((o: BaseLanguageModelRequestDto) => hasAnyCostField(o))
   @IsNumber()
   @Min(0)
@@ -89,6 +92,7 @@ export abstract class BaseLanguageModelRequestDto {
     example: 15,
     minimum: 0,
   })
+  @Transform(nullToUndefined)
   @ValidateIf((o: BaseLanguageModelRequestDto) => hasAnyCostField(o))
   @IsNumber()
   @Min(0)

--- a/ayunis-core-backend/src/domain/threads/infrastructure/persistence/local/local-threads.repository.ts
+++ b/ayunis-core-backend/src/domain/threads/infrastructure/persistence/local/local-threads.repository.ts
@@ -7,7 +7,7 @@ import {
 } from 'src/domain/threads/application/ports/threads.repository';
 import { Logger, Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { FindOptionsRelations, Repository } from 'typeorm';
+import { Repository } from 'typeorm';
 import { ThreadRecord } from './schema/thread.record';
 import { ThreadMapper } from './mappers/thread.mapper';
 import { UUID } from 'crypto';
@@ -41,6 +41,7 @@ export class LocalThreadsRepository extends ThreadsRepository {
         'model',
         'sourceAssignments',
         'sourceAssignments.source',
+        'sourceAssignments.source.dataSourceDetails',
         'knowledgeBaseAssignments',
         'knowledgeBaseAssignments.knowledgeBase',
         'mcpIntegrations',
@@ -64,17 +65,16 @@ export class LocalThreadsRepository extends ThreadsRepository {
     this.logger.log('findOne', { id, userId });
     const threadEntity = await this.threadRepository.findOne({
       where: { id, userId },
-      relations: {
-        messages: true,
-        model: true,
-        sourceAssignments: {
-          source: true,
-        },
-        knowledgeBaseAssignments: {
-          knowledgeBase: true,
-        },
-        mcpIntegrations: true,
-      },
+      relations: [
+        'messages',
+        'model',
+        'sourceAssignments',
+        'sourceAssignments.source',
+        'sourceAssignments.source.dataSourceDetails',
+        'knowledgeBaseAssignments',
+        'knowledgeBaseAssignments.knowledgeBase',
+        'mcpIntegrations',
+      ],
       order: {
         messages: {
           createdAt: 'ASC',
@@ -199,18 +199,24 @@ export class LocalThreadsRepository extends ThreadsRepository {
     return threadEntities.map((entity) => this.threadMapper.toDomain(entity));
   }
 
-  private getRelations(
-    options?: ThreadsFindAllOptions,
-  ): FindOptionsRelations<ThreadRecord> {
-    return {
-      messages: options?.withMessages ? true : false,
-      sourceAssignments: options?.withSources ? { source: true } : false,
-      model: options?.withModel ? true : false,
-      knowledgeBaseAssignments: options?.withKnowledgeBases
-        ? { knowledgeBase: true }
-        : false,
-      mcpIntegrations: true,
-    };
+  private getRelations(options?: ThreadsFindAllOptions): string[] {
+    const relations: string[] = ['mcpIntegrations'];
+    if (options?.withMessages) relations.push('messages');
+    if (options?.withModel) relations.push('model');
+    if (options?.withSources) {
+      relations.push(
+        'sourceAssignments',
+        'sourceAssignments.source',
+        'sourceAssignments.source.dataSourceDetails',
+      );
+    }
+    if (options?.withKnowledgeBases) {
+      relations.push(
+        'knowledgeBaseAssignments',
+        'knowledgeBaseAssignments.knowledgeBase',
+      );
+    }
+    return relations;
   }
 
   async update(thread: Thread): Promise<Thread> {


### PR DESCRIPTION
- Add @Transform(nullToUndefined) on optional cost fields in both
  language and embedding model request DTOs
- Fixes 400 error when updating models without pricing set: DB null
  values round-tripped through the frontend as JSON null, which
  bypassed the ValidateIf guard (null !== undefined) and failed
  @IsNumber validation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Low-to-moderate risk: changes request DTO transformation/validation and modifies TypeORM relation loading for threads, which could affect API behavior and query performance if relation paths are incorrect.
> 
> **Overview**
> Fixes model update DTO validation by introducing a shared `nullToUndefined` transform and applying it to optional `inputTokenCost`/`outputTokenCost` fields for both language and embedding model requests, so JSON `null` no longer triggers `@IsNumber` errors.
> 
> Updates `LocalThreadsRepository` relation loading to consistently use string-based `relations` arrays and to also eager-load `sourceAssignments.source.dataSourceDetails` in `create`, `findOne`, and `findAllBy*` queries.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 99d66e8ef3386be267ba7bf0e9ed9cd28d922619. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->