### PR TITLE
chore(tooling): track .claude skills and CLAUDE.md (AYC-000)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,93 @@
+# AI Coding Agent Guidelines
+
+> **Philosophy**: Code is opaque weights. Correctness is inferred from externally observable behavior.
+
+For architecture overview and module navigation, see [ARCHITECTURE.md](ARCHITECTURE.md).
+
+---
+
+## Repository Overview
+
+**Ayunis Core** is an open-source AI gateway enabling municipalities to run customizable AI assistants with multi-provider LLM support, tool integration, document retrieval (RAG), and organization-scoped access control.
+
+```text
+ayunis-core/
+├── ayunis-core-backend/          # NestJS API server (hexagonal architecture)
+├── ayunis-core-frontend/         # React SPA (Feature-Sliced Design)
+├── ayunis-core-code-execution/   # Sandboxed code execution microservice
+├── ayunis-core-anonymize/        # PII anonymization service
+├── docker-compose.yml            # Local dev infrastructure
+├── ARCHITECTURE.md               # Full architecture docs with module index
+└── AGENTS.md                     # This file
+```
+
+---
+
+## Core Principles
+
+### 1. Validation-First
+
+Do NOT trust your own assessment of code correctness. Verify through observable behavior — lint, type-check, tests, and runtime. See the development skills below for specific validation sequences.
+
+### 2. Incremental Progress
+
+- Make one change at a time
+- Validate after each change
+- Commit after each validated change
+- Never batch multiple logical changes
+
+### 3. Respect Boundaries
+
+- Read the target module's SUMMARY.md before making changes
+- Never import across module boundaries — use ports/adapters
+- Never edit generated code (e.g., the frontend API client)
+
+---
+
+## Forbidden Actions
+
+These rules exist because an agent violated them and caused data loss. They are non-negotiable.
+
+### Never kill processes
+
+You do not understand what is running on the host machine. Processes that look like "just postgres" or "just ssh" may be Colima's infrastructure, SSH tunnels, or other critical services. If a port is occupied or a process is blocking something, **describe the problem and ask** — never `kill`, `pkill`, or `killall`.
+
+### Never use destructive Docker flags
+
+Never use `docker compose down -v`, `docker volume rm`, `docker system prune`, or any command that deletes volumes. Volumes contain database data that cannot be restored. The only safe Docker commands are:
+
+- `docker compose up` / `docker compose down` (without `-v`)
+- `docker compose ps` / `docker compose logs`
+- `docker compose exec` (to run commands inside containers)
+
+### Never modify system or infrastructure state
+
+Do not stop/restart Colima, edit Docker configs, change network settings, modify `/etc/hosts`, or touch anything outside the repository that isn't a source file.
+
+### When the environment is broken, stop and ask
+
+If Docker won't start, ports are occupied, containers won't come up, or anything infrastructure-related is failing: **describe what you see and ask for instructions.** Do not attempt to diagnose or fix environment issues autonomously. Every escalating "fix" risks making things worse.
+
+### General rule
+
+If an action is irreversible and isn't writing/editing source code, **ask first**.
+
+---
+
+## Code Quality Enforcement
+
+The following rules are enforced by ESLint, pre-commit hooks, and CI. Violations block commits and PRs.
+
+- **Strict TypeScript** — Backend uses `strict: true` (no implicit any, strict null checks, strict bind/call/apply). Frontend uses strict null checks.
+- **`no-explicit-any: error`** — Both backend and frontend. Use `unknown` or specific types. If `any` is truly unavoidable (e.g., TypeORM pgvector), add a targeted `eslint-disable` comment with a justification.
+- **sonarjs** — Both packages use `eslint-plugin-sonarjs` (recommended config). Cognitive complexity threshold: 15.
+- **Complexity thresholds** — Enforced by pre-commit hooks and CI: cyclomatic complexity (CCN) ≤ 10, function length ≤ 50 lines, arguments ≤ 5. If a function exceeds these limits, split it into smaller units before committing.
+- **File size limit** — 500 lines per file (excluding tests, migrations, records, generated code). Enforced by `scripts/check-file-size.sh` in pre-commit.
+- **No `console.*`** — Use NestJS `Logger` on the backend. `console.warn` and `console.error` are allowed in specific infrastructure code.
+- **Circular dependency detection** — `madge` runs in pre-commit and CI.
+
+---
+
+## Development Skills
+
+For detailed development workflows, patterns, and validation checklists, load the appropriate skill. Skills are listed with descriptions in the system prompt — pick the one that matches the task.

--- a/.claude/skills/ayunis-core-backend/SKILL.md
+++ b/.claude/skills/ayunis-core-backend/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: ayunis-core-backend
+description: Ayunis Core backend specifics — module boundaries, key files, and project conventions. Complements the nestjs-hexagonal-backend skill.
+---
+
+# Ayunis Core Backend
+
+Load the `nestjs-hexagonal-backend` skill first — this skill adds project-specific context on top.
+
+## Working Directory
+
+**All commands run from `ayunis-core-backend/`:**
+
+```bash
+cd ayunis-core-backend
+```
+
+## Module Boundaries
+
+The backend enforces strict bounded contexts:
+
+- **`src/domain/*`** — Core business logic (agents, threads, messages, runs, models, tools, prompts, sources, RAG, etc.)
+- **`src/iam/*`** — Identity and access management (auth, users, orgs, subscriptions, quotas, teams, etc.)
+- **`src/common/*`** — Shared infrastructure only (base classes, utilities)
+- **`src/admin/*`** — Super admin routes
+
+Cross-module communication uses **exported use cases**, not ports/adapters. When module A needs functionality from module B, module A imports B's module and injects B's use case directly — do NOT create a port in A with an adapter that wraps B. Ports (abstract interfaces) are only for **infrastructure boundaries within a module** (e.g., a repository port implemented by a persistence adapter). Before modifying any module, read its `SUMMARY.md`. See [ARCHITECTURE.md](../../ARCHITECTURE.md) for the complete module index.
+
+## User Context
+
+User identity comes from `ContextService`, not method parameters:
+
+```typescript
+// CORRECT ✓
+const userId = this.contextService.get('userId');
+
+// WRONG ✗
+async execute(command: { userId: string })  // Don't pass context
+```
+
+## Key Files
+
+| Purpose                     | Location                                        |
+| --------------------------- | ----------------------------------------------- |
+| Architecture & module index | `ARCHITECTURE.md`                               |
+| Module summaries            | `src/[area]/[module]/SUMMARY.md`                |
+| TypeORM config              | `src/db/datasource.ts`                          |
+| OpenAPI spec                | `http://localhost:PORT/api/docs` (when running) |
+
+> [!IMPORTANT] Always update `ARCHITECTURE.md` and the module's `SUMMARY.md` file if necessary!
+
+## Health Check
+
+After changes, verify the service responds:
+
+```bash
+curl http://localhost:PORT/api/health
+```
+
+The port depends on the dev slot — check with `./dev status` from the repo root.

--- a/.claude/skills/ayunis-core-frontend-dev/SKILL.md
+++ b/.claude/skills/ayunis-core-frontend-dev/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: ayunis-core-frontend-dev
+description: Frontend development in ayunis-core. Use when creating, modifying, or debugging frontend code (React, Feature-Sliced Design, API client).
+---
+
+# Frontend Development — ayunis-core-frontend
+
+## Working Directory
+
+**All commands run from `ayunis-core-frontend/`:**
+
+```bash
+cd ayunis-core-frontend
+```
+
+Before modifying any layer, read its `SUMMARY.md` in `src/[layer]/SUMMARY.md`. The top-level `src/SUMMARY.md` provides an overview.
+
+## Validation Sequence
+
+```bash
+npm run build                  # Must succeed
+npm run lint                   # Must pass
+```
+
+## Architecture (Feature-Sliced Design)
+
+```text
+src/
+├── pages/      # Route components (compose widgets/features)
+├── widgets/    # Reusable composites (used in ≥2 pages)
+├── features/   # Self-contained business logic
+└── shared/     # Primitives (ui, api, lib)
+```
+
+**Import rules**: `pages → widgets → features → shared`
+
+Layers only depend on layers to their right. Never import upward.
+
+### Page module internals
+
+Each page module can have these subdirectories:
+
+```text
+src/pages/<page-name>/
+├── ui/       # Components — state, hooks, JSX only
+├── api/      # Mutation hooks (one per operation)
+├── model/    # Types, constants, schemas
+└── lib/      # Pure helper functions (formatting, URL building, data transforms)
+```
+
+Keep `ui/` components focused on component logic. Extract pure functions that don't depend on React state or hooks into `lib/`.
+
+## API Client
+
+After backend API changes, regenerate the client:
+
+```bash
+npm run openapi:update  # Regenerates src/shared/api/generated/
+```
+
+**Never edit generated code manually** — it will be overwritten.
+
+## Hook Pattern
+
+One hook per operation, encapsulating mutation logic. Use `showSuccess`/`showError` from `@/shared/lib/toast` for user feedback, and `extractErrorData` from `@/shared/api/extract-error-data` for structured error handling.
+
+For hooks that back a form (create/update dialogs), load the **frontend-form-pattern** skill — it covers form types, structure, and the full end-to-end validation pattern including backend DTO validation, field-level error display, and i18n.
+
+## Completion Checklist
+
+- [ ] `npm run build` succeeds
+- [ ] `npm run lint` passes
+- [ ] Page renders without console errors
+- [ ] No `any` types introduced
+- [ ] Import rules respected (no upward imports)

--- a/.claude/skills/backend-debugging/SKILL.md
+++ b/.claude/skills/backend-debugging/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: backend-debugging
+description: Debug backend runtime errors (500s, crashes, unexpected behavior). Use when something is broken at runtime — not for writing new code.
+---
+
+# Backend Debugging
+
+## Step 1 — Read the logs
+
+Before reading code, guessing, or querying the database, **check the backend logs**:
+
+```bash
+# From the repo root (slot is remembered from ./dev up):
+./dev logs backend                # Last 80 lines
+./dev logs --tail 200 backend     # More context
+
+# Or read the log file directly:
+cat .dev/slot-$(cat .dev/slot)/backend.log
+```
+
+The logs contain full stack traces with file names and line numbers. This tells you exactly what's broken — no guessing needed.
+
+**Do not skip this step.** Code review without the actual error is guesswork.
+
+## Step 2 — Reproduce the error
+
+Confirm the error independently with curl. This isolates whether the problem is backend vs. frontend vs. CORS:
+
+```bash
+# Login first (adjust credentials as needed):
+curl -s -c /tmp/cookies.txt http://localhost:3020/api/auth/login \
+  -X POST -H 'Content-Type: application/json' \
+  -d '{"email":"...","password":"..."}'
+
+# Hit the failing endpoint:
+curl -s -b /tmp/cookies.txt "http://localhost:3020/api/..." | head -50
+```
+
+Replace port `3020` with whatever the current slot uses. Check with `./dev status`.
+
+### Recognizing CORS errors
+
+If the browser console shows "blocked by CORS policy" but the request returns a valid status code (e.g., 201), the backend works — the browser is rejecting the response. Look for:
+
+- Hardcoded `Access-Control-Allow-Origin` headers in the controller that override the global CORS middleware
+- The global CORS config in `src/main.ts` — in development mode (`NODE_ENV !== 'production'`) it should allow all origins
+
+## Step 3 — Go to the error location
+
+The stack trace gives you the exact file and line. Read that code. Common patterns:
+
+### "Cannot read properties of undefined (reading 'map')"
+
+A relation wasn't loaded by TypeORM but the mapper assumes it's always present. Fix with optional chaining:
+
+```typescript
+// Before — crashes when relation not loaded:
+items.map(x => ...)
+
+// After:
+items?.map(x => ...) ?? []
+```
+
+This is especially common when:
+
+- A `findAll` query doesn't load the same relations as `findOne`
+- Eager relations don't cascade through deeply nested joins (e.g., `thread → sourceAssignments → source → details → contentChunks`)
+
+### "Invalid source type" / "Invalid message role"
+
+A mapper's `instanceof` or `switch` doesn't cover all cases. Check what the database actually contains:
+
+```bash
+# Quick database query through the dev stack:
+cd ayunis-core-backend
+npx ts-node -r tsconfig-paths/register -e "
+import './src/config/env';
+import { DataSource } from 'typeorm';
+// ... query the relevant table
+"
+```
+
+## Step 4 — Fix, verify, check logs again
+
+1. Make the fix
+2. Wait for `nest --watch` to reload (or check `./dev logs backend` for compilation errors)
+3. Re-run the curl command from Step 2
+4. Check `./dev logs backend` to confirm no new errors
+5. Run the validation sequence:
+
+```bash
+cd ayunis-core-backend
+npm run lint && npx tsc --noEmit && npm run test
+```

