### PR TITLE
fix(sources): batch queue-based document ingestion to stop embedding API floods (AYC-183)

### DIFF
--- a/ayunis-core-backend/src/domain/sources/infrastructure/queue/document-processing.consumer.spec.ts
+++ b/ayunis-core-backend/src/domain/sources/infrastructure/queue/document-processing.consumer.spec.ts
@@ -1,15 +1,6 @@
 import type { UUID } from 'crypto';
 import type { Job } from 'bullmq';
 import { SourceStatus } from 'src/domain/sources/domain/source-status.enum';
-
-// p-limit is ESM-only — mock the dynamic import so Jest (CJS) doesn't choke.
-jest.mock('p-limit', () => ({
-  __esModule: true,
-  default:
-    () =>
-    <T>(fn: () => T) =>
-      fn(),
-}));
 import { TextType } from 'src/domain/sources/domain/source-type.enum';
 import { FileType } from 'src/domain/sources/domain/source-type.enum';
 import { FileSource } from 'src/domain/sources/domain/sources/text-source.entity';
@@ -82,7 +73,7 @@ const splitTextUseCase = {
   }),
 };
 
-const ingestContentUseCase = {
+const ingestBulkContentUseCase = {
   execute: jest.fn().mockResolvedValue(undefined),
 };
 const deleteContentUseCase = {
@@ -126,7 +117,7 @@ describe('DocumentProcessingConsumer', () => {
       contextService as never,
       retrieveFileContentUseCase as never,
       splitTextUseCase as never,
-      ingestContentUseCase as never,
+      ingestBulkContentUseCase as never,
       deleteContentUseCase as never,
       downloadObjectUseCase as never,
       deleteObjectUseCase as never,
@@ -192,5 +183,14 @@ describe('DocumentProcessingConsumer', () => {
       SourceStatus.READY,
       { processingError: null },
     );
+    // Chunks are indexed via a single bulk call (not one call per chunk)
+    expect(ingestBulkContentUseCase.execute).toHaveBeenCalledTimes(1);
+    const bulkCommand = ingestBulkContentUseCase.execute.mock.calls[0][0];
+    expect(bulkCommand.orgId).toBe(ORG_ID);
+    expect(bulkCommand.entries).toHaveLength(1);
+    expect(bulkCommand.entries[0]).toMatchObject({
+      documentId: SOURCE_ID,
+      content: 'hello world',
+    });
   });
 });

--- a/ayunis-core-backend/src/domain/sources/infrastructure/queue/document-processing.consumer.ts
+++ b/ayunis-core-backend/src/domain/sources/infrastructure/queue/document-processing.consumer.ts
@@ -7,8 +7,8 @@ import { RetrieveFileContentUseCase } from 'src/domain/retrievers/file-retriever
 import { RetrieveFileContentCommand } from 'src/domain/retrievers/file-retrievers/application/use-cases/retrieve-file-content/retrieve-file-content.command';
 import { SplitTextUseCase } from 'src/domain/rag/splitters/application/use-cases/split-text/split-text.use-case';
 import { SplitTextCommand } from 'src/domain/rag/splitters/application/use-cases/split-text/split-text.command';
-import { IngestContentUseCase } from 'src/domain/rag/indexers/application/use-cases/ingest-content/ingest-content.use-case';
-import { IngestContentCommand } from 'src/domain/rag/indexers/application/use-cases/ingest-content/ingest-content.command';
+import { IngestBulkContentUseCase } from 'src/domain/rag/indexers/application/use-cases/ingest-bulk-content/ingest-bulk-content.use-case';
+import { IngestBulkContentCommand } from 'src/domain/rag/indexers/application/use-cases/ingest-bulk-content/ingest-bulk-content.command';
 import { DeleteContentUseCase } from 'src/domain/rag/indexers/application/use-cases/delete-content/delete-content.use-case';
 import { DeleteContentCommand } from 'src/domain/rag/indexers/application/use-cases/delete-content/delete-content.command';
 import { DownloadObjectUseCase } from 'src/domain/storage/application/use-cases/download-object/download-object.use-case';
@@ -26,9 +26,6 @@ import { TextSource } from 'src/domain/sources/domain/sources/text-source.entity
 import type { DocumentProcessingJobData } from '../../application/ports/document-processing.port';
 import { DOCUMENT_PROCESSING_QUEUE } from './document-processing.constants';
 
-/** Max concurrent embedding API calls to avoid rate limits */
-const EMBEDDING_CONCURRENCY = 20;
-
 @Processor(DOCUMENT_PROCESSING_QUEUE, { concurrency: 2 })
 export class DocumentProcessingConsumer extends WorkerHost {
   private readonly logger = new Logger(DocumentProcessingConsumer.name);
@@ -37,7 +34,7 @@ export class DocumentProcessingConsumer extends WorkerHost {
     private readonly contextService: ContextService,
     private readonly retrieveFileContentUseCase: RetrieveFileContentUseCase,
     private readonly splitTextUseCase: SplitTextUseCase,
-    private readonly ingestContentUseCase: IngestContentUseCase,
+    private readonly ingestBulkContentUseCase: IngestBulkContentUseCase,
     private readonly deleteContentUseCase: DeleteContentUseCase,
     private readonly downloadObjectUseCase: DownloadObjectUseCase,
     private readonly deleteObjectUseCase: DeleteObjectUseCase,
@@ -236,23 +233,20 @@ export class DocumentProcessingConsumer extends WorkerHost {
       new DeleteContentCommand({ documentId: sourceId }),
     );
 
-    // Dynamic import required: p-limit is ESM-only, our codebase uses CJS
-    const { default: pLimit } = await import('p-limit');
-    const limit = pLimit(EMBEDDING_CONCURRENCY);
-    await Promise.all(
-      chunks.map((chunk) =>
-        limit(async () => {
-          await this.ingestContentUseCase.execute(
-            new IngestContentCommand({
-              orgId,
-              documentId: sourceId,
-              chunkId: chunk.id,
-              content: chunk.content,
-              type: IndexType.PARENT_CHILD,
-            }),
-          );
-        }),
-      ),
+    // Bulk ingest all chunks: the embedding model is resolved once, child
+    // texts are embedded in batched API calls, and all parent chunks are saved
+    // in a single DB write. This keeps embedding API pressure low (sequential
+    // batches) instead of firing one call per chunk.
+    await this.ingestBulkContentUseCase.execute(
+      new IngestBulkContentCommand({
+        orgId,
+        entries: chunks.map((chunk) => ({
+          documentId: sourceId,
+          chunkId: chunk.id,
+          content: chunk.content,
+        })),
+        type: IndexType.PARENT_CHILD,
+      }),
     );
   }
 


### PR DESCRIPTION
The async document-processing queue indexed content per chunk via
IngestContentUseCase inside pLimit(20), producing hundreds of tiny
embedding calls (input 1-5) ~20-wide per large document. This
saturated Mistral's shared, retrieval-hot-path embeddings client,
whose 429 retry backoffs then slowed chat for every org.

- Switch the consumer to the existing batched IngestBulkContentUseCase
  (model resolved once, child texts embedded 64-per-call sequentially,
  single saveMany), mirroring CreateTextSourceUseCase
- Remove the pLimit(20) per-chunk loop and EMBEDDING_CONCURRENCY
- Cuts system-wide ingestion concurrency from 2x20 to ~2 embed calls
- Update consumer spec to assert a single bulk ingest call

Durable cross-org throttle tracked in AYC-182.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how RAG index writes and embedding calls run for async documents; behavior should be equivalent but failures or batching edge cases could differ from the old per-chunk path.
> 
> **Overview**
> **Queue-based document indexing** no longer runs one `IngestContentUseCase` per chunk behind `p-limit(20)`. **`indexChunks`** now issues a single **`IngestBulkContentUseCase`** call with all chunk entries and `IndexType.PARENT_CHILD`, matching the batched embedding/DB path used elsewhere (e.g. text source creation).
> 
> The **`p-limit`** dynamic import and **`EMBEDDING_CONCURRENCY`** constant are removed. Specs drop the **`p-limit`** Jest mock and assert **one** bulk ingest with the expected **`orgId`**, **`documentId`**, and chunk **`content`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3234029693b9b4bbba1b1d8c2ca573347c123352. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->