### PR TITLE
wip(users): migrate user use cases from inline webhooks/metrics to domain events (AYC-71)

### DIFF
--- a/ayunis-core-backend/src/domain/skill-templates/application/listeners/user-created.listener.spec.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/application/listeners/user-created.listener.spec.ts
@@ -1,7 +1,23 @@
 import { SkillTemplateUserCreatedListener } from './user-created.listener';
 import type { SkillTemplateInstallationService } from '../services/skill-template-installation.service';
 import { UserCreatedEvent } from 'src/iam/users/application/events/user-created.event';
+import { User } from 'src/iam/users/domain/user.entity';
+import { UserRole } from 'src/iam/users/domain/value-objects/role.object';
+import type { UUID } from 'crypto';
 import { randomUUID } from 'crypto';
+
+function makeUser(id?: UUID, orgId?: UUID): User {
+  return new User({
+    id: id ?? randomUUID(),
+    email: 'test@example.com',
+    emailVerified: true,
+    passwordHash: 'hashed',
+    role: UserRole.USER,
+    orgId: orgId ?? randomUUID(),
+    name: 'Test User',
+    hasAcceptedMarketing: false,
+  });
+}
 
 describe('SkillTemplateUserCreatedListener', () => {
   let listener: SkillTemplateUserCreatedListener;
@@ -18,7 +34,8 @@ describe('SkillTemplateUserCreatedListener', () => {
   it('should call installAllPreCreatedForUser with the user ID', async () => {
     const userId = randomUUID();
     const orgId = randomUUID();
-    const event = new UserCreatedEvent(userId, orgId);
+    const user = makeUser(userId, orgId);
+    const event = new UserCreatedEvent(userId, orgId, user);
 
     await listener.handleUserCreated(event);
 
@@ -32,7 +49,9 @@ describe('SkillTemplateUserCreatedListener', () => {
       new Error('Unexpected error'),
     );
 
-    const event = new UserCreatedEvent(randomUUID(), randomUUID());
+    const userId = randomUUID();
+    const orgId = randomUUID();
+    const event = new UserCreatedEvent(userId, orgId, makeUser(userId, orgId));
 
     await expect(listener.handleUserCreated(event)).resolves.toBeUndefined();
   });

--- a/ayunis-core-backend/src/domain/skills/application/listeners/user-created.listener.spec.ts
+++ b/ayunis-core-backend/src/domain/skills/application/listeners/user-created.listener.spec.ts
@@ -1,10 +1,25 @@
 import { UserCreatedListener } from './user-created.listener';
 import { UserCreatedEvent } from 'src/iam/users/application/events/user-created.event';
 import type { MarketplaceSkillInstallationService } from '../services/marketplace-skill-installation.service';
+import { User } from 'src/iam/users/domain/user.entity';
+import { UserRole } from 'src/iam/users/domain/value-objects/role.object';
 import type { UUID } from 'crypto';
 
 const USER_ID = '00000000-0000-0000-0000-000000000001' as UUID;
 const ORG_ID = '00000000-0000-0000-0000-000000000002' as UUID;
+
+function makeUser(): User {
+  return new User({
+    id: USER_ID,
+    email: 'test@example.com',
+    emailVerified: true,
+    passwordHash: 'hashed',
+    role: UserRole.USER,
+    orgId: ORG_ID,
+    name: 'Test User',
+    hasAcceptedMarketing: false,
+  });
+}
 
 describe('UserCreatedListener', () => {
   let listener: UserCreatedListener;
@@ -20,7 +35,9 @@ describe('UserCreatedListener', () => {
   });
 
   it('should delegate to installAllPreInstalled with the user ID from the event', async () => {
-    await listener.handleUserCreated(new UserCreatedEvent(USER_ID, ORG_ID));
+    await listener.handleUserCreated(
+      new UserCreatedEvent(USER_ID, ORG_ID, makeUser()),
+    );
 
     expect(
       skillInstallationService.installAllPreInstalled,
@@ -36,7 +53,9 @@ describe('UserCreatedListener', () => {
     );
 
     await expect(
-      listener.handleUserCreated(new UserCreatedEvent(USER_ID, ORG_ID)),
+      listener.handleUserCreated(
+        new UserCreatedEvent(USER_ID, ORG_ID, makeUser()),
+      ),
     ).resolves.toBeUndefined();
   });
 });

--- a/ayunis-core-backend/src/iam/users/application/events/user-created.event.ts
+++ b/ayunis-core-backend/src/iam/users/application/events/user-created.event.ts
@@ -7,7 +7,6 @@ export class UserCreatedEvent {
   constructor(
     public readonly userId: UUID,
     public readonly orgId: UUID,
-    public readonly user?: User,
-    public readonly department?: string,
+    public readonly user: User,
   ) {}
 }

--- a/ayunis-core-backend/src/iam/users/application/use-cases/confirm-email/confirm-email.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/confirm-email/confirm-email.use-case.spec.ts
@@ -1,0 +1,170 @@
+import type { TestingModule } from '@nestjs/testing';
+import { Test } from '@nestjs/testing';
+import { ConfirmEmailUseCase } from './confirm-email.use-case';
+import { ConfirmEmailCommand } from './confirm-email.command';
+import { UserUpdatedEvent } from '../../events/user-updated.event';
+import { UsersRepository } from '../../ports/users.repository';
+import { EmailConfirmationJwtService } from '../../services/email-confirmation-jwt.service';
+import { User } from '../../../domain/user.entity';
+import { UserRole } from '../../../domain/value-objects/role.object';
+import {
+  InvalidEmailConfirmationTokenError,
+  UserNotFoundError,
+  UserEmailMismatchError,
+} from '../../users.errors';
+import type { UUID } from 'crypto';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+
+const USER_ID = '00000000-0000-0000-0000-000000000001' as UUID;
+const ORG_ID = '00000000-0000-0000-0000-000000000002' as UUID;
+const EMAIL = 'maria.schmidt@example.com';
+
+function makeUser(): User {
+  return new User({
+    id: USER_ID,
+    email: EMAIL,
+    emailVerified: false,
+    passwordHash: 'hashed-password',
+    role: UserRole.USER,
+    orgId: ORG_ID,
+    name: 'Maria Schmidt',
+    hasAcceptedMarketing: false,
+  });
+}
+
+describe('ConfirmEmailUseCase', () => {
+  let useCase: ConfirmEmailUseCase;
+  let mockUsersRepository: Partial<UsersRepository>;
+  let mockJwtService: Partial<EmailConfirmationJwtService>;
+  let mockEventEmitter: { emitAsync: jest.Mock };
+
+  beforeAll(async () => {
+    mockUsersRepository = {
+      findOneById: jest.fn(),
+      update: jest.fn(),
+    };
+    mockJwtService = {
+      verifyEmailConfirmationToken: jest.fn(),
+    };
+    mockEventEmitter = {
+      emitAsync: jest.fn().mockResolvedValue([]),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ConfirmEmailUseCase,
+        { provide: UsersRepository, useValue: mockUsersRepository },
+        {
+          provide: EmailConfirmationJwtService,
+          useValue: mockJwtService,
+        },
+        { provide: EventEmitter2, useValue: mockEventEmitter },
+      ],
+    }).compile();
+
+    useCase = module.get<ConfirmEmailUseCase>(ConfirmEmailUseCase);
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should confirm email and set emailVerified to true', async () => {
+    const command = new ConfirmEmailCommand('valid-token');
+    const mockUser = makeUser();
+
+    jest
+      .spyOn(mockJwtService, 'verifyEmailConfirmationToken')
+      .mockReturnValue({ userId: USER_ID, email: EMAIL });
+    jest.spyOn(mockUsersRepository, 'findOneById').mockResolvedValue(mockUser);
+    jest.spyOn(mockUsersRepository, 'update').mockResolvedValue(mockUser);
+
+    await useCase.execute(command);
+
+    expect(mockUser.emailVerified).toBe(true);
+    expect(mockUsersRepository.update).toHaveBeenCalledWith(mockUser);
+  });
+
+  it('should emit UserUpdatedEvent after successful confirmation', async () => {
+    const command = new ConfirmEmailCommand('valid-token');
+    const mockUser = makeUser();
+
+    jest
+      .spyOn(mockJwtService, 'verifyEmailConfirmationToken')
+      .mockReturnValue({ userId: USER_ID, email: EMAIL });
+    jest.spyOn(mockUsersRepository, 'findOneById').mockResolvedValue(mockUser);
+    jest.spyOn(mockUsersRepository, 'update').mockResolvedValue(mockUser);
+
+    await useCase.execute(command);
+
+    expect(mockEventEmitter.emitAsync).toHaveBeenCalledWith(
+      UserUpdatedEvent.EVENT_NAME,
+      expect.objectContaining({
+        userId: mockUser.id,
+        orgId: mockUser.orgId,
+        user: mockUser,
+      }),
+    );
+  });
+
+  it('should throw InvalidEmailConfirmationTokenError when token is invalid', async () => {
+    const command = new ConfirmEmailCommand('invalid-token');
+
+    jest
+      .spyOn(mockJwtService, 'verifyEmailConfirmationToken')
+      .mockImplementation(() => {
+        throw new Error('jwt malformed');
+      });
+
+    await expect(useCase.execute(command)).rejects.toThrow(
+      InvalidEmailConfirmationTokenError,
+    );
+    expect(mockUsersRepository.findOneById).not.toHaveBeenCalled();
+    expect(mockEventEmitter.emitAsync).not.toHaveBeenCalled();
+  });
+
+  it('should throw UserNotFoundError when user does not exist', async () => {
+    const command = new ConfirmEmailCommand('valid-token');
+
+    jest
+      .spyOn(mockJwtService, 'verifyEmailConfirmationToken')
+      .mockReturnValue({ userId: USER_ID, email: EMAIL });
+    jest.spyOn(mockUsersRepository, 'findOneById').mockResolvedValue(null);
+
+    await expect(useCase.execute(command)).rejects.toThrow(UserNotFoundError);
+    expect(mockUsersRepository.update).not.toHaveBeenCalled();
+    expect(mockEventEmitter.emitAsync).not.toHaveBeenCalled();
+  });
+
+  it('should throw UserEmailMismatchError when email does not match', async () => {
+    const command = new ConfirmEmailCommand('valid-token');
+    const mockUser = makeUser();
+
+    jest
+      .spyOn(mockJwtService, 'verifyEmailConfirmationToken')
+      .mockReturnValue({ userId: USER_ID, email: 'other@example.com' });
+    jest.spyOn(mockUsersRepository, 'findOneById').mockResolvedValue(mockUser);
+
+    await expect(useCase.execute(command)).rejects.toThrow(
+      UserEmailMismatchError,
+    );
+    expect(mockUsersRepository.update).not.toHaveBeenCalled();
+    expect(mockEventEmitter.emitAsync).not.toHaveBeenCalled();
+  });
+
+  it('should not emit event when repository update fails', async () => {
+    const command = new ConfirmEmailCommand('valid-token');
+    const mockUser = makeUser();
+
+    jest
+      .spyOn(mockJwtService, 'verifyEmailConfirmationToken')
+      .mockReturnValue({ userId: USER_ID, email: EMAIL });
+    jest.spyOn(mockUsersRepository, 'findOneById').mockResolvedValue(mockUser);
+    jest
+      .spyOn(mockUsersRepository, 'update')
+      .mockRejectedValue(new Error('Database write failed'));
+
+    await expect(useCase.execute(command)).rejects.toThrow();
+    expect(mockEventEmitter.emitAsync).not.toHaveBeenCalled();
+  });
+});

--- a/ayunis-core-backend/src/iam/users/application/use-cases/confirm-email/confirm-email.use-case.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/confirm-email/confirm-email.use-case.ts
@@ -1,4 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { EventEmitter2 } from '@nestjs/event-emitter';
 import { ConfirmEmailCommand } from './confirm-email.command';
 import { UsersRepository } from '../../ports/users.repository';
 import {
@@ -11,10 +12,8 @@ import {
   EmailConfirmationJwtService,
   EmailConfirmationJwtPayload,
 } from '../../services/email-confirmation-jwt.service';
-import { SendWebhookCommand } from 'src/integrations/webhooks/application/use-cases/send-webhook/send-webhook.command';
-import { UserUpdatedWebhookEvent } from 'src/integrations/webhooks/domain/webhook-events/user-updated.webhook-event';
-import { SendWebhookUseCase } from 'src/integrations/webhooks/application/use-cases/send-webhook/send-webhook.use-case';
 import { ApplicationError } from 'src/common/errors/base.error';
+import { UserUpdatedEvent } from '../../events/user-updated.event';
 
 @Injectable()
 export class ConfirmEmailUseCase {
@@ -23,7 +22,7 @@ export class ConfirmEmailUseCase {
   constructor(
     private readonly usersRepository: UsersRepository,
     private readonly emailConfirmationJwtService: EmailConfirmationJwtService,
-    private readonly sendWebhookUseCase: SendWebhookUseCase,
+    private readonly eventEmitter: EventEmitter2,
   ) {}
 
   async execute(command: ConfirmEmailCommand): Promise<void> {
@@ -69,10 +68,17 @@ export class ConfirmEmailUseCase {
         email: user.email,
       });
 
-      // Send webhook asynchronously (don't block the main operation)
-      void this.sendWebhookUseCase.execute(
-        new SendWebhookCommand(new UserUpdatedWebhookEvent(user)),
-      );
+      this.eventEmitter
+        .emitAsync(
+          UserUpdatedEvent.EVENT_NAME,
+          new UserUpdatedEvent(user.id, user.orgId, user),
+        )
+        .catch((err: unknown) => {
+          this.logger.error('Failed to emit UserUpdatedEvent', {
+            error: err instanceof Error ? err.message : 'Unknown error',
+            userId: user.id,
+          });
+        });
     } catch (error) {
       if (error instanceof ApplicationError) {
         throw error;

--- a/ayunis-core-backend/src/iam/users/application/use-cases/create-user/create-user.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/create-user/create-user.use-case.spec.ts
@@ -9,7 +9,6 @@ import {
 } from '../../users.errors';
 import type { UsersRepository } from '../../ports/users.repository';
 import type { HashTextUseCase } from '../../../../hashing/application/use-cases/hash-text/hash-text.use-case';
-import type { SendWebhookUseCase } from 'src/integrations/webhooks/application/use-cases/send-webhook/send-webhook.use-case';
 import type { ConfigService } from '@nestjs/config';
 import type { EventEmitter2 } from '@nestjs/event-emitter';
 import type { UUID } from 'crypto';
@@ -18,10 +17,8 @@ describe('CreateUserUseCase', () => {
   let useCase: CreateUserUseCase;
   let usersRepository: jest.Mocked<UsersRepository>;
   let hashTextUseCase: jest.Mocked<HashTextUseCase>;
-  let sendWebhookUseCase: jest.Mocked<SendWebhookUseCase>;
   let configService: jest.Mocked<ConfigService>;
   let eventEmitter: jest.Mocked<EventEmitter2>;
-  let mockCounter: { inc: jest.Mock };
 
   const orgId = '550e8400-e29b-41d4-a716-446655440000' as UUID;
 
@@ -45,10 +42,6 @@ describe('CreateUserUseCase', () => {
       execute: jest.fn().mockResolvedValue('hashed-password-value'),
     } as unknown as jest.Mocked<HashTextUseCase>;
 
-    sendWebhookUseCase = {
-      execute: jest.fn().mockResolvedValue(undefined),
-    } as unknown as jest.Mocked<SendWebhookUseCase>;
-
     configService = {
       get: jest.fn().mockImplementation((key: string) => {
         if (key === 'auth.emailProviderBlacklist') return ['tempmail.com'];
@@ -60,19 +53,15 @@ describe('CreateUserUseCase', () => {
       emitAsync: jest.fn().mockResolvedValue([]),
     } as unknown as jest.Mocked<EventEmitter2>;
 
-    mockCounter = { inc: jest.fn() };
-
     useCase = new CreateUserUseCase(
       usersRepository,
       hashTextUseCase,
-      sendWebhookUseCase,
       configService,
       eventEmitter,
-      mockCounter as never,
     );
   });
 
-  it('should emit UserCreatedEvent with correct userId and orgId after user creation', async () => {
+  it('should emit UserCreatedEvent with user data after user creation', async () => {
     const result = await useCase.execute(validCommand);
 
     expect(eventEmitter.emitAsync).toHaveBeenCalledWith(
@@ -80,11 +69,12 @@ describe('CreateUserUseCase', () => {
       expect.objectContaining({
         userId: result.id,
         orgId,
+        user: result,
       }),
     );
   });
 
-  it('should increment user creations counter with correct labels', async () => {
+  it('should include department on user in UserCreatedEvent', async () => {
     const commandWithDept = new CreateUserCommand({
       email: 'counter@ayunis.de',
       password: 'Sicher3sPasswort!',
@@ -96,41 +86,16 @@ describe('CreateUserUseCase', () => {
       department: 'bauamt',
     });
 
-    await useCase.execute(commandWithDept);
+    const result = await useCase.execute(commandWithDept);
 
-    expect(mockCounter.inc).toHaveBeenCalledWith({
-      org_id: orgId,
-      department: 'bauamt',
-    });
-  });
-
-  it('should normalize other: department prefix to "other" in counter label', async () => {
-    const commandWithOtherDept = new CreateUserCommand({
-      email: 'other@ayunis.de',
-      password: 'Sicher3sPasswort!',
-      orgId,
-      name: 'Other Dept Test',
-      role: UserRole.USER,
-      emailVerified: false,
-      hasAcceptedMarketing: false,
-      department: 'other:Bürgermeisterbüro',
-    });
-
-    await useCase.execute(commandWithOtherDept);
-
-    expect(mockCounter.inc).toHaveBeenCalledWith({
-      org_id: orgId,
-      department: 'other',
-    });
-  });
-
-  it('should use "none" as department label when department is undefined', async () => {
-    await useCase.execute(validCommand);
-
-    expect(mockCounter.inc).toHaveBeenCalledWith({
-      org_id: orgId,
-      department: 'none',
-    });
+    expect(eventEmitter.emitAsync).toHaveBeenCalledWith(
+      UserCreatedEvent.EVENT_NAME,
+      expect.objectContaining({
+        userId: result.id,
+        orgId,
+        user: expect.objectContaining({ department: 'bauamt' }),
+      }),
+    );
   });
 
   it('should not emit UserCreatedEvent when user already exists', async () => {

--- a/ayunis-core-backend/src/iam/users/application/use-cases/create-user/create-user.use-case.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/create-user/create-user.use-case.ts
@@ -1,7 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { EventEmitter2 } from '@nestjs/event-emitter';
-import { InjectMetric } from '@willsoto/nestjs-prometheus';
-import { Counter } from 'prom-client';
 import { UsersRepository } from '../../ports/users.repository';
 import { CreateUserCommand } from './create-user.command';
 import { User } from '../../../domain/user.entity';
@@ -13,14 +11,9 @@ import {
   UserEmailProviderBlacklistedError,
 } from '../../users.errors';
 import { HashingError } from '../../../../hashing/application/hashing.errors';
-import { UserCreatedWebhookEvent } from 'src/integrations/webhooks/domain/webhook-events/user-created.webhook-event';
-import { SendWebhookCommand } from 'src/integrations/webhooks/application/use-cases/send-webhook/send-webhook.command';
-import { SendWebhookUseCase } from 'src/integrations/webhooks/application/use-cases/send-webhook/send-webhook.use-case';
 import { ConfigService } from '@nestjs/config';
 import { ApplicationError } from 'src/common/errors/base.error';
 import { UserCreatedEvent } from '../../events/user-created.event';
-import { AYUNIS_USER_CREATIONS_TOTAL } from 'src/integrations/metrics/metrics.constants';
-import { safeMetric } from 'src/integrations/metrics/metrics.utils';
 
 @Injectable()
 export class CreateUserUseCase {
@@ -29,11 +22,8 @@ export class CreateUserUseCase {
   constructor(
     private readonly usersRepository: UsersRepository,
     private readonly hashTextUseCase: HashTextUseCase,
-    private readonly sendWebhookUseCase: SendWebhookUseCase,
     private readonly configService: ConfigService,
     private readonly eventEmitter: EventEmitter2,
-    @InjectMetric(AYUNIS_USER_CREATIONS_TOTAL)
-    private readonly userCreationsCounter: Counter<string>,
   ) {}
 
   async execute(command: CreateUserCommand): Promise<User> {
@@ -100,30 +90,10 @@ export class CreateUserUseCase {
         role: command.role,
       });
 
-      safeMetric(this.logger, () => {
-        this.userCreationsCounter.inc({
-          org_id: command.orgId,
-          department:
-            (createdUser.department?.startsWith('other:')
-              ? 'other'
-              : createdUser.department) ?? 'none',
-        });
-      });
-
-      // Send webhook asynchronously (don't block the main operation)
-      void this.sendWebhookUseCase.execute(
-        new SendWebhookCommand(
-          new UserCreatedWebhookEvent({
-            user: createdUser,
-            orgId: command.orgId,
-          }),
-        ),
-      );
-
       this.eventEmitter
         .emitAsync(
           UserCreatedEvent.EVENT_NAME,
-          new UserCreatedEvent(createdUser.id, command.orgId),
+          new UserCreatedEvent(createdUser.id, command.orgId, createdUser),
         )
         .catch((err: unknown) => {
           this.logger.error('Failed to emit UserCreatedEvent', {

--- a/ayunis-core-backend/src/iam/users/application/use-cases/delete-user/delete-user.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/delete-user/delete-user.use-case.spec.ts
@@ -4,15 +4,17 @@ import { Test } from '@nestjs/testing';
 // Mock the Transactional decorator
 jest.mock('@nestjs-cls/transactional', () => ({
   Transactional:
-    () => (target: any, propertyName: string, descriptor: PropertyDescriptor) =>
+    () =>
+    (_target: unknown, _propertyName: string, descriptor: PropertyDescriptor) =>
       descriptor,
 }));
 
 import { DeleteUserUseCase } from './delete-user.use-case';
 import { DeleteUserCommand } from './delete-user.command';
+import { UserDeletedEvent } from '../../events/user-deleted.event';
 import { UsersRepository } from '../../ports/users.repository';
 import type { UUID } from 'crypto';
-import { SendWebhookUseCase } from 'src/integrations/webhooks/application/use-cases/send-webhook/send-webhook.use-case';
+import { EventEmitter2 } from '@nestjs/event-emitter';
 import { DeleteInviteByEmailUseCase } from 'src/iam/invites/application/use-cases/delete-invite-by-email/delete-invite-by-email.use-case';
 import { ContextService } from 'src/common/context/services/context.service';
 import { User } from 'src/iam/users/domain/user.entity';
@@ -21,7 +23,7 @@ import { UserRole } from 'src/iam/users/domain/value-objects/role.object';
 describe('DeleteUserUseCase', () => {
   let useCase: DeleteUserUseCase;
   let mockUsersRepository: Partial<UsersRepository>;
-  let mockSendWebhookUseCase: Partial<SendWebhookUseCase>;
+  let mockEventEmitter: { emitAsync: jest.Mock };
   let mockDeleteInviteByEmailUseCase: Partial<DeleteInviteByEmailUseCase>;
   let mockContextService: Partial<ContextService>;
 
@@ -30,8 +32,8 @@ describe('DeleteUserUseCase', () => {
       delete: jest.fn(),
       findOneById: jest.fn(),
     };
-    mockSendWebhookUseCase = {
-      execute: jest.fn(),
+    mockEventEmitter = {
+      emitAsync: jest.fn().mockResolvedValue([]),
     };
     mockDeleteInviteByEmailUseCase = {
       execute: jest.fn().mockResolvedValue(undefined),
@@ -39,20 +41,20 @@ describe('DeleteUserUseCase', () => {
     mockContextService = {
       get: jest.fn((key?: string) => {
         if (!key) return undefined;
-        const context: Record<string, any> = {
+        const context: Record<string, unknown> = {
           userId: '123e4567-e89b-12d3-a456-426614174000',
           orgId: '123e4567-e89b-12d3-a456-426614174000',
           role: UserRole.ADMIN,
           systemRole: null,
         };
         return context[key];
-      }) as any,
+      }) as ContextService['get'],
     };
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         DeleteUserUseCase,
         { provide: UsersRepository, useValue: mockUsersRepository },
-        { provide: SendWebhookUseCase, useValue: mockSendWebhookUseCase },
+        { provide: EventEmitter2, useValue: mockEventEmitter },
         {
           provide: DeleteInviteByEmailUseCase,
           useValue: mockDeleteInviteByEmailUseCase,
@@ -96,6 +98,37 @@ describe('DeleteUserUseCase', () => {
     expect(mockUsersRepository.delete).toHaveBeenCalledWith(command.userId);
   });
 
+  it('should emit UserDeletedEvent after successful deletion', async () => {
+    const command = new DeleteUserCommand({
+      userId: '123e4567-e89b-12d3-a456-426614174000' as UUID,
+      orgId: '123e4567-e89b-12d3-a456-426614174000' as UUID,
+    });
+
+    const mockUser = new User({
+      id: command.userId,
+      email: 'user@example.com',
+      emailVerified: true,
+      passwordHash: 'hash',
+      role: UserRole.ADMIN,
+      orgId: '123e4567-e89b-12d3-a456-426614174000' as UUID,
+      name: 'Test User',
+      hasAcceptedMarketing: false,
+    });
+
+    jest.spyOn(mockUsersRepository, 'findOneById').mockResolvedValue(mockUser);
+    jest.spyOn(mockUsersRepository, 'delete').mockResolvedValue(undefined);
+
+    await useCase.execute(command);
+
+    expect(mockEventEmitter.emitAsync).toHaveBeenCalledWith(
+      UserDeletedEvent.EVENT_NAME,
+      expect.objectContaining({
+        userId: command.userId,
+        orgId: mockUser.orgId,
+      }),
+    );
+  });
+
   it('should handle repository errors', async () => {
     const command = new DeleteUserCommand({
       userId: 'user-id' as UUID,
@@ -123,5 +156,6 @@ describe('DeleteUserUseCase', () => {
       command.userId,
     );
     expect(mockUsersRepository.delete).toHaveBeenCalledWith(command.userId);
+    expect(mockEventEmitter.emitAsync).not.toHaveBeenCalled();
   });
 });

--- a/ayunis-core-backend/src/iam/users/application/use-cases/delete-user/delete-user.use-case.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/delete-user/delete-user.use-case.ts
@@ -1,17 +1,16 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { EventEmitter2 } from '@nestjs/event-emitter';
 import { UsersRepository } from '../../ports/users.repository';
 import { DeleteUserCommand } from './delete-user.command';
 import { UserNotFoundError, UserUnauthorizedError } from '../../users.errors';
 import { UserRole } from 'src/iam/users/domain/value-objects/role.object';
 import { SystemRole } from 'src/iam/users/domain/value-objects/system-role.enum';
-import { SendWebhookCommand } from 'src/integrations/webhooks/application/use-cases/send-webhook/send-webhook.command';
-import { SendWebhookUseCase } from 'src/integrations/webhooks/application/use-cases/send-webhook/send-webhook.use-case';
-import { UserDeletedWebhookEvent } from 'src/integrations/webhooks/domain/webhook-events/user-deleted.webhook-event';
 import { DeleteInviteByEmailUseCase } from 'src/iam/invites/application/use-cases/delete-invite-by-email/delete-invite-by-email.use-case';
 import { DeleteInviteByEmailCommand } from 'src/iam/invites/application/use-cases/delete-invite-by-email/delete-invite-by-email.command';
 import { ContextService } from 'src/common/context/services/context.service';
 import { Transactional } from '@nestjs-cls/transactional';
 import { InviteNotFoundError } from 'src/iam/invites/application/invites.errors';
+import { UserDeletedEvent } from '../../events/user-deleted.event';
 
 @Injectable()
 export class DeleteUserUseCase {
@@ -20,7 +19,7 @@ export class DeleteUserUseCase {
   constructor(
     private readonly contextService: ContextService,
     private readonly usersRepository: UsersRepository,
-    private readonly sendWebhookUseCase: SendWebhookUseCase,
+    private readonly eventEmitter: EventEmitter2,
     private readonly deleteInviteByEmailUseCase: DeleteInviteByEmailUseCase,
   ) {}
 
@@ -65,8 +64,16 @@ export class DeleteUserUseCase {
         }
         throw error;
       });
-    void this.sendWebhookUseCase.execute(
-      new SendWebhookCommand(new UserDeletedWebhookEvent(command.userId)),
-    );
+    this.eventEmitter
+      .emitAsync(
+        UserDeletedEvent.EVENT_NAME,
+        new UserDeletedEvent(command.userId, userToDelete.orgId),
+      )
+      .catch((err: unknown) => {
+        this.logger.error('Failed to emit UserDeletedEvent', {
+          error: err instanceof Error ? err.message : 'Unknown error',
+          userId: command.userId,
+        });
+      });
   }
 }

--- a/ayunis-core-backend/src/iam/users/application/use-cases/update-user-name/update-user-name.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/update-user-name/update-user-name.use-case.spec.ts
@@ -2,31 +2,32 @@ import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import { UpdateUserNameUseCase } from './update-user-name.use-case';
 import { UpdateUserNameCommand } from './update-user-name.command';
+import { UserUpdatedEvent } from '../../events/user-updated.event';
 import { UsersRepository } from '../../ports/users.repository';
 import { User } from '../../../domain/user.entity';
 import { UserRole } from '../../../domain/value-objects/role.object';
 import type { UUID } from 'crypto';
-import { SendWebhookUseCase } from 'src/integrations/webhooks/application/use-cases/send-webhook/send-webhook.use-case';
+import { EventEmitter2 } from '@nestjs/event-emitter';
 
 describe('UpdateUserNameUseCase', () => {
   let useCase: UpdateUserNameUseCase;
   let mockUsersRepository: Partial<UsersRepository>;
-  let mockSendWebhookUseCase: Partial<SendWebhookUseCase>;
+  let mockEventEmitter: { emitAsync: jest.Mock };
 
   beforeAll(async () => {
     mockUsersRepository = {
       findOneById: jest.fn(),
       update: jest.fn(),
     };
-    mockSendWebhookUseCase = {
-      execute: jest.fn(),
+    mockEventEmitter = {
+      emitAsync: jest.fn().mockResolvedValue([]),
     };
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         UpdateUserNameUseCase,
         { provide: UsersRepository, useValue: mockUsersRepository },
-        { provide: SendWebhookUseCase, useValue: mockSendWebhookUseCase },
+        { provide: EventEmitter2, useValue: mockEventEmitter },
       ],
     }).compile();
 
@@ -67,6 +68,34 @@ describe('UpdateUserNameUseCase', () => {
     expect(result).toBe(updatedUser);
   });
 
+  it('should emit UserUpdatedEvent after successful update', async () => {
+    const command = new UpdateUserNameCommand('user-id' as UUID, 'New Name');
+    const mockUser = new User({
+      id: 'user-id' as UUID,
+      email: 'test@example.com',
+      emailVerified: false,
+      passwordHash: 'hash',
+      role: UserRole.USER,
+      orgId: 'org-id' as UUID,
+      name: 'Old Name',
+      hasAcceptedMarketing: false,
+    });
+
+    jest.spyOn(mockUsersRepository, 'findOneById').mockResolvedValue(mockUser);
+    jest.spyOn(mockUsersRepository, 'update').mockResolvedValue(mockUser);
+
+    await useCase.execute(command);
+
+    expect(mockEventEmitter.emitAsync).toHaveBeenCalledWith(
+      UserUpdatedEvent.EVENT_NAME,
+      expect.objectContaining({
+        userId: mockUser.id,
+        orgId: mockUser.orgId,
+        user: mockUser,
+      }),
+    );
+  });
+
   it('should handle repository errors when finding user', async () => {
     const command = new UpdateUserNameCommand('user-id' as UUID, 'New Name');
     const error = new Error('User not found');
@@ -76,6 +105,7 @@ describe('UpdateUserNameUseCase', () => {
     await expect(useCase.execute(command)).rejects.toThrow();
     expect(mockUsersRepository.findOneById).toHaveBeenCalledWith('user-id');
     expect(mockUsersRepository.update).not.toHaveBeenCalled();
+    expect(mockEventEmitter.emitAsync).not.toHaveBeenCalled();
   });
 
   it('should handle repository errors when updating user', async () => {
@@ -98,5 +128,6 @@ describe('UpdateUserNameUseCase', () => {
     await expect(useCase.execute(command)).rejects.toThrow();
     expect(mockUsersRepository.findOneById).toHaveBeenCalledWith('user-id');
     expect(mockUsersRepository.update).toHaveBeenCalledWith(mockUser);
+    expect(mockEventEmitter.emitAsync).not.toHaveBeenCalled();
   });
 });

--- a/ayunis-core-backend/src/iam/users/application/use-cases/update-user-name/update-user-name.use-case.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/update-user-name/update-user-name.use-case.ts
@@ -1,12 +1,11 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { EventEmitter2 } from '@nestjs/event-emitter';
 import { UsersRepository } from '../../ports/users.repository';
 import { UpdateUserNameCommand } from './update-user-name.command';
 import { User } from '../../../domain/user.entity';
 import { UserNotFoundError, UserUnexpectedError } from '../../users.errors';
-import { UserUpdatedWebhookEvent } from 'src/integrations/webhooks/domain/webhook-events/user-updated.webhook-event';
-import { SendWebhookCommand } from 'src/integrations/webhooks/application/use-cases/send-webhook/send-webhook.command';
-import { SendWebhookUseCase } from 'src/integrations/webhooks/application/use-cases/send-webhook/send-webhook.use-case';
 import { ApplicationError } from 'src/common/errors/base.error';
+import { UserUpdatedEvent } from '../../events/user-updated.event';
 
 @Injectable()
 export class UpdateUserNameUseCase {
@@ -14,7 +13,7 @@ export class UpdateUserNameUseCase {
 
   constructor(
     private readonly usersRepository: UsersRepository,
-    private readonly sendWebhookUseCase: SendWebhookUseCase,
+    private readonly eventEmitter: EventEmitter2,
   ) {}
 
   async execute(command: UpdateUserNameCommand): Promise<User> {
@@ -39,9 +38,17 @@ export class UpdateUserNameUseCase {
         newName: updatedUser.name,
       });
 
-      void this.sendWebhookUseCase.execute(
-        new SendWebhookCommand(new UserUpdatedWebhookEvent(updatedUser)),
-      );
+      this.eventEmitter
+        .emitAsync(
+          UserUpdatedEvent.EVENT_NAME,
+          new UserUpdatedEvent(updatedUser.id, updatedUser.orgId, updatedUser),
+        )
+        .catch((err: unknown) => {
+          this.logger.error('Failed to emit UserUpdatedEvent', {
+            error: err instanceof Error ? err.message : 'Unknown error',
+            userId: updatedUser.id,
+          });
+        });
 
       return updatedUser;
     } catch (error) {

--- a/ayunis-core-backend/src/iam/users/application/use-cases/update-user-role/update-user-role.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/update-user-role/update-user-role.use-case.spec.ts
@@ -2,31 +2,32 @@ import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import { UpdateUserRoleUseCase } from './update-user-role.use-case';
 import { UpdateUserRoleCommand } from './update-user-role.command';
+import { UserUpdatedEvent } from '../../events/user-updated.event';
 import { UsersRepository } from '../../ports/users.repository';
 import { User } from '../../../domain/user.entity';
 import { UserRole } from '../../../domain/value-objects/role.object';
 import type { UUID } from 'crypto';
-import { SendWebhookUseCase } from 'src/integrations/webhooks/application/use-cases/send-webhook/send-webhook.use-case';
+import { EventEmitter2 } from '@nestjs/event-emitter';
 import { UserUnexpectedError } from '../../users.errors';
 
 describe('UpdateUserRoleUseCase', () => {
   let useCase: UpdateUserRoleUseCase;
   let mockUsersRepository: Partial<UsersRepository>;
-  let mockSendWebhookUseCase: Partial<SendWebhookUseCase>;
+  let mockEventEmitter: { emitAsync: jest.Mock };
 
   beforeAll(async () => {
     mockUsersRepository = {
       findOneById: jest.fn(),
       update: jest.fn(),
     };
-    mockSendWebhookUseCase = {
-      execute: jest.fn(),
+    mockEventEmitter = {
+      emitAsync: jest.fn().mockResolvedValue([]),
     };
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         UpdateUserRoleUseCase,
         { provide: UsersRepository, useValue: mockUsersRepository },
-        { provide: SendWebhookUseCase, useValue: mockSendWebhookUseCase },
+        { provide: EventEmitter2, useValue: mockEventEmitter },
       ],
     }).compile();
 
@@ -70,6 +71,37 @@ describe('UpdateUserRoleUseCase', () => {
     expect(result).toBe(updatedUser);
   });
 
+  it('should emit UserUpdatedEvent after successful update', async () => {
+    const command = new UpdateUserRoleCommand(
+      'user-id' as UUID,
+      UserRole.ADMIN,
+    );
+    const mockUser = new User({
+      id: 'user-id' as UUID,
+      email: 'test@example.com',
+      emailVerified: false,
+      passwordHash: 'hash',
+      role: UserRole.USER,
+      orgId: 'org-id' as UUID,
+      name: 'Test User',
+      hasAcceptedMarketing: false,
+    });
+
+    jest.spyOn(mockUsersRepository, 'findOneById').mockResolvedValue(mockUser);
+    jest.spyOn(mockUsersRepository, 'update').mockResolvedValue(mockUser);
+
+    await useCase.execute(command);
+
+    expect(mockEventEmitter.emitAsync).toHaveBeenCalledWith(
+      UserUpdatedEvent.EVENT_NAME,
+      expect.objectContaining({
+        userId: mockUser.id,
+        orgId: mockUser.orgId,
+        user: mockUser,
+      }),
+    );
+  });
+
   it('should handle repository errors when finding user', async () => {
     const command = new UpdateUserRoleCommand(
       'user-id' as UUID,
@@ -80,9 +112,9 @@ describe('UpdateUserRoleUseCase', () => {
     jest.spyOn(mockUsersRepository, 'findOneById').mockRejectedValue(error);
 
     await expect(useCase.execute(command)).rejects.toThrow();
-    await expect(useCase.execute(command)).rejects.toThrow();
     expect(mockUsersRepository.findOneById).toHaveBeenCalledWith('user-id');
     expect(mockUsersRepository.update).not.toHaveBeenCalled();
+    expect(mockEventEmitter.emitAsync).not.toHaveBeenCalled();
   });
 
   it('should handle repository errors when updating user', async () => {
@@ -106,10 +138,8 @@ describe('UpdateUserRoleUseCase', () => {
     jest.spyOn(mockUsersRepository, 'update').mockRejectedValue(updateError);
 
     await expect(useCase.execute(command)).rejects.toThrow(UserUnexpectedError);
-    await expect(useCase.execute(command)).rejects.toThrow(
-      'An unexpected error occurred',
-    );
     expect(mockUsersRepository.findOneById).toHaveBeenCalledWith('user-id');
     expect(mockUsersRepository.update).toHaveBeenCalledWith(mockUser);
+    expect(mockEventEmitter.emitAsync).not.toHaveBeenCalled();
   });
 });

--- a/ayunis-core-backend/src/iam/users/application/use-cases/update-user-role/update-user-role.use-case.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/update-user-role/update-user-role.use-case.ts
@@ -1,12 +1,11 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { EventEmitter2 } from '@nestjs/event-emitter';
 import { UsersRepository } from '../../ports/users.repository';
 import { UpdateUserRoleCommand } from './update-user-role.command';
 import { User } from '../../../domain/user.entity';
 import { UserNotFoundError, UserUnexpectedError } from '../../users.errors';
 import { ApplicationError } from 'src/common/errors/base.error';
-import { SendWebhookUseCase } from 'src/integrations/webhooks/application/use-cases/send-webhook/send-webhook.use-case';
-import { SendWebhookCommand } from 'src/integrations/webhooks/application/use-cases/send-webhook/send-webhook.command';
-import { UserUpdatedWebhookEvent } from 'src/integrations/webhooks/domain/webhook-events/user-updated.webhook-event';
+import { UserUpdatedEvent } from '../../events/user-updated.event';
 
 @Injectable()
 export class UpdateUserRoleUseCase {
@@ -14,7 +13,7 @@ export class UpdateUserRoleUseCase {
 
   constructor(
     private readonly usersRepository: UsersRepository,
-    private readonly sendWebhookUseCase: SendWebhookUseCase,
+    private readonly eventEmitter: EventEmitter2,
   ) {}
 
   async execute(command: UpdateUserRoleCommand): Promise<User> {
@@ -36,9 +35,17 @@ export class UpdateUserRoleUseCase {
       // Save the updated user
       const updatedUser = await this.usersRepository.update(user);
 
-      void this.sendWebhookUseCase.execute(
-        new SendWebhookCommand(new UserUpdatedWebhookEvent(updatedUser)),
-      );
+      this.eventEmitter
+        .emitAsync(
+          UserUpdatedEvent.EVENT_NAME,
+          new UserUpdatedEvent(updatedUser.id, updatedUser.orgId, updatedUser),
+        )
+        .catch((err: unknown) => {
+          this.logger.error('Failed to emit UserUpdatedEvent', {
+            error: err instanceof Error ? err.message : 'Unknown error',
+            userId: updatedUser.id,
+          });
+        });
 
       return updatedUser;
     } catch (error) {

--- a/ayunis-core-backend/src/iam/users/users.module.ts
+++ b/ayunis-core-backend/src/iam/users/users.module.ts
@@ -42,7 +42,6 @@ import { FindUserByEmailUseCase } from './application/use-cases/find-user-by-ema
 import { FindAllUserIdsByOrgIdUseCase } from './application/use-cases/find-all-user-ids-by-org-id/find-all-user-ids-by-org-id.use-case';
 import { AdminTriggerPasswordResetUseCase } from './application/use-cases/admin-trigger-password-reset/admin-trigger-password-reset.use-case';
 import { SuperAdminTriggerPasswordResetUseCase } from './application/use-cases/super-admin-trigger-password-reset/super-admin-trigger-password-reset.use-case';
-import { WebhooksModule } from 'src/integrations/webhooks/webhooks.module';
 import { InvitesModule } from '../invites/invites.module';
 import { SuperAdminUsersController } from './presenters/http/super-admin-users.controller';
 import { SuperAdminManagementController } from './presenters/http/super-admin-management.controller';
@@ -57,7 +56,6 @@ import { DemoteFromSuperAdminUseCase } from './application/use-cases/demote-from
     HashingModule,
     EmailsModule,
     EmailTemplatesModule,
-    WebhooksModule,
     JwtModule.registerAsync({
       imports: [ConfigModule],
       inject: [ConfigService],

--- a/ayunis-core-backend/src/integrations/metrics/listeners/prometheus-metrics.listener.spec.ts
+++ b/ayunis-core-backend/src/integrations/metrics/listeners/prometheus-metrics.listener.spec.ts
@@ -8,11 +8,27 @@ import { InferenceCompletedEvent } from 'src/domain/runs/application/events/infe
 import { TokensConsumedEvent } from 'src/domain/runs/application/events/tokens-consumed.event';
 import { ToolUsedEvent } from 'src/domain/runs/application/events/tool-used.event';
 import { ThreadMessageAddedEvent } from 'src/domain/threads/application/events/thread-message-added.event';
+import { User } from 'src/iam/users/domain/user.entity';
+import { UserRole } from 'src/iam/users/domain/value-objects/role.object';
 
 const USER_ID = '00000000-0000-0000-0000-000000000001' as UUID;
 const ORG_ID = '00000000-0000-0000-0000-000000000002' as UUID;
 const THREAD_ID = '00000000-0000-0000-0000-000000000003' as UUID;
 const MESSAGE_ID = '00000000-0000-0000-0000-000000000004' as UUID;
+
+function makeUser(overrides?: Partial<{ department: string }>): User {
+  return new User({
+    id: USER_ID,
+    email: 'test@example.com',
+    emailVerified: true,
+    passwordHash: 'hashed',
+    role: UserRole.ADMIN,
+    orgId: ORG_ID,
+    name: 'Test User',
+    hasAcceptedMarketing: false,
+    department: overrides?.department,
+  });
+}
 
 function mockCounter() {
   return { inc: jest.fn() };
@@ -58,7 +74,11 @@ describe('PrometheusMetricsListener', () => {
   describe('handleUserCreated', () => {
     it('should increment user creations counter with org and department', () => {
       listener.handleUserCreated(
-        new UserCreatedEvent(USER_ID, ORG_ID, undefined, 'engineering'),
+        new UserCreatedEvent(
+          USER_ID,
+          ORG_ID,
+          makeUser({ department: 'engineering' }),
+        ),
       );
 
       expect(userCreationsCounter.inc).toHaveBeenCalledWith({
@@ -69,7 +89,11 @@ describe('PrometheusMetricsListener', () => {
 
     it('should normalize "other:" prefixed departments to "other"', () => {
       listener.handleUserCreated(
-        new UserCreatedEvent(USER_ID, ORG_ID, undefined, 'other:custom'),
+        new UserCreatedEvent(
+          USER_ID,
+          ORG_ID,
+          makeUser({ department: 'other:custom' }),
+        ),
       );
 
       expect(userCreationsCounter.inc).toHaveBeenCalledWith({
@@ -79,7 +103,9 @@ describe('PrometheusMetricsListener', () => {
     });
 
     it('should use "none" when department is undefined', () => {
-      listener.handleUserCreated(new UserCreatedEvent(USER_ID, ORG_ID));
+      listener.handleUserCreated(
+        new UserCreatedEvent(USER_ID, ORG_ID, makeUser()),
+      );
 
       expect(userCreationsCounter.inc).toHaveBeenCalledWith({
         org_id: ORG_ID,
@@ -279,7 +305,9 @@ describe('PrometheusMetricsListener', () => {
       });
 
       expect(() =>
-        listener.handleUserCreated(new UserCreatedEvent(USER_ID, ORG_ID)),
+        listener.handleUserCreated(
+          new UserCreatedEvent(USER_ID, ORG_ID, makeUser()),
+        ),
       ).not.toThrow();
     });
   });

--- a/ayunis-core-backend/src/integrations/metrics/listeners/prometheus-metrics.listener.ts
+++ b/ayunis-core-backend/src/integrations/metrics/listeners/prometheus-metrics.listener.ts
@@ -55,7 +55,7 @@ export class PrometheusMetricsListener {
     safeMetric(this.logger, () => {
       this.userCreationsCounter.inc({
         org_id: event.orgId,
-        department: normalizeDepartment(event.department),
+        department: normalizeDepartment(event.user.department),
       });
     });
   }

--- a/ayunis-core-backend/src/integrations/webhooks/listeners/webhook-dispatch.listener.spec.ts
+++ b/ayunis-core-backend/src/integrations/webhooks/listeners/webhook-dispatch.listener.spec.ts
@@ -70,21 +70,15 @@ describe('WebhookDispatchListener', () => {
   });
 
   describe('handleUserCreated', () => {
-    it('should dispatch UserCreatedWebhookEvent when user is present', async () => {
+    it('should dispatch UserCreatedWebhookEvent', async () => {
       const user = makeUser();
       await listener.handleUserCreated(
-        new UserCreatedEvent(USER_ID, ORG_ID, user, 'engineering'),
+        new UserCreatedEvent(USER_ID, ORG_ID, user),
       );
 
       expect(sendWebhookUseCase.execute).toHaveBeenCalledTimes(1);
       const command = sendWebhookUseCase.execute.mock.calls[0][0];
       expect(command.event.eventType).toBe(WebhookEventType.USER_CREATED);
-    });
-
-    it('should not dispatch when user is absent', async () => {
-      await listener.handleUserCreated(new UserCreatedEvent(USER_ID, ORG_ID));
-
-      expect(sendWebhookUseCase.execute).not.toHaveBeenCalled();
     });
   });
 

--- a/ayunis-core-backend/src/integrations/webhooks/listeners/webhook-dispatch.listener.ts
+++ b/ayunis-core-backend/src/integrations/webhooks/listeners/webhook-dispatch.listener.ts
@@ -37,7 +37,6 @@ export class WebhookDispatchListener {
 
   @OnEvent(UserCreatedEvent.EVENT_NAME)
   async handleUserCreated(event: UserCreatedEvent): Promise<void> {
-    if (!event.user) return;
     await this.dispatch(
       new UserCreatedWebhookEvent({ user: event.user, orgId: event.orgId }),
     );


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches user creation/update/deletion and email confirmation flows, replacing side effects (webhooks/metrics) with event emission; main risk is missing/changed event payloads breaking downstream listeners.
> 
> **Overview**
> User lifecycle use-cases (`CreateUserUseCase`, `ConfirmEmailUseCase`, `UpdateUserNameUseCase`, `UpdateUserRoleUseCase`, `DeleteUserUseCase`) now **emit domain events via `EventEmitter2`** (`UserCreatedEvent`, `UserUpdatedEvent`, `UserDeletedEvent`) instead of calling webhook use-cases directly (and removes the user-creation Prometheus counter from `CreateUserUseCase`).
> 
> `UserCreatedEvent` is changed to require a non-optional `user: User` payload (dropping the old optional `department` field), and downstream listeners/tests are updated accordingly: Prometheus metrics now read `department` from `event.user.department`, webhook dispatch no longer guards against missing `event.user`, and skill/skill-template user-created listeners’ tests now construct events with a real `User`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e840f579530bae2ac96b0e90da1e4fed913fffb5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->