### PR TITLE
chore: ignore CLAUDE.md (AYC-000)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,10 +6,11 @@ node_modules
 
 # Auto-generated type-checking tsconfig files (tool-generated with hash names)
 tsconfig.?????????*.json
-# Agent config (symlinked from ayunis-ai)
 .pi
+.agents/
 .pi/
 .claude/
 AGENTS.md
+CLAUDE.md
 .agentfiles
 .agentfiles.lock


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: only updates `.gitignore` to exclude additional agent-related files from version control, with no runtime or logic changes.
> 
> **Overview**
> Updates `.gitignore` to ignore `CLAUDE.md` and the `.agents/` directory (alongside existing agent config ignores), preventing these local agent artifacts from being committed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 48bf4e53fd991c7d227121381af9e6dd2a2c6938. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->