### PR TITLE
fix(openai-compat): accept stricter-than-spec request shapes (AYC-000)

### DIFF
--- a/ayunis-core-backend/src/domain/openai-compat/application/mappers/openai-request.mapper.spec.ts
+++ b/ayunis-core-backend/src/domain/openai-compat/application/mappers/openai-request.mapper.spec.ts
@@ -1,0 +1,182 @@
+import { randomUUID } from 'crypto';
+import { OpenAIRequestMapper } from './openai-request.mapper';
+import { OpenAIInvalidRequestError } from '../openai-compat.errors';
+import { UserMessage } from 'src/domain/messages/domain/messages/user-message.entity';
+import { AssistantMessage } from 'src/domain/messages/domain/messages/assistant-message.entity';
+import { ToolResultMessage } from 'src/domain/messages/domain/messages/tool-result-message.entity';
+import { TextMessageContent } from 'src/domain/messages/domain/message-contents/text-message-content.entity';
+import type { ToolResultMessageContent } from 'src/domain/messages/domain/message-contents/tool-result.message-content.entity';
+import type { OpenAIChatCompletionRequest } from '../types/openai-request.types';
+
+describe('OpenAIRequestMapper', () => {
+  const mapper = new OpenAIRequestMapper();
+  const threadId = randomUUID();
+
+  describe('array-of-parts content', () => {
+    it('folds text parts into a single string for user messages', () => {
+      const request: OpenAIChatCompletionRequest = {
+        model: 'gpt-4o',
+        messages: [
+          {
+            role: 'user',
+            content: [
+              { type: 'text', text: 'Hello, ' },
+              { type: 'text', text: 'world!' },
+            ],
+          },
+        ],
+      };
+
+      const { messages } = mapper.toDomainMessages(request, threadId);
+
+      expect(messages).toHaveLength(1);
+      expect(messages[0]).toBeInstanceOf(UserMessage);
+      const content = messages[0].content[0];
+      expect(content).toBeInstanceOf(TextMessageContent);
+      expect((content as TextMessageContent).text).toBe('Hello, world!');
+    });
+
+    it('accepts array-of-parts on system messages', () => {
+      const request: OpenAIChatCompletionRequest = {
+        model: 'gpt-4o',
+        messages: [
+          {
+            role: 'system',
+            content: [{ type: 'text', text: 'You are helpful.' }],
+          },
+          { role: 'user', content: 'Hi' },
+        ],
+      };
+
+      const { systemPrompt } = mapper.toDomainMessages(request, threadId);
+
+      expect(systemPrompt).toBe('You are helpful.');
+    });
+
+    it('accepts array-of-parts on tool result messages', () => {
+      const request: OpenAIChatCompletionRequest = {
+        model: 'gpt-4o',
+        messages: [
+          {
+            role: 'assistant',
+            content: null,
+            tool_calls: [
+              {
+                id: 'call_1',
+                type: 'function',
+                function: { name: 'lookup', arguments: '{}' },
+              },
+            ],
+          },
+          {
+            role: 'tool',
+            tool_call_id: 'call_1',
+            content: [{ type: 'text', text: 'result-body' }],
+          },
+        ],
+      };
+
+      const { messages } = mapper.toDomainMessages(request, threadId);
+
+      const toolResult = messages[1];
+      expect(toolResult).toBeInstanceOf(ToolResultMessage);
+      const part = toolResult.content[0] as ToolResultMessageContent;
+      expect(part.result).toBe('result-body');
+    });
+
+    it('rejects non-text parts with a descriptive error', () => {
+      const request: OpenAIChatCompletionRequest = {
+        model: 'gpt-4o',
+        messages: [
+          {
+            role: 'user',
+            content: [
+              { type: 'text', text: 'Look at this:' },
+              {
+                type: 'image_url',
+                image_url: { url: 'https://example.com/cat.png' },
+              },
+            ],
+          },
+        ],
+      };
+
+      expect(() => mapper.toDomainMessages(request, threadId)).toThrow(
+        OpenAIInvalidRequestError,
+      );
+      expect(() => mapper.toDomainMessages(request, threadId)).toThrow(
+        /image_url/,
+      );
+    });
+  });
+
+  describe("role: 'developer'", () => {
+    it("folds 'developer' messages into the system prompt", () => {
+      const request: OpenAIChatCompletionRequest = {
+        model: 'o1-mini',
+        messages: [
+          { role: 'developer', content: 'Reason step by step.' },
+          { role: 'user', content: 'What is 2+2?' },
+        ],
+      };
+
+      const { systemPrompt, messages } = mapper.toDomainMessages(
+        request,
+        threadId,
+      );
+
+      expect(systemPrompt).toBe('Reason step by step.');
+      expect(messages).toHaveLength(1);
+      expect(messages[0]).toBeInstanceOf(UserMessage);
+    });
+
+    it("concatenates 'system' and 'developer' prompts in order", () => {
+      const request: OpenAIChatCompletionRequest = {
+        model: 'o1-mini',
+        messages: [
+          { role: 'system', content: 'You are helpful.' },
+          { role: 'developer', content: 'Use chain-of-thought.' },
+          { role: 'user', content: 'Hi' },
+        ],
+      };
+
+      const { systemPrompt } = mapper.toDomainMessages(request, threadId);
+
+      expect(systemPrompt).toBe('You are helpful.\n\nUse chain-of-thought.');
+    });
+  });
+
+  describe('lenient empty content', () => {
+    it('accepts an empty-string user message', () => {
+      const request: OpenAIChatCompletionRequest = {
+        model: 'gpt-4o',
+        messages: [{ role: 'user', content: '' }],
+      };
+
+      const { messages } = mapper.toDomainMessages(request, threadId);
+
+      expect(messages).toHaveLength(1);
+      expect(messages[0]).toBeInstanceOf(UserMessage);
+      expect((messages[0].content[0] as TextMessageContent).text).toBe('');
+    });
+
+    it('accepts an assistant placeholder with no text and no tool_calls', () => {
+      const request: OpenAIChatCompletionRequest = {
+        model: 'gpt-4o',
+        messages: [
+          { role: 'user', content: 'Hi' },
+          { role: 'assistant', content: null },
+          { role: 'user', content: 'Are you there?' },
+        ],
+      };
+
+      const { messages } = mapper.toDomainMessages(request, threadId);
+
+      expect(messages).toHaveLength(3);
+      expect(messages[1]).toBeInstanceOf(AssistantMessage);
+      const block = messages[1].content[0] as TextMessageContent;
+      expect(block).toBeInstanceOf(TextMessageContent);
+      expect(block.text).toBe('');
+    });
+  });
+});

