### PR TITLE
feat(super-admin): show organization ID on org detail page (AYC-000)

### DIFF
--- a/ayunis-core-frontend/src/pages/super-admin-settings/org/ui/OrgDetails.tsx
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/org/ui/OrgDetails.tsx
@@ -5,19 +5,44 @@ import {
   CardHeader,
   CardTitle,
 } from '@/shared/ui/shadcn/card';
+import {
+  Item,
+  ItemContent,
+  ItemDescription,
+  ItemGroup,
+  ItemSeparator,
+  ItemTitle,
+} from '@/shared/ui/shadcn/item';
+import { useTranslation } from 'react-i18next';
 
 interface OrgDetailsProps {
   org: SuperAdminOrgResponseDto;
 }
 
 export default function OrgDetails({ org }: Readonly<OrgDetailsProps>) {
+  const { t } = useTranslation('super-admin-settings-org');
+
   return (
     <Card>
       <CardHeader>
         <CardTitle>{org.name}</CardTitle>
       </CardHeader>
       <CardContent>
-        <p>{org.name}</p>
+        <ItemGroup>
+          <Item>
+            <ItemContent>
+              <ItemTitle>{t('orgDetails.name')}</ItemTitle>
+              <ItemDescription>{org.name}</ItemDescription>
+            </ItemContent>
+          </Item>
+          <ItemSeparator />
+          <Item>
+            <ItemContent>
+              <ItemTitle>{t('orgDetails.id')}</ItemTitle>
+              <ItemDescription>{org.id}</ItemDescription>
+            </ItemContent>
+          </Item>
+        </ItemGroup>
       </CardContent>
     </Card>
   );

--- a/ayunis-core-frontend/src/shared/locales/de/super-admin-settings-org.json
+++ b/ayunis-core-frontend/src/shared/locales/de/super-admin-settings-org.json
@@ -245,6 +245,10 @@
     "models": "Modelle",
     "usage": "Nutzung"
   },
+  "orgDetails": {
+    "name": "Name",
+    "id": "ID"
+  },
   "trial": {
     "title": "Trial-Informationen",
     "messagesSent": "Gesendete Nachrichten",

--- a/ayunis-core-frontend/src/shared/locales/en/super-admin-settings-org.json
+++ b/ayunis-core-frontend/src/shared/locales/en/super-admin-settings-org.json
@@ -245,6 +245,10 @@
     "models": "Models",
     "usage": "Usage"
   },
+  "orgDetails": {
+    "name": "Name",
+    "id": "ID"
+  },
   "trial": {
     "title": "Trial Information",
     "messagesSent": "Messages Sent",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk UI-only change that adds a new field to the org details view and introduces two new i18n keys; no data flow or permission logic is modified.
> 
> **Overview**
> **Org details view now shows the organization ID.** `OrgDetails` replaces the single name paragraph with a labeled item list and adds an ID row (`org.id`) alongside the name.
> 
> Adds `orgDetails.name` and `orgDetails.id` translation strings in both `en` and `de` locale files for the new labels.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a8fe8008157c19663f6fe01f1cd02ffab560c08. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->