### PR TITLE
fix(install): use native form validation for terms checkbox (AYC-000)

### DIFF
--- a/ayunis-core-frontend/src/pages/install/ui/AcceptanceCheckboxField.tsx
+++ b/ayunis-core-frontend/src/pages/install/ui/AcceptanceCheckboxField.tsx
@@ -1,0 +1,58 @@
+import type { ReactNode } from 'react';
+import type {
+  FieldPath,
+  FieldPathByValue,
+  FieldValues,
+  UseFormReturn,
+} from 'react-hook-form';
+import { Checkbox } from '@/shared/ui/shadcn/checkbox';
+import {
+  FormControl,
+  FormField,
+  FormItem,
+  FormMessage,
+} from '@/shared/ui/shadcn/form';
+import { Label } from '@/shared/ui/shadcn/label';
+
+interface AcceptanceCheckboxFieldProps<TFieldValues extends FieldValues> {
+  readonly form: UseFormReturn<TFieldValues>;
+  readonly name: FieldPathByValue<TFieldValues, boolean>;
+  readonly id: string;
+  readonly disabled?: boolean;
+  readonly children: ReactNode;
+}
+
+export function AcceptanceCheckboxField<TFieldValues extends FieldValues>({
+  form,
+  name,
+  id,
+  disabled,
+  children,
+}: AcceptanceCheckboxFieldProps<TFieldValues>) {
+  return (
+    <FormField
+      control={form.control}
+      name={name as FieldPath<TFieldValues>}
+      render={({ field }) => (
+        <FormItem>
+          <FormControl>
+            <div className="flex items-start gap-2">
+              <Checkbox
+                id={id}
+                className="mt-0.5"
+                required
+                checked={Boolean(field.value)}
+                onCheckedChange={field.onChange}
+                disabled={disabled}
+              />
+              <Label htmlFor={id} className="block font-normal leading-normal">
+                {children}
+              </Label>
+            </div>
+          </FormControl>
+          <FormMessage />
+        </FormItem>
+      )}
+    />
+  );
+}

--- a/ayunis-core-frontend/src/pages/install/ui/InstallIntegrationPage.tsx
+++ b/ayunis-core-frontend/src/pages/install/ui/InstallIntegrationPage.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useForm, type UseFormReturn } from 'react-hook-form';
 import { useTranslation, Trans } from 'react-i18next';
 import { Link } from '@tanstack/react-router';
 import type { TFunction } from 'i18next';
@@ -20,13 +21,19 @@ import {
   CardHeader,
   CardTitle,
 } from '@/shared/ui/shadcn/card';
-import { Checkbox } from '@/shared/ui/shadcn/checkbox';
+import { Form } from '@/shared/ui/shadcn/form';
 import { useMarketplaceConfig } from '@/features/marketplace';
 
 import { ConfigFieldInput } from '@/shared/ui/config-field-input';
