### PR TITLE
chore(docker): bind minio s3 api to host loopback (AYC-000)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,8 +48,9 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
-    # Only expose console port externally if needed
+    # S3 API on loopback so a host-side proxy can front it for presigned URLs
     ports:
+      - "127.0.0.1:9000:9000"
       - "9001:9001"
     logging:
       driver: json-file


### PR DESCRIPTION
## Summary

- Bind MinIO's S3 API (port 9000) to `127.0.0.1` so a host-side reverse proxy can front it under a public hostname.
- Console port `9001` mapping is unchanged.

## Why

Presigned URLs (e.g. for generated images) embed the `MINIO_ENDPOINT` host in the SigV4 signature, so clients must reach MinIO at that exact host. Previously only `9001` (console) was exposed, so presigned URLs pointed at the internal Docker DNS name `minio:9000` and failed outside the bridge network. With `9000` on loopback, the VM's nginx (or equivalent) can proxy e.g. `https://cdn-core-stage.ayunis.de` → `http://127.0.0.1:9000`.

## Deployment notes (stage)

Alongside this change, stage needs:

1. DNS for `cdn-core-stage.ayunis.de` pointing to the VM.
2. Nginx vhost on the VM: `cdn-core-stage.ayunis.de` → `http://127.0.0.1:9000`.
3. `ayunis-core-backend/.env` on stage:
   ```
   MINIO_ENDPOINT=cdn-core-stage.ayunis.de
   MINIO_PORT=443
   MINIO_USE_SSL=true
   ```
4. `docker compose up -d --force-recreate app`

## Test plan

- [ ] `docker compose up -d minio` recreates minio with `127.0.0.1:9000->9000/tcp`.
- [ ] `curl -I http://127.0.0.1:9000/minio/health/live` returns `200` on the host.
- [ ] `curl -I https://cdn-core-stage.ayunis.de/minio/health/live` returns `200`.
- [ ] Generating an image in the UI on stage produces a URL starting with `https://cdn-core-stage.ayunis.de/...` and the PNG loads in the browser.
- [ ] Console on `:9001` still reachable if it was before.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single docker-compose port-binding change; main risk is deployment misconfiguration causing MinIO access issues if callers expected `:9000` to be publicly reachable.
> 
> **Overview**
> Updates `docker-compose.yml` to expose MinIO’s S3 API on the host loopback only by binding port `9000` to `127.0.0.1:9000`, enabling a host-side reverse proxy to serve presigned-URL traffic without exposing MinIO publicly.
> 
> MinIO console port `9001` remains mapped as before; change is limited to port binding/comment tweaks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d57e4020366866aff3bc5a97465aa7ab256de3b2. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->