### PR TITLE
feat(chat): enable multi-select document upload (AYC-105)

### DIFF
--- a/ayunis-core-frontend/src/pages/chat/api/useCreateFileSource.ts
+++ b/ayunis-core-frontend/src/pages/chat/api/useCreateFileSource.ts
@@ -5,7 +5,11 @@ import {
 import type { ThreadSourcesControllerAddFileSourceBody } from '@/shared/api/generated/ayunisCoreAPI.schemas';
 import handleSourceUploadError from '@/shared/lib/handle-source-upload-error';
 import { useTranslation } from 'react-i18next';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
+import {
+  useIsMutating,
+  useMutation,
+  useQueryClient,
+} from '@tanstack/react-query';
 import { useRouter } from '@tanstack/react-router';
 
 const UPLOAD_TIMEOUT_MS = 60_000;
@@ -22,7 +26,9 @@ export function useCreateFileSource({ threadId }: UseFileSourceProps = {}) {
   const { t } = useTranslation('common');
   const router = useRouter();
   const queryClient = useQueryClient();
+  const mutationKey = ['createFileSource', threadId];
   const createFileSourceMutation = useMutation({
+    mutationKey,
     retry: 0,
     mutationFn: ({
       id,
@@ -68,10 +74,12 @@ export function useCreateFileSource({ threadId }: UseFileSourceProps = {}) {
     return createFileSourceMutation.mutateAsync({ id: threadId, data });
   }
 
+  const activeUploads = useIsMutating({ mutationKey });
+
   return {
     createFileSource,
     createFileSourceAsync,
-    isLoading: createFileSourceMutation.isPending,
+    isLoading: activeUploads > 0,
     error: createFileSourceMutation.error,
     reset: createFileSourceMutation.reset,
   };

--- a/ayunis-core-frontend/src/pages/chat/ui/ChatPage.tsx
+++ b/ayunis-core-frontend/src/pages/chat/ui/ChatPage.tsx
@@ -203,12 +203,8 @@ export default function ChatPage({
     });
   }, []);
 
-  const handleFileUpload = useCallback(
-    (file: File) => {
-      createFileSource({ file });
-    },
-    [createFileSource],
-  );
+  const handleFileUpload = (files: File[]) =>
+    files.forEach((file) => createFileSource({ file }));
 
   const handleError = useRunErrorHandler(thread.id);
 

--- a/ayunis-core-frontend/src/pages/knowledge-base/api/useUploadDocument.ts
+++ b/ayunis-core-frontend/src/pages/knowledge-base/api/useUploadDocument.ts
@@ -1,4 +1,4 @@
-import { useQueryClient } from '@tanstack/react-query';
+import { useIsMutating, useQueryClient } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
 import { showSuccess, showInfo, showError } from '@/shared/lib/toast';
 import {
@@ -11,9 +11,11 @@ import handleSourceUploadError from '@/shared/lib/handle-source-upload-error';
 export function useUploadDocument(knowledgeBaseId: string) {
   const { t } = useTranslation('knowledge-bases');
   const queryClient = useQueryClient();
+  const mutationKey = ['knowledgeBasesAddDocument', knowledgeBaseId];
 
   const mutation = useKnowledgeBasesControllerAddDocument({
     mutation: {
+      mutationKey,
       onSuccess: (data) => {
         void queryClient.invalidateQueries({
           queryKey:
@@ -42,5 +44,7 @@ export function useUploadDocument(knowledgeBaseId: string) {
     });
   };
 
-  return { uploadDocument, isUploading: mutation.isPending };
+  const activeUploads = useIsMutating({ mutationKey });
+
+  return { uploadDocument, isUploading: activeUploads > 0 };
 }

--- a/ayunis-core-frontend/src/pages/knowledge-base/ui/KnowledgeBaseDocumentsCard.tsx
+++ b/ayunis-core-frontend/src/pages/knowledge-base/ui/KnowledgeBaseDocumentsCard.tsx
@@ -93,15 +93,21 @@ export default function KnowledgeBaseDocumentsCard({
 
   const { isDragging } = useDocumentDrop({
     containerRef: cardRef,
-    onDrop: uploadDocument,
+    onDrop: (files) => {
+      for (const file of files) {
+        uploadDocument(file);
+      }
+    },
     acceptedExtensions: ACCEPTED_EXTENSIONS,
     disabled,
   });
 
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-    if (file) {
-      uploadDocument(file);
+    const files = e.target.files;
+    if (files && files.length > 0) {
+      for (const file of Array.from(files)) {
+        uploadDocument(file);
+      }
       e.target.value = '';
     }
   };
@@ -149,6 +155,7 @@ export default function KnowledgeBaseDocumentsCard({
             <input
               ref={fileInputRef}
               type="file"
+              multiple
               accept={ACCEPTED_FILE_TYPES}
               onChange={handleFileChange}
               className="hidden"

--- a/ayunis-core-frontend/src/pages/new-chat/ui/NewChatPage.tsx
+++ b/ayunis-core-frontend/src/pages/new-chat/ui/NewChatPage.tsx
@@ -111,19 +111,16 @@ export default function NewChatPage({
     ? (selectedAgent?.model.canVision ?? false)
     : (selectedModel?.canVision ?? false);
 
-  function handleFileUpload(file: File) {
-    const isCsvFile = file.name.endsWith('.csv');
-    setSources([
-      ...sources,
-      {
-        id: generateUUID(),
-        name: file.name,
-        type: isCsvFile
-          ? SourceResponseDtoType.data
-          : SourceResponseDtoType.text,
-        file,
-      },
-    ]);
+  function handleFileUpload(files: File[]) {
+    const newSources: LocalSource[] = files.map((file) => ({
+      id: generateUUID(),
+      name: file.name,
+      type: file.name.endsWith('.csv')
+        ? SourceResponseDtoType.data
+        : SourceResponseDtoType.text,
+      file,
+    }));
+    setSources([...sources, ...newSources]);
   }
 
   function handleRemoveSource(sourceId: string) {

--- a/ayunis-core-frontend/src/shared/hooks/useDocumentDrop.ts
+++ b/ayunis-core-frontend/src/shared/hooks/useDocumentDrop.ts
@@ -5,7 +5,7 @@ import { useDragOver } from './useDragOver';
 
 interface UseDocumentDropOptions {
   containerRef: RefObject<HTMLElement | null>;
-  onDrop: (file: File) => void;
+  onDrop: (files: File[]) => void;
   acceptedExtensions: string[];
   disabled?: boolean;
 }
@@ -42,7 +42,7 @@ export function useDocumentDrop({
         showError(t('chatInput.invalidDroppedFileType'));
       }
 
-      onDrop(validFiles[0]);
+      onDrop(validFiles);
     },
     [isValidFile, onDrop, t],
   );

--- a/ayunis-core-frontend/src/widgets/chat-input/hooks/useFileDrop.ts
+++ b/ayunis-core-frontend/src/widgets/chat-input/hooks/useFileDrop.ts
@@ -6,7 +6,7 @@ import { separateFilesByType } from '../utils/fileHandlers';
 
 interface UseFileDropOptions {
   containerRef: RefObject<HTMLElement | null>;
-  onDocumentDrop: (file: File) => void;
+  onDocumentDrop: (files: File[]) => void;
   onImagesDrop: (files: File[]) => void;
   isDocumentUploadEnabled: boolean;
   isImageUploadEnabled: boolean;
@@ -49,7 +49,7 @@ export function useFileDrop({
       if (isDocumentUploadEnabled && regularFiles.length > 0) {
         const validDocuments = regularFiles.filter(isValidDocumentFile);
         if (validDocuments.length > 0) {
-          onDocumentDrop(validDocuments[0]);
+          onDocumentDrop(validDocuments);
         }
         if (validDocuments.length < regularFiles.length) {
           hasSkippedFiles = true;

--- a/ayunis-core-frontend/src/widgets/chat-input/ui/ChatInput.tsx
+++ b/ayunis-core-frontend/src/widgets/chat-input/ui/ChatInput.tsx
@@ -74,7 +74,7 @@ interface ChatInputProps {
   onModelChange: (modelId: string) => void;
   onAgentChange: (agentId: string) => void;
   onAgentRemove: (agentId: string) => void;
-  onFileUpload: (file: File) => void;
+  onFileUpload: (files: File[]) => void;
   onRemoveSource: (sourceId: string) => void;
   onDownloadSource: (sourceId: string) => void;
   onAddKnowledgeBase?: (knowledgeBase: KnowledgeBaseSummary) => void;

--- a/ayunis-core-frontend/src/widgets/chat-input/ui/PlusButton.tsx
+++ b/ayunis-core-frontend/src/widgets/chat-input/ui/PlusButton.tsx
@@ -27,7 +27,7 @@ import type { KnowledgeBaseSummary } from '@/shared/contexts/chat/chatContext';
 import { useIsKnowledgeBasesEnabled } from '@/features/feature-toggles';
 
 interface PlusButtonProps {
-  onFileUpload: (file: File) => void;
+  onFileUpload: (files: File[]) => void;
   onImageSelect?: (files: FileList | null) => void;
   isFileSourceDisabled?: boolean;
   isImageUploadDisabled?: boolean;
@@ -59,13 +59,11 @@ export default function PlusButton({
   const handleDocumentChange = (files: FileList | null) => {
     if (!files || files.length === 0) return;
 
-    // Only allow single document upload
-    const file = files[0];
     if (isFileSourceDisabled) {
       showError(t('chatInput.noEmbeddingModelEnabled'));
       return;
     }
-    onFileUpload(file);
+    onFileUpload(Array.from(files));
 
     // Reset input to allow selecting the same file again
     if (documentInputRef.current) {
@@ -191,6 +189,7 @@ export default function PlusButton({
       <Input
         type="file"
         hidden
+        multiple
         accept=".pdf,.csv,.xlsx,.xls,.docx,.pptx,.txt,.md,.mp3,.m4a,.wav,.webm"
         onChange={(e) => handleDocumentChange(e.target.files)}
         ref={documentInputRef}

--- a/ayunis-core-frontend/src/widgets/knowledge-base-card/ui/KnowledgeBaseCard.tsx
+++ b/ayunis-core-frontend/src/widgets/knowledge-base-card/ui/KnowledgeBaseCard.tsx
@@ -90,7 +90,8 @@ export default function KnowledgeBaseCard({
 
   const { isDragging } = useDocumentDrop({
     containerRef: cardRef,
-    onDrop: (file) => addFileSource({ id: entity.id, data: { file } }),
+    onDrop: (files) =>
+      addFileSource({ id: entity.id, data: { file: files[0] } }),
     acceptedExtensions: ACCEPTED_EXTENSIONS,
     disabled: disabled || !isEnabled,
   });


### PR DESCRIPTION
- Chat input: allow picking or dropping multiple documents at once;
  each is uploaded through the existing per-file source pipeline.
- Knowledge base detail: allow picking or dropping multiple documents
  on the Documents card; each goes through the per-file upload hook.
- Lift the 'single file' assumption out of PlusButton, useFileDrop, and
  useDocumentDrop by changing their callbacks from File to File[].
- Agent/skill 'additional documents' widget (out of ticket scope) keeps
  single-file behaviour by reading files[0] in its drop callback.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Frontend-only UX and React Query loading semantics; no auth or API contract changes beyond repeated existing per-file upload calls.
> 
> **Overview**
> Enables **multi-document** selection and drag-and-drop in chat and knowledge-base detail: shared hooks (`useDocumentDrop`, `useFileDrop`) and `ChatInput`/`PlusButton` now take `File[]` instead of a single `File`, with `multiple` on the document file picker. Each selected file still uses the existing **one-file-per-request** upload path (`createFileSource` / `uploadDocument` per file).
> 
> **Upload-in-progress UX** is fixed for batches: `useCreateFileSource` and `useUploadDocument` tag mutations with a scoped `mutationKey` and derive loading from `useIsMutating` so send/upload stays disabled until **all** in-flight uploads finish, not just the latest mutation instance.
> 
> Agent/skill **additional documents** (`KnowledgeBaseCard`) still uploads only the first dropped file via `files[0]`; its file-picker path is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ebd1523adb32c9ca5ab9c9774ffe1df31dbc6145. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->