### PR TITLE
fix(api-keys, auth): harden revoke and auth scoping (AYC-77)

### DIFF
--- a/ayunis-core-backend/src/db/migrations/1777542056607-AddApiKeyRevokedAt.ts
+++ b/ayunis-core-backend/src/db/migrations/1777542056607-AddApiKeyRevokedAt.ts
@@ -1,0 +1,15 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddApiKeyRevokedAt1777542056607 implements MigrationInterface {
+  name = 'AddApiKeyRevokedAt1777542056607';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "api_keys" ADD "revoked_at" TIMESTAMP WITH TIME ZONE`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "api_keys" DROP COLUMN "revoked_at"`);
+  }
+}

--- a/ayunis-core-backend/src/domain/models/presenters/http/openai/chat-completions.controller.ts
+++ b/ayunis-core-backend/src/domain/models/presenters/http/openai/chat-completions.controller.ts
@@ -11,6 +11,7 @@ import type { Subscription } from 'rxjs';
 import { isUUID } from 'class-validator';
 import type { UUID } from 'crypto';
 
+import { RequirePrincipalKind } from 'src/iam/authorization/application/decorators/require-principal-kind.decorator';
 import { RequireSubscription } from 'src/iam/authorization/application/decorators/subscription.decorator';
 import type { RequestWithSubscriptionContext } from 'src/iam/authorization/application/guards/subscription.guard';
 import { getPrincipal } from 'src/iam/authentication/application/util/get-principal';
@@ -39,6 +40,7 @@ const HEARTBEAT_INTERVAL_MS = 15_000;
 @ApiTags('openai-compat')
 @ApiExcludeController()
 @Controller('openai/v1/chat/completions')
