### PR TITLE
wip(tools): add create_diagram and update_diagram tools (AYC-31)

### DIFF
--- a/ayunis-core-backend/src/domain/runs/application/services/artifact-tool-assembler.service.ts
+++ b/ayunis-core-backend/src/domain/runs/application/services/artifact-tool-assembler.service.ts
@@ -1,0 +1,144 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Tool } from 'src/domain/tools/domain/tool.entity';
+import { ToolType } from 'src/domain/tools/domain/value-objects/tool-type.enum';
+import { AssembleToolUseCase } from 'src/domain/tools/application/use-cases/assemble-tool/assemble-tool.use-case';
+import { AssembleToolCommand } from 'src/domain/tools/application/use-cases/assemble-tool/assemble-tool.command';
+import { Thread } from 'src/domain/threads/domain/thread.entity';
+import { FindArtifactsByThreadUseCase } from 'src/domain/artifacts/application/use-cases/find-artifacts-by-thread/find-artifacts-by-thread.use-case';
+import { FindArtifactsByThreadQuery } from 'src/domain/artifacts/application/use-cases/find-artifacts-by-thread/find-artifacts-by-thread.query';
+import { FindArtifactWithVersionsUseCase } from 'src/domain/artifacts/application/use-cases/find-artifact-with-versions/find-artifact-with-versions.use-case';
+import { FindArtifactWithVersionsQuery } from 'src/domain/artifacts/application/use-cases/find-artifact-with-versions/find-artifact-with-versions.query';
+import { AuthorType } from 'src/domain/artifacts/domain/value-objects/author-type.enum';
+import { DiagramArtifact } from 'src/domain/artifacts/domain/artifact.entity';
+import { FindAllLetterheadsUseCase } from 'src/domain/letterheads/application/use-cases/find-all-letterheads/find-all-letterheads.use-case';
+import type { Letterhead } from 'src/domain/letterheads/domain/letterhead.entity';
+import { buildLetterheadSuffix } from './letterhead-suffix.helper';
+
+/**
+ * Assembles artifact-related always-on tools (document + diagram) for a
+ * thread. Lives outside ToolAssemblyService to keep that file under the
+ * 500-line cap and to keep artifact-specific logic in one place.
+ */
+@Injectable()
+export class ArtifactToolAssemblerService {
+  private readonly logger = new Logger(ArtifactToolAssemblerService.name);
+
+  constructor(
+    private readonly assembleToolsUseCase: AssembleToolUseCase,
+    private readonly findArtifactsByThreadUseCase: FindArtifactsByThreadUseCase,
+    private readonly findArtifactWithVersionsUseCase: FindArtifactWithVersionsUseCase,
+    private readonly findAllLetterheadsUseCase: FindAllLetterheadsUseCase,
+  ) {}
+
+  async assembleDocumentAndDiagramTools(thread: Thread): Promise<Tool[]> {
+    const letterheads = await this.fetchLetterheadsSafe();
+    const letterheadSuffix = buildLetterheadSuffix(letterheads);
+
+    const tools: Tool[] = [];
+
+    const createDocTool = await this.assembleToolsUseCase.execute(
+      new AssembleToolCommand({ type: ToolType.CREATE_DOCUMENT }),
+    );
+    if (letterheadSuffix) {
+      createDocTool.descriptionLong = `${createDocTool.descriptionLong ?? createDocTool.description}${letterheadSuffix}`;
+    }
+    tools.push(createDocTool);
+
+    tools.push(
+      ...(await this.assembleDocumentEditTools(thread, letterheadSuffix)),
+    );
+
+    tools.push(
+      await this.assembleToolsUseCase.execute(
+        new AssembleToolCommand({ type: ToolType.CREATE_DIAGRAM }),
+      ),
+    );
+
+    tools.push(...(await this.assembleDiagramEditTools(thread)));
+
+    return tools;
+  }
+
+  private async assembleDocumentEditTools(
+    thread: Thread,
+    letterheadSuffix: string,
+  ): Promise<Tool[]> {
+    const threadArtifacts = await this.findArtifactsByThreadUseCase.execute(
+      new FindArtifactsByThreadQuery({ threadId: thread.id }),
+    );
+
+    const artifactLines: string[] = [];
+    for (const a of threadArtifacts) {
+      const full = await this.findArtifactWithVersionsUseCase.execute(
+        new FindArtifactWithVersionsQuery({ artifactId: a.id }),
+      );
+      const cur = full.versions.find(
+        (v) => v.versionNumber === full.currentVersionNumber,
+      );
+      const warn =
+        cur?.authorType === AuthorType.USER
+          ? ' (⚠ user-edited — use read_document before editing)'
+          : '';
+      artifactLines.push(`- ${a.id}: "${a.title}"${warn}`);
+    }
+
+    const suffix =
+      artifactLines.length > 0
+        ? `\n\nAvailable documents in this conversation:\n${artifactLines.join('\n')}`
+        : '';
+
+    const toolTypes = [
+      ToolType.UPDATE_DOCUMENT,
+      ToolType.EDIT_DOCUMENT,
+      ToolType.READ_DOCUMENT,
+    ];
+    const tools: Tool[] = [];
+    for (const type of toolTypes) {
+      const tool = await this.assembleToolsUseCase.execute(
+        new AssembleToolCommand({ type }),
+      );
+      const extra =
+        type === ToolType.UPDATE_DOCUMENT
+          ? `${suffix}${letterheadSuffix}`
+          : suffix;
+      if (extra) {
+        tool.descriptionLong = `${tool.descriptionLong ?? tool.description}${extra}`;
+      }
+      tools.push(tool);
+    }
+    return tools;
+  }
+
+  private async assembleDiagramEditTools(thread: Thread): Promise<Tool[]> {
+    const threadArtifacts = await this.findArtifactsByThreadUseCase.execute(
+      new FindArtifactsByThreadQuery({ threadId: thread.id }),
+    );
+
+    const diagrams = threadArtifacts.filter(
+      (a) => a instanceof DiagramArtifact,
+    );
+    if (diagrams.length === 0) {
+      return [];
+    }
+
+    const artifactLines = diagrams.map((a) => `- ${a.id}: "${a.title}"`);
+    const suffix = `\n\nAvailable diagrams in this conversation:\n${artifactLines.join('\n')}`;
+
+    const tool = await this.assembleToolsUseCase.execute(
+      new AssembleToolCommand({ type: ToolType.UPDATE_DIAGRAM }),
+    );
+    tool.descriptionLong = `${tool.descriptionLong ?? tool.description}${suffix}`;
+    return [tool];
+  }
+
+  private async fetchLetterheadsSafe(): Promise<Letterhead[]> {
+    try {
+      return await this.findAllLetterheadsUseCase.execute();
+    } catch (error) {
+      this.logger.warn('Failed to fetch letterheads, continuing without them', {
+        error: error instanceof Error ? error.message : 'Unknown error',
+      });
+      return [];
+    }
+  }
+}

