### PR TITLE
fix(chat): preserve formatting when copying email body (AYC-20)

### DIFF
--- a/ayunis-core-frontend/src/pages/chat/ui/chat-widgets/SendEmailWidget.tsx
+++ b/ayunis-core-frontend/src/pages/chat/ui/chat-widgets/SendEmailWidget.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState, useEffect } from 'react';
+import { useMemo, useState, useEffect, useRef } from 'react';
 import type { ToolUseMessageContent } from '../../model/openapi';
 import { useTranslation } from 'react-i18next';
 import { Label } from '@/shared/ui/shadcn/label';
@@ -7,6 +7,7 @@ import { Textarea } from '@/shared/ui/shadcn/textarea';
 import { Button } from '@/shared/ui/shadcn/button';
 import { Mail } from 'lucide-react';
 import { cn } from '@/shared/lib/shadcn/utils';
+import { Markdown } from '@/widgets/markdown';
 
 export default function SendEmailWidget({
   content,
@@ -32,6 +33,7 @@ export default function SendEmailWidget({
   const [body, setBody] = useState<string>(initialBody);
   const [to, setTo] = useState<string>(initialTo);
   const [copied, setCopied] = useState<boolean>(false);
+  const markdownRef = useRef<HTMLDivElement>(null);
 
   // Update state when params change (for streaming updates)
   useEffect(() => {
@@ -42,6 +44,39 @@ export default function SendEmailWidget({
     };
     updateWidget();
   }, [params.subject, params.body, params.to, content.id]);
+
+  const writeBodyToClipboard = async (
+    html: string,
+    plain: string,
+  ): Promise<void> => {
+    if (html && typeof ClipboardItem !== 'undefined') {
+      try {
+        await navigator.clipboard.write([
+          new ClipboardItem({
+            'text/html': new Blob([html], { type: 'text/html' }),
+            'text/plain': new Blob([plain], { type: 'text/plain' }),
+          }),
+        ]);
+        return;
+      } catch {
+        // fall through to plain-text fallback
+      }
+    }
+    await navigator.clipboard.writeText(plain);
+  };
+
+  const handleCopyBody = () => {
+    void (async () => {
+      const html = markdownRef.current?.innerHTML ?? '';
+      try {
+        await writeBodyToClipboard(html, body);
+        setCopied(true);
+        setTimeout(() => setCopied(false), 1200);
+      } catch {
+        // noop
+      }
+    })();
+  };
 
   const mailtoHref = useMemo(() => {
     const mailtoPath = to ? encodeURIComponent(to) : '';
@@ -123,22 +158,15 @@ export default function SendEmailWidget({
           className={cn(isStreaming && 'animate-pulse')}
           type="button"
           variant="secondary"
-          onClick={() => {
-            void (async () => {
-              try {
-                await navigator.clipboard.writeText(body);
-                setCopied(true);
-                setTimeout(() => setCopied(false), 1200);
-              } catch {
-                // noop
-              }
-            })();
-          }}
+          onClick={handleCopyBody}
         >
           {copied
             ? t('chat.tools.send_email.copied')
             : t('chat.tools.send_email.copyBody')}
         </Button>
+      </div>
+      <div ref={markdownRef} aria-hidden="true" className="sr-only">
+        <Markdown>{body}</Markdown>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

- `SendEmailWidget` now writes both `text/html` and `text/plain` to the clipboard so pasting into Word/Outlook/Gmail preserves markdown formatting (bold, lists, headings) instead of showing literal `**stars**`.
- Renders the email body through the existing `<Markdown>` widget in a visually hidden `sr-only` div and snapshots its `innerHTML` at copy time.
- Falls back to plain-text `writeText(body)` when `ClipboardItem` isn't available or the rich write fails.

**Stacked on** #607 (removes deprecated tsconfig `baseUrl` so pre-commit typecheck passes).

## Test plan

- [x] `npx tsc --noEmit`, `npx eslint …`, `npm run build` all pass
- [ ] Manual: copy an AI-generated email body with `**bold**`, lists, and `[links](…)`; paste into Word / Outlook / Gmail compose — formatting renders correctly
- [ ] Manual: paste into a plain-text target (terminal, VS Code) — gets raw markdown source

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Frontend-only clipboard behavior change scoped to one widget, with a safe plain-text fallback if `ClipboardItem`/HTML writes aren’t available.
> 
> **Overview**
> Updates `SendEmailWidget` so “Copy body” writes rich clipboard content: it renders the email body through the existing `Markdown` renderer in a hidden node, copies both `text/html` and `text/plain` via `ClipboardItem`, and falls back to `navigator.clipboard.writeText` when rich copy isn’t supported or fails.
> 
> This refactors the copy handler into `handleCopyBody`/`writeBodyToClipboard` and adds a `ref` to snapshot rendered HTML at copy time, improving paste formatting in clients like Outlook/Word/Gmail while preserving plain-text behavior elsewhere.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0e3c1e052c2571694401877532921378d25e47d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->