### PR TITLE
feat(chat): add zoom and pan to diagram viewer (AYC-31)

### DIFF
--- a/ayunis-core-frontend/package-lock.json
+++ b/ayunis-core-frontend/package-lock.json
@@ -60,6 +60,7 @@
         "react-resizable-panels": "^4.6.4",
         "react-syntax-highlighter": "^15.6.1",
         "react-textarea-autosize": "^8.5.9",
+        "react-zoom-pan-pinch": "^4.0.3",
         "recharts": "^2.15.4",
         "remark-gfm": "^4.0.1",
         "sonner": "^2.0.5",
@@ -15495,6 +15496,20 @@
       "peerDependencies": {
         "react": ">=16.6.0",
         "react-dom": ">=16.6.0"
+      }
+    },
+    "node_modules/react-zoom-pan-pinch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/react-zoom-pan-pinch/-/react-zoom-pan-pinch-4.0.3.tgz",
+      "integrity": "sha512-N2Hi6L78fFmhRra+ORpFSW7WST5x6kxpOPplIvtB0b7b+U2anpo1z1wLgaWRPS2kUSqcraRG+JgBCIlDJnqqAg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8",
+        "npm": ">=5"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-dom": "*"
       }
     },
     "node_modules/readable-stream": {

--- a/ayunis-core-frontend/package.json
+++ b/ayunis-core-frontend/package.json
@@ -75,6 +75,7 @@
     "react-resizable-panels": "^4.6.4",
     "react-syntax-highlighter": "^15.6.1",
     "react-textarea-autosize": "^8.5.9",
+    "react-zoom-pan-pinch": "^4.0.3",
     "recharts": "^2.15.4",
     "remark-gfm": "^4.0.1",
     "sonner": "^2.0.5",

--- a/ayunis-core-frontend/src/shared/locales/de/artifacts.json
+++ b/ayunis-core-frontend/src/shared/locales/de/artifacts.json
@@ -43,6 +43,11 @@
       "svg": "SVG",
       "png": "PNG",
       "failed": "Diagramm-Export fehlgeschlagen"
+    },
+    "zoom": {
+      "in": "Vergrößern",
+      "out": "Verkleinern",
+      "reset": "Ansicht zurücksetzen"
     }
   }
 }

--- a/ayunis-core-frontend/src/shared/locales/en/artifacts.json
+++ b/ayunis-core-frontend/src/shared/locales/en/artifacts.json
@@ -43,6 +43,11 @@
       "svg": "SVG",
       "png": "PNG",
       "failed": "Failed to export diagram"
+    },
+    "zoom": {
+      "in": "Zoom in",
+      "out": "Zoom out",
+      "reset": "Reset view"
     }
   }
 }

--- a/ayunis-core-frontend/src/widgets/diagram-viewer/ui/MermaidRenderer.tsx
+++ b/ayunis-core-frontend/src/widgets/diagram-viewer/ui/MermaidRenderer.tsx
@@ -1,6 +1,10 @@
 import { useEffect, useId, useRef, useState } from 'react';
 import mermaid from 'mermaid';
+import { Maximize2, ZoomIn, ZoomOut } from 'lucide-react';
+import { TransformComponent, TransformWrapper } from 'react-zoom-pan-pinch';
+import { useTranslation } from 'react-i18next';
 import { useTheme } from '@/features/theme';
