### PR TITLE
wip(academy): add academy module with chapter and lesson persistence (AYC-243)

### DIFF
--- a/ayunis-core-backend/src/app/app.module.ts
+++ b/ayunis-core-backend/src/app/app.module.ts
@@ -26,6 +26,7 @@ import { AnonymizationSettingsModule } from '../domain/anonymization-settings/an
 import { KnowledgeBasesModule } from '../domain/knowledge-bases/knowledge-bases.module';
 import { CrawlDomainGrantsModule } from '../domain/crawl-domain-grants/crawl-domain-grants.module';
 import { SkillTemplatesModule } from '../domain/skill-templates/skill-templates.module';
+import { AcademyModule } from '../domain/academy/academy.module';
 import { ArtifactsModule } from '../domain/artifacts/artifacts.module';
 import { LetterheadsModule } from '../domain/letterheads/letterheads.module';
 import { OpenAICompatModule } from '../domain/openai-compat/openai-compat.module';
@@ -168,6 +169,7 @@ import { IntegrationsModule } from '../integrations/integrations.module';
     KnowledgeBasesModule,
     CrawlDomainGrantsModule,
     SkillTemplatesModule,
+    AcademyModule,
     ArtifactsModule,
     LetterheadsModule,
     OpenAICompatModule,

--- a/ayunis-core-backend/src/db/migrations/1781274231542-CreateAcademyTables.ts
+++ b/ayunis-core-backend/src/db/migrations/1781274231542-CreateAcademyTables.ts
@@ -1,0 +1,31 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateAcademyTables1781274231542 implements MigrationInterface {
+  name = 'CreateAcademyTables1781274231542';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE "academy_chapters" ("id" character varying NOT NULL, "createdAt" TIMESTAMP NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP NOT NULL DEFAULT now(), "title" character varying NOT NULL, "description" text NOT NULL, "position" integer NOT NULL, CONSTRAINT "PK_95a85d6d36700f8bc6c16e3d22d" PRIMARY KEY ("id"))`,
+    );
+    await queryRunner.query(
+      `CREATE TABLE "academy_lessons" ("id" character varying NOT NULL, "createdAt" TIMESTAMP NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP NOT NULL DEFAULT now(), "chapterId" character varying NOT NULL, "title" character varying NOT NULL, "description" text, "loomUrl" character varying NOT NULL, "position" integer NOT NULL, CONSTRAINT "PK_473048a74027e35086529d18488" PRIMARY KEY ("id"))`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_53d374c31fe02d9a59daf7392d" ON "academy_lessons" ("chapterId") `,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "academy_lessons" ADD CONSTRAINT "FK_53d374c31fe02d9a59daf7392d4" FOREIGN KEY ("chapterId") REFERENCES "academy_chapters"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "academy_lessons" DROP CONSTRAINT "FK_53d374c31fe02d9a59daf7392d4"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_53d374c31fe02d9a59daf7392d"`,
+    );
+    await queryRunner.query(`DROP TABLE "academy_lessons"`);
+    await queryRunner.query(`DROP TABLE "academy_chapters"`);
+  }
+}

--- a/ayunis-core-backend/src/domain/academy/SUMMARY.md
+++ b/ayunis-core-backend/src/domain/academy/SUMMARY.md
@@ -1,0 +1,46 @@
+# Academy Module
+
+## Purpose
+
+The academy provides admin-managed learning content organized as chapters that group ordered lessons. Each lesson links to a Loom video and carries a title, optional description, and a position within its chapter.
+
+## Key Concepts
+
+- **Chapter**: A titled, described, positioned grouping of lessons (`AcademyChapter`).
+- **Lesson**: A titled video lesson belonging to a chapter, with an optional description, a Loom URL, and a position within the chapter (`AcademyLesson`).
+- **Ordering**: Both chapters and lessons are ordered by an integer `position`. Repositories expose `findMaxPosition` for appending and `updatePositions` for reordering.
+
+## Structure
+
+```text
+academy/
+├── SUMMARY.md
+├── domain/
+│   ├── academy-chapter.entity.ts   # AcademyChapter domain entity (holds its lessons)
+│   └── academy-lesson.entity.ts    # AcademyLesson domain entity
+├── application/
+│   ├── academy.errors.ts           # Domain errors + AcademyErrorCode
+│   └── ports/
+│       ├── academy-chapter.repository.ts  # Abstract chapter repository interface
+│       └── academy-lesson.repository.ts   # Abstract lesson repository interface
+├── infrastructure/
+│   └── persistence/local/
+│       ├── schema/
+│       │   ├── academy-chapter.record.ts  # AcademyChapterRecord TypeORM entity
+│       │   └── academy-lesson.record.ts   # AcademyLessonRecord TypeORM entity (ManyToOne chapter)
+│       ├── mappers/academy.mapper.ts      # Domain ↔ Record conversion for chapters and lessons
+│       ├── local-academy-chapter.repository.ts  # PostgreSQL chapter repository
+│       └── local-academy-lesson.repository.ts   # PostgreSQL lesson repository
+└── academy.module.ts               # NestJS wiring
+```
+
+## Errors
+
+- `ChapterNotFoundError` (404) — chapter id not found.
+- `LessonNotFoundError` (404) — lesson id not found.
+- `InvalidReorderError` (400) — submitted ids do not match the current set of items.
+- `UnexpectedAcademyError` (500) — wraps unexpected errors.
+
+## Module Wiring
+
+`AcademyModule` registers the `AcademyChapterRecord` and `AcademyLessonRecord` TypeORM entities, the `AcademyMapper`, and binds the `AcademyChapterRepository` / `AcademyLessonRepository` ports to their local PostgreSQL implementations (`LocalAcademyChapterRepository`, `LocalAcademyLessonRepository`).

