### PR TITLE
wip(api-client): regenerate client for thread mcp integration endpoints (AYC-000)

### DIFF
--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
@@ -2287,6 +2287,18 @@ export interface PiiMaskResponseDto {
   category: PiiCategory;
 }
 
+export interface McpIntegrationSummaryResponseDto {
+  /** Unique identifier for the MCP integration */
+  id: string;
+  /** Name of the MCP integration */
+  name: string;
+  /**
+   * Logo URL for marketplace integrations
+   * @nullable
+   */
+  logoUrl?: string | null;
+}
+
 export type GetThreadResponseDtoMessagesItem = UserMessageResponseDto | SystemMessageResponseDto | AssistantMessageResponseDto | ToolResultMessageResponseDto;
 
 export interface GetThreadResponseDto {
@@ -2314,6 +2326,8 @@ export interface GetThreadResponseDto {
   knowledgeBases: KnowledgeBaseSummaryResponseDto[];
   /** PII mask dictionary for anonymous threads — resolves {{pii:...}} tokens in message text to their original values. Empty for non-anonymous threads. */
   piiMasks: PiiMaskResponseDto[];
+  /** MCP integrations attached to this thread */
+  mcpIntegrations: McpIntegrationSummaryResponseDto[];
 }
 
 export interface GetThreadsResponseDtoItem {

--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.ts
@@ -8530,6 +8530,133 @@ export const useThreadKnowledgeBasesControllerRemoveKnowledgeBase = <TError = vo
     }
     
 /**
+ * @summary Add an MCP integration to a thread
+ */
+export const threadMcpIntegrationsControllerAddMcpIntegration = (
+    id: string,
+    mcpIntegrationId: string,
+ signal?: AbortSignal
+) => {
+      
+      
+      return customAxiosInstance<void>(
+      {url: `/threads/${id}/mcp-integrations/${mcpIntegrationId}`, method: 'POST', signal
+    },
+      );
+    }
+  
+
+
+export const getThreadMcpIntegrationsControllerAddMcpIntegrationMutationOptions = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof threadMcpIntegrationsControllerAddMcpIntegration>>, TError,{id: string;mcpIntegrationId: string}, TContext>, }
+): UseMutationOptions<Awaited<ReturnType<typeof threadMcpIntegrationsControllerAddMcpIntegration>>, TError,{id: string;mcpIntegrationId: string}, TContext> => {
+
+const mutationKey = ['threadMcpIntegrationsControllerAddMcpIntegration'];
+const {mutation: mutationOptions} = options ?
+      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
+      options
+      : {...options, mutation: {...options.mutation, mutationKey}}
+      : {mutation: { mutationKey, }};
+
+      
+
+
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof threadMcpIntegrationsControllerAddMcpIntegration>>, {id: string;mcpIntegrationId: string}> = (props) => {
+          const {id,mcpIntegrationId} = props ?? {};
+
+          return  threadMcpIntegrationsControllerAddMcpIntegration(id,mcpIntegrationId,)
+        }
+
+        
+
+
+  return  { mutationFn, ...mutationOptions }}
+
+    export type ThreadMcpIntegrationsControllerAddMcpIntegrationMutationResult = NonNullable<Awaited<ReturnType<typeof threadMcpIntegrationsControllerAddMcpIntegration>>>
+    
+    export type ThreadMcpIntegrationsControllerAddMcpIntegrationMutationError = void
+
+    /**
+ * @summary Add an MCP integration to a thread
+ */
+export const useThreadMcpIntegrationsControllerAddMcpIntegration = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof threadMcpIntegrationsControllerAddMcpIntegration>>, TError,{id: string;mcpIntegrationId: string}, TContext>, }
+ , queryClient?: QueryClient): UseMutationResult<
+        Awaited<ReturnType<typeof threadMcpIntegrationsControllerAddMcpIntegration>>,
+        TError,
+        {id: string;mcpIntegrationId: string},
+        TContext
+      > => {
+
+      const mutationOptions = getThreadMcpIntegrationsControllerAddMcpIntegrationMutationOptions(options);
+
+      return useMutation(mutationOptions, queryClient);
+    }
+    
+/**
+ * @summary Remove an MCP integration from a thread
+ */
+export const threadMcpIntegrationsControllerRemoveMcpIntegration = (
+    id: string,
+    mcpIntegrationId: string,
+ ) => {
+      
+      
+      return customAxiosInstance<void>(
+      {url: `/threads/${id}/mcp-integrations/${mcpIntegrationId}`, method: 'DELETE'
+    },
+      );
+    }
+  
+
+
+export const getThreadMcpIntegrationsControllerRemoveMcpIntegrationMutationOptions = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof threadMcpIntegrationsControllerRemoveMcpIntegration>>, TError,{id: string;mcpIntegrationId: string}, TContext>, }
+): UseMutationOptions<Awaited<ReturnType<typeof threadMcpIntegrationsControllerRemoveMcpIntegration>>, TError,{id: string;mcpIntegrationId: string}, TContext> => {
+
+const mutationKey = ['threadMcpIntegrationsControllerRemoveMcpIntegration'];
+const {mutation: mutationOptions} = options ?
+      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
+      options
+      : {...options, mutation: {...options.mutation, mutationKey}}
+      : {mutation: { mutationKey, }};
+
+      
+
+
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof threadMcpIntegrationsControllerRemoveMcpIntegration>>, {id: string;mcpIntegrationId: string}> = (props) => {
+          const {id,mcpIntegrationId} = props ?? {};
+
+          return  threadMcpIntegrationsControllerRemoveMcpIntegration(id,mcpIntegrationId,)
+        }
+
+        
+
+
+  return  { mutationFn, ...mutationOptions }}
+
+    export type ThreadMcpIntegrationsControllerRemoveMcpIntegrationMutationResult = NonNullable<Awaited<ReturnType<typeof threadMcpIntegrationsControllerRemoveMcpIntegration>>>
+    
+    export type ThreadMcpIntegrationsControllerRemoveMcpIntegrationMutationError = void
+
+    /**
+ * @summary Remove an MCP integration from a thread
+ */
+export const useThreadMcpIntegrationsControllerRemoveMcpIntegration = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof threadMcpIntegrationsControllerRemoveMcpIntegration>>, TError,{id: string;mcpIntegrationId: string}, TContext>, }
+ , queryClient?: QueryClient): UseMutationResult<
+        Awaited<ReturnType<typeof threadMcpIntegrationsControllerRemoveMcpIntegration>>,
+        TError,
+        {id: string;mcpIntegrationId: string},
+        TContext
+      > => {
+
+      const mutationOptions = getThreadMcpIntegrationsControllerRemoveMcpIntegrationMutationOptions(options);
+
+      return useMutation(mutationOptions, queryClient);
+    }
+    
+/**
  * @summary Get presigned URL for a generated image
  */
 export const generatedImagesControllerResolve = (

--- a/ayunis-core-frontend/src/shared/api/openapi-schema.json
+++ b/ayunis-core-frontend/src/shared/api/openapi-schema.json
@@ -4282,6 +4282,78 @@
         "tags": ["threads"]
       }
     },
