### PR TITLE
fix(db): remove duplicate startsAt in subscription seed (AYC-000)

### DIFF
--- a/ayunis-core-backend/src/db/scripts/seed-minimal.ts
+++ b/ayunis-core-backend/src/db/scripts/seed-minimal.ts
@@ -195,7 +195,6 @@ async function seedSubscription(
     renewalCycle: fixture.subscription.renewalCycle,
     startsAt: new Date(),
     renewalCycleAnchor: new Date(),
-    startsAt: new Date(),
     cancelledAt: null,
   } as Partial<SeatBasedSubscriptionRecord>);
   await subRepo.save(record);


### PR DESCRIPTION
## Summary
- Remove duplicate `startsAt: new Date()` in subscription seed record that caused `TS1117` and broke Backend Tests CI on main.
- Two PRs merged on 2026-04-20 (#570 and #556) each independently added the same `startsAt` assignment; since the duplicates were in different diff contexts, neither merge conflicted.

## Test plan
- [x] Local pre-commit typecheck passes
- [ ] CI `Backend Tests` → lint-and-typecheck turns green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: removes a redundant `startsAt` assignment in a dev/seed script without changing runtime business logic.
> 
> **Overview**
> Fixes the minimal DB seed script (`seed-minimal.ts`) by removing a duplicate `startsAt` field when creating a `SeatBasedSubscriptionRecord`, avoiding ambiguous/overridden values during seeding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c026977fa573726fc732566b833e764b4e0a1eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->