### PR TITLE
wip(anonymization): regenerate api client for pii whitelist endpoints (AYC-59)

### DIFF
--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
@@ -3869,6 +3869,50 @@ export interface UpdateTrialRequestDto {
   messagesSent?: number;
 }
 
+/**
+ * PII category exempt from anonymization
+ */
+export type PiiCategory = typeof PiiCategory[keyof typeof PiiCategory];
+
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const PiiCategory = {
+  person_name: 'person_name',
+  organization: 'organization',
+  location: 'location',
+  email_address: 'email_address',
+  phone_number: 'phone_number',
+  url_or_ip: 'url_or_ip',
+  date_time: 'date_time',
+  financial_account: 'financial_account',
+  government_id: 'government_id',
+  nationality_religion_politics: 'nationality_religion_politics',
+} as const;
+
+export interface PiiWhitelistEntryDto {
+  /** PII category exempt from anonymization */
+  category: PiiCategory;
+  /**
+   * Optional regex; when set, only values fully matching it (case-insensitive) are exempt. Null exempts the whole category.
+   * @maxLength 200
+   * @nullable
+   */
+  pattern: string | null;
+}
+
+export interface PiiWhitelistResponseDto {
+  /** Current whitelist entries for the org */
+  entries: PiiWhitelistEntryDto[];
+}
+
+export interface UpdatePiiWhitelistRequestDto {
+  /**
+   * Full replacement whitelist; an empty array removes all entries
+   * @maxItems 50
+   */
+  entries: PiiWhitelistEntryDto[];
+}
+
 export interface UserSystemPromptResponseDto {
   /**
    * The custom system prompt for the user, or null if not set

--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.ts
@@ -108,6 +108,7 @@ import type {
   PaginatedUsersListResponseDto,
   PermittedLanguageModelResponseDto,
   PermittedLanguageModelResponseDtoNullable,
+  PiiWhitelistResponseDto,
   PredefinedConfigResponseDto,
   PriceResponseDto,
   PromoteToSuperAdminDto,
@@ -174,6 +175,7 @@ import type {
   UpdateMonthlyCreditsDto,
   UpdatePasswordDto,
   UpdatePermittedModelDto,
+  UpdatePiiWhitelistRequestDto,
   UpdateSeatsDto,
   UpdateSkillDto,
   UpdateSkillTemplateDto,
@@ -15532,6 +15534,163 @@ export const useSuperAdminTrialsControllerUpdateTrial = <TError = void,
       > => {
 
       const mutationOptions = getSuperAdminTrialsControllerUpdateTrialMutationOptions(options);
+
+      return useMutation(mutationOptions, queryClient);
+    }
+    
+/**
+ * @summary Get the PII whitelist for the current org
+ */
+export const anonymizationSettingsControllerGet = (
+    
+ signal?: AbortSignal
+) => {
+      
+      
+      return customAxiosInstance<PiiWhitelistResponseDto>(
+      {url: `/anonymization-settings/pii-whitelist`, method: 'GET', signal
+    },
+      );
+    }
+  
+
+
+
+export const getAnonymizationSettingsControllerGetQueryKey = () => {
+    return [
+    `/anonymization-settings/pii-whitelist`
+    ] as const;
+    }
+
+    
+export const getAnonymizationSettingsControllerGetQueryOptions = <TData = Awaited<ReturnType<typeof anonymizationSettingsControllerGet>>, TError = unknown>( options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof anonymizationSettingsControllerGet>>, TError, TData>>, }
+) => {
+
+const {query: queryOptions} = options ?? {};
+
+  const queryKey =  queryOptions?.queryKey ?? getAnonymizationSettingsControllerGetQueryKey();
+
+  
+
+    const queryFn: QueryFunction<Awaited<ReturnType<typeof anonymizationSettingsControllerGet>>> = ({ signal }) => anonymizationSettingsControllerGet(signal);
+
+      
+
+      
+
+   return  { queryKey, queryFn, ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof anonymizationSettingsControllerGet>>, TError, TData> & { queryKey: DataTag<QueryKey, TData, TError> }
+}
+
+export type AnonymizationSettingsControllerGetQueryResult = NonNullable<Awaited<ReturnType<typeof anonymizationSettingsControllerGet>>>
+export type AnonymizationSettingsControllerGetQueryError = unknown
+
+
+export function useAnonymizationSettingsControllerGet<TData = Awaited<ReturnType<typeof anonymizationSettingsControllerGet>>, TError = unknown>(
+  options: { query:Partial<UseQueryOptions<Awaited<ReturnType<typeof anonymizationSettingsControllerGet>>, TError, TData>> & Pick<
+        DefinedInitialDataOptions<
+          Awaited<ReturnType<typeof anonymizationSettingsControllerGet>>,
+          TError,
+          Awaited<ReturnType<typeof anonymizationSettingsControllerGet>>
+        > , 'initialData'
+      >, }
+ , queryClient?: QueryClient
+  ):  DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useAnonymizationSettingsControllerGet<TData = Awaited<ReturnType<typeof anonymizationSettingsControllerGet>>, TError = unknown>(
+  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof anonymizationSettingsControllerGet>>, TError, TData>> & Pick<
+        UndefinedInitialDataOptions<
+          Awaited<ReturnType<typeof anonymizationSettingsControllerGet>>,
+          TError,
+          Awaited<ReturnType<typeof anonymizationSettingsControllerGet>>
+        > , 'initialData'
+      >, }
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useAnonymizationSettingsControllerGet<TData = Awaited<ReturnType<typeof anonymizationSettingsControllerGet>>, TError = unknown>(
+  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof anonymizationSettingsControllerGet>>, TError, TData>>, }
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+/**
+ * @summary Get the PII whitelist for the current org
+ */
+
+export function useAnonymizationSettingsControllerGet<TData = Awaited<ReturnType<typeof anonymizationSettingsControllerGet>>, TError = unknown>(
+  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof anonymizationSettingsControllerGet>>, TError, TData>>, }
+ , queryClient?: QueryClient 
+ ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
+
+  const queryOptions = getAnonymizationSettingsControllerGetQueryOptions(options)
+
+  const query = useQuery(queryOptions, queryClient) as  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+
+  query.queryKey = queryOptions.queryKey ;
+
+  return query;
+}
+
+
+
+
+
+/**
+ * @summary Replace the PII whitelist for the current org
+ */
+export const anonymizationSettingsControllerUpdate = (
+    updatePiiWhitelistRequestDto: UpdatePiiWhitelistRequestDto,
+ ) => {
+      
+      
+      return customAxiosInstance<PiiWhitelistResponseDto>(
+      {url: `/anonymization-settings/pii-whitelist`, method: 'PUT',
+      headers: {'Content-Type': 'application/json', },
+      data: updatePiiWhitelistRequestDto
+    },
+      );
+    }
+  
+
+
+export const getAnonymizationSettingsControllerUpdateMutationOptions = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof anonymizationSettingsControllerUpdate>>, TError,{data: UpdatePiiWhitelistRequestDto}, TContext>, }
+): UseMutationOptions<Awaited<ReturnType<typeof anonymizationSettingsControllerUpdate>>, TError,{data: UpdatePiiWhitelistRequestDto}, TContext> => {
+
+const mutationKey = ['anonymizationSettingsControllerUpdate'];
+const {mutation: mutationOptions} = options ?
+      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
+      options
+      : {...options, mutation: {...options.mutation, mutationKey}}
+      : {mutation: { mutationKey, }};
+
+      
+
+
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof anonymizationSettingsControllerUpdate>>, {data: UpdatePiiWhitelistRequestDto}> = (props) => {
+          const {data} = props ?? {};
+
+          return  anonymizationSettingsControllerUpdate(data,)
+        }
+
+        
+
+
+  return  { mutationFn, ...mutationOptions }}
+
+    export type AnonymizationSettingsControllerUpdateMutationResult = NonNullable<Awaited<ReturnType<typeof anonymizationSettingsControllerUpdate>>>
+    export type AnonymizationSettingsControllerUpdateMutationBody = UpdatePiiWhitelistRequestDto
+    export type AnonymizationSettingsControllerUpdateMutationError = void
+
+    /**
+ * @summary Replace the PII whitelist for the current org
+ */
+export const useAnonymizationSettingsControllerUpdate = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof anonymizationSettingsControllerUpdate>>, TError,{data: UpdatePiiWhitelistRequestDto}, TContext>, }
+ , queryClient?: QueryClient): UseMutationResult<
+        Awaited<ReturnType<typeof anonymizationSettingsControllerUpdate>>,
+        TError,
+        {data: UpdatePiiWhitelistRequestDto},
+        TContext
+      > => {
+
+      const mutationOptions = getAnonymizationSettingsControllerUpdateMutationOptions(options);
 
       return useMutation(mutationOptions, queryClient);
     }

