### PR TITLE
fix(models): expose numeric embedding dimensions enum, unpin @nestjs/swagger (AYC-150)

### DIFF
--- a/ayunis-core-backend/package.json
+++ b/ayunis-core-backend/package.json
@@ -64,7 +64,7 @@
     "@nestjs/platform-express": "^11.1.17",
     "@nestjs/schedule": "^6.1.1",
     "@nestjs/serve-static": "^5.0.3",
-    "@nestjs/swagger": "^11.1.5",
+    "@nestjs/swagger": "^11.4.4",
     "@nestjs/typeorm": "^11.0.0",
     "@sentry/nestjs": "^10.25.0",
     "@willsoto/nestjs-prometheus": "^6.0.2",

--- a/ayunis-core-backend/src/domain/models/presenters/http/dto/embedding-model-response.dto.ts
+++ b/ayunis-core-backend/src/domain/models/presenters/http/dto/embedding-model-response.dto.ts
@@ -51,7 +51,9 @@ export class EmbeddingModelResponseDto {
 
   @ApiProperty({
     type: 'number',
-    enum: Object.values(EmbeddingDimensions),
+    enum: Object.values(EmbeddingDimensions).filter(
+      (value): value is EmbeddingDimensions => typeof value === 'number',
+    ),
     description: 'The dimensions of the embedding',
     example: EmbeddingDimensions.DIMENSION_1536,
   })

--- a/ayunis-core-frontend/src/pages/super-admin-settings/models-catalog/ui/EditEmbeddingModelDialog.tsx
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/models-catalog/ui/EditEmbeddingModelDialog.tsx
@@ -6,7 +6,6 @@ import type {
   EmbeddingModelResponseDto,
   UpdateEmbeddingModelRequestDtoProvider,
 } from '@/shared/api';
-import { CreateEmbeddingModelRequestDtoDimensions } from '@/shared/api/generated/ayunisCoreAPI.schemas';
 import { EMBEDDING_MODEL_PROVIDERS } from '@/features/models';
 import { ModelFormDialog } from './ModelFormDialog';
 import { EmbeddingDimensionsField } from './EmbeddingDimensionsField';
@@ -16,26 +15,6 @@ interface EditEmbeddingModelDialogProps {
   model: EmbeddingModelResponseDto | null;
   open: boolean;
   onOpenChange: (open: boolean) => void;
-}
-
-function parseDimensions(
-  dimensions: EmbeddingModelResponseDto['dimensions'],
-): CreateEmbeddingModelRequestDtoDimensions {
-  if (typeof dimensions === 'number') {
-    return dimensions;
-  }
-  if (typeof dimensions === 'string') {
-    const parsed = Number(dimensions.split('_')[1]);
-    if (
-      !isNaN(parsed) &&
-      Object.values(CreateEmbeddingModelRequestDtoDimensions).includes(
-        parsed as CreateEmbeddingModelRequestDtoDimensions,
-      )
-    ) {
-      return parsed as CreateEmbeddingModelRequestDtoDimensions;
-    }
-  }
-  return CreateEmbeddingModelRequestDtoDimensions.NUMBER_1536;
 }
 
 export function EditEmbeddingModelDialog({
@@ -64,7 +43,7 @@ export function EditEmbeddingModelDialog({
         name: model.name,
         provider: model.provider,
         displayName: model.displayName,
-        dimensions: parseDimensions(model.dimensions),
+        dimensions: model.dimensions,
         isArchived: model.isArchived,
         inputTokenCost: model.inputTokenCost,
         outputTokenCost: model.outputTokenCost,

--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
@@ -504,9 +504,6 @@ export type EmbeddingModelResponseDtoDimensions = typeof EmbeddingModelResponseD
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const EmbeddingModelResponseDtoDimensions = {
-  DIMENSION_1024: 'DIMENSION_1024',
-  DIMENSION_1536: 'DIMENSION_1536',
-  DIMENSION_2560: 'DIMENSION_2560',
   NUMBER_1024: 1024,
   NUMBER_1536: 1536,
   NUMBER_2560: 2560,

--- a/ayunis-core-frontend/src/shared/api/openapi-schema.json
+++ b/ayunis-core-frontend/src/shared/api/openapi-schema.json
@@ -9002,6 +9002,7 @@
           "permittedLanguageModel": {
             "description": "The permitted language model",
             "nullable": true,
+            "type": "object",
             "allOf": [
               {
                 "$ref": "#/components/schemas/PermittedLanguageModelResponseDto"
@@ -9220,15 +9221,8 @@
             "example": false
           },
           "dimensions": {
-            "type": "string",
-            "enum": [
-              "DIMENSION_1024",
-              "DIMENSION_1536",
-              "DIMENSION_2560",
-              1024,
-              1536,
-              2560
-            ],
+            "type": "number",
+            "enum": [1024, 1536, 2560],
             "description": "The dimensions of the embedding",
             "example": 1536
           },

--- a/package.json
+++ b/package.json
@@ -19,8 +19,7 @@
       "typescript-eslint": "8.56.0",
       "@typescript-eslint/eslint-plugin": "8.56.0",
       "@typescript-eslint/parser": "8.56.0",
-      "eslint-plugin-react-hooks": "7.0.1",
-      "@nestjs/swagger": "11.2.6"
+      "eslint-plugin-react-hooks": "7.0.1"
     }
   },
   "overridesNotes": {
@@ -28,7 +27,6 @@
     "protobufjs": "Patches GHSA-xq3m-2v4x-88gg (arbitrary code execution, fixed in 7.5.5). Transitive via @google/genai. @google/genai declares `^7.5.4`, so this floor stays within its range. Remove when @google/genai's declared range moves past 7.5.5 — verify with `pnpm why protobufjs` after any @google/genai upgrade.",
     "puppeteer-core": "Pinned to 24.37.5 (the version the npm lockfile resolved pre-pnpm-migration) to keep the workspace migration behavior-neutral. puppeteer-core 24.4x narrowed Page.setContent's waitUntil to exclude 'networkidle0'/'networkidle2'; absorbing that upgrade + adjusting PDF wait behavior belongs in its own reviewed PR. Remove this pin when intentionally upgrading puppeteer-core (see html-document-export.service.ts).",
     "@types/mjml-core": "Pinned to 4.15.2 to match the mjml@4 runtime (sync mjml2html). @types/mjml declares @types/mjml-core:'*', which otherwise resolves to 5.0.0 (the async mjml v5 API) and breaks the sync `.html` usage in mjml.handler.ts. Remove when upgrading to mjml v5.",
-    "@nestjs/swagger": "Pinned to 11.2.6 (the npm-lockfile version pre-pnpm-migration) to keep the generated OpenAPI schema byte-identical. 11.4.x serializes the numeric EmbeddingDimensions enum differently, which drifts the checked-in frontend API client and fails the schema-drift check. Remove + regenerate the client (pnpm run openapi:update) when intentionally upgrading @nestjs/swagger.",
     "typescript-eslint / eslint-plugin-react-hooks": "typescript-eslint pinned to 8.56.0 and eslint-plugin-react-hooks to 7.0.1 (pre-migration versions). Newer releases added/changed type-aware rules (no-unnecessary-type-assertion, set-state-in-effect) that flag previously-clean code; pinning keeps lint behaviour unchanged. Remove when intentionally adopting the newer lint rules."
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,7 +13,6 @@ overrides:
   '@typescript-eslint/eslint-plugin': 8.56.0
   '@typescript-eslint/parser': 8.56.0
   eslint-plugin-react-hooks: 7.0.1
-  '@nestjs/swagger': 11.2.6
 
 importers:
 
@@ -86,8 +85,8 @@ importers:
         specifier: ^5.0.3
         version: 5.0.5(@nestjs/common@11.1.24(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.24)(express@5.2.1)
       '@nestjs/swagger':
-        specifier: 11.2.6
-        version: 11.2.6(@nestjs/common@11.1.24(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.24)(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)
+        specifier: ^11.4.4
+        version: 11.4.4(@nestjs/common@11.1.24(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.24)(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)
       '@nestjs/typeorm':
         specifier: ^11.0.0
         version: 11.0.1(@nestjs/common@11.1.24(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.24)(reflect-metadata@0.2.2)(rxjs@7.8.2)(typeorm@0.3.30(ioredis@5.11.0)(pg@8.21.0)(ts-node@10.9.2(@swc/core@1.15.40)(@types/node@24.12.4)(typescript@5.9.3)))
@@ -232,7 +231,7 @@ importers:
         version: 9.39.4
       '@nestjs/cli':
         specifier: ^11.0.0
-        version: 11.0.21(@swc/cli@0.6.0(@swc/core@1.15.40)(chokidar@4.0.3))(@swc/core@1.15.40)(@types/node@24.12.4)(prettier@3.8.3)
+        version: 11.0.21(@swc/cli@0.6.0(@swc/core@1.15.40)(chokidar@4.0.3))(@swc/core@1.15.40)(@types/node@24.12.4)(postcss@8.5.15)(prettier@3.8.3)
       '@nestjs/schematics':
         specifier: ^11.0.0
         version: 11.1.0(chokidar@4.0.3)(prettier@3.8.3)(typescript@5.9.3)
@@ -433,7 +432,7 @@ importers:
         version: 1.167.0(@tanstack/react-router@1.170.8(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@tanstack/router-core@1.171.6)(csstype@3.2.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@tanstack/router-plugin':
         specifier: ^1.166.13
-        version: 1.168.11(@tanstack/react-router@1.170.8(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite@6.4.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(yaml@2.9.0))(webpack@5.106.0(lightningcss@1.32.0)(postcss@8.5.15))
+        version: 1.168.11(@tanstack/react-router@1.170.8(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite@6.4.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(yaml@2.9.0))(webpack@5.106.0(lightningcss@1.32.0))
       '@tiptap/extension-link':
         specifier: ^3.20.0
         version: 3.23.6(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))(@tiptap/pm@3.23.6)
@@ -2001,12 +2000,12 @@ packages:
     peerDependencies:
       '@nestjs/common': ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0
 
-  '@nestjs/mapped-types@2.1.0':
-    resolution: {integrity: sha512-W+n+rM69XsFdwORF11UqJahn4J3xi4g/ZEOlJNL6KoW5ygWSmBB2p0S2BZ4FQeS/NDH72e6xIcu35SfJnE8bXw==}
+  '@nestjs/mapped-types@2.1.1':
+    resolution: {integrity: sha512-SCCoMEJ6jdeI5h/N+KCVF1+pmg/hmEkNA5nHTS8Gvww7T/LCl4o1gFLinw2iQ60w7slFkszHcGLKGdazVI4F8A==}
     peerDependencies:
       '@nestjs/common': ^10.0.0 || ^11.0.0
       class-transformer: ^0.4.0 || ^0.5.0
-      class-validator: ^0.13.0 || ^0.14.0
+      class-validator: ^0.13.0 || ^0.14.0 || ^0.15.0
       reflect-metadata: ^0.1.12 || ^0.2.0
     peerDependenciesMeta:
       class-transformer:
@@ -2057,8 +2056,8 @@ packages:
       fastify:
         optional: true
 
-  '@nestjs/swagger@11.2.6':
-    resolution: {integrity: sha512-oiXOxMQqDFyv1AKAqFzSo6JPvMEs4uA36Eyz/s2aloZLxUjcLfUMELSLSNQunr61xCPTpwEOShfmO7NIufKXdA==}
+  '@nestjs/swagger@11.4.4':
+    resolution: {integrity: sha512-VaIo1ruV2G7b+f2zPzkBSUNy9a/WQ9sg8TLKhWlrTfg4O6U10M/PA7Xi6XMXadOVhwOqoesijba8jH3i/3adrA==}
     peerDependencies:
       '@fastify/static': ^8.0.0 || ^9.0.0
       '@nestjs/common': ^11.0.1
@@ -8525,9 +8524,6 @@ packages:
     resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
     engines: {node: 18 || 20 || >=22}
 
-  path-to-regexp@8.3.0:
-    resolution: {integrity: sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==}
-
   path-to-regexp@8.4.2:
     resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
 
@@ -9605,8 +9601,8 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
-  swagger-ui-dist@5.31.0:
-    resolution: {integrity: sha512-zSUTIck02fSga6rc0RZP3b7J7wgHXwLea8ZjgLA3Vgnb8QeOl3Wou2/j5QkzSGeoz6HusP/coYuJl33aQxQZpg==}
+  swagger-ui-dist@5.32.6:
+    resolution: {integrity: sha512-75ttZNaYCLoFPnozPZcTUU6mS3wKT8l7WLjU5zJSHFeJa23i5vtnze6IiCl4jDMPeQTXVXIgovq4M11NNfQvSA==}
 
   swagger2openapi@7.0.8:
     resolution: {integrity: sha512-upi/0ZGkYgEcLeGieoz8gT74oWHA0E7JivX7aN9mAf+Tc7BQoRBvnIGHoPDw+f9TXTW4s6kGYCZJtauP6OYp7g==}
@@ -12079,7 +12075,7 @@ snapshots:
       bullmq: 5.77.6
       tslib: 2.8.1
 
-  '@nestjs/cli@11.0.21(@swc/cli@0.6.0(@swc/core@1.15.40)(chokidar@4.0.3))(@swc/core@1.15.40)(@types/node@24.12.4)(prettier@3.8.3)':
+  '@nestjs/cli@11.0.21(@swc/cli@0.6.0(@swc/core@1.15.40)(chokidar@4.0.3))(@swc/core@1.15.40)(@types/node@24.12.4)(postcss@8.5.15)(prettier@3.8.3)':
     dependencies:
       '@angular-devkit/core': 19.2.24(chokidar@4.0.3)
       '@angular-devkit/schematics': 19.2.24(chokidar@4.0.3)
@@ -12090,14 +12086,14 @@ snapshots:
       chokidar: 4.0.3
       cli-table3: 0.6.5
       commander: 4.1.1
-      fork-ts-checker-webpack-plugin: 9.1.0(typescript@5.9.3)(webpack@5.106.0(@swc/core@1.15.40))
+      fork-ts-checker-webpack-plugin: 9.1.0(typescript@5.9.3)(webpack@5.106.0(@swc/core@1.15.40)(postcss@8.5.15))
       glob: 13.0.6
       node-emoji: 1.11.0
       ora: 5.4.1
       tsconfig-paths: 4.2.0
       tsconfig-paths-webpack-plugin: 4.2.0
       typescript: 5.9.3
-      webpack: 5.106.0(@swc/core@1.15.40)
+      webpack: 5.106.0(@swc/core@1.15.40)(postcss@8.5.15)
       webpack-node-externals: 3.0.0
     optionalDependencies:
       '@swc/cli': 0.6.0(@swc/core@1.15.40)(chokidar@4.0.3)
@@ -12167,7 +12163,7 @@ snapshots:
       '@types/jsonwebtoken': 9.0.10
       jsonwebtoken: 9.0.3
 
-  '@nestjs/mapped-types@2.1.0(@nestjs/common@11.1.24(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)':
+  '@nestjs/mapped-types@2.1.1(@nestjs/common@11.1.24(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)':
     dependencies:
       '@nestjs/common': 11.1.24(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       reflect-metadata: 0.2.2
@@ -12219,17 +12215,17 @@ snapshots:
     optionalDependencies:
       express: 5.2.1
 
-  '@nestjs/swagger@11.2.6(@nestjs/common@11.1.24(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.24)(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)':
+  '@nestjs/swagger@11.4.4(@nestjs/common@11.1.24(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.24)(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)':
     dependencies:
       '@microsoft/tsdoc': 0.16.0
       '@nestjs/common': 11.1.24(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@nestjs/core': 11.1.24(@nestjs/common@11.1.24(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.24)(reflect-metadata@0.2.2)(rxjs@7.8.2)
-      '@nestjs/mapped-types': 2.1.0(@nestjs/common@11.1.24(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)
+      '@nestjs/mapped-types': 2.1.1(@nestjs/common@11.1.24(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)
       js-yaml: 4.1.1
-      lodash: 4.17.23
-      path-to-regexp: 8.3.0
+      lodash: 4.18.1
+      path-to-regexp: 8.4.2
       reflect-metadata: 0.2.2
-      swagger-ui-dist: 5.31.0
+      swagger-ui-dist: 5.32.6
     optionalDependencies:
       class-transformer: 0.5.1
       class-validator: 0.15.1
@@ -13919,7 +13915,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@tanstack/router-plugin@1.168.11(@tanstack/react-router@1.170.8(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite@6.4.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(yaml@2.9.0))(webpack@5.106.0(lightningcss@1.32.0)(postcss@8.5.15))':
+  '@tanstack/router-plugin@1.168.11(@tanstack/react-router@1.170.8(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite@6.4.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(yaml@2.9.0))(webpack@5.106.0(lightningcss@1.32.0))':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/plugin-syntax-jsx': 7.29.7(@babel/core@7.29.7)
@@ -13937,7 +13933,7 @@ snapshots:
     optionalDependencies:
       '@tanstack/react-router': 1.170.8(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       vite: 6.4.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(yaml@2.9.0)
-      webpack: 5.106.0(lightningcss@1.32.0)(postcss@8.5.15)
+      webpack: 5.106.0(lightningcss@1.32.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -17120,7 +17116,7 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
-  fork-ts-checker-webpack-plugin@9.1.0(typescript@5.9.3)(webpack@5.106.0(@swc/core@1.15.40)):
+  fork-ts-checker-webpack-plugin@9.1.0(typescript@5.9.3)(webpack@5.106.0(@swc/core@1.15.40)(postcss@8.5.15)):
     dependencies:
       '@babel/code-frame': 7.29.7
       chalk: 4.1.2
@@ -17135,7 +17131,7 @@ snapshots:
       semver: 7.8.1
       tapable: 2.3.3
       typescript: 5.9.3
-      webpack: 5.106.0(@swc/core@1.15.40)
+      webpack: 5.106.0(@swc/core@1.15.40)(postcss@8.5.15)
 
   form-data-encoder@1.7.2: {}
 
@@ -20111,8 +20107,6 @@ snapshots:
       lru-cache: 11.5.1
       minipass: 7.1.3
 
-  path-to-regexp@8.3.0: {}
-
   path-to-regexp@8.4.2: {}
 
   path-type@4.0.0: {}
@@ -21352,7 +21346,7 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  swagger-ui-dist@5.31.0:
+  swagger-ui-dist@5.32.6:
     dependencies:
       '@scarf/scarf': 1.4.0
 
@@ -21433,26 +21427,26 @@ snapshots:
       - bare-abort-controller
       - react-native-b4a
 
-  terser-webpack-plugin@5.6.1(@swc/core@1.15.40)(webpack@5.106.0(@swc/core@1.15.40)):
+  terser-webpack-plugin@5.6.1(@swc/core@1.15.40)(postcss@8.5.15)(webpack@5.106.0(@swc/core@1.15.40)(postcss@8.5.15)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       terser: 5.48.0
-      webpack: 5.106.0(@swc/core@1.15.40)
+      webpack: 5.106.0(@swc/core@1.15.40)(postcss@8.5.15)
     optionalDependencies:
       '@swc/core': 1.15.40
+      postcss: 8.5.15
 
-  terser-webpack-plugin@5.6.1(lightningcss@1.32.0)(postcss@8.5.15)(webpack@5.106.0(lightningcss@1.32.0)(postcss@8.5.15)):
+  terser-webpack-plugin@5.6.1(lightningcss@1.32.0)(webpack@5.106.0(lightningcss@1.32.0)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       terser: 5.48.0
-      webpack: 5.106.0(lightningcss@1.32.0)(postcss@8.5.15)
+      webpack: 5.106.0(lightningcss@1.32.0)
     optionalDependencies:
       lightningcss: 1.32.0
-      postcss: 8.5.15
     optional: true
 
   terser@5.48.0:
@@ -22079,7 +22073,7 @@ snapshots:
 
   webpack-virtual-modules@0.6.2: {}
 
-  webpack@5.106.0(@swc/core@1.15.40):
+  webpack@5.106.0(@swc/core@1.15.40)(postcss@8.5.15):
     dependencies:
       '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.9
@@ -22103,7 +22097,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.3
-      terser-webpack-plugin: 5.6.1(@swc/core@1.15.40)(webpack@5.106.0(@swc/core@1.15.40))
+      terser-webpack-plugin: 5.6.1(@swc/core@1.15.40)(postcss@8.5.15)(webpack@5.106.0(@swc/core@1.15.40)(postcss@8.5.15))
       watchpack: 2.5.1
       webpack-sources: 3.5.0
     transitivePeerDependencies:
@@ -22120,7 +22114,7 @@ snapshots:
       - postcss
       - uglify-js
 
-  webpack@5.106.0(lightningcss@1.32.0)(postcss@8.5.15):
+  webpack@5.106.0(lightningcss@1.32.0):
     dependencies:
       '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.9
@@ -22144,7 +22138,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.3
-      terser-webpack-plugin: 5.6.1(lightningcss@1.32.0)(postcss@8.5.15)(webpack@5.106.0(lightningcss@1.32.0)(postcss@8.5.15))
+      terser-webpack-plugin: 5.6.1(lightningcss@1.32.0)(webpack@5.106.0(lightningcss@1.32.0))
       watchpack: 2.5.1
       webpack-sources: 3.5.0
     transitivePeerDependencies:


### PR DESCRIPTION
embedding-model-response.dto.ts declared enum: Object.values(EmbeddingDimensions), which on a numeric TS enum yields the reverse-mapping mix ['DIMENSION_1024',...,1024,...]. @nestjs/swagger 11.4.x serializes that as type:number, making orval emit uncompilable client code (DIMENSION_1024: DIMENSION_1024) — the reason the package was pinned to 11.2.6 during the pnpm migration.

- Filter to numeric values so the schema is a clean enum [1024,1536,2560]
- Remove the @nestjs/swagger override + note from root package.json; bump the backend floor to ^11.4.4 and regenerate the API client
- Drop the now-dead parseDimensions string-decoding workaround in EditEmbeddingModelDialog

Refs: AYC-150

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Contract and dependency alignment for admin embedding-model UI; no auth or runtime embedding logic changes beyond API/schema shape.
> 
> **Overview**
> Fixes **embedding model `dimensions`** in the OpenAPI contract so clients see a **numeric** enum (`1024`, `1536`, `2560`) instead of a mixed string/number list from TypeScript numeric enums.
> 
> The backend **`@ApiProperty` enum** on `EmbeddingModelResponseDto` now passes only numeric `EmbeddingDimensions` values. **`@nestjs/swagger` is unpinned** and raised to **^11.4.4**; the checked-in **OpenAPI schema and Orval-generated types** are updated accordingly. The super-admin **edit embedding model** dialog drops **`parseDimensions`** and uses **`model.dimensions` directly**.
> 
> Also adds **`type: object`** on a nullable wrapper in the schema (permitted language model).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb8409df69bb1f3bfb107e75a8aefdaed241d3ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->