### PR TITLE
feat(metrics): track marketplace installs as prometheus counter (AYC-000)

### DIFF
--- a/ayunis-core-backend/src/domain/mcp/application/events/marketplace-integration-installed.event.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/events/marketplace-integration-installed.event.ts
@@ -1,0 +1,11 @@
+import type { UUID } from 'crypto';
+
+export class MarketplaceIntegrationInstalledEvent {
+  static readonly EVENT_NAME = 'marketplace.integration-installed';
+
+  constructor(
+    public readonly userId: UUID,
+    public readonly orgId: UUID,
+    public readonly identifier: string,
+  ) {}
+}

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/install-marketplace-integration/install-marketplace-integration.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/install-marketplace-integration/install-marketplace-integration.use-case.spec.ts
@@ -9,6 +9,8 @@ import { McpIntegrationAuthFactory } from '../../factories/mcp-integration-auth.
 import type { ValidateMcpIntegrationUseCase } from '../validate-mcp-integration/validate-mcp-integration.use-case';
 import { ConnectionValidationService } from '../../services/connection-validation.service';
 import type { ContextService } from 'src/common/context/services/context.service';
+import type { EventEmitter2 } from '@nestjs/event-emitter';
+import { MarketplaceIntegrationInstalledEvent } from '../../events/marketplace-integration-installed.event';
 import { MarketplaceMcpIntegration } from '../../../domain/integrations/marketplace-mcp-integration.entity';
 import { NoAuthMcpIntegrationAuth } from '../../../domain/auth/no-auth-mcp-integration-auth.entity';
 import { McpIntegrationKind } from '../../../domain/value-objects/mcp-integration-kind.enum';
