### PR TITLE
feat(retention): admin UI for data-retention policy (AYC-66)

### DIFF
--- a/ayunis-core-frontend/src/app/routeTree.gen.ts
+++ b/ayunis-core-frontend/src/app/routeTree.gen.ts
@@ -36,6 +36,7 @@ import { Route as AuthenticatedChatsThreadIdRouteImport } from './routes/_authen
 import { Route as AuthenticatedAdminSettingsUsersRouteImport } from './routes/_authenticated/admin-settings.users'
 import { Route as AuthenticatedAdminSettingsUsageRouteImport } from './routes/_authenticated/admin-settings.usage'
 import { Route as AuthenticatedAdminSettingsSecurityRouteImport } from './routes/_authenticated/admin-settings.security'
+import { Route as AuthenticatedAdminSettingsRetentionRouteImport } from './routes/_authenticated/admin-settings.retention'
 import { Route as AuthenticatedAdminSettingsModelsRouteImport } from './routes/_authenticated/admin-settings.models'
 import { Route as AuthenticatedAdminSettingsIntegrationsRouteImport } from './routes/_authenticated/admin-settings.integrations'
 import { Route as AuthenticatedAdminSettingsInstructionsRouteImport } from './routes/_authenticated/admin-settings.instructions'
@@ -206,6 +207,12 @@ const AuthenticatedAdminSettingsSecurityRoute =
     path: '/admin-settings/security',
     getParentRoute: () => AuthenticatedRoute,
   } as any)
