### PR TITLE
fix(sources): prevent OOM restarts from large CSV uploads (AYC-000)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,6 +60,7 @@ RUN mkdir -p uploads
 
 # Set environment variables
 ENV NODE_ENV=production
+ENV NODE_OPTIONS="--max-old-space-size=3072"
 # PORT is set via environment variable at runtime, defaults to 3000 in app code
 # Port exposure is handled by docker-compose port mapping
 

--- a/ayunis-core-backend/src/app/app.module.ts
+++ b/ayunis-core-backend/src/app/app.module.ts
@@ -66,6 +66,7 @@ import { TransactionalAdapterTypeOrm } from '@nestjs-cls/transactional-adapter-t
 import { ClsPluginTransactional } from '@nestjs-cls/transactional';
 import { SentryModule } from '@sentry/nestjs/setup';
 import { ApplicationErrorFilter } from 'src/common/filters/application-error.filter';
+import { PayloadTooLargeExceptionFilter } from 'src/common/filters/payload-too-large.filter';
 import { IntegrationsModule } from '../integrations/integrations.module';
 
 @Module({
@@ -181,6 +182,10 @@ import { IntegrationsModule } from '../integrations/integrations.module';
     // - Everything else   → NestJS BaseExceptionFilter defaults
     // @SentryExceptionCaptured() on catch() reports unexpected errors to Sentry.
     // 4xx errors are dropped by the beforeSend hook in instrument.ts.
+    {
+      provide: APP_FILTER,
+      useClass: PayloadTooLargeExceptionFilter,
+    },
     {
       provide: APP_FILTER,
       useClass: ApplicationErrorFilter,

--- a/ayunis-core-backend/src/common/filters/payload-too-large.filter.ts
+++ b/ayunis-core-backend/src/common/filters/payload-too-large.filter.ts
@@ -1,0 +1,26 @@
+import {
+  ArgumentsHost,
+  Catch,
+  ExceptionFilter,
+  HttpStatus,
+  Injectable,
+  PayloadTooLargeException,
+} from '@nestjs/common';
+import { Request, Response } from 'express';
+
+@Injectable()
+@Catch(PayloadTooLargeException)
+export class PayloadTooLargeExceptionFilter implements ExceptionFilter {
+  catch(exception: PayloadTooLargeException, host: ArgumentsHost) {
+    const ctx = host.switchToHttp();
+    const response = ctx.getResponse<Response>();
+    const request = ctx.getRequest<Request>();
+
+    response.status(HttpStatus.PAYLOAD_TOO_LARGE).json({
+      code: 'FILE_TOO_LARGE',
+      message: exception.message,
+      timestamp: new Date().toISOString(),
+      path: request.url,
+    });
+  }
+}

--- a/ayunis-core-backend/src/domain/agents/presenters/http/agents.controller.ts
+++ b/ayunis-core-backend/src/domain/agents/presenters/http/agents.controller.ts
@@ -292,7 +292,7 @@ export class AgentsController {
         file: {
           type: 'string',
           format: 'binary',
-          description: 'The file to upload',
+          description: 'The file to upload (max 25 MB)',
         },
       },
       required: ['file'],
@@ -308,9 +308,13 @@ export class AgentsController {
     description:
       'Invalid or unsupported file type. Supported types: PDF, DOCX, PPTX, TXT, CSV, XLSX, XLS',
   })
+  @ApiResponse({
+    status: 413,
+    description: 'File exceeds the 25 MB upload limit',
+  })
   @ApiResponse({ status: 500, description: 'Internal server error' })
   @UseInterceptors(
-    /* eslint-disable sonarjs/content-length -- file size validated downstream */
+    /* eslint-disable sonarjs/content-length -- multer file size limit, not HTTP Content-Length */
     FileInterceptor('file', {
       storage: diskStorage({
         // eslint-disable-next-line sonarjs/todo-tag -- pre-existing, tracked separately
@@ -321,6 +325,7 @@ export class AgentsController {
           cb(null, `${randomName}${extname(file.originalname)}`);
         },
       }),
+      limits: { fileSize: 25 * 1024 * 1024 }, // 25 MB
     }),
     /* eslint-enable sonarjs/content-length */
   )

--- a/ayunis-core-backend/src/domain/skills/presenters/http/skill-sources.controller.ts
+++ b/ayunis-core-backend/src/domain/skills/presenters/http/skill-sources.controller.ts
@@ -131,7 +131,7 @@ export class SkillSourcesController {
         file: {
           type: 'string',
           format: 'binary',
-          description: 'The file to upload',
+          description: 'The file to upload (max 25 MB)',
         },
       },
       required: ['file'],
@@ -147,9 +147,13 @@ export class SkillSourcesController {
     status: 400,
     description: 'Invalid or unsupported file type',
   })
+  @ApiResponse({
+    status: 413,
+    description: 'File exceeds the 25 MB upload limit',
+  })
   @UseInterceptors(
+    /* eslint-disable sonarjs/content-length -- multer file size limit, not HTTP Content-Length */
     FileInterceptor('file', {
-      // eslint-disable-next-line sonarjs/content-length -- false positive: diskStorage config, not a Content-Length header
       storage: diskStorage({
         destination: './uploads',
         filename: (req, file, cb) => {
@@ -157,7 +161,9 @@ export class SkillSourcesController {
           cb(null, `${randomName}${extname(file.originalname)}`);
         },
       }),
+      limits: { fileSize: 25 * 1024 * 1024 }, // 25 MB
     }),
+    /* eslint-enable sonarjs/content-length */
   )
   async addFileSource(
     @CurrentUser(UserProperty.ID) userId: UUID,

--- a/ayunis-core-backend/src/domain/sources/application/use-cases/create-data-source/create-data-source.use-case.ts
+++ b/ayunis-core-backend/src/domain/sources/application/use-cases/create-data-source/create-data-source.use-case.ts
@@ -22,7 +22,16 @@ export class CreateDataSourceUseCase {
   async execute(command: CreateCSVDataSourceCommand): Promise<CSVDataSource>;
   async execute(command: CreateDataSourceCommand): Promise<DataSource>;
   async execute(command: CreateDataSourceCommand): Promise<DataSource> {
-    this.logger.log('execute', { command });
+    this.logger.log('execute', {
+      name:
+        command instanceof CreateCSVDataSourceCommand
+          ? command.name
+          : undefined,
+      rowCount:
+        command instanceof CreateCSVDataSourceCommand
+          ? command.data.rows.length
+          : undefined,
+    });
     try {
       if (command instanceof CreateCSVDataSourceCommand) {
         const dataSource = new CSVDataSource({

--- a/ayunis-core-backend/src/domain/threads/presenters/http/thread-sources.controller.ts
+++ b/ayunis-core-backend/src/domain/threads/presenters/http/thread-sources.controller.ts
@@ -160,7 +160,7 @@ export class ThreadSourcesController {
         file: {
           type: 'string',
           format: 'binary',
-          description: 'The file to upload',
+          description: 'The file to upload (max 25 MB)',
         },
       },
       required: ['file'],
@@ -180,13 +180,17 @@ export class ThreadSourcesController {
       },
     },
   })
+  @ApiResponse({
+    status: 413,
+    description: 'File exceeds the 25 MB upload limit',
+  })
   @ApiExtraModels(
     FileSourceResponseDto,
     UrlSourceResponseDto,
     CSVDataSourceResponseDto,
   )
   @UseInterceptors(
-    /* eslint-disable sonarjs/content-length -- file size validated downstream */
+    /* eslint-disable sonarjs/content-length -- multer file size limit, not HTTP Content-Length */
     FileInterceptor('file', {
       storage: diskStorage({
         // eslint-disable-next-line sonarjs/todo-tag -- pre-existing, tracked separately
@@ -197,6 +201,7 @@ export class ThreadSourcesController {
           cb(null, `${randomName}${extname(file.originalname)}`);
         },
       }),
+      limits: { fileSize: 25 * 1024 * 1024 }, // 25 MB
     }),
     /* eslint-enable sonarjs/content-length */
   )

--- a/ayunis-core-backend/src/domain/tools/application/handlers/code-execution-tool.handler.ts
+++ b/ayunis-core-backend/src/domain/tools/application/handlers/code-execution-tool.handler.ts
@@ -6,7 +6,10 @@ import {
 import { UUID } from 'crypto';
 import { ToolExecutionFailedError } from '../tools.errors';
 import { getAyunisCodeExecutionService } from '../../../../common/clients/code-execution/generated/ayunisCodeExecutionService';
-import type { ExecutionRequest } from '../../../../common/clients/code-execution/generated/ayunisCodeExecutionService.schemas';
+import type {
+  ExecutionRequest,
+  ExecutionResponse,
+} from '../../../../common/clients/code-execution/generated/ayunisCodeExecutionService.schemas';
 import { Injectable, Logger } from '@nestjs/common';
 import { GetSourceByIdUseCase } from 'src/domain/sources/application/use-cases/get-source-by-id/get-source-by-id.use-case';
 import { GetSourceByIdQuery } from 'src/domain/sources/application/use-cases/get-source-by-id/get-source-by-id.query';
@@ -40,136 +43,27 @@ export class CodeExecutionToolHandler extends ToolExecutionHandler {
     const { tool, input, context } = params;
 
     try {
-      const validatedInput = tool.validateParams(input);
-      const { code, dataSourceIds } = validatedInput;
-      // Get the code execution service client
+      const { code, dataSourceIds } = tool.validateParams(input);
+
+      const executionFiles = await this.prepareExecutionFiles(
+        dataSourceIds,
+        tool.name,
+      );
+
       const codeExecutionService = getAyunisCodeExecutionService();
-
-      // Prepare files object
-      const executionFiles: Record<string, string> = {};
-
-      // Add CSV data sources as files
-      if (dataSourceIds && Array.isArray(dataSourceIds)) {
-        for (const sourceId of dataSourceIds) {
-          const csvSource = await this.getSourceByIdUseCase
-            .execute(new GetSourceByIdQuery(sourceId as UUID))
-            .catch((error) => {
-              this.logger.error('Error getting CSV data source', error);
-              throw new ToolExecutionFailedError({
-                toolName: tool.name,
-                message: `Error getting CSV data source: ${error instanceof Error ? error.message : 'Unknown error. Source ID: ' + sourceId}`,
-                exposeToLLM: true,
-              });
-            });
-          if (csvSource instanceof CSVDataSource) {
-            try {
-              const csvContent = convertCSVToString(csvSource.data);
-              executionFiles[`${sourceId}.csv`] =
-                Buffer.from(csvContent).toString('base64');
-            } catch (error) {
-              this.logger.error(
-                'Error converting CSV data source to string',
-                error,
-                { data: csvSource.data },
-              );
-              throw new ToolExecutionFailedError({
-                toolName: tool.name,
-                message: `Error converting CSV data source to string: ${error instanceof Error ? error.message : 'Unknown error'} Source data: ${JSON.stringify(csvSource.data)}`,
-                exposeToLLM: true,
-              });
-            }
-          }
-        }
-      }
-
-      // Prepare the execution request
       const executionRequest: ExecutionRequest = {
-        code: code,
+        code,
         files: executionFiles,
       };
-
-      // Execute the code using the generated client (returns data directly via custom mutator)
       const response =
         await codeExecutionService.executeCodeExecutePost(executionRequest);
 
-      // Handle output CSV files if present
-      const createdSources: string[] = [];
-      if (
-        response.output_files &&
-        Object.keys(response.output_files).length > 0
-      ) {
-        try {
-          const { thread } = await this.findThreadUseCase.execute(
-            new FindThreadQuery(context.threadId),
-          );
+      const createdSources = await this.processOutputFiles(
+        response.output_files,
+        context.threadId,
+      );
 
-          for (const [filename, content_b64] of Object.entries(
-            response.output_files,
-          )) {
-            try {
-              // Decode the base64 content
-              const csvContent = Buffer.from(content_b64, 'base64').toString(
-                'utf-8',
-              );
-
-              // Parse CSV
-              const { headers, data } = parseCSV(csvContent);
-
-              // Create data source
-              const sourceName = filename.replace('.csv', '');
-              const source = await this.createDataSourceUseCase.execute(
-                new CreateCSVDataSourceCommand({
-                  name: sourceName,
-                  data: { headers, rows: data },
-                  createdBy: SourceCreator.LLM,
-                }),
-              );
-
-              // Add source to thread
-              await this.addSourceToThreadUseCase.execute(
-                new AddSourceCommand(thread, source),
-              );
-
-              createdSources.push(`${sourceName} (ID: ${source.id})`);
-              this.logger.log(
-                `Created and attached CSV source: ${sourceName}`,
-                {
-                  sourceId: source.id,
-                  threadId: context.threadId,
-                },
-              );
-            } catch (error) {
-              this.logger.error(
-                `Failed to process output file ${filename}`,
-                error,
-              );
-              // Continue processing other files
-            }
-          }
-        } catch (error) {
-          this.logger.error('Failed to handle output files', error);
-          // Don't fail the entire execution if source creation fails
-        }
-      }
-
-      // Format the response for the LLM
-      if (response.success) {
-        let result = `Code executed successfully (ID: ${response.execution_id})\n`;
-        if (response.output) {
-          result += `Output:\n${response.output}\n`;
-        }
-        if (createdSources.length > 0) {
-          result += `\nCreated ${createdSources.length} CSV data source(s):\n${createdSources.map((s) => `- ${s}`).join('\n')}\n`;
-          result += `These sources are now available for analysis in this conversation.\n`;
-        }
-        if (response.error) {
-          result += `Warnings/Errors:\n${response.error}\n`;
-        }
-        result += `Exit code: ${response.exit_code}`;
-        return result;
-      } else {
-        return `Code execution failed (ID: ${response.execution_id})\nError: ${response.error}\nExit code: ${response.exit_code}`;
-      }
+      return this.formatLLMResponse(response, createdSources);
     } catch (error) {
       if (error instanceof ToolExecutionFailedError) {
         throw error;
@@ -180,5 +74,161 @@ export class CodeExecutionToolHandler extends ToolExecutionHandler {
         exposeToLLM: true,
       });
     }
+  }
+
+  private async prepareExecutionFiles(
+    dataSourceIds: unknown,
+    toolName: string,
+  ): Promise<Record<string, string>> {
+    const executionFiles: Record<string, string> = {};
+    if (!Array.isArray(dataSourceIds)) {
+      return executionFiles;
+    }
+
+    for (const sourceId of dataSourceIds) {
+      const csvSource = await this.loadCsvSource(sourceId as UUID, toolName);
+      if (csvSource instanceof CSVDataSource) {
+        executionFiles[`${sourceId}.csv`] = this.encodeCsvToBase64(
+          csvSource,
+          sourceId as UUID,
+          toolName,
+        );
+      }
+    }
+    return executionFiles;
+  }
+
+  private async loadCsvSource(sourceId: UUID, toolName: string) {
+    try {
+      return await this.getSourceByIdUseCase.execute(
+        new GetSourceByIdQuery(sourceId),
+      );
+    } catch (error) {
+      this.logger.error('Error getting CSV data source', error);
+      throw new ToolExecutionFailedError({
+        toolName,
+        message: `Error getting CSV data source: ${error instanceof Error ? error.message : 'Unknown error. Source ID: ' + sourceId}`,
+        exposeToLLM: true,
+      });
+    }
+  }
+
+  private encodeCsvToBase64(
+    csvSource: CSVDataSource,
+    sourceId: UUID,
+    toolName: string,
+  ): string {
+    try {
+      const csvContent = convertCSVToString(csvSource.data);
+      return Buffer.from(csvContent).toString('base64');
+    } catch (error) {
+      this.logger.error('Error converting CSV data source to string', error, {
+        sourceId,
+        rowCount: csvSource.data.rows.length,
+        headerCount: csvSource.data.headers.length,
+      });
+      throw new ToolExecutionFailedError({
+        toolName,
+        message: `Error converting CSV data source to string: ${error instanceof Error ? error.message : 'Unknown error'}`,
+        exposeToLLM: true,
+      });
+    }
+  }
+
+  private async processOutputFiles(
+    outputFiles: ExecutionResponse['output_files'],
+    threadId: UUID,
+  ): Promise<string[]> {
+    const createdSources: string[] = [];
+    if (!outputFiles || Object.keys(outputFiles).length === 0) {
+      return createdSources;
+    }
+
+    try {
+      const { thread } = await this.findThreadUseCase.execute(
+        new FindThreadQuery(threadId),
+      );
+
+      for (const [filename, content_b64] of Object.entries(outputFiles)) {
+        const summary = await this.persistOutputFile(
+          filename,
+          content_b64,
+          thread,
+          threadId,
+        );
+        if (summary) {
+          createdSources.push(summary);
+        }
+      }
+    } catch (error) {
+      this.logger.error('Failed to handle output files', error);
+    }
+
+    return createdSources;
+  }
+
+  private async persistOutputFile(
+    filename: string,
+    contentBase64: string,
+    thread: Parameters<AddSourceToThreadUseCase['execute']>[0]['thread'],
+    threadId: UUID,
+  ): Promise<string | null> {
+    try {
+      const csvContent = Buffer.from(contentBase64, 'base64').toString('utf-8');
+      const { headers, data } = parseCSV(csvContent);
+      const sourceName = filename.replace('.csv', '');
+
+      const source = await this.createDataSourceUseCase.execute(
+        new CreateCSVDataSourceCommand({
+          name: sourceName,
+          data: { headers, rows: data },
+          createdBy: SourceCreator.LLM,
+        }),
+      );
+
+      await this.addSourceToThreadUseCase.execute(
+        new AddSourceCommand(thread, source),
+      );
+
+      this.logger.log(`Created and attached CSV source: ${sourceName}`, {
+        sourceId: source.id,
+        threadId,
+      });
+
+      return `${sourceName} (ID: ${source.id})`;
+    } catch (error) {
+      this.logger.error(`Failed to process output file ${filename}`, error);
+      return null;
+    }
+  }
+
+  private formatLLMResponse(
+    response: ExecutionResponse,
+    createdSources: string[],
+  ): string {
+    if (!response.success) {
+      return `Code execution failed (ID: ${response.execution_id})\nError: ${response.error}\nExit code: ${response.exit_code}`;
+    }
+
+    const lines: string[] = [
+      `Code executed successfully (ID: ${response.execution_id})`,
+    ];
+    if (response.output) {
+      lines.push(`Output:\n${response.output}`);
+    }
+    if (createdSources.length > 0) {
+      const sourceList = createdSources.map((s) => `- ${s}`).join('\n');
+      lines.push(
+        `\nCreated ${createdSources.length} CSV data source(s):\n${sourceList}`,
+      );
+      lines.push(
+        'These sources are now available for analysis in this conversation.',
+      );
+    }
+    if (response.error) {
+      lines.push(`Warnings/Errors:\n${response.error}`);
+    }
+    lines.push(`Exit code: ${response.exit_code}`);
+    return lines.join('\n');
   }
 }

--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
@@ -4076,14 +4076,14 @@ offset?: number;
 export type ThreadSourcesControllerGetThreadSources200Item = FileSourceResponseDto | UrlSourceResponseDto | CSVDataSourceResponseDto;
 
 export type ThreadSourcesControllerAddFileSourceBody = {
-  /** The file to upload */
+  /** The file to upload (max 25 MB) */
   file: Blob;
 };
 
 export type ThreadSourcesControllerAddFileSource201Item = FileSourceResponseDto | UrlSourceResponseDto | CSVDataSourceResponseDto;
 
 export type AgentsControllerAddFileSourceBody = {
-  /** The file to upload */
+  /** The file to upload (max 25 MB) */
   file: Blob;
 };
 
@@ -4115,7 +4115,7 @@ export type KnowledgeBasesControllerAddDocumentBody = {
 };
 
 export type SkillSourcesControllerAddFileSourceBody = {
-  /** The file to upload */
+  /** The file to upload (max 25 MB) */
   file: Blob;
 };
 

--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.ts
@@ -7323,7 +7323,7 @@ formData.append(`file`, threadSourcesControllerAddFileSourceBody.file)
   
 
 
-export const getThreadSourcesControllerAddFileSourceMutationOptions = <TError = unknown,
+export const getThreadSourcesControllerAddFileSourceMutationOptions = <TError = void,
     TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof threadSourcesControllerAddFileSource>>, TError,{id: string;data: ThreadSourcesControllerAddFileSourceBody}, TContext>, }
 ): UseMutationOptions<Awaited<ReturnType<typeof threadSourcesControllerAddFileSource>>, TError,{id: string;data: ThreadSourcesControllerAddFileSourceBody}, TContext> => {
 
@@ -7350,12 +7350,12 @@ const {mutation: mutationOptions} = options ?
 
     export type ThreadSourcesControllerAddFileSourceMutationResult = NonNullable<Awaited<ReturnType<typeof threadSourcesControllerAddFileSource>>>
     export type ThreadSourcesControllerAddFileSourceMutationBody = ThreadSourcesControllerAddFileSourceBody
-    export type ThreadSourcesControllerAddFileSourceMutationError = unknown
+    export type ThreadSourcesControllerAddFileSourceMutationError = void
 
     /**
  * @summary Add a file source to a thread
  */
-export const useThreadSourcesControllerAddFileSource = <TError = unknown,
+export const useThreadSourcesControllerAddFileSource = <TError = void,
     TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof threadSourcesControllerAddFileSource>>, TError,{id: string;data: ThreadSourcesControllerAddFileSourceBody}, TContext>, }
  , queryClient?: QueryClient): UseMutationResult<
         Awaited<ReturnType<typeof threadSourcesControllerAddFileSource>>,

--- a/ayunis-core-frontend/src/shared/api/openapi-schema.json
+++ b/ayunis-core-frontend/src/shared/api/openapi-schema.json
@@ -3593,7 +3593,7 @@
                   "file": {
                     "type": "string",
                     "format": "binary",
-                    "description": "The file to upload"
+                    "description": "The file to upload (max 25 MB)"
                   }
                 },
                 "required": ["file"]
@@ -3624,6 +3624,9 @@
                 }
               }
             }
