### PR TITLE
wip(mcp): add application-layer ports, errors, and factory update (AYC-110)

### DIFF
--- a/ayunis-core-backend/src/common/errors/base.error.ts
+++ b/ayunis-core-backend/src/common/errors/base.error.ts
@@ -1,4 +1,5 @@
 import {
+  BadGatewayException,
   BadRequestException,
   ConflictException,
   ForbiddenException,
@@ -6,6 +7,7 @@ import {
   InternalServerErrorException,
   NotFoundException,
   NotImplementedException,
+  PreconditionFailedException,
   ServiceUnavailableException,
   UnauthorizedException,
 } from '@nestjs/common';
@@ -72,10 +74,14 @@ export abstract class ApplicationError extends Error {
         return new NotFoundException(body);
       case 409:
         return new ConflictException(body);
+      case 412:
+        return new PreconditionFailedException(body);
       case 500:
         return new InternalServerErrorException(body);
       case 501:
         return new NotImplementedException(body);
+      case 502:
+        return new BadGatewayException(body);
       case 503:
         return new ServiceUnavailableException(body);
       case 504:

--- a/ayunis-core-backend/src/domain/mcp/application/factories/mcp-integration.factory.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/factories/mcp-integration.factory.spec.ts
@@ -9,6 +9,7 @@ import { OAuthMcpIntegrationAuth } from '../../domain/auth/oauth-mcp-integration
 import { CustomMcpIntegration } from '../../domain/integrations/custom-mcp-integration.entity';
 import { PredefinedMcpIntegration } from '../../domain/integrations/predefined-mcp-integration.entity';
 import { MarketplaceMcpIntegration } from '../../domain/integrations/marketplace-mcp-integration.entity';
+import { SelfDefinedMcpIntegration } from '../../domain/integrations/self-defined-mcp-integration.entity';
 import type { IntegrationConfigSchema } from '../../domain/value-objects/integration-config-schema';
 
 describe('McpIntegrationFactory', () => {
@@ -199,6 +200,89 @@ describe('McpIntegrationFactory', () => {
           orgConfigValues: {},
         }),
       ).toThrow('Marketplace integrations require a config schema');
+    });
+
+    it('creates self-defined integrations with config schema and org config values', () => {
+      const configSchema: IntegrationConfigSchema = {
+        authType: 'NO_AUTH',
+        orgFields: [
+          {
+            key: 'baseUrl',
+            label: 'Base URL',
+            type: 'url',
+            required: true,
+          },
+        ],
+        userFields: [],
+      };
+      const auth = new NoAuthMcpIntegrationAuth();
+
+      const integration = factory.createIntegration({
+        kind: McpIntegrationKind.SELF_DEFINED,
+        orgId,
+        name,
+        serverUrl,
+        auth,
+        configSchema,
+        orgConfigValues: { baseUrl: 'http://example.com' },
+      });
+
+      expect(integration).toBeInstanceOf(SelfDefinedMcpIntegration);
+      expect(integration.kind).toBe(McpIntegrationKind.SELF_DEFINED);
+      expect(integration.configSchema).toBe(configSchema);
+      expect(integration.orgConfigValues).toEqual({
+        baseUrl: 'http://example.com',
+      });
+      expect(integration.serverUrl).toBe(serverUrl);
+      expect(integration.isSelfDefined()).toBe(true);
+      expect(integration.isMarketplace()).toBe(false);
+    });
+
+    it('creates self-defined integrations with OAuth client credentials', () => {
+      const configSchema: IntegrationConfigSchema = {
+        authType: 'OAUTH',
+        orgFields: [],
+        userFields: [],
+        oauth: {
+          authorizationUrl: 'https://auth.example.com/authorize',
+          tokenUrl: 'https://auth.example.com/token',
+          scopes: ['read', 'write'],
+          level: 'org',
+        },
+      };
+      const auth = new NoAuthMcpIntegrationAuth();
+
+      const integration = factory.createIntegration({
+        kind: McpIntegrationKind.SELF_DEFINED,
+        orgId,
+        name,
+        serverUrl,
+        auth,
+        configSchema,
+        orgConfigValues: {},
+        oauthClientId: 'client-123',
+        oauthClientSecretEncrypted: 'encrypted-secret',
+      });
+
+      expect(integration).toBeInstanceOf(SelfDefinedMcpIntegration);
+      expect(integration.oauthClientId).toBe('client-123');
+      expect(integration.oauthClientSecretEncrypted).toBe('encrypted-secret');
+    });
+
+    it('throws when self-defined integration is missing config schema', () => {
+      const auth = new NoAuthMcpIntegrationAuth();
+
+      expect(() =>
+        factory.createIntegration({
+          kind: McpIntegrationKind.SELF_DEFINED,
+          orgId,
+          name,
+          serverUrl,
+          auth,
+          configSchema: undefined as any,
+          orgConfigValues: {},
+        }),
+      ).toThrow('Self-defined integrations require a config schema');
     });
   });
 });

