### PR TITLE
fix(embeddings): add global throttle prioritizing retrieval over ingestion (AYC-182)

### DIFF
--- a/ayunis-core-backend/package.json
+++ b/ayunis-core-backend/package.json
@@ -94,6 +94,7 @@
     "ollama": "^0.6.3",
     "openai": "^4.104.0",
     "p-limit": "^7.3.0",
+    "p-queue": "^9.3.0",
     "passport": "^0.7.0",
     "passport-http-bearer": "^1.0.1",
     "passport-jwt": "^4.0.1",

--- a/ayunis-core-backend/src/config/embeddings.config.ts
+++ b/ayunis-core-backend/src/config/embeddings.config.ts
@@ -11,4 +11,13 @@ export const embeddingsConfig = registerAs('embeddings', () => ({
     baseURL: process.env.AYUNIS_BASE_URL,
     authToken: process.env.AYUNIS_AUTH_TOKEN,
   },
+  throttle: {
+    // Max concurrent embedding API calls across the whole process. Ingestion
+    // and retrieval share this budget; retrieval is prioritized within it.
+    // See EmbeddingsThrottleService.
+    maxConcurrency: parseInt(
+      process.env.EMBEDDINGS_MAX_CONCURRENCY ?? '16',
+      10,
+    ),
+  },
 }));

--- a/ayunis-core-backend/src/domain/rag/embeddings/application/services/embeddings-throttle.service.spec.ts
+++ b/ayunis-core-backend/src/domain/rag/embeddings/application/services/embeddings-throttle.service.spec.ts
@@ -1,0 +1,75 @@
+import type { ConfigService } from '@nestjs/config';
+import {
+  EmbeddingsThrottleService,
+  type PriorityQueue,
+} from './embeddings-throttle.service';
+import { EmbeddingPriority } from '../../domain/embedding-priority.enum';
+
+/**
+ * Records the priority each task was enqueued with and runs it immediately.
+ * Lets us assert the throttle's mapping/contract without loading the ESM-only
+ * p-queue (which the repo's CommonJS jest config cannot import). Real
+ * priority-ordering fairness is p-queue's responsibility, exercised end-to-end
+ * on the dev stack.
+ */
+class FakeQueue implements PriorityQueue {
+  public readonly priorities: number[] = [];
+  async add<T>(
+    fn: () => Promise<T>,
+    options: { priority: number },
+  ): Promise<T | void> {
+    this.priorities.push(options.priority);
+    return fn();
+  }
+}
+
+/** Exposes the queue seam so tests inject the fake instead of real p-queue. */
+class TestableThrottle extends EmbeddingsThrottleService {
+  public readonly queue = new FakeQueue();
+  public createQueueCalls = 0;
+  protected createQueue(): Promise<PriorityQueue> {
+    this.createQueueCalls++;
+    return Promise.resolve(this.queue);
+  }
+}
+
+describe('EmbeddingsThrottleService', () => {
+  let service: TestableThrottle;
+  const configService = {
+    get: jest.fn().mockReturnValue(16),
+  } as unknown as ConfigService;
+
+  beforeEach(() => {
+    service = new TestableThrottle(configService);
+  });
+
+  it('runs the task and returns its result', async () => {
+    const result = await service.run(EmbeddingPriority.INGESTION, () =>
+      Promise.resolve('embedding'),
+    );
+    expect(result).toBe('embedding');
+  });
+
+  it('propagates task rejections to the caller (never swallows)', async () => {
+    await expect(
+      service.run(EmbeddingPriority.RETRIEVAL, () =>
+        Promise.reject(new Error('boom')),
+      ),
+    ).rejects.toThrow('boom');
+  });
+
+  it('enqueues retrieval at a strictly higher priority than ingestion', async () => {
+    await service.run(EmbeddingPriority.INGESTION, () => Promise.resolve(0));
+    await service.run(EmbeddingPriority.RETRIEVAL, () => Promise.resolve(0));
+
+    const [ingestionPriority, retrievalPriority] = service.queue.priorities;
+    expect(retrievalPriority).toBeGreaterThan(ingestionPriority);
+  });
+
+  it('creates the shared queue lazily and reuses it across calls', async () => {
+    expect(service.createQueueCalls).toBe(0);
+    await service.run(EmbeddingPriority.INGESTION, () => Promise.resolve(0));
+    await service.run(EmbeddingPriority.RETRIEVAL, () => Promise.resolve(0));
+    expect(service.createQueueCalls).toBe(1);
+  });
+});

