### PR TITLE
wip(mcp): unblock marketplace oauth and extend update use case (AYC-110)

### DIFF
--- a/ayunis-core-backend/src/domain/mcp/application/mcp.errors.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/mcp.errors.ts
@@ -16,7 +16,6 @@ export enum McpErrorCode {
   UNEXPECTED_MCP_ERROR = 'UNEXPECTED_MCP_ERROR',
   MCP_AUTH_NOT_IMPLEMENTED = 'MCP_AUTH_NOT_IMPLEMENTED',
   DUPLICATE_MCP_INTEGRATION = 'DUPLICATE_MCP_INTEGRATION',
-  MCP_OAUTH_NOT_SUPPORTED = 'MCP_OAUTH_NOT_SUPPORTED',
   MCP_MISSING_REQUIRED_CONFIG = 'MCP_MISSING_REQUIRED_CONFIG',
   MCP_MARKETPLACE_INTEGRATION_NOT_FOUND = 'MCP_MARKETPLACE_INTEGRATION_NOT_FOUND',
   MCP_NOT_MARKETPLACE_INTEGRATION = 'MCP_NOT_MARKETPLACE_INTEGRATION',
@@ -249,17 +248,6 @@ export class DuplicateMarketplaceMcpIntegrationError extends McpError {
       `Marketplace integration '${identifier}' is already installed for this organization.`,
       McpErrorCode.DUPLICATE_MCP_INTEGRATION,
       409,
-      metadata,
-    );
-  }
-}
-
-export class McpOAuthNotSupportedError extends McpError {
-  constructor(metadata?: ErrorMetadata) {
-    super(
-      'OAuth authentication is not yet supported for marketplace integrations. Please use a different authentication method.',
-      McpErrorCode.MCP_OAUTH_NOT_SUPPORTED,
-      400,
       metadata,
     );
   }

--- a/ayunis-core-backend/src/domain/mcp/application/services/marketplace-config.service.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/services/marketplace-config.service.ts
@@ -1,7 +1,10 @@
 import { Injectable } from '@nestjs/common';
 import { McpCredentialEncryptionPort } from '../ports/mcp-credential-encryption.port';
 import { ConfigField } from '../../domain/value-objects/integration-config-schema';
-import { McpMissingRequiredConfigError } from '../mcp.errors';
+import {
+  McpMissingRequiredConfigError,
+  McpAuthorizationHeaderCollisionError,
+} from '../mcp.errors';
 
 /**
  * Shared service for marketplace integration config processing.
@@ -13,6 +16,27 @@ export class MarketplaceConfigService {
   constructor(
     private readonly credentialEncryption: McpCredentialEncryptionPort,
   ) {}
+
+  /**
+   * Asserts that no config field declares `headerName: 'Authorization'` when
+   * OAuth is also configured. OAuth sets `Authorization: Bearer …` automatically,
+   * so a config field mapping to the same header would cause a collision.
+   *
+   * Call this after parsing the config schema and only when `configSchema.oauth`
+   * is defined.
+   */
+  assertNoAuthorizationHeaderCollision(
+    orgFields: ConfigField[],
+    userFields: ConfigField[],
+  ): void {
+    const allFields = [...orgFields, ...userFields];
+    const hasCollision = allFields.some(
+      (f) => f.headerName?.toLowerCase() === 'authorization',
+    );
+    if (hasCollision) {
+      throw new McpAuthorizationHeaderCollisionError();
+    }
+  }
 
   /**
    * Merges fixed (system-controlled) values from the config schema into user-provided values.

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/create-self-defined-mcp-integration/create-self-defined-mcp-integration.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/create-self-defined-mcp-integration/create-self-defined-mcp-integration.use-case.spec.ts
@@ -99,6 +99,7 @@ describe('CreateSelfDefinedMcpIntegrationUseCase', () => {
             mergeFixedValues: jest.fn(),
             validateRequiredFields: jest.fn(),
             encryptSecretFields: jest.fn(),
+            assertNoAuthorizationHeaderCollision: jest.fn(),
           },
         },
         {
@@ -331,6 +332,11 @@ describe('CreateSelfDefinedMcpIntegrationUseCase', () => {
   describe('error — Authorization header collision', () => {
     it('should throw McpAuthorizationHeaderCollisionError when orgField has Authorization header and OAuth', async () => {
       contextService.get.mockReturnValue(mockOrgId);
+      marketplaceConfigService.assertNoAuthorizationHeaderCollision.mockImplementation(
+        () => {
+          throw new McpAuthorizationHeaderCollisionError();
+        },
+      );
 
       const command = new CreateSelfDefinedMcpIntegrationCommand(
         'Collision',
@@ -349,6 +355,11 @@ describe('CreateSelfDefinedMcpIntegrationUseCase', () => {
 
     it('should throw when userField has Authorization header and OAuth', async () => {
       contextService.get.mockReturnValue(mockOrgId);
+      marketplaceConfigService.assertNoAuthorizationHeaderCollision.mockImplementation(
+        () => {
+          throw new McpAuthorizationHeaderCollisionError();
+        },
+      );
 
       const schemaWithUserCollision: IntegrationConfigSchema = {
         authType: 'OAUTH',

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/create-self-defined-mcp-integration/create-self-defined-mcp-integration.use-case.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/create-self-defined-mcp-integration/create-self-defined-mcp-integration.use-case.ts
@@ -12,11 +12,9 @@ import { NoAuthMcpIntegrationAuth } from '../../../domain/auth/no-auth-mcp-integ
 import { SelfDefinedMcpIntegration } from '../../../domain/integrations/self-defined-mcp-integration.entity';
 import {
   McpOAuthClientNotConfiguredError,
-  McpAuthorizationHeaderCollisionError,
   UnexpectedMcpError,
 } from '../../mcp.errors';
 import { ApplicationError } from 'src/common/errors/base.error';
-import { ConfigField } from '../../../domain/value-objects/integration-config-schema';
 
 @Injectable()
 export class CreateSelfDefinedMcpIntegrationUseCase {
@@ -52,7 +50,7 @@ export class CreateSelfDefinedMcpIntegrationUseCase {
         if (!command.oauthClientId || !command.oauthClientSecret) {
           throw new McpOAuthClientNotConfiguredError();
         }
-        this.assertNoAuthorizationHeaderCollision(
+        this.marketplaceConfigService.assertNoAuthorizationHeaderCollision(
           configSchema.orgFields,
           configSchema.userFields,
         );
@@ -122,19 +120,6 @@ export class CreateSelfDefinedMcpIntegrationUseCase {
         { error: error as Error },
       );
       throw new UnexpectedMcpError('Unexpected error occurred');
-    }
-  }
-
-  private assertNoAuthorizationHeaderCollision(
-    orgFields: ConfigField[],
-    userFields: ConfigField[],
-  ): void {
-    const allFields = [...orgFields, ...userFields];
-    const hasCollision = allFields.some(
-      (f) => f.headerName?.toLowerCase() === 'authorization',
-    );
-    if (hasCollision) {
-      throw new McpAuthorizationHeaderCollisionError();
     }
   }
 }

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/install-marketplace-integration/install-marketplace-integration.command.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/install-marketplace-integration/install-marketplace-integration.command.ts
@@ -3,5 +3,7 @@ export class InstallMarketplaceIntegrationCommand {
     public readonly identifier: string,
     public readonly orgConfigValues: Record<string, string>,
     public readonly returnsPii?: boolean,
+    public readonly oauthClientId?: string,
+    public readonly oauthClientSecret?: string,
   ) {}
 }

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/install-marketplace-integration/install-marketplace-integration.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/install-marketplace-integration/install-marketplace-integration.use-case.spec.ts
@@ -13,7 +13,8 @@ import { MarketplaceMcpIntegration } from '../../../domain/integrations/marketpl
 import { NoAuthMcpIntegrationAuth } from '../../../domain/auth/no-auth-mcp-integration-auth.entity';
 import { McpIntegrationKind } from '../../../domain/value-objects/mcp-integration-kind.enum';
 import {
-  McpOAuthNotSupportedError,
+  McpOAuthClientNotConfiguredError,
+  McpAuthorizationHeaderCollisionError,
   McpMissingRequiredConfigError,
   DuplicateMarketplaceMcpIntegrationError,
 } from '../../mcp.errors';
@@ -26,6 +27,7 @@ describe('InstallMarketplaceIntegrationUseCase', () => {
   let getMarketplaceIntegrationUseCase: jest.Mocked<GetMarketplaceIntegrationUseCase>;
   let repository: jest.Mocked<McpIntegrationsRepositoryPort>;
   let credentialEncryption: jest.Mocked<McpCredentialEncryptionPort>;
+  let credentialEncryptionForUseCase: jest.Mocked<McpCredentialEncryptionPort>;
   let marketplaceConfigService: MarketplaceConfigService;
   let factory: McpIntegrationFactory;
   let authFactory: McpIntegrationAuthFactory;
@@ -101,9 +103,9 @@ describe('InstallMarketplaceIntegrationUseCase', () => {
       authType: 'OAUTH',
       orgFields: [
         {
-          key: 'clientId',
+          key: 'tenantId',
           type: 'text' as const,
-          label: 'Client ID',
+          label: 'Tenant ID',
           headerName: null,
           prefix: null,
           required: true,
@@ -112,6 +114,40 @@ describe('InstallMarketplaceIntegrationUseCase', () => {
         },
       ],
       userFields: [],
+      oauth: {
+        authorizationUrl: 'https://auth.example.com/authorize',
+        tokenUrl: 'https://auth.example.com/token',
+        scopes: ['read', 'write'],
+        level: 'org',
+      },
+    },
+  };
+
+  const oauthWithCollisionResponse: IntegrationResponseDto = {
+    ...oparlMarketplaceResponse,
+    identifier: 'oauth-collision',
+    name: 'OAuth Collision Integration',
+    configSchema: {
+      authType: 'OAUTH',
+      orgFields: [
+        {
+          key: 'authHeader',
+          type: 'secret' as const,
+          label: 'Auth Header',
+          headerName: 'Authorization',
+          prefix: null,
+          required: true,
+          help: null,
+          value: null,
+        },
+      ],
+      userFields: [],
+      oauth: {
+        authorizationUrl: 'https://auth.example.com/authorize',
+        tokenUrl: 'https://auth.example.com/token',
+        scopes: ['read'],
+        level: 'org',
+      },
     },
   };
 
@@ -135,6 +171,11 @@ describe('InstallMarketplaceIntegrationUseCase', () => {
       decrypt: jest.fn(),
     } as jest.Mocked<McpCredentialEncryptionPort>;
 
+    credentialEncryptionForUseCase = {
+      encrypt: jest.fn(),
+      decrypt: jest.fn(),
+    } as jest.Mocked<McpCredentialEncryptionPort>;
+
     factory = new McpIntegrationFactory();
     authFactory = new McpIntegrationAuthFactory();
 
@@ -150,6 +191,9 @@ describe('InstallMarketplaceIntegrationUseCase', () => {
 
     repository.save.mockImplementation(async (integration) => integration);
     credentialEncryption.encrypt.mockImplementation(
+      async (plaintext) => `encrypted:${plaintext}`,
+    );
+    credentialEncryptionForUseCase.encrypt.mockImplementation(
       async (plaintext) => `encrypted:${plaintext}`,
     );
     validateUseCase.execute.mockResolvedValue({
@@ -175,6 +219,7 @@ describe('InstallMarketplaceIntegrationUseCase', () => {
       authFactory,
       connectionValidationService,
       contextService,
+      credentialEncryptionForUseCase,
     );
   });
 
@@ -270,7 +315,32 @@ describe('InstallMarketplaceIntegrationUseCase', () => {
     expect(credentialEncryption.encrypt).not.toHaveBeenCalled();
   });
 
-  it('should reject OAUTH auth type', async () => {
+  it('should install an OAuth integration when client credentials are provided', async () => {
+    getMarketplaceIntegrationUseCase.execute.mockResolvedValue(
+      oauthIntegrationResponse,
+    );
+
+    const result = await useCase.execute(
+      new InstallMarketplaceIntegrationCommand(
+        'oauth-integration',
+        { tenantId: 'my-tenant' },
+        undefined,
+        'my-client-id',
+        'my-client-secret',
+      ),
+    );
+
+    expect(result).toBeInstanceOf(MarketplaceMcpIntegration);
+    expect(result.oauthClientId).toBe('my-client-id');
+    expect(result.oauthClientSecretEncrypted).toBe(
+      'encrypted:my-client-secret',
+    );
+    expect(credentialEncryptionForUseCase.encrypt).toHaveBeenCalledWith(
+      'my-client-secret',
+    );
+  });
+
+  it('should throw McpOAuthClientNotConfiguredError when OAuth schema present but no client credentials', async () => {
     getMarketplaceIntegrationUseCase.execute.mockResolvedValue(
       oauthIntegrationResponse,
     );
@@ -278,10 +348,28 @@ describe('InstallMarketplaceIntegrationUseCase', () => {
     await expect(
       useCase.execute(
         new InstallMarketplaceIntegrationCommand('oauth-integration', {
-          clientId: 'my-client',
+          tenantId: 'my-tenant',
         }),
       ),
-    ).rejects.toThrow(McpOAuthNotSupportedError);
+    ).rejects.toThrow(McpOAuthClientNotConfiguredError);
+  });
+
+  it('should throw McpAuthorizationHeaderCollisionError when OAuth + Authorization headerName', async () => {
+    getMarketplaceIntegrationUseCase.execute.mockResolvedValue(
+      oauthWithCollisionResponse,
+    );
+
+    await expect(
+      useCase.execute(
+        new InstallMarketplaceIntegrationCommand(
+          'oauth-collision',
+          { authHeader: 'some-value' },
+          undefined,
+          'client-id',
+          'client-secret',
+        ),
+      ),
+    ).rejects.toThrow(McpAuthorizationHeaderCollisionError);
   });
 
   it('should throw when required org fields are missing', async () => {

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/install-marketplace-integration/install-marketplace-integration.use-case.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/install-marketplace-integration/install-marketplace-integration.use-case.ts
@@ -41,13 +41,20 @@ interface MarketplaceConfigSchemaDto {
     help: string | null;
     value: string | null;
   }>;
+  oauth?: {
+    authorizationUrl: string;
+    tokenUrl: string;
+    scopes: string[];
+    level: 'org' | 'user';
+  };
 }
 import {
-  McpOAuthNotSupportedError,
   DuplicateMarketplaceMcpIntegrationError,
+  McpOAuthClientNotConfiguredError,
   UnexpectedMcpError,
 } from '../../mcp.errors';
 import { ApplicationError } from 'src/common/errors/base.error';
+import { McpCredentialEncryptionPort } from '../../ports/mcp-credential-encryption.port';
 
 @Injectable()
 export class InstallMarketplaceIntegrationUseCase {
@@ -63,6 +70,7 @@ export class InstallMarketplaceIntegrationUseCase {
     private readonly authFactory: McpIntegrationAuthFactory,
     private readonly connectionValidationService: ConnectionValidationService,
     private readonly contextService: ContextService,
+    private readonly credentialEncryption: McpCredentialEncryptionPort,
   ) {}
 
   async execute(
@@ -95,8 +103,18 @@ export class InstallMarketplaceIntegrationUseCase {
         marketplaceIntegration.configSchema,
       );
 
-      if (configSchema.authType === (McpAuthMethod.OAUTH as string)) {
-        throw new McpOAuthNotSupportedError();
+      let encryptedClientSecret: string | undefined;
+      if (configSchema.oauth) {
+        if (!command.oauthClientId || !command.oauthClientSecret) {
+          throw new McpOAuthClientNotConfiguredError();
+        }
+        this.marketplaceConfigService.assertNoAuthorizationHeaderCollision(
+          configSchema.orgFields,
+          configSchema.userFields,
+        );
+        encryptedClientSecret = await this.credentialEncryption.encrypt(
+          command.oauthClientSecret,
+        );
       }
 
       const mergedValues = this.marketplaceConfigService.mergeFixedValues(
@@ -132,6 +150,17 @@ export class InstallMarketplaceIntegrationUseCase {
         logoUrl: marketplaceIntegration.logoUrl ?? null,
       });
 
+      if (
+        configSchema.oauth &&
+        command.oauthClientId &&
+        encryptedClientSecret
+      ) {
+        integration.setOAuthClientCredentials(
+          command.oauthClientId,
+          encryptedClientSecret,
+        );
+      }
+
       const saved = await this.repository.save(integration);
 
       const validated =
@@ -157,11 +186,20 @@ export class InstallMarketplaceIntegrationUseCase {
     dto: Record<string, unknown>,
   ): IntegrationConfigSchema {
     const schema = dto as unknown as MarketplaceConfigSchemaDto;
-    return {
+    const result: IntegrationConfigSchema = {
       authType: schema.authType,
       orgFields: schema.orgFields.map((f) => this.parseConfigField(f)),
       userFields: schema.userFields.map((f) => this.parseConfigField(f)),
     };
+    if (schema.oauth) {
+      result.oauth = {
+        authorizationUrl: schema.oauth.authorizationUrl,
+        tokenUrl: schema.oauth.tokenUrl,
+        scopes: schema.oauth.scopes,
+        level: schema.oauth.level,
+      };
+    }
+    return result;
   }
 
   private parseConfigField(

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/update-mcp-integration/update-mcp-integration.command.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/update-mcp-integration/update-mcp-integration.command.ts
@@ -1,3 +1,5 @@
+import type { IntegrationConfigSchema } from '../../../domain/value-objects/integration-config-schema';
+
 interface UpdateMcpIntegrationParams {
   integrationId: string;
   name?: string;
@@ -5,6 +7,9 @@ interface UpdateMcpIntegrationParams {
   authHeaderName?: string;
   returnsPii?: boolean;
   orgConfigValues?: Record<string, string>;
+  oauthClientId?: string;
+  oauthClientSecret?: string;
+  configSchema?: IntegrationConfigSchema;
 }
 
 export class UpdateMcpIntegrationCommand {
@@ -14,6 +19,9 @@ export class UpdateMcpIntegrationCommand {
   public readonly authHeaderName?: string;
   public readonly returnsPii?: boolean;
   public readonly orgConfigValues?: Record<string, string>;
+  public readonly oauthClientId?: string;
+  public readonly oauthClientSecret?: string;
+  public readonly configSchema?: IntegrationConfigSchema;
 
   constructor(params: UpdateMcpIntegrationParams) {
     this.integrationId = params.integrationId;
@@ -22,5 +30,8 @@ export class UpdateMcpIntegrationCommand {
     this.authHeaderName = params.authHeaderName;
     this.returnsPii = params.returnsPii;
     this.orgConfigValues = params.orgConfigValues;
+    this.oauthClientId = params.oauthClientId;
+    this.oauthClientSecret = params.oauthClientSecret;
+    this.configSchema = params.configSchema;
   }
 }

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/update-mcp-integration/update-mcp-integration.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/update-mcp-integration/update-mcp-integration.use-case.spec.ts
@@ -10,12 +10,15 @@ import { ConnectionValidationService } from '../../services/connection-validatio
 import type { ValidateMcpIntegrationUseCase } from '../validate-mcp-integration/validate-mcp-integration.use-case';
 import { CustomMcpIntegration } from '../../../domain/integrations/custom-mcp-integration.entity';
 import { MarketplaceMcpIntegration } from '../../../domain/integrations/marketplace-mcp-integration.entity';
+import { SelfDefinedMcpIntegration } from '../../../domain/integrations/self-defined-mcp-integration.entity';
 import { BearerMcpIntegrationAuth } from '../../../domain/auth/bearer-mcp-integration-auth.entity';
 import { CustomHeaderMcpIntegrationAuth } from '../../../domain/auth/custom-header-mcp-integration-auth.entity';
 import { NoAuthMcpIntegrationAuth } from '../../../domain/auth/no-auth-mcp-integration-auth.entity';
 import {
   McpNotMarketplaceIntegrationError,
   McpMissingRequiredConfigError,
+  McpValidationFailedError,
+  McpAuthorizationHeaderCollisionError,
 } from '../../mcp.errors';
 import type { IntegrationConfigSchema } from '../../../domain/value-objects/integration-config-schema';
 
@@ -368,6 +371,252 @@ describe('UpdateMcpIntegrationUseCase', () => {
       // Should not throw even though validation failed
       const result = await useCase.execute(command);
       expect(result).toBeInstanceOf(MarketplaceMcpIntegration);
+    });
+  });
+
+  describe('OAuth client credential rotation', () => {
+    const oauthConfigSchema: IntegrationConfigSchema = {
+      authType: 'OAUTH',
+      orgFields: [
+        {
+          key: 'tenantId',
+          label: 'Tenant ID',
+          type: 'text',
+          required: true,
+        },
+      ],
+      userFields: [],
+      oauth: {
+        authorizationUrl: 'https://auth.example.com/authorize',
+        tokenUrl: 'https://auth.example.com/token',
+        scopes: ['read'],
+        level: 'org',
+      },
+    };
+
+    it('rotates OAuth client credentials on a marketplace integration', async () => {
+      const integration = new MarketplaceMcpIntegration({
+        id: integrationId,
+        orgId,
+        name: 'OAuth Marketplace',
+        serverUrl: 'https://mcp.example.com',
+        marketplaceIdentifier: 'oauth-marketplace',
+        configSchema: oauthConfigSchema,
+        orgConfigValues: { tenantId: 'my-tenant' },
+        auth: new NoAuthMcpIntegrationAuth(),
+        oauthClientId: 'old-client-id',
+        oauthClientSecretEncrypted: 'encrypted:old-secret',
+      });
+      repository.findById.mockResolvedValue(integration);
+      encryption.encrypt.mockResolvedValue('encrypted:new-secret');
+
+      const command = new UpdateMcpIntegrationCommand({
+        integrationId,
+        oauthClientId: 'new-client-id',
+        oauthClientSecret: 'new-secret',
+      });
+
+      const result = await useCase.execute(command);
+
+      expect(result.oauthClientId).toBe('new-client-id');
+      expect(result.oauthClientSecretEncrypted).toBe('encrypted:new-secret');
+      expect(encryption.encrypt).toHaveBeenCalledWith('new-secret');
+    });
+
+    it('rotates only client ID keeping existing encrypted secret', async () => {
+      const integration = new MarketplaceMcpIntegration({
+        id: integrationId,
+        orgId,
+        name: 'OAuth Marketplace',
+        serverUrl: 'https://mcp.example.com',
+        marketplaceIdentifier: 'oauth-marketplace',
+        configSchema: oauthConfigSchema,
+        orgConfigValues: { tenantId: 'my-tenant' },
+        auth: new NoAuthMcpIntegrationAuth(),
+        oauthClientId: 'old-client-id',
+        oauthClientSecretEncrypted: 'encrypted:existing-secret',
+      });
+      repository.findById.mockResolvedValue(integration);
+
+      const command = new UpdateMcpIntegrationCommand({
+        integrationId,
+        oauthClientId: 'new-client-id',
+      });
+
+      const result = await useCase.execute(command);
+
+      expect(result.oauthClientId).toBe('new-client-id');
+      expect(result.oauthClientSecretEncrypted).toBe(
+        'encrypted:existing-secret',
+      );
+      expect(encryption.encrypt).not.toHaveBeenCalled();
+    });
+
+    it('rejects OAuth credential rotation on a custom integration', async () => {
+      const integration = new CustomMcpIntegration({
+        id: integrationId,
+        orgId,
+        name: 'Custom',
+        serverUrl: 'https://example.com/mcp',
+        auth: new NoAuthMcpIntegrationAuth(),
+      });
+      repository.findById.mockResolvedValue(integration);
+
+      const command = new UpdateMcpIntegrationCommand({
+        integrationId,
+        oauthClientId: 'new-client-id',
+        oauthClientSecret: 'new-secret',
+      });
+
+      await expect(useCase.execute(command)).rejects.toThrow(
+        McpValidationFailedError,
+      );
+    });
+  });
+
+  describe('self-defined configSchema and orgConfigValues', () => {
+    const selfDefinedConfigSchema: IntegrationConfigSchema = {
+      authType: 'NO_AUTH',
+      orgFields: [
+        {
+          key: 'endpointUrl',
+          label: 'Endpoint URL',
+          type: 'url',
+          headerName: 'X-Endpoint-Url',
+          required: true,
+        },
+      ],
+      userFields: [],
+    };
+
+    function createSelfDefinedIntegration(
+      overrides: Partial<{
+        orgConfigValues: Record<string, string>;
+        configSchema: IntegrationConfigSchema;
+      }> = {},
+    ): SelfDefinedMcpIntegration {
+      return new SelfDefinedMcpIntegration({
+        id: integrationId,
+        orgId,
+        name: 'Self Defined Integration',
+        serverUrl: 'https://mcp.example.com',
+        configSchema: overrides.configSchema ?? selfDefinedConfigSchema,
+        orgConfigValues: overrides.orgConfigValues ?? {
+          endpointUrl: 'https://old-endpoint.com',
+        },
+        auth: new NoAuthMcpIntegrationAuth(),
+      });
+    }
+
+    it('updates orgConfigValues for a self-defined integration', async () => {
+      const integration = createSelfDefinedIntegration();
+      repository.findById.mockResolvedValue(integration);
+
+      const command = new UpdateMcpIntegrationCommand({
+        integrationId,
+        orgConfigValues: { endpointUrl: 'https://new-endpoint.com' },
+      });
+
+      const result = await useCase.execute(command);
+
+      expect(
+        (result as SelfDefinedMcpIntegration).orgConfigValues.endpointUrl,
+      ).toBe('https://new-endpoint.com');
+    });
+
+    it('updates configSchema for a self-defined integration', async () => {
+      const integration = createSelfDefinedIntegration();
+      repository.findById.mockResolvedValue(integration);
+
+      const newSchema: IntegrationConfigSchema = {
+        authType: 'BEARER_TOKEN',
+        orgFields: [
+          {
+            key: 'apiKey',
+            label: 'API Key',
+            type: 'secret',
+            headerName: 'Authorization',
+            prefix: 'Bearer ',
+            required: true,
+          },
+        ],
+        userFields: [],
+      };
+
+      const command = new UpdateMcpIntegrationCommand({
+        integrationId,
+        configSchema: newSchema,
+      });
+
+      const result = await useCase.execute(command);
+
+      expect((result as SelfDefinedMcpIntegration).configSchema.authType).toBe(
+        'BEARER_TOKEN',
+      );
+      expect(
+        (result as SelfDefinedMcpIntegration).configSchema.orgFields,
+      ).toHaveLength(1);
+      expect(
+        (result as SelfDefinedMcpIntegration).configSchema.orgFields[0].key,
+      ).toBe('apiKey');
+    });
+
+    it('rejects configSchema with OAuth and Authorization header collision', async () => {
+      const integration = createSelfDefinedIntegration();
+      repository.findById.mockResolvedValue(integration);
+
+      const schemaWithCollision: IntegrationConfigSchema = {
+        authType: 'OAUTH',
+        orgFields: [
+          {
+            key: 'token',
+            label: 'Token',
+            type: 'secret',
+            headerName: 'Authorization',
+            prefix: 'Bearer ',
+            required: true,
+          },
+        ],
+        userFields: [],
+        oauth: {
+          authorizationUrl: 'https://auth.example.com/authorize',
+          tokenUrl: 'https://auth.example.com/token',
+          scopes: ['read'],
+          level: 'org',
+        },
+      };
+
+      const command = new UpdateMcpIntegrationCommand({
+        integrationId,
+        configSchema: schemaWithCollision,
+      });
+
+      await expect(useCase.execute(command)).rejects.toThrow(
+        McpAuthorizationHeaderCollisionError,
+      );
+    });
+
+    it('rejects configSchema update on a marketplace integration', async () => {
+      const integration = new MarketplaceMcpIntegration({
+        id: integrationId,
+        orgId,
+        name: 'Marketplace',
+        serverUrl: 'https://mcp.example.com',
+        marketplaceIdentifier: 'some-marketplace',
+        configSchema: selfDefinedConfigSchema,
+        orgConfigValues: { endpointUrl: 'https://old.com' },
+        auth: new NoAuthMcpIntegrationAuth(),
+      });
+      repository.findById.mockResolvedValue(integration);
+
+      const command = new UpdateMcpIntegrationCommand({
+        integrationId,
+        configSchema: selfDefinedConfigSchema,
+      });
+
+      await expect(useCase.execute(command)).rejects.toThrow(
+        McpValidationFailedError,
+      );
     });
   });
 });

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/update-mcp-integration/update-mcp-integration.use-case.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/update-mcp-integration/update-mcp-integration.use-case.ts
@@ -17,8 +17,10 @@ import { BearerMcpIntegrationAuth } from '../../../domain/auth/bearer-mcp-integr
 import { CustomHeaderMcpIntegrationAuth } from '../../../domain/auth/custom-header-mcp-integration-auth.entity';
 import { McpValidationFailedError } from '../../mcp.errors';
 import { MarketplaceMcpIntegration } from '../../../domain/integrations/marketplace-mcp-integration.entity';
+import { SelfDefinedMcpIntegration } from '../../../domain/integrations/self-defined-mcp-integration.entity';
 import { MarketplaceConfigService } from '../../services/marketplace-config.service';
 import { ConnectionValidationService } from '../../services/connection-validation.service';
+import { validateConfigSchema } from '../../services/integration-config-schema.validator';
 
 @Injectable()
 export class UpdateMcpIntegrationUseCase {
@@ -52,33 +54,17 @@ export class UpdateMcpIntegrationUseCase {
         throw new McpIntegrationAccessDeniedError(command.integrationId);
       }
 
-      // Update fields (only if provided)
-      if (command.name !== undefined) {
-        integration.updateName(command.name);
-      }
-
-      if (command.returnsPii !== undefined) {
-        integration.updateReturnsPii(command.returnsPii);
-      }
-
-      if (
-        command.credentials !== undefined ||
-        command.authHeaderName !== undefined
-      ) {
-        await this.rotateCredentials(
-          integration,
-          command.credentials,
-          command.authHeaderName,
-        );
-      }
-
-      if (command.orgConfigValues !== undefined) {
-        await this.updateOrgConfigValues(integration, command.orgConfigValues);
-      }
+      await this.applyFieldUpdates(integration, command);
 
       let saved = await this.repository.save(integration);
 
-      if (command.orgConfigValues !== undefined) {
+      const needsRevalidation =
+        command.orgConfigValues !== undefined ||
+        command.configSchema !== undefined ||
+        command.oauthClientId !== undefined ||
+        command.oauthClientSecret !== undefined;
+
+      if (needsRevalidation) {
         saved =
           await this.connectionValidationService.validateAndUpdateStatus(saved);
       }
@@ -98,21 +84,130 @@ export class UpdateMcpIntegrationUseCase {
     }
   }
 
+  private async applyFieldUpdates(
+    integration: McpIntegration,
+    command: UpdateMcpIntegrationCommand,
+  ): Promise<void> {
+    if (command.name !== undefined) {
+      integration.updateName(command.name);
+    }
+
+    if (command.returnsPii !== undefined) {
+      integration.updateReturnsPii(command.returnsPii);
+    }
+
+    if (
+      command.credentials !== undefined ||
+      command.authHeaderName !== undefined
+    ) {
+      await this.rotateCredentials(
+        integration,
+        command.credentials,
+        command.authHeaderName,
+      );
+    }
+
+    if (
+      command.oauthClientId !== undefined ||
+      command.oauthClientSecret !== undefined
+    ) {
+      await this.rotateOAuthClientCredentials(
+        integration,
+        command.oauthClientId,
+        command.oauthClientSecret,
+      );
+    }
+
+    if (command.configSchema !== undefined) {
+      this.updateConfigSchema(integration, command.configSchema);
+    }
+
+    if (command.orgConfigValues !== undefined) {
+      await this.updateOrgConfigValues(integration, command.orgConfigValues);
+    }
+  }
+
+  private async rotateOAuthClientCredentials(
+    integration: McpIntegration,
+    oauthClientId?: string,
+    oauthClientSecret?: string,
+  ): Promise<void> {
+    if (!integration.isMarketplace() && !integration.isSelfDefined()) {
+      throw new McpValidationFailedError(
+        integration.id,
+        integration.name,
+        'OAuth client credentials are only supported for MARKETPLACE and SELF_DEFINED integrations.',
+      );
+    }
+
+    const newClientId = oauthClientId ?? integration.oauthClientId;
+    if (!newClientId) {
+      throw new McpValidationFailedError(
+        integration.id,
+        integration.name,
+        'oauthClientId must be provided when setting OAuth client credentials.',
+      );
+    }
+
+    const newSecret = oauthClientSecret
+      ? await this.credentialEncryption.encrypt(oauthClientSecret)
+      : integration.oauthClientSecretEncrypted;
+    if (!newSecret) {
+      throw new McpValidationFailedError(
+        integration.id,
+        integration.name,
+        'oauthClientSecret must be provided when setting OAuth client credentials.',
+      );
+    }
+
+    integration.setOAuthClientCredentials(newClientId, newSecret);
+  }
+
+  private updateConfigSchema(
+    integration: McpIntegration,
+    rawSchema: unknown,
+  ): void {
+    if (!(integration instanceof SelfDefinedMcpIntegration)) {
+      throw new McpValidationFailedError(
+        integration.id,
+        integration.name,
+        'configSchema can only be updated on SELF_DEFINED integrations.',
+      );
+    }
+
+    // Validate and replace — a full re-validate of orgConfigValues against the
+    // new schema is the caller's responsibility (typically done alongside an
+    // orgConfigValues update in the same command).
+    const validated = validateConfigSchema(rawSchema);
+
+    if (validated.oauth) {
+      this.marketplaceConfigService.assertNoAuthorizationHeaderCollision(
+        validated.orgFields,
+        validated.userFields,
+      );
+    }
+
+    integration.updateConfigSchema(validated);
+  }
+
   private async updateOrgConfigValues(
     integration: McpIntegration,
     orgConfigValues: Record<string, string>,
   ): Promise<void> {
-    if (!(integration instanceof MarketplaceMcpIntegration)) {
-      throw new McpNotMarketplaceIntegrationError(integration.id);
+    if (
+      integration instanceof MarketplaceMcpIntegration ||
+      integration instanceof SelfDefinedMcpIntegration
+    ) {
+      const mergedValues = await this.marketplaceConfigService.mergeForUpdate(
+        integration.orgConfigValues,
+        orgConfigValues,
+        integration.configSchema.orgFields,
+      );
+      integration.updateOrgConfigValues(mergedValues);
+      return;
     }
 
-    const mergedValues = await this.marketplaceConfigService.mergeForUpdate(
-      integration.orgConfigValues,
-      orgConfigValues,
-      integration.configSchema.orgFields,
-    );
-
-    integration.updateOrgConfigValues(mergedValues);
+    throw new McpNotMarketplaceIntegrationError(integration.id);
   }
 
   private async rotateCredentials(
@@ -124,70 +219,99 @@ export class UpdateMcpIntegrationUseCase {
     const authMethod = auth.getMethod();
 
     switch (authMethod) {
-      case McpAuthMethod.NO_AUTH: {
-        if (credentials !== undefined || authHeaderName !== undefined) {
-          throw new McpValidationFailedError(
-            integration.id,
-            integration.name,
-            'This integration does not support authentication credentials.',
-          );
-        }
+      case McpAuthMethod.NO_AUTH:
+      case McpAuthMethod.OAUTH:
+        this.rejectCredentialRotation(
+          integration,
+          authMethod,
+          credentials,
+          authHeaderName,
+        );
         return;
-      }
-      case McpAuthMethod.BEARER_TOKEN: {
-        if (authHeaderName !== undefined) {
-          throw new McpValidationFailedError(
-            integration.id,
-            integration.name,
-            'Bearer token integrations always use the Authorization header.',
-          );
-        }
-
-        if (credentials === undefined) {
-          return;
-        }
-
-        const encryptedToken =
-          await this.credentialEncryption.encrypt(credentials);
-        (auth as BearerMcpIntegrationAuth).setToken(encryptedToken);
+      case McpAuthMethod.BEARER_TOKEN:
+        await this.rotateBearerToken(
+          integration,
+          auth as BearerMcpIntegrationAuth,
+          credentials,
+          authHeaderName,
+        );
         return;
-      }
-      case McpAuthMethod.CUSTOM_HEADER: {
-        const customAuth = auth as CustomHeaderMcpIntegrationAuth;
-
-        if (credentials !== undefined) {
-          const encryptedSecret =
-            await this.credentialEncryption.encrypt(credentials);
-          const headerNameToUse =
-            authHeaderName ?? customAuth.getAuthHeaderName();
-          customAuth.setSecret(encryptedSecret, headerNameToUse);
-          return;
-        }
-
-        if (authHeaderName !== undefined) {
-          const currentSecret = customAuth.secret;
-          if (!currentSecret) {
-            throw new McpValidationFailedError(
-              integration.id,
-              integration.name,
-              'Credentials must be configured before updating the header name.',
-            );
-          }
-
-          customAuth.setSecret(currentSecret, authHeaderName);
-        }
+      case McpAuthMethod.CUSTOM_HEADER:
+        await this.rotateCustomHeader(
+          integration,
+          auth as CustomHeaderMcpIntegrationAuth,
+          credentials,
+          authHeaderName,
+        );
         return;
+    }
+  }
+
+  private rejectCredentialRotation(
+    integration: McpIntegration,
+    authMethod: McpAuthMethod,
+    credentials?: string,
+    authHeaderName?: string,
+  ): void {
+    if (credentials !== undefined || authHeaderName !== undefined) {
+      const message =
+        authMethod === McpAuthMethod.NO_AUTH
+          ? 'This integration does not support authentication credentials.'
+          : `Credential rotation is not supported for auth method ${authMethod}.`;
+      throw new McpValidationFailedError(
+        integration.id,
+        integration.name,
+        message,
+      );
+    }
+  }
+
+  private async rotateBearerToken(
+    integration: McpIntegration,
+    auth: BearerMcpIntegrationAuth,
+    credentials?: string,
+    authHeaderName?: string,
+  ): Promise<void> {
+    if (authHeaderName !== undefined) {
+      throw new McpValidationFailedError(
+        integration.id,
+        integration.name,
+        'Bearer token integrations always use the Authorization header.',
+      );
+    }
+
+    if (credentials === undefined) {
+      return;
+    }
+
+    const encryptedToken = await this.credentialEncryption.encrypt(credentials);
+    auth.setToken(encryptedToken);
+  }
+
+  private async rotateCustomHeader(
+    integration: McpIntegration,
+    customAuth: CustomHeaderMcpIntegrationAuth,
+    credentials?: string,
+    authHeaderName?: string,
+  ): Promise<void> {
+    if (credentials !== undefined) {
+      const encryptedSecret =
+        await this.credentialEncryption.encrypt(credentials);
+      const headerNameToUse = authHeaderName ?? customAuth.getAuthHeaderName();
+      customAuth.setSecret(encryptedSecret, headerNameToUse);
+      return;
+    }
+
+    if (authHeaderName !== undefined) {
+      const currentSecret = customAuth.secret;
+      if (!currentSecret) {
+        throw new McpValidationFailedError(
+          integration.id,
+          integration.name,
+          'Credentials must be configured before updating the header name.',
+        );
       }
-      case McpAuthMethod.OAUTH: {
-        if (credentials !== undefined || authHeaderName !== undefined) {
-          throw new McpValidationFailedError(
-            integration.id,
-            integration.name,
-            `Credential rotation is not supported for auth method ${authMethod}.`,
-          );
-        }
-        return;
-      }
+      customAuth.setSecret(currentSecret, authHeaderName);
     }
   }
 }

--- a/ayunis-core-backend/src/domain/mcp/domain/integrations/self-defined-mcp-integration.entity.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/domain/integrations/self-defined-mcp-integration.entity.spec.ts
@@ -138,6 +138,32 @@ describe('SelfDefinedMcpIntegration', () => {
     expect(integration.orgConfigValues).toEqual({});
   });
 
+  it('should update config schema and refresh updatedAt', () => {
+    const integration = new SelfDefinedMcpIntegration({
+      orgId,
+      name: 'Internal Wiki MCP',
+      serverUrl: 'https://wiki.internal.example.org/mcp',
+      configSchema,
+      orgConfigValues: {},
+      auth: new NoAuthMcpIntegrationAuth(),
+    });
+
+    const previousUpdatedAt = integration.updatedAt;
+
+    const newSchema: IntegrationConfigSchema = {
+      authType: 'NO_AUTH',
+      orgFields: [],
+      userFields: [],
+    };
+
+    integration.updateConfigSchema(newSchema);
+
+    expect(integration.configSchema).toBe(newSchema);
+    expect(integration.updatedAt.getTime()).toBeGreaterThanOrEqual(
+      previousUpdatedAt.getTime(),
+    );
+  });
+
   it('should accept and expose OAuth client credentials when provided', () => {
     const integration = new SelfDefinedMcpIntegration({
       orgId,

--- a/ayunis-core-backend/src/domain/mcp/domain/integrations/self-defined-mcp-integration.entity.ts
+++ b/ayunis-core-backend/src/domain/mcp/domain/integrations/self-defined-mcp-integration.entity.ts
@@ -14,7 +14,7 @@ import type { IntegrationConfigSchema } from '../value-objects/integration-confi
  * hierarchy. The auth entity is always `NoAuthMcpIntegrationAuth`.
  */
 export class SelfDefinedMcpIntegration extends McpIntegration {
-  public readonly configSchema: IntegrationConfigSchema;
+  private _configSchema: IntegrationConfigSchema;
   private _orgConfigValues: Record<string, string>;
   private readonly _serverUrl: string;
 
@@ -54,7 +54,7 @@ export class SelfDefinedMcpIntegration extends McpIntegration {
       oauthClientSecretEncrypted: params.oauthClientSecretEncrypted,
     });
 
-    this.configSchema = params.configSchema;
+    this._configSchema = params.configSchema;
     this._orgConfigValues = { ...params.orgConfigValues };
     this._serverUrl = params.serverUrl;
   }
