### PR TITLE
wip(threads): track lastActivityAt for data retention (AYC-66)

### DIFF
--- a/ayunis-core-backend/src/db/migrations/1781641427435-AddLastActivityAtToThreads.ts
+++ b/ayunis-core-backend/src/db/migrations/1781641427435-AddLastActivityAtToThreads.ts
@@ -1,0 +1,36 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddLastActivityAtToThreads1781641427435 implements MigrationInterface {
+  name = 'AddLastActivityAtToThreads1781641427435';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "threads" ADD "lastActivityAt" TIMESTAMP`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_75bb0778b90741be9a49adfc24" ON "threads" ("lastActivityAt") `,
+    );
+    // Backfill existing rows from the most recent message, falling back to
+    // the thread's creation time for empty threads. Without this, every
+    // pre-existing thread's activity would default to its creation date,
+    // which could cause retention to delete old-but-recently-active
+    // threads on the first enforcement run. Data-only; no schema drift.
+    await queryRunner.query(`
+            UPDATE "threads" t
+            SET "lastActivityAt" = COALESCE(
+                (SELECT MAX(m."createdAt") FROM "messages" m WHERE m."threadId" = t."id"),
+                t."createdAt"
+            )
+            WHERE t."lastActivityAt" IS NULL
+        `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_75bb0778b90741be9a49adfc24"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "threads" DROP COLUMN "lastActivityAt"`,
+    );
+  }
+}

--- a/ayunis-core-backend/src/domain/threads/application/listeners/thread-activity.listener.spec.ts
+++ b/ayunis-core-backend/src/domain/threads/application/listeners/thread-activity.listener.spec.ts
@@ -1,0 +1,33 @@
+import { randomUUID } from 'crypto';
+import { ThreadActivityListener } from './thread-activity.listener';
+import type { RecordThreadActivityUseCase } from '../use-cases/record-thread-activity/record-thread-activity.use-case';
+import { ThreadMessageAddedEvent } from '../events/thread-message-added.event';
+
+describe('ThreadActivityListener', () => {
+  let listener: ThreadActivityListener;
+  let recordThreadActivity: { execute: jest.Mock };
+
+  beforeEach(() => {
+    recordThreadActivity = { execute: jest.fn().mockResolvedValue(undefined) };
+    listener = new ThreadActivityListener(
+      recordThreadActivity as unknown as RecordThreadActivityUseCase,
+    );
+  });
+
+  it('records activity for the thread named in the message-added event', async () => {
+    const threadId = randomUUID();
+    const event = new ThreadMessageAddedEvent(
+      randomUUID(),
+      randomUUID(),
+      threadId,
+      3,
+    );
+
+    await listener.handleThreadMessageAdded(event);
+
+    expect(recordThreadActivity.execute).toHaveBeenCalledTimes(1);
+    expect(recordThreadActivity.execute).toHaveBeenCalledWith(
+      expect.objectContaining({ threadId }),
+    );
+  });
+});

--- a/ayunis-core-backend/src/domain/threads/application/listeners/thread-activity.listener.ts
+++ b/ayunis-core-backend/src/domain/threads/application/listeners/thread-activity.listener.ts
@@ -1,0 +1,27 @@
+import { Injectable } from '@nestjs/common';
+import { OnEvent } from '@nestjs/event-emitter';
+import { ThreadMessageAddedEvent } from '../events/thread-message-added.event';
+import { RecordThreadActivityUseCase } from '../use-cases/record-thread-activity/record-thread-activity.use-case';
+import { RecordThreadActivityCommand } from '../use-cases/record-thread-activity/record-thread-activity.command';
+
+/**
+ * Keeps `thread.lastActivityAt` current for data-retention purposes by
+ * reacting to every message added to a thread. The event is the single
+ * chokepoint for message additions (emitted by AddMessageToThreadUseCase),
+ * so this is the one place activity is recorded.
+ */
+@Injectable()
+export class ThreadActivityListener {
+  constructor(
+    private readonly recordThreadActivity: RecordThreadActivityUseCase,
+  ) {}
+
+  @OnEvent(ThreadMessageAddedEvent.EVENT_NAME)
+  async handleThreadMessageAdded(
+    event: ThreadMessageAddedEvent,
+  ): Promise<void> {
+    await this.recordThreadActivity.execute(
+      new RecordThreadActivityCommand(event.threadId, new Date()),
+    );
+  }
+}

