### PR TITLE
fix(tools): instruct LLM to use plain text in email widget (AYC-20)

### DIFF
--- a/ayunis-core-backend/src/domain/tools/domain/tools/send-email-tool.entity.ts
+++ b/ayunis-core-backend/src/domain/tools/domain/tools/send-email-tool.entity.ts
@@ -8,11 +8,12 @@ const sendEmailToolParameters = {
   properties: {
     subject: {
       type: 'string' as const,
-      description: 'The subject of the email',
+      description: 'The subject of the email as plain text (no Markdown).',
     },
     body: {
       type: 'string' as const,
-      description: 'The body of the email',
+      description:
+        'The body of the email as PLAIN TEXT only. Do NOT use Markdown formatting (no **bold**, _italics_, # headings, - bullet lists, [links](url), etc.). The widget renders the value verbatim, so any Markdown syntax would appear literally to the recipient. Use blank lines and plain punctuation for structure.',
     },
     to: {
       type: 'string' as const,
@@ -31,7 +32,7 @@ export class SendEmailTool extends DisplayableTool {
     super({
       name: ToolType.SEND_EMAIL,
       description:
-        'Display an email composition widget. The user reviews and controls the final send action.',
+        'Display an email composition widget. The user reviews and controls the final send action. Subject and body must be PLAIN TEXT only — do not use Markdown formatting; the widget renders the values verbatim and Markdown syntax would appear literally to the recipient.',
       parameters: sendEmailToolParameters,
       type: ToolType.SEND_EMAIL,
     });


### PR DESCRIPTION
The send-email widget renders subject and body verbatim, so any Markdown syntax (e.g. **bold**, _italics_, # headings, bullet lists) appears literally to the recipient. Update the SendEmailTool description and the subject/body parameter descriptions to instruct the model to emit plain text only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation/prompt-string only changes; no behavior, validation logic, or data flow is modified.
> 
> **Overview**
> Updates the `SendEmailTool` schema and tool description to explicitly require *plain-text* `subject` and `body`, warning the model not to emit Markdown because the email widget renders values verbatim.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fec9ab98c67151d99be934875de9cb701c61372b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->