### PR TITLE
chore(lint): format files committed with lint violations (AYC-227)

### DIFF
--- a/ayunis-core-backend/src/db/migrations/1780642265172-CreateCrawlDomainGrantsTable.ts
+++ b/ayunis-core-backend/src/db/migrations/1780642265172-CreateCrawlDomainGrantsTable.ts
@@ -1,18 +1,27 @@
-import { MigrationInterface, QueryRunner } from "typeorm";
+import type { MigrationInterface, QueryRunner } from 'typeorm';
 
 export class CreateCrawlDomainGrantsTable1780642265172 implements MigrationInterface {
-    name = 'CreateCrawlDomainGrantsTable1780642265172'
+  name = 'CreateCrawlDomainGrantsTable1780642265172';
 
-    public async up(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.query(`CREATE TABLE "crawl_domain_grants" ("id" character varying NOT NULL, "createdAt" TIMESTAMP NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP NOT NULL DEFAULT now(), "domain" character varying NOT NULL, "orgId" character varying NOT NULL, CONSTRAINT "UQ_db3eb87481937f459c372128278" UNIQUE ("domain"), CONSTRAINT "PK_742af002e017f2e98ae7eeeff77" PRIMARY KEY ("id"))`);
-        await queryRunner.query(`CREATE INDEX "IDX_0703c6d88796fa39ae43e325fc" ON "crawl_domain_grants" ("orgId") `);
-        await queryRunner.query(`ALTER TABLE "crawl_domain_grants" ADD CONSTRAINT "FK_0703c6d88796fa39ae43e325fc2" FOREIGN KEY ("orgId") REFERENCES "orgs"("id") ON DELETE CASCADE ON UPDATE NO ACTION`);
-    }
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE "crawl_domain_grants" ("id" character varying NOT NULL, "createdAt" TIMESTAMP NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP NOT NULL DEFAULT now(), "domain" character varying NOT NULL, "orgId" character varying NOT NULL, CONSTRAINT "UQ_db3eb87481937f459c372128278" UNIQUE ("domain"), CONSTRAINT "PK_742af002e017f2e98ae7eeeff77" PRIMARY KEY ("id"))`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_0703c6d88796fa39ae43e325fc" ON "crawl_domain_grants" ("orgId") `,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "crawl_domain_grants" ADD CONSTRAINT "FK_0703c6d88796fa39ae43e325fc2" FOREIGN KEY ("orgId") REFERENCES "orgs"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+  }
 
-    public async down(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.query(`ALTER TABLE "crawl_domain_grants" DROP CONSTRAINT "FK_0703c6d88796fa39ae43e325fc2"`);
-        await queryRunner.query(`DROP INDEX "public"."IDX_0703c6d88796fa39ae43e325fc"`);
-        await queryRunner.query(`DROP TABLE "crawl_domain_grants"`);
-    }
-
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "crawl_domain_grants" DROP CONSTRAINT "FK_0703c6d88796fa39ae43e325fc2"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_0703c6d88796fa39ae43e325fc"`,
+    );
+    await queryRunner.query(`DROP TABLE "crawl_domain_grants"`);
+  }
 }

--- a/ayunis-core-backend/src/db/scripts/seed-marketplace-mcp.ts
+++ b/ayunis-core-backend/src/db/scripts/seed-marketplace-mcp.ts
@@ -13,7 +13,6 @@
  */
 import 'src/config/env';
 import { randomUUID } from 'crypto';
-import type { UUID } from 'crypto';
 import dataSource from 'src/db/datasource';
 import { OrgRecord } from 'src/iam/orgs/infrastructure/repositories/local/schema/org.record';
 import { MarketplaceMcpIntegrationRecord } from 'src/domain/mcp/infrastructure/persistence/postgres/schema/marketplace-mcp-integration.record';
@@ -49,7 +48,7 @@ async function run(): Promise<void> {
     for (const org of orgs) {
       const existing = await intRepo.findOne({
         where: {
-          orgId: org.id as UUID,
+          orgId: org.id,
           marketplaceIdentifier: MARKETPLACE_IDENTIFIER,
         },
       });
@@ -62,7 +61,7 @@ async function run(): Promise<void> {
 
       const record = new MarketplaceMcpIntegrationRecord();
       record.id = integrationId;
-      record.orgId = org.id as UUID;
+      record.orgId = org.id;
       record.name = 'Local Test (User Auth)';
       record.serverUrl = 'https://staging-api.speechmind.com/mcp/';
       record.enabled = true;

--- a/ayunis-core-backend/src/domain/models/infrastructure/stream-inference/base-ollama.stream-inference.ts
+++ b/ayunis-core-backend/src/domain/models/infrastructure/stream-inference/base-ollama.stream-inference.ts
@@ -111,7 +111,7 @@ export class BaseOllamaStreamInferenceHandler implements StreamInferenceHandler 
   ): StreamInferenceResponseChunk => {
     const delta = chunk.message;
     const { thinkingDelta, textContentDelta } = this.parseChunkContent(delta);
-    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- thinking may be empty string at runtime
+
     const thinkingContent = delta.thinking || null;
 
     return new StreamInferenceResponseChunk({

--- a/ayunis-core-backend/src/iam/quotas/application/use-cases/check-quota/check-quota.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/quotas/application/use-cases/check-quota/check-quota.use-case.spec.ts
@@ -24,7 +24,7 @@ describe('CheckQuotaUseCase', () => {
     usageQuotaRepository = {
       checkAndIncrement: jest.fn(),
       incrementAndGet: jest.fn(),
-    } as unknown as jest.Mocked<UsageQuotaRepositoryPort>;
+    };
 
     limitResolver = {
       resolve: jest.fn().mockResolvedValue({ limit: 10, windowMs: 60_000 }),


### PR DESCRIPTION
Four files on main fail eslint --fix / prettier, so they were
committed bypassing hooks and dirty the working tree of anyone
running pnpm lint:

- CreateCrawlDomainGrantsTable migration (raw TypeORM output)
- seed-marketplace-mcp.ts (unused UUID import)
- base-ollama.stream-inference.ts
- check-quota.use-case.spec.ts

Pure formatting plus one unused-import removal, no behavior change.
Found during AYC-184.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Style and typing-only edits; migration SQL and runtime logic are unchanged.
> 
> **Overview**
> Brings four files that were committed without passing **eslint/prettier** back in line so `pnpm lint` no longer dirties the working tree (AYC-227).
> 
> **`CreateCrawlDomainGrantsTable` migration** is reformatted (type-only TypeORM import, indentation, wrapped SQL strings) with the same DDL.
> 
> **`seed-marketplace-mcp.ts`** drops an unused `UUID` import and removes redundant `as UUID` casts on `org.id`.
> 
> **`base-ollama.stream-inference.ts`** removes an eslint-disable above `delta.thinking || null` without changing the logic.
> 
> **`check-quota.use-case.spec.ts`** simplifies the `usageQuotaRepository` test double typing (no `as unknown as jest.Mocked<...>`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cee700819c2e144423d7c83277f0ebc08065ef93. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->