### PR TITLE
wip(academy): add chapter and lesson management use cases (AYC-243)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -46,6 +46,7 @@ ayunis-core/
 | [transcriptions](ayunis-core-backend/src/domain/transcriptions/SUMMARY.md) | Voice | Audio transcription service |
 | [usage](ayunis-core-backend/src/domain/usage/SUMMARY.md) | Metering | Token and credit usage tracking |
 | [skill-templates](ayunis-core-backend/src/domain/skill-templates/SUMMARY.md) | Blueprints | Admin-managed skill templates with distribution modes |
+| [academy](ayunis-core-backend/src/domain/academy/SUMMARY.md) | Learning Content | Admin-managed chapters and ordered Loom lessons |
 | [anonymization-settings](ayunis-core-backend/src/domain/anonymization-settings) | Privacy Config | Org-level PII whitelist for anonymous mode |
 | [thread-pii-masks](ayunis-core-backend/src/domain/thread-pii-masks/SUMMARY.md) | Privacy | Per-thread PII mask dictionary for anonymous mode |
 

--- a/ayunis-core-backend/src/domain/academy/SUMMARY.md
+++ b/ayunis-core-backend/src/domain/academy/SUMMARY.md
@@ -20,9 +20,20 @@ academy/
 │   └── academy-lesson.entity.ts    # AcademyLesson domain entity
 ├── application/
 │   ├── academy.errors.ts           # Domain errors + AcademyErrorCode
-│   └── ports/
-│       ├── academy-chapter.repository.ts  # Abstract chapter repository interface
-│       └── academy-lesson.repository.ts   # Abstract lesson repository interface
+│   ├── reorder-validation.ts       # Shared set equality validation for reorder commands
+│   ├── ports/
+│   │   ├── academy-chapter.repository.ts  # Abstract chapter repository interface
+│   │   └── academy-lesson.repository.ts   # Abstract lesson repository interface
+│   └── use-cases/
+│       ├── get-academy-content/    # Load chapters with ordered lessons
+│       ├── create-chapter/         # Append a chapter after the last position
+│       ├── update-chapter/         # Update title/description while preserving position
+│       ├── delete-chapter/         # Delete a chapter
+│       ├── reorder-chapters/       # Rewrite chapter positions after validating id set
+│       ├── create-lesson/          # Append a lesson within an existing chapter
+│       ├── update-lesson/          # Update title/video/description while preserving position
+│       ├── delete-lesson/          # Delete a lesson
+│       └── reorder-lessons/        # Rewrite lesson positions scoped to a chapter
 ├── infrastructure/
 │   └── persistence/local/
 │       ├── schema/
@@ -43,4 +54,4 @@ academy/
 
 ## Module Wiring
 
-`AcademyModule` registers the `AcademyChapterRecord` and `AcademyLessonRecord` TypeORM entities, the `AcademyMapper`, and binds the `AcademyChapterRepository` / `AcademyLessonRepository` ports to their local PostgreSQL implementations (`LocalAcademyChapterRepository`, `LocalAcademyLessonRepository`).
+`AcademyModule` registers the `AcademyChapterRecord` and `AcademyLessonRecord` TypeORM entities, the `AcademyMapper`, binds the `AcademyChapterRepository` / `AcademyLessonRepository` ports to their local PostgreSQL implementations (`LocalAcademyChapterRepository`, `LocalAcademyLessonRepository`), and provides the academy content management use cases. Only `GetAcademyContentUseCase` is exported for cross-module consumption for now.

--- a/ayunis-core-backend/src/domain/academy/academy.module.ts
+++ b/ayunis-core-backend/src/domain/academy/academy.module.ts
@@ -7,6 +7,15 @@ import { LocalAcademyChapterRepository } from './infrastructure/persistence/loca
 import { LocalAcademyLessonRepository } from './infrastructure/persistence/local/local-academy-lesson.repository';
 import { AcademyChapterRepository } from './application/ports/academy-chapter.repository';
 import { AcademyLessonRepository } from './application/ports/academy-lesson.repository';
+import { GetAcademyContentUseCase } from './application/use-cases/get-academy-content/get-academy-content.use-case';
+import { CreateChapterUseCase } from './application/use-cases/create-chapter/create-chapter.use-case';
+import { UpdateChapterUseCase } from './application/use-cases/update-chapter/update-chapter.use-case';
+import { DeleteChapterUseCase } from './application/use-cases/delete-chapter/delete-chapter.use-case';
+import { ReorderChaptersUseCase } from './application/use-cases/reorder-chapters/reorder-chapters.use-case';
+import { CreateLessonUseCase } from './application/use-cases/create-lesson/create-lesson.use-case';
+import { UpdateLessonUseCase } from './application/use-cases/update-lesson/update-lesson.use-case';
+import { DeleteLessonUseCase } from './application/use-cases/delete-lesson/delete-lesson.use-case';
+import { ReorderLessonsUseCase } from './application/use-cases/reorder-lessons/reorder-lessons.use-case';
 
 @Module({
   imports: [
@@ -24,6 +33,16 @@ import { AcademyLessonRepository } from './application/ports/academy-lesson.repo
       provide: AcademyLessonRepository,
       useExisting: LocalAcademyLessonRepository,
     },
+    GetAcademyContentUseCase,
+    CreateChapterUseCase,
+    UpdateChapterUseCase,
+    DeleteChapterUseCase,
+    ReorderChaptersUseCase,
+    CreateLessonUseCase,
+    UpdateLessonUseCase,
+    DeleteLessonUseCase,
+    ReorderLessonsUseCase,
   ],
+  exports: [GetAcademyContentUseCase],
 })
 export class AcademyModule {}