+          },
+          "413": {
+            "description": "File exceeds the 25 MB upload limit"
           }
         },
         "summary": "Add a file source to a thread",
@@ -4025,7 +4028,7 @@
                   "file": {
                     "type": "string",
                     "format": "binary",
-                    "description": "The file to upload"
+                    "description": "The file to upload (max 25 MB)"
                   }
                 },
                 "required": ["file"]
@@ -4042,6 +4045,9 @@
           },
           "404": {
             "description": "Agent not found"
+          },
+          "413": {
+            "description": "File exceeds the 25 MB upload limit"
           },
           "500": {
             "description": "Internal server error"
@@ -5611,7 +5617,7 @@
                   "file": {
                     "type": "string",
                     "format": "binary",
-                    "description": "The file to upload"
+                    "description": "The file to upload (max 25 MB)"
                   }
                 },
                 "required": ["file"]
@@ -5635,6 +5641,9 @@
           },
           "404": {
             "description": "Skill not found"
+          },
+          "413": {
+            "description": "File exceeds the 25 MB upload limit"
           }
         },
         "summary": "Add a file source to a skill",

--- a/ayunis-core-frontend/src/shared/locales/de/agent.json
+++ b/ayunis-core-frontend/src/shared/locales/de/agent.json
@@ -40,7 +40,7 @@
     "failedToAdd": "Fehler beim Hinzufügen der Quelle",
     "invalidFileTypeError": "Dieser Dateityp wird derzeit nicht unterstützt.",
     "fileSourceEmptyDataError": "Die hochgeladene Datei enthält keine verarbeitbaren Daten.",
