### PR TITLE
feat(api-keys): add bearer-token auth guard for API keys (AYC-69)

### DIFF
--- a/ayunis-core-backend/src/iam/api-keys/api-keys.module.ts
+++ b/ayunis-core-backend/src/iam/api-keys/api-keys.module.ts
@@ -9,9 +9,11 @@ import { ApiKeyRecord } from './infrastructure/repositories/local/schema/api-key
 import { CreateApiKeyUseCase } from './application/use-cases/create-api-key/create-api-key.use-case';
 import { ListApiKeysByOrgUseCase } from './application/use-cases/list-api-keys-by-org/list-api-keys-by-org.use-case';
 import { RevokeApiKeyUseCase } from './application/use-cases/revoke-api-key/revoke-api-key.use-case';
+import { ValidateApiKeyUseCase } from './application/use-cases/validate-api-key/validate-api-key.use-case';
 
 import { ApiKeysController } from './presenters/http/api-keys.controller';
 import { ApiKeyDtoMapper } from './presenters/http/mappers/api-key-dto.mapper';
+import { ApiKeyAuthGuard } from './application/guards/api-key-auth.guard';
 
 import { HashingModule } from '../hashing/hashing.module';
 
@@ -29,8 +31,16 @@ import { HashingModule } from '../hashing/hashing.module';
     CreateApiKeyUseCase,
     ListApiKeysByOrgUseCase,
     RevokeApiKeyUseCase,
+    ValidateApiKeyUseCase,
     ApiKeyDtoMapper,
+    ApiKeyAuthGuard,
   ],
-  exports: [CreateApiKeyUseCase, ListApiKeysByOrgUseCase, RevokeApiKeyUseCase],
+  exports: [
+    CreateApiKeyUseCase,
+    ListApiKeysByOrgUseCase,
+    RevokeApiKeyUseCase,
+    ValidateApiKeyUseCase,
+    ApiKeyAuthGuard,
+  ],
 })
 export class ApiKeysModule {}

--- a/ayunis-core-backend/src/iam/api-keys/application/api-keys.errors.ts
+++ b/ayunis-core-backend/src/iam/api-keys/application/api-keys.errors.ts
@@ -5,6 +5,8 @@ export enum ApiKeyErrorCode {
   API_KEY_NOT_FOUND = 'API_KEY_NOT_FOUND',
   API_KEY_INVALID_INPUT = 'API_KEY_INVALID_INPUT',
   API_KEY_EXPIRATION_IN_PAST = 'API_KEY_EXPIRATION_IN_PAST',
+  API_KEY_INVALID = 'API_KEY_INVALID',
+  API_KEY_EXPIRED = 'API_KEY_EXPIRED',
   UNEXPECTED_API_KEY_ERROR = 'UNEXPECTED_API_KEY_ERROR',
 }
 
@@ -47,6 +49,23 @@ export class ApiKeyExpirationInPastError extends ApiKeyError {
       'API key expiration date must be in the future',
       ApiKeyErrorCode.API_KEY_EXPIRATION_IN_PAST,
       400,
+      metadata,
+    );
+  }
+}
+
+export class ApiKeyInvalidError extends ApiKeyError {
+  constructor(metadata?: ErrorMetadata) {
+    super('Invalid API key', ApiKeyErrorCode.API_KEY_INVALID, 401, metadata);
+  }
+}
+
+export class ApiKeyExpiredError extends ApiKeyError {
+  constructor(metadata?: ErrorMetadata) {
+    super(
+      'API key has expired',
+      ApiKeyErrorCode.API_KEY_EXPIRED,
+      401,
       metadata,
     );
   }

--- a/ayunis-core-backend/src/iam/api-keys/application/guards/api-key-auth.guard.ts
+++ b/ayunis-core-backend/src/iam/api-keys/application/guards/api-key-auth.guard.ts
@@ -1,0 +1,46 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  Injectable,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { Request } from 'express';
+import { ValidateApiKeyUseCase } from '../use-cases/validate-api-key/validate-api-key.use-case';
+import { ValidateApiKeyCommand } from '../use-cases/validate-api-key/validate-api-key.command';
+import { ActiveApiKey } from 'src/iam/authentication/domain/active-api-key.entity';
+import { UserRole } from 'src/iam/users/domain/value-objects/role.object';
+import { SystemRole } from 'src/iam/users/domain/value-objects/system-role.enum';
+
+const BEARER_PREFIX = 'Bearer ';
+
+@Injectable()
+export class ApiKeyAuthGuard implements CanActivate {
+  constructor(private readonly validateApiKeyUseCase: ValidateApiKeyUseCase) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const request = context.switchToHttp().getRequest<Request>();
+    const header = request.headers.authorization;
+
+    if (!header?.startsWith(BEARER_PREFIX)) {
+      throw new UnauthorizedException(
+        'Missing or malformed Authorization header',
+      );
+    }
+
+    const token = header.slice(BEARER_PREFIX.length).trim();
+
+    const apiKey = await this.validateApiKeyUseCase.execute(
+      new ValidateApiKeyCommand(token),
+    );
+
+    request.apiKey = new ActiveApiKey({
+      apiKeyId: apiKey.id,
+      label: apiKey.name,
+      orgId: apiKey.orgId,
+      role: UserRole.USER,
+      systemRole: SystemRole.CUSTOMER,
+    });
+
+    return true;
+  }
+}