+import { AcceptanceCheckboxField } from './AcceptanceCheckboxField';
 
 interface InstallIntegrationPageProps {
   readonly integrationIdentifier: string | undefined;
+}
+
+interface InstallIntegrationFormFields {
+  legalAccepted: boolean;
+  termsAccepted: boolean;
 }
 
 export default function InstallIntegrationPage({
@@ -73,8 +80,9 @@ function InstallIntegrationContent({
   } = useMarketplaceControllerGetIntegration(integrationIdentifier);
   const installMutation = useInstallIntegrationFromMarketplace();
   const [formValues, setFormValues] = useState<Record<string, string>>({});
-  const [legalAccepted, setLegalAccepted] = useState(false);
-  const [termsAccepted, setTermsAccepted] = useState(false);
+  const form = useForm<InstallIntegrationFormFields>({
+    defaultValues: { legalAccepted: false, termsAccepted: false },
+  });
 
   if (isLoading) {
     return <InstallLoadingSkeleton />;
@@ -107,10 +115,7 @@ function InstallIntegrationContent({
       onFormValuesChange={setFormValues}
       onInstall={handleInstall}
       isInstalling={installMutation.isPending}
-      legalAccepted={legalAccepted}
-      onLegalAcceptedChange={setLegalAccepted}
-      termsAccepted={termsAccepted}
-      onTermsAcceptedChange={setTermsAccepted}
+      form={form}
     />
   );
 }
@@ -121,10 +126,7 @@ interface InstallIntegrationCardProps {
   readonly onFormValuesChange: (values: Record<string, string>) => void;
   readonly onInstall: () => void;
   readonly isInstalling: boolean;
-  readonly legalAccepted: boolean;
-  readonly onLegalAcceptedChange: (accepted: boolean) => void;
-  readonly termsAccepted: boolean;
-  readonly onTermsAcceptedChange: (accepted: boolean) => void;
+  readonly form: UseFormReturn<InstallIntegrationFormFields>;
 }
 
 function InstallIntegrationCard({
@@ -133,10 +135,7 @@ function InstallIntegrationCard({
   onFormValuesChange,
   onInstall,
   isInstalling,
-  legalAccepted,
-  onLegalAcceptedChange,
-  termsAccepted,
-  onTermsAcceptedChange,
+  form,
 }: InstallIntegrationCardProps) {
   const { t } = useTranslation('install-integration');
   const marketplace = useMarketplaceConfig();
@@ -161,10 +160,7 @@ function InstallIntegrationCard({
       onFormValuesChange={onFormValuesChange}
       onInstall={onInstall}
       isInstalling={isInstalling}
-      legalAccepted={legalAccepted}
-      onLegalAcceptedChange={onLegalAcceptedChange}
-      termsAccepted={termsAccepted}
-      onTermsAcceptedChange={onTermsAcceptedChange}
+      form={form}
       termsOfServiceUrl={termsOfServiceUrl}
       t={t}
     />
@@ -197,10 +193,7 @@ interface InstallIntegrationCardViewProps {
   readonly onFormValuesChange: (values: Record<string, string>) => void;
   readonly onInstall: () => void;
   readonly isInstalling: boolean;
-  readonly legalAccepted: boolean;
-  readonly onLegalAcceptedChange: (accepted: boolean) => void;
-  readonly termsAccepted: boolean;
-  readonly onTermsAcceptedChange: (accepted: boolean) => void;
+  readonly form: UseFormReturn<InstallIntegrationFormFields>;
   readonly termsOfServiceUrl: string | null;
   readonly t: TFunction;
 }
@@ -214,10 +207,7 @@ function InstallIntegrationCardView({
   onFormValuesChange,
   onInstall,
   isInstalling,
-  legalAccepted,
-  onLegalAcceptedChange,
-  termsAccepted,
-  onTermsAcceptedChange,
+  form,
   termsOfServiceUrl,
   t,
 }: InstallIntegrationCardViewProps) {
@@ -243,53 +233,72 @@ function InstallIntegrationCardView({
         <CardDescription>{integration.description}</CardDescription>
       </CardHeader>
 
-      <CardContent className="space-y-4">
-        <div className="rounded-md bg-muted/50 p-4">
-          <p className="text-sm text-muted-foreground">
-            {isZeroConfig
-              ? t('detail.zeroConfigNote')
-              : t('detail.installNote')}
-          </p>
-        </div>
+      <Form {...form}>
+        <form
+          onSubmit={(e) => {
+            void form.handleSubmit(() => onInstall())(e);
+          }}
+        >
+          <CardContent className="space-y-4">
+            <div className="rounded-md bg-muted/50 p-4">
+              <p className="text-sm text-muted-foreground">
+                {isZeroConfig
+                  ? t('detail.zeroConfigNote')
+                  : t('detail.installNote')}
+              </p>
+            </div>
 
-        {editableFields.map((field) => (
-          <ConfigFieldInput
-            key={field.key}
-            field={field}
-            value={formValues[field.key] ?? ''}
-            onChange={(value) =>
-              onFormValuesChange({ ...formValues, [field.key]: value })
-            }
-            disabled={isInstalling}
-          />
-        ))}
-
-        {hasLegalText && (
-          <div className="flex items-start gap-2">
-            <Checkbox
-              id="legal-accept"
-              className="mt-0.5"
-              checked={legalAccepted}
-              onCheckedChange={(checked) =>
-                onLegalAcceptedChange(checked === true)
-              }
-              disabled={isInstalling}
-            />
-            <span
-              className="text-sm leading-normal cursor-pointer select-none"
-              onClick={(e) => {
-                if (!isInstalling && !(e.target as HTMLElement).closest('a')) {
-                  onLegalAcceptedChange(!legalAccepted);
+            {editableFields.map((field) => (
+              <ConfigFieldInput
+                key={field.key}
+                field={field}
+                value={formValues[field.key] ?? ''}
+                onChange={(value) =>
+                  onFormValuesChange({ ...formValues, [field.key]: value })
                 }
-              }}
+                disabled={isInstalling}
+              />
+            ))}
+
+            {hasLegalText && (
+              <AcceptanceCheckboxField
+                form={form}
+                name="legalAccepted"
+                id="legal-accept"
+                disabled={isInstalling}
+              >
+                <Trans
+                  ns="install-integration"
+                  i18nKey="detail.legalText"
+                  components={{
+                    legalLink: (
+                      <a
+                        href={integration.legalTextUrl ?? ''}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="underline text-primary hover:text-primary/80"
+                      >
+                        placeholder
+                      </a>
+                    ),
+                  }}
+                />
+              </AcceptanceCheckboxField>
+            )}
+
+            <AcceptanceCheckboxField
+              form={form}
+              name="termsAccepted"
+              id="terms-accept"
+              disabled={isInstalling}
             >
               <Trans
                 ns="install-integration"
-                i18nKey="detail.legalText"
+                i18nKey="detail.termsOfServiceText"
                 components={{
-                  legalLink: (
+                  termsLink: (
                     <a
-                      href={integration.legalTextUrl ?? ''}
+                      href={termsOfServiceUrl ?? '#'}
                       target="_blank"
                       rel="noopener noreferrer"
                       className="underline text-primary hover:text-primary/80"
@@ -299,65 +308,25 @@ function InstallIntegrationCardView({
                   ),
                 }}
               />
-            </span>
-          </div>
-        )}
+            </AcceptanceCheckboxField>
+          </CardContent>
 
-        <div className="flex items-start gap-2">
-          <Checkbox
-            id="terms-accept"
-            className="mt-0.5"
-            checked={termsAccepted}
-            onCheckedChange={(checked) =>
-              onTermsAcceptedChange(checked === true)
-            }
-            disabled={isInstalling}
-          />
-          <span
-            className="text-sm leading-normal cursor-pointer select-none"
-            onClick={(e) => {
-              if (!isInstalling && !(e.target as HTMLElement).closest('a')) {
-                onTermsAcceptedChange(!termsAccepted);
-              }
-            }}
-          >
-            <Trans
-              ns="install-integration"
-              i18nKey="detail.termsOfServiceText"
-              components={{
-                termsLink: (
-                  <a
-                    href={termsOfServiceUrl ?? '#'}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="underline text-primary hover:text-primary/80"
-                  >
-                    placeholder
-                  </a>
-                ),
-              }}
-            />
-          </span>
-        </div>
-      </CardContent>
-
-      <CardFooter className="flex gap-3">
-        <Button variant="outline" className="flex-1" asChild>
-          <Link to="/admin-settings/integrations">{t('action.cancel')}</Link>
-        </Button>
-        <Button
-          className="flex-1"
-          onClick={onInstall}
-          disabled={
-            isInstalling ||
-            !allRequiredFilled ||
-            (hasLegalText && !legalAccepted) ||
-            !termsAccepted
-          }
-        >
-          {isInstalling ? t('action.installing') : t('action.install')}
-        </Button>
-      </CardFooter>
+          <CardFooter className="flex gap-3">
+            <Button variant="outline" className="flex-1" asChild>
+              <Link to="/admin-settings/integrations">
+                {t('action.cancel')}
+              </Link>
+            </Button>
+            <Button
+              type="submit"
+              className="flex-1"
+              disabled={isInstalling || !allRequiredFilled}
+            >
+              {isInstalling ? t('action.installing') : t('action.install')}
+            </Button>
+          </CardFooter>
+        </form>
+      </Form>
     </Card>
   );
 }

--- a/ayunis-core-frontend/src/pages/install/ui/InstallSkillCard.tsx
+++ b/ayunis-core-frontend/src/pages/install/ui/InstallSkillCard.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useForm } from 'react-hook-form';
 import { Button } from '@/shared/ui/shadcn/button';
 import {
   Card,
@@ -8,12 +8,13 @@ import {
   CardHeader,
   CardTitle,
 } from '@/shared/ui/shadcn/card';
-import { Checkbox } from '@/shared/ui/shadcn/checkbox';
+import { Form } from '@/shared/ui/shadcn/form';
 import { Bot } from 'lucide-react';
 import { useTranslation, Trans } from 'react-i18next';
 import { Link } from '@tanstack/react-router';
 import { useMarketplaceConfig } from '@/features/marketplace';
 import type { MarketplaceSkillResponseDto } from '../api/useFetchMarketplaceSkill';
+import { AcceptanceCheckboxField } from './AcceptanceCheckboxField';
 
 interface InstallSkillCardProps {
   skill: MarketplaceSkillResponseDto;
@@ -28,7 +29,9 @@ export function InstallSkillCard({
 }: Readonly<InstallSkillCardProps>) {
   const { t } = useTranslation('install');
   const marketplace = useMarketplaceConfig();
-  const [termsAccepted, setTermsAccepted] = useState(false);
+  const form = useForm<{ termsAccepted: boolean }>({
+    defaultValues: { termsAccepted: false },
+  });
 
   const termsOfServiceUrl = marketplace.url
     ? `${marketplace.url.replace(/\/$/, '')}/nutzungsbedingungen`
@@ -52,61 +55,54 @@ export function InstallSkillCard({
         <CardDescription>{skill.shortDescription}</CardDescription>
       </CardHeader>
 
-      <CardContent className="space-y-4">
-        <div className="rounded-md bg-muted/50 p-4">
-          <p className="text-sm text-muted-foreground">
-            {t('detail.installNote')}
-          </p>
-        </div>
-
-        <div className="flex items-start gap-2">
-          <Checkbox
-            id="terms-accept"
-            className="mt-0.5"
-            checked={termsAccepted}
-            onCheckedChange={(checked) => setTermsAccepted(checked === true)}
-            disabled={isInstalling}
-          />
-          <span
-            className="text-sm leading-normal cursor-pointer select-none"
-            onClick={(e) => {
-              if (!isInstalling && !(e.target as HTMLElement).closest('a')) {
-                setTermsAccepted(!termsAccepted);
-              }
-            }}
-          >
-            <Trans
-              ns="install"
-              i18nKey="detail.termsOfServiceText"
-              components={{
-                termsLink: (
-                  <a
-                    href={termsOfServiceUrl ?? '#'}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="underline text-primary hover:text-primary/80"
-                  >
-                    placeholder
-                  </a>
-                ),
-              }}
-            />
-          </span>
-        </div>
-      </CardContent>
-
-      <CardFooter className="flex gap-3">
-        <Button variant="outline" className="flex-1" asChild>
-          <Link to="/skills">{t('action.cancel')}</Link>
-        </Button>
-        <Button
-          className="flex-1"
-          onClick={onInstall}
-          disabled={isInstalling || !termsAccepted}
+      <Form {...form}>
+        <form
+          onSubmit={(e) => {
+            void form.handleSubmit(() => onInstall())(e);
+          }}
         >
-          {isInstalling ? t('action.installing') : t('action.install')}
-        </Button>
-      </CardFooter>
+          <CardContent className="space-y-4">
+            <div className="rounded-md bg-muted/50 p-4">
+              <p className="text-sm text-muted-foreground">
+                {t('detail.installNote')}
+              </p>
+            </div>
+
+            <AcceptanceCheckboxField
+              form={form}
+              name="termsAccepted"
+              id="terms-accept"
+              disabled={isInstalling}
+            >
+              <Trans
+                ns="install"
+                i18nKey="detail.termsOfServiceText"
+                components={{
+                  termsLink: (
+                    <a
+                      href={termsOfServiceUrl ?? '#'}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="underline text-primary hover:text-primary/80"
+                    >
+                      placeholder
+                    </a>
+                  ),
+                }}
+              />
+            </AcceptanceCheckboxField>
+          </CardContent>
+
+          <CardFooter className="flex gap-3">
+            <Button variant="outline" className="flex-1" asChild>
+              <Link to="/skills">{t('action.cancel')}</Link>
+            </Button>
+            <Button type="submit" className="flex-1" disabled={isInstalling}>
+              {isInstalling ? t('action.installing') : t('action.install')}
+            </Button>
+          </CardFooter>
+        </form>
+      </Form>
     </Card>
   );
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Moderate UI/UX risk: installation gating for terms/legal acceptance moves from explicit state checks to form submission/`required` checkbox validation, which could change when/if installs are blocked depending on how the custom `Checkbox` component propagates native validity.
> 
> **Overview**
> Introduces a reusable `AcceptanceCheckboxField` that wraps the Shadcn/Radix `Checkbox` in `react-hook-form` (`FormField`/`FormMessage`) and marks it `required`.
> 
> Refactors both `InstallIntegrationPage` and `InstallSkillCard` to use `react-hook-form` forms and submit buttons instead of local checkbox state and manual disabled logic, with install now triggered via form `onSubmit`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66adc103f3654a702b25e2929428e1be868df91a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->