### PR TITLE
fix(invites): allow re-inviting a deleted user's email (AYC-299)

### DIFF
--- a/ayunis-core-backend/src/db/migrations/1781707812150-CleanupOrphanedAcceptedInvites.ts
+++ b/ayunis-core-backend/src/db/migrations/1781707812150-CleanupOrphanedAcceptedInvites.ts
@@ -1,0 +1,36 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Data cleanup for AYC-299: deleting a user failed to remove that user's
+ * already-accepted invite, leaving an orphaned row behind. Because
+ * `invites.email` carries a global UNIQUE constraint, the orphan blocked
+ * re-inviting the same email (the insert hit the unique violation).
+ *
+ * The code path is fixed separately (delete-by-email now matches accepted
+ * invites too), but rows orphaned before that fix still need clearing. This
+ * deletes every accepted invite whose email no longer maps to a user —
+ * i.e. invites left behind by a deleted user. Accepted invites for users
+ * that still exist are untouched.
+ *
+ * This is a one-way data fix: `down()` cannot recreate deleted rows (and
+ * doing so would re-introduce the bug), so it is intentionally a no-op.
+ */
+export class CleanupOrphanedAcceptedInvites1781707812150 implements MigrationInterface {
+  name = 'CleanupOrphanedAcceptedInvites1781707812150';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DELETE FROM "invites" AS "i"
+       WHERE "i"."acceptedAt" IS NOT NULL
+         AND NOT EXISTS (
+           SELECT 1 FROM "users" AS "u"
+           WHERE LOWER("u"."email") = LOWER("i"."email")
+         )`,
+    );
+  }
+
+  public async down(): Promise<void> {
+    // Irreversible data cleanup — orphaned rows cannot (and should not) be
+    // recreated. Intentional no-op.
+  }
+}

--- a/ayunis-core-backend/src/iam/invites/infrastructure/persistence/local/local-invites.repository.spec.ts
+++ b/ayunis-core-backend/src/iam/invites/infrastructure/persistence/local/local-invites.repository.spec.ts
@@ -1,0 +1,62 @@
+import { randomUUID } from 'crypto';
+import { ILike, IsNull, type Repository } from 'typeorm';
+
+import { LocalInvitesRepository } from './local-invites.repository';
+import { InviteRecord } from './schema/invite.record';
+import { InviteMapper } from './mappers/invite.mapper';
+import { UserRole } from '../../../../users/domain/value-objects/role.object';
+
+function makeAcceptedInviteRecord(email: string): InviteRecord {
+  const record = new InviteRecord();
+  record.id = randomUUID();
+  record.email = email;
+  record.orgId = randomUUID();
+  record.role = UserRole.USER;
+  record.acceptedAt = new Date('2026-01-01T00:00:00Z');
+  record.expiresAt = new Date('2026-02-01T00:00:00Z');
+  record.createdAt = new Date('2026-01-01T00:00:00Z');
+  record.updatedAt = new Date('2026-01-01T00:00:00Z');
+  return record;
+}
+
+describe('LocalInvitesRepository', () => {
+  let inviteRepo: jest.Mocked<Pick<Repository<InviteRecord>, 'findOne'>>;
+  let repository: LocalInvitesRepository;
+
+  beforeEach(() => {
+    inviteRepo = { findOne: jest.fn() };
+    repository = new LocalInvitesRepository(
+      inviteRepo as unknown as Repository<InviteRecord>,
+      new InviteMapper(),
+    );
+  });
+
+  describe('findOneByEmail', () => {
+    // Regression test for AYC-299: deleting a user fails to clean up the
+    // user's already-accepted invite, so re-inviting the same email hits the
+    // global UNIQUE constraint on invites.email. The deletion path looks the
+    // invite up via findOneByEmail, which must therefore match accepted
+    // invites too — not just pending ones.
+    it('returns an invite even when it has already been accepted', async () => {
+      const accepted = makeAcceptedInviteRecord('user@example.com');
+      inviteRepo.findOne.mockResolvedValue(accepted);
+
+      const result = await repository.findOneByEmail('user@example.com');
+
+      expect(result).not.toBeNull();
+      expect(result?.id).toBe(accepted.id);
+
+      const where = inviteRepo.findOne.mock.calls[0][0].where;
+      expect(where).toEqual({ email: ILike('user@example.com') });
+      expect(where).not.toHaveProperty('acceptedAt', IsNull());
+    });
+
+    it('returns null when no invite exists for the email', async () => {
+      inviteRepo.findOne.mockResolvedValue(null);
+
+      const result = await repository.findOneByEmail('missing@example.com');
+
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/ayunis-core-backend/src/iam/invites/infrastructure/persistence/local/local-invites.repository.ts
+++ b/ayunis-core-backend/src/iam/invites/infrastructure/persistence/local/local-invites.repository.ts
@@ -110,8 +110,13 @@ export class LocalInvitesRepository implements InvitesRepository {
 
   async findOneByEmail(email: string): Promise<Invite | null> {
     this.logger.log('findOneByEmail', { email });
+    // Match the single invite row for this email regardless of acceptance
+    // state. invites.email is globally unique, so there is at most one row.
+    // Deletion paths (delete-user, delete-invite-by-email) rely on this to
+    // clean up already-accepted invites; filtering on acceptedAt would leave
+    // them orphaned and block re-inviting the same email (AYC-299).
     const entity = await this.inviteRepository.findOne({
-      where: { email: ILike(email), acceptedAt: IsNull() },
+      where: { email: ILike(email) },
     });
     if (!entity) {
       this.logger.debug('Invite not found by email', { email });


### PR DESCRIPTION
Deleting a user tried to clean up that user's invite but looked it up
via findOneByEmail, which filtered acceptedAt IS NULL and so never
matched an already-accepted invite. The accepted invite row was left
orphaned, and because invites.email is globally unique, re-inviting the
same email failed on the unique constraint.

- Drop the acceptedAt filter from LocalInvitesRepository.findOneByEmail
  (its only callers are deletion paths; email is globally unique so at
  most one row matches)
- Add a data-cleanup migration removing accepted invites with no
  matching user (unblocks already-affected customers)
- Add a regression test for findOneByEmail

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes invite lookup behavior used on deletion paths and runs irreversible DELETE migration on production invite data; scope is narrow and logic is well documented.
> 
> **Overview**
> Fixes **AYC-299**, where deleting a user could leave an **accepted** invite row behind and block re-inviting the same email because `invites.email` is globally unique.
> 
> **`LocalInvitesRepository.findOneByEmail`** no longer filters to pending invites only (`acceptedAt IS NULL` removed). User-delete and delete-by-email flows use this lookup to remove the invite row regardless of acceptance state.
> 
> A **one-way data migration** deletes accepted invites whose email has no matching user (case-insensitive), clearing rows created before the code fix without touching accepted invites for users that still exist.
> 
> **Regression tests** assert `findOneByEmail` returns accepted invites and does not require `acceptedAt` in the query.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93d1856b383b5bd2714a6b49f47da08e971c1745. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->