### PR TITLE
wip(academy): expose super-admin academy management API (AYC-243)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -46,7 +46,7 @@ ayunis-core/
 | [transcriptions](ayunis-core-backend/src/domain/transcriptions/SUMMARY.md) | Voice | Audio transcription service |
 | [usage](ayunis-core-backend/src/domain/usage/SUMMARY.md) | Metering | Token and credit usage tracking |
 | [skill-templates](ayunis-core-backend/src/domain/skill-templates/SUMMARY.md) | Blueprints | Admin-managed skill templates with distribution modes |
-| [academy](ayunis-core-backend/src/domain/academy/SUMMARY.md) | Learning Content | Admin-managed chapters and ordered Loom lessons |
+| [academy](ayunis-core-backend/src/domain/academy/SUMMARY.md) | Learning | Academy chapters and lessons managed by super admins |
 | [anonymization-settings](ayunis-core-backend/src/domain/anonymization-settings) | Privacy Config | Org-level PII whitelist for anonymous mode |
 | [thread-pii-masks](ayunis-core-backend/src/domain/thread-pii-masks/SUMMARY.md) | Privacy | Per-thread PII mask dictionary for anonymous mode |
 

--- a/ayunis-core-backend/src/domain/academy/SUMMARY.md
+++ b/ayunis-core-backend/src/domain/academy/SUMMARY.md
@@ -1,57 +1,46 @@
-# Academy Module
+# Academy
 
-## Purpose
+Platform-global learning content for the **Ayunis Core Academy** add-on
+(`AddonType.AYUNIS_CORE_ACADEMY`): chapters containing video lessons, authored
+centrally by super admins. There is no org or user-facing surface yet — read
+access gated by the org's add-on activation is a follow-up.
 
-The academy provides admin-managed learning content organized as chapters that group ordered lessons. Each lesson links to a Loom video and carries a title, optional description, and a position within its chapter.
+## Model
 
-## Key Concepts
+- `AcademyChapter` — `{ id, title, description, position, lessons[] }`.
+- `AcademyLesson` — `{ id, chapterId, title, description?, loomUrl, position }`,
+  cascade-deleted with its chapter. `loomUrl` is a validated Loom share/embed
+  link (`https://loom.com/(share|embed)/...`).
 
-- **Chapter**: A titled, described, positioned grouping of lessons (`AcademyChapter`).
-- **Lesson**: A titled video lesson belonging to a chapter, with an optional description, a Loom URL, and a position within the chapter (`AcademyLesson`).
-- **Ordering**: Both chapters and lessons are ordered by an integer `position`. Repositories expose `findMaxPosition` for appending and `updatePositions` for reordering.
+## Ordering
 
-## Structure
+Both chapters (globally) and lessons (per chapter) carry a 0-based `position`
+and are freely sortable:
 
-```text
-academy/
-├── SUMMARY.md
-├── domain/
-│   ├── academy-chapter.entity.ts   # AcademyChapter domain entity (holds its lessons)
-│   └── academy-lesson.entity.ts    # AcademyLesson domain entity
-├── application/
-│   ├── academy.errors.ts           # Domain errors + AcademyErrorCode
-│   ├── reorder-validation.ts       # Shared set equality validation for reorder commands
-│   ├── ports/
-│   │   ├── academy-chapter.repository.ts  # Abstract chapter repository interface
-│   │   └── academy-lesson.repository.ts   # Abstract lesson repository interface
-│   └── use-cases/
-│       ├── get-academy-content/    # Load chapters with ordered lessons
-│       ├── create-chapter/         # Append a chapter after the last position
-│       ├── update-chapter/         # Update title/description while preserving position
-│       ├── delete-chapter/         # Delete a chapter
-│       ├── reorder-chapters/       # Rewrite chapter positions after validating id set
-│       ├── create-lesson/          # Append a lesson within an existing chapter
-│       ├── update-lesson/          # Update title/video/description while preserving position
-│       ├── delete-lesson/          # Delete a lesson
-│       └── reorder-lessons/        # Rewrite lesson positions scoped to a chapter
-├── infrastructure/
-│   └── persistence/local/
-│       ├── schema/
-│       │   ├── academy-chapter.record.ts  # AcademyChapterRecord TypeORM entity
-│       │   └── academy-lesson.record.ts   # AcademyLessonRecord TypeORM entity (ManyToOne chapter)
-│       ├── mappers/academy.mapper.ts      # Domain ↔ Record conversion for chapters and lessons
-│       ├── local-academy-chapter.repository.ts  # PostgreSQL chapter repository
-│       └── local-academy-lesson.repository.ts   # PostgreSQL lesson repository
-└── academy.module.ts               # NestJS wiring
-```
+- Creates append at `max(position) + 1`; reads order by
+  `position ASC, createdAt ASC`.
+- Reorder use cases require the submitted ids to be exactly the current set
+  (set equality, validated via `reorder-validation.ts`) and rewrite positions
+  `0..n-1` in a single transaction. Mismatches throw `InvalidReorderError`
+  (400) with `missing`/`extra` metadata.
+- Concurrent reorders are last-write-wins (acceptable for a super-admin-only
+  surface).
 
