### PR TITLE
wip(academy): add super-admin academy management page (AYC-243)

### DIFF
--- a/ayunis-core-frontend/package.json
+++ b/ayunis-core-frontend/package.json
@@ -22,6 +22,9 @@
   },
   "dependencies": {
     "@base-ui/react": "^1.2.0",
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@hookform/resolvers": "^5.0.1",
     "@radix-ui/react-accordion": "^1.2.11",
     "@radix-ui/react-alert-dialog": "^1.1.15",

--- a/ayunis-core-frontend/src/app/routeTree.gen.ts
+++ b/ayunis-core-frontend/src/app/routeTree.gen.ts
@@ -48,6 +48,7 @@ import { Route as AuthenticatedSuperAdminSettingsSkillsIndexRouteImport } from '
 import { Route as AuthenticatedSuperAdminSettingsPlatformConfigIndexRouteImport } from './routes/_authenticated/super-admin-settings.platform-config.index'
 import { Route as AuthenticatedSuperAdminSettingsOrgsIndexRouteImport } from './routes/_authenticated/super-admin-settings.orgs.index'
 import { Route as AuthenticatedSuperAdminSettingsModelsCatalogIndexRouteImport } from './routes/_authenticated/super-admin-settings.models-catalog.index'
+import { Route as AuthenticatedSuperAdminSettingsAcademyIndexRouteImport } from './routes/_authenticated/super-admin-settings.academy.index'
 import { Route as AuthenticatedAdminSettingsTeamsIndexRouteImport } from './routes/_authenticated/admin-settings.teams.index'
 import { Route as AuthenticatedAdminSettingsLetterheadsIndexRouteImport } from './routes/_authenticated/admin-settings.letterheads.index'
 import { Route as AuthenticatedSuperAdminSettingsOrgsIdRouteImport } from './routes/_authenticated/super-admin-settings.orgs.$id'
@@ -274,6 +275,12 @@ const AuthenticatedSuperAdminSettingsModelsCatalogIndexRoute =
     path: '/super-admin-settings/models-catalog/',
     getParentRoute: () => AuthenticatedRoute,
   } as any)
