### PR TITLE
feat(usage): make user_id nullable + add api_key_id for principal-aware attribution (AYC-69)

### DIFF
--- a/ayunis-core-backend/src/common/context/services/context.service.ts
+++ b/ayunis-core-backend/src/common/context/services/context.service.ts
@@ -49,7 +49,6 @@ export class ContextService {
   // is preferred for new code.
   get<T>(key: keyof MyClsStore): T | undefined;
   get(key: keyof MyClsStore): unknown {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-return -- ClsService.get returns any
     return this.cls.get(key);
   }
 

--- a/ayunis-core-backend/src/db/migrations/1777356908150-UsageNullableUserIdAndAddApiKeyId.ts
+++ b/ayunis-core-backend/src/db/migrations/1777356908150-UsageNullableUserIdAndAddApiKeyId.ts
@@ -1,0 +1,52 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class UsageNullableUserIdAndAddApiKeyId1777356908150 implements MigrationInterface {
+  name = 'UsageNullableUserIdAndAddApiKeyId1777356908150';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "usage" ADD "apiKeyId" character varying`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "usage" ALTER COLUMN "userId" DROP NOT NULL`,
+    );
+    // Switch userId FK from CASCADE to SET NULL so deleting a user preserves
+    // their usage history; org-level reporting stays valid.
+    await queryRunner.query(
+      `ALTER TABLE "usage" DROP CONSTRAINT "FK_91e198d9fab36eceba00b08f2b6"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "usage" ADD CONSTRAINT "FK_91e198d9fab36eceba00b08f2b6" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "usage" ADD CONSTRAINT "FK_82cc3e3b0ea240eec1df45598c8" FOREIGN KEY ("apiKeyId") REFERENCES "api_keys"("id") ON DELETE SET NULL ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_66cdd82a1ffc35f8d78c35c99f" ON "usage" ("apiKeyId", "createdAt")`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_66cdd82a1ffc35f8d78c35c99f"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "usage" DROP CONSTRAINT "FK_82cc3e3b0ea240eec1df45598c8"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "usage" DROP CONSTRAINT "FK_91e198d9fab36eceba00b08f2b6"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "usage" ADD CONSTRAINT "FK_91e198d9fab36eceba00b08f2b6" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+    // DESTRUCTIVE: api-key-attributed usage rows (userId IS NULL) cannot
+    // satisfy the restored NOT NULL constraint, so they are deleted before
+    // it is reapplied. Reverting this migration permanently loses api-key
+    // usage history.
+    await queryRunner.query(`DELETE FROM "usage" WHERE "userId" IS NULL`);
+    await queryRunner.query(
+      `ALTER TABLE "usage" ALTER COLUMN "userId" SET NOT NULL`,
+    );
+    await queryRunner.query(`ALTER TABLE "usage" DROP COLUMN "apiKeyId"`);
+  }
+}

--- a/ayunis-core-backend/src/domain/usage/application/events/tokens-consumed.event.ts
+++ b/ayunis-core-backend/src/domain/usage/application/events/tokens-consumed.event.ts
@@ -1,10 +1,15 @@
 import type { UUID } from 'crypto';