+@RequirePrincipalKind('apiKey')
 @RequireSubscription()
 export class ChatCompletionsController {
   private readonly logger = new Logger(ChatCompletionsController.name);

--- a/ayunis-core-backend/src/iam/api-keys/application/api-keys.errors.ts
+++ b/ayunis-core-backend/src/iam/api-keys/application/api-keys.errors.ts
@@ -7,6 +7,7 @@ export enum ApiKeyErrorCode {
   API_KEY_EXPIRATION_IN_PAST = 'API_KEY_EXPIRATION_IN_PAST',
   API_KEY_INVALID = 'API_KEY_INVALID',
   API_KEY_EXPIRED = 'API_KEY_EXPIRED',
+  API_KEY_REVOKED = 'API_KEY_REVOKED',
   UNEXPECTED_API_KEY_ERROR = 'UNEXPECTED_API_KEY_ERROR',
 }
 
@@ -65,6 +66,17 @@ export class ApiKeyExpiredError extends ApiKeyError {
     super(
       'API key has expired',
       ApiKeyErrorCode.API_KEY_EXPIRED,
+      401,
+      metadata,
+    );
+  }
+}
+
+export class ApiKeyRevokedError extends ApiKeyError {
+  constructor(metadata?: ErrorMetadata) {
+    super(
+      'API key has been revoked',
+      ApiKeyErrorCode.API_KEY_REVOKED,
       401,
       metadata,
     );

--- a/ayunis-core-backend/src/iam/api-keys/application/ports/api-keys.repository.ts
+++ b/ayunis-core-backend/src/iam/api-keys/application/ports/api-keys.repository.ts
@@ -6,5 +6,5 @@ export abstract class ApiKeysRepository {
   abstract findByPrefix(prefix: string): Promise<ApiKey | null>;
   abstract findByOrgId(orgId: UUID): Promise<ApiKey[]>;
   abstract create(apiKey: ApiKey): Promise<ApiKey>;
-  abstract delete(id: UUID): Promise<void>;
+  abstract revoke(id: UUID): Promise<void>;
 }

--- a/ayunis-core-backend/src/iam/api-keys/application/use-cases/revoke-api-key/revoke-api-key.use-case.ts
+++ b/ayunis-core-backend/src/iam/api-keys/application/use-cases/revoke-api-key/revoke-api-key.use-case.ts
@@ -47,7 +47,18 @@ export class RevokeApiKeyUseCase {
         throw new ApiKeyNotFoundError(command.apiKeyId);
       }
 
-      await this.apiKeysRepository.delete(command.apiKeyId);
+      if (apiKey.revokedAt) {
+        // Re-revoking an already-revoked key is a no-op — preserve the
+        // original revocation timestamp for the audit trail rather than
+        // shifting it forward on each call.
+        this.logger.debug('API key already revoked', {
+          apiKeyId: command.apiKeyId,
+          revokedAt: apiKey.revokedAt,
+        });
+        return;
+      }
+
+      await this.apiKeysRepository.revoke(command.apiKeyId);
 
       this.logger.debug('API key revoked', { apiKeyId: command.apiKeyId });
     } catch (error) {

--- a/ayunis-core-backend/src/iam/api-keys/application/use-cases/validate-api-key/validate-api-key.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/api-keys/application/use-cases/validate-api-key/validate-api-key.use-case.spec.ts
@@ -7,7 +7,11 @@ import { ValidateApiKeyUseCase } from './validate-api-key.use-case';
 import { ValidateApiKeyCommand } from './validate-api-key.command';
 import { ApiKeysRepository } from '../../ports/api-keys.repository';
 import { ApiKey } from '../../../domain/api-key.entity';
-import { ApiKeyExpiredError, ApiKeyInvalidError } from '../../api-keys.errors';
+import {
+  ApiKeyExpiredError,
+  ApiKeyInvalidError,
+  ApiKeyRevokedError,
+} from '../../api-keys.errors';
 import { CompareHashUseCase } from '../../../../hashing/application/use-cases/compare-hash/compare-hash.use-case';
 
 describe('ValidateApiKeyUseCase', () => {
@@ -17,7 +21,7 @@ describe('ValidateApiKeyUseCase', () => {
     findById: jest.Mock;
     findByOrgId: jest.Mock;
     create: jest.Mock;
-    delete: jest.Mock;
+    revoke: jest.Mock;
   };
   let mockCompareHashUseCase: { execute: jest.Mock };
 
@@ -45,7 +49,7 @@ describe('ValidateApiKeyUseCase', () => {
       findById: jest.fn(),
       findByOrgId: jest.fn(),
       create: jest.fn(),
-      delete: jest.fn(),
+      revoke: jest.fn(),
     };
 
     mockCompareHashUseCase = {
@@ -63,6 +67,7 @@ describe('ValidateApiKeyUseCase', () => {
     useCase = module.get<ValidateApiKeyUseCase>(ValidateApiKeyUseCase);
 
     jest.spyOn(Logger.prototype, 'log').mockImplementation();
+    jest.spyOn(Logger.prototype, 'warn').mockImplementation();
     jest.spyOn(Logger.prototype, 'error').mockImplementation();
   });
 
@@ -111,7 +116,7 @@ describe('ValidateApiKeyUseCase', () => {
     expect(mockCompareHashUseCase.execute).toHaveBeenCalledTimes(1);
   });
 
-  it('throws ApiKeyExpiredError carrying the apiKeyId when the key is past expiration', async () => {
+  it('throws ApiKeyExpiredError without leaking apiKeyId in the public payload when the key is past expiration', async () => {
     const past = new Date(Date.now() - 60_000);
     mockApiKeysRepository.findByPrefix.mockResolvedValue(
       buildApiKey({ expiresAt: past }),
@@ -126,9 +131,22 @@ describe('ValidateApiKeyUseCase', () => {
     }
 
     expect(caught).toBeInstanceOf(ApiKeyExpiredError);
-    expect((caught as ApiKeyExpiredError).metadata).toEqual(
-      expect.objectContaining({ apiKeyId }),
+    // The use case is exported and ApplicationErrorFilter would serialize
+    // metadata into the public response body, so apiKeyId must not be on
+    // the error itself — it stays in server-side logs only.
+    expect((caught as ApiKeyExpiredError).metadata).toBeUndefined();
+  });
+
+  it('throws ApiKeyRevokedError when the key has revokedAt set', async () => {
+    const past = new Date(Date.now() - 60_000);
+    mockApiKeysRepository.findByPrefix.mockResolvedValue(
+      buildApiKey({ revokedAt: past }),
     );
+    mockCompareHashUseCase.execute.mockResolvedValue(true);
+
+    await expect(
+      useCase.execute(new ValidateApiKeyCommand(validToken)),
+    ).rejects.toThrow(ApiKeyRevokedError);
   });
 
   it('returns the api key when hash matches and there is no expiration', async () => {

--- a/ayunis-core-backend/src/iam/api-keys/application/use-cases/validate-api-key/validate-api-key.use-case.ts
+++ b/ayunis-core-backend/src/iam/api-keys/application/use-cases/validate-api-key/validate-api-key.use-case.ts
@@ -5,6 +5,7 @@ import { ValidateApiKeyCommand } from './validate-api-key.command';
 import {
   ApiKeyExpiredError,
   ApiKeyInvalidError,
+  ApiKeyRevokedError,
   UnexpectedApiKeyError,
 } from '../../api-keys.errors';
 import { ApplicationError } from 'src/common/errors/base.error';
@@ -48,8 +49,14 @@ export class ValidateApiKeyUseCase {
         throw new ApiKeyInvalidError();
       }
 
+      if (apiKey.revokedAt) {
+        this.logger.warn('API key revoked', { apiKeyId: apiKey.id });
+        throw new ApiKeyRevokedError();
+      }
+
       if (apiKey.expiresAt && apiKey.expiresAt.getTime() <= Date.now()) {
-        throw new ApiKeyExpiredError({ apiKeyId: apiKey.id });
+        this.logger.warn('API key expired', { apiKeyId: apiKey.id });
+        throw new ApiKeyExpiredError();
       }
 
       return apiKey;

--- a/ayunis-core-backend/src/iam/api-keys/domain/api-key.entity.ts
+++ b/ayunis-core-backend/src/iam/api-keys/domain/api-key.entity.ts
@@ -17,6 +17,7 @@ export class ApiKey {
   public prefix: string;
   public hash: string;
   public expiresAt: Date | null;
+  public revokedAt: Date | null;
   public orgId: UUID;
   public createdByUserId: UUID | null;
   public createdAt: Date;
@@ -28,6 +29,7 @@ export class ApiKey {
     prefix: string;
     hash: string;
     expiresAt?: Date | null;
+    revokedAt?: Date | null;
     orgId: UUID;
     createdByUserId: UUID | null;
     createdAt?: Date;
@@ -38,6 +40,7 @@ export class ApiKey {
     this.prefix = params.prefix;
     this.hash = params.hash;
     this.expiresAt = params.expiresAt ?? null;
+    this.revokedAt = params.revokedAt ?? null;
     this.orgId = params.orgId;
     this.createdByUserId = params.createdByUserId;
     this.createdAt = params.createdAt ?? new Date();

--- a/ayunis-core-backend/src/iam/api-keys/infrastructure/repositories/local/local-api-keys.repository.ts
+++ b/ayunis-core-backend/src/iam/api-keys/infrastructure/repositories/local/local-api-keys.repository.ts
@@ -1,6 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { IsNull, Repository } from 'typeorm';
 import { UUID } from 'crypto';
 import { ApiKeysRepository } from '../../../application/ports/api-keys.repository';
 import { ApiKey } from '../../../domain/api-key.entity';
@@ -42,7 +42,7 @@ export class LocalApiKeysRepository extends ApiKeysRepository {
     this.logger.log('findByOrgId', { orgId });
 
     const records = await this.apiKeyRepository.find({
-      where: { orgId },
+      where: { orgId, revokedAt: IsNull() },
       order: { createdAt: 'DESC' },
     });
     return records.map((record) => ApiKeyMapper.toDomain(record));
@@ -56,9 +56,9 @@ export class LocalApiKeysRepository extends ApiKeysRepository {
     return ApiKeyMapper.toDomain(saved);
   }
 
-  async delete(id: UUID): Promise<void> {
-    this.logger.log('delete', { id });
+  async revoke(id: UUID): Promise<void> {
+    this.logger.log('revoke', { id });
 
-    await this.apiKeyRepository.delete(id);
+    await this.apiKeyRepository.update(id, { revokedAt: new Date() });
   }
 }

--- a/ayunis-core-backend/src/iam/api-keys/infrastructure/repositories/local/mappers/api-key.mapper.ts
+++ b/ayunis-core-backend/src/iam/api-keys/infrastructure/repositories/local/mappers/api-key.mapper.ts
@@ -9,6 +9,7 @@ export class ApiKeyMapper {
       prefix: record.prefix,
       hash: record.hash,
       expiresAt: record.expiresAt,
+      revokedAt: record.revokedAt,
       orgId: record.orgId,
       createdByUserId: record.createdByUserId,
       createdAt: record.createdAt,
@@ -23,6 +24,7 @@ export class ApiKeyMapper {
     record.prefix = domain.prefix;
     record.hash = domain.hash;
     record.expiresAt = domain.expiresAt;
+    record.revokedAt = domain.revokedAt;
     record.orgId = domain.orgId;
     record.createdByUserId = domain.createdByUserId;
     record.createdAt = domain.createdAt;

--- a/ayunis-core-backend/src/iam/api-keys/infrastructure/repositories/local/schema/api-key.record.ts
+++ b/ayunis-core-backend/src/iam/api-keys/infrastructure/repositories/local/schema/api-key.record.ts
@@ -19,6 +19,9 @@ export class ApiKeyRecord extends BaseRecord {
   @Column({ name: 'expires_at', type: 'timestamptz', nullable: true })
   expiresAt: Date | null;
 
+  @Column({ name: 'revoked_at', type: 'timestamptz', nullable: true })
+  revokedAt: Date | null;
+
   @Index()
   @Column({ name: 'org_id' })
   orgId: UUID;

--- a/ayunis-core-backend/src/iam/authorization/application/decorators/require-principal-kind.decorator.ts
+++ b/ayunis-core-backend/src/iam/authorization/application/decorators/require-principal-kind.decorator.ts
@@ -1,0 +1,18 @@
+import { SetMetadata } from '@nestjs/common';
+import type { PrincipalKind } from 'src/iam/authentication/domain/active-principal.entity';
+
+export const REQUIRE_PRINCIPAL_KIND_KEY = 'requirePrincipalKind';
+
+/**
+ * Restrict a route (or controller) to a specific principal kind. Returns 403
+ * when the authenticated principal's kind does not match.
+ *
+ * @example
+ * ```typescript
+ * @RequirePrincipalKind('apiKey')
+ * @Controller('openai/v1/chat/completions')
+ * export class ChatCompletionsController { ... }
+ * ```
+ */
+export const RequirePrincipalKind = (kind: PrincipalKind) =>
+  SetMetadata(REQUIRE_PRINCIPAL_KIND_KEY, kind);

--- a/ayunis-core-backend/src/iam/authorization/application/guards/require-principal-kind.guard.ts
+++ b/ayunis-core-backend/src/iam/authorization/application/guards/require-principal-kind.guard.ts
@@ -1,31 +1,28 @@
 import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
 import { Request } from 'express';
-import { SystemRole } from 'src/iam/users/domain/value-objects/system-role.enum';
-import { SYSTEM_ROLES_KEY } from '../decorators/system-roles.decorator';
+import type { PrincipalKind } from 'src/iam/authentication/domain/active-principal.entity';
 import { getPrincipal } from 'src/iam/authentication/application/util/get-principal';
+import { REQUIRE_PRINCIPAL_KIND_KEY } from '../decorators/require-principal-kind.decorator';
 
 @Injectable()
-export class SystemRolesGuard implements CanActivate {
+export class RequirePrincipalKindGuard implements CanActivate {
   constructor(private readonly reflector: Reflector) {}
 
   canActivate(context: ExecutionContext): boolean {
-    const requiredRoles = this.reflector.getAllAndOverride<SystemRole[]>(
-      SYSTEM_ROLES_KEY,
+    const requiredKind = this.reflector.getAllAndOverride<PrincipalKind>(
+      REQUIRE_PRINCIPAL_KIND_KEY,
       [context.getHandler(), context.getClass()],
     );
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Reflector returns T but is undefined at runtime when no metadata is set
-    if (!requiredRoles) {
+    if (!requiredKind) {
       return true;
     }
     const request = context.switchToHttp().getRequest<Request>();
     const principal = getPrincipal(request);
-    // System roles are a user-level concept. API-key principals must never
-    // satisfy `@SystemRoles(...)`, mirroring the same invariant `RolesGuard`
-    // enforces.
-    if (principal?.kind !== 'user') {
+    if (!principal) {
       return false;
     }
-    return requiredRoles.some((role) => principal.systemRole === role);
+    return principal.kind === requiredKind;
   }
 }

--- a/ayunis-core-backend/src/iam/authorization/application/guards/roles.guard.spec.ts
+++ b/ayunis-core-backend/src/iam/authorization/application/guards/roles.guard.spec.ts
@@ -1,0 +1,93 @@
+import type { Reflector } from '@nestjs/core';
+import type { ExecutionContext } from '@nestjs/common';
+import { randomUUID } from 'crypto';
+
+import { ActiveUser } from 'src/iam/authentication/domain/active-user.entity';
+import { ActiveApiKey } from 'src/iam/authentication/domain/active-api-key.entity';
+import { UserRole } from 'src/iam/users/domain/value-objects/role.object';
+import { SystemRole } from 'src/iam/users/domain/value-objects/system-role.enum';
+
+import { RolesGuard } from './roles.guard';
+
+const buildContext = (request: { user?: unknown }): ExecutionContext =>
+  ({
+    getHandler: jest.fn(),
+    getClass: jest.fn(),
+    switchToHttp: () => ({
+      getRequest: () => request,
+    }),
+  }) as unknown as ExecutionContext;
+
+const orgId = randomUUID();
+
+const buildUser = (role: UserRole): ActiveUser =>
+  new ActiveUser({
+    id: randomUUID(),
+    email: 'admin@example.com',
+    emailVerified: true,
+    name: 'Admin',
+    orgId,
+    role,
+    systemRole: SystemRole.CUSTOMER,
+  });
+
+const buildApiKey = (role: UserRole): ActiveApiKey =>
+  new ActiveApiKey({
+    apiKeyId: randomUUID(),
+    label: 'ci-bot',
+    orgId,
+    role,
+    systemRole: SystemRole.CUSTOMER,
+  });
+
+describe('RolesGuard', () => {
+  let guard: RolesGuard;
+  let reflector: jest.Mocked<Reflector>;
+
+  beforeEach(() => {
+    reflector = {
+      getAllAndOverride: jest.fn(),
+    } as unknown as jest.Mocked<Reflector>;
+    guard = new RolesGuard(reflector);
+  });
+
+  it('returns true when no @Roles metadata is set on the route', () => {
+    reflector.getAllAndOverride.mockReturnValue(undefined);
+
+    expect(guard.canActivate(buildContext({}))).toBe(true);
+  });
+
+  it('returns false when there is no authenticated principal', () => {
+    reflector.getAllAndOverride.mockReturnValue([UserRole.ADMIN]);
+
+    expect(guard.canActivate(buildContext({}))).toBe(false);
+  });
+
+  it('returns true for a user principal whose role matches', () => {
+    reflector.getAllAndOverride.mockReturnValue([UserRole.ADMIN]);
+
+    expect(
+      guard.canActivate(buildContext({ user: buildUser(UserRole.ADMIN) })),
+    ).toBe(true);
+  });
+
+  it('returns false for a user principal whose role does not match', () => {
+    reflector.getAllAndOverride.mockReturnValue([UserRole.ADMIN]);
+
+    expect(
+      guard.canActivate(buildContext({ user: buildUser(UserRole.USER) })),
+    ).toBe(false);
+  });
+
+  it('returns false for an api-key principal even when the role would match', () => {
+    // Pin the security invariant: roles are a user concept, so api keys must
+    // never satisfy @Roles(...) regardless of what role they carry. A future
+    // change to ApiKeyStrategy that promotes an api key to ADMIN must not
+    // grant access to role-protected endpoints.
+    reflector.getAllAndOverride.mockReturnValue([UserRole.ADMIN]);
+
+    expect(
+      guard.canActivate(buildContext({ user: buildApiKey(UserRole.ADMIN) })),
+    ).toBe(false);
+  });
+});

--- a/ayunis-core-backend/src/iam/authorization/application/guards/roles.guard.ts
+++ b/ayunis-core-backend/src/iam/authorization/application/guards/roles.guard.ts
@@ -23,7 +23,10 @@ export class RolesGuard implements CanActivate {
     }
     const request = context.switchToHttp().getRequest<Request>();
     const principal = getPrincipal(request);
-    if (!principal) {
+    // Roles are a user-permission concept. API-key principals must never
+    // satisfy `@Roles(...)` regardless of what role field they carry — the
+    // role they hold is currently a hardcoded artifact of the principal type.
+    if (principal?.kind !== 'user') {
       return false;
     }
     return contextRoles.some((role) => principal.role === role);

--- a/ayunis-core-backend/src/iam/authorization/application/guards/system-roles.guard.spec.ts
+++ b/ayunis-core-backend/src/iam/authorization/application/guards/system-roles.guard.spec.ts
@@ -1,0 +1,96 @@
+import type { Reflector } from '@nestjs/core';
+import type { ExecutionContext } from '@nestjs/common';
+import { randomUUID } from 'crypto';
+
+import { ActiveUser } from 'src/iam/authentication/domain/active-user.entity';
+import { ActiveApiKey } from 'src/iam/authentication/domain/active-api-key.entity';
+import { UserRole } from 'src/iam/users/domain/value-objects/role.object';
+import { SystemRole } from 'src/iam/users/domain/value-objects/system-role.enum';
+
+import { SystemRolesGuard } from './system-roles.guard';
+
+const buildContext = (request: { user?: unknown }): ExecutionContext =>
+  ({
+    getHandler: jest.fn(),
+    getClass: jest.fn(),
+    switchToHttp: () => ({
+      getRequest: () => request,
+    }),
+  }) as unknown as ExecutionContext;
+
+const orgId = randomUUID();
+
+const buildUser = (systemRole: SystemRole): ActiveUser =>
+  new ActiveUser({
+    id: randomUUID(),
+    email: 'admin@example.com',
+    emailVerified: true,
+    name: 'Admin',
+    orgId,
+    role: UserRole.ADMIN,
+    systemRole,
+  });
+
+const buildApiKey = (systemRole: SystemRole): ActiveApiKey =>
+  new ActiveApiKey({
+    apiKeyId: randomUUID(),
+    label: 'ci-bot',
+    orgId,
+    role: UserRole.USER,
+    systemRole,
+  });
+
+describe('SystemRolesGuard', () => {
+  let guard: SystemRolesGuard;
+  let reflector: jest.Mocked<Reflector>;
+
+  beforeEach(() => {
+    reflector = {
+      getAllAndOverride: jest.fn(),
+    } as unknown as jest.Mocked<Reflector>;
+    guard = new SystemRolesGuard(reflector);
+  });
+
+  it('returns true when no @SystemRoles metadata is set on the route', () => {
+    reflector.getAllAndOverride.mockReturnValue(undefined);
+
+    expect(guard.canActivate(buildContext({}))).toBe(true);
+  });
+
+  it('returns false when there is no authenticated principal', () => {
+    reflector.getAllAndOverride.mockReturnValue([SystemRole.SUPER_ADMIN]);
+
+    expect(guard.canActivate(buildContext({}))).toBe(false);
+  });
+
+  it('returns true for a user principal whose systemRole matches', () => {
+    reflector.getAllAndOverride.mockReturnValue([SystemRole.SUPER_ADMIN]);
+
+    expect(
+      guard.canActivate(
+        buildContext({ user: buildUser(SystemRole.SUPER_ADMIN) }),
+      ),
+    ).toBe(true);
+  });
+
+  it('returns false for a user principal whose systemRole does not match', () => {
+    reflector.getAllAndOverride.mockReturnValue([SystemRole.SUPER_ADMIN]);
+
+    expect(
+      guard.canActivate(buildContext({ user: buildUser(SystemRole.CUSTOMER) })),
+    ).toBe(false);
+  });
+
+  it('returns false for an api-key principal even when the systemRole would match', () => {
+    // Pin the security invariant: system roles are a user concept, so api
+    // keys must never satisfy @SystemRoles(...) regardless of what
+    // systemRole they carry — mirrors the same enforcement RolesGuard does.
+    reflector.getAllAndOverride.mockReturnValue([SystemRole.SUPER_ADMIN]);
+
+    expect(
+      guard.canActivate(
+        buildContext({ user: buildApiKey(SystemRole.SUPER_ADMIN) }),
+      ),
+    ).toBe(false);
+  });
+});

--- a/ayunis-core-backend/src/iam/authorization/authorization.module.ts
+++ b/ayunis-core-backend/src/iam/authorization/authorization.module.ts
@@ -7,6 +7,7 @@ import { SubscriptionsModule } from '../subscriptions/subscriptions.module';
 import { TrialsModule } from '../trials/trials.module';
 import { EmailConfirmGuard } from './application/guards/email-confirm.guard';
 import { SystemRolesGuard } from './application/guards/system-roles.guard';
+import { RequirePrincipalKindGuard } from './application/guards/require-principal-kind.guard';
 import { IpAllowlistModule } from '../ip-allowlist/ip-allowlist.module';
 import { IpAllowlistGuard } from '../ip-allowlist/application/guards/ip-allowlist.guard';
 
@@ -16,6 +17,10 @@ import { IpAllowlistGuard } from '../ip-allowlist/application/guards/ip-allowlis
     {
       provide: APP_GUARD,
       useExisting: IpAllowlistGuard,
+    },
+    {
+      provide: APP_GUARD,
+      useClass: RequirePrincipalKindGuard,
     },
     {
       provide: APP_GUARD,


### PR DESCRIPTION
- Soft-revoke api keys: add revoked_at column, reject revoked keys at
  validate-time, switch revoke use case from hard-delete to status
  update so usage.api_key_id attribution survives revocation.
- Pin /openai/v1/chat/completions to api-key auth via new
  @RequirePrincipalKind decorator + guard, registered as APP_GUARD.
  Cookie JWT can no longer hit the OpenAI-compat route (no CSRF
  protection in the repo, cookies are sameSite: lax).
- Tighten RolesGuard and SystemRolesGuard to require user principals.
  API keys can no longer satisfy @Roles(...) / @SystemRoles(...)
  regardless of the role they carry; removes a future privilege-
  escalation surface (an attacker holding one stolen key minting more).
- Strip apiKeyId from ApiKeyExpiredError public payload — keep it in
  server-side logs only. The use case is exported, so a future direct
  caller would otherwise leak it via ApplicationErrorFilter.

Structural follow-up to remove role/systemRole from ActiveApiKey is
tracked in AYC-84.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authentication/authorization and API key lifecycle handling, which can change access behavior and could inadvertently block legitimate requests if guard ordering or revoked-state propagation is wrong.
> 
> **Overview**
> This PR switches API key revocation from hard-delete to **soft revoke** by adding `api_keys.revoked_at`, persisting revocation via repository `revoke()`, filtering revoked keys out of org listings, and rejecting revoked keys during `ValidateApiKeyUseCase` (new `ApiKeyRevokedError`). It also stops including `apiKeyId` in the public `ApiKeyExpiredError` metadata while keeping server-side logging.
> 
> Authorization is tightened by introducing `@RequirePrincipalKind` + `RequirePrincipalKindGuard` (registered as an `APP_GUARD`) and using it to restrict the OpenAI-compat `chat/completions` controller to `apiKey` principals. `RolesGuard` and `SystemRolesGuard` are hardened to only allow `user` principals to satisfy `@Roles`/`@SystemRoles`, with new tests to pin the invariant that API keys never pass role-based checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b6ae22c2c9d7cb09716d9a5f152862cce835705. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->