### PR TITLE
feat(admin-settings): add org-wide instructions admin page (AYC-219)

### DIFF
--- a/ayunis-core-frontend/src/app/routeTree.gen.ts
+++ b/ayunis-core-frontend/src/app/routeTree.gen.ts
@@ -37,6 +37,7 @@ import { Route as AuthenticatedAdminSettingsUsageRouteImport } from './routes/_a
 import { Route as AuthenticatedAdminSettingsSecurityRouteImport } from './routes/_authenticated/admin-settings.security'
 import { Route as AuthenticatedAdminSettingsModelsRouteImport } from './routes/_authenticated/admin-settings.models'
 import { Route as AuthenticatedAdminSettingsIntegrationsRouteImport } from './routes/_authenticated/admin-settings.integrations'
+import { Route as AuthenticatedAdminSettingsInstructionsRouteImport } from './routes/_authenticated/admin-settings.instructions'
 import { Route as AuthenticatedAdminSettingsApiKeysRouteImport } from './routes/_authenticated/admin-settings.api-keys'
 import { Route as AuthenticatedAdminSettingsAnonymizationRouteImport } from './routes/_authenticated/admin-settings.anonymization'
 import { Route as onboardingPasswordResetRouteImport } from './routes/(onboarding)/password.reset'
@@ -208,6 +209,12 @@ const AuthenticatedAdminSettingsIntegrationsRoute =
     path: '/admin-settings/integrations',
     getParentRoute: () => AuthenticatedRoute,
   } as any)