--- a/ayunis-core-backend/src/domain/academy/application/reorder-validation.ts
+++ b/ayunis-core-backend/src/domain/academy/application/reorder-validation.ts
@@ -1,0 +1,19 @@
+import type { UUID } from 'crypto';
+import { InvalidReorderError } from './academy.errors';
+
+/**
+ * Ensures the submitted ids are exactly the current set of ids
+ * (same members, any order). Throws InvalidReorderError otherwise.
+ */
+export function assertSameIdSet(
+  currentIds: UUID[],
+  submittedIds: UUID[],
+): void {
+  const current = new Set<UUID>(currentIds);
+  const submitted = new Set<UUID>(submittedIds);
+  const missing = currentIds.filter((id) => !submitted.has(id));
+  const extra = submittedIds.filter((id) => !current.has(id));
+  if (missing.length > 0 || extra.length > 0) {
+    throw new InvalidReorderError({ missing, extra });
+  }
+}

--- a/ayunis-core-backend/src/domain/academy/application/use-cases/create-chapter/create-chapter.command.ts
+++ b/ayunis-core-backend/src/domain/academy/application/use-cases/create-chapter/create-chapter.command.ts
@@ -1,0 +1,9 @@
+export class CreateChapterCommand {
+  public readonly title: string;
+  public readonly description: string;
+
+  constructor(params: { title: string; description: string }) {
+    this.title = params.title;
+    this.description = params.description;
+  }
+}

--- a/ayunis-core-backend/src/domain/academy/application/use-cases/create-chapter/create-chapter.use-case.ts
+++ b/ayunis-core-backend/src/domain/academy/application/use-cases/create-chapter/create-chapter.use-case.ts
@@ -1,0 +1,32 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ApplicationError } from 'src/common/errors/base.error';
+import { AcademyChapterRepository } from '../../ports/academy-chapter.repository';
+import { AcademyChapter } from '../../../domain/academy-chapter.entity';
+import { UnexpectedAcademyError } from '../../academy.errors';
+import { CreateChapterCommand } from './create-chapter.command';
+
+@Injectable()
+export class CreateChapterUseCase {
+  private readonly logger = new Logger(CreateChapterUseCase.name);
+
+  constructor(private readonly chapterRepository: AcademyChapterRepository) {}
+
+  async execute(command: CreateChapterCommand): Promise<AcademyChapter> {
+    this.logger.log('Creating academy chapter', { title: command.title });
+    try {
+      const maxPosition = await this.chapterRepository.findMaxPosition();
+      const chapter = new AcademyChapter({
+        title: command.title,
+        description: command.description,
+        position: (maxPosition ?? -1) + 1,
+      });
+      return await this.chapterRepository.create(chapter);
+    } catch (error) {
+      if (error instanceof ApplicationError) throw error;
+      this.logger.error('Error creating academy chapter', {
+        error: error as Error,
+      });
+      throw new UnexpectedAcademyError(error);
+    }
+  }
+}

--- a/ayunis-core-backend/src/domain/academy/application/use-cases/create-lesson/create-lesson.command.ts
+++ b/ayunis-core-backend/src/domain/academy/application/use-cases/create-lesson/create-lesson.command.ts
@@ -1,0 +1,20 @@
+import type { UUID } from 'crypto';
+
+export class CreateLessonCommand {
+  public readonly chapterId: UUID;
+  public readonly title: string;
+  public readonly description?: string | null;
+  public readonly loomUrl: string;
+
+  constructor(params: {
+    chapterId: UUID;
+    title: string;
+    description?: string | null;
+    loomUrl: string;
+  }) {
+    this.chapterId = params.chapterId;
+    this.title = params.title;
+    this.description = params.description;
+    this.loomUrl = params.loomUrl;
+  }
+}

