### PR TITLE
wip(mcp): add create self-defined use case, schema validator, delete cleanup (AYC-110)

### DIFF
--- a/ayunis-core-backend/src/domain/mcp/SUMMARY.md
+++ b/ayunis-core-backend/src/domain/mcp/SUMMARY.md
@@ -12,7 +12,8 @@ The MCP module manages connections to external Model Context Protocol servers at
 - `ListOrgMcpIntegrationsUseCase` — Lists all integrations for the current org
 - `ListAvailableMcpIntegrationsUseCase` — Lists enabled integrations for the current org
 - `UpdateMcpIntegrationUseCase` — Updates integration settings (name, credentials, org config values, etc.)
-- `DeleteMcpIntegrationUseCase` — Deletes an integration and its associated user configs
+- `CreateSelfDefinedMcpIntegrationUseCase` — Creates a self-defined integration with admin-authored config schema
+- `DeleteMcpIntegrationUseCase` — Deletes an integration, its associated user configs, and OAuth tokens
 - `EnableMcpIntegrationUseCase` / `DisableMcpIntegrationUseCase` — Toggles integration enabled state
 - `ValidateMcpIntegrationUseCase` — Validates connection to the MCP server
 - `ListPredefinedMcpIntegrationConfigsUseCase` — Lists available predefined integration configurations

