### PR TITLE
refactor(auth): drop role/systemRole from api-key principal (AYC-84)

### DIFF
--- a/ayunis-core-backend/src/common/context/services/context.service.spec.ts
+++ b/ayunis-core-backend/src/common/context/services/context.service.spec.ts
@@ -58,15 +58,11 @@ describe('ContextService', () => {
         principalKind: 'apiKey',
         apiKeyId: API_KEY_ID,
         orgId: ORG_ID,
-        role: UserRole.USER,
-        systemRole: SystemRole.CUSTOMER,
       });
       expect(ctx.requirePrincipal()).toEqual({
         kind: 'apiKey',
         apiKeyId: API_KEY_ID,
         orgId: ORG_ID,
-        role: UserRole.USER,
-        systemRole: SystemRole.CUSTOMER,
       });
     });
 
@@ -89,8 +85,6 @@ describe('ContextService', () => {
       const ctx = makeStore({
         principalKind: 'apiKey',
         orgId: ORG_ID,
-        role: UserRole.USER,
-        systemRole: SystemRole.CUSTOMER,
       });
       expect(() => ctx.requirePrincipal()).toThrow(UnauthorizedAccessError);
     });

--- a/ayunis-core-backend/src/common/context/services/context.service.ts
+++ b/ayunis-core-backend/src/common/context/services/context.service.ts
@@ -14,7 +14,9 @@ export interface MyClsStore extends ClsStore {
   /** API key UUID. Set only when `principalKind === 'apiKey'`. */
   apiKeyId?: UUID;
   orgId?: UUID;
+  /** Set only when `principalKind === 'user'`. */
   systemRole?: SystemRole;
+  /** Set only when `principalKind === 'user'`. */
   role?: UserRole;
 }
 
@@ -30,8 +32,6 @@ export type ResolvedPrincipal =
       kind: 'apiKey';
       apiKeyId: UUID;
       orgId: UUID;
