### PR TITLE
fix(openai-compat): error envelope filter, streaming bugs, per-turn tool-call scoping (AYC-78)

### DIFF
--- a/ayunis-core-backend/src/domain/models/presenters/http/openai/chat-completions.controller.ts
+++ b/ayunis-core-backend/src/domain/models/presenters/http/openai/chat-completions.controller.ts
@@ -1,4 +1,12 @@
-import { Body, Controller, Logger, Post, Req, Res } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Logger,
+  Post,
+  Req,
+  Res,
+  UseFilters,
+} from '@nestjs/common';
 import {
   ApiBody,
   ApiExcludeController,
@@ -32,6 +40,7 @@ import { GetPermittedLanguageModelByNameQuery } from '../../../application/use-c
 import type { PermittedLanguageModel } from '../../../domain/permitted-model.entity';
 import { ChatCompletionRequestDto } from './dto/chat-completion-request.dto';
 import { ChatCompletionResponseDto } from './dto/chat-completion-response.dto';
+import { OpenAIExceptionFilter } from './filters/openai-exception.filter';
 import { OpenAIChatCompletionsMappers } from './mappers/openai-mappers';
 
 const HEARTBEAT_INTERVAL_MS = 15_000;
@@ -40,6 +49,7 @@ const HEARTBEAT_INTERVAL_MS = 15_000;
 @ApiExcludeController()
 @Controller('openai/v1/chat/completions')
 @RequireSubscription()
+@UseFilters(OpenAIExceptionFilter)
 export class ChatCompletionsController {
   private readonly logger = new Logger(ChatCompletionsController.name);
 
@@ -71,28 +81,24 @@ export class ChatCompletionsController {
     @Req() request: RequestWithSubscriptionContext,
     @Res() response: Response,
   ): Promise<void> {
-    try {
-      const orgId = this.mappers.context.requireOrgId();
-      const model = await this.resolveModel(dto.model);
+    const orgId = this.mappers.context.requireOrgId();
+    const model = await this.resolveModel(dto.model);
 
-      // Charge fair-use bucket on the resolved model's tier. The bucket is
-      // keyed on the principal — a user-anchored quota for UI requests, an
-      // api-key-anchored quota for API-key requests. ZERO-tier models bypass
-      // the check (no bucket, no row).
-      await this.enforceFairUse(model, request);
+    // Charge fair-use bucket on the resolved model's tier. The bucket is
+    // keyed on the principal — a user-anchored quota for UI requests, an
+    // api-key-anchored quota for API-key requests. ZERO-tier models bypass
+    // the check (no bucket, no row).
+    await this.enforceFairUse(model, request);
 
-      // Trial cap: a single chat-completion request counts as one message,
-      // mirroring runs.controller. SubscriptionGuard already gated entry; we
-      // only need to advance the counter when we're inside the trial window.
-      this.maybeIncrementTrial(orgId, request);
+    // Trial cap: a single chat-completion request counts as one message,
+    // mirroring runs.controller. SubscriptionGuard already gated entry; we
+    // only need to advance the counter when we're inside the trial window.
+    this.maybeIncrementTrial(orgId, request);
 
-      if (dto.stream) {
-        await this.handleStream(dto, model, orgId, request, response);
-      } else {
-        await this.handleNonStream(dto, model, response);
-      }
-    } catch (error) {
-      this.sendError(response, error);
+    if (dto.stream) {
+      await this.handleStream(dto, model, orgId, request, response);
+    } else {
+      await this.handleNonStream(dto, model, response);
     }
   }
 
@@ -213,39 +219,53 @@ export class ChatCompletionsController {
         }
       }, HEARTBEAT_INTERVAL_MS);
 
-      subscriptionRef.current = stream$.subscribe({
-        next: (chunk) => {
-          if (chunk.usage) {
-            if (chunk.usage.inputTokens !== undefined) {
-              lastInputTokens = chunk.usage.inputTokens;
+      try {
+        subscriptionRef.current = stream$.subscribe({
+          next: (chunk) => {
+            if (chunk.usage) {
+              if (chunk.usage.inputTokens !== undefined) {
+                lastInputTokens = chunk.usage.inputTokens;
+              }
+              if (chunk.usage.outputTokens !== undefined) {
+                lastOutputTokens = chunk.usage.outputTokens;
+              }
             }
-            if (chunk.usage.outputTokens !== undefined) {
-              lastOutputTokens = chunk.usage.outputTokens;
+            if (disconnected) return;
+            const dtoChunk = this.mappers.stream.toChunkDto(chunk, ctx);
+            if (dtoChunk) {
+              response.write(`data: ${JSON.stringify(dtoChunk)}\n\n`);
             }
-          }
-          if (disconnected) return;
-          const dtoChunk = this.mappers.stream.toChunkDto(chunk, ctx);
-          if (dtoChunk) {
-            response.write(`data: ${JSON.stringify(dtoChunk)}\n\n`);
-          }
-        },
-        error: (err) => {
-          this.logger.error('Streaming inference failed', err);
-          if (!disconnected) {
-            const envelope = this.mappers.error.toEnvelope(err).body;
-            response.write(`data: ${JSON.stringify(envelope)}\n\n`);
-            // Always emit [DONE] so OpenAI SDK clients close cleanly even
-            // on the error path.
-            response.write('data: [DONE]\n\n');
-          }
-          settle();
-        },
-        complete: () => {
-          if (!disconnected) response.write('data: [DONE]\n\n');
-          this.collectUsage(model, lastInputTokens, lastOutputTokens);
-          settle();
-        },
-      });
+          },
+          error: (err) => {
+            this.logger.error('Streaming inference failed', err);
+            if (!disconnected) {
+              const envelope = this.mappers.error.toEnvelope(err).body;
+              response.write(`data: ${JSON.stringify(envelope)}\n\n`);
+              // Always emit [DONE] so OpenAI SDK clients close cleanly even
+              // on the error path.
+              response.write('data: [DONE]\n\n');
+            }
+            settle();
+          },
+          complete: () => {
+            if (!disconnected) response.write('data: [DONE]\n\n');
+            this.collectUsage(model, lastInputTokens, lastOutputTokens);
+            settle();
+          },
+        });
+      } catch (err) {
+        // rxjs subscribe() can throw synchronously when the producer factory
+        // throws before scheduling. Without this catch, the throw escapes the
+        // executor, settle() never runs, and the heartbeat keeps writing into
+        // a half-open response forever.
+        this.logger.error('Streaming inference threw synchronously', err);
+        if (!disconnected) {
+          const envelope = this.mappers.error.toEnvelope(err).body;
+          response.write(`data: ${JSON.stringify(envelope)}\n\n`);
+          response.write('data: [DONE]\n\n');
+        }
+        settle();
+      }
     });
   }
 