--- a/.claude/skills/browser-verify/SKILL.md
+++ b/.claude/skills/browser-verify/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: browser-verify
+description: Verify frontend changes in the browser — check pages render, catch console errors, and debug runtime issues using bb (headless Chrome CLI).
+---
+
+# Browser Verification
+
+Use `bb` (headless Chrome CLI) to verify frontend changes render correctly and produce no runtime errors. Run `bb help` for the full command reference.
+
+## Determine the Frontend URL
+
+The frontend port depends on the dev slot. Check with:
+
+```bash
+./dev status
+```
+
+Or derive it: frontend port = `3001 + (slot × 10)`. Slot 2 → `http://localhost:3021`.
+
+## Verification Flow
+
+After making frontend changes:
+
+1. **Open the page** — `bb open http://localhost:PORT/your-page`
+2. **Check for React error overlay** — `bb exists "#webpack-dev-server-client-overlay"`
+3. **Screenshot if needed** — `bb screenshot page.png`
+4. **Stop when done** — `bb stop`
+
+## Catching Console Errors
+
+Inject an error collector before navigating, then check it after:
+
+```bash
+bb open --raw http://localhost:PORT
+bb js "window.__errs=[]; const o=console.error; console.error=(...a)=>{window.__errs.push(a.join(' ')); o.apply(console,a)}"
+bb open http://localhost:PORT/your-page
+bb js "window.__errs"
+```
+
+## Debugging with CDP
+
+`bb cdp <method> [params-json]` gives direct access to the Chrome DevTools Protocol. Useful for:
+
+- **Network issues** — `bb cdp Network.enable`, then inspect cookies or replay requests
+- **Runtime exceptions** — `bb cdp Runtime.enable` to track uncaught errors
+- **DOM inspection** — `bb cdp DOM.getDocument '{"depth": 3}'`
+
+## Authentication
+
+If the page requires login, use the seeded admin credentials (see `seed-database` skill for details):
+
+```bash
+bb open http://localhost:3021/login
+bb input "input[name='email']" "admin@demo.local"
+bb input "input[name='password']" "admin"
+bb click "button[type='submit']"
+bb sleep 2
+bb open http://localhost:3021/your-page
+```
+
+## Cleanup
+
+Always stop the browser when done to free resources:
+
+```bash
+bb stop
+```

--- a/.claude/skills/code-review/SKILL.md
+++ b/.claude/skills/code-review/SKILL.md
@@ -1,0 +1,158 @@
+---
+name: code-review
+description: Self-review local changes before creating a PR. Use when the user says "review", "review my code", "check my changes", or wants confidence before submitting.
+---
+
+# Code Review — Local Self-Assurance
+
+Review your own uncommitted or committed-but-not-pushed changes locally. The goal is to catch real issues **before** creating a PR, so you submit with confidence.
+
+This is a local-only review — nothing is posted to GitHub.
+
+## Input
+
+The user invokes `/code-review` optionally with a scope:
+
+- `/code-review` — review all local changes (staged + unstaged + unpushed commits)
+- `/code-review staged` — only staged changes
+- `/code-review <path>` — only changes in specific files or directories
+
+## Steps
+
+### 1. Determine the diff
+
+Identify what to review based on the scope:
+
+```bash
+# Default: all local changes vs the merge base
+git diff $(git merge-base HEAD main)..HEAD
+git diff HEAD
+
+# Staged only
+git diff --cached
+
+# Specific path
+git diff $(git merge-base HEAD main)..HEAD -- <path>
+```
+
+If there are no changes, tell the user and stop.
+
+### 2. Gather context
+
+In parallel, collect:
+
+- The list of changed files and their directories
+- Any `CLAUDE.md` files in the repo root and in affected directories
+- A short summary of what the changes do (read the diff)
+
+### 3. Launch review agents
+
+Launch **5 parallel agents**, each with a different review lens. Provide each agent with the diff, changed file list, and relevant CLAUDE.md content.
+
+#### Agent 1 — CLAUDE.md & Convention Compliance
+
+Check whether the changes follow project conventions defined in CLAUDE.md files:
+
+- Naming patterns, coding style, comment style
+- Architecture boundaries and module rules
+- Any explicit "do" / "don't" instructions
+
+#### Agent 2 — Bug Scan
+
+Shallow scan for obvious bugs in the changed lines only:
+
+- Null/undefined risks, off-by-one errors, missing awaits
+- Incorrect conditions, wrong variable references
+- Broken error handling, silent failures
+- Focus on real bugs — skip anything a linter or type checker would catch
+
+#### Agent 3 — Logic & Completeness
+
+Read the changed files more broadly (not just the diff) to check:
+
+- Does the change do what it claims? Any missing cases?
+- Are there partial implementations (TODO left behind, half-wired features)?
+- Do new code paths have matching cleanup, rollback, or error handling?
+
+#### Agent 4 — DRY & Simplicity
+
+Check for unnecessary complexity in the changes:
+
+- Duplicated logic that should be extracted
+- Over-engineering (abstractions for single use, premature generalization)
+- Code that could be simplified without losing clarity
+- Dead code or unused imports introduced by the change
+
+#### Agent 5 — Security & Data Integrity
+
+Check the changes for security and data concerns:
+
+- Injection risks (SQL, command, XSS)
+- Secrets or credentials in code
+- Missing input validation at system boundaries
+- Unsafe data handling (unvalidated casts, unchecked access)
+
+### 4. Score each finding
+
+For each issue found across all agents, assign a confidence score (0–100):
+
+| Score | Meaning |
+|-------|---------|
+| 0–25  | Likely false positive or pre-existing issue |
+| 26–50 | Might be real but could be a nitpick |
+| 51–75 | Probably real, worth a look |
+| 76–100 | High confidence — real issue that should be fixed |
+
+**Discard anything scoring below 60.**
+
+### 5. Present findings
+
+Group the surviving findings by severity:
+
+```markdown
+## Code Review — Local
+
+Reviewed N files, M lines changed.
+
+### Critical (must fix)
+- [Bug] Missing null check in `src/service.ts:42` — `user.org` can be undefined
+  when called from the public endpoint (confidence: 92)
+
+### Important (should fix)
+- [Convention] CLAUDE.md requires early returns, but `handleRequest` uses
+  nested if/else at `src/handler.ts:18-34` (confidence: 81)
+
+### Suggestions (consider)
+- [Simplicity] Lines 50-62 in `src/utils.ts` duplicate the pattern at line 12 —
+  extract to a shared helper (confidence: 65)
+
+### Looks Good
+- No security issues found
+- Error handling is consistent with existing patterns
+```
+
+If no issues survive the confidence filter, say so clearly:
+
+```markdown
+## Code Review — Local
+
+Reviewed N files, M lines changed.
+No significant issues found. Good to submit.
+```
+
+### 6. Offer to fix
+
+After presenting findings, ask:
+
+> "Want me to fix any of these before you create the PR?"
+
+If the user says yes, fix the issues and re-run only the affected review agents to verify.
+
+## Guidelines
+
+- **Local only** — never post to GitHub, never read PR comments, never interact with remote
+- **Changes only** — review what the user changed, not pre-existing code (unless needed for context)
+- **Real issues only** — the confidence scoring exists to kill false positives; be aggressive about filtering
+- **Actionable** — every finding must include the file, line, and what's wrong; no vague warnings
+- **Fast** — use parallel agents; the user is waiting to submit
+- **Respect the codebase** — always check CLAUDE.md conventions before calling something an issue

--- a/.claude/skills/dev-environment/SKILL.md
+++ b/.claude/skills/dev-environment/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: dev-environment
+description: Start, stop, and manage the local dev stack (Docker infra, backend, frontend). Works in any directory — worktree or main repo.
+---
+
+# Dev Environment
+
+## Starting the Stack
+
+The `./dev` script manages the full local development stack. It works from any checkout — worktree or main repo.
+
+```bash
+# Start everything (requires a slot number on first run)
+./dev up --slot 2
+
+# Subsequent runs remember the slot
+./dev up
+```
+
+### What `./dev up` does
+
+1. Starts Docker infrastructure (postgres, minio, mailcatcher, code-execution, anonymize)
+2. Generates `.env.dev` with localhost connection config for the slot
+3. Runs database migrations
+4. Starts the backend natively (`nest start --watch`)
+5. Starts the frontend natively (`vite`)
+6. Waits for the backend health check, prints port summary, returns
+
+## Port Reference
+
+Ports are offset by `slot × 10`:
+
+| Service  | Formula       | Slot 2 | Slot 3 | Slot 4 |
+| -------- | ------------- | ------ | ------ | ------ |
+| Backend  | 3000 + offset | 3020   | 3030   | 3040   |
+| Frontend | 3001 + offset | 3021   | 3031   | 3041   |
+| Postgres | 5432 + offset | 5452   | 5462   | 5472   |
+| MinIO    | 9000 + offset | 9020   | 9030   | 9040   |
+
+**Avoid slots 0 and 1** — their ports (5432, 3000, etc.) often conflict with existing services on the host.
+
+## Checking Status and Logs
+
+```bash
+./dev status                      # Overview of all services
+./dev logs backend                # Backend logs (last 80 lines)
+./dev logs frontend               # Frontend logs
+./dev logs infra                  # Docker infrastructure logs
+./dev logs --tail 200 backend     # More lines
+```
+
+## Restarting
+
+The backend runs `nest start --watch` — it auto-reloads on code changes. If it crashes:
+
+```bash
+./dev logs backend    # Check what went wrong
+./dev down
+./dev up              # Slot is remembered
+```
+
+## Stopping
+
+```bash
+./dev down
+```
+
+## Troubleshooting
+
+If `./dev up` fails, check logs:
+
+```bash
+./dev logs backend
+./dev logs infra
+```

--- a/.claude/skills/feature-toggles/SKILL.md
+++ b/.claude/skills/feature-toggles/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: feature-toggles
+description: Add, modify, or remove feature toggles. Use when gating new features or changing toggle defaults.
+---
+
+# Feature Toggles
+
+## Key files
+
+- Config: `ayunis-core-backend/src/config/features.config.ts` — `FeaturesConfig` interface + `registerAs('features', ...)`
+- Guard: `ayunis-core-backend/src/common/guards/feature.guard.ts` — `@RequireFeature(FeatureFlag.Xxx)` decorator (composes `UseGuards` internally)
+- Endpoint: `ayunis-core-backend/src/app/presenters/http/app.controller.ts` — `GET /feature-toggles`
+- Response DTO: `ayunis-core-backend/src/app/presenters/http/dto/feature-toggles-response.dto.ts`
+- Frontend hooks: `ayunis-core-frontend/src/features/feature-toggles/`
+
+## Adding a new toggle
+
+### Backend
+
+1. Add property to `FeaturesConfig` interface and the `registerAs` factory in `features.config.ts`. Env var pattern: `FEATURE_<SNAKE_CASE>_ENABLED`. Pick the right default (off = not yet released, on = already shipped).
+2. Add property to `FeatureTogglesResponseDto` with `@ApiProperty`.
+3. Return it in `AppController.featureToggles()`.
+4. Apply `@RequireFeature(FeatureFlag.Xxx)` to the controller(s). Controller-level = gates all routes. The decorator composes `UseGuards` internally — do not add `@UseGuards(FeatureGuard)` separately.
+5. Run guard tests: `npm run test -- --testPathPattern=feature.guard`
+
+### Frontend
+
+1. Regenerate API client: `VITE_API_BASE_URL=http://localhost:<backend-port>/api npm run openapi:update` from `ayunis-core-frontend/`.
+1. Add convenience hook in `useIsFeatureEnabled.ts` (follow `useIsSkillsEnabled` pattern).
+1. Gate sidebar item in `AppSidebar.tsx` — add to the conditional spread pattern.
+1. Gate route loaders — `throw redirect({ to: '/chat' })` when disabled (see `skills.index.tsx`).
+1. Gate any other UI that references the feature (chat widgets, plus button, etc.).
+
+## Changing a default
+
+Edit the default value in `features.config.ts`. That's it — production never sets env vars, so the code default is the production value.
+
+## Guard behavior
+
+- `@RequireFeature(FeatureFlag.Xxx)` on class → applies to all routes in that controller
+- `@RequireFeature(FeatureFlag.Xxx)` on method → applies to that route only
+- Disabled → throws `NotFoundException` (404)
+- Missing metadata → allows (guard is a no-op without `@RequireFeature`)
+- Flag must be a member of `FeatureFlag` enum (type-safe)

--- a/.claude/skills/fix-schema-drift/SKILL.md
+++ b/.claude/skills/fix-schema-drift/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: fix-schema-drift
+description: Fix OpenAPI schema drift between backend and frontend. Use when CI fails with "API Schema Drift" or "API client is out of date", or after adding/changing backend controllers or DTOs.
+---
+
+# Fix OpenAPI Schema Drift
+
+## Prerequisites
+
+The dev stack must be running (`./dev status`). Start with `./dev up` if needed.
+
+## Fix
+
+```bash
+cd ayunis-core-frontend
+npm run openapi:update
+```
+
+Then stage and commit the changed files with `gt modify` or `gt create`.
+
+## Notes
+
+- Never hand-edit generated files — always regenerate via `npm run openapi:update`
+- `npm run openapi:update` runs `openapi:fetch` → `openapi:format` → `openapi:generate`. The format step (`prettier --write`) is required: `fetch-openapi-schema.js` writes via `JSON.stringify(_, null, 2)`, which puts every short array on multiple lines, but the canonical on-disk format is prettier's compact-when-fits style. Without the format step, schema regens produce ~2000 lines of whitespace-only churn.
+- If you ever need to format the schema by itself: `npm run openapi:format`
+- Formatting-only changes are normal — still commit them to keep CI green