--- a/ayunis-core-backend/src/domain/academy/academy.module.ts
+++ b/ayunis-core-backend/src/domain/academy/academy.module.ts
@@ -1,0 +1,29 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { AcademyChapterRecord } from './infrastructure/persistence/local/schema/academy-chapter.record';
+import { AcademyLessonRecord } from './infrastructure/persistence/local/schema/academy-lesson.record';
+import { AcademyMapper } from './infrastructure/persistence/local/mappers/academy.mapper';
+import { LocalAcademyChapterRepository } from './infrastructure/persistence/local/local-academy-chapter.repository';
+import { LocalAcademyLessonRepository } from './infrastructure/persistence/local/local-academy-lesson.repository';
+import { AcademyChapterRepository } from './application/ports/academy-chapter.repository';
+import { AcademyLessonRepository } from './application/ports/academy-lesson.repository';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([AcademyChapterRecord, AcademyLessonRecord]),
+  ],
+  providers: [
+    AcademyMapper,
+    LocalAcademyChapterRepository,
+    LocalAcademyLessonRepository,
+    {
+      provide: AcademyChapterRepository,
+      useExisting: LocalAcademyChapterRepository,
+    },
+    {
+      provide: AcademyLessonRepository,
+      useExisting: LocalAcademyLessonRepository,
+    },
+  ],
+})
+export class AcademyModule {}

--- a/ayunis-core-backend/src/domain/academy/application/academy.errors.ts
+++ b/ayunis-core-backend/src/domain/academy/application/academy.errors.ts
@@ -1,0 +1,64 @@
+import type { ErrorMetadata } from '../../../common/errors/base.error';
+import { ApplicationError } from '../../../common/errors/base.error';
+
+export enum AcademyErrorCode {
+  CHAPTER_NOT_FOUND = 'CHAPTER_NOT_FOUND',
+  LESSON_NOT_FOUND = 'LESSON_NOT_FOUND',
+  INVALID_REORDER = 'INVALID_REORDER',
+  UNEXPECTED_ACADEMY_ERROR = 'UNEXPECTED_ACADEMY_ERROR',
+}
+
+export abstract class AcademyError extends ApplicationError {
+  constructor(
+    message: string,
+    code: AcademyErrorCode,
+    statusCode: number = 400,
+    metadata?: ErrorMetadata,
+  ) {
+    super(message, code, statusCode, metadata);
+  }
+}
+
+export class ChapterNotFoundError extends AcademyError {
+  constructor(chapterId: string, metadata?: ErrorMetadata) {
+    super(
+      `Academy chapter with ID ${chapterId} not found`,
+      AcademyErrorCode.CHAPTER_NOT_FOUND,
+      404,
+      metadata,
+    );
+  }
+}
+
+export class LessonNotFoundError extends AcademyError {
+  constructor(lessonId: string, metadata?: ErrorMetadata) {
+    super(
+      `Academy lesson with ID ${lessonId} not found`,
+      AcademyErrorCode.LESSON_NOT_FOUND,
+      404,
+      metadata,
+    );
+  }
+}
+
+export class InvalidReorderError extends AcademyError {
+  constructor(metadata?: ErrorMetadata) {
+    super(
+      'The submitted ids do not match the current set of items',
+      AcademyErrorCode.INVALID_REORDER,
+      400,
+      metadata,
+    );
+  }
+}
+
+export class UnexpectedAcademyError extends AcademyError {
+  constructor(error: unknown) {
+    super(
+      'Unexpected error occurred',
+      AcademyErrorCode.UNEXPECTED_ACADEMY_ERROR,
+      500,
+      { error },
+    );
+  }
+}