--- a/ayunis-core-backend/src/domain/academy/application/use-cases/create-lesson/create-lesson.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/academy/application/use-cases/create-lesson/create-lesson.use-case.spec.ts
@@ -1,0 +1,110 @@
+import type { TestingModule } from '@nestjs/testing';
+import { Test } from '@nestjs/testing';
+import { Logger } from '@nestjs/common';
+import { randomUUID } from 'crypto';
+import { CreateLessonUseCase } from './create-lesson.use-case';
+import { CreateLessonCommand } from './create-lesson.command';
+import { AcademyChapterRepository } from '../../ports/academy-chapter.repository';
+import { AcademyLessonRepository } from '../../ports/academy-lesson.repository';
+import { AcademyChapter } from '../../../domain/academy-chapter.entity';
+import { AcademyLesson } from '../../../domain/academy-lesson.entity';
+import { ChapterNotFoundError } from '../../academy.errors';
+
+describe('CreateLessonUseCase', () => {
+  let useCase: CreateLessonUseCase;
+  let chapterRepository: jest.Mocked<AcademyChapterRepository>;
+  let lessonRepository: jest.Mocked<AcademyLessonRepository>;
+
+  const chapter = new AcademyChapter({
+    title: 'Getting Started',
+    description: 'Basics of Ayunis Core',
+    position: 0,
+  });
+
+  beforeAll(async () => {
+    const mockChapterRepository = {
+      findOne: jest.fn(),
+    };
+    const mockLessonRepository = {
+      findMaxPosition: jest.fn(),
+      create: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        CreateLessonUseCase,
+        { provide: AcademyChapterRepository, useValue: mockChapterRepository },
+        { provide: AcademyLessonRepository, useValue: mockLessonRepository },
+      ],
+    }).compile();
+
+    useCase = module.get<CreateLessonUseCase>(CreateLessonUseCase);
+    chapterRepository = module.get(AcademyChapterRepository);
+    lessonRepository = module.get(AcademyLessonRepository);
+
+    jest.spyOn(Logger.prototype, 'log').mockImplementation();
+    jest.spyOn(Logger.prototype, 'error').mockImplementation();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should create a lesson appended after the last position', async () => {
+    chapterRepository.findOne.mockResolvedValue(chapter);
+    lessonRepository.findMaxPosition.mockResolvedValue(3);
+    lessonRepository.create.mockImplementation(
+      async (lesson: AcademyLesson) => lesson,
+    );
+
+    const result = await useCase.execute(
+      new CreateLessonCommand({
+        chapterId: chapter.id,
+        title: 'Creating your first chat',
+        loomUrl: 'https://www.loom.com/share/abc123def456',
+      }),
+    );
+
+    expect(result.position).toBe(4);
+    expect(result.chapterId).toBe(chapter.id);
+    expect(result.description).toBeNull();
+    expect(lessonRepository.create).toHaveBeenCalledWith(
+      expect.any(AcademyLesson),
+    );
+  });
+
+  it('should create the first lesson of a chapter at position 0', async () => {
+    chapterRepository.findOne.mockResolvedValue(chapter);
+    lessonRepository.findMaxPosition.mockResolvedValue(null);
+    lessonRepository.create.mockImplementation(
+      async (lesson: AcademyLesson) => lesson,
+    );
+
+    const result = await useCase.execute(
+      new CreateLessonCommand({
+        chapterId: chapter.id,
+        title: 'Welcome to the academy',
+        description: 'A short introduction video',
+        loomUrl: 'https://www.loom.com/share/abc123def456',
+      }),
+    );
+
+    expect(result.position).toBe(0);
+    expect(result.description).toBe('A short introduction video');
+  });
+
+  it('should reject lesson creation for a non-existent chapter', async () => {
+    chapterRepository.findOne.mockResolvedValue(null);
+
+    await expect(
+      useCase.execute(
+        new CreateLessonCommand({
+          chapterId: randomUUID(),
+          title: 'Orphan lesson',
+          loomUrl: 'https://www.loom.com/share/abc123def456',
+        }),
+      ),
+    ).rejects.toThrow(ChapterNotFoundError);
+    expect(lessonRepository.create).not.toHaveBeenCalled();
+  });
+});

--- a/ayunis-core-backend/src/domain/academy/application/use-cases/create-lesson/create-lesson.use-case.ts
+++ b/ayunis-core-backend/src/domain/academy/application/use-cases/create-lesson/create-lesson.use-case.ts
@@ -1,0 +1,50 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ApplicationError } from 'src/common/errors/base.error';
+import { AcademyChapterRepository } from '../../ports/academy-chapter.repository';
+import { AcademyLessonRepository } from '../../ports/academy-lesson.repository';
+import { AcademyLesson } from '../../../domain/academy-lesson.entity';
+import {
+  ChapterNotFoundError,
+  UnexpectedAcademyError,
+} from '../../academy.errors';
+import { CreateLessonCommand } from './create-lesson.command';
+
+@Injectable()
+export class CreateLessonUseCase {
+  private readonly logger = new Logger(CreateLessonUseCase.name);
+
+  constructor(
+    private readonly chapterRepository: AcademyChapterRepository,
+    private readonly lessonRepository: AcademyLessonRepository,
+  ) {}
+
+  async execute(command: CreateLessonCommand): Promise<AcademyLesson> {
+    this.logger.log('Creating academy lesson', {
+      chapterId: command.chapterId,
+      title: command.title,
+    });
+    try {
+      const chapter = await this.chapterRepository.findOne(command.chapterId);
+      if (!chapter) {
+        throw new ChapterNotFoundError(command.chapterId);
+      }
+      const maxPosition = await this.lessonRepository.findMaxPosition(
+        command.chapterId,
+      );
+      const lesson = new AcademyLesson({
+        chapterId: command.chapterId,
+        title: command.title,
+        description: command.description,
+        loomUrl: command.loomUrl,
+        position: (maxPosition ?? -1) + 1,
+      });
+      return await this.lessonRepository.create(lesson);
+    } catch (error) {
+      if (error instanceof ApplicationError) throw error;
+      this.logger.error('Error creating academy lesson', {
+        error: error as Error,
+      });
+      throw new UnexpectedAcademyError(error);
+    }
+  }
+}

--- a/ayunis-core-backend/src/domain/academy/application/use-cases/delete-chapter/delete-chapter.command.ts
+++ b/ayunis-core-backend/src/domain/academy/application/use-cases/delete-chapter/delete-chapter.command.ts
@@ -1,0 +1,9 @@
+import type { UUID } from 'crypto';
+
+export class DeleteChapterCommand {
+  public readonly chapterId: UUID;
+
+  constructor(params: { chapterId: UUID }) {
+    this.chapterId = params.chapterId;
+  }
+}

