### PR TITLE
wip(mcp): add persistence records, mapper, and migration for self-defined + oauth tokens (AYC-110)

### DIFF
--- a/ayunis-core-backend/src/db/migrations/1775649274121-AddSelfDefinedMcpAndOAuthTokens.ts
+++ b/ayunis-core-backend/src/db/migrations/1775649274121-AddSelfDefinedMcpAndOAuthTokens.ts
@@ -1,0 +1,78 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddSelfDefinedMcpAndOAuthTokens1775649274121 implements MigrationInterface {
+  name = 'AddSelfDefinedMcpAndOAuthTokens1775649274121';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // 1. Add OAuth client credential columns to the base mcp_integrations table
+    await queryRunner.query(
+      `ALTER TABLE "mcp_integrations" ADD "oauth_client_id" character varying(255)`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "mcp_integrations" ADD "oauth_client_secret_encrypted" text`,
+    );
+
+    // 2. Create the OAuth token table
+    await queryRunner.query(
+      `CREATE TABLE "mcp_integration_oauth_tokens" (
+        "id" character varying NOT NULL,
+        "createdAt" TIMESTAMP NOT NULL DEFAULT now(),
+        "updatedAt" TIMESTAMP NOT NULL DEFAULT now(),
+        "integration_id" character varying NOT NULL,
+        "user_id" character varying,
+        "access_token_encrypted" text NOT NULL,
+        "refresh_token_encrypted" text,
+        "token_expires_at" TIMESTAMP,
+        "scope" text,
+        CONSTRAINT "PK_6cb5e52dee49b8e98018fdfd045" PRIMARY KEY ("id")
+      )`,
+    );
+
+    // 3. Standard indexes
+    await queryRunner.query(
+      `CREATE INDEX "idx_mcp_oauth_token_integration" ON "mcp_integration_oauth_tokens" ("integration_id")`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "idx_mcp_oauth_token_user" ON "mcp_integration_oauth_tokens" ("user_id")`,
+    );
+
+    // 4. Partial unique indexes — enforce (integration_id, user_id) uniqueness
+    //    with distinct handling for NULL user_id (org-level) vs non-NULL (per-user)
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX "uq_mcp_oauth_token_user" ON "mcp_integration_oauth_tokens" ("integration_id", "user_id") WHERE "user_id" IS NOT NULL`,
+    );
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX "uq_mcp_oauth_token_org" ON "mcp_integration_oauth_tokens" ("integration_id") WHERE "user_id" IS NULL`,
+    );
+
+    // 5. Foreign keys
+    await queryRunner.query(
+      `ALTER TABLE "mcp_integration_oauth_tokens" ADD CONSTRAINT "FK_mcp_oauth_token_integration" FOREIGN KEY ("integration_id") REFERENCES "mcp_integrations"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "mcp_integration_oauth_tokens" ADD CONSTRAINT "FK_mcp_oauth_token_user" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "mcp_integration_oauth_tokens" DROP CONSTRAINT "FK_mcp_oauth_token_user"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "mcp_integration_oauth_tokens" DROP CONSTRAINT "FK_mcp_oauth_token_integration"`,
+    );
+    await queryRunner.query(`DROP INDEX "public"."uq_mcp_oauth_token_org"`);
+    await queryRunner.query(`DROP INDEX "public"."uq_mcp_oauth_token_user"`);
+    await queryRunner.query(`DROP INDEX "public"."idx_mcp_oauth_token_user"`);
+    await queryRunner.query(
+      `DROP INDEX "public"."idx_mcp_oauth_token_integration"`,
+    );
+    await queryRunner.query(`DROP TABLE "mcp_integration_oauth_tokens"`);
+    await queryRunner.query(
+      `ALTER TABLE "mcp_integrations" DROP COLUMN "oauth_client_secret_encrypted"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "mcp_integrations" DROP COLUMN "oauth_client_id"`,
+    );
+  }
+}

