### PR TITLE
wip(mcp): add OAuthFlowService and OAuth use cases (start, complete, revoke, get-status)

### DIFF
--- a/ayunis-core-backend/src/domain/mcp/SUMMARY.md
+++ b/ayunis-core-backend/src/domain/mcp/SUMMARY.md
@@ -22,17 +22,24 @@ The MCP module manages connections to external Model Context Protocol servers at
 - `GetMcpPromptUseCase` — Fetches a prompt from a remote MCP server
 - `SetUserMcpConfigUseCase` — Saves per-user config values for a marketplace integration
 - `GetUserMcpConfigUseCase` — Retrieves per-user config values (with secret masking)
+- `StartMcpOAuthAuthorizationUseCase` — Initiates OAuth authorization flow, returns authorization URL
+- `CompleteMcpOAuthAuthorizationUseCase` — Handles OAuth callback, exchanges code for tokens
+- `RevokeMcpOAuthAuthorizationUseCase` — Revokes stored OAuth tokens
+- `GetMcpOAuthAuthorizationStatusUseCase` — Returns authorization status for an integration
 
 **Services:**
 - `McpClientService` — Handles actual server communication via the MCP SDK
 - `MarketplaceConfigService` — Resolves effective server URL and auth headers by merging org-level and user-level config values against the integration's config schema
 - `ConnectionValidationService` — Validates MCP server connectivity, used by `ValidateMcpIntegrationUseCase`
+- `OAuthFlowService` — Orchestrates OAuth 2.1 + PKCE flows (authorization URL building, code exchange, lazy token refresh, revocation, status queries)
 
 **Ports:**
 - `McpIntegrationsRepository` — Persistence port for MCP integrations
 - `McpIntegrationUserConfigRepository` — Persistence port for per-user config values
 - `McpClientPort` — Abstract port for MCP server communication
 - `McpCredentialEncryptionPort` — Abstract port for credential encryption/decryption
+- `McpIntegrationOAuthTokenRepositoryPort` — Abstract repository for OAuth token persistence
+- `McpOAuthStatePort` — Abstract port for signing/verifying OAuth state JWTs
 
 **Presenters:**
 - `McpIntegrationsController` — REST controller exposing:

