### PR TITLE
feat(academy): add user-facing academy page gated by org add-on (AYC-238)

### DIFF
--- a/ayunis-core-backend/src/domain/academy/academy.module.ts
+++ b/ayunis-core-backend/src/domain/academy/academy.module.ts
@@ -18,6 +18,7 @@ import { DeleteLessonUseCase } from './application/use-cases/delete-lesson/delet
 import { ReorderLessonsUseCase } from './application/use-cases/reorder-lessons/reorder-lessons.use-case';
 import { SuperAdminAcademyChaptersController } from './presenters/http/super-admin-academy-chapters.controller';
 import { SuperAdminAcademyLessonsController } from './presenters/http/super-admin-academy-lessons.controller';
+import { AcademyChaptersController } from './presenters/http/academy-chapters.controller';
 import { AcademyResponseDtoMapper } from './presenters/http/mappers/academy-response-dto.mapper';
 
 @Module({
@@ -25,6 +26,7 @@ import { AcademyResponseDtoMapper } from './presenters/http/mappers/academy-resp
     TypeOrmModule.forFeature([AcademyChapterRecord, AcademyLessonRecord]),
   ],
   controllers: [
+    AcademyChaptersController,
     SuperAdminAcademyChaptersController,
     SuperAdminAcademyLessonsController,
   ],

--- a/ayunis-core-backend/src/domain/academy/presenters/http/academy-chapters.controller.ts
+++ b/ayunis-core-backend/src/domain/academy/presenters/http/academy-chapters.controller.ts
@@ -1,0 +1,49 @@
+import { Controller, Get, HttpCode, HttpStatus, Logger } from '@nestjs/common';
+import {
+  ApiInternalServerErrorResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiTags,
+  ApiUnauthorizedResponse,
+} from '@nestjs/swagger';
+import { RequireAddon } from 'src/iam/authorization/application/decorators/addon.decorator';
+import { AddonType } from 'src/iam/addons/domain/value-objects/addon-type.enum';
+import { GetAcademyContentUseCase } from '../../application/use-cases/get-academy-content/get-academy-content.use-case';
+import { GetAcademyContentQuery } from '../../application/use-cases/get-academy-content/get-academy-content.query';
+import { AcademyChapterResponseDto } from './dto/academy-chapter-response.dto';
+import { AcademyResponseDtoMapper } from './mappers/academy-response-dto.mapper';
+
+@ApiTags('Academy')
+@Controller('academy/chapters')
+@RequireAddon(AddonType.AYUNIS_CORE_ACADEMY)
+export class AcademyChaptersController {
+  private readonly logger = new Logger(AcademyChaptersController.name);
+
+  constructor(
+    private readonly getAcademyContentUseCase: GetAcademyContentUseCase,
+    private readonly responseMapper: AcademyResponseDtoMapper,
+  ) {}
+
+  @Get()
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Get all academy chapters with their lessons',
+    description:
+      'Retrieve all chapters with nested lessons, ordered by position. Requires the academy add-on to be active for the organization.',
+  })
+  @ApiOkResponse({
+    description: 'Successfully retrieved academy chapters',
+    type: [AcademyChapterResponseDto],
+  })
+  @ApiUnauthorizedResponse({
+    description: 'User not authenticated or academy add-on not active',
+  })
+  @ApiInternalServerErrorResponse({ description: 'Internal server error' })
+  async getChapters(): Promise<AcademyChapterResponseDto[]> {
+    this.logger.log('Getting academy chapters');
+    const chapters = await this.getAcademyContentUseCase.execute(
+      new GetAcademyContentQuery(),
+    );
+    return this.responseMapper.chapterToDtoArray(chapters);
+  }
+}

--- a/ayunis-core-backend/src/iam/addons/addons.module.ts
+++ b/ayunis-core-backend/src/iam/addons/addons.module.ts
@@ -8,12 +8,14 @@ import { PostgresOrgAddonRepository } from './infrastructure/persistence/postgre
 import { ListOrgAddonsUseCase } from './application/use-cases/list-org-addons/list-org-addons.use-case';
 import { ActivateAddonUseCase } from './application/use-cases/activate-addon/activate-addon.use-case';
 import { DeactivateAddonUseCase } from './application/use-cases/deactivate-addon/deactivate-addon.use-case';
+import { IsAddonActiveUseCase } from './application/use-cases/is-addon-active/is-addon-active.use-case';
 
 import { SuperAdminAddonsController } from './presenters/http/super-admin-addons.controller';
+import { AddonsController } from './presenters/http/addons.controller';
 
 @Module({
   imports: [TypeOrmModule.forFeature([OrgAddonRecord])],
-  controllers: [SuperAdminAddonsController],
+  controllers: [SuperAdminAddonsController, AddonsController],
   providers: [
     {
       provide: OrgAddonRepository,
@@ -22,8 +24,9 @@ import { SuperAdminAddonsController } from './presenters/http/super-admin-addons
     ListOrgAddonsUseCase,
     ActivateAddonUseCase,
     DeactivateAddonUseCase,
+    IsAddonActiveUseCase,
   ],
   // Exported so future feature modules can gate behavior on active add-ons.
-  exports: [ListOrgAddonsUseCase],
+  exports: [ListOrgAddonsUseCase, IsAddonActiveUseCase],
 })
 export class AddonsModule {}

--- a/ayunis-core-backend/src/iam/addons/application/use-cases/is-addon-active/is-addon-active.query.ts
+++ b/ayunis-core-backend/src/iam/addons/application/use-cases/is-addon-active/is-addon-active.query.ts
@@ -1,0 +1,9 @@
+import type { UUID } from 'crypto';
+import type { AddonType } from '../../../domain/value-objects/addon-type.enum';
+
+export class IsAddonActiveQuery {
+  constructor(
+    public readonly orgId: UUID,
+    public readonly type: AddonType,
+  ) {}
+}

--- a/ayunis-core-backend/src/iam/addons/application/use-cases/is-addon-active/is-addon-active.use-case.ts
+++ b/ayunis-core-backend/src/iam/addons/application/use-cases/is-addon-active/is-addon-active.use-case.ts
@@ -1,0 +1,33 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ApplicationError } from 'src/common/errors/base.error';
+import { OrgAddonRepository } from '../../ports/org-addon.repository';
+import { UnexpectedAddonError } from '../../addons.errors';
+import { IsAddonActiveQuery } from './is-addon-active.query';
+
+@Injectable()
+export class IsAddonActiveUseCase {
+  private readonly logger = new Logger(IsAddonActiveUseCase.name);
+
+  constructor(private readonly orgAddonRepository: OrgAddonRepository) {}
+
+  async execute(query: IsAddonActiveQuery): Promise<boolean> {
+    this.logger.log('Checking if addon is active', {
+      orgId: query.orgId,
+      type: query.type,
+    });
+
+    try {
+      const addon = await this.orgAddonRepository.findByOrgAndType(
+        query.orgId,
+        query.type,
+      );
+      return addon !== null;
+    } catch (error) {
+      if (error instanceof ApplicationError) throw error;
+      this.logger.error('Error checking if addon is active', {
+        error: error as Error,
+      });
+      throw new UnexpectedAddonError('check', { error: error as Error });
+    }
+  }
+}

--- a/ayunis-core-backend/src/iam/addons/presenters/http/addons.controller.ts
+++ b/ayunis-core-backend/src/iam/addons/presenters/http/addons.controller.ts
@@ -1,0 +1,52 @@
+import { Controller, Get, HttpStatus, Logger } from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiUnauthorizedResponse,
+} from '@nestjs/swagger';
+import { UUID } from 'crypto';
+import {
+  CurrentUser,
+  UserProperty,
+} from 'src/iam/authentication/application/decorators/current-user.decorator';
+import { AddonType } from '../../domain/value-objects/addon-type.enum';
+import { ListOrgAddonsUseCase } from '../../application/use-cases/list-org-addons/list-org-addons.use-case';
+import { ListOrgAddonsQuery } from '../../application/use-cases/list-org-addons/list-org-addons.query';
+import { AddonStatusResponseDto } from './dto/addon-status-response.dto';
+
+@ApiTags('Addons')
+@Controller('addons')
+export class AddonsController {
+  private readonly logger = new Logger(AddonsController.name);
+
+  constructor(private readonly listOrgAddonsUseCase: ListOrgAddonsUseCase) {}
+
+  @Get()
+  @ApiOperation({
+    summary:
+      "List all add-ons with their active state for the current user's organization",
+  })
+  @ApiResponse({ status: HttpStatus.OK, type: [AddonStatusResponseDto] })
+  @ApiUnauthorizedResponse({ description: 'Not authenticated' })
+  async list(
+    @CurrentUser(UserProperty.ORG_ID) orgId: UUID,
+  ): Promise<AddonStatusResponseDto[]> {
+    this.logger.log('list', { orgId });
+
+    const statuses = await this.listOrgAddonsUseCase.execute(
+      new ListOrgAddonsQuery(orgId),
+    );
+    return statuses.map((status) => this.toDto(status));
+  }
+
+  private toDto(status: {
+    type: AddonType;
+    active: boolean;
+  }): AddonStatusResponseDto {
+    return {
+      type: status.type,
+      active: status.active,
+    };
+  }
+}

