### PR TITLE
docs: bump documented node prerequisite to v24 (AYC-000)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ By participating in this project, you agree to abide by our Code of Conduct. Ple
 
 ### Prerequisites
 
-- Node.js (v18 or higher)
+- Node.js (v24 or higher)
 - npm
 - Docker and Docker Compose
 
@@ -65,8 +65,8 @@ npm run dev
 
 **Access the application:**
 
-- Frontend: http://localhost:3001
-- Backend API: http://localhost:3000
+- Frontend: <http://localhost:3001>
+- Backend API: <http://localhost:3000>
 
 ## Architecture Overview
 
@@ -74,7 +74,7 @@ npm run dev
 
 Ayunis Core follows a **Hexagonal Architecture** (Ports and Adapters) pattern with clear separation of concerns:
 
-```
+```text
 src/domain/[module-name]/
 ├── application/
 │   ├── use-cases/          # Business logic use cases with commands / queries
@@ -87,7 +87,7 @@ src/domain/[module-name]/
     └── http/
 ```
 
-**Key Principles**
+#### Backend Key Principles
 
 - **Domain modules** live in `src/domain/[module-name]`
 - **Interfaces** are represented through abstract classes when possible
@@ -107,7 +107,7 @@ The frontend follows a **feature sliced design** architecture with:
 - `features/` - Reusable feature modules
 - `shared/` - Common utilities and components
 
-**Key Principles**
+#### Frontend Key Principles
 
 - **Data loading** in routes, optionally used as initial data for page specific data queries
 - **Import hierarchy** according to feature sliced design guidelines
@@ -171,12 +171,14 @@ npm run test:integration
 
 1. **Create a feature branch** from `main`
 2. **Write clear commit messages** following conventional commits:
-   ```
+
+   ```text
    feat: add user authentication
    fix: resolve database connection issue
    docs: update API documentation
    refac: split create-user-use-case
    ```
+
 3. **Update documentation** if needed
 4. **Add/update tests** for your changes
 5. **Ensure all tests pass** locally

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -15,7 +15,7 @@ This guide covers deploying Ayunis Core to production and managing configuration
 
 ### Prerequisites
 
-- Node.js 18 or higher
+- Node.js 24 or higher
 - npm
 - Docker and Docker Compose
 - PostgreSQL database (can be containerized)
@@ -24,12 +24,14 @@ This guide covers deploying Ayunis Core to production and managing configuration
 ### Deployment Steps
 
 1. **Clone the repository**
+
    ```bash
    git clone https://github.com/your-org/ayunis-core.git
    cd ayunis-core
    ```
 
 2. **Create environment files**
+
    ```bash
    cp .env.example .env
    cp ayunis-core-backend/.env.example ayunis-core-backend/.env
@@ -42,20 +44,22 @@ This guide covers deploying Ayunis Core to production and managing configuration
    - Critical variables: `JWT_SECRET`, `COOKIE_SECRET`, `MCP_ENCRYPTION_KEY`, `DATABASE_*`
 
 4. **Start services**
+
    ```bash
    docker compose up -d --build
    ```
 
 5. **Run migrations**
+
    ```bash
    cd ayunis-core-backend
    npm run migration:run
    ```
 
 6. **Verify deployment**
-   - Frontend: http://your-domain:3000
-   - Backend API: http://your-domain:3000/api
-   - Swagger UI: http://your-domain:3000/api/docs
+   - Frontend: <http://your-domain:3000>
+   - Backend API: <http://your-domain:3000/api>
+   - Swagger UI: <http://your-domain:3000/api/docs>
 
 ## Environment Configuration
 
@@ -73,13 +77,17 @@ These variables MUST be configured before deployment:
 #### Authentication
 
 - `JWT_SECRET`: Secure random string for signing JWT tokens
+
   ```bash
   openssl rand -hex 32
   ```
+
 - `COOKIE_SECRET`: Secure random string for signing cookies
+
   ```bash
   openssl rand -hex 32
   ```
+
 - `COOKIE_SECURE`: Set to `true` in production (requires HTTPS)
 
 #### Database
@@ -93,9 +101,11 @@ These variables MUST be configured before deployment:
 #### MCP Integration (Required)
 
 - `MCP_ENCRYPTION_KEY`: 64-character hex string for encrypting credentials
+
   ```bash
   openssl rand -hex 32
   ```
+
   - Must be set before starting the application
   - Application will fail to start if invalid
   - Used for AES-256-GCM encryption of MCP credentials
@@ -191,6 +201,7 @@ If deploying with Locaboo 4 integration:
    - Note the base URL (e.g., `http://locaboo-server:8080`)
 
 2. **Set LOCABOO_4_URL in environment**
+
    ```bash
    LOCABOO_4_URL=http://locaboo-server:8080
    ```
@@ -228,11 +239,13 @@ Encryption happens transparently; no application code changes needed for key rot
 ### Updating Environment Variables
 
 1. **Edit environment file**
