### PR TITLE
wip(retention): add org data-retention policy settings (AYC-66)

### DIFF
--- a/ayunis-core-backend/src/app/app.module.ts
+++ b/ayunis-core-backend/src/app/app.module.ts
@@ -23,6 +23,7 @@ import { UsageModule } from '../domain/usage/usage.module';
 import { TranscriptionsModule } from '../domain/transcriptions/transcriptions.module';
 import { ChatSettingsModule } from '../domain/chat-settings/chat-settings.module';
 import { AnonymizationSettingsModule } from '../domain/anonymization-settings/anonymization-settings.module';
+import { RetentionPoliciesModule } from '../domain/retention-policies/retention-policies.module';
 import { KnowledgeBasesModule } from '../domain/knowledge-bases/knowledge-bases.module';
 import { CrawlDomainGrantsModule } from '../domain/crawl-domain-grants/crawl-domain-grants.module';
 import { SkillTemplatesModule } from '../domain/skill-templates/skill-templates.module';
@@ -166,6 +167,7 @@ import { IntegrationsModule } from '../integrations/integrations.module';
     TranscriptionsModule,
     ChatSettingsModule,
     AnonymizationSettingsModule,
+    RetentionPoliciesModule,
     KnowledgeBasesModule,
     CrawlDomainGrantsModule,
     SkillTemplatesModule,

--- a/ayunis-core-backend/src/db/migrations/1781642066562-CreateOrgRetentionPoliciesTable.ts
+++ b/ayunis-core-backend/src/db/migrations/1781642066562-CreateOrgRetentionPoliciesTable.ts
@@ -1,0 +1,27 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateOrgRetentionPoliciesTable1781642066562 implements MigrationInterface {
+  name = 'CreateOrgRetentionPoliciesTable1781642066562';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE "org_retention_policies" ("id" character varying NOT NULL, "createdAt" TIMESTAMP NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP NOT NULL DEFAULT now(), "orgId" character varying NOT NULL, "retentionDays" integer, CONSTRAINT "UQ_a4d7f545955a16e80c9b97044f6" UNIQUE ("orgId"), CONSTRAINT "PK_13884251d23bfa97980552a0d5b" PRIMARY KEY ("id"))`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_a4d7f545955a16e80c9b97044f" ON "org_retention_policies" ("orgId") `,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "org_retention_policies" ADD CONSTRAINT "FK_a4d7f545955a16e80c9b97044f6" FOREIGN KEY ("orgId") REFERENCES "orgs"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "org_retention_policies" DROP CONSTRAINT "FK_a4d7f545955a16e80c9b97044f6"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_a4d7f545955a16e80c9b97044f"`,
+    );
+    await queryRunner.query(`DROP TABLE "org_retention_policies"`);
+  }
+}

--- a/ayunis-core-backend/src/domain/retention-policies/application/ports/retention-policies.repository.ts
+++ b/ayunis-core-backend/src/domain/retention-policies/application/ports/retention-policies.repository.ts
@@ -1,0 +1,16 @@
+import type { UUID } from 'crypto';
+import type { OrgRetentionPolicy } from '../../domain/org-retention-policy.entity';
+
+export abstract class RetentionPoliciesRepository {
+  /** Returns the org's policy, or null when none has been configured. */
+  abstract findByOrgId(orgId: UUID): Promise<OrgRetentionPolicy | null>;
+
+  /** Creates or replaces the org's policy (unique per org). */
+  abstract upsert(policy: OrgRetentionPolicy): Promise<OrgRetentionPolicy>;
+
+  /**
+   * Returns every org's policy that has retention enabled
+   * (`retentionDays !== null`). Drives the nightly enforcement job.
+   */
+  abstract findAllEnabled(): Promise<OrgRetentionPolicy[]>;
+}

--- a/ayunis-core-backend/src/domain/retention-policies/application/retention-policies.errors.ts
+++ b/ayunis-core-backend/src/domain/retention-policies/application/retention-policies.errors.ts
@@ -1,0 +1,31 @@
+import type { ErrorMetadata } from 'src/common/errors/base.error';
+import { ApplicationError } from 'src/common/errors/base.error';
+import { ALLOWED_RETENTION_DAYS } from '../domain/retention-period';
+
+export enum RetentionPolicyErrorCode {
+  INVALID_RETENTION_PERIOD = 'INVALID_RETENTION_PERIOD',
+  UNEXPECTED_ERROR = 'UNEXPECTED_RETENTION_POLICY_ERROR',
+}
+
+export class InvalidRetentionPeriodError extends ApplicationError {
+  constructor(value: number | null, metadata?: ErrorMetadata) {
+    super(
+      `Invalid retention period: ${value}. Allowed values are null (disabled) ` +
+        `or one of [${ALLOWED_RETENTION_DAYS.join(', ')}] days.`,
+      RetentionPolicyErrorCode.INVALID_RETENTION_PERIOD,
+      400,
+      { value, allowed: [...ALLOWED_RETENTION_DAYS], ...metadata },
+    );
+  }
+}
+
+export class UnexpectedRetentionPolicyError extends ApplicationError {
+  constructor(operation: string, metadata?: ErrorMetadata) {
+    super(
+      `Unexpected retention policy error during ${operation}`,
+      RetentionPolicyErrorCode.UNEXPECTED_ERROR,
+      500,
+      { operation, ...metadata },
+    );
+  }
+}

