### PR TITLE
fix(chat): block send while uploaded sources are still processing (AYC-94)

### DIFF
--- a/ayunis-core-frontend/src/pages/chat/hooks/usePendingMessage.ts
+++ b/ayunis-core-frontend/src/pages/chat/hooks/usePendingMessage.ts
@@ -9,6 +9,7 @@ import type { PendingImage } from '../api/useMessageSend';
 import { SourceResponseDtoStatus } from '@/shared/api/generated/ayunisCoreAPI.schemas';
 
 const PROCESSING_POLL_INTERVAL_MS = 500;
+const PROCESSING_TIMEOUT_MS = 60_000;
 
 interface ThreadSourceStatus {
   id: string;
@@ -47,8 +48,14 @@ function areSourcesReady(
   );
 }
 
-function delay(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
+function delay(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(resolve, ms);
+    signal?.addEventListener('abort', () => {
+      clearTimeout(timer);
+      reject(signal.reason);
+    });
+  });
 }
 
 interface UsePendingMessageParams {
@@ -108,14 +115,21 @@ export function usePendingMessage({
       return extractSourceIds(results);
     }
 
-    async function waitForSourcesProcessed(uploadedIds: string[]) {
-      // Wait until: (a) every just-uploaded source is visible in the thread
-      // query (covers the brief gap between upload-success and refetch), and
-      // (b) no thread source is still PROCESSING.
+    async function waitForSourcesProcessed(
+      uploadedIds: string[],
+      signal: AbortSignal,
+    ) {
+      const deadline = Date.now() + PROCESSING_TIMEOUT_MS;
       let ready = false;
       while (!ready) {
+        signal.throwIfAborted();
         ready = areSourcesReady(threadSourcesRef.current, uploadedIds);
-        if (!ready) await delay(PROCESSING_POLL_INTERVAL_MS);
+        if (!ready) {
+          if (Date.now() >= deadline) {
+            throw new Error('Source processing timed out');
+          }
+          await delay(PROCESSING_POLL_INTERVAL_MS, signal);
+        }
       }
     }
 
@@ -140,6 +154,8 @@ export function usePendingMessage({
       }));
     }
 
+    const abortController = new AbortController();
+
     async function sendPendingMessage() {
       if (
         !pendingMessage ||
@@ -152,7 +168,7 @@ export function usePendingMessage({
       try {
         const uploadedIds = await uploadPendingSources();
         setSources([]);
-        await waitForSourcesProcessed(uploadedIds);
+        await waitForSourcesProcessed(uploadedIds, abortController.signal);
         await attachPendingKnowledgeBases();
         await sendTextMessage({
           text: pendingMessage,
@@ -160,6 +176,7 @@ export function usePendingMessage({
           skillId: pendingSkillId,
         });
       } catch (error) {
+        if (abortController.signal.aborted) return;
         if (error instanceof AxiosError && error.response?.status === 403) {
           showError(t('chat.upgradeToProError'));
         } else {
@@ -167,14 +184,20 @@ export function usePendingMessage({
         }
         chatInputRef.current?.setMessage(pendingMessage);
       } finally {
-        setIsProcessingPendingSources(false);
-        setPendingMessage('');
-        setPendingImages([]);
-        setPendingKnowledgeBases([]);
-        setPendingSkillId(undefined);
+        if (!abortController.signal.aborted) {
+          setIsProcessingPendingSources(false);
+          setPendingMessage('');
+          setPendingImages([]);
+          setPendingKnowledgeBases([]);
+          setPendingSkillId(undefined);
+        }
       }
     }
     void sendPendingMessage();
+
+    return () => {
+      abortController.abort();
+    };
   }, [
     pendingMessage,
     sendTextMessage,

--- a/ayunis-core-frontend/src/pages/chat/hooks/usePendingMessage.ts
+++ b/ayunis-core-frontend/src/pages/chat/hooks/usePendingMessage.ts
@@ -53,7 +53,12 @@ function delay(ms: number, signal?: AbortSignal): Promise<void> {
     const timer = setTimeout(resolve, ms);
     signal?.addEventListener('abort', () => {
       clearTimeout(timer);
-      reject(signal.reason);
+      const reason: unknown = signal.reason;
+      reject(
+        reason instanceof Error
+          ? reason
+          : new Error(typeof reason === 'string' ? reason : 'Aborted'),
+      );
     });
   });
 }

--- a/ayunis-core-frontend/src/pages/chat/hooks/usePendingMessage.ts
+++ b/ayunis-core-frontend/src/pages/chat/hooks/usePendingMessage.ts
@@ -9,7 +9,7 @@ import type { PendingImage } from '../api/useMessageSend';
 import { SourceResponseDtoStatus } from '@/shared/api/generated/ayunisCoreAPI.schemas';
 
 const PROCESSING_POLL_INTERVAL_MS = 500;
-const PROCESSING_TIMEOUT_MS = 60_000;
+const PROCESSING_TIMEOUT_MS = 180_000;
 
 interface ThreadSourceStatus {
   id: string;

--- a/ayunis-core-frontend/src/pages/chat/hooks/usePendingMessage.ts
+++ b/ayunis-core-frontend/src/pages/chat/hooks/usePendingMessage.ts
@@ -6,6 +6,50 @@ import { useChatContext } from '@/shared/contexts/chat/useChatContext';
 import { showError } from '@/shared/lib/toast';
 import type { ChatInputRef } from '@/widgets/chat-input/ui/ChatInput';
 import type { PendingImage } from '../api/useMessageSend';
+import { SourceResponseDtoStatus } from '@/shared/api/generated/ayunisCoreAPI.schemas';
+
+const PROCESSING_POLL_INTERVAL_MS = 500;
+
+interface ThreadSourceStatus {
+  id: string;
+  status?: SourceResponseDtoStatus;
+}
+
+function isSourceWithId(value: unknown): value is { id: string } {
+  if (value === null || typeof value !== 'object' || !('id' in value)) {
+    return false;
+  }
+  return typeof (value as { id: unknown }).id === 'string';
+}
+
+function extractSourceIds(results: unknown[]): string[] {
+  const ids: string[] = [];
+  for (const result of results) {
+    if (!Array.isArray(result)) continue;
+    for (const source of result) {
+      if (isSourceWithId(source)) {
+        ids.push(source.id);
+      }
+    }
+  }
+  return ids;
+}
+
+function areSourcesReady(
+  threadSources: ThreadSourceStatus[],
+  uploadedIds: string[],
+): boolean {
+  for (const id of uploadedIds) {
+    if (!threadSources.some((s) => s.id === id)) return false;
+  }
+  return !threadSources.some(
+    (s) => s.status === SourceResponseDtoStatus.processing,
+  );
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
 
 interface UsePendingMessageParams {
   sendTextMessage: (params: {
@@ -17,6 +61,7 @@ interface UsePendingMessageParams {
   resetCreateFileSourceMutation: () => void;
   addKnowledgeBaseAsync: (id: string) => Promise<unknown>;
   chatInputRef: RefObject<ChatInputRef | null>;
+  threadSources: ThreadSourceStatus[];
 }
 
 export function usePendingMessage({
@@ -25,6 +70,7 @@ export function usePendingMessage({
   resetCreateFileSourceMutation,
   addKnowledgeBaseAsync,
   chatInputRef,
+  threadSources,
 }: UsePendingMessageParams) {
   const { t } = useTranslation('chat');
   const processedPendingMessageRef = useRef<string | null>(null);
@@ -44,15 +90,33 @@ export function usePendingMessage({
     setPendingSkillId,
   } = useChatContext();
 
+  // Keep the latest thread sources accessible to the polling loop without
+  // re-running the send effect whenever statuses tick.
+  const threadSourcesRef = useRef(threadSources);
   useEffect(() => {
-    async function uploadPendingSources() {
-      if (sources.length === 0) return;
-      setIsProcessingPendingSources(true);
+    threadSourcesRef.current = threadSources;
+  }, [threadSources]);
+
+  useEffect(() => {
+    async function uploadPendingSources(): Promise<string[]> {
+      if (sources.length === 0) return [];
       const promises = sources.map((source) =>
         createFileSourceAsync({ file: source.file }),
       );
-      await Promise.all(promises as Promise<unknown>[]);
+      const results = await Promise.all(promises as Promise<unknown>[]);
       resetCreateFileSourceMutation();
+      return extractSourceIds(results);
+    }
+
+    async function waitForSourcesProcessed(uploadedIds: string[]) {
+      // Wait until: (a) every just-uploaded source is visible in the thread
+      // query (covers the brief gap between upload-success and refetch), and
+      // (b) no thread source is still PROCESSING.
+      let ready = false;
+      while (!ready) {
+        ready = areSourcesReady(threadSourcesRef.current, uploadedIds);
+        if (!ready) await delay(PROCESSING_POLL_INTERVAL_MS);
+      }
     }
 
     async function attachPendingKnowledgeBases() {
@@ -84,9 +148,11 @@ export function usePendingMessage({
         return;
       }
       processedPendingMessageRef.current = pendingMessage;
+      setIsProcessingPendingSources(true);
       try {
-        await uploadPendingSources();
+        const uploadedIds = await uploadPendingSources();
         setSources([]);
+        await waitForSourcesProcessed(uploadedIds);
         await attachPendingKnowledgeBases();
         await sendTextMessage({
           text: pendingMessage,

--- a/ayunis-core-frontend/src/pages/chat/ui/ChatPage.tsx
+++ b/ayunis-core-frontend/src/pages/chat/ui/ChatPage.tsx
@@ -246,16 +246,21 @@ export default function ChatPage({
     },
   });
 
+  const hasProcessingSources = thread.sources.some(
+    (s) => s.status === SourceResponseDtoStatus.processing,
+  );
+
   const { isProcessingPendingSources } = usePendingMessage({
     sendTextMessage,
     createFileSourceAsync,
     resetCreateFileSourceMutation,
     addKnowledgeBaseAsync,
     chatInputRef,
+    threadSources: thread.sources,
   });
 
   const isTotallyCreatingFileSource =
-    isCreatingFileSource || isProcessingPendingSources;
+    isCreatingFileSource || isProcessingPendingSources || hasProcessingSources;
 
   async function handleSend(
     message: string,

--- a/ayunis-core-frontend/src/widgets/chat-input/ui/ChatInput.tsx
+++ b/ayunis-core-frontend/src/widgets/chat-input/ui/ChatInput.tsx
@@ -173,7 +173,8 @@ const ChatInput = forwardRef<ChatInputRef, ChatInputProps>(
     const handleSend = () => {
       if (
         (!message.trim() && pendingImages.length === 0 && !selectedSkillId) ||
-        !(modelId || agentId)
+        !(modelId || agentId) ||
+        isCreatingFileSource
       ) {
         return;
       }
@@ -221,7 +222,8 @@ const ChatInput = forwardRef<ChatInputRef, ChatInputProps>(
     const canSend =
       (message.trim() || pendingImages.length > 0 || selectedSkillId) &&
       // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- intentional: empty string should use fallback
-      (modelId || agentId);
+      (modelId || agentId) &&
+      !isCreatingFileSource;
 
     function handlePaste(e: React.ClipboardEvent<HTMLTextAreaElement>) {
       // Ensure emojis are preserved when pasting


### PR DESCRIPTION
- Compute hasProcessingSources from thread.sources and fold it into the
  flag passed to ChatInput as isCreatingFileSource.
- Disable the Send button and gate the Enter-key shortcut on the same
  flag so users cannot submit before async document processing finishes.
- usePendingMessage now captures uploaded source IDs and polls a ref to
  thread.sources, waiting for them to leave PROCESSING before calling
  sendTextMessage.

Field reports (Gemeinde Maulburg) showed users sending prompts before
async PDF processing finished, then getting "doesn't work" responses.
The async backend pipeline is shared with KB and skills and stays
unchanged; only the chat UX is gated.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds client-side polling and send-gating around source processing; mistakes could cause the chat UI to get stuck disabled or send earlier/later than expected based on source status timing.
> 
> **Overview**
> Prevents users from sending prompts while newly uploaded document sources are still in `PROCESSING`.
> 
> `usePendingMessage` now collects uploaded source IDs and polls the latest `thread.sources` (via a ref) until those sources appear and all sources leave `processing` before calling `sendTextMessage`. `ChatPage` folds current thread processing state into the `isCreatingFileSource` flag, and `ChatInput` blocks both the Send button and Enter-to-send while that flag is true.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8ac54d1e5d6868ab9ee4c5d6910bec8ff3dac8b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->