### PR TITLE
fix(chat): reconcile streaming text with server state to prevent visual truncation (AYC-93)

### DIFF
--- a/ayunis-core-frontend/src/pages/chat/api/useMessageSend.ts
+++ b/ayunis-core-frontend/src/pages/chat/api/useMessageSend.ts
@@ -135,7 +135,33 @@ export function useMessageSend(params: UseMessageSendParams) {
         const reader = response.body.getReader();
         const decoder = new TextDecoder();
         let buffer = '';
-        let _eventCount = 0;
+
+        const dispatchLine = (line: string) => {
+          if (line.startsWith(':')) return;
+          if (!line.startsWith('data: ')) return;
+          try {
+            const data = JSON.parse(line.slice(6)) as { type?: string };
+            switch (data.type) {
+              case 'session':
+                params.onSessionEvent?.(data as RunSessionResponseDto);
+                break;
+              case 'message':
+                params.onMessageEvent?.(data as RunMessageResponseDto);
+                break;
+              case 'thread':
+                params.onThreadEvent?.(data as RunThreadResponseDto);
+                break;
+              case 'error':
+                params.onErrorEvent?.(data as RunErrorResponseDto);
+                break;
+              case undefined:
+              default:
+                console.warn('Unknown SSE event type:', data.type);
+            }
+          } catch (parseError) {
+            console.warn('Failed to parse SSE data:', line, parseError);
+          }
+        };
 
         try {
           // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
@@ -153,44 +179,24 @@ export function useMessageSend(params: UseMessageSendParams) {
             buffer = lines.pop() ?? '';
 
             for (const line of lines) {
-              // Handle SSE comment lines
-              if (line.startsWith(':')) {
-                continue;
-              }
-
-              // Handle SSE data lines
-              if (line.startsWith('data: ')) {
-                try {
-                  const jsonData = line.slice(6);
-                  const data = JSON.parse(jsonData) as { type?: string };
-                  _eventCount++;
-
-                  switch (data.type) {
-                    case 'session':
-                      params.onSessionEvent?.(data as RunSessionResponseDto);
-                      break;
-                    case 'message':
-                      params.onMessageEvent?.(data as RunMessageResponseDto);
-                      break;
-                    case 'thread':
-                      params.onThreadEvent?.(data as RunThreadResponseDto);
-                      break;
-                    case 'error':
-                      params.onErrorEvent?.(data as RunErrorResponseDto);
-                      break;
-                    case undefined:
-                    default:
-                      console.warn('Unknown SSE event type:', data.type);
-                  }
-                } catch (parseError) {
-                  console.warn('Failed to parse SSE data:', line, parseError);
-                }
-              }
+              dispatchLine(line);
             }
           }
         } catch (readerError) {
           console.error('Error reading SSE stream:', readerError);
           throw readerError;
+        }
+
+        // Flush any bytes pending in the decoder (e.g. multi-byte UTF-8
+        // codepoint split across the last chunk) and process the final
+        // line in the buffer. Defensive: an upstream proxy may close the
+        // connection after delivering a complete `data: …` line but
+        // before its trailing `\n\n`, which would otherwise be dropped.
+        buffer += decoder.decode();
+        if (buffer.length > 0) {
+          for (const line of buffer.split('\n')) {
+            dispatchLine(line);
+          }
         }
 
         params.onComplete?.();
@@ -232,8 +238,23 @@ export function useMessageSend(params: UseMessageSendParams) {
         // When aborted, we keep the optimistic local state to avoid race conditions
         // with the backend's async save operation
         if (!wasAbortedRef.current) {
+          // Cancel any in-flight thread refetch (e.g. an active refetchInterval
+          // poll) so its older response can't land after ours and shorten the
+          // displayed assistant text. Then await the refetch so the cache
+          // holds the post-save server state before sendMessage resolves.
+          const threadQueryKey = getThreadsControllerFindOneQueryKey(
+            params.threadId,
+          );
+          await queryClient.cancelQueries({
+            queryKey: threadQueryKey,
+            exact: true,
+          });
+          await queryClient.refetchQueries({
+            queryKey: threadQueryKey,
+            exact: true,
+          });
+
           [
-            getThreadsControllerFindOneQueryKey(params.threadId),
             getThreadsControllerFindAllQueryKey(),
             getArtifactsControllerFindByThreadQueryKey(params.threadId),
           ].forEach((queryKey) => {

--- a/ayunis-core-frontend/src/pages/chat/api/useMessageSend.ts
+++ b/ayunis-core-frontend/src/pages/chat/api/useMessageSend.ts
@@ -199,7 +199,6 @@ export function useMessageSend(params: UseMessageSendParams) {
           }
         }
 
-        params.onComplete?.();
       } catch (error) {
         console.error('Error in sendMessage', error);
 
@@ -238,6 +237,7 @@ export function useMessageSend(params: UseMessageSendParams) {
         // When aborted, we keep the optimistic local state to avoid race conditions
         // with the backend's async save operation
         if (!wasAbortedRef.current) {
+          params.onComplete?.();
           // Cancel any in-flight thread refetch (e.g. an active refetchInterval
           // poll) so its older response can't land after ours and shorten the
           // displayed assistant text. Then await the refetch so the cache

--- a/ayunis-core-frontend/src/pages/chat/api/useMessageSend.ts
+++ b/ayunis-core-frontend/src/pages/chat/api/useMessageSend.ts
@@ -198,7 +198,6 @@ export function useMessageSend(params: UseMessageSendParams) {
             dispatchLine(line);
           }
         }
-
       } catch (error) {
         console.error('Error in sendMessage', error);
 

--- a/ayunis-core-frontend/src/pages/chat/ui/ChatPage.tsx
+++ b/ayunis-core-frontend/src/pages/chat/ui/ChatPage.tsx
@@ -85,6 +85,7 @@ export default function ChatPage({
     enabled: isAgentsEnabled,
   });
   const { models, isLoading: isLoadingModels } = usePermittedModels();
+  const [isStreaming, setIsStreaming] = useState(false);
   const { data: thread = initialThread } = useQuery({
     queryKey: getThreadsControllerFindOneQueryKey(initialThread.id),
     queryFn: () => threadsControllerFindOne(initialThread.id),
@@ -92,6 +93,10 @@ export default function ChatPage({
     staleTime: 0,
     // eslint-disable-next-line sonarjs/function-return-type -- React Query's refetchInterval expects number | false
     refetchInterval: (query) => {
+      // Pause polling while streaming so a poll started before stream end
+      // can't land in the cache afterwards and shorten the displayed text
+      // via the [thread] reconciliation effect.
+      if (isStreaming) return false;
       const data = query.state.data;
       if (!data) return false;
       const hasProcessing = data.sources.some(
@@ -130,7 +135,6 @@ export default function ChatPage({
     thread.title,
   );
   const [messages, setMessages] = useState<Message[]>(thread.messages);
-  const [isStreaming, setIsStreaming] = useState(false);
   const [pendingSubmission, setPendingSubmission] = useState<string | null>(
     null,
   );


### PR DESCRIPTION
- Pause refetchInterval during streaming so a poll started before stream
  end can't land in the cache afterwards and shorten the displayed
  assistant text via the [thread] reconciliation effect
- Replace fire-and-forget invalidateQueries with awaited cancelQueries +
  refetchQueries on the thread query so the cache holds authoritative
  server state before sendMessage resolves
- Drain leftover SSE buffer and flush the TextDecoder after done=true so
  a final data: line whose trailing newlines were trimmed by an upstream
  proxy still reaches the message handler

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts SSE parsing and React Query refetch timing/polling during streaming; mistakes could cause missed final events or stale thread cache updates in the chat UI.
> 
> **Overview**
> Prevents assistant text from visually truncating after streaming by **pausing thread polling while `isStreaming`** so an in-flight `refetchInterval` request can’t overwrite newer streamed content.
> 
> Hardens `useMessageSend` by refactoring SSE line handling into `dispatchLine`, **flushing the `TextDecoder`/buffer on stream end** to avoid dropping a final `data:` event, and by replacing fire-and-forget invalidation with **`cancelQueries` + awaited `refetchQueries` for the thread** before invalidating related lists/artifacts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36f057b4881af9bdbd96644adc44ac64e9dd7c0f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->