--- a/ayunis-core-backend/src/iam/authorization/application/decorators/addon.decorator.ts
+++ b/ayunis-core-backend/src/iam/authorization/application/decorators/addon.decorator.ts
@@ -1,0 +1,18 @@
+import { SetMetadata } from '@nestjs/common';
+import type { AddonType } from 'src/iam/addons/domain/value-objects/addon-type.enum';
+
+export const REQUIRE_ADDON_KEY = 'requiresAddon';
+
+/**
+ * Decorator to mark routes that require an add-on to be active for the
+ * caller's organization. Access is denied (403) when the add-on is not active.
+ *
+ * @example
+ * ```typescript
+ * @RequireAddon(AddonType.AYUNIS_CORE_ACADEMY)
+ * @Get('academy/chapters')
+ * getChapters() {}
+ * ```
+ */
+export const RequireAddon = (type: AddonType) =>
+  SetMetadata(REQUIRE_ADDON_KEY, type);

--- a/ayunis-core-backend/src/iam/authorization/application/guards/addon.guard.ts
+++ b/ayunis-core-backend/src/iam/authorization/application/guards/addon.guard.ts
@@ -1,0 +1,70 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  Injectable,
+  Logger,
+} from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { Request } from 'express';
+import type { UUID } from 'crypto';
+import { ActiveUser } from 'src/iam/authentication/domain/active-user.entity';
+import type { ApiKeyPrincipal } from 'src/iam/authentication/application/strategies/api-key.strategy';
+import { AddonType } from 'src/iam/addons/domain/value-objects/addon-type.enum';
+import { IsAddonActiveUseCase } from 'src/iam/addons/application/use-cases/is-addon-active/is-addon-active.use-case';
+import { IsAddonActiveQuery } from 'src/iam/addons/application/use-cases/is-addon-active/is-addon-active.query';
+import { REQUIRE_ADDON_KEY } from '../decorators/addon.decorator';
+
+interface RequestWithUser extends Request {
+  user?: ActiveUser | ApiKeyPrincipal;
+}
+
+@Injectable()
+export class AddonGuard implements CanActivate {
+  private readonly logger = new Logger(AddonGuard.name);
+
+  constructor(
+    private readonly reflector: Reflector,
+    private readonly isAddonActiveUseCase: IsAddonActiveUseCase,
+  ) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const requiredAddon = this.reflector.getAllAndOverride<
+      AddonType | undefined
+    >(REQUIRE_ADDON_KEY, [context.getHandler(), context.getClass()]);
+
+    if (!requiredAddon) {
+      return true;
+    }
+
+    const request = context.switchToHttp().getRequest<RequestWithUser>();
+    const orgId = this.resolveOrgId(request);
+    if (!orgId) {
+      this.logger.warn('No principal found on request when checking addon', {
+        requiredAddon,
+      });
+      return false;
+    }
+
+    const isActive = await this.isAddonActiveUseCase.execute(
+      new IsAddonActiveQuery(orgId, requiredAddon),
+    );
+    if (!isActive) {
+      this.logger.warn('Access denied: required addon not active', {
+        orgId,
+        requiredAddon,
+      });
+    }
+    return isActive;
+  }
+
+  private resolveOrgId(request: RequestWithUser): UUID | null {
+    const user = request.user as unknown;
+    if (!user || typeof user !== 'object') {
+      return null;
+    }
+    if ('orgId' in user) {
+      return (user as { orgId: UUID }).orgId;
+    }
+    return null;
+  }
+}

--- a/ayunis-core-backend/src/iam/authorization/application/guards/addon.guard.ts
+++ b/ayunis-core-backend/src/iam/authorization/application/guards/addon.guard.ts
@@ -12,6 +12,7 @@ import type { ApiKeyPrincipal } from 'src/iam/authentication/application/strateg
 import { AddonType } from 'src/iam/addons/domain/value-objects/addon-type.enum';
 import { IsAddonActiveUseCase } from 'src/iam/addons/application/use-cases/is-addon-active/is-addon-active.use-case';
 import { IsAddonActiveQuery } from 'src/iam/addons/application/use-cases/is-addon-active/is-addon-active.query';
