### PR TITLE
wip(anonymization): add org-scoped pii whitelist settings module (AYC-59)

### DIFF
--- a/ayunis-core-backend/package.json
+++ b/ayunis-core-backend/package.json
@@ -106,6 +106,7 @@
     "puppeteer-core": "^24.37.5",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",
+    "safe-regex2": "^5.1.1",
     "sanitize-html": "^2.17.1",
     "tiktoken": "^1.0.22",
     "typeorm": "^0.3.25",

--- a/ayunis-core-backend/src/app/app.module.ts
+++ b/ayunis-core-backend/src/app/app.module.ts
@@ -22,6 +22,7 @@ import { MarketplaceModule } from '../domain/marketplace/marketplace.module';
 import { UsageModule } from '../domain/usage/usage.module';
 import { TranscriptionsModule } from '../domain/transcriptions/transcriptions.module';
 import { ChatSettingsModule } from '../domain/chat-settings/chat-settings.module';
+import { AnonymizationSettingsModule } from '../domain/anonymization-settings/anonymization-settings.module';
 import { KnowledgeBasesModule } from '../domain/knowledge-bases/knowledge-bases.module';
 import { CrawlDomainGrantsModule } from '../domain/crawl-domain-grants/crawl-domain-grants.module';
 import { SkillTemplatesModule } from '../domain/skill-templates/skill-templates.module';
@@ -163,6 +164,7 @@ import { IntegrationsModule } from '../integrations/integrations.module';
     UsageModule,
     TranscriptionsModule,
     ChatSettingsModule,
+    AnonymizationSettingsModule,
     KnowledgeBasesModule,
     CrawlDomainGrantsModule,
     SkillTemplatesModule,

