### PR TITLE
fix(threads): prevent FK violation when adding thread sources (AYC-000)

### DIFF
--- a/ayunis-core-backend/src/domain/threads/application/use-cases/add-source-to-thread/add-source-to-thread.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/threads/application/use-cases/add-source-to-thread/add-source-to-thread.use-case.spec.ts
@@ -3,6 +3,13 @@ import { Test } from '@nestjs/testing';
 import { Logger } from '@nestjs/common';
 import type { UUID } from 'crypto';
 import { randomUUID } from 'crypto';
+
+jest.mock('@nestjs-cls/transactional', () => ({
+  Transactional:
+    () => (_target: unknown, _prop: string, descriptor: PropertyDescriptor) =>
+      descriptor,
+}));
+
 import { AddSourceToThreadUseCase } from './add-source-to-thread.use-case';
 import { AddSourceCommand } from './add-source.command';
 import { ThreadsRepository } from '../../ports/threads.repository';
@@ -94,6 +101,29 @@ describe('AddSourceToThreadUseCase', () => {
     expect(savedAssignments).toHaveLength(1);
     expect(savedAssignments[0].source.id).toBe(source.id);
     expect(savedAssignments[0].originSkillId).toBeUndefined();
+  });
+
+  it('should pass survivors alongside the new assignment when the thread already has sources', async () => {
+    const existingSource = new ConcreteSource({ name: 'Existing.pdf' });
+    const existingAssignment = new SourceAssignment({ source: existingSource });
+    const newSource = new ConcreteSource({ name: 'New.pdf' });
+    const freshThread = new Thread({
+      userId: mockUserId,
+      messages: [],
+      sourceAssignments: [existingAssignment],
+    });
+    const command = new AddSourceCommand(freshThread, newSource);
+
+    threadsRepository.findOne.mockResolvedValue(freshThread);
+
+    await useCase.execute(command);
+
+    const savedAssignments =
+      threadsRepository.updateSourceAssignments.mock.calls[0][0]
+        .sourceAssignments;
+    expect(savedAssignments).toHaveLength(2);
+    expect(savedAssignments[0]).toBe(existingAssignment);
+    expect(savedAssignments[1].source.id).toBe(newSource.id);
   });
 
   it('should propagate originSkillId to the created SourceAssignment', async () => {

--- a/ayunis-core-backend/src/domain/threads/application/use-cases/add-source-to-thread/add-source-to-thread.use-case.ts
+++ b/ayunis-core-backend/src/domain/threads/application/use-cases/add-source-to-thread/add-source-to-thread.use-case.ts
@@ -1,4 +1,5 @@
 import { Injectable, Logger, UnauthorizedException } from '@nestjs/common';
+import { Transactional } from '@nestjs-cls/transactional';
 import { ThreadsRepository } from '../../ports/threads.repository';
 import { AddSourceCommand } from './add-source.command';
 import { SourceAdditionError } from '../../threads.errors';
@@ -16,6 +17,7 @@ export class AddSourceToThreadUseCase {
     private readonly contextService: ContextService,
   ) {}
 
+  @Transactional()
   async execute(command: AddSourceCommand): Promise<void> {
     this.logger.log('addSource', {
       threadId: command.thread.id,

--- a/ayunis-core-backend/src/domain/threads/infrastructure/persistence/local/local-thread-assignments.repository.spec.ts
+++ b/ayunis-core-backend/src/domain/threads/infrastructure/persistence/local/local-thread-assignments.repository.spec.ts
@@ -1,0 +1,239 @@
+import { randomUUID, type UUID } from 'crypto';
+import type { Repository } from 'typeorm';
+
+import { LocalThreadAssignmentsRepository } from './local-thread-assignments.repository';
+import type { ThreadRecord } from './schema/thread.record';
+import { ThreadSourceAssignmentRecord } from './schema/thread-source-assignment.record';
+import type { ThreadKnowledgeBaseAssignmentRecord } from './schema/thread-knowledge-base-assignment.record';
+import type { ThreadSourceAssignmentMapper } from './mappers/thread-source-assignment.mapper';
+import { ThreadNotFoundError } from 'src/domain/threads/application/threads.errors';
+import { SourceAssignment } from 'src/domain/threads/domain/thread-source-assignment.entity';
+import { Source } from 'src/domain/sources/domain/source.entity';
+import { SourceType } from 'src/domain/sources/domain/source-type.enum';
+
+class ConcreteSource extends Source {
+  constructor(params: { id?: UUID; name: string }) {
+    super({ id: params.id, type: SourceType.TEXT, name: params.name });
+  }
+}
+
+function makeAssignmentRecord(
+  threadId: UUID,
+  sourceId: UUID,
+): ThreadSourceAssignmentRecord {
+  const record = new ThreadSourceAssignmentRecord();
+  record.id = randomUUID();
+  record.threadId = threadId;
+  record.sourceId = sourceId;
+  record.originSkillId = null;
+  record.createdAt = new Date('2026-04-14T00:00:00Z');
+  record.updatedAt = new Date('2026-04-14T00:00:00Z');
+  return record;
+}
+
+describe('LocalThreadAssignmentsRepository', () => {
+  let repository: LocalThreadAssignmentsRepository;
+  let threadRepo: jest.Mocked<Pick<Repository<ThreadRecord>, 'findOne'>>;
+  let sourceAssignmentRepo: jest.Mocked<
+    Pick<Repository<ThreadSourceAssignmentRecord>, 'remove' | 'save'>
+  >;
+  let kbAssignmentRepo: jest.Mocked<
+    Repository<ThreadKnowledgeBaseAssignmentRecord>
+  >;
+  let mapper: jest.Mocked<Pick<ThreadSourceAssignmentMapper, 'toRecord'>> &
+    ThreadSourceAssignmentMapper;
+
+  const userId = randomUUID();
+  const threadId = randomUUID();
+
+  beforeEach(() => {
+    threadRepo = {
+      findOne: jest.fn(),
+    } as jest.Mocked<Pick<Repository<ThreadRecord>, 'findOne'>>;
+    sourceAssignmentRepo = {
+      remove: jest.fn(),
+      save: jest.fn(),
+    } as jest.Mocked<
+      Pick<Repository<ThreadSourceAssignmentRecord>, 'remove' | 'save'>
+    >;
+    kbAssignmentRepo = {} as jest.Mocked<
+      Repository<ThreadKnowledgeBaseAssignmentRecord>
+    >;
+    mapper = {
+      toRecord: jest
+        .fn()
+        .mockImplementation((assignment: SourceAssignment, tid: UUID) => {
+          const record = new ThreadSourceAssignmentRecord();
+          record.id = assignment.id;
+          record.threadId = tid;
+          record.sourceId = assignment.source.id;
+          record.originSkillId = assignment.originSkillId ?? null;
+          record.createdAt = assignment.createdAt;
+          record.updatedAt = assignment.updatedAt;
+          return record;
+        }),
+    } as unknown as jest.Mocked<
+      Pick<ThreadSourceAssignmentMapper, 'toRecord'>
+    > &
+      ThreadSourceAssignmentMapper;
+
+    repository = new LocalThreadAssignmentsRepository(
+      threadRepo as unknown as Repository<ThreadRecord>,
+      sourceAssignmentRepo as unknown as Repository<ThreadSourceAssignmentRecord>,
+      kbAssignmentRepo,
+      mapper,
+    );
+  });
+
+  describe('updateSourceAssignments', () => {
+    it('inserts only the new assignment when adding to an existing list', async () => {
+      const existingSource = new ConcreteSource({ name: 'existing.pdf' });
+      const existingRecord = makeAssignmentRecord(threadId, existingSource.id);
+      const newSource = new ConcreteSource({ name: 'new.pdf' });
+
+      threadRepo.findOne.mockResolvedValue({
+        id: threadId,
+        userId,
+        sourceAssignments: [existingRecord],
+      } as ThreadRecord);
+
+      await repository.updateSourceAssignments({
+        threadId,
+        userId,
+        sourceAssignments: [
+          new SourceAssignment({
+            id: existingRecord.id,
+            source: existingSource,
+            createdAt: existingRecord.createdAt,
+            updatedAt: existingRecord.updatedAt,
+          }),
+          new SourceAssignment({ source: newSource }),
+        ],
+      });
+
+      expect(sourceAssignmentRepo.remove).not.toHaveBeenCalled();
+      expect(mapper.toRecord).toHaveBeenCalledTimes(1);
+      expect(mapper.toRecord).toHaveBeenCalledWith(
+        expect.objectContaining({ source: newSource }),
+        threadId,
+      );
+      expect(sourceAssignmentRepo.save).toHaveBeenCalledTimes(1);
+      const savedRecords = sourceAssignmentRepo.save.mock
+        .calls[0][0] as ThreadSourceAssignmentRecord[];
+      expect(savedRecords).toHaveLength(1);
+      expect(savedRecords[0].sourceId).toBe(newSource.id);
+    });
+
+    it('removes stale assignments and does not re-insert survivors', async () => {
+      const keptSource = new ConcreteSource({ name: 'kept.pdf' });
+      const droppedSource = new ConcreteSource({ name: 'dropped.pdf' });
+      const keptRecord = makeAssignmentRecord(threadId, keptSource.id);
+      const droppedRecord = makeAssignmentRecord(threadId, droppedSource.id);
+
+      threadRepo.findOne.mockResolvedValue({
+        id: threadId,
+        userId,
+        sourceAssignments: [keptRecord, droppedRecord],
+      } as ThreadRecord);
+
+      await repository.updateSourceAssignments({
+        threadId,
+        userId,
+        sourceAssignments: [
+          new SourceAssignment({
+            id: keptRecord.id,
+            source: keptSource,
+            createdAt: keptRecord.createdAt,
+            updatedAt: keptRecord.updatedAt,
+          }),
+        ],
+      });
+
+      expect(sourceAssignmentRepo.remove).toHaveBeenCalledTimes(1);
+      expect(sourceAssignmentRepo.remove).toHaveBeenCalledWith([droppedRecord]);
+      expect(mapper.toRecord).not.toHaveBeenCalled();
+      expect(sourceAssignmentRepo.save).not.toHaveBeenCalled();
+    });
+
+    it('no-ops when target list matches the existing assignments', async () => {
+      const source = new ConcreteSource({ name: 'same.pdf' });
+      const record = makeAssignmentRecord(threadId, source.id);
+
+      threadRepo.findOne.mockResolvedValue({
+        id: threadId,
+        userId,
+        sourceAssignments: [record],
+      } as ThreadRecord);
+
+      await repository.updateSourceAssignments({
+        threadId,
+        userId,
+        sourceAssignments: [
+          new SourceAssignment({
+            id: record.id,
+            source,
+            createdAt: record.createdAt,
+            updatedAt: record.updatedAt,
+          }),
+        ],
+      });
+
+      expect(sourceAssignmentRepo.remove).not.toHaveBeenCalled();
+      expect(mapper.toRecord).not.toHaveBeenCalled();
+      expect(sourceAssignmentRepo.save).not.toHaveBeenCalled();
+    });
+
+    it('handles mixed add and remove in one call', async () => {
+      const keptSource = new ConcreteSource({ name: 'kept.pdf' });
+      const droppedSource = new ConcreteSource({ name: 'dropped.pdf' });
+      const addedSource = new ConcreteSource({ name: 'added.pdf' });
+      const keptRecord = makeAssignmentRecord(threadId, keptSource.id);
+      const droppedRecord = makeAssignmentRecord(threadId, droppedSource.id);
+
+      threadRepo.findOne.mockResolvedValue({
+        id: threadId,
+        userId,
+        sourceAssignments: [keptRecord, droppedRecord],
+      } as ThreadRecord);
+
+      await repository.updateSourceAssignments({
+        threadId,
+        userId,
+        sourceAssignments: [
+          new SourceAssignment({
+            id: keptRecord.id,
+            source: keptSource,
+            createdAt: keptRecord.createdAt,
+            updatedAt: keptRecord.updatedAt,
+          }),
+          new SourceAssignment({ source: addedSource }),
+        ],
+      });
+
+      expect(sourceAssignmentRepo.remove).toHaveBeenCalledWith([droppedRecord]);
+      expect(mapper.toRecord).toHaveBeenCalledTimes(1);
+      expect(mapper.toRecord).toHaveBeenCalledWith(
+        expect.objectContaining({ source: addedSource }),
+        threadId,
+      );
+      const savedRecords = sourceAssignmentRepo.save.mock
+        .calls[0][0] as ThreadSourceAssignmentRecord[];
+      expect(savedRecords).toHaveLength(1);
+      expect(savedRecords[0].sourceId).toBe(addedSource.id);
+    });
+
+    it('throws ThreadNotFoundError when the thread does not exist', async () => {
+      threadRepo.findOne.mockResolvedValue(null);
+
+      await expect(
+        repository.updateSourceAssignments({
+          threadId,
+          userId,
+          sourceAssignments: [],
+        }),
+      ).rejects.toBeInstanceOf(ThreadNotFoundError);
+      expect(sourceAssignmentRepo.remove).not.toHaveBeenCalled();
+      expect(sourceAssignmentRepo.save).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/ayunis-core-backend/src/domain/threads/infrastructure/persistence/local/local-thread-assignments.repository.ts
+++ b/ayunis-core-backend/src/domain/threads/infrastructure/persistence/local/local-thread-assignments.repository.ts
@@ -29,8 +29,6 @@ export class LocalThreadAssignmentsRepository {
     userId: UUID;
     sourceAssignments: SourceAssignment[];
   }): Promise<void> {
-    this.logger.log('updateSourceAssignments', { params });
-
     const threadEntity = await this.threadRepository.findOne({
       where: { id: params.threadId, userId: params.userId },
       relations: ['sourceAssignments'],
@@ -40,23 +38,39 @@ export class LocalThreadAssignmentsRepository {
       throw new ThreadNotFoundError(params.threadId, params.userId);
     }
 
-    const sourceAssignmentsToDelete =
-      threadEntity.sourceAssignments?.filter(
-        (assignment) =>
-          !params.sourceAssignments.some(
-            (s) => s.source.id === assignment.source.id,
-          ),
-      ) ?? [];
+    // Diff against DB state so we only INSERT genuinely new rows and only
+    // DELETE dropped ones; touching unchanged rows would both waste writes
+    // and race with cascade deletes on the source FK.
+    const existing = threadEntity.sourceAssignments ?? [];
+    const targetSourceIds = new Set(
+      params.sourceAssignments.map((a) => a.source.id),
+    );
+    const existingSourceIds = new Set(existing.map((a) => a.sourceId));
 
-    await this.threadSourceAssignmentRepository.remove(
-      sourceAssignmentsToDelete,
+    const toDelete = existing.filter(
+      (assignment) => !targetSourceIds.has(assignment.sourceId),
+    );
+    const toInsert = params.sourceAssignments.filter(
+      (assignment) => !existingSourceIds.has(assignment.source.id),
     );
 
-    const sourceAssignmentRecords = params.sourceAssignments.map((assignment) =>
-      this.sourceAssignmentMapper.toRecord(assignment, params.threadId),
-    );
+    this.logger.log('updateSourceAssignments', {
+      threadId: params.threadId,
+      userId: params.userId,
+      addCount: toInsert.length,
+      removeCount: toDelete.length,
+    });
 
-    await this.threadSourceAssignmentRepository.save(sourceAssignmentRecords);
+    if (toDelete.length > 0) {
+      await this.threadSourceAssignmentRepository.remove(toDelete);
+    }
+
+    if (toInsert.length > 0) {
+      const records = toInsert.map((assignment) =>
+        this.sourceAssignmentMapper.toRecord(assignment, params.threadId),
+      );
+      await this.threadSourceAssignmentRepository.save(records);
+    }
   }
 
   async updateMcpIntegrations(params: {


### PR DESCRIPTION
- Diff DB state in updateSourceAssignments so only genuinely new
  rows are inserted and only dropped ones removed. The old code
  re-saved every assignment via save(array), which TypeORM treated
  as a bulk INSERT of fresh entities and raced with cascade deletes
  on the source FK when a concurrent request removed a referenced
  source.
- Decorate AddSourceToThreadUseCase.execute with @Transactional() so
  the findOne + duplicate check + write is atomic for
  non-transactional callers.
- Add repository spec covering add/remove/no-op/mixed/not-found, and
  a use-case test for the non-empty-existing path.

Refs: AYC-32, AYC-33, AYC-34

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches write-path persistence logic and transaction boundaries for thread-source assignments; mistakes could cause missing inserts/deletes or unexpected concurrency behavior, but changes are localized and covered by new tests.
> 
> **Overview**
> Fixes thread source assignment persistence by changing `LocalThreadAssignmentsRepository.updateSourceAssignments` to *diff against DB state* and only `remove` dropped assignments and `save` genuinely new ones (instead of re-saving the full list), with updated logging to report add/remove counts.
> 
> Wraps `AddSourceToThreadUseCase.execute` in `@Transactional()` to make the read/duplicate-check/write sequence atomic, and extends tests to cover adding a source when the thread already has existing assignments plus a new repository spec covering add/remove/no-op/mixed/not-found behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ad2bf2b3390e3ec46635fbda3f7c756c46c9464. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->