### PR TITLE
wip(integrations): migrate domain use cases from inline metrics to domain events (AYC-71)

### DIFF
--- a/ayunis-core-backend/src/domain/messages/application/use-cases/create-assistant-message/create-assistant-message.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/messages/application/use-cases/create-assistant-message/create-assistant-message.use-case.spec.ts
@@ -10,14 +10,14 @@ import { ToolUseMessageContent } from '../../../domain/message-contents/tool-use
 import { MessageCreationError } from '../../messages.errors';
 import { randomUUID } from 'crypto';
 import { ContextService } from 'src/common/context/services/context.service';
-import { getToken } from '@willsoto/nestjs-prometheus';
-import { AYUNIS_MESSAGES_TOTAL } from 'src/integrations/metrics/metrics.constants';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { AssistantMessageCreatedEvent } from '../../events/assistant-message-created.event';
 
 describe('CreateAssistantMessageUseCase', () => {
   let useCase: CreateAssistantMessageUseCase;
   let mockMessagesRepository: Partial<MessagesRepository>;
   let mockContextService: Partial<ContextService>;
-  let mockMessagesCounter: { inc: jest.Mock };
+  let mockEventEmitter: { emitAsync: jest.Mock };
 
   beforeAll(async () => {
     mockMessagesRepository = {
@@ -28,17 +28,16 @@ describe('CreateAssistantMessageUseCase', () => {
       get: jest.fn().mockReturnValue(randomUUID()),
     };
 
-    mockMessagesCounter = { inc: jest.fn() };
+    mockEventEmitter = {
+      emitAsync: jest.fn().mockResolvedValue([]),
+    };
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         CreateAssistantMessageUseCase,
         { provide: MESSAGES_REPOSITORY, useValue: mockMessagesRepository },
         { provide: ContextService, useValue: mockContextService },
-        {
-          provide: getToken(AYUNIS_MESSAGES_TOTAL),
-          useValue: mockMessagesCounter,
-        },
+        { provide: EventEmitter2, useValue: mockEventEmitter },
       ],
     }).compile();
 
@@ -202,7 +201,7 @@ describe('CreateAssistantMessageUseCase', () => {
       );
     });
 
-    it('should increment the messages counter on success', async () => {
+    it('should emit AssistantMessageCreatedEvent on success', async () => {
       // Arrange
       const threadId = randomUUID();
       const content = [new TextMessageContent('Hello!')];
@@ -217,12 +216,16 @@ describe('CreateAssistantMessageUseCase', () => {
       await useCase.execute(command);
 
       // Assert
-      expect(mockMessagesCounter.inc).toHaveBeenCalledWith(
-        expect.objectContaining({ role: 'assistant' }),
+      expect(mockEventEmitter.emitAsync).toHaveBeenCalledWith(
+        AssistantMessageCreatedEvent.EVENT_NAME,
+        expect.objectContaining({
+          threadId,
+          messageId: expectedMessage.id,
+        }),
       );
     });
 
-    it('should not propagate metric errors', async () => {
+    it('should not propagate event emission errors', async () => {
       // Arrange
       const threadId = randomUUID();
       const content = [new TextMessageContent('Hello!')];
@@ -232,9 +235,9 @@ describe('CreateAssistantMessageUseCase', () => {
       jest
         .spyOn(mockMessagesRepository, 'create')
         .mockResolvedValue(expectedMessage);
-      mockMessagesCounter.inc.mockImplementation(() => {
-        throw new Error('Metric registration error');
-      });
+      mockEventEmitter.emitAsync.mockRejectedValue(
+        new Error('Event emission error'),
+      );
 
       // Act
       const result = await useCase.execute(command);

--- a/ayunis-core-backend/src/domain/messages/application/use-cases/create-assistant-message/create-assistant-message.use-case.ts
+++ b/ayunis-core-backend/src/domain/messages/application/use-cases/create-assistant-message/create-assistant-message.use-case.ts
@@ -1,6 +1,5 @@
 import { Injectable, Logger, Inject } from '@nestjs/common';
-import { Counter } from 'prom-client';
-import { InjectMetric } from '@willsoto/nestjs-prometheus';
+import { EventEmitter2 } from '@nestjs/event-emitter';
 import { CreateAssistantMessageCommand } from './create-assistant-message.command';
 import { AssistantMessage } from '../../../domain/messages/assistant-message.entity';
 import {
@@ -10,11 +9,8 @@ import {
 import { MessageRole } from '../../../domain/value-objects/message-role.object';
 import { MessageCreationError } from '../../messages.errors';
 import { ContextService } from 'src/common/context/services/context.service';
-import { AYUNIS_MESSAGES_TOTAL } from 'src/integrations/metrics/metrics.constants';
-import {
-  getUserContextLabels,
-  safeMetric,
-} from 'src/integrations/metrics/metrics.utils';
+import { AssistantMessageCreatedEvent } from '../../events/assistant-message-created.event';
+import type { UUID } from 'crypto';
 
 @Injectable()
 export class CreateAssistantMessageUseCase {
@@ -24,8 +20,7 @@ export class CreateAssistantMessageUseCase {
     @Inject(MESSAGES_REPOSITORY)
     private readonly messagesRepository: MessagesRepository,
     private readonly contextService: ContextService,
-    @InjectMetric(AYUNIS_MESSAGES_TOTAL)
-    private readonly messagesCounter: Counter<string>,
+    private readonly eventEmitter: EventEmitter2,
   ) {}
 
   async execute(
@@ -45,10 +40,24 @@ export class CreateAssistantMessageUseCase {
         assistantMessage,
       )) as AssistantMessage;
 
-      safeMetric(this.logger, () => {
-        const labels = getUserContextLabels(this.contextService);
-        this.messagesCounter.inc({ ...labels, role: 'assistant' });
-      });
+      const userId = this.contextService.get('userId');
+      const orgId = this.contextService.get('orgId');
+      this.eventEmitter
+        .emitAsync(
+          AssistantMessageCreatedEvent.EVENT_NAME,
+          new AssistantMessageCreatedEvent(
+            userId ?? ('unknown' as UUID),
+            orgId ?? ('unknown' as UUID),
+            command.threadId,
+            saved.id,
+          ),
+        )
+        .catch((err: unknown) => {
+          this.logger.error('Failed to emit AssistantMessageCreatedEvent', {
+            error: err instanceof Error ? err.message : 'Unknown error',
+            messageId: saved.id,
+          });
+        });
 
       return saved;
     } catch (error) {

--- a/ayunis-core-backend/src/domain/messages/application/use-cases/create-user-message/create-user-message.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/messages/application/use-cases/create-user-message/create-user-message.use-case.spec.ts
@@ -12,8 +12,8 @@ import { UploadObjectUseCase } from 'src/domain/storage/application/use-cases/up
 import { DeleteObjectUseCase } from 'src/domain/storage/application/use-cases/delete-object/delete-object.use-case';
 import { ContextService } from 'src/common/context/services/context.service';
 import { UnauthorizedException } from '@nestjs/common';
-import { getToken } from '@willsoto/nestjs-prometheus';
-import { AYUNIS_MESSAGES_TOTAL } from 'src/integrations/metrics/metrics.constants';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { UserMessageCreatedEvent } from '../../events/user-message-created.event';
 
 describe('CreateUserMessageUseCase', () => {
   let useCase: CreateUserMessageUseCase;
@@ -21,6 +21,7 @@ describe('CreateUserMessageUseCase', () => {
   let mockUploadObjectUseCase: Partial<UploadObjectUseCase>;
   let mockDeleteObjectUseCase: Partial<DeleteObjectUseCase>;
   let mockContextService: Partial<ContextService>;
+  let mockEventEmitter: { emitAsync: jest.Mock };
 
   const mockOrgId = randomUUID();
 
@@ -41,6 +42,10 @@ describe('CreateUserMessageUseCase', () => {
       get: jest.fn().mockReturnValue(mockOrgId),
     };
 
+    mockEventEmitter = {
+      emitAsync: jest.fn().mockResolvedValue([]),
+    };
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         CreateUserMessageUseCase,
@@ -48,10 +53,7 @@ describe('CreateUserMessageUseCase', () => {
         { provide: UploadObjectUseCase, useValue: mockUploadObjectUseCase },
         { provide: DeleteObjectUseCase, useValue: mockDeleteObjectUseCase },
         { provide: ContextService, useValue: mockContextService },
-        {
-          provide: getToken(AYUNIS_MESSAGES_TOTAL),
-          useValue: { inc: jest.fn() },
-        },
+        { provide: EventEmitter2, useValue: mockEventEmitter },
       ],
     }).compile();
 
@@ -219,6 +221,58 @@ describe('CreateUserMessageUseCase', () => {
       expect(mockMessagesRepository.create).toHaveBeenCalledWith(
         expect.any(UserMessage),
       );
+    });
+
+    it('should emit UserMessageCreatedEvent on success', async () => {
+      // Arrange
+      const threadId = randomUUID();
+      const text = 'Hello world';
+      const command = new CreateUserMessageCommand(threadId, text);
+
+      const expectedMessage = new UserMessage({
+        threadId,
+        content: [],
+      });
+      jest
+        .spyOn(mockMessagesRepository, 'create')
+        .mockResolvedValue(expectedMessage);
+
+      // Act
+      await useCase.execute(command);
+
+      // Assert
+      expect(mockEventEmitter.emitAsync).toHaveBeenCalledWith(
+        UserMessageCreatedEvent.EVENT_NAME,
+        expect.objectContaining({
+          orgId: mockOrgId,
+          threadId,
+          messageId: expectedMessage.id,
+        }),
+      );
+    });
+
+    it('should not propagate event emission errors', async () => {
+      // Arrange
+      const threadId = randomUUID();
+      const text = 'Hello world';
+      const command = new CreateUserMessageCommand(threadId, text);
+
+      const expectedMessage = new UserMessage({
+        threadId,
+        content: [],
+      });
+      jest
+        .spyOn(mockMessagesRepository, 'create')
+        .mockResolvedValue(expectedMessage);
+      mockEventEmitter.emitAsync.mockRejectedValue(
+        new Error('Event emission error'),
+      );
+
+      // Act
+      const result = await useCase.execute(command);
+
+      // Assert
+      expect(result).toBe(expectedMessage);
     });
 
     it('should handle non-Error repository failures', async () => {

--- a/ayunis-core-backend/src/domain/messages/application/use-cases/create-user-message/create-user-message.use-case.ts
+++ b/ayunis-core-backend/src/domain/messages/application/use-cases/create-user-message/create-user-message.use-case.ts
@@ -4,8 +4,7 @@ import {
   Inject,
   UnauthorizedException,
 } from '@nestjs/common';
-import { Counter } from 'prom-client';
-import { InjectMetric } from '@willsoto/nestjs-prometheus';
+import { EventEmitter2 } from '@nestjs/event-emitter';
 import { CreateUserMessageCommand } from './create-user-message.command';
 import { UserMessage } from '../../../domain/messages/user-message.entity';
 import {
@@ -22,11 +21,8 @@ import { DeleteObjectCommand } from 'src/domain/storage/application/use-cases/de
 import { TextMessageContent } from '../../../domain/message-contents/text-message-content.entity';
 import { ImageMessageContent } from '../../../domain/message-contents/image-message-content.entity';
 import { getImageStoragePath } from '../../../domain/image-storage-path.util';
-import { AYUNIS_MESSAGES_TOTAL } from 'src/integrations/metrics/metrics.constants';
-import {
-  getUserContextLabels,
-  safeMetric,
-} from 'src/integrations/metrics/metrics.utils';
+import { UserMessageCreatedEvent } from '../../events/user-message-created.event';
+import type { UUID } from 'crypto';
 
 @Injectable()
 export class CreateUserMessageUseCase {
@@ -38,8 +34,7 @@ export class CreateUserMessageUseCase {
     private readonly uploadObjectUseCase: UploadObjectUseCase,
     private readonly deleteObjectUseCase: DeleteObjectUseCase,
     private readonly contextService: ContextService,
-    @InjectMetric(AYUNIS_MESSAGES_TOTAL)
-    private readonly messagesCounter: Counter<string>,
+    private readonly eventEmitter: EventEmitter2,
   ) {}
 
   async execute(command: CreateUserMessageCommand): Promise<UserMessage> {
@@ -116,10 +111,23 @@ export class CreateUserMessageUseCase {
         userMessage,
       )) as UserMessage;
 
-      safeMetric(this.logger, () => {
-        const labels = getUserContextLabels(this.contextService);
-        this.messagesCounter.inc({ ...labels, role: 'user' });
-      });
+      const userId = this.contextService.get('userId');
+      this.eventEmitter
+        .emitAsync(
+          UserMessageCreatedEvent.EVENT_NAME,
+          new UserMessageCreatedEvent(
+            userId ?? ('unknown' as UUID),
+            orgId,
+            command.threadId,
+            savedMessage.id,
+          ),
+        )
+        .catch((err: unknown) => {
+          this.logger.error('Failed to emit UserMessageCreatedEvent', {
+            error: err instanceof Error ? err.message : 'Unknown error',
+            messageId: savedMessage.id,
+          });
+        });
 
       this.logger.log('User message created successfully', {
         messageId: savedMessage.id,

--- a/ayunis-core-backend/src/domain/messages/application/use-cases/save-assistant-message/save-assistant-message.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/messages/application/use-cases/save-assistant-message/save-assistant-message.use-case.spec.ts
@@ -8,14 +8,14 @@ import { AssistantMessage } from '../../../domain/messages/assistant-message.ent
 import { MessageCreationError } from '../../messages.errors';
 import { randomUUID } from 'crypto';
 import { ContextService } from 'src/common/context/services/context.service';
-import { getToken } from '@willsoto/nestjs-prometheus';
-import { AYUNIS_MESSAGES_TOTAL } from 'src/integrations/metrics/metrics.constants';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { AssistantMessageCreatedEvent } from '../../events/assistant-message-created.event';
 
 describe('SaveAssistantMessageUseCase', () => {
   let useCase: SaveAssistantMessageUseCase;
   let mockMessagesRepository: Partial<MessagesRepository>;
   let mockContextService: Partial<ContextService>;
-  let mockMessagesCounter: { inc: jest.Mock };
+  let mockEventEmitter: { emitAsync: jest.Mock };
 
   beforeAll(async () => {
     mockMessagesRepository = {
@@ -26,17 +26,16 @@ describe('SaveAssistantMessageUseCase', () => {
       get: jest.fn().mockReturnValue(randomUUID()),
     };
 
-    mockMessagesCounter = { inc: jest.fn() };
+    mockEventEmitter = {
+      emitAsync: jest.fn().mockResolvedValue([]),
+    };
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         SaveAssistantMessageUseCase,
         { provide: MESSAGES_REPOSITORY, useValue: mockMessagesRepository },
         { provide: ContextService, useValue: mockContextService },
-        {
-          provide: getToken(AYUNIS_MESSAGES_TOTAL),
-          useValue: mockMessagesCounter,
-        },
+        { provide: EventEmitter2, useValue: mockEventEmitter },
       ],
     }).compile();
 
@@ -54,7 +53,7 @@ describe('SaveAssistantMessageUseCase', () => {
     expect(useCase).toBeDefined();
   });
 
-  it('should save an assistant message and increment the metric', async () => {
+  it('should save an assistant message and emit event', async () => {
     const threadId = randomUUID();
     const message = new AssistantMessage({ threadId, content: [] });
     const command = new SaveAssistantMessageCommand(message);
@@ -65,8 +64,12 @@ describe('SaveAssistantMessageUseCase', () => {
 
     expect(result).toBe(message);
     expect(mockMessagesRepository.create).toHaveBeenCalledWith(message);
-    expect(mockMessagesCounter.inc).toHaveBeenCalledWith(
-      expect.objectContaining({ role: 'assistant' }),
+    expect(mockEventEmitter.emitAsync).toHaveBeenCalledWith(
+      AssistantMessageCreatedEvent.EVENT_NAME,
+      expect.objectContaining({
+        threadId: message.threadId,
+        messageId: message.id,
+      }),
     );
   });
 
@@ -84,15 +87,15 @@ describe('SaveAssistantMessageUseCase', () => {
     );
   });
 
-  it('should not propagate metric errors', async () => {
+  it('should not propagate event emission errors', async () => {
     const threadId = randomUUID();
     const message = new AssistantMessage({ threadId, content: [] });
     const command = new SaveAssistantMessageCommand(message);
 
     jest.spyOn(mockMessagesRepository, 'create').mockResolvedValue(message);
-    mockMessagesCounter.inc.mockImplementation(() => {
-      throw new Error('Metric registration error');
-    });
+    mockEventEmitter.emitAsync.mockRejectedValue(
+      new Error('Event emission error'),
+    );
 
     const result = await useCase.execute(command);
 

--- a/ayunis-core-backend/src/domain/messages/application/use-cases/save-assistant-message/save-assistant-message.use-case.ts
+++ b/ayunis-core-backend/src/domain/messages/application/use-cases/save-assistant-message/save-assistant-message.use-case.ts
@@ -1,6 +1,5 @@
 import { Injectable, Logger, Inject } from '@nestjs/common';
-import { Counter } from 'prom-client';
-import { InjectMetric } from '@willsoto/nestjs-prometheus';
+import { EventEmitter2 } from '@nestjs/event-emitter';
 import { SaveAssistantMessageCommand } from './save-assistant-message.command';
 import { AssistantMessage } from '../../../domain/messages/assistant-message.entity';
 import {
@@ -10,11 +9,8 @@ import {
 import { MessageRole } from '../../../domain/value-objects/message-role.object';
 import { MessageCreationError } from '../../messages.errors';
 import { ContextService } from 'src/common/context/services/context.service';
-import { AYUNIS_MESSAGES_TOTAL } from 'src/integrations/metrics/metrics.constants';
-import {
-  getUserContextLabels,
-  safeMetric,
-} from 'src/integrations/metrics/metrics.utils';
+import { AssistantMessageCreatedEvent } from '../../events/assistant-message-created.event';
+import type { UUID } from 'crypto';
 
 @Injectable()
 export class SaveAssistantMessageUseCase {
@@ -24,8 +20,7 @@ export class SaveAssistantMessageUseCase {
     @Inject(MESSAGES_REPOSITORY)
     private readonly messagesRepository: MessagesRepository,
     private readonly contextService: ContextService,
-    @InjectMetric(AYUNIS_MESSAGES_TOTAL)
-    private readonly messagesCounter: Counter<string>,
+    private readonly eventEmitter: EventEmitter2,
   ) {}
 
   async execute(
@@ -41,10 +36,24 @@ export class SaveAssistantMessageUseCase {
         command.message,
       )) as AssistantMessage;
 
-      safeMetric(this.logger, () => {
-        const labels = getUserContextLabels(this.contextService);
-        this.messagesCounter.inc({ ...labels, role: 'assistant' });
-      });
+      const userId = this.contextService.get('userId');
+      const orgId = this.contextService.get('orgId');
+      this.eventEmitter
+        .emitAsync(
+          AssistantMessageCreatedEvent.EVENT_NAME,
+          new AssistantMessageCreatedEvent(
+            userId ?? ('unknown' as UUID),
+            orgId ?? ('unknown' as UUID),
+            command.message.threadId,
+            saved.id,
+          ),
+        )
+        .catch((err: unknown) => {
+          this.logger.error('Failed to emit AssistantMessageCreatedEvent', {
+            error: err instanceof Error ? err.message : 'Unknown error',
+            messageId: saved.id,
+          });
+        });
 
       return saved;
     } catch (error) {

--- a/ayunis-core-backend/src/domain/runs/application/events/inference-completed.event.ts
+++ b/ayunis-core-backend/src/domain/runs/application/events/inference-completed.event.ts
@@ -1,5 +1,10 @@
 import type { UUID } from 'crypto';
 
+export interface InferenceErrorInfo {
+  message: string;
+  statusCode?: number;
+}
+
 export class InferenceCompletedEvent {
   static readonly EVENT_NAME = 'run.inference-completed';
 
@@ -10,6 +15,6 @@ export class InferenceCompletedEvent {
     public readonly provider: string,
     public readonly streaming: boolean,
     public readonly durationMs: number,
-    public readonly error?: string,
+    public readonly error?: InferenceErrorInfo,
   ) {}
 }

--- a/ayunis-core-backend/src/domain/runs/application/helpers/extract-inference-error-info.helper.spec.ts
+++ b/ayunis-core-backend/src/domain/runs/application/helpers/extract-inference-error-info.helper.spec.ts
@@ -1,0 +1,87 @@
+import { extractInferenceErrorInfo } from './extract-inference-error-info.helper';
+
+describe('extractInferenceErrorInfo', () => {
+  it('should extract message from Error instance', () => {
+    const result = extractInferenceErrorInfo(new Error('something broke'));
+
+    expect(result).toEqual({
+      message: 'something broke',
+      statusCode: undefined,
+    });
+  });
+
+  it('should extract message and status from Error with status property', () => {
+    const error = Object.assign(new Error('Too Many Requests'), {
+      status: 429,
+    });
+
+    const result = extractInferenceErrorInfo(error);
+
+    expect(result).toEqual({
+      message: 'Too Many Requests',
+      statusCode: 429,
+    });
+  });
+
+  it('should extract message and statusCode from Error with statusCode property', () => {
+    const error = Object.assign(new Error('Internal Server Error'), {
+      statusCode: 500,
+    });
+
+    const result = extractInferenceErrorInfo(error);
+
+    expect(result).toEqual({
+      message: 'Internal Server Error',
+      statusCode: 500,
+    });
+  });
+
+  it('should handle plain object with message and status', () => {
+    const error = { message: 'rate limited', status: 429 };
+
+    const result = extractInferenceErrorInfo(error);
+
+    expect(result).toEqual({
+      message: 'rate limited',
+      statusCode: 429,
+    });
+  });
+
+  it('should handle plain object with message and statusCode', () => {
+    const error = { message: 'server error', statusCode: 500 };
+
+    const result = extractInferenceErrorInfo(error);
+
+    expect(result).toEqual({
+      message: 'server error',
+      statusCode: 500,
+    });
+  });
+
+  it('should stringify object without message property', () => {
+    const error = { code: 'TIMEOUT', detail: 'request timed out' };
+
+    const result = extractInferenceErrorInfo(error);
+
+    expect(result.message).toBe(JSON.stringify(error));
+    expect(result.statusCode).toBeUndefined();
+  });
+
+  it('should stringify non-object, non-Error exceptions', () => {
+    expect(extractInferenceErrorInfo('string error')).toEqual({
+      message: 'string error',
+    });
+
+    expect(extractInferenceErrorInfo(42)).toEqual({
+      message: '42',
+    });
+
+    expect(extractInferenceErrorInfo(null)).toEqual({
+      message: 'null',
+    });
+
+    expect(extractInferenceErrorInfo(undefined)).toEqual({
+      message: 'undefined',
+    });
+  });
+});

--- a/ayunis-core-backend/src/domain/runs/application/helpers/extract-inference-error-info.helper.ts
+++ b/ayunis-core-backend/src/domain/runs/application/helpers/extract-inference-error-info.helper.ts
@@ -1,0 +1,41 @@
+import type { InferenceErrorInfo } from '../events/inference-completed.event';
+
+/**
+ * Extracts a status code from an unknown error object.
+ * Provider SDKs (OpenAI, Anthropic) attach `status` or `statusCode` properties.
+ */
+function extractStatusCode(error: unknown): number | undefined {
+  if (typeof error !== 'object' || error === null) return undefined;
+  const record = error as Record<string, unknown>;
+  if (typeof record['status'] === 'number') return record['status'];
+  if (typeof record['statusCode'] === 'number') return record['statusCode'];
+  return undefined;
+}
+
+/**
+ * Builds an {@link InferenceErrorInfo} from an unknown caught error.
+ * Handles Error instances, objects with a `message` property, and
+ * arbitrary non-Error exceptions (stringified).
+ */
+export function extractInferenceErrorInfo(error: unknown): InferenceErrorInfo {
+  if (error instanceof Error) {
+    return {
+      message: error.message,
+      statusCode: extractStatusCode(error),
+    };
+  }
+
+  if (typeof error === 'object' && error !== null) {
+    const record = error as Record<string, unknown>;
+    const message =
+      typeof record['message'] === 'string'
+        ? record['message']
+        : JSON.stringify(error);
+    return {
+      message,
+      statusCode: extractStatusCode(error),
+    };
+  }
+
+  return { message: String(error) };
+}

--- a/ayunis-core-backend/src/domain/runs/application/services/collect-usage-async.service.ts
+++ b/ayunis-core-backend/src/domain/runs/application/services/collect-usage-async.service.ts
@@ -1,16 +1,11 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { EventEmitter2 } from '@nestjs/event-emitter';
 import type { UUID } from 'crypto';
-import { Counter } from 'prom-client';
-import { InjectMetric } from '@willsoto/nestjs-prometheus';
 import { CollectUsageUseCase } from 'src/domain/usage/application/use-cases/collect-usage/collect-usage.use-case';
 import { CollectUsageCommand } from 'src/domain/usage/application/use-cases/collect-usage/collect-usage.command';
 import { LanguageModel } from 'src/domain/models/domain/models/language.model';
 import { ContextService } from 'src/common/context/services/context.service';
-import { AYUNIS_TOKENS_TOTAL } from 'src/integrations/metrics/metrics.constants';
-import {
-  getUserContextLabels,
-  safeMetric,
-} from 'src/integrations/metrics/metrics.utils';
+import { TokensConsumedEvent } from '../events/tokens-consumed.event';
 
 /**
  * Collects usage data asynchronously (fire-and-forget).
@@ -23,8 +18,7 @@ export class CollectUsageAsyncService {
   constructor(
     private readonly collectUsageUseCase: CollectUsageUseCase,
     private readonly contextService: ContextService,
-    @InjectMetric(AYUNIS_TOKENS_TOTAL)
-    private readonly tokensCounter: Counter<string>,
+    private readonly eventEmitter: EventEmitter2,
   ) {}
 
   collect(
@@ -41,35 +35,26 @@ export class CollectUsageAsyncService {
       messageId,
     });
 
-    const labels = getUserContextLabels(this.contextService);
+    const userId = this.contextService.get('userId');
+    const orgId = this.contextService.get('orgId');
 
-    if (inputTokens > 0) {
-      safeMetric(this.logger, () => {
-        this.tokensCounter.inc(
-          {
-            ...labels,
-            model: model.name,
-            provider: model.provider,
-            direction: 'input',
-          },
+    this.eventEmitter
+      .emitAsync(
+        TokensConsumedEvent.EVENT_NAME,
+        new TokensConsumedEvent(
+          userId ?? ('unknown' as UUID),
+          orgId ?? ('unknown' as UUID),
+          model.name,
+          model.provider,
           inputTokens,
-        );
-      });
-    }
-
-    if (outputTokens > 0) {
-      safeMetric(this.logger, () => {
-        this.tokensCounter.inc(
-          {
-            ...labels,
-            model: model.name,
-            provider: model.provider,
-            direction: 'output',
-          },
           outputTokens,
-        );
+        ),
+      )
+      .catch((err: unknown) => {
+        this.logger.error('Failed to emit TokensConsumedEvent', {
+          error: err instanceof Error ? err.message : 'Unknown error',
+        });
       });
-    }
 
     this.collectUsageUseCase
       .execute(

--- a/ayunis-core-backend/src/domain/runs/application/services/non-streaming-inference.service.spec.ts
+++ b/ayunis-core-backend/src/domain/runs/application/services/non-streaming-inference.service.spec.ts
@@ -1,36 +1,44 @@
-import { Logger } from '@nestjs/common';
 import { NonStreamingInferenceService } from './non-streaming-inference.service';
 import type { GetInferenceUseCase } from 'src/domain/models/application/use-cases/get-inference/get-inference.use-case';
 import { InferenceResponse } from 'src/domain/models/application/ports/inference.handler';
 import type { LanguageModel } from 'src/domain/models/domain/models/language.model';
 import type { Message } from 'src/domain/messages/domain/message.entity';
 import type { Tool } from 'src/domain/tools/domain/tool.entity';
+import { InferenceCompletedEvent } from '../events/inference-completed.event';
+import { randomUUID } from 'crypto';
 
 describe('NonStreamingInferenceService', () => {
   let service: NonStreamingInferenceService;
   let getInferenceUseCase: { execute: jest.Mock };
-  let histogram: { observe: jest.Mock };
-  let errorCounter: { inc: jest.Mock };
+  let mockEventEmitter: { emitAsync: jest.Mock };
+  let mockContextService: { get: jest.Mock };
 
   const model = { name: 'gpt-4o', provider: 'openai' } as LanguageModel;
   const messages = [] as Message[];
   const tools = [] as Tool[];
 
+  const userId = randomUUID();
+  const orgId = randomUUID();
+
   beforeEach(() => {
     getInferenceUseCase = { execute: jest.fn() };
-    histogram = { observe: jest.fn() };
-    errorCounter = { inc: jest.fn() };
+    mockEventEmitter = { emitAsync: jest.fn().mockResolvedValue([]) };
+    mockContextService = {
+      get: jest.fn().mockImplementation((key?: string | symbol) => {
+        if (key === 'userId') return userId;
+        if (key === 'orgId') return orgId;
+        return undefined;
+      }),
+    };
 
     service = new NonStreamingInferenceService(
       getInferenceUseCase as unknown as GetInferenceUseCase,
-      histogram as never,
-      errorCounter as never,
+      mockContextService as never,
+      mockEventEmitter as never,
     );
-
-    jest.spyOn(Logger.prototype, 'warn').mockImplementation();
   });
 
-  it('should return inference response and observe duration on histogram', async () => {
+  it('should return inference response and emit InferenceCompletedEvent', async () => {
     const response = new InferenceResponse([], {
       inputTokens: 100,
       outputTokens: 50,
@@ -40,51 +48,91 @@ describe('NonStreamingInferenceService', () => {
     const result = await service.execute({ model, messages, tools });
 
     expect(result).toBe(response);
-    expect(histogram.observe).toHaveBeenCalledWith(
-      { model: 'gpt-4o', provider: 'openai', streaming: 'false' },
-      expect.any(Number),
+    expect(mockEventEmitter.emitAsync).toHaveBeenCalledWith(
+      InferenceCompletedEvent.EVENT_NAME,
+      expect.objectContaining({
+        model: 'gpt-4o',
+        provider: 'openai',
+        streaming: false,
+        error: undefined,
+      }),
     );
-    expect(errorCounter.inc).not.toHaveBeenCalled();
   });
 
-  it('should increment error counter and rethrow when inference fails', async () => {
-    const error = Object.assign(new Error('Request timeout'), { status: 408 });
+  it('should emit event with error and rethrow when inference fails', async () => {
+    const error = new Error('Request timeout');
     getInferenceUseCase.execute.mockRejectedValue(error);
 
     await expect(service.execute({ model, messages, tools })).rejects.toThrow(
       error,
     );
 
-    expect(histogram.observe).toHaveBeenCalled();
-    expect(errorCounter.inc).toHaveBeenCalledWith({
-      model: 'gpt-4o',
-      provider: 'openai',
-      error_type: 'timeout',
-      streaming: 'false',
-    });
+    expect(mockEventEmitter.emitAsync).toHaveBeenCalledWith(
+      InferenceCompletedEvent.EVENT_NAME,
+      expect.objectContaining({
+        model: 'gpt-4o',
+        provider: 'openai',
+        streaming: false,
+        error: { message: 'Request timeout', statusCode: undefined },
+      }),
+    );
   });
 
-  it('should not propagate metric failures from histogram', async () => {
+  it('should emit event with statusCode when error has status property', async () => {
+    const error = Object.assign(new Error('Too Many Requests'), {
+      status: 429,
+    });
+    getInferenceUseCase.execute.mockRejectedValue(error);
+
+    await expect(service.execute({ model, messages, tools })).rejects.toThrow(
+      error,
+    );
+
+    expect(mockEventEmitter.emitAsync).toHaveBeenCalledWith(
+      InferenceCompletedEvent.EVENT_NAME,
+      expect.objectContaining({
+        error: { message: 'Too Many Requests', statusCode: 429 },
+      }),
+    );
+  });
+
+  it('should handle non-Error exceptions', async () => {
+    const nonErrorObj = { message: 'some failure', statusCode: 500 };
+    getInferenceUseCase.execute.mockRejectedValue(nonErrorObj);
+
+    await expect(service.execute({ model, messages, tools })).rejects.toBe(
+      nonErrorObj,
+    );
+
+    expect(mockEventEmitter.emitAsync).toHaveBeenCalledWith(
+      InferenceCompletedEvent.EVENT_NAME,
+      expect.objectContaining({
+        error: { message: 'some failure', statusCode: 500 },
+      }),
+    );
+  });
+
+  it('should not propagate event emission failures', async () => {
     const response = new InferenceResponse([], {
       inputTokens: 10,
       outputTokens: 5,
     });
     getInferenceUseCase.execute.mockResolvedValue(response);
-    histogram.observe.mockImplementation(() => {
-      throw new Error('prometheus broken');
-    });
+    mockEventEmitter.emitAsync.mockRejectedValue(
+      new Error('event emitter broken'),
+    );
 
     const result = await service.execute({ model, messages, tools });
 
     expect(result).toBe(response);
   });
 
-  it('should not propagate metric failures from error counter', async () => {
+  it('should not propagate event emission failures on inference error path', async () => {
     const inferenceError = new Error('some provider error');
     getInferenceUseCase.execute.mockRejectedValue(inferenceError);
-    errorCounter.inc.mockImplementation(() => {
-      throw new Error('prometheus broken');
-    });
+    mockEventEmitter.emitAsync.mockRejectedValue(
+      new Error('event emitter broken'),
+    );
 
     await expect(service.execute({ model, messages, tools })).rejects.toThrow(
       inferenceError,

--- a/ayunis-core-backend/src/domain/runs/application/services/non-streaming-inference.service.ts
+++ b/ayunis-core-backend/src/domain/runs/application/services/non-streaming-inference.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { Counter, Histogram } from 'prom-client';
-import { InjectMetric } from '@willsoto/nestjs-prometheus';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import type { UUID } from 'crypto';
 import { GetInferenceUseCase } from 'src/domain/models/application/use-cases/get-inference/get-inference.use-case';
 import { GetInferenceCommand } from 'src/domain/models/application/use-cases/get-inference/get-inference.command';
 import { InferenceResponse } from 'src/domain/models/application/ports/inference.handler';
@@ -8,11 +8,9 @@ import { ModelToolChoice } from 'src/domain/models/domain/value-objects/model-to
 import { LanguageModel } from 'src/domain/models/domain/models/language.model';
 import { Message } from 'src/domain/messages/domain/message.entity';
 import { Tool } from 'src/domain/tools/domain/tool.entity';
-import {
-  AYUNIS_INFERENCE_DURATION_SECONDS,
-  AYUNIS_INFERENCE_ERRORS_TOTAL,
-} from 'src/integrations/metrics/metrics.constants';
-import { recordInferenceMetrics } from 'src/integrations/metrics/record-inference-metrics.helper';
+import { ContextService } from 'src/common/context/services/context.service';
+import { InferenceCompletedEvent } from '../events/inference-completed.event';
+import { extractInferenceErrorInfo } from '../helpers/extract-inference-error-info.helper';
 
 /**
  * Executes non-streaming inference with metrics instrumentation.
@@ -23,10 +21,8 @@ export class NonStreamingInferenceService {
 
   constructor(
     private readonly getInferenceUseCase: GetInferenceUseCase,
-    @InjectMetric(AYUNIS_INFERENCE_DURATION_SECONDS)
-    private readonly inferenceHistogram: Histogram<string>,
-    @InjectMetric(AYUNIS_INFERENCE_ERRORS_TOTAL)
-    private readonly inferenceErrorsCounter: Counter<string>,
+    private readonly contextService: ContextService,
+    private readonly eventEmitter: EventEmitter2,
   ) {}
 
   async execute(params: {
@@ -36,14 +32,6 @@ export class NonStreamingInferenceService {
     instructions?: string;
   }): Promise<InferenceResponse> {
     const startTime = Date.now();
-    const metricsOpts = {
-      histogram: this.inferenceHistogram,
-      errorCounter: this.inferenceErrorsCounter,
-      logger: this.logger,
-      model: params.model.name,
-      provider: params.model.provider,
-      streaming: 'false' as const,
-    };
 
     let inferenceError: unknown;
     try {
@@ -60,11 +48,28 @@ export class NonStreamingInferenceService {
       inferenceError = error;
       throw error;
     } finally {
-      recordInferenceMetrics(
-        metricsOpts,
-        Date.now() - startTime,
-        inferenceError,
-      );
+      const userId = this.contextService.get('userId');
+      const orgId = this.contextService.get('orgId');
+      this.eventEmitter
+        .emitAsync(
+          InferenceCompletedEvent.EVENT_NAME,
+          new InferenceCompletedEvent(
+            userId ?? ('unknown' as UUID),
+            orgId ?? ('unknown' as UUID),
+            params.model.name,
+            params.model.provider,
+            false,
+            Date.now() - startTime,
+            inferenceError
+              ? extractInferenceErrorInfo(inferenceError)
+              : undefined,
+          ),
+        )
+        .catch((err: unknown) => {
+          this.logger.error('Failed to emit InferenceCompletedEvent', {
+            error: err instanceof Error ? err.message : 'Unknown error',
+          });
+        });
     }
   }
 }

--- a/ayunis-core-backend/src/domain/runs/application/services/streaming-inference.service.ts
+++ b/ayunis-core-backend/src/domain/runs/application/services/streaming-inference.service.ts
@@ -1,7 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { EventEmitter2 } from '@nestjs/event-emitter';
 import { UUID } from 'crypto';
-import { Counter, Histogram } from 'prom-client';
-import { InjectMetric } from '@willsoto/nestjs-prometheus';
 import { AssistantMessage } from 'src/domain/messages/domain/messages/assistant-message.entity';
 import { TextMessageContent } from 'src/domain/messages/domain/message-contents/text-message-content.entity';
 import { ThinkingMessageContent } from 'src/domain/messages/domain/message-contents/thinking-message-content.entity';
@@ -16,16 +15,14 @@ import {
 } from 'src/domain/models/application/ports/stream-inference.handler';
 import { CollectUsageAsyncService } from './collect-usage-async.service';
 import { LanguageModel } from 'src/domain/models/domain/models/language.model';
-import {
-  AYUNIS_INFERENCE_DURATION_SECONDS,
-  AYUNIS_INFERENCE_ERRORS_TOTAL,
-} from 'src/integrations/metrics/metrics.constants';
 import { ModelToolChoice } from 'src/domain/models/domain/value-objects/model-tool-choice.enum';
 import { Message } from 'src/domain/messages/domain/message.entity';
 import { Tool } from 'src/domain/tools/domain/tool.entity';
 import { resolveIntegration } from '../helpers/resolve-integration.helper';
 import { safeJsonParse } from 'src/common/util/unicode-sanitizer';
-import { recordInferenceMetrics } from 'src/integrations/metrics/record-inference-metrics.helper';
+import { ContextService } from 'src/common/context/services/context.service';
+import { InferenceCompletedEvent } from '../events/inference-completed.event';
+import { extractInferenceErrorInfo } from '../helpers/extract-inference-error-info.helper';
 
 type AssistantContentBlock =
   | TextMessageContent
@@ -60,10 +57,8 @@ export class StreamingInferenceService {
     private readonly streamInferenceUseCase: StreamInferenceUseCase,
     private readonly saveAssistantMessageUseCase: SaveAssistantMessageUseCase,
     private readonly collectUsageAsyncService: CollectUsageAsyncService,
-    @InjectMetric(AYUNIS_INFERENCE_DURATION_SECONDS)
-    private readonly inferenceHistogram: Histogram<string>,
-    @InjectMetric(AYUNIS_INFERENCE_ERRORS_TOTAL)
-    private readonly inferenceErrorsCounter: Counter<string>,
+    private readonly contextService: ContextService,
+    private readonly eventEmitter: EventEmitter2,
   ) {}
 
   async *executeStreamingInference(params: {
@@ -123,18 +118,28 @@ export class StreamingInferenceService {
       inferenceError = error;
       throw error;
     } finally {
-      recordInferenceMetrics(
-        {
-          histogram: this.inferenceHistogram,
-          errorCounter: this.inferenceErrorsCounter,
-          logger: this.logger,
-          model: model.name,
-          provider: model.provider,
-          streaming: 'true',
-        },
-        Date.now() - startTime,
-        inferenceError,
-      );
+      const userId = this.contextService.get('userId');
+      const contextOrgId = this.contextService.get('orgId');
+      this.eventEmitter
+        .emitAsync(
+          InferenceCompletedEvent.EVENT_NAME,
+          new InferenceCompletedEvent(
+            userId ?? ('unknown' as UUID),
+            contextOrgId ?? orgId,
+            model.name,
+            model.provider,
+            true,
+            Date.now() - startTime,
+            inferenceError
+              ? extractInferenceErrorInfo(inferenceError)
+              : undefined,
+          ),
+        )
+        .catch((err: unknown) => {
+          this.logger.error('Failed to emit InferenceCompletedEvent', {
+            error: err instanceof Error ? err.message : 'Unknown error',
+          });
+        });
       // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- mutated in callback, TS can't track
       if (streamCompletedSuccessfully && allChunks.length > 0) {
         const usage = this.extractUsageFromChunks(allChunks);

--- a/ayunis-core-backend/src/domain/runs/application/services/tool-result-collector.service.spec.ts
+++ b/ayunis-core-backend/src/domain/runs/application/services/tool-result-collector.service.spec.ts
@@ -1,4 +1,3 @@
-import type { Counter } from 'prom-client';
 import { AnonymizationFailedError } from 'src/common/anonymization/application/anonymization.errors';
 import type { AnonymizeTextUseCase } from 'src/common/anonymization/application/use-cases/anonymize-text/anonymize-text.use-case';
 import { RunAnonymizationUnavailableError } from '../runs.errors';
@@ -86,16 +85,16 @@ describe('ToolResultCollectorService', () => {
       get: jest.fn().mockReturnValue(randomUUID()),
     } as unknown as jest.Mocked<ContextService>;
 
-    const toolUsesCounter = {
-      inc: jest.fn(),
-    } as unknown as Counter<string>;
+    const mockEventEmitter = {
+      emitAsync: jest.fn().mockResolvedValue([]),
+    };
 
     service = new ToolResultCollectorService(
       executeToolUseCase,
       checkToolCapabilitiesUseCase,
       anonymizeTextUseCase,
       contextService,
-      toolUsesCounter,
+      mockEventEmitter as never,
     );
   });
 

--- a/ayunis-core-backend/src/domain/runs/application/services/tool-result-collector.service.ts
+++ b/ayunis-core-backend/src/domain/runs/application/services/tool-result-collector.service.ts
@@ -1,6 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { Counter } from 'prom-client';
-import { InjectMetric } from '@willsoto/nestjs-prometheus';
+import { EventEmitter2 } from '@nestjs/event-emitter';
 import { UUID } from 'crypto';
 import { ToolResultMessageContent } from 'src/domain/messages/domain/message-contents/tool-result.message-content.entity';
 import { ToolUseMessageContent } from 'src/domain/messages/domain/message-contents/tool-use.message-content.entity';
@@ -17,11 +16,7 @@ import { AnonymizeTextUseCase } from 'src/common/anonymization/application/use-c
 import { AnonymizeTextCommand } from 'src/common/anonymization/application/use-cases/anonymize-text/anonymize-text.command';
 import { ApplicationError } from 'src/common/errors/base.error';
 import { ContextService } from 'src/common/context/services/context.service';
-import { AYUNIS_TOOL_USES_TOTAL } from 'src/integrations/metrics/metrics.constants';
-import {
-  getUserContextLabels,
-  safeMetric,
-} from 'src/integrations/metrics/metrics.utils';
+import { ToolUsedEvent } from '../events/tool-used.event';
 import {
   RunAnonymizationUnavailableError,
   RunToolExecutionFailedError,
@@ -39,8 +34,7 @@ export class ToolResultCollectorService {
     private readonly checkToolCapabilitiesUseCase: CheckToolCapabilitiesUseCase,
     private readonly anonymizeTextUseCase: AnonymizeTextUseCase,
     private readonly contextService: ContextService,
-    @InjectMetric(AYUNIS_TOOL_USES_TOTAL)
-    private readonly toolUsesCounter: Counter<string>,
+    private readonly eventEmitter: EventEmitter2,
   ) {}
 
   async collectToolResults(params: {
@@ -94,13 +88,18 @@ export class ToolResultCollectorService {
       );
     }
 
-    safeMetric(this.logger, () => {
-      const labels = getUserContextLabels(this.contextService);
-      this.toolUsesCounter.inc({
-        ...labels,
-        tool_name: content.name,
+    const userId = this.contextService.get('userId');
+    this.eventEmitter
+      .emitAsync(
+        ToolUsedEvent.EVENT_NAME,
+        new ToolUsedEvent(userId ?? ('unknown' as UUID), orgId, content.name),
+      )
+      .catch((err: unknown) => {
+        this.logger.error('Failed to emit ToolUsedEvent', {
+          error: err instanceof Error ? err.message : 'Unknown error',
+          toolName: content.name,
+        });
       });
-    });
 
     try {
       const capabilities = this.checkToolCapabilitiesUseCase.execute(

--- a/ayunis-core-backend/src/domain/runs/application/use-cases/execute-run/execute-run.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/runs/application/use-cases/execute-run/execute-run.use-case.spec.ts
@@ -24,8 +24,8 @@ import type { StreamingInferenceService } from '../../services/streaming-inferen
 import type { NonStreamingInferenceService } from '../../services/non-streaming-inference.service';
 import type { SkillActivationService } from 'src/domain/skills/application/services/skill-activation.service';
 import type { AssistantMessage } from 'src/domain/messages/domain/messages/assistant-message.entity';
-import type { Counter } from 'prom-client';
 import { ToolResultMessageContent } from 'src/domain/messages/domain/message-contents/tool-result.message-content.entity';
+import type { EventEmitter2 } from '@nestjs/event-emitter';
 import { ToolType } from 'src/domain/tools/domain/value-objects/tool-type.enum';
 import { randomUUID } from 'crypto';
 
@@ -120,7 +120,9 @@ describe('ExecuteRunUseCase', () => {
       {
         activateOnThread: jest.fn(),
       } as unknown as jest.Mocked<SkillActivationService>,
-      { inc: jest.fn() } as unknown as Counter<string>,
+      {
+        emitAsync: jest.fn().mockResolvedValue([]),
+      } as unknown as EventEmitter2,
     );
   });
 

--- a/ayunis-core-backend/src/domain/runs/application/use-cases/execute-run/execute-run.use-case.ts
+++ b/ayunis-core-backend/src/domain/runs/application/use-cases/execute-run/execute-run.use-case.ts
@@ -1,6 +1,5 @@
 import { Injectable, Logger, UnauthorizedException } from '@nestjs/common';
-import { Counter } from 'prom-client';
-import { InjectMetric } from '@willsoto/nestjs-prometheus';
+import { EventEmitter2 } from '@nestjs/event-emitter';
 import { Message } from '../../../../messages/domain/message.entity';
 import { AddMessageCommand } from '../../../../threads/application/use-cases/add-message-to-thread/add-message.command';
 import { Thread } from '../../../../threads/domain/thread.entity';
@@ -49,8 +48,7 @@ import { StreamingInferenceService } from '../../services/streaming-inference.se
 import { NonStreamingInferenceService } from '../../services/non-streaming-inference.service';
 import { enrichContentWithIntegration } from '../../helpers/resolve-integration.helper';
 import type { RunParams } from './run-params.interface';
-import { AYUNIS_USER_ACTIVITY_TOTAL } from 'src/integrations/metrics/metrics.constants';
-import { safeMetric } from 'src/integrations/metrics/metrics.utils';
+import { RunExecutedEvent } from '../../events/run-executed.event';
 
 const MAX_CONTEXT_TOKENS = 80000;
 
@@ -75,8 +73,7 @@ export class ExecuteRunUseCase {
     private readonly streamingInferenceService: StreamingInferenceService,
     private readonly nonStreamingInferenceService: NonStreamingInferenceService,
     private readonly skillActivationService: SkillActivationService,
-    @InjectMetric(AYUNIS_USER_ACTIVITY_TOTAL)
-    private readonly userActivityCounter: Counter<string>,
+    private readonly eventEmitter: EventEmitter2,
   ) {}
 
   async execute(
@@ -96,9 +93,17 @@ export class ExecuteRunUseCase {
 
       // Counts "attempted runs" — fires before run validity is established.
       // This is intentional: it serves as the DAU (daily active users) metric.
-      safeMetric(this.logger, () =>
-        this.userActivityCounter.inc({ user_id: userId, org_id: orgId }),
-      );
+      this.eventEmitter
+        .emitAsync(
+          RunExecutedEvent.EVENT_NAME,
+          new RunExecutedEvent(userId, orgId),
+        )
+        .catch((err: unknown) => {
+          this.logger.error('Failed to emit RunExecutedEvent', {
+            error: err instanceof Error ? err.message : 'Unknown error',
+            userId,
+          });
+        });
 
       const { thread } = await this.findThreadUseCase.execute(
         new FindThreadQuery(command.threadId),

--- a/ayunis-core-backend/src/domain/threads/application/use-cases/add-message-to-thread/add-message-to-thread.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/threads/application/use-cases/add-message-to-thread/add-message-to-thread.use-case.spec.ts
@@ -5,30 +5,29 @@ import { AddMessageCommand } from './add-message.command';
 import { Thread } from '../../../domain/thread.entity';
 import { randomUUID } from 'crypto';
 import { ContextService } from 'src/common/context/services/context.service';
-import { getToken } from '@willsoto/nestjs-prometheus';
-import { AYUNIS_THREAD_MESSAGE_COUNT } from 'src/integrations/metrics/metrics.constants';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { ThreadMessageAddedEvent } from '../../events/thread-message-added.event';
 import { AssistantMessage } from 'src/domain/messages/domain/messages/assistant-message.entity';
 
 describe('AddMessageToThreadUseCase', () => {
   let useCase: AddMessageToThreadUseCase;
   let mockContextService: Partial<ContextService>;
-  let mockHistogram: { observe: jest.Mock };
+  let mockEventEmitter: { emitAsync: jest.Mock };
 
   beforeAll(async () => {
     mockContextService = {
       get: jest.fn().mockReturnValue(randomUUID()),
     };
 
-    mockHistogram = { observe: jest.fn() };
+    mockEventEmitter = {
+      emitAsync: jest.fn().mockResolvedValue([]),
+    };
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         AddMessageToThreadUseCase,
         { provide: ContextService, useValue: mockContextService },
-        {
-          provide: getToken(AYUNIS_THREAD_MESSAGE_COUNT),
-          useValue: mockHistogram,
-        },
+        { provide: EventEmitter2, useValue: mockEventEmitter },
       ],
     }).compile();
 
@@ -44,7 +43,7 @@ describe('AddMessageToThreadUseCase', () => {
     expect(useCase).toBeDefined();
   });
 
-  it('should add a message to the thread and observe the histogram', () => {
+  it('should add a message to the thread and emit ThreadMessageAddedEvent', () => {
     const thread = new Thread({
       userId: randomUUID(),
       messages: [],
@@ -60,13 +59,16 @@ describe('AddMessageToThreadUseCase', () => {
 
     expect(result.messages).toContain(message);
     expect(result.messages).toHaveLength(1);
-    expect(mockHistogram.observe).toHaveBeenCalledWith(
-      expect.objectContaining({ user_id: expect.any(String) }),
-      1,
+    expect(mockEventEmitter.emitAsync).toHaveBeenCalledWith(
+      ThreadMessageAddedEvent.EVENT_NAME,
+      expect.objectContaining({
+        threadId: thread.id,
+        messageCount: 1,
+      }),
     );
   });
 
-  it('should observe correct message count for thread with existing messages', () => {
+  it('should emit correct message count for thread with existing messages', () => {
     const existingMessage = new AssistantMessage({
       threadId: randomUUID(),
       content: [],
@@ -84,6 +86,11 @@ describe('AddMessageToThreadUseCase', () => {
 
     useCase.execute(command);
 
-    expect(mockHistogram.observe).toHaveBeenCalledWith(expect.any(Object), 2);
+    expect(mockEventEmitter.emitAsync).toHaveBeenCalledWith(
+      ThreadMessageAddedEvent.EVENT_NAME,
+      expect.objectContaining({
+        messageCount: 2,
+      }),
+    );
   });
 });

--- a/ayunis-core-backend/src/domain/threads/application/use-cases/add-message-to-thread/add-message-to-thread.use-case.ts
+++ b/ayunis-core-backend/src/domain/threads/application/use-cases/add-message-to-thread/add-message-to-thread.use-case.ts
@@ -1,15 +1,11 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { Histogram } from 'prom-client';
-import { InjectMetric } from '@willsoto/nestjs-prometheus';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import type { UUID } from 'crypto';
 import { Thread } from '../../../domain/thread.entity';
 import { AddMessageCommand } from './add-message.command';
 import { MessageAdditionError } from '../../threads.errors';
 import { ContextService } from 'src/common/context/services/context.service';
-import { AYUNIS_THREAD_MESSAGE_COUNT } from 'src/integrations/metrics/metrics.constants';
-import {
-  getUserContextLabels,
-  safeMetric,
-} from 'src/integrations/metrics/metrics.utils';
+import { ThreadMessageAddedEvent } from '../../events/thread-message-added.event';
 
 @Injectable()
 export class AddMessageToThreadUseCase {
@@ -17,8 +13,7 @@ export class AddMessageToThreadUseCase {
 
   constructor(
     private readonly contextService: ContextService,
-    @InjectMetric(AYUNIS_THREAD_MESSAGE_COUNT)
-    private readonly threadMessageHistogram: Histogram<string>,
+    private readonly eventEmitter: EventEmitter2,
   ) {}
 
   execute(command: AddMessageCommand): Thread {
@@ -29,16 +24,27 @@ export class AddMessageToThreadUseCase {
     try {
       command.thread.messages.push(command.message);
 
-      // Observing on every message addition is intentional: it gives the
+      // Emitting on every message addition is intentional: it gives the
       // distribution of thread sizes at write time. The _sum/_count ratio
       // yields average thread length across all writes.
-      safeMetric(this.logger, () => {
-        const labels = getUserContextLabels(this.contextService);
-        this.threadMessageHistogram.observe(
-          labels,
-          command.thread.messages.length,
-        );
-      });
+      const userId = this.contextService.get('userId');
+      const orgId = this.contextService.get('orgId');
+      this.eventEmitter
+        .emitAsync(
+          ThreadMessageAddedEvent.EVENT_NAME,
+          new ThreadMessageAddedEvent(
+            userId ?? ('unknown' as UUID),
+            orgId ?? ('unknown' as UUID),
+            command.thread.id,
+            command.thread.messages.length,
+          ),
+        )
+        .catch((err: unknown) => {
+          this.logger.error('Failed to emit ThreadMessageAddedEvent', {
+            error: err instanceof Error ? err.message : 'Unknown error',
+            threadId: command.thread.id,
+          });
+        });
 
       return command.thread;
     } catch (error) {

--- a/ayunis-core-backend/src/integrations/metrics/listeners/prometheus-metrics.listener.spec.ts
+++ b/ayunis-core-backend/src/integrations/metrics/listeners/prometheus-metrics.listener.spec.ts
@@ -195,7 +195,7 @@ describe('PrometheusMetricsListener', () => {
       );
     });
 
-    it('should increment error counter when error is present', () => {
+    it('should classify and increment error counter when error is present', () => {
       listener.handleInferenceCompleted(
         new InferenceCompletedEvent(
           USER_ID,
@@ -204,7 +204,10 @@ describe('PrometheusMetricsListener', () => {
           'openai',
           false,
           500,
-          'rate_limit',
+          {
+            message: 'Too Many Requests',
+            statusCode: 429,
+          },
         ),
       );
 
@@ -212,6 +215,52 @@ describe('PrometheusMetricsListener', () => {
         model: 'gpt-4',
         provider: 'openai',
         error_type: 'rate_limit',
+        streaming: 'false',
+      });
+    });
+
+    it('should classify error by message when no statusCode', () => {
+      listener.handleInferenceCompleted(
+        new InferenceCompletedEvent(
+          USER_ID,
+          ORG_ID,
+          'gpt-4',
+          'openai',
+          false,
+          500,
+          {
+            message: 'Request timed out',
+          },
+        ),
+      );
+
+      expect(inferenceErrorsCounter.inc).toHaveBeenCalledWith({
+        model: 'gpt-4',
+        provider: 'openai',
+        error_type: 'timeout',
+        streaming: 'false',
+      });
+    });
+
+    it('should classify unknown errors as "unknown"', () => {
+      listener.handleInferenceCompleted(
+        new InferenceCompletedEvent(
+          USER_ID,
+          ORG_ID,
+          'gpt-4',
+          'openai',
+          false,
+          500,
+          {
+            message: 'Something completely unexpected happened',
+          },
+        ),
+      );
+
+      expect(inferenceErrorsCounter.inc).toHaveBeenCalledWith({
+        model: 'gpt-4',
+        provider: 'openai',
+        error_type: 'unknown',
         streaming: 'false',
       });
     });

--- a/ayunis-core-backend/src/integrations/metrics/listeners/prometheus-metrics.listener.ts
+++ b/ayunis-core-backend/src/integrations/metrics/listeners/prometheus-metrics.listener.ts
@@ -21,6 +21,7 @@ import {
   AYUNIS_THREAD_MESSAGE_COUNT,
 } from '../metrics.constants';
 import { safeMetric } from '../metrics.utils';
+import { classifyInferenceError } from '../classify-inference-error.helper';
 
 /**
  * Subscribes to domain events and records the corresponding Prometheus
@@ -112,7 +113,10 @@ export class PrometheusMetricsListener {
         this.inferenceErrorsCounter.inc({
           model: event.model,
           provider: event.provider,
-          error_type: event.error!,
+          error_type: classifyInferenceError({
+            message: event.error!.message,
+            status: event.error!.statusCode,
+          }),
           streaming: streamingLabel,
         });
       });


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Refactors how key run/message/tool usage metrics are recorded by switching from direct Prometheus instrumentation to async domain event emission; risk is mainly around observability regressions if events/listeners are miswired or context IDs are missing.
> 
> **Overview**
> Moves metrics instrumentation out of several domain use cases/services by replacing direct Prometheus counter/histogram updates with fire-and-forget `EventEmitter2.emitAsync` domain events (message created, run executed, tokens consumed, tool used, thread message added, inference completed).
> 
> Updates inference tracking to emit `InferenceCompletedEvent` with structured `InferenceErrorInfo` (message + optional status code) and adds `extractInferenceErrorInfo` to normalize unknown provider errors. The Prometheus listener is adjusted to classify inference errors from this structured payload before incrementing error counters, and unit tests are updated accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 955edd7e53fdca5476a0921731fb16d280365d87. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->