### PR TITLE
wip(chat-settings): add org system prompt entity, use cases, and persistence (AYC-219)

### DIFF
--- a/ayunis-core-backend/src/domain/chat-settings/application/ports/org-system-prompts.repository.ts
+++ b/ayunis-core-backend/src/domain/chat-settings/application/ports/org-system-prompts.repository.ts
@@ -1,0 +1,8 @@
+import type { UUID } from 'crypto';
+import type { OrgSystemPrompt } from '../../domain/org-system-prompt.entity';
+
+export abstract class OrgSystemPromptsRepository {
+  abstract findByOrgId(orgId: UUID): Promise<OrgSystemPrompt | null>;
+  abstract upsert(orgSystemPrompt: OrgSystemPrompt): Promise<OrgSystemPrompt>;
+  abstract deleteByOrgId(orgId: UUID): Promise<void>;
+}

--- a/ayunis-core-backend/src/domain/chat-settings/application/use-cases/delete-org-system-prompt/delete-org-system-prompt.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/chat-settings/application/use-cases/delete-org-system-prompt/delete-org-system-prompt.use-case.spec.ts
@@ -1,0 +1,44 @@
+import { DeleteOrgSystemPromptUseCase } from './delete-org-system-prompt.use-case';
+import type { OrgSystemPromptsRepository } from '../../ports/org-system-prompts.repository';
+import { randomUUID } from 'crypto';
+import type { ContextService } from 'src/common/context/services/context.service';
+
+describe('DeleteOrgSystemPromptUseCase', () => {
+  let useCase: DeleteOrgSystemPromptUseCase;
+  let repository: jest.Mocked<OrgSystemPromptsRepository>;
+  let contextService: jest.Mocked<Pick<ContextService, 'get'>>;
+
+  const orgId = randomUUID();
+
+  beforeEach(() => {
+    repository = {
+      findByOrgId: jest.fn(),
+      upsert: jest.fn(),
+      deleteByOrgId: jest.fn(),
+    };
+
+    contextService = {
+      get: jest.fn().mockReturnValue(orgId),
+    };
+
+    useCase = new DeleteOrgSystemPromptUseCase(
+      repository,
+      contextService as unknown as ContextService,
+    );
+  });
+
+  it('should call deleteByOrgId with orgId from context', async () => {
+    repository.deleteByOrgId.mockResolvedValue();
+
+    await useCase.execute();
+
+    expect(repository.deleteByOrgId).toHaveBeenCalledWith(orgId);
+    expect(contextService.get).toHaveBeenCalledWith('orgId');
+  });
+
+  it('should not throw when no system prompt exists for the org', async () => {
+    repository.deleteByOrgId.mockResolvedValue();
+
+    await expect(useCase.execute()).resolves.not.toThrow();
+  });
+});

--- a/ayunis-core-backend/src/domain/chat-settings/application/use-cases/delete-org-system-prompt/delete-org-system-prompt.use-case.ts
+++ b/ayunis-core-backend/src/domain/chat-settings/application/use-cases/delete-org-system-prompt/delete-org-system-prompt.use-case.ts
@@ -1,0 +1,34 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { OrgSystemPromptsRepository } from '../../ports/org-system-prompts.repository';
+import { ContextService } from 'src/common/context/services/context.service';
+import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
+import { UnexpectedChatSettingsError } from '../../chat-settings.errors';
+import { ApplicationError } from 'src/common/errors/base.error';
+
+@Injectable()
+export class DeleteOrgSystemPromptUseCase {
+  private readonly logger = new Logger(DeleteOrgSystemPromptUseCase.name);
+
+  constructor(
+    private readonly orgSystemPromptsRepository: OrgSystemPromptsRepository,
+    private readonly contextService: ContextService,
+  ) {}
+
+  async execute(): Promise<void> {
+    const orgId = this.contextService.get('orgId');
+    if (!orgId) {
+      throw new UnauthorizedAccessError();
+    }
+    this.logger.log('execute', { orgId });
+
+    try {
+      await this.orgSystemPromptsRepository.deleteByOrgId(orgId);
+
+      this.logger.debug('Org system prompt deleted', { orgId });
+    } catch (error) {
+      if (error instanceof ApplicationError) throw error;
+      this.logger.error('Failed to delete org system prompt', error);
+      throw new UnexpectedChatSettingsError(error as Error);
+    }
+  }
+}