-## Errors
+## Management
 
-- `ChapterNotFoundError` (404) — chapter id not found.
-- `LessonNotFoundError` (404) — lesson id not found.
-- `InvalidReorderError` (400) — submitted ids do not match the current set of items.
-- `UnexpectedAcademyError` (500) — wraps unexpected errors.
+Super-admin only (`@SystemRoles(SUPER_ADMIN)`), two controllers under
+`super-admin/academy`:
 
-## Module Wiring
+- `SuperAdminAcademyChaptersController` (`super-admin/academy/chapters`) —
+  list (chapters with nested ordered lessons), create, update, delete,
+  reorder (`PUT chapters/order`, declared before the `:id` routes).
+- `SuperAdminAcademyLessonsController` (`super-admin/academy`) — create
+  (`POST chapters/:chapterId/lessons`), reorder
+  (`PUT chapters/:chapterId/lessons/order`), update/delete (`lessons/:id`).
 
-`AcademyModule` registers the `AcademyChapterRecord` and `AcademyLessonRecord` TypeORM entities, the `AcademyMapper`, binds the `AcademyChapterRepository` / `AcademyLessonRepository` ports to their local PostgreSQL implementations (`LocalAcademyChapterRepository`, `LocalAcademyLessonRepository`), and provides the academy content management use cases. Only `GetAcademyContentUseCase` is exported for cross-module consumption for now.
+## Layout
+
+Standard hexagonal: `domain/` (chapter + lesson entities), `application/`
+(repository ports, use-cases, errors, reorder validation), `infrastructure/`
+(Postgres records + mapper + repositories), `presenters/http/` (super-admin
+controllers + DTOs + response mapper).

--- a/ayunis-core-backend/src/domain/academy/academy.module.ts
+++ b/ayunis-core-backend/src/domain/academy/academy.module.ts
@@ -16,12 +16,20 @@ import { CreateLessonUseCase } from './application/use-cases/create-lesson/creat
 import { UpdateLessonUseCase } from './application/use-cases/update-lesson/update-lesson.use-case';
 import { DeleteLessonUseCase } from './application/use-cases/delete-lesson/delete-lesson.use-case';
 import { ReorderLessonsUseCase } from './application/use-cases/reorder-lessons/reorder-lessons.use-case';
+import { SuperAdminAcademyChaptersController } from './presenters/http/super-admin-academy-chapters.controller';
+import { SuperAdminAcademyLessonsController } from './presenters/http/super-admin-academy-lessons.controller';
+import { AcademyResponseDtoMapper } from './presenters/http/mappers/academy-response-dto.mapper';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([AcademyChapterRecord, AcademyLessonRecord]),
   ],
+  controllers: [
+    SuperAdminAcademyChaptersController,
+    SuperAdminAcademyLessonsController,
+  ],
   providers: [
+    AcademyResponseDtoMapper,
     AcademyMapper,
     LocalAcademyChapterRepository,
     LocalAcademyLessonRepository,

--- a/ayunis-core-backend/src/domain/academy/application/use-cases/update-chapter/update-chapter.use-case.ts
+++ b/ayunis-core-backend/src/domain/academy/application/use-cases/update-chapter/update-chapter.use-case.ts
@@ -28,10 +28,20 @@ export class UpdateChapterUseCase {
         title: command.title,
         description: command.description,
         position: existing.position,
+        lessons: existing.lessons,
         createdAt: existing.createdAt,
         updatedAt: new Date(),
       });
