### PR TITLE
fix(documents): narrow instructions for document creation to prefer inline in most cases (AYC-000)

### DIFF
--- a/ayunis-core-backend/src/domain/runs/application/services/system-prompt-builder.service.ts
+++ b/ayunis-core-backend/src/domain/runs/application/services/system-prompt-builder.service.ts
@@ -131,6 +131,14 @@ When using tools:
 4. **Verify before actions** — For consequential actions (sending emails, creating events), confirm with the user first
 </tool_guidelines>
 
+<document_usage>
+**Default to inline responses.** Respond directly in the chat for questions, explanations, summaries, brainstorming, code snippets, and general conversation — even if the response is long or uses formatting.
+
+Only use create_document when the user explicitly asks for a document they intend to edit, export, or download — for example: "Write me a letter", "Create a report I can export as PDF", "Draft a formal document". Keywords like "document", "letter", "report", "draft", "Schreiben", "Dokument", "Brief", or "Vorlage" are strong signals.
+
+If in doubt, respond inline. The user can always ask you to turn a response into a document.
+</document_usage>
+
 ${toolSpecificSections}
 
 </tool_usage>`;

--- a/ayunis-core-backend/src/domain/tools/domain/tools/create-document-tool.entity.ts
+++ b/ayunis-core-backend/src/domain/tools/domain/tools/create-document-tool.entity.ts
@@ -36,7 +36,7 @@ export class CreateDocumentTool extends DisplayableTool {
     super({
       name: ToolType.CREATE_DOCUMENT,
       description:
-        'Create a new document that the user can view and edit in a WYSIWYG editor. Use this when the user asks you to write, draft, or create a document, report, letter, or any structured text content.',
+        'Create a new document that the user can view and edit in a WYSIWYG editor. Only use this when the user explicitly asks for a document they can edit, export, or download — for example a letter, report, or formal text. Do not use this for regular conversational answers.',
       parameters: createDocumentToolParameters,
       type: ToolType.CREATE_DOCUMENT,
     });


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Prompting-only changes that narrow when `create_document` should be used; low risk but could affect when the assistant generates WYSIWYG documents vs. inline text.
> 
> **Overview**
> Updates the system prompt to **default to inline chat responses** and to use `create_document` *only* when the user explicitly asks for an editable/exportable document (e.g., letter/report), including keyword guidance.
> 
> Aligns the `CreateDocumentTool` description with this stricter intent so agents are less likely to create documents for normal conversational answers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2ba8d744dacec3e822ad51c4bc5bb2d2d5094ba9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->