### PR TITLE
wip(agent-runtime): add core contracts and run context (AYC-148)

### DIFF
--- a/packages/agent-runtime/.madgerc
+++ b/packages/agent-runtime/.madgerc
@@ -1,0 +1,7 @@
+{
+  "detectiveOptions": {
+    "ts": {
+      "skipTypeImports": true
+    }
+  }
+}

--- a/packages/agent-runtime/src/context/run-context.spec.ts
+++ b/packages/agent-runtime/src/context/run-context.spec.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest';
+
+import { RunContext } from './run-context';
+
+describe('RunContext', () => {
+  it('creates a root context with depth 0 and a single-entry path', () => {
+    const context = RunContext.create();
+
+    expect(context.depth).toBe(0);
+    expect(context.path).toEqual([context.runId]);
+  });
+
+  it('stores initial values and reads them back', () => {
+    const context = RunContext.create({ orgId: 'org-1', userId: 'user-1' });
+
+    expect(context.get<string>('orgId')).toBe('org-1');
+    expect(context.get<string>('userId')).toBe('user-1');
+    expect(context.has('orgId')).toBe(true);
+  });
+
+  it('returns undefined for unknown keys', () => {
+    const context = RunContext.create();
+
+    expect(context.get('missing')).toBeUndefined();
+    expect(context.has('missing')).toBe(false);
+  });
+
+  it('supports symbol keys', () => {
+    const key = Symbol('masks');
+    const context = RunContext.create();
+    context.set(key, ['a', 'b']);
+
+    expect(context.get<string[]>(key)).toEqual(['a', 'b']);
+  });
+
+  it('overwrites values on set', () => {
+    const context = RunContext.create({ count: 1 });
+    context.set('count', 2);
+
+    expect(context.get<number>('count')).toBe(2);
+  });
+
+  it('isolates values between independent contexts', () => {
+    const a = RunContext.create({ tenant: 'a' });
+    const b = RunContext.create({ tenant: 'b' });
+
+    expect(a.get('tenant')).toBe('a');
+    expect(b.get('tenant')).toBe('b');
+    expect(a.runId).not.toBe(b.runId);
+  });
+
+  describe('deriveChild', () => {
+    it('increments depth and extends the path', () => {
+      const parent = RunContext.create();
+      const child = parent.deriveChild();
+      const grandchild = child.deriveChild();
+
+      expect(child.depth).toBe(1);
+      expect(child.path).toEqual([parent.runId, child.runId]);
+      expect(grandchild.depth).toBe(2);
+      expect(grandchild.path).toEqual([
+        parent.runId,
+        child.runId,
+        grandchild.runId,
+      ]);
+    });
+
+    it('reads parent values through the child', () => {
+      const parent = RunContext.create({ orgId: 'org-1' });
+      const child = parent.deriveChild();
+
+      expect(child.get<string>('orgId')).toBe('org-1');
+      expect(child.has('orgId')).toBe(true);
+    });
+
+    it('keeps child writes local to the child', () => {
+      const parent = RunContext.create({ orgId: 'org-1' });
+      const child = parent.deriveChild();
+      child.set('masks', ['m1']);
+
+      expect(child.get<string[]>('masks')).toEqual(['m1']);
+      expect(parent.get('masks')).toBeUndefined();
+      expect(parent.has('masks')).toBe(false);
+    });
+
+    it('shadows parent values without mutating the parent', () => {
+      const parent = RunContext.create({ orgId: 'org-1' });
+      const child = parent.deriveChild();
+      child.set('orgId', 'org-2');
+
+      expect(child.get<string>('orgId')).toBe('org-2');
+      expect(parent.get<string>('orgId')).toBe('org-1');
+    });
+
+    it('sees parent writes made after derivation (read-through)', () => {
+      const parent = RunContext.create();
+      const child = parent.deriveChild();
+      parent.set('lateValue', 42);
+
+      expect(child.get<number>('lateValue')).toBe(42);
+    });
+  });
+});