--- a/ayunis-core-backend/src/domain/retention-policies/application/use-cases/get-org-retention-policy/get-org-retention-policy.query.ts
+++ b/ayunis-core-backend/src/domain/retention-policies/application/use-cases/get-org-retention-policy/get-org-retention-policy.query.ts
@@ -1,0 +1,5 @@
+import type { UUID } from 'crypto';
+
+export class GetOrgRetentionPolicyQuery {
+  constructor(public readonly orgId: UUID) {}
+}

--- a/ayunis-core-backend/src/domain/retention-policies/application/use-cases/get-org-retention-policy/get-org-retention-policy.use-case.ts
+++ b/ayunis-core-backend/src/domain/retention-policies/application/use-cases/get-org-retention-policy/get-org-retention-policy.use-case.ts
@@ -1,0 +1,36 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ApplicationError } from 'src/common/errors/base.error';
+import { RetentionPoliciesRepository } from '../../ports/retention-policies.repository';
+import { UnexpectedRetentionPolicyError } from '../../retention-policies.errors';
+import type { OrgRetentionPolicy } from '../../../domain/org-retention-policy.entity';
+import type { GetOrgRetentionPolicyQuery } from './get-org-retention-policy.query';
+
+@Injectable()
+export class GetOrgRetentionPolicyUseCase {
+  private readonly logger = new Logger(GetOrgRetentionPolicyUseCase.name);
+
+  constructor(private readonly repository: RetentionPoliciesRepository) {}
+
+  /** Returns the org's policy, or null when retention has never been set. */
+  async execute(
+    query: GetOrgRetentionPolicyQuery,
+  ): Promise<OrgRetentionPolicy | null> {
+    this.logger.debug('Getting retention policy', { orgId: query.orgId });
+
+    try {
+      return await this.repository.findByOrgId(query.orgId);
+    } catch (error) {
+      if (error instanceof ApplicationError) throw error;
+
+      this.logger.error('Failed to get retention policy', {
+        error: error instanceof Error ? error.message : 'Unknown error',
+        orgId: query.orgId,
+      });
+
+      throw new UnexpectedRetentionPolicyError('get', {
+        orgId: query.orgId,
+        ...(error instanceof Error && { originalError: error.message }),
+      });
+    }
+  }
+}

--- a/ayunis-core-backend/src/domain/retention-policies/application/use-cases/upsert-org-retention-policy/upsert-org-retention-policy.command.ts
+++ b/ayunis-core-backend/src/domain/retention-policies/application/use-cases/upsert-org-retention-policy/upsert-org-retention-policy.command.ts
@@ -1,0 +1,9 @@
+import type { UUID } from 'crypto';
+
+export class UpsertOrgRetentionPolicyCommand {
+  constructor(
+    public readonly orgId: UUID,
+    /** Days of inactivity before deletion, or null to disable retention. */
+    public readonly retentionDays: number | null,
+  ) {}
+}

--- a/ayunis-core-backend/src/domain/retention-policies/application/use-cases/upsert-org-retention-policy/upsert-org-retention-policy.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/retention-policies/application/use-cases/upsert-org-retention-policy/upsert-org-retention-policy.use-case.spec.ts
@@ -1,0 +1,91 @@
+import type { TestingModule } from '@nestjs/testing';
+import { Test } from '@nestjs/testing';
+import { randomUUID } from 'crypto';
+import { UpsertOrgRetentionPolicyUseCase } from './upsert-org-retention-policy.use-case';
+import { UpsertOrgRetentionPolicyCommand } from './upsert-org-retention-policy.command';
+import { RetentionPoliciesRepository } from '../../ports/retention-policies.repository';
+import { InvalidRetentionPeriodError } from '../../retention-policies.errors';
+import { OrgRetentionPolicy } from '../../../domain/org-retention-policy.entity';
+
+describe('UpsertOrgRetentionPolicyUseCase', () => {
+  let useCase: UpsertOrgRetentionPolicyUseCase;
+  let repository: {
+    findByOrgId: jest.Mock;
+    upsert: jest.Mock;
+    findAllEnabled: jest.Mock;
+  };
+
+  beforeEach(async () => {
+    repository = {
+      findByOrgId: jest.fn().mockResolvedValue(null),
+      upsert: jest
+        .fn()
+        .mockImplementation((policy: OrgRetentionPolicy) =>
+          Promise.resolve(policy),
+        ),
+      findAllEnabled: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        UpsertOrgRetentionPolicyUseCase,
+        { provide: RetentionPoliciesRepository, useValue: repository },
+      ],
+    }).compile();
+
+    useCase = module.get(UpsertOrgRetentionPolicyUseCase);
+  });
+
+  it('persists an allowed retention window', async () => {
+    const orgId = randomUUID();
+
+    const result = await useCase.execute(
+      new UpsertOrgRetentionPolicyCommand(orgId, 90),
+    );
+
+    expect(result.retentionDays).toBe(90);
+    expect(repository.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({ orgId, retentionDays: 90 }),
+    );
+  });
+
+  it('persists null to disable retention (keep forever)', async () => {
+    const result = await useCase.execute(
+      new UpsertOrgRetentionPolicyCommand(randomUUID(), null),
+    );
+
+    expect(result.retentionDays).toBeNull();
+    expect(result.isEnabled()).toBe(false);
+  });
+
+  it('rejects a value below the allowed floor instead of persisting it', async () => {
+    await expect(
+      useCase.execute(new UpsertOrgRetentionPolicyCommand(randomUUID(), 1)),
+    ).rejects.toBeInstanceOf(InvalidRetentionPeriodError);
+    expect(repository.upsert).not.toHaveBeenCalled();
+  });
+
+  it('rejects an arbitrary off-allowlist value', async () => {
+    await expect(
+      useCase.execute(new UpsertOrgRetentionPolicyCommand(randomUUID(), 100)),
+    ).rejects.toBeInstanceOf(InvalidRetentionPeriodError);
+  });
+
+  it('preserves the original id and createdAt when updating an existing policy', async () => {
+    const orgId = randomUUID();
+    const existing = new OrgRetentionPolicy({
+      orgId,
+      retentionDays: 30,
+      createdAt: new Date('2026-01-01T00:00:00.000Z'),
+    });
+    repository.findByOrgId.mockResolvedValueOnce(existing);
+
+    const result = await useCase.execute(
+      new UpsertOrgRetentionPolicyCommand(orgId, 365),
+    );
+
+    expect(result.id).toBe(existing.id);
+    expect(result.createdAt).toEqual(existing.createdAt);
+    expect(result.retentionDays).toBe(365);
+  });
+});

