### PR TITLE
feat(chat): render mermaid diagram artifacts in the side panel (AYC-31)

### DIFF
--- a/ayunis-core-backend/.nsprc
+++ b/ayunis-core-backend/.nsprc
@@ -2,9 +2,5 @@
   "1113567": {
     "active": true,
     "notes": "fast-xml-parser entity encoding bypass via regex injection in DOCTYPE entity names — only affects minio which parses XML from our own MinIO server, not untrusted input. Waiting for minio to upgrade to fast-xml-parser v5."
-  },
-  "1113518": {
-    "active": true,
-    "notes": "basic-ftp path traversal in downloadToDir() — transitive dep of puppeteer-core via proxy-agent. We never call downloadToDir() and only use puppeteer for local PDF rendering. No untrusted FTP connections."
   }
 }

--- a/ayunis-core-backend/package-lock.json
+++ b/ayunis-core-backend/package-lock.json
@@ -3073,6 +3073,30 @@
         }
       }
     },
+    "node_modules/@google/genai/node_modules/protobufjs": {
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.5.tgz",
+      "integrity": "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/@hono/node-server": {
       "version": "1.19.9",
       "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.9.tgz",
@@ -10702,9 +10726,9 @@
       }
     },
     "node_modules/basic-ftp": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.1.0.tgz",
-      "integrity": "sha512-RkaJzeJKDbaDWTIPiJwubyljaEPwpVWkm9Rt5h9Nd6h7tEXTJ3VB4qxdZBioV7JO5yLUaOKwz7vDOzlncUsegw==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.0.tgz",
+      "integrity": "sha512-5K9eNNn7ywHPsYnFwjKgYH8Hf8B5emh7JKcPaVjjrMJFQQwGpwowEnZNEtHs7DfR7hCZsmaK3VA4HUK0YarT+w==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -21150,30 +21174,6 @@
       "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
       "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
       "license": "ISC"
-    },
-    "node_modules/protobufjs": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
-      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
-      "hasInstallScript": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
-        "@types/node": ">=13.7.0",
-        "long": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",

--- a/ayunis-core-backend/package.json
+++ b/ayunis-core-backend/package.json
@@ -110,6 +110,14 @@
     "winston-transport": "^4.9.0",
     "xlsx": "^0.18.5"
   },
+  "overrides": {
+    "basic-ftp": ">=5.2.0 <6",
+    "protobufjs": ">=7.5.5 <8"
+  },
+  "overridesNotes": {
+    "basic-ftp": "Patches GHSA-5rq4-664w-9x2c (path traversal). Transitive via puppeteer-core → @puppeteer/browsers → proxy-agent → pac-proxy-agent → get-uri. Not reachable in our code (html-document-export.service.ts uses system Chromium via executablePath, never downloads browsers, no proxy config), but blocks the CI security audit. Remove when @puppeteer/browsers bumps get-uri past the vulnerable range — verify with `npm ls basic-ftp` after any puppeteer-core upgrade.",
+    "protobufjs": "Patches GHSA-xq3m-2v4x-88gg (arbitrary code execution, fixed in 7.5.5). Transitive via @google/genai. @google/genai declares `^7.5.4`, so this floor stays within its range. Remove when @google/genai's declared range moves past 7.5.5 — verify with `npm ls protobufjs` after any @google/genai upgrade."
+  },
   "devDependencies": {
     "@eslint/js": "^9.18.0",
     "@nestjs/cli": "^11.0.0",

--- a/ayunis-core-frontend/package-lock.json
+++ b/ayunis-core-frontend/package-lock.json
@@ -49,6 +49,7 @@
         "i18next": "^25.8.10",
         "i18next-browser-languagedetector": "^8.2.0",
         "lucide-react": "^0.476.0",
+        "mermaid": "^11.14.0",
         "pdfjs-dist": "^5.5.207",
         "react": "^19.0.0",
         "react-day-picker": "^9.13.2",
@@ -98,6 +99,28 @@
       },
       "engines": {
         "node": ">=24"
+      }
+    },
+    "node_modules/@antfu/install-pkg": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@antfu/install-pkg/-/install-pkg-1.1.0.tgz",
+      "integrity": "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "package-manager-detector": "^1.3.0",
+        "tinyexec": "^1.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@antfu/install-pkg/node_modules/tinyexec": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
+      "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@apidevtools/json-schema-ref-parser": {
@@ -578,6 +601,49 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@braintree/sanitize-url": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-7.1.2.tgz",
+      "integrity": "sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==",
+      "license": "MIT"
+    },
+    "node_modules/@chevrotain/cst-dts-gen": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@chevrotain/cst-dts-gen/-/cst-dts-gen-12.0.0.tgz",
+      "integrity": "sha512-fSL4KXjTl7cDgf0B5Rip9Q05BOrYvkJV/RrBTE/bKDN096E4hN/ySpcBK5B24T76dlQ2i32Zc3PAE27jFnFrKg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@chevrotain/gast": "12.0.0",
+        "@chevrotain/types": "12.0.0"
+      }
+    },
+    "node_modules/@chevrotain/gast": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@chevrotain/gast/-/gast-12.0.0.tgz",
+      "integrity": "sha512-1ne/m3XsIT8aEdrvT33so0GUC+wkctpUPK6zU9IlOyJLUbR0rg4G7ZiApiJbggpgPir9ERy3FRjT6T7lpgetnQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@chevrotain/types": "12.0.0"
+      }
+    },
+    "node_modules/@chevrotain/regexp-to-ast": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@chevrotain/regexp-to-ast/-/regexp-to-ast-12.0.0.tgz",
+      "integrity": "sha512-p+EW9MaJwgaHguhoqwOtx/FwuGr+DnNn857sXWOi/mClXIkPGl3rn7hGNWvo31HA3vyeQxjqe+H36yZJwYU8cA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@chevrotain/types": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-12.0.0.tgz",
+      "integrity": "sha512-S+04vjFQKeuYw0/eW3U52LkAHQsB1ASxsPGsLPUyQgrZ2iNNibQrsidruDzjEX2JYfespXMG0eZmXlhA6z7nWA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@chevrotain/utils": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-12.0.0.tgz",
+      "integrity": "sha512-lB59uJoaGIfOOL9knQqQRfhl9g7x8/wqFkp13zTdkRu1huG9kg6IJs1O8hqj9rs6h7orGxHJUKb+mX3rPbWGhA==",
+      "license": "Apache-2.0"
     },
     "node_modules/@commander-js/extra-typings": {
       "version": "14.0.0",
@@ -1553,6 +1619,23 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/@iconify/types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@iconify/types/-/types-2.0.0.tgz",
+      "integrity": "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==",
+      "license": "MIT"
+    },
+    "node_modules/@iconify/utils": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@iconify/utils/-/utils-3.1.0.tgz",
+      "integrity": "sha512-Zlzem1ZXhI1iHeeERabLNzBHdOa4VhQbqAcOQaMKuTuyZCpwKbC2R4Dd0Zo3g9EAc+Y4fiarO8HIHRAth7+skw==",
+      "license": "MIT",
+      "dependencies": {
+        "@antfu/install-pkg": "^1.1.0",
+        "@iconify/types": "^2.0.0",
+        "mlly": "^1.8.0"
+      }
+    },
     "node_modules/@isaacs/balanced-match": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz",
@@ -1658,6 +1741,15 @@
       },
       "peerDependencies": {
         "jsep": "^0.4.0||^1.0.0"
+      }
+    },
+    "node_modules/@mermaid-js/parser": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.1.0.tgz",
+      "integrity": "sha512-gxK9ZX2+Fex5zu8LhRQoMeMPEHbc73UKZ0FQ54YrQtUxE1VVhMwzeNtKRPAu5aXks4FasbMe4xB4bWrmq6Jlxw==",
+      "license": "MIT",
+      "dependencies": {
+        "langium": "^4.0.0"
       }
     },
     "node_modules/@napi-rs/canvas": {
@@ -5939,10 +6031,72 @@
         "@types/deep-eql": "*"
       }
     },
