### PR TITLE
fix(ui): consistent destructive styling and dropdown icon spacing (AYC-000)

### DIFF
--- a/ayunis-core-frontend/src/layouts/chat-interface-layout/ui/ChatInterfaceLayout.tsx
+++ b/ayunis-core-frontend/src/layouts/chat-interface-layout/ui/ChatInterfaceLayout.tsx
@@ -24,7 +24,7 @@ export const ChatInterfaceLayout: React.FC<ChatInterfaceLayoutProps> = ({
   const { scrollRef, handleScroll } = useAutoScroll(chatContent);
 
   const chatPane = (
-    <div className={`flex flex-col h-full px-4 ${className}`}>
+    <div className={`flex flex-col h-full px-4 pb-4 ${className}`}>
       {/* Chat Header - sticky at top, not scrollable */}
       <div className="flex-shrink-0 sticky top-0 z-10">{chatHeader}</div>
 

--- a/ayunis-core-frontend/src/pages/admin-settings/integrations-settings/ui/integration-card.tsx
+++ b/ayunis-core-frontend/src/pages/admin-settings/integrations-settings/ui/integration-card.tsx
@@ -100,7 +100,7 @@ export function IntegrationCard({
             </DropdownMenuItem>
             <DropdownMenuItem
               onClick={() => onDelete(integration)}
-              className="text-red-600"
+              variant="destructive"
             >
               {t('integrations.card.delete')}
             </DropdownMenuItem>

--- a/ayunis-core-frontend/src/pages/admin-settings/letterheads-settings/ui/LetterheadsSettingsPage.tsx
+++ b/ayunis-core-frontend/src/pages/admin-settings/letterheads-settings/ui/LetterheadsSettingsPage.tsx
@@ -87,12 +87,13 @@ export function LetterheadsSettingsPage() {
                 <Button
                   variant="ghost"
                   size="icon"
+                  className="text-destructive hover:text-destructive"
                   onClick={(e) => {
                     e.stopPropagation();
                     setDeleteTarget(lh);
                   }}
                 >
-                  <Trash2 className="h-4 w-4" />
+                  <Trash2 />
                 </Button>
                 <Link
                   to="/admin-settings/letterheads/$id"

--- a/ayunis-core-frontend/src/pages/admin-settings/team-detail/ui/TeamMembersList.tsx
+++ b/ayunis-core-frontend/src/pages/admin-settings/team-detail/ui/TeamMembersList.tsx
@@ -51,10 +51,11 @@ export function TeamMembersList({
               <Button
                 variant="ghost"
                 size="icon"
+                className="text-destructive hover:text-destructive"
                 onClick={() => removeTeamMember(member.userId)}
                 disabled={removingUserIds.has(member.userId)}
               >
-                <Trash2 className="h-4 w-4" />
+                <Trash2 />
               </Button>
             </TableCell>
           </TableRow>

--- a/ayunis-core-frontend/src/pages/admin-settings/teams-settings/ui/TeamsList.tsx
+++ b/ayunis-core-frontend/src/pages/admin-settings/teams-settings/ui/TeamsList.tsx
@@ -69,13 +69,14 @@ export function TeamsList({ teams, onEditTeam }: Readonly<TeamsListProps>) {
             <Button
               variant="ghost"
               size="icon"
+              className="text-destructive hover:text-destructive"
               onClick={(e) => {
                 e.stopPropagation();
                 deleteTeam(team.id);
               }}
               disabled={isDeleting}
             >
-              <Trash2 className="h-4 w-4" />
+              <Trash2 />
             </Button>
             <Link
               to="/admin-settings/teams/$id"

--- a/ayunis-core-frontend/src/pages/admin-settings/users-settings/ui/BulkInviteDialog.tsx
+++ b/ayunis-core-frontend/src/pages/admin-settings/users-settings/ui/BulkInviteDialog.tsx
@@ -291,7 +291,7 @@ export default function BulkInviteDialog({
           size="sm"
           onClick={handleDownloadTemplate}
         >
-          <Download className="mr-2 h-4 w-4" />
+          <Download />
           {t('bulkInvite.downloadTemplate')}
         </Button>
       </div>

--- a/ayunis-core-frontend/src/pages/admin-settings/users-settings/ui/BulkInviteResultsContent.tsx
+++ b/ayunis-core-frontend/src/pages/admin-settings/users-settings/ui/BulkInviteResultsContent.tsx
@@ -72,7 +72,7 @@ export default function BulkInviteResultsContent({
       <DialogFooter>
         {hasUrls && (
           <Button type="button" variant="outline" onClick={onDownloadUrls}>
-            <Download className="mr-2 h-4 w-4" />
+            <Download />
             {t('bulkInvite.downloadUrls')}
           </Button>
         )}

--- a/ayunis-core-frontend/src/pages/admin-settings/users-settings/ui/InviteMenuButton.tsx
+++ b/ayunis-core-frontend/src/pages/admin-settings/users-settings/ui/InviteMenuButton.tsx
@@ -27,11 +27,11 @@ export default function InviteMenuButton() {
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end">
           <DropdownMenuItem onClick={() => setSingleInviteOpen(true)}>
-            <UserPlus className="mr-2 h-4 w-4" />
+            <UserPlus />
             {t('inviteMenu.inviteOne')}
           </DropdownMenuItem>
           <DropdownMenuItem onClick={() => setBulkInviteOpen(true)}>
-            <Users className="mr-2 h-4 w-4" />
+            <Users />
             {t('inviteMenu.inviteMany')}
           </DropdownMenuItem>
         </DropdownMenuContent>

--- a/ayunis-core-frontend/src/pages/admin-settings/users-settings/ui/InvitesSection.tsx
+++ b/ayunis-core-frontend/src/pages/admin-settings/users-settings/ui/InvitesSection.tsx
@@ -92,7 +92,7 @@ export default function InvitesSection({
             onClick={handleDeleteAllInvites}
             disabled={isDeleting || isDeletingInvite || totalInvites === 0}
           >
-            <Trash2 className="h-4 w-4" />
+            <Trash2 />
             {t('users.deleteAll')}
           </Button>
         </CardAction>
@@ -157,16 +157,16 @@ export default function InvitesSection({
                             onClick={() => handleResendInvite(invite)}
                             disabled={isResending}
                           >
-                            <RefreshCw className="mr-2 h-4 w-4" />
+                            <RefreshCw />
                             {t('users.resend')}
                           </DropdownMenuItem>
                         )}
                         <DropdownMenuItem
-                          className="text-red-600"
+                          variant="destructive"
                           onClick={() => handleDeleteInvite(invite)}
                           disabled={isDeletingInvite}
                         >
-                          <Trash2 className="mr-2 h-4 w-4" />
+                          <Trash2 />
                           {t('users.delete')}
                         </DropdownMenuItem>
                       </DropdownMenuContent>

--- a/ayunis-core-frontend/src/pages/admin-settings/users-settings/ui/UsersSection.tsx
+++ b/ayunis-core-frontend/src/pages/admin-settings/users-settings/ui/UsersSection.tsx
@@ -169,14 +169,14 @@ export default function UsersSection({
                     </DropdownMenuTrigger>
                     <DropdownMenuContent align="end">
                       <DropdownMenuItem disabled>
-                        <Edit className="mr-2 h-4 w-4" />
+                        <Edit />
                         {t('users.edit')}
                       </DropdownMenuItem>
                       <DropdownMenuItem
                         onClick={() => handleRoleToggle(user)}
                         disabled={isUserLoading(user.id)}
                       >
-                        <UserCheck className="mr-2 h-4 w-4" />
+                        <UserCheck />
                         {t('users.changeRole', {
                           role:
                             user.role === 'admin'
@@ -188,15 +188,15 @@ export default function UsersSection({
                         onClick={() => handleTriggerPasswordReset(user)}
                         disabled={isUserLoading(user.id)}
                       >
-                        <Mail className="mr-2 h-4 w-4" />
+                        <Mail />
                         {t('users.sendPasswordReset')}
                       </DropdownMenuItem>
                       <DropdownMenuItem
-                        className="text-red-600"
+                        variant="destructive"
                         onClick={() => handleDeleteUser(user)}
                         disabled={isUserLoading(user.id)}
                       >
-                        <Trash2 className="mr-2 h-4 w-4" />
+                        <Trash2 />
                         {t('users.delete')}
                       </DropdownMenuItem>
                     </DropdownMenuContent>

--- a/ayunis-core-frontend/src/pages/agents/ui/AgentCard.tsx
+++ b/ayunis-core-frontend/src/pages/agents/ui/AgentCard.tsx
@@ -73,6 +73,7 @@ export default function AgentCard({ agent }: Readonly<AgentCardProps>) {
         <Button
           variant="ghost"
           size="icon"
+          className="text-destructive hover:text-destructive"
           onClick={(e) => {
             e.stopPropagation();
             if (agent.isShared) return null;
@@ -80,7 +81,7 @@ export default function AgentCard({ agent }: Readonly<AgentCardProps>) {
           }}
           disabled={deleteAgent.isPending || agent.isShared}
         >
-          <Trash2 className="h-4 w-4" />
+          <Trash2 />
         </Button>
       </ItemActions>
     </Item>

--- a/ayunis-core-frontend/src/pages/chat/ui/ChatHeader.tsx
+++ b/ayunis-core-frontend/src/pages/chat/ui/ChatHeader.tsx
@@ -79,7 +79,7 @@ export default function ChatHeader({
                 <span>{t('chat.renameThread')}</span>
               </DropdownMenuItem>
               <DropdownMenuItem onClick={onDelete} variant="destructive">
-                <Trash2 className="h-4 w-4" />
+                <Trash2 />
                 <span>{t('chat.deleteThread')}</span>
               </DropdownMenuItem>
             </DropdownMenuContent>

--- a/ayunis-core-frontend/src/pages/chats/ui/ChatCard.tsx
+++ b/ayunis-core-frontend/src/pages/chats/ui/ChatCard.tsx
@@ -71,10 +71,11 @@ export default function ChatCard({ chat }: Readonly<ChatCardProps>) {
         <Button
           variant="ghost"
           size="icon"
+          className="text-destructive hover:text-destructive"
           onClick={handleDelete}
           disabled={isDeleting}
         >
-          <Trash2 className="h-4 w-4" />
+          <Trash2 />
         </Button>
       </ItemActions>
     </Item>

--- a/ayunis-core-frontend/src/pages/chats/ui/ChatsEmptyState.tsx
+++ b/ayunis-core-frontend/src/pages/chats/ui/ChatsEmptyState.tsx
@@ -29,7 +29,7 @@ export default function ChatsEmptyState({
       action={
         <Button asChild>
           <Link to="/chat">
-            <MessageCircle className="mr-2 h-4 w-4" />
+            <MessageCircle />
             {t('emptyState.startChat')}
           </Link>
         </Button>

--- a/ayunis-core-frontend/src/pages/knowledge-base/ui/KnowledgeBaseDocumentsCard.tsx
+++ b/ayunis-core-frontend/src/pages/knowledge-base/ui/KnowledgeBaseDocumentsCard.tsx
@@ -157,7 +157,7 @@ export default function KnowledgeBaseDocumentsCard({
                 {isAddingUrl ? (
                   <Loader2 className="mr-2 h-4 w-4 animate-spin" />
                 ) : (
-                  <Globe className="mr-2 h-4 w-4" />
+                  <Globe />
                 )}
                 {t('detail.documents.addUrl')}
               </Button>
@@ -170,7 +170,7 @@ export default function KnowledgeBaseDocumentsCard({
                 {isUploading ? (
                   <Loader2 className="mr-2 h-4 w-4 animate-spin" />
                 ) : (
-                  <Upload className="mr-2 h-4 w-4" />
+                  <Upload />
                 )}
                 {t('detail.documents.upload')}
               </Button>

--- a/ayunis-core-frontend/src/pages/knowledge-base/ui/KnowledgeBasePage.tsx
+++ b/ayunis-core-frontend/src/pages/knowledge-base/ui/KnowledgeBasePage.tsx
@@ -113,11 +113,12 @@ export function KnowledgeBasePage({
                     <Button
                       variant="ghost"
                       size="icon"
+                      className="text-destructive hover:text-destructive"
                       onClick={handleDelete}
                       disabled={deleteKnowledgeBase.isPending}
                       aria-label={t('detail.deleteLabel')}
                     >
-                      <Trash2 className="h-4 w-4" />
+                      <Trash2 />
                     </Button>
                   </TooltipTrigger>
                   <TooltipContent>{t('detail.deleteLabel')}</TooltipContent>

--- a/ayunis-core-frontend/src/pages/knowledge-bases/ui/KnowledgeBaseCard.tsx
+++ b/ayunis-core-frontend/src/pages/knowledge-bases/ui/KnowledgeBaseCard.tsx
@@ -72,13 +72,14 @@ export default function KnowledgeBaseCard({
           <Button
             variant="ghost"
             size="icon"
+            className="text-destructive hover:text-destructive"
             onClick={(e) => {
               e.stopPropagation();
               handleDelete();
             }}
             disabled={deleteKnowledgeBase.isPending}
           >
-            <Trash2 className="h-4 w-4" />
+            <Trash2 />
           </Button>
         </ItemActions>
       )}

--- a/ayunis-core-frontend/src/pages/skill/ui/SkillPage.tsx
+++ b/ayunis-core-frontend/src/pages/skill/ui/SkillPage.tsx
@@ -154,11 +154,12 @@ export function SkillPage({
                       <Button
                         variant="ghost"
                         size="icon"
+                        className="text-destructive hover:text-destructive"
                         onClick={handleDelete}
                         disabled={deleteSkill.isPending}
                         aria-label={tSkills('card.deleteLabel')}
                       >
-                        <Trash2 className="h-4 w-4" />
+                        <Trash2 />
                       </Button>
                     </TooltipTrigger>
                     <TooltipContent>

--- a/ayunis-core-frontend/src/pages/skills/ui/SkillCard.tsx
+++ b/ayunis-core-frontend/src/pages/skills/ui/SkillCard.tsx
@@ -121,6 +121,7 @@ export default function SkillCard({ skill }: Readonly<SkillCardProps>) {
               <Button
                 variant="ghost"
                 size="icon"
+                className="text-destructive hover:text-destructive"
                 onClick={(e) => {
                   e.stopPropagation();
                   handleDelete();
@@ -128,7 +129,7 @@ export default function SkillCard({ skill }: Readonly<SkillCardProps>) {
                 disabled={deleteSkill.isPending}
                 aria-label={t('card.deleteLabel')}
               >
-                <Trash2 className="h-4 w-4" />
+                <Trash2 />
               </Button>
             </TooltipTrigger>
             <TooltipContent>{t('card.deleteLabel')}</TooltipContent>

--- a/ayunis-core-frontend/src/pages/super-admin-settings/org/ui/SubscriptionStartDateField.tsx
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/org/ui/SubscriptionStartDateField.tsx
@@ -45,7 +45,7 @@ export default function SubscriptionStartDateField({
                   variant="outline"
                   className={cn('w-full justify-start font-normal')}
                 >
-                  <CalendarIcon className="mr-2 h-4 w-4" />
+                  <CalendarIcon />
                   {utcDateToLocal(field.value).toLocaleDateString()}
                 </Button>
               </FormControl>

--- a/ayunis-core-frontend/src/pages/super-admin-settings/org/ui/UsersTable.tsx
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/org/ui/UsersTable.tsx
@@ -171,15 +171,15 @@ export default function UsersTable({
                             onClick={() => handleTriggerPasswordReset(user)}
                             disabled={isLoading}
                           >
-                            <Mail className="mr-2 h-4 w-4" />
+                            <Mail />
                             {t('table.sendPasswordReset')}
                           </DropdownMenuItem>
                           <DropdownMenuItem
-                            className="text-destructive"
+                            variant="destructive"
                             onClick={() => handleDeleteUser(user)}
                             disabled={isLoading}
                           >
-                            <Trash2 className="mr-2 h-4 w-4" />
+                            <Trash2 />
                             {t('table.delete')}
                           </DropdownMenuItem>
                         </DropdownMenuContent>

--- a/ayunis-core-frontend/src/widgets/app-sidebar/ui/ChatsSidebarGroup.tsx
+++ b/ayunis-core-frontend/src/widgets/app-sidebar/ui/ChatsSidebarGroup.tsx
@@ -219,7 +219,7 @@ export function ChatsSidebarGroup() {
                         </SidebarMenuAction>
                       </DropdownMenuTrigger>
                       <DropdownMenuContent
-                        className="w-48 rounded-lg"
+                        className="rounded-lg"
                         side="bottom"
                         align="end"
                         data-testid="chat-dropdown"
@@ -230,14 +230,15 @@ export function ChatsSidebarGroup() {
                           }
                           data-testid="rename"
                         >
-                          <Pencil className="h-4 w-4" />
+                          <Pencil />
                           <span>{t('sidebar.renameChat')}</span>
                         </DropdownMenuItem>
                         <DropdownMenuItem
+                          variant="destructive"
                           onClick={() => handleDeleteClick(thread.id)}
                           data-testid="delete"
                         >
-                          <Trash className="text-destructive" />
+                          <Trash />
                           <span>{t('sidebar.deleteChat')}</span>
                         </DropdownMenuItem>
                       </DropdownMenuContent>

--- a/ayunis-core-frontend/src/widgets/billing/ui/CreateSubscriptionDialog.tsx
+++ b/ayunis-core-frontend/src/widgets/billing/ui/CreateSubscriptionDialog.tsx
@@ -377,7 +377,7 @@ function StartDateField({
                         !field.value && 'text-muted-foreground',
                       )}
                     >
-                      <CalendarIcon className="mr-2 h-4 w-4" />
+                      <CalendarIcon />
                       {selectedDate
                         ? selectedDate.toLocaleDateString()
                         : t('subscriptionDialog.startsAtPlaceholder')}

--- a/ayunis-core-frontend/src/widgets/chat-input/ui/AgentButton.tsx
+++ b/ayunis-core-frontend/src/widgets/chat-input/ui/AgentButton.tsx
@@ -121,7 +121,7 @@ export default function AgentButton({
           <DropdownMenuSeparator />
           <DropdownMenuLabel>{t('chatInput.tools.title')}</DropdownMenuLabel>
           <DropdownMenuGroup>
-            <DropdownMenuItem className="flex items-center justify-between">
+            <DropdownMenuItem className="justify-between">
               {t('chatInput.tools.internet_search')}
               <Tooltip>
                 <TooltipTrigger asChild>
@@ -134,7 +134,7 @@ export default function AgentButton({
                 </TooltipContent>
               </Tooltip>
             </DropdownMenuItem>
-            <DropdownMenuItem className="flex items-center justify-between">
+            <DropdownMenuItem className="justify-between">
               {t('chatInput.tools.send_email')}
               <Tooltip>
                 <TooltipTrigger asChild>

--- a/ayunis-core-frontend/src/widgets/shares-tab/ui/SharesEmptyState.tsx
+++ b/ayunis-core-frontend/src/widgets/shares-tab/ui/SharesEmptyState.tsx
@@ -20,7 +20,7 @@ export default function SharesEmptyState({
       description={t('shares.empty.description')}
       action={
         <Button onClick={onCreateClick}>
-          <Share2 className="mr-2 h-4 w-4" />
+          <Share2 />
           {t('shares.empty.button')}
         </Button>
       }


### PR DESCRIPTION
- Replace manual text-red-600/text-destructive on dropdown items with
  variant="destructive" for proper hover treatment
- Apply text-destructive ghost styling to all delete icon buttons for
  visual consistency across cards/lists
- Remove redundant mr-2 h-4 w-4 from icons inside Button and
  DropdownMenuItem (both already provide gap and auto-size svgs)
- Add bottom padding to active chat layout so chat input doesn't sit
  flush against the viewport edge