### PR TITLE
chore(usage): remove stray blank line in collect-usage spec (AYC-000)

### DIFF
--- a/ayunis-core-backend/src/domain/usage/application/use-cases/collect-usage/collect-usage.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/usage/application/use-cases/collect-usage/collect-usage.use-case.spec.ts
@@ -268,7 +268,6 @@ describe('CollectUsageUseCase', () => {
       expect(saveCall.cost).toBeUndefined();
     });
 
-
     it('should return undefined cost if only input cost is set', async () => {
       const model = createMockModel({
         inputTokenCost: 1,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Whitespace-only change in a test file; no production code or behavior is affected.
> 
> **Overview**
> Removes a stray blank line in `collect-usage.use-case.spec.ts`, with no changes to test logic or runtime behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3affe80fc9a7477dbb7fa247ee6abd0022668d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->