### PR TITLE
wip(admin-users): add admin endpoint to update user name and email (AYC-123)

### DIFF
--- a/ayunis-core-backend/src/iam/users/application/use-cases/admin-update-user/admin-update-user.command.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/admin-update-user/admin-update-user.command.ts
@@ -1,0 +1,9 @@
+import type { UUID } from 'crypto';
+
+export class AdminUpdateUserCommand {
+  constructor(
+    public readonly userId: UUID,
+    public readonly name?: string,
+    public readonly email?: string,
+  ) {}
+}

--- a/ayunis-core-backend/src/iam/users/application/use-cases/admin-update-user/admin-update-user.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/admin-update-user/admin-update-user.use-case.spec.ts
@@ -1,0 +1,272 @@
+import type { TestingModule } from '@nestjs/testing';
+import { Test } from '@nestjs/testing';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import type { UUID } from 'crypto';
+import { AdminUpdateUserUseCase } from './admin-update-user.use-case';
+import { AdminUpdateUserCommand } from './admin-update-user.command';
+import { ContextService } from 'src/common/context/services/context.service';
+import { UsersRepository } from '../../ports/users.repository';
+import { User } from '../../../domain/user.entity';
+import { UserRole } from '../../../domain/value-objects/role.object';
+import { UserUpdatedEvent } from '../../events/user-updated.event';
+import { SendConfirmationEmailUseCase } from '../send-confirmation-email/send-confirmation-email.use-case';
+import {
+  UserAlreadyExistsError,
+  UserInvalidInputError,
+  UserNotFoundError,
+  UserUnauthorizedError,
+} from '../../users.errors';
+
+describe('AdminUpdateUserUseCase', () => {
+  let useCase: AdminUpdateUserUseCase;
+  let mockUsersRepository: Partial<UsersRepository>;
+  let mockContextService: Partial<ContextService>;
+  let mockEventEmitter: { emitAsync: jest.Mock };
+  let mockSendConfirmationEmailUseCase: { execute: jest.Mock };
+
+  const targetUserId = '550e8400-e29b-41d4-a716-446655440000' as UUID;
+  const orgId = '660e8400-e29b-41d4-a716-446655440000' as UUID;
+  const otherOrgId = '770e8400-e29b-41d4-a716-446655440000' as UUID;
+
+  const buildTargetUser = (overrides: Partial<User> = {}): User =>
+    new User({
+      id: targetUserId,
+      email: 'maria.mueller@gemeinde.de',
+      emailVerified: true,
+      passwordHash: 'hashed-password',
+      role: UserRole.USER,
+      orgId,
+      name: 'Maria Müller',
+      hasAcceptedMarketing: false,
+      ...overrides,
+    });
+
+  beforeAll(async () => {
+    mockUsersRepository = {
+      findOneById: jest.fn(),
+      findOneByEmail: jest.fn(),
+      update: jest.fn(),
+    };
+    mockContextService = {
+      get: jest.fn(),
+    };
+    mockEventEmitter = {
+      emitAsync: jest.fn().mockResolvedValue([]),
+    };
+    mockSendConfirmationEmailUseCase = {
+      execute: jest.fn().mockResolvedValue(undefined),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AdminUpdateUserUseCase,
+        { provide: UsersRepository, useValue: mockUsersRepository },
+        { provide: ContextService, useValue: mockContextService },
+        { provide: EventEmitter2, useValue: mockEventEmitter },
+        {
+          provide: SendConfirmationEmailUseCase,
+          useValue: mockSendConfirmationEmailUseCase,
+        },
+      ],
+    }).compile();
+
+    useCase = module.get<AdminUpdateUserUseCase>(AdminUpdateUserUseCase);
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(mockContextService, 'get').mockImplementation((key) => {
+      if (key === 'orgId') return orgId;
+      return undefined;
+    });
+  });
+
+  it('should update both name and email and emit UserUpdatedEvent', async () => {
+    const targetUser = buildTargetUser();
+    jest
+      .spyOn(mockUsersRepository, 'findOneById')
+      .mockResolvedValue(targetUser);
+    jest.spyOn(mockUsersRepository, 'findOneByEmail').mockResolvedValue(null);
+    jest
+      .spyOn(mockUsersRepository, 'update')
+      .mockImplementation(async (u) => u);
+
+    const command = new AdminUpdateUserCommand(
+      targetUserId,
+      'Maria Schmidt',
+      'maria.schmidt@gemeinde.de',
+    );
+
+    const result = await useCase.execute(command);
+
+    expect(result.name).toBe('Maria Schmidt');
+    expect(result.email).toBe('maria.schmidt@gemeinde.de');
+    expect(mockEventEmitter.emitAsync).toHaveBeenCalledWith(
+      UserUpdatedEvent.EVENT_NAME,
+      expect.objectContaining({
+        userId: targetUserId,
+        orgId,
+      }),
+    );
+  });
+
+  it('should reset emailVerified and send a confirmation email when admin changes the email', async () => {
+    const targetUser = buildTargetUser({ emailVerified: true });
+    jest
+      .spyOn(mockUsersRepository, 'findOneById')
+      .mockResolvedValue(targetUser);
+    jest.spyOn(mockUsersRepository, 'findOneByEmail').mockResolvedValue(null);
+    jest
+      .spyOn(mockUsersRepository, 'update')
+      .mockImplementation(async (u) => u);
+
+    const command = new AdminUpdateUserCommand(
+      targetUserId,
+      undefined,
+      'maria.schmidt@gemeinde.de',
+    );
+
+    const result = await useCase.execute(command);
+
+    expect(result.emailVerified).toBe(false);
+    expect(mockSendConfirmationEmailUseCase.execute).toHaveBeenCalledWith(
+      expect.objectContaining({
+        user: expect.objectContaining({
+          id: targetUserId,
+          email: 'maria.schmidt@gemeinde.de',
+          emailVerified: false,
+        }),
+      }),
+    );
+  });
+
+  it('should not send a confirmation email when the email is unchanged', async () => {
+    const targetUser = buildTargetUser({ emailVerified: true });
+    jest
+      .spyOn(mockUsersRepository, 'findOneById')
+      .mockResolvedValue(targetUser);
+    jest
+      .spyOn(mockUsersRepository, 'update')
+      .mockImplementation(async (u) => u);
+
+    const command = new AdminUpdateUserCommand(targetUserId, 'Maria Schmidt');
+
+    const result = await useCase.execute(command);
+
+    expect(result.emailVerified).toBe(true);
+    expect(mockSendConfirmationEmailUseCase.execute).not.toHaveBeenCalled();
+  });
+
+  it('should update name only when email is omitted', async () => {
+    const targetUser = buildTargetUser();
+    jest
+      .spyOn(mockUsersRepository, 'findOneById')
+      .mockResolvedValue(targetUser);
+    jest
+      .spyOn(mockUsersRepository, 'update')
+      .mockImplementation(async (u) => u);
+
+    const command = new AdminUpdateUserCommand(targetUserId, 'Maria Schmidt');
+
+    const result = await useCase.execute(command);
+
+    expect(result.name).toBe('Maria Schmidt');
+    expect(result.email).toBe('maria.mueller@gemeinde.de');
+    expect(mockUsersRepository.findOneByEmail).not.toHaveBeenCalled();
+  });
+
+  it('should skip the uniqueness check when email is unchanged', async () => {
+    const targetUser = buildTargetUser();
+    jest
+      .spyOn(mockUsersRepository, 'findOneById')
+      .mockResolvedValue(targetUser);
+    jest
+      .spyOn(mockUsersRepository, 'update')
+      .mockImplementation(async (u) => u);
+
+    const command = new AdminUpdateUserCommand(
+      targetUserId,
+      undefined,
+      targetUser.email,
+    );
+
+    await useCase.execute(command);
+
+    expect(mockUsersRepository.findOneByEmail).not.toHaveBeenCalled();
+  });
+
+  it('should throw UserInvalidInputError when both fields are omitted', async () => {
+    const command = new AdminUpdateUserCommand(targetUserId);
+
+    await expect(useCase.execute(command)).rejects.toThrow(
+      UserInvalidInputError,
+    );
+    expect(mockUsersRepository.findOneById).not.toHaveBeenCalled();
+  });
+
+  it('should throw UserNotFoundError when the target user does not exist', async () => {
+    jest.spyOn(mockUsersRepository, 'findOneById').mockResolvedValue(null);
+
+    const command = new AdminUpdateUserCommand(targetUserId, 'New Name');
+
+    await expect(useCase.execute(command)).rejects.toThrow(UserNotFoundError);
+    expect(mockUsersRepository.update).not.toHaveBeenCalled();
+    expect(mockEventEmitter.emitAsync).not.toHaveBeenCalled();
+  });
+
+  it('should reject cross-org updates with UserUnauthorizedError', async () => {
+    const targetUser = buildTargetUser({ orgId: otherOrgId });
+    jest
+      .spyOn(mockUsersRepository, 'findOneById')
+      .mockResolvedValue(targetUser);
+
+    const command = new AdminUpdateUserCommand(targetUserId, 'New Name');
+
+    await expect(useCase.execute(command)).rejects.toThrow(
+      UserUnauthorizedError,
+    );
+    expect(mockUsersRepository.update).not.toHaveBeenCalled();
+  });
+
+  it('should throw UserAlreadyExistsError when the new email is taken by another user', async () => {
+    const targetUser = buildTargetUser();
+    const otherUser = new User({
+      id: '880e8400-e29b-41d4-a716-446655440000' as UUID,
+      email: 'taken@gemeinde.de',
+      emailVerified: true,
+      passwordHash: 'hash',
+      role: UserRole.USER,
+      orgId,
+      name: 'Other',
+      hasAcceptedMarketing: false,
+    });
+    jest
+      .spyOn(mockUsersRepository, 'findOneById')
+      .mockResolvedValue(targetUser);
+    jest
+      .spyOn(mockUsersRepository, 'findOneByEmail')
+      .mockResolvedValue(otherUser);
+
+    const command = new AdminUpdateUserCommand(
+      targetUserId,
+      undefined,
+      'taken@gemeinde.de',
+    );
+
+    await expect(useCase.execute(command)).rejects.toThrow(
+      UserAlreadyExistsError,
+    );
+    expect(mockUsersRepository.update).not.toHaveBeenCalled();
+  });
+
+  it('should throw UserUnauthorizedError when the requester has no orgId in context', async () => {
+    jest.spyOn(mockContextService, 'get').mockReturnValue(undefined);
+
+    const command = new AdminUpdateUserCommand(targetUserId, 'New Name');
+
+    await expect(useCase.execute(command)).rejects.toThrow(
+      UserUnauthorizedError,
+    );
+    expect(mockUsersRepository.findOneById).not.toHaveBeenCalled();
+  });
+});

