### PR TITLE
wip(anonymization): stream pii masks and teach the model the token format (AYC-118)

### DIFF
--- a/ayunis-core-backend/src/domain/runs/application/run-events.ts
+++ b/ayunis-core-backend/src/domain/runs/application/run-events.ts
@@ -1,4 +1,5 @@
 import type { Message } from 'src/domain/messages/domain/message.entity';
+import type { PiiCategory } from 'src/common/anonymization/domain/pii-category.enum';
 
 export interface RunSessionEvent {
   type: 'session';
@@ -31,8 +32,23 @@ export interface RunThreadEvent {
   timestamp: string;
 }
 
+export interface RunMaskPayload {
+  token: string;
+  value: string;
+  category: PiiCategory;
+}
+
+export interface RunMasksEvent {
+  type: 'masks';
+  threadId: string;
+  /** Full mask dictionary of the thread (idempotent to re-apply). */
+  masks: RunMaskPayload[];
+  timestamp: string;
+}
+
 export type RunEvent =
   | RunSessionEvent
   | RunMessageEvent
   | RunErrorEvent
-  | RunThreadEvent;
+  | RunThreadEvent
+  | RunMasksEvent;

--- a/ayunis-core-backend/src/domain/runs/application/services/system-prompt-builder.service.spec.ts
+++ b/ayunis-core-backend/src/domain/runs/application/services/system-prompt-builder.service.spec.ts
@@ -15,6 +15,35 @@ describe('SystemPromptBuilderService', () => {
     service = new SystemPromptBuilderService();
   });
 
+  describe('anonymization section', () => {
+    it('includes the anonymized_data section when isAnonymous is true', () => {
+      const prompt = service.build({
+        tools: [],
+        currentTime: new Date(),
+        isAnonymous: true,
+      });
+
+      expect(prompt).toContain('<anonymized_data>');
+      expect(prompt).toContain('{{pii:CATEGORY_NUMBER}}');
+      expect(prompt).toContain('copy its placeholder verbatim');
+    });
+
+    it('omits the anonymized_data section when isAnonymous is false or unset', () => {
+      const withFalse = service.build({
+        tools: [],
+        currentTime: new Date(),
+        isAnonymous: false,
+      });
+      const withUnset = service.build({
+        tools: [],
+        currentTime: new Date(),
+      });
+
+      expect(withFalse).not.toContain('<anonymized_data>');
+      expect(withUnset).not.toContain('<anonymized_data>');
+    });
+  });
+
   describe('skills section', () => {
     it('should include available_skills section when active skills are provided', () => {
       const skills: SkillEntry[] = [

--- a/ayunis-core-backend/src/domain/runs/application/services/system-prompt-builder.service.ts
+++ b/ayunis-core-backend/src/domain/runs/application/services/system-prompt-builder.service.ts
@@ -22,6 +22,7 @@ export interface SystemPromptBuildParams {
   skills?: SkillEntry[];
   knowledgeBases?: KnowledgeBaseSummary[];
   userSystemPrompt?: string;
+  isAnonymous?: boolean;
 }
 
 @Injectable()
@@ -34,6 +35,7 @@ export class SystemPromptBuilderService {
       skills = [],
       knowledgeBases = [],
       userSystemPrompt,
+      isAnonymous = false,
     } = params;
 
     const sections = [
@@ -44,6 +46,7 @@ export class SystemPromptBuilderService {
       this.buildFilesSection(sources),
       this.buildKnowledgeBasesSection(knowledgeBases),
       this.buildDataHandlingSection(),
+      isAnonymous ? this.buildAnonymizationSection() : '',
       this.buildResponseGuidelines(),
       this.buildPlatformSection(),
       userSystemPrompt
@@ -172,6 +175,19 @@ Ayunis Core is multi-tenant. You operate within the context of a specific organi
 
 If users ask about platform-wide information you don't have access to, explain that your context is scoped to their organization.
 </multi_tenant_context>`;
+  }
+
+  private buildAnonymizationSection(): string {
+    return `<anonymized_data>
+This conversation runs in anonymous mode: personally identifiable information in user messages and tool results has been replaced with placeholder tokens of the form {{pii:CATEGORY_NUMBER}} before reaching you (e.g. {{pii:PERSON_NAME_1}}, {{pii:EMAIL_ADDRESS_2}}).
+
+Rules for handling these placeholders:
+
+- Each placeholder consistently refers to the same real entity throughout the conversation.
+- When referring to such an entity, copy its placeholder verbatim — exact braces, spelling, and number (e.g. {{pii:PERSON_NAME_1}}).
+- Never invent new placeholders, alter existing ones, or guess the hidden values.
+- Do not mention this anonymization mechanism unless the user asks about it.
+</anonymized_data>`;
   }
 
   private buildResponseGuidelines(): string {

--- a/ayunis-core-backend/src/domain/runs/application/services/tool-assembly.service.ts
+++ b/ayunis-core-backend/src/domain/runs/application/services/tool-assembly.service.ts
@@ -65,6 +65,7 @@ export class ToolAssemblyService {
     thread: Thread,
     activeSkills: Skill[],
     canUseTools: boolean,
+    isAnonymous: boolean,
   ): Promise<{ tools: Tool[]; instructions: string }> {
     // Fetch always-on skill templates (cached, 60s TTL)
     let alwaysOnTemplates: SkillTemplate[] = [];
@@ -107,6 +108,7 @@ export class ToolAssemblyService {
       skills: canUseTools && this.features.skillsEnabled ? skillEntries : [],
       knowledgeBases: canUseTools ? thread.getUniqueKnowledgeBases() : [],
       userSystemPrompt,
+      isAnonymous,
     });
 
     return { tools, instructions };

--- a/ayunis-core-backend/src/domain/runs/application/services/tool-result-collector.service.spec.ts
+++ b/ayunis-core-backend/src/domain/runs/application/services/tool-result-collector.service.spec.ts
@@ -1,5 +1,5 @@
 import { AnonymizationFailedError } from 'src/common/anonymization/application/anonymization.errors';
-import type { AnonymizeTextForOrgUseCase } from 'src/domain/anonymization-settings/application/use-cases/anonymize-text-for-org/anonymize-text-for-org.use-case';
+import type { AnonymizeTextForThreadUseCase } from 'src/domain/thread-pii-masks/application/use-cases/anonymize-text-for-thread/anonymize-text-for-thread.use-case';
 import { RunAnonymizationUnavailableError } from '../runs.errors';
 import { ToolResultMessageContent } from 'src/domain/messages/domain/message-contents/tool-result.message-content.entity';
 import { ToolUseMessageContent } from 'src/domain/messages/domain/message-contents/tool-use.message-content.entity';
@@ -60,7 +60,7 @@ describe('ToolResultCollectorService', () => {
   let service: ToolResultCollectorService;
   let executeToolUseCase: jest.Mocked<ExecuteToolUseCase>;
   let checkToolCapabilitiesUseCase: jest.Mocked<CheckToolCapabilitiesUseCase>;
-  let anonymizeTextForOrgUseCase: jest.Mocked<AnonymizeTextForOrgUseCase>;
+  let anonymizeTextForThreadUseCase: jest.Mocked<AnonymizeTextForThreadUseCase>;
   let contextService: jest.Mocked<ContextService>;
 
   const orgId = randomUUID();
@@ -76,9 +76,9 @@ describe('ToolResultCollectorService', () => {
       execute: jest.fn(),
     } as unknown as jest.Mocked<CheckToolCapabilitiesUseCase>;
 
-    anonymizeTextForOrgUseCase = {
+    anonymizeTextForThreadUseCase = {
       execute: jest.fn(),
-    } as unknown as jest.Mocked<AnonymizeTextForOrgUseCase>;
+    } as unknown as jest.Mocked<AnonymizeTextForThreadUseCase>;
 
     contextService = {
       get: jest.fn().mockReturnValue(randomUUID()),
@@ -91,7 +91,7 @@ describe('ToolResultCollectorService', () => {
     service = new ToolResultCollectorService(
       executeToolUseCase,
       checkToolCapabilitiesUseCase,
-      anonymizeTextForOrgUseCase,
+      anonymizeTextForThreadUseCase,
       contextService,
       mockEventEmitter as never,
     );
@@ -108,7 +108,7 @@ describe('ToolResultCollectorService', () => {
         isExecutable: false,
       });
 
-      const results = await service.collectToolResults({
+      const { contents: results } = await service.collectToolResults({
         thread,
         tools: [tool],
         input: null,
@@ -133,7 +133,7 @@ describe('ToolResultCollectorService', () => {
 
       executeToolUseCase.execute.mockResolvedValue('backend result');
 
-      const results = await service.collectToolResults({
+      const { contents: results } = await service.collectToolResults({
         thread,
         tools: [tool],
         input: null,
@@ -161,7 +161,7 @@ describe('ToolResultCollectorService', () => {
 
       executeToolUseCase.execute.mockResolvedValue('artifact created');
 
-      const results = await service.collectToolResults({
+      const { contents: results } = await service.collectToolResults({
         thread,
         tools: [tool],
         input: null,
@@ -193,7 +193,7 @@ describe('ToolResultCollectorService', () => {
         new Error('DB constraint violation'),
       );
 
-      const results = await service.collectToolResults({
+      const { contents: results } = await service.collectToolResults({
         thread,
         tools: [tool],
         input: null,
@@ -273,7 +273,7 @@ describe('ToolResultCollectorService', () => {
         'Max Mustermann, Hauptstraße 42, 80331 München, Tel: 089-12345678',
       );
 
-      anonymizeTextForOrgUseCase.execute.mockRejectedValue(
+      anonymizeTextForThreadUseCase.execute.mockRejectedValue(
         new AnonymizationFailedError('Connection refused'),
       );
 
@@ -293,6 +293,62 @@ describe('ToolResultCollectorService', () => {
           isAnonymous: true,
         }),
       ).rejects.toThrow(RunAnonymizationUnavailableError);
+    });
+
+    it('should return anonymized text and the mask dictionary for PII-returning tools', async () => {
+      const toolName = 'search_citizens_database';
+      const tool = {
+        name: toolName,
+        type: 'search',
+        returnsPii: true,
+      } as unknown as Tool;
+
+      const toolUseContent = Object.assign(
+        Object.create(ToolUseMessageContent.prototype),
+        { id: toolUseId, name: toolName, params: { query: 'Mustermann' } },
+      );
+
+      checkToolCapabilitiesUseCase.execute.mockReturnValue({
+        isDisplayable: false,
+        isExecutable: true,
+      });
+
+      executeToolUseCase.execute.mockResolvedValue(
+        'Max Mustermann, Hauptstraße 42',
+      );
+
+      const mask = {
+        token: '{{pii:PERSON_NAME_1}}',
+        value: 'Max Mustermann',
+        category: 'person_name',
+      };
+      anonymizeTextForThreadUseCase.execute.mockResolvedValue({
+        originalText: 'Max Mustermann, Hauptstraße 42',
+        anonymizedText: '{{pii:PERSON_NAME_1}}, {{pii:LOCATION_1}}',
+        replacements: [],
+        newMasks: [],
+        masks: [mask],
+      } as never);
+
+      const thread = {
+        id: threadId,
+        getLastMessage: jest.fn().mockReturnValue({
+          content: [toolUseContent],
+        }),
+      } as unknown as Thread;
+
+      const { contents, piiMasks } = await service.collectToolResults({
+        thread,
+        tools: [tool],
+        input: null,
+        orgId,
+        isAnonymous: true,
+      });
+
+      expect(contents[0].result).toBe(
+        '{{pii:PERSON_NAME_1}}, {{pii:LOCATION_1}}',
+      );
+      expect(piiMasks).toEqual([mask]);
     });
 
     it('should not anonymize tool results when anonymous mode is disabled', async () => {
@@ -323,7 +379,7 @@ describe('ToolResultCollectorService', () => {
         }),
       } as unknown as Thread;
 
-      const results = await service.collectToolResults({
+      const { contents: results } = await service.collectToolResults({
         thread,
         tools: [tool],
         input: null,
@@ -334,7 +390,7 @@ describe('ToolResultCollectorService', () => {
       expect(results).toHaveLength(1);
       expect(results[0]).toBeInstanceOf(ToolResultMessageContent);
       expect(results[0].result).toBe(rawResult);
-      expect(anonymizeTextForOrgUseCase.execute).not.toHaveBeenCalled();
+      expect(anonymizeTextForThreadUseCase.execute).not.toHaveBeenCalled();
     });
   });
 });

--- a/ayunis-core-backend/src/domain/runs/application/services/tool-result-collector.service.ts
+++ b/ayunis-core-backend/src/domain/runs/application/services/tool-result-collector.service.ts
@@ -12,8 +12,9 @@ import { ExecuteToolCommand } from 'src/domain/tools/application/use-cases/execu
 import { CheckToolCapabilitiesUseCase } from 'src/domain/tools/application/use-cases/check-tool-capabilities/check-tool-capabilities.use-case';
 import { CheckToolCapabilitiesQuery } from 'src/domain/tools/application/use-cases/check-tool-capabilities/check-tool-capabilities.query';
 import { ToolExecutionFailedError } from 'src/domain/tools/application/tools.errors';
-import { AnonymizeTextForOrgUseCase } from 'src/domain/anonymization-settings/application/use-cases/anonymize-text-for-org/anonymize-text-for-org.use-case';
-import { AnonymizeTextForOrgCommand } from 'src/domain/anonymization-settings/application/use-cases/anonymize-text-for-org/anonymize-text-for-org.command';
+import { AnonymizeTextForThreadUseCase } from 'src/domain/thread-pii-masks/application/use-cases/anonymize-text-for-thread/anonymize-text-for-thread.use-case';
+import { AnonymizeTextForThreadCommand } from 'src/domain/thread-pii-masks/application/use-cases/anonymize-text-for-thread/anonymize-text-for-thread.command';
+import type { ThreadPiiMask } from 'src/domain/thread-pii-masks/domain/thread-pii-mask.entity';
 import { ApplicationError } from 'src/common/errors/base.error';
 import { ContextService } from 'src/common/context/services/context.service';
 import { ToolUsedEvent } from '../events/tool-used.event';
@@ -25,6 +26,12 @@ import { RunToolResultInput } from '../../domain/run-input.entity';
 
 const MAX_TOOL_RESULT_LENGTH = 20000;
 
+export interface CollectedToolResults {
+  contents: ToolResultMessageContent[];
+  /** Latest full mask dictionary when any result was anonymized, else null. */
+  piiMasks: ThreadPiiMask[] | null;
+}
+
 @Injectable()
 export class ToolResultCollectorService {
   private readonly logger = new Logger(ToolResultCollectorService.name);
@@ -32,7 +39,7 @@ export class ToolResultCollectorService {
   constructor(
     private readonly executeToolUseCase: ExecuteToolUseCase,
     private readonly checkToolCapabilitiesUseCase: CheckToolCapabilitiesUseCase,
-    private readonly anonymizeTextForOrgUseCase: AnonymizeTextForOrgUseCase,
+    private readonly anonymizeTextForThreadUseCase: AnonymizeTextForThreadUseCase,
     private readonly contextService: ContextService,
     private readonly eventEmitter: EventEmitter2,
   ) {}
@@ -43,7 +50,7 @@ export class ToolResultCollectorService {
     input: RunToolResultInput | null;
     orgId: UUID;
     isAnonymous: boolean;
-  }): Promise<ToolResultMessageContent[]> {
+  }): Promise<CollectedToolResults> {
     this.logger.debug('collectToolResults');
     const { thread, tools, input, orgId, isAnonymous } = params;
 
@@ -54,7 +61,8 @@ export class ToolResultCollectorService {
         )
       : [];
 
-    const toolResultMessageContent: ToolResultMessageContent[] = [];
+    const contents: ToolResultMessageContent[] = [];
+    let piiMasks: ThreadPiiMask[] | null = null;
 
     for (const content of toolUseMessageContent) {
       const result = await this.processToolUse(
@@ -65,10 +73,12 @@ export class ToolResultCollectorService {
         thread.id,
         isAnonymous,
       );
-      toolResultMessageContent.push(result);
+      contents.push(result.content);
+      // Each anonymization returns the full dictionary — the latest wins.
+      piiMasks = result.piiMasks ?? piiMasks;
     }
 
-    return toolResultMessageContent;
+    return { contents, piiMasks };
   }
 
   private async processToolUse(
@@ -78,14 +88,20 @@ export class ToolResultCollectorService {
     orgId: UUID,
     threadId: UUID,
     isAnonymous: boolean,
-  ): Promise<ToolResultMessageContent> {
+  ): Promise<{
+    content: ToolResultMessageContent;
+    piiMasks: ThreadPiiMask[] | null;
+  }> {
     const tool = tools.find((t) => t.name === content.name);
     if (!tool) {
-      return new ToolResultMessageContent(
-        content.id,
-        content.name,
-        `A tool with the name ${content.name} was not found. Only use tools that are available in your given list of tools.`,
-      );
+      return {
+        content: new ToolResultMessageContent(
+          content.id,
+          content.name,
+          `A tool with the name ${content.name} was not found. Only use tools that are available in your given list of tools.`,
+        ),
+        piiMasks: null,
+      };
     }
 
     const userId = this.contextService.get('userId');
@@ -118,7 +134,10 @@ export class ToolResultCollectorService {
       }
 
       if (capabilities.isDisplayable) {
-        return this.handleDisplayableTool(content, input);
+        return {
+          content: this.handleDisplayableTool(content, input),
+          piiMasks: null,
+        };
       }
 
       if (capabilities.isExecutable) {
@@ -129,14 +148,20 @@ export class ToolResultCollectorService {
           threadId,
           isAnonymous,
         );
-        return executionResult.content;
+        return {
+          content: executionResult.content,
+          piiMasks: executionResult.piiMasks,
+        };
       }
 
-      return new ToolResultMessageContent(
-        content.id,
-        content.name,
-        `Tool ${content.name} has no executable or displayable capability.`,
-      );
+      return {
+        content: new ToolResultMessageContent(
+          content.id,
+          content.name,
+          `Tool ${content.name} has no executable or displayable capability.`,
+        ),
+        piiMasks: null,
+      };
     } catch (error) {
       if (error instanceof ApplicationError) {
         throw error;
@@ -155,7 +180,10 @@ export class ToolResultCollectorService {
     orgId: UUID,
     threadId: UUID,
     isAnonymous: boolean,
-  ): Promise<ToolResultMessageContent> {
+  ): Promise<{
+    content: ToolResultMessageContent;
+    piiMasks: ThreadPiiMask[] | null;
+  }> {
     const executionResult = await this.executeBackendTool(
       tool,
       content,
@@ -164,9 +192,15 @@ export class ToolResultCollectorService {
       isAnonymous,
     );
     if (executionResult.succeeded) {
-      return this.handleDisplayableTool(content, input);
+      return {
+        content: this.handleDisplayableTool(content, input),
+        piiMasks: executionResult.piiMasks,
+      };
     }
-    return executionResult.content;
+    return {
+      content: executionResult.content,
+      piiMasks: executionResult.piiMasks,
+    };
   }
 
   exitLoopAfterAgentResponse(
@@ -228,7 +262,11 @@ export class ToolResultCollectorService {
     orgId: UUID,
     threadId: UUID,
     isAnonymous: boolean,
-  ): Promise<{ content: ToolResultMessageContent; succeeded: boolean }> {
+  ): Promise<{
+    content: ToolResultMessageContent;
+    succeeded: boolean;
+    piiMasks: ThreadPiiMask[] | null;
+  }> {
     const context = {
       orgId,
       threadId,
@@ -250,22 +288,30 @@ export class ToolResultCollectorService {
       result = `The tool result was too long to display. Please use the tool in a way that produces a shorter result. Here's the beginning of the result: ${result.substring(0, 200)}`;
     }
 
+    let piiMasks: ThreadPiiMask[] | null = null;
     if (isAnonymous && tool.returnsPii) {
-      result = await this.anonymizeText(result, orgId);
+      const anonymized = await this.anonymizeText(result, orgId, threadId);
+      result = anonymized.anonymizedText;
+      piiMasks = anonymized.masks;
     }
 
     return {
       content: new ToolResultMessageContent(content.id, content.name, result),
       succeeded,
+      piiMasks,
     };
   }
 
-  private async anonymizeText(text: string, orgId: UUID): Promise<string> {
+  private async anonymizeText(
+    text: string,
+    orgId: UUID,
+    threadId: UUID,
+  ): Promise<{ anonymizedText: string; masks: ThreadPiiMask[] }> {
     try {
-      const result = await this.anonymizeTextForOrgUseCase.execute(
-        new AnonymizeTextForOrgCommand(text, orgId),
+      const result = await this.anonymizeTextForThreadUseCase.execute(
+        new AnonymizeTextForThreadCommand(text, orgId, threadId),
       );
-      return result.anonymizedText;
+      return { anonymizedText: result.anonymizedText, masks: result.masks };
     } catch (error) {
       throw new RunAnonymizationUnavailableError({
         originalError: error instanceof Error ? error.message : 'Unknown error',

--- a/ayunis-core-backend/src/domain/runs/application/use-cases/execute-run-and-set-title/execute-run-and-set-title.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/runs/application/use-cases/execute-run-and-set-title/execute-run-and-set-title.use-case.spec.ts
@@ -8,7 +8,16 @@ import type { AnonymizeTextForOrgUseCase } from 'src/domain/anonymization-settin
 import type { ContextService } from 'src/common/context/services/context.service';
 import { RunUserInput } from 'src/domain/runs/domain/run-input.entity';
 import type { Thread } from 'src/domain/threads/domain/thread.entity';
-import type { RunEvent, RunErrorEvent } from '../../run-events';
+import type {
+  RunEvent,
+  RunErrorEvent,
+  RunMasksEvent,
+  RunMessageEvent,
+} from '../../run-events';
+import { RunPiiMasksUpdate } from '../../../domain/run-pii-masks-update.entity';
+import { ThreadPiiMask } from 'src/domain/thread-pii-masks/domain/thread-pii-mask.entity';
+import { PiiCategory } from 'src/common/anonymization/domain/pii-category.enum';
+import type { Message } from 'src/domain/messages/domain/message.entity';
 import {
   QuotaExceededError,
   QuotaErrorCode,
@@ -76,6 +85,52 @@ describe('ExecuteRunAndSetTitleUseCase', () => {
       anonymizeTextForOrgUseCase,
       contextService,
     );
+  });
+
+  describe('PII masks stream items', () => {
+    it('maps RunPiiMasksUpdate items to masks events before the message event', async () => {
+      const mask = new ThreadPiiMask({
+        threadId,
+        category: PiiCategory.PERSON_NAME,
+        maskIndex: 1,
+        value: 'Max Mustermann',
+      });
+      const userMessage = { id: randomUUID() } as unknown as Message;
+
+      executeRunUseCase.execute.mockResolvedValue(
+        (async function* () {
+          yield new RunPiiMasksUpdate([mask]);
+          yield userMessage;
+        })(),
+      );
+
+      const events = await drain(
+        useCase.execute(
+          new ExecuteRunAndSetTitleCommand({
+            threadId,
+            input: new RunUserInput('hello', []),
+            streaming: true,
+          }),
+        ),
+      );
+
+      const masksIndex = events.findIndex((e) => e.type === 'masks');
+      const messageIndex = events.findIndex((e) => e.type === 'message');
+      expect(masksIndex).toBeGreaterThan(-1);
+      expect(masksIndex).toBeLessThan(messageIndex);
+
+      const masksEvent = events[masksIndex] as RunMasksEvent;
+      expect(masksEvent.masks).toEqual([
+        {
+          token: '{{pii:PERSON_NAME_1}}',
+          value: 'Max Mustermann',
+          category: PiiCategory.PERSON_NAME,
+        },
+      ]);
+
+      const messageEvent = events[messageIndex] as RunMessageEvent;
+      expect(messageEvent.message).toBe(userMessage);
+    });
   });
 
   describe('SSE error event conversion', () => {

--- a/ayunis-core-backend/src/domain/runs/application/use-cases/execute-run-and-set-title/execute-run-and-set-title.use-case.ts
+++ b/ayunis-core-backend/src/domain/runs/application/use-cases/execute-run-and-set-title/execute-run-and-set-title.use-case.ts
@@ -8,11 +8,14 @@ import { GenerateAndSetThreadTitleUseCase } from '../../../../threads/applicatio
 import { GenerateAndSetThreadTitleCommand } from '../../../../threads/application/use-cases/generate-and-set-thread-title/generate-and-set-thread-title.command';
 import {
   RunEvent,
+  RunMasksEvent,
   RunMessageEvent,
   RunThreadEvent,
   RunErrorEvent,
   RunSessionEvent,
 } from '../../run-events';
+import { RunPiiMasksUpdate } from '../../../domain/run-pii-masks-update.entity';
+import type { Message } from 'src/domain/messages/domain/message.entity';
 import {
   RunInput,
   RunUserInput,
@@ -67,15 +70,8 @@ export class ExecuteRunAndSetTitleUseCase {
         }),
       );
 
-      for await (const message of messageGenerator) {
-        // Yield message event with domain entity
-        const messageEvent: RunMessageEvent = {
-          type: 'message',
-          message,
-          threadId: command.threadId,
-          timestamp: new Date().toISOString(),
-        };
-        yield messageEvent;
+      for await (const item of messageGenerator) {
+        yield this.toStreamEvent(item, command.threadId);
       }
       if (shouldGenerateTitle) {
         const titleEvent = await this.generateTitle(command, thread);
@@ -120,6 +116,30 @@ export class ExecuteRunAndSetTitleUseCase {
       };
       yield streamingEndEvent;
     }
+  }
+
+  private toStreamEvent(
+    item: Message | RunPiiMasksUpdate,
+    threadId: string,
+  ): RunMasksEvent | RunMessageEvent {
+    if (item instanceof RunPiiMasksUpdate) {
+      return {
+        type: 'masks',
+        threadId,
+        masks: item.masks.map((mask) => ({
+          token: mask.token,
+          value: mask.value,
+          category: mask.category,
+        })),
+        timestamp: new Date().toISOString(),
+      };
+    }
+    return {
+      type: 'message',
+      message: item,
+      threadId,
+      timestamp: new Date().toISOString(),
+    };
   }
 
   private async generateTitle(

--- a/ayunis-core-backend/src/domain/runs/application/use-cases/execute-run/execute-run.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/runs/application/use-cases/execute-run/execute-run.use-case.spec.ts
@@ -1,5 +1,5 @@
 import { AnonymizationFailedError } from 'src/common/anonymization/application/anonymization.errors';
-import type { AnonymizeTextForOrgUseCase } from 'src/domain/anonymization-settings/application/use-cases/anonymize-text-for-org/anonymize-text-for-org.use-case';
+import type { AnonymizeTextForThreadUseCase } from 'src/domain/thread-pii-masks/application/use-cases/anonymize-text-for-thread/anonymize-text-for-thread.use-case';
 import { RunAnonymizationUnavailableError } from '../../runs.errors';
 import type { ContextService } from 'src/common/context/services/context.service';
 import type { CreateToolResultMessageUseCase } from 'src/domain/messages/application/use-cases/create-tool-result-message/create-tool-result-message.use-case';
@@ -33,7 +33,7 @@ import { randomUUID } from 'crypto';
 
 describe('ExecuteRunUseCase', () => {
   let useCase: ExecuteRunUseCase;
-  let anonymizeTextForOrgUseCase: jest.Mocked<AnonymizeTextForOrgUseCase>;
+  let anonymizeTextForThreadUseCase: jest.Mocked<AnonymizeTextForThreadUseCase>;
   let findThreadUseCase: jest.Mocked<FindThreadUseCase>;
   let contextService: jest.Mocked<ContextService>;
   let toolAssemblyService: jest.Mocked<ToolAssemblyService>;
@@ -67,9 +67,9 @@ describe('ExecuteRunUseCase', () => {
   }
 
   beforeEach(() => {
-    anonymizeTextForOrgUseCase = {
+    anonymizeTextForThreadUseCase = {
       execute: jest.fn(),
-    } as unknown as jest.Mocked<AnonymizeTextForOrgUseCase>;
+    } as unknown as jest.Mocked<AnonymizeTextForThreadUseCase>;
 
     findThreadUseCase = {
       execute: jest.fn(),
@@ -123,11 +123,13 @@ describe('ExecuteRunUseCase', () => {
       findThreadUseCase,
       { execute: jest.fn() } as unknown as AddMessageToThreadUseCase,
       contextService,
-      anonymizeTextForOrgUseCase,
+      anonymizeTextForThreadUseCase,
       inferenceUsageGuard,
       toolAssemblyService,
       {
-        collectToolResults: jest.fn().mockResolvedValue([]),
+        collectToolResults: jest
+          .fn()
+          .mockResolvedValue({ contents: [], piiMasks: null }),
         exitLoopAfterAgentResponse: jest.fn().mockReturnValue(true),
       } as unknown as ToolResultCollectorService,
       messageCleanupService,
@@ -282,16 +284,19 @@ describe('ExecuteRunUseCase', () => {
           collectCallCount++;
           if (collectCallCount === 1) {
             // First call: no pending results (initial processToolResults)
-            return [];
+            return { contents: [], piiMasks: null };
           }
           // Second call: activate_skill tool result
-          return [
-            new ToolResultMessageContent(
-              'tool-1',
-              ToolType.ACTIVATE_SKILL,
-              'Skill activated successfully',
-            ),
-          ];
+          return {
+            contents: [
+              new ToolResultMessageContent(
+                'tool-1',
+                ToolType.ACTIVATE_SKILL,
+                'Skill activated successfully',
+              ),
+            ],
+            piiMasks: null,
+          };
         },
       );
 
@@ -336,7 +341,7 @@ describe('ExecuteRunUseCase', () => {
         thread,
         isLongChat: false,
       });
-      anonymizeTextForOrgUseCase.execute.mockRejectedValue(
+      anonymizeTextForThreadUseCase.execute.mockRejectedValue(
         new AnonymizationFailedError('Connection refused'),
       );
 
@@ -370,7 +375,7 @@ describe('ExecuteRunUseCase', () => {
         thread,
         isLongChat: false,
       });
-      anonymizeTextForOrgUseCase.execute.mockRejectedValue(
+      anonymizeTextForThreadUseCase.execute.mockRejectedValue(
         new AnonymizationFailedError('Service timeout'),
       );
 

--- a/ayunis-core-backend/src/domain/runs/application/use-cases/execute-run/execute-run.use-case.ts
+++ b/ayunis-core-backend/src/domain/runs/application/use-cases/execute-run/execute-run.use-case.ts
@@ -27,8 +27,13 @@ import { UUID } from 'crypto';
 import { PermittedLanguageModel } from 'src/domain/models/domain/permitted-model.entity';
 import { ContextService } from 'src/common/context/services/context.service';
 import { ToolType } from 'src/domain/tools/domain/value-objects/tool-type.enum';
-import { AnonymizeTextForOrgUseCase } from 'src/domain/anonymization-settings/application/use-cases/anonymize-text-for-org/anonymize-text-for-org.use-case';
-import { AnonymizeTextForOrgCommand } from 'src/domain/anonymization-settings/application/use-cases/anonymize-text-for-org/anonymize-text-for-org.command';
+import { AnonymizeTextForThreadUseCase } from 'src/domain/thread-pii-masks/application/use-cases/anonymize-text-for-thread/anonymize-text-for-thread.use-case';
+import { AnonymizeTextForThreadCommand } from 'src/domain/thread-pii-masks/application/use-cases/anonymize-text-for-thread/anonymize-text-for-thread.command';
+import type { ThreadPiiMask } from 'src/domain/thread-pii-masks/domain/thread-pii-mask.entity';
+import {
+  RunPiiMasksUpdate,
+  RunStreamItem,
+} from '../../../domain/run-pii-masks-update.entity';
 import { InferenceUsageGuard } from '../../services/inference-usage-guard.service';
 import { SkillActivationService } from 'src/domain/skills/application/services/skill-activation.service';
 import { ToolAssemblyService } from '../../services/tool-assembly.service';
@@ -48,7 +53,7 @@ export class ExecuteRunUseCase {
     private readonly findThreadUseCase: FindThreadUseCase,
     private readonly addMessageToThreadUseCase: AddMessageToThreadUseCase,
     private readonly contextService: ContextService,
-    private readonly anonymizeTextForOrgUseCase: AnonymizeTextForOrgUseCase,
+    private readonly anonymizeTextForThreadUseCase: AnonymizeTextForThreadUseCase,
     private readonly inferenceUsageGuard: InferenceUsageGuard,
     private readonly toolAssemblyService: ToolAssemblyService,
     private readonly toolResultCollectorService: ToolResultCollectorService,
@@ -60,7 +65,7 @@ export class ExecuteRunUseCase {
 
   async execute(
     command: ExecuteRunCommand,
-  ): Promise<AsyncGenerator<Message, void, void>> {
+  ): Promise<AsyncGenerator<RunStreamItem, void, void>> {
     this.logger.log('executeRun', {
       threadId: command.threadId,
       streaming: command.streaming,
@@ -127,6 +132,7 @@ export class ExecuteRunUseCase {
         thread,
         activeSkills,
         model.model.canUseTools,
+        isAnonymous,
       );
 
     return {
@@ -169,7 +175,7 @@ export class ExecuteRunUseCase {
 
   private async *orchestrateRun(
     params: RunParams,
-  ): AsyncGenerator<Message, void, void> {
+  ): AsyncGenerator<RunStreamItem, void, void> {
     this.logger.log('orchestrateRun', { threadId: params.thread.id });
     const iterations = 20;
     let succeeded = false;
@@ -225,12 +231,20 @@ export class ExecuteRunUseCase {
   private async *handleFirstIteration(
     params: RunParams,
     userInput: RunUserInput | null,
-  ): AsyncGenerator<Message, void, void> {
+  ): AsyncGenerator<RunStreamItem, void, void> {
     if (params.skillId) {
       await this.activateSkillOnThread(params);
     }
     if (userInput) {
-      yield await this.processUserMessage(params, userInput);
+      const { message, piiMasks } = await this.processUserMessage(
+        params,
+        userInput,
+      );
+      // Masks first, so the client can resolve tokens in the message below.
+      if (piiMasks) {
+        yield new RunPiiMasksUpdate(piiMasks);
+      }
+      yield message;
     }
   }
 
@@ -249,8 +263,8 @@ export class ExecuteRunUseCase {
   private async *processToolResults(
     params: RunParams,
     toolResultInput: RunToolResultInput | null,
-  ): AsyncGenerator<Message, void, void> {
-    const toolResultMessageContent =
+  ): AsyncGenerator<RunStreamItem, void, void> {
+    const { contents: toolResultMessageContent, piiMasks } =
       await this.toolResultCollectorService.collectToolResults({
         thread: params.thread,
         tools: params.tools,
@@ -270,6 +284,10 @@ export class ExecuteRunUseCase {
     this.addMessageToThreadUseCase.execute(
       new AddMessageCommand(params.thread, toolResultMessage),
     );
+    // Masks first, so the client can resolve tokens in the message below.
+    if (piiMasks) {
+      yield new RunPiiMasksUpdate(piiMasks);
+    }
     yield toolResultMessage;
 
     const skillWasActivated = toolResultMessageContent.some(
@@ -313,6 +331,7 @@ Skill "${skillName}" has already been activated on this thread. Do not call acti
       refreshedThread,
       params.activeSkills,
       params.model.canUseTools,
+      params.isAnonymous,
     );
     params.tools = refreshed.tools;
     params.instructions = refreshed.instructions;
@@ -328,7 +347,7 @@ Skill "${skillName}" has already been activated on this thread. Do not call acti
   private async processUserMessage(
     params: RunParams,
     userInput: RunUserInput,
-  ): Promise<Message> {
+  ): Promise<{ message: Message; piiMasks: ThreadPiiMask[] | null }> {
     const hasText = userInput.text && userInput.text.trim().length > 0;
     const hasImages = userInput.pendingImages.length > 0;
     const hasSkillInstructions =
@@ -345,10 +364,17 @@ Skill "${skillName}" has already been activated on this thread. Do not call acti
       );
     }
 
-    const messageText =
-      hasText && params.isAnonymous
-        ? await this.anonymizeText(userInput.text, params.orgId)
-        : userInput.text;
+    let messageText = userInput.text;
+    let piiMasks: ThreadPiiMask[] | null = null;
+    if (hasText && params.isAnonymous) {
+      const anonymized = await this.anonymizeText(
+        userInput.text,
+        params.orgId,
+        params.thread.id,
+      );
+      messageText = anonymized.anonymizedText;
+      piiMasks = anonymized.masks;
+    }
 
     const newUserMessage = await this.createUserMessageUseCase.execute(
       new CreateUserMessageCommand(
@@ -361,13 +387,17 @@ Skill "${skillName}" has already been activated on this thread. Do not call acti
     this.addMessageToThreadUseCase.execute(
       new AddMessageCommand(params.thread, newUserMessage),
     );
-    return newUserMessage;
+    return { message: newUserMessage, piiMasks };
   }
 
-  private async anonymizeText(text: string, orgId: UUID): Promise<string> {
+  private async anonymizeText(
+    text: string,
+    orgId: UUID,
+    threadId: UUID,
+  ): Promise<{ anonymizedText: string; masks: ThreadPiiMask[] }> {
     try {
-      const result = await this.anonymizeTextForOrgUseCase.execute(
-        new AnonymizeTextForOrgCommand(text, orgId),
+      const result = await this.anonymizeTextForThreadUseCase.execute(
+        new AnonymizeTextForThreadCommand(text, orgId, threadId),
       );
       if (result.replacements.length > 0) {
         this.logger.log('Anonymized text', {
@@ -376,7 +406,7 @@ Skill "${skillName}" has already been activated on this thread. Do not call acti
           replacementsCount: result.replacements.length,
         });
       }
-      return result.anonymizedText;
+      return { anonymizedText: result.anonymizedText, masks: result.masks };
     } catch (error) {
       this.logger.error('Anonymization service unavailable', {
         error: error as Error,

--- a/ayunis-core-backend/src/domain/runs/domain/run-pii-masks-update.entity.ts
+++ b/ayunis-core-backend/src/domain/runs/domain/run-pii-masks-update.entity.ts
@@ -1,0 +1,13 @@
+import type { Message } from 'src/domain/messages/domain/message.entity';
+import type { ThreadPiiMask } from 'src/domain/thread-pii-masks/domain/thread-pii-mask.entity';
+
+/**
+ * Stream item carrying the thread's full mask dictionary. Yielded before any
+ * message whose text contains freshly created `{{pii:...}}` tokens, so SSE
+ * consumers can resolve them the moment the message arrives.
+ */
+export class RunPiiMasksUpdate {
+  constructor(public readonly masks: ThreadPiiMask[]) {}
+}
+
+export type RunStreamItem = Message | RunPiiMasksUpdate;

--- a/ayunis-core-backend/src/domain/runs/presenters/http/dto/run-response.dto.ts
+++ b/ayunis-core-backend/src/domain/runs/presenters/http/dto/run-response.dto.ts
@@ -9,6 +9,7 @@ import {
   ToolResultMessageResponseDto,
   SystemMessageResponseDto,
 } from '../../../../threads/presenters/http/dto/get-thread-response.dto/message-response.dto';
+import { PiiMaskResponseDto } from 'src/domain/thread-pii-masks/presenters/http/dtos/pii-mask-response.dto';
 
 export class RunSessionResponseDto {
   @ApiProperty({
@@ -203,10 +204,43 @@ export class RunHeartbeatResponseDto {
   sequence?: number;
 }
 
+export class RunMasksResponseDto {
+  @ApiProperty({
+    description: 'Response type identifier',
+    example: 'masks',
+    enum: ['masks'],
+    required: true,
+  })
+  type: 'masks';
+
+  @ApiProperty({
+    description: 'Thread ID the mask dictionary belongs to',
+    example: '123e4567-e89b-12d3-a456-426614174000',
+    required: true,
+  })
+  threadId: string;
+
+  @ApiProperty({
+    description:
+      'Full PII mask dictionary of the thread (idempotent to re-apply)',
+    type: [PiiMaskResponseDto],
+    required: true,
+  })
+  masks: PiiMaskResponseDto[];
+
+  @ApiProperty({
+    description: 'Event timestamp',
+    example: '2024-01-01T12:00:00.000Z',
+    required: true,
+  })
+  timestamp: string;
+}
+
 // Union type for TypeScript usage
 export type RunResponse =
   | RunSessionResponseDto
   | RunMessageResponseDto
   | RunErrorResponseDto
   | RunThreadResponseDto
-  | RunHeartbeatResponseDto;
+  | RunHeartbeatResponseDto
+  | RunMasksResponseDto;

--- a/ayunis-core-backend/src/domain/runs/presenters/http/runs.controller.ts
+++ b/ayunis-core-backend/src/domain/runs/presenters/http/runs.controller.ts
@@ -47,8 +47,10 @@ import {
   RunMessageResponseDto,
   RunErrorResponseDto,
   RunThreadResponseDto,
+  RunMasksResponseDto,
   RunResponse,
 } from './dto/run-response.dto';
+import { PiiMaskResponseDto } from 'src/domain/thread-pii-masks/presenters/http/dtos/pii-mask-response.dto';
 import { ExecuteRunAndSetTitleUseCase } from '../../application/use-cases/execute-run-and-set-title/execute-run-and-set-title.use-case';
 import { ExecuteRunAndSetTitleCommand } from '../../application/use-cases/execute-run-and-set-title/execute-run-and-set-title.command';
 import { RunEvent } from '../../application/run-events';
@@ -87,6 +89,8 @@ const ALLOWED_IMAGE_TYPES = [
   RunMessageResponseDto,
   RunErrorResponseDto,
   RunThreadResponseDto,
+  RunMasksResponseDto,
+  PiiMaskResponseDto,
   SendMessageDto,
   TextInput,
   ToolResultInput,
@@ -173,6 +177,7 @@ export class RunsController {
             { $ref: getSchemaPath(RunMessageResponseDto) },
             { $ref: getSchemaPath(RunErrorResponseDto) },
             { $ref: getSchemaPath(RunThreadResponseDto) },
+            { $ref: getSchemaPath(RunMasksResponseDto) },
           ],
           discriminator: {
             propertyName: 'type',
@@ -181,6 +186,7 @@ export class RunsController {
               message: getSchemaPath(RunMessageResponseDto),
               error: getSchemaPath(RunErrorResponseDto),
               thread: getSchemaPath(RunThreadResponseDto),
+              masks: getSchemaPath(RunMasksResponseDto),
             },
           },
         },
@@ -367,6 +373,13 @@ export class RunsController {
           threadId: event.threadId,
           timestamp: event.timestamp,
         };
+      case 'masks':
+        return {
+          type: 'masks',
+          threadId: event.threadId,
+          masks: event.masks,
+          timestamp: event.timestamp,
+        };
     }
   }
 
@@ -439,6 +452,9 @@ export class RunsController {
               break;
             case 'session':
               eventId = 'session';
+              break;
+            case 'masks':
+              eventId = `masks-${event.timestamp}`;
               break;
             default:
               eventId = 'event';

--- a/ayunis-core-backend/src/domain/runs/runs.module.ts
+++ b/ayunis-core-backend/src/domain/runs/runs.module.ts
@@ -22,6 +22,7 @@ import { TrialsModule } from 'src/iam/trials/trials.module';
 import { McpModule } from 'src/domain/mcp/mcp.module';
 import { SourcesModule } from 'src/domain/sources/sources.module';
 import { AnonymizationSettingsModule } from 'src/domain/anonymization-settings/anonymization-settings.module';
+import { ThreadPiiMasksModule } from 'src/domain/thread-pii-masks/thread-pii-masks.module';
 import { UsageModule } from 'src/domain/usage/usage.module';
 import { QuotasModule } from 'src/iam/quotas/quotas.module';
 import { SkillsModule } from 'src/domain/skills/skills.module';
@@ -41,6 +42,7 @@ import { LetterheadsModule } from 'src/domain/letterheads/letterheads.module';
     McpModule,
     SourcesModule,
     AnonymizationSettingsModule,
+    ThreadPiiMasksModule,
     UsageModule,
     QuotasModule,
     SkillsModule,

--- a/ayunis-core-backend/src/domain/threads/presenters/http/dto/get-thread-response.dto/index.ts
+++ b/ayunis-core-backend/src/domain/threads/presenters/http/dto/get-thread-response.dto/index.ts
@@ -26,6 +26,7 @@ import {
   UrlSourceResponseDto,
 } from './source-response.dto';
 import { KnowledgeBaseSummaryResponseDto } from '../knowledge-base-summary-response.dto';
+import { PiiMaskResponseDto } from 'src/domain/thread-pii-masks/presenters/http/dtos/pii-mask-response.dto';
 
 @ApiExtraModels(
   UserMessageResponseDto,
@@ -121,4 +122,11 @@ export class GetThreadResponseDto {
     type: [KnowledgeBaseSummaryResponseDto],
   })
   knowledgeBases: KnowledgeBaseSummaryResponseDto[];
+
+  @ApiProperty({
+    description:
+      'PII mask dictionary for anonymous threads — resolves {{pii:...}} tokens in message text to their original values. Empty for non-anonymous threads.',
+    type: [PiiMaskResponseDto],
+  })
+  piiMasks: PiiMaskResponseDto[];
 }

--- a/ayunis-core-backend/src/domain/threads/presenters/http/mappers/get-thread.mapper.ts
+++ b/ayunis-core-backend/src/domain/threads/presenters/http/mappers/get-thread.mapper.ts
@@ -4,15 +4,21 @@ import { GetThreadResponseDto } from '../dto/get-thread-response.dto';
 import { MessageDtoMapper } from './message.mapper';
 import { SourceDtoMapper } from './source.mapper';
 import { FindThreadResult } from '../../../application/use-cases/find-thread/find-thread.use-case';
+import { PiiMaskDtoMapper } from 'src/domain/thread-pii-masks/presenters/http/mappers/pii-mask.mapper';
+import type { ThreadPiiMask } from 'src/domain/thread-pii-masks/domain/thread-pii-mask.entity';
 
 @Injectable()
 export class GetThreadDtoMapper {
   constructor(
     private readonly messageDtoMapper: MessageDtoMapper,
     private readonly sourceDtoMapper: SourceDtoMapper,
+    private readonly piiMaskDtoMapper: PiiMaskDtoMapper,
   ) {}
 
-  toDto(result: FindThreadResult): GetThreadResponseDto {
+  toDto(
+    result: FindThreadResult,
+    piiMasks: ThreadPiiMask[] = [],
+  ): GetThreadResponseDto {
     const { thread, isLongChat } = result;
 
     return {
@@ -30,6 +36,7 @@ export class GetThreadDtoMapper {
       isAnonymous: thread.isAnonymous,
       isLongChat,
       knowledgeBases: thread.getUniqueKnowledgeBases(),
+      piiMasks: this.piiMaskDtoMapper.toDtoArray(piiMasks),
     };
   }
 

--- a/ayunis-core-backend/src/domain/threads/presenters/http/threads.controller.ts
+++ b/ayunis-core-backend/src/domain/threads/presenters/http/threads.controller.ts
@@ -45,6 +45,8 @@ import { GetThreadsResponseDto } from './dto/get-threads-response.dto';
 import { FindAllThreadsQueryParamsDto } from './dto/find-all-threads-query-params.dto';
 import { GetThreadDtoMapper } from './mappers/get-thread.mapper';
 import { GetThreadsDtoMapper } from './mappers/get-threads.mapper';
+import { GetThreadPiiMasksUseCase } from 'src/domain/thread-pii-masks/application/use-cases/get-thread-pii-masks/get-thread-pii-masks.use-case';
+import { GetThreadPiiMasksQuery } from 'src/domain/thread-pii-masks/application/use-cases/get-thread-pii-masks/get-thread-pii-masks.query';
 
 @ApiTags('threads')
 @Controller('threads')
@@ -59,6 +61,7 @@ export class ThreadsController {
     private readonly updateThreadTitleUseCase: UpdateThreadTitleUseCase,
     private readonly getThreadDtoMapper: GetThreadDtoMapper,
     private readonly getThreadsDtoMapper: GetThreadsDtoMapper,
+    private readonly getThreadPiiMasksUseCase: GetThreadPiiMasksUseCase,
   ) {}
 
   @Post()
@@ -157,7 +160,12 @@ export class ThreadsController {
     const result = await this.findThreadUseCase.execute(
       new FindThreadQuery(id),
     );
-    return this.getThreadDtoMapper.toDto(result);
+    const piiMasks = result.thread.isAnonymous
+      ? await this.getThreadPiiMasksUseCase.execute(
+          new GetThreadPiiMasksQuery(id),
+        )
+      : [];
+    return this.getThreadDtoMapper.toDto(result, piiMasks);
   }
 
   @Delete(':id')

--- a/ayunis-core-backend/src/domain/threads/threads.module.ts
+++ b/ayunis-core-backend/src/domain/threads/threads.module.ts
@@ -44,6 +44,7 @@ import { KnowledgeBasesModule } from '../knowledge-bases/knowledge-bases.module'
 import { StorageModule } from '../storage/storage.module';
 import { MessagesModule } from '../messages/messages.module';
 import { SharesModule } from '../shares/shares.module';
+import { ThreadPiiMasksModule } from '../thread-pii-masks/thread-pii-masks.module';
 @Module({
   imports: [
     LocalThreadsRepositoryModule,
@@ -54,6 +55,7 @@ import { SharesModule } from '../shares/shares.module';
     OrgsModule,
     StorageModule,
     SharesModule,
+    ThreadPiiMasksModule,
   ],
   controllers: [
     ThreadsController,

--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
@@ -2237,6 +2237,36 @@ export interface KnowledgeBaseSummaryResponseDto {
   name: string;
 }
 
+/**
+ * PII category of the masked value
+ */
+export type PiiCategory = typeof PiiCategory[keyof typeof PiiCategory];
+
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const PiiCategory = {
+  person_name: 'person_name',
+  organization: 'organization',
+  location: 'location',
+  email_address: 'email_address',
+  phone_number: 'phone_number',
+  url_or_ip: 'url_or_ip',
+  date_time: 'date_time',
+  financial_account: 'financial_account',
+  government_id: 'government_id',
+  nationality_religion_politics: 'nationality_religion_politics',
+  other: 'other',
+} as const;
+
+export interface PiiMaskResponseDto {
+  /** The placeholder token as it appears in message text, e.g. {{pii:PERSON_NAME_1}} */
+  token: string;
+  /** The original value the token stands in for */
+  value: string;
+  /** PII category of the masked value */
+  category: PiiCategory;
+}
+
 export type GetThreadResponseDtoMessagesItem = UserMessageResponseDto | SystemMessageResponseDto | AssistantMessageResponseDto | ToolResultMessageResponseDto;
 
 export interface GetThreadResponseDto {
@@ -2262,6 +2292,8 @@ export interface GetThreadResponseDto {
   isLongChat: boolean;
   /** Knowledge bases attached to this thread */
   knowledgeBases: KnowledgeBaseSummaryResponseDto[];
+  /** PII mask dictionary for anonymous threads — resolves {{pii:...}} tokens in message text to their original values. Empty for non-anonymous threads. */
+  piiMasks: PiiMaskResponseDto[];
 }
 
 export interface GetThreadsResponseDtoItem {
@@ -3080,6 +3112,30 @@ export interface MarketplaceIntegrationResponseDto {
   updatedAt: string;
 }
 
+export interface PiiWhitelistEntryDto {
+  /** PII category exempt from anonymization */
+  category: PiiCategory;
+  /**
+   * Optional regex; when set, only values fully matching it (case-insensitive) are exempt. Null exempts the whole category.
+   * @maxLength 200
+   * @nullable
+   */
+  pattern: string | null;
+}
+
+export interface PiiWhitelistResponseDto {
+  /** Current whitelist entries for the org */
+  entries: PiiWhitelistEntryDto[];
+}
+
+export interface UpdatePiiWhitelistRequestDto {
+  /**
+   * Full replacement whitelist; an empty array removes all entries
+   * @maxItems 50
+   */
+  entries: PiiWhitelistEntryDto[];
+}
+
 /**
  * The distribution mode of the skill template
  */
@@ -3766,6 +3822,28 @@ export interface RunThreadResponseDto {
 }
 
 /**
+ * Response type identifier
+ */
+export type RunMasksResponseDtoType = typeof RunMasksResponseDtoType[keyof typeof RunMasksResponseDtoType];
+
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const RunMasksResponseDtoType = {
+  masks: 'masks',
+} as const;
+
+export interface RunMasksResponseDto {
+  /** Response type identifier */
+  type: RunMasksResponseDtoType;
+  /** Thread ID the mask dictionary belongs to */
+  threadId: string;
+  /** Full PII mask dictionary of the thread (idempotent to re-apply) */
+  masks: PiiMaskResponseDto[];
+  /** Event timestamp */
+  timestamp: string;
+}
+
+/**
  * The type of input
  */
 export type TextInputType = typeof TextInputType[keyof typeof TextInputType];
@@ -3867,50 +3945,6 @@ export interface UpdateTrialRequestDto {
    * @minimum 0
    */
   messagesSent?: number;
-}
-
-/**
- * PII category exempt from anonymization
- */
-export type PiiCategory = typeof PiiCategory[keyof typeof PiiCategory];
-
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const PiiCategory = {
-  person_name: 'person_name',
-  organization: 'organization',
-  location: 'location',
-  email_address: 'email_address',
-  phone_number: 'phone_number',
-  url_or_ip: 'url_or_ip',
-  date_time: 'date_time',
-  financial_account: 'financial_account',
-  government_id: 'government_id',
-  nationality_religion_politics: 'nationality_religion_politics',
-} as const;
-
-export interface PiiWhitelistEntryDto {
-  /** PII category exempt from anonymization */
-  category: PiiCategory;
-  /**
-   * Optional regex; when set, only values fully matching it (case-insensitive) are exempt. Null exempts the whole category.
-   * @maxLength 200
-   * @nullable
-   */
-  pattern: string | null;
-}
-
-export interface PiiWhitelistResponseDto {
-  /** Current whitelist entries for the org */
-  entries: PiiWhitelistEntryDto[];
-}
-
-export interface UpdatePiiWhitelistRequestDto {
-  /**
-   * Full replacement whitelist; an empty array removes all entries
-   * @maxItems 50
-   */
-  entries: PiiWhitelistEntryDto[];
 }
 
 export interface UserSystemPromptResponseDto {
@@ -4414,5 +4448,5 @@ export type RunsControllerSendMessageBody = {
   streaming?: boolean;
 };
 
-export type RunsControllerSendMessage200 = RunSessionResponseDto | RunMessageResponseDto | RunErrorResponseDto | RunThreadResponseDto;
+export type RunsControllerSendMessage200 = RunSessionResponseDto | RunMessageResponseDto | RunErrorResponseDto | RunThreadResponseDto | RunMasksResponseDto;
 

--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.ts
@@ -12133,6 +12133,163 @@ export function useMarketplaceControllerGetIntegration<TData = Awaited<ReturnTyp
 
 
 /**
+ * @summary Get the PII whitelist for the current org
+ */
+export const anonymizationSettingsControllerGet = (
+    
+ signal?: AbortSignal
+) => {
+      
+      
+      return customAxiosInstance<PiiWhitelistResponseDto>(
+      {url: `/anonymization-settings/pii-whitelist`, method: 'GET', signal
+    },
+      );
+    }
+  
+
+
+
+export const getAnonymizationSettingsControllerGetQueryKey = () => {
+    return [
+    `/anonymization-settings/pii-whitelist`
+    ] as const;
+    }
+
+    
+export const getAnonymizationSettingsControllerGetQueryOptions = <TData = Awaited<ReturnType<typeof anonymizationSettingsControllerGet>>, TError = unknown>( options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof anonymizationSettingsControllerGet>>, TError, TData>>, }
+) => {
+
+const {query: queryOptions} = options ?? {};
+
+  const queryKey =  queryOptions?.queryKey ?? getAnonymizationSettingsControllerGetQueryKey();
+
+  
+
+    const queryFn: QueryFunction<Awaited<ReturnType<typeof anonymizationSettingsControllerGet>>> = ({ signal }) => anonymizationSettingsControllerGet(signal);
+
+      
+
+      
+
+   return  { queryKey, queryFn, ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof anonymizationSettingsControllerGet>>, TError, TData> & { queryKey: DataTag<QueryKey, TData, TError> }
+}
+
+export type AnonymizationSettingsControllerGetQueryResult = NonNullable<Awaited<ReturnType<typeof anonymizationSettingsControllerGet>>>
+export type AnonymizationSettingsControllerGetQueryError = unknown
+
+
+export function useAnonymizationSettingsControllerGet<TData = Awaited<ReturnType<typeof anonymizationSettingsControllerGet>>, TError = unknown>(
+  options: { query:Partial<UseQueryOptions<Awaited<ReturnType<typeof anonymizationSettingsControllerGet>>, TError, TData>> & Pick<
+        DefinedInitialDataOptions<
+          Awaited<ReturnType<typeof anonymizationSettingsControllerGet>>,
+          TError,
+          Awaited<ReturnType<typeof anonymizationSettingsControllerGet>>
+        > , 'initialData'
+      >, }
+ , queryClient?: QueryClient
+  ):  DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useAnonymizationSettingsControllerGet<TData = Awaited<ReturnType<typeof anonymizationSettingsControllerGet>>, TError = unknown>(
+  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof anonymizationSettingsControllerGet>>, TError, TData>> & Pick<
+        UndefinedInitialDataOptions<
+          Awaited<ReturnType<typeof anonymizationSettingsControllerGet>>,
+          TError,
+          Awaited<ReturnType<typeof anonymizationSettingsControllerGet>>
+        > , 'initialData'
+      >, }
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useAnonymizationSettingsControllerGet<TData = Awaited<ReturnType<typeof anonymizationSettingsControllerGet>>, TError = unknown>(
+  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof anonymizationSettingsControllerGet>>, TError, TData>>, }
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+/**
+ * @summary Get the PII whitelist for the current org
+ */
+
+export function useAnonymizationSettingsControllerGet<TData = Awaited<ReturnType<typeof anonymizationSettingsControllerGet>>, TError = unknown>(
+  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof anonymizationSettingsControllerGet>>, TError, TData>>, }
+ , queryClient?: QueryClient 
+ ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
+
+  const queryOptions = getAnonymizationSettingsControllerGetQueryOptions(options)
+
+  const query = useQuery(queryOptions, queryClient) as  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+
+  query.queryKey = queryOptions.queryKey ;
+
+  return query;
+}
+
+
+
+
+
+/**
+ * @summary Replace the PII whitelist for the current org
+ */
+export const anonymizationSettingsControllerUpdate = (
+    updatePiiWhitelistRequestDto: UpdatePiiWhitelistRequestDto,
+ ) => {
+      
+      
+      return customAxiosInstance<PiiWhitelistResponseDto>(
+      {url: `/anonymization-settings/pii-whitelist`, method: 'PUT',
+      headers: {'Content-Type': 'application/json', },
+      data: updatePiiWhitelistRequestDto
+    },
+      );
+    }
+  
+
+
+export const getAnonymizationSettingsControllerUpdateMutationOptions = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof anonymizationSettingsControllerUpdate>>, TError,{data: UpdatePiiWhitelistRequestDto}, TContext>, }
+): UseMutationOptions<Awaited<ReturnType<typeof anonymizationSettingsControllerUpdate>>, TError,{data: UpdatePiiWhitelistRequestDto}, TContext> => {
+
+const mutationKey = ['anonymizationSettingsControllerUpdate'];
+const {mutation: mutationOptions} = options ?
+      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
+      options
+      : {...options, mutation: {...options.mutation, mutationKey}}
+      : {mutation: { mutationKey, }};
+
+      
+
+
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof anonymizationSettingsControllerUpdate>>, {data: UpdatePiiWhitelistRequestDto}> = (props) => {
+          const {data} = props ?? {};
+
+          return  anonymizationSettingsControllerUpdate(data,)
+        }
+
+        
+
+
+  return  { mutationFn, ...mutationOptions }}
+
+    export type AnonymizationSettingsControllerUpdateMutationResult = NonNullable<Awaited<ReturnType<typeof anonymizationSettingsControllerUpdate>>>
+    export type AnonymizationSettingsControllerUpdateMutationBody = UpdatePiiWhitelistRequestDto
+    export type AnonymizationSettingsControllerUpdateMutationError = void
+
+    /**
+ * @summary Replace the PII whitelist for the current org
+ */
+export const useAnonymizationSettingsControllerUpdate = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof anonymizationSettingsControllerUpdate>>, TError,{data: UpdatePiiWhitelistRequestDto}, TContext>, }
+ , queryClient?: QueryClient): UseMutationResult<
+        Awaited<ReturnType<typeof anonymizationSettingsControllerUpdate>>,
+        TError,
+        {data: UpdatePiiWhitelistRequestDto},
+        TContext
+      > => {
+
+      const mutationOptions = getAnonymizationSettingsControllerUpdateMutationOptions(options);
+
+      return useMutation(mutationOptions, queryClient);
+    }
+    
+/**
  * Create a new skill template. Only accessible to super admins.
  * @summary Create a new skill template
  */
@@ -15534,163 +15691,6 @@ export const useSuperAdminTrialsControllerUpdateTrial = <TError = void,
       > => {
 
       const mutationOptions = getSuperAdminTrialsControllerUpdateTrialMutationOptions(options);
-
-      return useMutation(mutationOptions, queryClient);
-    }
-    
-/**
- * @summary Get the PII whitelist for the current org
- */
-export const anonymizationSettingsControllerGet = (
-    
- signal?: AbortSignal
-) => {
-      
-      
-      return customAxiosInstance<PiiWhitelistResponseDto>(
-      {url: `/anonymization-settings/pii-whitelist`, method: 'GET', signal
-    },
-      );
-    }
-  
-
-
-
-export const getAnonymizationSettingsControllerGetQueryKey = () => {
-    return [
-    `/anonymization-settings/pii-whitelist`
-    ] as const;
-    }
-
-    
-export const getAnonymizationSettingsControllerGetQueryOptions = <TData = Awaited<ReturnType<typeof anonymizationSettingsControllerGet>>, TError = unknown>( options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof anonymizationSettingsControllerGet>>, TError, TData>>, }
-) => {
-
-const {query: queryOptions} = options ?? {};
-
-  const queryKey =  queryOptions?.queryKey ?? getAnonymizationSettingsControllerGetQueryKey();
-
-  
-
-    const queryFn: QueryFunction<Awaited<ReturnType<typeof anonymizationSettingsControllerGet>>> = ({ signal }) => anonymizationSettingsControllerGet(signal);
-
-      
-
-      
-
-   return  { queryKey, queryFn, ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof anonymizationSettingsControllerGet>>, TError, TData> & { queryKey: DataTag<QueryKey, TData, TError> }
-}
-
-export type AnonymizationSettingsControllerGetQueryResult = NonNullable<Awaited<ReturnType<typeof anonymizationSettingsControllerGet>>>
-export type AnonymizationSettingsControllerGetQueryError = unknown
-
-
-export function useAnonymizationSettingsControllerGet<TData = Awaited<ReturnType<typeof anonymizationSettingsControllerGet>>, TError = unknown>(
-  options: { query:Partial<UseQueryOptions<Awaited<ReturnType<typeof anonymizationSettingsControllerGet>>, TError, TData>> & Pick<
-        DefinedInitialDataOptions<
-          Awaited<ReturnType<typeof anonymizationSettingsControllerGet>>,
-          TError,
-          Awaited<ReturnType<typeof anonymizationSettingsControllerGet>>
-        > , 'initialData'
-      >, }
- , queryClient?: QueryClient
-  ):  DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
-export function useAnonymizationSettingsControllerGet<TData = Awaited<ReturnType<typeof anonymizationSettingsControllerGet>>, TError = unknown>(
-  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof anonymizationSettingsControllerGet>>, TError, TData>> & Pick<
-        UndefinedInitialDataOptions<
-          Awaited<ReturnType<typeof anonymizationSettingsControllerGet>>,
-          TError,
-          Awaited<ReturnType<typeof anonymizationSettingsControllerGet>>
-        > , 'initialData'
-      >, }
- , queryClient?: QueryClient
-  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
-export function useAnonymizationSettingsControllerGet<TData = Awaited<ReturnType<typeof anonymizationSettingsControllerGet>>, TError = unknown>(
-  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof anonymizationSettingsControllerGet>>, TError, TData>>, }
- , queryClient?: QueryClient
-  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
-/**
- * @summary Get the PII whitelist for the current org
- */
-
-export function useAnonymizationSettingsControllerGet<TData = Awaited<ReturnType<typeof anonymizationSettingsControllerGet>>, TError = unknown>(
-  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof anonymizationSettingsControllerGet>>, TError, TData>>, }
- , queryClient?: QueryClient 
- ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
-
-  const queryOptions = getAnonymizationSettingsControllerGetQueryOptions(options)
-
-  const query = useQuery(queryOptions, queryClient) as  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
-
-  query.queryKey = queryOptions.queryKey ;
-
-  return query;
-}
-
-
-
-
-
-/**
- * @summary Replace the PII whitelist for the current org
- */
-export const anonymizationSettingsControllerUpdate = (
-    updatePiiWhitelistRequestDto: UpdatePiiWhitelistRequestDto,
- ) => {
-      
-      
-      return customAxiosInstance<PiiWhitelistResponseDto>(
-      {url: `/anonymization-settings/pii-whitelist`, method: 'PUT',
-      headers: {'Content-Type': 'application/json', },
-      data: updatePiiWhitelistRequestDto
-    },
-      );
-    }
-  
-
-
-export const getAnonymizationSettingsControllerUpdateMutationOptions = <TError = void,
-    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof anonymizationSettingsControllerUpdate>>, TError,{data: UpdatePiiWhitelistRequestDto}, TContext>, }
-): UseMutationOptions<Awaited<ReturnType<typeof anonymizationSettingsControllerUpdate>>, TError,{data: UpdatePiiWhitelistRequestDto}, TContext> => {
-
-const mutationKey = ['anonymizationSettingsControllerUpdate'];
-const {mutation: mutationOptions} = options ?
-      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
-      options
-      : {...options, mutation: {...options.mutation, mutationKey}}
-      : {mutation: { mutationKey, }};
-
-      
-
-
-      const mutationFn: MutationFunction<Awaited<ReturnType<typeof anonymizationSettingsControllerUpdate>>, {data: UpdatePiiWhitelistRequestDto}> = (props) => {
-          const {data} = props ?? {};
-
-          return  anonymizationSettingsControllerUpdate(data,)
-        }
-
-        
-
-
-  return  { mutationFn, ...mutationOptions }}
-
-    export type AnonymizationSettingsControllerUpdateMutationResult = NonNullable<Awaited<ReturnType<typeof anonymizationSettingsControllerUpdate>>>
-    export type AnonymizationSettingsControllerUpdateMutationBody = UpdatePiiWhitelistRequestDto
-    export type AnonymizationSettingsControllerUpdateMutationError = void
-
-    /**
- * @summary Replace the PII whitelist for the current org
- */
-export const useAnonymizationSettingsControllerUpdate = <TError = void,
-    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof anonymizationSettingsControllerUpdate>>, TError,{data: UpdatePiiWhitelistRequestDto}, TContext>, }
- , queryClient?: QueryClient): UseMutationResult<
-        Awaited<ReturnType<typeof anonymizationSettingsControllerUpdate>>,
-        TError,
-        {data: UpdatePiiWhitelistRequestDto},
-        TContext
-      > => {
-
-      const mutationOptions = getAnonymizationSettingsControllerUpdateMutationOptions(options);
 
       return useMutation(mutationOptions, queryClient);
     }

--- a/ayunis-core-frontend/src/shared/api/openapi-schema.json
+++ b/ayunis-core-frontend/src/shared/api/openapi-schema.json
@@ -5999,6 +5999,57 @@
         "tags": ["marketplace"]
       }
     },
+    "/anonymization-settings/pii-whitelist": {
+      "get": {
+        "operationId": "AnonymizationSettingsController_get",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Current PII whitelist (empty list if none)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PiiWhitelistResponseDto"
+                }
+              }
+            }
+          }
+        },
+        "summary": "Get the PII whitelist for the current org",
+        "tags": ["anonymization-settings"]
+      },
+      "put": {
+        "operationId": "AnonymizationSettingsController_update",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdatePiiWhitelistRequestDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated PII whitelist",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PiiWhitelistResponseDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid or unsafe regex pattern, or duplicate category"
+          }
+        },
+        "summary": "Replace the PII whitelist for the current org",
+        "tags": ["anonymization-settings"]
+      }
+    },
     "/super-admin/skill-templates": {
       "post": {
         "description": "Create a new skill template. Only accessible to super admins.",
@@ -7529,6 +7580,9 @@
                     },
                     {
                       "$ref": "#/components/schemas/RunThreadResponseDto"
+                    },
+                    {
+                      "$ref": "#/components/schemas/RunMasksResponseDto"
                     }
                   ],
                   "discriminator": {
@@ -7537,7 +7591,8 @@
                       "session": "#/components/schemas/RunSessionResponseDto",
                       "message": "#/components/schemas/RunMessageResponseDto",
                       "error": "#/components/schemas/RunErrorResponseDto",
-                      "thread": "#/components/schemas/RunThreadResponseDto"
+                      "thread": "#/components/schemas/RunThreadResponseDto",
+                      "masks": "#/components/schemas/RunMasksResponseDto"
                     }
                   }
                 }
@@ -7700,57 +7755,6 @@
         },
         "summary": "Update a trial",
         "tags": ["Super Admin Trials"]
-      }
-    },
-    "/anonymization-settings/pii-whitelist": {
-      "get": {
-        "operationId": "AnonymizationSettingsController_get",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "description": "Current PII whitelist (empty list if none)",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PiiWhitelistResponseDto"
-                }
-              }
-            }
-          }
-        },
-        "summary": "Get the PII whitelist for the current org",
-        "tags": ["anonymization-settings"]
-      },
-      "put": {
-        "operationId": "AnonymizationSettingsController_update",
-        "parameters": [],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/UpdatePiiWhitelistRequestDto"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Updated PII whitelist",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PiiWhitelistResponseDto"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Invalid or unsafe regex pattern, or duplicate category"
-          }
-        },
-        "summary": "Replace the PII whitelist for the current org",
-        "tags": ["anonymization-settings"]
       }
     },
     "/chat-settings/system-prompt": {
@@ -11373,6 +11377,48 @@
         },
         "required": ["id", "name"]
       },
+      "PiiCategory": {
+        "type": "string",
+        "enum": [
+          "person_name",
+          "organization",
+          "location",
+          "email_address",
+          "phone_number",
+          "url_or_ip",
+          "date_time",
+          "financial_account",
+          "government_id",
+          "nationality_religion_politics",
+          "other"
+        ],
+        "description": "PII category of the masked value"
+      },
+      "PiiMaskResponseDto": {
+        "type": "object",
+        "properties": {
+          "token": {
+            "type": "string",
+            "description": "The placeholder token as it appears in message text, e.g. {{pii:PERSON_NAME_1}}",
+            "example": "{{pii:PERSON_NAME_1}}"
+          },
+          "value": {
+            "type": "string",
+            "description": "The original value the token stands in for",
+            "example": "Max Mustermann"
+          },
+          "category": {
+            "description": "PII category of the masked value",
+            "example": "person_name",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PiiCategory"
+              }
+            ]
+          }
+        },
+        "required": ["token", "value", "category"]
+      },
       "GetThreadResponseDto": {
         "type": "object",
         "properties": {
@@ -11449,6 +11495,13 @@
             "items": {
               "$ref": "#/components/schemas/KnowledgeBaseSummaryResponseDto"
             }
+          },
+          "piiMasks": {
+            "description": "PII mask dictionary for anonymous threads — resolves {{pii:...}} tokens in message text to their original values. Empty for non-anonymous threads.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PiiMaskResponseDto"
+            }
           }
         },
         "required": [
@@ -11461,7 +11514,8 @@
           "updatedAt",
           "isAnonymous",
           "isLongChat",
-          "knowledgeBases"
+          "knowledgeBases",
+          "piiMasks"
         ]
       },
       "GetThreadsResponseDtoItem": {
@@ -12696,6 +12750,55 @@
           "updatedAt"
         ]
       },
+      "PiiWhitelistEntryDto": {
+        "type": "object",
+        "properties": {
+          "category": {
+            "description": "PII category exempt from anonymization",
+            "example": "email_address",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PiiCategory"
+              }
+            ]
+          },
+          "pattern": {
+            "type": "string",
+            "description": "Optional regex; when set, only values fully matching it (case-insensitive) are exempt. Null exempts the whole category.",
+            "example": ".*@muster-stadt\\.de",
+            "nullable": true,
+            "maxLength": 200
+          }
+        },
+        "required": ["category", "pattern"]
+      },
+      "PiiWhitelistResponseDto": {
+        "type": "object",
+        "properties": {
+          "entries": {
+            "description": "Current whitelist entries for the org",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PiiWhitelistEntryDto"
+            }
+          }
+        },
+        "required": ["entries"]
+      },
+      "UpdatePiiWhitelistRequestDto": {
+        "type": "object",
+        "properties": {
+          "entries": {
+            "description": "Full replacement whitelist; an empty array removes all entries",
+            "maxItems": 50,
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PiiWhitelistEntryDto"
+            }
+          }
+        },
+        "required": ["entries"]
+      },
       "CreateSkillTemplateDto": {
         "type": "object",
         "properties": {
@@ -13819,6 +13922,35 @@
         },
         "required": ["type", "threadId", "updateType", "title", "timestamp"]
       },
+      "RunMasksResponseDto": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "description": "Response type identifier",
+            "example": "masks",
+            "enum": ["masks"]
+          },
+          "threadId": {
+            "type": "string",
+            "description": "Thread ID the mask dictionary belongs to",
+            "example": "123e4567-e89b-12d3-a456-426614174000"
+          },
+          "masks": {
+            "description": "Full PII mask dictionary of the thread (idempotent to re-apply)",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PiiMaskResponseDto"
+            }
+          },
+          "timestamp": {
+            "type": "string",
+            "description": "Event timestamp",
+            "example": "2024-01-01T12:00:00.000Z"
+          }
+        },
+        "required": ["type", "threadId", "masks", "timestamp"]
+      },
       "TextInput": {
         "type": "object",
         "properties": {
@@ -14006,71 +14138,6 @@
             "minimum": 0
           }
         }
-      },
-      "PiiCategory": {
-        "type": "string",
-        "enum": [
-          "person_name",
-          "organization",
-          "location",
-          "email_address",
-          "phone_number",
-          "url_or_ip",
-          "date_time",
-          "financial_account",
-          "government_id",
-          "nationality_religion_politics"
-        ],
-        "description": "PII category exempt from anonymization"
-      },
-      "PiiWhitelistEntryDto": {
-        "type": "object",
-        "properties": {
-          "category": {
-            "description": "PII category exempt from anonymization",
-            "example": "email_address",
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/PiiCategory"
-              }
-            ]
-          },
-          "pattern": {
-            "type": "string",
-            "description": "Optional regex; when set, only values fully matching it (case-insensitive) are exempt. Null exempts the whole category.",
-            "example": ".*@muster-stadt\\.de",
-            "nullable": true,
-            "maxLength": 200
-          }
-        },
-        "required": ["category", "pattern"]
-      },
-      "PiiWhitelistResponseDto": {
-        "type": "object",
-        "properties": {
-          "entries": {
-            "description": "Current whitelist entries for the org",
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/PiiWhitelistEntryDto"
-            }
-          }
-        },
-        "required": ["entries"]
-      },
-      "UpdatePiiWhitelistRequestDto": {
-        "type": "object",
-        "properties": {
-          "entries": {
-            "description": "Full replacement whitelist; an empty array removes all entries",
-            "maxItems": 50,
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/PiiWhitelistEntryDto"
-            }
-          }
-        },
-        "required": ["entries"]
       },
       "UserSystemPromptResponseDto": {
         "type": "object",


### PR DESCRIPTION
- execute-run and tool-result-collector anonymize via the thread mask
  dictionary; mask updates are yielded as stream items before the
  message containing the tokens
- new 'masks' SSE event (RunMasksResponseDto) on the run stream
- GET /threads/:id returns the piiMasks dictionary for anonymous threads
- system prompt gains an anonymized_data section in anonymous mode so
  the model reuses pii tokens verbatim
- title generation stays on the legacy path (no dictionary in the
  sidebar); frontend API client regenerated

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes anonymization scope, run SSE contract, and PII handling on the critical chat path; clients must handle `masks` events before messages.
> 
> **Overview**
> Anonymous runs now use a **per-thread PII mask dictionary** instead of org-only anonymization for user messages and PII-returning tool results. `ExecuteRunUseCase` and `ToolResultCollectorService` call `AnonymizeTextForThreadUseCase` and emit **`RunPiiMasksUpdate` stream items before** the related message so clients can resolve `{{pii:...}}` tokens immediately.
> 
> The run **SSE stream** adds a **`masks`** event (`RunMasksResponseDto`) with the full thread dictionary; **`GET /threads/:id`** includes **`piiMasks`** for anonymous threads. The system prompt gains an **`<anonymized_data>`** section when `isAnonymous` is true so the model reuses placeholders verbatim. **Title generation** still anonymizes via the org use case (unchanged path).
> 
> Backend wires **`ThreadPiiMasksModule`** into runs/threads; the **frontend OpenAPI client** is regenerated for the new types and stream union.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb766eb9988d7c5f9084f997774ee8c26d6fbcc0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->