### PR TITLE
wip(provider-openai): add an Azure entry point reusing the chat converters (AYC-148)

### DIFF
--- a/packages/provider-openai/src/index.ts
+++ b/packages/provider-openai/src/index.ts
@@ -1,1 +1,6 @@
-export { openai, type OpenAIProviderOptions } from './openai-provider';
+export {
+  azure,
+  openai,
+  type AzureProviderOptions,
+  type OpenAIProviderOptions,
+} from './openai-provider';

--- a/packages/provider-openai/src/openai-provider.spec.ts
+++ b/packages/provider-openai/src/openai-provider.spec.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+
+import { azure, openai } from './openai-provider';
+
+describe('openai', () => {
+  it('names the provider openai:<model> and exposes a stream function', () => {
+    const provider = openai({ apiKey: 'sk-test', model: 'gpt-4.1' });
+    expect(provider.name).toBe('openai:gpt-4.1');
+    expect(typeof provider.stream).toBe('function');
+  });
+
+  it('accepts a custom baseUrl (OpenAI-compatible endpoint)', () => {
+    const provider = openai({
+      apiKey: 'sk-test',
+      model: 'llama-3.3-70b',
+      baseUrl: 'https://api.scaleway.ai/v1',
+    });
+    expect(provider.name).toBe('openai:llama-3.3-70b');
+  });
+});
+
+describe('azure', () => {
+  it('names the provider azure:<deployment> and exposes a stream function', () => {
+    const provider = azure({
+      apiKey: 'azure-test',
+      endpoint: 'https://my-resource.openai.azure.com',
+      apiVersion: '2024-10-21',
+      model: 'gpt-4o-deployment',
+    });
+    expect(provider.name).toBe('azure:gpt-4o-deployment');
+    expect(typeof provider.stream).toBe('function');
+  });
+});

--- a/packages/provider-openai/src/openai-provider.ts
+++ b/packages/provider-openai/src/openai-provider.ts
@@ -1,4 +1,4 @@
-import OpenAI from 'openai';
+import OpenAI, { AzureOpenAI } from 'openai';
 import type { ChatCompletionCreateParamsStreaming } from 'openai/resources/chat/completions';
 
 import type {
@@ -23,6 +23,18 @@ export interface OpenAIProviderOptions {
   maxRetries?: number;
 }
 
+export interface AzureProviderOptions {
+  apiKey: string;
+  /** Azure resource endpoint, e.g. 'https://my-resource.openai.azure.com'. */
+  endpoint: string;
+  /** Azure API version, e.g. '2024-10-21'. */
+  apiVersion: string;
+  /** Azure deployment name, passed through as the model id. */
+  model: string;
+  /** SDK-level retry count for transient failures. Default: 2. */
+  maxRetries?: number;
+}
+
 /**
  * A minimal OpenAI Chat Completions ModelProvider. The host supplies
  * selection and credentials. Text, tool calls, finish reason and usage are
@@ -36,18 +48,41 @@ export const openai = (options: OpenAIProviderOptions): ModelProvider => {
       ? { maxRetries: options.maxRetries }
       : {}),
   });
-  return {
-    name: `openai:${options.model}`,
-    stream: (request) => streamOpenAI(client, options, request),
-  };
+  return createProvider(client, `openai:${options.model}`, options.model);
 };
 
-async function* streamOpenAI(
+/**
+ * Azure OpenAI ModelProvider. Same Chat Completions protocol as `openai`,
+ * only the client differs (resource endpoint + API version). `model` is the
+ * Azure deployment name.
+ */
+export const azure = (options: AzureProviderOptions): ModelProvider => {
+  const client = new AzureOpenAI({
+    apiKey: options.apiKey,
+    endpoint: options.endpoint,
+    apiVersion: options.apiVersion,
+    ...(options.maxRetries !== undefined
+      ? { maxRetries: options.maxRetries }
+      : {}),
+  });
+  return createProvider(client, `azure:${options.model}`, options.model);
+};
+
+const createProvider = (
   client: OpenAI,
-  options: OpenAIProviderOptions,
+  name: string,
+  model: string,
+): ModelProvider => ({
+  name,
+  stream: (request) => streamChat(client, model, request),
+});
+
+async function* streamChat(
+  client: OpenAI,
+  model: string,
   request: ProviderRequest,
 ): AsyncIterable<ProviderChunk> {
-  const params = buildParams(options, request);
+  const params = buildParams(model, request);
   const stream = await client.chat.completions.create(
     params,
     request.signal ? { signal: request.signal } : undefined,
@@ -61,12 +96,12 @@ async function* streamOpenAI(
 }
 
 const buildParams = (
-  options: OpenAIProviderOptions,
+  model: string,
   request: ProviderRequest,
 ): ChatCompletionCreateParamsStreaming => {
   const hasTools = request.tools.length > 0;
   return {
-    model: options.model,
+    model,
     messages: convertMessages(request.instructions, request.messages),
     ...(hasTools ? { tools: request.tools.map(convertTool) } : {}),
     ...(hasTools && request.toolChoice !== undefined


### PR DESCRIPTION
Adds azure() alongside openai() in @ayunis/provider-openai. Azure is the same OpenAI Chat Completions protocol with a different client, so it reuses the existing request/chunk converters unchanged and only swaps new OpenAI for new AzureOpenAI (endpoint + apiVersion); model is the Azure deployment name. The streaming core is extracted into a shared createProvider/streamChat so both factories share it. AzureOpenAI comes from the openai package already in deps, so no new dependency. Construction/name unit tests added; converter tests unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small additive API plus internal refactor; streaming behavior for existing `openai()` should stay equivalent with no new dependencies.
> 
> **Overview**
> Adds an **`azure()`** factory to `@ayunis/provider-openai` alongside **`openai()`**, wired through **`AzureOpenAI`** (endpoint, apiVersion, deployment as `model`) while reusing the same chat request/chunk converters.
> 
> Refactors the OpenAI path by extracting **`createProvider`** / **`streamChat`** and passing a model string into **`buildParams`** instead of full options, so both factories share one streaming implementation. Public exports now include **`azure`**, **`AzureProviderOptions`**, and the existing OpenAI symbols. Vitest covers provider naming, **`stream`**, and OpenAI **`baseUrl`** behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a39fc50bad3a03db99e3a6f67da0382a7d1239b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->