-      return await this.chapterRepository.update(updated);
+      const persisted = await this.chapterRepository.update(updated);
+      return new AcademyChapter({
+        id: persisted.id,
+        title: persisted.title,
+        description: persisted.description,
+        position: persisted.position,
+        lessons: existing.lessons,
+        createdAt: persisted.createdAt,
+        updatedAt: persisted.updatedAt,
+      });
     } catch (error) {
       if (error instanceof ApplicationError) throw error;
       this.logger.error('Error updating academy chapter', {

--- a/ayunis-core-backend/src/domain/academy/infrastructure/persistence/local/local-academy-chapter.repository.ts
+++ b/ayunis-core-backend/src/domain/academy/infrastructure/persistence/local/local-academy-chapter.repository.ts
@@ -35,7 +35,11 @@ export class LocalAcademyChapterRepository implements AcademyChapterRepository {
 
   async findOne(id: UUID): Promise<AcademyChapter | null> {
     this.logger.log('findOne', { id });
-    const record = await this.repository.findOne({ where: { id } });
+    const record = await this.repository.findOne({
+      where: { id },
+      relations: { lessons: true },
+      order: { lessons: { position: 'ASC', createdAt: 'ASC' } },
+    });
     if (!record) return null;
     return this.mapper.chapterToDomain(record);
   }

--- a/ayunis-core-backend/src/domain/academy/presenters/http/dto/academy-chapter-response.dto.ts
+++ b/ayunis-core-backend/src/domain/academy/presenters/http/dto/academy-chapter-response.dto.ts
@@ -1,0 +1,53 @@
+import { ApiProperty } from '@nestjs/swagger';
+import type { UUID } from 'crypto';
+import { AcademyLessonResponseDto } from './academy-lesson-response.dto';
+
+export class AcademyChapterResponseDto {
+  @ApiProperty({
+    type: 'string',
+    format: 'uuid',
+    description: 'The unique identifier of the chapter',
+  })
+  id: UUID;
+
+  @ApiProperty({
+    type: 'string',
+    description: 'The title of the chapter',
+    example: 'Getting Started',
+  })
+  title: string;
+
+  @ApiProperty({
+    type: 'string',
+    description: 'A description of what the chapter covers',
+    example: 'Learn the basics of working with Ayunis Core.',
+  })
+  description: string;
+
+  @ApiProperty({
+    type: 'integer',
+    description: 'The position of the chapter (0-based)',
+    example: 0,
+  })
+  position: number;
+
+  @ApiProperty({
+    type: [AcademyLessonResponseDto],
+    description: 'The lessons of the chapter, ordered by position',
+  })
+  lessons: AcademyLessonResponseDto[];
+
+  @ApiProperty({
+    type: 'string',
+    format: 'date-time',
+    description: 'The date the chapter was created',
+  })
+  createdAt: Date;
+
+  @ApiProperty({
+    type: 'string',
+    format: 'date-time',
+    description: 'The date the chapter was last updated',
+  })
+  updatedAt: Date;
+}

--- a/ayunis-core-backend/src/domain/academy/presenters/http/dto/academy-lesson-response.dto.ts
+++ b/ayunis-core-backend/src/domain/academy/presenters/http/dto/academy-lesson-response.dto.ts
@@ -1,0 +1,61 @@
+import { ApiProperty } from '@nestjs/swagger';
+import type { UUID } from 'crypto';
+
+export class AcademyLessonResponseDto {
+  @ApiProperty({
+    type: 'string',
+    format: 'uuid',
+    description: 'The unique identifier of the lesson',
+  })
+  id: UUID;
+
+  @ApiProperty({
+    type: 'string',
+    format: 'uuid',
+    description: 'The id of the chapter the lesson belongs to',
+  })
+  chapterId: UUID;
+
+  @ApiProperty({
+    type: 'string',
+    description: 'The title of the lesson',
+    example: 'Creating your first chat',
+  })
+  title: string;
+
+  @ApiProperty({
+    type: 'string',
+    nullable: true,
+    description: 'An optional description of the lesson',
+    example: 'A short walkthrough of the chat interface.',
+  })
+  description: string | null;
+
+  @ApiProperty({
+    type: 'string',
+    description: 'The Loom share or embed link of the lesson video',
+    example: 'https://www.loom.com/share/abc123def456',
+  })
+  loomUrl: string;
+
+  @ApiProperty({
+    type: 'integer',
+    description: 'The position of the lesson within its chapter (0-based)',
+    example: 0,
+  })
+  position: number;
+
+  @ApiProperty({
+    type: 'string',
+    format: 'date-time',
+    description: 'The date the lesson was created',
+  })
+  createdAt: Date;
+
+  @ApiProperty({
+    type: 'string',
+    format: 'date-time',
+    description: 'The date the lesson was last updated',
+  })
+  updatedAt: Date;
+}

--- a/ayunis-core-backend/src/domain/academy/presenters/http/dto/create-chapter-request.dto.ts
+++ b/ayunis-core-backend/src/domain/academy/presenters/http/dto/create-chapter-request.dto.ts
@@ -1,0 +1,24 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsString, MaxLength } from 'class-validator';
+
+export class CreateChapterRequestDto {
+  @ApiProperty({
+    description: 'The title of the chapter',
+    example: 'Getting Started',
+    maxLength: 255,
+  })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(255)
+  title: string;
+
+  @ApiProperty({
+    description: 'A description of what the chapter covers',
+    example: 'Learn the basics of working with Ayunis Core.',
+    maxLength: 2000,
+  })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(2000)
+  description: string;
+}

--- a/ayunis-core-backend/src/domain/academy/presenters/http/dto/create-lesson-request.dto.ts
+++ b/ayunis-core-backend/src/domain/academy/presenters/http/dto/create-lesson-request.dto.ts
@@ -1,0 +1,47 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  IsUrl,
+  Matches,
+  MaxLength,
+} from 'class-validator';
+
+export class CreateLessonRequestDto {
+  @ApiProperty({
+    description: 'The title of the lesson',
+    example: 'Creating your first chat',
+    maxLength: 255,
+  })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(255)
+  title: string;
+
+  @ApiPropertyOptional({
+    description: 'An optional description of the lesson',
+    example: 'A short walkthrough of the chat interface.',
+    maxLength: 2000,
+  })
+  @IsString()
+  @IsOptional()
+  @MaxLength(2000)
+  description?: string;
+
+  @ApiProperty({
+    description: 'The Loom share or embed link of the lesson video',
+    example: 'https://www.loom.com/share/abc123def456',
+    maxLength: 500,
+  })
+  @IsUrl({
+    require_protocol: true,
+    protocols: ['https'],
+    host_whitelist: ['loom.com', 'www.loom.com'],
+  })
+  @Matches(/^https:\/\/(www\.)?loom\.com\/(share|embed)\/[A-Za-z0-9]+/, {
+    message: 'loomUrl must be a Loom share or embed link',
+  })
+  @MaxLength(500)
+  loomUrl: string;
+}

--- a/ayunis-core-backend/src/domain/academy/presenters/http/dto/reorder-chapters-request.dto.ts
+++ b/ayunis-core-backend/src/domain/academy/presenters/http/dto/reorder-chapters-request.dto.ts
@@ -1,0 +1,17 @@
+import { ApiProperty } from '@nestjs/swagger';
+import type { UUID } from 'crypto';
+import { ArrayNotEmpty, ArrayUnique, IsArray, IsUUID } from 'class-validator';
+
+export class ReorderChaptersRequestDto {
+  @ApiProperty({
+    description:
+      'All chapter ids in their new order. Must contain exactly the ids of all existing chapters.',
+    type: 'array',
+    items: { type: 'string', format: 'uuid' },
+  })
+  @IsArray()
+  @ArrayNotEmpty()
+  @ArrayUnique()
+  @IsUUID(undefined, { each: true })
+  chapterIds: UUID[];
+}

--- a/ayunis-core-backend/src/domain/academy/presenters/http/dto/reorder-lessons-request.dto.ts
+++ b/ayunis-core-backend/src/domain/academy/presenters/http/dto/reorder-lessons-request.dto.ts
@@ -1,0 +1,17 @@
+import { ApiProperty } from '@nestjs/swagger';
+import type { UUID } from 'crypto';
+import { ArrayNotEmpty, ArrayUnique, IsArray, IsUUID } from 'class-validator';
+
+export class ReorderLessonsRequestDto {
+  @ApiProperty({
+    description:
+      'All lesson ids of the chapter in their new order. Must contain exactly the ids of all lessons in the chapter.',
+    type: 'array',
+    items: { type: 'string', format: 'uuid' },
+  })
+  @IsArray()
+  @ArrayNotEmpty()
+  @ArrayUnique()
+  @IsUUID(undefined, { each: true })
+  lessonIds: UUID[];
+}

--- a/ayunis-core-backend/src/domain/academy/presenters/http/dto/update-chapter-request.dto.ts
+++ b/ayunis-core-backend/src/domain/academy/presenters/http/dto/update-chapter-request.dto.ts
@@ -1,0 +1,4 @@
+import { CreateChapterRequestDto } from './create-chapter-request.dto';
+
+// Full-replace update: same fields and validation as create.
+export class UpdateChapterRequestDto extends CreateChapterRequestDto {}

--- a/ayunis-core-backend/src/domain/academy/presenters/http/dto/update-lesson-request.dto.ts
+++ b/ayunis-core-backend/src/domain/academy/presenters/http/dto/update-lesson-request.dto.ts
@@ -1,0 +1,4 @@
+import { CreateLessonRequestDto } from './create-lesson-request.dto';
+
+// Full-replace update: same fields and validation as create.
+export class UpdateLessonRequestDto extends CreateLessonRequestDto {}

--- a/ayunis-core-backend/src/domain/academy/presenters/http/mappers/academy-response-dto.mapper.ts
+++ b/ayunis-core-backend/src/domain/academy/presenters/http/mappers/academy-response-dto.mapper.ts
@@ -1,0 +1,37 @@
+import { Injectable } from '@nestjs/common';
+import type { AcademyChapter } from '../../../domain/academy-chapter.entity';
+import type { AcademyLesson } from '../../../domain/academy-lesson.entity';
+import { AcademyChapterResponseDto } from '../dto/academy-chapter-response.dto';
+import { AcademyLessonResponseDto } from '../dto/academy-lesson-response.dto';
+
+@Injectable()
+export class AcademyResponseDtoMapper {
+  chapterToDto(entity: AcademyChapter): AcademyChapterResponseDto {
+    const dto = new AcademyChapterResponseDto();
+    dto.id = entity.id;
+    dto.title = entity.title;
+    dto.description = entity.description;
+    dto.position = entity.position;
+    dto.lessons = entity.lessons.map((lesson) => this.lessonToDto(lesson));
+    dto.createdAt = entity.createdAt;
+    dto.updatedAt = entity.updatedAt;
+    return dto;
+  }
+
+  chapterToDtoArray(entities: AcademyChapter[]): AcademyChapterResponseDto[] {
+    return entities.map((entity) => this.chapterToDto(entity));
+  }
+
+  lessonToDto(entity: AcademyLesson): AcademyLessonResponseDto {
+    const dto = new AcademyLessonResponseDto();
+    dto.id = entity.id;
+    dto.chapterId = entity.chapterId;
+    dto.title = entity.title;
+    dto.description = entity.description;
+    dto.loomUrl = entity.loomUrl;
+    dto.position = entity.position;
+    dto.createdAt = entity.createdAt;
+    dto.updatedAt = entity.updatedAt;
+    return dto;
+  }
+}

--- a/ayunis-core-backend/src/domain/academy/presenters/http/super-admin-academy-chapters.controller.ts
+++ b/ayunis-core-backend/src/domain/academy/presenters/http/super-admin-academy-chapters.controller.ts
@@ -1,0 +1,205 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Logger,
+  Param,
+  ParseUUIDPipe,
+  Post,
+  Put,
+} from '@nestjs/common';
+import {
+  ApiBody,
+  ApiCreatedResponse,
+  ApiInternalServerErrorResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiParam,
+  ApiResponse,
+  ApiTags,
+  ApiUnauthorizedResponse,
+} from '@nestjs/swagger';
+import type { UUID } from 'crypto';
+import { SystemRoles } from 'src/iam/authorization/application/decorators/system-roles.decorator';
+import { SystemRole } from 'src/iam/users/domain/value-objects/system-role.enum';
+import { GetAcademyContentUseCase } from '../../application/use-cases/get-academy-content/get-academy-content.use-case';
+import { GetAcademyContentQuery } from '../../application/use-cases/get-academy-content/get-academy-content.query';
+import { CreateChapterUseCase } from '../../application/use-cases/create-chapter/create-chapter.use-case';
+import { CreateChapterCommand } from '../../application/use-cases/create-chapter/create-chapter.command';
+import { UpdateChapterUseCase } from '../../application/use-cases/update-chapter/update-chapter.use-case';
+import { UpdateChapterCommand } from '../../application/use-cases/update-chapter/update-chapter.command';
+import { DeleteChapterUseCase } from '../../application/use-cases/delete-chapter/delete-chapter.use-case';
+import { DeleteChapterCommand } from '../../application/use-cases/delete-chapter/delete-chapter.command';
+import { ReorderChaptersUseCase } from '../../application/use-cases/reorder-chapters/reorder-chapters.use-case';
+import { ReorderChaptersCommand } from '../../application/use-cases/reorder-chapters/reorder-chapters.command';
+import { CreateChapterRequestDto } from './dto/create-chapter-request.dto';
+import { UpdateChapterRequestDto } from './dto/update-chapter-request.dto';
+import { ReorderChaptersRequestDto } from './dto/reorder-chapters-request.dto';
+import { AcademyChapterResponseDto } from './dto/academy-chapter-response.dto';
+import { AcademyResponseDtoMapper } from './mappers/academy-response-dto.mapper';
+
+@ApiTags('Super Admin Academy')
+@Controller('super-admin/academy/chapters')
+@SystemRoles(SystemRole.SUPER_ADMIN)
+export class SuperAdminAcademyChaptersController {
+  private readonly logger = new Logger(
+    SuperAdminAcademyChaptersController.name,
+  );
+
+  constructor(
+    private readonly getAcademyContentUseCase: GetAcademyContentUseCase,
+    private readonly createChapterUseCase: CreateChapterUseCase,
+    private readonly updateChapterUseCase: UpdateChapterUseCase,
+    private readonly deleteChapterUseCase: DeleteChapterUseCase,
+    private readonly reorderChaptersUseCase: ReorderChaptersUseCase,
+    private readonly responseMapper: AcademyResponseDtoMapper,
+  ) {}
+
+  @Get()
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Get all academy chapters with their lessons',
+    description:
+      'Retrieve all chapters with nested lessons, ordered by position. Only accessible to super admins.',
+  })
+  @ApiOkResponse({
+    description: 'Successfully retrieved academy chapters',
+    type: [AcademyChapterResponseDto],
+  })
+  @ApiUnauthorizedResponse({
+    description: 'User not authenticated or not authorized as super admin',
+  })
+  @ApiInternalServerErrorResponse({ description: 'Internal server error' })
+  async getChapters(): Promise<AcademyChapterResponseDto[]> {
+    this.logger.log('Getting academy chapters');
+    const chapters = await this.getAcademyContentUseCase.execute(
+      new GetAcademyContentQuery(),
+    );
+    return this.responseMapper.chapterToDtoArray(chapters);
+  }
+
+  @Post()
+  @HttpCode(HttpStatus.CREATED)
+  @ApiOperation({
+    summary: 'Create a new academy chapter',
+    description:
+      'Create a new chapter appended after the last position. Only accessible to super admins.',
+  })
+  @ApiBody({ type: CreateChapterRequestDto })
+  @ApiCreatedResponse({
+    description: 'Successfully created chapter',
+    type: AcademyChapterResponseDto,
+  })
+  @ApiUnauthorizedResponse({
+    description: 'User not authenticated or not authorized as super admin',
+  })
+  @ApiInternalServerErrorResponse({ description: 'Internal server error' })
+  async createChapter(
+    @Body() dto: CreateChapterRequestDto,
+  ): Promise<AcademyChapterResponseDto> {
+    this.logger.log(`Creating academy chapter: ${dto.title}`);
+    const chapter = await this.createChapterUseCase.execute(
+      new CreateChapterCommand({
+        title: dto.title,
+        description: dto.description,
+      }),
+    );
+    return this.responseMapper.chapterToDto(chapter);
+  }
+
+  // NOTE: this route must stay declared before the ':id' routes —
+  // Nest matches routes in declaration order and 'chapters/:id'
+  // would otherwise swallow 'chapters/order'.
+  @Put('order')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({
+    summary: 'Reorder academy chapters',
+    description:
+      'Persist a new chapter order. The submitted ids must be exactly the ids of all existing chapters. Only accessible to super admins.',
+  })
+  @ApiBody({ type: ReorderChaptersRequestDto })
+  @ApiResponse({
+    status: HttpStatus.NO_CONTENT,
+    description: 'Successfully reordered chapters',
+  })
+  @ApiResponse({
+    status: HttpStatus.BAD_REQUEST,
+    description: 'Submitted ids do not match the current set of chapters',
+  })
+  @ApiUnauthorizedResponse({
+    description: 'User not authenticated or not authorized as super admin',
+  })
+  @ApiInternalServerErrorResponse({ description: 'Internal server error' })
+  async reorderChapters(@Body() dto: ReorderChaptersRequestDto): Promise<void> {
+    this.logger.log(`Reordering ${dto.chapterIds.length} academy chapters`);
+    await this.reorderChaptersUseCase.execute(
+      new ReorderChaptersCommand({ chapterIds: dto.chapterIds }),
+    );
+  }
+
+  @Put(':id')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Update an academy chapter',
+    description:
+      'Replace title and description of a chapter. Only accessible to super admins.',
+  })
+  @ApiParam({ name: 'id', description: 'Chapter ID', format: 'uuid' })
+  @ApiBody({ type: UpdateChapterRequestDto })
+  @ApiOkResponse({
+    description: 'Successfully updated chapter',
+    type: AcademyChapterResponseDto,
+  })
+  @ApiResponse({
+    status: HttpStatus.NOT_FOUND,
+    description: 'Chapter not found',
+  })
+  @ApiUnauthorizedResponse({
+    description: 'User not authenticated or not authorized as super admin',
+  })
+  @ApiInternalServerErrorResponse({ description: 'Internal server error' })
+  async updateChapter(
+    @Param('id', ParseUUIDPipe) id: UUID,
+    @Body() dto: UpdateChapterRequestDto,
+  ): Promise<AcademyChapterResponseDto> {
+    this.logger.log(`Updating academy chapter ${id}`);
+    const chapter = await this.updateChapterUseCase.execute(
+      new UpdateChapterCommand({
+        chapterId: id,
+        title: dto.title,
+        description: dto.description,
+      }),
+    );
+    return this.responseMapper.chapterToDto(chapter);
+  }
+
+  @Delete(':id')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({
+    summary: 'Delete an academy chapter',
+    description:
+      'Delete a chapter and all of its lessons. Only accessible to super admins.',
+  })
+  @ApiParam({ name: 'id', description: 'Chapter ID', format: 'uuid' })
+  @ApiResponse({
+    status: HttpStatus.NO_CONTENT,
+    description: 'Successfully deleted chapter',
+  })
+  @ApiResponse({
+    status: HttpStatus.NOT_FOUND,
+    description: 'Chapter not found',
+  })
+  @ApiUnauthorizedResponse({
+    description: 'User not authenticated or not authorized as super admin',
+  })
+  @ApiInternalServerErrorResponse({ description: 'Internal server error' })
+  async deleteChapter(@Param('id', ParseUUIDPipe) id: UUID): Promise<void> {
+    this.logger.log(`Deleting academy chapter ${id}`);
+    await this.deleteChapterUseCase.execute(
+      new DeleteChapterCommand({ chapterId: id }),
+    );
+  }
+}

