### PR TITLE
wip(provider-openai): add a minimal OpenAI Chat Completions provider (AYC-148)

### DIFF
--- a/packages/provider-openai/.gitignore
+++ b/packages/provider-openai/.gitignore
@@ -1,0 +1,3 @@
+dist/
+node_modules/
+coverage/

--- a/packages/provider-openai/.madgerc
+++ b/packages/provider-openai/.madgerc
@@ -1,0 +1,7 @@
+{
+  "detectiveOptions": {
+    "ts": {
+      "skipTypeImports": true
+    }
+  }
+}

--- a/packages/provider-openai/.prettierrc
+++ b/packages/provider-openai/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "trailingComma": "all"
+}

--- a/packages/provider-openai/eslint.config.mjs
+++ b/packages/provider-openai/eslint.config.mjs
@@ -1,0 +1,84 @@
+// @ts-check
+import eslint from '@eslint/js';
+import eslintPluginPrettierRecommended from 'eslint-plugin-prettier/recommended';
+import sonarjs from 'eslint-plugin-sonarjs';
+import unusedImports from 'eslint-plugin-unused-imports';
+import globals from 'globals';
+import tseslint from 'typescript-eslint';
+
+export default tseslint.config(
+  {
+    ignores: [
+      'eslint.config.mjs',
+      '**/node_modules/**',
+      '**/dist/**',
+      '**/coverage/**',
+    ],
+  },
+  eslint.configs.recommended,
+  ...tseslint.configs.recommendedTypeChecked,
+  sonarjs.configs.recommended,
+  eslintPluginPrettierRecommended,
+  {
+    languageOptions: {
+      globals: {
+        ...globals.node,
+      },
+      ecmaVersion: 'latest',
+      sourceType: 'module',
+      parserOptions: {
+        projectService: true,
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+    plugins: {
+      'unused-imports': unusedImports,
+    },
+  },
+  {
+    rules: {
+      '@typescript-eslint/no-explicit-any': 'error',
+      '@typescript-eslint/no-floating-promises': 'error',
+      '@typescript-eslint/no-misused-promises': 'error',
+      '@typescript-eslint/require-await': 'error',
+      '@typescript-eslint/no-unnecessary-type-assertion': 'error',
+      '@typescript-eslint/switch-exhaustiveness-check': [
+        'error',
+        {
+          allowDefaultCaseForExhaustiveSwitch: true,
+          requireDefaultForNonUnion: false,
+        },
+      ],
+      '@typescript-eslint/no-duplicate-enum-values': 'error',
+      eqeqeq: 'error',
+      'unused-imports/no-unused-imports': 'error',
+      '@typescript-eslint/no-unnecessary-condition': 'warn',
+      '@typescript-eslint/prefer-nullish-coalescing': [
+        'warn',
+        { ignorePrimitives: true },
+      ],
+      '@typescript-eslint/prefer-optional-chain': 'warn',
+      '@typescript-eslint/consistent-type-imports': 'warn',
+      '@typescript-eslint/no-import-type-side-effects': 'warn',
+      'no-console': ['warn', { allow: ['warn', 'error'] }],
+    },
+  },
+  // Relaxed rules for test files
+  {
+    files: ['**/*.spec.ts'],
+    rules: {
+      '@typescript-eslint/no-explicit-any': 'off',
+      '@typescript-eslint/no-unsafe-assignment': 'off',
+      '@typescript-eslint/no-unsafe-member-access': 'off',
+      '@typescript-eslint/no-unsafe-call': 'off',
+      '@typescript-eslint/no-unsafe-return': 'off',
+      '@typescript-eslint/no-unsafe-argument': 'off',
+      '@typescript-eslint/no-floating-promises': 'off',
+      '@typescript-eslint/unbound-method': 'off',
+      '@typescript-eslint/no-non-null-assertion': 'off',
+      '@typescript-eslint/require-await': 'off',
+      '@typescript-eslint/no-unnecessary-condition': 'off',
+      'no-console': 'off',
+    },
+  },
+);

--- a/packages/provider-openai/knip.json
+++ b/packages/provider-openai/knip.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://unpkg.com/knip@latest/schema.json",
+  "entry": ["src/index.ts", "src/**/*.spec.ts"],
+  "project": ["src/**/*.ts"],
+  "ignoreDependencies": ["@ayunis/inference"]
+}

--- a/packages/provider-openai/package.json
+++ b/packages/provider-openai/package.json
@@ -1,0 +1,54 @@
+{
+  "name": "@ayunis/provider-openai",
+  "version": "0.1.0",
+  "description": "OpenAI ModelProvider for the Ayunis agent runtime",
+  "private": true,
+  "type": "module",
+  "engines": {
+    "node": ">=20"
+  },
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
+    "format": "prettier --write \"src/**/*.ts\"",
+    "deps:check": "madge --circular --extensions ts src"
+  },
+  "dependencies": {
+    "@ayunis/inference": "workspace:*",
+    "openai": "^4.104.0"
+  },
+  "devDependencies": {
+    "@eslint/js": "^9.18.0",
+    "@types/node": "^24.12.2",
+    "eslint": "^9.18.0",
+    "eslint-config-prettier": "^10.0.1",
+    "eslint-plugin-prettier": "^5.5.5",
+    "eslint-plugin-sonarjs": "^4.0.2",
+    "eslint-plugin-unused-imports": "^4.1.4",
+    "globals": "^16.0.0",
+    "knip": "^5.84.1",
+    "madge": "^8.0.0",
+    "prettier": "^3.8.1",
+    "tsup": "^8.3.5",
+    "typescript": "^5.7.3",
+    "typescript-eslint": "^8.60.0",
+    "vitest": "^3.2.6"
+  }
+}