--- a/ayunis-core-backend/src/domain/mcp/application/factories/mcp-integration.factory.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/factories/mcp-integration.factory.ts
@@ -64,6 +64,8 @@ export class McpIntegrationFactory {
     lastConnectionCheck?: Date;
     returnsPii?: boolean;
     description?: string;
+    oauthClientId?: string;
+    oauthClientSecretEncrypted?: string;
   }): MarketplaceMcpIntegration;
   createIntegration(params: {
     kind: McpIntegrationKind.SELF_DEFINED;
@@ -125,6 +127,8 @@ export class McpIntegrationFactory {
       lastConnectionCheck: params.lastConnectionCheck,
       returnsPii: params.returnsPii,
       description: params.description,
+      oauthClientId: params.oauthClientId,
+      oauthClientSecretEncrypted: params.oauthClientSecretEncrypted,
     } as const;
   }
 
@@ -168,8 +172,6 @@ export class McpIntegrationFactory {
       ...base,
       configSchema: params.configSchema,
       orgConfigValues: params.orgConfigValues ?? {},
-      oauthClientId: params.oauthClientId,
-      oauthClientSecretEncrypted: params.oauthClientSecretEncrypted,
     });
   }
 }

--- a/ayunis-core-backend/src/domain/mcp/infrastructure/persistence/postgres/mappers/mcp-integration.mapper.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/infrastructure/persistence/postgres/mappers/mcp-integration.mapper.spec.ts
@@ -3,6 +3,7 @@ import { McpIntegrationMapper } from './mcp-integration.mapper';
 import { CustomMcpIntegration } from '../../../../domain/integrations/custom-mcp-integration.entity';
 import { PredefinedMcpIntegration } from '../../../../domain/integrations/predefined-mcp-integration.entity';
 import { MarketplaceMcpIntegration } from '../../../../domain/integrations/marketplace-mcp-integration.entity';
+import { SelfDefinedMcpIntegration } from '../../../../domain/integrations/self-defined-mcp-integration.entity';
 import { McpIntegrationKind } from '../../../../domain/value-objects/mcp-integration-kind.enum';
 import { PredefinedMcpIntegrationSlug } from '../../../../domain/value-objects/predefined-mcp-integration-slug.enum';
 import type { IntegrationConfigSchema } from '../../../../domain/value-objects/integration-config-schema';