--- a/ayunis-core-frontend/src/shared/api/openapi-schema.json
+++ b/ayunis-core-frontend/src/shared/api/openapi-schema.json
@@ -7702,6 +7702,57 @@
         "tags": ["Super Admin Trials"]
       }
     },
+    "/anonymization-settings/pii-whitelist": {
+      "get": {
+        "operationId": "AnonymizationSettingsController_get",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Current PII whitelist (empty list if none)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PiiWhitelistResponseDto"
+                }
+              }
+            }
+          }
+        },
+        "summary": "Get the PII whitelist for the current org",
+        "tags": ["anonymization-settings"]
+      },
+      "put": {
+        "operationId": "AnonymizationSettingsController_update",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdatePiiWhitelistRequestDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated PII whitelist",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PiiWhitelistResponseDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid or unsafe regex pattern, or duplicate category"
+          }
+        },
+        "summary": "Replace the PII whitelist for the current org",
+        "tags": ["anonymization-settings"]
+      }
+    },
     "/chat-settings/system-prompt": {
       "get": {
         "description": "Returns the custom system prompt for the authenticated user, or null if not set.",
@@ -13955,6 +14006,71 @@
             "minimum": 0
           }
         }
+      },
+      "PiiCategory": {
+        "type": "string",
+        "enum": [
+          "person_name",
+          "organization",
+          "location",
+          "email_address",
+          "phone_number",
+          "url_or_ip",
+          "date_time",
+          "financial_account",
+          "government_id",
+          "nationality_religion_politics"
+        ],
+        "description": "PII category exempt from anonymization"
+      },
+      "PiiWhitelistEntryDto": {
+        "type": "object",
+        "properties": {
+          "category": {
+            "description": "PII category exempt from anonymization",
+            "example": "email_address",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PiiCategory"
+              }
+            ]
+          },
+          "pattern": {
+            "type": "string",
+            "description": "Optional regex; when set, only values fully matching it (case-insensitive) are exempt. Null exempts the whole category.",
+            "example": ".*@muster-stadt\\.de",
+            "nullable": true,
+            "maxLength": 200
+          }
+        },
+        "required": ["category", "pattern"]
+      },
+      "PiiWhitelistResponseDto": {
+        "type": "object",
+        "properties": {
+          "entries": {
+            "description": "Current whitelist entries for the org",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PiiWhitelistEntryDto"
+            }
+          }
+        },
+        "required": ["entries"]
+      },
+      "UpdatePiiWhitelistRequestDto": {
+        "type": "object",
+        "properties": {
+          "entries": {
+            "description": "Full replacement whitelist; an empty array removes all entries",
+            "maxItems": 50,
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PiiWhitelistEntryDto"
+            }
+          }
+        },
+        "required": ["entries"]
       },
       "UserSystemPromptResponseDto": {
         "type": "object",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Generated API artifacts only; no runtime behavior changes until feature code consumes the new hooks.
> 
> **Overview**
> Regenerates the frontend API client from the updated OpenAPI spec so the app can call **org-level PII whitelist** anonymization settings (AYC-59).
> 
> The OpenAPI schema and generated types now include **`PiiCategory`**, whitelist entry/response DTOs, and **`UpdatePiiWhitelistRequestDto`** (full replace, up to 50 entries; optional per-category regex pattern). New **`GET`** and **`PUT`** `/anonymization-settings/pii-whitelist` operations are exposed as **`useAnonymizationSettingsControllerGet`** and **`useAnonymizationSettingsControllerUpdate`** (React Query). No application UI or business logic changes in this PR—only **`openapi-schema.json`** and Orval-generated **`ayunisCoreAPI`** files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5567da3204e2ee008fdf04980c9a768bd9ce257c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->