### PR TITLE
wip(provider-openai): convert image content to data-URI image parts (AYC-148)

### DIFF
--- a/packages/provider-openai/src/convert-request.spec.ts
+++ b/packages/provider-openai/src/convert-request.spec.ts
@@ -206,6 +206,65 @@ describe('convertMessages', () => {
     ]);
   });
 
+  it('emits an array of content parts when a user turn has an image', () => {
+    const messages: Message[] = [
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'What is this?' },
+          { type: 'image', data: 'aGVsbG8=', mediaType: 'image/png' },
+        ],
+      },
+    ];
+
+    expect(convertMessages('', messages)).toEqual([
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'What is this?' },
+          {
+            type: 'image_url',
+            image_url: { url: 'data:image/png;base64,aGVsbG8=' },
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('keeps a plain string for text-only user turns', () => {
+    const messages: Message[] = [
+      { role: 'user', content: [{ type: 'text', text: 'Hi' }] },
+    ];
+    expect(convertMessages('', messages)).toEqual([
+      { role: 'user', content: 'Hi' },
+    ]);
+  });
+
+  it('preserves the order of image and text parts', () => {
+    const messages: Message[] = [
+      {
+        role: 'user',
+        content: [
+          { type: 'image', data: 'aGVsbG8=', mediaType: 'image/png' },
+          { type: 'text', text: 'Describe this' },
+        ],
+      },
+    ];
+
+    expect(convertMessages('', messages)).toEqual([
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'image_url',
+            image_url: { url: 'data:image/png;base64,aGVsbG8=' },
+          },
+          { type: 'text', text: 'Describe this' },
+        ],
+      },
+    ]);
+  });
+
   it('drops thinking content', () => {
     const messages: Message[] = [
       {

--- a/packages/provider-openai/src/convert-request.ts
+++ b/packages/provider-openai/src/convert-request.ts
@@ -1,9 +1,11 @@
 import type {
   ChatCompletionAssistantMessageParam,
+  ChatCompletionContentPart,
   ChatCompletionMessageParam,
   ChatCompletionMessageToolCall,
   ChatCompletionTool,
   ChatCompletionToolChoiceOption,
+  ChatCompletionUserMessageParam,
 } from 'openai/resources/chat/completions';
 
 import type {
@@ -73,10 +75,40 @@ export const convertMessages = (
     } else if (message.role === 'system') {
       converted.push({ role: 'system', content: joinText(message.content) });
     } else {
-      converted.push({ role: 'user', content: joinText(message.content) });
+      converted.push(convertUser(message.content));
     }
   }
   return converted;
+};
+
+/**
+ * A user turn is a plain string when it is text-only, or an array of content
+ * parts (text + image_url) when it carries images. Images arrive already
+ * resolved; they are emitted as base64 data URIs.
+ */
+const convertUser = (
+  content: readonly MessageContent[],
+): ChatCompletionUserMessageParam => {
+  const hasImage = content.some((c) => c.type === 'image');
+  if (!hasImage) {
+    return { role: 'user', content: joinText(content) };
+  }
+  // Preserve the original order of text and image parts (e.g. image-then-text
+  // or interleaved) rather than hoisting all text ahead of all images.
+  const parts: ChatCompletionContentPart[] = [];
+  for (const c of content) {
+    if (c.type === 'text') {
+      if (c.text) {
+        parts.push({ type: 'text', text: c.text });
+      }
+    } else if (c.type === 'image') {
+      parts.push({
+        type: 'image_url',
+        image_url: { url: `data:${c.mediaType};base64,${c.data}` },
+      });
+    }
+  }
+  return { role: 'user', content: parts };
 };
 
 const convertAssistant = (


### PR DESCRIPTION
A user turn with images now emits an array of content parts (text + image_url) with base64 data URIs; text-only turns keep the plain string form. Shared by openai() and azure() via the common converter. Unit tests added for both shapes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to message shaping in the shared OpenAI converter with tests; no auth or persistence changes, though multimodal payloads may affect request size and model compatibility.
> 
> **Overview**
> **User message conversion** now routes through `convertUser` instead of flattening everything with `joinText`. Text-only turns still become a plain string; turns that include `image` blocks become an ordered array of `text` and `image_url` parts, with images encoded as `data:{mediaType};base64,{data}` URIs.
> 
> Part order matches the runtime message (text-then-image, image-then-text, or interleaved). Empty text parts are omitted when building multimodal arrays.
> 
> Unit tests cover multimodal output, the text-only string shape, and ordering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dba0acbe522e015f1f0a6ee29c6aef4cfcb77b99. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->