### PR TITLE
wip(anonymization): add pii mask domain and mask-aware anonymization (AYC-118)

### DIFF
--- a/ayunis-core-backend/src/common/anonymization/application/ports/anonymization.port.ts
+++ b/ayunis-core-backend/src/common/anonymization/application/ports/anonymization.port.ts
@@ -1,9 +1,10 @@
 import type { PiiCategory } from '../../domain/pii-category.enum';
 import type { PiiDetection } from '../../domain/pii-detection';
+import type { PiiMask } from '../../domain/pii-mask';
 
 export interface AnonymizationReplacement {
   entityType: string;
-  category?: PiiCategory;
+  category: PiiCategory;
   originalValue: string;
   start: number;
   end: number;
@@ -14,6 +15,8 @@ export interface AnonymizationResult {
   originalText: string;
   anonymizedText: string;
   replacements: AnonymizationReplacement[];
+  /** Masks newly created for this text; empty in legacy placeholder mode. */
+  newMasks: PiiMask[];
 }
 
 /**

--- a/ayunis-core-backend/src/common/anonymization/application/use-cases/anonymize-text/anonymize-text.command.ts
+++ b/ayunis-core-backend/src/common/anonymization/application/use-cases/anonymize-text/anonymize-text.command.ts
@@ -1,3 +1,4 @@
+import type { PiiMask } from '../../../domain/pii-mask';
 import type { PiiWhitelistEntry } from '../../../domain/pii-whitelist-entry';
 
 export class AnonymizeTextCommand {
@@ -5,5 +6,11 @@ export class AnonymizeTextCommand {
     public readonly text: string,
     public readonly entities?: string[],
     public readonly whitelist?: PiiWhitelistEntry[],
+    /**
+     * When set (even if empty), detections are replaced with stable
+     * `{{pii:CATEGORY_n}}` tokens dedup'd against these masks instead of the
+     * legacy `[ENTITY_TYPE]` placeholders.
+     */
+    public readonly existingMasks?: PiiMask[],
   ) {}
 }

--- a/ayunis-core-backend/src/common/anonymization/application/use-cases/anonymize-text/anonymize-text.use-case.spec.ts
+++ b/ayunis-core-backend/src/common/anonymization/application/use-cases/anonymize-text/anonymize-text.use-case.spec.ts
@@ -72,4 +72,56 @@ describe('AnonymizeTextUseCase', () => {
 
     expect(detect).toHaveBeenCalledWith(text, ['PERSON']);
   });
+
+  it('produces legacy placeholders and no new masks without existingMasks', async () => {
+    detect.mockResolvedValue(detections);
+
+    const result = await useCase.execute(new AnonymizeTextCommand(text));
+
+    expect(result.anonymizedText).toBe(
+      'Ich bin der [PERSON], erreichbar unter [EMAIL_ADDRESS]',
+    );
+    expect(result.newMasks).toEqual([]);
+  });
+
+  it('produces numbered mask tokens when existingMasks is given', async () => {
+    detect.mockResolvedValue(detections);
+
+    const result = await useCase.execute(
+      new AnonymizeTextCommand(text, undefined, undefined, []),
+    );
+
+    expect(result.anonymizedText).toBe(
+      'Ich bin der {{pii:PERSON_NAME_1}}, erreichbar unter {{pii:EMAIL_ADDRESS_1}}',
+    );
+    expect(result.newMasks).toEqual([
+      {
+        category: PiiCategory.PERSON_NAME,
+        maskIndex: 1,
+        value: 'Dani',
+      },
+      {
+        category: PiiCategory.EMAIL_ADDRESS,
+        maskIndex: 1,
+        value: 'amt32@stadt-marl.de',
+      },
+    ]);
+  });
+
+  it('reuses existing masks and applies the whitelist before masking', async () => {
+    detect.mockResolvedValue(detections);
+    const whitelist = [new PiiWhitelistEntry(PiiCategory.EMAIL_ADDRESS, null)];
+    const existingMasks = [
+      { category: PiiCategory.PERSON_NAME, maskIndex: 1, value: 'Dani' },
+    ];
+
+    const result = await useCase.execute(
+      new AnonymizeTextCommand(text, undefined, whitelist, existingMasks),
+    );
+
+    expect(result.anonymizedText).toBe(
+      'Ich bin der {{pii:PERSON_NAME_1}}, erreichbar unter amt32@stadt-marl.de',
+    );
+    expect(result.newMasks).toEqual([]);
+  });
 });

