### PR TITLE
wip(provider-anthropic): add the Anthropic provider as a sibling package (AYC-148)

### DIFF
--- a/packages/provider-anthropic/.gitignore
+++ b/packages/provider-anthropic/.gitignore
@@ -1,0 +1,3 @@
+dist/
+node_modules/
+coverage/

--- a/packages/provider-anthropic/.madgerc
+++ b/packages/provider-anthropic/.madgerc
@@ -1,0 +1,7 @@
+{
+  "detectiveOptions": {
+    "ts": {
+      "skipTypeImports": true
+    }
+  }
+}

--- a/packages/provider-anthropic/.prettierrc
+++ b/packages/provider-anthropic/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "trailingComma": "all"
+}

--- a/packages/provider-anthropic/eslint.config.mjs
+++ b/packages/provider-anthropic/eslint.config.mjs
@@ -1,0 +1,84 @@
+// @ts-check
+import eslint from '@eslint/js';
+import eslintPluginPrettierRecommended from 'eslint-plugin-prettier/recommended';
+import sonarjs from 'eslint-plugin-sonarjs';
+import unusedImports from 'eslint-plugin-unused-imports';
+import globals from 'globals';
+import tseslint from 'typescript-eslint';
+
+export default tseslint.config(
+  {
+    ignores: [
+      'eslint.config.mjs',
+      '**/node_modules/**',
+      '**/dist/**',
+      '**/coverage/**',
+    ],
+  },
+  eslint.configs.recommended,
+  ...tseslint.configs.recommendedTypeChecked,
+  sonarjs.configs.recommended,
+  eslintPluginPrettierRecommended,
+  {
+    languageOptions: {
+      globals: {
+        ...globals.node,
+      },
+      ecmaVersion: 'latest',
+      sourceType: 'module',
+      parserOptions: {
+        projectService: true,
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+    plugins: {
+      'unused-imports': unusedImports,
+    },
+  },
+  {
+    rules: {
+      '@typescript-eslint/no-explicit-any': 'error',
+      '@typescript-eslint/no-floating-promises': 'error',
+      '@typescript-eslint/no-misused-promises': 'error',
+      '@typescript-eslint/require-await': 'error',
+      '@typescript-eslint/no-unnecessary-type-assertion': 'error',
+      '@typescript-eslint/switch-exhaustiveness-check': [
+        'error',
+        {
+          allowDefaultCaseForExhaustiveSwitch: true,
+          requireDefaultForNonUnion: false,
+        },
+      ],
+      '@typescript-eslint/no-duplicate-enum-values': 'error',
+      eqeqeq: 'error',
+      'unused-imports/no-unused-imports': 'error',
+      '@typescript-eslint/no-unnecessary-condition': 'warn',
+      '@typescript-eslint/prefer-nullish-coalescing': [
+        'warn',
+        { ignorePrimitives: true },
+      ],
+      '@typescript-eslint/prefer-optional-chain': 'warn',
+      '@typescript-eslint/consistent-type-imports': 'warn',
+      '@typescript-eslint/no-import-type-side-effects': 'warn',
+      'no-console': ['warn', { allow: ['warn', 'error'] }],
+    },
+  },
+  // Relaxed rules for test files
+  {
+    files: ['**/*.spec.ts'],
+    rules: {
+      '@typescript-eslint/no-explicit-any': 'off',
+      '@typescript-eslint/no-unsafe-assignment': 'off',
+      '@typescript-eslint/no-unsafe-member-access': 'off',
+      '@typescript-eslint/no-unsafe-call': 'off',
+      '@typescript-eslint/no-unsafe-return': 'off',
+      '@typescript-eslint/no-unsafe-argument': 'off',
+      '@typescript-eslint/no-floating-promises': 'off',
+      '@typescript-eslint/unbound-method': 'off',
+      '@typescript-eslint/no-non-null-assertion': 'off',
+      '@typescript-eslint/require-await': 'off',
+      '@typescript-eslint/no-unnecessary-condition': 'off',
+      'no-console': 'off',
+    },
+  },
+);

--- a/packages/provider-anthropic/knip.json
+++ b/packages/provider-anthropic/knip.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://unpkg.com/knip@latest/schema.json",
+  "entry": ["src/index.ts", "src/**/*.spec.ts"],
+  "project": ["src/**/*.ts"],
+  "ignoreDependencies": ["@ayunis/inference", "@ayunis/agent-runtime"]
+}

--- a/packages/provider-anthropic/package.json
+++ b/packages/provider-anthropic/package.json
@@ -1,0 +1,55 @@
+{
+  "name": "@ayunis/provider-anthropic",
+  "version": "0.1.0",
+  "description": "Anthropic ModelProvider for the Ayunis agent runtime",
+  "private": true,
+  "type": "module",
+  "engines": {
+    "node": ">=20"
+  },
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
+    "format": "prettier --write \"src/**/*.ts\"",
+    "deps:check": "madge --circular --extensions ts src"
+  },
+  "dependencies": {
+    "@anthropic-ai/sdk": "^0.59.0",
+    "@ayunis/inference": "workspace:*"
+  },
+  "devDependencies": {
+    "@ayunis/agent-runtime": "workspace:*",
+    "@eslint/js": "^9.18.0",
+    "@types/node": "^24.12.2",
+    "eslint": "^9.18.0",
+    "eslint-config-prettier": "^10.0.1",
+    "eslint-plugin-prettier": "^5.5.5",
+    "eslint-plugin-sonarjs": "^4.0.2",
+    "eslint-plugin-unused-imports": "^4.1.4",
+    "globals": "^16.0.0",
+    "knip": "^5.84.1",
+    "madge": "^8.0.0",
+    "prettier": "^3.8.1",
+    "tsup": "^8.3.5",
+    "typescript": "^5.7.3",
+    "typescript-eslint": "^8.60.0",
+    "vitest": "^3.2.6"
+  }
+}