--- a/ayunis-core-backend/src/iam/users/application/use-cases/admin-update-user/admin-update-user.use-case.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/admin-update-user/admin-update-user.use-case.ts
@@ -1,0 +1,151 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { ApplicationError } from 'src/common/errors/base.error';
+import { ContextService } from 'src/common/context/services/context.service';
+import { UsersRepository } from '../../ports/users.repository';
+import { AdminUpdateUserCommand } from './admin-update-user.command';
+import { User } from '../../../domain/user.entity';
+import {
+  UserAlreadyExistsError,
+  UserInvalidInputError,
+  UserNotFoundError,
+  UserUnauthorizedError,
+  UserUnexpectedError,
+} from '../../users.errors';
+import { UserUpdatedEvent } from '../../events/user-updated.event';
+import { SendConfirmationEmailUseCase } from '../send-confirmation-email/send-confirmation-email.use-case';
+import { SendConfirmationEmailCommand } from '../send-confirmation-email/send-confirmation-email.command';
+
+@Injectable()
+export class AdminUpdateUserUseCase {
+  private readonly logger = new Logger(AdminUpdateUserUseCase.name);
+
+  constructor(
+    private readonly contextService: ContextService,
+    private readonly usersRepository: UsersRepository,
+    private readonly eventEmitter: EventEmitter2,
+    private readonly sendConfirmationEmailUseCase: SendConfirmationEmailUseCase,
+  ) {}
+
+  async execute(command: AdminUpdateUserCommand): Promise<User> {
+    this.logger.log('adminUpdateUser', {
+      userId: command.userId,
+      hasName: command.name !== undefined,
+      hasEmail: command.email !== undefined,
+    });
+
+    this.assertHasFieldsToUpdate(command);
+    const requesterOrgId = this.readRequesterOrgId();
+
+    try {
+      const targetUser = await this.loadTargetUser(
+        command.userId,
+        requesterOrgId,
+      );
+
+      const emailChanged = await this.applyChanges(targetUser, command);
+
+      const updatedUser = await this.usersRepository.update(targetUser);
+      this.emitUserUpdated(updatedUser);
+      if (emailChanged) {
+        await this.sendConfirmationEmail(updatedUser);
+      }
+      return updatedUser;
+    } catch (error) {
+      if (error instanceof ApplicationError) {
+        throw error;
+      }
+      this.logger.error('Failed to update user', {
+        error: error instanceof Error ? error.message : 'Unknown error',
+        userId: command.userId,
+      });
+      throw new UserUnexpectedError(error as Error);
+    }
+  }
+
+  private assertHasFieldsToUpdate(command: AdminUpdateUserCommand): void {
+    if (command.name === undefined && command.email === undefined) {
+      throw new UserInvalidInputError(
+        'At least one of name or email must be provided',
+      );
+    }
+  }
+
+  private readRequesterOrgId(): string {
+    const requesterOrgId = this.contextService.get('orgId');
+    if (!requesterOrgId) {
+      throw new UserUnauthorizedError('User not authenticated');
+    }
+    return requesterOrgId;
+  }
+
+  private async loadTargetUser(
+    userId: AdminUpdateUserCommand['userId'],
+    requesterOrgId: string,
+  ): Promise<User> {
+    const targetUser = await this.usersRepository.findOneById(userId);
+    if (!targetUser) {
+      throw new UserNotFoundError(userId);
+    }
+    if (targetUser.orgId !== requesterOrgId) {
+      throw new UserUnauthorizedError(
+        'You are not allowed to update this user',
+      );
+    }
+    return targetUser;
+  }
+
+  private async applyChanges(
+    user: User,
+    command: AdminUpdateUserCommand,
+  ): Promise<boolean> {
+    let emailChanged = false;
+    if (command.email !== undefined && command.email !== user.email) {
+      await this.assertEmailAvailable(command.email, user.id);
+      user.email = command.email;
+      user.emailVerified = false;
+      emailChanged = true;
+    }
+    if (command.name !== undefined) {
+      user.name = command.name;
+    }
+    return emailChanged;
+  }
+
+  private async assertEmailAvailable(
+    email: string,
+    currentUserId: User['id'],
+  ): Promise<void> {
+    const existing = await this.usersRepository.findOneByEmail(email);
+    if (existing && existing.id !== currentUserId) {
+      throw new UserAlreadyExistsError(email);
+    }
+  }
+
+  private async sendConfirmationEmail(user: User): Promise<void> {
+    try {
+      await this.sendConfirmationEmailUseCase.execute(
+        new SendConfirmationEmailCommand(user),
+      );
+    } catch (error) {
+      this.logger.error('Failed to send confirmation email after admin update', {
+        error: error instanceof Error ? error.message : 'Unknown error',
+        userId: user.id,
+      });
+    }
+  }
+
+  private emitUserUpdated(user: User): void {
+    this.eventEmitter
+      .emitAsync(
+        UserUpdatedEvent.EVENT_NAME,
+        new UserUpdatedEvent(user.id, user.orgId, user),
+      )
+      .catch((err: unknown) => {
+        this.logger.error('Failed to emit UserUpdatedEvent', {
+          error: err instanceof Error ? err.message : 'Unknown error',
+          userId: user.id,
+        });
+      });
+  }
+}

