### PR TITLE
feat(admin-users): enable editing user name and email from admin list (AYC-123)

### DIFF
--- a/ayunis-core-frontend/src/pages/admin-settings/users-settings/api/useUserUpdate.ts
+++ b/ayunis-core-frontend/src/pages/admin-settings/users-settings/api/useUserUpdate.ts
@@ -1,0 +1,68 @@
+import {
+  getUserControllerGetUsersInOrganizationQueryKey,
+  useAdminUserControllerAdminUpdateUser,
+} from '@/shared/api/generated/ayunisCoreAPI';
+import type { AdminUpdateUserDto } from '@/shared/api/generated/ayunisCoreAPI.schemas';
+import { useQueryClient } from '@tanstack/react-query';
+import { useRouter } from '@tanstack/react-router';
+import { showError, showSuccess } from '@/shared/lib/toast';
+import { useTranslation } from 'react-i18next';
+import extractErrorData from '@/shared/api/extract-error-data';
+
+interface UserUpdateData {
+  id: string;
+  data: AdminUpdateUserDto;
+}
+
+interface UseUserUpdateOptions {
+  onSuccessCallback?: () => void;
+}
+
+export function useUserUpdate(options?: UseUserUpdateOptions) {
+  const queryClient = useQueryClient();
+  const router = useRouter();
+  const { t } = useTranslation('admin-settings-users');
+  const mutation = useAdminUserControllerAdminUpdateUser({
+    mutation: {
+      onSuccess: () => {
+        showSuccess(t('userUpdate.success'));
+        options?.onSuccessCallback?.();
+      },
+      onError: (err) => {
+        console.error('Error updating user', err);
+        try {
+          const { code } = extractErrorData(err);
+          switch (code) {
+            case 'USER_NOT_FOUND':
+              showError(t('userUpdate.notFound'));
+              break;
+            case 'USER_ALREADY_EXISTS':
+              showError(t('userUpdate.emailInUse'));
+              break;
+            default:
+              showError(t('userUpdate.error'));
+          }
+        } catch {
+          showError(t('userUpdate.error'));
+        }
+      },
+      onSettled: () => {
+        void queryClient.invalidateQueries({
+          queryKey: getUserControllerGetUsersInOrganizationQueryKey(),
+        });
+        void router.invalidate();
+      },
+    },
+  });
+
+  function updateUser({ id, data }: UserUpdateData) {
+    mutation.mutate({ id, data });
+  }
+
+  return {
+    updateUser,
+    isLoading: mutation.isPending,
+    isError: mutation.isError,
+    error: mutation.error,
+  };
+}

--- a/ayunis-core-frontend/src/pages/admin-settings/users-settings/model/editUserFormSchema.ts
+++ b/ayunis-core-frontend/src/pages/admin-settings/users-settings/model/editUserFormSchema.ts
@@ -1,0 +1,15 @@
+import * as z from 'zod';
+
+export function createEditUserFormSchema(t: (key: string) => string) {
+  return z.object({
+    name: z.string().min(1, t('editUserDialog.nameRequired')),
+    email: z
+      .string()
+      .min(1, t('editUserDialog.emailRequired'))
+      .email(t('editUserDialog.emailInvalid')),
+  });
+}
+
+export type EditUserFormValues = z.infer<
+  ReturnType<typeof createEditUserFormSchema>
+>;

