### PR TITLE
fix(dev): prevent ./dev up from aborting when .env.dev is missing or stale (AYC-000)

### DIFF
--- a/dev
+++ b/dev
@@ -126,7 +126,7 @@ cmd_up() {
   # Preserve an existing MCP_ENCRYPTION_KEY across restarts so locally-stored
   # MCP credentials remain decryptable; generate a new one on first run.
   local mcp_key
-  mcp_key="$(grep -E '^MCP_ENCRYPTION_KEY=' "$env_dev" 2>/dev/null | cut -d= -f2-)"
+  mcp_key="$(grep -E '^MCP_ENCRYPTION_KEY=' "$env_dev" 2>/dev/null | cut -d= -f2- || true)"
   if [[ -z "$mcp_key" ]]; then
     mcp_key="$(openssl rand -hex 32)"
   fi


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: a small change to the `./dev` bash script to ignore `grep` non-zero exit codes, only affecting local dev startup behavior.
> 
> **Overview**
> Makes `./dev up` resilient when `ayunis-core-backend/.env.dev` is missing or doesn’t contain `MCP_ENCRYPTION_KEY` by appending `|| true` to the key lookup, preventing `set -euo pipefail` from aborting and allowing a new key to be generated as intended.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1363ba8ce5cc2a29722df4e728991aae6b64d18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->