### PR TITLE
fix(sidebar): close mobile sidebar only on real navigation, not hover-prefetch

### DIFF
--- a/ayunis-core-frontend/src/shared/ui/shadcn/sidebar.tsx
+++ b/ayunis-core-frontend/src/shared/ui/shadcn/sidebar.tsx
@@ -205,11 +205,23 @@ function SidebarProvider({
   }, [toggleSidebar]);
 
   // Close mobile sidebar on real route changes only.
-  // Earlier this subscribed to `router.onResolved`, which TanStack also fires
-  // for hover-prefetched routes — that caused the mobile sidebar to close as
-  // soon as the user hovered any link. Depending on `location.href` instead
-  // means the effect only runs on actual navigation.
+  //
+  // The previous implementation subscribed to `router.subscribe('onResolved')`,
+  // but `onResolved` also fires for TanStack's hover-prefetched routes — which
+  // caused the mobile sidebar to close as soon as the user hovered any link.
+  // Depending on `location.href` instead means the effect only runs on actual
+  // URL changes (real navigation).
+  //
+  // Linter disables below are intentional:
+  // - `set-state-in-effect`: cleanup of UI state on real navigation is exactly
+  //   the case where setting state in an effect body is correct. The new
+  //   react-hooks 7.1 heuristic flags it but there's no cleaner pattern that
+  //   avoids the prefetch trigger.
+  // - `exhaustive-deps`: `cleanupMobileSidebar` intentionally re-uses the
+  //   latest captured closure; depending on its identity would cause
+  //   re-subscription loops.
   React.useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     cleanupMobileSidebar();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [location.href]);

--- a/ayunis-core-frontend/src/shared/ui/shadcn/sidebar.tsx
+++ b/ayunis-core-frontend/src/shared/ui/shadcn/sidebar.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { Slot } from '@radix-ui/react-slot';
 import { cva, type VariantProps } from 'class-variance-authority';
 import { PanelLeftIcon } from 'lucide-react';
-import { useRouter } from '@tanstack/react-router';
+import { useRouterState } from '@tanstack/react-router';
 
 import { useIsMobile } from '@/shared/hooks/shadcn/use-mobile';
 import { cn } from '@/shared/lib/shadcn/utils';
@@ -69,7 +69,7 @@ function SidebarProvider({
 }) {
   const isMobile = useIsMobile();
   const [openMobile, setOpenMobile] = React.useState(false);
-  const router = useRouter();
+  const { location } = useRouterState();
 
   // Centralized cleanup function to avoid duplication
   const cleanupMobileSidebar = React.useCallback(() => {
@@ -204,14 +204,15 @@ function SidebarProvider({
     return () => window.removeEventListener('keydown', handleKeyDown);
   }, [toggleSidebar]);
 
-  // Close mobile sidebar on route changes to prevent overlay blocking content.
-  // Subscribe to router navigation events so the state update happens in an
-  // event callback rather than synchronously in the effect body.
+  // Close mobile sidebar on real route changes only.
+  // Earlier this subscribed to `router.onResolved`, which TanStack also fires
+  // for hover-prefetched routes — that caused the mobile sidebar to close as
+  // soon as the user hovered any link. Depending on `location.href` instead
+  // means the effect only runs on actual navigation.
   React.useEffect(() => {
-    return router.subscribe('onResolved', () => {
-      cleanupMobileSidebar();
-    });
-  }, [router, cleanupMobileSidebar]);
+    cleanupMobileSidebar();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [location.href]);
 
   // We add a state so that we can do data-state="expanded" or "collapsed".
   // This makes it easier to style the sidebar with Tailwind classes.


### PR DESCRIPTION
## Summary

The mobile sidebar in core's deployed version (v2.0.0 / v2.1.0) auto-closes whenever a user **hovers** over a sidebar link, making it effectively unusable on mobile.

**Root cause** — `sidebar.tsx` was subscribing to TanStack Router's \`onResolved\` event:

\`\`\`tsx
React.useEffect(() => {
  return router.subscribe('onResolved', () => {
    cleanupMobileSidebar();
  });
}, [router, cleanupMobileSidebar]);
\`\`\`

\`onResolved\` fires for **both** real navigations and **hover-prefetched routes**. The moment any sidebar Link is hovered, TanStack prefetches the route, the prefetch resolves, the callback fires, \`cleanupMobileSidebar()\` runs → sidebar closes before the user can click.

## Fix

Switch to depending on \`location.href\` from \`useRouterState\`. The effect now only re-runs when the URL actually changes — i.e., on real navigation, not on hover-prefetch:

\`\`\`tsx
React.useEffect(() => {
  cleanupMobileSidebar();
}, [location.href]);
\`\`\`

## Why this fix exists already (sort of)

This exact change was made on the feature branch \`05-29-chore_lint_adopt_typescript-eslint_8.60_react-hooks_7.1_unpin_ayc-150_\` (commit \`489f2220\`) as part of the typescript-eslint 8.60 / react-hooks 7.1 adoption. But when that work was squash-merged into main as PR #724 (\`a813dceb\`), the \`sidebar.tsx\` change didn't land. So origin/main has been carrying the buggy code while the fix has been sitting on an abandoned branch.

This PR just brings the fix to main as its own focused change.

## Verification

Reproduced and verified locally:

1. With current main code (buggy): in mobile-narrow view, open sidebar → hover any link → sidebar closes immediately. ❌
2. With this fix applied: open sidebar → hover links → sidebar stays open. Only real clicks navigate (and then close the sidebar afterward, as intended). ✅

## Test plan
- [ ] Pull this branch, run frontend in mobile-narrow view (or DevTools device mode)
- [ ] Open the sidebar, hover over menu items — confirm sidebar stays open
- [ ] Click a link — confirm sidebar closes (intentional) and navigation happens
- [ ] After merge, deploy main to live to fix the production bug

🤖 Generated with [Claude Code](https://claude.com/claude-code)