### PR TITLE
wip(artifacts): refactor artifacts to polymorphic STI for diagram support (AYC-31)

### DIFF
--- a/ayunis-core-backend/src/db/migrations/1776519724721-AddArtifactTypeDiscriminator.ts
+++ b/ayunis-core-backend/src/db/migrations/1776519724721-AddArtifactTypeDiscriminator.ts
@@ -1,0 +1,21 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddArtifactTypeDiscriminator1776519724721 implements MigrationInterface {
+  name = 'AddArtifactTypeDiscriminator1776519724721';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "artifacts" ADD "type" character varying NOT NULL DEFAULT 'document'`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_37e60dbaec20da2fe8dd446396" ON "artifacts" ("type") `,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_37e60dbaec20da2fe8dd446396"`,
+    );
+    await queryRunner.query(`ALTER TABLE "artifacts" DROP COLUMN "type"`);
+  }
+}

--- a/ayunis-core-backend/src/domain/artifacts/application/artifacts.errors.ts
+++ b/ayunis-core-backend/src/domain/artifacts/application/artifacts.errors.ts
@@ -12,6 +12,8 @@ export enum ArtifactErrorCode {
   ARTIFACT_CONTENT_TOO_LARGE = 'ARTIFACT_CONTENT_TOO_LARGE',
   ARTIFACT_EDIT_NOT_FOUND = 'ARTIFACT_EDIT_NOT_FOUND',
   ARTIFACT_EDIT_AMBIGUOUS = 'ARTIFACT_EDIT_AMBIGUOUS',
+  ARTIFACT_LETTERHEAD_NOT_SUPPORTED = 'ARTIFACT_LETTERHEAD_NOT_SUPPORTED',
+  ARTIFACT_NOT_EXPORTABLE = 'ARTIFACT_NOT_EXPORTABLE',
   ARTIFACT_UNEXPECTED = 'ARTIFACT_UNEXPECTED',
 }
 
@@ -118,6 +120,28 @@ export class ArtifactEditAmbiguousError extends ArtifactError {
       ArtifactErrorCode.ARTIFACT_EDIT_AMBIGUOUS,
       400,
       { editIndex, ...metadata },
+    );
+  }
+}
+
+export class ArtifactLetterheadNotSupportedError extends ArtifactError {
+  constructor(artifactType: string, metadata?: ErrorMetadata) {
+    super(
+      `Letterheads are not supported for artifacts of type '${artifactType}'`,
+      ArtifactErrorCode.ARTIFACT_LETTERHEAD_NOT_SUPPORTED,
+      400,
+      { artifactType, ...metadata },
+    );
+  }
+}
+
+export class ArtifactNotExportableError extends ArtifactError {
+  constructor(artifactType: string, metadata?: ErrorMetadata) {
+    super(
+      `Artifacts of type '${artifactType}' cannot be exported server-side`,
+      ArtifactErrorCode.ARTIFACT_NOT_EXPORTABLE,
+      400,
+      { artifactType, ...metadata },
     );
   }
 }

--- a/ayunis-core-backend/src/domain/artifacts/application/use-cases/apply-edits-to-artifact/apply-edits-to-artifact.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/artifacts/application/use-cases/apply-edits-to-artifact/apply-edits-to-artifact.use-case.spec.ts
@@ -13,7 +13,7 @@ import {
   ArtifactNotFoundError,
   ARTIFACT_MAX_CONTENT_LENGTH,
 } from '../../artifacts.errors';
-import { Artifact } from '../../../domain/artifact.entity';
+import { DocumentArtifact } from '../../../domain/artifact.entity';
 import { ArtifactVersion } from '../../../domain/artifact-version.entity';
 import { AuthorType } from '../../../domain/value-objects/author-type.enum';
 import { ContextService } from 'src/common/context/services/context.service';
@@ -69,7 +69,9 @@ describe('ApplyEditsToArtifactUseCase', () => {
     updateArtifactUseCase = module.get(UpdateArtifactUseCase);
   });
 