--- a/packages/agent-runtime/src/context/run-context.ts
+++ b/packages/agent-runtime/src/context/run-context.ts
@@ -1,0 +1,58 @@
+/**
+ * Explicit, per-run key/value bag threaded through every hook and tool
+ * execution. Replaces implicit request-context mechanisms (e.g. CLS) in
+ * hosts. The runtime core never reads it — only host-written hooks and
+ * tools do, which is what keeps multi-tenancy out of the core.
+ *
+ * Reads fall through to the parent context (a subagent inherits identity
+ * like orgId/userId); writes stay local (a child's state never pollutes
+ * the parent).
+ */
+export class RunContext {
+  readonly runId: string;
+  readonly depth: number;
+  readonly path: readonly string[];
+
+  private readonly values = new Map<string | symbol, unknown>();
+  private readonly parent?: RunContext;
+
+  private constructor(parent?: RunContext) {
+    this.runId = crypto.randomUUID();
+    this.parent = parent;
+    this.depth = parent ? parent.depth + 1 : 0;
+    this.path = parent ? [...parent.path, this.runId] : [this.runId];
+  }
+
+  static create(initial?: Record<string, unknown>): RunContext {
+    const context = new RunContext();
+    if (initial) {
+      for (const [key, value] of Object.entries(initial)) {
+        context.set(key, value);
+      }
+    }
+    return context;
+  }
+
+  get<T>(key: string | symbol): T | undefined {
+    if (this.values.has(key)) {
+      return this.values.get(key) as T;
+    }
+    return this.parent?.get<T>(key);
+  }
+
+  has(key: string | symbol): boolean {
+    return this.values.has(key) || (this.parent?.has(key) ?? false);
+  }
+
+  set<T>(key: string | symbol, value: T): void {
+    this.values.set(key, value);
+  }
+
+  /**
+   * Reserved subagent seam: derives a child context that inherits this
+   * context's values via read-through while keeping its own writes local.
+   */
+  deriveChild(): RunContext {
+    return new RunContext(this);
+  }
+}

--- a/packages/agent-runtime/src/contracts/errors.ts
+++ b/packages/agent-runtime/src/contracts/errors.ts
@@ -1,0 +1,50 @@
+export class AgentRuntimeError extends Error {
+  readonly code: string;
+  readonly details?: Readonly<Record<string, unknown>>;
+
+  constructor(
+    code: string,
+    message: string,
+    options?: {
+      details?: Readonly<Record<string, unknown>>;
+      cause?: unknown;
+    },
+  ) {
+    super(message, { cause: options?.cause });
+    this.name = new.target.name;
+    this.code = code;
+    this.details = options?.details;
+  }
+}
+
+/** Thrown synchronously by run() on invalid input — the only throwing path. */
+export class InvalidRunInputError extends AgentRuntimeError {
+  constructor(message: string, details?: Readonly<Record<string, unknown>>) {
+    super('INVALID_INPUT', message, { details });
+  }
+}
+
+/** Surfaced as an `error` event + `run_end { status: 'max_iterations' }`. */
+export class MaxIterationsError extends AgentRuntimeError {
+  constructor(maxIterations: number) {
+    super(
+      'MAX_ITERATIONS_REACHED',
+      `Run reached the maximum of ${maxIterations} iterations`,
+      { details: { maxIterations } },
+    );
+  }
+}
+
+/** Surfaced as `run_end { status: 'aborted' }`. */
+export class RunAbortedError extends AgentRuntimeError {
+  constructor(reason?: string) {
+    super('RUN_ABORTED', reason ?? 'Run aborted');
+  }
+}
+
+/** Wraps model provider failures; surfaced as an `error` event. */
+export class ProviderError extends AgentRuntimeError {
+  constructor(message: string, cause?: unknown) {
+    super('PROVIDER_FAILED', message, { cause });
+  }
+}