--- a/ayunis-core-backend/src/domain/retention-policies/application/use-cases/upsert-org-retention-policy/upsert-org-retention-policy.use-case.ts
+++ b/ayunis-core-backend/src/domain/retention-policies/application/use-cases/upsert-org-retention-policy/upsert-org-retention-policy.use-case.ts
@@ -1,0 +1,56 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ApplicationError } from 'src/common/errors/base.error';
+import { RetentionPoliciesRepository } from '../../ports/retention-policies.repository';
+import {
+  InvalidRetentionPeriodError,
+  UnexpectedRetentionPolicyError,
+} from '../../retention-policies.errors';
+import { OrgRetentionPolicy } from '../../../domain/org-retention-policy.entity';
+import { isValidRetentionDays } from '../../../domain/retention-period';
+import type { UpsertOrgRetentionPolicyCommand } from './upsert-org-retention-policy.command';
+
+@Injectable()
+export class UpsertOrgRetentionPolicyUseCase {
+  private readonly logger = new Logger(UpsertOrgRetentionPolicyUseCase.name);
+
+  constructor(private readonly repository: RetentionPoliciesRepository) {}
+
+  async execute(
+    command: UpsertOrgRetentionPolicyCommand,
+  ): Promise<OrgRetentionPolicy> {
+    this.logger.log('Upserting retention policy', {
+      orgId: command.orgId,
+      retentionDays: command.retentionDays,
+    });
+
+    if (!isValidRetentionDays(command.retentionDays)) {
+      throw new InvalidRetentionPeriodError(command.retentionDays, {
+        orgId: command.orgId,
+      });
+    }
+
+    try {
+      const existing = await this.repository.findByOrgId(command.orgId);
+      const policy = new OrgRetentionPolicy({
+        id: existing?.id,
+        orgId: command.orgId,
+        retentionDays: command.retentionDays,
+        createdAt: existing?.createdAt,
+        updatedAt: new Date(),
+      });
+      return await this.repository.upsert(policy);
+    } catch (error) {
+      if (error instanceof ApplicationError) throw error;
+
+      this.logger.error('Failed to upsert retention policy', {
+        error: error instanceof Error ? error.message : 'Unknown error',
+        orgId: command.orgId,
+      });
+
+      throw new UnexpectedRetentionPolicyError('upsert', {
+        orgId: command.orgId,
+        ...(error instanceof Error && { originalError: error.message }),
+      });
+    }
+  }
+}

--- a/ayunis-core-backend/src/domain/retention-policies/domain/org-retention-policy.entity.spec.ts
+++ b/ayunis-core-backend/src/domain/retention-policies/domain/org-retention-policy.entity.spec.ts
@@ -1,0 +1,26 @@
+import { randomUUID } from 'crypto';
+import { OrgRetentionPolicy } from './org-retention-policy.entity';
+
+describe('OrgRetentionPolicy', () => {
+  it('is disabled when retentionDays is null and has no cutoff', () => {
+    const policy = new OrgRetentionPolicy({
+      orgId: randomUUID(),
+      retentionDays: null,
+    });
+
+    expect(policy.isEnabled()).toBe(false);
+    expect(policy.cutoffFrom(new Date('2026-06-16T00:00:00.000Z'))).toBeNull();
+  });
+
+  it('computes the activity cutoff by subtracting retentionDays from now', () => {
+    const policy = new OrgRetentionPolicy({
+      orgId: randomUUID(),
+      retentionDays: 90,
+    });
+
+    const cutoff = policy.cutoffFrom(new Date('2026-06-16T00:00:00.000Z'));
+
+    expect(policy.isEnabled()).toBe(true);
+    expect(cutoff?.toISOString()).toBe('2026-03-18T00:00:00.000Z');
+  });
+});

