### PR TITLE
chore: add auto-sync workflow for ayunis UI library

### DIFF
--- a/.github/workflows/ui-library-update.yml
+++ b/.github/workflows/ui-library-update.yml
@@ -26,6 +26,10 @@ permissions:
   contents: write
   pull-requests: write
 
+concurrency:
+  group: ui-library-update
+  cancel-in-progress: true
+
 jobs:
   sync-ui-library:
     runs-on: ubuntu-latest

--- a/.github/workflows/ui-library-update.yml
+++ b/.github/workflows/ui-library-update.yml
@@ -1,0 +1,169 @@
+# Listens for UI library releases published from ayunis-core/ayunis-ui.
+# When one is received, a Cursor agent syncs the changed components via the
+# shadcn registry, scans the codebase for usages that might break, and opens
+# a PR with findings.
+#
+# Required secrets:
+#   CURSOR_API_KEY          Cursor agent key
+#   AYUNIS_REGISTRY_TOKEN   Bearer token for https://registry.ayunis.de
+#   UI_REPO_READ_TOKEN      GitHub PAT with `repo` scope (checks out ayunis-ui for CHANGELOG reading)
+
+name: UI Library Update
+
+on:
+  repository_dispatch:
+    types: [ui-library-released]
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: 'UI library version tag (e.g. v1.2.3)'
+        required: true
+      release_url:
+        description: 'URL of the release notes'
+        required: false
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  sync-ui-library:
+    runs-on: ubuntu-latest
+    env:
+      TAG_NAME: ${{ github.event.client_payload.tag_name || github.event.inputs.tag_name }}
+      RELEASE_URL: ${{ github.event.client_payload.release_url || github.event.inputs.release_url }}
+    steps:
+      - name: Checkout consumer repository
+        uses: actions/checkout@v4
+        with:
+          path: app
+          fetch-depth: 0
+
+      - name: Checkout ayunis-ui (read-only reference)
+        uses: actions/checkout@v4
+        with:
+          repository: ayunis-core/ayunis-ui
+          path: ui
+          fetch-depth: 0
+          token: ${{ secrets.UI_REPO_READ_TOKEN }}
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install Cursor CLI
+        run: |
+          curl https://cursor.com/install -fsS | bash
+          echo "$HOME/.cursor/bin" >> $GITHUB_PATH
+
+      - name: Write agent instructions
+        run: |
+          cat << 'INSTRUCTIONS_EOF' > /tmp/agent-instructions.txt
+          Sync the @ayunis UI library to version ${TAG_NAME} in this repo and flag
+          any code that might break as a result.
+
+          REPOSITORY LAYOUT
+          - ./app/   — the consumer application (make changes here)
+          - ./ui/    — the ayunis-ui source repo, read-only reference
+
+          RELEASE CONTEXT
+          - New tag:       ${TAG_NAME}
+          - Release notes: ${RELEASE_URL}
+
+          STEP 1 — UNDERSTAND WHAT CHANGED
+          1. cd ./ui/ and run: git tag --sort=-version:refname | head -5
+          2. Identify the previous release tag (just before ${TAG_NAME}).
+          3. List commits: git log <prev>..${TAG_NAME} --oneline
+          4. Read ./ui/CHANGELOG.md — find the section for ${TAG_NAME}.
+          5. Find changed components:
+             git diff <prev>..${TAG_NAME} -- packages/kit/src/components/ --name-only
+             Extract the component folder names (e.g. button, card, etc.).
+          6. For each changed component, scan the diff for BREAKING CHANGES:
+             - Removed exports / renamed prop names
+             - Changed prop types / defaults
+             - Removed CSS classes / theme variables
+             Record a list: component name → summary of change → breaking? y/n.
+
+          STEP 2 — LOCATE ALL FRONTENDS IN THE CONSUMER REPO
+          Find every folder in ./app/ that contains a components.json (shadcn config).
+          For example, in ayunis-core this is ./app/ayunis-core-frontend/.
+          In ayunis-locaboo it is ./app/locaboo-4.0-frontend/ (and possibly
+          ./app/booking-platform-frontend/).
+
+          STEP 3 — UPDATE CHANGED COMPONENTS VIA SHADCN
+          The AYUNIS_REGISTRY_TOKEN env var is already available; shadcn reads it
+          automatically from each components.json config. For every changed component:
+            npx shadcn@latest add "@ayunis/<component-name>" --overwrite --yes
+          Example: npx shadcn@latest add "@ayunis/button" --overwrite --yes
+          If shadcn fails for a component, record the error and move on.
+
+          STEP 4 — SCAN FOR BREAKAGE
+          For every breaking change identified in step 1:
+          1. Search the consumer codebase for usages (ripgrep across *.ts *.tsx *.js *.jsx *.css).
+          2. For each match, decide: compatible / needs manual review / safe to auto-fix.
+          3. Record findings as: file:line — what changed — status.
+
+          STEP 5 — ATTEMPT TRIVIAL AUTO-FIXES
+          Safe to auto-fix:
+          - Renamed exports (update import paths)
+          - Renamed props with clearly unambiguous mapping
+          Do NOT auto-fix anything ambiguous — flag it for human review instead.
+
+          STEP 6 — VERIFY BUILDS
+          For each frontend folder, run its type-check if available
+          (tsc --noEmit, or npm run typecheck, or the project's build --dry-run).
+          Record whether it passes.
+
+          STEP 7 — OPEN PR
+          cd ./app/
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          BRANCH="chore/sync-ayunis-kit-${TAG_NAME}"
+          git checkout -b "$BRANCH"
+          git add -A
+          git commit -m "chore: sync @ayunis/kit to ${TAG_NAME}"
+          git push -u origin "$BRANCH"
+
+          PR BODY (use this exact structure):
+
+            ## Ayunis UI Library sync: ${TAG_NAME}
+            Release notes: ${RELEASE_URL}
+
+            ### Components updated
+            <list each component name that was re-pulled, with a one-line summary of what changed>
+
+            ### Breaking changes detected
+            <each item: file:line — what broke — status (auto-fixed / manual review)>
+            (If none: "No breaking changes detected — safe to merge.")
+
+            ### Auto-fixes applied
+            <list of files modified, with short description>
+
+            ### Manual action required
+            <list of spots flagged for human review>
+
+            ### Build status per frontend
+            <folder: pass/fail of type-check>
+
+          Create with: gh pr create --title "chore: sync @ayunis/kit to ${TAG_NAME}" --body "<body>"
+
+          IMPORTANT
+          - Never merge automatically.
+          - If you detect risk, highlight it at the TOP of the PR body.
+          - If nothing in the release affects this repo's code, still open the PR so the
+            component sources stay in sync, but state that manual merging is safe.
+          INSTRUCTIONS_EOF
+
+          # Only substitute TAG_NAME and RELEASE_URL; leave all other $VAR references
+          # (like $BRANCH, which the agent creates at runtime) untouched.
+          envsubst '$TAG_NAME $RELEASE_URL' < /tmp/agent-instructions.txt > /tmp/agent-instructions.final.txt
+          mv /tmp/agent-instructions.final.txt /tmp/agent-instructions.txt
+
+      - name: Run Cursor Agent
+        env:
+          CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
+          AYUNIS_REGISTRY_TOKEN: ${{ secrets.AYUNIS_REGISTRY_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          agent -p "$(cat /tmp/agent-instructions.txt)" --force --model claude-4.6-opus-high-thinking

--- a/.github/workflows/ui-library-update.yml
+++ b/.github/workflows/ui-library-update.yml
@@ -38,6 +38,24 @@ jobs:
       TAG_NAME: ${{ github.event.client_payload.tag_name || github.event.inputs.tag_name }}
       RELEASE_URL: ${{ github.event.client_payload.release_url || github.event.inputs.release_url }}
     steps:
+      # Validate the dispatch inputs BEFORE anything else — these come from an
+      # external repository_dispatch payload and would otherwise be interpolated
+      # straight into the agent prompt, enabling prompt-injection attacks.
+      # Strict format checks make it impossible to smuggle arbitrary text in.
+      - name: Validate dispatch inputs
+        run: |
+          TAG_RE='^v[0-9]+\.[0-9]+\.[0-9]+$'
+          URL_RE='^https://github\.com/ayunis-core/ayunis-ui/releases/tag/v[0-9]+\.[0-9]+\.[0-9]+$'
+          if [[ ! "$TAG_NAME" =~ $TAG_RE ]]; then
+            echo "::error::Invalid tag_name '$TAG_NAME' — must match $TAG_RE"
+            exit 1
+          fi
+          if [ -n "$RELEASE_URL" ] && [[ ! "$RELEASE_URL" =~ $URL_RE ]]; then
+            echo "::error::Invalid release_url '$RELEASE_URL' — must match $URL_RE"
+            exit 1
+          fi
+          echo "✓ Inputs validated: tag=$TAG_NAME"
+
       - name: Checkout consumer repository
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/ui-library-update.yml
+++ b/.github/workflows/ui-library-update.yml
@@ -170,4 +170,6 @@ jobs:
           AYUNIS_REGISTRY_TOKEN: ${{ secrets.AYUNIS_REGISTRY_TOKEN }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          agent -p "$(cat /tmp/agent-instructions.txt)" --force --model claude-4.6-opus-high-thinking
+          # Use --model auto on purpose: Cursor retires pinned models quietly,
+          # which silently breaks rarely-run workflows like this one. auto stays valid.
+          agent -p "$(cat /tmp/agent-instructions.txt)" --force --model auto

--- a/.github/workflows/ui-library-update.yml
+++ b/.github/workflows/ui-library-update.yml
@@ -1,12 +1,13 @@
 # Listens for UI library releases published from ayunis-core/ayunis-ui.
-# When one is received, a Cursor agent syncs the changed components via the
-# shadcn registry, scans the codebase for usages that might break, and opens
+# When one is received, the Claude Code action syncs the changed components via
+# the shadcn registry, scans the codebase for usages that might break, and opens
 # a PR with findings.
 #
-# Required secrets:
-#   CURSOR_API_KEY          Cursor agent key
+# Required secrets in the consumer repo:
+#   ANTHROPIC_API_KEY       Claude API key (for the Claude Code action)
 #   AYUNIS_REGISTRY_TOKEN   Bearer token for https://registry.ayunis.de
-#   UI_REPO_READ_TOKEN      GitHub PAT with `repo` scope (checks out ayunis-ui for CHANGELOG reading)
+#   UI_REPO_READ_TOKEN      Fine-grained PAT, scoped to ayunis-ui only, "Contents: read"
+#                           (least privilege — only used to read the CHANGELOG)
 
 name: UI Library Update
 
@@ -56,120 +57,88 @@ jobs:
         with:
           node-version: 20
 
-      - name: Install Cursor CLI
-        run: |
-          curl https://cursor.com/install -fsS | bash
-          echo "$HOME/.cursor/bin" >> $GITHUB_PATH
-
-      - name: Write agent instructions
-        run: |
-          cat << 'INSTRUCTIONS_EOF' > /tmp/agent-instructions.txt
-          Sync the @ayunis UI library to version ${TAG_NAME} in this repo and flag
-          any code that might break as a result.
-
-          REPOSITORY LAYOUT
-          - ./app/   — the consumer application (make changes here)
-          - ./ui/    — the ayunis-ui source repo, read-only reference
-
-          RELEASE CONTEXT
-          - New tag:       ${TAG_NAME}
-          - Release notes: ${RELEASE_URL}
-
-          STEP 1 — UNDERSTAND WHAT CHANGED
-          1. cd ./ui/ and run: git tag --sort=-version:refname | head -5
-          2. Identify the previous release tag (just before ${TAG_NAME}).
-          3. List commits: git log <prev>..${TAG_NAME} --oneline
-          4. Read ./ui/CHANGELOG.md — find the section for ${TAG_NAME}.
-          5. Find changed components:
-             git diff <prev>..${TAG_NAME} -- packages/kit/src/components/ --name-only
-             Extract the component folder names (e.g. button, card, etc.).
-          6. For each changed component, scan the diff for BREAKING CHANGES:
-             - Removed exports / renamed prop names
-             - Changed prop types / defaults
-             - Removed CSS classes / theme variables
-             Record a list: component name → summary of change → breaking? y/n.
-
-          STEP 2 — LOCATE ALL FRONTENDS IN THE CONSUMER REPO
-          Find every folder in ./app/ that contains a components.json (shadcn config).
-          For example, in ayunis-core this is ./app/ayunis-core-frontend/.
-          In ayunis-locaboo it is ./app/locaboo-4.0-frontend/ (and possibly
-          ./app/booking-platform-frontend/).
-
-          STEP 3 — UPDATE CHANGED COMPONENTS VIA SHADCN
-          The AYUNIS_REGISTRY_TOKEN env var is already available; shadcn reads it
-          automatically from each components.json config. For every changed component:
-            npx shadcn@latest add "@ayunis/<component-name>" --overwrite --yes
-          Example: npx shadcn@latest add "@ayunis/button" --overwrite --yes
-          If shadcn fails for a component, record the error and move on.
-
-          STEP 4 — SCAN FOR BREAKAGE
-          For every breaking change identified in step 1:
-          1. Search the consumer codebase for usages (ripgrep across *.ts *.tsx *.js *.jsx *.css).
-          2. For each match, decide: compatible / needs manual review / safe to auto-fix.
-          3. Record findings as: file:line — what changed — status.
-
-          STEP 5 — ATTEMPT TRIVIAL AUTO-FIXES
-          Safe to auto-fix:
-          - Renamed exports (update import paths)
-          - Renamed props with clearly unambiguous mapping
-          Do NOT auto-fix anything ambiguous — flag it for human review instead.
-
-          STEP 6 — VERIFY BUILDS
-          For each frontend folder, run its type-check if available
-          (tsc --noEmit, or npm run typecheck, or the project's build --dry-run).
-          Record whether it passes.
-
-          STEP 7 — OPEN PR
-          cd ./app/
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          BRANCH="chore/sync-ayunis-kit-${TAG_NAME}"
-          git checkout -b "$BRANCH"
-          git add -A
-          git commit -m "chore: sync @ayunis/kit to ${TAG_NAME}"
-          git push -u origin "$BRANCH"
-
-          PR BODY (use this exact structure):
-
-            ## Ayunis UI Library sync: ${TAG_NAME}
-            Release notes: ${RELEASE_URL}
-
-            ### Components updated
-            <list each component name that was re-pulled, with a one-line summary of what changed>
-
-            ### Breaking changes detected
-            <each item: file:line — what broke — status (auto-fixed / manual review)>
-            (If none: "No breaking changes detected — safe to merge.")
-
-            ### Auto-fixes applied
-            <list of files modified, with short description>
-
-            ### Manual action required
-            <list of spots flagged for human review>
-
-            ### Build status per frontend
-            <folder: pass/fail of type-check>
-
-          Create with: gh pr create --title "chore: sync @ayunis/kit to ${TAG_NAME}" --body "<body>"
-
-          IMPORTANT
-          - Never merge automatically.
-          - If you detect risk, highlight it at the TOP of the PR body.
-          - If nothing in the release affects this repo's code, still open the PR so the
-            component sources stay in sync, but state that manual merging is safe.
-          INSTRUCTIONS_EOF
-
-          # Only substitute TAG_NAME and RELEASE_URL; leave all other $VAR references
-          # (like $BRANCH, which the agent creates at runtime) untouched.
-          envsubst '$TAG_NAME $RELEASE_URL' < /tmp/agent-instructions.txt > /tmp/agent-instructions.final.txt
-          mv /tmp/agent-instructions.final.txt /tmp/agent-instructions.txt
-
-      - name: Run Cursor Agent
+      - name: Sync components with Claude Code
+        uses: anthropics/claude-code-action@v1
         env:
-          CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
           AYUNIS_REGISTRY_TOKEN: ${{ secrets.AYUNIS_REGISTRY_TOKEN }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          # Use --model auto on purpose: Cursor retires pinned models quietly,
-          # which silently breaks rarely-run workflows like this one. auto stays valid.
-          agent -p "$(cat /tmp/agent-instructions.txt)" --force --model auto
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          # No --model on purpose: pinned models get retired and break the workflow
+          # silently. Omitting it uses Claude Code's current default, which stays valid.
+          claude_args: |
+            --allowedTools Edit,Read,Write,Bash,Glob,Grep
+            --max-turns 40
+          prompt: |
+            Sync the @ayunis UI library to version ${{ env.TAG_NAME }} in this repo and
+            flag any code that might break as a result.
+
+            REPOSITORY LAYOUT
+            - ./app/   — the consumer application (make changes here)
+            - ./ui/    — the ayunis-ui source repo, read-only reference
+
+            RELEASE CONTEXT
+            - New tag:       ${{ env.TAG_NAME }}
+            - Release notes: ${{ env.RELEASE_URL }}
+            - The AYUNIS_REGISTRY_TOKEN env var is set; shadcn reads it automatically
+              from each components.json so registry auth just works.
+
+            STEP 1 — UNDERSTAND WHAT CHANGED
+            1. cd ./ui/ and run: git tag --sort=-version:refname | head -5
+            2. Identify the previous release tag (just before ${{ env.TAG_NAME }}).
+            3. List commits: git log <prev>..${{ env.TAG_NAME }} --oneline
+            4. Read ./ui/CHANGELOG.md — find the section for ${{ env.TAG_NAME }}.
+            5. Find changed components:
+               git diff <prev>..${{ env.TAG_NAME }} -- packages/kit/src/components/ --name-only
+               Extract the component folder names (e.g. button, card).
+            6. For each changed component, scan the diff for BREAKING CHANGES:
+               removed exports, renamed props, changed prop types/defaults,
+               removed CSS classes / theme variables. Record: component → change → breaking? y/n.
+
+            STEP 2 — LOCATE ALL FRONTENDS
+            Find every folder in ./app/ that contains a components.json (shadcn config).
+            Example: ./app/ayunis-core-frontend/ or ./app/locaboo-4.0-frontend/ and
+            ./app/booking-platform-frontend/.
+
+            STEP 3 — UPDATE CHANGED COMPONENTS VIA SHADCN
+            In each frontend folder, for every changed component:
+              npx shadcn@latest add "@ayunis/<component-name>" --overwrite --yes
+            If shadcn fails for a component, record the error and move on.
+
+            STEP 4 — SCAN FOR BREAKAGE
+            For each breaking change from step 1, search ./app/ for usages
+            (ripgrep across *.ts *.tsx *.js *.jsx *.css). For each hit decide:
+            compatible / needs manual review / safe to auto-fix. Record file:line — change — status.
+
+            STEP 5 — TRIVIAL AUTO-FIXES ONLY
+            Safe: renamed exports (update imports), unambiguous prop renames.
+            Do NOT auto-fix anything ambiguous — flag it for human review instead.
+
+            STEP 6 — VERIFY BUILDS
+            For each frontend, run its type-check if available
+            (tsc --noEmit, or npm run typecheck, or build --dry-run). Record pass/fail.
+
+            STEP 7 — OPEN PR
+            cd ./app/
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git checkout -b "chore/sync-ayunis-kit-${{ env.TAG_NAME }}"
+            git add -A
+            git commit -m "chore: sync @ayunis/kit to ${{ env.TAG_NAME }}"
+            git push -u origin "chore/sync-ayunis-kit-${{ env.TAG_NAME }}"
+
+            Then open a PR with gh pr create. The PR body MUST use this structure:
+              ## Ayunis UI Library sync: ${{ env.TAG_NAME }}
+              Release notes: ${{ env.RELEASE_URL }}
+              ### Components updated
+              ### Breaking changes detected   (file:line — change — status; or "none — safe to merge")
+              ### Auto-fixes applied
+              ### Manual action required
+              ### Build status per frontend
+
+            IMPORTANT
+            - Never merge automatically.
+            - If you detect any risk, highlight it at the TOP of the PR body.
+            - If nothing in the release affects this repo, still open the PR to keep the
+              component sources in sync, but state that manual merging is safe.

--- a/.github/workflows/ui-library-update.yml
+++ b/.github/workflows/ui-library-update.yml
@@ -1,10 +1,10 @@
 # Listens for UI library releases published from ayunis-core/ayunis-ui.
-# When one is received, the Claude Code action syncs the changed components via
-# the shadcn registry, scans the codebase for usages that might break, and opens
+# When one is received, a Cursor agent syncs the changed components via the
+# shadcn registry, scans the codebase for usages that might break, and opens
 # a PR with findings.
 #
 # Required secrets in the consumer repo:
-#   ANTHROPIC_API_KEY       Claude API key (for the Claude Code action)
+#   CURSOR_API_KEY          Cursor agent key
 #   AYUNIS_REGISTRY_TOKEN   Bearer token for https://registry.ayunis.de
 #   UI_REPO_READ_TOKEN      Fine-grained PAT, scoped to ayunis-ui only, "Contents: read"
 #                           (least privilege — only used to read the CHANGELOG)
@@ -57,88 +57,91 @@ jobs:
         with:
           node-version: 20
 
-      - name: Sync components with Claude Code
-        uses: anthropics/claude-code-action@v1
+      - name: Install Cursor CLI
+        run: |
+          curl https://cursor.com/install -fsS | bash
+          echo "$HOME/.cursor/bin" >> $GITHUB_PATH
+
+      - name: Sync components with Cursor agent
         env:
+          CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
           AYUNIS_REGISTRY_TOKEN: ${{ secrets.AYUNIS_REGISTRY_TOKEN }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          # No --model on purpose: pinned models get retired and break the workflow
-          # silently. Omitting it uses Claude Code's current default, which stays valid.
-          claude_args: |
-            --allowedTools Edit,Read,Write,Bash,Glob,Grep
-            --max-turns 40
-          prompt: |
-            Sync the @ayunis UI library to version ${{ env.TAG_NAME }} in this repo and
-            flag any code that might break as a result.
+        run: |
+          cat > /tmp/agent-instructions.txt <<'EOF'
+          Sync the @ayunis UI library to version ${{ env.TAG_NAME }} in this repo and
+          flag any code that might break as a result.
 
-            REPOSITORY LAYOUT
-            - ./app/   — the consumer application (make changes here)
-            - ./ui/    — the ayunis-ui source repo, read-only reference
+          REPOSITORY LAYOUT
+          - ./app/   — the consumer application (make changes here)
+          - ./ui/    — the ayunis-ui source repo, read-only reference
 
-            RELEASE CONTEXT
-            - New tag:       ${{ env.TAG_NAME }}
-            - Release notes: ${{ env.RELEASE_URL }}
-            - The AYUNIS_REGISTRY_TOKEN env var is set; shadcn reads it automatically
-              from each components.json so registry auth just works.
+          RELEASE CONTEXT
+          - New tag:       ${{ env.TAG_NAME }}
+          - Release notes: ${{ env.RELEASE_URL }}
+          - The AYUNIS_REGISTRY_TOKEN env var is set; shadcn reads it automatically
+            from each components.json so registry auth just works.
 
-            STEP 1 — UNDERSTAND WHAT CHANGED
-            1. cd ./ui/ and run: git tag --sort=-version:refname | head -5
-            2. Identify the previous release tag (just before ${{ env.TAG_NAME }}).
-            3. List commits: git log <prev>..${{ env.TAG_NAME }} --oneline
-            4. Read ./ui/CHANGELOG.md — find the section for ${{ env.TAG_NAME }}.
-            5. Find changed components:
-               git diff <prev>..${{ env.TAG_NAME }} -- packages/kit/src/components/ --name-only
-               Extract the component folder names (e.g. button, card).
-            6. For each changed component, scan the diff for BREAKING CHANGES:
-               removed exports, renamed props, changed prop types/defaults,
-               removed CSS classes / theme variables. Record: component → change → breaking? y/n.
+          STEP 1 — UNDERSTAND WHAT CHANGED
+          1. cd ./ui/ and run: git tag --sort=-version:refname | head -5
+          2. Identify the previous release tag (just before ${{ env.TAG_NAME }}).
+          3. List commits: git log <prev>..${{ env.TAG_NAME }} --oneline
+          4. Read ./ui/CHANGELOG.md — find the section for ${{ env.TAG_NAME }}.
+          5. Find changed components:
+             git diff <prev>..${{ env.TAG_NAME }} -- packages/kit/src/components/ --name-only
+             Extract the component folder names (e.g. button, card).
+          6. For each changed component, scan the diff for BREAKING CHANGES:
+             removed exports, renamed props, changed prop types/defaults,
+             removed CSS classes / theme variables. Record: component → change → breaking? y/n.
 
-            STEP 2 — LOCATE ALL FRONTENDS
-            Find every folder in ./app/ that contains a components.json (shadcn config).
-            Example: ./app/ayunis-core-frontend/ or ./app/locaboo-4.0-frontend/ and
-            ./app/booking-platform-frontend/.
+          STEP 2 — LOCATE ALL FRONTENDS
+          Find every folder in ./app/ that contains a components.json (shadcn config).
+          Example: ./app/ayunis-core-frontend/ or ./app/locaboo-4.0-frontend/ and
+          ./app/booking-platform-frontend/.
 
-            STEP 3 — UPDATE CHANGED COMPONENTS VIA SHADCN
-            In each frontend folder, for every changed component:
-              npx shadcn@latest add "@ayunis/<component-name>" --overwrite --yes
-            If shadcn fails for a component, record the error and move on.
+          STEP 3 — UPDATE CHANGED COMPONENTS VIA SHADCN
+          In each frontend folder, for every changed component:
+            npx shadcn@latest add "@ayunis/<component-name>" --overwrite --yes
+          If shadcn fails for a component, record the error and move on.
 
-            STEP 4 — SCAN FOR BREAKAGE
-            For each breaking change from step 1, search ./app/ for usages
-            (ripgrep across *.ts *.tsx *.js *.jsx *.css). For each hit decide:
-            compatible / needs manual review / safe to auto-fix. Record file:line — change — status.
+          STEP 4 — SCAN FOR BREAKAGE
+          For each breaking change from step 1, search ./app/ for usages
+          (ripgrep across *.ts *.tsx *.js *.jsx *.css). For each hit decide:
+          compatible / needs manual review / safe to auto-fix. Record file:line — change — status.
 
-            STEP 5 — TRIVIAL AUTO-FIXES ONLY
-            Safe: renamed exports (update imports), unambiguous prop renames.
-            Do NOT auto-fix anything ambiguous — flag it for human review instead.
+          STEP 5 — TRIVIAL AUTO-FIXES ONLY
+          Safe: renamed exports (update imports), unambiguous prop renames.
+          Do NOT auto-fix anything ambiguous — flag it for human review instead.
 
-            STEP 6 — VERIFY BUILDS
-            For each frontend, run its type-check if available
-            (tsc --noEmit, or npm run typecheck, or build --dry-run). Record pass/fail.
+          STEP 6 — VERIFY BUILDS
+          For each frontend, run its type-check if available
+          (tsc --noEmit, or npm run typecheck, or build --dry-run). Record pass/fail.
 
-            STEP 7 — OPEN PR
-            cd ./app/
-            git config user.name "github-actions[bot]"
-            git config user.email "github-actions[bot]@users.noreply.github.com"
-            git checkout -b "chore/sync-ayunis-kit-${{ env.TAG_NAME }}"
-            git add -A
-            git commit -m "chore: sync @ayunis/kit to ${{ env.TAG_NAME }}"
-            git push -u origin "chore/sync-ayunis-kit-${{ env.TAG_NAME }}"
+          STEP 7 — OPEN PR
+          cd ./app/
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b "chore/sync-ayunis-kit-${{ env.TAG_NAME }}"
+          git add -A
+          git commit -m "chore: sync @ayunis/kit to ${{ env.TAG_NAME }}"
+          git push -u origin "chore/sync-ayunis-kit-${{ env.TAG_NAME }}"
 
-            Then open a PR with gh pr create. The PR body MUST use this structure:
-              ## Ayunis UI Library sync: ${{ env.TAG_NAME }}
-              Release notes: ${{ env.RELEASE_URL }}
-              ### Components updated
-              ### Breaking changes detected   (file:line — change — status; or "none — safe to merge")
-              ### Auto-fixes applied
-              ### Manual action required
-              ### Build status per frontend
+          Then open a PR with gh pr create. The PR body MUST use this structure:
+            ## Ayunis UI Library sync: ${{ env.TAG_NAME }}
+            Release notes: ${{ env.RELEASE_URL }}
+            ### Components updated
+            ### Breaking changes detected   (file:line — change — status; or "none — safe to merge")
+            ### Auto-fixes applied
+            ### Manual action required
+            ### Build status per frontend
 
-            IMPORTANT
-            - Never merge automatically.
-            - If you detect any risk, highlight it at the TOP of the PR body.
-            - If nothing in the release affects this repo, still open the PR to keep the
-              component sources in sync, but state that manual merging is safe.
+          IMPORTANT
+          - Never merge automatically.
+          - If you detect any risk, highlight it at the TOP of the PR body.
+          - If nothing in the release affects this repo, still open the PR to keep the
+            component sources in sync, but state that manual merging is safe.
+          EOF
+
+          # Use --model auto on purpose: Cursor retires pinned models quietly,
+          # which silently breaks rarely-run workflows like this one. auto stays valid.
+          agent -p "$(cat /tmp/agent-instructions.txt)" --force --model auto


### PR DESCRIPTION
## Summary

Adds a workflow that listens for release events from [ayunis-core/ayunis-ui](https://github.com/ayunis-core/ayunis-ui) and runs a **Cursor agent** which:

- Reads the ayunis-ui CHANGELOG for the new tag
- Re-pulls components that changed via `shadcn add --overwrite`
- Scans this repo for usages affected by breaking changes (renamed props, removed exports, changed defaults)
- Opens a PR with a findings report — including auto-fixes applied and items needing human review

No changes to any existing code — this is purely additive CI glue.

## Files
- `.github/workflows/ui-library-update.yml`

## Required setup

Add these secrets at Settings → Secrets and variables → Actions:

| Secret | Notes |
|---|---|
| `CURSOR_API_KEY` | Cursor agent key (same one used by the existing docs automation) |
| `AYUNIS_REGISTRY_TOKEN` | Bearer token for `registry.ayunis.de` |
| `UI_REPO_READ_TOKEN` | Fine-grained PAT, scoped to `ayunis-ui` only, **Contents: read** |

Companion PR on the ayunis-ui side (fires the dispatch): ayunis-core/ayunis-ui#16

## Test plan
- [ ] Set the three secrets
- [ ] Manually trigger via Actions → UI Library Update → Run workflow with a known tag (e.g. `v1.0.1`)
- [ ] Verify a PR is opened with the expected structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)