### PR TITLE
fix(artifacts): png download for diagrams (AYC-68)

### DIFF
--- a/ayunis-core-frontend/src/widgets/diagram-viewer/ui/DiagramExportButtons.tsx
+++ b/ayunis-core-frontend/src/widgets/diagram-viewer/ui/DiagramExportButtons.tsx
@@ -24,6 +24,68 @@ function safeTitle(input: string): string {
   return input.replace(/[^a-zA-Z0-9-_ ]/g, '').trim() || 'diagram';
 }
 
+function computeSvgDimensions(svg: SVGSVGElement): {
+  width: number;
+  height: number;
+} {
+  const viewBox = svg.viewBox.baseVal;
+  const rect = svg.getBoundingClientRect();
+  const width =
+    (viewBox.width > 0 ? viewBox.width : 0) ||
+    svg.clientWidth ||
+    rect.width ||
+    800;
+  const height =
+    (viewBox.height > 0 ? viewBox.height : 0) ||
+    svg.clientHeight ||
+    rect.height ||
+    600;
+  return { width, height };
+}
+
+function svgToDataUrl(svg: SVGSVGElement, width: number, height: number) {
+  const cloned = svg.cloneNode(true) as SVGSVGElement;
+  if (!cloned.getAttribute('xmlns')) {
+    cloned.setAttribute('xmlns', 'http://www.w3.org/2000/svg');
+  }
+  cloned.setAttribute('width', String(width));
+  cloned.setAttribute('height', String(height));
+  const svgString = new XMLSerializer().serializeToString(cloned);
+  // Data URLs render more reliably than blob URLs when rasterising SVG
+  // into an Image/Canvas pipeline across browsers.
+  return `data:image/svg+xml;charset=utf-8,${encodeURIComponent(svgString)}`;
+}
+
+function rasteriseToPng(
+  img: HTMLImageElement,
+  width: number,
+  height: number,
+): Promise<Blob | null> {
+  return new Promise((resolve, reject) => {
+    const canvas = document.createElement('canvas');
+    const scale = 2;
+    canvas.width = Math.max(1, Math.round(width * scale));
+    canvas.height = Math.max(1, Math.round(height * scale));
+    const ctx = canvas.getContext('2d');
+    if (!ctx) {
+      resolve(null);
+      return;
+    }
+    // Fill with white so transparent SVG regions don't become black on
+    // some rasterisers — Mermaid diagrams are authored against a light
+    // canvas.
+    ctx.fillStyle = '#ffffff';
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+    ctx.scale(scale, scale);
+    ctx.drawImage(img, 0, 0, width, height);
+    try {
+      canvas.toBlob((pngBlob) => resolve(pngBlob), 'image/png');
+    } catch (err) {
+      reject(err instanceof Error ? err : new Error('toBlob failed'));
+    }
+  });
+}
+
 export function DiagramExportButtons({
   containerRef,
   fileName,
@@ -42,39 +104,25 @@ export function DiagramExportButtons({
   const handlePngExport = useCallback(() => {
     const svg = containerRef.current?.querySelector('svg');
     if (!svg) return;
-    const serializer = new XMLSerializer();
-    const svgString = serializer.serializeToString(svg);
-    const blob = new Blob([svgString], { type: 'image/svg+xml' });
-    const url = URL.createObjectURL(blob);
+
+    const { width, height } = computeSvgDimensions(svg);
+    const svgDataUrl = svgToDataUrl(svg, width, height);
+    const fail = () => showError(t('diagram.export.failed'));
 
     const img = new Image();
     img.onload = () => {
-      const canvas = document.createElement('canvas');
-      const width = svg.clientWidth || 800;
-      const height = svg.clientHeight || 600;
-      const scale = 2;
-      canvas.width = width * scale;
-      canvas.height = height * scale;
-      const ctx = canvas.getContext('2d');
-      if (!ctx) {
-        URL.revokeObjectURL(url);
-        showError(t('diagram.export.failed'));
-        return;
-      }
-      ctx.scale(scale, scale);
-      ctx.drawImage(img, 0, 0, width, height);
-      URL.revokeObjectURL(url);
-      canvas.toBlob((pngBlob) => {
-        if (pngBlob) {
-          triggerDownload(pngBlob, `${safeTitle(fileName)}.png`);
-        }
-      }, 'image/png');
+      rasteriseToPng(img, width, height)
+        .then((pngBlob) => {
+          if (pngBlob) {
+            triggerDownload(pngBlob, `${safeTitle(fileName)}.png`);
+          } else {
+            fail();
+          }
+        })
+        .catch(fail);
     };
-    img.onerror = () => {
-      URL.revokeObjectURL(url);
-      showError(t('diagram.export.failed'));
-    };
-    img.src = url;
+    img.onerror = fail;
+    img.src = svgDataUrl;
   }, [containerRef, fileName, t]);
 
   return (


### PR DESCRIPTION
## Summary

Fixes PNG download for Mermaid diagrams in the artifacts editor. The button previously did nothing silently; SVG download was unaffected.

## Root cause

The SVG → Canvas → PNG pipeline silently swallowed failures:

- The serialized SVG lacked explicit `width`/`height` and `xmlns`, so image-loading edge cases produced 0×0 canvases in some browsers.
- `canvas.toBlob()` can throw `SecurityError` on a tainted canvas; the exception fired inside `img.onload` without a handler, so no toast.
- A `null` `toBlob` result was silently ignored (no download, no error message).

## Fix

- Compute dimensions from `viewBox` → `clientWidth` → `getBoundingClientRect` → fallback.
- Clone the SVG and set `xmlns`, `width`, `height` before serialization.
- Use a `data:image/svg+xml;charset=utf-8,…` URL instead of a blob URL (more reliable rasterization across browsers).
- Fill the canvas white before drawing (avoids black backgrounds on transparent regions).
- Wrap `toBlob` in try/catch and show the existing `diagram.export.failed` toast when it throws or returns null.
- Split into small helpers so `handlePngExport` stays within the 50-line limit.

Closes AYC-68.

## Test plan

- [ ] Generate a diagram in the editor, click "PNG" → file downloads
- [ ] SVG download still works
- [ ] If PNG export fails (e.g., malformed SVG), a toast is shown instead of silent failure

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the SVG→PNG rasterization pipeline (dimensions, encoding, canvas rendering), which can affect output fidelity and browser-specific behavior. No backend/security impact, but needs cross-browser validation for sizing/background and download success.
> 
> **Overview**
> Fixes diagram PNG downloads by replacing the blob-URL SVG serialization path with a more robust SVG-to-`data:` URL pipeline and explicit dimension calculation.
> 
> PNG export now derives width/height from `viewBox`/layout, forces SVG `xmlns`/size on a clone, rasterises with a higher-resolution canvas, and fills a white background to avoid black/transparent artifacts; error handling is consolidated to consistently toast failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 215ce4c559978a0585a59978bf6b89898cd6b533. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->