### PR TITLE
fix(runs): disable proxy buffering on SSE stream to prevent truncation (AYC-93)

### DIFF
--- a/ayunis-core-backend/src/domain/runs/presenters/http/runs.controller.ts
+++ b/ayunis-core-backend/src/domain/runs/presenters/http/runs.controller.ts
@@ -256,6 +256,12 @@ export class RunsController {
     response.setHeader('Content-Type', 'text/event-stream');
     response.setHeader('Cache-Control', 'no-cache');
     response.setHeader('Connection', 'keep-alive');
+    // Disable response buffering in nginx-style reverse proxies so SSE chunks
+    // reach the client immediately. Without this, buffered streams that get
+    // interrupted mid-flight surface as permanently truncated assistant
+    // messages because the server-side finally-block persists what it has.
+    response.setHeader('X-Accel-Buffering', 'no');
+    response.flushHeaders();
     // Send initial connection confirmation
     response.write(': connection established\n\n');
 

--- a/ayunis-core-backend/src/domain/usage/application/use-cases/get-monthly-credit-usage/get-monthly-credit-usage.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/usage/application/use-cases/get-monthly-credit-usage/get-monthly-credit-usage.use-case.spec.ts
@@ -57,7 +57,11 @@ describe('GetMonthlyCreditUsageUseCase', () => {
   });
 
   it('should use since date when it is later than month start', async () => {
-    const since = new Date('2026-04-10T00:00:00.000Z');
+    const now = new Date();
+    const monthStart = new Date(
+      Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1),
+    );
+    const since = new Date(monthStart.getTime() + 24 * 60 * 60 * 1000);
     await useCase.execute(new GetMonthlyCreditUsageQuery(orgId, since));
 
     const startDate = mockUsageRepository.getMonthlyCreditUsage.mock


### PR DESCRIPTION
Add X-Accel-Buffering: no header and explicit flushHeaders() call so
nginx-style reverse proxies forward chunks immediately. Without these
directives, buffered streams that get interrupted mid-flight surface
as permanently truncated assistant messages because the finally-block
in streaming-inference.service.ts persists whatever was accumulated.

Other proxies (Cloudflare, Envoy) ignore the header but auto-handle
text/event-stream correctly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small, localized change to SSE response headers that primarily affects streaming behavior behind nginx-style proxies.
> 
> **Overview**
> Prevents truncated SSE responses in `runs.controller.ts` by adding `X-Accel-Buffering: no` and calling `response.flushHeaders()` before streaming begins, ensuring reverse proxies forward chunks immediately.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58f62bb61f52a75cacf00965169d1063bdb6b007. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->