### PR TITLE
fix(models): update model tier tooltip wording to "Performance & Credit Consumption" (AYC-000)

### DIFF
--- a/ayunis-core-frontend/src/shared/locales/de/admin-settings-models.json
+++ b/ayunis-core-frontend/src/shared/locales/de/admin-settings-models.json
@@ -56,7 +56,7 @@
       "low": "Niedrig",
       "medium": "Mittel",
       "high": "Hoch",
-      "tooltip": "Stufe: {{label}}"
+      "tooltip": "Leistung & Credit Verbrauch: {{label}}"
     },
     "defaultModel": {
       "title": "Standardmodell der Organisation",

--- a/ayunis-core-frontend/src/shared/locales/en/admin-settings-models.json
+++ b/ayunis-core-frontend/src/shared/locales/en/admin-settings-models.json
@@ -56,7 +56,7 @@
       "low": "Low",
       "medium": "Medium",
       "high": "High",
-      "tooltip": "Tier: {{label}}"
+      "tooltip": "Performance & Credit Consumption: {{label}}"
     },
     "defaultModel": {
       "title": "Organization default model",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates the tooltip text shown on the model tier stars in the admin model selection.

**Before:**
- EN: `Tier: Low/Medium/High`
- DE: `Stufe: Niedrig/Mittel/Hoch`

**After:**
- EN: `Performance & Credit Consumption: Low/Medium/High`
- DE: `Leistung & Credit Verbrauch: Niedrig/Mittel/Hoch`

## Context

Per feedback from the Slack #review channel, "Tier" / "Stufe" was ambiguous — it didn't clearly convey that the star rating reflects both performance **and** cost/consumption. The new wording makes this dual meaning explicit, reducing the risk of users misinterpreting the stars as a pure quality rating.

## Changes

- `src/shared/locales/en/admin-settings-models.json` — updated `models.tier.tooltip`
- `src/shared/locales/de/admin-settings-models.json` — updated `models.tier.tooltip`
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://locaboo.slack.com/archives/C01R8KNRVPD/p1776093141198529?thread_ts=1776093141.198529&cid=C01R8KNRVPD)

<div><a href="https://cursor.com/agents/bc-024d0e63-b139-5dbd-a5b0-e4e05a433e8b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-024d0e63-b139-5dbd-a5b0-e4e05a433e8b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

