### PR TITLE
feat(skills): process uploads async (AYC-108)

### DIFF
--- a/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/add-document-to-knowledge-base/add-document-to-knowledge-base.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/add-document-to-knowledge-base/add-document-to-knowledge-base.use-case.spec.ts
@@ -7,12 +7,7 @@ import { AddDocumentToKnowledgeBaseCommand } from './add-document-to-knowledge-b
 import { KnowledgeBaseRepository } from '../../ports/knowledge-base.repository';
 import { KnowledgeBase } from '../../../domain/knowledge-base.entity';
 import { KnowledgeBaseNotFoundError } from '../../knowledge-bases.errors';
-import { CreateProcessingSourceUseCase } from 'src/domain/sources/application/use-cases/create-processing-source/create-processing-source.use-case';
-import { MarkSourceFailedUseCase } from 'src/domain/sources/application/use-cases/mark-source-failed/mark-source-failed.use-case';
-import { EnqueueDocumentProcessingUseCase } from 'src/domain/sources/application/use-cases/enqueue-document-processing/enqueue-document-processing.use-case';
-import { UploadObjectUseCase } from 'src/domain/storage/application/use-cases/upload-object/upload-object.use-case';
-import { DeleteObjectUseCase } from 'src/domain/storage/application/use-cases/delete-object/delete-object.use-case';
-import { ContextService } from 'src/common/context/services/context.service';
+import { StartDocumentProcessingUseCase } from 'src/domain/sources/application/use-cases/start-document-processing/start-document-processing.use-case';
 import { SourceStatus } from 'src/domain/sources/domain/source-status.enum';
 import { FileSource } from 'src/domain/sources/domain/sources/text-source.entity';
 import { FileType, TextType } from 'src/domain/sources/domain/source-type.enum';