--- a/ayunis-core-backend/src/domain/academy/application/ports/academy-chapter.repository.ts
+++ b/ayunis-core-backend/src/domain/academy/application/ports/academy-chapter.repository.ts
@@ -1,0 +1,13 @@
+import type { UUID } from 'crypto';
+import type { AcademyChapter } from '../../domain/academy-chapter.entity';
+
+export abstract class AcademyChapterRepository {
+  abstract findAllWithLessons(): Promise<AcademyChapter[]>;
+  abstract findOne(id: UUID): Promise<AcademyChapter | null>;
+  abstract findAllIds(): Promise<UUID[]>;
+  abstract findMaxPosition(): Promise<number | null>;
+  abstract create(chapter: AcademyChapter): Promise<AcademyChapter>;
+  abstract update(chapter: AcademyChapter): Promise<AcademyChapter>;
+  abstract delete(id: UUID): Promise<void>;
+  abstract updatePositions(orderedIds: UUID[]): Promise<void>;
+}

--- a/ayunis-core-backend/src/domain/academy/application/ports/academy-lesson.repository.ts
+++ b/ayunis-core-backend/src/domain/academy/application/ports/academy-lesson.repository.ts
@@ -1,0 +1,12 @@
+import type { UUID } from 'crypto';
+import type { AcademyLesson } from '../../domain/academy-lesson.entity';
+
+export abstract class AcademyLessonRepository {
+  abstract findOne(id: UUID): Promise<AcademyLesson | null>;
+  abstract findIdsByChapterId(chapterId: UUID): Promise<UUID[]>;
+  abstract findMaxPosition(chapterId: UUID): Promise<number | null>;
+  abstract create(lesson: AcademyLesson): Promise<AcademyLesson>;
+  abstract update(lesson: AcademyLesson): Promise<AcademyLesson>;
+  abstract delete(id: UUID): Promise<void>;
+  abstract updatePositions(chapterId: UUID, orderedIds: UUID[]): Promise<void>;
+}

--- a/ayunis-core-backend/src/domain/academy/domain/academy-chapter.entity.ts
+++ b/ayunis-core-backend/src/domain/academy/domain/academy-chapter.entity.ts
@@ -1,0 +1,31 @@
+import type { UUID } from 'crypto';
+import { randomUUID } from 'crypto';
+import type { AcademyLesson } from './academy-lesson.entity';
+
+export class AcademyChapter {
+  public readonly id: UUID;
+  public readonly title: string;
+  public readonly description: string;
+  public readonly position: number;
+  public readonly lessons: AcademyLesson[];
+  public readonly createdAt: Date;
+  public readonly updatedAt: Date;
+
+  constructor(params: {
+    id?: UUID;
+    title: string;
+    description: string;
+    position: number;
+    lessons?: AcademyLesson[];
+    createdAt?: Date;
+    updatedAt?: Date;
+  }) {
+    this.id = params.id ?? randomUUID();
+    this.title = params.title;
+    this.description = params.description;
+    this.position = params.position;
+    this.lessons = params.lessons ?? [];
+    this.createdAt = params.createdAt ?? new Date();
+    this.updatedAt = params.updatedAt ?? new Date();
+  }
+}

--- a/ayunis-core-backend/src/domain/academy/domain/academy-lesson.entity.ts
+++ b/ayunis-core-backend/src/domain/academy/domain/academy-lesson.entity.ts
@@ -1,0 +1,33 @@
+import type { UUID } from 'crypto';
+import { randomUUID } from 'crypto';
+
+export class AcademyLesson {
+  public readonly id: UUID;
+  public readonly chapterId: UUID;
+  public readonly title: string;
+  public readonly description: string | null;
+  public readonly loomUrl: string;
+  public readonly position: number;
+  public readonly createdAt: Date;
+  public readonly updatedAt: Date;
+
+  constructor(params: {
+    id?: UUID;
+    chapterId: UUID;
+    title: string;
+    description?: string | null;
+    loomUrl: string;
+    position: number;
+    createdAt?: Date;
+    updatedAt?: Date;
+  }) {
+    this.id = params.id ?? randomUUID();
+    this.chapterId = params.chapterId;
+    this.title = params.title;
+    this.description = params.description ?? null;
+    this.loomUrl = params.loomUrl;
+    this.position = params.position;
+    this.createdAt = params.createdAt ?? new Date();
+    this.updatedAt = params.updatedAt ?? new Date();
+  }
+}

