### PR TITLE
wip(provider-anthropic): add a Bedrock entry point reusing the Anthropic converters (AYC-148)

### DIFF
--- a/packages/provider-anthropic/knip.json
+++ b/packages/provider-anthropic/knip.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://unpkg.com/knip@latest/schema.json",
-  "entry": ["src/index.ts", "src/**/*.spec.ts"],
+  "entry": ["src/index.ts", "src/bedrock.ts", "src/**/*.spec.ts"],
   "project": ["src/**/*.ts"],
   "ignoreDependencies": ["@ayunis/inference", "@ayunis/agent-runtime"]
 }

--- a/packages/provider-anthropic/package.json
+++ b/packages/provider-anthropic/package.json
@@ -15,6 +15,18 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
+    },
+    "./bedrock": {
+      "types": "./dist/bedrock.d.ts",
+      "import": "./dist/bedrock.js",
+      "require": "./dist/bedrock.cjs"
+    }
+  },
+  "typesVersions": {
+    "*": {
+      "bedrock": [
+        "./dist/bedrock.d.ts"
+      ]
     }
   },
   "files": [
@@ -31,6 +43,7 @@
     "deps:check": "madge --circular --extensions ts src"
   },
   "dependencies": {
+    "@anthropic-ai/bedrock-sdk": "^0.26.4",
     "@anthropic-ai/sdk": "^0.59.0",
     "@ayunis/inference": "workspace:*"
   },

--- a/packages/provider-anthropic/src/anthropic-provider.ts
+++ b/packages/provider-anthropic/src/anthropic-provider.ts
@@ -14,7 +14,15 @@ import {
   convertToolChoice,
 } from './convert-request';
 
-const DEFAULT_MAX_TOKENS = 64_000;
+export const DEFAULT_MAX_TOKENS = 64_000;
+
+/**
+ * Any client that speaks the Anthropic Messages streaming API — the Anthropic
+ * SDK and the Bedrock SDK both satisfy this, so they share the stream core.
+ */
+export type AnthropicCompatibleClient = {
+  messages: { create: Anthropic['messages']['create'] };
+};
 
 export interface AnthropicProviderOptions {
   apiKey: string;
@@ -39,18 +47,35 @@ export const anthropic = (options: AnthropicProviderOptions): ModelProvider => {
       ? { maxRetries: options.maxRetries }
       : {}),
   });
-  return {
-    name: `anthropic:${options.model}`,
-    stream: (request) => streamAnthropic(client, options, request),
-  };
+  return createMessagesProvider(
+    client,
+    `anthropic:${options.model}`,
+    options.model,
+    options.maxTokens ?? DEFAULT_MAX_TOKENS,
+  );
 };
 