@@ -20,12 +15,7 @@ import { FileType, TextType } from 'src/domain/sources/domain/source-type.enum';
 describe('AddDocumentToKnowledgeBaseUseCase', () => {
   let useCase: AddDocumentToKnowledgeBaseUseCase;
   let mockKbRepository: jest.Mocked<KnowledgeBaseRepository>;
-  let mockCreateProcessingSourceUseCase: jest.Mocked<CreateProcessingSourceUseCase>;
-  let mockMarkSourceFailedUseCase: jest.Mocked<MarkSourceFailedUseCase>;
-  let mockUploadObjectUseCase: jest.Mocked<UploadObjectUseCase>;
-  let mockDeleteObjectUseCase: jest.Mocked<DeleteObjectUseCase>;
-  let mockEnqueueDocumentProcessingUseCase: jest.Mocked<EnqueueDocumentProcessingUseCase>;
-  let mockContextService: jest.Mocked<ContextService>;
+  let mockStartDocumentProcessingUseCase: jest.Mocked<StartDocumentProcessingUseCase>;
   let mockTxHost: { withTransaction: jest.Mock };
 
   const userId = '11111111-1111-1111-1111-111111111111' as UUID;
@@ -56,33 +46,9 @@ describe('AddDocumentToKnowledgeBaseUseCase', () => {
       findSourceByIdAndKnowledgeBaseId: jest.fn(),
     } as jest.Mocked<KnowledgeBaseRepository>;
 
-    mockCreateProcessingSourceUseCase = {
+    mockStartDocumentProcessingUseCase = {
       execute: jest.fn(),
-    } as unknown as jest.Mocked<CreateProcessingSourceUseCase>;
-
-    mockMarkSourceFailedUseCase = {
-      execute: jest.fn(),
-    } as unknown as jest.Mocked<MarkSourceFailedUseCase>;
-
-    mockUploadObjectUseCase = {
-      execute: jest.fn(),
-    } as unknown as jest.Mocked<UploadObjectUseCase>;
-
-    mockDeleteObjectUseCase = {
-      execute: jest.fn(),
-    } as unknown as jest.Mocked<DeleteObjectUseCase>;
-
-    mockEnqueueDocumentProcessingUseCase = {
-      execute: jest.fn(),
-    } as unknown as jest.Mocked<EnqueueDocumentProcessingUseCase>;
-
-    mockContextService = {
-      get: jest.fn().mockImplementation((key: string) => {
-        if (key === 'orgId') return orgId;
-        if (key === 'userId') return userId;
-        return undefined;
-      }),
-    } as unknown as jest.Mocked<ContextService>;
+    } as unknown as jest.Mocked<StartDocumentProcessingUseCase>;
 
     mockTxHost = {
       withTransaction: jest
@@ -91,7 +57,7 @@ describe('AddDocumentToKnowledgeBaseUseCase', () => {
     };
 
     // Default: return a processing source
-    mockCreateProcessingSourceUseCase.execute.mockImplementation(async (cmd) =>
+    mockStartDocumentProcessingUseCase.execute.mockImplementation(async (cmd) =>
       buildProcessingSource({ name: cmd.fileName }),
     );
 
@@ -100,20 +66,9 @@ describe('AddDocumentToKnowledgeBaseUseCase', () => {
         AddDocumentToKnowledgeBaseUseCase,
         { provide: KnowledgeBaseRepository, useValue: mockKbRepository },
         {
-          provide: CreateProcessingSourceUseCase,
-          useValue: mockCreateProcessingSourceUseCase,
+          provide: StartDocumentProcessingUseCase,
+          useValue: mockStartDocumentProcessingUseCase,
         },
-        {
-          provide: MarkSourceFailedUseCase,
-          useValue: mockMarkSourceFailedUseCase,
-        },
-        { provide: UploadObjectUseCase, useValue: mockUploadObjectUseCase },
-        { provide: DeleteObjectUseCase, useValue: mockDeleteObjectUseCase },
-        {
-          provide: EnqueueDocumentProcessingUseCase,
-          useValue: mockEnqueueDocumentProcessingUseCase,
-        },
-        { provide: ContextService, useValue: mockContextService },
         { provide: TransactionHost, useValue: mockTxHost },
       ],
     }).compile();
@@ -121,7 +76,7 @@ describe('AddDocumentToKnowledgeBaseUseCase', () => {
     useCase = module.get(AddDocumentToKnowledgeBaseUseCase);
   });
 
-  it('should create a PROCESSING source, upload to MinIO, and enqueue job', async () => {
+  it('should validate KB, start document processing, and assign source to KB', async () => {
     const knowledgeBase = new KnowledgeBase({
       id: knowledgeBaseId,
       name: 'Stadtratsprotokolle 2025',
@@ -144,27 +99,19 @@ describe('AddDocumentToKnowledgeBaseUseCase', () => {
     expect(result.status).toBe(SourceStatus.PROCESSING);
     expect(result.name).toBe('Protokoll_März_2025.pdf');
 
-    // Source created via use case
-    expect(mockCreateProcessingSourceUseCase.execute).toHaveBeenCalledTimes(1);
+    // StartDocumentProcessingUseCase called with correct params
+    expect(mockStartDocumentProcessingUseCase.execute).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fileData: command.fileData,
+        fileName: 'Protokoll_März_2025.pdf',
+        fileType: 'application/pdf',
+      }),
+    );
 
     // Assigned to KB
     expect(mockKbRepository.assignSourceToKnowledgeBase).toHaveBeenCalledWith(
       result.id,
       knowledgeBaseId,
-    );
-
-    // File uploaded to MinIO
-    expect(mockUploadObjectUseCase.execute).toHaveBeenCalledTimes(1);
-
-    // Job enqueued
-    expect(mockEnqueueDocumentProcessingUseCase.execute).toHaveBeenCalledWith(
-      expect.objectContaining({
-        sourceId: result.id,
-        orgId,
-        userId,
-        fileName: 'Protokoll_März_2025.pdf',
-        fileType: 'application/pdf',
-      }),
     );
   });
 
@@ -189,7 +136,7 @@ describe('AddDocumentToKnowledgeBaseUseCase', () => {
     await expect(useCase.execute(command)).rejects.toThrow(
       KnowledgeBaseNotFoundError,
     );
-    expect(mockCreateProcessingSourceUseCase.execute).not.toHaveBeenCalled();
+    expect(mockStartDocumentProcessingUseCase.execute).not.toHaveBeenCalled();
   });
 
   it('should throw KnowledgeBaseNotFoundError when KB does not exist', async () => {
@@ -208,7 +155,7 @@ describe('AddDocumentToKnowledgeBaseUseCase', () => {
     );
   });
 
-  it('should mark source as FAILED when MinIO upload fails', async () => {
+  it('should propagate StartDocumentProcessingUseCase failure', async () => {
     const knowledgeBase = new KnowledgeBase({
       id: knowledgeBaseId,
       name: 'Stadtratsprotokolle 2025',
@@ -216,7 +163,7 @@ describe('AddDocumentToKnowledgeBaseUseCase', () => {
       userId,
     });
     mockKbRepository.findById.mockResolvedValue(knowledgeBase);
-    mockUploadObjectUseCase.execute.mockRejectedValue(
+    mockStartDocumentProcessingUseCase.execute.mockRejectedValue(
       new Error('MinIO connection refused'),
     );
 
@@ -230,15 +177,11 @@ describe('AddDocumentToKnowledgeBaseUseCase', () => {
 
     await expect(useCase.execute(command)).rejects.toThrow();
 
-    // Source should be marked as FAILED via use case
-    expect(mockMarkSourceFailedUseCase.execute).toHaveBeenCalledWith(
-      expect.objectContaining({
-        errorMessage: 'Failed to upload file to storage',
-      }),
-    );
+    // Source should NOT be assigned to KB
+    expect(mockKbRepository.assignSourceToKnowledgeBase).not.toHaveBeenCalled();
   });
 
-  it('should mark source as FAILED when enqueue fails after MinIO upload', async () => {
+  it('should leave orphaned source when KB assignment fails after processing starts', async () => {
     const knowledgeBase = new KnowledgeBase({
       id: knowledgeBaseId,
       name: 'Stadtratsprotokolle 2025',
@@ -246,8 +189,8 @@ describe('AddDocumentToKnowledgeBaseUseCase', () => {
       userId,
     });
     mockKbRepository.findById.mockResolvedValue(knowledgeBase);
-    mockEnqueueDocumentProcessingUseCase.execute.mockRejectedValue(
-      new Error('Redis connection refused'),
+    mockKbRepository.assignSourceToKnowledgeBase.mockRejectedValue(
+      new Error('DB constraint violation'),
     );
 
     const command = new AddDocumentToKnowledgeBaseCommand({
@@ -258,13 +201,10 @@ describe('AddDocumentToKnowledgeBaseUseCase', () => {
       fileType: 'application/pdf',
     });
 
+    // Should throw — orphaned source will be cleaned by stale processing cron
     await expect(useCase.execute(command)).rejects.toThrow();
 
-    // Source should be marked as FAILED via use case
-    expect(mockMarkSourceFailedUseCase.execute).toHaveBeenCalledWith(
-      expect.objectContaining({
-        errorMessage: 'Failed to enqueue processing job',
-      }),
-    );
+    // Processing was started (source created)
+    expect(mockStartDocumentProcessingUseCase.execute).toHaveBeenCalledTimes(1);
   });
 });

--- a/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/add-document-to-knowledge-base/add-document-to-knowledge-base.use-case.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/add-document-to-knowledge-base/add-document-to-knowledge-base.use-case.ts
@@ -1,20 +1,10 @@
-import * as path from 'path';
 import { Injectable, Logger } from '@nestjs/common';
 import { TransactionHost } from '@nestjs-cls/transactional';
 import { TransactionalAdapterTypeOrm } from '@nestjs-cls/transactional-adapter-typeorm';
-import { ContextService } from 'src/common/context/services/context.service';
 import { ApplicationError } from 'src/common/errors/base.error';
 import { FileSource } from 'src/domain/sources/domain/sources/text-source.entity';
-import { CreateProcessingSourceUseCase } from 'src/domain/sources/application/use-cases/create-processing-source/create-processing-source.use-case';
-import { CreateProcessingSourceCommand } from 'src/domain/sources/application/use-cases/create-processing-source/create-processing-source.command';
-import { MarkSourceFailedUseCase } from 'src/domain/sources/application/use-cases/mark-source-failed/mark-source-failed.use-case';
-import { MarkSourceFailedCommand } from 'src/domain/sources/application/use-cases/mark-source-failed/mark-source-failed.command';
-import { EnqueueDocumentProcessingUseCase } from 'src/domain/sources/application/use-cases/enqueue-document-processing/enqueue-document-processing.use-case';
-import { EnqueueDocumentProcessingCommand } from 'src/domain/sources/application/use-cases/enqueue-document-processing/enqueue-document-processing.command';
-import { UploadObjectUseCase } from 'src/domain/storage/application/use-cases/upload-object/upload-object.use-case';
-import { UploadObjectCommand } from 'src/domain/storage/application/use-cases/upload-object/upload-object.command';
-import { DeleteObjectUseCase } from 'src/domain/storage/application/use-cases/delete-object/delete-object.use-case';
-import { DeleteObjectCommand } from 'src/domain/storage/application/use-cases/delete-object/delete-object.command';
+import { StartDocumentProcessingUseCase } from 'src/domain/sources/application/use-cases/start-document-processing/start-document-processing.use-case';
+import { StartDocumentProcessingCommand } from 'src/domain/sources/application/use-cases/start-document-processing/start-document-processing.command';
 import { KnowledgeBaseRepository } from '../../ports/knowledge-base.repository';
 import {
   KnowledgeBaseNotFoundError,
@@ -28,12 +18,7 @@ export class AddDocumentToKnowledgeBaseUseCase {
 
   constructor(
     private readonly knowledgeBaseRepository: KnowledgeBaseRepository,
-    private readonly createProcessingSourceUseCase: CreateProcessingSourceUseCase,
-    private readonly markSourceFailedUseCase: MarkSourceFailedUseCase,
-    private readonly uploadObjectUseCase: UploadObjectUseCase,
-    private readonly deleteObjectUseCase: DeleteObjectUseCase,
-    private readonly enqueueDocumentProcessingUseCase: EnqueueDocumentProcessingUseCase,
-    private readonly contextService: ContextService,
+    private readonly startDocumentProcessingUseCase: StartDocumentProcessingUseCase,
     private readonly txHost: TransactionHost<TransactionalAdapterTypeOrm>,
   ) {}
 
@@ -46,55 +31,30 @@ export class AddDocumentToKnowledgeBaseUseCase {
     });
 
     try {
-      const orgId = this.contextService.get('orgId');
-      if (!orgId) {
-        throw new Error('orgId is required');
-      }
+      // 1. Validate KB exists and belongs to user (in transaction)
+      await this.txHost.withTransaction(async () => {
+        const knowledgeBase = await this.knowledgeBaseRepository.findById(
+          command.knowledgeBaseId,
+        );
+        if (knowledgeBase?.userId !== command.userId) {
+          throw new KnowledgeBaseNotFoundError(command.knowledgeBaseId);
+        }
+      });
 
-      // 1. DB writes in a transaction
-      const savedSource = await this.persistSourceInTransaction(command);
+      // 2. Start async document processing (creates PROCESSING source, uploads to MinIO, enqueues job)
+      const savedSource = await this.startDocumentProcessingUseCase.execute(
+        new StartDocumentProcessingCommand({
+          fileData: command.fileData,
+          fileName: command.fileName,
+          fileType: command.fileType,
+        }),
+      );
 
-      // 2. Upload file to MinIO (outside transaction)
-      const sanitizedFileName = path
-        .basename(command.fileName)
-        .replace(/[^a-zA-Z0-9._-]/g, '_');
-      const minioPath = `${orgId}/processing/${savedSource.id}/${sanitizedFileName}`;
-      try {
-        await this.uploadObjectUseCase.execute(
-          new UploadObjectCommand(minioPath, command.fileData),
-        );
-      } catch (error) {
-        await this.tryMarkSourceFailed(
-          savedSource,
-          'Failed to upload file to storage',
-        );
-        throw error;
-      }
-
-      // 3. Enqueue BullMQ job (outside transaction)
-      try {
-        await this.enqueueDocumentProcessingUseCase.execute(
-          new EnqueueDocumentProcessingCommand({
-            sourceId: savedSource.id,
-            orgId,
-            userId: command.userId,
-            minioPath,
-            fileName: command.fileName,
-            fileType: command.fileType,
-          }),
-        );
-      } catch (error) {
-        this.logger.error('Failed to enqueue document processing job', {
-          sourceId: savedSource.id,
-          error: error as Error,
-        });
-        await this.tryMarkSourceFailed(
-          savedSource,
-          'Failed to enqueue processing job',
-        );
-        await this.cleanupMinioFile(minioPath);
-        throw error;
-      }
+      // 3. Assign source to KB
+      await this.knowledgeBaseRepository.assignSourceToKnowledgeBase(
+        savedSource.id,
+        command.knowledgeBaseId,
+      );
 
       return savedSource;
     } catch (error) {
@@ -108,68 +68,6 @@ export class AddDocumentToKnowledgeBaseUseCase {
         'Error adding document to knowledge base',
         { error: error as Error },
       );
-    }
-  }
-
-  private async persistSourceInTransaction(
-    command: AddDocumentToKnowledgeBaseCommand,
-  ): Promise<FileSource> {
-    return this.txHost.withTransaction(async () => {
-      // Verify KB exists and belongs to user
-      const knowledgeBase = await this.knowledgeBaseRepository.findById(
-        command.knowledgeBaseId,
-      );
-      if (knowledgeBase?.userId !== command.userId) {
-        throw new KnowledgeBaseNotFoundError(command.knowledgeBaseId);
-      }
-
-      // Create source with PROCESSING status via sources module use case
-      const savedSource = await this.createProcessingSourceUseCase.execute(
-        new CreateProcessingSourceCommand({
-          fileType: command.fileType,
-          fileName: command.fileName,
-        }),
-      );
-
-      // Assign source to KB
-      await this.knowledgeBaseRepository.assignSourceToKnowledgeBase(
-        savedSource.id,
-        command.knowledgeBaseId,
-      );
-
-      return savedSource;
-    });
-  }
-
-  private async cleanupMinioFile(minioPath: string): Promise<void> {
-    try {
-      await this.deleteObjectUseCase.execute(
-        new DeleteObjectCommand(minioPath),
-      );
-    } catch (err) {
-      this.logger.warn('Failed to clean up MinIO processing file', {
-        minioPath,
-        error: err as Error,
-      });
-    }
-  }
-
-  private async tryMarkSourceFailed(
-    source: FileSource,
-    errorMessage: string,
-  ): Promise<void> {
-    try {
-      await this.markSourceFailedUseCase.execute(
-        new MarkSourceFailedCommand({
-          sourceId: source.id,
-          errorMessage,
-        }),
-      );
-    } catch (err) {
-      this.logger.error('Failed to mark source as FAILED', {
-        sourceId: source.id,
-        error: err as Error,
-      });
     }
   }
 }

--- a/ayunis-core-backend/src/domain/skills/application/services/skill-activation.service.spec.ts
+++ b/ayunis-core-backend/src/domain/skills/application/services/skill-activation.service.spec.ts
@@ -14,6 +14,7 @@ import { Skill } from 'src/domain/skills/domain/skill.entity';
 import { Thread } from 'src/domain/threads/domain/thread.entity';
 import { UrlSource } from 'src/domain/sources/domain/sources/text-source.entity';
 import { TextType } from 'src/domain/sources/domain/source-type.enum';
+import { SourceStatus } from 'src/domain/sources/domain/source-status.enum';
 import type { UUID } from 'crypto';
 
 describe('SkillActivationService', () => {
@@ -54,12 +55,13 @@ describe('SkillActivationService', () => {
       ...overrides,
     });
 
-  const makeSource = (id: UUID) =>
+  const makeSource = (id: UUID, status: SourceStatus = SourceStatus.READY) =>
     new UrlSource({
       id,
       url: `https://example.com/doc-${id}`,
       name: `Source ${id}`,
       type: TextType.WEB,
+      status,
     });
 
   beforeEach(async () => {
@@ -329,6 +331,67 @@ describe('SkillActivationService', () => {
       await service.activateOnThread(skillId, thread);
 
       expect(addKnowledgeBaseToThreadUseCase.execute).toHaveBeenCalledTimes(2);
+    });
+
+    it('should skip sources with FAILED status and only attach READY sources', async () => {
+      const thread = makeThread();
+      const skill = makeSkill({
+        mcpIntegrationIds: [],
+        knowledgeBaseIds: [],
+      });
+      const readySource = makeSource(sourceId1, SourceStatus.READY);
+      const failedSource = makeSource(sourceId2, SourceStatus.FAILED);
+
+      skillAccessService.findAccessibleSkill.mockResolvedValue(skill);
+      getSourcesByIdsUseCase.execute.mockResolvedValue([
+        readySource,
+        failedSource,
+      ]);
+
+      await service.activateOnThread(skillId, thread);
+
+      expect(addSourceToThreadUseCase.execute).toHaveBeenCalledTimes(1);
+      expect(addSourceToThreadUseCase.execute).toHaveBeenCalledWith(
+        expect.objectContaining({ source: readySource }),
+      );
+    });
+
+    it('should skip sources with PROCESSING status', async () => {
+      const thread = makeThread();
+      const skill = makeSkill({
+        mcpIntegrationIds: [],
+        knowledgeBaseIds: [],
+      });
+      const processingSource = makeSource(sourceId1, SourceStatus.PROCESSING);
+
+      skillAccessService.findAccessibleSkill.mockResolvedValue(skill);
+      getSourcesByIdsUseCase.execute.mockResolvedValue([processingSource]);
+
+      await service.activateOnThread(skillId, thread);
+
+      expect(addSourceToThreadUseCase.execute).not.toHaveBeenCalled();
+    });
+
+    it('should log a warning for each non-ready source that is skipped', async () => {
+      const thread = makeThread();
+      const skill = makeSkill({
+        mcpIntegrationIds: [],
+        knowledgeBaseIds: [],
+      });
+      const failedSource = makeSource(sourceId1, SourceStatus.FAILED);
+
+      skillAccessService.findAccessibleSkill.mockResolvedValue(skill);
+      getSourcesByIdsUseCase.execute.mockResolvedValue([failedSource]);
+
+      await service.activateOnThread(skillId, thread);
+
+      expect(Logger.prototype.warn).toHaveBeenCalledWith(
+        'Skipping non-ready source',
+        expect.objectContaining({
+          sourceId: sourceId1,
+          status: SourceStatus.FAILED,
+        }),
+      );
     });
   });
 });

--- a/ayunis-core-backend/src/domain/skills/application/services/skill-activation.service.ts
+++ b/ayunis-core-backend/src/domain/skills/application/services/skill-activation.service.ts
@@ -10,6 +10,7 @@ import { GetSourcesByIdsUseCase } from 'src/domain/sources/application/use-cases
 import { GetSourcesByIdsQuery } from 'src/domain/sources/application/use-cases/get-sources-by-ids/get-sources-by-ids.query';
 import { SourceAlreadyAssignedError } from 'src/domain/threads/application/threads.errors';
 import { KnowledgeBaseNotFoundError } from 'src/domain/knowledge-bases/application/knowledge-bases.errors';
+import { SourceStatus } from 'src/domain/sources/domain/source-status.enum';
 import type { Thread } from 'src/domain/threads/domain/thread.entity';
 import type { UUID } from 'crypto';
 
@@ -46,10 +47,21 @@ export class SkillActivationService {
 
     const skill = await this.skillAccessService.findAccessibleSkill(skillId);
 
-    // Copy skill's sources to the thread
-    const sources = await this.getSourcesByIdsUseCase.execute(
+    // Copy skill's sources to the thread (skip non-ready sources)
+    const allSources = await this.getSourcesByIdsUseCase.execute(
       new GetSourcesByIdsQuery(skill.sourceIds),
     );
+    const sources = allSources.filter((source) => {
+      if (source.status !== SourceStatus.READY) {
+        this.logger.warn('Skipping non-ready source', {
+          sourceId: source.id,
+          status: source.status,
+          threadId: thread.id,
+        });
+        return false;
+      }
+      return true;
+    });
     for (const source of sources) {
       try {
         await this.addSourceToThreadUseCase.execute(

--- a/ayunis-core-backend/src/domain/skills/presenters/http/dto/skill-response.dto.ts
+++ b/ayunis-core-backend/src/domain/skills/presenters/http/dto/skill-response.dto.ts
@@ -1,5 +1,6 @@
-import { ApiProperty } from '@nestjs/swagger';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { UUID } from 'crypto';
+import { SourceStatus } from 'src/domain/sources/domain/source-status.enum';
 
 export class SkillResponseDto {
   @ApiProperty({
@@ -103,4 +104,25 @@ export class SkillSourceResponseDto {
     example: 'file',
   })
   type: string;
+
+  @ApiProperty({
+    description: 'Processing status of the source',
+    enum: SourceStatus,
+    example: SourceStatus.READY,
+  })
+  status: SourceStatus;
+
+  @ApiPropertyOptional({
+    description: 'Error message if processing failed',
+    example: 'OCR extraction timed out',
+  })
+  processingError?: string;
+
+  @ApiProperty({
+    description: 'The date and time when the source was created',
+    example: '2025-01-15T10:00:00.000Z',
+    type: 'string',
+    format: 'date-time',
+  })
+  createdAt: string;
 }

--- a/ayunis-core-backend/src/domain/skills/presenters/http/mappers/skill.mapper.ts
+++ b/ayunis-core-backend/src/domain/skills/presenters/http/mappers/skill.mapper.ts
@@ -45,6 +45,9 @@ export class SkillDtoMapper {
       id: source.id,
       name: source.name,
       type: source.type,
+      status: source.status,
+      processingError: source.processingError ?? undefined,
+      createdAt: source.createdAt.toISOString(),
     };
   }
 

--- a/ayunis-core-backend/src/domain/skills/presenters/http/skill-sources.controller.ts
+++ b/ayunis-core-backend/src/domain/skills/presenters/http/skill-sources.controller.ts
@@ -46,7 +46,6 @@ import { diskStorage } from 'multer';
 import { extname } from 'path';
 import { randomUUID } from 'crypto';
 import * as fs from 'fs';
-import { Transactional } from '@nestjs-cls/transactional';
 import { StartDocumentProcessingUseCase } from 'src/domain/sources/application/use-cases/start-document-processing/start-document-processing.use-case';
 import { StartDocumentProcessingCommand } from 'src/domain/sources/application/use-cases/start-document-processing/start-document-processing.command';
 import { CreateCSVDataSourceCommand } from 'src/domain/sources/application/use-cases/create-data-source/create-data-source.command';
@@ -158,7 +157,6 @@ export class SkillSourcesController {
       }),
     }),
   )
-  @Transactional()
   async addFileSource(
     @CurrentUser(UserProperty.ID) userId: UUID,
     @Param('id', ParseUUIDPipe) skillId: UUID,

--- a/ayunis-core-backend/src/domain/skills/presenters/http/skill-sources.controller.ts
+++ b/ayunis-core-backend/src/domain/skills/presenters/http/skill-sources.controller.ts
@@ -47,14 +47,13 @@ import { extname } from 'path';
 import { randomUUID } from 'crypto';
 import * as fs from 'fs';
 import { Transactional } from '@nestjs-cls/transactional';
-import { CreateFileSourceCommand } from 'src/domain/sources/application/use-cases/create-text-source/create-text-source.command';
-import { CreateTextSourceUseCase } from 'src/domain/sources/application/use-cases/create-text-source/create-text-source.use-case';
+import { StartDocumentProcessingUseCase } from 'src/domain/sources/application/use-cases/start-document-processing/start-document-processing.use-case';
+import { StartDocumentProcessingCommand } from 'src/domain/sources/application/use-cases/start-document-processing/start-document-processing.command';
 import { CreateCSVDataSourceCommand } from 'src/domain/sources/application/use-cases/create-data-source/create-data-source.command';
 import { CreateDataSourceUseCase } from 'src/domain/sources/application/use-cases/create-data-source/create-data-source.use-case';
 import { Source } from 'src/domain/sources/domain/source.entity';
 import { Skill } from '../../domain/skill.entity';
 import {
-  DetectedFileType,
   detectFileType,
   getCanonicalMimeType,
   isDocumentFile,
@@ -83,7 +82,7 @@ export class SkillSourcesController {
     private readonly removeSourceFromSkillUseCase: RemoveSourceFromSkillUseCase,
     private readonly listSkillSourcesUseCase: ListSkillSourcesUseCase,
     private readonly skillDtoMapper: SkillDtoMapper,
-    private readonly createTextSourceUseCase: CreateTextSourceUseCase,
+    private readonly startDocumentProcessingUseCase: StartDocumentProcessingUseCase,
     private readonly createDataSourceUseCase: CreateDataSourceUseCase,
     private readonly skillAccessService: SkillAccessService,
   ) {}
@@ -241,7 +240,20 @@ export class SkillSourcesController {
     const detectedType = detectFileType(file.mimetype, file.originalname);
 
     if (isDocumentFile(detectedType) || isPlainTextFile(detectedType)) {
-      const source = await this.createDocumentSource(file, detectedType);
+      const fileData = fs.readFileSync(file.path);
+      const canonicalMimeType = getCanonicalMimeType(detectedType);
+      if (!canonicalMimeType) {
+        throw new Error(
+          `Unable to determine MIME type for detected file type: ${detectedType}`,
+        );
+      }
+      const source = await this.startDocumentProcessingUseCase.execute(
+        new StartDocumentProcessingCommand({
+          fileData,
+          fileName: file.originalname,
+          fileType: canonicalMimeType,
+        }),
+      );
       sources.push(source);
     } else if (isCSVFile(detectedType)) {
       const source = await this.createCsvSource(file);
@@ -264,27 +276,6 @@ export class SkillSourcesController {
     }
 
     return updatedSkill!;
-  }
-
-  private async createDocumentSource(
-    file: { originalname: string; path: string },
-    detectedType: DetectedFileType,
-  ): Promise<Source> {
-    const fileData = fs.readFileSync(file.path);
-    const canonicalMimeType = getCanonicalMimeType(detectedType);
-    if (!canonicalMimeType) {
-      throw new Error(
-        `Unable to determine MIME type for detected file type: ${detectedType}`,
-      );
-    }
-
-    return this.createTextSourceUseCase.execute(
-      new CreateFileSourceCommand({
-        fileType: canonicalMimeType,
-        fileData: fileData,
-        fileName: file.originalname,
-      }),
-    );
   }
 
   private async createCsvSource(file: {

--- a/ayunis-core-backend/src/domain/skills/presenters/http/skill-sources.controller.ts
+++ b/ayunis-core-backend/src/domain/skills/presenters/http/skill-sources.controller.ts
@@ -46,6 +46,7 @@ import { diskStorage } from 'multer';
 import { extname } from 'path';
 import { randomUUID } from 'crypto';
 import * as fs from 'fs';
+import { Transactional } from '@nestjs-cls/transactional';
 import { StartDocumentProcessingUseCase } from 'src/domain/sources/application/use-cases/start-document-processing/start-document-processing.use-case';
 import { StartDocumentProcessingCommand } from 'src/domain/sources/application/use-cases/start-document-processing/start-document-processing.command';
 import { CreateCSVDataSourceCommand } from 'src/domain/sources/application/use-cases/create-data-source/create-data-source.command';
@@ -234,7 +235,6 @@ export class SkillSourcesController {
     skillId: UUID,
     file: { originalname: string; mimetype: string; path: string },
   ): Promise<Skill> {
-    const sources: Source[] = [];
     const detectedType = detectFileType(file.mimetype, file.originalname);
 
     if (isDocumentFile(detectedType) || isPlainTextFile(detectedType)) {
@@ -252,27 +252,44 @@ export class SkillSourcesController {
           fileType: canonicalMimeType,
         }),
       );
-      sources.push(source);
+      return this.addSourceToSkillUseCase.execute(
+        new AddSourceToSkillCommand({ skillId, sourceId: source.id }),
+      );
     } else if (isCSVFile(detectedType)) {
-      const source = await this.createCsvSource(file);
-      sources.push(source);
+      return this.processCSVUpload(skillId, file);
     } else if (isSpreadsheetFile(detectedType)) {
-      const sheetSources = await this.createSpreadsheetSources(file);
-      sources.push(...sheetSources);
+      return this.processSpreadsheetUpload(skillId, file);
     } else {
       throw new UnsupportedFileTypeError(
         detectedType === 'unknown' ? file.originalname : detectedType,
         ['PDF', 'DOCX', 'PPTX', 'TXT', 'CSV', 'XLSX', 'XLS'],
       );
     }
+  }
 
+  @Transactional()
+  private async processCSVUpload(
+    skillId: UUID,
+    file: { originalname: string; path: string },
+  ): Promise<Skill> {
+    const source = await this.createCsvSource(file);
+    return this.addSourceToSkillUseCase.execute(
+      new AddSourceToSkillCommand({ skillId, sourceId: source.id }),
+    );
+  }
+
+  @Transactional()
+  private async processSpreadsheetUpload(
+    skillId: UUID,
+    file: { originalname: string; path: string },
+  ): Promise<Skill> {
+    const sources = await this.createSpreadsheetSources(file);
     let updatedSkill: Skill | undefined;
     for (const source of sources) {
       updatedSkill = await this.addSourceToSkillUseCase.execute(
         new AddSourceToSkillCommand({ skillId, sourceId: source.id }),
       );
     }
-
     return updatedSkill!;
   }
 

--- a/ayunis-core-backend/src/domain/sources/application/use-cases/start-document-processing/start-document-processing.command.ts
+++ b/ayunis-core-backend/src/domain/sources/application/use-cases/start-document-processing/start-document-processing.command.ts
@@ -1,0 +1,15 @@
+export class StartDocumentProcessingCommand {
+  readonly fileData: Buffer;
+  readonly fileName: string;
+  readonly fileType: string;
+
+  constructor(params: {
+    fileData: Buffer;
+    fileName: string;
+    fileType: string;
+  }) {
+    this.fileData = params.fileData;
+    this.fileName = params.fileName;
+    this.fileType = params.fileType;
+  }
+}

--- a/ayunis-core-backend/src/domain/sources/application/use-cases/start-document-processing/start-document-processing.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/sources/application/use-cases/start-document-processing/start-document-processing.use-case.spec.ts
@@ -1,0 +1,211 @@
+import type { TestingModule } from '@nestjs/testing';
+import { Test } from '@nestjs/testing';
+import type { UUID } from 'crypto';
+import { StartDocumentProcessingUseCase } from './start-document-processing.use-case';
+import { StartDocumentProcessingCommand } from './start-document-processing.command';
+import { CreateProcessingSourceUseCase } from 'src/domain/sources/application/use-cases/create-processing-source/create-processing-source.use-case';
+import { MarkSourceFailedUseCase } from 'src/domain/sources/application/use-cases/mark-source-failed/mark-source-failed.use-case';
+import { EnqueueDocumentProcessingUseCase } from 'src/domain/sources/application/use-cases/enqueue-document-processing/enqueue-document-processing.use-case';
+import { UploadObjectUseCase } from 'src/domain/storage/application/use-cases/upload-object/upload-object.use-case';
+import { DeleteObjectUseCase } from 'src/domain/storage/application/use-cases/delete-object/delete-object.use-case';
+import { ContextService } from 'src/common/context/services/context.service';
+import { SourceStatus } from 'src/domain/sources/domain/source-status.enum';
+import { FileSource } from 'src/domain/sources/domain/sources/text-source.entity';
+import { FileType, TextType } from 'src/domain/sources/domain/source-type.enum';
+
+describe('StartDocumentProcessingUseCase', () => {
+  let useCase: StartDocumentProcessingUseCase;
+  let mockCreateProcessingSourceUseCase: jest.Mocked<CreateProcessingSourceUseCase>;
+  let mockMarkSourceFailedUseCase: jest.Mocked<MarkSourceFailedUseCase>;
+  let mockUploadObjectUseCase: jest.Mocked<UploadObjectUseCase>;
+  let mockDeleteObjectUseCase: jest.Mocked<DeleteObjectUseCase>;
+  let mockEnqueueDocumentProcessingUseCase: jest.Mocked<EnqueueDocumentProcessingUseCase>;
+  let mockContextService: jest.Mocked<ContextService>;
+
+  const userId = '11111111-1111-1111-1111-111111111111' as UUID;
+  const orgId = '22222222-2222-2222-2222-222222222222' as UUID;
+
+  function buildProcessingSource(
+    overrides: Partial<{ name: string }> = {},
+  ): FileSource {
+    return new FileSource({
+      fileType: FileType.PDF,
+      name: overrides.name ?? 'Protokoll.pdf',
+      type: TextType.FILE,
+      status: SourceStatus.PROCESSING,
+      processingStartedAt: new Date(),
+    });
+  }
+
+  beforeEach(async () => {
+    mockCreateProcessingSourceUseCase = {
+      execute: jest.fn(),
+    } as unknown as jest.Mocked<CreateProcessingSourceUseCase>;
+
+    mockMarkSourceFailedUseCase = {
+      execute: jest.fn(),
+    } as unknown as jest.Mocked<MarkSourceFailedUseCase>;
+
+    mockUploadObjectUseCase = {
+      execute: jest.fn(),
+    } as unknown as jest.Mocked<UploadObjectUseCase>;
+
+    mockDeleteObjectUseCase = {
+      execute: jest.fn(),
+    } as unknown as jest.Mocked<DeleteObjectUseCase>;
+
+    mockEnqueueDocumentProcessingUseCase = {
+      execute: jest.fn(),
+    } as unknown as jest.Mocked<EnqueueDocumentProcessingUseCase>;
+
+    mockContextService = {
+      get: jest.fn().mockImplementation((key: string) => {
+        if (key === 'orgId') return orgId;
+        if (key === 'userId') return userId;
+        return undefined;
+      }),
+    } as unknown as jest.Mocked<ContextService>;
+
+    mockCreateProcessingSourceUseCase.execute.mockImplementation(async (cmd) =>
+      buildProcessingSource({ name: cmd.fileName }),
+    );
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        StartDocumentProcessingUseCase,
+        {
+          provide: CreateProcessingSourceUseCase,
+          useValue: mockCreateProcessingSourceUseCase,
+        },
+        {
+          provide: MarkSourceFailedUseCase,
+          useValue: mockMarkSourceFailedUseCase,
+        },
+        { provide: UploadObjectUseCase, useValue: mockUploadObjectUseCase },
+        { provide: DeleteObjectUseCase, useValue: mockDeleteObjectUseCase },
+        {
+          provide: EnqueueDocumentProcessingUseCase,
+          useValue: mockEnqueueDocumentProcessingUseCase,
+        },
+        { provide: ContextService, useValue: mockContextService },
+      ],
+    }).compile();
+
+    useCase = module.get(StartDocumentProcessingUseCase);
+  });
+
+  it('should create a PROCESSING source, upload to MinIO, and enqueue job', async () => {
+    const command = new StartDocumentProcessingCommand({
+      fileData: Buffer.from('fake pdf content'),
+      fileName: 'Protokoll_März_2025.pdf',
+      fileType: 'application/pdf',
+    });
+
+    const result = await useCase.execute(command);
+
+    // Source created with PROCESSING status
+    expect(result.status).toBe(SourceStatus.PROCESSING);
+    expect(result.name).toBe('Protokoll_März_2025.pdf');
+
+    // Source created via use case
+    expect(mockCreateProcessingSourceUseCase.execute).toHaveBeenCalledTimes(1);
+
+    // File uploaded to MinIO with correct path
+    expect(mockUploadObjectUseCase.execute).toHaveBeenCalledTimes(1);
+    const uploadCall = mockUploadObjectUseCase.execute.mock.calls[0][0];
+    expect(uploadCall.objectName).toContain(`${orgId}/processing/`);
+    expect(uploadCall.objectName).toContain('Protokoll_M_rz_2025.pdf');
+
+    // Job enqueued with correct params
+    expect(mockEnqueueDocumentProcessingUseCase.execute).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sourceId: result.id,
+        orgId,
+        userId,
+        fileName: 'Protokoll_März_2025.pdf',
+        fileType: 'application/pdf',
+      }),
+    );
+  });
+
+  it('should mark source as FAILED when MinIO upload fails', async () => {
+    mockUploadObjectUseCase.execute.mockRejectedValue(
+      new Error('MinIO connection refused'),
+    );
+
+    const command = new StartDocumentProcessingCommand({
+      fileData: Buffer.from('fake pdf content'),
+      fileName: 'Protokoll.pdf',
+      fileType: 'application/pdf',
+    });
+
+    await expect(useCase.execute(command)).rejects.toThrow();
+
+    // Source should be marked as FAILED
+    expect(mockMarkSourceFailedUseCase.execute).toHaveBeenCalledWith(
+      expect.objectContaining({
+        errorMessage: 'Failed to upload file to storage',
+      }),
+    );
+
+    // MinIO file should NOT be cleaned up (upload failed, nothing to clean)
+    expect(mockDeleteObjectUseCase.execute).not.toHaveBeenCalled();
+  });
+
+  it('should mark source as FAILED and clean up MinIO when enqueue fails', async () => {
+    mockEnqueueDocumentProcessingUseCase.execute.mockRejectedValue(
+      new Error('Redis connection refused'),
+    );
+
+    const command = new StartDocumentProcessingCommand({
+      fileData: Buffer.from('fake pdf content'),
+      fileName: 'Protokoll.pdf',
+      fileType: 'application/pdf',
+    });
+
+    await expect(useCase.execute(command)).rejects.toThrow();
+
+    // Source should be marked as FAILED
+    expect(mockMarkSourceFailedUseCase.execute).toHaveBeenCalledWith(
+      expect.objectContaining({
+        errorMessage: 'Failed to enqueue processing job',
+      }),
+    );
+
+    // MinIO file should be cleaned up
+    expect(mockDeleteObjectUseCase.execute).toHaveBeenCalledTimes(1);
+  });
+
+  it('should throw when orgId is missing from context', async () => {
+    mockContextService.get.mockReturnValue(undefined);
+
+    const command = new StartDocumentProcessingCommand({
+      fileData: Buffer.from('fake pdf content'),
+      fileName: 'Protokoll.pdf',
+      fileType: 'application/pdf',
+    });
+
+    await expect(useCase.execute(command)).rejects.toThrow();
+
+    // No source should be created
+    expect(mockCreateProcessingSourceUseCase.execute).not.toHaveBeenCalled();
+  });
+
+  it('should throw when userId is missing from context', async () => {
+    mockContextService.get.mockImplementation((key?: string | symbol) => {
+      if (key === 'orgId') return orgId;
+      return undefined;
+    });
+
+    const command = new StartDocumentProcessingCommand({
+      fileData: Buffer.from('fake pdf content'),
+      fileName: 'Protokoll.pdf',
+      fileType: 'application/pdf',
+    });
+
+    await expect(useCase.execute(command)).rejects.toThrow();
+
+    // No source should be created
+    expect(mockCreateProcessingSourceUseCase.execute).not.toHaveBeenCalled();
+  });
+});

--- a/ayunis-core-backend/src/domain/sources/application/use-cases/start-document-processing/start-document-processing.use-case.ts
+++ b/ayunis-core-backend/src/domain/sources/application/use-cases/start-document-processing/start-document-processing.use-case.ts
@@ -1,0 +1,142 @@
+import * as path from 'path';
+import { Injectable, Logger } from '@nestjs/common';
+import { ContextService } from 'src/common/context/services/context.service';
+import { ApplicationError } from 'src/common/errors/base.error';
+import { FileSource } from 'src/domain/sources/domain/sources/text-source.entity';
+import { CreateProcessingSourceUseCase } from 'src/domain/sources/application/use-cases/create-processing-source/create-processing-source.use-case';
+import { CreateProcessingSourceCommand } from 'src/domain/sources/application/use-cases/create-processing-source/create-processing-source.command';
+import { MarkSourceFailedUseCase } from 'src/domain/sources/application/use-cases/mark-source-failed/mark-source-failed.use-case';
+import { MarkSourceFailedCommand } from 'src/domain/sources/application/use-cases/mark-source-failed/mark-source-failed.command';
+import { EnqueueDocumentProcessingUseCase } from 'src/domain/sources/application/use-cases/enqueue-document-processing/enqueue-document-processing.use-case';
+import { EnqueueDocumentProcessingCommand } from 'src/domain/sources/application/use-cases/enqueue-document-processing/enqueue-document-processing.command';
+import { UploadObjectUseCase } from 'src/domain/storage/application/use-cases/upload-object/upload-object.use-case';
+import { UploadObjectCommand } from 'src/domain/storage/application/use-cases/upload-object/upload-object.command';
+import { DeleteObjectUseCase } from 'src/domain/storage/application/use-cases/delete-object/delete-object.use-case';
+import { DeleteObjectCommand } from 'src/domain/storage/application/use-cases/delete-object/delete-object.command';
+import { UnexpectedSourceError } from '../../sources.errors';
+import { StartDocumentProcessingCommand } from './start-document-processing.command';
+
+@Injectable()
+export class StartDocumentProcessingUseCase {
+  private readonly logger = new Logger(StartDocumentProcessingUseCase.name);
+
+  constructor(
+    private readonly createProcessingSourceUseCase: CreateProcessingSourceUseCase,
+    private readonly markSourceFailedUseCase: MarkSourceFailedUseCase,
+    private readonly uploadObjectUseCase: UploadObjectUseCase,
+    private readonly deleteObjectUseCase: DeleteObjectUseCase,
+    private readonly enqueueDocumentProcessingUseCase: EnqueueDocumentProcessingUseCase,
+    private readonly contextService: ContextService,
+  ) {}
+
+  async execute(command: StartDocumentProcessingCommand): Promise<FileSource> {
+    this.logger.log('Starting async document processing', {
+      fileName: command.fileName,
+    });
+
+    try {
+      const orgId = this.contextService.get('orgId');
+      if (!orgId) {
+        throw new Error('orgId is required');
+      }
+      const userId = this.contextService.get('userId');
+      if (!userId) {
+        throw new Error('userId is required');
+      }
+
+      // 1. Create source with PROCESSING status
+      const savedSource = await this.createProcessingSourceUseCase.execute(
+        new CreateProcessingSourceCommand({
+          fileType: command.fileType,
+          fileName: command.fileName,
+        }),
+      );
+
+      // 2. Upload file to MinIO (outside transaction)
+      const sanitizedFileName = path
+        .basename(command.fileName)
+        .replace(/[^a-zA-Z0-9._-]/g, '_');
+      const minioPath = `${orgId}/processing/${savedSource.id}/${sanitizedFileName}`;
+      try {
+        await this.uploadObjectUseCase.execute(
+          new UploadObjectCommand(minioPath, command.fileData),
+        );
+      } catch (error) {
+        await this.tryMarkSourceFailed(
+          savedSource,
+          'Failed to upload file to storage',
+        );
+        throw error;
+      }
+
+      // 3. Enqueue BullMQ job (outside transaction)
+      try {
+        await this.enqueueDocumentProcessingUseCase.execute(
+          new EnqueueDocumentProcessingCommand({
+            sourceId: savedSource.id,
+            orgId,
+            userId,
+            minioPath,
+            fileName: command.fileName,
+            fileType: command.fileType,
+          }),
+        );
+      } catch (error) {
+        this.logger.error('Failed to enqueue document processing job', {
+          sourceId: savedSource.id,
+          error: error as Error,
+        });
+        await this.tryMarkSourceFailed(
+          savedSource,
+          'Failed to enqueue processing job',
+        );
+        await this.cleanupMinioFile(minioPath);
+        throw error;
+      }
+
+      return savedSource;
+    } catch (error) {
+      if (error instanceof ApplicationError) {
+        throw error;
+      }
+      this.logger.error('Error starting document processing', {
+        error: error as Error,
+      });
+      throw new UnexpectedSourceError('Error starting document processing', {
+        error: error as Error,
+      });
+    }
+  }
+
+  private async cleanupMinioFile(minioPath: string): Promise<void> {
+    try {
+      await this.deleteObjectUseCase.execute(
+        new DeleteObjectCommand(minioPath),
+      );
+    } catch (err) {
+      this.logger.warn('Failed to clean up MinIO processing file', {
+        minioPath,
+        error: err as Error,
+      });
+    }
+  }
+
+  private async tryMarkSourceFailed(
+    source: FileSource,
+    errorMessage: string,
+  ): Promise<void> {
+    try {
+      await this.markSourceFailedUseCase.execute(
+        new MarkSourceFailedCommand({
+          sourceId: source.id,
+          errorMessage,
+        }),
+      );
+    } catch (err) {
+      this.logger.error('Failed to mark source as FAILED', {
+        sourceId: source.id,
+        error: err as Error,
+      });
+    }
+  }
+}

--- a/ayunis-core-backend/src/domain/sources/sources.module.ts
+++ b/ayunis-core-backend/src/domain/sources/sources.module.ts
@@ -23,6 +23,7 @@ import { CreateProcessingSourceUseCase } from './application/use-cases/create-pr
 import { MarkSourceFailedUseCase } from './application/use-cases/mark-source-failed/mark-source-failed.use-case';
 import { EnqueueDocumentProcessingUseCase } from './application/use-cases/enqueue-document-processing/enqueue-document-processing.use-case';
 import { SourceProcessingCleanupService } from './application/services/source-processing-cleanup.service';
+import { StartDocumentProcessingUseCase } from './application/use-cases/start-document-processing/start-document-processing.use-case';
 
 @Module({
   imports: [
@@ -50,6 +51,7 @@ import { SourceProcessingCleanupService } from './application/services/source-pr
     CreateProcessingSourceUseCase,
     MarkSourceFailedUseCase,
     EnqueueDocumentProcessingUseCase,
+    StartDocumentProcessingUseCase,
   ],
   exports: [
     LocalSourceRepositoryModule,
@@ -69,6 +71,7 @@ import { SourceProcessingCleanupService } from './application/services/source-pr
     CreateProcessingSourceUseCase,
     MarkSourceFailedUseCase,
     EnqueueDocumentProcessingUseCase,
+    StartDocumentProcessingUseCase,
   ],
 })
 export class SourcesModule {}

--- a/ayunis-core-frontend/src/pages/skill/api/useSkillSources.ts
+++ b/ayunis-core-frontend/src/pages/skill/api/useSkillSources.ts
@@ -4,10 +4,13 @@ import {
   useSkillSourcesControllerRemoveSource,
 } from '@/shared/api/generated/ayunisCoreAPI';
 import type { SkillResponseDto } from '@/shared/api/generated/ayunisCoreAPI.schemas';
+import { SkillSourceResponseDtoStatus } from '@/shared/api/generated/ayunisCoreAPI.schemas';
 import handleSourceUploadError from '@/shared/lib/handle-source-upload-error';
 import { useQueryClient } from '@tanstack/react-query';
 import { showSuccess, showError } from '@/shared/lib/toast';
 import { useTranslation } from 'react-i18next';
+
+const PROCESSING_POLL_INTERVAL = 5000;
 
 export default function useSkillSources({
   skill,
@@ -18,7 +21,19 @@ export default function useSkillSources({
   const queryClient = useQueryClient();
 
   const { data: sources = [], isLoading: isLoadingSources } =
-    useSkillSourcesControllerGetSkillSources(skill.id);
+    useSkillSourcesControllerGetSkillSources(skill.id, {
+      query: {
+        staleTime: 0,
+        // eslint-disable-next-line sonarjs/function-return-type -- React Query's refetchInterval expects number | false
+        refetchInterval: (query) => {
+          const data = query.state.data ?? [];
+          const hasProcessing = data.some(
+            (s) => s.status === SkillSourceResponseDtoStatus.processing,
+          );
+          return hasProcessing ? PROCESSING_POLL_INTERVAL : false;
+        },
+      },
+    });
 
   const addFileSourceMutation = useSkillSourcesControllerAddFileSource({
     mutation: {

--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
@@ -2906,6 +2906,19 @@ export interface UpdateSkillDto {
   instructions: string;
 }
 
+/**
+ * Processing status of the source
+ */
+export type SkillSourceResponseDtoStatus = typeof SkillSourceResponseDtoStatus[keyof typeof SkillSourceResponseDtoStatus];
+
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const SkillSourceResponseDtoStatus = {
+  processing: 'processing',
+  ready: 'ready',
+  failed: 'failed',
+} as const;
+
 export interface SkillSourceResponseDto {
   /** The unique identifier of the source */
   id: string;
@@ -2913,6 +2926,12 @@ export interface SkillSourceResponseDto {
   name: string;
   /** The type of source */
   type: string;
+  /** Processing status of the source */
+  status: SkillSourceResponseDtoStatus;
+  /** Error message if processing failed */
+  processingError?: string;
+  /** The date and time when the source was created */
+  createdAt: string;
 }
 
 /**

--- a/ayunis-core-frontend/src/shared/api/openapi-schema.json
+++ b/ayunis-core-frontend/src/shared/api/openapi-schema.json
@@ -9810,17 +9810,6 @@
           "resetUrl"
         ]
       },
-      "TriggerPasswordResetResponseDto": {
-        "type": "object",
-        "properties": {
-          "resetUrl": {
-            "type": "string",
-            "description": "The password reset URL sent to the user",
-            "example": "https://app.ayunis.de/password/reset?token=eyJhbGci..."
-          }
-        },
-        "required": ["resetUrl"]
-      },
       "CreateUserDto": {
         "type": "object",
         "properties": {
@@ -13376,12 +13365,35 @@
             "type": "string",
             "description": "The type of source",
             "example": "file"
+          },
+          "status": {
+            "type": "string",
+            "description": "Processing status of the source",
+            "enum": [
+              "processing",
+              "ready",
+              "failed"
+            ],
+            "example": "ready"
+          },
+          "processingError": {
+            "type": "string",
+            "description": "Error message if processing failed",
+            "example": "OCR extraction timed out"
+          },
+          "createdAt": {
+            "type": "string",
+            "description": "The date and time when the source was created",
+            "example": "2025-01-15T10:00:00.000Z",
+            "format": "date-time"
           }
         },
         "required": [
           "id",
           "name",
-          "type"
+          "type",
+          "status",
+          "createdAt"
         ]
       },
       "CreateSkillTemplateDto": {

--- a/ayunis-core-frontend/src/shared/locales/de/skill.json
+++ b/ayunis-core-frontend/src/shared/locales/de/skill.json
@@ -85,7 +85,11 @@
     "description": "Dokumente direkt zu dieser Fähigkeit hochladen",
     "adding": "Wird hinzugefügt...",
     "addSource": "Quelle hinzufügen",
-    "disabledTooltip": "Um Dokumente hochzuladen, muss ein Embedding-Modell aktiviert sein."
+    "disabledTooltip": "Um Dokumente hochzuladen, muss ein Embedding-Modell aktiviert sein.",
+    "statusProcessing": "wird verarbeitet…",
+    "statusProcessingSlow": "wird noch verarbeitet…",
+    "statusFailed": "fehlgeschlagen",
+    "retryUpload": "Versuchen Sie, die Datei erneut hochzuladen."
   },
   "knowledgeBases": {
     "title": "Wissenssammlungen",

--- a/ayunis-core-frontend/src/shared/locales/en/skill.json
+++ b/ayunis-core-frontend/src/shared/locales/en/skill.json
@@ -85,7 +85,11 @@
     "description": "Upload documents directly to this skill",
     "adding": "Adding...",
     "addSource": "Add Source",
-    "disabledTooltip": "To upload documents, an embedding model must be enabled."
+    "disabledTooltip": "To upload documents, an embedding model must be enabled.",
+    "statusProcessing": "processing…",
+    "statusProcessingSlow": "still processing…",
+    "statusFailed": "failed",
+    "retryUpload": "Try uploading the file again."
   },
   "knowledgeBases": {
     "title": "Knowledge Bases",

--- a/ayunis-core-frontend/src/widgets/knowledge-base-card/ui/KnowledgeBaseCard.tsx
+++ b/ayunis-core-frontend/src/widgets/knowledge-base-card/ui/KnowledgeBaseCard.tsx
@@ -10,15 +10,21 @@ import {
   Item,
   ItemContent,
   ItemTitle,
+  ItemDescription,
   ItemActions,
   ItemMedia,
   ItemGroup,
   ItemSeparator,
 } from '@/shared/ui/shadcn/item';
-import { FileText, Loader, X } from 'lucide-react';
+import { FileText, Loader2, AlertCircle, Clock, X } from 'lucide-react';
 import { Input } from '@/shared/ui/shadcn/input';
 import { Button } from '@/shared/ui/shadcn/button';
-import { useRef } from 'react';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/shared/ui/shadcn/tooltip';
+import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import TooltipIf from '@/widgets/tooltip-if/ui/TooltipIf';
 import { showError } from '@/shared/lib/toast';
@@ -26,6 +32,9 @@ import { showError } from '@/shared/lib/toast';
 export interface Source {
   id: string;
   name: string;
+  status?: string;
+  processingError?: string;
+  createdAt?: string;
 }
 
 export interface SourcesHook {
@@ -64,24 +73,6 @@ export default function KnowledgeBaseCard({
     removeSourcePending,
   } = sourcesHook;
 
-  function handleFileRemove(sourceId: string) {
-    removeSource(sourceId);
-  }
-
-  function handleFileChange(event: React.ChangeEvent<HTMLInputElement>) {
-    const file = event.target.files?.[0];
-    if (!isEnabled) {
-      showError(t('additionalDocuments.disabledTooltip'));
-      return;
-    }
-    if (file) {
-      addFileSource({
-        id: entity.id,
-        data: { file },
-      });
-    }
-  }
-
   return (
     <Card>
       <CardHeader>
@@ -92,70 +83,255 @@ export default function KnowledgeBaseCard({
       </CardHeader>
       <CardContent>
         <div className="space-y-4">
-          {/* Display existing sources */}
           {isLoadingSources && (
             <div className="text-sm text-muted-foreground">
-              <Loader className="h-4 w-4 animate-spin" />
+              <Loader2 className="h-4 w-4 animate-spin" />
             </div>
           )}
           {!isLoadingSources && sources.length > 0 && (
-            <ItemGroup>
-              {sources.map((source, index) => (
-                <Fragment key={source.id}>
-                  <Item>
-                    <ItemMedia variant="icon">
-                      <FileText className="h-4 w-4" />
-                    </ItemMedia>
-                    <ItemContent>
-                      <ItemTitle>{source.name}</ItemTitle>
-                    </ItemContent>
-                    {!disabled && (
-                      <ItemActions>
-                        <Button
-                          variant="ghost"
-                          size="icon"
-                          onClick={() => handleFileRemove(source.id)}
-                          disabled={removeSourcePending}
-                        >
-                          <X className="h-4 w-4" />
-                        </Button>
-                      </ItemActions>
-                    )}
-                  </Item>
-                  {index < sources.length - 1 && <ItemSeparator />}
-                </Fragment>
-              ))}
-            </ItemGroup>
+            <SourceList
+              sources={sources}
+              onRemove={removeSource}
+              removeDisabled={removeSourcePending}
+              disabled={disabled}
+              translationNamespace={translationNamespace}
+            />
           )}
-
-          {/* Add Source Button */}
           {!disabled && (
-            <>
-              <Input
-                ref={fileInputRef}
-                type="file"
-                className="hidden"
-                onChange={handleFileChange}
-                accept=".pdf,.docx,.pptx,.txt,.md,.csv,.xlsx,.xls"
-              />
-              <TooltipIf
-                condition={!isEnabled}
-                tooltip={t('additionalDocuments.disabledTooltip')}
-              >
-                <Button
-                  variant="outline"
-                  onClick={() => fileInputRef.current?.click()}
-                  disabled={addFileSourcePending || removeSourcePending}
-                >
-                  {addFileSourcePending
-                    ? t('additionalDocuments.adding')
-                    : t('additionalDocuments.addSource')}
-                </Button>
-              </TooltipIf>
-            </>
+            <UploadButton
+              fileInputRef={fileInputRef}
+              isEnabled={isEnabled}
+              addFileSource={addFileSource}
+              entityId={entity.id}
+              addFileSourcePending={addFileSourcePending}
+              removeSourcePending={removeSourcePending}
+              t={t}
+            />
           )}
         </div>
       </CardContent>
     </Card>
+  );
+}
+
+function SourceList({
+  sources,
+  onRemove,
+  removeDisabled,
+  disabled,
+  translationNamespace,
+}: Readonly<{
+  sources: Source[];
+  onRemove: (id: string) => void;
+  removeDisabled: boolean;
+  disabled: boolean;
+  translationNamespace: string;
+}>) {
+  return (
+    <ItemGroup>
+      {sources.map((source, index) => (
+        <Fragment key={source.id}>
+          <SourceItem
+            source={source}
+            onRemove={onRemove}
+            removeDisabled={removeDisabled}
+            disabled={disabled}
+            translationNamespace={translationNamespace}
+          />
+          {index < sources.length - 1 && <ItemSeparator />}
+        </Fragment>
+      ))}
+    </ItemGroup>
+  );
+}
+
+/** Processing sources older than this are shown with a slow-processing warning. */
+const SLOW_PROCESSING_THRESHOLD_MS = 3 * 60 * 1000; // 3 minutes
+
+function SourceItem({
+  source,
+  onRemove,
+  removeDisabled,
+  disabled,
+  translationNamespace,
+}: Readonly<{
+  source: Source;
+  onRemove: (id: string) => void;
+  removeDisabled: boolean;
+  disabled: boolean;
+  translationNamespace: string;
+}>) {
+  const { t } = useTranslation(translationNamespace);
+  const isProcessing = source.status === 'processing';
+  const isFailed = source.status === 'failed';
+
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    if (!isProcessing) return;
+    const id = setInterval(() => setNow(Date.now()), 30_000);
+    return () => clearInterval(id);
+  }, [isProcessing]);
+
+  const isProcessingSlow =
+    isProcessing &&
+    !!source.createdAt &&
+    now - new Date(source.createdAt).getTime() > SLOW_PROCESSING_THRESHOLD_MS;
+
+  return (
+    <Item>
+      <ItemMedia variant="icon">
+        <SourceItemIcon
+          isProcessing={isProcessing}
+          isProcessingSlow={isProcessingSlow}
+          isFailed={isFailed}
+        />
+      </ItemMedia>
+      <ItemContent>
+        <ItemTitle>{source.name}</ItemTitle>
+        <SourceItemDescription
+          isProcessing={isProcessing}
+          isProcessingSlow={isProcessingSlow}
+          isFailed={isFailed}
+          processingError={source.processingError}
+          t={t}
+        />
+      </ItemContent>
+      {!disabled && (
+        <ItemActions>
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={() => onRemove(source.id)}
+            disabled={removeDisabled}
+          >
+            <X className="h-4 w-4" />
+          </Button>
+        </ItemActions>
+      )}
+    </Item>
+  );
+}
+
+function SourceItemIcon({
+  isProcessing,
+  isProcessingSlow,
+  isFailed,
+}: Readonly<{
+  isProcessing: boolean;
+  isProcessingSlow: boolean;
+  isFailed: boolean;
+}>) {
+  if (isProcessingSlow) {
+    return (
+      <Clock className="h-3.5 w-3.5 shrink-0 text-amber-600 dark:text-amber-400" />
+    );
+  }
+  if (isProcessing) {
+    return <Loader2 className="h-3.5 w-3.5 shrink-0 animate-spin" />;
+  }
+  if (isFailed) {
+    return <AlertCircle className="h-3.5 w-3.5 shrink-0 text-destructive" />;
+  }
+  return <FileText className="h-3.5 w-3.5 shrink-0" />;
+}
+
+function SourceItemDescription({
+  isProcessing,
+  isProcessingSlow,
+  isFailed,
+  processingError,
+  t,
+}: Readonly<{
+  isProcessing: boolean;
+  isProcessingSlow: boolean;
+  isFailed: boolean;
+  processingError: string | undefined;
+  t: (key: string) => string;
+}>) {
+  if (isProcessing) {
+    return (
+      <ItemDescription
+        className={
+          isProcessingSlow ? 'text-amber-600 dark:text-amber-400' : undefined
+        }
+      >
+        {isProcessingSlow
+          ? t('additionalDocuments.statusProcessingSlow')
+          : t('additionalDocuments.statusProcessing')}
+      </ItemDescription>
+    );
+  }
+  if (isFailed) {
+    return (
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <ItemDescription className="text-destructive cursor-help">
+            {t('additionalDocuments.statusFailed')}
+          </ItemDescription>
+        </TooltipTrigger>
+        <TooltipContent>
+          {processingError ?? t('additionalDocuments.retryUpload')}
+        </TooltipContent>
+      </Tooltip>
+    );
+  }
+  return null;
+}
+
+function UploadButton({
+  fileInputRef,
+  isEnabled,
+  addFileSource,
+  entityId,
+  addFileSourcePending,
+  removeSourcePending,
+  t,
+}: Readonly<{
+  fileInputRef: React.RefObject<HTMLInputElement | null>;
+  isEnabled: boolean;
+  addFileSource: (params: { id: string; data: { file: File } }) => void;
+  entityId: string;
+  addFileSourcePending: boolean;
+  removeSourcePending: boolean;
+  t: (key: string) => string;
+}>) {
+  function handleFileChange(event: React.ChangeEvent<HTMLInputElement>) {
+    const file = event.target.files?.[0];
+    if (!isEnabled) {
+      showError(t('additionalDocuments.disabledTooltip'));
+      return;
+    }
+    if (file) {
+      addFileSource({
+        id: entityId,
+        data: { file },
+      });
+    }
+  }
+
+  return (
+    <>
+      <Input
+        ref={fileInputRef}
+        type="file"
+        className="hidden"
+        onChange={handleFileChange}
+        accept=".pdf,.docx,.pptx,.txt,.md,.csv,.xlsx,.xls"
+      />
+      <TooltipIf
+        condition={!isEnabled}
+        tooltip={t('additionalDocuments.disabledTooltip')}
+      >
+        <Button
+          variant="outline"
+          onClick={() => fileInputRef.current?.click()}
+          disabled={addFileSourcePending || removeSourcePending}
+        >
+          {addFileSourcePending
+            ? t('additionalDocuments.adding')
+            : t('additionalDocuments.addSource')}
+        </Button>
+      </TooltipIf>
+    </>
   );
 }

--- a/compose.dev.yml
+++ b/compose.dev.yml
@@ -130,6 +130,17 @@ services:
       timeout: 5s
       retries: 5
 
+  gotenberg:
+    image: gotenberg/gotenberg:8
+    restart: unless-stopped
+    ports:
+      - '${GOTENBERG_HOST_PORT:-3100}:3000'
+    healthcheck:
+      test: ['CMD', 'curl', '-f', 'http://localhost:3000/health']
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
 volumes:
   postgres-data:
   minio-data:

--- a/dev
+++ b/dev
@@ -66,6 +66,7 @@ export MAILCATCHER_WEB_HOST_PORT=$((1080 + OFFSET))
 export CODE_EXEC_HOST_PORT=$((8080 + OFFSET))
 export ANONYMIZE_HOST_PORT=$((8002 + OFFSET))
 export REDIS_HOST_PORT=$((6379 + OFFSET))
+export GOTENBERG_HOST_PORT=$((3100 + OFFSET))
 
 BACKEND_PORT=$((3000 + OFFSET))
 FRONTEND_PORT=$((3001 + OFFSET))
@@ -118,6 +119,7 @@ CORS_ALLOWED_ORIGINS=http://localhost:$FRONTEND_PORT,http://localhost:$BACKEND_P
 MARKETPLACE_SERVICE_URL=http://localhost:3002
 REDIS_HOST=localhost
 REDIS_PORT=$REDIS_HOST_PORT
+GOTENBERG_URL=http://localhost:$GOTENBERG_HOST_PORT
 EOF
 
   # -- 3. Run database migrations ------------------------------------------
@@ -183,6 +185,7 @@ EOF
   echo "  Mailcatcher:  smtp :$MAILCATCHER_SMTP_HOST_PORT  web :$MAILCATCHER_WEB_HOST_PORT"
   echo "  Code exec:    localhost:$CODE_EXEC_HOST_PORT"
   echo "  Anonymize:    localhost:$ANONYMIZE_HOST_PORT"
+  echo "  Gotenberg:    localhost:$GOTENBERG_HOST_PORT"
   echo ""
   echo "  Logs dir:     $STATE_DIR/"
   echo ""


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk: refactors the document upload/processing orchestration and changes skill source API payloads, which can affect processing/job enqueue behavior and frontend polling/UI if status handling is incorrect.
> 
> **Overview**
> **Async document uploads are now centralized.** Knowledge base document ingestion and skill file uploads switch to a new `StartDocumentProcessingUseCase`, which creates a `PROCESSING` source, uploads the file to storage, and enqueues processing; `AddDocumentToKnowledgeBaseUseCase` is simplified to only validate KB ownership in a transaction, then start processing and assign the created source.
> 
> **Skill sources now expose processing metadata and behave accordingly.** The skills sources API response adds `status`, optional `processingError`, and `createdAt`; skill activation skips non-`READY` sources (with warning logs), and the frontend polls `/skills/:id/sources` while any source is `processing` and renders processing/slow/failed states with localized copy.
> 
> **Dev environment update.** Adds a `gotenberg` container plus `GOTENBERG_URL` wiring to the dev scripts/compose.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cde0818d77fdaa00ac08b51f3aa018720bb7c9fb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->