--- a/ayunis-core-backend/src/domain/academy/infrastructure/persistence/local/local-academy-chapter.repository.ts
+++ b/ayunis-core-backend/src/domain/academy/infrastructure/persistence/local/local-academy-chapter.repository.ts
@@ -1,0 +1,84 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { DataSource, Repository } from 'typeorm';
+import type { UUID } from 'crypto';
+
+import { AcademyChapterRepository } from '../../../application/ports/academy-chapter.repository';
+import { AcademyChapter } from '../../../domain/academy-chapter.entity';
+import { AcademyChapterRecord } from './schema/academy-chapter.record';
+import { AcademyMapper } from './mappers/academy.mapper';
+import { ChapterNotFoundError } from '../../../application/academy.errors';
+
+@Injectable()
+export class LocalAcademyChapterRepository implements AcademyChapterRepository {
+  private readonly logger = new Logger(LocalAcademyChapterRepository.name);
+
+  constructor(
+    @InjectRepository(AcademyChapterRecord)
+    private readonly repository: Repository<AcademyChapterRecord>,
+    private readonly dataSource: DataSource,
+    private readonly mapper: AcademyMapper,
+  ) {}
+
+  async findAllWithLessons(): Promise<AcademyChapter[]> {
+    this.logger.log('findAllWithLessons');
+    const records = await this.repository.find({
+      relations: { lessons: true },
+      order: {
+        position: 'ASC',
+        createdAt: 'ASC',
+        lessons: { position: 'ASC', createdAt: 'ASC' },
+      },
+    });
+    return records.map((record) => this.mapper.chapterToDomain(record));
+  }
+
+  async findOne(id: UUID): Promise<AcademyChapter | null> {
+    this.logger.log('findOne', { id });
+    const record = await this.repository.findOne({ where: { id } });
+    if (!record) return null;
+    return this.mapper.chapterToDomain(record);
+  }
+
+  async findAllIds(): Promise<UUID[]> {
+    this.logger.log('findAllIds');
+    const records = await this.repository.find({ select: { id: true } });
+    return records.map((record) => record.id);
+  }
+
+  async findMaxPosition(): Promise<number | null> {
+    this.logger.log('findMaxPosition');
+    return this.repository.maximum('position');
+  }
+
+  async create(chapter: AcademyChapter): Promise<AcademyChapter> {
+    this.logger.log('create', { title: chapter.title });
+    const record = this.mapper.chapterToRecord(chapter);
+    const saved = await this.repository.save(record);
+    return this.mapper.chapterToDomain(saved);
+  }
+
+  async update(chapter: AcademyChapter): Promise<AcademyChapter> {
+    this.logger.log('update', { id: chapter.id });
+    const record = this.mapper.chapterToRecord(chapter);
+    const saved = await this.repository.save(record);
+    return this.mapper.chapterToDomain(saved);
+  }
+
+  async delete(id: UUID): Promise<void> {
+    this.logger.log('delete', { id });
+    const result = await this.repository.delete({ id });
+    if (result.affected === 0) {
+      throw new ChapterNotFoundError(id);
+    }
+  }
+
+  async updatePositions(orderedIds: UUID[]): Promise<void> {
+    this.logger.log('updatePositions', { count: orderedIds.length });
+    await this.dataSource.transaction(async (manager) => {
+      for (const [index, id] of orderedIds.entries()) {
+        await manager.update(AcademyChapterRecord, { id }, { position: index });
+      }
+    });
+  }
+}

