### PR TITLE
wip(agent-runtime): implement the agent loop, hook engine, and mock provider (AYC-148)

### DIFF
--- a/packages/agent-runtime/knip.json
+++ b/packages/agent-runtime/knip.json
@@ -2,5 +2,5 @@
   "$schema": "https://unpkg.com/knip@latest/schema.json",
   "entry": ["src/index.ts", "examples/*.ts"],
   "project": ["src/**/*.ts", "examples/**/*.ts"],
-  "ignore": ["**/*.spec.ts"]
+  "ignore": ["**/*.spec.ts", "src/engine/test-helpers.ts"]
 }

--- a/packages/agent-runtime/src/contracts/errors.ts
+++ b/packages/agent-runtime/src/contracts/errors.ts
@@ -48,3 +48,22 @@ export class ProviderError extends AgentRuntimeError {
     super('PROVIDER_FAILED', message, { cause });
   }
 }
+
+/**
+ * Wraps a hook failure with the hook's name and the phase it failed in,
+ * so multi-hook runs stay debuggable; surfaced as an `error` event.
+ */
+export class HookFailedError extends AgentRuntimeError {
+  constructor(options: { hookName: string; phase: string; cause: unknown }) {
+    const reason =
+      options.cause instanceof Error ? options.cause.message : 'unknown error';
+    super(
+      'HOOK_FAILED',
+      `Hook '${options.hookName}' failed in ${options.phase}: ${reason}`,
+      {
+        details: { hookName: options.hookName, phase: options.phase },
+        cause: options.cause,
+      },
+    );
+  }
+}

