### PR TITLE
wip(anonymization): add thread-pii-masks module with mask dictionary (AYC-118)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -46,6 +46,8 @@ ayunis-core/
 | [transcriptions](ayunis-core-backend/src/domain/transcriptions/SUMMARY.md) | Voice | Audio transcription service |
 | [usage](ayunis-core-backend/src/domain/usage/SUMMARY.md) | Metering | Token and credit usage tracking |
 | [skill-templates](ayunis-core-backend/src/domain/skill-templates/SUMMARY.md) | Blueprints | Admin-managed skill templates with distribution modes |
+| [anonymization-settings](ayunis-core-backend/src/domain/anonymization-settings) | Privacy Config | Org-level PII whitelist for anonymous mode |
+| [thread-pii-masks](ayunis-core-backend/src/domain/thread-pii-masks/SUMMARY.md) | Privacy | Per-thread PII mask dictionary for anonymous mode |
 
 ### IAM Modules — Identity & Access Management
 

--- a/ayunis-core-backend/src/common/anonymization/domain/apply-mask-replacements.ts
+++ b/ayunis-core-backend/src/common/anonymization/domain/apply-mask-replacements.ts
@@ -32,7 +32,10 @@ export function applyMaskReplacements(
   const masks = new Map(
     inDocumentOrder.map((detection) => [
       detection,
-      registry.resolve(detection.category, text.slice(detection.start, detection.end)),
+      registry.resolve(
+        detection.category,
+        text.slice(detection.start, detection.end),
+      ),
     ]),
   );
 

--- a/ayunis-core-backend/src/db/migrations/1781161486267-CreateThreadPiiMasksTable.ts
+++ b/ayunis-core-backend/src/db/migrations/1781161486267-CreateThreadPiiMasksTable.ts
@@ -1,0 +1,69 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateThreadPiiMasksTable1781161486267 implements MigrationInterface {
+  name = 'CreateThreadPiiMasksTable1781161486267';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TYPE "public"."thread_pii_masks_category_enum" AS ENUM('person_name', 'organization', 'location', 'email_address', 'phone_number', 'url_or_ip', 'date_time', 'financial_account', 'government_id', 'nationality_religion_politics', 'other')`,
+    );
+    await queryRunner.query(
+      `CREATE TABLE "thread_pii_masks" ("id" character varying NOT NULL, "createdAt" TIMESTAMP NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP NOT NULL DEFAULT now(), "threadId" character varying NOT NULL, "category" "public"."thread_pii_masks_category_enum" NOT NULL, "maskIndex" integer NOT NULL, "value" text NOT NULL, CONSTRAINT "UQ_a25260d1828a75a47c9f7651871" UNIQUE ("threadId", "category", "value"), CONSTRAINT "UQ_9bcca61906737e8a5b08263eb46" UNIQUE ("threadId", "category", "maskIndex"), CONSTRAINT "PK_4e5c29156ec3aa1ab17f0ccc775" PRIMARY KEY ("id"))`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_297e25137f828aa2d8d10f6d26" ON "thread_pii_masks" ("threadId") `,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "anonymization_whitelist_entries" DROP CONSTRAINT "UQ_398e29bebe8413873fc849a16c4"`,
+    );
+    await queryRunner.query(
+      `ALTER TYPE "public"."anonymization_whitelist_entries_category_enum" RENAME TO "anonymization_whitelist_entries_category_enum_old"`,
+    );
+    await queryRunner.query(
+      `CREATE TYPE "public"."anonymization_whitelist_entries_category_enum" AS ENUM('person_name', 'organization', 'location', 'email_address', 'phone_number', 'url_or_ip', 'date_time', 'financial_account', 'government_id', 'nationality_religion_politics', 'other')`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "anonymization_whitelist_entries" ALTER COLUMN "category" TYPE "public"."anonymization_whitelist_entries_category_enum" USING "category"::"text"::"public"."anonymization_whitelist_entries_category_enum"`,
+    );
+    await queryRunner.query(
+      `DROP TYPE "public"."anonymization_whitelist_entries_category_enum_old"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "anonymization_whitelist_entries" ADD CONSTRAINT "UQ_398e29bebe8413873fc849a16c4" UNIQUE ("orgId", "category")`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "thread_pii_masks" ADD CONSTRAINT "FK_297e25137f828aa2d8d10f6d267" FOREIGN KEY ("threadId") REFERENCES "threads"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "thread_pii_masks" DROP CONSTRAINT "FK_297e25137f828aa2d8d10f6d267"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "anonymization_whitelist_entries" DROP CONSTRAINT "UQ_398e29bebe8413873fc849a16c4"`,
+    );
+    await queryRunner.query(
+      `CREATE TYPE "public"."anonymization_whitelist_entries_category_enum_old" AS ENUM('date_time', 'email_address', 'financial_account', 'government_id', 'location', 'nationality_religion_politics', 'organization', 'person_name', 'phone_number', 'url_or_ip')`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "anonymization_whitelist_entries" ALTER COLUMN "category" TYPE "public"."anonymization_whitelist_entries_category_enum_old" USING "category"::"text"::"public"."anonymization_whitelist_entries_category_enum_old"`,
+    );
+    await queryRunner.query(
+      `DROP TYPE "public"."anonymization_whitelist_entries_category_enum"`,
+    );
+    await queryRunner.query(
+      `ALTER TYPE "public"."anonymization_whitelist_entries_category_enum_old" RENAME TO "anonymization_whitelist_entries_category_enum"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "anonymization_whitelist_entries" ADD CONSTRAINT "UQ_398e29bebe8413873fc849a16c4" UNIQUE ("orgId", "category")`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_297e25137f828aa2d8d10f6d26"`,
+    );
+    await queryRunner.query(`DROP TABLE "thread_pii_masks"`);
+    await queryRunner.query(
+      `DROP TYPE "public"."thread_pii_masks_category_enum"`,
+    );
+  }
+}

