### PR TITLE
fix(mcp): add /api prefix to OAuth redirect URI and remove duplicate gitignore entry (AYC-110)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,6 @@ tsconfig.?????????*.json
 .pi
 .agents/
 .pi/
-.agents/
 .claude/
 AGENTS.md
 CLAUDE.md

--- a/ayunis-core-backend/src/domain/mcp/application/services/oauth-flow.service.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/services/oauth-flow.service.spec.ts
@@ -164,7 +164,7 @@ describe('OAuthFlowService', () => {
       expect(url.searchParams.get('response_type')).toBe('code');
       expect(url.searchParams.get('client_id')).toBe('client-id');
       expect(url.searchParams.get('redirect_uri')).toBe(
-        'http://localhost:3000/mcp-integrations/oauth/callback',
+        'http://localhost:3000/api/mcp-integrations/oauth/callback',
       );
       expect(url.searchParams.get('scope')).toBe('read write');
       expect(url.searchParams.get('state')).toBe('signed-state-jwt');
@@ -179,7 +179,7 @@ describe('OAuthFlowService', () => {
           orgId: integration.orgId,
           userId: null,
           codeVerifier: expect.any(String),
-          redirectUri: 'http://localhost:3000/mcp-integrations/oauth/callback',
+          redirectUri: 'http://localhost:3000/api/mcp-integrations/oauth/callback',
           returnPath: '/settings/integrations?tab=mcp',
           nonce: expect.any(String),
         }),
@@ -242,7 +242,7 @@ describe('OAuthFlowService', () => {
         orgId: integration.orgId,
         userId: null,
         codeVerifier: 'test-verifier',
-        redirectUri: 'http://localhost:3000/mcp-integrations/oauth/callback',
+        redirectUri: 'http://localhost:3000/api/mcp-integrations/oauth/callback',
         returnPath: '/settings/integrations?tab=mcp',
         nonce: 'test-nonce',
       };
@@ -279,7 +279,7 @@ describe('OAuthFlowService', () => {
           },
           authorizationCode: 'auth-code',
           codeVerifier: 'test-verifier',
-          redirectUri: 'http://localhost:3000/mcp-integrations/oauth/callback',
+          redirectUri: 'http://localhost:3000/api/mcp-integrations/oauth/callback',
         }),
       );
 
@@ -301,7 +301,7 @@ describe('OAuthFlowService', () => {
         orgId: integration.orgId,
         userId: null,
         codeVerifier: 'test-verifier',
-        redirectUri: 'http://localhost:3000/mcp-integrations/oauth/callback',
+        redirectUri: 'http://localhost:3000/api/mcp-integrations/oauth/callback',
         returnPath: '/settings/integrations',
         nonce: 'test-nonce',
       };
@@ -347,7 +347,7 @@ describe('OAuthFlowService', () => {
         orgId: integration.orgId,
         userId: null,
         codeVerifier: 'test-verifier',
-        redirectUri: 'http://localhost:3000/mcp-integrations/oauth/callback',
+        redirectUri: 'http://localhost:3000/api/mcp-integrations/oauth/callback',
         returnPath: '/settings/integrations',
         nonce: 'test-nonce',
       };
@@ -403,7 +403,7 @@ describe('OAuthFlowService', () => {
         orgId: integration.orgId,
         userId: null,
         codeVerifier: 'v',
-        redirectUri: 'http://localhost:3000/mcp-integrations/oauth/callback',
+        redirectUri: 'http://localhost:3000/api/mcp-integrations/oauth/callback',
         returnPath: '/settings/integrations',
         nonce: 'n',
       };
@@ -429,7 +429,7 @@ describe('OAuthFlowService', () => {
         orgId,
         userId: null,
         codeVerifier: 'v',
-        redirectUri: 'http://localhost:3000/mcp-integrations/oauth/callback',
+        redirectUri: 'http://localhost:3000/api/mcp-integrations/oauth/callback',
         returnPath: '/settings/integrations',
         nonce: 'n',
       };
@@ -450,7 +450,7 @@ describe('OAuthFlowService', () => {
         orgId: randomUUID(), // different orgId
         userId: null,
         codeVerifier: 'v',
-        redirectUri: 'http://localhost:3000/mcp-integrations/oauth/callback',
+        redirectUri: 'http://localhost:3000/api/mcp-integrations/oauth/callback',
         returnPath: '/settings/integrations',
         nonce: 'n',
       };
@@ -780,7 +780,7 @@ describe('OAuthFlowService', () => {
         orgId: randomUUID(),
         userId: null,
         codeVerifier: 'code-verifier',
-        redirectUri: 'http://localhost:3000/mcp-integrations/oauth/callback',
+        redirectUri: 'http://localhost:3000/api/mcp-integrations/oauth/callback',
         returnPath: '/skills/skill-123',
         nonce: 'nonce',
       });

--- a/ayunis-core-backend/src/domain/mcp/application/services/oauth-flow.service.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/services/oauth-flow.service.ts
@@ -77,7 +77,7 @@ export class OAuthFlowService {
     const backendBaseUrl = this.configService.getOrThrow<string>(
       'app.backend.baseUrl',
     );
-    const redirectUri = `${backendBaseUrl}/mcp-integrations/oauth/callback`;
+    const redirectUri = `${backendBaseUrl}/api/mcp-integrations/oauth/callback`;
 
     const codeVerifier = randomBytes(32).toString('base64url');
     const codeChallenge = createHash('sha256')

--- a/ayunis-core-backend/src/domain/mcp/infrastructure/oauth/jwt-oauth-state.adapter.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/infrastructure/oauth/jwt-oauth-state.adapter.spec.ts
@@ -14,7 +14,7 @@ describe('JwtOAuthStateAdapter', () => {
     orgId: randomUUID(),
     userId: null,
     codeVerifier: 'test-code-verifier-abc123',
-    redirectUri: 'http://localhost:3000/mcp-integrations/oauth/callback',
+    redirectUri: 'http://localhost:3000/api/mcp-integrations/oauth/callback',
     returnPath: '/settings/integrations?tab=mcp',
     nonce: 'test-nonce-xyz',
   });


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the OAuth redirect URI used during authorization and token exchange; misconfiguration could break existing OAuth flows until providers are updated. Otherwise the change is small and covered by updated tests.
> 
> **Overview**
> Fixes MCP OAuth by changing the redirect URI to include the `'/api'` prefix (now `${backendBaseUrl}/api/mcp-integrations/oauth/callback`) so the authorization URL, signed state payload, and token exchange all use the new callback path.
> 
> Updates related unit tests to expect the new redirect URI, and removes a duplicate `.agents/` entry from `.gitignore`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 563deaca5c097ce110cf2218338aa6ce2533d6aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->