--- a/ayunis-core-backend/src/domain/chat-settings/application/use-cases/get-org-system-prompt/get-org-system-prompt.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/chat-settings/application/use-cases/get-org-system-prompt/get-org-system-prompt.use-case.spec.ts
@@ -1,0 +1,68 @@
+import { GetOrgSystemPromptUseCase } from './get-org-system-prompt.use-case';
+import type { OrgSystemPromptsRepository } from '../../ports/org-system-prompts.repository';
+import { OrgSystemPrompt } from '../../../domain/org-system-prompt.entity';
+import { randomUUID } from 'crypto';
+import type { ContextService } from 'src/common/context/services/context.service';
+import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
+
+describe('GetOrgSystemPromptUseCase', () => {
+  let useCase: GetOrgSystemPromptUseCase;
+  let repository: jest.Mocked<OrgSystemPromptsRepository>;
+  let contextService: jest.Mocked<Pick<ContextService, 'get'>>;
+
+  const orgId = randomUUID();
+
+  beforeEach(() => {
+    repository = {
+      findByOrgId: jest.fn(),
+      upsert: jest.fn(),
+      deleteByOrgId: jest.fn(),
+    };
+
+    contextService = {
+      get: jest.fn().mockReturnValue(orgId),
+    };
+
+    useCase = new GetOrgSystemPromptUseCase(
+      repository,
+      contextService as unknown as ContextService,
+    );
+  });
+
+  it('should return the org system prompt when it exists', async () => {
+    const existingPrompt = new OrgSystemPrompt({
+      orgId,
+      systemPrompt: 'Refer to citizens as "Bürgerinnen und Bürger".',
+    });
+    repository.findByOrgId.mockResolvedValue(existingPrompt);
+
+    const result = await useCase.execute();
+
+    expect(result).toEqual(existingPrompt);
+    expect(repository.findByOrgId).toHaveBeenCalledWith(orgId);
+  });
+
+  it('should return null when no system prompt exists for the org', async () => {
+    repository.findByOrgId.mockResolvedValue(null);
+
+    const result = await useCase.execute();
+
+    expect(result).toBeNull();
+    expect(repository.findByOrgId).toHaveBeenCalledWith(orgId);
+  });
+
+  it('should get the orgId from the context service', async () => {
+    repository.findByOrgId.mockResolvedValue(null);
+
+    await useCase.execute();
+
+    expect(contextService.get).toHaveBeenCalledWith('orgId');
+  });
+
+  it('should throw UnauthorizedAccessError when orgId is missing from context', async () => {
+    contextService.get.mockReturnValue(undefined);
+
+    await expect(useCase.execute()).rejects.toThrow(UnauthorizedAccessError);
+    expect(repository.findByOrgId).not.toHaveBeenCalled();
+  });
+});

--- a/ayunis-core-backend/src/domain/chat-settings/application/use-cases/get-org-system-prompt/get-org-system-prompt.use-case.ts
+++ b/ayunis-core-backend/src/domain/chat-settings/application/use-cases/get-org-system-prompt/get-org-system-prompt.use-case.ts
@@ -1,0 +1,42 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { OrgSystemPrompt } from '../../../domain/org-system-prompt.entity';
+import { OrgSystemPromptsRepository } from '../../ports/org-system-prompts.repository';
+import { ContextService } from 'src/common/context/services/context.service';
+import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
+import { UnexpectedChatSettingsError } from '../../chat-settings.errors';
+import { ApplicationError } from 'src/common/errors/base.error';
+
+@Injectable()
+export class GetOrgSystemPromptUseCase {
+  private readonly logger = new Logger(GetOrgSystemPromptUseCase.name);
+
+  constructor(
+    private readonly orgSystemPromptsRepository: OrgSystemPromptsRepository,
+    private readonly contextService: ContextService,
+  ) {}
+
+  async execute(): Promise<OrgSystemPrompt | null> {
+    const orgId = this.contextService.get('orgId');
+    if (!orgId) {
+      throw new UnauthorizedAccessError();
+    }
+    this.logger.log('execute', { orgId });
+
+    try {
+      const orgSystemPrompt =
+        await this.orgSystemPromptsRepository.findByOrgId(orgId);
+
+      if (orgSystemPrompt) {
+        this.logger.debug('Org system prompt found', { orgId });
+      } else {
+        this.logger.debug('No org system prompt found', { orgId });
+      }
+
+      return orgSystemPrompt;
+    } catch (error) {
+      if (error instanceof ApplicationError) throw error;
+      this.logger.error('Failed to get org system prompt', error);
+      throw new UnexpectedChatSettingsError(error as Error);
+    }
+  }
+}