--- a/ayunis-core-backend/src/domain/thread-pii-masks/SUMMARY.md
+++ b/ayunis-core-backend/src/domain/thread-pii-masks/SUMMARY.md
@@ -1,0 +1,45 @@
+# Thread PII Masks Module
+
+## Purpose
+
+Stores the per-thread mask dictionary behind anonymous mode: every PII value detected in an anonymous thread is replaced by a stable `{{pii:CATEGORY_n}}` token, and this module owns the token → original value mapping. The LLM provider only ever sees tokens; the frontend resolves them back to the original values for display.
+
+## Domain Concepts
+
+- **ThreadPiiMask** — One dictionary entry: the original value, its `PiiCategory`, and a per-thread, per-category 1-based `maskIndex`. The `token` getter renders the placeholder (e.g. `{{pii:PERSON_NAME_1}}`).
+- **Stable numbering** — The same (category, value) pair always resolves to the same token within a thread; new values get the next free index. Numbering and dedup live in `applyMaskReplacements` (`src/common/anonymization/domain/apply-mask-replacements.ts`); this module supplies the existing masks and persists new ones.
+
+## Architecture
+
+```text
+thread-pii-masks/
+├── domain/
+│   └── thread-pii-mask.entity.ts
+├── application/
+│   ├── thread-pii-masks.errors.ts
+│   ├── ports/
+│   │   └── thread-pii-mask.repository.ts
+│   └── use-cases/
+│       ├── anonymize-text-for-thread/   # whitelist + existing masks → anonymize → persist new masks
+│       └── get-thread-pii-masks/
+├── infrastructure/
+│   └── persistence/postgres/
+│       ├── schema/thread-pii-mask.record.ts   # unique (threadId, category, maskIndex) and (threadId, category, value)
+│       ├── mappers/thread-pii-mask.mapper.ts
+│       └── thread-pii-mask.repository.ts
+├── presenters/
+│   └── http/
+│       ├── dtos/pii-mask-response.dto.ts      # { token, value, category } — no controller; embedded by threads/runs
+│       └── mappers/pii-mask.mapper.ts
+└── thread-pii-masks.module.ts
+```
+
+## Key Flows
+
+- **AnonymizeTextForThreadUseCase** — Loads the org PII whitelist (via `GetPiiWhitelistUseCase` from `anonymization-settings`) and the thread's existing masks, delegates to the common `AnonymizeTextUseCase` in mask mode, persists newly created masks *before* returning, and returns the anonymized text plus the full updated dictionary. Engine failures propagate unchanged so callers keep their fail-safe handling (run aborts, original text never leaks).
+- **GetThreadPiiMasksUseCase** — Returns a thread's dictionary; used by the threads GET endpoint so the frontend can resolve tokens after a reload.
+
+## Consumers
+
+- `runs` — anonymizes user input and PII-returning tool results, streams new masks to the client as `masks` SSE events.
+- `threads` — embeds the dictionary in the thread GET response for anonymous threads.