--- a/ayunis-core-backend/src/domain/retention-policies/domain/org-retention-policy.entity.ts
+++ b/ayunis-core-backend/src/domain/retention-policies/domain/org-retention-policy.entity.ts
@@ -1,0 +1,50 @@
+import type { UUID } from 'crypto';
+import { randomUUID } from 'crypto';
+
+export interface OrgRetentionPolicyParams {
+  id?: UUID;
+  orgId: UUID;
+  retentionDays: number | null;
+  createdAt?: Date;
+  updatedAt?: Date;
+}
+
+/**
+ * Org-level data-retention setting. `retentionDays === null` means retention
+ * is disabled (data is kept forever) — the default for every org until an
+ * admin opts in. When enabled, conversation data with no activity for longer
+ * than `retentionDays` is deleted by the nightly enforcement job.
+ */
+export class OrgRetentionPolicy {
+  id: UUID;
+  orgId: UUID;
+  retentionDays: number | null;
+  createdAt: Date;
+  updatedAt: Date;
+
+  constructor(params: OrgRetentionPolicyParams) {
+    this.id = params.id ?? randomUUID();
+    this.orgId = params.orgId;
+    this.retentionDays = params.retentionDays;
+    this.createdAt = params.createdAt ?? new Date();
+    this.updatedAt = params.updatedAt ?? new Date();
+  }
+
+  isEnabled(): boolean {
+    return this.retentionDays !== null;
+  }
+
+  /**
+   * The activity cutoff for this policy: threads whose last activity is before
+   * the returned date are expired. Returns `null` when retention is disabled.
+   */
+  cutoffFrom(now: Date): Date | null {
+    if (this.retentionDays === null) {
+      return null;
+    }
+    // Absolute-time arithmetic (not setDate) so the cutoff is deterministic
+    // and independent of the server's timezone / DST transitions.
+    const millisPerDay = 24 * 60 * 60 * 1000;
+    return new Date(now.getTime() - this.retentionDays * millisPerDay);
+  }
+}

--- a/ayunis-core-backend/src/domain/retention-policies/domain/retention-period.ts
+++ b/ayunis-core-backend/src/domain/retention-policies/domain/retention-period.ts
@@ -1,0 +1,21 @@
+/**
+ * Allowed retention windows, in days. Retention is restricted to this
+ * allowlist (rather than a free-form integer) so an admin cannot accidentally
+ * configure a destructive value like "1 day". The lowest value doubles as the
+ * floor. `null` is a valid, separate state meaning "disabled / keep forever".
+ */
+export const ALLOWED_RETENTION_DAYS = [30, 90, 180, 365, 730] as const;
+
+export type RetentionDays = (typeof ALLOWED_RETENTION_DAYS)[number];
+
+/**
+ * A retention setting is valid when it is either `null` (disabled) or one of
+ * the allowed windows. Used by both the HTTP DTO and the domain use case so
+ * non-HTTP callers (e.g. seeds, scripts) are held to the same constraint.
+ */
+export function isValidRetentionDays(value: number | null): boolean {
+  if (value === null) {
+    return true;
+  }
+  return (ALLOWED_RETENTION_DAYS as readonly number[]).includes(value);
+}

--- a/ayunis-core-backend/src/domain/retention-policies/infrastructure/persistence/postgres/mappers/org-retention-policy.mapper.ts
+++ b/ayunis-core-backend/src/domain/retention-policies/infrastructure/persistence/postgres/mappers/org-retention-policy.mapper.ts
@@ -1,0 +1,24 @@
+import { OrgRetentionPolicy } from '../../../../domain/org-retention-policy.entity';
+import { OrgRetentionPolicyRecord } from '../schema/org-retention-policy.record';
+
+export class OrgRetentionPolicyMapper {
+  static toDomain(record: OrgRetentionPolicyRecord): OrgRetentionPolicy {
+    return new OrgRetentionPolicy({
+      id: record.id,
+      orgId: record.orgId,
+      retentionDays: record.retentionDays,
+      createdAt: record.createdAt,
+      updatedAt: record.updatedAt,
+    });
+  }
+
+  static toRecord(domain: OrgRetentionPolicy): OrgRetentionPolicyRecord {
+    const record = new OrgRetentionPolicyRecord();
+    record.id = domain.id;
+    record.orgId = domain.orgId;
+    record.retentionDays = domain.retentionDays;
+    record.createdAt = domain.createdAt;
+    record.updatedAt = domain.updatedAt;
+    return record;
+  }
+}

--- a/ayunis-core-backend/src/domain/retention-policies/infrastructure/persistence/postgres/postgres-retention-policies.repository.ts
+++ b/ayunis-core-backend/src/domain/retention-policies/infrastructure/persistence/postgres/postgres-retention-policies.repository.ts
@@ -1,0 +1,45 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Not, IsNull, Repository } from 'typeorm';
+import type { UUID } from 'crypto';
+import { RetentionPoliciesRepository } from '../../../application/ports/retention-policies.repository';
+import { OrgRetentionPolicy } from '../../../domain/org-retention-policy.entity';
+import { OrgRetentionPolicyRecord } from './schema/org-retention-policy.record';
+import { OrgRetentionPolicyMapper } from './mappers/org-retention-policy.mapper';
+
+@Injectable()
+export class PostgresRetentionPoliciesRepository extends RetentionPoliciesRepository {
+  private readonly logger = new Logger(
+    PostgresRetentionPoliciesRepository.name,
+  );
+
+  constructor(
+    @InjectRepository(OrgRetentionPolicyRecord)
+    private readonly repository: Repository<OrgRetentionPolicyRecord>,
+  ) {
+    super();
+  }
+
+  async findByOrgId(orgId: UUID): Promise<OrgRetentionPolicy | null> {
+    const record = await this.repository.findOne({ where: { orgId } });
+    return record ? OrgRetentionPolicyMapper.toDomain(record) : null;
+  }
+
+  async upsert(policy: OrgRetentionPolicy): Promise<OrgRetentionPolicy> {
+    this.logger.debug('upsert', {
+      orgId: policy.orgId,
+      retentionDays: policy.retentionDays,
+    });
+    const saved = await this.repository.save(
+      OrgRetentionPolicyMapper.toRecord(policy),
+    );
+    return OrgRetentionPolicyMapper.toDomain(saved);
+  }
+
+  async findAllEnabled(): Promise<OrgRetentionPolicy[]> {
+    const records = await this.repository.find({
+      where: { retentionDays: Not(IsNull()) },
+    });
+    return records.map((record) => OrgRetentionPolicyMapper.toDomain(record));
+  }
+}