+import { Button } from '@/shared/ui/shadcn/button';
 import { cn } from '@/shared/lib/shadcn/utils';
 
 interface MermaidRendererProps {
@@ -11,6 +15,8 @@ interface MermaidRendererProps {
 }
 
 const BRAND_PRIMARY = '#8178c3';
+const MIN_SCALE = 0.25;
+const MAX_SCALE = 4;
 
 export function MermaidRenderer({
   source,
@@ -18,8 +24,10 @@ export function MermaidRenderer({
   containerRef: externalRef,
 }: MermaidRendererProps) {
   const { theme } = useTheme();
+  const { t } = useTranslation('artifacts');
   const internalRef = useRef<HTMLDivElement>(null);
   const containerRef = externalRef ?? internalRef;
+  const svgHolderRef = useRef<HTMLDivElement>(null);
   const [error, setError] = useState<string | null>(null);
   const rawId = useId();
   // mermaid rejects IDs containing ":"; useId returns something like ":r1:"
@@ -50,16 +58,16 @@ export function MermaidRenderer({
 
     const render = async () => {
       if (!source.trim()) {
-        if (!cancelled && containerRef.current) {
-          containerRef.current.innerHTML = '';
+        if (!cancelled && svgHolderRef.current) {
+          svgHolderRef.current.innerHTML = '';
         }
         setError(null);
         return;
       }
       try {
         const { svg } = await mermaid.render(renderId, source);
-        if (!cancelled && containerRef.current) {
-          containerRef.current.innerHTML = svg;
+        if (!cancelled && svgHolderRef.current) {
+          svgHolderRef.current.innerHTML = svg;
           setError(null);
         }
       } catch (err) {
@@ -76,14 +84,67 @@ export function MermaidRenderer({
     return () => {
       cancelled = true;
     };
-  }, [source, theme, containerRef, renderId]);
+  }, [source, theme, renderId]);
 
   return (
     <div className={cn('flex h-full flex-col', className)}>
-      <div
-        ref={containerRef}
-        className="flex flex-1 items-center justify-center overflow-auto p-4 [&>svg]:max-h-full [&>svg]:max-w-full"
-      />
+      <div ref={containerRef} className="relative flex-1 overflow-hidden">
+        <TransformWrapper
+          key={source}
+          minScale={MIN_SCALE}
+          maxScale={MAX_SCALE}
+          wheel={{ step: 0.03 }}
+          doubleClick={{ disabled: true }}
+          limitToBounds={false}
+          centerOnInit
+        >
+          {({ zoomIn, zoomOut, resetTransform }) => (
+            <>
+              <TransformComponent
+                wrapperClass="!h-full !w-full"
+                contentClass="!h-full !w-full items-center justify-center"
+              >
+                <div
+                  ref={svgHolderRef}
+                  className="flex h-full w-full items-center justify-center p-4"
+                />
+              </TransformComponent>
+              <div className="absolute bottom-3 right-3 flex items-center gap-1 rounded-md border bg-background/80 p-1 shadow-sm backdrop-blur">
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="h-8 w-8 p-0"
+                  onClick={() => zoomIn()}
+                  title={t('diagram.zoom.in')}
+                  aria-label={t('diagram.zoom.in')}
+                >
+                  <ZoomIn className="size-4" />
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="h-8 w-8 p-0"
+                  onClick={() => zoomOut()}
+                  title={t('diagram.zoom.out')}
+                  aria-label={t('diagram.zoom.out')}
+                >
+                  <ZoomOut className="size-4" />
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="h-8 w-8 p-0"
+                  onClick={() => resetTransform()}
+                  title={t('diagram.zoom.reset')}
+                  aria-label={t('diagram.zoom.reset')}
+                >
+                  <Maximize2 className="size-4" />
+                </Button>
+              </div>
+            </>
+          )}
+        </TransformWrapper>
+      </div>
       {error && (
         <div className="border-t border-destructive/30 bg-destructive/10 px-3 py-2 text-xs text-destructive">
           {error}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk UI-only change that introduces a new third-party zoom/pan dependency; main concern is potential layout/interaction regressions in the diagram viewer.
> 
> **Overview**
> Adds zoom and pan support to the Mermaid diagram viewer by wrapping the rendered SVG in `react-zoom-pan-pinch`, with new on-canvas controls for zoom in/out and reset.
> 
> Updates `MermaidRenderer` to render the SVG into an inner holder (preserving the external `containerRef` for export) and adds i18n strings for the new zoom control tooltips/labels, plus the new dependency in `package.json`/lockfile.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 156aa3c7bad380d701ed368372560a7944b89215. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->