--- a/ayunis-core-backend/src/domain/thread-pii-masks/application/ports/thread-pii-mask.repository.ts
+++ b/ayunis-core-backend/src/domain/thread-pii-masks/application/ports/thread-pii-mask.repository.ts
@@ -1,0 +1,7 @@
+import type { UUID } from 'crypto';
+import type { ThreadPiiMask } from '../../domain/thread-pii-mask.entity';
+
+export abstract class ThreadPiiMaskRepository {
+  abstract findByThreadId(threadId: UUID): Promise<ThreadPiiMask[]>;
+  abstract saveMany(masks: ThreadPiiMask[]): Promise<void>;
+}

--- a/ayunis-core-backend/src/domain/thread-pii-masks/application/thread-pii-masks.errors.ts
+++ b/ayunis-core-backend/src/domain/thread-pii-masks/application/thread-pii-masks.errors.ts
@@ -1,0 +1,17 @@
+import type { ErrorMetadata } from 'src/common/errors/base.error';
+import { ApplicationError } from 'src/common/errors/base.error';
+
+export enum ThreadPiiMasksErrorCode {
+  UNEXPECTED_ERROR = 'UNEXPECTED_THREAD_PII_MASKS_ERROR',
+}
+
+export class UnexpectedThreadPiiMasksError extends ApplicationError {
+  constructor(operation: string, metadata?: ErrorMetadata) {
+    super(
+      `Unexpected thread PII masks error during ${operation}`,
+      ThreadPiiMasksErrorCode.UNEXPECTED_ERROR,
+      500,
+      { operation, ...metadata },
+    );
+  }
+}

--- a/ayunis-core-backend/src/domain/thread-pii-masks/application/use-cases/anonymize-text-for-thread/anonymize-text-for-thread.command.ts
+++ b/ayunis-core-backend/src/domain/thread-pii-masks/application/use-cases/anonymize-text-for-thread/anonymize-text-for-thread.command.ts
@@ -1,0 +1,9 @@
+import type { UUID } from 'crypto';
+
+export class AnonymizeTextForThreadCommand {
+  constructor(
+    public readonly text: string,
+    public readonly orgId: UUID,
+    public readonly threadId: UUID,
+  ) {}
+}

