### PR TITLE
fix(chat): rework new-chat submission flow and unify ChatInput states (AYC-94)

### DIFF
--- a/ayunis-core-frontend/src/pages/chat/hooks/usePendingMessage.ts
+++ b/ayunis-core-frontend/src/pages/chat/hooks/usePendingMessage.ts
@@ -1,67 +1,9 @@
-import type { RefObject } from 'react';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef } from 'react';
 import { AxiosError } from 'axios';
 import { useTranslation } from 'react-i18next';
 import { useChatContext } from '@/shared/contexts/chat/useChatContext';
 import { showError } from '@/shared/lib/toast';
-import type { ChatInputRef } from '@/widgets/chat-input/ui/ChatInput';
 import type { PendingImage } from '../api/useMessageSend';
-import { SourceResponseDtoStatus } from '@/shared/api/generated/ayunisCoreAPI.schemas';
-
-const PROCESSING_POLL_INTERVAL_MS = 500;
-const PROCESSING_TIMEOUT_MS = 180_000;
-
-interface ThreadSourceStatus {
-  id: string;
-  status?: SourceResponseDtoStatus;
-}
-
-function isSourceWithId(value: unknown): value is { id: string } {
-  if (value === null || typeof value !== 'object' || !('id' in value)) {
-    return false;
-  }
-  return typeof (value as { id: unknown }).id === 'string';
-}
-
-function extractSourceIds(results: unknown[]): string[] {
-  const ids: string[] = [];
-  for (const result of results) {
-    if (!Array.isArray(result)) continue;
-    for (const source of result) {
-      if (isSourceWithId(source)) {
-        ids.push(source.id);
-      }
-    }
-  }
-  return ids;
-}
-
-function areSourcesReady(
-  threadSources: ThreadSourceStatus[],
-  uploadedIds: string[],
-): boolean {
-  for (const id of uploadedIds) {
-    if (!threadSources.some((s) => s.id === id)) return false;
-  }
-  return !threadSources.some(
-    (s) => s.status === SourceResponseDtoStatus.processing,
-  );
-}
-
-function delay(ms: number, signal?: AbortSignal): Promise<void> {
-  return new Promise((resolve, reject) => {
-    const timer = setTimeout(resolve, ms);
-    signal?.addEventListener('abort', () => {
-      clearTimeout(timer);
-      const reason: unknown = signal.reason;
-      reject(
-        reason instanceof Error
-          ? reason
-          : new Error(typeof reason === 'string' ? reason : 'Aborted'),
-      );
-    });
-  });
-}
 
 interface UsePendingMessageParams {
   sendTextMessage: (params: {
@@ -69,165 +11,67 @@ interface UsePendingMessageParams {
     images?: PendingImage[];
     skillId?: string;
   }) => Promise<void>;
-  createFileSourceAsync: (params: { file: File }) => unknown;
-  resetCreateFileSourceMutation: () => void;
-  addKnowledgeBaseAsync: (id: string) => Promise<unknown>;
-  chatInputRef: RefObject<ChatInputRef | null>;
-  threadSources: ThreadSourceStatus[];
 }
 
+/**
+ * After redirect from the new-chat page, ChatPage mounts with a pending
+ * message stashed in chat context. This hook fires once on mount, sends
+ * the message, and clears the context. Source uploads, knowledge-base
+ * attachment, and source-processing waits all happen *before* navigation
+ * (see useInitiateChat) — by the time we get here the thread is already
+ * fully prepared.
+ */
 export function usePendingMessage({
   sendTextMessage,
-  createFileSourceAsync,
-  resetCreateFileSourceMutation,
-  addKnowledgeBaseAsync,
-  chatInputRef,
-  threadSources,
 }: UsePendingMessageParams) {
   const { t } = useTranslation('chat');
-  const processedPendingMessageRef = useRef<string | null>(null);
-  const [isProcessingPendingSources, setIsProcessingPendingSources] =
-    useState(false);
-
+  const sentRef = useRef(false);
   const {
     pendingMessage,
     setPendingMessage,
-    sources,
-    setSources,
     pendingImages,
     setPendingImages,
-    pendingKnowledgeBases,
-    setPendingKnowledgeBases,
     pendingSkillId,
     setPendingSkillId,
   } = useChatContext();
 
-  // Keep the latest thread sources accessible to the polling loop without
-  // re-running the send effect whenever statuses tick.
-  const threadSourcesRef = useRef(threadSources);
   useEffect(() => {
-    threadSourcesRef.current = threadSources;
-  }, [threadSources]);
+    if (!pendingMessage || sentRef.current) return;
+    sentRef.current = true;
 
-  useEffect(() => {
-    async function uploadPendingSources(): Promise<string[]> {
-      if (sources.length === 0) return [];
-      const promises = sources.map((source) =>
-        createFileSourceAsync({ file: source.file }),
-      );
-      const results = await Promise.all(promises as Promise<unknown>[]);
-      resetCreateFileSourceMutation();
-      return extractSourceIds(results);
-    }
+    const text = pendingMessage;
+    const images: PendingImage[] | undefined =
+      pendingImages.length > 0
+        ? pendingImages.map((img) => ({
+            file: img.file,
+            altText: img.altText ?? (img.file.name || 'Pasted image'),
+          }))
+        : undefined;
+    const skillId = pendingSkillId;
 
-    async function waitForSourcesProcessed(
-      uploadedIds: string[],
-      signal: AbortSignal,
-    ) {
-      const deadline = Date.now() + PROCESSING_TIMEOUT_MS;
-      let ready = false;
-      while (!ready) {
-        signal.throwIfAborted();
-        ready = areSourcesReady(threadSourcesRef.current, uploadedIds);
-        if (!ready) {
-          if (Date.now() >= deadline) {
-            throw new Error('Source processing timed out');
-          }
-          await delay(PROCESSING_POLL_INTERVAL_MS, signal);
-        }
-      }
-    }
+    setPendingMessage('');
+    setPendingImages([]);
+    setPendingSkillId(undefined);
 
-    async function attachPendingKnowledgeBases() {
-      if (pendingKnowledgeBases.length === 0) return;
-      const results = await Promise.allSettled(
-        pendingKnowledgeBases.map((kb) => addKnowledgeBaseAsync(kb.id)),
-      );
-      const failed = results.filter((r) => r.status === 'rejected');
-      if (failed.length > 0) {
-        console.error(
-          `Failed to attach ${String(failed.length)} knowledge base(s)`,
-        );
-      }
-    }
-
-    function buildPendingImages(): PendingImage[] | undefined {
-      if (pendingImages.length === 0) return undefined;
-      return pendingImages.map((img) => ({
-        file: img.file,
-        altText: img.altText ?? (img.file.name || 'Pasted image'),
-      }));
-    }
-
-    const abortController = new AbortController();
-
-    async function sendPendingMessage() {
-      if (
-        !pendingMessage ||
-        processedPendingMessageRef.current === pendingMessage
-      ) {
-        return;
-      }
-      processedPendingMessageRef.current = pendingMessage;
-      setIsProcessingPendingSources(true);
+    void (async () => {
       try {
-        const uploadedIds = await uploadPendingSources();
-        setSources([]);
-        await waitForSourcesProcessed(uploadedIds, abortController.signal);
-        await attachPendingKnowledgeBases();
-        await sendTextMessage({
-          text: pendingMessage,
-          images: buildPendingImages(),
-          skillId: pendingSkillId,
-        });
+        await sendTextMessage({ text, images, skillId });
       } catch (error) {
-        if (abortController.signal.aborted) return;
         if (error instanceof AxiosError && error.response?.status === 403) {
           showError(t('chat.upgradeToProError'));
         } else {
           showError(t('chat.errorSendMessage'));
         }
-        chatInputRef.current?.setMessage(pendingMessage);
-      } finally {
-        if (!abortController.signal.aborted) {
-          setIsProcessingPendingSources(false);
-          setPendingMessage('');
-          setPendingImages([]);
-          setPendingKnowledgeBases([]);
-          setPendingSkillId(undefined);
-        }
       }
-    }
-    void sendPendingMessage();
-
-    return () => {
-      abortController.abort();
-    };
+    })();
   }, [
     pendingMessage,
+    pendingImages,
+    pendingSkillId,
     sendTextMessage,
     setPendingMessage,
-    sources,
-    createFileSourceAsync,
-    setSources,
-    pendingImages,
     setPendingImages,
-    pendingKnowledgeBases,
-    setPendingKnowledgeBases,
-    pendingSkillId,
     setPendingSkillId,
-    addKnowledgeBaseAsync,
-    chatInputRef,
     t,
-    resetCreateFileSourceMutation,
   ]);
-
-  return {
-    pendingMessage,
-    sources,
-    pendingImages,
-    pendingKnowledgeBases,
-    pendingSkillId,
-    isProcessingPendingSources,
-  };
 }

--- a/ayunis-core-frontend/src/pages/chat/hooks/usePendingMessage.ts
+++ b/ayunis-core-frontend/src/pages/chat/hooks/usePendingMessage.ts
@@ -11,6 +11,7 @@ interface UsePendingMessageParams {
     images?: PendingImage[];
     skillId?: string;
   }) => Promise<void>;
