### PR TITLE
wip(mcp): wire oauth into mcp client service and connection validation (AYC-110)

### DIFF
--- a/ayunis-core-backend/src/domain/mcp/application/services/connection-validation.service.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/services/connection-validation.service.spec.ts
@@ -3,6 +3,7 @@ import type { ValidateMcpIntegrationUseCase } from '../use-cases/validate-mcp-in
 import type { McpIntegrationsRepositoryPort } from '../ports/mcp-integrations.repository.port';
 import { CustomMcpIntegration } from '../../domain/integrations/custom-mcp-integration.entity';
 import { NoAuthMcpIntegrationAuth } from '../../domain/auth/no-auth-mcp-integration-auth.entity';
+import { McpOAuthAuthorizationRequiredError } from '../mcp.errors';
 import { randomUUID } from 'crypto';
 
 describe('ConnectionValidationService', () => {
@@ -121,5 +122,18 @@ describe('ConnectionValidationService', () => {
     await expect(
       service.validateAndUpdateStatus(integration),
     ).resolves.not.toThrow();
+  });
+
+  it('sets status to pending_auth when validation throws McpOAuthAuthorizationRequiredError', async () => {
+    const integration = createIntegration();
+    validateUseCase.execute.mockRejectedValue(
+      new McpOAuthAuthorizationRequiredError(integrationId),
+    );
+
+    await service.validateAndUpdateStatus(integration);
+
+    expect(integration.connectionStatus).toBe('pending_auth');
+    expect(integration.lastConnectionError).toBeUndefined();
+    expect(repository.save).toHaveBeenCalledWith(integration);
   });
 });

--- a/ayunis-core-backend/src/domain/mcp/application/services/connection-validation.service.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/services/connection-validation.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { ValidateMcpIntegrationUseCase } from '../use-cases/validate-mcp-integration/validate-mcp-integration.use-case';
 import { McpIntegrationsRepositoryPort } from '../ports/mcp-integrations.repository.port';
 import { McpIntegration } from '../../domain/mcp-integration.entity';