+const AuthenticatedAdminSettingsRetentionRoute =
+  AuthenticatedAdminSettingsRetentionRouteImport.update({
+    id: '/admin-settings/retention',
+    path: '/admin-settings/retention',
+    getParentRoute: () => AuthenticatedRoute,
+  } as any)
 const AuthenticatedAdminSettingsModelsRoute =
   AuthenticatedAdminSettingsModelsRouteImport.update({
     id: '/admin-settings/models',
@@ -344,6 +351,7 @@ export interface FileRoutesByFullPath {
   '/admin-settings/instructions': typeof AuthenticatedAdminSettingsInstructionsRoute
   '/admin-settings/integrations': typeof AuthenticatedAdminSettingsIntegrationsRoute
   '/admin-settings/models': typeof AuthenticatedAdminSettingsModelsRoute
+  '/admin-settings/retention': typeof AuthenticatedAdminSettingsRetentionRoute
   '/admin-settings/security': typeof AuthenticatedAdminSettingsSecurityRoute
   '/admin-settings/usage': typeof AuthenticatedAdminSettingsUsageRoute
   '/admin-settings/users': typeof AuthenticatedAdminSettingsUsersRoute
@@ -392,6 +400,7 @@ export interface FileRoutesByTo {
   '/admin-settings/instructions': typeof AuthenticatedAdminSettingsInstructionsRoute
   '/admin-settings/integrations': typeof AuthenticatedAdminSettingsIntegrationsRoute
   '/admin-settings/models': typeof AuthenticatedAdminSettingsModelsRoute
+  '/admin-settings/retention': typeof AuthenticatedAdminSettingsRetentionRoute
   '/admin-settings/security': typeof AuthenticatedAdminSettingsSecurityRoute
   '/admin-settings/usage': typeof AuthenticatedAdminSettingsUsageRoute
   '/admin-settings/users': typeof AuthenticatedAdminSettingsUsersRoute
@@ -442,6 +451,7 @@ export interface FileRoutesById {
   '/_authenticated/admin-settings/instructions': typeof AuthenticatedAdminSettingsInstructionsRoute
   '/_authenticated/admin-settings/integrations': typeof AuthenticatedAdminSettingsIntegrationsRoute
   '/_authenticated/admin-settings/models': typeof AuthenticatedAdminSettingsModelsRoute
+  '/_authenticated/admin-settings/retention': typeof AuthenticatedAdminSettingsRetentionRoute
   '/_authenticated/admin-settings/security': typeof AuthenticatedAdminSettingsSecurityRoute
   '/_authenticated/admin-settings/usage': typeof AuthenticatedAdminSettingsUsageRoute
   '/_authenticated/admin-settings/users': typeof AuthenticatedAdminSettingsUsersRoute
@@ -492,6 +502,7 @@ export interface FileRouteTypes {
     | '/admin-settings/instructions'
     | '/admin-settings/integrations'
     | '/admin-settings/models'
+    | '/admin-settings/retention'
     | '/admin-settings/security'
     | '/admin-settings/usage'
     | '/admin-settings/users'
@@ -540,6 +551,7 @@ export interface FileRouteTypes {
     | '/admin-settings/instructions'
     | '/admin-settings/integrations'
     | '/admin-settings/models'
+    | '/admin-settings/retention'
     | '/admin-settings/security'
     | '/admin-settings/usage'
     | '/admin-settings/users'
@@ -589,6 +601,7 @@ export interface FileRouteTypes {
     | '/_authenticated/admin-settings/instructions'
     | '/_authenticated/admin-settings/integrations'
     | '/_authenticated/admin-settings/models'
+    | '/_authenticated/admin-settings/retention'
     | '/_authenticated/admin-settings/security'
     | '/_authenticated/admin-settings/usage'
     | '/_authenticated/admin-settings/users'
@@ -825,6 +838,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedAdminSettingsSecurityRouteImport
       parentRoute: typeof AuthenticatedRoute
     }
+    '/_authenticated/admin-settings/retention': {
+      id: '/_authenticated/admin-settings/retention'
+      path: '/admin-settings/retention'
+      fullPath: '/admin-settings/retention'
+      preLoaderRoute: typeof AuthenticatedAdminSettingsRetentionRouteImport
+      parentRoute: typeof AuthenticatedRoute
+    }
     '/_authenticated/admin-settings/models': {
       id: '/_authenticated/admin-settings/models'
       path: '/admin-settings/models'
@@ -976,6 +996,7 @@ interface AuthenticatedRouteChildren {
   AuthenticatedAdminSettingsInstructionsRoute: typeof AuthenticatedAdminSettingsInstructionsRoute
   AuthenticatedAdminSettingsIntegrationsRoute: typeof AuthenticatedAdminSettingsIntegrationsRoute
   AuthenticatedAdminSettingsModelsRoute: typeof AuthenticatedAdminSettingsModelsRoute
+  AuthenticatedAdminSettingsRetentionRoute: typeof AuthenticatedAdminSettingsRetentionRoute
   AuthenticatedAdminSettingsSecurityRoute: typeof AuthenticatedAdminSettingsSecurityRoute
   AuthenticatedAdminSettingsUsageRoute: typeof AuthenticatedAdminSettingsUsageRoute
   AuthenticatedAdminSettingsUsersRoute: typeof AuthenticatedAdminSettingsUsersRoute
@@ -1019,6 +1040,8 @@ const AuthenticatedRouteChildren: AuthenticatedRouteChildren = {
   AuthenticatedAdminSettingsIntegrationsRoute:
     AuthenticatedAdminSettingsIntegrationsRoute,
   AuthenticatedAdminSettingsModelsRoute: AuthenticatedAdminSettingsModelsRoute,
+  AuthenticatedAdminSettingsRetentionRoute:
+    AuthenticatedAdminSettingsRetentionRoute,
   AuthenticatedAdminSettingsSecurityRoute:
     AuthenticatedAdminSettingsSecurityRoute,
   AuthenticatedAdminSettingsUsageRoute: AuthenticatedAdminSettingsUsageRoute,

--- a/ayunis-core-frontend/src/app/routes/_authenticated/admin-settings.retention.tsx
+++ b/ayunis-core-frontend/src/app/routes/_authenticated/admin-settings.retention.tsx
@@ -1,0 +1,12 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { RetentionSettingsPage } from '@/pages/admin-settings/retention-settings';
+
+export const Route = createFileRoute(
+  '/_authenticated/admin-settings/retention',
+)({
+  component: RouteComponent,
+});
+
+function RouteComponent() {
+  return <RetentionSettingsPage />;
+}

--- a/ayunis-core-frontend/src/i18n.ts
+++ b/ayunis-core-frontend/src/i18n.ts
@@ -56,6 +56,8 @@ import enAdminSettingsSecurity from './shared/locales/en/admin-settings-security
 import deAdminSettingsSecurity from './shared/locales/de/admin-settings-security.json';
 import enAdminSettingsAnonymization from './shared/locales/en/admin-settings-anonymization.json';
 import deAdminSettingsAnonymization from './shared/locales/de/admin-settings-anonymization.json';
+import enAdminSettingsRetention from './shared/locales/en/admin-settings-retention.json';
+import deAdminSettingsRetention from './shared/locales/de/admin-settings-retention.json';
 import enAdminSettingsLetterheads from './shared/locales/en/admin-settings-letterheads.json';
 import deAdminSettingsLetterheads from './shared/locales/de/admin-settings-letterheads.json';
 import enAdminSettingsApiKeys from './shared/locales/en/admin-settings-api-keys.json';
@@ -94,6 +96,7 @@ const resources = {
     'super-admin-settings-platform-config': enSuperAdminSettingsPlatformConfig,
     'admin-settings-security': enAdminSettingsSecurity,
     'admin-settings-anonymization': enAdminSettingsAnonymization,
+    'admin-settings-retention': enAdminSettingsRetention,
     'admin-settings-letterheads': enAdminSettingsLetterheads,
     'admin-settings-api-keys': enAdminSettingsApiKeys,
     'mcp-user-config': enMcpUserConfig,
@@ -127,6 +130,7 @@ const resources = {
     'super-admin-settings-platform-config': deSuperAdminSettingsPlatformConfig,
     'admin-settings-security': deAdminSettingsSecurity,
     'admin-settings-anonymization': deAdminSettingsAnonymization,
+    'admin-settings-retention': deAdminSettingsRetention,
     'admin-settings-letterheads': deAdminSettingsLetterheads,
     'admin-settings-api-keys': deAdminSettingsApiKeys,
     'mcp-user-config': deMcpUserConfig,

--- a/ayunis-core-frontend/src/pages/admin-settings/admin-settings-layout/ui/AdminSettingsSidebar.tsx
+++ b/ayunis-core-frontend/src/pages/admin-settings/admin-settings-layout/ui/AdminSettingsSidebar.tsx
@@ -9,6 +9,7 @@ import {
   Key,
   ShieldCheck,
   MessageSquareText,
+  Trash2,
 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import {
@@ -51,6 +52,11 @@ export function AdminSettingsSidebar() {
       to: '/admin-settings/anonymization',
       icon: <ShieldCheck />,
       label: t('layout.anonymization'),
+    },
+    {
+      to: '/admin-settings/retention',
+      icon: <Trash2 />,
+      label: t('layout.retention'),
     },
     {
       to: '/admin-settings/instructions',

--- a/ayunis-core-frontend/src/pages/admin-settings/retention-settings/index.ts
+++ b/ayunis-core-frontend/src/pages/admin-settings/retention-settings/index.ts
@@ -1,0 +1,1 @@
+export { RetentionSettingsPage } from './ui/RetentionSettingsPage';

--- a/ayunis-core-frontend/src/pages/admin-settings/retention-settings/lib/format-period.spec.ts
+++ b/ayunis-core-frontend/src/pages/admin-settings/retention-settings/lib/format-period.spec.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { formatRetentionPeriod, isMoreAggressive } from './format-period';
+
+describe('formatRetentionPeriod', () => {
+  const t = ((key: string, opts?: { count?: number }) =>
+    `${key}:${opts?.count}`) as unknown as Parameters<
+    typeof formatRetentionPeriod
+  >[1];
+
+  it('renders whole years as years', () => {
+    expect(formatRetentionPeriod(365, t)).toBe('retention.year:1');
+    expect(formatRetentionPeriod(730, t)).toBe('retention.year:2');
+  });
+
+  it('renders sub-year windows as days', () => {
+    expect(formatRetentionPeriod(30, t)).toBe('retention.days:30');
+    expect(formatRetentionPeriod(180, t)).toBe('retention.days:180');
+  });
+});
+
+describe('isMoreAggressive', () => {
+  it('flags enabling retention from disabled', () => {
+    expect(isMoreAggressive(null, 90)).toBe(true);
+  });
+
+  it('flags shortening the window', () => {
+    expect(isMoreAggressive(365, 30)).toBe(true);
+  });
+
+  it('does not flag disabling retention', () => {
+    expect(isMoreAggressive(90, null)).toBe(false);
+  });
+
+  it('does not flag lengthening the window', () => {
+    expect(isMoreAggressive(30, 365)).toBe(false);
+  });
+});

--- a/ayunis-core-frontend/src/pages/admin-settings/retention-settings/lib/format-period.ts
+++ b/ayunis-core-frontend/src/pages/admin-settings/retention-settings/lib/format-period.ts
@@ -1,0 +1,32 @@
+import type { TFunction } from 'i18next';
+
+/**
+ * Human-readable label for a retention window. Whole years render as years
+ * (365 → "1 year", 730 → "2 years"); everything else renders in days.
+ */
+export function formatRetentionPeriod(days: number, t: TFunction): string {
+  if (days % 365 === 0) {
+    const years = days / 365;
+    return t('retention.year', { count: years });
+  }
+  return t('retention.days', { count: days });
+}
+
+/**
+ * Whether changing the retention window from `current` to `next` makes deletion
+ * start or become more aggressive — i.e. a destructive change that warrants a
+ * confirmation. Enabling (current null → a value) or shortening the window
+ * qualifies; disabling or lengthening it does not.
+ */
+export function isMoreAggressive(
+  current: number | null,
+  next: number | null,
+): boolean {
+  if (next === null) {
+    return false;
+  }
+  if (current === null) {
+    return true;
+  }
+  return next < current;
+}

--- a/ayunis-core-frontend/src/pages/admin-settings/retention-settings/ui/RetentionSettingsPage.tsx
+++ b/ayunis-core-frontend/src/pages/admin-settings/retention-settings/ui/RetentionSettingsPage.tsx
@@ -64,6 +64,7 @@ export function RetentionSettingsPage() {
   const selected = draft === undefined ? serverValue : draft;
   const isDirty = draft !== undefined && draft !== serverValue;
   const [confirmOpen, setConfirmOpen] = useState(false);
+  const [pendingValue, setPendingValue] = useState<number | null>(null);
 
   function persist(retentionDays: number | null) {
     updateMutation.mutate(
@@ -95,6 +96,7 @@ export function RetentionSettingsPage() {
   function handleSave() {
     // Confirm only when the change starts or intensifies deletion.
     if (isMoreAggressive(serverValue, selected)) {
+      setPendingValue(selected);
       setConfirmOpen(true);
       return;
     }
@@ -103,7 +105,7 @@ export function RetentionSettingsPage() {
 
   function handleConfirm() {
     setConfirmOpen(false);
-    persist(selected);
+    persist(pendingValue);
   }
 
   function handleMutationError(error: unknown) {
@@ -213,7 +215,9 @@ export function RetentionSettingsPage() {
             <AlertDialogDescription>
               {t('retention.confirm.body', {
                 period:
-                  selected === null ? '' : formatRetentionPeriod(selected, t),
+                  pendingValue === null
+                    ? ''
+                    : formatRetentionPeriod(pendingValue, t),
               })}
             </AlertDialogDescription>
           </AlertDialogHeader>

--- a/ayunis-core-frontend/src/pages/admin-settings/retention-settings/ui/RetentionSettingsPage.tsx
+++ b/ayunis-core-frontend/src/pages/admin-settings/retention-settings/ui/RetentionSettingsPage.tsx
@@ -1,0 +1,232 @@
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useQueryClient } from '@tanstack/react-query';
+import { AlertCircle, Loader2 } from 'lucide-react';
+import SettingsLayout from '../../admin-settings-layout';
+import { Button } from '@/shared/ui/shadcn/button';
+import { Label } from '@/shared/ui/shadcn/label';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/shared/ui/shadcn/card';
+import { Alert, AlertDescription } from '@/shared/ui/shadcn/alert';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/shared/ui/shadcn/select';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/shared/ui/shadcn/alert-dialog';
+import {
+  useRetentionPoliciesControllerGet,
+  useRetentionPoliciesControllerUpdate,
+  getRetentionPoliciesControllerGetQueryKey,
+} from '@/shared/api';
+import type { UpdateRetentionPolicyRequestDtoRetentionDays } from '@/shared/api';
+import extractErrorData from '@/shared/api/extract-error-data';
+import { showSuccess, showError } from '@/shared/lib/toast';
+import { formatRetentionPeriod, isMoreAggressive } from '../lib/format-period';
+
+const KEEP_FOREVER = 'keep-forever';
+
+function toSelectValue(retentionDays: number | null): string {
+  return retentionDays === null ? KEEP_FOREVER : String(retentionDays);
+}
+
+function fromSelectValue(value: string): number | null {
+  return value === KEEP_FOREVER ? null : Number(value);
+}
+
+export function RetentionSettingsPage() {
+  const { t: tLayout } = useTranslation('admin-settings-layout');
+  const { t } = useTranslation('admin-settings-retention');
+  const queryClient = useQueryClient();
+
+  const { data, isLoading, isError, refetch } =
+    useRetentionPoliciesControllerGet();
+  const updateMutation = useRetentionPoliciesControllerUpdate();
+
+  const serverValue = data?.retentionDays ?? null;
+  const [draft, setDraft] = useState<number | null | undefined>(undefined);
+  const selected = draft === undefined ? serverValue : draft;
+  const isDirty = draft !== undefined && draft !== serverValue;
+  const [confirmOpen, setConfirmOpen] = useState(false);
+
+  function persist(retentionDays: number | null) {
+    updateMutation.mutate(
+      {
+        // Values come from the server's allowlist (or null), so they always
+        // satisfy the generated enum union.
+        data: {
+          retentionDays:
+            retentionDays as UpdateRetentionPolicyRequestDtoRetentionDays,
+        },
+      },
+      {
+        onSuccess: (updated) => {
+          showSuccess(t('retention.saveSuccess'));
+          queryClient.setQueryData(
+            getRetentionPoliciesControllerGetQueryKey(),
+            updated,
+          );
+          setDraft(undefined);
+          void queryClient.invalidateQueries({
+            queryKey: getRetentionPoliciesControllerGetQueryKey(),
+          });
+        },
+        onError: handleMutationError,
+      },
+    );
+  }
+
+  function handleSave() {
+    // Confirm only when the change starts or intensifies deletion.
+    if (isMoreAggressive(serverValue, selected)) {
+      setConfirmOpen(true);
+      return;
+    }
+    persist(selected);
+  }
+
+  function handleConfirm() {
+    setConfirmOpen(false);
+    persist(selected);
+  }
+
+  function handleMutationError(error: unknown) {
+    try {
+      const { code } = extractErrorData(error);
+      showError(
+        code === 'INVALID_RETENTION_PERIOD'
+          ? t('retention.invalidPeriod')
+          : t('retention.saveError'),
+      );
+    } catch {
+      showError(t('retention.saveError'));
+    }
+  }
+
+  if (isLoading) {
+    return (
+      <SettingsLayout title={tLayout('layout.retention')}>
+        <Card>
+          <CardContent className="flex items-center justify-center py-12">
+            <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+          </CardContent>
+        </Card>
+      </SettingsLayout>
+    );
+  }
+
+  if (isError || !data) {
+    return (
+      <SettingsLayout title={tLayout('layout.retention')}>
+        <Card>
+          <CardContent className="pt-6">
+            <Alert variant="destructive">
+              <AlertCircle className="h-4 w-4" />
+              <AlertDescription>
+                {t('retention.loadError')}
+                <Button
+                  variant="link"
+                  className="ml-2 h-auto p-0"
+                  onClick={() => void refetch()}
+                >
+                  {t('retention.retry')}
+                </Button>
+              </AlertDescription>
+            </Alert>
+          </CardContent>
+        </Card>
+      </SettingsLayout>
+    );
+  }
+
+  return (
+    <SettingsLayout title={tLayout('layout.retention')}>
+      <Card>
+        <CardHeader>
+          <CardTitle>{t('retention.heading')}</CardTitle>
+          <CardDescription>{t('retention.description')}</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="retention-period">
+              {t('retention.periodLabel')}
+            </Label>
+            <Select
+              value={toSelectValue(selected)}
+              onValueChange={(value) => setDraft(fromSelectValue(value))}
+              disabled={updateMutation.isPending}
+            >
+              <SelectTrigger id="retention-period" className="w-[320px]">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value={KEEP_FOREVER}>
+                  {t('retention.keepForever')}
+                </SelectItem>
+                {data.allowedRetentionDays.map((days) => (
+                  <SelectItem key={days} value={String(days)}>
+                    {formatRetentionPeriod(days, t)}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            {selected === null && (
+              <p className="text-sm text-muted-foreground">
+                {t('retention.currentlyDisabled')}
+              </p>
+            )}
+          </div>
+
+          <div className="flex justify-end">
+            <Button
+              onClick={handleSave}
+              disabled={updateMutation.isPending || !isDirty}
+            >
+              {updateMutation.isPending
+                ? t('retention.saving')
+                : t('retention.saveButton')}
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+
+      <AlertDialog open={confirmOpen} onOpenChange={setConfirmOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{t('retention.confirm.title')}</AlertDialogTitle>
+            <AlertDialogDescription>
+              {t('retention.confirm.body', {
+                period:
+                  selected === null ? '' : formatRetentionPeriod(selected, t),
+              })}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>
+              {t('retention.confirm.cancel')}
+            </AlertDialogCancel>
+            <AlertDialogAction onClick={handleConfirm}>
+              {t('retention.confirm.confirm')}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </SettingsLayout>
+  );
+}

--- a/ayunis-core-frontend/src/shared/locales/de/admin-settings-layout.json
+++ b/ayunis-core-frontend/src/shared/locales/de/admin-settings-layout.json
@@ -11,6 +11,7 @@
     "usage": "Nutzung",
     "security": "Sicherheit",
     "anonymization": "Anonymisierung",
+    "retention": "Datenaufbewahrung",
     "instructions": "Anweisungen",
     "letterheads": "Briefpapier",
     "apiKeys": "API-Schlüssel"

--- a/ayunis-core-frontend/src/shared/locales/de/admin-settings-retention.json
+++ b/ayunis-core-frontend/src/shared/locales/de/admin-settings-retention.json
@@ -1,0 +1,27 @@
+{
+  "retention": {
+    "heading": "Datenaufbewahrung",
+    "description": "Unterhaltungen nach einer Zeit der Inaktivität automatisch löschen. Dabei werden der Chat, seine Nachrichten, generierte Bilder und darin erstellte Dokumente unwiderruflich entfernt. Wissensdatenbanken, Skills und andere Einstellungen sind nicht betroffen.",
+    "periodLabel": "Unterhaltungen löschen, die länger inaktiv sind als",
+    "keepForever": "Dauerhaft behalten (keine automatische Löschung)",
+    "days_one": "{{count}} Tag",
+    "days_other": "{{count}} Tage",
+    "months": "{{count}} Monate",
+    "year_one": "{{count}} Jahr",
+    "year_other": "{{count}} Jahre",
+    "currentlyDisabled": "Die Aufbewahrung ist deaktiviert. Unterhaltungen bleiben erhalten, bis sie manuell gelöscht werden.",
+    "saveButton": "Speichern",
+    "saving": "Speichern…",
+    "saveSuccess": "Einstellungen zur Datenaufbewahrung gespeichert.",
+    "saveError": "Das Speichern der Einstellungen zur Datenaufbewahrung ist fehlgeschlagen.",
+    "invalidPeriod": "Der gewählte Aufbewahrungszeitraum ist nicht zulässig.",
+    "loadError": "Die Einstellungen zur Datenaufbewahrung konnten nicht geladen werden.",
+    "retry": "Erneut versuchen",
+    "confirm": {
+      "title": "Alte Unterhaltungen dauerhaft löschen?",
+      "body": "Unterhaltungen ohne Aktivität seit mehr als {{period}} werden beim nächsten nächtlichen Lauf und fortlaufend dauerhaft gelöscht. Dies kann nicht rückgängig gemacht werden. Wissensdatenbanken und Skills sind nicht betroffen.",
+      "cancel": "Abbrechen",
+      "confirm": "Aufbewahrung aktivieren"
+    }
+  }
+}

--- a/ayunis-core-frontend/src/shared/locales/en/admin-settings-layout.json
+++ b/ayunis-core-frontend/src/shared/locales/en/admin-settings-layout.json
@@ -11,6 +11,7 @@
     "usage": "Usage",
     "security": "Security",
     "anonymization": "Anonymization",
+    "retention": "Data retention",
     "instructions": "Instructions",
     "letterheads": "Letterheads",
     "apiKeys": "API Keys"

--- a/ayunis-core-frontend/src/shared/locales/en/admin-settings-retention.json
+++ b/ayunis-core-frontend/src/shared/locales/en/admin-settings-retention.json
@@ -1,0 +1,27 @@
+{
+  "retention": {
+    "heading": "Data retention",
+    "description": "Automatically delete conversations after a period of inactivity. This permanently removes the chat, its messages, generated images, and documents created in it. Knowledge bases, skills, and other settings are not affected.",
+    "periodLabel": "Delete conversations inactive for longer than",
+    "keepForever": "Keep forever (no automatic deletion)",
+    "days_one": "{{count}} day",
+    "days_other": "{{count}} days",
+    "months": "{{count}} months",
+    "year_one": "{{count}} year",
+    "year_other": "{{count}} years",
+    "currentlyDisabled": "Retention is disabled. Conversations are kept until deleted manually.",
+    "saveButton": "Save",
+    "saving": "Saving…",
+    "saveSuccess": "Data retention settings saved.",
+    "saveError": "Saving the data retention settings failed.",
+    "invalidPeriod": "The selected retention period is not allowed.",
+    "loadError": "The data retention settings could not be loaded.",
+    "retry": "Retry",
+    "confirm": {
+      "title": "Permanently delete old conversations?",
+      "body": "Conversations with no activity for more than {{period}} will be permanently deleted on the next nightly run, and on an ongoing basis. This cannot be undone. Knowledge bases and skills are not affected.",
+      "cancel": "Cancel",
+      "confirm": "Enable retention"
+    }
+  }
+}


### PR DESCRIPTION
- Admin Settings > Data retention page: pick an inactivity window or
  keep forever, backed by the retention-policies API
- Confirmation dialog before enabling or shortening retention, since
  deletion is permanent
- Regenerate OpenAPI client; add EN/DE translations and sidebar entry

Completes admin-defined data retention: threads inactive past the
configured window are deleted nightly (storage + cascades), opt-in and
off by default.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Admins can configure permanent automatic deletion of inactive conversations; mistakes are mitigated by a confirmation on more aggressive changes but still affect org-wide data lifecycle.
> 
> **Overview**
> Adds **Admin Settings → Data retention** so org admins can view and update the org’s inactivity-based conversation retention policy via the **retention-policies** API.
> 
> The new page loads current `retentionDays` and server **allowed** periods, lets admins pick **keep forever** (`null`) or a fixed window, and saves with loading/error toasts and cache updates. **Enabling retention** or **shortening** the window triggers a confirmation dialog (`isMoreAggressive`); lengthening or disabling saves without that step. Period labels use small helpers (years vs days) with unit tests.
> 
> Wiring includes a TanStack route at `/admin-settings/retention`, a sidebar item, EN/DE copy, and the generated route tree entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8ac890ec5ba07d22e22fd482323bffa0bec09d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->