### PR TITLE
wip(integrations): add prometheus and webhook domain event listeners (AYC-71)

### DIFF
--- a/ayunis-core-backend/src/integrations/metrics/listeners/prometheus-metrics.listener.spec.ts
+++ b/ayunis-core-backend/src/integrations/metrics/listeners/prometheus-metrics.listener.spec.ts
@@ -1,0 +1,286 @@
+import type { UUID } from 'crypto';
+import { PrometheusMetricsListener } from './prometheus-metrics.listener';
+import { UserCreatedEvent } from 'src/iam/users/application/events/user-created.event';
+import { UserMessageCreatedEvent } from 'src/domain/messages/application/events/user-message-created.event';
+import { AssistantMessageCreatedEvent } from 'src/domain/messages/application/events/assistant-message-created.event';
+import { RunExecutedEvent } from 'src/domain/runs/application/events/run-executed.event';
+import { InferenceCompletedEvent } from 'src/domain/runs/application/events/inference-completed.event';
+import { TokensConsumedEvent } from 'src/domain/runs/application/events/tokens-consumed.event';
+import { ToolUsedEvent } from 'src/domain/runs/application/events/tool-used.event';
+import { ThreadMessageAddedEvent } from 'src/domain/threads/application/events/thread-message-added.event';
+
+const USER_ID = '00000000-0000-0000-0000-000000000001' as UUID;
+const ORG_ID = '00000000-0000-0000-0000-000000000002' as UUID;
+const THREAD_ID = '00000000-0000-0000-0000-000000000003' as UUID;
+const MESSAGE_ID = '00000000-0000-0000-0000-000000000004' as UUID;
+
+function mockCounter() {
+  return { inc: jest.fn() };
+}
+
+function mockHistogram() {
+  return { observe: jest.fn() };
+}
+
+describe('PrometheusMetricsListener', () => {
+  let listener: PrometheusMetricsListener;
+  let userCreationsCounter: ReturnType<typeof mockCounter>;
+  let messagesCounter: ReturnType<typeof mockCounter>;
+  let userActivityCounter: ReturnType<typeof mockCounter>;
+  let inferenceHistogram: ReturnType<typeof mockHistogram>;
+  let inferenceErrorsCounter: ReturnType<typeof mockCounter>;
+  let tokensCounter: ReturnType<typeof mockCounter>;
+  let toolUsesCounter: ReturnType<typeof mockCounter>;
+  let threadMessageHistogram: ReturnType<typeof mockHistogram>;
+
+  beforeEach(() => {
+    userCreationsCounter = mockCounter();
+    messagesCounter = mockCounter();
+    userActivityCounter = mockCounter();
+    inferenceHistogram = mockHistogram();
+    inferenceErrorsCounter = mockCounter();
+    tokensCounter = mockCounter();
+    toolUsesCounter = mockCounter();
+    threadMessageHistogram = mockHistogram();
+
+    listener = new PrometheusMetricsListener(
+      userCreationsCounter as never,
+      messagesCounter as never,
+      userActivityCounter as never,
+      inferenceHistogram as never,
+      inferenceErrorsCounter as never,
+      tokensCounter as never,
+      toolUsesCounter as never,
+      threadMessageHistogram as never,
+    );
+  });
+
+  describe('handleUserCreated', () => {
+    it('should increment user creations counter with org and department', () => {
+      listener.handleUserCreated(
+        new UserCreatedEvent(USER_ID, ORG_ID, undefined, 'engineering'),
+      );
+
+      expect(userCreationsCounter.inc).toHaveBeenCalledWith({
+        org_id: ORG_ID,
+        department: 'engineering',
+      });
+    });
+
+    it('should normalize "other:" prefixed departments to "other"', () => {
+      listener.handleUserCreated(
+        new UserCreatedEvent(USER_ID, ORG_ID, undefined, 'other:custom'),
+      );
+
+      expect(userCreationsCounter.inc).toHaveBeenCalledWith({
+        org_id: ORG_ID,
+        department: 'other',
+      });
+    });
+
+    it('should use "none" when department is undefined', () => {
+      listener.handleUserCreated(new UserCreatedEvent(USER_ID, ORG_ID));
+
+      expect(userCreationsCounter.inc).toHaveBeenCalledWith({
+        org_id: ORG_ID,
+        department: 'none',
+      });
+    });
+  });
+
+  describe('handleUserMessageCreated', () => {
+    it('should increment messages counter with role "user"', () => {
+      listener.handleUserMessageCreated(
+        new UserMessageCreatedEvent(USER_ID, ORG_ID, THREAD_ID, MESSAGE_ID),
+      );
+
+      expect(messagesCounter.inc).toHaveBeenCalledWith({
+        user_id: USER_ID,
+        org_id: ORG_ID,
+        role: 'user',
+      });
+    });
+  });
+
+  describe('handleAssistantMessageCreated', () => {
+    it('should increment messages counter with role "assistant"', () => {
+      listener.handleAssistantMessageCreated(
+        new AssistantMessageCreatedEvent(
+          USER_ID,
+          ORG_ID,
+          THREAD_ID,
+          MESSAGE_ID,
+        ),
+      );
+
+      expect(messagesCounter.inc).toHaveBeenCalledWith({
+        user_id: USER_ID,
+        org_id: ORG_ID,
+        role: 'assistant',
+      });
+    });
+  });
+
+  describe('handleRunExecuted', () => {
+    it('should increment user activity counter', () => {
+      listener.handleRunExecuted(new RunExecutedEvent(USER_ID, ORG_ID));
+
+      expect(userActivityCounter.inc).toHaveBeenCalledWith({
+        user_id: USER_ID,
+        org_id: ORG_ID,
+      });
+    });
+  });
+
+  describe('handleInferenceCompleted', () => {
+    it('should observe inference duration histogram', () => {
+      listener.handleInferenceCompleted(
+        new InferenceCompletedEvent(
+          USER_ID,
+          ORG_ID,
+          'gpt-4',
+          'openai',
+          false,
+          1500,
+        ),
+      );
+
+      expect(inferenceHistogram.observe).toHaveBeenCalledWith(
+        { model: 'gpt-4', provider: 'openai', streaming: 'false' },
+        1.5,
+      );
+    });
+
+    it('should observe with streaming=true for streaming inference', () => {
+      listener.handleInferenceCompleted(
+        new InferenceCompletedEvent(
+          USER_ID,
+          ORG_ID,
+          'claude-3',
+          'anthropic',
+          true,
+          2000,
+        ),
+      );
+
+      expect(inferenceHistogram.observe).toHaveBeenCalledWith(
+        { model: 'claude-3', provider: 'anthropic', streaming: 'true' },
+        2,
+      );
+    });
+
+    it('should increment error counter when error is present', () => {
+      listener.handleInferenceCompleted(
+        new InferenceCompletedEvent(
+          USER_ID,
+          ORG_ID,
+          'gpt-4',
+          'openai',
+          false,
+          500,
+          'rate_limit',
+        ),
+      );
+
+      expect(inferenceErrorsCounter.inc).toHaveBeenCalledWith({
+        model: 'gpt-4',
+        provider: 'openai',
+        error_type: 'rate_limit',
+        streaming: 'false',
+      });
+    });
+
+    it('should not increment error counter when there is no error', () => {
+      listener.handleInferenceCompleted(
+        new InferenceCompletedEvent(
+          USER_ID,
+          ORG_ID,
+          'gpt-4',
+          'openai',
+          false,
+          500,
+        ),
+      );
+
+      expect(inferenceErrorsCounter.inc).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('handleTokensConsumed', () => {
+    it('should increment tokens counter for input and output', () => {
+      listener.handleTokensConsumed(
+        new TokensConsumedEvent(USER_ID, ORG_ID, 'gpt-4', 'openai', 100, 50),
+      );
+
+      expect(tokensCounter.inc).toHaveBeenCalledWith(
+        {
+          user_id: USER_ID,
+          org_id: ORG_ID,
+          model: 'gpt-4',
+          provider: 'openai',
+          direction: 'input',
+        },
+        100,
+      );
+      expect(tokensCounter.inc).toHaveBeenCalledWith(
+        {
+          user_id: USER_ID,
+          org_id: ORG_ID,
+          model: 'gpt-4',
+          provider: 'openai',
+          direction: 'output',
+        },
+        50,
+      );
+    });
+
+    it('should skip zero-value token counts', () => {
+      listener.handleTokensConsumed(
+        new TokensConsumedEvent(USER_ID, ORG_ID, 'gpt-4', 'openai', 100, 0),
+      );
+
+      expect(tokensCounter.inc).toHaveBeenCalledTimes(1);
+      expect(tokensCounter.inc).toHaveBeenCalledWith(
+        expect.objectContaining({ direction: 'input' }),
+        100,
+      );
+    });
+  });
+
+  describe('handleToolUsed', () => {
+    it('should increment tool uses counter', () => {
+      listener.handleToolUsed(new ToolUsedEvent(USER_ID, ORG_ID, 'web_search'));
+
+      expect(toolUsesCounter.inc).toHaveBeenCalledWith({
+        user_id: USER_ID,
+        org_id: ORG_ID,
+        tool_name: 'web_search',
+      });
+    });
+  });
+
+  describe('handleThreadMessageAdded', () => {
+    it('should observe thread message count histogram', () => {
+      listener.handleThreadMessageAdded(
+        new ThreadMessageAddedEvent(USER_ID, ORG_ID, THREAD_ID, 5),
+      );
+
+      expect(threadMessageHistogram.observe).toHaveBeenCalledWith(
+        { user_id: USER_ID, org_id: ORG_ID },
+        5,
+      );
+    });
+  });
+
+  describe('safeMetric wrapping', () => {
+    it('should not throw when a metric operation fails', () => {
+      userCreationsCounter.inc.mockImplementation(() => {
+        throw new Error('Prometheus failure');
+      });
+
+      expect(() =>
+        listener.handleUserCreated(new UserCreatedEvent(USER_ID, ORG_ID)),
+      ).not.toThrow();
+    });
+  });
+});

--- a/ayunis-core-backend/src/integrations/metrics/listeners/prometheus-metrics.listener.ts
+++ b/ayunis-core-backend/src/integrations/metrics/listeners/prometheus-metrics.listener.ts
@@ -1,0 +1,179 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { OnEvent } from '@nestjs/event-emitter';
+import { InjectMetric } from '@willsoto/nestjs-prometheus';
+import { Counter, Histogram } from 'prom-client';
+import { UserCreatedEvent } from 'src/iam/users/application/events/user-created.event';
+import { UserMessageCreatedEvent } from 'src/domain/messages/application/events/user-message-created.event';
+import { AssistantMessageCreatedEvent } from 'src/domain/messages/application/events/assistant-message-created.event';
+import { RunExecutedEvent } from 'src/domain/runs/application/events/run-executed.event';
+import { InferenceCompletedEvent } from 'src/domain/runs/application/events/inference-completed.event';
+import { TokensConsumedEvent } from 'src/domain/runs/application/events/tokens-consumed.event';
+import { ToolUsedEvent } from 'src/domain/runs/application/events/tool-used.event';
+import { ThreadMessageAddedEvent } from 'src/domain/threads/application/events/thread-message-added.event';
+import {
+  AYUNIS_USER_CREATIONS_TOTAL,
+  AYUNIS_MESSAGES_TOTAL,
+  AYUNIS_USER_ACTIVITY_TOTAL,
+  AYUNIS_INFERENCE_DURATION_SECONDS,
+  AYUNIS_INFERENCE_ERRORS_TOTAL,
+  AYUNIS_TOKENS_TOTAL,
+  AYUNIS_TOOL_USES_TOTAL,
+  AYUNIS_THREAD_MESSAGE_COUNT,
+} from '../metrics.constants';
+import { safeMetric } from '../metrics.utils';
+
+/**
+ * Subscribes to domain events and records the corresponding Prometheus
+ * metrics. This consolidates all metric recording that previously lived
+ * in individual use cases and services.
+ */
+@Injectable()
+export class PrometheusMetricsListener {
+  private readonly logger = new Logger(PrometheusMetricsListener.name);
+
+  constructor(
+    @InjectMetric(AYUNIS_USER_CREATIONS_TOTAL)
+    private readonly userCreationsCounter: Counter<string>,
+    @InjectMetric(AYUNIS_MESSAGES_TOTAL)
+    private readonly messagesCounter: Counter<string>,
+    @InjectMetric(AYUNIS_USER_ACTIVITY_TOTAL)
+    private readonly userActivityCounter: Counter<string>,
+    @InjectMetric(AYUNIS_INFERENCE_DURATION_SECONDS)
+    private readonly inferenceHistogram: Histogram<string>,
+    @InjectMetric(AYUNIS_INFERENCE_ERRORS_TOTAL)
+    private readonly inferenceErrorsCounter: Counter<string>,
+    @InjectMetric(AYUNIS_TOKENS_TOTAL)
+    private readonly tokensCounter: Counter<string>,
+    @InjectMetric(AYUNIS_TOOL_USES_TOTAL)
+    private readonly toolUsesCounter: Counter<string>,
+    @InjectMetric(AYUNIS_THREAD_MESSAGE_COUNT)
+    private readonly threadMessageHistogram: Histogram<string>,
+  ) {}
+
+  @OnEvent(UserCreatedEvent.EVENT_NAME)
+  handleUserCreated(event: UserCreatedEvent): void {
+    safeMetric(this.logger, () => {
+      this.userCreationsCounter.inc({
+        org_id: event.orgId,
+        department: normalizeDepartment(event.department),
+      });
+    });
+  }
+
+  @OnEvent(UserMessageCreatedEvent.EVENT_NAME)
+  handleUserMessageCreated(event: UserMessageCreatedEvent): void {
+    safeMetric(this.logger, () => {
+      this.messagesCounter.inc({
+        user_id: event.userId,
+        org_id: event.orgId,
+        role: 'user',
+      });
+    });
+  }
+
+  @OnEvent(AssistantMessageCreatedEvent.EVENT_NAME)
+  handleAssistantMessageCreated(event: AssistantMessageCreatedEvent): void {
+    safeMetric(this.logger, () => {
+      this.messagesCounter.inc({
+        user_id: event.userId,
+        org_id: event.orgId,
+        role: 'assistant',
+      });
+    });
+  }
+
+  @OnEvent(RunExecutedEvent.EVENT_NAME)
+  handleRunExecuted(event: RunExecutedEvent): void {
+    safeMetric(this.logger, () => {
+      this.userActivityCounter.inc({
+        user_id: event.userId,
+        org_id: event.orgId,
+      });
+    });
+  }
+
+  @OnEvent(InferenceCompletedEvent.EVENT_NAME)
+  handleInferenceCompleted(event: InferenceCompletedEvent): void {
+    const streamingLabel = event.streaming ? 'true' : 'false';
+
+    safeMetric(this.logger, () => {
+      this.inferenceHistogram.observe(
+        {
+          model: event.model,
+          provider: event.provider,
+          streaming: streamingLabel,
+        },
+        event.durationMs / 1000,
+      );
+    });
+
+    if (event.error) {
+      safeMetric(this.logger, () => {
+        this.inferenceErrorsCounter.inc({
+          model: event.model,
+          provider: event.provider,
+          error_type: event.error!,
+          streaming: streamingLabel,
+        });
+      });
+    }
+  }
+
+  @OnEvent(TokensConsumedEvent.EVENT_NAME)
+  handleTokensConsumed(event: TokensConsumedEvent): void {
+    const baseLabels = {
+      user_id: event.userId,
+      org_id: event.orgId,
+      model: event.model,
+      provider: event.provider,
+    };
+
+    if (event.inputTokens > 0) {
+      safeMetric(this.logger, () => {
+        this.tokensCounter.inc(
+          { ...baseLabels, direction: 'input' },
+          event.inputTokens,
+        );
+      });
+    }
+
+    if (event.outputTokens > 0) {
+      safeMetric(this.logger, () => {
+        this.tokensCounter.inc(
+          { ...baseLabels, direction: 'output' },
+          event.outputTokens,
+        );
+      });
+    }
+  }
+
+  @OnEvent(ToolUsedEvent.EVENT_NAME)
+  handleToolUsed(event: ToolUsedEvent): void {
+    safeMetric(this.logger, () => {
+      this.toolUsesCounter.inc({
+        user_id: event.userId,
+        org_id: event.orgId,
+        tool_name: event.toolName,
+      });
+    });
+  }
+
+  @OnEvent(ThreadMessageAddedEvent.EVENT_NAME)
+  handleThreadMessageAdded(event: ThreadMessageAddedEvent): void {
+    safeMetric(this.logger, () => {
+      this.threadMessageHistogram.observe(
+        { user_id: event.userId, org_id: event.orgId },
+        event.messageCount,
+      );
+    });
+  }
+}
+
+/**
+ * Normalizes the department label for Prometheus. The "other:" prefix
+ * is stripped to a plain "other" to keep cardinality low.
+ */
+function normalizeDepartment(department?: string): string {
+  if (!department) return 'none';
+  return department.startsWith('other:') ? 'other' : department;
+}

--- a/ayunis-core-backend/src/integrations/metrics/metrics.module.ts
+++ b/ayunis-core-backend/src/integrations/metrics/metrics.module.ts
@@ -27,6 +27,7 @@ import {
 } from './metrics.constants';
 import { MetricsAuthMiddleware } from './metrics-auth.middleware';
 import { MetricsController } from './metrics.controller';
+import { PrometheusMetricsListener } from './listeners/prometheus-metrics.listener';
 
 const tokensCounter = makeCounterProvider({
   name: AYUNIS_TOKENS_TOTAL,
@@ -104,7 +105,7 @@ const metricProviders = [
       controller: MetricsController,
     }),
   ],
-  providers: metricProviders,
+  providers: [...metricProviders, PrometheusMetricsListener],
   exports: metricProviders,
 })
 export class MetricsModule implements NestModule {

--- a/ayunis-core-backend/src/integrations/webhooks/listeners/billing-info-payload.mapper.ts
+++ b/ayunis-core-backend/src/integrations/webhooks/listeners/billing-info-payload.mapper.ts
@@ -1,0 +1,23 @@
+import type { BillingInfoEventData } from 'src/iam/subscriptions/application/events/subscription-event-data.types';
+import type { BillingInfoPayload } from '../domain/subscription-webhook-payload.types';
+
+/**
+ * Maps domain-level {@link BillingInfoEventData} to the webhook-specific
+ * {@link BillingInfoPayload}.
+ */
+export function mapBillingInfoToWebhookPayload(
+  data: BillingInfoEventData,
+): BillingInfoPayload {
+  return {
+    companyName: data.companyName,
+    street: data.street,
+    houseNumber: data.houseNumber,
+    postalCode: data.postalCode,
+    city: data.city,
+    country: data.country,
+    vatNumber: data.vatNumber,
+    subText: data.subText,
+    orgId: data.orgId,
+    subscriptionId: data.subscriptionId,
+  };
+}

--- a/ayunis-core-backend/src/integrations/webhooks/listeners/subscription-payload.mapper.ts
+++ b/ayunis-core-backend/src/integrations/webhooks/listeners/subscription-payload.mapper.ts
@@ -1,0 +1,41 @@
+import type { SubscriptionEventData } from 'src/iam/subscriptions/application/events/subscription-event-data.types';
+import { SubscriptionType } from 'src/iam/subscriptions/domain/value-objects/subscription-type.enum';
+import type {
+  SubscriptionWebhookPayload,
+  SeatBasedWebhookPayload,
+  UsageBasedWebhookPayload,
+} from '../domain/subscription-webhook-payload.types';
+
+/**
+ * Maps domain-level {@link SubscriptionEventData} to the webhook-specific
+ * {@link SubscriptionWebhookPayload}. The main difference is that domain
+ * types use `Date` objects while webhook payloads use ISO 8601 strings.
+ */
+export function mapSubscriptionToWebhookPayload(
+  data: SubscriptionEventData,
+): SubscriptionWebhookPayload {
+  const base = {
+    id: data.id,
+    orgId: data.orgId,
+    cancelledAt: data.cancelledAt?.toISOString() ?? null,
+    createdAt: data.createdAt.toISOString(),
+    updatedAt: data.updatedAt.toISOString(),
+  };
+
+  if (data.type === SubscriptionType.SEAT_BASED) {
+    return {
+      ...base,
+      type: 'SEAT_BASED',
+      noOfSeats: data.noOfSeats,
+      pricePerSeat: data.pricePerSeat,
+      renewalCycle: data.renewalCycle,
+      renewalCycleAnchor: data.renewalCycleAnchor.toISOString(),
+    } satisfies SeatBasedWebhookPayload;
+  }
+
+  return {
+    ...base,
+    type: 'USAGE_BASED',
+    monthlyCredits: data.monthlyCredits,
+  } satisfies UsageBasedWebhookPayload;
+}

--- a/ayunis-core-backend/src/integrations/webhooks/listeners/webhook-dispatch.listener.spec.ts
+++ b/ayunis-core-backend/src/integrations/webhooks/listeners/webhook-dispatch.listener.spec.ts
@@ -1,0 +1,236 @@
+import type { UUID } from 'crypto';
+import { WebhookDispatchListener } from './webhook-dispatch.listener';
+import { UserCreatedEvent } from 'src/iam/users/application/events/user-created.event';
+import { UserUpdatedEvent } from 'src/iam/users/application/events/user-updated.event';
+import { UserDeletedEvent } from 'src/iam/users/application/events/user-deleted.event';
+import { OrgCreatedEvent } from 'src/iam/orgs/application/events/org-created.event';
+import { SubscriptionCreatedEvent } from 'src/iam/subscriptions/application/events/subscription-created.event';
+import { SubscriptionCancelledEvent } from 'src/iam/subscriptions/application/events/subscription-cancelled.event';
+import { SubscriptionUncancelledEvent } from 'src/iam/subscriptions/application/events/subscription-uncancelled.event';
+import { SubscriptionSeatsUpdatedEvent } from 'src/iam/subscriptions/application/events/subscription-seats-updated.event';
+import { SubscriptionBillingInfoUpdatedEvent } from 'src/iam/subscriptions/application/events/subscription-billing-info-updated.event';
+import { WebhookEventType } from '../domain/value-objects/webhook-event-type.enum';
+import { User } from 'src/iam/users/domain/user.entity';
+import { Org } from 'src/iam/orgs/domain/org.entity';
+import { SubscriptionType } from 'src/iam/subscriptions/domain/value-objects/subscription-type.enum';
+import { RenewalCycle } from 'src/iam/subscriptions/domain/value-objects/renewal-cycle.enum';
+import { UserRole } from 'src/iam/users/domain/value-objects/role.object';
+import type { SendWebhookUseCase } from '../application/use-cases/send-webhook/send-webhook.use-case';
+import type { SeatBasedSubscriptionEventData } from 'src/iam/subscriptions/application/events/subscription-event-data.types';
+
+const USER_ID = '00000000-0000-0000-0000-000000000001' as UUID;
+const ORG_ID = '00000000-0000-0000-0000-000000000002' as UUID;
+const SUB_ID = '00000000-0000-0000-0000-000000000003' as UUID;
+
+function makeUser(): User {
+  return new User({
+    id: USER_ID,
+    email: 'test@example.com',
+    emailVerified: true,
+    passwordHash: 'hashed',
+    role: UserRole.ADMIN,
+    orgId: ORG_ID,
+    name: 'Test User',
+    hasAcceptedMarketing: false,
+  });
+}
+
+function makeOrg(): Org {
+  return new Org({
+    id: ORG_ID,
+    name: 'Test Org',
+  });
+}
+
+function makeSeatBasedPayload(): SeatBasedSubscriptionEventData {
+  return {
+    id: SUB_ID,
+    orgId: ORG_ID,
+    type: SubscriptionType.SEAT_BASED,
+    cancelledAt: null,
+    createdAt: new Date('2025-01-01T00:00:00Z'),
+    updatedAt: new Date('2025-01-02T00:00:00Z'),
+    noOfSeats: 10,
+    pricePerSeat: 25,
+    renewalCycle: RenewalCycle.MONTHLY,
+    renewalCycleAnchor: new Date('2025-01-01T00:00:00Z'),
+  };
+}
+
+describe('WebhookDispatchListener', () => {
+  let listener: WebhookDispatchListener;
+  let sendWebhookUseCase: jest.Mocked<SendWebhookUseCase>;
+
+  beforeEach(() => {
+    sendWebhookUseCase = {
+      execute: jest.fn().mockResolvedValue(undefined),
+    } as unknown as jest.Mocked<SendWebhookUseCase>;
+
+    listener = new WebhookDispatchListener(sendWebhookUseCase);
+  });
+
+  describe('handleUserCreated', () => {
+    it('should dispatch UserCreatedWebhookEvent when user is present', async () => {
+      const user = makeUser();
+      await listener.handleUserCreated(
+        new UserCreatedEvent(USER_ID, ORG_ID, user, 'engineering'),
+      );
+
+      expect(sendWebhookUseCase.execute).toHaveBeenCalledTimes(1);
+      const command = sendWebhookUseCase.execute.mock.calls[0][0];
+      expect(command.event.eventType).toBe(WebhookEventType.USER_CREATED);
+    });
+
+    it('should not dispatch when user is absent', async () => {
+      await listener.handleUserCreated(new UserCreatedEvent(USER_ID, ORG_ID));
+
+      expect(sendWebhookUseCase.execute).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('handleUserUpdated', () => {
+    it('should dispatch UserUpdatedWebhookEvent', async () => {
+      const user = makeUser();
+      await listener.handleUserUpdated(
+        new UserUpdatedEvent(USER_ID, ORG_ID, user),
+      );
+
+      expect(sendWebhookUseCase.execute).toHaveBeenCalledTimes(1);
+      const command = sendWebhookUseCase.execute.mock.calls[0][0];
+      expect(command.event.eventType).toBe(WebhookEventType.USER_UPDATED);
+    });
+  });
+
+  describe('handleUserDeleted', () => {
+    it('should dispatch UserDeletedWebhookEvent', async () => {
+      await listener.handleUserDeleted(new UserDeletedEvent(USER_ID, ORG_ID));
+
+      expect(sendWebhookUseCase.execute).toHaveBeenCalledTimes(1);
+      const command = sendWebhookUseCase.execute.mock.calls[0][0];
+      expect(command.event.eventType).toBe(WebhookEventType.USER_DELETED);
+    });
+  });
+
+  describe('handleOrgCreated', () => {
+    it('should dispatch OrgCreatedWebhookEvent', async () => {
+      await listener.handleOrgCreated(
+        new OrgCreatedEvent(ORG_ID, makeOrg(), makeUser()),
+      );
+
+      expect(sendWebhookUseCase.execute).toHaveBeenCalledTimes(1);
+      const command = sendWebhookUseCase.execute.mock.calls[0][0];
+      expect(command.event.eventType).toBe(WebhookEventType.ORG_CREATED);
+    });
+  });
+
+  describe('handleSubscriptionCreated', () => {
+    it('should dispatch SubscriptionCreatedWebhookEvent with mapped payload', async () => {
+      await listener.handleSubscriptionCreated(
+        new SubscriptionCreatedEvent(ORG_ID, makeSeatBasedPayload()),
+      );
+
+      expect(sendWebhookUseCase.execute).toHaveBeenCalledTimes(1);
+      const command = sendWebhookUseCase.execute.mock.calls[0][0];
+      expect(command.event.eventType).toBe(
+        WebhookEventType.SUBSCRIPTION_CREATED,
+      );
+      expect(command.event.data).toEqual(
+        expect.objectContaining({
+          type: 'SEAT_BASED',
+          createdAt: '2025-01-01T00:00:00.000Z',
+        }),
+      );
+    });
+  });
+
+  describe('handleSubscriptionCancelled', () => {
+    it('should dispatch SubscriptionCancelledWebhookEvent', async () => {
+      await listener.handleSubscriptionCancelled(
+        new SubscriptionCancelledEvent(ORG_ID, makeSeatBasedPayload()),
+      );
+
+      expect(sendWebhookUseCase.execute).toHaveBeenCalledTimes(1);
+      const command = sendWebhookUseCase.execute.mock.calls[0][0];
+      expect(command.event.eventType).toBe(
+        WebhookEventType.SUBSCRIPTION_CANCELLED,
+      );
+    });
+  });
+
+  describe('handleSubscriptionUncancelled', () => {
+    it('should dispatch SubscriptionUncancelledWebhookEvent', async () => {
+      await listener.handleSubscriptionUncancelled(
+        new SubscriptionUncancelledEvent(ORG_ID, makeSeatBasedPayload()),
+      );
+
+      expect(sendWebhookUseCase.execute).toHaveBeenCalledTimes(1);
+      const command = sendWebhookUseCase.execute.mock.calls[0][0];
+      expect(command.event.eventType).toBe(
+        WebhookEventType.SUBSCRIPTION_UNCANCELLED,
+      );
+    });
+  });
+
+  describe('handleSubscriptionSeatsUpdated', () => {
+    it('should dispatch SubscriptionSeatsUpdatedWebhookEvent', async () => {
+      await listener.handleSubscriptionSeatsUpdated(
+        new SubscriptionSeatsUpdatedEvent(ORG_ID, makeSeatBasedPayload()),
+      );
+
+      expect(sendWebhookUseCase.execute).toHaveBeenCalledTimes(1);
+      const command = sendWebhookUseCase.execute.mock.calls[0][0];
+      expect(command.event.eventType).toBe(
+        WebhookEventType.SUBSCRIPTION_SEATS_UPDATED,
+      );
+    });
+  });
+
+  describe('handleSubscriptionBillingInfoUpdated', () => {
+    it('should dispatch SubscriptionBillingInfoUpdatedWebhookEvent with mapped payload', async () => {
+      await listener.handleSubscriptionBillingInfoUpdated(
+        new SubscriptionBillingInfoUpdatedEvent(ORG_ID, {
+          companyName: 'Acme',
+          street: 'Main St',
+          houseNumber: '1',
+          postalCode: '12345',
+          city: 'Berlin',
+          country: 'DE',
+          vatNumber: 'DE123456789',
+          subText: 'Dept. Finance',
+          orgId: ORG_ID,
+          subscriptionId: SUB_ID,
+        }),
+      );
+
+      expect(sendWebhookUseCase.execute).toHaveBeenCalledTimes(1);
+      const command = sendWebhookUseCase.execute.mock.calls[0][0];
+      expect(command.event.eventType).toBe(
+        WebhookEventType.SUBSCRIPTION_BILLING_INFO_UPDATED,
+      );
+      expect(command.event.data).toEqual({
+        companyName: 'Acme',
+        street: 'Main St',
+        houseNumber: '1',
+        postalCode: '12345',
+        city: 'Berlin',
+        country: 'DE',
+        vatNumber: 'DE123456789',
+        subText: 'Dept. Finance',
+        orgId: ORG_ID,
+        subscriptionId: SUB_ID,
+      });
+    });
+  });
+
+  describe('error handling', () => {
+    it('should not throw when SendWebhookUseCase fails', async () => {
+      sendWebhookUseCase.execute.mockRejectedValue(
+        new Error('Network failure'),
+      );
+
+      await expect(
+        listener.handleUserDeleted(new UserDeletedEvent(USER_ID, ORG_ID)),
+      ).resolves.toBeUndefined();
+    });
+  });
+});

--- a/ayunis-core-backend/src/integrations/webhooks/listeners/webhook-dispatch.listener.ts
+++ b/ayunis-core-backend/src/integrations/webhooks/listeners/webhook-dispatch.listener.ts
@@ -1,0 +1,128 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { OnEvent } from '@nestjs/event-emitter';
+import { UserCreatedEvent } from 'src/iam/users/application/events/user-created.event';
+import { UserUpdatedEvent } from 'src/iam/users/application/events/user-updated.event';
+import { UserDeletedEvent } from 'src/iam/users/application/events/user-deleted.event';
+import { OrgCreatedEvent } from 'src/iam/orgs/application/events/org-created.event';
+import { SubscriptionCreatedEvent } from 'src/iam/subscriptions/application/events/subscription-created.event';
+import { SubscriptionCancelledEvent } from 'src/iam/subscriptions/application/events/subscription-cancelled.event';
+import { SubscriptionUncancelledEvent } from 'src/iam/subscriptions/application/events/subscription-uncancelled.event';
+import { SubscriptionSeatsUpdatedEvent } from 'src/iam/subscriptions/application/events/subscription-seats-updated.event';
+import { SubscriptionBillingInfoUpdatedEvent } from 'src/iam/subscriptions/application/events/subscription-billing-info-updated.event';
+import { SendWebhookUseCase } from '../application/use-cases/send-webhook/send-webhook.use-case';
+import { SendWebhookCommand } from '../application/use-cases/send-webhook/send-webhook.command';
+import { UserCreatedWebhookEvent } from '../domain/webhook-events/user-created.webhook-event';
+import { UserUpdatedWebhookEvent } from '../domain/webhook-events/user-updated.webhook-event';
+import { UserDeletedWebhookEvent } from '../domain/webhook-events/user-deleted.webhook-event';
+import { OrgCreatedWebhookEvent } from '../domain/webhook-events/org-created.webhook-event';
+import { SubscriptionCreatedWebhookEvent } from '../domain/webhook-events/subscription-created.webhook-events';
+import { SubscriptionCancelledWebhookEvent } from '../domain/webhook-events/subscription-cancelled.webhook-event';
+import { SubscriptionUncancelledWebhookEvent } from '../domain/webhook-events/subscription-uncancelled.webhook-event';
+import { SubscriptionSeatsUpdatedWebhookEvent } from '../domain/webhook-events/subscription-seats-updated.webhook-event';
+import { SubscriptionBillingInfoUpdatedWebhookEvent } from '../domain/webhook-events/subscription-billing-info-updated.webhook-event';
+import { mapSubscriptionToWebhookPayload } from './subscription-payload.mapper';
+import { mapBillingInfoToWebhookPayload } from './billing-info-payload.mapper';
+import type { WebhookEvent } from '../domain/webhook-event.entity';
+
+/**
+ * Subscribes to domain events that have corresponding webhook event types
+ * and dispatches them via {@link SendWebhookUseCase}. Errors are caught
+ * and logged — matching the existing fire-and-forget pattern.
+ */
+@Injectable()
+export class WebhookDispatchListener {
+  private readonly logger = new Logger(WebhookDispatchListener.name);
+
+  constructor(private readonly sendWebhookUseCase: SendWebhookUseCase) {}
+
+  @OnEvent(UserCreatedEvent.EVENT_NAME)
+  async handleUserCreated(event: UserCreatedEvent): Promise<void> {
+    if (!event.user) return;
+    await this.dispatch(
+      new UserCreatedWebhookEvent({ user: event.user, orgId: event.orgId }),
+    );
+  }
+
+  @OnEvent(UserUpdatedEvent.EVENT_NAME)
+  async handleUserUpdated(event: UserUpdatedEvent): Promise<void> {
+    await this.dispatch(new UserUpdatedWebhookEvent(event.user));
+  }
+
+  @OnEvent(UserDeletedEvent.EVENT_NAME)
+  async handleUserDeleted(event: UserDeletedEvent): Promise<void> {
+    await this.dispatch(new UserDeletedWebhookEvent(event.userId));
+  }
+
+  @OnEvent(OrgCreatedEvent.EVENT_NAME)
+  async handleOrgCreated(event: OrgCreatedEvent): Promise<void> {
+    await this.dispatch(new OrgCreatedWebhookEvent(event.org, event.user));
+  }
+
+  @OnEvent(SubscriptionCreatedEvent.EVENT_NAME)
+  async handleSubscriptionCreated(
+    event: SubscriptionCreatedEvent,
+  ): Promise<void> {
+    await this.dispatch(
+      new SubscriptionCreatedWebhookEvent(
+        mapSubscriptionToWebhookPayload(event.payload),
+      ),
+    );
+  }
+
+  @OnEvent(SubscriptionCancelledEvent.EVENT_NAME)
+  async handleSubscriptionCancelled(
+    event: SubscriptionCancelledEvent,
+  ): Promise<void> {
+    await this.dispatch(
+      new SubscriptionCancelledWebhookEvent(
+        mapSubscriptionToWebhookPayload(event.payload),
+      ),
+    );
+  }
+
+  @OnEvent(SubscriptionUncancelledEvent.EVENT_NAME)
+  async handleSubscriptionUncancelled(
+    event: SubscriptionUncancelledEvent,
+  ): Promise<void> {
+    await this.dispatch(
+      new SubscriptionUncancelledWebhookEvent(
+        mapSubscriptionToWebhookPayload(event.payload),
+      ),
+    );
+  }
+
+  @OnEvent(SubscriptionSeatsUpdatedEvent.EVENT_NAME)
+  async handleSubscriptionSeatsUpdated(
+    event: SubscriptionSeatsUpdatedEvent,
+  ): Promise<void> {
+    await this.dispatch(
+      new SubscriptionSeatsUpdatedWebhookEvent(
+        mapSubscriptionToWebhookPayload(event.payload),
+      ),
+    );
+  }
+
+  @OnEvent(SubscriptionBillingInfoUpdatedEvent.EVENT_NAME)
+  async handleSubscriptionBillingInfoUpdated(
+    event: SubscriptionBillingInfoUpdatedEvent,
+  ): Promise<void> {
+    await this.dispatch(
+      new SubscriptionBillingInfoUpdatedWebhookEvent(
+        mapBillingInfoToWebhookPayload(event.payload),
+      ),
+    );
+  }
+
+  private async dispatch(webhookEvent: WebhookEvent): Promise<void> {
+    try {
+      await this.sendWebhookUseCase.execute(
+        new SendWebhookCommand(webhookEvent),
+      );
+    } catch (error) {
+      this.logger.error('Webhook dispatch failed', {
+        eventType: webhookEvent.eventType,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      });
+    }
+  }
+}

--- a/ayunis-core-backend/src/integrations/webhooks/webhooks.module.ts
+++ b/ayunis-core-backend/src/integrations/webhooks/webhooks.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { SendWebhookUseCase } from './application/use-cases/send-webhook/send-webhook.use-case';
 import { WebhookHandler } from './application/ports/webhook.handler';
 import { HttpWebhookHandler } from './infrastructure/http/http-webhook.handler';
+import { WebhookDispatchListener } from './listeners/webhook-dispatch.listener';
 
 @Module({
   providers: [
@@ -10,6 +11,7 @@ import { HttpWebhookHandler } from './infrastructure/http/http-webhook.handler';
       useClass: HttpWebhookHandler,
     },
     SendWebhookUseCase,
+    WebhookDispatchListener,
   ],
   exports: [SendWebhookUseCase],
 })


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds new event-driven side effects (metric recording and outbound webhook dispatch) on core domain events; while errors are caught, mislabeling or increased event volume could impact observability accuracy and webhook traffic.
> 
> **Overview**
> **Adds event-driven integrations for metrics and webhooks.** A new `PrometheusMetricsListener` subscribes to user/message/run/inference/token/tool/thread events and records the corresponding Prometheus counters/histograms (including department normalization, streaming labels, and skipping zero-token increments), with all metric ops wrapped in `safeMetric` to avoid breaking business flows.
> 
> **Introduces webhook dispatch via domain events.** A new `WebhookDispatchListener` listens to user/org/subscription lifecycle events and triggers `SendWebhookUseCase`, using new mappers to convert subscription/billing-info event payloads into webhook payload shapes (notably serializing `Date` fields to ISO strings); failures are caught and logged. Both listeners are registered in `MetricsModule` and `WebhooksModule`, and include new unit tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0985f1e9faae030f08bc631e8387dd43c8614c3f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->