--- a/ayunis-core-backend/src/domain/thread-pii-masks/application/use-cases/anonymize-text-for-thread/anonymize-text-for-thread.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/thread-pii-masks/application/use-cases/anonymize-text-for-thread/anonymize-text-for-thread.use-case.spec.ts
@@ -1,0 +1,146 @@
+import { Logger } from '@nestjs/common';
+import type { UUID } from 'crypto';
+import { AnonymizeTextForThreadUseCase } from './anonymize-text-for-thread.use-case';
+import { AnonymizeTextForThreadCommand } from './anonymize-text-for-thread.command';
+import type { AnonymizeTextUseCase } from 'src/common/anonymization/application/use-cases/anonymize-text/anonymize-text.use-case';
+import type { GetPiiWhitelistUseCase } from 'src/domain/anonymization-settings/application/use-cases/get-pii-whitelist/get-pii-whitelist.use-case';
+import { AnonymizationFailedError } from 'src/common/anonymization/application/anonymization.errors';
+import { PiiCategory } from 'src/common/anonymization/domain/pii-category.enum';
+import { PiiWhitelistEntry } from 'src/common/anonymization/domain/pii-whitelist-entry';
+import { AnonymizationWhitelistEntry } from 'src/domain/anonymization-settings/domain/anonymization-whitelist-entry.entity';
+import { ThreadPiiMask } from '../../../domain/thread-pii-mask.entity';
+import { UnexpectedThreadPiiMasksError } from '../../thread-pii-masks.errors';
+
+describe('AnonymizeTextForThreadUseCase', () => {
+  const orgId = '0d4f9c5e-7a36-4b34-9c1b-2f8d6a1e5b3c' as UUID;
+  const threadId = '7b1f2a3c-4d5e-6f70-8192-a3b4c5d6e7f8' as UUID;
+  const text = 'Ich bin der Dani';
+  let useCase: AnonymizeTextForThreadUseCase;
+  let findByThreadId: jest.Mock;
+  let saveMany: jest.Mock;
+  let whitelistExecute: jest.Mock;
+  let anonymizeExecute: jest.Mock;
+
+  beforeEach(() => {
+    findByThreadId = jest.fn().mockResolvedValue([]);
+    saveMany = jest.fn().mockResolvedValue(undefined);
+    whitelistExecute = jest.fn().mockResolvedValue([]);
+    anonymizeExecute = jest.fn().mockResolvedValue({
+      originalText: text,
+      anonymizedText: 'Ich bin der {{pii:PERSON_NAME_1}}',
+      replacements: [],
+      newMasks: [
+        { category: PiiCategory.PERSON_NAME, maskIndex: 1, value: 'Dani' },
+      ],
+    });
+    useCase = new AnonymizeTextForThreadUseCase(
+      { findByThreadId, saveMany },
+      { execute: whitelistExecute } as unknown as GetPiiWhitelistUseCase,
+      { execute: anonymizeExecute } as unknown as AnonymizeTextUseCase,
+    );
+    jest.spyOn(Logger.prototype, 'debug').mockImplementation();
+    jest.spyOn(Logger.prototype, 'error').mockImplementation();
+  });
+
+  const command = () =>
+    new AnonymizeTextForThreadCommand(text, orgId, threadId);
+
+  it('passes the org whitelist and existing thread masks to anonymization', async () => {
+    whitelistExecute.mockResolvedValue([
+      new AnonymizationWhitelistEntry({
+        orgId,
+        category: PiiCategory.LOCATION,
+        pattern: null,
+      }),
+    ]);
+    const existing = new ThreadPiiMask({
+      threadId,
+      category: PiiCategory.PERSON_NAME,
+      maskIndex: 1,
+      value: 'Moritz',
+    });
+    findByThreadId.mockResolvedValue([existing]);
+
+    await useCase.execute(command());
+
+    expect(anonymizeExecute).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text,
+        whitelist: [new PiiWhitelistEntry(PiiCategory.LOCATION, null)],
+        existingMasks: [
+          {
+            category: PiiCategory.PERSON_NAME,
+            maskIndex: 1,
+            value: 'Moritz',
+          },
+        ],
+      }),
+    );
+  });
+
+  it('persists only the newly created masks before returning', async () => {
+    await useCase.execute(command());
+
+    expect(saveMany).toHaveBeenCalledTimes(1);
+    const saved = (saveMany.mock.calls[0] as [ThreadPiiMask[]])[0];
+    expect(saved).toHaveLength(1);
+    expect(saved[0]).toMatchObject({
+      threadId,
+      category: PiiCategory.PERSON_NAME,
+      maskIndex: 1,
+      value: 'Dani',
+    });
+  });
+
+  it('does not persist when no new masks were created', async () => {
+    anonymizeExecute.mockResolvedValue({
+      originalText: text,
+      anonymizedText: text,
+      replacements: [],
+      newMasks: [],
+    });
+
+    await useCase.execute(command());
+
+    expect(saveMany).not.toHaveBeenCalled();
+  });
+
+  it('returns the merged mask dictionary of existing and new masks', async () => {
+    const existing = new ThreadPiiMask({
+      threadId,
+      category: PiiCategory.EMAIL_ADDRESS,
+      maskIndex: 1,
+      value: 'a@b.de',
+    });
+    findByThreadId.mockResolvedValue([existing]);
+
+    const result = await useCase.execute(command());
+
+    expect(result.anonymizedText).toBe('Ich bin der {{pii:PERSON_NAME_1}}');
+    expect(result.masks).toHaveLength(2);
+    expect(result.masks[0]).toBe(existing);
+    expect(result.masks[1]).toMatchObject({
+      threadId,
+      category: PiiCategory.PERSON_NAME,
+      value: 'Dani',
+    });
+  });
+
+  it('propagates engine failures unchanged for fail-safe handling', async () => {
+    anonymizeExecute.mockRejectedValue(
+      new AnonymizationFailedError('connect ECONNREFUSED'),
+    );
+
+    await expect(useCase.execute(command())).rejects.toThrow(
+      AnonymizationFailedError,
+    );
+  });
+
+  it('wraps repository failures in a module error', async () => {
+    saveMany.mockRejectedValue(new Error('unique constraint violation'));
+
+    await expect(useCase.execute(command())).rejects.toThrow(
+      UnexpectedThreadPiiMasksError,
+    );
+  });
+});