--- a/packages/provider-anthropic/src/anthropic-provider.smoke.spec.ts
+++ b/packages/provider-anthropic/src/anthropic-provider.smoke.spec.ts
@@ -1,0 +1,52 @@
+import { run } from '@ayunis/agent-runtime';
+import { describe, expect, it } from 'vitest';
+
+import { anthropic } from './anthropic-provider';
+
+const apiKey = process.env.ANTHROPIC_API_KEY;
+
+/**
+ * Live smoke against the real Anthropic API. Skipped unless
+ * ANTHROPIC_API_KEY is set; excluded from CI by default. This is also the
+ * canonical host-composition example: a resolved provider handed to run().
+ */
+describe.skipIf(!apiKey)('anthropic provider (live)', () => {
+  it('streams a tool-use run end to end', async () => {
+    const model = anthropic({
+      apiKey: apiKey ?? '',
+      model: 'claude-haiku-4-5',
+      maxTokens: 1024,
+    });
+    const types: string[] = [];
+    let answer = '';
+    for await (const event of run({
+      instructions:
+        'Use the get_number tool, then answer with the number it returns.',
+      model,
+      tools: [
+        {
+          name: 'get_number',
+          description: 'Returns a secret number',
+          parameters: { type: 'object', properties: {} },
+          execute: () => 'The number is 7274.',
+        },
+      ],
+      messages: [
+        {
+          role: 'user',
+          content: [{ type: 'text', text: 'What is the number?' }],
+        },
+      ],
+    })) {
+      types.push(event.type);
+      if (event.type === 'text_delta') {
+        answer += event.delta;
+      }
+    }
+
+    expect(types).toContain('tool_call');
+    expect(types).toContain('tool_result');
+    expect(types.at(-1)).toBe('run_end');
+    expect(answer).toContain('7274');
+  }, 60_000);
+});