@@ -17,6 +18,7 @@ import {
   CustomHeaderMcpIntegrationAuthRecord,
   CustomMcpIntegrationRecord,
   MarketplaceMcpIntegrationRecord,
+  SelfDefinedMcpIntegrationRecord,
   NoAuthMcpIntegrationAuthRecord,
   OAuthMcpIntegrationAuthRecord,
   PredefinedMcpIntegrationRecord,
@@ -359,5 +361,160 @@ describe('McpIntegrationMapper', () => {
     expect(marketplace.logoUrl).toBe(
       'https://marketplace.ayunis.de/logos/oparl.png',
     );
+  });
+
+  const selfDefinedConfigSchema: IntegrationConfigSchema = {
+    authType: 'NO_AUTH',
+    orgFields: [
+      {
+        key: 'apiUrl',
+        type: 'url',
+        label: 'API URL',
+        headerName: 'X-Api-Url',
+        required: true,
+      },
+    ],
+    userFields: [],
+  };
+
+  describe('toRecord — self-defined', () => {
+    it('maps self-defined integration with config schema and org config values', () => {
+      const auth = new NoAuthMcpIntegrationAuth();
+      const integration = new SelfDefinedMcpIntegration({
+        ...baseParams,
+        auth,
+        configSchema: selfDefinedConfigSchema,
+        orgConfigValues: { apiUrl: 'https://api.example.com' },
+      });
+
+      const record = mapper.toRecord(integration);
+
+      expect(record).toBeInstanceOf(SelfDefinedMcpIntegrationRecord);
+      const sdRecord = record as SelfDefinedMcpIntegrationRecord;
+      expect(sdRecord.configSchema).toEqual(selfDefinedConfigSchema);
+      expect(sdRecord.orgConfigValues).toEqual({
+        apiUrl: 'https://api.example.com',
+      });
+      expect(record.auth).toBeInstanceOf(NoAuthMcpIntegrationAuthRecord);
+    });
+  });
+
+  describe('toDomain — self-defined', () => {
+    it('maps self-defined integration record to domain entity', () => {
+      const record = new SelfDefinedMcpIntegrationRecord();
+      record.id = randomUUID();
+      record.orgId = baseParams.orgId;
+      record.name = 'Self Defined Integration';
+      record.serverUrl = 'https://mcp.example.com';
+      record.configSchema = selfDefinedConfigSchema;
+      record.orgConfigValues = { apiUrl: 'https://api.example.com' };
+      record.enabled = true;
+      record.connectionStatus = 'pending';
+      record.createdAt = baseParams.createdAt;
+      record.updatedAt = baseParams.updatedAt;
+
+      const authRecord = new NoAuthMcpIntegrationAuthRecord();
+      authRecord.id = randomUUID();
+      authRecord.integrationId = record.id;
+      authRecord.createdAt = baseParams.createdAt;
+      authRecord.updatedAt = baseParams.updatedAt;
+      authRecord.integration = record;
+      record.auth = authRecord;
+
+      const domain = mapper.toDomain(record);
+
+      expect(domain).toBeInstanceOf(SelfDefinedMcpIntegration);
+      expect(domain.kind).toBe(McpIntegrationKind.SELF_DEFINED);
+      const sd = domain as SelfDefinedMcpIntegration;
+      expect(sd.configSchema).toEqual(selfDefinedConfigSchema);
+      expect(sd.orgConfigValues).toEqual({
+        apiUrl: 'https://api.example.com',
+      });
+      expect(domain.auth).toBeInstanceOf(NoAuthMcpIntegrationAuth);
+    });
+  });
+
+  it('round-trips a self-defined integration through record mapping', () => {
+    const auth = new NoAuthMcpIntegrationAuth();
+    const original = new SelfDefinedMcpIntegration({
+      ...baseParams,
+      auth,
+      configSchema: selfDefinedConfigSchema,
+      orgConfigValues: { apiUrl: 'https://api.example.com' },
+    });
+
+    const record = mapper.toRecord(original);
+    const reconstructed = mapper.toDomain(record);
+
+    expect(reconstructed.kind).toBe(McpIntegrationKind.SELF_DEFINED);
+    const sd = reconstructed as SelfDefinedMcpIntegration;
+    expect(sd.configSchema).toEqual(selfDefinedConfigSchema);
+    expect(sd.orgConfigValues).toEqual({
+      apiUrl: 'https://api.example.com',
+    });
+  });
+
+  describe('OAuth base columns', () => {
+    it('round-trips OAuth client credentials on a marketplace integration', () => {
+      const auth = new NoAuthMcpIntegrationAuth();
+      const original = new MarketplaceMcpIntegration({
+        ...baseParams,
+        auth,
+        marketplaceIdentifier: 'oauth-mcp',
+        configSchema: oparlConfigSchema,
+        orgConfigValues: {},
+        oauthClientId: 'my-client-id',
+        oauthClientSecretEncrypted: 'encrypted-secret',
+      });
+
+      const record = mapper.toRecord(original);
+      expect(record.oauthClientId).toBe('my-client-id');
+      expect(record.oauthClientSecretEncrypted).toBe('encrypted-secret');
+
+      const reconstructed = mapper.toDomain(record);
+      expect(reconstructed.oauthClientId).toBe('my-client-id');
+      expect(reconstructed.oauthClientSecretEncrypted).toBe('encrypted-secret');
+    });
+
+    it('round-trips OAuth client credentials on a self-defined integration', () => {
+      const auth = new NoAuthMcpIntegrationAuth();
+      const original = new SelfDefinedMcpIntegration({
+        ...baseParams,
+        auth,
+        configSchema: selfDefinedConfigSchema,
+        orgConfigValues: {},
+        oauthClientId: 'sd-client-id',
+        oauthClientSecretEncrypted: 'sd-encrypted-secret',
+      });
+
+      const record = mapper.toRecord(original);
+      expect(record.oauthClientId).toBe('sd-client-id');
+      expect(record.oauthClientSecretEncrypted).toBe('sd-encrypted-secret');
+
+      const reconstructed = mapper.toDomain(record);
+      expect(reconstructed.oauthClientId).toBe('sd-client-id');
+      expect(reconstructed.oauthClientSecretEncrypted).toBe(
+        'sd-encrypted-secret',
+      );
+    });
+
+    it('preserves undefined OAuth client credentials', () => {
+      const auth = new NoAuthMcpIntegrationAuth();
+      const original = new MarketplaceMcpIntegration({
+        ...baseParams,
+        auth,
+        marketplaceIdentifier: 'no-oauth-mcp',
+        configSchema: oparlConfigSchema,
+        orgConfigValues: {},
+      });
+
+      const record = mapper.toRecord(original);
+      expect(record.oauthClientId).toBeUndefined();
+      expect(record.oauthClientSecretEncrypted).toBeUndefined();
+
+      const reconstructed = mapper.toDomain(record);
+      expect(reconstructed.oauthClientId).toBeUndefined();
+      expect(reconstructed.oauthClientSecretEncrypted).toBeUndefined();
+    });
   });
 });

