### PR TITLE
fix(usage): preserve fractional credits in admin user usage display (AYC-000)

### DIFF
--- a/ayunis-core-backend/src/domain/usage/infrastructure/persistence/local-usage/local-usage.repository.ts
+++ b/ayunis-core-backend/src/domain/usage/infrastructure/persistence/local-usage/local-usage.repository.ts
@@ -373,7 +373,7 @@ export class LocalUsageRepository extends UsageRepository {
     lastActivity?: Date | string | null;
   }): { credits: number; requests: number; lastActivity: Date | null } {
     return {
-      credits: row.credits ? Math.round(parseFloat(row.credits)) : 0,
+      credits: row.credits ? parseFloat(row.credits) : 0,
       requests: row.requests ? parseInt(row.requests, 10) : 0,
       lastActivity: row.lastActivity ? new Date(row.lastActivity) : null,
     };

--- a/ayunis-core-backend/src/domain/usage/infrastructure/persistence/local-usage/queries/sum-credits-for-org.db-query.spec.ts
+++ b/ayunis-core-backend/src/domain/usage/infrastructure/persistence/local-usage/queries/sum-credits-for-org.db-query.spec.ts
@@ -1,0 +1,46 @@
+import type { Repository } from 'typeorm';
+import { randomUUID } from 'crypto';
+import { sumCreditsForOrg } from './sum-credits-for-org.db-query';
+import type { UsageRecord } from '../schema/usage.record';
+
+describe('sumCreditsForOrg', () => {
+  function buildRepoReturning(totalCredits: string | undefined) {
+    const qb = {
+      select: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      getRawOne: jest
+        .fn()
+        .mockResolvedValue(
+          totalCredits === undefined ? undefined : { totalCredits },
+        ),
+    };
+    return {
+      createQueryBuilder: jest.fn().mockReturnValue(qb),
+    } as unknown as Repository<UsageRecord>;
+  }
+
+  it('preserves fractional credits instead of rounding to nearest integer', async () => {
+    const repo = buildRepoReturning('3.7');
+    const result = await sumCreditsForOrg(repo, randomUUID());
+    expect(result).toBe(3.7);
+  });
+
+  it('returns sub-credit fractions as decimals (not 0)', async () => {
+    const repo = buildRepoReturning('0.4');
+    const result = await sumCreditsForOrg(repo, randomUUID());
+    expect(result).toBe(0.4);
+  });
+
+  it('returns 0 when there are no usage records', async () => {
+    const repo = buildRepoReturning(undefined);
+    const result = await sumCreditsForOrg(repo, randomUUID());
+    expect(result).toBe(0);
+  });
+
+  it('returns 0 when the SUM is "0"', async () => {
+    const repo = buildRepoReturning('0');
+    const result = await sumCreditsForOrg(repo, randomUUID());
+    expect(result).toBe(0);
+  });
+});

--- a/ayunis-core-backend/src/domain/usage/infrastructure/persistence/local-usage/queries/sum-credits-for-org.db-query.ts
+++ b/ayunis-core-backend/src/domain/usage/infrastructure/persistence/local-usage/queries/sum-credits-for-org.db-query.ts
@@ -22,5 +22,5 @@ export async function sumCreditsForOrg(
 
   const result = await qb.getRawOne<{ totalCredits: string }>();
 
-  return Math.round(parseFloat(result?.totalCredits ?? '0'));
+  return parseFloat(result?.totalCredits ?? '0') || 0;
 }


### PR DESCRIPTION
- Drop Math.round in sumCreditsForOrg and mapUsageRow so per-user
  credits and the org total flow through as decimals
- Sub-credit usage no longer collapses to 0, fixing the appearance
  that "way too few credits are being deducted"
- Storage, budget enforcement, and the customer credit-usage endpoint
  were already decimal-correct; only the admin User Usage table was
  affected
- Add unit test for sumCreditsForOrg covering fractional sums

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: limited to parsing/display of usage credit aggregates, with added unit coverage; main impact is that decimals will now appear where integers were previously shown.
> 
> **Overview**
> Admin usage credit totals now **preserve decimals** instead of rounding: `mapUsageRow` and `sumCreditsForOrg` drop `Math.round` so fractional and sub-credit consumption flows through as a `number`.
> 
> Adds a unit test for `sumCreditsForOrg` covering fractional sums and empty/zero results.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d720f55dab48582c92730d34f0e42daaf389ca9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->