--- a/ayunis-core-backend/src/domain/thread-pii-masks/application/use-cases/anonymize-text-for-thread/anonymize-text-for-thread.use-case.ts
+++ b/ayunis-core-backend/src/domain/thread-pii-masks/application/use-cases/anonymize-text-for-thread/anonymize-text-for-thread.use-case.ts
@@ -1,0 +1,86 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ApplicationError } from 'src/common/errors/base.error';
+import { AnonymizeTextUseCase } from 'src/common/anonymization/application/use-cases/anonymize-text/anonymize-text.use-case';
+import { AnonymizeTextCommand } from 'src/common/anonymization/application/use-cases/anonymize-text/anonymize-text.command';
+import { PiiWhitelistEntry } from 'src/common/anonymization/domain/pii-whitelist-entry';
+import type { AnonymizationResult } from 'src/common/anonymization/application/ports/anonymization.port';
+import { GetPiiWhitelistUseCase } from 'src/domain/anonymization-settings/application/use-cases/get-pii-whitelist/get-pii-whitelist.use-case';
+import { GetPiiWhitelistQuery } from 'src/domain/anonymization-settings/application/use-cases/get-pii-whitelist/get-pii-whitelist.query';
+import { ThreadPiiMaskRepository } from '../../ports/thread-pii-mask.repository';
+import { ThreadPiiMask } from '../../../domain/thread-pii-mask.entity';
+import { UnexpectedThreadPiiMasksError } from '../../thread-pii-masks.errors';
+import type { AnonymizeTextForThreadCommand } from './anonymize-text-for-thread.command';
+
+export interface ThreadAnonymizationResult extends AnonymizationResult {
+  /** The thread's full mask dictionary including masks created by this call. */
+  masks: ThreadPiiMask[];
+}
+
+/**
+ * Anonymizes text with stable `{{pii:CATEGORY_n}}` tokens scoped to one
+ * thread, honoring the org's PII whitelist. New masks are persisted before
+ * the result is returned, so anonymized text never circulates without its
+ * dictionary entries. Engine failures (AnonymizationFailedError) propagate
+ * unchanged so callers keep their fail-safe handling.
+ */
+@Injectable()
+export class AnonymizeTextForThreadUseCase {
+  private readonly logger = new Logger(AnonymizeTextForThreadUseCase.name);
+
+  constructor(
+    private readonly repository: ThreadPiiMaskRepository,
+    private readonly getPiiWhitelistUseCase: GetPiiWhitelistUseCase,
+    private readonly anonymizeTextUseCase: AnonymizeTextUseCase,
+  ) {}
+
+  async execute(
+    command: AnonymizeTextForThreadCommand,
+  ): Promise<ThreadAnonymizationResult> {
+    this.logger.debug('Anonymizing text for thread', {
+      orgId: command.orgId,
+      threadId: command.threadId,
+    });
+
+    try {
+      const entries = await this.getPiiWhitelistUseCase.execute(
+        new GetPiiWhitelistQuery(command.orgId),
+      );
+      const whitelist = entries.map(
+        (entry) => new PiiWhitelistEntry(entry.category, entry.pattern),
+      );
+      const existing = await this.repository.findByThreadId(command.threadId);
+
+      const result = await this.anonymizeTextUseCase.execute(
+        new AnonymizeTextCommand(
+          command.text,
+          undefined,
+          whitelist,
+          existing.map((mask) => mask.toPiiMask()),
+        ),
+      );
+
+      const created = result.newMasks.map((mask) =>
+        ThreadPiiMask.fromPiiMask(command.threadId, mask),
+      );
+      if (created.length > 0) {
+        await this.repository.saveMany(created);
+      }
+
+      return { ...result, masks: [...existing, ...created] };
+    } catch (error) {
+      if (error instanceof ApplicationError) throw error;
+
+      this.logger.error('Failed to anonymize text for thread', {
+        error: error instanceof Error ? error.message : 'Unknown error',
+        orgId: command.orgId,
+        threadId: command.threadId,
+      });
+
+      throw new UnexpectedThreadPiiMasksError('anonymize', {
+        orgId: command.orgId,
+        threadId: command.threadId,
+        ...(error instanceof Error && { originalError: error.message }),
+      });
+    }
+  }
+}

--- a/ayunis-core-backend/src/domain/thread-pii-masks/application/use-cases/get-thread-pii-masks/get-thread-pii-masks.query.ts
+++ b/ayunis-core-backend/src/domain/thread-pii-masks/application/use-cases/get-thread-pii-masks/get-thread-pii-masks.query.ts
@@ -1,0 +1,5 @@
+import type { UUID } from 'crypto';
+
+export class GetThreadPiiMasksQuery {
+  constructor(public readonly threadId: UUID) {}
+}