--- a/ayunis-core-frontend/src/pages/admin-settings/users-settings/ui/EditUserDialog.tsx
+++ b/ayunis-core-frontend/src/pages/admin-settings/users-settings/ui/EditUserDialog.tsx
@@ -1,0 +1,144 @@
+import { Button } from '@/shared/ui/shadcn/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/shared/ui/shadcn/dialog';
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/shared/ui/shadcn/form';
+import { Input } from '@/shared/ui/shadcn/input';
+import { useEffect } from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useTranslation } from 'react-i18next';
+import type { User } from '../model/openapi';
+import {
+  createEditUserFormSchema,
+  type EditUserFormValues,
+} from '../model/editUserFormSchema';
+import { useUserUpdate } from '../api/useUserUpdate';
+
+interface EditUserDialogProps {
+  user: User | null;
+  onClose: () => void;
+}
+
+export default function EditUserDialog({
+  user,
+  onClose,
+}: Readonly<EditUserDialogProps>) {
+  const { t } = useTranslation('admin-settings-users');
+
+  const form = useForm<EditUserFormValues>({
+    resolver: zodResolver(createEditUserFormSchema(t)),
+    defaultValues: {
+      name: user?.name ?? '',
+      email: user?.email ?? '',
+    },
+  });
+
+  useEffect(() => {
+    if (user) {
+      form.reset({ name: user.name, email: user.email });
+    }
+  }, [user, form]);
+
+  const { updateUser, isLoading } = useUserUpdate({
+    onSuccessCallback: onClose,
+  });
+
+  function onSubmit(values: EditUserFormValues) {
+    if (!user) return;
+    const payload: { name?: string; email?: string } = {};
+    if (values.name !== user.name) payload.name = values.name;
+    if (values.email !== user.email) payload.email = values.email;
+    if (Object.keys(payload).length === 0) {
+      onClose();
+      return;
+    }
+    updateUser({ id: user.id, data: payload });
+  }
+
+  function handleOpenChange(open: boolean) {
+    if (!open) onClose();
+  }
+
+  return (
+    <Dialog open={user !== null} onOpenChange={handleOpenChange}>
+      <DialogContent className="sm:max-w-[525px]">
+        <DialogHeader>
+          <DialogTitle>{t('editUserDialog.title')}</DialogTitle>
+          <DialogDescription>
+            {t('editUserDialog.description')}
+          </DialogDescription>
+        </DialogHeader>
+        <Form {...form}>
+          <form
+            onSubmit={(e) => void form.handleSubmit(onSubmit)(e)}
+            className="space-y-4"
+          >
+            <FormField
+              control={form.control}
+              name="name"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>{t('editUserDialog.nameLabel')}</FormLabel>
+                  <FormControl>
+                    <Input
+                      placeholder={t('editUserDialog.namePlaceholder')}
+                      autoComplete="name"
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="email"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>{t('editUserDialog.emailLabel')}</FormLabel>
+                  <FormControl>
+                    <Input
+                      type="email"
+                      autoComplete="email"
+                      placeholder={t('editUserDialog.emailPlaceholder')}
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <DialogFooter>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={onClose}
+                disabled={isLoading}
+              >
+                {t('editUserDialog.cancel')}
+              </Button>
+              <Button type="submit" disabled={isLoading}>
+                {isLoading
+                  ? t('editUserDialog.saving')
+                  : t('editUserDialog.save')}
+              </Button>
+            </DialogFooter>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/ayunis-core-frontend/src/pages/admin-settings/users-settings/ui/UsersSection.tsx
+++ b/ayunis-core-frontend/src/pages/admin-settings/users-settings/ui/UsersSection.tsx
@@ -23,6 +23,7 @@ import { MoreHorizontal, Edit, Trash2, UserCheck, Mail } from 'lucide-react';
 import { useUserRoleUpdate } from '../api/useUserRoleUpdate';
 import { useUserDelete } from '../api/useUserDelete';
 import { useTriggerPasswordReset } from '../api/useTriggerPasswordReset';
+import EditUserDialog from './EditUserDialog';
 import { useState, type ReactNode } from 'react';
 import type { User } from '../model/openapi';
 import type { UserResponseDto } from '@/shared/api/generated/ayunisCoreAPI.schemas';
@@ -44,6 +45,7 @@ export default function UsersSection({
 }: Readonly<UsersSectionProps>) {
   const { t } = useTranslation('admin-settings-users');
   const [loadingUserId, setLoadingUserId] = useState<string | null>(null);
+  const [editingUser, setEditingUser] = useState<User | null>(null);
   const { updateUserRole, isLoading: isUpdatingRole } = useUserRoleUpdate({
     onSuccessCallback: () => setLoadingUserId(null),
   });
@@ -164,7 +166,10 @@ export default function UsersSection({
                       </Button>
                     </DropdownMenuTrigger>
                     <DropdownMenuContent align="end">
-                      <DropdownMenuItem disabled>
+                      <DropdownMenuItem
+                        onClick={() => setEditingUser(user)}
+                        disabled={isUserLoading(user.id)}
+                      >
                         <Edit />
                         {t('users.edit')}
                       </DropdownMenuItem>
@@ -204,6 +209,7 @@ export default function UsersSection({
         </Table>
         {paginationSlot}
       </CardContent>
+      <EditUserDialog user={editingUser} onClose={() => setEditingUser(null)} />
     </Card>
   );
 }

--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
@@ -1039,6 +1039,17 @@ export interface ResetPasswordDto {
   newPasswordConfirmation: string;
 }
 
+export interface AdminUpdateUserDto {
+  /**
+   * New name for the user
+   * @minLength 1
+   * @maxLength 100
+   */
+  name?: string;
+  /** New email address for the user */
+  email?: string;
+}
+
 export interface TriggerPasswordResetResponseDto {
   /** The password reset URL sent to the user */
   resetUrl: string;

--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.ts
@@ -30,6 +30,7 @@ import type {
   ActiveSubscriptionResponseDto,
   AddTeamMemberDto,
   AddUrlToKnowledgeBaseDto,
+  AdminUpdateUserDto,
   AgentResponseDto,
   AgentSourceResponseDto,
   AgentsControllerAddFileSourceBody,
@@ -4208,6 +4209,72 @@ export const useUserControllerDeleteUser = <TError = void,
       > => {
 
       const mutationOptions = getUserControllerDeleteUserMutationOptions(options);
+
+      return useMutation(mutationOptions, queryClient);
+    }
+    
+/**
+ * Update another user's name and/or email within your organization. You cannot edit your own profile through this endpoint.
+ * @summary Update a user (admin)
+ */
+export const adminUserControllerAdminUpdateUser = (
+    id: string,
+    adminUpdateUserDto: AdminUpdateUserDto,
+ ) => {
+      
+      
+      return customAxiosInstance<UserResponseDto>(
+      {url: `/users/${id}`, method: 'PATCH',
+      headers: {'Content-Type': 'application/json', },
+      data: adminUpdateUserDto
+    },
+      );
+    }
+  
+
+
+export const getAdminUserControllerAdminUpdateUserMutationOptions = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof adminUserControllerAdminUpdateUser>>, TError,{id: string;data: AdminUpdateUserDto}, TContext>, }
+): UseMutationOptions<Awaited<ReturnType<typeof adminUserControllerAdminUpdateUser>>, TError,{id: string;data: AdminUpdateUserDto}, TContext> => {
+
+const mutationKey = ['adminUserControllerAdminUpdateUser'];
+const {mutation: mutationOptions} = options ?
+      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
+      options
+      : {...options, mutation: {...options.mutation, mutationKey}}
+      : {mutation: { mutationKey, }};
+
+      
+
+
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof adminUserControllerAdminUpdateUser>>, {id: string;data: AdminUpdateUserDto}> = (props) => {
+          const {id,data} = props ?? {};
+
+          return  adminUserControllerAdminUpdateUser(id,data,)
+        }
+
+        
+
+
+  return  { mutationFn, ...mutationOptions }}
+
+    export type AdminUserControllerAdminUpdateUserMutationResult = NonNullable<Awaited<ReturnType<typeof adminUserControllerAdminUpdateUser>>>
+    export type AdminUserControllerAdminUpdateUserMutationBody = AdminUpdateUserDto
+    export type AdminUserControllerAdminUpdateUserMutationError = void
+
+    /**
+ * @summary Update a user (admin)
+ */
+export const useAdminUserControllerAdminUpdateUser = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof adminUserControllerAdminUpdateUser>>, TError,{id: string;data: AdminUpdateUserDto}, TContext>, }
+ , queryClient?: QueryClient): UseMutationResult<
+        Awaited<ReturnType<typeof adminUserControllerAdminUpdateUser>>,
+        TError,
+        {id: string;data: AdminUpdateUserDto},
+        TContext
+      > => {
+
+      const mutationOptions = getAdminUserControllerAdminUpdateUserMutationOptions(options);
 
       return useMutation(mutationOptions, queryClient);
     }

--- a/ayunis-core-frontend/src/shared/api/openapi-schema.json
+++ b/ayunis-core-frontend/src/shared/api/openapi-schema.json
@@ -1920,6 +1920,60 @@
         },
         "summary": "Delete a user",
         "tags": ["Users"]
+      },
+      "patch": {
+        "description": "Update another user's name and/or email within your organization. You cannot edit your own profile through this endpoint.",
+        "operationId": "AdminUserController_adminUpdateUser",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "description": "User ID to update",
+            "schema": {
+              "format": "uuid",
+              "example": "123e4567-e89b-12d3-a456-426614174000",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "description": "Fields to update (at least one of name or email)",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AdminUpdateUserDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "User successfully updated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserResponseDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid input or no fields to update"
+          },
+          "401": {
+            "description": "User not authenticated, trying to edit own profile, or target user is in a different organization"
+          },
+          "404": {
+            "description": "User not found"
+          },
+          "500": {
+            "description": "Internal server error occurred while updating user"
+          }
+        },
+        "summary": "Update a user (admin)",
+        "tags": ["Users"]
       }
     },
     "/users/{id}/trigger-password-reset": {
@@ -9791,6 +9845,23 @@
           }
         },
         "required": ["resetToken", "newPassword", "newPasswordConfirmation"]
