### PR TITLE
chore(frontend): drop redundant tsconfig baseUrl (AYC-000)

### DIFF
--- a/ayunis-core-frontend/tsconfig.json
+++ b/ayunis-core-frontend/tsconfig.json
@@ -20,7 +20,6 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true,
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"],
     }


### PR DESCRIPTION
## Summary

- Remove the deprecated `"baseUrl": "."` from `ayunis-core-frontend/tsconfig.json`.
- `paths` already use relative `./src/*` entries, so `baseUrl` is redundant; removing it avoids TS 5.9's new `TS5101` deprecation error that breaks the pre-commit `tsc-files` typecheck.
- No import in `src/` relies on baseUrl-style resolution (all non-relative imports go through the `@/…` alias, which Vite aliases independently).

## Test plan

- [x] `npx tsc --noEmit` in `ayunis-core-frontend`
- [x] `npm run build` in `ayunis-core-frontend`
- [x] `tsc-files --noEmit -p tsconfig.json <file>` (pre-commit hook path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that removes `baseUrl` from the frontend TypeScript config; main impact is on module resolution during typechecking/build if any code relied on baseUrl-based imports.
> 
> **Overview**
> Removes the deprecated `"baseUrl": "."` setting from `ayunis-core-frontend/tsconfig.json` to rely solely on the existing `paths` alias (`@/* -> ./src/*`) and avoid newer TypeScript deprecation errors during typechecking.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e324036cf3c3341123d6127d640cd7bd5cfcaa78. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->