--- a/packages/provider-anthropic/src/anthropic-provider.ts
+++ b/packages/provider-anthropic/src/anthropic-provider.ts
@@ -1,0 +1,81 @@
+import Anthropic from '@anthropic-ai/sdk';
+import type { MessageCreateParamsStreaming } from '@anthropic-ai/sdk/resources/messages';
+
+import type {
+  ModelProvider,
+  ProviderChunk,
+  ProviderRequest,
+} from '@ayunis/inference';
+
+import { convertChunk } from './convert-chunk';
+import {
+  convertMessages,
+  convertTool,
+  convertToolChoice,
+} from './convert-request';
+
+const DEFAULT_MAX_TOKENS = 64_000;
+
+export interface AnthropicProviderOptions {
+  apiKey: string;
+  /** Anthropic model id, e.g. 'claude-sonnet-4-5'. */
+  model: string;
+  maxTokens?: number;
+  baseUrl?: string;
+  /** SDK-level retry count for transient failures. Default: 2. */
+  maxRetries?: number;
+}
+
+/**
+ * The shipped Anthropic ModelProvider. The host supplies selection and
+ * credentials; everything else (wire format, streaming, chunk parsing)
+ * lives here.
+ */
+export const anthropic = (options: AnthropicProviderOptions): ModelProvider => {
+  const client = new Anthropic({
+    apiKey: options.apiKey,
+    ...(options.baseUrl ? { baseURL: options.baseUrl } : {}),
+    ...(options.maxRetries !== undefined
+      ? { maxRetries: options.maxRetries }
+      : {}),
+  });
+  return {
+    name: `anthropic:${options.model}`,
+    stream: (request) => streamAnthropic(client, options, request),
+  };
+};
+
+async function* streamAnthropic(
+  client: Anthropic,
+  options: AnthropicProviderOptions,
+  request: ProviderRequest,
+): AsyncIterable<ProviderChunk> {
+  const params = buildParams(options, request);
+  const stream = await client.messages.create(
+    params,
+    request.signal ? { signal: request.signal } : undefined,
+  );
+  for await (const event of stream) {
+    const chunk = convertChunk(event);
+    if (chunk) {
+      yield chunk;
+    }
+  }
+}
+
+const buildParams = (
+  options: AnthropicProviderOptions,
+  request: ProviderRequest,
+): MessageCreateParamsStreaming => ({
+  model: options.model,
+  system: request.instructions,
+  messages: convertMessages(request.messages),
+  tools: request.tools.map(convertTool),
+  // Anthropic rejects tool_choice when no tools are supplied, so only send it
+  // alongside a non-empty tools array.
+  ...(request.tools.length > 0 && request.toolChoice !== undefined
+    ? { tool_choice: convertToolChoice(request.toolChoice) }
+    : {}),
+  max_tokens: options.maxTokens ?? DEFAULT_MAX_TOKENS,
+  stream: true,
+});