+      },
+      "AdminUpdateUserDto": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "New name for the user",
+            "example": "Maria Schmidt",
+            "minLength": 1,
+            "maxLength": 100
+          },
+          "email": {
+            "type": "string",
+            "description": "New email address for the user",
+            "example": "maria.schmidt@gemeinde.de"
+          }
+        }
       },
       "TriggerPasswordResetResponseDto": {
         "type": "object",

--- a/ayunis-core-frontend/src/shared/locales/de/admin-settings-users.json
+++ b/ayunis-core-frontend/src/shared/locales/de/admin-settings-users.json
@@ -117,6 +117,26 @@
     "error": "Fehler beim Ändern der Benutzerrolle. Bitte versuchen Sie es erneut.",
     "notFound": "Benutzer nicht gefunden. Er wurde möglicherweise entfernt."
   },
+  "editUserDialog": {
+    "title": "Benutzer bearbeiten",
+    "description": "Name und E-Mail-Adresse des Benutzers aktualisieren.",
+    "nameLabel": "Name",
+    "namePlaceholder": "Vollständiger Name",
+    "nameRequired": "Name ist erforderlich",
+    "emailLabel": "E-Mail",
+    "emailPlaceholder": "benutzer@beispiel.de",
+    "emailRequired": "E-Mail-Adresse ist erforderlich",
+    "emailInvalid": "Bitte geben Sie eine gültige E-Mail-Adresse ein",
+    "cancel": "Abbrechen",
+    "save": "Speichern",
+    "saving": "Wird gespeichert..."
+  },
+  "userUpdate": {
+    "success": "Benutzer erfolgreich aktualisiert",
+    "error": "Fehler beim Aktualisieren des Benutzers. Bitte versuchen Sie es erneut.",
+    "notFound": "Benutzer nicht gefunden. Er wurde möglicherweise entfernt.",
+    "emailInUse": "Diese E-Mail-Adresse wird bereits von einem anderen Benutzer verwendet."
+  },
   "triggerPasswordReset": {
     "success": "Passwort-Reset-E-Mail erfolgreich gesendet",
     "error": "Fehler beim Senden der Passwort-Reset-E-Mail. Bitte versuchen Sie es erneut."

--- a/ayunis-core-frontend/src/shared/locales/en/admin-settings-users.json
+++ b/ayunis-core-frontend/src/shared/locales/en/admin-settings-users.json
@@ -116,6 +116,26 @@
     "error": "Failed to update user role. Please try again.",
     "notFound": "User not found. They may have been removed."
   },