--- a/ayunis-core-backend/src/domain/chat-settings/application/use-cases/upsert-org-system-prompt/upsert-org-system-prompt.command.ts
+++ b/ayunis-core-backend/src/domain/chat-settings/application/use-cases/upsert-org-system-prompt/upsert-org-system-prompt.command.ts
@@ -1,0 +1,3 @@
+export class UpsertOrgSystemPromptCommand {
+  constructor(public readonly systemPrompt: string) {}
+}

--- a/ayunis-core-backend/src/domain/chat-settings/application/use-cases/upsert-org-system-prompt/upsert-org-system-prompt.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/chat-settings/application/use-cases/upsert-org-system-prompt/upsert-org-system-prompt.use-case.spec.ts
@@ -1,0 +1,63 @@
+import { UpsertOrgSystemPromptUseCase } from './upsert-org-system-prompt.use-case';
+import { UpsertOrgSystemPromptCommand } from './upsert-org-system-prompt.command';
+import type { OrgSystemPromptsRepository } from '../../ports/org-system-prompts.repository';
+import { OrgSystemPrompt } from '../../../domain/org-system-prompt.entity';
+import { randomUUID } from 'crypto';
+import type { ContextService } from 'src/common/context/services/context.service';
+
+describe('UpsertOrgSystemPromptUseCase', () => {
+  let useCase: UpsertOrgSystemPromptUseCase;
+  let repository: jest.Mocked<OrgSystemPromptsRepository>;
+  let contextService: jest.Mocked<Pick<ContextService, 'get'>>;
+
+  const orgId = randomUUID();
+
+  beforeEach(() => {
+    repository = {
+      findByOrgId: jest.fn(),
+      upsert: jest.fn(),
+      deleteByOrgId: jest.fn(),
+    };
+
+    contextService = {
+      get: jest.fn().mockReturnValue(orgId),
+    };
+
+    useCase = new UpsertOrgSystemPromptUseCase(
+      repository,
+      contextService as unknown as ContextService,
+    );
+  });
+
+  it('should create a new org system prompt and return the result', async () => {
+    const systemPrompt =
+      'All responses must comply with municipal communication guidelines.';
+    const savedPrompt = new OrgSystemPrompt({ orgId, systemPrompt });
+
+    repository.upsert.mockResolvedValue(savedPrompt);
+
+    const result = await useCase.execute(
+      new UpsertOrgSystemPromptCommand(systemPrompt),
+    );
+
+    expect(result.orgId).toEqual(orgId);
+    expect(result.systemPrompt).toEqual(systemPrompt);
+    expect(repository.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({ orgId, systemPrompt }),
+    );
+  });
+
+  it('should pass an OrgSystemPrompt domain object with orgId from context to the repository', async () => {
+    const systemPrompt = 'Always answer in plain administrative German.';
+    const savedPrompt = new OrgSystemPrompt({ orgId, systemPrompt });
+    repository.upsert.mockResolvedValue(savedPrompt);
+
+    await useCase.execute(new UpsertOrgSystemPromptCommand(systemPrompt));
+
+    const passedArg = repository.upsert.mock.calls[0][0];
+    expect(passedArg).toBeInstanceOf(OrgSystemPrompt);
+    expect(passedArg.id).toBeDefined();
+    expect(passedArg.orgId).toBe(orgId);
+    expect(passedArg.systemPrompt).toBe(systemPrompt);
+  });
+});