--- a/packages/agent-runtime/src/contracts/event.ts
+++ b/packages/agent-runtime/src/contracts/event.ts
@@ -1,0 +1,53 @@
+import type { AssistantMessage, Message } from './message';
+import type { Usage } from './provider';
+
+/**
+ * Every event carries the nesting envelope so consumers can attribute
+ * events to nested (subagent) runs or flatten them. `depth` is 0 for the
+ * root run; `path` lists run ids from root to the emitting run.
+ */
+export interface RunEventEnvelope {
+  runId: string;
+  depth: number;
+  path: readonly string[];
+  timestamp: string;
+}
+
+export type RunStatus = 'completed' | 'aborted' | 'max_iterations' | 'error';
+
+/** Input to `emit` from hooks and tools; becomes a `custom` RunEvent. */
+export interface CustomEventInput {
+  name: string;
+  data: unknown;
+}
+
+export interface ToolCallSummary {
+  id: string;
+  name: string;
+  input: Record<string, unknown>;
+}
+
+export type RunEventPayload =
+  | { type: 'run_start'; maxIterations: number }
+  | { type: 'text_delta'; delta: string }
+  | { type: 'thinking_delta'; delta: string }
+  | { type: 'tool_call'; toolCall: ToolCallSummary }
+  | { type: 'assistant_message'; message: AssistantMessage; usage?: Usage }
+  | {
+      type: 'tool_result';
+      toolCallId: string;
+      toolName: string;
+      result: string;
+      isError: boolean;
+    }
+  | { type: 'tool_result_message'; message: Message }
+  | { type: 'custom'; name: string; data: unknown }
+  | {
+      type: 'error';
+      code: string;
+      message: string;
+      details?: Readonly<Record<string, unknown>>;
+    }
+  | { type: 'run_end'; status: RunStatus; usage: Usage };
+
+export type RunEvent = RunEventEnvelope & RunEventPayload;

--- a/packages/agent-runtime/src/contracts/hook.ts
+++ b/packages/agent-runtime/src/contracts/hook.ts
@@ -1,0 +1,87 @@
+import type { RunContext } from '../context/run-context';
+import type { AgentRuntimeError } from './errors';
+import type { CustomEventInput, RunStatus, ToolCallSummary } from './event';
+import type { AssistantMessage, Message } from './message';
+import type { FinishReason, Usage } from './provider';
+import type { Tool } from './tool';
+
+/**
+ * The mutation API available to every hook phase. Tool/instruction/message
+ * mutations are buffered and applied at the next provider-request assembly
+ * (which happens after `beforeModelCall` fires): mutations made in
+ * `runStart`/`beforeModelCall` affect the imminent model call; mutations
+ * made in `afterModelCall`/`afterToolCall` affect the next iteration.
+ * `abort` and `emit` take effect immediately.
+ */
+export interface HookApi {
+  readonly context: RunContext;
+  transformMessages(fn: (messages: readonly Message[]) => Message[]): void;
+  addTools(...tools: Tool[]): void;
+  removeTools(...names: string[]): void;
+  /** Full-replace escape hatch (e.g. re-assembling the whole tool set). */
+  setTools(tools: Tool[]): void;
+  addInstructions(text: string): void;
+  /** Ends the run with status 'aborted' before the next loop step. */
+  abort(reason?: string): void;
+  /** Emits a `custom` RunEvent into the run's event stream. */
+  emit(event: CustomEventInput): void;
+}
+
+export interface RunStartContext extends HookApi {
+  readonly messages: readonly Message[];
+  readonly instructions: string;
+  readonly tools: readonly Tool[];
+}
+
+export interface BeforeModelCallContext extends HookApi {
+  readonly iteration: number;
+  readonly messages: readonly Message[];
+  readonly tools: readonly Tool[];
+}
+
+export interface AfterModelCallContext extends HookApi {
+  readonly iteration: number;
+  readonly message: AssistantMessage;
+  readonly usage: Usage;
+  readonly finishReason: FinishReason;
+}
+
+export interface BeforeToolCallContext extends HookApi {
+  readonly iteration: number;
+  readonly toolCall: ToolCallSummary;
+  /** Undefined when the model called a tool that is not in the tool set. */
+  readonly tool: Tool | undefined;
+  /** Rewrites THIS tool call before execution (same-phase mutation). */
+  rewriteToolCall(patch: {
+    name?: string;
+    input?: Record<string, unknown>;
+  }): void;
+}
+
+export interface AfterToolCallContext extends HookApi {
+  readonly iteration: number;
+  readonly toolCall: ToolCallSummary;
+  readonly result: string;
+  readonly isError: boolean;
+}
+
+export interface RunEndContext extends HookApi {
+  readonly messages: readonly Message[];
+  readonly status: RunStatus;
+  readonly error?: AgentRuntimeError;
+}
+
+/**
+ * The single extension mechanism. Hooks fire in registration order and are
+ * awaited sequentially. Hooks inherit downward to child (subagent) runs by
+ * default.
+ */
+export interface Hook {
+  readonly name: string;
+  runStart?(ctx: RunStartContext): void | Promise<void>;
+  beforeModelCall?(ctx: BeforeModelCallContext): void | Promise<void>;
+  afterModelCall?(ctx: AfterModelCallContext): void | Promise<void>;
+  beforeToolCall?(ctx: BeforeToolCallContext): void | Promise<void>;
+  afterToolCall?(ctx: AfterToolCallContext): void | Promise<void>;
+  runEnd?(ctx: RunEndContext): void | Promise<void>;
+}