--- a/ayunis-core-backend/src/domain/mcp/application/services/oauth-flow.service.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/services/oauth-flow.service.spec.ts
@@ -1,0 +1,763 @@
+import type { TestingModule } from '@nestjs/testing';
+import { Test } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { randomUUID, type UUID } from 'crypto';
+import { OAuthFlowService } from './oauth-flow.service';
+import { McpOAuthStatePort } from '../ports/mcp-oauth-state.port';
+import { McpIntegrationOAuthTokenRepositoryPort } from '../ports/mcp-integration-oauth-token.repository.port';
+import { McpCredentialEncryptionPort } from '../ports/mcp-credential-encryption.port';
+import { McpIntegrationsRepositoryPort } from '../ports/mcp-integrations.repository.port';
+import { McpIntegrationOAuthToken } from '../../domain/mcp-integration-oauth-token.entity';
+import { SelfDefinedMcpIntegration } from '../../domain/integrations/self-defined-mcp-integration.entity';
+import { NoAuthMcpIntegrationAuth } from '../../domain/auth/no-auth-mcp-integration-auth.entity';
+import type { IntegrationConfigSchema } from '../../domain/value-objects/integration-config-schema';
+import type { McpOAuthAuthorizationState } from '../ports/mcp-oauth-state.port';
+import {
+  McpOAuthClientNotConfiguredError,
+  McpOAuthAuthorizationRequiredError,
+  McpOAuthStateInvalidError,
+  McpOAuthExchangeFailedError,
+  McpInvalidConfigSchemaError,
+  McpIntegrationNotFoundError,
+} from '../mcp.errors';
+
+// ── SDK mocks ─────────────────────────────────────────────────────
+const mockExchangeAuthorization = jest.fn();
+const mockRefreshAuthorization = jest.fn();
+
+jest.mock('@modelcontextprotocol/sdk/client/auth.js', () => ({
+  exchangeAuthorization: (...args: unknown[]) =>
+    mockExchangeAuthorization(...args),
+  refreshAuthorization: (...args: unknown[]) =>
+    mockRefreshAuthorization(...args),
+}));
+
+// ── Mock port implementations ─────────────────────────────────────
+
+class MockStateAdapter extends McpOAuthStatePort {
+  sign = jest.fn();
+  verify = jest.fn();
+}
+
+class MockTokenRepository extends McpIntegrationOAuthTokenRepositoryPort {
+  findByIntegrationAndUser = jest.fn();
+  save = jest.fn();
+  deleteByIntegrationAndUser = jest.fn();
+  deleteAllByIntegration = jest.fn();
+}
+
+class MockEncryption extends McpCredentialEncryptionPort {
+  encrypt = jest.fn();
+  decrypt = jest.fn();
+}
+
+class MockIntegrationsRepository extends McpIntegrationsRepositoryPort {
+  findById = jest.fn();
+  findByOrgId = jest.fn();
+  findAll = jest.fn();
+  save = jest.fn();
+  delete = jest.fn();
+  findByOrgIdAndSlug = jest.fn();
+  findAvailableByOrgId = jest.fn();
+  findByIds = jest.fn();
+  findByOrgIdAndMarketplaceIdentifier = jest.fn();
+}
+
+// ── Helpers ───────────────────────────────────────────────────────
+
+const OAUTH_CONFIG_SCHEMA: IntegrationConfigSchema = {
+  authType: 'OAUTH',
+  orgFields: [],
+  userFields: [],
+  oauth: {
+    authorizationUrl: 'https://auth.example.com/authorize',
+    tokenUrl: 'https://auth.example.com/token',
+    scopes: ['read', 'write'],
+    level: 'org',
+  },
+};
+
+function buildIntegration(
+  overrides?: Partial<{
+    id: UUID;
+    oauthClientId: string;
+    oauthClientSecretEncrypted: string;
+    configSchema: IntegrationConfigSchema;
+    orgId: UUID;
+  }>,
+): SelfDefinedMcpIntegration {
+  return new SelfDefinedMcpIntegration({
+    id: overrides?.id ?? randomUUID(),
+    orgId: overrides?.orgId ?? randomUUID(),
+    name: 'Test Integration',
+    serverUrl: 'https://mcp.example.com',
+    configSchema: overrides?.configSchema ?? OAUTH_CONFIG_SCHEMA,
+    orgConfigValues: {},
+    auth: new NoAuthMcpIntegrationAuth(),
+    oauthClientId: overrides?.oauthClientId ?? 'client-id',
+    oauthClientSecretEncrypted:
+      overrides?.oauthClientSecretEncrypted ?? 'encrypted-secret',
+  });
+}
+
+// ── Tests ─────────────────────────────────────────────────────────
+
+describe('OAuthFlowService', () => {
+  let service: OAuthFlowService;
+  let stateAdapter: MockStateAdapter;
+  let tokenRepository: MockTokenRepository;
+  let encryption: MockEncryption;
+  let integrationsRepository: MockIntegrationsRepository;
+
+  beforeAll(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        OAuthFlowService,
+        { provide: McpOAuthStatePort, useClass: MockStateAdapter },
+        {
+          provide: McpIntegrationOAuthTokenRepositoryPort,
+          useClass: MockTokenRepository,
+        },
+        { provide: McpCredentialEncryptionPort, useClass: MockEncryption },
+        {
+          provide: McpIntegrationsRepositoryPort,
+          useClass: MockIntegrationsRepository,
+        },
+        {
+          provide: ConfigService,
+          useValue: {
+            getOrThrow: jest.fn().mockReturnValue('http://localhost:3000'),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get(OAuthFlowService);
+    stateAdapter = module.get(McpOAuthStatePort);
+    tokenRepository = module.get(McpIntegrationOAuthTokenRepositoryPort);
+    encryption = module.get(McpCredentialEncryptionPort);
+    integrationsRepository = module.get(McpIntegrationsRepositoryPort);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  // ── buildAuthorizationUrl ───────────────────────────────────────
+
+  describe('buildAuthorizationUrl', () => {
+    it('should produce a valid OAuth authorization URL', async () => {
+      const integration = buildIntegration();
+      stateAdapter.sign.mockReturnValue('signed-state-jwt');
+
+      const result = service.buildAuthorizationUrl(
+        integration,
+        'org',
+        integration.orgId,
+        null,
+      );
+
+      const url = new URL(result.url);
+      expect(url.origin).toBe('https://auth.example.com');
+      expect(url.pathname).toBe('/authorize');
+      expect(url.searchParams.get('response_type')).toBe('code');
+      expect(url.searchParams.get('client_id')).toBe('client-id');
+      expect(url.searchParams.get('redirect_uri')).toBe(
+        'http://localhost:3000/mcp-integrations/oauth/callback',
+      );
+      expect(url.searchParams.get('scope')).toBe('read write');
+      expect(url.searchParams.get('state')).toBe('signed-state-jwt');
+      expect(url.searchParams.get('code_challenge_method')).toBe('S256');
+      expect(url.searchParams.get('code_challenge')).toBeTruthy();
+
+      // Verify state was signed with the right payload shape
+      expect(stateAdapter.sign).toHaveBeenCalledWith(
+        expect.objectContaining({
+          integrationId: integration.id,
+          level: 'org',
+          orgId: integration.orgId,
+          userId: null,
+          codeVerifier: expect.any(String),
+          redirectUri: 'http://localhost:3000/mcp-integrations/oauth/callback',
+          nonce: expect.any(String),
+        }),
+        600,
+      );
+    });
+
+    it('should throw McpOAuthClientNotConfiguredError when oauthClientId is missing', () => {
+      const integration = new SelfDefinedMcpIntegration({
+        orgId: randomUUID(),
+        name: 'No Client',
+        serverUrl: 'https://mcp.example.com',
+        configSchema: OAUTH_CONFIG_SCHEMA,
+        orgConfigValues: {},
+        auth: new NoAuthMcpIntegrationAuth(),
+        // No oauthClientId / oauthClientSecretEncrypted
+      });
+
+      expect(() =>
+        service.buildAuthorizationUrl(
+          integration,
+          'org',
+          integration.orgId,
+          null,
+        ),
+      ).toThrow(McpOAuthClientNotConfiguredError);
+    });
+
+    it('should throw McpInvalidConfigSchemaError when OAuth config is missing', () => {
+      const integration = new SelfDefinedMcpIntegration({
+        orgId: randomUUID(),
+        name: 'No OAuth',
+        serverUrl: 'https://mcp.example.com',
+        configSchema: { authType: 'NONE', orgFields: [], userFields: [] },
+        orgConfigValues: {},
+        auth: new NoAuthMcpIntegrationAuth(),
+      });
+
+      expect(() =>
+        service.buildAuthorizationUrl(
+          integration,
+          'org',
+          integration.orgId,
+          null,
+        ),
+      ).toThrow(McpInvalidConfigSchemaError);
+    });
+  });
+
+  // ── handleCallback ──────────────────────────────────────────────
+
+  describe('handleCallback', () => {
+    it('should exchange code for tokens and persist them', async () => {
+      const integration = buildIntegration();
+      const state: McpOAuthAuthorizationState = {
+        integrationId: integration.id,
+        level: 'org',
+        orgId: integration.orgId,
+        userId: null,
+        codeVerifier: 'test-verifier',
+        redirectUri: 'http://localhost:3000/mcp-integrations/oauth/callback',
+        nonce: 'test-nonce',
+      };
+
+      stateAdapter.verify.mockReturnValue(state);
+      integrationsRepository.findById.mockResolvedValue(integration);
+      encryption.decrypt.mockResolvedValue('plain-client-secret');
+      encryption.encrypt.mockImplementation(
+        async (v: string) => `encrypted:${v}`,
+      );
+      mockExchangeAuthorization.mockResolvedValue({
+        access_token: 'new-access-token',
+        refresh_token: 'new-refresh-token',
+        token_type: 'Bearer',
+        expires_in: 3600,
+        scope: 'read write',
+      });
+      tokenRepository.findByIntegrationAndUser.mockResolvedValue(null);
+      tokenRepository.save.mockImplementation(async (t: unknown) => t);
+
+      const result = await service.handleCallback('auth-code', 'state-jwt');
+
+      expect(result.integrationId).toBe(integration.id);
+      expect(result.level).toBe('org');
+      expect(result.userId).toBeNull();
+
+      expect(mockExchangeAuthorization).toHaveBeenCalledWith(
+        'https://auth.example.com/token',
+        expect.objectContaining({
+          clientInformation: {
+            client_id: 'client-id',
+            client_secret: 'plain-client-secret',
+          },
+          authorizationCode: 'auth-code',
+          codeVerifier: 'test-verifier',
+          redirectUri: 'http://localhost:3000/mcp-integrations/oauth/callback',
+        }),
+      );
+
+      expect(tokenRepository.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          integrationId: integration.id,
+          userId: null,
+          accessTokenEncrypted: 'encrypted:new-access-token',
+          refreshTokenEncrypted: 'encrypted:new-refresh-token',
+        }),
+      );
+    });
+
+    it('should clear stale refresh token when re-authorization response omits refresh_token', async () => {
+      const integration = buildIntegration();
+      const state: McpOAuthAuthorizationState = {
+        integrationId: integration.id,
+        level: 'org',
+        orgId: integration.orgId,
+        userId: null,
+        codeVerifier: 'test-verifier',
+        redirectUri: 'http://localhost:3000/mcp-integrations/oauth/callback',
+        nonce: 'test-nonce',
+      };
+
+      stateAdapter.verify.mockReturnValue(state);
+      integrationsRepository.findById.mockResolvedValue(integration);
+      encryption.decrypt.mockResolvedValue('plain-client-secret');
+      encryption.encrypt.mockImplementation(
+        async (v: string) => `encrypted:${v}`,
+      );
+
+      // Exchange response omits refresh_token entirely
+      mockExchangeAuthorization.mockResolvedValue({
+        access_token: 'new-access-token',
+        token_type: 'Bearer',
+        expires_in: 3600,
+        scope: 'read write',
+      });
+
+      // Existing token has a stale refresh token from a previous grant
+      const existingToken = new McpIntegrationOAuthToken({
+        integrationId: integration.id,
+        userId: null,
+        accessTokenEncrypted: 'old-encrypted-access',
+        refreshTokenEncrypted: 'stale-encrypted-refresh',
+        tokenExpiresAt: new Date(Date.now() - 1000),
+        scope: 'old-scope',
+      });
+      tokenRepository.findByIntegrationAndUser.mockResolvedValue(existingToken);
+      tokenRepository.save.mockImplementation(async (t: unknown) => t);
+
+      await service.handleCallback('auth-code', 'state-jwt');
+
+      // The stale refresh token must be cleared, not preserved
+      expect(existingToken.refreshTokenEncrypted).toBeUndefined();
+    });
+
+    it('should clear stale scope when re-authorization response omits scope', async () => {
+      const integration = buildIntegration();
+      const state: McpOAuthAuthorizationState = {
+        integrationId: integration.id,
+        level: 'org',
+        orgId: integration.orgId,
+        userId: null,
+        codeVerifier: 'test-verifier',
+        redirectUri: 'http://localhost:3000/mcp-integrations/oauth/callback',
+        nonce: 'test-nonce',
+      };
+
+      stateAdapter.verify.mockReturnValue(state);
+      integrationsRepository.findById.mockResolvedValue(integration);
+      encryption.decrypt.mockResolvedValue('plain-client-secret');
+      encryption.encrypt.mockImplementation(
+        async (v: string) => `encrypted:${v}`,
+      );
+
+      // Exchange response omits scope entirely
+      mockExchangeAuthorization.mockResolvedValue({
+        access_token: 'new-access-token',
+        refresh_token: 'new-refresh-token',
+        token_type: 'Bearer',
+        expires_in: 3600,
+      });
+
+      // Existing token has a stale scope from a previous grant
+      const existingToken = new McpIntegrationOAuthToken({
+        integrationId: integration.id,
+        userId: null,
+        accessTokenEncrypted: 'old-encrypted-access',
+        refreshTokenEncrypted: 'old-encrypted-refresh',
+        tokenExpiresAt: new Date(Date.now() - 1000),
+        scope: 'old-scope',
+      });
+      tokenRepository.findByIntegrationAndUser.mockResolvedValue(existingToken);
+      tokenRepository.save.mockImplementation(async (t: unknown) => t);
+
+      await service.handleCallback('auth-code', 'state-jwt');
+
+      // The stale scope must be cleared, not preserved
+      expect(existingToken.scope).toBeUndefined();
+    });
+
+    it('should throw McpOAuthStateInvalidError on invalid state', async () => {
+      stateAdapter.verify.mockImplementation(() => {
+        throw new Error('expired');
+      });
+
+      await expect(service.handleCallback('code', 'bad-state')).rejects.toThrow(
+        McpOAuthStateInvalidError,
+      );
+    });
+
+    it('should throw McpOAuthExchangeFailedError when SDK exchange fails', async () => {
+      const integration = buildIntegration();
+      const state: McpOAuthAuthorizationState = {
+        integrationId: integration.id,
+        level: 'org',
+        orgId: integration.orgId,
+        userId: null,
+        codeVerifier: 'v',
+        redirectUri: 'http://localhost:3000/mcp-integrations/oauth/callback',
+        nonce: 'n',
+      };
+
+      stateAdapter.verify.mockReturnValue(state);
+      integrationsRepository.findById.mockResolvedValue(integration);
+      encryption.decrypt.mockResolvedValue('plain-secret');
+      mockExchangeAuthorization.mockRejectedValue(
+        new Error('token_endpoint_error'),
+      );
+
+      await expect(service.handleCallback('code', 'state-jwt')).rejects.toThrow(
+        McpOAuthExchangeFailedError,
+      );
+    });
+
+    it('should throw McpIntegrationNotFoundError when integration is deleted between auth start and callback', async () => {
+      const integrationId = randomUUID();
+      const orgId = randomUUID();
+      const state: McpOAuthAuthorizationState = {
+        integrationId,
+        level: 'org',
+        orgId,
+        userId: null,
+        codeVerifier: 'v',
+        redirectUri: 'http://localhost:3000/mcp-integrations/oauth/callback',
+        nonce: 'n',
+      };
+
+      stateAdapter.verify.mockReturnValue(state);
+      integrationsRepository.findById.mockResolvedValue(null);
+
+      await expect(service.handleCallback('code', 'state-jwt')).rejects.toThrow(
+        McpIntegrationNotFoundError,
+      );
+    });
+
+    it('should throw McpOAuthStateInvalidError when orgId in state does not match integration', async () => {
+      const integration = buildIntegration();
+      const state: McpOAuthAuthorizationState = {
+        integrationId: integration.id,
+        level: 'org',
+        orgId: randomUUID(), // different orgId
+        userId: null,
+        codeVerifier: 'v',
+        redirectUri: 'http://localhost:3000/mcp-integrations/oauth/callback',
+        nonce: 'n',
+      };
+
+      stateAdapter.verify.mockReturnValue(state);
+      integrationsRepository.findById.mockResolvedValue(integration);
+
+      await expect(service.handleCallback('code', 'state-jwt')).rejects.toThrow(
+        McpOAuthStateInvalidError,
+      );
+    });
+  });
+
+  // ── getValidAccessToken ─────────────────────────────────────────
+
+  describe('getValidAccessToken', () => {
+    it('should return decrypted access token when not expired', async () => {
+      const integration = buildIntegration();
+      const token = new McpIntegrationOAuthToken({
+        integrationId: integration.id,
+        userId: null,
+        accessTokenEncrypted: 'encrypted-access',
+        tokenExpiresAt: new Date(Date.now() + 3600_000),
+      });
+
+      tokenRepository.findByIntegrationAndUser.mockResolvedValue(token);
+      encryption.decrypt.mockResolvedValue('plain-access-token');
+
+      const result = await service.getValidAccessToken(integration, null);
+
+      expect(result).toBe('plain-access-token');
+      expect(encryption.decrypt).toHaveBeenCalledWith('encrypted-access');
+      expect(mockRefreshAuthorization).not.toHaveBeenCalled();
+    });
+
+    it('should throw McpOAuthAuthorizationRequiredError when no token exists', async () => {
+      const integration = buildIntegration();
+      tokenRepository.findByIntegrationAndUser.mockResolvedValue(null);
+
+      await expect(
+        service.getValidAccessToken(integration, null),
+      ).rejects.toThrow(McpOAuthAuthorizationRequiredError);
+    });
+
+    it('should refresh when token is expired and refresh token exists', async () => {
+      const integration = buildIntegration();
+      const token = new McpIntegrationOAuthToken({
+        integrationId: integration.id,
+        userId: null,
+        accessTokenEncrypted: 'old-encrypted-access',
+        refreshTokenEncrypted: 'encrypted-refresh',
+        tokenExpiresAt: new Date(Date.now() - 1000), // expired
+      });
+
+      tokenRepository.findByIntegrationAndUser.mockResolvedValue(token);
+      encryption.decrypt
+        .mockResolvedValueOnce('plain-refresh-token') // for refresh token
+        .mockResolvedValueOnce('plain-client-secret'); // for client secret
+      encryption.encrypt.mockImplementation(
+        async (v: string) => `encrypted:${v}`,
+      );
+
+      mockRefreshAuthorization.mockResolvedValue({
+        access_token: 'refreshed-access-token',
+        refresh_token: 'new-refresh-token',
+        token_type: 'Bearer',
+        expires_in: 3600,
+        scope: 'read write',
+      });
+
+      // For the upsertTokens call — existing token lookup
+      tokenRepository.findByIntegrationAndUser
+        .mockResolvedValueOnce(token) // first call in getValidAccessToken
+        .mockResolvedValueOnce(token); // second call in upsertTokens
+      tokenRepository.save.mockImplementation(async (t: unknown) => t);
+
+      const result = await service.getValidAccessToken(integration, null);
+
+      expect(result).toBe('refreshed-access-token');
+      expect(mockRefreshAuthorization).toHaveBeenCalled();
+    });
+
+    it('should preserve existing refresh token when refresh response omits refresh_token', async () => {
+      const integration = buildIntegration();
+      const existingRefreshEncrypted = 'encrypted-existing-refresh';
+      const token = new McpIntegrationOAuthToken({
+        integrationId: integration.id,
+        userId: null,
+        accessTokenEncrypted: 'old-encrypted-access',
+        refreshTokenEncrypted: existingRefreshEncrypted,
+        tokenExpiresAt: new Date(Date.now() - 1000), // expired
+        scope: 'read write',
+      });
+
+      tokenRepository.findByIntegrationAndUser.mockResolvedValue(token);
+      encryption.decrypt
+        .mockResolvedValueOnce('plain-refresh-token') // for refresh token
+        .mockResolvedValueOnce('plain-client-secret'); // for client secret
+      encryption.encrypt.mockImplementation(
+        async (v: string) => `encrypted:${v}`,
+      );
+
+      // Response omits refresh_token (RFC 6749 §6 — server reuses existing)
+      mockRefreshAuthorization.mockResolvedValue({
+        access_token: 'refreshed-access-token',
+        token_type: 'Bearer',
+        expires_in: 3600,
+      });
+
+      tokenRepository.save.mockImplementation(async (t: unknown) => t);
+
+      const result = await service.getValidAccessToken(integration, null);
+
+      expect(result).toBe('refreshed-access-token');
+      // The existing refresh token must be preserved, not cleared
+      expect(token.refreshTokenEncrypted).toBe(existingRefreshEncrypted);
+    });
+
+    it('should clear tokenExpiresAt when refresh response omits expires_in (no refresh loop)', async () => {
+      const integration = buildIntegration();
+      const token = new McpIntegrationOAuthToken({
+        integrationId: integration.id,
+        userId: null,
+        accessTokenEncrypted: 'old-encrypted-access',
+        refreshTokenEncrypted: 'encrypted-refresh',
+        tokenExpiresAt: new Date(Date.now() - 1000), // expired
+        scope: 'read write',
+      });
+
+      tokenRepository.findByIntegrationAndUser.mockResolvedValue(token);
+      encryption.decrypt
+        .mockResolvedValueOnce('plain-refresh-token')
+        .mockResolvedValueOnce('plain-client-secret');
+      encryption.encrypt.mockImplementation(
+        async (v: string) => `encrypted:${v}`,
+      );
+
+      // Response omits both refresh_token AND expires_in
+      mockRefreshAuthorization.mockResolvedValue({
+        access_token: 'refreshed-access-token',
+        token_type: 'Bearer',
+      });
+
+      tokenRepository.save.mockImplementation(async (t: unknown) => t);
+
+      const result = await service.getValidAccessToken(integration, null);
+
+      expect(result).toBe('refreshed-access-token');
+      // tokenExpiresAt must be cleared (not preserved as old expired value)
+      expect(token.tokenExpiresAt).toBeUndefined();
+      // Therefore isExpired() must return false (no known expiry = non-expiring)
+      expect(token.isExpired()).toBe(false);
+    });
+
+    it('should delete token and throw when expired with no refresh token', async () => {
+      const integration = buildIntegration();
+      const token = new McpIntegrationOAuthToken({
+        integrationId: integration.id,
+        userId: null,
+        accessTokenEncrypted: 'old-encrypted-access',
+        tokenExpiresAt: new Date(Date.now() - 1000), // expired, no refresh
+      });
+
+      tokenRepository.findByIntegrationAndUser.mockResolvedValue(token);
+
+      await expect(
+        service.getValidAccessToken(integration, null),
+      ).rejects.toThrow(McpOAuthAuthorizationRequiredError);
+
+      expect(tokenRepository.deleteByIntegrationAndUser).toHaveBeenCalledWith(
+        integration.id,
+        null,
+      );
+    });
+
+    it('should not delete token when refresh succeeds but persistence fails', async () => {
+      const integration = buildIntegration();
+      const token = new McpIntegrationOAuthToken({
+        integrationId: integration.id,
+        userId: null,
+        accessTokenEncrypted: 'old-encrypted-access',
+        refreshTokenEncrypted: 'encrypted-refresh',
+        tokenExpiresAt: new Date(Date.now() - 1000),
+      });
+
+      tokenRepository.findByIntegrationAndUser.mockResolvedValue(token);
+      encryption.decrypt
+        .mockResolvedValueOnce('plain-refresh')
+        .mockResolvedValueOnce('plain-client-secret');
+      encryption.encrypt.mockImplementation(
+        async (v: string) => `encrypted:${v}`,
+      );
+
+      mockRefreshAuthorization.mockResolvedValue({
+        access_token: 'refreshed-access-token',
+        refresh_token: 'new-refresh-token',
+        token_type: 'Bearer',
+        expires_in: 3600,
+      });
+
+      // Persistence fails (transient DB error)
+      tokenRepository.save.mockRejectedValue(new Error('DB connection lost'));
+
+      await expect(
+        service.getValidAccessToken(integration, null),
+      ).rejects.toThrow('DB connection lost');
+
+      // Old token must NOT be deleted — it's still valid in DB
+      expect(tokenRepository.deleteByIntegrationAndUser).not.toHaveBeenCalled();
+    });
+
+    it('should delete token and throw when refresh fails', async () => {
+      const integration = buildIntegration();
+      const token = new McpIntegrationOAuthToken({
+        integrationId: integration.id,
+        userId: null,
+        accessTokenEncrypted: 'old-encrypted-access',
+        refreshTokenEncrypted: 'encrypted-refresh',
+        tokenExpiresAt: new Date(Date.now() - 1000),
+      });
+
+      tokenRepository.findByIntegrationAndUser.mockResolvedValue(token);
+      encryption.decrypt
+        .mockResolvedValueOnce('plain-refresh')
+        .mockResolvedValueOnce('plain-client-secret');
+      mockRefreshAuthorization.mockRejectedValue(new Error('refresh_revoked'));
+
+      await expect(
+        service.getValidAccessToken(integration, null),
+      ).rejects.toThrow(McpOAuthAuthorizationRequiredError);
+
+      expect(tokenRepository.deleteByIntegrationAndUser).toHaveBeenCalledWith(
+        integration.id,
+        null,
+      );
+    });
+  });
+
+  // ── revoke ──────────────────────────────────────────────────────
+
+  describe('revoke', () => {
+    it('should delete the token row', async () => {
+      const integrationId = randomUUID();
+      await service.revoke(integrationId, null);
+
+      expect(tokenRepository.deleteByIntegrationAndUser).toHaveBeenCalledWith(
+        integrationId,
+        null,
+      );
+    });
+  });
+
+  // ── getStatus ───────────────────────────────────────────────────
+
+  describe('getStatus', () => {
+    it('should return authorized: false when no token exists', async () => {
+      tokenRepository.findByIntegrationAndUser.mockResolvedValue(null);
+
+      const result = await service.getStatus(randomUUID(), null);
+
+      expect(result).toEqual({
+        authorized: false,
+        expiresAt: null,
+        scope: null,
+      });
+    });
+
+    it('should return authorized: true with token details', async () => {
+      const expiresAt = new Date(Date.now() + 3600_000);
+      const token = new McpIntegrationOAuthToken({
+        integrationId: randomUUID(),
+        userId: null,
+        accessTokenEncrypted: 'enc',
+        tokenExpiresAt: expiresAt,
+        scope: 'read write',
+      });
+
+      tokenRepository.findByIntegrationAndUser.mockResolvedValue(token);
+
+      const result = await service.getStatus(token.integrationId, null);
+
+      expect(result.authorized).toBe(true);
+      expect(result.scope).toBe('read write');
+      // tokenExpiresAt returns a defensive copy
+      expect(result.expiresAt?.getTime()).toBe(expiresAt.getTime());
+    });
+
+    it('should return authorized: false for expired token with no refresh token', async () => {
+      const token = new McpIntegrationOAuthToken({
+        integrationId: randomUUID(),
+        userId: null,
+        accessTokenEncrypted: 'enc',
+        tokenExpiresAt: new Date(Date.now() - 1000), // expired
+        scope: 'read write',
+      });
+
+      tokenRepository.findByIntegrationAndUser.mockResolvedValue(token);
+
+      const result = await service.getStatus(token.integrationId, null);
+
+      expect(result.authorized).toBe(false);
+    });
+
+    it('should return authorized: true for expired token with refresh token', async () => {
+      const token = new McpIntegrationOAuthToken({
+        integrationId: randomUUID(),
+        userId: null,
+        accessTokenEncrypted: 'enc',
+        refreshTokenEncrypted: 'enc-refresh',
+        tokenExpiresAt: new Date(Date.now() - 1000), // expired
+        scope: 'read write',
+      });
+
+      tokenRepository.findByIntegrationAndUser.mockResolvedValue(token);
+
+      const result = await service.getStatus(token.integrationId, null);
+
+      expect(result.authorized).toBe(true);
+    });
+  });
+});

--- a/ayunis-core-backend/src/domain/mcp/application/services/oauth-flow.service.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/services/oauth-flow.service.spec.ts
@@ -12,6 +12,8 @@ import { SelfDefinedMcpIntegration } from '../../domain/integrations/self-define
 import { NoAuthMcpIntegrationAuth } from '../../domain/auth/no-auth-mcp-integration-auth.entity';
 import type { IntegrationConfigSchema } from '../../domain/value-objects/integration-config-schema';
 import type { McpOAuthAuthorizationState } from '../ports/mcp-oauth-state.port';
+import { ValidateIntegrationAccessService } from './validate-integration-access.service';
+import { ContextService } from 'src/common/context/services/context.service';
 import {
   McpOAuthClientNotConfiguredError,
   McpOAuthAuthorizationRequiredError,
@@ -19,6 +21,7 @@ import {
   McpOAuthExchangeFailedError,
   McpInvalidConfigSchemaError,
   McpIntegrationNotFoundError,
+  McpUnauthenticatedError,
 } from '../mcp.errors';
 
 // ── SDK mocks ─────────────────────────────────────────────────────
@@ -108,6 +111,8 @@ describe('OAuthFlowService', () => {
   let tokenRepository: MockTokenRepository;
   let encryption: MockEncryption;
   let integrationsRepository: MockIntegrationsRepository;
+  let validateAccess: ValidateIntegrationAccessService;
+  let contextService: ContextService;
 
   beforeAll(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -129,6 +134,14 @@ describe('OAuthFlowService', () => {
             getOrThrow: jest.fn().mockReturnValue('http://localhost:3000'),
           },
         },
+        {
+          provide: ValidateIntegrationAccessService,
+          useValue: { validate: jest.fn() },
+        },
+        {
+          provide: ContextService,
+          useValue: { get: jest.fn() },
+        },
       ],
     }).compile();
 
@@ -137,6 +150,8 @@ describe('OAuthFlowService', () => {
     tokenRepository = module.get(McpIntegrationOAuthTokenRepositoryPort);
     encryption = module.get(McpCredentialEncryptionPort);
     integrationsRepository = module.get(McpIntegrationsRepositoryPort);
+    validateAccess = module.get(ValidateIntegrationAccessService);
+    contextService = module.get(ContextService);
   });
 
   afterEach(() => {
@@ -758,6 +773,75 @@ describe('OAuthFlowService', () => {
       const result = await service.getStatus(token.integrationId, null);
 
       expect(result.authorized).toBe(true);
+    });
+  });
+
+  // ── resolveOAuthActor ────────────────────────────────────────────
+
+  describe('resolveOAuthActor', () => {
+    it('should return actor context for org-level OAuth', async () => {
+      const integration = buildIntegration();
+      const orgId = integration.orgId;
+      const userId = randomUUID();
+
+      jest
+        .spyOn(contextService, 'get')
+        .mockImplementation((key) => (key === 'orgId' ? orgId : userId));
+      jest.spyOn(validateAccess, 'validate').mockResolvedValue(integration);
+
+      const result = await service.resolveOAuthActor(integration.id);
+
+      expect(result.integration).toBe(integration);
+      expect(result.level).toBe('org');
+      expect(result.orgId).toBe(orgId);
+      expect(result.userIdOrNull).toBeNull();
+    });
+
+    it('should return actor context with userId for user-level OAuth', async () => {
+      const userLevelSchema: IntegrationConfigSchema = {
+        ...OAUTH_CONFIG_SCHEMA,
+        oauth: { ...OAUTH_CONFIG_SCHEMA.oauth!, level: 'user' },
+      };
+      const integration = buildIntegration({ configSchema: userLevelSchema });
+      const orgId = integration.orgId;
+      const userId = randomUUID();
+
+      jest
+        .spyOn(contextService, 'get')
+        .mockImplementation((key) => (key === 'orgId' ? orgId : userId));
+      jest.spyOn(validateAccess, 'validate').mockResolvedValue(integration);
+
+      const result = await service.resolveOAuthActor(integration.id);
+
+      expect(result.level).toBe('user');
+      expect(result.userIdOrNull).toBe(userId);
+    });
+
+    it('should throw McpUnauthenticatedError when orgId is missing', async () => {
+      jest.spyOn(contextService, 'get').mockReturnValue(undefined);
+
+      await expect(service.resolveOAuthActor(randomUUID())).rejects.toThrow(
+        McpUnauthenticatedError,
+      );
+    });
+
+    it('should throw McpUnauthenticatedError for user-level OAuth when userId is missing', async () => {
+      const userLevelSchema: IntegrationConfigSchema = {
+        ...OAUTH_CONFIG_SCHEMA,
+        oauth: { ...OAUTH_CONFIG_SCHEMA.oauth!, level: 'user' },
+      };
+      const integration = buildIntegration({ configSchema: userLevelSchema });
+
+      jest
+        .spyOn(contextService, 'get')
+        .mockImplementation((key) =>
+          key === 'orgId' ? integration.orgId : undefined,
+        );
+      jest.spyOn(validateAccess, 'validate').mockResolvedValue(integration);
+
+      await expect(service.resolveOAuthActor(integration.id)).rejects.toThrow(
+        McpUnauthenticatedError,
+      );
     });
   });
 });