--- a/packages/provider-anthropic/src/convert-chunk.spec.ts
+++ b/packages/provider-anthropic/src/convert-chunk.spec.ts
@@ -1,0 +1,114 @@
+import type Anthropic from '@anthropic-ai/sdk';
+import { describe, expect, it } from 'vitest';
+
+import { convertChunk } from './convert-chunk';
+
+const event = (value: unknown): Anthropic.Messages.MessageStreamEvent =>
+  value as Anthropic.Messages.MessageStreamEvent;
+
+describe('convertChunk', () => {
+  it('converts message_start to input usage', () => {
+    expect(
+      convertChunk(
+        event({
+          type: 'message_start',
+          message: { usage: { input_tokens: 123 } },
+        }),
+      ),
+    ).toEqual({ usage: { inputTokens: 123 } });
+  });
+
+  it('converts text deltas', () => {
+    expect(
+      convertChunk(
+        event({
+          type: 'content_block_delta',
+          index: 0,
+          delta: { type: 'text_delta', text: 'Hello' },
+        }),
+      ),
+    ).toEqual({ textDelta: 'Hello' });
+  });
+
+  it('converts thinking and signature deltas', () => {
+    expect(
+      convertChunk(
+        event({
+          type: 'content_block_delta',
+          index: 0,
+          delta: { type: 'thinking_delta', thinking: 'Hmm' },
+        }),
+      ),
+    ).toEqual({ thinkingDelta: 'Hmm' });
+    expect(
+      convertChunk(
+        event({
+          type: 'content_block_delta',
+          index: 0,
+          delta: { type: 'signature_delta', signature: 'sig-1' },
+        }),
+      ),
+    ).toEqual({ thinkingSignature: 'sig-1' });
+  });
+
+  it('converts tool_use block starts to id/name deltas', () => {
+    expect(
+      convertChunk(
+        event({
+          type: 'content_block_start',
+          index: 1,
+          content_block: { type: 'tool_use', id: 'toolu_1', name: 'search' },
+        }),
+      ),
+    ).toEqual({
+      toolCallDeltas: [{ index: 1, id: 'toolu_1', name: 'search' }],
+    });
+  });
+
+  it('converts input_json deltas to argument deltas', () => {
+    expect(
+      convertChunk(
+        event({
+          type: 'content_block_delta',
+          index: 1,
+          delta: { type: 'input_json_delta', partial_json: '{"q":' },
+        }),
+      ),
+    ).toEqual({ toolCallDeltas: [{ index: 1, argumentsDelta: '{"q":' }] });
+  });
+
+  it.each([
+    ['end_turn', 'stop'],
+    ['stop_sequence', 'stop'],
+    ['max_tokens', 'length'],
+    ['tool_use', 'tool_calls'],
+    ['refusal', null],
+    [null, null],
+  ])('maps stop reason %s to %s', (stopReason, finishReason) => {
+    expect(
+      convertChunk(
+        event({
+          type: 'message_delta',
+          delta: { stop_reason: stopReason },
+          usage: { output_tokens: 7 },
+        }),
+      ),
+    ).toEqual({ finishReason, usage: { outputTokens: 7 } });
+  });
+
+  it('returns null for events without content', () => {
+    expect(convertChunk(event({ type: 'message_stop' }))).toBeNull();
+    expect(
+      convertChunk(
+        event({
+          type: 'content_block_start',
+          index: 0,
+          content_block: { type: 'thinking' },
+        }),
+      ),
+    ).toBeNull();
+    expect(
+      convertChunk(event({ type: 'content_block_stop', index: 0 })),
+    ).toBeNull();
+  });
+});

--- a/packages/provider-anthropic/src/convert-chunk.ts
+++ b/packages/provider-anthropic/src/convert-chunk.ts
@@ -1,0 +1,87 @@
+import type Anthropic from '@anthropic-ai/sdk';
+
+import type { FinishReason, ProviderChunk } from '@ayunis/inference';
+
+/**
+ * Converts one Anthropic stream event to a provider-agnostic chunk.
+ * Returns null for events that carry nothing (ping, block stops).
+ */
+export const convertChunk = (
+  event: Anthropic.Messages.MessageStreamEvent,
+): ProviderChunk | null => {
+  switch (event.type) {
+    case 'content_block_delta':
+      return convertContentBlockDelta(event);
+    case 'content_block_start':
+      return convertContentBlockStart(event);
+    case 'message_start':
+      return {
+        usage: { inputTokens: event.message.usage.input_tokens },
+      };
+    case 'message_delta':
+      return {
+        finishReason: mapStopReason(event.delta.stop_reason),
+        usage: { outputTokens: event.usage.output_tokens },
+      };
+    case 'message_stop':
+    case 'content_block_stop':
+      return null;
+  }
+};
+
+const convertContentBlockDelta = (
+  event: Anthropic.Messages.ContentBlockDeltaEvent,
+): ProviderChunk | null => {
+  switch (event.delta.type) {
+    case 'thinking_delta':
+      return { thinkingDelta: event.delta.thinking };
+    case 'signature_delta':
+      return { thinkingSignature: event.delta.signature };
+    case 'text_delta':
+      return { textDelta: event.delta.text };
+    case 'input_json_delta':
+      return {
+        toolCallDeltas: [
+          { index: event.index, argumentsDelta: event.delta.partial_json },
+        ],
+      };
+    case 'citations_delta':
+      return null;
+  }
+};
+
+const convertContentBlockStart = (
+  event: Anthropic.Messages.ContentBlockStartEvent,
+): ProviderChunk | null => {
+  if (event.content_block.type !== 'tool_use') {
+    return null;
+  }
+  return {
+    toolCallDeltas: [
+      {
+        index: event.index,
+        id: event.content_block.id,
+        name: event.content_block.name,
+      },
+    ],
+  };
+};
+
+const mapStopReason = (
+  reason: Anthropic.Messages.MessageDeltaEvent['delta']['stop_reason'],
+): FinishReason => {
+  switch (reason) {
+    case 'end_turn':
+    case 'stop_sequence':
+      return 'stop';
+    case 'max_tokens':
+      return 'length';
+    case 'tool_use':
+      return 'tool_calls';
+    case 'pause_turn':
+    case 'refusal':
+    case null:
+    default:
+      return null;
+  }
+};

