### PR TITLE
wip(agent-runtime): add the shipped Anthropic model provider (AYC-148)

### DIFF
--- a/packages/agent-runtime/package.json
+++ b/packages/agent-runtime/package.json
@@ -30,6 +30,9 @@
     "format": "prettier --write \"src/**/*.ts\" \"examples/**/*.ts\"",
     "deps:check": "madge --circular --extensions ts src"
   },
+  "dependencies": {
+    "@anthropic-ai/sdk": "^0.59.0"
+  },
   "devDependencies": {
     "@eslint/js": "^9.18.0",
     "@types/node": "^24.12.2",

--- a/packages/agent-runtime/src/index.ts
+++ b/packages/agent-runtime/src/index.ts
@@ -59,3 +59,7 @@ export {
   textTurn,
   toolCallTurn,
 } from './providers/mock/mock-provider';
+export {
+  anthropic,
+  type AnthropicProviderOptions,
+} from './providers/anthropic/anthropic-provider';

--- a/packages/agent-runtime/src/providers/anthropic/anthropic-provider.smoke.spec.ts
+++ b/packages/agent-runtime/src/providers/anthropic/anthropic-provider.smoke.spec.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+
+import { run } from '../../engine/run';
+import { anthropic } from './anthropic-provider';
+
+const apiKey = process.env.ANTHROPIC_API_KEY;
+
+/**
+ * Live smoke against the real Anthropic API. Skipped unless
+ * ANTHROPIC_API_KEY is set; excluded from CI by default.
+ */
+describe.skipIf(!apiKey)('anthropic provider (live)', () => {
+  it('streams a tool-use run end to end', async () => {
+    const model = anthropic({
+      apiKey: apiKey ?? '',
+      model: 'claude-haiku-4-5',
+      maxTokens: 1024,
+    });
+    const types: string[] = [];
+    let answer = '';
+    for await (const event of run({
+      instructions:
+        'Use the get_number tool, then answer with the number it returns.',
+      model,
+      tools: [
+        {
+          name: 'get_number',
+          description: 'Returns a secret number',
+          parameters: { type: 'object', properties: {} },
+          execute: () => 'The number is 7274.',
+        },
+      ],
+      messages: [
+        {
+          role: 'user',
+          content: [{ type: 'text', text: 'What is the number?' }],
+        },
+      ],
+    })) {
+      types.push(event.type);
+      if (event.type === 'text_delta') {
+        answer += event.delta;
+      }
+    }
+
+    expect(types).toContain('tool_call');
+    expect(types).toContain('tool_result');
+    expect(types.at(-1)).toBe('run_end');
+    expect(answer).toContain('7274');
+  }, 60_000);
+});

--- a/packages/agent-runtime/src/providers/anthropic/anthropic-provider.ts
+++ b/packages/agent-runtime/src/providers/anthropic/anthropic-provider.ts
@@ -1,0 +1,78 @@
+import Anthropic from '@anthropic-ai/sdk';
+import type { MessageCreateParamsStreaming } from '@anthropic-ai/sdk/resources/messages';
+
+import type {
+  ModelProvider,
+  ProviderChunk,
+  ProviderRequest,
+} from '../../contracts/provider';
+import { convertChunk } from './convert-chunk';
+import {
+  convertMessages,
+  convertTool,
+  convertToolChoice,
+} from './convert-request';
+
+const DEFAULT_MAX_TOKENS = 64_000;
+
+export interface AnthropicProviderOptions {
+  apiKey: string;
+  /** Anthropic model id, e.g. 'claude-sonnet-4-5'. */
+  model: string;
+  maxTokens?: number;
+  baseUrl?: string;
+  /** SDK-level retry count for transient failures. Default: 2. */
+  maxRetries?: number;
+}
+
+/**
+ * The shipped Anthropic ModelProvider. The host supplies selection and
+ * credentials; everything else (wire format, streaming, chunk parsing)
+ * lives here.
+ */
+export const anthropic = (options: AnthropicProviderOptions): ModelProvider => {
+  const client = new Anthropic({
+    apiKey: options.apiKey,
+    ...(options.baseUrl ? { baseURL: options.baseUrl } : {}),
+    ...(options.maxRetries !== undefined
+      ? { maxRetries: options.maxRetries }
+      : {}),
+  });
+  return {
+    name: `anthropic:${options.model}`,
+    stream: (request) => streamAnthropic(client, options, request),
+  };
+};
+
+async function* streamAnthropic(
+  client: Anthropic,
+  options: AnthropicProviderOptions,
+  request: ProviderRequest,
+): AsyncIterable<ProviderChunk> {
+  const params = buildParams(options, request);
+  const stream = await client.messages.create(
+    params,
+    request.signal ? { signal: request.signal } : undefined,
+  );
+  for await (const event of stream) {
+    const chunk = convertChunk(event);
+    if (chunk) {
+      yield chunk;
+    }
+  }
+}
+
+const buildParams = (
+  options: AnthropicProviderOptions,
+  request: ProviderRequest,
+): MessageCreateParamsStreaming => ({
+  model: options.model,
+  system: request.instructions,
+  messages: convertMessages(request.messages),
+  tools: request.tools.map(convertTool),
+  ...(request.toolChoice !== undefined
+    ? { tool_choice: convertToolChoice(request.toolChoice) }
+    : {}),
+  max_tokens: options.maxTokens ?? DEFAULT_MAX_TOKENS,
+  stream: true,
+});

--- a/packages/agent-runtime/src/providers/anthropic/convert-chunk.spec.ts
+++ b/packages/agent-runtime/src/providers/anthropic/convert-chunk.spec.ts
@@ -1,0 +1,114 @@
+import type Anthropic from '@anthropic-ai/sdk';
+import { describe, expect, it } from 'vitest';
+
+import { convertChunk } from './convert-chunk';
+
+const event = (value: unknown): Anthropic.Messages.MessageStreamEvent =>
+  value as Anthropic.Messages.MessageStreamEvent;
+
+describe('convertChunk', () => {
+  it('converts message_start to input usage', () => {
+    expect(
+      convertChunk(
+        event({
+          type: 'message_start',
+          message: { usage: { input_tokens: 123 } },
+        }),
+      ),
+    ).toEqual({ usage: { inputTokens: 123 } });
+  });
+
+  it('converts text deltas', () => {
+    expect(
+      convertChunk(
+        event({
+          type: 'content_block_delta',
+          index: 0,
+          delta: { type: 'text_delta', text: 'Hello' },
+        }),
+      ),
+    ).toEqual({ textDelta: 'Hello' });
+  });
+
+  it('converts thinking and signature deltas', () => {
+    expect(
+      convertChunk(
+        event({
+          type: 'content_block_delta',
+          index: 0,
+          delta: { type: 'thinking_delta', thinking: 'Hmm' },
+        }),
+      ),
+    ).toEqual({ thinkingDelta: 'Hmm' });
+    expect(
+      convertChunk(
+        event({
+          type: 'content_block_delta',
+          index: 0,
+          delta: { type: 'signature_delta', signature: 'sig-1' },
+        }),
+      ),
+    ).toEqual({ thinkingSignature: 'sig-1' });
+  });
+
+  it('converts tool_use block starts to id/name deltas', () => {
+    expect(
+      convertChunk(
+        event({
+          type: 'content_block_start',
+          index: 1,
+          content_block: { type: 'tool_use', id: 'toolu_1', name: 'search' },
+        }),
+      ),
+    ).toEqual({
+      toolCallDeltas: [{ index: 1, id: 'toolu_1', name: 'search' }],
+    });
+  });
+
+  it('converts input_json deltas to argument deltas', () => {
+    expect(
+      convertChunk(
+        event({
+          type: 'content_block_delta',
+          index: 1,
+          delta: { type: 'input_json_delta', partial_json: '{"q":' },
+        }),
+      ),
+    ).toEqual({ toolCallDeltas: [{ index: 1, argumentsDelta: '{"q":' }] });
+  });
+
+  it.each([
+    ['end_turn', 'stop'],
+    ['stop_sequence', 'stop'],
+    ['max_tokens', 'length'],
+    ['tool_use', 'tool_calls'],
+    ['refusal', null],
+    [null, null],
+  ])('maps stop reason %s to %s', (stopReason, finishReason) => {
+    expect(
+      convertChunk(
+        event({
+          type: 'message_delta',
+          delta: { stop_reason: stopReason },
+          usage: { output_tokens: 7 },
+        }),
+      ),
+    ).toEqual({ finishReason, usage: { outputTokens: 7 } });
+  });
+
+  it('returns null for events without content', () => {
+    expect(convertChunk(event({ type: 'message_stop' }))).toBeNull();
+    expect(
+      convertChunk(
+        event({
+          type: 'content_block_start',
+          index: 0,
+          content_block: { type: 'thinking' },
+        }),
+      ),
+    ).toBeNull();
+    expect(
+      convertChunk(event({ type: 'content_block_stop', index: 0 })),
+    ).toBeNull();
+  });
+});

--- a/packages/agent-runtime/src/providers/anthropic/convert-chunk.ts
+++ b/packages/agent-runtime/src/providers/anthropic/convert-chunk.ts
@@ -1,0 +1,87 @@
+import type Anthropic from '@anthropic-ai/sdk';
+
+import type { FinishReason, ProviderChunk } from '../../contracts/provider';
+
+/**
+ * Converts one Anthropic stream event to a provider-agnostic chunk.
+ * Returns null for events that carry nothing (ping, block stops).
+ */
+export const convertChunk = (
+  event: Anthropic.Messages.MessageStreamEvent,
+): ProviderChunk | null => {
+  switch (event.type) {
+    case 'content_block_delta':
+      return convertContentBlockDelta(event);
+    case 'content_block_start':
+      return convertContentBlockStart(event);
+    case 'message_start':
+      return {
+        usage: { inputTokens: event.message.usage.input_tokens },
+      };
+    case 'message_delta':
+      return {
+        finishReason: mapStopReason(event.delta.stop_reason),
+        usage: { outputTokens: event.usage.output_tokens },
+      };
+    case 'message_stop':
+    case 'content_block_stop':
+      return null;
+  }
+};
+
+const convertContentBlockDelta = (
+  event: Anthropic.Messages.ContentBlockDeltaEvent,
+): ProviderChunk | null => {
+  switch (event.delta.type) {
+    case 'thinking_delta':
+      return { thinkingDelta: event.delta.thinking };
+    case 'signature_delta':
+      return { thinkingSignature: event.delta.signature };
+    case 'text_delta':
+      return { textDelta: event.delta.text };
+    case 'input_json_delta':
+      return {
+        toolCallDeltas: [
+          { index: event.index, argumentsDelta: event.delta.partial_json },
+        ],
+      };
+    case 'citations_delta':
+      return null;
+  }
+};
+
+const convertContentBlockStart = (
+  event: Anthropic.Messages.ContentBlockStartEvent,
+): ProviderChunk | null => {
+  if (event.content_block.type !== 'tool_use') {
+    return null;
+  }
+  return {
+    toolCallDeltas: [
+      {
+        index: event.index,
+        id: event.content_block.id,
+        name: event.content_block.name,
+      },
+    ],
+  };
+};
+
+const mapStopReason = (
+  reason: Anthropic.Messages.MessageDeltaEvent['delta']['stop_reason'],
+): FinishReason => {
+  switch (reason) {
+    case 'end_turn':
+    case 'stop_sequence':
+      return 'stop';
+    case 'max_tokens':
+      return 'length';
+    case 'tool_use':
+      return 'tool_calls';
+    case 'pause_turn':
+    case 'refusal':
+    case null:
+    default:
+      return null;
+  }
+};

--- a/packages/agent-runtime/src/providers/anthropic/convert-request.spec.ts
+++ b/packages/agent-runtime/src/providers/anthropic/convert-request.spec.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it } from 'vitest';
+
+import type { Message } from '../../contracts/message';
+import {
+  convertMessages,
+  convertTool,
+  convertToolChoice,
+} from './convert-request';
+
+describe('convertTool', () => {
+  it('maps the schema to Anthropic input_schema', () => {
+    expect(
+      convertTool({
+        name: 'search',
+        description: 'Searches',
+        parameters: { type: 'object', properties: {} },
+      }),
+    ).toEqual({
+      name: 'search',
+      description: 'Searches',
+      input_schema: { type: 'object', properties: {} },
+    });
+  });
+});
+
+describe('convertToolChoice', () => {
+  it('maps auto, required, and specific tool', () => {
+    expect(convertToolChoice('auto')).toEqual({ type: 'auto' });
+    expect(convertToolChoice('required')).toEqual({ type: 'any' });
+    expect(convertToolChoice({ tool: 'search' })).toEqual({
+      type: 'tool',
+      name: 'search',
+    });
+  });
+});
+
+describe('convertMessages', () => {
+  it('converts a user/assistant/tool_result conversation', () => {
+    const messages: Message[] = [
+      { role: 'user', content: [{ type: 'text', text: 'Find agents' }] },
+      {
+        role: 'assistant',
+        content: [
+          { type: 'text', text: 'Searching.' },
+          {
+            type: 'tool_use',
+            id: 'toolu_1',
+            name: 'search',
+            input: { q: 'agents' },
+          },
+        ],
+      },
+      {
+        role: 'tool_result',
+        content: [
+          {
+            type: 'tool_result',
+            toolCallId: 'toolu_1',
+            toolName: 'search',
+            result: '3 results',
+          },
+        ],
+      },
+    ];
+
+    expect(convertMessages(messages)).toEqual([
+      { role: 'user', content: [{ type: 'text', text: 'Find agents' }] },
+      {
+        role: 'assistant',
+        content: [
+          { type: 'text', text: 'Searching.' },
+          {
+            type: 'tool_use',
+            id: 'toolu_1',
+            name: 'search',
+            input: { q: 'agents' },
+          },
+        ],
+      },
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: 'toolu_1',
+            content: '3 results',
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('merges consecutive non-assistant messages into one user turn', () => {
+    const messages: Message[] = [
+      {
+        role: 'tool_result',
+        content: [
+          {
+            type: 'tool_result',
+            toolCallId: 'toolu_1',
+            toolName: 'search',
+            result: 'ok',
+          },
+        ],
+      },
+      { role: 'user', content: [{ type: 'text', text: 'Continue' }] },
+    ];
+
+    const converted = convertMessages(messages);
+    expect(converted).toHaveLength(1);
+    expect(converted[0].role).toBe('user');
+    expect(converted[0].content).toHaveLength(2);
+  });
+
+  it('marks errored tool results with is_error', () => {
+    const messages: Message[] = [
+      {
+        role: 'tool_result',
+        content: [
+          {
+            type: 'tool_result',
+            toolCallId: 'toolu_1',
+            toolName: 'search',
+            result: 'not found',
+            isError: true,
+          },
+        ],
+      },
+    ];
+
+    expect(convertMessages(messages)[0].content).toEqual([
+      {
+        type: 'tool_result',
+        tool_use_id: 'toolu_1',
+        content: 'not found',
+        is_error: true,
+      },
+    ]);
+  });
+
+  it('drops assistant turns whose content converts to nothing', () => {
+    const messages: Message[] = [
+      { role: 'user', content: [{ type: 'text', text: 'Hi' }] },
+      {
+        role: 'assistant',
+        content: [
+          { type: 'thinking', thinking: 'unsigned', id: null, signature: null },
+        ],
+      },
+      { role: 'user', content: [{ type: 'text', text: 'Still there?' }] },
+    ];
+
+    const converted = convertMessages(messages);
+    expect(converted).toHaveLength(1);
+    expect(converted[0].role).toBe('user');
+    expect(converted[0].content).toHaveLength(2);
+  });
+
+  it('replays signed thinking blocks and drops unsigned ones', () => {
+    const messages: Message[] = [
+      {
+        role: 'assistant',
+        content: [
+          { type: 'thinking', thinking: 'unsigned', id: null, signature: null },
+          {
+            type: 'thinking',
+            thinking: 'signed',
+            id: null,
+            signature: 'sig-1',
+          },
+          { type: 'text', text: 'Answer' },
+        ],
+      },
+    ];
+
+    expect(convertMessages(messages)[0].content).toEqual([
+      { type: 'thinking', thinking: 'signed', signature: 'sig-1' },
+      { type: 'text', text: 'Answer' },
+    ]);
+  });
+});

--- a/packages/agent-runtime/src/providers/anthropic/convert-request.ts
+++ b/packages/agent-runtime/src/providers/anthropic/convert-request.ts
@@ -1,0 +1,120 @@
+import type Anthropic from '@anthropic-ai/sdk';
+
+import type { Message, MessageContent } from '../../contracts/message';
+import type { ToolChoice } from '../../contracts/provider';
+import type { ToolSchema } from '../../contracts/tool';
+
+type AnthropicToolChoice =
+  | Anthropic.Messages.ToolChoiceAuto
+  | Anthropic.Messages.ToolChoiceAny
+  | Anthropic.Messages.ToolChoiceTool;
+
+export const convertTool = (tool: ToolSchema): Anthropic.Tool => ({
+  name: tool.name,
+  description: tool.description,
+  input_schema: tool.parameters as Anthropic.Messages.Tool.InputSchema,
+});
+
+export const convertToolChoice = (
+  toolChoice: ToolChoice,
+): AnthropicToolChoice => {
+  if (toolChoice === 'auto') {
+    return { type: 'auto' };
+  }
+  if (toolChoice === 'required') {
+    return { type: 'any' };
+  }
+  return { type: 'tool', name: toolChoice.tool };
+};
+
+/**
+ * Converts runtime messages to Anthropic params. Consecutive non-assistant
+ * messages (user input, tool results) are merged into a single user turn —
+ * Anthropic requires alternating user/assistant roles.
+ */
+export const convertMessages = (
+  messages: readonly Message[],
+): Anthropic.MessageParam[] => {
+  const converted: Anthropic.MessageParam[] = [];
+  for (const message of messages) {
+    const next = convertMessage(message);
+    // A message can convert to nothing (e.g. an assistant turn whose only
+    // content was unsigned thinking) — Anthropic rejects empty content.
+    if (asBlocks(next.content).length === 0) {
+      continue;
+    }
+    const last = converted.at(-1);
+    if (last?.role === 'user' && next.role === 'user') {
+      last.content = [...asBlocks(last.content), ...asBlocks(next.content)];
+    } else {
+      converted.push(next);
+    }
+  }
+  return converted;
+};
+
+const asBlocks = (
+  content: Anthropic.MessageParam['content'],
+): Anthropic.ContentBlockParam[] =>
+  typeof content === 'string' ? [{ type: 'text', text: content }] : content;
+
+const convertMessage = (message: Message): Anthropic.MessageParam => {
+  if (message.role === 'assistant') {
+    return {
+      role: 'assistant',
+      content: message.content
+        .map(convertAssistantContent)
+        .filter((block): block is NonNullable<typeof block> => block !== null),
+    };
+  }
+  return { role: 'user', content: message.content.map(convertUserContent) };
+};
+
+const convertAssistantContent = (
+  content: MessageContent,
+): Anthropic.ContentBlockParam | null => {
+  switch (content.type) {
+    case 'thinking':
+      // Thinking blocks without a signature cannot be replayed to Anthropic.
+      if (!content.signature) {
+        return null;
+      }
+      return {
+        type: 'thinking',
+        thinking: content.thinking,
+        signature: content.signature,
+      };
+    case 'text':
+      return { type: 'text', text: content.text };
+    case 'tool_use':
+      return {
+        type: 'tool_use',
+        id: content.id,
+        name: content.name,
+        input: content.input,
+      };
+    case 'tool_result':
+      return null;
+  }
+};
+
+const convertUserContent = (
+  content: MessageContent,
+): Anthropic.ContentBlockParam => {
+  switch (content.type) {
+    case 'tool_result':
+      return {
+        type: 'tool_result',
+        tool_use_id: content.toolCallId,
+        content: content.result,
+        ...(content.isError ? { is_error: true } : {}),
+      };
+    case 'text':
+    case 'thinking':
+    case 'tool_use':
+      return {
+        type: 'text',
+        text: content.type === 'text' ? content.text : '',
+      };
+  }
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -627,6 +627,10 @@ importers:
         version: 4.2.4
 
   packages/agent-runtime:
+    dependencies:
+      '@anthropic-ai/sdk':
+        specifier: ^0.59.0
+        version: 0.59.0
     devDependencies:
       '@eslint/js':
         specifier: ^9.18.0


### PR DESCRIPTION
- anthropic({ apiKey, model, maxTokens?, baseUrl?, maxRetries? }) factory:
  the host supplies selection + credentials, the provider owns wire
  format, streaming, and chunk parsing
- request conversion ported from the backend's AnthropicMessageConverter:
  alternating-role merge, signed-thinking replay (unsigned dropped),
  tool_result with is_error; toolChoice 'required' maps to {type:'any'}
  instead of throwing
- chunk conversion ported from BaseAnthropicStreamInferenceHandler:
  thinking/signature/text/input_json deltas, tool_use block starts,
  stop-reason mapping, usage from message_start/message_delta
- fixture-based conversion specs + live smoke behind ANTHROPIC_API_KEY

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New external API integration and message/thinking replay rules affect real agent runs; scope is isolated to the new provider module with strong unit coverage and optional live smoke only.
> 
> **Overview**
> Adds a **production Anthropic `ModelProvider`** to `@ayunis/agent-runtime`, exported as `anthropic()` alongside the existing mock provider. Hosts pass **API key, model id**, and optional **max tokens, base URL, and SDK retries**; the provider builds streaming Messages API calls and maps SDK stream events into **`ProviderChunk`** for the existing `run()` loop.
> 
> **Request path:** runtime messages/tools/tool choice are converted to Anthropic wire format—**alternating user/assistant roles** via merging consecutive user-side turns, **tool results** with `is_error`, **signed thinking replay** (unsigned thinking dropped), and **`required` tool choice → `{ type: 'any' }`**.
> 
> **Response path:** stream events become text/thinking/signature deltas, **tool-use** id/name/JSON argument deltas, **finish reason** mapping, and **input/output token usage**.
> 
> Adds **`@anthropic-ai/sdk`** as a runtime dependency, **unit specs** for converters, and an **optional live smoke test** gated on `ANTHROPIC_API_KEY`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d282e85accd4571dfd5f2d44c842d4a76c5ec6fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->