+import { IS_PUBLIC_KEY } from 'src/common/guards/public.guard';
 import { REQUIRE_ADDON_KEY } from '../decorators/addon.decorator';
 
 interface RequestWithUser extends Request {
@@ -39,22 +40,43 @@ export class AddonGuard implements CanActivate {
     const request = context.switchToHttp().getRequest<RequestWithUser>();
     const orgId = this.resolveOrgId(request);
     if (!orgId) {
+      // On @Public() routes the global JwtAuthGuard skips, so the global
+      // AddonGuard binding runs before any controller-level auth (e.g.
+      // AuthGuard('api-key')) populates `request.user`. Defer in that case —
+      // the controller is expected to bind AddonGuard locally AFTER its auth
+      // guard so this re-runs with a principal in place.
+      const isPublic = this.reflector.getAllAndOverride<boolean>(
+        IS_PUBLIC_KEY,
+        [context.getHandler(), context.getClass()],
+      );
+      if (isPublic) {
+        return true;
+      }
       this.logger.warn('No principal found on request when checking addon', {
         requiredAddon,
       });
       return false;
     }
 
-    const isActive = await this.isAddonActiveUseCase.execute(
-      new IsAddonActiveQuery(orgId, requiredAddon),
-    );
-    if (!isActive) {
-      this.logger.warn('Access denied: required addon not active', {
+    try {
+      const isActive = await this.isAddonActiveUseCase.execute(
+        new IsAddonActiveQuery(orgId, requiredAddon),
+      );
+      if (!isActive) {
+        this.logger.warn('Access denied: required addon not active', {
+          orgId,
+          requiredAddon,
+        });
+      }
+      return isActive;
+    } catch (error) {
+      this.logger.error('Error checking addon', {
+        error: error instanceof Error ? error.message : 'Unknown error',
         orgId,
         requiredAddon,
       });
+      return false;
     }
-    return isActive;
   }
 
   private resolveOrgId(request: RequestWithUser): UUID | null {

--- a/ayunis-core-backend/src/iam/authorization/authorization.module.ts
+++ b/ayunis-core-backend/src/iam/authorization/authorization.module.ts
@@ -4,8 +4,10 @@ import { SubscriptionGuard } from './application/guards/subscription.guard';
 import { RateLimitGuard } from './application/guards/rate-limit.guard';
 import { SubscriptionsModule } from '../subscriptions/subscriptions.module';
 import { TrialsModule } from '../trials/trials.module';
+import { AddonsModule } from '../addons/addons.module';
 import { EmailConfirmGuard } from './application/guards/email-confirm.guard';
 import { SystemRolesGuard } from './application/guards/system-roles.guard';
+import { AddonGuard } from './application/guards/addon.guard';
 
 /**
  * Authorization guards live here as regular providers and are exported for
@@ -20,13 +22,14 @@ import { SystemRolesGuard } from './application/guards/system-roles.guard';
  * @nestjs/passport exposes its strategy module.
  */
 @Module({
-  imports: [SubscriptionsModule, TrialsModule],
+  imports: [SubscriptionsModule, TrialsModule, AddonsModule],
   providers: [
     EmailConfirmGuard,
     RolesGuard,
     SystemRolesGuard,
     SubscriptionGuard,
     RateLimitGuard,
+    AddonGuard,
   ],
   exports: [
     EmailConfirmGuard,
@@ -34,8 +37,10 @@ import { SystemRolesGuard } from './application/guards/system-roles.guard';
     SystemRolesGuard,
     SubscriptionGuard,
     RateLimitGuard,
+    AddonGuard,
     SubscriptionsModule,
     TrialsModule,
+    AddonsModule,
   ],
 })
 export class AuthorizationModule {}

--- a/ayunis-core-backend/src/iam/iam.module.spec.ts
+++ b/ayunis-core-backend/src/iam/iam.module.spec.ts
@@ -8,6 +8,7 @@ import { RolesGuard } from './authorization/application/guards/roles.guard';
 import { SystemRolesGuard } from './authorization/application/guards/system-roles.guard';
 import { SubscriptionGuard } from './authorization/application/guards/subscription.guard';
 import { RateLimitGuard } from './authorization/application/guards/rate-limit.guard';
+import { AddonGuard } from './authorization/application/guards/addon.guard';
 
 type GuardRef = abstract new (...args: never[]) => unknown;
 
@@ -48,6 +49,7 @@ describe('IamModule global guard order', () => {
       EmailConfirmGuard,
       RolesGuard,
       SystemRolesGuard,
+      AddonGuard,
       SubscriptionGuard,
       RateLimitGuard,
     ]);

--- a/ayunis-core-backend/src/iam/iam.module.ts
+++ b/ayunis-core-backend/src/iam/iam.module.ts
@@ -27,6 +27,7 @@ import { RolesGuard } from './authorization/application/guards/roles.guard';
 import { SystemRolesGuard } from './authorization/application/guards/system-roles.guard';
 import { SubscriptionGuard } from './authorization/application/guards/subscription.guard';
 import { RateLimitGuard } from './authorization/application/guards/rate-limit.guard';
+import { AddonGuard } from './authorization/application/guards/addon.guard';
 
 // Feature modules re-exported by IamModule. Listed once and spread into both
 // `imports` and `exports` so the two cannot drift out of sync.
@@ -71,6 +72,7 @@ const GLOBAL_GUARD_PROVIDERS = [
   { provide: APP_GUARD, useExisting: EmailConfirmGuard },
   { provide: APP_GUARD, useExisting: RolesGuard },
   { provide: APP_GUARD, useExisting: SystemRolesGuard },
+  { provide: APP_GUARD, useExisting: AddonGuard },
   { provide: APP_GUARD, useExisting: SubscriptionGuard },
   { provide: APP_GUARD, useExisting: RateLimitGuard },
 ];

--- a/ayunis-core-frontend/src/app/routeTree.gen.ts
+++ b/ayunis-core-frontend/src/app/routeTree.gen.ts
@@ -25,6 +25,7 @@ import { Route as AuthenticatedKnowledgeBasesIndexRouteImport } from './routes/_
 import { Route as AuthenticatedChatsIndexRouteImport } from './routes/_authenticated/chats.index'
 import { Route as AuthenticatedChatIndexRouteImport } from './routes/_authenticated/chat.index'
 import { Route as AuthenticatedAdminSettingsIndexRouteImport } from './routes/_authenticated/admin-settings.index'
+import { Route as AuthenticatedAcademyIndexRouteImport } from './routes/_authenticated/academy.index'
 import { Route as AuthenticatedSkillsIdRouteImport } from './routes/_authenticated/skills.$id'
 import { Route as AuthenticatedSettingsIntegrationsRouteImport } from './routes/_authenticated/settings.integrations'
 import { Route as AuthenticatedSettingsGeneralRouteImport } from './routes/_authenticated/settings.general'
@@ -137,6 +138,12 @@ const AuthenticatedAdminSettingsIndexRoute =
   AuthenticatedAdminSettingsIndexRouteImport.update({
     id: '/admin-settings/',
     path: '/admin-settings/',
+    getParentRoute: () => AuthenticatedRoute,
+  } as any)
+const AuthenticatedAcademyIndexRoute =
+  AuthenticatedAcademyIndexRouteImport.update({
+    id: '/academy/',
+    path: '/academy/',
     getParentRoute: () => AuthenticatedRoute,
   } as any)
 const AuthenticatedSkillsIdRoute = AuthenticatedSkillsIdRouteImport.update({
@@ -339,6 +346,7 @@ export interface FileRoutesByFullPath {
   '/settings/general': typeof AuthenticatedSettingsGeneralRoute
   '/settings/integrations': typeof AuthenticatedSettingsIntegrationsRoute
   '/skills/$id': typeof AuthenticatedSkillsIdRoute
+  '/academy/': typeof AuthenticatedAcademyIndexRoute
   '/admin-settings/': typeof AuthenticatedAdminSettingsIndexRoute
   '/chat/': typeof AuthenticatedChatIndexRoute
   '/chats/': typeof AuthenticatedChatsIndexRoute
@@ -385,6 +393,7 @@ export interface FileRoutesByTo {
   '/settings/general': typeof AuthenticatedSettingsGeneralRoute
   '/settings/integrations': typeof AuthenticatedSettingsIntegrationsRoute
   '/skills/$id': typeof AuthenticatedSkillsIdRoute
+  '/academy': typeof AuthenticatedAcademyIndexRoute
   '/admin-settings': typeof AuthenticatedAdminSettingsIndexRoute
   '/chat': typeof AuthenticatedChatIndexRoute
   '/chats': typeof AuthenticatedChatsIndexRoute
@@ -433,6 +442,7 @@ export interface FileRoutesById {
   '/_authenticated/settings/general': typeof AuthenticatedSettingsGeneralRoute
   '/_authenticated/settings/integrations': typeof AuthenticatedSettingsIntegrationsRoute
   '/_authenticated/skills/$id': typeof AuthenticatedSkillsIdRoute
+  '/_authenticated/academy/': typeof AuthenticatedAcademyIndexRoute
   '/_authenticated/admin-settings/': typeof AuthenticatedAdminSettingsIndexRoute
   '/_authenticated/chat/': typeof AuthenticatedChatIndexRoute
   '/_authenticated/chats/': typeof AuthenticatedChatsIndexRoute
@@ -481,6 +491,7 @@ export interface FileRouteTypes {
     | '/settings/general'
     | '/settings/integrations'
     | '/skills/$id'
+    | '/academy/'
     | '/admin-settings/'
     | '/chat/'
     | '/chats/'
@@ -527,6 +538,7 @@ export interface FileRouteTypes {
     | '/settings/general'
     | '/settings/integrations'
     | '/skills/$id'
+    | '/academy'
     | '/admin-settings'
     | '/chat'
     | '/chats'
@@ -574,6 +586,7 @@ export interface FileRouteTypes {
     | '/_authenticated/settings/general'
     | '/_authenticated/settings/integrations'
     | '/_authenticated/skills/$id'
+    | '/_authenticated/academy/'
     | '/_authenticated/admin-settings/'
     | '/_authenticated/chat/'
     | '/_authenticated/chats/'
@@ -720,6 +733,13 @@ declare module '@tanstack/react-router' {
       path: '/admin-settings'
       fullPath: '/admin-settings/'
       preLoaderRoute: typeof AuthenticatedAdminSettingsIndexRouteImport
+      parentRoute: typeof AuthenticatedRoute
+    }
+    '/_authenticated/academy/': {
+      id: '/_authenticated/academy/'
+      path: '/academy'
+      fullPath: '/academy/'
+      preLoaderRoute: typeof AuthenticatedAcademyIndexRouteImport
       parentRoute: typeof AuthenticatedRoute
     }
     '/_authenticated/skills/$id': {
@@ -945,6 +965,7 @@ interface AuthenticatedRouteChildren {
   AuthenticatedSettingsGeneralRoute: typeof AuthenticatedSettingsGeneralRoute
   AuthenticatedSettingsIntegrationsRoute: typeof AuthenticatedSettingsIntegrationsRoute
   AuthenticatedSkillsIdRoute: typeof AuthenticatedSkillsIdRoute
+  AuthenticatedAcademyIndexRoute: typeof AuthenticatedAcademyIndexRoute
   AuthenticatedAdminSettingsIndexRoute: typeof AuthenticatedAdminSettingsIndexRoute
   AuthenticatedChatIndexRoute: typeof AuthenticatedChatIndexRoute
   AuthenticatedChatsIndexRoute: typeof AuthenticatedChatsIndexRoute
@@ -988,6 +1009,7 @@ const AuthenticatedRouteChildren: AuthenticatedRouteChildren = {
   AuthenticatedSettingsIntegrationsRoute:
     AuthenticatedSettingsIntegrationsRoute,
   AuthenticatedSkillsIdRoute: AuthenticatedSkillsIdRoute,
+  AuthenticatedAcademyIndexRoute: AuthenticatedAcademyIndexRoute,
   AuthenticatedAdminSettingsIndexRoute: AuthenticatedAdminSettingsIndexRoute,
   AuthenticatedChatIndexRoute: AuthenticatedChatIndexRoute,
   AuthenticatedChatsIndexRoute: AuthenticatedChatsIndexRoute,

--- a/ayunis-core-frontend/src/app/routes/_authenticated/academy.index.tsx
+++ b/ayunis-core-frontend/src/app/routes/_authenticated/academy.index.tsx
@@ -1,0 +1,32 @@
+import { createFileRoute, redirect } from '@tanstack/react-router';
+import { AcademyPage } from '@/pages/academy';
+import { isAcademyAddonActive } from '@/features/academy';
+import {
+  addonsControllerList,
+  getAddonsControllerListQueryKey,
+  academyChaptersControllerGetChapters,
+  getAcademyChaptersControllerGetChaptersQueryKey,
+} from '@/shared/api/generated/ayunisCoreAPI';
+
+export const Route = createFileRoute('/_authenticated/academy/')({
+  component: RouteComponent,
+  loader: async ({ context: { queryClient } }) => {
+    const addons = await queryClient.fetchQuery({
+      queryKey: getAddonsControllerListQueryKey(),
+      queryFn: () => addonsControllerList(),
+    });
+    if (!isAcademyAddonActive(addons)) {
+      throw redirect({ to: '/chat' });
+    }
+    const chapters = await queryClient.fetchQuery({
+      queryKey: getAcademyChaptersControllerGetChaptersQueryKey(),
+      queryFn: () => academyChaptersControllerGetChapters(),
+    });
+    return { chapters };
+  },
+});
+
+function RouteComponent() {
+  const { chapters } = Route.useLoaderData();
+  return <AcademyPage chapters={chapters} />;
+}

--- a/ayunis-core-frontend/src/features/academy/index.ts
+++ b/ayunis-core-frontend/src/features/academy/index.ts
@@ -1,0 +1,2 @@
+export { useAcademyActive } from './useAcademyActive';
+export { isAcademyAddonActive } from './isAcademyAddonActive';

--- a/ayunis-core-frontend/src/features/academy/isAcademyAddonActive.ts
+++ b/ayunis-core-frontend/src/features/academy/isAcademyAddonActive.ts
@@ -1,0 +1,16 @@
+import { AddonType } from '@/shared/api/generated/ayunisCoreAPI.schemas';
+import type { AddonStatusResponseDto } from '@/shared/api/generated/ayunisCoreAPI.schemas';
+
+/**
+ * Whether the academy add-on is active in a list of org add-on statuses.
+ * Shared by the sidebar hook and the `/academy` route guard.
+ */
+export function isAcademyAddonActive(
+  addons: AddonStatusResponseDto[],
+): boolean {
+  return addons.some(
+    (addon) =>
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- AddonType currently has a single member, so this comparison narrows to always-true; the type guard is intentional so the check stays correct once more add-ons exist.
+      addon.type === AddonType.ayunis_core_academy && addon.active,
+  );
+}

--- a/ayunis-core-frontend/src/features/academy/useAcademyActive.ts
+++ b/ayunis-core-frontend/src/features/academy/useAcademyActive.ts
@@ -1,0 +1,13 @@
+import { useAddonsControllerList } from '@/shared/api/generated/ayunisCoreAPI';
+import { isAcademyAddonActive } from './isAcademyAddonActive';
+
+/**
+ * Whether the academy add-on is active for the current user's organization.
+ * Defaults to `false` while loading or when the request fails, so the academy
+ * surface stays hidden until activation is confirmed.
+ */
+export function useAcademyActive(): boolean {
+  const { data } = useAddonsControllerList();
+
+  return isAcademyAddonActive(data ?? []);
+}

--- a/ayunis-core-frontend/src/i18n.ts
+++ b/ayunis-core-frontend/src/i18n.ts
@@ -46,6 +46,8 @@ import enSuperAdminSettingsSuperAdmins from './shared/locales/en/super-admin-set
 import deSuperAdminSettingsSuperAdmins from './shared/locales/de/super-admin-settings-super-admins.json';
 import enSuperAdminSettingsAcademy from './shared/locales/en/super-admin-settings-academy.json';
 import deSuperAdminSettingsAcademy from './shared/locales/de/super-admin-settings-academy.json';
+import enAcademy from './shared/locales/en/academy.json';
+import deAcademy from './shared/locales/de/academy.json';
 import enArtifacts from './shared/locales/en/artifacts.json';
 import deArtifacts from './shared/locales/de/artifacts.json';
 import enSuperAdminSettingsPlatformConfig from './shared/locales/en/super-admin-settings-platform-config.json';
@@ -87,6 +89,7 @@ const resources = {
     'super-admin-settings-skills': enSuperAdminSettingsSkills,
     'super-admin-settings-super-admins': enSuperAdminSettingsSuperAdmins,
     'super-admin-settings-academy': enSuperAdminSettingsAcademy,
+    academy: enAcademy,
     artifacts: enArtifacts,
     'super-admin-settings-platform-config': enSuperAdminSettingsPlatformConfig,
     'admin-settings-security': enAdminSettingsSecurity,
@@ -119,6 +122,7 @@ const resources = {
     'super-admin-settings-skills': deSuperAdminSettingsSkills,
     'super-admin-settings-super-admins': deSuperAdminSettingsSuperAdmins,
     'super-admin-settings-academy': deSuperAdminSettingsAcademy,
+    academy: deAcademy,
     artifacts: deArtifacts,
     'super-admin-settings-platform-config': deSuperAdminSettingsPlatformConfig,
     'admin-settings-security': deAdminSettingsSecurity,

--- a/ayunis-core-frontend/src/pages/academy/index.ts
+++ b/ayunis-core-frontend/src/pages/academy/index.ts
@@ -1,0 +1,1 @@
+export { default as AcademyPage } from './ui/AcademyPage';

--- a/ayunis-core-frontend/src/pages/academy/ui/AcademyPage.tsx
+++ b/ayunis-core-frontend/src/pages/academy/ui/AcademyPage.tsx
@@ -1,0 +1,60 @@
+import AppLayout from '@/layouts/app-layout';
+import ContentAreaLayout from '@/layouts/content-area-layout/ui/ContentAreaLayout';
+import ContentAreaHeader from '@/widgets/content-area-header/ui/ContentAreaHeader';
+import FullScreenMessageLayout from '@/layouts/full-screen-message-layout/ui/FullScreenMessageLayout';
+import { EmptyState } from '@/widgets/empty-state';
+import {
+  Card,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/shared/ui/shadcn/card';
+import { useTranslation } from 'react-i18next';
+import type { AcademyChapterResponseDto } from '@/shared/api/generated/ayunisCoreAPI.schemas';
+
+interface AcademyPageProps {
+  chapters: AcademyChapterResponseDto[];
+}
+
+export default function AcademyPage({ chapters }: Readonly<AcademyPageProps>) {
+  const { t } = useTranslation('academy');
+
+  const sortedChapters = [...chapters].sort((a, b) => a.position - b.position);
+
+  const header = (
+    <ContentAreaHeader breadcrumbs={[{ label: t('page.title') }]} />
+  );
+
+  if (sortedChapters.length === 0) {
+    return (
+      <AppLayout>
+        <FullScreenMessageLayout header={header}>
+          <EmptyState
+            title={t('emptyState.title')}
+            description={t('emptyState.description')}
+          />
+        </FullScreenMessageLayout>
+      </AppLayout>
+    );
+  }
+
+  return (
+    <AppLayout>
+      <ContentAreaLayout
+        contentHeader={header}
+        contentArea={
+          <div className="space-y-3">
+            {sortedChapters.map((chapter) => (
+              <Card key={chapter.id}>
+                <CardHeader>
+                  <CardTitle>{chapter.title}</CardTitle>
+                  <CardDescription>{chapter.description}</CardDescription>
+                </CardHeader>
+              </Card>
+            ))}
+          </div>
+        }
+      />
+    </AppLayout>
+  );
+}

--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
@@ -4151,6 +4151,24 @@ export interface UpdateLessonRequestDto {
 
 export interface ChatCompletionRequestDto { [key: string]: unknown }
 
+/**
+ * The add-on this status entry refers to
+ */
+export type AddonType = typeof AddonType[keyof typeof AddonType];
+
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const AddonType = {
+  ayunis_core_academy: 'ayunis_core_academy',
+} as const;
+
+export interface AddonStatusResponseDto {
+  /** The add-on this status entry refers to */
+  type: AddonType;
+  /** Whether the add-on is active for the organization */
+  active: boolean;
+}
+
 export interface LoginDto {
   /** Email address for authentication */
   email: string;
@@ -4290,24 +4308,6 @@ export interface CreateApiKeyResponseDto {
   createdAt: string;
   /** The full plaintext API key. This is the only response that will ever contain it — store it securely and immediately. It cannot be retrieved later. */
   secret: string;
-}
-
-/**
- * The add-on this status entry refers to
- */
-export type AddonType = typeof AddonType[keyof typeof AddonType];
-
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const AddonType = {
-  ayunis_core_academy: 'ayunis_core_academy',
-} as const;
-
-export interface AddonStatusResponseDto {
-  /** The add-on this status entry refers to */
-  type: AddonType;
-  /** Whether the add-on is active for the organization */
-  active: boolean;
 }
 
 export type UserControllerGetUsersInOrganizationParams = {

--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.ts
@@ -16344,6 +16344,100 @@ export const useOrgSystemPromptControllerDeleteOrgSystemPrompt = <TError = void,
     }
     
 /**
+ * Retrieve all chapters with nested lessons, ordered by position. Requires the academy add-on to be active for the organization.
+ * @summary Get all academy chapters with their lessons
+ */
+export const academyChaptersControllerGetChapters = (
+    
+ signal?: AbortSignal
+) => {
+      
+      
+      return customAxiosInstance<AcademyChapterResponseDto[]>(
+      {url: `/academy/chapters`, method: 'GET', signal
+    },
+      );
+    }
+  
+
+
+
+export const getAcademyChaptersControllerGetChaptersQueryKey = () => {
+    return [
+    `/academy/chapters`
+    ] as const;
+    }
+
+    
+export const getAcademyChaptersControllerGetChaptersQueryOptions = <TData = Awaited<ReturnType<typeof academyChaptersControllerGetChapters>>, TError = void>( options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof academyChaptersControllerGetChapters>>, TError, TData>>, }
+) => {
+
+const {query: queryOptions} = options ?? {};
+
+  const queryKey =  queryOptions?.queryKey ?? getAcademyChaptersControllerGetChaptersQueryKey();
+
+  
+
+    const queryFn: QueryFunction<Awaited<ReturnType<typeof academyChaptersControllerGetChapters>>> = ({ signal }) => academyChaptersControllerGetChapters(signal);
+
+      
+
+      
+
+   return  { queryKey, queryFn, ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof academyChaptersControllerGetChapters>>, TError, TData> & { queryKey: DataTag<QueryKey, TData, TError> }
+}
+
+export type AcademyChaptersControllerGetChaptersQueryResult = NonNullable<Awaited<ReturnType<typeof academyChaptersControllerGetChapters>>>
+export type AcademyChaptersControllerGetChaptersQueryError = void
+
+
+export function useAcademyChaptersControllerGetChapters<TData = Awaited<ReturnType<typeof academyChaptersControllerGetChapters>>, TError = void>(
+  options: { query:Partial<UseQueryOptions<Awaited<ReturnType<typeof academyChaptersControllerGetChapters>>, TError, TData>> & Pick<
+        DefinedInitialDataOptions<
+          Awaited<ReturnType<typeof academyChaptersControllerGetChapters>>,
+          TError,
+          Awaited<ReturnType<typeof academyChaptersControllerGetChapters>>
+        > , 'initialData'
+      >, }
+ , queryClient?: QueryClient
+  ):  DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useAcademyChaptersControllerGetChapters<TData = Awaited<ReturnType<typeof academyChaptersControllerGetChapters>>, TError = void>(
+  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof academyChaptersControllerGetChapters>>, TError, TData>> & Pick<
+        UndefinedInitialDataOptions<
+          Awaited<ReturnType<typeof academyChaptersControllerGetChapters>>,
+          TError,
+          Awaited<ReturnType<typeof academyChaptersControllerGetChapters>>
+        > , 'initialData'
+      >, }
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useAcademyChaptersControllerGetChapters<TData = Awaited<ReturnType<typeof academyChaptersControllerGetChapters>>, TError = void>(
+  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof academyChaptersControllerGetChapters>>, TError, TData>>, }
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+/**
+ * @summary Get all academy chapters with their lessons
+ */
+
+export function useAcademyChaptersControllerGetChapters<TData = Awaited<ReturnType<typeof academyChaptersControllerGetChapters>>, TError = void>(
+  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof academyChaptersControllerGetChapters>>, TError, TData>>, }
+ , queryClient?: QueryClient 
+ ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
+
+  const queryOptions = getAcademyChaptersControllerGetChaptersQueryOptions(options)
+
+  const query = useQuery(queryOptions, queryClient) as  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+
+  query.queryKey = queryOptions.queryKey ;
+
+  return query;
+}
+
+
+
+
+
+/**
  * Retrieve all chapters with nested lessons, ordered by position. Only accessible to super admins.
  * @summary Get all academy chapters with their lessons
  */
@@ -17018,6 +17112,319 @@ const {mutation: mutationOptions} = options ?
       return useMutation(mutationOptions, queryClient);
     }
     
+/**
+ * @summary List all add-ons with their active state for an organization
+ */
+export const superAdminAddonsControllerList = (
+    orgId: string,
+ signal?: AbortSignal
+) => {
+      
+      
+      return customAxiosInstance<AddonStatusResponseDto[]>(
+      {url: `/super-admin/addons/${orgId}`, method: 'GET', signal
+    },
+      );
+    }
+  
+
+
+
+export const getSuperAdminAddonsControllerListQueryKey = (orgId?: string,) => {
+    return [
+    `/super-admin/addons/${orgId}`
+    ] as const;
+    }
+
+    
+export const getSuperAdminAddonsControllerListQueryOptions = <TData = Awaited<ReturnType<typeof superAdminAddonsControllerList>>, TError = void>(orgId: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof superAdminAddonsControllerList>>, TError, TData>>, }
+) => {
+
+const {query: queryOptions} = options ?? {};
+
+  const queryKey =  queryOptions?.queryKey ?? getSuperAdminAddonsControllerListQueryKey(orgId);
+
+  
+
+    const queryFn: QueryFunction<Awaited<ReturnType<typeof superAdminAddonsControllerList>>> = ({ signal }) => superAdminAddonsControllerList(orgId, signal);
+
+      
+
+      
+
+   return  { queryKey, queryFn, enabled: !!(orgId), ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof superAdminAddonsControllerList>>, TError, TData> & { queryKey: DataTag<QueryKey, TData, TError> }
+}
+
+export type SuperAdminAddonsControllerListQueryResult = NonNullable<Awaited<ReturnType<typeof superAdminAddonsControllerList>>>
+export type SuperAdminAddonsControllerListQueryError = void
+
+
+export function useSuperAdminAddonsControllerList<TData = Awaited<ReturnType<typeof superAdminAddonsControllerList>>, TError = void>(
+ orgId: string, options: { query:Partial<UseQueryOptions<Awaited<ReturnType<typeof superAdminAddonsControllerList>>, TError, TData>> & Pick<
+        DefinedInitialDataOptions<
+          Awaited<ReturnType<typeof superAdminAddonsControllerList>>,
+          TError,
+          Awaited<ReturnType<typeof superAdminAddonsControllerList>>
+        > , 'initialData'
+      >, }
+ , queryClient?: QueryClient
+  ):  DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useSuperAdminAddonsControllerList<TData = Awaited<ReturnType<typeof superAdminAddonsControllerList>>, TError = void>(
+ orgId: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof superAdminAddonsControllerList>>, TError, TData>> & Pick<
+        UndefinedInitialDataOptions<
+          Awaited<ReturnType<typeof superAdminAddonsControllerList>>,
+          TError,
+          Awaited<ReturnType<typeof superAdminAddonsControllerList>>
+        > , 'initialData'
+      >, }
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useSuperAdminAddonsControllerList<TData = Awaited<ReturnType<typeof superAdminAddonsControllerList>>, TError = void>(
+ orgId: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof superAdminAddonsControllerList>>, TError, TData>>, }
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+/**
+ * @summary List all add-ons with their active state for an organization
+ */
+
+export function useSuperAdminAddonsControllerList<TData = Awaited<ReturnType<typeof superAdminAddonsControllerList>>, TError = void>(
+ orgId: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof superAdminAddonsControllerList>>, TError, TData>>, }
+ , queryClient?: QueryClient 
+ ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
+
+  const queryOptions = getSuperAdminAddonsControllerListQueryOptions(orgId,options)
+
+  const query = useQuery(queryOptions, queryClient) as  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+
+  query.queryKey = queryOptions.queryKey ;
+
+  return query;
+}
+
+
+
+
+
+/**
+ * @summary Activate an add-on for an organization
+ */
+export const superAdminAddonsControllerActivate = (
+    orgId: string,
+    type: 'ayunis_core_academy',
+ signal?: AbortSignal
+) => {
+      
+      
+      return customAxiosInstance<void>(
+      {url: `/super-admin/addons/${orgId}/${type}`, method: 'POST', signal
+    },
+      );
+    }
+  
+
+
+export const getSuperAdminAddonsControllerActivateMutationOptions = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof superAdminAddonsControllerActivate>>, TError,{orgId: string;type: 'ayunis_core_academy'}, TContext>, }
+): UseMutationOptions<Awaited<ReturnType<typeof superAdminAddonsControllerActivate>>, TError,{orgId: string;type: 'ayunis_core_academy'}, TContext> => {
+
+const mutationKey = ['superAdminAddonsControllerActivate'];
+const {mutation: mutationOptions} = options ?
+      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
+      options
+      : {...options, mutation: {...options.mutation, mutationKey}}
+      : {mutation: { mutationKey, }};
+
+      
+
+
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof superAdminAddonsControllerActivate>>, {orgId: string;type: 'ayunis_core_academy'}> = (props) => {
+          const {orgId,type} = props ?? {};
+
+          return  superAdminAddonsControllerActivate(orgId,type,)
+        }
+
+        
+
+
+  return  { mutationFn, ...mutationOptions }}
+
+    export type SuperAdminAddonsControllerActivateMutationResult = NonNullable<Awaited<ReturnType<typeof superAdminAddonsControllerActivate>>>
+    
+    export type SuperAdminAddonsControllerActivateMutationError = void
+
+    /**
+ * @summary Activate an add-on for an organization
+ */
+export const useSuperAdminAddonsControllerActivate = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof superAdminAddonsControllerActivate>>, TError,{orgId: string;type: 'ayunis_core_academy'}, TContext>, }
+ , queryClient?: QueryClient): UseMutationResult<
+        Awaited<ReturnType<typeof superAdminAddonsControllerActivate>>,
+        TError,
+        {orgId: string;type: 'ayunis_core_academy'},
+        TContext
+      > => {
+
+      const mutationOptions = getSuperAdminAddonsControllerActivateMutationOptions(options);
+
+      return useMutation(mutationOptions, queryClient);
+    }
+    
+/**
+ * @summary Deactivate an add-on for an organization
+ */
+export const superAdminAddonsControllerDeactivate = (
+    orgId: string,
+    type: 'ayunis_core_academy',
+ ) => {
+      
+      
+      return customAxiosInstance<void>(
+      {url: `/super-admin/addons/${orgId}/${type}`, method: 'DELETE'
+    },
+      );
+    }
+  
+
+
+export const getSuperAdminAddonsControllerDeactivateMutationOptions = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof superAdminAddonsControllerDeactivate>>, TError,{orgId: string;type: 'ayunis_core_academy'}, TContext>, }
+): UseMutationOptions<Awaited<ReturnType<typeof superAdminAddonsControllerDeactivate>>, TError,{orgId: string;type: 'ayunis_core_academy'}, TContext> => {
+
+const mutationKey = ['superAdminAddonsControllerDeactivate'];
+const {mutation: mutationOptions} = options ?
+      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
+      options
+      : {...options, mutation: {...options.mutation, mutationKey}}
+      : {mutation: { mutationKey, }};
+
+      
+
+
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof superAdminAddonsControllerDeactivate>>, {orgId: string;type: 'ayunis_core_academy'}> = (props) => {
+          const {orgId,type} = props ?? {};
+
+          return  superAdminAddonsControllerDeactivate(orgId,type,)
+        }
+
+        
+
+
+  return  { mutationFn, ...mutationOptions }}
+
+    export type SuperAdminAddonsControllerDeactivateMutationResult = NonNullable<Awaited<ReturnType<typeof superAdminAddonsControllerDeactivate>>>
+    
+    export type SuperAdminAddonsControllerDeactivateMutationError = void
+
+    /**
+ * @summary Deactivate an add-on for an organization
+ */
+export const useSuperAdminAddonsControllerDeactivate = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof superAdminAddonsControllerDeactivate>>, TError,{orgId: string;type: 'ayunis_core_academy'}, TContext>, }
+ , queryClient?: QueryClient): UseMutationResult<
+        Awaited<ReturnType<typeof superAdminAddonsControllerDeactivate>>,
+        TError,
+        {orgId: string;type: 'ayunis_core_academy'},
+        TContext
+      > => {
+
+      const mutationOptions = getSuperAdminAddonsControllerDeactivateMutationOptions(options);
+
+      return useMutation(mutationOptions, queryClient);
+    }
+    
+/**
+ * @summary List all add-ons with their active state for the current user's organization
+ */
+export const addonsControllerList = (
+    
+ signal?: AbortSignal
+) => {
+      
+      
+      return customAxiosInstance<AddonStatusResponseDto[]>(
+      {url: `/addons`, method: 'GET', signal
+    },
+      );
+    }
+  
+
+
+
+export const getAddonsControllerListQueryKey = () => {
+    return [
+    `/addons`
+    ] as const;
+    }
+
+    
+export const getAddonsControllerListQueryOptions = <TData = Awaited<ReturnType<typeof addonsControllerList>>, TError = void>( options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof addonsControllerList>>, TError, TData>>, }
+) => {
+
+const {query: queryOptions} = options ?? {};
+
+  const queryKey =  queryOptions?.queryKey ?? getAddonsControllerListQueryKey();
+
+  
+
+    const queryFn: QueryFunction<Awaited<ReturnType<typeof addonsControllerList>>> = ({ signal }) => addonsControllerList(signal);
+
+      
+
+      
+
+   return  { queryKey, queryFn, ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof addonsControllerList>>, TError, TData> & { queryKey: DataTag<QueryKey, TData, TError> }
+}
+
+export type AddonsControllerListQueryResult = NonNullable<Awaited<ReturnType<typeof addonsControllerList>>>
+export type AddonsControllerListQueryError = void
+
+
+export function useAddonsControllerList<TData = Awaited<ReturnType<typeof addonsControllerList>>, TError = void>(
+  options: { query:Partial<UseQueryOptions<Awaited<ReturnType<typeof addonsControllerList>>, TError, TData>> & Pick<
+        DefinedInitialDataOptions<
+          Awaited<ReturnType<typeof addonsControllerList>>,
+          TError,
+          Awaited<ReturnType<typeof addonsControllerList>>
+        > , 'initialData'
+      >, }
+ , queryClient?: QueryClient
+  ):  DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useAddonsControllerList<TData = Awaited<ReturnType<typeof addonsControllerList>>, TError = void>(
+  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof addonsControllerList>>, TError, TData>> & Pick<
+        UndefinedInitialDataOptions<
+          Awaited<ReturnType<typeof addonsControllerList>>,
+          TError,
+          Awaited<ReturnType<typeof addonsControllerList>>
+        > , 'initialData'
+      >, }
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useAddonsControllerList<TData = Awaited<ReturnType<typeof addonsControllerList>>, TError = void>(
+  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof addonsControllerList>>, TError, TData>>, }
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+/**
+ * @summary List all add-ons with their active state for the current user's organization
+ */
+
+export function useAddonsControllerList<TData = Awaited<ReturnType<typeof addonsControllerList>>, TError = void>(
+  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof addonsControllerList>>, TError, TData>>, }
+ , queryClient?: QueryClient 
+ ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
+
+  const queryOptions = getAddonsControllerListQueryOptions(options)
+
+  const query = useQuery(queryOptions, queryClient) as  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+
+  query.queryKey = queryOptions.queryKey ;
+
+  return query;
+}
+
+
+
+
+
 /**
  * Authenticate user with email and password. Sets authentication cookies on successful login.
  * @summary User login
@@ -17807,226 +18214,6 @@ export const useApiKeysControllerRevokeApiKey = <TError = void,
       > => {
 
       const mutationOptions = getApiKeysControllerRevokeApiKeyMutationOptions(options);
-
-      return useMutation(mutationOptions, queryClient);
-    }
-    
-/**
- * @summary List all add-ons with their active state for an organization
- */
-export const superAdminAddonsControllerList = (
-    orgId: string,
- signal?: AbortSignal
-) => {
-      
-      
-      return customAxiosInstance<AddonStatusResponseDto[]>(
-      {url: `/super-admin/addons/${orgId}`, method: 'GET', signal
-    },
-      );
-    }
-  
-
-
-
-export const getSuperAdminAddonsControllerListQueryKey = (orgId?: string,) => {
-    return [
-    `/super-admin/addons/${orgId}`
-    ] as const;
-    }
-
-    
-export const getSuperAdminAddonsControllerListQueryOptions = <TData = Awaited<ReturnType<typeof superAdminAddonsControllerList>>, TError = void>(orgId: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof superAdminAddonsControllerList>>, TError, TData>>, }
-) => {
-
-const {query: queryOptions} = options ?? {};
-
-  const queryKey =  queryOptions?.queryKey ?? getSuperAdminAddonsControllerListQueryKey(orgId);
-
-  
-
-    const queryFn: QueryFunction<Awaited<ReturnType<typeof superAdminAddonsControllerList>>> = ({ signal }) => superAdminAddonsControllerList(orgId, signal);
-
-      
-
-      
-
-   return  { queryKey, queryFn, enabled: !!(orgId), ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof superAdminAddonsControllerList>>, TError, TData> & { queryKey: DataTag<QueryKey, TData, TError> }
-}
-
-export type SuperAdminAddonsControllerListQueryResult = NonNullable<Awaited<ReturnType<typeof superAdminAddonsControllerList>>>
-export type SuperAdminAddonsControllerListQueryError = void
-
-
-export function useSuperAdminAddonsControllerList<TData = Awaited<ReturnType<typeof superAdminAddonsControllerList>>, TError = void>(
- orgId: string, options: { query:Partial<UseQueryOptions<Awaited<ReturnType<typeof superAdminAddonsControllerList>>, TError, TData>> & Pick<
-        DefinedInitialDataOptions<
-          Awaited<ReturnType<typeof superAdminAddonsControllerList>>,
-          TError,
-          Awaited<ReturnType<typeof superAdminAddonsControllerList>>
-        > , 'initialData'
-      >, }
- , queryClient?: QueryClient
-  ):  DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
-export function useSuperAdminAddonsControllerList<TData = Awaited<ReturnType<typeof superAdminAddonsControllerList>>, TError = void>(
- orgId: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof superAdminAddonsControllerList>>, TError, TData>> & Pick<
-        UndefinedInitialDataOptions<
-          Awaited<ReturnType<typeof superAdminAddonsControllerList>>,
-          TError,
-          Awaited<ReturnType<typeof superAdminAddonsControllerList>>
-        > , 'initialData'
-      >, }
- , queryClient?: QueryClient
-  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
-export function useSuperAdminAddonsControllerList<TData = Awaited<ReturnType<typeof superAdminAddonsControllerList>>, TError = void>(
- orgId: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof superAdminAddonsControllerList>>, TError, TData>>, }
- , queryClient?: QueryClient
-  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
-/**
- * @summary List all add-ons with their active state for an organization
- */
-
-export function useSuperAdminAddonsControllerList<TData = Awaited<ReturnType<typeof superAdminAddonsControllerList>>, TError = void>(
- orgId: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof superAdminAddonsControllerList>>, TError, TData>>, }
- , queryClient?: QueryClient 
- ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
-
-  const queryOptions = getSuperAdminAddonsControllerListQueryOptions(orgId,options)
-
-  const query = useQuery(queryOptions, queryClient) as  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
-
-  query.queryKey = queryOptions.queryKey ;
-
-  return query;
-}
-
-
-
-
-
-/**
- * @summary Activate an add-on for an organization
- */
-export const superAdminAddonsControllerActivate = (
-    orgId: string,
-    type: 'ayunis_core_academy',
- signal?: AbortSignal
-) => {
-      
-      
-      return customAxiosInstance<void>(
-      {url: `/super-admin/addons/${orgId}/${type}`, method: 'POST', signal
-    },
-      );
-    }
-  
-
-
-export const getSuperAdminAddonsControllerActivateMutationOptions = <TError = void,
-    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof superAdminAddonsControllerActivate>>, TError,{orgId: string;type: 'ayunis_core_academy'}, TContext>, }
-): UseMutationOptions<Awaited<ReturnType<typeof superAdminAddonsControllerActivate>>, TError,{orgId: string;type: 'ayunis_core_academy'}, TContext> => {
-
-const mutationKey = ['superAdminAddonsControllerActivate'];
-const {mutation: mutationOptions} = options ?
-      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
-      options
-      : {...options, mutation: {...options.mutation, mutationKey}}
-      : {mutation: { mutationKey, }};
-
-      
-
-
-      const mutationFn: MutationFunction<Awaited<ReturnType<typeof superAdminAddonsControllerActivate>>, {orgId: string;type: 'ayunis_core_academy'}> = (props) => {
-          const {orgId,type} = props ?? {};
-
-          return  superAdminAddonsControllerActivate(orgId,type,)
-        }
-
-        
-
-
-  return  { mutationFn, ...mutationOptions }}
-
-    export type SuperAdminAddonsControllerActivateMutationResult = NonNullable<Awaited<ReturnType<typeof superAdminAddonsControllerActivate>>>
-    
-    export type SuperAdminAddonsControllerActivateMutationError = void
-
-    /**
- * @summary Activate an add-on for an organization
- */
-export const useSuperAdminAddonsControllerActivate = <TError = void,
-    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof superAdminAddonsControllerActivate>>, TError,{orgId: string;type: 'ayunis_core_academy'}, TContext>, }
- , queryClient?: QueryClient): UseMutationResult<
-        Awaited<ReturnType<typeof superAdminAddonsControllerActivate>>,
-        TError,
-        {orgId: string;type: 'ayunis_core_academy'},
-        TContext
-      > => {
-
-      const mutationOptions = getSuperAdminAddonsControllerActivateMutationOptions(options);
-
-      return useMutation(mutationOptions, queryClient);
-    }
-    
-/**
- * @summary Deactivate an add-on for an organization
- */
-export const superAdminAddonsControllerDeactivate = (
-    orgId: string,
-    type: 'ayunis_core_academy',
- ) => {
-      
-      
-      return customAxiosInstance<void>(
-      {url: `/super-admin/addons/${orgId}/${type}`, method: 'DELETE'
-    },
-      );
-    }
-  
-
-
-export const getSuperAdminAddonsControllerDeactivateMutationOptions = <TError = void,
-    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof superAdminAddonsControllerDeactivate>>, TError,{orgId: string;type: 'ayunis_core_academy'}, TContext>, }
-): UseMutationOptions<Awaited<ReturnType<typeof superAdminAddonsControllerDeactivate>>, TError,{orgId: string;type: 'ayunis_core_academy'}, TContext> => {
-
-const mutationKey = ['superAdminAddonsControllerDeactivate'];
-const {mutation: mutationOptions} = options ?
-      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
-      options
-      : {...options, mutation: {...options.mutation, mutationKey}}
-      : {mutation: { mutationKey, }};
-
-      
-
-
-      const mutationFn: MutationFunction<Awaited<ReturnType<typeof superAdminAddonsControllerDeactivate>>, {orgId: string;type: 'ayunis_core_academy'}> = (props) => {
-          const {orgId,type} = props ?? {};
-
-          return  superAdminAddonsControllerDeactivate(orgId,type,)
-        }
-
-        
-
-
-  return  { mutationFn, ...mutationOptions }}
-
-    export type SuperAdminAddonsControllerDeactivateMutationResult = NonNullable<Awaited<ReturnType<typeof superAdminAddonsControllerDeactivate>>>
-    
-    export type SuperAdminAddonsControllerDeactivateMutationError = void
-
-    /**
- * @summary Deactivate an add-on for an organization
- */
-export const useSuperAdminAddonsControllerDeactivate = <TError = void,
-    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof superAdminAddonsControllerDeactivate>>, TError,{orgId: string;type: 'ayunis_core_academy'}, TContext>, }
- , queryClient?: QueryClient): UseMutationResult<
-        Awaited<ReturnType<typeof superAdminAddonsControllerDeactivate>>,
-        TError,
-        {orgId: string;type: 'ayunis_core_academy'},
-        TContext
-      > => {
-
-      const mutationOptions = getSuperAdminAddonsControllerDeactivateMutationOptions(options);
 
       return useMutation(mutationOptions, queryClient);
     }