--- a/ayunis-core-backend/src/domain/academy/presenters/http/super-admin-academy-lessons.controller.ts
+++ b/ayunis-core-backend/src/domain/academy/presenters/http/super-admin-academy-lessons.controller.ts
@@ -1,0 +1,192 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  HttpCode,
+  HttpStatus,
+  Logger,
+  Param,
+  ParseUUIDPipe,
+  Post,
+  Put,
+} from '@nestjs/common';
+import {
+  ApiBody,
+  ApiCreatedResponse,
+  ApiInternalServerErrorResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiParam,
+  ApiResponse,
+  ApiTags,
+  ApiUnauthorizedResponse,
+} from '@nestjs/swagger';
+import type { UUID } from 'crypto';
+import { SystemRoles } from 'src/iam/authorization/application/decorators/system-roles.decorator';
+import { SystemRole } from 'src/iam/users/domain/value-objects/system-role.enum';
+import { CreateLessonUseCase } from '../../application/use-cases/create-lesson/create-lesson.use-case';
+import { CreateLessonCommand } from '../../application/use-cases/create-lesson/create-lesson.command';
+import { UpdateLessonUseCase } from '../../application/use-cases/update-lesson/update-lesson.use-case';
+import { UpdateLessonCommand } from '../../application/use-cases/update-lesson/update-lesson.command';
+import { DeleteLessonUseCase } from '../../application/use-cases/delete-lesson/delete-lesson.use-case';
+import { DeleteLessonCommand } from '../../application/use-cases/delete-lesson/delete-lesson.command';
+import { ReorderLessonsUseCase } from '../../application/use-cases/reorder-lessons/reorder-lessons.use-case';
+import { ReorderLessonsCommand } from '../../application/use-cases/reorder-lessons/reorder-lessons.command';
+import { CreateLessonRequestDto } from './dto/create-lesson-request.dto';
+import { UpdateLessonRequestDto } from './dto/update-lesson-request.dto';
+import { ReorderLessonsRequestDto } from './dto/reorder-lessons-request.dto';
+import { AcademyLessonResponseDto } from './dto/academy-lesson-response.dto';
+import { AcademyResponseDtoMapper } from './mappers/academy-response-dto.mapper';
+
+@ApiTags('Super Admin Academy')
+@Controller('super-admin/academy')
+@SystemRoles(SystemRole.SUPER_ADMIN)
+export class SuperAdminAcademyLessonsController {
+  private readonly logger = new Logger(SuperAdminAcademyLessonsController.name);
+
+  constructor(
+    private readonly createLessonUseCase: CreateLessonUseCase,
+    private readonly updateLessonUseCase: UpdateLessonUseCase,
+    private readonly deleteLessonUseCase: DeleteLessonUseCase,
+    private readonly reorderLessonsUseCase: ReorderLessonsUseCase,
+    private readonly responseMapper: AcademyResponseDtoMapper,
+  ) {}
+
+  @Post('chapters/:chapterId/lessons')
+  @HttpCode(HttpStatus.CREATED)
+  @ApiOperation({
+    summary: 'Create a new academy lesson',
+    description:
+      'Create a lesson in a chapter, appended after the last position. Only accessible to super admins.',
+  })
+  @ApiParam({ name: 'chapterId', description: 'Chapter ID', format: 'uuid' })
+  @ApiBody({ type: CreateLessonRequestDto })
+  @ApiCreatedResponse({
+    description: 'Successfully created lesson',
+    type: AcademyLessonResponseDto,
+  })
+  @ApiResponse({
+    status: HttpStatus.NOT_FOUND,
+    description: 'Chapter not found',
+  })
+  @ApiUnauthorizedResponse({
+    description: 'User not authenticated or not authorized as super admin',
+  })
+  @ApiInternalServerErrorResponse({ description: 'Internal server error' })
+  async createLesson(
+    @Param('chapterId', ParseUUIDPipe) chapterId: UUID,
+    @Body() dto: CreateLessonRequestDto,
+  ): Promise<AcademyLessonResponseDto> {
+    this.logger.log(`Creating academy lesson in chapter ${chapterId}`);
+    const lesson = await this.createLessonUseCase.execute(
+      new CreateLessonCommand({
+        chapterId,
+        title: dto.title,
+        description: dto.description,
+        loomUrl: dto.loomUrl,
+      }),
+    );
+    return this.responseMapper.lessonToDto(lesson);
+  }
+
+  @Put('chapters/:chapterId/lessons/order')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({
+    summary: 'Reorder the lessons of a chapter',
+    description:
+      'Persist a new lesson order within a chapter. The submitted ids must be exactly the ids of all lessons in the chapter. Only accessible to super admins.',
+  })
+  @ApiParam({ name: 'chapterId', description: 'Chapter ID', format: 'uuid' })
+  @ApiBody({ type: ReorderLessonsRequestDto })
+  @ApiResponse({
+    status: HttpStatus.NO_CONTENT,
+    description: 'Successfully reordered lessons',
+  })
+  @ApiResponse({
+    status: HttpStatus.BAD_REQUEST,
+    description:
+      'Submitted ids do not match the current lessons of the chapter',
+  })
+  @ApiResponse({
+    status: HttpStatus.NOT_FOUND,
+    description: 'Chapter not found',
+  })
+  @ApiUnauthorizedResponse({
+    description: 'User not authenticated or not authorized as super admin',
+  })
+  @ApiInternalServerErrorResponse({ description: 'Internal server error' })
+  async reorderLessons(
+    @Param('chapterId', ParseUUIDPipe) chapterId: UUID,
+    @Body() dto: ReorderLessonsRequestDto,
+  ): Promise<void> {
+    this.logger.log(
+      `Reordering ${dto.lessonIds.length} lessons of chapter ${chapterId}`,
+    );
+    await this.reorderLessonsUseCase.execute(
+      new ReorderLessonsCommand({ chapterId, lessonIds: dto.lessonIds }),
+    );
+  }
+
+  @Put('lessons/:id')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Update an academy lesson',
+    description:
+      'Replace title, description, and Loom link of a lesson. Only accessible to super admins.',
+  })
+  @ApiParam({ name: 'id', description: 'Lesson ID', format: 'uuid' })
+  @ApiBody({ type: UpdateLessonRequestDto })
+  @ApiOkResponse({
+    description: 'Successfully updated lesson',
+    type: AcademyLessonResponseDto,
+  })
+  @ApiResponse({
+    status: HttpStatus.NOT_FOUND,
+    description: 'Lesson not found',
+  })
+  @ApiUnauthorizedResponse({
+    description: 'User not authenticated or not authorized as super admin',
+  })
+  @ApiInternalServerErrorResponse({ description: 'Internal server error' })
+  async updateLesson(
+    @Param('id', ParseUUIDPipe) id: UUID,
+    @Body() dto: UpdateLessonRequestDto,
+  ): Promise<AcademyLessonResponseDto> {
+    this.logger.log(`Updating academy lesson ${id}`);
+    const lesson = await this.updateLessonUseCase.execute(
+      new UpdateLessonCommand({
+        lessonId: id,
+        title: dto.title,
+        description: dto.description,
+        loomUrl: dto.loomUrl,
+      }),
+    );
+    return this.responseMapper.lessonToDto(lesson);
+  }
+
+  @Delete('lessons/:id')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({
+    summary: 'Delete an academy lesson',
+    description: 'Delete a lesson. Only accessible to super admins.',
+  })
+  @ApiParam({ name: 'id', description: 'Lesson ID', format: 'uuid' })
+  @ApiResponse({
+    status: HttpStatus.NO_CONTENT,
+    description: 'Successfully deleted lesson',
+  })
+  @ApiResponse({
+    status: HttpStatus.NOT_FOUND,
+    description: 'Lesson not found',
+  })
+  @ApiUnauthorizedResponse({
+    description: 'User not authenticated or not authorized as super admin',
+  })
+  @ApiInternalServerErrorResponse({ description: 'Internal server error' })
+  async deleteLesson(@Param('id', ParseUUIDPipe) id: UUID): Promise<void> {
+    this.logger.log(`Deleting academy lesson ${id}`);
+    await this.deleteLessonUseCase.execute(
+      new DeleteLessonCommand({ lessonId: id }),
+    );
+  }
+}