+const AuthenticatedAdminSettingsInstructionsRoute =
+  AuthenticatedAdminSettingsInstructionsRouteImport.update({
+    id: '/admin-settings/instructions',
+    path: '/admin-settings/instructions',
+    getParentRoute: () => AuthenticatedRoute,
+  } as any)
 const AuthenticatedAdminSettingsApiKeysRoute =
   AuthenticatedAdminSettingsApiKeysRouteImport.update({
     id: '/admin-settings/api-keys',
@@ -312,6 +319,7 @@ export interface FileRoutesByFullPath {
   '/password/reset': typeof onboardingPasswordResetRoute
   '/admin-settings/anonymization': typeof AuthenticatedAdminSettingsAnonymizationRoute
   '/admin-settings/api-keys': typeof AuthenticatedAdminSettingsApiKeysRoute
+  '/admin-settings/instructions': typeof AuthenticatedAdminSettingsInstructionsRoute
   '/admin-settings/integrations': typeof AuthenticatedAdminSettingsIntegrationsRoute
   '/admin-settings/models': typeof AuthenticatedAdminSettingsModelsRoute
   '/admin-settings/security': typeof AuthenticatedAdminSettingsSecurityRoute
@@ -356,6 +364,7 @@ export interface FileRoutesByTo {
   '/password/reset': typeof onboardingPasswordResetRoute
   '/admin-settings/anonymization': typeof AuthenticatedAdminSettingsAnonymizationRoute
   '/admin-settings/api-keys': typeof AuthenticatedAdminSettingsApiKeysRoute
+  '/admin-settings/instructions': typeof AuthenticatedAdminSettingsInstructionsRoute
   '/admin-settings/integrations': typeof AuthenticatedAdminSettingsIntegrationsRoute
   '/admin-settings/models': typeof AuthenticatedAdminSettingsModelsRoute
   '/admin-settings/security': typeof AuthenticatedAdminSettingsSecurityRoute
@@ -402,6 +411,7 @@ export interface FileRoutesById {
   '/(onboarding)/password/reset': typeof onboardingPasswordResetRoute
   '/_authenticated/admin-settings/anonymization': typeof AuthenticatedAdminSettingsAnonymizationRoute
   '/_authenticated/admin-settings/api-keys': typeof AuthenticatedAdminSettingsApiKeysRoute
+  '/_authenticated/admin-settings/instructions': typeof AuthenticatedAdminSettingsInstructionsRoute
   '/_authenticated/admin-settings/integrations': typeof AuthenticatedAdminSettingsIntegrationsRoute
   '/_authenticated/admin-settings/models': typeof AuthenticatedAdminSettingsModelsRoute
   '/_authenticated/admin-settings/security': typeof AuthenticatedAdminSettingsSecurityRoute
@@ -448,6 +458,7 @@ export interface FileRouteTypes {
     | '/password/reset'
     | '/admin-settings/anonymization'
     | '/admin-settings/api-keys'
+    | '/admin-settings/instructions'
     | '/admin-settings/integrations'
     | '/admin-settings/models'
     | '/admin-settings/security'
@@ -492,6 +503,7 @@ export interface FileRouteTypes {
     | '/password/reset'
     | '/admin-settings/anonymization'
     | '/admin-settings/api-keys'
+    | '/admin-settings/instructions'
     | '/admin-settings/integrations'
     | '/admin-settings/models'
     | '/admin-settings/security'
@@ -537,6 +549,7 @@ export interface FileRouteTypes {
     | '/(onboarding)/password/reset'
     | '/_authenticated/admin-settings/anonymization'
     | '/_authenticated/admin-settings/api-keys'
+    | '/_authenticated/admin-settings/instructions'
     | '/_authenticated/admin-settings/integrations'
     | '/_authenticated/admin-settings/models'
     | '/_authenticated/admin-settings/security'
@@ -780,6 +793,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedAdminSettingsIntegrationsRouteImport
       parentRoute: typeof AuthenticatedRoute
     }
+    '/_authenticated/admin-settings/instructions': {
+      id: '/_authenticated/admin-settings/instructions'
+      path: '/admin-settings/instructions'
+      fullPath: '/admin-settings/instructions'
+      preLoaderRoute: typeof AuthenticatedAdminSettingsInstructionsRouteImport
+      parentRoute: typeof AuthenticatedRoute
+    }
     '/_authenticated/admin-settings/api-keys': {
       id: '/_authenticated/admin-settings/api-keys'
       path: '/admin-settings/api-keys'
@@ -892,6 +912,7 @@ interface AuthenticatedRouteChildren {
   AuthenticatedInstallRoute: typeof AuthenticatedInstallRoute
   AuthenticatedAdminSettingsAnonymizationRoute: typeof AuthenticatedAdminSettingsAnonymizationRoute
   AuthenticatedAdminSettingsApiKeysRoute: typeof AuthenticatedAdminSettingsApiKeysRoute
+  AuthenticatedAdminSettingsInstructionsRoute: typeof AuthenticatedAdminSettingsInstructionsRoute
   AuthenticatedAdminSettingsIntegrationsRoute: typeof AuthenticatedAdminSettingsIntegrationsRoute
   AuthenticatedAdminSettingsModelsRoute: typeof AuthenticatedAdminSettingsModelsRoute
   AuthenticatedAdminSettingsSecurityRoute: typeof AuthenticatedAdminSettingsSecurityRoute
@@ -929,6 +950,8 @@ const AuthenticatedRouteChildren: AuthenticatedRouteChildren = {
     AuthenticatedAdminSettingsAnonymizationRoute,
   AuthenticatedAdminSettingsApiKeysRoute:
     AuthenticatedAdminSettingsApiKeysRoute,
+  AuthenticatedAdminSettingsInstructionsRoute:
+    AuthenticatedAdminSettingsInstructionsRoute,
   AuthenticatedAdminSettingsIntegrationsRoute:
     AuthenticatedAdminSettingsIntegrationsRoute,
   AuthenticatedAdminSettingsModelsRoute: AuthenticatedAdminSettingsModelsRoute,

--- a/ayunis-core-frontend/src/app/routes/_authenticated/admin-settings.instructions.tsx
+++ b/ayunis-core-frontend/src/app/routes/_authenticated/admin-settings.instructions.tsx
@@ -1,0 +1,12 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { InstructionsSettingsPage } from '@/pages/admin-settings/instructions-settings';
+
+export const Route = createFileRoute(
+  '/_authenticated/admin-settings/instructions',
+)({
+  component: RouteComponent,
+});
+
+function RouteComponent() {
+  return <InstructionsSettingsPage />;
+}

--- a/ayunis-core-frontend/src/i18n.ts
+++ b/ayunis-core-frontend/src/i18n.ts
@@ -58,6 +58,8 @@ import enAdminSettingsApiKeys from './shared/locales/en/admin-settings-api-keys.
 import deAdminSettingsApiKeys from './shared/locales/de/admin-settings-api-keys.json';
 import enMcpUserConfig from './shared/locales/en/mcp-user-config.json';
 import deMcpUserConfig from './shared/locales/de/mcp-user-config.json';
+import enAdminSettingsInstructions from './shared/locales/en/admin-settings-instructions.json';
+import deAdminSettingsInstructions from './shared/locales/de/admin-settings-instructions.json';
 
 const resources = {
   en: {
@@ -89,6 +91,7 @@ const resources = {
     'admin-settings-letterheads': enAdminSettingsLetterheads,
     'admin-settings-api-keys': enAdminSettingsApiKeys,
     'mcp-user-config': enMcpUserConfig,
+    'admin-settings-instructions': enAdminSettingsInstructions,
   },
   de: {
     auth: deAuth,
@@ -119,6 +122,7 @@ const resources = {
     'admin-settings-letterheads': deAdminSettingsLetterheads,
     'admin-settings-api-keys': deAdminSettingsApiKeys,
     'mcp-user-config': deMcpUserConfig,
+    'admin-settings-instructions': deAdminSettingsInstructions,
   },
 };
 

--- a/ayunis-core-frontend/src/pages/admin-settings/admin-settings-layout/ui/AdminSettingsSidebar.tsx
+++ b/ayunis-core-frontend/src/pages/admin-settings/admin-settings-layout/ui/AdminSettingsSidebar.tsx
@@ -8,6 +8,7 @@ import {
   FileText,
   Key,
   ShieldCheck,
+  MessageSquareText,
 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import {
@@ -50,6 +51,11 @@ export function AdminSettingsSidebar() {
       to: '/admin-settings/anonymization',
       icon: <ShieldCheck />,
       label: t('layout.anonymization'),
+    },
+    {
+      to: '/admin-settings/instructions',
+      icon: <MessageSquareText />,
+      label: t('layout.instructions'),
     },
     {
       to: '/admin-settings/api-keys',

--- a/ayunis-core-frontend/src/pages/admin-settings/instructions-settings/api/useOrgSystemPrompt.ts
+++ b/ayunis-core-frontend/src/pages/admin-settings/instructions-settings/api/useOrgSystemPrompt.ts
@@ -1,0 +1,77 @@
+import {
+  useOrgSystemPromptControllerGetOrgSystemPrompt,
+  useOrgSystemPromptControllerUpsertOrgSystemPrompt,
+  useOrgSystemPromptControllerDeleteOrgSystemPrompt,
+  getOrgSystemPromptControllerGetOrgSystemPromptQueryKey,
+} from '@/shared/api/generated/ayunisCoreAPI';
+import type { UpsertOrgSystemPromptDto } from '@/shared/api/generated/ayunisCoreAPI.schemas';
+import { useQueryClient } from '@tanstack/react-query';
+import { useRouter } from '@tanstack/react-router';
+import { showSuccess, showError } from '@/shared/lib/toast';
+import { useTranslation } from 'react-i18next';
+
+export function useOrgSystemPrompt() {
+  const { t } = useTranslation('admin-settings-instructions');
+  const queryClient = useQueryClient();
+  const router = useRouter();
+  const queryKey = getOrgSystemPromptControllerGetOrgSystemPromptQueryKey();
+
+  const {
+    data: orgSystemPromptResponse,
+    error,
+    isError,
+    isLoading,
+    refetch,
+  } = useOrgSystemPromptControllerGetOrgSystemPrompt();
+
+  const upsertMutation = useOrgSystemPromptControllerUpsertOrgSystemPrompt({
+    mutation: {
+      onSuccess: () => {
+        showSuccess(t('instructions.saved'));
+      },
+      onError: () => {
+        showError(t('instructions.error'));
+      },
+      onSettled: async () => {
+        await queryClient.invalidateQueries({ queryKey });
+        await router.invalidate();
+      },
+    },
+  });
+
+  const deleteMutation = useOrgSystemPromptControllerDeleteOrgSystemPrompt({
+    mutation: {
+      onSuccess: () => {
+        showSuccess(t('instructions.deleted'));
+      },
+      onError: () => {
+        showError(t('instructions.error'));
+      },
+      onSettled: async () => {
+        await queryClient.invalidateQueries({ queryKey });
+        await router.invalidate();
+      },
+    },
+  });
+
+  function upsertSystemPrompt(systemPrompt: string) {
+    const data: UpsertOrgSystemPromptDto = { systemPrompt };
+    return upsertMutation.mutate({ data });
+  }
+
+  function deleteSystemPrompt() {
+    return deleteMutation.mutate();
+  }
+
+  return {
+    systemPrompt: orgSystemPromptResponse?.systemPrompt ?? null,
+    isLoading,
+    isError,
+    error,
+    refetch,
+    isUpserting: upsertMutation.isPending,
+    isDeleting: deleteMutation.isPending,
+    upsertSystemPrompt,
+    deleteSystemPrompt,
+  };
+}

--- a/ayunis-core-frontend/src/pages/admin-settings/instructions-settings/index.ts
+++ b/ayunis-core-frontend/src/pages/admin-settings/instructions-settings/index.ts
@@ -1,0 +1,1 @@
+export { InstructionsSettingsPage } from './ui/InstructionsSettingsPage';

--- a/ayunis-core-frontend/src/pages/admin-settings/instructions-settings/ui/InstructionsSettingsPage.tsx
+++ b/ayunis-core-frontend/src/pages/admin-settings/instructions-settings/ui/InstructionsSettingsPage.tsx
@@ -1,0 +1,158 @@
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import SettingsLayout from '../../admin-settings-layout';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/shared/ui/shadcn/card';
+import { Label } from '@/shared/ui/shadcn/label';
+import { Textarea } from '@/shared/ui/shadcn/textarea';
+import { Button } from '@/shared/ui/shadcn/button';
+import { Alert, AlertDescription } from '@/shared/ui/shadcn/alert';
+import { AlertCircle, Loader2 } from 'lucide-react';
+import { useOrgSystemPrompt } from '../api/useOrgSystemPrompt';
+
+function InstructionsForm({
+  initialValue,
+  systemPrompt,
+  isUpserting,
+  isDeleting,
+  onUpsert,
+  onDelete,
+}: Readonly<{
+  initialValue: string;
+  systemPrompt: string | null;
+  isUpserting: boolean;
+  isDeleting: boolean;
+  onUpsert: (value: string) => void;
+  onDelete: () => void;
+}>) {
+  const { t } = useTranslation('admin-settings-instructions');
+  const [localValue, setLocalValue] = useState(initialValue);
+
+  const isChanged = localValue !== (systemPrompt ?? '');
+
+  const handleSave = () => {
+    if (localValue.trim()) {
+      onUpsert(localValue.trim());
+    } else {
+      onDelete();
+    }
+  };
+
+  return (
+    <div className="space-y-2">
+      <Label htmlFor="org-system-prompt-textarea">
+        {t('instructions.label')}
+      </Label>
+      <Textarea
+        id="org-system-prompt-textarea"
+        value={localValue}
+        onChange={(e) => setLocalValue(e.target.value)}
+        placeholder={t('instructions.placeholder')}
+        className="min-h-32 resize-y"
+        maxLength={10000}
+        disabled={isUpserting || isDeleting}
+      />
+      <div className="flex justify-end items-center text-sm">
+        <div className="flex gap-2">
+          {systemPrompt && (
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={onDelete}
+              disabled={isUpserting || isDeleting}
+            >
+              {isDeleting
+                ? t('instructions.deleting')
+                : t('instructions.delete')}
+            </Button>
+          )}
+          <Button
+            size="sm"
+            onClick={handleSave}
+            disabled={
+              !isChanged ||
+              isUpserting ||
+              isDeleting ||
+              (!localValue.trim() && !systemPrompt)
+            }
+          >
+            {isUpserting ? t('instructions.saving') : t('instructions.save')}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function InstructionsSettingsPage() {
+  const { t: tLayout } = useTranslation('admin-settings-layout');
+  const { t } = useTranslation('admin-settings-instructions');
+
+  const {
+    systemPrompt,
+    isLoading,
+    isError,
+    refetch,
+    isUpserting,
+    isDeleting,
+    upsertSystemPrompt,
+    deleteSystemPrompt,
+  } = useOrgSystemPrompt();
+
+  if (isError) {
+    return (
+      <SettingsLayout title={tLayout('layout.instructions')}>
+        <Card>
+          <CardContent className="pt-6">
+            <Alert variant="destructive">
+              <AlertCircle className="h-4 w-4" />
+              <AlertDescription>
+                {t('instructions.loadError')}
+                <Button
+                  variant="link"
+                  className="ml-2 h-auto p-0"
+                  onClick={() => void refetch()}
+                >
+                  {t('instructions.retry')}
+                </Button>
+              </AlertDescription>
+            </Alert>
+          </CardContent>
+        </Card>
+      </SettingsLayout>
+    );
+  }
+
+  return (
+    <SettingsLayout title={tLayout('layout.instructions')}>
+      <Card>
+        <CardHeader>
+          <CardTitle>{t('instructions.title')}</CardTitle>
+          <CardDescription>{t('instructions.description')}</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {isLoading ? (
+            <div className="flex items-center justify-center py-8">
+              <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+            </div>
+          ) : (
+            <InstructionsForm
+              key={systemPrompt ?? ''}
+              initialValue={systemPrompt ?? ''}
+              systemPrompt={systemPrompt}
+              isUpserting={isUpserting}
+              isDeleting={isDeleting}
+              onUpsert={upsertSystemPrompt}
+              onDelete={deleteSystemPrompt}
+            />
+          )}
+        </CardContent>
+      </Card>
+    </SettingsLayout>
+  );
+}

--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
@@ -4008,6 +4008,22 @@ export interface GeneratePersonalizedSystemPromptResponseDto {
   welcomeMessage: string;
 }
 
+export interface OrgSystemPromptResponseDto {
+  /**
+   * The organization-wide system prompt, or null if not set
+   * @nullable
+   */
+  systemPrompt: string | null;
+}
+
+export interface UpsertOrgSystemPromptDto {
+  /**
+   * The organization-wide system prompt
+   * @maxLength 10000
+   */
+  systemPrompt: string;
+}
+
 export interface ChatCompletionRequestDto { [key: string]: unknown }
 
 export interface LoginDto {

--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.ts
@@ -103,6 +103,7 @@ import type {
   ModelProviderInfoResponseDto,
   ModelWithConfigResponseDto,
   ModelsControllerUpdatePermittedModel200,
+  OrgSystemPromptResponseDto,
   PaginatedInvitesListResponseDto,
   PaginatedTeamMembersResponseDto,
   PaginatedUsersListResponseDto,
@@ -186,6 +187,7 @@ import type {
   UpdateUserNameDto,
   UpdateUserRoleDto,
   UploadFileResponseDto,
+  UpsertOrgSystemPromptDto,
   UpsertUserSystemPromptDto,
   UsageConfigResponseDto,
   UsageControllerGetModelDistributionParams,
@@ -15979,6 +15981,228 @@ export const useChatSettingsControllerGeneratePersonalizedSystemPrompt = <TError
       > => {
 
       const mutationOptions = getChatSettingsControllerGeneratePersonalizedSystemPromptMutationOptions(options);
+
+      return useMutation(mutationOptions, queryClient);
+    }
+    
+/**
+ * Returns the organization-wide system prompt for the admin's organization, or null if not set. Admin only.
+ * @summary Get the organization-wide system prompt
+ */
+export const orgSystemPromptControllerGetOrgSystemPrompt = (
+    
+ signal?: AbortSignal
+) => {
+      
+      
+      return customAxiosInstance<OrgSystemPromptResponseDto>(
+      {url: `/chat-settings/org-system-prompt`, method: 'GET', signal
+    },
+      );
+    }
+  
+
+
+
+export const getOrgSystemPromptControllerGetOrgSystemPromptQueryKey = () => {
+    return [
+    `/chat-settings/org-system-prompt`
+    ] as const;
+    }
+
+    
+export const getOrgSystemPromptControllerGetOrgSystemPromptQueryOptions = <TData = Awaited<ReturnType<typeof orgSystemPromptControllerGetOrgSystemPrompt>>, TError = void>( options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof orgSystemPromptControllerGetOrgSystemPrompt>>, TError, TData>>, }
+) => {
+
+const {query: queryOptions} = options ?? {};
+
+  const queryKey =  queryOptions?.queryKey ?? getOrgSystemPromptControllerGetOrgSystemPromptQueryKey();
+
+  
+
+    const queryFn: QueryFunction<Awaited<ReturnType<typeof orgSystemPromptControllerGetOrgSystemPrompt>>> = ({ signal }) => orgSystemPromptControllerGetOrgSystemPrompt(signal);
+
+      
+
+      
+
+   return  { queryKey, queryFn, ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof orgSystemPromptControllerGetOrgSystemPrompt>>, TError, TData> & { queryKey: DataTag<QueryKey, TData, TError> }
+}
+
+export type OrgSystemPromptControllerGetOrgSystemPromptQueryResult = NonNullable<Awaited<ReturnType<typeof orgSystemPromptControllerGetOrgSystemPrompt>>>
+export type OrgSystemPromptControllerGetOrgSystemPromptQueryError = void
+
+
+export function useOrgSystemPromptControllerGetOrgSystemPrompt<TData = Awaited<ReturnType<typeof orgSystemPromptControllerGetOrgSystemPrompt>>, TError = void>(
+  options: { query:Partial<UseQueryOptions<Awaited<ReturnType<typeof orgSystemPromptControllerGetOrgSystemPrompt>>, TError, TData>> & Pick<
+        DefinedInitialDataOptions<
+          Awaited<ReturnType<typeof orgSystemPromptControllerGetOrgSystemPrompt>>,
+          TError,
+          Awaited<ReturnType<typeof orgSystemPromptControllerGetOrgSystemPrompt>>
+        > , 'initialData'
+      >, }
+ , queryClient?: QueryClient
+  ):  DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useOrgSystemPromptControllerGetOrgSystemPrompt<TData = Awaited<ReturnType<typeof orgSystemPromptControllerGetOrgSystemPrompt>>, TError = void>(
+  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof orgSystemPromptControllerGetOrgSystemPrompt>>, TError, TData>> & Pick<
+        UndefinedInitialDataOptions<
+          Awaited<ReturnType<typeof orgSystemPromptControllerGetOrgSystemPrompt>>,
+          TError,
+          Awaited<ReturnType<typeof orgSystemPromptControllerGetOrgSystemPrompt>>
+        > , 'initialData'
+      >, }
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useOrgSystemPromptControllerGetOrgSystemPrompt<TData = Awaited<ReturnType<typeof orgSystemPromptControllerGetOrgSystemPrompt>>, TError = void>(
+  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof orgSystemPromptControllerGetOrgSystemPrompt>>, TError, TData>>, }
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+/**
+ * @summary Get the organization-wide system prompt
+ */
+
+export function useOrgSystemPromptControllerGetOrgSystemPrompt<TData = Awaited<ReturnType<typeof orgSystemPromptControllerGetOrgSystemPrompt>>, TError = void>(
+  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof orgSystemPromptControllerGetOrgSystemPrompt>>, TError, TData>>, }
+ , queryClient?: QueryClient 
+ ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
+
+  const queryOptions = getOrgSystemPromptControllerGetOrgSystemPromptQueryOptions(options)
+
+  const query = useQuery(queryOptions, queryClient) as  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+
+  query.queryKey = queryOptions.queryKey ;
+
+  return query;
+}
+
+
+
+
+
+/**
+ * Creates or replaces the organization-wide system prompt, which is injected into all conversations of users of the organization. Admin only.
+ * @summary Set or update the organization-wide system prompt
+ */
+export const orgSystemPromptControllerUpsertOrgSystemPrompt = (
+    upsertOrgSystemPromptDto: UpsertOrgSystemPromptDto,
+ ) => {
+      
+      
+      return customAxiosInstance<OrgSystemPromptResponseDto>(
+      {url: `/chat-settings/org-system-prompt`, method: 'PUT',
+      headers: {'Content-Type': 'application/json', },
+      data: upsertOrgSystemPromptDto
+    },
+      );
+    }
+  
+
+
+export const getOrgSystemPromptControllerUpsertOrgSystemPromptMutationOptions = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof orgSystemPromptControllerUpsertOrgSystemPrompt>>, TError,{data: UpsertOrgSystemPromptDto}, TContext>, }
+): UseMutationOptions<Awaited<ReturnType<typeof orgSystemPromptControllerUpsertOrgSystemPrompt>>, TError,{data: UpsertOrgSystemPromptDto}, TContext> => {
+
+const mutationKey = ['orgSystemPromptControllerUpsertOrgSystemPrompt'];
+const {mutation: mutationOptions} = options ?
+      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
+      options
+      : {...options, mutation: {...options.mutation, mutationKey}}
+      : {mutation: { mutationKey, }};
+
+      
+
+
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof orgSystemPromptControllerUpsertOrgSystemPrompt>>, {data: UpsertOrgSystemPromptDto}> = (props) => {
+          const {data} = props ?? {};
+
+          return  orgSystemPromptControllerUpsertOrgSystemPrompt(data,)
+        }
+
+        
+
+
+  return  { mutationFn, ...mutationOptions }}
+
+    export type OrgSystemPromptControllerUpsertOrgSystemPromptMutationResult = NonNullable<Awaited<ReturnType<typeof orgSystemPromptControllerUpsertOrgSystemPrompt>>>
+    export type OrgSystemPromptControllerUpsertOrgSystemPromptMutationBody = UpsertOrgSystemPromptDto
+    export type OrgSystemPromptControllerUpsertOrgSystemPromptMutationError = void
+
+    /**
+ * @summary Set or update the organization-wide system prompt
+ */
+export const useOrgSystemPromptControllerUpsertOrgSystemPrompt = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof orgSystemPromptControllerUpsertOrgSystemPrompt>>, TError,{data: UpsertOrgSystemPromptDto}, TContext>, }
+ , queryClient?: QueryClient): UseMutationResult<
+        Awaited<ReturnType<typeof orgSystemPromptControllerUpsertOrgSystemPrompt>>,
+        TError,
+        {data: UpsertOrgSystemPromptDto},
+        TContext
+      > => {
+
+      const mutationOptions = getOrgSystemPromptControllerUpsertOrgSystemPromptMutationOptions(options);
+
+      return useMutation(mutationOptions, queryClient);
+    }
+    
+/**
+ * Deletes the organization-wide system prompt. Admin only.
+ * @summary Delete the organization-wide system prompt
+ */
+export const orgSystemPromptControllerDeleteOrgSystemPrompt = (
+    
+ ) => {
+      
+      
+      return customAxiosInstance<void>(
+      {url: `/chat-settings/org-system-prompt`, method: 'DELETE'
+    },
+      );
+    }
+  
+
+
+export const getOrgSystemPromptControllerDeleteOrgSystemPromptMutationOptions = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof orgSystemPromptControllerDeleteOrgSystemPrompt>>, TError,void, TContext>, }
+): UseMutationOptions<Awaited<ReturnType<typeof orgSystemPromptControllerDeleteOrgSystemPrompt>>, TError,void, TContext> => {
+
+const mutationKey = ['orgSystemPromptControllerDeleteOrgSystemPrompt'];
+const {mutation: mutationOptions} = options ?
+      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
+      options
+      : {...options, mutation: {...options.mutation, mutationKey}}
+      : {mutation: { mutationKey, }};
+
+      
+
+
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof orgSystemPromptControllerDeleteOrgSystemPrompt>>, void> = () => {
+          
+
+          return  orgSystemPromptControllerDeleteOrgSystemPrompt()
+        }
+
+        
+
+
+  return  { mutationFn, ...mutationOptions }}
+
+    export type OrgSystemPromptControllerDeleteOrgSystemPromptMutationResult = NonNullable<Awaited<ReturnType<typeof orgSystemPromptControllerDeleteOrgSystemPrompt>>>
+    
+    export type OrgSystemPromptControllerDeleteOrgSystemPromptMutationError = void
+
+    /**
+ * @summary Delete the organization-wide system prompt
+ */
+export const useOrgSystemPromptControllerDeleteOrgSystemPrompt = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof orgSystemPromptControllerDeleteOrgSystemPrompt>>, TError,void, TContext>, }
+ , queryClient?: QueryClient): UseMutationResult<
+        Awaited<ReturnType<typeof orgSystemPromptControllerDeleteOrgSystemPrompt>>,
+        TError,
+        void,
+        TContext
+      > => {
+
+      const mutationOptions = getOrgSystemPromptControllerDeleteOrgSystemPromptMutationOptions(options);
 
       return useMutation(mutationOptions, queryClient);
     }

--- a/ayunis-core-frontend/src/shared/api/openapi-schema.json
+++ b/ayunis-core-frontend/src/shared/api/openapi-schema.json
@@ -7862,6 +7862,80 @@
         "tags": ["Chat Settings"]
       }
     },
+    "/chat-settings/org-system-prompt": {
+      "get": {
+        "description": "Returns the organization-wide system prompt for the admin's organization, or null if not set. Admin only.",
+        "operationId": "OrgSystemPromptController_getOrgSystemPrompt",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "The organization-wide system prompt",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OrgSystemPromptResponseDto"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "User is not an organization admin"
+          }
+        },
+        "summary": "Get the organization-wide system prompt",
+        "tags": ["Chat Settings"]
+      },
+      "put": {
+        "description": "Creates or replaces the organization-wide system prompt, which is injected into all conversations of users of the organization. Admin only.",
+        "operationId": "OrgSystemPromptController_upsertOrgSystemPrompt",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpsertOrgSystemPromptDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successfully set or updated the organization-wide system prompt",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OrgSystemPromptResponseDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request payload"
+          },
+          "403": {
+            "description": "User is not an organization admin"
+          }
+        },
+        "summary": "Set or update the organization-wide system prompt",
+        "tags": ["Chat Settings"]
+      },
+      "delete": {
+        "description": "Deletes the organization-wide system prompt. Admin only.",
+        "operationId": "OrgSystemPromptController_deleteOrgSystemPrompt",
+        "parameters": [],
+        "responses": {
+          "204": {
+            "description": "Successfully deleted the organization-wide system prompt"
+          },
+          "403": {
+            "description": "User is not an organization admin"
+          }
+        },
+        "summary": "Delete the organization-wide system prompt",
+        "tags": ["Chat Settings"]
+      }
+    },
     "/openai-compat/v1/chat/completions": {
       "post": {
         "operationId": "ChatCompletionsController_create",
@@ -14208,6 +14282,30 @@
           }
         },
         "required": ["systemPrompt", "welcomeMessage"]
+      },
+      "OrgSystemPromptResponseDto": {
+        "type": "object",
+        "properties": {
+          "systemPrompt": {
+            "type": "string",
+            "description": "The organization-wide system prompt, or null if not set",
+            "example": "All responses must comply with municipal communication guidelines.",
+            "nullable": true
+          }
+        },
+        "required": ["systemPrompt"]
+      },
+      "UpsertOrgSystemPromptDto": {
+        "type": "object",
+        "properties": {
+          "systemPrompt": {
+            "type": "string",
+            "description": "The organization-wide system prompt",
+            "example": "All responses must comply with municipal communication guidelines.",
+            "maxLength": 10000
+          }
+        },
+        "required": ["systemPrompt"]
       },
       "ChatCompletionRequestDto": {
         "type": "object",

--- a/ayunis-core-frontend/src/shared/locales/de/admin-settings-instructions.json
+++ b/ayunis-core-frontend/src/shared/locales/de/admin-settings-instructions.json
@@ -1,0 +1,17 @@
+{
+  "instructions": {
+    "title": "Organisationsweite Anweisungen",
+    "description": "Definieren Sie Anweisungen, die auf alle Unterhaltungen aller Benutzer Ihrer Organisation angewendet werden. Benutzer sehen diese Anweisungen nicht, der KI-Assistent befolgt sie jedoch in jedem Chat.",
+    "label": "Anweisungen",
+    "placeholder": "z. B. Alle Antworten müssen unseren Kommunikationsrichtlinien entsprechen. Verwenden Sie stets formelle Sprache.",
+    "save": "Speichern",
+    "saving": "Wird gespeichert...",
+    "delete": "Entfernen",
+    "deleting": "Wird entfernt...",
+    "saved": "Organisationsanweisungen gespeichert.",
+    "deleted": "Organisationsanweisungen entfernt.",
+    "error": "Organisationsanweisungen konnten nicht aktualisiert werden.",
+    "loadError": "Organisationsanweisungen konnten nicht geladen werden.",
+    "retry": "Erneut versuchen"
+  }
+}

--- a/ayunis-core-frontend/src/shared/locales/de/admin-settings-layout.json
+++ b/ayunis-core-frontend/src/shared/locales/de/admin-settings-layout.json
@@ -11,6 +11,7 @@
     "usage": "Nutzung",
     "security": "Sicherheit",
     "anonymization": "Anonymisierung",
+    "instructions": "Anweisungen",
     "letterheads": "Briefpapier",
     "apiKeys": "API-Schlüssel"
   }

--- a/ayunis-core-frontend/src/shared/locales/en/admin-settings-instructions.json
+++ b/ayunis-core-frontend/src/shared/locales/en/admin-settings-instructions.json
@@ -1,0 +1,17 @@
+{
+  "instructions": {
+    "title": "Organization-wide Instructions",
+    "description": "Define instructions that are applied to all conversations of all users in your organization. Users do not see these instructions, but the AI assistant follows them in every chat.",
+    "label": "Instructions",
+    "placeholder": "e.g. All responses must comply with our communication guidelines. Always use formal language.",
+    "save": "Save",
+    "saving": "Saving...",
+    "delete": "Remove",
+    "deleting": "Removing...",
+    "saved": "Organization instructions saved.",
+    "deleted": "Organization instructions removed.",
+    "error": "Failed to update organization instructions.",
+    "loadError": "Failed to load organization instructions.",
+    "retry": "Retry"
+  }
+}

--- a/ayunis-core-frontend/src/shared/locales/en/admin-settings-layout.json
+++ b/ayunis-core-frontend/src/shared/locales/en/admin-settings-layout.json
@@ -11,6 +11,7 @@
     "usage": "Usage",
     "security": "Security",
     "anonymization": "Anonymization",
+    "instructions": "Instructions",
     "letterheads": "Letterheads",
     "apiKeys": "API Keys"
   }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Org-wide prompts affect AI behavior for every user in the tenant; the UI relies on admin-only API enforcement (403) with no extra frontend guard visible in this diff.
> 
> **Overview**
> Adds an **admin Instructions** area at `/admin-settings/instructions` so org admins can manage organization-wide AI instructions (org system prompt) that apply to every user’s chats without users seeing the text.
> 
> The new **Instructions** settings page loads, saves, and removes the prompt via `/chat-settings/org-system-prompt` (GET/PUT/DELETE), with loading and error states, a 10k-character textarea, save/remove actions, and clearing the field on save triggers delete. A `useOrgSystemPrompt` hook wraps the generated API clients with cache invalidation, router refresh, and toasts.
> 
> Navigation and i18n are wired in: sidebar entry with **Instructions** label (EN/DE), new locale bundles, route file, and regenerated OpenAPI client types for `OrgSystemPromptResponseDto` / `UpsertOrgSystemPromptDto`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ab648caabd950f73174082b12e0e84c829f1c15. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->