-async function* streamAnthropic(
-  client: Anthropic,
-  options: AnthropicProviderOptions,
+/**
+ * Builds a ModelProvider over any Anthropic Messages-compatible client (the
+ * Anthropic SDK, the Bedrock SDK). Shared by `anthropic` and `bedrock`.
+ */
+export const createMessagesProvider = (
+  client: AnthropicCompatibleClient,
+  name: string,
+  model: string,
+  maxTokens: number,
+): ModelProvider => ({
+  name,
+  stream: (request) => streamMessages(client, model, maxTokens, request),
+});
+
+async function* streamMessages(
+  client: AnthropicCompatibleClient,
+  model: string,
+  maxTokens: number,
   request: ProviderRequest,
 ): AsyncIterable<ProviderChunk> {
-  const params = buildParams(options, request);
+  const params = buildParams(model, maxTokens, request);
   const stream = await client.messages.create(
     params,
     request.signal ? { signal: request.signal } : undefined,
@@ -64,10 +89,11 @@ async function* streamAnthropic(
 }
 
 const buildParams = (
-  options: AnthropicProviderOptions,
+  model: string,
+  maxTokens: number,
   request: ProviderRequest,
 ): MessageCreateParamsStreaming => ({
-  model: options.model,
+  model,
   system: request.instructions,
   messages: convertMessages(request.messages),
   tools: request.tools.map(convertTool),
@@ -76,6 +102,6 @@ const buildParams = (
   ...(request.tools.length > 0 && request.toolChoice !== undefined
     ? { tool_choice: convertToolChoice(request.toolChoice) }
     : {}),
-  max_tokens: options.maxTokens ?? DEFAULT_MAX_TOKENS,
+  max_tokens: maxTokens,
   stream: true,
 });

--- a/packages/provider-anthropic/src/bedrock-provider.spec.ts
+++ b/packages/provider-anthropic/src/bedrock-provider.spec.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+
+import { bedrock, resolveAwsRegion } from './bedrock-provider';
+
+describe('bedrock', () => {
+  it('names the provider bedrock:<model> and exposes a stream function', () => {
+    const provider = bedrock({
+      model: 'anthropic.claude-sonnet-4-20250514-v1:0',
+      awsRegion: 'eu-central-1',
+      awsAccessKey: 'AKIA-test',
+      awsSecretKey: 'secret-test',
+    });
+    expect(provider.name).toBe(
+      'bedrock:anthropic.claude-sonnet-4-20250514-v1:0',
+    );
+    expect(typeof provider.stream).toBe('function');
+  });
+
+  it('constructs with region only (AWS credential chain)', () => {
+    const provider = bedrock({ model: 'anthropic.claude-3-5-haiku-v1:0' });
+    expect(provider.name).toBe('bedrock:anthropic.claude-3-5-haiku-v1:0');
+    expect(typeof provider.stream).toBe('function');
+  });
+});
+
+describe('resolveAwsRegion', () => {
+  it('prefers the explicit option over env and default', () => {
+    expect(resolveAwsRegion('eu-west-1', { AWS_REGION: 'us-west-2' })).toBe(
+      'eu-west-1',
+    );
+  });
+
+  it('falls back to AWS_REGION then AWS_DEFAULT_REGION', () => {
+    expect(resolveAwsRegion(undefined, { AWS_REGION: 'eu-central-1' })).toBe(
+      'eu-central-1',
+    );
+    expect(
+      resolveAwsRegion(undefined, { AWS_DEFAULT_REGION: 'ap-south-1' }),
+    ).toBe('ap-south-1');
+  });
+
+  it('uses us-east-1 when nothing is set', () => {
+    expect(resolveAwsRegion(undefined, {})).toBe('us-east-1');
+  });
+});

--- a/packages/provider-anthropic/src/bedrock-provider.ts
+++ b/packages/provider-anthropic/src/bedrock-provider.ts
@@ -1,0 +1,68 @@
+import AnthropicBedrock from '@anthropic-ai/bedrock-sdk';
+
+import type { ModelProvider } from '@ayunis/inference';
+
+import {
+  createMessagesProvider,
+  DEFAULT_MAX_TOKENS,
+} from './anthropic-provider';
+
+const DEFAULT_AWS_REGION = 'us-east-1';
+
+export interface BedrockProviderOptions {
+  /** Bedrock model id, e.g. 'anthropic.claude-sonnet-4-20250514-v1:0'. */
+  model: string;
+  /** AWS region. Default: 'us-east-1'. */
+  awsRegion?: string;
+  /** Static AWS access key. Omit both keys to use the AWS credential chain. */
+  awsAccessKey?: string;
+  /** Static AWS secret key. Omit both keys to use the AWS credential chain. */
+  awsSecretKey?: string;
+  maxTokens?: number;
+  /** SDK-level retry count for transient failures. Default: 2. */
+  maxRetries?: number;
+}
+
+/**
+ * Anthropic-on-Bedrock ModelProvider. Same Messages protocol as `anthropic`,
+ * so it reuses the request/chunk converters; only the client differs. With
+ * both static keys it uses them, otherwise it falls back to the AWS credential
+ * provider chain (env, instance/task role, …).
+ */
+export const bedrock = (options: BedrockProviderOptions): ModelProvider => {
+  const client = createBedrockClient(options);
+  return createMessagesProvider(
+    client,
+    `bedrock:${options.model}`,
+    options.model,
+    options.maxTokens ?? DEFAULT_MAX_TOKENS,
+  );
+};
+
+/**
+ * Resolves the AWS region: an explicit option wins, then the standard AWS
+ * region env vars, then the default — so a deployment configured purely via
+ * the environment isn't silently pinned to us-east-1.
+ */
+export const resolveAwsRegion = (
+  region: string | undefined,
+  env: Record<string, string | undefined> = process.env,
+): string =>
+  region ?? env.AWS_REGION ?? env.AWS_DEFAULT_REGION ?? DEFAULT_AWS_REGION;
+
+const createBedrockClient = (
+  options: BedrockProviderOptions,
+): AnthropicBedrock => {
+  const awsRegion = resolveAwsRegion(options.awsRegion);
+  const maxRetries =
+    options.maxRetries !== undefined ? { maxRetries: options.maxRetries } : {};
+  if (options.awsAccessKey && options.awsSecretKey) {
+    return new AnthropicBedrock({
+      awsRegion,
+      awsAccessKey: options.awsAccessKey,
+      awsSecretKey: options.awsSecretKey,
+      ...maxRetries,
+    });
+  }
+  return new AnthropicBedrock({ awsRegion, ...maxRetries });
+};

--- a/packages/provider-anthropic/src/bedrock.ts
+++ b/packages/provider-anthropic/src/bedrock.ts
@@ -1,0 +1,3 @@
+// Separate entry point so consumers that only use the Anthropic provider don't
+// load the Bedrock + AWS SDK. Import as `@ayunis/provider-anthropic/bedrock`.
+export { bedrock, type BedrockProviderOptions } from './bedrock-provider';

--- a/packages/provider-anthropic/src/index.ts
+++ b/packages/provider-anthropic/src/index.ts
@@ -1,1 +1,4 @@
+// Bedrock is a separate entry point (`@ayunis/provider-anthropic/bedrock`) so
+// importing the Anthropic provider does not pull in `@anthropic-ai/bedrock-sdk`
+// and the AWS client code at module load.
 export { anthropic, type AnthropicProviderOptions } from './anthropic-provider';

--- a/packages/provider-anthropic/tsup.config.ts
+++ b/packages/provider-anthropic/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'tsup';
 
 export default defineConfig({
-  entry: ['src/index.ts'],
+  entry: ['src/index.ts', 'src/bedrock.ts'],
   format: ['esm', 'cjs'],
   dts: true,
   sourcemap: true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -728,6 +728,9 @@ importers:
 
   packages/provider-anthropic:
     dependencies:
+      '@anthropic-ai/bedrock-sdk':
+        specifier: ^0.26.4
+        version: 0.26.4
       '@anthropic-ai/sdk':
         specifier: ^0.59.0
         version: 0.59.0


### PR DESCRIPTION
Adds bedrock() to @ayunis/provider-anthropic. Anthropic-on-Bedrock speaks the same Messages streaming protocol, so it reuses the existing request/chunk converters unchanged; only the client differs. The stream core is generalized over an AnthropicCompatibleClient type (the Anthropic SDK and the Bedrock SDK both satisfy it) and exposed via a shared createMessagesProvider. bedrock() lives in its own file so the @anthropic-ai/bedrock-sdk import is tree-shakeable for anthropic-only consumers. With both static AWS keys it uses them, otherwise it falls back to the AWS credential chain. Adds @anthropic-ai/bedrock-sdk@^0.26.4; construction/name tests added.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces AWS credential handling and a new inference path, but behavior is isolated behind a new entry point with limited refactor of the existing Anthropic provider.
> 
> **Overview**
> Adds **`bedrock()`** as a new `ModelProvider` for Anthropic models on AWS Bedrock, importable from `@ayunis/provider-anthropic/bedrock` so the main package entry does not load Bedrock/AWS SDK at startup.
> 
> The Anthropic provider’s streaming path is refactored into shared **`createMessagesProvider`** / **`streamMessages`**, typed against **`AnthropicCompatibleClient`**, so Bedrock reuses the same request/chunk converters as direct Anthropic API calls. **`bedrock()`** wires `@anthropic-ai/bedrock-sdk`, names providers `bedrock:<model>`, supports optional static AWS keys or the default credential chain, and resolves region via option → `AWS_REGION` / `AWS_DEFAULT_REGION` → `us-east-1`.
> 
> Package build and exports add a second tsup entry, `./bedrock` export map, `@anthropic-ai/bedrock-sdk` dependency, and unit tests for provider naming and region resolution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e592cb5a2de13915ad7a5ae158716698c61a7e9b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->