--- a/ayunis-core-backend/src/domain/mcp/application/factories/mcp-integration.factory.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/factories/mcp-integration.factory.ts
@@ -4,6 +4,7 @@ import { McpIntegrationKind } from '../../domain/value-objects/mcp-integration-k
 import { CustomMcpIntegration } from '../../domain/integrations/custom-mcp-integration.entity';
 import { PredefinedMcpIntegration } from '../../domain/integrations/predefined-mcp-integration.entity';
 import { MarketplaceMcpIntegration } from '../../domain/integrations/marketplace-mcp-integration.entity';
+import { SelfDefinedMcpIntegration } from '../../domain/integrations/self-defined-mcp-integration.entity';
 import { PredefinedMcpIntegrationSlug } from '../../domain/value-objects/predefined-mcp-integration-slug.enum';
 import { IntegrationConfigSchema } from '../../domain/value-objects/integration-config-schema';
 import { McpIntegrationAuth } from '../../domain/auth/mcp-integration-auth.entity';
@@ -64,6 +65,26 @@ export class McpIntegrationFactory {
     returnsPii?: boolean;
     description?: string;
   }): MarketplaceMcpIntegration;
+  createIntegration(params: {
+    kind: McpIntegrationKind.SELF_DEFINED;
+    orgId: UUID;
+    name: string;
+    serverUrl: string;
+    auth: McpIntegrationAuth;
+    configSchema: IntegrationConfigSchema;
+    orgConfigValues: Record<string, string>;
+    id?: UUID;
+    enabled?: boolean;
+    createdAt?: Date;
+    updatedAt?: Date;
+    connectionStatus?: string;
+    lastConnectionError?: string;
+    lastConnectionCheck?: Date;
+    returnsPii?: boolean;
+    description?: string;
+    oauthClientId?: string;
+    oauthClientSecretEncrypted?: string;
+  }): SelfDefinedMcpIntegration;
   createIntegration(params: CreateIntegrationParams): McpIntegration {
     const base = this.extractBaseParams(params);
 
@@ -75,12 +96,7 @@ export class McpIntegrationFactory {
       case McpIntegrationKind.CUSTOM:
         return new CustomMcpIntegration(base);
       case McpIntegrationKind.SELF_DEFINED:
-        // SELF_DEFINED factory branch is added in a later step (Step 2).
-        // Until then this branch is unreachable because no caller constructs
-        // a SELF_DEFINED kind via the factory.
-        throw new Error(
-          'SELF_DEFINED MCP integration factory branch not yet implemented (Step 2)',
-        );
+        return this.createSelfDefined(base, params);
       default: {
         // Exhaustiveness guard: if a new `McpIntegrationKind` is added, this
         // assignment fails to compile and points directly at this switch.
@@ -94,8 +110,6 @@ export class McpIntegrationFactory {
     }
   }
 
-  // OAuth client credentials are not threaded through this helper yet — they
-  // are set per-kind via `setOAuthClientCredentials()` in Steps 2 and 7.
   private extractBaseParams(params: CreateIntegrationParams) {
     return {
       id: params.id,
@@ -142,6 +156,22 @@ export class McpIntegrationFactory {
       logoUrl: params.logoUrl,
     });
   }
+
+  private createSelfDefined(
+    base: ReturnType<McpIntegrationFactory['extractBaseParams']>,
+    params: CreateIntegrationParams,
+  ): SelfDefinedMcpIntegration {
+    if (!params.configSchema) {
+      throw new Error('Self-defined integrations require a config schema');
+    }
+    return new SelfDefinedMcpIntegration({
+      ...base,
+      configSchema: params.configSchema,
+      orgConfigValues: params.orgConfigValues ?? {},
+      oauthClientId: params.oauthClientId,
+      oauthClientSecretEncrypted: params.oauthClientSecretEncrypted,
+    });
+  }
 }
 
 type CreateIntegrationParams = {
@@ -164,4 +194,6 @@ type CreateIntegrationParams = {
   lastConnectionCheck?: Date;
   returnsPii?: boolean;
   description?: string;
+  oauthClientId?: string;
+  oauthClientSecretEncrypted?: string;
 };

--- a/ayunis-core-backend/src/domain/mcp/application/mcp.errors.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/mcp.errors.ts
@@ -22,6 +22,12 @@ export enum McpErrorCode {
   MCP_NOT_MARKETPLACE_INTEGRATION = 'MCP_NOT_MARKETPLACE_INTEGRATION',
   MCP_NO_USER_FIELDS = 'MCP_NO_USER_FIELDS',
   MCP_INVALID_CONFIG_KEYS = 'MCP_INVALID_CONFIG_KEYS',
+  MCP_OAUTH_AUTHORIZATION_REQUIRED = 'MCP_OAUTH_AUTHORIZATION_REQUIRED',
+  MCP_OAUTH_STATE_INVALID = 'MCP_OAUTH_STATE_INVALID',
+  MCP_OAUTH_EXCHANGE_FAILED = 'MCP_OAUTH_EXCHANGE_FAILED',
+  MCP_INVALID_CONFIG_SCHEMA = 'MCP_INVALID_CONFIG_SCHEMA',
+  MCP_OAUTH_CLIENT_NOT_CONFIGURED = 'MCP_OAUTH_CLIENT_NOT_CONFIGURED',
+  MCP_AUTHORIZATION_HEADER_COLLISION = 'MCP_AUTHORIZATION_HEADER_COLLISION',
 }
 
 export abstract class McpError extends ApplicationError {
@@ -308,6 +314,74 @@ export class McpInvalidConfigKeysError extends McpError {
     super(
       `Unknown config keys: ${invalidKeys.join(', ')}`,
       McpErrorCode.MCP_INVALID_CONFIG_KEYS,
+      400,
+      metadata,
+    );
+  }
+}
+
+export class McpOAuthAuthorizationRequiredError extends McpError {
+  constructor(integrationId: string, metadata?: ErrorMetadata) {
+    super(
+      `OAuth authorization required for MCP integration ${integrationId}. The user must complete the OAuth authorization flow before using this integration.`,
+      McpErrorCode.MCP_OAUTH_AUTHORIZATION_REQUIRED,
+      412,
+      metadata,
+    );
+  }
+}
+
+export class McpOAuthStateInvalidError extends McpError {
+  constructor(metadata?: ErrorMetadata) {
+    super(
+      'Invalid or expired OAuth state token. Please restart the authorization flow.',
+      McpErrorCode.MCP_OAUTH_STATE_INVALID,
+      400,
+      metadata,
+    );
+  }
+}
+
+export class McpOAuthExchangeFailedError extends McpError {
+  constructor(reason: string, metadata?: ErrorMetadata) {
+    super(
+      `OAuth token exchange failed: ${reason}`,
+      McpErrorCode.MCP_OAUTH_EXCHANGE_FAILED,
+      502,
+      metadata,
+    );
+  }
+}
+
+export class McpInvalidConfigSchemaError extends McpError {
+  constructor(reason: string, field?: string, metadata?: ErrorMetadata) {
+    const fieldMsg = field ? ` (field: ${field})` : '';
+    const meta = field ? { ...metadata, field } : metadata;
+    super(
+      `Invalid config schema${fieldMsg}: ${reason}`,
+      McpErrorCode.MCP_INVALID_CONFIG_SCHEMA,
+      400,
+      meta,
+    );
+  }
+}
+
+export class McpOAuthClientNotConfiguredError extends McpError {
+  constructor(metadata?: ErrorMetadata) {
+    super(
+      'OAuth client credentials (clientId and clientSecret) are required when the config schema declares OAuth.',
+      McpErrorCode.MCP_OAUTH_CLIENT_NOT_CONFIGURED,
+      400,
+      metadata,
+    );
+  }
+}
+
+export class McpAuthorizationHeaderCollisionError extends McpError {
+  constructor(metadata?: ErrorMetadata) {
+    super(
+      'Config schema declares a field with headerName "Authorization" while OAuth is also configured. OAuth sets the Authorization header automatically — remove the conflicting field or disable OAuth.',
+      McpErrorCode.MCP_AUTHORIZATION_HEADER_COLLISION,
       400,
       metadata,
     );

--- a/ayunis-core-backend/src/domain/mcp/application/ports/mcp-integration-oauth-token.repository.port.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/ports/mcp-integration-oauth-token.repository.port.ts
@@ -1,0 +1,49 @@
+import type { UUID } from 'crypto';
+import type { McpIntegrationOAuthToken } from '../../domain/mcp-integration-oauth-token.entity';
+
+/**
+ * Repository port for MCP integration OAuth token persistence.
+ * Defines the contract for storing and retrieving OAuth tokens
+ * that are scoped to an integration and optionally a user.
+ */
+export abstract class McpIntegrationOAuthTokenRepositoryPort {
+  /**
+   * Finds an OAuth token by integration and user.
+   * Pass `null` for userId to find the org-level token.
+   * @param integrationId The integration ID
+   * @param userId The user ID, or null for org-level tokens
+   * @returns The token or null if not found
+   */
+  abstract findByIntegrationAndUser(
+    integrationId: UUID,
+    userId: UUID | null,
+  ): Promise<McpIntegrationOAuthToken | null>;
+
+  /**
+   * Saves an OAuth token (create or update).
+   * @param token The token entity to save
+   * @returns The saved token
+   */
+  abstract save(
+    token: McpIntegrationOAuthToken,
+  ): Promise<McpIntegrationOAuthToken>;
+
+  /**
+   * Deletes the OAuth token for a specific integration and user.
+   * Pass `null` for userId to delete the org-level token.
+   * @param integrationId The integration ID
+   * @param userId The user ID, or null for org-level tokens
+   */
+  abstract deleteByIntegrationAndUser(
+    integrationId: UUID,
+    userId: UUID | null,
+  ): Promise<void>;
+
+  /**
+   * Deletes all OAuth tokens for an integration (both org-level and per-user).
+   * Used during integration deletion for belt-and-suspenders cleanup
+   * alongside the FK CASCADE.
+   * @param integrationId The integration ID
+   */
+  abstract deleteAllByIntegration(integrationId: UUID): Promise<void>;
+}

--- a/ayunis-core-backend/src/domain/mcp/application/ports/mcp-oauth-state.port.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/ports/mcp-oauth-state.port.ts
@@ -1,0 +1,46 @@
+import type { UUID } from 'crypto';
+
+/**
+ * Payload signed into the OAuth state JWT during the authorization round-trip.
+ *
+ * The `codeVerifier` is stored here so that the callback handler can recover it
+ * without a server-side session. The JWT is signed with `MCP_OAUTH_STATE_SECRET`
+ * (HS256) and has a short TTL (typically 10 minutes).
+ */
+export interface McpOAuthAuthorizationState {
+  integrationId: UUID;
+  level: 'org' | 'user';
+  orgId: UUID;
+  userId: UUID | null;
+  codeVerifier: string;
+  redirectUri: string;
+  nonce: string;
+}
+
+/**
+ * Port for signing and verifying OAuth authorization state tokens.
+ *
+ * Implementations must produce a tamper-proof, time-limited token that
+ * round-trips the {@link McpOAuthAuthorizationState} payload. The canonical
+ * adapter uses a HS256 JWT via NestJS `JwtService`.
+ */
+export abstract class McpOAuthStatePort {
+  /**
+   * Signs the payload into a compact token string.
+   * @param payload The authorization state to sign
+   * @param ttlSeconds Time-to-live in seconds before the token expires
+   * @returns A signed, opaque token string
+   */
+  abstract sign(
+    payload: McpOAuthAuthorizationState,
+    ttlSeconds: number,
+  ): string;
+
+  /**
+   * Verifies and decodes a previously-signed state token.
+   * @param token The token string returned from {@link sign}
+   * @returns The decoded authorization state
+   * @throws McpOAuthStateInvalidError if the token is expired, malformed, or tampered
+   */
+  abstract verify(token: string): McpOAuthAuthorizationState;
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Enables creation of `SELF_DEFINED` integrations (including optional OAuth client credentials) and expands HTTP error mapping, which can change runtime behavior and error responses. New OAuth state/token ports and additional MCP error types introduce new contracts that downstream adapters must implement correctly.
> 
> **Overview**
> Adds application-layer contracts for MCP OAuth via new ports for OAuth *state token* signing/verification (`McpOAuthStatePort`) and OAuth *token persistence* (`McpIntegrationOAuthTokenRepositoryPort`).
> 
> Expands MCP error coverage with new OAuth/config-schema focused errors (including **`412 Precondition Failed`** for “authorization required” and **`502 Bad Gateway`** for exchange failures) and updates `ApplicationError.toHttpException()` to map `412` and `502` to proper NestJS exceptions.
> 
> Implements the previously-unhandled `McpIntegrationKind.SELF_DEFINED` branch in `McpIntegrationFactory`, allowing self-defined integrations to be created with a required `configSchema`, `orgConfigValues`, and optional OAuth client credentials; adds unit tests for the new factory behavior and validation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5192a391568af27e5512d8a4d52e010598fcaf91. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->