### PR TITLE
fix(org): use bg-background token for preview toggle thumbs

### DIFF
--- a/ayunis-core-frontend/src/pages/admin-settings/organization-settings/ui/SidebarPreview.tsx
+++ b/ayunis-core-frontend/src/pages/admin-settings/organization-settings/ui/SidebarPreview.tsx
@@ -171,7 +171,7 @@ function TogglesSnippet({ primaryColor }: { primaryColor: string | null }) {
           )}
           style={primaryColor ? { backgroundColor: primaryColor } : undefined}
         >
-          <span className="size-4 translate-x-4 rounded-full bg-white shadow-sm transition-transform" />
+          <span className="size-4 translate-x-4 rounded-full bg-background shadow-sm transition-transform" />
         </span>
       </div>
       <div className="flex items-center justify-between">
@@ -180,7 +180,7 @@ function TogglesSnippet({ primaryColor }: { primaryColor: string | null }) {
           <span>GPT-5</span>
         </span>
         <span className="relative inline-flex h-5 w-9 shrink-0 items-center rounded-full bg-muted px-0.5">
-          <span className="size-4 rounded-full bg-white shadow-sm transition-transform" />
+          <span className="size-4 rounded-full bg-background shadow-sm transition-transform" />
         </span>
       </div>
     </div>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Cosmetic class swap in a non-interactive, aria-hidden preview component with no behavior or data impact.
> 
> **Overview**
> Updates the organization settings **Toggles** preview so switch thumb circles use the semantic `bg-background` token instead of hardcoded `bg-white`.
> 
> Both the on-state (primary/custom color track) and off-state (`bg-muted` track) thumbs in `TogglesSnippet` are changed, so the preview tracks light/dark theme like the rest of the admin UI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 967451f7578da612450aa032cef4df2f6a141596. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->