+import type { PrincipalKind } from 'src/iam/authentication/domain/active-principal.entity';
 
 export class TokensConsumedEvent {
   static readonly EVENT_NAME = 'run.tokens-consumed';
 
   constructor(
-    public readonly userId: UUID,
+    public readonly principalKind: PrincipalKind,
+    /** Set only when principalKind === 'user'. */
+    public readonly userId: UUID | null,
+    /** Set only when principalKind === 'apiKey'. */
+    public readonly apiKeyId: UUID | null,
     public readonly orgId: UUID,
     public readonly model: string,
     public readonly provider: string,

--- a/ayunis-core-backend/src/domain/usage/application/services/collect-usage-async.service.ts
+++ b/ayunis-core-backend/src/domain/usage/application/services/collect-usage-async.service.ts
@@ -1,7 +1,10 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import type { UUID } from 'crypto';
-import { ContextService } from 'src/common/context/services/context.service';
+import {
+  ContextService,
+  ResolvedPrincipal,
+} from 'src/common/context/services/context.service';
 import { ImageGenerationModel } from 'src/domain/models/domain/models/image-generation.model';
 import { LanguageModel } from 'src/domain/models/domain/models/language.model';
 import { CollectUsageCommand } from '../use-cases/collect-usage/collect-usage.command';
@@ -36,15 +39,41 @@ export class CollectUsageAsyncService {
       messageId,
     });
 
-    const userId = this.contextService.get('userId');
-    const orgId = this.contextService.get('orgId');
+    const principal = this.resolvePrincipalSafely(model.id);
+    if (!principal) return;
 
+    this.emitTokensConsumed(principal, model, inputTokens, outputTokens);
+    this.persistUsage(model, inputTokens, outputTokens, messageId);
+  }
+
+  private resolvePrincipalSafely(modelId: UUID): ResolvedPrincipal | null {
+    try {
+      return this.contextService.requirePrincipal();
+    } catch {
+      this.logger.warn(
+        'Cannot collect usage: no authenticated principal in context',
+        { modelId },
+      );
+      return null;
+    }
+  }
+
+  private emitTokensConsumed(
+    principal: ResolvedPrincipal,
+    model: LanguageModel | ImageGenerationModel,
+    inputTokens: number,
+    outputTokens: number,
+  ): void {
+    const userId = principal.kind === 'user' ? principal.userId : null;
+    const apiKeyId = principal.kind === 'apiKey' ? principal.apiKeyId : null;
     this.eventEmitter
       .emitAsync(
         TokensConsumedEvent.EVENT_NAME,
         new TokensConsumedEvent(
-          userId ?? ('unknown' as UUID),
-          orgId ?? ('unknown' as UUID),
+          principal.kind,
+          userId,
+          apiKeyId,
+          principal.orgId,
           model.name,
           model.provider,
           inputTokens,
@@ -56,7 +85,14 @@ export class CollectUsageAsyncService {
           error: err instanceof Error ? err.message : 'Unknown error',
         });
       });
+  }
 