--- a/ayunis-core-backend/src/domain/academy/infrastructure/persistence/local/local-academy-lesson.repository.ts
+++ b/ayunis-core-backend/src/domain/academy/infrastructure/persistence/local/local-academy-lesson.repository.ts
@@ -1,0 +1,81 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { DataSource, Repository } from 'typeorm';
+import type { UUID } from 'crypto';
+
+import { AcademyLessonRepository } from '../../../application/ports/academy-lesson.repository';
+import { AcademyLesson } from '../../../domain/academy-lesson.entity';
+import { AcademyLessonRecord } from './schema/academy-lesson.record';
+import { AcademyMapper } from './mappers/academy.mapper';
+import { LessonNotFoundError } from '../../../application/academy.errors';
+
+@Injectable()
+export class LocalAcademyLessonRepository implements AcademyLessonRepository {
+  private readonly logger = new Logger(LocalAcademyLessonRepository.name);
+
+  constructor(
+    @InjectRepository(AcademyLessonRecord)
+    private readonly repository: Repository<AcademyLessonRecord>,
+    private readonly dataSource: DataSource,
+    private readonly mapper: AcademyMapper,
+  ) {}
+
+  async findOne(id: UUID): Promise<AcademyLesson | null> {
+    this.logger.log('findOne', { id });
+    const record = await this.repository.findOne({ where: { id } });
+    if (!record) return null;
+    return this.mapper.lessonToDomain(record);
+  }
+
+  async findIdsByChapterId(chapterId: UUID): Promise<UUID[]> {
+    this.logger.log('findIdsByChapterId', { chapterId });
+    const records = await this.repository.find({
+      select: { id: true },
+      where: { chapterId },
+    });
+    return records.map((record) => record.id);
+  }
+
+  async findMaxPosition(chapterId: UUID): Promise<number | null> {
+    this.logger.log('findMaxPosition', { chapterId });
+    return this.repository.maximum('position', { chapterId });
+  }
+
+  async create(lesson: AcademyLesson): Promise<AcademyLesson> {
+    this.logger.log('create', { title: lesson.title });
+    const record = this.mapper.lessonToRecord(lesson);
+    const saved = await this.repository.save(record);
+    return this.mapper.lessonToDomain(saved);
+  }
+
+  async update(lesson: AcademyLesson): Promise<AcademyLesson> {
+    this.logger.log('update', { id: lesson.id });
+    const record = this.mapper.lessonToRecord(lesson);
+    const saved = await this.repository.save(record);
+    return this.mapper.lessonToDomain(saved);
+  }
+
+  async delete(id: UUID): Promise<void> {
+    this.logger.log('delete', { id });
+    const result = await this.repository.delete({ id });
+    if (result.affected === 0) {
+      throw new LessonNotFoundError(id);
+    }
+  }
+
+  async updatePositions(chapterId: UUID, orderedIds: UUID[]): Promise<void> {
+    this.logger.log('updatePositions', {
+      chapterId,
+      count: orderedIds.length,
+    });
+    await this.dataSource.transaction(async (manager) => {
+      for (const [index, id] of orderedIds.entries()) {
+        await manager.update(
+          AcademyLessonRecord,
+          { id, chapterId },
+          { position: index },
+        );
+      }
+    });
+  }
+}

--- a/ayunis-core-backend/src/domain/academy/infrastructure/persistence/local/mappers/academy.mapper.ts
+++ b/ayunis-core-backend/src/domain/academy/infrastructure/persistence/local/mappers/academy.mapper.ts
@@ -1,0 +1,53 @@
+import { Injectable } from '@nestjs/common';
+import { AcademyChapter } from '../../../../domain/academy-chapter.entity';
+import { AcademyLesson } from '../../../../domain/academy-lesson.entity';
+import { AcademyChapterRecord } from '../schema/academy-chapter.record';
+import { AcademyLessonRecord } from '../schema/academy-lesson.record';
+
+@Injectable()
+export class AcademyMapper {
+  chapterToDomain(record: AcademyChapterRecord): AcademyChapter {
+    return new AcademyChapter({
+      id: record.id,
+      title: record.title,
+      description: record.description,
+      position: record.position,
+      lessons: record.lessons?.map((lesson) => this.lessonToDomain(lesson)),
+      createdAt: record.createdAt,
+      updatedAt: record.updatedAt,
+    });
+  }
+
+  chapterToRecord(domain: AcademyChapter): AcademyChapterRecord {
+    const record = new AcademyChapterRecord();
+    record.id = domain.id;
+    record.title = domain.title;
+    record.description = domain.description;
+    record.position = domain.position;
+    return record;
+  }
+
+  lessonToDomain(record: AcademyLessonRecord): AcademyLesson {
+    return new AcademyLesson({
+      id: record.id,
+      chapterId: record.chapterId,
+      title: record.title,
+      description: record.description,
+      loomUrl: record.loomUrl,
+      position: record.position,
+      createdAt: record.createdAt,
+      updatedAt: record.updatedAt,
+    });
+  }
+
+  lessonToRecord(domain: AcademyLesson): AcademyLessonRecord {
+    const record = new AcademyLessonRecord();
+    record.id = domain.id;
+    record.chapterId = domain.chapterId;
+    record.title = domain.title;
+    record.description = domain.description;
+    record.loomUrl = domain.loomUrl;
+    record.position = domain.position;
+    return record;
+  }
+}

