### PR TITLE
feat(anonymization): de-anonymize PII tokens at export egress points (AYC-290)

### DIFF
--- a/ayunis-core-backend/src/common/anonymization/domain/deanonymize-text.spec.ts
+++ b/ayunis-core-backend/src/common/anonymization/domain/deanonymize-text.spec.ts
@@ -1,0 +1,39 @@
+import { deanonymizeText } from './deanonymize-text';
+
+describe('deanonymizeText', () => {
+  it('replaces known tokens with their values', () => {
+    const map = new Map([
+      ['{{pii:PERSON_NAME_1}}', 'Max Mustermann'],
+      ['{{pii:EMAIL_ADDRESS_1}}', 'max@example.de'],
+    ]);
+    expect(
+      deanonymizeText(
+        'Hallo {{pii:PERSON_NAME_1}}, schreib an {{pii:EMAIL_ADDRESS_1}}',
+        map,
+      ),
+    ).toBe('Hallo Max Mustermann, schreib an max@example.de');
+  });
+
+  it('leaves unknown tokens as literal text', () => {
+    const map = new Map([['{{pii:PERSON_NAME_1}}', 'Max']]);
+    expect(deanonymizeText('{{pii:LOCATION_2}}', map)).toBe(
+      '{{pii:LOCATION_2}}',
+    );
+  });
+
+  it('is a no-op when there are no tokens', () => {
+    const map = new Map([['{{pii:PERSON_NAME_1}}', 'Max']]);
+    expect(deanonymizeText('plain text', map)).toBe('plain text');
+  });
+
+  it('replaces repeated occurrences of the same token', () => {
+    const map = new Map([['{{pii:PERSON_NAME_1}}', 'Max']]);
+    expect(
+      deanonymizeText('{{pii:PERSON_NAME_1}} und {{pii:PERSON_NAME_1}}', map),
+    ).toBe('Max und Max');
+  });
+
+  it('does not touch legacy bracket placeholders', () => {
+    expect(deanonymizeText('Hallo [PERSON]', new Map())).toBe('Hallo [PERSON]');
+  });
+});

--- a/ayunis-core-backend/src/common/anonymization/domain/deanonymize-text.ts
+++ b/ayunis-core-backend/src/common/anonymization/domain/deanonymize-text.ts
@@ -1,0 +1,21 @@
+/**
+ * Matches anonymization placeholder tokens like `{{pii:PERSON_NAME_1}}`. Mirrors
+ * the format produced by `formatPiiToken` / `ThreadPiiMask.token`.
+ */
+const PII_TOKEN_REGEX = /\{\{pii:[A-Z][A-Z0-9_]*_\d+\}\}/g;
+
+/**
+ * Replaces every `{{pii:...}}` token with its original value from the thread's
+ * mask dictionary. Unknown tokens are left as the literal token text. Use this
+ * at egress points (e.g. document export) where the resolved value is needed;
+ * stored content stays anonymized.
+ */
+export function deanonymizeText(
+  text: string,
+  tokenToValue: ReadonlyMap<string, string>,
+): string {
+  return text.replace(
+    PII_TOKEN_REGEX,
+    (token) => tokenToValue.get(token) ?? token,
+  );
+}

--- a/ayunis-core-backend/src/domain/artifacts/application/use-cases/export-artifact/export-artifact.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/artifacts/application/use-cases/export-artifact/export-artifact.use-case.spec.ts
@@ -18,6 +18,9 @@ import { DownloadObjectUseCase } from 'src/domain/storage/application/use-cases/
 import { DownloadObjectCommand } from 'src/domain/storage/application/use-cases/download-object/download-object.command';
 import { Letterhead } from 'src/domain/letterheads/domain/letterhead.entity';
 import { LetterheadNotFoundError } from 'src/domain/letterheads/application/letterheads.errors';
