### PR TITLE
wip(academy): regenerate API client with academy endpoints (AYC-243)

### DIFF
--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
@@ -4038,6 +4038,117 @@ export interface UpsertOrgSystemPromptDto {
   systemPrompt: string;
 }
 
+export interface AcademyLessonResponseDto {
+  /** The unique identifier of the lesson */
+  id: string;
+  /** The id of the chapter the lesson belongs to */
+  chapterId: string;
+  /** The title of the lesson */
+  title: string;
+  /**
+   * An optional description of the lesson
+   * @nullable
+   */
+  description: string | null;
+  /** The Loom share or embed link of the lesson video */
+  loomUrl: string;
+  /** The position of the lesson within its chapter (0-based) */
+  position: number;
+  /** The date the lesson was created */
+  createdAt: string;
+  /** The date the lesson was last updated */
+  updatedAt: string;
+}
+
+export interface AcademyChapterResponseDto {
+  /** The unique identifier of the chapter */
+  id: string;
+  /** The title of the chapter */
+  title: string;
+  /** A description of what the chapter covers */
+  description: string;
+  /** The position of the chapter (0-based) */
+  position: number;
+  /** The lessons of the chapter, ordered by position */
+  lessons: AcademyLessonResponseDto[];
+  /** The date the chapter was created */
+  createdAt: string;
+  /** The date the chapter was last updated */
+  updatedAt: string;
+}
+
+export interface CreateChapterRequestDto {
+  /**
+   * The title of the chapter
+   * @maxLength 255
+   */
+  title: string;
+  /**
+   * A description of what the chapter covers
+   * @maxLength 2000
+   */
+  description: string;
+}
+
+export interface ReorderChaptersRequestDto {
+  /** All chapter ids in their new order. Must contain exactly the ids of all existing chapters. */
+  chapterIds: string[];
+}
+
+export interface UpdateChapterRequestDto {
+  /**
+   * The title of the chapter
+   * @maxLength 255
+   */
+  title: string;
+  /**
+   * A description of what the chapter covers
+   * @maxLength 2000
+   */
+  description: string;
+}
+
+export interface CreateLessonRequestDto {
+  /**
+   * The title of the lesson
+   * @maxLength 255
+   */
+  title: string;
+  /**
+   * An optional description of the lesson
+   * @maxLength 2000
+   */
+  description?: string;
+  /**
+   * The Loom share or embed link of the lesson video
+   * @maxLength 500
+   */
+  loomUrl: string;
+}
+
+export interface ReorderLessonsRequestDto {
+  /** All lesson ids of the chapter in their new order. Must contain exactly the ids of all lessons in the chapter. */
+  lessonIds: string[];
+}
+
+export interface UpdateLessonRequestDto {
+  /**
+   * The title of the lesson
+   * @maxLength 255
+   */
+  title: string;
+  /**
+   * An optional description of the lesson
+   * @maxLength 2000
+   */
+  description?: string;
+  /**
+   * The Loom share or embed link of the lesson video
+   * @maxLength 500
+   */
+  loomUrl: string;
+}
+
 export interface ChatCompletionRequestDto { [key: string]: unknown }
 
 export interface LoginDto {

--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.ts
@@ -25,6 +25,8 @@ import type {
 } from '@tanstack/react-query';
 
 import type {
+  AcademyChapterResponseDto,
+  AcademyLessonResponseDto,
   AcceptInviteDto,
   AcceptInviteResponseDto,
   ActiveSubscriptionResponseDto,
@@ -44,6 +46,7 @@ import type {
   CreateArtifactDto,
   CreateBulkInvitesDto,
   CreateBulkInvitesResponseDto,
+  CreateChapterRequestDto,
   CreateCustomIntegrationDto,
   CreateEmbeddingModelRequestDto,
   CreateImageGenerationModelRequestDto,
@@ -52,6 +55,7 @@ import type {
   CreateKnowledgeBaseDto,
   CreateKnowledgeBaseShareDto,
   CreateLanguageModelRequestDto,
+  CreateLessonRequestDto,
   CreateLetterheadDto,
   CreateOrgRequestDto,
   CreatePermittedModelDto,
@@ -117,6 +121,8 @@ import type {
   ProviderUsageChartResponseDto,
   ProviderUsageResponseDto,
   RegisterDto,
+  ReorderChaptersRequestDto,
+  ReorderLessonsRequestDto,
   ResendEmailConfirmationDto,
   ResetPasswordDto,
   RevertArtifactDto,
@@ -167,11 +173,13 @@ import type {
   TriggerPasswordResetResponseDto,
   UpdateArtifactDto,
   UpdateBillingInfoDto,
+  UpdateChapterRequestDto,
   UpdateEmbeddingModelRequestDto,
   UpdateImageGenerationModelRequestDto,
   UpdateIpAllowlistRequestDto,
   UpdateKnowledgeBaseDto,
   UpdateLanguageModelRequestDto,
+  UpdateLessonRequestDto,
   UpdateLetterheadDto,
   UpdateMcpIntegrationDto,
   UpdateMonthlyCreditsDto,
@@ -16331,6 +16339,622 @@ export const useOrgSystemPromptControllerDeleteOrgSystemPrompt = <TError = void,
       > => {
 
       const mutationOptions = getOrgSystemPromptControllerDeleteOrgSystemPromptMutationOptions(options);
+
+      return useMutation(mutationOptions, queryClient);
+    }
+    
+/**
+ * Retrieve all chapters with nested lessons, ordered by position. Only accessible to super admins.
+ * @summary Get all academy chapters with their lessons
+ */
+export const superAdminAcademyChaptersControllerGetChapters = (
+    
+ signal?: AbortSignal
+) => {
+      
+      
+      return customAxiosInstance<AcademyChapterResponseDto[]>(
+      {url: `/super-admin/academy/chapters`, method: 'GET', signal
+    },
+      );
+    }
+  
+
+
+
+export const getSuperAdminAcademyChaptersControllerGetChaptersQueryKey = () => {
+    return [
+    `/super-admin/academy/chapters`
+    ] as const;
+    }
+
+    
+export const getSuperAdminAcademyChaptersControllerGetChaptersQueryOptions = <TData = Awaited<ReturnType<typeof superAdminAcademyChaptersControllerGetChapters>>, TError = void>( options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof superAdminAcademyChaptersControllerGetChapters>>, TError, TData>>, }
+) => {
+
+const {query: queryOptions} = options ?? {};
+
+  const queryKey =  queryOptions?.queryKey ?? getSuperAdminAcademyChaptersControllerGetChaptersQueryKey();
+
+  
+
+    const queryFn: QueryFunction<Awaited<ReturnType<typeof superAdminAcademyChaptersControllerGetChapters>>> = ({ signal }) => superAdminAcademyChaptersControllerGetChapters(signal);
+
+      
+
+      
+
+   return  { queryKey, queryFn, ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof superAdminAcademyChaptersControllerGetChapters>>, TError, TData> & { queryKey: DataTag<QueryKey, TData, TError> }
+}
+
+export type SuperAdminAcademyChaptersControllerGetChaptersQueryResult = NonNullable<Awaited<ReturnType<typeof superAdminAcademyChaptersControllerGetChapters>>>
+export type SuperAdminAcademyChaptersControllerGetChaptersQueryError = void
+
+
+export function useSuperAdminAcademyChaptersControllerGetChapters<TData = Awaited<ReturnType<typeof superAdminAcademyChaptersControllerGetChapters>>, TError = void>(
+  options: { query:Partial<UseQueryOptions<Awaited<ReturnType<typeof superAdminAcademyChaptersControllerGetChapters>>, TError, TData>> & Pick<
+        DefinedInitialDataOptions<
+          Awaited<ReturnType<typeof superAdminAcademyChaptersControllerGetChapters>>,
+          TError,
+          Awaited<ReturnType<typeof superAdminAcademyChaptersControllerGetChapters>>
+        > , 'initialData'
+      >, }
+ , queryClient?: QueryClient
+  ):  DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useSuperAdminAcademyChaptersControllerGetChapters<TData = Awaited<ReturnType<typeof superAdminAcademyChaptersControllerGetChapters>>, TError = void>(
+  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof superAdminAcademyChaptersControllerGetChapters>>, TError, TData>> & Pick<
+        UndefinedInitialDataOptions<
+          Awaited<ReturnType<typeof superAdminAcademyChaptersControllerGetChapters>>,
+          TError,
+          Awaited<ReturnType<typeof superAdminAcademyChaptersControllerGetChapters>>
+        > , 'initialData'
+      >, }
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useSuperAdminAcademyChaptersControllerGetChapters<TData = Awaited<ReturnType<typeof superAdminAcademyChaptersControllerGetChapters>>, TError = void>(
+  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof superAdminAcademyChaptersControllerGetChapters>>, TError, TData>>, }
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+/**
+ * @summary Get all academy chapters with their lessons
+ */
+
+export function useSuperAdminAcademyChaptersControllerGetChapters<TData = Awaited<ReturnType<typeof superAdminAcademyChaptersControllerGetChapters>>, TError = void>(
+  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof superAdminAcademyChaptersControllerGetChapters>>, TError, TData>>, }
+ , queryClient?: QueryClient 
+ ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
+
+  const queryOptions = getSuperAdminAcademyChaptersControllerGetChaptersQueryOptions(options)
+
+  const query = useQuery(queryOptions, queryClient) as  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+
+  query.queryKey = queryOptions.queryKey ;
+
+  return query;
+}
+
+
+
+
+
+/**
+ * Create a new chapter appended after the last position. Only accessible to super admins.
+ * @summary Create a new academy chapter
+ */
+export const superAdminAcademyChaptersControllerCreateChapter = (
+    createChapterRequestDto: CreateChapterRequestDto,
+ signal?: AbortSignal
+) => {
+      
+      
+      return customAxiosInstance<AcademyChapterResponseDto>(
+      {url: `/super-admin/academy/chapters`, method: 'POST',
+      headers: {'Content-Type': 'application/json', },
+      data: createChapterRequestDto, signal
+    },
+      );
+    }
+  
+
+
+export const getSuperAdminAcademyChaptersControllerCreateChapterMutationOptions = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof superAdminAcademyChaptersControllerCreateChapter>>, TError,{data: CreateChapterRequestDto}, TContext>, }
+): UseMutationOptions<Awaited<ReturnType<typeof superAdminAcademyChaptersControllerCreateChapter>>, TError,{data: CreateChapterRequestDto}, TContext> => {
+
+const mutationKey = ['superAdminAcademyChaptersControllerCreateChapter'];
+const {mutation: mutationOptions} = options ?
+      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
+      options
+      : {...options, mutation: {...options.mutation, mutationKey}}
+      : {mutation: { mutationKey, }};
+
+      
+
+
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof superAdminAcademyChaptersControllerCreateChapter>>, {data: CreateChapterRequestDto}> = (props) => {
+          const {data} = props ?? {};
+
+          return  superAdminAcademyChaptersControllerCreateChapter(data,)
+        }
+
+        
+
+
+  return  { mutationFn, ...mutationOptions }}
+
+    export type SuperAdminAcademyChaptersControllerCreateChapterMutationResult = NonNullable<Awaited<ReturnType<typeof superAdminAcademyChaptersControllerCreateChapter>>>
+    export type SuperAdminAcademyChaptersControllerCreateChapterMutationBody = CreateChapterRequestDto
+    export type SuperAdminAcademyChaptersControllerCreateChapterMutationError = void
+
+    /**
+ * @summary Create a new academy chapter
+ */
+export const useSuperAdminAcademyChaptersControllerCreateChapter = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof superAdminAcademyChaptersControllerCreateChapter>>, TError,{data: CreateChapterRequestDto}, TContext>, }
+ , queryClient?: QueryClient): UseMutationResult<
+        Awaited<ReturnType<typeof superAdminAcademyChaptersControllerCreateChapter>>,
+        TError,
+        {data: CreateChapterRequestDto},
+        TContext
+      > => {
+
+      const mutationOptions = getSuperAdminAcademyChaptersControllerCreateChapterMutationOptions(options);
+
+      return useMutation(mutationOptions, queryClient);
+    }
+    
+/**
+ * Persist a new chapter order. The submitted ids must be exactly the ids of all existing chapters. Only accessible to super admins.
+ * @summary Reorder academy chapters
+ */
+export const superAdminAcademyChaptersControllerReorderChapters = (
+    reorderChaptersRequestDto: ReorderChaptersRequestDto,
+ ) => {
+      
+      
+      return customAxiosInstance<void>(
+      {url: `/super-admin/academy/chapters/order`, method: 'PUT',
+      headers: {'Content-Type': 'application/json', },
+      data: reorderChaptersRequestDto
+    },
+      );
+    }
+  
+
+
+export const getSuperAdminAcademyChaptersControllerReorderChaptersMutationOptions = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof superAdminAcademyChaptersControllerReorderChapters>>, TError,{data: ReorderChaptersRequestDto}, TContext>, }
+): UseMutationOptions<Awaited<ReturnType<typeof superAdminAcademyChaptersControllerReorderChapters>>, TError,{data: ReorderChaptersRequestDto}, TContext> => {
+
+const mutationKey = ['superAdminAcademyChaptersControllerReorderChapters'];
+const {mutation: mutationOptions} = options ?
+      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
+      options
+      : {...options, mutation: {...options.mutation, mutationKey}}
+      : {mutation: { mutationKey, }};
+
+      
+
+
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof superAdminAcademyChaptersControllerReorderChapters>>, {data: ReorderChaptersRequestDto}> = (props) => {
+          const {data} = props ?? {};
+
+          return  superAdminAcademyChaptersControllerReorderChapters(data,)
+        }
+
+        
+
+
+  return  { mutationFn, ...mutationOptions }}
+
+    export type SuperAdminAcademyChaptersControllerReorderChaptersMutationResult = NonNullable<Awaited<ReturnType<typeof superAdminAcademyChaptersControllerReorderChapters>>>
+    export type SuperAdminAcademyChaptersControllerReorderChaptersMutationBody = ReorderChaptersRequestDto
+    export type SuperAdminAcademyChaptersControllerReorderChaptersMutationError = void
+
+    /**
+ * @summary Reorder academy chapters
+ */
+export const useSuperAdminAcademyChaptersControllerReorderChapters = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof superAdminAcademyChaptersControllerReorderChapters>>, TError,{data: ReorderChaptersRequestDto}, TContext>, }
+ , queryClient?: QueryClient): UseMutationResult<
+        Awaited<ReturnType<typeof superAdminAcademyChaptersControllerReorderChapters>>,
+        TError,
+        {data: ReorderChaptersRequestDto},
+        TContext
+      > => {
+
+      const mutationOptions = getSuperAdminAcademyChaptersControllerReorderChaptersMutationOptions(options);
+
+      return useMutation(mutationOptions, queryClient);
+    }
+    
+/**
+ * Replace title and description of a chapter. Only accessible to super admins.
+ * @summary Update an academy chapter
+ */
+export const superAdminAcademyChaptersControllerUpdateChapter = (
+    id: string,
+    updateChapterRequestDto: UpdateChapterRequestDto,
+ ) => {
+      
+      
+      return customAxiosInstance<AcademyChapterResponseDto>(
+      {url: `/super-admin/academy/chapters/${id}`, method: 'PUT',
+      headers: {'Content-Type': 'application/json', },
+      data: updateChapterRequestDto
+    },
+      );
+    }
+  
+
+
+export const getSuperAdminAcademyChaptersControllerUpdateChapterMutationOptions = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof superAdminAcademyChaptersControllerUpdateChapter>>, TError,{id: string;data: UpdateChapterRequestDto}, TContext>, }
+): UseMutationOptions<Awaited<ReturnType<typeof superAdminAcademyChaptersControllerUpdateChapter>>, TError,{id: string;data: UpdateChapterRequestDto}, TContext> => {
+
+const mutationKey = ['superAdminAcademyChaptersControllerUpdateChapter'];
+const {mutation: mutationOptions} = options ?
+      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
+      options
+      : {...options, mutation: {...options.mutation, mutationKey}}
+      : {mutation: { mutationKey, }};
+
+      
+
+
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof superAdminAcademyChaptersControllerUpdateChapter>>, {id: string;data: UpdateChapterRequestDto}> = (props) => {
+          const {id,data} = props ?? {};
+
+          return  superAdminAcademyChaptersControllerUpdateChapter(id,data,)
+        }
+
+        
+
+
+  return  { mutationFn, ...mutationOptions }}
+
+    export type SuperAdminAcademyChaptersControllerUpdateChapterMutationResult = NonNullable<Awaited<ReturnType<typeof superAdminAcademyChaptersControllerUpdateChapter>>>
+    export type SuperAdminAcademyChaptersControllerUpdateChapterMutationBody = UpdateChapterRequestDto
+    export type SuperAdminAcademyChaptersControllerUpdateChapterMutationError = void
+
+    /**
+ * @summary Update an academy chapter
+ */
+export const useSuperAdminAcademyChaptersControllerUpdateChapter = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof superAdminAcademyChaptersControllerUpdateChapter>>, TError,{id: string;data: UpdateChapterRequestDto}, TContext>, }
+ , queryClient?: QueryClient): UseMutationResult<
+        Awaited<ReturnType<typeof superAdminAcademyChaptersControllerUpdateChapter>>,
+        TError,
+        {id: string;data: UpdateChapterRequestDto},
+        TContext
+      > => {
+
+      const mutationOptions = getSuperAdminAcademyChaptersControllerUpdateChapterMutationOptions(options);
+
+      return useMutation(mutationOptions, queryClient);
+    }
+    
+/**
+ * Delete a chapter and all of its lessons. Only accessible to super admins.
+ * @summary Delete an academy chapter
+ */
+export const superAdminAcademyChaptersControllerDeleteChapter = (
+    id: string,
+ ) => {
+      
+      
+      return customAxiosInstance<void>(
+      {url: `/super-admin/academy/chapters/${id}`, method: 'DELETE'
+    },
+      );
+    }
+  
+
+
+export const getSuperAdminAcademyChaptersControllerDeleteChapterMutationOptions = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof superAdminAcademyChaptersControllerDeleteChapter>>, TError,{id: string}, TContext>, }
+): UseMutationOptions<Awaited<ReturnType<typeof superAdminAcademyChaptersControllerDeleteChapter>>, TError,{id: string}, TContext> => {
+
+const mutationKey = ['superAdminAcademyChaptersControllerDeleteChapter'];
+const {mutation: mutationOptions} = options ?
+      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
+      options
+      : {...options, mutation: {...options.mutation, mutationKey}}
+      : {mutation: { mutationKey, }};
+
+      
+
+
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof superAdminAcademyChaptersControllerDeleteChapter>>, {id: string}> = (props) => {
+          const {id} = props ?? {};
+
+          return  superAdminAcademyChaptersControllerDeleteChapter(id,)
+        }
+
+        
+
+
+  return  { mutationFn, ...mutationOptions }}
+
+    export type SuperAdminAcademyChaptersControllerDeleteChapterMutationResult = NonNullable<Awaited<ReturnType<typeof superAdminAcademyChaptersControllerDeleteChapter>>>
+    
+    export type SuperAdminAcademyChaptersControllerDeleteChapterMutationError = void
+
+    /**
+ * @summary Delete an academy chapter
+ */
+export const useSuperAdminAcademyChaptersControllerDeleteChapter = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof superAdminAcademyChaptersControllerDeleteChapter>>, TError,{id: string}, TContext>, }
+ , queryClient?: QueryClient): UseMutationResult<
+        Awaited<ReturnType<typeof superAdminAcademyChaptersControllerDeleteChapter>>,
+        TError,
+        {id: string},
+        TContext
+      > => {
+
+      const mutationOptions = getSuperAdminAcademyChaptersControllerDeleteChapterMutationOptions(options);
+
+      return useMutation(mutationOptions, queryClient);
+    }
+    
+/**
+ * Create a lesson in a chapter, appended after the last position. Only accessible to super admins.
+ * @summary Create a new academy lesson
+ */
+export const superAdminAcademyLessonsControllerCreateLesson = (
+    chapterId: string,
+    createLessonRequestDto: CreateLessonRequestDto,
+ signal?: AbortSignal
+) => {
+      
+      
+      return customAxiosInstance<AcademyLessonResponseDto>(
+      {url: `/super-admin/academy/chapters/${chapterId}/lessons`, method: 'POST',
+      headers: {'Content-Type': 'application/json', },
+      data: createLessonRequestDto, signal
+    },
+      );
+    }
+  
+
+
+export const getSuperAdminAcademyLessonsControllerCreateLessonMutationOptions = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof superAdminAcademyLessonsControllerCreateLesson>>, TError,{chapterId: string;data: CreateLessonRequestDto}, TContext>, }
+): UseMutationOptions<Awaited<ReturnType<typeof superAdminAcademyLessonsControllerCreateLesson>>, TError,{chapterId: string;data: CreateLessonRequestDto}, TContext> => {
+
+const mutationKey = ['superAdminAcademyLessonsControllerCreateLesson'];
+const {mutation: mutationOptions} = options ?
+      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
+      options
+      : {...options, mutation: {...options.mutation, mutationKey}}
+      : {mutation: { mutationKey, }};
+
+      
+
+
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof superAdminAcademyLessonsControllerCreateLesson>>, {chapterId: string;data: CreateLessonRequestDto}> = (props) => {
+          const {chapterId,data} = props ?? {};
+
+          return  superAdminAcademyLessonsControllerCreateLesson(chapterId,data,)
+        }
+
+        
+
+
+  return  { mutationFn, ...mutationOptions }}
+
+    export type SuperAdminAcademyLessonsControllerCreateLessonMutationResult = NonNullable<Awaited<ReturnType<typeof superAdminAcademyLessonsControllerCreateLesson>>>
+    export type SuperAdminAcademyLessonsControllerCreateLessonMutationBody = CreateLessonRequestDto
+    export type SuperAdminAcademyLessonsControllerCreateLessonMutationError = void
+
+    /**
+ * @summary Create a new academy lesson
+ */
+export const useSuperAdminAcademyLessonsControllerCreateLesson = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof superAdminAcademyLessonsControllerCreateLesson>>, TError,{chapterId: string;data: CreateLessonRequestDto}, TContext>, }
+ , queryClient?: QueryClient): UseMutationResult<
+        Awaited<ReturnType<typeof superAdminAcademyLessonsControllerCreateLesson>>,
+        TError,
+        {chapterId: string;data: CreateLessonRequestDto},
+        TContext
+      > => {
+
+      const mutationOptions = getSuperAdminAcademyLessonsControllerCreateLessonMutationOptions(options);
+
+      return useMutation(mutationOptions, queryClient);
+    }
+    
+/**
+ * Persist a new lesson order within a chapter. The submitted ids must be exactly the ids of all lessons in the chapter. Only accessible to super admins.
+ * @summary Reorder the lessons of a chapter
+ */
+export const superAdminAcademyLessonsControllerReorderLessons = (
+    chapterId: string,
+    reorderLessonsRequestDto: ReorderLessonsRequestDto,
+ ) => {
+      
+      
+      return customAxiosInstance<void>(
+      {url: `/super-admin/academy/chapters/${chapterId}/lessons/order`, method: 'PUT',
+      headers: {'Content-Type': 'application/json', },
+      data: reorderLessonsRequestDto
+    },
+      );
+    }
+  
+
+
+export const getSuperAdminAcademyLessonsControllerReorderLessonsMutationOptions = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof superAdminAcademyLessonsControllerReorderLessons>>, TError,{chapterId: string;data: ReorderLessonsRequestDto}, TContext>, }
+): UseMutationOptions<Awaited<ReturnType<typeof superAdminAcademyLessonsControllerReorderLessons>>, TError,{chapterId: string;data: ReorderLessonsRequestDto}, TContext> => {
+
+const mutationKey = ['superAdminAcademyLessonsControllerReorderLessons'];
+const {mutation: mutationOptions} = options ?
+      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
+      options
+      : {...options, mutation: {...options.mutation, mutationKey}}
+      : {mutation: { mutationKey, }};
+
+      
+
+
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof superAdminAcademyLessonsControllerReorderLessons>>, {chapterId: string;data: ReorderLessonsRequestDto}> = (props) => {
+          const {chapterId,data} = props ?? {};
+
+          return  superAdminAcademyLessonsControllerReorderLessons(chapterId,data,)
+        }
+
+        
+
+
+  return  { mutationFn, ...mutationOptions }}
+
+    export type SuperAdminAcademyLessonsControllerReorderLessonsMutationResult = NonNullable<Awaited<ReturnType<typeof superAdminAcademyLessonsControllerReorderLessons>>>
+    export type SuperAdminAcademyLessonsControllerReorderLessonsMutationBody = ReorderLessonsRequestDto
+    export type SuperAdminAcademyLessonsControllerReorderLessonsMutationError = void
+
+    /**
+ * @summary Reorder the lessons of a chapter
+ */
+export const useSuperAdminAcademyLessonsControllerReorderLessons = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof superAdminAcademyLessonsControllerReorderLessons>>, TError,{chapterId: string;data: ReorderLessonsRequestDto}, TContext>, }
+ , queryClient?: QueryClient): UseMutationResult<
+        Awaited<ReturnType<typeof superAdminAcademyLessonsControllerReorderLessons>>,
+        TError,
+        {chapterId: string;data: ReorderLessonsRequestDto},
+        TContext
+      > => {
+
+      const mutationOptions = getSuperAdminAcademyLessonsControllerReorderLessonsMutationOptions(options);
+
+      return useMutation(mutationOptions, queryClient);
+    }
+    
+/**
+ * Replace title, description, and Loom link of a lesson. Only accessible to super admins.
+ * @summary Update an academy lesson
+ */
+export const superAdminAcademyLessonsControllerUpdateLesson = (
+    id: string,
+    updateLessonRequestDto: UpdateLessonRequestDto,
+ ) => {
+      
+      
+      return customAxiosInstance<AcademyLessonResponseDto>(
+      {url: `/super-admin/academy/lessons/${id}`, method: 'PUT',
+      headers: {'Content-Type': 'application/json', },
+      data: updateLessonRequestDto
+    },
+      );
+    }
+  
+
+
+export const getSuperAdminAcademyLessonsControllerUpdateLessonMutationOptions = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof superAdminAcademyLessonsControllerUpdateLesson>>, TError,{id: string;data: UpdateLessonRequestDto}, TContext>, }
+): UseMutationOptions<Awaited<ReturnType<typeof superAdminAcademyLessonsControllerUpdateLesson>>, TError,{id: string;data: UpdateLessonRequestDto}, TContext> => {
+
+const mutationKey = ['superAdminAcademyLessonsControllerUpdateLesson'];
+const {mutation: mutationOptions} = options ?
+      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
+      options
+      : {...options, mutation: {...options.mutation, mutationKey}}
+      : {mutation: { mutationKey, }};
+
+      
+
+
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof superAdminAcademyLessonsControllerUpdateLesson>>, {id: string;data: UpdateLessonRequestDto}> = (props) => {
+          const {id,data} = props ?? {};
+
+          return  superAdminAcademyLessonsControllerUpdateLesson(id,data,)
+        }
+
+        
+
+
+  return  { mutationFn, ...mutationOptions }}
+
+    export type SuperAdminAcademyLessonsControllerUpdateLessonMutationResult = NonNullable<Awaited<ReturnType<typeof superAdminAcademyLessonsControllerUpdateLesson>>>
+    export type SuperAdminAcademyLessonsControllerUpdateLessonMutationBody = UpdateLessonRequestDto
+    export type SuperAdminAcademyLessonsControllerUpdateLessonMutationError = void
+
+    /**
+ * @summary Update an academy lesson
+ */
+export const useSuperAdminAcademyLessonsControllerUpdateLesson = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof superAdminAcademyLessonsControllerUpdateLesson>>, TError,{id: string;data: UpdateLessonRequestDto}, TContext>, }
+ , queryClient?: QueryClient): UseMutationResult<
+        Awaited<ReturnType<typeof superAdminAcademyLessonsControllerUpdateLesson>>,
+        TError,
+        {id: string;data: UpdateLessonRequestDto},
+        TContext
+      > => {
+
+      const mutationOptions = getSuperAdminAcademyLessonsControllerUpdateLessonMutationOptions(options);
+
+      return useMutation(mutationOptions, queryClient);
+    }
+    
+/**
+ * Delete a lesson. Only accessible to super admins.
+ * @summary Delete an academy lesson
+ */
+export const superAdminAcademyLessonsControllerDeleteLesson = (
+    id: string,
+ ) => {
+      
+      
+      return customAxiosInstance<void>(
+      {url: `/super-admin/academy/lessons/${id}`, method: 'DELETE'
+    },
+      );
+    }
+  
+
+
+export const getSuperAdminAcademyLessonsControllerDeleteLessonMutationOptions = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof superAdminAcademyLessonsControllerDeleteLesson>>, TError,{id: string}, TContext>, }
+): UseMutationOptions<Awaited<ReturnType<typeof superAdminAcademyLessonsControllerDeleteLesson>>, TError,{id: string}, TContext> => {
+
+const mutationKey = ['superAdminAcademyLessonsControllerDeleteLesson'];
+const {mutation: mutationOptions} = options ?
+      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
+      options
+      : {...options, mutation: {...options.mutation, mutationKey}}
+      : {mutation: { mutationKey, }};
+
+      
+
+
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof superAdminAcademyLessonsControllerDeleteLesson>>, {id: string}> = (props) => {
+          const {id} = props ?? {};
+
+          return  superAdminAcademyLessonsControllerDeleteLesson(id,)
+        }
+
+        
+
+
+  return  { mutationFn, ...mutationOptions }}
+
+    export type SuperAdminAcademyLessonsControllerDeleteLessonMutationResult = NonNullable<Awaited<ReturnType<typeof superAdminAcademyLessonsControllerDeleteLesson>>>
+    
+    export type SuperAdminAcademyLessonsControllerDeleteLessonMutationError = void
+
+    /**
+ * @summary Delete an academy lesson
+ */
+export const useSuperAdminAcademyLessonsControllerDeleteLesson = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof superAdminAcademyLessonsControllerDeleteLesson>>, TError,{id: string}, TContext>, }
+ , queryClient?: QueryClient): UseMutationResult<
+        Awaited<ReturnType<typeof superAdminAcademyLessonsControllerDeleteLesson>>,
+        TError,
+        {id: string},
+        TContext
+      > => {
+
+      const mutationOptions = getSuperAdminAcademyLessonsControllerDeleteLessonMutationOptions(options);
 
       return useMutation(mutationOptions, queryClient);
     }

