### PR TITLE
fix(dev): unbreak slot startup and stop clobbering provider keys (AYC-000)

### DIFF
--- a/ayunis-core-anonymize/.dockerignore
+++ b/ayunis-core-anonymize/.dockerignore
@@ -1,0 +1,33 @@
+# Python-generated files
+__pycache__/
+*.py[oc]
+build/
+dist/
+wheels/
+*.egg-info
+
+# Virtual environments — must not clobber the in-image .venv created by `uv sync`
+.venv
+venv/
+env/
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# Environment variables
+.env
+.env.local
+
+# Git / Docker meta
+.git
+.gitignore
+.dockerignore
+Dockerfile
+
+# OS
+.DS_Store
+Thumbs.db

--- a/ayunis-core-anonymize/Dockerfile
+++ b/ayunis-core-anonymize/Dockerfile
@@ -15,11 +15,15 @@ RUN uv sync --frozen --no-dev
 ENV HF_HOME=/root/.cache/huggingface
 RUN uv run python -c "from huggingface_hub import snapshot_download; snapshot_download('urchade/gliner_multi_pii-v1')"
 
-# Copy application code
+# Copy application code, then re-sync so the project install reflects the
+# actual source (otherwise `uv run` does this on every container start and
+# restarts uvicorn mid-boot, blowing past the healthcheck window).
 COPY . .
+RUN uv sync --frozen --no-dev
 
 # Expose the service port
 EXPOSE 8000
 
-# Run the application
-CMD ["uv", "run", "uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]
+# --no-sync skips the implicit sync uv would otherwise run on every container
+# start; the venv is already complete from the build step above.
+CMD ["uv", "run", "--no-sync", "uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/dev
+++ b/dev
@@ -156,18 +156,11 @@ REDIS_HOST=localhost
 REDIS_PORT=$REDIS_HOST_PORT
 GOTENBERG_URL=http://localhost:$GOTENBERG_HOST_PORT
 MCP_ENCRYPTION_KEY=$mcp_key
-# Provider API key stubs — every inference handler except Azure eagerly
-# constructs its SDK client at module init and the SDKs throw on empty
-# apiKey. Placeholders let the backend boot; real keys override these
-# via the user's shell env if set. Remove when handlers lazy-init (see
-# AzureStreamInferenceHandler for the correct pattern).
-OPENAI_API_KEY=\${OPENAI_API_KEY:-sk-dev-placeholder}
-ANTHROPIC_API_KEY=\${ANTHROPIC_API_KEY:-sk-ant-dev-placeholder}
-MISTRAL_API_KEY=\${MISTRAL_API_KEY:-dev-placeholder}
-OTC_API_KEY=\${OTC_API_KEY:-dev-placeholder}
-SCALEWAY_API_KEY=\${SCALEWAY_API_KEY:-dev-placeholder}
-STACKIT_API_KEY=\${STACKIT_API_KEY:-dev-placeholder}
-GEMINI_API_KEY=\${GEMINI_API_KEY:-dev-placeholder}
+# Provider API keys (OPENAI_API_KEY, ANTHROPIC_API_KEY, MISTRAL_API_KEY, …)
+# are intentionally NOT written here — they belong in .env (or your shell)
+# and would otherwise be clobbered by placeholders. If the backend crashes
+# at boot because a provider SDK rejects an empty key, add the key to
+# ayunis-core-backend/.env.
 EOF
 
   # -- 3. Run database migrations ------------------------------------------


### PR DESCRIPTION
- ayunis-core-anonymize: add .dockerignore so the host's local .venv
  no longer overwrites the in-image one created by `uv sync`. Without
  it, every container start wiped and reinstalled 96 packages, blowing
  past the healthcheck window and causing `compose up --wait` to mark
  the container unhealthy and exit 1.
- ayunis-core-anonymize: re-sync after `COPY . .` and run uvicorn with
  `uv run --no-sync` so container start is just an exec — `uv run`'s
  implicit sync was uninstalling/reinstalling the project itself
  (ms-presidio) on every boot and restarting uvicorn mid-startup.
- dev: drop the provider-key stub lines from the generated .env.dev.
  They wrote the literal text `${OPENAI_API_KEY:-…}` (escaped `$` in
  the heredoc, and dotenv doesn't expand shell syntax), which then
  overrode real keys from .env. Provider keys belong in .env or the
  shell — not in the slot-specific override file.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes container build/runtime behavior (`uv sync`/`uv run`) and alters generated env overrides, which could impact local/dev startup if assumptions about dependency syncing or env loading differ.
> 
> **Overview**
> Improves `ayunis-core-anonymize` Docker startup stability by adding a `.dockerignore` (so host virtualenvs don’t overwrite the image venv), re-running `uv sync` after `COPY . .`, and starting `uvicorn` via `uv run --no-sync` to avoid implicit re-sync/restarts at container boot.
> 
> Updates the `dev` slot script to stop writing placeholder provider API keys into `ayunis-core-backend/.env.dev`, ensuring real keys from `.env` or the shell aren’t clobbered; replaces those lines with guidance comments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d13ac34df08cdf80a179ff8df01281d3fb43165. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->