--- a/packages/provider-openai/src/convert-chunk.spec.ts
+++ b/packages/provider-openai/src/convert-chunk.spec.ts
@@ -1,0 +1,98 @@
+import type { ChatCompletionChunk } from 'openai/resources/chat/completions';
+import { describe, expect, it } from 'vitest';
+
+import { convertChunk } from './convert-chunk';
+
+const chunk = (value: unknown): ChatCompletionChunk =>
+  value as ChatCompletionChunk;
+
+describe('convertChunk', () => {
+  it('converts a text content delta', () => {
+    expect(
+      convertChunk(
+        chunk({ choices: [{ delta: { content: 'Hello' }, index: 0 }] }),
+      ),
+    ).toEqual({ textDelta: 'Hello' });
+  });
+
+  it('converts tool_call deltas, carrying id, name and arguments', () => {
+    expect(
+      convertChunk(
+        chunk({
+          choices: [
+            {
+              index: 0,
+              delta: {
+                tool_calls: [
+                  {
+                    index: 0,
+                    id: 'call_1',
+                    function: { name: 'search', arguments: '{"q":' },
+                  },
+                ],
+              },
+            },
+          ],
+        }),
+      ),
+    ).toEqual({
+      toolCallDeltas: [
+        { index: 0, id: 'call_1', name: 'search', argumentsDelta: '{"q":' },
+      ],
+    });
+  });
+
+  it('defaults missing tool_call fields to null', () => {
+    expect(
+      convertChunk(
+        chunk({
+          choices: [
+            {
+              index: 0,
+              delta: {
+                tool_calls: [{ index: 0, function: { arguments: 'ents"}' } }],
+              },
+            },
+          ],
+        }),
+      ),
+    ).toEqual({
+      toolCallDeltas: [
+        { index: 0, id: null, name: null, argumentsDelta: 'ents"}' },
+      ],
+    });
+  });
+
+  it.each([
+    ['stop', 'stop'],
+    ['content_filter', 'stop'],
+    ['length', 'length'],
+    ['tool_calls', 'tool_calls'],
+    ['function_call', 'tool_calls'],
+  ])('maps finish_reason %s to %s', (finishReason, expected) => {
+    expect(
+      convertChunk(
+        chunk({
+          choices: [{ index: 0, delta: {}, finish_reason: finishReason }],
+        }),
+      ),
+    ).toEqual({ finishReason: expected });
+  });
+
+  it('converts a trailing usage-only chunk', () => {
+    expect(
+      convertChunk(
+        chunk({
+          choices: [],
+          usage: { prompt_tokens: 11, completion_tokens: 22 },
+        }),
+      ),
+    ).toEqual({ usage: { inputTokens: 11, outputTokens: 22 } });
+  });
+
+  it('returns null for an empty delta chunk', () => {
+    expect(
+      convertChunk(chunk({ choices: [{ index: 0, delta: {} }] })),
+    ).toBeNull();
+  });
+});