+
    ```bash
    nano ayunis-core-backend/.env
    ```
 
 2. **Restart application**
+
    ```bash
    docker compose restart ayunis-core-backend
    ```
@@ -265,17 +278,20 @@ Then restart the backend for changes to take effect.
 MCP_ENCRYPTION_KEY can be rotated without data loss:
 
 1. **Generate new key**
+
    ```bash
    openssl rand -hex 32
    ```
 
 2. **Update environment**
+
    ```bash
    # Update ayunis-core-backend/.env
    MCP_ENCRYPTION_KEY=<new-64-char-hex-string>
    ```
 
 3. **Restart application**
+
    ```bash
    docker compose restart ayunis-core-backend
    ```
@@ -303,19 +319,20 @@ The application validates critical configuration on startup:
 
 If validation fails:
 
-```
+```text
 MCP_ENCRYPTION_KEY environment variable is not configured. Generate a key with: openssl rand -hex 32
 ```
 
 or
 
-```
+```text
 MCP_ENCRYPTION_KEY must be a 64-character hex string (32 bytes). Generate a key with: openssl rand -hex 32
 ```
 
 ### Resolving Validation Failures
 
 1. **Check configuration**
+
    ```bash
    # Verify key format
    echo $MCP_ENCRYPTION_KEY | wc -c  # Should be 65 (64 chars + newline)
@@ -323,11 +340,13 @@ MCP_ENCRYPTION_KEY must be a 64-character hex string (32 bytes). Generate a key 
    ```
 
 2. **Generate new key**
+
    ```bash
    openssl rand -hex 32
    ```
 
 3. **Update environment and restart**
+
    ```bash
    docker compose restart ayunis-core-backend
    ```
@@ -346,7 +365,7 @@ crontab -e
 
 Add this line (adjust the path to your checkout):
 
-```
+```text
 0 3 * * * /opt/ayunis/ayunis-core/scripts/backup.sh >> /var/log/ayunis-backup.log 2>&1
 ```
 
@@ -354,7 +373,7 @@ Add this line (adjust the path to your checkout):
 
 Order a [Storage Box](https://www.hetzner.com/storage/storage-box/) and configure SSH key access, then set `BACKUP_REMOTE` in your cron entry:
 
-```
+```text
 0 3 * * * BACKUP_REMOTE="u123456@u123456.your-storagebox.de:backups/" /opt/ayunis/ayunis-core/scripts/backup.sh >> /var/log/ayunis-backup.log 2>&1
 ```
 
@@ -390,8 +409,8 @@ source /opt/ayunis/ayunis-core/ayunis-core-backend/.env
 
 ### Health Checks
 
-- **Frontend**: http://your-domain/health (Vite dev mode only)
-- **Backend**: http://your-domain/api/health
+- **Frontend**: <http://your-domain/health> (Vite dev mode only)
+- **Backend**: <http://your-domain/api/health>
 - **MCP integrations**: Check via `/api/mcp-integrations` endpoint
 
 ### Logs
@@ -426,11 +445,13 @@ ORDER BY pg_total_relation_size(relid) DESC;
 ### Application fails to start
 
 **Check MCP encryption key**:
+
 ```bash
 docker compose logs ayunis-core-backend | grep -i "encryption"
 ```
 
 **Verify environment variables**:
+
 ```bash
 docker exec ayunis-core-backend env | grep -E "(MCP|JWT|COOKIE|POSTGRES)"
 ```

--- a/README.md
+++ b/README.md
@@ -32,19 +32,19 @@ Ayunis Core is a comprehensive AI platform that enables intelligent conversation
 
 ### Prerequisites
 
-- Node.js (v18 or higher)
+- Node.js (v24 or higher)
 - npm
 - Docker and Docker Compose
 
 ### Installation
 
-**Clone the repository and navigate to the project root**
+#### Clone the repository and navigate to the project root
 
 ```bash
 cd /path/to/ayunis-core
 ```
 
-**Create your production environment file**
+#### Create your production environment file
 
 > [!] You must create each env file, even if you don't change variables
 