--- a/ayunis-core-backend/src/domain/rag/embeddings/application/services/embeddings-throttle.service.ts
+++ b/ayunis-core-backend/src/domain/rag/embeddings/application/services/embeddings-throttle.service.ts
@@ -1,0 +1,69 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { EmbeddingPriority } from '../../domain/embedding-priority.enum';
+
+/**
+ * Structural slice of p-queue's API that we depend on. Declaring it locally
+ * keeps the service unit-testable (a fake can be substituted) and avoids a
+ * type-level import of the ESM-only package.
+ */
+export interface PriorityQueue {
+  add<T>(
+    fn: () => Promise<T>,
+    options: { priority: number },
+  ): Promise<T | void>;
+}
+
+const DEFAULT_MAX_CONCURRENCY = 16;
+// p-queue runs higher-priority queued tasks first, so retrieval must rank
+// above ingestion. The absolute values don't matter, only the ordering.
+const RETRIEVAL_PRIORITY = 1;
+const INGESTION_PRIORITY = 0;
+
+/**
+ * Global throttle for every embedding API call in the process.
+ *
+ * All embedding traffic — document/URL ingestion and chat-query retrieval —
+ * funnels through {@link EmbedTextUseCase} into a single shared queue with a
+ * bounded concurrency. Callers tag each request with an {@link EmbeddingPriority}
+ * so retrieval embeds jump ahead of ingestion embeds: a heavy ingestion
+ * workload from one org can never starve chat search for other orgs. Requests
+ * over the cap **wait** in the queue rather than being rejected.
+ */
+@Injectable()
+export class EmbeddingsThrottleService {
+  private readonly logger = new Logger(EmbeddingsThrottleService.name);
+  private queuePromise: Promise<PriorityQueue> | null = null;
+
+  constructor(private readonly configService: ConfigService) {}
+
+  async run<T>(priority: EmbeddingPriority, fn: () => Promise<T>): Promise<T> {
+    const queue = await this.getQueue();
+    const queuePriority =
+      priority === EmbeddingPriority.RETRIEVAL
+        ? RETRIEVAL_PRIORITY
+        : INGESTION_PRIORITY;
+    return queue.add(fn, { priority: queuePriority }) as Promise<T>;
+  }
+
+  private getQueue(): Promise<PriorityQueue> {
+    // Memoize so every embedding call shares one queue (one concurrency budget).
+    this.queuePromise ??= this.createQueue();
+    return this.queuePromise;
+  }
+
+  /**
+   * Builds the shared p-queue. `protected` so tests can substitute a fake —
+   * p-queue is ESM-only and the dynamic import cannot run under the repo's
+   * CommonJS jest config (it works at runtime under Node's require-of-ESM,
+   * the same pattern already used for p-limit elsewhere).
+   */
+  protected async createQueue(): Promise<PriorityQueue> {
+    const concurrency =
+      this.configService.get<number>('embeddings.throttle.maxConcurrency') ??
+      DEFAULT_MAX_CONCURRENCY;
+    const { default: PQueue } = await import('p-queue');
+    this.logger.log('Embeddings throttle initialized', { concurrency });
+    return new PQueue({ concurrency });
+  }
+}

--- a/ayunis-core-backend/src/domain/rag/embeddings/application/use-cases/embed-text/embed-text.command.ts
+++ b/ayunis-core-backend/src/domain/rag/embeddings/application/use-cases/embed-text/embed-text.command.ts
@@ -1,12 +1,21 @@
 import type { UUID } from 'crypto';
 import type { EmbeddingModel } from 'src/domain/rag/embeddings/domain/embedding-model.entity';
