### PR TITLE
feat(chat): feedback Herzebrock Clarholz: trust and clarity tweaks across chat, skills, and settings (AYC-000)

### DIFF
--- a/ayunis-core-frontend/src/pages/new-chat/ui/NewChatPage.tsx
+++ b/ayunis-core-frontend/src/pages/new-chat/ui/NewChatPage.tsx
@@ -1,3 +1,4 @@
+import { Lock } from 'lucide-react';
 import NewChatPageLayout from './NewChatPageLayout';
 import ChatInput from '@/widgets/chat-input';
 import {
@@ -277,6 +278,10 @@ export default function NewChatPage({
           onSkillSelect={handleSkillSelect}
           selectedSkillId={selectedSkillId}
         />
+        <div className="flex justify-center items-center gap-1.5 text-xs text-muted-foreground">
+          <Lock className="h-3 w-3" />
+          <span>{t('newChat.privacyHint')}</span>
+        </div>
       </div>
     </NewChatPageLayout>
   );

--- a/ayunis-core-frontend/src/pages/new-chat/ui/PinnedSkills.tsx
+++ b/ayunis-core-frontend/src/pages/new-chat/ui/PinnedSkills.tsx
@@ -1,5 +1,12 @@
 import { Sparkles } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 import { Button } from '@/shared/ui/shadcn/button';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/shared/ui/shadcn/tooltip';
+import { HelpLink } from '@/shared/ui/help-link/HelpLink';
 import { useSkillsControllerFindAll } from '@/shared/api/generated/ayunisCoreAPI';
 import { useIsSkillsEnabled } from '@/features/feature-toggles';
 
@@ -12,6 +19,7 @@ export function PinnedSkills({
   onSkillSelect,
   selectedSkillId,
 }: Readonly<PinnedSkillsProps>) {
+  const { t } = useTranslation('common');
   const skillsEnabled = useIsSkillsEnabled();
   const { data: skills } = useSkillsControllerFindAll({
     query: { enabled: skillsEnabled },
@@ -24,18 +32,26 @@ export function PinnedSkills({
   }
 
   return (
-    <div className="flex justify-center gap-2 flex-wrap">
+    <div className="flex justify-center items-center gap-2 flex-wrap">
       {pinnedSkills.map((skill) => (
-        <Button
-          key={skill.id}
-          variant={selectedSkillId === skill.id ? 'default' : 'outline'}
-          size="sm"
-          onClick={() => onSkillSelect(skill.id, skill.name)}
-        >
-          <Sparkles className="h-4 w-4" />
-          {skill.name}
-        </Button>
+        <Tooltip key={skill.id}>
+          <TooltipTrigger asChild>
+            <Button
+              variant={selectedSkillId === skill.id ? 'default' : 'outline'}
+              size="sm"
+              onClick={() => onSkillSelect(skill.id, skill.name)}
+            >
+              <Sparkles className="h-4 w-4" />
+              {skill.name}
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>{t('pinnedSkills.activateTooltip')}</TooltipContent>
+        </Tooltip>
       ))}
+      <HelpLink
+        path="skills/name-and-description/#f%C3%A4higkeiten-anheften--manuelle-aktivierung"
+        variant="icon"
+      />
     </div>
   );
 }

--- a/ayunis-core-frontend/src/pages/skills/ui/CreateSkillDialog.tsx
+++ b/ayunis-core-frontend/src/pages/skills/ui/CreateSkillDialog.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Form } from '@/shared/ui/shadcn/form';
 import { type CreateSkillData, useCreateSkill } from '../api/useCreateSkill';
 import {
@@ -23,6 +24,7 @@ export default function CreateSkillDialog({
   buttonClassName = '',
 }: Readonly<CreateSkillDialogProps>) {
   const translations = useCreateDialogTranslations('skills');
+  const { t } = useTranslation('skills');
   const [isOpen, setIsOpen] = useState(false);
   const {
     form,
@@ -51,6 +53,7 @@ export default function CreateSkillDialog({
       buttonText={buttonText}
       showIcon={showIcon}
       buttonClassName={buttonClassName}
+      footerHint={t('createDialog.marketplaceHint')}
     >
       <Form {...form}>
         <div className="space-y-6">

--- a/ayunis-core-frontend/src/shared/locales/de/chat.json
+++ b/ayunis-core-frontend/src/shared/locales/de/chat.json
@@ -187,6 +187,7 @@
     "personalizedPromptError": "Personalisierter System-Prompt konnte nicht erstellt werden",
     "systemPromptLoadError": "Personalisierungsstatus konnte nicht geladen werden. Die Personalisierung wurde möglicherweise übersprungen.",
     "noDefaultModelError": "Kein Standardmodell konfiguriert. Bitte wenden Sie sich an Ihren Administrator.",
+    "privacyHint": "Nur Sie sehen Ihre Chats.",
     "personalization": {
       "stepperName": "Name",
       "stepperStyle": "Stil",

--- a/ayunis-core-frontend/src/shared/locales/de/common.json
+++ b/ayunis-core-frontend/src/shared/locales/de/common.json
@@ -87,10 +87,12 @@
     "microphonePermissionDenied": "Mikrofonzugriff verweigert",
     "recordingNotSupported": "Sprachaufnahme wird in diesem Browser nicht unterstützt",
     "transcriptionFailed": "Transkription fehlgeschlagen",
-    "modelSelectorAriaLabel": "KI-Modell auswählen"
+    "modelSelectorAriaLabel": "KI-Modell auswählen",
+    "deactivateSkillTooltip": "Fähigkeit deaktivieren"
   },
   "pinnedSkills": {
-    "empty": "Keine angehefteten Fähigkeiten"
+    "empty": "Keine angehefteten Fähigkeiten",
+    "activateTooltip": "Fähigkeit aktivieren"
   },
   "common": {
     "loading": "Laden...",

--- a/ayunis-core-frontend/src/shared/locales/de/settings.json
+++ b/ayunis-core-frontend/src/shared/locales/de/settings.json
@@ -56,7 +56,7 @@
     "defaultModelDescription": "Wählen Sie das Standard-KI-Modell für neue Gespräche",
     "selectDefaultModel": "Standardmodell auswählen",
     "none": "Kein Modell ausgewählt",
-    "systemPromptTitle": "System-Prompt",
+    "systemPromptTitle": "Personalisierung",
     "systemPromptLabel": "Persönliche Anweisung",
     "systemPromptDescription": "Definieren Sie einen persönlichen System-Prompt, der in jede KI-Unterhaltung eingefügt wird. Verwenden Sie dies, um das KI-Verhalten an Ihre Präferenzen anzupassen.",
     "systemPromptPlaceholder": "z.B. Antworten Sie immer in Stichpunkten. Ich arbeite in der Finanzabteilung.",

--- a/ayunis-core-frontend/src/shared/locales/de/skills.json
+++ b/ayunis-core-frontend/src/shared/locales/de/skills.json
@@ -62,6 +62,7 @@
       "create": "Fähigkeit erstellen",
       "creating": "Wird erstellt..."
     },
+    "marketplaceHint": "Fähigkeiten werden nicht automatisch im Marketplace veröffentlicht.",
     "validation": {
       "nameRequired": "Name ist erforderlich",
       "shortDescriptionRequired": "Auslöser ist erforderlich",

--- a/ayunis-core-frontend/src/shared/locales/en/chat.json
+++ b/ayunis-core-frontend/src/shared/locales/en/chat.json
@@ -187,6 +187,7 @@
     "personalizedPromptError": "Failed to generate personalized system prompt",
     "systemPromptLoadError": "Could not load personalization status. Personalization may have been skipped.",
     "noDefaultModelError": "No default model configured. Please contact your administrator.",
+    "privacyHint": "Only you can see your chats.",
     "personalization": {
       "stepperName": "Name",
       "stepperStyle": "Style",

--- a/ayunis-core-frontend/src/shared/locales/en/common.json
+++ b/ayunis-core-frontend/src/shared/locales/en/common.json
@@ -87,10 +87,12 @@
     "microphonePermissionDenied": "Microphone access denied",
     "recordingNotSupported": "Voice recording is not supported in this browser",
     "transcriptionFailed": "Transcription failed",
-    "modelSelectorAriaLabel": "Select AI model"
+    "modelSelectorAriaLabel": "Select AI model",
+    "deactivateSkillTooltip": "Deactivate skill"
   },
   "pinnedSkills": {
-    "empty": "No pinned skills"
+    "empty": "No pinned skills",
+    "activateTooltip": "Activate skill"
   },
   "common": {
     "loading": "Loading...",

--- a/ayunis-core-frontend/src/shared/locales/en/settings.json
+++ b/ayunis-core-frontend/src/shared/locales/en/settings.json
@@ -56,7 +56,7 @@
     "defaultModelDescription": "Choose the default AI model for new conversations",
     "selectDefaultModel": "Select default model",
     "none": "No model selected",
-    "systemPromptTitle": "System Prompt",
+    "systemPromptTitle": "Personalization",
     "systemPromptLabel": "Personal Instruction",
     "systemPromptDescription": "Define a personal system prompt that gets injected into every AI conversation. Use this to customize AI behavior to your preferences.",
     "systemPromptPlaceholder": "e.g. Always respond in bullet points. I work in the finance department.",

--- a/ayunis-core-frontend/src/shared/locales/en/skills.json
+++ b/ayunis-core-frontend/src/shared/locales/en/skills.json
@@ -62,6 +62,7 @@
       "create": "Create Skill",
       "creating": "Creating..."
     },
+    "marketplaceHint": "Skills are not automatically published to the marketplace.",
     "validation": {
       "nameRequired": "Name is required",
       "shortDescriptionRequired": "Trigger is required",

--- a/ayunis-core-frontend/src/shared/ui/help-link/HelpLink.tsx
+++ b/ayunis-core-frontend/src/shared/ui/help-link/HelpLink.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from 'react-i18next';
-import { ExternalLink } from 'lucide-react';
+import { CircleHelp } from 'lucide-react';
 import { Button } from '@/shared/ui/shadcn/button';
 import {
   Tooltip,
@@ -25,7 +25,7 @@ export function HelpLink({ path, variant = 'default' }: HelpLinkProps) {
         <TooltipTrigger asChild>
           <Button variant="ghost" size="icon" asChild>
             <a href={url} target="_blank" rel="noopener noreferrer">
-              <ExternalLink className="h-4 w-4" />
+              <CircleHelp className="h-4 w-4" />
             </a>
           </Button>
         </TooltipTrigger>
@@ -37,7 +37,7 @@ export function HelpLink({ path, variant = 'default' }: HelpLinkProps) {
   return (
     <Button variant="outline" size="sm" asChild>
       <a href={url} target="_blank" rel="noopener noreferrer">
-        <ExternalLink className="h-4 w-4" />
+        <CircleHelp className="h-4 w-4" />
         {label}
       </a>
     </Button>

--- a/ayunis-core-frontend/src/widgets/chat-input/ui/SkillBadge.tsx
+++ b/ayunis-core-frontend/src/widgets/chat-input/ui/SkillBadge.tsx
@@ -1,5 +1,11 @@
 import { Sparkles, XIcon } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 import { Badge } from '@/shared/ui/shadcn/badge';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/shared/ui/shadcn/tooltip';
 
 interface SkillBadgeProps {
   skillName: string;
@@ -7,13 +13,21 @@ interface SkillBadgeProps {
 }
 
 export function SkillBadge({ skillName, onRemove }: Readonly<SkillBadgeProps>) {
+  const { t } = useTranslation('common');
   return (
-    <Badge variant="secondary">
-      <Sparkles className="h-3 w-3" />
-      {skillName}
-      <div className="cursor-pointer" onClick={() => onRemove()}>
-        <XIcon className="h-3 w-3" />
-      </div>
-    </Badge>
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Badge
+          variant="secondary"
+          className="cursor-pointer"
+          onClick={() => onRemove()}
+        >
+          <Sparkles className="h-3 w-3" />
+          {skillName}
+          <XIcon className="h-3 w-3" />
+        </Badge>
+      </TooltipTrigger>
+      <TooltipContent>{t('chatInput.deactivateSkillTooltip')}</TooltipContent>
+    </Tooltip>
   );
 }

--- a/ayunis-core-frontend/src/widgets/create-entity-dialog/ui/CreateEntityDialog.tsx
+++ b/ayunis-core-frontend/src/widgets/create-entity-dialog/ui/CreateEntityDialog.tsx
@@ -28,6 +28,7 @@ interface CreateEntityDialogProps {
   buttonText?: string;
   showIcon?: boolean;
   buttonClassName?: string;
+  footerHint?: ReactNode;
   children: ReactNode;
 }
 
@@ -41,6 +42,7 @@ export default function CreateEntityDialog({
   buttonText,
   showIcon = false,
   buttonClassName = '',
+  footerHint,
   children,
 }: Readonly<CreateEntityDialogProps>) {
   return (
@@ -61,18 +63,29 @@ export default function CreateEntityDialog({
         </DialogHeader>
         <form onSubmit={onSubmit} className="space-y-6">
           {children}
-          <DialogFooter>
-            <Button
-              type="button"
-              variant="outline"
-              onClick={onCancel}
-              disabled={isLoading}
-            >
-              {translations.cancel}
-            </Button>
-            <Button type="submit" disabled={isLoading}>
-              {isLoading ? translations.creating : translations.create}
-            </Button>
+          <DialogFooter
+            className={
+              footerHint ? 'sm:justify-between sm:items-center' : undefined
+            }
+          >
+            {footerHint && (
+              <p className="text-xs text-muted-foreground sm:max-w-xs">
+                {footerHint}
+              </p>
+            )}
+            <div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={onCancel}
+                disabled={isLoading}
+              >
+                {translations.cancel}
+              </Button>
+              <Button type="submit" disabled={isLoading}>
+                {isLoading ? translations.creating : translations.create}
+              </Button>
+            </div>
           </DialogFooter>
         </form>
       </DialogContent>


### PR DESCRIPTION
Feedback from Herzebrock-Clarholz workshop — surface privacy and
publishing context where users were uncertain.

- new-chat: muted "only you can see your chats" hint below input
- pinned skills: activate tooltip + help link to docs anchor
- chat input: deactivate tooltip on the active skill badge
- create skill dialog: muted hint that skills aren't auto-published
- settings/chat: rename "System Prompt" card to "Personalization"
- HelpLink: swap external-link icon for a question-mark (CircleHelp)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily UI copy/tooltips and minor layout tweaks; low risk aside from potential missing i18n keys or tooltip behavior regressions.
> 
> **Overview**
> Adds a muted privacy hint below the new chat input and improves *pinned skills* UX by wrapping each pinned skill button in a tooltip and adding an inline `HelpLink` to relevant docs.
> 
> Introduces clearer skill affordances by adding a tooltip to the active-skill badge for deactivation, and enhances `CreateEntityDialog` with an optional `footerHint` used in the skill creation dialog to note skills aren’t auto-published to the marketplace.
> 
> Updates help-link iconography (`ExternalLink` → `CircleHelp`) and adjusts localized strings (including renaming the settings chat card title from **System Prompt** to **Personalization**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2593f92942045606a66de8c2117044eda8a80e2f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->