### PR TITLE
fix(anonymize): drop overlapping GLiNER spans before applying replacements (AYC-000)

### DIFF
--- a/ayunis-core-backend/src/common/anonymization/infrastructure/providers/presidio-anonymization.provider.spec.ts
+++ b/ayunis-core-backend/src/common/anonymization/infrastructure/providers/presidio-anonymization.provider.spec.ts
@@ -1,0 +1,91 @@
+import { Logger } from '@nestjs/common';
+import { PresidioAnonymizationProvider } from './presidio-anonymization.provider';
+import type { RecognizerResult } from 'src/common/clients/anonymize/generated/mSPresidioPIIDetectionAPI.schemas';
+
+const mockAnalyzeTextAnalyzePost = jest.fn();
+jest.mock(
+  'src/common/clients/anonymize/generated/mSPresidioPIIDetectionAPI',
+  () => ({
+    getMSPresidioPIIDetectionAPI: () => ({
+      analyzeTextAnalyzePost: mockAnalyzeTextAnalyzePost,
+    }),
+  }),
+);
+
+describe('PresidioAnonymizationProvider', () => {
+  let provider: PresidioAnonymizationProvider;
+
+  beforeEach(() => {
+    provider = new PresidioAnonymizationProvider();
+    jest.spyOn(Logger.prototype, 'debug').mockImplementation();
+    jest.spyOn(Logger.prototype, 'error').mockImplementation();
+    mockAnalyzeTextAnalyzePost.mockReset();
+  });
+
+  const mockResults = (results: RecognizerResult[]) => {
+    mockAnalyzeTextAnalyzePost.mockResolvedValue({ results });
+  };
+
+  it('replaces a single detected entity with its type placeholder', async () => {
+    const text = 'Ich bin der Dani';
+    mockResults([{ entity_type: 'PERSON', start: 12, end: 16, score: 0.9 }]);
+
+    const result = await provider.anonymize(text);
+
+    expect(result.anonymizedText).toBe('Ich bin der [PERSON]');
+  });
+
+  it('replaces multiple non-overlapping entities in a single pass', async () => {
+    const text = 'Ich bin der Dani, ich komm aus Deisenhofen und bin Metzger';
+    mockResults([
+      { entity_type: 'PERSON', start: 12, end: 16, score: 0.9 },
+      { entity_type: 'LOCATION', start: 31, end: 42, score: 0.9 },
+    ]);
+
+    const result = await provider.anonymize(text);
+
+    expect(result.anonymizedText).toBe(
+      'Ich bin der [PERSON], ich komm aus [LOCATION] und bin Metzger',
+    );
+  });
+
+  it('collapses overlapping spans sharing an end position into one replacement', async () => {
+    const text = 'Ich bin der Dani, ich komm aus Deisenhofen und bin Metzger';
+    mockResults([
+      { entity_type: 'PERSON', start: 0, end: 16, score: 0.85 },
+      { entity_type: 'PERSON', start: 12, end: 16, score: 0.9 },
+      { entity_type: 'LOCATION', start: 31, end: 42, score: 0.9 },
+    ]);
+
+    const result = await provider.anonymize(text);
+
+    expect(result.anonymizedText).not.toContain('[PERSON]SON]');
+    expect(result.anonymizedText).toBe(
+      '[PERSON], ich komm aus [LOCATION] und bin Metzger',
+    );
+    expect(result.replacements).toHaveLength(2);
+  });
+
+  it('collapses nested spans sharing a start position into one replacement', async () => {
+    const text = 'Berlin University is in Germany';
+    mockResults([
+      { entity_type: 'LOCATION', start: 0, end: 6, score: 0.8 },
+      { entity_type: 'ORGANIZATION', start: 0, end: 17, score: 0.9 },
+    ]);
+
+    const result = await provider.anonymize(text);
+
+    expect(result.anonymizedText).toBe('[ORGANIZATION] is in Germany');
+    expect(result.replacements).toHaveLength(1);
+  });
+
+  it('returns the original text when no entities are detected', async () => {
+    const text = 'Der Wetterbericht für morgen sagt Regen voraus';
+    mockResults([]);
+
+    const result = await provider.anonymize(text);
+
+    expect(result.anonymizedText).toBe(text);
+    expect(result.replacements).toHaveLength(0);
+  });
+});

--- a/ayunis-core-backend/src/common/anonymization/infrastructure/providers/presidio-anonymization.provider.ts
+++ b/ayunis-core-backend/src/common/anonymization/infrastructure/providers/presidio-anonymization.provider.ts
@@ -29,8 +29,14 @@ export class PresidioAnonymizationProvider extends AnonymizationPort {
         entities: entities ?? null,
       });
 
-      const replacements = this.buildReplacements(text, response.results);
-      const anonymizedText = this.applyReplacements(text, response.results);
+      const nonOverlappingResults = this.dropOverlappingResults(
+        response.results,
+      );
+      const replacements = this.buildReplacements(text, nonOverlappingResults);
+      const anonymizedText = this.applyReplacements(
+        text,
+        nonOverlappingResults,
+      );
 
       this.logger.debug('Anonymization complete', {
         originalLength: text.length,
@@ -84,5 +90,31 @@ export class PresidioAnonymizationProvider extends AnonymizationPort {
     }
 
     return anonymizedText;
+  }
+
+  // GLiNER runs with flat_ner=False and can return nested/overlapping spans
+  // for the same text (e.g. "Dani" and "der Dani" both as PERSON). Applying
+  // them both with naive offset-based substitution corrupts the output
+  // (e.g. "[PERSON]SON]"), so keep only the outermost of each overlap chain.
+  private dropOverlappingResults(
+    results: RecognizerResult[],
+  ): RecognizerResult[] {
+    if (results.length < 2) {
+      return results;
+    }
+
+    const sorted = [...results].sort(
+      (a, b) => a.start - b.start || b.end - a.end,
+    );
+
+    const kept: RecognizerResult[] = [];
+    let lastEnd = -1;
+    for (const result of sorted) {
+      if (result.start >= lastEnd) {
+        kept.push(result);
+        lastEnd = result.end;
+      }
+    }
+    return kept;
   }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes anonymization output by dropping overlapping/nested detection results, which can alter what gets redacted in edge cases. Logic is small and covered by new unit tests, but impacts PII masking behavior.
> 
> **Overview**
> Prevents corrupted anonymized output when the Presidio/GLiNER detector returns nested or overlapping spans by filtering results to a non-overlapping set before building replacements and applying substitutions.
> 
> Adds a Jest spec for `PresidioAnonymizationProvider` covering single/multiple replacements, overlapping and nested span collapsing, and the no-entity case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78b429ae6d05961781302894acfbb960b6d17895. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->