--- a/packages/provider-anthropic/src/convert-request.spec.ts
+++ b/packages/provider-anthropic/src/convert-request.spec.ts
@@ -1,0 +1,200 @@
+import type { Message } from '@ayunis/inference';
+import { describe, expect, it } from 'vitest';
+
+import {
+  convertMessages,
+  convertTool,
+  convertToolChoice,
+} from './convert-request';
+
+describe('convertTool', () => {
+  it('maps the schema to Anthropic input_schema', () => {
+    expect(
+      convertTool({
+        name: 'search',
+        description: 'Searches',
+        parameters: { type: 'object', properties: {} },
+      }),
+    ).toEqual({
+      name: 'search',
+      description: 'Searches',
+      input_schema: { type: 'object', properties: {} },
+    });
+  });
+});
+
+describe('convertToolChoice', () => {
+  it('maps auto, required, and specific tool', () => {
+    expect(convertToolChoice('auto')).toEqual({ type: 'auto' });
+    expect(convertToolChoice('required')).toEqual({ type: 'any' });
+    expect(convertToolChoice({ tool: 'search' })).toEqual({
+      type: 'tool',
+      name: 'search',
+    });
+  });
+});
+
+describe('convertMessages', () => {
+  it('converts a user/assistant/tool_result conversation', () => {
+    const messages: Message[] = [
+      { role: 'user', content: [{ type: 'text', text: 'Find agents' }] },
+      {
+        role: 'assistant',
+        content: [
+          { type: 'text', text: 'Searching.' },
+          {
+            type: 'tool_use',
+            id: 'toolu_1',
+            name: 'search',
+            input: { q: 'agents' },
+          },
+        ],
+      },
+      {
+        role: 'tool_result',
+        content: [
+          {
+            type: 'tool_result',
+            toolCallId: 'toolu_1',
+            toolName: 'search',
+            result: '3 results',
+          },
+        ],
+      },
+    ];
+
+    expect(convertMessages(messages)).toEqual([
+      { role: 'user', content: [{ type: 'text', text: 'Find agents' }] },
+      {
+        role: 'assistant',
+        content: [
+          { type: 'text', text: 'Searching.' },
+          {
+            type: 'tool_use',
+            id: 'toolu_1',
+            name: 'search',
+            input: { q: 'agents' },
+          },
+        ],
+      },
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: 'toolu_1',
+            content: '3 results',
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('merges consecutive non-assistant messages into one user turn', () => {
+    const messages: Message[] = [
+      {
+        role: 'tool_result',
+        content: [
+          {
+            type: 'tool_result',
+            toolCallId: 'toolu_1',
+            toolName: 'search',
+            result: 'ok',
+          },
+        ],
+      },
+      { role: 'user', content: [{ type: 'text', text: 'Continue' }] },
+    ];
+
+    const converted = convertMessages(messages);
+    expect(converted).toHaveLength(1);
+    expect(converted[0].role).toBe('user');
+    expect(converted[0].content).toHaveLength(2);
+  });
+
+  it('marks errored tool results with is_error', () => {
+    const messages: Message[] = [
+      {
+        role: 'tool_result',
+        content: [
+          {
+            type: 'tool_result',
+            toolCallId: 'toolu_1',
+            toolName: 'search',
+            result: 'not found',
+            isError: true,
+          },
+        ],
+      },
+    ];
+
+    expect(convertMessages(messages)[0].content).toEqual([
+      {
+        type: 'tool_result',
+        tool_use_id: 'toolu_1',
+        content: 'not found',
+        is_error: true,
+      },
+    ]);
+  });
+
+  it('drops assistant turns whose content converts to nothing', () => {
+    const messages: Message[] = [
+      { role: 'user', content: [{ type: 'text', text: 'Hi' }] },
+      {
+        role: 'assistant',
+        content: [
+          { type: 'thinking', thinking: 'unsigned', id: null, signature: null },
+        ],
+      },
+      { role: 'user', content: [{ type: 'text', text: 'Still there?' }] },
+    ];
+
+    const converted = convertMessages(messages);
+    expect(converted).toHaveLength(1);
+    expect(converted[0].role).toBe('user');
+    expect(converted[0].content).toHaveLength(2);
+  });
+
+  it('replays signed thinking blocks and drops unsigned ones', () => {
+    const messages: Message[] = [
+      {
+        role: 'assistant',
+        content: [
+          { type: 'thinking', thinking: 'unsigned', id: null, signature: null },
+          {
+            type: 'thinking',
+            thinking: 'signed',
+            id: null,
+            signature: 'sig-1',
+          },
+          { type: 'text', text: 'Answer' },
+        ],
+      },
+    ];
+
+    expect(convertMessages(messages)[0].content).toEqual([
+      { type: 'thinking', thinking: 'signed', signature: 'sig-1' },
+      { type: 'text', text: 'Answer' },
+    ]);
+  });
+
+  it('throws when a non-empty history reduces to no messages', () => {
+    const messages: Message[] = [
+      {
+        role: 'assistant',
+        content: [
+          { type: 'thinking', thinking: 'unsigned', id: null, signature: null },
+        ],
+      },
+    ];
+
+    expect(() => convertMessages(messages)).toThrow(
+      'all messages converted to empty content',
+    );
+  });
+
+  it('returns an empty array for an empty history', () => {
+    expect(convertMessages([])).toEqual([]);
+  });
+});

--- a/packages/provider-anthropic/src/convert-request.ts
+++ b/packages/provider-anthropic/src/convert-request.ts
@@ -1,0 +1,131 @@
+import type Anthropic from '@anthropic-ai/sdk';
+
+import type {
+  Message,
+  MessageContent,
+  ToolChoice,
+  ToolSchema,
+} from '@ayunis/inference';
+
+type AnthropicToolChoice =
+  | Anthropic.Messages.ToolChoiceAuto
+  | Anthropic.Messages.ToolChoiceAny
+  | Anthropic.Messages.ToolChoiceTool;
+
+export const convertTool = (tool: ToolSchema): Anthropic.Tool => ({
+  name: tool.name,
+  description: tool.description,
+  input_schema: tool.parameters as Anthropic.Messages.Tool.InputSchema,
+});
+
+export const convertToolChoice = (
+  toolChoice: ToolChoice,
+): AnthropicToolChoice => {
+  if (toolChoice === 'auto') {
+    return { type: 'auto' };
+  }
+  if (toolChoice === 'required') {
+    return { type: 'any' };
+  }
+  return { type: 'tool', name: toolChoice.tool };
+};
+
+/**
+ * Converts runtime messages to Anthropic params. Consecutive non-assistant
+ * messages (user input, tool results) are merged into a single user turn —
+ * Anthropic requires alternating user/assistant roles.
+ */
+export const convertMessages = (
+  messages: readonly Message[],
+): Anthropic.MessageParam[] => {
+  const converted: Anthropic.MessageParam[] = [];
+  for (const message of messages) {
+    const next = convertMessage(message);
+    // A message can convert to nothing (e.g. an assistant turn whose only
+    // content was unsigned thinking) — Anthropic rejects empty content.
+    if (asBlocks(next.content).length === 0) {
+      continue;
+    }
+    const last = converted.at(-1);
+    if (last?.role === 'user' && next.role === 'user') {
+      last.content = [...asBlocks(last.content), ...asBlocks(next.content)];
+    } else {
+      converted.push(next);
+    }
+  }
+  // Anthropic rejects an empty messages array. If a non-empty history reduced
+  // to nothing (every turn dropped as empty content), surface a clear error
+  // rather than letting the API fail with an opaque 400.
+  if (converted.length === 0 && messages.length > 0) {
+    throw new Error(
+      'Cannot build an Anthropic request: all messages converted to empty content',
+    );
+  }
+  return converted;
+};
+
+const asBlocks = (
+  content: Anthropic.MessageParam['content'],
+): Anthropic.ContentBlockParam[] =>
+  typeof content === 'string' ? [{ type: 'text', text: content }] : content;
+
+const convertMessage = (message: Message): Anthropic.MessageParam => {
+  if (message.role === 'assistant') {
+    return {
+      role: 'assistant',
+      content: message.content
+        .map(convertAssistantContent)
+        .filter((block): block is NonNullable<typeof block> => block !== null),
+    };
+  }
+  return { role: 'user', content: message.content.map(convertUserContent) };
+};
+
+const convertAssistantContent = (
+  content: MessageContent,
+): Anthropic.ContentBlockParam | null => {
+  switch (content.type) {
+    case 'thinking':
+      // Thinking blocks without a signature cannot be replayed to Anthropic.
+      if (!content.signature) {
+        return null;
+      }
+      return {
+        type: 'thinking',
+        thinking: content.thinking,
+        signature: content.signature,
+      };
+    case 'text':
+      return { type: 'text', text: content.text };
+    case 'tool_use':
+      return {
+        type: 'tool_use',
+        id: content.id,
+        name: content.name,
+        input: content.input,
+      };
+    case 'tool_result':
+      return null;
+  }
+};
+
+const convertUserContent = (
+  content: MessageContent,
+): Anthropic.ContentBlockParam => {
+  switch (content.type) {
+    case 'tool_result':
+      return {
+        type: 'tool_result',
+        tool_use_id: content.toolCallId,
+        content: content.result,
+        ...(content.isError ? { is_error: true } : {}),
+      };
+    case 'text':
+    case 'thinking':
+    case 'tool_use':
+      return {
+        type: 'text',
+        text: content.type === 'text' ? content.text : '',
+      };
+  }
+};

--- a/packages/provider-anthropic/src/index.ts
+++ b/packages/provider-anthropic/src/index.ts
@@ -1,0 +1,1 @@
+export { anthropic, type AnthropicProviderOptions } from './anthropic-provider';

--- a/packages/provider-anthropic/tsconfig.json
+++ b/packages/provider-anthropic/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "target": "ES2023",
+    "lib": ["ES2023"],
+    "strict": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["src", "vitest.config.ts", "tsup.config.ts"]
+}

--- a/packages/provider-anthropic/tsup.config.ts
+++ b/packages/provider-anthropic/tsup.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  dts: true,
+  sourcemap: true,
+  clean: true,
+  target: 'es2023',
+});

--- a/packages/provider-anthropic/vitest.config.ts
+++ b/packages/provider-anthropic/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/**/*.spec.ts'],
+    passWithNoTests: true,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -726,6 +726,64 @@ importers:
         specifier: ^3.2.6
         version: 3.2.6(@types/debug@4.1.13)(@types/node@24.13.2)(jiti@2.7.0)(jsdom@26.1.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
 
+  packages/provider-anthropic:
+    dependencies:
+      '@anthropic-ai/sdk':
+        specifier: ^0.59.0
+        version: 0.59.0
+      '@ayunis/inference':
+        specifier: workspace:*
+        version: link:../inference
+    devDependencies:
+      '@ayunis/agent-runtime':
+        specifier: workspace:*
+        version: link:../agent-runtime
+      '@eslint/js':
+        specifier: ^9.18.0
+        version: 9.39.4
+      '@types/node':
+        specifier: ^24.12.2
+        version: 24.13.2
+      eslint:
+        specifier: ^9.18.0
+        version: 9.39.4(jiti@2.7.0)
+      eslint-config-prettier:
+        specifier: ^10.0.1
+        version: 10.1.8(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-prettier:
+        specifier: ^5.5.5
+        version: 5.5.6(@types/eslint@9.6.1)(eslint-config-prettier@10.1.8(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))(prettier@3.8.3)
+      eslint-plugin-sonarjs:
+        specifier: ^4.0.2
+        version: 4.0.3(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-unused-imports:
+        specifier: ^4.1.4
+        version: 4.4.1(@typescript-eslint/eslint-plugin@8.60.0(@typescript-eslint/parser@8.60.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))
+      globals:
+        specifier: ^16.0.0
+        version: 16.5.0
+      knip:
+        specifier: ^5.84.1
+        version: 5.88.1(@types/node@24.13.2)(typescript@5.9.3)
+      madge:
+        specifier: ^8.0.0
+        version: 8.0.0(typescript@5.9.3)
+      prettier:
+        specifier: ^3.8.1
+        version: 3.8.3
+      tsup:
+        specifier: ^8.3.5
+        version: 8.5.1(@swc/core@1.15.40)(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.3
+      typescript-eslint:
+        specifier: ^8.60.0
+        version: 8.60.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      vitest:
+        specifier: ^3.2.6
+        version: 3.2.6(@types/debug@4.1.13)(@types/node@24.13.2)(jiti@2.7.0)(jsdom@26.1.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+
 packages:
 
   '@angular-devkit/core@19.2.24':


### PR DESCRIPTION
New @ayunis/provider-anthropic package holding the Anthropic ModelProvider, its request/chunk converters, and unit tests, moved out of the runtime. It depends on @ayunis/inference for the contracts and on @anthropic-ai/sdk for the wire format; the runtime is no longer involved at build time. The live smoke spec depends on @ayunis/agent-runtime (devDependency) and doubles as the canonical host-composition example: a resolved provider handed to run(). knip ignores the two workspace deps since they are consumed only through type-only re-exports and the skipped smoke spec.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly additive package extraction with well-tested converters; runtime integration is opt-in via host wiring, and live API tests are skipped without credentials.
> 
> **Overview**
> Introduces **`@ayunis/provider-anthropic`**, a standalone package that implements the **`ModelProvider`** port from **`@ayunis/inference`** using **`@anthropic-ai/sdk`**. Hosts call **`anthropic({ apiKey, model, … })`** and pass the result into the runtime; the package owns streaming, request shaping, and chunk normalization.
> 
> The **`anthropic()`** factory opens a streaming **`messages.create`** call (optional **`AbortSignal`**, configurable **`baseUrl`** / **`maxRetries`**, default **`max_tokens`**) and maps SDK events to **`ProviderChunk`** via **`convertChunk`**. **`convert-request`** maps runtime messages/tools/tool choice to Anthropic wire format, including merging consecutive user/tool-result turns, replaying signed thinking blocks, omitting **`tool_choice`** when there are no tools, and throwing if history collapses to empty content.
> 
> Coverage includes unit tests for converters, package build/lint tooling, **`pnpm-lock`** workspace entry, and an optional live smoke spec ( **`ANTHROPIC_API_KEY`** ) that wires the provider through **`run()`** from **`@ayunis/agent-runtime`** as a composition example.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27e35157b422ad461b90bf9c5821318f96cdb6b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->