--- a/ayunis-core-backend/src/domain/academy/infrastructure/persistence/local/schema/academy-chapter.record.ts
+++ b/ayunis-core-backend/src/domain/academy/infrastructure/persistence/local/schema/academy-chapter.record.ts
@@ -1,0 +1,19 @@
+import { Column, Entity, OneToMany } from 'typeorm';
+import { BaseRecord } from '../../../../../../common/db/base-record';
+import { AcademyLessonRecord } from './academy-lesson.record';
+
+@Entity({ name: 'academy_chapters' })
+export class AcademyChapterRecord extends BaseRecord {
+  @Column({ nullable: false })
+  title: string;
+
+  @Column({ nullable: false, type: 'text' })
+  description: string;
+
+  @Column({ nullable: false, type: 'int' })
+  position: number;
+
+  // Only populated when the relation is explicitly loaded
+  @OneToMany(() => AcademyLessonRecord, (lesson) => lesson.chapter)
+  lessons?: AcademyLessonRecord[];
+}

--- a/ayunis-core-backend/src/domain/academy/infrastructure/persistence/local/schema/academy-lesson.record.ts
+++ b/ayunis-core-backend/src/domain/academy/infrastructure/persistence/local/schema/academy-lesson.record.ts
@@ -5,14 +5,14 @@ import { AcademyChapterRecord } from './academy-chapter.record';
 
 @Entity({ name: 'academy_lessons' })
 export class AcademyLessonRecord extends BaseRecord {
+  @Column()
+  @Index()
+  chapterId: UUID;
+
   @ManyToOne(() => AcademyChapterRecord, (chapter) => chapter.lessons, {
     onDelete: 'CASCADE',
   })
   chapter: AcademyChapterRecord;
-
-  @Column()
-  @Index()
-  chapterId: UUID;
 
   @Column({ nullable: false })
   title: string;

--- a/ayunis-core-backend/src/domain/academy/infrastructure/persistence/local/schema/academy-lesson.record.ts
+++ b/ayunis-core-backend/src/domain/academy/infrastructure/persistence/local/schema/academy-lesson.record.ts
@@ -1,0 +1,28 @@
+import { UUID } from 'crypto';
+import { Column, Entity, Index, ManyToOne } from 'typeorm';
+import { BaseRecord } from '../../../../../../common/db/base-record';
+import { AcademyChapterRecord } from './academy-chapter.record';
+
+@Entity({ name: 'academy_lessons' })
+export class AcademyLessonRecord extends BaseRecord {
+  @ManyToOne(() => AcademyChapterRecord, (chapter) => chapter.lessons, {
+    onDelete: 'CASCADE',
+  })
+  chapter: AcademyChapterRecord;
+
+  @Column()
+  @Index()
+  chapterId: UUID;
+
+  @Column({ nullable: false })
+  title: string;
+
+  @Column({ nullable: true, type: 'text' })
+  description: string | null;
+
+  @Column({ nullable: false })
+  loomUrl: string;
+
+  @Column({ nullable: false, type: 'int' })
+  position: number;
+}


### PR DESCRIPTION
- Chapters (title, description, position) and lessons (title, optional
  description, loom url, position) as platform-global content
- Repository ports + local Postgres implementations with transactional
  position updates
- CreateAcademyTables migration with cascade FK lessons -> chapters

Refs: AYC-239, AYC-240

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive schema and isolated domain module; no auth or existing behavior changes, though the migration must run cleanly in deployed environments.
> 
> **Overview**
> Introduces a new **Academy** domain for platform-global learning content: ordered **chapters** (title, description, position) containing ordered **lessons** (title, optional description, Loom URL, position).
> 
> Adds a TypeORM migration for `academy_chapters` and `academy_lessons` with a cascade FK from lessons to chapters, plus a Nest `AcademyModule` wired into `AppModule`. The module follows the existing hexagonal pattern—domain entities, repository ports, Postgres implementations with transactional `updatePositions`, mapper, and academy-specific errors (including `InvalidReorderError` for future reorder validation).
> 
> This PR is **persistence and wiring only**; there are no HTTP controllers, use cases, or exported providers in the diff yet.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84467801830d61f8de9bbaeeb21fdaacb0ab8679. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->