### PR TITLE
feat(admin-teams): add search bar to teams overview (AYC-212)

### DIFF
--- a/ayunis-core-frontend/src/pages/admin-settings/teams-settings/ui/TeamsEmptyState.tsx
+++ b/ayunis-core-frontend/src/pages/admin-settings/teams-settings/ui/TeamsEmptyState.tsx
@@ -1,28 +1,24 @@
 import { useTranslation } from 'react-i18next';
 import { EmptyState } from '@/widgets/empty-state';
 
-interface TeamsEmptyStateProps {
-  hasFilters?: boolean;
-}
-
-export function TeamsEmptyState({
-  hasFilters = false,
-}: Readonly<TeamsEmptyStateProps>) {
+export function CreateFirstTeamEmptyState() {
   const { t } = useTranslation('admin-settings-teams');
-
-  if (hasFilters) {
-    return (
-      <EmptyState
-        title={t('teams.list.noMatchesTitle')}
-        description={t('teams.list.noMatchesDescription')}
-      />
-    );
-  }
 
   return (
     <EmptyState
       title={t('teams.list.emptyTitle')}
       description={t('teams.list.emptyDescription')}
+    />
+  );
+}
+
+export function NoTeamsFoundEmptyState() {
+  const { t } = useTranslation('admin-settings-teams');
+
+  return (
+    <EmptyState
+      title={t('teams.list.noMatchesTitle')}
+      description={t('teams.list.noMatchesDescription')}
     />
   );
 }

--- a/ayunis-core-frontend/src/pages/admin-settings/teams-settings/ui/TeamsEmptyState.tsx
+++ b/ayunis-core-frontend/src/pages/admin-settings/teams-settings/ui/TeamsEmptyState.tsx
@@ -1,8 +1,23 @@
 import { useTranslation } from 'react-i18next';
 import { EmptyState } from '@/widgets/empty-state';
 
-export function TeamsEmptyState() {
+interface TeamsEmptyStateProps {
+  hasFilters?: boolean;
+}
+
+export function TeamsEmptyState({
+  hasFilters = false,
+}: Readonly<TeamsEmptyStateProps>) {
   const { t } = useTranslation('admin-settings-teams');
+
+  if (hasFilters) {
+    return (
+      <EmptyState
+        title={t('teams.list.noMatchesTitle')}
+        description={t('teams.list.noMatchesDescription')}
+      />
+    );
+  }
 
   return (
     <EmptyState

--- a/ayunis-core-frontend/src/pages/admin-settings/teams-settings/ui/TeamsFilters.tsx
+++ b/ayunis-core-frontend/src/pages/admin-settings/teams-settings/ui/TeamsFilters.tsx
@@ -1,0 +1,37 @@
+import { Input } from '@/shared/ui/shadcn/input';
+import { Search } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { useEffect, useRef } from 'react';
+
+interface TeamsFiltersProps {
+  value: string;
+  onChange: (value: string) => void;
+}
+
+export default function TeamsFilters({
+  value,
+  onChange,
+}: Readonly<TeamsFiltersProps>) {
+  const { t } = useTranslation('admin-settings-teams');
+  const searchInputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    searchInputRef.current?.focus();
+  }, []);
+
+  return (
+    <div className="flex gap-4 mb-6">
+      <div className="relative flex-1 max-w-md">
+        <Search className="absolute left-3 top-1/2 -translate-y-1/2 size-4 text-muted-foreground" />
+        <Input
+          ref={searchInputRef}
+          type="text"
+          placeholder={t('teams.filters.searchPlaceholder')}
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          className="pl-10"
+        />
+      </div>
+    </div>
+  );
+}

--- a/ayunis-core-frontend/src/pages/admin-settings/teams-settings/ui/TeamsList.tsx
+++ b/ayunis-core-frontend/src/pages/admin-settings/teams-settings/ui/TeamsList.tsx
@@ -10,27 +10,17 @@ import {
   ItemTitle,
   ItemDescription,
 } from '@/shared/ui/shadcn/item';
-import { TeamsEmptyState } from './TeamsEmptyState';
 import { useDeleteTeam } from '../api/useDeleteTeam';
 import type { Team } from '../model/types';
 
 interface TeamsListProps {
   teams: Team[];
   onEditTeam: (team: Team) => void;
-  hasFilters?: boolean;
 }
 
-export function TeamsList({
-  teams,
-  onEditTeam,
-  hasFilters = false,
-}: Readonly<TeamsListProps>) {
+export function TeamsList({ teams, onEditTeam }: Readonly<TeamsListProps>) {
   const { t } = useTranslation('admin-settings-teams');
   const { deleteTeam, isDeleting } = useDeleteTeam();
-
-  if (teams.length === 0) {
-    return <TeamsEmptyState hasFilters={hasFilters} />;
-  }
 
   return (
     <div className="space-y-3">

--- a/ayunis-core-frontend/src/pages/admin-settings/teams-settings/ui/TeamsList.tsx
+++ b/ayunis-core-frontend/src/pages/admin-settings/teams-settings/ui/TeamsList.tsx
@@ -17,14 +17,19 @@ import type { Team } from '../model/types';
 interface TeamsListProps {
   teams: Team[];
   onEditTeam: (team: Team) => void;
+  hasFilters?: boolean;
 }
 
-export function TeamsList({ teams, onEditTeam }: Readonly<TeamsListProps>) {
+export function TeamsList({
+  teams,
+  onEditTeam,
+  hasFilters = false,
+}: Readonly<TeamsListProps>) {
   const { t } = useTranslation('admin-settings-teams');
   const { deleteTeam, isDeleting } = useDeleteTeam();
 
   if (teams.length === 0) {
-    return <TeamsEmptyState />;
+    return <TeamsEmptyState hasFilters={hasFilters} />;
   }
 
   return (

--- a/ayunis-core-frontend/src/pages/admin-settings/teams-settings/ui/TeamsSettingsPage.test.tsx
+++ b/ayunis-core-frontend/src/pages/admin-settings/teams-settings/ui/TeamsSettingsPage.test.tsx
@@ -1,0 +1,94 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import type { ReactNode } from 'react';
+import { TeamsSettingsPage } from './TeamsSettingsPage';
+import type { Team } from '../model/types';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock('@tanstack/react-router', () => ({
+  Link: ({
+    children,
+    to,
+    className,
+  }: {
+    children: ReactNode;
+    to: string;
+    className?: string;
+  }) => (
+    <a href={to} className={className}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock('../../admin-settings-layout', () => ({
+  default: ({
+    children,
+    action,
+    title,
+  }: {
+    children: ReactNode;
+    action: ReactNode;
+    title: string;
+  }) => (
+    <section>
+      <h1>{title}</h1>
+      {action}
+      {children}
+    </section>
+  ),
+}));
+
+vi.mock('@/shared/ui/help-link/HelpLink', () => ({
+  HelpLink: () => <a href="/help">Help</a>,
+}));
+
+vi.mock('./CreateTeamDialog', () => ({
+  CreateTeamDialog: () => null,
+}));
+
+vi.mock('./EditTeamDialog', () => ({
+  EditTeamDialog: () => null,
+}));
+
+vi.mock('../api/useDeleteTeam', () => ({
+  useDeleteTeam: () => ({
+    deleteTeam: vi.fn(),
+    isDeleting: false,
+  }),
+}));
+
+const createTeam = (overrides: Partial<Team> = {}): Team => ({
+  id: 'team-1',
+  name: 'City Services',
+  orgId: 'org-1',
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+  modelOverrideEnabled: false,
+  ...overrides,
+});
+
+describe('TeamsSettingsPage', () => {
+  it('shows only the create-first-team empty state when there are no teams', () => {
+    render(<TeamsSettingsPage teams={[]} />);
+
+    expect(
+      screen.queryByPlaceholderText('teams.filters.searchPlaceholder'),
+    ).toBeNull();
+    expect(screen.getByText('teams.list.emptyTitle')).toBeTruthy();
+  });
+
+  it('shows the filters and list when teams exist', () => {
+    render(<TeamsSettingsPage teams={[createTeam()]} />);
+
+    expect(
+      screen.getByPlaceholderText('teams.filters.searchPlaceholder'),
+    ).toBeTruthy();
+    expect(screen.getByText('City Services')).toBeTruthy();
+  });
+});

--- a/ayunis-core-frontend/src/pages/admin-settings/teams-settings/ui/TeamsSettingsPage.test.tsx
+++ b/ayunis-core-frontend/src/pages/admin-settings/teams-settings/ui/TeamsSettingsPage.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import type { ReactNode } from 'react';
 import { TeamsSettingsPage } from './TeamsSettingsPage';
@@ -90,5 +90,19 @@ describe('TeamsSettingsPage', () => {
       screen.getByPlaceholderText('teams.filters.searchPlaceholder'),
     ).toBeTruthy();
     expect(screen.getByText('City Services')).toBeTruthy();
+  });
+
+  it('shows the no-matches empty state when a search has no team matches', () => {
+    render(<TeamsSettingsPage teams={[createTeam()]} />);
+
+    fireEvent.change(
+      screen.getByPlaceholderText('teams.filters.searchPlaceholder'),
+      {
+        target: { value: 'missing' },
+      },
+    );
+
+    expect(screen.getByText('teams.list.noMatchesTitle')).toBeTruthy();
+    expect(screen.queryByText('City Services')).toBeNull();
   });
 });

--- a/ayunis-core-frontend/src/pages/admin-settings/teams-settings/ui/TeamsSettingsPage.tsx
+++ b/ayunis-core-frontend/src/pages/admin-settings/teams-settings/ui/TeamsSettingsPage.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button } from '@/shared/ui/shadcn/button';
 import { TeamsList } from './TeamsList';
+import TeamsFilters from './TeamsFilters';
 import { CreateTeamDialog } from './CreateTeamDialog';
 import { EditTeamDialog } from './EditTeamDialog';
 import SettingsLayout from '../../admin-settings-layout';
@@ -17,6 +18,12 @@ export function TeamsSettingsPage({ teams }: Readonly<TeamsSettingsPageProps>) {
   const { t: tLayout } = useTranslation('admin-settings-layout');
   const [createDialogOpen, setCreateDialogOpen] = useState(false);
   const [editTeam, setEditTeam] = useState<Team | null>(null);
+  const [search, setSearch] = useState('');
+
+  const normalizedSearch = search.trim().toLowerCase();
+  const filteredTeams = teams.filter((team) =>
+    team.name.toLowerCase().includes(normalizedSearch),
+  );
 
   const headerActions = (
     <div className="flex gap-2">
@@ -30,7 +37,12 @@ export function TeamsSettingsPage({ teams }: Readonly<TeamsSettingsPageProps>) {
   return (
     <SettingsLayout action={headerActions} title={tLayout('layout.teams')}>
       <div className="space-y-4">
-        <TeamsList teams={teams} onEditTeam={setEditTeam} />
+        <TeamsFilters value={search} onChange={setSearch} />
+        <TeamsList
+          teams={filteredTeams}
+          onEditTeam={setEditTeam}
+          hasFilters={normalizedSearch.length > 0}
+        />
 
         <CreateTeamDialog
           open={createDialogOpen}

--- a/ayunis-core-frontend/src/pages/admin-settings/teams-settings/ui/TeamsSettingsPage.tsx
+++ b/ayunis-core-frontend/src/pages/admin-settings/teams-settings/ui/TeamsSettingsPage.tsx
@@ -3,6 +3,10 @@ import { useTranslation } from 'react-i18next';
 import { Button } from '@/shared/ui/shadcn/button';
 import { TeamsList } from './TeamsList';
 import TeamsFilters from './TeamsFilters';
+import {
+  CreateFirstTeamEmptyState,
+  NoTeamsFoundEmptyState,
+} from './TeamsEmptyState';
 import { CreateTeamDialog } from './CreateTeamDialog';
 import { EditTeamDialog } from './EditTeamDialog';
 import SettingsLayout from '../../admin-settings-layout';
@@ -25,6 +29,11 @@ export function TeamsSettingsPage({ teams }: Readonly<TeamsSettingsPageProps>) {
   const filteredTeams = teams.filter((team) =>
     team.name.toLowerCase().includes(normalizedSearch),
   );
+  const hasSearch = normalizedSearch.length > 0;
+  const hasVisibleTeams = filteredTeams.length > 0;
+  const showCreateFirstTeamEmptyState = !hasTeams;
+  const showNoTeamsFoundEmptyState = hasTeams && hasSearch && !hasVisibleTeams;
+  const showTeamsList = hasTeams && hasVisibleTeams;
 
   const headerActions = (
     <div className="flex gap-2">
@@ -39,11 +48,11 @@ export function TeamsSettingsPage({ teams }: Readonly<TeamsSettingsPageProps>) {
     <SettingsLayout action={headerActions} title={tLayout('layout.teams')}>
       <div className="space-y-4">
         {hasTeams && <TeamsFilters value={search} onChange={setSearch} />}
-        <TeamsList
-          teams={filteredTeams}
-          onEditTeam={setEditTeam}
-          hasFilters={hasTeams && normalizedSearch.length > 0}
-        />
+        {showCreateFirstTeamEmptyState && <CreateFirstTeamEmptyState />}
+        {showNoTeamsFoundEmptyState && <NoTeamsFoundEmptyState />}
+        {showTeamsList && (
+          <TeamsList teams={filteredTeams} onEditTeam={setEditTeam} />
+        )}
 
         <CreateTeamDialog
           open={createDialogOpen}

--- a/ayunis-core-frontend/src/pages/admin-settings/teams-settings/ui/TeamsSettingsPage.tsx
+++ b/ayunis-core-frontend/src/pages/admin-settings/teams-settings/ui/TeamsSettingsPage.tsx
@@ -20,6 +20,7 @@ export function TeamsSettingsPage({ teams }: Readonly<TeamsSettingsPageProps>) {
   const [editTeam, setEditTeam] = useState<Team | null>(null);
   const [search, setSearch] = useState('');
 
+  const hasTeams = teams.length > 0;
   const normalizedSearch = search.trim().toLowerCase();
   const filteredTeams = teams.filter((team) =>
     team.name.toLowerCase().includes(normalizedSearch),
@@ -37,11 +38,11 @@ export function TeamsSettingsPage({ teams }: Readonly<TeamsSettingsPageProps>) {
   return (
     <SettingsLayout action={headerActions} title={tLayout('layout.teams')}>
       <div className="space-y-4">
-        <TeamsFilters value={search} onChange={setSearch} />
+        {hasTeams && <TeamsFilters value={search} onChange={setSearch} />}
         <TeamsList
           teams={filteredTeams}
           onEditTeam={setEditTeam}
-          hasFilters={normalizedSearch.length > 0}
+          hasFilters={hasTeams && normalizedSearch.length > 0}
         />
 
         <CreateTeamDialog

--- a/ayunis-core-frontend/src/shared/locales/de/admin-settings-teams.json
+++ b/ayunis-core-frontend/src/shared/locales/de/admin-settings-teams.json
@@ -3,9 +3,14 @@
     "page": {
       "add": "Team hinzufügen"
     },
+    "filters": {
+      "searchPlaceholder": "Teams suchen..."
+    },
     "list": {
       "emptyTitle": "Noch keine Teams",
       "emptyDescription": "Erstellen Sie Ihr erstes Team, um Ihre Benutzer zu organisieren.",
+      "noMatchesTitle": "Keine Teams gefunden",
+      "noMatchesDescription": "Keine Teams entsprechen Ihrer Suche.",
       "createdAt": "Erstellt am {{date}}",
       "memberCount_one": "{{count}} Mitglied",
       "memberCount_other": "{{count}} Mitglieder"

--- a/ayunis-core-frontend/src/shared/locales/en/admin-settings-teams.json
+++ b/ayunis-core-frontend/src/shared/locales/en/admin-settings-teams.json
@@ -3,9 +3,14 @@
     "page": {
       "add": "Add Team"
     },
+    "filters": {
+      "searchPlaceholder": "Search teams..."
+    },
     "list": {
       "emptyTitle": "No teams yet",
       "emptyDescription": "Create your first team to organize your users.",
+      "noMatchesTitle": "No teams found",
+      "noMatchesDescription": "No teams match your search.",
       "createdAt": "Created {{date}}",
       "memberCount_one": "{{count}} member",
       "memberCount_other": "{{count}} members"

--- a/scripts/check-duplication.sh
+++ b/scripts/check-duplication.sh
@@ -48,9 +48,13 @@ trap 'rm -rf "$REPORT_DIR"' EXIT
 # - generated/**, *.gen.ts & migrations/**: auto-generated code (e.g. route tree)
 # - *.spec/test.*: test files
 # - *.entity.ts & *.record.ts: TypeORM entities/records (constructor param forwarding is intentional)
+#
+# Pin to jscpd@4: v5 (2026-06-08) is a Rust rewrite with an incompatible CLI
+# (renamed to `cpd`, dropped --ignore/--reporters/--output/--silent), which
+# breaks this invocation. Unpin once the script is migrated to the v5 flags.
 (
   cd "$PROJECT_DIR"
-  pnpm dlx jscpd src \
+  pnpm dlx jscpd@4 src \
     --threshold 100 \
     --min-lines "$MIN_LINES" \
     --min-tokens "$MIN_TOKENS" \


### PR DESCRIPTION
- Add TeamsFilters search input (magnifier icon, auto-focus) mirroring
  the /chats search bar
- Filter the loaded teams array client-side, case-insensitive by name
- Show a 'No teams found' empty state for non-matching searches,
  distinct from the create-first-team state
- Add EN/DE i18n keys for placeholder and no-match copy
- Pin jscpd@4 in check-duplication.sh: v5 (released 2026-06-08) is a
  Rust rewrite with an incompatible CLI that broke the pre-commit
  duplication check

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Admin UI-only filtering on already-loaded team data; the jscpd pin is a dev-tooling fix with no runtime impact.
> 
> **Overview**
> Adds **client-side team search** on the admin teams overview: a new `TeamsFilters` search field (icon, auto-focus) appears only when at least one team exists, and `TeamsSettingsPage` filters teams by name case-insensitively before rendering the list.
> 
> Empty states are split so **“no teams yet”** (create-first) and **“no teams match your search”** are shown from the page instead of inside `TeamsList`. EN/DE strings cover the placeholder and no-match copy. **`TeamsSettingsPage.test.tsx`** covers the three display modes.
> 
> Separately, **`check-duplication.sh`** pins **`jscpd@4`** because jscpd v5’s CLI changes broke the pre-commit duplication check.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8bcf42d710782ca1a1bd81297828a67a80016014. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->