--- a/ayunis-core-backend/src/domain/academy/application/use-cases/delete-chapter/delete-chapter.use-case.ts
+++ b/ayunis-core-backend/src/domain/academy/application/use-cases/delete-chapter/delete-chapter.use-case.ts
@@ -1,0 +1,27 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ApplicationError } from 'src/common/errors/base.error';
+import { AcademyChapterRepository } from '../../ports/academy-chapter.repository';
+import { UnexpectedAcademyError } from '../../academy.errors';
+import { DeleteChapterCommand } from './delete-chapter.command';
+
+@Injectable()
+export class DeleteChapterUseCase {
+  private readonly logger = new Logger(DeleteChapterUseCase.name);
+
+  constructor(private readonly chapterRepository: AcademyChapterRepository) {}
+
+  async execute(command: DeleteChapterCommand): Promise<void> {
+    this.logger.log('Deleting academy chapter', {
+      chapterId: command.chapterId,
+    });
+    try {
+      await this.chapterRepository.delete(command.chapterId);
+    } catch (error) {
+      if (error instanceof ApplicationError) throw error;
+      this.logger.error('Error deleting academy chapter', {
+        error: error as Error,
+      });
+      throw new UnexpectedAcademyError(error);
+    }
+  }
+}

--- a/ayunis-core-backend/src/domain/academy/application/use-cases/delete-lesson/delete-lesson.command.ts
+++ b/ayunis-core-backend/src/domain/academy/application/use-cases/delete-lesson/delete-lesson.command.ts
@@ -1,0 +1,9 @@
+import type { UUID } from 'crypto';
+
+export class DeleteLessonCommand {
+  public readonly lessonId: UUID;
+
+  constructor(params: { lessonId: UUID }) {
+    this.lessonId = params.lessonId;
+  }
+}

--- a/ayunis-core-backend/src/domain/academy/application/use-cases/delete-lesson/delete-lesson.use-case.ts
+++ b/ayunis-core-backend/src/domain/academy/application/use-cases/delete-lesson/delete-lesson.use-case.ts
@@ -1,0 +1,25 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ApplicationError } from 'src/common/errors/base.error';
+import { AcademyLessonRepository } from '../../ports/academy-lesson.repository';
+import { UnexpectedAcademyError } from '../../academy.errors';
+import { DeleteLessonCommand } from './delete-lesson.command';
+
+@Injectable()
+export class DeleteLessonUseCase {
+  private readonly logger = new Logger(DeleteLessonUseCase.name);
+
+  constructor(private readonly lessonRepository: AcademyLessonRepository) {}
+
+  async execute(command: DeleteLessonCommand): Promise<void> {
+    this.logger.log('Deleting academy lesson', { lessonId: command.lessonId });
+    try {
+      await this.lessonRepository.delete(command.lessonId);
+    } catch (error) {
+      if (error instanceof ApplicationError) throw error;
+      this.logger.error('Error deleting academy lesson', {
+        error: error as Error,
+      });
+      throw new UnexpectedAcademyError(error);
+    }
+  }
+}

--- a/ayunis-core-backend/src/domain/academy/application/use-cases/get-academy-content/get-academy-content.query.ts
+++ b/ayunis-core-backend/src/domain/academy/application/use-cases/get-academy-content/get-academy-content.query.ts
@@ -1,0 +1,1 @@
+export class GetAcademyContentQuery {}

--- a/ayunis-core-backend/src/domain/academy/application/use-cases/get-academy-content/get-academy-content.use-case.ts
+++ b/ayunis-core-backend/src/domain/academy/application/use-cases/get-academy-content/get-academy-content.use-case.ts
@@ -1,0 +1,27 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ApplicationError } from 'src/common/errors/base.error';
+import { AcademyChapterRepository } from '../../ports/academy-chapter.repository';
+import { AcademyChapter } from '../../../domain/academy-chapter.entity';
+import { UnexpectedAcademyError } from '../../academy.errors';
+import { GetAcademyContentQuery } from './get-academy-content.query';
+
+@Injectable()
+export class GetAcademyContentUseCase {
+  private readonly logger = new Logger(GetAcademyContentUseCase.name);
+
+  constructor(private readonly chapterRepository: AcademyChapterRepository) {}
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  async execute(_query: GetAcademyContentQuery): Promise<AcademyChapter[]> {
+    this.logger.log('Getting academy content');
+    try {
+      return await this.chapterRepository.findAllWithLessons();
+    } catch (error) {
+      if (error instanceof ApplicationError) throw error;
+      this.logger.error('Error getting academy content', {
+        error: error as Error,
+      });
+      throw new UnexpectedAcademyError(error);
+    }
+  }
+}

--- a/ayunis-core-backend/src/domain/academy/application/use-cases/reorder-chapters/reorder-chapters.command.ts
+++ b/ayunis-core-backend/src/domain/academy/application/use-cases/reorder-chapters/reorder-chapters.command.ts
@@ -1,0 +1,9 @@
+import type { UUID } from 'crypto';
+
+export class ReorderChaptersCommand {
+  public readonly chapterIds: UUID[];
+
+  constructor(params: { chapterIds: UUID[] }) {
+    this.chapterIds = params.chapterIds;
+  }
+}