+  private persistUsage(
+    model: LanguageModel | ImageGenerationModel,
+    inputTokens: number,
+    outputTokens: number,
+    messageId?: UUID,
+  ): void {
     this.collectUsageUseCase
       .execute(
         new CollectUsageCommand({

--- a/ayunis-core-backend/src/domain/usage/application/use-cases/collect-usage/collect-usage.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/usage/application/use-cases/collect-usage/collect-usage.use-case.spec.ts
@@ -14,6 +14,8 @@ import { ImageGenerationModel } from '../../../../models/domain/models/image-gen
 import { LanguageModel } from '../../../../models/domain/models/language.model';
 import type { Usage } from '../../../domain/usage.entity';
 import { ContextService } from '../../../../../common/context/services/context.service';
+import { UserRole } from '../../../../../iam/users/domain/value-objects/role.object';
+import { SystemRole } from '../../../../../iam/users/domain/value-objects/system-role.enum';
 import { GetCreditsPerEuroUseCase } from '../../../../../iam/platform-config/application/use-cases/get-credits-per-euro/get-credits-per-euro.use-case';
 import { PlatformConfigNotFoundError } from '../../../../../iam/platform-config/application/platform-config.errors';
 import { PlatformConfigKey } from '../../../../../iam/platform-config/domain/platform-config-keys.enum';
@@ -57,6 +59,13 @@ describe('CollectUsageUseCase', () => {
         if (key === 'orgId') return orgId;
         return undefined;
       }) as any,
+      requirePrincipal: jest.fn(() => ({
+        kind: 'user' as const,
+        userId,
+        orgId,
+        role: UserRole.USER,
+        systemRole: SystemRole.CUSTOMER,
+      })),
     };
 
     mockGetCreditsPerEuroUseCase = {
@@ -85,6 +94,15 @@ describe('CollectUsageUseCase', () => {
         if (key === 'orgId') return orgId;
         return undefined;
       },
+    );
+    (mockContextService.requirePrincipal as jest.Mock).mockImplementation(
+      () => ({
+        kind: 'user' as const,
+        userId,
+        orgId,
+        role: UserRole.USER,
+        systemRole: SystemRole.CUSTOMER,
+      }),
     );
     (mockUsageRepository.save as jest.Mock).mockResolvedValue(undefined);
     mockGetCreditsPerEuroUseCase.execute.mockResolvedValue(100);
@@ -343,14 +361,12 @@ describe('CollectUsageUseCase', () => {
   });
 
   describe('error handling', () => {
-    it('should throw UsageCollectionFailedError when userId is missing from context', async () => {
-      jest.spyOn(mockContextService, 'get').mockImplementation(((
-        key?: 'userId' | 'orgId',
-      ) => {
-        if (key === 'userId') return undefined;
-        if (key === 'orgId') return orgId;
-        return undefined;
-      }) as any);
+    it('should throw UsageCollectionFailedError when no principal is in context', async () => {
+      (mockContextService.requirePrincipal as jest.Mock).mockImplementation(
+        () => {
+          throw new Error('No principal');
+        },
+      );
 
       const model = createMockModel();
       const command = new CollectUsageCommand({
@@ -366,14 +382,17 @@ describe('CollectUsageUseCase', () => {
       expect(mockUsageRepository.save).not.toHaveBeenCalled();
     });
 
-    it('should throw UsageCollectionFailedError when orgId is missing from context', async () => {
-      jest.spyOn(mockContextService, 'get').mockImplementation(((
-        key?: 'userId' | 'orgId',
-      ) => {
-        if (key === 'userId') return userId;
-        if (key === 'orgId') return undefined;
-        return undefined;
-      }) as any);
+    it('records api-key principal usage with apiKeyId, userId null', async () => {
+      const apiKeyId = 'api-key-id' as UUID;
+      (mockContextService.requirePrincipal as jest.Mock).mockImplementation(
+        () => ({
+          kind: 'apiKey' as const,
+          apiKeyId,
+          orgId,
+          role: UserRole.USER,
+          systemRole: SystemRole.CUSTOMER,
+        }),
+      );
 
       const model = createMockModel();
       const command = new CollectUsageCommand({
@@ -383,10 +402,15 @@ describe('CollectUsageUseCase', () => {
         requestId,
       });
 
-      await expect(useCase.execute(command)).rejects.toThrow(
-        UsageCollectionFailedError,
+      await useCase.execute(command);
+
+      expect(mockUsageRepository.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          userId: null,
+          apiKeyId,
+          organizationId: orgId,
+        }),
       );
-      expect(mockUsageRepository.save).not.toHaveBeenCalled();
     });
 
     it('should wrap repository errors in UnexpectedUsageError', async () => {

--- a/ayunis-core-backend/src/domain/usage/application/use-cases/collect-usage/collect-usage.use-case.ts
+++ b/ayunis-core-backend/src/domain/usage/application/use-cases/collect-usage/collect-usage.use-case.ts
@@ -9,7 +9,10 @@ import {
   UnexpectedUsageError,
 } from '../../usage.errors';
 import { ApplicationError } from '../../../../../common/errors/base.error';
-import { ContextService } from '../../../../../common/context/services/context.service';
+import {
+  ContextService,
+  ResolvedPrincipal,
+} from '../../../../../common/context/services/context.service';
 import { GetCreditsPerEuroUseCase } from '../../../../../iam/platform-config/application/use-cases/get-credits-per-euro/get-credits-per-euro.use-case';
 import { PlatformConfigNotFoundError } from '../../../../../iam/platform-config/application/platform-config.errors';
 
@@ -24,62 +27,24 @@ export class CollectUsageUseCase {
   ) {}
 
   async execute(command: CollectUsageCommand): Promise<void> {
-    const userId = this.contextService.get('userId');
-    const organizationId = this.contextService.get('orgId');
-
-    if (!userId || !organizationId) {
-      throw new UsageCollectionFailedError(
-        'User ID or Organization ID not available in context',
-        {
-          userId: userId ?? undefined,
-          organizationId: organizationId ?? undefined,
-          modelId: command.modelId,
-        },
-      );
-    }
-
-    this.logger.log('CollectUsageUseCase.execute called', {
-      userId,
-      organizationId,
-      modelId: command.modelId,
-      provider: command.provider,
-      totalTokens: command.totalTokens,
-    });
+    const principal = this.resolvePrincipal(command);
+    const userId = principal.kind === 'user' ? principal.userId : null;
+    const apiKeyId = principal.kind === 'apiKey' ? principal.apiKeyId : null;
 
     try {
       this.validateCommand(command);
-
-      const cost = this.calculateCost(command);
-      const creditsConsumed = await this.calculateCredits(cost);
-
-      const usage = new Usage({
-        userId,
-        organizationId,
-        modelId: command.modelId,
-        provider: command.provider,
-        inputTokens: command.inputTokens,
-        outputTokens: command.outputTokens,
-        totalTokens: command.totalTokens,
-        cost,
-        creditsConsumed,
-        requestId: command.requestId ?? randomUUID(),
-      });
-
+      const usage = await this.buildUsage(command, principal);
       await this.usageRepository.save(usage);
-
       this.logger.log('Usage collected successfully', {
-        userId,
-        organizationId,
+        principalKind: principal.kind,
+        organizationId: principal.orgId,
         modelId: command.modelId,
-        provider: command.provider,
         totalTokens: command.totalTokens,
-        cost,
+        cost: usage.cost,
         requestId: command.requestId,
       });
     } catch (error) {
-      if (error instanceof ApplicationError) {
-        throw error;
-      }
+      if (error instanceof ApplicationError) throw error;
       this.logger.error('Failed to collect usage', {
         error: error as Error,
         command,
@@ -87,12 +52,45 @@ export class CollectUsageUseCase {
       throw new UnexpectedUsageError(
         error instanceof Error ? error : new Error('Unknown error'),
         {
-          userId,
-          organizationId,
+          userId: userId ?? undefined,
+          apiKeyId: apiKeyId ?? undefined,
+          organizationId: principal.orgId,
           modelId: command.modelId,
         },
       );
     }
+  }
+
+  private resolvePrincipal(command: CollectUsageCommand): ResolvedPrincipal {
+    try {
+      return this.contextService.requirePrincipal();
+    } catch {
+      throw new UsageCollectionFailedError(
+        'No authenticated principal in context for usage collection',
+        { modelId: command.modelId },
+      );
+    }
+  }
+
+  private async buildUsage(
+    command: CollectUsageCommand,
+    principal: ResolvedPrincipal,
+  ): Promise<Usage> {
+    const cost = this.calculateCost(command);
+    const creditsConsumed = await this.calculateCredits(cost);
+    return Usage.create({
+      userId: principal.kind === 'user' ? principal.userId : null,
+      apiKeyId: principal.kind === 'apiKey' ? principal.apiKeyId : null,
+      organizationId: principal.orgId,
+      modelId: command.modelId,
+      provider: command.provider,
+      inputTokens: command.inputTokens,
+      outputTokens: command.outputTokens,
+      totalTokens: command.totalTokens,
+      cost,
+      creditsConsumed,
+      requestId: command.requestId ?? randomUUID(),
+    });
   }
 
   private validateCommand(command: CollectUsageCommand): void {

--- a/ayunis-core-backend/src/domain/usage/domain/usage.entity.ts
+++ b/ayunis-core-backend/src/domain/usage/domain/usage.entity.ts
@@ -2,9 +2,36 @@ import type { UUID } from 'crypto';
 import { randomUUID } from 'crypto';
 import type { ModelProvider } from '../../models/domain/value-objects/model-provider.enum';
 
+interface UsageProps {
+  id?: UUID;
+  userId: UUID | null;
+  apiKeyId: UUID | null;
+  organizationId: UUID;
+  modelId: UUID;
+  provider: ModelProvider;
+  inputTokens: number;
+  outputTokens: number;
+  totalTokens: number;
+  cost?: number;
+  creditsConsumed?: number;
+  requestId: UUID;
+  createdAt?: Date;
+}
+
+export type UsageAttributionState = 'user' | 'apiKey' | 'orphaned';
+
 export class Usage {
   public readonly id: UUID;
-  public readonly userId: UUID;
+  /**
+   * The user who generated this usage. `null` when the call was authenticated
+   * via an API key — in that case `apiKeyId` is set instead. On insert, exactly
+   * one of `userId` / `apiKeyId` is populated (enforced by `Usage.create()`).
+   * After the referenced principal is deleted, the FK is set to NULL — so
+   * existing rows reconstituted via `Usage.fromPersistence()` may have both
+   * columns null. Use `attributionState()` to distinguish.
+   */
+  public readonly userId: UUID | null;
+  public readonly apiKeyId: UUID | null;
   public readonly organizationId: UUID;
   /**
    * The base model ID (not the permitted model ID).
@@ -23,22 +50,10 @@ export class Usage {
   public readonly requestId: UUID;
   public readonly createdAt: Date;
 
-  constructor(params: {
-    id?: UUID;
-    userId: UUID;
-    organizationId: UUID;
-    modelId: UUID;
-    provider: ModelProvider;
-    inputTokens: number;
-    outputTokens: number;
-    totalTokens: number;
-    cost?: number;
-    creditsConsumed?: number;
-    requestId: UUID;
-    createdAt?: Date;
-  }) {
+  private constructor(params: UsageProps) {
     this.id = params.id ?? randomUUID();
     this.userId = params.userId;
+    this.apiKeyId = params.apiKeyId;
     this.organizationId = params.organizationId;
     this.modelId = params.modelId;
     this.provider = params.provider;
@@ -49,5 +64,29 @@ export class Usage {
     this.creditsConsumed = params.creditsConsumed;
     this.requestId = params.requestId;
     this.createdAt = params.createdAt ?? new Date();
+  }
+
+  static create(params: UsageProps): Usage {
+    if (!params.userId && !params.apiKeyId) {
+      throw new Error(
+        'Usage row must have either userId or apiKeyId — both are null',
+      );
+    }
+    if (params.userId && params.apiKeyId) {
+      throw new Error(
+        'Usage row must have exactly one principal — userId and apiKeyId are both set',
+      );
+    }
+    return new Usage(params);
+  }
+
+  static fromPersistence(params: UsageProps): Usage {
+    return new Usage(params);
+  }
+
+  attributionState(): UsageAttributionState {
+    if (this.userId) return 'user';
+    if (this.apiKeyId) return 'apiKey';
+    return 'orphaned';
   }
 }

--- a/ayunis-core-backend/src/domain/usage/infrastructure/persistence/local-usage/mappers/usage.mapper.ts
+++ b/ayunis-core-backend/src/domain/usage/infrastructure/persistence/local-usage/mappers/usage.mapper.ts
@@ -8,6 +8,7 @@ export class UsageMapper {
     const record = new UsageRecord();
     record.id = usage.id;
     record.userId = usage.userId;
+    record.apiKeyId = usage.apiKeyId;
     record.organizationId = usage.organizationId;
     record.modelId = usage.modelId;
     record.provider = usage.provider;
@@ -22,9 +23,10 @@ export class UsageMapper {
   }
 
   toDomain(record: UsageRecord): Usage {
-    return new Usage({
+    return Usage.fromPersistence({
       id: record.id,
       userId: record.userId,
+      apiKeyId: record.apiKeyId,
       organizationId: record.organizationId,
       modelId: record.modelId,
       provider: record.provider,

--- a/ayunis-core-backend/src/domain/usage/infrastructure/persistence/local-usage/schema/usage.record.ts
+++ b/ayunis-core-backend/src/domain/usage/infrastructure/persistence/local-usage/schema/usage.record.ts
@@ -1,8 +1,9 @@
-import { Entity, Column, Index, ManyToOne } from 'typeorm';
+import { Entity, Column, Index, ManyToOne, JoinColumn } from 'typeorm';
 import { BaseRecord } from '../../../../../../common/db/base-record';
 import { UUID } from 'crypto';
 import { UserRecord } from '../../../../../../iam/users/infrastructure/repositories/local/schema/user.record';
 import { OrgRecord } from '../../../../../../iam/orgs/infrastructure/repositories/local/schema/org.record';
+import { ApiKeyRecord } from '../../../../../../iam/api-keys/infrastructure/repositories/local/schema/api-key.record';
 import { ModelRecord } from '../../../../../models/infrastructure/persistence/local-models/schema/model.record';
 import { ModelProvider } from '../../../../../models/domain/value-objects/model-provider.enum';
 
@@ -14,27 +15,42 @@ const decimalTransformer = {
 
 /**
  * All costs are stored in EUR.
+ *
+ * On insert, each row attributes usage to exactly one principal: either a
+ * user (`userId`) or an API key (`apiKeyId`). This is enforced at write time
+ * by the `Usage` domain entity. After a principal is deleted, the FK is
+ * set to NULL — so existing rows may have both columns null. Org-level
+ * aggregates (`organizationId`) remain valid regardless.
  */
 @Entity('usage')
 @Index(['organizationId', 'createdAt'])
 @Index(['userId', 'createdAt'])
+@Index(['apiKeyId', 'createdAt'])
 @Index(['modelId', 'createdAt'])
 @Index(['provider', 'createdAt'])
 @Index(['organizationId', 'provider', 'createdAt'])
 export class UsageRecord extends BaseRecord {
-  @Column('uuid')
-  userId: UUID;
+  @Column({ nullable: true })
+  userId: UUID | null;
 
-  @ManyToOne(() => UserRecord, { nullable: false, onDelete: 'CASCADE' })
-  user: UserRecord;
+  @ManyToOne(() => UserRecord, { nullable: true, onDelete: 'SET NULL' })
+  @JoinColumn({ name: 'userId' })
+  user: UserRecord | null;
 
-  @Column('uuid')
+  @Column({ nullable: true })
+  apiKeyId: UUID | null;
+
+  @ManyToOne(() => ApiKeyRecord, { nullable: true, onDelete: 'SET NULL' })
+  @JoinColumn({ name: 'apiKeyId' })
+  apiKey: ApiKeyRecord | null;
+
+  @Column()
   organizationId: UUID;
 
   @ManyToOne(() => OrgRecord, { nullable: false, onDelete: 'CASCADE' })
   organization: OrgRecord;
 
-  @Column('uuid')
+  @Column()
   modelId: UUID;
 
   @ManyToOne(() => ModelRecord, { nullable: false, onDelete: 'NO ACTION' })

--- a/ayunis-core-backend/src/integrations/metrics/listeners/prometheus-metrics.listener.spec.ts
+++ b/ayunis-core-backend/src/integrations/metrics/listeners/prometheus-metrics.listener.spec.ts
@@ -287,9 +287,18 @@ describe('PrometheusMetricsListener', () => {
   });
 
   describe('handleTokensConsumed', () => {
-    it('should increment tokens counter for input and output', () => {
+    it('should increment tokens counter for input and output (user principal)', () => {
       listener.handleTokensConsumed(
-        new TokensConsumedEvent(USER_ID, ORG_ID, 'gpt-4', 'openai', 100, 50),
+        new TokensConsumedEvent(
+          'user',
+          USER_ID,
+          null,
+          ORG_ID,
+          'gpt-4',
+          'openai',
+          100,
+          50,
+        ),
       );
 
       expect(tokensCounter.inc).toHaveBeenCalledWith(
@@ -316,12 +325,46 @@ describe('PrometheusMetricsListener', () => {
 
     it('should skip zero-value token counts', () => {
       listener.handleTokensConsumed(
-        new TokensConsumedEvent(USER_ID, ORG_ID, 'gpt-4', 'openai', 100, 0),
+        new TokensConsumedEvent(
+          'user',
+          USER_ID,
+          null,
+          ORG_ID,
+          'gpt-4',
+          'openai',
+          100,
+          0,
+        ),
       );
 
       expect(tokensCounter.inc).toHaveBeenCalledTimes(1);
       expect(tokensCounter.inc).toHaveBeenCalledWith(
         expect.objectContaining({ direction: 'input' }),
+        100,
+      );
+    });
+
+    it('uses apiKeyId in the user_id label slot for api-key principals', () => {
+      const API_KEY_ID =
+        '11111111-1111-1111-1111-111111111111' as typeof USER_ID;
+      listener.handleTokensConsumed(
+        new TokensConsumedEvent(
+          'apiKey',
+          null,
+          API_KEY_ID,
+          ORG_ID,
+          'gpt-4',
+          'openai',
+          100,
+          50,
+        ),
+      );
+
+      expect(tokensCounter.inc).toHaveBeenCalledWith(
+        expect.objectContaining({
+          user_id: API_KEY_ID,
+          direction: 'input',
+        }),
         100,
       );
     });

--- a/ayunis-core-backend/src/integrations/metrics/listeners/prometheus-metrics.listener.ts
+++ b/ayunis-core-backend/src/integrations/metrics/listeners/prometheus-metrics.listener.ts
@@ -130,8 +130,12 @@ export class PrometheusMetricsListener {
 
   @OnEvent(TokensConsumedEvent.EVENT_NAME)
   handleTokensConsumed(event: TokensConsumedEvent): void {
+    // For api-key principals, write the api-key UUID into the existing
+    // `user_id` label slot — keeps the label set stable for dashboards while
+    // still uniquely identifying the caller.
+    const principalId = event.userId ?? event.apiKeyId ?? '';
     const baseLabels = {
-      user_id: event.userId,
+      user_id: principalId,
       org_id: event.orgId,
       model: event.model,
       provider: event.provider,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Schema + FK changes to the `usage` table and updated attribution logic could affect reporting/metrics and have irreversible data loss if the migration is rolled back (down migration deletes rows with `userId IS NULL`).
> 
> **Overview**
> Usage attribution is updated to support both user- and API-key-authenticated calls by making `usage.userId` nullable and adding `usage.apiKeyId`, with FK behavior changed to **preserve usage history** by setting principal FKs to NULL on delete.
> 
> Usage collection now resolves a discriminated principal via `ContextService.requirePrincipal()` and writes usage rows with either `userId` *or* `apiKeyId` (enforced by `Usage.create()`), while `TokensConsumedEvent` and Prometheus token metrics are updated to carry/emit principal-aware identifiers (api-key UUIDs are recorded in the existing `user_id` label slot to keep dashboards stable).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d2e6c6f4285d7787e133054be4b3ea386612eda. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->