### PR TITLE
wip(chat-settings): add admin endpoints and migration for org system prompt (AYC-219)

### DIFF
--- a/ayunis-core-backend/src/db/migrations/1781161472259-CreateOrgSystemPromptsTable.ts
+++ b/ayunis-core-backend/src/db/migrations/1781161472259-CreateOrgSystemPromptsTable.ts
@@ -1,0 +1,27 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateOrgSystemPromptsTable1781161472259 implements MigrationInterface {
+  name = 'CreateOrgSystemPromptsTable1781161472259';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE "org_system_prompts" ("id" character varying NOT NULL, "createdAt" TIMESTAMP NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP NOT NULL DEFAULT now(), "orgId" character varying NOT NULL, "systemPrompt" text NOT NULL, CONSTRAINT "PK_01f2eebbbc16903068294a27a24" PRIMARY KEY ("id"))`,
+    );
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX "IDX_218d23ec3c056fa568b5c8beb4" ON "org_system_prompts" ("orgId") `,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "org_system_prompts" ADD CONSTRAINT "FK_218d23ec3c056fa568b5c8beb4a" FOREIGN KEY ("orgId") REFERENCES "orgs"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "org_system_prompts" DROP CONSTRAINT "FK_218d23ec3c056fa568b5c8beb4a"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_218d23ec3c056fa568b5c8beb4"`,
+    );
+    await queryRunner.query(`DROP TABLE "org_system_prompts"`);
+  }
+}

--- a/ayunis-core-backend/src/domain/chat-settings/SUMMARY.md
+++ b/ayunis-core-backend/src/domain/chat-settings/SUMMARY.md
@@ -1,14 +1,16 @@
 # Chat Settings Module
 
