### PR TITLE
fix(models): forward images through openai-compatible chat providers (AYC-000)

### DIFF
--- a/ayunis-core-backend/src/db/fixtures/minimal.fixture.ts
+++ b/ayunis-core-backend/src/db/fixtures/minimal.fixture.ts
@@ -18,6 +18,7 @@ export const minimalFixture = {
 
   user: {
     email: 'admin@demo.local',
+    // eslint-disable-next-line sonarjs/no-hardcoded-passwords -- dev-only seed credential
     password: 'admin',
     name: 'Admin',
     role: UserRole.ADMIN,
@@ -28,6 +29,7 @@ export const minimalFixture = {
 
   usageUser: {
     email: 'admin@usage.local',
+    // eslint-disable-next-line sonarjs/no-hardcoded-passwords -- dev-only seed credential
     password: 'admin',
     name: 'Usage Admin',
     role: UserRole.ADMIN,
@@ -40,6 +42,19 @@ export const minimalFixture = {
     name: 'eu.anthropic.claude-sonnet-4-6',
     displayName: 'Claude Sonnet 4 (Bedrock)',
     provider: ModelProvider.BEDROCK,
+    canStream: true,
+    isReasoning: false,
+    isArchived: false,
+    canUseTools: true,
+    canVision: true,
+    inputTokenCost: 3,
+    outputTokenCost: 15,
+  },
+
+  azureLanguageModel: {
+    name: 'gpt-5.4',
+    displayName: 'GPT-5.4 (Azure)',
+    provider: ModelProvider.AZURE,
     canStream: true,
     isReasoning: false,
     isArchived: false,
@@ -94,6 +109,11 @@ export const minimalFixture = {
       anonymousOnly: false,
     },
     {
+      modelKey: 'azureLanguageModel',
+      isDefault: false,
+      anonymousOnly: false,
+    },
+    {
       // Embedding model as default
       modelKey: 'embeddingModel',
       isDefault: true,
@@ -104,5 +124,5 @@ export const minimalFixture = {
 
 export type ModelKey = keyof Pick<
   typeof minimalFixture,
-  'languageModel' | 'embeddingModel'
+  'languageModel' | 'azureLanguageModel' | 'embeddingModel'
 >;

--- a/ayunis-core-backend/src/db/scripts/seed-minimal.ts
+++ b/ayunis-core-backend/src/db/scripts/seed-minimal.ts
@@ -51,9 +51,11 @@ async function seedOrgByName(name: string): Promise<OrgRecord> {
   return record;
 }
 
-async function seedLanguageModel(): Promise<LanguageModelRecord> {
+async function seedLanguageModelFromFixture(
+  entry: typeof fixture.languageModel | typeof fixture.azureLanguageModel,
+): Promise<LanguageModelRecord> {
   const repo = dataSource.getRepository(LanguageModelRecord);
-  const { name, displayName, provider, ...flags } = fixture.languageModel;
+  const { name, displayName, provider, ...flags } = entry;
   const existing = await repo.findOne({ where: { name, provider } });
   if (existing) {
     log('Language model', existing.name, false);
@@ -295,14 +297,16 @@ async function seedMinimal(): Promise<void> {
     console.log('🌱 Starting minimal seed…\n'); // eslint-disable-line no-console
 
     // Seed independent entities first
-    const [org, usageOrg, languageModel, embeddingModel] = await Promise.all([
-      seedOrgByName(fixture.org.name),
-      seedOrgByName(fixture.usageOrg.name),
-      seedLanguageModel(),
-      seedEmbeddingModel(),
-    ]);
+    const [org, usageOrg, languageModel, azureLanguageModel, embeddingModel] =
+      await Promise.all([
+        seedOrgByName(fixture.org.name),
+        seedOrgByName(fixture.usageOrg.name),
+        seedLanguageModelFromFixture(fixture.languageModel),
+        seedLanguageModelFromFixture(fixture.azureLanguageModel),
+        seedEmbeddingModel(),
+      ]);
 
-    const models = { languageModel, embeddingModel };
+    const models = { languageModel, azureLanguageModel, embeddingModel };
 
     // Seed seat-based org
     await seedUser(org.id, runner, fixture.user);

--- a/ayunis-core-backend/src/domain/models/infrastructure/converters/openai-chat-message.converter.ts
+++ b/ayunis-core-backend/src/domain/models/infrastructure/converters/openai-chat-message.converter.ts
@@ -3,8 +3,10 @@ import type { FunctionParameters } from 'openai/resources/shared';
 import type { Tool } from 'src/domain/tools/domain/tool.entity';
 import type { Message } from 'src/domain/messages/domain/message.entity';
 import { TextMessageContent } from 'src/domain/messages/domain/message-contents/text-message-content.entity';
+import { ImageMessageContent } from 'src/domain/messages/domain/message-contents/image-message-content.entity';
 import { ToolUseMessageContent } from 'src/domain/messages/domain/message-contents/tool-use.message-content.entity';
 import { ToolResultMessageContent } from 'src/domain/messages/domain/message-contents/tool-result.message-content.entity';
+import type { ImageContentService } from 'src/domain/messages/application/services/image-content.service';
 import { ModelToolChoice } from '../../domain/value-objects/model-tool-choice.enum';
 import { MessageRole } from 'src/domain/messages/domain/value-objects/message-role.object';
 import { normalizeSchemaForOpenAI } from '../util/normalize-schema-for-openai';
@@ -14,6 +16,8 @@ import { normalizeSchemaForOpenAI } from '../util/normalize-schema-for-openai';
  * used by both BaseOpenAIChatInferenceHandler and BaseOpenAIChatStreamInferenceHandler.
  */
 export class OpenAIChatMessageConverter {
+  constructor(private readonly imageContentService: ImageContentService) {}
+
   convertTool(tool: Tool): OpenAI.ChatCompletionTool {
     return {
       type: 'function' as const,
@@ -31,10 +35,13 @@ export class OpenAIChatMessageConverter {
     return { role: 'system' as const, content: systemPrompt };
   }
 
-  convertMessages(messages: Message[]): OpenAI.ChatCompletionMessageParam[] {
+  async convertMessages(
+    messages: Message[],
+    orgId: string,
+  ): Promise<OpenAI.ChatCompletionMessageParam[]> {
     const converted: OpenAI.ChatCompletionMessageParam[] = [];
     for (const message of messages) {
-      converted.push(...this.convertMessage(message));
+      converted.push(...(await this.convertMessage(message, orgId)));
     }
     return converted;
   }
@@ -49,11 +56,12 @@ export class OpenAIChatMessageConverter {
     return { type: 'function', function: { name: toolChoice } };
   }
 
-  private convertMessage(
+  private async convertMessage(
     message: Message,
-  ): OpenAI.ChatCompletionMessageParam[] {
+    orgId: string,
+  ): Promise<OpenAI.ChatCompletionMessageParam[]> {
     if (message.role === MessageRole.USER)
-      return this.convertUserMessage(message);
+      return this.convertUserMessage(message, orgId);
     if (message.role === MessageRole.ASSISTANT)
       return [this.convertAssistantMessage(message)];
     if (message.role === MessageRole.SYSTEM)
@@ -64,16 +72,44 @@ export class OpenAIChatMessageConverter {
     return [];
   }
 
-  private convertUserMessage(
+  private async convertUserMessage(
     message: Message,
-  ): OpenAI.ChatCompletionMessageParam[] {
-    const contentParts: OpenAI.ChatCompletionContentPart[] = message.content
-      .filter((c) => c instanceof TextMessageContent)
-      .map((c) => ({ type: 'text' as const, text: c.text }));
+    orgId: string,
+  ): Promise<OpenAI.ChatCompletionMessageParam[]> {
+    const contentParts: OpenAI.ChatCompletionContentPart[] = [];
+    for (const content of message.content) {
+      if (content instanceof TextMessageContent) {
+        contentParts.push({ type: 'text' as const, text: content.text });
+      } else if (content instanceof ImageMessageContent) {
+        contentParts.push(
+          await this.convertImageContent(content, {
+            orgId,
+            threadId: message.threadId,
+            messageId: message.id,
+          }),
+        );
+      }
+    }
 
     if (contentParts.length === 0) return [];
 
     return [{ role: 'user' as const, content: contentParts }];
+  }
+
+  private async convertImageContent(
+    content: ImageMessageContent,
+    context: { orgId: string; threadId: string; messageId: string },
+  ): Promise<OpenAI.ChatCompletionContentPartImage> {
+    const imageData = await this.imageContentService.convertImageToBase64(
+      content,
+      context,
+    );
+    return {
+      type: 'image_url' as const,
+      image_url: {
+        url: `data:${imageData.contentType};base64,${imageData.base64}`,
+      },
+    };
   }
 
   private convertAssistantMessage(

--- a/ayunis-core-backend/src/domain/models/infrastructure/inference/azure.inference.ts
+++ b/ayunis-core-backend/src/domain/models/infrastructure/inference/azure.inference.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { BaseOpenAIChatInferenceHandler } from './base-openai-chat.inference';
 import { ConfigService } from '@nestjs/config';
 import { AzureOpenAI } from 'openai';
+import { ImageContentService } from 'src/domain/messages/application/services/image-content.service';
 import {
   InferenceInput,
   InferenceResponse,
@@ -9,11 +10,15 @@ import {
 
 @Injectable()
 export class AzureInferenceHandler extends BaseOpenAIChatInferenceHandler {
-  constructor(private readonly configService: ConfigService) {
-    super();
+  constructor(
+    private readonly configService: ConfigService,
+    imageContentService: ImageContentService,
+  ) {
+    super(imageContentService);
   }
 
   private getClient(): AzureOpenAI {
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- client is lazily initialized; base class types it as non-null
     if (!this.client) {
       this.client = new AzureOpenAI({
         apiKey: this.configService.get('models.azure.apiKey'),

--- a/ayunis-core-backend/src/domain/models/infrastructure/inference/base-openai-chat.inference.ts
+++ b/ayunis-core-backend/src/domain/models/infrastructure/inference/base-openai-chat.inference.ts
@@ -11,6 +11,7 @@ import { ThinkingMessageContent } from 'src/domain/messages/domain/message-conte
 import retryWithBackoff from 'src/common/util/retryWithBackoff';
 import { InferenceFailedError } from '../../application/models.errors';
 import { ThinkingContentParser } from 'src/common/util/thinking-content-parser';
+import { ImageContentService } from 'src/domain/messages/application/services/image-content.service';
 import { OpenAIChatMessageConverter } from '../converters/openai-chat-message.converter';
 
 @Injectable()
@@ -18,7 +19,12 @@ export abstract class BaseOpenAIChatInferenceHandler extends InferenceHandler {
   private readonly logger = new Logger(BaseOpenAIChatInferenceHandler.name);
   private readonly thinkingParser = new ThinkingContentParser();
   protected client: OpenAI;
-  protected readonly chatConverter = new OpenAIChatMessageConverter();
+  protected readonly chatConverter: OpenAIChatMessageConverter;
+
+  constructor(protected readonly imageContentService: ImageContentService) {
+    super();
+    this.chatConverter = new OpenAIChatMessageConverter(imageContentService);
+  }
 
   async answer(input: InferenceInput): Promise<InferenceResponse> {
     this.logger.log('answer', {
@@ -28,14 +34,17 @@ export abstract class BaseOpenAIChatInferenceHandler extends InferenceHandler {
       toolChoice: input.toolChoice,
     });
     try {
-      const { messages, tools, toolChoice } = input;
+      const { messages, tools, toolChoice, orgId } = input;
       const openAiTools = tools
         .map((t) => this.chatConverter.convertTool(t))
         .map((tool) => ({
           ...tool,
           function: { ...tool.function, strict: true },
         }));
-      const openAiMessages = this.chatConverter.convertMessages(messages);
+      const openAiMessages = await this.chatConverter.convertMessages(
+        messages,
+        orgId,
+      );
       const systemPrompt = input.systemPrompt
         ? this.chatConverter.convertSystemPrompt(input.systemPrompt)
         : undefined;

--- a/ayunis-core-backend/src/domain/models/infrastructure/inference/otc.inference.ts
+++ b/ayunis-core-backend/src/domain/models/infrastructure/inference/otc.inference.ts
@@ -2,11 +2,15 @@ import { Injectable } from '@nestjs/common';
 import { BaseOpenAIChatInferenceHandler } from './base-openai-chat.inference';
 import { ConfigService } from '@nestjs/config';
 import OpenAI from 'openai';
+import { ImageContentService } from 'src/domain/messages/application/services/image-content.service';
 
 @Injectable()
 export class OtcInferenceHandler extends BaseOpenAIChatInferenceHandler {
-  constructor(private readonly configService: ConfigService) {
-    super();
+  constructor(
+    private readonly configService: ConfigService,
+    imageContentService: ImageContentService,
+  ) {
+    super(imageContentService);
     this.client = new OpenAI({
       apiKey: this.configService.get('models.otc.apiKey'),
       baseURL: this.configService.get('models.otc.baseURL'),

--- a/ayunis-core-backend/src/domain/models/infrastructure/inference/scaleway.inference.ts
+++ b/ayunis-core-backend/src/domain/models/infrastructure/inference/scaleway.inference.ts
@@ -2,11 +2,15 @@ import { Injectable } from '@nestjs/common';
 import { BaseOpenAIChatInferenceHandler } from './base-openai-chat.inference';
 import { ConfigService } from '@nestjs/config';
 import OpenAI from 'openai';
+import { ImageContentService } from 'src/domain/messages/application/services/image-content.service';
 
 @Injectable()
 export class ScalewayInferenceHandler extends BaseOpenAIChatInferenceHandler {
-  constructor(private readonly configService: ConfigService) {
-    super();
+  constructor(
+    private readonly configService: ConfigService,
+    imageContentService: ImageContentService,
+  ) {
+    super(imageContentService);
     this.client = new OpenAI({
       apiKey: this.configService.get('models.scaleway.apiKey'),
       baseURL: this.configService.get('models.scaleway.baseURL'),

--- a/ayunis-core-backend/src/domain/models/infrastructure/inference/stackit.inference.ts
+++ b/ayunis-core-backend/src/domain/models/infrastructure/inference/stackit.inference.ts
@@ -2,11 +2,15 @@ import { Injectable } from '@nestjs/common';
 import { BaseOpenAIChatInferenceHandler } from './base-openai-chat.inference';
 import { ConfigService } from '@nestjs/config';
 import OpenAI from 'openai';
+import { ImageContentService } from 'src/domain/messages/application/services/image-content.service';
 
 @Injectable()
 export class StackitInferenceHandler extends BaseOpenAIChatInferenceHandler {
-  constructor(private readonly configService: ConfigService) {
-    super();
+  constructor(
+    private readonly configService: ConfigService,
+    imageContentService: ImageContentService,
+  ) {
+    super(imageContentService);
     this.client = new OpenAI({
       apiKey: this.configService.get('models.stackit.apiKey'),
       baseURL: this.configService.get('models.stackit.baseURL'),

--- a/ayunis-core-backend/src/domain/models/infrastructure/stream-inference/azure.stream-inference.ts
+++ b/ayunis-core-backend/src/domain/models/infrastructure/stream-inference/azure.stream-inference.ts
@@ -3,6 +3,7 @@ import { BaseOpenAIChatStreamInferenceHandler } from './base-openai-chat.stream-
 import { ConfigService } from '@nestjs/config';
 import { AzureOpenAI } from 'openai';
 import { Observable } from 'rxjs';
+import { ImageContentService } from 'src/domain/messages/application/services/image-content.service';
 import {
   StreamInferenceInput,
   StreamInferenceResponseChunk,
@@ -10,11 +11,15 @@ import {
 
 @Injectable()
 export class AzureStreamInferenceHandler extends BaseOpenAIChatStreamInferenceHandler {
-  constructor(private readonly configService: ConfigService) {
-    super();
+  constructor(
+    private readonly configService: ConfigService,
+    imageContentService: ImageContentService,
+  ) {
+    super(imageContentService);
   }
 
   private getClient(): AzureOpenAI {
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- client is lazily initialized; base class types it as non-null
     if (!this.client) {
       this.client = new AzureOpenAI({
         apiKey: this.configService.get('models.azure.apiKey'),

--- a/ayunis-core-backend/src/domain/models/infrastructure/stream-inference/base-openai-chat.stream-inference.ts
+++ b/ayunis-core-backend/src/domain/models/infrastructure/stream-inference/base-openai-chat.stream-inference.ts
@@ -9,6 +9,7 @@ import { Observable, Subscriber } from 'rxjs';
 import OpenAI from 'openai';
 import retryWithBackoff from 'src/common/util/retryWithBackoff';
 import { ThinkingContentParser } from 'src/common/util/thinking-content-parser';
+import { ImageContentService } from 'src/domain/messages/application/services/image-content.service';
 import { OpenAIChatMessageConverter } from '../converters/openai-chat-message.converter';
 
 @Injectable()
@@ -18,7 +19,11 @@ export class BaseOpenAIChatStreamInferenceHandler implements StreamInferenceHand
   );
   private readonly thinkingParser = new ThinkingContentParser();
   protected client: OpenAI;
-  protected readonly chatConverter = new OpenAIChatMessageConverter();
+  protected readonly chatConverter: OpenAIChatMessageConverter;
+
+  constructor(protected readonly imageContentService: ImageContentService) {
+    this.chatConverter = new OpenAIChatMessageConverter(imageContentService);
+  }
 
   answer(
     input: StreamInferenceInput,
@@ -36,14 +41,17 @@ export class BaseOpenAIChatStreamInferenceHandler implements StreamInferenceHand
       // Reset thinking parser for new stream
       this.thinkingParser.reset();
 
-      const { messages, tools, toolChoice } = input;
+      const { messages, tools, toolChoice, orgId } = input;
       const openAiTools = tools
         .map((t) => this.chatConverter.convertTool(t))
         .map((tool) => ({
           ...tool,
           function: { ...tool.function, strict: true },
         }));
-      const openAiMessages = this.chatConverter.convertMessages(messages);
+      const openAiMessages = await this.chatConverter.convertMessages(
+        messages,
+        orgId,
+      );
       const systemPrompt = input.systemPrompt
         ? this.chatConverter.convertSystemPrompt(input.systemPrompt)
         : undefined;

--- a/ayunis-core-backend/src/domain/models/infrastructure/stream-inference/otc.stream-inference.ts
+++ b/ayunis-core-backend/src/domain/models/infrastructure/stream-inference/otc.stream-inference.ts
@@ -2,11 +2,15 @@ import { Injectable } from '@nestjs/common';
 import { BaseOpenAIChatStreamInferenceHandler } from './base-openai-chat.stream-inference';
 import { ConfigService } from '@nestjs/config';
 import OpenAI from 'openai';
+import { ImageContentService } from 'src/domain/messages/application/services/image-content.service';
 
 @Injectable()
 export class OtcStreamInferenceHandler extends BaseOpenAIChatStreamInferenceHandler {
-  constructor(private readonly configService: ConfigService) {
-    super();
+  constructor(
+    private readonly configService: ConfigService,
+    imageContentService: ImageContentService,
+  ) {
+    super(imageContentService);
     this.client = new OpenAI({
       apiKey: this.configService.get('models.otc.apiKey'),
       baseURL: this.configService.get('models.otc.baseURL'),

--- a/ayunis-core-backend/src/domain/models/infrastructure/stream-inference/scaleway.stream-inference.ts
+++ b/ayunis-core-backend/src/domain/models/infrastructure/stream-inference/scaleway.stream-inference.ts
@@ -2,11 +2,15 @@ import { Injectable } from '@nestjs/common';
 import { BaseOpenAIChatStreamInferenceHandler } from './base-openai-chat.stream-inference';
 import { ConfigService } from '@nestjs/config';
 import OpenAI from 'openai';
+import { ImageContentService } from 'src/domain/messages/application/services/image-content.service';
 
 @Injectable()
 export class ScalewayStreamInferenceHandler extends BaseOpenAIChatStreamInferenceHandler {
-  constructor(private readonly configService: ConfigService) {
-    super();
+  constructor(
+    private readonly configService: ConfigService,
+    imageContentService: ImageContentService,
+  ) {
+    super(imageContentService);
     this.client = new OpenAI({
       apiKey: this.configService.get('models.scaleway.apiKey'),
       baseURL: this.configService.get('models.scaleway.baseURL'),

--- a/ayunis-core-backend/src/domain/models/infrastructure/stream-inference/stackit.stream-inference.ts
+++ b/ayunis-core-backend/src/domain/models/infrastructure/stream-inference/stackit.stream-inference.ts
@@ -2,11 +2,15 @@ import { Injectable } from '@nestjs/common';
 import { BaseOpenAIChatStreamInferenceHandler } from './base-openai-chat.stream-inference';
 import { ConfigService } from '@nestjs/config';
 import OpenAI from 'openai';
+import { ImageContentService } from 'src/domain/messages/application/services/image-content.service';
 
 @Injectable()
 export class StackitStreamInferenceHandler extends BaseOpenAIChatStreamInferenceHandler {
-  constructor(private readonly configService: ConfigService) {
-    super();
+  constructor(
+    private readonly configService: ConfigService,
+    imageContentService: ImageContentService,
+  ) {
+    super(imageContentService);
     this.client = new OpenAI({
       apiKey: this.configService.get('models.stackit.apiKey'),
       baseURL: this.configService.get('models.stackit.baseURL'),


### PR DESCRIPTION
Azure, Stackit, Scaleway, and OTC use the OpenAI Chat Completions
converter, which silently dropped ImageMessageContent — so vision-capable
models in the catalogue received only text even though the UI let users
attach images.

- Inject ImageContentService into OpenAIChatMessageConverter; map
  ImageMessageContent to OpenAI image_url parts (base64 data URL)
- Propagate orgId through base and subclass handlers so the converter
  can resolve image storage paths
- Add Azure GPT-5.4 to the minimal seed fixture for local testing

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the model inference request path by changing message conversion to include base64-encoded images and making OpenAI handlers async, which could affect payload size/performance and provider compatibility. Scope is limited to OpenAI-compatible providers and dev seeding.
> 
> **Overview**
> Fixes OpenAI-compatible chat providers (Azure/Stackit/Scaleway/OTC, streaming and non-streaming) dropping `ImageMessageContent` by converting user images into OpenAI `image_url` content parts (base64 data URLs) via injected `ImageContentService`.
> 
> Plumbs `orgId` through the OpenAI chat/stream base handlers into the converter and updates all derived handlers to inject `ImageContentService`.
> 
> Extends the minimal dev seed to include an additional Azure language model (`gpt-5.4`) and permits it for seeded orgs, plus suppresses hardcoded-password lint warnings for dev-only fixture users.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e72e6e34c02bcae89378baf18097875b9856735. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->