### PR TITLE
fix(db): align entities with migrations and add schema drift CI check (AYC-000)

### DIFF
--- a/.github/workflows/api-schema-drift.yml
+++ b/.github/workflows/api-schema-drift.yml
@@ -105,7 +105,9 @@ jobs:
       - name: Check for database schema drift
         working-directory: ayunis-core-backend
         run: |
-          npm run typeorm -- migration:generate -d src/db/datasource.ts src/db/migrations/__DriftCheck 2>&1 | tee /tmp/drift-output.txt
+          set -o pipefail
+          TYPEORM_EXIT=0
+          npm run typeorm -- migration:generate -d src/db/datasource.ts src/db/migrations/__DriftCheck 2>&1 | tee /tmp/drift-output.txt || TYPEORM_EXIT=$?
           if grep -q "has been generated successfully" /tmp/drift-output.txt; then
             echo ""
             echo "❌ Database schema drift detected."
@@ -114,6 +116,12 @@ jobs:
             echo ""
             echo "Generated drift:"
             cat src/db/migrations/*__DriftCheck.ts
+            exit 1
+          fi
+          if [ "$TYPEORM_EXIT" -ne 0 ] && ! grep -q "No changes in database schema were found" /tmp/drift-output.txt; then
+            echo ""
+            echo "❌ migration:generate failed unexpectedly (exit code $TYPEORM_EXIT):"
+            cat /tmp/drift-output.txt
             exit 1
           fi
           echo "✅ No database schema drift"

--- a/.github/workflows/api-schema-drift.yml
+++ b/.github/workflows/api-schema-drift.yml
@@ -1,4 +1,4 @@
-name: API Schema Drift
+name: Schema Drift
 
 on:
   pull_request:
@@ -8,7 +8,7 @@ on:
 
 jobs:
   check:
-    name: Check API client is up to date
+    name: Check database and API client are up to date
     runs-on: ubuntu-latest
 
     services:
@@ -101,6 +101,22 @@ jobs:
         run: npm run typeorm migration:run -- -d src/db/datasource.ts
         env:
           NODE_ENV: test
+
+      - name: Check for database schema drift
+        working-directory: ayunis-core-backend
+        run: |
+          npm run typeorm -- migration:generate -d src/db/datasource.ts src/db/migrations/__DriftCheck 2>&1 | tee /tmp/drift-output.txt
+          if grep -q "has been generated successfully" /tmp/drift-output.txt; then
+            echo ""
+            echo "❌ Database schema drift detected."
+            echo "Entities and migrations are out of sync. Run:"
+            echo "  npm run migration:generate:dev -- src/db/migrations/DescriptiveName"
+            echo ""
+            echo "Generated drift:"
+            cat src/db/migrations/*__DriftCheck.ts
+            exit 1
+          fi
+          echo "✅ No database schema drift"
 
       - name: Start backend
         working-directory: ayunis-core-backend

--- a/ayunis-core-backend/src/db/migrations/1776162477472-FixSchemaDrift.ts
+++ b/ayunis-core-backend/src/db/migrations/1776162477472-FixSchemaDrift.ts
@@ -1,0 +1,42 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class FixSchemaDrift1776162477472 implements MigrationInterface {
+    name = 'FixSchemaDrift1776162477472'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "permitted_models" DROP CONSTRAINT "FK_b6d0e7d1fa9fa0c343b75152f94"`);
+        await queryRunner.query(`ALTER TABLE "mcp_integration_user_configs" DROP CONSTRAINT "FK_user_config_integration"`);
+        await queryRunner.query(`ALTER TABLE "letterheads" DROP CONSTRAINT "FK_letterheads_orgId_orgs"`);
+        await queryRunner.query(`DROP INDEX "public"."IDX_605f8ca2a5a7123c96c2f145a2"`);
+        await queryRunner.query(`DROP INDEX "public"."UQ_marketplace_org_identifier"`);
+        await queryRunner.query(`ALTER TYPE "public"."agent_tools_tooltype_enum" RENAME TO "agent_tools_tooltype_enum_old"`);
+        await queryRunner.query(`CREATE TYPE "public"."agent_tools_tooltype_enum" AS ENUM('http', 'source_query', 'source_get_text', 'internet_search', 'website_content', 'send_email', 'create_calendar_event', 'code_execution', 'bar_chart', 'line_chart', 'pie_chart', 'mcp_tool', 'mcp_resource', 'mcp_prompt', 'activate_skill', 'create_skill', 'knowledge_query', 'knowledge_get_text', 'create_document', 'update_document', 'edit_document', 'read_document')`);
+        await queryRunner.query(`ALTER TABLE "agent_tools" ALTER COLUMN "toolType" TYPE "public"."agent_tools_tooltype_enum" USING "toolType"::"text"::"public"."agent_tools_tooltype_enum"`);
+        await queryRunner.query(`DROP TYPE "public"."agent_tools_tooltype_enum_old"`);
+        await queryRunner.query(`CREATE UNIQUE INDEX "IDX_2d4c91a8c18766bbbcba842d07" ON "permitted_models" ("scope_id", "modelId") WHERE "scope" = 'team'`);
+        await queryRunner.query(`CREATE UNIQUE INDEX "IDX_63afa79e56fd0523bc7f8f1a30" ON "mcp_integrations" ("orgId", "marketplace_identifier") WHERE "marketplace_identifier" IS NOT NULL`);
+        await queryRunner.query(`CREATE INDEX "IDX_d5214d1c8a5cb55639fc05e33a" ON "skill_templates" ("distributionMode") `);
+        await queryRunner.query(`ALTER TABLE "permitted_models" ADD CONSTRAINT "FK_67e70e76f8ac05331cc49032517" FOREIGN KEY ("scope_id") REFERENCES "teams"("id") ON DELETE CASCADE ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE "mcp_integration_user_configs" ADD CONSTRAINT "FK_d3a56555dd20f2c0af66c10959c" FOREIGN KEY ("integration_id") REFERENCES "mcp_integrations"("id") ON DELETE CASCADE ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE "letterheads" ADD CONSTRAINT "FK_ed5c8c0b59525d6ee217b5e2714" FOREIGN KEY ("orgId") REFERENCES "orgs"("id") ON DELETE CASCADE ON UPDATE NO ACTION`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "letterheads" DROP CONSTRAINT "FK_ed5c8c0b59525d6ee217b5e2714"`);
+        await queryRunner.query(`ALTER TABLE "mcp_integration_user_configs" DROP CONSTRAINT "FK_d3a56555dd20f2c0af66c10959c"`);
+        await queryRunner.query(`ALTER TABLE "permitted_models" DROP CONSTRAINT "FK_67e70e76f8ac05331cc49032517"`);
+        await queryRunner.query(`DROP INDEX "public"."IDX_d5214d1c8a5cb55639fc05e33a"`);
+        await queryRunner.query(`DROP INDEX "public"."IDX_63afa79e56fd0523bc7f8f1a30"`);
+        await queryRunner.query(`DROP INDEX "public"."IDX_2d4c91a8c18766bbbcba842d07"`);
+        await queryRunner.query(`CREATE TYPE "public"."agent_tools_tooltype_enum_old" AS ENUM('activate_skill', 'bar_chart', 'code_execution', 'create_calendar_event', 'create_document', 'create_skill', 'edit_document', 'http', 'internet_search', 'knowledge_get_text', 'knowledge_query', 'line_chart', 'mcp_prompt', 'mcp_resource', 'mcp_tool', 'pie_chart', 'send_email', 'source_get_text', 'source_query', 'update_document', 'website_content')`);
+        await queryRunner.query(`ALTER TABLE "agent_tools" ALTER COLUMN "toolType" TYPE "public"."agent_tools_tooltype_enum_old" USING "toolType"::"text"::"public"."agent_tools_tooltype_enum_old"`);
+        await queryRunner.query(`DROP TYPE "public"."agent_tools_tooltype_enum"`);
+        await queryRunner.query(`ALTER TYPE "public"."agent_tools_tooltype_enum_old" RENAME TO "agent_tools_tooltype_enum"`);
+        await queryRunner.query(`CREATE UNIQUE INDEX "UQ_marketplace_org_identifier" ON "mcp_integrations" ("orgId", "marketplace_identifier") WHERE (marketplace_identifier IS NOT NULL)`);
+        await queryRunner.query(`CREATE UNIQUE INDEX "IDX_605f8ca2a5a7123c96c2f145a2" ON "permitted_models" ("modelId", "scope_id") WHERE (scope = 'team'::permitted_models_scope_enum)`);
+        await queryRunner.query(`ALTER TABLE "letterheads" ADD CONSTRAINT "FK_letterheads_orgId_orgs" FOREIGN KEY ("orgId") REFERENCES "orgs"("id") ON DELETE CASCADE ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE "mcp_integration_user_configs" ADD CONSTRAINT "FK_user_config_integration" FOREIGN KEY ("integration_id") REFERENCES "mcp_integrations"("id") ON DELETE CASCADE ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE "permitted_models" ADD CONSTRAINT "FK_b6d0e7d1fa9fa0c343b75152f94" FOREIGN KEY ("scope_id") REFERENCES "teams"("id") ON DELETE CASCADE ON UPDATE NO ACTION`);
+    }
+
+}

--- a/ayunis-core-backend/src/domain/letterheads/infrastructure/persistence/local/schema/letterhead.record.ts
+++ b/ayunis-core-backend/src/domain/letterheads/infrastructure/persistence/local/schema/letterhead.record.ts
@@ -1,6 +1,7 @@
-import { Column, Entity, Index } from 'typeorm';
+import { Column, Entity, Index, JoinColumn, ManyToOne } from 'typeorm';
 import type { UUID } from 'crypto';
 import { BaseRecord } from '../../../../../../common/db/base-record';
+import { OrgRecord } from '../../../../../../iam/orgs/infrastructure/repositories/local/schema/org.record';
 import type { PageMargins } from '../../../../domain/value-objects/page-margins';
 
 @Entity({ name: 'letterheads' })
@@ -8,6 +9,10 @@ export class LetterheadRecord extends BaseRecord {
   @Column()
   @Index()
   orgId: UUID;
+
+  @ManyToOne(() => OrgRecord, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'orgId' })
+  org: OrgRecord;
 
   @Column({ type: 'varchar', length: 255 })
   name: string;

--- a/ayunis-core-backend/src/domain/mcp/infrastructure/persistence/postgres/schema/marketplace-mcp-integration.record.ts
+++ b/ayunis-core-backend/src/domain/mcp/infrastructure/persistence/postgres/schema/marketplace-mcp-integration.record.ts
@@ -1,10 +1,13 @@
-import { ChildEntity, Column, Unique } from 'typeorm';
+import { ChildEntity, Column, Index } from 'typeorm';
 import { McpIntegrationRecord } from './mcp-integration.record';
 import { McpIntegrationKind } from '../../../../domain/value-objects/mcp-integration-kind.enum';
 import { IntegrationConfigSchema } from '../../../../domain/value-objects/integration-config-schema';
 
 @ChildEntity(McpIntegrationKind.MARKETPLACE)
-@Unique(['orgId', 'marketplaceIdentifier'])
+@Index(['orgId', 'marketplaceIdentifier'], {
+  unique: true,
+  where: '"marketplace_identifier" IS NOT NULL',
+})
 export class MarketplaceMcpIntegrationRecord extends McpIntegrationRecord {
   @Column({ name: 'marketplace_identifier' })
   marketplaceIdentifier: string;

--- a/ayunis-core-backend/src/domain/mcp/infrastructure/persistence/postgres/schema/mcp-integration-user-config.record.ts
+++ b/ayunis-core-backend/src/domain/mcp/infrastructure/persistence/postgres/schema/mcp-integration-user-config.record.ts
@@ -1,12 +1,17 @@
-import { Column, Entity, Unique } from 'typeorm';
+import { Column, Entity, JoinColumn, ManyToOne, Unique } from 'typeorm';
 import { BaseRecord } from '../../../../../../common/db/base-record';
 import { UUID } from 'crypto';
+import { McpIntegrationRecord } from './mcp-integration.record';
 
 @Entity('mcp_integration_user_configs')
 @Unique(['integrationId', 'userId'])
 export class McpIntegrationUserConfigRecord extends BaseRecord {
   @Column({ name: 'integration_id', type: 'varchar' })
   integrationId: string;
+
+  @ManyToOne(() => McpIntegrationRecord, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'integration_id' })
+  integration: McpIntegrationRecord;
 
   @Column({ name: 'user_id', type: 'uuid' })
   userId: UUID;

--- a/ayunis-core-backend/src/domain/models/infrastructure/persistence/local-permitted-models/schema/permitted-model.record.ts
+++ b/ayunis-core-backend/src/domain/models/infrastructure/persistence/local-permitted-models/schema/permitted-model.record.ts
@@ -2,7 +2,7 @@ import { UUID } from 'crypto';
 import { BaseRecord } from '../../../../../../common/db/base-record';
 import { Org } from '../../../../../../iam/orgs/domain/org.entity';
 import { OrgRecord } from '../../../../../../iam/orgs/infrastructure/repositories/local/schema/org.record';
-import { Column, Entity, Index, JoinColumn, ManyToOne } from 'typeorm';
+import { Check, Column, Entity, Index, JoinColumn, ManyToOne } from 'typeorm';
 import { ModelRecord } from '../../local-models/schema/model.record';
 import { TeamRecord } from '../../../../../../iam/teams/infrastructure/repositories/local/schema/team.record';
 import { PermittedModelScope } from '../../../../domain/value-objects/permitted-model-scope.enum';
@@ -10,6 +10,10 @@ import { PermittedModelScope } from '../../../../domain/value-objects/permitted-
 @Entity({ name: 'permitted_models' })
 @Index(['orgId', 'modelId'], { unique: true, where: `"scope" = 'org'` })
 @Index(['scopeId', 'modelId'], { unique: true, where: `"scope" = 'team'` })
+@Check(
+  'CHK_permitted_models_scope_team',
+  `("scope" = 'org' AND "scope_id" IS NULL) OR ("scope" = 'team' AND "scope_id" IS NOT NULL)`,
+)
 export class PermittedModelRecord extends BaseRecord {
   @Column({ nullable: false })
   orgId: UUID;


### PR DESCRIPTION
- Add missing @ManyToOne relations to mcp-integration-user-config and
  letterhead entities to match FKs created by migrations
- Change @Unique to partial @Index on marketplace-mcp-integration to
  match existing partial unique index semantics
- Add @Check decorator to permitted-model entity for scope/scope_id
  invariant
- Generate migration to fix constraint/index name mismatches, add
  read_document enum value, and add skill_templates discriminator index
- Add database schema drift check to CI workflow so entity-migration
  mismatches are caught on PRs

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches database schema constraints/indexes and TypeORM metadata; a mismatch could break migrations or data integrity in production. CI drift detection reduces long-term risk but adds a new failing check path on PRs.
> 
> **Overview**
> Adds a CI **database schema drift** gate to the existing schema/client workflow by generating a throwaway TypeORM migration after running migrations and failing the job if any changes are produced.
> 
> Aligns TypeORM persistence metadata with the actual schema by adding missing `ManyToOne` relations for `letterheads.orgId` and `mcp_integration_user_configs.integration_id`, switching `MarketplaceMcpIntegrationRecord` uniqueness to a partial unique `Index`, and enforcing a scope invariant on `PermittedModelRecord` via a `Check` constraint.
> 
> Introduces a `FixSchemaDrift` migration to reconcile constraint/index naming and semantics, update the `agent_tools.toolType` enum (including `read_document`), and add an index on `skill_templates.distributionMode`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 790ee316f890c12abf4533a4971f80484a9ea52a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->