--- a/packages/provider-openai/src/convert-chunk.ts
+++ b/packages/provider-openai/src/convert-chunk.ts
@@ -1,0 +1,64 @@
+import type { ChatCompletionChunk } from 'openai/resources/chat/completions';
+
+import type { FinishReason, ProviderChunk } from '@ayunis/inference';
+
+/**
+ * Converts one OpenAI Chat Completions stream chunk to a provider-agnostic
+ * chunk. Returns null for chunks that carry nothing usable. Usage arrives in
+ * a trailing chunk (requires stream_options.include_usage).
+ */
+export const convertChunk = (
+  chunk: ChatCompletionChunk,
+): ProviderChunk | null => {
+  const result: ProviderChunk = {};
+  let carriesSomething = false;
+
+  // A trailing usage-only chunk carries an empty choices array.
+  const choice = chunk.choices.at(0);
+  if (choice) {
+    if (choice.delta.content) {
+      result.textDelta = choice.delta.content;
+      carriesSomething = true;
+    }
+    if (choice.delta.tool_calls && choice.delta.tool_calls.length > 0) {
+      result.toolCallDeltas = choice.delta.tool_calls.map((call) => ({
+        index: call.index,
+        id: call.id ?? null,
+        name: call.function?.name ?? null,
+        argumentsDelta: call.function?.arguments ?? null,
+      }));
+      carriesSomething = true;
+    }
+    if (choice.finish_reason) {
+      result.finishReason = mapFinishReason(choice.finish_reason);
+      carriesSomething = true;
+    }
+  }
+
+  if (chunk.usage) {
+    result.usage = {
+      inputTokens: chunk.usage.prompt_tokens,
+      outputTokens: chunk.usage.completion_tokens,
+    };
+    carriesSomething = true;
+  }
+
+  return carriesSomething ? result : null;
+};
+
+const mapFinishReason = (
+  reason: NonNullable<ChatCompletionChunk.Choice['finish_reason']>,
+): FinishReason => {
+  switch (reason) {
+    case 'stop':
+    case 'content_filter':
+      return 'stop';
+    case 'length':
+      return 'length';
+    case 'tool_calls':
+    case 'function_call':
+      return 'tool_calls';
+    default:
+      return null;
+  }
+};

