### PR TITLE
wip(inference): add an image message content type (AYC-148)

### DIFF
--- a/packages/inference/src/index.ts
+++ b/packages/inference/src/index.ts
@@ -1,5 +1,6 @@
 export type {
   AssistantMessage,
+  ImageContent,
   Message,
   MessageContent,
   MessageRole,

--- a/packages/inference/src/message.ts
+++ b/packages/inference/src/message.ts
@@ -35,11 +35,26 @@ export interface ToolResultContent {
   isError?: boolean;
 }
 
+/**
+ * An image supplied in an input message, already resolved to inline data.
+ * Fetching, validation and access control (storage, tenancy) are host
+ * concerns done before the message reaches a provider — providers only ever
+ * see resolved bytes.
+ */
+export interface ImageContent {
+  type: 'image';
+  /** Base64-encoded image bytes (no `data:` prefix). */
+  data: string;
+  /** MIME type, e.g. 'image/png'. */
+  mediaType: string;
+}
+
 export type MessageContent =
   | TextContent
   | ThinkingContent
   | ToolUseContent
-  | ToolResultContent;
+  | ToolResultContent
+  | ImageContent;
 
 /**
  * `system` carries an in-thread system instruction (distinct from the


### PR DESCRIPTION
Adds an ImageContent variant (type 'image' + base64 data + mediaType) to the MessageContent union. Images arrive already resolved to inline bytes; fetching, validation and access control (storage, tenancy) stay host concerns done before a message reaches a provider. This unblocks multimodal in the provider converters. The agent-runtime is unaffected: images only appear in input messages, which the loop passes through untouched.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only additive API change with no runtime or agent-loop behavior in this diff; downstream converters must handle the new variant explicitly.
> 
> **Overview**
> Extends the shared inference message model with a new **`ImageContent`** block (`type: 'image'`, base64 **`data`**, **`mediaType`**) and adds it to the **`MessageContent`** union. The type is re-exported from **`packages/inference`**.
> 
> The contract assumes images are **already resolved to inline bytes** before they hit providers; fetching, validation, and tenancy stay outside this layer so provider converters can handle multimodal input next.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fcf974fa96167fe5045bdec26f6938e10958dead. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->