### PR TITLE
wip(anonymization): add admin api for pii whitelist (AYC-59)

### DIFF
--- a/ayunis-core-backend/src/domain/anonymization-settings/anonymization-settings.module.ts
+++ b/ayunis-core-backend/src/domain/anonymization-settings/anonymization-settings.module.ts
@@ -9,12 +9,14 @@ import { PostgresAnonymizationWhitelistRepository } from './infrastructure/persi
 import { GetPiiWhitelistUseCase } from './application/use-cases/get-pii-whitelist/get-pii-whitelist.use-case';
 import { UpdatePiiWhitelistUseCase } from './application/use-cases/update-pii-whitelist/update-pii-whitelist.use-case';
 import { AnonymizeTextForOrgUseCase } from './application/use-cases/anonymize-text-for-org/anonymize-text-for-org.use-case';
+import { AnonymizationSettingsController } from './presenters/http/anonymization-settings.controller';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([AnonymizationWhitelistEntryRecord]),
     AnonymizationModule,
   ],
+  controllers: [AnonymizationSettingsController],
   providers: [
     {
       provide: AnonymizationWhitelistRepository,

--- a/ayunis-core-backend/src/domain/anonymization-settings/presenters/http/anonymization-settings.controller.ts
+++ b/ayunis-core-backend/src/domain/anonymization-settings/presenters/http/anonymization-settings.controller.ts
@@ -1,0 +1,94 @@
+import { Body, Controller, Get, Logger, Put } from '@nestjs/common';
+import {
+  ApiExtraModels,
+  ApiOperation,
+  ApiResponse,
+  ApiTags,
+  getSchemaPath,
+} from '@nestjs/swagger';
+import type { UUID } from 'crypto';
+import {
+  CurrentUser,
+  UserProperty,
+} from 'src/iam/authentication/application/decorators/current-user.decorator';
+import { Roles } from 'src/iam/authorization/application/decorators/roles.decorator';
+import { UserRole } from 'src/iam/users/domain/value-objects/role.object';
+import { GetPiiWhitelistUseCase } from '../../application/use-cases/get-pii-whitelist/get-pii-whitelist.use-case';
+import { GetPiiWhitelistQuery } from '../../application/use-cases/get-pii-whitelist/get-pii-whitelist.query';
+import { UpdatePiiWhitelistUseCase } from '../../application/use-cases/update-pii-whitelist/update-pii-whitelist.use-case';
+import { UpdatePiiWhitelistCommand } from '../../application/use-cases/update-pii-whitelist/update-pii-whitelist.command';
+import { UpdatePiiWhitelistRequestDto } from './dtos/update-pii-whitelist-request.dto';
+import { PiiWhitelistResponseDto } from './dtos/pii-whitelist-response.dto';
+import type { AnonymizationWhitelistEntry } from '../../domain/anonymization-whitelist-entry.entity';
+
+@ApiTags('anonymization-settings')
+@Controller('anonymization-settings')
+@ApiExtraModels(PiiWhitelistResponseDto)
+export class AnonymizationSettingsController {
+  private readonly logger = new Logger(AnonymizationSettingsController.name);
+
+  constructor(
+    private readonly getPiiWhitelistUseCase: GetPiiWhitelistUseCase,
+    private readonly updatePiiWhitelistUseCase: UpdatePiiWhitelistUseCase,
+  ) {}
+
+  @Get('pii-whitelist')
+  @Roles(UserRole.ADMIN)
+  @ApiOperation({ summary: 'Get the PII whitelist for the current org' })
+  @ApiResponse({
+    status: 200,
+    description: 'Current PII whitelist (empty list if none)',
+    schema: { $ref: getSchemaPath(PiiWhitelistResponseDto) },
+  })
+  async get(
+    @CurrentUser(UserProperty.ORG_ID) orgId: UUID,
+  ): Promise<PiiWhitelistResponseDto> {
+    this.logger.log(`Getting PII whitelist for org ${orgId}`);
+
+    const entries = await this.getPiiWhitelistUseCase.execute(
+      new GetPiiWhitelistQuery(orgId),
+    );
+    return this.toResponse(entries);
+  }
+
+  @Put('pii-whitelist')
+  @Roles(UserRole.ADMIN)
+  @ApiOperation({ summary: 'Replace the PII whitelist for the current org' })
+  @ApiResponse({
+    status: 200,
+    description: 'Updated PII whitelist',
+    schema: { $ref: getSchemaPath(PiiWhitelistResponseDto) },
+  })
+  @ApiResponse({
+    status: 400,
+    description: 'Invalid or unsafe regex pattern, or duplicate category',
+  })
+  async update(
+    @CurrentUser(UserProperty.ORG_ID) orgId: UUID,
+    @Body() dto: UpdatePiiWhitelistRequestDto,
+  ): Promise<PiiWhitelistResponseDto> {
+    this.logger.log(`Updating PII whitelist for org ${orgId}`);
+
+    const entries = await this.updatePiiWhitelistUseCase.execute(
+      new UpdatePiiWhitelistCommand(
+        orgId,
+        dto.entries.map((entry) => ({
+          category: entry.category,
+          pattern: entry.pattern ?? null,
+        })),
+      ),
+    );
+    return this.toResponse(entries);
+  }
+
+  private toResponse(
+    entries: AnonymizationWhitelistEntry[],
+  ): PiiWhitelistResponseDto {
+    return {
+      entries: entries.map((entry) => ({
+        category: entry.category,
+        pattern: entry.pattern,
+      })),
+    };
+  }
+}

--- a/ayunis-core-backend/src/domain/anonymization-settings/presenters/http/dtos/pii-whitelist-entry.dto.ts
+++ b/ayunis-core-backend/src/domain/anonymization-settings/presenters/http/dtos/pii-whitelist-entry.dto.ts
@@ -1,0 +1,28 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsEnum, IsOptional, IsString, MaxLength } from 'class-validator';
+import { PiiCategory } from 'src/common/anonymization/domain/pii-category.enum';
+import { MAX_PATTERN_LENGTH } from '../../../domain/validate-pattern';
+
+export class PiiWhitelistEntryDto {
+  @ApiProperty({
+    description: 'PII category exempt from anonymization',
+    enum: PiiCategory,
+    enumName: 'PiiCategory',
+    example: PiiCategory.EMAIL_ADDRESS,
+  })
+  @IsEnum(PiiCategory)
+  category: PiiCategory;
+
+  @ApiProperty({
+    description:
+      'Optional regex; when set, only values fully matching it (case-insensitive) are exempt. Null exempts the whole category.',
+    example: '.*@muster-stadt\\.de',
+    type: String,
+    nullable: true,
+    maxLength: MAX_PATTERN_LENGTH,
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(MAX_PATTERN_LENGTH)
+  pattern: string | null;
+}

--- a/ayunis-core-backend/src/domain/anonymization-settings/presenters/http/dtos/pii-whitelist-response.dto.ts
+++ b/ayunis-core-backend/src/domain/anonymization-settings/presenters/http/dtos/pii-whitelist-response.dto.ts
@@ -1,0 +1,10 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { PiiWhitelistEntryDto } from './pii-whitelist-entry.dto';
+
+export class PiiWhitelistResponseDto {
+  @ApiProperty({
+    description: 'Current whitelist entries for the org',
+    type: [PiiWhitelistEntryDto],
+  })
+  entries: PiiWhitelistEntryDto[];
+}

--- a/ayunis-core-backend/src/domain/anonymization-settings/presenters/http/dtos/update-pii-whitelist-request.dto.ts
+++ b/ayunis-core-backend/src/domain/anonymization-settings/presenters/http/dtos/update-pii-whitelist-request.dto.ts
@@ -1,0 +1,18 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { ArrayMaxSize, IsArray, ValidateNested } from 'class-validator';
+import { PiiWhitelistEntryDto } from './pii-whitelist-entry.dto';
+
+export class UpdatePiiWhitelistRequestDto {
+  @ApiProperty({
+    description:
+      'Full replacement whitelist; an empty array removes all entries',
+    type: [PiiWhitelistEntryDto],
+    maxItems: 50,
+  })
+  @IsArray()
+  @ArrayMaxSize(50)
+  @ValidateNested({ each: true })
+  @Type(() => PiiWhitelistEntryDto)
+  entries: PiiWhitelistEntryDto[];
+}


### PR DESCRIPTION
- GET/PUT /anonymization-settings/pii-whitelist, admin-only
- PUT replaces the full whitelist; empty array clears it

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes control which PII categories/regexes skip anonymization for an org; misconfiguration could weaken privacy, though access is admin-only and patterns are validated in the update use case.
> 
> **Overview**
> Exposes **admin-only** HTTP APIs for per-org PII anonymization whitelist management by wiring existing use cases into a new `AnonymizationSettingsController` and registering it on `AnonymizationSettingsModule`.
> 
> **GET** and **PUT** `anonymization-settings/pii-whitelist` scope data to the caller’s org via `@CurrentUser(ORG_ID)`. PUT performs a **full replace** of whitelist entries (including clearing with an empty array) and returns the updated list. Request/response DTOs add Swagger docs plus validation: PII category enum, optional regex pattern with max length, and up to 50 entries per update.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5dcf618ff44d9bc7fe5643ce087bebb2479aec0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->