### PR TITLE
fix(super-admin): add breadcrumbs to org detail page (AYC-9)

### DIFF
--- a/ayunis-core-frontend/src/pages/super-admin-settings/org/ui/Page.tsx
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/org/ui/Page.tsx
@@ -58,6 +58,7 @@ export default function SuperAdminSettingsOrgPage({
   initialTab = 'org',
 }: Readonly<SuperAdminSettingsOrgPageProps>) {
   const { t } = useTranslation('super-admin-settings-org');
+  const { t: tLayout } = useTranslation('super-admin-settings-layout');
   const navigate = useNavigate();
   const { id } = useParams({
     from: '/_authenticated/super-admin-settings/orgs/$id',
@@ -83,7 +84,12 @@ export default function SuperAdminSettingsOrgPage({
   );
 
   return (
-    <SuperAdminSettingsLayout pageTitle={org.name}>
+    <SuperAdminSettingsLayout
+      breadcrumbs={[
+        { label: tLayout('layout.orgs'), href: '/super-admin-settings/orgs' },
+        { label: org.name },
+      ]}
+    >
       <Tabs
         value={initialTab}
         onValueChange={handleTabChange}

--- a/ayunis-core-frontend/src/pages/super-admin-settings/super-admin-settings-layout/ui/SuperAdminSettingsLayout.tsx
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/super-admin-settings-layout/ui/SuperAdminSettingsLayout.tsx
@@ -1,24 +1,28 @@
 import AppLayout from '@/layouts/app-layout/ui/AppLayout';
 import ContentAreaLayout from '@/layouts/content-area-layout/ui/ContentAreaLayout';
-import ContentAreaHeader from '@/widgets/content-area-header/ui/ContentAreaHeader';
+import ContentAreaHeader, {
+  type BreadcrumbEntry,
+} from '@/widgets/content-area-header/ui/ContentAreaHeader';
 import { SuperAdminSettingsSidebar } from './SuperAdminSettingsSidebar';
 import { useTranslation } from 'react-i18next';
 
 interface SuperAdminSettingsLayoutProps {
   pageTitle?: string;
+  breadcrumbs?: BreadcrumbEntry[];
   children: React.ReactNode;
   action?: React.ReactNode;
 }
 
 export default function SuperAdminSettingsLayout({
   pageTitle,
+  breadcrumbs,
   children,
   action,
 }: Readonly<SuperAdminSettingsLayoutProps>) {
   const { t } = useTranslation('super-admin-settings-layout');
   const contentHeader = (
     <ContentAreaHeader
-      breadcrumbs={[{ label: pageTitle ?? t('layout.title') }]}
+      breadcrumbs={breadcrumbs ?? [{ label: pageTitle ?? t('layout.title') }]}
       action={action}
     />
   );


### PR DESCRIPTION
## Summary
- Add optional `breadcrumbs` prop to `SuperAdminSettingsLayout` for detail pages that need hierarchical breadcrumbs
- Org detail page (`/super-admin-settings/orgs/$id`) now shows `Organizations > OrgName` with a clickable back-link, matching the standard pattern used by AgentPage, SkillPage, etc.

## Test plan
- [ ] Navigate to `/super-admin-settings/orgs` — breadcrumb shows `Organizations` (unchanged)
- [ ] Click into an org — breadcrumb shows `Organizations > OrgName`
- [ ] Click the `Organizations` breadcrumb link — navigates back to the orgs list
- [ ] Verify in both EN and DE locales

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that adds an optional `breadcrumbs` prop and uses it on the org detail page; no auth/data-flow logic is touched.
> 
> **Overview**
> Adds optional breadcrumb support to `SuperAdminSettingsLayout`, allowing pages to override the default single-title breadcrumb.
> 
> Updates the super-admin org detail page to pass `Organizations` → `Org name` breadcrumbs (with a back link to the org list) instead of relying on `pageTitle` alone.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4f2a5b433e02f3f39f7c3a2782cc1115811e9a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->