--- a/ayunis-core-backend/src/iam/users/presenters/http/admin-user.controller.ts
+++ b/ayunis-core-backend/src/iam/users/presenters/http/admin-user.controller.ts
@@ -1,0 +1,104 @@
+import {
+  Body,
+  Controller,
+  HttpCode,
+  HttpStatus,
+  Logger,
+  Param,
+  Patch,
+  UnauthorizedException,
+} from '@nestjs/common';
+import {
+  ApiBadRequestResponse,
+  ApiBody,
+  ApiInternalServerErrorResponse,
+  ApiNotFoundResponse,
+  ApiOperation,
+  ApiParam,
+  ApiResponse,
+  ApiTags,
+  ApiUnauthorizedResponse,
+} from '@nestjs/swagger';
+import { UUID } from 'crypto';
+import {
+  CurrentUser,
+  UserProperty,
+} from '../../../authentication/application/decorators/current-user.decorator';
+import { Roles } from 'src/iam/authorization/application/decorators/roles.decorator';
+import { UserRole } from '../../domain/value-objects/role.object';
+import { AdminUpdateUserUseCase } from '../../application/use-cases/admin-update-user/admin-update-user.use-case';
+import { AdminUpdateUserCommand } from '../../application/use-cases/admin-update-user/admin-update-user.command';
+import { AdminUpdateUserDto } from './dtos/admin-update-user.dto';
+import { UserResponseDto } from './dtos/user-response.dto';
+import { UserResponseDtoMapper } from './mappers/user-response-dto.mapper';
+
+@ApiTags('Users')
+@Controller('users')
+export class AdminUserController {
+  private readonly logger = new Logger(AdminUserController.name);
+
+  constructor(
+    private readonly adminUpdateUserUseCase: AdminUpdateUserUseCase,
+    private readonly userResponseDtoMapper: UserResponseDtoMapper,
+  ) {}
+
+  @Roles(UserRole.ADMIN)
+  @Patch(':id')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Update a user (admin)',
+    description:
+      "Update another user's name and/or email within your organization. You cannot edit your own profile through this endpoint.",
+  })
+  @ApiParam({
+    name: 'id',
+    description: 'User ID to update',
+    format: 'uuid',
+    example: '123e4567-e89b-12d3-a456-426614174000',
+  })
+  @ApiBody({
+    type: AdminUpdateUserDto,
+    description: 'Fields to update (at least one of name or email)',
+  })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'User successfully updated',
+    type: UserResponseDto,
+  })
+  @ApiBadRequestResponse({
+    description: 'Invalid input or no fields to update',
+  })
+  @ApiNotFoundResponse({
+    description: 'User not found',
+  })
+  @ApiUnauthorizedResponse({
+    description:
+      'User not authenticated, trying to edit own profile, or target user is in a different organization',
+  })
+  @ApiInternalServerErrorResponse({
+    description: 'Internal server error occurred while updating user',
+  })
+  async adminUpdateUser(
+    @Param('id') userId: UUID,
+    @Body() dto: AdminUpdateUserDto,
+    @CurrentUser(UserProperty.ID) currentUserId: UUID,
+  ): Promise<UserResponseDto> {
+    this.logger.log('adminUpdateUser', {
+      userId,
+      hasName: dto.name !== undefined,
+      hasEmail: dto.email !== undefined,
+    });
+
+    if (userId === currentUserId) {
+      throw new UnauthorizedException(
+        'You cannot edit your own profile through this endpoint',
+      );
+    }
+
+    const updatedUser = await this.adminUpdateUserUseCase.execute(
+      new AdminUpdateUserCommand(userId, dto.name, dto.email),
+    );
+
+    return this.userResponseDtoMapper.toDto(updatedUser);
+  }
+}