--- a/ayunis-core-backend/src/domain/retention-policies/infrastructure/persistence/postgres/schema/org-retention-policy.record.ts
+++ b/ayunis-core-backend/src/domain/retention-policies/infrastructure/persistence/postgres/schema/org-retention-policy.record.ts
@@ -1,0 +1,20 @@
+import { Column, Entity, Index, JoinColumn, ManyToOne, Unique } from 'typeorm';
+import type { UUID } from 'crypto';
+import { BaseRecord } from '../../../../../../common/db/base-record';
+import { OrgRecord } from '../../../../../../iam/orgs/infrastructure/repositories/local/schema/org.record';
+
+@Entity({ name: 'org_retention_policies' })
+@Unique(['orgId'])
+export class OrgRetentionPolicyRecord extends BaseRecord {
+  @Index()
+  @Column()
+  orgId: UUID;
+
+  @ManyToOne(() => OrgRecord, { nullable: false, onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'orgId' })
+  org: OrgRecord;
+
+  /** Days of inactivity before deletion; null disables retention. */
+  @Column({ type: 'int', nullable: true })
+  retentionDays: number | null;
+}

--- a/ayunis-core-backend/src/domain/retention-policies/presenters/http/dtos/retention-policy-response.dto.ts
+++ b/ayunis-core-backend/src/domain/retention-policies/presenters/http/dtos/retention-policy-response.dto.ts
@@ -1,0 +1,29 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { ALLOWED_RETENTION_DAYS } from '../../../domain/retention-period';
+
+export class RetentionPolicyResponseDto {
+  @ApiProperty({
+    description:
+      'Configured retention window in days, or null when retention is ' +
+      'disabled (data kept forever).',
+    type: Number,
+    nullable: true,
+    example: 90,
+  })
+  retentionDays: number | null;
+
+  @ApiProperty({
+    description: 'Whether retention is currently enabled for the org.',
+    example: true,
+  })
+  enabled: boolean;
+
+  @ApiProperty({
+    description:
+      'Retention windows (in days) the admin may choose from. Lets the UI ' +
+      'render the selector without hardcoding the allowlist.',
+    type: [Number],
+    example: [...ALLOWED_RETENTION_DAYS],
+  })
+  allowedRetentionDays: number[];
+}

--- a/ayunis-core-backend/src/domain/retention-policies/presenters/http/dtos/update-retention-policy-request.dto.ts
+++ b/ayunis-core-backend/src/domain/retention-policies/presenters/http/dtos/update-retention-policy-request.dto.ts
@@ -1,0 +1,20 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsIn } from 'class-validator';
+import { ALLOWED_RETENTION_DAYS } from '../../../domain/retention-period';
+
+export class UpdateRetentionPolicyRequestDto {
+  @ApiProperty({
+    description:
+      'Days of inactivity after which conversation data is permanently ' +
+      'deleted. Null disables retention (keep data forever). Must be one of ' +
+      'the allowed windows.',
+    enum: ALLOWED_RETENTION_DAYS,
+    nullable: true,
+    example: 90,
+  })
+  // IsIn (with null in the list) both constrains the value to the allowlist
+  // and makes the field required — undefined is not a member, so it is
+  // rejected with 400. The use case re-validates for non-HTTP callers.
+  @IsIn([...ALLOWED_RETENTION_DAYS, null])
+  retentionDays: number | null;
+}

