### PR TITLE
wip(image-gen): add painterly loading animation for image generation (AYC-111)

### DIFF
--- a/ayunis-core-frontend/src/pages/chat/hooks/useSnippetRotation.ts
+++ b/ayunis-core-frontend/src/pages/chat/hooks/useSnippetRotation.ts
@@ -1,0 +1,57 @@
+import { useEffect, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+interface Snippet {
+  de: string;
+  en: string;
+}
+
+function getRandomSnippetIndex(total: number, exclude?: number): number {
+  const indices = Array.from({ length: total }, (_, i) => i);
+  const available =
+    exclude !== undefined ? indices.filter((i) => i !== exclude) : indices;
+  // eslint-disable-next-line sonarjs/pseudo-random -- UI variety, not security-sensitive
+  return available[Math.floor(Math.random() * available.length)];
+}
+
+interface UseSnippetRotationOptions {
+  readonly snippets: readonly Snippet[];
+  readonly intervalMs: number;
+  readonly fadeMs: number;
+}
+
+export function useSnippetRotation({
+  snippets,
+  intervalMs,
+  fadeMs,
+}: UseSnippetRotationOptions) {
+  const { i18n } = useTranslation();
+  const [snippetIndex, setSnippetIndex] = useState(() =>
+    getRandomSnippetIndex(snippets.length),
+  );
+  const [isVisible, setIsVisible] = useState(true);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    const changeSnippet = () => {
+      setSnippetIndex((prev) => getRandomSnippetIndex(snippets.length, prev));
+      setIsVisible(true);
+    };
+
+    const interval = setInterval(() => {
+      setIsVisible(false);
+      timeoutRef.current = setTimeout(changeSnippet, fadeMs);
+    }, intervalMs);
+    return () => {
+      clearInterval(interval);
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+    };
+  }, [snippets.length, intervalMs, fadeMs]);
+
+  const snippet = snippets[snippetIndex];
+  const displayText = i18n.language === 'en' ? snippet.en : snippet.de;
+
+  return { displayText, isVisible };
+}

--- a/ayunis-core-frontend/src/pages/chat/ui/StreamingLoadingIndicator.tsx
+++ b/ayunis-core-frontend/src/pages/chat/ui/StreamingLoadingIndicator.tsx
@@ -1,14 +1,10 @@
-import { useState, useEffect, useRef } from 'react';
 import { Loader2 } from 'lucide-react';
-import { useTranslation } from 'react-i18next';
 
-interface LoadingSnippet {
-  de: string;
-  en: string;
-}
+import { cn } from '@/shared/lib/shadcn/utils';
 
