### PR TITLE
chore(api): regenerate frontend client for KB upload changes (AYC-74)

### DIFF
--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
@@ -4304,7 +4304,7 @@ export const SharesControllerGetSharesEntityType = {
 } as const;
 
 export type KnowledgeBasesControllerAddDocumentBody = {
-  /** The file to upload (PDF, DOCX, PPTX, TXT) */
+  /** The file to upload (PDF, DOCX, PPTX, TXT, max 25 MB) */
   file: Blob;
 };
 

--- a/ayunis-core-frontend/src/shared/api/openapi-schema.json
+++ b/ayunis-core-frontend/src/shared/api/openapi-schema.json
@@ -5468,7 +5468,7 @@
                   "file": {
                     "type": "string",
                     "format": "binary",
-                    "description": "The file to upload (PDF, DOCX, PPTX, TXT)"
+                    "description": "The file to upload (PDF, DOCX, PPTX, TXT, max 25 MB)"
                   }
                 },
                 "required": ["file"]
@@ -5489,6 +5489,9 @@
           },
           "404": {
             "description": "Knowledge base not found"
+          },
+          "413": {
+            "description": "File exceeds the 25 MB upload limit"
           }
         },
         "summary": "Add a document to a knowledge base",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Generated schema/doc updates only; no runtime logic changes, but clients may now handle an additional `413` error code.
> 
> **Overview**
> Updates the generated frontend OpenAPI client for knowledge base document uploads to explicitly document a **25 MB max file size**, and adds an explicit `413` response for oversized uploads on `POST /knowledge-bases/{id}/documents`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f049c246c036741229b1ddce534dea84ae63301. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->