--- a/ayunis-core-backend/src/domain/mcp/infrastructure/persistence/postgres/mappers/mcp-integration.mapper.ts
+++ b/ayunis-core-backend/src/domain/mcp/infrastructure/persistence/postgres/mappers/mcp-integration.mapper.ts
@@ -3,6 +3,7 @@ import { McpIntegration } from '../../../../domain/mcp-integration.entity';
 import { CustomMcpIntegration } from '../../../../domain/integrations/custom-mcp-integration.entity';
 import { PredefinedMcpIntegration } from '../../../../domain/integrations/predefined-mcp-integration.entity';
 import { MarketplaceMcpIntegration } from '../../../../domain/integrations/marketplace-mcp-integration.entity';
+import { SelfDefinedMcpIntegration } from '../../../../domain/integrations/self-defined-mcp-integration.entity';
 import { McpIntegrationAuth } from '../../../../domain/auth/mcp-integration-auth.entity';
 import { NoAuthMcpIntegrationAuth } from '../../../../domain/auth/no-auth-mcp-integration-auth.entity';
 import { BearerMcpIntegrationAuth } from '../../../../domain/auth/bearer-mcp-integration-auth.entity';
@@ -17,6 +18,7 @@ import {
   CustomHeaderMcpIntegrationAuthRecord,
   CustomMcpIntegrationRecord,
   MarketplaceMcpIntegrationRecord,
+  SelfDefinedMcpIntegrationRecord,
   McpIntegrationAuthRecord,
   NoAuthMcpIntegrationAuthRecord,
   OAuthMcpIntegrationAuthRecord,
@@ -51,6 +53,9 @@ export class McpIntegrationMapper {
     if (record instanceof MarketplaceMcpIntegrationRecord) {
       return this.marketplaceToDomain(base, record);
     }
+    if (record instanceof SelfDefinedMcpIntegrationRecord) {
+      return this.selfDefinedToDomain(base, record);
+    }
     throw new Error(
       `Unknown MCP integration record type: ${record.constructor.name}`,
     );
@@ -67,6 +72,9 @@ export class McpIntegrationMapper {
     }
     if (entity instanceof MarketplaceMcpIntegration) {
       return this.marketplaceToRecord(entity, authRecord);
+    }
+    if (entity instanceof SelfDefinedMcpIntegration) {
+      return this.selfDefinedToRecord(entity, authRecord);
     }
     throw new Error(
       `Unknown MCP integration entity type: ${entity.constructor.name}`,
@@ -91,6 +99,8 @@ export class McpIntegrationMapper {
       lastConnectionCheck: record.lastConnectionCheck,
       returnsPii: record.returnsPii,
       description: record.description,
+      oauthClientId: record.oauthClientId,
+      oauthClientSecretEncrypted: record.oauthClientSecretEncrypted,
     } as const;
   }
 
@@ -145,6 +155,8 @@ export class McpIntegrationMapper {
     record.lastConnectionCheck = entity.lastConnectionCheck;
     record.returnsPii = entity.returnsPii;
     record.description = entity.description;
+    record.oauthClientId = entity.oauthClientId;
+    record.oauthClientSecretEncrypted = entity.oauthClientSecretEncrypted;
     record.auth = authRecord;
     authRecord.integration = record;
   }
@@ -178,6 +190,29 @@ export class McpIntegrationMapper {
     record.configSchema = entity.configSchema;
     record.orgConfigValues = entity.orgConfigValues;
     record.logoUrl = entity.logoUrl;
+    return record;
+  }
+
+  private selfDefinedToDomain(
+    base: ReturnType<McpIntegrationMapper['extractBaseFromRecord']>,
+    record: SelfDefinedMcpIntegrationRecord,
+  ): McpIntegration {
+    return this.integrationFactory.createIntegration({
+      kind: McpIntegrationKind.SELF_DEFINED,
+      ...base,
+      configSchema: record.configSchema,
+      orgConfigValues: record.orgConfigValues,
+    });
+  }
+
+  private selfDefinedToRecord(
+    entity: SelfDefinedMcpIntegration,
+    authRecord: McpIntegrationAuthRecord,
+  ): SelfDefinedMcpIntegrationRecord {
+    const record = new SelfDefinedMcpIntegrationRecord();
+    this.applyBaseToRecord(record, entity, authRecord);
+    record.configSchema = entity.configSchema;
+    record.orgConfigValues = entity.orgConfigValues;
     return record;
   }
 

--- a/ayunis-core-backend/src/domain/mcp/infrastructure/persistence/postgres/schema/index.ts
+++ b/ayunis-core-backend/src/domain/mcp/infrastructure/persistence/postgres/schema/index.ts
@@ -2,6 +2,7 @@ export { McpIntegrationRecord } from './mcp-integration.record';
 export { CustomMcpIntegrationRecord } from './custom-mcp-integration.record';
 export { PredefinedMcpIntegrationRecord } from './predefined-mcp-integration.record';
 export { MarketplaceMcpIntegrationRecord } from './marketplace-mcp-integration.record';
+export { SelfDefinedMcpIntegrationRecord } from './self-defined-mcp-integration.record';
 
 export { McpIntegrationAuthRecord } from './mcp-integration-auth.record';
 export { NoAuthMcpIntegrationAuthRecord } from './no-auth-mcp-integration-auth.record';
@@ -10,3 +11,4 @@ export { CustomHeaderMcpIntegrationAuthRecord } from './custom-header-mcp-integr
 export { OAuthMcpIntegrationAuthRecord } from './oauth-mcp-integration-auth.record';
 
 export { McpIntegrationUserConfigRecord } from './mcp-integration-user-config.record';
+export { McpIntegrationOAuthTokenRecord } from './mcp-integration-oauth-token.record';

--- a/ayunis-core-backend/src/domain/mcp/infrastructure/persistence/postgres/schema/mcp-integration-oauth-token.record.ts
+++ b/ayunis-core-backend/src/domain/mcp/infrastructure/persistence/postgres/schema/mcp-integration-oauth-token.record.ts
@@ -1,0 +1,39 @@
+import { Column, Entity, Index, JoinColumn, ManyToOne } from 'typeorm';
+import { BaseRecord } from '../../../../../../common/db/base-record';
+import { UUID } from 'crypto';
+import { McpIntegrationRecord } from './mcp-integration.record';
+
+/**
+ * Partial unique indexes (uq_mcp_oauth_token_user WHERE user_id IS NOT NULL,
+ * uq_mcp_oauth_token_org WHERE user_id IS NULL) are migration-only because
+ * TypeORM decorators cannot express partial indexes.
+ *
+ * The FK from user_id → users is also migration-only to avoid a cross-domain
+ * import. Only integration has a decorator-based relation (@ManyToOne).
+ */
+@Entity('mcp_integration_oauth_tokens')
+@Index('idx_mcp_oauth_token_integration', ['integrationId'])
+@Index('idx_mcp_oauth_token_user', ['userId'])
+export class McpIntegrationOAuthTokenRecord extends BaseRecord {
+  @Column({ name: 'integration_id', type: 'varchar' })
+  integrationId: UUID;
+
+  @Column({ name: 'user_id', type: 'varchar', nullable: true })
+  userId: UUID | null;
+
+  @Column({ name: 'access_token_encrypted', type: 'text' })
+  accessTokenEncrypted: string;
+
+  @Column({ name: 'refresh_token_encrypted', type: 'text', nullable: true })
+  refreshTokenEncrypted: string | null;
+
+  @Column({ name: 'token_expires_at', type: 'timestamp', nullable: true })
+  tokenExpiresAt: Date | null;
+
+  @Column({ type: 'text', nullable: true })
+  scope: string | null;
+
+  @ManyToOne(() => McpIntegrationRecord, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'integration_id' })
+  integration?: McpIntegrationRecord;
+}

--- a/ayunis-core-backend/src/domain/mcp/infrastructure/persistence/postgres/schema/mcp-integration.record.ts
+++ b/ayunis-core-backend/src/domain/mcp/infrastructure/persistence/postgres/schema/mcp-integration.record.ts
@@ -33,6 +33,21 @@ export abstract class McpIntegrationRecord extends BaseRecord {
   @Column({ type: 'text', nullable: true })
   description?: string;
 
+  @Column({
+    name: 'oauth_client_id',
+    type: 'varchar',
+    length: 255,
+    nullable: true,
+  })
+  oauthClientId?: string;
+
+  @Column({
+    name: 'oauth_client_secret_encrypted',
+    type: 'text',
+    nullable: true,
+  })
+  oauthClientSecretEncrypted?: string;
+
   @OneToOne(() => McpIntegrationAuthRecord, (auth) => auth.integration, {
     cascade: ['insert', 'update'],
     eager: true,

--- a/ayunis-core-backend/src/domain/mcp/infrastructure/persistence/postgres/schema/self-defined-mcp-integration.record.ts
+++ b/ayunis-core-backend/src/domain/mcp/infrastructure/persistence/postgres/schema/self-defined-mcp-integration.record.ts
@@ -1,0 +1,13 @@
+import { ChildEntity, Column } from 'typeorm';
+import { McpIntegrationRecord } from './mcp-integration.record';
+import { McpIntegrationKind } from '../../../../domain/value-objects/mcp-integration-kind.enum';
+import { IntegrationConfigSchema } from '../../../../domain/value-objects/integration-config-schema';
+
+@ChildEntity(McpIntegrationKind.SELF_DEFINED)
+export class SelfDefinedMcpIntegrationRecord extends McpIntegrationRecord {
+  @Column({ name: 'config_schema', type: 'jsonb' })
+  configSchema: IntegrationConfigSchema;
+
+  @Column({ name: 'org_config_values', type: 'jsonb', default: '{}' })
+  orgConfigValues: Record<string, string>;
+}

--- a/ayunis-core-backend/src/domain/mcp/mcp.module.ts
+++ b/ayunis-core-backend/src/domain/mcp/mcp.module.ts
@@ -18,11 +18,13 @@ import {
   CustomMcpIntegrationRecord,
   MarketplaceMcpIntegrationRecord,
   McpIntegrationAuthRecord,
+  McpIntegrationOAuthTokenRecord,
   McpIntegrationRecord,
   McpIntegrationUserConfigRecord,
   NoAuthMcpIntegrationAuthRecord,
   OAuthMcpIntegrationAuthRecord,
   PredefinedMcpIntegrationRecord,
+  SelfDefinedMcpIntegrationRecord,
 } from './infrastructure/persistence/postgres/schema';
 import { McpIntegrationMapper } from './infrastructure/persistence/postgres/mappers/mcp-integration.mapper';
 import { McpIntegrationFactory } from './application/factories/mcp-integration.factory';
@@ -69,6 +71,8 @@ import { PredefinedConfigDtoMapper } from './presenters/http/mappers/predefined-
       CustomHeaderMcpIntegrationAuthRecord,
       OAuthMcpIntegrationAuthRecord,
       McpIntegrationUserConfigRecord,
+      SelfDefinedMcpIntegrationRecord,
+      McpIntegrationOAuthTokenRecord,
     ]),
     SourcesModule, // Import sources module for CreateDataSourceUseCase
     MarketplaceModule,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces new DB tables/columns and mapper logic for storing OAuth client credentials and per-user/org OAuth tokens, which affects persistence and encrypted secret handling. Risk is mainly around migration correctness and ensuring token/credential data is written/read as intended.
> 
> **Overview**
> Adds persistence support for **self-defined MCP integrations** and **OAuth credential/token storage**.
> 
> A new migration extends `mcp_integrations` with `oauth_client_id`/`oauth_client_secret_encrypted` and creates `mcp_integration_oauth_tokens` with indexes, partial unique constraints (org-level vs user-level), and cascading FKs.
> 
> TypeORM persistence is updated with new records (`SelfDefinedMcpIntegrationRecord`, `McpIntegrationOAuthTokenRecord`), mapper support to round-trip self-defined config schema/org config values, and base mapping for OAuth client credentials across integration kinds, with corresponding unit tests and module registration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a8ae4e8678e2cd807ffda68261da807420f7de3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->