### PR TITLE
fix(chat): prevent browser auto-translate from corrupting streamed messages (AYC-220)

### DIFF
--- a/ayunis-core-frontend/index.html
+++ b/ayunis-core-frontend/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="de">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/ayunis-core-frontend/src/i18n.ts
+++ b/ayunis-core-frontend/src/i18n.ts
@@ -133,6 +133,13 @@ const resources = {
 //   checkWhitelist: true,
 // };
 
+// Keep <html lang> in sync with the active locale. A mismatched lang
+// (e.g. lang="en" on German content) triggers Chrome auto-translate,
+// which rewrites DOM text nodes and corrupts streamed assistant messages.
+i18n.on('languageChanged', (lng) => {
+  document.documentElement.lang = lng;
+});
+
 void i18n
   // detect user language
   //.use(LanguageDetector)

--- a/ayunis-core-frontend/src/pages/chat/ui/agent-run-timeline/ui/AgentRunTimeline.tsx
+++ b/ayunis-core-frontend/src/pages/chat/ui/agent-run-timeline/ui/AgentRunTimeline.tsx
@@ -41,7 +41,12 @@ export default function AgentRunTimeline({
   const showHeader = stepCount > 0;
 
   return (
-    <div className="flex flex-col gap-3 w-full">
+    // translate="no" while streaming: browser page translation rewrites
+    // text nodes mid-stream, freezing each paragraph at its first chunk.
+    <div
+      className="flex flex-col gap-3 w-full"
+      translate={unit.isStreaming ? 'no' : undefined}
+    >
       {showHeader && (
         <Collapsible open={open} onOpenChange={setUserOpen}>
           <div className="rounded-lg border border-border bg-muted/30">


### PR DESCRIPTION
- set html lang to de and sync it with the active i18n locale; the
  hardcoded lang="en" on German content made Chrome offer/auto-run
  page translation
- mark the streaming agent run container translate="no" so translation
  cannot rewrite text nodes mid-stream, which froze each paragraph at
  its first streamed chunk

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted UI/i18n DOM changes with no auth, API, or data-handling impact.
> 
> **Overview**
> Fixes **Chrome auto-translate** breaking **live assistant output** by aligning document language with i18n and blocking translation on the streaming timeline.
> 
> **`index.html`** now uses **`lang="de"`** instead of **`en`**, matching the app’s German default. **`i18n.ts`** adds a **`languageChanged`** listener that sets **`document.documentElement.lang`** to the active locale so the browser doesn’t treat German UI as English and offer or run page translation.
> 
> While an agent run is streaming, **`AgentRunTimeline`** sets **`translate="no"`** on its root container so translation can’t rewrite DOM text nodes mid-stream (which left paragraphs stuck at their first chunk). The attribute is removed when streaming finishes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a89fcc30f704d95c674aa703e25a98101c5724d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->