@@ -69,6 +69,15 @@ export class SelfDefinedMcpIntegration extends McpIntegration {
 
   get orgConfigValues(): Record<string, string> {
     return { ...this._orgConfigValues };
+  }
+
+  get configSchema(): IntegrationConfigSchema {
+    return this._configSchema;
+  }
+
+  updateConfigSchema(schema: IntegrationConfigSchema): void {
+    this._configSchema = schema;
+    this.touch();
   }
 
   updateOrgConfigValues(values: Record<string, string>): void {

--- a/ayunis-core-backend/src/domain/mcp/domain/mcp-integration-oauth-token.entity.ts
+++ b/ayunis-core-backend/src/domain/mcp/domain/mcp-integration-oauth-token.entity.ts
@@ -19,9 +19,7 @@ import { randomUUID, type UUID } from 'crypto';
  * `CreateMcpIntegrationUseCase` OAuth branch (which currently throws
  * `McpAuthNotImplementedError`). New OAuth flows use this entity plus the
  * base-class `oauthClientId` / `oauthClientSecretEncrypted` fields on
- * `McpIntegration`; the legacy entity is untouched by this task (scheduled
- * for removal in Step 7, which also deletes `McpOAuthNotSupportedError` and
- * unblocks marketplace OAuth).
+ * `McpIntegration`; the legacy entity is untouched by this task.
  */
 export class McpIntegrationOAuthToken {
   public readonly id: UUID;

--- a/ayunis-core-backend/src/domain/mcp/domain/mcp-integration.entity.ts
+++ b/ayunis-core-backend/src/domain/mcp/domain/mcp-integration.entity.ts
@@ -39,9 +39,7 @@ export abstract class McpIntegration {
    * under `domain/mcp/domain/auth/` is still used by the legacy
    * `CreateMcpIntegrationUseCase` OAuth branch (which currently throws
    * `McpAuthNotImplementedError`). New OAuth flows use these fields plus
-   * `McpIntegrationOAuthToken`; the legacy entity is untouched by this task
-   * (scheduled for removal in Step 7, which also deletes
-   * `McpOAuthNotSupportedError` and unblocks marketplace OAuth).
+   * `McpIntegrationOAuthToken`; the legacy entity is untouched by this task.
    */
   private _oauthClientId?: string;
   private _oauthClientSecretEncrypted?: string;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds support for storing/rotating OAuth client credentials and updating self-defined schemas, which changes validation/encryption paths for integration configuration and could affect auth/config correctness if misused.
> 
> **Overview**
> **Marketplace OAuth is now supported on install.** `InstallMarketplaceIntegrationUseCase` accepts `oauthClientId`/`oauthClientSecret`, parses the `oauth` block from marketplace `configSchema`, encrypts/stores client credentials, and fails fast with `McpOAuthClientNotConfiguredError` when credentials are missing.
> 
> **OAuth/header safety check is centralized.** A new `MarketplaceConfigService.assertNoAuthorizationHeaderCollision()` is used by install/create/update flows to reject schemas that map any field to the `Authorization` header when OAuth is configured.
> 
> **`UpdateMcpIntegrationUseCase` is expanded and refactored.** It now supports rotating OAuth client credentials (marketplace/self-defined only), allows updating `orgConfigValues` for self-defined integrations, allows updating `configSchema` for self-defined integrations (validated via `validateConfigSchema`), and triggers connection revalidation when config/schema/OAuth credentials change.
> 
> **Cleanup & domain tweaks.** Removes `McpOAuthNotSupportedError`, updates tests accordingly, and makes `SelfDefinedMcpIntegration.configSchema` mutable via `updateConfigSchema()` (touching `updatedAt`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad088145ade493f327c0b0ddc33605840360d3b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->