### PR TITLE
ci: sync Linear releases after deploys (AYC-126)

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -185,3 +185,18 @@ jobs:
           token: ${{ secrets.DOCS_REPO_PAT }}
           repository: ayunis-core/ayunis-core-docs
           event-type: release-published
+
+  linear-release:
+    name: Linear Release
+    runs-on: ubuntu-latest
+    needs: [release-please, deploy-internal, deploy-production]
+    if: ${{ needs.release-please.outputs.releases_created == 'true' }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: linear/linear-release-action@v0
+        with:
+          access_key: ${{ secrets.LINEAR_ACCESS_KEY }}
+          name: ${{ needs.release-please.outputs.tag_name }}
+          version: ${{ needs.release-please.outputs.tag_name }}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: only adds a new GitHub Actions job; main impact is potential CI failures or missed Linear updates if the secret/action config is wrong.
> 
> **Overview**
> After a successful `release-please` run and both internal and production deploys, the workflow now also creates/updates a Linear release using `linear/linear-release-action@v0`.
> 
> The new `linear-release` job checks out the repo (full history) and publishes a Linear release named/versioned from the generated `tag_name`, authenticated via `LINEAR_ACCESS_KEY`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc6d468d078e6f13ffd2231a92e6076c406d0e36. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->