--- a/ayunis-core-frontend/src/shared/api/openapi-schema.json
+++ b/ayunis-core-frontend/src/shared/api/openapi-schema.json
@@ -8008,6 +8008,36 @@
         "tags": ["Chat Settings"]
       }
     },
+    "/academy/chapters": {
+      "get": {
+        "description": "Retrieve all chapters with nested lessons, ordered by position. Requires the academy add-on to be active for the organization.",
+        "operationId": "AcademyChaptersController_getChapters",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved academy chapters",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/AcademyChapterResponseDto"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "User not authenticated or academy add-on not active"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "summary": "Get all academy chapters with their lessons",
+        "tags": ["Academy"]
+      }
+    },
     "/super-admin/academy/chapters": {
       "get": {
         "description": "Retrieve all chapters with nested lessons, ordered by position. Only accessible to super admins.",
@@ -8392,6 +8422,136 @@
         "tags": ["ChatCompletions"]
       }
     },
+    "/super-admin/addons/{orgId}": {
+      "get": {
+        "operationId": "SuperAdminAddonsController_list",
+        "parameters": [
+          {
+            "name": "orgId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/AddonStatusResponseDto"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Not authorized as super admin"
+          }
+        },
+        "summary": "List all add-ons with their active state for an organization",
+        "tags": ["Super Admin Addons"]
+      }
+    },
+    "/super-admin/addons/{orgId}/{type}": {
+      "post": {
+        "operationId": "SuperAdminAddonsController_activate",
+        "parameters": [
+          {
+            "name": "orgId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "name": "type",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "enum": ["ayunis_core_academy"],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Add-on active"
+          },
+          "401": {
+            "description": "Not authorized as super admin"
+          }
+        },
+        "summary": "Activate an add-on for an organization",
+        "tags": ["Super Admin Addons"]
+      },
+      "delete": {
+        "operationId": "SuperAdminAddonsController_deactivate",
+        "parameters": [
+          {
+            "name": "orgId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "name": "type",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "enum": ["ayunis_core_academy"],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Add-on inactive"
+          },
+          "401": {
+            "description": "Not authorized as super admin"
+          }
+        },
+        "summary": "Deactivate an add-on for an organization",
+        "tags": ["Super Admin Addons"]
+      }
+    },
+    "/addons": {
+      "get": {
+        "operationId": "AddonsController_list",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/AddonStatusResponseDto"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Not authenticated"
+          }
+        },
+        "summary": "List all add-ons with their active state for the current user's organization",
+        "tags": ["Addons"]
+      }
+    },
     "/auth/login": {
       "post": {
         "description": "Authenticate user with email and password. Sets authentication cookies on successful login.",
@@ -8761,110 +8921,6 @@
         },
         "summary": "Revoke an API key",
         "tags": ["api-keys"]
-      }
-    },
-    "/super-admin/addons/{orgId}": {
-      "get": {
-        "operationId": "SuperAdminAddonsController_list",
-        "parameters": [
-          {
-            "name": "orgId",
-            "required": true,
-            "in": "path",
-            "schema": {
-              "format": "uuid",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/AddonStatusResponseDto"
-                  }
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Not authorized as super admin"
-          }
-        },
-        "summary": "List all add-ons with their active state for an organization",
-        "tags": ["Super Admin Addons"]
-      }
-    },
-    "/super-admin/addons/{orgId}/{type}": {
-      "post": {
-        "operationId": "SuperAdminAddonsController_activate",
-        "parameters": [
-          {
-            "name": "orgId",
-            "required": true,
-            "in": "path",
-            "schema": {
-              "format": "uuid",
-              "type": "string"
-            }
-          },
-          {
-            "name": "type",
-            "required": true,
-            "in": "path",
-            "schema": {
-              "enum": ["ayunis_core_academy"],
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "Add-on active"
-          },
-          "401": {
-            "description": "Not authorized as super admin"
-          }
-        },
-        "summary": "Activate an add-on for an organization",
-        "tags": ["Super Admin Addons"]
-      },
-      "delete": {
-        "operationId": "SuperAdminAddonsController_deactivate",
-        "parameters": [
-          {
-            "name": "orgId",
-            "required": true,
-            "in": "path",
-            "schema": {
-              "format": "uuid",
-              "type": "string"
-            }
-          },
-          {
-            "name": "type",
-            "required": true,
-            "in": "path",
-            "schema": {
-              "enum": ["ayunis_core_academy"],
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "Add-on inactive"
-          },
-          "401": {
-            "description": "Not authorized as super admin"
-          }
-        },
-        "summary": "Deactivate an add-on for an organization",
-        "tags": ["Super Admin Addons"]
       }
     }
   },
@@ -15098,6 +15154,29 @@
         "type": "object",
         "properties": {}
       },