-// Funny German bureaucratic loading snippets with English translations
-const loadingSnippets: LoadingSnippet[] = [
+import { useSnippetRotation } from '../hooks/useSnippetRotation';
+
+const loadingSnippets = [
   { de: 'Akten durchforsten', en: 'Sifting through files' },
   { de: 'Faxe schicken', en: 'Sending faxes' },
   { de: 'Stempel suchen', en: 'Looking for the stamp' },
@@ -39,51 +35,23 @@ const loadingSnippets: LoadingSnippet[] = [
   { de: 'Eingangsstempel setzen', en: 'Stamping the receipt date' },
   { de: 'Aktendeckel beschriften', en: 'Labeling the file cover' },
   { de: 'Hauspost verteilen', en: 'Distributing internal mail' },
-];
-
-function getRandomSnippetIndex(exclude?: number): number {
-  const indices = Array.from({ length: loadingSnippets.length }, (_, i) => i);
-  const available =
-    exclude !== undefined ? indices.filter((i) => i !== exclude) : indices;
-  // eslint-disable-next-line sonarjs/pseudo-random -- Random selection for UI variety, not security-sensitive
-  return available[Math.floor(Math.random() * available.length)];
-}
+] as const;
 
 export default function StreamingLoadingIndicator() {
-  const { i18n } = useTranslation();
-  const [snippetIndex, setSnippetIndex] = useState(() =>
-    getRandomSnippetIndex(),
-  );
-  const [isVisible, setIsVisible] = useState(true);
-  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  useEffect(() => {
-    const changeSnippet = () => {
-      setSnippetIndex((prev) => getRandomSnippetIndex(prev));
-      setIsVisible(true);
-    };
-
-    const interval = setInterval(() => {
-      // Fade out, then change snippet and fade in
-      setIsVisible(false);
-      timeoutRef.current = setTimeout(changeSnippet, 150);
-    }, 4000);
-    return () => {
-      clearInterval(interval);
-      if (timeoutRef.current) {
-        clearTimeout(timeoutRef.current);
-      }
-    };
-  }, []);
-
-  const snippet = loadingSnippets[snippetIndex];
-  const displayText = i18n.language === 'en' ? snippet.en : snippet.de;
+  const { displayText, isVisible } = useSnippetRotation({
+    snippets: loadingSnippets,
+    intervalMs: 4000,
+    fadeMs: 150,
+  });
 
   return (
     <div className="flex items-center gap-2 mt-4">
       <Loader2 className="h-4 w-4 animate-spin" />
       <span
-        className={`text-sm text-muted-foreground transition-opacity duration-150 ${isVisible ? 'opacity-100' : 'opacity-0'}`}
+        className={cn(
+          'text-sm text-muted-foreground transition-opacity duration-150',
+          isVisible ? 'opacity-100' : 'opacity-0',
+        )}
       >
         {displayText}...
       </span>

--- a/ayunis-core-frontend/src/pages/chat/ui/chat-widgets/GenerateImageWidget.tsx
+++ b/ayunis-core-frontend/src/pages/chat/ui/chat-widgets/GenerateImageWidget.tsx
@@ -2,9 +2,9 @@ import { useState } from 'react';
 import { Image as ImageIcon, Loader2 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { Dialog, DialogContent, DialogTitle } from '@/shared/ui/shadcn/dialog';
-import { cn } from '@/shared/lib/shadcn/utils';
 import { useResolveGeneratedImage } from '../../api/useResolveGeneratedImage';
 import type { ToolUseMessageContent } from '../../model/openapi';
+import ImageGenerationLoader from './ImageGenerationLoader';
 
 interface GenerateImageWidgetProps {
   readonly content: ToolUseMessageContent;
@@ -34,28 +34,7 @@ export default function GenerateImageWidget({
   const isGenerating = isStreaming || !hasIds;
 
   if (isGenerating) {
-    return (
-      <div className="my-2 w-full rounded-lg border bg-card p-4">
-        <div className="flex items-center gap-3">
-          <div
-            className={cn(
-              'flex size-10 items-center justify-center rounded-lg bg-primary/10 animate-pulse',
-            )}
-          >
-            <ImageIcon className="size-5 text-primary" />
-          </div>
-          <div className="flex-1 min-w-0">
-            <p className="text-sm font-medium truncate animate-pulse">
-              {t('chat.tools.generate_image.generating')}
-            </p>
-            {prompt && (
-              <p className="text-xs text-muted-foreground truncate">{prompt}</p>
-            )}
-          </div>
-          <Loader2 className="size-4 animate-spin text-muted-foreground" />
-        </div>
-      </div>
-    );
+    return <ImageGenerationLoader prompt={prompt} />;
   }
 
   if (isLoading) {

--- a/ayunis-core-frontend/src/pages/chat/ui/chat-widgets/ImageGenerationLoader.tsx
+++ b/ayunis-core-frontend/src/pages/chat/ui/chat-widgets/ImageGenerationLoader.tsx
@@ -1,12 +1,8 @@
-import { useEffect, useRef, useState } from 'react';
-import { useTranslation } from 'react-i18next';
+import { cn } from '@/shared/lib/shadcn/utils';
 
-interface Snippet {
-  de: string;
-  en: string;
-}
+import { useSnippetRotation } from '../../hooks/useSnippetRotation';
 
-const snippets: Snippet[] = [
+const snippets = [
   { de: 'Farben mischen', en: 'Mixing colors' },
   { de: 'Leinwand aufspannen', en: 'Stretching the canvas' },
   { de: 'Skizze anfertigen', en: 'Sketching the outline' },
@@ -25,15 +21,7 @@ const snippets: Snippet[] = [
   { de: 'Perspektive prüfen', en: 'Checking perspective' },
   { de: 'Proportionen justieren', en: 'Adjusting proportions' },
   { de: 'Firnis auftragen', en: 'Applying the varnish' },
-];
-
-function getRandomSnippetIndex(exclude?: number): number {
-  const indices = Array.from({ length: snippets.length }, (_, i) => i);
-  const available =
-    exclude !== undefined ? indices.filter((i) => i !== exclude) : indices;
-  // eslint-disable-next-line sonarjs/pseudo-random -- UI variety, not security-sensitive
-  return available[Math.floor(Math.random() * available.length)];
-}
+] as const;
 
 interface ImageGenerationLoaderProps {
   readonly prompt?: string;
@@ -42,33 +30,11 @@ interface ImageGenerationLoaderProps {
 export default function ImageGenerationLoader({
   prompt,
 }: ImageGenerationLoaderProps) {
-  const { i18n } = useTranslation();
-  const [snippetIndex, setSnippetIndex] = useState(() =>
-    getRandomSnippetIndex(),
-  );
-  const [isVisible, setIsVisible] = useState(true);
-  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  useEffect(() => {
-    const changeSnippet = () => {
-      setSnippetIndex((prev) => getRandomSnippetIndex(prev));
-      setIsVisible(true);
-    };
-
-    const interval = setInterval(() => {
-      setIsVisible(false);
-      timeoutRef.current = setTimeout(changeSnippet, 180);
-    }, 3500);
-    return () => {
-      clearInterval(interval);
-      if (timeoutRef.current) {
-        clearTimeout(timeoutRef.current);
-      }
-    };
-  }, []);
-
-  const snippet = snippets[snippetIndex];
-  const displayText = i18n.language === 'en' ? snippet.en : snippet.de;
+  const { displayText, isVisible } = useSnippetRotation({
+    snippets,
+    intervalMs: 3500,
+    fadeMs: 180,
+  });
 
   return (
     <div className="my-2 w-full max-w-md rounded-lg border bg-card p-3">
@@ -160,7 +126,10 @@ export default function ImageGenerationLoader({
 
       <div className="mt-3 px-1">
         <p
-          className={`text-sm font-medium transition-opacity duration-200 ${isVisible ? 'opacity-100' : 'opacity-0'}`}
+          className={cn(
+            'text-sm font-medium transition-opacity duration-200',
+            isVisible ? 'opacity-100' : 'opacity-0',
+          )}
         >
           {displayText}…
         </p>

--- a/ayunis-core-frontend/src/pages/chat/ui/chat-widgets/ImageGenerationLoader.tsx
+++ b/ayunis-core-frontend/src/pages/chat/ui/chat-widgets/ImageGenerationLoader.tsx
@@ -1,0 +1,175 @@
+import { useEffect, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+interface Snippet {
+  de: string;
+  en: string;
+}
+
+const snippets: Snippet[] = [
+  { de: 'Farben mischen', en: 'Mixing colors' },
+  { de: 'Leinwand aufspannen', en: 'Stretching the canvas' },
+  { de: 'Skizze anfertigen', en: 'Sketching the outline' },
+  { de: 'Komposition wählen', en: 'Choosing the composition' },
+  { de: 'Pinsel auswählen', en: 'Selecting the brush' },
+  { de: 'Pigmente anrühren', en: 'Preparing pigments' },
+  { de: 'Erste Schicht auftragen', en: 'Applying the first layer' },
+  { de: 'Glanzlichter setzen', en: 'Adding highlights' },
+  { de: 'Schatten verblenden', en: 'Blending shadows' },
+  { de: 'Feinheiten ausarbeiten', en: 'Working out the details' },
+  { de: 'Kontraste schärfen', en: 'Sharpening contrasts' },
+  { de: 'Palette abstimmen', en: 'Harmonizing the palette' },
+  { de: 'Licht komponieren', en: 'Composing the light' },
+  { de: 'Texturen rendern', en: 'Rendering textures' },
+  { de: 'Motiv einrahmen', en: 'Framing the subject' },
+  { de: 'Perspektive prüfen', en: 'Checking perspective' },
+  { de: 'Proportionen justieren', en: 'Adjusting proportions' },
+  { de: 'Firnis auftragen', en: 'Applying the varnish' },
+];
+
+function getRandomSnippetIndex(exclude?: number): number {
+  const indices = Array.from({ length: snippets.length }, (_, i) => i);
+  const available =
+    exclude !== undefined ? indices.filter((i) => i !== exclude) : indices;
+  // eslint-disable-next-line sonarjs/pseudo-random -- UI variety, not security-sensitive
+  return available[Math.floor(Math.random() * available.length)];
+}
+
+interface ImageGenerationLoaderProps {
+  readonly prompt?: string;
+}
+
+export default function ImageGenerationLoader({
+  prompt,
+}: ImageGenerationLoaderProps) {
+  const { i18n } = useTranslation();
+  const [snippetIndex, setSnippetIndex] = useState(() =>
+    getRandomSnippetIndex(),
+  );
+  const [isVisible, setIsVisible] = useState(true);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    const changeSnippet = () => {
+      setSnippetIndex((prev) => getRandomSnippetIndex(prev));
+      setIsVisible(true);
+    };
+
+    const interval = setInterval(() => {
+      setIsVisible(false);
+      timeoutRef.current = setTimeout(changeSnippet, 180);
+    }, 3500);
+    return () => {
+      clearInterval(interval);
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+    };
+  }, []);
+
+  const snippet = snippets[snippetIndex];
+  const displayText = i18n.language === 'en' ? snippet.en : snippet.de;
+
+  return (
+    <div className="my-2 w-full max-w-md rounded-lg border bg-card p-3">
+      <style>{`
+        @keyframes paint-float-a {
+          0%, 100% { transform: translate(0%, 0%) scale(1); }
+          50% { transform: translate(18%, 12%) scale(1.2); }
+        }
+        @keyframes paint-float-b {
+          0%, 100% { transform: translate(0%, 0%) scale(1.1); }
+          50% { transform: translate(-14%, 16%) scale(0.95); }
+        }
+        @keyframes paint-float-c {
+          0%, 100% { transform: translate(0%, 0%) scale(1); }
+          50% { transform: translate(14%, -12%) scale(1.2); }
+        }
+        @keyframes paint-float-d {
+          0%, 100% { transform: translate(0%, 0%) scale(1.05); }
+          50% { transform: translate(-18%, -14%) scale(0.9); }
+        }
+        @keyframes paint-shimmer {
+          0% { transform: translateX(-120%) skewX(-18deg); opacity: 0; }
+          15% { opacity: 1; }
+          85% { opacity: 1; }
+          100% { transform: translateX(260%) skewX(-18deg); opacity: 0; }
+        }
+        .paint-blob {
+          position: absolute;
+          border-radius: 9999px;
+          filter: blur(28px);
+          opacity: 0.55;
+          will-change: transform;
+        }
+      `}</style>
+
+      <div className="relative aspect-[4/3] w-full overflow-hidden rounded-md bg-gradient-to-br from-muted/40 to-muted">
+        <div
+          className="paint-blob"
+          style={{
+            width: '65%',
+            height: '65%',
+            top: '-12%',
+            left: '-12%',
+            background: '#EB9169',
+            animation: 'paint-float-a 6s ease-in-out infinite',
+          }}
+        />
+        <div
+          className="paint-blob"
+          style={{
+            width: '60%',
+            height: '60%',
+            top: '-8%',
+            right: '-12%',
+            background: '#8F81E2',
+            animation: 'paint-float-b 7s ease-in-out infinite',
+            animationDelay: '-1.2s',
+          }}
+        />
+        <div
+          className="paint-blob"
+          style={{
+            width: '60%',
+            height: '60%',
+            bottom: '-12%',
+            left: '-8%',
+            background: '#596D6B',
+            animation: 'paint-float-c 8s ease-in-out infinite',
+            animationDelay: '-2.4s',
+          }}
+        />
+        <div
+          className="paint-blob"
+          style={{
+            width: '65%',
+            height: '65%',
+            bottom: '-12%',
+            right: '-10%',
+            background: '#B5A9EB',
+            animation: 'paint-float-d 7s ease-in-out infinite',
+            animationDelay: '-3.6s',
+          }}
+        />
+        <div
+          className="pointer-events-none absolute inset-y-0 w-1/3 bg-gradient-to-r from-transparent via-white/25 to-transparent"
+          style={{ animation: 'paint-shimmer 3s ease-in-out infinite' }}
+        />
+      </div>
+
+      <div className="mt-3 px-1">
+        <p
+          className={`text-sm font-medium transition-opacity duration-200 ${isVisible ? 'opacity-100' : 'opacity-0'}`}
+        >
+          {displayText}…
+        </p>
+        {prompt && (
+          <p className="mt-0.5 truncate text-xs text-muted-foreground">
+            {prompt}
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk UI-only changes that refactor loading-snippet rotation into a shared hook and update loaders/animations, with no data or auth logic touched.
> 
> **Overview**
> Adds a reusable `useSnippetRotation` hook to centralize timed, fade-based rotation of localized (DE/EN) loading snippets.
> 
> Updates the chat `StreamingLoadingIndicator` to use this hook, and replaces the inline “generating image” placeholder in `GenerateImageWidget` with a new `ImageGenerationLoader` that shows a painterly animated preview plus rotating status text (including the prompt when present).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e639888e9ac17e015485cc86ce6d03afb6491ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->