@@ -32,8 +34,10 @@ describe('InstallMarketplaceIntegrationUseCase', () => {
   let validateUseCase: jest.Mocked<ValidateMcpIntegrationUseCase>;
   let connectionValidationService: ConnectionValidationService;
   let contextService: jest.Mocked<ContextService>;
+  let eventEmitter: jest.Mocked<EventEmitter2>;
 
   const orgId = '660e8400-e29b-41d4-a716-446655440001' as UUID;
+  const userId = '550e8400-e29b-41d4-a716-446655440000' as UUID;
 
   const oparlMarketplaceResponse: IntegrationResponseDto = {
     id: '550e8400-e29b-41d4-a716-446655440000',
@@ -146,7 +150,15 @@ describe('InstallMarketplaceIntegrationUseCase', () => {
       get: jest.fn(),
     } as unknown as jest.Mocked<ContextService>;
 
-    contextService.get.mockReturnValue(orgId);
+    contextService.get.mockImplementation((key) => {
+      if (key === 'userId') return userId;
+      if (key === 'orgId') return orgId;
+      return undefined;
+    });
+
+    eventEmitter = {
+      emitAsync: jest.fn().mockResolvedValue([]),
+    } as unknown as jest.Mocked<EventEmitter2>;
 
     repository.save.mockImplementation(async (integration) => integration);
     credentialEncryption.encrypt.mockImplementation(
@@ -175,6 +187,7 @@ describe('InstallMarketplaceIntegrationUseCase', () => {
       authFactory,
       connectionValidationService,
       contextService,
+      eventEmitter,
     );
   });
 
@@ -437,5 +450,45 @@ describe('InstallMarketplaceIntegrationUseCase', () => {
     expect(result.orgConfigValues).toEqual({
       authToken: 'encrypted:sk-fixed-token-we-control',
     });
+  });
+
+  it('should emit MarketplaceIntegrationInstalledEvent with the canonical identifier on success', async () => {
+    getMarketplaceIntegrationUseCase.execute.mockResolvedValue(
+      oparlMarketplaceResponse,
+    );
+
+    await useCase.execute(
+      new InstallMarketplaceIntegrationCommand('oparl-council-data', {
+        oparlEndpointUrl: 'https://rim.ekom21.de/oparl/v1',
+      }),
+    );
+
+    expect(eventEmitter.emitAsync).toHaveBeenCalledWith(
+      MarketplaceIntegrationInstalledEvent.EVENT_NAME,
+      expect.objectContaining({
+        userId,
+        orgId,
+        identifier: 'oparl-council-data',
+      }),
+    );
+  });
+
+  it('should not emit an event when install fails (duplicate)', async () => {
+    getMarketplaceIntegrationUseCase.execute.mockResolvedValue(
+      oparlMarketplaceResponse,
+    );
+    repository.findByOrgIdAndMarketplaceIdentifier.mockResolvedValue(
+      {} as never,
+    );
+
+    await expect(
+      useCase.execute(
+        new InstallMarketplaceIntegrationCommand('oparl-council-data', {
+          oparlEndpointUrl: 'https://rim.ekom21.de/oparl/v1',
+        }),
+      ),
+    ).rejects.toThrow(DuplicateMarketplaceMcpIntegrationError);
+
+    expect(eventEmitter.emitAsync).not.toHaveBeenCalled();
   });
 });

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/install-marketplace-integration/install-marketplace-integration.use-case.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/install-marketplace-integration/install-marketplace-integration.use-case.ts
@@ -1,4 +1,5 @@
 import { Injectable, Logger, UnauthorizedException } from '@nestjs/common';
+import { EventEmitter2 } from '@nestjs/event-emitter';
 import { InstallMarketplaceIntegrationCommand } from './install-marketplace-integration.command';
 import { GetMarketplaceIntegrationUseCase } from 'src/domain/marketplace/application/use-cases/get-marketplace-integration/get-marketplace-integration.use-case';
 import { GetMarketplaceIntegrationQuery } from 'src/domain/marketplace/application/use-cases/get-marketplace-integration/get-marketplace-integration.query';
@@ -15,6 +16,7 @@ import {
   IntegrationConfigSchema,
   ConfigField,
 } from '../../../domain/value-objects/integration-config-schema';
+import { MarketplaceIntegrationInstalledEvent } from '../../events/marketplace-integration-installed.event';
 /**
  * Runtime shape of the configSchema returned by the marketplace API.
  * The OpenAPI spec declares this as a generic object, so we cast at the boundary.
@@ -63,6 +65,7 @@ export class InstallMarketplaceIntegrationUseCase {
     private readonly authFactory: McpIntegrationAuthFactory,
     private readonly connectionValidationService: ConnectionValidationService,
     private readonly contextService: ContextService,
+    private readonly eventEmitter: EventEmitter2,
   ) {}
 
   async execute(
@@ -71,7 +74,8 @@ export class InstallMarketplaceIntegrationUseCase {
     this.logger.log('execute', { identifier: command.identifier });
 
     const orgId = this.contextService.get('orgId');
-    if (!orgId) {
+    const userId = this.contextService.get('userId');
+    if (!orgId || !userId) {
       throw new UnauthorizedException('User not authenticated');
     }
 
@@ -136,6 +140,26 @@ export class InstallMarketplaceIntegrationUseCase {
 
       const validated =
         await this.connectionValidationService.validateAndUpdateStatus(saved);
+
+      this.eventEmitter
+        .emitAsync(
+          MarketplaceIntegrationInstalledEvent.EVENT_NAME,
+          new MarketplaceIntegrationInstalledEvent(
+            userId,
+            orgId,
+            marketplaceIntegration.identifier,
+          ),
+        )
+        .catch((err: unknown) => {
+          this.logger.error(
+            'Failed to emit MarketplaceIntegrationInstalledEvent',
+            {
+              error: err instanceof Error ? err.message : 'Unknown error',
+              identifier: marketplaceIntegration.identifier,
+              orgId,
+            },
+          );
+        });
 
       return validated as MarketplaceMcpIntegration;
     } catch (error) {

--- a/ayunis-core-backend/src/domain/skills/application/events/marketplace-skill-installed.event.ts
+++ b/ayunis-core-backend/src/domain/skills/application/events/marketplace-skill-installed.event.ts
@@ -1,0 +1,11 @@
+import type { UUID } from 'crypto';
+
+export class MarketplaceSkillInstalledEvent {
+  static readonly EVENT_NAME = 'marketplace.skill-installed';
+
+  constructor(
+    public readonly userId: UUID,
+    public readonly orgId: UUID,
+    public readonly identifier: string,
+  ) {}
+}

--- a/ayunis-core-backend/src/domain/skills/application/use-cases/install-skill-from-marketplace/install-skill-from-marketplace.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/skills/application/use-cases/install-skill-from-marketplace/install-skill-from-marketplace.use-case.spec.ts
@@ -1,6 +1,7 @@
 import { InstallSkillFromMarketplaceUseCase } from './install-skill-from-marketplace.use-case';
 import { InstallSkillFromMarketplaceCommand } from './install-skill-from-marketplace.command';
 import type { ContextService } from 'src/common/context/services/context.service';
+import type { EventEmitter2 } from '@nestjs/event-emitter';
 import {
   MarketplaceSkillNotFoundError,
   MarketplaceUnavailableError,
@@ -9,13 +10,24 @@ import { MarketplaceInstallFailedError } from '../../skills.errors';
 import { Skill } from '../../../domain/skill.entity';
 import type { UUID } from 'crypto';
 import type { MarketplaceSkillInstallationService } from '../../services/marketplace-skill-installation.service';
+import { MarketplaceSkillInstalledEvent } from '../../events/marketplace-skill-installed.event';
 
 describe('InstallSkillFromMarketplaceUseCase', () => {
   let useCase: InstallSkillFromMarketplaceUseCase;
   let skillInstallationService: jest.Mocked<MarketplaceSkillInstallationService>;
   let contextService: jest.Mocked<ContextService>;
+  let eventEmitter: jest.Mocked<EventEmitter2>;
 
   const userId = '550e8400-e29b-41d4-a716-446655440000' as UUID;
+  const orgId = '660e8400-e29b-41d4-a716-446655440001' as UUID;
+
+  const mockAuthenticatedContext = () => {
+    contextService.get.mockImplementation((key) => {
+      if (key === 'userId') return userId;
+      if (key === 'orgId') return orgId;
+      return undefined;
+    });
+  };
 
   const installedSkill = new Skill({
     name: 'Meeting Summarizer',
@@ -35,14 +47,19 @@ describe('InstallSkillFromMarketplaceUseCase', () => {
       get: jest.fn(),
     } as unknown as jest.Mocked<ContextService>;
 
+    eventEmitter = {
+      emitAsync: jest.fn().mockResolvedValue([]),
+    } as unknown as jest.Mocked<EventEmitter2>;
+
     useCase = new InstallSkillFromMarketplaceUseCase(
       skillInstallationService,
       contextService,
+      eventEmitter,
     );
   });
 
   it('should delegate to MarketplaceSkillInstallationService and return the created skill', async () => {
-    contextService.get.mockReturnValue(userId);
+    mockAuthenticatedContext();
     skillInstallationService.installFromMarketplace.mockResolvedValue(
       installedSkill,
     );
@@ -66,7 +83,7 @@ describe('InstallSkillFromMarketplaceUseCase', () => {
   });
 
   it('should propagate MarketplaceSkillNotFoundError when skill is not found', async () => {
-    contextService.get.mockReturnValue(userId);
+    mockAuthenticatedContext();
     skillInstallationService.installFromMarketplace.mockRejectedValue(
       new MarketplaceSkillNotFoundError('nonexistent-skill'),
     );
@@ -79,7 +96,7 @@ describe('InstallSkillFromMarketplaceUseCase', () => {
   });
 
   it('should propagate MarketplaceUnavailableError when marketplace is down', async () => {
-    contextService.get.mockReturnValue(userId);
+    mockAuthenticatedContext();
     skillInstallationService.installFromMarketplace.mockRejectedValue(
       new MarketplaceUnavailableError(),
     );
@@ -102,7 +119,7 @@ describe('InstallSkillFromMarketplaceUseCase', () => {
   });
 
   it('should throw MarketplaceInstallFailedError on unexpected errors', async () => {
-    contextService.get.mockReturnValue(userId);
+    mockAuthenticatedContext();
     skillInstallationService.installFromMarketplace.mockRejectedValue(
       new Error('Database error'),
     );
@@ -112,5 +129,40 @@ describe('InstallSkillFromMarketplaceUseCase', () => {
         new InstallSkillFromMarketplaceCommand('meeting-summarizer'),
       ),
     ).rejects.toThrow(MarketplaceInstallFailedError);
+  });
+
+  it('should emit MarketplaceSkillInstalledEvent with the canonical identifier on success', async () => {
+    mockAuthenticatedContext();
+    skillInstallationService.installFromMarketplace.mockResolvedValue(
+      installedSkill,
+    );
+
+    await useCase.execute(
+      new InstallSkillFromMarketplaceCommand('meeting-summarizer'),
+    );
+
+    expect(eventEmitter.emitAsync).toHaveBeenCalledWith(
+      MarketplaceSkillInstalledEvent.EVENT_NAME,
+      expect.objectContaining({
+        userId,
+        orgId,
+        identifier: 'meeting-summarizer',
+      }),
+    );
+  });
+
+  it('should not emit an event when the install fails', async () => {
+    mockAuthenticatedContext();
+    skillInstallationService.installFromMarketplace.mockRejectedValue(
+      new MarketplaceSkillNotFoundError('nonexistent-skill'),
+    );
+
+    await expect(
+      useCase.execute(
+        new InstallSkillFromMarketplaceCommand('nonexistent-skill'),
+      ),
+    ).rejects.toThrow(MarketplaceSkillNotFoundError);
+
+    expect(eventEmitter.emitAsync).not.toHaveBeenCalled();
   });
 });

--- a/ayunis-core-backend/src/domain/skills/application/use-cases/install-skill-from-marketplace/install-skill-from-marketplace.use-case.ts
+++ b/ayunis-core-backend/src/domain/skills/application/use-cases/install-skill-from-marketplace/install-skill-from-marketplace.use-case.ts
@@ -1,10 +1,12 @@
 import { Injectable, Logger, UnauthorizedException } from '@nestjs/common';
+import { EventEmitter2 } from '@nestjs/event-emitter';
 import { Skill } from '../../../domain/skill.entity';
 import { InstallSkillFromMarketplaceCommand } from './install-skill-from-marketplace.command';
 import { ContextService } from 'src/common/context/services/context.service';
 import { ApplicationError } from 'src/common/errors/base.error';
 import { MarketplaceInstallFailedError } from '../../skills.errors';
 import { MarketplaceSkillInstallationService } from '../../services/marketplace-skill-installation.service';
+import { MarketplaceSkillInstalledEvent } from '../../events/marketplace-skill-installed.event';
 
 @Injectable()
 export class InstallSkillFromMarketplaceUseCase {
@@ -13,21 +15,39 @@ export class InstallSkillFromMarketplaceUseCase {
   constructor(
     private readonly skillInstallationService: MarketplaceSkillInstallationService,
     private readonly contextService: ContextService,
+    private readonly eventEmitter: EventEmitter2,
   ) {}
 
   async execute(command: InstallSkillFromMarketplaceCommand): Promise<Skill> {
     this.logger.log('execute', { identifier: command.identifier });
 
     const userId = this.contextService.get('userId');
-    if (!userId) {
+    const orgId = this.contextService.get('orgId');
+    if (!userId || !orgId) {
       throw new UnauthorizedException('User not authenticated');
     }
 
     try {
-      return await this.skillInstallationService.installFromMarketplace(
+      const skill = await this.skillInstallationService.installFromMarketplace(
         command.identifier,
         userId,
       );
+
+      const identifier = skill.marketplaceIdentifier ?? command.identifier;
+      this.eventEmitter
+        .emitAsync(
+          MarketplaceSkillInstalledEvent.EVENT_NAME,
+          new MarketplaceSkillInstalledEvent(userId, orgId, identifier),
+        )
+        .catch((err: unknown) => {
+          this.logger.error('Failed to emit MarketplaceSkillInstalledEvent', {
+            error: err instanceof Error ? err.message : 'Unknown error',
+            identifier,
+            userId,
+          });
+        });
+
+      return skill;
     } catch (error) {
       if (error instanceof ApplicationError) {
         throw error;

--- a/ayunis-core-backend/src/integrations/metrics/listeners/prometheus-metrics.listener.spec.ts
+++ b/ayunis-core-backend/src/integrations/metrics/listeners/prometheus-metrics.listener.spec.ts
@@ -8,6 +8,8 @@ import { InferenceCompletedEvent } from 'src/domain/runs/application/events/infe
 import { TokensConsumedEvent } from 'src/domain/runs/application/events/tokens-consumed.event';
 import { ToolUsedEvent } from 'src/domain/runs/application/events/tool-used.event';
 import { ThreadMessageAddedEvent } from 'src/domain/threads/application/events/thread-message-added.event';
+import { MarketplaceSkillInstalledEvent } from 'src/domain/skills/application/events/marketplace-skill-installed.event';
+import { MarketplaceIntegrationInstalledEvent } from 'src/domain/mcp/application/events/marketplace-integration-installed.event';
 import { User } from 'src/iam/users/domain/user.entity';
 import { UserRole } from 'src/iam/users/domain/value-objects/role.object';
 
@@ -48,6 +50,7 @@ describe('PrometheusMetricsListener', () => {
   let tokensCounter: ReturnType<typeof mockCounter>;
   let toolUsesCounter: ReturnType<typeof mockCounter>;
   let threadMessageHistogram: ReturnType<typeof mockHistogram>;
+  let marketplaceInstallsCounter: ReturnType<typeof mockCounter>;
 
   beforeEach(() => {
     userCreationsCounter = mockCounter();
@@ -58,6 +61,7 @@ describe('PrometheusMetricsListener', () => {
     tokensCounter = mockCounter();
     toolUsesCounter = mockCounter();
     threadMessageHistogram = mockHistogram();
+    marketplaceInstallsCounter = mockCounter();
 
     listener = new PrometheusMetricsListener(
       userCreationsCounter as never,
@@ -68,6 +72,7 @@ describe('PrometheusMetricsListener', () => {
       tokensCounter as never,
       toolUsesCounter as never,
       threadMessageHistogram as never,
+      marketplaceInstallsCounter as never,
     );
   });
 
@@ -358,6 +363,44 @@ describe('PrometheusMetricsListener', () => {
           new UserCreatedEvent(USER_ID, ORG_ID, makeUser()),
         ),
       ).not.toThrow();
+    });
+  });
+
+  describe('handleMarketplaceSkillInstalled', () => {
+    it('should increment marketplace installs counter with type "skill" and slug', () => {
+      listener.handleMarketplaceSkillInstalled(
+        new MarketplaceSkillInstalledEvent(
+          USER_ID,
+          ORG_ID,
+          'meeting-summarizer',
+        ),
+      );
+
+      expect(marketplaceInstallsCounter.inc).toHaveBeenCalledWith({
+        user_id: USER_ID,
+        org_id: ORG_ID,
+        marketplace_type: 'skill',
+        marketplace_slug: 'meeting-summarizer',
+      });
+    });
+  });
+
+  describe('handleMarketplaceIntegrationInstalled', () => {
+    it('should increment marketplace installs counter with type "integration" and slug', () => {
+      listener.handleMarketplaceIntegrationInstalled(
+        new MarketplaceIntegrationInstalledEvent(
+          USER_ID,
+          ORG_ID,
+          'oparl-council-data',
+        ),
+      );
+
+      expect(marketplaceInstallsCounter.inc).toHaveBeenCalledWith({
+        user_id: USER_ID,
+        org_id: ORG_ID,
+        marketplace_type: 'integration',
+        marketplace_slug: 'oparl-council-data',
+      });
     });
   });
 });

--- a/ayunis-core-backend/src/integrations/metrics/listeners/prometheus-metrics.listener.ts
+++ b/ayunis-core-backend/src/integrations/metrics/listeners/prometheus-metrics.listener.ts
@@ -10,6 +10,8 @@ import { InferenceCompletedEvent } from 'src/domain/runs/application/events/infe
 import { TokensConsumedEvent } from 'src/domain/runs/application/events/tokens-consumed.event';
 import { ToolUsedEvent } from 'src/domain/runs/application/events/tool-used.event';
 import { ThreadMessageAddedEvent } from 'src/domain/threads/application/events/thread-message-added.event';
+import { MarketplaceSkillInstalledEvent } from 'src/domain/skills/application/events/marketplace-skill-installed.event';
+import { MarketplaceIntegrationInstalledEvent } from 'src/domain/mcp/application/events/marketplace-integration-installed.event';
 import {
   AYUNIS_USER_CREATIONS_TOTAL,
   AYUNIS_MESSAGES_TOTAL,
@@ -19,6 +21,7 @@ import {
   AYUNIS_TOKENS_TOTAL,
   AYUNIS_TOOL_USES_TOTAL,
   AYUNIS_THREAD_MESSAGE_COUNT,
+  AYUNIS_MARKETPLACE_INSTALLS_TOTAL,
 } from '../metrics.constants';
 import { safeMetric } from '../metrics.utils';
 import { classifyInferenceError } from '../classify-inference-error.helper';
@@ -49,6 +52,8 @@ export class PrometheusMetricsListener {
     private readonly toolUsesCounter: Counter<string>,
     @InjectMetric(AYUNIS_THREAD_MESSAGE_COUNT)
     private readonly threadMessageHistogram: Histogram<string>,
+    @InjectMetric(AYUNIS_MARKETPLACE_INSTALLS_TOTAL)
+    private readonly marketplaceInstallsCounter: Counter<string>,
   ) {}
 
   @OnEvent(UserCreatedEvent.EVENT_NAME)
@@ -169,6 +174,32 @@ export class PrometheusMetricsListener {
         { user_id: event.userId, org_id: event.orgId },
         event.messageCount,
       );
+    });
+  }
+
+  @OnEvent(MarketplaceSkillInstalledEvent.EVENT_NAME)
+  handleMarketplaceSkillInstalled(event: MarketplaceSkillInstalledEvent): void {
+    safeMetric(this.logger, () => {
+      this.marketplaceInstallsCounter.inc({
+        user_id: event.userId,
+        org_id: event.orgId,
+        marketplace_type: 'skill',
+        marketplace_slug: event.identifier,
+      });
+    });
+  }
+
+  @OnEvent(MarketplaceIntegrationInstalledEvent.EVENT_NAME)
+  handleMarketplaceIntegrationInstalled(
+    event: MarketplaceIntegrationInstalledEvent,
+  ): void {
+    safeMetric(this.logger, () => {
+      this.marketplaceInstallsCounter.inc({
+        user_id: event.userId,
+        org_id: event.orgId,
+        marketplace_type: 'integration',
+        marketplace_slug: event.identifier,
+      });
     });
   }
 }

--- a/ayunis-core-backend/src/integrations/metrics/metrics.constants.ts
+++ b/ayunis-core-backend/src/integrations/metrics/metrics.constants.ts
@@ -11,6 +11,8 @@ export const AYUNIS_USER_ACTIVITY_TOTAL = 'ayunis_user_activity_total';
 export const AYUNIS_THREAD_MESSAGE_COUNT = 'ayunis_thread_message_count';
 export const AYUNIS_TOOL_USES_TOTAL = 'ayunis_tool_uses_total';
 export const AYUNIS_USER_CREATIONS_TOTAL = 'ayunis_user_creations_total';
+export const AYUNIS_MARKETPLACE_INSTALLS_TOTAL =
+  'ayunis_marketplace_installs_total';
 
 // Shared label names
 //
@@ -30,3 +32,5 @@ export const LABEL_ERROR_TYPE = 'error_type';
 export const LABEL_STREAMING = 'streaming';
 export const LABEL_TOOL_NAME = 'tool_name';
 export const LABEL_DEPARTMENT = 'department';
+export const LABEL_MARKETPLACE_TYPE = 'marketplace_type';
+export const LABEL_MARKETPLACE_SLUG = 'marketplace_slug';

--- a/ayunis-core-backend/src/integrations/metrics/metrics.module.ts
+++ b/ayunis-core-backend/src/integrations/metrics/metrics.module.ts
@@ -14,6 +14,7 @@ import {
   AYUNIS_THREAD_MESSAGE_COUNT,
   AYUNIS_TOOL_USES_TOTAL,
   AYUNIS_USER_CREATIONS_TOTAL,
+  AYUNIS_MARKETPLACE_INSTALLS_TOTAL,
   LABEL_USER_ID,
   LABEL_ORG_ID,
   LABEL_MODEL,
@@ -24,6 +25,8 @@ import {
   LABEL_STREAMING,
   LABEL_TOOL_NAME,
   LABEL_DEPARTMENT,
+  LABEL_MARKETPLACE_TYPE,
+  LABEL_MARKETPLACE_SLUG,
 } from './metrics.constants';
 import { MetricsAuthMiddleware } from './metrics-auth.middleware';
 import { MetricsController } from './metrics.controller';
@@ -85,6 +88,17 @@ const userCreationsCounter = makeCounterProvider({
   labelNames: [LABEL_ORG_ID, LABEL_DEPARTMENT],
 });
 
+const marketplaceInstallsCounter = makeCounterProvider({
+  name: AYUNIS_MARKETPLACE_INSTALLS_TOTAL,
+  help: 'Total number of marketplace installs (skill or integration)',
+  labelNames: [
+    LABEL_USER_ID,
+    LABEL_ORG_ID,
+    LABEL_MARKETPLACE_TYPE,
+    LABEL_MARKETPLACE_SLUG,
+  ],
+});
+
 const metricProviders = [
   tokensCounter,
   inferenceDurationHistogram,
@@ -94,6 +108,7 @@ const metricProviders = [
   threadMessageCountHistogram,
   toolUsesCounter,
   userCreationsCounter,
+  marketplaceInstallsCounter,
 ];
 
 @Module({


### PR DESCRIPTION
- New counter ayunis_marketplace_installs_total with labels user_id, org_id, marketplace_type (skill|integration), marketplace_slug
- Emit domain events from skill and integration install use cases on successful install; listener records the counter
- Use canonical identifier from marketplace response for the slug label to avoid casing/variant cardinality

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily additive observability changes; main behavior change is emitting non-blocking events after successful installs plus slightly stricter auth context checks (`userId` and `orgId`).
> 
> **Overview**
> Adds a new Prometheus counter `ayunis_marketplace_installs_total` (labels `user_id`, `org_id`, `marketplace_type`, `marketplace_slug`) and wires it into the metrics module and `PrometheusMetricsListener`.
> 
> Emits new domain events (`MarketplaceSkillInstalledEvent`, `MarketplaceIntegrationInstalledEvent`) from the skill and MCP marketplace install use cases on successful installs (using the canonical marketplace identifier) and logs-but-does-not-fail if event emission fails; tests were updated to cover event emission and the new metrics listener handlers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6105a7786c32e6e6a0153c77c4f882d218d2b136. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->