### PR TITLE
feat(academy): super-admin academy management with sortable chapters and lessons (AYC-243)

### DIFF
--- a/ayunis-core-frontend/src/pages/super-admin-settings/academy/api/useReorderChapters.ts
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/academy/api/useReorderChapters.ts
@@ -14,6 +14,9 @@ export function useReorderChapters() {
   const router = useRouter();
   const mutation = useSuperAdminAcademyChaptersControllerReorderChapters({
     mutation: {
+      // Serialize reorder requests so a slower earlier request cannot finish
+      // after a newer one and overwrite the latest order on the server.
+      scope: { id: 'reorder-academy-chapters' },
       onSuccess: async () => {
         await queryClient.invalidateQueries({
           queryKey: getSuperAdminAcademyChaptersControllerGetChaptersQueryKey(),

--- a/ayunis-core-frontend/src/pages/super-admin-settings/academy/api/useReorderChapters.ts
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/academy/api/useReorderChapters.ts
@@ -1,0 +1,50 @@
+import { useQueryClient } from '@tanstack/react-query';
+import { useRouter } from '@tanstack/react-router';
+import { useTranslation } from 'react-i18next';
+import { showError } from '@/shared/lib/toast';
+import {
+  useSuperAdminAcademyChaptersControllerReorderChapters,
+  getSuperAdminAcademyChaptersControllerGetChaptersQueryKey,
+} from '@/shared/api';
+import extractErrorData from '@/shared/api/extract-error-data';
+
+export function useReorderChapters() {
+  const { t } = useTranslation('super-admin-settings-academy');
+  const queryClient = useQueryClient();
+  const router = useRouter();
+  const mutation = useSuperAdminAcademyChaptersControllerReorderChapters({
+    mutation: {
+      onSuccess: async () => {
+        await queryClient.invalidateQueries({
+          queryKey: getSuperAdminAcademyChaptersControllerGetChaptersQueryKey(),
+        });
+      },
+      onError: (error: unknown) => {
+        // All backend error codes (INVALID_REORDER, unexpected) map to the
+        // same user feedback — the list silently snaps back to server order.
+        try {
+          extractErrorData(error);
+          showError(t('toast.reorderError'));
+        } catch {
+          showError(t('toast.reorderError'));
+        }
+        // Re-sync the optimistic local order with the server state
+        void queryClient.invalidateQueries({
+          queryKey: getSuperAdminAcademyChaptersControllerGetChaptersQueryKey(),
+        });
+      },
+      onSettled: async () => {
+        await router.invalidate();
+      },
+    },
+  });
+
+  function reorderChapters(chapterIds: string[]) {
+    mutation.mutate({ data: { chapterIds } });
+  }
+
+  return {
+    reorderChapters,
+    isReordering: mutation.isPending,
+  };
+}

--- a/ayunis-core-frontend/src/pages/super-admin-settings/academy/api/useReorderLessons.ts
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/academy/api/useReorderLessons.ts
@@ -14,6 +14,9 @@ export function useReorderLessons() {
   const router = useRouter();
   const mutation = useSuperAdminAcademyLessonsControllerReorderLessons({
     mutation: {
+      // Serialize reorder requests so a slower earlier request cannot finish
+      // after a newer one and overwrite the latest order on the server.
+      scope: { id: 'reorder-academy-lessons' },
       onSuccess: async () => {
         await queryClient.invalidateQueries({
           queryKey: getSuperAdminAcademyChaptersControllerGetChaptersQueryKey(),

--- a/ayunis-core-frontend/src/pages/super-admin-settings/academy/api/useReorderLessons.ts
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/academy/api/useReorderLessons.ts
@@ -1,0 +1,52 @@
+import { useQueryClient } from '@tanstack/react-query';
+import { useRouter } from '@tanstack/react-router';
+import { useTranslation } from 'react-i18next';
+import { showError } from '@/shared/lib/toast';
+import {
+  useSuperAdminAcademyLessonsControllerReorderLessons,
+  getSuperAdminAcademyChaptersControllerGetChaptersQueryKey,
+} from '@/shared/api';
+import extractErrorData from '@/shared/api/extract-error-data';
+
+export function useReorderLessons() {
+  const { t } = useTranslation('super-admin-settings-academy');
+  const queryClient = useQueryClient();
+  const router = useRouter();
+  const mutation = useSuperAdminAcademyLessonsControllerReorderLessons({
+    mutation: {
+      onSuccess: async () => {
+        await queryClient.invalidateQueries({
+          queryKey: getSuperAdminAcademyChaptersControllerGetChaptersQueryKey(),
+        });
+      },
+      onError: (error: unknown) => {
+        try {
+          const { code } = extractErrorData(error);
+          if (code === 'CHAPTER_NOT_FOUND') {
+            showError(t('toast.chapterNotFound'));
+          } else {
+            showError(t('toast.reorderError'));
+          }
+        } catch {
+          showError(t('toast.reorderError'));
+        }
+        // Re-sync the optimistic local order with the server state
+        void queryClient.invalidateQueries({
+          queryKey: getSuperAdminAcademyChaptersControllerGetChaptersQueryKey(),
+        });
+      },
+      onSettled: async () => {
+        await router.invalidate();
+      },
+    },
+  });
+
+  function reorderLessons(chapterId: string, lessonIds: string[]) {
+    mutation.mutate({ chapterId, data: { lessonIds } });
+  }
+
+  return {
+    reorderLessons,
+    isReordering: mutation.isPending,
+  };
+}

--- a/ayunis-core-frontend/src/pages/super-admin-settings/academy/lib/sortOrder.ts
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/academy/lib/sortOrder.ts
@@ -1,0 +1,17 @@
+import { arrayMove } from '@dnd-kit/sortable';
+
+/**
+ * Moves the item with `activeId` to the position of the item with `overId`.
+ * Returns null when nothing changes (unknown ids or same position).
+ */
+export function moveById<T extends { id: string }>(
+  items: T[],
+  activeId: string,
+  overId: string,
+): T[] | null {
+  if (activeId === overId) return null;
+  const oldIndex = items.findIndex((item) => item.id === activeId);
+  const newIndex = items.findIndex((item) => item.id === overId);
+  if (oldIndex === -1 || newIndex === -1) return null;
+  return arrayMove(items, oldIndex, newIndex);
+}

--- a/ayunis-core-frontend/src/pages/super-admin-settings/academy/ui/ChapterCard.tsx
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/academy/ui/ChapterCard.tsx
@@ -1,3 +1,20 @@
+import { useState } from 'react';
+import {
+  DndContext,
+  KeyboardSensor,
+  PointerSensor,
+  closestCenter,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from '@dnd-kit/core';
+import {
+  SortableContext,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
 import { useTranslation } from 'react-i18next';
 import type {
   AcademyChapterResponseDto,
@@ -11,8 +28,10 @@ import {
   CardTitle,
 } from '@/shared/ui/shadcn/card';
 import { Button } from '@/shared/ui/shadcn/button';
-import { Pencil, Plus, Trash2 } from 'lucide-react';
+import { GripVertical, Pencil, Plus, Trash2 } from 'lucide-react';
 import { LessonItem } from './LessonItem';
+import { useReorderLessons } from '../api/useReorderLessons';
+import { moveById } from '../lib/sortOrder';
 
 interface ChapterCardProps {
   chapter: AcademyChapterResponseDto;
@@ -36,54 +55,124 @@ export function ChapterCard({
   isDeletingLesson,
 }: Readonly<ChapterCardProps>) {
   const { t } = useTranslation('super-admin-settings-academy');
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    setActivatorNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: chapter.id });
+
+  // Optimistic order during drag; re-synced whenever the loader data changes
+  const [orderedLessons, setOrderedLessons] = useState(chapter.lessons);
+  const [prevLessons, setPrevLessons] = useState(chapter.lessons);
+  if (prevLessons !== chapter.lessons) {
+    setPrevLessons(chapter.lessons);
+    setOrderedLessons(chapter.lessons);
+  }
+
+  const { reorderLessons } = useReorderLessons();
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    }),
+  );
+
+  function handleLessonDragEnd(event: DragEndEvent) {
+    const { active, over } = event;
+    if (!over) return;
+    const next = moveById(orderedLessons, String(active.id), String(over.id));
+    if (!next) return;
+    setOrderedLessons(next);
+    reorderLessons(
+      chapter.id,
+      next.map((lesson) => lesson.id),
+    );
+  }
 
   return (
-    <Card>
-      <CardHeader>
-        <div className="flex items-start justify-between gap-2">
-          <div className="space-y-1.5">
-            <CardTitle>{chapter.title}</CardTitle>
-            <CardDescription>{chapter.description}</CardDescription>
+    <div
+      ref={setNodeRef}
+      style={{
+        transform: CSS.Transform.toString(transform),
+        transition,
+      }}
+      className={isDragging ? 'z-10 opacity-60' : undefined}
+    >
+      <Card>
+        <CardHeader>
+          <div className="flex items-start justify-between gap-2">
+            <div className="flex items-start gap-1">
+              <Button
+                ref={setActivatorNodeRef}
+                variant="ghost"
+                size="icon"
+                className="cursor-grab touch-none"
+                aria-label={t('page.dragChapter')}
+                {...attributes}
+                {...listeners}
+              >
+                <GripVertical className="h-4 w-4 text-muted-foreground" />
+              </Button>
+              <div className="space-y-1.5 pt-1.5">
+                <CardTitle>{chapter.title}</CardTitle>
+                <CardDescription>{chapter.description}</CardDescription>
+              </div>
+            </div>
+            <div className="flex shrink-0 items-center gap-1">
+              <Button variant="ghost" size="icon" onClick={onEdit}>
+                <Pencil className="h-4 w-4" />
+              </Button>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="text-destructive hover:text-destructive"
+                onClick={onDelete}
+                disabled={isDeletingChapter}
+              >
+                <Trash2 className="h-4 w-4" />
+              </Button>
+            </div>
           </div>
-          <div className="flex shrink-0 items-center gap-1">
-            <Button variant="ghost" size="icon" onClick={onEdit}>
-              <Pencil className="h-4 w-4" />
-            </Button>
-            <Button
-              variant="ghost"
-              size="icon"
-              className="text-destructive hover:text-destructive"
-              onClick={onDelete}
-              disabled={isDeletingChapter}
+        </CardHeader>
+        <CardContent className="space-y-2">
+          {orderedLessons.length === 0 ? (
+            <p className="py-2 text-sm text-muted-foreground">
+              {t('page.noLessons')}
+            </p>
+          ) : (
+            <DndContext
+              sensors={sensors}
+              collisionDetection={closestCenter}
+              onDragEnd={handleLessonDragEnd}
             >
-              <Trash2 className="h-4 w-4" />
-            </Button>
-          </div>
-        </div>
-      </CardHeader>
-      <CardContent className="space-y-2">
-        {chapter.lessons.length === 0 ? (
-          <p className="py-2 text-sm text-muted-foreground">
-            {t('page.noLessons')}
-          </p>
-        ) : (
-          <div className="flex flex-col gap-2">
-            {chapter.lessons.map((lesson) => (
-              <LessonItem
-                key={lesson.id}
-                lesson={lesson}
-                onEdit={() => onEditLesson(lesson)}
-                onDelete={() => onDeleteLesson(lesson)}
-                isDeleting={isDeletingLesson}
-              />
-            ))}
-          </div>
-        )}
-        <Button variant="outline" size="sm" onClick={onAddLesson}>
-          <Plus className="h-4 w-4" />
-          {t('page.addLesson')}
-        </Button>
-      </CardContent>
-    </Card>
+              <SortableContext
+                items={orderedLessons.map((lesson) => lesson.id)}
+                strategy={verticalListSortingStrategy}
+              >
+                <div className="flex flex-col gap-2">
+                  {orderedLessons.map((lesson) => (
+                    <LessonItem
+                      key={lesson.id}
+                      lesson={lesson}
+                      onEdit={() => onEditLesson(lesson)}
+                      onDelete={() => onDeleteLesson(lesson)}
+                      isDeleting={isDeletingLesson}
+                    />
+                  ))}
+                </div>
+              </SortableContext>
+            </DndContext>
+          )}
+          <Button variant="outline" size="sm" onClick={onAddLesson}>
+            <Plus className="h-4 w-4" />
+            {t('page.addLesson')}
+          </Button>
+        </CardContent>
+      </Card>
+    </div>
   );
 }

--- a/ayunis-core-frontend/src/pages/super-admin-settings/academy/ui/ChapterCard.tsx
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/academy/ui/ChapterCard.tsx
@@ -65,15 +65,19 @@ export function ChapterCard({
     isDragging,
   } = useSortable({ id: chapter.id });
 
-  // Optimistic order during drag; re-synced whenever the loader data changes
+  const { reorderLessons, isReordering } = useReorderLessons();
+
+  // Optimistic order during drag; re-synced from loader data, except while a
+  // reorder is in flight so an unrelated refetch cannot snap back the order.
   const [orderedLessons, setOrderedLessons] = useState(chapter.lessons);
   const [prevLessons, setPrevLessons] = useState(chapter.lessons);
   if (prevLessons !== chapter.lessons) {
     setPrevLessons(chapter.lessons);
-    setOrderedLessons(chapter.lessons);
+    if (!isReordering) {
+      setOrderedLessons(chapter.lessons);
+    }
   }
 
-  const { reorderLessons } = useReorderLessons();
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
     useSensor(KeyboardSensor, {

--- a/ayunis-core-frontend/src/pages/super-admin-settings/academy/ui/LessonItem.tsx
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/academy/ui/LessonItem.tsx
@@ -1,3 +1,6 @@
+import { useSortable } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import { useTranslation } from 'react-i18next';
 import type { AcademyLessonResponseDto } from '@/shared/api';
 import {
   Item,
@@ -7,7 +10,7 @@ import {
   ItemTitle,
 } from '@/shared/ui/shadcn/item';
 import { Button } from '@/shared/ui/shadcn/button';
-import { ExternalLink, Pencil, Trash2 } from 'lucide-react';
+import { ExternalLink, GripVertical, Pencil, Trash2 } from 'lucide-react';
 
 interface LessonItemProps {
   lesson: AcademyLessonResponseDto;
@@ -22,33 +25,64 @@ export function LessonItem({
   onDelete,
   isDeleting,
 }: Readonly<LessonItemProps>) {
+  const { t } = useTranslation('super-admin-settings-academy');
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    setActivatorNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: lesson.id });
+
   return (
-    <Item variant="outline" size="sm">
-      <ItemContent>
-        <ItemTitle>{lesson.title}</ItemTitle>
-        {lesson.description && (
-          <ItemDescription>{lesson.description}</ItemDescription>
-        )}
-      </ItemContent>
-      <ItemActions>
-        <Button variant="ghost" size="icon" asChild>
-          <a href={lesson.loomUrl} target="_blank" rel="noopener noreferrer">
-            <ExternalLink className="h-4 w-4" />
-          </a>
-        </Button>
-        <Button variant="ghost" size="icon" onClick={onEdit}>
-          <Pencil className="h-4 w-4" />
-        </Button>
+    <div
+      ref={setNodeRef}
+      style={{
+        transform: CSS.Transform.toString(transform),
+        transition,
+      }}
+      className={isDragging ? 'z-10 opacity-60' : undefined}
+    >
+      <Item variant="outline" size="sm">
         <Button
+          ref={setActivatorNodeRef}
           variant="ghost"
           size="icon"
-          className="text-destructive hover:text-destructive"
-          onClick={onDelete}
-          disabled={isDeleting}
+          className="cursor-grab touch-none"
+          aria-label={t('page.dragLesson')}
+          {...attributes}
+          {...listeners}
         >
-          <Trash2 className="h-4 w-4" />
+          <GripVertical className="h-4 w-4 text-muted-foreground" />
         </Button>
-      </ItemActions>
-    </Item>
+        <ItemContent>
+          <ItemTitle>{lesson.title}</ItemTitle>
+          {lesson.description && (
+            <ItemDescription>{lesson.description}</ItemDescription>
+          )}
+        </ItemContent>
+        <ItemActions>
+          <Button variant="ghost" size="icon" asChild>
+            <a href={lesson.loomUrl} target="_blank" rel="noopener noreferrer">
+              <ExternalLink className="h-4 w-4" />
+            </a>
+          </Button>
+          <Button variant="ghost" size="icon" onClick={onEdit}>
+            <Pencil className="h-4 w-4" />
+          </Button>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="text-destructive hover:text-destructive"
+            onClick={onDelete}
+            disabled={isDeleting}
+          >
+            <Trash2 className="h-4 w-4" />
+          </Button>
+        </ItemActions>
+      </Item>
+    </div>
   );
 }

--- a/ayunis-core-frontend/src/pages/super-admin-settings/academy/ui/Page.tsx
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/academy/ui/Page.tsx
@@ -1,4 +1,18 @@
 import { useState } from 'react';
+import {
+  DndContext,
+  KeyboardSensor,
+  PointerSensor,
+  closestCenter,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from '@dnd-kit/core';
+import {
+  SortableContext,
+  sortableKeyboardCoordinates,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable';
 import { useTranslation } from 'react-i18next';
 import type {
   AcademyChapterResponseDto,
@@ -12,6 +26,8 @@ import { ChapterFormDialog } from './ChapterFormDialog';
 import { LessonFormDialog } from './LessonFormDialog';
 import { useDeleteChapter } from '../api/useDeleteChapter';
 import { useDeleteLesson } from '../api/useDeleteLesson';
+import { useReorderChapters } from '../api/useReorderChapters';
+import { moveById } from '../lib/sortOrder';
 
 interface AcademyPageProps {
   chapters: AcademyChapterResponseDto[];
@@ -32,7 +48,32 @@ export default function AcademyPage({ chapters }: Readonly<AcademyPageProps>) {
   );
   const { deleteChapter, isDeleting: isDeletingChapter } = useDeleteChapter();
   const { deleteLesson, isDeleting: isDeletingLesson } = useDeleteLesson();
+  const { reorderChapters } = useReorderChapters();
   const { confirm } = useConfirmation();
+
+  // Optimistic order during drag; re-synced whenever the loader data changes
+  const [orderedChapters, setOrderedChapters] = useState(chapters);
+  const [prevChapters, setPrevChapters] = useState(chapters);
+  if (prevChapters !== chapters) {
+    setPrevChapters(chapters);
+    setOrderedChapters(chapters);
+  }
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    }),
+  );
+
+  function handleChapterDragEnd(event: DragEndEvent) {
+    const { active, over } = event;
+    if (!over) return;
+    const next = moveById(orderedChapters, String(active.id), String(over.id));
+    if (!next) return;
+    setOrderedChapters(next);
+    reorderChapters(next.map((chapter) => chapter.id));
+  }
 
   function handleDeleteChapter(chapter: AcademyChapterResponseDto) {
     confirm({
@@ -75,7 +116,7 @@ export default function AcademyPage({ chapters }: Readonly<AcademyPageProps>) {
         </Button>
       }
     >
-      {chapters.length === 0 ? (
+      {orderedChapters.length === 0 ? (
         <div className="flex flex-col items-center justify-center space-y-2 py-10 text-center">
           <h3 className="text-lg font-semibold">{t('page.empty')}</h3>
           <p className="max-w-sm text-sm text-muted-foreground">
@@ -83,28 +124,39 @@ export default function AcademyPage({ chapters }: Readonly<AcademyPageProps>) {
           </p>
         </div>
       ) : (
-        <div className="flex flex-col gap-4">
-          {chapters.map((chapter) => (
-            <ChapterCard
-              key={chapter.id}
-              chapter={chapter}
-              onEdit={() => {
-                setEditChapter(chapter);
-                setChapterDialogOpen(true);
-              }}
-              onDelete={() => handleDeleteChapter(chapter)}
-              onAddLesson={() =>
-                setLessonDialog({ chapterId: chapter.id, lesson: null })
-              }
-              onEditLesson={(lesson) =>
-                setLessonDialog({ chapterId: chapter.id, lesson })
-              }
-              onDeleteLesson={handleDeleteLesson}
-              isDeletingChapter={isDeletingChapter}
-              isDeletingLesson={isDeletingLesson}
-            />
-          ))}
-        </div>
+        <DndContext
+          sensors={sensors}
+          collisionDetection={closestCenter}
+          onDragEnd={handleChapterDragEnd}
+        >
+          <SortableContext
+            items={orderedChapters.map((chapter) => chapter.id)}
+            strategy={verticalListSortingStrategy}
+          >
+            <div className="flex flex-col gap-4">
+              {orderedChapters.map((chapter) => (
+                <ChapterCard
+                  key={chapter.id}
+                  chapter={chapter}
+                  onEdit={() => {
+                    setEditChapter(chapter);
+                    setChapterDialogOpen(true);
+                  }}
+                  onDelete={() => handleDeleteChapter(chapter)}
+                  onAddLesson={() =>
+                    setLessonDialog({ chapterId: chapter.id, lesson: null })
+                  }
+                  onEditLesson={(lesson) =>
+                    setLessonDialog({ chapterId: chapter.id, lesson })
+                  }
+                  onDeleteLesson={handleDeleteLesson}
+                  isDeletingChapter={isDeletingChapter}
+                  isDeletingLesson={isDeletingLesson}
+                />
+              ))}
+            </div>
+          </SortableContext>
+        </DndContext>
       )}
 
       <ChapterFormDialog

--- a/ayunis-core-frontend/src/pages/super-admin-settings/academy/ui/Page.tsx
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/academy/ui/Page.tsx
@@ -48,15 +48,18 @@ export default function AcademyPage({ chapters }: Readonly<AcademyPageProps>) {
   );
   const { deleteChapter, isDeleting: isDeletingChapter } = useDeleteChapter();
   const { deleteLesson, isDeleting: isDeletingLesson } = useDeleteLesson();
-  const { reorderChapters } = useReorderChapters();
+  const { reorderChapters, isReordering } = useReorderChapters();
   const { confirm } = useConfirmation();
 
-  // Optimistic order during drag; re-synced whenever the loader data changes
+  // Optimistic order during drag; re-synced from loader data, except while a
+  // reorder is in flight so an unrelated refetch cannot snap back the order.
   const [orderedChapters, setOrderedChapters] = useState(chapters);
   const [prevChapters, setPrevChapters] = useState(chapters);
   if (prevChapters !== chapters) {
     setPrevChapters(chapters);
-    setOrderedChapters(chapters);
+    if (!isReordering) {
+      setOrderedChapters(chapters);
+    }
   }
 
   const sensors = useSensors(

--- a/ayunis-core-frontend/src/shared/locales/de/super-admin-settings-academy.json
+++ b/ayunis-core-frontend/src/shared/locales/de/super-admin-settings-academy.json
@@ -5,7 +5,9 @@
     "emptyDescription": "Erstellen Sie Ihr erstes Kapitel, um die Academy aufzubauen.",
     "addChapter": "Kapitel hinzufügen",
     "addLesson": "Lektion hinzufügen",
-    "noLessons": "Noch keine Lektionen in diesem Kapitel."
+    "noLessons": "Noch keine Lektionen in diesem Kapitel.",
+    "dragChapter": "Kapitel per Drag & Drop sortieren",
+    "dragLesson": "Lektion per Drag & Drop sortieren"
   },
   "chapterForm": {
     "createTitle": "Kapitel erstellen",

--- a/ayunis-core-frontend/src/shared/locales/en/super-admin-settings-academy.json
+++ b/ayunis-core-frontend/src/shared/locales/en/super-admin-settings-academy.json
@@ -5,7 +5,9 @@
     "emptyDescription": "Create your first chapter to start building the academy.",
     "addChapter": "Add Chapter",
     "addLesson": "Add Lesson",
-    "noLessons": "No lessons in this chapter yet."
+    "noLessons": "No lessons in this chapter yet.",
+    "dragChapter": "Drag to reorder chapter",
+    "dragLesson": "Drag to reorder lesson"
   },
   "chapterForm": {
     "createTitle": "Create Chapter",


### PR DESCRIPTION
- Drag-and-drop reordering for chapters and per-chapter lessons via
  dnd-kit with optimistic local order and server re-sync on error
- Completes the academy authoring surface: chapter/lesson CRUD,
  Loom link validation, reorder persistence

Refs: AYC-239, AYC-240

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Super-admin-only UI and content-order mutations; race handling is explicit, with no auth or broad data-model changes in this diff.
> 
> **Overview**
> Adds **drag-and-drop reordering** on the super-admin Academy page for **chapters** (top-level list) and **lessons** (within each chapter), using **dnd-kit** with grip handles, pointer/keyboard sensors, and optimistic local order.
> 
> New **`useReorderChapters`** and **`useReorderLessons`** hooks call the existing reorder APIs, **serialize** mutations per scope so out-of-order responses cannot overwrite newer order, invalidate the chapters query on success/error, show toasts on failure (including **`CHAPTER_NOT_FOUND`** for lesson reorder), and **`router.invalidate()`** on settle. Shared **`moveById`** applies reorder math from drag end events.
> 
> **`Page`**, **`ChapterCard`**, and **`LessonItem`** wire sortable contexts; local order resyncs from loader data unless a reorder is in flight. EN/DE strings add drag **aria-labels**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d46bf97afa2c820e7324f4338bd1c36c60343c37. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->