--- a/ayunis-core-backend/src/domain/chat-settings/application/use-cases/upsert-org-system-prompt/upsert-org-system-prompt.use-case.ts
+++ b/ayunis-core-backend/src/domain/chat-settings/application/use-cases/upsert-org-system-prompt/upsert-org-system-prompt.use-case.ts
@@ -1,0 +1,49 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { UpsertOrgSystemPromptCommand } from './upsert-org-system-prompt.command';
+import { OrgSystemPrompt } from '../../../domain/org-system-prompt.entity';
+import { OrgSystemPromptsRepository } from '../../ports/org-system-prompts.repository';
+import { ContextService } from 'src/common/context/services/context.service';
+import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
+import { UnexpectedChatSettingsError } from '../../chat-settings.errors';
+import { ApplicationError } from 'src/common/errors/base.error';
+
+@Injectable()
+export class UpsertOrgSystemPromptUseCase {
+  private readonly logger = new Logger(UpsertOrgSystemPromptUseCase.name);
+
+  constructor(
+    private readonly orgSystemPromptsRepository: OrgSystemPromptsRepository,
+    private readonly contextService: ContextService,
+  ) {}
+
+  async execute(
+    command: UpsertOrgSystemPromptCommand,
+  ): Promise<OrgSystemPrompt> {
+    const orgId = this.contextService.get('orgId');
+    if (!orgId) {
+      throw new UnauthorizedAccessError();
+    }
+    this.logger.log('execute', { orgId });
+
+    try {
+      const orgSystemPrompt = new OrgSystemPrompt({
+        orgId,
+        systemPrompt: command.systemPrompt,
+      });
+
+      const result =
+        await this.orgSystemPromptsRepository.upsert(orgSystemPrompt);
+
+      this.logger.debug('Org system prompt upserted', {
+        orgId,
+        id: result.id,
+      });
+
+      return result;
+    } catch (error) {
+      if (error instanceof ApplicationError) throw error;
+      this.logger.error('Failed to upsert org system prompt', error);
+      throw new UnexpectedChatSettingsError(error as Error);
+    }
+  }
+}

--- a/ayunis-core-backend/src/domain/chat-settings/chat-settings.module.ts
+++ b/ayunis-core-backend/src/domain/chat-settings/chat-settings.module.ts
@@ -1,21 +1,32 @@
 import { Module } from '@nestjs/common';
 import { ChatSettingsController } from './presenters/http/chat-settings.controller';
 import { LocalUserSystemPromptsRepositoryModule } from './infrastructure/persistence/local-user-system-prompts/local-user-system-prompts-repository.module';
+import { LocalOrgSystemPromptsRepositoryModule } from './infrastructure/persistence/local-org-system-prompts/local-org-system-prompts-repository.module';
 import { GetUserSystemPromptUseCase } from './application/use-cases/get-user-system-prompt/get-user-system-prompt.use-case';
 import { UpsertUserSystemPromptUseCase } from './application/use-cases/upsert-user-system-prompt/upsert-user-system-prompt.use-case';
 import { DeleteUserSystemPromptUseCase } from './application/use-cases/delete-user-system-prompt/delete-user-system-prompt.use-case';
