### PR TITLE
chore: pin node engines to >=24 (AYC-000)

### DIFF
--- a/ayunis-core-backend/package-lock.json
+++ b/ayunis-core-backend/package-lock.json
@@ -111,6 +111,9 @@
         "tsconfig-paths": "^4.2.0",
         "typescript": "^5.7.3",
         "typescript-eslint": "^8.20.0"
+      },
+      "engines": {
+        "node": ">=24"
       }
     },
     "node_modules/@angular-devkit/core": {

--- a/ayunis-core-backend/package.json
+++ b/ayunis-core-backend/package.json
@@ -5,6 +5,9 @@
   "author": "",
   "private": true,
   "license": "UNLICENSED",
+  "engines": {
+    "node": ">=24"
+  },
   "scripts": {
     "build": "nest build",
     "format": "prettier --write \"src/**/*.ts\"",

--- a/ayunis-core-frontend/package-lock.json
+++ b/ayunis-core-frontend/package-lock.json
@@ -95,6 +95,9 @@
         "vite": "^6.1.0",
         "vitest": "^3.0.5",
         "web-vitals": "^4.2.4"
+      },
+      "engines": {
+        "node": ">=24"
       }
     },
     "node_modules/@apidevtools/json-schema-ref-parser": {

--- a/ayunis-core-frontend/package.json
+++ b/ayunis-core-frontend/package.json
@@ -2,6 +2,9 @@
   "name": "core-frontend-tanstack",
   "private": true,
   "type": "module",
+  "engines": {
+    "node": ">=24"
+  },
   "scripts": {
     "dev": "vite --port 3001",
     "start": "vite --port 3001",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk metadata-only change, but it can block installs/CI on older Node versions and may require environment updates.
> 
> **Overview**
> Sets an explicit Node.js requirement of `>=24` by adding an `engines.node` field to both the backend and frontend `package.json` files, and mirrors this in their `package-lock.json` metadata.
> 
> This tightens runtime/tooling expectations and will cause npm to warn or fail (depending on configuration) when using older Node versions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ddc0bec2f10b4a7fa7bd1e2a4122b1db0fbf01a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->