--- a/ayunis-core-backend/src/domain/academy/application/use-cases/reorder-chapters/reorder-chapters.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/academy/application/use-cases/reorder-chapters/reorder-chapters.use-case.spec.ts
@@ -1,0 +1,73 @@
+import type { TestingModule } from '@nestjs/testing';
+import { Test } from '@nestjs/testing';
+import { Logger } from '@nestjs/common';
+import { randomUUID } from 'crypto';
+import { ReorderChaptersUseCase } from './reorder-chapters.use-case';
+import { ReorderChaptersCommand } from './reorder-chapters.command';
+import { AcademyChapterRepository } from '../../ports/academy-chapter.repository';
+import { InvalidReorderError } from '../../academy.errors';
+
+describe('ReorderChaptersUseCase', () => {
+  let useCase: ReorderChaptersUseCase;
+  let repository: jest.Mocked<AcademyChapterRepository>;
+
+  beforeAll(async () => {
+    const mockRepository = {
+      findAllIds: jest.fn(),
+      updatePositions: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ReorderChaptersUseCase,
+        { provide: AcademyChapterRepository, useValue: mockRepository },
+      ],
+    }).compile();
+
+    useCase = module.get<ReorderChaptersUseCase>(ReorderChaptersUseCase);
+    repository = module.get(AcademyChapterRepository);
+
+    jest.spyOn(Logger.prototype, 'log').mockImplementation();
+    jest.spyOn(Logger.prototype, 'error').mockImplementation();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should persist the submitted order when ids match the current chapters', async () => {
+    const ids = [randomUUID(), randomUUID(), randomUUID()];
+    repository.findAllIds.mockResolvedValue(ids);
+    const reversed = [...ids].reverse();
+
+    await useCase.execute(new ReorderChaptersCommand({ chapterIds: reversed }));
+
+    expect(repository.updatePositions).toHaveBeenCalledWith(reversed);
+  });
+
+  it('should reject a reorder that omits an existing chapter', async () => {
+    const ids = [randomUUID(), randomUUID(), randomUUID()];
+    repository.findAllIds.mockResolvedValue(ids);
+
+    await expect(
+      useCase.execute(
+        new ReorderChaptersCommand({ chapterIds: [ids[0], ids[1]] }),
+      ),
+    ).rejects.toThrow(InvalidReorderError);
+    expect(repository.updatePositions).not.toHaveBeenCalled();
+  });
+
+  it('should reject a reorder that contains an unknown chapter id', async () => {
+    const ids = [randomUUID(), randomUUID()];
+    repository.findAllIds.mockResolvedValue(ids);
+
+    await expect(
+      useCase.execute(
+        new ReorderChaptersCommand({
+          chapterIds: [ids[0], ids[1], randomUUID()],
+        }),
+      ),
+    ).rejects.toThrow(InvalidReorderError);
+    expect(repository.updatePositions).not.toHaveBeenCalled();
+  });
+});

--- a/ayunis-core-backend/src/domain/academy/application/use-cases/reorder-chapters/reorder-chapters.use-case.ts
+++ b/ayunis-core-backend/src/domain/academy/application/use-cases/reorder-chapters/reorder-chapters.use-case.ts
@@ -1,0 +1,30 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ApplicationError } from 'src/common/errors/base.error';
+import { AcademyChapterRepository } from '../../ports/academy-chapter.repository';
+import { UnexpectedAcademyError } from '../../academy.errors';
+import { assertSameIdSet } from '../../reorder-validation';
+import { ReorderChaptersCommand } from './reorder-chapters.command';
+
+@Injectable()
+export class ReorderChaptersUseCase {
+  private readonly logger = new Logger(ReorderChaptersUseCase.name);
+
+  constructor(private readonly chapterRepository: AcademyChapterRepository) {}
+
+  async execute(command: ReorderChaptersCommand): Promise<void> {
+    this.logger.log('Reordering academy chapters', {
+      count: command.chapterIds.length,
+    });
+    try {
+      const currentIds = await this.chapterRepository.findAllIds();
+      assertSameIdSet(currentIds, command.chapterIds);
+      await this.chapterRepository.updatePositions(command.chapterIds);
+    } catch (error) {
+      if (error instanceof ApplicationError) throw error;
+      this.logger.error('Error reordering academy chapters', {
+        error: error as Error,
+      });
+      throw new UnexpectedAcademyError(error);
+    }
+  }
+}

--- a/ayunis-core-backend/src/domain/academy/application/use-cases/reorder-lessons/reorder-lessons.command.ts
+++ b/ayunis-core-backend/src/domain/academy/application/use-cases/reorder-lessons/reorder-lessons.command.ts
@@ -1,0 +1,11 @@
+import type { UUID } from 'crypto';
+
+export class ReorderLessonsCommand {
+  public readonly chapterId: UUID;
+  public readonly lessonIds: UUID[];
+
+  constructor(params: { chapterId: UUID; lessonIds: UUID[] }) {
+    this.chapterId = params.chapterId;
+    this.lessonIds = params.lessonIds;
+  }
+}