+import { GetOrgSystemPromptUseCase } from './application/use-cases/get-org-system-prompt/get-org-system-prompt.use-case';
+import { UpsertOrgSystemPromptUseCase } from './application/use-cases/upsert-org-system-prompt/upsert-org-system-prompt.use-case';
+import { DeleteOrgSystemPromptUseCase } from './application/use-cases/delete-org-system-prompt/delete-org-system-prompt.use-case';
 import { GeneratePersonalizedSystemPromptUseCase } from './application/use-cases/generate-personalized-system-prompt/generate-personalized-system-prompt.use-case';
 import { ModelsModule } from '../models/models.module';
 
 @Module({
-  imports: [LocalUserSystemPromptsRepositoryModule, ModelsModule],
+  imports: [
+    LocalUserSystemPromptsRepositoryModule,
+    LocalOrgSystemPromptsRepositoryModule,
+    ModelsModule,
+  ],
   controllers: [ChatSettingsController],
   providers: [
     GetUserSystemPromptUseCase,
     UpsertUserSystemPromptUseCase,
     DeleteUserSystemPromptUseCase,
+    GetOrgSystemPromptUseCase,
+    UpsertOrgSystemPromptUseCase,
+    DeleteOrgSystemPromptUseCase,
     GeneratePersonalizedSystemPromptUseCase,
   ],
-  exports: [GetUserSystemPromptUseCase],
+  exports: [GetUserSystemPromptUseCase, GetOrgSystemPromptUseCase],
 })
 export class ChatSettingsModule {}

--- a/ayunis-core-backend/src/domain/chat-settings/domain/org-system-prompt.entity.ts
+++ b/ayunis-core-backend/src/domain/chat-settings/domain/org-system-prompt.entity.ts
@@ -1,0 +1,24 @@
+import type { UUID } from 'crypto';
+import { randomUUID } from 'crypto';
+
+export class OrgSystemPrompt {
+  id: UUID;
+  orgId: UUID;
+  systemPrompt: string;
+  createdAt: Date;
+  updatedAt: Date;
+
+  constructor(params: {
+    id?: UUID;
+    orgId: UUID;
+    systemPrompt: string;
+    createdAt?: Date;
+    updatedAt?: Date;
+  }) {
+    this.id = params.id ?? randomUUID();
+    this.orgId = params.orgId;
+    this.systemPrompt = params.systemPrompt;
+    this.createdAt = params.createdAt ?? new Date();
+    this.updatedAt = params.updatedAt ?? new Date();
+  }
+}

--- a/ayunis-core-backend/src/domain/chat-settings/infrastructure/persistence/local-org-system-prompts/local-org-system-prompts-repository.module.ts
+++ b/ayunis-core-backend/src/domain/chat-settings/infrastructure/persistence/local-org-system-prompts/local-org-system-prompts-repository.module.ts
@@ -1,0 +1,20 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { OrgSystemPromptRecord } from './schema/org-system-prompt.record';
+import { OrgSystemPromptMapper } from './mappers/org-system-prompt.mapper';
+import { LocalOrgSystemPromptsRepository } from './local-org-system-prompts.repository';
+import { OrgSystemPromptsRepository } from '../../../application/ports/org-system-prompts.repository';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([OrgSystemPromptRecord])],
+  providers: [
+    LocalOrgSystemPromptsRepository,
+    OrgSystemPromptMapper,
+    {
+      provide: OrgSystemPromptsRepository,
+      useClass: LocalOrgSystemPromptsRepository,
+    },
+  ],
+  exports: [OrgSystemPromptsRepository],
+})
+export class LocalOrgSystemPromptsRepositoryModule {}