--- a/ayunis-core-backend/src/domain/mcp/application/services/oauth-flow.service.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/services/oauth-flow.service.ts
@@ -1,0 +1,395 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { createHash, randomBytes, type UUID } from 'crypto';
+import {
+  exchangeAuthorization,
+  refreshAuthorization,
+} from '@modelcontextprotocol/sdk/client/auth.js';
+import type { OAuthTokens } from '@modelcontextprotocol/sdk/shared/auth.js';
+import { McpOAuthStatePort } from '../ports/mcp-oauth-state.port';
+import { McpIntegrationOAuthTokenRepositoryPort } from '../ports/mcp-integration-oauth-token.repository.port';
+import { McpCredentialEncryptionPort } from '../ports/mcp-credential-encryption.port';
+import { McpIntegrationsRepositoryPort } from '../ports/mcp-integrations.repository.port';
+import { McpIntegration } from '../../domain/mcp-integration.entity';
+import { McpIntegrationOAuthToken } from '../../domain/mcp-integration-oauth-token.entity';
+import {
+  McpInvalidConfigSchemaError,
+  McpOAuthClientNotConfiguredError,
+  McpOAuthAuthorizationRequiredError,
+  McpOAuthStateInvalidError,
+  McpOAuthExchangeFailedError,
+  McpIntegrationNotFoundError,
+} from '../mcp.errors';
+import type {
+  IntegrationConfigSchema,
+  OAuthConfig,
+} from '../../domain/value-objects/integration-config-schema';
+
+/**
+ * Orchestrates the OAuth 2.1 + PKCE authorization flow for MCP integrations.
+ *
+ * Delegates PKCE generation, state JWT signing, and SDK-level token exchange
+ * to the appropriate ports / libraries. Never hand-rolls OAuth protocol logic.
+ */
+@Injectable()
+export class OAuthFlowService {
+  private readonly logger = new Logger(OAuthFlowService.name);
+
+  constructor(
+    private readonly stateAdapter: McpOAuthStatePort,
+    private readonly tokenRepository: McpIntegrationOAuthTokenRepositoryPort,
+    private readonly credentialEncryption: McpCredentialEncryptionPort,
+    private readonly integrationRepository: McpIntegrationsRepositoryPort,
+    private readonly configService: ConfigService,
+  ) {}
+
+  /**
+   * Extracts and validates the OAuth configuration from an integration.
+   * Use cases should call this instead of duplicating the config extraction logic.
+   */
+  resolveOAuthConfig(integration: McpIntegration): {
+    config: OAuthConfig;
+    level: 'org' | 'user';
+  } {
+    const configSchema = this.getOAuthConfigOrThrow(integration);
+    return { config: configSchema.oauth!, level: configSchema.oauth!.level };
+  }
+
+  /**
+   * Builds the OAuth authorization URL that the user should be redirected to.
+   * Generates a PKCE verifier, signs it (alongside integration metadata) into
+   * a state JWT, and constructs the full authorization URL with all required
+   * OAuth 2.1 parameters.
+   */
+  buildAuthorizationUrl(
+    integration: McpIntegration,
+    level: 'org' | 'user',
+    orgId: UUID,
+    userIdOrNull: UUID | null,
+  ): { url: string } {
+    const configSchema = this.getOAuthConfigOrThrow(integration);
+
+    if (!integration.oauthClientId) {
+      throw new McpOAuthClientNotConfiguredError();
+    }
+
+    const backendBaseUrl = this.configService.getOrThrow<string>(
+      'app.backend.baseUrl',
+    );
+    const redirectUri = `${backendBaseUrl}/mcp-integrations/oauth/callback`;
+
+    const codeVerifier = randomBytes(32).toString('base64url');
+    const codeChallenge = createHash('sha256')
+      .update(codeVerifier)
+      .digest('base64url');
+
+    const stateToken = this.stateAdapter.sign(
+      {
+        integrationId: integration.id,
+        level,
+        orgId,
+        userId: userIdOrNull,
+        codeVerifier,
+        redirectUri,
+        nonce: randomBytes(16).toString('base64url'),
+      },
+      600,
+    );
+
+    const url = new URL(configSchema.oauth!.authorizationUrl);
+    url.searchParams.set('response_type', 'code');
+    url.searchParams.set('client_id', integration.oauthClientId);
+    url.searchParams.set('redirect_uri', redirectUri);
+    url.searchParams.set('scope', configSchema.oauth!.scopes.join(' '));
+    url.searchParams.set('state', stateToken);
+    url.searchParams.set('code_challenge', codeChallenge);
+    url.searchParams.set('code_challenge_method', 'S256');
+
+    return { url: url.toString() };
+  }
+
+  /**
+   * Handles the OAuth callback: verifies the state JWT, exchanges the
+   * authorization code for tokens via the MCP SDK, encrypts and persists
+   * the tokens, and returns identifying info for the controller redirect.
+   */
+  async handleCallback(
+    code: string,
+    stateToken: string,
+  ): Promise<{
+    integrationId: UUID;
+    level: 'org' | 'user';
+    userId: UUID | null;
+  }> {
+    const state = this.verifyStateOrThrow(stateToken);
+
+    const integration = await this.integrationRepository.findById(
+      state.integrationId,
+    );
+    if (!integration) {
+      throw new McpIntegrationNotFoundError(state.integrationId);
+    }
+
+    if (integration.orgId !== state.orgId) {
+      throw new McpOAuthStateInvalidError();
+    }
+
+    const configSchema = this.getOAuthConfigOrThrow(integration);
+    const decryptedClientSecret = await this.decryptClientSecret(integration);
+
+    let tokens: {
+      access_token: string;
+      refresh_token?: string;
+      expires_in?: number;
+      scope?: string;
+    };
+    try {
+      tokens = await exchangeAuthorization(configSchema.oauth!.tokenUrl, {
+        clientInformation: {
+          client_id: integration.oauthClientId!,
+          client_secret: decryptedClientSecret,
+        },
+        authorizationCode: code,
+        codeVerifier: state.codeVerifier,
+        redirectUri: state.redirectUri,
+      });
+    } catch (error) {
+      const reason =
+        error instanceof Error ? error.message : 'Unknown exchange error';
+      throw new McpOAuthExchangeFailedError(reason);
+    }
+
+    // Fresh authorization: if the grant omits refresh_token, explicitly
+    // clear any stale refresh token from a previous (unrelated) grant.
+    // This differs from the refresh path where undefined means "preserve".
+    await this.upsertTokens(integration.id, state.userId, {
+      ...tokens,
+      refresh_token: tokens.refresh_token ?? null,
+      scope: tokens.scope ?? null,
+    });
+
+    return {
+      integrationId: state.integrationId,
+      level: state.level,
+      userId: state.userId,
+    };
+  }
+
+  /**
+   * Returns a valid (non-expired) plaintext access token for the given
+   * integration and user. If the token is expired and a refresh token is
+   * available, performs a lazy refresh. Otherwise throws
+   * `McpOAuthAuthorizationRequiredError`.
+   */
+  async getValidAccessToken(
+    integration: McpIntegration,
+    userIdOrNull: UUID | null,
+  ): Promise<string> {
+    const tokenRow = await this.tokenRepository.findByIntegrationAndUser(
+      integration.id,
+      userIdOrNull,
+    );
+
+    if (!tokenRow) {
+      throw new McpOAuthAuthorizationRequiredError(integration.id);
+    }
+
+    if (!tokenRow.isExpired()) {
+      return this.credentialEncryption.decrypt(tokenRow.accessTokenEncrypted);
+    }
+
+    return this.refreshOrRequireAuth(integration, tokenRow);
+  }
+
+  /**
+   * Deletes the OAuth token for the given integration and user (or org-level).
+   */
+  async revoke(integrationId: UUID, userIdOrNull: UUID | null): Promise<void> {
+    await this.tokenRepository.deleteByIntegrationAndUser(
+      integrationId,
+      userIdOrNull,
+    );
+  }
+
+  /**
+   * Returns the authorization status for the given integration and user
+   * without decrypting or returning any token values.
+   */
+  async getStatus(
+    integrationId: UUID,
+    userIdOrNull: UUID | null,
+  ): Promise<{
+    authorized: boolean;
+    expiresAt: Date | null;
+    scope: string | null;
+  }> {
+    const tokenRow = await this.tokenRepository.findByIntegrationAndUser(
+      integrationId,
+      userIdOrNull,
+    );
+
+    if (!tokenRow) {
+      return { authorized: false, expiresAt: null, scope: null };
+    }
+
+    const expired = tokenRow.isExpired();
+    const hasRefreshToken = !!tokenRow.refreshTokenEncrypted;
+
+    return {
+      authorized: !expired || hasRefreshToken,
+      expiresAt: tokenRow.tokenExpiresAt ?? null,
+      scope: tokenRow.scope ?? null,
+    };
+  }
+
+  // ── Private helpers ──────────────────────────────────────────────
+
+  private getOAuthConfigOrThrow(
+    integration: McpIntegration,
+  ): IntegrationConfigSchema {
+    const configSchema = this.extractConfigSchema(integration);
+    if (!configSchema?.oauth) {
+      throw new McpInvalidConfigSchemaError(
+        'Integration does not have OAuth configured',
+      );
+    }
+    return configSchema;
+  }
+
+  private extractConfigSchema(
+    integration: McpIntegration,
+  ): IntegrationConfigSchema | undefined {
+    // Both MarketplaceMcpIntegration and SelfDefinedMcpIntegration expose
+    // `configSchema` — use a structural check to avoid importing both.
+    if ('configSchema' in integration) {
+      return (
+        integration as unknown as { configSchema: IntegrationConfigSchema }
+      ).configSchema;
+    }
+    return undefined;
+  }
+
+  private verifyStateOrThrow(stateToken: string) {
+    try {
+      return this.stateAdapter.verify(stateToken);
+    } catch {
+      throw new McpOAuthStateInvalidError();
+    }
+  }
+
+  private async decryptClientSecret(
+    integration: McpIntegration,
+  ): Promise<string> {
+    if (!integration.oauthClientSecretEncrypted) {
+      throw new McpOAuthClientNotConfiguredError();
+    }
+    return this.credentialEncryption.decrypt(
+      integration.oauthClientSecretEncrypted,
+    );
+  }
+
+  /**
+   * Persists OAuth tokens for an integration.
+   *
+   * `refresh_token` follows a three-state convention:
+   *   - `string`    → encrypt and store the new refresh token
+   *   - `undefined` → preserve the existing refresh token (RFC 6749 §6 refresh)
+   *   - `null`      → clear the existing refresh token (fresh authorization)
+   */
+  private async upsertTokens(
+    integrationId: UUID,
+    userIdOrNull: UUID | null,
+    tokens: {
+      access_token: string;
+      refresh_token?: string | null;
+      expires_in?: number;
+      scope?: string | null;
+    },
+  ): Promise<void> {
+    const accessTokenEncrypted = await this.credentialEncryption.encrypt(
+      tokens.access_token,
+    );
+    const refreshTokenEncrypted: string | null | undefined =
+      tokens.refresh_token
+        ? await this.credentialEncryption.encrypt(tokens.refresh_token)
+        : tokens.refresh_token === null
+          ? null
+          : undefined;
+    const tokenExpiresAt: Date | null =
+      tokens.expires_in !== undefined
+        ? new Date(Date.now() + tokens.expires_in * 1000)
+        : null; // clear stale expiry — "no known expiry" = treat as never expires
+
+    const existing = await this.tokenRepository.findByIntegrationAndUser(
+      integrationId,
+      userIdOrNull,
+    );
+
+    if (existing) {
+      existing.updateTokens({
+        accessTokenEncrypted,
+        refreshTokenEncrypted,
+        tokenExpiresAt,
+        scope: tokens.scope,
+      });
+      await this.tokenRepository.save(existing);
+    } else {
+      const token = new McpIntegrationOAuthToken({
+        integrationId,
+        userId: userIdOrNull,
+        accessTokenEncrypted,
+        refreshTokenEncrypted: refreshTokenEncrypted ?? undefined,
+        tokenExpiresAt: tokenExpiresAt ?? undefined,
+        scope: tokens.scope ?? undefined,
+      });
+      await this.tokenRepository.save(token);
+    }
+  }
+
+  private async refreshOrRequireAuth(
+    integration: McpIntegration,
+    tokenRow: McpIntegrationOAuthToken,
+  ): Promise<string> {
+    if (!tokenRow.refreshTokenEncrypted) {
+      await this.tokenRepository.deleteByIntegrationAndUser(
+        integration.id,
+        tokenRow.userId,
+      );
+      throw new McpOAuthAuthorizationRequiredError(integration.id);
+    }
+
+    const configSchema = this.getOAuthConfigOrThrow(integration);
+
+    let newTokens: OAuthTokens;
+    try {
+      const decryptedRefreshToken = await this.credentialEncryption.decrypt(
+        tokenRow.refreshTokenEncrypted,
+      );
+      const decryptedClientSecret = await this.decryptClientSecret(integration);
+
+      newTokens = await refreshAuthorization(configSchema.oauth!.tokenUrl, {
+        clientInformation: {
+          client_id: integration.oauthClientId!,
+          client_secret: decryptedClientSecret,
+        },
+        refreshToken: decryptedRefreshToken,
+      });
+    } catch (error) {
+      this.logger.warn('OAuth refresh failed, requiring re-authorization', {
+        integrationId: integration.id,
+        error: error instanceof Error ? error.message : String(error),
+      });
+
+      await this.tokenRepository.deleteByIntegrationAndUser(
+        integration.id,
+        tokenRow.userId,
+      );
+      throw new McpOAuthAuthorizationRequiredError(integration.id);
+    }
+
+    // Persistence errors propagate naturally — old token is still valid in DB
+    await this.upsertTokens(integration.id, tokenRow.userId, newTokens);
+
+    return newTokens.access_token;
+  }
+}