--- a/ayunis-core-frontend/src/shared/api/openapi-schema.json
+++ b/ayunis-core-frontend/src/shared/api/openapi-schema.json
@@ -8008,6 +8008,368 @@
         "tags": ["Chat Settings"]
       }
     },
+    "/super-admin/academy/chapters": {
+      "get": {
+        "description": "Retrieve all chapters with nested lessons, ordered by position. Only accessible to super admins.",
+        "operationId": "SuperAdminAcademyChaptersController_getChapters",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved academy chapters",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/AcademyChapterResponseDto"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "User not authenticated or not authorized as super admin"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "summary": "Get all academy chapters with their lessons",
+        "tags": ["Super Admin Academy"]
+      },
+      "post": {
+        "description": "Create a new chapter appended after the last position. Only accessible to super admins.",
+        "operationId": "SuperAdminAcademyChaptersController_createChapter",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateChapterRequestDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Successfully created chapter",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AcademyChapterResponseDto"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "User not authenticated or not authorized as super admin"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "summary": "Create a new academy chapter",
+        "tags": ["Super Admin Academy"]
+      }
+    },
+    "/super-admin/academy/chapters/order": {
+      "put": {
+        "description": "Persist a new chapter order. The submitted ids must be exactly the ids of all existing chapters. Only accessible to super admins.",
+        "operationId": "SuperAdminAcademyChaptersController_reorderChapters",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ReorderChaptersRequestDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "description": "Successfully reordered chapters"
+          },
+          "400": {
+            "description": "Submitted ids do not match the current set of chapters"
+          },
+          "401": {
+            "description": "User not authenticated or not authorized as super admin"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "summary": "Reorder academy chapters",
+        "tags": ["Super Admin Academy"]
+      }
+    },
+    "/super-admin/academy/chapters/{id}": {
+      "put": {
+        "description": "Replace title and description of a chapter. Only accessible to super admins.",
+        "operationId": "SuperAdminAcademyChaptersController_updateChapter",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "description": "Chapter ID",
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateChapterRequestDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successfully updated chapter",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AcademyChapterResponseDto"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "User not authenticated or not authorized as super admin"
+          },
+          "404": {
+            "description": "Chapter not found"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "summary": "Update an academy chapter",
+        "tags": ["Super Admin Academy"]
+      },
+      "delete": {
+        "description": "Delete a chapter and all of its lessons. Only accessible to super admins.",
+        "operationId": "SuperAdminAcademyChaptersController_deleteChapter",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "description": "Chapter ID",
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successfully deleted chapter"
+          },
+          "401": {
+            "description": "User not authenticated or not authorized as super admin"
+          },
+          "404": {
+            "description": "Chapter not found"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "summary": "Delete an academy chapter",
+        "tags": ["Super Admin Academy"]
+      }
+    },
+    "/super-admin/academy/chapters/{chapterId}/lessons": {
+      "post": {
+        "description": "Create a lesson in a chapter, appended after the last position. Only accessible to super admins.",
+        "operationId": "SuperAdminAcademyLessonsController_createLesson",
+        "parameters": [
+          {
+            "name": "chapterId",
+            "required": true,
+            "in": "path",
+            "description": "Chapter ID",
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateLessonRequestDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Successfully created lesson",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AcademyLessonResponseDto"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "User not authenticated or not authorized as super admin"
+          },
+          "404": {
+            "description": "Chapter not found"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "summary": "Create a new academy lesson",
+        "tags": ["Super Admin Academy"]
+      }
+    },
+    "/super-admin/academy/chapters/{chapterId}/lessons/order": {
+      "put": {
+        "description": "Persist a new lesson order within a chapter. The submitted ids must be exactly the ids of all lessons in the chapter. Only accessible to super admins.",
+        "operationId": "SuperAdminAcademyLessonsController_reorderLessons",
+        "parameters": [
+          {
+            "name": "chapterId",
+            "required": true,
+            "in": "path",
+            "description": "Chapter ID",
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ReorderLessonsRequestDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "description": "Successfully reordered lessons"
+          },
+          "400": {
+            "description": "Submitted ids do not match the current lessons of the chapter"
+          },
+          "401": {
+            "description": "User not authenticated or not authorized as super admin"
+          },
+          "404": {
+            "description": "Chapter not found"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "summary": "Reorder the lessons of a chapter",
+        "tags": ["Super Admin Academy"]
+      }
+    },
+    "/super-admin/academy/lessons/{id}": {
+      "put": {
+        "description": "Replace title, description, and Loom link of a lesson. Only accessible to super admins.",
+        "operationId": "SuperAdminAcademyLessonsController_updateLesson",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "description": "Lesson ID",
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateLessonRequestDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successfully updated lesson",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AcademyLessonResponseDto"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "User not authenticated or not authorized as super admin"
+          },
+          "404": {
+            "description": "Lesson not found"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "summary": "Update an academy lesson",
+        "tags": ["Super Admin Academy"]
+      },
+      "delete": {
+        "description": "Delete a lesson. Only accessible to super admins.",
+        "operationId": "SuperAdminAcademyLessonsController_deleteLesson",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "description": "Lesson ID",
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successfully deleted lesson"
+          },
+          "401": {
+            "description": "User not authenticated or not authorized as super admin"
+          },
+          "404": {
+            "description": "Lesson not found"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "summary": "Delete an academy lesson",
+        "tags": ["Super Admin Academy"]
+      }
+    },
     "/openai-compat/v1/chat/completions": {
       "post": {
         "operationId": "ChatCompletionsController_create",
@@ -14512,6 +14874,225 @@
           }
         },
         "required": ["systemPrompt"]
+      },
+      "AcademyLessonResponseDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "The unique identifier of the lesson"
+          },
+          "chapterId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "The id of the chapter the lesson belongs to"
+          },
+          "title": {
+            "type": "string",
+            "description": "The title of the lesson",
+            "example": "Creating your first chat"
+          },
+          "description": {
+            "type": "string",
+            "nullable": true,
+            "description": "An optional description of the lesson",
+            "example": "A short walkthrough of the chat interface."
+          },
+          "loomUrl": {
+            "type": "string",
+            "description": "The Loom share or embed link of the lesson video",
+            "example": "https://www.loom.com/share/abc123def456"
+          },
+          "position": {
+            "type": "integer",
+            "description": "The position of the lesson within its chapter (0-based)",
+            "example": 0
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "The date the lesson was created"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "The date the lesson was last updated"
+          }
+        },
+        "required": [
+          "id",
+          "chapterId",
+          "title",
+          "description",
+          "loomUrl",
+          "position",
+          "createdAt",
+          "updatedAt"
+        ]
+      },
+      "AcademyChapterResponseDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "The unique identifier of the chapter"
+          },
+          "title": {
+            "type": "string",
+            "description": "The title of the chapter",
+            "example": "Getting Started"
+          },
+          "description": {
+            "type": "string",
+            "description": "A description of what the chapter covers",
+            "example": "Learn the basics of working with Ayunis Core."
+          },
+          "position": {
+            "type": "integer",
+            "description": "The position of the chapter (0-based)",
+            "example": 0
+          },
+          "lessons": {
+            "description": "The lessons of the chapter, ordered by position",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AcademyLessonResponseDto"
+            }
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "The date the chapter was created"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "The date the chapter was last updated"
+          }
+        },
+        "required": [
+          "id",
+          "title",
+          "description",
+          "position",
+          "lessons",
+          "createdAt",
+          "updatedAt"
+        ]
+      },
+      "CreateChapterRequestDto": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string",
+            "description": "The title of the chapter",
+            "example": "Getting Started",
+            "maxLength": 255
+          },
+          "description": {
+            "type": "string",
+            "description": "A description of what the chapter covers",
+            "example": "Learn the basics of working with Ayunis Core.",
+            "maxLength": 2000
+          }
+        },
+        "required": ["title", "description"]
+      },
+      "ReorderChaptersRequestDto": {
+        "type": "object",
+        "properties": {
+          "chapterIds": {
+            "type": "array",
+            "description": "All chapter ids in their new order. Must contain exactly the ids of all existing chapters.",
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        },
+        "required": ["chapterIds"]
+      },
+      "UpdateChapterRequestDto": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string",
+            "description": "The title of the chapter",
+            "example": "Getting Started",
+            "maxLength": 255
+          },
+          "description": {
+            "type": "string",
+            "description": "A description of what the chapter covers",
+            "example": "Learn the basics of working with Ayunis Core.",
+            "maxLength": 2000
+          }
+        },
+        "required": ["title", "description"]
+      },
+      "CreateLessonRequestDto": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string",
+            "description": "The title of the lesson",
+            "example": "Creating your first chat",
+            "maxLength": 255
+          },
+          "description": {
+            "type": "string",
+            "description": "An optional description of the lesson",
+            "example": "A short walkthrough of the chat interface.",
+            "maxLength": 2000
+          },
+          "loomUrl": {
+            "type": "string",
+            "description": "The Loom share or embed link of the lesson video",
+            "example": "https://www.loom.com/share/abc123def456",
+            "maxLength": 500
+          }
+        },
+        "required": ["title", "loomUrl"]
+      },
+      "ReorderLessonsRequestDto": {
+        "type": "object",
+        "properties": {
+          "lessonIds": {
+            "type": "array",
+            "description": "All lesson ids of the chapter in their new order. Must contain exactly the ids of all lessons in the chapter.",
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        },
+        "required": ["lessonIds"]
+      },
+      "UpdateLessonRequestDto": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string",
+            "description": "The title of the lesson",
+            "example": "Creating your first chat",
+            "maxLength": 255
+          },
+          "description": {
+            "type": "string",
+            "description": "An optional description of the lesson",
+            "example": "A short walkthrough of the chat interface.",
+            "maxLength": 2000
+          },
+          "loomUrl": {
+            "type": "string",
+            "description": "The Loom share or embed link of the lesson video",
+            "example": "https://www.loom.com/share/abc123def456",
+            "maxLength": 500
+          }
+        },
+        "required": ["title", "loomUrl"]
       },
       "ChatCompletionRequestDto": {
         "type": "object",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Auto-generated API bindings only; super-admin authorization remains on the backend and nothing in this diff changes runtime app behavior until feature code consumes the new hooks.
> 
> **Overview**
> Regenerates the frontend API layer from an updated OpenAPI spec so **super-admin Academy** (chapters and Loom-backed lessons) is callable from the app.
> 
> **OpenAPI** adds routes under `/super-admin/academy/` for listing nested chapters/lessons, CRUD on chapters and lessons, and full reorder payloads (`chapterIds` / `lessonIds`). **Generated types** cover chapter/lesson responses and create/update/reorder DTOs (including `loomUrl` on lessons).
> 
> **Orval output** adds axios functions and React Query hooks (e.g. `useSuperAdminAcademyChaptersControllerGetChapters`, chapter/lesson mutations). This PR is client/schema sync only; no new UI in the diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23408b090e5780ddc0bab84e3c5718e3a7c580e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->