--- a/ayunis-core-backend/src/domain/threads/application/ports/threads.repository.ts
+++ b/ayunis-core-backend/src/domain/threads/application/ports/threads.repository.ts
@@ -43,6 +43,15 @@ export abstract class ThreadsRepository {
     userId: UUID;
     title: string;
   }): Promise<void>;
+  /**
+   * Bumps the thread's last-activity timestamp. Best-effort and scoped by
+   * threadId only (no userId): it is driven by the message-added event, which
+   * carries no per-call ownership guarantee. A no-op if the thread is gone.
+   */
+  abstract updateLastActivityAt(params: {
+    threadId: UUID;
+    lastActivityAt: Date;
+  }): Promise<void>;
   abstract updateSourceAssignments(params: {
     threadId: UUID;
     userId: UUID;

--- a/ayunis-core-backend/src/domain/threads/application/use-cases/record-thread-activity/record-thread-activity.command.ts
+++ b/ayunis-core-backend/src/domain/threads/application/use-cases/record-thread-activity/record-thread-activity.command.ts
@@ -1,0 +1,8 @@
+import type { UUID } from 'crypto';
+
+export class RecordThreadActivityCommand {
+  constructor(
+    public readonly threadId: UUID,
+    public readonly occurredAt: Date,
+  ) {}
+}

--- a/ayunis-core-backend/src/domain/threads/application/use-cases/record-thread-activity/record-thread-activity.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/threads/application/use-cases/record-thread-activity/record-thread-activity.use-case.spec.ts
@@ -1,0 +1,52 @@
+import type { TestingModule } from '@nestjs/testing';
+import { Test } from '@nestjs/testing';
+import { randomUUID } from 'crypto';
+import { RecordThreadActivityUseCase } from './record-thread-activity.use-case';
+import { RecordThreadActivityCommand } from './record-thread-activity.command';
+import { ThreadsRepository } from '../../ports/threads.repository';
+
+describe('RecordThreadActivityUseCase', () => {
+  let useCase: RecordThreadActivityUseCase;
+  let mockThreadsRepository: { updateLastActivityAt: jest.Mock };
+
+  beforeEach(async () => {
+    mockThreadsRepository = {
+      updateLastActivityAt: jest.fn().mockResolvedValue(undefined),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        RecordThreadActivityUseCase,
+        { provide: ThreadsRepository, useValue: mockThreadsRepository },
+      ],
+    }).compile();
+
+    useCase = module.get(RecordThreadActivityUseCase);
+  });
+
+  it('bumps lastActivityAt for the thread to the activity time', async () => {
+    const threadId = randomUUID();
+    const occurredAt = new Date('2026-06-16T10:30:00.000Z');
+
+    await useCase.execute(
+      new RecordThreadActivityCommand(threadId, occurredAt),
+    );
+
+    expect(mockThreadsRepository.updateLastActivityAt).toHaveBeenCalledWith({
+      threadId,
+      lastActivityAt: occurredAt,
+    });
+  });
+
+  it('swallows repository errors so the message-add path is never broken', async () => {
+    mockThreadsRepository.updateLastActivityAt.mockRejectedValueOnce(
+      new Error('db unavailable'),
+    );
+
+    await expect(
+      useCase.execute(
+        new RecordThreadActivityCommand(randomUUID(), new Date()),
+      ),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/ayunis-core-backend/src/domain/threads/application/use-cases/record-thread-activity/record-thread-activity.use-case.ts
+++ b/ayunis-core-backend/src/domain/threads/application/use-cases/record-thread-activity/record-thread-activity.use-case.ts
@@ -1,0 +1,31 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ThreadsRepository } from '../../ports/threads.repository';
+import { RecordThreadActivityCommand } from './record-thread-activity.command';
+
+/**
+ * Bumps a thread's `lastActivityAt` to the time a message was added. Drives
+ * inactivity-based data retention. Best-effort: failures are logged, not
+ * thrown, because this runs off a fire-and-forget domain event and must never
+ * break the message-add path. A missed bump is self-healing — the next message
+ * advances the timestamp again, and retention windows are measured in months.
+ */
+@Injectable()
+export class RecordThreadActivityUseCase {
+  private readonly logger = new Logger(RecordThreadActivityUseCase.name);
+
+  constructor(private readonly threadsRepository: ThreadsRepository) {}
+
+  async execute(command: RecordThreadActivityCommand): Promise<void> {
+    try {
+      await this.threadsRepository.updateLastActivityAt({
+        threadId: command.threadId,
+        lastActivityAt: command.occurredAt,
+      });
+    } catch (error) {
+      this.logger.error('Failed to record thread activity', {
+        threadId: command.threadId,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      });
+    }
+  }
+}

--- a/ayunis-core-backend/src/domain/threads/domain/thread.entity.ts
+++ b/ayunis-core-backend/src/domain/threads/domain/thread.entity.ts
@@ -16,6 +16,7 @@ export class Thread {
   title?: string;
   messages: Message[];
   isAnonymous: boolean;
+  lastActivityAt: Date;
   createdAt: Date;
   updatedAt: Date;
 
@@ -29,6 +30,7 @@ export class Thread {
     title?: string;
     messages: Message[];
     isAnonymous?: boolean;
+    lastActivityAt?: Date;
     createdAt?: Date;
     updatedAt?: Date;
   }) {
@@ -43,6 +45,9 @@ export class Thread {
     this.isAnonymous = params.isAnonymous ?? false;
     this.createdAt = params.createdAt ?? new Date();
     this.updatedAt = params.updatedAt ?? new Date();
+    // A freshly created thread's last activity is its creation time; it is
+    // bumped whenever a message is added (see RecordThreadActivityUseCase).
+    this.lastActivityAt = params.lastActivityAt ?? this.createdAt;
   }
 
   getLastMessage(): Message | undefined {

--- a/ayunis-core-backend/src/domain/threads/infrastructure/persistence/local/local-threads.repository.ts
+++ b/ayunis-core-backend/src/domain/threads/infrastructure/persistence/local/local-threads.repository.ts
@@ -216,6 +216,17 @@ export class LocalThreadsRepository extends ThreadsRepository {
     }
   }
 
+  async updateLastActivityAt(params: {
+    threadId: UUID;
+    lastActivityAt: Date;
+  }): Promise<void> {
+    // Best-effort, fire-and-forget driven: no throw if the thread is gone.
+    await this.threadRepository.update(
+      { id: params.threadId },
+      { lastActivityAt: params.lastActivityAt },
+    );
+  }
+
   async updateSourceAssignments(params: {
     threadId: UUID;
     userId: UUID;

--- a/ayunis-core-backend/src/domain/threads/infrastructure/persistence/local/mappers/thread.mapper.ts
+++ b/ayunis-core-backend/src/domain/threads/infrastructure/persistence/local/mappers/thread.mapper.ts
@@ -43,6 +43,7 @@ export class ThreadMapper {
         (assignment) => this.kbAssignmentMapper.toRecord(assignment, thread.id),
       );
     }
+    record.lastActivityAt = thread.lastActivityAt;
     record.createdAt = thread.createdAt;
     record.updatedAt = thread.updatedAt;
     return record;
@@ -59,6 +60,7 @@ export class ThreadMapper {
       title: threadEntity.title,
       isAnonymous: threadEntity.isAnonymous,
       messages: this.mapMessages(threadEntity),
+      lastActivityAt: threadEntity.lastActivityAt ?? threadEntity.createdAt,
       createdAt: threadEntity.createdAt,
       updatedAt: threadEntity.updatedAt,
     });

--- a/ayunis-core-backend/src/domain/threads/infrastructure/persistence/local/schema/thread.record.ts
+++ b/ayunis-core-backend/src/domain/threads/infrastructure/persistence/local/schema/thread.record.ts
@@ -34,6 +34,18 @@ export class ThreadRecord extends BaseRecord {
   @Column({ default: false })
   isAnonymous: boolean;
 
+  /**
+   * Timestamp of the most recent conversation activity (last message added).
+   * Drives admin-defined data-retention deletion, which keys off inactivity
+   * rather than creation date. Distinct from `updatedAt`, which is bumped by
+   * any row write (rename, model change) and would let incidental edits
+   * silently extend retention. Nullable for backfill safety; the mapper always
+   * sets it and retention queries COALESCE to `createdAt` defensively.
+   */
+  @Column({ type: 'timestamp', nullable: true })
+  @Index()
+  lastActivityAt?: Date;
+
   @OneToMany(() => MessageRecord, (message) => message.thread)
   messages?: MessageRecord[];
 

--- a/ayunis-core-backend/src/domain/threads/threads.module.ts
+++ b/ayunis-core-backend/src/domain/threads/threads.module.ts
@@ -40,6 +40,8 @@ import { SaveGeneratedImageUseCase } from './application/use-cases/save-generate
 import { ResolveGeneratedImageUseCase } from './application/use-cases/resolve-generated-image/resolve-generated-image.use-case';
 import { GeneratedImagesController } from './presenters/http/generated-images.controller';
 import { ShareDeletedListener } from './application/listeners/share-deleted.listener';
+import { ThreadActivityListener } from './application/listeners/thread-activity.listener';
+import { RecordThreadActivityUseCase } from './application/use-cases/record-thread-activity/record-thread-activity.use-case';
 import { CleanupStaleThreadSourcesUseCase } from './application/use-cases/cleanup-stale-thread-sources/cleanup-stale-thread-sources.use-case';
 import { StaleThreadSourcesCleanupTask } from './infrastructure/tasks/stale-thread-sources-cleanup.task';
 import { KnowledgeBasesModule } from '../knowledge-bases/knowledge-bases.module';
@@ -100,8 +102,10 @@ import { McpModule } from '../mcp/mcp.module';
     SaveGeneratedImageUseCase,
     ResolveGeneratedImageUseCase,
     CleanupStaleThreadSourcesUseCase,
+    RecordThreadActivityUseCase,
     // Listeners
     ShareDeletedListener,
+    ThreadActivityListener,
     // Tasks
     StaleThreadSourcesCleanupTask,
     // Mappers
@@ -114,6 +118,7 @@ import { McpModule } from '../mcp/mcp.module';
     // Export use cases
     FindThreadUseCase,
     FindAllThreadsUseCase,
+    DeleteThreadUseCase,
     AddMessageToThreadUseCase,
     AddSourceToThreadUseCase,
     RemoveSourceFromThreadUseCase,


### PR DESCRIPTION
- Add lastActivityAt column to threads, bumped on each message add
- Drives inactivity-based retention; distinct from updatedAt so incidental
  row edits do not silently extend retention
- Record activity via ThreadActivityListener on ThreadMessageAddedEvent
- Migration backfills existing rows from MAX(message.createdAt)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Production migration backfills all threads from messages; missed async updates are tolerated but could skew retention until the next message.
> 
> **Overview**
> Adds **`lastActivityAt`** on threads so retention can use **conversation inactivity** instead of **`updatedAt`** (renames/model changes no longer extend retention).
> 
> A migration adds the indexed column and **backfills** existing rows from the latest message timestamp, or **`createdAt`** when there are no messages. On each **`ThreadMessageAddedEvent`**, **`ThreadActivityListener`** runs a best-effort **`RecordThreadActivityUseCase`** that updates **`lastActivityAt`** without failing the message-add flow if the write errors. **`DeleteThreadUseCase`** is also exported from **`ThreadsModule`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dce50da6f33c30e68fcceaec6d5a9bcc204c24f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->