--- a/ayunis-core-backend/src/domain/mcp/application/services/integration-config-schema.validator.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/services/integration-config-schema.validator.spec.ts
@@ -1,0 +1,419 @@
+import { validateConfigSchema } from './integration-config-schema.validator';
+import { McpInvalidConfigSchemaError } from '../mcp.errors';
+import type { IntegrationConfigSchema } from '../../domain/value-objects/integration-config-schema';
+
+describe('validateConfigSchema', () => {
+  const validField = {
+    key: 'api_key',
+    label: 'API Key',
+    type: 'secret',
+    headerName: 'Authorization',
+    prefix: 'Bearer ',
+    required: true,
+    help: 'Your API key',
+  };
+
+  const minimalSchema = {
+    authType: 'HEADER',
+    orgFields: [validField],
+    userFields: [],
+  };
+
+  it('should validate a minimal valid schema', () => {
+    const result = validateConfigSchema(minimalSchema);
+    expect(result.authType).toBe('HEADER');
+    expect(result.orgFields).toHaveLength(1);
+    expect(result.orgFields[0].key).toBe('api_key');
+    expect(result.userFields).toHaveLength(0);
+    expect(result.oauth).toBeUndefined();
+  });
+
+  it('should validate a schema with oauth block', () => {
+    const schema = {
+      ...minimalSchema,
+      oauth: {
+        authorizationUrl: 'https://auth.example.com/authorize',
+        tokenUrl: 'https://auth.example.com/token',
+        scopes: ['read', 'write'],
+        level: 'org',
+      },
+    };
+    const result = validateConfigSchema(schema);
+    expect(result.oauth).toBeDefined();
+    expect(result.oauth!.level).toBe('org');
+    expect(result.oauth!.scopes).toEqual(['read', 'write']);
+  });
+
+  it('should validate a schema with user-level oauth', () => {
+    const schema = {
+      ...minimalSchema,
+      oauth: {
+        authorizationUrl: 'https://auth.example.com/authorize',
+        tokenUrl: 'https://auth.example.com/token',
+        scopes: [],
+        level: 'user',
+      },
+    };
+    const result = validateConfigSchema(schema);
+    expect(result.oauth!.level).toBe('user');
+  });
+
+  it('should accept optional field properties as undefined', () => {
+    const field = {
+      key: 'name',
+      label: 'Name',
+      type: 'text',
+      required: false,
+    };
+    const result = validateConfigSchema({
+      authType: 'NONE',
+      orgFields: [field],
+      userFields: [],
+    });
+    expect(result.orgFields[0].headerName).toBeUndefined();
+    expect(result.orgFields[0].prefix).toBeUndefined();
+    expect(result.orgFields[0].help).toBeUndefined();
+    expect(result.orgFields[0].value).toBeUndefined();
+  });
+
+  it('should accept field with fixed value', () => {
+    const field = {
+      ...validField,
+      value: 'fixed-value',
+    };
+    const result = validateConfigSchema({
+      authType: 'HEADER',
+      orgFields: [field],
+      userFields: [],
+    });
+    expect(result.orgFields[0].value).toBe('fixed-value');
+  });
+
+  describe('top-level validation', () => {
+    it('should reject null', () => {
+      expect(() => validateConfigSchema(null)).toThrow(
+        McpInvalidConfigSchemaError,
+      );
+    });
+
+    it('should reject an array', () => {
+      expect(() => validateConfigSchema([])).toThrow(
+        McpInvalidConfigSchemaError,
+      );
+    });
+
+    it('should reject a non-object', () => {
+      expect(() => validateConfigSchema('string')).toThrow(
+        McpInvalidConfigSchemaError,
+      );
+    });
+
+    it('should reject missing authType', () => {
+      expect(() =>
+        validateConfigSchema({ orgFields: [], userFields: [] }),
+      ).toThrow(McpInvalidConfigSchemaError);
+    });
+
+    it('should reject empty authType', () => {
+      expect(() =>
+        validateConfigSchema({
+          authType: '',
+          orgFields: [],
+          userFields: [],
+        }),
+      ).toThrow(McpInvalidConfigSchemaError);
+    });
+
+    it('should reject missing orgFields', () => {
+      expect(() =>
+        validateConfigSchema({ authType: 'NONE', userFields: [] }),
+      ).toThrow(McpInvalidConfigSchemaError);
+    });
+
+    it('should reject missing userFields', () => {
+      expect(() =>
+        validateConfigSchema({ authType: 'NONE', orgFields: [] }),
+      ).toThrow(McpInvalidConfigSchemaError);
+    });
+  });
+
+  describe('field validation', () => {
+    it('should reject field without key', () => {
+      expect(() =>
+        validateConfigSchema({
+          authType: 'NONE',
+          orgFields: [{ label: 'X', type: 'text', required: false }],
+          userFields: [],
+        }),
+      ).toThrow(McpInvalidConfigSchemaError);
+    });
+
+    it('should reject field with empty key', () => {
+      expect(() =>
+        validateConfigSchema({
+          authType: 'NONE',
+          orgFields: [{ key: '', label: 'X', type: 'text', required: false }],
+          userFields: [],
+        }),
+      ).toThrow(McpInvalidConfigSchemaError);
+    });
+
+    it('should reject field without label', () => {
+      expect(() =>
+        validateConfigSchema({
+          authType: 'NONE',
+          orgFields: [{ key: 'k', type: 'text', required: false }],
+          userFields: [],
+        }),
+      ).toThrow(McpInvalidConfigSchemaError);
+    });
+
+    it('should reject field with invalid type', () => {
+      expect(() =>
+        validateConfigSchema({
+          authType: 'NONE',
+          orgFields: [
+            { key: 'k', label: 'L', type: 'number', required: false },
+          ],
+          userFields: [],
+        }),
+      ).toThrow(McpInvalidConfigSchemaError);
+    });
+
+    it('should reject field without required', () => {
+      expect(() =>
+        validateConfigSchema({
+          authType: 'NONE',
+          orgFields: [{ key: 'k', label: 'L', type: 'text' }],
+          userFields: [],
+        }),
+      ).toThrow(McpInvalidConfigSchemaError);
+    });
+
+    it('should reject non-string headerName', () => {
+      expect(() =>
+        validateConfigSchema({
+          authType: 'NONE',
+          orgFields: [
+            {
+              key: 'k',
+              label: 'L',
+              type: 'text',
+              required: false,
+              headerName: 123,
+            },
+          ],
+          userFields: [],
+        }),
+      ).toThrow(McpInvalidConfigSchemaError);
+    });
+
+    it('should reject empty-string headerName', () => {
+      expect(() =>
+        validateConfigSchema({
+          authType: 'NONE',
+          orgFields: [
+            {
+              key: 'k',
+              label: 'L',
+              type: 'text',
+              required: false,
+              headerName: '',
+            },
+          ],
+          userFields: [],
+        }),
+      ).toThrow(McpInvalidConfigSchemaError);
+    });
+
+    it('should reject non-object field', () => {
+      expect(() =>
+        validateConfigSchema({
+          authType: 'NONE',
+          orgFields: ['not-an-object'],
+          userFields: [],
+        }),
+      ).toThrow(McpInvalidConfigSchemaError);
+    });
+
+    it('should reject duplicate key within orgFields', () => {
+      expect(() =>
+        validateConfigSchema({
+          authType: 'NONE',
+          orgFields: [
+            { key: 'dup', label: 'A', type: 'text', required: false },
+            { key: 'dup', label: 'B', type: 'text', required: false },
+          ],
+          userFields: [],
+        }),
+      ).toThrow(McpInvalidConfigSchemaError);
+    });
+
+    it('should reject duplicate key across orgFields and userFields', () => {
+      expect(() =>
+        validateConfigSchema({
+          authType: 'NONE',
+          orgFields: [
+            { key: 'shared', label: 'Org', type: 'text', required: false },
+          ],
+          userFields: [
+            { key: 'shared', label: 'User', type: 'text', required: false },
+          ],
+        }),
+      ).toThrow(McpInvalidConfigSchemaError);
+    });
+
+    it('should validate userFields the same way', () => {
+      expect(() =>
+        validateConfigSchema({
+          authType: 'NONE',
+          orgFields: [],
+          userFields: [{ key: '', label: 'X', type: 'text', required: false }],
+        }),
+      ).toThrow(McpInvalidConfigSchemaError);
+    });
+  });
+
+  describe('oauth validation', () => {
+    it('should reject oauth without authorizationUrl', () => {
+      expect(() =>
+        validateConfigSchema({
+          ...minimalSchema,
+          oauth: {
+            tokenUrl: 'https://example.com/token',
+            scopes: [],
+            level: 'org',
+          },
+        }),
+      ).toThrow(McpInvalidConfigSchemaError);
+    });
+
+    it('should reject oauth without tokenUrl', () => {
+      expect(() =>
+        validateConfigSchema({
+          ...minimalSchema,
+          oauth: {
+            authorizationUrl: 'https://example.com/auth',
+            scopes: [],
+            level: 'org',
+          },
+        }),
+      ).toThrow(McpInvalidConfigSchemaError);
+    });
+
+    it('should reject oauth with non-array scopes', () => {
+      expect(() =>
+        validateConfigSchema({
+          ...minimalSchema,
+          oauth: {
+            authorizationUrl: 'https://example.com/auth',
+            tokenUrl: 'https://example.com/token',
+            scopes: 'read',
+            level: 'org',
+          },
+        }),
+      ).toThrow(McpInvalidConfigSchemaError);
+    });
+
+    it('should reject oauth with invalid level', () => {
+      expect(() =>
+        validateConfigSchema({
+          ...minimalSchema,
+          oauth: {
+            authorizationUrl: 'https://example.com/auth',
+            tokenUrl: 'https://example.com/token',
+            scopes: [],
+            level: 'global',
+          },
+        }),
+      ).toThrow(McpInvalidConfigSchemaError);
+    });
+
+    it('should reject oauth as non-object', () => {
+      expect(() =>
+        validateConfigSchema({
+          ...minimalSchema,
+          oauth: 'not-an-object',
+        }),
+      ).toThrow(McpInvalidConfigSchemaError);
+    });
+
+    it('should reject oauth scopes with non-string entries', () => {
+      expect(() =>
+        validateConfigSchema({
+          ...minimalSchema,
+          oauth: {
+            authorizationUrl: 'https://example.com/auth',
+            tokenUrl: 'https://example.com/token',
+            scopes: ['read', 123],
+            level: 'org',
+          },
+        }),
+      ).toThrow(McpInvalidConfigSchemaError);
+    });
+  });
+
+  describe('error field paths', () => {
+    it('should include field path for orgFields errors', () => {
+      try {
+        validateConfigSchema({
+          authType: 'NONE',
+          orgFields: [
+            { key: 'ok', label: 'OK', type: 'text', required: true },
+            { key: '', label: 'Bad', type: 'text', required: true },
+          ],
+          userFields: [],
+        });
+        fail('Should have thrown');
+      } catch (error) {
+        expect(error).toBeInstanceOf(McpInvalidConfigSchemaError);
+        expect((error as McpInvalidConfigSchemaError).metadata).toEqual(
+          expect.objectContaining({ field: '/orgFields/1/key' }),
+        );
+      }
+    });
+
+    it('should include field path for oauth errors', () => {
+      try {
+        validateConfigSchema({
+          ...minimalSchema,
+          oauth: {
+            authorizationUrl: '',
+            tokenUrl: 'https://example.com/token',
+            scopes: [],
+            level: 'org',
+          },
+        });
+        fail('Should have thrown');
+      } catch (error) {
+        expect(error).toBeInstanceOf(McpInvalidConfigSchemaError);
+        expect((error as McpInvalidConfigSchemaError).metadata).toEqual(
+          expect.objectContaining({ field: '/oauth/authorizationUrl' }),
+        );
+      }
+    });
+  });
+
+  describe('return type shape', () => {
+    it('should return a proper IntegrationConfigSchema', () => {
+      const result: IntegrationConfigSchema =
+        validateConfigSchema(minimalSchema);
+      expect(result).toEqual({
+        authType: 'HEADER',
+        orgFields: [
+          {
+            key: 'api_key',
+            label: 'API Key',
+            type: 'secret',
+            headerName: 'Authorization',
+            prefix: 'Bearer ',
+            required: true,
+            help: 'Your API key',
+            value: undefined,
+          },
+        ],
+        userFields: [],
+      });
+    });
+  });
+});

