### PR TITLE
fix(admin-users): restore actions menu visibility in user list (AYC-112)

### DIFF
--- a/ayunis-core-frontend/src/pages/admin-settings/users-settings/ui/UsersSection.tsx
+++ b/ayunis-core-frontend/src/pages/admin-settings/users-settings/ui/UsersSection.tsx
@@ -136,7 +136,6 @@ export default function UsersSection({
               <TableHead>{t('users.email')}</TableHead>
               <TableHead>{t('users.role')}</TableHead>
               <TableHead>{t('users.status')}</TableHead>
-              <TableHead>{t('users.joinDate')}</TableHead>
               <TableHead className="w-[50px]"></TableHead>
             </TableRow>
           </TableHeader>
@@ -152,9 +151,6 @@ export default function UsersSection({
                   <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800">
                     {t('users.active')}
                   </span>
-                </TableCell>
-                <TableCell>
-                  {new Date(user.createdAt).toLocaleDateString()}
                 </TableCell>
                 <TableCell>
                   <DropdownMenu>

--- a/ayunis-core-frontend/src/shared/locales/de/admin-settings-users.json
+++ b/ayunis-core-frontend/src/shared/locales/de/admin-settings-users.json
@@ -17,7 +17,6 @@
     "status": "Status",
     "sentDate": "Sendedatum",
     "name": "Name",
-    "joinDate": "Beitrittsdatum",
     "active": "Aktiv",
     "pending": "ausstehend",
     "accepted": "akzeptiert",

--- a/ayunis-core-frontend/src/shared/locales/en/admin-settings-users.json
+++ b/ayunis-core-frontend/src/shared/locales/en/admin-settings-users.json
@@ -17,7 +17,6 @@
     "status": "Status",
     "sentDate": "Sent Date",
     "name": "Name",
-    "joinDate": "Join Date",
     "active": "Active",
     "pending": "pending",
     "accepted": "accepted",

--- a/ayunis-core-frontend/src/shared/ui/shadcn/scroll-area.tsx
+++ b/ayunis-core-frontend/src/shared/ui/shadcn/scroll-area.tsx
@@ -21,7 +21,6 @@ function ScrollArea({
         {children}
       </ScrollAreaPrimitive.Viewport>
       <ScrollBar />
-      <ScrollBar orientation="horizontal" />
       <ScrollAreaPrimitive.Corner />
     </ScrollAreaPrimitive.Root>
   );

--- a/ayunis-core-frontend/src/shared/ui/shadcn/scroll-area.tsx
+++ b/ayunis-core-frontend/src/shared/ui/shadcn/scroll-area.tsx
@@ -21,6 +21,7 @@ function ScrollArea({
         {children}
       </ScrollAreaPrimitive.Viewport>
       <ScrollBar />
+      <ScrollBar orientation="horizontal" />
       <ScrollAreaPrimitive.Corner />
     </ScrollAreaPrimitive.Root>
   );


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> UI-only changes, but updating the shared `ScrollArea` to always render a horizontal scrollbar can affect layout/scroll behavior across multiple screens that use it.
> 
> **Overview**
> Removes the *Join Date* column from the admin users table, including its localized `joinDate` strings.
> 
> Updates the shared `ScrollArea` component to render an additional horizontal scrollbar, improving horizontal overflow handling (and potentially restoring visibility of clipped UI like action menus).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cefd7e630769d9c0a5293b958b2141b04a9f9dfc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->