+    "/threads/{id}/mcp-integrations/{mcpIntegrationId}": {
+      "post": {
+        "operationId": "ThreadMcpIntegrationsController_addMcpIntegration",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "description": "The UUID of the thread",
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "name": "mcpIntegrationId",
+            "required": true,
+            "in": "path",
+            "description": "The UUID of the MCP integration to add",
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "The MCP integration has been successfully added to the thread"
+          },
+          "404": {
+            "description": "Thread or MCP integration not found"
+          }
+        },
+        "summary": "Add an MCP integration to a thread",
+        "tags": ["threads"]
+      },
+      "delete": {
+        "operationId": "ThreadMcpIntegrationsController_removeMcpIntegration",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "description": "The UUID of the thread",
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "name": "mcpIntegrationId",
+            "required": true,
+            "in": "path",
+            "description": "The UUID of the MCP integration to remove",
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "The MCP integration has been successfully removed from the thread"
+          },
+          "404": {
+            "description": "Thread not found"
+          }
+        },
+        "summary": "Remove an MCP integration from a thread",
+        "tags": ["threads"]
+      }
+    },
     "/threads/{threadId}/generated-images/{imageId}": {
       "get": {
         "operationId": "GeneratedImagesController_resolve",
@@ -11499,6 +11571,28 @@
         },
         "required": ["token", "value", "category"]
       },
+      "McpIntegrationSummaryResponseDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Unique identifier for the MCP integration",
+            "example": "123e4567-e89b-12d3-a456-426614174000"
+          },
+          "name": {
+            "type": "string",
+            "description": "Name of the MCP integration",
+            "example": "OParl Council Data"
+          },
+          "logoUrl": {
+            "type": "string",
+            "description": "Logo URL for marketplace integrations",
+            "nullable": true,
+            "example": "https://marketplace.ayunis.de/logos/oparl.png"
+          }
+        },
+        "required": ["id", "name"]
+      },
       "GetThreadResponseDto": {
         "type": "object",
         "properties": {
@@ -11582,6 +11676,13 @@
             "items": {
               "$ref": "#/components/schemas/PiiMaskResponseDto"
             }
+          },
+          "mcpIntegrations": {
+            "description": "MCP integrations attached to this thread",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/McpIntegrationSummaryResponseDto"
+            }
           }
         },
         "required": [
@@ -11595,7 +11696,8 @@
           "isAnonymous",
           "isLongChat",
           "knowledgeBases",
-          "piiMasks"
+          "piiMasks",
+          "mcpIntegrations"
         ]
       },
       "GetThreadsResponseDtoItem": {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Generated-only changes with no app logic in this PR; consumers must handle the new required `mcpIntegrations` field on thread fetches.
> 
> **Overview**
> Regenerates the frontend API client from an updated OpenAPI spec so threads can **attach and detach MCP integrations** and thread fetches can return which integrations are linked.
> 
> **OpenAPI** adds `POST`/`DELETE` on `/threads/{id}/mcp-integrations/{mcpIntegrationId}` (204 on success) and documents **`McpIntegrationSummaryResponseDto`** (`id`, `name`, optional `logoUrl`). **`GetThreadResponseDto`** now includes a required **`mcpIntegrations`** array alongside existing fields like `knowledgeBases`.
> 
> **Generated client** exports **`McpIntegrationSummaryResponseDto`**, extends thread types with `mcpIntegrations`, and adds **`threadMcpIntegrationsControllerAddMcpIntegration`** / **`Remove`** plus matching React Query **`useThreadMcpIntegrationsController*`** mutations—same pattern as thread knowledge-base attach APIs already used in chat init.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f31e798e7fe6bfd502aaf71f168ef841e37d448c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->