### PR TITLE
feat(uploads): enforce source and file-size limits for chats, skills, and KBs (AYC-74)

### DIFF
--- a/ayunis-core-backend/src/domain/knowledge-bases/application/knowledge-bases.errors.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/application/knowledge-bases.errors.ts
@@ -6,6 +6,7 @@ export enum KnowledgeBaseErrorCode {
   UNEXPECTED_KNOWLEDGE_BASE_ERROR = 'UNEXPECTED_KNOWLEDGE_BASE_ERROR',
   DOCUMENT_NOT_IN_KNOWLEDGE_BASE = 'DOCUMENT_NOT_IN_KNOWLEDGE_BASE',
   MISSING_FILE = 'MISSING_FILE',
+  SOURCE_LIMIT_EXCEEDED = 'SOURCE_LIMIT_EXCEEDED',
 }
 
 export abstract class KnowledgeBaseError extends ApplicationError {
@@ -52,6 +53,17 @@ export class DocumentNotInKnowledgeBaseError extends KnowledgeBaseError {
       KnowledgeBaseErrorCode.DOCUMENT_NOT_IN_KNOWLEDGE_BASE,
       404,
       metadata,
+    );
+  }
+}
+
+export class KnowledgeBaseSourceLimitExceededError extends KnowledgeBaseError {
+  constructor(limit: number, metadata?: ErrorMetadata) {
+    super(
+      `Cannot add more than ${limit} documents to a knowledge base`,
+      KnowledgeBaseErrorCode.SOURCE_LIMIT_EXCEEDED,
+      409,
+      { limit, ...metadata },
     );
   }
 }