--- a/ayunis-core-backend/src/domain/academy/application/use-cases/reorder-lessons/reorder-lessons.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/academy/application/use-cases/reorder-lessons/reorder-lessons.use-case.spec.ts
@@ -1,0 +1,116 @@
+import type { TestingModule } from '@nestjs/testing';
+import { Test } from '@nestjs/testing';
+import { Logger } from '@nestjs/common';
+import { randomUUID } from 'crypto';
+import { ReorderLessonsUseCase } from './reorder-lessons.use-case';
+import { ReorderLessonsCommand } from './reorder-lessons.command';
+import { AcademyChapterRepository } from '../../ports/academy-chapter.repository';
+import { AcademyLessonRepository } from '../../ports/academy-lesson.repository';
+import { AcademyChapter } from '../../../domain/academy-chapter.entity';
+import {
+  ChapterNotFoundError,
+  InvalidReorderError,
+} from '../../academy.errors';
+
+describe('ReorderLessonsUseCase', () => {
+  let useCase: ReorderLessonsUseCase;
+  let chapterRepository: jest.Mocked<AcademyChapterRepository>;
+  let lessonRepository: jest.Mocked<AcademyLessonRepository>;
+
+  const chapter = new AcademyChapter({
+    title: 'Getting Started',
+    description: 'Basics of Ayunis Core',
+    position: 0,
+  });
+
+  beforeAll(async () => {
+    const mockChapterRepository = {
+      findOne: jest.fn(),
+    };
+    const mockLessonRepository = {
+      findIdsByChapterId: jest.fn(),
+      updatePositions: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ReorderLessonsUseCase,
+        { provide: AcademyChapterRepository, useValue: mockChapterRepository },
+        { provide: AcademyLessonRepository, useValue: mockLessonRepository },
+      ],
+    }).compile();
+
+    useCase = module.get<ReorderLessonsUseCase>(ReorderLessonsUseCase);
+    chapterRepository = module.get(AcademyChapterRepository);
+    lessonRepository = module.get(AcademyLessonRepository);
+
+    jest.spyOn(Logger.prototype, 'log').mockImplementation();
+    jest.spyOn(Logger.prototype, 'error').mockImplementation();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should persist the submitted order scoped to the chapter', async () => {
+    const lessonIds = [randomUUID(), randomUUID()];
+    chapterRepository.findOne.mockResolvedValue(chapter);
+    lessonRepository.findIdsByChapterId.mockResolvedValue(lessonIds);
+    const reversed = [...lessonIds].reverse();
+
+    await useCase.execute(
+      new ReorderLessonsCommand({ chapterId: chapter.id, lessonIds: reversed }),
+    );
+
+    expect(lessonRepository.updatePositions).toHaveBeenCalledWith(
+      chapter.id,
+      reversed,
+    );
+  });
+
+  it('should reject reordering lessons of a non-existent chapter', async () => {
+    chapterRepository.findOne.mockResolvedValue(null);
+
+    await expect(
+      useCase.execute(
+        new ReorderLessonsCommand({
+          chapterId: randomUUID(),
+          lessonIds: [randomUUID()],
+        }),
+      ),
+    ).rejects.toThrow(ChapterNotFoundError);
+    expect(lessonRepository.updatePositions).not.toHaveBeenCalled();
+  });
+
+  it('should reject a reorder containing a lesson from another chapter', async () => {
+    const lessonIds = [randomUUID(), randomUUID()];
+    chapterRepository.findOne.mockResolvedValue(chapter);
+    lessonRepository.findIdsByChapterId.mockResolvedValue(lessonIds);
+
+    await expect(
+      useCase.execute(
+        new ReorderLessonsCommand({
+          chapterId: chapter.id,
+          lessonIds: [lessonIds[0], lessonIds[1], randomUUID()],
+        }),
+      ),
+    ).rejects.toThrow(InvalidReorderError);
+    expect(lessonRepository.updatePositions).not.toHaveBeenCalled();
+  });
+
+  it('should reject a reorder that omits a lesson of the chapter', async () => {
+    const lessonIds = [randomUUID(), randomUUID()];
+    chapterRepository.findOne.mockResolvedValue(chapter);
+    lessonRepository.findIdsByChapterId.mockResolvedValue(lessonIds);
+
+    await expect(
+      useCase.execute(
+        new ReorderLessonsCommand({
+          chapterId: chapter.id,
+          lessonIds: [lessonIds[0]],
+        }),
+      ),
+    ).rejects.toThrow(InvalidReorderError);
+    expect(lessonRepository.updatePositions).not.toHaveBeenCalled();
+  });
+});

--- a/ayunis-core-backend/src/domain/academy/application/use-cases/reorder-lessons/reorder-lessons.use-case.ts
+++ b/ayunis-core-backend/src/domain/academy/application/use-cases/reorder-lessons/reorder-lessons.use-case.ts
@@ -1,0 +1,47 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ApplicationError } from 'src/common/errors/base.error';
+import { AcademyChapterRepository } from '../../ports/academy-chapter.repository';
+import { AcademyLessonRepository } from '../../ports/academy-lesson.repository';
+import {
+  ChapterNotFoundError,
+  UnexpectedAcademyError,
+} from '../../academy.errors';
+import { assertSameIdSet } from '../../reorder-validation';
+import { ReorderLessonsCommand } from './reorder-lessons.command';
+
+@Injectable()
+export class ReorderLessonsUseCase {
+  private readonly logger = new Logger(ReorderLessonsUseCase.name);
+
+  constructor(
+    private readonly chapterRepository: AcademyChapterRepository,
+    private readonly lessonRepository: AcademyLessonRepository,
+  ) {}
+
+  async execute(command: ReorderLessonsCommand): Promise<void> {
+    this.logger.log('Reordering academy lessons', {
+      chapterId: command.chapterId,
+      count: command.lessonIds.length,
+    });
+    try {
+      const chapter = await this.chapterRepository.findOne(command.chapterId);
+      if (!chapter) {
+        throw new ChapterNotFoundError(command.chapterId);
+      }
+      const currentIds = await this.lessonRepository.findIdsByChapterId(
+        command.chapterId,
+      );
+      assertSameIdSet(currentIds, command.lessonIds);
+      await this.lessonRepository.updatePositions(
+        command.chapterId,
+        command.lessonIds,
+      );
+    } catch (error) {
+      if (error instanceof ApplicationError) throw error;
+      this.logger.error('Error reordering academy lessons', {
+        error: error as Error,
+      });
+      throw new UnexpectedAcademyError(error);
+    }
+  }
+}

