### PR TITLE
fix(help-center): Correct Helpcenter Link and better tooltip description (AYC-270)

### DIFF
--- a/ayunis-core-frontend/src/shared/lib/help-center.test.ts
+++ b/ayunis-core-frontend/src/shared/lib/help-center.test.ts
@@ -16,21 +16,21 @@ describe('getHelpCenterUrl', () => {
   it('returns English URL when language is en', () => {
     mockLanguage.value = 'en';
     expect(getHelpCenterUrl('skills/')).toBe(
-      'https://docs.ayunis.com/en/skills/',
+      'https://help.ayunis.com/en/skills/',
     );
   });
 
   it('returns German URL when language is de', () => {
     mockLanguage.value = 'de';
     expect(getHelpCenterUrl('skills/')).toBe(
-      'https://docs.ayunis.com/de/skills/',
+      'https://help.ayunis.com/de/skills/',
     );
   });
 
   it('defaults to de for unknown languages', () => {
     mockLanguage.value = 'fr';
     expect(getHelpCenterUrl('skills/')).toBe(
-      'https://docs.ayunis.com/de/skills/',
+      'https://help.ayunis.com/de/skills/',
     );
   });
 });

--- a/ayunis-core-frontend/src/shared/lib/help-center.ts
+++ b/ayunis-core-frontend/src/shared/lib/help-center.ts
@@ -1,6 +1,6 @@
 import i18n from '@/i18n';
 
-export const HELP_CENTER_BASE_URL = 'https://docs.ayunis.com';
+export const HELP_CENTER_BASE_URL = 'https://help.ayunis.com';
 
 export function getHelpCenterUrl(path: string): string {
   const locale = i18n.language === 'en' ? 'en' : 'de';

--- a/ayunis-core-frontend/src/shared/locales/de/common.json
+++ b/ayunis-core-frontend/src/shared/locales/de/common.json
@@ -86,6 +86,7 @@
     "recordingNotSupported": "Sprachaufnahme wird in diesem Browser nicht unterstützt",
     "transcriptionFailed": "Transkription fehlgeschlagen",
     "modelSelectorAriaLabel": "KI-Modell auswählen",
+    "modelChangeDisabledTooltip": "Das Modell kann in einem bestehenden Chat nicht mehr gewechselt werden.",
     "deactivateSkillTooltip": "Fähigkeit deaktivieren"
   },
   "pinnedSkills": {

--- a/ayunis-core-frontend/src/shared/locales/en/common.json
+++ b/ayunis-core-frontend/src/shared/locales/en/common.json
@@ -86,6 +86,7 @@
     "recordingNotSupported": "Voice recording is not supported in this browser",
     "transcriptionFailed": "Transcription failed",
     "modelSelectorAriaLabel": "Select AI model",
+    "modelChangeDisabledTooltip": "The model can't be changed in an existing chat.",
     "deactivateSkillTooltip": "Deactivate skill"
   },
   "pinnedSkills": {


### PR DESCRIPTION
Zwei kleine, unabhängige Frontend-Fixes (bewusst in einem PR gebündelt).

## 1. Helpcenter-Link vereinheitlichen (AYC-270)

Der Helpcenter-Link zeigte auf `docs.ayunis.com` und verweist jetzt einheitlich auf `help.ayunis.com`.

- `HELP_CENTER_BASE_URL` in `ayunis-core-frontend/src/shared/lib/help-center.ts` angepasst
- Test-Assertions in `help-center.test.ts` aktualisiert (3/3 grün)

## 2. Fehlender Tooltip im Chat-Input (AYC-269)

In einem bestehenden Chat ist der Modell-Wechsel deaktiviert; der Tooltip zeigte den rohen i18n-Key `chatInput.modelChangeDisabledTooltip` an, weil die Übersetzung in keiner `common.json` existierte.

- Key in `de/common.json` und `en/common.json` ergänzt
  - DE: „Das Modell kann in einem bestehenden Chat nicht mehr gewechselt werden."
  - EN: „The model can't be changed in an existing chat."

## Verifikation

- Locale-JSON valide, Keys lösen korrekt auf
- Tooltip-Fix visuell auf localhost geprüft
- Pre-commit-Checks (Prettier, ESLint, TypeScript, Dependency-/Duplication-/File-Size) grün

## Tickets

- AYC-270 — https://linear.app/ayunis/issue/AYC-270
- AYC-269 — https://linear.app/ayunis/issue/AYC-269

🤖 Generated with [Claude Code](https://claude.com/claude-code)