--- a/ayunis-core-backend/src/domain/openai-compat/application/mappers/openai-request.mapper.ts
+++ b/ayunis-core-backend/src/domain/openai-compat/application/mappers/openai-request.mapper.ts
@@ -174,6 +174,11 @@ export class OpenAIRequestMapper {
     // for plain text. Fold all text parts into a single string; reject only
     // genuinely unsupported modalities so connection tests pass. The DTO
     // doesn't deeply validate parts, so treat each as unknown at runtime.
+    if (!Array.isArray(msg.content)) {
+      throw new OpenAIInvalidRequestError(
+        'message content must be a string or an array of content parts',
+      );
+    }
     const texts: string[] = [];
     for (const raw of msg.content as unknown[]) {
       if (raw === null || typeof raw !== 'object') {

--- a/ayunis-core-backend/src/domain/openai-compat/application/mappers/openai-request.mapper.ts
+++ b/ayunis-core-backend/src/domain/openai-compat/application/mappers/openai-request.mapper.ts
@@ -41,7 +41,9 @@ export class OpenAIRequestMapper {
     let currentTurnToolMap = new Map<string, string>();
 
     for (const msg of request.messages) {
-      if (msg.role === 'system') {
+      if (msg.role === 'system' || msg.role === 'developer') {
+        // OpenAI's 'developer' role (o1+ models) replaces 'system' — fold
+        // both into the same system prompt.
         const text = this.extractTextContent(msg);
         systemPrompt = systemPrompt ? `${systemPrompt}\n\n${text}` : text;
       } else if (msg.role === 'user') {
@@ -65,12 +67,9 @@ export class OpenAIRequestMapper {
     msg: OpenAIChatCompletionMessage,
     threadId: UUID,
   ): UserMessage {
+    // OpenAI permits empty user content (turn markers, conversation
+    // replays). Forward an empty TextMessageContent rather than throwing.
     const text = this.extractTextContent(msg);
-    if (!text) {
-      throw new OpenAIInvalidRequestError(
-        'user message must have non-empty text content',
-      );
-    }
     return new UserMessage({
       threadId,
       content: [new TextMessageContent(text)],
@@ -98,11 +97,10 @@ export class OpenAIRequestMapper {
       }
     }
     if (blocks.length === 0) {
-      // OpenAI permits assistant messages with content=null + tool_calls
-      // undefined as placeholders; reject as invalid.
-      throw new OpenAIInvalidRequestError(
-        'assistant message must contain text or tool_calls',
-      );
+      // OpenAI clients sometimes replay assistant turns with content=null
+      // and no tool_calls (placeholders / continuation markers). Emit an
+      // empty text block so the domain model accepts it instead of throwing.
+      blocks.push(new TextMessageContent(''));
     }
     return new AssistantMessage({ threadId, content: blocks });
   }
@@ -172,10 +170,32 @@ export class OpenAIRequestMapper {
   private extractTextContent(msg: OpenAIChatCompletionMessage): string {
     if (msg.content === undefined || msg.content === null) return '';
     if (typeof msg.content === 'string') return msg.content;
-    // Array-of-parts content (multimodal) is not supported in iter 3.
-    throw new OpenAIInvalidRequestError(
-      'array-of-parts message content is not supported (use a string)',
-    );
+    // Many OpenAI-SDK clients always wrap content as an array of parts even
+    // for plain text. Fold all text parts into a single string; reject only
+    // genuinely unsupported modalities so connection tests pass. The DTO
+    // doesn't deeply validate parts, so treat each as unknown at runtime.
+    const texts: string[] = [];
+    for (const raw of msg.content as unknown[]) {
+      if (raw === null || typeof raw !== 'object') {
+        throw new OpenAIInvalidRequestError(
+          'message content parts must be objects with a "type" field',
+        );
+      }
+      const part = raw as { type?: unknown; text?: unknown };
+      if (part.type === 'text') {
+        if (typeof part.text !== 'string') {
+          throw new OpenAIInvalidRequestError(
+            'text content part must include a "text" string',
+          );
+        }
+        texts.push(part.text);
+      } else {
+        throw new OpenAIInvalidRequestError(
+          `message content part of type '${String(part.type)}' is not supported`,
+        );
+      }
+    }
+    return texts.join('');
   }
 
   private safeParseToolArgs(raw: string): Record<string, unknown> {

--- a/ayunis-core-backend/src/domain/openai-compat/application/types/openai-request.types.ts
+++ b/ayunis-core-backend/src/domain/openai-compat/application/types/openai-request.types.ts
@@ -32,9 +32,36 @@ export interface OpenAIChatCompletionToolCall {
   function: OpenAIChatCompletionFunctionCall;
 }
 
+export interface OpenAIChatCompletionTextPart {
+  type: 'text';
+  text: string;
+}
+
+export interface OpenAIChatCompletionImagePart {
+  type: 'image_url';
+  image_url: { url: string; detail?: string };
+}
+
+export interface OpenAIChatCompletionInputAudioPart {
+  type: 'input_audio';
+  input_audio: { data: string; format: string };
+}
+
+export type OpenAIChatCompletionContentPart =
+  | OpenAIChatCompletionTextPart
+  | OpenAIChatCompletionImagePart
+  | OpenAIChatCompletionInputAudioPart;
+
+export type OpenAIChatCompletionRole =
+  | 'system'
+  | 'developer'
+  | 'user'
+  | 'assistant'
+  | 'tool';
+
 export interface OpenAIChatCompletionMessage {
-  role: 'system' | 'user' | 'assistant' | 'tool';
-  content?: string | null;
+  role: OpenAIChatCompletionRole;
+  content?: string | OpenAIChatCompletionContentPart[] | null;
   tool_call_id?: string;
   tool_calls?: OpenAIChatCompletionToolCall[];
   name?: string;

--- a/ayunis-core-backend/src/domain/openai-compat/presenters/http/dto/chat-completion-request.dto.ts
+++ b/ayunis-core-backend/src/domain/openai-compat/presenters/http/dto/chat-completion-request.dto.ts
@@ -1,4 +1,5 @@
 import {
+  ArrayNotEmpty,
   IsArray,
   IsBoolean,
   IsIn,
@@ -10,8 +11,10 @@ import {
 } from 'class-validator';
 import { Type } from 'class-transformer';
 import type {
+  OpenAIChatCompletionContentPart,
   OpenAIChatCompletionMessage,
   OpenAIChatCompletionRequest,
+  OpenAIChatCompletionRole,
   OpenAIChatCompletionToolChoice,
 } from '../../../application/types/openai-request.types';
 
@@ -61,14 +64,17 @@ export class ChatCompletionToolCallDto {
 }
 
 export class ChatCompletionMessageDto implements OpenAIChatCompletionMessage {
-  @IsIn(['system', 'user', 'assistant', 'tool'])
-  role!: 'system' | 'user' | 'assistant' | 'tool';
+  // 'developer' is OpenAI's o1+ replacement for 'system'; the mapper folds
+  // it into the system prompt.
+  @IsIn(['system', 'developer', 'user', 'assistant', 'tool'])
+  role!: OpenAIChatCompletionRole;
 
-  // Either a string (OpenAI's common shorthand) or null on assistant
-  // messages that produced only tool_calls. Array-of-parts (multimodal) is
-  // not supported in iter 3 — reject in the mapper for clarity.
+  // string, null (assistant tool-call-only turns), or OpenAI's array-of-parts
+  // form. The mapper folds text parts into a single string and rejects
+  // non-text modalities (image_url, input_audio) since multimodal is not
+  // yet wired through the inference port.
   @IsOptional()
-  content?: string | null;
+  content?: string | OpenAIChatCompletionContentPart[] | null;
 
   @IsOptional()
   @IsString()
@@ -91,6 +97,7 @@ export class ChatCompletionRequestDto implements OpenAIChatCompletionRequest {
   model!: string;
 
   @IsArray()
+  @ArrayNotEmpty()
   @ValidateNested({ each: true })
   @Type(() => ChatCompletionMessageDto)
   messages!: ChatCompletionMessageDto[];


### PR DESCRIPTION
- Accept array-of-parts message content (text parts folded into a single
  string; non-text modalities still rejected with a specific error).
  Unblocks downstream clients that always wrap content as
  [{type:'text', ...}] even for plain text.
- Accept role 'developer' (o1+ replacement for 'system'), folding it
  into the system prompt.
- Stop rejecting empty user content and empty assistant placeholders;
  OpenAI permits both.
- Require non-empty messages array at the DTO layer.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Request parsing and validation only on the OpenAI-compat boundary; inference behavior unchanged aside from accepting more client payloads.
> 
> **Overview**
> Relaxes **OpenAI-compatible** chat completion request handling so common SDK and replay shapes stop failing validation.
> 
> **Message content** can be an array of parts: **text** segments are concatenated into one string (including for user, system, and tool messages). Non-text parts such as **`image_url`** still fail with an explicit unsupported-type error.
> 
> The **`developer`** role is accepted and merged into the **system prompt** (with **`system`**, in order, separated by blank lines). **Empty** user strings and **assistant** turns with `content: null` and no `tool_calls` map to empty text blocks instead of errors.
> 
> Types and the HTTP DTO now allow **`developer`**, string or array **`content`**, and **`@ArrayNotEmpty()`** on **`messages`** so empty request bodies are rejected at validation time. A focused **`openai-request.mapper.spec.ts`** suite documents the new behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c707301ae42e0dd2b213060e9b3f70da6d7cda55. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->