--- a/ayunis-core-backend/src/iam/users/presenters/http/dtos/admin-update-user.dto.ts
+++ b/ayunis-core-backend/src/iam/users/presenters/http/dtos/admin-update-user.dto.ts
@@ -1,0 +1,23 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsEmail, IsOptional, IsString, Length } from 'class-validator';
+
+export class AdminUpdateUserDto {
+  @ApiPropertyOptional({
+    description: 'New name for the user',
+    example: 'Maria Schmidt',
+    minLength: 1,
+    maxLength: 100,
+  })
+  @IsOptional()
+  @IsString({ message: 'Name must be a string' })
+  @Length(1, 100, { message: 'Name must be between 1 and 100 characters' })
+  name?: string;
+
+  @ApiPropertyOptional({
+    description: 'New email address for the user',
+    example: 'maria.schmidt@gemeinde.de',
+  })
+  @IsOptional()
+  @IsEmail({}, { message: 'Email must be a valid email address' })
+  email?: string;
+}

--- a/ayunis-core-backend/src/iam/users/users.module.ts
+++ b/ayunis-core-backend/src/iam/users/users.module.ts
@@ -23,6 +23,7 @@ import { CreateRegularUserUseCase } from './application/use-cases/create-regular
 import { ValidateUserUseCase } from './application/use-cases/validate-user/validate-user.use-case';
 import { IsValidPasswordUseCase } from './application/use-cases/is-valid-password/is-valid-password.use-case';
 import { UpdateUserNameUseCase } from './application/use-cases/update-user-name/update-user-name.use-case';
