### PR TITLE
feat(ui): adopt ghost-destructive button variant for delete icons (AYC-000)

### DIFF
--- a/ayunis-core-frontend/src/pages/admin-settings/letterheads-settings/ui/LetterheadsSettingsPage.tsx
+++ b/ayunis-core-frontend/src/pages/admin-settings/letterheads-settings/ui/LetterheadsSettingsPage.tsx
@@ -85,9 +85,8 @@ export function LetterheadsSettingsPage() {
                   </Button>
                 </Link>
                 <Button
-                  variant="ghost"
+                  variant="ghost-destructive"
                   size="icon"
-                  className="text-destructive hover:text-destructive"
                   onClick={(e) => {
                     e.stopPropagation();
                     setDeleteTarget(lh);

--- a/ayunis-core-frontend/src/pages/admin-settings/team-detail/ui/TeamMembersList.tsx
+++ b/ayunis-core-frontend/src/pages/admin-settings/team-detail/ui/TeamMembersList.tsx
@@ -49,9 +49,8 @@ export function TeamMembersList({
             </TableCell>
             <TableCell>
               <Button
-                variant="ghost"
+                variant="ghost-destructive"
                 size="icon"
-                className="text-destructive hover:text-destructive"
                 onClick={() => removeTeamMember(member.userId)}
                 disabled={removingUserIds.has(member.userId)}
               >

--- a/ayunis-core-frontend/src/pages/admin-settings/teams-settings/ui/TeamsList.tsx
+++ b/ayunis-core-frontend/src/pages/admin-settings/teams-settings/ui/TeamsList.tsx
@@ -62,9 +62,8 @@ export function TeamsList({ teams, onEditTeam }: Readonly<TeamsListProps>) {
               <Pencil className="h-4 w-4" />
             </Button>
             <Button
-              variant="ghost"
+              variant="ghost-destructive"
               size="icon"
-              className="text-destructive hover:text-destructive"
               onClick={(e) => {
                 e.stopPropagation();
                 deleteTeam(team.id);

--- a/ayunis-core-frontend/src/pages/chats/ui/ChatCard.tsx
+++ b/ayunis-core-frontend/src/pages/chats/ui/ChatCard.tsx
@@ -69,9 +69,8 @@ export default function ChatCard({ chat }: Readonly<ChatCardProps>) {
       </ItemContent>
       <ItemActions>
         <Button
-          variant="ghost"
+          variant="ghost-destructive"
           size="icon"
-          className="text-destructive hover:text-destructive"
           onClick={handleDelete}
           disabled={isDeleting}
         >

--- a/ayunis-core-frontend/src/pages/knowledge-base/ui/KnowledgeBasePage.tsx
+++ b/ayunis-core-frontend/src/pages/knowledge-base/ui/KnowledgeBasePage.tsx
@@ -111,9 +111,8 @@ export function KnowledgeBasePage({
                 <Tooltip>
                   <TooltipTrigger asChild>
                     <Button
-                      variant="ghost"
+                      variant="ghost-destructive"
                       size="icon"
-                      className="text-destructive hover:text-destructive"
                       onClick={handleDelete}
                       disabled={deleteKnowledgeBase.isPending}
                       aria-label={t('detail.deleteLabel')}

--- a/ayunis-core-frontend/src/pages/knowledge-bases/ui/KnowledgeBaseCard.tsx
+++ b/ayunis-core-frontend/src/pages/knowledge-bases/ui/KnowledgeBaseCard.tsx
@@ -70,9 +70,8 @@ export default function KnowledgeBaseCard({
       {!isShared && (
         <ItemActions>
           <Button
-            variant="ghost"
+            variant="ghost-destructive"
             size="icon"
-            className="text-destructive hover:text-destructive"
             onClick={(e) => {
               e.stopPropagation();
               handleDelete();

--- a/ayunis-core-frontend/src/pages/skill/ui/SkillPage.tsx
+++ b/ayunis-core-frontend/src/pages/skill/ui/SkillPage.tsx
@@ -159,9 +159,8 @@ export function SkillPage({
                   <Tooltip>
                     <TooltipTrigger asChild>
                       <Button
-                        variant="ghost"
+                        variant="ghost-destructive"
                         size="icon"
-                        className="text-destructive hover:text-destructive"
                         onClick={handleDelete}
                         disabled={deleteSkill.isPending}
                         aria-label={tSkills('card.deleteLabel')}

--- a/ayunis-core-frontend/src/pages/skills/ui/SkillCard.tsx
+++ b/ayunis-core-frontend/src/pages/skills/ui/SkillCard.tsx
@@ -124,9 +124,8 @@ export default function SkillCard({ skill }: Readonly<SkillCardProps>) {
           <Tooltip>
             <TooltipTrigger asChild>
               <Button
-                variant="ghost"
+                variant="ghost-destructive"
                 size="icon"
-                className="text-destructive hover:text-destructive"
                 onClick={(e) => {
                   e.stopPropagation();
                   handleDelete();

--- a/ayunis-core-frontend/src/pages/super-admin-settings/models-catalog/ui/ModelItem.tsx
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/models-catalog/ui/ModelItem.tsx
@@ -79,9 +79,8 @@ export function ModelItem({
           <Pencil className="h-4 w-4" />
         </Button>
         <Button
-          variant="ghost"
+          variant="ghost-destructive"
           size="icon"
-          className="text-destructive hover:text-destructive"
           onClick={onDelete}
           disabled={isDeleting}
         >

--- a/ayunis-core-frontend/src/pages/super-admin-settings/skill-templates/ui/SkillTemplateItem.tsx
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/skill-templates/ui/SkillTemplateItem.tsx
@@ -62,9 +62,8 @@ export function SkillTemplateItem({
           <Pencil className="h-4 w-4" />
         </Button>
         <Button
-          variant="ghost"
+          variant="ghost-destructive"
           size="icon"
-          className="text-destructive hover:text-destructive"
           onClick={onDelete}
           disabled={isDeleting}
         >

--- a/ayunis-core-frontend/src/shared/ui/shadcn/button.tsx
+++ b/ayunis-core-frontend/src/shared/ui/shadcn/button.tsx
@@ -18,6 +18,8 @@ const buttonVariants = cva(
           'bg-secondary text-secondary-foreground hover:bg-secondary/80',
         ghost:
           'hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50',
+        'ghost-destructive':
+          'text-destructive hover:bg-destructive/10 hover:text-destructive dark:hover:bg-destructive/20',
         link: 'text-primary underline-offset-4 hover:underline',
       },
       size: {


### PR DESCRIPTION
- Add ghost-destructive variant to shared Button (manually synced from
  @ayunis/ui until registry redeploy is fixed)
- Replace 'variant=ghost + className=text-destructive hover:text-destructive'
  workaround with the new variant across 11 ghost icon delete buttons
  (skills, agents, KB, chats, teams, letterheads, super-admin tables)

The variant gives a destructive-tinted hover background in addition to
red icon/text — the manual workaround only colored the icon, leaving a
neutral hover bg.