### PR TITLE
fix(subscriptions): exclude trial-period usage from subscription credit budget (AYC-000)

### DIFF
--- a/ayunis-core-backend/src/domain/runs/application/services/credit-budget-guard.service.spec.ts
+++ b/ayunis-core-backend/src/domain/runs/application/services/credit-budget-guard.service.spec.ts
@@ -4,6 +4,7 @@ import { CreditBudgetGuardService } from './credit-budget-guard.service';
 import { GetMonthlyCreditLimitUseCase } from 'src/iam/subscriptions/application/use-cases/get-monthly-credit-limit/get-monthly-credit-limit.use-case';
 import { GetMonthlyCreditUsageUseCase } from 'src/domain/usage/application/use-cases/get-monthly-credit-usage/get-monthly-credit-usage.use-case';
 import { CreditBudgetExceededError } from 'src/iam/subscriptions/application/subscription.errors';
+import { GetMonthlyCreditUsageQuery } from 'src/domain/usage/application/use-cases/get-monthly-credit-usage/get-monthly-credit-usage.query';
 import type { UUID } from 'crypto';
 
 describe('CreditBudgetGuardService', () => {
@@ -90,6 +91,35 @@ describe('CreditBudgetGuardService', () => {
 
     await expect(service.ensureBudgetAvailable(orgId)).rejects.toThrow(
       CreditBudgetExceededError,
+    );
+  });
+
+  it('should pass startsAt as since to credit usage query', async () => {
+    const startsAt = new Date('2026-04-10T00:00:00.000Z');
+    mockGetMonthlyCreditLimit.execute.mockResolvedValue({
+      monthlyCredits: 1000,
+      startsAt,
+    });
+    mockGetMonthlyCreditUsage.execute.mockResolvedValue({ creditsUsed: 0 });
+
+    await service.ensureBudgetAvailable(orgId);
+
+    expect(mockGetMonthlyCreditUsage.execute).toHaveBeenCalledWith(
+      new GetMonthlyCreditUsageQuery(orgId, startsAt),
+    );
+  });
+
+  it('should pass undefined since when startsAt is null', async () => {
+    mockGetMonthlyCreditLimit.execute.mockResolvedValue({
+      monthlyCredits: 1000,
+      startsAt: null,
+    });
+    mockGetMonthlyCreditUsage.execute.mockResolvedValue({ creditsUsed: 0 });
+
+    await service.ensureBudgetAvailable(orgId);
+
+    expect(mockGetMonthlyCreditUsage.execute).toHaveBeenCalledWith(
+      new GetMonthlyCreditUsageQuery(orgId, undefined),
     );
   });
 });