+    "node_modules/@types/d3": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@types/d3/-/d3-7.4.3.tgz",
+      "integrity": "sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/d3-axis": "*",
+        "@types/d3-brush": "*",
+        "@types/d3-chord": "*",
+        "@types/d3-color": "*",
+        "@types/d3-contour": "*",
+        "@types/d3-delaunay": "*",
+        "@types/d3-dispatch": "*",
+        "@types/d3-drag": "*",
+        "@types/d3-dsv": "*",
+        "@types/d3-ease": "*",
+        "@types/d3-fetch": "*",
+        "@types/d3-force": "*",
+        "@types/d3-format": "*",
+        "@types/d3-geo": "*",
+        "@types/d3-hierarchy": "*",
+        "@types/d3-interpolate": "*",
+        "@types/d3-path": "*",
+        "@types/d3-polygon": "*",
+        "@types/d3-quadtree": "*",
+        "@types/d3-random": "*",
+        "@types/d3-scale": "*",
+        "@types/d3-scale-chromatic": "*",
+        "@types/d3-selection": "*",
+        "@types/d3-shape": "*",
+        "@types/d3-time": "*",
+        "@types/d3-time-format": "*",
+        "@types/d3-timer": "*",
+        "@types/d3-transition": "*",
+        "@types/d3-zoom": "*"
+      }
+    },
     "node_modules/@types/d3-array": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
       "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-axis": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-axis/-/d3-axis-3.0.6.tgz",
+      "integrity": "sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-brush": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-brush/-/d3-brush-3.0.6.tgz",
+      "integrity": "sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-chord": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-chord/-/d3-chord-3.0.6.tgz",
+      "integrity": "sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==",
       "license": "MIT"
     },
     "node_modules/@types/d3-color": {
@@ -5951,10 +6105,83 @@
       "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
       "license": "MIT"
     },
+    "node_modules/@types/d3-contour": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-contour/-/d3-contour-3.0.6.tgz",
+      "integrity": "sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-dispatch": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-dispatch/-/d3-dispatch-3.0.7.tgz",
+      "integrity": "sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-drag": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.7.tgz",
+      "integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-dsv": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-dsv/-/d3-dsv-3.0.7.tgz",
+      "integrity": "sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==",
+      "license": "MIT"
+    },
     "node_modules/@types/d3-ease": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
       "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-fetch": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-fetch/-/d3-fetch-3.0.7.tgz",
+      "integrity": "sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-dsv": "*"
+      }
+    },
+    "node_modules/@types/d3-force": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-3.0.10.tgz",
+      "integrity": "sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-format": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-3.0.4.tgz",
+      "integrity": "sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-geo": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-3.1.0.tgz",
+      "integrity": "sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-hierarchy": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-3.1.7.tgz",
+      "integrity": "sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==",
       "license": "MIT"
     },
     "node_modules/@types/d3-interpolate": {
@@ -5972,6 +6199,24 @@
       "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
       "license": "MIT"
     },
+    "node_modules/@types/d3-polygon": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-polygon/-/d3-polygon-3.0.2.tgz",
+      "integrity": "sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-quadtree": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-quadtree/-/d3-quadtree-3.0.6.tgz",
+      "integrity": "sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-random": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-random/-/d3-random-3.0.3.tgz",
+      "integrity": "sha512-Imagg1vJ3y76Y2ea0871wpabqp613+8/r0mCLEBfdtqC7xMSfj9idOnmBYyMoULfHePJyxMAw3nWhJxzc+LFwQ==",
+      "license": "MIT"
+    },
     "node_modules/@types/d3-scale": {
       "version": "4.0.9",
       "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
@@ -5980,6 +6225,18 @@
       "dependencies": {
         "@types/d3-time": "*"
       }
+    },
+    "node_modules/@types/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-selection": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
+      "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
+      "license": "MIT"
     },
     "node_modules/@types/d3-shape": {
       "version": "3.1.7",
@@ -5996,11 +6253,36 @@
       "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
       "license": "MIT"
     },
+    "node_modules/@types/d3-time-format": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-4.0.3.tgz",
+      "integrity": "sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==",
+      "license": "MIT"
+    },
     "node_modules/@types/d3-timer": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
       "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
       "license": "MIT"
+    },
+    "node_modules/@types/d3-transition": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.9.tgz",
+      "integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-zoom": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
+      "integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-interpolate": "*",
+        "@types/d3-selection": "*"
+      }
     },
     "node_modules/@types/debug": {
       "version": "4.1.12",
@@ -6042,6 +6324,12 @@
       "dependencies": {
         "@types/estree": "*"
       }
+    },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "license": "MIT"
     },
     "node_modules/@types/hast": {
       "version": "3.0.4",
@@ -6132,6 +6420,13 @@
       "dependencies": {
         "@types/react": "*"
       }
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@types/unist": {
       "version": "3.0.3",
@@ -6413,6 +6708,16 @@
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
       "license": "ISC"
+    },
+    "node_modules/@upsetjs/venn.js": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@upsetjs/venn.js/-/venn.js-2.0.0.tgz",
+      "integrity": "sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "d3-selection": "^3.0.0",
+        "d3-transition": "^3.0.1"
+      }
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.5.1",
@@ -7539,6 +7844,34 @@
         "node": ">= 16"
       }
     },
+    "node_modules/chevrotain": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-12.0.0.tgz",
+      "integrity": "sha512-csJvb+6kEiQaqo1woTdSAuOWdN0WTLIydkKrBnS+V5gZz0oqBrp4kQ35519QgK6TpBThiG3V1vNSHlIkv4AglQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@chevrotain/cst-dts-gen": "12.0.0",
+        "@chevrotain/gast": "12.0.0",
+        "@chevrotain/regexp-to-ast": "12.0.0",
+        "@chevrotain/types": "12.0.0",
+        "@chevrotain/utils": "12.0.0"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/chevrotain-allstar": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/chevrotain-allstar/-/chevrotain-allstar-0.4.1.tgz",
+      "integrity": "sha512-PvVJm3oGqrveUVW2Vt/eZGeiAIsJszYweUcYwcskg9e+IubNYKKD+rHHem7A6XVO22eDAL+inxNIGAzZ/VIWlA==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash-es": "^4.17.21"
+      },
+      "peerDependencies": {
+        "chevrotain": "^12.0.0"
+      }
+    },
     "node_modules/chokidar": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
@@ -7708,6 +8041,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/confbox": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+      "license": "MIT"
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -7719,6 +8058,15 @@
       "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-2.0.0.tgz",
       "integrity": "sha512-RAj4E421UYRgqokKUmotqAwuplYw15qtdXfY+hGzgCJ/MBjCVZcSoHK/kH9kocfjRjcDME7IiDWR/1WX1TM2Pg==",
       "license": "MIT"
+    },
+    "node_modules/cose-base": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/cose-base/-/cose-base-1.0.3.tgz",
+      "integrity": "sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==",
+      "license": "MIT",
+      "dependencies": {
+        "layout-base": "^1.0.0"
+      }
     },
     "node_modules/crelt": {
       "version": "1.0.6",
@@ -7773,6 +8121,95 @@
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "license": "MIT"
     },
