### PR TITLE
feat(runs): verify time-sensitive facts externally (AYC-305)

### DIFF
--- a/ayunis-core-backend/src/domain/runs/application/services/system-prompt-builder.service.spec.ts
+++ b/ayunis-core-backend/src/domain/runs/application/services/system-prompt-builder.service.spec.ts
@@ -44,6 +44,19 @@ describe('SystemPromptBuilderService', () => {
     });
   });
 
+  describe('knowledge boundaries section', () => {
+    it('instructs the model to verify time-sensitive facts against external sources', () => {
+      const result = service.build({
+        tools: [],
+        currentTime: new Date('2026-01-15T10:00:00Z'),
+      });
+
+      expect(result).toContain('<knowledge_boundaries>');
+      expect(result).toContain('time-sensitive facts');
+      expect(result).toContain('web search');
+    });
+  });
+
   describe('skills section', () => {
     it('should include available_skills section when active skills are provided', () => {
       const skills: SkillEntry[] = [

--- a/ayunis-core-backend/src/domain/runs/application/services/system-prompt-builder.service.ts
+++ b/ayunis-core-backend/src/domain/runs/application/services/system-prompt-builder.service.ts
@@ -109,6 +109,8 @@ For German responses:
 Be honest about what you know and don't know. If asked about information that requires current data you don't have access to, say so clearly.
 
 When tools are available (such as source queries or web access), use them to provide accurate, up-to-date information rather than relying on training data alone.
+
+Do not assume that time-sensitive facts from your training data are still accurate. For questions whose answer can change over time — for example who currently holds a political office, current prices, recent events, or the latest version of something — confirm the answer against an external source such as web search before responding whenever a suitable tool is available. Only fall back to your training knowledge when no such tool is available, and clearly note that the information may be outdated.
 </knowledge_boundaries>
 
 </behavior_instructions>`;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The general system prompt did not explicitly discourage the model from answering time-sensitive questions (e.g. "who is the current Prime Minister of Hungary?") from its training data before consulting external sources. This was observed during testing with GPT 5.4, where the model answered from its knowledge cutoff before being asked to run a web search.

## Changes

- Extended the `<knowledge_boundaries>` section in `SystemPromptBuilderService` with an explicit instruction: do not assume time-sensitive facts from training data are still accurate; confirm against an external source such as web search whenever a suitable tool is available, and clearly note when falling back to (possibly outdated) training knowledge.
- Added a unit test asserting the system prompt includes this time-sensitive verification guidance.

## Testing

- `npx jest system-prompt-builder.service.spec` — 24 passed.
- Pre-commit checks (ESLint, Prettier, TypeScript, complexity, dependency, duplication, file size) all pass.

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [AYC-305](https://linear.app/ayunis/issue/AYC-305/update-system-prompt-to-verify-time-sensitive-facts-externally)

<div><a href="https://cursor.com/agents/bc-649caa1e-d112-444c-844a-94c305912d5d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-649caa1e-d112-444c-844a-94c305912d5d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

