### PR TITLE
wip(anonymization): add pii category taxonomy and detection-only port (AYC-59)

### DIFF
--- a/ayunis-core-backend/src/common/anonymization/application/ports/anonymization.port.ts
+++ b/ayunis-core-backend/src/common/anonymization/application/ports/anonymization.port.ts
@@ -1,5 +1,9 @@
+import type { PiiCategory } from '../../domain/pii-category.enum';
+import type { PiiDetection } from '../../domain/pii-detection';
+
 export interface AnonymizationReplacement {
   entityType: string;
+  category?: PiiCategory;
   originalValue: string;
   start: number;
   end: number;
@@ -12,9 +16,12 @@ export interface AnonymizationResult {
   replacements: AnonymizationReplacement[];
 }
 
+/**
+ * Detection-only engine port. Adapters detect PII spans (non-overlapping)
+ * and map their engine-specific entity types onto the PiiCategory taxonomy;
+ * whitelist filtering and placeholder replacement happen in the application
+ * layer.
+ */
 export abstract class AnonymizationPort {
-  abstract anonymize(
-    text: string,
-    entities?: string[],
-  ): Promise<AnonymizationResult>;
+  abstract detect(text: string, entities?: string[]): Promise<PiiDetection[]>;
 }

--- a/ayunis-core-backend/src/common/anonymization/application/use-cases/anonymize-text/anonymize-text.command.ts
+++ b/ayunis-core-backend/src/common/anonymization/application/use-cases/anonymize-text/anonymize-text.command.ts
@@ -1,6 +1,9 @@
+import type { PiiWhitelistEntry } from '../../../domain/pii-whitelist-entry';
+
 export class AnonymizeTextCommand {
   constructor(
     public readonly text: string,
     public readonly entities?: string[],
+    public readonly whitelist?: PiiWhitelistEntry[],
   ) {}
 }

--- a/ayunis-core-backend/src/common/anonymization/application/use-cases/anonymize-text/anonymize-text.use-case.spec.ts
+++ b/ayunis-core-backend/src/common/anonymization/application/use-cases/anonymize-text/anonymize-text.use-case.spec.ts
@@ -1,0 +1,75 @@
+import { Logger } from '@nestjs/common';
+import { AnonymizeTextUseCase } from './anonymize-text.use-case';
+import { AnonymizeTextCommand } from './anonymize-text.command';
+import { PiiCategory } from '../../../domain/pii-category.enum';
+import type { PiiDetection } from '../../../domain/pii-detection';
+import { PiiWhitelistEntry } from '../../../domain/pii-whitelist-entry';
+
+describe('AnonymizeTextUseCase', () => {
+  let useCase: AnonymizeTextUseCase;
+  let detect: jest.Mock;
+
+  beforeEach(() => {
+    detect = jest.fn();
+    useCase = new AnonymizeTextUseCase({ detect });
+    jest.spyOn(Logger.prototype, 'log').mockImplementation();
+  });
+
+  const text = 'Ich bin der Dani, erreichbar unter amt32@stadt-marl.de';
+  const detections: PiiDetection[] = [
+    {
+      entityType: 'PERSON',
+      category: PiiCategory.PERSON_NAME,
+      text: 'Dani',
+      start: 12,
+      end: 16,
+      score: 0.9,
+    },
+    {
+      entityType: 'EMAIL_ADDRESS',
+      category: PiiCategory.EMAIL_ADDRESS,
+      text: 'amt32@stadt-marl.de',
+      start: 35,
+      end: 54,
+      score: 0.95,
+    },
+  ];
+
+  it('anonymizes all detections when no whitelist is given', async () => {
+    detect.mockResolvedValue(detections);
+
+    const result = await useCase.execute(new AnonymizeTextCommand(text));
+
+    expect(result.anonymizedText).toBe(
+      'Ich bin der [PERSON], erreichbar unter [EMAIL_ADDRESS]',
+    );
+    expect(result.replacements).toHaveLength(2);
+    expect(result.replacements[0]).toMatchObject({
+      entityType: 'PERSON',
+      category: PiiCategory.PERSON_NAME,
+      originalValue: 'Dani',
+    });
+  });
+
+  it('keeps whitelisted categories unmasked', async () => {
+    detect.mockResolvedValue(detections);
+    const whitelist = [new PiiWhitelistEntry(PiiCategory.EMAIL_ADDRESS, null)];
+
+    const result = await useCase.execute(
+      new AnonymizeTextCommand(text, undefined, whitelist),
+    );
+
+    expect(result.anonymizedText).toBe(
+      'Ich bin der [PERSON], erreichbar unter amt32@stadt-marl.de',
+    );
+    expect(result.replacements).toHaveLength(1);
+  });
+
+  it('passes the requested entity types through to the engine', async () => {
+    detect.mockResolvedValue([]);
+
+    await useCase.execute(new AnonymizeTextCommand(text, ['PERSON']));
+
+    expect(detect).toHaveBeenCalledWith(text, ['PERSON']);
+  });
+});

--- a/ayunis-core-backend/src/common/anonymization/application/use-cases/anonymize-text/anonymize-text.use-case.ts
+++ b/ayunis-core-backend/src/common/anonymization/application/use-cases/anonymize-text/anonymize-text.use-case.ts
@@ -4,6 +4,9 @@ import {
   AnonymizationResult,
 } from '../../ports/anonymization.port';
 import { AnonymizeTextCommand } from './anonymize-text.command';
+import { filterWhitelistedDetections } from '../../../domain/whitelist-filter';
+import { applyReplacements } from '../../../domain/apply-replacements';
+import { PiiDetection } from '../../../domain/pii-detection';
 
 @Injectable()
 export class AnonymizeTextUseCase {
@@ -15,8 +18,32 @@ export class AnonymizeTextUseCase {
     this.logger.log('Executing anonymize text', {
       textLength: command.text.length,
       entities: command.entities,
+      whitelistSize: command.whitelist?.length ?? 0,
     });
 
-    return this.anonymizationPort.anonymize(command.text, command.entities);
+    const detections = await this.anonymizationPort.detect(
+      command.text,
+      command.entities,
+    );
+    const remaining = command.whitelist?.length
+      ? filterWhitelistedDetections(detections, command.whitelist)
+      : detections;
+
+    return {
+      originalText: command.text,
+      anonymizedText: applyReplacements(command.text, remaining),
+      replacements: remaining.map((detection) => this.toReplacement(detection)),
+    };
+  }
+
+  private toReplacement(detection: PiiDetection) {
+    return {
+      entityType: detection.entityType,
+      category: detection.category,
+      originalValue: detection.text,
+      start: detection.start,
+      end: detection.end,
+      score: detection.score,
+    };
   }
 }

--- a/ayunis-core-backend/src/common/anonymization/domain/apply-replacements.spec.ts
+++ b/ayunis-core-backend/src/common/anonymization/domain/apply-replacements.spec.ts
@@ -1,0 +1,53 @@
+import { applyReplacements } from './apply-replacements';
+import { PiiCategory } from './pii-category.enum';
+import type { PiiDetection } from './pii-detection';
+
+describe('applyReplacements', () => {
+  it('replaces a single detection with its entity type placeholder', () => {
+    const text = 'Ich bin der Dani';
+    const detections: PiiDetection[] = [
+      {
+        entityType: 'PERSON',
+        category: PiiCategory.PERSON_NAME,
+        text: 'Dani',
+        start: 12,
+        end: 16,
+        score: 0.9,
+      },
+    ];
+
+    expect(applyReplacements(text, detections)).toBe('Ich bin der [PERSON]');
+  });
+
+  it('replaces multiple detections while preserving earlier offsets', () => {
+    const text = 'Ich bin der Dani, ich komm aus Deisenhofen und bin Metzger';
+    const detections: PiiDetection[] = [
+      {
+        entityType: 'PERSON',
+        category: PiiCategory.PERSON_NAME,
+        text: 'Dani',
+        start: 12,
+        end: 16,
+        score: 0.9,
+      },
+      {
+        entityType: 'LOCATION',
+        category: PiiCategory.LOCATION,
+        text: 'Deisenhofen',
+        start: 31,
+        end: 42,
+        score: 0.9,
+      },
+    ];
+
+    expect(applyReplacements(text, detections)).toBe(
+      'Ich bin der [PERSON], ich komm aus [LOCATION] und bin Metzger',
+    );
+  });
+
+  it('returns the original text when there are no detections', () => {
+    const text = 'Der Wetterbericht für morgen sagt Regen voraus';
+
+    expect(applyReplacements(text, [])).toBe(text);
+  });
+});

--- a/ayunis-core-backend/src/common/anonymization/domain/apply-replacements.ts
+++ b/ayunis-core-backend/src/common/anonymization/domain/apply-replacements.ts
@@ -1,0 +1,27 @@
+import type { PiiDetection } from './pii-detection';
+
+/**
+ * Replaces each detected span with its `[ENTITY_TYPE]` placeholder.
+ * Detections must be non-overlapping (see dropOverlappingResults in the
+ * engine adapter); replacing from end to start preserves earlier offsets.
+ */
+export function applyReplacements(
+  text: string,
+  detections: PiiDetection[],
+): string {
+  if (detections.length === 0) {
+    return text;
+  }
+
+  const sorted = [...detections].sort((a, b) => b.end - a.end);
+
+  let anonymizedText = text;
+  for (const detection of sorted) {
+    anonymizedText =
+      anonymizedText.substring(0, detection.start) +
+      `[${detection.entityType}]` +
+      anonymizedText.substring(detection.end);
+  }
+
+  return anonymizedText;
+}

--- a/ayunis-core-backend/src/common/anonymization/domain/pii-category.enum.ts
+++ b/ayunis-core-backend/src/common/anonymization/domain/pii-category.enum.ts
@@ -1,0 +1,20 @@
+/**
+ * Engine-agnostic PII category taxonomy.
+ *
+ * Each anonymization engine adapter maps its own entity types onto these
+ * categories (see e.g. presidio-entity-category.mapper.ts). The mapping must
+ * be total in the engine→category direction; categories without a mapping on
+ * the current engine are simply dormant.
+ */
+export enum PiiCategory {
+  PERSON_NAME = 'person_name',
+  ORGANIZATION = 'organization',
+  LOCATION = 'location',
+  EMAIL_ADDRESS = 'email_address',
+  PHONE_NUMBER = 'phone_number',
+  URL_OR_IP = 'url_or_ip',
+  DATE_TIME = 'date_time',
+  FINANCIAL_ACCOUNT = 'financial_account',
+  GOVERNMENT_ID = 'government_id',
+  NATIONALITY_RELIGION_POLITICS = 'nationality_religion_politics',
+}

--- a/ayunis-core-backend/src/common/anonymization/domain/pii-detection.ts
+++ b/ayunis-core-backend/src/common/anonymization/domain/pii-detection.ts
@@ -1,0 +1,13 @@
+import type { PiiCategory } from './pii-category.enum';
+
+export interface PiiDetection {
+  /** Engine-specific entity type, e.g. Presidio's `IBAN_CODE`. */
+  entityType: string;
+  /** Engine-agnostic category; undefined when the engine emits an unmapped type. */
+  category?: PiiCategory;
+  /** The detected span text. */
+  text: string;
+  start: number;
+  end: number;
+  score: number;
+}

--- a/ayunis-core-backend/src/common/anonymization/domain/pii-whitelist-entry.ts
+++ b/ayunis-core-backend/src/common/anonymization/domain/pii-whitelist-entry.ts
@@ -1,0 +1,13 @@
+import type { PiiCategory } from './pii-category.enum';
+
+/**
+ * A single org whitelist rule: values of this category are exempt from
+ * anonymization — unconditionally when pattern is null, otherwise only when
+ * the full detected value matches the pattern (case-insensitive).
+ */
+export class PiiWhitelistEntry {
+  constructor(
+    public readonly category: PiiCategory,
+    public readonly pattern: string | null,
+  ) {}
+}

--- a/ayunis-core-backend/src/common/anonymization/domain/whitelist-filter.spec.ts
+++ b/ayunis-core-backend/src/common/anonymization/domain/whitelist-filter.spec.ts
@@ -1,0 +1,165 @@
+import { filterWhitelistedDetections } from './whitelist-filter';
+import { PiiCategory } from './pii-category.enum';
+import { PiiWhitelistEntry } from './pii-whitelist-entry';
+import type { PiiDetection } from './pii-detection';
+
+function detection(overrides: Partial<PiiDetection>): PiiDetection {
+  return {
+    entityType: 'PERSON',
+    category: PiiCategory.PERSON_NAME,
+    text: 'Daniel Benner',
+    start: 0,
+    end: 13,
+    score: 0.9,
+    ...overrides,
+  };
+}
+
+describe('filterWhitelistedDetections', () => {
+  it('exempts a detection whose category is whitelisted without a pattern', () => {
+    const detections = [
+      detection({
+        entityType: 'EMAIL_ADDRESS',
+        category: PiiCategory.EMAIL_ADDRESS,
+        text: 'sachbearbeitung@stadt-marl.de',
+      }),
+    ];
+    const entries = [new PiiWhitelistEntry(PiiCategory.EMAIL_ADDRESS, null)];
+
+    expect(filterWhitelistedDetections(detections, entries)).toHaveLength(0);
+  });
+
+  it('keeps detections whose category is not whitelisted', () => {
+    const detections = [
+      detection({
+        entityType: 'PHONE_NUMBER',
+        category: PiiCategory.PHONE_NUMBER,
+        text: '+49 2365 99-0',
+      }),
+    ];
+    const entries = [new PiiWhitelistEntry(PiiCategory.EMAIL_ADDRESS, null)];
+
+    expect(filterWhitelistedDetections(detections, entries)).toEqual(
+      detections,
+    );
+  });
+
+  it('returns all detections when the whitelist is empty', () => {
+    const detections = [detection({})];
+
+    expect(filterWhitelistedDetections(detections, [])).toEqual(detections);
+  });
+
+  it('exempts a value that fully matches the pattern', () => {
+    const detections = [
+      detection({
+        entityType: 'EMAIL_ADDRESS',
+        category: PiiCategory.EMAIL_ADDRESS,
+        text: 'amt32@stadt-marl.de',
+      }),
+    ];
+    const entries = [
+      new PiiWhitelistEntry(PiiCategory.EMAIL_ADDRESS, '.*@stadt-marl\\.de'),
+    ];
+
+    expect(filterWhitelistedDetections(detections, entries)).toHaveLength(0);
+  });
+
+  it('keeps a value that only partially matches the pattern', () => {
+    const detections = [
+      detection({
+        entityType: 'EMAIL_ADDRESS',
+        category: PiiCategory.EMAIL_ADDRESS,
+        text: 'privat@stadt-marl.de.example.org',
+      }),
+    ];
+    const entries = [
+      new PiiWhitelistEntry(PiiCategory.EMAIL_ADDRESS, '.*@stadt-marl\\.de'),
+    ];
+
+    expect(filterWhitelistedDetections(detections, entries)).toEqual(
+      detections,
+    );
+  });
+
+  it('matches patterns case-insensitively', () => {
+    const detections = [
+      detection({
+        entityType: 'PERSON',
+        category: PiiCategory.PERSON_NAME,
+        text: 'DANIEL',
+      }),
+    ];
+    const entries = [
+      new PiiWhitelistEntry(PiiCategory.PERSON_NAME, 'dani(el)?'),
+    ];
+
+    expect(filterWhitelistedDetections(detections, entries)).toHaveLength(0);
+  });
+
+  it('keeps the detection when the stored pattern is not a valid regex', () => {
+    const detections = [
+      detection({
+        entityType: 'PERSON',
+        category: PiiCategory.PERSON_NAME,
+        text: 'Daniel',
+      }),
+    ];
+    const entries = [new PiiWhitelistEntry(PiiCategory.PERSON_NAME, '([')];
+
+    expect(filterWhitelistedDetections(detections, entries)).toEqual(
+      detections,
+    );
+  });
+
+  it('never exempts a detection without a mapped category', () => {
+    const detections = [
+      detection({
+        entityType: 'CUSTOM_FUTURE_ENTITY',
+        category: undefined,
+        text: 'irgendein Wert',
+      }),
+    ];
+    const entries = Object.values(PiiCategory).map(
+      (category) => new PiiWhitelistEntry(category, null),
+    );
+
+    expect(filterWhitelistedDetections(detections, entries)).toEqual(
+      detections,
+    );
+  });
+
+  it('filters a mixed set of detections independently', () => {
+    const exemptByCategory = detection({
+      entityType: 'EMAIL_ADDRESS',
+      category: PiiCategory.EMAIL_ADDRESS,
+      text: 'amt32@stadt-marl.de',
+    });
+    const exemptByPattern = detection({
+      entityType: 'PERSON',
+      category: PiiCategory.PERSON_NAME,
+      text: 'Daniel',
+    });
+    const keptWrongPattern = detection({
+      entityType: 'PERSON',
+      category: PiiCategory.PERSON_NAME,
+      text: 'Moritz',
+    });
+    const keptNoEntry = detection({
+      entityType: 'PHONE_NUMBER',
+      category: PiiCategory.PHONE_NUMBER,
+      text: '+49 2365 99-0',
+    });
+    const entries = [
+      new PiiWhitelistEntry(PiiCategory.EMAIL_ADDRESS, null),
+      new PiiWhitelistEntry(PiiCategory.PERSON_NAME, 'dani(el)?'),
+    ];
+
+    const result = filterWhitelistedDetections(
+      [exemptByCategory, exemptByPattern, keptWrongPattern, keptNoEntry],
+      entries,
+    );
+
+    expect(result).toEqual([keptWrongPattern, keptNoEntry]);
+  });
+});

--- a/ayunis-core-backend/src/common/anonymization/domain/whitelist-filter.ts
+++ b/ayunis-core-backend/src/common/anonymization/domain/whitelist-filter.ts
@@ -1,0 +1,50 @@
+import type { PiiCategory } from './pii-category.enum';
+import type { PiiDetection } from './pii-detection';
+import type { PiiWhitelistEntry } from './pii-whitelist-entry';
+
+type EntriesByCategory = Map<PiiCategory, PiiWhitelistEntry>;
+
+/**
+ * Drops detections that the org whitelist exempts from anonymization.
+ * Fail-safe: detections without a mapped category and entries with invalid
+ * patterns never exempt anything.
+ */
+export function filterWhitelistedDetections(
+  detections: PiiDetection[],
+  entries: PiiWhitelistEntry[],
+): PiiDetection[] {
+  if (entries.length === 0) {
+    return detections;
+  }
+  const entriesByCategory = new Map(
+    entries.map((entry) => [entry.category, entry]),
+  );
+  return detections.filter(
+    (detection) => !isExempt(detection, entriesByCategory),
+  );
+}
+
+export function isExempt(
+  detection: PiiDetection,
+  entriesByCategory: EntriesByCategory,
+): boolean {
+  if (!detection.category) {
+    return false;
+  }
+  const entry = entriesByCategory.get(detection.category);
+  if (!entry) {
+    return false;
+  }
+  if (entry.pattern === null) {
+    return true;
+  }
+  return fullyMatches(entry.pattern, detection.text);
+}
+
+export function fullyMatches(pattern: string, value: string): boolean {
+  try {
+    return new RegExp(`^(?:${pattern})$`, 'i').test(value);
+  } catch {
+    return false;
+  }
+}

--- a/ayunis-core-backend/src/common/anonymization/infrastructure/providers/presidio-anonymization.provider.spec.ts
+++ b/ayunis-core-backend/src/common/anonymization/infrastructure/providers/presidio-anonymization.provider.spec.ts
@@ -1,5 +1,7 @@
 import { Logger } from '@nestjs/common';
 import { PresidioAnonymizationProvider } from './presidio-anonymization.provider';
+import { PiiCategory } from '../../domain/pii-category.enum';
+import { AnonymizationFailedError } from '../../application/anonymization.errors';
 import type { RecognizerResult } from 'src/common/clients/anonymize/generated/mSPresidioPIIDetectionAPI.schemas';
 
 const mockAnalyzeTextAnalyzePost = jest.fn();
@@ -26,30 +28,57 @@ describe('PresidioAnonymizationProvider', () => {
     mockAnalyzeTextAnalyzePost.mockResolvedValue({ results });
   };
 
-  it('replaces a single detected entity with its type placeholder', async () => {
+  it('maps a detected entity to a detection with span text and category', async () => {
     const text = 'Ich bin der Dani';
     mockResults([{ entity_type: 'PERSON', start: 12, end: 16, score: 0.9 }]);
 
-    const result = await provider.anonymize(text);
+    const detections = await provider.detect(text);
 
-    expect(result.anonymizedText).toBe('Ich bin der [PERSON]');
+    expect(detections).toEqual([
+      {
+        entityType: 'PERSON',
+        category: PiiCategory.PERSON_NAME,
+        text: 'Dani',
+        start: 12,
+        end: 16,
+        score: 0.9,
+      },
+    ]);
   });
 
-  it('replaces multiple non-overlapping entities in a single pass', async () => {
-    const text = 'Ich bin der Dani, ich komm aus Deisenhofen und bin Metzger';
+  it('maps Presidio entity types onto the engine-agnostic taxonomy', async () => {
+    const text = 'x'.repeat(100);
     mockResults([
-      { entity_type: 'PERSON', start: 12, end: 16, score: 0.9 },
-      { entity_type: 'LOCATION', start: 31, end: 42, score: 0.9 },
+      { entity_type: 'URL', start: 0, end: 5, score: 0.9 },
+      { entity_type: 'IP_ADDRESS', start: 10, end: 15, score: 0.9 },
+      { entity_type: 'IBAN_CODE', start: 20, end: 25, score: 0.9 },
+      { entity_type: 'US_SSN', start: 30, end: 35, score: 0.9 },
+      { entity_type: 'NRP', start: 40, end: 45, score: 0.9 },
     ]);
 
-    const result = await provider.anonymize(text);
+    const detections = await provider.detect(text);
 
-    expect(result.anonymizedText).toBe(
-      'Ich bin der [PERSON], ich komm aus [LOCATION] und bin Metzger',
-    );
+    expect(detections.map((d) => d.category)).toEqual([
+      PiiCategory.URL_OR_IP,
+      PiiCategory.URL_OR_IP,
+      PiiCategory.FINANCIAL_ACCOUNT,
+      PiiCategory.GOVERNMENT_ID,
+      PiiCategory.NATIONALITY_RELIGION_POLITICS,
+    ]);
   });
 
-  it('collapses overlapping spans sharing an end position into one replacement', async () => {
+  it('leaves the category undefined for unmapped entity types', async () => {
+    const text = 'mein Geheimnis: hunter2';
+    mockResults([
+      { entity_type: 'FUTURE_SECRET_TYPE', start: 16, end: 23, score: 0.8 },
+    ]);
+
+    const detections = await provider.detect(text);
+
+    expect(detections[0].category).toBeUndefined();
+  });
+
+  it('collapses overlapping spans sharing an end position', async () => {
     const text = 'Ich bin der Dani, ich komm aus Deisenhofen und bin Metzger';
     mockResults([
       { entity_type: 'PERSON', start: 0, end: 16, score: 0.85 },
@@ -57,35 +86,45 @@ describe('PresidioAnonymizationProvider', () => {
       { entity_type: 'LOCATION', start: 31, end: 42, score: 0.9 },
     ]);
 
-    const result = await provider.anonymize(text);
+    const detections = await provider.detect(text);
 
-    expect(result.anonymizedText).not.toContain('[PERSON]SON]');
-    expect(result.anonymizedText).toBe(
-      '[PERSON], ich komm aus [LOCATION] und bin Metzger',
-    );
-    expect(result.replacements).toHaveLength(2);
+    expect(detections).toHaveLength(2);
+    expect(detections[0]).toMatchObject({ start: 0, end: 16 });
   });
 
-  it('collapses nested spans sharing a start position into one replacement', async () => {
+  it('collapses nested spans sharing a start position', async () => {
     const text = 'Berlin University is in Germany';
     mockResults([
       { entity_type: 'LOCATION', start: 0, end: 6, score: 0.8 },
       { entity_type: 'ORGANIZATION', start: 0, end: 17, score: 0.9 },
     ]);
 
-    const result = await provider.anonymize(text);
+    const detections = await provider.detect(text);
 
-    expect(result.anonymizedText).toBe('[ORGANIZATION] is in Germany');
-    expect(result.replacements).toHaveLength(1);
+    expect(detections).toHaveLength(1);
+    expect(detections[0]).toMatchObject({
+      entityType: 'ORGANIZATION',
+      text: 'Berlin University',
+    });
   });
 
-  it('returns the original text when no entities are detected', async () => {
-    const text = 'Der Wetterbericht für morgen sagt Regen voraus';
+  it('returns no detections when the service finds no entities', async () => {
     mockResults([]);
 
-    const result = await provider.anonymize(text);
+    const detections = await provider.detect(
+      'Der Wetterbericht für morgen sagt Regen voraus',
+    );
 
-    expect(result.anonymizedText).toBe(text);
-    expect(result.replacements).toHaveLength(0);
+    expect(detections).toHaveLength(0);
+  });
+
+  it('throws AnonymizationFailedError when the service call fails', async () => {
+    mockAnalyzeTextAnalyzePost.mockRejectedValue(
+      new Error('connect ECONNREFUSED'),
+    );
+
+    await expect(provider.detect('Ich bin der Dani')).rejects.toThrow(
+      AnonymizationFailedError,
+    );
   });
 });

--- a/ayunis-core-backend/src/common/anonymization/infrastructure/providers/presidio-anonymization.provider.ts
+++ b/ayunis-core-backend/src/common/anonymization/infrastructure/providers/presidio-anonymization.provider.ts
@@ -1,10 +1,8 @@
 import { Injectable, Logger } from '@nestjs/common';
-import {
-  AnonymizationPort,
-  AnonymizationResult,
-  AnonymizationReplacement,
-} from '../../application/ports/anonymization.port';
+import { AnonymizationPort } from '../../application/ports/anonymization.port';
 import { AnonymizationFailedError } from '../../application/anonymization.errors';
+import { PiiDetection } from '../../domain/pii-detection';
+import { mapPresidioEntityToCategory } from './presidio-entity-category.mapper';
 import { getMSPresidioPIIDetectionAPI } from 'src/common/clients/anonymize/generated/mSPresidioPIIDetectionAPI';
 import type { RecognizerResult } from 'src/common/clients/anonymize/generated/mSPresidioPIIDetectionAPI.schemas';
 
@@ -12,11 +10,8 @@ import type { RecognizerResult } from 'src/common/clients/anonymize/generated/mS
 export class PresidioAnonymizationProvider extends AnonymizationPort {
   private readonly logger = new Logger(PresidioAnonymizationProvider.name);
 
-  async anonymize(
-    text: string,
-    entities?: string[],
-  ): Promise<AnonymizationResult> {
-    this.logger.debug('Anonymizing text', {
+  async detect(text: string, entities?: string[]): Promise<PiiDetection[]> {
+    this.logger.debug('Detecting PII', {
       textLength: text.length,
       entities,
     });
@@ -32,25 +27,18 @@ export class PresidioAnonymizationProvider extends AnonymizationPort {
       const nonOverlappingResults = this.dropOverlappingResults(
         response.results,
       );
-      const replacements = this.buildReplacements(text, nonOverlappingResults);
-      const anonymizedText = this.applyReplacements(
-        text,
-        nonOverlappingResults,
+      const detections = nonOverlappingResults.map((result) =>
+        this.toDetection(text, result),
       );
 
-      this.logger.debug('Anonymization complete', {
-        originalLength: text.length,
-        anonymizedLength: anonymizedText.length,
-        replacementCount: replacements.length,
+      this.logger.debug('PII detection complete', {
+        textLength: text.length,
+        detectionCount: detections.length,
       });
 
-      return {
-        originalText: text,
-        anonymizedText,
-        replacements,
-      };
+      return detections;
     } catch (error: unknown) {
-      this.logger.error('Anonymization failed', { error: error as Error });
+      this.logger.error('PII detection failed', { error: error as Error });
       throw new AnonymizationFailedError(
         error instanceof Error ? error.message : 'Unknown error',
         { error: error as Error },
@@ -58,38 +46,15 @@ export class PresidioAnonymizationProvider extends AnonymizationPort {
     }
   }
 
-  private buildReplacements(
-    text: string,
-    results: RecognizerResult[],
-  ): AnonymizationReplacement[] {
-    return results.map((result) => ({
+  private toDetection(text: string, result: RecognizerResult): PiiDetection {
+    return {
       entityType: result.entity_type,
-      originalValue: text.substring(result.start, result.end),
+      category: mapPresidioEntityToCategory(result.entity_type),
+      text: text.substring(result.start, result.end),
       start: result.start,
       end: result.end,
       score: result.score,
-    }));
-  }
-
-  private applyReplacements(text: string, results: RecognizerResult[]): string {
-    if (results.length === 0) {
-      return text;
-    }
-
-    // Sort by end position descending to replace from end to start
-    // This preserves character positions for earlier replacements
-    const sortedResults = [...results].sort((a, b) => b.end - a.end);
-
-    let anonymizedText = text;
-    for (const result of sortedResults) {
-      const replacement = `[${result.entity_type}]`;
-      anonymizedText =
-        anonymizedText.substring(0, result.start) +
-        replacement +
-        anonymizedText.substring(result.end);
-    }
-
-    return anonymizedText;
+    };
   }
 
   // GLiNER runs with flat_ner=False and can return nested/overlapping spans

--- a/ayunis-core-backend/src/common/anonymization/infrastructure/providers/presidio-entity-category.mapper.ts
+++ b/ayunis-core-backend/src/common/anonymization/infrastructure/providers/presidio-entity-category.mapper.ts
@@ -1,0 +1,30 @@
+import { PiiCategory } from '../../domain/pii-category.enum';
+
+const PRESIDIO_ENTITY_TO_CATEGORY: Record<string, PiiCategory> = {
+  PERSON: PiiCategory.PERSON_NAME,
+  ORGANIZATION: PiiCategory.ORGANIZATION,
+  LOCATION: PiiCategory.LOCATION,
+  EMAIL_ADDRESS: PiiCategory.EMAIL_ADDRESS,
+  PHONE_NUMBER: PiiCategory.PHONE_NUMBER,
+  URL: PiiCategory.URL_OR_IP,
+  IP_ADDRESS: PiiCategory.URL_OR_IP,
+  DATE_TIME: PiiCategory.DATE_TIME,
+  CREDIT_CARD: PiiCategory.FINANCIAL_ACCOUNT,
+  IBAN_CODE: PiiCategory.FINANCIAL_ACCOUNT,
+  US_BANK_NUMBER: PiiCategory.FINANCIAL_ACCOUNT,
+  US_SSN: PiiCategory.GOVERNMENT_ID,
+  PASSPORT: PiiCategory.GOVERNMENT_ID,
+  US_DRIVER_LICENSE: PiiCategory.GOVERNMENT_ID,
+  MEDICAL_LICENSE: PiiCategory.GOVERNMENT_ID,
+  NRP: PiiCategory.NATIONALITY_RELIGION_POLITICS,
+};
+
+/**
+ * Unmapped types return undefined, which the whitelist filter treats as
+ * never exemptable (fail-safe for entity types added to the engine later).
+ */
+export function mapPresidioEntityToCategory(
+  entityType: string,
+): PiiCategory | undefined {
+  return PRESIDIO_ENTITY_TO_CATEGORY[entityType];
+}


### PR DESCRIPTION
- Engine-agnostic PiiCategory enum (10 categories) mapped from
  Presidio entity types in the adapter
- AnonymizationPort reshaped to detect(); whitelist filtering and
  placeholder replacement are now pure domain functions
- AnonymizeTextCommand accepts an optional PiiWhitelistEntry list

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit cce7716b649b622d85f02b777e38af78f0d49528. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->