--- a/ayunis-core-backend/src/domain/runs/application/services/credit-budget-guard.service.ts
+++ b/ayunis-core-backend/src/domain/runs/application/services/credit-budget-guard.service.ts
@@ -25,16 +25,17 @@ export class CreditBudgetGuardService {
   ) {}
 
   async ensureBudgetAvailable(orgId: UUID): Promise<void> {
-    const { monthlyCredits } = await this.getMonthlyCreditLimitUseCase.execute(
-      new GetMonthlyCreditLimitQuery(orgId),
-    );
+    const { monthlyCredits, startsAt } =
+      await this.getMonthlyCreditLimitUseCase.execute(
+        new GetMonthlyCreditLimitQuery(orgId),
+      );
 
     if (monthlyCredits === null) {
       return;
     }
 
     const { creditsUsed } = await this.getMonthlyCreditUsageUseCase.execute(
-      new GetMonthlyCreditUsageQuery(orgId),
+      new GetMonthlyCreditUsageQuery(orgId, startsAt ?? undefined),
     );
 
     if (creditsUsed >= monthlyCredits) {

--- a/ayunis-core-backend/src/domain/usage/application/use-cases/get-credit-usage/get-credit-usage.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/usage/application/use-cases/get-credit-usage/get-credit-usage.use-case.spec.ts
@@ -3,6 +3,7 @@ import { Test } from '@nestjs/testing';
 import { GetCreditUsageUseCase } from './get-credit-usage.use-case';
 import { GetCreditUsageQuery } from './get-credit-usage.query';
 import { GetMonthlyCreditUsageUseCase } from '../get-monthly-credit-usage/get-monthly-credit-usage.use-case';
+import { GetMonthlyCreditUsageQuery } from '../get-monthly-credit-usage/get-monthly-credit-usage.query';
 import { GetMonthlyCreditLimitUseCase } from 'src/iam/subscriptions/application/use-cases/get-monthly-credit-limit/get-monthly-credit-limit.use-case';
 import type { UUID } from 'crypto';
 
@@ -97,6 +98,21 @@ describe('GetCreditUsageUseCase', () => {
       creditsUsed: 0,
       creditsRemaining: 5000,
     });
+  });
+
+  it('should pass startsAt as since to credit usage query', async () => {
+    const startsAt = new Date('2026-04-10T00:00:00.000Z');
+    mockGetMonthlyCreditLimit.execute.mockResolvedValue({
+      monthlyCredits: 5000,
+      startsAt,
+    });
+    mockMonthlyCreditUsage.execute.mockResolvedValue({ creditsUsed: 100 });
+
+    await useCase.execute(new GetCreditUsageQuery(orgId));
+
+    expect(mockMonthlyCreditUsage.execute).toHaveBeenCalledWith(
+      new GetMonthlyCreditUsageQuery(orgId, startsAt),
+    );
   });
 
   it('should propagate errors from the credit limit use case', async () => {

--- a/ayunis-core-backend/src/domain/usage/application/use-cases/get-credit-usage/get-credit-usage.use-case.ts
+++ b/ayunis-core-backend/src/domain/usage/application/use-cases/get-credit-usage/get-credit-usage.use-case.ts
@@ -21,13 +21,13 @@ export class GetCreditUsageUseCase {
     this.logger.log('Getting credit usage', { orgId: query.orgId });
 
     try {
-      const { monthlyCredits } =
+      const { monthlyCredits, startsAt } =
         await this.getMonthlyCreditLimitUseCase.execute(
           new GetMonthlyCreditLimitQuery(query.orgId),
         );
 
       const { creditsUsed } = await this.getMonthlyCreditUsageUseCase.execute(
-        new GetMonthlyCreditUsageQuery(query.orgId),
+        new GetMonthlyCreditUsageQuery(query.orgId, startsAt ?? undefined),
       );
 
       const creditsRemaining =

--- a/ayunis-core-backend/src/domain/usage/application/use-cases/get-monthly-credit-usage/get-monthly-credit-usage.query.ts
+++ b/ayunis-core-backend/src/domain/usage/application/use-cases/get-monthly-credit-usage/get-monthly-credit-usage.query.ts
@@ -2,8 +2,10 @@ import type { UUID } from 'crypto';
 
 export class GetMonthlyCreditUsageQuery {
   public readonly orgId: UUID;
+  public readonly since?: Date;
 
-  constructor(orgId: UUID) {
+  constructor(orgId: UUID, since?: Date) {
     this.orgId = orgId;
+    this.since = since;
   }
 }

--- a/ayunis-core-backend/src/domain/usage/application/use-cases/get-monthly-credit-usage/get-monthly-credit-usage.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/usage/application/use-cases/get-monthly-credit-usage/get-monthly-credit-usage.use-case.spec.ts
@@ -56,6 +56,27 @@ describe('GetMonthlyCreditUsageUseCase', () => {
     expect(monthStart.getUTCMinutes()).toBe(0);
   });
 
+  it('should use since date when it is later than month start', async () => {
+    const since = new Date('2026-04-10T00:00:00.000Z');
+    await useCase.execute(new GetMonthlyCreditUsageQuery(orgId, since));
+
+    const startDate = mockUsageRepository.getMonthlyCreditUsage.mock
+      .calls[0][1] as Date;
+    expect(startDate).toEqual(since);
+  });
+
+  it('should use month start when since date is earlier', async () => {
+    const since = new Date('2025-12-15T00:00:00.000Z');
+    await useCase.execute(new GetMonthlyCreditUsageQuery(orgId, since));
+
+    const startDate = mockUsageRepository.getMonthlyCreditUsage.mock
+      .calls[0][1] as Date;
+    const now = new Date();
+    expect(startDate.getUTCFullYear()).toBe(now.getUTCFullYear());
+    expect(startDate.getUTCMonth()).toBe(now.getUTCMonth());
+    expect(startDate.getUTCDate()).toBe(1);
+  });
+
   it('should handle zero usage (new month)', async () => {
     mockUsageRepository.getMonthlyCreditUsage.mockResolvedValue(0);
 

--- a/ayunis-core-backend/src/domain/usage/application/use-cases/get-monthly-credit-usage/get-monthly-credit-usage.use-case.ts
+++ b/ayunis-core-backend/src/domain/usage/application/use-cases/get-monthly-credit-usage/get-monthly-credit-usage.use-case.ts
@@ -17,16 +17,19 @@ export class GetMonthlyCreditUsageUseCase {
     const monthStart = new Date(
       Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1),
     );
+    const effectiveStart =
+      query.since && query.since > monthStart ? query.since : monthStart;
 
     this.logger.log('Getting monthly credit usage', {
       orgId: query.orgId,
       monthStart: monthStart.toISOString(),
+      effectiveStart: effectiveStart.toISOString(),
     });
 
     try {
       const creditsUsed = await this.usageRepository.getMonthlyCreditUsage(
         query.orgId,
-        monthStart,
+        effectiveStart,
       );
 
       return { creditsUsed };

--- a/ayunis-core-backend/src/iam/subscriptions/application/use-cases/get-monthly-credit-limit/get-monthly-credit-limit.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/subscriptions/application/use-cases/get-monthly-credit-limit/get-monthly-credit-limit.use-case.spec.ts
@@ -55,7 +55,7 @@ describe('GetMonthlyCreditLimitUseCase', () => {
 
     const result = await useCase.execute(new GetMonthlyCreditLimitQuery(orgId));
 
-    expect(result).toEqual({ monthlyCredits: null });
+    expect(result).toEqual({ monthlyCredits: null, startsAt: null });
   });
 
   it('should return null for seat-based subscription only', async () => {
@@ -72,7 +72,7 @@ describe('GetMonthlyCreditLimitUseCase', () => {
 
     const result = await useCase.execute(new GetMonthlyCreditLimitQuery(orgId));
 
-    expect(result).toEqual({ monthlyCredits: null });
+    expect(result).toEqual({ monthlyCredits: null, startsAt: null });
   });
 
   it('should return monthlyCredits for active usage-based subscription', async () => {
@@ -87,7 +87,7 @@ describe('GetMonthlyCreditLimitUseCase', () => {
 
     const result = await useCase.execute(new GetMonthlyCreditLimitQuery(orgId));
 
-    expect(result).toEqual({ monthlyCredits: 5000 });
+    expect(result).toEqual({ monthlyCredits: 5000, startsAt: expect.any(Date) });
   });
 
   it('should return null for cancelled usage-based subscription', async () => {
@@ -102,7 +102,7 @@ describe('GetMonthlyCreditLimitUseCase', () => {
 
     const result = await useCase.execute(new GetMonthlyCreditLimitQuery(orgId));
 
-    expect(result).toEqual({ monthlyCredits: null });
+    expect(result).toEqual({ monthlyCredits: null, startsAt: null });
   });
 
   it('should find usage-based subscription among mixed types', async () => {
@@ -125,6 +125,6 @@ describe('GetMonthlyCreditLimitUseCase', () => {
 
     const result = await useCase.execute(new GetMonthlyCreditLimitQuery(orgId));
 
-    expect(result).toEqual({ monthlyCredits: 3000 });
+    expect(result).toEqual({ monthlyCredits: 3000, startsAt: expect.any(Date) });
   });
 });

--- a/ayunis-core-backend/src/iam/subscriptions/application/use-cases/get-monthly-credit-limit/get-monthly-credit-limit.use-case.ts
+++ b/ayunis-core-backend/src/iam/subscriptions/application/use-cases/get-monthly-credit-limit/get-monthly-credit-limit.use-case.ts
@@ -20,7 +20,7 @@ export class GetMonthlyCreditLimitUseCase {
 
   async execute(
     query: GetMonthlyCreditLimitQuery,
-  ): Promise<{ monthlyCredits: number | null }> {
+  ): Promise<{ monthlyCredits: number | null; startsAt: Date | null }> {
     try {
       const subscriptions = await this.subscriptionRepository.findByOrgId(
         query.orgId,
@@ -33,10 +33,13 @@ export class GetMonthlyCreditLimitUseCase {
         this.logger.debug('No active usage-based subscription found', {
           orgId: query.orgId,
         });
-        return { monthlyCredits: null };
+        return { monthlyCredits: null, startsAt: null };
       }
 
-      return { monthlyCredits: usageSubscription.monthlyCredits };
+      return {
+        monthlyCredits: usageSubscription.monthlyCredits,
+        startsAt: usageSubscription.startsAt,
+      };
     } catch (error) {
       if (error instanceof ApplicationError) throw error;
       this.logger.error('Failed to get monthly credit limit', error);


### PR DESCRIPTION
## Summary

- When a usage-based subscription is scheduled for the future, trial-period credit consumption was incorrectly counted against the subscription's monthly credit budget once it activated
- Pass subscription `startsAt` into the monthly credit usage query via a generic `since` parameter, so only post-activation usage counts against the budget
- Fix applied to both the runtime budget guard (`CreditBudgetGuardService`) and the user-facing credit display (`GetCreditUsageUseCase`)

## Test plan

- [x] Existing tests updated to verify `startsAt` is returned from `GetMonthlyCreditLimitUseCase`
- [x] New tests verify `since` parameter is respected in `GetMonthlyCreditUsageUseCase`
- [x] New tests verify `startsAt` is passed through in both `CreditBudgetGuardService` and `GetCreditUsageUseCase`
- [x] All 24 tests pass, type-check clean, all pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how monthly credit usage is computed by introducing a subscription `startsAt` cutoff, which can affect billing/quotas and potentially under/over-count usage if the start-date logic is wrong.
> 
> **Overview**
> Fixes credit-budget enforcement to **exclude usage before a usage-based subscription becomes active**.
> 
> `GetMonthlyCreditLimitUseCase` now returns both `monthlyCredits` and the subscription `startsAt`, and callers (`CreditBudgetGuardService`, `GetCreditUsageUseCase`) pass this date into `GetMonthlyCreditUsageQuery` as an optional `since` value.
> 
> `GetMonthlyCreditUsageUseCase` now uses `max(monthStart, since)` as the effective start date when querying usage, with updated/added unit tests covering the new `since` behavior and propagation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fff47d3e35813079e962aba28e1da79b24e85f15. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->