-    "fileSourceTooLargeError": "Datei ist zu groß. Maximale Dateigröße ist 50MB.",
+    "fileSourceTooLargeError": "Datei ist zu groß. Maximale Dateigröße ist 25MB.",
     "fileSourceTooManyPagesError": "Dokument hat zu viele Seiten zur Verarbeitung.",
     "fileSourceServiceBusyError": "Der Dokumentenverarbeitungsdienst ist beschäftigt. Bitte versuchen Sie es später erneut.",
     "fileSourceTimeoutError": "Dokumentenverarbeitung hat das Zeitlimit überschritten. Die Datei ist möglicherweise zu komplex."

--- a/ayunis-core-frontend/src/shared/locales/de/common.json
+++ b/ayunis-core-frontend/src/shared/locales/de/common.json
@@ -52,7 +52,7 @@
     "fileSourceUploadError": "Fehler beim Hochladen der Datei",
     "fileSourceEmptyDataError": "Die hochgeladene Datei enthält keine verarbeitbaren Daten",
     "invalidFileTypeError": "Dieser Dateityp wird derzeit nicht unterstützt.",
-    "fileSourceTooLargeError": "Datei ist zu groß. Maximale Dateigröße ist 50MB.",
+    "fileSourceTooLargeError": "Datei ist zu groß. Maximale Dateigröße ist 25MB.",
     "fileSourceTooManyPagesError": "Dokument hat zu viele Seiten zur Verarbeitung.",
     "fileSourceServiceBusyError": "Der Dokumentenverarbeitungsdienst ist beschäftigt. Bitte versuchen Sie es später erneut.",
     "fileSourceTimeoutError": "Dokumentenverarbeitung hat das Zeitlimit überschritten. Die Datei ist möglicherweise zu komplex.",
