### PR TITLE
wip(anonymization): honor org pii whitelist at all anonymization points (AYC-59)

### DIFF
--- a/ayunis-core-backend/src/domain/runs/application/services/tool-result-collector.service.spec.ts
+++ b/ayunis-core-backend/src/domain/runs/application/services/tool-result-collector.service.spec.ts
@@ -1,5 +1,5 @@
 import { AnonymizationFailedError } from 'src/common/anonymization/application/anonymization.errors';
-import type { AnonymizeTextUseCase } from 'src/common/anonymization/application/use-cases/anonymize-text/anonymize-text.use-case';
+import type { AnonymizeTextForOrgUseCase } from 'src/domain/anonymization-settings/application/use-cases/anonymize-text-for-org/anonymize-text-for-org.use-case';
 import { RunAnonymizationUnavailableError } from '../runs.errors';
 import { ToolResultMessageContent } from 'src/domain/messages/domain/message-contents/tool-result.message-content.entity';
 import { ToolUseMessageContent } from 'src/domain/messages/domain/message-contents/tool-use.message-content.entity';
@@ -60,7 +60,7 @@ describe('ToolResultCollectorService', () => {
   let service: ToolResultCollectorService;
   let executeToolUseCase: jest.Mocked<ExecuteToolUseCase>;
   let checkToolCapabilitiesUseCase: jest.Mocked<CheckToolCapabilitiesUseCase>;
-  let anonymizeTextUseCase: jest.Mocked<AnonymizeTextUseCase>;
+  let anonymizeTextForOrgUseCase: jest.Mocked<AnonymizeTextForOrgUseCase>;
   let contextService: jest.Mocked<ContextService>;
 
   const orgId = randomUUID();
@@ -76,9 +76,9 @@ describe('ToolResultCollectorService', () => {
       execute: jest.fn(),
     } as unknown as jest.Mocked<CheckToolCapabilitiesUseCase>;
 
-    anonymizeTextUseCase = {
+    anonymizeTextForOrgUseCase = {
       execute: jest.fn(),
-    } as unknown as jest.Mocked<AnonymizeTextUseCase>;
+    } as unknown as jest.Mocked<AnonymizeTextForOrgUseCase>;
 
     contextService = {
       get: jest.fn().mockReturnValue(randomUUID()),
@@ -91,7 +91,7 @@ describe('ToolResultCollectorService', () => {
     service = new ToolResultCollectorService(
       executeToolUseCase,
       checkToolCapabilitiesUseCase,
-      anonymizeTextUseCase,
+      anonymizeTextForOrgUseCase,
       contextService,
       mockEventEmitter as never,
     );
@@ -273,7 +273,7 @@ describe('ToolResultCollectorService', () => {
         'Max Mustermann, Hauptstraße 42, 80331 München, Tel: 089-12345678',
       );
 
-      anonymizeTextUseCase.execute.mockRejectedValue(
+      anonymizeTextForOrgUseCase.execute.mockRejectedValue(
         new AnonymizationFailedError('Connection refused'),
       );
 
@@ -334,7 +334,7 @@ describe('ToolResultCollectorService', () => {
       expect(results).toHaveLength(1);
       expect(results[0]).toBeInstanceOf(ToolResultMessageContent);
       expect(results[0].result).toBe(rawResult);
-      expect(anonymizeTextUseCase.execute).not.toHaveBeenCalled();
+      expect(anonymizeTextForOrgUseCase.execute).not.toHaveBeenCalled();
     });
   });
 });

--- a/ayunis-core-backend/src/domain/runs/application/services/tool-result-collector.service.ts
+++ b/ayunis-core-backend/src/domain/runs/application/services/tool-result-collector.service.ts
@@ -12,8 +12,8 @@ import { ExecuteToolCommand } from 'src/domain/tools/application/use-cases/execu
 import { CheckToolCapabilitiesUseCase } from 'src/domain/tools/application/use-cases/check-tool-capabilities/check-tool-capabilities.use-case';
 import { CheckToolCapabilitiesQuery } from 'src/domain/tools/application/use-cases/check-tool-capabilities/check-tool-capabilities.query';
 import { ToolExecutionFailedError } from 'src/domain/tools/application/tools.errors';
-import { AnonymizeTextUseCase } from 'src/common/anonymization/application/use-cases/anonymize-text/anonymize-text.use-case';
-import { AnonymizeTextCommand } from 'src/common/anonymization/application/use-cases/anonymize-text/anonymize-text.command';
+import { AnonymizeTextForOrgUseCase } from 'src/domain/anonymization-settings/application/use-cases/anonymize-text-for-org/anonymize-text-for-org.use-case';
+import { AnonymizeTextForOrgCommand } from 'src/domain/anonymization-settings/application/use-cases/anonymize-text-for-org/anonymize-text-for-org.command';
 import { ApplicationError } from 'src/common/errors/base.error';
 import { ContextService } from 'src/common/context/services/context.service';
 import { ToolUsedEvent } from '../events/tool-used.event';
@@ -32,7 +32,7 @@ export class ToolResultCollectorService {
   constructor(
     private readonly executeToolUseCase: ExecuteToolUseCase,
     private readonly checkToolCapabilitiesUseCase: CheckToolCapabilitiesUseCase,
-    private readonly anonymizeTextUseCase: AnonymizeTextUseCase,
+    private readonly anonymizeTextForOrgUseCase: AnonymizeTextForOrgUseCase,
     private readonly contextService: ContextService,
     private readonly eventEmitter: EventEmitter2,
   ) {}
@@ -251,7 +251,7 @@ export class ToolResultCollectorService {
     }
 
     if (isAnonymous && tool.returnsPii) {
-      result = await this.anonymizeText(result);
+      result = await this.anonymizeText(result, orgId);
     }
 
     return {
@@ -260,10 +260,10 @@ export class ToolResultCollectorService {
     };
   }
 
-  private async anonymizeText(text: string): Promise<string> {
+  private async anonymizeText(text: string, orgId: UUID): Promise<string> {
     try {
-      const result = await this.anonymizeTextUseCase.execute(
-        new AnonymizeTextCommand(text),
+      const result = await this.anonymizeTextForOrgUseCase.execute(
+        new AnonymizeTextForOrgCommand(text, orgId),
       );
       return result.anonymizedText;
     } catch (error) {

--- a/ayunis-core-backend/src/domain/runs/application/use-cases/execute-run-and-set-title/execute-run-and-set-title.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/runs/application/use-cases/execute-run-and-set-title/execute-run-and-set-title.use-case.spec.ts
@@ -4,7 +4,8 @@ import { ExecuteRunAndSetTitleCommand } from './execute-run-and-set-title.comman
 import type { ExecuteRunUseCase } from '../execute-run/execute-run.use-case';
 import type { FindThreadUseCase } from 'src/domain/threads/application/use-cases/find-thread/find-thread.use-case';
 import type { GenerateAndSetThreadTitleUseCase } from 'src/domain/threads/application/use-cases/generate-and-set-thread-title/generate-and-set-thread-title.use-case';
-import type { AnonymizeTextUseCase } from 'src/common/anonymization/application/use-cases/anonymize-text/anonymize-text.use-case';
+import type { AnonymizeTextForOrgUseCase } from 'src/domain/anonymization-settings/application/use-cases/anonymize-text-for-org/anonymize-text-for-org.use-case';
+import type { ContextService } from 'src/common/context/services/context.service';
 import { RunUserInput } from 'src/domain/runs/domain/run-input.entity';
 import type { Thread } from 'src/domain/threads/domain/thread.entity';
 import type { RunEvent, RunErrorEvent } from '../../run-events';
@@ -19,7 +20,8 @@ describe('ExecuteRunAndSetTitleUseCase', () => {
   let executeRunUseCase: jest.Mocked<ExecuteRunUseCase>;
   let findThreadUseCase: jest.Mocked<FindThreadUseCase>;
   let generateAndSetThreadTitleUseCase: jest.Mocked<GenerateAndSetThreadTitleUseCase>;
-  let anonymizeTextUseCase: jest.Mocked<AnonymizeTextUseCase>;
+  let anonymizeTextForOrgUseCase: jest.Mocked<AnonymizeTextForOrgUseCase>;
+  let contextService: jest.Mocked<ContextService>;
 
   let threadId: UUID;
 
@@ -59,15 +61,20 @@ describe('ExecuteRunAndSetTitleUseCase', () => {
       execute: jest.fn().mockResolvedValue(null),
     } as unknown as jest.Mocked<GenerateAndSetThreadTitleUseCase>;
 
-    anonymizeTextUseCase = {
+    anonymizeTextForOrgUseCase = {
       execute: jest.fn(),
-    } as unknown as jest.Mocked<AnonymizeTextUseCase>;
+    } as unknown as jest.Mocked<AnonymizeTextForOrgUseCase>;
+
+    contextService = {
+      get: jest.fn().mockReturnValue(randomUUID()),
+    } as unknown as jest.Mocked<ContextService>;
 
     useCase = new ExecuteRunAndSetTitleUseCase(
       executeRunUseCase,
       findThreadUseCase,
       generateAndSetThreadTitleUseCase,
-      anonymizeTextUseCase,
+      anonymizeTextForOrgUseCase,
+      contextService,
     );
   });
 

--- a/ayunis-core-backend/src/domain/runs/application/use-cases/execute-run-and-set-title/execute-run-and-set-title.use-case.ts
+++ b/ayunis-core-backend/src/domain/runs/application/use-cases/execute-run-and-set-title/execute-run-and-set-title.use-case.ts
@@ -19,9 +19,11 @@ import {
 } from 'src/domain/runs/domain/run-input.entity';
 import { RunNoModelFoundError } from '../../runs.errors';
 import { Thread } from '../../../../threads/domain/thread.entity';
-import { AnonymizeTextUseCase } from 'src/common/anonymization/application/use-cases/anonymize-text/anonymize-text.use-case';
-import { AnonymizeTextCommand } from 'src/common/anonymization/application/use-cases/anonymize-text/anonymize-text.command';
+import { AnonymizeTextForOrgUseCase } from 'src/domain/anonymization-settings/application/use-cases/anonymize-text-for-org/anonymize-text-for-org.use-case';
+import { AnonymizeTextForOrgCommand } from 'src/domain/anonymization-settings/application/use-cases/anonymize-text-for-org/anonymize-text-for-org.command';
 import { ApplicationError } from 'src/common/errors/base.error';
+import { ContextService } from 'src/common/context/services/context.service';
+import { RunAnonymizationUnavailableError } from '../../runs.errors';
 
 @Injectable()
 export class ExecuteRunAndSetTitleUseCase {
@@ -31,7 +33,8 @@ export class ExecuteRunAndSetTitleUseCase {
     private readonly executeRunUseCase: ExecuteRunUseCase,
     private readonly findThreadUseCase: FindThreadUseCase,
     private readonly generateAndSetThreadTitleUseCase: GenerateAndSetThreadTitleUseCase,
-    private readonly anonymizeTextUseCase: AnonymizeTextUseCase,
+    private readonly anonymizeTextForOrgUseCase: AnonymizeTextForOrgUseCase,
+    private readonly contextService: ContextService,
   ) {}
 
   async *execute(
@@ -183,24 +186,26 @@ export class ExecuteRunAndSetTitleUseCase {
     return undefined;
   }
 
+  // Throws when anonymization is unavailable: generateTitle's catch then
+  // skips the title instead of sending raw PII to the model.
   private async anonymizeText(text: string): Promise<string> {
-    try {
-      const result = await this.anonymizeTextUseCase.execute(
-        new AnonymizeTextCommand(text),
-      );
-      if (result.replacements.length > 0) {
-        this.logger.log('Anonymized text for title generation', {
-          originalLength: text.length,
-          anonymizedLength: result.anonymizedText.length,
-          replacementsCount: result.replacements.length,
-        });
-      }
-      return result.anonymizedText;
-    } catch (error) {
-      this.logger.error('Failed to anonymize text, returning original', {
-        error: error as Error,
+    const orgId = this.contextService.get('orgId');
+    if (!orgId) {
+      throw new RunAnonymizationUnavailableError({
+        originalError: 'No org context available for anonymization',
       });
-      return text;
     }
+
+    const result = await this.anonymizeTextForOrgUseCase.execute(
+      new AnonymizeTextForOrgCommand(text, orgId),
+    );
+    if (result.replacements.length > 0) {
+      this.logger.log('Anonymized text for title generation', {
+        originalLength: text.length,
+        anonymizedLength: result.anonymizedText.length,
+        replacementsCount: result.replacements.length,
+      });
+    }
+    return result.anonymizedText;
   }
 }

--- a/ayunis-core-backend/src/domain/runs/application/use-cases/execute-run/execute-run.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/runs/application/use-cases/execute-run/execute-run.use-case.spec.ts
@@ -1,5 +1,5 @@
 import { AnonymizationFailedError } from 'src/common/anonymization/application/anonymization.errors';
-import type { AnonymizeTextUseCase } from 'src/common/anonymization/application/use-cases/anonymize-text/anonymize-text.use-case';
+import type { AnonymizeTextForOrgUseCase } from 'src/domain/anonymization-settings/application/use-cases/anonymize-text-for-org/anonymize-text-for-org.use-case';
 import { RunAnonymizationUnavailableError } from '../../runs.errors';
 import type { ContextService } from 'src/common/context/services/context.service';
 import type { CreateToolResultMessageUseCase } from 'src/domain/messages/application/use-cases/create-tool-result-message/create-tool-result-message.use-case';
@@ -33,7 +33,7 @@ import { randomUUID } from 'crypto';
 
 describe('ExecuteRunUseCase', () => {
   let useCase: ExecuteRunUseCase;
-  let anonymizeTextUseCase: jest.Mocked<AnonymizeTextUseCase>;
+  let anonymizeTextForOrgUseCase: jest.Mocked<AnonymizeTextForOrgUseCase>;
   let findThreadUseCase: jest.Mocked<FindThreadUseCase>;
   let contextService: jest.Mocked<ContextService>;
   let toolAssemblyService: jest.Mocked<ToolAssemblyService>;
@@ -67,9 +67,9 @@ describe('ExecuteRunUseCase', () => {
   }
 
   beforeEach(() => {
-    anonymizeTextUseCase = {
+    anonymizeTextForOrgUseCase = {
       execute: jest.fn(),
-    } as unknown as jest.Mocked<AnonymizeTextUseCase>;
+    } as unknown as jest.Mocked<AnonymizeTextForOrgUseCase>;
 
     findThreadUseCase = {
       execute: jest.fn(),
@@ -123,7 +123,7 @@ describe('ExecuteRunUseCase', () => {
       findThreadUseCase,
       { execute: jest.fn() } as unknown as AddMessageToThreadUseCase,
       contextService,
-      anonymizeTextUseCase,
+      anonymizeTextForOrgUseCase,
       inferenceUsageGuard,
       toolAssemblyService,
       {
@@ -336,7 +336,7 @@ describe('ExecuteRunUseCase', () => {
         thread,
         isLongChat: false,
       });
-      anonymizeTextUseCase.execute.mockRejectedValue(
+      anonymizeTextForOrgUseCase.execute.mockRejectedValue(
         new AnonymizationFailedError('Connection refused'),
       );
 
@@ -370,7 +370,7 @@ describe('ExecuteRunUseCase', () => {
         thread,
         isLongChat: false,
       });
-      anonymizeTextUseCase.execute.mockRejectedValue(
+      anonymizeTextForOrgUseCase.execute.mockRejectedValue(
         new AnonymizationFailedError('Service timeout'),
       );
 

--- a/ayunis-core-backend/src/domain/runs/application/use-cases/execute-run/execute-run.use-case.ts
+++ b/ayunis-core-backend/src/domain/runs/application/use-cases/execute-run/execute-run.use-case.ts
@@ -27,8 +27,8 @@ import { UUID } from 'crypto';
 import { PermittedLanguageModel } from 'src/domain/models/domain/permitted-model.entity';
 import { ContextService } from 'src/common/context/services/context.service';
 import { ToolType } from 'src/domain/tools/domain/value-objects/tool-type.enum';
-import { AnonymizeTextUseCase } from 'src/common/anonymization/application/use-cases/anonymize-text/anonymize-text.use-case';
-import { AnonymizeTextCommand } from 'src/common/anonymization/application/use-cases/anonymize-text/anonymize-text.command';
+import { AnonymizeTextForOrgUseCase } from 'src/domain/anonymization-settings/application/use-cases/anonymize-text-for-org/anonymize-text-for-org.use-case';
+import { AnonymizeTextForOrgCommand } from 'src/domain/anonymization-settings/application/use-cases/anonymize-text-for-org/anonymize-text-for-org.command';
 import { InferenceUsageGuard } from '../../services/inference-usage-guard.service';
 import { SkillActivationService } from 'src/domain/skills/application/services/skill-activation.service';
 import { ToolAssemblyService } from '../../services/tool-assembly.service';
@@ -48,7 +48,7 @@ export class ExecuteRunUseCase {
     private readonly findThreadUseCase: FindThreadUseCase,
     private readonly addMessageToThreadUseCase: AddMessageToThreadUseCase,
     private readonly contextService: ContextService,
-    private readonly anonymizeTextUseCase: AnonymizeTextUseCase,
+    private readonly anonymizeTextForOrgUseCase: AnonymizeTextForOrgUseCase,
     private readonly inferenceUsageGuard: InferenceUsageGuard,
     private readonly toolAssemblyService: ToolAssemblyService,
     private readonly toolResultCollectorService: ToolResultCollectorService,
@@ -347,7 +347,7 @@ Skill "${skillName}" has already been activated on this thread. Do not call acti
 
     const messageText =
       hasText && params.isAnonymous
-        ? await this.anonymizeText(userInput.text)
+        ? await this.anonymizeText(userInput.text, params.orgId)
         : userInput.text;
 
     const newUserMessage = await this.createUserMessageUseCase.execute(
@@ -364,10 +364,10 @@ Skill "${skillName}" has already been activated on this thread. Do not call acti
     return newUserMessage;
   }
 
-  private async anonymizeText(text: string): Promise<string> {
+  private async anonymizeText(text: string, orgId: UUID): Promise<string> {
     try {
-      const result = await this.anonymizeTextUseCase.execute(
-        new AnonymizeTextCommand(text),
+      const result = await this.anonymizeTextForOrgUseCase.execute(
+        new AnonymizeTextForOrgCommand(text, orgId),
       );
       if (result.replacements.length > 0) {
         this.logger.log('Anonymized text', {

--- a/ayunis-core-backend/src/domain/runs/runs.module.ts
+++ b/ayunis-core-backend/src/domain/runs/runs.module.ts
@@ -21,7 +21,7 @@ import { SubscriptionsModule } from 'src/iam/subscriptions/subscriptions.module'
 import { TrialsModule } from 'src/iam/trials/trials.module';
 import { McpModule } from 'src/domain/mcp/mcp.module';
 import { SourcesModule } from 'src/domain/sources/sources.module';
-import { AnonymizationModule } from 'src/common/anonymization/anonymization.module';
+import { AnonymizationSettingsModule } from 'src/domain/anonymization-settings/anonymization-settings.module';
 import { UsageModule } from 'src/domain/usage/usage.module';
 import { QuotasModule } from 'src/iam/quotas/quotas.module';
 import { SkillsModule } from 'src/domain/skills/skills.module';
@@ -40,7 +40,7 @@ import { LetterheadsModule } from 'src/domain/letterheads/letterheads.module';
     TrialsModule,
     McpModule,
     SourcesModule,
-    AnonymizationModule,
+    AnonymizationSettingsModule,
     UsageModule,
     QuotasModule,
     SkillsModule,


### PR DESCRIPTION
- execute-run, tool-result-collector, and title generation now use
  AnonymizeTextForOrgUseCase with the caller's orgId
- title generation no longer falls back to the original text when
  anonymization fails; it skips the title instead (fail-safe)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches PII handling on user input, tool results, and title generation; behavior changes when anonymization fails (titles skipped) and depends on org context being present.
> 
> **Overview**
> Run-time anonymization now goes through **`AnonymizeTextForOrgUseCase`** with the caller’s **`orgId`**, so org **PII whitelist** settings apply when anonymizing user messages, PII tool results, and first-message text used for thread titles. **`RunsModule`** wires **`AnonymizationSettingsModule`** instead of the generic **`AnonymizationModule`**.
> 
> **Title generation** in **`ExecuteRunAndSetTitleUseCase`** reads **`orgId`** from **`ContextService`**, calls the org-aware use case, and **no longer returns the original text** when anonymization fails—errors propagate and **`generateTitle`** skips the title instead of sending raw PII to the title model. User-message and tool-result paths still surface **`RunAnonymizationUnavailableError`** on anonymization failure in anonymous mode.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd6f77532a9dc4fb0f5d02bf4fafdeffe2e75202. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->