### PR TITLE
wip(provider-anthropic): convert image content to base64 image blocks (AYC-148)

### DIFF
--- a/packages/provider-anthropic/src/convert-request.spec.ts
+++ b/packages/provider-anthropic/src/convert-request.spec.ts
@@ -156,6 +156,26 @@ describe('convertMessages', () => {
     expect(converted[0].content).toHaveLength(2);
   });
 
+  it('maps image content to a base64 image block', () => {
+    const messages: Message[] = [
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'What is this?' },
+          { type: 'image', data: 'aGVsbG8=', mediaType: 'image/png' },
+        ],
+      },
+    ];
+
+    expect(convertMessages(messages)[0].content).toEqual([
+      { type: 'text', text: 'What is this?' },
+      {
+        type: 'image',
+        source: { type: 'base64', media_type: 'image/png', data: 'aGVsbG8=' },
+      },
+    ]);
+  });
+
   it('replays signed thinking blocks and drops unsigned ones', () => {
     const messages: Message[] = [
       {

--- a/packages/provider-anthropic/src/convert-request.ts
+++ b/packages/provider-anthropic/src/convert-request.ts
@@ -105,6 +105,7 @@ const convertAssistantContent = (
         input: content.input,
       };
     case 'tool_result':
+    case 'image':
       return null;
   }
 };
@@ -119,6 +120,16 @@ const convertUserContent = (
         tool_use_id: content.toolCallId,
         content: content.result,
         ...(content.isError ? { is_error: true } : {}),
+      };
+    case 'image':
+      return {
+        type: 'image',
+        source: {
+          type: 'base64',
+          media_type:
+            content.mediaType as Anthropic.Base64ImageSource['media_type'],
+          data: content.data,
+        },
       };
     case 'text':
     case 'thinking':


### PR DESCRIPTION
convertUserContent now maps ImageContent to an Anthropic base64 ImageBlockParam; assistant content drops images (models don't emit them). Shared by anthropic() and bedrock() via the common converter. Unit test added.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized mapping change in the Anthropic converter with test coverage; no auth or persistence impact.
> 
> **Overview**
> User messages with **`ImageContent`** are now converted into Anthropic **`image`** blocks with a **`base64`** source (`media_type` + `data`), so multimodal prompts can reach Claude/Bedrock through the shared **`convert-request`** path.
> 
> Assistant-side conversion explicitly **drops** **`image`** blocks (same as **`tool_result`**) so model turns that accidentally include images do not get sent upstream. A unit test asserts text + image user content maps to the expected block shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a27c635efde9ad3e955655edad3c490bdbdfec6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->