### PR TITLE
perf(routing): use cached /auth/me from route context

### DIFF
--- a/ayunis-core-frontend/src/app/routes/_authenticated/admin-settings.index.tsx
+++ b/ayunis-core-frontend/src/app/routes/_authenticated/admin-settings.index.tsx
@@ -1,14 +1,12 @@
 import { createFileRoute, redirect } from '@tanstack/react-router';
-import { authenticationControllerMe } from '@/shared/api';
 
 export const Route = createFileRoute('/_authenticated/admin-settings/')({
-  beforeLoad: async () => {
-    const user = await authenticationControllerMe();
+  beforeLoad: ({ context: { user } }) => {
     const isAdmin = user.role === 'admin';
     if (!isAdmin) {
       throw redirect({ to: '/' });
     }
 
-    throw redirect({ to: '/admin-settings/users' });
+    throw redirect({ to: '/admin-settings/organization' });
   },
 });

--- a/ayunis-core-frontend/src/app/routes/_authenticated/admin-settings.index.tsx
+++ b/ayunis-core-frontend/src/app/routes/_authenticated/admin-settings.index.tsx
@@ -7,6 +7,6 @@ export const Route = createFileRoute('/_authenticated/admin-settings/')({
       throw redirect({ to: '/' });
     }
 
-    throw redirect({ to: '/admin-settings/organization' });
+    throw redirect({ to: '/admin-settings/users' });
   },
 });

--- a/ayunis-core-frontend/src/app/routes/_authenticated/super-admin-settings.index.tsx
+++ b/ayunis-core-frontend/src/app/routes/_authenticated/super-admin-settings.index.tsx
@@ -1,10 +1,8 @@
-import { authenticationControllerMe } from '@/shared/api/generated/ayunisCoreAPI';
 import { MeResponseDtoSystemRole } from '@/shared/api/generated/ayunisCoreAPI.schemas';
 import { createFileRoute, redirect } from '@tanstack/react-router';
 
 export const Route = createFileRoute('/_authenticated/super-admin-settings/')({
-  beforeLoad: async () => {
-    const user = await authenticationControllerMe();
+  beforeLoad: ({ context: { user } }) => {
     if (user.systemRole !== MeResponseDtoSystemRole.super_admin) {
       throw redirect({ to: '/' });
     }


### PR DESCRIPTION
The /admin-settings and /super-admin-settings index routes were calling
authenticationControllerMe() directly in their beforeLoad hooks, firing
a fresh uncached HTTP request to /auth/me on every navigation. The
parent _authenticated route already fetches /auth/me via React Query
and exposes the user on the route context — read it from there instead.

Removes one HTTP round-trip per click on either dropdown entry.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small routing change reusing existing auth data; authorization logic is unchanged.
> 
> **Overview**
> **Admin and super-admin index routes** no longer call `authenticationControllerMe()` in `beforeLoad`. They read **`user` from the parent `_authenticated` route context** (already loaded via React Query) for the same admin / super-admin gate checks and redirects.
> 
> This removes a duplicate **`/auth/me`** request on each navigation into those settings entry paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3130a78fb120c2efe8d3d9af724368b8348649c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->