--- a/ayunis-core-backend/src/iam/api-keys/application/ports/api-keys.repository.ts
+++ b/ayunis-core-backend/src/iam/api-keys/application/ports/api-keys.repository.ts
@@ -3,6 +3,7 @@ import type { ApiKey } from '../../domain/api-key.entity';
 
 export abstract class ApiKeysRepository {
   abstract findById(id: UUID): Promise<ApiKey | null>;
+  abstract findByPrefix(prefix: string): Promise<ApiKey | null>;
   abstract findByOrgId(orgId: UUID): Promise<ApiKey[]>;
   abstract create(apiKey: ApiKey): Promise<ApiKey>;
   abstract delete(id: UUID): Promise<void>;

--- a/ayunis-core-backend/src/iam/api-keys/application/use-cases/validate-api-key/validate-api-key.command.ts
+++ b/ayunis-core-backend/src/iam/api-keys/application/use-cases/validate-api-key/validate-api-key.command.ts
@@ -1,0 +1,3 @@
+export class ValidateApiKeyCommand {
+  constructor(public readonly token: string) {}
+}

--- a/ayunis-core-backend/src/iam/api-keys/application/use-cases/validate-api-key/validate-api-key.use-case.ts
+++ b/ayunis-core-backend/src/iam/api-keys/application/use-cases/validate-api-key/validate-api-key.use-case.ts
@@ -1,0 +1,64 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ApiKeysRepository } from '../../ports/api-keys.repository';
+import { ApiKey } from '../../../domain/api-key.entity';
+import { ValidateApiKeyCommand } from './validate-api-key.command';
+import {
+  ApiKeyExpiredError,
+  ApiKeyInvalidError,
+  UnexpectedApiKeyError,
+} from '../../api-keys.errors';
+import { ApplicationError } from 'src/common/errors/base.error';
+import { CompareHashUseCase } from 'src/iam/hashing/application/use-cases/compare-hash/compare-hash.use-case';
+import { CompareHashCommand } from 'src/iam/hashing/application/use-cases/compare-hash/compare-hash.command';
+
+@Injectable()
+export class ValidateApiKeyUseCase {
+  private readonly logger = new Logger(ValidateApiKeyUseCase.name);
+
+  constructor(
+    private readonly apiKeysRepository: ApiKeysRepository,
+    private readonly compareHashUseCase: CompareHashUseCase,
+  ) {}
+
+  async execute(command: ValidateApiKeyCommand): Promise<ApiKey> {
+    this.logger.log('execute');
+
+    const token = command.token;
+    if (!token.startsWith(ApiKey.KEY_PREFIX)) {
+      throw new ApiKeyInvalidError();
+    }
+
+    const randomPart = token.slice(ApiKey.KEY_PREFIX.length);
+    if (randomPart.length < ApiKey.LOOKUP_PREFIX_LENGTH) {
+      throw new ApiKeyInvalidError();
+    }
+
+    const prefix = randomPart.slice(0, ApiKey.LOOKUP_PREFIX_LENGTH);
+
+    try {
+      const apiKey = await this.apiKeysRepository.findByPrefix(prefix);
+      if (!apiKey) {
+        throw new ApiKeyInvalidError();
+      }
+
+      const matches = await this.compareHashUseCase.execute(
+        new CompareHashCommand(token, apiKey.hash),
+      );
+      if (!matches) {
+        throw new ApiKeyInvalidError();
+      }
+
+      if (apiKey.expiresAt && apiKey.expiresAt.getTime() <= Date.now()) {
+        throw new ApiKeyExpiredError({ apiKeyId: apiKey.id });
+      }
+
+      return apiKey;
+    } catch (error) {
+      if (error instanceof ApplicationError) {
+        throw error;
+      }
+      this.logger.error('Failed to validate API key', error);
+      throw new UnexpectedApiKeyError();
+    }
+  }
+}

--- a/ayunis-core-backend/src/iam/api-keys/infrastructure/repositories/local/local-api-keys.repository.ts
+++ b/ayunis-core-backend/src/iam/api-keys/infrastructure/repositories/local/local-api-keys.repository.ts
@@ -28,6 +28,16 @@ export class LocalApiKeysRepository extends ApiKeysRepository {
     return ApiKeyMapper.toDomain(record);
   }
 
+  async findByPrefix(prefix: string): Promise<ApiKey | null> {
+    this.logger.log('findByPrefix');
+
+    const record = await this.apiKeyRepository.findOne({ where: { prefix } });
+    if (!record) {
+      return null;
+    }
+    return ApiKeyMapper.toDomain(record);
+  }
+
   async findByOrgId(orgId: UUID): Promise<ApiKey[]> {
     this.logger.log('findByOrgId', { orgId });
 

--- a/ayunis-core-backend/src/iam/authentication/application/interceptors/user-context.interceptor.ts
+++ b/ayunis-core-backend/src/iam/authentication/application/interceptors/user-context.interceptor.ts
@@ -65,3 +65,4 @@ declare module 'express-serve-static-core' {
     apiKey?: ActiveApiKey;
   }
 }
+


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces new authentication/authorization plumbing (guard + API key validation) where mistakes could allow unauthorized access or incorrectly reject valid requests.
> 
> **Overview**
> Enables API-key authentication via an injectable `ApiKeyAuthGuard` that reads `Authorization: Bearer ...`, validates the key, and attaches an `ActiveApiKey` principal to `req.apiKey` for downstream context.
> 
> Adds a `ValidateApiKeyUseCase` that performs prefix-based lookup (`findByPrefix`), bcrypt/hash comparison, and expiration checks, with new `API_KEY_INVALID`/`API_KEY_EXPIRED` error types; the `ApiKeysRepository` and local TypeORM implementation are extended to support prefix lookup, and the `ApiKeysModule` now exports the new use case and guard.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 532f78bd09c803a0a4c2761de1540231ddfa9588. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->