### PR TITLE
feat(anonymization): resolve pii mask tokens to original values in chat (AYC-118)

### DIFF
--- a/ayunis-core-frontend/src/pages/admin-settings/anonymization-settings/model/types.ts
+++ b/ayunis-core-frontend/src/pages/admin-settings/anonymization-settings/model/types.ts
@@ -12,6 +12,7 @@ export const PII_CATEGORIES: PiiCategory[] = [
   PiiCategory.financial_account,
   PiiCategory.government_id,
   PiiCategory.nationality_religion_politics,
+  PiiCategory.other,
 ];
 
 export interface CategoryRowState {

--- a/ayunis-core-frontend/src/pages/chat/api/useMessageSend.ts
+++ b/ayunis-core-frontend/src/pages/chat/api/useMessageSend.ts
@@ -3,6 +3,7 @@ import type {
   RunMessageResponseDto,
   RunErrorResponseDto,
   RunThreadResponseDto,
+  RunMasksResponseDto,
 } from '@/shared/api';
 import { showError } from '@/shared/lib/toast';
 import { useTranslation } from 'react-i18next';
@@ -37,6 +38,7 @@ interface UseMessageSendParams {
   onMessageEvent?: (data: RunMessageResponseDto) => void;
   onSessionEvent?: (data: RunSessionResponseDto) => void;
   onThreadEvent?: (data: RunThreadResponseDto) => void;
+  onMasksEvent?: (data: RunMasksResponseDto) => void;
   onErrorEvent?: (data: RunErrorResponseDto) => void;
   onError?: (error: Error) => void;
   onComplete?: () => void;
@@ -150,6 +152,9 @@ export function useMessageSend(params: UseMessageSendParams) {
                 break;
               case 'thread':
                 params.onThreadEvent?.(data as RunThreadResponseDto);
+                break;
+              case 'masks':
+                params.onMasksEvent?.(data as RunMasksResponseDto);
                 break;
               case 'error':
                 params.onErrorEvent?.(data as RunErrorResponseDto);

--- a/ayunis-core-frontend/src/pages/chat/ui/ChatPage.tsx
+++ b/ayunis-core-frontend/src/pages/chat/ui/ChatPage.tsx
@@ -18,10 +18,13 @@ import { useDeleteThread } from '@/features/useDeleteThread';
 import { useNavigate } from '@tanstack/react-router';
 import { useTranslation } from 'react-i18next';
 import type {
+  PiiMaskResponseDto,
+  RunMasksResponseDto,
   RunMessageResponseDtoMessage,
   RunSessionResponseDto,
   RunThreadResponseDto,
 } from '@/shared/api';
+import { PiiMaskProvider } from '@/widgets/markdown';
 import { SourceResponseDtoStatus } from '@/shared/api/generated/ayunisCoreAPI.schemas';
 import { useRunErrorHandler } from '../hooks/useRunErrorHandler';
 import { useLetterheadChange } from '../hooks/useLetterheadChange';
@@ -108,6 +111,9 @@ export default function ChatPage({
     thread.title,
   );
   const [messages, setMessages] = useState<Message[]>(thread.messages);
+  const [piiMasks, setPiiMasks] = useState<PiiMaskResponseDto[]>(
+    thread.piiMasks,
+  );
 
   // Reconcile local message/title state whenever the thread reference changes
   // (navigating to another thread, or a refetch returning fresh server data).
@@ -118,6 +124,7 @@ export default function ChatPage({
     setReconciledThread(thread);
     setMessages(thread.messages);
     setThreadTitle(thread.title);
+    setPiiMasks(thread.piiMasks);
   }
   const [pendingSubmission, setPendingSubmission] = useState<string | null>(
     null,
@@ -187,6 +194,18 @@ export default function ChatPage({
     });
   }, []);
 
+  const handleMasks = useCallback((data: RunMasksResponseDto) => {
+    // Events carry the thread's full dictionary — replace-by-token merge is
+    // idempotent and keeps any entries from earlier events.
+    setPiiMasks((prev) => {
+      const byToken = new Map(prev.map((mask) => [mask.token, mask]));
+      for (const mask of data.masks) {
+        byToken.set(mask.token, mask);
+      }
+      return [...byToken.values()];
+    });
+  }, []);
+
   const handleFileUpload = (files: File[]) =>
     files.forEach((file) => createFileSource({ file }));
 
@@ -221,6 +240,7 @@ export default function ChatPage({
     onErrorEvent: handleError,
     onSessionEvent: handleSession,
     onThreadEvent: handleThread,
+    onMasksEvent: handleMasks,
     onError: (error) => {
       console.error('Error in useMessageSend:', error);
       showError(t('chat.errorSendMessage'));
@@ -423,33 +443,35 @@ export default function ChatPage({
 
   return (
     <AppLayout>
-      <ChatInterfaceLayout
-        chatHeader={chatHeader}
-        chatContent={chatContent}
-        chatInput={chatInput}
-        sidePanel={
-          openArtifact ? (
-            <Suspense fallback={null}>
-              {openArtifact.type === 'diagram' ? (
-                <LazyDiagramViewer
-                  artifact={openArtifact}
-                  onClose={handleCloseArtifact}
-                />
-              ) : (
-                <LazyArtifactEditor
-                  artifact={openArtifact}
-                  onSave={handleSaveArtifact}
-                  onRevert={handleRevertArtifact}
-                  onExport={handleExportArtifact}
-                  onClose={handleCloseArtifact}
-                  onLetterheadChange={handleLetterheadChange}
-                  isExporting={isExporting}
-                />
-              )}
-            </Suspense>
-          ) : undefined
-        }
-      />
+      <PiiMaskProvider masks={piiMasks}>
+        <ChatInterfaceLayout
+          chatHeader={chatHeader}
+          chatContent={chatContent}
+          chatInput={chatInput}
+          sidePanel={
+            openArtifact ? (
+              <Suspense fallback={null}>
+                {openArtifact.type === 'diagram' ? (
+                  <LazyDiagramViewer
+                    artifact={openArtifact}
+                    onClose={handleCloseArtifact}
+                  />
+                ) : (
+                  <LazyArtifactEditor
+                    artifact={openArtifact}
+                    onSave={handleSaveArtifact}
+                    onRevert={handleRevertArtifact}
+                    onExport={handleExportArtifact}
+                    onClose={handleCloseArtifact}
+                    onLetterheadChange={handleLetterheadChange}
+                    isExporting={isExporting}
+                  />
+                )}
+              </Suspense>
+            ) : undefined
+          }
+        />
+      </PiiMaskProvider>
       <RenameThreadDialog
         open={renameDialogOpen}
         onOpenChange={setRenameDialogOpen}

--- a/ayunis-core-frontend/src/pages/chat/ui/agent-run-timeline/ui/AgentRunTimelineRow.tsx
+++ b/ayunis-core-frontend/src/pages/chat/ui/agent-run-timeline/ui/AgentRunTimelineRow.tsx
@@ -15,6 +15,7 @@ import {
   CollapsibleTrigger,
 } from '@/shared/ui/shadcn/collapsible';
 import { Badge } from '@/shared/ui/shadcn/badge';
+import { PiiText } from '@/widgets/markdown';
 import type { TimelineStep, StepStatus } from '../model/types';
 import { getToolActionLabel } from '../lib/get-tool-action-label';
 
@@ -121,7 +122,7 @@ function getStepView(
       details: (
         <ScrollArea className="max-h-40">
           <div className="text-xs text-muted-foreground whitespace-pre-wrap">
-            {step.transcript}
+            <PiiText>{step.transcript}</PiiText>
           </div>
         </ScrollArea>
       ),
@@ -171,7 +172,7 @@ function getStepView(
           >
             <ScrollArea className="max-h-32 w-full">
               <span className="text-xs text-muted-foreground whitespace-pre-wrap">
-                {step.result}
+                <PiiText>{step.result ?? ''}</PiiText>
               </span>
             </ScrollArea>
           </Badge>

--- a/ayunis-core-frontend/src/shared/locales/de/admin-settings-anonymization.json
+++ b/ayunis-core-frontend/src/shared/locales/de/admin-settings-anonymization.json
@@ -55,6 +55,10 @@
       "nationality_religion_politics": {
         "label": "Nationalität, Religion & Politik",
         "description": "Hinweise auf Nationalität, religiöse oder politische Zugehörigkeit"
+      },
+      "other": {
+        "label": "Sonstige / nicht zugeordnet",
+        "description": "Von der Erkennung gefundene personenbezogene Daten ohne bekannte Kategorie"
       }
     }
   }

--- a/ayunis-core-frontend/src/shared/locales/de/chat.json
+++ b/ayunis-core-frontend/src/shared/locales/de/chat.json
@@ -172,7 +172,23 @@
     },
     "longChatWarningTitle": "Konversation zu lang",
     "longChatWarningDescription": "Für bessere Ergebnisse sollten Sie einen neuen Chat starten.",
-    "inputDisclaimer": "Eingaben werden nicht für Training verwendet. KI kann Fehler machen—Antworten prüfen."
+    "inputDisclaimer": "Eingaben werden nicht für Training verwendet. KI kann Fehler machen—Antworten prüfen.",
+    "piiMask": {
+      "tooltip": "{{category}} — vor dem Senden an das KI-Modell anonymisiert",
+      "categories": {
+        "person_name": "Personenname",
+        "organization": "Organisation",
+        "location": "Ort oder Adresse",
+        "email_address": "E-Mail-Adresse",
+        "phone_number": "Telefonnummer",
+        "url_or_ip": "URL oder IP-Adresse",
+        "date_time": "Datum oder Uhrzeit",
+        "financial_account": "Finanzkonto",
+        "government_id": "Amtliche Kennung",
+        "nationality_religion_politics": "Nationalität, Religion oder Politik",
+        "other": "Personenbezogene Daten"
+      }
+    }
   },
   "newChat": {
     "newChat": "Neuer Chat",

--- a/ayunis-core-frontend/src/shared/locales/en/admin-settings-anonymization.json
+++ b/ayunis-core-frontend/src/shared/locales/en/admin-settings-anonymization.json
@@ -55,6 +55,10 @@
       "nationality_religion_politics": {
         "label": "Nationality, religion & politics",
         "description": "References to nationality, religious, or political affiliation"
+      },
+      "other": {
+        "label": "Other / unrecognized",
+        "description": "Personal data detected by the engine that does not fit a known category"
       }
     }
   }

--- a/ayunis-core-frontend/src/shared/locales/en/chat.json
+++ b/ayunis-core-frontend/src/shared/locales/en/chat.json
@@ -172,7 +172,23 @@
     },
     "longChatWarningTitle": "Conversation too long",
     "longChatWarningDescription": "For better results, consider starting a new chat.",
-    "inputDisclaimer": "Input not used for training. AI can make mistakes—verify answers."
+    "inputDisclaimer": "Input not used for training. AI can make mistakes—verify answers.",
+    "piiMask": {
+      "tooltip": "{{category}} — anonymized before being sent to the AI model",
+      "categories": {
+        "person_name": "Person name",
+        "organization": "Organization",
+        "location": "Location or address",
+        "email_address": "Email address",
+        "phone_number": "Phone number",
+        "url_or_ip": "URL or IP address",
+        "date_time": "Date or time",
+        "financial_account": "Financial account",
+        "government_id": "Government ID",
+        "nationality_religion_politics": "Nationality, religion, or politics",
+        "other": "Personal data"
+      }
+    }
   },
   "newChat": {
     "newChat": "New Chat",

--- a/ayunis-core-frontend/src/widgets/markdown/index.ts
+++ b/ayunis-core-frontend/src/widgets/markdown/index.ts
@@ -1,2 +1,5 @@
 export { default as Markdown } from './ui/Markdown';
 export { default as CodeBlock } from './ui/Codeblock';
+export { default as PiiText } from './ui/PiiText';
+export { PiiMaskProvider, usePiiMasks } from './model/pii-mask-context';
+export type { PiiMaskEntry } from './model/pii-mask-context';

--- a/ayunis-core-frontend/src/widgets/markdown/lib/pii-token.test.ts
+++ b/ayunis-core-frontend/src/widgets/markdown/lib/pii-token.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import { splitPiiTokens, containsPiiToken } from './pii-token';
+
+describe('splitPiiTokens', () => {
+  it('returns a single text part when there are no tokens', () => {
+    expect(splitPiiTokens('Hallo Welt')).toEqual([
+      { kind: 'text', text: 'Hallo Welt' },
+    ]);
+  });
+
+  it('splits a token in the middle of text', () => {
+    expect(splitPiiTokens('Schreib an {{pii:PERSON_NAME_1}} heute')).toEqual([
+      { kind: 'text', text: 'Schreib an ' },
+      { kind: 'token', token: '{{pii:PERSON_NAME_1}}' },
+      { kind: 'text', text: ' heute' },
+    ]);
+  });
+
+  it('handles tokens at the start and end of text', () => {
+    expect(
+      splitPiiTokens('{{pii:PERSON_NAME_1}} und {{pii:LOCATION_2}}'),
+    ).toEqual([
+      { kind: 'token', token: '{{pii:PERSON_NAME_1}}' },
+      { kind: 'text', text: ' und ' },
+      { kind: 'token', token: '{{pii:LOCATION_2}}' },
+    ]);
+  });
+
+  it('handles adjacent tokens without separator', () => {
+    expect(splitPiiTokens('{{pii:OTHER_1}}{{pii:OTHER_2}}')).toEqual([
+      { kind: 'token', token: '{{pii:OTHER_1}}' },
+      { kind: 'token', token: '{{pii:OTHER_2}}' },
+    ]);
+  });
+
+  it('does not match legacy bracket placeholders', () => {
+    expect(splitPiiTokens('Hallo [PERSON], wie geht es?')).toEqual([
+      { kind: 'text', text: 'Hallo [PERSON], wie geht es?' },
+    ]);
+  });
+
+  it('does not match malformed tokens', () => {
+    const malformed = '{{pii:}} {{pii:lowercase_1}} {{pii:PERSON_NAME}}';
+    expect(splitPiiTokens(malformed)).toEqual([
+      { kind: 'text', text: malformed },
+    ]);
+  });
+});
+
+describe('containsPiiToken', () => {
+  it('detects tokens regardless of prior calls', () => {
+    expect(containsPiiToken('a {{pii:PERSON_NAME_1}} b')).toBe(true);
+    expect(containsPiiToken('a {{pii:PERSON_NAME_1}} b')).toBe(true);
+    expect(containsPiiToken('plain text')).toBe(false);
+  });
+});

--- a/ayunis-core-frontend/src/widgets/markdown/lib/pii-token.ts
+++ b/ayunis-core-frontend/src/widgets/markdown/lib/pii-token.ts
@@ -1,0 +1,34 @@
+/**
+ * Matches anonymization placeholder tokens like `{{pii:PERSON_NAME_1}}`.
+ * The full match (including braces) is the dictionary key delivered by the
+ * backend (`PiiMaskResponseDto.token`).
+ */
+export const PII_TOKEN_REGEX = /\{\{pii:[A-Z][A-Z0-9_]*_\d+\}\}/g;
+
+export type PiiTextPart =
+  | { kind: 'text'; text: string }
+  | { kind: 'token'; token: string };
+
+/** Splits text into plain-text parts and `{{pii:...}}` token parts. */
+export function splitPiiTokens(text: string): PiiTextPart[] {
+  const parts: PiiTextPart[] = [];
+  let lastIndex = 0;
+  for (const match of text.matchAll(PII_TOKEN_REGEX)) {
+    if (match.index > lastIndex) {
+      parts.push({ kind: 'text', text: text.slice(lastIndex, match.index) });
+    }
+    parts.push({ kind: 'token', token: match[0] });
+    lastIndex = match.index + match[0].length;
+  }
+  if (lastIndex < text.length) {
+    parts.push({ kind: 'text', text: text.slice(lastIndex) });
+  }
+  return parts;
+}
+
+/** True when the text contains at least one `{{pii:...}}` token. */
+export function containsPiiToken(text: string): boolean {
+  // Reset lastIndex since the shared regex is global.
+  PII_TOKEN_REGEX.lastIndex = 0;
+  return PII_TOKEN_REGEX.test(text);
+}

--- a/ayunis-core-frontend/src/widgets/markdown/lib/rehype-pii-masks.test.ts
+++ b/ayunis-core-frontend/src/widgets/markdown/lib/rehype-pii-masks.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest';
+import { rehypePiiMasks } from './rehype-pii-masks';
+
+interface TestNode {
+  type: string;
+  tagName?: string;
+  value?: string;
+  properties?: Record<string, unknown>;
+  children?: TestNode[];
+}
+
+function text(value: string): TestNode {
+  return { type: 'text', value };
+}
+
+function element(tagName: string, children: TestNode[]): TestNode {
+  return { type: 'element', tagName, properties: {}, children };
+}
+
+function root(children: TestNode[]): TestNode {
+  return { type: 'root', children };
+}
+
+function run(tree: TestNode): TestNode {
+  rehypePiiMasks()(tree);
+  return tree;
+}
+
+describe('rehypePiiMasks', () => {
+  it('wraps tokens in paragraph text with marked spans', () => {
+    const tree = root([
+      element('p', [text('Hallo {{pii:PERSON_NAME_1}}, willkommen')]),
+    ]);
+
+    run(tree);
+
+    const p = tree.children![0];
+    expect(p.children).toEqual([
+      { type: 'text', value: 'Hallo ' },
+      {
+        type: 'element',
+        tagName: 'span',
+        properties: { 'data-pii-token': '{{pii:PERSON_NAME_1}}' },
+        children: [{ type: 'text', value: '{{pii:PERSON_NAME_1}}' }],
+      },
+      { type: 'text', value: ', willkommen' },
+    ]);
+  });
+
+  it('processes tokens nested inside bold and list items', () => {
+    const tree = root([
+      element('ul', [
+        element('li', [element('strong', [text('{{pii:EMAIL_ADDRESS_2}}')])]),
+      ]),
+    ]);
+
+    run(tree);
+
+    const strong = tree.children![0].children![0].children![0];
+    expect(strong.children).toHaveLength(1);
+    expect(strong.children![0]).toMatchObject({
+      tagName: 'span',
+      properties: { 'data-pii-token': '{{pii:EMAIL_ADDRESS_2}}' },
+    });
+  });
+
+  it('leaves text inside code and pre untouched', () => {
+    const codeText = 'const a = "{{pii:PERSON_NAME_1}}";';
+    const tree = root([
+      element('pre', [element('code', [text(codeText)])]),
+      element('code', [text('{{pii:LOCATION_1}}')]),
+    ]);
+
+    run(tree);
+
+    expect(tree.children![0].children![0].children).toEqual([
+      { type: 'text', value: codeText },
+    ]);
+    expect(tree.children![1].children).toEqual([
+      { type: 'text', value: '{{pii:LOCATION_1}}' },
+    ]);
+  });
+
+  it('leaves token-free trees unchanged', () => {
+    const tree = root([element('p', [text('Nur normaler Text')])]);
+
+    run(tree);
+
+    expect(tree.children![0].children).toEqual([
+      { type: 'text', value: 'Nur normaler Text' },
+    ]);
+  });
+});

--- a/ayunis-core-frontend/src/widgets/markdown/lib/rehype-pii-masks.ts
+++ b/ayunis-core-frontend/src/widgets/markdown/lib/rehype-pii-masks.ts
@@ -1,0 +1,82 @@
+import { splitPiiTokens } from './pii-token';
+
+// Minimal structural hast types — kept local so we don't depend on the
+// 'hast' package directly (it's only a transitive dep of react-markdown).
+interface HastText {
+  type: 'text';
+  value: string;
+}
+
+interface HastElement {
+  type: 'element';
+  tagName: string;
+  properties?: Record<string, unknown>;
+  children: HastNode[];
+}
+
+interface HastParent {
+  type: string;
+  children?: HastNode[];
+}
+
+type HastNode = HastText | HastElement | HastParent;
+
+/**
+ * Rehype plugin that wraps `{{pii:...}}` tokens in text nodes with
+ * `<span data-pii-token="...">` elements so the Markdown component can swap
+ * them for resolved mask values. Subtrees of `code`/`pre` are skipped — their
+ * custom renderers stringify children, and a span child would render empty.
+ *
+ * Dictionary-independent by design: mask updates don't require a re-parse.
+ */
+export function rehypePiiMasks() {
+  return (tree: HastParent): void => {
+    visit(tree);
+  };
+}
+
+function visit(node: HastNode): void {
+  if (isElement(node) && (node.tagName === 'code' || node.tagName === 'pre')) {
+    return;
+  }
+  const children = (node as HastParent).children;
+  if (!children) return;
+
+  for (let i = children.length - 1; i >= 0; i--) {
+    const child = children[i];
+    if (isText(child)) {
+      const replacement = splitTextNode(child);
+      if (replacement) {
+        children.splice(i, 1, ...replacement);
+      }
+    } else {
+      visit(child);
+    }
+  }
+}
+
+function splitTextNode(node: HastText): HastNode[] | null {
+  const parts = splitPiiTokens(node.value);
+  if (parts.length === 1 && parts[0].kind === 'text') {
+    return null;
+  }
+  return parts.map((part): HastNode => {
+    if (part.kind === 'text') {
+      return { type: 'text', value: part.text };
+    }
+    return {
+      type: 'element',
+      tagName: 'span',
+      properties: { 'data-pii-token': part.token },
+      children: [{ type: 'text', value: part.token }],
+    };
+  });
+}
+
+function isText(node: HastNode): node is HastText {
+  return node.type === 'text';
+}
+
+function isElement(node: HastNode): node is HastElement {
+  return node.type === 'element';
+}

--- a/ayunis-core-frontend/src/widgets/markdown/model/pii-mask-context.tsx
+++ b/ayunis-core-frontend/src/widgets/markdown/model/pii-mask-context.tsx
@@ -1,0 +1,41 @@
+import { createContext, useContext, useMemo } from 'react';
+import type { ReactNode } from 'react';
+
+export interface PiiMaskEntry {
+  /** Full token string, e.g. `{{pii:PERSON_NAME_1}}`. */
+  token: string;
+  /** The original value the token stands in for. */
+  value: string;
+  /** PII category enum value, e.g. `person_name`. */
+  category: string;
+}
+
+const EMPTY_MASKS: ReadonlyMap<string, PiiMaskEntry> = new Map();
+
+const PiiMaskContext =
+  createContext<ReadonlyMap<string, PiiMaskEntry>>(EMPTY_MASKS);
+
+interface PiiMaskProviderProps {
+  readonly masks: readonly PiiMaskEntry[];
+  readonly children: ReactNode;
+}
+
+/**
+ * Provides the thread's PII mask dictionary (token → entry) to markdown and
+ * plain-text renderers. Without a provider the dictionary is empty and
+ * tokens render as literal text.
+ */
+export function PiiMaskProvider({ masks, children }: PiiMaskProviderProps) {
+  const map = useMemo(
+    () => new Map(masks.map((mask) => [mask.token, mask])),
+    [masks],
+  );
+  return (
+    <PiiMaskContext.Provider value={map}>{children}</PiiMaskContext.Provider>
+  );
+}
+
+// eslint-disable-next-line react-refresh/only-export-components -- context hook belongs with its provider (repo convention, see shared/ui/shadcn)
+export function usePiiMasks(): ReadonlyMap<string, PiiMaskEntry> {
+  return useContext(PiiMaskContext);
+}

--- a/ayunis-core-frontend/src/widgets/markdown/ui/Markdown.pii.test.tsx
+++ b/ayunis-core-frontend/src/widgets/markdown/ui/Markdown.pii.test.tsx
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import Markdown from './Markdown';
+import { PiiMaskProvider } from '../model/pii-mask-context';
+import type { PiiMaskEntry } from '../model/pii-mask-context';
+
+const masks: PiiMaskEntry[] = [
+  {
+    token: '{{pii:PERSON_NAME_1}}',
+    value: 'Max Mustermann',
+    category: 'person_name',
+  },
+];
+
+describe('Markdown PII mask rendering', () => {
+  it('renders the original value highlighted for known tokens', () => {
+    render(
+      <PiiMaskProvider masks={masks}>
+        <Markdown>{'Schreib an {{pii:PERSON_NAME_1}} bitte'}</Markdown>
+      </PiiMaskProvider>,
+    );
+
+    const value = screen.getByText('Max Mustermann');
+    expect(value).toBeTruthy();
+    expect(value.className).toContain('bg-brand/15');
+    expect(screen.queryByText(/\{\{pii:/)).toBeNull();
+  });
+
+  it('resolves tokens nested in markdown formatting', () => {
+    render(
+      <PiiMaskProvider masks={masks}>
+        <Markdown>{'**Wichtig: {{pii:PERSON_NAME_1}}**'}</Markdown>
+      </PiiMaskProvider>,
+    );
+
+    expect(screen.getByText('Max Mustermann')).toBeTruthy();
+  });
+
+  it('renders unknown tokens as literal text', () => {
+    render(
+      <PiiMaskProvider masks={masks}>
+        <Markdown>{'Gruß an {{pii:LOCATION_9}}'}</Markdown>
+      </PiiMaskProvider>,
+    );
+
+    expect(screen.getByText('{{pii:LOCATION_9}}')).toBeTruthy();
+  });
+
+  it('renders tokens without a provider as literal text', () => {
+    render(<Markdown>{'Hallo {{pii:PERSON_NAME_1}}'}</Markdown>);
+
+    expect(screen.getByText('{{pii:PERSON_NAME_1}}')).toBeTruthy();
+  });
+
+  it('leaves tokens inside inline code untouched', () => {
+    render(
+      <PiiMaskProvider masks={masks}>
+        <Markdown>{'Nutze `{{pii:PERSON_NAME_1}}` als Platzhalter'}</Markdown>
+      </PiiMaskProvider>,
+    );
+
+    expect(screen.getByText('{{pii:PERSON_NAME_1}}')).toBeTruthy();
+    expect(screen.queryByText('Max Mustermann')).toBeNull();
+  });
+});

--- a/ayunis-core-frontend/src/widgets/markdown/ui/Markdown.tsx
+++ b/ayunis-core-frontend/src/widgets/markdown/ui/Markdown.tsx
@@ -3,10 +3,22 @@ import type { ReactNode } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import CodeBlock from './Codeblock';
+import PiiMaskInline from './PiiMaskInline';
+import { rehypePiiMasks } from '../lib/rehype-pii-masks';
+
+// Module constants so react-markdown doesn't re-parse on every render.
+const REMARK_PLUGINS = [remarkGfm];
+const REHYPE_PLUGINS = [rehypePiiMasks];
 
 interface MarkdownProps {
   children: string;
   className?: string;
+}
+
+interface SpanComponentProps {
+  children?: ReactNode;
+  // react-markdown delivers hast data attributes in kebab-case.
+  'data-pii-token'?: string;
 }
 
 interface CodeComponentProps {
@@ -30,8 +42,16 @@ function Markdown({ children, className = '' }: Readonly<MarkdownProps>) {
       className={`text leading-relaxed prose prose-sm max-w-none dark:prose-invert ${className}`}
     >
       <ReactMarkdown
-        remarkPlugins={[remarkGfm]}
+        remarkPlugins={REMARK_PLUGINS}
+        rehypePlugins={REHYPE_PLUGINS}
         components={{
+          span: (props: SpanComponentProps) => {
+            const token = props['data-pii-token'];
+            if (typeof token === 'string') {
+              return <PiiMaskInline token={token} />;
+            }
+            return <span>{props.children}</span>;
+          },
           code: ({ inline, className, children }: CodeComponentProps) => {
             // Convert children to string safely
             const childrenStr =

--- a/ayunis-core-frontend/src/widgets/markdown/ui/PiiMaskInline.tsx
+++ b/ayunis-core-frontend/src/widgets/markdown/ui/PiiMaskInline.tsx
@@ -1,0 +1,42 @@
+import { useTranslation } from 'react-i18next';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/shared/ui/shadcn/tooltip';
+import { usePiiMasks } from '../model/pii-mask-context';
+
+interface PiiMaskInlineProps {
+  readonly token: string;
+}
+
+/**
+ * Renders a `{{pii:...}}` token: when the thread's mask dictionary knows it,
+ * the original value is shown highlighted with an explanatory tooltip;
+ * unknown tokens fall back to the literal token text.
+ */
+export default function PiiMaskInline({ token }: PiiMaskInlineProps) {
+  const { t } = useTranslation('chat');
+  const entry = usePiiMasks().get(token);
+
+  if (!entry) {
+    return <span>{token}</span>;
+  }
+
+  const categoryLabel = t(`chat.piiMask.categories.${entry.category}`, {
+    defaultValue: t('chat.piiMask.categories.other'),
+  });
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span className="bg-brand/15 text-brand px-1 py-0.5 rounded font-medium">
+          {entry.value}
+        </span>
+      </TooltipTrigger>
+      <TooltipContent>
+        <p>{t('chat.piiMask.tooltip', { category: categoryLabel })}</p>
+      </TooltipContent>
+    </Tooltip>
+  );
+}

--- a/ayunis-core-frontend/src/widgets/markdown/ui/PiiText.tsx
+++ b/ayunis-core-frontend/src/widgets/markdown/ui/PiiText.tsx
@@ -1,0 +1,26 @@
+import { Fragment } from 'react';
+import { splitPiiTokens } from '../lib/pii-token';
+import PiiMaskInline from './PiiMaskInline';
+
+interface PiiTextProps {
+  readonly children: string;
+}
+
+/**
+ * Plain-text counterpart to the markdown pipeline: resolves `{{pii:...}}`
+ * tokens inside a raw string (tool results, thinking transcripts).
+ */
+export default function PiiText({ children }: PiiTextProps) {
+  const parts = splitPiiTokens(children);
+  return (
+    <>
+      {parts.map((part, index) =>
+        part.kind === 'text' ? (
+          <Fragment key={index}>{part.text}</Fragment>
+        ) : (
+          <PiiMaskInline key={index} token={part.token} />
+        ),
+      )}
+    </>
+  );
+}


### PR DESCRIPTION
- rehype plugin marks {{pii:...}} tokens in markdown (skipping code
  blocks); PiiMaskInline renders the original value highlighted with an
  explanatory tooltip; PiiText covers plain-text surfaces (thinking
  transcript, tool results)
- PiiMaskProvider at chat-page level seeds the dictionary from the
  thread GET response and merges 'masks' SSE events during streaming
- unknown tokens and legacy [PERSON] placeholders render as-is
- admin whitelist UI gains the new 'Other / unrecognized' category

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Shows original personal data in the browser when masks are known—intended for anonymous-mode UX but privacy-sensitive; changes are display-layer only with tests and no change to what is sent to the model.
> 
> **Overview**
> Chat now **resolves `{{pii:...}}` placeholders** to the real values users typed, with highlighting and category tooltips, instead of showing raw mask tokens.
> 
> **Mask dictionary wiring:** `ChatPage` keeps `piiMasks` from the thread payload, reconciles on refetch/navigation, merges **`masks` SSE events** during streaming via `useMessageSend`, and wraps the chat UI in **`PiiMaskProvider`**.
> 
> **Rendering pipeline:** A **`rehypePiiMasks`** plugin tags tokens in markdown (skipping `code`/`pre`); **`PiiMaskInline`** looks up tokens in context; **`PiiText`** does the same for plain strings. Agent timeline **thinking transcripts** and **tool results** use `PiiText`.
> 
> **Admin & i18n:** Anonymization whitelist gains **`PiiCategory.other`** with EN/DE copy; chat locales add **`piiMask`** tooltip/category strings.
> 
> Unit tests cover token splitting, rehype behavior, and markdown resolution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dee2836c7efa17f65caee9020fdcbd00ddf77be2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->