### PR TITLE
wip(models): add tier field to language models (AYC-109)

### DIFF
--- a/ayunis-core-backend/src/db/migrations/1775563024401-AddTierToLanguageModels.ts
+++ b/ayunis-core-backend/src/db/migrations/1775563024401-AddTierToLanguageModels.ts
@@ -1,0 +1,15 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddTierToLanguageModels1775563024401 implements MigrationInterface {
+  name = 'AddTierToLanguageModels1775563024401';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "models" ADD "tier" character varying`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "models" DROP COLUMN "tier"`);
+  }
+}

--- a/ayunis-core-backend/src/domain/models/application/use-cases/create-language-model/create-language-model.command.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/create-language-model/create-language-model.command.ts
@@ -1,4 +1,5 @@
 import type { ModelProvider } from 'src/domain/models/domain/value-objects/model-provider.enum';
+import type { ModelTier } from 'src/domain/models/domain/value-objects/model-tier.enum';
 
 export class CreateLanguageModelCommand {
   name: string;
@@ -11,6 +12,7 @@ export class CreateLanguageModelCommand {
   isArchived: boolean;
   inputTokenCost?: number;
   outputTokenCost?: number;
+  tier?: ModelTier;
 
   constructor(params: {
     name: string;
@@ -23,6 +25,7 @@ export class CreateLanguageModelCommand {
     isArchived: boolean;
     inputTokenCost?: number;
     outputTokenCost?: number;
+    tier?: ModelTier;
   }) {
     this.name = params.name;
     this.provider = params.provider;
@@ -34,5 +37,6 @@ export class CreateLanguageModelCommand {
     this.isArchived = params.isArchived;
     this.inputTokenCost = params.inputTokenCost;
     this.outputTokenCost = params.outputTokenCost;
+    this.tier = params.tier;
   }
 }

--- a/ayunis-core-backend/src/domain/models/application/use-cases/create-language-model/create-language-model.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/create-language-model/create-language-model.use-case.spec.ts
@@ -1,0 +1,92 @@
+import type { TestingModule } from '@nestjs/testing';
+import { Test } from '@nestjs/testing';
+import { CreateLanguageModelUseCase } from './create-language-model.use-case';
+import { CreateLanguageModelCommand } from './create-language-model.command';
+import { ModelsRepository } from '../../ports/models.repository';
+import { LanguageModel } from 'src/domain/models/domain/models/language.model';
+import { ModelProvider } from 'src/domain/models/domain/value-objects/model-provider.enum';
+import { ModelTier } from 'src/domain/models/domain/value-objects/model-tier.enum';
+
+describe('CreateLanguageModelUseCase', () => {
+  let useCase: CreateLanguageModelUseCase;
+  let modelsRepository: jest.Mocked<ModelsRepository>;
+
+  beforeAll(async () => {
+    const mockModelsRepository = {
+      findOne: jest.fn(),
+      save: jest.fn(),
+      findAll: jest.fn(),
+      findOneLanguage: jest.fn(),
+      findOneEmbedding: jest.fn(),
+      delete: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        CreateLanguageModelUseCase,
+        { provide: ModelsRepository, useValue: mockModelsRepository },
+      ],
+    }).compile();
+
+    useCase = module.get<CreateLanguageModelUseCase>(
+      CreateLanguageModelUseCase,
+    );
+    modelsRepository = module.get(ModelsRepository);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const createCommand = (tier?: ModelTier): CreateLanguageModelCommand => {
+    return new CreateLanguageModelCommand({
+      name: 'gpt-4',
+      displayName: 'GPT-4',
+      provider: ModelProvider.OPENAI,
+      canStream: true,
+      isReasoning: false,
+      isArchived: false,
+      canUseTools: true,
+      canVision: false,
+      tier,
+    });
+  };
+
+  describe('execute', () => {
+    it('should forward tier into the saved language model when set', async () => {
+      // Arrange
+      const command = createCommand(ModelTier.HIGH);
+
+      modelsRepository.findOne.mockResolvedValue(undefined);
+      modelsRepository.save.mockResolvedValue();
+
+      // Act
+      const result = await useCase.execute(command);
+
+      // Assert
+      expect(result).toBeInstanceOf(LanguageModel);
+      expect(result.tier).toBe(ModelTier.HIGH);
+      expect(modelsRepository.save).toHaveBeenCalledWith(
+        expect.objectContaining({ tier: ModelTier.HIGH }),
+      );
+    });
+
+    it('should persist tier as undefined when omitted from the command', async () => {
+      // Arrange
+      const command = createCommand();
+
+      modelsRepository.findOne.mockResolvedValue(undefined);
+      modelsRepository.save.mockResolvedValue();
+
+      // Act
+      const result = await useCase.execute(command);
+
+      // Assert
+      expect(result).toBeInstanceOf(LanguageModel);
+      expect(result.tier).toBeUndefined();
+      expect(modelsRepository.save).toHaveBeenCalledWith(
+        expect.objectContaining({ tier: undefined }),
+      );
+    });
+  });
+});

--- a/ayunis-core-backend/src/domain/models/application/use-cases/create-language-model/create-language-model.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/create-language-model/create-language-model.use-case.ts
@@ -35,6 +35,7 @@ export class CreateLanguageModelUseCase {
         isArchived: command.isArchived,
         inputTokenCost: command.inputTokenCost,
         outputTokenCost: command.outputTokenCost,
+        tier: command.tier,
       });
       await this.modelsRepository.save(model);
       return model;

--- a/ayunis-core-backend/src/domain/models/application/use-cases/update-language-model/update-language-model.command.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/update-language-model/update-language-model.command.ts
@@ -1,5 +1,6 @@
 import type { UUID } from 'crypto';
 import type { ModelProvider } from 'src/domain/models/domain/value-objects/model-provider.enum';
+import type { ModelTier } from 'src/domain/models/domain/value-objects/model-tier.enum';
 
 export class UpdateLanguageModelCommand {
   id: UUID;
@@ -13,6 +14,7 @@ export class UpdateLanguageModelCommand {
   canVision: boolean;
   inputTokenCost?: number;
   outputTokenCost?: number;
+  tier?: ModelTier;
 
   constructor(params: {
     id: UUID;
@@ -26,6 +28,7 @@ export class UpdateLanguageModelCommand {
     canVision: boolean;
     inputTokenCost?: number;
     outputTokenCost?: number;
+    tier?: ModelTier;
   }) {
     this.id = params.id;
     this.name = params.name;
@@ -38,5 +41,6 @@ export class UpdateLanguageModelCommand {
     this.canVision = params.canVision;
     this.inputTokenCost = params.inputTokenCost;
     this.outputTokenCost = params.outputTokenCost;
+    this.tier = params.tier;
   }
 }

--- a/ayunis-core-backend/src/domain/models/application/use-cases/update-language-model/update-language-model.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/update-language-model/update-language-model.use-case.spec.ts
@@ -7,6 +7,7 @@ import { ModelsRepository } from '../../ports/models.repository';
 import { ClearDefaultsByCatalogModelIdUseCase } from '../clear-defaults-by-catalog-model-id/clear-defaults-by-catalog-model-id.use-case';
 import { LanguageModel } from 'src/domain/models/domain/models/language.model';
 import { ModelProvider } from 'src/domain/models/domain/value-objects/model-provider.enum';
+import { ModelTier } from 'src/domain/models/domain/value-objects/model-tier.enum';
 import { ModelNotFoundByIdError } from '../../models.errors';
 import type { UUID } from 'crypto';
 
@@ -60,6 +61,7 @@ describe('UpdateLanguageModelUseCase', () => {
   const createMockLanguageModel = (
     id: UUID,
     isArchived: boolean,
+    tier?: ModelTier,
   ): LanguageModel => {
     return new LanguageModel({
       id,
@@ -71,12 +73,14 @@ describe('UpdateLanguageModelUseCase', () => {
       isArchived,
       canUseTools: true,
       canVision: false,
+      tier,
     });
   };
 
   const createUpdateCommand = (
     id: UUID,
     isArchived: boolean,
+    tier?: ModelTier,
   ): UpdateLanguageModelCommand => {
     return new UpdateLanguageModelCommand({
       id,
@@ -88,6 +92,7 @@ describe('UpdateLanguageModelUseCase', () => {
       isArchived,
       canUseTools: true,
       canVision: false,
+      tier,
     });
   };
 
@@ -230,6 +235,50 @@ describe('UpdateLanguageModelUseCase', () => {
       expect(logSpy).toHaveBeenCalledWith(
         'Model is being archived, clearing defaults',
         { modelId: mockModelId },
+      );
+    });
+
+    it('should forward tier into the saved language model when set', async () => {
+      // Arrange
+      const existingModel = createMockLanguageModel(mockModelId, false);
+      const command = createUpdateCommand(mockModelId, false, ModelTier.HIGH);
+
+      modelsRepository.findOne.mockResolvedValue(existingModel);
+      modelsRepository.save.mockResolvedValue();
+
+      // Act
+      const result = await useCase.execute(command);
+
+      // Assert
+      expect(result).toBeInstanceOf(LanguageModel);
+      expect(result.tier).toBe(ModelTier.HIGH);
+      expect(modelsRepository.save).toHaveBeenCalledWith(
+        expect.objectContaining({ tier: ModelTier.HIGH }),
+      );
+    });
+
+    it('should clear tier when omitted from the command (full-replace semantics)', async () => {
+      // Arrange — existing model has a tier set; the update command omits it.
+      // The use case treats updates as a full replace, so the saved model
+      // must have its tier cleared rather than carried over from the existing row.
+      const existingModel = createMockLanguageModel(
+        mockModelId,
+        false,
+        ModelTier.HIGH,
+      );
+      const command = createUpdateCommand(mockModelId, false);
+
+      modelsRepository.findOne.mockResolvedValue(existingModel);
+      modelsRepository.save.mockResolvedValue();
+
+      // Act
+      const result = await useCase.execute(command);
+
+      // Assert
+      expect(existingModel.tier).toBe(ModelTier.HIGH);
+      expect(result.tier).toBeUndefined();
+      expect(modelsRepository.save).toHaveBeenCalledWith(
+        expect.objectContaining({ tier: undefined }),
       );
     });
 

--- a/ayunis-core-backend/src/domain/models/application/use-cases/update-language-model/update-language-model.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/update-language-model/update-language-model.use-case.ts
@@ -44,6 +44,7 @@ export class UpdateLanguageModelUseCase {
         canVision: command.canVision,
         inputTokenCost: command.inputTokenCost,
         outputTokenCost: command.outputTokenCost,
+        tier: command.tier,
       });
       await this.modelsRepository.save(model);
 

--- a/ayunis-core-backend/src/domain/models/domain/models/language.model.ts
+++ b/ayunis-core-backend/src/domain/models/domain/models/language.model.ts
@@ -1,6 +1,7 @@
 import type { ModelProvider } from '../value-objects/model-provider.enum';
 import { Model } from '../model.entity';
 import { ModelType } from '../value-objects/model-type.enum';
+import type { ModelTier } from '../value-objects/model-tier.enum';
 import type { UUID } from 'crypto';
 
 export class LanguageModel extends Model {
@@ -12,6 +13,12 @@ export class LanguageModel extends Model {
   public readonly inputTokenCost?: number;
   /** Cost per million output tokens in EUR */
   public readonly outputTokenCost?: number;
+  /**
+   * Fair-use tier label assigned by super admins. Drives quota bucket
+   * selection. Optional today; runtime fallback for untiered models is
+   * tracked in AYC-109.
+   */
+  public readonly tier?: ModelTier;
 
   constructor(params: {
     id?: UUID;
@@ -27,6 +34,7 @@ export class LanguageModel extends Model {
     isArchived: boolean;
     inputTokenCost?: number;
     outputTokenCost?: number;
+    tier?: ModelTier;
   }) {
     super({ ...params, type: ModelType.LANGUAGE });
     this.canStream = params.canStream;
@@ -35,5 +43,6 @@ export class LanguageModel extends Model {
     this.canVision = params.canVision;
     this.inputTokenCost = params.inputTokenCost;
     this.outputTokenCost = params.outputTokenCost;
+    this.tier = params.tier;
   }
 }

--- a/ayunis-core-backend/src/domain/models/domain/value-objects/model-tier.enum.ts
+++ b/ayunis-core-backend/src/domain/models/domain/value-objects/model-tier.enum.ts
@@ -1,0 +1,5 @@
+export enum ModelTier {
+  LOW = 'low',
+  MEDIUM = 'medium',
+  HIGH = 'high',
+}

--- a/ayunis-core-backend/src/domain/models/infrastructure/persistence/local-models/mappers/model.mapper.spec.ts
+++ b/ayunis-core-backend/src/domain/models/infrastructure/persistence/local-models/mappers/model.mapper.spec.ts
@@ -1,0 +1,138 @@
+import { Logger } from '@nestjs/common';
+import { ModelMapper } from './model.mapper';
+import { LanguageModelRecord } from '../schema/model.record';
+import { LanguageModel } from '../../../../domain/models/language.model';
+import { ModelProvider } from '../../../../domain/value-objects/model-provider.enum';
+import { ModelTier } from '../../../../domain/value-objects/model-tier.enum';
+import type { UUID } from 'crypto';
+
+describe('ModelMapper', () => {
+  let mapper: ModelMapper;
+  let warnSpy: jest.SpyInstance;
+
+  const mockId = '123e4567-e89b-12d3-a456-426614174000' as UUID;
+
+  beforeEach(() => {
+    mapper = new ModelMapper();
+    warnSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  const buildLanguageRecord = (
+    tier: string | null | undefined,
+  ): LanguageModelRecord => {
+    const record = new LanguageModelRecord();
+    record.id = mockId;
+    record.name = 'gpt-4';
+    record.provider = ModelProvider.OPENAI;
+    record.displayName = 'GPT-4';
+    record.canStream = true;
+    record.canUseTools = true;
+    record.isReasoning = false;
+    record.canVision = false;
+    record.isArchived = false;
+    record.createdAt = new Date('2025-01-01T00:00:00Z');
+    record.updatedAt = new Date('2025-01-02T00:00:00Z');
+    record.tier = tier ?? null;
+    return record;
+  };
+
+  const buildLanguageDomain = (tier?: ModelTier): LanguageModel => {
+    return new LanguageModel({
+      id: mockId,
+      name: 'gpt-4',
+      provider: ModelProvider.OPENAI,
+      displayName: 'GPT-4',
+      canStream: true,
+      canUseTools: true,
+      isReasoning: false,
+      canVision: false,
+      isArchived: false,
+      createdAt: new Date('2025-01-01T00:00:00Z'),
+      updatedAt: new Date('2025-01-02T00:00:00Z'),
+      tier,
+    });
+  };
+
+  describe('toDomain (language model)', () => {
+    it('reads a valid tier value from the record', () => {
+      const record = buildLanguageRecord(ModelTier.HIGH);
+
+      const domain = mapper.toDomain(record);
+
+      expect(domain).toBeInstanceOf(LanguageModel);
+      expect((domain as LanguageModel).tier).toBe(ModelTier.HIGH);
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it('warns and falls back to undefined for an unknown tier value', () => {
+      const record = buildLanguageRecord('platinum');
+
+      const domain = mapper.toDomain(record);
+
+      expect((domain as LanguageModel).tier).toBeUndefined();
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy).toHaveBeenCalledWith(
+        'Encountered unknown model tier value, ignoring',
+        expect.objectContaining({
+          value: 'platinum',
+          modelId: mockId,
+          modelName: 'gpt-4',
+        }),
+      );
+    });
+
+    it('returns undefined tier for a null record value without warning', () => {
+      const record = buildLanguageRecord(null);
+
+      const domain = mapper.toDomain(record);
+
+      expect((domain as LanguageModel).tier).toBeUndefined();
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('toRecord (language model)', () => {
+    it('writes the tier onto the record', () => {
+      const domain = buildLanguageDomain(ModelTier.LOW);
+
+      const record = mapper.toRecord(domain);
+
+      expect(record).toBeInstanceOf(LanguageModelRecord);
+      expect((record as LanguageModelRecord).tier).toBe(ModelTier.LOW);
+    });
+
+    it('writes null onto the record when the domain tier is undefined', () => {
+      const domain = buildLanguageDomain();
+
+      const record = mapper.toRecord(domain);
+
+      expect((record as LanguageModelRecord).tier).toBeNull();
+    });
+  });
+
+  describe('round-trip', () => {
+    it('preserves a set tier through toRecord -> toDomain', () => {
+      const original = buildLanguageDomain(ModelTier.MEDIUM);
+
+      const record = mapper.toRecord(original) as LanguageModelRecord;
+      const roundTripped = mapper.toDomain(record) as LanguageModel;
+
+      expect(roundTripped.tier).toBe(ModelTier.MEDIUM);
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it('preserves an undefined tier through toRecord -> toDomain', () => {
+      const original = buildLanguageDomain();
+
+      const record = mapper.toRecord(original) as LanguageModelRecord;
+      const roundTripped = mapper.toDomain(record) as LanguageModel;
+
+      expect(roundTripped.tier).toBeUndefined();
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/ayunis-core-backend/src/domain/models/infrastructure/persistence/local-models/mappers/model.mapper.ts
+++ b/ayunis-core-backend/src/domain/models/infrastructure/persistence/local-models/mappers/model.mapper.ts
@@ -1,7 +1,8 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { Model } from '../../../../domain/model.entity';
 import { LanguageModel } from '../../../../domain/models/language.model';
 import { EmbeddingModel } from '../../../../domain/models/embedding.model';
+import { ModelTier } from '../../../../domain/value-objects/model-tier.enum';
 import {
   ModelRecord,
   LanguageModelRecord,
@@ -10,6 +11,28 @@ import {
 
 @Injectable()
 export class ModelMapper {
+  private readonly logger = new Logger(ModelMapper.name);
+
+  private parseTier(
+    value: string | null | undefined,
+    rowId: string,
+    rowName: string,
+  ): ModelTier | undefined {
+    if (value === null || value === undefined) {
+      return undefined;
+    }
+    const allowed = Object.values(ModelTier) as string[];
+    if (allowed.includes(value)) {
+      return value as ModelTier;
+    }
+    this.logger.warn('Encountered unknown model tier value, ignoring', {
+      value,
+      modelId: rowId,
+      modelName: rowName,
+    });
+    return undefined;
+  }
+
   toDomain(record: ModelRecord): Model {
     // TypeORM will provide the concrete record type based on the discriminator
     if (record instanceof LanguageModelRecord) {
@@ -27,6 +50,7 @@ export class ModelMapper {
         updatedAt: record.updatedAt,
         inputTokenCost: record.inputTokenCost,
         outputTokenCost: record.outputTokenCost,
+        tier: this.parseTier(record.tier, record.id, record.name),
       });
     }
 
@@ -64,6 +88,7 @@ export class ModelMapper {
       record.updatedAt = domain.updatedAt;
       record.inputTokenCost = domain.inputTokenCost;
       record.outputTokenCost = domain.outputTokenCost;
+      record.tier = domain.tier ?? null;
       return record;
     }
 

--- a/ayunis-core-backend/src/domain/models/infrastructure/persistence/local-models/schema/model.record.ts
+++ b/ayunis-core-backend/src/domain/models/infrastructure/persistence/local-models/schema/model.record.ts
@@ -69,6 +69,15 @@ export class LanguageModelRecord extends ModelRecord {
 
   @Column(tokenCostColumnOptions)
   outputTokenCost?: number;
+
+  // Stored as varchar (not a Postgres enum) on purpose: adding new tiers later
+  // should not require an `ALTER TYPE` migration. The allow-list in
+  // ModelMapper.parseTier defends against stray values when reading.
+  @Column({
+    type: 'varchar',
+    nullable: true,
+  })
+  tier?: string | null;
 }
 
 @ChildEntity(ModelType.EMBEDDING)

--- a/ayunis-core-backend/src/domain/models/presenters/http/dto/base-language-model-request.dto.ts
+++ b/ayunis-core-backend/src/domain/models/presenters/http/dto/base-language-model-request.dto.ts
@@ -5,11 +5,13 @@ import {
   IsEnum,
   IsBoolean,
   IsNumber,
+  IsOptional,
   Min,
   ValidateIf,
 } from 'class-validator';
 import { Transform } from 'class-transformer';
 import { ModelProvider } from 'src/domain/models/domain/value-objects/model-provider.enum';
+import { ModelTier } from 'src/domain/models/domain/value-objects/model-tier.enum';
 import { nullToUndefined } from 'src/common/util/null-to-undefined';
 
 function hasAnyCostField(o: BaseLanguageModelRequestDto): boolean {
@@ -97,4 +99,15 @@ export abstract class BaseLanguageModelRequestDto {
   @IsNumber()
   @Min(0)
   outputTokenCost?: number;
+
+  @ApiPropertyOptional({
+    description:
+      'Fair-use tier label assigned by super admins; drives which fair-use quota bucket the model consumes. Optional today — runtime fallback for untiered models is tracked in AYC-109.',
+    enum: ModelTier,
+    example: ModelTier.MEDIUM,
+  })
+  @Transform(nullToUndefined)
+  @IsOptional()
+  @IsEnum(ModelTier)
+  tier?: ModelTier;
 }

--- a/ayunis-core-backend/src/domain/models/presenters/http/dto/language-model-response.dto.ts
+++ b/ayunis-core-backend/src/domain/models/presenters/http/dto/language-model-response.dto.ts
@@ -1,6 +1,7 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { UUID } from 'crypto';
 import { ModelProvider } from 'src/domain/models/domain/value-objects/model-provider.enum';
+import { ModelTier } from 'src/domain/models/domain/value-objects/model-tier.enum';
 import { ModelType } from 'src/domain/models/domain/value-objects/model-type.enum';
 
 export class LanguageModelResponseDto {
@@ -103,4 +104,12 @@ export class LanguageModelResponseDto {
     example: 15,
   })
   outputTokenCost?: number;
+
+  @ApiPropertyOptional({
+    enum: ModelTier,
+    description:
+      'Fair-use tier label assigned by super admins; drives quota bucket selection. Optional today — runtime fallback for untiered models is tracked in AYC-109.',
+    example: ModelTier.MEDIUM,
+  })
+  tier?: ModelTier;
 }

--- a/ayunis-core-backend/src/domain/models/presenters/http/dto/model-with-config-response.dto.ts
+++ b/ayunis-core-backend/src/domain/models/presenters/http/dto/model-with-config-response.dto.ts
@@ -1,6 +1,7 @@
-import { ApiProperty } from '@nestjs/swagger';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { UUID } from 'crypto';
 import { ModelProvider } from 'src/domain/models/domain/value-objects/model-provider.enum';
+import { ModelTier } from 'src/domain/models/domain/value-objects/model-tier.enum';
 
 export class ModelWithConfigResponseDto {
   @ApiProperty({
@@ -84,4 +85,12 @@ export class ModelWithConfigResponseDto {
     nullable: true,
   })
   anonymousOnly?: boolean;
+
+  @ApiPropertyOptional({
+    enum: ModelTier,
+    description:
+      'Fair-use tier label assigned by super admins; drives quota bucket selection. Undefined for embedding models and untiered language models.',
+    example: ModelTier.MEDIUM,
+  })
+  tier?: ModelTier;
 }

--- a/ayunis-core-backend/src/domain/models/presenters/http/mappers/catalog-model-response-dto.mapper.ts
+++ b/ayunis-core-backend/src/domain/models/presenters/http/mappers/catalog-model-response-dto.mapper.ts
@@ -25,6 +25,7 @@ export class CatalogModelResponseDtoMapper {
       updatedAt: model.updatedAt,
       inputTokenCost: model.inputTokenCost,
       outputTokenCost: model.outputTokenCost,
+      tier: model.tier,
     };
   }
 

--- a/ayunis-core-backend/src/domain/models/presenters/http/mappers/model-with-config-response-dto.mapper.ts
+++ b/ayunis-core-backend/src/domain/models/presenters/http/mappers/model-with-config-response-dto.mapper.ts
@@ -32,6 +32,7 @@ export class ModelWithConfigResponseDtoMapper {
         isDefault,
         isEmbedding: model instanceof EmbeddingModel ? true : false,
         anonymousOnly: permittedModel?.anonymousOnly,
+        tier: model instanceof LanguageModel ? model.tier : undefined,
       };
     });
   }

--- a/ayunis-core-backend/src/domain/models/presenters/http/super-admin-catalog-models.controller.ts
+++ b/ayunis-core-backend/src/domain/models/presenters/http/super-admin-catalog-models.controller.ts
@@ -246,6 +246,7 @@ export class SuperAdminCatalogModelsController {
       isArchived: dto.isArchived,
       inputTokenCost: dto.inputTokenCost,
       outputTokenCost: dto.outputTokenCost,
+      tier: dto.tier,
     });
 
     const model = await this.createLanguageModelUseCase.execute(command);
@@ -308,6 +309,7 @@ export class SuperAdminCatalogModelsController {
       isArchived: dto.isArchived,
       inputTokenCost: dto.inputTokenCost,
       outputTokenCost: dto.outputTokenCost,
+      tier: dto.tier,
     });
 
     const model = await this.updateLanguageModelUseCase.execute(command);

--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
@@ -47,6 +47,19 @@ export const ModelWithConfigResponseDtoProvider = {
   scaleway: 'scaleway',
 } as const;
 
+/**
+ * Fair-use tier label assigned by super admins; drives quota bucket selection. Undefined for embedding models and untiered language models.
+ */
+export type ModelWithConfigResponseDtoTier = typeof ModelWithConfigResponseDtoTier[keyof typeof ModelWithConfigResponseDtoTier];
+
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const ModelWithConfigResponseDtoTier = {
+  low: 'low',
+  medium: 'medium',
+  high: 'high',
+} as const;
+
 export interface ModelWithConfigResponseDto {
   /** The id of the model */
   modelId: string;
@@ -80,6 +93,8 @@ export interface ModelWithConfigResponseDto {
    * @nullable
    */
   anonymousOnly: boolean | null;
+  /** Fair-use tier label assigned by super admins; drives quota bucket selection. Undefined for embedding models and untiered language models. */
+  tier?: ModelWithConfigResponseDtoTier;
 }
 
 /**
@@ -320,6 +335,19 @@ export const CreateLanguageModelRequestDtoProvider = {
   scaleway: 'scaleway',
 } as const;
 
+/**
+ * Fair-use tier label assigned by super admins; drives which fair-use quota bucket the model consumes. Optional today — runtime fallback for untiered models is tracked in AYC-109.
+ */
+export type CreateLanguageModelRequestDtoTier = typeof CreateLanguageModelRequestDtoTier[keyof typeof CreateLanguageModelRequestDtoTier];
+
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const CreateLanguageModelRequestDtoTier = {
+  low: 'low',
+  medium: 'medium',
+  high: 'high',
+} as const;
+
 export interface CreateLanguageModelRequestDto {
   /** The name of the model */
   name: string;
@@ -347,6 +375,8 @@ export interface CreateLanguageModelRequestDto {
    * @minimum 0
    */
   outputTokenCost?: number;
+  /** Fair-use tier label assigned by super admins; drives which fair-use quota bucket the model consumes. Optional today — runtime fallback for untiered models is tracked in AYC-109. */
+  tier?: CreateLanguageModelRequestDtoTier;
 }
 
 /**
@@ -369,6 +399,19 @@ export const UpdateLanguageModelRequestDtoProvider = {
   gemini: 'gemini',
   stackit: 'stackit',
   scaleway: 'scaleway',
+} as const;
+
+/**
+ * Fair-use tier label assigned by super admins; drives which fair-use quota bucket the model consumes. Optional today — runtime fallback for untiered models is tracked in AYC-109.
+ */
+export type UpdateLanguageModelRequestDtoTier = typeof UpdateLanguageModelRequestDtoTier[keyof typeof UpdateLanguageModelRequestDtoTier];
+
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const UpdateLanguageModelRequestDtoTier = {
+  low: 'low',
+  medium: 'medium',
+  high: 'high',
 } as const;
 
 export interface UpdateLanguageModelRequestDto {
@@ -398,6 +441,8 @@ export interface UpdateLanguageModelRequestDto {
    * @minimum 0
    */
   outputTokenCost?: number;
+  /** Fair-use tier label assigned by super admins; drives which fair-use quota bucket the model consumes. Optional today — runtime fallback for untiered models is tracked in AYC-109. */
+  tier?: UpdateLanguageModelRequestDtoTier;
 }
 
 /**
@@ -549,6 +594,19 @@ export const LanguageModelResponseDtoType = {
   language: 'language',
 } as const;
 
+/**
+ * Fair-use tier label assigned by super admins; drives quota bucket selection. Optional today — runtime fallback for untiered models is tracked in AYC-109.
+ */
+export type LanguageModelResponseDtoTier = typeof LanguageModelResponseDtoTier[keyof typeof LanguageModelResponseDtoTier];
+
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const LanguageModelResponseDtoTier = {
+  low: 'low',
+  medium: 'medium',
+  high: 'high',
+} as const;
+
 export interface LanguageModelResponseDto {
   /** The unique identifier of the model */
   id: string;
@@ -578,6 +636,8 @@ export interface LanguageModelResponseDto {
   inputTokenCost?: number;
   /** Cost per million output tokens in EUR */
   outputTokenCost?: number;
+  /** Fair-use tier label assigned by super admins; drives quota bucket selection. Optional today — runtime fallback for untiered models is tracked in AYC-109. */
+  tier?: LanguageModelResponseDtoTier;
 }
 
 /**

--- a/ayunis-core-frontend/src/shared/api/openapi-schema.json
+++ b/ayunis-core-frontend/src/shared/api/openapi-schema.json
@@ -8263,6 +8263,12 @@
             "type": "boolean",
             "description": "Whether this model enforces anonymous mode. Null if not permitted.",
             "nullable": true
+          },
+          "tier": {
+            "type": "string",
+            "enum": ["low", "medium", "high"],
+            "description": "Fair-use tier label assigned by super admins; drives quota bucket selection. Undefined for embedding models and untiered language models.",
+            "example": "medium"
           }
         },
         "required": [
@@ -8639,6 +8645,12 @@
             "description": "Cost per million output tokens in EUR",
             "example": 15,
             "minimum": 0
+          },
+          "tier": {
+            "type": "string",
+            "description": "Fair-use tier label assigned by super admins; drives which fair-use quota bucket the model consumes. Optional today — runtime fallback for untiered models is tracked in AYC-109.",
+            "enum": ["low", "medium", "high"],
+            "example": "medium"
           }
         },
         "required": [
@@ -8720,6 +8732,12 @@
             "description": "Cost per million output tokens in EUR",
             "example": 15,
             "minimum": 0
+          },
+          "tier": {
+            "type": "string",
+            "description": "Fair-use tier label assigned by super admins; drives which fair-use quota bucket the model consumes. Optional today — runtime fallback for untiered models is tracked in AYC-109.",
+            "enum": ["low", "medium", "high"],
+            "example": "medium"
           }
         },
         "required": [
@@ -8948,6 +8966,12 @@
             "type": "number",
             "description": "Cost per million output tokens in EUR",
             "example": 15
+          },
+          "tier": {
+            "type": "string",
+            "enum": ["low", "medium", "high"],
+            "description": "Fair-use tier label assigned by super admins; drives quota bucket selection. Optional today — runtime fallback for untiered models is tracked in AYC-109.",
+            "example": "medium"
           }
         },
         "required": [


### PR DESCRIPTION
- New ModelTier value object (low/medium/high) and nullable tier
  column on the language model record (one migration).
- LanguageModel entity carries optional tier; mapper round-trips it
  with safe parsing of unknown values.
- Tier flows through admin-facing DTOs (base/create/update request,
  language-model-response, model-with-config-response), the catalog
  and model-with-config response mappers, the create/update commands
  and use cases, and the super-admin catalog controller.
- Update use-case spec covers tier round-trip and undefined cases.

Note: super-admin-catalog-models.controller.ts was not in step 3's
explicit scope list but was updated to keep the DTO -> command chain
intact; without it the new field would silently be dropped.

Refs: AYC-109

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new nullable DB column and threads it through create/update flows and HTTP DTOs, which changes persisted data and API contracts. Risk is moderate due to migration/backward-compatibility concerns (untiered/unknown tier handling) but logic changes are straightforward and covered by tests.
> 
> **Overview**
> Adds an optional `tier` (low/medium/high) to language models end-to-end.
> 
> This introduces a nullable `models.tier` column (varchar) plus a new `ModelTier` enum, updates `LanguageModel`/persistence mapping to round-trip the value (logging and ignoring unknown DB values), and wires `tier` through super-admin create/update commands, use cases, controllers, and response/request DTOs (including `model-with-config` and generated frontend OpenAPI types). Tests were added/extended to verify create/update semantics (including clearing `tier` on update when omitted) and mapper behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 951bea1de80012227e2a13f19186f15105f7d859. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->