--- a/ayunis-core-backend/src/db/migrations/1781103662026-CreateAnonymizationWhitelistEntriesTable.ts
+++ b/ayunis-core-backend/src/db/migrations/1781103662026-CreateAnonymizationWhitelistEntriesTable.ts
@@ -1,0 +1,20 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class CreateAnonymizationWhitelistEntriesTable1781103662026 implements MigrationInterface {
+    name = 'CreateAnonymizationWhitelistEntriesTable1781103662026'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`CREATE TYPE "public"."anonymization_whitelist_entries_category_enum" AS ENUM('person_name', 'organization', 'location', 'email_address', 'phone_number', 'url_or_ip', 'date_time', 'financial_account', 'government_id', 'nationality_religion_politics')`);
+        await queryRunner.query(`CREATE TABLE "anonymization_whitelist_entries" ("id" character varying NOT NULL, "createdAt" TIMESTAMP NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP NOT NULL DEFAULT now(), "orgId" character varying NOT NULL, "category" "public"."anonymization_whitelist_entries_category_enum" NOT NULL, "pattern" text, CONSTRAINT "UQ_398e29bebe8413873fc849a16c4" UNIQUE ("orgId", "category"), CONSTRAINT "PK_87f703a36270e61894e2fba8163" PRIMARY KEY ("id"))`);
+        await queryRunner.query(`CREATE INDEX "IDX_afe776d2a9db9a54c762441699" ON "anonymization_whitelist_entries" ("orgId") `);
+        await queryRunner.query(`ALTER TABLE "anonymization_whitelist_entries" ADD CONSTRAINT "FK_afe776d2a9db9a54c762441699a" FOREIGN KEY ("orgId") REFERENCES "orgs"("id") ON DELETE CASCADE ON UPDATE NO ACTION`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "anonymization_whitelist_entries" DROP CONSTRAINT "FK_afe776d2a9db9a54c762441699a"`);
+        await queryRunner.query(`DROP INDEX "public"."IDX_afe776d2a9db9a54c762441699"`);
+        await queryRunner.query(`DROP TABLE "anonymization_whitelist_entries"`);
+        await queryRunner.query(`DROP TYPE "public"."anonymization_whitelist_entries_category_enum"`);
+    }
+
+}

--- a/ayunis-core-backend/src/domain/anonymization-settings/anonymization-settings.module.ts
+++ b/ayunis-core-backend/src/domain/anonymization-settings/anonymization-settings.module.ts
@@ -1,0 +1,33 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+
+import { AnonymizationModule } from 'src/common/anonymization/anonymization.module';
+import { AnonymizationWhitelistEntryRecord } from './infrastructure/persistence/postgres/schema/anonymization-whitelist-entry.record';
+import { AnonymizationWhitelistRepository } from './application/ports/anonymization-whitelist.repository';
+import { PostgresAnonymizationWhitelistRepository } from './infrastructure/persistence/postgres/anonymization-whitelist.repository';
+
+import { GetPiiWhitelistUseCase } from './application/use-cases/get-pii-whitelist/get-pii-whitelist.use-case';
+import { UpdatePiiWhitelistUseCase } from './application/use-cases/update-pii-whitelist/update-pii-whitelist.use-case';
+import { AnonymizeTextForOrgUseCase } from './application/use-cases/anonymize-text-for-org/anonymize-text-for-org.use-case';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([AnonymizationWhitelistEntryRecord]),
+    AnonymizationModule,
+  ],
+  providers: [
+    {
+      provide: AnonymizationWhitelistRepository,
+      useClass: PostgresAnonymizationWhitelistRepository,
+    },
+    GetPiiWhitelistUseCase,
+    UpdatePiiWhitelistUseCase,
+    AnonymizeTextForOrgUseCase,
+  ],
+  exports: [
+    GetPiiWhitelistUseCase,
+    UpdatePiiWhitelistUseCase,
+    AnonymizeTextForOrgUseCase,
+  ],
+})
+export class AnonymizationSettingsModule {}

--- a/ayunis-core-backend/src/domain/anonymization-settings/application/anonymization-settings.errors.ts
+++ b/ayunis-core-backend/src/domain/anonymization-settings/application/anonymization-settings.errors.ts
@@ -1,0 +1,42 @@
+import type { ErrorMetadata } from 'src/common/errors/base.error';
+import { ApplicationError } from 'src/common/errors/base.error';
+import type { PiiCategory } from 'src/common/anonymization/domain/pii-category.enum';
+
+export enum AnonymizationSettingsErrorCode {
+  INVALID_PATTERN = 'INVALID_PATTERN',
+  DUPLICATE_CATEGORY = 'DUPLICATE_CATEGORY',
+  UNEXPECTED_ERROR = 'UNEXPECTED_ANONYMIZATION_SETTINGS_ERROR',
+}
+
+export class InvalidPatternError extends ApplicationError {
+  constructor(category: PiiCategory, reason: string, metadata?: ErrorMetadata) {
+    super(
+      `Invalid whitelist pattern for category ${category}: ${reason}`,
+      AnonymizationSettingsErrorCode.INVALID_PATTERN,
+      400,
+      { category, reason, ...metadata },
+    );
+  }
+}
+
+export class DuplicateCategoryError extends ApplicationError {
+  constructor(category: PiiCategory, metadata?: ErrorMetadata) {
+    super(
+      `Whitelist contains category ${category} more than once`,
+      AnonymizationSettingsErrorCode.DUPLICATE_CATEGORY,
+      400,
+      { category, ...metadata },
+    );
+  }
+}
+
+export class UnexpectedAnonymizationSettingsError extends ApplicationError {
+  constructor(operation: string, metadata?: ErrorMetadata) {
+    super(
+      `Unexpected anonymization settings error during ${operation}`,
+      AnonymizationSettingsErrorCode.UNEXPECTED_ERROR,
+      500,
+      { operation, ...metadata },
+    );
+  }
+}

--- a/ayunis-core-backend/src/domain/anonymization-settings/application/ports/anonymization-whitelist.repository.ts
+++ b/ayunis-core-backend/src/domain/anonymization-settings/application/ports/anonymization-whitelist.repository.ts
@@ -1,0 +1,10 @@
+import type { UUID } from 'crypto';
+import type { AnonymizationWhitelistEntry } from '../../domain/anonymization-whitelist-entry.entity';
+
+export abstract class AnonymizationWhitelistRepository {
+  abstract findByOrgId(orgId: UUID): Promise<AnonymizationWhitelistEntry[]>;
+  abstract replaceForOrg(
+    orgId: UUID,
+    entries: AnonymizationWhitelistEntry[],
+  ): Promise<AnonymizationWhitelistEntry[]>;
+}

--- a/ayunis-core-backend/src/domain/anonymization-settings/application/use-cases/anonymize-text-for-org/anonymize-text-for-org.command.ts
+++ b/ayunis-core-backend/src/domain/anonymization-settings/application/use-cases/anonymize-text-for-org/anonymize-text-for-org.command.ts
@@ -1,0 +1,8 @@
+import type { UUID } from 'crypto';
+
+export class AnonymizeTextForOrgCommand {
+  constructor(
+    public readonly text: string,
+    public readonly orgId: UUID,
+  ) {}
+}

--- a/ayunis-core-backend/src/domain/anonymization-settings/application/use-cases/anonymize-text-for-org/anonymize-text-for-org.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/anonymization-settings/application/use-cases/anonymize-text-for-org/anonymize-text-for-org.use-case.spec.ts
@@ -1,0 +1,83 @@
+import { Logger } from '@nestjs/common';
+import type { UUID } from 'crypto';
+import { AnonymizeTextForOrgUseCase } from './anonymize-text-for-org.use-case';
+import { AnonymizeTextForOrgCommand } from './anonymize-text-for-org.command';
+import type { AnonymizeTextUseCase } from 'src/common/anonymization/application/use-cases/anonymize-text/anonymize-text.use-case';
+import { PiiCategory } from 'src/common/anonymization/domain/pii-category.enum';
+import { PiiWhitelistEntry } from 'src/common/anonymization/domain/pii-whitelist-entry';
+import { AnonymizationWhitelistEntry } from '../../../domain/anonymization-whitelist-entry.entity';
+import { AnonymizationFailedError } from 'src/common/anonymization/application/anonymization.errors';
+
+describe('AnonymizeTextForOrgUseCase', () => {
+  const orgId = '0d4f9c5e-7a36-4b34-9c1b-2f8d6a1e5b3c' as UUID;
+  const text = 'Ich bin der Dani aus Marl';
+  let useCase: AnonymizeTextForOrgUseCase;
+  let findByOrgId: jest.Mock;
+  let anonymizeExecute: jest.Mock;
+
+  beforeEach(() => {
+    findByOrgId = jest.fn().mockResolvedValue([]);
+    anonymizeExecute = jest.fn().mockResolvedValue({
+      originalText: text,
+      anonymizedText: 'Ich bin der [PERSON] aus [LOCATION]',
+      replacements: [],
+    });
+    useCase = new AnonymizeTextForOrgUseCase(
+      {
+        findByOrgId,
+        replaceForOrg: jest.fn(),
+      },
+      { execute: anonymizeExecute } as unknown as AnonymizeTextUseCase,
+    );
+    jest.spyOn(Logger.prototype, 'debug').mockImplementation();
+    jest.spyOn(Logger.prototype, 'error').mockImplementation();
+  });
+
+  it('passes the org whitelist to the anonymization use case', async () => {
+    findByOrgId.mockResolvedValue([
+      new AnonymizationWhitelistEntry({
+        orgId,
+        category: PiiCategory.LOCATION,
+        pattern: null,
+      }),
+      new AnonymizationWhitelistEntry({
+        orgId,
+        category: PiiCategory.PERSON_NAME,
+        pattern: 'dani(el)?',
+      }),
+    ]);
+
+    await useCase.execute(new AnonymizeTextForOrgCommand(text, orgId));
+
+    expect(anonymizeExecute).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text,
+        whitelist: [
+          new PiiWhitelistEntry(PiiCategory.LOCATION, null),
+          new PiiWhitelistEntry(PiiCategory.PERSON_NAME, 'dani(el)?'),
+        ],
+      }),
+    );
+  });
+
+  it('delegates with an empty whitelist when the org has no entries', async () => {
+    const result = await useCase.execute(
+      new AnonymizeTextForOrgCommand(text, orgId),
+    );
+
+    expect(anonymizeExecute).toHaveBeenCalledWith(
+      expect.objectContaining({ text, whitelist: [] }),
+    );
+    expect(result.anonymizedText).toBe('Ich bin der [PERSON] aus [LOCATION]');
+  });
+
+  it('propagates engine failures unchanged for fail-safe handling', async () => {
+    anonymizeExecute.mockRejectedValue(
+      new AnonymizationFailedError('connect ECONNREFUSED'),
+    );
+
+    await expect(
+      useCase.execute(new AnonymizeTextForOrgCommand(text, orgId)),
+    ).rejects.toThrow(AnonymizationFailedError);
+  });
+});

--- a/ayunis-core-backend/src/domain/anonymization-settings/application/use-cases/anonymize-text-for-org/anonymize-text-for-org.use-case.ts
+++ b/ayunis-core-backend/src/domain/anonymization-settings/application/use-cases/anonymize-text-for-org/anonymize-text-for-org.use-case.ts
@@ -1,0 +1,53 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ApplicationError } from 'src/common/errors/base.error';
+import { AnonymizeTextUseCase } from 'src/common/anonymization/application/use-cases/anonymize-text/anonymize-text.use-case';
+import { AnonymizeTextCommand } from 'src/common/anonymization/application/use-cases/anonymize-text/anonymize-text.command';
+import { PiiWhitelistEntry } from 'src/common/anonymization/domain/pii-whitelist-entry';
+import type { AnonymizationResult } from 'src/common/anonymization/application/ports/anonymization.port';
+import { AnonymizationWhitelistRepository } from '../../ports/anonymization-whitelist.repository';
+import { UnexpectedAnonymizationSettingsError } from '../../anonymization-settings.errors';
+import type { AnonymizeTextForOrgCommand } from './anonymize-text-for-org.command';
+
+/**
+ * Anonymizes text while honoring the org's PII whitelist. Errors from the
+ * anonymization engine (AnonymizationFailedError) propagate unchanged so
+ * callers keep their fail-safe handling.
+ */
+@Injectable()
+export class AnonymizeTextForOrgUseCase {
+  private readonly logger = new Logger(AnonymizeTextForOrgUseCase.name);
+
+  constructor(
+    private readonly repository: AnonymizationWhitelistRepository,
+    private readonly anonymizeTextUseCase: AnonymizeTextUseCase,
+  ) {}
+
+  async execute(
+    command: AnonymizeTextForOrgCommand,
+  ): Promise<AnonymizationResult> {
+    this.logger.debug('Anonymizing text for org', { orgId: command.orgId });
+
+    try {
+      const entries = await this.repository.findByOrgId(command.orgId);
+      const whitelist = entries.map(
+        (entry) => new PiiWhitelistEntry(entry.category, entry.pattern),
+      );
+
+      return await this.anonymizeTextUseCase.execute(
+        new AnonymizeTextCommand(command.text, undefined, whitelist),
+      );
+    } catch (error) {
+      if (error instanceof ApplicationError) throw error;
+
+      this.logger.error('Failed to anonymize text for org', {
+        error: error instanceof Error ? error.message : 'Unknown error',
+        orgId: command.orgId,
+      });
+
+      throw new UnexpectedAnonymizationSettingsError('anonymize', {
+        orgId: command.orgId,
+        ...(error instanceof Error && { originalError: error.message }),
+      });
+    }
+  }
+}

--- a/ayunis-core-backend/src/domain/anonymization-settings/application/use-cases/get-pii-whitelist/get-pii-whitelist.query.ts
+++ b/ayunis-core-backend/src/domain/anonymization-settings/application/use-cases/get-pii-whitelist/get-pii-whitelist.query.ts
@@ -1,0 +1,5 @@
+import type { UUID } from 'crypto';
+
+export class GetPiiWhitelistQuery {
+  constructor(public readonly orgId: UUID) {}
+}

--- a/ayunis-core-backend/src/domain/anonymization-settings/application/use-cases/get-pii-whitelist/get-pii-whitelist.use-case.ts
+++ b/ayunis-core-backend/src/domain/anonymization-settings/application/use-cases/get-pii-whitelist/get-pii-whitelist.use-case.ts
@@ -1,0 +1,35 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ApplicationError } from 'src/common/errors/base.error';
+import { AnonymizationWhitelistRepository } from '../../ports/anonymization-whitelist.repository';
+import { UnexpectedAnonymizationSettingsError } from '../../anonymization-settings.errors';
+import type { GetPiiWhitelistQuery } from './get-pii-whitelist.query';
+import type { AnonymizationWhitelistEntry } from '../../../domain/anonymization-whitelist-entry.entity';
+
+@Injectable()
+export class GetPiiWhitelistUseCase {
+  private readonly logger = new Logger(GetPiiWhitelistUseCase.name);
+
+  constructor(private readonly repository: AnonymizationWhitelistRepository) {}
+
+  async execute(
+    query: GetPiiWhitelistQuery,
+  ): Promise<AnonymizationWhitelistEntry[]> {
+    this.logger.debug('Getting PII whitelist', { orgId: query.orgId });
+
+    try {
+      return await this.repository.findByOrgId(query.orgId);
+    } catch (error) {
+      if (error instanceof ApplicationError) throw error;
+
+      this.logger.error('Failed to get PII whitelist', {
+        error: error instanceof Error ? error.message : 'Unknown error',
+        orgId: query.orgId,
+      });
+
+      throw new UnexpectedAnonymizationSettingsError('get', {
+        orgId: query.orgId,
+        ...(error instanceof Error && { originalError: error.message }),
+      });
+    }
+  }
+}

--- a/ayunis-core-backend/src/domain/anonymization-settings/application/use-cases/update-pii-whitelist/update-pii-whitelist.command.ts
+++ b/ayunis-core-backend/src/domain/anonymization-settings/application/use-cases/update-pii-whitelist/update-pii-whitelist.command.ts
@@ -1,0 +1,14 @@
+import type { UUID } from 'crypto';
+import type { PiiCategory } from 'src/common/anonymization/domain/pii-category.enum';
+
+export interface UpdatePiiWhitelistEntryInput {
+  category: PiiCategory;
+  pattern: string | null;
+}
+
+export class UpdatePiiWhitelistCommand {
+  constructor(
+    public readonly orgId: UUID,
+    public readonly entries: UpdatePiiWhitelistEntryInput[],
+  ) {}
+}

--- a/ayunis-core-backend/src/domain/anonymization-settings/application/use-cases/update-pii-whitelist/update-pii-whitelist.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/anonymization-settings/application/use-cases/update-pii-whitelist/update-pii-whitelist.use-case.spec.ts
@@ -1,0 +1,104 @@
+import { Logger } from '@nestjs/common';
+import type { UUID } from 'crypto';
+import { UpdatePiiWhitelistUseCase } from './update-pii-whitelist.use-case';
+import { UpdatePiiWhitelistCommand } from './update-pii-whitelist.command';
+import type { AnonymizationWhitelistRepository } from '../../ports/anonymization-whitelist.repository';
+import {
+  DuplicateCategoryError,
+  InvalidPatternError,
+} from '../../anonymization-settings.errors';
+import { PiiCategory } from 'src/common/anonymization/domain/pii-category.enum';
+import type { AnonymizationWhitelistEntry } from '../../../domain/anonymization-whitelist-entry.entity';
+
+describe('UpdatePiiWhitelistUseCase', () => {
+  const orgId = '0d4f9c5e-7a36-4b34-9c1b-2f8d6a1e5b3c' as UUID;
+  let useCase: UpdatePiiWhitelistUseCase;
+  let replaceForOrg: jest.Mock;
+
+  beforeEach(() => {
+    replaceForOrg = jest
+      .fn()
+      .mockImplementation(
+        (_orgId: UUID, entries: AnonymizationWhitelistEntry[]) =>
+          Promise.resolve(entries),
+      );
+    const repository = {
+      findByOrgId: jest.fn(),
+      replaceForOrg,
+    } as unknown as AnonymizationWhitelistRepository;
+    useCase = new UpdatePiiWhitelistUseCase(repository);
+    jest.spyOn(Logger.prototype, 'debug').mockImplementation();
+    jest.spyOn(Logger.prototype, 'error').mockImplementation();
+  });
+
+  it('replaces the whitelist with validated entries', async () => {
+    const result = await useCase.execute(
+      new UpdatePiiWhitelistCommand(orgId, [
+        { category: PiiCategory.EMAIL_ADDRESS, pattern: null },
+        { category: PiiCategory.PERSON_NAME, pattern: 'dani(el)?' },
+      ]),
+    );
+
+    expect(replaceForOrg).toHaveBeenCalledWith(orgId, expect.any(Array));
+    expect(result).toHaveLength(2);
+    expect(result[0]).toMatchObject({
+      orgId,
+      category: PiiCategory.EMAIL_ADDRESS,
+      pattern: null,
+    });
+  });
+
+  it('clears the whitelist when given no entries', async () => {
+    const result = await useCase.execute(
+      new UpdatePiiWhitelistCommand(orgId, []),
+    );
+
+    expect(replaceForOrg).toHaveBeenCalledWith(orgId, []);
+    expect(result).toHaveLength(0);
+  });
+
+  it('rejects a whitelist containing the same category twice', async () => {
+    await expect(
+      useCase.execute(
+        new UpdatePiiWhitelistCommand(orgId, [
+          { category: PiiCategory.LOCATION, pattern: null },
+          { category: PiiCategory.LOCATION, pattern: 'Marl' },
+        ]),
+      ),
+    ).rejects.toThrow(DuplicateCategoryError);
+    expect(replaceForOrg).not.toHaveBeenCalled();
+  });
+
+  it('rejects a pattern with invalid regex syntax', async () => {
+    await expect(
+      useCase.execute(
+        new UpdatePiiWhitelistCommand(orgId, [
+          { category: PiiCategory.PERSON_NAME, pattern: '([' },
+        ]),
+      ),
+    ).rejects.toThrow(InvalidPatternError);
+    expect(replaceForOrg).not.toHaveBeenCalled();
+  });
+
+  it('rejects a pattern vulnerable to catastrophic backtracking', async () => {
+    await expect(
+      useCase.execute(
+        new UpdatePiiWhitelistCommand(orgId, [
+          { category: PiiCategory.URL_OR_IP, pattern: '(a+)+$' },
+        ]),
+      ),
+    ).rejects.toThrow(InvalidPatternError);
+    expect(replaceForOrg).not.toHaveBeenCalled();
+  });
+
+  it('rejects a pattern exceeding the length limit', async () => {
+    await expect(
+      useCase.execute(
+        new UpdatePiiWhitelistCommand(orgId, [
+          { category: PiiCategory.LOCATION, pattern: 'a'.repeat(201) },
+        ]),
+      ),
+    ).rejects.toThrow(InvalidPatternError);
+    expect(replaceForOrg).not.toHaveBeenCalled();
+  });
+});

--- a/ayunis-core-backend/src/domain/anonymization-settings/application/use-cases/update-pii-whitelist/update-pii-whitelist.use-case.ts
+++ b/ayunis-core-backend/src/domain/anonymization-settings/application/use-cases/update-pii-whitelist/update-pii-whitelist.use-case.ts
@@ -1,0 +1,79 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ApplicationError } from 'src/common/errors/base.error';
+import { AnonymizationWhitelistRepository } from '../../ports/anonymization-whitelist.repository';
+import {
+  DuplicateCategoryError,
+  InvalidPatternError,
+  UnexpectedAnonymizationSettingsError,
+} from '../../anonymization-settings.errors';
+import type {
+  UpdatePiiWhitelistCommand,
+  UpdatePiiWhitelistEntryInput,
+} from './update-pii-whitelist.command';
+import { AnonymizationWhitelistEntry } from '../../../domain/anonymization-whitelist-entry.entity';
+import { validatePattern } from '../../../domain/validate-pattern';
+import type { UUID } from 'crypto';
+
+@Injectable()
+export class UpdatePiiWhitelistUseCase {
+  private readonly logger = new Logger(UpdatePiiWhitelistUseCase.name);
+
+  constructor(private readonly repository: AnonymizationWhitelistRepository) {}
+
+  async execute(
+    command: UpdatePiiWhitelistCommand,
+  ): Promise<AnonymizationWhitelistEntry[]> {
+    this.logger.debug('Updating PII whitelist', {
+      orgId: command.orgId,
+      entryCount: command.entries.length,
+    });
+
+    try {
+      this.validateEntries(command.entries);
+      const entities = command.entries.map((entry) =>
+        this.toEntity(command.orgId, entry),
+      );
+      return await this.repository.replaceForOrg(command.orgId, entities);
+    } catch (error) {
+      if (error instanceof ApplicationError) throw error;
+
+      this.logger.error('Failed to update PII whitelist', {
+        error: error instanceof Error ? error.message : 'Unknown error',
+        orgId: command.orgId,
+      });
+
+      throw new UnexpectedAnonymizationSettingsError('update', {
+        orgId: command.orgId,
+        ...(error instanceof Error && { originalError: error.message }),
+      });
+    }
+  }
+
+  private validateEntries(entries: UpdatePiiWhitelistEntryInput[]): void {
+    const seen = new Set<string>();
+    for (const entry of entries) {
+      if (seen.has(entry.category)) {
+        throw new DuplicateCategoryError(entry.category);
+      }
+      seen.add(entry.category);
+
+      if (entry.pattern !== null) {
+        const validationError = validatePattern(entry.pattern);
+        if (validationError) {
+          throw new InvalidPatternError(entry.category, validationError);
+        }
+      }
+    }
+  }
+
+  private toEntity(
+    orgId: UUID,
+    entry: UpdatePiiWhitelistEntryInput,
+  ): AnonymizationWhitelistEntry {
+    return new AnonymizationWhitelistEntry({
+      orgId,
+      category: entry.category,
+      pattern: entry.pattern,
+    });
+  }
+}

--- a/ayunis-core-backend/src/domain/anonymization-settings/domain/anonymization-whitelist-entry.entity.ts
+++ b/ayunis-core-backend/src/domain/anonymization-settings/domain/anonymization-whitelist-entry.entity.ts
@@ -1,0 +1,34 @@
+import type { UUID } from 'crypto';
+import { randomUUID } from 'crypto';
+import type { PiiCategory } from 'src/common/anonymization/domain/pii-category.enum';
+
+export interface AnonymizationWhitelistEntryParams {
+  id?: UUID;
+  orgId: UUID;
+  category: PiiCategory;
+  pattern: string | null;
+  createdAt?: Date;
+  updatedAt?: Date;
+}
+
+/**
+ * Org-level rule exempting one PII category from anonymization, optionally
+ * restricted to values fully matching a regex pattern.
+ */
+export class AnonymizationWhitelistEntry {
+  id: UUID;
+  orgId: UUID;
+  category: PiiCategory;
+  pattern: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+
+  constructor(params: AnonymizationWhitelistEntryParams) {
+    this.id = params.id ?? randomUUID();
+    this.orgId = params.orgId;
+    this.category = params.category;
+    this.pattern = params.pattern;
+    this.createdAt = params.createdAt ?? new Date();
+    this.updatedAt = params.updatedAt ?? new Date();
+  }
+}

--- a/ayunis-core-backend/src/domain/anonymization-settings/domain/validate-pattern.spec.ts
+++ b/ayunis-core-backend/src/domain/anonymization-settings/domain/validate-pattern.spec.ts
@@ -1,0 +1,25 @@
+import { validatePattern, MAX_PATTERN_LENGTH } from './validate-pattern';
+
+describe('validatePattern', () => {
+  it('accepts a typical domain-anchoring pattern', () => {
+    expect(validatePattern('.*@stadt-marl\\.de')).toBeNull();
+  });
+
+  it('rejects an empty pattern', () => {
+    expect(validatePattern('')).toBe('empty');
+  });
+
+  it('rejects a pattern exceeding the length limit', () => {
+    expect(validatePattern('a'.repeat(MAX_PATTERN_LENGTH + 1))).toBe(
+      'too_long',
+    );
+  });
+
+  it('rejects a pattern with invalid regex syntax', () => {
+    expect(validatePattern('([')).toBe('invalid_syntax');
+  });
+
+  it('rejects a pattern vulnerable to catastrophic backtracking', () => {
+    expect(validatePattern('(a+)+$')).toBe('unsafe');
+  });
+});

--- a/ayunis-core-backend/src/domain/anonymization-settings/domain/validate-pattern.ts
+++ b/ayunis-core-backend/src/domain/anonymization-settings/domain/validate-pattern.ts
@@ -1,0 +1,34 @@
+import safeRegex from 'safe-regex2';
+
+export const MAX_PATTERN_LENGTH = 200;
+
+export type PatternValidationError =
+  | 'empty'
+  | 'too_long'
+  | 'invalid_syntax'
+  | 'unsafe';
+
+/**
+ * Validates an admin-supplied whitelist regex at save time. Patterns are
+ * later executed server-side against detected PII spans, so reject anything
+ * that does not compile or is vulnerable to catastrophic backtracking.
+ */
+export function validatePattern(
+  pattern: string,
+): PatternValidationError | null {
+  if (pattern.length === 0) {
+    return 'empty';
+  }
+  if (pattern.length > MAX_PATTERN_LENGTH) {
+    return 'too_long';
+  }
+  try {
+    new RegExp(pattern, 'i');
+  } catch {
+    return 'invalid_syntax';
+  }
+  if (!safeRegex(pattern)) {
+    return 'unsafe';
+  }
+  return null;
+}

--- a/ayunis-core-backend/src/domain/anonymization-settings/infrastructure/persistence/postgres/anonymization-whitelist.repository.ts
+++ b/ayunis-core-backend/src/domain/anonymization-settings/infrastructure/persistence/postgres/anonymization-whitelist.repository.ts
@@ -1,0 +1,55 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import type { UUID } from 'crypto';
+import { AnonymizationWhitelistRepository } from '../../../application/ports/anonymization-whitelist.repository';
+import { AnonymizationWhitelistEntry } from '../../../domain/anonymization-whitelist-entry.entity';
+import { AnonymizationWhitelistEntryRecord } from './schema/anonymization-whitelist-entry.record';
+import { AnonymizationWhitelistEntryMapper } from './mappers/anonymization-whitelist-entry.mapper';
+
+@Injectable()
+export class PostgresAnonymizationWhitelistRepository extends AnonymizationWhitelistRepository {
+  private readonly logger = new Logger(
+    PostgresAnonymizationWhitelistRepository.name,
+  );
+
+  constructor(
+    @InjectRepository(AnonymizationWhitelistEntryRecord)
+    private readonly repository: Repository<AnonymizationWhitelistEntryRecord>,
+  ) {
+    super();
+  }
+
+  async findByOrgId(orgId: UUID): Promise<AnonymizationWhitelistEntry[]> {
+    this.logger.debug('findByOrgId', { orgId });
+
+    const records = await this.repository.find({
+      where: { orgId },
+      order: { category: 'ASC' },
+    });
+
+    return records.map((record) =>
+      AnonymizationWhitelistEntryMapper.toDomain(record),
+    );
+  }
+
+  async replaceForOrg(
+    orgId: UUID,
+    entries: AnonymizationWhitelistEntry[],
+  ): Promise<AnonymizationWhitelistEntry[]> {
+    this.logger.debug('replaceForOrg', { orgId, entryCount: entries.length });
+
+    await this.repository.manager.transaction(async (manager) => {
+      await manager.delete(AnonymizationWhitelistEntryRecord, { orgId });
+      if (entries.length > 0) {
+        await manager.save(
+          entries.map((entry) =>
+            AnonymizationWhitelistEntryMapper.toRecord(entry),
+          ),
+        );
+      }
+    });
+
+    return this.findByOrgId(orgId);
+  }
+}

--- a/ayunis-core-backend/src/domain/anonymization-settings/infrastructure/persistence/postgres/mappers/anonymization-whitelist-entry.mapper.ts
+++ b/ayunis-core-backend/src/domain/anonymization-settings/infrastructure/persistence/postgres/mappers/anonymization-whitelist-entry.mapper.ts
@@ -1,0 +1,30 @@
+import { AnonymizationWhitelistEntry } from '../../../../domain/anonymization-whitelist-entry.entity';
+import { AnonymizationWhitelistEntryRecord } from '../schema/anonymization-whitelist-entry.record';
+
+export class AnonymizationWhitelistEntryMapper {
+  static toDomain(
+    record: AnonymizationWhitelistEntryRecord,
+  ): AnonymizationWhitelistEntry {
+    return new AnonymizationWhitelistEntry({
+      id: record.id,
+      orgId: record.orgId,
+      category: record.category,
+      pattern: record.pattern,
+      createdAt: record.createdAt,
+      updatedAt: record.updatedAt,
+    });
+  }
+
+  static toRecord(
+    domain: AnonymizationWhitelistEntry,
+  ): AnonymizationWhitelistEntryRecord {
+    const record = new AnonymizationWhitelistEntryRecord();
+    record.id = domain.id;
+    record.orgId = domain.orgId;
+    record.category = domain.category;
+    record.pattern = domain.pattern;
+    record.createdAt = domain.createdAt;
+    record.updatedAt = new Date();
+    return record;
+  }
+}

--- a/ayunis-core-backend/src/domain/anonymization-settings/infrastructure/persistence/postgres/schema/anonymization-whitelist-entry.record.ts
+++ b/ayunis-core-backend/src/domain/anonymization-settings/infrastructure/persistence/postgres/schema/anonymization-whitelist-entry.record.ts
@@ -1,0 +1,23 @@
+import { Column, Entity, Index, JoinColumn, ManyToOne, Unique } from 'typeorm';
+import type { UUID } from 'crypto';
+import { BaseRecord } from '../../../../../../common/db/base-record';
+import { OrgRecord } from '../../../../../../iam/orgs/infrastructure/repositories/local/schema/org.record';
+import { PiiCategory } from '../../../../../../common/anonymization/domain/pii-category.enum';
+
+@Entity({ name: 'anonymization_whitelist_entries' })
+@Unique(['orgId', 'category'])
+export class AnonymizationWhitelistEntryRecord extends BaseRecord {
+  @Index()
+  @Column()
+  orgId: UUID;
+
+  @ManyToOne(() => OrgRecord, { nullable: false, onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'orgId' })
+  org: OrgRecord;
+
+  @Column({ type: 'enum', enum: PiiCategory })
+  category: PiiCategory;
+
+  @Column({ type: 'text', nullable: true })
+  pattern: string | null;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -206,6 +206,9 @@ importers:
       rxjs:
         specifier: ^7.8.1
         version: 7.8.2
+      safe-regex2:
+        specifier: ^5.1.1
+        version: 5.1.1
       sanitize-html:
         specifier: ^2.17.1
         version: 2.17.4
@@ -431,7 +434,7 @@ importers:
         version: 1.167.0(@tanstack/react-router@1.170.8(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@tanstack/router-core@1.171.6)(csstype@3.2.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@tanstack/router-plugin':
         specifier: ^1.166.13
-        version: 1.168.11(@tanstack/react-router@1.170.8(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite@6.4.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(yaml@2.9.0))(webpack@5.106.0(lightningcss@1.32.0)(postcss@8.5.15))
+        version: 1.168.11(@tanstack/react-router@1.170.8(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite@6.4.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(yaml@2.9.0))(webpack@5.106.0(lightningcss@1.32.0))
       '@tiptap/extension-link':
         specifier: ^3.20.0
         version: 3.23.6(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))(@tiptap/pm@3.23.6)
@@ -9339,6 +9342,10 @@ packages:
     resolution: {integrity: sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==}
     engines: {node: '>=8'}
 
+  ret@0.5.0:
+    resolution: {integrity: sha512-I1XxrZSQ+oErkRR4jYbAyEEu2I0avBvvMM5JN+6EBprOGRCs63ENqZ3vjavq8fBw2+62G5LF5XelKwuJpcvcxw==}
+    engines: {node: '>=10'}
+
   retry@0.13.1:
     resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
     engines: {node: '>= 4'}
@@ -9406,6 +9413,10 @@ packages:
   safe-regex-test@1.1.0:
     resolution: {integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==}
     engines: {node: '>= 0.4'}
+
+  safe-regex2@5.1.1:
+    resolution: {integrity: sha512-mOSBvHGDZMuIEZMdOz/aCEYDCv0E7nfcNsIhUF+/P+xC7Hyf3FkvymqgPbg9D1EdSGu+uKbJgy09K/RKKc7kJA==}
+    hasBin: true
 
   safe-regex@2.1.1:
     resolution: {integrity: sha512-rx+x8AMzKb5Q5lQ95Zoi6ZbJqwCLkqi3XuJXp5P3rT8OEc6sZCJG5AE5dU3lsgRr/F4Bs31jSlVN+j5KrsGu9A==}
@@ -14405,7 +14416,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@tanstack/router-plugin@1.168.11(@tanstack/react-router@1.170.8(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite@6.4.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(yaml@2.9.0))(webpack@5.106.0(lightningcss@1.32.0)(postcss@8.5.15))':
+  '@tanstack/router-plugin@1.168.11(@tanstack/react-router@1.170.8(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite@6.4.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(yaml@2.9.0))(webpack@5.106.0(lightningcss@1.32.0))':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/plugin-syntax-jsx': 7.29.7(@babel/core@7.29.7)
@@ -14423,7 +14434,7 @@ snapshots:
     optionalDependencies:
       '@tanstack/react-router': 1.170.8(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       vite: 6.4.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(yaml@2.9.0)
-      webpack: 5.106.0(lightningcss@1.32.0)(postcss@8.5.15)
+      webpack: 5.106.0(lightningcss@1.32.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -21314,6 +21325,8 @@ snapshots:
       onetime: 5.1.2
       signal-exit: 3.0.7
 
+  ret@0.5.0: {}
+
   retry@0.13.1: {}
 
   reusify@1.1.0: {}
@@ -21414,6 +21427,10 @@ snapshots:
       call-bound: 1.0.4
       es-errors: 1.3.0
       is-regex: 1.2.1
+
+  safe-regex2@5.1.1:
+    dependencies:
+      ret: 0.5.0
 
   safe-regex@2.1.1:
     dependencies:
@@ -21963,16 +21980,15 @@ snapshots:
       '@swc/core': 1.15.40
       postcss: 8.5.15
 
-  terser-webpack-plugin@5.6.1(lightningcss@1.32.0)(postcss@8.5.15)(webpack@5.106.0(lightningcss@1.32.0)(postcss@8.5.15)):
+  terser-webpack-plugin@5.6.1(lightningcss@1.32.0)(webpack@5.106.0(lightningcss@1.32.0)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       terser: 5.48.0
-      webpack: 5.106.0(lightningcss@1.32.0)(postcss@8.5.15)
+      webpack: 5.106.0(lightningcss@1.32.0)
     optionalDependencies:
       lightningcss: 1.32.0
-      postcss: 8.5.15
     optional: true
 
   terser@5.48.0:
@@ -22640,7 +22656,7 @@ snapshots:
       - postcss
       - uglify-js
 
-  webpack@5.106.0(lightningcss@1.32.0)(postcss@8.5.15):
+  webpack@5.106.0(lightningcss@1.32.0):
     dependencies:
       '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.9
@@ -22664,7 +22680,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.3
-      terser-webpack-plugin: 5.6.1(lightningcss@1.32.0)(postcss@8.5.15)(webpack@5.106.0(lightningcss@1.32.0)(postcss@8.5.15))
+      terser-webpack-plugin: 5.6.1(lightningcss@1.32.0)(webpack@5.106.0(lightningcss@1.32.0))
       watchpack: 2.5.1
       webpack-sources: 3.5.0
     transitivePeerDependencies:


### PR DESCRIPTION
- AnonymizationWhitelistEntry entity, repository, and migration:
  one row per (org, category) with optional full-match regex pattern
- Update use case validates patterns (syntax, length, ReDoS via
  safe-regex2) and rejects duplicate categories
- AnonymizeTextForOrgUseCase loads the org whitelist and delegates
  to the anonymization engine

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how PII may be left unmasked per org and runs admin-supplied regex at runtime; validation and tests mitigate ReDoS, but misconfiguration could leak PII into downstream LLM flows.
> 
> **Overview**
> Adds **org-scoped PII anonymization whitelist** settings: persisted rules (one row per org + PII category, optional regex) and use cases to read, replace, and apply them when anonymizing text.
> 
> A new `anonymization_whitelist_entries` table and TypeORM stack back **get** and **full replace** flows. **Update** rejects duplicate categories and validates optional patterns (syntax, 200-char cap, ReDoS via `safe-regex2`). **`AnonymizeTextForOrgUseCase`** loads the org whitelist and passes it into the existing `AnonymizeTextUseCase`; engine failures still propagate for fail-safe callers.
> 
> `AnonymizationSettingsModule` is registered in `AppModule` and exports the three use cases for follow-up HTTP or pipeline wiring (not in this diff).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68f0a16dea040dd7fa80197edb305da6a729368a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->