@@ -260,18 +280,5 @@ export class ChatCompletionsController {
       inputTokens,
       outputTokens,
     );
-  }
-
-  private sendError(response: Response, error: unknown): void {
-    if (response.headersSent) {
-      this.logger.error(
-        'Error after headers sent; cannot rewrite response',
-        error,
-      );
-      response.end();
-      return;
-    }
-    const { status, body } = this.mappers.error.toEnvelope(error);
-    response.status(status).json(body);
   }
 }

--- a/ayunis-core-backend/src/domain/models/presenters/http/openai/filters/openai-exception.filter.ts
+++ b/ayunis-core-backend/src/domain/models/presenters/http/openai/filters/openai-exception.filter.ts
@@ -1,0 +1,22 @@
+import { ArgumentsHost, Catch, ExceptionFilter } from '@nestjs/common';
+import type { Response } from 'express';
+import { OpenAIErrorMapper } from '../mappers/openai-error.mapper';
+
+@Catch()
+export class OpenAIExceptionFilter implements ExceptionFilter {
+  constructor(private readonly mapper: OpenAIErrorMapper) {}
+
+  catch(error: unknown, host: ArgumentsHost): void {
+    const response = host.switchToHttp().getResponse<Response>();
+    // The streaming path writes the error envelope into the SSE body itself
+    // (headers are flushed before the subscription starts). Once headers are
+    // out, we can only close the connection — Express won't let us rewrite
+    // the response.
+    if (response.headersSent) {
+      if (!response.writableEnded) response.end();
+      return;
+    }
+    const { status, body } = this.mapper.toEnvelope(error);
+    response.status(status).json(body);
+  }
+}