-      role: UserRole;
-      systemRole: SystemRole;
     };
 
 /**
@@ -81,14 +81,14 @@ export class ContextService {
   requirePrincipal(): ResolvedPrincipal {
     const kind = this.cls.get('principalKind');
     const orgId = this.cls.get('orgId');
-    const role = this.cls.get('role');
-    const systemRole = this.cls.get('systemRole');
-    if (!kind || !orgId || !role || !systemRole) {
+    if (!kind || !orgId) {
       throw new UnauthorizedAccessError();
     }
     if (kind === 'user') {
       const userId = this.cls.get('userId');
-      if (!userId) {
+      const role = this.cls.get('role');
+      const systemRole = this.cls.get('systemRole');
+      if (!userId || !role || !systemRole) {
         throw new UnauthorizedAccessError();
       }
       return { kind: 'user', userId, orgId, role, systemRole };
@@ -97,6 +97,6 @@ export class ContextService {
     if (!apiKeyId) {
       throw new UnauthorizedAccessError();
     }
-    return { kind: 'apiKey', apiKeyId, orgId, role, systemRole };
+    return { kind: 'apiKey', apiKeyId, orgId };
   }
 }

--- a/ayunis-core-backend/src/iam/api-keys/application/strategies/api-key.strategy.ts
+++ b/ayunis-core-backend/src/iam/api-keys/application/strategies/api-key.strategy.ts
@@ -2,8 +2,6 @@ import { Injectable, Logger } from '@nestjs/common';
 import { PassportStrategy } from '@nestjs/passport';
 import { Strategy as BearerStrategy } from 'passport-http-bearer';
 
-import { UserRole } from 'src/iam/users/domain/value-objects/role.object';
-import { SystemRole } from 'src/iam/users/domain/value-objects/system-role.enum';
 import { ActiveApiKey } from 'src/iam/authentication/domain/active-api-key.entity';
 
 import { ApiKey } from '../../domain/api-key.entity';
@@ -53,8 +51,6 @@ export class ApiKeyStrategy extends PassportStrategy(
         apiKeyId: apiKey.id,
         label: apiKey.name,
         orgId: apiKey.orgId,
-        role: UserRole.USER,
-        systemRole: SystemRole.CUSTOMER,
       });
     } catch (err) {
       if (err instanceof ApiKeyError && err.statusCode < 500) {

--- a/ayunis-core-backend/src/iam/authentication/application/interceptors/user-context.interceptor.spec.ts
+++ b/ayunis-core-backend/src/iam/authentication/application/interceptors/user-context.interceptor.spec.ts
@@ -61,8 +61,6 @@ describe('UserContextInterceptor', () => {
       apiKeyId: 'key-id' as UUID,
       label: 'ci-bot',
       orgId: 'org-id' as UUID,
-      role: UserRole.USER,
-      systemRole: SystemRole.CUSTOMER,
     });
     const callHandler = createCallHandler();
 
@@ -77,6 +75,8 @@ describe('UserContextInterceptor', () => {
     expect(setMock).toHaveBeenCalledWith('apiKeyId', activeApiKey.apiKeyId);
     expect(setMock).toHaveBeenCalledWith('orgId', activeApiKey.orgId);
     expect(setMock).not.toHaveBeenCalledWith('userId', expect.anything());
+    expect(setMock).not.toHaveBeenCalledWith('role', expect.anything());
+    expect(setMock).not.toHaveBeenCalledWith('systemRole', expect.anything());
     expect(callHandler.handle).toHaveBeenCalled();
   });
 

--- a/ayunis-core-backend/src/iam/authentication/application/interceptors/user-context.interceptor.ts
+++ b/ayunis-core-backend/src/iam/authentication/application/interceptors/user-context.interceptor.ts
@@ -47,13 +47,10 @@ export class UserContextInterceptor implements NestInterceptor {
       this.contextService.set('principalKind', 'apiKey');
       this.contextService.set('apiKeyId', principal.apiKeyId);
       this.contextService.set('orgId', principal.orgId);
-      this.contextService.set('role', principal.role);
-      this.contextService.set('systemRole', principal.systemRole);
 
       Sentry.getCurrentScope().setUser({
         id: principal.apiKeyId,
         orgId: principal.orgId,
-        role: principal.role,
         principalKind: 'apiKey',
       });
     }

--- a/ayunis-core-backend/src/iam/authentication/domain/active-api-key.entity.ts
+++ b/ayunis-core-backend/src/iam/authentication/domain/active-api-key.entity.ts
@@ -1,26 +1,14 @@
 import type { UUID } from 'crypto';
-import type { UserRole } from 'src/iam/users/domain/value-objects/role.object';
-import type { SystemRole } from 'src/iam/users/domain/value-objects/system-role.enum';
 
 export class ActiveApiKey {
   readonly kind = 'apiKey' as const;
   readonly apiKeyId: UUID;
   readonly label: string;
   readonly orgId: UUID;
-  readonly role: UserRole;
-  readonly systemRole: SystemRole;
 
-  constructor(params: {
-    apiKeyId: UUID;
-    label: string;
-    orgId: UUID;
-    role: UserRole;
-    systemRole: SystemRole;
-  }) {
+  constructor(params: { apiKeyId: UUID; label: string; orgId: UUID }) {
     this.apiKeyId = params.apiKeyId;
     this.label = params.label;
     this.orgId = params.orgId;
-    this.role = params.role;
-    this.systemRole = params.systemRole;
   }
 }

--- a/ayunis-core-backend/src/iam/authorization/application/guards/roles.guard.spec.ts
+++ b/ayunis-core-backend/src/iam/authorization/application/guards/roles.guard.spec.ts
@@ -31,13 +31,11 @@ const buildUser = (role: UserRole): ActiveUser =>
     systemRole: SystemRole.CUSTOMER,
   });
 
-const buildApiKey = (role: UserRole): ActiveApiKey =>
+const buildApiKey = (): ActiveApiKey =>
   new ActiveApiKey({
     apiKeyId: randomUUID(),
     label: 'ci-bot',
     orgId,
-    role,
-    systemRole: SystemRole.CUSTOMER,
   });
 
 describe('RolesGuard', () => {
@@ -79,15 +77,14 @@ describe('RolesGuard', () => {
     ).toBe(false);
   });
 
-  it('returns false for an api-key principal even when the role would match', () => {
+  it('returns false for an api-key principal regardless of the required role', () => {
     // Pin the security invariant: roles are a user concept, so api keys must
-    // never satisfy @Roles(...) regardless of what role they carry. A future
-    // change to ApiKeyStrategy that promotes an api key to ADMIN must not
-    // grant access to role-protected endpoints.
+    // never satisfy @Roles(...). The kind discriminator gates the check;
+    // ActiveApiKey structurally cannot carry a role.
     reflector.getAllAndOverride.mockReturnValue([UserRole.ADMIN]);
 
-    expect(
-      guard.canActivate(buildContext({ user: buildApiKey(UserRole.ADMIN) })),
-    ).toBe(false);
+    expect(guard.canActivate(buildContext({ user: buildApiKey() }))).toBe(
+      false,
+    );
   });
 });

--- a/ayunis-core-backend/src/iam/authorization/application/guards/system-roles.guard.spec.ts
+++ b/ayunis-core-backend/src/iam/authorization/application/guards/system-roles.guard.spec.ts
@@ -31,13 +31,11 @@ const buildUser = (systemRole: SystemRole): ActiveUser =>
     systemRole,
   });
 
-const buildApiKey = (systemRole: SystemRole): ActiveApiKey =>
+const buildApiKey = (): ActiveApiKey =>
   new ActiveApiKey({
     apiKeyId: randomUUID(),
     label: 'ci-bot',
     orgId,
-    role: UserRole.USER,
-    systemRole,
   });
 
 describe('SystemRolesGuard', () => {
@@ -81,16 +79,15 @@ describe('SystemRolesGuard', () => {
     ).toBe(false);
   });
 
-  it('returns false for an api-key principal even when the systemRole would match', () => {
+  it('returns false for an api-key principal regardless of the required systemRole', () => {
     // Pin the security invariant: system roles are a user concept, so api
-    // keys must never satisfy @SystemRoles(...) regardless of what
-    // systemRole they carry — mirrors the same enforcement RolesGuard does.
+    // keys must never satisfy @SystemRoles(...) — mirrors RolesGuard. The
+    // kind discriminator gates the check; ActiveApiKey structurally cannot
+    // carry a systemRole.
     reflector.getAllAndOverride.mockReturnValue([SystemRole.SUPER_ADMIN]);
 
-    expect(
-      guard.canActivate(
-        buildContext({ user: buildApiKey(SystemRole.SUPER_ADMIN) }),
-      ),
-    ).toBe(false);
+    expect(guard.canActivate(buildContext({ user: buildApiKey() }))).toBe(
+      false,
+    );
   });
 });


### PR DESCRIPTION
After AYC-77 tightened RolesGuard and SystemRolesGuard to require
principal.kind === 'user', the role and systemRole fields on
ActiveApiKey became vestigial — load-bearing for nothing, hardcoded
to UserRole.USER / SystemRole.CUSTOMER in ApiKeyStrategy, and
misleading to anyone editing the strategy.

- Drop role and systemRole from ActiveApiKey (entity + constructor).
- Drop the hardcodes and UserRole/SystemRole imports from
  ApiKeyStrategy.
- UserContextInterceptor's apiKey branch no longer copies role or
  systemRole into CLS or Sentry user context.
- ResolvedPrincipal's apiKey variant slimmed to { kind, apiKeyId,
  orgId }; requirePrincipal() reads role and systemRole only inside
  the user branch.
- Spec updates for the four touched files plus context.service spec.

The 25+ use cases that read role/systemRole directly from CLS via
contextService.get(...) still typecheck (MyClsStore keeps these as
optional UserRole | undefined / SystemRole | undefined) and remain
fail-closed for api-key callers. Migrating those readers to a typed,
narrowed accessor is the follow-up ticket.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authentication principal shape and request-scoped context resolution, so mistakes could break authorization or auditing for API-key requests, though the change is largely subtractive and covered by updated tests.
> 
> **Overview**
> **API-key principals are slimmed down to identifiers only.** `ActiveApiKey` and `ResolvedPrincipal` no longer carry `role`/`systemRole`, and `ApiKeyStrategy` stops hardcoding those values.
> 
> `ContextService.requirePrincipal()` now requires `role`/`systemRole` only for `user` principals, while the API-key branch returns `{ kind: 'apiKey', apiKeyId, orgId }`. `UserContextInterceptor` likewise stops copying role/systemRole into CLS and Sentry for API-key requests, with specs updated to assert the new behavior and to reinforce that API keys never satisfy `@Roles`/`@SystemRoles` guards.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02cb0ed6bdfcaf2e75dbcf8dade60553c6e49ae8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->