@@ -117,7 +117,7 @@
     "failedToAdd": "Fehler beim Hochladen der Datei",
     "invalidFileTypeError": "Dieser Dateityp wird derzeit nicht unterstützt.",
     "fileSourceEmptyDataError": "Die hochgeladene Datei enthält keine verarbeitbaren Daten.",
-    "fileSourceTooLargeError": "Datei ist zu groß. Maximale Dateigröße ist 50MB.",
+    "fileSourceTooLargeError": "Datei ist zu groß. Maximale Dateigröße ist 25MB.",
     "fileSourceTooManyPagesError": "Dokument hat zu viele Seiten zur Verarbeitung.",
     "fileSourceServiceBusyError": "Der Dokumentenverarbeitungsdienst ist beschäftigt. Bitte versuchen Sie es später erneut.",
     "fileSourceTimeoutError": "Dokumentenverarbeitung hat das Zeitlimit überschritten. Die Datei ist möglicherweise zu komplex."

--- a/ayunis-core-frontend/src/shared/locales/de/skill.json
+++ b/ayunis-core-frontend/src/shared/locales/de/skill.json
@@ -114,7 +114,7 @@
     "failedToAdd": "Quelle konnte nicht hinzugefügt werden",
     "invalidFileTypeError": "Dieser Dateityp wird derzeit nicht unterstützt.",
     "fileSourceEmptyDataError": "Die hochgeladene Datei enthält keine verarbeitbaren Daten.",