--- a/ayunis-core-backend/src/domain/academy/application/use-cases/update-chapter/update-chapter.command.ts
+++ b/ayunis-core-backend/src/domain/academy/application/use-cases/update-chapter/update-chapter.command.ts
@@ -1,0 +1,13 @@
+import type { UUID } from 'crypto';
+
+export class UpdateChapterCommand {
+  public readonly chapterId: UUID;
+  public readonly title: string;
+  public readonly description: string;
+
+  constructor(params: { chapterId: UUID; title: string; description: string }) {
+    this.chapterId = params.chapterId;
+    this.title = params.title;
+    this.description = params.description;
+  }
+}

--- a/ayunis-core-backend/src/domain/academy/application/use-cases/update-chapter/update-chapter.use-case.ts
+++ b/ayunis-core-backend/src/domain/academy/application/use-cases/update-chapter/update-chapter.use-case.ts
@@ -1,0 +1,43 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ApplicationError } from 'src/common/errors/base.error';
+import { AcademyChapterRepository } from '../../ports/academy-chapter.repository';
+import { AcademyChapter } from '../../../domain/academy-chapter.entity';
+import {
+  ChapterNotFoundError,
+  UnexpectedAcademyError,
+} from '../../academy.errors';
+import { UpdateChapterCommand } from './update-chapter.command';
+
+@Injectable()
+export class UpdateChapterUseCase {
+  private readonly logger = new Logger(UpdateChapterUseCase.name);
+
+  constructor(private readonly chapterRepository: AcademyChapterRepository) {}
+
+  async execute(command: UpdateChapterCommand): Promise<AcademyChapter> {
+    this.logger.log('Updating academy chapter', {
+      chapterId: command.chapterId,
+    });
+    try {
+      const existing = await this.chapterRepository.findOne(command.chapterId);
+      if (!existing) {
+        throw new ChapterNotFoundError(command.chapterId);
+      }
+      const updated = new AcademyChapter({
+        id: existing.id,
+        title: command.title,
+        description: command.description,
+        position: existing.position,
+        createdAt: existing.createdAt,
+        updatedAt: new Date(),
+      });
+      return await this.chapterRepository.update(updated);
+    } catch (error) {
+      if (error instanceof ApplicationError) throw error;
+      this.logger.error('Error updating academy chapter', {
+        error: error as Error,
+      });
+      throw new UnexpectedAcademyError(error);
+    }
+  }
+}

--- a/ayunis-core-backend/src/domain/academy/application/use-cases/update-lesson/update-lesson.command.ts
+++ b/ayunis-core-backend/src/domain/academy/application/use-cases/update-lesson/update-lesson.command.ts
@@ -1,0 +1,20 @@
+import type { UUID } from 'crypto';
+
+export class UpdateLessonCommand {
+  public readonly lessonId: UUID;
+  public readonly title: string;
+  public readonly description?: string | null;
+  public readonly loomUrl: string;
+
+  constructor(params: {
+    lessonId: UUID;
+    title: string;
+    description?: string | null;
+    loomUrl: string;
+  }) {
+    this.lessonId = params.lessonId;
+    this.title = params.title;
+    this.description = params.description;
+    this.loomUrl = params.loomUrl;
+  }
+}

--- a/ayunis-core-backend/src/domain/academy/application/use-cases/update-lesson/update-lesson.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/academy/application/use-cases/update-lesson/update-lesson.use-case.spec.ts
@@ -1,0 +1,102 @@
+import type { TestingModule } from '@nestjs/testing';
+import { Test } from '@nestjs/testing';
+import { Logger } from '@nestjs/common';
+import { randomUUID } from 'crypto';
+import { UpdateLessonUseCase } from './update-lesson.use-case';
+import { UpdateLessonCommand } from './update-lesson.command';
+import { AcademyLessonRepository } from '../../ports/academy-lesson.repository';
+import { AcademyLesson } from '../../../domain/academy-lesson.entity';
+import { LessonNotFoundError } from '../../academy.errors';
+
+describe('UpdateLessonUseCase', () => {
+  let useCase: UpdateLessonUseCase;
+  let lessonRepository: jest.Mocked<AcademyLessonRepository>;
+
+  beforeAll(async () => {
+    const mockLessonRepository = {
+      findOne: jest.fn(),
+      update: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        UpdateLessonUseCase,
+        { provide: AcademyLessonRepository, useValue: mockLessonRepository },
+      ],
+    }).compile();
+
+    useCase = module.get<UpdateLessonUseCase>(UpdateLessonUseCase);
+    lessonRepository = module.get(AcademyLessonRepository);
+
+    jest.spyOn(Logger.prototype, 'log').mockImplementation();
+    jest.spyOn(Logger.prototype, 'error').mockImplementation();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should preserve the existing description when the update omits it', async () => {
+    const existing = new AcademyLesson({
+      chapterId: randomUUID(),
+      title: 'Initial onboarding tour',
+      description: 'A walkthrough of the academy basics',
+      loomUrl: 'https://www.loom.com/share/initial-tour',
+      position: 2,
+    });
+    lessonRepository.findOne.mockResolvedValue(existing);
+    lessonRepository.update.mockImplementation(
+      async (lesson: AcademyLesson) => lesson,
+    );
+
+    const result = await useCase.execute(
+      new UpdateLessonCommand({
+        lessonId: existing.id,
+        title: 'Updated onboarding tour',
+        loomUrl: 'https://www.loom.com/share/updated-tour',
+      }),
+    );
+
+    expect(result.description).toBe('A walkthrough of the academy basics');
+  });
+
+  it('should clear the description when the update explicitly sets it to null', async () => {
+    const existing = new AcademyLesson({
+      chapterId: randomUUID(),
+      title: 'Initial prompt library tour',
+      description: 'A walkthrough of reusable prompts',
+      loomUrl: 'https://www.loom.com/share/prompt-library',
+      position: 1,
+    });
+    lessonRepository.findOne.mockResolvedValue(existing);
+    lessonRepository.update.mockImplementation(
+      async (lesson: AcademyLesson) => lesson,
+    );
+
+    const result = await useCase.execute(
+      new UpdateLessonCommand({
+        lessonId: existing.id,
+        title: 'Updated prompt library tour',
+        description: null,
+        loomUrl: 'https://www.loom.com/share/updated-prompt-library',
+      }),
+    );
+
+    expect(result.description).toBeNull();
+  });
+
+  it('should reject updates for a non-existent lesson', async () => {
+    lessonRepository.findOne.mockResolvedValue(null);
+
+    await expect(
+      useCase.execute(
+        new UpdateLessonCommand({
+          lessonId: randomUUID(),
+          title: 'Missing lesson',
+          loomUrl: 'https://www.loom.com/share/missing-lesson',
+        }),
+      ),
+    ).rejects.toThrow(LessonNotFoundError);
+    expect(lessonRepository.update).not.toHaveBeenCalled();
+  });
+});

