### PR TITLE
feat(sentry): send logs to sentry (AYC-000)

### DIFF
--- a/ayunis-core-backend/package.json
+++ b/ayunis-core-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "core-backend",
-  "version": "0.0.1",
+  "version": "1.27.0",
   "description": "",
   "author": "",
   "private": true,

--- a/ayunis-core-backend/src/common/logger/logger.ts
+++ b/ayunis-core-backend/src/common/logger/logger.ts
@@ -1,4 +1,5 @@
 import { createLogger, format, transports } from 'winston';
+import { SentryLogTransport } from './sentry-log.transport';
 
 const isDevelopment = process.env.NODE_ENV !== 'production';
 
@@ -30,11 +31,29 @@ function createConsoleFormat() {
 // ApplicationErrorFilter (exception pipeline), not via a Winston transport.
 // This avoids duplicate events when logger.error() is followed by a thrown
 // exception that the filter also captures.
+//
+// Sentry *Logs* (structured log product, separate from Issues) are forwarded
+// in production via SentryLogTransport so that every this.logger.log/warn/…
+// call automatically appears in Sentry Logs, linked to traces.
 export const logger = createLogger({
   level: isDevelopment ? 'debug' : 'info',
   transports: [
     new transports.Console({
       format: createConsoleFormat(),
     }),
+    ...buildSentryTransport(),
   ],
 });
+
+function buildSentryTransport(): SentryLogTransport[] {
+  if (isDevelopment || !process.env.SENTRY_DSN) {
+    return [];
+  }
+
+  return [
+    new SentryLogTransport({
+      // Only forward info+ to Sentry to avoid noise
+      level: 'info',
+    }),
+  ];
+}

--- a/ayunis-core-backend/src/common/logger/sentry-log.transport.ts
+++ b/ayunis-core-backend/src/common/logger/sentry-log.transport.ts
@@ -69,7 +69,7 @@ function buildAttributes(
   // Attach tenant context from CLS so logs fired outside a Sentry request
   // scope (background jobs, schedulers, queue workers) still carry user/org.
   const cls = ClsServiceManager.getClsService<MyClsStore>();
-  if (cls.isActive()) {
+  if (cls?.isActive()) {
     const userId = cls.get('userId');
     const orgId = cls.get('orgId');
     if (userId) attrs['user.id'] = userId;

--- a/ayunis-core-backend/src/common/logger/sentry-log.transport.ts
+++ b/ayunis-core-backend/src/common/logger/sentry-log.transport.ts
@@ -1,0 +1,88 @@
+import Transport from 'winston-transport';
+import * as Sentry from '@sentry/nestjs';
+import { ClsServiceManager } from 'nestjs-cls';
+import type { MyClsStore } from '../context/services/context.service';
+
+interface LogInfo {
+  level: string;
+  message: string;
+  context?: string;
+  [key: string]: unknown;
+}
+
+/**
+ * Winston transport that forwards log entries to Sentry Structured Logs.
+ *
+ * Sentry Logs are a separate product from Sentry Issues/Errors — they give
+ * you searchable, high-cardinality structured logs in the Sentry UI, linked
+ * to traces automatically.
+ *
+ * This transport maps Winston levels to Sentry.logger levels:
+ *   error  → Sentry.logger.error
+ *   warn   → Sentry.logger.warn
+ *   info   → Sentry.logger.info
+ *   debug  → Sentry.logger.debug
+ *   verbose/silly → Sentry.logger.trace
+ */
+export class SentryLogTransport extends Transport {
+  log(info: LogInfo, callback: () => void): void {
+    setImmediate(() => this.emit('logged', info));
+
+    const { level, message, context, ...rest } = info;
+    const attrs = buildAttributes(context, rest);
+
+    const sentryLog = this.mapLevel(level);
+    sentryLog(message, attrs);
+
+    callback();
+  }
+
+  private mapLevel(
+    winstonLevel: string,
+  ): (msg: string, attrs: Record<string, unknown>) => void {
+    switch (winstonLevel) {
+      case 'error':
+        return Sentry.logger.error;
+      case 'warn':
+        return Sentry.logger.warn;
+      case 'info':
+        return Sentry.logger.info;
+      case 'debug':
+        return Sentry.logger.debug;
+      default:
+        // verbose, silly, etc.
+        return Sentry.logger.trace;
+    }
+  }
+}
+
+function buildAttributes(
+  context: string | undefined,
+  rest: Record<string, unknown>,
+): Record<string, unknown> {
+  const attrs: Record<string, unknown> = {};
+
+  if (context) {
+    attrs['nestjs.context'] = context;
+  }
+
+  // Attach tenant context from CLS so logs fired outside a Sentry request
+  // scope (background jobs, schedulers, queue workers) still carry user/org.
+  const cls = ClsServiceManager.getClsService<MyClsStore>();
+  if (cls.isActive()) {
+    const userId = cls.get('userId');
+    const orgId = cls.get('orgId');
+    if (userId) attrs['user.id'] = userId;
+    if (orgId) attrs['org.id'] = orgId;
+  }
+
+  // Forward any structured metadata (NestJS Logger passes extra args as
+  // object properties on the info object). Skip internal Winston symbols.
+  for (const [key, value] of Object.entries(rest)) {
+    if (typeof key === 'string' && !key.startsWith('Symbol(')) {
+      attrs[key] = value;
+    }
+  }
+
+  return attrs;
+}

--- a/ayunis-core-backend/src/common/sentry/instrument.ts
+++ b/ayunis-core-backend/src/common/sentry/instrument.ts
@@ -1,15 +1,31 @@
 import * as Sentry from '@sentry/nestjs';
 import { HttpException } from '@nestjs/common';
+import { readFileSync } from 'fs';
+import { join } from 'path';
 import { ApplicationError } from '../errors/base.error';
 
 // Ensure to call this before requiring any other modules!
 const sentryDsn = process.env.SENTRY_DSN;
 const environment = process.env.NODE_ENV ?? 'development';
+const release = process.env.SENTRY_RELEASE ?? readPackageVersion();
+
+function readPackageVersion(): string | undefined {
+  try {
+    const pkg = JSON.parse(
+      readFileSync(join(process.cwd(), 'package.json'), 'utf-8'),
+    ) as { version?: string };
+    return pkg.version;
+  } catch {
+    return undefined;
+  }
+}
 
 if (sentryDsn) {
   Sentry.init({
     dsn: sentryDsn,
     environment,
+    release,
+    enableLogs: true,
     // Performance Monitoring - sample 100% in dev, 10% in prod
     tracesSampleRate: environment === 'production' ? 0.1 : 1.0,
     beforeSend(event, hint) {

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,7 +6,14 @@
       "release-type": "simple",
       "component": "ayunis-core",
       "include-component-in-tag": false,
-      "include-v-in-tag": true
+      "include-v-in-tag": true,
+      "extra-files": [
+        {
+          "type": "json",
+          "path": "ayunis-core-backend/package.json",
+          "jsonpath": "$.version"
+        }
+      ]
     }
   },
   "changelog-sections": [


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes production telemetry by exporting structured logs (including request/tenant identifiers) to Sentry, which could affect data exposure and logging volume/cost if misconfigured.
> 
> **Overview**
> Adds production forwarding of application logs to Sentry Structured Logs by introducing a custom Winston `SentryLogTransport` (including CLS-derived `userId`/`orgId` and extra structured metadata) and wiring it into the shared logger when `SENTRY_DSN` is set.
> 
> Updates Sentry initialization to enable logs and to set the Sentry `release` from `SENTRY_RELEASE` or the backend `package.json` version; also aligns release automation by bumping `ayunis-core-backend/package.json` to `1.27.0` and configuring `release-please` to update that version field.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac3ea4bf944711ee0f24163909b536e309797a53. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->