### PR TITLE
docs(api-keys): link admin page to help center (AYC-000)

### DIFF
--- a/ayunis-core-frontend/src/pages/admin-settings/api-keys-settings/ui/ApiKeysSettingsPage.tsx
+++ b/ayunis-core-frontend/src/pages/admin-settings/api-keys-settings/ui/ApiKeysSettingsPage.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button } from '@/shared/ui/shadcn/button';
+import { HelpLink } from '@/shared/ui/help-link/HelpLink';
 import SettingsLayout from '../../admin-settings-layout';
 import { ApiKeysList } from './ApiKeysList';
 import { CreateApiKeyDialog } from './CreateApiKeyDialog';
@@ -21,6 +22,7 @@ export function ApiKeysSettingsPage({
 
   const headerActions = (
     <div className="flex gap-2">
+      <HelpLink path="settings/admin/api-keys/" />
       <Button size="sm" onClick={() => setCreateDialogOpen(true)}>
         {t('apiKeys.page.add')}
       </Button>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> UI-only addition of an external documentation link; no changes to API key logic or security-sensitive flows.
> 
> **Overview**
> Adds a **help center** entry point on the admin **API keys** settings page by placing the shared `HelpLink` control in the page header actions (alongside **Add**), targeting documentation at `settings/admin/api-keys/`.
> 
> This mirrors the existing pattern used on other admin settings screens and does not change API key creation, listing, or secret reveal behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa39f4f9b45bcf5ec17c1f35a6709860b611d6ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->