--- a/ayunis-core-backend/src/domain/retention-policies/presenters/http/retention-policies.controller.ts
+++ b/ayunis-core-backend/src/domain/retention-policies/presenters/http/retention-policies.controller.ts
@@ -1,0 +1,91 @@
+import { Body, Controller, Get, Logger, Put } from '@nestjs/common';
+import {
+  ApiExtraModels,
+  ApiOperation,
+  ApiResponse,
+  ApiTags,
+  getSchemaPath,
+} from '@nestjs/swagger';
+import type { UUID } from 'crypto';
+import {
+  CurrentUser,
+  UserProperty,
+} from 'src/iam/authentication/application/decorators/current-user.decorator';
+import { Roles } from 'src/iam/authorization/application/decorators/roles.decorator';
+import { UserRole } from 'src/iam/users/domain/value-objects/role.object';
+import { GetOrgRetentionPolicyUseCase } from '../../application/use-cases/get-org-retention-policy/get-org-retention-policy.use-case';
+import { GetOrgRetentionPolicyQuery } from '../../application/use-cases/get-org-retention-policy/get-org-retention-policy.query';
+import { UpsertOrgRetentionPolicyUseCase } from '../../application/use-cases/upsert-org-retention-policy/upsert-org-retention-policy.use-case';
+import { UpsertOrgRetentionPolicyCommand } from '../../application/use-cases/upsert-org-retention-policy/upsert-org-retention-policy.command';
+import { ALLOWED_RETENTION_DAYS } from '../../domain/retention-period';
+import { UpdateRetentionPolicyRequestDto } from './dtos/update-retention-policy-request.dto';
+import { RetentionPolicyResponseDto } from './dtos/retention-policy-response.dto';
+
+@ApiTags('retention-policies')
+@Controller('retention-policies')
+@ApiExtraModels(RetentionPolicyResponseDto)
+export class RetentionPoliciesController {
+  private readonly logger = new Logger(RetentionPoliciesController.name);
+
+  constructor(
+    private readonly getOrgRetentionPolicy: GetOrgRetentionPolicyUseCase,
+    private readonly upsertOrgRetentionPolicy: UpsertOrgRetentionPolicyUseCase,
+  ) {}
+
+  @Get('org')
+  @Roles(UserRole.ADMIN)
+  @ApiOperation({
+    summary: 'Get the data-retention policy for the current org',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Current retention policy (disabled if never configured)',
+    schema: { $ref: getSchemaPath(RetentionPolicyResponseDto) },
+  })
+  async get(
+    @CurrentUser(UserProperty.ORG_ID) orgId: UUID,
+  ): Promise<RetentionPolicyResponseDto> {
+    this.logger.log(`Getting retention policy for org ${orgId}`);
+
+    const policy = await this.getOrgRetentionPolicy.execute(
+      new GetOrgRetentionPolicyQuery(orgId),
+    );
+    return this.toResponse(policy?.retentionDays ?? null);
+  }
+
+  @Put('org')
+  @Roles(UserRole.ADMIN)
+  @ApiOperation({
+    summary: 'Set or clear the data-retention policy for the current org',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Updated retention policy',
+    schema: { $ref: getSchemaPath(RetentionPolicyResponseDto) },
+  })
+  @ApiResponse({
+    status: 400,
+    description: 'Retention period is not one of the allowed windows',
+  })
+  async update(
+    @CurrentUser(UserProperty.ORG_ID) orgId: UUID,
+    @Body() dto: UpdateRetentionPolicyRequestDto,
+  ): Promise<RetentionPolicyResponseDto> {
+    this.logger.log(`Updating retention policy for org ${orgId}`, {
+      retentionDays: dto.retentionDays,
+    });
+
+    const policy = await this.upsertOrgRetentionPolicy.execute(
+      new UpsertOrgRetentionPolicyCommand(orgId, dto.retentionDays),
+    );
+    return this.toResponse(policy.retentionDays);
+  }
+
+  private toResponse(retentionDays: number | null): RetentionPolicyResponseDto {
+    return {
+      retentionDays,
+      enabled: retentionDays !== null,
+      allowedRetentionDays: [...ALLOWED_RETENTION_DAYS],
+    };
+  }
+}

--- a/ayunis-core-backend/src/domain/retention-policies/retention-policies.module.ts
+++ b/ayunis-core-backend/src/domain/retention-policies/retention-policies.module.ts
@@ -1,0 +1,24 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+
+import { OrgRetentionPolicyRecord } from './infrastructure/persistence/postgres/schema/org-retention-policy.record';
+import { RetentionPoliciesRepository } from './application/ports/retention-policies.repository';
+import { PostgresRetentionPoliciesRepository } from './infrastructure/persistence/postgres/postgres-retention-policies.repository';
+import { GetOrgRetentionPolicyUseCase } from './application/use-cases/get-org-retention-policy/get-org-retention-policy.use-case';
+import { UpsertOrgRetentionPolicyUseCase } from './application/use-cases/upsert-org-retention-policy/upsert-org-retention-policy.use-case';
+import { RetentionPoliciesController } from './presenters/http/retention-policies.controller';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([OrgRetentionPolicyRecord])],
+  controllers: [RetentionPoliciesController],
+  providers: [
+    {
+      provide: RetentionPoliciesRepository,
+      useClass: PostgresRetentionPoliciesRepository,
+    },
+    GetOrgRetentionPolicyUseCase,
+    UpsertOrgRetentionPolicyUseCase,
+  ],
+  exports: [GetOrgRetentionPolicyUseCase, UpsertOrgRetentionPolicyUseCase],
+})
+export class RetentionPoliciesModule {}

--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
@@ -4038,6 +4038,42 @@ export interface UpsertOrgSystemPromptDto {
   systemPrompt: string;
 }
 