-    "fileSourceTooLargeError": "Datei ist zu groß. Maximale Dateigröße beträgt 50 MB.",
+    "fileSourceTooLargeError": "Datei ist zu groß. Maximale Dateigröße beträgt 25 MB.",
     "fileSourceTooManyPagesError": "Dokument hat zu viele Seiten zur Verarbeitung.",
     "fileSourceServiceBusyError": "Der Dokumentenverarbeitungsdienst ist ausgelastet. Bitte versuchen Sie es später erneut.",
     "fileSourceTimeoutError": "Die Dokumentenverarbeitung hat das Zeitlimit überschritten. Die Datei ist möglicherweise zu komplex."

--- a/ayunis-core-frontend/src/shared/locales/en/agent.json
+++ b/ayunis-core-frontend/src/shared/locales/en/agent.json
@@ -40,7 +40,7 @@
     "failedToAdd": "Failed to add source",
     "invalidFileTypeError": "This file type is currently not supported.",
     "fileSourceEmptyDataError": "The uploaded file contains no processable data.",
-    "fileSourceTooLargeError": "File is too large. Maximum file size is 50MB.",
+    "fileSourceTooLargeError": "File is too large. Maximum file size is 25MB.",
     "fileSourceTooManyPagesError": "Document has too many pages to process.",
     "fileSourceServiceBusyError": "The document processing service is busy. Please try again later.",
     "fileSourceTimeoutError": "Document processing timed out. The file may be too complex."