--- a/ayunis-core-backend/src/domain/thread-pii-masks/application/use-cases/get-thread-pii-masks/get-thread-pii-masks.use-case.ts
+++ b/ayunis-core-backend/src/domain/thread-pii-masks/application/use-cases/get-thread-pii-masks/get-thread-pii-masks.use-case.ts
@@ -1,0 +1,35 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ApplicationError } from 'src/common/errors/base.error';
+import { ThreadPiiMaskRepository } from '../../ports/thread-pii-mask.repository';
+import { UnexpectedThreadPiiMasksError } from '../../thread-pii-masks.errors';
+import type { ThreadPiiMask } from '../../../domain/thread-pii-mask.entity';
+import type { GetThreadPiiMasksQuery } from './get-thread-pii-masks.query';
+
+@Injectable()
+export class GetThreadPiiMasksUseCase {
+  private readonly logger = new Logger(GetThreadPiiMasksUseCase.name);
+
+  constructor(private readonly repository: ThreadPiiMaskRepository) {}
+
+  async execute(query: GetThreadPiiMasksQuery): Promise<ThreadPiiMask[]> {
+    this.logger.debug('Getting thread PII masks', {
+      threadId: query.threadId,
+    });
+
+    try {
+      return await this.repository.findByThreadId(query.threadId);
+    } catch (error) {
+      if (error instanceof ApplicationError) throw error;
+
+      this.logger.error('Failed to get thread PII masks', {
+        error: error instanceof Error ? error.message : 'Unknown error',
+        threadId: query.threadId,
+      });
+
+      throw new UnexpectedThreadPiiMasksError('get', {
+        threadId: query.threadId,
+        ...(error instanceof Error && { originalError: error.message }),
+      });
+    }
+  }
+}

--- a/ayunis-core-backend/src/domain/thread-pii-masks/domain/thread-pii-mask.entity.ts
+++ b/ayunis-core-backend/src/domain/thread-pii-masks/domain/thread-pii-mask.entity.ts
@@ -1,0 +1,62 @@
+import type { UUID } from 'crypto';
+import { randomUUID } from 'crypto';
+import type { PiiCategory } from 'src/common/anonymization/domain/pii-category.enum';
+import type { PiiMask } from 'src/common/anonymization/domain/pii-mask';
+import { formatPiiToken } from 'src/common/anonymization/domain/pii-mask';
+
+export interface ThreadPiiMaskParams {
+  id?: UUID;
+  threadId: UUID;
+  category: PiiCategory;
+  maskIndex: number;
+  value: string;
+  createdAt?: Date;
+  updatedAt?: Date;
+}
+
+/**
+ * One entry of a thread's mask dictionary: the original PII value behind a
+ * stable `{{pii:CATEGORY_n}}` token. The token is what the LLM sees and what
+ * is persisted in message text; the value is only ever shown to thread
+ * participants in the frontend.
+ */
+export class ThreadPiiMask {
+  id: UUID;
+  threadId: UUID;
+  category: PiiCategory;
+  maskIndex: number;
+  value: string;
+  createdAt: Date;
+  updatedAt: Date;
+
+  constructor(params: ThreadPiiMaskParams) {
+    this.id = params.id ?? randomUUID();
+    this.threadId = params.threadId;
+    this.category = params.category;
+    this.maskIndex = params.maskIndex;
+    this.value = params.value;
+    this.createdAt = params.createdAt ?? new Date();
+    this.updatedAt = params.updatedAt ?? new Date();
+  }
+
+  get token(): string {
+    return formatPiiToken(this);
+  }
+
+  toPiiMask(): PiiMask {
+    return {
+      category: this.category,
+      maskIndex: this.maskIndex,
+      value: this.value,
+    };
+  }
+
+  static fromPiiMask(threadId: UUID, mask: PiiMask): ThreadPiiMask {
+    return new ThreadPiiMask({
+      threadId,
+      category: mask.category,
+      maskIndex: mask.maskIndex,
+      value: mask.value,
+    });
+  }
+}

--- a/ayunis-core-backend/src/domain/thread-pii-masks/infrastructure/persistence/postgres/mappers/thread-pii-mask.mapper.ts
+++ b/ayunis-core-backend/src/domain/thread-pii-masks/infrastructure/persistence/postgres/mappers/thread-pii-mask.mapper.ts
@@ -1,0 +1,28 @@
+import { ThreadPiiMask } from '../../../../domain/thread-pii-mask.entity';
+import { ThreadPiiMaskRecord } from '../schema/thread-pii-mask.record';
+
+export class ThreadPiiMaskMapper {
+  static toDomain(record: ThreadPiiMaskRecord): ThreadPiiMask {
+    return new ThreadPiiMask({
+      id: record.id,
+      threadId: record.threadId,
+      category: record.category,
+      maskIndex: record.maskIndex,
+      value: record.value,
+      createdAt: record.createdAt,
+      updatedAt: record.updatedAt,
+    });
+  }
+
+  static toRecord(domain: ThreadPiiMask): ThreadPiiMaskRecord {
+    const record = new ThreadPiiMaskRecord();
+    record.id = domain.id;
+    record.threadId = domain.threadId;
+    record.category = domain.category;
+    record.maskIndex = domain.maskIndex;
+    record.value = domain.value;
+    record.createdAt = domain.createdAt;
+    record.updatedAt = new Date();
+    return record;
+  }
+}