--- a/ayunis-core-backend/src/domain/chat-settings/infrastructure/persistence/local-org-system-prompts/local-org-system-prompts.repository.ts
+++ b/ayunis-core-backend/src/domain/chat-settings/infrastructure/persistence/local-org-system-prompts/local-org-system-prompts.repository.ts
@@ -1,0 +1,66 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { UUID } from 'crypto';
+import { OrgSystemPromptsRepository } from '../../../application/ports/org-system-prompts.repository';
+import { OrgSystemPrompt } from '../../../domain/org-system-prompt.entity';
+import { OrgSystemPromptRecord } from './schema/org-system-prompt.record';
+import { OrgSystemPromptMapper } from './mappers/org-system-prompt.mapper';
+
+@Injectable()
+export class LocalOrgSystemPromptsRepository extends OrgSystemPromptsRepository {
+  private readonly logger = new Logger(LocalOrgSystemPromptsRepository.name);
+
+  constructor(
+    @InjectRepository(OrgSystemPromptRecord)
+    private readonly repository: Repository<OrgSystemPromptRecord>,
+    private readonly mapper: OrgSystemPromptMapper,
+  ) {
+    super();
+  }
+
+  async findByOrgId(orgId: UUID): Promise<OrgSystemPrompt | null> {
+    this.logger.log('findByOrgId', { orgId });
+
+    const record = await this.repository.findOne({ where: { orgId } });
+
+    if (!record) {
+      this.logger.debug('No org system prompt found', { orgId });
+      return null;
+    }
+
+    return this.mapper.toDomain(record);
+  }
+
+  async upsert(orgSystemPrompt: OrgSystemPrompt): Promise<OrgSystemPrompt> {
+    this.logger.log('upsert', { orgId: orgSystemPrompt.orgId });
+
+    const record = this.mapper.toRecord(orgSystemPrompt);
+
+    // Use atomic upsert with conflict resolution on orgId
+    await this.repository.upsert(record, {
+      conflictPaths: ['orgId'],
+      skipUpdateIfNoValuesChanged: true,
+    });
+
+    // Fetch the saved record to get the actual id (may be existing or new)
+    const savedRecord = await this.repository.findOneOrFail({
+      where: { orgId: orgSystemPrompt.orgId },
+    });
+
+    this.logger.debug('Org system prompt upserted', {
+      orgId: orgSystemPrompt.orgId,
+      id: savedRecord.id,
+    });
+
+    return this.mapper.toDomain(savedRecord);
+  }
+
+  async deleteByOrgId(orgId: UUID): Promise<void> {
+    this.logger.log('deleteByOrgId', { orgId });
+
+    await this.repository.delete({ orgId });
+
+    this.logger.debug('Org system prompt deleted', { orgId });
+  }
+}

--- a/ayunis-core-backend/src/domain/chat-settings/infrastructure/persistence/local-org-system-prompts/mappers/org-system-prompt.mapper.spec.ts
+++ b/ayunis-core-backend/src/domain/chat-settings/infrastructure/persistence/local-org-system-prompts/mappers/org-system-prompt.mapper.spec.ts
@@ -1,0 +1,68 @@
+import { OrgSystemPromptMapper } from './org-system-prompt.mapper';
+import { OrgSystemPrompt } from '../../../../domain/org-system-prompt.entity';
+import { OrgSystemPromptRecord } from '../schema/org-system-prompt.record';
+import { randomUUID } from 'crypto';
+
+describe('OrgSystemPromptMapper', () => {
+  let mapper: OrgSystemPromptMapper;
+
+  beforeEach(() => {
+    mapper = new OrgSystemPromptMapper();
+  });
+
+  describe('round-trip: domain → record → domain', () => {
+    it('should preserve all fields through a round-trip conversion', () => {
+      const original = new OrgSystemPrompt({
+        id: randomUUID(),
+        orgId: randomUUID(),
+        systemPrompt:
+          'All responses must comply with municipal communication guidelines.',
+        createdAt: new Date('2026-01-15T10:00:00Z'),
+        updatedAt: new Date('2026-02-10T14:30:00Z'),
+      });
+
+      const record = mapper.toRecord(original);
+      const restored = mapper.toDomain(record);
+
+      expect(restored.id).toEqual(original.id);
+      expect(restored.orgId).toEqual(original.orgId);
+      expect(restored.systemPrompt).toEqual(original.systemPrompt);
+      expect(restored.createdAt).toEqual(original.createdAt);
+      expect(restored.updatedAt).toEqual(original.updatedAt);
+    });
+  });
+
+  describe('toDomain', () => {
+    it('should convert a record to an OrgSystemPrompt domain entity', () => {
+      const record = new OrgSystemPromptRecord();
+      record.id = randomUUID();
+      record.orgId = randomUUID();
+      record.systemPrompt = 'Always answer in plain administrative German.';
+      record.createdAt = new Date('2026-01-01T00:00:00Z');
+      record.updatedAt = new Date('2026-01-02T00:00:00Z');
+
+      const domain = mapper.toDomain(record);
+
+      expect(domain).toBeInstanceOf(OrgSystemPrompt);
+      expect(domain.id).toEqual(record.id);
+      expect(domain.orgId).toEqual(record.orgId);
+      expect(domain.systemPrompt).toEqual(record.systemPrompt);
+    });
+  });
+
+  describe('toRecord', () => {
+    it('should convert a domain entity to an OrgSystemPromptRecord', () => {
+      const domain = new OrgSystemPrompt({
+        orgId: randomUUID(),
+        systemPrompt: 'Refer to citizens as "Bürgerinnen und Bürger".',
+      });
+
+      const record = mapper.toRecord(domain);
+
+      expect(record).toBeInstanceOf(OrgSystemPromptRecord);
+      expect(record.id).toEqual(domain.id);
+      expect(record.orgId).toEqual(domain.orgId);
+      expect(record.systemPrompt).toEqual(domain.systemPrompt);
+    });
+  });
+});

