### PR TITLE
fix(artifacts): render tables in editor and size word export columns (AYC-56)

### DIFF
--- a/.github/workflows/complexity-check.yml
+++ b/.github/workflows/complexity-check.yml
@@ -24,7 +24,9 @@ jobs:
 
       - name: Install Lizard
         if: steps.changed-files.outputs.any_changed == 'true'
-        run: pip install lizard
+        # Pinned: 1.22.0 regressed TypeScript parsing, misreporting function length
+        # and param counts on files with complex type annotations.
+        run: pip install 'lizard==1.21.7'
 
       - name: Check complexity of changed files
         if: steps.changed-files.outputs.any_changed == 'true'

--- a/ayunis-core-backend/src/domain/artifacts/infrastructure/export/html-to-docx-converter.ts
+++ b/ayunis-core-backend/src/domain/artifacts/infrastructure/export/html-to-docx-converter.ts
@@ -68,6 +68,9 @@ const TABLE_BORDERS = {
   right: TABLE_BORDER,
 };
 
+// A4 portrait usable width = 210mm page − 2×25mm margins (see docx-document-config.ts).
+const TABLE_USABLE_WIDTH_TWIPS = convertMillimetersToTwip(210 - 2 * 25);
+
 /**
  * Converts TipTap-generated HTML into a DOCX buffer using the `docx` library.
  *
@@ -273,10 +276,12 @@ function convertListItem(
 // ---------------------------------------------------------------------------
 
 function convertTable(node: HTMLElement): Table {
-  const rows = node
-    .querySelectorAll(
-      ':scope > tr, :scope > thead > tr, :scope > tbody > tr, :scope > tfoot > tr',
-    )
+  const rowElements = node.querySelectorAll(
+    ':scope > tr, :scope > thead > tr, :scope > tbody > tr, :scope > tfoot > tr',
+  );
+  const columnCount = Math.max(1, countTableColumns(rowElements));
+  const columnWidths = buildEqualColumnWidths(columnCount);
+  const rows = rowElements
     .map(convertTableRow)
     .filter((r): r is TableRow => r !== null);
 
@@ -291,10 +296,34 @@ function convertTable(node: HTMLElement): Table {
           ],
         }),
       ],
+      columnWidths,
     });
   }
 
-  return new Table({ rows, width: { size: 100, type: WidthType.PERCENTAGE } });
+  return new Table({
+    rows,
+    columnWidths,
+    width: { size: 100, type: WidthType.PERCENTAGE },
+  });
+}
+
+function countTableColumns(rowElements: HTMLElement[]): number {
+  let max = 0;
+  for (const tr of rowElements) {
+    const cells = tr.querySelectorAll(':scope > td, :scope > th');
+    let count = 0;
+    for (const cell of cells) {
+      const colspan = parseInt(cell.getAttribute('colspan') ?? '1', 10);
+      count += Number.isFinite(colspan) && colspan > 0 ? colspan : 1;
+    }
+    if (count > max) max = count;
+  }
+  return max;
+}
+
+function buildEqualColumnWidths(columnCount: number): number[] {
+  const width = Math.floor(TABLE_USABLE_WIDTH_TWIPS / columnCount);
+  return Array.from({ length: columnCount }, () => width);
 }
 
 function convertTableRow(tr: HTMLElement): TableRow | null {

--- a/ayunis-core-backend/src/domain/artifacts/infrastructure/export/html-to-docx-converter.ts
+++ b/ayunis-core-backend/src/domain/artifacts/infrastructure/export/html-to-docx-converter.ts
@@ -9,6 +9,7 @@ import {
   AlignmentType,
   BorderStyle,
   WidthType,
+  TableLayoutType,
   UnderlineType,
   convertMillimetersToTwip,
   Packer,
@@ -297,12 +298,14 @@ function convertTable(node: HTMLElement): Table {
         }),
       ],
       columnWidths,
+      layout: TableLayoutType.FIXED,
     });
   }
 
   return new Table({
     rows,
     columnWidths,
+    layout: TableLayoutType.FIXED,
     width: { size: 100, type: WidthType.PERCENTAGE },
   });
 }

--- a/ayunis-core-frontend/package-lock.json
+++ b/ayunis-core-frontend/package-lock.json
@@ -35,6 +35,7 @@
         "@tanstack/router-plugin": "^1.166.13",
         "@tiptap/extension-link": "^3.20.0",
         "@tiptap/extension-placeholder": "^3.20.0",
+        "@tiptap/extension-table": "^3.22.4",
         "@tiptap/extension-text-align": "^3.20.0",
         "@tiptap/extension-underline": "^3.20.0",
         "@tiptap/pm": "^3.20.0",
@@ -3837,12 +3838,6 @@
       "integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==",
       "license": "MIT"
     },
-    "node_modules/@remirror/core-constants": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-3.0.0.tgz",
-      "integrity": "sha512-42aWfPrimMfDKDi4YegyS7x+/0tlzaqwPQCULLanv3DMIlu96KTJR0fM5isWX2UViOqlGnX6YFgqWepcX+XMNg==",
-      "license": "MIT"
-    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.9",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.9.tgz",
@@ -5410,16 +5405,16 @@
       }
     },
     "node_modules/@tiptap/core": {
-      "version": "3.20.0",
-      "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.20.0.tgz",
-      "integrity": "sha512-aC9aROgia/SpJqhsXFiX9TsligL8d+oeoI8W3u00WI45s0VfsqjgeKQLDLF7Tu7hC+7F02teC84SAHuup003VQ==",
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.22.4.tgz",
+      "integrity": "sha512-vGIGm/HpqLg8EAAQXQ+koV+/S828OEpzocfWcPOwo1u2QUVf9dQG47Yy6JJ8zFFaJwfv4dBcOXli+7BrJwsxDQ==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/pm": "^3.20.0"
+        "@tiptap/pm": "3.22.4"
       }
     },
     "node_modules/@tiptap/extension-blockquote": {
@@ -5723,6 +5718,20 @@
         "@tiptap/core": "^3.20.0"
       }
     },
+    "node_modules/@tiptap/extension-table": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-table/-/extension-table-3.22.4.tgz",
+      "integrity": "sha512-kjvLv3Z4JI+1tLDqZKa+bKU8VcxY+ZOyMCKWQA7wYmy8nKWkLJ60W+xy8AcXXpHB2goCIgSFLhsTyswx0GXH4w==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.22.4",
+        "@tiptap/pm": "3.22.4"
+      }
+    },
     "node_modules/@tiptap/extension-text": {
       "version": "3.20.0",
       "resolved": "https://registry.npmjs.org/@tiptap/extension-text/-/extension-text-3.20.0.tgz",
@@ -5777,27 +5786,21 @@
       }
     },
     "node_modules/@tiptap/pm": {
-      "version": "3.20.0",
-      "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.20.0.tgz",
-      "integrity": "sha512-jn+2KnQZn+b+VXr8EFOJKsnjVNaA4diAEr6FOazupMt8W8ro1hfpYtZ25JL87Kao/WbMze55sd8M8BDXLUKu1A==",
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.22.4.tgz",
+      "integrity": "sha512-hj8Qka6WcHRllHUdeSjDnq2XaisUo4KsoGJc1WcFpoa1Yd+OeD861zUMnV7DFVGdZRy45Obht0CUYJpXQ4yA4w==",
       "license": "MIT",
       "dependencies": {
         "prosemirror-changeset": "^2.3.0",
-        "prosemirror-collab": "^1.3.1",
         "prosemirror-commands": "^1.6.2",
         "prosemirror-dropcursor": "^1.8.1",
         "prosemirror-gapcursor": "^1.3.2",
         "prosemirror-history": "^1.4.1",
-        "prosemirror-inputrules": "^1.4.0",
         "prosemirror-keymap": "^1.2.2",
-        "prosemirror-markdown": "^1.13.1",
-        "prosemirror-menu": "^1.2.4",
         "prosemirror-model": "^1.24.1",
-        "prosemirror-schema-basic": "^1.2.3",
         "prosemirror-schema-list": "^1.5.0",
         "prosemirror-state": "^1.4.3",
         "prosemirror-tables": "^1.6.4",
-        "prosemirror-trailing-node": "^3.0.0",
         "prosemirror-transform": "^1.10.2",
         "prosemirror-view": "^1.38.1"
       },
@@ -6348,22 +6351,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/linkify-it": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
-      "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
-      "license": "MIT"
-    },
-    "node_modules/@types/markdown-it": {
-      "version": "14.1.2",
-      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
-      "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/linkify-it": "^5",
-        "@types/mdurl": "^2"
-      }
-    },
     "node_modules/@types/mdast": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
@@ -6372,12 +6359,6 @@
       "dependencies": {
         "@types/unist": "*"
       }
-    },
-    "node_modules/@types/mdurl": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
-      "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
-      "license": "MIT"
     },
     "node_modules/@types/ms": {
       "version": "2.1.0",
@@ -7156,6 +7137,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/aria-hidden": {
@@ -8068,12 +8050,6 @@
       "dependencies": {
         "layout-base": "^1.0.0"
       }
-    },
-    "node_modules/crelt": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
-      "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
-      "license": "MIT"
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -9540,6 +9516,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -12502,6 +12479,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
       "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "uc.micro": "^2.0.0"
@@ -12783,6 +12761,7 @@
       "version": "14.1.1",
       "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
       "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1",
@@ -12800,6 +12779,7 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
       "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
@@ -13125,6 +13105,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
       "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/merge-stream": {
@@ -14954,15 +14935,6 @@
         "prosemirror-transform": "^1.0.0"
       }
     },
-    "node_modules/prosemirror-collab": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/prosemirror-collab/-/prosemirror-collab-1.3.1.tgz",
-      "integrity": "sha512-4SnynYR9TTYaQVXd/ieUvsVV4PDMBzrq2xPUWutHivDuOshZXqQ5rGbZM84HEaXKbLdItse7weMGOUdDVcLKEQ==",
-      "license": "MIT",
-      "dependencies": {
-        "prosemirror-state": "^1.0.0"
-      }
-    },
     "node_modules/prosemirror-commands": {
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/prosemirror-commands/-/prosemirror-commands-1.7.1.tgz",
@@ -15009,16 +14981,6 @@
         "rope-sequence": "^1.3.0"
       }
     },
-    "node_modules/prosemirror-inputrules": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/prosemirror-inputrules/-/prosemirror-inputrules-1.5.1.tgz",
-      "integrity": "sha512-7wj4uMjKaXWAQ1CDgxNzNtR9AlsuwzHfdFH1ygEHA2KHF2DOEaXl1CJfNPAKCg9qNEh4rum975QLaCiQPyY6Fw==",
-      "license": "MIT",
-      "dependencies": {
-        "prosemirror-state": "^1.0.0",
-        "prosemirror-transform": "^1.0.0"
-      }
-    },
     "node_modules/prosemirror-keymap": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/prosemirror-keymap/-/prosemirror-keymap-1.2.3.tgz",
@@ -15029,29 +14991,6 @@
         "w3c-keyname": "^2.2.0"
       }
     },
-    "node_modules/prosemirror-markdown": {
-      "version": "1.13.4",
-      "resolved": "https://registry.npmjs.org/prosemirror-markdown/-/prosemirror-markdown-1.13.4.tgz",
-      "integrity": "sha512-D98dm4cQ3Hs6EmjK500TdAOew4Z03EV71ajEFiWra3Upr7diytJsjF4mPV2dW+eK5uNectiRj0xFxYI9NLXDbw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/markdown-it": "^14.0.0",
-        "markdown-it": "^14.0.0",
-        "prosemirror-model": "^1.25.0"
-      }
-    },
-    "node_modules/prosemirror-menu": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/prosemirror-menu/-/prosemirror-menu-1.3.0.tgz",
-      "integrity": "sha512-TImyPXCHPcDsSka2/lwJ6WjTASr4re/qWq1yoTTuLOqfXucwF6VcRa2LWCkM/EyTD1UO3CUwiH8qURJoWJRxwg==",
-      "license": "MIT",
-      "dependencies": {
-        "crelt": "^1.0.0",
-        "prosemirror-commands": "^1.0.0",
-        "prosemirror-history": "^1.0.0",
-        "prosemirror-state": "^1.0.0"
-      }
-    },
     "node_modules/prosemirror-model": {
       "version": "1.25.4",
       "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.4.tgz",
@@ -15059,15 +14998,6 @@
       "license": "MIT",
       "dependencies": {
         "orderedmap": "^2.0.0"
-      }
-    },
-    "node_modules/prosemirror-schema-basic": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/prosemirror-schema-basic/-/prosemirror-schema-basic-1.2.4.tgz",
-      "integrity": "sha512-ELxP4TlX3yr2v5rM7Sb70SqStq5NvI15c0j9j/gjsrO5vaw+fnnpovCLEGIcpeGfifkuqJwl4fon6b+KdrODYQ==",
-      "license": "MIT",
-      "dependencies": {
-        "prosemirror-model": "^1.25.0"
       }
     },
     "node_modules/prosemirror-schema-list": {
@@ -15103,21 +15033,6 @@
         "prosemirror-state": "^1.4.4",
         "prosemirror-transform": "^1.10.5",
         "prosemirror-view": "^1.41.4"
-      }
-    },
-    "node_modules/prosemirror-trailing-node": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/prosemirror-trailing-node/-/prosemirror-trailing-node-3.0.0.tgz",
-      "integrity": "sha512-xiun5/3q0w5eRnGYfNlW1uU9W6x5MoFKWwq/0TIRgt09lv7Hcser2QYV8t4muXbEr+Fwo0geYn79Xs4GKywrRQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@remirror/core-constants": "3.0.0",
-        "escape-string-regexp": "^4.0.0"
-      },
-      "peerDependencies": {
-        "prosemirror-model": "^1.22.1",
-        "prosemirror-state": "^1.4.2",
-        "prosemirror-view": "^1.33.8"
       }
     },
     "node_modules/prosemirror-transform": {
@@ -15160,6 +15075,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
       "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -17592,6 +17508,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
       "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/ufo": {

--- a/ayunis-core-frontend/package.json
+++ b/ayunis-core-frontend/package.json
@@ -50,6 +50,7 @@
     "@tanstack/router-plugin": "^1.166.13",
     "@tiptap/extension-link": "^3.20.0",
     "@tiptap/extension-placeholder": "^3.20.0",
+    "@tiptap/extension-table": "^3.22.4",
     "@tiptap/extension-text-align": "^3.20.0",
     "@tiptap/extension-underline": "^3.20.0",
     "@tiptap/pm": "^3.20.0",

--- a/ayunis-core-frontend/src/widgets/artifact-editor/ui/ArtifactEditor.tsx
+++ b/ayunis-core-frontend/src/widgets/artifact-editor/ui/ArtifactEditor.tsx
@@ -6,6 +6,7 @@ import LinkExtension from '@tiptap/extension-link';
 import UnderlineExtension from '@tiptap/extension-underline';
 import TextAlign from '@tiptap/extension-text-align';
 import Placeholder from '@tiptap/extension-placeholder';
+import { TableKit } from '@tiptap/extension-table';
 import { Save, X } from 'lucide-react';
 import { useCallback, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -48,6 +49,7 @@ export function ArtifactEditor({
       UnderlineExtension,
       TextAlign.configure({ types: ['heading', 'paragraph'] }),
       Placeholder.configure({ placeholder: t('editor.placeholder') }),
+      TableKit.configure({ table: { resizable: false } }),
     ],
     content: currentVersion?.content ?? '',
     editorProps: {


### PR DESCRIPTION
- Register TipTap TableKit in ArtifactEditor so ProseMirror keeps
  <table> nodes when parsing AI-generated HTML; without it the schema
  stripped tables on load and getHTML() then persisted the stripped
  version back to storage
- Pass columnWidths to docx Table so <w:tblGrid> has real widths; the
  library was emitting 100-twip placeholder columns, which Word rendered
  as ~7mm-wide cells (one character per line)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches rich-text editing schema/dependencies and document export formatting, so regressions could affect persisted artifact content and Word rendering, though the changes are localized and straightforward.
> 
> **Overview**
> **Tables are now preserved and rendered in the artifact editor** by registering TipTap `TableKit` (and adding `@tiptap/extension-table`), preventing `<table>` nodes from being stripped when loading/persisting AI-generated HTML.
> 
> **DOCX table exports now size columns correctly** by computing table column counts (including `colspan`) and passing explicit `columnWidths` based on A4 usable page width, avoiding Word’s ultra-narrow placeholder columns.
> 
> Pins the CI complexity checker to `lizard==1.21.7` to avoid a TypeScript parsing regression in newer versions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 035f62beb0a8283d1cd208c2071b35c5cb8009e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->