### PR TITLE
fix(threads): remove textSourceDetails eager loading from thread queries (AYC-000)

### DIFF
--- a/ayunis-core-backend/src/domain/threads/infrastructure/persistence/local/local-threads.repository.ts
+++ b/ayunis-core-backend/src/domain/threads/infrastructure/persistence/local/local-threads.repository.ts
@@ -121,10 +121,6 @@ export class LocalThreadsRepository extends ThreadsRepository {
       );
       queryBuilder.leftJoinAndSelect('sourceAssignments.source', 'source');
       queryBuilder.leftJoinAndSelect(
-        'source.textSourceDetails',
-        'textSourceDetails',
-      );
-      queryBuilder.leftJoinAndSelect(
         'source.dataSourceDetails',
         'dataSourceDetails',
       );
@@ -336,7 +332,6 @@ export class LocalThreadsRepository extends ThreadsRepository {
       .innerJoin('users', 'user', 'user.id = thread.userId')
       .leftJoinAndSelect('thread.sourceAssignments', 'sourceAssignments')
       .leftJoinAndSelect('sourceAssignments.source', 'source')
-      .leftJoinAndSelect('source.textSourceDetails', 'textSourceDetails')
       .leftJoinAndSelect('source.dataSourceDetails', 'dataSourceDetails')
       .where('user.orgId = :orgId', { orgId })
       .getMany();


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: removes an unused TypeORM join, primarily affecting query shape/performance; risk is limited to callers that implicitly relied on `textSourceDetails` being present in thread source results.
> 
> **Overview**
> Thread source-loading queries no longer `leftJoinAndSelect` `source.textSourceDetails` when `withSources` is enabled (including `findAll` and `findAllByOrgIdWithSources`).
> 
> This reduces the amount of related data fetched for threads and changes the returned graph so `textSourceDetails` will no longer be present unless loaded elsewhere.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a793245431e1a5d3bc758300292890e396bea297. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->