--- a/ayunis-core-backend/src/domain/knowledge-bases/application/ports/knowledge-base.repository.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/application/ports/knowledge-base.repository.ts
@@ -15,6 +15,9 @@ export abstract class KnowledgeBaseRepository {
   abstract findSourcesByKnowledgeBaseId(
     knowledgeBaseId: UUID,
   ): Promise<Source[]>;
+  abstract countSourcesByKnowledgeBaseId(
+    knowledgeBaseId: UUID,
+  ): Promise<number>;
   abstract findSourceByIdAndKnowledgeBaseId(
     sourceId: UUID,
     knowledgeBaseId: UUID,

--- a/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/add-document-to-knowledge-base/add-document-to-knowledge-base.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/add-document-to-knowledge-base/add-document-to-knowledge-base.use-case.spec.ts
@@ -44,6 +44,7 @@ describe('AddDocumentToKnowledgeBaseUseCase', () => {
       assignSourceToKnowledgeBase: jest.fn(),
       findSourcesByKnowledgeBaseId: jest.fn(),
       findSourceByIdAndKnowledgeBaseId: jest.fn(),
+      countSourcesByKnowledgeBaseId: jest.fn(),
     } as jest.Mocked<KnowledgeBaseRepository>;
 
     mockStartDocumentProcessingUseCase = {

--- a/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/add-document-to-knowledge-base/add-document-to-knowledge-base.use-case.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/add-document-to-knowledge-base/add-document-to-knowledge-base.use-case.ts
@@ -8,8 +8,10 @@ import { StartDocumentProcessingCommand } from 'src/domain/sources/application/u
 import { KnowledgeBaseRepository } from '../../ports/knowledge-base.repository';
 import {
   KnowledgeBaseNotFoundError,
+  KnowledgeBaseSourceLimitExceededError,
   UnexpectedKnowledgeBaseError,
 } from '../../knowledge-bases.errors';
+import { KnowledgeBasesConstants } from '../../../domain/knowledge-bases.constants';
 import { AddDocumentToKnowledgeBaseCommand } from './add-document-to-knowledge-base.command';
 
 @Injectable()
@@ -31,13 +33,23 @@ export class AddDocumentToKnowledgeBaseUseCase {
     });
 
     try {
-      // 1. Validate KB exists and belongs to user (in transaction)
+      // 1. Validate KB exists and belongs to user, enforce source limit
       await this.txHost.withTransaction(async () => {
         const knowledgeBase = await this.knowledgeBaseRepository.findById(
           command.knowledgeBaseId,
         );
         if (knowledgeBase?.userId !== command.userId) {
           throw new KnowledgeBaseNotFoundError(command.knowledgeBaseId);
+        }
+
+        const sourceCount =
+          await this.knowledgeBaseRepository.countSourcesByKnowledgeBaseId(
+            command.knowledgeBaseId,
+          );
+        if (sourceCount >= KnowledgeBasesConstants.MAX_SOURCES) {
+          throw new KnowledgeBaseSourceLimitExceededError(
+            KnowledgeBasesConstants.MAX_SOURCES,
+          );
         }
       });
 

--- a/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/add-url-to-knowledge-base/add-url-to-knowledge-base.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/add-url-to-knowledge-base/add-url-to-knowledge-base.use-case.spec.ts
@@ -39,6 +39,7 @@ describe('AddUrlToKnowledgeBaseUseCase', () => {
       assignSourceToKnowledgeBase: jest.fn(),
       findSourcesByKnowledgeBaseId: jest.fn(),
       findSourceByIdAndKnowledgeBaseId: jest.fn(),
+      countSourcesByKnowledgeBaseId: jest.fn(),
     } as jest.Mocked<KnowledgeBaseRepository>;
 
     mockCreateTextSourceUseCase = {

--- a/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/add-url-to-knowledge-base/add-url-to-knowledge-base.use-case.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/add-url-to-knowledge-base/add-url-to-knowledge-base.use-case.ts
@@ -7,8 +7,10 @@ import { ApplicationError } from 'src/common/errors/base.error';
 import { KnowledgeBaseRepository } from '../../ports/knowledge-base.repository';
 import {
   KnowledgeBaseNotFoundError,
+  KnowledgeBaseSourceLimitExceededError,
   UnexpectedKnowledgeBaseError,
 } from '../../knowledge-bases.errors';
+import { KnowledgeBasesConstants } from '../../../domain/knowledge-bases.constants';
 import { AddUrlToKnowledgeBaseCommand } from './add-url-to-knowledge-base.command';
 
 @Injectable()
@@ -33,6 +35,16 @@ export class AddUrlToKnowledgeBaseUseCase {
       );
       if (knowledgeBase?.userId !== command.userId) {
         throw new KnowledgeBaseNotFoundError(command.knowledgeBaseId);
+      }
+
+      const sourceCount =
+        await this.knowledgeBaseRepository.countSourcesByKnowledgeBaseId(
+          command.knowledgeBaseId,
+        );
+      if (sourceCount >= KnowledgeBasesConstants.MAX_SOURCES) {
+        throw new KnowledgeBaseSourceLimitExceededError(
+          KnowledgeBasesConstants.MAX_SOURCES,
+        );
       }
 
       const source = await this.createTextSourceUseCase.execute(

--- a/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/create-knowledge-base/create-knowledge-base.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/create-knowledge-base/create-knowledge-base.use-case.spec.ts
@@ -24,6 +24,7 @@ describe('CreateKnowledgeBaseUseCase', () => {
       assignSourceToKnowledgeBase: jest.fn(),
       findSourcesByKnowledgeBaseId: jest.fn(),
       findSourceByIdAndKnowledgeBaseId: jest.fn(),
+      countSourcesByKnowledgeBaseId: jest.fn(),
     } as jest.Mocked<KnowledgeBaseRepository>;
 
     const module: TestingModule = await Test.createTestingModule({

--- a/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/delete-knowledge-base/delete-knowledge-base.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/delete-knowledge-base/delete-knowledge-base.use-case.spec.ts
@@ -46,6 +46,7 @@ describe('DeleteKnowledgeBaseUseCase', () => {
       assignSourceToKnowledgeBase: jest.fn(),
       findSourcesByKnowledgeBaseId: jest.fn(),
       findSourceByIdAndKnowledgeBaseId: jest.fn(),
+      countSourcesByKnowledgeBaseId: jest.fn(),
     } as jest.Mocked<KnowledgeBaseRepository>;
 
     mockGetSourcesByKbId = {

--- a/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/find-knowledge-base/find-knowledge-base.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/find-knowledge-base/find-knowledge-base.use-case.spec.ts
@@ -28,6 +28,7 @@ describe('FindKnowledgeBaseUseCase', () => {
       assignSourceToKnowledgeBase: jest.fn(),
       findSourcesByKnowledgeBaseId: jest.fn(),
       findSourceByIdAndKnowledgeBaseId: jest.fn(),
+      countSourcesByKnowledgeBaseId: jest.fn(),
     } as jest.Mocked<KnowledgeBaseRepository>;
 
     const module: TestingModule = await Test.createTestingModule({

--- a/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/get-knowledge-base-document-text/get-knowledge-base-document-text.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/get-knowledge-base-document-text/get-knowledge-base-document-text.use-case.spec.ts
@@ -27,6 +27,7 @@ describe('GetKnowledgeBaseDocumentTextUseCase', () => {
     mockRepository = {
       findById: jest.fn(),
       findSourceByIdAndKnowledgeBaseId: jest.fn(),
+      countSourcesByKnowledgeBaseId: jest.fn(),
     } as unknown as jest.Mocked<KnowledgeBaseRepository>;
 
     mockAccessService = {

--- a/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/list-knowledge-base-documents/list-knowledge-base-documents.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/list-knowledge-base-documents/list-knowledge-base-documents.use-case.spec.ts
@@ -27,6 +27,7 @@ describe('ListKnowledgeBaseDocumentsUseCase', () => {
       assignSourceToKnowledgeBase: jest.fn(),
       findSourcesByKnowledgeBaseId: jest.fn(),
       findSourceByIdAndKnowledgeBaseId: jest.fn(),
+      countSourcesByKnowledgeBaseId: jest.fn(),
     } as jest.Mocked<KnowledgeBaseRepository>;
 
     const module: TestingModule = await Test.createTestingModule({

--- a/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/list-knowledge-bases/list-knowledge-bases.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/list-knowledge-bases/list-knowledge-bases.use-case.spec.ts
@@ -24,6 +24,7 @@ describe('ListKnowledgeBasesUseCase', () => {
       assignSourceToKnowledgeBase: jest.fn(),
       findSourcesByKnowledgeBaseId: jest.fn(),
       findSourceByIdAndKnowledgeBaseId: jest.fn(),
+      countSourcesByKnowledgeBaseId: jest.fn(),
     } as jest.Mocked<KnowledgeBaseRepository>;
 
     const module: TestingModule = await Test.createTestingModule({

--- a/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/query-knowledge-base/query-knowledge-base.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/query-knowledge-base/query-knowledge-base.use-case.spec.ts
@@ -42,6 +42,7 @@ describe('QueryKnowledgeBaseUseCase', () => {
       assignSourceToKnowledgeBase: jest.fn(),
       findSourcesByKnowledgeBaseId: jest.fn(),
       findSourceByIdAndKnowledgeBaseId: jest.fn(),
+      countSourcesByKnowledgeBaseId: jest.fn(),
     } as jest.Mocked<KnowledgeBaseRepository>;
 
     mockFindChunks = {

--- a/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/remove-document-from-knowledge-base/remove-document-from-knowledge-base.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/remove-document-from-knowledge-base/remove-document-from-knowledge-base.use-case.spec.ts
@@ -40,6 +40,7 @@ describe('RemoveDocumentFromKnowledgeBaseUseCase', () => {
       assignSourceToKnowledgeBase: jest.fn(),
       findSourcesByKnowledgeBaseId: jest.fn(),
       findSourceByIdAndKnowledgeBaseId: jest.fn(),
+      countSourcesByKnowledgeBaseId: jest.fn(),
     } as jest.Mocked<KnowledgeBaseRepository>;
 
     mockDeleteSourceUseCase = {

--- a/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/update-knowledge-base/update-knowledge-base.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/update-knowledge-base/update-knowledge-base.use-case.spec.ts
@@ -37,6 +37,7 @@ describe('UpdateKnowledgeBaseUseCase', () => {
       assignSourceToKnowledgeBase: jest.fn(),
       findSourcesByKnowledgeBaseId: jest.fn(),
       findSourceByIdAndKnowledgeBaseId: jest.fn(),
+      countSourcesByKnowledgeBaseId: jest.fn(),
     } as jest.Mocked<KnowledgeBaseRepository>;
 
     const module: TestingModule = await Test.createTestingModule({

--- a/ayunis-core-backend/src/domain/knowledge-bases/domain/knowledge-bases.constants.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/domain/knowledge-bases.constants.ts
@@ -1,0 +1,4 @@
+export const KnowledgeBasesConstants = {
+  MAX_SOURCES: 500,
+  MAX_FILE_SIZE_BYTES: 25 * 1024 * 1024,
+} as const;

--- a/ayunis-core-backend/src/domain/knowledge-bases/infrastructure/persistence/local/local-knowledge-base.repository.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/infrastructure/persistence/local/local-knowledge-base.repository.ts
@@ -86,6 +86,11 @@ export class LocalKnowledgeBaseRepository extends KnowledgeBaseRepository {
     return records.map((record) => this.sourceMapper.toDomain(record));
   }
 
+  async countSourcesByKnowledgeBaseId(knowledgeBaseId: UUID): Promise<number> {
+    this.logger.debug(`countSourcesByKnowledgeBaseId: ${knowledgeBaseId}`);
+    return this.sourceRepository.count({ where: { knowledgeBaseId } });
+  }
+
   async findSourceByIdAndKnowledgeBaseId(
     sourceId: UUID,
     knowledgeBaseId: UUID,

--- a/ayunis-core-backend/src/domain/knowledge-bases/presenters/http/knowledge-bases.controller.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/presenters/http/knowledge-bases.controller.ts
@@ -70,6 +70,7 @@ import {
   KnowledgeBaseDocumentListResponseDto,
 } from './dto/knowledge-base-document-response.dto';
 import { MissingFileError } from '../../application/knowledge-bases.errors';
+import { KnowledgeBasesConstants } from '../../domain/knowledge-bases.constants';
 import { KnowledgeBaseDtoMapper } from './mappers/knowledge-base-dto.mapper';
 import { RequireFeature } from 'src/common/guards/feature.guard';
 import { FeatureFlag } from 'src/config/features.config';
@@ -279,7 +280,7 @@ export class KnowledgeBasesController {
         file: {
           type: 'string',
           format: 'binary',
-          description: 'The file to upload (PDF, DOCX, PPTX, TXT)',
+          description: 'The file to upload (PDF, DOCX, PPTX, TXT, max 25 MB)',
         },
       },
       required: ['file'],
@@ -293,6 +294,10 @@ export class KnowledgeBasesController {
     type: KnowledgeBaseDocumentResponseDto,
   })
   @ApiResponse({ status: 404, description: 'Knowledge base not found' })
+  @ApiResponse({
+    status: 413,
+    description: 'File exceeds the 25 MB upload limit',
+  })
   /* eslint-disable sonarjs/content-length -- multer file size limit, not HTTP Content-Length */
   @UseInterceptors(
     FileInterceptor('file', {
@@ -303,7 +308,7 @@ export class KnowledgeBasesController {
           cb(null, `${randomName}${extname(file.originalname)}`);
         },
       }),
-      limits: { fileSize: 50 * 1024 * 1024 }, // 50 MB
+      limits: { fileSize: KnowledgeBasesConstants.MAX_FILE_SIZE_BYTES },
     }),
   )
   /* eslint-enable sonarjs/content-length */

--- a/ayunis-core-backend/src/domain/skills/application/skills.errors.ts
+++ b/ayunis-core-backend/src/domain/skills/application/skills.errors.ts
@@ -6,6 +6,7 @@ export enum SkillErrorCode {
   SKILL_INVALID_INPUT = 'SKILL_INVALID_INPUT',
   DUPLICATE_SKILL_NAME = 'DUPLICATE_SKILL_NAME',
   SOURCE_ALREADY_ASSIGNED = 'SOURCE_ALREADY_ASSIGNED',
+  SOURCE_LIMIT_EXCEEDED = 'SOURCE_LIMIT_EXCEEDED',
   MCP_INTEGRATION_NOT_FOUND = 'MCP_INTEGRATION_NOT_FOUND',
   MCP_INTEGRATION_ALREADY_ASSIGNED = 'MCP_INTEGRATION_ALREADY_ASSIGNED',
   MCP_INTEGRATION_DISABLED = 'MCP_INTEGRATION_DISABLED',
@@ -74,6 +75,17 @@ export class SkillSourceAlreadyAssignedError extends SkillError {
       SkillErrorCode.SOURCE_ALREADY_ASSIGNED,
       409,
       metadata,
+    );
+  }
+}
+
+export class SkillSourceLimitExceededError extends SkillError {
+  constructor(limit: number, metadata?: ErrorMetadata) {
+    super(
+      `Cannot add more than ${limit} sources to a skill`,
+      SkillErrorCode.SOURCE_LIMIT_EXCEEDED,
+      409,
+      { limit, ...metadata },
     );
   }
 }

--- a/ayunis-core-backend/src/domain/skills/application/use-cases/add-source-to-skill/add-source-to-skill.use-case.ts
+++ b/ayunis-core-backend/src/domain/skills/application/use-cases/add-source-to-skill/add-source-to-skill.use-case.ts
@@ -6,9 +6,11 @@ import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.e
 import {
   SkillNotFoundError,
   SkillSourceAlreadyAssignedError,
+  SkillSourceLimitExceededError,
   UnexpectedSkillError,
 } from '../../skills.errors';
 import { Skill } from '../../../domain/skill.entity';
+import { SkillsConstants } from '../../../domain/skills.constants';
 import { ApplicationError } from 'src/common/errors/base.error';
 
 @Injectable()
@@ -38,6 +40,10 @@ export class AddSourceToSkillUseCase {
 
       if (skill.sourceIds.includes(command.sourceId)) {
         throw new SkillSourceAlreadyAssignedError(command.sourceId);
+      }
+
+      if (skill.sourceIds.length >= SkillsConstants.MAX_SOURCES) {
+        throw new SkillSourceLimitExceededError(SkillsConstants.MAX_SOURCES);
       }
 
       const updatedSkill = new Skill({

--- a/ayunis-core-backend/src/domain/skills/domain/skills.constants.ts
+++ b/ayunis-core-backend/src/domain/skills/domain/skills.constants.ts
@@ -1,0 +1,3 @@
+export const SkillsConstants = {
+  MAX_SOURCES: 20,
+} as const;

--- a/ayunis-core-backend/src/domain/threads/application/threads.errors.ts
+++ b/ayunis-core-backend/src/domain/threads/application/threads.errors.ts
@@ -7,6 +7,7 @@ export enum ThreadErrorCode {
   THREAD_CREATION_FAILED = 'THREAD_CREATION_FAILED',
   MESSAGE_ADDITION_FAILED = 'MESSAGE_ADDITION_FAILED',
   SOURCE_ALREADY_ASSIGNED = 'SOURCE_ALREADY_ASSIGNED',
+  SOURCE_LIMIT_EXCEEDED = 'SOURCE_LIMIT_EXCEEDED',
   SOURCE_ADDITION_FAILED = 'SOURCE_ADDITION_FAILED',
   SOURCE_REMOVAL_FAILED = 'SOURCE_REMOVAL_FAILED',
   SOURCE_NOT_FOUND = 'SOURCE_NOT_FOUND',
@@ -86,6 +87,17 @@ export class SourceAlreadyAssignedError extends ThreadError {
       ThreadErrorCode.SOURCE_ALREADY_ASSIGNED,
       409,
       metadata,
+    );
+  }
+}
+
+export class ThreadSourceLimitExceededError extends ThreadError {
+  constructor(limit: number, metadata?: ErrorMetadata) {
+    super(
+      `Cannot add more than ${limit} sources to a thread`,
+      ThreadErrorCode.SOURCE_LIMIT_EXCEEDED,
+      409,
+      { limit, ...metadata },
     );
   }
 }

--- a/ayunis-core-backend/src/domain/threads/application/use-cases/add-source-to-thread/add-source-to-thread.use-case.ts
+++ b/ayunis-core-backend/src/domain/threads/application/use-cases/add-source-to-thread/add-source-to-thread.use-case.ts
@@ -6,7 +6,11 @@ import { SourceAdditionError } from '../../threads.errors';
 import { SourceAssignment } from '../../../domain/thread-source-assignment.entity';
 import { ApplicationError } from 'src/common/errors/base.error';
 import { ContextService } from 'src/common/context/services/context.service';
-import { SourceAlreadyAssignedError } from '../../threads.errors';
+import {
+  SourceAlreadyAssignedError,
+  ThreadSourceLimitExceededError,
+} from '../../threads.errors';
+import { ThreadsConstants } from '../../../domain/threads.constants';
 
 @Injectable()
 export class AddSourceToThreadUseCase {
@@ -50,6 +54,10 @@ export class AddSourceToThreadUseCase {
 
       if (sourceExists) {
         throw new SourceAlreadyAssignedError(command.source.id);
+      }
+
+      if (currentAssignments.length >= ThreadsConstants.MAX_SOURCES) {
+        throw new ThreadSourceLimitExceededError(ThreadsConstants.MAX_SOURCES);
       }
 
       const sourceAssignment = new SourceAssignment({

--- a/ayunis-core-backend/src/domain/threads/domain/threads.constants.ts
+++ b/ayunis-core-backend/src/domain/threads/domain/threads.constants.ts
@@ -1,4 +1,5 @@
 export const ThreadsConstants = {
   DEFAULT_LIMIT: 50,
   MAX_LIMIT: 1000,
+  MAX_SOURCES: 20,
 } as const;

--- a/ayunis-core-frontend/src/shared/lib/handle-source-upload-error.ts
+++ b/ayunis-core-frontend/src/shared/lib/handle-source-upload-error.ts
@@ -29,6 +29,9 @@ export default function handleSourceUploadError(
       case 'TOO_MANY_PAGES':
         showError(t('sources.fileSourceTooManyPagesError'));
         break;
+      case 'SOURCE_LIMIT_EXCEEDED':
+        showError(t('sources.sourceLimitExceededError'));
+        break;
       case 'SERVICE_BUSY':
         showError(t('sources.fileSourceServiceBusyError'));
         break;

--- a/ayunis-core-frontend/src/shared/locales/de/common.json
+++ b/ayunis-core-frontend/src/shared/locales/de/common.json
@@ -113,6 +113,7 @@
     "fileSourceTooLargeError": "Datei ist zu groß. Maximale Dateigröße ist 25MB.",
     "fileSourceTooManyPagesError": "Dokument hat zu viele Seiten zur Verarbeitung.",
     "fileSourceServiceBusyError": "Der Dokumentenverarbeitungsdienst ist beschäftigt. Bitte versuchen Sie es später erneut.",
-    "fileSourceTimeoutError": "Dokumentenverarbeitung hat das Zeitlimit überschritten. Die Datei ist möglicherweise zu komplex."
+    "fileSourceTimeoutError": "Dokumentenverarbeitung hat das Zeitlimit überschritten. Die Datei ist möglicherweise zu komplex.",
+    "sourceLimitExceededError": "Ein Chat kann maximal 20 Quellen enthalten. Bitte entfernen Sie eine, bevor Sie eine weitere hinzufügen."
   }
 }

--- a/ayunis-core-frontend/src/shared/locales/de/knowledge-bases.json
+++ b/ayunis-core-frontend/src/shared/locales/de/knowledge-bases.json
@@ -166,9 +166,10 @@
     "failedToAdd": "Dokument konnte nicht hochgeladen werden. Bitte versuchen Sie es erneut.",
     "invalidFileTypeError": "Dieser Dateityp wird derzeit nicht unterstützt.",
     "fileSourceEmptyDataError": "Die hochgeladene Datei enthält keine verarbeitbaren Daten.",
-    "fileSourceTooLargeError": "Datei ist zu groß. Maximale Dateigröße beträgt 50 MB.",
+    "fileSourceTooLargeError": "Datei ist zu groß. Maximale Dateigröße beträgt 25 MB.",
     "fileSourceTooManyPagesError": "Das Dokument hat zu viele Seiten zur Verarbeitung.",
     "fileSourceServiceBusyError": "Der Dokumentenverarbeitungsdienst ist beschäftigt. Bitte versuchen Sie es später erneut.",
-    "fileSourceTimeoutError": "Dokumentenverarbeitung hat das Zeitlimit überschritten. Die Datei ist möglicherweise zu komplex."
+    "fileSourceTimeoutError": "Dokumentenverarbeitung hat das Zeitlimit überschritten. Die Datei ist möglicherweise zu komplex.",
+    "sourceLimitExceededError": "Eine Wissensdatenbank kann maximal 500 Dokumente enthalten. Bitte entfernen Sie eines, bevor Sie ein weiteres hinzufügen."
   }
 }

--- a/ayunis-core-frontend/src/shared/locales/de/skill.json
+++ b/ayunis-core-frontend/src/shared/locales/de/skill.json
@@ -117,7 +117,8 @@
     "fileSourceTooLargeError": "Datei ist zu groß. Maximale Dateigröße beträgt 25 MB.",
     "fileSourceTooManyPagesError": "Dokument hat zu viele Seiten zur Verarbeitung.",
     "fileSourceServiceBusyError": "Der Dokumentenverarbeitungsdienst ist ausgelastet. Bitte versuchen Sie es später erneut.",
-    "fileSourceTimeoutError": "Die Dokumentenverarbeitung hat das Zeitlimit überschritten. Die Datei ist möglicherweise zu komplex."
+    "fileSourceTimeoutError": "Die Dokumentenverarbeitung hat das Zeitlimit überschritten. Die Datei ist möglicherweise zu komplex.",
+    "sourceLimitExceededError": "Ein Skill kann maximal 20 Quellen enthalten. Bitte entfernen Sie eine, bevor Sie eine weitere hinzufügen."
   },
   "mcpIntegrations": {
     "title": "Integrationen",

--- a/ayunis-core-frontend/src/shared/locales/en/common.json
+++ b/ayunis-core-frontend/src/shared/locales/en/common.json
@@ -113,6 +113,7 @@
     "fileSourceTooLargeError": "File is too large. Maximum file size is 25MB.",
     "fileSourceTooManyPagesError": "Document has too many pages to process.",
     "fileSourceServiceBusyError": "The document processing service is busy. Please try again later.",
-    "fileSourceTimeoutError": "Document processing timed out. The file may be too complex."
+    "fileSourceTimeoutError": "Document processing timed out. The file may be too complex.",
+    "sourceLimitExceededError": "A chat can have at most 20 sources. Please remove one before adding another."
   }
 }

--- a/ayunis-core-frontend/src/shared/locales/en/knowledge-bases.json
+++ b/ayunis-core-frontend/src/shared/locales/en/knowledge-bases.json
@@ -166,9 +166,10 @@
     "failedToAdd": "Failed to upload document. Please try again.",
     "invalidFileTypeError": "This file type is currently not supported.",
     "fileSourceEmptyDataError": "The uploaded file contains no processable data.",
-    "fileSourceTooLargeError": "File is too large. Maximum file size is 50MB.",
+    "fileSourceTooLargeError": "File is too large. Maximum file size is 25MB.",
     "fileSourceTooManyPagesError": "Document has too many pages to process.",
     "fileSourceServiceBusyError": "The document processing service is busy. Please try again later.",
-    "fileSourceTimeoutError": "Document processing timed out. The file may be too complex."
+    "fileSourceTimeoutError": "Document processing timed out. The file may be too complex.",
+    "sourceLimitExceededError": "A knowledge base can have at most 500 documents. Please remove one before adding another."
   }
 }

--- a/ayunis-core-frontend/src/shared/locales/en/skill.json
+++ b/ayunis-core-frontend/src/shared/locales/en/skill.json
@@ -117,7 +117,8 @@
     "fileSourceTooLargeError": "File is too large. Maximum file size is 25MB.",
     "fileSourceTooManyPagesError": "Document has too many pages to process.",
     "fileSourceServiceBusyError": "The document processing service is busy. Please try again later.",
-    "fileSourceTimeoutError": "Document processing timed out. The file may be too complex."
+    "fileSourceTimeoutError": "Document processing timed out. The file may be too complex.",
+    "sourceLimitExceededError": "A skill can have at most 20 sources. Please remove one before adding another."
   },
   "mcpIntegrations": {
     "title": "Integrations",


### PR DESCRIPTION
- Threads: cap thread sources at 20; throw SOURCE_LIMIT_EXCEEDED when adding past the cap
- Skills: cap skill sources at 20 with the same SOURCE_LIMIT_EXCEEDED signal
- Knowledge bases: cap documents at 500 (file + URL) and tighten per-file upload to 25 MB
  - Add countSourcesByKnowledgeBaseId repository method to check the cap inside the add transactions
- Frontend: surface SOURCE_LIMIT_EXCEEDED with namespaced toasts (chat / skill / knowledge-base) and update KB file-size copy to 25 MB

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core add-source/add-document flows and a repository interface, so missing implementations or mismatched error handling could block uploads or source attachment. No auth or data-model migrations are introduced.
> 
> **Overview**
> **Enforces new source-count and upload-size limits across chats, skills, and knowledge bases.** Threads and skills now reject adding a source beyond 20 with a new `SOURCE_LIMIT_EXCEEDED` (409) error.
> 
> Knowledge bases now cap documents (file and URL) at 500 by counting existing sources via a new `KnowledgeBaseRepository.countSourcesByKnowledgeBaseId` method (implemented in `LocalKnowledgeBaseRepository`) and throwing `KnowledgeBaseSourceLimitExceededError` when exceeded.
> 
> KB document uploads are tightened from 50MB to **25MB** (shared `KnowledgeBasesConstants.MAX_FILE_SIZE_BYTES`), with updated Swagger docs, and the frontend surfaces the new `SOURCE_LIMIT_EXCEEDED` code plus updated 25MB copy via i18n toasts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0dfd8f9fafac721224136c5b61c7d38aa44f4dd3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->