### PR TITLE
chore(models): seed openai, mistral and gemini chat models (AYC-283)

### DIFF
--- a/ayunis-core-backend/src/db/fixtures/minimal.fixture.ts
+++ b/ayunis-core-backend/src/db/fixtures/minimal.fixture.ts
@@ -60,6 +60,45 @@ export const minimalFixture = {
     outputTokenCost: 15,
   },
 
+  openaiLanguageModel: {
+    name: 'gpt-4o',
+    displayName: 'GPT-4o (OpenAI)',
+    provider: ModelProvider.OPENAI,
+    canStream: true,
+    isReasoning: false,
+    isArchived: false,
+    canUseTools: true,
+    canVision: true,
+    inputTokenCost: 2.5,
+    outputTokenCost: 10,
+  },
+
+  mistralLanguageModel: {
+    name: 'mistral-large-latest',
+    displayName: 'Mistral Large (Mistral)',
+    provider: ModelProvider.MISTRAL,
+    canStream: true,
+    isReasoning: false,
+    isArchived: false,
+    canUseTools: true,
+    canVision: false,
+    inputTokenCost: 2,
+    outputTokenCost: 6,
+  },
+
+  geminiLanguageModel: {
+    name: 'gemini-2.5-pro',
+    displayName: 'Gemini 2.5 Pro (Gemini)',
+    provider: ModelProvider.GEMINI,
+    canStream: true,
+    isReasoning: false,
+    isArchived: false,
+    canUseTools: true,
+    canVision: true,
+    inputTokenCost: 1.25,
+    outputTokenCost: 10,
+  },
+
   embeddingModel: {
     name: 'mistral-embed',
     displayName: 'Mistral Embed',
@@ -118,6 +157,21 @@ export const minimalFixture = {
       anonymousOnly: false,
     },
     {
+      modelKey: 'openaiLanguageModel',
+      isDefault: false,
+      anonymousOnly: false,
+    },
+    {
+      modelKey: 'mistralLanguageModel',
+      isDefault: false,
+      anonymousOnly: false,
+    },
+    {
+      modelKey: 'geminiLanguageModel',
+      isDefault: false,
+      anonymousOnly: false,
+    },
+    {
       // Embedding model as default
       modelKey: 'embeddingModel',
       isDefault: true,
@@ -132,10 +186,17 @@ export const minimalFixture = {
   ],
 } as const;
 
+export const LANGUAGE_MODEL_KEYS = [
+  'languageModel',
+  'azureLanguageModel',
+  'openaiLanguageModel',
+  'mistralLanguageModel',
+  'geminiLanguageModel',
+] as const;
+
 export type ModelKey = keyof Pick<
   typeof minimalFixture,
-  | 'languageModel'
-  | 'azureLanguageModel'
+  | (typeof LANGUAGE_MODEL_KEYS)[number]
   | 'embeddingModel'
   | 'imageGenerationModel'
 >;

--- a/ayunis-core-backend/src/db/scripts/seed-minimal.ts
+++ b/ayunis-core-backend/src/db/scripts/seed-minimal.ts
@@ -2,7 +2,11 @@ import 'src/config/env';
 import { randomUUID } from 'crypto';
 import dataSource from 'src/db/datasource';
 import { SeedRunner } from './utils/seed-runner';
-import { minimalFixture, type ModelKey } from '../fixtures/minimal.fixture';
+import {
+  minimalFixture,
+  LANGUAGE_MODEL_KEYS,
+  type ModelKey,
+} from '../fixtures/minimal.fixture';
 import { IsNull, MoreThanOrEqual } from 'typeorm';
 import type { UUID } from 'crypto';
 
@@ -27,19 +31,11 @@ import type { ModelProvider } from 'src/domain/models/domain/value-objects/model
 
 const fixture = minimalFixture;
 
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
 function log(entity: string, name: string, created: boolean): void {
   const icon = created ? '✅' : '⏭️ ';
   const verb = created ? 'Created' : 'Exists';
   console.log(`${icon} ${verb}: ${entity} (${name})`); // eslint-disable-line no-console
 }
-
-// ---------------------------------------------------------------------------
-// Seed steps
-// ---------------------------------------------------------------------------
 
 async function seedOrgByName(name: string): Promise<OrgRecord> {
   const repo = dataSource.getRepository(OrgRecord);
@@ -56,7 +52,7 @@ async function seedOrgByName(name: string): Promise<OrgRecord> {
 }
 
 async function seedLanguageModelFromFixture(
-  entry: typeof fixture.languageModel | typeof fixture.azureLanguageModel,
+  entry: (typeof fixture)[LanguageModelKey],
 ): Promise<LanguageModelRecord> {
   const repo = dataSource.getRepository(LanguageModelRecord);
   const { name, displayName, provider, ...flags } = entry;
@@ -327,11 +323,8 @@ interface UsageSeedModel {
   outputTokenCost?: number | null;
 }
 
-/**
- * Seeds usage records across the current calendar month so the credit-based
- * usage views (admin + super admin) show non-empty charts and tables.
- * Idempotent: skips if the org already has usage in the current month.
- */
+// Seeds usage records across the current calendar month so the credit-based
+// usage views show non-empty charts. Idempotent per org per month.
 async function seedUsageRecords(
   orgId: string,
   userId: string,
@@ -412,32 +405,36 @@ async function seedUsageRecords(
   log('Usage records', `org=${orgId} (${rows.length})`, true);
 }
 
-// ---------------------------------------------------------------------------
-// Main
-// ---------------------------------------------------------------------------
+type LanguageModelKey = (typeof LANGUAGE_MODEL_KEYS)[number];
+
+async function seedLanguageModels(): Promise<
+  Record<LanguageModelKey, LanguageModelRecord>
+> {
+  const entries = await Promise.all(
+    LANGUAGE_MODEL_KEYS.map(
+      async (key) =>
+        [key, await seedLanguageModelFromFixture(fixture[key])] as const,
+    ),
+  );
+  return Object.fromEntries(entries) as Record<
+    LanguageModelKey,
+    LanguageModelRecord
+  >;
+}
 
 async function seedAllFixtures(runner: SeedRunner): Promise<void> {
   console.log('🌱 Starting minimal seed…\n'); // eslint-disable-line no-console
 
-  const [
-    org,
-    usageOrg,
-    languageModel,
-    azureLanguageModel,
-    embeddingModel,
-    imageGenerationModel,
-  ] = await Promise.all([
-    seedOrgByName(fixture.org.name),
-    seedOrgByName(fixture.usageOrg.name),
-    seedLanguageModelFromFixture(fixture.languageModel),
-    seedLanguageModelFromFixture(fixture.azureLanguageModel),
-    seedEmbeddingModel(),
-    seedImageGenerationModel(),
-  ]);
+  const [org, usageOrg, embeddingModel, imageGenerationModel] =
+    await Promise.all([
+      seedOrgByName(fixture.org.name),
+      seedOrgByName(fixture.usageOrg.name),
+      seedEmbeddingModel(),
+      seedImageGenerationModel(),
+    ]);
 
   const models = {
-    languageModel,
-    azureLanguageModel,
+    ...(await seedLanguageModels()),
     embeddingModel,
     imageGenerationModel,
   };
@@ -453,9 +450,9 @@ async function seedAllFixtures(runner: SeedRunner): Promise<void> {
   await seedPlatformConfig();
 
   const usageModels: UsageSeedModel[] = [
-    languageModel,
-    azureLanguageModel,
-    imageGenerationModel,
+    models.languageModel,
+    models.azureLanguageModel,
+    models.imageGenerationModel,
   ];
   await seedUsageRecords(org.id, adminUser.id, usageModels);
   await seedUsageRecords(usageOrg.id, usageAdminUser.id, usageModels);


### PR DESCRIPTION
Add GPT-4o (OpenAI), Mistral Large (Mistral) and Gemini 2.5 Pro (Gemini)
language models to the minimal fixture, register them as non-default
permitted models for both seeded orgs, and wire them through the seed
script. Gives local dev coverage for the providers migrated onto the
@ayunis provider packages.

Refactor the language-model seeding into a keyed helper and lift the
shared LANGUAGE_MODEL_KEYS list into the fixture to keep seed-minimal.ts
under the function-length and file-size thresholds.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Local/dev seed and fixture changes only; no runtime API or production migration logic.
> 
> **Overview**
> Extends the **minimal dev seed** with three additional chat models—**GPT-4o (OpenAI)**, **Mistral Large**, and **Gemini 2.5 Pro**—each with provider metadata and token costs, and registers them as **non-default permitted models** for both seeded orgs alongside the existing Bedrock and Azure defaults.
> 
> Introduces a shared **`LANGUAGE_MODEL_KEYS`** list in the fixture and refactors **`seed-minimal`** to seed all language models in a loop via **`seedLanguageModels()`**, replacing per-model calls. **`ModelKey`** typing now derives language-model keys from that list. Sample usage records for charts are unchanged (still Bedrock, Azure, and image-gen only).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84a1f29acfca31358784e9aeb40e9a710ab4fde8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->