### PR TITLE
feat(marketplace): require terms acceptance before installing a skill (AYC-000)

### DIFF
--- a/ayunis-core-frontend/src/pages/install/ui/InstallSkillCard.tsx
+++ b/ayunis-core-frontend/src/pages/install/ui/InstallSkillCard.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { Button } from '@/shared/ui/shadcn/button';
 import {
   Card,
@@ -7,9 +8,11 @@ import {
   CardHeader,
   CardTitle,
 } from '@/shared/ui/shadcn/card';
+import { Checkbox } from '@/shared/ui/shadcn/checkbox';
 import { Bot } from 'lucide-react';
-import { useTranslation } from 'react-i18next';
+import { useTranslation, Trans } from 'react-i18next';
 import { Link } from '@tanstack/react-router';
+import { useMarketplaceConfig } from '@/features/marketplace';
 import type { MarketplaceSkillResponseDto } from '../api/useFetchMarketplaceSkill';
 
 interface InstallSkillCardProps {
@@ -24,6 +27,12 @@ export function InstallSkillCard({
   isInstalling,
 }: Readonly<InstallSkillCardProps>) {
   const { t } = useTranslation('install');
+  const marketplace = useMarketplaceConfig();
+  const [termsAccepted, setTermsAccepted] = useState(false);
+
+  const termsOfServiceUrl = marketplace.url
+    ? `${marketplace.url.replace(/\/$/, '')}/nutzungsbedingungen`
+    : null;
 
   return (
     <Card className="w-full max-w-lg">
@@ -49,13 +58,52 @@ export function InstallSkillCard({
             {t('detail.installNote')}
           </p>
         </div>
+
+        <div className="flex items-start gap-2">
+          <Checkbox
+            id="terms-accept"
+            className="mt-0.5"
+            checked={termsAccepted}
+            onCheckedChange={(checked) => setTermsAccepted(checked === true)}
+            disabled={isInstalling}
+          />
+          <span
+            className="text-sm leading-normal cursor-pointer select-none"
+            onClick={(e) => {
+              if (!isInstalling && !(e.target as HTMLElement).closest('a')) {
+                setTermsAccepted(!termsAccepted);
+              }
+            }}
+          >
+            <Trans
+              ns="install"
+              i18nKey="detail.termsOfServiceText"
+              components={{
+                termsLink: (
+                  <a
+                    href={termsOfServiceUrl ?? '#'}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="underline text-primary hover:text-primary/80"
+                  >
+                    placeholder
+                  </a>
+                ),
+              }}
+            />
+          </span>
+        </div>
       </CardContent>
 
       <CardFooter className="flex gap-3">
         <Button variant="outline" className="flex-1" asChild>
           <Link to="/skills">{t('action.cancel')}</Link>
         </Button>
-        <Button className="flex-1" onClick={onInstall} disabled={isInstalling}>
+        <Button
+          className="flex-1"
+          onClick={onInstall}
+          disabled={isInstalling || !termsAccepted}
+        >
           {isInstalling ? t('action.installing') : t('action.install')}
         </Button>
       </CardFooter>

--- a/ayunis-core-frontend/src/shared/locales/de/install.json
+++ b/ayunis-core-frontend/src/shared/locales/de/install.json
@@ -1,6 +1,7 @@
 {
   "detail": {
-    "installNote": "Diese Fähigkeit wird Ihrem Konto hinzugefügt. Sie können die Einstellungen der Fähigkeit nach der Installation anpassen."
+    "installNote": "Diese Fähigkeit wird Ihrem Konto hinzugefügt. Sie können die Einstellungen der Fähigkeit nach der Installation anpassen.",
+    "termsOfServiceText": "Ich habe die <termsLink>Nutzungsbedingungen</termsLink> gelesen und akzeptiere diese."
   },
   "action": {
     "install": "Fähigkeit installieren",

--- a/ayunis-core-frontend/src/shared/locales/en/install.json
+++ b/ayunis-core-frontend/src/shared/locales/en/install.json
@@ -1,6 +1,7 @@
 {
   "detail": {
-    "installNote": "This skill will be added to your account. You can customize the skill's settings after installation."
+    "installNote": "This skill will be added to your account. You can customize the skill's settings after installation.",
+    "termsOfServiceText": "I have read and accept the <termsLink>terms of service</termsLink>."
   },
   "action": {
     "install": "Install Skill",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> UI-only gating with a small state change and new i18n strings; minimal impact beyond potentially blocking installs if the marketplace URL is misconfigured.
> 
> **Overview**
> Adds a **Terms of Service acceptance gate** to the skill install flow: `InstallSkillCard` now shows a checkbox with i18n text and a link to the marketplace ToS, and blocks installation until the user accepts.
> 
> The install button is disabled until acceptance (and during install), and the ToS URL is derived from the configured marketplace base URL with a `/nutzungsbedingungen` suffix; new `detail.termsOfServiceText` strings are added for `en`/`de`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ecf801957dae4578852ef8114819dda704cc0162. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->