--- a/ayunis-core-frontend/src/shared/locales/en/common.json
+++ b/ayunis-core-frontend/src/shared/locales/en/common.json
@@ -52,7 +52,7 @@
     "fileSourceUploadError": "Error uploading file",
     "fileSourceEmptyDataError": "The uploaded file contains no processable data",
     "invalidFileTypeError": "This file type is currently not supported.",
-    "fileSourceTooLargeError": "File is too large. Maximum file size is 50MB.",
+    "fileSourceTooLargeError": "File is too large. Maximum file size is 25MB.",
     "fileSourceTooManyPagesError": "Document has too many pages to process.",
     "fileSourceServiceBusyError": "The document processing service is busy. Please try again later.",
     "fileSourceTimeoutError": "Document processing timed out. The file may be too complex.",
@@ -117,7 +117,7 @@
     "failedToAdd": "Error uploading file",
     "invalidFileTypeError": "This file type is currently not supported.",
     "fileSourceEmptyDataError": "The uploaded file contains no processable data.",
-    "fileSourceTooLargeError": "File is too large. Maximum file size is 50MB.",
+    "fileSourceTooLargeError": "File is too large. Maximum file size is 25MB.",
     "fileSourceTooManyPagesError": "Document has too many pages to process.",
     "fileSourceServiceBusyError": "The document processing service is busy. Please try again later.",
     "fileSourceTimeoutError": "Document processing timed out. The file may be too complex."

