### PR TITLE
feat(anonymization): org-level pii whitelist for anonymous mode (AYC-59)

### DIFF
--- a/ayunis-core-frontend/src/app/routeTree.gen.ts
+++ b/ayunis-core-frontend/src/app/routeTree.gen.ts
@@ -38,6 +38,7 @@ import { Route as AuthenticatedAdminSettingsSecurityRouteImport } from './routes
 import { Route as AuthenticatedAdminSettingsModelsRouteImport } from './routes/_authenticated/admin-settings.models'
 import { Route as AuthenticatedAdminSettingsIntegrationsRouteImport } from './routes/_authenticated/admin-settings.integrations'
 import { Route as AuthenticatedAdminSettingsApiKeysRouteImport } from './routes/_authenticated/admin-settings.api-keys'
+import { Route as AuthenticatedAdminSettingsAnonymizationRouteImport } from './routes/_authenticated/admin-settings.anonymization'
 import { Route as onboardingPasswordResetRouteImport } from './routes/(onboarding)/password.reset'
 import { Route as onboardingPasswordForgotRouteImport } from './routes/(onboarding)/password.forgot'
 import { Route as onboardingAccountActivateRouteImport } from './routes/(onboarding)/account.activate'
@@ -213,6 +214,12 @@ const AuthenticatedAdminSettingsApiKeysRoute =
     path: '/admin-settings/api-keys',
     getParentRoute: () => AuthenticatedRoute,
   } as any)