--- a/ayunis-core-backend/src/common/anonymization/application/use-cases/anonymize-text/anonymize-text.use-case.ts
+++ b/ayunis-core-backend/src/common/anonymization/application/use-cases/anonymize-text/anonymize-text.use-case.ts
@@ -6,7 +6,9 @@ import {
 import { AnonymizeTextCommand } from './anonymize-text.command';
 import { filterWhitelistedDetections } from '../../../domain/whitelist-filter';
 import { applyReplacements } from '../../../domain/apply-replacements';
+import { applyMaskReplacements } from '../../../domain/apply-mask-replacements';
 import { PiiDetection } from '../../../domain/pii-detection';
+import { PiiMask } from '../../../domain/pii-mask';
 
 @Injectable()
 export class AnonymizeTextUseCase {
@@ -29,10 +31,33 @@ export class AnonymizeTextUseCase {
       ? filterWhitelistedDetections(detections, command.whitelist)
       : detections;
 
+    const { anonymizedText, newMasks } = this.buildAnonymizedText(
+      command,
+      remaining,
+    );
+
     return {
       originalText: command.text,
-      anonymizedText: applyReplacements(command.text, remaining),
+      anonymizedText,
       replacements: remaining.map((detection) => this.toReplacement(detection)),
+      newMasks,
+    };
+  }
+
+  private buildAnonymizedText(
+    command: AnonymizeTextCommand,
+    detections: PiiDetection[],
+  ): { anonymizedText: string; newMasks: PiiMask[] } {
+    if (command.existingMasks !== undefined) {
+      return applyMaskReplacements(
+        command.text,
+        detections,
+        command.existingMasks,
+      );
+    }
+    return {
+      anonymizedText: applyReplacements(command.text, detections),
+      newMasks: [],
     };
   }
 

--- a/ayunis-core-backend/src/common/anonymization/domain/apply-mask-replacements.spec.ts
+++ b/ayunis-core-backend/src/common/anonymization/domain/apply-mask-replacements.spec.ts
@@ -1,0 +1,149 @@
+import { applyMaskReplacements } from './apply-mask-replacements';
+import type { PiiMask } from './pii-mask';
+import { formatPiiToken } from './pii-mask';
+import { PiiCategory } from './pii-category.enum';
+import type { PiiDetection } from './pii-detection';
+
+function detection(
+  text: string,
+  value: string,
+  category: PiiCategory,
+  start: number,
+): PiiDetection {
+  return {
+    entityType: 'TEST',
+    category,
+    text: value,
+    start,
+    end: start + value.length,
+    score: 0.9,
+  };
+}
+
+describe('formatPiiToken', () => {
+  it('formats the category uppercased with the mask index', () => {
+    expect(
+      formatPiiToken({ category: PiiCategory.PERSON_NAME, maskIndex: 1 }),
+    ).toBe('{{pii:PERSON_NAME_1}}');
+  });
+});
+
+describe('applyMaskReplacements', () => {
+  it('returns the original text and no new masks when there are no detections', () => {
+    const result = applyMaskReplacements('Hallo Welt', [], []);
+
+    expect(result.anonymizedText).toBe('Hallo Welt');
+    expect(result.newMasks).toEqual([]);
+  });
+
+  it('replaces the first value of a category with index 1', () => {
+    const text = 'Ich bin der Dani';
+    const result = applyMaskReplacements(
+      text,
+      [detection(text, 'Dani', PiiCategory.PERSON_NAME, 12)],
+      [],
+    );
+
+    expect(result.anonymizedText).toBe('Ich bin der {{pii:PERSON_NAME_1}}');
+    expect(result.newMasks).toEqual([
+      { category: PiiCategory.PERSON_NAME, maskIndex: 1, value: 'Dani' },
+    ]);
+  });
+
+  it('reuses one token for a repeated value within the same text', () => {
+    const text = 'Dani hier, schreib an Dani';
+    const result = applyMaskReplacements(
+      text,
+      [
+        detection(text, 'Dani', PiiCategory.PERSON_NAME, 0),
+        detection(text, 'Dani', PiiCategory.PERSON_NAME, 22),
+      ],
+      [],
+    );
+
+    expect(result.anonymizedText).toBe(
+      '{{pii:PERSON_NAME_1}} hier, schreib an {{pii:PERSON_NAME_1}}',
+    );
+    expect(result.newMasks).toHaveLength(1);
+  });
+
+  it('reuses an existing mask for a value seen in an earlier message', () => {
+    const text = 'Gruß an Dani';
+    const existing: PiiMask[] = [
+      { category: PiiCategory.PERSON_NAME, maskIndex: 1, value: 'Dani' },
+    ];
+    const result = applyMaskReplacements(
+      text,
+      [detection(text, 'Dani', PiiCategory.PERSON_NAME, 8)],
+      existing,
+    );
+
+    expect(result.anonymizedText).toBe('Gruß an {{pii:PERSON_NAME_1}}');
+    expect(result.newMasks).toEqual([]);
+  });
+
+  it('continues numbering from the highest existing index per category', () => {
+    const text = 'Gruß an Max';
+    const existing: PiiMask[] = [
+      { category: PiiCategory.PERSON_NAME, maskIndex: 1, value: 'Dani' },
+      { category: PiiCategory.PERSON_NAME, maskIndex: 2, value: 'Moritz' },
+      { category: PiiCategory.EMAIL_ADDRESS, maskIndex: 1, value: 'a@b.de' },
+    ];
+    const result = applyMaskReplacements(
+      text,
+      [detection(text, 'Max', PiiCategory.PERSON_NAME, 8)],
+      existing,
+    );
+
+    expect(result.anonymizedText).toBe('Gruß an {{pii:PERSON_NAME_3}}');
+    expect(result.newMasks).toEqual([
+      { category: PiiCategory.PERSON_NAME, maskIndex: 3, value: 'Max' },
+    ]);
+  });
+
+  it('assigns distinct tokens to the same value under different categories', () => {
+    const text = 'Berlin und Berlin';
+    const result = applyMaskReplacements(
+      text,
+      [
+        detection(text, 'Berlin', PiiCategory.PERSON_NAME, 0),
+        detection(text, 'Berlin', PiiCategory.LOCATION, 11),
+      ],
+      [],
+    );
+
+    expect(result.anonymizedText).toBe(
+      '{{pii:PERSON_NAME_1}} und {{pii:LOCATION_1}}',
+    );
+    expect(result.newMasks).toHaveLength(2);
+  });
+
+  it('masks unmapped engine types under the OTHER category', () => {
+    const text = 'Code X17B';
+    const result = applyMaskReplacements(
+      text,
+      [detection(text, 'X17B', PiiCategory.OTHER, 5)],
+      [],
+    );
+
+    expect(result.anonymizedText).toBe('Code {{pii:OTHER_1}}');
+  });
+
+  it('preserves offsets when replacing multiple detections across categories', () => {
+    const text = 'Dani wohnt in Deisenhofen und mailt über dani@example.com';
+    const result = applyMaskReplacements(
+      text,
+      [
+        detection(text, 'Dani', PiiCategory.PERSON_NAME, 0),
+        detection(text, 'Deisenhofen', PiiCategory.LOCATION, 14),
+        detection(text, 'dani@example.com', PiiCategory.EMAIL_ADDRESS, 41),
+      ],
+      [],
+    );
+
+    expect(result.anonymizedText).toBe(
+      '{{pii:PERSON_NAME_1}} wohnt in {{pii:LOCATION_1}} und mailt über {{pii:EMAIL_ADDRESS_1}}',
+    );
+    expect(result.newMasks).toHaveLength(3);
+  });
+});

--- a/ayunis-core-backend/src/common/anonymization/domain/apply-mask-replacements.ts
+++ b/ayunis-core-backend/src/common/anonymization/domain/apply-mask-replacements.ts
@@ -1,0 +1,85 @@
+import type { PiiCategory } from './pii-category.enum';
+import type { PiiDetection } from './pii-detection';
+import type { PiiMask } from './pii-mask';
+import { formatPiiToken } from './pii-mask';
+
+export interface MaskReplacementResult {
+  anonymizedText: string;
+  /** Masks created for values not covered by existingMasks. */
+  newMasks: PiiMask[];
+}
+
+/**
+ * Replaces each detected span with its `{{pii:CATEGORY_n}}` token, reusing
+ * existing masks so the same (category, value) pair always yields the same
+ * token across a thread. Detections must be non-overlapping (see
+ * dropOverlappingResults in the engine adapter); replacing from end to start
+ * preserves earlier offsets.
+ */
+export function applyMaskReplacements(
+  text: string,
+  detections: PiiDetection[],
+  existingMasks: PiiMask[],
+): MaskReplacementResult {
+  if (detections.length === 0) {
+    return { anonymizedText: text, newMasks: [] };
+  }
+
+  const registry = createMaskRegistry(existingMasks);
+
+  // Resolve in document order so indices read naturally, replace end-to-start.
+  const inDocumentOrder = [...detections].sort((a, b) => a.start - b.start);
+  const masks = new Map(
+    inDocumentOrder.map((detection) => [
+      detection,
+      registry.resolve(detection.category, text.slice(detection.start, detection.end)),
+    ]),
+  );
+
+  let anonymizedText = text;
+  for (const detection of [...detections].sort((a, b) => b.end - a.end)) {
+    anonymizedText =
+      anonymizedText.substring(0, detection.start) +
+      formatPiiToken(masks.get(detection) as PiiMask) +
+      anonymizedText.substring(detection.end);
+  }
+
+  return { anonymizedText, newMasks: registry.newMasks };
+}
+
+interface MaskRegistry {
+  resolve(category: PiiCategory, value: string): PiiMask;
+  newMasks: PiiMask[];
+}
+
+function createMaskRegistry(existingMasks: PiiMask[]): MaskRegistry {
+  const masksByValue = new Map<string, PiiMask>(
+    existingMasks.map((mask) => [maskKey(mask.category, mask.value), mask]),
+  );
+  const nextIndexByCategory = new Map<PiiCategory, number>();
+  for (const mask of existingMasks) {
+    const next = nextIndexByCategory.get(mask.category) ?? 1;
+    nextIndexByCategory.set(mask.category, Math.max(next, mask.maskIndex + 1));
+  }
+
+  const newMasks: PiiMask[] = [];
+  const resolve = (category: PiiCategory, value: string): PiiMask => {
+    const key = maskKey(category, value);
+    const existing = masksByValue.get(key);
+    if (existing) {
+      return existing;
+    }
+    const maskIndex = nextIndexByCategory.get(category) ?? 1;
+    nextIndexByCategory.set(category, maskIndex + 1);
+    const mask: PiiMask = { category, maskIndex, value };
+    masksByValue.set(key, mask);
+    newMasks.push(mask);
+    return mask;
+  };
+
+  return { resolve, newMasks };
+}
+
+function maskKey(category: PiiCategory, value: string): string {
+  return `${category} ${value}`;
+}

--- a/ayunis-core-backend/src/common/anonymization/domain/pii-category.enum.ts
+++ b/ayunis-core-backend/src/common/anonymization/domain/pii-category.enum.ts
@@ -3,8 +3,9 @@
  *
  * Each anonymization engine adapter maps its own entity types onto these
  * categories (see e.g. presidio-entity-category.mapper.ts). The mapping must
- * be total in the engine→category direction; categories without a mapping on
- * the current engine are simply dormant.
+ * be total in the engine→category direction; engine types without an explicit
+ * mapping fall back to OTHER, and categories without a mapping on the current
+ * engine are simply dormant.
  */
 export enum PiiCategory {
   PERSON_NAME = 'person_name',
@@ -17,4 +18,5 @@ export enum PiiCategory {
   FINANCIAL_ACCOUNT = 'financial_account',
   GOVERNMENT_ID = 'government_id',
   NATIONALITY_RELIGION_POLITICS = 'nationality_religion_politics',
+  OTHER = 'other',
 }

--- a/ayunis-core-backend/src/common/anonymization/domain/pii-detection.ts
+++ b/ayunis-core-backend/src/common/anonymization/domain/pii-detection.ts
@@ -3,8 +3,8 @@ import type { PiiCategory } from './pii-category.enum';
 export interface PiiDetection {
   /** Engine-specific entity type, e.g. Presidio's `IBAN_CODE`. */
   entityType: string;
-  /** Engine-agnostic category; undefined when the engine emits an unmapped type. */
-  category?: PiiCategory;
+  /** Engine-agnostic category; OTHER when the engine emits an unmapped type. */
+  category: PiiCategory;
   /** The detected span text. */
   text: string;
   start: number;

--- a/ayunis-core-backend/src/common/anonymization/domain/pii-mask.ts
+++ b/ayunis-core-backend/src/common/anonymization/domain/pii-mask.ts
@@ -1,0 +1,20 @@
+import type { PiiCategory } from './pii-category.enum';
+
+/**
+ * A stable pseudonym for one original PII value within a thread. The same
+ * (category, value) pair always resolves to the same token, so the LLM can
+ * refer to entities coherently across messages.
+ */
+export interface PiiMask {
+  category: PiiCategory;
+  /** 1-based, numbered per category within a thread. */
+  maskIndex: number;
+  /** The original (sensitive) text the token stands in for. */
+  value: string;
+}
+
+export function formatPiiToken(
+  mask: Pick<PiiMask, 'category' | 'maskIndex'>,
+): string {
+  return `{{pii:${mask.category.toUpperCase()}_${mask.maskIndex}}}`;
+}

--- a/ayunis-core-backend/src/common/anonymization/domain/whitelist-filter.spec.ts
+++ b/ayunis-core-backend/src/common/anonymization/domain/whitelist-filter.spec.ts
@@ -112,21 +112,34 @@ describe('filterWhitelistedDetections', () => {
     );
   });
 
-  it('never exempts a detection without a mapped category', () => {
+  it('keeps OTHER detections when only other categories are whitelisted', () => {
     const detections = [
       detection({
         entityType: 'CUSTOM_FUTURE_ENTITY',
-        category: undefined,
+        category: PiiCategory.OTHER,
         text: 'irgendein Wert',
       }),
     ];
-    const entries = Object.values(PiiCategory).map(
-      (category) => new PiiWhitelistEntry(category, null),
-    );
+    const entries = Object.values(PiiCategory)
+      .filter((category) => category !== PiiCategory.OTHER)
+      .map((category) => new PiiWhitelistEntry(category, null));
 
     expect(filterWhitelistedDetections(detections, entries)).toEqual(
       detections,
     );
+  });
+
+  it('exempts OTHER detections when OTHER is explicitly whitelisted', () => {
+    const detections = [
+      detection({
+        entityType: 'CUSTOM_FUTURE_ENTITY',
+        category: PiiCategory.OTHER,
+        text: 'irgendein Wert',
+      }),
+    ];
+    const entries = [new PiiWhitelistEntry(PiiCategory.OTHER, null)];
+
+    expect(filterWhitelistedDetections(detections, entries)).toEqual([]);
   });
 
   it('filters a mixed set of detections independently', () => {

--- a/ayunis-core-backend/src/common/anonymization/domain/whitelist-filter.ts
+++ b/ayunis-core-backend/src/common/anonymization/domain/whitelist-filter.ts
@@ -6,8 +6,7 @@ type EntriesByCategory = Map<PiiCategory, PiiWhitelistEntry>;
 
 /**
  * Drops detections that the org whitelist exempts from anonymization.
- * Fail-safe: detections without a mapped category and entries with invalid
- * patterns never exempt anything.
+ * Fail-safe: entries with invalid patterns never exempt anything.
  */
 export function filterWhitelistedDetections(
   detections: PiiDetection[],
@@ -28,9 +27,6 @@ export function isExempt(
   detection: PiiDetection,
   entriesByCategory: EntriesByCategory,
 ): boolean {
-  if (!detection.category) {
-    return false;
-  }
   const entry = entriesByCategory.get(detection.category);
   if (!entry) {
     return false;

--- a/ayunis-core-backend/src/common/anonymization/infrastructure/providers/presidio-anonymization.provider.spec.ts
+++ b/ayunis-core-backend/src/common/anonymization/infrastructure/providers/presidio-anonymization.provider.spec.ts
@@ -67,7 +67,7 @@ describe('PresidioAnonymizationProvider', () => {
     ]);
   });
 
-  it('leaves the category undefined for unmapped entity types', async () => {
+  it('maps unmapped entity types to the OTHER category', async () => {
     const text = 'mein Geheimnis: hunter2';
     mockResults([
       { entity_type: 'FUTURE_SECRET_TYPE', start: 16, end: 23, score: 0.8 },
@@ -75,7 +75,7 @@ describe('PresidioAnonymizationProvider', () => {
 
     const detections = await provider.detect(text);
 
-    expect(detections[0].category).toBeUndefined();
+    expect(detections[0].category).toBe(PiiCategory.OTHER);
   });
 
   it('collapses overlapping spans sharing an end position', async () => {

--- a/ayunis-core-backend/src/common/anonymization/infrastructure/providers/presidio-entity-category.mapper.ts
+++ b/ayunis-core-backend/src/common/anonymization/infrastructure/providers/presidio-entity-category.mapper.ts
@@ -20,11 +20,10 @@ const PRESIDIO_ENTITY_TO_CATEGORY: Record<string, PiiCategory> = {
 };
 
 /**
- * Unmapped types return undefined, which the whitelist filter treats as
- * never exemptable (fail-safe for entity types added to the engine later).
+ * Unmapped types fall back to OTHER (fail-safe for entity types added to the
+ * engine later): they are still anonymized, and only exemptable when an org
+ * explicitly whitelists OTHER.
  */
-export function mapPresidioEntityToCategory(
-  entityType: string,
-): PiiCategory | undefined {
-  return PRESIDIO_ENTITY_TO_CATEGORY[entityType];
+export function mapPresidioEntityToCategory(entityType: string): PiiCategory {
+  return PRESIDIO_ENTITY_TO_CATEGORY[entityType] ?? PiiCategory.OTHER;
 }


### PR DESCRIPTION
- add PiiCategory.OTHER as fail-safe fallback for unmapped engine types;
  PiiDetection.category is now always set
- add PiiMask domain type and {{pii:CATEGORY_n}} token format
- add applyMaskReplacements with thread-stable, dedup-aware numbering
- AnonymizeTextCommand accepts existingMasks to opt into mask mode;
  AnonymizationResult reports newly created masks

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how unmapped engine types are categorized and anonymized (OTHER vs undefined), and extends the anonymization result contract with `newMasks`; legacy call paths remain but PII handling semantics shifted for edge cases.
> 
> **Overview**
> Adds **thread-stable PII masking** alongside the existing `[ENTITY_TYPE]` placeholder flow. Callers opt in by passing `existingMasks` on `AnonymizeTextCommand` (including `[]`); the use case then emits `{{pii:CATEGORY_n}}` tokens via new `applyMaskReplacements`, reuses masks for the same `(category, value)` across messages, and returns **`newMasks`** on `AnonymizationResult` for values not already in the registry.
> 
> Introduces **`PiiMask`**, **`formatPiiToken`**, and **`PiiCategory.OTHER`**. Unmapped Presidio entity types now map to **OTHER** instead of leaving `category` undefined; **`PiiDetection.category`** and replacement **`category`** are always set. Whitelist filtering no longer special-cases “missing category”—**OTHER** is only exempt when explicitly whitelisted.
> 
> Legacy behavior is unchanged when `existingMasks` is omitted: same bracket placeholders and `newMasks: []`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95c9bc36f0ea6948e48a840b7d0f2549c6d4698e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->