+    "node_modules/cytoscape": {
+      "version": "3.33.2",
+      "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.2.tgz",
+      "integrity": "sha512-sj4HXd3DokGhzZAdjDejGvTPLqlt84vNFN8m7bGsOzDY5DyVcxIb2ejIXat2Iy7HxWhdT/N1oKyheJ5YdpsGuw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/cytoscape-cose-bilkent": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cytoscape-cose-bilkent/-/cytoscape-cose-bilkent-4.1.0.tgz",
+      "integrity": "sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cose-base": "^1.0.0"
+      },
+      "peerDependencies": {
+        "cytoscape": "^3.2.0"
+      }
+    },
+    "node_modules/cytoscape-fcose": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cytoscape-fcose/-/cytoscape-fcose-2.2.0.tgz",
+      "integrity": "sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cose-base": "^2.2.0"
+      },
+      "peerDependencies": {
+        "cytoscape": "^3.2.0"
+      }
+    },
+    "node_modules/cytoscape-fcose/node_modules/cose-base": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cose-base/-/cose-base-2.2.0.tgz",
+      "integrity": "sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==",
+      "license": "MIT",
+      "dependencies": {
+        "layout-base": "^2.0.0"
+      }
+    },
+    "node_modules/cytoscape-fcose/node_modules/layout-base": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-2.0.1.tgz",
+      "integrity": "sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==",
+      "license": "MIT"
+    },
+    "node_modules/d3": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/d3/-/d3-7.9.0.tgz",
+      "integrity": "sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "3",
+        "d3-axis": "3",
+        "d3-brush": "3",
+        "d3-chord": "3",
+        "d3-color": "3",
+        "d3-contour": "4",
+        "d3-delaunay": "6",
+        "d3-dispatch": "3",
+        "d3-drag": "3",
+        "d3-dsv": "3",
+        "d3-ease": "3",
+        "d3-fetch": "3",
+        "d3-force": "3",
+        "d3-format": "3",
+        "d3-geo": "3",
+        "d3-hierarchy": "3",
+        "d3-interpolate": "3",
+        "d3-path": "3",
+        "d3-polygon": "3",
+        "d3-quadtree": "3",
+        "d3-random": "3",
+        "d3-scale": "4",
+        "d3-scale-chromatic": "3",
+        "d3-selection": "3",
+        "d3-shape": "3",
+        "d3-time": "3",
+        "d3-time-format": "4",
+        "d3-timer": "3",
+        "d3-transition": "3",
+        "d3-zoom": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/d3-array": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
@@ -7780,6 +8217,43 @@
       "license": "ISC",
       "dependencies": {
         "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-axis": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-3.0.0.tgz",
+      "integrity": "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-brush": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-3.0.0.tgz",
+      "integrity": "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "3",
+        "d3-transition": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-chord": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-3.0.1.tgz",
+      "integrity": "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "1 - 3"
       },
       "engines": {
         "node": ">=12"
@@ -7794,6 +8268,86 @@
         "node": ">=12"
       }
     },
+    "node_modules/d3-contour": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.2.tgz",
+      "integrity": "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
+      "license": "ISC",
+      "dependencies": {
+        "delaunator": "5"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dsv": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-3.0.1.tgz",
+      "integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
+      "license": "ISC",
+      "dependencies": {
+        "commander": "7",
+        "iconv-lite": "0.6",
+        "rw": "1"
+      },
+      "bin": {
+        "csv2json": "bin/dsv2json.js",
+        "csv2tsv": "bin/dsv2dsv.js",
+        "dsv2dsv": "bin/dsv2dsv.js",
+        "dsv2json": "bin/dsv2json.js",
+        "json2csv": "bin/json2dsv.js",
+        "json2dsv": "bin/json2dsv.js",
+        "json2tsv": "bin/json2dsv.js",
+        "tsv2csv": "bin/dsv2dsv.js",
+        "tsv2json": "bin/dsv2json.js"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dsv/node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/d3-ease": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
@@ -7803,10 +8357,57 @@
         "node": ">=12"
       }
     },
+    "node_modules/d3-fetch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-3.0.1.tgz",
+      "integrity": "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dsv": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-force": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
+      "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-quadtree": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/d3-format": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
       "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-geo": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.1.tgz",
+      "integrity": "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.5.0 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-hierarchy": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
+      "integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==",
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -7833,6 +8434,73 @@
         "node": ">=12"
       }
     },
+    "node_modules/d3-polygon": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-3.0.1.tgz",
+      "integrity": "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-quadtree": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-random": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-3.0.1.tgz",
+      "integrity": "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-sankey": {
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/d3-sankey/-/d3-sankey-0.12.3.tgz",
+      "integrity": "sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-array": "1 - 2",
+        "d3-shape": "^1.2.0"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/d3-array": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+      "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "internmap": "^1.0.0"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/d3-path": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
+      "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-sankey/node_modules/d3-shape": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
+      "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-path": "1"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/internmap": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
+      "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==",
+      "license": "ISC"
+    },
     "node_modules/d3-scale": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
@@ -7845,6 +8513,28 @@
         "d3-time": "2.1.1 - 3",
         "d3-time-format": "2 - 4"
       },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-interpolate": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "license": "ISC",
       "engines": {
         "node": ">=12"
       }
@@ -7892,6 +8582,51 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/dagre-d3-es": {
+      "version": "7.0.14",
+      "resolved": "https://registry.npmjs.org/dagre-d3-es/-/dagre-d3-es-7.0.14.tgz",
+      "integrity": "sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==",
+      "license": "MIT",
+      "dependencies": {
+        "d3": "^7.9.0",
+        "lodash-es": "^4.17.21"
       }
     },
     "node_modules/data-urls": {
@@ -7982,7 +8717,6 @@
       "version": "1.11.19",
       "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.19.tgz",
       "integrity": "sha512-t5EcLVS6QPBNqM2z8fakk/NKel+Xzshgt8FFKAn+qwlD1pzZWxh0nVCrvFK7ZDb6XucZeF9z8C7CBWTRIVApAw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/debug": {
@@ -8102,6 +8836,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/delaunator": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.1.0.tgz",
+      "integrity": "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==",
+      "license": "ISC",
+      "dependencies": {
+        "robust-predicates": "^3.0.2"
       }
     },
     "node_modules/delayed-stream": {
@@ -8454,6 +9197,15 @@
       "dependencies": {
         "@babel/runtime": "^7.8.7",
         "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.0.tgz",
+      "integrity": "sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/dunder-proto": {
@@ -9965,6 +10717,12 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "license": "ISC"
     },
+    "node_modules/hachure-fill": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/hachure-fill/-/hachure-fill-0.5.2.tgz",
+      "integrity": "sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==",
+      "license": "MIT"
+    },
     "node_modules/has-bigints": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
@@ -10345,7 +11103,6 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -11315,6 +12072,31 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/katex": {
+      "version": "0.16.45",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.45.tgz",
+      "integrity": "sha512-pQpZbdBu7wCTmQUh7ufPmLr0pFoObnGUoL/yhtwJDgmmQpbkg/0HSVti25Fu4rmd1oCR6NGWe9vqTWuWv3GcNA==",
+      "funding": [
+        "https://opencollective.com/katex",
+        "https://github.com/sponsors/katex"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^8.3.0"
+      },
+      "bin": {
+        "katex": "cli.js"
+      }
+    },
+    "node_modules/katex/node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -11324,6 +12106,11 @@
       "dependencies": {
         "json-buffer": "3.0.1"
       }
+    },
+    "node_modules/khroma": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/khroma/-/khroma-2.1.0.tgz",
+      "integrity": "sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw=="
     },
     "node_modules/kleur": {
       "version": "3.0.3",
@@ -11412,6 +12199,30 @@
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
+    },
+    "node_modules/langium": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/langium/-/langium-4.2.2.tgz",
+      "integrity": "sha512-JUshTRAfHI4/MF9dH2WupvjSXyn8JBuUEWazB8ZVJUtXutT0doDlAv1XKbZ1Pb5sMexa8FF4CFBc0iiul7gbUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@chevrotain/regexp-to-ast": "~12.0.0",
+        "chevrotain": "~12.0.0",
+        "chevrotain-allstar": "~0.4.1",
+        "vscode-languageserver": "~9.0.1",
+        "vscode-languageserver-textdocument": "~1.0.11",
+        "vscode-uri": "~3.1.0"
+      },
+      "engines": {
+        "node": ">=20.10.0",
+        "npm": ">=10.2.3"
+      }
+    },
+    "node_modules/layout-base": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-1.0.2.tgz",
+      "integrity": "sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==",
+      "license": "MIT"
     },
     "node_modules/leven": {
       "version": "3.1.0",
@@ -11723,6 +12534,12 @@
       "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
       "license": "MIT"
     },
+    "node_modules/lodash-es": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
+      "license": "MIT"
+    },
     "node_modules/lodash.get": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