--- a/packages/provider-openai/src/convert-request.spec.ts
+++ b/packages/provider-openai/src/convert-request.spec.ts
@@ -1,0 +1,224 @@
+import type { Message } from '@ayunis/inference';
+import { describe, expect, it } from 'vitest';
+
+import {
+  convertMessages,
+  convertTool,
+  convertToolChoice,
+} from './convert-request';
+
+describe('convertTool', () => {
+  it('maps the schema to a strict OpenAI function tool', () => {
+    expect(
+      convertTool({
+        name: 'search',
+        description: 'Searches',
+        parameters: { type: 'object', properties: {} },
+      }),
+    ).toEqual({
+      type: 'function',
+      function: {
+        name: 'search',
+        description: 'Searches',
+        parameters: {
+          type: 'object',
+          properties: {},
+          additionalProperties: false,
+          required: [],
+        },
+        strict: true,
+      },
+    });
+  });
+
+  it('strips unsupported JSON schema format values', () => {
+    const tool = convertTool({
+      name: 'fetch',
+      description: 'Fetches a URL',
+      parameters: {
+        type: 'object',
+        properties: { url: { type: 'string', format: 'uri' } },
+      },
+    });
+    const params = tool.function.parameters as {
+      properties: { url: { format?: string } };
+      required: string[];
+    };
+    expect(params.properties.url.format).toBeUndefined();
+    expect(params.required).toEqual(['url']);
+    expect(tool.function.strict).toBe(true);
+  });
+});
+
+describe('convertToolChoice', () => {
+  it('maps auto, required, and specific tool', () => {
+    expect(convertToolChoice('auto')).toBe('auto');
+    expect(convertToolChoice('required')).toBe('required');
+    expect(convertToolChoice({ tool: 'search' })).toEqual({
+      type: 'function',
+      function: { name: 'search' },
+    });
+  });
+});
+
+describe('convertMessages', () => {
+  it('prepends instructions as a system message', () => {
+    const result = convertMessages('Be helpful', [
+      { role: 'user', content: [{ type: 'text', text: 'Hi' }] },
+    ]);
+    expect(result).toEqual([
+      { role: 'system', content: 'Be helpful' },
+      { role: 'user', content: 'Hi' },
+    ]);
+  });
+
+  it('omits the system message when instructions are empty', () => {
+    const result = convertMessages('', [
+      { role: 'user', content: [{ type: 'text', text: 'Hi' }] },
+    ]);
+    expect(result).toEqual([{ role: 'user', content: 'Hi' }]);
+  });
+
+  it('maps an in-thread system message to a system message', () => {
+    const result = convertMessages('', [
+      { role: 'system', content: [{ type: 'text', text: 'Stay terse' }] },
+      { role: 'user', content: [{ type: 'text', text: 'Hi' }] },
+    ]);
+    expect(result).toEqual([
+      { role: 'system', content: 'Stay terse' },
+      { role: 'user', content: 'Hi' },
+    ]);
+  });
+
+  it('maps assistant tool_use to tool_calls with stringified arguments', () => {
+    const messages: Message[] = [
+      {
+        role: 'assistant',
+        content: [
+          { type: 'text', text: 'Searching.' },
+          {
+            type: 'tool_use',
+            id: 'call_1',
+            name: 'search',
+            input: { q: 'agents' },
+          },
+        ],
+      },
+    ];
+
+    expect(convertMessages('', messages)).toEqual([
+      {
+        role: 'assistant',
+        content: 'Searching.',
+        tool_calls: [
+          {
+            id: 'call_1',
+            type: 'function',
+            function: { name: 'search', arguments: '{"q":"agents"}' },
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('uses null content for an assistant turn that only calls a tool', () => {
+    const messages: Message[] = [
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'tool_use',
+            id: 'call_1',
+            name: 'search',
+            input: {},
+          },
+        ],
+      },
+    ];
+
+    const result = convertMessages('', messages);
+    expect(result[0]).toMatchObject({ role: 'assistant', content: null });
+  });
+
+  it('emits one tool message per tool_result', () => {
+    const messages: Message[] = [
+      {
+        role: 'tool_result',
+        content: [
+          {
+            type: 'tool_result',
+            toolCallId: 'call_1',
+            toolName: 'search',
+            result: '3 results',
+          },
+          {
+            type: 'tool_result',
+            toolCallId: 'call_2',
+            toolName: 'lookup',
+            result: 'ok',
+          },
+        ],
+      },
+    ];
+
+    expect(convertMessages('', messages)).toEqual([
+      { role: 'tool', tool_call_id: 'call_1', content: '3 results' },
+      { role: 'tool', tool_call_id: 'call_2', content: 'ok' },
+    ]);
+  });
+
+  it('skips an assistant turn with neither text nor tool calls', () => {
+    const messages: Message[] = [
+      { role: 'user', content: [{ type: 'text', text: 'Hi' }] },
+      {
+        role: 'assistant',
+        content: [
+          { type: 'thinking', thinking: 'secret', id: null, signature: 's' },
+        ],
+      },
+      { role: 'user', content: [{ type: 'text', text: 'Still there?' }] },
+    ];
+
+    expect(convertMessages('', messages)).toEqual([
+      { role: 'user', content: 'Hi' },
+      { role: 'user', content: 'Still there?' },
+    ]);
+  });
+
+  it('marks errored tool results in the content', () => {
+    const messages: Message[] = [
+      {
+        role: 'tool_result',
+        content: [
+          {
+            type: 'tool_result',
+            toolCallId: 'call_1',
+            toolName: 'search',
+            result: 'boom',
+            isError: true,
+          },
+        ],
+      },
+    ];
+
+    expect(convertMessages('', messages)).toEqual([
+      { role: 'tool', tool_call_id: 'call_1', content: 'Error: boom' },
+    ]);
+  });
+
+  it('drops thinking content', () => {
+    const messages: Message[] = [
+      {
+        role: 'assistant',
+        content: [
+          { type: 'thinking', thinking: 'secret', id: null, signature: 's' },
+          { type: 'text', text: 'Answer' },
+        ],
+      },
+    ];
+
+    expect(convertMessages('', messages)).toEqual([
+      { role: 'assistant', content: 'Answer' },
+    ]);
+  });
+});

--- a/packages/provider-openai/src/convert-request.ts
+++ b/packages/provider-openai/src/convert-request.ts
@@ -1,0 +1,128 @@
+import type {
+  ChatCompletionAssistantMessageParam,
+  ChatCompletionMessageParam,
+  ChatCompletionMessageToolCall,
+  ChatCompletionTool,
+  ChatCompletionToolChoiceOption,
+} from 'openai/resources/chat/completions';
+
+import type {
+  Message,
+  MessageContent,
+  ToolChoice,
+  ToolSchema,
+} from '@ayunis/inference';
+
+import { normalizeSchemaForOpenAI } from './normalize-schema';
+
+export const convertTool = (tool: ToolSchema): ChatCompletionTool => ({
+  type: 'function',
+  function: {
+    name: tool.name,
+    description: tool.description,
+    // OpenAI requires strict-mode-compatible schemas (unsupported `format`
+    // values stripped, all properties required, additionalProperties false);
+    // strict tool calling is this provider's default.
+    parameters: normalizeSchemaForOpenAI(tool.parameters),
+    strict: true,
+  },
+});
+
+// OpenAI's tool_choice is inherently a string ('auto'/'required') or a named
+// tool object, so this function's return type is necessarily mixed.
+/* eslint-disable sonarjs/function-return-type */
+export const convertToolChoice = (
+  toolChoice: ToolChoice,
+): ChatCompletionToolChoiceOption => {
+  if (toolChoice === 'auto') {
+    return 'auto';
+  }
+  if (toolChoice === 'required') {
+    return 'required';
+  }
+  return { type: 'function', function: { name: toolChoice.tool } };
+};
+/* eslint-enable sonarjs/function-return-type */
+
+/**
+ * Converts the runtime request to OpenAI Chat Completions messages.
+ * `instructions` becomes a leading system message; in-thread `system` messages
+ * map to their own system message; assistant tool calls map to `tool_calls`;
+ * each runtime tool_result becomes its own `tool` message. Thinking content is
+ * dropped — Chat Completions has no replay slot for it.
+ */
+export const convertMessages = (
+  instructions: string,
+  messages: readonly Message[],
+): ChatCompletionMessageParam[] => {
+  const converted: ChatCompletionMessageParam[] = [];
+  if (instructions) {
+    converted.push({ role: 'system', content: instructions });
+  }
+  for (const message of messages) {
+    if (message.role === 'assistant') {
+      const assistant = convertAssistant(message.content);
+      // Skip assistant turns with neither text nor tool calls (e.g. a
+      // thinking-only turn, since thinking is dropped) — Chat Completions
+      // rejects an assistant message with null content and no tool_calls.
+      if (assistant.content !== null || assistant.tool_calls) {
+        converted.push(assistant);
+      }
+    } else if (message.role === 'tool_result') {
+      converted.push(...convertToolResults(message.content));
+    } else if (message.role === 'system') {
+      converted.push({ role: 'system', content: joinText(message.content) });
+    } else {
+      converted.push({ role: 'user', content: joinText(message.content) });
+    }
+  }
+  return converted;
+};
+
+const convertAssistant = (
+  content: readonly MessageContent[],
+): ChatCompletionAssistantMessageParam => {
+  const toolCalls = content
+    .filter((c): c is Extract<MessageContent, { type: 'tool_use' }> => {
+      return c.type === 'tool_use';
+    })
+    .map(
+      (c): ChatCompletionMessageToolCall => ({
+        id: c.id,
+        type: 'function',
+        function: { name: c.name, arguments: JSON.stringify(c.input) },
+      }),
+    );
+  const text = joinText(content);
+  const message: ChatCompletionAssistantMessageParam = {
+    role: 'assistant',
+    content: text || null,
+  };
+  if (toolCalls.length > 0) {
+    message.tool_calls = toolCalls;
+  }
+  return message;
+};
+
+const convertToolResults = (
+  content: readonly MessageContent[],
+): ChatCompletionMessageParam[] =>
+  content
+    .filter((c): c is Extract<MessageContent, { type: 'tool_result' }> => {
+      return c.type === 'tool_result';
+    })
+    .map((c) => ({
+      role: 'tool',
+      tool_call_id: c.toolCallId,
+      // Chat Completions tool messages have no structured error field, so fold
+      // the runtime's isError flag into the content the model sees.
+      content: c.isError ? `Error: ${c.result}` : c.result,
+    }));
+
+const joinText = (content: readonly MessageContent[]): string =>
+  content
+    .filter((c): c is Extract<MessageContent, { type: 'text' }> => {
+      return c.type === 'text';
+    })
+    .map((c) => c.text)
+    .join('');

--- a/packages/provider-openai/src/index.ts
+++ b/packages/provider-openai/src/index.ts
@@ -1,0 +1,1 @@
+export { openai, type OpenAIProviderOptions } from './openai-provider';

--- a/packages/provider-openai/src/normalize-schema.spec.ts
+++ b/packages/provider-openai/src/normalize-schema.spec.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+
+import { normalizeSchemaForOpenAI } from './normalize-schema';
+
+describe('normalizeSchemaForOpenAI', () => {
+  it('returns undefined for undefined input', () => {
+    expect(normalizeSchemaForOpenAI(undefined)).toBeUndefined();
+  });
+
+  it('adds additionalProperties:false and required for objects', () => {
+    expect(
+      normalizeSchemaForOpenAI({
+        type: 'object',
+        properties: { a: { type: 'string' }, b: { type: 'number' } },
+      }),
+    ).toEqual({
+      type: 'object',
+      additionalProperties: false,
+      required: ['a', 'b'],
+      properties: { a: { type: 'string' }, b: { type: 'number' } },
+    });
+  });
+
+  it('forces additionalProperties:false when the schema sets it to true', () => {
+    expect(
+      normalizeSchemaForOpenAI({
+        type: 'object',
+        additionalProperties: true,
+        properties: { a: { type: 'string' } },
+      }),
+    ).toEqual({
+      type: 'object',
+      additionalProperties: false,
+      required: ['a'],
+      properties: { a: { type: 'string' } },
+    });
+  });
+
+  it('normalizes object schemas that declare properties without type:object', () => {
+    expect(
+      normalizeSchemaForOpenAI({
+        properties: { a: { type: 'string' } },
+      }),
+    ).toEqual({
+      additionalProperties: false,
+      required: ['a'],
+      properties: { a: { type: 'string' } },
+    });
+  });
+
+  it('strips unsupported formats but keeps supported ones', () => {
+    expect(normalizeSchemaForOpenAI({ type: 'string', format: 'uri' })).toEqual(
+      { type: 'string' },
+    );
+    expect(
+      normalizeSchemaForOpenAI({ type: 'string', format: 'date-time' }),
+    ).toEqual({ type: 'string', format: 'date-time' });
+  });
+
+  it('recurses into array items', () => {
+    expect(
+      normalizeSchemaForOpenAI({
+        type: 'array',
+        items: { type: 'string', format: 'uri' },
+      }),
+    ).toEqual({ type: 'array', items: { type: 'string' } });
+  });
+});

--- a/packages/provider-openai/src/normalize-schema.ts
+++ b/packages/provider-openai/src/normalize-schema.ts
@@ -1,0 +1,89 @@
+import type { JsonSchema } from '@ayunis/inference';
+
+/**
+ * OpenAI only supports a subset of JSON Schema `format` values; MCP servers
+ * often emit unsupported ones (e.g. `uri`, `uri-reference`) that make the API
+ * reject the request with a 400. Anything outside this set is stripped.
+ *
+ * @see https://platform.openai.com/docs/guides/structured-outputs#supported-schemas
+ */
+const OPENAI_SUPPORTED_FORMATS = new Set([
+  'date-time',
+  'time',
+  'date',
+  'duration',
+  'email',
+  'hostname',
+  'ipv4',
+  'ipv6',
+  'uuid',
+]);
+
+/**
+ * Normalizes a tool's JSON schema for OpenAI Chat Completions tools used with
+ * `strict: true`. Strict mode requires `additionalProperties: false` on every
+ * object and every property listed in `required`; unsupported `format` values
+ * are also stripped. Recurses into properties and array items.
+ */
+export function normalizeSchemaForOpenAI(
+  schema: Record<string, unknown> | undefined,
+): JsonSchema | undefined {
+  if (!schema) return undefined;
+
+  const normalized = { ...schema };
+
+  if (
+    typeof normalized.format === 'string' &&
+    !OPENAI_SUPPORTED_FORMATS.has(normalized.format)
+  ) {
+    delete normalized.format;
+  }
+
+  normalizeObjectType(normalized);
+  normalizeProperties(normalized);
+  normalizeArrayItems(normalized);
+
+  return normalized;
+}
+
+/**
+ * Strict mode treats any schema declaring `properties` as an object, even when
+ * an explicit `type: 'object'` is omitted (common in MCP-style schemas).
+ */
+function isObjectSchema(schema: Record<string, unknown>): boolean {
+  return schema.type === 'object' || 'properties' in schema;
+}
+
+function normalizeObjectType(schema: Record<string, unknown>): void {
+  if (!isObjectSchema(schema)) return;
+  // Strict mode requires additionalProperties:false on every object — force it
+  // even when the source schema set it to `true`, which OpenAI rejects.
+  schema.additionalProperties = false;
+  if (!('properties' in schema)) {
+    schema.properties = {};
+    schema.required = [];
+  }
+}
+
+function normalizeProperties(schema: Record<string, unknown>): void {
+  if (!schema.properties || typeof schema.properties !== 'object') return;
+
+  const props = schema.properties as Record<string, Record<string, unknown>>;
+  schema.properties = Object.fromEntries(
+    Object.entries(props).map(([key, value]) => [
+      key,
+      normalizeSchemaForOpenAI(value),
+    ]),
+  );
+
+  // Strict mode requires every property to be listed in `required`. The
+  // presence of `properties` is what marks this node as an object.
+  schema.required = Object.keys(props);
+}
+
+function normalizeArrayItems(schema: Record<string, unknown>): void {
+  if (!schema.items || typeof schema.items !== 'object') return;
+  schema.items = normalizeSchemaForOpenAI(
+    schema.items as Record<string, unknown>,
+  );
+}

--- a/packages/provider-openai/src/openai-provider.ts
+++ b/packages/provider-openai/src/openai-provider.ts
@@ -1,0 +1,78 @@
+import OpenAI from 'openai';
+import type { ChatCompletionCreateParamsStreaming } from 'openai/resources/chat/completions';
+
+import type {
+  ModelProvider,
+  ProviderChunk,
+  ProviderRequest,
+} from '@ayunis/inference';
+
+import { convertChunk } from './convert-chunk';
+import {
+  convertMessages,
+  convertTool,
+  convertToolChoice,
+} from './convert-request';
+
+export interface OpenAIProviderOptions {
+  apiKey: string;
+  /** OpenAI model id, e.g. 'gpt-4.1'. */
+  model: string;
+  baseUrl?: string;
+  /** SDK-level retry count for transient failures. Default: 2. */
+  maxRetries?: number;
+}
+
+/**
+ * A minimal OpenAI Chat Completions ModelProvider. The host supplies
+ * selection and credentials. Text, tool calls, finish reason and usage are
+ * mapped; reasoning/thinking deltas are out of scope for this provider.
+ */
+export const openai = (options: OpenAIProviderOptions): ModelProvider => {
+  const client = new OpenAI({
+    apiKey: options.apiKey,
+    ...(options.baseUrl ? { baseURL: options.baseUrl } : {}),
+    ...(options.maxRetries !== undefined
+      ? { maxRetries: options.maxRetries }
+      : {}),
+  });
+  return {
+    name: `openai:${options.model}`,
+    stream: (request) => streamOpenAI(client, options, request),
+  };
+};
+
+async function* streamOpenAI(
+  client: OpenAI,
+  options: OpenAIProviderOptions,
+  request: ProviderRequest,
+): AsyncIterable<ProviderChunk> {
+  const params = buildParams(options, request);
+  const stream = await client.chat.completions.create(
+    params,
+    request.signal ? { signal: request.signal } : undefined,
+  );
+  for await (const chunk of stream) {
+    const converted = convertChunk(chunk);
+    if (converted) {
+      yield converted;
+    }
+  }
+}
+
+const buildParams = (
+  options: OpenAIProviderOptions,
+  request: ProviderRequest,
+): ChatCompletionCreateParamsStreaming => {
+  const hasTools = request.tools.length > 0;
+  return {
+    model: options.model,
+    messages: convertMessages(request.instructions, request.messages),
+    ...(hasTools ? { tools: request.tools.map(convertTool) } : {}),
+    ...(hasTools && request.toolChoice !== undefined
+      ? { tool_choice: convertToolChoice(request.toolChoice) }
+      : {}),
+    stream: true,
+    stream_options: { include_usage: true },
+  };
+};

--- a/packages/provider-openai/tsconfig.json
+++ b/packages/provider-openai/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "target": "ES2023",
+    "lib": ["ES2023"],
+    "strict": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["src", "vitest.config.ts", "tsup.config.ts"]
+}

--- a/packages/provider-openai/tsup.config.ts
+++ b/packages/provider-openai/tsup.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  dts: true,
+  sourcemap: true,
+  clean: true,
+  target: 'es2023',
+});

--- a/packages/provider-openai/vitest.config.ts
+++ b/packages/provider-openai/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/**/*.spec.ts'],
+    passWithNoTests: true,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -784,6 +784,61 @@ importers:
         specifier: ^3.2.6
         version: 3.2.6(@types/debug@4.1.13)(@types/node@24.13.2)(jiti@2.7.0)(jsdom@26.1.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
 
+  packages/provider-openai:
+    dependencies:
+      '@ayunis/inference':
+        specifier: workspace:*
+        version: link:../inference
+      openai:
+        specifier: ^4.104.0
+        version: 4.104.0(ws@8.21.0)(zod@3.25.76)
+    devDependencies:
+      '@eslint/js':
+        specifier: ^9.18.0
+        version: 9.39.4
+      '@types/node':
+        specifier: ^24.12.2
+        version: 24.13.2
+      eslint:
+        specifier: ^9.18.0
+        version: 9.39.4(jiti@2.7.0)
+      eslint-config-prettier:
+        specifier: ^10.0.1
+        version: 10.1.8(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-prettier:
+        specifier: ^5.5.5
+        version: 5.5.6(@types/eslint@9.6.1)(eslint-config-prettier@10.1.8(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))(prettier@3.8.3)
+      eslint-plugin-sonarjs:
+        specifier: ^4.0.2
+        version: 4.0.3(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-unused-imports:
+        specifier: ^4.1.4
+        version: 4.4.1(@typescript-eslint/eslint-plugin@8.60.0(@typescript-eslint/parser@8.60.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))
+      globals:
+        specifier: ^16.0.0
+        version: 16.5.0
+      knip:
+        specifier: ^5.84.1
+        version: 5.88.1(@types/node@24.13.2)(typescript@5.9.3)
+      madge:
+        specifier: ^8.0.0
+        version: 8.0.0(typescript@5.9.3)
+      prettier:
+        specifier: ^3.8.1
+        version: 3.8.3
+      tsup:
+        specifier: ^8.3.5
+        version: 8.5.1(@swc/core@1.15.40)(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.3
+      typescript-eslint:
+        specifier: ^8.60.0
+        version: 8.60.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      vitest:
+        specifier: ^3.2.6
+        version: 3.2.6(@types/debug@4.1.13)(@types/node@24.13.2)(jiti@2.7.0)(jsdom@26.1.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+
 packages:
 
   '@angular-devkit/core@19.2.24':
@@ -21477,6 +21532,21 @@ snapshots:
   onetime@5.1.2:
     dependencies:
       mimic-fn: 2.1.0
+
+  openai@4.104.0(ws@8.21.0)(zod@3.25.76):
+    dependencies:
+      '@types/node': 18.19.130
+      '@types/node-fetch': 2.6.13
+      abort-controller: 3.0.0
+      agentkeepalive: 4.6.0
+      form-data-encoder: 1.7.2
+      formdata-node: 4.4.1
+      node-fetch: 2.7.0
+    optionalDependencies:
+      ws: 8.21.0
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - encoding
 
   openai@4.104.0(ws@8.21.0)(zod@4.4.3):
     dependencies:


### PR DESCRIPTION
New @ayunis/provider-openai package: a second real vendor implemented fresh against the OpenAI Chat Completions streaming API, proving the @ayunis/inference contract is cross-vendor. It maps text, tool calls, finish reason and usage; reasoning/thinking deltas are out of scope. Mirrors the Anthropic provider's three-file shape (provider, convert-request, convert-chunk) with table-driven unit tests and no network. Depends on @ayunis/inference and openai; the runtime is not involved. It sits beside the runtime, not below it — the host composes provider plus runtime.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Greenfield library package with no runtime wiring changes; main behavioral risk is incorrect message/tool mapping or schema normalization causing OpenAI 400s or wrong agent tool loops.
> 
> **Overview**
> Introduces **`@ayunis/provider-openai`**, a new workspace package that implements the **`ModelProvider`** port from `@ayunis/inference` against OpenAI’s **Chat Completions** streaming API (via the official `openai` SDK).
> 
> The exported **`openai()`** factory wires **`stream()`** to build chat params (messages, optional strict function tools, tool choice, `stream_options.include_usage`), stream chunks, and map them through **`convertChunk`** into **`ProviderChunk`** (text deltas, tool-call deltas, finish reason, usage). **`convertMessages`** / **`convertTool`** translate runtime **`ProviderRequest`** shapes into OpenAI messages and tools; thinking content is dropped, errored tool results are prefixed in tool message text, and thinking-only assistant turns are skipped.
> 
> Tool schemas are passed through **`normalizeSchemaForOpenAI`** so **`strict: true`** tools stay API-valid (required keys, `additionalProperties: false`, unsupported `format` values stripped). Package tooling (tsup, vitest, eslint, knip) and unit tests cover converters and schema normalization; **`pnpm-lock.yaml`** picks up the new package and **`openai@4.104.0`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac603cda63c5b0785e5c2012b3420d8c072caa92. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->