--- a/.claude/skills/frontend-form-pattern/SKILL.md
+++ b/.claude/skills/frontend-form-pattern/SKILL.md
@@ -1,0 +1,266 @@
+---
+name: frontend-form-pattern
+description: Frontend form patterns — form types in model/, useForm setup, and end-to-end backend validation with field-level error display. Use when adding or modifying any form (page or dialog) that submits to the API.
+---
+
+# Frontend Form Pattern
+
+This skill covers how forms are structured in page modules and the complete validation flow from backend DTO → API response → frontend form field errors with i18n.
+
+## Form Types
+
+Form field interfaces live in the page module's `model/` directory — never inline in the component file.
+
+```typescript
+// model/types.ts
+export interface ThingFormFields {
+  name: string;
+  description: string;
+}
+```
+
+Multiple form types can share the same file (e.g. `CreateThingFormFields` and `UpdateThingFormFields`), or use separate files if they diverge significantly.
+
+The component imports the type:
+
+```typescript
+// ui/ThingDetailPage.tsx
+import type { ThingFormFields } from '../model/types';
+
+const form = useForm<ThingFormFields>({
+  defaultValues: { name: entity.name, description: entity.description ?? '' },
+});
+```
+
+### Existing examples
+
+- `pages/admin-settings/teams-settings/model/types.ts` — `CreateTeamFormData`, `UpdateTeamFormData`
+- `pages/admin-settings/letterhead-detail/model/types.ts` — `LetterheadFormFields`
+- `pages/prompts/model/createPromptSchema.ts` — Zod schema with inferred type
+
+## Page Component Structure
+
+Page components (`ui/`) should contain only component logic: state, hooks, form setup, event handlers, and JSX. Keep them focused:
+
+- **Form types** → `model/types.ts`
+- **Form setup** (`useForm`, `defaultValues`, `onSubmit`) stays in the component — it's component logic
+- **Pure helper functions** → `lib/` (see the `ayunis-core-frontend-dev` skill)
+
+## Validation
+
+### Overview
+
+```text
+Backend DTO (@MaxLength, @IsNotEmpty, …)
+  ↓ ValidationPipe rejects
+  ↓ exceptionFactory in main.ts formats response
+  ↓
+{ code: "VALIDATION_ERROR", errors: [{ field, constraints }] }
+  ↓
+Frontend hook: extractErrorData() → setValidationErrors(form, …)
+  ↓
+form.setError(field, { message: t("validation.field.constraint") })
+  ↓
+<FormMessage /> renders inline error
+```
+
+### Backend
+
+#### DTO (class-validator decorators)
+
+Validation rules live on the DTO. These are the source of truth — they also feed the OpenAPI spec and generated frontend client.
+
+```typescript
+// presenters/http/dto/create-thing.dto.ts
+import { IsString, IsNotEmpty, MaxLength } from 'class-validator';
+
+export class CreateThingDto {
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(100)
+  name: string;
+
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(500)
+  description: string;
+}
+```
+
+#### Global ValidationPipe (already configured in `main.ts`)
+
+The `exceptionFactory` normalizes validation errors into a structured response with a `VALIDATION_ERROR` code and field-level detail. **You don't need to touch this** — it applies globally to all DTOs.
+
+Response format:
+
+```json
+{
+  "code": "VALIDATION_ERROR",
+  "message": "Validation failed",
+  "errors": [
+    { "field": "description", "constraints": ["maxLength"] }
+  ]
+}
+```
+
+Nested DTOs produce dot-notation field names (e.g. `"address.street"`).
+
+#### Domain errors (ApplicationError)
+
+Domain-level errors (e.g. duplicate name, not found) are separate from DTO validation. They use the `ApplicationError` pattern with module-specific error codes:
+
+```typescript
+// application/thing.errors.ts
+export class DuplicateThingNameError extends ThingError {
+  constructor(name: string) {
+    super(`Thing "${name}" already exists`, ThingErrorCode.DUPLICATE_NAME, 409);
+  }
+}
+```
+
+These flow through `ApplicationErrorFilter` and arrive at the frontend with their own `code`.
+
+### Frontend
+
+#### `extractErrorData` (shared, already exists)
+
+Extracts `code`, `message`, `status`, and `errors` from Axios errors:
+
+```typescript
+import extractErrorData from '@/shared/api/extract-error-data';
+// Returns: { code, message, status, errors?: FieldError[] }
+```
+
+#### `setValidationErrors` (shared helper)
+
+Maps backend field errors to `form.setError()` with translated messages.
+
+```typescript
+import { setValidationErrors } from '@/shared/lib/set-validation-errors';
+```
+
+Translation key resolution order:
+
+1. `${prefix}.${field}.${constraint}` — e.g. `validation.description.maxLength`
+2. `${prefix}.${field}.invalid` — e.g. `validation.description.invalid`
+3. `${prefix}.invalid` — generic fallback
+
+#### Hook pattern
+
+The hook receives the `form` instance so it can set field errors on validation failure. Other error codes (domain errors) show toast messages as before.
+
+```typescript
+// api/useCreateThing.ts
+import type { UseFormReturn } from 'react-hook-form';
+import { showSuccess, showError } from '@/shared/lib/toast';
+import extractErrorData from '@/shared/api/extract-error-data';
+import { setValidationErrors } from '@/shared/lib/set-validation-errors';
+
+export function useCreateThing(
+  form: UseFormReturn<ThingFormData>,
+  onSuccess?: () => void,
+) {
+  const { t } = useTranslation('things');
+  const mutation = useThingsControllerCreate({
+    mutation: {
+      onSuccess: async () => {
+        showSuccess(t('toast.createSuccess'));
+        onSuccess?.();
+      },
+      onError: (error: unknown) => {
+        try {
+          const { code, errors } = extractErrorData(error);
+          if (code === 'VALIDATION_ERROR' && errors) {
+            setValidationErrors(form, errors, t, 'validation');
+          } else if (code === 'DUPLICATE_NAME') {
+            showError(t('toast.duplicateName'));
+          } else {
+            showError(t('toast.createError'));
+          }
+        } catch {
+          showError(t('toast.createError'));
+        }
+      },
+    },
+  });
+
+  return {
+    createThing: (data: CreateThingDto) => mutation.mutate({ data }),
+    isCreating: mutation.isPending,
+  };
+}
+```
+
+If a hook is used **without a form** (e.g. a toggle), make `form` optional and guard the `setValidationErrors` call:
+
+```typescript
+export function useUpdateThing(
+  form?: UseFormReturn<ThingFormData>,
+  onSuccess?: () => void,
+) {
+  // ...
+  if (code === 'VALIDATION_ERROR' && errors && form) {
+    setValidationErrors(form, errors, t, 'validation');
+  }
+}
+```
+
+#### Dialog component
+
+Pass the `form` to the hook:
+
+```typescript
+const form = useForm<ThingFormData>({ defaultValues: { name: '', description: '' } });
+const { createThing, isCreating } = useCreateThing(form, () => {
+  onOpenChange(false);
+  form.reset();
+});
+```
+
+The form fields must use `<FormMessage />` (from shadcn) to render errors inline — this is already standard in all form dialogs.
+
+#### Translation keys
+
+Add a `validation` section to the page's translation namespace:
+
+```json
+{
+  "validation": {
+    "name": {
+      "isNotEmpty": "Name is required",
+      "maxLength": "Name must be 100 characters or fewer",
+      "invalid": "Invalid name"
+    },
+    "description": {
+      "isNotEmpty": "Description is required",
+      "maxLength": "Description must be 500 characters or fewer",
+      "invalid": "Invalid description"
+    },
+    "invalid": "Invalid input"
+  }
+}
+```
+
+Constraint keys match the class-validator decorator names in camelCase: `isNotEmpty`, `maxLength`, `isString`, `isEnum`, `isEmail`, `minLength`, `length`, `matches`, etc.
+
+## Checklist
+
+- [ ] Form types defined in `model/types.ts`, not inline in the component
+- [ ] DTO has class-validator decorators for all constraints
+- [ ] Hook accepts `form` parameter and calls `setValidationErrors` on `VALIDATION_ERROR`
+- [ ] Hook still handles domain error codes (e.g. duplicate) via toast
+- [ ] Dialog passes `form` to the hook
+- [ ] Translation file has `validation.{field}.{constraint}` keys in all locales (en, de)
+- [ ] Form fields use `<FormMessage />` for inline error display
+
+## Reference implementation
+
+See the skill templates feature for a complete example:
+
+- Backend DTO: `ayunis-core-backend/src/domain/skill-templates/presenters/http/dto/create-skill-template.dto.ts`
+- Frontend hook: `ayunis-core-frontend/src/pages/super-admin-settings/skill-templates/api/useCreateSkillTemplate.ts`
+- Frontend dialog: `ayunis-core-frontend/src/pages/super-admin-settings/skill-templates/ui/CreateSkillTemplateDialog.tsx`
+- Translations: `ayunis-core-frontend/src/shared/locales/en/super-admin-settings-skills.json`
+- Shared helper: `ayunis-core-frontend/src/shared/lib/set-validation-errors.ts`
+- Error extractor: `ayunis-core-frontend/src/shared/api/extract-error-data.ts`
+- ValidationPipe config: `ayunis-core-backend/src/main.ts` (`exceptionFactory`)