@@ -54,28 +54,28 @@ cp ./ayunis-core-backend/.env.example ./ayunis-core-backend/.env
 cp ./ayunis-core-frontend/.env.example ./ayunis-core-frontend/.env
 ```
 
-**Edit the backend environment file with your production values**
+#### Edit the backend environment file with your production values
 
 ```bash
 nano ./ayunis-core-backend/.env
 ```
 
-**Build and start the production stack**
+#### Build and start the production stack
 
 ```bash
 docker compose up -d --build
 ```
 
-**Change application port**
+#### Change application port
 
 Change `HOST_PORT` in the `.env` file in the project root
 
-**Access the application**
+#### Access the application
 
-- Application: http://localhost:3000
-- Backend Base URL: http://localhost:3000/api
-- SwaggerUI: http://localhost:3000/api/docs
-- OpenAPI JSON: http://localhost:3000/api/docs-json
+- Application: <http://localhost:3000>
+- Backend Base URL: <http://localhost:3000/api>
+- SwaggerUI: <http://localhost:3000/api/docs>
+- OpenAPI JSON: <http://localhost:3000/api/docs-json>
 
 ## ⚙️ Configuration
 
@@ -96,16 +96,20 @@ MCP integration enables Ayunis Core to connect to external data sources through 
 #### Required Configuration
 
 **MCP_ENCRYPTION_KEY** (Required):
+
 - Encrypts all MCP integration credentials (API keys, bearer tokens) at rest in the database
 - Uses AES-256-GCM encryption
 - Must be a 64-character hexadecimal string (32 bytes)
 - Generate a secure key with:
+
   ```bash
   openssl rand -hex 32
   ```
+
 - The application will fail to start if this variable is not set or is invalid
 
 **LOCABOO_4_URL** (Required for Locaboo 4 integration):
+
 - Base URL of the Locaboo 4 MCP server instance
 - Example values:
   - Local development: `http://localhost:8080`
@@ -138,6 +142,7 @@ Ayunis Core uses a simplified authentication system for MCP integrations:
 #### Configuration Validation
 
 The application validates MCP configuration on startup:
+
 - `MCP_ENCRYPTION_KEY` must be set and valid (64 hex characters)
 - If validation fails, the application will not start
 - Check application logs for specific error messages if startup fails
@@ -180,6 +185,7 @@ Then use the authenticated API to manage the model catalog. See the full endpoin
 > [!ATTENTION] The embedding model dimension must match the model's required dimensions. If you need other dimensions, create a Github Issue and we will take care of it.
 
 See also:
+
 - `/src/domain/models/domain/models/language.model.ts`
 - `/src/domain/models/domain/models/embedding.model.ts`
 - `/src/domain/models/domain/value-objects/embedding-dimensions.enum.ts`
@@ -225,11 +231,12 @@ This installs Husky and configures Git to use the hooks in the `.husky/` directo
 
 Commit messages must follow this format:
 
-```
+```text
 <type>: <description> (AYC-<task-id>)
 ```
 
 Examples:
+
 - `feat: add new chart widget (AYC-123)`
 - `fix: correct date validation (AYC-456)`
 - `chore: update dependencies (AYC-789)`

--- a/ayunis-core-backend/README.md
+++ b/ayunis-core-backend/README.md
@@ -16,8 +16,6 @@ A NestJS backend application built with hexagonal architecture for the Ayunis pl
   - [Domain Modules](#domain-modules)
 - [API Documentation](#api-documentation)
 - [Testing](#testing)
-- [Deployment](#deployment)
-- [Useful Commands](#useful-commands)
 
 ## Overview
 
@@ -25,7 +23,7 @@ This is the core backend for the Ayunis platform, built with NestJS and followin
 
 ## Prerequisites
 
-- Node.js (v18+)
+- Node.js (v24+)
 - npm or yarn
 - Docker and Docker Compose
 - PostgreSQL with pgvector extension
@@ -35,9 +33,9 @@ This is the core backend for the Ayunis platform, built with NestJS and followin
 1. Clone the repository
 2. Copy the example environment file:
 
-```bash
-cp .env.example .env
-```
+   ```bash
+   cp .env.example .env
+   ```
 
 3. Update the `.env` file with your specific configuration values
 
@@ -79,6 +77,7 @@ npm run start:prod
 
 Check `.env.example` for necessary environment variables
 
+```text
 # Database
 
 POSTGRES_HOST=postgres
@@ -90,8 +89,7 @@ POSTGRES_DB=ayunis
 # Mistral API
 
 MISTRAL_API_KEY=your_mistral_api_key
-
-````
+```
 
 ## Database Migrations
 
@@ -115,7 +113,7 @@ npm run migration:generate:prod
 npm run migration:run:prod
 npm run migration:revert:prod
 npm run migration:show:prod
-````
+```
 
 ## Project Structure
 
@@ -125,7 +123,7 @@ The application follows a hexagonal (ports and adapters) architecture.
 
 The project structure follows the hexagonal architecture pattern:
 
-```
+```text
 src/
 ├── domain/                  # Domain modules
 │   ├── <module>/            # Domain module


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only changes; the only potential impact is developers/deployers aligning tooling to Node.js v24 as now stated in the guides.
> 
> **Overview**
> Updates project docs (`README.md`, `CONTRIBUTING.md`, `DEPLOYMENT.md`, and `ayunis-core-backend/README.md`) to **raise the documented Node.js prerequisite to v24**.
> 
> Cleans up Markdown formatting (proper `text` code fences, consistent headings/spacing) and standardizes link rendering for local and deployment URLs using `<http://...>`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73779bf141571a54a2d20116d18dc050adfeea2f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->