### PR TITLE
chore(deps-backend): bump @types/node to v24 (AYC-000)

### DIFF
--- a/ayunis-core-backend/.nsprc
+++ b/ayunis-core-backend/.nsprc
@@ -3,10 +3,6 @@
     "active": true,
     "notes": "fast-xml-parser entity encoding bypass via regex injection in DOCTYPE entity names — only affects minio which parses XML from our own MinIO server, not untrusted input. Waiting for minio to upgrade to fast-xml-parser v5."
   },
-  "1113407": {
-    "active": true,
-    "notes": "fast-xml-parser entity encoding bypass via regex injection — only affects minio which parses XML from our own MinIO server, not untrusted input. Waiting for minio to upgrade to fast-xml-parser v5."
-  },
   "1113518": {
     "active": true,
     "notes": "basic-ftp path traversal in downloadToDir() — transitive dep of puppeteer-core via proxy-agent. We never call downloadToDir() and only use puppeteer for local PDF rendering. No untrusted FTP connections."

--- a/ayunis-core-backend/package-lock.json
+++ b/ayunis-core-backend/package-lock.json
@@ -15186,9 +15186,9 @@
       }
     },
     "node_modules/handlebars": {
-      "version": "4.7.8",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
-      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/ayunis-core-backend/package-lock.json
+++ b/ayunis-core-backend/package-lock.json
@@ -87,7 +87,7 @@
         "@types/minio": "^7.1.0",
         "@types/mjml": "^4.7.4",
         "@types/multer": "^1.4.12",
-        "@types/node": "^22.15.3",
+        "@types/node": "^24.12.2",
         "@types/nodemailer": "^6.4.17",
         "@types/passport-jwt": "^4.0.1",
         "@types/passport-local": "^1.0.38",
@@ -8493,12 +8493,12 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "22.19.11",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.11.tgz",
-      "integrity": "sha512-BH7YwL6rA93ReqeQS1c4bsPpcfOmJasG+Fkr6Y59q83f9M1WcBRHR2vM+P9eOisYRcN3ujQoiZY8uk5W+1WL8w==",
+      "version": "24.12.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
+      "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~7.16.0"
       }
     },
     "node_modules/@types/node-fetch": {
@@ -24439,9 +24439,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "license": "MIT"
     },
     "node_modules/universalify": {

--- a/ayunis-core-backend/package.json
+++ b/ayunis-core-backend/package.json
@@ -122,7 +122,7 @@
     "@types/minio": "^7.1.0",
     "@types/mjml": "^4.7.4",
     "@types/multer": "^1.4.12",
-    "@types/node": "^22.15.3",
+    "@types/node": "^24.12.2",
     "@types/nodemailer": "^6.4.17",
     "@types/passport-jwt": "^4.0.1",
     "@types/passport-local": "^1.0.38",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk since this is primarily a dev-time type definition upgrade and lockfile refresh, but it may surface new TypeScript type errors or subtle Node API typing differences during builds/tests.
> 
> **Overview**
> Upgrades the backend’s TypeScript Node typings by bumping `@types/node` from v22 to v24, with corresponding `package-lock.json` updates (including newer `undici-types`).
> 
> Cleans up security-audit configuration by removing the older `fast-xml-parser` (`1113407`) exception entry from `.nsprc`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9ef40e44a290d030455fa11b34e8b7b27bc751e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->