--- a/.claude/skills/frontend-hook-reference/SKILL.md
+++ b/.claude/skills/frontend-hook-reference/SKILL.md
@@ -1,0 +1,281 @@
+---
+name: frontend-hook-reference
+description: "Reference implementation for frontend data hooks (queries and mutations). MUST be loaded when creating or modifying any hook in an api/ directory or any use*.ts file that calls the generated API client."
+---
+
+# Frontend Hook Reference Implementation
+
+This skill defines the canonical patterns for data-access hooks. Every hook that calls the API MUST follow these patterns.
+
+## Utilities
+
+- **`extractErrorData`** from `@/shared/api/extract-error-data` — extracts `{ code, message, status, errors }` from Axios errors. Throws if the error is not an `AxiosError` (network failure, cancellation, etc.).
+- **`showSuccess` / `showError`** from `@/shared/lib/toast` — user-facing toasts.
+- All user-facing strings use `useTranslation` with the appropriate namespace.
+
+## Pattern 1: Mutation Hook (no form)
+
+For simple actions (delete, toggle, assign, unassign).
+
+```typescript
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useTranslation } from 'react-i18next';
+import { showSuccess, showError } from '@/shared/lib/toast';
+import {
+  entityControllerDelete,
+  getEntityControllerFindAllQueryKey,
+} from '@/shared/api/generated/ayunisCoreAPI';
+import { useRouter } from '@tanstack/react-router';
+import extractErrorData from '@/shared/api/extract-error-data';
+
+interface DeleteEntityParams {
+  id: string;
+}
+
+export function useDeleteEntity() {
+  const { t } = useTranslation('entities');
+  const queryClient = useQueryClient();
+  const router = useRouter();
+
+  return useMutation({
+    mutationFn: async ({ id }: DeleteEntityParams) => {
+      await entityControllerDelete(id);
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
+        queryKey: getEntityControllerFindAllQueryKey(),
+      });
+      void router.invalidate();
+      showSuccess(t('delete.success'));
+    },
+    onError: (error) => {
+      try {
+        const { code } = extractErrorData(error);
+        switch (code) {
+          case 'ENTITY_NOT_FOUND':
+            showError(t('delete.notFound'));
+            break;
+          default:
+            showError(t('delete.error'));
+        }
+      } catch {
+        // Non-AxiosError (network failure, request cancellation, etc.)
+        showError(t('delete.error'));
+      }
+    },
+  });
+}
+```
+
+## Pattern 2: Mutation Hook (with form)
+
+For create/update operations that use `react-hook-form`. For the full form validation pattern including field-level backend errors, load the **form-validation-pattern** skill.
+
+```typescript
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import * as z from 'zod';
+import { useTranslation } from 'react-i18next';
+import { showSuccess, showError } from '@/shared/lib/toast';
+import {
+  entityControllerCreate,
+  getEntityControllerFindAllQueryKey,
+} from '@/shared/api/generated/ayunisCoreAPI';
+import { useRouter } from '@tanstack/react-router';
+import extractErrorData from '@/shared/api/extract-error-data';
+
+const createEntitySchema = z.object({
+  name: z.string().min(1, 'Name is required'),
+});
+
+export type CreateEntityData = z.infer<typeof createEntitySchema>;
+
+export function useCreateEntity() {
+  const { t } = useTranslation('entities');
+  const queryClient = useQueryClient();
+  const router = useRouter();
+
+  const form = useForm<CreateEntityData>({
+    resolver: zodResolver(createEntitySchema),
+    defaultValues: { name: '' },
+  });
+
+  const mutation = useMutation({
+    mutationFn: async (data: CreateEntityData) => {
+      return await entityControllerCreate(data);
+    },
+    onSuccess: (data) => {
+      void queryClient.invalidateQueries({
+        queryKey: getEntityControllerFindAllQueryKey(),
+      });
+      void router.invalidate();
+      showSuccess(t('create.success'));
+      if (data.id) {
+        void router.navigate({ to: '/entities/$id', params: { id: data.id } });
+      }
+    },
+    onError: (error) => {
+      try {
+        const { code } = extractErrorData(error);
+        switch (code) {
+          case 'DUPLICATE_ENTITY_NAME':
+            showError(t('create.duplicateName'));
+            break;
+          default:
+            showError(t('create.error'));
+        }
+      } catch {
+        showError(t('create.error'));
+      }
+    },
+  });
+
+  const onSubmit = (data: CreateEntityData) => {
+    mutation.mutate(data);
+  };
+
+  const resetForm = () => {
+    form.reset();
+  };
+
+  return {
+    form,
+    onSubmit,
+    resetForm,
+    isLoading: mutation.isPending,
+  };
+}
+```
+
+## Pattern 3: Query Hook
+
+For data fetching. Query hooks are simpler — error handling happens at render time via the `error` return value.
+
+```typescript
+import {
+  useEntityControllerFindAll,
+  getEntityControllerFindAllQueryKey,
+} from '@/shared/api/generated/ayunisCoreAPI';
+
+export function useEntities() {
+  const { data, isLoading, error, refetch } = useEntityControllerFindAll(
+    {},
+    {
+      query: {
+        queryKey: getEntityControllerFindAllQueryKey({}),
+      },
+    },
+  );
+
+  return {
+    entities: data?.data ?? [],
+    isLoading,
+    error,
+    refetch,
+  };
+}
+```
+
+## Rules
+
+### 1. Every `onError` MUST use `extractErrorData` and check error codes
+
+This is the most common mistake. Never show a generic error without checking the code first:
+
+```typescript
+// WRONG ✗ — ignores the error code
+onError: (error) => {
+  try {
+    extractErrorData(error);     // ← result thrown away!
+    showError(t('create.error'));
+  } catch {
+    showError(t('create.error'));
+  }
+}
+
+// WRONG ✗ — no error inspection at all
+onError: () => {
+  showError(t('update.error'));
+}
+
+// CORRECT ✓ — extracts and switches on code
+onError: (error) => {
+  try {
+    const { code } = extractErrorData(error);
+    switch (code) {
+      case 'ENTITY_NOT_FOUND':
+        showError(t('update.notFound'));
+        break;
+      case 'DUPLICATE_ENTITY_NAME':
+        showError(t('update.duplicateName'));
+        break;
+      default:
+        showError(t('update.error'));
+    }
+  } catch {
+    showError(t('update.error'));
+  }
+}
+```
+
+### 2. The try/catch in `onError` is structural, not optional
+
+`extractErrorData` throws for non-Axios errors (network failures, cancellations). The catch block must always show a generic fallback error.
+
+### 3. Map backend error codes to specific user messages
+
+Check the module's `*.errors.ts` file in the backend for the error codes the endpoint can return. Each relevant code should have a corresponding i18n key and toast message.
+
+### 4. Cache invalidation after mutations
+
+Always invalidate relevant query keys after successful mutations:
+
+```typescript
+onSuccess: () => {
+  void queryClient.invalidateQueries({
+    queryKey: getEntityControllerFindAllQueryKey(),
+  });
+  void router.invalidate();
+  showSuccess(t('action.success'));
+},
+```
+
+Use `void` for fire-and-forget invalidation. Invalidate both the list query and any detail queries if applicable.
+
+### 5. Return shape conventions
+
+**Mutation hooks without a form** return the mutation result directly via `useMutation(...)`.
+
+**Mutation hooks with a form** return:
+
+```typescript
+return {
+  form,         // react-hook-form instance
+  onSubmit,     // function to pass to form.handleSubmit
+  resetForm,    // resets the form to defaults
+  isLoading: mutation.isPending,
+};
+```
+
+**Query hooks** return domain data with loading/error state:
+
+```typescript
+return {
+  entities: data?.data ?? [],
+  isLoading,
+  error,
+  refetch,       // optional, if manual refetch is needed
+};
+```
+
+## Checklist
+
+When creating or modifying a hook, verify:
+
+- [ ] `onError` uses `extractErrorData` and switches on `code`
+- [ ] Non-Axios errors caught with fallback `showError`
+- [ ] Backend error codes mapped to specific i18n messages
+- [ ] `onSuccess` invalidates relevant query keys
+- [ ] `void` used for fire-and-forget `invalidateQueries`/`router.invalidate()`
+- [ ] User-facing strings go through `useTranslation`, not hardcoded

--- a/.claude/skills/git-workflow/SKILL.md
+++ b/.claude/skills/git-workflow/SKILL.md
@@ -1,0 +1,146 @@
+---
+name: git-workflow
+description: "MUST be loaded before ANY commit, push, or branch operation. Never use raw git commit/push — this project uses Graphite (gt). Load this skill first whenever you need to commit, push, branch, or ask about git workflow."
+---
+
+# Git Workflow
+
+This project uses **Graphite** for stacked PRs. Always use `gt` commands, never raw `git commit`.
+
+## Commit Message Format
+
+```text
+<type>(<scope>): <subject> (<ticket-id>)
+<BLANK LINE>
+<body>
+<BLANK LINE>
+<footer>
+```
+
+### Rules
+
+1. **Ticket ID is required** — appended in parentheses at the end of the subject line. Always ask the user for the ticket ID if not provided. Never invent a ticket ID.
+2. **Type** must be one of: `feat`, `fix`, `chore`, `refactor`, `ci`, `docs`, `test`, `perf`, `wip`.
+3. **Scope** — a short noun describing the area of the codebase (e.g., `auth`, `chat`, `api`). Required for `feat` and `fix`; optional for other types. For `chore` commits without a specific scope (e.g., release, tooling), use a generic scope: `chore(main): release 1.8.0`.
+4. **Subject** is lowercase, imperative mood, no period at end.
+5. **Body** (optional) — separated by blank line, explains *what* and *why*. Bullet points with `-`, wrap at ~72 chars.
+6. **Footer** (optional) — references, breaking changes (`BREAKING CHANGE: ...`), or co-authors.
+
+### Examples
+
+```text
+feat(chat): add streaming response support (TASK-42)
+
+- Buffer chunks and flush on newline boundaries
+- Add backpressure handling for slow clients
+
+Refs: TASK-40
+```
+
+```text
+fix(auth): prevent token refresh race condition (TASK-99)
+```
+
+```text
+wip(sources): add source entity and repository port (TASK-1)
+```
+
+## WIP vs Semantic Types — Changelog Hygiene
+
+Projects using **release-please** auto-generate changelogs from squash-merged PR titles on `main`. Only semantic types (`feat`, `fix`, `refactor`, `perf`, `docs`, `ci`, `chore`, `test`) appear in the changelog. The `wip` type is **excluded from the changelog and does not trigger version bumps**.
+
+### When to use `wip:`
+
+Use `wip:` for any PR that is **part of a larger feature but does not complete it**. This is the default for stacked PRs in a multi-branch feature:
+
+```text
+wip(sources): add source entity and repository port (TASK-1)        ← stack branch 1
+wip(sources): implement source ingestion use case (TASK-1)           ← stack branch 2
+feat(sources): add source management API and UI (TASK-1)             ← final branch, completes the feature
+```
+
+Only the last PR uses `feat:` — that's the one that appears in the changelog as a single entry.
+
+### When to use semantic types
+
+Use `feat:`, `fix:`, etc. when the PR **delivers a complete, user-visible change** on its own:
+
+- A standalone bug fix → `fix(auth): correct date validation (TASK-2)`
+- A self-contained feature in a single PR → `feat(agents): add agent install page (TASK-3)`
+- CI/tooling change → `ci: add dead code workflow`
+
+### Rule of thumb
+
+> If this PR were the only one merged, would the change make sense to a user reading the changelog? If yes → semantic type. If no → `wip:`.
+
+## Branching & Stacking
+
+The worktree branch (if using worktrees) is the **base branch**. Graphite stacks are built on top of it.
+
+### New commit → new stacked branch
+
+Each logical unit of work gets its own `gt create`:
+
+```bash
+# 1. Stage changes
+git add <files>
+
+# 2. Verify what's staged
+git status --short
+
+# 3. Create a new stacked branch (auto-stacks on current branch)
+gt create -m "<type>(<scope>): <description> (<ticket-id>)"
+
+# 4. If pre-commit hooks fail, fix issues and retry with gt modify
+```
+
+### Amending the current branch
+
+Use when fixing QA findings, addressing PR review comments, bug bot findings, or correcting issues on the current branch. **Never use `gt create` for these fixes** — they belong to the same logical change and should be folded into the existing commit:
+
+```bash
+# 1. Stage fixes (or use -a flag to auto-stage all changes)
+git add <files>
+
+# 2. Amend the current stacked branch (keeps the existing commit message)
+gt modify
+
+# 3. This automatically restacks any descendant branches
+```
+
+- `gt modify` without flags amends the existing commit and keeps its message — no need to repeat `-m`.
+- Use `gt modify -a` to auto-stage all changes and amend in one step.
+- Use `gt modify -m "..."` only if you need to **change** the commit message.
+- With `--commit` it creates an additional commit on the branch — that's not what we want for fixes.
+
+### Pushing to remote
+
+**Never use raw `git push`** — always use `gt submit`. Raw pushes bypass Graphite's metadata and desynchronize remote base branches, causing merge conflicts on GitHub.
+
+**Always push the full stack** — never push a single branch. Pushing only one branch after a restack or amend leaves descendant branches' remote refs stale (old SHAs), which causes duplicate-commit merge conflicts the next time someone restacks a child branch.
+
+```bash
+# Always use --stack to push all branches in the stack
+gt submit --stack --force --no-interactive
+```
+
+Use `--force` to ensure remote refs are updated even if Graphite thinks they're current. Add `--publish` to take PRs out of draft.
+
+### Rules
+
+- Each logical unit of work gets its own `gt create` — one stacked branch per batch/task
+- Fixes and amendments use `gt modify`, never `gt create`
+- Never use `--no-verify` — let the hooks run
+- Never use raw `git commit` — always go through `gt`
+- Never use raw `git push` — always go through `gt submit`
+
+## Pre-commit Hooks
+
+Projects typically enforce via pre-commit hooks:
+
+- **Commit message must include a ticket ID** (validated by `commit-msg` hook)
+- **Commit message must start with a valid type** (`feat`, `fix`, `chore`, `wip`, etc.)
+- **Linting, formatting, type-checking** on staged files
+- **Complexity checks** (if configured)
+
+If complexity fails, split the offending function into smaller units before retrying.