--- a/packages/agent-runtime/src/contracts/message.ts
+++ b/packages/agent-runtime/src/contracts/message.ts
@@ -1,0 +1,53 @@
+/**
+ * Opaque provider-specific metadata carried through chunks and message
+ * content so reasoning models round-trip correctly (e.g. Anthropic thinking
+ * signatures, OpenAI reasoning block ids, Gemini thought signatures).
+ * The runtime never inspects it.
+ */
+export type ProviderMetadata = Readonly<Record<string, unknown>> | null;
+
+export interface TextContent {
+  type: 'text';
+  text: string;
+  providerMetadata?: ProviderMetadata;
+}
+
+export interface ThinkingContent {
+  type: 'thinking';
+  thinking: string;
+  id?: string | null;
+  signature?: string | null;
+}
+
+export interface ToolUseContent {
+  type: 'tool_use';
+  id: string;
+  name: string;
+  input: Record<string, unknown>;
+  providerMetadata?: ProviderMetadata;
+}
+
+export interface ToolResultContent {
+  type: 'tool_result';
+  toolCallId: string;
+  toolName: string;
+  result: string;
+  isError?: boolean;
+}
+
+export type MessageContent =
+  | TextContent
+  | ThinkingContent
+  | ToolUseContent
+  | ToolResultContent;
+
+export type MessageRole = 'user' | 'assistant' | 'tool_result';
+
+export interface Message {
+  role: MessageRole;
+  content: MessageContent[];
+}
+
+export interface AssistantMessage extends Message {
+  role: 'assistant';
+}