+import { McpOAuthAuthorizationRequiredError } from '../mcp.errors';
 
 /**
  * Validates an MCP integration's connection and persists the resulting status.
@@ -31,11 +32,15 @@ export class ConnectionValidationService {
         );
       }
     } catch (error) {
-      const errorMessage =
-        error instanceof Error
-          ? `Validation failed: ${error.message}`
-          : 'Validation failed: Unknown error';
-      integration.updateConnectionStatus('error', errorMessage);
+      if (error instanceof McpOAuthAuthorizationRequiredError) {
+        integration.updateConnectionStatus('pending_auth', undefined);
+      } else {
+        const errorMessage =
+          error instanceof Error
+            ? `Validation failed: ${error.message}`
+            : 'Validation failed: Unknown error';
+        integration.updateConnectionStatus('error', errorMessage);
+      }
     }
 
     return this.repository.save(integration);

--- a/ayunis-core-backend/src/domain/mcp/application/services/mcp-client.service.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/services/mcp-client.service.spec.ts
@@ -15,7 +15,21 @@ import { BearerMcpIntegrationAuth } from '../../domain/auth/bearer-mcp-integrati
 import { CustomHeaderMcpIntegrationAuth } from '../../domain/auth/custom-header-mcp-integration-auth.entity';
 import { OAuthMcpIntegrationAuth } from '../../domain/auth/oauth-mcp-integration-auth.entity';
 import { NoAuthMcpIntegrationAuth } from '../../domain/auth/no-auth-mcp-integration-auth.entity';
-import { McpAuthenticationError } from '../mcp.errors';
+import {
+  McpAuthenticationError,
+  McpOAuthAuthorizationRequiredError,
+} from '../mcp.errors';
+import { SelfDefinedMcpIntegration } from '../../domain/integrations/self-defined-mcp-integration.entity';
+import { OAuthFlowService } from './oauth-flow.service';
+
+class MockOAuthFlowService {
+  getValidAccessToken = jest.fn();
+  buildAuthorizationUrl = jest.fn();
+  handleCallback = jest.fn();
+  revoke = jest.fn();
+  getStatus = jest.fn();
+  resolveOAuthConfig = jest.fn();
+}
 
 class MockMcpClientPort extends McpClientPort {
   listTools = jest.fn();
@@ -56,10 +70,14 @@ describe('McpClientService', () => {
     connectionStatus: 'pending',
   } as const;
 
+  let oauthFlowService: MockOAuthFlowService;
+
   beforeAll(async () => {
     client = new MockMcpClientPort();
     encryption = new MockCredentialEncryptionPort();
     userConfigRepo = new MockUserConfigRepository();
+
+    oauthFlowService = new MockOAuthFlowService();
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -70,6 +88,7 @@ describe('McpClientService', () => {
           provide: McpIntegrationUserConfigRepositoryPort,
           useValue: userConfigRepo,
         },
+        { provide: OAuthFlowService, useValue: oauthFlowService },
       ],
     }).compile();
 
@@ -461,6 +480,189 @@ describe('McpClientService', () => {
       const config = await service.buildConnectionConfig(integration);
 
       expect(config.headers).toEqual({});
+    });
+  });
+
+  describe('buildConnectionConfig — self-defined integrations', () => {
+    const buildSelfDefinedIntegration = (
+      configSchema: IntegrationConfigSchema,
+      orgConfigValues: Record<string, string>,
+      overrides?: {
+        oauthClientId?: string;
+        oauthClientSecretEncrypted?: string;
+      },
+    ) =>
+      new SelfDefinedMcpIntegration({
+        id: baseIntegrationParams.id,
+        orgId: baseIntegrationParams.orgId,
+        name: 'Self-Defined Integration',
+        serverUrl: 'https://mcp.example.com/self',
+        configSchema,
+        orgConfigValues,
+        auth: new NoAuthMcpIntegrationAuth(),
+        ...overrides,
+      });
+
+    it('maps org config fields to headers for self-defined integration', async () => {
+      const schema: IntegrationConfigSchema = {
+        authType: 'CUSTOM_HEADER',
+        orgFields: [
+          {
+            key: 'apiKey',
+            label: 'API Key',
+            type: 'secret',
+            headerName: 'X-API-Key',
+            required: true,
+          },
+        ],
+        userFields: [],
+      };
+      const integration = buildSelfDefinedIntegration(schema, {
+        apiKey: 'encrypted-key',
+      });
+
+      encryption.decrypt.mockResolvedValue('decrypted-api-key');
+
+      const config = await service.buildConnectionConfig(integration);
+
+      expect(config).toEqual({
+        serverUrl: 'https://mcp.example.com/self',
+        headers: { 'X-API-Key': 'decrypted-api-key' },
+      });
+    });
+
+    it('returns empty headers for self-defined NO_AUTH integration', async () => {
+      const schema: IntegrationConfigSchema = {
+        authType: 'NO_AUTH',
+        orgFields: [],
+        userFields: [],
+      };
+      const integration = buildSelfDefinedIntegration(schema, {});
+
+      const config = await service.buildConnectionConfig(integration);
+
+      expect(config.headers).toEqual({});
+    });
+  });
+
+  describe('buildConnectionConfig — OAuth token injection', () => {
+    const buildMarketplaceWithOAuth = (level: 'org' | 'user') =>
+      new MarketplaceMcpIntegration({
+        id: baseIntegrationParams.id,
+        orgId: baseIntegrationParams.orgId,
+        name: 'OAuth Integration',
+        serverUrl: 'https://mcp.example.com/oauth',
+        marketplaceIdentifier: 'oauth-mcp',
+        configSchema: {
+          authType: 'OAUTH',
+          orgFields: [],
+          userFields: [],
+          oauth: {
+            authorizationUrl: 'https://auth.example.com/authorize',
+            tokenUrl: 'https://auth.example.com/token',
+            scopes: ['read'],
+            level,
+          },
+        },
+        orgConfigValues: {},
+        auth: new NoAuthMcpIntegrationAuth(),
+        oauthClientId: 'client-id',
+        oauthClientSecretEncrypted: 'encrypted-secret',
+      });
+
+    it('injects Authorization Bearer header for org-level OAuth', async () => {
+      const integration = buildMarketplaceWithOAuth('org');
+      oauthFlowService.getValidAccessToken.mockResolvedValue(
+        'access-token-123',
+      );
+
+      const config = await service.buildConnectionConfig(integration);
+
+      expect(config.headers).toEqual({
+        Authorization: 'Bearer access-token-123',
+      });
+      expect(oauthFlowService.getValidAccessToken).toHaveBeenCalledWith(
+        integration,
+        null,
+      );
+    });
+
+    it('injects Authorization Bearer header for user-level OAuth', async () => {
+      const userId = randomUUID();
+      const integration = buildMarketplaceWithOAuth('user');
+      oauthFlowService.getValidAccessToken.mockResolvedValue('user-token-456');
+
+      const config = await service.buildConnectionConfig(integration, userId);
+
+      expect(config.headers).toEqual({
+        Authorization: 'Bearer user-token-456',
+      });
+      expect(oauthFlowService.getValidAccessToken).toHaveBeenCalledWith(
+        integration,
+        userId,
+      );
+    });
+
+    it('throws McpOAuthAuthorizationRequiredError when no token exists', async () => {
+      const integration = buildMarketplaceWithOAuth('org');
+      oauthFlowService.getValidAccessToken.mockRejectedValue(
+        new McpOAuthAuthorizationRequiredError(integration.id),
+      );
+
+      await expect(
+        service.buildConnectionConfig(integration),
+      ).rejects.toBeInstanceOf(McpOAuthAuthorizationRequiredError);
+    });
+
+    it('calls getValidAccessToken which triggers refresh for expired tokens', async () => {
+      const integration = buildMarketplaceWithOAuth('org');
+      oauthFlowService.getValidAccessToken.mockResolvedValue('refreshed-token');
+
+      const config = await service.buildConnectionConfig(integration);
+
+      expect(config.headers!['Authorization']).toBe('Bearer refreshed-token');
+      expect(oauthFlowService.getValidAccessToken).toHaveBeenCalledTimes(1);
+    });
+
+    it('injects OAuth token for self-defined integration with OAuth', async () => {
+      const integration = new SelfDefinedMcpIntegration({
+        id: baseIntegrationParams.id,
+        orgId: baseIntegrationParams.orgId,
+        name: 'Self OAuth',
+        serverUrl: 'https://mcp.example.com/self-oauth',
+        configSchema: {
+          authType: 'OAUTH',
+          orgFields: [],
+          userFields: [],
+          oauth: {
+            authorizationUrl: 'https://auth.example.com/authorize',
+            tokenUrl: 'https://auth.example.com/token',
+            scopes: ['read'],
+            level: 'org',
+          },
+        },
+        orgConfigValues: {},
+        auth: new NoAuthMcpIntegrationAuth(),
+        oauthClientId: 'client-id',
+        oauthClientSecretEncrypted: 'encrypted-secret',
+      });
+      oauthFlowService.getValidAccessToken.mockResolvedValue(
+        'self-defined-token',
+      );
+
+      const config = await service.buildConnectionConfig(integration);
+
+      expect(config.headers!['Authorization']).toBe(
+        'Bearer self-defined-token',
+      );
+    });
+
+    it('throws McpOAuthAuthorizationRequiredError for user-level OAuth when no userId provided', async () => {
+      const integration = buildMarketplaceWithOAuth('user');
+
+      await expect(service.buildConnectionConfig(integration)).rejects.toThrow(
+        McpOAuthAuthorizationRequiredError,
+      );
     });
   });
 });

--- a/ayunis-core-backend/src/domain/mcp/application/services/mcp-client.service.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/services/mcp-client.service.ts
@@ -13,11 +13,17 @@ import { McpCredentialEncryptionPort } from '../ports/mcp-credential-encryption.
 import { McpIntegrationUserConfigRepositoryPort } from '../ports/mcp-integration-user-config.repository.port';
 import { McpIntegration } from '../../domain/mcp-integration.entity';
 import { MarketplaceMcpIntegration } from '../../domain/integrations/marketplace-mcp-integration.entity';
+import { SelfDefinedMcpIntegration } from '../../domain/integrations/self-defined-mcp-integration.entity';
 import { ConfigField } from '../../domain/value-objects/integration-config-schema';
 import { BearerMcpIntegrationAuth } from '../../domain/auth/bearer-mcp-integration-auth.entity';
 import { CustomHeaderMcpIntegrationAuth } from '../../domain/auth/custom-header-mcp-integration-auth.entity';
 import { OAuthMcpIntegrationAuth } from '../../domain/auth/oauth-mcp-integration-auth.entity';
-import { McpAuthenticationError } from '../mcp.errors';
+import {
+  McpAuthenticationError,
+  McpError,
+  McpOAuthAuthorizationRequiredError,
+} from '../mcp.errors';
+import { OAuthFlowService } from './oauth-flow.service';
 
 /**
  * Service for executing MCP operations with authentication.
@@ -32,6 +38,7 @@ export class McpClientService {
     private readonly mcpClient: McpClientPort,
     private readonly credentialEncryption: McpCredentialEncryptionPort,
     private readonly userConfigRepository: McpIntegrationUserConfigRepositoryPort,
+    private readonly oauthFlowService: OAuthFlowService,
   ) {}
 
   /**
@@ -44,6 +51,7 @@ export class McpClientService {
    * @param userId Optional user ID for per-user config resolution (marketplace only)
    * @returns Connection configuration for MCP client
    * @throws McpAuthenticationError if authentication configuration fails
+   * @throws McpOAuthAuthorizationRequiredError if user-level OAuth is required but no userId is provided
    */
 
   async buildConnectionConfig(
@@ -51,17 +59,24 @@ export class McpClientService {
     userId?: UUID,
   ): Promise<McpConnectionConfig> {
     if (integration instanceof MarketplaceMcpIntegration) {
-      return this.buildMarketplaceConnectionConfig(integration, userId);
+      return this.buildSchemaConnectionConfig(integration, userId);
+    }
+    if (integration instanceof SelfDefinedMcpIntegration) {
+      return this.buildSchemaConnectionConfig(integration, userId);
     }
     return this.buildLegacyConnectionConfig(integration);
   }
 
   /**
-   * Builds connection config for marketplace integrations by resolving
-   * config schema fields to HTTP headers, with optional user-level overrides.
+   * Builds connection config for schema-based integrations (marketplace and
+   * self-defined) by resolving config fields to HTTP headers, applying
+   * optional per-user overrides, and injecting OAuth Bearer tokens when the
+   * integration's configSchema declares OAuth.
+   *
+   * @throws McpOAuthAuthorizationRequiredError if user-level OAuth is required but no userId is provided
    */
-  private async buildMarketplaceConnectionConfig(
-    integration: MarketplaceMcpIntegration,
+  private async buildSchemaConnectionConfig(
+    integration: MarketplaceMcpIntegration | SelfDefinedMcpIntegration,
     userId?: UUID,
   ): Promise<McpConnectionConfig> {
     try {
@@ -92,12 +107,26 @@ export class McpClientService {
         }
       }
 
+      // Inject OAuth Bearer token if the schema declares OAuth
+      if (configSchema.oauth) {
+        if (configSchema.oauth.level === 'user' && !userId) {
+          throw new McpOAuthAuthorizationRequiredError(integration.id);
+        }
+        const userIdOrNull: UUID | null =
+          configSchema.oauth.level === 'user' ? userId! : null;
+        const accessToken = await this.oauthFlowService.getValidAccessToken(
+          integration,
+          userIdOrNull,
+        );
+        headers['Authorization'] = `Bearer ${accessToken}`;
+      }
+
       return { serverUrl: integration.serverUrl, headers };
     } catch (error) {
-      if (error instanceof McpAuthenticationError) {
+      if (error instanceof McpError) {
         throw error;
       }
-      this.logger.error('Failed to build marketplace connection config', {
+      this.logger.error('Failed to build schema connection config', {
         error: error as Error,
         integrationId: integration.id,
       });


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds OAuth token retrieval/injection into connection config generation and changes connection validation status handling for OAuth-required cases, which can affect authentication behavior across MCP calls. Risk is moderate due to new dependency on `OAuthFlowService` and new error/status paths (`pending_auth`).
> 
> **Overview**
> Wires schema-declared OAuth into `McpClientService.buildConnectionConfig` for schema-based integrations (marketplace + self-defined) by fetching a valid access token via `OAuthFlowService` and injecting an `Authorization: Bearer ...` header, including enforcing `user`-level OAuth by throwing `McpOAuthAuthorizationRequiredError` when `userId` is missing.
> 
> Updates `ConnectionValidationService` to treat `McpOAuthAuthorizationRequiredError` as a non-error state by setting the integration connection status to `pending_auth` (instead of `error`), and extends tests to cover self-defined schema header mapping and OAuth token/authorization-required scenarios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38a6a17593084471f7ce57f1e94e5588be8283ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->