### PR TITLE
docs: add Cursor Cloud dev environment instructions (AYC-0000)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,6 @@ tsconfig.?????????*.json
 .pi
 .agents/
 .pi/
-AGENTS.md
 .agentfiles
 .agentfiles.lock
 .claude/worktrees/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,78 @@
+# AGENTS.md
+
+For repository overview, architecture, and development skills, see `.claude/CLAUDE.md`,
+`ARCHITECTURE.md`, `CONTRIBUTING.md`, and the skills under `.claude/skills/`.
+
+## Cursor Cloud specific instructions
+
+Durable, non-obvious notes for running this monorepo in the Cursor Cloud VM. The
+startup update script only refreshes JS dependencies (`pnpm install`); everything
+below must be done by the agent at the start of a session.
+
+### Toolchain
+
+- This repo requires Node **24** (`.node-version` = `24.14.1`, `engines.node >= 24`).
+  The VM's default `node` on `PATH` (`/exec-daemon/node`) is v22 and would shadow
+  nvm. A line appended to `~/.bashrc` prepends the nvm Node 24 bin so `node`/`pnpm`
+  resolve to v24 in login shells. If `node -v` ever shows v22, run
+  `nvm use 24.14.1` (and re-`corepack prepare pnpm@10.33.2 --activate` if `pnpm`
+  is missing). `pnpm` is provided via corepack, not a global npm install.
+
+### Starting the stack (do this every session — the update script does NOT)
+
+**1. Start the Docker daemon** — there is no systemd in this container, so dockerd
+is not auto-started. Run it in the background and make the socket usable without
+sudo:
+
+```bash
+sudo dockerd > /tmp/dockerd.log 2>&1 &
+sleep 8 && sudo chmod 666 /var/run/docker.sock
+```
+
+Docker is configured for `fuse-overlayfs` with the containerd snapshotter
+disabled (`/etc/docker/daemon.json`) — required for Docker 29 in this VM.
+
+**2. Bring up the app** with the `./dev` script (see the `dev-environment` skill).
+Use a slot ≥ 2 (slot 0/1 ports collide):
+
+```bash
+./dev up --slot 2
+```
+
+This starts Docker infra (postgres, minio, mailcatcher, redis, gotenberg,
+code-execution, anonymize), writes `ayunis-core-backend/.env.dev`, runs
+migrations, and starts the backend (`nest start --watch`) + frontend (vite)
+natively in tmux. Slot 2 ports: backend `3020`, frontend `3021`,
+API docs `3020/api/docs`.
+
+**3. Seed test data** (idempotent) for a login + fixtures (see `seed-database` skill):
+
+```bash
+cd ayunis-core-backend && pnpm run seed:minimal:ts
+```
+
+Default login: `admin@demo.local` / `admin`.
+
+The three `.env` files (`./.env`, `ayunis-core-backend/.env`,
+`ayunis-core-frontend/.env`) are gitignored and were created from the
+`.env.example` files. The backend `.env` sets `COOKIE_SECURE=false` so auth
+cookies work over plain HTTP in dev. `./dev up` regenerates `.env.dev` (connection
+config + a generated `MCP_ENCRYPTION_KEY`) on every run.
+
+### Caveats
+
+- **No LLM provider keys are configured** (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`,
+  AWS Bedrock, etc. are all unset). Logging in and non-LLM flows (creating skill
+  templates, knowledge bases, admin/org/user management, etc.) work end-to-end, but
+  actually chatting with a model will not return a completion until a provider key
+  is added to `ayunis-core-backend/.env`.
+- The UI is German by default.
+- The backend runs `nest start --watch`; after a `pnpm install` it does not always
+  pick up new native deps via hot reload — restart with `./dev down && ./dev up`.
+
+### Lint / test / build
+
+Standard package scripts (run inside `ayunis-core-backend/` and
+`ayunis-core-frontend/`): `pnpm run lint`, `pnpm run test`, `pnpm run build`.
+Backend `lint` runs `eslint --fix` and may reformat files — revert unintended
+diffs before committing.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Stop git-ignoring `AGENTS.md` and track a `## Cursor Cloud specific instructions` section so future Cursor Cloud agents have the environment setup notes in version control instead of only in the VM snapshot.

- Remove `AGENTS.md` from `.gitignore`.
- Add `AGENTS.md` documenting (for the Cursor Cloud VM): the Node 24 toolchain caveat (nvm overrides the v22 `node` on `PATH`), how to start `dockerd` manually (no systemd) and bring up the stack via `./dev up --slot 2`, database seeding + default login, and the "no LLM provider keys configured" caveat. It references `.claude/CLAUDE.md`, `ARCHITECTURE.md`, `CONTRIBUTING.md`, and the existing skills rather than duplicating them.

No application code is changed.

## Note on the ticket ID

The repo's `commit-msg` hook requires an `AYC-` task ID. None was provided for this environment-setup work, so the commit/title use the placeholder **`AYC-0000`** — please replace it with the real ticket (or drop it) before merging.

## Testing

- ✅ `pnpm exec markdownlint-cli2 AGENTS.md` (0 errors)
- ✅ pre-commit + commit-msg hooks passed on commit

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ec669b57-acb7-4a7c-8ffe-89df21869821"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ec669b57-acb7-4a7c-8ffe-89df21869821"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