+import { EmbeddingPriority } from 'src/domain/rag/embeddings/domain/embedding-priority.enum';
 
 export class EmbedTextCommand {
   model: EmbeddingModel;
   texts: string[];
+  priority: EmbeddingPriority;
 
-  constructor(params: { model: EmbeddingModel; texts: string[]; orgId: UUID }) {
+  constructor(params: {
+    model: EmbeddingModel;
+    texts: string[];
+    orgId: UUID;
+    priority?: EmbeddingPriority;
+  }) {
     this.model = params.model;
     this.texts = params.texts;
+    // Default to the low-priority ingestion lane; only retrieval is elevated.
+    this.priority = params.priority ?? EmbeddingPriority.INGESTION;
   }
 }

--- a/ayunis-core-backend/src/domain/rag/embeddings/application/use-cases/embed-text/embed-text.use-case.ts
+++ b/ayunis-core-backend/src/domain/rag/embeddings/application/use-cases/embed-text/embed-text.use-case.ts
@@ -1,6 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { EmbedTextCommand } from './embed-text.command';
 import { EmbeddingsHandlerRegistry } from '../../embeddings-handler.registry';
+import { EmbeddingsThrottleService } from '../../services/embeddings-throttle.service';
 import { Embedding } from '../../../domain/embedding.entity';
 import { ApplicationError } from 'src/common/errors/base.error';
 
@@ -8,7 +9,10 @@ import { ApplicationError } from 'src/common/errors/base.error';
 export class EmbedTextUseCase {
   private readonly logger = new Logger(EmbedTextUseCase.name);
 
-  constructor(private readonly providerRegistry: EmbeddingsHandlerRegistry) {}
+  constructor(
+    private readonly providerRegistry: EmbeddingsHandlerRegistry,
+    private readonly throttle: EmbeddingsThrottleService,
+  ) {}
 
   async execute(command: EmbedTextCommand): Promise<Embedding[]> {
     this.logger.log('execute', {
@@ -17,7 +21,11 @@ export class EmbedTextUseCase {
     try {
       const handler = this.providerRegistry.getHandler(command.model.provider);
 
-      return handler.embed(command.texts, command.model);
+      // Route through the global throttle so ingestion floods can never
+      // starve retrieval; retrieval embeds jump ahead of ingestion embeds.
+      return this.throttle.run(command.priority, () =>
+        handler.embed(command.texts, command.model),
+      );
     } catch (error) {
       if (error instanceof ApplicationError) {
         throw error;

--- a/ayunis-core-backend/src/domain/rag/embeddings/domain/embedding-priority.enum.ts
+++ b/ayunis-core-backend/src/domain/rag/embeddings/domain/embedding-priority.enum.ts
@@ -1,0 +1,13 @@
+/**
+ * Priority lane for an embedding request on the shared global throttle.
+ *
+ * Retrieval (chat query) embeds jump ahead of ingestion embeds so a heavy
+ * document/URL ingestion workload from one org can never starve chat search
+ * for other orgs. See {@link EmbeddingsThrottleService}.
+ */
+export enum EmbeddingPriority {
+  /** Chat query embeds — jump the queue. */
+  RETRIEVAL = 'retrieval',
+  /** Document/URL ingestion embeds — default lane. */
+  INGESTION = 'ingestion',
+}

--- a/ayunis-core-backend/src/domain/rag/embeddings/embeddings.module.ts
+++ b/ayunis-core-backend/src/domain/rag/embeddings/embeddings.module.ts
@@ -7,6 +7,7 @@ import { EmbedTextUseCase } from './application/use-cases/embed-text/embed-text.
 import { GetAvailableProvidersUseCase } from './application/use-cases/get-available-providers/get-available-providers.use-case';
 import { MistralEmbeddingsHandler } from './infrastructure/handler/mistral-embeddings.handler';
 import { AyunisOllamaEmbeddingsHandler } from './infrastructure/handler/ayunis-ollama-embeddings.handler';
+import { EmbeddingsThrottleService } from './application/services/embeddings-throttle.service';
 
 @Module({
   imports: [ConfigModule],
@@ -33,6 +34,7 @@ import { AyunisOllamaEmbeddingsHandler } from './infrastructure/handler/ayunis-o
     MistralEmbeddingsHandler,
     OpenAIEmbeddingsHandler,
     AyunisOllamaEmbeddingsHandler,
+    EmbeddingsThrottleService,
     // Use Cases
     EmbedTextUseCase,
     GetAvailableProvidersUseCase,

--- a/ayunis-core-backend/src/domain/rag/indexers/infrastructure/adapters/parent-child-index/application/use-cases/ingest-bulk-content/ingest-bulk-content.use-case.ts
+++ b/ayunis-core-backend/src/domain/rag/indexers/infrastructure/adapters/parent-child-index/application/use-cases/ingest-bulk-content/ingest-bulk-content.use-case.ts
@@ -7,6 +7,7 @@ import { SplitterType } from 'src/domain/rag/splitters/domain/splitter-type.enum
 import { ChildChunk } from '../../../domain/child-chunk.entity';
 import { EmbedTextUseCase } from 'src/domain/rag/embeddings/application/use-cases/embed-text/embed-text.use-case';
 import { EmbedTextCommand } from 'src/domain/rag/embeddings/application/use-cases/embed-text/embed-text.command';
+import { EmbeddingPriority } from 'src/domain/rag/embeddings/domain/embedding-priority.enum';
 import { GetPermittedEmbeddingModelUseCase } from 'src/domain/models/application/use-cases/get-permitted-embedding-model/get-permitted-embedding-model.use-case';
 import { GetPermittedEmbeddingModelQuery } from 'src/domain/models/application/use-cases/get-permitted-embedding-model/get-permitted-embedding-model.query';
 import { IngestBulkContentCommand } from './ingest-bulk-content.command';
@@ -106,7 +107,12 @@ export class IngestBulkContentUseCase {
     for (let i = 0; i < texts.length; i += EMBEDDING_BATCH_SIZE) {
       const batch = texts.slice(i, i + EMBEDDING_BATCH_SIZE);
       const embeddings = await this.embedTextUseCase.execute(
-        new EmbedTextCommand({ texts: batch, model, orgId }),
+        new EmbedTextCommand({
+          texts: batch,
+          model,
+          orgId,
+          priority: EmbeddingPriority.INGESTION,
+        }),
       );
       for (const embedding of embeddings) {
         allVectors.push(embedding.vector);

--- a/ayunis-core-backend/src/domain/rag/indexers/infrastructure/adapters/parent-child-index/application/use-cases/ingest-content/ingest-content.use-case.ts
+++ b/ayunis-core-backend/src/domain/rag/indexers/infrastructure/adapters/parent-child-index/application/use-cases/ingest-content/ingest-content.use-case.ts
@@ -7,6 +7,7 @@ import { SplitterType } from 'src/domain/rag/splitters/domain/splitter-type.enum
 import { ChildChunk } from '../../../domain/child-chunk.entity';
 import { EmbedTextUseCase } from 'src/domain/rag/embeddings/application/use-cases/embed-text/embed-text.use-case';
 import { EmbedTextCommand } from 'src/domain/rag/embeddings/application/use-cases/embed-text/embed-text.command';
+import { EmbeddingPriority } from 'src/domain/rag/embeddings/domain/embedding-priority.enum';
 import { GetPermittedEmbeddingModelUseCase } from 'src/domain/models/application/use-cases/get-permitted-embedding-model/get-permitted-embedding-model.use-case';
 import { GetPermittedEmbeddingModelQuery } from 'src/domain/models/application/use-cases/get-permitted-embedding-model/get-permitted-embedding-model.query';
 import { IngestContentCommand } from './ingest-content.command';
@@ -41,6 +42,7 @@ export class IngestContentUseCase {
         texts: childChunkTexts.chunks.map((chunk) => chunk.text),
         model: model.model,
         orgId: command.orgId,
+        priority: EmbeddingPriority.INGESTION,
       }),
     );
     const parentId = randomUUID();

--- a/ayunis-core-backend/src/domain/rag/indexers/infrastructure/adapters/parent-child-index/application/use-cases/search-content/search-content.use-case.ts
+++ b/ayunis-core-backend/src/domain/rag/indexers/infrastructure/adapters/parent-child-index/application/use-cases/search-content/search-content.use-case.ts
@@ -7,6 +7,7 @@ import { IndexEntry } from 'src/domain/rag/indexers/domain/index-entry.entity';
 import { ParentChildIndexerRepositoryPort } from '../../ports/parent-child-indexer-repository.port';
 import { EmbedTextUseCase } from 'src/domain/rag/embeddings/application/use-cases/embed-text/embed-text.use-case';
 import { EmbedTextCommand } from 'src/domain/rag/embeddings/application/use-cases/embed-text/embed-text.command';
+import { EmbeddingPriority } from 'src/domain/rag/embeddings/domain/embedding-priority.enum';
 import { GetPermittedEmbeddingModelUseCase } from 'src/domain/models/application/use-cases/get-permitted-embedding-model/get-permitted-embedding-model.use-case';
 import { GetPermittedEmbeddingModelQuery } from 'src/domain/models/application/use-cases/get-permitted-embedding-model/get-permitted-embedding-model.query';
 import type { UUID } from 'crypto';
@@ -55,6 +56,8 @@ export class SearchContentUseCase {
         model: model.model,
         texts: [query],
         orgId,
+        // Chat-query embed — jump ahead of ingestion on the shared throttle.
+        priority: EmbeddingPriority.RETRIEVAL,
       }),
     );
     this.logger.debug('Embedded query', {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -170,6 +170,9 @@ importers:
       p-limit:
         specifier: ^7.3.0
         version: 7.3.0
+      p-queue:
+        specifier: ^9.3.0
+        version: 9.3.0
       passport:
         specifier: ^0.7.0
         version: 0.7.0
@@ -227,7 +230,7 @@ importers:
         version: 9.39.4
       '@nestjs/cli':
         specifier: ^11.0.0
-        version: 11.0.21(@swc/cli@0.6.0(@swc/core@1.15.40)(chokidar@4.0.3))(@swc/core@1.15.40)(@types/node@24.12.4)(prettier@3.8.3)
+        version: 11.0.21(@swc/cli@0.6.0(@swc/core@1.15.40)(chokidar@4.0.3))(@swc/core@1.15.40)(@types/node@24.12.4)(postcss@8.5.15)(prettier@3.8.3)
       '@nestjs/schematics':
         specifier: ^11.0.0
         version: 11.1.0(chokidar@4.0.3)(prettier@3.8.3)(typescript@5.9.3)
@@ -8620,9 +8623,17 @@ packages:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
 
+  p-queue@9.3.0:
+    resolution: {integrity: sha512-7NED7xhQ74Ngp4JP/2e0VZHp7vSWfJfqeiR92jPgxsz6m0Se4P03YoTKa9dDXyZ3r6P616gUXttrB6nnHYKang==}
+    engines: {node: '>=20'}
+
   p-retry@4.6.2:
     resolution: {integrity: sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==}
     engines: {node: '>=8'}
+
+  p-timeout@7.0.1:
+    resolution: {integrity: sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg==}
+    engines: {node: '>=20'}
 
   p-try@2.2.0:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
@@ -12295,7 +12306,7 @@ snapshots:
       bullmq: 5.77.6
       tslib: 2.8.1
 
-  '@nestjs/cli@11.0.21(@swc/cli@0.6.0(@swc/core@1.15.40)(chokidar@4.0.3))(@swc/core@1.15.40)(@types/node@24.12.4)(prettier@3.8.3)':
+  '@nestjs/cli@11.0.21(@swc/cli@0.6.0(@swc/core@1.15.40)(chokidar@4.0.3))(@swc/core@1.15.40)(@types/node@24.12.4)(postcss@8.5.15)(prettier@3.8.3)':
     dependencies:
       '@angular-devkit/core': 19.2.24(chokidar@4.0.3)
       '@angular-devkit/schematics': 19.2.24(chokidar@4.0.3)
@@ -12306,14 +12317,14 @@ snapshots:
       chokidar: 4.0.3
       cli-table3: 0.6.5
       commander: 4.1.1
-      fork-ts-checker-webpack-plugin: 9.1.0(typescript@5.9.3)(webpack@5.106.0(@swc/core@1.15.40))
+      fork-ts-checker-webpack-plugin: 9.1.0(typescript@5.9.3)(webpack@5.106.0(@swc/core@1.15.40)(postcss@8.5.15))
       glob: 13.0.6
       node-emoji: 1.11.0
       ora: 5.4.1
       tsconfig-paths: 4.2.0
       tsconfig-paths-webpack-plugin: 4.2.0
       typescript: 5.9.3
-      webpack: 5.106.0(@swc/core@1.15.40)
+      webpack: 5.106.0(@swc/core@1.15.40)(postcss@8.5.15)
       webpack-node-externals: 3.0.0
     optionalDependencies:
       '@swc/cli': 0.6.0(@swc/core@1.15.40)(chokidar@4.0.3)
@@ -17560,7 +17571,7 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
-  fork-ts-checker-webpack-plugin@9.1.0(typescript@5.9.3)(webpack@5.106.0(@swc/core@1.15.40)):
+  fork-ts-checker-webpack-plugin@9.1.0(typescript@5.9.3)(webpack@5.106.0(@swc/core@1.15.40)(postcss@8.5.15)):
     dependencies:
       '@babel/code-frame': 7.29.7
       chalk: 4.1.2
@@ -17575,7 +17586,7 @@ snapshots:
       semver: 7.8.1
       tapable: 2.3.3
       typescript: 5.9.3
-      webpack: 5.106.0(@swc/core@1.15.40)
+      webpack: 5.106.0(@swc/core@1.15.40)(postcss@8.5.15)
 
   form-data-encoder@1.7.2: {}
 
@@ -20424,10 +20435,17 @@ snapshots:
     dependencies:
       p-limit: 3.1.0
 
+  p-queue@9.3.0:
+    dependencies:
+      eventemitter3: 5.0.4
+      p-timeout: 7.0.1
+
   p-retry@4.6.2:
     dependencies:
       '@types/retry': 0.12.0
       retry: 0.13.1
+
+  p-timeout@7.0.1: {}
 
   p-try@2.2.0: {}
 
@@ -21934,15 +21952,16 @@ snapshots:
       - bare-abort-controller
       - react-native-b4a
 
-  terser-webpack-plugin@5.6.1(@swc/core@1.15.40)(webpack@5.106.0(@swc/core@1.15.40)):
+  terser-webpack-plugin@5.6.1(@swc/core@1.15.40)(postcss@8.5.15)(webpack@5.106.0(@swc/core@1.15.40)(postcss@8.5.15)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       terser: 5.48.0
-      webpack: 5.106.0(@swc/core@1.15.40)
+      webpack: 5.106.0(@swc/core@1.15.40)(postcss@8.5.15)
     optionalDependencies:
       '@swc/core': 1.15.40
+      postcss: 8.5.15
 
   terser-webpack-plugin@5.6.1(lightningcss@1.32.0)(postcss@8.5.15)(webpack@5.106.0(lightningcss@1.32.0)(postcss@8.5.15)):
     dependencies:
@@ -22580,7 +22599,7 @@ snapshots:
 
   webpack-virtual-modules@0.6.2: {}
 
-  webpack@5.106.0(@swc/core@1.15.40):
+  webpack@5.106.0(@swc/core@1.15.40)(postcss@8.5.15):
     dependencies:
       '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.9
@@ -22604,7 +22623,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.3
-      terser-webpack-plugin: 5.6.1(@swc/core@1.15.40)(webpack@5.106.0(@swc/core@1.15.40))
+      terser-webpack-plugin: 5.6.1(@swc/core@1.15.40)(postcss@8.5.15)(webpack@5.106.0(@swc/core@1.15.40)(postcss@8.5.15))
       watchpack: 2.5.1
       webpack-sources: 3.5.0
     transitivePeerDependencies:


### PR DESCRIPTION
- Route every embedding call through a shared p-queue with bounded
  concurrency so one org's ingestion flood can no longer starve
  chat-query retrieval (or exhaust Mistral 429 retries) for other orgs.
- Tag each embed with an EmbeddingPriority lane: retrieval jumps ahead
  of ingestion. Callers over the cap wait in the queue, never reject.
- Concurrency is tunable via EMBEDDINGS_MAX_CONCURRENCY (default 16),
  kept loose enough that large docs still finish under the 15-min
  stale-processing ceiling.
- Throttle lives at the provider-agnostic EmbedTextUseCase boundary, so
  it covers Mistral, OpenAI and Ollama handlers alike.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the central RAG embedding path for all providers; mis-tuned concurrency could slow ingestion or add queue latency to search, but behavior is additive (queue/wait) rather than changing embed semantics.
> 
> **Overview**
> Adds a **process-wide embedding throttle** so ingestion and chat retrieval no longer compete without limits on provider APIs. Every call through `EmbedTextUseCase` now goes via `EmbeddingsThrottleService`, backed by **`p-queue`** with bounded concurrency (default **16**, overridable with `EMBEDDINGS_MAX_CONCURRENCY`). Over-cap work **waits** in the queue instead of being rejected.
> 
> Callers pass an **`EmbeddingPriority`** on `EmbedTextCommand`: **retrieval** (search query embeds) is queued ahead of **ingestion** (single/bulk ingest), so heavy indexing from one org is less likely to starve chat search or trigger rate-limit storms for others. Ingest paths default to the low lane when priority is omitted.
> 
> Unit tests cover the throttle contract with a fake queue (avoiding ESM `p-queue` in Jest).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95b5da9507e2702d6a4cfae0a9a184f1a8202fb5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->