--- a/packages/agent-runtime/src/contracts/provider.ts
+++ b/packages/agent-runtime/src/contracts/provider.ts
@@ -1,0 +1,57 @@
+import type { Message, ProviderMetadata } from './message';
+import type { ToolSchema } from './tool';
+
+export type ToolChoice = 'auto' | 'required' | { tool: string };
+
+export type FinishReason = 'stop' | 'length' | 'tool_calls' | null;
+
+export interface Usage {
+  inputTokens?: number;
+  outputTokens?: number;
+}
+
+export interface ToolCallDelta {
+  /** Index of the tool call within the assistant message. */
+  index: number;
+  id?: string | null;
+  name?: string | null;
+  /** Partial JSON of the tool call arguments. */
+  argumentsDelta?: string | null;
+  providerMetadata?: ProviderMetadata;
+}
+
+/**
+ * Provider-agnostic streaming chunk. Each chunk may carry any combination
+ * of facets; absent/null facets mean "nothing for this facet in this
+ * chunk".
+ */
+export interface ProviderChunk {
+  thinkingDelta?: string | null;
+  thinkingId?: string | null;
+  thinkingSignature?: string | null;
+  textDelta?: string | null;
+  textProviderMetadata?: ProviderMetadata;
+  toolCallDeltas?: ToolCallDelta[];
+  finishReason?: FinishReason;
+  usage?: Usage;
+}
+
+export interface ProviderRequest {
+  instructions: string;
+  messages: readonly Message[];
+  tools: readonly ToolSchema[];
+  toolChoice?: ToolChoice;
+  signal?: AbortSignal;
+}
+
+/**
+ * The runtime's one hard port: how to stream a model response. The package
+ * ships implementations (Anthropic, mock); hosts may bring their own. The
+ * host supplies a resolved instance — model selection and credentials are
+ * host concerns.
+ */
+export interface ModelProvider {
+  /** Identifying name, e.g. 'anthropic:claude-sonnet-4-5'. */
+  readonly name: string;
+  stream(request: ProviderRequest): AsyncIterable<ProviderChunk>;
+}

--- a/packages/agent-runtime/src/contracts/run-input.ts
+++ b/packages/agent-runtime/src/contracts/run-input.ts
@@ -1,0 +1,35 @@
+import type { RunContext } from '../context/run-context';
+import type { Hook } from './hook';
+import type { Message } from './message';
+import type { ModelProvider, ToolChoice } from './provider';
+import type { Tool } from './tool';
+
+export const DEFAULT_MAX_ITERATIONS = 20;
+
+/**
+ * Everything a run needs, passed flat — there is no runtime object and no
+ * initialization step. The host resolves model selection/credentials and
+ * concrete tools before calling run().
+ */
+export interface RunInput {
+  /** System instructions (the host assembles the content). */
+  instructions: string;
+  /** A resolved model provider instance. */
+  model: ModelProvider;
+  tools?: Tool[];
+  messages: Message[];
+  hooks?: Hook[];
+  /** Omit for a fresh root context. */
+  context?: RunContext;
+  signal?: AbortSignal;
+  /** Default: 20. */
+  maxIterations?: number;
+  toolChoice?: ToolChoice;
+}
+
+/**
+ * Input for a child (subagent) run via ToolExecutionContext.runChild.
+ * The child context is derived automatically; hooks are inherited from
+ * the parent unless explicitly overridden.
+ */
+export type ChildRunInput = Omit<RunInput, 'context'>;

--- a/packages/agent-runtime/src/contracts/tool.ts
+++ b/packages/agent-runtime/src/contracts/tool.ts
@@ -1,0 +1,41 @@
+import type { RunContext } from '../context/run-context';
+import type { CustomEventInput, RunEvent } from './event';
+import type { ChildRunInput } from './run-input';
+
+/** Minimal JSON Schema shape; tools declare their parameters with it. */
+export type JsonSchema = Readonly<Record<string, unknown>>;
+
+/** The schema-only view of a tool — what gets sent to the model. */
+export interface ToolSchema {
+  name: string;
+  description: string;
+  parameters: JsonSchema;
+}
+
+export interface ToolExecutionContext {
+  /** The run's context bag (host data: tenancy, identity, per-run state). */
+  readonly context: RunContext;
+  readonly toolCallId: string;
+  readonly signal?: AbortSignal;
+  /** Emits a `custom` RunEvent into the run's event stream. */
+  emit(event: CustomEventInput): void;
+  /**
+   * Reserved subagent seam: re-enters the loop with a derived child
+   * context; parent hooks are inherited unless overridden in the input.
+   */
+  runChild(input: ChildRunInput): AsyncIterable<RunEvent>;
+}
+
+/**
+ * A concrete, executable tool. Tools are pure signals: they never inject
+ * instructions or tools — only hooks do.
+ *
+ * A tool without `execute` is display-only: the model calling it ends the
+ * loop (the call is surfaced to the consumer instead of being executed).
+ */
+export interface Tool extends ToolSchema {
+  execute?(
+    input: Record<string, unknown>,
+    ctx: ToolExecutionContext,
+  ): string | Promise<string>;
+}

