### PR TITLE
wip(mcp): add oauth infrastructure adapters and module wiring (AYC-110)

### DIFF
--- a/ayunis-core-backend/.env.example
+++ b/ayunis-core-backend/.env.example
@@ -134,6 +134,12 @@ BRAVE_SEARCH_API_KEY=
 # Required for MCP integration credential encryption
 # Generate a secure key with: openssl rand -hex 32
 MCP_ENCRYPTION_KEY=
+# Required for OAuth state JWT signing during the MCP OAuth authorization flow.
+# Generate with: openssl rand -base64 32
+MCP_OAUTH_STATE_SECRET=
+# Public URL of the backend, used for OAuth redirect URIs.
+# Must be reachable by the browser (not just internally).
+BACKEND_BASEURL=http://localhost:3000
 
 # Locaboo 4 URL
 # Required for Locaboo 4 MCP server integration

--- a/ayunis-core-backend/src/config/app.config.ts
+++ b/ayunis-core-backend/src/config/app.config.ts
@@ -1,6 +1,27 @@
 import { registerAs } from '@nestjs/config';
 
+function getMcpOAuthStateSecret(): string {
+  const secret = process.env.MCP_OAUTH_STATE_SECRET;
+  if (secret) return secret;
+
+  const env = process.env.NODE_ENV;
+  if (env === 'development' || env === 'test') {
+    return 'dev-mcp-oauth-state-secret';
+  }
+
+  throw new Error(
+    'MCP_OAUTH_STATE_SECRET environment variable is not configured. ' +
+      'Set a strong random secret for signing OAuth state tokens.',
+  );
+}
+
 export const appConfig = registerAs('app', () => ({
+  backend: {
+    baseUrl: process.env.BACKEND_BASEURL ?? 'http://localhost:3000',
+  },
+  mcp: {
+    oauthStateSecret: getMcpOAuthStateSecret(),
+  },
   port: process.env.PORT || 3000,
   disableRegistration: process.env.DISABLE_REGISTRATION === 'true',
   isSelfHosted: process.env.APP_ENVIRONMENT === 'self-hosted',

--- a/ayunis-core-backend/src/domain/mcp/infrastructure/oauth/jwt-oauth-state.adapter.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/infrastructure/oauth/jwt-oauth-state.adapter.spec.ts
@@ -1,0 +1,96 @@
+import { JwtService } from '@nestjs/jwt';
+import { randomUUID } from 'crypto';
+import type { McpOAuthAuthorizationState } from '../../application/ports/mcp-oauth-state.port';
+import { JwtOAuthStateAdapter } from './jwt-oauth-state.adapter';
+import { McpOAuthStateInvalidError } from '../../application/mcp.errors';
+
+describe('JwtOAuthStateAdapter', () => {
+  const secret = 'test-secret-for-oauth-state-signing';
+  let adapter: JwtOAuthStateAdapter;
+
+  const buildPayload = (): McpOAuthAuthorizationState => ({
+    integrationId: randomUUID(),
+    level: 'org',
+    orgId: randomUUID(),
+    userId: null,
+    codeVerifier: 'test-code-verifier-abc123',
+    redirectUri: 'http://localhost:3000/mcp-integrations/oauth/callback',
+    nonce: 'test-nonce-xyz',
+  });
+
+  beforeEach(() => {
+    const jwtService = new JwtService({ secret });
+    adapter = new JwtOAuthStateAdapter(jwtService);
+  });
+
+  it('should round-trip sign and verify a payload', () => {
+    const payload = buildPayload();
+    const token = adapter.sign(payload, 600);
+
+    expect(typeof token).toBe('string');
+    expect(token.split('.')).toHaveLength(3); // JWT format
+
+    const decoded = adapter.verify(token);
+
+    expect(decoded).toEqual(payload);
+  });
+
+  it('should round-trip a user-level payload with non-null userId', () => {
+    const payload: McpOAuthAuthorizationState = {
+      ...buildPayload(),
+      level: 'user',
+      userId: randomUUID(),
+    };
+
+    const token = adapter.sign(payload, 600);
+    const decoded = adapter.verify(token);
+
+    expect(decoded).toEqual(payload);
+  });
+
+  it('should throw McpOAuthStateInvalidError on expired token', async () => {
+    const payload = buildPayload();
+
+    // Sign with a 1-second TTL
+    const jwtService = new JwtService({ secret });
+    const shortLivedAdapter = new JwtOAuthStateAdapter(jwtService);
+    const token = shortLivedAdapter.sign(payload, 1);
+
+    // Wait for expiry
+    await new Promise((resolve) => setTimeout(resolve, 1100));
+
+    expect(() => shortLivedAdapter.verify(token)).toThrow(
+      McpOAuthStateInvalidError,
+    );
+  });
+
+  it('should throw McpOAuthStateInvalidError on tampered token', () => {
+    const payload = buildPayload();
+    const token = adapter.sign(payload, 600);
+
+    // Tamper with the payload section
+    const parts = token.split('.');
+    parts[1] = parts[1] + 'TAMPERED';
+    const tamperedToken = parts.join('.');
+
+    expect(() => adapter.verify(tamperedToken)).toThrow(
+      McpOAuthStateInvalidError,
+    );
+  });
+
+  it('should throw McpOAuthStateInvalidError on token signed with different secret', () => {
+    const payload = buildPayload();
+
+    const otherJwtService = new JwtService({ secret: 'different-secret' });
+    const otherAdapter = new JwtOAuthStateAdapter(otherJwtService);
+    const token = otherAdapter.sign(payload, 600);
+
+    expect(() => adapter.verify(token)).toThrow(McpOAuthStateInvalidError);
+  });
+
+  it('should throw McpOAuthStateInvalidError on malformed token', () => {
+    expect(() => adapter.verify('not-a-jwt')).toThrow(
+      McpOAuthStateInvalidError,
+    );
+  });
+});

--- a/ayunis-core-backend/src/domain/mcp/infrastructure/oauth/jwt-oauth-state.adapter.ts
+++ b/ayunis-core-backend/src/domain/mcp/infrastructure/oauth/jwt-oauth-state.adapter.ts
@@ -1,0 +1,59 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+import type { McpOAuthAuthorizationState } from '../../application/ports/mcp-oauth-state.port';
+import { McpOAuthStatePort } from '../../application/ports/mcp-oauth-state.port';
+import { McpOAuthStateInvalidError } from '../../application/mcp.errors';
+
+/**
+ * JWT-based implementation of {@link McpOAuthStatePort}.
+ *
+ * Signs the OAuth authorization state into a HS256 JWT using the
+ * `MCP_OAUTH_STATE_SECRET` key configured in the module's JwtModule.
+ * The token carries the full {@link McpOAuthAuthorizationState} as its
+ * payload, including the PKCE `codeVerifier`, so no server-side session
+ * is needed for the OAuth callback.
+ */
+@Injectable()
+export class JwtOAuthStateAdapter extends McpOAuthStatePort {
+  private readonly logger = new Logger(JwtOAuthStateAdapter.name);
+
+  constructor(private readonly jwtService: JwtService) {
+    super();
+  }
+
+  sign(payload: McpOAuthAuthorizationState, ttlSeconds: number): string {
+    this.logger.log('sign', {
+      integrationId: payload.integrationId,
+      level: payload.level,
+    });
+
+    return this.jwtService.sign({ ...payload }, { expiresIn: ttlSeconds });
+  }
+
+  verify(token: string): McpOAuthAuthorizationState {
+    this.logger.log('verify');
+
+    try {
+      const decoded = this.jwtService.verify<McpOAuthAuthorizationState>(token);
+
+      // Explicitly pick domain fields to strip standard JWT claims (iat, exp, etc.)
+      // that JwtService.verify() adds to the decoded object. If new fields are added
+      // to McpOAuthAuthorizationState, they must be added here too.
+      return {
+        integrationId: decoded.integrationId,
+        level: decoded.level,
+        orgId: decoded.orgId,
+        userId: decoded.userId,
+        codeVerifier: decoded.codeVerifier,
+        redirectUri: decoded.redirectUri,
+        nonce: decoded.nonce,
+      };
+    } catch (error: unknown) {
+      this.logger.warn('OAuth state token verification failed', {
+        error,
+      });
+
+      throw new McpOAuthStateInvalidError();
+    }
+  }
+}

--- a/ayunis-core-backend/src/domain/mcp/infrastructure/persistence/postgres/mcp-integration-oauth-token.repository.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/infrastructure/persistence/postgres/mcp-integration-oauth-token.repository.spec.ts
@@ -1,0 +1,222 @@
+import { randomUUID } from 'crypto';
+import { IsNull } from 'typeorm';
+import type { Repository } from 'typeorm';
+import { McpIntegrationOAuthTokenRepository } from './mcp-integration-oauth-token.repository';
+import { McpIntegrationOAuthTokenRecord } from './schema/mcp-integration-oauth-token.record';
+import { McpIntegrationOAuthToken } from '../../../domain/mcp-integration-oauth-token.entity';
+
+class MockQueryBuilder {
+  private conditions: { where?: string; params?: Record<string, unknown> }[] =
+    [];
+  delete = jest.fn().mockReturnThis();
+  where = jest.fn((condition: string, params?: Record<string, unknown>) => {
+    this.conditions.push({ where: condition, params });
+    return this;
+  });
+  andWhere = jest.fn((condition: string, params?: Record<string, unknown>) => {
+    this.conditions.push({ where: condition, params });
+    return this;
+  });
+  execute = jest.fn().mockResolvedValue({ affected: 1, raw: [] });
+}
+
+describe('McpIntegrationOAuthTokenRepository', () => {
+  let repository: McpIntegrationOAuthTokenRepository;
+  let mockTypeOrmRepo: jest.Mocked<Repository<McpIntegrationOAuthTokenRecord>>;
+
+  const integrationId = randomUUID();
+  const userId = randomUUID();
+  const tokenId = randomUUID();
+  const now = new Date('2026-01-15T10:00:00.000Z');
+
+  beforeEach(() => {
+    mockTypeOrmRepo = {
+      save: jest.fn(),
+      findOne: jest.fn(),
+      delete: jest.fn(),
+      createQueryBuilder: jest.fn().mockReturnValue(new MockQueryBuilder()),
+    } as unknown as jest.Mocked<Repository<McpIntegrationOAuthTokenRecord>>;
+
+    repository = new McpIntegrationOAuthTokenRepository(mockTypeOrmRepo);
+  });
+
+  const buildToken = (overrides?: Partial<McpIntegrationOAuthToken>) =>
+    new McpIntegrationOAuthToken({
+      id: tokenId,
+      integrationId,
+      userId,
+      accessTokenEncrypted: 'encrypted-access-token',
+      refreshTokenEncrypted: 'encrypted-refresh-token',
+      tokenExpiresAt: new Date('2026-01-15T11:00:00.000Z'),
+      scope: 'read write',
+      createdAt: now,
+      updatedAt: now,
+      ...overrides,
+    });
+
+  const buildRecord = (): McpIntegrationOAuthTokenRecord => {
+    const record = new McpIntegrationOAuthTokenRecord();
+    record.id = tokenId;
+    record.integrationId = integrationId;
+    record.userId = userId;
+    record.accessTokenEncrypted = 'encrypted-access-token';
+    record.refreshTokenEncrypted = 'encrypted-refresh-token';
+    record.tokenExpiresAt = new Date('2026-01-15T11:00:00.000Z');
+    record.scope = 'read write';
+    record.createdAt = now;
+    record.updatedAt = now;
+    return record;
+  };
+
+  describe('save', () => {
+    it('should persist token and return domain entity', async () => {
+      const token = buildToken();
+      const savedRecord = buildRecord();
+      mockTypeOrmRepo.save.mockResolvedValue(savedRecord);
+
+      const result = await repository.save(token);
+
+      expect(mockTypeOrmRepo.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: tokenId,
+          integrationId,
+          userId,
+          accessTokenEncrypted: 'encrypted-access-token',
+          refreshTokenEncrypted: 'encrypted-refresh-token',
+        }),
+      );
+      expect(result).toBeInstanceOf(McpIntegrationOAuthToken);
+      expect(result.id).toBe(tokenId);
+      expect(result.accessTokenEncrypted).toBe('encrypted-access-token');
+    });
+
+    it('should handle org-level token (null userId)', async () => {
+      const token = buildToken({ userId: null });
+      const record = buildRecord();
+      record.userId = null;
+      mockTypeOrmRepo.save.mockResolvedValue(record);
+
+      const result = await repository.save(token);
+
+      expect(mockTypeOrmRepo.save).toHaveBeenCalledWith(
+        expect.objectContaining({ userId: null }),
+      );
+      expect(result.userId).toBeNull();
+    });
+
+    it('should handle token without optional fields', async () => {
+      const token = buildToken({
+        refreshTokenEncrypted: undefined,
+        tokenExpiresAt: undefined,
+        scope: undefined,
+      });
+      const record = buildRecord();
+      record.refreshTokenEncrypted = null;
+      record.tokenExpiresAt = null;
+      record.scope = null;
+      mockTypeOrmRepo.save.mockResolvedValue(record);
+
+      const result = await repository.save(token);
+
+      expect(mockTypeOrmRepo.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          refreshTokenEncrypted: null,
+          tokenExpiresAt: null,
+          scope: null,
+        }),
+      );
+      expect(result.refreshTokenEncrypted).toBeUndefined();
+      expect(result.tokenExpiresAt).toBeUndefined();
+      expect(result.scope).toBeUndefined();
+    });
+  });
+
+  describe('findByIntegrationAndUser', () => {
+    it('should return domain entity for user-level token', async () => {
+      const record = buildRecord();
+      mockTypeOrmRepo.findOne.mockResolvedValue(record);
+
+      const result = await repository.findByIntegrationAndUser(
+        integrationId,
+        userId,
+      );
+
+      expect(mockTypeOrmRepo.findOne).toHaveBeenCalledWith({
+        where: { integrationId, userId },
+      });
+      expect(result).toBeInstanceOf(McpIntegrationOAuthToken);
+      expect(result?.integrationId).toBe(integrationId);
+      expect(result?.userId).toBe(userId);
+    });
+
+    it('should query with IS NULL for org-level token', async () => {
+      const record = buildRecord();
+      record.userId = null;
+      mockTypeOrmRepo.findOne.mockResolvedValue(record);
+
+      const result = await repository.findByIntegrationAndUser(
+        integrationId,
+        null,
+      );
+
+      expect(mockTypeOrmRepo.findOne).toHaveBeenCalledWith({
+        where: { integrationId, userId: IsNull() },
+      });
+      expect(result).toBeInstanceOf(McpIntegrationOAuthToken);
+      expect(result?.userId).toBeNull();
+    });
+
+    it('should return null when no token exists', async () => {
+      mockTypeOrmRepo.findOne.mockResolvedValue(null);
+
+      const result = await repository.findByIntegrationAndUser(
+        integrationId,
+        userId,
+      );
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('deleteByIntegrationAndUser', () => {
+    it('should delete by integrationId and userId', async () => {
+      const qb = new MockQueryBuilder();
+      mockTypeOrmRepo.createQueryBuilder = jest.fn().mockReturnValue(qb);
+
+      await repository.deleteByIntegrationAndUser(integrationId, userId);
+
+      expect(qb.delete).toHaveBeenCalled();
+      expect(qb.where).toHaveBeenCalledWith('integration_id = :integrationId', {
+        integrationId,
+      });
+      expect(qb.andWhere).toHaveBeenCalledWith('user_id = :userId', {
+        userId,
+      });
+      expect(qb.execute).toHaveBeenCalled();
+    });
+
+    it('should delete with IS NULL for org-level token', async () => {
+      const qb = new MockQueryBuilder();
+      mockTypeOrmRepo.createQueryBuilder = jest.fn().mockReturnValue(qb);
+
+      await repository.deleteByIntegrationAndUser(integrationId, null);
+
+      expect(qb.delete).toHaveBeenCalled();
+      expect(qb.where).toHaveBeenCalledWith('integration_id = :integrationId', {
+        integrationId,
+      });
+      expect(qb.andWhere).toHaveBeenCalledWith('user_id IS NULL', {});
+      expect(qb.execute).toHaveBeenCalled();
+    });
+  });
+
+  describe('deleteAllByIntegration', () => {
+    it('should delete all tokens for the given integration', async () => {
+      mockTypeOrmRepo.delete.mockResolvedValue({ affected: 3, raw: [] });
+
+      await repository.deleteAllByIntegration(integrationId);
+
+      expect(mockTypeOrmRepo.delete).toHaveBeenCalledWith({ integrationId });
+    });
+  });
+});

--- a/ayunis-core-backend/src/domain/mcp/infrastructure/persistence/postgres/mcp-integration-oauth-token.repository.ts
+++ b/ayunis-core-backend/src/domain/mcp/infrastructure/persistence/postgres/mcp-integration-oauth-token.repository.ts
@@ -1,0 +1,115 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { IsNull, Repository } from 'typeorm';
+import { UUID } from 'crypto';
+import { McpIntegrationOAuthTokenRepositoryPort } from '../../../application/ports/mcp-integration-oauth-token.repository.port';
+import { McpIntegrationOAuthToken } from '../../../domain/mcp-integration-oauth-token.entity';
+import { McpIntegrationOAuthTokenRecord } from './schema/mcp-integration-oauth-token.record';
+
+/**
+ * PostgreSQL implementation of {@link McpIntegrationOAuthTokenRepositoryPort}.
+ *
+ * Handles persistence of OAuth tokens scoped to an MCP integration and
+ * optionally a user. For org-level tokens (`userId === null`), queries
+ * use `IS NULL` rather than equality to match the partial unique index.
+ */
+@Injectable()
+export class McpIntegrationOAuthTokenRepository extends McpIntegrationOAuthTokenRepositoryPort {
+  private readonly logger = new Logger(McpIntegrationOAuthTokenRepository.name);
+
+  constructor(
+    @InjectRepository(McpIntegrationOAuthTokenRecord)
+    private readonly repository: Repository<McpIntegrationOAuthTokenRecord>,
+  ) {
+    super();
+  }
+
+  async findByIntegrationAndUser(
+    integrationId: UUID,
+    userId: UUID | null,
+  ): Promise<McpIntegrationOAuthToken | null> {
+    this.logger.log('findByIntegrationAndUser', { integrationId, userId });
+
+    const record = await this.repository.findOne({
+      where: {
+        integrationId,
+        userId: userId ?? IsNull(),
+      },
+    });
+
+    if (!record) {
+      return null;
+    }
+
+    return this.toDomain(record);
+  }
+
+  async save(
+    token: McpIntegrationOAuthToken,
+  ): Promise<McpIntegrationOAuthToken> {
+    this.logger.log('save', {
+      tokenId: token.id,
+      integrationId: token.integrationId,
+      userId: token.userId,
+    });
+
+    const record = this.toRecord(token);
+    const saved = await this.repository.save(record);
+    return this.toDomain(saved);
+  }
+
+  async deleteByIntegrationAndUser(
+    integrationId: UUID,
+    userId: UUID | null,
+  ): Promise<void> {
+    this.logger.log('deleteByIntegrationAndUser', { integrationId, userId });
+
+    await this.repository
+      .createQueryBuilder()
+      .delete()
+      .where('integration_id = :integrationId', { integrationId })
+      .andWhere(
+        userId === null ? 'user_id IS NULL' : 'user_id = :userId',
+        userId === null ? {} : { userId },
+      )
+      .execute();
+  }
+
+  async deleteAllByIntegration(integrationId: UUID): Promise<void> {
+    this.logger.log('deleteAllByIntegration', { integrationId });
+
+    await this.repository.delete({ integrationId });
+  }
+
+  private toRecord(
+    entity: McpIntegrationOAuthToken,
+  ): McpIntegrationOAuthTokenRecord {
+    const record = new McpIntegrationOAuthTokenRecord();
+    record.id = entity.id;
+    record.integrationId = entity.integrationId;
+    record.userId = entity.userId;
+    record.accessTokenEncrypted = entity.accessTokenEncrypted;
+    record.refreshTokenEncrypted = entity.refreshTokenEncrypted ?? null;
+    record.tokenExpiresAt = entity.tokenExpiresAt ?? null;
+    record.scope = entity.scope ?? null;
+    record.createdAt = entity.createdAt;
+    record.updatedAt = entity.updatedAt;
+    return record;
+  }
+
+  private toDomain(
+    record: McpIntegrationOAuthTokenRecord,
+  ): McpIntegrationOAuthToken {
+    return new McpIntegrationOAuthToken({
+      id: record.id,
+      integrationId: record.integrationId,
+      userId: record.userId,
+      accessTokenEncrypted: record.accessTokenEncrypted,
+      refreshTokenEncrypted: record.refreshTokenEncrypted ?? undefined,
+      tokenExpiresAt: record.tokenExpiresAt ?? undefined,
+      scope: record.scope ?? undefined,
+      createdAt: record.createdAt,
+      updatedAt: record.updatedAt,
+    });
+  }
+}

--- a/ayunis-core-backend/src/domain/mcp/mcp.module.ts
+++ b/ayunis-core-backend/src/domain/mcp/mcp.module.ts
@@ -1,4 +1,6 @@
 import { Module } from '@nestjs/common';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+import { JwtModule } from '@nestjs/jwt';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { McpCredentialEncryptionPort } from './application/ports/mcp-credential-encryption.port';
 import { McpCredentialEncryptionService } from './infrastructure/encryption/mcp-credential-encryption.service';
@@ -29,6 +31,10 @@ import {
 import { McpIntegrationMapper } from './infrastructure/persistence/postgres/mappers/mcp-integration.mapper';
 import { McpIntegrationFactory } from './application/factories/mcp-integration.factory';
 import { McpIntegrationAuthFactory } from './application/factories/mcp-integration-auth.factory';
+import { McpIntegrationOAuthTokenRepositoryPort } from './application/ports/mcp-integration-oauth-token.repository.port';
+import { McpOAuthStatePort } from './application/ports/mcp-oauth-state.port';
+import { JwtOAuthStateAdapter } from './infrastructure/oauth/jwt-oauth-state.adapter';
+import { McpIntegrationOAuthTokenRepository } from './infrastructure/persistence/postgres/mcp-integration-oauth-token.repository';
 import { SourcesModule } from '../sources/sources.module';
 import { MarketplaceModule } from '../marketplace/marketplace.module';
 
@@ -74,6 +80,13 @@ import { PredefinedConfigDtoMapper } from './presenters/http/mappers/predefined-
       SelfDefinedMcpIntegrationRecord,
       McpIntegrationOAuthTokenRecord,
     ]),
+    JwtModule.registerAsync({
+      imports: [ConfigModule],
+      inject: [ConfigService],
+      useFactory: (configService: ConfigService) => ({
+        secret: configService.getOrThrow<string>('app.mcp.oauthStateSecret'),
+      }),
+    }),
     SourcesModule, // Import sources module for CreateDataSourceUseCase
     MarketplaceModule,
   ],
@@ -94,6 +107,14 @@ import { PredefinedConfigDtoMapper } from './presenters/http/mappers/predefined-
     {
       provide: McpIntegrationUserConfigRepositoryPort,
       useClass: McpIntegrationUserConfigRepository,
+    },
+    {
+      provide: McpOAuthStatePort,
+      useClass: JwtOAuthStateAdapter,
+    },
+    {
+      provide: McpIntegrationOAuthTokenRepositoryPort,
+      useClass: McpIntegrationOAuthTokenRepository,
     },
     McpIntegrationMapper,
     McpIntegrationFactory,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces new OAuth state JWT signing and OAuth token persistence wiring, which affects authentication-adjacent flows and relies on correct secret configuration and token validation behavior.
> 
> **Overview**
> Adds MCP OAuth infrastructure needed for an authorization-code + PKCE flow: a new `JwtOAuthStateAdapter` that signs/verifies the OAuth `state` as a short-lived JWT (with tests for expiry/tampering), and a new Postgres `McpIntegrationOAuthTokenRepository` for storing encrypted access/refresh tokens with org-level (`userId IS NULL`) handling.
> 
> Wires both adapters into `McpModule` (including `JwtModule` async configuration) and extends config/env support with `MCP_OAUTH_STATE_SECRET` plus a public `BACKEND_BASEURL`, failing fast in non-dev/test environments when the OAuth state secret is missing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4ac9868248d6a1b2536c60e344e94b85633f63f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->