### PR TITLE
fix(documents): handle char exceeded errors in document extract tools gracefully (AYC-000)

### DIFF
--- a/ayunis-core-backend/src/domain/artifacts/infrastructure/export/html-document-export.service.spec.ts
+++ b/ayunis-core-backend/src/domain/artifacts/infrastructure/export/html-document-export.service.spec.ts
@@ -29,6 +29,7 @@ jest.mock('puppeteer-core', () => ({
 describe('HtmlDocumentExportService', () => {
   let service: HtmlDocumentExportService;
   let compositor: jest.Mocked<PdfLetterheadCompositor>;
+  const originalPuppeteerExecutablePath = process.env.PUPPETEER_EXECUTABLE_PATH;
 
   const sampleHtml = `
     <h1>Test Document</h1>
@@ -44,6 +45,8 @@ describe('HtmlDocumentExportService', () => {
   `;
 
   beforeAll(() => {
+    process.env.PUPPETEER_EXECUTABLE_PATH = '/mock/chromium';
+
     compositor = {
       composite: jest.fn().mockResolvedValue(Buffer.from('%PDF-composited')),
     } as unknown as jest.Mocked<PdfLetterheadCompositor>;
@@ -52,6 +55,13 @@ describe('HtmlDocumentExportService', () => {
 
   afterAll(async () => {
     await service.onModuleDestroy();
+
+    if (originalPuppeteerExecutablePath === undefined) {
+      delete process.env.PUPPETEER_EXECUTABLE_PATH;
+      return;
+    }
+
+    process.env.PUPPETEER_EXECUTABLE_PATH = originalPuppeteerExecutablePath;
   });
 
   beforeEach(() => {

--- a/ayunis-core-backend/src/domain/tools/application/handlers/knowledge-get-text-tool.handler.spec.ts
+++ b/ayunis-core-backend/src/domain/tools/application/handlers/knowledge-get-text-tool.handler.spec.ts
@@ -29,6 +29,9 @@ describe('KnowledgeGetTextToolHandler', () => {
   let mockGetDocTextUseCase: jest.Mocked<GetKnowledgeBaseDocumentTextUseCase>;
   let mockExtractTextLines: jest.Mocked<ExtractTextLinesUseCase>;
   let mockContextService: jest.Mocked<ContextService>;
+  const mockToolsConfig = {
+    sourceGetText: { maxLines: 500, maxChars: 50000 },
+  };
 
   const mockKbId = randomUUID();
   const mockDocId = randomUUID();
@@ -66,9 +69,7 @@ describe('KnowledgeGetTextToolHandler', () => {
         },
         {
           provide: toolsConfig.KEY,
-          useValue: {
-            sourceGetText: { maxLines: 500, maxChars: 50000 },
-          },
+          useValue: mockToolsConfig,
         },
       ],
     }).compile();
@@ -81,6 +82,8 @@ describe('KnowledgeGetTextToolHandler', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockContextService.get.mockReturnValue(mockUserId);
+    mockToolsConfig.sourceGetText.maxLines = 500;
+    mockToolsConfig.sourceGetText.maxChars = 50000;
   });
 
   it('should return text content for a valid document', async () => {
@@ -198,6 +201,42 @@ describe('KnowledgeGetTextToolHandler', () => {
     const parsed = JSON.parse(result);
     expect(parsed.totalLines).toBe(0);
     expect(parsed.text).toBe('');
+  });
+
+  it('should include truncation metadata when text exceeds the char limit', async () => {
+    mockToolsConfig.sourceGetText.maxChars = 11;
+
+    const mockSource = new FileSource({
+      id: mockDocId,
+      name: 'policy-document.pdf',
+      type: TextType.FILE,
+      fileType: FileType.PDF,
+    });
+
+    mockGetDocTextUseCase.execute.mockResolvedValue(mockSource);
+    mockExtractTextLines.execute.mockResolvedValue({
+      totalLines: 3,
+      text: 'AAAAA\nBBBBB\nCCCCC',
+    });
+
+    const tool = createMockTool(mockKbId, mockDocId);
+    tool.validateParams = jest.fn().mockReturnValue({
+      knowledgeBaseId: mockKbId,
+      documentId: mockDocId,
+      startLine: 1,
+      numLines: 3,
+    });
+    const result = await handler.execute({
+      tool,
+      input: { knowledgeBaseId: mockKbId, documentId: mockDocId },
+      context: { orgId: mockOrgId, threadId: mockThreadId },
+    });
+
+    const parsed = JSON.parse(result);
+    expect(parsed.actualEndLine).toBe(2);
+    expect(parsed.text).toBe('AAAAA\nBBBBB');
+    expect(parsed.truncated).toBe(true);
+    expect(parsed.truncationReasons).toEqual(['max_chars']);
   });
 
   it('should throw when user is not authenticated', async () => {

--- a/ayunis-core-backend/src/domain/tools/application/handlers/knowledge-get-text-tool.handler.ts
+++ b/ayunis-core-backend/src/domain/tools/application/handlers/knowledge-get-text-tool.handler.ts
@@ -12,7 +12,10 @@ import {
 import { TextSource } from 'src/domain/sources/domain/sources/text-source.entity';
 import { ContextService } from 'src/common/context/services/context.service';
 import toolsConfig from 'src/config/tools.config';
-import { validateTextExtraction } from '../utils/text-extraction.utils';
+import {
+  TextExtractionTruncationReason,
+  validateTextExtraction,
+} from '../utils/text-extraction.utils';
 import {
   KnowledgeBaseNotFoundError,
   DocumentNotInKnowledgeBaseError,
@@ -32,6 +35,8 @@ interface KnowledgeGetTextResult {
   requestedNumLines: number;
   actualStartLine: number;
   actualEndLine: number;
+  truncated: boolean;
+  truncationReasons: TextExtractionTruncationReason[];
   text: string;
 }
 
@@ -133,6 +138,8 @@ export class KnowledgeGetTextToolHandler extends ToolExecutionHandler {
           numLines,
           actualStartLine: extraction.effectiveStartLine,
           actualEndLine: extraction.effectiveEndLine,
+          truncated: extraction.truncated,
+          truncationReasons: extraction.truncationReasons,
           text: extraction.extractedText,
         }),
       );
@@ -180,6 +187,8 @@ export class KnowledgeGetTextToolHandler extends ToolExecutionHandler {
     numLines: number;
     actualStartLine: number;
     actualEndLine: number;
+    truncated: boolean;
+    truncationReasons: TextExtractionTruncationReason[];
     text: string;
   }): KnowledgeGetTextResult {
     return {
@@ -191,6 +200,8 @@ export class KnowledgeGetTextToolHandler extends ToolExecutionHandler {
       requestedNumLines: params.numLines,
       actualStartLine: params.actualStartLine,
       actualEndLine: params.actualEndLine,
+      truncated: params.truncated,
+      truncationReasons: params.truncationReasons,
       text: params.text,
     };
   }

--- a/ayunis-core-backend/src/domain/tools/application/handlers/source-get-text-tool.handler.ts
+++ b/ayunis-core-backend/src/domain/tools/application/handlers/source-get-text-tool.handler.ts
@@ -11,7 +11,10 @@ import {
 } from '../ports/execution.handler';
 import { TextSource } from 'src/domain/sources/domain/sources/text-source.entity';
 import toolsConfig from 'src/config/tools.config';
-import { validateTextExtraction } from '../utils/text-extraction.utils';
+import {
+  TextExtractionTruncationReason,
+  validateTextExtraction,
+} from '../utils/text-extraction.utils';
 import { ExtractTextLinesUseCase } from 'src/domain/sources/application/use-cases/extract-text-lines/extract-text-lines.use-case';
 import { ExtractTextLinesQuery } from 'src/domain/sources/application/use-cases/extract-text-lines/extract-text-lines.query';
 
@@ -26,6 +29,8 @@ interface SourceGetTextResult {
   requestedEndLine: number;
   actualStartLine: number;
   actualEndLine: number;
+  truncated: boolean;
+  truncationReasons: TextExtractionTruncationReason[];
   text: string;
 }
 
@@ -103,6 +108,8 @@ export class SourceGetTextToolHandler extends ToolExecutionHandler {
         requestedEndLine: endLine,
         actualStartLine: extraction.effectiveStartLine,
         actualEndLine: extraction.effectiveEndLine,
+        truncated: extraction.truncated,
+        truncationReasons: extraction.truncationReasons,
         text: extraction.extractedText,
       };
 

--- a/ayunis-core-backend/src/domain/tools/application/utils/text-extraction.utils.spec.ts
+++ b/ayunis-core-backend/src/domain/tools/application/utils/text-extraction.utils.spec.ts
@@ -88,17 +88,47 @@ describe('extractTextByLineRange', () => {
     ).toThrow(ToolExecutionFailedError);
   });
 
-  it('should throw when extracted text exceeds maxChars', () => {
-    const longLine = 'A'.repeat(10000);
-    expect(() =>
-      extractTextByLineRange({
-        ...defaultParams,
-        text: `${longLine}\n${longLine}\n${longLine}`,
-        startLine: 1,
-        endLine: -1,
-        maxChars: 100,
-      }),
-    ).toThrow(ToolExecutionFailedError);
+  it('should truncate extracted text when it exceeds maxChars', () => {
+    const result = extractTextByLineRange({
+      ...defaultParams,
+      text: 'AAAAA\nBBBBB\nCCCCC',
+      startLine: 1,
+      endLine: -1,
+      maxChars: 11,
+    });
+
+    expect(result.extractedText).toBe('AAAAA\nBBBBB');
+    expect(result.effectiveEndLine).toBe(2);
+    expect(result.truncated).toBe(true);
+    expect(result.truncationReasons).toEqual(['max_chars']);
+  });
+
+  it('should report document_end truncation when request exceeds total lines', () => {
+    const result = extractTextByLineRange({
+      ...defaultParams,
+      text: 'Line 1\nLine 2\nLine 3',
+      startLine: 1,
+      endLine: 10,
+    });
+
+    expect(result.effectiveEndLine).toBe(3);
+    expect(result.truncated).toBe(true);
+    expect(result.truncationReasons).toEqual(['document_end']);
+  });
+
+  it('should include both truncation reasons when both limits apply', () => {
+    const result = extractTextByLineRange({
+      ...defaultParams,
+      text: 'AAAAA\nBBBBB\nCCCCC',
+      startLine: 1,
+      endLine: 10,
+      maxChars: 11,
+    });
+
+    expect(result.extractedText).toBe('AAAAA\nBBBBB');
+    expect(result.effectiveEndLine).toBe(2);
+    expect(result.truncated).toBe(true);
+    expect(result.truncationReasons).toEqual(['document_end', 'max_chars']);
   });
 
   it('should extract a specific line range', () => {
@@ -197,16 +227,47 @@ describe('validateTextExtraction', () => {
     ).toThrow(ToolExecutionFailedError);
   });
 
-  it('should throw when text exceeds maxChars', () => {
-    const longText = 'A'.repeat(200);
-    expect(() =>
-      validateTextExtraction({
-        ...defaultParams,
-        dbResult: { totalLines: 3, text: longText },
-        startLine: 1,
-        endLine: 3,
-        maxChars: 100,
-      }),
-    ).toThrow(ToolExecutionFailedError);
+  it('should truncate text when it exceeds maxChars', () => {
+    const result = validateTextExtraction({
+      ...defaultParams,
+      dbResult: { totalLines: 3, text: 'AAAAA\nBBBBB\nCCCCC' },
+      startLine: 1,
+      endLine: 3,
+      maxChars: 11,
+    });
+
+    expect(result.extractedText).toBe('AAAAA\nBBBBB');
+    expect(result.effectiveEndLine).toBe(2);
+    expect(result.truncated).toBe(true);
+    expect(result.truncationReasons).toEqual(['max_chars']);
+  });
+
+  it('should report document_end truncation when DB text is clamped to file end', () => {
+    const result = validateTextExtraction({
+      ...defaultParams,
+      dbResult: { totalLines: 3, text: 'Line 2\nLine 3' },
+      startLine: 2,
+      endLine: 10,
+    });
+
+    expect(result.effectiveStartLine).toBe(2);
+    expect(result.effectiveEndLine).toBe(3);
+    expect(result.truncated).toBe(true);
+    expect(result.truncationReasons).toEqual(['document_end']);
+  });
+
+  it('should include both truncation reasons when DB text hits both limits', () => {
+    const result = validateTextExtraction({
+      ...defaultParams,
+      dbResult: { totalLines: 3, text: 'AAAAA\nBBBBB\nCCCCC' },
+      startLine: 1,
+      endLine: 10,
+      maxChars: 11,
+    });
+
+    expect(result.extractedText).toBe('AAAAA\nBBBBB');
+    expect(result.effectiveEndLine).toBe(2);
+    expect(result.truncated).toBe(true);
+    expect(result.truncationReasons).toEqual(['document_end', 'max_chars']);
   });
 });

--- a/ayunis-core-backend/src/domain/tools/application/utils/text-extraction.utils.ts
+++ b/ayunis-core-backend/src/domain/tools/application/utils/text-extraction.utils.ts
@@ -69,7 +69,8 @@ const buildRangeValidationError = (params: {
   effectiveEndLine: number;
   maxLines: number;
 }): ToolExecutionFailedError | null => {
-  const { toolName, totalLines, startLine, effectiveEndLine, maxLines } = params;
+  const { toolName, totalLines, startLine, effectiveEndLine, maxLines } =
+    params;
   const clampedStart = Math.max(1, Math.min(startLine, totalLines));
   const requestedLineCount = effectiveEndLine - clampedStart + 1;
 
@@ -109,18 +110,22 @@ const truncateToCharLimit = (params: {
   }
 
   let text = '';
+  let isFirst = true;
   let actualEndLine = effectiveStartLine;
   for (const line of extractedText.split('\n')) {
-    const candidate = text === '' ? line : `${text}\n${line}`;
+    const candidate = isFirst ? line : `${text}\n${line}`;
     if (candidate.length > maxChars) {
       return {
-        text: text === '' ? line.slice(0, maxChars) : text,
+        text: isFirst ? line.slice(0, maxChars) : text,
         actualEndLine,
         charLimited: true,
       };
     }
     text = candidate;
-    actualEndLine += text === line ? 0 : 1;
+    if (!isFirst) {
+      actualEndLine += 1;
+    }
+    isFirst = false;
   }
 
   return { text, actualEndLine, charLimited: true };
@@ -133,7 +138,10 @@ const buildTruncationReasons = (params: {
 }): TextExtractionTruncationReason[] => {
   const reasons: TextExtractionTruncationReason[] = [];
 
-  if (params.requestedEndLine !== -1 && params.requestedEndLine > params.totalLines) {
+  if (
+    params.requestedEndLine !== -1 &&
+    params.requestedEndLine > params.totalLines
+  ) {
     reasons.push('document_end');
   }
   if (params.charLimited) {

--- a/ayunis-core-backend/src/domain/tools/application/utils/text-extraction.utils.ts
+++ b/ayunis-core-backend/src/domain/tools/application/utils/text-extraction.utils.ts
@@ -9,12 +9,16 @@ interface TextExtractionParams {
   maxChars: number;
 }
 
+export type TextExtractionTruncationReason = 'document_end' | 'max_chars';
+
 export interface TextExtractionResult {
   totalLines: number;
   effectiveStartLine: number;
   effectiveEndLine: number;
   extractedText: string;
   isEmpty: boolean;
+  truncated: boolean;
+  truncationReasons: TextExtractionTruncationReason[];
 }
 
 const EMPTY_RESULT: Readonly<TextExtractionResult> = Object.freeze({
@@ -23,6 +27,8 @@ const EMPTY_RESULT: Readonly<TextExtractionResult> = Object.freeze({
   effectiveEndLine: 0,
   extractedText: '',
   isEmpty: true,
+  truncated: false,
+  truncationReasons: [],
 });
 
 function clampLineRange(
@@ -38,51 +44,134 @@ function clampLineRange(
   return { effectiveStart, effectiveEnd };
 }
 
-interface ValidateLineRangeOptions {
+interface BuildExtractionResultParams {
   toolName: string;
-  startLine: number;
-  effectiveEnd: number;
   totalLines: number;
+  startLine: number;
+  effectiveStartLine: number;
+  effectiveEndLine: number;
+  requestedEndLine: number;
+  extractedText: string;
   maxLines: number;
+  maxChars: number;
 }
 
-function validateLineRange(options: ValidateLineRangeOptions): void {
-  const { toolName, startLine, effectiveEnd, totalLines, maxLines } = options;
+interface TruncateToCharLimitResult {
+  text: string;
+  actualEndLine: number;
+  charLimited: boolean;
+}
 
-  if (startLine > effectiveEnd && startLine !== 1) {
-    throw new ToolExecutionFailedError({
+const buildRangeValidationError = (params: {
+  toolName: string;
+  totalLines: number;
+  startLine: number;
+  effectiveEndLine: number;
+  maxLines: number;
+}): ToolExecutionFailedError | null => {
+  const { toolName, totalLines, startLine, effectiveEndLine, maxLines } = params;
+  const clampedStart = Math.max(1, Math.min(startLine, totalLines));
+  const requestedLineCount = effectiveEndLine - clampedStart + 1;
+
+  if (startLine > effectiveEndLine && startLine !== 1) {
+    return new ToolExecutionFailedError({
       toolName,
       message: `Invalid line range: startLine (${startLine}) is greater than the file's total lines (${totalLines}).`,
       exposeToLLM: true,
     });
   }
 
-  const clampedStart = Math.max(1, Math.min(startLine, totalLines));
-  const requestedLineCount = effectiveEnd - clampedStart + 1;
   if (requestedLineCount > maxLines) {
-    const suggestedEnd = clampedStart + maxLines - 1;
-    throw new ToolExecutionFailedError({
+    return new ToolExecutionFailedError({
       toolName,
-      message: `Requested range (${requestedLineCount} lines) exceeds maximum of ${maxLines} lines. Try lines ${clampedStart} to ${suggestedEnd}.`,
+      message: `Requested range (${requestedLineCount} lines) exceeds maximum of ${maxLines} lines. Try lines ${clampedStart} to ${clampedStart + maxLines - 1}.`,
       exposeToLLM: true,
     });
   }
-}
 
-function validateCharLimit(
-  toolName: string,
-  text: string,
-  lineCount: number,
-  maxChars: number,
-): void {
-  if (text.length > maxChars) {
-    const suggestedLines = Math.floor(maxChars / (text.length / lineCount));
-    throw new ToolExecutionFailedError({
-      toolName,
-      message: `Requested text (${text.length} characters) exceeds maximum of ${maxChars} characters. Try ~${suggestedLines} lines at a time.`,
-      exposeToLLM: true,
-    });
+  return null;
+};
+
+const truncateToCharLimit = (params: {
+  extractedText: string;
+  maxChars: number;
+  effectiveStartLine: number;
+  effectiveEndLine: number;
+}): TruncateToCharLimitResult => {
+  const { extractedText, maxChars, effectiveStartLine, effectiveEndLine } =
+    params;
+  if (extractedText.length <= maxChars) {
+    return {
+      text: extractedText,
+      actualEndLine: effectiveEndLine,
+      charLimited: false,
+    };
   }
+
+  let text = '';
+  let actualEndLine = effectiveStartLine;
+  for (const line of extractedText.split('\n')) {
+    const candidate = text === '' ? line : `${text}\n${line}`;
+    if (candidate.length > maxChars) {
+      return {
+        text: text === '' ? line.slice(0, maxChars) : text,
+        actualEndLine,
+        charLimited: true,
+      };
+    }
+    text = candidate;
+    actualEndLine += text === line ? 0 : 1;
+  }
+
+  return { text, actualEndLine, charLimited: true };
+};
+
+const buildTruncationReasons = (params: {
+  requestedEndLine: number;
+  totalLines: number;
+  charLimited: boolean;
+}): TextExtractionTruncationReason[] => {
+  const reasons: TextExtractionTruncationReason[] = [];
+
+  if (params.requestedEndLine !== -1 && params.requestedEndLine > params.totalLines) {
+    reasons.push('document_end');
+  }
+  if (params.charLimited) {
+    reasons.push('max_chars');
+  }
+
+  return reasons;
+};
+
+function buildExtractionResult(
+  params: BuildExtractionResultParams,
+): TextExtractionResult {
+  const rangeError = buildRangeValidationError(params);
+  if (rangeError) {
+    throw rangeError;
+  }
+
+  const charLimitResult = truncateToCharLimit({
+    extractedText: params.extractedText,
+    maxChars: params.maxChars,
+    effectiveStartLine: params.effectiveStartLine,
+    effectiveEndLine: params.effectiveEndLine,
+  });
+  const truncationReasons = buildTruncationReasons({
+    requestedEndLine: params.requestedEndLine,
+    totalLines: params.totalLines,
+    charLimited: charLimitResult.charLimited,
+  });
+
+  return {
+    totalLines: params.totalLines,
+    effectiveStartLine: params.effectiveStartLine,
+    effectiveEndLine: charLimitResult.actualEndLine,
+    extractedText: charLimitResult.text,
+    isEmpty: false,
+    truncated: truncationReasons.length > 0,
+    truncationReasons,
+  };
 }
 
 /**
@@ -105,28 +194,18 @@ export function extractTextByLineRange(
     endLine,
     totalLines,
   );
-  const lineCount = effectiveEnd - effectiveStart + 1;
 
-  validateLineRange({
+  return buildExtractionResult({
     toolName,
+    totalLines,
     startLine,
-    effectiveEnd,
-    totalLines,
-    maxLines,
-  });
-
-  const extractedText = lines
-    .slice(effectiveStart - 1, effectiveEnd)
-    .join('\n');
-  validateCharLimit(toolName, extractedText, lineCount, maxChars);
-
-  return {
-    totalLines,
     effectiveStartLine: effectiveStart,
     effectiveEndLine: effectiveEnd,
-    extractedText,
-    isEmpty: false,
-  };
+    requestedEndLine: endLine,
+    extractedText: lines.slice(effectiveStart - 1, effectiveEnd).join('\n'),
+    maxLines,
+    maxChars,
+  });
 }
 
 /**
@@ -153,23 +232,16 @@ export function validateTextExtraction(params: {
     endLine,
     totalLines,
   );
-  const lineCount = effectiveEnd - effectiveStart + 1;
 
-  validateLineRange({
+  return buildExtractionResult({
     toolName,
+    totalLines,
     startLine,
-    effectiveEnd,
-    totalLines,
-    maxLines,
-  });
-
-  validateCharLimit(toolName, text, lineCount, maxChars);
-
-  return {
-    totalLines,
     effectiveStartLine: effectiveStart,
     effectiveEndLine: effectiveEnd,
+    requestedEndLine: endLine,
     extractedText: text,
-    isEmpty: false,
-  };
+    maxLines,
+    maxChars,
+  });
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the runtime behavior and output schema of `source_get_text`/`knowledge_get_text` to truncate (instead of error) when `maxChars` is exceeded, which could affect downstream consumers expecting full text or previous failure semantics.
> 
> **Overview**
> Improves the document/source text extraction tools to **gracefully handle `maxChars` overruns** by truncating output instead of throwing, and returns explicit truncation metadata (`truncated`, `truncationReasons`, updated `actualEndLine`).
> 
> Refactors `text-extraction.utils` to centralize range validation + char-limit truncation (including a new `document_end` vs `max_chars` reason model), updates both `KnowledgeGetTextToolHandler` and `SourceGetTextToolHandler` to include the new fields in their JSON responses, and expands unit tests to cover truncation behavior. Also stabilizes the HTML export service test by setting/restoring `PUPPETEER_EXECUTABLE_PATH`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 44bf5a9539fd6d14975bc686a52a18dd65fd224c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->