### PR TITLE
fix(integrations): use marketplace config url instead of hardcoded .de domain (AYC-231)

### DIFF
--- a/ayunis-core-backend/src/domain/mcp/presenters/http/dto/mcp-integration-response.dto.ts
+++ b/ayunis-core-backend/src/domain/mcp/presenters/http/dto/mcp-integration-response.dto.ts
@@ -176,7 +176,7 @@ export class McpIntegrationResponseDto {
     description: 'Logo URL for marketplace integrations',
     type: 'string',
     nullable: true,
-    example: 'https://marketplace.ayunis.de/logos/oparl.png',
+    example: 'https://marketplace.ayunis.com/logos/oparl.png',
   })
   logoUrl?: string | null;
 

--- a/ayunis-core-backend/src/domain/threads/presenters/http/dto/get-thread-response.dto/message-response.dto.ts
+++ b/ayunis-core-backend/src/domain/threads/presenters/http/dto/get-thread-response.dto/message-response.dto.ts
@@ -42,7 +42,7 @@ export class ToolUseIntegrationDto {
 
   @ApiPropertyOptional({
     description: 'Integration logo URL',
-    example: 'https://marketplace.ayunis.de/logos/weather.png',
+    example: 'https://marketplace.ayunis.com/logos/weather.png',
     type: 'string',
     nullable: true,
   })

--- a/ayunis-core-frontend/src/pages/admin-settings/integrations-settings/ui/mcp-integrations-page.tsx
+++ b/ayunis-core-frontend/src/pages/admin-settings/integrations-settings/ui/mcp-integrations-page.tsx
@@ -25,6 +25,7 @@ import {
   ItemTitle,
 } from '@/shared/ui/shadcn/item';
 import { ComingSoonDialog } from './coming-soon-dialog';
+import { useMarketplaceConfig } from '@/features/marketplace';
 
 export function McpIntegrationsPage({
   isCloud,
@@ -170,19 +171,23 @@ function HeaderActions({
   onCreateCustom: () => void;
   t: (key: string) => string;
 }>) {
+  const marketplace = useMarketplaceConfig();
+
   return (
     <div className="flex gap-2">
       <HelpLink path="settings/admin/integrations/" />
-      <Button variant="outline" size="sm" asChild>
-        <a
-          href="https://marketplace.ayunis.de/integrations"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <ExternalLink className="h-4 w-4" />
-          {t('integrations.page.browseMarketplace')}
-        </a>
-      </Button>
+      {marketplace.enabled && marketplace.url && (
+        <Button variant="outline" size="sm" asChild>
+          <a
+            href={`${marketplace.url.replace(/\/$/, '')}/integrations`}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <ExternalLink className="h-4 w-4" />
+            {t('integrations.page.browseMarketplace')}
+          </a>
+        </Button>
+      )}
       {isCloud ? (
         <Button variant="default" size="sm" onClick={onCreatePredefined}>
           <Plus className="h-4 w-4" />

--- a/ayunis-core-frontend/src/shared/api/openapi-schema.json
+++ b/ayunis-core-frontend/src/shared/api/openapi-schema.json
@@ -10920,7 +10920,7 @@
           "logoUrl": {
             "type": "string",
             "description": "Integration logo URL",
-            "example": "https://marketplace.ayunis.de/logos/weather.png",
+            "example": "https://marketplace.ayunis.com/logos/weather.png",
             "nullable": true
           }
         },
@@ -12147,7 +12147,7 @@
             "type": "string",
             "description": "Logo URL for marketplace integrations",
             "nullable": true,
-            "example": "https://marketplace.ayunis.de/logos/oparl.png"
+            "example": "https://marketplace.ayunis.com/logos/oparl.png"
           },
           "description": {
             "type": "string",


### PR DESCRIPTION
- browse-marketplace button on the admin integrations page now builds
  its link from the backend-provided marketplace config (.com in
  production) and hides when the marketplace is disabled, matching
  every other marketplace entry point
- fix .de -> .com in logoUrl api doc examples and regenerate the
  frontend openapi schema

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI link and documentation examples only; no runtime API or auth behavior changes.
> 
> **Overview**
> The admin integrations **Browse marketplace** link no longer uses a hardcoded `marketplace.ayunis.de` URL. It now uses `useMarketplaceConfig()` to build `{marketplace.url}/integrations` and only renders when the marketplace is enabled and a URL is configured, consistent with other marketplace entry points.
> 
> OpenAPI/Swagger **examples** for integration `logoUrl` fields are updated from `marketplace.ayunis.de` to `marketplace.ayunis.com` in the backend DTOs, with the frontend `openapi-schema.json` regenerated to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit deda413279fe5e5a622721ed6bd672c65d450f7c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->