### PR TITLE
chore(tooling): add wt project hooks for env copy and npm install (AYC-000)

### DIFF
--- a/.config/wt.toml
+++ b/.config/wt.toml
@@ -15,7 +15,9 @@ done
 [post-start]
 install-node = '''
 (cd ayunis-core-backend && npm ci) &
+pid1=$!
 (cd ayunis-core-frontend && npm ci) &
-wait
+pid2=$!
+wait $pid1 && wait $pid2
 '''
 # install-python = "cd ayunis-core-anonymize && uv sync"  # uncomment if you work on anonymize

--- a/.config/wt.toml
+++ b/.config/wt.toml
@@ -1,0 +1,21 @@
+[pre-start]
+env = '''
+set -e
+for f in ayunis-core-backend/.env \
+         ayunis-core-backend/.env.dev \
+         ayunis-core-frontend/.env; do
+  src="{{ primary_worktree_path }}/$f"
+  if [ -f "$src" ] && [ ! -f "$f" ]; then
+    mkdir -p "$(dirname "$f")"
+    cp "$src" "$f"
+  fi
+done
+'''
+
+[post-start]
+install-node = '''
+(cd ayunis-core-backend && npm ci) &
+(cd ayunis-core-frontend && npm ci) &
+wait
+'''
+# install-python = "cd ayunis-core-anonymize && uv sync"  # uncomment if you work on anonymize


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: adds local dev/worktree automation only, with no production runtime or business-logic changes.
> 
> **Overview**
> Adds a `wt` project config (`.config/wt.toml`) that automates local setup.
> 
> On `pre-start`, it copies existing `.env` files from the primary worktree into the current worktree if missing; on `post-start`, it runs `npm ci` in `ayunis-core-backend` and `ayunis-core-frontend` in parallel (with an optional commented Python install hook).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4e0d0624690dbc9f7e5d75e619ab3e7759027da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->