--- a/ayunis-core-backend/src/domain/mcp/application/services/oauth-flow.service.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/services/oauth-flow.service.ts
@@ -10,6 +10,8 @@ import { McpOAuthStatePort } from '../ports/mcp-oauth-state.port';
 import { McpIntegrationOAuthTokenRepositoryPort } from '../ports/mcp-integration-oauth-token.repository.port';
 import { McpCredentialEncryptionPort } from '../ports/mcp-credential-encryption.port';
 import { McpIntegrationsRepositoryPort } from '../ports/mcp-integrations.repository.port';
+import { ValidateIntegrationAccessService } from './validate-integration-access.service';
+import { ContextService } from 'src/common/context/services/context.service';
 import { McpIntegration } from '../../domain/mcp-integration.entity';
 import { McpIntegrationOAuthToken } from '../../domain/mcp-integration-oauth-token.entity';
 import {
@@ -19,11 +21,19 @@ import {
   McpOAuthStateInvalidError,
   McpOAuthExchangeFailedError,
   McpIntegrationNotFoundError,
+  McpUnauthenticatedError,
 } from '../mcp.errors';
 import type {
   IntegrationConfigSchema,
   OAuthConfig,
 } from '../../domain/value-objects/integration-config-schema';
+
+export interface OAuthActorContext {
+  integration: McpIntegration;
+  level: 'org' | 'user';
+  orgId: UUID;
+  userIdOrNull: UUID | null;
+}
 
 /**
  * Orchestrates the OAuth 2.1 + PKCE authorization flow for MCP integrations.
@@ -41,6 +51,8 @@ export class OAuthFlowService {
     private readonly credentialEncryption: McpCredentialEncryptionPort,
     private readonly integrationRepository: McpIntegrationsRepositoryPort,
     private readonly configService: ConfigService,
+    private readonly validateAccess: ValidateIntegrationAccessService,
+    private readonly contextService: ContextService,
   ) {}
 
   /**
@@ -53,6 +65,32 @@ export class OAuthFlowService {
   } {
     const configSchema = this.getOAuthConfigOrThrow(integration);
     return { config: configSchema.oauth!, level: configSchema.oauth!.level };
+  }
+
+  /**
+   * Validates access, resolves OAuth config, and computes the actor context
+   * (integration, level, orgId, userIdOrNull) shared by all OAuth use cases.
+   */
+  async resolveOAuthActor(integrationId: string): Promise<OAuthActorContext> {
+    const orgId = this.contextService.get('orgId');
+    if (!orgId) {
+      throw new McpUnauthenticatedError();
+    }
+
+    const userId = this.contextService.get('userId');
+
+    const integration = await this.validateAccess.validate(integrationId, {
+      requireEnabled: false,
+    });
+
+    const { level } = this.resolveOAuthConfig(integration);
+
+    if (level === 'user' && !userId) {
+      throw new McpUnauthenticatedError();
+    }
+    const userIdOrNull: UUID | null = level === 'user' ? userId! : null;
+
+    return { integration, level, orgId, userIdOrNull };
   }
 
   /**

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/complete-mcp-oauth-authorization/complete-mcp-oauth-authorization.command.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/complete-mcp-oauth-authorization/complete-mcp-oauth-authorization.command.ts
@@ -1,0 +1,6 @@
+export class CompleteMcpOAuthAuthorizationCommand {
+  constructor(
+    public readonly code: string,
+    public readonly state: string,
+  ) {}
+}

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/complete-mcp-oauth-authorization/complete-mcp-oauth-authorization.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/complete-mcp-oauth-authorization/complete-mcp-oauth-authorization.use-case.spec.ts
@@ -1,0 +1,85 @@
+import type { TestingModule } from '@nestjs/testing';
+import { Test } from '@nestjs/testing';
+import { Logger } from '@nestjs/common';
+import { randomUUID } from 'crypto';
+import { CompleteMcpOAuthAuthorizationUseCase } from './complete-mcp-oauth-authorization.use-case';
+import { CompleteMcpOAuthAuthorizationCommand } from './complete-mcp-oauth-authorization.command';
+import { OAuthFlowService } from '../../services/oauth-flow.service';
+import {
+  McpOAuthExchangeFailedError,
+  McpOAuthStateInvalidError,
+} from '../../mcp.errors';
+
+describe('CompleteMcpOAuthAuthorizationUseCase', () => {
+  let useCase: CompleteMcpOAuthAuthorizationUseCase;
+  let oauthFlowService: OAuthFlowService;
+
+  beforeAll(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        CompleteMcpOAuthAuthorizationUseCase,
+        {
+          provide: OAuthFlowService,
+          useValue: { handleCallback: jest.fn() },
+        },
+      ],
+    }).compile();
+
+    useCase = module.get(CompleteMcpOAuthAuthorizationUseCase);
+    oauthFlowService = module.get(OAuthFlowService);
+
+    jest.spyOn(Logger.prototype, 'log').mockImplementation();
+    jest.spyOn(Logger.prototype, 'error').mockImplementation();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return success when callback completes', async () => {
+    const integrationId = randomUUID();
+    jest.spyOn(oauthFlowService, 'handleCallback').mockResolvedValue({
+      integrationId,
+      level: 'org',
+      userId: null,
+    });
+
+    const result = await useCase.execute(
+      new CompleteMcpOAuthAuthorizationCommand('auth-code', 'state-jwt'),
+    );
+
+    expect(result).toEqual({ success: true, integrationId });
+  });
+
+  it('should return failure on exchange error', async () => {
+    jest
+      .spyOn(oauthFlowService, 'handleCallback')
+      .mockRejectedValue(
+        new McpOAuthExchangeFailedError('token endpoint error'),
+      );
+
+    const result = await useCase.execute(
+      new CompleteMcpOAuthAuthorizationCommand('code', 'state'),
+    );
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.reason).toContain('token endpoint error');
+    }
+  });
+
+  it('should return failure on invalid state', async () => {
+    jest
+      .spyOn(oauthFlowService, 'handleCallback')
+      .mockRejectedValue(new McpOAuthStateInvalidError());
+
+    const result = await useCase.execute(
+      new CompleteMcpOAuthAuthorizationCommand('code', 'bad-state'),
+    );
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.reason).toBeDefined();
+    }
+  });
+});

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/complete-mcp-oauth-authorization/complete-mcp-oauth-authorization.use-case.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/complete-mcp-oauth-authorization/complete-mcp-oauth-authorization.use-case.ts
@@ -1,0 +1,58 @@
+import { Injectable, Logger } from '@nestjs/common';
+import type { UUID } from 'crypto';
+import { CompleteMcpOAuthAuthorizationCommand } from './complete-mcp-oauth-authorization.command';
+import { OAuthFlowService } from '../../services/oauth-flow.service';
+import {
+  McpOAuthExchangeFailedError,
+  McpOAuthStateInvalidError,
+  UnexpectedMcpError,
+} from '../../mcp.errors';
+import { ApplicationError } from 'src/common/errors/base.error';
+
+export type CompleteMcpOAuthResult =
+  | { success: true; integrationId: UUID }
+  | { success: false; reason: string };
+
+@Injectable()
+export class CompleteMcpOAuthAuthorizationUseCase {
+  private readonly logger = new Logger(
+    CompleteMcpOAuthAuthorizationUseCase.name,
+  );
+
+  constructor(private readonly oauthFlowService: OAuthFlowService) {}
+
+  async execute(
+    command: CompleteMcpOAuthAuthorizationCommand,
+  ): Promise<CompleteMcpOAuthResult> {
+    this.logger.log('completeMcpOAuthAuthorization');
+
+    try {
+      const result = await this.oauthFlowService.handleCallback(
+        command.code,
+        command.state,
+      );
+
+      return {
+        success: true,
+        integrationId: result.integrationId,
+      };
+    } catch (error) {
+      if (
+        error instanceof McpOAuthExchangeFailedError ||
+        error instanceof McpOAuthStateInvalidError
+      ) {
+        return {
+          success: false,
+          reason: error.message,
+        };
+      }
+      if (error instanceof ApplicationError) {
+        throw error;
+      }
+      this.logger.error('Unexpected error completing OAuth authorization', {
+        error: error as Error,
+      });
+      throw new UnexpectedMcpError('Unexpected error occurred');
+    }
+  }
+}

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/get-mcp-oauth-authorization-status/get-mcp-oauth-authorization-status.query.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/get-mcp-oauth-authorization-status/get-mcp-oauth-authorization-status.query.ts
@@ -1,0 +1,5 @@
+import type { UUID } from 'crypto';
+
+export class GetMcpOAuthAuthorizationStatusQuery {
+  constructor(public readonly integrationId: UUID) {}
+}

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/get-mcp-oauth-authorization-status/get-mcp-oauth-authorization-status.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/get-mcp-oauth-authorization-status/get-mcp-oauth-authorization-status.use-case.spec.ts
@@ -5,8 +5,6 @@ import { randomUUID } from 'crypto';
 import { GetMcpOAuthAuthorizationStatusUseCase } from './get-mcp-oauth-authorization-status.use-case';
 import { GetMcpOAuthAuthorizationStatusQuery } from './get-mcp-oauth-authorization-status.query';
 import { OAuthFlowService } from '../../services/oauth-flow.service';
-import { ValidateIntegrationAccessService } from '../../services/validate-integration-access.service';
-import { ContextService } from 'src/common/context/services/context.service';
 import { SelfDefinedMcpIntegration } from '../../../domain/integrations/self-defined-mcp-integration.entity';
 import { NoAuthMcpIntegrationAuth } from '../../../domain/auth/no-auth-mcp-integration-auth.entity';
 import type { IntegrationConfigSchema } from '../../../domain/value-objects/integration-config-schema';
@@ -15,8 +13,6 @@ import { McpUnauthenticatedError } from '../../mcp.errors';
 describe('GetMcpOAuthAuthorizationStatusUseCase', () => {
   let useCase: GetMcpOAuthAuthorizationStatusUseCase;
   let oauthFlowService: OAuthFlowService;
-  let validateAccess: ValidateIntegrationAccessService;
-  let contextService: ContextService;
 
   const mockOrgId = randomUUID();
   const mockUserId = randomUUID();
@@ -39,23 +35,16 @@ describe('GetMcpOAuthAuthorizationStatusUseCase', () => {
         GetMcpOAuthAuthorizationStatusUseCase,
         {
           provide: OAuthFlowService,
-          useValue: { getStatus: jest.fn(), resolveOAuthConfig: jest.fn() },
-        },
-        {
-          provide: ValidateIntegrationAccessService,
-          useValue: { validate: jest.fn() },
-        },
-        {
-          provide: ContextService,
-          useValue: { get: jest.fn() },
+          useValue: {
+            getStatus: jest.fn(),
+            resolveOAuthActor: jest.fn(),
+          },
         },
       ],
     }).compile();
 
     useCase = module.get(GetMcpOAuthAuthorizationStatusUseCase);
     oauthFlowService = module.get(OAuthFlowService);
-    validateAccess = module.get(ValidateIntegrationAccessService);
-    contextService = module.get(ContextService);
 
     jest.spyOn(Logger.prototype, 'log').mockImplementation();
     jest.spyOn(Logger.prototype, 'error').mockImplementation();
@@ -77,13 +66,12 @@ describe('GetMcpOAuthAuthorizationStatusUseCase', () => {
       oauthClientSecretEncrypted: 'enc',
     });
 
-    jest
-      .spyOn(contextService, 'get')
-      .mockImplementation((key) => (key === 'orgId' ? mockOrgId : mockUserId));
-    jest.spyOn(validateAccess, 'validate').mockResolvedValue(integration);
-    jest
-      .spyOn(oauthFlowService, 'resolveOAuthConfig')
-      .mockReturnValue({ config: oauthConfigSchema.oauth!, level: 'org' });
+    jest.spyOn(oauthFlowService, 'resolveOAuthActor').mockResolvedValue({
+      integration,
+      level: 'org',
+      orgId: mockOrgId,
+      userIdOrNull: null,
+    });
     jest.spyOn(oauthFlowService, 'getStatus').mockResolvedValue({
       authorized: true,
       expiresAt: new Date('2026-01-01'),
@@ -103,7 +91,7 @@ describe('GetMcpOAuthAuthorizationStatusUseCase', () => {
 
     expect(oauthFlowService.getStatus).toHaveBeenCalledWith(
       integration.id,
-      null, // org-level
+      null,
     );
   });
 
@@ -123,13 +111,12 @@ describe('GetMcpOAuthAuthorizationStatusUseCase', () => {
       oauthClientSecretEncrypted: 'enc',
     });
 
-    jest
-      .spyOn(contextService, 'get')
-      .mockImplementation((key) => (key === 'orgId' ? mockOrgId : mockUserId));
-    jest.spyOn(validateAccess, 'validate').mockResolvedValue(integration);
-    jest
-      .spyOn(oauthFlowService, 'resolveOAuthConfig')
-      .mockReturnValue({ config: userLevelSchema.oauth!, level: 'user' });
+    jest.spyOn(oauthFlowService, 'resolveOAuthActor').mockResolvedValue({
+      integration,
+      level: 'user',
+      orgId: mockOrgId,
+      userIdOrNull: mockUserId,
+    });
     jest.spyOn(oauthFlowService, 'getStatus').mockResolvedValue({
       authorized: false,
       expiresAt: null,
@@ -148,7 +135,9 @@ describe('GetMcpOAuthAuthorizationStatusUseCase', () => {
   });
 
   it('should throw McpUnauthenticatedError when orgId missing', async () => {
-    jest.spyOn(contextService, 'get').mockReturnValue(undefined);
+    jest
+      .spyOn(oauthFlowService, 'resolveOAuthActor')
+      .mockRejectedValue(new McpUnauthenticatedError());
 
     await expect(
       useCase.execute(new GetMcpOAuthAuthorizationStatusQuery(randomUUID())),

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/get-mcp-oauth-authorization-status/get-mcp-oauth-authorization-status.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/get-mcp-oauth-authorization-status/get-mcp-oauth-authorization-status.use-case.spec.ts
@@ -1,0 +1,157 @@
+import type { TestingModule } from '@nestjs/testing';
+import { Test } from '@nestjs/testing';
+import { Logger } from '@nestjs/common';
+import { randomUUID } from 'crypto';
+import { GetMcpOAuthAuthorizationStatusUseCase } from './get-mcp-oauth-authorization-status.use-case';
+import { GetMcpOAuthAuthorizationStatusQuery } from './get-mcp-oauth-authorization-status.query';
+import { OAuthFlowService } from '../../services/oauth-flow.service';
+import { ValidateIntegrationAccessService } from '../../services/validate-integration-access.service';
+import { ContextService } from 'src/common/context/services/context.service';
+import { SelfDefinedMcpIntegration } from '../../../domain/integrations/self-defined-mcp-integration.entity';
+import { NoAuthMcpIntegrationAuth } from '../../../domain/auth/no-auth-mcp-integration-auth.entity';
+import type { IntegrationConfigSchema } from '../../../domain/value-objects/integration-config-schema';
+import { McpUnauthenticatedError } from '../../mcp.errors';
+
+describe('GetMcpOAuthAuthorizationStatusUseCase', () => {
+  let useCase: GetMcpOAuthAuthorizationStatusUseCase;
+  let oauthFlowService: OAuthFlowService;
+  let validateAccess: ValidateIntegrationAccessService;
+  let contextService: ContextService;
+
+  const mockOrgId = randomUUID();
+  const mockUserId = randomUUID();
+
+  const oauthConfigSchema: IntegrationConfigSchema = {
+    authType: 'OAUTH',
+    orgFields: [],
+    userFields: [],
+    oauth: {
+      authorizationUrl: 'https://auth.example.com/authorize',
+      tokenUrl: 'https://auth.example.com/token',
+      scopes: ['read'],
+      level: 'org',
+    },
+  };
+
+  beforeAll(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        GetMcpOAuthAuthorizationStatusUseCase,
+        {
+          provide: OAuthFlowService,
+          useValue: { getStatus: jest.fn(), resolveOAuthConfig: jest.fn() },
+        },
+        {
+          provide: ValidateIntegrationAccessService,
+          useValue: { validate: jest.fn() },
+        },
+        {
+          provide: ContextService,
+          useValue: { get: jest.fn() },
+        },
+      ],
+    }).compile();
+
+    useCase = module.get(GetMcpOAuthAuthorizationStatusUseCase);
+    oauthFlowService = module.get(OAuthFlowService);
+    validateAccess = module.get(ValidateIntegrationAccessService);
+    contextService = module.get(ContextService);
+
+    jest.spyOn(Logger.prototype, 'log').mockImplementation();
+    jest.spyOn(Logger.prototype, 'error').mockImplementation();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return status with level for an org-level OAuth integration', async () => {
+    const integration = new SelfDefinedMcpIntegration({
+      orgId: mockOrgId,
+      name: 'Test',
+      serverUrl: 'https://mcp.example.com',
+      configSchema: oauthConfigSchema,
+      orgConfigValues: {},
+      auth: new NoAuthMcpIntegrationAuth(),
+      oauthClientId: 'cid',
+      oauthClientSecretEncrypted: 'enc',
+    });
+
+    jest
+      .spyOn(contextService, 'get')
+      .mockImplementation((key) => (key === 'orgId' ? mockOrgId : mockUserId));
+    jest.spyOn(validateAccess, 'validate').mockResolvedValue(integration);
+    jest
+      .spyOn(oauthFlowService, 'resolveOAuthConfig')
+      .mockReturnValue({ config: oauthConfigSchema.oauth!, level: 'org' });
+    jest.spyOn(oauthFlowService, 'getStatus').mockResolvedValue({
+      authorized: true,
+      expiresAt: new Date('2026-01-01'),
+      scope: 'read',
+    });
+
+    const result = await useCase.execute(
+      new GetMcpOAuthAuthorizationStatusQuery(integration.id),
+    );
+
+    expect(result).toEqual({
+      level: 'org',
+      authorized: true,
+      expiresAt: new Date('2026-01-01'),
+      scope: 'read',
+    });
+
+    expect(oauthFlowService.getStatus).toHaveBeenCalledWith(
+      integration.id,
+      null, // org-level
+    );
+  });
+
+  it('should use userId for user-level OAuth', async () => {
+    const userLevelSchema: IntegrationConfigSchema = {
+      ...oauthConfigSchema,
+      oauth: { ...oauthConfigSchema.oauth!, level: 'user' },
+    };
+    const integration = new SelfDefinedMcpIntegration({
+      orgId: mockOrgId,
+      name: 'Test',
+      serverUrl: 'https://mcp.example.com',
+      configSchema: userLevelSchema,
+      orgConfigValues: {},
+      auth: new NoAuthMcpIntegrationAuth(),
+      oauthClientId: 'cid',
+      oauthClientSecretEncrypted: 'enc',
+    });
+
+    jest
+      .spyOn(contextService, 'get')
+      .mockImplementation((key) => (key === 'orgId' ? mockOrgId : mockUserId));
+    jest.spyOn(validateAccess, 'validate').mockResolvedValue(integration);
+    jest
+      .spyOn(oauthFlowService, 'resolveOAuthConfig')
+      .mockReturnValue({ config: userLevelSchema.oauth!, level: 'user' });
+    jest.spyOn(oauthFlowService, 'getStatus').mockResolvedValue({
+      authorized: false,
+      expiresAt: null,
+      scope: null,
+    });
+
+    const result = await useCase.execute(
+      new GetMcpOAuthAuthorizationStatusQuery(integration.id),
+    );
+
+    expect(result.level).toBe('user');
+    expect(oauthFlowService.getStatus).toHaveBeenCalledWith(
+      integration.id,
+      mockUserId,
+    );
+  });
+
+  it('should throw McpUnauthenticatedError when orgId missing', async () => {
+    jest.spyOn(contextService, 'get').mockReturnValue(undefined);
+
+    await expect(
+      useCase.execute(new GetMcpOAuthAuthorizationStatusQuery(randomUUID())),
+    ).rejects.toThrow(McpUnauthenticatedError);
+  });
+});

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/get-mcp-oauth-authorization-status/get-mcp-oauth-authorization-status.use-case.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/get-mcp-oauth-authorization-status/get-mcp-oauth-authorization-status.use-case.ts
@@ -1,0 +1,75 @@
+import { Injectable, Logger } from '@nestjs/common';
+import type { UUID } from 'crypto';
+import { GetMcpOAuthAuthorizationStatusQuery } from './get-mcp-oauth-authorization-status.query';
+import { OAuthFlowService } from '../../services/oauth-flow.service';
+import { ValidateIntegrationAccessService } from '../../services/validate-integration-access.service';
+import { ContextService } from 'src/common/context/services/context.service';
+import { McpUnauthenticatedError, UnexpectedMcpError } from '../../mcp.errors';
+import { ApplicationError } from 'src/common/errors/base.error';
+
+export interface OAuthAuthorizationStatusResult {
+  level: 'org' | 'user';
+  authorized: boolean;
+  expiresAt: Date | null;
+  scope: string | null;
+}
+
+@Injectable()
+export class GetMcpOAuthAuthorizationStatusUseCase {
+  private readonly logger = new Logger(
+    GetMcpOAuthAuthorizationStatusUseCase.name,
+  );
+
+  constructor(
+    private readonly oauthFlowService: OAuthFlowService,
+    private readonly validateAccess: ValidateIntegrationAccessService,
+    private readonly contextService: ContextService,
+  ) {}
+
+  async execute(
+    query: GetMcpOAuthAuthorizationStatusQuery,
+  ): Promise<OAuthAuthorizationStatusResult> {
+    this.logger.log('getMcpOAuthAuthorizationStatus', {
+      integrationId: query.integrationId,
+    });
+
+    try {
+      const orgId = this.contextService.get('orgId');
+      if (!orgId) {
+        throw new McpUnauthenticatedError();
+      }
+
+      const userId = this.contextService.get('userId');
+
+      const integration = await this.validateAccess.validate(
+        query.integrationId,
+        { requireEnabled: false },
+      );
+
+      const { level } = this.oauthFlowService.resolveOAuthConfig(integration);
+
+      if (level === 'user' && !userId) {
+        throw new McpUnauthenticatedError();
+      }
+      const userIdOrNull: UUID | null = level === 'user' ? userId! : null;
+
+      const status = await this.oauthFlowService.getStatus(
+        integration.id,
+        userIdOrNull,
+      );
+
+      return {
+        level,
+        ...status,
+      };
+    } catch (error) {
+      if (error instanceof ApplicationError) {
+        throw error;
+      }
+      this.logger.error('Unexpected error getting OAuth status', {
+        error: error as Error,
+      });
+      throw new UnexpectedMcpError('Unexpected error occurred');
+    }
+  }
+}

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/get-mcp-oauth-authorization-status/get-mcp-oauth-authorization-status.use-case.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/get-mcp-oauth-authorization-status/get-mcp-oauth-authorization-status.use-case.ts
@@ -1,10 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
-import type { UUID } from 'crypto';
 import { GetMcpOAuthAuthorizationStatusQuery } from './get-mcp-oauth-authorization-status.query';
 import { OAuthFlowService } from '../../services/oauth-flow.service';
-import { ValidateIntegrationAccessService } from '../../services/validate-integration-access.service';
-import { ContextService } from 'src/common/context/services/context.service';
-import { McpUnauthenticatedError, UnexpectedMcpError } from '../../mcp.errors';
+import { UnexpectedMcpError } from '../../mcp.errors';
 import { ApplicationError } from 'src/common/errors/base.error';
 
 export interface OAuthAuthorizationStatusResult {
@@ -20,11 +17,7 @@ export class GetMcpOAuthAuthorizationStatusUseCase {
     GetMcpOAuthAuthorizationStatusUseCase.name,
   );
 
-  constructor(
-    private readonly oauthFlowService: OAuthFlowService,
-    private readonly validateAccess: ValidateIntegrationAccessService,
-    private readonly contextService: ContextService,
-  ) {}
+  constructor(private readonly oauthFlowService: OAuthFlowService) {}
 
   async execute(
     query: GetMcpOAuthAuthorizationStatusQuery,
@@ -34,24 +27,8 @@ export class GetMcpOAuthAuthorizationStatusUseCase {
     });
 
     try {
-      const orgId = this.contextService.get('orgId');
-      if (!orgId) {
-        throw new McpUnauthenticatedError();
-      }
-
-      const userId = this.contextService.get('userId');
-
-      const integration = await this.validateAccess.validate(
-        query.integrationId,
-        { requireEnabled: false },
-      );
-
-      const { level } = this.oauthFlowService.resolveOAuthConfig(integration);
-
-      if (level === 'user' && !userId) {
-        throw new McpUnauthenticatedError();
-      }
-      const userIdOrNull: UUID | null = level === 'user' ? userId! : null;
+      const { integration, level, userIdOrNull } =
+        await this.oauthFlowService.resolveOAuthActor(query.integrationId);
 
       const status = await this.oauthFlowService.getStatus(
         integration.id,

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/revoke-mcp-oauth-authorization/revoke-mcp-oauth-authorization.command.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/revoke-mcp-oauth-authorization/revoke-mcp-oauth-authorization.command.ts
@@ -1,0 +1,5 @@
+import type { UUID } from 'crypto';
+
+export class RevokeMcpOAuthAuthorizationCommand {
+  constructor(public readonly integrationId: UUID) {}
+}

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/revoke-mcp-oauth-authorization/revoke-mcp-oauth-authorization.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/revoke-mcp-oauth-authorization/revoke-mcp-oauth-authorization.use-case.spec.ts
@@ -1,0 +1,106 @@
+import type { TestingModule } from '@nestjs/testing';
+import { Test } from '@nestjs/testing';
+import { Logger } from '@nestjs/common';
+import { randomUUID } from 'crypto';
+import { RevokeMcpOAuthAuthorizationUseCase } from './revoke-mcp-oauth-authorization.use-case';
+import { RevokeMcpOAuthAuthorizationCommand } from './revoke-mcp-oauth-authorization.command';
+import { OAuthFlowService } from '../../services/oauth-flow.service';
+import { ValidateIntegrationAccessService } from '../../services/validate-integration-access.service';
+import { ContextService } from 'src/common/context/services/context.service';
+import { SelfDefinedMcpIntegration } from '../../../domain/integrations/self-defined-mcp-integration.entity';
+import { NoAuthMcpIntegrationAuth } from '../../../domain/auth/no-auth-mcp-integration-auth.entity';
+import type { IntegrationConfigSchema } from '../../../domain/value-objects/integration-config-schema';
+import { McpUnauthenticatedError } from '../../mcp.errors';
+
+describe('RevokeMcpOAuthAuthorizationUseCase', () => {
+  let useCase: RevokeMcpOAuthAuthorizationUseCase;
+  let oauthFlowService: OAuthFlowService;
+  let validateAccess: ValidateIntegrationAccessService;
+  let contextService: ContextService;
+
+  const mockOrgId = randomUUID();
+  const mockUserId = randomUUID();
+
+  const oauthConfigSchema: IntegrationConfigSchema = {
+    authType: 'OAUTH',
+    orgFields: [],
+    userFields: [],
+    oauth: {
+      authorizationUrl: 'https://auth.example.com/authorize',
+      tokenUrl: 'https://auth.example.com/token',
+      scopes: ['read'],
+      level: 'org',
+    },
+  };
+
+  beforeAll(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        RevokeMcpOAuthAuthorizationUseCase,
+        {
+          provide: OAuthFlowService,
+          useValue: { revoke: jest.fn(), resolveOAuthConfig: jest.fn() },
+        },
+        {
+          provide: ValidateIntegrationAccessService,
+          useValue: { validate: jest.fn() },
+        },
+        {
+          provide: ContextService,
+          useValue: { get: jest.fn() },
+        },
+      ],
+    }).compile();
+
+    useCase = module.get(RevokeMcpOAuthAuthorizationUseCase);
+    oauthFlowService = module.get(OAuthFlowService);
+    validateAccess = module.get(ValidateIntegrationAccessService);
+    contextService = module.get(ContextService);
+
+    jest.spyOn(Logger.prototype, 'log').mockImplementation();
+    jest.spyOn(Logger.prototype, 'error').mockImplementation();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should revoke org-level OAuth token', async () => {
+    const integration = new SelfDefinedMcpIntegration({
+      orgId: mockOrgId,
+      name: 'Test',
+      serverUrl: 'https://mcp.example.com',
+      configSchema: oauthConfigSchema,
+      orgConfigValues: {},
+      auth: new NoAuthMcpIntegrationAuth(),
+      oauthClientId: 'cid',
+      oauthClientSecretEncrypted: 'enc',
+    });
+
+    jest
+      .spyOn(contextService, 'get')
+      .mockImplementation((key) => (key === 'orgId' ? mockOrgId : mockUserId));
+    jest.spyOn(validateAccess, 'validate').mockResolvedValue(integration);
+    jest
+      .spyOn(oauthFlowService, 'resolveOAuthConfig')
+      .mockReturnValue({ config: oauthConfigSchema.oauth!, level: 'org' });
+    jest.spyOn(oauthFlowService, 'revoke').mockResolvedValue(undefined);
+
+    await useCase.execute(
+      new RevokeMcpOAuthAuthorizationCommand(integration.id),
+    );
+
+    expect(oauthFlowService.revoke).toHaveBeenCalledWith(
+      integration.id,
+      null, // org-level
+    );
+  });
+
+  it('should throw McpUnauthenticatedError when orgId missing', async () => {
+    jest.spyOn(contextService, 'get').mockReturnValue(undefined);
+
+    await expect(
+      useCase.execute(new RevokeMcpOAuthAuthorizationCommand(randomUUID())),
+    ).rejects.toThrow(McpUnauthenticatedError);
+  });
+});

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/revoke-mcp-oauth-authorization/revoke-mcp-oauth-authorization.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/revoke-mcp-oauth-authorization/revoke-mcp-oauth-authorization.use-case.spec.ts
@@ -5,8 +5,6 @@ import { randomUUID } from 'crypto';
 import { RevokeMcpOAuthAuthorizationUseCase } from './revoke-mcp-oauth-authorization.use-case';
 import { RevokeMcpOAuthAuthorizationCommand } from './revoke-mcp-oauth-authorization.command';
 import { OAuthFlowService } from '../../services/oauth-flow.service';
-import { ValidateIntegrationAccessService } from '../../services/validate-integration-access.service';
-import { ContextService } from 'src/common/context/services/context.service';
 import { SelfDefinedMcpIntegration } from '../../../domain/integrations/self-defined-mcp-integration.entity';
 import { NoAuthMcpIntegrationAuth } from '../../../domain/auth/no-auth-mcp-integration-auth.entity';
 import type { IntegrationConfigSchema } from '../../../domain/value-objects/integration-config-schema';
@@ -15,8 +13,6 @@ import { McpUnauthenticatedError } from '../../mcp.errors';
 describe('RevokeMcpOAuthAuthorizationUseCase', () => {
   let useCase: RevokeMcpOAuthAuthorizationUseCase;
   let oauthFlowService: OAuthFlowService;
-  let validateAccess: ValidateIntegrationAccessService;
-  let contextService: ContextService;
 
   const mockOrgId = randomUUID();
   const mockUserId = randomUUID();
@@ -39,23 +35,16 @@ describe('RevokeMcpOAuthAuthorizationUseCase', () => {
         RevokeMcpOAuthAuthorizationUseCase,
         {
           provide: OAuthFlowService,
-          useValue: { revoke: jest.fn(), resolveOAuthConfig: jest.fn() },
-        },
-        {
-          provide: ValidateIntegrationAccessService,
-          useValue: { validate: jest.fn() },
-        },
-        {
-          provide: ContextService,
-          useValue: { get: jest.fn() },
+          useValue: {
+            revoke: jest.fn(),
+            resolveOAuthActor: jest.fn(),
+          },
         },
       ],
     }).compile();
 
     useCase = module.get(RevokeMcpOAuthAuthorizationUseCase);
     oauthFlowService = module.get(OAuthFlowService);
-    validateAccess = module.get(ValidateIntegrationAccessService);
-    contextService = module.get(ContextService);
 
     jest.spyOn(Logger.prototype, 'log').mockImplementation();
     jest.spyOn(Logger.prototype, 'error').mockImplementation();
@@ -77,27 +66,25 @@ describe('RevokeMcpOAuthAuthorizationUseCase', () => {
       oauthClientSecretEncrypted: 'enc',
     });
 
-    jest
-      .spyOn(contextService, 'get')
-      .mockImplementation((key) => (key === 'orgId' ? mockOrgId : mockUserId));
-    jest.spyOn(validateAccess, 'validate').mockResolvedValue(integration);
-    jest
-      .spyOn(oauthFlowService, 'resolveOAuthConfig')
-      .mockReturnValue({ config: oauthConfigSchema.oauth!, level: 'org' });
+    jest.spyOn(oauthFlowService, 'resolveOAuthActor').mockResolvedValue({
+      integration,
+      level: 'org',
+      orgId: mockOrgId,
+      userIdOrNull: null,
+    });
     jest.spyOn(oauthFlowService, 'revoke').mockResolvedValue(undefined);
 
     await useCase.execute(
       new RevokeMcpOAuthAuthorizationCommand(integration.id),
     );
 
-    expect(oauthFlowService.revoke).toHaveBeenCalledWith(
-      integration.id,
-      null, // org-level
-    );
+    expect(oauthFlowService.revoke).toHaveBeenCalledWith(integration.id, null);
   });
 
   it('should throw McpUnauthenticatedError when orgId missing', async () => {
-    jest.spyOn(contextService, 'get').mockReturnValue(undefined);
+    jest
+      .spyOn(oauthFlowService, 'resolveOAuthActor')
+      .mockRejectedValue(new McpUnauthenticatedError());
 
     await expect(
       useCase.execute(new RevokeMcpOAuthAuthorizationCommand(randomUUID())),

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/revoke-mcp-oauth-authorization/revoke-mcp-oauth-authorization.use-case.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/revoke-mcp-oauth-authorization/revoke-mcp-oauth-authorization.use-case.ts
@@ -1,0 +1,56 @@
+import { Injectable, Logger } from '@nestjs/common';
+import type { UUID } from 'crypto';
+import { RevokeMcpOAuthAuthorizationCommand } from './revoke-mcp-oauth-authorization.command';
+import { OAuthFlowService } from '../../services/oauth-flow.service';
+import { ValidateIntegrationAccessService } from '../../services/validate-integration-access.service';
+import { ContextService } from 'src/common/context/services/context.service';
+import { McpUnauthenticatedError, UnexpectedMcpError } from '../../mcp.errors';
+import { ApplicationError } from 'src/common/errors/base.error';
+
+@Injectable()
+export class RevokeMcpOAuthAuthorizationUseCase {
+  private readonly logger = new Logger(RevokeMcpOAuthAuthorizationUseCase.name);
+
+  constructor(
+    private readonly oauthFlowService: OAuthFlowService,
+    private readonly validateAccess: ValidateIntegrationAccessService,
+    private readonly contextService: ContextService,
+  ) {}
+
+  async execute(command: RevokeMcpOAuthAuthorizationCommand): Promise<void> {
+    this.logger.log('revokeMcpOAuthAuthorization', {
+      integrationId: command.integrationId,
+    });
+
+    try {
+      const orgId = this.contextService.get('orgId');
+      if (!orgId) {
+        throw new McpUnauthenticatedError();
+      }
+
+      const userId = this.contextService.get('userId');
+
+      const integration = await this.validateAccess.validate(
+        command.integrationId,
+        { requireEnabled: false },
+      );
+
+      const { level } = this.oauthFlowService.resolveOAuthConfig(integration);
+
+      if (level === 'user' && !userId) {
+        throw new McpUnauthenticatedError();
+      }
+      const userIdOrNull: UUID | null = level === 'user' ? userId! : null;
+
+      await this.oauthFlowService.revoke(integration.id, userIdOrNull);
+    } catch (error) {
+      if (error instanceof ApplicationError) {
+        throw error;
+      }
+      this.logger.error('Unexpected error revoking OAuth authorization', {
+        error: error as Error,
+      });
+      throw new UnexpectedMcpError('Unexpected error occurred');
+    }
+  }
+}

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/revoke-mcp-oauth-authorization/revoke-mcp-oauth-authorization.use-case.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/revoke-mcp-oauth-authorization/revoke-mcp-oauth-authorization.use-case.ts
@@ -1,21 +1,14 @@
 import { Injectable, Logger } from '@nestjs/common';
-import type { UUID } from 'crypto';
 import { RevokeMcpOAuthAuthorizationCommand } from './revoke-mcp-oauth-authorization.command';
 import { OAuthFlowService } from '../../services/oauth-flow.service';
-import { ValidateIntegrationAccessService } from '../../services/validate-integration-access.service';
-import { ContextService } from 'src/common/context/services/context.service';
-import { McpUnauthenticatedError, UnexpectedMcpError } from '../../mcp.errors';
+import { UnexpectedMcpError } from '../../mcp.errors';
 import { ApplicationError } from 'src/common/errors/base.error';
 
 @Injectable()
 export class RevokeMcpOAuthAuthorizationUseCase {
   private readonly logger = new Logger(RevokeMcpOAuthAuthorizationUseCase.name);
 
-  constructor(
-    private readonly oauthFlowService: OAuthFlowService,
-    private readonly validateAccess: ValidateIntegrationAccessService,
-    private readonly contextService: ContextService,
-  ) {}
+  constructor(private readonly oauthFlowService: OAuthFlowService) {}
 
   async execute(command: RevokeMcpOAuthAuthorizationCommand): Promise<void> {
     this.logger.log('revokeMcpOAuthAuthorization', {
@@ -23,24 +16,8 @@ export class RevokeMcpOAuthAuthorizationUseCase {
     });
 
     try {
-      const orgId = this.contextService.get('orgId');
-      if (!orgId) {
-        throw new McpUnauthenticatedError();
-      }
-
-      const userId = this.contextService.get('userId');
-
-      const integration = await this.validateAccess.validate(
-        command.integrationId,
-        { requireEnabled: false },
-      );
-
-      const { level } = this.oauthFlowService.resolveOAuthConfig(integration);
-
-      if (level === 'user' && !userId) {
-        throw new McpUnauthenticatedError();
-      }
-      const userIdOrNull: UUID | null = level === 'user' ? userId! : null;
+      const { integration, userIdOrNull } =
+        await this.oauthFlowService.resolveOAuthActor(command.integrationId);
 
       await this.oauthFlowService.revoke(integration.id, userIdOrNull);
     } catch (error) {

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/start-mcp-oauth-authorization/start-mcp-oauth-authorization.command.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/start-mcp-oauth-authorization/start-mcp-oauth-authorization.command.ts
@@ -1,0 +1,5 @@
+import type { UUID } from 'crypto';
+
+export class StartMcpOAuthAuthorizationCommand {
+  constructor(public readonly integrationId: UUID) {}
+}

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/start-mcp-oauth-authorization/start-mcp-oauth-authorization.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/start-mcp-oauth-authorization/start-mcp-oauth-authorization.use-case.spec.ts
@@ -1,0 +1,199 @@
+import type { TestingModule } from '@nestjs/testing';
+import { Test } from '@nestjs/testing';
+import { Logger } from '@nestjs/common';
+import { randomUUID } from 'crypto';
+import { StartMcpOAuthAuthorizationUseCase } from './start-mcp-oauth-authorization.use-case';
+import { StartMcpOAuthAuthorizationCommand } from './start-mcp-oauth-authorization.command';
+import { OAuthFlowService } from '../../services/oauth-flow.service';
+import { ValidateIntegrationAccessService } from '../../services/validate-integration-access.service';
+import { ContextService } from 'src/common/context/services/context.service';
+import { SelfDefinedMcpIntegration } from '../../../domain/integrations/self-defined-mcp-integration.entity';
+import { NoAuthMcpIntegrationAuth } from '../../../domain/auth/no-auth-mcp-integration-auth.entity';
+import type { IntegrationConfigSchema } from '../../../domain/value-objects/integration-config-schema';
+import {
+  McpInvalidConfigSchemaError,
+  McpUnauthenticatedError,
+} from '../../mcp.errors';
+
+describe('StartMcpOAuthAuthorizationUseCase', () => {
+  let useCase: StartMcpOAuthAuthorizationUseCase;
+  let oauthFlowService: OAuthFlowService;
+  let validateAccess: ValidateIntegrationAccessService;
+  let contextService: ContextService;
+
+  const mockOrgId = randomUUID();
+  const mockUserId = randomUUID();
+
+  const oauthConfigSchema: IntegrationConfigSchema = {
+    authType: 'OAUTH',
+    orgFields: [],
+    userFields: [],
+    oauth: {
+      authorizationUrl: 'https://auth.example.com/authorize',
+      tokenUrl: 'https://auth.example.com/token',
+      scopes: ['read'],
+      level: 'org',
+    },
+  };
+
+  function buildIntegration(
+    configSchema: IntegrationConfigSchema = oauthConfigSchema,
+  ): SelfDefinedMcpIntegration {
+    return new SelfDefinedMcpIntegration({
+      orgId: mockOrgId,
+      name: 'Test',
+      serverUrl: 'https://mcp.example.com',
+      configSchema,
+      orgConfigValues: {},
+      auth: new NoAuthMcpIntegrationAuth(),
+      oauthClientId: 'cid',
+      oauthClientSecretEncrypted: 'enc-secret',
+    });
+  }
+
+  beforeAll(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        StartMcpOAuthAuthorizationUseCase,
+        {
+          provide: OAuthFlowService,
+          useValue: {
+            buildAuthorizationUrl: jest.fn(),
+            resolveOAuthConfig: jest.fn(),
+          },
+        },
+        {
+          provide: ValidateIntegrationAccessService,
+          useValue: { validate: jest.fn() },
+        },
+        {
+          provide: ContextService,
+          useValue: { get: jest.fn() },
+        },
+      ],
+    }).compile();
+
+    useCase = module.get(StartMcpOAuthAuthorizationUseCase);
+    oauthFlowService = module.get(OAuthFlowService);
+    validateAccess = module.get(ValidateIntegrationAccessService);
+    contextService = module.get(ContextService);
+
+    jest.spyOn(Logger.prototype, 'log').mockImplementation();
+    jest.spyOn(Logger.prototype, 'error').mockImplementation();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return the authorization URL for org-level OAuth', async () => {
+    const integration = buildIntegration();
+    jest
+      .spyOn(contextService, 'get')
+      .mockImplementation((key) => (key === 'orgId' ? mockOrgId : mockUserId));
+    jest.spyOn(validateAccess, 'validate').mockResolvedValue(integration);
+    jest
+      .spyOn(oauthFlowService, 'resolveOAuthConfig')
+      .mockReturnValue({ config: oauthConfigSchema.oauth!, level: 'org' });
+    jest
+      .spyOn(oauthFlowService, 'buildAuthorizationUrl')
+      .mockReturnValue({ url: 'https://auth.example.com/authorize?...' });
+
+    const result = await useCase.execute(
+      new StartMcpOAuthAuthorizationCommand(integration.id),
+    );
+
+    expect(result.authorizationUrl).toBe(
+      'https://auth.example.com/authorize?...',
+    );
+    expect(oauthFlowService.buildAuthorizationUrl).toHaveBeenCalledWith(
+      integration,
+      'org',
+      mockOrgId,
+      null, // org-level → null userId
+    );
+  });
+
+  it('should pass userId for user-level OAuth', async () => {
+    const userLevelSchema: IntegrationConfigSchema = {
+      ...oauthConfigSchema,
+      oauth: { ...oauthConfigSchema.oauth!, level: 'user' },
+    };
+    const integration = buildIntegration(userLevelSchema);
+
+    jest
+      .spyOn(contextService, 'get')
+      .mockImplementation((key) => (key === 'orgId' ? mockOrgId : mockUserId));
+    jest.spyOn(validateAccess, 'validate').mockResolvedValue(integration);
+    jest
+      .spyOn(oauthFlowService, 'resolveOAuthConfig')
+      .mockReturnValue({ config: userLevelSchema.oauth!, level: 'user' });
+    jest
+      .spyOn(oauthFlowService, 'buildAuthorizationUrl')
+      .mockReturnValue({ url: 'https://auth.example.com/auth' });
+
+    await useCase.execute(
+      new StartMcpOAuthAuthorizationCommand(integration.id),
+    );
+
+    expect(oauthFlowService.buildAuthorizationUrl).toHaveBeenCalledWith(
+      integration,
+      'user',
+      mockOrgId,
+      mockUserId,
+    );
+  });
+
+  it('should throw McpUnauthenticatedError for user-level OAuth when userId is missing', async () => {
+    const userLevelSchema: IntegrationConfigSchema = {
+      ...oauthConfigSchema,
+      oauth: { ...oauthConfigSchema.oauth!, level: 'user' },
+    };
+    const integration = buildIntegration(userLevelSchema);
+
+    jest
+      .spyOn(contextService, 'get')
+      .mockImplementation((key) => (key === 'orgId' ? mockOrgId : undefined));
+    jest.spyOn(validateAccess, 'validate').mockResolvedValue(integration);
+    jest
+      .spyOn(oauthFlowService, 'resolveOAuthConfig')
+      .mockReturnValue({ config: userLevelSchema.oauth!, level: 'user' });
+
+    await expect(
+      useCase.execute(new StartMcpOAuthAuthorizationCommand(integration.id)),
+    ).rejects.toThrow(McpUnauthenticatedError);
+  });
+
+  it('should throw McpUnauthenticatedError when orgId is missing', async () => {
+    jest.spyOn(contextService, 'get').mockReturnValue(undefined);
+
+    await expect(
+      useCase.execute(new StartMcpOAuthAuthorizationCommand(randomUUID())),
+    ).rejects.toThrow(McpUnauthenticatedError);
+  });
+
+  it('should propagate error when resolveOAuthConfig throws', async () => {
+    const noOauthSchema: IntegrationConfigSchema = {
+      authType: 'NONE',
+      orgFields: [],
+      userFields: [],
+    };
+    const integration = buildIntegration(noOauthSchema);
+
+    jest
+      .spyOn(contextService, 'get')
+      .mockImplementation((key) => (key === 'orgId' ? mockOrgId : mockUserId));
+    jest.spyOn(validateAccess, 'validate').mockResolvedValue(integration);
+    jest
+      .spyOn(oauthFlowService, 'resolveOAuthConfig')
+      .mockImplementation(() => {
+        throw new McpInvalidConfigSchemaError(
+          'Integration does not have OAuth configured',
+        );
+      });
+
+    await expect(
+      useCase.execute(new StartMcpOAuthAuthorizationCommand(integration.id)),
+    ).rejects.toThrow(McpInvalidConfigSchemaError);
+  });
+});

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/start-mcp-oauth-authorization/start-mcp-oauth-authorization.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/start-mcp-oauth-authorization/start-mcp-oauth-authorization.use-case.spec.ts
@@ -5,8 +5,6 @@ import { randomUUID } from 'crypto';
 import { StartMcpOAuthAuthorizationUseCase } from './start-mcp-oauth-authorization.use-case';
 import { StartMcpOAuthAuthorizationCommand } from './start-mcp-oauth-authorization.command';
 import { OAuthFlowService } from '../../services/oauth-flow.service';
-import { ValidateIntegrationAccessService } from '../../services/validate-integration-access.service';
-import { ContextService } from 'src/common/context/services/context.service';
 import { SelfDefinedMcpIntegration } from '../../../domain/integrations/self-defined-mcp-integration.entity';
 import { NoAuthMcpIntegrationAuth } from '../../../domain/auth/no-auth-mcp-integration-auth.entity';
 import type { IntegrationConfigSchema } from '../../../domain/value-objects/integration-config-schema';
@@ -18,8 +16,6 @@ import {
 describe('StartMcpOAuthAuthorizationUseCase', () => {
   let useCase: StartMcpOAuthAuthorizationUseCase;
   let oauthFlowService: OAuthFlowService;
-  let validateAccess: ValidateIntegrationAccessService;
-  let contextService: ContextService;
 
   const mockOrgId = randomUUID();
   const mockUserId = randomUUID();
@@ -59,24 +55,14 @@ describe('StartMcpOAuthAuthorizationUseCase', () => {
           provide: OAuthFlowService,
           useValue: {
             buildAuthorizationUrl: jest.fn(),
-            resolveOAuthConfig: jest.fn(),
+            resolveOAuthActor: jest.fn(),
           },
-        },
-        {
-          provide: ValidateIntegrationAccessService,
-          useValue: { validate: jest.fn() },
-        },
-        {
-          provide: ContextService,
-          useValue: { get: jest.fn() },
         },
       ],
     }).compile();
 
     useCase = module.get(StartMcpOAuthAuthorizationUseCase);
     oauthFlowService = module.get(OAuthFlowService);
-    validateAccess = module.get(ValidateIntegrationAccessService);
-    contextService = module.get(ContextService);
 
     jest.spyOn(Logger.prototype, 'log').mockImplementation();
     jest.spyOn(Logger.prototype, 'error').mockImplementation();
@@ -88,13 +74,12 @@ describe('StartMcpOAuthAuthorizationUseCase', () => {
 
   it('should return the authorization URL for org-level OAuth', async () => {
     const integration = buildIntegration();
-    jest
-      .spyOn(contextService, 'get')
-      .mockImplementation((key) => (key === 'orgId' ? mockOrgId : mockUserId));
-    jest.spyOn(validateAccess, 'validate').mockResolvedValue(integration);
-    jest
-      .spyOn(oauthFlowService, 'resolveOAuthConfig')
-      .mockReturnValue({ config: oauthConfigSchema.oauth!, level: 'org' });
+    jest.spyOn(oauthFlowService, 'resolveOAuthActor').mockResolvedValue({
+      integration,
+      level: 'org',
+      orgId: mockOrgId,
+      userIdOrNull: null,
+    });
     jest
       .spyOn(oauthFlowService, 'buildAuthorizationUrl')
       .mockReturnValue({ url: 'https://auth.example.com/authorize?...' });
@@ -110,7 +95,7 @@ describe('StartMcpOAuthAuthorizationUseCase', () => {
       integration,
       'org',
       mockOrgId,
-      null, // org-level → null userId
+      null,
     );
   });
 
@@ -121,13 +106,12 @@ describe('StartMcpOAuthAuthorizationUseCase', () => {
     };
     const integration = buildIntegration(userLevelSchema);
 
-    jest
-      .spyOn(contextService, 'get')
-      .mockImplementation((key) => (key === 'orgId' ? mockOrgId : mockUserId));
-    jest.spyOn(validateAccess, 'validate').mockResolvedValue(integration);
-    jest
-      .spyOn(oauthFlowService, 'resolveOAuthConfig')
-      .mockReturnValue({ config: userLevelSchema.oauth!, level: 'user' });
+    jest.spyOn(oauthFlowService, 'resolveOAuthActor').mockResolvedValue({
+      integration,
+      level: 'user',
+      orgId: mockOrgId,
+      userIdOrNull: mockUserId,
+    });
     jest
       .spyOn(oauthFlowService, 'buildAuthorizationUrl')
       .mockReturnValue({ url: 'https://auth.example.com/auth' });
@@ -145,55 +129,36 @@ describe('StartMcpOAuthAuthorizationUseCase', () => {
   });
 
   it('should throw McpUnauthenticatedError for user-level OAuth when userId is missing', async () => {
-    const userLevelSchema: IntegrationConfigSchema = {
-      ...oauthConfigSchema,
-      oauth: { ...oauthConfigSchema.oauth!, level: 'user' },
-    };
-    const integration = buildIntegration(userLevelSchema);
-
     jest
-      .spyOn(contextService, 'get')
-      .mockImplementation((key) => (key === 'orgId' ? mockOrgId : undefined));
-    jest.spyOn(validateAccess, 'validate').mockResolvedValue(integration);
-    jest
-      .spyOn(oauthFlowService, 'resolveOAuthConfig')
-      .mockReturnValue({ config: userLevelSchema.oauth!, level: 'user' });
-
-    await expect(
-      useCase.execute(new StartMcpOAuthAuthorizationCommand(integration.id)),
-    ).rejects.toThrow(McpUnauthenticatedError);
-  });
-
-  it('should throw McpUnauthenticatedError when orgId is missing', async () => {
-    jest.spyOn(contextService, 'get').mockReturnValue(undefined);
+      .spyOn(oauthFlowService, 'resolveOAuthActor')
+      .mockRejectedValue(new McpUnauthenticatedError());
 
     await expect(
       useCase.execute(new StartMcpOAuthAuthorizationCommand(randomUUID())),
     ).rejects.toThrow(McpUnauthenticatedError);
   });
 
-  it('should propagate error when resolveOAuthConfig throws', async () => {
-    const noOauthSchema: IntegrationConfigSchema = {
-      authType: 'NONE',
-      orgFields: [],
-      userFields: [],
-    };
-    const integration = buildIntegration(noOauthSchema);
-
+  it('should throw McpUnauthenticatedError when orgId is missing', async () => {
     jest
-      .spyOn(contextService, 'get')
-      .mockImplementation((key) => (key === 'orgId' ? mockOrgId : mockUserId));
-    jest.spyOn(validateAccess, 'validate').mockResolvedValue(integration);
-    jest
-      .spyOn(oauthFlowService, 'resolveOAuthConfig')
-      .mockImplementation(() => {
-        throw new McpInvalidConfigSchemaError(
-          'Integration does not have OAuth configured',
-        );
-      });
+      .spyOn(oauthFlowService, 'resolveOAuthActor')
+      .mockRejectedValue(new McpUnauthenticatedError());
 
     await expect(
-      useCase.execute(new StartMcpOAuthAuthorizationCommand(integration.id)),
+      useCase.execute(new StartMcpOAuthAuthorizationCommand(randomUUID())),
+    ).rejects.toThrow(McpUnauthenticatedError);
+  });
+
+  it('should propagate error when resolveOAuthActor throws', async () => {
+    jest
+      .spyOn(oauthFlowService, 'resolveOAuthActor')
+      .mockRejectedValue(
+        new McpInvalidConfigSchemaError(
+          'Integration does not have OAuth configured',
+        ),
+      );
+
+    await expect(
+      useCase.execute(new StartMcpOAuthAuthorizationCommand(randomUUID())),
     ).rejects.toThrow(McpInvalidConfigSchemaError);
   });
 });

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/start-mcp-oauth-authorization/start-mcp-oauth-authorization.use-case.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/start-mcp-oauth-authorization/start-mcp-oauth-authorization.use-case.ts
@@ -1,0 +1,65 @@
+import { Injectable, Logger } from '@nestjs/common';
+import type { UUID } from 'crypto';
+import { StartMcpOAuthAuthorizationCommand } from './start-mcp-oauth-authorization.command';
+import { OAuthFlowService } from '../../services/oauth-flow.service';
+import { ValidateIntegrationAccessService } from '../../services/validate-integration-access.service';
+import { ContextService } from 'src/common/context/services/context.service';
+import { McpUnauthenticatedError, UnexpectedMcpError } from '../../mcp.errors';
+import { ApplicationError } from 'src/common/errors/base.error';
+
+@Injectable()
+export class StartMcpOAuthAuthorizationUseCase {
+  private readonly logger = new Logger(StartMcpOAuthAuthorizationUseCase.name);
+
+  constructor(
+    private readonly oauthFlowService: OAuthFlowService,
+    private readonly validateAccess: ValidateIntegrationAccessService,
+    private readonly contextService: ContextService,
+  ) {}
+
+  async execute(
+    command: StartMcpOAuthAuthorizationCommand,
+  ): Promise<{ authorizationUrl: string }> {
+    this.logger.log('startMcpOAuthAuthorization', {
+      integrationId: command.integrationId,
+    });
+
+    try {
+      const orgId = this.contextService.get('orgId');
+      if (!orgId) {
+        throw new McpUnauthenticatedError();
+      }
+
+      const userId = this.contextService.get('userId');
+
+      const integration = await this.validateAccess.validate(
+        command.integrationId,
+        { requireEnabled: false },
+      );
+
+      const { level } = this.oauthFlowService.resolveOAuthConfig(integration);
+
+      if (level === 'user' && !userId) {
+        throw new McpUnauthenticatedError();
+      }
+      const userIdOrNull: UUID | null = level === 'user' ? userId! : null;
+
+      const { url } = this.oauthFlowService.buildAuthorizationUrl(
+        integration,
+        level,
+        orgId,
+        userIdOrNull,
+      );
+
+      return { authorizationUrl: url };
+    } catch (error) {
+      if (error instanceof ApplicationError) {
+        throw error;
+      }
+      this.logger.error('Unexpected error starting OAuth authorization', {
+        error: error as Error,
+      });
+      throw new UnexpectedMcpError('Unexpected error occurred');
+    }
+  }
+}

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/start-mcp-oauth-authorization/start-mcp-oauth-authorization.use-case.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/start-mcp-oauth-authorization/start-mcp-oauth-authorization.use-case.ts
@@ -1,21 +1,14 @@
 import { Injectable, Logger } from '@nestjs/common';
-import type { UUID } from 'crypto';
 import { StartMcpOAuthAuthorizationCommand } from './start-mcp-oauth-authorization.command';
 import { OAuthFlowService } from '../../services/oauth-flow.service';
-import { ValidateIntegrationAccessService } from '../../services/validate-integration-access.service';
-import { ContextService } from 'src/common/context/services/context.service';
-import { McpUnauthenticatedError, UnexpectedMcpError } from '../../mcp.errors';
+import { UnexpectedMcpError } from '../../mcp.errors';
 import { ApplicationError } from 'src/common/errors/base.error';
 
 @Injectable()
 export class StartMcpOAuthAuthorizationUseCase {
   private readonly logger = new Logger(StartMcpOAuthAuthorizationUseCase.name);
 
-  constructor(
-    private readonly oauthFlowService: OAuthFlowService,
-    private readonly validateAccess: ValidateIntegrationAccessService,
-    private readonly contextService: ContextService,
-  ) {}
+  constructor(private readonly oauthFlowService: OAuthFlowService) {}
 
   async execute(
     command: StartMcpOAuthAuthorizationCommand,
@@ -25,24 +18,8 @@ export class StartMcpOAuthAuthorizationUseCase {
     });
 
     try {
-      const orgId = this.contextService.get('orgId');
-      if (!orgId) {
-        throw new McpUnauthenticatedError();
-      }
-
-      const userId = this.contextService.get('userId');
-
-      const integration = await this.validateAccess.validate(
-        command.integrationId,
-        { requireEnabled: false },
-      );
-
-      const { level } = this.oauthFlowService.resolveOAuthConfig(integration);
-
-      if (level === 'user' && !userId) {
-        throw new McpUnauthenticatedError();
-      }
-      const userIdOrNull: UUID | null = level === 'user' ? userId! : null;
+      const { integration, level, orgId, userIdOrNull } =
+        await this.oauthFlowService.resolveOAuthActor(command.integrationId);
 
       const { url } = this.oauthFlowService.buildAuthorizationUrl(
         integration,

--- a/ayunis-core-backend/src/domain/mcp/mcp.module.ts
+++ b/ayunis-core-backend/src/domain/mcp/mcp.module.ts
@@ -58,6 +58,11 @@ import { DiscoverMcpCapabilitiesUseCase } from './application/use-cases/discover
 import { ExecuteMcpToolUseCase } from './application/use-cases/execute-mcp-tool/execute-mcp-tool.use-case';
 import { GetMcpPromptUseCase } from './application/use-cases/get-mcp-prompt/get-mcp-prompt.use-case';
 import { ValidateIntegrationAccessService } from './application/services/validate-integration-access.service';
+import { OAuthFlowService } from './application/services/oauth-flow.service';
+import { StartMcpOAuthAuthorizationUseCase } from './application/use-cases/start-mcp-oauth-authorization/start-mcp-oauth-authorization.use-case';
+import { CompleteMcpOAuthAuthorizationUseCase } from './application/use-cases/complete-mcp-oauth-authorization/complete-mcp-oauth-authorization.use-case';
+import { RevokeMcpOAuthAuthorizationUseCase } from './application/use-cases/revoke-mcp-oauth-authorization/revoke-mcp-oauth-authorization.use-case';
+import { GetMcpOAuthAuthorizationStatusUseCase } from './application/use-cases/get-mcp-oauth-authorization-status/get-mcp-oauth-authorization-status.use-case';
 
 // Controller and Mappers
 import { McpIntegrationsController } from './presenters/http/mcp-integrations.controller';
@@ -124,6 +129,7 @@ import { PredefinedConfigDtoMapper } from './presenters/http/mappers/predefined-
     ConnectionValidationService,
     PredefinedMcpIntegrationRegistry,
     ValidateIntegrationAccessService,
+    OAuthFlowService,
     // Use Cases
     CreateMcpIntegrationUseCase,
     GetMcpIntegrationUseCase,
@@ -143,6 +149,10 @@ import { PredefinedConfigDtoMapper } from './presenters/http/mappers/predefined-
     InstallMarketplaceIntegrationUseCase,
     SetUserMcpConfigUseCase,
     GetUserMcpConfigUseCase,
+    StartMcpOAuthAuthorizationUseCase,
+    CompleteMcpOAuthAuthorizationUseCase,
+    RevokeMcpOAuthAuthorizationUseCase,
+    GetMcpOAuthAuthorizationStatusUseCase,
     // Mappers
     McpIntegrationDtoMapper,
     PredefinedConfigDtoMapper,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds new OAuth 2.1 + PKCE authorization/refresh logic and token persistence for MCP integrations, which affects authentication behavior and credential handling. Risk is moderated by extensive unit tests covering state validation, token upsert semantics, and refresh/revocation edge cases.
> 
> **Overview**
> Adds **OAuth 2.1 + PKCE support** for MCP integrations via a new `OAuthFlowService` that builds authorization URLs, validates signed state, exchanges codes for tokens, lazily refreshes expired access tokens, and revokes tokens; tokens are encrypted and persisted with explicit *preserve vs clear vs replace* semantics for `refresh_token`, `expires_in`, and `scope`.
> 
> Introduces four new OAuth-focused use cases (`StartMcpOAuthAuthorizationUseCase`, `CompleteMcpOAuthAuthorizationUseCase`, `RevokeMcpOAuthAuthorizationUseCase`, `GetMcpOAuthAuthorizationStatusUseCase`) and wires them into `McpModule`, alongside broad unit test coverage for success/error and edge-case scenarios (stale refresh token/scope, missing expiry, refresh failures, unauthenticated context).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 254fc7262beec7538f74139b33f3900d35341ecf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->