--- a/ayunis-core-backend/src/domain/models/presenters/http/openai/mappers/openai-request.mapper.spec.ts
+++ b/ayunis-core-backend/src/domain/models/presenters/http/openai/mappers/openai-request.mapper.spec.ts
@@ -253,6 +253,47 @@ describe('OpenAIRequestMapper', () => {
       ).toThrow(BadRequestException);
     });
 
+    it('resolves a reused tool_call_id against the most recent assistant turn (not the first occurrence)', () => {
+      const dto = buildRequest({
+        messages: [
+          { role: 'user', content: 'hi' },
+          {
+            role: 'assistant',
+            tool_calls: [
+              {
+                id: 'call_1',
+                type: 'function',
+                function: { name: 'get_weather', arguments: '{}' },
+              },
+            ],
+          },
+          { role: 'tool', content: 'sunny', tool_call_id: 'call_1' },
+          { role: 'user', content: 'and the time?' },
+          {
+            role: 'assistant',
+            tool_calls: [
+              {
+                id: 'call_1',
+                type: 'function',
+                function: { name: 'get_time', arguments: '{}' },
+              },
+            ],
+          },
+          { role: 'tool', content: '12:00', tool_call_id: 'call_1' },
+        ],
+      });
+
+      const cmd = mapper.toGetInferenceCommand(
+        dto,
+        buildPermittedLanguageModel(),
+      );
+
+      const firstResult = cmd.messages[2] as ToolResultMessage;
+      const secondResult = cmd.messages[5] as ToolResultMessage;
+      expect(firstResult.content[0].toolName).toBe('get_weather');
+      expect(secondResult.content[0].toolName).toBe('get_time');
+    });
+
     it('produces a ToolResultMessageContent with the resolved tool name (not the tool_call_id)', () => {
       const dto = buildRequest({
         messages: [

--- a/ayunis-core-backend/src/domain/models/presenters/http/openai/mappers/openai-request.mapper.ts
+++ b/ayunis-core-backend/src/domain/models/presenters/http/openai/mappers/openai-request.mapper.ts
@@ -72,16 +72,21 @@ export class OpenAIRequestMapper {
     const { systemPrompt, conversation } = this.splitSystemMessages(
       dto.messages,
     );
-    // Build a tool_call_id → function.name map. Tool result messages carry
-    // only `tool_call_id` on the wire, so the name must be recovered from
-    // the prior assistant message that emitted the call. Without this,
-    // downstream provider converters that round-trip the name (Gemini, e.g.)
-    // would send the call id where the function name should be and the model
-    // would reject the request.
-    const toolCallIdToName = this.buildToolCallIdToNameMap(conversation);
-    const messages = conversation.map((msg) =>
-      this.toDomainMessage(msg, threadId, toolCallIdToName),
-    );
+    // Resolve tool result messages against the *current* assistant turn's
+    // tool_calls only. The map is rebuilt each time we encounter an assistant
+    // message with `tool_calls`, so a later turn that reuses an earlier
+    // tool_call_id can't mis-attribute the result to the earlier call.
+    const messages: Message[] = [];
+    let currentTurnMap = new Map<string, string>();
+    for (const msg of conversation) {
+      if (msg.role === 'assistant' && msg.tool_calls) {
+        currentTurnMap = new Map<string, string>();
+        for (const tc of msg.tool_calls) {
+          currentTurnMap.set(tc.id, tc.function.name);
+        }
+      }
+      messages.push(this.toDomainMessage(msg, threadId, currentTurnMap));
+    }
     const inlineTools = (dto.tools ?? []).map((tool) =>
       this.toInlineTool(tool),
     );
@@ -96,20 +101,6 @@ export class OpenAIRequestMapper {
       toolChoice,
       instructions: systemPrompt,
     };
-  }
-
-  private buildToolCallIdToNameMap(
-    messages: ChatCompletionMessageDto[],
-  ): Map<string, string> {
-    const map = new Map<string, string>();
-    for (const msg of messages) {
-      if (msg.role === 'assistant' && msg.tool_calls) {
-        for (const tc of msg.tool_calls) {
-          map.set(tc.id, tc.function.name);
-        }
-      }
-    }
-    return map;
   }
 
   private splitSystemMessages(messages: ChatCompletionMessageDto[]): {
@@ -203,7 +194,7 @@ export class OpenAIRequestMapper {
     const toolName = toolCallIdToName.get(dto.tool_call_id);
     if (!toolName) {
       throw new BadRequestException(
-        `No matching tool_call found for tool_call_id "${dto.tool_call_id}" in any preceding assistant message`,
+        `No matching tool_call found for tool_call_id "${dto.tool_call_id}" in the most recent assistant turn`,
       );
     }
     return new ToolResultMessage({

--- a/ayunis-core-backend/src/domain/models/presenters/http/openai/mappers/openai-stream.mapper.spec.ts
+++ b/ayunis-core-backend/src/domain/models/presenters/http/openai/mappers/openai-stream.mapper.spec.ts
@@ -145,7 +145,7 @@ describe('OpenAIStreamMapper', () => {
       expect(result!.choices[0].finish_reason).toBe('length');
     });
 
-    it('overrides finishReason to "tool_calls" when tool calls are present in the SAME chunk as finishReason "stop" (current behavior)', () => {
+    it('overrides finishReason to "tool_calls" when a NEW tool call (id/name) lands in the SAME chunk as finishReason "stop"', () => {
       const chunk = new StreamInferenceResponseChunk({
         thinkingDelta: null,
         textContentDelta: null,
@@ -164,6 +164,39 @@ describe('OpenAIStreamMapper', () => {
 
       expect(result).not.toBeNull();
       expect(result!.choices[0].finish_reason).toBe('tool_calls');
+    });
+
+    it('does NOT override finishReason "stop" when the toolCallsDelta is only an argumentsDelta continuation (id and name are null)', () => {
+      const chunk = new StreamInferenceResponseChunk({
+        thinkingDelta: null,
+        textContentDelta: null,
+        toolCallsDelta: [
+          new StreamInferenceResponseChunkToolCall({
+            index: 0,
+            id: null,
+            name: null,
+            argumentsDelta: '"city":"Berlin"}',
+          }),
+        ],
+        finishReason: 'stop',
+      });
+
+      const result = mapper.toChunkDto(chunk, ctx);
+
+      expect(result).not.toBeNull();
+      expect(result!.choices[0].finish_reason).toBe('stop');
+    });
+
+    it('drops a chunk whose textContentDelta is the empty string and has no other signal', () => {
+      const chunk = new StreamInferenceResponseChunk({
+        thinkingDelta: null,
+        textContentDelta: '',
+        toolCallsDelta: [],
+      });
+
+      const result = mapper.toChunkDto(chunk, ctx);
+
+      expect(result).toBeNull();
     });
 
     it('emits usage only when chunk.usage is set', () => {

--- a/ayunis-core-backend/src/domain/models/presenters/http/openai/mappers/openai-stream.mapper.ts
+++ b/ayunis-core-backend/src/domain/models/presenters/http/openai/mappers/openai-stream.mapper.ts
@@ -62,11 +62,18 @@ export class OpenAIStreamMapper {
       }),
     );
 
-    const hasContent = chunk.textContentDelta !== null;
+    const hasContent =
+      chunk.textContentDelta !== null && chunk.textContentDelta.length > 0;
     const hasToolCalls = toolCalls.length > 0;
+    // Only a delta carrying `id` or `name` introduces a new tool-call
+    // boundary. Pure `argumentsDelta` continuations of an in-flight call must
+    // not flip a legitimate `stop` into `tool_calls`.
+    const hasNewToolCall = chunk.toolCallsDelta.some(
+      (d) => d.id !== null || d.name !== null,
+    );
     const finishReason =
       chunk.finishReason !== null && chunk.finishReason !== undefined
-        ? this.mapFinishReason(chunk.finishReason, hasToolCalls)
+        ? this.mapFinishReason(chunk.finishReason, hasNewToolCall)
         : null;
     const usage = chunk.usage;
 
@@ -99,9 +106,9 @@ export class OpenAIStreamMapper {
 
   private mapFinishReason(
     upstream: string,
-    hasToolCalls: boolean,
+    hasNewToolCall: boolean,
   ): 'stop' | 'length' | 'tool_calls' {
-    if (hasToolCalls) return 'tool_calls';
+    if (hasNewToolCall) return 'tool_calls';
     if (upstream === 'length') return 'length';
     if (upstream === 'tool_calls' || upstream === 'tool_use')
       return 'tool_calls';

--- a/ayunis-core-backend/src/domain/models/presenters/http/openai/openai-compat.module.ts
+++ b/ayunis-core-backend/src/domain/models/presenters/http/openai/openai-compat.module.ts
@@ -7,6 +7,7 @@ import { UsageModule } from 'src/domain/usage/usage.module';
 import { ModelsModule } from '../../../models.module';
 
 import { ChatCompletionsController } from './chat-completions.controller';
+import { OpenAIExceptionFilter } from './filters/openai-exception.filter';
 import { OpenAIRequestMapper } from './mappers/openai-request.mapper';
 import { OpenAIResponseMapper } from './mappers/openai-response.mapper';
 import { OpenAIStreamMapper } from './mappers/openai-stream.mapper';
@@ -28,6 +29,7 @@ import { OpenAIChatCompletionsMappers } from './mappers/openai-mappers';
     OpenAIStreamMapper,
     OpenAIErrorMapper,
     OpenAIChatCompletionsMappers,
+    OpenAIExceptionFilter,
   ],
 })
 export class OpenAICompatModule {}


### PR DESCRIPTION
- Wire OpenAIExceptionFilter via @UseFilters so pre-handler errors
  (validation, guards) reach the OpenAI envelope instead of leaking
  Ayunis' internal envelope to OpenAI SDK clients (I3).
- Per-turn scoping for tool_call_id → name: a tool result resolves
  against the most recent assistant turn, never against earlier turns
  that may have reused the same id (I6).
- Wrap stream$.subscribe() in try/catch inside the Promise executor so
  a synchronous producer throw still triggers cleanup (heartbeat, end)
  instead of leaving a half-open response (I7).
- Gate the finish_reason 'tool_calls' override on a NEW tool call
  (id or name in the delta), not on any toolCallsDelta — argument
  continuations of an in-flight call no longer flip 'stop' to
  'tool_calls' (I8).
- Tighten hasContent to require length > 0 so empty-string text deltas
  don't leak as content chunks (S21).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches OpenAI-compatible API error handling and streaming SSE behavior; mistakes could change client-visible envelopes or leave streams hanging, though changes are localized and well-covered by tests.
> 
> **Overview**
> **OpenAI-compat errors are now consistently mapped to the OpenAI-style envelope** by introducing `OpenAIExceptionFilter` and applying it via `@UseFilters` on `ChatCompletionsController` (and wiring it in `OpenAICompatModule`), replacing the controller’s ad-hoc `sendError` path so pre-handler errors (guards/validation) don’t leak internal envelopes.
> 
> **Streaming SSE robustness is improved** by catching synchronous throws from `stream$.subscribe()` to ensure heartbeat/subscription cleanup and `[DONE]` emission, and by tightening `OpenAIStreamMapper` to (a) drop empty-string text deltas, and (b) only override `finish_reason` to `tool_calls` when a *new* tool call boundary (id/name) appears, not mere arguments continuations.
> 
> **Tool-call result mapping is corrected** in `OpenAIRequestMapper` by scoping `tool_call_id → name` resolution to the most recent assistant turn, preventing mis-attribution when IDs are reused across turns; corresponding unit tests were added/updated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf6ff26fde1378ec77a48ee28883b6215e54944a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->