+  "editUserDialog": {
+    "title": "Edit User",
+    "description": "Update the user's name and email address.",
+    "nameLabel": "Name",
+    "namePlaceholder": "Full name",
+    "nameRequired": "Name is required",
+    "emailLabel": "Email",
+    "emailPlaceholder": "user@example.com",
+    "emailRequired": "Email is required",
+    "emailInvalid": "Please enter a valid email address",
+    "cancel": "Cancel",
+    "save": "Save",
+    "saving": "Saving..."
+  },
+  "userUpdate": {
+    "success": "User updated successfully",
+    "error": "Failed to update user. Please try again.",
+    "notFound": "User not found. They may have been removed.",
+    "emailInUse": "This email address is already in use by another user."
+  },
   "triggerPasswordReset": {
     "success": "Password reset email sent successfully",
     "error": "Failed to send password reset email. Please try again."


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk because it introduces a new user-data mutation path (name/email) and wires in a new generated API endpoint with cache/router invalidation and error-code handling that could affect admin user management behavior.
> 
> **Overview**
> Enables admins to edit a user’s **name and email** directly from the users table by adding an `EditUserDialog` launched from the existing actions dropdown.
> 
> Introduces `useUserUpdate` (react-query mutation) backed by a newly generated `PATCH /users/{id}` (`AdminUpdateUserDto`) API client, including localized success/error toasts (e.g. *not found* / *email already in use*) and post-mutation refresh via query invalidation and `router.invalidate()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee7bce2513f46be87ba1c768ed7249e95000c14a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->