### PR TITLE
feat(chat): add copy button to code blocks in chat messages (AYC-106)

### DIFF
--- a/ayunis-core-frontend/src/widgets/markdown/ui/Codeblock.tsx
+++ b/ayunis-core-frontend/src/widgets/markdown/ui/Codeblock.tsx
@@ -72,8 +72,8 @@ export default function CodeBlock({
         <TooltipTrigger asChild>
           <Button
             variant="ghost"
-            size="icon"
-            className="absolute top-1 right-1 h-7 w-7 bg-background/60 hover:bg-background/80 backdrop-blur-sm"
+            size="icon-sm"
+            className="absolute top-1 right-1"
             onClick={() => void handleCopy()}
             aria-label={t('chat.copyToClipboard')}
           >

--- a/ayunis-core-frontend/src/widgets/markdown/ui/Codeblock.tsx
+++ b/ayunis-core-frontend/src/widgets/markdown/ui/Codeblock.tsx
@@ -1,9 +1,18 @@
+import { useState } from 'react';
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 import {
   oneDark,
   oneLight,
 } from 'react-syntax-highlighter/dist/esm/styles/prism';
+import { Check, Copy } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 import { useTheme } from '@/features/theme';
+import { Button } from '@/shared/ui/shadcn/button';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/shared/ui/shadcn/tooltip';
 
 interface CodeBlockProps {
   language?: string;
@@ -19,6 +28,8 @@ export default function CodeBlock({
   className = '',
 }: Readonly<CodeBlockProps>) {
   const { theme } = useTheme();
+  const { t } = useTranslation('chat');
+  const [copied, setCopied] = useState(false);
 
   if (inline) {
     return (
@@ -30,8 +41,20 @@ export default function CodeBlock({
     );
   }
 
+  const code = children.replace(/\n$/, '');
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(code);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch (error) {
+      console.error('Failed to copy code block:', error);
+    }
+  };
+
   return (
-    <div className="overflow-x-auto my-4 max-w-full">
+    <div className="relative my-4 max-w-full">
       <SyntaxHighlighter
         style={theme === 'dark' ? oneDark : oneLight}
         language={language ?? 'text'}
@@ -43,8 +66,26 @@ export default function CodeBlock({
           overflow: 'auto',
         }}
       >
-        {children.replace(/\n$/, '')}
+        {code}
       </SyntaxHighlighter>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="absolute top-1 right-1 h-7 w-7 bg-background/60 hover:bg-background/80 backdrop-blur-sm"
+            onClick={() => void handleCopy()}
+            aria-label={t('chat.copyToClipboard')}
+          >
+            {copied ? (
+              <Check className="h-3.5 w-3.5" />
+            ) : (
+              <Copy className="h-3.5 w-3.5" />
+            )}
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent>{t('chat.copyToClipboard')}</TooltipContent>
+      </Tooltip>
     </div>
   );
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk UI-only change that adds clipboard interaction for code blocks; potential issues are limited to browser clipboard permission/availability and minor layout overlay changes.
> 
> **Overview**
> Adds an in-code-block **copy button** to `CodeBlock` for non-inline markdown code, writing the block text to `navigator.clipboard` and showing a temporary copied state (icon swap) for 2s.
> 
> The code block wrapper is made `relative` and a Shadcn `Button` + `Tooltip` (localized via `t('chat.copyToClipboard')`) is positioned in the top-right over the syntax-highlighted output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0dbe12d99f9da6ba7fcd8e44379f9f9d0978c69b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->