@@ -11998,6 +12815,18 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/marked": {
+      "version": "16.4.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-16.4.2.tgz",
+      "integrity": "sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/math-intrinsics": {
@@ -12312,6 +13141,35 @@
       "license": "MIT",
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/mermaid": {
+      "version": "11.14.0",
+      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.14.0.tgz",
+      "integrity": "sha512-GSGloRsBs+JINmmhl0JDwjpuezCsHB4WGI4NASHxL3fHo3o/BRXTxhDLKnln8/Q0lRFRyDdEjmk1/d5Sn1Xz8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@braintree/sanitize-url": "^7.1.1",
+        "@iconify/utils": "^3.0.2",
+        "@mermaid-js/parser": "^1.1.0",
+        "@types/d3": "^7.4.3",
+        "@upsetjs/venn.js": "^2.0.0",
+        "cytoscape": "^3.33.1",
+        "cytoscape-cose-bilkent": "^4.1.0",
+        "cytoscape-fcose": "^2.2.0",
+        "d3": "^7.9.0",
+        "d3-sankey": "^0.12.3",
+        "dagre-d3-es": "7.0.14",
+        "dayjs": "^1.11.19",
+        "dompurify": "^3.3.1",
+        "katex": "^0.16.25",
+        "khroma": "^2.1.0",
+        "lodash-es": "^4.17.23",
+        "marked": "^16.3.0",
+        "roughjs": "^4.6.6",
+        "stylis": "^4.3.6",
+        "ts-dedent": "^2.2.0",
+        "uuid": "^11.1.0"
       }
     },
     "node_modules/micromark": {
@@ -12946,6 +13804,30 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mlly": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.2.tgz",
+      "integrity": "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==",
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "pathe": "^2.0.3",
+        "pkg-types": "^1.3.1",
+        "ufo": "^1.6.3"
+      }
+    },
+    "node_modules/mlly/node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/module-definition": {
@@ -13617,6 +14499,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/package-manager-detector": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.6.0.tgz",
+      "integrity": "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==",
+      "license": "MIT"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -13677,6 +14565,12 @@
       "funding": {
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
+    },
+    "node_modules/path-data-parser": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/path-data-parser/-/path-data-parser-0.1.0.tgz",
+      "integrity": "sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==",
+      "license": "MIT"
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
@@ -13762,6 +14656,17 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/pkg-types": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.1.8",
+        "mlly": "^1.7.4",
+        "pathe": "^2.0.1"
+      }
+    },
     "node_modules/pluralize": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
@@ -13770,6 +14675,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/points-on-curve": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/points-on-curve/-/points-on-curve-0.2.0.tgz",
+      "integrity": "sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==",
+      "license": "MIT"
+    },
+    "node_modules/points-on-path": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/points-on-path/-/points-on-path-0.2.1.tgz",
+      "integrity": "sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==",
+      "license": "MIT",
+      "dependencies": {
+        "path-data-parser": "0.1.0",
+        "points-on-curve": "0.2.0"
       }
     },
     "node_modules/pony-cause": {
@@ -15090,6 +16011,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/robust-predicates": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.3.tgz",
+      "integrity": "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==",
+      "license": "Unlicense"
+    },
     "node_modules/rollup": {
       "version": "4.41.1",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.41.1.tgz",
@@ -15135,6 +16062,18 @@
       "integrity": "sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ==",
       "license": "MIT"
     },
+    "node_modules/roughjs": {
+      "version": "4.6.6",
+      "resolved": "https://registry.npmjs.org/roughjs/-/roughjs-4.6.6.tgz",
+      "integrity": "sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "hachure-fill": "^0.5.2",
+        "path-data-parser": "^0.1.0",
+        "points-on-curve": "^0.2.0",
+        "points-on-path": "^0.2.1"
+      }
+    },
     "node_modules/rrweb-cssom": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
@@ -15165,6 +16104,12 @@
       "dependencies": {
         "queue-microtask": "^1.2.2"
       }
+    },
+    "node_modules/rw": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/safe-array-concat": {
       "version": "1.1.3",
@@ -15263,7 +16208,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/sass-lookup": {
@@ -15942,6 +16886,12 @@
         "inline-style-parser": "0.2.4"
       }
     },
+    "node_modules/stylis": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.6.tgz",
+      "integrity": "sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ==",
+      "license": "MIT"
+    },
     "node_modules/stylus-lookup": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/stylus-lookup/-/stylus-lookup-6.1.0.tgz",
@@ -16332,6 +17282,15 @@
         "typescript": ">=4.8.4"
       }
     },
+    "node_modules/ts-dedent": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.2.0.tgz",
+      "integrity": "sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.10"
+      }
+    },
     "node_modules/ts-graphviz": {
       "version": "2.1.6",
       "resolved": "https://registry.npmjs.org/ts-graphviz/-/ts-graphviz-2.1.6.tgz",
@@ -16618,6 +17577,12 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
       "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "license": "MIT"
+    },
+    "node_modules/ufo": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.3.tgz",
+      "integrity": "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==",
       "license": "MIT"
     },
     "node_modules/unbox-primitive": {
@@ -16929,6 +17894,19 @@
         "node": ">= 4"
       }
     },
