### PR TITLE
fix(models): read provider api keys from models config namespace (AYC-283)

### DIFF
--- a/ayunis-core-backend/src/domain/models/infrastructure/inference/anthropic.inference.ts
+++ b/ayunis-core-backend/src/domain/models/infrastructure/inference/anthropic.inference.ts
@@ -18,7 +18,7 @@ export class AnthropicInferenceHandler extends RuntimeInferenceHandler {
 
   protected createProvider(model: Model): ModelProvider {
     return anthropic({
-      apiKey: this.configService.get<string>('anthropic.apiKey') ?? '',
+      apiKey: this.configService.get<string>('models.anthropic.apiKey') ?? '',
       model: model.name,
       maxRetries: INFERENCE_MAX_RETRIES,
     });

--- a/ayunis-core-backend/src/domain/models/infrastructure/inference/mistral.inference.ts
+++ b/ayunis-core-backend/src/domain/models/infrastructure/inference/mistral.inference.ts
@@ -18,7 +18,7 @@ export class MistralInferenceHandler extends RuntimeInferenceHandler {
 
   protected createProvider(model: Model): ModelProvider {
     return mistral({
-      apiKey: this.configService.get<string>('mistral.apiKey') ?? '',
+      apiKey: this.configService.get<string>('models.mistral.apiKey') ?? '',
       model: model.name,
       maxRetries: INFERENCE_MAX_RETRIES,
     });

--- a/ayunis-core-backend/src/domain/models/infrastructure/inference/openai.inference.ts
+++ b/ayunis-core-backend/src/domain/models/infrastructure/inference/openai.inference.ts
@@ -18,7 +18,7 @@ export class OpenAIInferenceHandler extends RuntimeInferenceHandler {
 
   protected createProvider(model: Model): ModelProvider {
     return openai({
-      apiKey: this.configService.get<string>('openai.apiKey') ?? '',
+      apiKey: this.configService.get<string>('models.openai.apiKey') ?? '',
       model: model.name,
       maxRetries: INFERENCE_MAX_RETRIES,
     });

--- a/ayunis-core-backend/src/domain/models/infrastructure/stream-inference/anthropic.stream-inference.ts
+++ b/ayunis-core-backend/src/domain/models/infrastructure/stream-inference/anthropic.stream-inference.ts
@@ -18,7 +18,7 @@ export class AnthropicStreamInferenceHandler extends RuntimeStreamInferenceHandl
 
   protected createProvider(model: Model): ModelProvider {
     return anthropic({
-      apiKey: this.configService.get<string>('anthropic.apiKey') ?? '',
+      apiKey: this.configService.get<string>('models.anthropic.apiKey') ?? '',
       model: model.name,
       maxRetries: INFERENCE_MAX_RETRIES,
     });

--- a/ayunis-core-backend/src/domain/models/infrastructure/stream-inference/mistral.stream-inference.ts
+++ b/ayunis-core-backend/src/domain/models/infrastructure/stream-inference/mistral.stream-inference.ts
@@ -18,7 +18,7 @@ export class MistralStreamInferenceHandler extends RuntimeStreamInferenceHandler
 
   protected createProvider(model: Model): ModelProvider {
     return mistral({
-      apiKey: this.configService.get<string>('mistral.apiKey') ?? '',
+      apiKey: this.configService.get<string>('models.mistral.apiKey') ?? '',
       model: model.name,
       maxRetries: INFERENCE_MAX_RETRIES,
     });

--- a/ayunis-core-backend/src/domain/models/infrastructure/stream-inference/openai.stream-inference.ts
+++ b/ayunis-core-backend/src/domain/models/infrastructure/stream-inference/openai.stream-inference.ts
@@ -18,7 +18,7 @@ export class OpenAIStreamInferenceHandler extends RuntimeStreamInferenceHandler 
 
   protected createProvider(model: Model): ModelProvider {
     return openai({
-      apiKey: this.configService.get<string>('openai.apiKey') ?? '',
+      apiKey: this.configService.get<string>('models.openai.apiKey') ?? '',
       model: model.name,
       maxRetries: INFERENCE_MAX_RETRIES,
     });


### PR DESCRIPTION
The Mistral, OpenAI and Anthropic stream/inference handlers read their
API key via configService.get('<provider>.apiKey'), but provider config
is registered under the 'models' namespace (registerAs('models', ...)).
The un-namespaced path resolved to undefined, fell back to '', and the
provider SDK rejected the empty key with HTTP 401.

Read from 'models.<provider>.apiKey' to match the registered namespace,
consistent with the azure/otc/stackit/scaleway/gemini handlers.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small config-path fix with no new behavior beyond restoring correct API key resolution for three providers.
> 
> **Overview**
> Fixes **Anthropic**, **Mistral**, and **OpenAI** inference and streaming handlers so they load API keys from `models.<provider>.apiKey` instead of `<provider>.apiKey`.
> 
> Those handlers were reading keys outside the `models` config namespace, so lookups returned nothing, the code fell back to an empty string, and provider calls failed with **401**. The change matches how other providers (e.g. Azure, Gemini) already resolve credentials under `models`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eacb8fe51133bfa4abcd67fc5566801b88ec93e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->