### PR TITLE
fix(install): align spacing in install card form layouts (AYC-000)

### DIFF
--- a/ayunis-core-frontend/src/pages/install/ui/InstallIntegrationPage.tsx
+++ b/ayunis-core-frontend/src/pages/install/ui/InstallIntegrationPage.tsx
@@ -214,31 +214,31 @@ function InstallIntegrationCardView({
   const hasLegalText = Boolean(integration.legalTextUrl);
 
   return (
-    <Card className="w-full max-w-lg">
-      <CardHeader className="text-center">
-        <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center">
-          {integration.logoUrl ? (
-            <img
-              src={integration.logoUrl}
-              alt={integration.name}
-              className="h-16 w-16 object-contain"
-            />
-          ) : (
-            <div className="flex h-16 w-16 items-center justify-center rounded-full bg-primary/10">
-              <Plug className="h-8 w-8 text-primary" />
+    <Form {...form}>
+      <form
+        onSubmit={(e) => {
+          void form.handleSubmit(() => onInstall())(e);
+        }}
+      >
+        <Card className="w-full max-w-lg">
+          <CardHeader className="text-center">
+            <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center">
+              {integration.logoUrl ? (
+                <img
+                  src={integration.logoUrl}
+                  alt={integration.name}
+                  className="h-16 w-16 object-contain"
+                />
+              ) : (
+                <div className="flex h-16 w-16 items-center justify-center rounded-full bg-primary/10">
+                  <Plug className="h-8 w-8 text-primary" />
+                </div>
+              )}
             </div>
-          )}
-        </div>
-        <CardTitle className="text-xl">{integration.name}</CardTitle>
-        <CardDescription>{integration.description}</CardDescription>
-      </CardHeader>
+            <CardTitle className="text-xl">{integration.name}</CardTitle>
+            <CardDescription>{integration.description}</CardDescription>
+          </CardHeader>
 
-      <Form {...form}>
-        <form
-          onSubmit={(e) => {
-            void form.handleSubmit(() => onInstall())(e);
-          }}
-        >
           <CardContent className="space-y-4">
             <div className="rounded-md bg-muted/50 p-4">
               <p className="text-sm text-muted-foreground">
@@ -325,8 +325,8 @@ function InstallIntegrationCardView({
               {isInstalling ? t('action.installing') : t('action.install')}
             </Button>
           </CardFooter>
-        </form>
-      </Form>
-    </Card>
+        </Card>
+      </form>
+    </Form>
   );
 }

--- a/ayunis-core-frontend/src/pages/install/ui/InstallSkillCard.tsx
+++ b/ayunis-core-frontend/src/pages/install/ui/InstallSkillCard.tsx
@@ -38,29 +38,29 @@ export function InstallSkillCard({
     : null;
 
   return (
-    <Card className="w-full max-w-lg">
-      <CardHeader className="text-center">
-        <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-primary/10">
-          {skill.iconUrl ? (
-            <img
-              src={skill.iconUrl}
-              alt={skill.name}
-              className="h-10 w-10 rounded-full object-cover"
-            />
-          ) : (
-            <Bot className="h-8 w-8 text-primary" />
-          )}
-        </div>
-        <CardTitle className="text-xl">{skill.name}</CardTitle>
-        <CardDescription>{skill.shortDescription}</CardDescription>
-      </CardHeader>
+    <Form {...form}>
+      <form
+        onSubmit={(e) => {
+          void form.handleSubmit(() => onInstall())(e);
+        }}
+      >
+        <Card className="w-full max-w-lg">
+          <CardHeader className="text-center">
+            <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-primary/10">
+              {skill.iconUrl ? (
+                <img
+                  src={skill.iconUrl}
+                  alt={skill.name}
+                  className="h-10 w-10 rounded-full object-cover"
+                />
+              ) : (
+                <Bot className="h-8 w-8 text-primary" />
+              )}
+            </div>
+            <CardTitle className="text-xl">{skill.name}</CardTitle>
+            <CardDescription>{skill.shortDescription}</CardDescription>
+          </CardHeader>
 
-      <Form {...form}>
-        <form
-          onSubmit={(e) => {
-            void form.handleSubmit(() => onInstall())(e);
-          }}
-        >
           <CardContent className="space-y-4">
             <div className="rounded-md bg-muted/50 p-4">
               <p className="text-sm text-muted-foreground">
@@ -101,8 +101,8 @@ export function InstallSkillCard({
               {isInstalling ? t('action.installing') : t('action.install')}
             </Button>
           </CardFooter>
-        </form>
-      </Form>
-    </Card>
+        </Card>
+      </form>
+    </Form>
   );
 }


### PR DESCRIPTION
## Summary

- Beide Install-Karten (`InstallSkillCard.tsx`, `InstallIntegrationPage.tsx`) hatten ein fehlendes Spacing zwischen Checkbox/Content und Footer-Buttons.
- Ursache: Das `<form>`\-Element war zwischen `CardContent` und `CardFooter` als Wrapper eingefügt, wodurch der Shadcn-Card-eigene `gap-6` zwischen den direkten Kindern nicht mehr greifen konnte.
- Fix: Das `<form>`\-Element umschließt jetzt die gesamte `<Card>` von außen, statt einzelne Card-Kinder einzukapseln. Damit greifen die Shadcn-`Card`\-Defaults (`gap-6`) wieder — keine Custom-Spacing-Logik nötig.

## Hinweis für mich

**Ich löse das zu einem späteren Zeitpunkt in der Card Komponenten selbst,** **dann** **ist** **es** **auch** **überall** **konsitent** **;)** 

(Der hier offene **Duplication-Check** verweist auf die ~40 Zeilen Duplikation zwischen den beiden Files (Acceptance-Checkbox + CardFooter mit Cancel/Install) — die löst sich mit dem oben Refactor dann auf.)