+      "AddonType": {
+        "type": "string",
+        "enum": ["ayunis_core_academy"],
+        "description": "The add-on this status entry refers to"
+      },
+      "AddonStatusResponseDto": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "description": "The add-on this status entry refers to",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AddonType"
+              }
+            ]
+          },
+          "active": {
+            "type": "boolean",
+            "description": "Whether the add-on is active for the organization"
+          }
+        },
+        "required": ["type", "active"]
+      },
       "LoginDto": {
         "type": "object",
         "properties": {
@@ -15371,29 +15450,6 @@
           "createdAt",
           "secret"
         ]
-      },
-      "AddonType": {
-        "type": "string",
-        "enum": ["ayunis_core_academy"],
-        "description": "The add-on this status entry refers to"
-      },
-      "AddonStatusResponseDto": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "description": "The add-on this status entry refers to",
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/AddonType"
-              }
-            ]
-          },
-          "active": {
-            "type": "boolean",
-            "description": "Whether the add-on is active for the organization"
-          }
-        },
-        "required": ["type", "active"]
       }
     }
   }

--- a/ayunis-core-frontend/src/shared/locales/de/academy.json
+++ b/ayunis-core-frontend/src/shared/locales/de/academy.json
@@ -1,0 +1,9 @@
+{
+  "page": {
+    "title": "Academy"
+  },
+  "emptyState": {
+    "title": "Noch keine Kapitel",
+    "description": "Academy-Inhalte erscheinen hier, sobald sie veröffentlicht wurden."
+  }
+}

