### PR TITLE
feat(skills): show creator name on shared skills (AYC-11)

### DIFF
--- a/ayunis-core-backend/src/domain/skills/presenters/http/dto/skill-response.dto.ts
+++ b/ayunis-core-backend/src/domain/skills/presenters/http/dto/skill-response.dto.ts
@@ -55,6 +55,15 @@ export class SkillResponseDto {
   userId: UUID;
 
   @ApiProperty({
+    description:
+      'The display name of the user who created this skill. Null if the creator has been deleted.',
+    example: 'Jane Doe',
+    type: 'string',
+    nullable: true,
+  })
+  creatorName: string | null;
+
+  @ApiProperty({
     description: 'The date and time when the skill was created',
     example: '2023-12-01T10:00:00.000Z',
     type: 'string',

--- a/ayunis-core-backend/src/domain/skills/presenters/http/mappers/skill.mapper.ts
+++ b/ayunis-core-backend/src/domain/skills/presenters/http/mappers/skill.mapper.ts
@@ -7,39 +7,39 @@ import {
 } from '../dto/skill-response.dto';
 import { Source } from 'src/domain/sources/domain/source.entity';
 import { SkillUserContext } from '../../../application/services/skill-access.service';
-import { FindUserByIdUseCase } from 'src/iam/users/application/use-cases/find-user-by-id/find-user-by-id.use-case';
-import { FindUserByIdQuery } from 'src/iam/users/application/use-cases/find-user-by-id/find-user-by-id.query';
-import { FindUsersByIdsUseCase } from 'src/iam/users/application/use-cases/find-users-by-ids/find-users-by-ids.use-case';
-import { FindUsersByIdsQuery } from 'src/iam/users/application/use-cases/find-users-by-ids/find-users-by-ids.query';
-import { UserNotFoundError } from 'src/iam/users/application/users.errors';
 
 @Injectable()
 export class SkillDtoMapper {
-  constructor(
-    private readonly findUserByIdUseCase: FindUserByIdUseCase,
-    private readonly findUsersByIdsUseCase: FindUsersByIdsUseCase,
-  ) {}
-
-  async toDto(
+  toDto(
     skill: Skill,
     context: SkillUserContext,
-  ): Promise<SkillResponseDto> {
-    const creatorName = await this.resolveCreatorName(skill.userId);
-    return this.buildDto(skill, context, creatorName);
+    creatorName: string | null = null,
+  ): SkillResponseDto {
+    return {
+      id: skill.id,
+      name: skill.name,
+      shortDescription: skill.shortDescription,
+      instructions: skill.instructions,
+      marketplaceIdentifier: skill.marketplaceIdentifier,
+      isActive: context.isActive,
+      isShared: context.isShared,
+      isPinned: context.isPinned,
+      userId: skill.userId,
+      creatorName,
+      createdAt: skill.createdAt,
+      updatedAt: skill.updatedAt,
+    };
   }
 
-  async toDtoArray(
+  toDtoArray(
     skills: Skill[],
     activeSkillIds: Set<string>,
     sharedSkillIds: Set<string> = new Set(),
     pinnedSkillIds: Set<string> = new Set(),
-  ): Promise<SkillResponseDto[]> {
-    const creatorNamesByUserId = await this.resolveCreatorNames(
-      skills.map((s) => s.userId),
-    );
-
+    creatorNamesByUserId: Map<UUID, string> = new Map(),
+  ): SkillResponseDto[] {
     return skills.map((skill) =>
-      this.buildDto(
+      this.toDto(
         skill,
         {
           isActive: activeSkillIds.has(skill.id),
@@ -64,53 +64,5 @@ export class SkillDtoMapper {
 
   sourcesToDtoArray(sources: Source[]): SkillSourceResponseDto[] {
     return sources.map((source) => this.sourceToDto(source));
-  }
-
-  private buildDto(
-    skill: Skill,
-    context: SkillUserContext,
-    creatorName: string | null,
-  ): SkillResponseDto {
-    return {
-      id: skill.id,
-      name: skill.name,
-      shortDescription: skill.shortDescription,
-      instructions: skill.instructions,
-      marketplaceIdentifier: skill.marketplaceIdentifier,
-      isActive: context.isActive,
-      isShared: context.isShared,
-      isPinned: context.isPinned,
-      userId: skill.userId,
-      creatorName,
-      createdAt: skill.createdAt,
-      updatedAt: skill.updatedAt,
-    };
-  }
-
-  private async resolveCreatorName(userId: UUID): Promise<string | null> {
-    try {
-      const user = await this.findUserByIdUseCase.execute(
-        new FindUserByIdQuery(userId),
-      );
-      return user.name;
-    } catch (error) {
-      if (error instanceof UserNotFoundError) {
-        return null;
-      }
-      throw error;
-    }
-  }
-
-  private async resolveCreatorNames(
-    userIds: UUID[],
-  ): Promise<Map<string, string>> {
-    const uniqueIds = Array.from(new Set(userIds));
-    if (uniqueIds.length === 0) {
-      return new Map();
-    }
-    const users = await this.findUsersByIdsUseCase.execute(
-      new FindUsersByIdsQuery(uniqueIds),
-    );
-    return new Map(users.map((u) => [u.id, u.name]));
   }
 }

--- a/ayunis-core-backend/src/domain/skills/presenters/http/mappers/skill.mapper.ts
+++ b/ayunis-core-backend/src/domain/skills/presenters/http/mappers/skill.mapper.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@nestjs/common';
+import type { UUID } from 'crypto';
 import { Skill } from '../../../domain/skill.entity';
 import {
   SkillResponseDto,
@@ -6,37 +7,47 @@ import {
 } from '../dto/skill-response.dto';
 import { Source } from 'src/domain/sources/domain/source.entity';
 import { SkillUserContext } from '../../../application/services/skill-access.service';
+import { FindUserByIdUseCase } from 'src/iam/users/application/use-cases/find-user-by-id/find-user-by-id.use-case';
+import { FindUserByIdQuery } from 'src/iam/users/application/use-cases/find-user-by-id/find-user-by-id.query';
+import { FindUsersByIdsUseCase } from 'src/iam/users/application/use-cases/find-users-by-ids/find-users-by-ids.use-case';
+import { FindUsersByIdsQuery } from 'src/iam/users/application/use-cases/find-users-by-ids/find-users-by-ids.query';
+import { UserNotFoundError } from 'src/iam/users/application/users.errors';
 
 @Injectable()
 export class SkillDtoMapper {
-  toDto(skill: Skill, context: SkillUserContext): SkillResponseDto {
-    return {
-      id: skill.id,
-      name: skill.name,
-      shortDescription: skill.shortDescription,
-      instructions: skill.instructions,
-      marketplaceIdentifier: skill.marketplaceIdentifier,
-      isActive: context.isActive,
-      isShared: context.isShared,
-      isPinned: context.isPinned,
-      userId: skill.userId,
-      createdAt: skill.createdAt,
-      updatedAt: skill.updatedAt,
-    };
+  constructor(
+    private readonly findUserByIdUseCase: FindUserByIdUseCase,
+    private readonly findUsersByIdsUseCase: FindUsersByIdsUseCase,
+  ) {}
+
+  async toDto(
+    skill: Skill,
+    context: SkillUserContext,
+  ): Promise<SkillResponseDto> {
+    const creatorName = await this.resolveCreatorName(skill.userId);
+    return this.buildDto(skill, context, creatorName);
   }
 
-  toDtoArray(
+  async toDtoArray(
     skills: Skill[],
     activeSkillIds: Set<string>,
     sharedSkillIds: Set<string> = new Set(),
     pinnedSkillIds: Set<string> = new Set(),
-  ): SkillResponseDto[] {
+  ): Promise<SkillResponseDto[]> {
+    const creatorNamesByUserId = await this.resolveCreatorNames(
+      skills.map((s) => s.userId),
+    );
+
     return skills.map((skill) =>
-      this.toDto(skill, {
-        isActive: activeSkillIds.has(skill.id),
-        isShared: sharedSkillIds.has(skill.id),
-        isPinned: pinnedSkillIds.has(skill.id),
-      }),
+      this.buildDto(
+        skill,
+        {
+          isActive: activeSkillIds.has(skill.id),
+          isShared: sharedSkillIds.has(skill.id),
+          isPinned: pinnedSkillIds.has(skill.id),
+        },
+        creatorNamesByUserId.get(skill.userId) ?? null,
+      ),
     );
   }
 
@@ -53,5 +64,53 @@ export class SkillDtoMapper {
 
   sourcesToDtoArray(sources: Source[]): SkillSourceResponseDto[] {
     return sources.map((source) => this.sourceToDto(source));
+  }
+
+  private buildDto(
+    skill: Skill,
+    context: SkillUserContext,
+    creatorName: string | null,
+  ): SkillResponseDto {
+    return {
+      id: skill.id,
+      name: skill.name,
+      shortDescription: skill.shortDescription,
+      instructions: skill.instructions,
+      marketplaceIdentifier: skill.marketplaceIdentifier,
+      isActive: context.isActive,
+      isShared: context.isShared,
+      isPinned: context.isPinned,
+      userId: skill.userId,
+      creatorName,
+      createdAt: skill.createdAt,
+      updatedAt: skill.updatedAt,
+    };
+  }
+
+  private async resolveCreatorName(userId: UUID): Promise<string | null> {
+    try {
+      const user = await this.findUserByIdUseCase.execute(
+        new FindUserByIdQuery(userId),
+      );
+      return user.name;
+    } catch (error) {
+      if (error instanceof UserNotFoundError) {
+        return null;
+      }
+      throw error;
+    }
+  }
+
+  private async resolveCreatorNames(
+    userIds: UUID[],
+  ): Promise<Map<string, string>> {
+    const uniqueIds = Array.from(new Set(userIds));
+    if (uniqueIds.length === 0) {
+      return new Map();
+    }
+    const users = await this.findUsersByIdsUseCase.execute(
+      new FindUsersByIdsQuery(uniqueIds),
+    );
+    return new Map(users.map((u) => [u.id, u.name]));
   }
 }

--- a/ayunis-core-backend/src/domain/skills/presenters/http/services/skill-creator-name.resolver.ts
+++ b/ayunis-core-backend/src/domain/skills/presenters/http/services/skill-creator-name.resolver.ts
@@ -1,0 +1,40 @@
+import { Injectable } from '@nestjs/common';
+import type { UUID } from 'crypto';
+import { FindUserByIdUseCase } from 'src/iam/users/application/use-cases/find-user-by-id/find-user-by-id.use-case';
+import { FindUserByIdQuery } from 'src/iam/users/application/use-cases/find-user-by-id/find-user-by-id.query';
+import { FindUsersByIdsUseCase } from 'src/iam/users/application/use-cases/find-users-by-ids/find-users-by-ids.use-case';
+import { FindUsersByIdsQuery } from 'src/iam/users/application/use-cases/find-users-by-ids/find-users-by-ids.query';
+import { UserNotFoundError } from 'src/iam/users/application/users.errors';
+
+@Injectable()
+export class SkillCreatorNameResolver {
+  constructor(
+    private readonly findUserByIdUseCase: FindUserByIdUseCase,
+    private readonly findUsersByIdsUseCase: FindUsersByIdsUseCase,
+  ) {}
+
+  async resolveOne(userId: UUID): Promise<string | null> {
+    try {
+      const user = await this.findUserByIdUseCase.execute(
+        new FindUserByIdQuery(userId),
+      );
+      return user.name;
+    } catch (error) {
+      if (error instanceof UserNotFoundError) {
+        return null;
+      }
+      throw error;
+    }
+  }
+
+  async resolveMany(userIds: UUID[]): Promise<Map<UUID, string>> {
+    const uniqueIds = Array.from(new Set(userIds));
+    if (uniqueIds.length === 0) {
+      return new Map();
+    }
+    const users = await this.findUsersByIdsUseCase.execute(
+      new FindUsersByIdsQuery(uniqueIds),
+    );
+    return new Map(users.map((u) => [u.id, u.name]));
+  }
+}

--- a/ayunis-core-backend/src/domain/skills/presenters/http/skill-knowledge-bases.controller.ts
+++ b/ayunis-core-backend/src/domain/skills/presenters/http/skill-knowledge-bases.controller.ts
@@ -23,6 +23,7 @@ import { SkillAccessService } from '../../application/services/skill-access.serv
 
 import { SkillResponseDto } from './dto/skill-response.dto';
 import { SkillDtoMapper } from './mappers/skill.mapper';
+import { SkillCreatorNameResolver } from './services/skill-creator-name.resolver';
 import { KnowledgeBaseResponseDto } from 'src/domain/knowledge-bases/presenters/http/dto/knowledge-base-response.dto';
 import { KnowledgeBaseDtoMapper } from 'src/domain/knowledge-bases/presenters/http/mappers/knowledge-base-dto.mapper';
 import { RequireFeature } from 'src/common/guards/feature.guard';
@@ -40,6 +41,7 @@ export class SkillKnowledgeBasesController {
     private readonly unassignKnowledgeBaseFromSkillUseCase: UnassignKnowledgeBaseFromSkillUseCase,
     private readonly listSkillKnowledgeBasesUseCase: ListSkillKnowledgeBasesUseCase,
     private readonly skillDtoMapper: SkillDtoMapper,
+    private readonly skillCreatorNameResolver: SkillCreatorNameResolver,
     private readonly knowledgeBaseDtoMapper: KnowledgeBaseDtoMapper,
     private readonly skillAccessService: SkillAccessService,
   ) {}
@@ -80,8 +82,11 @@ export class SkillKnowledgeBasesController {
     );
 
     const context = await this.skillAccessService.resolveUserContext(skillId);
+    const creatorName = context.isShared
+      ? await this.skillCreatorNameResolver.resolveOne(skill.userId)
+      : null;
 
-    return this.skillDtoMapper.toDto(skill, context);
+    return this.skillDtoMapper.toDto(skill, context, creatorName);
   }
 
   @Delete(':skillId/knowledge-bases/:knowledgeBaseId')
@@ -118,8 +123,11 @@ export class SkillKnowledgeBasesController {
     );
 
     const context = await this.skillAccessService.resolveUserContext(skillId);
+    const creatorName = context.isShared
+      ? await this.skillCreatorNameResolver.resolveOne(skill.userId)
+      : null;
 
-    return this.skillDtoMapper.toDto(skill, context);
+    return this.skillDtoMapper.toDto(skill, context, creatorName);
   }
 
   @Get(':skillId/knowledge-bases')

--- a/ayunis-core-backend/src/domain/skills/presenters/http/skill-mcp-integrations.controller.ts
+++ b/ayunis-core-backend/src/domain/skills/presenters/http/skill-mcp-integrations.controller.ts
@@ -28,6 +28,7 @@ import { SkillAccessService } from '../../application/services/skill-access.serv
 
 import { SkillResponseDto } from './dto/skill-response.dto';
 import { SkillDtoMapper } from './mappers/skill.mapper';
+import { SkillCreatorNameResolver } from './services/skill-creator-name.resolver';
 import { McpIntegrationResponseDto } from 'src/domain/mcp/presenters/http/dto/mcp-integration-response.dto';
 import { McpIntegrationDtoMapper } from 'src/domain/mcp/presenters/http/mappers/mcp-integration-dto.mapper';
 import { RequireFeature } from 'src/common/guards/feature.guard';
@@ -44,6 +45,7 @@ export class SkillMcpIntegrationsController {
     private readonly unassignMcpIntegrationFromSkillUseCase: UnassignMcpIntegrationFromSkillUseCase,
     private readonly listSkillMcpIntegrationsUseCase: ListSkillMcpIntegrationsUseCase,
     private readonly skillDtoMapper: SkillDtoMapper,
+    private readonly skillCreatorNameResolver: SkillCreatorNameResolver,
     private readonly mcpIntegrationDtoMapper: McpIntegrationDtoMapper,
     private readonly skillAccessService: SkillAccessService,
   ) {}
@@ -82,8 +84,11 @@ export class SkillMcpIntegrationsController {
     );
 
     const context = await this.skillAccessService.resolveUserContext(skillId);
+    const creatorName = context.isShared
+      ? await this.skillCreatorNameResolver.resolveOne(skill.userId)
+      : null;
 
-    return this.skillDtoMapper.toDto(skill, context);
+    return this.skillDtoMapper.toDto(skill, context, creatorName);
   }
 
   @Delete(':skillId/mcp-integrations/:integrationId')
@@ -121,8 +126,11 @@ export class SkillMcpIntegrationsController {
     );
 
     const context = await this.skillAccessService.resolveUserContext(skillId);
+    const creatorName = context.isShared
+      ? await this.skillCreatorNameResolver.resolveOne(skill.userId)
+      : null;
 
-    return this.skillDtoMapper.toDto(skill, context);
+    return this.skillDtoMapper.toDto(skill, context, creatorName);
   }
 
   @Get(':skillId/mcp-integrations')

--- a/ayunis-core-backend/src/domain/skills/presenters/http/skill-sources.controller.ts
+++ b/ayunis-core-backend/src/domain/skills/presenters/http/skill-sources.controller.ts
@@ -40,6 +40,7 @@ import {
   SkillSourceResponseDto,
 } from './dto/skill-response.dto';
 import { SkillDtoMapper } from './mappers/skill.mapper';
+import { SkillCreatorNameResolver } from './services/skill-creator-name.resolver';
 
 import { FileInterceptor } from '@nestjs/platform-express';
 import { diskStorage } from 'multer';
@@ -83,6 +84,7 @@ export class SkillSourcesController {
     private readonly removeSourceFromSkillUseCase: RemoveSourceFromSkillUseCase,
     private readonly listSkillSourcesUseCase: ListSkillSourcesUseCase,
     private readonly skillDtoMapper: SkillDtoMapper,
+    private readonly skillCreatorNameResolver: SkillCreatorNameResolver,
     private readonly startDocumentProcessingUseCase: StartDocumentProcessingUseCase,
     private readonly createDataSourceUseCase: CreateDataSourceUseCase,
     private readonly skillAccessService: SkillAccessService,
@@ -195,7 +197,10 @@ export class SkillSourcesController {
 
       fs.unlinkSync(file.path);
       const context = await this.skillAccessService.resolveUserContext(skillId);
-      return this.skillDtoMapper.toDto(updatedSkill, context);
+      const creatorName = context.isShared
+        ? await this.skillCreatorNameResolver.resolveOne(updatedSkill.userId)
+        : null;
+      return this.skillDtoMapper.toDto(updatedSkill, context, creatorName);
     } catch (error: unknown) {
       this.logger.error('addFileSource', { error: error as Error });
       fs.unlinkSync(file.path);

--- a/ayunis-core-backend/src/domain/skills/presenters/http/skills.controller.ts
+++ b/ayunis-core-backend/src/domain/skills/presenters/http/skills.controller.ts
@@ -55,6 +55,7 @@ import { UpdateSkillDto } from './dto/update-skill.dto';
 import { InstallSkillFromMarketplaceDto } from './dto/install-skill-from-marketplace.dto';
 import { SkillResponseDto } from './dto/skill-response.dto';
 import { SkillDtoMapper } from './mappers/skill.mapper';
+import { SkillCreatorNameResolver } from './services/skill-creator-name.resolver';
 import { InvalidSkillNameError } from '../../domain/skill.entity';
 import { RequireFeature } from 'src/common/guards/feature.guard';
 import { FeatureFlag } from 'src/config/features.config';
@@ -75,6 +76,7 @@ export class SkillsController {
     private readonly toggleSkillActiveUseCase: ToggleSkillActiveUseCase,
     private readonly toggleSkillPinnedUseCase: ToggleSkillPinnedUseCase,
     private readonly skillDtoMapper: SkillDtoMapper,
+    private readonly skillCreatorNameResolver: SkillCreatorNameResolver,
     private readonly skillAccessService: SkillAccessService,
   ) {}
 
@@ -177,12 +179,18 @@ export class SkillsController {
     const sharedSkillIds = new Set<string>(
       results.filter((r) => r.isShared).map((r) => r.skill.id),
     );
+    const sharedCreatorIds = results
+      .filter((r) => r.isShared)
+      .map((r) => r.skill.userId);
+    const creatorNamesByUserId =
+      await this.skillCreatorNameResolver.resolveMany(sharedCreatorIds);
 
     return this.skillDtoMapper.toDtoArray(
       skills,
       activeSkillIds,
       sharedSkillIds,
       pinnedSkillIds,
+      creatorNamesByUserId,
     );
   }
 
@@ -209,7 +217,15 @@ export class SkillsController {
     const { skill, isActive, isShared, isPinned } =
       await this.findOneSkillUseCase.execute(new FindOneSkillQuery(id));
 
-    return this.skillDtoMapper.toDto(skill, { isActive, isShared, isPinned });
+    const creatorName = isShared
+      ? await this.skillCreatorNameResolver.resolveOne(skill.userId)
+      : null;
+
+    return this.skillDtoMapper.toDto(
+      skill,
+      { isActive, isShared, isPinned },
+      creatorName,
+    );
   }
 
   @Put(':id')
@@ -250,8 +266,11 @@ export class SkillsController {
       );
 
       const context = await this.skillAccessService.resolveUserContext(id);
+      const creatorName = context.isShared
+        ? await this.skillCreatorNameResolver.resolveOne(skill.userId)
+        : null;
 
-      return this.skillDtoMapper.toDto(skill, context);
+      return this.skillDtoMapper.toDto(skill, context, creatorName);
     } catch (error) {
       if (error instanceof InvalidSkillNameError) {
         throw new BadRequestException(error.message);
@@ -307,7 +326,15 @@ export class SkillsController {
         new ToggleSkillActiveCommand({ skillId: id }),
       );
 
-    return this.skillDtoMapper.toDto(skill, { isActive, isShared, isPinned });
+    const creatorName = isShared
+      ? await this.skillCreatorNameResolver.resolveOne(skill.userId)
+      : null;
+
+    return this.skillDtoMapper.toDto(
+      skill,
+      { isActive, isShared, isPinned },
+      creatorName,
+    );
   }
 
   @Patch(':id/toggle-pinned')
@@ -336,10 +363,18 @@ export class SkillsController {
         new ToggleSkillPinnedCommand({ skillId: id }),
       );
 
-    return this.skillDtoMapper.toDto(skill, {
-      isActive: true,
-      isShared,
-      isPinned,
-    });
+    const creatorName = isShared
+      ? await this.skillCreatorNameResolver.resolveOne(skill.userId)
+      : null;
+
+    return this.skillDtoMapper.toDto(
+      skill,
+      {
+        isActive: true,
+        isShared,
+        isPinned,
+      },
+      creatorName,
+    );
   }
 }

--- a/ayunis-core-backend/src/domain/skills/skills.module.ts
+++ b/ayunis-core-backend/src/domain/skills/skills.module.ts
@@ -52,6 +52,7 @@ import { SharedEntityType } from '../shares/domain/value-objects/shared-entity-t
 import { SharesModule } from '../shares/shares.module';
 
 import { ThreadsModule } from '../threads/threads.module';
+import { UsersModule } from 'src/iam/users/users.module';
 
 // Presenters
 import { SkillsController } from './presenters/http/skills.controller';
@@ -75,6 +76,7 @@ import { KnowledgeBaseDtoMapper } from '../knowledge-bases/presenters/http/mappe
     McpModule,
     KnowledgeBasesModule,
     MarketplaceModule,
+    UsersModule,
     forwardRef(() => SharesModule),
     forwardRef(() => ThreadsModule),
   ],

--- a/ayunis-core-backend/src/domain/skills/skills.module.ts
+++ b/ayunis-core-backend/src/domain/skills/skills.module.ts
@@ -60,6 +60,7 @@ import { SkillSourcesController } from './presenters/http/skill-sources.controll
 import { SkillMcpIntegrationsController } from './presenters/http/skill-mcp-integrations.controller';
 import { SkillKnowledgeBasesController } from './presenters/http/skill-knowledge-bases.controller';
 import { SkillDtoMapper } from './presenters/http/mappers/skill.mapper';
+import { SkillCreatorNameResolver } from './presenters/http/services/skill-creator-name.resolver';
 import { McpIntegrationDtoMapper } from '../mcp/presenters/http/mappers/mcp-integration-dto.mapper';
 import { KnowledgeBaseDtoMapper } from '../knowledge-bases/presenters/http/mappers/knowledge-base-dto.mapper';
 
@@ -127,6 +128,7 @@ import { KnowledgeBaseDtoMapper } from '../knowledge-bases/presenters/http/mappe
 
     // Presenters
     SkillDtoMapper,
+    SkillCreatorNameResolver,
     McpIntegrationDtoMapper,
     KnowledgeBaseDtoMapper,
   ],

--- a/ayunis-core-backend/src/iam/users/application/ports/users.repository.ts
+++ b/ayunis-core-backend/src/iam/users/application/ports/users.repository.ts
@@ -16,6 +16,7 @@ export abstract class UsersRepository {
   abstract findOneById(id: UUID): Promise<User | null>;
   abstract findOneByEmail(email: string): Promise<User | null>;
   abstract findManyByEmails(emails: string[]): Promise<User[]>;
+  abstract findManyByIds(ids: UUID[]): Promise<User[]>;
   abstract findManyBySystemRole(role: SystemRole): Promise<User[]>;
   abstract findManyByOrgId(
     orgId: UUID,

--- a/ayunis-core-backend/src/iam/users/application/use-cases/find-users-by-ids/find-users-by-ids.query.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/find-users-by-ids/find-users-by-ids.query.ts
@@ -1,0 +1,5 @@
+import type { UUID } from 'crypto';
+
+export class FindUsersByIdsQuery {
+  constructor(public readonly ids: UUID[]) {}
+}

--- a/ayunis-core-backend/src/iam/users/application/use-cases/find-users-by-ids/find-users-by-ids.use-case.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/find-users-by-ids/find-users-by-ids.use-case.ts
@@ -1,0 +1,24 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { UsersRepository } from '../../ports/users.repository';
+import { FindUsersByIdsQuery } from './find-users-by-ids.query';
+import { User } from '../../../domain/user.entity';
+import { UserError, UserUnexpectedError } from '../../users.errors';
+
+@Injectable()
+export class FindUsersByIdsUseCase {
+  private readonly logger = new Logger(FindUsersByIdsUseCase.name);
+
+  constructor(private readonly usersRepository: UsersRepository) {}
+
+  async execute(query: FindUsersByIdsQuery): Promise<User[]> {
+    this.logger.log('findManyByIds', { idCount: query.ids.length });
+    try {
+      return await this.usersRepository.findManyByIds(query.ids);
+    } catch (error) {
+      if (error instanceof UserError) {
+        throw error;
+      }
+      throw new UserUnexpectedError(error as Error);
+    }
+  }
+}

--- a/ayunis-core-backend/src/iam/users/application/use-cases/find-users-by-ids/find-users-by-ids.use-case.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/find-users-by-ids/find-users-by-ids.use-case.ts
@@ -3,17 +3,27 @@ import { UsersRepository } from '../../ports/users.repository';
 import { FindUsersByIdsQuery } from './find-users-by-ids.query';
 import { User } from '../../../domain/user.entity';
 import { UserError, UserUnexpectedError } from '../../users.errors';
+import { ContextService } from 'src/common/context/services/context.service';
+import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
 
 @Injectable()
 export class FindUsersByIdsUseCase {
   private readonly logger = new Logger(FindUsersByIdsUseCase.name);
 
-  constructor(private readonly usersRepository: UsersRepository) {}
+  constructor(
+    private readonly usersRepository: UsersRepository,
+    private readonly contextService: ContextService,
+  ) {}
 
   async execute(query: FindUsersByIdsQuery): Promise<User[]> {
     this.logger.log('findManyByIds', { idCount: query.ids.length });
+    const orgId = this.contextService.get('orgId');
+    if (!orgId) {
+      throw new UnauthorizedAccessError();
+    }
     try {
-      return await this.usersRepository.findManyByIds(query.ids);
+      const users = await this.usersRepository.findManyByIds(query.ids);
+      return users.filter((user) => user.orgId === orgId);
     } catch (error) {
       if (error instanceof UserError) {
         throw error;

--- a/ayunis-core-backend/src/iam/users/infrastructure/repositories/local/local-users.repository.ts
+++ b/ayunis-core-backend/src/iam/users/infrastructure/repositories/local/local-users.repository.ts
@@ -75,6 +75,21 @@ export class LocalUsersRepository extends UsersRepository {
     return userRecords.map((record) => UserMapper.toDomain(record));
   }
 
+  async findManyByIds(ids: UUID[]): Promise<User[]> {
+    this.logger.log('findManyByIds', { idCount: ids.length });
+
+    if (ids.length === 0) {
+      return [];
+    }
+
+    const userRecords = await this.userRepository
+      .createQueryBuilder('user')
+      .where('user.id IN (:...ids)', { ids })
+      .getMany();
+
+    return userRecords.map((record) => UserMapper.toDomain(record));
+  }
+
   async findManyBySystemRole(role: SystemRole): Promise<User[]> {
     this.logger.log('findManyBySystemRole', { role });
 

--- a/ayunis-core-backend/src/iam/users/users.module.ts
+++ b/ayunis-core-backend/src/iam/users/users.module.ts
@@ -14,6 +14,7 @@ import { EmailTemplatesModule } from 'src/common/email-templates/email-templates
 
 // Import use cases
 import { FindUserByIdUseCase } from './application/use-cases/find-user-by-id/find-user-by-id.use-case';
+import { FindUsersByIdsUseCase } from './application/use-cases/find-users-by-ids/find-users-by-ids.use-case';
 import { FindUsersByOrgIdUseCase } from './application/use-cases/find-users-by-org-id/find-users-by-org-id.use-case';
 import { DeleteUserUseCase } from './application/use-cases/delete-user/delete-user.use-case';
 import { UpdateUserRoleUseCase } from './application/use-cases/update-user-role/update-user-role.use-case';
@@ -89,6 +90,7 @@ import { DemoteFromSuperAdminUseCase } from './application/use-cases/demote-from
     },
     // Use cases
     FindUserByIdUseCase,
+    FindUsersByIdsUseCase,
     FindUsersByOrgIdUseCase,
     DeleteUserUseCase,
     UpdateUserRoleUseCase,
@@ -126,6 +128,7 @@ import { DemoteFromSuperAdminUseCase } from './application/use-cases/demote-from
     SendConfirmationEmailUseCase,
     ValidateUserUseCase,
     FindUserByIdUseCase,
+    FindUsersByIdsUseCase,
     FindUsersByOrgIdUseCase,
     IsValidPasswordUseCase,
     EmailConfirmationJwtService,

--- a/ayunis-core-frontend/src/pages/skill/ui/SkillPage.tsx
+++ b/ayunis-core-frontend/src/pages/skill/ui/SkillPage.tsx
@@ -102,7 +102,14 @@ export function SkillPage({
             ]}
             badge={
               isReadOnly ? (
-                <Badge variant="secondary">{t('shared.badge')}</Badge>
+                <div className="flex items-center gap-2">
+                  <Badge variant="secondary">{t('shared.badge')}</Badge>
+                  <span className="text-sm text-muted-foreground">
+                    {skill.creatorName
+                      ? t('shared.sharedBy', { name: skill.creatorName })
+                      : t('shared.sharedByUnknown')}
+                  </span>
+                </div>
               ) : undefined
             }
             action={

--- a/ayunis-core-frontend/src/pages/skills/ui/SkillCard.tsx
+++ b/ayunis-core-frontend/src/pages/skills/ui/SkillCard.tsx
@@ -78,7 +78,7 @@ export default function SkillCard({ skill }: Readonly<SkillCardProps>) {
         </ItemTitle>
         <ItemDescription>{skill.shortDescription}</ItemDescription>
         {skill.isShared && (
-          <ItemDescription className="text-xs">
+          <ItemDescription>
             {skill.creatorName
               ? t('shared.sharedBy', { name: skill.creatorName })
               : t('shared.sharedByUnknown')}

--- a/ayunis-core-frontend/src/pages/skills/ui/SkillCard.tsx
+++ b/ayunis-core-frontend/src/pages/skills/ui/SkillCard.tsx
@@ -77,6 +77,13 @@ export default function SkillCard({ skill }: Readonly<SkillCardProps>) {
           )}
         </ItemTitle>
         <ItemDescription>{skill.shortDescription}</ItemDescription>
+        {skill.isShared && (
+          <ItemDescription className="text-xs">
+            {skill.creatorName
+              ? t('shared.sharedBy', { name: skill.creatorName })
+              : t('shared.sharedByUnknown')}
+          </ItemDescription>
+        )}
       </ItemContent>
       <ItemActions>
         <div className="flex items-center gap-2">

--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
@@ -3140,6 +3140,11 @@ export interface SkillResponseDto {
   isActive: boolean;
   /** The unique identifier of the user who owns this skill */
   userId: string;
+  /**
+   * The display name of the user who created this skill. Null if the creator has been deleted.
+   * @nullable
+   */
+  creatorName: string | null;
   /** The date and time when the skill was created */
   createdAt: string;
   /** The date and time when the skill was last updated */

--- a/ayunis-core-frontend/src/shared/api/openapi-schema.json
+++ b/ayunis-core-frontend/src/shared/api/openapi-schema.json
@@ -12851,6 +12851,12 @@
             "example": "123e4567-e89b-12d3-a456-426614174000",
             "format": "uuid"
           },
+          "creatorName": {
+            "type": "string",
+            "description": "The display name of the user who created this skill. Null if the creator has been deleted.",
+            "example": "Jane Doe",
+            "nullable": true
+          },
           "createdAt": {
             "type": "string",
             "description": "The date and time when the skill was created",
@@ -12882,6 +12888,7 @@
           "marketplaceIdentifier",
           "isActive",
           "userId",
+          "creatorName",
           "createdAt",
           "updatedAt",
           "isShared",

--- a/ayunis-core-frontend/src/shared/locales/de/skill.json
+++ b/ayunis-core-frontend/src/shared/locales/de/skill.json
@@ -3,7 +3,9 @@
     "skills": "Fähigkeiten"
   },
   "shared": {
-    "badge": "Freigegeben"
+    "badge": "Freigegeben",
+    "sharedBy": "Geteilt von {{name}}",
+    "sharedByUnknown": "Geteilt von einem unbekannten Nutzer"
   },
   "tabs": {
     "configuration": "Konfiguration",

--- a/ayunis-core-frontend/src/shared/locales/de/skills.json
+++ b/ayunis-core-frontend/src/shared/locales/de/skills.json
@@ -1,6 +1,8 @@
 {
   "shared": {
-    "badge": "Freigegeben"
+    "badge": "Freigegeben",
+    "sharedBy": "Geteilt von {{name}}",
+    "sharedByUnknown": "Geteilt von einem unbekannten Nutzer"
   },
   "page": {
     "title": "Fähigkeiten"

--- a/ayunis-core-frontend/src/shared/locales/en/skill.json
+++ b/ayunis-core-frontend/src/shared/locales/en/skill.json
@@ -3,7 +3,9 @@
     "skills": "Skills"
   },
   "shared": {
-    "badge": "Shared"
+    "badge": "Shared",
+    "sharedBy": "Shared by {{name}}",
+    "sharedByUnknown": "Shared by an unknown user"
   },
   "tabs": {
     "configuration": "Configuration",

--- a/ayunis-core-frontend/src/shared/locales/en/skills.json
+++ b/ayunis-core-frontend/src/shared/locales/en/skills.json
@@ -1,6 +1,8 @@
 {
   "shared": {
-    "badge": "Shared"
+    "badge": "Shared",
+    "sharedBy": "Shared by {{name}}",
+    "sharedByUnknown": "Shared by an unknown user"
   },
   "page": {
     "title": "Skills"


### PR DESCRIPTION
## Summary

- Resolves [AYC-11](https://linear.app/ayunis/issue/AYC-11): recipients of shared skills couldn't see who shared them.
- Adds `creatorName` to `SkillResponseDto`, resolved from the users module via a new `FindUsersByIdsUseCase` (single-skill calls reuse the existing `FindUserByIdUseCase`).
- Renders "Shared by {name}" alongside the existing "Shared" badge on the skills list (`SkillCard`) and skill detail header (`SkillPage`).
- i18n strings added for EN and DE in both `skill` and `skills` namespaces, with a fallback "Shared by an unknown user" / "Geteilt von einem unbekannten Nutzer" when the creator account no longer exists.

## Test plan

- [ ] Shared skill appears in the recipient's list with "Shared by {creator name}" under the description.
- [ ] Shared skill detail page shows "Shared by {creator name}" next to the "Shared" badge in the header.
- [ ] Owner of a skill does not see "Shared by …" anywhere (only shared recipients do).
- [ ] If the creator account has been deleted, the UI shows the "unknown user" fallback rather than crashing.
- [ ] German UI shows "Geteilt von …" / "Geteilt von einem unbekannten Nutzer" correctly.

[AYC-11]: https://michael-loy.atlassian.net/browse/AYC-11?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Expands the public skills API schema and adds new user lookup paths (including org-based filtering) that could affect performance and response consistency for shared-skill endpoints.
> 
> **Overview**
> Adds `creatorName` to the `SkillResponseDto` and wires it through `SkillDtoMapper` so skill responses can include the display name of the user who created/shared the skill (nullable when the creator is missing).
> 
> Introduces `SkillCreatorNameResolver` plus a new users-layer `FindUsersByIdsUseCase`/`UsersRepository.findManyByIds` to efficiently resolve creator names for shared skills in bulk on `GET /skills`, and resolves it conditionally for shared skills across several skill-mutating endpoints.
> 
> Updates the frontend skill list and skill detail header to render “Shared by {name}” (with an unknown-user fallback) and adds the related EN/DE i18n strings; OpenAPI-generated schemas are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c288ab77cd296b91212741e4ef6971bbbed9a13. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->