--- a/ayunis-core-backend/src/domain/thread-pii-masks/infrastructure/persistence/postgres/schema/thread-pii-mask.record.ts
+++ b/ayunis-core-backend/src/domain/thread-pii-masks/infrastructure/persistence/postgres/schema/thread-pii-mask.record.ts
@@ -1,0 +1,27 @@
+import { Column, Entity, Index, JoinColumn, ManyToOne, Unique } from 'typeorm';
+import type { UUID } from 'crypto';
+import { BaseRecord } from '../../../../../../common/db/base-record';
+import { ThreadRecord } from '../../../../../threads/infrastructure/persistence/local/schema/thread.record';
+import { PiiCategory } from '../../../../../../common/anonymization/domain/pii-category.enum';
+
+@Entity({ name: 'thread_pii_masks' })
+@Unique(['threadId', 'category', 'maskIndex'])
+@Unique(['threadId', 'category', 'value'])
+export class ThreadPiiMaskRecord extends BaseRecord {
+  @Index()
+  @Column()
+  threadId: UUID;
+
+  @ManyToOne(() => ThreadRecord, { nullable: false, onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'threadId' })
+  thread: ThreadRecord;
+
+  @Column({ type: 'enum', enum: PiiCategory })
+  category: PiiCategory;
+
+  @Column({ type: 'int' })
+  maskIndex: number;
+
+  @Column({ type: 'text' })
+  value: string;
+}

--- a/ayunis-core-backend/src/domain/thread-pii-masks/infrastructure/persistence/postgres/thread-pii-mask.repository.ts
+++ b/ayunis-core-backend/src/domain/thread-pii-masks/infrastructure/persistence/postgres/thread-pii-mask.repository.ts
@@ -1,0 +1,42 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import type { UUID } from 'crypto';
+import { ThreadPiiMaskRepository } from '../../../application/ports/thread-pii-mask.repository';
+import { ThreadPiiMask } from '../../../domain/thread-pii-mask.entity';
+import { ThreadPiiMaskRecord } from './schema/thread-pii-mask.record';
+import { ThreadPiiMaskMapper } from './mappers/thread-pii-mask.mapper';
+
+@Injectable()
+export class PostgresThreadPiiMaskRepository extends ThreadPiiMaskRepository {
+  private readonly logger = new Logger(PostgresThreadPiiMaskRepository.name);
+
+  constructor(
+    @InjectRepository(ThreadPiiMaskRecord)
+    private readonly repository: Repository<ThreadPiiMaskRecord>,
+  ) {
+    super();
+  }
+
+  async findByThreadId(threadId: UUID): Promise<ThreadPiiMask[]> {
+    this.logger.debug('findByThreadId', { threadId });
+
+    const records = await this.repository.find({
+      where: { threadId },
+      order: { category: 'ASC', maskIndex: 'ASC' },
+    });
+
+    return records.map((record) => ThreadPiiMaskMapper.toDomain(record));
+  }
+
+  async saveMany(masks: ThreadPiiMask[]): Promise<void> {
+    this.logger.debug('saveMany', { count: masks.length });
+
+    if (masks.length === 0) {
+      return;
+    }
+    await this.repository.save(
+      masks.map((mask) => ThreadPiiMaskMapper.toRecord(mask)),
+    );
+  }
+}

--- a/ayunis-core-backend/src/domain/thread-pii-masks/presenters/http/dtos/pii-mask-response.dto.ts
+++ b/ayunis-core-backend/src/domain/thread-pii-masks/presenters/http/dtos/pii-mask-response.dto.ts
@@ -1,0 +1,25 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { PiiCategory } from 'src/common/anonymization/domain/pii-category.enum';
+
+export class PiiMaskResponseDto {
+  @ApiProperty({
+    description:
+      'The placeholder token as it appears in message text, e.g. {{pii:PERSON_NAME_1}}',
+    example: '{{pii:PERSON_NAME_1}}',
+  })
+  token: string;
+
+  @ApiProperty({
+    description: 'The original value the token stands in for',
+    example: 'Max Mustermann',
+  })
+  value: string;
+
+  @ApiProperty({
+    description: 'PII category of the masked value',
+    enum: PiiCategory,
+    enumName: 'PiiCategory',
+    example: PiiCategory.PERSON_NAME,
+  })
+  category: PiiCategory;
+}