+import { AdminUpdateUserUseCase } from './application/use-cases/admin-update-user/admin-update-user.use-case';
 import { UpdatePasswordUseCase } from './application/use-cases/update-password/update-password.use-case';
 import { ConfirmEmailUseCase } from './application/use-cases/confirm-email/confirm-email.use-case';
 import { ResendEmailConfirmationUseCase } from './application/use-cases/resend-email-confirmation/resend-email-confirmation.use-case';
@@ -30,6 +31,7 @@ import { EmailConfirmationJwtService } from './application/services/email-confir
 
 // Import controllers and mappers
 import { UserController } from './presenters/http/user.controller';
+import { AdminUserController } from './presenters/http/admin-user.controller';
 import { UserResponseDtoMapper } from './presenters/http/mappers/user-response-dto.mapper';
 import { SuperAdminUserResponseDtoMapper } from './presenters/http/mappers/super-admin-user-response-dto.mapper';
 import { SendConfirmationEmailUseCase } from './application/use-cases/send-confirmation-email/send-confirmation-email.use-case';
@@ -75,6 +77,7 @@ import { DemoteFromSuperAdminUseCase } from './application/use-cases/demote-from
   ],
   controllers: [
     UserController,
+    AdminUserController,
     SuperAdminUsersController,
     SuperAdminManagementController,
   ],