--- a/ayunis-core-frontend/src/shared/locales/en/skill.json
+++ b/ayunis-core-frontend/src/shared/locales/en/skill.json
@@ -114,7 +114,7 @@
     "failedToAdd": "Failed to add source",
     "invalidFileTypeError": "This file type is currently not supported.",
     "fileSourceEmptyDataError": "The uploaded file contains no processable data.",
-    "fileSourceTooLargeError": "File is too large. Maximum file size is 50MB.",
+    "fileSourceTooLargeError": "File is too large. Maximum file size is 25MB.",
     "fileSourceTooManyPagesError": "Document has too many pages to process.",
     "fileSourceServiceBusyError": "The document processing service is busy. Please try again later.",
     "fileSourceTimeoutError": "Document processing timed out. The file may be too complex."

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -231,10 +231,10 @@ services:
     deploy:
       resources:
         limits:
-          memory: 1G
+          memory: 4G
           cpus: "2"
         reservations:
-          memory: 512M
+          memory: 1G
 
   redis:
     image: redis:7-alpine


### PR DESCRIPTION
Production saw backend container restarts triggered by CSV
uploads being parsed and logged in full. Address the incident
at multiple layers:

- Raise `app` container memory from 1G to 4G (host has ~16G)
  and cap V8 heap at 3072 MB so GC runs before cgroup OOM