--- a/packages/agent-runtime/src/index.ts
+++ b/packages/agent-runtime/src/index.ts
@@ -1,1 +1,54 @@
-export {};
+export type {
+  AssistantMessage,
+  Message,
+  MessageContent,
+  MessageRole,
+  ProviderMetadata,
+  TextContent,
+  ThinkingContent,
+  ToolResultContent,
+  ToolUseContent,
+} from './contracts/message';
+export type {
+  JsonSchema,
+  Tool,
+  ToolExecutionContext,
+  ToolSchema,
+} from './contracts/tool';
+export type {
+  FinishReason,
+  ModelProvider,
+  ProviderChunk,
+  ProviderRequest,
+  ToolCallDelta,
+  ToolChoice,
+  Usage,
+} from './contracts/provider';
+export type {
+  AfterModelCallContext,
+  AfterToolCallContext,
+  BeforeModelCallContext,
+  BeforeToolCallContext,
+  Hook,
+  HookApi,
+  RunEndContext,
+  RunStartContext,
+} from './contracts/hook';
+export type {
+  CustomEventInput,
+  RunEvent,
+  RunEventEnvelope,
+  RunEventPayload,
+  RunStatus,
+  ToolCallSummary,
+} from './contracts/event';
+export type { ChildRunInput, RunInput } from './contracts/run-input';
+export { DEFAULT_MAX_ITERATIONS } from './contracts/run-input';
+export {
+  AgentRuntimeError,
+  InvalidRunInputError,
+  MaxIterationsError,
+  ProviderError,
+  RunAbortedError,
+} from './contracts/errors';
+export { RunContext } from './context/run-context';


### PR DESCRIPTION
- contracts: Message/content union with opaque providerMetadata, Tool
  (+ display-only signal tools, ToolExecutionContext with runChild
  subagent seam), ModelProvider/ProviderRequest/ProviderChunk, Hook with
  six phases and buffered mutation API (incl. setTools and emit),
  RunEvent union with nesting envelope + custom events, typed errors
- RunContext: explicit per-run bag replacing CLS-style context;
  read-through deriveChild for subagent inheritance with local writes
- madge configured to skip type-only imports (erased at compile time)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New package scaffolding and types only; no runtime loop or production integration yet.
> 
> **Overview**
> Introduces the **public API surface** for `packages/agent-runtime`: typed contracts for messages, tools, streaming providers, hooks, run events, errors, and flat `RunInput` / `ChildRunInput`—replacing the package’s empty stub export.
> 
> **`RunContext`** is the concrete per-run key/value bag (with `runId`, `depth`, `path`) meant to replace CLS-style implicit context in hosts. It supports read-through inheritance via **`deriveChild()`** for nested subagent runs while keeping writes local; behavior is covered by new Vitest specs.
> 
> Contract highlights: **messages** with reasoning-friendly opaque `providerMetadata`; **tools** with optional `execute`, display-only tools without handlers, and a **`runChild`** seam on `ToolExecutionContext`; **hooks** across six phases with a buffered mutation API (`transformMessages`, tool/instruction changes, `rewriteToolCall`, immediate `abort`/`emit`); **run events** as a discriminated union with a nesting envelope and **`custom`** events; **typed errors** aligned with event/`run_end` statuses.
> 
> Also adds **`.madgerc`** so dependency analysis skips type-only imports.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dba5c9bc8e0ed1a307934414c8d339e7266681b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->