+export interface RetentionPolicyResponseDto {
+  /**
+   * Configured retention window in days, or null when retention is disabled (data kept forever).
+   * @nullable
+   */
+  retentionDays: number | null;
+  /** Whether retention is currently enabled for the org. */
+  enabled: boolean;
+  /** Retention windows (in days) the admin may choose from. Lets the UI render the selector without hardcoding the allowlist. */
+  allowedRetentionDays: number[];
+}
+
+/**
+ * Days of inactivity after which conversation data is permanently deleted. Null disables retention (keep data forever). Must be one of the allowed windows.
+ * @nullable
+ */
+export type UpdateRetentionPolicyRequestDtoRetentionDays = typeof UpdateRetentionPolicyRequestDtoRetentionDays[keyof typeof UpdateRetentionPolicyRequestDtoRetentionDays] | null;
+
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const UpdateRetentionPolicyRequestDtoRetentionDays = {
+  NUMBER_30: 30,
+  NUMBER_90: 90,
+  NUMBER_180: 180,
+  NUMBER_365: 365,
+  NUMBER_730: 730,
+} as const;
+
+export interface UpdateRetentionPolicyRequestDto {
+  /**
+   * Days of inactivity after which conversation data is permanently deleted. Null disables retention (keep data forever). Must be one of the allowed windows.
+   * @nullable
+   */
+  retentionDays: UpdateRetentionPolicyRequestDtoRetentionDays;
+}
+
 export interface AcademyLessonResponseDto {
   /** The unique identifier of the lesson */
   id: string;

--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.ts
@@ -125,6 +125,7 @@ import type {
   ReorderLessonsRequestDto,
   ResendEmailConfirmationDto,
   ResetPasswordDto,
+  RetentionPolicyResponseDto,
   RevertArtifactDto,
   RunsControllerSendMessage200,
   RunsControllerSendMessageBody,
@@ -186,6 +187,7 @@ import type {
   UpdatePasswordDto,
   UpdatePermittedModelDto,
   UpdatePiiWhitelistRequestDto,
+  UpdateRetentionPolicyRequestDto,
   UpdateSeatsDto,
   UpdateSkillDto,
   UpdateSkillTemplateDto,
@@ -16339,6 +16341,163 @@ export const useOrgSystemPromptControllerDeleteOrgSystemPrompt = <TError = void,
       > => {
 
       const mutationOptions = getOrgSystemPromptControllerDeleteOrgSystemPromptMutationOptions(options);
+
+      return useMutation(mutationOptions, queryClient);
+    }
+    
+/**
+ * @summary Get the data-retention policy for the current org
+ */
+export const retentionPoliciesControllerGet = (
+    
+ signal?: AbortSignal
+) => {
+      
+      
+      return customAxiosInstance<RetentionPolicyResponseDto>(
+      {url: `/retention-policies/org`, method: 'GET', signal
+    },
+      );
+    }
+  
+
+
+
+export const getRetentionPoliciesControllerGetQueryKey = () => {
+    return [
+    `/retention-policies/org`
+    ] as const;
+    }
+
+    
+export const getRetentionPoliciesControllerGetQueryOptions = <TData = Awaited<ReturnType<typeof retentionPoliciesControllerGet>>, TError = unknown>( options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof retentionPoliciesControllerGet>>, TError, TData>>, }
+) => {
+
+const {query: queryOptions} = options ?? {};
+
+  const queryKey =  queryOptions?.queryKey ?? getRetentionPoliciesControllerGetQueryKey();
+
+  
+
+    const queryFn: QueryFunction<Awaited<ReturnType<typeof retentionPoliciesControllerGet>>> = ({ signal }) => retentionPoliciesControllerGet(signal);
+
+      
+
+      
+
+   return  { queryKey, queryFn, ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof retentionPoliciesControllerGet>>, TError, TData> & { queryKey: DataTag<QueryKey, TData, TError> }
+}
+
+export type RetentionPoliciesControllerGetQueryResult = NonNullable<Awaited<ReturnType<typeof retentionPoliciesControllerGet>>>
+export type RetentionPoliciesControllerGetQueryError = unknown
+
+
+export function useRetentionPoliciesControllerGet<TData = Awaited<ReturnType<typeof retentionPoliciesControllerGet>>, TError = unknown>(
+  options: { query:Partial<UseQueryOptions<Awaited<ReturnType<typeof retentionPoliciesControllerGet>>, TError, TData>> & Pick<
+        DefinedInitialDataOptions<
+          Awaited<ReturnType<typeof retentionPoliciesControllerGet>>,
+          TError,
+          Awaited<ReturnType<typeof retentionPoliciesControllerGet>>
+        > , 'initialData'
+      >, }
+ , queryClient?: QueryClient
+  ):  DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useRetentionPoliciesControllerGet<TData = Awaited<ReturnType<typeof retentionPoliciesControllerGet>>, TError = unknown>(
+  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof retentionPoliciesControllerGet>>, TError, TData>> & Pick<
+        UndefinedInitialDataOptions<
+          Awaited<ReturnType<typeof retentionPoliciesControllerGet>>,
+          TError,
+          Awaited<ReturnType<typeof retentionPoliciesControllerGet>>
+        > , 'initialData'
+      >, }
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useRetentionPoliciesControllerGet<TData = Awaited<ReturnType<typeof retentionPoliciesControllerGet>>, TError = unknown>(
+  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof retentionPoliciesControllerGet>>, TError, TData>>, }
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+/**
+ * @summary Get the data-retention policy for the current org
+ */
+
+export function useRetentionPoliciesControllerGet<TData = Awaited<ReturnType<typeof retentionPoliciesControllerGet>>, TError = unknown>(
+  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof retentionPoliciesControllerGet>>, TError, TData>>, }
+ , queryClient?: QueryClient 
+ ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
+
+  const queryOptions = getRetentionPoliciesControllerGetQueryOptions(options)
+
+  const query = useQuery(queryOptions, queryClient) as  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+
+  query.queryKey = queryOptions.queryKey ;
+
+  return query;
+}
+
+
+
+
+
+/**
+ * @summary Set or clear the data-retention policy for the current org
+ */
+export const retentionPoliciesControllerUpdate = (
+    updateRetentionPolicyRequestDto: UpdateRetentionPolicyRequestDto,
+ ) => {
+      
+      
+      return customAxiosInstance<RetentionPolicyResponseDto>(
+      {url: `/retention-policies/org`, method: 'PUT',
+      headers: {'Content-Type': 'application/json', },
+      data: updateRetentionPolicyRequestDto
+    },
+      );
+    }
+  
+
+
+export const getRetentionPoliciesControllerUpdateMutationOptions = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof retentionPoliciesControllerUpdate>>, TError,{data: UpdateRetentionPolicyRequestDto}, TContext>, }
+): UseMutationOptions<Awaited<ReturnType<typeof retentionPoliciesControllerUpdate>>, TError,{data: UpdateRetentionPolicyRequestDto}, TContext> => {
+
+const mutationKey = ['retentionPoliciesControllerUpdate'];
+const {mutation: mutationOptions} = options ?
+      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
+      options
+      : {...options, mutation: {...options.mutation, mutationKey}}
+      : {mutation: { mutationKey, }};
+
+      
+
+
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof retentionPoliciesControllerUpdate>>, {data: UpdateRetentionPolicyRequestDto}> = (props) => {
+          const {data} = props ?? {};
+
+          return  retentionPoliciesControllerUpdate(data,)
+        }
+
+        
+
+
+  return  { mutationFn, ...mutationOptions }}
+
+    export type RetentionPoliciesControllerUpdateMutationResult = NonNullable<Awaited<ReturnType<typeof retentionPoliciesControllerUpdate>>>
+    export type RetentionPoliciesControllerUpdateMutationBody = UpdateRetentionPolicyRequestDto
+    export type RetentionPoliciesControllerUpdateMutationError = void
+
+    /**
+ * @summary Set or clear the data-retention policy for the current org
+ */
+export const useRetentionPoliciesControllerUpdate = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof retentionPoliciesControllerUpdate>>, TError,{data: UpdateRetentionPolicyRequestDto}, TContext>, }
+ , queryClient?: QueryClient): UseMutationResult<
+        Awaited<ReturnType<typeof retentionPoliciesControllerUpdate>>,
+        TError,
+        {data: UpdateRetentionPolicyRequestDto},
+        TContext
+      > => {
+
+      const mutationOptions = getRetentionPoliciesControllerUpdateMutationOptions(options);
 
       return useMutation(mutationOptions, queryClient);
     }

