### PR TITLE
fix(models): redact prompt content from inference error logs (AYC-78)

### DIFF
--- a/ayunis-core-backend/src/domain/models/application/use-cases/get-inference/get-inference.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/get-inference/get-inference.use-case.ts
@@ -62,7 +62,13 @@ export class GetInferenceUseCase {
     if (error instanceof ModelError) throw error;
     this.logger.error('Inference failed', {
       model: command.model,
-      messages: command.messages,
+      // Conversation contents may carry user-provided PII; this logger sink
+      // reaches Sentry on the InferenceFailedError 500 path. Drop the bytes,
+      // keep the structure.
+      messages: command.messages.map((m) => ({
+        role: m.role,
+        contentParts: m.content.length,
+      })),
       tools: command.tools,
       toolChoice: command.toolChoice,
       error: error instanceof Error ? error : new Error('Unknown error'),


### PR DESCRIPTION
The InferenceFailedError 500 path serialises the full conversation —
including any user-provided PII — to the logger sink, which reaches
Sentry. The new OpenAI-compat surface widens this to programmatic
clients with long PII-bearing prompts.

Replace the messages payload in the error log with a structural summary
({role, contentParts}); model, tools, and toolChoice continue to be
logged as-is since they don't carry user content.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to error-log payload shaping on inference failures and do not affect inference execution or data persistence. Main risk is reduced observability when debugging prompt-related issues.
> 
> **Overview**
> On the `InferenceFailedError` (500) path, inference failure logging no longer serializes full conversation messages.
> 
> Instead, `GetInferenceUseCase.wrapHandlerError` logs a structural summary per message (`role` and `contentParts` count) while continuing to log `model`, `tools`, and `toolChoice`, reducing the risk of leaking user-provided PII to downstream log sinks (e.g., Sentry).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb8c511e9736205e71073a28a6ddad41280c5ff5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->