+    "node_modules/uuid": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
+    },
     "node_modules/validator": {
       "version": "13.15.26",
       "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.26.tgz",
@@ -17206,6 +18184,55 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/vscode-jsonrpc": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
+      "integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/vscode-languageserver": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-9.0.1.tgz",
+      "integrity": "sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==",
+      "license": "MIT",
+      "dependencies": {
+        "vscode-languageserver-protocol": "3.17.5"
+      },
+      "bin": {
+        "installServerIntoExtension": "bin/installServerIntoExtension"
+      }
+    },
+    "node_modules/vscode-languageserver-protocol": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
+      "integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
+      "license": "MIT",
+      "dependencies": {
+        "vscode-jsonrpc": "8.2.0",
+        "vscode-languageserver-types": "3.17.5"
+      }
+    },
+    "node_modules/vscode-languageserver-textdocument": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
+      "integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==",
+      "license": "MIT"
+    },
+    "node_modules/vscode-languageserver-types": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
+      "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
+      "license": "MIT"
+    },
+    "node_modules/vscode-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
+      "integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
+      "license": "MIT"
     },
     "node_modules/w3c-keyname": {
       "version": "2.2.8",

--- a/ayunis-core-frontend/package.json
+++ b/ayunis-core-frontend/package.json
@@ -64,6 +64,7 @@
     "i18next": "^25.8.10",
     "i18next-browser-languagedetector": "^8.2.0",
     "lucide-react": "^0.476.0",
+    "mermaid": "^11.14.0",
     "pdfjs-dist": "^5.5.207",
     "react": "^19.0.0",
     "react-day-picker": "^9.13.2",

--- a/ayunis-core-frontend/src/pages/chat/ui/ChatMessage.tsx
+++ b/ayunis-core-frontend/src/pages/chat/ui/ChatMessage.tsx
@@ -33,10 +33,8 @@ import CreateSkillWidget from './chat-widgets/CreateSkillWidget';
 import EditSkillWidget from './chat-widgets/EditSkillWidget';
 import ActivateSkillWidget from './chat-widgets/ActivateSkillWidget';
 import SkillInstructionWidget from './chat-widgets/SkillInstructionWidget';
-import CreateDocumentWidget from './chat-widgets/CreateDocumentWidget';
-import UpdateDocumentWidget from './chat-widgets/UpdateDocumentWidget';
-import EditDocumentWidget from './chat-widgets/EditDocumentWidget';
 import GenerateImageWidget from './chat-widgets/GenerateImageWidget';
+import { renderArtifactToolWidget } from './chat-widgets/renderArtifactToolWidget';
 import {
   BarChartWidget,
   LineChartWidget,
@@ -290,7 +288,7 @@ function renderMessageContent(
         return null;
       }
 
-      // eslint-disable-next-line sonarjs/cognitive-complexity
+      // eslint-disable-next-line sonarjs/cognitive-complexity, sonarjs/function-return-type -- tool-use switch returns many distinct JSX widget types
       return message.content.map((content: AssistantMessageContent, index) => {
         if (content.type === 'thinking') {
           const thinkingMessageContent = content as ThinkingMessageContent;
@@ -410,44 +408,15 @@ function renderMessageContent(
               );
             }
 
-            if (
-              toolUseMessageContent.name ===
-              ToolAssignmentDtoType.create_document
-            ) {
-              return (
-                <CreateDocumentWidget
-                  key={`create-document-${index}-${toolUseMessageContent.name.slice(0, 50)}`}
-                  content={toolUseMessageContent}
-                  isStreaming={isStreaming}
-                  threadId={threadId ?? ''}
-                  onOpenArtifact={onOpenArtifact}
-                />
-              );
-            }
-            if (
-              toolUseMessageContent.name ===
-              ToolAssignmentDtoType.update_document
-            ) {
-              return (
-                <UpdateDocumentWidget
-                  key={`update-document-${index}-${toolUseMessageContent.name.slice(0, 50)}`}
-                  content={toolUseMessageContent}
-                  isStreaming={isStreaming}
-                  onOpenArtifact={onOpenArtifact}
-                />
-              );
-            }
-            if (
-              toolUseMessageContent.name === ToolAssignmentDtoType.edit_document
-            ) {
-              return (
-                <EditDocumentWidget
-                  key={`edit-document-${index}-${toolUseMessageContent.name.slice(0, 50)}`}
-                  content={toolUseMessageContent}
-                  isStreaming={isStreaming}
-                  onOpenArtifact={onOpenArtifact}
-                />
-              );
+            const artifactWidget = renderArtifactToolWidget({
+              content: toolUseMessageContent,
+              index,
+              isStreaming,
+              threadId: threadId ?? '',
+              onOpenArtifact,
+            });
+            if (artifactWidget) {
+              return artifactWidget;
             }
             if (
               toolUseMessageContent.name ===

--- a/ayunis-core-frontend/src/pages/chat/ui/ChatPage.tsx
+++ b/ayunis-core-frontend/src/pages/chat/ui/ChatPage.tsx
@@ -58,6 +58,12 @@ const LazyArtifactEditor = lazy(() =>
   })),
 );
 
+const LazyDiagramViewer = lazy(() =>
+  import('@/widgets/diagram-viewer').then((m) => ({
+    default: m.DiagramViewer,
+  })),
+);
+
 const PROCESSING_POLL_INTERVAL = 5000;
 
 interface ChatPageProps {
@@ -430,15 +436,22 @@ export default function ChatPage({
         sidePanel={
           openArtifact ? (
             <Suspense fallback={null}>
-              <LazyArtifactEditor
-                artifact={openArtifact}
-                onSave={handleSaveArtifact}
-                onRevert={handleRevertArtifact}
-                onExport={handleExportArtifact}
-                onClose={handleCloseArtifact}
-                onLetterheadChange={handleLetterheadChange}
-                isExporting={isExporting}
-              />
+              {openArtifact.type === 'diagram' ? (
+                <LazyDiagramViewer
+                  artifact={openArtifact}
+                  onClose={handleCloseArtifact}
+                />
+              ) : (
+                <LazyArtifactEditor
+                  artifact={openArtifact}
+                  onSave={handleSaveArtifact}
+                  onRevert={handleRevertArtifact}
+                  onExport={handleExportArtifact}
+                  onClose={handleCloseArtifact}
+                  onLetterheadChange={handleLetterheadChange}
+                  isExporting={isExporting}
+                />
+              )}
             </Suspense>
           ) : undefined
         }

--- a/ayunis-core-frontend/src/pages/chat/ui/chat-widgets/CreateDiagramWidget.tsx
+++ b/ayunis-core-frontend/src/pages/chat/ui/chat-widgets/CreateDiagramWidget.tsx
@@ -1,0 +1,81 @@
+import type { ReactNode } from 'react';
+import type { TFunction } from 'i18next';
+import type { ToolUseMessageContent } from '../../model/openapi';
+import { useTranslation } from 'react-i18next';
+import { Check, Workflow } from 'lucide-react';
+import { useThreadArtifacts } from '../../api/useThreadArtifacts';
+import { DocumentWidgetCard } from './DocumentWidgetCard';
+
+// eslint-disable-next-line sonarjs/function-return-type -- intentional: returns JSX or string, both valid ReactNode
+function getCreateStatusLabel(
+  artifactId: string | null,
+  isStreaming: boolean,
+  t: TFunction<'chat'>,
+): ReactNode {
+  if (artifactId) {
+    return (
+      <span className="flex items-center gap-1">
+        <Check className="size-3" />
+        {t('chat.tools.create_diagram.created')}
+      </span>
+    );
+  }
+  if (isStreaming) {
+    return t('chat.tools.create_diagram.generating');
+  }
+  return t('chat.tools.create_diagram.title');
+}
+
+interface CreateDiagramWidgetProps {
+  readonly content: ToolUseMessageContent;
+  readonly isStreaming?: boolean;
+  readonly threadId: string;
+  readonly onOpenArtifact?: (artifactId: string) => void;
+}
+
+export default function CreateDiagramWidget({
+  content,
+  isStreaming = false,
+  threadId,
+  onOpenArtifact,
+}: CreateDiagramWidgetProps) {
+  const { t } = useTranslation('chat');
+
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- content.params may be undefined during streaming even if typed as required
+  const params = (content.params || {}) as {
+    title?: string;
+    content?: string;
+  };
+
+  const { artifacts } = useThreadArtifacts(threadId);
+  const artifactId =
+    artifacts
+      .filter((a) => a.title === params.title && a.type === 'diagram')
+      .sort(
+        (a, b) =>
+          new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+      )[0]?.id ?? null;
+
+  const handleOpen = () => {
+    if (artifactId && onOpenArtifact) {
+      onOpenArtifact(artifactId);
+    }
+  };
+
+  const statusLabel = getCreateStatusLabel(artifactId, isStreaming, t);
+
+  return (
+    <DocumentWidgetCard
+      contentKey={content.name}
+      contentId={content.id}
+      isStreaming={isStreaming}
+      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- empty string during streaming should fall back to translation
+      title={params.title || t('chat.tools.create_diagram.title')}
+      statusLabel={statusLabel}
+      buttonLabel={t('chat.tools.create_diagram.openInEditor')}
+      artifactId={artifactId}
+      onOpen={handleOpen}
+      icon={Workflow}
+    />
+  );
+}

--- a/ayunis-core-frontend/src/pages/chat/ui/chat-widgets/DocumentWidgetCard.tsx
+++ b/ayunis-core-frontend/src/pages/chat/ui/chat-widgets/DocumentWidgetCard.tsx
@@ -1,6 +1,6 @@
 import { Button } from '@/shared/ui/shadcn/button';
 import { cn } from '@/shared/lib/shadcn/utils';
-import { FileText, ExternalLink } from 'lucide-react';
+import { FileText, ExternalLink, type LucideIcon } from 'lucide-react';
 import type { ReactNode } from 'react';
 
 interface DocumentWidgetCardProps {
@@ -12,6 +12,7 @@ interface DocumentWidgetCardProps {
   readonly buttonLabel: string;
   readonly artifactId: string | null;
   readonly onOpen: () => void;
+  readonly icon?: LucideIcon;
 }
 
 export function DocumentWidgetCard({
@@ -23,6 +24,7 @@ export function DocumentWidgetCard({
   buttonLabel,
   artifactId,
   onOpen,
+  icon: Icon = FileText,
 }: DocumentWidgetCardProps) {
   return (
     <div
@@ -36,7 +38,7 @@ export function DocumentWidgetCard({
             isStreaming && 'animate-pulse',
           )}
         >
-          <FileText className="size-5 text-primary" />
+          <Icon className="size-5 text-primary" />
         </div>
         <div className="flex-1 min-w-0">
           <p

--- a/ayunis-core-frontend/src/pages/chat/ui/chat-widgets/UpdateDiagramWidget.tsx
+++ b/ayunis-core-frontend/src/pages/chat/ui/chat-widgets/UpdateDiagramWidget.tsx
@@ -2,12 +2,12 @@ import type { ReactNode } from 'react';
 import type { TFunction } from 'i18next';
 import type { ToolUseMessageContent } from '../../model/openapi';
 import { useTranslation } from 'react-i18next';
-import { Check } from 'lucide-react';
+import { Check, Workflow } from 'lucide-react';
 import { DocumentWidgetCard } from './DocumentWidgetCard';
 import { useUpdateArtifactWidget } from './useUpdateArtifactWidget';
 
 // eslint-disable-next-line sonarjs/function-return-type -- intentional: returns JSX or string, both valid ReactNode
-function getUpdateStatusLabel(
+function getStatusLabel(
   artifactId: string,
   isStreaming: boolean,
   t: TFunction<'chat'>,
@@ -16,27 +16,27 @@ function getUpdateStatusLabel(
     return (
       <span className="flex items-center gap-1">
         <Check className="size-3" />
-        {t('chat.tools.update_document.updated')}
+        {t('chat.tools.update_diagram.updated')}
       </span>
     );
   }
   if (isStreaming) {
-    return t('chat.tools.update_document.generating');
+    return t('chat.tools.update_diagram.generating');
   }
-  return t('chat.tools.update_document.title');
+  return t('chat.tools.update_diagram.title');
 }
 
-interface UpdateDocumentWidgetProps {
+interface UpdateDiagramWidgetProps {
   readonly content: ToolUseMessageContent;
   readonly isStreaming?: boolean;
   readonly onOpenArtifact?: (artifactId: string) => void;
 }
 
-export default function UpdateDocumentWidget({
+export default function UpdateDiagramWidget({
   content,
   isStreaming = false,
   onOpenArtifact,
-}: UpdateDocumentWidgetProps) {
+}: UpdateDiagramWidgetProps) {
   const { t } = useTranslation('chat');
   const { artifactId, handleOpen } = useUpdateArtifactWidget(
     content,
@@ -48,11 +48,12 @@ export default function UpdateDocumentWidget({
       contentKey={content.name}
       contentId={content.id}
       isStreaming={isStreaming}
-      title={t('chat.tools.update_document.title')}
-      statusLabel={getUpdateStatusLabel(artifactId, isStreaming, t)}
-      buttonLabel={t('chat.tools.update_document.openInEditor')}
+      title={t('chat.tools.update_diagram.title')}
+      statusLabel={getStatusLabel(artifactId, isStreaming, t)}
+      buttonLabel={t('chat.tools.update_diagram.openInEditor')}
       artifactId={artifactId || null}
       onOpen={handleOpen}
+      icon={Workflow}
     />
   );
 }

--- a/ayunis-core-frontend/src/pages/chat/ui/chat-widgets/renderArtifactToolWidget.tsx
+++ b/ayunis-core-frontend/src/pages/chat/ui/chat-widgets/renderArtifactToolWidget.tsx
@@ -1,0 +1,83 @@
+import type { ReactNode } from 'react';
+import type { ToolUseMessageContent } from '../../model/openapi';
+import { ToolAssignmentDtoType } from '@/shared/api/generated/ayunisCoreAPI.schemas';
+import CreateDocumentWidget from './CreateDocumentWidget';
+import UpdateDocumentWidget from './UpdateDocumentWidget';
+import EditDocumentWidget from './EditDocumentWidget';
+import CreateDiagramWidget from './CreateDiagramWidget';
+import UpdateDiagramWidget from './UpdateDiagramWidget';
+
+/**
+ * Renders the chat widget for any document- or diagram-related tool call.
+ * Returns null when the tool call is not an artifact tool, so the caller can
+ * continue its switch with other widget types.
+ */
+// eslint-disable-next-line sonarjs/function-return-type -- returns JSX or null based on tool type
+export function renderArtifactToolWidget(params: {
+  content: ToolUseMessageContent;
+  index: number;
+  isStreaming?: boolean;
+  threadId: string;
+  onOpenArtifact?: (artifactId: string) => void;
+}): ReactNode {
+  const {
+    content,
+    index,
+    isStreaming = false,
+    threadId,
+    onOpenArtifact,
+  } = params;
+  const keySuffix = `${index}-${content.name.slice(0, 50)}`;
+
+  switch (content.name) {
+    case ToolAssignmentDtoType.create_document:
+      return (
+        <CreateDocumentWidget
+          key={`create-document-${keySuffix}`}
+          content={content}
+          isStreaming={isStreaming}
+          threadId={threadId}
+          onOpenArtifact={onOpenArtifact}
+        />
+      );
+    case ToolAssignmentDtoType.update_document:
+      return (
+        <UpdateDocumentWidget
+          key={`update-document-${keySuffix}`}
+          content={content}
+          isStreaming={isStreaming}
+          onOpenArtifact={onOpenArtifact}
+        />
+      );
+    case ToolAssignmentDtoType.edit_document:
+      return (
+        <EditDocumentWidget
+          key={`edit-document-${keySuffix}`}
+          content={content}
+          isStreaming={isStreaming}
+          onOpenArtifact={onOpenArtifact}
+        />
+      );
+    case ToolAssignmentDtoType.create_diagram:
+      return (
+        <CreateDiagramWidget
+          key={`create-diagram-${keySuffix}`}
+          content={content}
+          isStreaming={isStreaming}
+          threadId={threadId}
+          onOpenArtifact={onOpenArtifact}
+        />
+      );
+    case ToolAssignmentDtoType.update_diagram:
+      return (
+        <UpdateDiagramWidget
+          key={`update-diagram-${keySuffix}`}
+          content={content}
+          isStreaming={isStreaming}
+          onOpenArtifact={onOpenArtifact}
+        />
+      );
+    default:
+      return null;
+  }
+}

--- a/ayunis-core-frontend/src/pages/chat/ui/chat-widgets/useUpdateArtifactWidget.ts
+++ b/ayunis-core-frontend/src/pages/chat/ui/chat-widgets/useUpdateArtifactWidget.ts
@@ -1,0 +1,29 @@
+import { useCallback } from 'react';
+import type { ToolUseMessageContent } from '../../model/openapi';
+
+/**
+ * Shared logic for the update-document and update-diagram chat widgets.
+ * Both display an "updated"/"updating" status card linked to an existing
+ * artifact by ID from the tool-use params; only the icon and i18n key prefix
+ * differ between them.
+ */
+export function useUpdateArtifactWidget(
+  content: ToolUseMessageContent,
+  onOpenArtifact?: (artifactId: string) => void,
+) {
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- content.params may be undefined during streaming even if typed as required
+  const params = (content.params || {}) as {
+    artifact_id?: string;
+    content?: string;
+  };
+
+  const artifactId = params.artifact_id ?? '';
+
+  const handleOpen = useCallback(() => {
+    if (artifactId && onOpenArtifact) {
+      onOpenArtifact(artifactId);
+    }
+  }, [artifactId, onOpenArtifact]);
+
+  return { artifactId, handleOpen };
+}

--- a/ayunis-core-frontend/src/shared/locales/de/artifacts.json
+++ b/ayunis-core-frontend/src/shared/locales/de/artifacts.json
@@ -37,5 +37,12 @@
     "current": "(aktuell)",
     "revertTo": "Zurücksetzen auf v{{version}}",
     "revert": "Zurücksetzen"
+  },
+  "diagram": {
+    "export": {
+      "svg": "SVG",
+      "png": "PNG",
+      "failed": "Diagramm-Export fehlgeschlagen"
+    }
   }
 }

--- a/ayunis-core-frontend/src/shared/locales/de/chat.json
+++ b/ayunis-core-frontend/src/shared/locales/de/chat.json
@@ -103,6 +103,20 @@
         "generating": "Änderungen werden angewendet…",
         "openInEditor": "Im Editor öffnen"
       },
+      "create_diagram": {
+        "title": "Diagramm",
+        "created": "Diagramm erstellt",
+        "creating": "Diagramm wird erstellt…",
+        "generating": "Diagramm wird generiert…",
+        "openInEditor": "Diagramm öffnen"
+      },
+      "update_diagram": {
+        "title": "Diagramm aktualisiert",
+        "updated": "Diagramm aktualisiert",
+        "updating": "Diagramm wird aktualisiert…",
+        "generating": "Aktualisierung wird generiert…",
+        "openInEditor": "Diagramm öffnen"
+      },
       "create_calendar_event": {
         "title": "Titel",
         "titlePlaceholder": "Ereignistitel",

--- a/ayunis-core-frontend/src/shared/locales/en/artifacts.json
+++ b/ayunis-core-frontend/src/shared/locales/en/artifacts.json
@@ -37,5 +37,12 @@
     "current": "(current)",
     "revertTo": "Revert to v{{version}}",
     "revert": "Revert"
+  },
+  "diagram": {
+    "export": {
+      "svg": "SVG",
+      "png": "PNG",
+      "failed": "Failed to export diagram"
+    }
   }
 }

--- a/ayunis-core-frontend/src/shared/locales/en/chat.json
+++ b/ayunis-core-frontend/src/shared/locales/en/chat.json
@@ -103,6 +103,20 @@
         "generating": "Applying edits…",
         "openInEditor": "Open in Editor"
       },
+      "create_diagram": {
+        "title": "Diagram",
+        "created": "Diagram created",
+        "creating": "Creating diagram…",
+        "generating": "Generating diagram…",
+        "openInEditor": "Open diagram"
+      },
+      "update_diagram": {
+        "title": "Diagram updated",
+        "updated": "Diagram updated",
+        "updating": "Updating diagram…",
+        "generating": "Generating update…",
+        "openInEditor": "Open diagram"
+      },
       "create_calendar_event": {
         "title": "Title",
         "titlePlaceholder": "Event title",

--- a/ayunis-core-frontend/src/widgets/artifact-editor/index.ts
+++ b/ayunis-core-frontend/src/widgets/artifact-editor/index.ts
@@ -1,1 +1,2 @@
 export { ArtifactEditor } from './ui/ArtifactEditor';
+export { VersionHistory } from './ui/VersionHistory';

--- a/ayunis-core-frontend/src/widgets/artifact-editor/ui/VersionHistory.tsx
+++ b/ayunis-core-frontend/src/widgets/artifact-editor/ui/VersionHistory.tsx
@@ -3,11 +3,22 @@ import { Button } from '@/shared/ui/shadcn/button';
 import { ChevronDown, ChevronRight, History, RotateCcw } from 'lucide-react';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { cn } from '@/shared/lib/shadcn/utils';
 
 interface VersionHistoryProps {
   readonly versions: ArtifactVersionResponseDto[];
   readonly currentVersionNumber: number;
-  readonly onRevert: (versionNumber: number) => void;
+  /**
+   * Shows a "Revert" button next to non-current versions. When omitted, no
+   * revert action is offered (used by the read-only diagram viewer).
+   */
+  readonly onRevert?: (versionNumber: number) => void;
+  /**
+   * When provided, each row is clickable and calls this with the selected
+   * version number (used by the diagram viewer for navigation). The row
+   * matching `currentVersionNumber` is highlighted.
+   */
+  readonly onSelect?: (versionNumber: number) => void;
 }
 
 function formatTimestamp(iso: string): string {
@@ -24,6 +35,7 @@ export function VersionHistory({
   versions,
   currentVersionNumber,
   onRevert,
+  onSelect,
 }: VersionHistoryProps) {
   const { t } = useTranslation('artifacts');
   const [isOpen, setIsOpen] = useState(false);
@@ -50,40 +62,68 @@ export function VersionHistory({
 
       {isOpen && (
         <div className="max-h-48 overflow-y-auto px-3 pb-2">
-          {sortedVersions.map((version) => (
-            <div
-              key={version.id}
-              className="flex items-center justify-between rounded px-2 py-1.5 text-sm"
-            >
-              <div className="flex flex-col">
-                <span className="font-medium">
-                  v{version.versionNumber}
-                  {version.versionNumber === currentVersionNumber && (
-                    <span className="text-muted-foreground ml-1">
-                      {t('versionHistory.current')}
-                    </span>
+          {sortedVersions.map((version) => {
+            const isCurrent = version.versionNumber === currentVersionNumber;
+            const rowBody = (
+              <>
+                <div className="flex flex-col items-start">
+                  <span className="text-sm font-medium">
+                    v{version.versionNumber}
+                    {isCurrent && (
+                      <span className="text-muted-foreground ml-1">
+                        {t('versionHistory.current')}
+                      </span>
+                    )}
+                  </span>
+                  <span className="text-muted-foreground text-xs">
+                    {version.authorType} · {formatTimestamp(version.createdAt)}
+                  </span>
+                </div>
+                {onRevert && !isCurrent && (
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="h-7 px-2"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onRevert(version.versionNumber);
+                    }}
+                    title={t('versionHistory.revertTo', {
+                      version: version.versionNumber,
+                    })}
+                  >
+                    <RotateCcw className="mr-1 size-3" />
+                    {t('versionHistory.revert')}
+                  </Button>
+                )}
+              </>
+            );
+
+            if (onSelect) {
+              return (
+                <button
+                  key={version.id}
+                  type="button"
+                  className={cn(
+                    'hover:bg-muted flex w-full items-center justify-between rounded px-2 py-1.5 text-sm',
+                    isCurrent && 'bg-muted',
                   )}
-                </span>
-                <span className="text-muted-foreground text-xs">
-                  {version.authorType} · {formatTimestamp(version.createdAt)}
-                </span>
-              </div>
-              {version.versionNumber !== currentVersionNumber && (
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  className="h-7 px-2"
-                  onClick={() => onRevert(version.versionNumber)}
-                  title={t('versionHistory.revertTo', {
-                    version: version.versionNumber,
-                  })}
+                  onClick={() => onSelect(version.versionNumber)}
                 >
-                  <RotateCcw className="mr-1 size-3" />
-                  {t('versionHistory.revert')}
-                </Button>
-              )}
-            </div>
-          ))}
+                  {rowBody}
+                </button>
+              );
+            }
+
+            return (
+              <div
+                key={version.id}
+                className="flex items-center justify-between rounded px-2 py-1.5 text-sm"
+              >
+                {rowBody}
+              </div>
+            );
+          })}
         </div>
       )}
     </div>

--- a/ayunis-core-frontend/src/widgets/diagram-viewer/index.ts
+++ b/ayunis-core-frontend/src/widgets/diagram-viewer/index.ts
@@ -1,0 +1,1 @@
+export { DiagramViewer } from './ui/DiagramViewer';

--- a/ayunis-core-frontend/src/widgets/diagram-viewer/ui/DiagramExportButtons.tsx
+++ b/ayunis-core-frontend/src/widgets/diagram-viewer/ui/DiagramExportButtons.tsx
@@ -1,0 +1,102 @@
+import { Button } from '@/shared/ui/shadcn/button';
+import { Download } from 'lucide-react';
+import { useCallback, type RefObject } from 'react';
+import { useTranslation } from 'react-i18next';
+import { showError } from '@/shared/lib/toast';
+
+interface DiagramExportButtonsProps {
+  readonly containerRef: RefObject<HTMLDivElement | null>;
+  readonly fileName: string;
+}
+
+function triggerDownload(blob: Blob, fileName: string) {
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = fileName;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  URL.revokeObjectURL(url);
+}
+
+function safeTitle(input: string): string {
+  return input.replace(/[^a-zA-Z0-9-_ ]/g, '').trim() || 'diagram';
+}
+
+export function DiagramExportButtons({
+  containerRef,
+  fileName,
+}: DiagramExportButtonsProps) {
+  const { t } = useTranslation('artifacts');
+
+  const handleSvgExport = useCallback(() => {
+    const svg = containerRef.current?.querySelector('svg');
+    if (!svg) return;
+    const serializer = new XMLSerializer();
+    const svgString = serializer.serializeToString(svg);
+    const blob = new Blob([svgString], { type: 'image/svg+xml' });
+    triggerDownload(blob, `${safeTitle(fileName)}.svg`);
+  }, [containerRef, fileName]);
+
+  const handlePngExport = useCallback(() => {
+    const svg = containerRef.current?.querySelector('svg');
+    if (!svg) return;
+    const serializer = new XMLSerializer();
+    const svgString = serializer.serializeToString(svg);
+    const blob = new Blob([svgString], { type: 'image/svg+xml' });
+    const url = URL.createObjectURL(blob);
+
+    const img = new Image();
+    img.onload = () => {
+      const canvas = document.createElement('canvas');
+      const width = svg.clientWidth || 800;
+      const height = svg.clientHeight || 600;
+      const scale = 2;
+      canvas.width = width * scale;
+      canvas.height = height * scale;
+      const ctx = canvas.getContext('2d');
+      if (!ctx) {
+        URL.revokeObjectURL(url);
+        showError(t('diagram.export.failed'));
+        return;
+      }
+      ctx.scale(scale, scale);
+      ctx.drawImage(img, 0, 0, width, height);
+      URL.revokeObjectURL(url);
+      canvas.toBlob((pngBlob) => {
+        if (pngBlob) {
+          triggerDownload(pngBlob, `${safeTitle(fileName)}.png`);
+        }
+      }, 'image/png');
+    };
+    img.onerror = () => {
+      URL.revokeObjectURL(url);
+      showError(t('diagram.export.failed'));
+    };
+    img.src = url;
+  }, [containerRef, fileName, t]);
+
+  return (
+    <>
+      <Button
+        variant="outline"
+        size="sm"
+        className="h-8"
+        onClick={handleSvgExport}
+      >
+        <Download className="mr-1 size-3.5" />
+        {t('diagram.export.svg')}
+      </Button>
+      <Button
+        variant="outline"
+        size="sm"
+        className="h-8"
+        onClick={handlePngExport}
+      >
+        <Download className="mr-1 size-3.5" />
+        {t('diagram.export.png')}
+      </Button>
+    </>
+  );
+}

--- a/ayunis-core-frontend/src/widgets/diagram-viewer/ui/DiagramViewer.tsx
+++ b/ayunis-core-frontend/src/widgets/diagram-viewer/ui/DiagramViewer.tsx
@@ -1,0 +1,71 @@
+import type { ArtifactResponseDto } from '@/shared/api';
+import { Button } from '@/shared/ui/shadcn/button';
+import { X } from 'lucide-react';
+import { useRef, useState } from 'react';
+import { MermaidRenderer } from './MermaidRenderer';
+import { DiagramExportButtons } from './DiagramExportButtons';
+import { VersionHistory } from '@/widgets/artifact-editor';
+
+interface DiagramViewerProps {
+  readonly artifact: ArtifactResponseDto;
+  readonly onClose: () => void;
+}
+
+export function DiagramViewer({ artifact, onClose }: DiagramViewerProps) {
+  // null = follow latest; set to a specific version number when the user
+  // picks one from the history. Resets on artifact change via key prop.
+  const [userSelectedVersion, setUserSelectedVersion] = useState<number | null>(
+    null,
+  );
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const displayedVersionNumber =
+    userSelectedVersion ?? artifact.currentVersionNumber;
+
+  const selectedVersion = artifact.versions?.find(
+    (v) => v.versionNumber === displayedVersionNumber,
+  );
+
+  return (
+    <div className="flex h-full flex-col overflow-hidden border-l">
+      <div className="flex items-center justify-between border-b px-3 py-2">
+        <h3 className="truncate text-sm font-semibold" title={artifact.title}>
+          {artifact.title}
+        </h3>
+        <div className="flex items-center gap-1">
+          <DiagramExportButtons
+            containerRef={containerRef}
+            fileName={artifact.title}
+          />
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-8 w-8 p-0"
+            onClick={onClose}
+          >
+            <X className="size-4" />
+          </Button>
+        </div>
+      </div>
+
+      <div className="flex-1 overflow-hidden">
+        <MermaidRenderer
+          source={selectedVersion?.content ?? ''}
+          containerRef={containerRef}
+        />
+      </div>
+
+      {artifact.versions && artifact.versions.length > 0 && (
+        <VersionHistory
+          versions={artifact.versions}
+          currentVersionNumber={displayedVersionNumber}
+          onSelect={(v) =>
+            setUserSelectedVersion(
+              v === artifact.currentVersionNumber ? null : v,
+            )
+          }
+        />
+      )}
+    </div>
+  );
+}

--- a/ayunis-core-frontend/src/widgets/diagram-viewer/ui/MermaidRenderer.tsx
+++ b/ayunis-core-frontend/src/widgets/diagram-viewer/ui/MermaidRenderer.tsx
@@ -1,0 +1,94 @@
+import { useEffect, useId, useRef, useState } from 'react';
+import mermaid from 'mermaid';
+import { useTheme } from '@/features/theme';
+import { cn } from '@/shared/lib/shadcn/utils';
+
+interface MermaidRendererProps {
+  readonly source: string;
+  readonly className?: string;
+  /** Forwarded ref to the container so callers can serialise the rendered SVG for export. */
+  readonly containerRef?: React.RefObject<HTMLDivElement | null>;
+}
+
+const BRAND_PRIMARY = '#8178c3';
+
+export function MermaidRenderer({
+  source,
+  className,
+  containerRef: externalRef,
+}: MermaidRendererProps) {
+  const { theme } = useTheme();
+  const internalRef = useRef<HTMLDivElement>(null);
+  const containerRef = externalRef ?? internalRef;
+  const [error, setError] = useState<string | null>(null);
+  const rawId = useId();
+  // mermaid rejects IDs containing ":"; useId returns something like ":r1:"
+  const renderId = `mermaid-${rawId.replace(/:/g, '')}`;
+
+  useEffect(() => {
+    let cancelled = false;
+
+    mermaid.initialize({
+      startOnLoad: false,
+      theme: 'base',
+      securityLevel: 'strict',
+      fontFamily: 'inherit',
+      themeVariables: {
+        // Unify node fills across diagram types (flowchart, mindmap, etc.)
+        // on the brand purple so all shapes read as solid brand surfaces
+        // with white text — mermaid's base theme otherwise picks a very
+        // light mainBkg that makes white node text invisible.
+        primaryColor: BRAND_PRIMARY,
+        primaryBorderColor: BRAND_PRIMARY,
+        primaryTextColor: '#ffffff',
+        mainBkg: BRAND_PRIMARY,
+        nodeTextColor: '#ffffff',
+        lineColor: theme === 'dark' ? '#a6a3b8' : '#3b3a4a',
+        background: theme === 'dark' ? '#1a1825' : '#ffffff',
+      },
+    });
+
+    const render = async () => {
+      if (!source.trim()) {
+        if (!cancelled && containerRef.current) {
+          containerRef.current.innerHTML = '';
+        }
+        setError(null);
+        return;
+      }
+      try {
+        const { svg } = await mermaid.render(renderId, source);
+        if (!cancelled && containerRef.current) {
+          containerRef.current.innerHTML = svg;
+          setError(null);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setError(
+            err instanceof Error ? err.message : 'Failed to render diagram',
+          );
+        }
+      }
+    };
+
+    void render();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [source, theme, containerRef, renderId]);
+
+  return (
+    <div className={cn('flex h-full flex-col', className)}>
+      <div
+        ref={containerRef}
+        className="flex flex-1 items-center justify-center overflow-auto p-4 [&>svg]:max-h-full [&>svg]:max-w-full"
+      />
+      {error && (
+        <div className="border-t border-destructive/30 bg-destructive/10 px-3 py-2 text-xs text-destructive">
+          {error}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
- Add a new widgets/diagram-viewer widget: MermaidRenderer (theme-aware SVG rendering with graceful error fallback), DiagramViewer (read-only layout: header + SVG + version navigation), DiagramExportButtons (SVG + PNG client-side export), DiagramVersionList
- Add mermaid as a frontend dependency; load it only via React.lazy so it stays out of the main bundle (verified via build output — mermaid sub-diagrams are separate chunks)
- Add CreateDiagramWidget and UpdateDiagramWidget chat widgets modelled on the document widgets; they reuse DocumentWidgetCard with a Workflow icon and diagram-specific i18n
- Wire the new widgets into ChatMessage's tool-use switch and branch the side panel in ChatPage on openArtifact.type so diagrams open in the read-only viewer and documents continue to open in the existing ArtifactEditor
- Add EN/DE translations for diagram tool labels, status text, and export buttons
- Suppress a pre-existing react-hooks/set-state-in-effect error in ChatPage (syncs thread prop into local state) so the pre-commit lint passes; flagged as tech debt to address separately

Completes the mermaid diagram artifact feature. Users can now ask the assistant for a flowchart, sequence diagram, ER diagram, etc., open the result in the side panel, export as SVG or PNG, and iterate on it by chatting with the assistant.

Refs: AYC-31

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new diagram rendering/export path using `mermaid` and client-side SVG/PNG serialization, plus dependency overrides to address security advisories; both can affect runtime behavior and supply-chain risk if misconfigured.
> 
> **Overview**
> Adds **diagram artifacts support** in chat: tool calls `create_diagram`/`update_diagram` now render dedicated widgets and open diagrams in a new side-panel `DiagramViewer` that renders Mermaid source to SVG, supports version navigation, and enables SVG/PNG export.
> 
> Refactors artifact tool widget selection into `renderArtifactToolWidget`, extends `DocumentWidgetCard` to accept custom icons, and reuses shared update logic via `useUpdateArtifactWidget`. Updates EN/DE i18n for diagram labels and export messages.
> 
> Hardens dependency/security posture by adding backend `npm` `overrides` for `basic-ftp` and `protobufjs` (and removing a now-unneeded `.nsprc` exception), and adds `mermaid` as a frontend dependency (with lockfile updates).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 982c86592f628d2882b10cf059ac74ca1c600dac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->