### PR TITLE
feat(openai-compat): add OpenAI-compatible chat completions endpoint (AYC-132)

### DIFF
--- a/ayunis-core-backend/.dependency-cruiser-known-violations.json
+++ b/ayunis-core-backend/.dependency-cruiser-known-violations.json
@@ -133,5 +133,32 @@
       "severity": "error",
       "name": "no-cross-module-port-imports"
     }
+  },
+  {
+    "type": "dependency",
+    "from": "src/domain/openai-compat/application/use-cases/execute-openai-chat-completion/execute-openai-chat-completion.use-case.ts",
+    "to": "src/domain/models/application/ports/stream-inference.handler.ts",
+    "rule": {
+      "severity": "error",
+      "name": "no-cross-module-port-imports"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "src/domain/openai-compat/application/mappers/openai-stream.mapper.ts",
+    "to": "src/domain/models/application/ports/stream-inference.handler.ts",
+    "rule": {
+      "severity": "error",
+      "name": "no-cross-module-port-imports"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "src/domain/openai-compat/application/mappers/openai-response.mapper.ts",
+    "to": "src/domain/models/application/ports/inference.handler.ts",
+    "rule": {
+      "severity": "error",
+      "name": "no-cross-module-port-imports"
+    }
   }
 ]

--- a/ayunis-core-backend/src/app/app.module.ts
+++ b/ayunis-core-backend/src/app/app.module.ts
@@ -27,6 +27,7 @@ import { KnowledgeBasesModule } from '../domain/knowledge-bases/knowledge-bases.
 import { SkillTemplatesModule } from '../domain/skill-templates/skill-templates.module';
 import { ArtifactsModule } from '../domain/artifacts/artifacts.module';
 import { LetterheadsModule } from '../domain/letterheads/letterheads.module';
+import { OpenAICompatModule } from '../domain/openai-compat/openai-compat.module';
 import { IamModule } from '../iam/iam.module';
 
 import { modelsConfig } from '../config/models.config';
@@ -167,6 +168,7 @@ import { IntegrationsModule } from '../integrations/integrations.module';
     SkillTemplatesModule,
     ArtifactsModule,
     LetterheadsModule,
+    OpenAICompatModule,
     IamModule.register({
       authProvider:
         // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- env var may be undefined at runtime despite type cast

--- a/ayunis-core-backend/src/db/fixtures/minimal.fixture.ts
+++ b/ayunis-core-backend/src/db/fixtures/minimal.fixture.ts
@@ -18,7 +18,7 @@ export const minimalFixture = {
 
   user: {
     email: 'admin@demo.local',
-    // eslint-disable-next-line sonarjs/no-hardcoded-passwords -- dev-only seed credential
+
     password: 'admin',
     name: 'Admin',
     role: UserRole.ADMIN,
@@ -29,7 +29,7 @@ export const minimalFixture = {
 
   usageUser: {
     email: 'admin@usage.local',
-    // eslint-disable-next-line sonarjs/no-hardcoded-passwords -- dev-only seed credential
+
     password: 'admin',
     name: 'Usage Admin',
     role: UserRole.ADMIN,

--- a/ayunis-core-backend/src/db/migrations/1777448937554-AddFairUseImagesQuotaType.ts
+++ b/ayunis-core-backend/src/db/migrations/1777448937554-AddFairUseImagesQuotaType.ts
@@ -1,38 +1,85 @@
-import { MigrationInterface, QueryRunner } from "typeorm";
+import type { MigrationInterface, QueryRunner } from 'typeorm';
 
 export class AddFairUseImagesQuotaType1777448937554 implements MigrationInterface {
-    name = 'AddFairUseImagesQuotaType1777448937554'
+  name = 'AddFairUseImagesQuotaType1777448937554';
 
-    public async up(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.query(`ALTER TYPE "public"."agent_tools_tooltype_enum" RENAME TO "agent_tools_tooltype_enum_old"`);
-        await queryRunner.query(`CREATE TYPE "public"."agent_tools_tooltype_enum" AS ENUM('http', 'source_query', 'source_get_text', 'internet_search', 'website_content', 'send_email', 'create_calendar_event', 'code_execution', 'bar_chart', 'line_chart', 'pie_chart', 'mcp_tool', 'mcp_resource', 'mcp_prompt', 'activate_skill', 'create_skill', 'edit_skill', 'knowledge_query', 'knowledge_get_text', 'create_document', 'update_document', 'edit_document', 'read_document', 'generate_image', 'create_diagram', 'update_diagram')`);
-        await queryRunner.query(`ALTER TABLE "agent_tools" ALTER COLUMN "toolType" TYPE "public"."agent_tools_tooltype_enum" USING "toolType"::"text"::"public"."agent_tools_tooltype_enum"`);
-        await queryRunner.query(`DROP TYPE "public"."agent_tools_tooltype_enum_old"`);
-        await queryRunner.query(`DROP INDEX "public"."IDX_394fe814ce4a600f6a08311199"`);
-        await queryRunner.query(`ALTER TABLE "usage_quotas" DROP CONSTRAINT "UQ_394fe814ce4a600f6a083111998"`);
-        await queryRunner.query(`ALTER TYPE "public"."usage_quotas_quotatype_enum" RENAME TO "usage_quotas_quotatype_enum_old"`);
-        await queryRunner.query(`CREATE TYPE "public"."usage_quotas_quotatype_enum" AS ENUM('FAIR_USE_MESSAGES_LOW', 'FAIR_USE_MESSAGES_MEDIUM', 'FAIR_USE_MESSAGES_HIGH', 'FAIR_USE_IMAGES')`);
-        await queryRunner.query(`ALTER TABLE "usage_quotas" ALTER COLUMN "quotaType" TYPE "public"."usage_quotas_quotatype_enum" USING "quotaType"::"text"::"public"."usage_quotas_quotatype_enum"`);
-        await queryRunner.query(`DROP TYPE "public"."usage_quotas_quotatype_enum_old"`);
-        await queryRunner.query(`CREATE INDEX "IDX_394fe814ce4a600f6a08311199" ON "usage_quotas" ("userId", "quotaType") `);
-        await queryRunner.query(`ALTER TABLE "usage_quotas" ADD CONSTRAINT "UQ_394fe814ce4a600f6a083111998" UNIQUE ("userId", "quotaType")`);
-    }
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TYPE "public"."agent_tools_tooltype_enum" RENAME TO "agent_tools_tooltype_enum_old"`,
+    );
+    await queryRunner.query(
+      `CREATE TYPE "public"."agent_tools_tooltype_enum" AS ENUM('http', 'source_query', 'source_get_text', 'internet_search', 'website_content', 'send_email', 'create_calendar_event', 'code_execution', 'bar_chart', 'line_chart', 'pie_chart', 'mcp_tool', 'mcp_resource', 'mcp_prompt', 'activate_skill', 'create_skill', 'edit_skill', 'knowledge_query', 'knowledge_get_text', 'create_document', 'update_document', 'edit_document', 'read_document', 'generate_image', 'create_diagram', 'update_diagram')`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "agent_tools" ALTER COLUMN "toolType" TYPE "public"."agent_tools_tooltype_enum" USING "toolType"::"text"::"public"."agent_tools_tooltype_enum"`,
+    );
+    await queryRunner.query(
+      `DROP TYPE "public"."agent_tools_tooltype_enum_old"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_394fe814ce4a600f6a08311199"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "usage_quotas" DROP CONSTRAINT "UQ_394fe814ce4a600f6a083111998"`,
+    );
+    await queryRunner.query(
+      `ALTER TYPE "public"."usage_quotas_quotatype_enum" RENAME TO "usage_quotas_quotatype_enum_old"`,
+    );
+    await queryRunner.query(
+      `CREATE TYPE "public"."usage_quotas_quotatype_enum" AS ENUM('FAIR_USE_MESSAGES_LOW', 'FAIR_USE_MESSAGES_MEDIUM', 'FAIR_USE_MESSAGES_HIGH', 'FAIR_USE_IMAGES')`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "usage_quotas" ALTER COLUMN "quotaType" TYPE "public"."usage_quotas_quotatype_enum" USING "quotaType"::"text"::"public"."usage_quotas_quotatype_enum"`,
+    );
+    await queryRunner.query(
+      `DROP TYPE "public"."usage_quotas_quotatype_enum_old"`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_394fe814ce4a600f6a08311199" ON "usage_quotas" ("userId", "quotaType") `,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "usage_quotas" ADD CONSTRAINT "UQ_394fe814ce4a600f6a083111998" UNIQUE ("userId", "quotaType")`,
+    );
+  }
 
-    public async down(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.query(`ALTER TABLE "usage_quotas" DROP CONSTRAINT "UQ_394fe814ce4a600f6a083111998"`);
-        await queryRunner.query(`DROP INDEX "public"."IDX_394fe814ce4a600f6a08311199"`);
-        await queryRunner.query(`DELETE FROM "usage_quotas" WHERE "quotaType" = 'FAIR_USE_IMAGES'`);
-        await queryRunner.query(`CREATE TYPE "public"."usage_quotas_quotatype_enum_old" AS ENUM('FAIR_USE_MESSAGES_HIGH', 'FAIR_USE_MESSAGES_LOW', 'FAIR_USE_MESSAGES_MEDIUM')`);
-        await queryRunner.query(`ALTER TABLE "usage_quotas" ALTER COLUMN "quotaType" TYPE "public"."usage_quotas_quotatype_enum_old" USING "quotaType"::"text"::"public"."usage_quotas_quotatype_enum_old"`);
-        await queryRunner.query(`DROP TYPE "public"."usage_quotas_quotatype_enum"`);
-        await queryRunner.query(`ALTER TYPE "public"."usage_quotas_quotatype_enum_old" RENAME TO "usage_quotas_quotatype_enum"`);
-        await queryRunner.query(`ALTER TABLE "usage_quotas" ADD CONSTRAINT "UQ_394fe814ce4a600f6a083111998" UNIQUE ("userId", "quotaType")`);
-        await queryRunner.query(`CREATE INDEX "IDX_394fe814ce4a600f6a08311199" ON "usage_quotas" ("userId", "quotaType") `);
-        await queryRunner.query(`DELETE FROM "agent_tools" WHERE "toolType" IN ('create_diagram', 'update_diagram')`);
-        await queryRunner.query(`CREATE TYPE "public"."agent_tools_tooltype_enum_old" AS ENUM('http', 'source_query', 'source_get_text', 'internet_search', 'website_content', 'send_email', 'create_calendar_event', 'code_execution', 'bar_chart', 'line_chart', 'pie_chart', 'mcp_tool', 'mcp_resource', 'mcp_prompt', 'activate_skill', 'create_skill', 'edit_skill', 'knowledge_query', 'knowledge_get_text', 'create_document', 'update_document', 'edit_document', 'read_document', 'generate_image')`);
-        await queryRunner.query(`ALTER TABLE "agent_tools" ALTER COLUMN "toolType" TYPE "public"."agent_tools_tooltype_enum_old" USING "toolType"::"text"::"public"."agent_tools_tooltype_enum_old"`);
-        await queryRunner.query(`DROP TYPE "public"."agent_tools_tooltype_enum"`);
-        await queryRunner.query(`ALTER TYPE "public"."agent_tools_tooltype_enum_old" RENAME TO "agent_tools_tooltype_enum"`);
-    }
-
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "usage_quotas" DROP CONSTRAINT "UQ_394fe814ce4a600f6a083111998"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_394fe814ce4a600f6a08311199"`,
+    );
+    await queryRunner.query(
+      `DELETE FROM "usage_quotas" WHERE "quotaType" = 'FAIR_USE_IMAGES'`,
+    );
+    await queryRunner.query(
+      `CREATE TYPE "public"."usage_quotas_quotatype_enum_old" AS ENUM('FAIR_USE_MESSAGES_HIGH', 'FAIR_USE_MESSAGES_LOW', 'FAIR_USE_MESSAGES_MEDIUM')`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "usage_quotas" ALTER COLUMN "quotaType" TYPE "public"."usage_quotas_quotatype_enum_old" USING "quotaType"::"text"::"public"."usage_quotas_quotatype_enum_old"`,
+    );
+    await queryRunner.query(`DROP TYPE "public"."usage_quotas_quotatype_enum"`);
+    await queryRunner.query(
+      `ALTER TYPE "public"."usage_quotas_quotatype_enum_old" RENAME TO "usage_quotas_quotatype_enum"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "usage_quotas" ADD CONSTRAINT "UQ_394fe814ce4a600f6a083111998" UNIQUE ("userId", "quotaType")`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_394fe814ce4a600f6a08311199" ON "usage_quotas" ("userId", "quotaType") `,
+    );
+    await queryRunner.query(
+      `DELETE FROM "agent_tools" WHERE "toolType" IN ('create_diagram', 'update_diagram')`,
+    );
+    await queryRunner.query(
+      `CREATE TYPE "public"."agent_tools_tooltype_enum_old" AS ENUM('http', 'source_query', 'source_get_text', 'internet_search', 'website_content', 'send_email', 'create_calendar_event', 'code_execution', 'bar_chart', 'line_chart', 'pie_chart', 'mcp_tool', 'mcp_resource', 'mcp_prompt', 'activate_skill', 'create_skill', 'edit_skill', 'knowledge_query', 'knowledge_get_text', 'create_document', 'update_document', 'edit_document', 'read_document', 'generate_image')`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "agent_tools" ALTER COLUMN "toolType" TYPE "public"."agent_tools_tooltype_enum_old" USING "toolType"::"text"::"public"."agent_tools_tooltype_enum_old"`,
+    );
+    await queryRunner.query(`DROP TYPE "public"."agent_tools_tooltype_enum"`);
+    await queryRunner.query(
+      `ALTER TYPE "public"."agent_tools_tooltype_enum_old" RENAME TO "agent_tools_tooltype_enum"`,
+    );
+  }
 }

--- a/ayunis-core-backend/src/db/migrations/1779367289418-AddApiKeyAttribution.ts
+++ b/ayunis-core-backend/src/db/migrations/1779367289418-AddApiKeyAttribution.ts
@@ -1,34 +1,67 @@
-import { MigrationInterface, QueryRunner } from "typeorm";
+import type { MigrationInterface, QueryRunner } from 'typeorm';
 
 export class AddApiKeyAttribution1779367289418 implements MigrationInterface {
-    name = 'AddApiKeyAttribution1779367289418'
+  name = 'AddApiKeyAttribution1779367289418';
 
-    public async up(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.query(`ALTER TABLE "usage" ADD "apiKeyId" character varying`);
-        await queryRunner.query(`ALTER TABLE "usage" DROP CONSTRAINT "FK_91e198d9fab36eceba00b08f2b6"`);
-        await queryRunner.query(`DROP INDEX "public"."IDX_3b5f7176c00a59a347ac3d0eb5"`);
-        await queryRunner.query(`ALTER TABLE "usage" ALTER COLUMN "userId" DROP NOT NULL`);
-        await queryRunner.query(`CREATE INDEX "IDX_66cdd82a1ffc35f8d78c35c99f" ON "usage" ("apiKeyId", "createdAt") `);
-        await queryRunner.query(`CREATE INDEX "IDX_3b5f7176c00a59a347ac3d0eb5" ON "usage" ("userId", "createdAt") `);
-        await queryRunner.query(`ALTER TABLE "usage" ADD CONSTRAINT "CHK_usage_principal_not_both" CHECK ("userId" IS NULL OR "apiKeyId" IS NULL)`);
-        await queryRunner.query(`ALTER TABLE "usage" ADD CONSTRAINT "FK_91e198d9fab36eceba00b08f2b6" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE NO ACTION`);
-        await queryRunner.query(`ALTER TABLE "usage" ADD CONSTRAINT "FK_82cc3e3b0ea240eec1df45598c8" FOREIGN KEY ("apiKeyId") REFERENCES "api_keys"("id") ON DELETE SET NULL ON UPDATE NO ACTION`);
-    }
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "usage" ADD "apiKeyId" character varying`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "usage" DROP CONSTRAINT "FK_91e198d9fab36eceba00b08f2b6"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_3b5f7176c00a59a347ac3d0eb5"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "usage" ALTER COLUMN "userId" DROP NOT NULL`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_66cdd82a1ffc35f8d78c35c99f" ON "usage" ("apiKeyId", "createdAt") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_3b5f7176c00a59a347ac3d0eb5" ON "usage" ("userId", "createdAt") `,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "usage" ADD CONSTRAINT "CHK_usage_principal_not_both" CHECK ("userId" IS NULL OR "apiKeyId" IS NULL)`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "usage" ADD CONSTRAINT "FK_91e198d9fab36eceba00b08f2b6" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "usage" ADD CONSTRAINT "FK_82cc3e3b0ea240eec1df45598c8" FOREIGN KEY ("apiKeyId") REFERENCES "api_keys"("id") ON DELETE SET NULL ON UPDATE NO ACTION`,
+    );
+  }
 
-    public async down(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.query(`ALTER TABLE "usage" DROP CONSTRAINT "FK_82cc3e3b0ea240eec1df45598c8"`);
-        await queryRunner.query(`ALTER TABLE "usage" DROP CONSTRAINT "FK_91e198d9fab36eceba00b08f2b6"`);
-        await queryRunner.query(`ALTER TABLE "usage" DROP CONSTRAINT "CHK_usage_principal_not_both"`);
-        await queryRunner.query(`DROP INDEX "public"."IDX_3b5f7176c00a59a347ac3d0eb5"`);
-        await queryRunner.query(`DROP INDEX "public"."IDX_66cdd82a1ffc35f8d78c35c99f"`);
-        // Required: rows attributed to an api-key have userId NULL and would
-        // violate the re-imposed NOT NULL constraint. Drop them first so the
-        // ALTER below can succeed.
-        await queryRunner.query(`DELETE FROM "usage" WHERE "userId" IS NULL`);
-        await queryRunner.query(`ALTER TABLE "usage" ALTER COLUMN "userId" SET NOT NULL`);
-        await queryRunner.query(`CREATE INDEX "IDX_3b5f7176c00a59a347ac3d0eb5" ON "usage" ("userId", "createdAt") `);
-        await queryRunner.query(`ALTER TABLE "usage" ADD CONSTRAINT "FK_91e198d9fab36eceba00b08f2b6" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE NO ACTION`);
-        await queryRunner.query(`ALTER TABLE "usage" DROP COLUMN "apiKeyId"`);
-    }
-
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "usage" DROP CONSTRAINT "FK_82cc3e3b0ea240eec1df45598c8"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "usage" DROP CONSTRAINT "FK_91e198d9fab36eceba00b08f2b6"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "usage" DROP CONSTRAINT "CHK_usage_principal_not_both"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_3b5f7176c00a59a347ac3d0eb5"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_66cdd82a1ffc35f8d78c35c99f"`,
+    );
+    // Required: rows attributed to an api-key have userId NULL and would
+    // violate the re-imposed NOT NULL constraint. Drop them first so the
+    // ALTER below can succeed.
+    await queryRunner.query(`DELETE FROM "usage" WHERE "userId" IS NULL`);
+    await queryRunner.query(
+      `ALTER TABLE "usage" ALTER COLUMN "userId" SET NOT NULL`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_3b5f7176c00a59a347ac3d0eb5" ON "usage" ("userId", "createdAt") `,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "usage" ADD CONSTRAINT "FK_91e198d9fab36eceba00b08f2b6" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(`ALTER TABLE "usage" DROP COLUMN "apiKeyId"`);
+  }
 }

--- a/ayunis-core-backend/src/domain/models/SUMMARY.md
+++ b/ayunis-core-backend/src/domain/models/SUMMARY.md
@@ -21,6 +21,10 @@ The models module is the central registry for AI model configuration. The abstra
 - **ModelPolicyService** (`application/services/model-policy.service.ts`): Enforces provider constraints on models. Currently validates that image-generation models only use supported providers (Azure).
 - **TeamPermittedModelValidatorService** (`application/services/team-permitted-model-validator.service.ts`): Validates team ownership and org-scoping for team-scoped permitted model operations.
 
+## Domain Value Objects
+
+- **ToolSchema** (`domain/value-objects/tool-schema.ts`): Schema-shaped view of a tool (`{ name, description, parameters }`) decoupled from the executable `Tool` entity. Inference ports and provider converters accept `ToolSchema` so callers without server-executable tools — e.g. the `openai-compat` surface, where the client owns execution — can advertise tools to the LLM without constructing a full `Tool`. `Tool` is structurally assignable to `ToolSchema`.
+
 ## Use Cases
 
 - **CreateLanguageModelUseCase** (`application/use-cases/create-language-model`): Creates a new language model in the catalog.

--- a/ayunis-core-backend/src/domain/models/application/ports/inference.handler.ts
+++ b/ayunis-core-backend/src/domain/models/application/ports/inference.handler.ts
@@ -1,16 +1,16 @@
 import type { Message } from 'src/domain/messages/domain/message.entity';
-import type { Tool } from 'src/domain/tools/domain/tool.entity';
 import type { ModelToolChoice } from 'src/domain/models/domain/value-objects/model-tool-choice.enum';
 import type { TextMessageContent } from 'src/domain/messages/domain/message-contents/text-message-content.entity';
 import type { ToolUseMessageContent } from 'src/domain/messages/domain/message-contents/tool-use.message-content.entity';
 import type { ThinkingMessageContent } from 'src/domain/messages/domain/message-contents/thinking-message-content.entity';
 import type { Model } from '../../domain/model.entity';
+import type { ToolSchema } from '../../domain/value-objects/tool-schema';
 
 export class InferenceInput {
   public readonly model: Model;
   public readonly messages: Message[];
   public readonly systemPrompt?: string;
-  public readonly tools: Tool[];
+  public readonly tools: ToolSchema[];
   public readonly toolChoice?: ModelToolChoice;
   public readonly orgId: string;
 
@@ -18,7 +18,7 @@ export class InferenceInput {
     model: Model;
     messages: Message[];
     systemPrompt?: string;
-    tools: Tool[];
+    tools: ToolSchema[];
     toolChoice: ModelToolChoice;
     orgId: string;
   }) {

--- a/ayunis-core-backend/src/domain/models/application/ports/stream-inference.handler.ts
+++ b/ayunis-core-backend/src/domain/models/application/ports/stream-inference.handler.ts
@@ -1,15 +1,15 @@
 import type { Message } from 'src/domain/messages/domain/message.entity';
-import type { Tool } from 'src/domain/tools/domain/tool.entity';
 import type { ModelToolChoice } from 'src/domain/models/domain/value-objects/model-tool-choice.enum';
 import type { Model } from '../../domain/model.entity';
 import type { Observable } from 'rxjs';
 import type { ProviderMetadata } from 'src/domain/messages/domain/message-contents/provider-metadata.type';
+import type { ToolSchema } from '../../domain/value-objects/tool-schema';
 
 export class StreamInferenceInput {
   public readonly model: Model;
   public readonly messages: Message[];
   public readonly systemPrompt: string;
-  public readonly tools: Tool[];
+  public readonly tools: ToolSchema[];
   public readonly toolChoice?: ModelToolChoice;
   public readonly orgId: string;
 
@@ -17,7 +17,7 @@ export class StreamInferenceInput {
     model: Model;
     messages: Message[];
     systemPrompt: string;
-    tools?: Tool[];
+    tools?: ToolSchema[];
     toolChoice?: ModelToolChoice;
     orgId: string;
   }) {

--- a/ayunis-core-backend/src/domain/models/application/use-cases/get-inference/get-inference.command.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/get-inference/get-inference.command.ts
@@ -1,19 +1,19 @@
 import type { LanguageModel } from 'src/domain/models/domain/models/language.model';
-import type { Tool } from '../../../../tools/domain/tool.entity';
 import type { ModelToolChoice } from '../../../domain/value-objects/model-tool-choice.enum';
 import type { Message } from 'src/domain/messages/domain/message.entity';
+import type { ToolSchema } from '../../../domain/value-objects/tool-schema';
 
 export class GetInferenceCommand {
   model: LanguageModel;
   messages: Message[];
-  tools: Tool[];
+  tools: ToolSchema[];
   toolChoice: ModelToolChoice;
   instructions?: string;
 
   constructor(params: {
     model: LanguageModel;
     messages: Message[];
-    tools: Tool[];
+    tools: ToolSchema[];
     toolChoice: ModelToolChoice;
     instructions?: string;
   }) {

--- a/ayunis-core-backend/src/domain/models/domain/value-objects/tool-schema.ts
+++ b/ayunis-core-backend/src/domain/models/domain/value-objects/tool-schema.ts
@@ -1,0 +1,17 @@
+import type { JSONSchema } from 'json-schema-to-ts';
+
+/**
+ * The schema-shaped view of a tool that the inference port needs in order
+ * to advertise it to the LLM. Decoupled from `Tool` (the executable, typed
+ * domain entity) so that callers without server-executable tools — e.g. the
+ * OpenAI-compat surface, where the client owns execution — can construct
+ * plain `{ name, description, parameters }` objects directly.
+ *
+ * `Tool` is structurally assignable to `ToolSchema`, so callers holding
+ * full `Tool` instances can pass them through unchanged.
+ */
+export interface ToolSchema {
+  readonly name: string;
+  readonly description: string;
+  readonly parameters: JSONSchema;
+}

--- a/ayunis-core-backend/src/domain/models/infrastructure/converters/anthropic-message.converter.ts
+++ b/ayunis-core-backend/src/domain/models/infrastructure/converters/anthropic-message.converter.ts
@@ -1,6 +1,6 @@
 import type Anthropic from '@anthropic-ai/sdk';
 import type { Message } from 'src/domain/messages/domain/message.entity';
-import type { Tool } from 'src/domain/tools/domain/tool.entity';
+import type { ToolSchema } from '../../domain/value-objects/tool-schema';
 import { SystemMessage } from 'src/domain/messages/domain/messages/system-message.entity';
 import { TextMessageContent } from 'src/domain/messages/domain/message-contents/text-message-content.entity';
 import { UserMessage } from 'src/domain/messages/domain/messages/user-message.entity';
@@ -28,7 +28,7 @@ type AnthropicToolChoice = ToolChoiceAny | ToolChoiceAuto | ToolChoiceTool;
 export class AnthropicMessageConverter {
   constructor(private readonly imageContentService: ImageContentService) {}
 
-  convertTool(tool: Tool): Anthropic.Tool {
+  convertTool(tool: ToolSchema): Anthropic.Tool {
     return {
       name: tool.name,
       description: tool.description,

--- a/ayunis-core-backend/src/domain/models/infrastructure/converters/gemini-message.converter.ts
+++ b/ayunis-core-backend/src/domain/models/infrastructure/converters/gemini-message.converter.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
-import { Tool } from 'src/domain/tools/domain/tool.entity';
 import { Message } from 'src/domain/messages/domain/message.entity';
+import type { ToolSchema } from '../../domain/value-objects/tool-schema';
 import { TextMessageContent } from 'src/domain/messages/domain/message-contents/text-message-content.entity';
 import { ToolUseMessageContent } from 'src/domain/messages/domain/message-contents/tool-use.message-content.entity';
 import { ToolResultMessage } from 'src/domain/messages/domain/messages/tool-result-message.entity';
@@ -35,7 +35,7 @@ export interface GeminiPart extends Part {
 export class GeminiMessageConverter {
   constructor(private readonly imageContentService: ImageContentService) {}
 
-  convertTool(tool: Tool): FunctionDeclaration {
+  convertTool(tool: ToolSchema): FunctionDeclaration {
     return {
       name: tool.name,
       description: tool.description,
@@ -59,7 +59,7 @@ export class GeminiMessageConverter {
 
   buildConfig(input: {
     systemPrompt?: string;
-    tools: Tool[];
+    tools: ToolSchema[];
     toolChoice?: ModelToolChoice;
   }): GenerateContentConfig {
     const { tools, toolChoice, systemPrompt } = input;

--- a/ayunis-core-backend/src/domain/models/infrastructure/converters/mistral-message.converter.ts
+++ b/ayunis-core-backend/src/domain/models/infrastructure/converters/mistral-message.converter.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
-import { Tool } from 'src/domain/tools/domain/tool.entity';
 import { Message } from 'src/domain/messages/domain/message.entity';
+import type { ToolSchema } from '../../domain/value-objects/tool-schema';
 import { TextMessageContent } from 'src/domain/messages/domain/message-contents/text-message-content.entity';
 import { ToolUseMessageContent } from 'src/domain/messages/domain/message-contents/tool-use.message-content.entity';
 import { ToolResultMessage } from 'src/domain/messages/domain/messages/tool-result-message.entity';
@@ -26,7 +26,7 @@ import {
 export class MistralMessageConverter {
   constructor(private readonly imageContentService: ImageContentService) {}
 
-  convertTool(tool: Tool): MistralTool {
+  convertTool(tool: ToolSchema): MistralTool {
     return {
       type: 'function' as const,
       function: {

--- a/ayunis-core-backend/src/domain/models/infrastructure/converters/ollama-message.converter.ts
+++ b/ayunis-core-backend/src/domain/models/infrastructure/converters/ollama-message.converter.ts
@@ -3,8 +3,8 @@ import type {
   Message as OllamaMessage,
   ToolCall as OllamaToolCall,
 } from 'ollama';
-import type { Tool } from 'src/domain/tools/domain/tool.entity';
 import type { Message } from 'src/domain/messages/domain/message.entity';
+import type { ToolSchema } from '../../domain/value-objects/tool-schema';
 import { TextMessageContent } from 'src/domain/messages/domain/message-contents/text-message-content.entity';
 import { ToolUseMessageContent } from 'src/domain/messages/domain/message-contents/tool-use.message-content.entity';
 import { MessageRole } from 'src/domain/messages/domain/value-objects/message-role.object';
@@ -21,7 +21,7 @@ import { ThinkingMessageContent } from 'src/domain/messages/domain/message-conte
 export class OllamaMessageConverter {
   constructor(private readonly imageContentService?: ImageContentService) {}
 
-  convertTool(tool: Tool): OllamaTool {
+  convertTool(tool: ToolSchema): OllamaTool {
     return {
       type: 'function' as const,
       function: {

--- a/ayunis-core-backend/src/domain/models/infrastructure/converters/openai-chat-message.converter.ts
+++ b/ayunis-core-backend/src/domain/models/infrastructure/converters/openai-chat-message.converter.ts
@@ -1,7 +1,7 @@
 import type OpenAI from 'openai';
 import type { FunctionParameters } from 'openai/resources/shared';
-import type { Tool } from 'src/domain/tools/domain/tool.entity';
 import type { Message } from 'src/domain/messages/domain/message.entity';
+import type { ToolSchema } from '../../domain/value-objects/tool-schema';
 import { TextMessageContent } from 'src/domain/messages/domain/message-contents/text-message-content.entity';
 import { ImageMessageContent } from 'src/domain/messages/domain/message-contents/image-message-content.entity';
 import { ToolUseMessageContent } from 'src/domain/messages/domain/message-contents/tool-use.message-content.entity';
@@ -18,7 +18,7 @@ import { normalizeSchemaForOpenAI } from '../util/normalize-schema-for-openai';
 export class OpenAIChatMessageConverter {
   constructor(private readonly imageContentService: ImageContentService) {}
 
-  convertTool(tool: Tool): OpenAI.ChatCompletionTool {
+  convertTool(tool: ToolSchema): OpenAI.ChatCompletionTool {
     return {
       type: 'function' as const,
       function: {

--- a/ayunis-core-backend/src/domain/models/infrastructure/converters/openai-responses-message.converter.ts
+++ b/ayunis-core-backend/src/domain/models/infrastructure/converters/openai-responses-message.converter.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import OpenAI from 'openai';
-import { Tool } from 'src/domain/tools/domain/tool.entity';
 import { Message } from 'src/domain/messages/domain/message.entity';
+import type { ToolSchema } from '../../domain/value-objects/tool-schema';
 import { TextMessageContent } from 'src/domain/messages/domain/message-contents/text-message-content.entity';
 import { ToolUseMessageContent } from 'src/domain/messages/domain/message-contents/tool-use.message-content.entity';
 import { ToolResultMessage } from 'src/domain/messages/domain/messages/tool-result-message.entity';
@@ -22,7 +22,7 @@ import { normalizeSchemaForOpenAI } from '../util/normalize-schema-for-openai';
 export class OpenAIResponsesMessageConverter {
   constructor(private readonly imageContentService: ImageContentService) {}
 
-  convertTool(tool: Tool): OpenAI.Responses.Tool {
+  convertTool(tool: ToolSchema): OpenAI.Responses.Tool {
     return {
       type: 'function' as const,
       name: tool.name,

--- a/ayunis-core-backend/src/domain/models/infrastructure/stream-inference/base-anthropic.stream-inference.ts
+++ b/ayunis-core-backend/src/domain/models/infrastructure/stream-inference/base-anthropic.stream-inference.ts
@@ -178,10 +178,36 @@ export abstract class BaseAnthropicStreamInferenceHandler implements StreamInfer
       thinkingDelta: null,
       textContentDelta: null,
       toolCallsDelta: [],
+      // Map Anthropic's stop_reason into the provider-neutral terms the
+      // OpenAI-compat stream mapper understands. Anthropic's `tool_use`
+      // becomes `tool_calls` (the OpenAI finish_reason); the rest pass
+      // through. The stream mapper's own fallback turns anything unknown
+      // into `stop`, so this conversion is best-effort, not exhaustive.
+      finishReason: mapAnthropicStopReason(chunk.delta.stop_reason),
       usage: {
         inputTokens: undefined,
         outputTokens: chunk.usage.output_tokens,
       },
     });
+  }
+}
+
+function mapAnthropicStopReason(
+  reason: Anthropic.Messages.MessageDeltaEvent['delta']['stop_reason'],
+): string | null {
+  switch (reason) {
+    case 'end_turn':
+    case 'stop_sequence':
+      return 'stop';
+    case 'max_tokens':
+      return 'length';
+    case 'tool_use':
+      return 'tool_calls';
+    case 'pause_turn':
+    case 'refusal':
+    case null:
+      return null;
+    default:
+      return null;
   }
 }

--- a/ayunis-core-backend/src/domain/models/models.module.ts
+++ b/ayunis-core-backend/src/domain/models/models.module.ts
@@ -341,6 +341,7 @@ import { MistralMessageConverter } from './infrastructure/converters/mistral-mes
     UpdatePermittedModelUseCase,
     GetPermittedModelUseCase,
     GetPermittedLanguageModelUseCase,
+    GetPermittedLanguageModelsUseCase,
     GetPermittedEmbeddingModelUseCase,
     GetPermittedImageGenerationModelUseCase,
     GetPermittedModelsUseCase,

--- a/ayunis-core-backend/src/domain/openai-compat/SUMMARY.md
+++ b/ayunis-core-backend/src/domain/openai-compat/SUMMARY.md
@@ -1,0 +1,25 @@
+OpenAI-compatible Chat Completions
+Stateless POST /api/openai-compat/v1/chat/completions surface compatible with the OpenAI SDK (clients configure `base_url=…/api/openai-compat/v1`)
+
+This module exposes an OpenAI-compatible chat-completions endpoint so external clients can target ayunis with the standard OpenAI SDK. The surface is stateless — no thread persistence, `threadId` is synthesised per request — and authenticated via API key.
+
+The module consumes `ModelsModule` for `GetPermittedLanguageModelsUseCase`, `GetInferenceUseCase`, and `StreamInferenceUseCase`, and `RunsModule` for `InferenceUsageGuard` (preflight quota check + post-hoc usage accounting). It does not own its own persistence. Cross-module imports of inference port shapes (`StreamInferenceInput`, `InferenceResponse`, chunk types) are an intentional trade-off baselined in `.dependency-cruiser-known-violations.json` for the openai-compat → models edge.
+
+## Controllers
+
+- **ChatCompletionsController** (`presenters/http/chat-completions.controller.ts`): POST `/api/openai-compat/v1/chat/completions` (controller path `openai-compat/v1/chat` + global `api` prefix; SDK clients set `base_url=…/api/openai-compat/v1`) supporting both non-streaming JSON and Server-Sent Events streaming. Authenticated via `AuthGuard('api-key')` (overrides the global `JwtAuthGuard` for this route). Rate-limited at 60 requests/minute per client IP via the global `RateLimitGuard` (production only; the guard short-circuits in non-prod). All orchestration is delegated to the use case; the controller only handles DTO ↔ command conversion and SSE framing.
+
+## Use Cases
+
+- **ExecuteOpenAIChatCompletionUseCase** (`application/use-cases/execute-openai-chat-completion`): Sole orchestrator on this surface. Resolves the requested model against the caller's org permits, runs `InferenceUsageGuard.preflight`, dispatches to `GetInferenceUseCase` (non-streaming) or `StreamInferenceUseCase` (streaming), and accounts usage via `InferenceUsageGuard.collectUsage`. Streaming usage is recorded via RxJS `finalize()` so totals are summed across chunks and flushed on complete, error, or client unsubscribe (AYC-92 streaming usage-drift fix).
+
+## Mappers
+
+- **OpenAIRequestMapper** (`application/mappers/openai-request.mapper.ts`): Maps the OpenAI request DTO to domain `Message` entities, `ToolSchema[]`, system prompt, and `ModelToolChoice`. Rebuilds the `tool_call_id → name` map per assistant turn (AYC-78 finding I6). Forwards named `tool_choice` as the function name string — provider converters interpret a non-enum string as a named-tool choice.
+- **OpenAIResponseMapper** (`application/mappers/openai-response.mapper.ts`): Converts an `InferenceResponse` into the OpenAI `chat.completion` shape.
+- **OpenAIStreamMapper** (`application/mappers/openai-stream.mapper.ts`): Converts a domain stream chunk into an OpenAI `chat.completion.chunk`, dropping empty/thinking-only/usage-only chunks (returns `null`, filtered upstream).
+- **OpenAIErrorMapper** (`application/mappers/openai-error.mapper.ts`): Converts domain errors to OpenAI-style error response bodies.
+
+## Filters
+
+- **OpenAIExceptionFilter** (`presenters/http/filters/openai-exception.filter.ts`): Wraps thrown domain errors into OpenAI-compatible HTTP error responses so SDK clients see the shape they expect.

--- a/ayunis-core-backend/src/domain/openai-compat/application/mappers/openai-error-helpers.ts
+++ b/ayunis-core-backend/src/domain/openai-compat/application/mappers/openai-error-helpers.ts
@@ -1,0 +1,48 @@
+import type {
+  MappedOpenAIError,
+  OpenAIErrorEnvelope,
+  OpenAIErrorType,
+} from './openai-error.types';
+
+export function envelope(params: {
+  message: string;
+  type: OpenAIErrorType;
+  code?: string | null;
+  param?: string | null;
+}): OpenAIErrorEnvelope {
+  return {
+    error: {
+      message: params.message,
+      type: params.type,
+      code: params.code ?? null,
+      param: params.param ?? null,
+    },
+  };
+}
+
+/**
+ * HTTP status → OpenAI error type mapping.
+ *
+ * AYC-92 bug fix: 429 → `'rate_limit_error'`. The previous attempt let
+ * 429 fall through to `'invalid_request_error'`, breaking OpenAI SDK
+ * retry semantics for rate-limit / quota / credit-budget errors.
+ */
+export function statusToType(status: number): OpenAIErrorType {
+  if (status === 401) return 'authentication_error';
+  if (status === 403) return 'permission_error';
+  if (status === 429) return 'rate_limit_error';
+  if (status >= 500) return 'server_error';
+  return 'invalid_request_error';
+}
+
+export function mappedError(
+  status: number,
+  message: string,
+  code?: string | null,
+  param?: string | null,
+): MappedOpenAIError {
+  return {
+    status,
+    body: envelope({ message, type: statusToType(status), code, param }),
+  };
+}

--- a/ayunis-core-backend/src/domain/openai-compat/application/mappers/openai-error.mapper.spec.ts
+++ b/ayunis-core-backend/src/domain/openai-compat/application/mappers/openai-error.mapper.spec.ts
@@ -1,0 +1,110 @@
+import { OpenAIErrorMapper } from './openai-error.mapper';
+import { QuotaExceededError } from 'src/iam/quotas/application/quotas.errors';
+import { QuotaType } from 'src/iam/quotas/domain/quota-type.enum';
+import { CreditBudgetExceededError } from 'src/iam/subscriptions/application/subscription.errors';
+import { RateLimitExceededError } from 'src/iam/authorization/application/authorization.errors';
+import {
+  BadRequestException,
+  ForbiddenException,
+  UnauthorizedException,
+  InternalServerErrorException,
+} from '@nestjs/common';
+import { OpenAIModelNotFoundError } from '../openai-compat.errors';
+
+describe('OpenAIErrorMapper', () => {
+  const mapper = new OpenAIErrorMapper();
+
+  describe('429 → rate_limit_error (regression for AYC-92 / AYC-78 finding I5)', () => {
+    it('maps QuotaExceededError (HTTP 429) to rate_limit_error', () => {
+      const result = mapper.toEnvelope(
+        new QuotaExceededError(
+          QuotaType.FAIR_USE_MESSAGES_MEDIUM,
+          100,
+          3600_000,
+          60,
+        ),
+      );
+
+      expect(result.status).toBe(429);
+      expect(result.body.error.type).toBe('rate_limit_error');
+    });
+
+    it('maps CreditBudgetExceededError (HTTP 429) to rate_limit_error', () => {
+      const result = mapper.toEnvelope(
+        new CreditBudgetExceededError({
+          orgId: 'org' as never,
+          creditsUsed: 1000,
+          monthlyCredits: 500,
+        }),
+      );
+
+      expect(result.status).toBe(429);
+      expect(result.body.error.type).toBe('rate_limit_error');
+    });
+
+    it('maps RateLimitExceededError (HTTP 429) to rate_limit_error', () => {
+      const result = mapper.toEnvelope(new RateLimitExceededError());
+
+      expect(result.status).toBe(429);
+      expect(result.body.error.type).toBe('rate_limit_error');
+    });
+  });
+
+  describe('domain errors', () => {
+    it('maps model-not-found to invalid_request_error 404', () => {
+      const result = mapper.toEnvelope(new OpenAIModelNotFoundError('gpt-4o'));
+      expect(result.status).toBe(404);
+      // 404 falls through to default → invalid_request_error.
+      expect(result.body.error.type).toBe('invalid_request_error');
+      expect(result.body.error.code).toBe('OPENAI_COMPAT_MODEL_NOT_FOUND');
+    });
+  });
+
+  describe('HTTP exceptions', () => {
+    it.each([
+      [new UnauthorizedException(), 401, 'authentication_error'],
+      [new ForbiddenException(), 403, 'permission_error'],
+      [new BadRequestException('bad'), 400, 'invalid_request_error'],
+      [new InternalServerErrorException(), 500, 'server_error'],
+    ])('%p → %d / %s', (exception, expectedStatus, expectedType) => {
+      const result = mapper.toEnvelope(exception);
+      expect(result.status).toBe(expectedStatus);
+      expect(result.body.error.type).toBe(expectedType);
+    });
+  });
+
+  describe('validation errors expose `param` (regression for AYC-132 bug 7)', () => {
+    it('populates `param` with the first field from a ValidationPipe BadRequestException', () => {
+      const result = mapper.toEnvelope(
+        new BadRequestException({
+          code: 'VALIDATION_ERROR',
+          message: 'Validation failed',
+          errors: [{ field: 'messages', constraints: ['arrayMinSize'] }],
+        }),
+      );
+      expect(result.status).toBe(400);
+      expect(result.body.error.type).toBe('invalid_request_error');
+      expect(result.body.error.code).toBe('VALIDATION_ERROR');
+      expect(result.body.error.param).toBe('messages');
+      expect(result.body.error.message).toBe('messages: arrayMinSize');
+    });
+
+    it('falls back to the generic message shape for non-validation BadRequestException bodies', () => {
+      const result = mapper.toEnvelope(new BadRequestException('plain bad'));
+      expect(result.body.error.param).toBeNull();
+      expect(result.body.error.message).toBe('plain bad');
+    });
+  });
+
+  describe('unknown errors', () => {
+    it('maps plain Error to server_error 500 without echoing the message', () => {
+      const result = mapper.toEnvelope(
+        new Error('upstream API: prompt content "hidden secret"'),
+      );
+      expect(result.status).toBe(500);
+      expect(result.body.error.type).toBe('server_error');
+      // The public message must NOT echo the upstream payload.
+      expect(result.body.error.message).toBe('Internal server error');
+    });
+  });
+});

--- a/ayunis-core-backend/src/domain/openai-compat/application/mappers/openai-error.mapper.ts
+++ b/ayunis-core-backend/src/domain/openai-compat/application/mappers/openai-error.mapper.ts
@@ -1,0 +1,101 @@
+import { Injectable, Logger, HttpException } from '@nestjs/common';
+import { ApplicationError } from 'src/common/errors/base.error';
+import { mappedError } from './openai-error-helpers';
+import type { MappedOpenAIError } from './openai-error.types';
+import { envelope } from './openai-error-helpers';
+
+@Injectable()
+export class OpenAIErrorMapper {
+  private readonly logger = new Logger(OpenAIErrorMapper.name);
+
+  /**
+   * Convert any thrown value into an OpenAI error envelope. Domain errors
+   * carry an HTTP status; HTTP exceptions carry one directly; anything
+   * else is treated as a 500 `server_error`.
+   */
+  toEnvelope(error: unknown): MappedOpenAIError {
+    if (error instanceof ApplicationError) {
+      return mappedError(error.statusCode, error.message, error.code);
+    }
+    if (error instanceof HttpException) {
+      const status = error.getStatus();
+      const body = error.getResponse();
+      const validation = extractValidationDetails(body);
+      if (validation) {
+        // Surface the failing field via `param` — OpenAI SDKs use it to
+        // attach error UX to the offending input. Constructed message
+        // includes the field name so SDK clients without param-aware UX
+        // still get an actionable string.
+        const message = validation.constraint
+          ? `${validation.field}: ${validation.constraint}`
+          : `Invalid value for '${validation.field}'`;
+        return mappedError(
+          status,
+          message,
+          'VALIDATION_ERROR',
+          validation.field,
+        );
+      }
+      const message =
+        typeof body === 'string'
+          ? body
+          : ((body as { message?: string }).message ?? error.message);
+      return mappedError(status, message);
+    }
+    // Log structurally — never include the raw error object, which can
+    // echo prompt fragments from upstream SDKs (AYC-92 redaction sweep).
+    this.logger.error('Unhandled error in OpenAI-compat path', {
+      status: extractStatus(error),
+    });
+    return {
+      status: 500,
+      body: envelope({
+        message: 'Internal server error',
+        type: 'server_error',
+      }),
+    };
+  }
+}
+
+function extractStatus(error: unknown): number | undefined {
+  if (typeof error !== 'object' || error === null) return undefined;
+  const maybeStatus = (error as { status?: unknown }).status;
+  if (typeof maybeStatus === 'number') return maybeStatus;
+  const maybeResponse = (error as { response?: { status?: unknown } }).response;
+  if (
+    maybeResponse &&
+    typeof maybeResponse === 'object' &&
+    typeof maybeResponse.status === 'number'
+  ) {
+    return maybeResponse.status;
+  }
+  return undefined;
+}
+
+interface ValidationDetails {
+  field: string;
+  constraint?: string;
+}
+
+/**
+ * Recognises the shape produced by main.ts's ValidationPipe exceptionFactory:
+ * `{ code: 'VALIDATION_ERROR', message, errors: [{ field, constraints }] }`.
+ * Returns the first failing field so the OpenAI envelope can populate `param`
+ * (otherwise it would always be null, which SDKs can't attach UX to).
+ */
+function extractValidationDetails(body: unknown): ValidationDetails | null {
+  if (typeof body !== 'object' || body === null) return null;
+  const obj = body as {
+    code?: unknown;
+    errors?: unknown;
+  };
+  if (obj.code !== 'VALIDATION_ERROR') return null;
+  if (!Array.isArray(obj.errors) || obj.errors.length === 0) return null;
+  const first = obj.errors[0] as { field?: unknown; constraints?: unknown };
+  if (typeof first.field !== 'string') return null;
+  const constraint =
+    Array.isArray(first.constraints) && typeof first.constraints[0] === 'string'
+      ? first.constraints[0]
+      : undefined;
+  return { field: first.field, constraint };
+}

--- a/ayunis-core-backend/src/domain/openai-compat/application/mappers/openai-error.types.ts
+++ b/ayunis-core-backend/src/domain/openai-compat/application/mappers/openai-error.types.ts
@@ -1,0 +1,29 @@
+/**
+ * Discriminator union for OpenAI's error envelope. The OpenAI SDK keys
+ * retry logic off `error.type`: `'rate_limit_error'` and `'server_error'`
+ * are retried, others are surfaced to the caller.
+ *
+ * AYC-92 bug fix: the previous attempt mapped 429 → `'invalid_request_error'`
+ * (the default), which broke SDK retry on rate-limit / quota / credit-budget
+ * errors. 429 now maps to `'rate_limit_error'`.
+ */
+export type OpenAIErrorType =
+  | 'invalid_request_error'
+  | 'authentication_error'
+  | 'permission_error'
+  | 'rate_limit_error'
+  | 'server_error';
+
+export interface OpenAIErrorEnvelope {
+  error: {
+    message: string;
+    type: OpenAIErrorType;
+    code: string | null;
+    param: string | null;
+  };
+}
+
+export interface MappedOpenAIError {
+  status: number;
+  body: OpenAIErrorEnvelope;
+}

--- a/ayunis-core-backend/src/domain/openai-compat/application/mappers/openai-request.mapper.ts
+++ b/ayunis-core-backend/src/domain/openai-compat/application/mappers/openai-request.mapper.ts
@@ -1,0 +1,192 @@
+import { Injectable } from '@nestjs/common';
+import { randomUUID, type UUID } from 'crypto';
+import { Message } from 'src/domain/messages/domain/message.entity';
+import { UserMessage } from 'src/domain/messages/domain/messages/user-message.entity';
+import { AssistantMessage } from 'src/domain/messages/domain/messages/assistant-message.entity';
+import { ToolResultMessage } from 'src/domain/messages/domain/messages/tool-result-message.entity';
+import { TextMessageContent } from 'src/domain/messages/domain/message-contents/text-message-content.entity';
+import { ToolUseMessageContent } from 'src/domain/messages/domain/message-contents/tool-use.message-content.entity';
+import { ToolResultMessageContent } from 'src/domain/messages/domain/message-contents/tool-result.message-content.entity';
+import { ModelToolChoice } from 'src/domain/models/domain/value-objects/model-tool-choice.enum';
+import type { ToolSchema } from 'src/domain/models/domain/value-objects/tool-schema';
+import type { JSONSchema } from 'json-schema-to-ts';
+import { OpenAIInvalidRequestError } from '../openai-compat.errors';
+import type {
+  OpenAIChatCompletionMessage,
+  OpenAIChatCompletionRequest,
+} from '../types/openai-request.types';
+
+/**
+ * Maps OpenAI chat-completion request DTOs into the domain shapes that
+ * `GetInferenceUseCase` / `StreamInferenceUseCase` expect.
+ *
+ * Tool-call scoping note: the previous attempt built a *global*
+ * tool_call_id → name map across the entire conversation, so a tool result
+ * for a reused id resolved to the first-ever occurrence instead of the
+ * most-recent assistant turn that emitted it. This mapper rebuilds the map
+ * per assistant turn — tool results resolve against the most recent
+ * assistant turn that introduced the id (AYC-78 finding I6).
+ */
+@Injectable()
+export class OpenAIRequestMapper {
+  toDomainMessages(
+    request: OpenAIChatCompletionRequest,
+    threadId: UUID,
+  ): {
+    systemPrompt: string;
+    messages: Message[];
+  } {
+    const messages: Message[] = [];
+    let systemPrompt = '';
+    let currentTurnToolMap = new Map<string, string>();
+
+    for (const msg of request.messages) {
+      if (msg.role === 'system') {
+        const text = this.extractTextContent(msg);
+        systemPrompt = systemPrompt ? `${systemPrompt}\n\n${text}` : text;
+      } else if (msg.role === 'user') {
+        messages.push(this.buildUserMessage(msg, threadId));
+      } else if (msg.role === 'assistant') {
+        currentTurnToolMap = new Map();
+        messages.push(
+          this.buildAssistantMessage(msg, threadId, currentTurnToolMap),
+        );
+      } else {
+        messages.push(
+          this.buildToolResultMessage(msg, threadId, currentTurnToolMap),
+        );
+      }
+    }
+
+    return { systemPrompt, messages };
+  }
+
+  private buildUserMessage(
+    msg: OpenAIChatCompletionMessage,
+    threadId: UUID,
+  ): UserMessage {
+    const text = this.extractTextContent(msg);
+    if (!text) {
+      throw new OpenAIInvalidRequestError(
+        'user message must have non-empty text content',
+      );
+    }
+    return new UserMessage({
+      threadId,
+      content: [new TextMessageContent(text)],
+    });
+  }
+
+  private buildAssistantMessage(
+    msg: OpenAIChatCompletionMessage,
+    threadId: UUID,
+    turnToolMap: Map<string, string>,
+  ): AssistantMessage {
+    const blocks: Array<TextMessageContent | ToolUseMessageContent> = [];
+
+    const text = this.extractTextContent(msg);
+    if (text) {
+      blocks.push(new TextMessageContent(text));
+    }
+    if (msg.tool_calls && msg.tool_calls.length > 0) {
+      for (const tc of msg.tool_calls) {
+        const parsedArgs = this.safeParseToolArgs(tc.function.arguments);
+        blocks.push(
+          new ToolUseMessageContent(tc.id, tc.function.name, parsedArgs),
+        );
+        turnToolMap.set(tc.id, tc.function.name);
+      }
+    }
+    if (blocks.length === 0) {
+      // OpenAI permits assistant messages with content=null + tool_calls
+      // undefined as placeholders; reject as invalid.
+      throw new OpenAIInvalidRequestError(
+        'assistant message must contain text or tool_calls',
+      );
+    }
+    return new AssistantMessage({ threadId, content: blocks });
+  }
+
+  private buildToolResultMessage(
+    msg: OpenAIChatCompletionMessage,
+    threadId: UUID,
+    turnToolMap: Map<string, string>,
+  ): ToolResultMessage {
+    if (!msg.tool_call_id) {
+      throw new OpenAIInvalidRequestError(
+        'tool message must include tool_call_id',
+      );
+    }
+    const toolName = turnToolMap.get(msg.tool_call_id) ?? msg.name ?? 'unknown';
+    const result = this.extractTextContent(msg);
+    return new ToolResultMessage({
+      threadId,
+      content: [
+        new ToolResultMessageContent(msg.tool_call_id, toolName, result),
+      ],
+    });
+  }
+
+  toModelToolChoice(request: OpenAIChatCompletionRequest): ModelToolChoice {
+    const tc = request.tool_choice;
+    if (tc === 'required') return ModelToolChoice.REQUIRED;
+    // typeof null === 'object', and JSON can deliver null even though the
+    // DTO type does not model it — guard explicitly.
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition, sonarjs/different-types-comparison
+    if (tc !== null && typeof tc === 'object') {
+      // Forward the named tool. Downstream provider converters
+      // (openai-chat-message.converter.ts, anthropic-message.converter.ts)
+      // treat any non-enum string as a tool name and emit a named-tool
+      // tool_choice in the provider call.
+      const fn = (tc as { function?: { name?: unknown } }).function;
+      if (!fn || typeof fn.name !== 'string' || fn.name.length === 0) {
+        throw new OpenAIInvalidRequestError(
+          "tool_choice object must include a 'function.name' string",
+        );
+      }
+      return fn.name as ModelToolChoice;
+    }
+    // 'auto' | 'none' | undefined → AUTO ('none' best-effort: tools are
+    // still passed but model is told it's free to ignore them).
+    return ModelToolChoice.AUTO;
+  }
+
+  /**
+   * Map the OpenAI request's `tools` array into the inference port's
+   * `ToolSchema[]` contract. The OpenAI surface is stateless and the client
+   * owns execution, so we never construct domain `Tool` entities here — the
+   * schema is all the LLM needs to be told the tool exists.
+   */
+  toToolSchemas(request: OpenAIChatCompletionRequest): ToolSchema[] {
+    return (request.tools ?? []).map((t) => ({
+      name: t.function.name,
+      description: t.function.description ?? '',
+      parameters: (t.function.parameters ?? {}) as JSONSchema,
+    }));
+  }
+
+  newRequestId(): UUID {
+    return randomUUID();
+  }
+
+  private extractTextContent(msg: OpenAIChatCompletionMessage): string {
+    if (msg.content === undefined || msg.content === null) return '';
+    if (typeof msg.content === 'string') return msg.content;
+    // Array-of-parts content (multimodal) is not supported in iter 3.
+    throw new OpenAIInvalidRequestError(
+      'array-of-parts message content is not supported (use a string)',
+    );
+  }
+
+  private safeParseToolArgs(raw: string): Record<string, unknown> {
+    if (!raw) return {};
+    try {
+      const parsed = JSON.parse(raw) as unknown;
+      return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+        ? (parsed as Record<string, unknown>)
+        : {};
+    } catch {
+      return {};
+    }
+  }
+}

--- a/ayunis-core-backend/src/domain/openai-compat/application/mappers/openai-response.mapper.ts
+++ b/ayunis-core-backend/src/domain/openai-compat/application/mappers/openai-response.mapper.ts
@@ -1,0 +1,74 @@
+import { Injectable } from '@nestjs/common';
+import { TextMessageContent } from 'src/domain/messages/domain/message-contents/text-message-content.entity';
+import { ToolUseMessageContent } from 'src/domain/messages/domain/message-contents/tool-use.message-content.entity';
+import type { InferenceResponse } from 'src/domain/models/application/ports/inference.handler';
+import type {
+  ChatCompletionResponse,
+  ChatCompletionResponseChoice,
+  ChatCompletionResponseMessage,
+  ChatCompletionToolCallResponse,
+} from '../types/openai-response.types';
+
+@Injectable()
+export class OpenAIResponseMapper {
+  toResponse(params: {
+    id: string;
+    modelName: string;
+    response: InferenceResponse;
+  }): ChatCompletionResponse {
+    const message = this.buildAssistantMessage(params.response);
+    const finishReason: ChatCompletionResponseChoice['finish_reason'] =
+      message.tool_calls && message.tool_calls.length > 0
+        ? 'tool_calls'
+        : 'stop';
+
+    return {
+      id: params.id,
+      object: 'chat.completion',
+      created: Math.floor(Date.now() / 1000),
+      model: params.modelName,
+      choices: [{ index: 0, message, finish_reason: finishReason }],
+      usage:
+        params.response.meta.inputTokens !== undefined &&
+        params.response.meta.outputTokens !== undefined
+          ? {
+              prompt_tokens: params.response.meta.inputTokens,
+              completion_tokens: params.response.meta.outputTokens,
+              total_tokens:
+                params.response.meta.totalTokens ??
+                params.response.meta.inputTokens +
+                  params.response.meta.outputTokens,
+            }
+          : undefined,
+    };
+  }
+
+  private buildAssistantMessage(
+    response: InferenceResponse,
+  ): ChatCompletionResponseMessage {
+    let textContent = '';
+    const toolCalls: ChatCompletionToolCallResponse[] = [];
+
+    for (const block of response.content) {
+      if (block instanceof TextMessageContent) {
+        textContent += block.text;
+      } else if (block instanceof ToolUseMessageContent) {
+        toolCalls.push({
+          id: block.id,
+          type: 'function',
+          function: {
+            name: block.name,
+            arguments: JSON.stringify(block.params),
+          },
+        });
+      }
+      // ThinkingMessageContent is dropped — OpenAI's schema has no equivalent.
+    }
+
+    return {
+      role: 'assistant',
+      content: textContent.length > 0 ? textContent : null,
+      ...(toolCalls.length > 0 && { tool_calls: toolCalls }),
+    };
+  }
+}

--- a/ayunis-core-backend/src/domain/openai-compat/application/mappers/openai-stream.mapper.spec.ts
+++ b/ayunis-core-backend/src/domain/openai-compat/application/mappers/openai-stream.mapper.spec.ts
@@ -1,0 +1,221 @@
+import {
+  OpenAIStreamMapper,
+  OpenAIStreamSession,
+} from './openai-stream.mapper';
+import {
+  StreamInferenceResponseChunk,
+  StreamInferenceResponseChunkToolCall,
+} from 'src/domain/models/application/ports/stream-inference.handler';
+
+describe('OpenAIStreamMapper', () => {
+  const mapper = new OpenAIStreamMapper();
+
+  const make = (params: {
+    text?: string | null;
+    thinking?: string | null;
+    toolCallsDelta?: StreamInferenceResponseChunkToolCall[];
+    finishReason?: string | null;
+  }): StreamInferenceResponseChunk =>
+    new StreamInferenceResponseChunk({
+      thinkingDelta: params.thinking ?? null,
+      textContentDelta: params.text ?? null,
+      toolCallsDelta: params.toolCallsDelta ?? [],
+      finishReason: params.finishReason,
+    });
+
+  const newSession = () => new OpenAIStreamSession();
+
+  it('drops empty-string textContentDelta (regression for AYC-78 finding S21)', () => {
+    const result = mapper.toChunk({
+      id: 'chatcmpl-1',
+      modelName: 'gpt-4o',
+      chunk: make({ text: '' }),
+      isFirst: false,
+      session: newSession(),
+    });
+    expect(result).toBeNull();
+  });
+
+  it('drops thinking-only chunks (no OpenAI equivalent)', () => {
+    const result = mapper.toChunk({
+      id: 'chatcmpl-1',
+      modelName: 'gpt-4o',
+      chunk: make({ thinking: 'pondering...' }),
+      isFirst: false,
+      session: newSession(),
+    });
+    expect(result).toBeNull();
+  });
+
+  it('emits content delta with role on the first non-null chunk', () => {
+    const result = mapper.toChunk({
+      id: 'chatcmpl-1',
+      modelName: 'gpt-4o',
+      chunk: make({ text: 'Hello' }),
+      isFirst: true,
+      session: newSession(),
+    });
+    expect(result?.choices[0].delta).toEqual({
+      role: 'assistant',
+      content: 'Hello',
+    });
+  });
+
+  describe('finish_reason mapping (regression for AYC-78 finding I8)', () => {
+    it("emits 'tool_calls' only when a NEW tool call appears in the same chunk", () => {
+      const result = mapper.toChunk({
+        id: 'chatcmpl-1',
+        modelName: 'gpt-4o',
+        chunk: make({
+          finishReason: 'stop',
+          toolCallsDelta: [
+            new StreamInferenceResponseChunkToolCall({
+              index: 0,
+              id: 'call_1',
+              name: 'lookup',
+              argumentsDelta: null,
+            }),
+          ],
+        }),
+        isFirst: false,
+        session: newSession(),
+      });
+      expect(result?.choices[0].finish_reason).toBe('tool_calls');
+    });
+
+    it("preserves 'stop' when only an argument-delta continuation is present", () => {
+      const result = mapper.toChunk({
+        id: 'chatcmpl-1',
+        modelName: 'gpt-4o',
+        chunk: make({
+          finishReason: 'stop',
+          toolCallsDelta: [
+            // Continuation chunk: no id, no name — argument bytes only.
+            new StreamInferenceResponseChunkToolCall({
+              index: 0,
+              id: null,
+              name: null,
+              argumentsDelta: '"value"',
+            }),
+          ],
+        }),
+        isFirst: false,
+        session: newSession(),
+      });
+      expect(result?.choices[0].finish_reason).toBe('stop');
+    });
+
+    it('emits null finish_reason for chunks without one', () => {
+      const result = mapper.toChunk({
+        id: 'chatcmpl-1',
+        modelName: 'gpt-4o',
+        chunk: make({ text: 'partial' }),
+        isFirst: false,
+        session: newSession(),
+      });
+      expect(result?.choices[0].finish_reason).toBeNull();
+    });
+  });
+
+  describe('tool-call index remapping (regression for AYC-132 bug 3)', () => {
+    it('remaps a single non-zero provider index to OpenAI index 0', () => {
+      // Anthropic emits content-block index 1 for a tool call that follows
+      // a text content block at index 0. OpenAI clients expect tool_calls
+      // to be zero-based by position in tool_calls[].
+      const session = newSession();
+      const result = mapper.toChunk({
+        id: 'chatcmpl-1',
+        modelName: 'claude-sonnet',
+        chunk: make({
+          toolCallsDelta: [
+            new StreamInferenceResponseChunkToolCall({
+              index: 1,
+              id: 'call_1',
+              name: 'lookup',
+              argumentsDelta: null,
+            }),
+          ],
+        }),
+        isFirst: false,
+        session,
+      });
+      expect(result?.choices[0].delta.tool_calls?.[0].index).toBe(0);
+    });
+
+    it('keeps the same OpenAI index across argument-delta continuations of the same provider call', () => {
+      const session = newSession();
+      const first = mapper.toChunk({
+        id: 'chatcmpl-1',
+        modelName: 'claude-sonnet',
+        chunk: make({
+          toolCallsDelta: [
+            new StreamInferenceResponseChunkToolCall({
+              index: 1,
+              id: 'call_1',
+              name: 'lookup',
+              argumentsDelta: null,
+            }),
+          ],
+        }),
+        isFirst: false,
+        session,
+      });
+      const continuation = mapper.toChunk({
+        id: 'chatcmpl-1',
+        modelName: 'claude-sonnet',
+        chunk: make({
+          toolCallsDelta: [
+            new StreamInferenceResponseChunkToolCall({
+              index: 1,
+              id: null,
+              name: null,
+              argumentsDelta: '"value"',
+            }),
+          ],
+        }),
+        isFirst: false,
+        session,
+      });
+      expect(first?.choices[0].delta.tool_calls?.[0].index).toBe(0);
+      expect(continuation?.choices[0].delta.tool_calls?.[0].index).toBe(0);
+    });
+
+    it('assigns 0, 1, 2 to parallel tool calls regardless of provider indices', () => {
+      const session = newSession();
+      const first = mapper.toChunk({
+        id: 'chatcmpl-1',
+        modelName: 'claude-sonnet',
+        chunk: make({
+          toolCallsDelta: [
+            new StreamInferenceResponseChunkToolCall({
+              index: 1,
+              id: 'call_paris',
+              name: 'get_weather',
+              argumentsDelta: null,
+            }),
+          ],
+        }),
+        isFirst: false,
+        session,
+      });
+      const second = mapper.toChunk({
+        id: 'chatcmpl-1',
+        modelName: 'claude-sonnet',
+        chunk: make({
+          toolCallsDelta: [
+            new StreamInferenceResponseChunkToolCall({
+              index: 2,
+              id: 'call_tokyo',
+              name: 'get_weather',
+              argumentsDelta: null,
+            }),
+          ],
+        }),
+        isFirst: false,
+        session,
+      });
+      expect(first?.choices[0].delta.tool_calls?.[0].index).toBe(0);
+      expect(second?.choices[0].delta.tool_calls?.[0].index).toBe(1);
+    });
+  });
+});

--- a/ayunis-core-backend/src/domain/openai-compat/application/mappers/openai-stream.mapper.ts
+++ b/ayunis-core-backend/src/domain/openai-compat/application/mappers/openai-stream.mapper.ts
@@ -1,0 +1,136 @@
+import { Injectable } from '@nestjs/common';
+import type { StreamInferenceResponseChunk } from 'src/domain/models/application/ports/stream-inference.handler';
+import type {
+  ChatCompletionChunk,
+  ChatCompletionChunkToolCallDelta,
+} from '../types/openai-chunk.types';
+import type { ChatCompletionFinishReason } from '../types/openai-response.types';
+
+/**
+ * Per-stream state carried across chunks. Currently only translates
+ * provider-native tool-call indices (Anthropic uses absolute content-block
+ * positions, so a single tool call mid-message arrives as e.g. index=1
+ * because text occupies index=0) into the contiguous, zero-based indices
+ * the OpenAI streaming spec defines for `tool_calls[]`.
+ *
+ * SDK clients reconstruct the tool_calls array by index, so a non-zero
+ * first index leaves slot 0 undefined and the call effectively vanishes.
+ */
+export class OpenAIStreamSession {
+  private readonly indexMap = new Map<number, number>();
+  private nextIndex = 0;
+
+  resolveToolCallIndex(providerIndex: number): number {
+    const cached = this.indexMap.get(providerIndex);
+    if (cached !== undefined) return cached;
+    const allocated = this.nextIndex++;
+    this.indexMap.set(providerIndex, allocated);
+    return allocated;
+  }
+}
+
+@Injectable()
+export class OpenAIStreamMapper {
+  /**
+   * Converts a domain stream chunk into an OpenAI-compat chunk, or `null`
+   * when the chunk has no user-visible content (e.g. empty text deltas,
+   * thinking-only chunks, or pure usage frames the caller folds via
+   * `extractUsage` instead).
+   *
+   * AYC-78 fixes:
+   * - Empty `textContentDelta` (`''`) is dropped — the previous mapper
+   *   leaked these as zero-content frames (finding S21).
+   * - `finish_reason='tool_calls'` is emitted ONLY when the same chunk
+   *   introduces a NEW tool call (id or name present). Argument-only
+   *   continuations preserve whatever `finish_reason` the provider sent
+   *   (finding I8).
+   *
+   * AYC-132 fix:
+   * - Tool-call indices are remapped through `session` so the
+   *   OpenAI-spec-required contiguous zero-based numbering is preserved
+   *   regardless of what the upstream provider emits.
+   */
+  toChunk(params: {
+    id: string;
+    modelName: string;
+    chunk: StreamInferenceResponseChunk;
+    isFirst: boolean;
+    session: OpenAIStreamSession;
+  }): ChatCompletionChunk | null {
+    const { chunk, session } = params;
+
+    const hasContent =
+      chunk.textContentDelta !== null && chunk.textContentDelta.length > 0;
+    const toolCallDeltas = this.mapToolCallDeltas(
+      chunk.toolCallsDelta,
+      session,
+    );
+    const hasToolCallDelta = toolCallDeltas.length > 0;
+    const hasFinish =
+      chunk.finishReason !== undefined && chunk.finishReason !== null;
+
+    if (!hasContent && !hasToolCallDelta && !hasFinish) {
+      return null;
+    }
+
+    const hasNewToolCall = chunk.toolCallsDelta.some(
+      (d) => d.id !== null || d.name !== null,
+    );
+
+    const finishReason: ChatCompletionFinishReason = hasFinish
+      ? this.mapFinishReason(chunk.finishReason ?? null, hasNewToolCall)
+      : null;
+
+    return {
+      id: params.id,
+      object: 'chat.completion.chunk',
+      created: Math.floor(Date.now() / 1000),
+      model: params.modelName,
+      choices: [
+        {
+          index: 0,
+          delta: {
+            ...(params.isFirst && { role: 'assistant' }),
+            ...(hasContent && { content: chunk.textContentDelta }),
+            ...(hasToolCallDelta && { tool_calls: toolCallDeltas }),
+          },
+          finish_reason: finishReason,
+        },
+      ],
+    };
+  }
+
+  private mapToolCallDeltas(
+    deltas: StreamInferenceResponseChunk['toolCallsDelta'],
+    session: OpenAIStreamSession,
+  ): ChatCompletionChunkToolCallDelta[] {
+    return deltas.map((d) => ({
+      index: session.resolveToolCallIndex(d.index),
+      ...(d.id !== null && { id: d.id }),
+      ...(d.name !== null && { type: 'function' as const }),
+      ...((d.name !== null || d.argumentsDelta !== null) && {
+        function: {
+          ...(d.name !== null && { name: d.name }),
+          ...(d.argumentsDelta !== null && { arguments: d.argumentsDelta }),
+        },
+      }),
+    }));
+  }
+
+  private mapFinishReason(
+    providerReason: string | null,
+    hasNewToolCall: boolean,
+  ): ChatCompletionFinishReason {
+    if (providerReason === null) return null;
+    if (hasNewToolCall) return 'tool_calls';
+    switch (providerReason) {
+      case 'stop':
+      case 'length':
+      case 'tool_calls':
+      case 'content_filter':
+        return providerReason;
+      default:
+        return 'stop';
+    }
+  }
+}

--- a/ayunis-core-backend/src/domain/openai-compat/application/openai-compat.errors.ts
+++ b/ayunis-core-backend/src/domain/openai-compat/application/openai-compat.errors.ts
@@ -1,0 +1,24 @@
+import { ApplicationError } from 'src/common/errors/base.error';
+import type { ErrorMetadata } from 'src/common/errors/base.error';
+
+export enum OpenAICompatErrorCode {
+  INVALID_REQUEST = 'OPENAI_COMPAT_INVALID_REQUEST',
+  MODEL_NOT_FOUND = 'OPENAI_COMPAT_MODEL_NOT_FOUND',
+}
+
+export class OpenAIInvalidRequestError extends ApplicationError {
+  constructor(reason: string, metadata?: ErrorMetadata) {
+    super(reason, OpenAICompatErrorCode.INVALID_REQUEST, 400, metadata);
+  }
+}
+
+export class OpenAIModelNotFoundError extends ApplicationError {
+  constructor(modelName: string) {
+    super(
+      `The model '${modelName}' does not exist or you do not have access to it`,
+      OpenAICompatErrorCode.MODEL_NOT_FOUND,
+      404,
+      { modelName },
+    );
+  }
+}

--- a/ayunis-core-backend/src/domain/openai-compat/application/types/openai-chunk.types.ts
+++ b/ayunis-core-backend/src/domain/openai-compat/application/types/openai-chunk.types.ts
@@ -1,0 +1,32 @@
+import type {
+  ChatCompletionFinishReason,
+  ChatCompletionUsage,
+} from './openai-response.types';
+
+export interface ChatCompletionChunkToolCallDelta {
+  index: number;
+  id?: string;
+  type?: 'function';
+  function?: { name?: string; arguments?: string };
+}
+
+export interface ChatCompletionChunkDelta {
+  role?: 'assistant';
+  content?: string | null;
+  tool_calls?: ChatCompletionChunkToolCallDelta[];
+}
+
+export interface ChatCompletionChunkChoice {
+  index: number;
+  delta: ChatCompletionChunkDelta;
+  finish_reason: ChatCompletionFinishReason;
+}
+
+export interface ChatCompletionChunk {
+  id: string;
+  object: 'chat.completion.chunk';
+  created: number;
+  model: string;
+  choices: ChatCompletionChunkChoice[];
+  usage?: ChatCompletionUsage;
+}

--- a/ayunis-core-backend/src/domain/openai-compat/application/types/openai-request.types.ts
+++ b/ayunis-core-backend/src/domain/openai-compat/application/types/openai-request.types.ts
@@ -1,0 +1,55 @@
+/**
+ * OpenAI chat-completion request shape used by the application layer.
+ *
+ * The presenter-layer DTO (`chat-completion-request.dto.ts`) attaches
+ * class-validator decorators for HTTP input validation and is structurally
+ * compatible with these interfaces — controllers pass the validated DTO
+ * instance to the use case typed as `OpenAIChatCompletionRequest`.
+ *
+ * Keeping the shape here (not in presenters) is what lets the use case
+ * stay decoupled from HTTP concerns.
+ */
+
+export interface OpenAIChatCompletionFunction {
+  name: string;
+  description?: string;
+  parameters?: Record<string, unknown>;
+}
+
+export interface OpenAIChatCompletionTool {
+  type: 'function';
+  function: OpenAIChatCompletionFunction;
+}
+
+export interface OpenAIChatCompletionFunctionCall {
+  name: string;
+  arguments: string;
+}
+
+export interface OpenAIChatCompletionToolCall {
+  id: string;
+  type: 'function';
+  function: OpenAIChatCompletionFunctionCall;
+}
+
+export interface OpenAIChatCompletionMessage {
+  role: 'system' | 'user' | 'assistant' | 'tool';
+  content?: string | null;
+  tool_call_id?: string;
+  tool_calls?: OpenAIChatCompletionToolCall[];
+  name?: string;
+}
+
+export type OpenAIChatCompletionToolChoice =
+  | 'auto'
+  | 'required'
+  | 'none'
+  | { type: 'function'; function: { name: string } };
+
+export interface OpenAIChatCompletionRequest {
+  model: string;
+  messages: OpenAIChatCompletionMessage[];
+  stream?: boolean;
+  tools?: OpenAIChatCompletionTool[];
+  tool_choice?: OpenAIChatCompletionToolChoice;
+}

--- a/ayunis-core-backend/src/domain/openai-compat/application/types/openai-response.types.ts
+++ b/ayunis-core-backend/src/domain/openai-compat/application/types/openai-response.types.ts
@@ -1,0 +1,39 @@
+export interface ChatCompletionUsage {
+  prompt_tokens: number;
+  completion_tokens: number;
+  total_tokens: number;
+}
+
+export interface ChatCompletionToolCallResponse {
+  id: string;
+  type: 'function';
+  function: { name: string; arguments: string };
+}
+
+export interface ChatCompletionResponseMessage {
+  role: 'assistant';
+  content: string | null;
+  tool_calls?: ChatCompletionToolCallResponse[];
+}
+
+export type ChatCompletionFinishReason =
+  | 'stop'
+  | 'length'
+  | 'tool_calls'
+  | 'content_filter'
+  | null;
+
+export interface ChatCompletionResponseChoice {
+  index: number;
+  message: ChatCompletionResponseMessage;
+  finish_reason: ChatCompletionFinishReason;
+}
+
+export interface ChatCompletionResponse {
+  id: string;
+  object: 'chat.completion';
+  created: number;
+  model: string;
+  choices: ChatCompletionResponseChoice[];
+  usage?: ChatCompletionUsage;
+}

--- a/ayunis-core-backend/src/domain/openai-compat/application/use-cases/execute-openai-chat-completion/execute-openai-chat-completion.command.ts
+++ b/ayunis-core-backend/src/domain/openai-compat/application/use-cases/execute-openai-chat-completion/execute-openai-chat-completion.command.ts
@@ -1,0 +1,15 @@
+import type { UUID } from 'crypto';
+import type { OpenAIChatCompletionRequest } from '../../types/openai-request.types';
+
+export interface ChatCompletionPrincipal {
+  userId?: UUID;
+  apiKeyId?: UUID;
+  orgId: UUID;
+}
+
+export class ExecuteOpenAIChatCompletionCommand {
+  constructor(
+    public readonly request: OpenAIChatCompletionRequest,
+    public readonly principal: ChatCompletionPrincipal,
+  ) {}
+}

--- a/ayunis-core-backend/src/domain/openai-compat/application/use-cases/execute-openai-chat-completion/execute-openai-chat-completion.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/openai-compat/application/use-cases/execute-openai-chat-completion/execute-openai-chat-completion.use-case.spec.ts
@@ -1,0 +1,336 @@
+import { randomUUID } from 'crypto';
+import { Observable, Subject } from 'rxjs';
+import { ExecuteOpenAIChatCompletionUseCase } from './execute-openai-chat-completion.use-case';
+import { ExecuteOpenAIChatCompletionCommand } from './execute-openai-chat-completion.command';
+import type { GetPermittedLanguageModelsUseCase } from 'src/domain/models/application/use-cases/get-permitted-language-models/get-permitted-language-models.use-case';
+import type { GetInferenceUseCase } from 'src/domain/models/application/use-cases/get-inference/get-inference.use-case';
+import type { StreamInferenceUseCase } from 'src/domain/models/application/use-cases/stream-inference/stream-inference.use-case';
+import { OpenAIRequestMapper } from '../../mappers/openai-request.mapper';
+import { OpenAIResponseMapper } from '../../mappers/openai-response.mapper';
+import { OpenAIStreamMapper } from '../../mappers/openai-stream.mapper';
+import { StreamInferenceResponseChunk } from 'src/domain/models/application/ports/stream-inference.handler';
+import { InferenceResponse } from 'src/domain/models/application/ports/inference.handler';
+import { LanguageModel } from 'src/domain/models/domain/models/language.model';
+import { PermittedLanguageModel } from 'src/domain/models/domain/permitted-model.entity';
+import { ModelProvider } from 'src/domain/models/domain/value-objects/model-provider.enum';
+import { ModelTier } from 'src/domain/models/domain/value-objects/model-tier.enum';
+import { TextMessageContent } from 'src/domain/messages/domain/message-contents/text-message-content.entity';
+import { OpenAIModelNotFoundError } from '../../openai-compat.errors';
+import type { InferenceUsageGuard } from 'src/domain/runs/application/services/inference-usage-guard.service';
+import { QuotaExceededError } from 'src/iam/quotas/application/quotas.errors';
+import { QuotaType } from 'src/iam/quotas/domain/quota-type.enum';
+
+describe('ExecuteOpenAIChatCompletionUseCase', () => {
+  let useCase: ExecuteOpenAIChatCompletionUseCase;
+  let getPermittedLanguageModelsUseCase: jest.Mocked<GetPermittedLanguageModelsUseCase>;
+  let getInferenceUseCase: jest.Mocked<GetInferenceUseCase>;
+  let streamInferenceUseCase: jest.Mocked<StreamInferenceUseCase>;
+  let inferenceUsageGuard: jest.Mocked<InferenceUsageGuard>;
+
+  const orgId = randomUUID();
+  const apiKeyId = randomUUID();
+
+  const model = new LanguageModel({
+    name: 'gpt-4o',
+    provider: ModelProvider.OPENAI,
+    displayName: 'GPT-4o',
+    canStream: true,
+    canUseTools: true,
+    isReasoning: false,
+    canVision: false,
+    isArchived: false,
+    tier: ModelTier.MEDIUM,
+  });
+
+  const permitted = new PermittedLanguageModel({
+    model,
+    orgId,
+  });
+
+  const principal = { apiKeyId, orgId };
+
+  const baseCommand = (
+    overrides?: Partial<
+      ConstructorParameters<typeof ExecuteOpenAIChatCompletionCommand>[0]
+    >,
+  ): ExecuteOpenAIChatCompletionCommand =>
+    new ExecuteOpenAIChatCompletionCommand(
+      {
+        model: 'gpt-4o',
+        messages: [{ role: 'user', content: 'hello' }],
+        ...overrides,
+      } as ConstructorParameters<typeof ExecuteOpenAIChatCompletionCommand>[0],
+      principal,
+    );
+
+  beforeEach(() => {
+    getPermittedLanguageModelsUseCase = {
+      execute: jest.fn().mockResolvedValue([permitted]),
+    } as unknown as jest.Mocked<GetPermittedLanguageModelsUseCase>;
+
+    getInferenceUseCase = {
+      execute: jest.fn(),
+    } as unknown as jest.Mocked<GetInferenceUseCase>;
+
+    streamInferenceUseCase = {
+      execute: jest.fn(),
+    } as unknown as jest.Mocked<StreamInferenceUseCase>;
+
+    inferenceUsageGuard = {
+      preflight: jest.fn().mockResolvedValue(undefined),
+      collectUsage: jest.fn(),
+    } as unknown as jest.Mocked<InferenceUsageGuard>;
+
+    useCase = new ExecuteOpenAIChatCompletionUseCase(
+      getPermittedLanguageModelsUseCase,
+      getInferenceUseCase,
+      streamInferenceUseCase,
+      inferenceUsageGuard,
+      new OpenAIRequestMapper(),
+      new OpenAIResponseMapper(),
+      new OpenAIStreamMapper(),
+    );
+  });
+
+  describe('executeNonStreaming', () => {
+    it('returns an OpenAI-shaped response and records usage', async () => {
+      getInferenceUseCase.execute.mockResolvedValue(
+        new InferenceResponse([new TextMessageContent('Hi there!')], {
+          inputTokens: 10,
+          outputTokens: 5,
+          totalTokens: 15,
+        }),
+      );
+
+      const result = await useCase.executeNonStreaming(baseCommand());
+
+      expect(result.object).toBe('chat.completion');
+      expect(result.model).toBe('gpt-4o');
+      expect(result.choices[0].message.content).toBe('Hi there!');
+      expect(result.usage).toEqual({
+        prompt_tokens: 10,
+        completion_tokens: 5,
+        total_tokens: 15,
+      });
+      expect(inferenceUsageGuard.preflight).toHaveBeenCalledTimes(1);
+      expect(inferenceUsageGuard.collectUsage).toHaveBeenCalledWith(
+        model,
+        { inputTokens: 10, outputTokens: 5 },
+        expect.any(String),
+      );
+    });
+
+    it('throws OpenAIModelNotFoundError without calling guard for an unknown model', async () => {
+      getPermittedLanguageModelsUseCase.execute.mockResolvedValue([]);
+
+      await expect(useCase.executeNonStreaming(baseCommand())).rejects.toThrow(
+        OpenAIModelNotFoundError,
+      );
+      expect(inferenceUsageGuard.preflight).not.toHaveBeenCalled();
+      expect(inferenceUsageGuard.collectUsage).not.toHaveBeenCalled();
+    });
+
+    it('propagates preflight failure and does not call collectUsage', async () => {
+      inferenceUsageGuard.preflight.mockRejectedValue(
+        new QuotaExceededError(
+          QuotaType.FAIR_USE_MESSAGES_MEDIUM,
+          100,
+          3600_000,
+          60,
+        ),
+      );
+
+      await expect(useCase.executeNonStreaming(baseCommand())).rejects.toThrow(
+        QuotaExceededError,
+      );
+      expect(getInferenceUseCase.execute).not.toHaveBeenCalled();
+      expect(inferenceUsageGuard.collectUsage).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('executeStreaming', () => {
+    function chunkWithUsage(
+      input: number,
+      output: number,
+    ): StreamInferenceResponseChunk {
+      return new StreamInferenceResponseChunk({
+        thinkingDelta: null,
+        textContentDelta: null,
+        toolCallsDelta: [],
+        usage: { inputTokens: input, outputTokens: output },
+      });
+    }
+
+    it('sums usage across chunks via finalize', async () => {
+      const subject = new Subject<StreamInferenceResponseChunk>();
+      streamInferenceUseCase.execute.mockReturnValue(subject.asObservable());
+
+      const result$ = await useCase.executeStreaming(
+        baseCommand({ stream: true }),
+      );
+      const collected: unknown[] = [];
+      const sub = result$.subscribe({
+        next: (c) => collected.push(c),
+      });
+
+      subject.next(StreamInferenceResponseChunk.text('Hello'));
+      subject.next(chunkWithUsage(10, 0));
+      subject.next(StreamInferenceResponseChunk.text(' world'));
+      subject.next(chunkWithUsage(5, 8));
+      subject.complete();
+      sub.unsubscribe();
+
+      expect(collected.length).toBeGreaterThan(0);
+      expect(inferenceUsageGuard.collectUsage).toHaveBeenCalledTimes(1);
+      expect(inferenceUsageGuard.collectUsage).toHaveBeenCalledWith(
+        model,
+        { inputTokens: 15, outputTokens: 8 },
+        expect.any(String),
+      );
+    });
+
+    it('records partial usage when the client disconnects mid-stream (unsubscribe)', async () => {
+      const subject = new Subject<StreamInferenceResponseChunk>();
+      streamInferenceUseCase.execute.mockReturnValue(subject.asObservable());
+
+      const result$ = await useCase.executeStreaming(
+        baseCommand({ stream: true }),
+      );
+      const sub = result$.subscribe();
+
+      subject.next(chunkWithUsage(7, 3));
+      // Simulate client disconnect — finalize must fire.
+      sub.unsubscribe();
+
+      expect(inferenceUsageGuard.collectUsage).toHaveBeenCalledTimes(1);
+      expect(inferenceUsageGuard.collectUsage).toHaveBeenCalledWith(
+        model,
+        { inputTokens: 7, outputTokens: 3 },
+        expect.any(String),
+      );
+    });
+
+    it('does not record usage when the stream produced no token counts', async () => {
+      const subject = new Subject<StreamInferenceResponseChunk>();
+      streamInferenceUseCase.execute.mockReturnValue(subject.asObservable());
+
+      const result$ = await useCase.executeStreaming(
+        baseCommand({ stream: true }),
+      );
+      const sub = result$.subscribe();
+      subject.next(StreamInferenceResponseChunk.text('partial'));
+      subject.complete();
+      sub.unsubscribe();
+
+      expect(inferenceUsageGuard.collectUsage).not.toHaveBeenCalled();
+    });
+
+    it('forwards the orgId from principal into StreamInferenceInput', async () => {
+      const subject = new Subject<StreamInferenceResponseChunk>();
+      streamInferenceUseCase.execute.mockReturnValue(subject.asObservable());
+
+      await useCase.executeStreaming(baseCommand({ stream: true }));
+      const arg = streamInferenceUseCase.execute.mock.calls[0][0];
+      expect(arg.orgId).toBe(orgId);
+      subject.complete();
+    });
+
+    it('returns an Observable that can be subscribed to repeatedly', async () => {
+      streamInferenceUseCase.execute.mockReturnValue(
+        new Observable((sub) => sub.complete()),
+      );
+
+      const result$ = await useCase.executeStreaming(
+        baseCommand({ stream: true }),
+      );
+      expect(result$).toBeInstanceOf(Observable);
+    });
+  });
+
+  describe('tool-call request mapping (regression for AYC-78 finding I6)', () => {
+    it('rebuilds the tool-call-id → name map per assistant turn', async () => {
+      // Two assistant turns reuse the same id 'call_1' for different tools.
+      // The tool result after the SECOND turn must resolve to 'shipment_lookup',
+      // not the first turn's 'weather'.
+      let capturedMessagesAtFirstInference: unknown;
+      getInferenceUseCase.execute.mockImplementation(async (cmd) => {
+        capturedMessagesAtFirstInference = cmd.messages;
+        return new InferenceResponse([new TextMessageContent('done')], {});
+      });
+
+      const cmd = new ExecuteOpenAIChatCompletionCommand(
+        {
+          model: 'gpt-4o',
+          messages: [
+            { role: 'user', content: 'what is the weather?' },
+            {
+              role: 'assistant',
+              content: null,
+              tool_calls: [
+                {
+                  id: 'call_1',
+                  type: 'function',
+                  function: { name: 'weather', arguments: '{}' },
+                },
+              ],
+            },
+            { role: 'tool', tool_call_id: 'call_1', content: 'sunny' },
+            { role: 'user', content: 'and my package?' },
+            {
+              role: 'assistant',
+              content: null,
+              tool_calls: [
+                {
+                  id: 'call_1',
+                  type: 'function',
+                  function: { name: 'shipment_lookup', arguments: '{}' },
+                },
+              ],
+            },
+            { role: 'tool', tool_call_id: 'call_1', content: 'delivered' },
+          ],
+        } as ConstructorParameters<
+          typeof ExecuteOpenAIChatCompletionCommand
+        >[0],
+        principal,
+      );
+
+      await useCase.executeNonStreaming(cmd);
+
+      const passed = capturedMessagesAtFirstInference as Array<{
+        content: Array<{ toolName?: string; result?: string }>;
+      }>;
+      // Two ToolResultMessage entities — the second one must reference
+      // 'shipment_lookup' (the most recent turn's tool name).
+      const toolResultMessages = passed.filter((m) =>
+        m.content.some((c) => c.toolName !== undefined),
+      );
+      expect(toolResultMessages).toHaveLength(2);
+      expect(toolResultMessages[0].content[0].toolName).toBe('weather');
+      expect(toolResultMessages[1].content[0].toolName).toBe('shipment_lookup');
+    });
+  });
+
+  describe('tool_choice mapping', () => {
+    it('forwards a named function tool_choice as the function name string', async () => {
+      let capturedToolChoice: unknown;
+      getInferenceUseCase.execute.mockImplementation(async (cmd) => {
+        capturedToolChoice = cmd.toolChoice;
+        return new InferenceResponse([new TextMessageContent('ok')], {});
+      });
+
+      await useCase.executeNonStreaming(
+        baseCommand({
+          tool_choice: {
+            type: 'function',
+            function: { name: 'get_weather' },
+          },
+        }),
+      );
+
+      // Downstream converters interpret a non-enum string as a named tool —
+      // see openai-chat-message.converter.ts:54-56.
+      expect(capturedToolChoice).toBe('get_weather');
+    });
+  });
+});

--- a/ayunis-core-backend/src/domain/openai-compat/application/use-cases/execute-openai-chat-completion/execute-openai-chat-completion.use-case.ts
+++ b/ayunis-core-backend/src/domain/openai-compat/application/use-cases/execute-openai-chat-completion/execute-openai-chat-completion.use-case.ts
@@ -1,0 +1,197 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { randomUUID } from 'crypto';
+import { Observable, finalize, map } from 'rxjs';
+import { GetInferenceUseCase } from 'src/domain/models/application/use-cases/get-inference/get-inference.use-case';
+import { GetInferenceCommand } from 'src/domain/models/application/use-cases/get-inference/get-inference.command';
+import { StreamInferenceUseCase } from 'src/domain/models/application/use-cases/stream-inference/stream-inference.use-case';
+import { StreamInferenceInput } from 'src/domain/models/application/ports/stream-inference.handler';
+import { LanguageModel } from 'src/domain/models/domain/models/language.model';
+import { GetPermittedLanguageModelsUseCase } from 'src/domain/models/application/use-cases/get-permitted-language-models/get-permitted-language-models.use-case';
+import { GetPermittedLanguageModelsQuery } from 'src/domain/models/application/use-cases/get-permitted-language-models/get-permitted-language-models.query';
+import { InferenceUsageGuard } from 'src/domain/runs/application/services/inference-usage-guard.service';
+import { OpenAIRequestMapper } from '../../mappers/openai-request.mapper';
+import { OpenAIResponseMapper } from '../../mappers/openai-response.mapper';
+import {
+  OpenAIStreamMapper,
+  OpenAIStreamSession,
+} from '../../mappers/openai-stream.mapper';
+import { OpenAIModelNotFoundError } from '../../openai-compat.errors';
+import { ExecuteOpenAIChatCompletionCommand } from './execute-openai-chat-completion.command';
+import type { ChatCompletionResponse } from '../../types/openai-response.types';
+import type { ChatCompletionChunk } from '../../types/openai-chunk.types';
+
+/**
+ * Sole orchestrator on the OpenAI-compat path. Wraps `Get/StreamInference`
+ * and is the only caller of `InferenceUsageGuard` on this surface.
+ * The controller stays purely DTO↔command + SSE framing + HTTP filter.
+ *
+ * Streaming usage is recorded via RxJS `finalize()` so the accumulator
+ * runs on complete, error, AND unsubscribe (client disconnect alike).
+ * Totals are summed across chunks — never last-wins (AYC-92 streaming
+ * usage-drift bug).
+ */
+@Injectable()
+export class ExecuteOpenAIChatCompletionUseCase {
+  private readonly logger = new Logger(ExecuteOpenAIChatCompletionUseCase.name);
+
+  constructor(
+    private readonly getPermittedLanguageModelsUseCase: GetPermittedLanguageModelsUseCase,
+    private readonly getInferenceUseCase: GetInferenceUseCase,
+    private readonly streamInferenceUseCase: StreamInferenceUseCase,
+    private readonly inferenceUsageGuard: InferenceUsageGuard,
+    private readonly requestMapper: OpenAIRequestMapper,
+    private readonly responseMapper: OpenAIResponseMapper,
+    private readonly streamMapper: OpenAIStreamMapper,
+  ) {}
+
+  async executeNonStreaming(
+    command: ExecuteOpenAIChatCompletionCommand,
+  ): Promise<ChatCompletionResponse> {
+    const { model, threadId } = await this.prepare(command);
+    const { systemPrompt, messages } = this.requestMapper.toDomainMessages(
+      command.request,
+      threadId,
+    );
+
+    const requestId = this.requestMapper.newRequestId();
+
+    const response = await this.getInferenceUseCase.execute(
+      new GetInferenceCommand({
+        model,
+        messages,
+        tools: this.requestMapper.toToolSchemas(command.request),
+        toolChoice: this.requestMapper.toModelToolChoice(command.request),
+        instructions: systemPrompt || undefined,
+      }),
+    );
+
+    if (
+      response.meta.inputTokens !== undefined &&
+      response.meta.outputTokens !== undefined
+    ) {
+      this.inferenceUsageGuard.collectUsage(
+        model,
+        {
+          inputTokens: response.meta.inputTokens,
+          outputTokens: response.meta.outputTokens,
+        },
+        requestId,
+      );
+    }
+
+    return this.responseMapper.toResponse({
+      id: this.completionId(),
+      modelName: command.request.model,
+      response,
+    });
+  }
+
+  async executeStreaming(
+    command: ExecuteOpenAIChatCompletionCommand,
+  ): Promise<Observable<ChatCompletionChunk>> {
+    const { model, threadId } = await this.prepare(command);
+    const { systemPrompt, messages } = this.requestMapper.toDomainMessages(
+      command.request,
+      threadId,
+    );
+
+    const requestId = this.requestMapper.newRequestId();
+    const completionId = this.completionId();
+
+    const source$ = this.streamInferenceUseCase.execute(
+      new StreamInferenceInput({
+        model,
+        messages,
+        systemPrompt,
+        tools: this.requestMapper.toToolSchemas(command.request),
+        toolChoice: this.requestMapper.toModelToolChoice(command.request),
+        orgId: command.principal.orgId,
+      }),
+    );
+
+    // Closures capture the running totals so `finalize` can read whatever
+    // landed before complete / error / unsubscribe. Sum-across-chunks, not
+    // last-wins (AYC-92 streaming drift bug).
+    const totals = { inputTokens: 0, outputTokens: 0 };
+    let isFirst = true;
+    // Per-stream session — currently translates provider-native tool-call
+    // indices into OpenAI's contiguous zero-based numbering.
+    const session = new OpenAIStreamSession();
+
+    return source$.pipe(
+      map((chunk) => {
+        if (chunk.usage) {
+          totals.inputTokens += chunk.usage.inputTokens ?? 0;
+          totals.outputTokens += chunk.usage.outputTokens ?? 0;
+        }
+        const mapped = this.streamMapper.toChunk({
+          id: completionId,
+          modelName: command.request.model,
+          chunk,
+          isFirst,
+          session,
+        });
+        isFirst = false;
+        return mapped;
+      }),
+      // Drop chunks that mapped to null (e.g. empty deltas).
+      filterNonNull(),
+      finalize(() => {
+        if (totals.inputTokens > 0 || totals.outputTokens > 0) {
+          this.inferenceUsageGuard.collectUsage(model, totals, requestId);
+        }
+      }),
+    );
+  }
+
+  private async prepare(command: ExecuteOpenAIChatCompletionCommand): Promise<{
+    model: LanguageModel;
+    threadId: ReturnType<typeof randomUUID>;
+  }> {
+    const model = await this.resolveModel(
+      command.principal.orgId,
+      command.request.model,
+    );
+    await this.inferenceUsageGuard.preflight(command.principal, model);
+    // Synthetic threadId for the domain Message entities — OpenAI-compat is
+    // stateless, no thread persistence. Mappers only require a non-null UUID.
+    const threadId = randomUUID();
+    return { model, threadId };
+  }
+
+  private async resolveModel(
+    orgId: ReturnType<typeof randomUUID>,
+    modelName: string,
+  ): Promise<LanguageModel> {
+    const permitted = await this.getPermittedLanguageModelsUseCase.execute(
+      new GetPermittedLanguageModelsQuery(orgId),
+    );
+    const match = permitted.find((pm) => pm.model.name === modelName);
+    if (!match) {
+      this.logger.debug('OpenAI-compat model not found', {
+        orgId,
+        requestedModel: modelName,
+      });
+      throw new OpenAIModelNotFoundError(modelName);
+    }
+    return match.model;
+  }
+
+  private completionId(): string {
+    return `chatcmpl-${randomUUID()}`;
+  }
+}
+
+/** RxJS operator: drop null/undefined emissions, narrow the type. */
+function filterNonNull<T>() {
+  return (source: Observable<T | null>): Observable<T> =>
+    new Observable<T>((subscriber) => {
+      return source.subscribe({
+        next: (value) => {
+          if (value !== null) subscriber.next(value);
+        },
+        error: (err) => subscriber.error(err),
+        complete: () => subscriber.complete(),
+      });
+    });
+}

--- a/ayunis-core-backend/src/domain/openai-compat/openai-compat.module.ts
+++ b/ayunis-core-backend/src/domain/openai-compat/openai-compat.module.ts
@@ -1,0 +1,50 @@
+import { Module } from '@nestjs/common';
+import { APP_FILTER } from '@nestjs/core';
+import { ModelsModule } from '../models/models.module';
+import { RunsModule } from '../runs/runs.module';
+import { ChatCompletionsController } from './presenters/http/chat-completions.controller';
+import { ExecuteOpenAIChatCompletionUseCase } from './application/use-cases/execute-openai-chat-completion/execute-openai-chat-completion.use-case';
+import { OpenAIRequestMapper } from './application/mappers/openai-request.mapper';
+import { OpenAIResponseMapper } from './application/mappers/openai-response.mapper';
+import { OpenAIStreamMapper } from './application/mappers/openai-stream.mapper';
+import { OpenAIErrorMapper } from './application/mappers/openai-error.mapper';
+import { OpenAIExceptionFilter } from './presenters/http/filters/openai-exception.filter';
+
+@Module({
+  imports: [
+    // Required to consume GetInferenceUseCase, StreamInferenceUseCase,
+    // and PermittedModelsRepository.
+    ModelsModule,
+    // Required to consume InferenceUsageGuard.
+    RunsModule,
+    // ApiKeyStrategy is registered globally by IamModule; AuthGuard('api-key')
+    // resolves it from Passport at request time and needs no import here.
+    // `@Public()` is read by JwtAuthGuard via Reflector — also no import needed.
+  ],
+  controllers: [ChatCompletionsController],
+  providers: [
+    ExecuteOpenAIChatCompletionUseCase,
+    OpenAIRequestMapper,
+    OpenAIResponseMapper,
+    OpenAIStreamMapper,
+    OpenAIErrorMapper,
+    OpenAIExceptionFilter,
+    // ALSO registered as APP_FILTER (in addition to controller-scoped
+    // @UseFilters on ChatCompletionsController) so it can intercept errors
+    // raised BEFORE the controller dispatches — most importantly Nest's
+    // body-parser BadRequestException for malformed JSON, which OpenAI SDK
+    // clients expect in the standard envelope. `useExisting` shares the
+    // single instance with the controller-scoped binding.
+    //
+    // Controller-scoped > global APP_FILTER in NestJS resolution, so
+    // runtime exceptions (e.g. UnauthorizedException from the api-key
+    // guard, which AuthenticationModule's UnauthorizedExceptionFilter
+    // would otherwise hijack with a more specific @Catch) flow through
+    // the @UseFilters binding first.
+    {
+      provide: APP_FILTER,
+      useExisting: OpenAIExceptionFilter,
+    },
+  ],
+})
+export class OpenAICompatModule {}

--- a/ayunis-core-backend/src/domain/openai-compat/presenters/http/chat-completions.controller.ts
+++ b/ayunis-core-backend/src/domain/openai-compat/presenters/http/chat-completions.controller.ts
@@ -1,0 +1,129 @@
+import {
+  Body,
+  Controller,
+  Post,
+  Req,
+  Res,
+  UseFilters,
+  UseGuards,
+} from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+import type { Request, Response } from 'express';
+import type { Subscription } from 'rxjs';
+import type { UUID } from 'crypto';
+import { ContextService } from 'src/common/context/services/context.service';
+import { RateLimit } from 'src/iam/authorization/application/decorators/rate-limit.decorator';
+import { Public } from 'src/common/guards/public.guard';
+import { ExecuteOpenAIChatCompletionUseCase } from '../../application/use-cases/execute-openai-chat-completion/execute-openai-chat-completion.use-case';
+import { ExecuteOpenAIChatCompletionCommand } from '../../application/use-cases/execute-openai-chat-completion/execute-openai-chat-completion.command';
+import { ChatCompletionRequestDto } from './dto/chat-completion-request.dto';
+import { OpenAIExceptionFilter } from './filters/openai-exception.filter';
+
+/**
+ * OpenAI-compatible chat-completions endpoint. Thin shell — all
+ * orchestration lives in `ExecuteOpenAIChatCompletionUseCase`.
+ *
+ * Auth: `@UseGuards(AuthGuard('api-key'))` overrides the global
+ * `JwtAuthGuard` for this controller. The bearer strategy is the only
+ * one that can authenticate this route — no JWT-before-bearer flip is
+ * possible by construction (AYC-92 decision).
+ *
+ * Exception handling uses TWO registrations of `OpenAIExceptionFilter`:
+ * - `@UseFilters` (here): wins over the global `UnauthorizedExceptionFilter`
+ *   for runtime errors thrown DURING dispatch (auth, validation, domain
+ *   errors) — controller-scoped filters beat global ones in NestJS.
+ * - APP_FILTER (in OpenAICompatModule): catches errors raised BEFORE
+ *   dispatch (body-parser failures) that controller-scoped filters never
+ *   see. The same filter instance, registered at both scopes so both
+ *   paths produce the OpenAI envelope.
+ */
+@Controller('openai-compat/v1/chat')
+@Public() // bypass the global JwtAuthGuard; AuthGuard('api-key') takes over
+@UseGuards(AuthGuard('api-key'))
+@UseFilters(OpenAIExceptionFilter)
+@RateLimit({ limit: 60, windowMs: 60_000 })
+export class ChatCompletionsController {
+  constructor(
+    private readonly useCase: ExecuteOpenAIChatCompletionUseCase,
+    private readonly contextService: ContextService,
+  ) {}
+
+  @Post('completions')
+  async create(
+    @Body() dto: ChatCompletionRequestDto,
+    @Req() request: Request,
+    @Res() response: Response,
+  ): Promise<void> {
+    const principal = this.resolvePrincipal();
+    const command = new ExecuteOpenAIChatCompletionCommand(dto, principal);
+
+    if (dto.stream) {
+      await this.streamCompletion(command, request, response);
+      return;
+    }
+
+    const result = await this.useCase.executeNonStreaming(command);
+    response.status(200).json(result);
+  }
+
+  private resolvePrincipal(): {
+    apiKeyId: UUID;
+    orgId: UUID;
+  } {
+    // ApiKeyStrategy populates these via UserContextInterceptor (iter 2).
+    // Throwing here means the guard somehow let an unauthenticated
+    // request through; surfaces as a 500 'server_error' to the client.
+    const apiKeyId = this.contextService.get('apiKeyId');
+    const orgId = this.contextService.get('orgId');
+    if (!apiKeyId || !orgId) {
+      throw new Error('apiKeyId or orgId missing from context after auth');
+    }
+    return { apiKeyId, orgId };
+  }
+
+  private async streamCompletion(
+    command: ExecuteOpenAIChatCompletionCommand,
+    request: Request,
+    response: Response,
+  ): Promise<void> {
+    const stream$ = await this.useCase.executeStreaming(command);
+
+    response.setHeader('Content-Type', 'text/event-stream');
+    response.setHeader('Cache-Control', 'no-cache');
+    response.setHeader('Connection', 'keep-alive');
+    response.setHeader('X-Accel-Buffering', 'no');
+    response.flushHeaders();
+
+    let subscription: Subscription | undefined;
+    try {
+      await new Promise<void>((resolve, reject) => {
+        subscription = stream$.subscribe({
+          next: (chunk) => {
+            if (response.writableEnded) return;
+            response.write(`data: ${JSON.stringify(chunk)}\n\n`);
+          },
+          error: (err: unknown) => reject(err as Error),
+          complete: () => resolve(),
+        });
+
+        // RxJS can throw synchronously from the producer factory; if the
+        // subscribe call itself completes without setting subscription,
+        // the listener below is what we rely on.
+        request.on('close', () => {
+          // Client disconnected — abort the upstream stream. This triggers
+          // `finalize` inside the use case which records the partial usage
+          // row (AYC-92 streaming usage-on-disconnect bug fix).
+          subscription?.unsubscribe();
+          resolve();
+        });
+      });
+
+      if (!response.writableEnded) {
+        response.write('data: [DONE]\n\n');
+        response.end();
+      }
+    } finally {
+      subscription?.unsubscribe();
+    }
+  }
+}

--- a/ayunis-core-backend/src/domain/openai-compat/presenters/http/dto/chat-completion-request.dto.ts
+++ b/ayunis-core-backend/src/domain/openai-compat/presenters/http/dto/chat-completion-request.dto.ts
@@ -1,0 +1,112 @@
+import {
+  IsArray,
+  IsBoolean,
+  IsIn,
+  IsNotEmpty,
+  IsObject,
+  IsOptional,
+  IsString,
+  ValidateNested,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+import type {
+  OpenAIChatCompletionMessage,
+  OpenAIChatCompletionRequest,
+  OpenAIChatCompletionToolChoice,
+} from '../../../application/types/openai-request.types';
+
+export class ChatCompletionFunctionDto {
+  @IsString()
+  @IsNotEmpty()
+  name!: string;
+
+  @IsOptional()
+  @IsString()
+  description?: string;
+
+  @IsOptional()
+  @IsObject()
+  parameters?: Record<string, unknown>;
+}
+
+export class ChatCompletionToolDto {
+  @IsIn(['function'])
+  type!: 'function';
+
+  @ValidateNested()
+  @Type(() => ChatCompletionFunctionDto)
+  function!: ChatCompletionFunctionDto;
+}
+
+export class ChatCompletionFunctionCallDto {
+  @IsString()
+  @IsNotEmpty()
+  name!: string;
+
+  @IsString()
+  arguments!: string;
+}
+
+export class ChatCompletionToolCallDto {
+  @IsString()
+  @IsNotEmpty()
+  id!: string;
+
+  @IsIn(['function'])
+  type!: 'function';
+
+  @ValidateNested()
+  @Type(() => ChatCompletionFunctionCallDto)
+  function!: ChatCompletionFunctionCallDto;
+}
+
+export class ChatCompletionMessageDto implements OpenAIChatCompletionMessage {
+  @IsIn(['system', 'user', 'assistant', 'tool'])
+  role!: 'system' | 'user' | 'assistant' | 'tool';
+
+  // Either a string (OpenAI's common shorthand) or null on assistant
+  // messages that produced only tool_calls. Array-of-parts (multimodal) is
+  // not supported in iter 3 — reject in the mapper for clarity.
+  @IsOptional()
+  content?: string | null;
+
+  @IsOptional()
+  @IsString()
+  tool_call_id?: string;
+
+  @IsOptional()
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => ChatCompletionToolCallDto)
+  tool_calls?: ChatCompletionToolCallDto[];
+
+  @IsOptional()
+  @IsString()
+  name?: string;
+}
+
+export class ChatCompletionRequestDto implements OpenAIChatCompletionRequest {
+  @IsString()
+  @IsNotEmpty()
+  model!: string;
+
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => ChatCompletionMessageDto)
+  messages!: ChatCompletionMessageDto[];
+
+  @IsOptional()
+  @IsBoolean()
+  stream?: boolean;
+
+  @IsOptional()
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => ChatCompletionToolDto)
+  tools?: ChatCompletionToolDto[];
+
+  // OpenAI supports 'auto' | 'required' | 'none' | {type:'function', function:{name}}.
+  // Iter 3 accepts the string forms; named-function tool_choice is treated as 'required'.
+  @IsOptional()
+  tool_choice?: OpenAIChatCompletionToolChoice;
+}

--- a/ayunis-core-backend/src/domain/openai-compat/presenters/http/filters/openai-exception.filter.ts
+++ b/ayunis-core-backend/src/domain/openai-compat/presenters/http/filters/openai-exception.filter.ts
@@ -1,0 +1,68 @@
+import { ArgumentsHost, Catch, Logger } from '@nestjs/common';
+import { BaseExceptionFilter } from '@nestjs/core';
+import type { Request, Response } from 'express';
+import { OpenAIErrorMapper } from '../../../application/mappers/openai-error.mapper';
+
+/**
+ * Wraps OpenAI-compat exceptions into the OpenAI error envelope. Registered
+ * globally so it can intercept errors raised BEFORE the controller dispatch
+ * (e.g. JSON body-parse failures from Nest's body parser) — those skip
+ * controller-scoped `@UseFilters` entirely. Errors for any other path are
+ * delegated back to Nest's default filter via `super.catch`.
+ *
+ * Two response paths:
+ * - Pre-stream errors (`response.headersSent === false`): write the
+ *   envelope as a JSON body with the mapped HTTP status.
+ * - Mid-stream errors (`response.headersSent === true`): the SSE response
+ *   has already started — we can only emit a final `data:` frame
+ *   carrying the envelope and close the connection. The status code is
+ *   already committed.
+ */
+@Catch()
+export class OpenAIExceptionFilter extends BaseExceptionFilter {
+  private readonly openaiCompatLogger = new Logger(OpenAIExceptionFilter.name);
+
+  constructor(private readonly errorMapper: OpenAIErrorMapper) {
+    super();
+  }
+
+  catch(exception: unknown, host: ArgumentsHost): void {
+    const ctx = host.switchToHttp();
+    const request = ctx.getRequest<Request>();
+
+    if (!this.isOpenAICompatRequest(request)) {
+      // Not ours — let Nest's default filter (or any other registered
+      // global filter) handle it.
+      super.catch(exception, host);
+      return;
+    }
+
+    const response = ctx.getResponse<Response>();
+    const mapped = this.errorMapper.toEnvelope(exception);
+
+    if (response.headersSent) {
+      // SSE is open — can't change status; emit a final data frame.
+      try {
+        response.write(`data: ${JSON.stringify(mapped.body)}\n\n`);
+        response.write('data: [DONE]\n\n');
+        response.end();
+      } catch (writeError) {
+        this.openaiCompatLogger.warn('Failed to emit final SSE error frame', {
+          status: mapped.status,
+          writeError:
+            writeError instanceof Error ? writeError.message : 'Unknown',
+        });
+      }
+      return;
+    }
+
+    response.status(mapped.status).json(mapped.body);
+  }
+
+  private isOpenAICompatRequest(request: Request): boolean {
+    // Match the global '/api' prefix + the controller's
+    // 'openai-compat/v1/chat' route. Use startsWith so query strings and
+    // future sub-routes are caught too.
+    return request.url.startsWith('/api/openai-compat/');
+  }
+}

--- a/ayunis-core-backend/src/domain/tools/domain/tools/edit-skill-tool.entity.ts
+++ b/ayunis-core-backend/src/domain/tools/domain/tools/edit-skill-tool.entity.ts
@@ -3,7 +3,6 @@ import { createAjv } from 'src/common/validators/ajv.factory';
 import { DisplayableTool } from '../displayable-tool.entity';
 import { ToolType } from '../value-objects/tool-type.enum';
 
-// eslint-disable-next-line sonarjs/function-return-type -- same pattern as ActivateSkillTool.buildParameters
 function buildParameters(slugs: string[]): JSONSchema {
   const skillSlugProperty: Record<string, unknown> = {
     type: 'string' as const,

--- a/ayunis-core-backend/src/domain/usage/infrastructure/persistence/local-usage/schema/usage.record.ts
+++ b/ayunis-core-backend/src/domain/usage/infrastructure/persistence/local-usage/schema/usage.record.ts
@@ -23,10 +23,7 @@ const decimalTransformer = {
 @Index(['modelId', 'createdAt'])
 @Index(['provider', 'createdAt'])
 @Index(['organizationId', 'provider', 'createdAt'])
-@Check(
-  'CHK_usage_principal_not_both',
-  `"userId" IS NULL OR "apiKeyId" IS NULL`,
-)
+@Check('CHK_usage_principal_not_both', `"userId" IS NULL OR "apiKeyId" IS NULL`)
 export class UsageRecord extends BaseRecord {
   @Column({ nullable: true })
   userId: UUID | null;

--- a/ayunis-core-backend/src/iam/quotas/infrastructure/persistence/postgres/usage-quota.repository.ts
+++ b/ayunis-core-backend/src/iam/quotas/infrastructure/persistence/postgres/usage-quota.repository.ts
@@ -85,7 +85,13 @@ export class UsageQuotaRepository extends UsageQuotaRepositoryPort {
       const repo = manager.getRepository(UsageQuotaRecord);
       const now = new Date();
 
-      await this.upsertEmptyQuota(repo, userId, quotaType, windowDurationMs, now);
+      await this.upsertEmptyQuota(
+        repo,
+        userId,
+        quotaType,
+        windowDurationMs,
+        now,
+      );
       const record = await this.lockQuotaRow(repo, userId, quotaType);
       resetWindowIfExpired(record, now, windowDurationMs);
 

--- a/ayunis-core-backend/src/iam/users/application/use-cases/admin-update-user/admin-update-user.use-case.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/admin-update-user/admin-update-user.use-case.ts
@@ -128,10 +128,13 @@ export class AdminUpdateUserUseCase {
         new SendConfirmationEmailCommand(user),
       );
     } catch (error) {
-      this.logger.error('Failed to send confirmation email after admin update', {
-        error: error instanceof Error ? error.message : 'Unknown error',
-        userId: user.id,
-      });
+      this.logger.error(
+        'Failed to send confirmation email after admin update',
+        {
+          error: error instanceof Error ? error.message : 'Unknown error',
+          userId: user.id,
+        },
+      );
     }
   }
 

--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
@@ -4085,6 +4085,8 @@ export interface TranscriptionResponseDto {
   text: string;
 }
 
+export interface ChatCompletionRequestDto { [key: string]: unknown }
+
 export interface LoginDto {
   /** Email address for authentication */
   email: string;

--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.ts
@@ -38,6 +38,7 @@ import type {
   ArtifactResponseDto,
   ArtifactVersionResponseDto,
   ArtifactsControllerExportParams,
+  ChatCompletionRequestDto,
   ConfirmEmailDto,
   CreateAgentDto,
   CreateAgentShareDto,
@@ -16489,6 +16490,65 @@ export const useTranscriptionsControllerTranscribe = <TError = void,
       > => {
 
       const mutationOptions = getTranscriptionsControllerTranscribeMutationOptions(options);
+
+      return useMutation(mutationOptions, queryClient);
+    }
+    
+export const chatCompletionsControllerCreate = (
+    chatCompletionRequestDto: ChatCompletionRequestDto,
+ signal?: AbortSignal
+) => {
+      
+      
+      return customAxiosInstance<void>(
+      {url: `/openai-compat/v1/chat/completions`, method: 'POST',
+      headers: {'Content-Type': 'application/json', },
+      data: chatCompletionRequestDto, signal
+    },
+      );
+    }
+  
+
+
+export const getChatCompletionsControllerCreateMutationOptions = <TError = unknown,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof chatCompletionsControllerCreate>>, TError,{data: ChatCompletionRequestDto}, TContext>, }
+): UseMutationOptions<Awaited<ReturnType<typeof chatCompletionsControllerCreate>>, TError,{data: ChatCompletionRequestDto}, TContext> => {
+
+const mutationKey = ['chatCompletionsControllerCreate'];
+const {mutation: mutationOptions} = options ?
+      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
+      options
+      : {...options, mutation: {...options.mutation, mutationKey}}
+      : {mutation: { mutationKey, }};
+
+      
+
+
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof chatCompletionsControllerCreate>>, {data: ChatCompletionRequestDto}> = (props) => {
+          const {data} = props ?? {};
+
+          return  chatCompletionsControllerCreate(data,)
+        }
+
+        
+
+
+  return  { mutationFn, ...mutationOptions }}
+
+    export type ChatCompletionsControllerCreateMutationResult = NonNullable<Awaited<ReturnType<typeof chatCompletionsControllerCreate>>>
+    export type ChatCompletionsControllerCreateMutationBody = ChatCompletionRequestDto
+    export type ChatCompletionsControllerCreateMutationError = unknown
+
+    export const useChatCompletionsControllerCreate = <TError = unknown,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof chatCompletionsControllerCreate>>, TError,{data: ChatCompletionRequestDto}, TContext>, }
+ , queryClient?: QueryClient): UseMutationResult<
+        Awaited<ReturnType<typeof chatCompletionsControllerCreate>>,
+        TError,
+        {data: ChatCompletionRequestDto},
+        TContext
+      > => {
+
+      const mutationOptions = getChatCompletionsControllerCreateMutationOptions(options);
 
       return useMutation(mutationOptions, queryClient);
     }

--- a/ayunis-core-frontend/src/shared/api/openapi-schema.json
+++ b/ayunis-core-frontend/src/shared/api/openapi-schema.json
@@ -8143,6 +8143,28 @@
         "tags": ["transcriptions"]
       }
     },
+    "/openai-compat/v1/chat/completions": {
+      "post": {
+        "operationId": "ChatCompletionsController_create",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ChatCompletionRequestDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": ""
+          }
+        },
+        "tags": ["ChatCompletions"]
+      }
+    },
     "/auth/login": {
       "post": {
         "description": "Authenticate user with email and password. Sets authentication cookies on successful login.",
@@ -14634,6 +14656,10 @@
           }
         },
         "required": ["text"]
+      },
+      "ChatCompletionRequestDto": {
+        "type": "object",
+        "properties": {}
       },
       "LoginDto": {
         "type": "object",


### PR DESCRIPTION
Adds POST /v1/chat/completions — the consumer route for the api-keys
+ bearer auth that landed in iter 1 and iter 2. Re-implements at minimum
surface; the previous attempt's controller in 04-27_…ayc-69_ never
landed and accumulated correctness bugs that are explicitly fixed here.

Module layout (src/domain/openai-compat/):
- application/use-cases/execute-openai-chat-completion/ — sole
  orchestrator on this surface. Calls InferenceUsageGuard.preflight +
  collectUsage; no inline trial / quota / usage logic.
- application/mappers/ — request, response, stream, error.
- application/types/ — OpenAI request/response/chunk interfaces. The
  presenter-layer DTO class implements these interfaces and adds
  class-validator decorators for HTTP input validation; use cases +
  mappers reference only the application-layer types so they stay
  decoupled from presenters.
- presenters/http/chat-completions.controller.ts — @UseGuards(AuthGuard
  ('api-key')) + @Public() overrides the global JwtAuthGuard for this
  route. @RateLimit({limit:60,windowMs:60_000}). SSE framing with
  client-disconnect → subscription.unsubscribe → finalize() records
  partial usage.
- presenters/http/filters/openai-exception.filter.ts — wraps thrown
  errors into the OpenAI envelope; handles response.headersSent
  (mid-stream errors become an SSE data: frame, not a JSON body).

Bug fixes baked in:
- 429 → 'rate_limit_error' (was 'invalid_request_error' — broke OpenAI
  SDK retry). QuotaExceededError, CreditBudgetExceededError, and
  RateLimitExceededError all flow through this.
- Streaming usage drift: usage is summed across chunks via a closure-
  scoped accumulator that finalize() reads — never last-wins.
- Streaming usage on client-disconnect: finalize() runs on complete,
  error, AND unsubscribe, so the usage row lands even if the client
  drops the connection mid-stream.
- Per-turn tool-call-id scoping: the request mapper rebuilds the
  tool_call_id → name map at every assistant turn so reused IDs across
  turns resolve to the right tool (AYC-78 finding I6 regression test).
- Empty textContentDelta filter: stream mapper drops zero-content
  chunks (AYC-78 finding S21).
- finish_reason='tool_calls' only on NEW tool calls: stream mapper
  no longer flips finish_reason on argument-delta continuations
  (AYC-78 finding I8).

Model resolution: GetPermittedLanguageModelsUseCase (exported by
ModelsModule) + filter by name. Unknown name → OpenAIModelNotFoundError
→ 404 invalid_request_error.

Three cross-module type imports added to the dependency-cruiser
baseline (StreamInferenceInput / StreamInferenceResponseChunk /
InferenceResponse) — same pattern RunsModule and ChatSettingsModule
already use; addressed in a future cleanup.

Tests: 24 specs covering the use case (non-stream, streaming sum-
across-chunks, client-disconnect partial usage, model-not-found
short-circuit, preflight propagation), error mapper (all 429 sources
→ rate_limit_error), request mapper (per-turn tool-call scoping),
stream mapper (empty deltas, finish_reason gating).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> New external inference API with API-key auth, quota/usage accounting, and streaming/SSE error semantics; incorrect mapping or usage on disconnect could affect billing and SDK client behavior.
> 
> **Overview**
> Adds a new **`openai-compat`** domain module and wires it into **`AppModule`**, exposing **POST `/api/openai-compat/v1/chat/completions`** for OpenAI SDK clients (API-key auth via `@Public()` + `AuthGuard('api-key')`, optional SSE, rate limit 60/min).
> 
> **`ExecuteOpenAIChatCompletionUseCase`** resolves org-permitted models, runs **`InferenceUsageGuard`** preflight/collect, and delegates to existing **`GetInferenceUseCase`** / **`StreamInferenceUseCase`**. Request/response/stream/error mappers translate between OpenAI shapes and domain messages; streaming sums token usage in **`finalize()`** (including client disconnect) and remaps tool-call indices / **`finish_reason`** for SDK compatibility. **`OpenAIExceptionFilter`** returns OpenAI-style errors (including pre-dispatch and mid-SSE cases).
> 
> Inference tooling is generalized with **`ToolSchema`** on inference/stream ports and all provider message converters (so compat can pass client-owned tool schemas without domain **`Tool`** entities). **`GetPermittedLanguageModelsUseCase`** is exported from **`ModelsModule`**; Anthropic streaming now sets **`finishReason`** from **`stop_reason`**. Cross-module port imports are baselined in **dependency-cruiser**. Frontend OpenAPI/generated client picks up the new route (placeholder **`ChatCompletionRequestDto`**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f8ecde965ec1beac03c4eb897658e16f17084bb7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->