-Per-user chat configuration. Currently contains the **user system prompt** feature — a personal system prompt that gets injected into every AI conversation.
+Chat configuration. Contains the **user system prompt** feature (a personal system prompt injected into every AI conversation) and the **org system prompt** feature (an organization-wide system prompt injected into all conversations of an org's users).
 
 ## Domain Entities
 
 - **`UserSystemPrompt`** — A user's custom system prompt (`id`, `userId`, `systemPrompt`, `createdAt`, `updatedAt`). One per user, upsert semantics.
+- **`OrgSystemPrompt`** — An organization's system prompt (`id`, `orgId`, `systemPrompt`, `createdAt`, `updatedAt`). One per org, upsert semantics.
 
 ## Ports
 
 - **`UserSystemPromptsRepository`** — `findByUserId`, `upsert`, `deleteByUserId`
+- **`OrgSystemPromptsRepository`** — `findByOrgId`, `upsert`, `deleteByOrgId`
 
 ## Use Cases
 
@@ -16,12 +18,18 @@ Per-user chat configuration. Currently contains the **user system prompt** featu
 - **`UpsertUserSystemPromptUseCase`** — Creates or replaces the user's system prompt
 - **`DeleteUserSystemPromptUseCase`** — Deletes the user's system prompt (idempotent)
 - **`GeneratePersonalizedSystemPromptUseCase`** — Generates a personalized system prompt and welcome message via LLM inference based on user preferences, then upserts the generated system prompt
+- **`GetOrgSystemPromptUseCase`** — Retrieves the org's system prompt (returns `null` if not set)
+- **`UpsertOrgSystemPromptUseCase`** — Creates or replaces the org's system prompt
+- **`DeleteOrgSystemPromptUseCase`** — Deletes the org's system prompt (idempotent)
 
 ## Infrastructure
 
 - **`LocalUserSystemPromptsRepository`** — TypeORM implementation backed by `user_system_prompts` table
 - **`UserSystemPromptRecord`** — TypeORM entity with unique index on `userId`
 - **`UserSystemPromptMapper`** — Domain ↔ Record conversion
+- **`LocalOrgSystemPromptsRepository`** — TypeORM implementation backed by `org_system_prompts` table
+- **`OrgSystemPromptRecord`** — TypeORM entity with unique index on `orgId`
+- **`OrgSystemPromptMapper`** — Domain ↔ Record conversion
 
 ## HTTP API
 
@@ -34,9 +42,18 @@ Controller: `ChatSettingsController` — base path `/chat-settings`, tag `Chat S
 | DELETE | `/chat-settings/system-prompt`                        | Delete user's system prompt                      |
 | POST   | `/chat-settings/generate-personalized-system-prompt`  | Generate and save a personalized system prompt   |
 
+Controller: `OrgSystemPromptController` — base path `/chat-settings`, tag `Chat Settings` (admin only)
+
+| Method | Path                                                  | Description                                      |
+| ------ | ----------------------------------------------------- | ------------------------------------------------ |
+| GET    | `/chat-settings/org-system-prompt`                    | Get org's system prompt (admin only)             |
+| PUT    | `/chat-settings/org-system-prompt`                    | Set/update org's system prompt (admin only)      |
+| DELETE | `/chat-settings/org-system-prompt`                    | Delete org's system prompt (admin only)          |
+
 ## Exports
 
 - `GetUserSystemPromptUseCase` — Used by the runs module to inject user instructions into the system prompt
+- `GetOrgSystemPromptUseCase` — Used to inject org-wide instructions into the system prompt
 
 ## Future
 

--- a/ayunis-core-backend/src/domain/chat-settings/chat-settings.module.ts
+++ b/ayunis-core-backend/src/domain/chat-settings/chat-settings.module.ts
@@ -1,5 +1,6 @@
 import { Module } from '@nestjs/common';
 import { ChatSettingsController } from './presenters/http/chat-settings.controller';
+import { OrgSystemPromptController } from './presenters/http/org-system-prompt.controller';
 import { LocalUserSystemPromptsRepositoryModule } from './infrastructure/persistence/local-user-system-prompts/local-user-system-prompts-repository.module';
 import { LocalOrgSystemPromptsRepositoryModule } from './infrastructure/persistence/local-org-system-prompts/local-org-system-prompts-repository.module';
 import { GetUserSystemPromptUseCase } from './application/use-cases/get-user-system-prompt/get-user-system-prompt.use-case';
@@ -17,7 +18,7 @@ import { ModelsModule } from '../models/models.module';
     LocalOrgSystemPromptsRepositoryModule,
     ModelsModule,
   ],
-  controllers: [ChatSettingsController],
+  controllers: [ChatSettingsController, OrgSystemPromptController],
   providers: [
     GetUserSystemPromptUseCase,
     UpsertUserSystemPromptUseCase,

--- a/ayunis-core-backend/src/domain/chat-settings/presenters/http/dtos/org-system-prompt-response.dto.ts
+++ b/ayunis-core-backend/src/domain/chat-settings/presenters/http/dtos/org-system-prompt-response.dto.ts
@@ -1,0 +1,12 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class OrgSystemPromptResponseDto {
+  @ApiProperty({
+    description: 'The organization-wide system prompt, or null if not set',
+    example:
+      'All responses must comply with municipal communication guidelines.',
+    nullable: true,
+    type: String,
+  })
+  systemPrompt: string | null;
+}

--- a/ayunis-core-backend/src/domain/chat-settings/presenters/http/dtos/upsert-org-system-prompt.dto.ts
+++ b/ayunis-core-backend/src/domain/chat-settings/presenters/http/dtos/upsert-org-system-prompt.dto.ts
@@ -1,0 +1,15 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsString, MaxLength } from 'class-validator';
+
+export class UpsertOrgSystemPromptDto {
+  @ApiProperty({
+    description: 'The organization-wide system prompt',
+    example:
+      'All responses must comply with municipal communication guidelines.',
+    maxLength: 10000,
+  })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(10000)
+  systemPrompt: string;
+}

--- a/ayunis-core-backend/src/domain/chat-settings/presenters/http/org-system-prompt.controller.ts
+++ b/ayunis-core-backend/src/domain/chat-settings/presenters/http/org-system-prompt.controller.ts
@@ -1,0 +1,104 @@
+import {
+  Controller,
+  Get,
+  Put,
+  Delete,
+  Body,
+  HttpCode,
+  HttpStatus,
+} from '@nestjs/common';
+import { ApiOperation, ApiTags, ApiResponse, ApiBody } from '@nestjs/swagger';
+import { Roles } from 'src/iam/authorization/application/decorators/roles.decorator';
+import { UserRole } from 'src/iam/users/domain/value-objects/role.object';
+import { GetOrgSystemPromptUseCase } from '../../application/use-cases/get-org-system-prompt/get-org-system-prompt.use-case';
+import { UpsertOrgSystemPromptUseCase } from '../../application/use-cases/upsert-org-system-prompt/upsert-org-system-prompt.use-case';
+import { UpsertOrgSystemPromptCommand } from '../../application/use-cases/upsert-org-system-prompt/upsert-org-system-prompt.command';
+import { DeleteOrgSystemPromptUseCase } from '../../application/use-cases/delete-org-system-prompt/delete-org-system-prompt.use-case';
+import { UpsertOrgSystemPromptDto } from './dtos/upsert-org-system-prompt.dto';
+import { OrgSystemPromptResponseDto } from './dtos/org-system-prompt-response.dto';
+
+@ApiTags('Chat Settings')
+@Controller('chat-settings')
+export class OrgSystemPromptController {
+  constructor(
+    private readonly getOrgSystemPromptUseCase: GetOrgSystemPromptUseCase,
+    private readonly upsertOrgSystemPromptUseCase: UpsertOrgSystemPromptUseCase,
+    private readonly deleteOrgSystemPromptUseCase: DeleteOrgSystemPromptUseCase,
+  ) {}
+
+  @Get('org-system-prompt')
+  @Roles(UserRole.ADMIN)
+  @ApiOperation({
+    summary: 'Get the organization-wide system prompt',
+    description:
+      "Returns the organization-wide system prompt for the admin's organization, or null if not set. Admin only.",
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'The organization-wide system prompt',
+    type: OrgSystemPromptResponseDto,
+  })
+  @ApiResponse({
+    status: 403,
+    description: 'User is not an organization admin',
+  })
+  async getOrgSystemPrompt(): Promise<OrgSystemPromptResponseDto> {
+    const result = await this.getOrgSystemPromptUseCase.execute();
+
+    return {
+      systemPrompt: result?.systemPrompt ?? null,
+    };
+  }
+
+  @Put('org-system-prompt')
+  @Roles(UserRole.ADMIN)
+  @ApiOperation({
+    summary: 'Set or update the organization-wide system prompt',
+    description:
+      'Creates or replaces the organization-wide system prompt, which is injected into all conversations of users of the organization. Admin only.',
+  })
+  @ApiBody({ type: UpsertOrgSystemPromptDto })
+  @ApiResponse({
+    status: 200,
+    description:
+      'Successfully set or updated the organization-wide system prompt',
+    type: OrgSystemPromptResponseDto,
+  })
+  @ApiResponse({
+    status: 400,
+    description: 'Invalid request payload',
+  })
+  @ApiResponse({
+    status: 403,
+    description: 'User is not an organization admin',
+  })
+  async upsertOrgSystemPrompt(
+    @Body() dto: UpsertOrgSystemPromptDto,
+  ): Promise<OrgSystemPromptResponseDto> {
+    const command = new UpsertOrgSystemPromptCommand(dto.systemPrompt);
+    const result = await this.upsertOrgSystemPromptUseCase.execute(command);
+
+    return {
+      systemPrompt: result.systemPrompt,
+    };
+  }
+
+  @Delete('org-system-prompt')
+  @Roles(UserRole.ADMIN)
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({
+    summary: 'Delete the organization-wide system prompt',
+    description: 'Deletes the organization-wide system prompt. Admin only.',
+  })
+  @ApiResponse({
+    status: 204,
+    description: 'Successfully deleted the organization-wide system prompt',
+  })
+  @ApiResponse({
+    status: 403,
+    description: 'User is not an organization admin',
+  })
+  async deleteOrgSystemPrompt(): Promise<void> {
+    await this.deleteOrgSystemPromptUseCase.execute();
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Org admins can change text injected into every member’s AI conversations; access is role-gated but the blast radius is org-wide.
> 
> **Overview**
> Adds persistence and **admin-only HTTP APIs** so organizations can store a single org-wide system prompt (mirroring the existing per-user flow).
> 
> A new migration creates **`org_system_prompts`** with one row per org (`unique orgId`, FK to `orgs` with cascade delete). **`OrgSystemPromptController`** exposes GET/PUT/DELETE on `/chat-settings/org-system-prompt`, guarded by **`@Roles(UserRole.ADMIN)`**, with PUT validated via **`UpsertOrgSystemPromptDto`** (non-empty string, max 10k chars). The chat-settings module registers the controller and documents the feature in **`SUMMARY.md`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f7dd2651f118c593c98aa89282d490c097b9160. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->