### PR TITLE
perf(anonymize): raise CPU and memory limits for PII detection (AYC-000)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -154,6 +154,9 @@ services:
     restart: unless-stopped
     networks:
       - ayunis-network
+    environment:
+      OMP_NUM_THREADS: "4"
+      MKL_NUM_THREADS: "4"
     healthcheck:
       test:
         [
@@ -172,10 +175,10 @@ services:
     deploy:
       resources:
         limits:
-          memory: 2G
-          cpus: "2"
+          memory: 3G
+          cpus: "4"
         reservations:
-          memory: 1G
+          memory: 1500M
 
   app:
     build:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk config-only change, but it increases `anonymize` CPU/memory usage which could impact host capacity and scheduling in constrained environments.
> 
> **Overview**
> **Boosts performance capacity for the `anonymize` service** by increasing Docker resource allocations and tuning CPU thread usage.
> 
> `docker-compose.yml` raises `anonymize` limits from 2G/2 CPUs to 3G/4 CPUs, increases reserved memory to 1500M, and sets `OMP_NUM_THREADS`/`MKL_NUM_THREADS` to `4` to better utilize available cores during PII detection/model workloads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f89b43bce118c2b6d90a0781229b1e689cadf715. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->