--- a/ayunis-core-backend/src/domain/academy/application/use-cases/update-lesson/update-lesson.use-case.ts
+++ b/ayunis-core-backend/src/domain/academy/application/use-cases/update-lesson/update-lesson.use-case.ts
@@ -1,0 +1,43 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ApplicationError } from 'src/common/errors/base.error';
+import { AcademyLessonRepository } from '../../ports/academy-lesson.repository';
+import { AcademyLesson } from '../../../domain/academy-lesson.entity';
+import {
+  LessonNotFoundError,
+  UnexpectedAcademyError,
+} from '../../academy.errors';
+import { UpdateLessonCommand } from './update-lesson.command';
+
+@Injectable()
+export class UpdateLessonUseCase {
+  private readonly logger = new Logger(UpdateLessonUseCase.name);
+
+  constructor(private readonly lessonRepository: AcademyLessonRepository) {}
+
+  async execute(command: UpdateLessonCommand): Promise<AcademyLesson> {
+    this.logger.log('Updating academy lesson', { lessonId: command.lessonId });
+    try {
+      const existing = await this.lessonRepository.findOne(command.lessonId);
+      if (!existing) {
+        throw new LessonNotFoundError(command.lessonId);
+      }
+      const updated = new AcademyLesson({
+        id: existing.id,
+        chapterId: existing.chapterId,
+        title: command.title,
+        description: command.description,
+        loomUrl: command.loomUrl,
+        position: existing.position,
+        createdAt: existing.createdAt,
+        updatedAt: new Date(),
+      });
+      return await this.lessonRepository.update(updated);
+    } catch (error) {
+      if (error instanceof ApplicationError) throw error;
+      this.logger.error('Error updating academy lesson', {
+        error: error as Error,
+      });
+      throw new UnexpectedAcademyError(error);
+    }
+  }
+}

--- a/ayunis-core-backend/src/domain/academy/application/use-cases/update-lesson/update-lesson.use-case.ts
+++ b/ayunis-core-backend/src/domain/academy/application/use-cases/update-lesson/update-lesson.use-case.ts
@@ -25,7 +25,10 @@ export class UpdateLessonUseCase {
         id: existing.id,
         chapterId: existing.chapterId,
         title: command.title,
-        description: command.description,
+        description:
+          command.description === undefined
+            ? existing.description
+            : command.description,
         loomUrl: command.loomUrl,
         position: existing.position,
         createdAt: existing.createdAt,


### PR DESCRIPTION
- CRUD use cases for chapters and lessons with append-at-end positioning
- Reorder use cases validate set equality between submitted and current
  ids before transactionally rewriting positions
- Specs for reorder validation and lesson creation

Refs: AYC-239, AYC-240

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Application-layer-only changes to admin learning content with no new public API surface; reorder validation and several use cases are covered by unit tests.
> 
> **Overview**
> Adds the **academy application layer** so admin-managed chapters and Loom lessons can be loaded, created, updated, deleted, and reordered without new HTTP endpoints in this PR.
> 
> **`AcademyModule`** now registers nine use cases (get content, chapter/lesson CRUD, chapter/lesson reorder) and **exports only** `GetAcademyContentUseCase` for other modules. **`ARCHITECTURE.md`** and **`academy/SUMMARY.md`** document the new use-case layout and shared **`assertSameIdSet`** helper used by reorder flows to reject missing or extra IDs before **`updatePositions`** runs.
> 
> Create flows **append at the end** via `findMaxPosition`; updates **keep position** (and lesson updates **preserve description** when omitted or clear it when set to `null`). Reorder-lessons is **scoped to a chapter** and validates the ID set against that chapter’s lessons. **Jest specs** cover reorder validation, lesson creation, and lesson update description behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4264102ca46bc9553bc730d8b4d5c28b7d628ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->