--- a/ayunis-core-backend/src/domain/runs/application/services/system-prompt-builder.service.ts
+++ b/ayunis-core-backend/src/domain/runs/application/services/system-prompt-builder.service.ts
@@ -140,6 +140,12 @@ Only use create_document when the user explicitly asks for a document they inten
 If in doubt, respond inline. The user can always ask you to turn a response into a document.
 </document_usage>
 
+<diagram_usage>
+Use create_diagram when the user asks for a visual — a flowchart, sequence diagram, entity-relationship diagram, class diagram, state diagram, or similar. The content must be valid mermaid source (e.g. starting with "flowchart TD", "sequenceDiagram", "erDiagram"). Do not wrap the source in code fences or markdown.
+
+Prefer create_diagram over inline mermaid code blocks when the user explicitly asks for a diagram they want to view, iterate on, or export. For a quick sketch in the middle of a conversation, an inline mermaid code block is fine.
+</diagram_usage>
+
 ${toolSpecificSections}
 
 </tool_usage>`;

--- a/ayunis-core-backend/src/domain/runs/application/services/tool-assembly.service.spec.ts
+++ b/ayunis-core-backend/src/domain/runs/application/services/tool-assembly.service.spec.ts
@@ -1,80 +1,7 @@
 import { randomUUID } from 'crypto';
-import type { UUID } from 'crypto';
-import { Letterhead } from 'src/domain/letterheads/domain/letterhead.entity';
 import { Thread } from 'src/domain/threads/domain/thread.entity';
 import { ToolType } from 'src/domain/tools/domain/value-objects/tool-type.enum';
 import { PermittedImageGenerationModelNotFoundForOrgError } from 'src/domain/models/application/models.errors';
-import { buildLetterheadSuffix } from './letterhead-suffix.helper';
-
-/**
- * Tests for the letterhead suffix logic extracted to letterhead-suffix.helper.ts.
- */
-describe('buildLetterheadSuffix', () => {
-  const mockOrgId = randomUUID();
-
-  function createLetterhead(overrides?: {
-    name?: string;
-    description?: string | null;
-    id?: UUID;
-  }): Letterhead {
-    return new Letterhead({
-      id: overrides?.id ?? randomUUID(),
-      orgId: mockOrgId,
-      name: overrides?.name ?? 'Stadt Musterstadt',
-      description:
-        overrides?.description !== undefined
-          ? overrides.description
-          : 'Offizielles Briefpapier',
-      firstPageStoragePath: `letterheads/${mockOrgId}/first.pdf`,
-      firstPageMargins: { top: 55, bottom: 20, left: 20, right: 20 },
-      continuationPageMargins: { top: 20, bottom: 20, left: 20, right: 20 },
-    });
-  }
-
-  it('should return empty string when no letterheads exist', () => {
-    const result = buildLetterheadSuffix([]);
-    expect(result).toBe('');
-  });
-
-  it('should include letterhead name and description in suffix', () => {
-    const letterhead = createLetterhead({
-      name: 'Gemeinde Testdorf',
-      description: 'Für formelle Schreiben',
-    });
-
-    const result = buildLetterheadSuffix([letterhead]);
-
-    expect(result).toContain('Gemeinde Testdorf');
-    expect(result).toContain('Für formelle Schreiben');
-    expect(result).toContain(letterhead.id);
-    expect(result).toContain('letterhead_id');
-  });
-
-  it('should handle letterhead without description', () => {
-    const letterhead = createLetterhead({
-      name: 'Einfaches Briefpapier',
-      description: null,
-    });
-
-    const result = buildLetterheadSuffix([letterhead]);
-
-    expect(result).toContain('Einfaches Briefpapier');
-    expect(result).not.toContain(' — ');
-  });
-
-  it('should list multiple letterheads', () => {
-    const letterheads = [
-      createLetterhead({ name: 'Briefpapier A' }),
-      createLetterhead({ name: 'Briefpapier B' }),
-    ];
-
-    const result = buildLetterheadSuffix(letterheads);
-
-    expect(result).toContain('Briefpapier A');
-    expect(result).toContain('Briefpapier B');
-    expect(result).toContain('Available letterheads (Briefpapier)');
-  });
-});
 
 describe('ToolAssemblyService — image generation tool assembly', () => {
   const mockOrgId = randomUUID();
@@ -94,14 +21,13 @@ describe('ToolAssemblyService — image generation tool assembly', () => {
 
   /**
    * Build a ToolAssemblyService with mocked dependencies.
-   * Constructor order (14 params):
+   * Constructor order (12 params):
    *  0 configService, 1 assembleToolsUseCase, 2 discoverMcpCapabilitiesUseCase,
    *  3 systemPromptBuilderService, 4 findActiveSkillsUseCase,
    *  5 getUserSystemPromptUseCase, 6 getMcpIntegrationsByIdsUseCase,
    *  7 findActiveAlwaysOnTemplatesUseCase, 8 features,
-   *  9 findArtifactsByThreadUseCase, 10 findArtifactWithVersionsUseCase,
-   *  11 findAllLetterheadsUseCase, 12 contextService,
-   *  13 getPermittedImageGenerationModelUseCase
+   *  9 contextService, 10 getPermittedImageGenerationModelUseCase,
+   *  11 artifactToolAssembler
    */
   async function buildService(overrides: {
     contextServiceGet?: jest.Mock;
@@ -129,18 +55,14 @@ describe('ToolAssemblyService — image generation tool assembly', () => {
     };
     const findActiveAlwaysOnTemplatesUseCase = null;
     const features = { skillsEnabled: false };
-    const findArtifactsByThreadUseCase = {
-      execute: jest.fn().mockResolvedValue([]),
-    };
-    const findArtifactWithVersionsUseCase = null;
-    const findAllLetterheadsUseCase = {
-      execute: jest.fn().mockResolvedValue([]),
-    };
     const contextService = {
       get: overrides.contextServiceGet ?? jest.fn().mockReturnValue(undefined),
     };
     const getPermittedImageGenerationModelUseCase = {
       execute: overrides.imageModelExecute ?? jest.fn().mockResolvedValue({}),
+    };
+    const artifactToolAssembler = {
+      assembleDocumentAndDiagramTools: jest.fn().mockResolvedValue([]),
     };
 
     const service = new (mod.ToolAssemblyService as any)(
@@ -153,11 +75,9 @@ describe('ToolAssemblyService — image generation tool assembly', () => {
       getMcpIntegrationsByIdsUseCase,
       findActiveAlwaysOnTemplatesUseCase,
       features,
-      findArtifactsByThreadUseCase,
-      findArtifactWithVersionsUseCase,
-      findAllLetterheadsUseCase,
       contextService,
       getPermittedImageGenerationModelUseCase,
+      artifactToolAssembler,
     );
 
     return {

--- a/ayunis-core-backend/src/domain/runs/application/services/tool-assembly.service.ts
+++ b/ayunis-core-backend/src/domain/runs/application/services/tool-assembly.service.ts
@@ -33,16 +33,10 @@ import {
   type SkillPrefix,
 } from 'src/common/util/skill-slug';
 import type { SkillTemplate } from 'src/domain/skill-templates/domain/skill-template.entity';
-import { FindArtifactsByThreadUseCase } from 'src/domain/artifacts/application/use-cases/find-artifacts-by-thread/find-artifacts-by-thread.use-case';
-import { FindArtifactsByThreadQuery } from 'src/domain/artifacts/application/use-cases/find-artifacts-by-thread/find-artifacts-by-thread.query';
-import { FindArtifactWithVersionsUseCase } from 'src/domain/artifacts/application/use-cases/find-artifact-with-versions/find-artifact-with-versions.use-case';
-import { FindArtifactWithVersionsQuery } from 'src/domain/artifacts/application/use-cases/find-artifact-with-versions/find-artifact-with-versions.query';
-import { AuthorType } from 'src/domain/artifacts/domain/value-objects/author-type.enum';
-import { FindAllLetterheadsUseCase } from 'src/domain/letterheads/application/use-cases/find-all-letterheads/find-all-letterheads.use-case';
-import { buildLetterheadSuffix } from './letterhead-suffix.helper';
 import { assembleImageGenerationTools } from './image-generation-tool-assembly.helper';
 import { ContextService } from 'src/common/context/services/context.service';
 import { GetPermittedImageGenerationModelUseCase } from 'src/domain/models/application/use-cases/get-permitted-image-generation-model/get-permitted-image-generation-model.use-case';
+import { ArtifactToolAssemblerService } from './artifact-tool-assembler.service';
 
 @Injectable()
 export class ToolAssemblyService {
@@ -59,11 +53,9 @@ export class ToolAssemblyService {
     private readonly findActiveAlwaysOnTemplatesUseCase: FindActiveAlwaysOnTemplatesUseCase,
     @Inject(featuresConfig.KEY)
     private readonly features: ConfigType<typeof featuresConfig>,
-    private readonly findArtifactsByThreadUseCase: FindArtifactsByThreadUseCase,
-    private readonly findArtifactWithVersionsUseCase: FindArtifactWithVersionsUseCase,
-    private readonly findAllLetterheadsUseCase: FindAllLetterheadsUseCase,
     private readonly contextService: ContextService,
     private readonly getPermittedImageGenerationModelUseCase: GetPermittedImageGenerationModelUseCase,
+    private readonly artifactToolAssembler: ArtifactToolAssemblerService,
   ) {}
 
   async findActiveSkills(): Promise<Skill[]> {
@@ -240,25 +232,14 @@ export class ToolAssemblyService {
       );
     }
 
-    // Fetch org letterheads for document tool descriptions
-    const letterheads = await this.fetchLetterheadsSafe();
-    const letterheadSuffix = buildLetterheadSuffix(letterheads);
-
-    // Document tools are always available
-    const createDocTool = await this.assembleToolsUseCase.execute(
-      new AssembleToolCommand({ type: ToolType.CREATE_DOCUMENT }),
+    // Artifact-related always-on tools (document create/update/edit/read +
+    // diagram create/update). Handles letterhead suffix + artifact context
+    // injection internally.
+    tools.push(
+      ...(await this.artifactToolAssembler.assembleDocumentAndDiagramTools(
+        thread,
+      )),
     );
-    if (letterheadSuffix) {
-      createDocTool.descriptionLong = `${createDocTool.descriptionLong ?? createDocTool.description}${letterheadSuffix}`;
-    }
-    tools.push(createDocTool);
-
-    // Document editing tools with artifact context + letterhead info
-    const documentEditTools = await this.assembleDocumentEditTools(
-      thread,
-      letterheadSuffix,
-    );
-    tools.push(...documentEditTools);
 
     if (skillsEnabled) {
       tools.push(
@@ -429,66 +410,5 @@ export class ToolAssemblyService {
         ),
       ),
     ];
-  }
-
-  private async assembleDocumentEditTools(
-    thread: Thread,
-    letterheadSuffix: string,
-  ): Promise<Tool[]> {
-    const threadArtifacts = await this.findArtifactsByThreadUseCase.execute(
-      new FindArtifactsByThreadQuery({ threadId: thread.id }),
-    );
-
-    const artifactLines: string[] = [];
-    for (const a of threadArtifacts) {
-      const full = await this.findArtifactWithVersionsUseCase.execute(
-        new FindArtifactWithVersionsQuery({ artifactId: a.id }),
-      );
-      const cur = full.versions.find(
-        (v) => v.versionNumber === full.currentVersionNumber,
-      );
-      const warn =
-        cur?.authorType === AuthorType.USER
-          ? ' (⚠ user-edited — use read_document before editing)'
-          : '';
-      artifactLines.push(`- ${a.id}: "${a.title}"${warn}`);
-    }
-
-    const suffix =
-      artifactLines.length > 0
-        ? `\n\nAvailable documents in this conversation:\n${artifactLines.join('\n')}`
-        : '';
-
-    const toolTypes = [
-      ToolType.UPDATE_DOCUMENT,
-      ToolType.EDIT_DOCUMENT,
-      ToolType.READ_DOCUMENT,
-    ];
-    const tools: Tool[] = [];
-    for (const type of toolTypes) {
-      const tool = await this.assembleToolsUseCase.execute(
-        new AssembleToolCommand({ type }),
-      );
-      const extra =
-        type === ToolType.UPDATE_DOCUMENT
-          ? `${suffix}${letterheadSuffix}`
-          : suffix;
-      if (extra) {
-        tool.descriptionLong = `${tool.descriptionLong ?? tool.description}${extra}`;
-      }
-      tools.push(tool);
-    }
-    return tools;
-  }
-
-  private async fetchLetterheadsSafe() {
-    try {
-      return await this.findAllLetterheadsUseCase.execute();
-    } catch (error) {
-      this.logger.warn('Failed to fetch letterheads, continuing without them', {
-        error: error instanceof Error ? error.message : 'Unknown error',
-      });
-      return [];
-    }
   }
 }

--- a/ayunis-core-backend/src/domain/runs/runs.module.ts
+++ b/ayunis-core-backend/src/domain/runs/runs.module.ts
@@ -9,6 +9,7 @@ import { ExecuteRunUseCase } from './application/use-cases/execute-run/execute-r
 import { ExecuteRunAndSetTitleUseCase } from './application/use-cases/execute-run-and-set-title/execute-run-and-set-title.use-case';
 import { SystemPromptBuilderService } from './application/services/system-prompt-builder.service';
 import { ToolAssemblyService } from './application/services/tool-assembly.service';
+import { ArtifactToolAssemblerService } from './application/services/artifact-tool-assembler.service';
 import { ToolResultCollectorService } from './application/services/tool-result-collector.service';
 import { MessageCleanupService } from './application/services/message-cleanup.service';
 import { StreamingInferenceService } from './application/services/streaming-inference.service';
@@ -55,6 +56,7 @@ import { LetterheadsModule } from 'src/domain/letterheads/letterheads.module';
     ExecuteRunAndSetTitleUseCase,
     SystemPromptBuilderService,
     ToolAssemblyService,
+    ArtifactToolAssemblerService,
     ToolResultCollectorService,
     MessageCleanupService,
     StreamingInferenceService,

--- a/ayunis-core-backend/src/domain/tools/application/handlers/create-diagram-tool.handler.ts
+++ b/ayunis-core-backend/src/domain/tools/application/handlers/create-diagram-tool.handler.ts
@@ -1,0 +1,55 @@
+import { Injectable, Logger } from '@nestjs/common';
+import {
+  ToolExecutionContext,
+  ToolExecutionHandler,
+} from '../ports/execution.handler';
+import { CreateDiagramTool } from '../../domain/tools/create-diagram-tool.entity';
+import { ToolExecutionFailedError } from '../tools.errors';
+import { CreateArtifactUseCase } from 'src/domain/artifacts/application/use-cases/create-artifact/create-artifact.use-case';
+import { CreateArtifactCommand } from 'src/domain/artifacts/application/use-cases/create-artifact/create-artifact.command';
+import { AuthorType } from 'src/domain/artifacts/domain/value-objects/author-type.enum';
+import { ArtifactType } from 'src/domain/artifacts/domain/value-objects/artifact-type.enum';
+
+@Injectable()
+export class CreateDiagramToolHandler extends ToolExecutionHandler {
+  private readonly logger = new Logger(CreateDiagramToolHandler.name);
+
+  constructor(private readonly createArtifactUseCase: CreateArtifactUseCase) {
+    super();
+  }
+
+  async execute(params: {
+    tool: CreateDiagramTool;
+    input: Record<string, unknown>;
+    context: ToolExecutionContext;
+  }): Promise<string> {
+    const { tool, input, context } = params;
+    this.logger.log('Executing create_diagram tool');
+
+    try {
+      const validatedInput = tool.validateParams(input);
+
+      const artifact = await this.createArtifactUseCase.execute(
+        new CreateArtifactCommand({
+          threadId: context.threadId,
+          type: ArtifactType.DIAGRAM,
+          title: validatedInput.title,
+          content: validatedInput.content,
+          authorType: AuthorType.ASSISTANT,
+        }),
+      );
+
+      return `Diagram created successfully. Artifact ID: ${artifact.id}, version: ${artifact.currentVersionNumber}`;
+    } catch (error) {
+      if (error instanceof ToolExecutionFailedError) {
+        throw error;
+      }
+      this.logger.error('Failed to execute create_diagram tool', error);
+      throw new ToolExecutionFailedError({
+        toolName: tool.name,
+        message: error instanceof Error ? error.message : 'Unknown error',
+        exposeToLLM: true,
+      });
+    }
+  }
+}

--- a/ayunis-core-backend/src/domain/tools/application/handlers/update-diagram-tool.handler.ts
+++ b/ayunis-core-backend/src/domain/tools/application/handlers/update-diagram-tool.handler.ts
@@ -1,0 +1,64 @@
+import { Injectable, Logger } from '@nestjs/common';
+import {
+  ToolExecutionContext,
+  ToolExecutionHandler,
+} from '../ports/execution.handler';
+import { UpdateDiagramTool } from '../../domain/tools/update-diagram-tool.entity';
+import { ToolExecutionFailedError } from '../tools.errors';
+import { UpdateArtifactUseCase } from 'src/domain/artifacts/application/use-cases/update-artifact/update-artifact.use-case';
+import { UpdateArtifactCommand } from 'src/domain/artifacts/application/use-cases/update-artifact/update-artifact.command';
+import { AuthorType } from 'src/domain/artifacts/domain/value-objects/author-type.enum';
+import { ArtifactExpectedVersionMismatchError } from 'src/domain/artifacts/application/artifacts.errors';
+import { UUID } from 'crypto';
+
+@Injectable()
+export class UpdateDiagramToolHandler extends ToolExecutionHandler {
+  private readonly logger = new Logger(UpdateDiagramToolHandler.name);
+
+  constructor(private readonly updateArtifactUseCase: UpdateArtifactUseCase) {
+    super();
+  }
+
+  async execute(params: {
+    tool: UpdateDiagramTool;
+    input: Record<string, unknown>;
+    context: ToolExecutionContext;
+  }): Promise<string> {
+    const { tool, input } = params;
+    this.logger.log('Executing update_diagram tool');
+
+    try {
+      const validatedInput = tool.validateParams(input);
+
+      const version = await this.updateArtifactUseCase.execute(
+        new UpdateArtifactCommand({
+          artifactId: validatedInput.artifact_id as UUID,
+          content: validatedInput.content,
+          authorType: AuthorType.ASSISTANT,
+          expectedVersionNumber: validatedInput.expected_version,
+        }),
+      );
+
+      return `Diagram updated successfully. Artifact ID: ${validatedInput.artifact_id}, version: ${version?.versionNumber}`;
+    } catch (error) {
+      if (error instanceof ToolExecutionFailedError) {
+        throw error;
+      }
+
+      if (error instanceof ArtifactExpectedVersionMismatchError) {
+        throw new ToolExecutionFailedError({
+          toolName: tool.name,
+          message: error.message,
+          exposeToLLM: true,
+        });
+      }
+
+      this.logger.error('Failed to execute update_diagram tool', error);
+      throw new ToolExecutionFailedError({
+        toolName: tool.name,
+        message: error instanceof Error ? error.message : 'Unknown error',
+        exposeToLLM: true,
+      });
+    }
+  }
+}

--- a/ayunis-core-backend/src/domain/tools/application/tool-handler.registry.ts
+++ b/ayunis-core-backend/src/domain/tools/application/tool-handler.registry.ts
@@ -34,6 +34,10 @@ import { ReadDocumentToolHandler } from './handlers/read-document-tool.handler';
 import { ReadDocumentTool } from '../domain/tools/read-document-tool.entity';
 import { GenerateImageToolHandler } from './handlers/generate-image-tool.handler';
 import { GenerateImageTool } from '../domain/tools/generate-image-tool.entity';
+import { CreateDiagramToolHandler } from './handlers/create-diagram-tool.handler';
+import { CreateDiagramTool } from '../domain/tools/create-diagram-tool.entity';
+import { UpdateDiagramToolHandler } from './handlers/update-diagram-tool.handler';
+import { UpdateDiagramTool } from '../domain/tools/update-diagram-tool.entity';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- constructor types vary; used only as Map keys for instanceof matching
 type ToolConstructor = abstract new (...args: any[]) => Tool;
@@ -60,6 +64,8 @@ export class ToolHandlerRegistry {
     editDocumentToolHandler: EditDocumentToolHandler,
     readDocumentToolHandler: ReadDocumentToolHandler,
     generateImageToolHandler: GenerateImageToolHandler,
+    createDiagramToolHandler: CreateDiagramToolHandler,
+    updateDiagramToolHandler: UpdateDiagramToolHandler,
   ) {
     this.handlers = [
       [HttpTool, httpToolHandler],
@@ -78,6 +84,8 @@ export class ToolHandlerRegistry {
       [EditDocumentTool, editDocumentToolHandler],
       [ReadDocumentTool, readDocumentToolHandler],
       [GenerateImageTool, generateImageToolHandler],
+      [CreateDiagramTool, createDiagramToolHandler],
+      [UpdateDiagramTool, updateDiagramToolHandler],
     ];
   }
 

--- a/ayunis-core-backend/src/domain/tools/application/tool.factory.spec.ts
+++ b/ayunis-core-backend/src/domain/tools/application/tool.factory.spec.ts
@@ -167,8 +167,10 @@ describe('ToolFactory', () => {
       expect(types).toContain(ToolType.EDIT_DOCUMENT);
       expect(types).toContain(ToolType.READ_DOCUMENT);
       expect(types).toContain(ToolType.GENERATE_IMAGE);
+      expect(types).toContain(ToolType.CREATE_DIAGRAM);
+      expect(types).toContain(ToolType.UPDATE_DIAGRAM);
 
-      expect(types.length).toBe(24);
+      expect(types.length).toBe(26);
     });
   });
 });

--- a/ayunis-core-backend/src/domain/tools/application/tool.factory.ts
+++ b/ayunis-core-backend/src/domain/tools/application/tool.factory.ts
@@ -34,6 +34,8 @@ import { UpdateDocumentTool } from '../domain/tools/update-document-tool.entity'
 import { EditDocumentTool } from '../domain/tools/edit-document-tool.entity';
 import { ReadDocumentTool } from '../domain/tools/read-document-tool.entity';
 import { GenerateImageTool } from '../domain/tools/generate-image-tool.entity';
+import { CreateDiagramTool } from '../domain/tools/create-diagram-tool.entity';
+import { UpdateDiagramTool } from '../domain/tools/update-diagram-tool.entity';
 
 type ToolCreator = (params: { config?: ToolConfig; context?: unknown }) => Tool;
 
@@ -51,6 +53,8 @@ const SIMPLE_TOOLS: Record<string, () => Tool> = {
   [ToolType.EDIT_DOCUMENT]: () => new EditDocumentTool(),
   [ToolType.READ_DOCUMENT]: () => new ReadDocumentTool(),
   [ToolType.GENERATE_IMAGE]: () => new GenerateImageTool(),
+  [ToolType.CREATE_DIAGRAM]: () => new CreateDiagramTool(),
+  [ToolType.UPDATE_DIAGRAM]: () => new UpdateDiagramTool(),
 };
 
 @Injectable()

--- a/ayunis-core-backend/src/domain/tools/domain/tools/create-diagram-tool.entity.ts
+++ b/ayunis-core-backend/src/domain/tools/domain/tools/create-diagram-tool.entity.ts
@@ -1,0 +1,53 @@
+import { createAjv } from 'src/common/validators/ajv.factory';
+import { ToolType } from '../value-objects/tool-type.enum';
+import type { FromSchema, JSONSchema } from 'json-schema-to-ts';
+import { DisplayableTool } from '../displayable-tool.entity';
+
+const createDiagramToolParameters = {
+  type: 'object' as const,
+  properties: {
+    title: {
+      type: 'string' as const,
+      description: 'The title of the diagram to create',
+    },
+    content: {
+      type: 'string' as const,
+      description:
+        'The full mermaid source of the diagram. Start with a mermaid diagram declaration (e.g. "flowchart TD", "sequenceDiagram", "erDiagram"). Do not wrap in code fences.',
+    },
+  },
+  required: ['title', 'content'],
+  additionalProperties: false,
+} as const satisfies JSONSchema;
+
+type CreateDiagramToolParameters = FromSchema<
+  typeof createDiagramToolParameters
+>;
+
+export class CreateDiagramTool extends DisplayableTool {
+  override isExecutable: boolean = true;
+
+  constructor() {
+    super({
+      name: ToolType.CREATE_DIAGRAM,
+      description:
+        'Create a new visual diagram that the user can view and export. Use this when the user asks for a flowchart, sequence diagram, entity-relationship diagram, class diagram, or similar — anything expressed as mermaid source. Do not use this for regular conversational answers or for text documents (use create_document instead).',
+      parameters: createDiagramToolParameters,
+      type: ToolType.CREATE_DIAGRAM,
+    });
+  }
+
+  validateParams(params: Record<string, unknown>): CreateDiagramToolParameters {
+    const ajv = createAjv();
+    const validate = ajv.compile(this.parameters);
+    const valid = validate(params);
+    if (!valid) {
+      throw new Error(JSON.stringify(validate.errors));
+    }
+    return params as CreateDiagramToolParameters;
+  }
+
+  get returnsPii(): boolean {
+    return false;
+  }
+}

--- a/ayunis-core-backend/src/domain/tools/domain/tools/update-diagram-tool.entity.ts
+++ b/ayunis-core-backend/src/domain/tools/domain/tools/update-diagram-tool.entity.ts
@@ -1,0 +1,64 @@
+import { createAjv } from 'src/common/validators/ajv.factory';
+import { ToolType } from '../value-objects/tool-type.enum';
+import type { FromSchema, JSONSchema } from 'json-schema-to-ts';
+import { DisplayableTool } from '../displayable-tool.entity';
+
+const updateDiagramToolParameters = {
+  type: 'object' as const,
+  properties: {
+    artifact_id: {
+      type: 'string' as const,
+      description: 'The UUID of the existing diagram artifact to update',
+    },
+    content: {
+      type: 'string' as const,
+      description:
+        'The full updated mermaid source of the diagram. Provide the complete source, not just the changes.',
+    },
+    expected_version: {
+      type: 'integer' as const,
+      description:
+        'The version number you expect the diagram to be at. Pass the version from your last create/update result. The operation will fail if the diagram has been modified since.',
+    },
+  },
+  required: ['artifact_id', 'content', 'expected_version'],
+  additionalProperties: false,
+} as const satisfies JSONSchema;
+
+type UpdateDiagramToolParameters = FromSchema<
+  typeof updateDiagramToolParameters
+>;
+
+export class UpdateDiagramTool extends DisplayableTool {
+  override isExecutable: boolean = true;
+
+  constructor() {
+    super({
+      name: ToolType.UPDATE_DIAGRAM,
+      description:
+        'Update an existing diagram with new mermaid source. Use this when the user asks you to modify or revise an existing diagram.',
+      descriptionLong:
+        'Use update_diagram when a diagram already exists in the conversation (was previously created with create_diagram). ' +
+        'Use create_diagram instead when the user wants a brand new diagram. ' +
+        'Always provide the full updated mermaid source, not a partial diff — diagrams are small enough that full replacement is fine. ' +
+        'You must pass expected_version with the version number from your last tool result. ' +
+        'If the diagram was modified by the user since then, the operation will fail.',
+      parameters: updateDiagramToolParameters,
+      type: ToolType.UPDATE_DIAGRAM,
+    });
+  }
+
+  validateParams(params: Record<string, unknown>): UpdateDiagramToolParameters {
+    const ajv = createAjv();
+    const validate = ajv.compile(this.parameters);
+    const valid = validate(params);
+    if (!valid) {
+      throw new Error(JSON.stringify(validate.errors));
+    }
+    return params as UpdateDiagramToolParameters;
+  }
+
+  get returnsPii(): boolean {
+    return false;
+  }
+}

--- a/ayunis-core-backend/src/domain/tools/domain/value-objects/tool-type.enum.ts
+++ b/ayunis-core-backend/src/domain/tools/domain/value-objects/tool-type.enum.ts
@@ -24,4 +24,6 @@ export enum ToolType {
   EDIT_DOCUMENT = 'edit_document',
   READ_DOCUMENT = 'read_document',
   GENERATE_IMAGE = 'generate_image',
+  CREATE_DIAGRAM = 'create_diagram',
+  UPDATE_DIAGRAM = 'update_diagram',
 }

--- a/ayunis-core-backend/src/domain/tools/tools.module.ts
+++ b/ayunis-core-backend/src/domain/tools/tools.module.ts
@@ -27,6 +27,8 @@ import { CreateDocumentToolHandler } from './application/handlers/create-documen
 import { UpdateDocumentToolHandler } from './application/handlers/update-document-tool.handler';
 import { EditDocumentToolHandler } from './application/handlers/edit-document-tool.handler';
 import { ReadDocumentToolHandler } from './application/handlers/read-document-tool.handler';
+import { CreateDiagramToolHandler } from './application/handlers/create-diagram-tool.handler';
+import { UpdateDiagramToolHandler } from './application/handlers/update-diagram-tool.handler';
 import { SkillsModule } from '../skills/skills.module';
 import { KnowledgeBasesModule } from '../knowledge-bases/knowledge-bases.module';
 import { SkillTemplatesModule } from '../skill-templates/skill-templates.module';
@@ -72,6 +74,8 @@ import { UsageModule } from '../usage/usage.module';
     EditDocumentToolHandler,
     ReadDocumentToolHandler,
     GenerateImageToolHandler,
+    CreateDiagramToolHandler,
+    UpdateDiagramToolHandler,
     // Repositories and factories
     {
       provide: ToolConfigRepository,

--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
@@ -2287,6 +2287,8 @@ export const ToolAssignmentDtoType = {
   edit_document: 'edit_document',
   read_document: 'read_document',
   generate_image: 'generate_image',
+  create_diagram: 'create_diagram',
+  update_diagram: 'update_diagram',
 } as const;
 
 export interface ToolAssignmentDto {
@@ -2343,6 +2345,8 @@ export const ToolResponseDtoType = {
   edit_document: 'edit_document',
   read_document: 'read_document',
   generate_image: 'generate_image',
+  create_diagram: 'create_diagram',
+  update_diagram: 'update_diagram',
 } as const;
 
 export interface ToolResponseDto {

--- a/ayunis-core-frontend/src/shared/api/openapi-schema.json
+++ b/ayunis-core-frontend/src/shared/api/openapi-schema.json
@@ -11603,7 +11603,9 @@
               "update_document",
               "edit_document",
               "read_document",
-              "generate_image"
+              "generate_image",
+              "create_diagram",
+              "update_diagram"
             ]
           },
           "toolConfigId": {
@@ -11677,7 +11679,9 @@
               "update_document",
               "edit_document",
               "read_document",
-              "generate_image"
+              "generate_image",
+              "create_diagram",
+              "update_diagram"
             ]
           }
         },


### PR DESCRIPTION
- Add CREATE_DIAGRAM and UPDATE_DIAGRAM to the ToolType enum
- Add CreateDiagramTool + UpdateDiagramTool entities (mermaid source params, no letterhead, no search-and-replace)
- Add matching handlers that call CreateArtifact/UpdateArtifact with ArtifactType.DIAGRAM so diagram content is not HTML-sanitized
- Register both in the tool factory, handler registry, and tools module
- Extract artifact-related tool assembly (document + diagram) into a new ArtifactToolAssemblerService to keep tool-assembly.service.ts under the 500-line cap; add create_diagram as always-on and inject diagram-artifact context into update_diagram's descriptionLong
- Add a diagram_usage guidance section to the system prompt so the LLM knows when to call create_diagram vs. inline mermaid
- Regenerate the frontend API client so create_diagram / update_diagram are available in ToolAssignmentDtoType

Prepares PR 2 of 3 for the mermaid diagram artifact feature. Tools are wired end-to-end in the backend; the frontend widget + viewer follow in PR 3.

Refs: AYC-31

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new always-on executable tools that create/update persisted artifacts, so mistakes could affect stored conversation data and tool prompting. Refactors tool assembly wiring, which could change which tools are exposed to agents if misconfigured.
> 
> **Overview**
> Adds new diagram tooling end-to-end: `create_diagram` and `update_diagram` tool types, schemas, factory registration, handler registry wiring, and Nest providers, with handlers that create/update `ArtifactType.DIAGRAM` artifacts using full mermaid source and optimistic version checks.
> 
> Refactors always-on artifact tool assembly out of `ToolAssemblyService` into `ArtifactToolAssemblerService`, which now injects letterhead info into document tool descriptions and appends per-thread document/diagram context (including user-edited warnings and available diagram IDs) into `descriptionLong`.
> 
> Updates the system prompt with a new `diagram_usage` section guiding when to call `create_diagram` vs inline mermaid, and regenerates frontend OpenAPI types so `ToolAssignmentDtoType` includes the new diagram tool types.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e242c469cdd7df800c863299130ca95134c3309. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->