--- a/ayunis-core-frontend/src/shared/locales/de/common.json
+++ b/ayunis-core-frontend/src/shared/locales/de/common.json
@@ -7,6 +7,7 @@
     "skills": "Fähigkeiten",
     "knowledge": "Wissen",
     "marketplace": "Marketplace",
+    "academy": "Academy",
     "accountSettings": "Konto-Einstellungen",
     "adminSettings": "Admin-Einstellungen",
     "superAdminSettings": "Super Admin-Einstellungen",

--- a/ayunis-core-frontend/src/shared/locales/en/academy.json
+++ b/ayunis-core-frontend/src/shared/locales/en/academy.json
@@ -1,0 +1,9 @@
+{
+  "page": {
+    "title": "Academy"
+  },
+  "emptyState": {
+    "title": "No chapters yet",
+    "description": "Academy content will appear here once it has been published."
+  }
+}

--- a/ayunis-core-frontend/src/shared/locales/en/common.json
+++ b/ayunis-core-frontend/src/shared/locales/en/common.json
@@ -7,6 +7,7 @@
     "skills": "Skills",
     "knowledge": "Knowledge",
     "marketplace": "Marketplace",
+    "academy": "Academy",
     "accountSettings": "Account Settings",
     "adminSettings": "Admin Settings",
     "superAdminSettings": "Super Admin Settings",