+  onSendStart?: () => void;
 }
 
 /**
@@ -23,6 +24,7 @@ interface UsePendingMessageParams {
  */
 export function usePendingMessage({
   sendTextMessage,
+  onSendStart,
 }: UsePendingMessageParams) {
   const { t } = useTranslation('chat');
   const sentRef = useRef(false);
@@ -55,6 +57,7 @@ export function usePendingMessage({
 
     void (async () => {
       try {
+        onSendStart?.();
         await sendTextMessage({ text, images, skillId });
       } catch (error) {
         if (error instanceof AxiosError && error.response?.status === 403) {
@@ -68,6 +71,7 @@ export function usePendingMessage({
     pendingMessage,
     pendingImages,
     pendingSkillId,
+    onSendStart,
     sendTextMessage,
     setPendingMessage,
     setPendingImages,

--- a/ayunis-core-frontend/src/pages/chat/ui/ChatPage.tsx
+++ b/ayunis-core-frontend/src/pages/chat/ui/ChatPage.tsx
@@ -247,7 +247,10 @@ export default function ChatPage({
     (s) => s.status === SourceResponseDtoStatus.processing,
   );
 
-  usePendingMessage({ sendTextMessage });
+  usePendingMessage({
+    sendTextMessage,
+    onSendStart: () => setIsStreaming(true),
+  });
 
   // Send is gated while a fresh upload is in flight or while server-side
   // processing of an attached source hasn't finished — both are reasons we

--- a/ayunis-core-frontend/src/pages/chat/ui/ChatPage.tsx
+++ b/ayunis-core-frontend/src/pages/chat/ui/ChatPage.tsx
@@ -173,20 +173,17 @@ export default function ChatPage({
     },
   });
 
-  const {
-    createFileSource,
-    createFileSourceAsync,
-    isLoading: isCreatingFileSource,
-    reset: resetCreateFileSourceMutation,
-  } = useCreateFileSource({
-    threadId: thread.id,
-  });
+  const { createFileSource, isLoading: isCreatingFileSource } =
+    useCreateFileSource({
+      threadId: thread.id,
+    });
   const { deleteFileSource } = useDeleteFileSource({
     threadId: thread.id,
   });
 
-  const { addKnowledgeBase, addKnowledgeBaseAsync, removeKnowledgeBase } =
-    useKnowledgeBaseAttachment({ threadId: thread.id });
+  const { addKnowledgeBase, removeKnowledgeBase } = useKnowledgeBaseAttachment({
+    threadId: thread.id,
+  });
   const { downloadSource } = useDownloadSource(thread);
 
   const handleMessage = useCallback((message: RunMessageResponseDtoMessage) => {
@@ -250,17 +247,12 @@ export default function ChatPage({
     (s) => s.status === SourceResponseDtoStatus.processing,
   );
 
-  const { isProcessingPendingSources } = usePendingMessage({
-    sendTextMessage,
-    createFileSourceAsync,
-    resetCreateFileSourceMutation,
-    addKnowledgeBaseAsync,
-    chatInputRef,
-    threadSources: thread.sources,
-  });
+  usePendingMessage({ sendTextMessage });
 
-  const isTotallyCreatingFileSource =
-    isCreatingFileSource || isProcessingPendingSources || hasProcessingSources;
+  // Send is gated while a fresh upload is in flight or while server-side
+  // processing of an attached source hasn't finished — both are reasons we
+  // want the user to wait before they can submit a message.
+  const isSendDisabled = isCreatingFileSource || hasProcessingSources;
 
   async function handleSend(
     message: string,
@@ -410,8 +402,8 @@ export default function ChatPage({
         sources={thread.sources}
         knowledgeBases={thread.knowledgeBases}
         isAnonymous={thread.isAnonymous}
-        isStreaming={isStreaming}
-        isCreatingFileSource={isTotallyCreatingFileSource}
+        submissionState={isStreaming ? 'streaming' : 'idle'}
+        isSendDisabled={isSendDisabled}
         onModelChange={() => {}}
         onAgentChange={() => {}}
         onAgentRemove={() => {}}
@@ -421,7 +413,7 @@ export default function ChatPage({
         onAddKnowledgeBase={(kb) => addKnowledgeBase(kb.id)}
         onRemoveKnowledgeBase={removeKnowledgeBase}
         onSend={(m, imageFiles) => void handleSend(m, imageFiles)}
-        onSendCancelled={handleSendCancelled}
+        onCancel={handleSendCancelled}
         isEmbeddingModelEnabled={isEmbeddingModelEnabled}
         isVisionEnabled={isVisionEnabled}
       />

--- a/ayunis-core-frontend/src/pages/new-chat/api/useInitiateChat.tsx
+++ b/ayunis-core-frontend/src/pages/new-chat/api/useInitiateChat.tsx
@@ -1,69 +1,239 @@
-import { getThreadsControllerFindAllQueryKey } from '@/shared/api';
+import {
+  getThreadsControllerFindAllQueryKey,
+  getThreadsControllerFindOneQueryKey,
+  threadKnowledgeBasesControllerAddKnowledgeBase,
+  threadSourcesControllerAddFileSource,
+  threadsControllerFindOne,
+  useThreadsControllerCreate,
+} from '@/shared/api/generated/ayunisCoreAPI';
+import { SourceResponseDtoStatus } from '@/shared/api/generated/ayunisCoreAPI.schemas';
+import handleSourceUploadError from '@/shared/lib/handle-source-upload-error';
+import { showError } from '@/shared/lib/toast';
 import { useChatContext } from '@/shared/contexts/chat/useChatContext';
+import type { KnowledgeBaseSummary } from '@/shared/contexts/chat/chatContext';
 import { useNavigate } from '@tanstack/react-router';
-import { useThreadsControllerCreate } from '@/shared/api/generated/ayunisCoreAPI';
+import { useQueryClient } from '@tanstack/react-query';
+import { useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import type { CreateThreadData } from '../model/openapi';
 import type { SourceResponseDtoType } from '@/shared/api';
-import { useQueryClient } from '@tanstack/react-query';
+
+const PROCESSING_POLL_INTERVAL_MS = 500;
+const PROCESSING_TIMEOUT_MS = 180_000;
+const UPLOAD_TIMEOUT_MS = 60_000;
+
+interface PendingSource {
+  id: string;
+  name: string;
+  type: SourceResponseDtoType;
+  file: File;
+}
+
+export type SourceUploadStatus =
+  | { kind: 'uploading' }
+  | { kind: 'processing' }
+  | { kind: 'failed'; message: string };
+
+interface InitiateChatParams {
+  message: string;
+  modelId?: string;
+  agentId?: string;
+  sources: PendingSource[];
+  knowledgeBases: KnowledgeBaseSummary[];
+  isAnonymous: boolean;
+  /** Reports per-source progress so the page can render upload/processing
+   *  state on each chip. */
+  onSourceStatus?: (sourceId: string, status: SourceUploadStatus) => void;
+}
+
+class CancelledError extends Error {
+  constructor() {
+    super('Cancelled');
+    this.name = 'CancelledError';
+  }
+}
+
+async function waitForSourcesProcessed(
+  threadId: string,
+  isCancelled: () => boolean,
+): Promise<void> {
+  const deadline = Date.now() + PROCESSING_TIMEOUT_MS;
+  for (;;) {
+    if (isCancelled()) throw new CancelledError();
+    const thread = await threadsControllerFindOne(threadId);
+    const stillProcessing = thread.sources.some(
+      (s) => s.status === SourceResponseDtoStatus.processing,
+    );
+    if (!stillProcessing) return;
+    if (Date.now() >= deadline) {
+      throw new Error('Source processing timed out');
+    }
+    await new Promise((resolve) =>
+      setTimeout(resolve, PROCESSING_POLL_INTERVAL_MS),
+    );
+  }
+}
 
 export const useInitiateChat = (options?: { onSuccess?: () => void }) => {
-  const { setPendingMessage, setSources } = useChatContext();
+  const { t } = useTranslation('chat');
+  const { t: tCommon } = useTranslation('common');
+  const { setPendingMessage } = useChatContext();
   const navigate = useNavigate();
   const queryClient = useQueryClient();
-  const createThreadMutation = useThreadsControllerCreate({
-    mutation: {
-      onSuccess: (threadResponse) => {
-        void queryClient.invalidateQueries({
-          queryKey: getThreadsControllerFindAllQueryKey(),
-        });
-        options?.onSuccess?.();
-        // Navigate to the new thread
-        void navigate({
-          to: '/chats/$threadId',
-          params: { threadId: threadResponse.id },
-        });
-      },
-      onError: (error) => {
-        console.error('Failed to create thread:', error);
-        // Clear pending message on error
-        setPendingMessage('');
-      },
-    },
-  });
+  const createThreadMutation = useThreadsControllerCreate();
+  const [isAttachingResources, setIsAttachingResources] = useState(false);
 
-  function initiateChat(
-    message: string,
-    modelId?: string,
-    agentId?: string,
-    sources?: Array<{
-      id: string;
-      name: string;
-      type: SourceResponseDtoType;
-      file: File;
-    }>,
-    isAnonymous?: boolean,
-  ) {
-    // Store the message and attachments as pending so ChatPage can send them
-    // Note: Images are already stored in context by ChatInput when threadId is not available
-    setPendingMessage(message);
-    setSources(sources ?? []);
+  // Cancellation flag is a ref because we want `cancel()` to flip it
+  // synchronously and have any in-flight pipeline observe it on the next
+  // checkpoint, without dragging it through the dependency graph.
+  const cancelledRef = useRef(false);
 
-    // Create thread data
-    const createThreadData: CreateThreadData = {
-      modelId,
-      agentId,
-      isAnonymous,
-    };
+  async function uploadOneSource(
+    threadId: string,
+    source: PendingSource,
+    onSourceStatus?: (id: string, status: SourceUploadStatus) => void,
+  ): Promise<void> {
+    try {
+      await threadSourcesControllerAddFileSource(
+        threadId,
+        { file: source.file },
+        AbortSignal.timeout(UPLOAD_TIMEOUT_MS),
+      );
+      onSourceStatus?.(source.id, { kind: 'processing' });
+    } catch (error) {
+      onSourceStatus?.(source.id, {
+        kind: 'failed',
+        message: error instanceof Error ? error.message : 'Upload failed',
+      });
+      throw error;
+    }
+  }
 
-    // Create the new thread
-    createThreadMutation.mutate({
-      data: createThreadData,
+  /** Returns true on success, false on user-visible failure (toast already
+   *  shown). Caller should bail on false. */
+  async function uploadAllSources(
+    threadId: string,
+    sources: PendingSource[],
+    onSourceStatus?: (id: string, status: SourceUploadStatus) => void,
+  ): Promise<boolean> {
+    sources.forEach((s) => onSourceStatus?.(s.id, { kind: 'uploading' }));
+    try {
+      await Promise.all(
+        sources.map((source) =>
+          uploadOneSource(threadId, source, onSourceStatus),
+        ),
+      );
+      return true;
+    } catch (error) {
+      console.error('Failed to upload sources:', error);
+      handleSourceUploadError(error, tCommon);
+      return false;
+    }
+  }
+
+  /** Returns true on success, false on user-visible failure (toast shown). */
+  async function attachKnowledgeBases(
+    threadId: string,
+    knowledgeBases: KnowledgeBaseSummary[],
+    isCancelled: () => boolean,
+  ): Promise<boolean> {
+    for (const kb of knowledgeBases) {
+      if (isCancelled()) return false;
+      try {
+        await threadKnowledgeBasesControllerAddKnowledgeBase(threadId, kb.id);
+      } catch (error) {
+        console.error('Failed to attach knowledge base:', error);
+        showError(t('chat.errorAddKnowledgeBase'));
+        return false;
+      }
+    }
+    return true;
+  }
+
+  async function initiateChat({
+    message,
+    modelId,
+    agentId,
+    sources,
+    knowledgeBases,
+    isAnonymous,
+    onSourceStatus,
+  }: InitiateChatParams): Promise<void> {
+    cancelledRef.current = false;
+    const isCancelled = () => cancelledRef.current;
+
+    let thread;
+    try {
+      const createThreadData: CreateThreadData = {
+        modelId,
+        agentId,
+        isAnonymous,
+      };
+      thread = await createThreadMutation.mutateAsync({
+        data: createThreadData,
+      });
+    } catch (error) {
+      console.error('Failed to create thread:', error);
+      showError(t('chat.errorSendMessage'));
+      return;
+    }
+    if (isCancelled()) return;
+
+    if (sources.length === 0 && knowledgeBases.length === 0) {
+      finalizeAndNavigate(thread.id, message);
+      return;
+    }
+
+    setIsAttachingResources(true);
+    try {
+      if (sources.length > 0) {
+        const ok = await uploadAllSources(thread.id, sources, onSourceStatus);
+        if (!ok || isCancelled()) return;
+
+        try {
+          await waitForSourcesProcessed(thread.id, isCancelled);
+        } catch (error) {
+          if (error instanceof CancelledError) return;
+          console.error('Source processing failed or timed out:', error);
+          showError(tCommon('sources.fileSourceTimeoutError'));
+          return;
+        }
+      }
+
+      const kbOk = await attachKnowledgeBases(
+        thread.id,
+        knowledgeBases,
+        isCancelled,
+      );
+      if (!kbOk || isCancelled()) return;
+
+      finalizeAndNavigate(thread.id, message);
+    } finally {
+      setIsAttachingResources(false);
+    }
+  }
+
+  function finalizeAndNavigate(threadId: string, message: string) {
+    void queryClient.invalidateQueries({
+      queryKey: getThreadsControllerFindAllQueryKey(),
     });
+    void queryClient.invalidateQueries({
+      queryKey: getThreadsControllerFindOneQueryKey(threadId),
+    });
+    setPendingMessage(message);
+    options?.onSuccess?.();
+    void navigate({ to: '/chats/$threadId', params: { threadId } });
+  }
+
+  function cancel() {
+    cancelledRef.current = true;
+    setIsAttachingResources(false);
   }
 
   return {
     initiateChat,
-    isCreating: createThreadMutation.isPending,
+    cancel,
+    isCreating: createThreadMutation.isPending || isAttachingResources,
     error: createThreadMutation.error,
   };
 };

--- a/ayunis-core-frontend/src/pages/new-chat/ui/NewChatPage.tsx
+++ b/ayunis-core-frontend/src/pages/new-chat/ui/NewChatPage.tsx
@@ -1,6 +1,9 @@
 import NewChatPageLayout from './NewChatPageLayout';
 import ChatInput from '@/widgets/chat-input';
-import { useInitiateChat } from '../api/useInitiateChat';
+import {
+  useInitiateChat,
+  type SourceUploadStatus,
+} from '../api/useInitiateChat';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import ContentAreaHeader from '@/widgets/content-area-header/ui/ContentAreaHeader';
@@ -8,7 +11,10 @@ import { HelpLink } from '@/shared/ui/help-link/HelpLink';
 import { showError } from '@/shared/lib/toast';
 import { generateUUID } from '@/shared/lib/uuid';
 import type { AgentResponseDto } from '@/shared/api';
-import { SourceResponseDtoType } from '@/shared/api/generated/ayunisCoreAPI.schemas';
+import {
+  SourceResponseDtoStatus,
+  SourceResponseDtoType,
+} from '@/shared/api/generated/ayunisCoreAPI.schemas';
 import { usePermittedModels } from '@/features/usePermittedModels';
 import { useTimeBasedGreeting } from '../model/useTimeBasedGreeting';
 import { useChatContext } from '@/shared/contexts/chat/useChatContext';
@@ -35,11 +41,10 @@ export default function NewChatPage({
   agents,
 }: Readonly<NewChatPageProps>) {
   const { t } = useTranslation('chat');
-  const { initiateChat } = useInitiateChat();
+  const { initiateChat, cancel, isCreating } = useInitiateChat();
   const { models } = usePermittedModels();
   const greeting = useTimeBasedGreeting();
-  const { setPendingImages, setPendingKnowledgeBases, setPendingSkillId } =
-    useChatContext();
+  const { setPendingImages, setPendingSkillId } = useChatContext();
   const {
     hasSystemPrompt,
     isLoading: isSystemPromptLoading,
@@ -57,14 +62,36 @@ export default function NewChatPage({
   const [modelId, setModelId] = useState(selectedModelId);
   const [agentId, setAgentId] = useState(selectedAgentId);
   const [isAnonymous, setIsAnonymous] = useState(false);
-  const [sources, setSources] = useState<
-    Array<{
-      id: string;
-      name: string;
-      type: SourceResponseDtoType;
-      file: File;
-    }>
-  >([]);
+  type LocalSource = {
+    id: string;
+    name: string;
+    type: SourceResponseDtoType;
+    file: File;
+    // Local status mirroring the server-side SourceResponseDtoStatus values
+    // — set during upload+processing so the chip in ChatInput renders the
+    // correct spinner/error state via the same code path the chat page uses.
+    status?: SourceResponseDtoStatus;
+    processingError?: string;
+  };
+  const [sources, setSources] = useState<LocalSource[]>([]);
+
+  function applySourceStatus(
+    source: LocalSource,
+    status: SourceUploadStatus,
+  ): LocalSource {
+    if (status.kind === 'failed') {
+      return {
+        ...source,
+        status: SourceResponseDtoStatus.failed,
+        processingError: status.message,
+      };
+    }
+    return {
+      ...source,
+      status: SourceResponseDtoStatus.processing,
+      processingError: undefined,
+    };
+  }
   const [selectedKnowledgeBases, setSelectedKnowledgeBases] = useState<
     KnowledgeBaseSummary[]
   >([]);
@@ -132,6 +159,12 @@ export default function NewChatPage({
     setModelId(selectedModelId);
   }
 
+  function handleSourceStatus(sourceId: string, status: SourceUploadStatus) {
+    setSources((prev) =>
+      prev.map((s) => (s.id === sourceId ? applySourceStatus(s, status) : s)),
+    );
+  }
+
   function handleSend(
     message: string,
     imageFiles?: Array<{ file: File; altText?: string }>,
@@ -142,18 +175,36 @@ export default function NewChatPage({
       return;
     }
 
-    // Store images in context for ChatPage to upload after thread creation
+    // Images are sent as part of the first multipart request from ChatPage,
+    // so they hitch a ride through context. KBs and sources are attached
+    // before navigation by initiateChat itself.
     if (imageFiles && imageFiles.length > 0) {
       setPendingImages(imageFiles);
     }
-
-    // Store selected KBs in context for ChatPage to attach after thread creation
-    // Always set — even when empty — to clear stale KBs from a previous failed attempt
-    setPendingKnowledgeBases(selectedKnowledgeBases);
-
     setPendingSkillId(skillId);
 
-    initiateChat(message, modelId, agentId, sources, isAnonymous);
+    void initiateChat({
+      message,
+      modelId,
+      agentId,
+      sources,
+      knowledgeBases: selectedKnowledgeBases,
+      isAnonymous,
+      onSourceStatus: handleSourceStatus,
+    });
+  }
+
+  function handleCancel() {
+    cancel();
+    // Clear in-flight statuses so chips become removable again. Keep the
+    // sources themselves so the user doesn't lose their attachments.
+    setSources((prev) =>
+      prev.map((s) => ({
+        ...s,
+        status: undefined,
+        processingError: undefined,
+      })),
+    );
   }
 
   if (!isSystemPromptLoading && !isSystemPromptError && !hasSystemPrompt) {
@@ -198,11 +249,12 @@ export default function NewChatPage({
           agentId={agentId}
           sources={sources}
           knowledgeBases={selectedKnowledgeBases}
+          submissionState={isCreating ? 'submitting' : 'idle'}
           onModelChange={handleModelChange}
           onAgentChange={handleAgentChange}
           onAgentRemove={handleAgentRemove}
           onSend={handleSend}
-          onSendCancelled={() => null}
+          onCancel={handleCancel}
           onFileUpload={handleFileUpload}
           onRemoveSource={handleRemoveSource}
           onDownloadSource={() => null}

--- a/ayunis-core-frontend/src/pages/new-chat/ui/NewChatPage.tsx
+++ b/ayunis-core-frontend/src/pages/new-chat/ui/NewChatPage.tsx
@@ -178,9 +178,7 @@ export default function NewChatPage({
     // Images are sent as part of the first multipart request from ChatPage,
     // so they hitch a ride through context. KBs and sources are attached
     // before navigation by initiateChat itself.
-    if (imageFiles && imageFiles.length > 0) {
-      setPendingImages(imageFiles);
-    }
+    setPendingImages(imageFiles && imageFiles.length > 0 ? imageFiles : []);
     setPendingSkillId(skillId);
 
     void initiateChat({

--- a/ayunis-core-frontend/src/shared/contexts/chat/ChatContextProvider.tsx
+++ b/ayunis-core-frontend/src/shared/contexts/chat/ChatContextProvider.tsx
@@ -1,6 +1,5 @@
 import { useState, useMemo } from 'react';
-import { ChatContext, type KnowledgeBaseSummary } from './chatContext';
-import type { SourceResponseDtoType } from '@/shared/api';
+import { ChatContext } from './chatContext';
 
 type PendingImageFile = {
   file: File;
@@ -13,41 +12,19 @@ export const ChatContextProvider = ({
   children: React.ReactNode;
 }) => {
   const [pendingMessage, setPendingMessage] = useState('');
-  const [sources, setSources] = useState<
-    Array<{
-      id: string;
-      name: string;
-      type: SourceResponseDtoType;
-      file: File;
-    }>
-  >([]);
   const [pendingImages, setPendingImages] = useState<PendingImageFile[]>([]);
-  const [pendingKnowledgeBases, setPendingKnowledgeBases] = useState<
-    KnowledgeBaseSummary[]
-  >([]);
   const [pendingSkillId, setPendingSkillId] = useState<string | undefined>();
 
-  // Memoize the context value to prevent unnecessary re-renders
   const contextValue = useMemo(
     () => ({
       pendingMessage,
       setPendingMessage,
-      sources,
-      setSources,
       pendingImages,
       setPendingImages,
-      pendingKnowledgeBases,
-      setPendingKnowledgeBases,
       pendingSkillId,
       setPendingSkillId,
     }),
-    [
-      pendingMessage,
-      sources,
-      pendingImages,
-      pendingKnowledgeBases,
-      pendingSkillId,
-    ],
+    [pendingMessage, pendingImages, pendingSkillId],
   );
 
   return (

--- a/ayunis-core-frontend/src/shared/contexts/chat/chatContext.ts
+++ b/ayunis-core-frontend/src/shared/contexts/chat/chatContext.ts
@@ -1,4 +1,3 @@
-import type { SourceResponseDtoType } from '@/shared/api';
 import { createContext } from 'react';
 
 type PendingImageFile = {
@@ -14,24 +13,8 @@ export type KnowledgeBaseSummary = {
 type ChatContextType = {
   pendingMessage: string;
   setPendingMessage: (message: string) => void;
-  sources: Array<{
-    id: string;
-    name: string;
-    type: SourceResponseDtoType;
-    file: File;
-  }>;
-  setSources: (
-    sources: Array<{
-      id: string;
-      name: string;
-      type: SourceResponseDtoType;
-      file: File;
-    }>,
-  ) => void;
   pendingImages: PendingImageFile[];
   setPendingImages: (images: PendingImageFile[]) => void;
-  pendingKnowledgeBases: KnowledgeBaseSummary[];
-  setPendingKnowledgeBases: (kbs: KnowledgeBaseSummary[]) => void;
   pendingSkillId: string | undefined;
   setPendingSkillId: (skillId: string | undefined) => void;
 };
@@ -41,17 +24,9 @@ export const ChatContext = createContext<ChatContextType>({
   setPendingMessage: () => {
     throw new Error('setPendingMessage is not implemented');
   },
-  sources: [],
-  setSources: () => {
-    throw new Error('setSources is not implemented');
-  },
   pendingImages: [],
   setPendingImages: () => {
     throw new Error('setPendingImages is not implemented');
-  },
-  pendingKnowledgeBases: [],
-  setPendingKnowledgeBases: () => {
-    throw new Error('setPendingKnowledgeBases is not implemented');
   },
   pendingSkillId: undefined,
   setPendingSkillId: () => {

--- a/ayunis-core-frontend/src/widgets/chat-input/ui/ChatInput.tsx
+++ b/ayunis-core-frontend/src/widgets/chat-input/ui/ChatInput.tsx
@@ -32,6 +32,21 @@ import { showError } from '@/shared/lib/toast';
 import { MicrophoneButton } from './MicrophoneButton';
 import type { KnowledgeBaseSummary } from '@/shared/contexts/chat/chatContext';
 
+/**
+ * Lifecycle of an in-flight submit. The input behaves differently in each:
+ *
+ * - `idle`     — fully editable, send button visible, can submit if `canSend`.
+ * - `submitting` — message is being delivered (upload + processing pipeline
+ *                  on the new-chat page). Textarea is read-only, plus button
+ *                  disabled, send button replaced with a cancel button. Local
+ *                  message state is preserved so it survives a cancellation
+ *                  or a failure.
+ * - `streaming`  — assistant response is streaming. Textarea remains editable
+ *                  (so the user can prepare a follow-up), but the send button
+ *                  is replaced with a cancel button.
+ */
+export type ChatInputSubmissionState = 'idle' | 'submitting' | 'streaming';
+
 interface ChatInputProps {
   modelId: string | undefined;
   agentId: string | undefined;
@@ -44,8 +59,13 @@ interface ChatInputProps {
     processingError?: string;
   }[];
   knowledgeBases?: KnowledgeBaseSummary[];
-  isStreaming?: boolean;
-  isCreatingFileSource?: boolean;
+  /** Default `'idle'`. See {@link ChatInputSubmissionState}. */
+  submissionState?: ChatInputSubmissionState;
+  /**
+   * Extra reason to disable the send button even when `submissionState` is
+   * `'idle'` — e.g. existing-chat sources still processing server-side.
+   */
+  isSendDisabled?: boolean;
   isModelChangeDisabled: boolean;
   isAgentChangeDisabled?: boolean;
   isAnonymousChangeDisabled?: boolean;
@@ -62,7 +82,8 @@ interface ChatInputProps {
     imageFiles?: Array<{ file: File; altText?: string }>,
     skillId?: string,
   ) => void;
-  onSendCancelled: () => void;
+  /** Fired when the user clicks the cancel button while in-flight. */
+  onCancel: () => void;
   selectedSkillId?: string;
   selectedSkillName?: string;
   onSkillRemove?: () => void;
@@ -89,8 +110,8 @@ const ChatInput = forwardRef<ChatInputRef, ChatInputProps>(
       agentId,
       sources,
       knowledgeBases,
-      isStreaming,
-      isCreatingFileSource,
+      submissionState = 'idle',
+      isSendDisabled,
       isModelChangeDisabled,
       isAgentChangeDisabled,
       isAnonymousChangeDisabled,
@@ -103,7 +124,7 @@ const ChatInput = forwardRef<ChatInputRef, ChatInputProps>(
       onAddKnowledgeBase,
       onRemoveKnowledgeBase,
       onSend,
-      onSendCancelled,
+      onCancel,
       isEmbeddingModelEnabled,
       isAnonymous,
       onAnonymousChange,
@@ -117,6 +138,8 @@ const ChatInput = forwardRef<ChatInputRef, ChatInputProps>(
   ) => {
     const [isFocused, setIsFocused] = useState<boolean>(false);
     const [message, setMessage] = useState('');
+    const isSubmitting = submissionState === 'submitting';
+    const inFlight = submissionState !== 'idle';
     const { t } = useTranslation('common');
     const isAgentsEnabled = useIsAgentsEnabled();
     const { agents } = useAgents({ enabled: isAgentsEnabled });
@@ -149,7 +172,7 @@ const ChatInput = forwardRef<ChatInputRef, ChatInputProps>(
           showError(t('chatInput.imageLimitExceeded', { max: MAX_IMAGES }));
         }
       },
-      isDocumentUploadEnabled: isEmbeddingModelEnabled && !isCreatingFileSource,
+      isDocumentUploadEnabled: isEmbeddingModelEnabled && !inFlight,
       isImageUploadEnabled: isVisionEnabled,
       acceptedDocumentExtensions: [
         '.pdf',
@@ -174,7 +197,8 @@ const ChatInput = forwardRef<ChatInputRef, ChatInputProps>(
       if (
         (!message.trim() && pendingImages.length === 0 && !selectedSkillId) ||
         !(modelId || agentId) ||
-        isCreatingFileSource
+        inFlight ||
+        isSendDisabled
       ) {
         return;
       }
@@ -190,7 +214,10 @@ const ChatInput = forwardRef<ChatInputRef, ChatInputProps>(
         imageFiles.length > 0 ? imageFiles : undefined,
         selectedSkillId,
       );
-      setMessage('');
+      // Note: we deliberately do NOT clear `message` here. Parents can call
+      // `chatInputRef.current.setMessage('')` once the submit has actually
+      // committed (e.g. after navigation). This way the typed text survives
+      // the upload pipeline and any cancellation/error.
       clearImages();
     };
 
@@ -223,7 +250,8 @@ const ChatInput = forwardRef<ChatInputRef, ChatInputProps>(
       (message.trim() || pendingImages.length > 0 || selectedSkillId) &&
       // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- intentional: empty string should use fallback
       (modelId || agentId) &&
-      !isCreatingFileSource;
+      !inFlight &&
+      !isSendDisabled;
 
     function handlePaste(e: React.ClipboardEvent<HTMLTextAreaElement>) {
       // Ensure emojis are preserved when pasting
@@ -293,13 +321,17 @@ const ChatInput = forwardRef<ChatInputRef, ChatInputProps>(
                 maxRows={10}
                 value={message}
                 autoFocus
+                readOnly={isSubmitting}
                 onChange={(e) => setMessage(e.target.value)}
                 onPaste={handlePaste}
                 onFocus={() => setIsFocused(true)}
                 onBlur={() => setIsFocused(false)}
                 placeholder={t('chatInput.placeholder')}
                 aria-label={t('chatInput.placeholder')}
-                className="border-0 border-none bg-transparent rounded-none resize-none focus:outline-none p-0"
+                className={cn(
+                  'border-0 border-none bg-transparent rounded-none resize-none focus:outline-none p-0',
+                  isSubmitting && 'opacity-60 cursor-not-allowed',
+                )}
                 data-testid="input"
               />
 
@@ -309,9 +341,8 @@ const ChatInput = forwardRef<ChatInputRef, ChatInputProps>(
                   <PlusButton
                     onFileUpload={onFileUpload}
                     onImageSelect={handleImageSelect}
-                    isFileSourceDisabled={!isEmbeddingModelEnabled}
-                    isCreatingFileSource={isCreatingFileSource}
-                    isImageUploadDisabled={!isVisionEnabled}
+                    isFileSourceDisabled={!isEmbeddingModelEnabled || inFlight}
+                    isImageUploadDisabled={!isVisionEnabled || inFlight}
                     onKnowledgeBaseSelect={onAddKnowledgeBase}
                     attachedKnowledgeBaseIds={knowledgeBases?.map(
                       (kb) => kb.id,
@@ -372,10 +403,10 @@ const ChatInput = forwardRef<ChatInputRef, ChatInputProps>(
                     }}
                   />
                   <SendButton
-                    isStreaming={!!isStreaming}
+                    inFlight={inFlight}
                     canSend={!!canSend}
                     onSend={handleSend}
-                    onCancel={onSendCancelled}
+                    onCancel={onCancel}
                   />
                 </div>
               </div>

--- a/ayunis-core-frontend/src/widgets/chat-input/ui/ChatInput.tsx
+++ b/ayunis-core-frontend/src/widgets/chat-input/ui/ChatInput.tsx
@@ -341,7 +341,9 @@ const ChatInput = forwardRef<ChatInputRef, ChatInputProps>(
                   <PlusButton
                     onFileUpload={onFileUpload}
                     onImageSelect={handleImageSelect}
-                    isFileSourceDisabled={!isEmbeddingModelEnabled || isSubmitting}
+                    isFileSourceDisabled={
+                      !isEmbeddingModelEnabled || isSubmitting
+                    }
                     isImageUploadDisabled={!isVisionEnabled || isSubmitting}
                     onKnowledgeBaseSelect={onAddKnowledgeBase}
                     attachedKnowledgeBaseIds={knowledgeBases?.map(

--- a/ayunis-core-frontend/src/widgets/chat-input/ui/ChatInput.tsx
+++ b/ayunis-core-frontend/src/widgets/chat-input/ui/ChatInput.tsx
@@ -341,8 +341,8 @@ const ChatInput = forwardRef<ChatInputRef, ChatInputProps>(
                   <PlusButton
                     onFileUpload={onFileUpload}
                     onImageSelect={handleImageSelect}
-                    isFileSourceDisabled={!isEmbeddingModelEnabled || inFlight}
-                    isImageUploadDisabled={!isVisionEnabled || inFlight}
+                    isFileSourceDisabled={!isEmbeddingModelEnabled || isSubmitting}
+                    isImageUploadDisabled={!isVisionEnabled || isSubmitting}
                     onKnowledgeBaseSelect={onAddKnowledgeBase}
                     attachedKnowledgeBaseIds={knowledgeBases?.map(
                       (kb) => kb.id,

--- a/ayunis-core-frontend/src/widgets/chat-input/ui/PlusButton.tsx
+++ b/ayunis-core-frontend/src/widgets/chat-input/ui/PlusButton.tsx
@@ -29,8 +29,6 @@ import { useIsKnowledgeBasesEnabled } from '@/features/feature-toggles';
 interface PlusButtonProps {
   onFileUpload: (file: File) => void;
   onImageSelect?: (files: FileList | null) => void;
-  isCreatingFileSource?: boolean;
-  isUploadingFile?: boolean;
   isFileSourceDisabled?: boolean;
   isImageUploadDisabled?: boolean;
   onKnowledgeBaseSelect?: (knowledgeBase: KnowledgeBaseSummary) => void;
@@ -41,8 +39,6 @@ export default function PlusButton({
   onFileUpload,
   onImageSelect,
   isFileSourceDisabled,
-  isUploadingFile,
-  isCreatingFileSource,
   isImageUploadDisabled = false,
   onKnowledgeBaseSelect,
   attachedKnowledgeBaseIds = [],
@@ -90,9 +86,6 @@ export default function PlusButton({
     }
   };
 
-  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- boolean OR, false should fall through
-  const isLoading = isUploadingFile || isCreatingFileSource;
-
   // Filter out already-attached knowledge bases
   const availableKBs = knowledgeBases.filter(
     (kb) => !attachedKnowledgeBaseIds.includes(kb.id),
@@ -107,13 +100,10 @@ export default function PlusButton({
             <Button
               size="icon"
               variant="outline"
+              disabled={isFileSourceDisabled && isImageUploadDisabled}
               aria-label={t('chatInput.addButtonTooltip')}
             >
-              {isLoading ? (
-                <Loader2 className="h-4 w-4 animate-spin" />
-              ) : (
-                <Plus className="h-4 w-4" />
-              )}
+              <Plus className="h-4 w-4" />
             </Button>
           </TooltipTrigger>
         </DropdownMenuTrigger>
@@ -125,8 +115,7 @@ export default function PlusButton({
             >
               <DropdownMenuItem
                 onClick={() => documentInputRef.current?.click()}
-                // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- boolean OR, false should fall through
-                disabled={isLoading || isFileSourceDisabled}
+                disabled={isFileSourceDisabled}
               >
                 <FileText className="h-4 w-4" />
                 <span>{t('chatInput.uploadDocument')}</span>
@@ -134,8 +123,7 @@ export default function PlusButton({
             </TooltipIf>
             <DropdownMenuItem
               onClick={() => imageInputRef.current?.click()}
-              // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- boolean OR, false should fall through
-              disabled={isLoading || isImageUploadDisabled}
+              disabled={isImageUploadDisabled}
             >
               <Image className="h-4 w-4" />
               <span>{t('chatInput.uploadImage')}</span>

--- a/ayunis-core-frontend/src/widgets/chat-input/ui/SendButton.tsx
+++ b/ayunis-core-frontend/src/widgets/chat-input/ui/SendButton.tsx
@@ -8,21 +8,23 @@ import {
 import { useTranslation } from 'react-i18next';
 
 interface SendButtonProps {
-  isStreaming: boolean;
+  /** True while a submit is in flight (submitting or streaming). Replaces
+   *  the send icon with a stop icon wired to {@link onCancel}. */
+  inFlight: boolean;
   canSend: boolean;
   onSend: () => void;
   onCancel: () => void;
 }
 
 export function SendButton({
-  isStreaming,
+  inFlight,
   canSend,
   onSend,
   onCancel,
 }: Readonly<SendButtonProps>) {
   const { t } = useTranslation('common');
 
-  if (isStreaming) {
+  if (inFlight) {
     return (
       <Tooltip>
         <TooltipTrigger asChild>


### PR DESCRIPTION
The previous gating in usePendingMessage hosted a multi-step async
pipeline (upload → wait → attach → send) inside a useEffect keyed on
sixteen deps. Several of those deps — notably createFileSourceAsync —
get fresh references during the upload itself, which fired the effect
cleanup and aborted the in-flight work, leaving the user with an
endless spinner and a lost message.

- Move upload + processing-wait + KB-attach into useInitiateChat,
  before navigation. usePendingMessage collapses to a one-shot
  sendTextMessage call with no abort plumbing or polling.
- Drop sources/setSources and pendingKnowledgeBases from chat context;
  they only existed to bridge the navigation that no longer happens
  mid-pipeline.
- Replace the ad-hoc isStreaming + isCreatingFileSource booleans on
  ChatInput with submissionState ('idle' | 'submitting' | 'streaming')
  plus a separate isSendDisabled. Each call site derives both;
  ChatInput has no page-detection branches.
- During submission on NewChatPage: the typed message stays visible
  (read-only), each source chip shows its own uploading/processing/
  failed state, and the send button becomes a cancel button that aborts
  the pipeline without losing the user's input.
- Remove the loader from PlusButton — the loading state belongs on the
  source chip that's actually loading.

Supersedes the AYC-94 fix in #660.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Refactors the new-chat submit pipeline (thread creation + source upload/processing polling + KB attachment + navigation) and changes how send/cancel gating works, which can impact message delivery and attachment behavior. Risk is moderated by keeping existing error-toasts/timeouts but touches core chat flows.
> 
> **Overview**
> Reworks the *new chat* submission flow so thread resources (file sources and knowledge bases) are uploaded/attached **before** navigating to `ChatPage`, including per-source status callbacks, upload/processing timeouts, and a user-cancellable pipeline in `useInitiateChat`.
> 
> Simplifies `usePendingMessage` to a one-shot “send stashed message on mount” hook (no source polling/KB attach/abort plumbing) and trims chat context to only keep `pendingMessage`, `pendingImages`, and `pendingSkillId`.
> 
> Unifies `ChatInput` control flow by replacing `isStreaming`/`isCreatingFileSource`/`onSendCancelled` with `submissionState` (`idle` | `submitting` | `streaming`), `isSendDisabled`, and `onCancel`; the input now preserves typed text during submission, disables uploads appropriately, and removes the plus-button loader in favor of per-source chip status.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2030012e14c7c5d815231b8aef65af684882ccc1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->