+const AuthenticatedSuperAdminSettingsAcademyIndexRoute =
+  AuthenticatedSuperAdminSettingsAcademyIndexRouteImport.update({
+    id: '/super-admin-settings/academy/',
+    path: '/super-admin-settings/academy/',
+    getParentRoute: () => AuthenticatedRoute,
+  } as any)
 const AuthenticatedAdminSettingsTeamsIndexRoute =
   AuthenticatedAdminSettingsTeamsIndexRouteImport.update({
     id: '/admin-settings/teams/',
@@ -344,6 +351,7 @@ export interface FileRoutesByFullPath {
   '/super-admin-settings/orgs/$id': typeof AuthenticatedSuperAdminSettingsOrgsIdRoute
   '/admin-settings/letterheads/': typeof AuthenticatedAdminSettingsLetterheadsIndexRoute
   '/admin-settings/teams/': typeof AuthenticatedAdminSettingsTeamsIndexRoute
+  '/super-admin-settings/academy/': typeof AuthenticatedSuperAdminSettingsAcademyIndexRoute
   '/super-admin-settings/models-catalog/': typeof AuthenticatedSuperAdminSettingsModelsCatalogIndexRoute
   '/super-admin-settings/orgs/': typeof AuthenticatedSuperAdminSettingsOrgsIndexRoute
   '/super-admin-settings/platform-config/': typeof AuthenticatedSuperAdminSettingsPlatformConfigIndexRoute
@@ -389,6 +397,7 @@ export interface FileRoutesByTo {
   '/super-admin-settings/orgs/$id': typeof AuthenticatedSuperAdminSettingsOrgsIdRoute
   '/admin-settings/letterheads': typeof AuthenticatedAdminSettingsLetterheadsIndexRoute
   '/admin-settings/teams': typeof AuthenticatedAdminSettingsTeamsIndexRoute
+  '/super-admin-settings/academy': typeof AuthenticatedSuperAdminSettingsAcademyIndexRoute
   '/super-admin-settings/models-catalog': typeof AuthenticatedSuperAdminSettingsModelsCatalogIndexRoute
   '/super-admin-settings/orgs': typeof AuthenticatedSuperAdminSettingsOrgsIndexRoute
   '/super-admin-settings/platform-config': typeof AuthenticatedSuperAdminSettingsPlatformConfigIndexRoute
@@ -436,6 +445,7 @@ export interface FileRoutesById {
   '/_authenticated/super-admin-settings/orgs/$id': typeof AuthenticatedSuperAdminSettingsOrgsIdRoute
   '/_authenticated/admin-settings/letterheads/': typeof AuthenticatedAdminSettingsLetterheadsIndexRoute
   '/_authenticated/admin-settings/teams/': typeof AuthenticatedAdminSettingsTeamsIndexRoute
+  '/_authenticated/super-admin-settings/academy/': typeof AuthenticatedSuperAdminSettingsAcademyIndexRoute
   '/_authenticated/super-admin-settings/models-catalog/': typeof AuthenticatedSuperAdminSettingsModelsCatalogIndexRoute
   '/_authenticated/super-admin-settings/orgs/': typeof AuthenticatedSuperAdminSettingsOrgsIndexRoute
   '/_authenticated/super-admin-settings/platform-config/': typeof AuthenticatedSuperAdminSettingsPlatformConfigIndexRoute
@@ -483,6 +493,7 @@ export interface FileRouteTypes {
     | '/super-admin-settings/orgs/$id'
     | '/admin-settings/letterheads/'
     | '/admin-settings/teams/'
+    | '/super-admin-settings/academy/'
     | '/super-admin-settings/models-catalog/'
     | '/super-admin-settings/orgs/'
     | '/super-admin-settings/platform-config/'
@@ -528,6 +539,7 @@ export interface FileRouteTypes {
     | '/super-admin-settings/orgs/$id'
     | '/admin-settings/letterheads'
     | '/admin-settings/teams'
+    | '/super-admin-settings/academy'
     | '/super-admin-settings/models-catalog'
     | '/super-admin-settings/orgs'
     | '/super-admin-settings/platform-config'
@@ -574,6 +586,7 @@ export interface FileRouteTypes {
     | '/_authenticated/super-admin-settings/orgs/$id'
     | '/_authenticated/admin-settings/letterheads/'
     | '/_authenticated/admin-settings/teams/'
+    | '/_authenticated/super-admin-settings/academy/'
     | '/_authenticated/super-admin-settings/models-catalog/'
     | '/_authenticated/super-admin-settings/orgs/'
     | '/_authenticated/super-admin-settings/platform-config/'
@@ -870,6 +883,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedSuperAdminSettingsModelsCatalogIndexRouteImport
       parentRoute: typeof AuthenticatedRoute
     }
+    '/_authenticated/super-admin-settings/academy/': {
+      id: '/_authenticated/super-admin-settings/academy/'
+      path: '/super-admin-settings/academy'
+      fullPath: '/super-admin-settings/academy/'
+      preLoaderRoute: typeof AuthenticatedSuperAdminSettingsAcademyIndexRouteImport
+      parentRoute: typeof AuthenticatedRoute
+    }
     '/_authenticated/admin-settings/teams/': {
       id: '/_authenticated/admin-settings/teams/'
       path: '/admin-settings/teams'
@@ -937,6 +957,7 @@ interface AuthenticatedRouteChildren {
   AuthenticatedSuperAdminSettingsOrgsIdRoute: typeof AuthenticatedSuperAdminSettingsOrgsIdRoute
   AuthenticatedAdminSettingsLetterheadsIndexRoute: typeof AuthenticatedAdminSettingsLetterheadsIndexRoute
   AuthenticatedAdminSettingsTeamsIndexRoute: typeof AuthenticatedAdminSettingsTeamsIndexRoute
+  AuthenticatedSuperAdminSettingsAcademyIndexRoute: typeof AuthenticatedSuperAdminSettingsAcademyIndexRoute
   AuthenticatedSuperAdminSettingsModelsCatalogIndexRoute: typeof AuthenticatedSuperAdminSettingsModelsCatalogIndexRoute
   AuthenticatedSuperAdminSettingsOrgsIndexRoute: typeof AuthenticatedSuperAdminSettingsOrgsIndexRoute
   AuthenticatedSuperAdminSettingsPlatformConfigIndexRoute: typeof AuthenticatedSuperAdminSettingsPlatformConfigIndexRoute
@@ -985,6 +1006,8 @@ const AuthenticatedRouteChildren: AuthenticatedRouteChildren = {
     AuthenticatedAdminSettingsLetterheadsIndexRoute,
   AuthenticatedAdminSettingsTeamsIndexRoute:
     AuthenticatedAdminSettingsTeamsIndexRoute,
+  AuthenticatedSuperAdminSettingsAcademyIndexRoute:
+    AuthenticatedSuperAdminSettingsAcademyIndexRoute,
   AuthenticatedSuperAdminSettingsModelsCatalogIndexRoute:
     AuthenticatedSuperAdminSettingsModelsCatalogIndexRoute,
   AuthenticatedSuperAdminSettingsOrgsIndexRoute:

--- a/ayunis-core-frontend/src/app/routes/_authenticated/super-admin-settings.academy.index.tsx
+++ b/ayunis-core-frontend/src/app/routes/_authenticated/super-admin-settings.academy.index.tsx
@@ -1,0 +1,31 @@
+import { createFileRoute, redirect } from '@tanstack/react-router';
+import AcademyPage from '@/pages/super-admin-settings/academy';
+import { MeResponseDtoSystemRole } from '@/shared/api/generated/ayunisCoreAPI.schemas';
+import {
+  getSuperAdminAcademyChaptersControllerGetChaptersQueryKey,
+  superAdminAcademyChaptersControllerGetChapters,
+} from '@/shared/api';
+
+export const Route = createFileRoute(
+  '/_authenticated/super-admin-settings/academy/',
+)({
+  component: RouteComponent,
+  beforeLoad: ({ context: { user } }) => {
+    if (user.systemRole !== MeResponseDtoSystemRole.super_admin) {
+      throw redirect({ to: '/' });
+    }
+  },
+  loader: async ({ context: { queryClient } }) => {
+    return {
+      chapters: await queryClient.fetchQuery({
+        queryKey: getSuperAdminAcademyChaptersControllerGetChaptersQueryKey(),
+        queryFn: () => superAdminAcademyChaptersControllerGetChapters(),
+      }),
+    };
+  },
+});
+
+function RouteComponent() {
+  const { chapters } = Route.useLoaderData();
+  return <AcademyPage chapters={chapters} />;
+}

--- a/ayunis-core-frontend/src/i18n.ts
+++ b/ayunis-core-frontend/src/i18n.ts
@@ -44,6 +44,8 @@ import enSuperAdminSettingsSkills from './shared/locales/en/super-admin-settings
 import deSuperAdminSettingsSkills from './shared/locales/de/super-admin-settings-skills.json';
 import enSuperAdminSettingsSuperAdmins from './shared/locales/en/super-admin-settings-super-admins.json';
 import deSuperAdminSettingsSuperAdmins from './shared/locales/de/super-admin-settings-super-admins.json';
+import enSuperAdminSettingsAcademy from './shared/locales/en/super-admin-settings-academy.json';
+import deSuperAdminSettingsAcademy from './shared/locales/de/super-admin-settings-academy.json';
 import enArtifacts from './shared/locales/en/artifacts.json';
 import deArtifacts from './shared/locales/de/artifacts.json';
 import enSuperAdminSettingsPlatformConfig from './shared/locales/en/super-admin-settings-platform-config.json';
@@ -84,6 +86,7 @@ const resources = {
     'knowledge-bases': enKnowledgeBases,
     'super-admin-settings-skills': enSuperAdminSettingsSkills,
     'super-admin-settings-super-admins': enSuperAdminSettingsSuperAdmins,
+    'super-admin-settings-academy': enSuperAdminSettingsAcademy,
     artifacts: enArtifacts,
     'super-admin-settings-platform-config': enSuperAdminSettingsPlatformConfig,
     'admin-settings-security': enAdminSettingsSecurity,
@@ -115,6 +118,7 @@ const resources = {
     'knowledge-bases': deKnowledgeBases,
     'super-admin-settings-skills': deSuperAdminSettingsSkills,
     'super-admin-settings-super-admins': deSuperAdminSettingsSuperAdmins,
+    'super-admin-settings-academy': deSuperAdminSettingsAcademy,
     artifacts: deArtifacts,
     'super-admin-settings-platform-config': deSuperAdminSettingsPlatformConfig,
     'admin-settings-security': deAdminSettingsSecurity,

--- a/ayunis-core-frontend/src/pages/super-admin-settings/academy/api/useCreateChapter.ts
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/academy/api/useCreateChapter.ts
@@ -1,0 +1,57 @@
+import { useQueryClient } from '@tanstack/react-query';
+import type { UseFormReturn } from 'react-hook-form';
+import { useRouter } from '@tanstack/react-router';
+import { useTranslation } from 'react-i18next';
+import { showSuccess, showError } from '@/shared/lib/toast';
+import {
+  useSuperAdminAcademyChaptersControllerCreateChapter,
+  getSuperAdminAcademyChaptersControllerGetChaptersQueryKey,
+  type CreateChapterRequestDto,
+} from '@/shared/api';
+import extractErrorData from '@/shared/api/extract-error-data';
+import { setValidationErrors } from '@/shared/lib/set-validation-errors';
+import type { ChapterFormValues } from '../model/chapterFormSchema';
+
+export function useCreateChapter(
+  form: UseFormReturn<ChapterFormValues>,
+  onSuccess?: () => void,
+) {
+  const { t } = useTranslation('super-admin-settings-academy');
+  const queryClient = useQueryClient();
+  const router = useRouter();
+  const mutation = useSuperAdminAcademyChaptersControllerCreateChapter({
+    mutation: {
+      onSuccess: async () => {
+        await queryClient.invalidateQueries({
+          queryKey: getSuperAdminAcademyChaptersControllerGetChaptersQueryKey(),
+        });
+        showSuccess(t('toast.chapterCreateSuccess'));
+        onSuccess?.();
+      },
+      onError: (error: unknown) => {
+        try {
+          const { code, errors } = extractErrorData(error);
+          if (code === 'VALIDATION_ERROR' && errors) {
+            setValidationErrors(form, errors, t, 'validation');
+          } else {
+            showError(t('toast.chapterCreateError'));
+          }
+        } catch {
+          showError(t('toast.chapterCreateError'));
+        }
+      },
+      onSettled: async () => {
+        await router.invalidate();
+      },
+    },
+  });
+
+  function createChapter(data: CreateChapterRequestDto) {
+    mutation.mutate({ data });
+  }
+
+  return {
+    createChapter,
+    isCreating: mutation.isPending,
+  };
+}

--- a/ayunis-core-frontend/src/pages/super-admin-settings/academy/api/useCreateLesson.ts
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/academy/api/useCreateLesson.ts
@@ -1,0 +1,59 @@
+import { useQueryClient } from '@tanstack/react-query';
+import type { UseFormReturn } from 'react-hook-form';
+import { useRouter } from '@tanstack/react-router';
+import { useTranslation } from 'react-i18next';
+import { showSuccess, showError } from '@/shared/lib/toast';
+import {
+  useSuperAdminAcademyLessonsControllerCreateLesson,
+  getSuperAdminAcademyChaptersControllerGetChaptersQueryKey,
+  type CreateLessonRequestDto,
+} from '@/shared/api';
+import extractErrorData from '@/shared/api/extract-error-data';
+import { setValidationErrors } from '@/shared/lib/set-validation-errors';
+import type { LessonFormValues } from '../model/lessonFormSchema';
+
+export function useCreateLesson(
+  form: UseFormReturn<LessonFormValues>,
+  onSuccess?: () => void,
+) {
+  const { t } = useTranslation('super-admin-settings-academy');
+  const queryClient = useQueryClient();
+  const router = useRouter();
+  const mutation = useSuperAdminAcademyLessonsControllerCreateLesson({
+    mutation: {
+      onSuccess: async () => {
+        await queryClient.invalidateQueries({
+          queryKey: getSuperAdminAcademyChaptersControllerGetChaptersQueryKey(),
+        });
+        showSuccess(t('toast.lessonCreateSuccess'));
+        onSuccess?.();
+      },
+      onError: (error: unknown) => {
+        try {
+          const { code, errors } = extractErrorData(error);
+          if (code === 'VALIDATION_ERROR' && errors) {
+            setValidationErrors(form, errors, t, 'validation');
+          } else if (code === 'CHAPTER_NOT_FOUND') {
+            showError(t('toast.chapterNotFound'));
+          } else {
+            showError(t('toast.lessonCreateError'));
+          }
+        } catch {
+          showError(t('toast.lessonCreateError'));
+        }
+      },
+      onSettled: async () => {
+        await router.invalidate();
+      },
+    },
+  });
+
+  function createLesson(chapterId: string, data: CreateLessonRequestDto) {
+    mutation.mutate({ chapterId, data });
+  }
+
+  return {
+    createLesson,
+    isCreating: mutation.isPending,
+  };
+}

--- a/ayunis-core-frontend/src/pages/super-admin-settings/academy/api/useDeleteChapter.ts
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/academy/api/useDeleteChapter.ts
@@ -1,0 +1,49 @@
+import { useQueryClient } from '@tanstack/react-query';
+import { useRouter } from '@tanstack/react-router';
+import { useTranslation } from 'react-i18next';
+import { showSuccess, showError } from '@/shared/lib/toast';
+import {
+  useSuperAdminAcademyChaptersControllerDeleteChapter,
+  getSuperAdminAcademyChaptersControllerGetChaptersQueryKey,
+} from '@/shared/api';
+import extractErrorData from '@/shared/api/extract-error-data';
+
+export function useDeleteChapter() {
+  const { t } = useTranslation('super-admin-settings-academy');
+  const queryClient = useQueryClient();
+  const router = useRouter();
+  const mutation = useSuperAdminAcademyChaptersControllerDeleteChapter({
+    mutation: {
+      onSuccess: async () => {
+        await queryClient.invalidateQueries({
+          queryKey: getSuperAdminAcademyChaptersControllerGetChaptersQueryKey(),
+        });
+        showSuccess(t('toast.chapterDeleteSuccess'));
+      },
+      onError: (error: unknown) => {
+        try {
+          const { code } = extractErrorData(error);
+          if (code === 'CHAPTER_NOT_FOUND') {
+            showError(t('toast.chapterNotFound'));
+          } else {
+            showError(t('toast.chapterDeleteError'));
+          }
+        } catch {
+          showError(t('toast.chapterDeleteError'));
+        }
+      },
+      onSettled: async () => {
+        await router.invalidate();
+      },
+    },
+  });
+
+  function deleteChapter(id: string) {
+    mutation.mutate({ id });
+  }
+
+  return {
+    deleteChapter,
+    isDeleting: mutation.isPending,
+  };
+}

--- a/ayunis-core-frontend/src/pages/super-admin-settings/academy/api/useDeleteLesson.ts
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/academy/api/useDeleteLesson.ts
@@ -1,0 +1,49 @@
+import { useQueryClient } from '@tanstack/react-query';
+import { useRouter } from '@tanstack/react-router';
+import { useTranslation } from 'react-i18next';
+import { showSuccess, showError } from '@/shared/lib/toast';
+import {
+  useSuperAdminAcademyLessonsControllerDeleteLesson,
+  getSuperAdminAcademyChaptersControllerGetChaptersQueryKey,
+} from '@/shared/api';
+import extractErrorData from '@/shared/api/extract-error-data';
+
+export function useDeleteLesson() {
+  const { t } = useTranslation('super-admin-settings-academy');
+  const queryClient = useQueryClient();
+  const router = useRouter();
+  const mutation = useSuperAdminAcademyLessonsControllerDeleteLesson({
+    mutation: {
+      onSuccess: async () => {
+        await queryClient.invalidateQueries({
+          queryKey: getSuperAdminAcademyChaptersControllerGetChaptersQueryKey(),
+        });
+        showSuccess(t('toast.lessonDeleteSuccess'));
+      },
+      onError: (error: unknown) => {
+        try {
+          const { code } = extractErrorData(error);
+          if (code === 'LESSON_NOT_FOUND') {
+            showError(t('toast.lessonNotFound'));
+          } else {
+            showError(t('toast.lessonDeleteError'));
+          }
+        } catch {
+          showError(t('toast.lessonDeleteError'));
+        }
+      },
+      onSettled: async () => {
+        await router.invalidate();
+      },
+    },
+  });
+
+  function deleteLesson(id: string) {
+    mutation.mutate({ id });
+  }
+
+  return {
+    deleteLesson,
+    isDeleting: mutation.isPending,
+  };
+}

--- a/ayunis-core-frontend/src/pages/super-admin-settings/academy/api/useUpdateChapter.ts
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/academy/api/useUpdateChapter.ts
@@ -1,0 +1,59 @@
+import { useQueryClient } from '@tanstack/react-query';
+import type { UseFormReturn } from 'react-hook-form';
+import { useRouter } from '@tanstack/react-router';
+import { useTranslation } from 'react-i18next';
+import { showSuccess, showError } from '@/shared/lib/toast';
+import {
+  useSuperAdminAcademyChaptersControllerUpdateChapter,
+  getSuperAdminAcademyChaptersControllerGetChaptersQueryKey,
+  type UpdateChapterRequestDto,
+} from '@/shared/api';
+import extractErrorData from '@/shared/api/extract-error-data';
+import { setValidationErrors } from '@/shared/lib/set-validation-errors';
+import type { ChapterFormValues } from '../model/chapterFormSchema';
+
+export function useUpdateChapter(
+  form: UseFormReturn<ChapterFormValues>,
+  onSuccess?: () => void,
+) {
+  const { t } = useTranslation('super-admin-settings-academy');
+  const queryClient = useQueryClient();
+  const router = useRouter();
+  const mutation = useSuperAdminAcademyChaptersControllerUpdateChapter({
+    mutation: {
+      onSuccess: async () => {
+        await queryClient.invalidateQueries({
+          queryKey: getSuperAdminAcademyChaptersControllerGetChaptersQueryKey(),
+        });
+        showSuccess(t('toast.chapterUpdateSuccess'));
+        onSuccess?.();
+      },
+      onError: (error: unknown) => {
+        try {
+          const { code, errors } = extractErrorData(error);
+          if (code === 'VALIDATION_ERROR' && errors) {
+            setValidationErrors(form, errors, t, 'validation');
+          } else if (code === 'CHAPTER_NOT_FOUND') {
+            showError(t('toast.chapterNotFound'));
+          } else {
+            showError(t('toast.chapterUpdateError'));
+          }
+        } catch {
+          showError(t('toast.chapterUpdateError'));
+        }
+      },
+      onSettled: async () => {
+        await router.invalidate();
+      },
+    },
+  });
+
+  function updateChapter(id: string, data: UpdateChapterRequestDto) {
+    mutation.mutate({ id, data });
+  }
+
+  return {
+    updateChapter,
+    isUpdating: mutation.isPending,
+  };
+}

--- a/ayunis-core-frontend/src/pages/super-admin-settings/academy/api/useUpdateLesson.ts
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/academy/api/useUpdateLesson.ts
@@ -1,0 +1,59 @@
+import { useQueryClient } from '@tanstack/react-query';
+import type { UseFormReturn } from 'react-hook-form';
+import { useRouter } from '@tanstack/react-router';
+import { useTranslation } from 'react-i18next';
+import { showSuccess, showError } from '@/shared/lib/toast';
+import {
+  useSuperAdminAcademyLessonsControllerUpdateLesson,
+  getSuperAdminAcademyChaptersControllerGetChaptersQueryKey,
+  type UpdateLessonRequestDto,
+} from '@/shared/api';
+import extractErrorData from '@/shared/api/extract-error-data';
+import { setValidationErrors } from '@/shared/lib/set-validation-errors';
+import type { LessonFormValues } from '../model/lessonFormSchema';
+
+export function useUpdateLesson(
+  form: UseFormReturn<LessonFormValues>,
+  onSuccess?: () => void,
+) {
+  const { t } = useTranslation('super-admin-settings-academy');
+  const queryClient = useQueryClient();
+  const router = useRouter();
+  const mutation = useSuperAdminAcademyLessonsControllerUpdateLesson({
+    mutation: {
+      onSuccess: async () => {
+        await queryClient.invalidateQueries({
+          queryKey: getSuperAdminAcademyChaptersControllerGetChaptersQueryKey(),
+        });
+        showSuccess(t('toast.lessonUpdateSuccess'));
+        onSuccess?.();
+      },
+      onError: (error: unknown) => {
+        try {
+          const { code, errors } = extractErrorData(error);
+          if (code === 'VALIDATION_ERROR' && errors) {
+            setValidationErrors(form, errors, t, 'validation');
+          } else if (code === 'LESSON_NOT_FOUND') {
+            showError(t('toast.lessonNotFound'));
+          } else {
+            showError(t('toast.lessonUpdateError'));
+          }
+        } catch {
+          showError(t('toast.lessonUpdateError'));
+        }
+      },
+      onSettled: async () => {
+        await router.invalidate();
+      },
+    },
+  });
+
+  function updateLesson(id: string, data: UpdateLessonRequestDto) {
+    mutation.mutate({ id, data });
+  }
+
+  return {
+    updateLesson,
+    isUpdating: mutation.isPending,
+  };
+}

--- a/ayunis-core-frontend/src/pages/super-admin-settings/academy/index.ts
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/academy/index.ts
@@ -1,0 +1,1 @@
+export { default } from './ui/Page';

--- a/ayunis-core-frontend/src/pages/super-admin-settings/academy/model/chapterFormSchema.ts
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/academy/model/chapterFormSchema.ts
@@ -1,0 +1,18 @@
+import * as z from 'zod';
+
+export function createChapterFormSchema(t: (key: string) => string) {
+  return z.object({
+    title: z
+      .string()
+      .min(1, t('chapterForm.titleRequired'))
+      .max(255, t('chapterForm.titleTooLong')),
+    description: z
+      .string()
+      .min(1, t('chapterForm.descriptionRequired'))
+      .max(2000, t('chapterForm.descriptionTooLong')),
+  });
+}
+
+export type ChapterFormValues = z.infer<
+  ReturnType<typeof createChapterFormSchema>
+>;

--- a/ayunis-core-frontend/src/pages/super-admin-settings/academy/model/lessonFormSchema.ts
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/academy/model/lessonFormSchema.ts
@@ -1,0 +1,24 @@
+import * as z from 'zod';
+
+// Mirrors the backend DTO validation (CreateLessonRequestDto)
+const LOOM_URL_PATTERN =
+  /^https:\/\/(www\.)?loom\.com\/(share|embed)\/[A-Za-z0-9]+/;
+
+export function createLessonFormSchema(t: (key: string) => string) {
+  return z.object({
+    title: z
+      .string()
+      .min(1, t('lessonForm.titleRequired'))
+      .max(255, t('lessonForm.titleTooLong')),
+    description: z.string().max(2000, t('lessonForm.descriptionTooLong')),
+    loomUrl: z
+      .string()
+      .min(1, t('lessonForm.loomUrlRequired'))
+      .max(500, t('lessonForm.loomUrlTooLong'))
+      .regex(LOOM_URL_PATTERN, t('lessonForm.loomUrlInvalid')),
+  });
+}
+
+export type LessonFormValues = z.infer<
+  ReturnType<typeof createLessonFormSchema>
+>;

--- a/ayunis-core-frontend/src/pages/super-admin-settings/academy/ui/ChapterCard.tsx
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/academy/ui/ChapterCard.tsx
@@ -1,0 +1,89 @@
+import { useTranslation } from 'react-i18next';
+import type {
+  AcademyChapterResponseDto,
+  AcademyLessonResponseDto,
+} from '@/shared/api';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/shared/ui/shadcn/card';
+import { Button } from '@/shared/ui/shadcn/button';
+import { Pencil, Plus, Trash2 } from 'lucide-react';
+import { LessonItem } from './LessonItem';
+
+interface ChapterCardProps {
+  chapter: AcademyChapterResponseDto;
+  onEdit: () => void;
+  onDelete: () => void;
+  onAddLesson: () => void;
+  onEditLesson: (lesson: AcademyLessonResponseDto) => void;
+  onDeleteLesson: (lesson: AcademyLessonResponseDto) => void;
+  isDeletingChapter: boolean;
+  isDeletingLesson: boolean;
+}
+
+export function ChapterCard({
+  chapter,
+  onEdit,
+  onDelete,
+  onAddLesson,
+  onEditLesson,
+  onDeleteLesson,
+  isDeletingChapter,
+  isDeletingLesson,
+}: Readonly<ChapterCardProps>) {
+  const { t } = useTranslation('super-admin-settings-academy');
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-start justify-between gap-2">
+          <div className="space-y-1.5">
+            <CardTitle>{chapter.title}</CardTitle>
+            <CardDescription>{chapter.description}</CardDescription>
+          </div>
+          <div className="flex shrink-0 items-center gap-1">
+            <Button variant="ghost" size="icon" onClick={onEdit}>
+              <Pencil className="h-4 w-4" />
+            </Button>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="text-destructive hover:text-destructive"
+              onClick={onDelete}
+              disabled={isDeletingChapter}
+            >
+              <Trash2 className="h-4 w-4" />
+            </Button>
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        {chapter.lessons.length === 0 ? (
+          <p className="py-2 text-sm text-muted-foreground">
+            {t('page.noLessons')}
+          </p>
+        ) : (
+          <div className="flex flex-col gap-2">
+            {chapter.lessons.map((lesson) => (
+              <LessonItem
+                key={lesson.id}
+                lesson={lesson}
+                onEdit={() => onEditLesson(lesson)}
+                onDelete={() => onDeleteLesson(lesson)}
+                isDeleting={isDeletingLesson}
+              />
+            ))}
+          </div>
+        )}
+        <Button variant="outline" size="sm" onClick={onAddLesson}>
+          <Plus className="h-4 w-4" />
+          {t('page.addLesson')}
+        </Button>
+      </CardContent>
+    </Card>
+  );
+}

--- a/ayunis-core-frontend/src/pages/super-admin-settings/academy/ui/ChapterFormDialog.tsx
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/academy/ui/ChapterFormDialog.tsx
@@ -1,0 +1,142 @@
+import { useEffect } from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useTranslation } from 'react-i18next';
+import type { AcademyChapterResponseDto } from '@/shared/api';
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/shared/ui/shadcn/dialog';
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/shared/ui/shadcn/form';
+import { Input } from '@/shared/ui/shadcn/input';
+import { Textarea } from '@/shared/ui/shadcn/textarea';
+import { Button } from '@/shared/ui/shadcn/button';
+import {
+  createChapterFormSchema,
+  type ChapterFormValues,
+} from '../model/chapterFormSchema';
+import { useCreateChapter } from '../api/useCreateChapter';
+import { useUpdateChapter } from '../api/useUpdateChapter';
+
+interface ChapterFormDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  chapter: AcademyChapterResponseDto | null;
+}
+
+export function ChapterFormDialog({
+  open,
+  onOpenChange,
+  chapter,
+}: Readonly<ChapterFormDialogProps>) {
+  const { t } = useTranslation('super-admin-settings-academy');
+  const isEdit = chapter !== null;
+
+  const form = useForm<ChapterFormValues>({
+    resolver: zodResolver(createChapterFormSchema(t)),
+    defaultValues: { title: '', description: '' },
+  });
+
+  useEffect(() => {
+    if (open) {
+      form.reset({
+        title: chapter?.title ?? '',
+        description: chapter?.description ?? '',
+      });
+    }
+  }, [open, chapter, form]);
+
+  function close() {
+    onOpenChange(false);
+    form.reset();
+  }
+
+  const { createChapter, isCreating } = useCreateChapter(form, close);
+  const { updateChapter, isUpdating } = useUpdateChapter(form, close);
+  const isSubmitting = isCreating || isUpdating;
+
+  function onSubmit(data: ChapterFormValues) {
+    if (isEdit) {
+      updateChapter(chapter.id, data);
+    } else {
+      createChapter(data);
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[525px]">
+        <DialogHeader>
+          <DialogTitle>
+            {isEdit ? t('chapterForm.editTitle') : t('chapterForm.createTitle')}
+          </DialogTitle>
+        </DialogHeader>
+        <Form {...form}>
+          <form
+            onSubmit={(e) => void form.handleSubmit(onSubmit)(e)}
+            className="space-y-4"
+          >
+            <FormField
+              control={form.control}
+              name="title"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>{t('chapterForm.title')}</FormLabel>
+                  <FormControl>
+                    <Input
+                      {...field}
+                      placeholder={t('chapterForm.titlePlaceholder')}
+                      disabled={isSubmitting}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="description"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>{t('chapterForm.description')}</FormLabel>
+                  <FormControl>
+                    <Textarea
+                      {...field}
+                      placeholder={t('chapterForm.descriptionPlaceholder')}
+                      disabled={isSubmitting}
+                      rows={4}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <DialogFooter>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={close}
+                disabled={isSubmitting}
+              >
+                {t('chapterForm.cancel')}
+              </Button>
+              <Button type="submit" disabled={isSubmitting}>
+                {isSubmitting ? t('chapterForm.saving') : t('chapterForm.save')}
+              </Button>
+            </DialogFooter>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/ayunis-core-frontend/src/pages/super-admin-settings/academy/ui/LessonFormDialog.tsx
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/academy/ui/LessonFormDialog.tsx
@@ -1,0 +1,167 @@
+import { useEffect } from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useTranslation } from 'react-i18next';
+import type { AcademyLessonResponseDto } from '@/shared/api';
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/shared/ui/shadcn/dialog';
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/shared/ui/shadcn/form';
+import { Input } from '@/shared/ui/shadcn/input';
+import { Textarea } from '@/shared/ui/shadcn/textarea';
+import { Button } from '@/shared/ui/shadcn/button';
+import {
+  createLessonFormSchema,
+  type LessonFormValues,
+} from '../model/lessonFormSchema';
+import { useCreateLesson } from '../api/useCreateLesson';
+import { useUpdateLesson } from '../api/useUpdateLesson';
+
+interface LessonFormDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  chapterId: string | null;
+  lesson: AcademyLessonResponseDto | null;
+}
+
+export function LessonFormDialog({
+  open,
+  onOpenChange,
+  chapterId,
+  lesson,
+}: Readonly<LessonFormDialogProps>) {
+  const { t } = useTranslation('super-admin-settings-academy');
+  const isEdit = lesson !== null;
+
+  const form = useForm<LessonFormValues>({
+    resolver: zodResolver(createLessonFormSchema(t)),
+    defaultValues: { title: '', description: '', loomUrl: '' },
+  });
+
+  useEffect(() => {
+    if (open) {
+      form.reset({
+        title: lesson?.title ?? '',
+        description: lesson?.description ?? '',
+        loomUrl: lesson?.loomUrl ?? '',
+      });
+    }
+  }, [open, lesson, form]);
+
+  function close() {
+    onOpenChange(false);
+    form.reset();
+  }
+
+  const { createLesson, isCreating } = useCreateLesson(form, close);
+  const { updateLesson, isUpdating } = useUpdateLesson(form, close);
+  const isSubmitting = isCreating || isUpdating;
+
+  function onSubmit(data: LessonFormValues) {
+    const payload = {
+      title: data.title,
+      description: data.description === '' ? undefined : data.description,
+      loomUrl: data.loomUrl,
+    };
+    if (isEdit) {
+      updateLesson(lesson.id, payload);
+    } else if (chapterId) {
+      createLesson(chapterId, payload);
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[525px]">
+        <DialogHeader>
+          <DialogTitle>
+            {isEdit ? t('lessonForm.editTitle') : t('lessonForm.createTitle')}
+          </DialogTitle>
+        </DialogHeader>
+        <Form {...form}>
+          <form
+            onSubmit={(e) => void form.handleSubmit(onSubmit)(e)}
+            className="space-y-4"
+          >
+            <FormField
+              control={form.control}
+              name="title"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>{t('lessonForm.title')}</FormLabel>
+                  <FormControl>
+                    <Input
+                      {...field}
+                      placeholder={t('lessonForm.titlePlaceholder')}
+                      disabled={isSubmitting}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="description"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>{t('lessonForm.description')}</FormLabel>
+                  <FormControl>
+                    <Textarea
+                      {...field}
+                      placeholder={t('lessonForm.descriptionPlaceholder')}
+                      disabled={isSubmitting}
+                      rows={3}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="loomUrl"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>{t('lessonForm.loomUrl')}</FormLabel>
+                  <FormControl>
+                    <Input
+                      {...field}
+                      placeholder={t('lessonForm.loomUrlPlaceholder')}
+                      disabled={isSubmitting}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <DialogFooter>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={close}
+                disabled={isSubmitting}
+              >
+                {t('lessonForm.cancel')}
+              </Button>
+              <Button type="submit" disabled={isSubmitting}>
+                {isSubmitting ? t('lessonForm.saving') : t('lessonForm.save')}
+              </Button>
+            </DialogFooter>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/ayunis-core-frontend/src/pages/super-admin-settings/academy/ui/LessonItem.tsx
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/academy/ui/LessonItem.tsx
@@ -1,0 +1,54 @@
+import type { AcademyLessonResponseDto } from '@/shared/api';
+import {
+  Item,
+  ItemActions,
+  ItemContent,
+  ItemDescription,
+  ItemTitle,
+} from '@/shared/ui/shadcn/item';
+import { Button } from '@/shared/ui/shadcn/button';
+import { ExternalLink, Pencil, Trash2 } from 'lucide-react';
+
+interface LessonItemProps {
+  lesson: AcademyLessonResponseDto;
+  onEdit: () => void;
+  onDelete: () => void;
+  isDeleting: boolean;
+}
+
+export function LessonItem({
+  lesson,
+  onEdit,
+  onDelete,
+  isDeleting,
+}: Readonly<LessonItemProps>) {
+  return (
+    <Item variant="outline" size="sm">
+      <ItemContent>
+        <ItemTitle>{lesson.title}</ItemTitle>
+        {lesson.description && (
+          <ItemDescription>{lesson.description}</ItemDescription>
+        )}
+      </ItemContent>
+      <ItemActions>
+        <Button variant="ghost" size="icon" asChild>
+          <a href={lesson.loomUrl} target="_blank" rel="noopener noreferrer">
+            <ExternalLink className="h-4 w-4" />
+          </a>
+        </Button>
+        <Button variant="ghost" size="icon" onClick={onEdit}>
+          <Pencil className="h-4 w-4" />
+        </Button>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="text-destructive hover:text-destructive"
+          onClick={onDelete}
+          disabled={isDeleting}
+        >
+          <Trash2 className="h-4 w-4" />
+        </Button>
+      </ItemActions>
+    </Item>
+  );
+}

--- a/ayunis-core-frontend/src/pages/super-admin-settings/academy/ui/Page.tsx
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/academy/ui/Page.tsx
@@ -1,0 +1,128 @@
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import type {
+  AcademyChapterResponseDto,
+  AcademyLessonResponseDto,
+} from '@/shared/api';
+import SuperAdminSettingsLayout from '../../super-admin-settings-layout';
+import { Button } from '@/shared/ui/shadcn/button';
+import { useConfirmation } from '@/widgets/confirmation-modal';
+import { ChapterCard } from './ChapterCard';
+import { ChapterFormDialog } from './ChapterFormDialog';
+import { LessonFormDialog } from './LessonFormDialog';
+import { useDeleteChapter } from '../api/useDeleteChapter';
+import { useDeleteLesson } from '../api/useDeleteLesson';
+
+interface AcademyPageProps {
+  chapters: AcademyChapterResponseDto[];
+}
+
+interface LessonDialogState {
+  chapterId: string;
+  lesson: AcademyLessonResponseDto | null;
+}
+
+export default function AcademyPage({ chapters }: Readonly<AcademyPageProps>) {
+  const { t } = useTranslation('super-admin-settings-academy');
+  const [chapterDialogOpen, setChapterDialogOpen] = useState(false);
+  const [editChapter, setEditChapter] =
+    useState<AcademyChapterResponseDto | null>(null);
+  const [lessonDialog, setLessonDialog] = useState<LessonDialogState | null>(
+    null,
+  );
+  const { deleteChapter, isDeleting: isDeletingChapter } = useDeleteChapter();
+  const { deleteLesson, isDeleting: isDeletingLesson } = useDeleteLesson();
+  const { confirm } = useConfirmation();
+
+  function handleDeleteChapter(chapter: AcademyChapterResponseDto) {
+    confirm({
+      title: t('deleteChapter.title'),
+      description: t('deleteChapter.description', { title: chapter.title }),
+      confirmText: t('deleteChapter.confirm'),
+      cancelText: t('deleteChapter.cancel'),
+      variant: 'destructive',
+      onConfirm: () => {
+        deleteChapter(chapter.id);
+      },
+    });
+  }
+
+  function handleDeleteLesson(lesson: AcademyLessonResponseDto) {
+    confirm({
+      title: t('deleteLesson.title'),
+      description: t('deleteLesson.description', { title: lesson.title }),
+      confirmText: t('deleteLesson.confirm'),
+      cancelText: t('deleteLesson.cancel'),
+      variant: 'destructive',
+      onConfirm: () => {
+        deleteLesson(lesson.id);
+      },
+    });
+  }
+
+  return (
+    <SuperAdminSettingsLayout
+      pageTitle={t('page.title')}
+      action={
+        <Button
+          size="sm"
+          onClick={() => {
+            setEditChapter(null);
+            setChapterDialogOpen(true);
+          }}
+        >
+          {t('page.addChapter')}
+        </Button>
+      }
+    >
+      {chapters.length === 0 ? (
+        <div className="flex flex-col items-center justify-center space-y-2 py-10 text-center">
+          <h3 className="text-lg font-semibold">{t('page.empty')}</h3>
+          <p className="max-w-sm text-sm text-muted-foreground">
+            {t('page.emptyDescription')}
+          </p>
+        </div>
+      ) : (
+        <div className="flex flex-col gap-4">
+          {chapters.map((chapter) => (
+            <ChapterCard
+              key={chapter.id}
+              chapter={chapter}
+              onEdit={() => {
+                setEditChapter(chapter);
+                setChapterDialogOpen(true);
+              }}
+              onDelete={() => handleDeleteChapter(chapter)}
+              onAddLesson={() =>
+                setLessonDialog({ chapterId: chapter.id, lesson: null })
+              }
+              onEditLesson={(lesson) =>
+                setLessonDialog({ chapterId: chapter.id, lesson })
+              }
+              onDeleteLesson={handleDeleteLesson}
+              isDeletingChapter={isDeletingChapter}
+              isDeletingLesson={isDeletingLesson}
+            />
+          ))}
+        </div>
+      )}
+
+      <ChapterFormDialog
+        open={chapterDialogOpen}
+        onOpenChange={(open) => {
+          setChapterDialogOpen(open);
+          if (!open) setEditChapter(null);
+        }}
+        chapter={editChapter}
+      />
+      <LessonFormDialog
+        open={lessonDialog !== null}
+        onOpenChange={(open) => {
+          if (!open) setLessonDialog(null);
+        }}
+        chapterId={lessonDialog?.chapterId ?? null}
+        lesson={lessonDialog?.lesson ?? null}
+      />
+    </SuperAdminSettingsLayout>
+  );
+}

--- a/ayunis-core-frontend/src/pages/super-admin-settings/super-admin-settings-layout/ui/SuperAdminSettingsSidebar.tsx
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/super-admin-settings-layout/ui/SuperAdminSettingsSidebar.tsx
@@ -4,6 +4,7 @@ import {
   Sparkles,
   ShieldCheck,
   Settings2,
+  GraduationCap,
 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import {
@@ -29,6 +30,11 @@ export function SuperAdminSettingsSidebar() {
       to: '/super-admin-settings/skills',
       icon: <Sparkles />,
       label: t('layout.skills'),
+    },
+    {
+      to: '/super-admin-settings/academy',
+      icon: <GraduationCap />,
+      label: t('layout.academy'),
     },
     {
       to: '/super-admin-settings/super-admins',

--- a/ayunis-core-frontend/src/shared/locales/de/super-admin-settings-academy.json
+++ b/ayunis-core-frontend/src/shared/locales/de/super-admin-settings-academy.json
@@ -1,0 +1,92 @@
+{
+  "page": {
+    "title": "Academy",
+    "empty": "Noch keine Kapitel",
+    "emptyDescription": "Erstellen Sie Ihr erstes Kapitel, um die Academy aufzubauen.",
+    "addChapter": "Kapitel hinzufügen",
+    "addLesson": "Lektion hinzufügen",
+    "noLessons": "Noch keine Lektionen in diesem Kapitel."
+  },
+  "chapterForm": {
+    "createTitle": "Kapitel erstellen",
+    "editTitle": "Kapitel bearbeiten",
+    "title": "Titel",
+    "titlePlaceholder": "z. B. Erste Schritte",
+    "titleRequired": "Titel ist erforderlich",
+    "titleTooLong": "Titel darf höchstens 255 Zeichen lang sein",
+    "description": "Beschreibung",
+    "descriptionPlaceholder": "Worum geht es in diesem Kapitel?",
+    "descriptionRequired": "Beschreibung ist erforderlich",
+    "descriptionTooLong": "Beschreibung darf höchstens 2.000 Zeichen lang sein",
+    "save": "Speichern",
+    "saving": "Wird gespeichert...",
+    "cancel": "Abbrechen"
+  },
+  "lessonForm": {
+    "createTitle": "Lektion erstellen",
+    "editTitle": "Lektion bearbeiten",
+    "title": "Titel",
+    "titlePlaceholder": "z. B. Ihren ersten Chat erstellen",
+    "titleRequired": "Titel ist erforderlich",
+    "titleTooLong": "Titel darf höchstens 255 Zeichen lang sein",
+    "description": "Beschreibung (optional)",
+    "descriptionPlaceholder": "Worum geht es in dieser Lektion?",
+    "descriptionTooLong": "Beschreibung darf höchstens 2.000 Zeichen lang sein",
+    "loomUrl": "Loom-Link",
+    "loomUrlPlaceholder": "https://www.loom.com/share/...",
+    "loomUrlRequired": "Loom-Link ist erforderlich",
+    "loomUrlTooLong": "Loom-Link darf höchstens 500 Zeichen lang sein",
+    "loomUrlInvalid": "Muss ein Loom-Share- oder -Embed-Link sein (https://www.loom.com/share/...)",
+    "save": "Speichern",
+    "saving": "Wird gespeichert...",
+    "cancel": "Abbrechen"
+  },
+  "deleteChapter": {
+    "title": "Kapitel löschen",
+    "description": "Möchten Sie \"{{title}}\" und alle zugehörigen Lektionen wirklich löschen? Diese Aktion kann nicht rückgängig gemacht werden.",
+    "confirm": "Löschen",
+    "cancel": "Abbrechen"
+  },
+  "deleteLesson": {
+    "title": "Lektion löschen",
+    "description": "Möchten Sie \"{{title}}\" wirklich löschen? Diese Aktion kann nicht rückgängig gemacht werden.",
+    "confirm": "Löschen",
+    "cancel": "Abbrechen"
+  },
+  "toast": {
+    "chapterCreateSuccess": "Kapitel erfolgreich erstellt",
+    "chapterCreateError": "Kapitel konnte nicht erstellt werden",
+    "chapterUpdateSuccess": "Kapitel erfolgreich aktualisiert",
+    "chapterUpdateError": "Kapitel konnte nicht aktualisiert werden",
+    "chapterDeleteSuccess": "Kapitel erfolgreich gelöscht",
+    "chapterDeleteError": "Kapitel konnte nicht gelöscht werden",
+    "chapterNotFound": "Kapitel nicht gefunden",
+    "lessonCreateSuccess": "Lektion erfolgreich erstellt",
+    "lessonCreateError": "Lektion konnte nicht erstellt werden",
+    "lessonUpdateSuccess": "Lektion erfolgreich aktualisiert",
+    "lessonUpdateError": "Lektion konnte nicht aktualisiert werden",
+    "lessonDeleteSuccess": "Lektion erfolgreich gelöscht",
+    "lessonDeleteError": "Lektion konnte nicht gelöscht werden",
+    "lessonNotFound": "Lektion nicht gefunden",
+    "reorderError": "Die neue Reihenfolge konnte nicht gespeichert werden"
+  },
+  "validation": {
+    "title": {
+      "isNotEmpty": "Titel ist erforderlich",
+      "maxLength": "Titel darf höchstens 255 Zeichen lang sein",
+      "invalid": "Ungültiger Titel"
+    },
+    "description": {
+      "isNotEmpty": "Beschreibung ist erforderlich",
+      "maxLength": "Beschreibung darf höchstens 2.000 Zeichen lang sein",
+      "invalid": "Ungültige Beschreibung"
+    },
+    "loomUrl": {
+      "isUrl": "Muss eine gültige Loom-URL sein",
+      "matches": "Muss ein Loom-Share- oder -Embed-Link sein",
+      "maxLength": "Loom-Link darf höchstens 500 Zeichen lang sein",
+      "invalid": "Ungültiger Loom-Link"
+    },
+    "invalid": "Ungültige Eingabe"
+  }
+}

--- a/ayunis-core-frontend/src/shared/locales/de/super-admin-settings-layout.json
+++ b/ayunis-core-frontend/src/shared/locales/de/super-admin-settings-layout.json
@@ -7,6 +7,7 @@
     "orgs": "Organisationen",
     "modelsCatalog": "Model-Katalog",
     "skills": "Skill-Vorlagen",
+    "academy": "Academy",
     "superAdmins": "Super-Admins",
     "platformConfig": "Plattform-Konfiguration"
   }

--- a/ayunis-core-frontend/src/shared/locales/en/super-admin-settings-academy.json
+++ b/ayunis-core-frontend/src/shared/locales/en/super-admin-settings-academy.json
@@ -1,0 +1,92 @@
+{
+  "page": {
+    "title": "Academy",
+    "empty": "No chapters yet",
+    "emptyDescription": "Create your first chapter to start building the academy.",
+    "addChapter": "Add Chapter",
+    "addLesson": "Add Lesson",
+    "noLessons": "No lessons in this chapter yet."
+  },
+  "chapterForm": {
+    "createTitle": "Create Chapter",
+    "editTitle": "Edit Chapter",
+    "title": "Title",
+    "titlePlaceholder": "e.g., Getting Started",
+    "titleRequired": "Title is required",
+    "titleTooLong": "Title must be 255 characters or fewer",
+    "description": "Description",
+    "descriptionPlaceholder": "What does this chapter cover?",
+    "descriptionRequired": "Description is required",
+    "descriptionTooLong": "Description must be 2,000 characters or fewer",
+    "save": "Save",
+    "saving": "Saving...",
+    "cancel": "Cancel"
+  },
+  "lessonForm": {
+    "createTitle": "Create Lesson",
+    "editTitle": "Edit Lesson",
+    "title": "Title",
+    "titlePlaceholder": "e.g., Creating your first chat",
+    "titleRequired": "Title is required",
+    "titleTooLong": "Title must be 255 characters or fewer",
+    "description": "Description (optional)",
+    "descriptionPlaceholder": "What does this lesson cover?",
+    "descriptionTooLong": "Description must be 2,000 characters or fewer",
+    "loomUrl": "Loom link",
+    "loomUrlPlaceholder": "https://www.loom.com/share/...",
+    "loomUrlRequired": "Loom link is required",
+    "loomUrlTooLong": "Loom link must be 500 characters or fewer",
+    "loomUrlInvalid": "Must be a Loom share or embed link (https://www.loom.com/share/...)",
+    "save": "Save",
+    "saving": "Saving...",
+    "cancel": "Cancel"
+  },
+  "deleteChapter": {
+    "title": "Delete Chapter",
+    "description": "Are you sure you want to delete \"{{title}}\" and all of its lessons? This action cannot be undone.",
+    "confirm": "Delete",
+    "cancel": "Cancel"
+  },
+  "deleteLesson": {
+    "title": "Delete Lesson",
+    "description": "Are you sure you want to delete \"{{title}}\"? This action cannot be undone.",
+    "confirm": "Delete",
+    "cancel": "Cancel"
+  },
+  "toast": {
+    "chapterCreateSuccess": "Chapter created successfully",
+    "chapterCreateError": "Failed to create chapter",
+    "chapterUpdateSuccess": "Chapter updated successfully",
+    "chapterUpdateError": "Failed to update chapter",
+    "chapterDeleteSuccess": "Chapter deleted successfully",
+    "chapterDeleteError": "Failed to delete chapter",
+    "chapterNotFound": "Chapter not found",
+    "lessonCreateSuccess": "Lesson created successfully",
+    "lessonCreateError": "Failed to create lesson",
+    "lessonUpdateSuccess": "Lesson updated successfully",
+    "lessonUpdateError": "Failed to update lesson",
+    "lessonDeleteSuccess": "Lesson deleted successfully",
+    "lessonDeleteError": "Failed to delete lesson",
+    "lessonNotFound": "Lesson not found",
+    "reorderError": "Failed to save the new order"
+  },
+  "validation": {
+    "title": {
+      "isNotEmpty": "Title is required",
+      "maxLength": "Title must be 255 characters or fewer",
+      "invalid": "Invalid title"
+    },
+    "description": {
+      "isNotEmpty": "Description is required",
+      "maxLength": "Description must be 2,000 characters or fewer",
+      "invalid": "Invalid description"
+    },
+    "loomUrl": {
+      "isUrl": "Must be a valid Loom URL",
+      "matches": "Must be a Loom share or embed link",
+      "maxLength": "Loom link must be 500 characters or fewer",
+      "invalid": "Invalid Loom link"
+    },
+    "invalid": "Invalid input"
+  }
+}

--- a/ayunis-core-frontend/src/shared/locales/en/super-admin-settings-layout.json
+++ b/ayunis-core-frontend/src/shared/locales/en/super-admin-settings-layout.json
@@ -7,6 +7,7 @@
     "orgs": "Organizations",
     "modelsCatalog": "Models Catalog",
     "skills": "Skill Templates",
+    "academy": "Academy",
     "superAdmins": "Super Admins",
     "platformConfig": "Platform Config"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -360,6 +360,15 @@ importers:
       '@base-ui/react':
         specifier: ^1.2.0
         version: 1.5.0(@date-fns/tz@1.5.0)(@types/react@19.2.15)(date-fns@4.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@dnd-kit/core':
+        specifier: ^6.3.1
+        version: 6.3.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@dnd-kit/sortable':
+        specifier: ^10.0.0
+        version: 10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
+      '@dnd-kit/utilities':
+        specifier: ^3.2.2
+        version: 3.2.2(react@19.2.6)
       '@hookform/resolvers':
         specifier: ^5.0.1
         version: 5.4.0(react-hook-form@7.76.1(react@19.2.6))
@@ -1296,6 +1305,28 @@ packages:
   '@discoveryjs/json-ext@1.1.0':
     resolution: {integrity: sha512-Xc3VhU02wqZ1HvHRJUwL09HkZSTvidqY5Ya0NXBSYOxAp+Ln9dcJr9fySI+CkONzP3PekQo9WdzCv0PGER/mOA==}
     engines: {node: '>=14.17.0'}
+
+  '@dnd-kit/accessibility@3.1.1':
+    resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
+    peerDependencies:
+      react: '>=16.8.0'
+
+  '@dnd-kit/core@6.3.1':
+    resolution: {integrity: sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@dnd-kit/sortable@10.0.0':
+    resolution: {integrity: sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==}
+    peerDependencies:
+      '@dnd-kit/core': ^6.3.0
+      react: '>=16.8.0'
+
+  '@dnd-kit/utilities@3.2.2':
+    resolution: {integrity: sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==}
+    peerDependencies:
+      react: '>=16.8.0'
 
   '@emnapi/core@1.10.0':
     resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
@@ -12285,6 +12316,31 @@ snapshots:
       node-source-walk: 7.0.2
 
   '@discoveryjs/json-ext@1.1.0': {}
+
+  '@dnd-kit/accessibility@3.1.1(react@19.2.6)':
+    dependencies:
+      react: 19.2.6
+      tslib: 2.8.1
+
+  '@dnd-kit/core@6.3.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@dnd-kit/accessibility': 3.1.1(react@19.2.6)
+      '@dnd-kit/utilities': 3.2.2(react@19.2.6)
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+      tslib: 2.8.1
+
+  '@dnd-kit/sortable@10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@dnd-kit/core': 6.3.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@dnd-kit/utilities': 3.2.2(react@19.2.6)
+      react: 19.2.6
+      tslib: 2.8.1
+
+  '@dnd-kit/utilities@3.2.2(react@19.2.6)':
+    dependencies:
+      react: 19.2.6
+      tslib: 2.8.1
 
   '@emnapi/core@1.10.0':
     dependencies:


### PR DESCRIPTION
- Academy page under super-admin settings: chapter cards with nested
  lessons, create/edit dialogs, delete confirmations
- CRUD hooks with toast feedback and field-level backend validation
- Sidebar entry, en/de translations, dnd-kit dependency for follow-up
  drag-and-drop

Refs: AYC-239, AYC-240

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New super-admin-only UI behind existing role checks; no auth or payment changes. Destructive deletes are confirmed; main follow-up risk is unused dnd-kit deps until reorder ships.
> 
> **Overview**
> Adds a **super-admin Academy** area at `/super-admin-settings/academy` so platform content (chapters and Loom-based lessons) can be managed from the UI.
> 
> The new route loads chapters via the existing super-admin Academy API, **restricts access to `super_admin`**, and renders a page with chapter cards, nested lessons, create/edit dialogs, and destructive delete confirmations. **CRUD** is wired through dedicated mutation hooks (invalidate chapters query, toasts, backend validation mapping, router invalidation). Lesson forms validate **Loom share/embed URLs** with Zod aligned to the backend DTO.
> 
> Navigation and i18n are extended with an **Academy** sidebar entry and **en/de** locale bundles. **`@dnd-kit/*`** packages are added for planned reorder UI; this PR does not implement drag-and-drop yet (reorder strings exist for follow-up).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08bd661cd6479344f1158b01b9e292fb907f1f84. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->