### PR TITLE
feat(knowledge-bases): show created date for sources (AYC-300)

### DIFF
--- a/ayunis-core-frontend/src/pages/knowledge-base/ui/KnowledgeBaseDocumentsCard.tsx
+++ b/ayunis-core-frontend/src/pages/knowledge-base/ui/KnowledgeBaseDocumentsCard.tsx
@@ -41,6 +41,7 @@ import {
 import { useTranslation } from 'react-i18next';
 import { HelpLink } from '@/shared/ui/help-link/HelpLink';
 import { cn } from '@/shared/lib/shadcn/utils';
+import { formatDate } from '@/shared/lib/format-date';
 import { useDocumentDrop } from '@/shared/hooks/useDocumentDrop';
 import {
   useKnowledgeBaseDocuments,
@@ -311,6 +312,11 @@ function DocumentItem({
           processingError={doc.processingError}
           t={t}
         />
+        <ItemDescription>
+          {t('detail.documents.addedAt', {
+            date: formatDate(doc.createdAt),
+          })}
+        </ItemDescription>
       </ItemContent>
       {!disabled && (
         <ItemActions>

--- a/ayunis-core-frontend/src/shared/locales/de/knowledge-bases.json
+++ b/ayunis-core-frontend/src/shared/locales/de/knowledge-bases.json
@@ -158,6 +158,7 @@
       "addUrlError": "URL konnte nicht hinzugefügt werden. Bitte überprüfen Sie die URL und versuchen Sie es erneut.",
       "addUrlRetrievalFailed": "Die Website konnte nicht erreicht werden. Bitte überprüfen Sie, ob die URL korrekt ist und die Website erreichbar ist.",
       "addUrlUnsupportedContentType": "Diese URL verweist auf eine Datei (z. B. PDF) statt auf eine Website. Bitte laden Sie die Datei herunter und laden Sie sie direkt hoch.",
+      "addedAt": "Hinzugefügt am {{date}}",
       "statusProcessing": "Wird verarbeitet… Sie können diese Seite verlassen.",
       "statusProcessingSlow": "Verarbeitung dauert länger als erwartet… Sie können diese Seite verlassen.",
       "statusFailed": "Fehlgeschlagen",

--- a/ayunis-core-frontend/src/shared/locales/en/knowledge-bases.json
+++ b/ayunis-core-frontend/src/shared/locales/en/knowledge-bases.json
@@ -158,6 +158,7 @@
       "addUrlError": "Failed to add URL. Please check the URL and try again.",
       "addUrlRetrievalFailed": "The website could not be reached. Please check that the URL is correct and the website is accessible.",
       "addUrlUnsupportedContentType": "This URL points to a file (e.g. PDF) instead of a website. Please download the file and upload it directly.",
+      "addedAt": "Added {{date}}",
       "statusProcessing": "Processing… You can safely navigate away.",
       "statusProcessingSlow": "Taking longer than expected… You can safely navigate away.",
       "statusFailed": "Failed",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds the created date for individual sources in the knowledge base documents list so source age is visible to the user.

Closes AYC-300.

## Changes

- Display an "Added {date}" line for each source in `KnowledgeBaseDocumentsCard` (`DocumentItem`).
- The date uses the shared `formatDate` helper (`@/shared/lib/format-date`), which formats according to the browser locale.
- Added the `detail.documents.addedAt` translation key in both EN (`Added {{date}}`) and DE (`Hinzugefügt am {{date}}`) locale files.

## Notes

- No backend change was required: `createdAt` is already exposed on `KnowledgeBaseDocumentResponseDto` and returned by `GET /knowledge-bases/:id/documents`.
- The sources list is rendered as an `ItemGroup` list (not a shadcn table), so the date is shown as a secondary description line under each item rather than a table column.

## Validation

- `npm run build` succeeds.
- `npm run lint` passes (0 errors; only pre-existing warnings unrelated to this change).
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [AYC-300](https://linear.app/ayunis/issue/AYC-300/show-created-date-for-individual-knowledge-base-sources)

<div><a href="https://cursor.com/agents/bc-d100df6e-f544-454f-a375-a65738b0afb9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d100df6e-f544-454f-a375-a65738b0afb9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