-  function createArtifactWithVersions(currentContent: string): Artifact {
+  function createArtifactWithVersions(
+    currentContent: string,
+  ): DocumentArtifact {
     const currentVersion = new ArtifactVersion({
       artifactId: mockArtifactId,
       versionNumber: 1,
@@ -78,7 +80,7 @@ describe('ApplyEditsToArtifactUseCase', () => {
       authorId: mockUserId,
     });
 
-    return new Artifact({
+    return new DocumentArtifact({
       id: mockArtifactId,
       threadId: mockThreadId,
       userId: mockUserId,
@@ -217,7 +219,7 @@ describe('ApplyEditsToArtifactUseCase', () => {
     });
 
     it('should throw ArtifactExpectedVersionMismatchError when expected version does not match', async () => {
-      const advancedArtifact = new Artifact({
+      const advancedArtifact = new DocumentArtifact({
         id: mockArtifactId,
         threadId: mockThreadId,
         userId: mockUserId,

--- a/ayunis-core-backend/src/domain/artifacts/application/use-cases/create-artifact/create-artifact.command.ts
+++ b/ayunis-core-backend/src/domain/artifacts/application/use-cases/create-artifact/create-artifact.command.ts
@@ -1,8 +1,10 @@
 import type { UUID } from 'crypto';
 import type { AuthorType } from '../../../domain/value-objects/author-type.enum';
+import { ArtifactType } from '../../../domain/value-objects/artifact-type.enum';
 
 export class CreateArtifactCommand {
   readonly threadId: UUID;
+  readonly type: ArtifactType;
   readonly title: string;
   readonly content: string;
   readonly authorType: AuthorType;
@@ -10,12 +12,14 @@ export class CreateArtifactCommand {
 
   constructor(params: {
     threadId: UUID;
+    type?: ArtifactType;
     title: string;
     content: string;
     authorType: AuthorType;
     letterheadId?: UUID;
   }) {
     this.threadId = params.threadId;
+    this.type = params.type ?? ArtifactType.DOCUMENT;
     this.title = params.title;
     this.content = params.content;
     this.authorType = params.authorType;

--- a/ayunis-core-backend/src/domain/artifacts/application/use-cases/create-artifact/create-artifact.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/artifacts/application/use-cases/create-artifact/create-artifact.use-case.spec.ts
@@ -22,6 +22,7 @@ import {
   ArtifactContentTooLargeError,
   ARTIFACT_MAX_CONTENT_LENGTH,
 } from '../../artifacts.errors';
+import { DocumentArtifact } from '../../../domain/artifact.entity';
 
 describe('CreateArtifactUseCase', () => {
   let useCase: CreateArtifactUseCase;
@@ -101,7 +102,8 @@ describe('CreateArtifactUseCase', () => {
     expect(result.title).toBe('Quarterly Budget Report');
     expect(result.threadId).toBe(mockThreadId);
     expect(result.userId).toBe(mockUserId);
-    expect(result.letterheadId).toBeNull();
+    expect(result).toBeInstanceOf(DocumentArtifact);
+    expect((result as DocumentArtifact).letterheadId).toBeNull();
     expect(result.currentVersionNumber).toBe(1);
     expect(result.versions).toHaveLength(1);
     expect(result.versions[0].versionNumber).toBe(1);
@@ -129,7 +131,8 @@ describe('CreateArtifactUseCase', () => {
 
     const result = await useCase.execute(command);
 
-    expect(result.letterheadId).toBe(mockLetterheadId);
+    expect(result).toBeInstanceOf(DocumentArtifact);
+    expect((result as DocumentArtifact).letterheadId).toBe(mockLetterheadId);
   });
 
   it('should set authorId to userId when author type is USER', async () => {
@@ -231,7 +234,7 @@ describe('CreateArtifactUseCase', () => {
 
     const command = new CreateArtifactCommand({
       threadId: otherUserThreadId,
-      title: 'Malicious Artifact',
+      title: 'Malicious DocumentArtifact',
       content: '<p>Should not be created</p>',
       authorType: AuthorType.USER,
     });

--- a/ayunis-core-backend/src/domain/artifacts/application/use-cases/create-artifact/create-artifact.use-case.ts
+++ b/ayunis-core-backend/src/domain/artifacts/application/use-cases/create-artifact/create-artifact.use-case.ts
@@ -2,9 +2,14 @@ import { Injectable, Logger } from '@nestjs/common';
 import { Transactional } from '@nestjs-cls/transactional';
 import { ArtifactsRepository } from '../../ports/artifacts-repository.port';
 import { CreateArtifactCommand } from './create-artifact.command';
-import { Artifact } from '../../../domain/artifact.entity';
+import {
+  Artifact,
+  DiagramArtifact,
+  DocumentArtifact,
+} from '../../../domain/artifact.entity';
 import { ArtifactVersion } from '../../../domain/artifact-version.entity';
 import { AuthorType } from '../../../domain/value-objects/author-type.enum';
+import { ArtifactType } from '../../../domain/value-objects/artifact-type.enum';
 import { ContextService } from 'src/common/context/services/context.service';
 import { sanitizeHtmlContent } from '../../helpers/sanitize-html-content';
 import { FindThreadUseCase } from 'src/domain/threads/application/use-cases/find-thread/find-thread.use-case';
@@ -32,7 +37,10 @@ export class CreateArtifactUseCase {
 
   @Transactional()
   async execute(command: CreateArtifactCommand): Promise<Artifact> {
-    this.logger.log('Creating artifact', { title: command.title });
+    this.logger.log('Creating artifact', {
+      title: command.title,
+      type: command.type,
+    });
 
     try {
       const userId = this.contextService.get('userId');
@@ -51,37 +59,67 @@ export class CreateArtifactUseCase {
         new FindThreadQuery(command.threadId),
       );
 
-      if (command.letterheadId) {
+      const isDocument = command.type === ArtifactType.DOCUMENT;
+
+      if (isDocument && command.letterheadId) {
         await this.findLetterheadUseCase.execute(
           new FindLetterheadQuery({ letterheadId: command.letterheadId }),
         );
       }
 
-      const artifact = new Artifact({
-        threadId: command.threadId,
-        userId,
-        title: command.title,
-        letterheadId: command.letterheadId ?? null,
-        currentVersionNumber: 1,
-      });
+      const artifact: Artifact = isDocument
+        ? new DocumentArtifact({
+            threadId: command.threadId,
+            userId,
+            title: command.title,
+            letterheadId: command.letterheadId ?? null,
+            currentVersionNumber: 1,
+          })
+        : new DiagramArtifact({
+            threadId: command.threadId,
+            userId,
+            title: command.title,
+            currentVersionNumber: 1,
+          });
 
       const createdArtifact = await this.artifactsRepository.create(artifact);
 
-      const sanitizedContent = sanitizeHtmlContent(command.content);
+      const content = isDocument
+        ? sanitizeHtmlContent(command.content)
+        : command.content;
 
       const version = new ArtifactVersion({
         artifactId: createdArtifact.id,
         versionNumber: 1,
-        content: sanitizedContent,
+        content,
         authorType: command.authorType,
         authorId: command.authorType === AuthorType.USER ? userId : null,
       });
 
       await this.artifactsRepository.addVersion(version);
 
-      return new Artifact({
-        ...createdArtifact,
+      if (createdArtifact instanceof DocumentArtifact) {
+        return new DocumentArtifact({
+          id: createdArtifact.id,
+          threadId: createdArtifact.threadId,
+          userId: createdArtifact.userId,
+          title: createdArtifact.title,
+          letterheadId: createdArtifact.letterheadId,
+          currentVersionNumber: createdArtifact.currentVersionNumber,
+          versions: [version],
+          createdAt: createdArtifact.createdAt,
+          updatedAt: createdArtifact.updatedAt,
+        });
+      }
+      return new DiagramArtifact({
+        id: createdArtifact.id,
+        threadId: createdArtifact.threadId,
+        userId: createdArtifact.userId,
+        title: createdArtifact.title,
+        currentVersionNumber: createdArtifact.currentVersionNumber,
         versions: [version],
+        createdAt: createdArtifact.createdAt,
+        updatedAt: createdArtifact.updatedAt,
       });
     } catch (error) {
       if (error instanceof ApplicationError) {

--- a/ayunis-core-backend/src/domain/artifacts/application/use-cases/export-artifact/export-artifact.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/artifacts/application/use-cases/export-artifact/export-artifact.use-case.spec.ts
@@ -9,7 +9,7 @@ import { ExportArtifactCommand } from './export-artifact.command';
 import { ArtifactsRepository } from '../../ports/artifacts-repository.port';
 import { DocumentExportPort } from '../../ports/document-export.port';
 import { ArtifactNotFoundError } from '../../artifacts.errors';
-import { Artifact } from '../../../domain/artifact.entity';
+import { DocumentArtifact } from '../../../domain/artifact.entity';
 import { ArtifactVersion } from '../../../domain/artifact-version.entity';
 import { AuthorType } from '../../../domain/value-objects/author-type.enum';
 import { ContextService } from 'src/common/context/services/context.service';
@@ -99,8 +99,8 @@ describe('ExportArtifactUseCase', () => {
   function createArtifact(overrides?: {
     title?: string;
     letterheadId?: UUID | null;
-  }): Artifact {
-    return new Artifact({
+  }): DocumentArtifact {
+    return new DocumentArtifact({
       id: mockArtifactId,
       threadId: mockThreadId,
       userId: mockUserId,
@@ -131,7 +131,7 @@ describe('ExportArtifactUseCase', () => {
   }
 
   it('should export the current version as DOCX', async () => {
-    const artifact = new Artifact({
+    const artifact = new DocumentArtifact({
       id: mockArtifactId,
       threadId: mockThreadId,
       userId: mockUserId,

--- a/ayunis-core-backend/src/domain/artifacts/application/use-cases/export-artifact/export-artifact.use-case.ts
+++ b/ayunis-core-backend/src/domain/artifacts/application/use-cases/export-artifact/export-artifact.use-case.ts
@@ -8,9 +8,11 @@ import {
 import { ExportArtifactCommand } from './export-artifact.command';
 import {
   ArtifactNotFoundError,
+  ArtifactNotExportableError,
   ArtifactVersionNotFoundError,
   UnexpectedArtifactError,
 } from '../../artifacts.errors';
+import { DocumentArtifact } from '../../../domain/artifact.entity';
 import { ContextService } from 'src/common/context/services/context.service';
 import { ApplicationError } from 'src/common/errors/base.error';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
@@ -50,62 +52,18 @@ export class ExportArtifactUseCase {
         throw new UnauthorizedAccessError();
       }
 
-      const artifact = await this.artifactsRepository.findByIdWithVersions(
+      const artifact = await this.loadExportableArtifact(
         command.artifactId,
         userId,
       );
-      if (!artifact) {
-        throw new ArtifactNotFoundError(command.artifactId);
-      }
-
-      const currentVersion = artifact.versions.find(
-        (v) => v.versionNumber === artifact.currentVersionNumber,
-      );
-      if (!currentVersion) {
-        throw new ArtifactVersionNotFoundError(
-          command.artifactId,
-          artifact.currentVersionNumber,
-        );
-      }
-
-      const safeTitle =
-        artifact.title.replace(/[^a-zA-Z0-9-_ ]/g, '').trim() || 'artifact';
+      const currentVersion = this.requireCurrentVersion(artifact);
+      const safeTitle = this.buildSafeTitle(artifact.title);
 
       if (command.format === 'docx') {
-        const buffer = await this.documentExportPort.exportToDocx(
-          currentVersion.content,
-        );
-        return {
-          buffer,
-          fileName: `${safeTitle}.docx`,
-          mimeType:
-            'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-        };
+        return await this.exportDocx(currentVersion.content, safeTitle);
       }
 
-      const letterheadConfig = await this.resolveLetterhead(artifact);
-
-      let buffer: Buffer;
-      try {
-        buffer = await this.documentExportPort.exportToPdf(
-          currentVersion.content,
-          letterheadConfig,
-        );
-      } catch (error) {
-        if (!letterheadConfig) throw error;
-        const reason = error instanceof Error ? error.message : 'Unknown error';
-        this.logger.warn(
-          `Letterhead compositing failed, exporting without letterhead: ${reason}`,
-        );
-        buffer = await this.documentExportPort.exportToPdf(
-          currentVersion.content,
-        );
-      }
-      return {
-        buffer,
-        fileName: `${safeTitle}.pdf`,
-        mimeType: 'application/pdf',
-      };
+      return await this.exportPdf(artifact, currentVersion.content, safeTitle);
     } catch (error) {
       if (error instanceof ApplicationError) {
         throw error;
@@ -119,6 +77,81 @@ export class ExportArtifactUseCase {
         error instanceof Error ? error.message : 'Unknown error',
       );
     }
+  }
+
+  private async loadExportableArtifact(
+    artifactId: UUID,
+    userId: UUID,
+  ): Promise<DocumentArtifact> {
+    const artifact = await this.artifactsRepository.findByIdWithVersions(
+      artifactId,
+      userId,
+    );
+    if (!artifact) {
+      throw new ArtifactNotFoundError(artifactId);
+    }
+    if (!(artifact instanceof DocumentArtifact)) {
+      throw new ArtifactNotExportableError(artifact.type);
+    }
+    return artifact;
+  }
+
+  private requireCurrentVersion(artifact: DocumentArtifact) {
+    const currentVersion = artifact.versions.find(
+      (v) => v.versionNumber === artifact.currentVersionNumber,
+    );
+    if (!currentVersion) {
+      throw new ArtifactVersionNotFoundError(
+        artifact.id,
+        artifact.currentVersionNumber,
+      );
+    }
+    return currentVersion;
+  }
+
+  private buildSafeTitle(title: string): string {
+    return title.replace(/[^a-zA-Z0-9-_ ]/g, '').trim() || 'artifact';
+  }
+
+  private async exportDocx(
+    content: string,
+    safeTitle: string,
+  ): Promise<ExportResult> {
+    const buffer = await this.documentExportPort.exportToDocx(content);
+    return {
+      buffer,
+      fileName: `${safeTitle}.docx`,
+      mimeType:
+        'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+    };
+  }
+
+  private async exportPdf(
+    artifact: DocumentArtifact,
+    content: string,
+    safeTitle: string,
+  ): Promise<ExportResult> {
+    const letterheadConfig = await this.resolveLetterhead(artifact);
+
+    let buffer: Buffer;
+    try {
+      buffer = await this.documentExportPort.exportToPdf(
+        content,
+        letterheadConfig,
+      );
+    } catch (error) {
+      if (!letterheadConfig) throw error;
+      const reason = error instanceof Error ? error.message : 'Unknown error';
+      this.logger.warn(
+        `Letterhead compositing failed, exporting without letterhead: ${reason}`,
+      );
+      buffer = await this.documentExportPort.exportToPdf(content);
+    }
+    return {
+      buffer,
+      fileName: `${safeTitle}.pdf`,
+      mimeType: 'application/pdf',
+    };
   }
 
   private async resolveLetterhead(artifact: {

--- a/ayunis-core-backend/src/domain/artifacts/application/use-cases/find-artifact-with-versions/find-artifact-with-versions.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/artifacts/application/use-cases/find-artifact-with-versions/find-artifact-with-versions.use-case.spec.ts
@@ -6,7 +6,7 @@ import { FindArtifactWithVersionsUseCase } from './find-artifact-with-versions.u
 import { FindArtifactWithVersionsQuery } from './find-artifact-with-versions.query';
 import { ArtifactsRepository } from '../../ports/artifacts-repository.port';
 import { ArtifactNotFoundError } from '../../artifacts.errors';
-import { Artifact } from '../../../domain/artifact.entity';
+import { DocumentArtifact } from '../../../domain/artifact.entity';
 import { ArtifactVersion } from '../../../domain/artifact-version.entity';
 import { AuthorType } from '../../../domain/value-objects/author-type.enum';
 import { ContextService } from 'src/common/context/services/context.service';
@@ -72,7 +72,7 @@ describe('FindArtifactWithVersionsUseCase', () => {
       }),
     ];
 
-    const artifact = new Artifact({
+    const artifact = new DocumentArtifact({
       id: mockArtifactId,
       threadId: mockThreadId,
       userId: mockUserId,

--- a/ayunis-core-backend/src/domain/artifacts/application/use-cases/find-artifacts-by-thread/find-artifacts-by-thread.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/artifacts/application/use-cases/find-artifacts-by-thread/find-artifacts-by-thread.use-case.spec.ts
@@ -5,7 +5,7 @@ import type { UUID } from 'crypto';
 import { FindArtifactsByThreadUseCase } from './find-artifacts-by-thread.use-case';
 import { FindArtifactsByThreadQuery } from './find-artifacts-by-thread.query';
 import { ArtifactsRepository } from '../../ports/artifacts-repository.port';
-import { Artifact } from '../../../domain/artifact.entity';
+import { DocumentArtifact } from '../../../domain/artifact.entity';
 import { ContextService } from 'src/common/context/services/context.service';
 
 describe('FindArtifactsByThreadUseCase', () => {
@@ -53,13 +53,13 @@ describe('FindArtifactsByThreadUseCase', () => {
 
   it('should return all artifacts for a given thread scoped by userId', async () => {
     const artifacts = [
-      new Artifact({
+      new DocumentArtifact({
         threadId: mockThreadId,
         userId: mockUserId,
         title: 'Budget Report 2026',
         currentVersionNumber: 3,
       }),
-      new Artifact({
+      new DocumentArtifact({
         threadId: mockThreadId,
         userId: mockUserId,
         title: 'Meeting Minutes - February',

--- a/ayunis-core-backend/src/domain/artifacts/application/use-cases/revert-artifact/revert-artifact.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/artifacts/application/use-cases/revert-artifact/revert-artifact.use-case.spec.ts
@@ -11,7 +11,7 @@ import {
   ArtifactVersionConflictError,
   ArtifactVersionNotFoundError,
 } from '../../artifacts.errors';
-import { Artifact } from '../../../domain/artifact.entity';
+import { DocumentArtifact } from '../../../domain/artifact.entity';
 import { ArtifactVersion } from '../../../domain/artifact-version.entity';
 import { AuthorType } from '../../../domain/value-objects/author-type.enum';
 import { ContextService } from 'src/common/context/services/context.service';
@@ -99,7 +99,7 @@ describe('RevertArtifactUseCase', () => {
       }),
     ];
 
-    const artifact = new Artifact({
+    const artifact = new DocumentArtifact({
       id: mockArtifactId,
       threadId: mockThreadId,
       userId: mockUserId,
@@ -147,7 +147,7 @@ describe('RevertArtifactUseCase', () => {
       }),
     ];
 
-    const artifact = new Artifact({
+    const artifact = new DocumentArtifact({
       id: mockArtifactId,
       threadId: mockThreadId,
       userId: mockUserId,
@@ -193,7 +193,7 @@ describe('RevertArtifactUseCase', () => {
   });
 
   it('should throw ArtifactVersionNotFoundError when target version does not exist', async () => {
-    const artifact = new Artifact({
+    const artifact = new DocumentArtifact({
       id: mockArtifactId,
       threadId: mockThreadId,
       userId: mockUserId,
@@ -240,11 +240,11 @@ describe('RevertArtifactUseCase', () => {
       }),
     ];
 
-    const artifact = new Artifact({
+    const artifact = new DocumentArtifact({
       id: mockArtifactId,
       threadId: mockThreadId,
       userId: mockUserId,
-      title: 'Test Artifact',
+      title: 'Test DocumentArtifact',
       currentVersionNumber: 2,
       versions,
     });
@@ -295,7 +295,7 @@ describe('RevertArtifactUseCase', () => {
 
   describe('retry on version conflict', () => {
     it('should retry and succeed when addVersionAndUpdateArtifact fails once with conflict', async () => {
-      const artifactV2 = new Artifact({
+      const artifactV2 = new DocumentArtifact({
         id: mockArtifactId,
         threadId: mockThreadId,
         userId: mockUserId,
@@ -304,7 +304,7 @@ describe('RevertArtifactUseCase', () => {
         versions: makeVersions(2),
       });
 
-      const artifactV3 = new Artifact({
+      const artifactV3 = new DocumentArtifact({
         id: mockArtifactId,
         threadId: mockThreadId,
         userId: mockUserId,
@@ -346,7 +346,7 @@ describe('RevertArtifactUseCase', () => {
     });
 
     it('should throw ArtifactVersionConflictError after exhausting all retries', async () => {
-      const artifact = new Artifact({
+      const artifact = new DocumentArtifact({
         id: mockArtifactId,
         threadId: mockThreadId,
         userId: mockUserId,
@@ -376,7 +376,7 @@ describe('RevertArtifactUseCase', () => {
     });
 
     it('should rethrow non-conflict errors without retrying', async () => {
-      const artifact = new Artifact({
+      const artifact = new DocumentArtifact({
         id: mockArtifactId,
         threadId: mockThreadId,
         userId: mockUserId,

--- a/ayunis-core-backend/src/domain/artifacts/application/use-cases/revert-artifact/revert-artifact.use-case.ts
+++ b/ayunis-core-backend/src/domain/artifacts/application/use-cases/revert-artifact/revert-artifact.use-case.ts
@@ -8,6 +8,7 @@ import {
 } from '../../artifacts.errors';
 import { ArtifactVersion } from '../../../domain/artifact-version.entity';
 import { AuthorType } from '../../../domain/value-objects/author-type.enum';
+import { DocumentArtifact } from '../../../domain/artifact.entity';
 import { sanitizeHtmlContent } from '../../helpers/sanitize-html-content';
 import { ContextService } from 'src/common/context/services/context.service';
 import { ApplicationError } from 'src/common/errors/base.error';
@@ -58,12 +59,17 @@ export class RevertArtifactUseCase {
             );
           }
 
+          const content =
+            artifact instanceof DocumentArtifact
+              ? sanitizeHtmlContent(targetVersion.content)
+              : targetVersion.content;
+
           return {
             expectedCurrentVersionNumber: artifact.currentVersionNumber,
             version: new ArtifactVersion({
               artifactId: artifact.id,
               versionNumber: artifact.currentVersionNumber + 1,
-              content: sanitizeHtmlContent(targetVersion.content),
+              content,
               authorType: AuthorType.USER,
               authorId: userId,
             }),

--- a/ayunis-core-backend/src/domain/artifacts/application/use-cases/update-artifact/update-artifact.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/artifacts/application/use-cases/update-artifact/update-artifact.use-case.spec.ts
@@ -13,7 +13,7 @@ import {
   ArtifactVersionConflictError,
   ARTIFACT_MAX_CONTENT_LENGTH,
 } from '../../artifacts.errors';
-import { Artifact } from '../../../domain/artifact.entity';
+import { DocumentArtifact } from '../../../domain/artifact.entity';
 import type { ArtifactVersion } from '../../../domain/artifact-version.entity';
 import { AuthorType } from '../../../domain/value-objects/author-type.enum';
 import { ContextService } from 'src/common/context/services/context.service';
@@ -78,7 +78,7 @@ describe('UpdateArtifactUseCase', () => {
   });
 
   it('should add a new version with incremented version number', async () => {
-    const existingArtifact = new Artifact({
+    const existingArtifact = new DocumentArtifact({
       id: mockArtifactId,
       threadId: mockThreadId,
       userId: mockUserId,
@@ -111,7 +111,7 @@ describe('UpdateArtifactUseCase', () => {
   });
 
   it('should call addVersionAndUpdateArtifact with the new version', async () => {
-    const existingArtifact = new Artifact({
+    const existingArtifact = new DocumentArtifact({
       id: mockArtifactId,
       threadId: mockThreadId,
       userId: mockUserId,
@@ -158,7 +158,7 @@ describe('UpdateArtifactUseCase', () => {
   });
 
   it('should set authorId to null for ASSISTANT-authored versions', async () => {
-    const existingArtifact = new Artifact({
+    const existingArtifact = new DocumentArtifact({
       id: mockArtifactId,
       threadId: mockThreadId,
       userId: mockUserId,
@@ -182,7 +182,7 @@ describe('UpdateArtifactUseCase', () => {
   });
 
   it('should sanitize HTML content by stripping script tags', async () => {
-    const existingArtifact = new Artifact({
+    const existingArtifact = new DocumentArtifact({
       id: mockArtifactId,
       threadId: mockThreadId,
       userId: mockUserId,
@@ -207,7 +207,7 @@ describe('UpdateArtifactUseCase', () => {
   });
 
   it('should sanitize HTML content by stripping event handlers', async () => {
-    const existingArtifact = new Artifact({
+    const existingArtifact = new DocumentArtifact({
       id: mockArtifactId,
       threadId: mockThreadId,
       userId: mockUserId,
@@ -232,7 +232,7 @@ describe('UpdateArtifactUseCase', () => {
   });
 
   it('should preserve safe Tiptap HTML during update sanitization', async () => {
-    const existingArtifact = new Artifact({
+    const existingArtifact = new DocumentArtifact({
       id: mockArtifactId,
       threadId: mockThreadId,
       userId: mockUserId,
@@ -277,7 +277,7 @@ describe('UpdateArtifactUseCase', () => {
   it('should accept content at exactly the maximum allowed length', async () => {
     const maxContent = 'A'.repeat(ARTIFACT_MAX_CONTENT_LENGTH);
 
-    const existingArtifact = new Artifact({
+    const existingArtifact = new DocumentArtifact({
       id: mockArtifactId,
       threadId: mockThreadId,
       userId: mockUserId,
@@ -303,7 +303,7 @@ describe('UpdateArtifactUseCase', () => {
   it('should pass letterheadId to the atomic artifact update when provided in command', async () => {
     const mockLetterheadId = '423e4567-e89b-12d3-a456-426614174000' as UUID;
 
-    const existingArtifact = new Artifact({
+    const existingArtifact = new DocumentArtifact({
       id: mockArtifactId,
       threadId: mockThreadId,
       userId: mockUserId,
@@ -340,7 +340,7 @@ describe('UpdateArtifactUseCase', () => {
   });
 
   it('should leave letterheadId unchanged when not provided in command', async () => {
-    const existingArtifact = new Artifact({
+    const existingArtifact = new DocumentArtifact({
       id: mockArtifactId,
       threadId: mockThreadId,
       userId: mockUserId,
@@ -372,7 +372,7 @@ describe('UpdateArtifactUseCase', () => {
   });
 
   it('should pass letterheadId as null to remove letterhead atomically', async () => {
-    const existingArtifact = new Artifact({
+    const existingArtifact = new DocumentArtifact({
       id: mockArtifactId,
       threadId: mockThreadId,
       userId: mockUserId,
@@ -439,7 +439,7 @@ describe('UpdateArtifactUseCase', () => {
 
   describe('expected version check', () => {
     it('should throw ArtifactExpectedVersionMismatchError when expected version does not match', async () => {
-      const existingArtifact = new Artifact({
+      const existingArtifact = new DocumentArtifact({
         id: mockArtifactId,
         threadId: mockThreadId,
         userId: mockUserId,
@@ -462,7 +462,7 @@ describe('UpdateArtifactUseCase', () => {
     });
 
     it('should succeed when expected version matches current version', async () => {
-      const existingArtifact = new Artifact({
+      const existingArtifact = new DocumentArtifact({
         id: mockArtifactId,
         threadId: mockThreadId,
         userId: mockUserId,
@@ -488,7 +488,7 @@ describe('UpdateArtifactUseCase', () => {
     });
 
     it('should skip version check when expectedVersionNumber is not provided', async () => {
-      const existingArtifact = new Artifact({
+      const existingArtifact = new DocumentArtifact({
         id: mockArtifactId,
         threadId: mockThreadId,
         userId: mockUserId,
@@ -516,7 +516,7 @@ describe('UpdateArtifactUseCase', () => {
   it('should update only letterheadId without creating a new version when no content is provided', async () => {
     const mockLetterheadId = '423e4567-e89b-12d3-a456-426614174000' as UUID;
 
-    const existingArtifact = new Artifact({
+    const existingArtifact = new DocumentArtifact({
       id: mockArtifactId,
       threadId: mockThreadId,
       userId: mockUserId,
@@ -593,7 +593,7 @@ describe('UpdateArtifactUseCase', () => {
   it('should validate letterheadId belongs to org before updating', async () => {
     const mockLetterheadId = '423e4567-e89b-12d3-a456-426614174000' as UUID;
 
-    const existingArtifact = new Artifact({
+    const existingArtifact = new DocumentArtifact({
       id: mockArtifactId,
       threadId: mockThreadId,
       userId: mockUserId,
@@ -622,7 +622,7 @@ describe('UpdateArtifactUseCase', () => {
 
   describe('retry on version conflict', () => {
     it('should retry and succeed when addVersionAndUpdateArtifact fails once with conflict', async () => {
-      const artifactV2 = new Artifact({
+      const artifactV2 = new DocumentArtifact({
         id: mockArtifactId,
         threadId: mockThreadId,
         userId: mockUserId,
@@ -630,7 +630,7 @@ describe('UpdateArtifactUseCase', () => {
         currentVersionNumber: 2,
       });
 
-      const artifactV3 = new Artifact({
+      const artifactV3 = new DocumentArtifact({
         id: mockArtifactId,
         threadId: mockThreadId,
         userId: mockUserId,
@@ -664,7 +664,7 @@ describe('UpdateArtifactUseCase', () => {
     });
 
     it('should throw ArtifactVersionConflictError after exhausting all retries', async () => {
-      const artifact = new Artifact({
+      const artifact = new DocumentArtifact({
         id: mockArtifactId,
         threadId: mockThreadId,
         userId: mockUserId,
@@ -695,7 +695,7 @@ describe('UpdateArtifactUseCase', () => {
     });
 
     it('should rethrow non-conflict errors without retrying', async () => {
-      const artifact = new Artifact({
+      const artifact = new DocumentArtifact({
         id: mockArtifactId,
         threadId: mockThreadId,
         userId: mockUserId,

--- a/ayunis-core-backend/src/domain/artifacts/application/use-cases/update-artifact/update-artifact.use-case.ts
+++ b/ayunis-core-backend/src/domain/artifacts/application/use-cases/update-artifact/update-artifact.use-case.ts
@@ -1,3 +1,4 @@
+import type { UUID } from 'crypto';
 import { Injectable, Logger } from '@nestjs/common';
 import { ArtifactsRepository } from '../../ports/artifacts-repository.port';
 import { UpdateArtifactCommand } from './update-artifact.command';
@@ -5,11 +6,13 @@ import {
   ArtifactContentTooLargeError,
   ArtifactExpectedVersionMismatchError,
   ArtifactNotFoundError,
+  ArtifactLetterheadNotSupportedError,
   UnexpectedArtifactError,
   ARTIFACT_MAX_CONTENT_LENGTH,
 } from '../../artifacts.errors';
 import { ArtifactVersion } from '../../../domain/artifact-version.entity';
 import { AuthorType } from '../../../domain/value-objects/author-type.enum';
+import { Artifact, DocumentArtifact } from '../../../domain/artifact.entity';
 import { ContextService } from 'src/common/context/services/context.service';
 import { sanitizeHtmlContent } from '../../helpers/sanitize-html-content';
 import { ApplicationError } from 'src/common/errors/base.error';
@@ -34,21 +37,8 @@ export class UpdateArtifactUseCase {
     this.logger.log('Updating artifact', { artifactId: command.artifactId });
 
     try {
-      const userId = this.contextService.get('userId');
-      if (!userId) {
-        throw new UnauthorizedAccessError();
-      }
-
-      // Validate content length early before any DB calls
-      if (
-        command.content !== undefined &&
-        command.content.length > ARTIFACT_MAX_CONTENT_LENGTH
-      ) {
-        throw new ArtifactContentTooLargeError(
-          command.content.length,
-          ARTIFACT_MAX_CONTENT_LENGTH,
-        );
-      }
+      const userId = this.resolveUserId();
+      this.validateContentLength(command.content);
 
       if (command.letterheadId) {
         await this.findLetterheadUseCase.execute(
@@ -56,7 +46,6 @@ export class UpdateArtifactUseCase {
         );
       }
 
-      // Verify ownership before any mutation
       const artifact = await this.artifactsRepository.findById(
         command.artifactId,
         userId,
@@ -65,58 +54,14 @@ export class UpdateArtifactUseCase {
         throw new ArtifactNotFoundError(command.artifactId);
       }
 
-      // When no content is provided, update only the letterhead — no new version needed
-      if (command.content === undefined) {
-        if (command.letterheadId !== undefined) {
-          await this.artifactsRepository.updateLetterheadId(
-            command.artifactId,
-            command.letterheadId,
-          );
-        }
+      const isDocument = artifact instanceof DocumentArtifact;
+      this.assertLetterheadAllowed(command, artifact, isDocument);
 
-        return;
+      if (command.content === undefined) {
+        return await this.updateLetterheadOnly(command);
       }
 
-      const sanitizedContent = sanitizeHtmlContent(command.content);
-      const authorType = command.authorType ?? AuthorType.USER;
-
-      return await addVersionWithRetry({
-        repository: this.artifactsRepository,
-        logger: this.logger,
-        artifactId: command.artifactId,
-        buildVersion: async () => {
-          const freshArtifact = await this.artifactsRepository.findById(
-            command.artifactId,
-            userId,
-          );
-          if (!freshArtifact) {
-            throw new ArtifactNotFoundError(command.artifactId);
-          }
-
-          if (
-            command.expectedVersionNumber !== undefined &&
-            command.expectedVersionNumber !== freshArtifact.currentVersionNumber
-          ) {
-            throw new ArtifactExpectedVersionMismatchError(
-              command.artifactId,
-              command.expectedVersionNumber,
-              freshArtifact.currentVersionNumber,
-            );
-          }
-
-          return {
-            expectedCurrentVersionNumber: freshArtifact.currentVersionNumber,
-            letterheadId: command.letterheadId,
-            version: new ArtifactVersion({
-              artifactId: freshArtifact.id,
-              versionNumber: freshArtifact.currentVersionNumber + 1,
-              content: sanitizedContent,
-              authorType,
-              authorId: authorType === AuthorType.USER ? userId : null,
-            }),
-          };
-        },
-      });
+      return await this.addContentVersion(command, userId, isDocument);
     } catch (error) {
       if (error instanceof ApplicationError) {
         throw error;
@@ -130,5 +75,92 @@ export class UpdateArtifactUseCase {
         error instanceof Error ? error.message : 'Unknown error',
       );
     }
+  }
+
+  private resolveUserId(): UUID {
+    const userId = this.contextService.get('userId');
+    if (!userId) {
+      throw new UnauthorizedAccessError();
+    }
+    return userId;
+  }
+
+  private validateContentLength(content: string | undefined): void {
+    if (content !== undefined && content.length > ARTIFACT_MAX_CONTENT_LENGTH) {
+      throw new ArtifactContentTooLargeError(
+        content.length,
+        ARTIFACT_MAX_CONTENT_LENGTH,
+      );
+    }
+  }
+
+  private assertLetterheadAllowed(
+    command: UpdateArtifactCommand,
+    artifact: Artifact,
+    isDocument: boolean,
+  ): void {
+    if (command.letterheadId !== undefined && !isDocument) {
+      throw new ArtifactLetterheadNotSupportedError(artifact.type);
+    }
+  }
+
+  private async updateLetterheadOnly(
+    command: UpdateArtifactCommand,
+  ): Promise<void> {
+    if (command.letterheadId !== undefined) {
+      await this.artifactsRepository.updateLetterheadId(
+        command.artifactId,
+        command.letterheadId,
+      );
+    }
+  }
+
+  private async addContentVersion(
+    command: UpdateArtifactCommand,
+    userId: UUID,
+    isDocument: boolean,
+  ): Promise<ArtifactVersion> {
+    const content = isDocument
+      ? sanitizeHtmlContent(command.content!)
+      : command.content!;
+    const authorType = command.authorType ?? AuthorType.USER;
+
+    return addVersionWithRetry({
+      repository: this.artifactsRepository,
+      logger: this.logger,
+      artifactId: command.artifactId,
+      buildVersion: async () => {
+        const freshArtifact = await this.artifactsRepository.findById(
+          command.artifactId,
+          userId,
+        );
+        if (!freshArtifact) {
+          throw new ArtifactNotFoundError(command.artifactId);
+        }
+
+        if (
+          command.expectedVersionNumber !== undefined &&
+          command.expectedVersionNumber !== freshArtifact.currentVersionNumber
+        ) {
+          throw new ArtifactExpectedVersionMismatchError(
+            command.artifactId,
+            command.expectedVersionNumber,
+            freshArtifact.currentVersionNumber,
+          );
+        }
+
+        return {
+          expectedCurrentVersionNumber: freshArtifact.currentVersionNumber,
+          letterheadId: command.letterheadId,
+          version: new ArtifactVersion({
+            artifactId: freshArtifact.id,
+            versionNumber: freshArtifact.currentVersionNumber + 1,
+            content,
+            authorType,
+            authorId: authorType === AuthorType.USER ? userId : null,
+          }),
+        };
+      },
+    });
   }
 }

--- a/ayunis-core-backend/src/domain/artifacts/domain/artifact.entity.ts
+++ b/ayunis-core-backend/src/domain/artifacts/domain/artifact.entity.ts
@@ -1,17 +1,44 @@
 import type { UUID } from 'crypto';
 import { randomUUID } from 'crypto';
 import type { ArtifactVersion } from './artifact-version.entity';
+import { ArtifactType } from './value-objects/artifact-type.enum';
 
-export class Artifact {
+export abstract class Artifact {
   public readonly id: UUID;
+  public readonly type: ArtifactType;
   public readonly threadId: UUID;
   public readonly userId: UUID;
   public readonly title: string;
-  public readonly letterheadId: UUID | null;
   public readonly currentVersionNumber: number;
   public readonly versions: ArtifactVersion[];
   public readonly createdAt: Date;
   public readonly updatedAt: Date;
+
+  protected constructor(params: {
+    id?: UUID;
+    type: ArtifactType;
+    threadId: UUID;
+    userId: UUID;
+    title: string;
+    currentVersionNumber?: number;
+    versions?: ArtifactVersion[];
+    createdAt?: Date;
+    updatedAt?: Date;
+  }) {
+    this.id = params.id ?? randomUUID();
+    this.type = params.type;
+    this.threadId = params.threadId;
+    this.userId = params.userId;
+    this.title = params.title;
+    this.currentVersionNumber = params.currentVersionNumber ?? 1;
+    this.versions = params.versions ?? [];
+    this.createdAt = params.createdAt ?? new Date();
+    this.updatedAt = params.updatedAt ?? new Date();
+  }
+}
+
+export class DocumentArtifact extends Artifact {
+  public readonly letterheadId: UUID | null;
 
   constructor(params: {
     id?: UUID;
@@ -24,14 +51,22 @@ export class Artifact {
     createdAt?: Date;
     updatedAt?: Date;
   }) {
-    this.id = params.id ?? randomUUID();
-    this.threadId = params.threadId;
-    this.userId = params.userId;
-    this.title = params.title;
+    super({ ...params, type: ArtifactType.DOCUMENT });
     this.letterheadId = params.letterheadId ?? null;
-    this.currentVersionNumber = params.currentVersionNumber ?? 1;
-    this.versions = params.versions ?? [];
-    this.createdAt = params.createdAt ?? new Date();
-    this.updatedAt = params.updatedAt ?? new Date();
+  }
+}
+
+export class DiagramArtifact extends Artifact {
+  constructor(params: {
+    id?: UUID;
+    threadId: UUID;
+    userId: UUID;
+    title: string;
+    currentVersionNumber?: number;
+    versions?: ArtifactVersion[];
+    createdAt?: Date;
+    updatedAt?: Date;
+  }) {
+    super({ ...params, type: ArtifactType.DIAGRAM });
   }
 }

--- a/ayunis-core-backend/src/domain/artifacts/domain/value-objects/artifact-type.enum.ts
+++ b/ayunis-core-backend/src/domain/artifacts/domain/value-objects/artifact-type.enum.ts
@@ -1,0 +1,4 @@
+export enum ArtifactType {
+  DOCUMENT = 'document',
+  DIAGRAM = 'diagram',
+}

--- a/ayunis-core-backend/src/domain/artifacts/infrastructure/persistence/local/local-artifacts-repository.module.ts
+++ b/ayunis-core-backend/src/domain/artifacts/infrastructure/persistence/local/local-artifacts-repository.module.ts
@@ -1,13 +1,22 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { ArtifactRecord } from './schema/artifact.record';
+import { DocumentArtifactRecord } from './schema/document-artifact.record';
+import { DiagramArtifactRecord } from './schema/diagram-artifact.record';
 import { ArtifactVersionRecord } from './schema/artifact-version.record';
 import { LocalArtifactsRepository } from './local-artifacts.repository';
 import { ArtifactMapper } from './mappers/artifact.mapper';
 import { ArtifactVersionMapper } from './mappers/artifact-version.mapper';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([ArtifactRecord, ArtifactVersionRecord])],
+  imports: [
+    TypeOrmModule.forFeature([
+      ArtifactRecord,
+      DocumentArtifactRecord,
+      DiagramArtifactRecord,
+      ArtifactVersionRecord,
+    ]),
+  ],
   providers: [LocalArtifactsRepository, ArtifactMapper, ArtifactVersionMapper],
   exports: [LocalArtifactsRepository],
 })

--- a/ayunis-core-backend/src/domain/artifacts/infrastructure/persistence/local/local-artifacts.repository.ts
+++ b/ayunis-core-backend/src/domain/artifacts/infrastructure/persistence/local/local-artifacts.repository.ts
@@ -9,6 +9,7 @@ import { ArtifactVersionConflictError } from '../../../application/artifacts.err
 import { Artifact } from '../../../domain/artifact.entity';
 import { ArtifactVersion } from '../../../domain/artifact-version.entity';
 import { ArtifactRecord } from './schema/artifact.record';
+import { DocumentArtifactRecord } from './schema/document-artifact.record';
 import { ArtifactVersionRecord } from './schema/artifact-version.record';
 import { ArtifactMapper } from './mappers/artifact.mapper';
 import { ArtifactVersionMapper } from './mappers/artifact-version.mapper';
@@ -21,6 +22,8 @@ export class LocalArtifactsRepository extends ArtifactsRepository {
   constructor(
     @InjectRepository(ArtifactRecord)
     private readonly artifactRepo: Repository<ArtifactRecord>,
+    @InjectRepository(DocumentArtifactRecord)
+    private readonly documentArtifactRepo: Repository<DocumentArtifactRecord>,
     @InjectRepository(ArtifactVersionRecord)
     private readonly versionRepo: Repository<ArtifactVersionRecord>,
     private readonly artifactMapper: ArtifactMapper,
@@ -30,7 +33,11 @@ export class LocalArtifactsRepository extends ArtifactsRepository {
   }
 
   async create(artifact: Artifact): Promise<Artifact> {
-    this.logger.log('create', { id: artifact.id, title: artifact.title });
+    this.logger.log('create', {
+      id: artifact.id,
+      title: artifact.title,
+      type: artifact.type,
+    });
     const record = this.artifactMapper.toRecord(artifact);
     const saved = await this.artifactRepo.save(record);
     return this.artifactMapper.toDomain(saved);
@@ -84,7 +91,7 @@ export class LocalArtifactsRepository extends ArtifactsRepository {
     artifactId: UUID,
     letterheadId: UUID | null,
   ): Promise<void> {
-    await this.artifactRepo.update(
+    await this.documentArtifactRepo.update(
       { id: artifactId },
       { letterheadId, updatedAt: new Date() },
     );
@@ -122,7 +129,7 @@ export class LocalArtifactsRepository extends ArtifactsRepository {
                 updatedAt: new Date(),
               },
             )
-          : await this.artifactRepo.update(
+          : await this.documentArtifactRepo.update(
               {
                 id: version.artifactId,
                 currentVersionNumber: expectedCurrentVersionNumber,

--- a/ayunis-core-backend/src/domain/artifacts/infrastructure/persistence/local/mappers/artifact.mapper.spec.ts
+++ b/ayunis-core-backend/src/domain/artifacts/infrastructure/persistence/local/mappers/artifact.mapper.spec.ts
@@ -1,9 +1,9 @@
 import { randomUUID } from 'crypto';
 import { ArtifactMapper } from './artifact.mapper';
 import { ArtifactVersionMapper } from './artifact-version.mapper';
-import { Artifact } from '../../../../domain/artifact.entity';
+import { DocumentArtifact } from '../../../../domain/artifact.entity';
 import { ArtifactVersion } from '../../../../domain/artifact-version.entity';
-import { ArtifactRecord } from '../schema/artifact.record';
+import { DocumentArtifactRecord } from '../schema/document-artifact.record';
 import { ArtifactVersionRecord } from '../schema/artifact-version.record';
 import { AuthorType } from '../../../../domain/value-objects/author-type.enum';
 
@@ -24,7 +24,7 @@ describe('ArtifactMapper', () => {
 
   describe('toDomain', () => {
     it('should map a record without versions to a domain entity', () => {
-      const record = new ArtifactRecord();
+      const record = new DocumentArtifactRecord();
       record.id = artifactId;
       record.threadId = threadId;
       record.userId = userId;
@@ -36,7 +36,7 @@ describe('ArtifactMapper', () => {
 
       const domain = mapper.toDomain(record);
 
-      expect(domain).toBeInstanceOf(Artifact);
+      expect(domain).toBeInstanceOf(DocumentArtifact);
       expect(domain.id).toBe(artifactId);
       expect(domain.threadId).toBe(threadId);
       expect(domain.userId).toBe(userId);
@@ -48,7 +48,7 @@ describe('ArtifactMapper', () => {
     });
 
     it('should map a record with letterheadId to a domain entity', () => {
-      const record = new ArtifactRecord();
+      const record = new DocumentArtifactRecord();
       record.id = artifactId;
       record.threadId = threadId;
       record.userId = userId;
@@ -73,7 +73,7 @@ describe('ArtifactMapper', () => {
       versionRecord.authorId = null;
       versionRecord.createdAt = now;
 
-      const record = new ArtifactRecord();
+      const record = new DocumentArtifactRecord();
       record.id = artifactId;
       record.threadId = threadId;
       record.userId = userId;
@@ -94,7 +94,7 @@ describe('ArtifactMapper', () => {
 
   describe('toRecord', () => {
     it('should map a domain entity to a record', () => {
-      const domain = new Artifact({
+      const domain = new DocumentArtifact({
         id: artifactId,
         threadId,
         userId,
@@ -106,7 +106,7 @@ describe('ArtifactMapper', () => {
 
       const record = mapper.toRecord(domain);
 
-      expect(record).toBeInstanceOf(ArtifactRecord);
+      expect(record).toBeInstanceOf(DocumentArtifactRecord);
       expect(record.id).toBe(artifactId);
       expect(record.threadId).toBe(threadId);
       expect(record.userId).toBe(userId);
@@ -116,7 +116,7 @@ describe('ArtifactMapper', () => {
     });
 
     it('should map a domain entity with letterheadId to a record', () => {
-      const domain = new Artifact({
+      const domain = new DocumentArtifact({
         id: artifactId,
         threadId,
         userId,
@@ -144,7 +144,7 @@ describe('ArtifactMapper', () => {
         createdAt: now,
       });
 
-      const original = new Artifact({
+      const original = new DocumentArtifact({
         id: artifactId,
         threadId,
         userId,

--- a/ayunis-core-backend/src/domain/artifacts/infrastructure/persistence/local/mappers/artifact.mapper.ts
+++ b/ayunis-core-backend/src/domain/artifacts/infrastructure/persistence/local/mappers/artifact.mapper.ts
@@ -1,37 +1,79 @@
 import { Injectable } from '@nestjs/common';
-import { Artifact } from '../../../../domain/artifact.entity';
+import {
+  Artifact,
+  DiagramArtifact,
+  DocumentArtifact,
+} from '../../../../domain/artifact.entity';
 import { ArtifactRecord } from '../schema/artifact.record';
+import { DocumentArtifactRecord } from '../schema/document-artifact.record';
+import { DiagramArtifactRecord } from '../schema/diagram-artifact.record';
 import { ArtifactVersionMapper } from './artifact-version.mapper';
 
 @Injectable()
 export class ArtifactMapper {
   constructor(private readonly versionMapper: ArtifactVersionMapper) {}
 
+  toDomain(record: DocumentArtifactRecord): DocumentArtifact;
+  toDomain(record: DiagramArtifactRecord): DiagramArtifact;
+  toDomain(record: ArtifactRecord): Artifact;
   toDomain(record: ArtifactRecord): Artifact {
-    return new Artifact({
-      id: record.id,
-      threadId: record.threadId,
-      userId: record.userId,
-      title: record.title,
-      letterheadId: record.letterheadId,
-      currentVersionNumber: record.currentVersionNumber,
-      versions: record.versions?.map((v) => this.versionMapper.toDomain(v)),
-      createdAt: record.createdAt,
-      updatedAt: record.updatedAt,
-    });
+    if (record instanceof DocumentArtifactRecord) {
+      return new DocumentArtifact({
+        id: record.id,
+        threadId: record.threadId,
+        userId: record.userId,
+        title: record.title,
+        letterheadId: record.letterheadId,
+        currentVersionNumber: record.currentVersionNumber,
+        versions: record.versions?.map((v) => this.versionMapper.toDomain(v)),
+        createdAt: record.createdAt,
+        updatedAt: record.updatedAt,
+      });
+    }
+    if (record instanceof DiagramArtifactRecord) {
+      return new DiagramArtifact({
+        id: record.id,
+        threadId: record.threadId,
+        userId: record.userId,
+        title: record.title,
+        currentVersionNumber: record.currentVersionNumber,
+        versions: record.versions?.map((v) => this.versionMapper.toDomain(v)),
+        createdAt: record.createdAt,
+        updatedAt: record.updatedAt,
+      });
+    }
+    throw new Error('Invalid artifact record type');
   }
 
+  toRecord(domain: DocumentArtifact): DocumentArtifactRecord;
+  toRecord(domain: DiagramArtifact): DiagramArtifactRecord;
+  toRecord(domain: Artifact): ArtifactRecord;
   toRecord(domain: Artifact): ArtifactRecord {
-    const record = new ArtifactRecord();
-    record.id = domain.id;
-    record.threadId = domain.threadId;
-    record.userId = domain.userId;
-    record.title = domain.title;
-    record.letterheadId = domain.letterheadId;
-    record.currentVersionNumber = domain.currentVersionNumber;
-    record.versions = domain.versions?.map((v) =>
-      this.versionMapper.toRecord(v),
-    );
-    return record;
+    if (domain instanceof DocumentArtifact) {
+      const record = new DocumentArtifactRecord();
+      record.id = domain.id;
+      record.threadId = domain.threadId;
+      record.userId = domain.userId;
+      record.title = domain.title;
+      record.letterheadId = domain.letterheadId;
+      record.currentVersionNumber = domain.currentVersionNumber;
+      record.versions = domain.versions.map((v) =>
+        this.versionMapper.toRecord(v),
+      );
+      return record;
+    }
+    if (domain instanceof DiagramArtifact) {
+      const record = new DiagramArtifactRecord();
+      record.id = domain.id;
+      record.threadId = domain.threadId;
+      record.userId = domain.userId;
+      record.title = domain.title;
+      record.currentVersionNumber = domain.currentVersionNumber;
+      record.versions = domain.versions.map((v) =>
+        this.versionMapper.toRecord(v),
+      );
+      return record;
+    }
+    throw new Error('Invalid artifact domain type');
   }
 }

--- a/ayunis-core-backend/src/domain/artifacts/infrastructure/persistence/local/schema/artifact.record.ts
+++ b/ayunis-core-backend/src/domain/artifacts/infrastructure/persistence/local/schema/artifact.record.ts
@@ -1,12 +1,22 @@
-import { Column, Entity, Index, ManyToOne, OneToMany } from 'typeorm';
+import {
+  Column,
+  Entity,
+  Index,
+  ManyToOne,
+  OneToMany,
+  TableInheritance,
+} from 'typeorm';
 import { UUID } from 'crypto';
 import { BaseRecord } from '../../../../../../common/db/base-record';
 import { ArtifactVersionRecord } from './artifact-version.record';
 import { ThreadRecord } from '../../../../../threads/infrastructure/persistence/local/schema/thread.record';
-import { LetterheadRecord } from '../../../../../letterheads/infrastructure/persistence/local/schema/letterhead.record';
+import { ArtifactType } from '../../../../domain/value-objects/artifact-type.enum';
 
 @Entity({ name: 'artifacts' })
-export class ArtifactRecord extends BaseRecord {
+@TableInheritance({
+  column: { type: 'varchar', name: 'type', default: ArtifactType.DOCUMENT },
+})
+export abstract class ArtifactRecord extends BaseRecord {
   @Column()
   @Index()
   threadId: UUID;
@@ -20,13 +30,6 @@ export class ArtifactRecord extends BaseRecord {
 
   @Column()
   title: string;
-
-  @Column({ nullable: true })
-  @Index()
-  letterheadId: UUID | null;
-
-  @ManyToOne(() => LetterheadRecord, { onDelete: 'SET NULL', nullable: true })
-  letterhead: LetterheadRecord | null;
 
   @Column({ default: 1 })
   currentVersionNumber: number;

--- a/ayunis-core-backend/src/domain/artifacts/infrastructure/persistence/local/schema/diagram-artifact.record.ts
+++ b/ayunis-core-backend/src/domain/artifacts/infrastructure/persistence/local/schema/diagram-artifact.record.ts
@@ -1,0 +1,6 @@
+import { ChildEntity } from 'typeorm';
+import { ArtifactRecord } from './artifact.record';
+import { ArtifactType } from '../../../../domain/value-objects/artifact-type.enum';
+
+@ChildEntity(ArtifactType.DIAGRAM)
+export class DiagramArtifactRecord extends ArtifactRecord {}

--- a/ayunis-core-backend/src/domain/artifacts/infrastructure/persistence/local/schema/document-artifact.record.ts
+++ b/ayunis-core-backend/src/domain/artifacts/infrastructure/persistence/local/schema/document-artifact.record.ts
@@ -1,0 +1,15 @@
+import { ChildEntity, Column, Index, ManyToOne } from 'typeorm';
+import { UUID } from 'crypto';
+import { ArtifactRecord } from './artifact.record';
+import { LetterheadRecord } from '../../../../../letterheads/infrastructure/persistence/local/schema/letterhead.record';
+import { ArtifactType } from '../../../../domain/value-objects/artifact-type.enum';
+
+@ChildEntity(ArtifactType.DOCUMENT)
+export class DocumentArtifactRecord extends ArtifactRecord {
+  @Column({ nullable: true })
+  @Index()
+  letterheadId: UUID | null;
+
+  @ManyToOne(() => LetterheadRecord, { onDelete: 'SET NULL', nullable: true })
+  letterhead: LetterheadRecord | null;
+}

--- a/ayunis-core-backend/src/domain/artifacts/presenters/http/dtos/artifact-response.dto.ts
+++ b/ayunis-core-backend/src/domain/artifacts/presenters/http/dtos/artifact-response.dto.ts
@@ -1,5 +1,6 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { AuthorType } from '../../../domain/value-objects/author-type.enum';
+import { ArtifactType } from '../../../domain/value-objects/artifact-type.enum';
 
 export class ArtifactVersionResponseDto {
   @ApiProperty({
@@ -53,6 +54,13 @@ export class ArtifactResponseDto {
     example: '123e4567-e89b-12d3-a456-426614174000',
   })
   id: string;
+
+  @ApiProperty({
+    description: 'The kind of artifact — document (HTML) or diagram (mermaid)',
+    enum: ArtifactType,
+    example: ArtifactType.DOCUMENT,
+  })
+  type: ArtifactType;
 
   @ApiProperty({
     description: 'The thread this artifact belongs to',

--- a/ayunis-core-backend/src/domain/artifacts/presenters/http/mappers/artifact-dto.mapper.ts
+++ b/ayunis-core-backend/src/domain/artifacts/presenters/http/mappers/artifact-dto.mapper.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { Artifact } from '../../../domain/artifact.entity';
+import { Artifact, DocumentArtifact } from '../../../domain/artifact.entity';
 import { ArtifactVersion } from '../../../domain/artifact-version.entity';
 import {
   ArtifactResponseDto,
@@ -11,15 +11,17 @@ export class ArtifactDtoMapper {
   toDto(artifact: Artifact): ArtifactResponseDto {
     const dto = new ArtifactResponseDto();
     dto.id = artifact.id;
+    dto.type = artifact.type;
     dto.threadId = artifact.threadId;
     dto.userId = artifact.userId;
     dto.title = artifact.title;
-    dto.letterheadId = artifact.letterheadId;
+    dto.letterheadId =
+      artifact instanceof DocumentArtifact ? artifact.letterheadId : null;
     dto.currentVersionNumber = artifact.currentVersionNumber;
     dto.createdAt = artifact.createdAt.toISOString();
     dto.updatedAt = artifact.updatedAt.toISOString();
 
-    if (artifact.versions && artifact.versions.length > 0) {
+    if (artifact.versions.length > 0) {
       dto.versions = artifact.versions.map((v) => this.toVersionDto(v));
     }
 

--- a/ayunis-core-backend/src/domain/tools/application/handlers/create-document-tool.handler.spec.ts
+++ b/ayunis-core-backend/src/domain/tools/application/handlers/create-document-tool.handler.spec.ts
@@ -5,7 +5,7 @@ import { randomUUID } from 'crypto';
 import { CreateDocumentToolHandler } from './create-document-tool.handler';
 import { CreateArtifactUseCase } from 'src/domain/artifacts/application/use-cases/create-artifact/create-artifact.use-case';
 import { CreateDocumentTool } from '../../domain/tools/create-document-tool.entity';
-import { Artifact } from 'src/domain/artifacts/domain/artifact.entity';
+import { DocumentArtifact } from 'src/domain/artifacts/domain/artifact.entity';
 import { AuthorType } from 'src/domain/artifacts/domain/value-objects/author-type.enum';
 import { ToolExecutionFailedError } from '../tools.errors';
 
@@ -42,8 +42,8 @@ describe('CreateDocumentToolHandler', () => {
     jest.clearAllMocks();
   });
 
-  function createMockArtifact(): Artifact {
-    return new Artifact({
+  function createMockArtifact(): DocumentArtifact {
+    return new DocumentArtifact({
       id: mockArtifactId,
       threadId: mockThreadId,
       userId: randomUUID(),

--- a/ayunis-core-backend/src/domain/tools/application/handlers/read-document-tool.handler.spec.ts
+++ b/ayunis-core-backend/src/domain/tools/application/handlers/read-document-tool.handler.spec.ts
@@ -5,7 +5,7 @@ import { randomUUID } from 'crypto';
 import { ReadDocumentToolHandler } from './read-document-tool.handler';
 import { FindArtifactWithVersionsUseCase } from 'src/domain/artifacts/application/use-cases/find-artifact-with-versions/find-artifact-with-versions.use-case';
 import { ReadDocumentTool } from '../../domain/tools/read-document-tool.entity';
-import { Artifact } from 'src/domain/artifacts/domain/artifact.entity';
+import { DocumentArtifact } from 'src/domain/artifacts/domain/artifact.entity';
 import { ArtifactVersion } from 'src/domain/artifacts/domain/artifact-version.entity';
 import { AuthorType } from 'src/domain/artifacts/domain/value-objects/author-type.enum';
 import { ToolExecutionFailedError } from '../tools.errors';
@@ -47,7 +47,7 @@ describe('ReadDocumentToolHandler', () => {
   function createMockArtifact(
     versionNumber: number,
     content: string,
-  ): Artifact {
+  ): DocumentArtifact {
     const version = new ArtifactVersion({
       id: randomUUID(),
       artifactId: mockArtifactId,
@@ -57,7 +57,7 @@ describe('ReadDocumentToolHandler', () => {
       authorId: mockUserId,
     });
 
-    return new Artifact({
+    return new DocumentArtifact({
       id: mockArtifactId,
       threadId: mockThreadId,
       userId: mockUserId,
@@ -108,7 +108,7 @@ describe('ReadDocumentToolHandler', () => {
 
   it('should throw ToolExecutionFailedError when use case fails', async () => {
     mockFindArtifactUseCase.execute.mockRejectedValue(
-      new Error('Artifact not found'),
+      new Error('DocumentArtifact not found'),
     );
 
     const tool = new ReadDocumentTool();

--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
@@ -3185,9 +3185,23 @@ export interface ArtifactVersionResponseDto {
   createdAt: string;
 }
 
+/**
+ * The kind of artifact — document (HTML) or diagram (mermaid)
+ */
+export type ArtifactResponseDtoType = typeof ArtifactResponseDtoType[keyof typeof ArtifactResponseDtoType];
+
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const ArtifactResponseDtoType = {
+  document: 'document',
+  diagram: 'diagram',
+} as const;
+
 export interface ArtifactResponseDto {
   /** Unique identifier of the artifact */
   id: string;
+  /** The kind of artifact — document (HTML) or diagram (mermaid) */
+  type: ArtifactResponseDtoType;
   /** The thread this artifact belongs to */
   threadId: string;
   /** The user who owns this artifact */

--- a/ayunis-core-frontend/src/shared/api/openapi-schema.json
+++ b/ayunis-core-frontend/src/shared/api/openapi-schema.json
@@ -12870,6 +12870,12 @@
             "description": "Unique identifier of the artifact",
             "example": "123e4567-e89b-12d3-a456-426614174000"
           },
+          "type": {
+            "type": "string",
+            "description": "The kind of artifact — document (HTML) or diagram (mermaid)",
+            "enum": ["document", "diagram"],
+            "example": "document"
+          },
           "threadId": {
             "type": "string",
             "description": "The thread this artifact belongs to",
@@ -12917,6 +12923,7 @@
         },
         "required": [
           "id",
+          "type",
           "threadId",
           "userId",
           "title",


### PR DESCRIPTION
- Make Artifact abstract; add DocumentArtifact and DiagramArtifact subclasses
- Switch ArtifactRecord to @TableInheritance on a 'type' discriminator column
  defaulting to 'document' so existing rows backfill cleanly
- Push letterheadId down to DocumentArtifactRecord; route letterhead-touching
  updates through the document-typed repo
- Make create/update/revert type-aware: skip sanitizeHtmlContent for diagrams
  and guard letterheadId on document-only paths
- Reject server-side export for non-document artifacts
- Expose artifact type via ArtifactResponseDto and regenerate the frontend
  client so the field is available to consumers

Prepares PR 1 of 3 for the mermaid diagram artifact feature. No new tools
or UI are introduced yet; diagrams cannot be created via this PR alone.

Refs: AYC-31

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a DB migration and TypeORM single-table inheritance for `artifacts`, which can impact persistence/mapping and any code paths assuming a single artifact shape. Behavior changes around sanitization, letterheads, and export are guarded by runtime type checks but could surface edge cases for existing data or consumers.
> 
> **Overview**
> Refactors artifacts to **polymorphic single-table inheritance** by adding a `type` discriminator column (defaulting to `document`) and introducing `DocumentArtifact`/`DiagramArtifact` domain + record subclasses; letterhead fields are moved to document-only persistence.
> 
> Updates create/update/revert flows to be *type-aware*: document content continues to be sanitized and can use `letterheadId`, while non-document artifacts skip sanitization and reject letterhead updates via new `ARTIFACT_LETTERHEAD_NOT_SUPPORTED` errors. Server-side export is restricted to `DocumentArtifact` only (new `ARTIFACT_NOT_EXPORTABLE` error), and the HTTP `ArtifactResponseDto` now includes `type`, with regenerated frontend OpenAPI types reflecting the new field.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 068a112ee4563a131fa26c46526aa4c15b47df0f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->