--- a/packages/agent-runtime/src/contracts/hook.ts
+++ b/packages/agent-runtime/src/contracts/hook.ts
@@ -49,7 +49,10 @@ export interface AfterModelCallContext extends HookApi {
 export interface BeforeToolCallContext extends HookApi {
   readonly iteration: number;
   readonly toolCall: ToolCallSummary;
-  /** Undefined when the model called a tool that is not in the tool set. */
+  /**
+   * The definition matching toolCall.name, including rewrites by earlier
+   * hooks. Undefined when that name is not in the tool set.
+   */
   readonly tool: Tool | undefined;
   /** Rewrites THIS tool call before execution (same-phase mutation). */
   rewriteToolCall(patch: {

--- a/packages/agent-runtime/src/engine/abort.spec.ts
+++ b/packages/agent-runtime/src/engine/abort.spec.ts
@@ -1,0 +1,203 @@
+import { describe, expect, it } from 'vitest';
+
+import type { Hook } from '../contracts/hook';
+import type { ProviderChunk, ProviderRequest } from '../contracts/provider';
+import {
+  MockProvider,
+  textTurn,
+  toolCallTurn,
+} from '../providers/mock/mock-provider';
+import { baseInput, collectEvents, echoTool } from './test-helpers';
+
+describe('abort handling', () => {
+  it('ends with status aborted when the signal fires mid-stream', async () => {
+    const controller = new AbortController();
+    const model = new MockProvider([]);
+    model.stream = async function* (): AsyncIterable<ProviderChunk> {
+      await Promise.resolve();
+      yield { textDelta: 'first' };
+      controller.abort();
+      yield { textDelta: 'second' };
+    };
+    const events = await collectEvents(
+      baseInput(model, { signal: controller.signal }),
+    );
+
+    expect(events.at(-1)).toMatchObject({
+      type: 'run_end',
+      status: 'aborted',
+    });
+  });
+
+  it('stops before the next iteration when a tool aborts via signal', async () => {
+    const controller = new AbortController();
+    const abortingTool = echoTool({
+      execute: () => {
+        controller.abort();
+        return 'done anyway';
+      },
+    });
+    const model = new MockProvider([
+      toolCallTurn({ id: 'c1', name: 'echo', input: { value: 'x' } }),
+      textTurn('never reached'),
+    ]);
+    const events = await collectEvents(
+      baseInput(model, { tools: [abortingTool], signal: controller.signal }),
+    );
+
+    expect(events.at(-1)).toMatchObject({
+      type: 'run_end',
+      status: 'aborted',
+    });
+    expect(model.requests).toHaveLength(1);
+  });
+
+  it('stops before the model call when a beforeModelCall hook aborts', async () => {
+    const abortOnSecond: Hook = {
+      name: 'abort-on-second',
+      beforeModelCall: (ctx) => {
+        if (ctx.iteration === 1) {
+          ctx.abort('enough');
+        }
+      },
+    };
+    const model = new MockProvider([
+      toolCallTurn({ id: 'c1', name: 'echo', input: { value: 'x' } }),
+      textTurn('never reached'),
+    ]);
+    const events = await collectEvents(
+      baseInput(model, { tools: [echoTool()], hooks: [abortOnSecond] }),
+    );
+
+    expect(events.at(-1)).toMatchObject({
+      type: 'run_end',
+      status: 'aborted',
+    });
+    expect(model.requests).toHaveLength(1);
+  });
+
+  it('exposes the abort signal to tool executions', async () => {
+    const controller = new AbortController();
+    let seenSignal: AbortSignal | undefined;
+    const observingTool = echoTool({
+      execute: (_input, ctx) => {
+        seenSignal = ctx.signal;
+        return 'ok';
+      },
+    });
+    const model = new MockProvider([
+      toolCallTurn({ id: 'c1', name: 'echo', input: { value: 'x' } }),
+      textTurn('Done'),
+    ]);
+    await collectEvents(
+      baseInput(model, { tools: [observingTool], signal: controller.signal }),
+    );
+
+    expect(seenSignal).toBe(controller.signal);
+  });
+
+  it('passes the signal through to the provider request', async () => {
+    const controller = new AbortController();
+    let seenSignal: AbortSignal | undefined;
+    const model = new MockProvider([textTurn('Hi')]);
+    const originalStream = model.stream.bind(model);
+    model.stream = (request: ProviderRequest) => {
+      seenSignal = request.signal;
+      return originalStream(request);
+    };
+    await collectEvents(baseInput(model, { signal: controller.signal }));
+
+    expect(seenSignal).toBe(controller.signal);
+  });
+
+  it('does not execute the tool when a beforeToolCall hook aborts', async () => {
+    let executed = false;
+    const observingTool = echoTool({
+      execute: () => {
+        executed = true;
+        return 'ran';
+      },
+    });
+    const gate: Hook = {
+      name: 'gate',
+      beforeToolCall: (ctx) => ctx.abort('blocked'),
+    };
+    const model = new MockProvider([
+      toolCallTurn({ id: 'c1', name: 'echo', input: { value: 'x' } }),
+      textTurn('never reached'),
+    ]);
+    const events = await collectEvents(
+      baseInput(model, { tools: [observingTool], hooks: [gate] }),
+    );
+
+    expect(executed).toBe(false);
+    const toolResult = events.find((e) => e.type === 'tool_result');
+    expect(toolResult).toMatchObject({
+      isError: true,
+      result: expect.stringContaining('aborted'),
+    });
+    expect(events.at(-1)).toMatchObject({
+      type: 'run_end',
+      status: 'aborted',
+    });
+    expect(model.requests).toHaveLength(1);
+  });
+
+  it('ends as aborted when afterModelCall aborts on a final turn', async () => {
+    const abortAtEnd: Hook = {
+      name: 'abort-at-end',
+      afterModelCall: (ctx) => ctx.abort('stop'),
+    };
+    const model = new MockProvider([textTurn('Final answer')]);
+    const events = await collectEvents(
+      baseInput(model, { hooks: [abortAtEnd] }),
+    );
+
+    expect(events.at(-1)).toMatchObject({
+      type: 'run_end',
+      status: 'aborted',
+    });
+  });
+
+  it('pairs every tool_use with a result when aborting mid-batch', async () => {
+    const controller = new AbortController();
+    const abortingTool = echoTool({
+      execute: (input) => {
+        controller.abort();
+        return `ran: ${String(input.value)}`;
+      },
+    });
+    const twoCallTurn: ProviderChunk[] = [
+      {
+        toolCallDeltas: [
+          { index: 0, id: 'c1', name: 'echo', argumentsDelta: '{"value":"a"}' },
+          { index: 1, id: 'c2', name: 'echo', argumentsDelta: '{"value":"b"}' },
+        ],
+      },
+      { finishReason: 'tool_calls' },
+    ];
+    const model = new MockProvider([twoCallTurn]);
+    const events = await collectEvents(
+      baseInput(model, { tools: [abortingTool], signal: controller.signal }),
+    );
+
+    const resultsMessage = events.find((e) => e.type === 'tool_result_message');
+    expect(resultsMessage).toBeDefined();
+    if (resultsMessage?.type === 'tool_result_message') {
+      expect(resultsMessage.message.content).toHaveLength(2);
+      expect(resultsMessage.message.content[0]).toMatchObject({
+        toolCallId: 'c1',
+        result: 'ran: a',
+      });
+      expect(resultsMessage.message.content[1]).toMatchObject({
+        toolCallId: 'c2',
+        isError: true,
+        result: expect.stringContaining('aborted'),
+      });
+    }
+    expect(events.at(-1)).toMatchObject({
+      type: 'run_end',
+      status: 'aborted',
+    });
+  });
+});

--- a/packages/agent-runtime/src/engine/accumulator.spec.ts
+++ b/packages/agent-runtime/src/engine/accumulator.spec.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest';
+
+import { ChunkAccumulator } from './accumulator';
+
+describe('ChunkAccumulator', () => {
+  it('reassembles tool arguments split across deltas', () => {
+    const accumulator = new ChunkAccumulator();
+    accumulator.accept({
+      toolCallDeltas: [{ index: 0, id: 'c1', name: 'search' }],
+    });
+    accumulator.accept({
+      toolCallDeltas: [{ index: 0, argumentsDelta: '{"query":' }],
+    });
+    accumulator.accept({
+      toolCallDeltas: [{ index: 0, argumentsDelta: '"agents"}' }],
+    });
+
+    const { message } = accumulator.finalize();
+    expect(message.content).toEqual([
+      {
+        type: 'tool_use',
+        id: 'c1',
+        name: 'search',
+        input: { query: 'agents' },
+      },
+    ]);
+  });
+
+  it('accumulates multiple parallel tool calls by index', () => {
+    const accumulator = new ChunkAccumulator();
+    accumulator.accept({
+      toolCallDeltas: [
+        { index: 1, id: 'c2', name: 'second', argumentsDelta: '{"b":2}' },
+        { index: 0, id: 'c1', name: 'first', argumentsDelta: '{"a":1}' },
+      ],
+    });
+
+    const { message } = accumulator.finalize();
+    expect(message.content.map((c) => ('name' in c ? c.name : null))).toEqual([
+      'first',
+      'second',
+    ]);
+  });
+
+  it('falls back to an empty object for malformed argument JSON', () => {
+    const accumulator = new ChunkAccumulator();
+    accumulator.accept({
+      toolCallDeltas: [
+        { index: 0, id: 'c1', name: 'broken', argumentsDelta: '{"a": ' },
+      ],
+    });
+
+    const { message } = accumulator.finalize();
+    expect(message.content[0]).toMatchObject({ input: {} });
+  });
+
+  it('assembles thinking with id and an accumulated signature', () => {
+    const accumulator = new ChunkAccumulator();
+    accumulator.accept({ thinkingDelta: 'Let me ', thinkingId: 'rs_1' });
+    accumulator.accept({ thinkingDelta: 'think.', thinkingSignature: 'sig-a' });
+    accumulator.accept({ thinkingSignature: 'sig-b' });
+    accumulator.accept({ textDelta: 'Answer' });
+
+    const { message } = accumulator.finalize();
+    expect(message.content[0]).toEqual({
+      type: 'thinking',
+      thinking: 'Let me think.',
+      id: 'rs_1',
+      signature: 'sig-asig-b',
+    });
+    expect(message.content[1]).toEqual({ type: 'text', text: 'Answer' });
+  });
+
+  it('round-trips provider metadata on text and tool calls', () => {
+    const accumulator = new ChunkAccumulator();
+    accumulator.accept({
+      textDelta: 'Hi',
+      textProviderMetadata: { gemini: { thoughtSignature: 'ts-1' } },
+    });
+    accumulator.accept({
+      toolCallDeltas: [
+        {
+          index: 0,
+          id: 'c1',
+          name: 'tool',
+          argumentsDelta: '{}',
+          providerMetadata: { gemini: { thoughtSignature: 'ts-2' } },
+        },
+      ],
+    });
+
+    const { message } = accumulator.finalize();
+    expect(message.content[0]).toMatchObject({
+      providerMetadata: { gemini: { thoughtSignature: 'ts-1' } },
+    });
+    expect(message.content[1]).toMatchObject({
+      providerMetadata: { gemini: { thoughtSignature: 'ts-2' } },
+    });
+  });
+
+  it('keeps the latest defined usage fields and finish reason', () => {
+    const accumulator = new ChunkAccumulator();
+    accumulator.accept({ usage: { inputTokens: 100 } });
+    accumulator.accept({ textDelta: 'Hi' });
+    accumulator.accept({ finishReason: 'stop', usage: { outputTokens: 7 } });
+
+    const result = accumulator.finalize();
+    expect(result.usage).toEqual({ inputTokens: 100, outputTokens: 7 });
+    expect(result.finishReason).toBe('stop');
+  });
+
+  it('produces an empty content array when nothing streamed', () => {
+    const accumulator = new ChunkAccumulator();
+
+    const { message } = accumulator.finalize();
+    expect(message).toEqual({ role: 'assistant', content: [] });
+  });
+});

--- a/packages/agent-runtime/src/engine/accumulator.ts
+++ b/packages/agent-runtime/src/engine/accumulator.ts
@@ -1,0 +1,153 @@
+import type {
+  AssistantMessage,
+  ProviderMetadata,
+  ThinkingContent,
+  ToolUseContent,
+} from '../contracts/message';
+import type { FinishReason, ProviderChunk, Usage } from '../contracts/provider';
+
+interface AccumulatingToolCall {
+  id: string | null;
+  name: string | null;
+  argumentsJson: string;
+  providerMetadata?: ProviderMetadata;
+}
+
+export interface ModelCallResult {
+  message: AssistantMessage;
+  usage: Usage;
+  finishReason: FinishReason;
+}
+
+/** Assembles streamed ProviderChunks into a complete assistant message. */
+export class ChunkAccumulator {
+  private thinking = '';
+  private thinkingId: string | null = null;
+  private thinkingSignature = '';
+  private text = '';
+  private textProviderMetadata: ProviderMetadata = null;
+  private readonly toolCalls = new Map<number, AccumulatingToolCall>();
+  private usage: Usage = {};
+  private finishReason: FinishReason = null;
+
+  accept(chunk: ProviderChunk): void {
+    this.acceptThinking(chunk);
+    this.acceptText(chunk);
+    this.acceptToolCalls(chunk);
+    this.acceptMeta(chunk);
+  }
+
+  private acceptThinking(chunk: ProviderChunk): void {
+    if (chunk.thinkingDelta) {
+      this.thinking += chunk.thinkingDelta;
+    }
+    if (chunk.thinkingId) {
+      this.thinkingId = chunk.thinkingId;
+    }
+    if (chunk.thinkingSignature) {
+      this.thinkingSignature += chunk.thinkingSignature;
+    }
+  }
+
+  private acceptText(chunk: ProviderChunk): void {
+    if (chunk.textDelta) {
+      this.text += chunk.textDelta;
+    }
+    if (chunk.textProviderMetadata) {
+      this.textProviderMetadata = chunk.textProviderMetadata;
+    }
+  }
+
+  private acceptToolCalls(chunk: ProviderChunk): void {
+    for (const delta of chunk.toolCallDeltas ?? []) {
+      const call = this.toolCalls.get(delta.index) ?? {
+        id: null,
+        name: null,
+        argumentsJson: '',
+      };
+      call.id = delta.id ?? call.id;
+      call.name = delta.name ?? call.name;
+      call.argumentsJson += delta.argumentsDelta ?? '';
+      if (delta.providerMetadata) {
+        call.providerMetadata = delta.providerMetadata;
+      }
+      this.toolCalls.set(delta.index, call);
+    }
+  }
+
+  private acceptMeta(chunk: ProviderChunk): void {
+    if (chunk.finishReason !== undefined) {
+      this.finishReason = chunk.finishReason;
+    }
+    if (chunk.usage) {
+      this.usage = { ...this.usage, ...chunk.usage };
+    }
+  }
+
+  finalize(): ModelCallResult {
+    const content: AssistantMessage['content'] = [];
+    const thinking = this.finalizeThinking();
+    if (thinking) {
+      content.push(thinking);
+    }
+    if (this.text) {
+      content.push({
+        type: 'text',
+        text: this.text,
+        ...(this.textProviderMetadata
+          ? { providerMetadata: this.textProviderMetadata }
+          : {}),
+      });
+    }
+    content.push(...this.finalizeToolCalls());
+    return {
+      message: { role: 'assistant', content },
+      usage: this.usage,
+      finishReason: this.finishReason,
+    };
+  }
+
+  private finalizeThinking(): ThinkingContent | null {
+    if (!this.thinking) {
+      return null;
+    }
+    return {
+      type: 'thinking',
+      thinking: this.thinking,
+      id: this.thinkingId,
+      signature: this.thinkingSignature || null,
+    };
+  }
+
+  private finalizeToolCalls(): ToolUseContent[] {
+    const entries = [...this.toolCalls.entries()].sort((a, b) => a[0] - b[0]);
+    return entries.map(([index, call]) => ({
+      type: 'tool_use',
+      id: call.id ?? `call_${index}`,
+      name: call.name ?? '',
+      input: safeParseJsonObject(call.argumentsJson),
+      ...(call.providerMetadata
+        ? { providerMetadata: call.providerMetadata }
+        : {}),
+    }));
+  }
+}
+
+const safeParseJsonObject = (json: string): Record<string, unknown> => {
+  if (!json) {
+    return {};
+  }
+  try {
+    const parsed: unknown = JSON.parse(json);
+    if (
+      parsed !== null &&
+      typeof parsed === 'object' &&
+      !Array.isArray(parsed)
+    ) {
+      return parsed as Record<string, unknown>;
+    }
+    return {};
+  } catch {
+    return {};
+  }
+};

--- a/packages/agent-runtime/src/engine/event-queue.ts
+++ b/packages/agent-runtime/src/engine/event-queue.ts
@@ -1,0 +1,28 @@
+import type { CustomEventInput, RunEventPayload } from '../contracts/event';
+
+/**
+ * Buffer between push-style emitters (hooks, tools) and the pull-style run
+ * generator. The loop drains it after every step so hook/tool emits
+ * interleave with streamed events in order.
+ */
+export class EmitBuffer {
+  private buffer: CustomEventInput[] = [];
+
+  push(event: CustomEventInput): void {
+    this.buffer.push(event);
+  }
+
+  drain(): CustomEventInput[] {
+    const drained = this.buffer;
+    this.buffer = [];
+    return drained;
+  }
+}
+
+export function* drainEmits(state: {
+  emits: EmitBuffer;
+}): Generator<RunEventPayload> {
+  for (const event of state.emits.drain()) {
+    yield { type: 'custom', name: event.name, data: event.data };
+  }
+}

--- a/packages/agent-runtime/src/engine/exit-conditions.ts
+++ b/packages/agent-runtime/src/engine/exit-conditions.ts
@@ -1,0 +1,29 @@
+import type { AssistantMessage, ToolUseContent } from '../contracts/message';
+import type { Tool } from '../contracts/tool';
+
+export const getToolUseContents = (
+  message: AssistantMessage,
+): ToolUseContent[] => {
+  return message.content.filter(
+    (content): content is ToolUseContent => content.type === 'tool_use',
+  );
+};
+
+/**
+ * The loop exits when the model requests no tool calls, or when any
+ * requested tool is display-only (no `execute`) — the call is surfaced to
+ * the consumer instead of being executed.
+ */
+export const shouldExitLoop = (
+  message: AssistantMessage,
+  tools: readonly Tool[],
+): boolean => {
+  const calls = getToolUseContents(message);
+  if (calls.length === 0) {
+    return true;
+  }
+  return calls.some((call) => {
+    const tool = tools.find((candidate) => candidate.name === call.name);
+    return tool !== undefined && tool.execute === undefined;
+  });
+};

--- a/packages/agent-runtime/src/engine/hook-runner.spec.ts
+++ b/packages/agent-runtime/src/engine/hook-runner.spec.ts
@@ -1,0 +1,244 @@
+import { describe, expect, it } from 'vitest';
+
+import type { Hook } from '../contracts/hook';
+import {
+  MockProvider,
+  textTurn,
+  toolCallTurn,
+} from '../providers/mock/mock-provider';
+import { baseInput, collectEvents, echoTool, eventTypes } from './test-helpers';
+
+describe('hook lifecycle', () => {
+  it('fires all six phases in order across a tool-call run', async () => {
+    const phases: string[] = [];
+    const recorder: Hook = {
+      name: 'recorder',
+      runStart: () => {
+        phases.push('runStart');
+      },
+      beforeModelCall: (ctx) => {
+        phases.push(`beforeModelCall:${ctx.iteration}`);
+      },
+      afterModelCall: (ctx) => {
+        phases.push(`afterModelCall:${ctx.iteration}`);
+      },
+      beforeToolCall: () => {
+        phases.push('beforeToolCall');
+      },
+      afterToolCall: () => {
+        phases.push('afterToolCall');
+      },
+      runEnd: (ctx) => {
+        phases.push(`runEnd:${ctx.status}`);
+      },
+    };
+    const model = new MockProvider([
+      toolCallTurn({ id: 'c1', name: 'echo', input: { value: 'x' } }),
+      textTurn('Done'),
+    ]);
+    await collectEvents(
+      baseInput(model, { tools: [echoTool()], hooks: [recorder] }),
+    );
+
+    expect(phases).toEqual([
+      'runStart',
+      'beforeModelCall:0',
+      'afterModelCall:0',
+      'beforeToolCall',
+      'afterToolCall',
+      'beforeModelCall:1',
+      'afterModelCall:1',
+      'runEnd:completed',
+    ]);
+  });
+
+  it('fires multiple hooks in registration order within a phase', async () => {
+    const order: string[] = [];
+    const hook = (name: string): Hook => ({
+      name,
+      beforeModelCall: () => {
+        order.push(name);
+      },
+    });
+    const model = new MockProvider([textTurn('Hi')]);
+    await collectEvents(
+      baseInput(model, { hooks: [hook('first'), hook('second')] }),
+    );
+
+    expect(order).toEqual(['first', 'second']);
+  });
+
+  it('awaits async hooks before proceeding', async () => {
+    const order: string[] = [];
+    const slow: Hook = {
+      name: 'slow',
+      runStart: async () => {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        order.push('slow-done');
+      },
+    };
+    const after: Hook = {
+      name: 'after',
+      runStart: () => {
+        order.push('after');
+      },
+    };
+    const model = new MockProvider([textTurn('Hi')]);
+    await collectEvents(baseInput(model, { hooks: [slow, after] }));
+
+    expect(order).toEqual(['slow-done', 'after']);
+  });
+
+  it('ends the run with status aborted when a runStart hook aborts', async () => {
+    const guard: Hook = {
+      name: 'guard',
+      runStart: (ctx) => ctx.abort('quota exhausted'),
+    };
+    const model = new MockProvider([textTurn('never')]);
+    const events = await collectEvents(baseInput(model, { hooks: [guard] }));
+
+    expect(events.at(-1)).toMatchObject({
+      type: 'run_end',
+      status: 'aborted',
+    });
+    expect(model.requests).toHaveLength(0);
+  });
+
+  it('fails the run with hook attribution when a hook throws', async () => {
+    const broken: Hook = {
+      name: 'broken',
+      beforeModelCall: () => {
+        throw new Error('hook exploded');
+      },
+    };
+    const model = new MockProvider([textTurn('never')]);
+    const events = await collectEvents(baseInput(model, { hooks: [broken] }));
+
+    const error = events.find((e) => e.type === 'error');
+    expect(error).toMatchObject({
+      code: 'HOOK_FAILED',
+      message: "Hook 'broken' failed in beforeModelCall: hook exploded",
+      details: { hookName: 'broken', phase: 'beforeModelCall' },
+    });
+    expect(events.at(-1)).toMatchObject({ type: 'run_end', status: 'error' });
+  });
+
+  it('streams hook emits as custom events in order', async () => {
+    const emitter: Hook = {
+      name: 'emitter',
+      beforeModelCall: (ctx) => ctx.emit({ name: 'masks', data: { count: 2 } }),
+    };
+    const model = new MockProvider([textTurn('Hi')]);
+    const events = await collectEvents(baseInput(model, { hooks: [emitter] }));
+
+    const types = eventTypes(events);
+    expect(types.indexOf('custom')).toBeLessThan(
+      types.indexOf('assistant_message'),
+    );
+    const custom = events.find((e) => e.type === 'custom');
+    expect(custom).toMatchObject({ name: 'masks', data: { count: 2 } });
+  });
+
+  it('lets tools emit custom events through their execution context', async () => {
+    const emittingTool = echoTool({
+      execute: (input, ctx) => {
+        ctx.emit({ name: 'progress', data: 'halfway' });
+        return `echo: ${String(input.value)}`;
+      },
+    });
+    const model = new MockProvider([
+      toolCallTurn({ id: 'c1', name: 'echo', input: { value: 'x' } }),
+      textTurn('Done'),
+    ]);
+    const events = await collectEvents(
+      baseInput(model, { tools: [emittingTool] }),
+    );
+
+    const custom = events.find((e) => e.type === 'custom');
+    expect(custom).toMatchObject({ name: 'progress', data: 'halfway' });
+  });
+
+  it('rewrites a tool call in beforeToolCall before execution', async () => {
+    const rewriter: Hook = {
+      name: 'rewriter',
+      beforeToolCall: (ctx) =>
+        ctx.rewriteToolCall({ input: { value: 'rewritten' } }),
+    };
+    const model = new MockProvider([
+      toolCallTurn({ id: 'c1', name: 'echo', input: { value: 'original' } }),
+      textTurn('Done'),
+    ]);
+    const events = await collectEvents(
+      baseInput(model, { tools: [echoTool()], hooks: [rewriter] }),
+    );
+
+    const toolResult = events.find((e) => e.type === 'tool_result');
+    expect(toolResult).toMatchObject({ result: 'echo: rewritten' });
+  });
+
+  it('resolves ctx.tool from the rewritten name for subsequent hooks', async () => {
+    const seenToolNames: (string | undefined)[] = [];
+    const renamer: Hook = {
+      name: 'renamer',
+      beforeToolCall: (ctx) => ctx.rewriteToolCall({ name: 'echo-internal' }),
+    };
+    const inspector: Hook = {
+      name: 'inspector',
+      beforeToolCall: (ctx) => {
+        seenToolNames.push(ctx.tool?.name);
+      },
+    };
+    const internalTool = echoTool({
+      name: 'echo-internal',
+      execute: (input) => `internal: ${String(input.value)}`,
+    });
+    const model = new MockProvider([
+      toolCallTurn({ id: 'c1', name: 'echo', input: { value: 'x' } }),
+      textTurn('Done'),
+    ]);
+    const events = await collectEvents(
+      baseInput(model, {
+        tools: [echoTool(), internalTool],
+        hooks: [renamer, inspector],
+      }),
+    );
+
+    expect(seenToolNames).toEqual(['echo-internal']);
+    const toolResult = events.find((e) => e.type === 'tool_result');
+    expect(toolResult).toMatchObject({ result: 'internal: x' });
+  });
+
+  it('passes the run context to hooks for per-run state', async () => {
+    const seen: unknown[] = [];
+    const statefulHook: Hook = {
+      name: 'stateful',
+      runStart: (ctx) => ctx.context.set('marker', 'set-at-start'),
+      runEnd: (ctx) => {
+        seen.push(ctx.context.get('marker'));
+      },
+    };
+    const model = new MockProvider([textTurn('Hi')]);
+    await collectEvents(baseInput(model, { hooks: [statefulHook] }));
+
+    expect(seen).toEqual(['set-at-start']);
+  });
+
+  it('notifies runEnd hooks when the consumer abandons the stream', async () => {
+    const statuses: string[] = [];
+    const observer: Hook = {
+      name: 'observer',
+      runEnd: (ctx) => {
+        statuses.push(ctx.status);
+      },
+    };
+    const model = new MockProvider([textTurn('Hello there')]);
+    const { run } = await import('./run');
+    for await (const event of run(baseInput(model, { hooks: [observer] }))) {
+      if (event.type === 'text_delta') {
+        break;
+      }
+    }
+
+    expect(statuses).toEqual(['aborted']);
+  });
+});

--- a/packages/agent-runtime/src/engine/hook-runner.ts
+++ b/packages/agent-runtime/src/engine/hook-runner.ts
@@ -1,0 +1,151 @@
+import type { RunContext } from '../context/run-context';
+import { HookFailedError } from '../contracts/errors';
+import type { AgentRuntimeError } from '../contracts/errors';
+import type { RunStatus, ToolCallSummary } from '../contracts/event';
+import type {
+  AfterModelCallContext,
+  AfterToolCallContext,
+  Hook,
+  HookApi,
+} from '../contracts/hook';
+import type { AssistantMessage, Message } from '../contracts/message';
+import type { FinishReason, Usage } from '../contracts/provider';
+import type { Tool } from '../contracts/tool';
+import type { EmitBuffer } from './event-queue';
+import type { PendingMutations } from './mutations';
+import type { AbortState } from './run-state';
+
+interface HookRunnerDeps {
+  hooks: readonly Hook[];
+  context: RunContext;
+  mutations: PendingMutations;
+  emits: EmitBuffer;
+  abortState: AbortState;
+}
+
+/**
+ * Fires hook phases in registration order, awaited sequentially. Builds
+ * the shared mutation API each phase context extends.
+ */
+export class HookRunner {
+  constructor(private readonly deps: HookRunnerDeps) {}
+
+  get hooks(): readonly Hook[] {
+    return this.deps.hooks;
+  }
+
+  private api(): HookApi {
+    const { context, mutations, emits, abortState } = this.deps;
+    return {
+      context,
+      transformMessages: (fn) => mutations.transformMessages(fn),
+      addTools: (...tools) => mutations.addTools(...tools),
+      removeTools: (...names) => mutations.removeTools(...names),
+      setTools: (tools) => mutations.setTools(tools),
+      addInstructions: (text) => mutations.addInstructions(text),
+      abort: (reason) => abortState.abort(reason),
+      emit: (event) => emits.push(event),
+    };
+  }
+
+  async runStart(info: {
+    messages: readonly Message[];
+    instructions: string;
+    tools: readonly Tool[];
+  }): Promise<void> {
+    const ctx = { ...this.api(), ...info };
+    for (const hook of this.deps.hooks) {
+      await this.invoke(hook, 'runStart', () => hook.runStart?.(ctx));
+    }
+  }
+
+  async beforeModelCall(info: {
+    iteration: number;
+    messages: readonly Message[];
+    tools: readonly Tool[];
+  }): Promise<void> {
+    const ctx = { ...this.api(), ...info };
+    for (const hook of this.deps.hooks) {
+      await this.invoke(hook, 'beforeModelCall', () =>
+        hook.beforeModelCall?.(ctx),
+      );
+    }
+  }
+
+  async afterModelCall(info: {
+    iteration: number;
+    message: AssistantMessage;
+    usage: Usage;
+    finishReason: FinishReason;
+  }): Promise<void> {
+    const ctx: AfterModelCallContext = { ...this.api(), ...info };
+    for (const hook of this.deps.hooks) {
+      await this.invoke(hook, 'afterModelCall', () =>
+        hook.afterModelCall?.(ctx),
+      );
+    }
+  }
+
+  /** Returns the (possibly rewritten) tool call to execute. */
+  async beforeToolCall(info: {
+    iteration: number;
+    toolCall: ToolCallSummary;
+    findTool: (name: string) => Tool | undefined;
+  }): Promise<ToolCallSummary> {
+    let current = info.toolCall;
+    const rewriteToolCall = (patch: {
+      name?: string;
+      input?: Record<string, unknown>;
+    }): void => {
+      current = { ...current, ...patch };
+    };
+    for (const hook of this.deps.hooks) {
+      await this.invoke(hook, 'beforeToolCall', () =>
+        hook.beforeToolCall?.({
+          ...this.api(),
+          iteration: info.iteration,
+          toolCall: current,
+          tool: info.findTool(current.name),
+          rewriteToolCall,
+        }),
+      );
+    }
+    return current;
+  }
+
+  /** Wraps a hook failure with the hook's name and phase for attribution. */
+  private async invoke(
+    hook: Hook,
+    phase: string,
+    call: () => void | Promise<void>,
+  ): Promise<void> {
+    try {
+      await call();
+    } catch (error) {
+      throw new HookFailedError({ hookName: hook.name, phase, cause: error });
+    }
+  }
+
+  async afterToolCall(info: {
+    iteration: number;
+    toolCall: ToolCallSummary;
+    result: string;
+    isError: boolean;
+  }): Promise<void> {
+    const ctx: AfterToolCallContext = { ...this.api(), ...info };
+    for (const hook of this.deps.hooks) {
+      await this.invoke(hook, 'afterToolCall', () => hook.afterToolCall?.(ctx));
+    }
+  }
+
+  async runEnd(info: {
+    messages: readonly Message[];
+    status: RunStatus;
+    error?: AgentRuntimeError;
+  }): Promise<void> {
+    const ctx = { ...this.api(), ...info };
+    for (const hook of this.deps.hooks) {
+      await this.invoke(hook, 'runEnd', () => hook.runEnd?.(ctx));
+    }
+  }
+}

--- a/packages/agent-runtime/src/engine/loop.spec.ts
+++ b/packages/agent-runtime/src/engine/loop.spec.ts
@@ -1,0 +1,214 @@
+import { describe, expect, it } from 'vitest';
+
+import type { RunEvent } from '../contracts/event';
+import {
+  MockProvider,
+  textTurn,
+  toolCallTurn,
+} from '../providers/mock/mock-provider';
+import { baseInput, collectEvents, echoTool, eventTypes } from './test-helpers';
+
+describe('the agent loop', () => {
+  it('completes after a single text-only turn', async () => {
+    const model = new MockProvider([textTurn('Hello there')]);
+    const events = await collectEvents(baseInput(model));
+
+    expect(eventTypes(events)).toEqual([
+      'run_start',
+      'text_delta',
+      'text_delta',
+      'assistant_message',
+      'run_end',
+    ]);
+    const runEnd = events.at(-1);
+    expect(runEnd).toMatchObject({ type: 'run_end', status: 'completed' });
+    expect(model.requests).toHaveLength(1);
+  });
+
+  it('reassembles text deltas into the assistant message', async () => {
+    const model = new MockProvider([textTurn('Hello there')]);
+    const events = await collectEvents(baseInput(model));
+
+    const message = events.find((e) => e.type === 'assistant_message');
+    expect(message).toMatchObject({
+      message: {
+        role: 'assistant',
+        content: [{ type: 'text', text: 'Hello there' }],
+      },
+    });
+  });
+
+  it('executes a tool call and iterates until the model stops', async () => {
+    const model = new MockProvider([
+      toolCallTurn({ id: 'call-1', name: 'echo', input: { value: '42' } }),
+      textTurn('The echo said 42'),
+    ]);
+    const events = await collectEvents(
+      baseInput(model, { tools: [echoTool()] }),
+    );
+
+    expect(eventTypes(events)).toEqual([
+      'run_start',
+      'tool_call',
+      'assistant_message',
+      'tool_result',
+      'tool_result_message',
+      'text_delta',
+      'text_delta',
+      'assistant_message',
+      'run_end',
+    ]);
+    const toolResult = events.find((e) => e.type === 'tool_result');
+    expect(toolResult).toMatchObject({
+      toolCallId: 'call-1',
+      toolName: 'echo',
+      result: 'echo: 42',
+      isError: false,
+    });
+    expect(model.requests).toHaveLength(2);
+  });
+
+  it('sends the tool result back to the model on the next iteration', async () => {
+    const model = new MockProvider([
+      toolCallTurn({ id: 'call-1', name: 'echo', input: { value: '42' } }),
+      textTurn('Done'),
+    ]);
+    await collectEvents(baseInput(model, { tools: [echoTool()] }));
+
+    const secondRequest = model.requests[1];
+    const lastMessage = secondRequest.messages.at(-1);
+    expect(lastMessage).toMatchObject({
+      role: 'tool_result',
+      content: [
+        {
+          type: 'tool_result',
+          toolCallId: 'call-1',
+          toolName: 'echo',
+          result: 'echo: 42',
+        },
+      ],
+    });
+  });
+
+  it('exits without executing when a display-only tool is called', async () => {
+    const displayOnly = echoTool({ name: 'show_chart', execute: undefined });
+    const model = new MockProvider([
+      toolCallTurn({ id: 'call-1', name: 'show_chart', input: { value: 'x' } }),
+    ]);
+    const events = await collectEvents(
+      baseInput(model, { tools: [displayOnly] }),
+    );
+
+    expect(eventTypes(events)).not.toContain('tool_result');
+    expect(events.at(-1)).toMatchObject({
+      type: 'run_end',
+      status: 'completed',
+    });
+    expect(model.requests).toHaveLength(1);
+  });
+
+  it('returns an error result for unknown tools and keeps looping', async () => {
+    const model = new MockProvider([
+      toolCallTurn({ id: 'call-1', name: 'missing_tool', input: {} }),
+      textTurn('Recovered'),
+    ]);
+    const events = await collectEvents(
+      baseInput(model, { tools: [echoTool()] }),
+    );
+
+    const toolResult = events.find((e) => e.type === 'tool_result');
+    expect(toolResult).toMatchObject({ isError: true });
+    expect(toolResult).toMatchObject({
+      result: expect.stringContaining('was not found'),
+    });
+    expect(events.at(-1)).toMatchObject({
+      type: 'run_end',
+      status: 'completed',
+    });
+    expect(model.requests).toHaveLength(2);
+  });
+
+  it('turns tool execution failures into error results without throwing', async () => {
+    const failing = echoTool({
+      name: 'broken',
+      execute: () => {
+        throw new Error('boom');
+      },
+    });
+    const model = new MockProvider([
+      toolCallTurn({ id: 'call-1', name: 'broken', input: {} }),
+      textTurn('Recovered'),
+    ]);
+    const events = await collectEvents(baseInput(model, { tools: [failing] }));
+
+    const toolResult = events.find((e) => e.type === 'tool_result');
+    expect(toolResult).toMatchObject({ result: 'boom', isError: true });
+    expect(events.at(-1)).toMatchObject({
+      type: 'run_end',
+      status: 'completed',
+    });
+  });
+
+  it('stops at the iteration cap with an error event', async () => {
+    const callTurn = (): ReturnType<typeof toolCallTurn> =>
+      toolCallTurn({ id: 'call', name: 'echo', input: { value: 'again' } });
+    const model = new MockProvider([callTurn(), callTurn(), callTurn()]);
+    const events = await collectEvents(
+      baseInput(model, { tools: [echoTool()], maxIterations: 2 }),
+    );
+
+    const error = events.find((e) => e.type === 'error');
+    expect(error).toMatchObject({ code: 'MAX_ITERATIONS_REACHED' });
+    expect(events.at(-1)).toMatchObject({
+      type: 'run_end',
+      status: 'max_iterations',
+    });
+    expect(model.requests).toHaveLength(2);
+  });
+
+  it('aggregates usage across iterations into run_end', async () => {
+    const model = new MockProvider([
+      toolCallTurn(
+        { id: 'call-1', name: 'echo', input: { value: 'x' } },
+        { inputTokens: 10, outputTokens: 5 },
+      ),
+      textTurn('Done', { inputTokens: 20, outputTokens: 7 }),
+    ]);
+    const events = await collectEvents(
+      baseInput(model, { tools: [echoTool()] }),
+    );
+
+    expect(events.at(-1)).toMatchObject({
+      type: 'run_end',
+      usage: { inputTokens: 30, outputTokens: 12 },
+    });
+  });
+
+  it('surfaces provider failures as an error event + run_end error', async () => {
+    const model = new MockProvider([]);
+    model.stream = () => {
+      throw new Error('connection refused');
+    };
+    const events = await collectEvents(baseInput(model));
+
+    const error = events.find((e) => e.type === 'error');
+    expect(error).toMatchObject({
+      code: 'PROVIDER_FAILED',
+      message: 'connection refused',
+    });
+    expect(events.at(-1)).toMatchObject({ type: 'run_end', status: 'error' });
+  });
+
+  it('stamps every event with the run envelope', async () => {
+    const model = new MockProvider([textTurn('Hi')]);
+    const events = await collectEvents(baseInput(model));
+
+    const isEnvelope = (event: RunEvent): boolean =>
+      typeof event.runId === 'string' &&
+      event.depth === 0 &&
+      event.path.length === 1 &&
+      typeof event.timestamp === 'string';
+    expect(events.every(isEnvelope)).toBe(true);
+    expect(new Set(events.map((e) => e.runId)).size).toBe(1);
+  });
+});

--- a/packages/agent-runtime/src/engine/loop.ts
+++ b/packages/agent-runtime/src/engine/loop.ts
@@ -1,0 +1,134 @@
+import type { RunEventPayload } from '../contracts/event';
+import type { Message, ToolUseContent } from '../contracts/message';
+import type { ProviderRequest, Usage } from '../contracts/provider';
+import type { ModelCallResult } from './accumulator';
+import { drainEmits } from './event-queue';
+import { getToolUseContents, shouldExitLoop } from './exit-conditions';
+import { streamModelCall } from './model-call';
+import type { RunState } from './run-state';
+import { isAborted } from './run-state';
+import { executeToolCalls } from './tool-executor';
+
+export interface LoopCompletion {
+  status: 'completed' | 'aborted' | 'max_iterations';
+}
+
+/**
+ * The agent loop: call the model, execute requested tools, append results,
+ * repeat — until the model stops requesting tools, a display-only tool is
+ * called, the iteration cap is hit, or the run is aborted.
+ */
+export async function* executeLoop(
+  state: RunState,
+): AsyncGenerator<RunEventPayload, LoopCompletion> {
+  for (let iteration = 0; iteration < state.maxIterations; iteration++) {
+    const completion = yield* runIteration(state, iteration);
+    if (completion) {
+      return completion;
+    }
+  }
+  return { status: 'max_iterations' };
+}
+
+/** One iteration; returns a completion to stop, or null to keep looping. */
+async function* runIteration(
+  state: RunState,
+  iteration: number,
+): AsyncGenerator<RunEventPayload, LoopCompletion | null> {
+  await state.hookRunner.beforeModelCall({
+    iteration,
+    messages: state.messages,
+    tools: state.tools,
+  });
+  yield* drainEmits(state);
+  if (isAborted(state)) {
+    return { status: 'aborted' };
+  }
+  applyPendingMutations(state);
+  const result = yield* streamModelCall({
+    model: state.model,
+    request: assembleRequest(state),
+  });
+  state.messages.push(result.message);
+  addUsage(state, result.usage);
+  const toolCalls = getToolUseContents(result.message);
+  yield* assistantEvents(result, toolCalls);
+  await state.hookRunner.afterModelCall({
+    iteration,
+    message: result.message,
+    usage: result.usage,
+    finishReason: result.finishReason,
+  });
+  yield* drainEmits(state);
+  if (isAborted(state)) {
+    return { status: 'aborted' };
+  }
+  if (shouldExitLoop(result.message, state.tools)) {
+    return { status: 'completed' };
+  }
+  yield* runToolPhase(state, iteration, toolCalls);
+  return isAborted(state) ? { status: 'aborted' } : null;
+}
+
+function* assistantEvents(
+  result: ModelCallResult,
+  toolCalls: readonly ToolUseContent[],
+): Generator<RunEventPayload> {
+  for (const call of toolCalls) {
+    yield {
+      type: 'tool_call',
+      toolCall: { id: call.id, name: call.name, input: call.input },
+    };
+  }
+  yield {
+    type: 'assistant_message',
+    message: result.message,
+    usage: result.usage,
+  };
+}
+
+async function* runToolPhase(
+  state: RunState,
+  iteration: number,
+  toolCalls: readonly ToolUseContent[],
+): AsyncGenerator<RunEventPayload> {
+  const results = yield* executeToolCalls(state, iteration, toolCalls);
+  const toolResultMessage: Message = {
+    role: 'tool_result',
+    content: results,
+  };
+  state.messages.push(toolResultMessage);
+  yield { type: 'tool_result_message', message: toolResultMessage };
+}
+
+const applyPendingMutations = (state: RunState): void => {
+  const applied = state.mutations.apply({
+    messages: state.messages,
+    tools: state.tools,
+    instructions: state.instructions,
+  });
+  state.messages = applied.messages;
+  state.tools = applied.tools;
+  state.instructions = applied.instructions;
+};
+
+const assembleRequest = (state: RunState): ProviderRequest => {
+  return {
+    instructions: state.instructions,
+    messages: state.messages,
+    tools: state.tools.map(({ name, description, parameters }) => ({
+      name,
+      description,
+      parameters,
+    })),
+    ...(state.toolChoice !== undefined && state.tools.length > 0
+      ? { toolChoice: state.toolChoice }
+      : {}),
+    ...(state.signal ? { signal: state.signal } : {}),
+  };
+};
+
+const addUsage = (state: RunState, usage: Usage): void => {
+  state.usage.inputTokens += usage.inputTokens ?? 0;
+  state.usage.outputTokens += usage.outputTokens ?? 0;
+};

--- a/packages/agent-runtime/src/engine/model-call.ts
+++ b/packages/agent-runtime/src/engine/model-call.ts
@@ -1,0 +1,66 @@
+import { ProviderError, RunAbortedError } from '../contracts/errors';
+import type { RunEventPayload } from '../contracts/event';
+import type {
+  ModelProvider,
+  ProviderChunk,
+  ProviderRequest,
+} from '../contracts/provider';
+import type { ModelCallResult } from './accumulator';
+import { ChunkAccumulator } from './accumulator';
+
+/**
+ * Performs one model call: streams chunks, yields delta events as they
+ * arrive, and returns the assembled assistant message. Provider failures
+ * are wrapped in ProviderError; an aborted signal throws RunAbortedError.
+ */
+export async function* streamModelCall(params: {
+  model: ModelProvider;
+  request: ProviderRequest;
+}): AsyncGenerator<RunEventPayload, ModelCallResult> {
+  const accumulator = new ChunkAccumulator();
+  const stream = openStream(params.model, params.request);
+  try {
+    for await (const chunk of stream) {
+      accumulator.accept(chunk);
+      yield* deltaEvents(chunk);
+      if (params.request.signal?.aborted) {
+        throw new RunAbortedError('Run aborted during model call');
+      }
+    }
+  } catch (error) {
+    if (error instanceof RunAbortedError) {
+      throw error;
+    }
+    throw toProviderError(error);
+  }
+  return accumulator.finalize();
+}
+
+const openStream = (
+  model: ModelProvider,
+  request: ProviderRequest,
+): AsyncIterable<ProviderChunk> => {
+  try {
+    return model.stream(request);
+  } catch (error) {
+    throw toProviderError(error);
+  }
+};
+
+function* deltaEvents(chunk: ProviderChunk): Generator<RunEventPayload> {
+  if (chunk.thinkingDelta) {
+    yield { type: 'thinking_delta', delta: chunk.thinkingDelta };
+  }
+  if (chunk.textDelta) {
+    yield { type: 'text_delta', delta: chunk.textDelta };
+  }
+}
+
+const toProviderError = (error: unknown): ProviderError => {
+  if (error instanceof ProviderError) {
+    return error;
+  }
+  const message =
+    error instanceof Error ? error.message : 'Model provider failed';
+  return new ProviderError(message, error);
+};

--- a/packages/agent-runtime/src/engine/mutations.spec.ts
+++ b/packages/agent-runtime/src/engine/mutations.spec.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it } from 'vitest';
+
+import type { Hook } from '../contracts/hook';
+import {
+  MockProvider,
+  textTurn,
+  toolCallTurn,
+} from '../providers/mock/mock-provider';
+import { baseInput, collectEvents, echoTool } from './test-helpers';
+
+const twoIterationModel = (): MockProvider =>
+  new MockProvider([
+    toolCallTurn({ id: 'c1', name: 'echo', input: { value: 'x' } }),
+    textTurn('Done'),
+  ]);
+
+describe('hook mutations', () => {
+  it('applies runStart mutations to the first model call', async () => {
+    const seeder: Hook = {
+      name: 'seeder',
+      runStart: (ctx) => ctx.addInstructions('Seeded instruction.'),
+    };
+    const model = new MockProvider([textTurn('Hi')]);
+    await collectEvents(baseInput(model, { hooks: [seeder] }));
+
+    expect(model.requests[0].instructions).toBe(
+      'Be helpful.\n\nSeeded instruction.',
+    );
+  });
+
+  it('applies beforeModelCall message transforms to the imminent call', async () => {
+    const redactor: Hook = {
+      name: 'redactor',
+      beforeModelCall: (ctx) =>
+        ctx.transformMessages((messages) =>
+          messages.map((message) => ({
+            ...message,
+            content: message.content.map((content) =>
+              content.type === 'text'
+                ? {
+                    ...content,
+                    text: content.text.replaceAll('Hi', '[GREETING]'),
+                  }
+                : content,
+            ),
+          })),
+        ),
+    };
+    const model = new MockProvider([textTurn('Hello')]);
+    await collectEvents(baseInput(model, { hooks: [redactor] }));
+
+    expect(model.requests[0].messages[0].content[0]).toMatchObject({
+      text: '[GREETING]',
+    });
+  });
+
+  it('applies afterToolCall tool injection to the next iteration only', async () => {
+    const injected = echoTool({ name: 'injected_tool' });
+    const injector: Hook = {
+      name: 'injector',
+      afterToolCall: (ctx) => ctx.addTools(injected),
+    };
+    const model = twoIterationModel();
+    await collectEvents(
+      baseInput(model, { tools: [echoTool()], hooks: [injector] }),
+    );
+
+    const first = model.requests[0].tools.map((tool) => tool.name);
+    const second = model.requests[1].tools.map((tool) => tool.name);
+    expect(first).toEqual(['echo']);
+    expect(second).toEqual(['echo', 'injected_tool']);
+  });
+
+  it('replaces the entire tool set with setTools', async () => {
+    const replacement = echoTool({ name: 'replacement' });
+    const replacer: Hook = {
+      name: 'replacer',
+      afterToolCall: (ctx) => ctx.setTools([replacement]),
+    };
+    const model = twoIterationModel();
+    await collectEvents(
+      baseInput(model, { tools: [echoTool()], hooks: [replacer] }),
+    );
+
+    expect(model.requests[1].tools.map((tool) => tool.name)).toEqual([
+      'replacement',
+    ]);
+  });
+
+  it('removes tools by name', async () => {
+    const remover: Hook = {
+      name: 'remover',
+      afterToolCall: (ctx) => ctx.removeTools('echo'),
+    };
+    const model = twoIterationModel();
+    await collectEvents(
+      baseInput(model, { tools: [echoTool()], hooks: [remover] }),
+    );
+
+    expect(model.requests[1].tools).toEqual([]);
+  });
+
+  it('appends afterToolCall instruction additions to the next call', async () => {
+    const injector: Hook = {
+      name: 'injector',
+      afterToolCall: (ctx) => ctx.addInstructions('Skill instructions.'),
+    };
+    const model = twoIterationModel();
+    await collectEvents(
+      baseInput(model, { tools: [echoTool()], hooks: [injector] }),
+    );
+
+    expect(model.requests[0].instructions).toBe('Be helpful.');
+    expect(model.requests[1].instructions).toBe(
+      'Be helpful.\n\nSkill instructions.',
+    );
+  });
+
+  it('replaces a tool when adding one with an existing name', async () => {
+    const upgraded = echoTool({ description: 'Upgraded echo' });
+    const upgrader: Hook = {
+      name: 'upgrader',
+      afterToolCall: (ctx) => ctx.addTools(upgraded),
+    };
+    const model = twoIterationModel();
+    await collectEvents(
+      baseInput(model, { tools: [echoTool()], hooks: [upgrader] }),
+    );
+
+    expect(model.requests[1].tools).toHaveLength(1);
+    expect(model.requests[1].tools[0].description).toBe('Upgraded echo');
+  });
+
+  it('keeps injected tools executable on the following iteration', async () => {
+    const injected = echoTool({
+      name: 'injected_tool',
+      execute: () => 'injected result',
+    });
+    const injector: Hook = {
+      name: 'injector',
+      afterToolCall: (ctx) => ctx.addTools(injected),
+    };
+    const model = new MockProvider([
+      toolCallTurn({ id: 'c1', name: 'echo', input: { value: 'x' } }),
+      toolCallTurn({ id: 'c2', name: 'injected_tool', input: {} }),
+      textTurn('Done'),
+    ]);
+    const events = await collectEvents(
+      baseInput(model, { tools: [echoTool()], hooks: [injector] }),
+    );
+
+    const results = events.filter((e) => e.type === 'tool_result');
+    expect(results[1]).toMatchObject({
+      toolName: 'injected_tool',
+      result: 'injected result',
+    });
+  });
+});

--- a/packages/agent-runtime/src/engine/mutations.ts
+++ b/packages/agent-runtime/src/engine/mutations.ts
@@ -1,0 +1,80 @@
+import type { Message } from '../contracts/message';
+import type { Tool } from '../contracts/tool';
+
+type MessageTransform = (messages: readonly Message[]) => Message[];
+
+type ToolOp =
+  | { kind: 'add'; tools: Tool[] }
+  | { kind: 'remove'; names: string[] }
+  | { kind: 'set'; tools: Tool[] };
+
+export interface MutableRunConfig {
+  messages: Message[];
+  tools: Tool[];
+  instructions: string;
+}
+
+/**
+ * Buffers hook mutations between request assemblies. Drained (in arrival
+ * order per kind) when the loop assembles the next provider request.
+ */
+export class PendingMutations {
+  private messageTransforms: MessageTransform[] = [];
+  private toolOps: ToolOp[] = [];
+  private instructionAdditions: string[] = [];
+
+  transformMessages(fn: MessageTransform): void {
+    this.messageTransforms.push(fn);
+  }
+
+  addTools(...tools: Tool[]): void {
+    this.toolOps.push({ kind: 'add', tools });
+  }
+
+  removeTools(...names: string[]): void {
+    this.toolOps.push({ kind: 'remove', names });
+  }
+
+  setTools(tools: Tool[]): void {
+    this.toolOps.push({ kind: 'set', tools });
+  }
+
+  addInstructions(text: string): void {
+    this.instructionAdditions.push(text);
+  }
+
+  apply(config: MutableRunConfig): MutableRunConfig {
+    let messages = config.messages;
+    for (const transform of this.messageTransforms) {
+      messages = transform(messages);
+    }
+    let tools = config.tools;
+    for (const op of this.toolOps) {
+      tools = applyToolOp(tools, op);
+    }
+    let instructions = config.instructions;
+    for (const addition of this.instructionAdditions) {
+      instructions = instructions ? `${instructions}\n\n${addition}` : addition;
+    }
+    this.messageTransforms = [];
+    this.toolOps = [];
+    this.instructionAdditions = [];
+    return { messages, tools, instructions };
+  }
+}
+
+const applyToolOp = (tools: Tool[], op: ToolOp): Tool[] => {
+  switch (op.kind) {
+    case 'add': {
+      // Adding a tool with an existing name replaces it.
+      const added = new Set(op.tools.map((tool) => tool.name));
+      return [...tools.filter((tool) => !added.has(tool.name)), ...op.tools];
+    }
+    case 'remove': {
+      const removed = new Set(op.names);
+      return tools.filter((tool) => !removed.has(tool.name));
+    }
+    case 'set':
+      return [...op.tools];
+  }
+};

--- a/packages/agent-runtime/src/engine/run-state.ts
+++ b/packages/agent-runtime/src/engine/run-state.ts
@@ -1,0 +1,55 @@
+import type { RunContext } from '../context/run-context';
+import type { RunEvent } from '../contracts/event';
+import type { Message } from '../contracts/message';
+import type { ModelProvider, ToolChoice } from '../contracts/provider';
+import type { ChildRunInput, RunInput } from '../contracts/run-input';
+import type { Tool } from '../contracts/tool';
+import type { EmitBuffer } from './event-queue';
+import type { HookRunner } from './hook-runner';
+import type { PendingMutations } from './mutations';
+
+/** Hook-driven abort flag; checked by the loop between steps. */
+export class AbortState {
+  aborted = false;
+  reason?: string;
+
+  abort(reason?: string): void {
+    this.aborted = true;
+    if (reason !== undefined) {
+      this.reason = reason;
+    }
+  }
+}
+
+export interface RunUsageTotals {
+  inputTokens: number;
+  outputTokens: number;
+}
+
+/**
+ * All per-run state, bundled. There is no module-level state anywhere in
+ * the engine — this object is what makes the loop re-entrant (subagent
+ * runs are just another RunState).
+ */
+export interface RunState {
+  readonly context: RunContext;
+  readonly model: ModelProvider;
+  messages: Message[];
+  tools: Tool[];
+  instructions: string;
+  readonly toolChoice?: ToolChoice;
+  readonly signal?: AbortSignal;
+  readonly maxIterations: number;
+  readonly usage: RunUsageTotals;
+  readonly mutations: PendingMutations;
+  readonly emits: EmitBuffer;
+  readonly abortState: AbortState;
+  readonly hookRunner: HookRunner;
+  readonly runChild: (input: ChildRunInput) => AsyncIterable<RunEvent>;
+}
+
+export type RunFn = (input: RunInput) => AsyncIterable<RunEvent>;
+
+export const isAborted = (state: RunState): boolean => {
+  return state.abortState.aborted || (state.signal?.aborted ?? false);
+};

--- a/packages/agent-runtime/src/engine/run.spec.ts
+++ b/packages/agent-runtime/src/engine/run.spec.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it } from 'vitest';
+
+import { InvalidRunInputError } from '../contracts/errors';
+import type { RunEvent } from '../contracts/event';
+import type { Hook } from '../contracts/hook';
+import {
+  MockProvider,
+  textTurn,
+  toolCallTurn,
+} from '../providers/mock/mock-provider';
+import { run } from './run';
+import {
+  baseInput,
+  collectEvents,
+  echoTool,
+  userMessage,
+} from './test-helpers';
+
+describe('run input validation', () => {
+  it('throws synchronously on empty messages', () => {
+    const model = new MockProvider([]);
+    expect(() => run({ instructions: '', model, messages: [] })).toThrow(
+      InvalidRunInputError,
+    );
+  });
+
+  it('throws synchronously on a non-positive iteration cap', () => {
+    const model = new MockProvider([]);
+    expect(() =>
+      run({
+        instructions: '',
+        model,
+        messages: [userMessage('Hi')],
+        maxIterations: 0,
+      }),
+    ).toThrow(InvalidRunInputError);
+  });
+});
+
+describe('re-entrancy and child runs', () => {
+  it('runs two concurrent runs without shared state', async () => {
+    const modelA = new MockProvider([textTurn('A')]);
+    const modelB = new MockProvider([textTurn('B')]);
+    const [eventsA, eventsB] = await Promise.all([
+      collectEvents(baseInput(modelA)),
+      collectEvents(baseInput(modelB)),
+    ]);
+
+    const runIdA = eventsA[0].runId;
+    const runIdB = eventsB[0].runId;
+    expect(runIdA).not.toBe(runIdB);
+    expect(eventsA.every((e) => e.runId === runIdA)).toBe(true);
+    expect(eventsB.every((e) => e.runId === runIdB)).toBe(true);
+  });
+
+  it('lets a tool re-enter the loop via runChild with a derived context', async () => {
+    const childModel = new MockProvider([textTurn('child says hi')]);
+    const childEvents: RunEvent[] = [];
+    const spawningTool = echoTool({
+      name: 'spawn',
+      execute: async (_input, ctx) => {
+        for await (const event of ctx.runChild({
+          instructions: 'You are the child.',
+          model: childModel,
+          messages: [userMessage('Go')],
+        })) {
+          childEvents.push(event);
+        }
+        return 'child finished';
+      },
+    });
+    const parentModel = new MockProvider([
+      toolCallTurn({ id: 'c1', name: 'spawn', input: {} }),
+      textTurn('parent done'),
+    ]);
+    const parentEvents = await collectEvents(
+      baseInput(parentModel, { tools: [spawningTool] }),
+    );
+
+    expect(childEvents.at(-1)).toMatchObject({
+      type: 'run_end',
+      status: 'completed',
+    });
+    expect(childEvents[0].depth).toBe(1);
+    expect(childEvents[0].path).toHaveLength(2);
+    expect(childEvents[0].path[0]).toBe(parentEvents[0].runId);
+    const toolResult = parentEvents.find((e) => e.type === 'tool_result');
+    expect(toolResult).toMatchObject({ result: 'child finished' });
+  });
+
+  it('inherits parent hooks in child runs by default', async () => {
+    const phases: string[] = [];
+    const childStatuses: string[] = [];
+    const observer: Hook = {
+      name: 'observer',
+      runStart: (ctx) => {
+        phases.push(`start:${ctx.context.depth}`);
+      },
+    };
+    const childModel = new MockProvider([textTurn('child')]);
+    const spawningTool = echoTool({
+      name: 'spawn',
+      execute: async (_input, ctx) => {
+        for await (const event of ctx.runChild({
+          instructions: '',
+          model: childModel,
+          messages: [userMessage('Go')],
+        })) {
+          if (event.type === 'run_end') {
+            childStatuses.push(event.status);
+          }
+        }
+        return 'done';
+      },
+    });
+    const parentModel = new MockProvider([
+      toolCallTurn({ id: 'c1', name: 'spawn', input: {} }),
+      textTurn('parent done'),
+    ]);
+    await collectEvents(
+      baseInput(parentModel, { tools: [spawningTool], hooks: [observer] }),
+    );
+
+    expect(phases).toEqual(['start:0', 'start:1']);
+    expect(childStatuses).toEqual(['completed']);
+  });
+
+  it('reads parent context values from the child run', async () => {
+    const seen: unknown[] = [];
+    const childStatuses: string[] = [];
+    const reader: Hook = {
+      name: 'reader',
+      runStart: (ctx) => {
+        seen.push(ctx.context.get('orgId'));
+      },
+    };
+    const { RunContext } = await import('../context/run-context');
+    const childModel = new MockProvider([textTurn('child')]);
+    const spawningTool = echoTool({
+      name: 'spawn',
+      execute: async (_input, ctx) => {
+        for await (const event of ctx.runChild({
+          instructions: '',
+          model: childModel,
+          messages: [userMessage('Go')],
+        })) {
+          if (event.type === 'run_end') {
+            childStatuses.push(event.status);
+          }
+        }
+        return 'done';
+      },
+    });
+    const parentModel = new MockProvider([
+      toolCallTurn({ id: 'c1', name: 'spawn', input: {} }),
+      textTurn('parent done'),
+    ]);
+    await collectEvents(
+      baseInput(parentModel, {
+        tools: [spawningTool],
+        hooks: [reader],
+        context: RunContext.create({ orgId: 'org-1' }),
+      }),
+    );
+
+    expect(seen).toEqual(['org-1', 'org-1']);
+    expect(childStatuses).toEqual(['completed']);
+  });
+});

--- a/packages/agent-runtime/src/engine/run.ts
+++ b/packages/agent-runtime/src/engine/run.ts
@@ -1,0 +1,211 @@
+import { RunContext } from '../context/run-context';
+import {
+  AgentRuntimeError,
+  InvalidRunInputError,
+  MaxIterationsError,
+  RunAbortedError,
+} from '../contracts/errors';
+import type { RunEvent, RunEventPayload, RunStatus } from '../contracts/event';
+import { DEFAULT_MAX_ITERATIONS, type RunInput } from '../contracts/run-input';
+import { EmitBuffer, drainEmits } from './event-queue';
+import { HookRunner } from './hook-runner';
+import type { LoopCompletion } from './loop';
+import { executeLoop } from './loop';
+import { PendingMutations } from './mutations';
+import { AbortState, type RunState } from './run-state';
+
+type Stamper = (payload: RunEventPayload) => RunEvent;
+
+interface RunOutcome {
+  status: RunStatus;
+  error?: AgentRuntimeError;
+}
+
+/**
+ * The runtime's single entry point. Validates input synchronously (the
+ * only throwing path), then returns the run's event stream. All other
+ * failures surface as `error` events + `run_end` with a status.
+ */
+export const run = (input: RunInput): AsyncIterable<RunEvent> => {
+  validateRunInput(input);
+  return executeRun(input);
+};
+
+const validateRunInput = (input: RunInput): void => {
+  validateModel(input);
+  validateMessages(input);
+  validateMaxIterations(input);
+};
+
+const validateModel = (input: RunInput): void => {
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- runtime guard for untyped (plain JS) callers
+  if (!input.model) {
+    throw new InvalidRunInputError('model is required');
+  }
+};
+
+const validateMessages = (input: RunInput): void => {
+  if (!Array.isArray(input.messages) || input.messages.length === 0) {
+    throw new InvalidRunInputError('messages must be a non-empty array');
+  }
+};
+
+const validateMaxIterations = (input: RunInput): void => {
+  if (input.maxIterations === undefined) {
+    return;
+  }
+  if (!Number.isInteger(input.maxIterations) || input.maxIterations < 1) {
+    throw new InvalidRunInputError('maxIterations must be a positive integer');
+  }
+};
+
+async function* executeRun(input: RunInput): AsyncGenerator<RunEvent> {
+  const context = input.context ?? RunContext.create();
+  const state = createRunState(input, context);
+  const stamp = createStamper(context);
+  let runEndFired = false;
+  try {
+    yield stamp({ type: 'run_start', maxIterations: state.maxIterations });
+    const outcome = yield* runMain(state, stamp);
+    if (outcome.error) {
+      yield stamp(errorPayload(outcome.error));
+    }
+    runEndFired = true;
+    await fireRunEnd(state, outcome);
+    yield* stampedEmits(state, stamp);
+    yield stamp({
+      type: 'run_end',
+      status: outcome.status,
+      usage: state.usage,
+    });
+  } finally {
+    if (!runEndFired) {
+      // Consumer abandoned the stream (early return); still notify hooks.
+      await fireRunEnd(state, { status: 'aborted' });
+    }
+  }
+}
+
+async function* runMain(
+  state: RunState,
+  stamp: Stamper,
+): AsyncGenerator<RunEvent, RunOutcome> {
+  try {
+    await state.hookRunner.runStart({
+      messages: state.messages,
+      instructions: state.instructions,
+      tools: state.tools,
+    });
+    yield* stampedEmits(state, stamp);
+    const completion = yield* stampedLoop(state, stamp);
+    if (completion.status === 'max_iterations') {
+      return {
+        status: 'max_iterations',
+        error: new MaxIterationsError(state.maxIterations),
+      };
+    }
+    return { status: completion.status };
+  } catch (error) {
+    if (error instanceof RunAbortedError) {
+      return { status: 'aborted' };
+    }
+    return { status: 'error', error: toRuntimeError(error) };
+  }
+}
+
+async function* stampedLoop(
+  state: RunState,
+  stamp: Stamper,
+): AsyncGenerator<RunEvent, LoopCompletion> {
+  const generator = executeLoop(state);
+  for (;;) {
+    const next = await generator.next();
+    if (next.done) {
+      return next.value;
+    }
+    yield stamp(next.value);
+  }
+}
+
+function* stampedEmits(state: RunState, stamp: Stamper): Generator<RunEvent> {
+  for (const payload of drainEmits(state)) {
+    yield stamp(payload);
+  }
+}
+
+const createRunState = (input: RunInput, context: RunContext): RunState => {
+  const mutations = new PendingMutations();
+  const emits = new EmitBuffer();
+  const abortState = new AbortState();
+  const hooks = input.hooks ?? [];
+  const hookRunner = new HookRunner({
+    hooks,
+    context,
+    mutations,
+    emits,
+    abortState,
+  });
+  return {
+    context,
+    model: input.model,
+    messages: [...input.messages],
+    tools: [...(input.tools ?? [])],
+    instructions: input.instructions,
+    toolChoice: input.toolChoice,
+    signal: input.signal,
+    maxIterations: input.maxIterations ?? DEFAULT_MAX_ITERATIONS,
+    usage: { inputTokens: 0, outputTokens: 0 },
+    mutations,
+    emits,
+    abortState,
+    hookRunner,
+    runChild: (child) =>
+      run({
+        ...child,
+        hooks: child.hooks ?? hooks,
+        context: context.deriveChild(),
+      }),
+  };
+};
+
+const createStamper = (context: RunContext): Stamper => {
+  return (payload) => ({
+    ...payload,
+    runId: context.runId,
+    depth: context.depth,
+    path: context.path,
+    timestamp: new Date().toISOString(),
+  });
+};
+
+const errorPayload = (error: AgentRuntimeError): RunEventPayload => {
+  return {
+    type: 'error',
+    code: error.code,
+    message: error.message,
+    ...(error.details ? { details: error.details } : {}),
+  };
+};
+
+const fireRunEnd = async (
+  state: RunState,
+  outcome: RunOutcome,
+): Promise<void> => {
+  try {
+    await state.hookRunner.runEnd({
+      messages: state.messages,
+      status: outcome.status,
+      error: outcome.error,
+    });
+  } catch {
+    // runEnd hook failures must not mask the run's outcome.
+  }
+};
+
+const toRuntimeError = (error: unknown): AgentRuntimeError => {
+  if (error instanceof AgentRuntimeError) {
+    return error;
+  }
+  const message = error instanceof Error ? error.message : 'Run failed';
+  return new AgentRuntimeError('RUN_FAILED', message, { cause: error });
+};

--- a/packages/agent-runtime/src/engine/test-helpers.ts
+++ b/packages/agent-runtime/src/engine/test-helpers.ts
@@ -1,0 +1,46 @@
+import type { RunEvent } from '../contracts/event';
+import type { Message } from '../contracts/message';
+import type { RunInput } from '../contracts/run-input';
+import type { Tool } from '../contracts/tool';
+import type { MockProvider } from '../providers/mock/mock-provider';
+import { run } from './run';
+
+export const userMessage = (text: string): Message => ({
+  role: 'user',
+  content: [{ type: 'text', text }],
+});
+
+export const echoTool = (overrides: Partial<Tool> = {}): Tool => ({
+  name: 'echo',
+  description: 'Echoes the input back',
+  parameters: {
+    type: 'object',
+    properties: { value: { type: 'string' } },
+  },
+  execute: (input) => `echo: ${String(input.value)}`,
+  ...overrides,
+});
+
+export const collectEvents = async (input: RunInput): Promise<RunEvent[]> => {
+  const events: RunEvent[] = [];
+  for await (const event of run(input)) {
+    events.push(event);
+  }
+  return events;
+};
+
+export const eventTypes = (events: readonly RunEvent[]): string[] => {
+  return events.map((event) => event.type);
+};
+
+export const baseInput = (
+  model: MockProvider,
+  overrides: Partial<RunInput> = {},
+): RunInput => {
+  return {
+    instructions: 'Be helpful.',
+    model,
+    messages: [userMessage('Hi')],
+    ...overrides,
+  };
+};

--- a/packages/agent-runtime/src/engine/tool-executor.ts
+++ b/packages/agent-runtime/src/engine/tool-executor.ts
@@ -1,0 +1,134 @@
+import type { RunEventPayload, ToolCallSummary } from '../contracts/event';
+import type { ToolResultContent, ToolUseContent } from '../contracts/message';
+import type { Tool, ToolExecutionContext } from '../contracts/tool';
+import { drainEmits } from './event-queue';
+import type { RunState } from './run-state';
+import { isAborted } from './run-state';
+
+export const MAX_TOOL_RESULT_LENGTH = 20_000;
+
+interface ToolOutcome {
+  result: string;
+  isError: boolean;
+}
+
+/**
+ * Executes the tool calls of one iteration sequentially, firing
+ * beforeToolCall/afterToolCall hooks around each and yielding tool_result
+ * events. Tool failures become error-flagged results — never throws.
+ *
+ * Once the run is aborted (via signal or a hook, including beforeToolCall
+ * itself), remaining calls are not executed; they get synthetic aborted
+ * results instead, so the tool_result message always pairs every tool_use
+ * block and the transcript stays well-formed.
+ */
+export async function* executeToolCalls(
+  state: RunState,
+  iteration: number,
+  calls: readonly ToolUseContent[],
+): AsyncGenerator<RunEventPayload, ToolResultContent[]> {
+  const results: ToolResultContent[] = [];
+  for (const call of calls) {
+    const requested: ToolCallSummary = {
+      id: call.id,
+      name: call.name,
+      input: call.input,
+    };
+    let toolCall = requested;
+    let outcome: ToolOutcome;
+    if (isAborted(state)) {
+      outcome = abortedOutcome();
+    } else {
+      toolCall = await state.hookRunner.beforeToolCall({
+        iteration,
+        toolCall: requested,
+        findTool: (name) => findTool(state, name),
+      });
+      yield* drainEmits(state);
+      outcome = isAborted(state)
+        ? abortedOutcome()
+        : await runTool(state, findTool(state, toolCall.name), toolCall);
+    }
+    await state.hookRunner.afterToolCall({
+      iteration,
+      toolCall,
+      result: outcome.result,
+      isError: outcome.isError,
+    });
+    yield* drainEmits(state);
+    results.push({
+      type: 'tool_result',
+      toolCallId: toolCall.id,
+      toolName: toolCall.name,
+      result: outcome.result,
+      isError: outcome.isError,
+    });
+    yield {
+      type: 'tool_result',
+      toolCallId: toolCall.id,
+      toolName: toolCall.name,
+      result: outcome.result,
+      isError: outcome.isError,
+    };
+  }
+  return results;
+}
+
+const abortedOutcome = (): ToolOutcome => ({
+  result: 'The run was aborted before this tool call was executed.',
+  isError: true,
+});
+
+const findTool = (state: RunState, name: string): Tool | undefined => {
+  return state.tools.find((tool) => tool.name === name);
+};
+
+const runTool = async (
+  state: RunState,
+  tool: Tool | undefined,
+  call: ToolCallSummary,
+): Promise<ToolOutcome> => {
+  if (!tool) {
+    return {
+      result: `A tool with the name ${call.name} was not found. It might have been removed or renamed.`,
+      isError: true,
+    };
+  }
+  if (!tool.execute) {
+    return {
+      result: `The tool ${call.name} is display-only and cannot be executed.`,
+      isError: true,
+    };
+  }
+  try {
+    const value = await tool.execute(
+      call.input,
+      buildToolContext(state, call.id),
+    );
+    return { result: clampResult(value), isError: false };
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : 'Tool execution failed';
+    return { result: message, isError: true };
+  }
+};
+
+const buildToolContext = (
+  state: RunState,
+  toolCallId: string,
+): ToolExecutionContext => {
+  return {
+    context: state.context,
+    toolCallId,
+    signal: state.signal,
+    emit: (event) => state.emits.push(event),
+    runChild: state.runChild,
+  };
+};
+
+const clampResult = (result: string): string => {
+  if (result.length <= MAX_TOOL_RESULT_LENGTH) {
+    return result;
+  }
+  return `${result.slice(0, MAX_TOOL_RESULT_LENGTH)}\n[result truncated]`;
+};

--- a/packages/agent-runtime/src/index.ts
+++ b/packages/agent-runtime/src/index.ts
@@ -46,9 +46,16 @@ export type { ChildRunInput, RunInput } from './contracts/run-input';
 export { DEFAULT_MAX_ITERATIONS } from './contracts/run-input';
 export {
   AgentRuntimeError,
+  HookFailedError,
   InvalidRunInputError,
   MaxIterationsError,
   ProviderError,
   RunAbortedError,
 } from './contracts/errors';
 export { RunContext } from './context/run-context';
+export { run } from './engine/run';
+export {
+  MockProvider,
+  textTurn,
+  toolCallTurn,
+} from './providers/mock/mock-provider';

--- a/packages/agent-runtime/src/providers/mock/mock-provider.ts
+++ b/packages/agent-runtime/src/providers/mock/mock-provider.ts
@@ -1,0 +1,70 @@
+import type {
+  ModelProvider,
+  ProviderChunk,
+  ProviderRequest,
+  Usage,
+} from '../../contracts/provider';
+
+/**
+ * Deterministic provider for tests and examples. Plays back one scripted
+ * chunk turn per stream() call and records every request it receives
+ * (snapshotted, so later state mutations don't affect assertions).
+ */
+export class MockProvider implements ModelProvider {
+  readonly name = 'mock';
+  readonly requests: ProviderRequest[] = [];
+  private turnIndex = 0;
+
+  constructor(private readonly turns: readonly (readonly ProviderChunk[])[]) {}
+
+  async *stream(request: ProviderRequest): AsyncIterable<ProviderChunk> {
+    this.requests.push(snapshotRequest(request));
+    const turn = this.turns[this.turnIndex] ?? [];
+    this.turnIndex += 1;
+    for (const chunk of turn) {
+      await Promise.resolve();
+      yield chunk;
+    }
+  }
+}
+
+const snapshotRequest = (request: ProviderRequest): ProviderRequest => {
+  return {
+    instructions: request.instructions,
+    messages: [...request.messages],
+    tools: request.tools.map((tool) => ({ ...tool })),
+    ...(request.toolChoice !== undefined
+      ? { toolChoice: request.toolChoice }
+      : {}),
+  };
+};
+
+const DEFAULT_USAGE: Usage = { inputTokens: 10, outputTokens: 5 };
+
+/** A text-only turn, split into two deltas plus a finish chunk. */
+export const textTurn = (
+  text: string,
+  usage: Usage = DEFAULT_USAGE,
+): ProviderChunk[] => {
+  const mid = Math.ceil(text.length / 2);
+  return [
+    { textDelta: text.slice(0, mid) },
+    { textDelta: text.slice(mid) },
+    { finishReason: 'stop', usage },
+  ];
+};
+
+/** A tool-call turn with the arguments JSON split across two deltas. */
+export const toolCallTurn = (
+  call: { id: string; name: string; input: Record<string, unknown> },
+  usage: Usage = DEFAULT_USAGE,
+): ProviderChunk[] => {
+  const json = JSON.stringify(call.input);
+  const mid = Math.ceil(json.length / 2);
+  return [
+    { toolCallDeltas: [{ index: 0, id: call.id, name: call.name }] },
+    { toolCallDeltas: [{ index: 0, argumentsDelta: json.slice(0, mid) }] },
+    { toolCallDeltas: [{ index: 0, argumentsDelta: json.slice(mid) }] },
+    { finishReason: 'tool_calls', usage },
+  ];
+};


### PR DESCRIPTION
- run(): flat free-function entry; validates synchronously, then streams
  RunEvents; errors surface as events + run_end status, never mid-stream
  throws
- loop: iteration cap, no-tool-calls / display-only exit, chunk
  accumulation with providerMetadata + thinking signature round-trip,
  20k tool-result clamp, unknown-tool synthetic error results
- hooks: six phases in registration order; buffered mutations
  (transformMessages, add/remove/setTools, addInstructions) applied at
  next request assembly; immediate abort + custom-event emit;
  rewriteToolCall in beforeToolCall
- subagent seams: re-entrant loop with zero module state, runChild with
  derived context + inherited hooks, depth/path event envelope
- deterministic MockProvider with scripted turns + request recording
- top-level helpers are arrow consts: lizard's TS parser merges plain
  annotated function declarations into following functions, which both
  causes spurious threshold failures and hides real ones
- 58 vitest specs covering loop semantics, hook order, mutation timing,
  accumulator, abort, and re-entrancy

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new core orchestration (hooks can mutate messages/tools, subagent re-entrancy, abort mid-batch) with extensive tests but no prior production callers in this diff; integration mistakes could affect all future agent runs.
> 
> **Overview**
> Adds the **agent-runtime execution engine**: a streaming **`run()`** entry that validates input synchronously, then emits stamped **`RunEvent`**s; runtime failures show up as **`error`** plus **`run_end`**, not mid-stream throws.
> 
> The **model ↔ tool loop** streams provider chunks through **`ChunkAccumulator`** (text/thinking/tool JSON, usage, provider metadata), runs tools with error results and a 20k result clamp, honors iteration caps and **display-only** tools (no execute), and wires **`AbortSignal`** through model calls and tool context.
> 
> **Hooks** run six phases in order via **`HookRunner`**, with buffered mutations applied before each model request, immediate **`abort`** / **`emit`**, **`rewriteToolCall`** in **`beforeToolCall`**, and **`HookFailedError`** for attributed failures. **`runChild`** supports nested runs with derived context, inherited hooks, and depth/path on events.
> 
> Also ships a deterministic **`MockProvider`**, exports **`run`** / mock helpers from the package index, and adds broad Vitest coverage for loop, hooks, abort, mutations, and re-entrancy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e1462aaf72f6850642b1ed64b70b640253fdc07. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->