--- a/ayunis-core-frontend/src/widgets/app-sidebar/ui/AppSidebar.tsx
+++ b/ayunis-core-frontend/src/widgets/app-sidebar/ui/AppSidebar.tsx
@@ -8,6 +8,7 @@ import {
   Brain,
   Sparkles,
   Store,
+  GraduationCap,
 } from 'lucide-react';
 
 import {
@@ -42,6 +43,7 @@ import config from '@/shared/config';
 import { ReleaseNotesButton } from './ReleaseNotesButton';
 import { useFeatureToggles } from '@/features/feature-toggles';
 import { useMarketplaceConfig } from '@/features/marketplace';
+import { useAcademyActive } from '@/features/academy';
 
 export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
   const { theme } = useTheme();
@@ -52,6 +54,7 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
   const { closeMobileWithCleanup } = useSidebar();
   const featureToggles = useFeatureToggles();
   const marketplace = useMarketplaceConfig();
+  const academyActive = useAcademyActive();
   const location = useLocation();
   useKeyboardShortcut(['j', 'Meta'], () => {
     void navigate({ to: '/chat' });
@@ -136,6 +139,19 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
                     <Store />
                     <span>{t('sidebar.marketplace')}</span>
                   </a>
+                </SidebarMenuButton>
+              </SidebarMenuItem>
+            )}
+            {academyActive && (
+              <SidebarMenuItem>
+                <SidebarMenuButton
+                  asChild
+                  isActive={location.pathname.startsWith('/academy')}
+                >
+                  <Link to="/academy">
+                    <GraduationCap />
+                    <span>{t('sidebar.academy')}</span>
+                  </Link>
                 </SidebarMenuButton>
               </SidebarMenuItem>
             )}


### PR DESCRIPTION
- Add reusable @RequireAddon decorator + global AddonGuard (mirrors
  SubscriptionGuard) backed by a new IsAddonActiveUseCase, so any route
  can be gated on an active org add-on
- Add current-org GET /addons and addon-gated GET /academy/chapters
  endpoints (reuse ListOrgAddonsUseCase / GetAcademyContentUseCase)
- Frontend: Academy sidebar link below Marketplace, /academy route that
  redirects when inactive, and a chapters list page; regen API client
  and add the academy i18n namespace

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new global authorization guard in the load-bearing IAM guard order; mis-ordering or guard failures could deny access broadly, though tests pin `AddonGuard` placement after authn/roles.
> 
> **Overview**
> Introduces **org add-on gating** for product features and ships the first user-facing **Academy** experience behind the academy add-on.
> 
> On the backend, a reusable **`@RequireAddon`** decorator and a global **`AddonGuard`** (patterned like subscription gating) call a new **`IsAddonActiveUseCase`**. The guard is registered in the global IAM guard chain (after JWT/roles, before subscription). Authenticated orgs get **`GET /addons`** (add-on active flags) and **`GET /academy/chapters`** (chapters + lessons), with the academy route requiring **`AYUNIS_CORE_ACADEMY`**.
> 
> On the frontend, **`/academy`** loads add-on status and redirects to chat when inactive; the sidebar shows **Academy** only when the add-on is active. The page lists chapter cards (or an empty state), with new **academy** i18n and regenerated API client types.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03319069b0d96d348caa7711bc34ba4cbfd2d417. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->