+const AuthenticatedAdminSettingsAnonymizationRoute =
+  AuthenticatedAdminSettingsAnonymizationRouteImport.update({
+    id: '/admin-settings/anonymization',
+    path: '/admin-settings/anonymization',
+    getParentRoute: () => AuthenticatedRoute,
+  } as any)
 const onboardingPasswordResetRoute = onboardingPasswordResetRouteImport.update({
   id: '/(onboarding)/password/reset',
   path: '/password/reset',
@@ -303,6 +310,7 @@ export interface FileRoutesByFullPath {
   '/account/activate': typeof onboardingAccountActivateRoute
   '/password/forgot': typeof onboardingPasswordForgotRoute
   '/password/reset': typeof onboardingPasswordResetRoute
+  '/admin-settings/anonymization': typeof AuthenticatedAdminSettingsAnonymizationRoute
   '/admin-settings/api-keys': typeof AuthenticatedAdminSettingsApiKeysRoute
   '/admin-settings/integrations': typeof AuthenticatedAdminSettingsIntegrationsRoute
   '/admin-settings/models': typeof AuthenticatedAdminSettingsModelsRoute
@@ -346,6 +354,7 @@ export interface FileRoutesByTo {
   '/account/activate': typeof onboardingAccountActivateRoute
   '/password/forgot': typeof onboardingPasswordForgotRoute
   '/password/reset': typeof onboardingPasswordResetRoute
+  '/admin-settings/anonymization': typeof AuthenticatedAdminSettingsAnonymizationRoute
   '/admin-settings/api-keys': typeof AuthenticatedAdminSettingsApiKeysRoute
   '/admin-settings/integrations': typeof AuthenticatedAdminSettingsIntegrationsRoute
   '/admin-settings/models': typeof AuthenticatedAdminSettingsModelsRoute
@@ -391,6 +400,7 @@ export interface FileRoutesById {
   '/(onboarding)/account/activate': typeof onboardingAccountActivateRoute
   '/(onboarding)/password/forgot': typeof onboardingPasswordForgotRoute
   '/(onboarding)/password/reset': typeof onboardingPasswordResetRoute
+  '/_authenticated/admin-settings/anonymization': typeof AuthenticatedAdminSettingsAnonymizationRoute
   '/_authenticated/admin-settings/api-keys': typeof AuthenticatedAdminSettingsApiKeysRoute
   '/_authenticated/admin-settings/integrations': typeof AuthenticatedAdminSettingsIntegrationsRoute
   '/_authenticated/admin-settings/models': typeof AuthenticatedAdminSettingsModelsRoute
@@ -436,6 +446,7 @@ export interface FileRouteTypes {
     | '/account/activate'
     | '/password/forgot'
     | '/password/reset'
+    | '/admin-settings/anonymization'
     | '/admin-settings/api-keys'
     | '/admin-settings/integrations'
     | '/admin-settings/models'
@@ -479,6 +490,7 @@ export interface FileRouteTypes {
     | '/account/activate'
     | '/password/forgot'
     | '/password/reset'
+    | '/admin-settings/anonymization'
     | '/admin-settings/api-keys'
     | '/admin-settings/integrations'
     | '/admin-settings/models'
@@ -523,6 +535,7 @@ export interface FileRouteTypes {
     | '/(onboarding)/account/activate'
     | '/(onboarding)/password/forgot'
     | '/(onboarding)/password/reset'
+    | '/_authenticated/admin-settings/anonymization'
     | '/_authenticated/admin-settings/api-keys'
     | '/_authenticated/admin-settings/integrations'
     | '/_authenticated/admin-settings/models'
@@ -774,6 +787,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedAdminSettingsApiKeysRouteImport
       parentRoute: typeof AuthenticatedRoute
     }
+    '/_authenticated/admin-settings/anonymization': {
+      id: '/_authenticated/admin-settings/anonymization'
+      path: '/admin-settings/anonymization'
+      fullPath: '/admin-settings/anonymization'
+      preLoaderRoute: typeof AuthenticatedAdminSettingsAnonymizationRouteImport
+      parentRoute: typeof AuthenticatedRoute
+    }
     '/(onboarding)/password/reset': {
       id: '/(onboarding)/password/reset'
       path: '/password/reset'
@@ -870,6 +890,7 @@ declare module '@tanstack/react-router' {
 
 interface AuthenticatedRouteChildren {
   AuthenticatedInstallRoute: typeof AuthenticatedInstallRoute
+  AuthenticatedAdminSettingsAnonymizationRoute: typeof AuthenticatedAdminSettingsAnonymizationRoute
   AuthenticatedAdminSettingsApiKeysRoute: typeof AuthenticatedAdminSettingsApiKeysRoute
   AuthenticatedAdminSettingsIntegrationsRoute: typeof AuthenticatedAdminSettingsIntegrationsRoute
   AuthenticatedAdminSettingsModelsRoute: typeof AuthenticatedAdminSettingsModelsRoute
@@ -904,6 +925,8 @@ interface AuthenticatedRouteChildren {
 
 const AuthenticatedRouteChildren: AuthenticatedRouteChildren = {
   AuthenticatedInstallRoute: AuthenticatedInstallRoute,
+  AuthenticatedAdminSettingsAnonymizationRoute:
+    AuthenticatedAdminSettingsAnonymizationRoute,
   AuthenticatedAdminSettingsApiKeysRoute:
     AuthenticatedAdminSettingsApiKeysRoute,
   AuthenticatedAdminSettingsIntegrationsRoute:

--- a/ayunis-core-frontend/src/app/routes/_authenticated/admin-settings.anonymization.tsx
+++ b/ayunis-core-frontend/src/app/routes/_authenticated/admin-settings.anonymization.tsx
@@ -1,0 +1,12 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { AnonymizationSettingsPage } from '@/pages/admin-settings/anonymization-settings';
+
+export const Route = createFileRoute(
+  '/_authenticated/admin-settings/anonymization',
+)({
+  component: RouteComponent,
+});
+
+function RouteComponent() {
+  return <AnonymizationSettingsPage />;
+}

--- a/ayunis-core-frontend/src/i18n.ts
+++ b/ayunis-core-frontend/src/i18n.ts
@@ -50,6 +50,8 @@ import enSuperAdminSettingsPlatformConfig from './shared/locales/en/super-admin-
 import deSuperAdminSettingsPlatformConfig from './shared/locales/de/super-admin-settings-platform-config.json';
 import enAdminSettingsSecurity from './shared/locales/en/admin-settings-security.json';
 import deAdminSettingsSecurity from './shared/locales/de/admin-settings-security.json';
+import enAdminSettingsAnonymization from './shared/locales/en/admin-settings-anonymization.json';
+import deAdminSettingsAnonymization from './shared/locales/de/admin-settings-anonymization.json';
 import enAdminSettingsLetterheads from './shared/locales/en/admin-settings-letterheads.json';
 import deAdminSettingsLetterheads from './shared/locales/de/admin-settings-letterheads.json';
 import enAdminSettingsApiKeys from './shared/locales/en/admin-settings-api-keys.json';
@@ -83,6 +85,7 @@ const resources = {
     artifacts: enArtifacts,
     'super-admin-settings-platform-config': enSuperAdminSettingsPlatformConfig,
     'admin-settings-security': enAdminSettingsSecurity,
+    'admin-settings-anonymization': enAdminSettingsAnonymization,
     'admin-settings-letterheads': enAdminSettingsLetterheads,
     'admin-settings-api-keys': enAdminSettingsApiKeys,
     'mcp-user-config': enMcpUserConfig,
@@ -112,6 +115,7 @@ const resources = {
     artifacts: deArtifacts,
     'super-admin-settings-platform-config': deSuperAdminSettingsPlatformConfig,
     'admin-settings-security': deAdminSettingsSecurity,
+    'admin-settings-anonymization': deAdminSettingsAnonymization,
     'admin-settings-letterheads': deAdminSettingsLetterheads,
     'admin-settings-api-keys': deAdminSettingsApiKeys,
     'mcp-user-config': deMcpUserConfig,

--- a/ayunis-core-frontend/src/pages/admin-settings/admin-settings-layout/ui/AdminSettingsSidebar.tsx
+++ b/ayunis-core-frontend/src/pages/admin-settings/admin-settings-layout/ui/AdminSettingsSidebar.tsx
@@ -7,7 +7,7 @@ import {
   Shield,
   FileText,
   Key,
-  VenetianMask,
+  ShieldCheck,
 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import {
@@ -48,7 +48,7 @@ export function AdminSettingsSidebar() {
     },
     {
       to: '/admin-settings/anonymization',
-      icon: <VenetianMask />,
+      icon: <ShieldCheck />,
       label: t('layout.anonymization'),
     },
     {

--- a/ayunis-core-frontend/src/pages/admin-settings/admin-settings-layout/ui/AdminSettingsSidebar.tsx
+++ b/ayunis-core-frontend/src/pages/admin-settings/admin-settings-layout/ui/AdminSettingsSidebar.tsx
@@ -7,6 +7,7 @@ import {
   Shield,
   FileText,
   Key,
+  VenetianMask,
 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import {
@@ -44,6 +45,11 @@ export function AdminSettingsSidebar() {
       to: '/admin-settings/security',
       icon: <Shield />,
       label: t('layout.security'),
+    },
+    {
+      to: '/admin-settings/anonymization',
+      icon: <VenetianMask />,
+      label: t('layout.anonymization'),
     },
     {
       to: '/admin-settings/api-keys',

--- a/ayunis-core-frontend/src/pages/admin-settings/anonymization-settings/index.ts
+++ b/ayunis-core-frontend/src/pages/admin-settings/anonymization-settings/index.ts
@@ -1,0 +1,1 @@
+export { AnonymizationSettingsPage } from './ui/AnonymizationSettingsPage';

--- a/ayunis-core-frontend/src/pages/admin-settings/anonymization-settings/lib/rows.spec.ts
+++ b/ayunis-core-frontend/src/pages/admin-settings/anonymization-settings/lib/rows.spec.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import { PiiCategory } from '@/shared/api';
+import { buildRows, toEntries, validateRows } from './rows';
+import { PII_CATEGORIES } from '../model/types';
+
+describe('buildRows', () => {
+  it('marks all categories disabled when there are no entries', () => {
+    const rows = buildRows([]);
+
+    expect(Object.keys(rows)).toHaveLength(PII_CATEGORIES.length);
+    expect(rows[PiiCategory.email_address]).toEqual({
+      enabled: false,
+      pattern: '',
+    });
+  });
+
+  it('enables categories from server entries and keeps their patterns', () => {
+    const rows = buildRows([
+      { category: PiiCategory.email_address, pattern: null },
+      { category: PiiCategory.person_name, pattern: 'dani(el)?' },
+    ]);
+
+    expect(rows[PiiCategory.email_address]).toEqual({
+      enabled: true,
+      pattern: '',
+    });
+    expect(rows[PiiCategory.person_name]).toEqual({
+      enabled: true,
+      pattern: 'dani(el)?',
+    });
+    expect(rows[PiiCategory.location].enabled).toBe(false);
+  });
+});
+
+describe('toEntries', () => {
+  it('serializes enabled rows and turns blank patterns into null', () => {
+    const rows = buildRows([]);
+    rows[PiiCategory.email_address] = { enabled: true, pattern: '  ' };
+    rows[PiiCategory.person_name] = { enabled: true, pattern: ' dani ' };
+
+    expect(toEntries(rows)).toEqual([
+      { category: PiiCategory.person_name, pattern: 'dani' },
+      { category: PiiCategory.email_address, pattern: null },
+    ]);
+  });
+});
+
+describe('validateRows', () => {
+  it('reports invalid patterns only for enabled rows', () => {
+    const rows = buildRows([]);
+    rows[PiiCategory.person_name] = { enabled: true, pattern: '([' };
+    rows[PiiCategory.location] = { enabled: false, pattern: '([' };
+
+    expect(validateRows(rows)).toEqual({
+      [PiiCategory.person_name]: 'invalid_syntax',
+    });
+  });
+});

--- a/ayunis-core-frontend/src/pages/admin-settings/anonymization-settings/lib/rows.ts
+++ b/ayunis-core-frontend/src/pages/admin-settings/anonymization-settings/lib/rows.ts
@@ -1,0 +1,43 @@
+import type { PiiCategory, PiiWhitelistEntryDto } from '@/shared/api';
+import { PII_CATEGORIES } from '../model/types';
+import type { RowsState } from '../model/types';
+import { validateRegexPattern } from './validate-regex';
+import type { RegexValidationError } from './validate-regex';
+
+export function buildRows(entries: PiiWhitelistEntryDto[]): RowsState {
+  const rows = {} as RowsState;
+  for (const category of PII_CATEGORIES) {
+    rows[category] = { enabled: false, pattern: '' };
+  }
+  for (const entry of entries) {
+    rows[entry.category] = {
+      enabled: true,
+      pattern: entry.pattern ?? '',
+    };
+  }
+  return rows;
+}
+
+export function toEntries(rows: RowsState): PiiWhitelistEntryDto[] {
+  return PII_CATEGORIES.filter((category) => rows[category].enabled).map(
+    (category) => {
+      const pattern = rows[category].pattern.trim();
+      return { category, pattern: pattern.length > 0 ? pattern : null };
+    },
+  );
+}
+
+export type RowErrors = Partial<Record<PiiCategory, RegexValidationError>>;
+
+export function validateRows(rows: RowsState): RowErrors {
+  const errors: RowErrors = {};
+  for (const category of PII_CATEGORIES) {
+    const row = rows[category];
+    if (!row.enabled) continue;
+    const error = validateRegexPattern(row.pattern.trim());
+    if (error) {
+      errors[category] = error;
+    }
+  }
+  return errors;
+}

--- a/ayunis-core-frontend/src/pages/admin-settings/anonymization-settings/lib/validate-regex.spec.ts
+++ b/ayunis-core-frontend/src/pages/admin-settings/anonymization-settings/lib/validate-regex.spec.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { MAX_PATTERN_LENGTH, validateRegexPattern } from './validate-regex';
+
+describe('validateRegexPattern', () => {
+  it('accepts a typical domain-anchoring pattern', () => {
+    expect(validateRegexPattern('.*@stadt-marl\\.de')).toBeNull();
+  });
+
+  it('accepts an empty pattern', () => {
+    expect(validateRegexPattern('')).toBeNull();
+  });
+
+  it('rejects a pattern exceeding the length limit', () => {
+    expect(validateRegexPattern('a'.repeat(MAX_PATTERN_LENGTH + 1))).toBe(
+      'too_long',
+    );
+  });
+
+  it('rejects invalid regex syntax', () => {
+    expect(validateRegexPattern('([')).toBe('invalid_syntax');
+  });
+});

--- a/ayunis-core-frontend/src/pages/admin-settings/anonymization-settings/lib/validate-regex.ts
+++ b/ayunis-core-frontend/src/pages/admin-settings/anonymization-settings/lib/validate-regex.ts
@@ -1,0 +1,22 @@
+export const MAX_PATTERN_LENGTH = 200;
+
+export type RegexValidationError = 'too_long' | 'invalid_syntax';
+
+/**
+ * Client-side mirror of the backend pattern validation (length + syntax).
+ * The backend additionally rejects ReDoS-prone patterns; that error is
+ * surfaced from the save response.
+ */
+export function validateRegexPattern(
+  pattern: string,
+): RegexValidationError | null {
+  if (pattern.length > MAX_PATTERN_LENGTH) {
+    return 'too_long';
+  }
+  try {
+    new RegExp(pattern, 'i');
+    return null;
+  } catch {
+    return 'invalid_syntax';
+  }
+}

--- a/ayunis-core-frontend/src/pages/admin-settings/anonymization-settings/model/types.ts
+++ b/ayunis-core-frontend/src/pages/admin-settings/anonymization-settings/model/types.ts
@@ -1,0 +1,22 @@
+import { PiiCategory } from '@/shared/api';
+
+/** Fixed display order of all PII categories. */
+export const PII_CATEGORIES: PiiCategory[] = [
+  PiiCategory.person_name,
+  PiiCategory.organization,
+  PiiCategory.location,
+  PiiCategory.email_address,
+  PiiCategory.phone_number,
+  PiiCategory.url_or_ip,
+  PiiCategory.date_time,
+  PiiCategory.financial_account,
+  PiiCategory.government_id,
+  PiiCategory.nationality_religion_politics,
+];
+
+export interface CategoryRowState {
+  enabled: boolean;
+  pattern: string;
+}
+
+export type RowsState = Record<PiiCategory, CategoryRowState>;

--- a/ayunis-core-frontend/src/pages/admin-settings/anonymization-settings/ui/AnonymizationSettingsPage.tsx
+++ b/ayunis-core-frontend/src/pages/admin-settings/anonymization-settings/ui/AnonymizationSettingsPage.tsx
@@ -1,0 +1,157 @@
+import { useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useQueryClient } from '@tanstack/react-query';
+import { AlertCircle, Loader2 } from 'lucide-react';
+import SettingsLayout from '../../admin-settings-layout';
+import { Button } from '@/shared/ui/shadcn/button';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/shared/ui/shadcn/card';
+import { Alert, AlertDescription } from '@/shared/ui/shadcn/alert';
+import {
+  useAnonymizationSettingsControllerGet,
+  useAnonymizationSettingsControllerUpdate,
+  getAnonymizationSettingsControllerGetQueryKey,
+} from '@/shared/api';
+import type { PiiCategory } from '@/shared/api';
+import extractErrorData from '@/shared/api/extract-error-data';
+import { showSuccess, showError } from '@/shared/lib/toast';
+import { PII_CATEGORIES } from '../model/types';
+import type { CategoryRowState, RowsState } from '../model/types';
+import { buildRows, toEntries, validateRows } from '../lib/rows';
+import type { RowErrors } from '../lib/rows';
+import { PiiCategoryRow } from './PiiCategoryRow';
+
+export function AnonymizationSettingsPage() {
+  const { t: tLayout } = useTranslation('admin-settings-layout');
+  const { t } = useTranslation('admin-settings-anonymization');
+  const queryClient = useQueryClient();
+
+  const { data, isLoading, isError, refetch } =
+    useAnonymizationSettingsControllerGet();
+  const serverRows = useMemo(() => buildRows(data?.entries ?? []), [data]);
+
+  const [draft, setDraft] = useState<RowsState | null>(null);
+  const [errors, setErrors] = useState<RowErrors>({});
+  const rows = draft ?? serverRows;
+
+  const updateMutation = useAnonymizationSettingsControllerUpdate();
+
+  function handleRowChange(category: PiiCategory, row: CategoryRowState) {
+    setDraft({ ...rows, [category]: row });
+    if (errors[category]) {
+      setErrors({ ...errors, [category]: undefined });
+    }
+  }
+
+  function handleSave() {
+    const validationErrors = validateRows(rows);
+    setErrors(validationErrors);
+    if (Object.values(validationErrors).some(Boolean)) {
+      return;
+    }
+
+    updateMutation.mutate(
+      { data: { entries: toEntries(rows) } },
+      {
+        onSuccess: () => {
+          showSuccess(t('piiWhitelist.saveSuccess'));
+          setDraft(null);
+          void queryClient.invalidateQueries({
+            queryKey: getAnonymizationSettingsControllerGetQueryKey(),
+          });
+        },
+        onError: (error) => {
+          handleMutationError(error);
+        },
+      },
+    );
+  }
+
+  function handleMutationError(error: unknown) {
+    try {
+      const { code } = extractErrorData(error);
+      showError(
+        code === 'INVALID_PATTERN'
+          ? t('piiWhitelist.unsafePattern')
+          : t('piiWhitelist.saveError'),
+      );
+    } catch {
+      showError(t('piiWhitelist.saveError'));
+    }
+  }
+
+  if (isLoading) {
+    return (
+      <SettingsLayout title={tLayout('layout.anonymization')}>
+        <Card>
+          <CardContent className="flex items-center justify-center py-12">
+            <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+          </CardContent>
+        </Card>
+      </SettingsLayout>
+    );
+  }
+
+  if (isError) {
+    return (
+      <SettingsLayout title={tLayout('layout.anonymization')}>
+        <Card>
+          <CardContent className="pt-6">
+            <Alert variant="destructive">
+              <AlertCircle className="h-4 w-4" />
+              <AlertDescription>
+                {t('piiWhitelist.loadError')}
+                <Button
+                  variant="link"
+                  className="ml-2 h-auto p-0"
+                  onClick={() => void refetch()}
+                >
+                  {t('piiWhitelist.retry')}
+                </Button>
+              </AlertDescription>
+            </Alert>
+          </CardContent>
+        </Card>
+      </SettingsLayout>
+    );
+  }
+
+  return (
+    <SettingsLayout title={tLayout('layout.anonymization')}>
+      <Card>
+        <CardHeader>
+          <CardTitle>{t('piiWhitelist.heading')}</CardTitle>
+          <CardDescription>{t('piiWhitelist.description')}</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {PII_CATEGORIES.map((category) => (
+            <PiiCategoryRow
+              key={category}
+              category={category}
+              row={rows[category]}
+              error={errors[category]}
+              disabled={updateMutation.isPending}
+              onChange={(row) => handleRowChange(category, row)}
+            />
+          ))}
+
+          <div className="flex justify-end">
+            <Button
+              onClick={handleSave}
+              disabled={updateMutation.isPending || draft === null}
+            >
+              {updateMutation.isPending
+                ? t('piiWhitelist.saving')
+                : t('piiWhitelist.saveButton')}
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+    </SettingsLayout>
+  );
+}

--- a/ayunis-core-frontend/src/pages/admin-settings/anonymization-settings/ui/AnonymizationSettingsPage.tsx
+++ b/ayunis-core-frontend/src/pages/admin-settings/anonymization-settings/ui/AnonymizationSettingsPage.tsx
@@ -58,8 +58,12 @@ export function AnonymizationSettingsPage() {
     updateMutation.mutate(
       { data: { entries: toEntries(rows) } },
       {
-        onSuccess: () => {
+        onSuccess: (updated) => {
           showSuccess(t('piiWhitelist.saveSuccess'));
+          queryClient.setQueryData(
+            getAnonymizationSettingsControllerGetQueryKey(),
+            updated,
+          );
           setDraft(null);
           void queryClient.invalidateQueries({
             queryKey: getAnonymizationSettingsControllerGetQueryKey(),

--- a/ayunis-core-frontend/src/pages/admin-settings/anonymization-settings/ui/PiiCategoryRow.tsx
+++ b/ayunis-core-frontend/src/pages/admin-settings/anonymization-settings/ui/PiiCategoryRow.tsx
@@ -1,0 +1,91 @@
+import { useTranslation } from 'react-i18next';
+import { AlertCircle } from 'lucide-react';
+import { Switch } from '@/shared/ui/shadcn/switch';
+import { Input } from '@/shared/ui/shadcn/input';
+import { Label } from '@/shared/ui/shadcn/label';
+import {
+  Item,
+  ItemActions,
+  ItemContent,
+  ItemDescription,
+  ItemFooter,
+  ItemTitle,
+} from '@/shared/ui/shadcn/item';
+import type { PiiCategory } from '@/shared/api';
+import type { CategoryRowState } from '../model/types';
+import { MAX_PATTERN_LENGTH } from '../lib/validate-regex';
+import type { RegexValidationError } from '../lib/validate-regex';
+
+interface PiiCategoryRowProps {
+  category: PiiCategory;
+  row: CategoryRowState;
+  error?: RegexValidationError;
+  disabled: boolean;
+  onChange: (row: CategoryRowState) => void;
+}
+
+export function PiiCategoryRow({
+  category,
+  row,
+  error,
+  disabled,
+  onChange,
+}: Readonly<PiiCategoryRowProps>) {
+  const { t } = useTranslation('admin-settings-anonymization');
+
+  const label = t(`piiWhitelist.categories.${category}.label`);
+  const errorMessage =
+    error === 'too_long'
+      ? t('piiWhitelist.patternTooLong', { max: MAX_PATTERN_LENGTH })
+      : t('piiWhitelist.invalidPattern');
+
+  return (
+    <Item variant="outline">
+      <ItemContent>
+        <ItemTitle>{label}</ItemTitle>
+        <ItemDescription>
+          {t(`piiWhitelist.categories.${category}.description`)}
+        </ItemDescription>
+      </ItemContent>
+      <ItemActions>
+        <Switch
+          checked={row.enabled}
+          disabled={disabled}
+          aria-label={label}
+          onCheckedChange={(enabled) => onChange({ ...row, enabled })}
+        />
+      </ItemActions>
+
+      {row.enabled && (
+        <ItemFooter>
+          <div className="w-full space-y-2">
+            <Label
+              htmlFor={`pii-pattern-${category}`}
+              className="text-sm font-normal"
+            >
+              {t('piiWhitelist.patternLabel')}
+            </Label>
+            <Input
+              id={`pii-pattern-${category}`}
+              value={row.pattern}
+              disabled={disabled}
+              placeholder={t('piiWhitelist.patternPlaceholder')}
+              className="font-mono text-sm"
+              onChange={(e) => onChange({ ...row, pattern: e.target.value })}
+            />
+            {error ? (
+              <div className="flex items-center gap-2 text-sm text-destructive">
+                <AlertCircle className="h-4 w-4 shrink-0" />
+                <span>{errorMessage}</span>
+              </div>
+            ) : (
+              <p className="text-xs text-muted-foreground">
+                {t('piiWhitelist.patternHint')}
+              </p>
+            )}
+          </div>
+        </ItemFooter>
+      )}
+    </Item>
+  );
+}

--- a/ayunis-core-frontend/src/shared/locales/de/admin-settings-anonymization.json
+++ b/ayunis-core-frontend/src/shared/locales/de/admin-settings-anonymization.json
@@ -1,0 +1,61 @@
+{
+  "piiWhitelist": {
+    "heading": "Ausnahmen von der Anonymisierung",
+    "description": "Im anonymen Modus werden erkannte personenbezogene Daten maskiert, bevor sie an das KI-Modell gesendet werden. Unten aktivierte Kategorien werden von der Maskierung ausgenommen — entweder vollständig oder nur für Werte, die einem optionalen Muster vollständig entsprechen.",
+    "patternLabel": "Nur Werte ausnehmen, die diesem Muster entsprechen (optional)",
+    "patternPlaceholder": "z. B. .*@muster-stadt\\.de",
+    "patternHint": "Regulärer Ausdruck, Groß-/Kleinschreibung wird ignoriert. Der gesamte erkannte Wert muss übereinstimmen. Leer lassen, um die ganze Kategorie auszunehmen.",
+    "invalidPattern": "Dieses Muster ist kein gültiger regulärer Ausdruck.",
+    "patternTooLong": "Das Muster darf höchstens {{max}} Zeichen lang sein.",
+    "unsafePattern": "Dieses Muster wurde abgelehnt, da es zu übermäßiger Verarbeitungszeit führen könnte.",
+    "saveButton": "Speichern",
+    "saving": "Wird gespeichert…",
+    "saveSuccess": "Ausnahmen von der Anonymisierung gespeichert.",
+    "saveError": "Speichern der Ausnahmen ist fehlgeschlagen.",
+    "loadError": "Die Ausnahmen konnten nicht geladen werden.",
+    "retry": "Erneut versuchen",
+    "exemptBadge": "Nicht maskiert",
+    "categories": {
+      "person_name": {
+        "label": "Personennamen",
+        "description": "Vor- und Nachnamen natürlicher Personen"
+      },
+      "organization": {
+        "label": "Organisationen",
+        "description": "Namen von Unternehmen, Institutionen und Behörden"
+      },
+      "location": {
+        "label": "Orte & Adressen",
+        "description": "Städte, Länder, Straßen und Adressen"
+      },
+      "email_address": {
+        "label": "E-Mail-Adressen",
+        "description": "Persönliche und organisatorische E-Mail-Adressen"
+      },
+      "phone_number": {
+        "label": "Telefonnummern",
+        "description": "Festnetz- und Mobilfunknummern"
+      },
+      "url_or_ip": {
+        "label": "URLs & IP-Adressen",
+        "description": "Webadressen und IP-Adressen"
+      },
+      "date_time": {
+        "label": "Datums- & Zeitangaben",
+        "description": "Konkrete Daten und Uhrzeiten, z. B. Geburtsdaten"
+      },
+      "financial_account": {
+        "label": "Finanzdaten",
+        "description": "Kreditkartennummern, IBANs und Kontonummern"
+      },
+      "government_id": {
+        "label": "Amtliche Kennnummern",
+        "description": "Sozialversicherungs-, Pass-, Führerschein- und Approbationsnummern"
+      },
+      "nationality_religion_politics": {
+        "label": "Nationalität, Religion & Politik",
+        "description": "Hinweise auf Nationalität, religiöse oder politische Zugehörigkeit"
+      }
+    }
+  }
+}

--- a/ayunis-core-frontend/src/shared/locales/de/admin-settings-layout.json
+++ b/ayunis-core-frontend/src/shared/locales/de/admin-settings-layout.json
@@ -10,6 +10,7 @@
     "integrations": "Integrationen",
     "usage": "Nutzung",
     "security": "Sicherheit",
+    "anonymization": "Anonymisierung",
     "letterheads": "Briefpapier",
     "apiKeys": "API-Schlüssel"
   }

--- a/ayunis-core-frontend/src/shared/locales/en/admin-settings-anonymization.json
+++ b/ayunis-core-frontend/src/shared/locales/en/admin-settings-anonymization.json
@@ -1,0 +1,61 @@
+{
+  "piiWhitelist": {
+    "heading": "Anonymization exceptions",
+    "description": "In anonymous mode, detected personal data is masked before it is sent to the AI model. Categories enabled below are exempt from masking — either entirely, or only for values that fully match an optional pattern.",
+    "patternLabel": "Only exempt values matching this pattern (optional)",
+    "patternPlaceholder": "e.g. .*@muster-stadt\\.de",
+    "patternHint": "Regular expression, case-insensitive. The entire detected value must match. Leave empty to exempt the whole category.",
+    "invalidPattern": "This pattern is not a valid regular expression.",
+    "patternTooLong": "The pattern must not exceed {{max}} characters.",
+    "unsafePattern": "This pattern was rejected because it could cause excessive processing time.",
+    "saveButton": "Save",
+    "saving": "Saving…",
+    "saveSuccess": "Anonymization exceptions saved.",
+    "saveError": "Saving the anonymization exceptions failed.",
+    "loadError": "The anonymization exceptions could not be loaded.",
+    "retry": "Retry",
+    "exemptBadge": "Not masked",
+    "categories": {
+      "person_name": {
+        "label": "Person names",
+        "description": "First and last names of natural persons"
+      },
+      "organization": {
+        "label": "Organizations",
+        "description": "Names of companies, institutions, and public bodies"
+      },
+      "location": {
+        "label": "Locations & addresses",
+        "description": "Cities, countries, streets, and addresses"
+      },
+      "email_address": {
+        "label": "Email addresses",
+        "description": "Personal and organizational email addresses"
+      },
+      "phone_number": {
+        "label": "Phone numbers",
+        "description": "Landline and mobile numbers"
+      },
+      "url_or_ip": {
+        "label": "URLs & IP addresses",
+        "description": "Web addresses and IP addresses"
+      },
+      "date_time": {
+        "label": "Dates & times",
+        "description": "Specific dates and times, e.g. dates of birth"
+      },
+      "financial_account": {
+        "label": "Financial accounts",
+        "description": "Credit card numbers, IBANs, and bank account numbers"
+      },
+      "government_id": {
+        "label": "Government IDs",
+        "description": "Social security, passport, driver's license, and medical license numbers"
+      },
+      "nationality_religion_politics": {
+        "label": "Nationality, religion & politics",
+        "description": "References to nationality, religious, or political affiliation"
+      }
+    }
+  }
+}

--- a/ayunis-core-frontend/src/shared/locales/en/admin-settings-layout.json
+++ b/ayunis-core-frontend/src/shared/locales/en/admin-settings-layout.json
@@ -10,6 +10,7 @@
     "integrations": "Integrations",
     "usage": "Usage",
     "security": "Security",
+    "anonymization": "Anonymization",
     "letterheads": "Letterheads",
     "apiKeys": "API Keys"
   }


### PR DESCRIPTION
- Admin settings page listing all PII categories with an exemption
  toggle and optional full-match regex per category
- Client-side regex validation mirroring backend rules
- DE/EN translations and sidebar entry

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Misconfigured exemptions could reduce masking in anonymous mode and expose PII to the model; impact is limited to org admins and save is validated client- and server-side.
> 
> **Overview**
> Adds an **org-level anonymization exceptions** admin screen at `/admin-settings/anonymization`, wired into the admin sidebar and i18n (EN/DE).
> 
> Admins can load and save the org **PII whitelist** via the existing anonymization settings API: each PII category has an **exemption toggle** and an optional **full-match regex** (blank pattern = exempt the whole category). The UI uses draft state, blocks save until there are edits, validates patterns client-side (length + syntax, aligned with backend), and surfaces backend `INVALID_PATTERN` (e.g. ReDoS) on save.
> 
> Supporting pieces include row mapping helpers (`buildRows` / `toEntries` / `validateRows`), Vitest coverage, and generated route tree updates for the new page.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d624c2f0d6aa73dcb9942cecaf59b1d1cbb9540. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->