- Add 25 MB `limits.fileSize` to agents, threads, and skills
  upload endpoints that previously had no cap
- Map multer's LIMIT_FILE_SIZE to the `FILE_TOO_LARGE` error
  code expected by the frontend error handler
- Declare 413 responses and document the 25 MB cap in the
  Swagger annotations for the three controllers
- Sync `{en,de}/{agent,skill,common}.json` error copy to 25 MB
- Stop logging full CSV payloads from CreateDataSourceUseCase
  and CodeExecutionToolHandler; split the handler's execute()
  into helpers to satisfy complexity budget after the touch

Follow-ups tracked as AYC-36 (streaming parse + multipart to
code-execution) and AYC-37 (BullMQ queue + row cap).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches request upload handling and global exception filtering, which can change API behavior for oversized requests and error shapes. Resource limit increases and logging reductions are low-risk, but require validation in production-like environments.
> 
> **Overview**
> Prevents backend OOM restarts from large CSV uploads by **capping multipart uploads at 25MB** and avoiding logging/processing patterns that can explode memory.
> 
> Backend now enforces `limits.fileSize` (25MB) on agent/thread/skill file upload endpoints, documents the 413 response in Swagger, and adds a global `PayloadTooLargeExceptionFilter` that converts Nest’s `PayloadTooLargeException` into a consistent `{ code: 'FILE_TOO_LARGE' }` JSON error. CSV creation/execution paths were hardened by logging only lightweight CSV metadata (e.g. name/row counts) and refactoring `CodeExecutionToolHandler` into helper methods while preserving behavior around attaching generated output CSVs.
> 
> Deployment settings were adjusted to be more OOM-resistant by increasing the app container memory limit (1G → 4G) and setting `NODE_OPTIONS=--max-old-space-size=3072`; frontend OpenAPI artifacts and locale strings were updated to reflect the new 25MB limit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a2249efd56083b0f06ab46309c393356a8a0efc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->