--- a/ayunis-core-backend/src/domain/thread-pii-masks/presenters/http/mappers/pii-mask.mapper.ts
+++ b/ayunis-core-backend/src/domain/thread-pii-masks/presenters/http/mappers/pii-mask.mapper.ts
@@ -1,0 +1,18 @@
+import { Injectable } from '@nestjs/common';
+import type { ThreadPiiMask } from '../../../domain/thread-pii-mask.entity';
+import { PiiMaskResponseDto } from '../dtos/pii-mask-response.dto';
+
+@Injectable()
+export class PiiMaskDtoMapper {
+  toDto(mask: ThreadPiiMask): PiiMaskResponseDto {
+    return {
+      token: mask.token,
+      value: mask.value,
+      category: mask.category,
+    };
+  }
+
+  toDtoArray(masks: ThreadPiiMask[]): PiiMaskResponseDto[] {
+    return masks.map((mask) => this.toDto(mask));
+  }
+}

--- a/ayunis-core-backend/src/domain/thread-pii-masks/thread-pii-masks.module.ts
+++ b/ayunis-core-backend/src/domain/thread-pii-masks/thread-pii-masks.module.ts
@@ -1,0 +1,35 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+
+import { AnonymizationModule } from 'src/common/anonymization/anonymization.module';
+import { AnonymizationSettingsModule } from 'src/domain/anonymization-settings/anonymization-settings.module';
+import { ThreadPiiMaskRecord } from './infrastructure/persistence/postgres/schema/thread-pii-mask.record';
+import { ThreadPiiMaskRepository } from './application/ports/thread-pii-mask.repository';
+import { PostgresThreadPiiMaskRepository } from './infrastructure/persistence/postgres/thread-pii-mask.repository';
+
+import { GetThreadPiiMasksUseCase } from './application/use-cases/get-thread-pii-masks/get-thread-pii-masks.use-case';
+import { AnonymizeTextForThreadUseCase } from './application/use-cases/anonymize-text-for-thread/anonymize-text-for-thread.use-case';
+import { PiiMaskDtoMapper } from './presenters/http/mappers/pii-mask.mapper';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([ThreadPiiMaskRecord]),
+    AnonymizationModule,
+    AnonymizationSettingsModule,
+  ],
+  providers: [
+    {
+      provide: ThreadPiiMaskRepository,
+      useClass: PostgresThreadPiiMaskRepository,
+    },
+    GetThreadPiiMasksUseCase,
+    AnonymizeTextForThreadUseCase,
+    PiiMaskDtoMapper,
+  ],
+  exports: [
+    GetThreadPiiMasksUseCase,
+    AnonymizeTextForThreadUseCase,
+    PiiMaskDtoMapper,
+  ],
+})
+export class ThreadPiiMasksModule {}


### PR DESCRIPTION
- ThreadPiiMask entity + postgres persistence with unique
  (threadId, category, maskIndex) and (threadId, category, value)
- AnonymizeTextForThreadUseCase: org whitelist + existing masks ->
  anonymize in mask mode -> persist new masks before returning
- GetThreadPiiMasksUseCase + PiiMaskResponseDto for embedding by
  threads/runs presenters (no own controller)
- migration creates thread_pii_masks and adds 'other' to the
  whitelist category enum

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Stores raw PII values in a new table and changes whitelist category enums via migration; incorrect anonymization or exposure paths would leak sensitive data to LLM providers or APIs.
> 
> **Overview**
> Adds a **thread-pii-masks** domain module so anonymous chat threads can keep a stable token → original PII mapping (`{{pii:CATEGORY_n}}`).
> 
> **`AnonymizeTextForThreadUseCase`** loads the org whitelist and existing thread masks, runs shared mask-mode anonymization, **persists new masks before returning**, and returns anonymized text plus the full dictionary; **`GetThreadPiiMasksUseCase`** and **`PiiMaskResponseDto`** are exported for **threads** / **runs** presenters (no dedicated HTTP controller in this PR).
> 
> A migration creates **`thread_pii_masks`** (unique per thread on category+index and category+value, FK to threads with cascade) and extends the anonymization whitelist category enum with **`other`**. **`ARCHITECTURE.md`** documents the new module alongside anonymization-settings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6425dde7cd0314318bb584a08316ca7d6e248b01. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->