### PR DESCRIPTION
- SuperAdminAcademyChaptersController: list/create/update/delete and
  PUT chapters/order (declared before :id routes)
- SuperAdminAcademyLessonsController: nested create + reorder under
  chapters/:chapterId/lessons, update/delete under lessons/:id
- Loom URL validation pinned to https://(www.)loom.com/(share|embed)/
- Module SUMMARY.md and ARCHITECTURE.md index entry

Refs: AYC-239, AYC-240

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New privileged admin surface with destructive deletes and reorder semantics; gated to SUPER_ADMIN but mistakes affect global learning content.
> 
> **Overview**
> Adds **super-admin HTTP endpoints** so platform admins can manage global Academy chapters and Loom-backed lessons via existing use cases.
> 
> **Chapters** (`super-admin/academy/chapters`): list with nested ordered lessons, create, full-replace update, delete (cascade lessons), and `PUT order` for reordering (route declared before `:id` so `order` is not captured as an id).
> 
> **Lessons** (`super-admin/academy`): create under `chapters/:chapterId/lessons`, reorder via `PUT chapters/:chapterId/lessons/order`, update/delete on `lessons/:id`. Lesson writes validate **https Loom share/embed URLs** only.
> 
> Supporting tweaks: `AcademyModule` registers the two controllers plus `AcademyResponseDtoMapper`; chapter `findOne` loads ordered lessons; **update chapter** keeps nested `lessons` on the returned entity after persist. Docs refreshed in academy `SUMMARY.md` and `ARCHITECTURE.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b79afa2cb649b073923119d2c58a4c75cc504426. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->