+import { GetThreadPiiMasksUseCase } from 'src/domain/thread-pii-masks/application/use-cases/get-thread-pii-masks/get-thread-pii-masks.use-case';
+import { ThreadPiiMask } from 'src/domain/thread-pii-masks/domain/thread-pii-mask.entity';
+import { PiiCategory } from 'src/common/anonymization/domain/pii-category.enum';
 
 function createBufferStream(buf: Buffer): NodeJS.ReadableStream {
   const readable = new Readable();
@@ -32,6 +35,7 @@ describe('ExportArtifactUseCase', () => {
   let documentExportPort: jest.Mocked<DocumentExportPort>;
   let findLetterheadUseCase: jest.Mocked<FindLetterheadUseCase>;
   let downloadObjectUseCase: jest.Mocked<DownloadObjectUseCase>;
+  let getThreadPiiMasksUseCase: jest.Mocked<GetThreadPiiMasksUseCase>;
 
   const mockUserId = '123e4567-e89b-12d3-a456-426614174000' as UUID;
   const mockOrgId = '423e4567-e89b-12d3-a456-426614174000' as UUID;
@@ -71,6 +75,10 @@ describe('ExportArtifactUseCase', () => {
       execute: jest.fn(),
     };
 
+    const mockGetThreadPiiMasks = {
+      execute: jest.fn().mockResolvedValue([]),
+    };
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         ExportArtifactUseCase,
@@ -79,6 +87,7 @@ describe('ExportArtifactUseCase', () => {
         { provide: ContextService, useValue: mockContextService },
         { provide: FindLetterheadUseCase, useValue: mockFindLetterhead },
         { provide: DownloadObjectUseCase, useValue: mockDownloadObject },
+        { provide: GetThreadPiiMasksUseCase, useValue: mockGetThreadPiiMasks },
       ],
     }).compile();
 
@@ -87,6 +96,7 @@ describe('ExportArtifactUseCase', () => {
     documentExportPort = module.get(DocumentExportPort);
     findLetterheadUseCase = module.get(FindLetterheadUseCase);
     downloadObjectUseCase = module.get(DownloadObjectUseCase);
+    getThreadPiiMasksUseCase = module.get(GetThreadPiiMasksUseCase);
 
     jest.spyOn(Logger.prototype, 'log').mockImplementation();
     jest.spyOn(Logger.prototype, 'warn').mockImplementation();
@@ -376,6 +386,10 @@ describe('ExportArtifactUseCase', () => {
         { provide: ContextService, useValue: mockContextService },
         { provide: FindLetterheadUseCase, useValue: findLetterheadUseCase },
         { provide: DownloadObjectUseCase, useValue: downloadObjectUseCase },
+        {
+          provide: GetThreadPiiMasksUseCase,
+          useValue: getThreadPiiMasksUseCase,
+        },
       ],
     }).compile();
 
@@ -390,6 +404,68 @@ describe('ExportArtifactUseCase', () => {
 
     await expect(useCaseNoAuth.execute(command)).rejects.toThrow(
       UnauthorizedAccessError,
+    );
+  });
+
+  it('should de-anonymize PII tokens in the content before DOCX export', async () => {
+    const artifact = new DocumentArtifact({
+      id: mockArtifactId,
+      threadId: mockThreadId,
+      userId: mockUserId,
+      title: 'Anonymous Notes',
+      currentVersionNumber: 1,
+      versions: [
+        new ArtifactVersion({
+          artifactId: mockArtifactId,
+          versionNumber: 1,
+          content:
+            '<p>Kontaktieren Sie {{pii:PERSON_NAME_1}} unter {{pii:EMAIL_ADDRESS_1}}</p>',
+          authorType: AuthorType.ASSISTANT,
+        }),
+      ],
+    });
+
+    artifactsRepository.findByIdWithVersions.mockResolvedValue(artifact);
+    documentExportPort.exportToDocx.mockResolvedValue(Buffer.from('docx'));
+    getThreadPiiMasksUseCase.execute.mockResolvedValue([
+      new ThreadPiiMask({
+        threadId: mockThreadId,
+        category: PiiCategory.PERSON_NAME,
+        maskIndex: 1,
+        value: 'Max Mustermann',
+      }),
+      new ThreadPiiMask({
+        threadId: mockThreadId,
+        category: PiiCategory.EMAIL_ADDRESS,
+        maskIndex: 1,
+        value: 'max@example.de',
+      }),
+    ]);
+
+    await useCase.execute(
+      new ExportArtifactCommand({ artifactId: mockArtifactId, format: 'docx' }),
+    );
+
+    expect(getThreadPiiMasksUseCase.execute).toHaveBeenCalledWith(
+      expect.objectContaining({ threadId: mockThreadId }),
+    );
+    expect(documentExportPort.exportToDocx).toHaveBeenCalledWith(
+      '<p>Kontaktieren Sie Max Mustermann unter max@example.de</p>',
+    );
+  });
+
+  it('should leave content unchanged when the thread has no PII masks', async () => {
+    const artifact = createArtifact();
+    artifactsRepository.findByIdWithVersions.mockResolvedValue(artifact);
+    documentExportPort.exportToDocx.mockResolvedValue(Buffer.from('docx'));
+    getThreadPiiMasksUseCase.execute.mockResolvedValue([]);
+
+    await useCase.execute(
+      new ExportArtifactCommand({ artifactId: mockArtifactId, format: 'docx' }),
+    );
+
+    expect(documentExportPort.exportToDocx).toHaveBeenCalledWith(
+      '<p>Meeting notes content</p>',
     );
   });
 

--- a/ayunis-core-backend/src/domain/artifacts/application/use-cases/export-artifact/export-artifact.use-case.ts
+++ b/ayunis-core-backend/src/domain/artifacts/application/use-cases/export-artifact/export-artifact.use-case.ts
@@ -21,6 +21,9 @@ import { FindLetterheadQuery } from 'src/domain/letterheads/application/use-case
 import { DownloadObjectUseCase } from 'src/domain/storage/application/use-cases/download-object/download-object.use-case';
 import { DownloadObjectCommand } from 'src/domain/storage/application/use-cases/download-object/download-object.command';
 import type { Letterhead } from 'src/domain/letterheads/domain/letterhead.entity';
+import { GetThreadPiiMasksUseCase } from 'src/domain/thread-pii-masks/application/use-cases/get-thread-pii-masks/get-thread-pii-masks.use-case';
+import { GetThreadPiiMasksQuery } from 'src/domain/thread-pii-masks/application/use-cases/get-thread-pii-masks/get-thread-pii-masks.query';
+import { deanonymizeText } from 'src/common/anonymization/domain/deanonymize-text';
 
 export interface ExportResult {
   buffer: Buffer;
@@ -38,6 +41,7 @@ export class ExportArtifactUseCase {
     private readonly contextService: ContextService,
     private readonly findLetterheadUseCase: FindLetterheadUseCase,
     private readonly downloadObjectUseCase: DownloadObjectUseCase,
+    private readonly getThreadPiiMasksUseCase: GetThreadPiiMasksUseCase,
   ) {}
 
   async execute(command: ExportArtifactCommand): Promise<ExportResult> {
@@ -58,12 +62,16 @@ export class ExportArtifactUseCase {
       );
       const currentVersion = this.requireCurrentVersion(artifact);
       const safeTitle = this.buildSafeTitle(artifact.title);
+      const content = await this.deanonymizeContent(
+        artifact.threadId,
+        currentVersion.content,
+      );
 
       if (command.format === 'docx') {
-        return await this.exportDocx(currentVersion.content, safeTitle);
+        return await this.exportDocx(content, safeTitle);
       }
 
-      return await this.exportPdf(artifact, currentVersion.content, safeTitle);
+      return await this.exportPdf(artifact, content, safeTitle);
     } catch (error) {
       if (error instanceof ApplicationError) {
         throw error;
@@ -107,6 +115,25 @@ export class ExportArtifactUseCase {
       );
     }
     return currentVersion;
+  }
+
+  /**
+   * Replaces `{{pii:...}}` tokens in the artifact content with the thread's
+   * original values so the exported file is de-anonymized. Stored content stays
+   * masked; this resolution happens only at export egress.
+   */
+  private async deanonymizeContent(
+    threadId: UUID,
+    content: string,
+  ): Promise<string> {
+    const masks = await this.getThreadPiiMasksUseCase.execute(
+      new GetThreadPiiMasksQuery(threadId),
+    );
+    if (masks.length === 0) {
+      return content;
+    }
+    const tokenToValue = new Map(masks.map((mask) => [mask.token, mask.value]));
+    return deanonymizeText(content, tokenToValue);
   }
 
   private buildSafeTitle(title: string): string {

--- a/ayunis-core-backend/src/domain/artifacts/artifacts.module.ts
+++ b/ayunis-core-backend/src/domain/artifacts/artifacts.module.ts
@@ -10,6 +10,7 @@ import { ArtifactDtoMapper } from './presenters/http/mappers/artifact-dto.mapper
 import { ThreadsModule } from 'src/domain/threads/threads.module';
 import { LetterheadsModule } from 'src/domain/letterheads/letterheads.module';
 import { StorageModule } from 'src/domain/storage/storage.module';
+import { ThreadPiiMasksModule } from 'src/domain/thread-pii-masks/thread-pii-masks.module';
 
 // Use cases
 import { CreateArtifactUseCase } from './application/use-cases/create-artifact/create-artifact.use-case';
@@ -26,6 +27,7 @@ import { ApplyEditsToArtifactUseCase } from './application/use-cases/apply-edits
     forwardRef(() => ThreadsModule),
     LetterheadsModule,
     StorageModule,
+    ThreadPiiMasksModule,
   ],
   controllers: [ArtifactsController],
   providers: [

--- a/ayunis-core-frontend/src/pages/chat/ui/chat-widgets/SendEmailWidget.tsx
+++ b/ayunis-core-frontend/src/pages/chat/ui/chat-widgets/SendEmailWidget.tsx
@@ -7,6 +7,7 @@ import { Textarea } from '@/shared/ui/shadcn/textarea';
 import { Button } from '@/shared/ui/shadcn/button';
 import { Mail } from 'lucide-react';
 import { cn } from '@/shared/lib/shadcn/utils';
+import { usePiiMasks, resolvePiiTokens } from '@/widgets/markdown';
 
 export default function SendEmailWidget({
   content,
@@ -32,6 +33,9 @@ export default function SendEmailWidget({
   const [body, setBody] = useState<string>(initialBody);
   const [to, setTo] = useState<string>(initialTo);
   const [copied, setCopied] = useState<boolean>(false);
+  // Mask dictionary so egress (clipboard, mailto) emits original values while
+  // the on-screen fields keep showing `{{pii:...}}` tokens.
+  const masks = usePiiMasks();
 
   // Update state when params change (for streaming updates)
   useEffect(() => {
@@ -44,24 +48,27 @@ export default function SendEmailWidget({
   }, [params.subject, params.body, params.to, content.id]);
 
   const mailtoHref = useMemo(() => {
-    const mailtoPath = to ? encodeURIComponent(to) : '';
+    const resolvedTo = resolvePiiTokens(to, masks);
+    const resolvedSubject = resolvePiiTokens(subject, masks);
+    const resolvedBody = resolvePiiTokens(body, masks);
+    const mailtoPath = resolvedTo ? encodeURIComponent(resolvedTo) : '';
 
     // Normalize line breaks, then force CRLF in the percent-encoded output for maximum client compatibility
-    const normalizedBody = (body || '').replace(/\r\n|\r|\n/g, '\n');
+    const normalizedBody = (resolvedBody || '').replace(/\r\n|\r|\n/g, '\n');
     const encodedBodyWithCrlf = encodeURIComponent(normalizedBody).replace(
       /%0A/g,
       '%0D%0A',
     );
     const queryParams: string[] = [];
-    if ((subject || '').length > 0) {
-      queryParams.push(`subject=${encodeURIComponent(subject)}`);
+    if ((resolvedSubject || '').length > 0) {
+      queryParams.push(`subject=${encodeURIComponent(resolvedSubject)}`);
     }
     if (normalizedBody.length > 0) {
       queryParams.push(`body=${encodedBodyWithCrlf}`);
     }
     const query = queryParams.length > 0 ? `?${queryParams.join('&')}` : '';
     return `mailto:${mailtoPath}${query}`;
-  }, [subject, body, to]);
+  }, [subject, body, to, masks]);
 
   return (
     <div
@@ -126,7 +133,9 @@ export default function SendEmailWidget({
           onClick={() => {
             void (async () => {
               try {
-                await navigator.clipboard.writeText(body);
+                await navigator.clipboard.writeText(
+                  resolvePiiTokens(body, masks),
+                );
                 setCopied(true);
                 setTimeout(() => setCopied(false), 1200);
               } catch {

--- a/ayunis-core-frontend/src/widgets/diagram-viewer/ui/DiagramExportButtons.tsx
+++ b/ayunis-core-frontend/src/widgets/diagram-viewer/ui/DiagramExportButtons.tsx
@@ -3,6 +3,8 @@ import { Download } from 'lucide-react';
 import { useCallback, type RefObject } from 'react';
 import { useTranslation } from 'react-i18next';
 import { showError } from '@/shared/lib/toast';
+import { usePiiMasks, resolvePiiTokens } from '@/widgets/markdown';
+import type { PiiMaskEntry } from '@/widgets/markdown';
 
 interface DiagramExportButtonsProps {
   readonly containerRef: RefObject<HTMLDivElement | null>;
@@ -43,8 +45,39 @@ function computeSvgDimensions(svg: SVGSVGElement): {
   return { width, height };
 }
 
-function svgToDataUrl(svg: SVGSVGElement, width: number, height: number) {
+/**
+ * Replaces `{{pii:...}}` tokens with their original values in every text node of
+ * the (cloned) SVG, so exported files carry real values while the on-screen
+ * viewer stays masked. A token wrapped across multiple <tspan>s won't match, but
+ * tokens are short single words so this is unlikely.
+ */
+function deanonymizeSvgText(
+  root: SVGSVGElement,
+  masks: ReadonlyMap<string, PiiMaskEntry>,
+): void {
+  if (masks.size === 0) return;
+  const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+  let node = walker.nextNode();
+  while (node) {
+    const text = node.textContent;
+    if (text) {
+      const resolved = resolvePiiTokens(text, masks);
+      if (resolved !== text) {
+        node.textContent = resolved;
+      }
+    }
+    node = walker.nextNode();
+  }
+}
+
+function svgToDataUrl(
+  svg: SVGSVGElement,
+  width: number,
+  height: number,
+  masks: ReadonlyMap<string, PiiMaskEntry>,
+) {
   const cloned = svg.cloneNode(true) as SVGSVGElement;
+  deanonymizeSvgText(cloned, masks);
   if (!cloned.getAttribute('xmlns')) {
     cloned.setAttribute('xmlns', 'http://www.w3.org/2000/svg');
   }
@@ -91,22 +124,25 @@ export function DiagramExportButtons({
   fileName,
 }: DiagramExportButtonsProps) {
   const { t } = useTranslation('artifacts');
+  const masks = usePiiMasks();
 
   const handleSvgExport = useCallback(() => {
     const svg = containerRef.current?.querySelector('svg');
     if (!svg) return;
+    const cloned = svg.cloneNode(true) as SVGSVGElement;
+    deanonymizeSvgText(cloned, masks);
     const serializer = new XMLSerializer();
-    const svgString = serializer.serializeToString(svg);
+    const svgString = serializer.serializeToString(cloned);
     const blob = new Blob([svgString], { type: 'image/svg+xml' });
     triggerDownload(blob, `${safeTitle(fileName)}.svg`);
-  }, [containerRef, fileName]);
+  }, [containerRef, fileName, masks]);
 
   const handlePngExport = useCallback(() => {
     const svg = containerRef.current?.querySelector('svg');
     if (!svg) return;
 
     const { width, height } = computeSvgDimensions(svg);
-    const svgDataUrl = svgToDataUrl(svg, width, height);
+    const svgDataUrl = svgToDataUrl(svg, width, height, masks);
     const fail = () => showError(t('diagram.export.failed'));
 
     const img = new Image();
@@ -123,7 +159,7 @@ export function DiagramExportButtons({
     };
     img.onerror = fail;
     img.src = svgDataUrl;
-  }, [containerRef, fileName, t]);
+  }, [containerRef, fileName, t, masks]);
 
   return (
     <>

--- a/ayunis-core-frontend/src/widgets/markdown/index.ts
+++ b/ayunis-core-frontend/src/widgets/markdown/index.ts
@@ -3,3 +3,4 @@ export { default as CodeBlock } from './ui/Codeblock';
 export { default as PiiText } from './ui/PiiText';
 export { PiiMaskProvider, usePiiMasks } from './model/pii-mask-context';
 export type { PiiMaskEntry } from './model/pii-mask-context';
+export { resolvePiiTokens } from './lib/pii-token';

--- a/ayunis-core-frontend/src/widgets/markdown/lib/pii-token.test.ts
+++ b/ayunis-core-frontend/src/widgets/markdown/lib/pii-token.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { splitPiiTokens, containsPiiToken } from './pii-token';
+import {
+  splitPiiTokens,
+  containsPiiToken,
+  resolvePiiTokens,
+} from './pii-token';
 
 describe('splitPiiTokens', () => {
   it('returns a single text part when there are no tokens', () => {
@@ -52,5 +56,31 @@ describe('containsPiiToken', () => {
     expect(containsPiiToken('a {{pii:PERSON_NAME_1}} b')).toBe(true);
     expect(containsPiiToken('a {{pii:PERSON_NAME_1}} b')).toBe(true);
     expect(containsPiiToken('plain text')).toBe(false);
+  });
+});
+
+describe('resolvePiiTokens', () => {
+  const masks = new Map([
+    ['{{pii:PERSON_NAME_1}}', { value: 'Max Mustermann' }],
+    ['{{pii:EMAIL_ADDRESS_1}}', { value: 'max@example.de' }],
+  ]);
+
+  it('replaces every known token with its value', () => {
+    expect(
+      resolvePiiTokens(
+        'Hallo {{pii:PERSON_NAME_1}}, schreib an {{pii:EMAIL_ADDRESS_1}}',
+        masks,
+      ),
+    ).toBe('Hallo Max Mustermann, schreib an max@example.de');
+  });
+
+  it('leaves unknown tokens as literal text', () => {
+    expect(resolvePiiTokens('{{pii:LOCATION_2}}', masks)).toBe(
+      '{{pii:LOCATION_2}}',
+    );
+  });
+
+  it('returns the input unchanged when there are no tokens', () => {
+    expect(resolvePiiTokens('plain text', masks)).toBe('plain text');
   });
 });

--- a/ayunis-core-frontend/src/widgets/markdown/lib/pii-token.ts
+++ b/ayunis-core-frontend/src/widgets/markdown/lib/pii-token.ts
@@ -32,3 +32,19 @@ export function containsPiiToken(text: string): boolean {
   PII_TOKEN_REGEX.lastIndex = 0;
   return PII_TOKEN_REGEX.test(text);
 }
+
+/**
+ * Replaces every `{{pii:...}}` token with its original value from the thread's
+ * mask dictionary. Unknown tokens are left as the literal token text. Use this
+ * at egress points (clipboard, mailto, file export) where the resolved value is
+ * needed — display surfaces should keep rendering tokens via the mask context.
+ */
+export function resolvePiiTokens(
+  text: string,
+  masks: ReadonlyMap<string, { value: string }>,
+): string {
+  return text.replace(
+    PII_TOKEN_REGEX,
+    (token) => masks.get(token)?.value ?? token,
+  );
+}


### PR DESCRIPTION
Anonymous threads store only {{pii:...}} tokens; several egress points
emitted them raw, producing broken emails and exports.

- Add resolvePiiTokens (frontend) and deanonymizeText (backend) helpers
- Email widget: resolve to/subject/body at clipboard copy and mailto only
- Document export: resolve tokens via GetThreadPiiMasksUseCase before
  DOCX/PDF conversion
- Diagram export: clone SVG and rewrite token text nodes before serialize
- On-screen widget/viewer content stays masked; stored content unchanged

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Egress paths now emit real PII from thread masks (clipboard, mailto, file downloads); behavior is intentional but increases exposure if masks are wrong or accessed inappropriately.
> 
> **Overview**
> Anonymous threads keep `{{pii:...}}` placeholders in stored content and on-screen UI; several **egress** paths were still emitting those tokens, so exports and email actions were unusable. This PR resolves tokens only at those boundaries and leaves persistence and display masked.
> 
> **Backend:** Adds `deanonymizeText` and wires `ExportArtifactUseCase` to load thread PII masks via `GetThreadPiiMasksUseCase` before DOCX/PDF conversion. **Frontend:** Adds `resolvePiiTokens` (exported from the markdown widget) and uses the existing `usePiiMasks` context in the send-email widget (mailto + copy body) and diagram SVG/PNG export (clone SVG, rewrite text nodes before serialize).
> 
> Unit tests cover the new helpers and export de-anonymization behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72f6535a7e141a953f324f4e2432ea746a079712. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->