--- a/ayunis-core-backend/src/domain/chat-settings/infrastructure/persistence/local-org-system-prompts/mappers/org-system-prompt.mapper.ts
+++ b/ayunis-core-backend/src/domain/chat-settings/infrastructure/persistence/local-org-system-prompts/mappers/org-system-prompt.mapper.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@nestjs/common';
+import { OrgSystemPromptRecord } from '../schema/org-system-prompt.record';
+import { OrgSystemPrompt } from '../../../../domain/org-system-prompt.entity';
+
+@Injectable()
+export class OrgSystemPromptMapper {
+  toDomain(record: OrgSystemPromptRecord): OrgSystemPrompt {
+    return new OrgSystemPrompt({
+      id: record.id,
+      orgId: record.orgId,
+      systemPrompt: record.systemPrompt,
+      createdAt: record.createdAt,
+      updatedAt: record.updatedAt,
+    });
+  }
+
+  toRecord(domain: OrgSystemPrompt): OrgSystemPromptRecord {
+    const record = new OrgSystemPromptRecord();
+    record.id = domain.id;
+    record.orgId = domain.orgId;
+    record.systemPrompt = domain.systemPrompt;
+    record.createdAt = domain.createdAt;
+    record.updatedAt = domain.updatedAt;
+    return record;
+  }
+}

--- a/ayunis-core-backend/src/domain/chat-settings/infrastructure/persistence/local-org-system-prompts/schema/org-system-prompt.record.ts
+++ b/ayunis-core-backend/src/domain/chat-settings/infrastructure/persistence/local-org-system-prompts/schema/org-system-prompt.record.ts
@@ -1,0 +1,18 @@
+import { UUID } from 'crypto';
+import { BaseRecord } from '../../../../../../common/db/base-record';
+import { Column, Entity, Index, JoinColumn, ManyToOne } from 'typeorm';
+import { OrgRecord } from 'src/iam/orgs/infrastructure/repositories/local/schema/org.record';
+
+@Entity({ name: 'org_system_prompts' })
+export class OrgSystemPromptRecord extends BaseRecord {
+  @Column({ nullable: false })
+  @Index({ unique: true })
+  orgId: UUID;
+
+  @ManyToOne(() => OrgRecord, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'orgId' })
+  org: OrgRecord;
+
+  @Column({ type: 'text', nullable: false })
+  systemPrompt: string;
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> New persisted org-wide prompts can affect LLM behavior org-wide once consumed, and the schema/migration for `org_system_prompts` must deploy cleanly; scope is bounded by no new public API in this diff.
> 
> **Overview**
> Adds **org-scoped custom system prompts** alongside the existing user-level chat settings, so each organization can store one shared prompt (e.g. municipal tone guidelines).
> 
> The change introduces an `OrgSystemPrompt` domain model, get/upsert/delete use cases keyed off `orgId` from `ContextService` (with `UnauthorizedAccessError` when missing), and TypeORM persistence on a new `org_system_prompts` table with a **unique `orgId`** and cascade delete on the org. Upsert uses conflict resolution on `orgId`.
> 
> `ChatSettingsModule` wires the new repository module and use cases and **exports `GetOrgSystemPromptUseCase`** for other modules to read org prompts; **no HTTP endpoints** for org prompts appear in this diff (still WIP vs user `system-prompt` routes).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74169062a52ddc8dadd1650a8aa5ba1886b93d59. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->