### PR TITLE
feat(webhooks): enrich usage.collected with user email and name (AYC-88)

### DIFF
--- a/ayunis-core-backend/src/integrations/webhooks/domain/webhook-events/usage-collected.webhook-event.ts
+++ b/ayunis-core-backend/src/integrations/webhooks/domain/webhook-events/usage-collected.webhook-event.ts
@@ -1,6 +1,7 @@
 import type { UUID } from 'crypto';
 import type { Usage } from 'src/domain/usage/domain/usage.entity';
 import type { ModelProvider } from 'src/domain/models/domain/value-objects/model-provider.enum';
+import type { User } from 'src/iam/users/domain/user.entity';
 import { WebhookEvent } from '../webhook-event.entity';
 import { WebhookEventType } from '../value-objects/webhook-event-type.enum';
 
@@ -18,6 +19,13 @@ export interface UsageCollectedWebhookPayload {
   creditsConsumed?: number;
   requestId: UUID;
   createdAt: string;
+  /**
+   * Present when the usage was triggered by a user (not an API key) and the
+   * user could be resolved. Lets receivers lazily create the user in
+   * external systems without calling back into Ayunis Core.
+   */
+  userEmail?: string;
+  userName?: string;
 }
 
 export class UsageCollectedWebhookEvent extends WebhookEvent<UsageCollectedWebhookPayload> {
@@ -25,7 +33,7 @@ export class UsageCollectedWebhookEvent extends WebhookEvent<UsageCollectedWebho
   readonly data: UsageCollectedWebhookPayload;
   readonly timestamp: Date;
 
-  constructor(usage: Usage, modelName: string) {
+  constructor(usage: Usage, modelName: string, user?: User | null) {
     super();
     this.eventType = WebhookEventType.USAGE_COLLECTED;
     this.data = {
@@ -42,6 +50,8 @@ export class UsageCollectedWebhookEvent extends WebhookEvent<UsageCollectedWebho
       creditsConsumed: usage.creditsConsumed,
       requestId: usage.requestId,
       createdAt: usage.createdAt.toISOString(),
+      userEmail: user?.email,
+      userName: user?.name,
     };
     this.timestamp = new Date();
   }

--- a/ayunis-core-backend/src/integrations/webhooks/listeners/webhook-dispatch.listener.spec.ts
+++ b/ayunis-core-backend/src/integrations/webhooks/listeners/webhook-dispatch.listener.spec.ts
@@ -20,6 +20,7 @@ import { SubscriptionType } from 'src/iam/subscriptions/domain/value-objects/sub
 import { RenewalCycle } from 'src/iam/subscriptions/domain/value-objects/renewal-cycle.enum';
 import { UserRole } from 'src/iam/users/domain/value-objects/role.object';
 import type { SendWebhookUseCase } from '../application/use-cases/send-webhook/send-webhook.use-case';
+import type { UsageCollectedWebhookPayload } from '../domain/webhook-events/usage-collected.webhook-event';
 import type { FindUserByIdUseCase } from 'src/iam/users/application/use-cases/find-user-by-id/find-user-by-id.use-case';
 import type { ConfigService } from '@nestjs/config';
 import type { SeatBasedSubscriptionEventData } from 'src/iam/subscriptions/application/events/subscription-event-data.types';
@@ -242,21 +243,25 @@ describe('WebhookDispatchListener', () => {
   });
 
   describe('handleUsageCollected', () => {
-    it('should dispatch UsageCollectedWebhookEvent with the model name and ISO createdAt', async () => {
-      const usage = new Usage({
-        id: '00000000-0000-0000-0000-000000000099' as UUID,
-        userId: USER_ID,
+    function makeUsage(userId: UUID | null = USER_ID): Usage {
+      return new Usage({
+        id: '00000000-0000-0000-0000-000000000099',
+        userId,
         organizationId: ORG_ID,
-        modelId: '00000000-0000-0000-0000-0000000000aa' as UUID,
+        modelId: '00000000-0000-0000-0000-0000000000aa',
         provider: ModelProvider.OPENAI,
         inputTokens: 100,
         outputTokens: 50,
         totalTokens: 150,
         cost: 0.0012,
         creditsConsumed: 0.12,
-        requestId: '00000000-0000-0000-0000-0000000000bb' as UUID,
+        requestId: '00000000-0000-0000-0000-0000000000bb',
         createdAt: new Date('2026-04-07T12:00:00.000Z'),
       });
+    }
+
+    it('should dispatch UsageCollectedWebhookEvent with the model name and ISO createdAt', async () => {
+      const usage = makeUsage();
 
       await listener.handleUsageCollected(
         new UsageCollectedEvent(usage, 'gpt-4o-mini'),
@@ -283,11 +288,71 @@ describe('WebhookDispatchListener', () => {
         }),
       );
     });
+
+    it('should enrich the payload with user email and name', async () => {
+      await listener.handleUsageCollected(
+        new UsageCollectedEvent(makeUsage(), 'gpt-4o-mini'),
+      );
+
+      const command = sendWebhookUseCase.execute.mock.calls[0][0];
+      expect(command.event.data).toEqual(
+        expect.objectContaining({
+          userEmail: 'test@example.com',
+          userName: 'Test User',
+        }),
+      );
+    });
+
+    it('should dispatch unenriched without a user lookup for API-key usage (null userId)', async () => {
+      await listener.handleUsageCollected(
+        new UsageCollectedEvent(makeUsage(null), 'gpt-4o-mini'),
+      );
+
+      expect(findUserByIdUseCase.execute).not.toHaveBeenCalled();
+      expect(sendWebhookUseCase.execute).toHaveBeenCalledTimes(1);
+      const command = sendWebhookUseCase.execute.mock.calls[0][0];
+      const data = command.event.data as UsageCollectedWebhookPayload;
+      expect(data.userId).toBeNull();
+      expect(data.userEmail).toBeUndefined();
+      expect(data.userName).toBeUndefined();
+    });
+
+    it('should dispatch unenriched when the user lookup fails', async () => {
+      findUserByIdUseCase.execute.mockRejectedValue(
+        new Error('User not found'),
+      );
+
+      await listener.handleUsageCollected(
+        new UsageCollectedEvent(makeUsage(), 'gpt-4o-mini'),
+      );
+
+      expect(sendWebhookUseCase.execute).toHaveBeenCalledTimes(1);
+      const command = sendWebhookUseCase.execute.mock.calls[0][0];
+      const data = command.event.data as UsageCollectedWebhookPayload;
+      expect(data.userEmail).toBeUndefined();
+      expect(data.userName).toBeUndefined();
+    });
+
+    it('should skip the user lookup when no webhook url is configured', async () => {
+      configService.get.mockReturnValue(undefined);
+
+      await listener.handleUsageCollected(
+        new UsageCollectedEvent(makeUsage(), 'gpt-4o-mini'),
+      );
+
+      expect(findUserByIdUseCase.execute).not.toHaveBeenCalled();
+      expect(sendWebhookUseCase.execute).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('handleUserMessageCreated', () => {
     function makeEvent(): UserMessageCreatedEvent {
-      return new UserMessageCreatedEvent(USER_ID, ORG_ID, THREAD_ID, MESSAGE_ID);
+      return new UserMessageCreatedEvent(
+        USER_ID,
+        ORG_ID,
+        THREAD_ID,
+        MESSAGE_ID,
+      );
     }
 
     it('should dispatch ChatSentWebhookEvent enriched with user email and name', async () => {

--- a/ayunis-core-backend/src/integrations/webhooks/listeners/webhook-dispatch.listener.ts
+++ b/ayunis-core-backend/src/integrations/webhooks/listeners/webhook-dispatch.listener.ts
@@ -127,8 +127,14 @@ export class WebhookDispatchListener {
 
   @OnEvent(UsageCollectedEvent.EVENT_NAME)
   async handleUsageCollected(event: UsageCollectedEvent): Promise<void> {
+    // API-key usage has no user; the event is still dispatched unenriched —
+    // receivers decide whether unattributed usage is relevant to them.
+    const user =
+      event.usage.userId && this.webhookConfigured()
+        ? await this.resolveUser(event.usage.userId)
+        : null;
     await this.dispatch(
-      new UsageCollectedWebhookEvent(event.usage, event.modelName),
+      new UsageCollectedWebhookEvent(event.usage, event.modelName, user),
     );
   }
 
@@ -138,7 +144,7 @@ export class WebhookDispatchListener {
   ): Promise<void> {
     // Skip the per-message user lookup entirely when no webhook receiver is
     // configured — this handler fires for every chat message.
-    if (!this.configService.get<string>('app.orgEventsWebhookUrl')) {
+    if (!this.webhookConfigured()) {
       return;
     }
     const user = await this.resolveUser(event.userId);
@@ -146,6 +152,10 @@ export class WebhookDispatchListener {
       return;
     }
     await this.dispatch(new ChatSentWebhookEvent(event, user));
+  }
+
+  private webhookConfigured(): boolean {
+    return !!this.configService.get<string>('app.orgEventsWebhookUrl');
   }
 
   /**


### PR DESCRIPTION
- UsageCollectedWebhookPayload gains optional userEmail/userName so
  receivers (Startdeliver via ayunis-core-connect) can lazily create
  users in external systems without calling back into core
- API-key usage (null userId) is still dispatched, just unenriched —
  core emits domain facts, consumers decide what to drop
- User lookup is skipped when no webhook URL is configured; lookup
  failures degrade to an unenriched payload

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Optional PII on an existing webhook event with graceful degradation; no auth or persistence changes, but receivers should treat new fields as part of the contract.
> 
> **Overview**
> **`usage.collected` webhooks** can now carry optional **`userEmail`** and **`userName`** when usage is tied to a user and that user resolves successfully, so downstream systems can provision users without calling back into Core.
> 
> `handleUsageCollected` performs a best-effort user lookup (same `resolveUser` path as chat webhooks) only when `usage.userId` is set and `app.orgEventsWebhookUrl` is configured; API-key usage (`null` userId) still fires the webhook without enrichment, and lookup failures leave the payload without those fields. Webhook URL checks are centralized in a new **`webhookConfigured()`** helper (also used by `handleUserMessageCreated`).
> 
> Specs cover enrichment, API-key usage, failed lookup, and skipping lookup when no webhook URL is set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc0c074fb6a222e4604e4b2ac8aac4be80006cbf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->