@@ -98,6 +101,7 @@ import { DemoteFromSuperAdminUseCase } from './application/use-cases/demote-from
     ValidateUserUseCase,
     IsValidPasswordUseCase,
     UpdateUserNameUseCase,
+    AdminUpdateUserUseCase,
     UpdatePasswordUseCase,
     ConfirmEmailUseCase,
     ResendEmailConfirmationUseCase,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new admin-only write endpoint that can change user email (including resetting `emailVerified` and sending confirmation), which impacts identity data and triggers side effects (events/emails). Logic is well-covered by new unit tests, but reviewers should verify authorization/org-scoping and email uniqueness semantics match requirements.
> 
> **Overview**
> Adds a new admin-only `PATCH /users/:id` endpoint (`AdminUserController`) to update *another* user’s `name` and/or `email`, explicitly blocking self-updates and validating input via `AdminUpdateUserDto`.
> 
> Introduces `AdminUpdateUserUseCase` to enforce org-scoped authorization, perform email uniqueness checks, reset `emailVerified` + trigger `SendConfirmationEmailUseCase` when email changes, and emit `UserUpdatedEvent`; registers the controller/use case in `UsersModule` and adds comprehensive unit tests for success and error paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5b424acd09608f6d58c70b8bbbb32d315495de4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->