--- a/.claude/skills/linear-build/SKILL.md
+++ b/.claude/skills/linear-build/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: linear-build
+description: Execute sub-issues from a Linear plan issue in reviewed batches. Reads sub-issues, identifies what's done, proposes the next batch, executes with validation, and marks sub-issues complete.
+---
+
+# Linear Build
+
+Execute implementation steps stored as Linear sub-issues in reviewed batches. This is the third phase of the linear-plan → linear-implementation-plan → linear-build workflow.
+
+## Input
+
+The user provides a parent Linear issue ID, or says something like "next batch" / "continue building" when one is already in context.
+
+If no ID is given, look for the plan issue referenced earlier in the conversation.
+
+## Process
+
+### 1. Read the plan
+
+Load the parent issue with `linear issue view <ID> --json` to get the plan context (problem, solution, decisions, gotchas).
+
+If the parent issue itself has a parent, read that too — it may contain broader context about why this work exists and constraints that apply.
+
+Then list sub-issues to get the implementation steps. Use the GraphQL API to fetch sub-issues with their state:
+
+```bash
+linear api 'query($id: String!) { issue(id: $id) { children { nodes { id identifier title state { name type } sortOrder } } } }' --variable id=<UUID>
+```
+
+Get the parent's UUID from `linear issue view <ID> --json` first.
+
+Sort sub-issues by `sortOrder` (ascending) to preserve the intended step sequence. Identify:
+
+- **Completed steps** — state type is `completed` or `canceled`
+- **In progress** — state type is `started`
+- **Remaining steps** — state type is `unstarted` or `backlog`
+- **Current position** — the first non-completed step
+
+If all steps are complete, say so and stop.
+
+### 2. Propose the batch
+
+Determine the next logical batch of sub-issues. A batch is a group that:
+
+- Are sequential from the current position (don't skip)
+- Form a coherent unit of work that makes sense as a single pull request
+- Tell a clear story in code review
+- Don't split tightly coupled changes across batches (e.g., entity + migration, API + tests)
+- Typically 1-3 steps, rarely more
+
+Present the batch:
+
+```text
+Next batch:
+
+- AYC-43: <title> (<scope summary>)
+- AYC-44: <title> (<scope summary>)
+
+This batch adds <what capability>. Good commit point after.
+```
+
+Proceed immediately to execution — don't wait for approval.
+
+### 3. Execute
+
+For each sub-issue in the batch, in order:
+
+1. **Read the sub-issue** — `linear issue view <ID> --json` to load scope, creates/edits/deletes, validation commands, and DO NOT touch list
+2. **Mark in progress** — `linear issue update <ID> --state "In Progress"`
+3. **Execute the work** — create files, make edits, follow the sub-issue's instructions precisely
+4. **Run validation** — execute the exact validation commands from the sub-issue description
+5. **Stop on failure** — if validation fails, fix the issue. If the fix is non-trivial, present it to the user before continuing. Do not proceed to the next step with broken validation.
+6. **Mark complete** — `linear issue update <ID> --state "Done"`
+
+### 4. Report
+
+After the batch is complete, present:
+
+```text
+Batch complete
+
+Done:
+- AYC-43: <title> — <what was done>
+- AYC-44: <title> — <what was done>
+
+Validation: all passing
+Next up: <brief description of upcoming sub-issues>
+```
+
+If this batch represents a meaningful change (new capability, architectural milestone), suggest updating the context graph.
+
+## Rules
+
+### Respect scope boundaries
+
+The sub-issue's **Scope** and **DO NOT touch** lines are hard constraints. Do not touch files outside the step's declared scope, even if it seems convenient.
+
+### Don't batch across natural commit boundaries
+
+If a sub-issue changes something risky (migration, public API change, config change), it should be the last in its batch so the user can review and commit before moving on.
+
+### Commit only when instructed
+
+If the caller explicitly tells you to commit (e.g., with a specific type and task ID), do so after validation passes. Otherwise, leave changes staged for review.
+
+### Follow existing patterns
+
+When a sub-issue says "same pattern as X," go read X. Don't guess what the pattern is.
+
+### Sub-issue is the source of truth
+
+Don't improvise beyond what the sub-issue specifies. If it's missing something, flag it — don't silently add scope. If the instructions conflict with what you see in the codebase, stop and ask.
+
+### Emergent work
+
+If execution surfaces work outside the current sub-issue's scope:
+
+- **Small fix in scope** — handle it within the current step if it's in the declared scope
+- **New sub-issue** — if it's clearly part of the parent plan, create a sub-issue on the parent and mention it in the report
+- **Related but independent** — create a separate issue and link it with `linear issue relation add <parentID> related <newID>`
+- **Blocking** — stop, create the issue, add a `blocks` relation, and inform the user
+
+Do NOT silently expand scope. Surface it, link it, move on.

--- a/.claude/skills/linear-implementation-plan/SKILL.md
+++ b/.claude/skills/linear-implementation-plan/SKILL.md
@@ -1,0 +1,191 @@
+---
+name: linear-implementation-plan
+description: Break a plan into Linear sub-issues as self-contained, testable implementation steps. Use when a feature spans multiple files/modules and needs careful sequencing.
+---
+
+# Linear Implementation Plan
+
+This skill breaks a plan into sub-issues on a parent Linear issue, where every sub-issue is a self-contained unit that compiles, passes tests, and can be committed independently.
+
+## Relationship to other skills
+
+This is the second phase of a three-phase workflow:
+
+1. **`linear-plan`** — research and create a plan issue (what and why)
+2. **`linear-implementation-plan`** (this skill) — break it into sub-issues (how and in what order)
+3. **`build`** — execute sub-issues in reviewed batches
+
+## Input
+
+The user provides a Linear issue ID (the plan issue), or says something like "break this into steps". Example: `/linear-implementation-plan AYC-42`
+
+If no issue ID is given, look for the plan issue created earlier in this conversation.
+
+## Process
+
+### 1. Read the plan
+
+Load the parent issue with `linear issue view <ID> --json`. Understand the problem, solution, key decisions, and gotchas.
+
+If the issue has a parent, read that too — it may contain broader context about why this work exists and constraints that apply.
+
+### 2. Research
+
+Read the codebase to understand:
+
+- What modules/files will be affected
+- What the dependency graph looks like (what depends on what)
+- What patterns exist that should be followed (look at analogous features)
+- What the validation infrastructure is (test commands, lint, type-check, CI)
+
+### 3. Clarify
+
+If anything is ambiguous, ask before creating sub-issues. Don't guess at:
+
+- Requirements or acceptance criteria
+- Which existing patterns to follow
+- Naming conventions
+- Whether something is in scope or not
+
+If everything is clear, say so and proceed.
+
+### 4. Design the steps
+
+Plan the sub-issues before creating them. Present the full breakdown to the user for approval:
+
+```text
+Implementation steps for AYC-42:
+
+1. <title> — <scope summary>
+2. <title> — <scope summary>
+3. <title> — <scope summary>
+...
+
+Shall I create these as sub-issues?
+```
+
+**Wait for approval before creating sub-issues.**
+
+### 5. Create sub-issues
+
+For each step, create a sub-issue on the parent:
+
+```bash
+linear issue create \
+  --team <TEAM> \
+  --project <PROJECT> \
+  --parent <PARENT-ID> \
+  --title "Step N: <short title>" \
+  --description-file <temp-file> \
+  --no-interactive
+```
+
+#### Sub-issue description format
+
+````markdown
+**Scope:** ONLY `<exact directories and files this step may touch>`
+
+## Creates
+- `path/to/new-file.ts` — what and why
+
+## Edits
+- `path/to/existing-file.ts` — what changes and why
+
+## Deletes
+(if any)
+- `path/to/old-file.ts` — why
+
+## Tests
+- What to test and how (specific commands, not vague "verify it works")
+
+## Validation
+```bash
+<exact commands to run — e.g. npm run lint && npx tsc --noEmit && npm run test>
+```
+
+## DO NOT touch
+`<explicit list of directories/files that are OFF LIMITS>`
+````
+
+### 6. Present
+
+- List the created sub-issue IDs
+- Summarize the implementation sequence
+- Suggest running `build` to start execution
+
+## Rules for designing steps
+
+### Each step is a compilable checkpoint
+
+After completing a step, the project MUST:
+
+- Type-check cleanly (`tsc --noEmit` or equivalent)
+- Pass linting
+- Pass all tests (existing + new)
+- Start/build without errors
+
+If a step can't meet this bar on its own, it's scoped wrong. Restructure.
+
+### Scope boundaries are hard walls
+
+Every sub-issue has an explicit **Scope** line listing the ONLY files/directories it may create or edit. Everything else is off-limits.
+
+Every sub-issue has a **DO NOT touch** line listing what's explicitly forbidden. This prevents premature cross-module changes.
+
+A step must NEVER:
+
+- Add imports for code that doesn't exist yet (will be created in a later step)
+- Write stub/placeholder implementations "for later"
+- Modify files belonging to another step's scope
+- Create .backup files or temp files
+
+### Dependencies flow forward, never backward
+
+If step 5 needs something from step 3, step 3 must create it. Step 5 never reaches back to modify step 3's files.
+
+### Stubs are forbidden
+
+Do not create files with `// TODO: implement in step N` or `throw new Error('not implemented')`. If a file can't be fully functional in the current step, it doesn't belong in this step.
+
+The one exception: if a step creates a use case that will be *called by* a later step, the use case itself must be complete and tested — only the *wiring* in the caller happens later.
+
+### Test commands are explicit
+
+Don't write "verify it works". Write:
+
+```bash
+npm run lint && npx tsc --noEmit && npm run test
+```
+
+### Don't spell out commands the agent already knows
+
+If the executing agent has a skill for something (e.g., a migration skill), state the intent — don't hardcode CLI commands.
+
+### Step granularity
+
+- Too small: "add one import statement" — not worth a step
+- Too large: "build the entire backend" — can't verify incrementally
+- Right size: a logical unit that adds one capability, touches 1-3 modules, and can be validated independently
+
+### Backend and frontend travel together
+
+Don't build the entire backend first, then the entire frontend. Sequence steps so that each backend capability is followed by its frontend counterpart as soon as possible. Verify observable end-to-end functionality at every stage.
+
+### Migration steps are always separate
+
+Database migrations get their own step because:
+
+- They have their own validation
+- They're irreversible in shared environments
+- They must match the record definitions exactly
+
+A migration step modifies records and generates/runs the migration. It does NOT modify domain entities, mappers, or repositories — those are separate steps.
+
+## Emergent work
+
+During implementation planning, if you discover work that is outside the scope of the parent issue:
+
+- **Related but independent** — create a separate issue with `linear issue relation add <parentID> related <newID>` and note it in the parent issue as a comment
+- **Blocking dependency** — create the issue and add a `blocks` relation: `linear issue relation add <newID> blocks <parentID>`
+
+Do NOT silently expand the scope of the parent issue. Surface it, link it, move on.

--- a/.claude/skills/linear-plan/SKILL.md
+++ b/.claude/skills/linear-plan/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: linear-plan
+description: Research a task and create a Linear issue as the plan instead of a file. Use when you need to think before doing in a Linear-tracked project.
+---
+
+# Linear Plan
+
+When this skill is active, you are **planning, not executing**. Do not make any changes to code, config, or project files.
+
+This is the first phase of a three-phase workflow:
+
+1. **`linear-plan`** (this skill) — research and create a plan as a Linear issue (what and why)
+2. **`linear-implementation-plan`** — break it into sub-issues (how and in what order)
+3. **`build`** — execute sub-issues in reviewed batches
+
+If the task warrants step-by-step execution, suggest following up with the `linear-implementation-plan` skill after the plan is approved.
+
+## Input
+
+The user provides a task description after `/linear-plan`. Example: `/linear-plan refactor the auth module to use JWT`
+
+An existing Linear issue ID may also be provided. In that case, read it and use it as the plan issue — skip to the Present step.
+
+## Steps
+
+### 1. Orient
+
+- Read relevant files to understand the current state
+- Check compass files if the task relates to goals or ongoing work
+- Check references if the task involves people, products, or projects
+- Look at existing code, config, or notes that would be affected
+
+### 2. Clarify
+
+- If anything is ambiguous, **ask before writing the plan**
+- Don't guess at requirements — surface assumptions and get confirmation
+- Keep questions focused: what you need to know to write a precise plan, nothing more
+- If everything is clear, skip this step and say so
+
+### 3. Create the Linear issue
+
+Use `manage-linear` to create the plan issue. The issue description IS the plan.
+
+```bash
+linear issue create \
+  --team <TEAM> \
+  --project <PROJECT> \
+  --title "Plan: <concise title>" \
+  --description-file <temp-file> \
+  --no-interactive
+```
+
+Write the description to a temp file first (for markdown formatting), then pass via `--description-file`.
+
+#### Description format
+
+```markdown
+## Problem
+
+What we're solving and why. 2-4 sentences max.
+
+## Solution
+
+Step-by-step outline of the approach. Precise enough that someone with no prior context
+can execute it, but not so detailed that it's pseudocode. Think "senior dev handoff."
+
+Include:
+- Key decisions and why (not just what)
+- Architecture or structural choices
+- Edge cases or gotchas worth flagging
+- Pointers to relevant files, docs, or context (full paths) so the executor can
+  quickly load what they need without re-doing the research
+
+Do NOT include a file changes list — that belongs in the implementation plan
+(sub-issues). The plan stays at the "what and why" altitude.
+```
+
+### 4. Present
+
+- Share the issue ID and link with the user
+- Show the plan summary
+- Wait for approval, feedback, or questions
+- Do **not** start executing unless explicitly told to
+
+## Guidelines
+
+- The plan issue must be **self-contained enough to hand off**. A fresh session with no context should be able to read the issue + the referenced files and understand the approach.
+- Include full file paths, not relative ones — the executor may be in a different working directory.
+- Keep the solution section at the right altitude: architectural decisions yes, line-by-line changes no.
+- If the task is trivial (< 5 minutes of work), say so and ask if the user still wants a plan or just wants it done.
+- **Ask before creating the issue** — confirm the plan content with the user first, then create.

--- a/.claude/skills/manage-linear/SKILL.md
+++ b/.claude/skills/manage-linear/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: manage-linear
+description: "Manage Linear issues, projects, cycles, initiatives, and teams via the `linear` CLI (schpet/linear-cli)"
+---
+
+# Manage Linear
+
+CLI tool: `linear` (installed via Homebrew). Authenticated and ready to use.
+
+Run `linear --help` or `linear <command> --help` for full option details — don't memorize flags, look them up.
+
+## Important: --sort flag
+
+`linear issue list` **requires** a sort: `--sort priority` or `--sort manual`. Always include it.
+
+## Core commands
+
+### Issues
+
+- **List issues:** `linear issue list --team <KEY> --sort priority [--limit N]`
+- **List all states:** add `--all-states` (default: unstarted only)
+- **Filter by state:** `--state started`, `--state backlog`, etc.
+- **All assignees:** `--all-assignees` (default: your issues only)
+- **Create issue:** `linear issue create --team <KEY> --title "..." [--description "..." | --description-file path] [--assignee self] [--priority 1-4] [--label "..."] [--project "..."] [--state "..."]`
+- **View issue:** `linear issue view <ID> [--json]`
+- **Update issue:** `linear issue update <ID> [--state "..." | --title "..." | --assignee "..." | --priority N | --label "..." | ...]`
+- **Delete issue:** `linear issue delete <ID>`
+- **Comments:** `linear issue comment add <ID>`, `linear issue comment list <ID>`
+- **Relations:** `linear issue relation add <ID> <type> <relatedID>`
+
+### Teams
+
+- **List teams:** `linear team list`
+- **Team members:** `linear team members [KEY]`
+
+### Projects
+
+- **List:** `linear project list`
+- **View:** `linear project view <ID>`
+- **Create/update/delete** — see `linear project --help`
+
+### Cycles, Milestones, Initiatives
+
+- `linear cycle list --team <KEY>`, `linear cycle view <ref>`
+- `linear milestone list --project <ID>`, `linear milestone create/update/delete`
+- `linear initiative list`, `linear initiative view/create/update/archive`
+- `linear project-update create <projectId>`, `linear initiative-update create <initId>`
+
+### Labels & Documents
+
+- `linear label list`, `linear label create`
+- `linear document list`, `linear document view <ID>`, `linear document create/update`
+
+### Raw GraphQL
+
+For anything the CLI doesn't cover: `linear api '<query>' [--variable key=value] [--paginate]`
+
+## Ayunis workspace teams
+
+| Key  | Name        |
+|------|-------------|
+| AYC  | Ayunis Core |
+| DEM  | Demo        |
+| ENG  | Engineering |
+| AYL3 | Locaboo 3   |
+| AYL4 | Locaboo 4   |
+| MGM  | Management  |
+| SAL  | Sales       |
+
+## Project mapping
+
+| Team | Project slug | Use for                     |
+|------|--------------|-----------------------------|
+| AYC  | AYC          | Ayunis Core development     |
+
+When creating issues for a mapped team, always set `--project <slug>` so issues land in the right project.
+
+## Guidelines
+
+- **Always use `--no-interactive`** on `issue create` when running non-interactively (avoids prompts).
+- **Use `--json`** on `issue view` when you need structured data to process.
+- **Issue IDs** look like `AYC-4` (team key + number).
+- **Ask before creating/updating/deleting** — treat writes with care.

--- a/.claude/skills/nestjs-hexagonal-backend/SKILL.md
+++ b/.claude/skills/nestjs-hexagonal-backend/SKILL.md
@@ -1,0 +1,134 @@
+---
+name: nestjs-hexagonal-backend
+description: Backend development with NestJS, TypeORM, and hexagonal architecture. Use when creating, modifying, or debugging backend code.
+---
+
+# NestJS Hexagonal Backend Development
+
+## Red-Green TDD Workflow
+
+Every change follows red-green TDD. Do NOT write production code without a failing test first.
+
+### Cycle
+
+1. **Red** — Write a test that captures the desired behavior. Run it. It MUST fail.
+   - If the test passes immediately, it's not testing anything new — delete it or rethink.
+2. **Green** — Write the minimum production code to make the test pass. Nothing more.
+3. **Refactor** — Clean up while keeping tests green. Run the full validation sequence.
+4. **Repeat** — Next behavior, next test.
+
+```bash
+# During each cycle:
+npm run test -- --testPathPattern=<module>   # Run focused tests (red → green)
+npm run lint && npx tsc --noEmit && npm run test  # Full validation (refactor step)
+```
+
+### What Makes a Meaningful Test
+
+- **Test behavior, not implementation** — assert on outputs and side effects, not internal method calls.
+- **One logical assertion per test** — each test proves one thing. Name it after what it proves.
+- **Use realistic data** — don't use `"test"`, `"foo"`, `"bar"`. Use domain-realistic values.
+- **Cover the edges** — happy path alone is insufficient. Test error cases, boundary values, empty inputs, duplicates.
+- **Tests are documentation** — a reader should understand the feature by reading tests alone.
+
+```typescript
+// GOOD ✓ — behavior-focused, descriptive name, realistic data
+it("should reject agent creation when name exceeds 200 characters", async () => {
+  const longName = "A".repeat(201);
+  await expect(useCase.execute({ name: longName })).rejects.toThrow(
+    AgentNameTooLongError,
+  );
+});
+
+// BAD ✗ — tests implementation, vague name, no real assertion
+it("should work", async () => {
+  const result = await useCase.execute({ name: "test" });
+  expect(result).toBeDefined();
+});
+```
+
+### Test Structure
+
+- **Use cases** — test through the public `execute()` method with stubbed ports.
+- **Domain entities** — test invariants and business rules directly.
+- **Mappers** — test round-trip: domain → record → domain preserves all fields.
+- **Controllers** — only test HTTP-specific concerns (status codes, serialization). Business logic is tested via use cases.
+
+## Validation Sequence
+
+```bash
+npm run lint                    # Must pass
+npx tsc --noEmit               # 0 type errors
+npm run test                   # All tests pass
+```
+
+## Backend-Specific TypeScript Rules
+
+- `strict: true` with `strictPropertyInitialization: false` (for TypeORM entities)
+- `noImplicitReturns: true` — every code path must return
+- Use `Logger` (from `@nestjs/common`) instead of `console.*`
+
+## Module Structure (Hexagonal)
+
+```text
+[module]/
+├── SUMMARY.md           # ← Read this first
+├── domain/              # Pure entities, no decorators
+├── application/
+│   ├── use-cases/       # Business operations
+│   ├── ports/           # Abstract interfaces
+│   └── dtos/            # Validation decorators
+├── infrastructure/
+│   └── persistence/postgres/
+│       ├── schema/      # TypeORM records
+│       ├── mappers/     # Domain ↔ Record conversion
+│       └── *.repository.ts
+├── presenters/http/     # Controllers (thin)
+└── [module].module.ts   # NestJS wiring
+```
+
+## Key Patterns
+
+### Entity IDs — Generated in domain layer, not database
+
+```typescript
+// Domain entity
+constructor(id: string | null) {
+  this.id = id ?? randomUUID();  // ID generated HERE
+}
+
+// Record uses @PrimaryColumn, NOT @PrimaryGeneratedColumn
+@PrimaryColumn('uuid')
+id: string;
+```
+
+### Errors — Domain errors, not HTTP exceptions
+
+```typescript
+// In use case
+throw new AgentNotFoundError(agentId); // Domain error
+
+// NOT
+throw new NotFoundException(); // ✗ HTTP exception
+```
+
+## Database Migrations
+
+For schema changes, use the `typeorm-migrations` skill. Never write migrations by hand — always auto-generate from entity changes.
+
+## Completion Checklist
+
+- [ ] `npm run lint` passes
+- [ ] `npx tsc --noEmit` shows 0 errors
+- [ ] `npm run test` all pass
+- [ ] No `any` types introduced
+- [ ] DTOs have validation decorators
+- [ ] New entities have proper mappers
+
+## Anti-Patterns
+
+| Don't                                                 | Why                                  | Instead                                |
+| ----------------------------------------------------- | ------------------------------------ | -------------------------------------- |
+| Test implementation details (mock internals)          | Brittle tests that break on refactor | Test inputs → outputs and side effects |
+| Use vague test names (`should work`, `handles error`) | Tests are documentation              | Name the specific behavior being proven|
+| Throw HTTP exceptions from use cases                  | Couples domain to HTTP               | Throw domain errors                    |

--- a/.claude/skills/new-page/SKILL.md
+++ b/.claude/skills/new-page/SKILL.md
@@ -1,0 +1,309 @@
+---
+name: new-page
+description: Scaffold a new frontend page in ayunis-core. Use when adding a new route with its page component following Feature-Sliced Design conventions.
+---
+
+# New Frontend Page — ayunis-core-frontend
+
+## Prerequisites
+
+- Read the `ayunis-core-frontend-dev` skill for validation sequence and FSD rules
+- Ensure the dev stack is running (`./dev up` from repo root)
+
+## Working Directory
+
+```bash
+cd ayunis-core-frontend
+```
+
+## Directory Structure
+
+Every page follows this structure:
+
+```text
+src/pages/<page-name>/
+├── ui/
+│   └── <PageName>Page.tsx       # Main page component (default export)
+├── api/                          # Optional: mutation hooks
+│   ├── useCreate<Entity>.ts
+│   ├── useUpdate<Entity>.ts
+│   └── useDelete<Entity>.ts
+├── model/                        # Optional: types, constants
+│   └── openapi.ts               # Re-exported types from generated API
+└── index.ts                      # Barrel export
+
+src/app/routes/_authenticated/
+└── <page-name>.index.tsx          # TanStack Router route file
+```
+
+## File Templates
+
+### 1. Barrel Export
+
+```typescript
+// src/pages/<page-name>/index.ts
+export { default as MyPagePage } from './ui/MyPagePage';
+```
+
+### 2. Page Component
+
+Pages compose layouts, widgets, and features. They receive data via props (from the route loader) or fetch it internally.
+
+```typescript
+// src/pages/<page-name>/ui/MyPagePage.tsx
+import AppLayout from '@/layouts/app-layout';
+import ContentAreaLayout from '@/layouts/content-area-layout/ui/ContentAreaLayout';
+import ContentAreaHeader from '@/widgets/content-area-header/ui/ContentAreaHeader';
+import { useTranslation } from 'react-i18next';
+
+interface MyPagePageProps {
+  items: Item[];
+}
+
+export default function MyPagePage({ items }: MyPagePageProps) {
+  const { t } = useTranslation('<page-name>');
+
+  return (
+    <AppLayout>
+      <ContentAreaLayout
+        contentHeader={
+          <ContentAreaHeader title={t('page.title')} />
+        }
+        contentArea={
+          <div>
+            {items.map((item) => (
+              <div key={item.id}>{item.name}</div>
+            ))}
+          </div>
+        }
+      />
+    </AppLayout>
+  );
+}
+```
+
+### 3. Route File
+
+Routes use TanStack Router's `createFileRoute`. Data fetching happens in the `loader`.
+
+```typescript
+// src/app/routes/_authenticated/<page-name>.index.tsx
+import { createFileRoute } from '@tanstack/react-router';
+import { MyPagePage } from '@/pages/<page-name>';
+import {
+  getMyEntitiesControllerFindAllQueryKey,
+  myEntitiesControllerFindAll,
+} from '@/shared/api/generated/ayunisCoreAPI';
+
+export const Route = createFileRoute('/_authenticated/<page-name>/')({
+  component: RouteComponent,
+  loader: async ({ context: { queryClient } }) => {
+    const items = await queryClient.fetchQuery({
+      queryKey: getMyEntitiesControllerFindAllQueryKey(),
+      queryFn: () => myEntitiesControllerFindAll(),
+    });
+    return { items };
+  },
+});
+
+function RouteComponent() {
+  const { items } = Route.useLoaderData();
+  return <MyPagePage items={items} />;
+}
+```
+
+For routes with URL parameters:
+
+```typescript
+// src/app/routes/_authenticated/<page-name>.$id.tsx
+import { createFileRoute } from '@tanstack/react-router';
+import { MyDetailPage } from '@/pages/<page-name>';
+import {
+  getMyEntitiesControllerFindOneQueryKey,
+  myEntitiesControllerFindOne,
+} from '@/shared/api/generated/ayunisCoreAPI';
+
+export const Route = createFileRoute('/_authenticated/<page-name>/$id')({
+  component: RouteComponent,
+  loader: async ({ params: { id }, context: { queryClient } }) => {
+    const item = await queryClient.fetchQuery({
+      queryKey: getMyEntitiesControllerFindOneQueryKey(id),
+      queryFn: () => myEntitiesControllerFindOne(id),
+    });
+    return { item };
+  },
+});
+
+function RouteComponent() {
+  const { item } = Route.useLoaderData();
+  return <MyDetailPage item={item} />;
+}
+```
+
+For routes with search params:
+
+```typescript
+// src/app/routes/_authenticated/<page-name>.tsx
+import { createFileRoute } from '@tanstack/react-router';
+import { z } from 'zod';
+import { MyPagePage } from '@/pages/<page-name>';
+
+const searchSchema = z.object({
+  filter: z.string().optional(),
+});
+
+export const Route = createFileRoute('/_authenticated/<page-name>')({
+  component: RouteComponent,
+  validateSearch: searchSchema,
+});
+
+function RouteComponent() {
+  const { filter } = Route.useSearch();
+  return <MyPagePage filter={filter} />;
+}
+```
+
+### 4. Mutation Hooks (Optional)
+
+One hook per operation. Each encapsulates a TanStack Query mutation with cache invalidation.
+
+```typescript
+// src/pages/<page-name>/api/useCreateMyEntity.ts
+import {
+  useMyEntitiesControllerCreate,
+  getMyEntitiesControllerFindAllQueryKey,
+} from '@/shared/api/generated/ayunisCoreAPI';
+import { useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import { useTranslation } from 'react-i18next';
+
+export function useCreateMyEntity(onSuccess?: () => void) {
+  const queryClient = useQueryClient();
+  const { t } = useTranslation('<page-name>');
+
+  const mutation = useMyEntitiesControllerCreate({
+    mutation: {
+      onSuccess: () => {
+        void queryClient.invalidateQueries({
+          queryKey: getMyEntitiesControllerFindAllQueryKey(),
+        });
+        toast.success(t('toast.createSuccess'));
+        onSuccess?.();
+      },
+      onError: () => {
+        toast.error(t('toast.createError'));
+      },
+    },
+  });
+
+  return {
+    createMyEntity: (data: { name: string }) =>
+      mutation.mutate({ data }),
+    isCreating: mutation.isPending,
+  };
+}
+```
+
+### 5. Model Types (Optional)
+
+Re-export types from the generated API client for cleaner imports within the page module.
+
+```typescript
+// src/pages/<page-name>/model/openapi.ts
+export type {
+  MyEntityResponseDto as MyEntity,
+} from '@/shared/api/generated/ayunisCoreAPI.schemas';
+```
+
+## Internationalization
+
+Add translation keys for the new page:
+
+```bash
+# Create translation files
+# src/shared/i18n/locales/de/<page-name>.json
+# src/shared/i18n/locales/en/<page-name>.json
+```
+
+```json
+{
+  "page": {
+    "title": "My Page"
+  },
+  "toast": {
+    "createSuccess": "Created successfully",
+    "createError": "Failed to create"
+  }
+}
+```
+
+Register the namespace in `src/shared/i18n/i18n.ts`.
+
+## FSD Import Rules
+
+Pages sit at the top of the dependency hierarchy:
+
+```text
+pages → widgets → features → shared
+```
+
+A page **can** import from:
+
+- `@/widgets/*` — Composite UI components
+- `@/features/*` — Business logic features
+- `@/shared/*` — Primitives (UI, API, lib, i18n)
+- `@/layouts/*` — Layout components
+
+A page **cannot** import from:
+
+- Other pages (`@/pages/*`) — pages are siblings, never dependencies
+- `@/app/*` — the app layer is above pages
+
+## Available Layouts
+
+| Layout | Use Case |
+|--------|----------|
+| `AppLayout` | Standard authenticated page with sidebar |
+| `ContentAreaLayout` | Page with header + scrollable content area |
+| `FullScreenMessageLayout` | Centered message (empty states, errors) |
+| `ChatInterfaceLayout` | Chat conversation layout with input area |
+
+## Scaffold Checklist
+
+1. **Create page files**:
+   - [ ] `src/pages/<page-name>/ui/<PageName>Page.tsx`
+   - [ ] `src/pages/<page-name>/index.ts`
+   - [ ] `src/app/routes/_authenticated/<page-name>.index.tsx`
+
+2. **Create translations** (if using i18n):
+   - [ ] `src/shared/i18n/locales/de/<page-name>.json`
+   - [ ] `src/shared/i18n/locales/en/<page-name>.json`
+   - [ ] Register namespace in `src/shared/i18n/i18n.ts`
+
+3. **Regenerate route tree**:
+
+   ```bash
+   npx tsr generate
+   ```
+
+   This updates `src/app/routeTree.gen.ts` automatically.
+
+4. **Validate**:
+
+   ```bash
+   npm run lint
+   npx tsc --noEmit
+   npm run build
+   ```
+
+5. **Visual check**: Navigate to the new route in the browser and verify it renders.
+
+## Reference Pages
+
+Study these existing pages as examples:
+
+- **Simple list page**: `src/pages/agents/` — list with tabs, create dialog
+- **Detail page with params**: `src/pages/agent/` — single entity view with `$id` param
+- **Search params**: `src/pages/install/` — page with search schema validation
+- **Settings sub-pages**: `src/pages/settings/` — nested layout with multiple sub-routes
+- **Data loading in route**: `src/app/routes/_authenticated/prompts.index.tsx` — loader pattern with query prefetch

--- a/.claude/skills/pr-review-comments/SKILL.md
+++ b/.claude/skills/pr-review-comments/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: pr-review-comments
+description: "Address PR review comments. Use when the user says \"check comments\", \"address comments\", \"fix PR feedback\", or similar."
+---
+
+# PR Review Comments
+
+## Context
+
+- GitHub user: **devbydaniel**
+- Relevant comment authors: `devbydaniel`, `cursor[bot]` (Bugbot)
+- Ignore automated/bot comments: Graphite stack comments, `github-actions` size warnings
+
+## Fetching Comments
+
+PR comments live in two separate API resources. Fetch both:
+
+```bash
+# 1. PR conversation comments (rare for review feedback, but check)
+gh pr view <number> --json comments --jq \
+  '.comments[] | select(.author.login == "devbydaniel" or .author.login == "cursor[bot]") | "--- \(.author.login) at \(.createdAt) ---\n\(.body)\n"'
+
+# 2. Inline review comments (where most feedback lives)
+gh api repos/{owner}/{repo}/pulls/<number>/comments --jq \
+  '.[] | select(.user.login == "devbydaniel" or .user.login == "cursor[bot]") | "--- \(.user.login) at \(.created_at) on \(.path):\(.line // .original_line) ---\n\(.body)\n"'
+```
+
+The `{owner}/{repo}` can be read from `gh repo view --json nameWithOwner --jq .nameWithOwner`.
+
+## Finding the PR
+
+If no PR number is given, use the current branch:
+
+```bash
+gh pr view --json number --jq .number
+```

--- a/.claude/skills/rebase/SKILL.md
+++ b/.claude/skills/rebase/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: rebase
+description: Rebase a branch onto another — resolve merge conflicts carefully by inspecting each conflict individually. Use when rebasing, restacking, or resolving merge conflicts.
+---
+
+# Rebase & Conflict Resolution
+
+## Golden Rule
+
+**NEVER blindly accept "ours" or "theirs" for all conflicts.** Every conflict must be inspected individually and resolved with a conscious decision based on understanding both sides.
+
+Blanket strategies like `git checkout --ours .` or `git checkout --theirs .` or scripted mass-resolution are **strictly forbidden**. They silently discard work and introduce subtle bugs.
+
+## Rebasing with Graphite
+
+This project uses Graphite (see `git-workflow` skill). Prefer Graphite commands:
+
+```bash
+# Restack the current stack onto latest main
+gt restack
+
+# If you need to rebase onto a specific branch
+gt restack --onto <branch>
+```
+
+If raw git rebase is needed (rare):
+
+```bash
+git rebase <target-branch>
+```
+
+## Resolving Conflicts — Step by Step
+
+When a rebase stops on a conflict:
+
+### 1. Identify all conflicting files
+
+```bash
+git diff --name-only --diff-filter=U
+```
+
+### 2. For EACH conflicting file, understand the context
+
+Before touching the file, understand **what both sides intended**:
+
+```bash
+# What did OUR side change in this file? (the branch being rebased)
+git log --oneline HEAD -- <file>
+git diff HEAD~1 HEAD -- <file>   # or check relevant commits
+
+# What did THEIR side change? (the target branch)
+git log --oneline REBASE_HEAD..HEAD -- <file>  # commits on target affecting this file
+```
+
+### 3. Open the file and read the conflict markers
+
+```text
+<<<<<<< HEAD
+(their version — what's on the target branch)
+=======
+(our version — what's on the branch being rebased)
+>>>>>>> <commit>
+```
+
+Read **both sides completely**. Understand the intent of each change.
+
+### 4. Make a conscious resolution decision
+
+For each conflict hunk, decide:
+
+- **Keep ours** — if our change is the correct/newer behavior
+- **Keep theirs** — if their change supersedes ours
+- **Merge both** — if both changes are needed (most common with adjacent edits)
+- **Rewrite** — if neither side is correct after the merge
+
+**State your reasoning** for non-trivial conflicts (e.g., "keeping theirs because this function was refactored on main and our change targeted the old signature").
+
+### 5. After resolving each file
+
+```bash
+git add <file>
+```
+
+### 6. After all files are resolved
+
+```bash
+git rebase --continue
+```
+
+If more conflicts arise on the next commit, repeat from step 1.
+
+## Common Conflict Patterns
+
+### Lock files (`package-lock.json`, `pnpm-lock.yaml`)
+
+Don't manually resolve. Accept either side and regenerate:
+
+```bash
+git checkout --theirs package-lock.json
+npm install
+git add package-lock.json
+```
+
+### Auto-generated files (migrations, GraphQL schema)
+
+Accept theirs (mainline version), then regenerate if our branch needs changes.
+
+### Import ordering / formatting
+
+If the only difference is formatting or import order, accept theirs and let the formatter/linter re-apply on the next commit.
+
+## What to Do When Conflicts Are Overwhelming
+
+If a rebase produces dozens of conflicts across many files:
+
+1. **Stop and assess** — `git rebase --abort` is always an option
+2. **Inform the user** — describe the scope: how many files, which areas of code
+3. **Propose a strategy** — e.g., interactive rebase to squash first, or rebase commit-by-commit
+4. **Never take shortcuts** — even if there are 50 conflicts, each one gets individual attention
+
+## Forbidden Practices
+
+- ❌ `git checkout --ours .` or `git checkout --theirs .`
+- ❌ `xargs git checkout --ours` or any scripted bulk resolution
+- ❌ Accepting all changes from one side without reading the diffs
+- ❌ Using `rerere` results without verifying they're still correct
+- ❌ Skipping conflict review because "it's just formatting"
+- ❌ Using `--strategy-option=ours` or `--strategy-option=theirs` on the entire rebase

--- a/.claude/skills/seed-database/SKILL.md
+++ b/.claude/skills/seed-database/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: seed-database
+description: Seed the local development database with fixture data (org, user, models, subscription). Use when you need test data or login credentials.
+---
+
+# Seed Database
+
+Populate the local dev database with minimal fixture data for development and testing.
+
+## Commands
+
+Run from `ayunis-core-backend/`:
+
+| Command | Description |
+|---|---|
+| `npm run seed:minimal:ts` | Upsert fixture data (idempotent — skips existing rows) |
+| `npm run seed:clean:ts` | Truncate all tables first, then seed |
+
+The `:ts` variants run from source; the non-`:ts` variants run from `dist/` (requires a build).
+
+## What Gets Seeded
+
+Defined in `src/db/fixtures/minimal.fixture.ts`:
+
+| Entity | Key values |
+|---|---|
+| **Org** | `Demo Org` |
+| **User** | `admin@demo.local` / `admin` — Admin + Super Admin, email verified |
+| **Language model** | `eu.anthropic.claude-sonnet-4-6` (Bedrock) — streaming, tools, vision |
+| **Embedding model** | `text-embedding-3-large` (OpenAI) — 1536 dimensions |
+| **Subscription** | 5 seats, €10/seat, monthly renewal |
+| **Permitted models** | Language model (default), embedding model |
+
+## Default Login Credentials
+
+```text
+Email:    admin@demo.local
+Password: admin
+```
+
+## Prerequisites
+
+The database must be running. Check with:
+
+```bash
+./dev status
+```
+
+If infrastructure isn't up, see the `dev-environment` skill.

--- a/.claude/skills/typeorm-migrations/SKILL.md
+++ b/.claude/skills/typeorm-migrations/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: typeorm-migrations
+description: Creating TypeORM database migrations. Use when schema changes are needed (new columns, tables, indexes, constraints).
+---
+
+# TypeORM Database Migrations
+
+## Golden Rule
+
+**Never write migration files by hand.** Always auto-generate them from TypeORM entity changes. Never edit a generated migration — if it's wrong, fix the entity and regenerate.
+
+## Entity Rules — The Source of Truth
+
+TypeORM entities (Records) are the **single source of truth** for the database schema. Everything must be expressed through decorators. If a constraint, index, or FK exists in the database but not in an entity decorator, TypeORM will try to drop it on the next `migration:generate`.
+
+### Relations define constraints, not loading behavior
+
+`@ManyToOne` creates a **foreign key constraint** in the database. It does NOT mean the relation is eagerly loaded — relations are lazy by default. You control loading per-query via `relations: { ... }`.
+
+**Always define `@ManyToOne` when a column references another table**, even if you never load the relation object:
+
+```typescript
+// CORRECT — column + relation = FK constraint in DB
+@Column({ name: 'integration_id', type: 'varchar' })
+integrationId: string;
+
+@ManyToOne(() => McpIntegrationRecord, { onDelete: 'CASCADE' })
+@JoinColumn({ name: 'integration_id' })
+integration: McpIntegrationRecord;
+
+// WRONG — plain column = no FK, no referential integrity
+@Column({ name: 'integration_id', type: 'varchar' })
+integrationId: string;
+```
+
+### All constraints must use decorators
+
+| DB concept | Decorator |
+|---|---|
+| Foreign key | `@ManyToOne` / `@OneToOne` + `@JoinColumn` |
+| Unique constraint (full) | `@Unique([...])` on class |
+| Unique constraint (partial) | `@Index([...], { unique: true, where: '...' })` on class |
+| Check constraint | `@Check('name', 'expression')` on class |
+| Index | `@Index()` on property or `@Index([...])` on class |
+| Enum column | `@Column({ type: 'enum', enum: MyEnum })` |
+
+**Partial unique indexes** (with `WHERE` clause) cannot use `@Unique` — use `@Index` with `unique: true` and `where` instead.
+
+If you add a value to a TypeScript enum used in `@Column({ type: 'enum' })`, you **must** generate a migration.
+
+### Never hand-write constraint names
+
+TypeORM generates deterministic constraint/index names. Hand-written names (e.g. `FK_my_custom_name`) will mismatch, causing perpetual drift.
+
+## Workflow
+
+### 1. Modify the Entity
+
+Change the record file. Extend `BaseRecord` for `id`, `createdAt`, `updatedAt`:
+
+```typescript
+@Entity('agents')
+export class AgentRecord extends BaseRecord {
+  @Column({ type: 'varchar', length: 255, nullable: true })
+  marketplaceSlug: string | null;
+}
+```
+
+### 2. Generate the Migration
+
+The dev stack must be running (`./dev status`).
+
+```bash
+npm run migration:generate:dev -- src/db/migrations/DescriptiveMigrationName
+```
+
+### 3. Review the Generated Migration
+
+- Contains **only** the expected changes (no unrelated drift)
+- `up()` and `down()` are symmetric
+- No hand-written constraint or index names
+
+If the migration contains unexpected drift, the local DB may be out of sync. Recreate it (`DROP DATABASE` + `CREATE DATABASE`), run all migrations, then regenerate.
+
+### 4. Run the Migration
+
+```bash
+npm run migration:run:dev
+```
+
+### 5. Verify Zero Drift
+
+```bash
+npm run migration:generate:dev -- src/db/migrations/VerifyNoDrift
+```
+
+This **must** print `No changes in database schema were found`. If it generates a file, entities and migrations are still out of sync — investigate before committing.
+
+### 6. Validate
+
+```bash
+npx tsc --noEmit
+npm run test
+```
+
+## Naming Convention
+
+PascalCase describing the change:
+
+| Change | Migration Name |
+|---|---|
+| Add a column | `AddMarketplaceSlugToAgents` |
+| Create a table | `CreateTeamSharesTable` |
+| Add an index | `AddIndexOnThreadCreatedAt` |
+| Remove a column | `RemoveUserShareScope` |
+| Add a constraint | `CascadeDeleteSharesOnScopeDelete` |
+
+## Anti-Patterns
+
+| Don't | Why | Instead |
+|---|---|---|
+| Write migration SQL by hand | Drift between entities and schema | Modify the entity, then auto-generate |
+| Edit a generated migration | Constraint names will mismatch | Fix the entity and regenerate |
+| Hand-write FK/index/constraint names | Perpetual drift on future generates | Let TypeORM name everything |
+| Use `@Column` for a FK without `@ManyToOne` | No FK in the database, no referential integrity | Add `@ManyToOne` + `@JoinColumn` |
+| Add enum values without a migration | DB enum won't match TypeScript enum | Generate a migration after adding values |
+| Use `@Unique` for partial constraints | Produces full constraint, not partial | Use `@Index({ unique: true, where: '...' })` |
+| Skip zero-drift verification | Entities and migrations may still be misaligned | Always verify after running |
+| Commit without running | May fail at runtime | Always `migration:run:dev` first |

--- a/.claude/skills/use-case-reference/SKILL.md
+++ b/.claude/skills/use-case-reference/SKILL.md
@@ -1,0 +1,204 @@
+---
+name: use-case-reference
+description: "Reference implementation for backend use cases — error handling, structure, and patterns. MUST be loaded when creating or modifying any *.use-case.ts file."
+---
+
+# Use Case Reference Implementation
+
+This skill defines the canonical use case structure. Every use case MUST follow this pattern.
+
+The structural rules (try/catch shape, error wrapping, single `execute()` method, repository injection via interface) are non-negotiable. Things that **vary by project** — exact import paths, auth context handling, domain model style — are marked with `// ...` placeholders and inline comments.
+
+## Structure
+
+```typescript
+import { Injectable, Logger } from '@nestjs/common';
+// ApplicationError base class — exact import path varies by project
+import { ApplicationError } from '...';
+// Module-specific errors
+import { EntityNotFoundError, UnexpectedEntityError } from '../../entity.errors';
+// Repository class — the type doubles as the DI token (no @Inject() needed)
+import { EntityRepository } from '...';
+
+interface DoSomethingCommand {
+  entityId: string;
+  // ... other command fields
+}
+
+@Injectable()
+export class DoSomethingUseCase {
+  private readonly logger = new Logger(DoSomethingUseCase.name);
+
+  constructor(
+    private readonly entityRepository: EntityRepository,
+    // ... other dependencies (other use cases, infra services, etc.)
+  ) {}
+
+  async execute(command: DoSomethingCommand): Promise<Entity> {
+    this.logger.log('Doing something', { entityId: command.entityId });
+
+    try {
+      // 1. Auth context — handling varies by project, see Rule 5 below
+
+      // 2. Precondition checks (existence, permissions, business rules)
+      // (multi-tenant projects typically pass userId here for tenant isolation)
+      const entity = await this.entityRepository.findOne(command.entityId);
+      if (!entity) {
+        throw new EntityNotFoundError(command.entityId);
+      }
+
+      // 3. Business logic — mutate, orchestrate, call other use cases / repos
+      //    (style varies: rich domain methods like entity.updateName(...), or
+      //    anemic record updates — follow your project's convention)
+
+      // 4. Persist and return
+      return await this.entityRepository.save(entity);
+
+    } catch (error) {
+      // 5. Error handling — REQUIRED in every use case
+      if (error instanceof ApplicationError) throw error;
+      this.logger.error('Error doing something', { error: error as Error });
+      throw new UnexpectedEntityError(error);
+    }
+  }
+}
+```
+
+## Rules
+
+### 1. Every `execute()` method MUST be wrapped in try/catch
+
+The catch block follows this exact pattern:
+
+```typescript
+catch (error) {
+  if (error instanceof ApplicationError) throw error;
+  this.logger.error('<descriptive context>', { error: error as Error });
+  throw new UnexpectedModuleError(error);
+}
+```
+
+- **Re-throw `ApplicationError`** subclasses as-is — these are domain errors with proper status codes
+- **Log unexpected errors** with context (what operation failed)
+- **Wrap in a module-specific `Unexpected*Error`** — never let raw errors escape
+
+### 2. Never throw HTTP exceptions from use cases
+
+```typescript
+// WRONG ✗ — couples domain to HTTP
+throw new UnauthorizedException('User not authenticated');
+throw new NotFoundException('Entity not found');
+
+// CORRECT ✓ — domain errors
+throw new UnauthorizedAccessError();
+throw new EntityNotFoundError(entityId);
+```
+
+Use cases throw `ApplicationError` subclasses. The global exception filter converts them to HTTP responses.
+
+### 3. One operation per file, one `execute()` per use case
+
+A use case is a single business operation. Don't bundle multiple operations into one class with `execute1()` / `execute2()`. If you need two operations, write two use cases.
+
+### 4. Inject repositories via the repository class — never database clients directly
+
+Use cases depend on a repository class. They MUST NOT import a database client (TypeORM, Drizzle, raw `pg`, etc.) directly. This keeps the use case testable without a real database.
+
+```ts
+constructor(
+  private readonly entityRepository: EntityRepository,
+) {}
+```
+
+Whether `EntityRepository` is an **abstract class** with a separate concrete implementation bound via `{ provide: EntityRepository, useClass: ConcreteRepository }` (port/adapter pattern), or a **single concrete class** registered directly in `providers: [EntityRepository]`, is a project-level decision — see your project's structural conventions skill. In both cases the use case constructor looks the same: TypeScript reflection picks up the class as the DI token, so **no `@Inject()` decorator is needed**.
+
+### 5. Auth context — varies by project
+
+Auth handling is a project-level convention. Common patterns:
+
+- **`ContextService` / async-local-storage**: read the current user from a request-scoped context service
+
+  ```typescript
+  const userId = this.contextService.get('userId');
+  if (!userId) throw new UnauthorizedAccessError();
+  ```
+
+- **Command parameter**: the controller (or a guard) injects `userId` into the command before calling the use case
+- **Guard + decorator**: an auth guard runs before the controller and rejects unauthenticated requests; use cases assume auth has already passed
+
+Whichever pattern your project uses, apply it consistently inside `execute()`. **Never** accept `userId` ad-hoc in some use cases and not others.
+
+### 6. Validate preconditions before mutating
+
+Always check existence and permissions before performing writes:
+
+```typescript
+// (multi-tenant projects typically pass userId for tenant isolation)
+const entity = await this.repository.findOne(id);
+if (!entity) {
+  throw new EntityNotFoundError(id);
+}
+// Only then proceed with mutation
+```
+
+### 7. Each module has its own errors file
+
+Errors live in a module-specific errors file (e.g. `application/<module>.errors.ts`):
+
+```typescript
+// ApplicationError import path varies by project
+import { ApplicationError } from '...';
+
+export enum EntityErrorCode {
+  ENTITY_NOT_FOUND = 'ENTITY_NOT_FOUND',
+  UNEXPECTED_ENTITY_ERROR = 'UNEXPECTED_ENTITY_ERROR',
+  // ... other codes
+}
+
+export abstract class EntityError extends ApplicationError {
+  constructor(message: string, code: EntityErrorCode, statusCode: number = 400) {
+    super(message, code, statusCode);
+  }
+}
+
+export class EntityNotFoundError extends EntityError {
+  constructor(entityId: string) {
+    super(`Entity with ID ${entityId} not found`, EntityErrorCode.ENTITY_NOT_FOUND, 404);
+  }
+}
+
+export class UnexpectedEntityError extends EntityError {
+  constructor(error: unknown) {
+    // If your project's `ApplicationError` accepts a metadata object as a 4th
+    // arg (some do, some don't), pass `{ error }` for context.
+    super('Unexpected error occurred', EntityErrorCode.UNEXPECTED_ENTITY_ERROR, 500);
+  }
+}
+```
+
+Every module MUST have an `Unexpected*Error` class for the catch block.
+
+### 8. Logger — use the class name, log entry and errors
+
+```typescript
+private readonly logger = new Logger(MyUseCase.name);
+
+// At the start of execute():
+this.logger.log('Descriptive action', { relevantId: command.id });
+
+// In catch block:
+this.logger.error('Error descriptive action', { error: error as Error });
+```
+
+## Checklist
+
+When creating or modifying a use case, verify:
+
+- [ ] `execute()` body is wrapped in try/catch
+- [ ] Catch block re-throws `ApplicationError`, logs and wraps everything else
+- [ ] No HTTP exceptions (`NotFoundException`, `UnauthorizedException`, etc.)
+- [ ] Auth context handled per the project's convention (Rule 5)
+- [ ] Preconditions checked before mutations (entity exists, permissions valid)
+- [ ] Repositories injected via DI token (interface), not concrete class
+- [ ] Module has an `Unexpected*Error` class in its errors file
+- [ ] Logger uses class name, logs entry point and errors

--- a/.claude/skills/worktree/SKILL.md
+++ b/.claude/skills/worktree/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: worktree
+description: Create and manage git worktrees for isolated working directories. Use when starting a new task that needs its own branch and directory.
+---
+
+# Git Worktree Management
+
+## When to Use
+
+At the start of a task, the user will tell you which environment to work in. This skill covers creating and removing worktrees — for starting the dev stack, see the `dev-environment` skill.
+
+## Creating a Worktree
+
+The user gives you a **task ID** and optionally a **branch name** (if the branch already exists).
+
+```bash
+TASK_ID="AYC-123"  # from user
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+WORKTREE_DIR="$(dirname "$REPO_ROOT")/ayunis-core-wt-${TASK_ID,,}"
+
+# New branch from HEAD:
+git worktree add "$WORKTREE_DIR" -b "feat/${TASK_ID,,}/work" HEAD
+
+# OR existing branch:
+git worktree add "$WORKTREE_DIR" "$BRANCH"
+
+# Symlink secret .env files (gitignored, not in the new worktree)
+ln -sf "$REPO_ROOT/ayunis-core-backend/.env" "$WORKTREE_DIR/ayunis-core-backend/.env"
+ln -sf "$REPO_ROOT/ayunis-core-frontend/.env" "$WORKTREE_DIR/ayunis-core-frontend/.env"
+
+# Install dependencies
+cd "$WORKTREE_DIR/ayunis-core-backend" && npm install
+cd "$WORKTREE_DIR/ayunis-core-frontend" && npm install
+```
+
+## Scenario C — Use an existing worktree
+
+The user points you to a **worktree that already exists**. Just `cd` into it and start working.
+
+```bash
+WORKTREE_DIR="/path/to/existing/worktree"  # from user
+cd "$WORKTREE_DIR"
+```
+
+## Cleanup
+
+Only tear down when the user asks you to, or when they explicitly say the task is complete. Worktrees persist across agent sessions.
+
+```bash
+# First stop the dev stack if running (see dev-environment skill)
+cd "$WORKTREE_DIR" && ./dev down
+
+# Remove the worktree (from the main repo)
+cd "$REPO_ROOT"
+git worktree remove "$WORKTREE_DIR"
+```
+
+## Branch Naming
+
+Worktree branches follow the pattern `feat/${TASK_ID,,}/work` (e.g., `feat/ayc-123/work`). This is the base branch that Graphite stacks are built on top of — see the `git-workflow` skill.

--- a/.gitignore
+++ b/.gitignore
@@ -9,8 +9,8 @@ tsconfig.?????????*.json
 .pi
 .agents/
 .pi/
-.claude/
 AGENTS.md
-CLAUDE.md
 .agentfiles
 .agentfiles.lock
+.claude/worktrees/
+.claude/**/*.local.*


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: documentation-only additions plus a small `.gitignore` tweak; no runtime code paths or build artifacts are affected aside from what gets committed/ignored.
> 
> **Overview**
> Introduces a tracked `.claude/` documentation set: a top-level `CLAUDE.md` with non-destructive agent rules and multiple `skills/*/SKILL.md` playbooks for backend/frontend/dev workflow, debugging, migrations, and Linear/Git processes.
> 
> Updates `.gitignore` to **stop ignoring the entire `.claude/` directory** (so these docs are versioned) while continuing to ignore local/worktree-specific files via `.claude/worktrees/` and `.claude/**/*.local.*`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6f2a31ff31fe48812fdb2927aa31905343747ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->