### PR TITLE
feat(addons): add org add-on management with webhook events (AYC-154)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -58,6 +58,7 @@ ayunis-core/
 | [users](ayunis-core-backend/src/iam/users/SUMMARY.md) | Accounts | User profiles and credentials |
 | [orgs](ayunis-core-backend/src/iam/orgs/SUMMARY.md) | Tenants | Multi-tenant organization management |
 | [subscriptions](ayunis-core-backend/src/iam/subscriptions/SUMMARY.md) | Billing | Package and subscription management |
+| [addons](ayunis-core-backend/src/iam/addons/SUMMARY.md) | Add-ons | Per-org add-on activation managed by super admins |
 | [quotas](ayunis-core-backend/src/iam/quotas/SUMMARY.md) | Limits | Usage quota enforcement |
 | [teams](ayunis-core-backend/src/iam/teams/SUMMARY.md) | Groups | Team-based access control |
 | [invites](ayunis-core-backend/src/iam/invites/SUMMARY.md) | Onboarding | User invitation flows |

--- a/ayunis-core-backend/src/db/migrations/1781266620302-CreateOrgAddonsTable.ts
+++ b/ayunis-core-backend/src/db/migrations/1781266620302-CreateOrgAddonsTable.ts
@@ -1,0 +1,18 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class CreateOrgAddonsTable1781266620302 implements MigrationInterface {
+    name = 'CreateOrgAddonsTable1781266620302'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`CREATE TABLE "org_addons" ("id" character varying NOT NULL, "createdAt" TIMESTAMP NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP NOT NULL DEFAULT now(), "type" character varying NOT NULL, "orgId" character varying NOT NULL, CONSTRAINT "UQ_a953cb4c09b15312670c9b231f3" UNIQUE ("orgId", "type"), CONSTRAINT "PK_5dbfcf5b94594de8a2784e7f02c" PRIMARY KEY ("id"))`);
+        await queryRunner.query(`CREATE INDEX "IDX_fb23061601e379b2b95aef9040" ON "org_addons" ("orgId") `);
+        await queryRunner.query(`ALTER TABLE "org_addons" ADD CONSTRAINT "FK_fb23061601e379b2b95aef90408" FOREIGN KEY ("orgId") REFERENCES "orgs"("id") ON DELETE CASCADE ON UPDATE NO ACTION`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "org_addons" DROP CONSTRAINT "FK_fb23061601e379b2b95aef90408"`);
+        await queryRunner.query(`DROP INDEX "public"."IDX_fb23061601e379b2b95aef9040"`);
+        await queryRunner.query(`DROP TABLE "org_addons"`);
+    }
+
+}

--- a/ayunis-core-backend/src/iam/addons/SUMMARY.md
+++ b/ayunis-core-backend/src/iam/addons/SUMMARY.md
@@ -1,0 +1,40 @@
+# Addons
+
+Per-organization **add-ons** that super admins activate and deactivate. The
+add-on catalog is the hardcoded `AddonType` enum (currently only
+`ayunis_core_academy` — Ayunis Core Academy).
+
+## Model
+
+- `OrgAddon` — `{ id, orgId, type }`, one row per active (org, add-on) pair
+  with `UNIQUE(orgId, type)`.
+- **Row exists = active.** Activation inserts the row, deactivation deletes it.
+  Both operations are idempotent: re-activating an active add-on (or
+  re-deactivating an inactive one) is a no-op and emits no event.
+
+## Events
+
+On a real state change the use cases emit fire-and-forget domain events that
+the webhooks module relays to the configured webhook endpoint:
+
+- `addon.activated` (`AddonActivatedEvent`)
+- `addon.deactivated` (`AddonDeactivatedEvent`)
+
+Payload: `{ orgId, addonType, actorUserId }` — `actorUserId` is the super
+admin who flipped the toggle.
+
+## Management
+
+Super-admin only — `SuperAdminAddonsController`
+(`super-admin/addons/:orgId`, `@SystemRoles(SUPER_ADMIN)`): list the full
+catalog with active flags / activate (`POST :orgId/:type`) / deactivate
+(`DELETE :orgId/:type`). There is no org-facing surface yet; feature gating
+on active add-ons comes with the first concrete add-on implementation
+(`ListOrgAddonsUseCase` is exported for that purpose).
+
+## Layout
+
+Standard hexagonal: `domain/` (entity, `AddonType` enum, `AddonStatus`),
+`application/` (repository port, use-cases, events, errors), `infrastructure/`
+(Postgres record + mapper + repository), `presenters/http/` (super-admin
+controller + DTO).

--- a/ayunis-core-backend/src/iam/addons/addons.module.ts
+++ b/ayunis-core-backend/src/iam/addons/addons.module.ts
@@ -1,0 +1,29 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+
+import { OrgAddonRecord } from './infrastructure/persistence/postgres/schema/org-addon.record';
+import { OrgAddonRepository } from './application/ports/org-addon.repository';
+import { PostgresOrgAddonRepository } from './infrastructure/persistence/postgres/org-addon.repository';
+
+import { ListOrgAddonsUseCase } from './application/use-cases/list-org-addons/list-org-addons.use-case';
+import { ActivateAddonUseCase } from './application/use-cases/activate-addon/activate-addon.use-case';
+import { DeactivateAddonUseCase } from './application/use-cases/deactivate-addon/deactivate-addon.use-case';
+
+import { SuperAdminAddonsController } from './presenters/http/super-admin-addons.controller';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([OrgAddonRecord])],
+  controllers: [SuperAdminAddonsController],
+  providers: [
+    {
+      provide: OrgAddonRepository,
+      useClass: PostgresOrgAddonRepository,
+    },
+    ListOrgAddonsUseCase,
+    ActivateAddonUseCase,
+    DeactivateAddonUseCase,
+  ],
+  // Exported so future feature modules can gate behavior on active add-ons.
+  exports: [ListOrgAddonsUseCase],
+})
+export class AddonsModule {}

--- a/ayunis-core-backend/src/iam/addons/application/addons.errors.ts
+++ b/ayunis-core-backend/src/iam/addons/application/addons.errors.ts
@@ -1,0 +1,17 @@
+import type { ErrorMetadata } from 'src/common/errors/base.error';
+import { ApplicationError } from 'src/common/errors/base.error';
+
+export enum AddonErrorCode {
+  UNEXPECTED_ERROR = 'ADDON_UNEXPECTED_ERROR',
+}
+
+export class UnexpectedAddonError extends ApplicationError {
+  constructor(operation: string, metadata?: ErrorMetadata) {
+    super(
+      `Unexpected addon error during ${operation}`,
+      AddonErrorCode.UNEXPECTED_ERROR,
+      500,
+      { operation, ...metadata },
+    );
+  }
+}

--- a/ayunis-core-backend/src/iam/addons/application/events/addon-activated.event.ts
+++ b/ayunis-core-backend/src/iam/addons/application/events/addon-activated.event.ts
@@ -1,0 +1,12 @@
+import type { UUID } from 'crypto';
+import type { AddonType } from '../../domain/value-objects/addon-type.enum';
+
+export class AddonActivatedEvent {
+  static readonly EVENT_NAME = 'addon.activated';
+
+  constructor(
+    public readonly orgId: UUID,
+    public readonly addonType: AddonType,
+    public readonly actorUserId: UUID,
+  ) {}
+}

--- a/ayunis-core-backend/src/iam/addons/application/events/addon-deactivated.event.ts
+++ b/ayunis-core-backend/src/iam/addons/application/events/addon-deactivated.event.ts
@@ -1,0 +1,12 @@
+import type { UUID } from 'crypto';
+import type { AddonType } from '../../domain/value-objects/addon-type.enum';
+
+export class AddonDeactivatedEvent {
+  static readonly EVENT_NAME = 'addon.deactivated';
+
+  constructor(
+    public readonly orgId: UUID,
+    public readonly addonType: AddonType,
+    public readonly actorUserId: UUID,
+  ) {}
+}

--- a/ayunis-core-backend/src/iam/addons/application/ports/org-addon.repository.ts
+++ b/ayunis-core-backend/src/iam/addons/application/ports/org-addon.repository.ts
@@ -1,0 +1,13 @@
+import type { UUID } from 'crypto';
+import type { OrgAddon } from '../../domain/org-addon.entity';
+import type { AddonType } from '../../domain/value-objects/addon-type.enum';
+
+export abstract class OrgAddonRepository {
+  abstract findAllByOrgId(orgId: UUID): Promise<OrgAddon[]>;
+  abstract findByOrgAndType(
+    orgId: UUID,
+    type: AddonType,
+  ): Promise<OrgAddon | null>;
+  abstract create(addon: OrgAddon): Promise<OrgAddon>;
+  abstract delete(id: UUID): Promise<void>;
+}

--- a/ayunis-core-backend/src/iam/addons/application/use-cases/activate-addon/activate-addon.command.ts
+++ b/ayunis-core-backend/src/iam/addons/application/use-cases/activate-addon/activate-addon.command.ts
@@ -1,0 +1,10 @@
+import type { UUID } from 'crypto';
+import type { AddonType } from '../../../domain/value-objects/addon-type.enum';
+
+export class ActivateAddonCommand {
+  constructor(
+    public readonly orgId: UUID,
+    public readonly type: AddonType,
+    public readonly requestingUserId: UUID,
+  ) {}
+}

--- a/ayunis-core-backend/src/iam/addons/application/use-cases/activate-addon/activate-addon.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/addons/application/use-cases/activate-addon/activate-addon.use-case.spec.ts
@@ -1,0 +1,93 @@
+import type { UUID } from 'crypto';
+import type { EventEmitter2 } from '@nestjs/event-emitter';
+import { ActivateAddonUseCase } from './activate-addon.use-case';
+import { ActivateAddonCommand } from './activate-addon.command';
+import type { OrgAddonRepository } from '../../ports/org-addon.repository';
+import { OrgAddon } from '../../../domain/org-addon.entity';
+import { AddonType } from '../../../domain/value-objects/addon-type.enum';
+import { AddonActivatedEvent } from '../../events/addon-activated.event';
+import { UnexpectedAddonError } from '../../addons.errors';
+
+const ORG_ID = '11111111-1111-1111-1111-111111111111' as UUID;
+const SUPER_ADMIN_ID = '99999999-9999-9999-9999-999999999999' as UUID;
+
+function makeRepo(existing: OrgAddon | null): OrgAddonRepository {
+  return {
+    findAllByOrgId: jest.fn(),
+    findByOrgAndType: jest.fn(async () => existing),
+    create: jest.fn(async (addon: OrgAddon) => addon),
+    delete: jest.fn(),
+  };
+}
+
+function makeEventEmitter(): EventEmitter2 {
+  return { emitAsync: jest.fn(async () => []) } as unknown as EventEmitter2;
+}
+
+describe('ActivateAddonUseCase', () => {
+  it('creates the addon row and emits addon.activated when the addon is inactive', async () => {
+    const repo = makeRepo(null);
+    const eventEmitter = makeEventEmitter();
+    const useCase = new ActivateAddonUseCase(repo, eventEmitter);
+
+    await useCase.execute(
+      new ActivateAddonCommand(
+        ORG_ID,
+        AddonType.AYUNIS_CORE_ACADEMY,
+        SUPER_ADMIN_ID,
+      ),
+    );
+
+    expect(repo.create).toHaveBeenCalledTimes(1);
+    const created = (repo.create as jest.Mock).mock.calls[0][0] as OrgAddon;
+    expect(created.orgId).toBe(ORG_ID);
+    expect(created.type).toBe(AddonType.AYUNIS_CORE_ACADEMY);
+    expect(eventEmitter.emitAsync).toHaveBeenCalledWith(
+      AddonActivatedEvent.EVENT_NAME,
+      new AddonActivatedEvent(
+        ORG_ID,
+        AddonType.AYUNIS_CORE_ACADEMY,
+        SUPER_ADMIN_ID,
+      ),
+    );
+  });
+
+  it('is a no-op without an event when the addon is already active', async () => {
+    const existing = new OrgAddon({
+      orgId: ORG_ID,
+      type: AddonType.AYUNIS_CORE_ACADEMY,
+    });
+    const repo = makeRepo(existing);
+    const eventEmitter = makeEventEmitter();
+    const useCase = new ActivateAddonUseCase(repo, eventEmitter);
+
+    await useCase.execute(
+      new ActivateAddonCommand(
+        ORG_ID,
+        AddonType.AYUNIS_CORE_ACADEMY,
+        SUPER_ADMIN_ID,
+      ),
+    );
+
+    expect(repo.create).not.toHaveBeenCalled();
+    expect(eventEmitter.emitAsync).not.toHaveBeenCalled();
+  });
+
+  it('wraps repository failures in UnexpectedAddonError', async () => {
+    const repo = makeRepo(null);
+    (repo.create as jest.Mock).mockRejectedValue(
+      new Error('unique constraint violation'),
+    );
+    const useCase = new ActivateAddonUseCase(repo, makeEventEmitter());
+
+    await expect(
+      useCase.execute(
+        new ActivateAddonCommand(
+          ORG_ID,
+          AddonType.AYUNIS_CORE_ACADEMY,
+          SUPER_ADMIN_ID,
+        ),
+      ),
+    ).rejects.toBeInstanceOf(UnexpectedAddonError);
+  });
+});

--- a/ayunis-core-backend/src/iam/addons/application/use-cases/activate-addon/activate-addon.use-case.ts
+++ b/ayunis-core-backend/src/iam/addons/application/use-cases/activate-addon/activate-addon.use-case.ts
@@ -1,0 +1,63 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { ApplicationError } from 'src/common/errors/base.error';
+import { OrgAddon } from '../../../domain/org-addon.entity';
+import { OrgAddonRepository } from '../../ports/org-addon.repository';
+import { AddonActivatedEvent } from '../../events/addon-activated.event';
+import { UnexpectedAddonError } from '../../addons.errors';
+import { ActivateAddonCommand } from './activate-addon.command';
+
+@Injectable()
+export class ActivateAddonUseCase {
+  private readonly logger = new Logger(ActivateAddonUseCase.name);
+
+  constructor(
+    private readonly orgAddonRepository: OrgAddonRepository,
+    private readonly eventEmitter: EventEmitter2,
+  ) {}
+
+  async execute(command: ActivateAddonCommand): Promise<void> {
+    this.logger.log('Activating addon', {
+      orgId: command.orgId,
+      type: command.type,
+    });
+
+    try {
+      const existing = await this.orgAddonRepository.findByOrgAndType(
+        command.orgId,
+        command.type,
+      );
+      if (existing) {
+        // Already active — idempotent, no event.
+        return;
+      }
+
+      const addon = new OrgAddon({
+        orgId: command.orgId,
+        type: command.type,
+      });
+      await this.orgAddonRepository.create(addon);
+
+      this.eventEmitter
+        .emitAsync(
+          AddonActivatedEvent.EVENT_NAME,
+          new AddonActivatedEvent(
+            command.orgId,
+            command.type,
+            command.requestingUserId,
+          ),
+        )
+        .catch((err: unknown) => {
+          this.logger.error('Failed to emit AddonActivatedEvent', {
+            error: err instanceof Error ? err.message : 'Unknown error',
+            orgId: command.orgId,
+            type: command.type,
+          });
+        });
+    } catch (error) {
+      if (error instanceof ApplicationError) throw error;
+      this.logger.error('Error activating addon', { error: error as Error });
+      throw new UnexpectedAddonError('activate', { error: error as Error });
+    }
+  }
+}

--- a/ayunis-core-backend/src/iam/addons/application/use-cases/deactivate-addon/deactivate-addon.command.ts
+++ b/ayunis-core-backend/src/iam/addons/application/use-cases/deactivate-addon/deactivate-addon.command.ts
@@ -1,0 +1,10 @@
+import type { UUID } from 'crypto';
+import type { AddonType } from '../../../domain/value-objects/addon-type.enum';
+
+export class DeactivateAddonCommand {
+  constructor(
+    public readonly orgId: UUID,
+    public readonly type: AddonType,
+    public readonly requestingUserId: UUID,
+  ) {}
+}

--- a/ayunis-core-backend/src/iam/addons/application/use-cases/deactivate-addon/deactivate-addon.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/addons/application/use-cases/deactivate-addon/deactivate-addon.use-case.spec.ts
@@ -1,0 +1,92 @@
+import type { UUID } from 'crypto';
+import type { EventEmitter2 } from '@nestjs/event-emitter';
+import { DeactivateAddonUseCase } from './deactivate-addon.use-case';
+import { DeactivateAddonCommand } from './deactivate-addon.command';
+import type { OrgAddonRepository } from '../../ports/org-addon.repository';
+import { OrgAddon } from '../../../domain/org-addon.entity';
+import { AddonType } from '../../../domain/value-objects/addon-type.enum';
+import { AddonDeactivatedEvent } from '../../events/addon-deactivated.event';
+import { UnexpectedAddonError } from '../../addons.errors';
+
+const ORG_ID = '11111111-1111-1111-1111-111111111111' as UUID;
+const SUPER_ADMIN_ID = '99999999-9999-9999-9999-999999999999' as UUID;
+
+function makeRepo(existing: OrgAddon | null): OrgAddonRepository {
+  return {
+    findAllByOrgId: jest.fn(),
+    findByOrgAndType: jest.fn(async () => existing),
+    create: jest.fn(),
+    delete: jest.fn(),
+  };
+}
+
+function makeEventEmitter(): EventEmitter2 {
+  return { emitAsync: jest.fn(async () => []) } as unknown as EventEmitter2;
+}
+
+describe('DeactivateAddonUseCase', () => {
+  it('deletes the addon row and emits addon.deactivated when the addon is active', async () => {
+    const existing = new OrgAddon({
+      orgId: ORG_ID,
+      type: AddonType.AYUNIS_CORE_ACADEMY,
+    });
+    const repo = makeRepo(existing);
+    const eventEmitter = makeEventEmitter();
+    const useCase = new DeactivateAddonUseCase(repo, eventEmitter);
+
+    await useCase.execute(
+      new DeactivateAddonCommand(
+        ORG_ID,
+        AddonType.AYUNIS_CORE_ACADEMY,
+        SUPER_ADMIN_ID,
+      ),
+    );
+
+    expect(repo.delete).toHaveBeenCalledWith(existing.id);
+    expect(eventEmitter.emitAsync).toHaveBeenCalledWith(
+      AddonDeactivatedEvent.EVENT_NAME,
+      new AddonDeactivatedEvent(
+        ORG_ID,
+        AddonType.AYUNIS_CORE_ACADEMY,
+        SUPER_ADMIN_ID,
+      ),
+    );
+  });
+
+  it('is a no-op without an event when the addon is already inactive', async () => {
+    const repo = makeRepo(null);
+    const eventEmitter = makeEventEmitter();
+    const useCase = new DeactivateAddonUseCase(repo, eventEmitter);
+
+    await useCase.execute(
+      new DeactivateAddonCommand(
+        ORG_ID,
+        AddonType.AYUNIS_CORE_ACADEMY,
+        SUPER_ADMIN_ID,
+      ),
+    );
+
+    expect(repo.delete).not.toHaveBeenCalled();
+    expect(eventEmitter.emitAsync).not.toHaveBeenCalled();
+  });
+
+  it('wraps repository failures in UnexpectedAddonError', async () => {
+    const existing = new OrgAddon({
+      orgId: ORG_ID,
+      type: AddonType.AYUNIS_CORE_ACADEMY,
+    });
+    const repo = makeRepo(existing);
+    (repo.delete as jest.Mock).mockRejectedValue(new Error('deadlock'));
+    const useCase = new DeactivateAddonUseCase(repo, makeEventEmitter());
+
+    await expect(
+      useCase.execute(
+        new DeactivateAddonCommand(
+          ORG_ID,
+          AddonType.AYUNIS_CORE_ACADEMY,
+          SUPER_ADMIN_ID,
+        ),
+      ),
+    ).rejects.toBeInstanceOf(UnexpectedAddonError);
+  });
+});

--- a/ayunis-core-backend/src/iam/addons/application/use-cases/deactivate-addon/deactivate-addon.use-case.ts
+++ b/ayunis-core-backend/src/iam/addons/application/use-cases/deactivate-addon/deactivate-addon.use-case.ts
@@ -1,0 +1,58 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { ApplicationError } from 'src/common/errors/base.error';
+import { OrgAddonRepository } from '../../ports/org-addon.repository';
+import { AddonDeactivatedEvent } from '../../events/addon-deactivated.event';
+import { UnexpectedAddonError } from '../../addons.errors';
+import { DeactivateAddonCommand } from './deactivate-addon.command';
+
+@Injectable()
+export class DeactivateAddonUseCase {
+  private readonly logger = new Logger(DeactivateAddonUseCase.name);
+
+  constructor(
+    private readonly orgAddonRepository: OrgAddonRepository,
+    private readonly eventEmitter: EventEmitter2,
+  ) {}
+
+  async execute(command: DeactivateAddonCommand): Promise<void> {
+    this.logger.log('Deactivating addon', {
+      orgId: command.orgId,
+      type: command.type,
+    });
+
+    try {
+      const existing = await this.orgAddonRepository.findByOrgAndType(
+        command.orgId,
+        command.type,
+      );
+      if (!existing) {
+        // Already inactive — idempotent, no event.
+        return;
+      }
+
+      await this.orgAddonRepository.delete(existing.id);
+
+      this.eventEmitter
+        .emitAsync(
+          AddonDeactivatedEvent.EVENT_NAME,
+          new AddonDeactivatedEvent(
+            command.orgId,
+            command.type,
+            command.requestingUserId,
+          ),
+        )
+        .catch((err: unknown) => {
+          this.logger.error('Failed to emit AddonDeactivatedEvent', {
+            error: err instanceof Error ? err.message : 'Unknown error',
+            orgId: command.orgId,
+            type: command.type,
+          });
+        });
+    } catch (error) {
+      if (error instanceof ApplicationError) throw error;
+      this.logger.error('Error deactivating addon', { error: error as Error });
+      throw new UnexpectedAddonError('deactivate', { error: error as Error });
+    }
+  }
+}

--- a/ayunis-core-backend/src/iam/addons/application/use-cases/list-org-addons/list-org-addons.query.ts
+++ b/ayunis-core-backend/src/iam/addons/application/use-cases/list-org-addons/list-org-addons.query.ts
@@ -1,0 +1,5 @@
+import type { UUID } from 'crypto';
+
+export class ListOrgAddonsQuery {
+  constructor(public readonly orgId: UUID) {}
+}

--- a/ayunis-core-backend/src/iam/addons/application/use-cases/list-org-addons/list-org-addons.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/addons/application/use-cases/list-org-addons/list-org-addons.use-case.spec.ts
@@ -1,0 +1,57 @@
+import type { UUID } from 'crypto';
+import { ListOrgAddonsUseCase } from './list-org-addons.use-case';
+import { ListOrgAddonsQuery } from './list-org-addons.query';
+import type { OrgAddonRepository } from '../../ports/org-addon.repository';
+import { OrgAddon } from '../../../domain/org-addon.entity';
+import { AddonType } from '../../../domain/value-objects/addon-type.enum';
+import { UnexpectedAddonError } from '../../addons.errors';
+
+const ORG_ID = '11111111-1111-1111-1111-111111111111' as UUID;
+
+function makeRepo(active: OrgAddon[]): OrgAddonRepository {
+  return {
+    findAllByOrgId: jest.fn(async () => active),
+    findByOrgAndType: jest.fn(),
+    create: jest.fn(),
+    delete: jest.fn(),
+  };
+}
+
+describe('ListOrgAddonsUseCase', () => {
+  it('returns the full addon catalog with active=false when the org has no addons', async () => {
+    const useCase = new ListOrgAddonsUseCase(makeRepo([]));
+
+    const result = await useCase.execute(new ListOrgAddonsQuery(ORG_ID));
+
+    expect(result).toEqual(
+      Object.values(AddonType).map((type) => ({ type, active: false })),
+    );
+  });
+
+  it('marks an addon as active when a row exists for the org', async () => {
+    const academy = new OrgAddon({
+      orgId: ORG_ID,
+      type: AddonType.AYUNIS_CORE_ACADEMY,
+    });
+    const useCase = new ListOrgAddonsUseCase(makeRepo([academy]));
+
+    const result = await useCase.execute(new ListOrgAddonsQuery(ORG_ID));
+
+    expect(result).toContainEqual({
+      type: AddonType.AYUNIS_CORE_ACADEMY,
+      active: true,
+    });
+  });
+
+  it('wraps repository failures in UnexpectedAddonError', async () => {
+    const repo = makeRepo([]);
+    (repo.findAllByOrgId as jest.Mock).mockRejectedValue(
+      new Error('connection refused'),
+    );
+    const useCase = new ListOrgAddonsUseCase(repo);
+
+    await expect(
+      useCase.execute(new ListOrgAddonsQuery(ORG_ID)),
+    ).rejects.toBeInstanceOf(UnexpectedAddonError);
+  });
+});

--- a/ayunis-core-backend/src/iam/addons/application/use-cases/list-org-addons/list-org-addons.use-case.ts
+++ b/ayunis-core-backend/src/iam/addons/application/use-cases/list-org-addons/list-org-addons.use-case.ts
@@ -1,0 +1,37 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ApplicationError } from 'src/common/errors/base.error';
+import { AddonStatus } from '../../../domain/addon-status';
+import { AddonType } from '../../../domain/value-objects/addon-type.enum';
+import { OrgAddonRepository } from '../../ports/org-addon.repository';
+import { UnexpectedAddonError } from '../../addons.errors';
+import { ListOrgAddonsQuery } from './list-org-addons.query';
+
+@Injectable()
+export class ListOrgAddonsUseCase {
+  private readonly logger = new Logger(ListOrgAddonsUseCase.name);
+
+  constructor(private readonly orgAddonRepository: OrgAddonRepository) {}
+
+  async execute(query: ListOrgAddonsQuery): Promise<AddonStatus[]> {
+    this.logger.log('Listing org addons', { orgId: query.orgId });
+
+    try {
+      const activeAddons = await this.orgAddonRepository.findAllByOrgId(
+        query.orgId,
+      );
+      const activeTypes = new Set(activeAddons.map((addon) => addon.type));
+
+      // Always return the full catalog so the caller sees inactive addons too.
+      return Object.values(AddonType).map((type) => ({
+        type,
+        active: activeTypes.has(type),
+      }));
+    } catch (error) {
+      if (error instanceof ApplicationError) throw error;
+      this.logger.error('Error listing org addons', {
+        error: error as Error,
+      });
+      throw new UnexpectedAddonError('list', { error: error as Error });
+    }
+  }
+}

--- a/ayunis-core-backend/src/iam/addons/domain/addon-status.ts
+++ b/ayunis-core-backend/src/iam/addons/domain/addon-status.ts
@@ -1,0 +1,6 @@
+import type { AddonType } from './value-objects/addon-type.enum';
+
+export interface AddonStatus {
+  type: AddonType;
+  active: boolean;
+}

--- a/ayunis-core-backend/src/iam/addons/domain/org-addon.entity.ts
+++ b/ayunis-core-backend/src/iam/addons/domain/org-addon.entity.ts
@@ -1,0 +1,31 @@
+import type { UUID } from 'crypto';
+import { randomUUID } from 'crypto';
+import type { AddonType } from './value-objects/addon-type.enum';
+
+export interface OrgAddonParams {
+  id?: UUID;
+  orgId: UUID;
+  type: AddonType;
+  createdAt?: Date;
+  updatedAt?: Date;
+}
+
+/**
+ * Marks an add-on as active for an organization. An add-on is active while
+ * a row exists for the (org, type) pair; deactivation deletes the row.
+ */
+export class OrgAddon {
+  id: UUID;
+  orgId: UUID;
+  type: AddonType;
+  createdAt: Date;
+  updatedAt: Date;
+
+  constructor(params: OrgAddonParams) {
+    this.id = params.id ?? randomUUID();
+    this.orgId = params.orgId;
+    this.type = params.type;
+    this.createdAt = params.createdAt ?? new Date();
+    this.updatedAt = params.updatedAt ?? new Date();
+  }
+}

--- a/ayunis-core-backend/src/iam/addons/domain/value-objects/addon-type.enum.ts
+++ b/ayunis-core-backend/src/iam/addons/domain/value-objects/addon-type.enum.ts
@@ -1,0 +1,3 @@
+export enum AddonType {
+  AYUNIS_CORE_ACADEMY = 'ayunis_core_academy',
+}

--- a/ayunis-core-backend/src/iam/addons/infrastructure/persistence/postgres/mappers/org-addon.mapper.ts
+++ b/ayunis-core-backend/src/iam/addons/infrastructure/persistence/postgres/mappers/org-addon.mapper.ts
@@ -1,0 +1,24 @@
+import { OrgAddon } from 'src/iam/addons/domain/org-addon.entity';
+import { OrgAddonRecord } from '../schema/org-addon.record';
+
+export class OrgAddonMapper {
+  static toDomain(record: OrgAddonRecord): OrgAddon {
+    return new OrgAddon({
+      id: record.id,
+      orgId: record.orgId,
+      type: record.type,
+      createdAt: record.createdAt,
+      updatedAt: record.updatedAt,
+    });
+  }
+
+  static toRecord(domain: OrgAddon): OrgAddonRecord {
+    const record = new OrgAddonRecord();
+    record.id = domain.id;
+    record.orgId = domain.orgId;
+    record.type = domain.type;
+    record.createdAt = domain.createdAt;
+    record.updatedAt = new Date();
+    return record;
+  }
+}

--- a/ayunis-core-backend/src/iam/addons/infrastructure/persistence/postgres/org-addon.repository.ts
+++ b/ayunis-core-backend/src/iam/addons/infrastructure/persistence/postgres/org-addon.repository.ts
@@ -1,0 +1,55 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import type { UUID } from 'crypto';
+import { OrgAddonRepository } from 'src/iam/addons/application/ports/org-addon.repository';
+import { OrgAddon } from 'src/iam/addons/domain/org-addon.entity';
+import { AddonType } from 'src/iam/addons/domain/value-objects/addon-type.enum';
+import { OrgAddonRecord } from './schema/org-addon.record';
+import { OrgAddonMapper } from './mappers/org-addon.mapper';
+
+@Injectable()
+export class PostgresOrgAddonRepository extends OrgAddonRepository {
+  private readonly logger = new Logger(PostgresOrgAddonRepository.name);
+
+  constructor(
+    @InjectRepository(OrgAddonRecord)
+    private readonly repository: Repository<OrgAddonRecord>,
+  ) {
+    super();
+  }
+
+  async findAllByOrgId(orgId: UUID): Promise<OrgAddon[]> {
+    const records = await this.repository.find({
+      where: { orgId },
+      order: { createdAt: 'DESC' },
+    });
+    return records.map((record) => OrgAddonMapper.toDomain(record));
+  }
+
+  async findByOrgAndType(
+    orgId: UUID,
+    type: AddonType,
+  ): Promise<OrgAddon | null> {
+    const record = await this.repository.findOne({ where: { orgId, type } });
+    return record ? OrgAddonMapper.toDomain(record) : null;
+  }
+
+  async create(addon: OrgAddon): Promise<OrgAddon> {
+    this.logger.debug('create', { orgId: addon.orgId, type: addon.type });
+
+    const record = OrgAddonMapper.toRecord(addon);
+    await this.repository.save(record);
+
+    // Re-fetch to get accurate DB-managed timestamps.
+    const saved = await this.repository.findOne({ where: { id: addon.id } });
+    if (!saved) {
+      throw new Error('Failed to re-fetch org addon after save');
+    }
+    return OrgAddonMapper.toDomain(saved);
+  }
+
+  async delete(id: UUID): Promise<void> {
+    await this.repository.delete({ id });
+  }
+}

--- a/ayunis-core-backend/src/iam/addons/infrastructure/persistence/postgres/schema/org-addon.record.ts
+++ b/ayunis-core-backend/src/iam/addons/infrastructure/persistence/postgres/schema/org-addon.record.ts
@@ -1,0 +1,20 @@
+import { Column, Entity, Index, JoinColumn, ManyToOne, Unique } from 'typeorm';
+import type { UUID } from 'crypto';
+import { BaseRecord } from 'src/common/db/base-record';
+import { OrgRecord } from 'src/iam/orgs/infrastructure/repositories/local/schema/org.record';
+import { AddonType } from 'src/iam/addons/domain/value-objects/addon-type.enum';
+
+@Entity({ name: 'org_addons' })
+@Unique(['orgId', 'type'])
+export class OrgAddonRecord extends BaseRecord {
+  @Column({ type: 'varchar' })
+  type: AddonType;
+
+  @Column()
+  @Index()
+  orgId: UUID;
+
+  @ManyToOne(() => OrgRecord, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'orgId' })
+  org: OrgRecord;
+}

--- a/ayunis-core-backend/src/iam/addons/presenters/http/dto/addon-status-response.dto.ts
+++ b/ayunis-core-backend/src/iam/addons/presenters/http/dto/addon-status-response.dto.ts
@@ -1,0 +1,16 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { AddonType } from 'src/iam/addons/domain/value-objects/addon-type.enum';
+
+export class AddonStatusResponseDto {
+  @ApiProperty({
+    enum: AddonType,
+    enumName: 'AddonType',
+    description: 'The add-on this status entry refers to',
+  })
+  type: AddonType;
+
+  @ApiProperty({
+    description: 'Whether the add-on is active for the organization',
+  })
+  active: boolean;
+}

--- a/ayunis-core-backend/src/iam/addons/presenters/http/super-admin-addons.controller.ts
+++ b/ayunis-core-backend/src/iam/addons/presenters/http/super-admin-addons.controller.ts
@@ -1,0 +1,113 @@
+import {
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Logger,
+  Param,
+  ParseEnumPipe,
+  Post,
+} from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiParam,
+  ApiResponse,
+  ApiUnauthorizedResponse,
+} from '@nestjs/swagger';
+import { UUID } from 'crypto';
+import { SystemRoles } from 'src/iam/authorization/application/decorators/system-roles.decorator';
+import { SystemRole } from 'src/iam/users/domain/value-objects/system-role.enum';
+import {
+  CurrentUser,
+  UserProperty,
+} from 'src/iam/authentication/application/decorators/current-user.decorator';
+import { AddonType } from '../../domain/value-objects/addon-type.enum';
+import { ListOrgAddonsUseCase } from '../../application/use-cases/list-org-addons/list-org-addons.use-case';
+import { ListOrgAddonsQuery } from '../../application/use-cases/list-org-addons/list-org-addons.query';
+import { ActivateAddonUseCase } from '../../application/use-cases/activate-addon/activate-addon.use-case';
+import { ActivateAddonCommand } from '../../application/use-cases/activate-addon/activate-addon.command';
+import { DeactivateAddonUseCase } from '../../application/use-cases/deactivate-addon/deactivate-addon.use-case';
+import { DeactivateAddonCommand } from '../../application/use-cases/deactivate-addon/deactivate-addon.command';
+import { AddonStatusResponseDto } from './dto/addon-status-response.dto';
+
+@ApiTags('Super Admin Addons')
+@Controller('super-admin/addons')
+@SystemRoles(SystemRole.SUPER_ADMIN)
+export class SuperAdminAddonsController {
+  private readonly logger = new Logger(SuperAdminAddonsController.name);
+
+  constructor(
+    private readonly listOrgAddonsUseCase: ListOrgAddonsUseCase,
+    private readonly activateAddonUseCase: ActivateAddonUseCase,
+    private readonly deactivateAddonUseCase: DeactivateAddonUseCase,
+  ) {}
+
+  @Get(':orgId')
+  @ApiOperation({
+    summary: 'List all add-ons with their active state for an organization',
+  })
+  @ApiParam({ name: 'orgId', format: 'uuid' })
+  @ApiResponse({ status: HttpStatus.OK, type: [AddonStatusResponseDto] })
+  @ApiUnauthorizedResponse({ description: 'Not authorized as super admin' })
+  async list(@Param('orgId') orgId: UUID): Promise<AddonStatusResponseDto[]> {
+    this.logger.log('list', { orgId });
+
+    const statuses = await this.listOrgAddonsUseCase.execute(
+      new ListOrgAddonsQuery(orgId),
+    );
+    return statuses.map((status) => this.toDto(status));
+  }
+
+  @Post(':orgId/:type')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({ summary: 'Activate an add-on for an organization' })
+  @ApiParam({ name: 'orgId', format: 'uuid' })
+  @ApiParam({ name: 'type', enum: AddonType })
+  @ApiResponse({ status: HttpStatus.NO_CONTENT, description: 'Add-on active' })
+  @ApiUnauthorizedResponse({ description: 'Not authorized as super admin' })
+  async activate(
+    @Param('orgId') orgId: UUID,
+    @Param('type', new ParseEnumPipe(AddonType)) type: AddonType,
+    @CurrentUser(UserProperty.ID) userId: UUID,
+  ): Promise<void> {
+    this.logger.log('activate', { orgId, type });
+
+    await this.activateAddonUseCase.execute(
+      new ActivateAddonCommand(orgId, type, userId),
+    );
+  }
+
+  @Delete(':orgId/:type')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({ summary: 'Deactivate an add-on for an organization' })
+  @ApiParam({ name: 'orgId', format: 'uuid' })
+  @ApiParam({ name: 'type', enum: AddonType })
+  @ApiResponse({
+    status: HttpStatus.NO_CONTENT,
+    description: 'Add-on inactive',
+  })
+  @ApiUnauthorizedResponse({ description: 'Not authorized as super admin' })
+  async deactivate(
+    @Param('orgId') orgId: UUID,
+    @Param('type', new ParseEnumPipe(AddonType)) type: AddonType,
+    @CurrentUser(UserProperty.ID) userId: UUID,
+  ): Promise<void> {
+    this.logger.log('deactivate', { orgId, type });
+
+    await this.deactivateAddonUseCase.execute(
+      new DeactivateAddonCommand(orgId, type, userId),
+    );
+  }
+
+  private toDto(status: {
+    type: AddonType;
+    active: boolean;
+  }): AddonStatusResponseDto {
+    return {
+      type: status.type,
+      active: status.active,
+    };
+  }
+}

--- a/ayunis-core-backend/src/iam/iam.module.ts
+++ b/ayunis-core-backend/src/iam/iam.module.ts
@@ -17,6 +17,7 @@ import { LegalAcceptancesModule } from './legal-acceptances/legal-acceptances.mo
 import { QuotasModule } from './quotas/quotas.module';
 import { TeamsModule } from './teams/teams.module';
 import { PlatformConfigModule } from './platform-config/platform-config.module';
+import { AddonsModule } from './addons/addons.module';
 import { IpAllowlistModule } from './ip-allowlist/ip-allowlist.module';
 import { ApiKeysModule } from './api-keys/api-keys.module';
 import { JwtAuthGuard } from './authentication/application/guards/jwt-auth.guard';
@@ -43,6 +44,7 @@ const IAM_FEATURE_MODULES = [
   PlatformConfigModule,
   IpAllowlistModule,
   ApiKeysModule,
+  AddonsModule,
 ];
 
 // Global guard execution order is declared HERE — explicitly, in array

--- a/ayunis-core-backend/src/integrations/webhooks/SUMMARY.md
+++ b/ayunis-core-backend/src/integrations/webhooks/SUMMARY.md
@@ -1,16 +1,16 @@
 Event Webhooks
 Deliver lifecycle webhook events to external systems via HTTP.
 
-The webhooks module dispatches domain lifecycle events (user created/updated/deleted, org created, subscription changes) to a configured external URL. Webhook dispatch is triggered by `WebhookDispatchListener`, which subscribes to domain events emitted by use cases — no domain or IAM code imports from this module directly.
+The webhooks module dispatches domain lifecycle events (user created/updated/deleted, org created, subscription changes, add-on activation) to a configured external URL. Webhook dispatch is triggered by `WebhookDispatchListener`, which subscribes to domain events emitted by use cases — no domain or IAM code imports from this module directly.
 
 **Key files:**
 
 - `webhooks.module.ts` — NestJS module wiring. Registers `SendWebhookUseCase`, `WebhookHandler` port/adapter binding, and `WebhookDispatchListener`. Imports `UsersModule` for `FindUserByIdUseCase` (payload enrichment). Implements `OnModuleInit` to validate at boot time that `WEBHOOK_SIGNING_SECRET` is present when a webhook URL is configured in production (fails loud); outside production a warning is logged instead. Depends on `ConfigService` for reading app configuration.
-- `listeners/webhook-dispatch.listener.ts` — Central listener that subscribes to domain events (`UserCreatedEvent`, `UserUpdatedEvent`, `UserDeletedEvent`, `OrgCreatedEvent`, subscription events, `UsageCollectedEvent`, `UserMessageCreatedEvent`) and dispatches them as webhook HTTP calls via `SendWebhookUseCase`. The `chat.sent` webhook enriches the payload with the sender's email/name via `FindUserByIdUseCase` and skips the lookup entirely when no webhook URL is configured.
+- `listeners/webhook-dispatch.listener.ts` — Central listener that subscribes to domain events (`UserCreatedEvent`, `UserUpdatedEvent`, `UserDeletedEvent`, `OrgCreatedEvent`, subscription events, `UsageCollectedEvent`, `UserMessageCreatedEvent`, `AddonActivatedEvent`, `AddonDeactivatedEvent`) and dispatches them as webhook HTTP calls via `SendWebhookUseCase`. The `chat.sent` webhook enriches the payload with the sender's email/name via `FindUserByIdUseCase` and skips the lookup entirely when no webhook URL is configured.
 - `application/use-cases/send-webhook/send-webhook.use-case.ts` — Receives a `SendWebhookCommand` and delegates to the `WebhookHandler` port.
 - `application/ports/webhook.handler.ts` — Abstract port defining the webhook delivery contract.
 - `infrastructure/http/http-webhook.handler.ts` — Infrastructure adapter that performs the actual HTTP POST to the configured webhook URL. Signs outbound payloads with HMAC-SHA256 when `WEBHOOK_SIGNING_SECRET` is configured, producing a Stripe-style `X-Webhook-Signature` header (`t=<unix_seconds>,v1=<hex>`). Uses `ConfigService` to read the webhook URL and signing secret.
-- `domain/entities/webhook-event.entity.ts` — Abstract `WebhookEvent` entity with UUID, event type enum, data payload, and timestamp. Eleven concrete event types cover organization, user, subscription lifecycle, usage, and chat events.
+- `domain/entities/webhook-event.entity.ts` — Abstract `WebhookEvent` entity with UUID, event type enum, data payload, and timestamp. Thirteen concrete event types cover organization, user, subscription lifecycle, usage, chat, and add-on events.
 
 **Architecture:**
 

--- a/ayunis-core-backend/src/integrations/webhooks/domain/value-objects/webhook-event-type.enum.ts
+++ b/ayunis-core-backend/src/integrations/webhooks/domain/value-objects/webhook-event-type.enum.ts
@@ -10,4 +10,6 @@ export enum WebhookEventType {
   SUBSCRIPTION_BILLING_INFO_UPDATED = 'subscription.billing_info_updated',
   USAGE_COLLECTED = 'usage.collected',
   CHAT_SENT = 'chat.sent',
+  ADDON_ACTIVATED = 'addon.activated',
+  ADDON_DEACTIVATED = 'addon.deactivated',
 }

--- a/ayunis-core-backend/src/integrations/webhooks/domain/webhook-events/addon-activated.webhook-event.ts
+++ b/ayunis-core-backend/src/integrations/webhooks/domain/webhook-events/addon-activated.webhook-event.ts
@@ -1,0 +1,23 @@
+import type { UUID } from 'crypto';
+import { WebhookEvent } from '../webhook-event.entity';
+import { WebhookEventType } from '../value-objects/webhook-event-type.enum';
+import type { AddonType } from 'src/iam/addons/domain/value-objects/addon-type.enum';
+
+export interface AddonWebhookPayload {
+  orgId: UUID;
+  addonType: AddonType;
+  actorUserId: UUID;
+}
+
+export class AddonActivatedWebhookEvent extends WebhookEvent<AddonWebhookPayload> {
+  readonly eventType: WebhookEventType;
+  readonly data: AddonWebhookPayload;
+  readonly timestamp: Date;
+
+  constructor(payload: AddonWebhookPayload) {
+    super();
+    this.eventType = WebhookEventType.ADDON_ACTIVATED;
+    this.data = payload;
+    this.timestamp = new Date();
+  }
+}

--- a/ayunis-core-backend/src/integrations/webhooks/domain/webhook-events/addon-deactivated.webhook-event.ts
+++ b/ayunis-core-backend/src/integrations/webhooks/domain/webhook-events/addon-deactivated.webhook-event.ts
@@ -1,0 +1,16 @@
+import { WebhookEvent } from '../webhook-event.entity';
+import { WebhookEventType } from '../value-objects/webhook-event-type.enum';
+import type { AddonWebhookPayload } from './addon-activated.webhook-event';
+
+export class AddonDeactivatedWebhookEvent extends WebhookEvent<AddonWebhookPayload> {
+  readonly eventType: WebhookEventType;
+  readonly data: AddonWebhookPayload;
+  readonly timestamp: Date;
+
+  constructor(payload: AddonWebhookPayload) {
+    super();
+    this.eventType = WebhookEventType.ADDON_DEACTIVATED;
+    this.data = payload;
+    this.timestamp = new Date();
+  }
+}

--- a/ayunis-core-backend/src/integrations/webhooks/listeners/webhook-dispatch.listener.spec.ts
+++ b/ayunis-core-backend/src/integrations/webhooks/listeners/webhook-dispatch.listener.spec.ts
@@ -10,6 +10,9 @@ import { SubscriptionUncancelledEvent } from 'src/iam/subscriptions/application/
 import { SubscriptionSeatsUpdatedEvent } from 'src/iam/subscriptions/application/events/subscription-seats-updated.event';
 import { SubscriptionBillingInfoUpdatedEvent } from 'src/iam/subscriptions/application/events/subscription-billing-info-updated.event';
 import { UsageCollectedEvent } from 'src/domain/usage/application/events/usage-collected.event';
+import { AddonActivatedEvent } from 'src/iam/addons/application/events/addon-activated.event';
+import { AddonDeactivatedEvent } from 'src/iam/addons/application/events/addon-deactivated.event';
+import { AddonType } from 'src/iam/addons/domain/value-objects/addon-type.enum';
 import { UserMessageCreatedEvent } from 'src/domain/messages/application/events/user-message-created.event';
 import { Usage } from 'src/domain/usage/domain/usage.entity';
 import { ModelProvider } from 'src/domain/models/domain/value-objects/model-provider.enum';
@@ -388,6 +391,44 @@ describe('WebhookDispatchListener', () => {
       await listener.handleUserMessageCreated(makeEvent());
 
       expect(sendWebhookUseCase.execute).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('handleAddonActivated', () => {
+    it('should dispatch AddonActivatedWebhookEvent with org, addon type, and actor', async () => {
+      await listener.handleAddonActivated(
+        new AddonActivatedEvent(ORG_ID, AddonType.AYUNIS_CORE_ACADEMY, USER_ID),
+      );
+
+      expect(sendWebhookUseCase.execute).toHaveBeenCalledTimes(1);
+      const command = sendWebhookUseCase.execute.mock.calls[0][0];
+      expect(command.event.eventType).toBe(WebhookEventType.ADDON_ACTIVATED);
+      expect(command.event.data).toEqual({
+        orgId: ORG_ID,
+        addonType: AddonType.AYUNIS_CORE_ACADEMY,
+        actorUserId: USER_ID,
+      });
+    });
+  });
+
+  describe('handleAddonDeactivated', () => {
+    it('should dispatch AddonDeactivatedWebhookEvent with org, addon type, and actor', async () => {
+      await listener.handleAddonDeactivated(
+        new AddonDeactivatedEvent(
+          ORG_ID,
+          AddonType.AYUNIS_CORE_ACADEMY,
+          USER_ID,
+        ),
+      );
+
+      expect(sendWebhookUseCase.execute).toHaveBeenCalledTimes(1);
+      const command = sendWebhookUseCase.execute.mock.calls[0][0];
+      expect(command.event.eventType).toBe(WebhookEventType.ADDON_DEACTIVATED);
+      expect(command.event.data).toEqual({
+        orgId: ORG_ID,
+        addonType: AddonType.AYUNIS_CORE_ACADEMY,
+        actorUserId: USER_ID,
+      });
     });
   });
 

--- a/ayunis-core-backend/src/integrations/webhooks/listeners/webhook-dispatch.listener.ts
+++ b/ayunis-core-backend/src/integrations/webhooks/listeners/webhook-dispatch.listener.ts
@@ -12,6 +12,8 @@ import { SubscriptionUncancelledEvent } from 'src/iam/subscriptions/application/
 import { SubscriptionSeatsUpdatedEvent } from 'src/iam/subscriptions/application/events/subscription-seats-updated.event';
 import { SubscriptionBillingInfoUpdatedEvent } from 'src/iam/subscriptions/application/events/subscription-billing-info-updated.event';
 import { UsageCollectedEvent } from 'src/domain/usage/application/events/usage-collected.event';
+import { AddonActivatedEvent } from 'src/iam/addons/application/events/addon-activated.event';
+import { AddonDeactivatedEvent } from 'src/iam/addons/application/events/addon-deactivated.event';
 import { UserMessageCreatedEvent } from 'src/domain/messages/application/events/user-message-created.event';
 import { FindUserByIdUseCase } from 'src/iam/users/application/use-cases/find-user-by-id/find-user-by-id.use-case';
 import { FindUserByIdQuery } from 'src/iam/users/application/use-cases/find-user-by-id/find-user-by-id.query';
@@ -29,6 +31,8 @@ import { SubscriptionSeatsUpdatedWebhookEvent } from '../domain/webhook-events/s
 import { SubscriptionBillingInfoUpdatedWebhookEvent } from '../domain/webhook-events/subscription-billing-info-updated.webhook-event';
 import { UsageCollectedWebhookEvent } from '../domain/webhook-events/usage-collected.webhook-event';
 import { ChatSentWebhookEvent } from '../domain/webhook-events/chat-sent.webhook-event';
+import { AddonActivatedWebhookEvent } from '../domain/webhook-events/addon-activated.webhook-event';
+import { AddonDeactivatedWebhookEvent } from '../domain/webhook-events/addon-deactivated.webhook-event';
 import { mapSubscriptionToWebhookPayload } from './subscription-payload.mapper';
 import { mapBillingInfoToWebhookPayload } from './billing-info-payload.mapper';
 import type { WebhookEvent } from '../domain/webhook-event.entity';
@@ -152,6 +156,28 @@ export class WebhookDispatchListener {
       return;
     }
     await this.dispatch(new ChatSentWebhookEvent(event, user));
+  }
+
+  @OnEvent(AddonActivatedEvent.EVENT_NAME)
+  async handleAddonActivated(event: AddonActivatedEvent): Promise<void> {
+    await this.dispatch(
+      new AddonActivatedWebhookEvent({
+        orgId: event.orgId,
+        addonType: event.addonType,
+        actorUserId: event.actorUserId,
+      }),
+    );
+  }
+
+  @OnEvent(AddonDeactivatedEvent.EVENT_NAME)
+  async handleAddonDeactivated(event: AddonDeactivatedEvent): Promise<void> {
+    await this.dispatch(
+      new AddonDeactivatedWebhookEvent({
+        orgId: event.orgId,
+        addonType: event.addonType,
+        actorUserId: event.actorUserId,
+      }),
+    );
   }
 
   private webhookConfigured(): boolean {

--- a/ayunis-core-frontend/src/app/routes/_authenticated/super-admin-settings.orgs.$id.tsx
+++ b/ayunis-core-frontend/src/app/routes/_authenticated/super-admin-settings.orgs.$id.tsx
@@ -24,6 +24,7 @@ const searchSchema = z.object({
       'trials',
       'usage',
       'crawl-domains',
+      'addons',
     ])
     .optional(),
   usersSearch: z.string().optional(),

--- a/ayunis-core-frontend/src/pages/super-admin-settings/org/api/useSuperAdminActivateAddon.ts
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/org/api/useSuperAdminActivateAddon.ts
@@ -1,0 +1,42 @@
+import {
+  useSuperAdminAddonsControllerActivate,
+  getSuperAdminAddonsControllerListQueryKey,
+} from '@/shared/api';
+import type { AddonType } from '@/shared/api';
+import { showError, showSuccess } from '@/shared/lib/toast';
+import extractErrorData from '@/shared/api/extract-error-data';
+import { useQueryClient } from '@tanstack/react-query';
+import { useTranslation } from 'react-i18next';
+
+export function useSuperAdminActivateAddon(orgId: string) {
+  const { t } = useTranslation('super-admin-settings-org');
+  const queryClient = useQueryClient();
+
+  const mutation = useSuperAdminAddonsControllerActivate({
+    mutation: {
+      onSuccess: () => {
+        void queryClient.invalidateQueries({
+          queryKey: getSuperAdminAddonsControllerListQueryKey(orgId),
+        });
+        showSuccess(t('addons.activate.success'));
+      },
+      onError: (error) => {
+        try {
+          extractErrorData(error);
+          showError(t('addons.activate.error'));
+        } catch {
+          showError(t('addons.activate.error'));
+        }
+      },
+    },
+  });
+
+  function activateAddon(type: AddonType) {
+    mutation.mutate({ orgId, type });
+  }
+
+  return {
+    activateAddon,
+    isLoading: mutation.isPending,
+  };
+}

--- a/ayunis-core-frontend/src/pages/super-admin-settings/org/api/useSuperAdminAddons.ts
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/org/api/useSuperAdminAddons.ts
@@ -1,0 +1,10 @@
+import { useSuperAdminAddonsControllerList } from '@/shared/api';
+import type { AddonStatusResponseDto } from '@/shared/api';
+
+export function useSuperAdminAddons(orgId: string) {
+  const { data, isLoading, isError } = useSuperAdminAddonsControllerList(orgId);
+
+  const addons: AddonStatusResponseDto[] = data ?? [];
+
+  return { addons, isLoading, isError };
+}

--- a/ayunis-core-frontend/src/pages/super-admin-settings/org/api/useSuperAdminDeactivateAddon.ts
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/org/api/useSuperAdminDeactivateAddon.ts
@@ -1,0 +1,42 @@
+import {
+  useSuperAdminAddonsControllerDeactivate,
+  getSuperAdminAddonsControllerListQueryKey,
+} from '@/shared/api';
+import type { AddonType } from '@/shared/api';
+import { showError, showSuccess } from '@/shared/lib/toast';
+import extractErrorData from '@/shared/api/extract-error-data';
+import { useQueryClient } from '@tanstack/react-query';
+import { useTranslation } from 'react-i18next';
+
+export function useSuperAdminDeactivateAddon(orgId: string) {
+  const { t } = useTranslation('super-admin-settings-org');
+  const queryClient = useQueryClient();
+
+  const mutation = useSuperAdminAddonsControllerDeactivate({
+    mutation: {
+      onSuccess: () => {
+        void queryClient.invalidateQueries({
+          queryKey: getSuperAdminAddonsControllerListQueryKey(orgId),
+        });
+        showSuccess(t('addons.deactivate.success'));
+      },
+      onError: (error) => {
+        try {
+          extractErrorData(error);
+          showError(t('addons.deactivate.error'));
+        } catch {
+          showError(t('addons.deactivate.error'));
+        }
+      },
+    },
+  });
+
+  function deactivateAddon(type: AddonType) {
+    mutation.mutate({ orgId, type });
+  }
+
+  return {
+    deactivateAddon,
+    isLoading: mutation.isPending,
+  };
+}

--- a/ayunis-core-frontend/src/pages/super-admin-settings/org/ui/AddonsSection.tsx
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/org/ui/AddonsSection.tsx
@@ -1,0 +1,91 @@
+import { useTranslation } from 'react-i18next';
+import { GraduationCapIcon } from 'lucide-react';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/shared/ui/shadcn/card';
+import { Skeleton } from '@/shared/ui/shadcn/skeleton';
+import { Switch } from '@/shared/ui/shadcn/switch';
+import { Label } from '@/shared/ui/shadcn/label';
+import type { AddonType } from '@/shared/api';
+import { useSuperAdminAddons } from '../api/useSuperAdminAddons';
+import { useSuperAdminActivateAddon } from '../api/useSuperAdminActivateAddon';
+import { useSuperAdminDeactivateAddon } from '../api/useSuperAdminDeactivateAddon';
+
+const ADDON_ICONS: Record<AddonType, typeof GraduationCapIcon> = {
+  ayunis_core_academy: GraduationCapIcon,
+};
+
+interface AddonsSectionProps {
+  orgId: string;
+}
+
+export default function AddonsSection({ orgId }: Readonly<AddonsSectionProps>) {
+  const { t } = useTranslation('super-admin-settings-org');
+  const { addons, isLoading, isError } = useSuperAdminAddons(orgId);
+  const { activateAddon, isLoading: isActivating } =
+    useSuperAdminActivateAddon(orgId);
+  const { deactivateAddon, isLoading: isDeactivating } =
+    useSuperAdminDeactivateAddon(orgId);
+
+  function renderContent() {
+    if (isLoading) {
+      return (
+        <div className="space-y-2">
+          <Skeleton className="h-16 w-full" />
+        </div>
+      );
+    }
+    if (isError) {
+      return <p className="text-destructive text-sm">{t('addons.error')}</p>;
+    }
+    return (
+      <div className="space-y-4">
+        {addons.map((addon) => {
+          const Icon = ADDON_ICONS[addon.type];
+          return (
+            <div
+              key={addon.type}
+              className="flex items-center justify-between rounded-lg border p-4"
+            >
+              <div className="flex items-start gap-3">
+                <Icon className="text-muted-foreground mt-1 h-5 w-5" />
+                <div className="space-y-1">
+                  <Label htmlFor={`addon-${addon.type}`}>
+                    {t(`addons.items.${addon.type}.title`)}
+                  </Label>
+                  <p className="text-muted-foreground text-sm">
+                    {t(`addons.items.${addon.type}.description`)}
+                  </p>
+                </div>
+              </div>
+              <Switch
+                id={`addon-${addon.type}`}
+                checked={addon.active}
+                disabled={isActivating || isDeactivating}
+                onCheckedChange={(checked) =>
+                  checked
+                    ? activateAddon(addon.type)
+                    : deactivateAddon(addon.type)
+                }
+              />
+            </div>
+          );
+        })}
+      </div>
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{t('addons.title')}</CardTitle>
+        <CardDescription>{t('addons.description')}</CardDescription>
+      </CardHeader>
+      <CardContent>{renderContent()}</CardContent>
+    </Card>
+  );
+}

--- a/ayunis-core-frontend/src/pages/super-admin-settings/org/ui/Page.tsx
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/org/ui/Page.tsx
@@ -19,6 +19,7 @@ import SubscriptionCancellationSection from './SubscriptionCancellationSection';
 import NoSubscriptionSection from './NoSubscriptionSection';
 import ModelsSection from './ModelsSection';
 import CrawlDomainsSection from './CrawlDomainsSection';
+import AddonsSection from './AddonsSection';
 import TrialSection from './TrialSection';
 import NoTrialSection from './NoTrialSection';
 import UsageTab from './UsageTab';
@@ -47,7 +48,8 @@ interface SuperAdminSettingsOrgPageProps {
     | 'models'
     | 'trials'
     | 'usage'
-    | 'crawl-domains';
+    | 'crawl-domains'
+    | 'addons';
 }
 export default function SuperAdminSettingsOrgPage({
   org,
@@ -79,7 +81,8 @@ export default function SuperAdminSettingsOrgPage({
             | 'models'
             | 'trials'
             | 'usage'
-            | 'crawl-domains',
+            | 'crawl-domains'
+            | 'addons',
         },
       });
     },
@@ -109,6 +112,7 @@ export default function SuperAdminSettingsOrgPage({
           <TabsTrigger value="crawl-domains">
             {t('tabs.crawlDomains')}
           </TabsTrigger>
+          <TabsTrigger value="addons">{t('tabs.addons')}</TabsTrigger>
           <TabsTrigger value="usage">{t('tabs.usage')}</TabsTrigger>
         </TabsList>
         <TabsContent value="org" className="mt-4">
@@ -176,6 +180,9 @@ export default function SuperAdminSettingsOrgPage({
         </TabsContent>
         <TabsContent value="crawl-domains" className="mt-4">
           <CrawlDomainsSection orgId={org.id} />
+        </TabsContent>
+        <TabsContent value="addons" className="mt-4">
+          <AddonsSection orgId={org.id} />
         </TabsContent>
         <TabsContent value="usage" className="mt-4">
           <UsageTab orgId={org.id} />

--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
@@ -4181,6 +4181,24 @@ export interface CreateApiKeyResponseDto {
   secret: string;
 }
 
+/**
+ * The add-on this status entry refers to
+ */
+export type AddonType = typeof AddonType[keyof typeof AddonType];
+
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const AddonType = {
+  ayunis_core_academy: 'ayunis_core_academy',
+} as const;
+
+export interface AddonStatusResponseDto {
+  /** The add-on this status entry refers to */
+  type: AddonType;
+  /** Whether the add-on is active for the organization */
+  active: boolean;
+}
+
 export type UserControllerGetUsersInOrganizationParams = {
 /**
  * Search users by name or email

--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.ts
@@ -30,6 +30,7 @@ import type {
   ActiveSubscriptionResponseDto,
   AddTeamMemberDto,
   AddUrlToKnowledgeBaseDto,
+  AddonStatusResponseDto,
   AdminUpdateUserDto,
   ApiKeyResponseDto,
   ArtifactResponseDto,
@@ -17182,6 +17183,226 @@ export const useApiKeysControllerRevokeApiKey = <TError = void,
       > => {
 
       const mutationOptions = getApiKeysControllerRevokeApiKeyMutationOptions(options);
+
+      return useMutation(mutationOptions, queryClient);
+    }
+    
+/**
+ * @summary List all add-ons with their active state for an organization
+ */
+export const superAdminAddonsControllerList = (
+    orgId: string,
+ signal?: AbortSignal
+) => {
+      
+      
+      return customAxiosInstance<AddonStatusResponseDto[]>(
+      {url: `/super-admin/addons/${orgId}`, method: 'GET', signal
+    },
+      );
+    }
+  
+
+
+
+export const getSuperAdminAddonsControllerListQueryKey = (orgId?: string,) => {
+    return [
+    `/super-admin/addons/${orgId}`
+    ] as const;
+    }
+
+    
+export const getSuperAdminAddonsControllerListQueryOptions = <TData = Awaited<ReturnType<typeof superAdminAddonsControllerList>>, TError = void>(orgId: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof superAdminAddonsControllerList>>, TError, TData>>, }
+) => {
+
+const {query: queryOptions} = options ?? {};
+
+  const queryKey =  queryOptions?.queryKey ?? getSuperAdminAddonsControllerListQueryKey(orgId);
+
+  
+
+    const queryFn: QueryFunction<Awaited<ReturnType<typeof superAdminAddonsControllerList>>> = ({ signal }) => superAdminAddonsControllerList(orgId, signal);
+
+      
+
+      
+
+   return  { queryKey, queryFn, enabled: !!(orgId), ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof superAdminAddonsControllerList>>, TError, TData> & { queryKey: DataTag<QueryKey, TData, TError> }
+}
+
+export type SuperAdminAddonsControllerListQueryResult = NonNullable<Awaited<ReturnType<typeof superAdminAddonsControllerList>>>
+export type SuperAdminAddonsControllerListQueryError = void
+
+
+export function useSuperAdminAddonsControllerList<TData = Awaited<ReturnType<typeof superAdminAddonsControllerList>>, TError = void>(
+ orgId: string, options: { query:Partial<UseQueryOptions<Awaited<ReturnType<typeof superAdminAddonsControllerList>>, TError, TData>> & Pick<
+        DefinedInitialDataOptions<
+          Awaited<ReturnType<typeof superAdminAddonsControllerList>>,
+          TError,
+          Awaited<ReturnType<typeof superAdminAddonsControllerList>>
+        > , 'initialData'
+      >, }
+ , queryClient?: QueryClient
+  ):  DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useSuperAdminAddonsControllerList<TData = Awaited<ReturnType<typeof superAdminAddonsControllerList>>, TError = void>(
+ orgId: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof superAdminAddonsControllerList>>, TError, TData>> & Pick<
+        UndefinedInitialDataOptions<
+          Awaited<ReturnType<typeof superAdminAddonsControllerList>>,
+          TError,
+          Awaited<ReturnType<typeof superAdminAddonsControllerList>>
+        > , 'initialData'
+      >, }
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useSuperAdminAddonsControllerList<TData = Awaited<ReturnType<typeof superAdminAddonsControllerList>>, TError = void>(
+ orgId: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof superAdminAddonsControllerList>>, TError, TData>>, }
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+/**
+ * @summary List all add-ons with their active state for an organization
+ */
+
+export function useSuperAdminAddonsControllerList<TData = Awaited<ReturnType<typeof superAdminAddonsControllerList>>, TError = void>(
+ orgId: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof superAdminAddonsControllerList>>, TError, TData>>, }
+ , queryClient?: QueryClient 
+ ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
+
+  const queryOptions = getSuperAdminAddonsControllerListQueryOptions(orgId,options)
+
+  const query = useQuery(queryOptions, queryClient) as  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+
+  query.queryKey = queryOptions.queryKey ;
+
+  return query;
+}
+
+
+
+
+
+/**
+ * @summary Activate an add-on for an organization
+ */
+export const superAdminAddonsControllerActivate = (
+    orgId: string,
+    type: 'ayunis_core_academy',
+ signal?: AbortSignal
+) => {
+      
+      
+      return customAxiosInstance<void>(
+      {url: `/super-admin/addons/${orgId}/${type}`, method: 'POST', signal
+    },
+      );
+    }
+  
+
+
+export const getSuperAdminAddonsControllerActivateMutationOptions = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof superAdminAddonsControllerActivate>>, TError,{orgId: string;type: 'ayunis_core_academy'}, TContext>, }
+): UseMutationOptions<Awaited<ReturnType<typeof superAdminAddonsControllerActivate>>, TError,{orgId: string;type: 'ayunis_core_academy'}, TContext> => {
+
+const mutationKey = ['superAdminAddonsControllerActivate'];
+const {mutation: mutationOptions} = options ?
+      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
+      options
+      : {...options, mutation: {...options.mutation, mutationKey}}
+      : {mutation: { mutationKey, }};
+
+      
+
+
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof superAdminAddonsControllerActivate>>, {orgId: string;type: 'ayunis_core_academy'}> = (props) => {
+          const {orgId,type} = props ?? {};
+
+          return  superAdminAddonsControllerActivate(orgId,type,)
+        }
+
+        
+
+
+  return  { mutationFn, ...mutationOptions }}
+
+    export type SuperAdminAddonsControllerActivateMutationResult = NonNullable<Awaited<ReturnType<typeof superAdminAddonsControllerActivate>>>
+    
+    export type SuperAdminAddonsControllerActivateMutationError = void
+
+    /**
+ * @summary Activate an add-on for an organization
+ */
+export const useSuperAdminAddonsControllerActivate = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof superAdminAddonsControllerActivate>>, TError,{orgId: string;type: 'ayunis_core_academy'}, TContext>, }
+ , queryClient?: QueryClient): UseMutationResult<
+        Awaited<ReturnType<typeof superAdminAddonsControllerActivate>>,
+        TError,
+        {orgId: string;type: 'ayunis_core_academy'},
+        TContext
+      > => {
+
+      const mutationOptions = getSuperAdminAddonsControllerActivateMutationOptions(options);
+
+      return useMutation(mutationOptions, queryClient);
+    }
+    
+/**
+ * @summary Deactivate an add-on for an organization
+ */
+export const superAdminAddonsControllerDeactivate = (
+    orgId: string,
+    type: 'ayunis_core_academy',
+ ) => {
+      
+      
+      return customAxiosInstance<void>(
+      {url: `/super-admin/addons/${orgId}/${type}`, method: 'DELETE'
+    },
+      );
+    }
+  
+
+
+export const getSuperAdminAddonsControllerDeactivateMutationOptions = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof superAdminAddonsControllerDeactivate>>, TError,{orgId: string;type: 'ayunis_core_academy'}, TContext>, }
+): UseMutationOptions<Awaited<ReturnType<typeof superAdminAddonsControllerDeactivate>>, TError,{orgId: string;type: 'ayunis_core_academy'}, TContext> => {
+
+const mutationKey = ['superAdminAddonsControllerDeactivate'];
+const {mutation: mutationOptions} = options ?
+      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
+      options
+      : {...options, mutation: {...options.mutation, mutationKey}}
+      : {mutation: { mutationKey, }};
+
+      
+
+
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof superAdminAddonsControllerDeactivate>>, {orgId: string;type: 'ayunis_core_academy'}> = (props) => {
+          const {orgId,type} = props ?? {};
+
+          return  superAdminAddonsControllerDeactivate(orgId,type,)
+        }
+
+        
+
+
+  return  { mutationFn, ...mutationOptions }}
+
+    export type SuperAdminAddonsControllerDeactivateMutationResult = NonNullable<Awaited<ReturnType<typeof superAdminAddonsControllerDeactivate>>>
+    
+    export type SuperAdminAddonsControllerDeactivateMutationError = void
+
+    /**
+ * @summary Deactivate an add-on for an organization
+ */
+export const useSuperAdminAddonsControllerDeactivate = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof superAdminAddonsControllerDeactivate>>, TError,{orgId: string;type: 'ayunis_core_academy'}, TContext>, }
+ , queryClient?: QueryClient): UseMutationResult<
+        Awaited<ReturnType<typeof superAdminAddonsControllerDeactivate>>,
+        TError,
+        {orgId: string;type: 'ayunis_core_academy'},
+        TContext
+      > => {
+
+      const mutationOptions = getSuperAdminAddonsControllerDeactivateMutationOptions(options);
 
       return useMutation(mutationOptions, queryClient);
     }

--- a/ayunis-core-frontend/src/shared/api/openapi-schema.json
+++ b/ayunis-core-frontend/src/shared/api/openapi-schema.json
@@ -8400,6 +8400,110 @@
         "summary": "Revoke an API key",
         "tags": ["api-keys"]
       }
+    },
+    "/super-admin/addons/{orgId}": {
+      "get": {
+        "operationId": "SuperAdminAddonsController_list",
+        "parameters": [
+          {
+            "name": "orgId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/AddonStatusResponseDto"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Not authorized as super admin"
+          }
+        },
+        "summary": "List all add-ons with their active state for an organization",
+        "tags": ["Super Admin Addons"]
+      }
+    },
+    "/super-admin/addons/{orgId}/{type}": {
+      "post": {
+        "operationId": "SuperAdminAddonsController_activate",
+        "parameters": [
+          {
+            "name": "orgId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "name": "type",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "enum": ["ayunis_core_academy"],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Add-on active"
+          },
+          "401": {
+            "description": "Not authorized as super admin"
+          }
+        },
+        "summary": "Activate an add-on for an organization",
+        "tags": ["Super Admin Addons"]
+      },
+      "delete": {
+        "operationId": "SuperAdminAddonsController_deactivate",
+        "parameters": [
+          {
+            "name": "orgId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "name": "type",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "enum": ["ayunis_core_academy"],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Add-on inactive"
+          },
+          "401": {
+            "description": "Not authorized as super admin"
+          }
+        },
+        "summary": "Deactivate an add-on for an organization",
+        "tags": ["Super Admin Addons"]
+      }
     }
   },
   "info": {
@@ -14686,6 +14790,29 @@
           "createdAt",
           "secret"
         ]
+      },
+      "AddonType": {
+        "type": "string",
+        "enum": ["ayunis_core_academy"],
+        "description": "The add-on this status entry refers to"
+      },
+      "AddonStatusResponseDto": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "description": "The add-on this status entry refers to",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AddonType"
+              }
+            ]
+          },
+          "active": {
+            "type": "boolean",
+            "description": "Whether the add-on is active for the organization"
+          }
+        },
+        "required": ["type", "active"]
       }
     }
   }

--- a/ayunis-core-frontend/src/shared/locales/de/super-admin-settings-org.json
+++ b/ayunis-core-frontend/src/shared/locales/de/super-admin-settings-org.json
@@ -254,7 +254,27 @@
     "trials": "Trial",
     "models": "Modelle",
     "usage": "Nutzung",
-    "crawlDomains": "Crawl-Domains"
+    "crawlDomains": "Crawl-Domains",
+    "addons": "Add-ons"
+  },
+  "addons": {
+    "title": "Add-ons",
+    "description": "Optionale Produktmodule, die für diese Organisation aktiviert werden können.",
+    "error": "Add-ons konnten nicht geladen werden.",
+    "activate": {
+      "success": "Add-on aktiviert.",
+      "error": "Das Add-on konnte nicht aktiviert werden."
+    },
+    "deactivate": {
+      "success": "Add-on deaktiviert.",
+      "error": "Das Add-on konnte nicht deaktiviert werden."
+    },
+    "items": {
+      "ayunis_core_academy": {
+        "title": "Ayunis Core Academy",
+        "description": "Lernplattform mit Schulungsinhalten für die Arbeit mit Ayunis Core."
+      }
+    }
   },
   "crawlDomains": {
     "title": "Crawl-Domains",

--- a/ayunis-core-frontend/src/shared/locales/en/super-admin-settings-org.json
+++ b/ayunis-core-frontend/src/shared/locales/en/super-admin-settings-org.json
@@ -254,7 +254,27 @@
     "trials": "Trials",
     "models": "Models",
     "usage": "Usage",
-    "crawlDomains": "Crawl Domains"
+    "crawlDomains": "Crawl Domains",
+    "addons": "Add-ons"
+  },
+  "addons": {
+    "title": "Add-ons",
+    "description": "Optional product modules that can be activated for this organization.",
+    "error": "Could not load add-ons.",
+    "activate": {
+      "success": "Add-on activated.",
+      "error": "Could not activate the add-on."
+    },
+    "deactivate": {
+      "success": "Add-on deactivated.",
+      "error": "Could not deactivate the add-on."
+    },
+    "items": {
+      "ayunis_core_academy": {
+        "title": "Ayunis Core Academy",
+        "description": "Learning platform with training content for working with Ayunis Core."
+      }
+    }
   },
   "crawlDomains": {
     "title": "Crawl Domains",


### PR DESCRIPTION
- New iam/addons module: per-org add-ons toggled by super admins,
  catalog as AddonType enum (first entry: ayunis_core_academy)
- Row exists = active; activate/deactivate are idempotent and emit
  addon.activated / addon.deactivated webhooks only on state change,
  payload { orgId, addonType, actorUserId }
- Super-admin endpoints: GET/POST/DELETE /super-admin/addons/:orgId[/:type]
- New Add-ons tab with toggle in the super-admin org detail page (en/de)
- Migration CreateOrgAddonsTable, regenerated OpenAPI client

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New super-admin entitlement surface and DB migration affect org configuration; access is restricted to super admins and changes are covered by unit tests, but incorrect toggles could enable product modules prematurely.
> 
> **Overview**
> Introduces **per-organization add-ons** that super admins turn on or off, starting with `ayunis_core_academy` in a hardcoded `AddonType` catalog. Active state is stored in a new `org_addons` table (row present = active); activate/deactivate are **idempotent** and only emit `addon.activated` / `addon.deactivated` domain events when state actually changes.
> 
> Backend adds the `iam/addons` module (list / activate / deactivate use cases, Postgres persistence, migration) and **super-admin** routes `GET/POST/DELETE /super-admin/addons/:orgId[/:type]` behind `@SystemRoles(SUPER_ADMIN)`. `ListOrgAddonsUseCase` is exported for future feature gating; there is no tenant-facing API yet. Webhooks gain matching `addon.activated` and `addon.deactivated` types with payload `{ orgId, addonType, actorUserId }`.
> 
> The super-admin org detail UI gets an **Add-ons** tab with catalog toggles (en/de copy), backed by regenerated OpenAPI client hooks and query invalidation on mutations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51183894903423ec861aa03a71d994857e1696f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->