### PR TITLE
feat(ui): show model name for API in models section (AYC-92)

### DIFF
--- a/ayunis-core-frontend/src/widgets/model-type-card/ModelTypeCard.tsx
+++ b/ayunis-core-frontend/src/widgets/model-type-card/ModelTypeCard.tsx
@@ -17,6 +17,7 @@ import {
   Item,
   ItemActions,
   ItemContent,
+  ItemDescription,
   ItemTitle,
 } from '@/shared/ui/shadcn/item';
 import {
@@ -205,6 +206,9 @@ export default function ModelTypeCard({
                       {model.displayName || model.name}
                       {model.tier && <ModelTierStars tier={model.tier} />}
                     </ItemTitle>
+                    {model.displayName && (
+                      <ItemDescription>{model.name}</ItemDescription>
+                    )}
                   </ItemContent>
                   <ItemActions>
                     {model.isPermitted && updatePermittedModel && (


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Presentation-only change in admin models UI with no API or permission logic touched.
> 
> **Overview**
> When a model has a **display name**, the admin models list now shows the underlying **API model id** (`model.name`) as secondary text under the title via `ItemDescription`, so admins can copy the correct identifier for API calls.
> 
> The title still shows `displayName` (or `name` if no display name); the extra line only appears when `displayName` is set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b4ed097885c95db48d8ab6f08cb654ceb8e7da1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->