--- a/ayunis-core-backend/src/domain/mcp/application/services/integration-config-schema.validator.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/services/integration-config-schema.validator.ts
@@ -1,0 +1,250 @@
+import type {
+  IntegrationConfigSchema,
+  ConfigField,
+  OAuthConfig,
+} from '../../domain/value-objects/integration-config-schema';
+import { McpInvalidConfigSchemaError } from '../mcp.errors';
+
+const VALID_FIELD_TYPES = new Set(['text', 'url', 'secret']);
+const VALID_OAUTH_LEVELS = new Set(['org', 'user']);
+
+type TopLevelSchema = Record<string, unknown> & {
+  authType: string;
+  orgFields: unknown[];
+  userFields: unknown[];
+};
+
+/**
+ * Runtime validator for self-defined integration config schemas.
+ * Validates the top-level shape, each field's structure, and the
+ * optional OAuth block. Throws McpInvalidConfigSchemaError with a
+ * JSON-pointer-style field path on any violation.
+ */
+export function validateConfigSchema(schema: unknown): IntegrationConfigSchema {
+  const s = validateTopLevelShape(schema);
+
+  const orgFields = s.orgFields.map((f: unknown, i: number) =>
+    validateConfigField(f, `/orgFields/${i}`),
+  );
+
+  const userFields = s.userFields.map((f: unknown, i: number) =>
+    validateConfigField(f, `/userFields/${i}`),
+  );
+
+  assertNoDuplicateKeys(orgFields, userFields);
+
+  const result: IntegrationConfigSchema = {
+    authType: s.authType,
+    orgFields,
+    userFields,
+  };
+
+  if (s.oauth !== undefined) {
+    result.oauth = validateOAuthConfig(s.oauth);
+  }
+
+  return result;
+}
+
+export function validateTopLevelShape(schema: unknown): TopLevelSchema {
+  if (!schema || typeof schema !== 'object' || Array.isArray(schema)) {
+    throw new McpInvalidConfigSchemaError('Schema must be a non-null object');
+  }
+
+  const s = schema as Record<string, unknown>;
+
+  if (typeof s.authType !== 'string' || s.authType.length === 0) {
+    throw new McpInvalidConfigSchemaError(
+      'authType must be a non-empty string',
+      '/authType',
+    );
+  }
+
+  if (!Array.isArray(s.orgFields)) {
+    throw new McpInvalidConfigSchemaError(
+      'orgFields must be an array',
+      '/orgFields',
+    );
+  }
+
+  if (!Array.isArray(s.userFields)) {
+    throw new McpInvalidConfigSchemaError(
+      'userFields must be an array',
+      '/userFields',
+    );
+  }
+
+  return s as TopLevelSchema;
+}
+
+export function validateConfigField(field: unknown, path: string): ConfigField {
+  if (!field || typeof field !== 'object' || Array.isArray(field)) {
+    throw new McpInvalidConfigSchemaError(
+      'Field must be a non-null object',
+      path,
+    );
+  }
+
+  const f = field as Record<string, unknown>;
+
+  validateRequiredFieldProps(f, path);
+  validateOptionalFieldProps(f, path);
+
+  return {
+    key: f.key as string,
+    label: f.label as string,
+    type: f.type as ConfigField['type'],
+    headerName: f.headerName as string | undefined,
+    prefix: f.prefix as string | undefined,
+    required: f.required as boolean,
+    help: f.help as string | undefined,
+    value: f.value as string | undefined,
+  };
+}
+
+export function validateRequiredFieldProps(
+  f: Record<string, unknown>,
+  path: string,
+): void {
+  if (typeof f.key !== 'string' || f.key.length === 0) {
+    throw new McpInvalidConfigSchemaError(
+      'key must be a non-empty string',
+      `${path}/key`,
+    );
+  }
+
+  if (typeof f.label !== 'string' || f.label.length === 0) {
+    throw new McpInvalidConfigSchemaError(
+      'label must be a non-empty string',
+      `${path}/label`,
+    );
+  }
+
+  if (typeof f.type !== 'string' || !VALID_FIELD_TYPES.has(f.type)) {
+    throw new McpInvalidConfigSchemaError(
+      `type must be one of: ${[...VALID_FIELD_TYPES].join(', ')}`,
+      `${path}/type`,
+    );
+  }
+
+  if (typeof f.required !== 'boolean') {
+    throw new McpInvalidConfigSchemaError(
+      'required must be a boolean',
+      `${path}/required`,
+    );
+  }
+}
+
+export function validateOptionalFieldProps(
+  f: Record<string, unknown>,
+  path: string,
+): void {
+  if (f.headerName !== undefined) {
+    if (typeof f.headerName !== 'string' || f.headerName.length === 0) {
+      throw new McpInvalidConfigSchemaError(
+        'headerName must be a non-empty string if provided',
+        `${path}/headerName`,
+      );
+    }
+  }
+
+  if (f.prefix !== undefined && typeof f.prefix !== 'string') {
+    throw new McpInvalidConfigSchemaError(
+      'prefix must be a string if provided',
+      `${path}/prefix`,
+    );
+  }
+
+  if (f.help !== undefined && typeof f.help !== 'string') {
+    throw new McpInvalidConfigSchemaError(
+      'help must be a string if provided',
+      `${path}/help`,
+    );
+  }
+
+  if (f.value !== undefined && typeof f.value !== 'string') {
+    throw new McpInvalidConfigSchemaError(
+      'value must be a string if provided',
+      `${path}/value`,
+    );
+  }
+}
+
+export function assertNoDuplicateKeys(
+  orgFields: ConfigField[],
+  userFields: ConfigField[],
+): void {
+  const seen = new Set<string>();
+  const allFields = [
+    ...orgFields.map((f, i) => ({ key: f.key, path: `/orgFields/${i}` })),
+    ...userFields.map((f, i) => ({ key: f.key, path: `/userFields/${i}` })),
+  ];
+  for (const { key, path } of allFields) {
+    if (seen.has(key)) {
+      throw new McpInvalidConfigSchemaError(
+        `duplicate key "${key}"`,
+        `${path}/key`,
+      );
+    }
+    seen.add(key);
+  }
+}
+
+export function validateOAuthConfig(oauth: unknown): OAuthConfig {
+  if (!oauth || typeof oauth !== 'object' || Array.isArray(oauth)) {
+    throw new McpInvalidConfigSchemaError(
+      'oauth must be a non-null object',
+      '/oauth',
+    );
+  }
+
+  const o = oauth as Record<string, unknown>;
+
+  validateOAuthUrls(o);
+  validateOAuthScopesAndLevel(o);
+
+  return {
+    authorizationUrl: o.authorizationUrl as string,
+    tokenUrl: o.tokenUrl as string,
+    scopes: o.scopes as string[],
+    level: o.level as 'org' | 'user',
+  };
+}
+
+export function validateOAuthUrls(o: Record<string, unknown>): void {
+  if (
+    typeof o.authorizationUrl !== 'string' ||
+    o.authorizationUrl.length === 0
+  ) {
+    throw new McpInvalidConfigSchemaError(
+      'authorizationUrl must be a non-empty string',
+      '/oauth/authorizationUrl',
+    );
+  }
+
+  if (typeof o.tokenUrl !== 'string' || o.tokenUrl.length === 0) {
+    throw new McpInvalidConfigSchemaError(
+      'tokenUrl must be a non-empty string',
+      '/oauth/tokenUrl',
+    );
+  }
+}
+
+export function validateOAuthScopesAndLevel(o: Record<string, unknown>): void {
+  if (
+    !Array.isArray(o.scopes) ||
+    !o.scopes.every((s: unknown) => typeof s === 'string')
+  ) {
+    throw new McpInvalidConfigSchemaError(
+      'scopes must be an array of strings',
+      '/oauth/scopes',
+    );
+  }
+
+  if (typeof o.level !== 'string' || !VALID_OAUTH_LEVELS.has(o.level)) {
+    throw new McpInvalidConfigSchemaError(
+      'level must be "org" or "user"',
+      '/oauth/level',
+    );
+  }
+}

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/create-self-defined-mcp-integration/create-self-defined-mcp-integration.command.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/create-self-defined-mcp-integration/create-self-defined-mcp-integration.command.ts
@@ -1,0 +1,14 @@
+import type { IntegrationConfigSchema } from '../../../domain/value-objects/integration-config-schema';
+
+export class CreateSelfDefinedMcpIntegrationCommand {
+  constructor(
+    public readonly name: string,
+    public readonly serverUrl: string,
+    public readonly configSchema: IntegrationConfigSchema,
+    public readonly orgConfigValues: Record<string, string>,
+    public readonly description?: string,
+    public readonly oauthClientId?: string,
+    public readonly oauthClientSecret?: string,
+    public readonly returnsPii?: boolean,
+  ) {}
+}

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/create-self-defined-mcp-integration/create-self-defined-mcp-integration.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/create-self-defined-mcp-integration/create-self-defined-mcp-integration.use-case.spec.ts
@@ -1,0 +1,425 @@
+import type { TestingModule } from '@nestjs/testing';
+import { Test } from '@nestjs/testing';
+import { Logger, UnauthorizedException } from '@nestjs/common';
+import { randomUUID } from 'crypto';
+import { CreateSelfDefinedMcpIntegrationUseCase } from './create-self-defined-mcp-integration.use-case';
+import { CreateSelfDefinedMcpIntegrationCommand } from './create-self-defined-mcp-integration.command';
+import { McpIntegrationsRepositoryPort } from '../../ports/mcp-integrations.repository.port';
+import { McpCredentialEncryptionPort } from '../../ports/mcp-credential-encryption.port';
+import { McpIntegrationFactory } from '../../factories/mcp-integration.factory';
+import { MarketplaceConfigService } from '../../services/marketplace-config.service';
+import { ConnectionValidationService } from '../../services/connection-validation.service';
+import { ContextService } from 'src/common/context/services/context.service';
+import {
+  McpOAuthClientNotConfiguredError,
+  McpAuthorizationHeaderCollisionError,
+  McpInvalidConfigSchemaError,
+  UnexpectedMcpError,
+} from '../../mcp.errors';
+import { SelfDefinedMcpIntegration } from '../../../domain/integrations/self-defined-mcp-integration.entity';
+import type { IntegrationConfigSchema } from '../../../domain/value-objects/integration-config-schema';
+
+describe('CreateSelfDefinedMcpIntegrationUseCase', () => {
+  let useCase: CreateSelfDefinedMcpIntegrationUseCase;
+  let repository: jest.Mocked<McpIntegrationsRepositoryPort>;
+  let credentialEncryption: jest.Mocked<McpCredentialEncryptionPort>;
+  let marketplaceConfigService: jest.Mocked<MarketplaceConfigService>;
+  let connectionValidationService: jest.Mocked<ConnectionValidationService>;
+  let contextService: jest.Mocked<ContextService>;
+
+  const mockOrgId = randomUUID();
+
+  const noAuthSchema: IntegrationConfigSchema = {
+    authType: 'HEADER',
+    orgFields: [
+      {
+        key: 'api_key',
+        label: 'API Key',
+        type: 'secret',
+        headerName: 'X-Api-Key',
+        required: true,
+      },
+    ],
+    userFields: [],
+  };
+
+  const oauthSchema: IntegrationConfigSchema = {
+    authType: 'OAUTH',
+    orgFields: [],
+    userFields: [],
+    oauth: {
+      authorizationUrl: 'https://auth.example.com/authorize',
+      tokenUrl: 'https://auth.example.com/token',
+      scopes: ['read'],
+      level: 'org',
+    },
+  };
+
+  const collisionSchema: IntegrationConfigSchema = {
+    authType: 'OAUTH',
+    orgFields: [
+      {
+        key: 'auth_header',
+        label: 'Auth Header',
+        type: 'secret',
+        headerName: 'Authorization',
+        required: true,
+      },
+    ],
+    userFields: [],
+    oauth: {
+      authorizationUrl: 'https://auth.example.com/authorize',
+      tokenUrl: 'https://auth.example.com/token',
+      scopes: ['read'],
+      level: 'org',
+    },
+  };
+
+  beforeAll(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        CreateSelfDefinedMcpIntegrationUseCase,
+        McpIntegrationFactory,
+        {
+          provide: McpIntegrationsRepositoryPort,
+          useValue: {
+            save: jest.fn(),
+          },
+        },
+        {
+          provide: McpCredentialEncryptionPort,
+          useValue: {
+            encrypt: jest.fn(),
+            decrypt: jest.fn(),
+          },
+        },
+        {
+          provide: MarketplaceConfigService,
+          useValue: {
+            mergeFixedValues: jest.fn(),
+            validateRequiredFields: jest.fn(),
+            encryptSecretFields: jest.fn(),
+          },
+        },
+        {
+          provide: ConnectionValidationService,
+          useValue: {
+            validateAndUpdateStatus: jest.fn(),
+          },
+        },
+        {
+          provide: ContextService,
+          useValue: {
+            get: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    useCase = module.get(CreateSelfDefinedMcpIntegrationUseCase);
+    repository = module.get(McpIntegrationsRepositoryPort);
+    credentialEncryption = module.get(McpCredentialEncryptionPort);
+    marketplaceConfigService = module.get(MarketplaceConfigService);
+    connectionValidationService = module.get(ConnectionValidationService);
+    contextService = module.get(ContextService);
+
+    jest.spyOn(Logger.prototype, 'log').mockImplementation();
+    jest.spyOn(Logger.prototype, 'error').mockImplementation();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  function setupHappyPath(): void {
+    contextService.get.mockReturnValue(mockOrgId);
+    marketplaceConfigService.mergeFixedValues.mockReturnValue({
+      api_key: 'test-key',
+    });
+    marketplaceConfigService.validateRequiredFields.mockReturnValue(undefined);
+    marketplaceConfigService.encryptSecretFields.mockResolvedValue({
+      api_key: 'encrypted-key',
+    });
+    repository.save.mockImplementation(async (entity) => entity);
+    connectionValidationService.validateAndUpdateStatus.mockImplementation(
+      async (entity) => entity,
+    );
+  }
+
+  describe('happy path — NO_AUTH with header secret', () => {
+    it('should create a self-defined integration', async () => {
+      setupHappyPath();
+
+      const command = new CreateSelfDefinedMcpIntegrationCommand(
+        'Test Integration',
+        'https://mcp.example.com',
+        noAuthSchema,
+        { api_key: 'test-key' },
+        'A test integration',
+        undefined,
+        undefined,
+        false,
+      );
+
+      const result = await useCase.execute(command);
+
+      expect(result).toBeInstanceOf(SelfDefinedMcpIntegration);
+      expect(result.name).toBe('Test Integration');
+      expect(result.serverUrl).toBe('https://mcp.example.com');
+      expect(result.orgId).toBe(mockOrgId);
+      expect(result.description).toBe('A test integration');
+      expect(result.returnsPii).toBe(false);
+
+      expect(marketplaceConfigService.mergeFixedValues).toHaveBeenCalledWith(
+        { api_key: 'test-key' },
+        noAuthSchema.orgFields,
+      );
+      expect(
+        marketplaceConfigService.validateRequiredFields,
+      ).toHaveBeenCalled();
+      expect(marketplaceConfigService.encryptSecretFields).toHaveBeenCalled();
+      expect(repository.save).toHaveBeenCalled();
+      expect(
+        connectionValidationService.validateAndUpdateStatus,
+      ).toHaveBeenCalled();
+    });
+  });
+
+  describe('happy path — with OAuth', () => {
+    it('should create an integration with encrypted OAuth client credentials', async () => {
+      setupHappyPath();
+      marketplaceConfigService.mergeFixedValues.mockReturnValue({});
+      marketplaceConfigService.encryptSecretFields.mockResolvedValue({});
+      credentialEncryption.encrypt.mockResolvedValue('encrypted-client-secret');
+
+      const command = new CreateSelfDefinedMcpIntegrationCommand(
+        'OAuth Integration',
+        'https://mcp.example.com',
+        oauthSchema,
+        {},
+        undefined,
+        'my-client-id',
+        'my-client-secret',
+        false,
+      );
+
+      const result = await useCase.execute(command);
+
+      expect(result).toBeInstanceOf(SelfDefinedMcpIntegration);
+      expect(result.oauthClientId).toBe('my-client-id');
+      expect(result.oauthClientSecretEncrypted).toBe('encrypted-client-secret');
+      expect(credentialEncryption.encrypt).toHaveBeenCalledWith(
+        'my-client-secret',
+      );
+    });
+  });
+
+  describe('non-OAuth with Authorization headerName', () => {
+    it('should allow headerName "Authorization" when there is no OAuth block', async () => {
+      setupHappyPath();
+
+      const schemaWithAuthHeader: IntegrationConfigSchema = {
+        authType: 'HEADER',
+        orgFields: [
+          {
+            key: 'token',
+            label: 'Token',
+            type: 'secret',
+            headerName: 'Authorization',
+            prefix: 'Bearer ',
+            required: true,
+          },
+        ],
+        userFields: [],
+      };
+
+      const command = new CreateSelfDefinedMcpIntegrationCommand(
+        'Auth Header Integration',
+        'https://mcp.example.com',
+        schemaWithAuthHeader,
+        { token: 'my-token' },
+      );
+
+      const result = await useCase.execute(command);
+      expect(result).toBeInstanceOf(SelfDefinedMcpIntegration);
+    });
+  });
+
+  describe('OAuth creds ignored when no OAuth in schema', () => {
+    it('should NOT store OAuth credentials when schema has no OAuth block', async () => {
+      setupHappyPath();
+
+      const command = new CreateSelfDefinedMcpIntegrationCommand(
+        'No OAuth Schema',
+        'https://mcp.example.com',
+        noAuthSchema,
+        { api_key: 'test-key' },
+        undefined,
+        'stray-client-id',
+        'stray-client-secret',
+        false,
+      );
+
+      const result = await useCase.execute(command);
+
+      expect(result).toBeInstanceOf(SelfDefinedMcpIntegration);
+      expect(result.oauthClientId).toBeUndefined();
+      expect(result.oauthClientSecretEncrypted).toBeUndefined();
+      expect(credentialEncryption.encrypt).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('error — invalid config schema', () => {
+    it('should throw McpInvalidConfigSchemaError for bad schema', async () => {
+      contextService.get.mockReturnValue(mockOrgId);
+
+      const command = new CreateSelfDefinedMcpIntegrationCommand(
+        'Bad Schema',
+        'https://mcp.example.com',
+        {
+          authType: '',
+          orgFields: [],
+          userFields: [],
+        } as unknown as IntegrationConfigSchema,
+        {},
+      );
+
+      await expect(useCase.execute(command)).rejects.toThrow(
+        McpInvalidConfigSchemaError,
+      );
+    });
+  });
+
+  describe('error — OAuth without client credentials', () => {
+    it('should throw McpOAuthClientNotConfiguredError when clientId missing', async () => {
+      contextService.get.mockReturnValue(mockOrgId);
+
+      const command = new CreateSelfDefinedMcpIntegrationCommand(
+        'OAuth No Creds',
+        'https://mcp.example.com',
+        oauthSchema,
+        {},
+        undefined,
+        undefined,
+        undefined,
+      );
+
+      await expect(useCase.execute(command)).rejects.toThrow(
+        McpOAuthClientNotConfiguredError,
+      );
+    });
+
+    it('should throw McpOAuthClientNotConfiguredError when clientSecret missing', async () => {
+      contextService.get.mockReturnValue(mockOrgId);
+
+      const command = new CreateSelfDefinedMcpIntegrationCommand(
+        'OAuth No Secret',
+        'https://mcp.example.com',
+        oauthSchema,
+        {},
+        undefined,
+        'my-client-id',
+        undefined,
+      );
+
+      await expect(useCase.execute(command)).rejects.toThrow(
+        McpOAuthClientNotConfiguredError,
+      );
+    });
+  });
+
+  describe('error — Authorization header collision', () => {
+    it('should throw McpAuthorizationHeaderCollisionError when orgField has Authorization header and OAuth', async () => {
+      contextService.get.mockReturnValue(mockOrgId);
+
+      const command = new CreateSelfDefinedMcpIntegrationCommand(
+        'Collision',
+        'https://mcp.example.com',
+        collisionSchema,
+        {},
+        undefined,
+        'my-client-id',
+        'my-client-secret',
+      );
+
+      await expect(useCase.execute(command)).rejects.toThrow(
+        McpAuthorizationHeaderCollisionError,
+      );
+    });
+
+    it('should throw when userField has Authorization header and OAuth', async () => {
+      contextService.get.mockReturnValue(mockOrgId);
+
+      const schemaWithUserCollision: IntegrationConfigSchema = {
+        authType: 'OAUTH',
+        orgFields: [],
+        userFields: [
+          {
+            key: 'token',
+            label: 'Token',
+            type: 'secret',
+            headerName: 'authorization',
+            required: true,
+          },
+        ],
+        oauth: {
+          authorizationUrl: 'https://auth.example.com/authorize',
+          tokenUrl: 'https://auth.example.com/token',
+          scopes: [],
+          level: 'user',
+        },
+      };
+
+      const command = new CreateSelfDefinedMcpIntegrationCommand(
+        'Collision',
+        'https://mcp.example.com',
+        schemaWithUserCollision,
+        {},
+        undefined,
+        'my-client-id',
+        'my-client-secret',
+      );
+
+      await expect(useCase.execute(command)).rejects.toThrow(
+        McpAuthorizationHeaderCollisionError,
+      );
+    });
+  });
+
+  describe('error — unauthenticated', () => {
+    it('should throw UnauthorizedException when orgId is missing', async () => {
+      contextService.get.mockReturnValue(undefined);
+
+      const command = new CreateSelfDefinedMcpIntegrationCommand(
+        'Test',
+        'https://mcp.example.com',
+        noAuthSchema,
+        {},
+      );
+
+      await expect(useCase.execute(command)).rejects.toThrow(
+        UnauthorizedException,
+      );
+    });
+  });
+
+  describe('error — unexpected', () => {
+    it('should wrap unexpected errors in UnexpectedMcpError', async () => {
+      contextService.get.mockReturnValue(mockOrgId);
+      marketplaceConfigService.mergeFixedValues.mockImplementation(() => {
+        throw new Error('DB down');
+      });
+
+      const command = new CreateSelfDefinedMcpIntegrationCommand(
+        'Test',
+        'https://mcp.example.com',
+        noAuthSchema,
+        { api_key: 'test-key' },
+      );
+
+      await expect(useCase.execute(command)).rejects.toThrow(
+        UnexpectedMcpError,
+      );
+    });
+  });
+});

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/create-self-defined-mcp-integration/create-self-defined-mcp-integration.use-case.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/create-self-defined-mcp-integration/create-self-defined-mcp-integration.use-case.ts
@@ -1,0 +1,140 @@
+import { Injectable, Logger, UnauthorizedException } from '@nestjs/common';
+import { CreateSelfDefinedMcpIntegrationCommand } from './create-self-defined-mcp-integration.command';
+import { McpIntegrationsRepositoryPort } from '../../ports/mcp-integrations.repository.port';
+import { McpCredentialEncryptionPort } from '../../ports/mcp-credential-encryption.port';
+import { McpIntegrationFactory } from '../../factories/mcp-integration.factory';
+import { MarketplaceConfigService } from '../../services/marketplace-config.service';
+import { ConnectionValidationService } from '../../services/connection-validation.service';
+import { validateConfigSchema } from '../../services/integration-config-schema.validator';
+import { ContextService } from 'src/common/context/services/context.service';
+import { McpIntegrationKind } from '../../../domain/value-objects/mcp-integration-kind.enum';
+import { NoAuthMcpIntegrationAuth } from '../../../domain/auth/no-auth-mcp-integration-auth.entity';
+import { SelfDefinedMcpIntegration } from '../../../domain/integrations/self-defined-mcp-integration.entity';
+import {
+  McpOAuthClientNotConfiguredError,
+  McpAuthorizationHeaderCollisionError,
+  UnexpectedMcpError,
+} from '../../mcp.errors';
+import { ApplicationError } from 'src/common/errors/base.error';
+import { ConfigField } from '../../../domain/value-objects/integration-config-schema';
+
+@Injectable()
+export class CreateSelfDefinedMcpIntegrationUseCase {
+  private readonly logger = new Logger(
+    CreateSelfDefinedMcpIntegrationUseCase.name,
+  );
+
+  constructor(
+    private readonly repository: McpIntegrationsRepositoryPort,
+    private readonly credentialEncryption: McpCredentialEncryptionPort,
+    private readonly factory: McpIntegrationFactory,
+    private readonly marketplaceConfigService: MarketplaceConfigService,
+    private readonly connectionValidationService: ConnectionValidationService,
+    private readonly contextService: ContextService,
+  ) {}
+
+  async execute(
+    command: CreateSelfDefinedMcpIntegrationCommand,
+  ): Promise<SelfDefinedMcpIntegration> {
+    this.logger.log('Creating self-defined MCP integration', {
+      name: command.name,
+    });
+
+    const orgId = this.contextService.get('orgId');
+    if (!orgId) {
+      throw new UnauthorizedException('User not authenticated');
+    }
+
+    try {
+      const configSchema = validateConfigSchema(command.configSchema);
+
+      if (configSchema.oauth) {
+        if (!command.oauthClientId || !command.oauthClientSecret) {
+          throw new McpOAuthClientNotConfiguredError();
+        }
+        this.assertNoAuthorizationHeaderCollision(
+          configSchema.orgFields,
+          configSchema.userFields,
+        );
+      }
+
+      const mergedValues = this.marketplaceConfigService.mergeFixedValues(
+        command.orgConfigValues,
+        configSchema.orgFields,
+      );
+
+      this.marketplaceConfigService.validateRequiredFields(
+        configSchema.orgFields,
+        mergedValues,
+      );
+
+      const encryptedValues =
+        await this.marketplaceConfigService.encryptSecretFields(
+          configSchema.orgFields,
+          mergedValues,
+        );
+
+      let encryptedClientSecret: string | undefined;
+      if (configSchema.oauth && command.oauthClientSecret) {
+        encryptedClientSecret = await this.credentialEncryption.encrypt(
+          command.oauthClientSecret,
+        );
+      }
+
+      const integration = this.factory.createIntegration({
+        kind: McpIntegrationKind.SELF_DEFINED,
+        orgId,
+        name: command.name,
+        serverUrl: command.serverUrl,
+        auth: new NoAuthMcpIntegrationAuth(),
+        configSchema,
+        orgConfigValues: encryptedValues,
+        returnsPii: command.returnsPii,
+        description: command.description,
+      });
+
+      if (
+        configSchema.oauth &&
+        command.oauthClientId &&
+        encryptedClientSecret
+      ) {
+        integration.setOAuthClientCredentials(
+          command.oauthClientId,
+          encryptedClientSecret,
+        );
+      }
+
+      const saved = await this.repository.save(integration);
+
+      const validated =
+        await this.connectionValidationService.validateAndUpdateStatus(saved);
+
+      return validated as SelfDefinedMcpIntegration;
+    } catch (error) {
+      if (
+        error instanceof ApplicationError ||
+        error instanceof UnauthorizedException
+      ) {
+        throw error;
+      }
+      this.logger.error(
+        'Unexpected error creating self-defined MCP integration',
+        { error: error as Error },
+      );
+      throw new UnexpectedMcpError('Unexpected error occurred');
+    }
+  }
+
+  private assertNoAuthorizationHeaderCollision(
+    orgFields: ConfigField[],
+    userFields: ConfigField[],
+  ): void {
+    const allFields = [...orgFields, ...userFields];
+    const hasCollision = allFields.some(
+      (f) => f.headerName?.toLowerCase() === 'authorization',
+    );
+    if (hasCollision) {
+      throw new McpAuthorizationHeaderCollisionError();
+    }
+  }
+}

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/delete-mcp-integration/delete-mcp-integration.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/delete-mcp-integration/delete-mcp-integration.use-case.spec.ts
@@ -6,6 +6,7 @@ import { DeleteMcpIntegrationUseCase } from './delete-mcp-integration.use-case';
 import { DeleteMcpIntegrationCommand } from './delete-mcp-integration.command';
 import { McpIntegrationsRepositoryPort } from '../../ports/mcp-integrations.repository.port';
 import { McpIntegrationUserConfigRepositoryPort } from '../../ports/mcp-integration-user-config.repository.port';
+import { McpIntegrationOAuthTokenRepositoryPort } from '../../ports/mcp-integration-oauth-token.repository.port';
 import { ContextService } from 'src/common/context/services/context.service';
 import {
   McpIntegrationNotFoundError,
@@ -20,6 +21,7 @@ describe('DeleteMcpIntegrationUseCase', () => {
   let useCase: DeleteMcpIntegrationUseCase;
   let repository: McpIntegrationsRepositoryPort;
   let userConfigRepository: McpIntegrationUserConfigRepositoryPort;
+  let oauthTokenRepository: McpIntegrationOAuthTokenRepositoryPort;
   let contextService: ContextService;
   let loggerLogSpy: jest.SpyInstance;
   let loggerErrorSpy: jest.SpyInstance;
@@ -65,6 +67,12 @@ describe('DeleteMcpIntegrationUseCase', () => {
           },
         },
         {
+          provide: McpIntegrationOAuthTokenRepositoryPort,
+          useValue: {
+            deleteAllByIntegration: jest.fn(),
+          },
+        },
+        {
           provide: ContextService,
           useValue: {
             get: jest.fn(),
@@ -81,6 +89,9 @@ describe('DeleteMcpIntegrationUseCase', () => {
     );
     userConfigRepository = module.get<McpIntegrationUserConfigRepositoryPort>(
       McpIntegrationUserConfigRepositoryPort,
+    );
+    oauthTokenRepository = module.get<McpIntegrationOAuthTokenRepositoryPort>(
+      McpIntegrationOAuthTokenRepositoryPort,
     );
     contextService = module.get<ContextService>(ContextService);
 
@@ -134,6 +145,25 @@ describe('DeleteMcpIntegrationUseCase', () => {
 
       // Assert
       expect(userConfigRepository.deleteByIntegrationId).toHaveBeenCalledWith(
+        mockIntegrationId,
+      );
+    });
+
+    it('should delete associated OAuth tokens when deleting an integration', async () => {
+      // Arrange
+      const mockIntegration = buildIntegration();
+
+      jest.spyOn(contextService, 'get').mockReturnValue(mockOrgId);
+      jest.spyOn(repository, 'findById').mockResolvedValue(mockIntegration);
+      jest.spyOn(repository, 'delete').mockResolvedValue(undefined);
+
+      const command = new DeleteMcpIntegrationCommand(mockIntegrationId);
+
+      // Act
+      await useCase.execute(command);
+
+      // Assert
+      expect(oauthTokenRepository.deleteAllByIntegration).toHaveBeenCalledWith(
         mockIntegrationId,
       );
     });

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/delete-mcp-integration/delete-mcp-integration.use-case.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/delete-mcp-integration/delete-mcp-integration.use-case.ts
@@ -2,6 +2,7 @@ import { Injectable, Logger, UnauthorizedException } from '@nestjs/common';
 import { DeleteMcpIntegrationCommand } from './delete-mcp-integration.command';
 import { McpIntegrationsRepositoryPort } from '../../ports/mcp-integrations.repository.port';
 import { McpIntegrationUserConfigRepositoryPort } from '../../ports/mcp-integration-user-config.repository.port';
+import { McpIntegrationOAuthTokenRepositoryPort } from '../../ports/mcp-integration-oauth-token.repository.port';
 import { ContextService } from 'src/common/context/services/context.service';
 import {
   McpIntegrationNotFoundError,
@@ -20,6 +21,7 @@ export class DeleteMcpIntegrationUseCase {
   constructor(
     private readonly repository: McpIntegrationsRepositoryPort,
     private readonly userConfigRepository: McpIntegrationUserConfigRepositoryPort,
+    private readonly oauthTokenRepository: McpIntegrationOAuthTokenRepositoryPort,
     private readonly contextService: ContextService,
   ) {}
 
@@ -53,6 +55,11 @@ export class DeleteMcpIntegrationUseCase {
 
       // Delete associated user configs before deleting the integration
       await this.userConfigRepository.deleteByIntegrationId(
+        command.integrationId,
+      );
+
+      // Delete associated OAuth tokens
+      await this.oauthTokenRepository.deleteAllByIntegration(
         command.integrationId,
       );
 

--- a/ayunis-core-backend/src/domain/mcp/mcp.module.ts
+++ b/ayunis-core-backend/src/domain/mcp/mcp.module.ts
@@ -63,6 +63,7 @@ import { StartMcpOAuthAuthorizationUseCase } from './application/use-cases/start
 import { CompleteMcpOAuthAuthorizationUseCase } from './application/use-cases/complete-mcp-oauth-authorization/complete-mcp-oauth-authorization.use-case';
 import { RevokeMcpOAuthAuthorizationUseCase } from './application/use-cases/revoke-mcp-oauth-authorization/revoke-mcp-oauth-authorization.use-case';
 import { GetMcpOAuthAuthorizationStatusUseCase } from './application/use-cases/get-mcp-oauth-authorization-status/get-mcp-oauth-authorization-status.use-case';
+import { CreateSelfDefinedMcpIntegrationUseCase } from './application/use-cases/create-self-defined-mcp-integration/create-self-defined-mcp-integration.use-case';
 
 // Controller and Mappers
 import { McpIntegrationsController } from './presenters/http/mcp-integrations.controller';
@@ -153,6 +154,7 @@ import { PredefinedConfigDtoMapper } from './presenters/http/mappers/predefined-
     CompleteMcpOAuthAuthorizationUseCase,
     RevokeMcpOAuthAuthorizationUseCase,
     GetMcpOAuthAuthorizationStatusUseCase,
+    CreateSelfDefinedMcpIntegrationUseCase,
     // Mappers
     McpIntegrationDtoMapper,
     PredefinedConfigDtoMapper,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds new creation flow for self-defined MCP integrations including runtime schema validation and optional OAuth client credential handling, which could affect integration setup and OAuth behavior. Also changes deletion behavior to purge OAuth tokens, impacting data cleanup and authorization state.
> 
> **Overview**
> Adds `CreateSelfDefinedMcpIntegrationUseCase` to create `SELF_DEFINED` MCP integrations from an admin-provided `configSchema` and org config values, including runtime schema validation, required-field enforcement, secret encryption, optional OAuth client credential encryption, and a guard against `Authorization` header collisions when OAuth is declared.
> 
> Introduces `validateConfigSchema()` (with extensive tests) to validate config schema shape, field types, duplicate keys, optional fixed values, and optional OAuth metadata while returning normalized `IntegrationConfigSchema` objects.
> 
> Updates `DeleteMcpIntegrationUseCase` to also delete all associated OAuth tokens via `McpIntegrationOAuthTokenRepositoryPort`, and wires the new use case into `mcp.module.ts` (plus docs updates in `SUMMARY.md`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bfdca6407d8c765b137bac104134ef2aae0db587. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->