--- a/ayunis-core-frontend/src/shared/api/openapi-schema.json
+++ b/ayunis-core-frontend/src/shared/api/openapi-schema.json
@@ -8008,6 +8008,57 @@
         "tags": ["Chat Settings"]
       }
     },
+    "/retention-policies/org": {
+      "get": {
+        "operationId": "RetentionPoliciesController_get",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Current retention policy (disabled if never configured)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RetentionPolicyResponseDto"
+                }
+              }
+            }
+          }
+        },
+        "summary": "Get the data-retention policy for the current org",
+        "tags": ["retention-policies"]
+      },
+      "put": {
+        "operationId": "RetentionPoliciesController_update",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateRetentionPolicyRequestDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated retention policy",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RetentionPolicyResponseDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Retention period is not one of the allowed windows"
+          }
+        },
+        "summary": "Set or clear the data-retention policy for the current org",
+        "tags": ["retention-policies"]
+      }
+    },
     "/academy/chapters": {
       "get": {
         "description": "Retrieve all chapters with nested lessons, ordered by position. Requires the academy add-on to be active for the organization.",
@@ -14930,6 +14981,44 @@
           }
         },
         "required": ["systemPrompt"]
+      },
+      "RetentionPolicyResponseDto": {
+        "type": "object",
+        "properties": {
+          "retentionDays": {
+            "type": "number",
+            "description": "Configured retention window in days, or null when retention is disabled (data kept forever).",
+            "nullable": true,
+            "example": 90
+          },
+          "enabled": {
+            "type": "boolean",
+            "description": "Whether retention is currently enabled for the org.",
+            "example": true
+          },
+          "allowedRetentionDays": {
+            "description": "Retention windows (in days) the admin may choose from. Lets the UI render the selector without hardcoding the allowlist.",
+            "example": [30, 90, 180, 365, 730],
+            "type": "array",
+            "items": {
+              "type": "number"
+            }
+          }
+        },
+        "required": ["retentionDays", "enabled", "allowedRetentionDays"]
+      },
+      "UpdateRetentionPolicyRequestDto": {
+        "type": "object",
+        "properties": {
+          "retentionDays": {
+            "type": "number",
+            "description": "Days of inactivity after which conversation data is permanently deleted. Null disables retention (keep data forever). Must be one of the allowed windows.",
+            "enum": [30, 90, 180, 365, 730],
+            "nullable": true,
+            "example": 90
+          }
+        },
+        "required": ["retentionDays"]
       },
       "AcademyLessonResponseDto": {
         "type": "object",


### PR DESCRIPTION
- New retention-policies module mirroring anonymization-settings
- OrgRetentionPolicy: per-org retentionDays (null = disabled/keep forever)
- Admin-guarded GET/PUT /retention-policies/org
- Period restricted to an allowlist (30/90/180/365/730d) with a 30d
  floor so a destructive tiny value cannot be set
- Opt-in, off by default

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Settings govern future permanent data deletion and are admin-controlled with an allowlist, but no enforcement runs in this PR; misconfiguration risk is limited to stored policy until a job lands.
> 
> **Overview**
> Adds **org-level data retention configuration** so admins can opt in to deleting inactive conversation data after a fixed window, or leave retention off (default).
> 
> A new `retention-policies` backend module persists one policy per org (`retentionDays`, or `null` = disabled) via migration and Postgres repository. Domain logic includes an allowlist of **30 / 90 / 180 / 365 / 730** days (plus `null`), activity **cutoff** calculation on `OrgRetentionPolicy`, and validation in both the HTTP DTO and upsert use case. **Admin-only** `GET` and `PUT` `/retention-policies/org` return the current setting, `enabled`, and `allowedRetentionDays` for the UI. The module is wired into `AppModule`; OpenAPI and generated frontend client hooks/types are updated. Repository **`findAllEnabled`** is included for a future nightly enforcement job—**this PR does not implement deletion or scheduling**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a90602ef18bfb6c8e7d0c9924bff19311ba219f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->