### PR TITLE
feat(anonymization): clarify exception copy and add per-category examples (AYC-275)

### DIFF
--- a/ayunis-core-frontend/src/pages/admin-settings/anonymization-settings/ui/PiiCategoryRow.tsx
+++ b/ayunis-core-frontend/src/pages/admin-settings/anonymization-settings/ui/PiiCategoryRow.tsx
@@ -34,6 +34,8 @@ export function PiiCategoryRow({
   const { t } = useTranslation('admin-settings-anonymization');
 
   const label = t(`piiWhitelist.categories.${category}.label`);
+  const placeholder = t(`piiWhitelist.categories.${category}.placeholder`);
+  const example = t(`piiWhitelist.categories.${category}.example`);
   const errorMessage =
     error === 'too_long'
       ? t('piiWhitelist.patternTooLong', { max: MAX_PATTERN_LENGTH })
@@ -69,8 +71,8 @@ export function PiiCategoryRow({
               id={`pii-pattern-${category}`}
               value={row.pattern}
               disabled={disabled}
-              placeholder={t('piiWhitelist.patternPlaceholder')}
-              className="font-mono text-sm"
+              placeholder={placeholder}
+              className="text-sm"
               onChange={(e) => onChange({ ...row, pattern: e.target.value })}
             />
             {error ? (
@@ -79,9 +81,15 @@ export function PiiCategoryRow({
                 <span>{errorMessage}</span>
               </div>
             ) : (
-              <p className="text-xs text-muted-foreground">
-                {t('piiWhitelist.patternHint')}
-              </p>
+              <div className="space-y-1 text-xs text-muted-foreground">
+                <p>
+                  {t('piiWhitelist.exampleLabel')}{' '}
+                  <span className="text-foreground">{placeholder}</span>
+                  {' – '}
+                  {example}
+                </p>
+                <p>{t('piiWhitelist.patternHint')}</p>
+              </div>
             )}
           </div>
         </ItemFooter>

--- a/ayunis-core-frontend/src/shared/locales/de/admin-settings-anonymization.json
+++ b/ayunis-core-frontend/src/shared/locales/de/admin-settings-anonymization.json
@@ -1,10 +1,10 @@
 {
   "piiWhitelist": {
     "heading": "Ausnahmen von der Anonymisierung",
-    "description": "Im anonymen Modus werden erkannte personenbezogene Daten maskiert, bevor sie an das KI-Modell gesendet werden. Unten aktivierte Kategorien werden von der Maskierung ausgenommen — entweder vollständig oder nur für Werte, die einem optionalen Muster vollständig entsprechen.",
-    "patternLabel": "Nur Werte ausnehmen, die diesem Muster entsprechen (optional)",
-    "patternPlaceholder": "z. B. .*@muster-stadt\\.de",
-    "patternHint": "Regulärer Ausdruck, Groß-/Kleinschreibung wird ignoriert. Der gesamte erkannte Wert muss übereinstimmen. Leer lassen, um die ganze Kategorie auszunehmen.",
+    "description": "Im anonymen Modus ersetzt Ayunis Core erkannte personenbezogene Daten durch Platzhalter, bevor sie an das Sprachmodell gesendet werden. Hier können Sie einzelne Daten-Arten (z. B. Namen oder E-Mails) von der Anonymisierung ausnehmen – entweder vollständig oder nur für bestimmte Werte, die Sie angeben. Alles andere wird weiterhin maskiert.",
+    "patternLabel": "Nur bestimmte Werte ausnehmen (optional)",
+    "exampleLabel": "Beispiel:",
+    "patternHint": "Das Muster ist ein regulärer Ausdruck – der Wert muss vollständig dazu passen, Groß- und Kleinschreibung spielt keine Rolle. Leer lassen, um die ganze Kategorie auszunehmen.",
     "invalidPattern": "Dieses Muster ist kein gültiger regulärer Ausdruck.",
     "patternTooLong": "Das Muster darf höchstens {{max}} Zeichen lang sein.",
     "unsafePattern": "Dieses Muster wurde abgelehnt, da es zu übermäßiger Verarbeitungszeit führen könnte.",
@@ -18,47 +18,69 @@
     "categories": {
       "person_name": {
         "label": "Personennamen",
-        "description": "Vor- und Nachnamen natürlicher Personen"
+        "description": "Vor- und Nachnamen natürlicher Personen",
+        "placeholder": "Erika Mustermann",
+        "example": "nimmt genau diesen Namen aus. Mit der Tastatureingabe | mehrere Namen angeben."
       },
       "organization": {
         "label": "Organisationen",
-        "description": "Namen von Unternehmen, Institutionen und Behörden"
+        "description": "Namen von Unternehmen, Institutionen und Behörden",
+        "placeholder": "Stadt Musterstadt",
+        "example": "nimmt genau diese Organisation aus. Mit der Tastatureingabe | mehrere Organisationen angeben."
       },
       "location": {
         "label": "Orte & Adressen",
-        "description": "Städte, Länder, Straßen und Adressen"
+        "description": "Städte, Länder, Straßen und Adressen",
+        "placeholder": "Musterstadt",
+        "example": "nimmt genau diesen Ort aus. Mit der Tastatureingabe | mehrere Orte angeben."
       },
       "email_address": {
         "label": "E-Mail-Adressen",
-        "description": "Persönliche und organisatorische E-Mail-Adressen"
+        "description": "Persönliche und organisatorische E-Mail-Adressen",
+        "placeholder": ".*@muster-stadt\\.de",
+        "example": "nimmt alle E-Mail-Adressen aus, die auf @muster-stadt.de enden. Mit der Tastatureingabe | mehrere Adressen angeben."
       },
       "phone_number": {
         "label": "Telefonnummern",
-        "description": "Festnetz- und Mobilfunknummern"
+        "description": "Festnetz- und Mobilfunknummern",
+        "placeholder": "0681 .*",
+        "example": "nimmt alle Telefonnummern mit der Vorwahl 0681 aus. Mit der Tastatureingabe | mehrere Nummern angeben."
       },
       "url_or_ip": {
         "label": "URLs & IP-Adressen",
-        "description": "Webadressen und IP-Adressen"
+        "description": "Webadressen und IP-Adressen",
+        "placeholder": ".*muster-stadt\\.de.*",
+        "example": "nimmt alle Adressen aus, die muster-stadt.de enthalten. Mit der Tastatureingabe | mehrere Adressen angeben."
       },
       "date_time": {
         "label": "Datums- & Zeitangaben",
-        "description": "Konkrete Daten und Uhrzeiten, z. B. Geburtsdaten"
+        "description": "Konkrete Daten und Uhrzeiten, z. B. Geburtsdaten",
+        "placeholder": "\\d{4}",
+        "example": "nimmt alle vierstelligen Zahlen aus, z. B. Jahreszahlen. Mit der Tastatureingabe | mehrere Angaben angeben."
       },
       "financial_account": {
         "label": "Finanzdaten",
-        "description": "Kreditkartennummern, IBANs und Kontonummern"
+        "description": "Kreditkartennummern, IBANs und Kontonummern",
+        "placeholder": "DE12 .*",
+        "example": "nimmt alle IBANs aus, die mit DE12 beginnen. Mit der Tastatureingabe | mehrere Angaben angeben."
       },
       "government_id": {
         "label": "Amtliche Kennnummern",
-        "description": "Sozialversicherungs-, Pass-, Führerschein- und Approbationsnummern"
+        "description": "Sozialversicherungs-, Pass-, Führerschein- und Approbationsnummern",
+        "placeholder": ".*muster.*",
+        "example": "nimmt alle Werte aus, die „muster“ enthalten. Mit der Tastatureingabe | mehrere Werte angeben."
       },
       "nationality_religion_politics": {
         "label": "Nationalität, Religion & Politik",
-        "description": "Hinweise auf Nationalität, religiöse oder politische Zugehörigkeit"
+        "description": "Hinweise auf Nationalität, religiöse oder politische Zugehörigkeit",
+        "placeholder": ".*muster.*",
+        "example": "nimmt alle Werte aus, die „muster“ enthalten. Mit der Tastatureingabe | mehrere Werte angeben."
       },
       "other": {
         "label": "Sonstige / nicht zugeordnet",
-        "description": "Von der Erkennung gefundene personenbezogene Daten ohne bekannte Kategorie"
+        "description": "Von der Erkennung gefundene personenbezogene Daten ohne bekannte Kategorie",
+        "placeholder": ".*muster.*",
+        "example": "nimmt alle Werte aus, die „muster“ enthalten. Mit der Tastatureingabe | mehrere Werte angeben."
       }
     }
   }

--- a/ayunis-core-frontend/src/shared/locales/en/admin-settings-anonymization.json
+++ b/ayunis-core-frontend/src/shared/locales/en/admin-settings-anonymization.json
@@ -1,10 +1,10 @@
 {
   "piiWhitelist": {
     "heading": "Anonymization exceptions",
-    "description": "In anonymous mode, detected personal data is masked before it is sent to the AI model. Categories enabled below are exempt from masking — either entirely, or only for values that fully match an optional pattern.",
-    "patternLabel": "Only exempt values matching this pattern (optional)",
-    "patternPlaceholder": "e.g. .*@muster-stadt\\.de",
-    "patternHint": "Regular expression, case-insensitive. The entire detected value must match. Leave empty to exempt the whole category.",
+    "description": "In anonymous mode, Ayunis Core replaces detected personal data with placeholders before it is sent to the language model. Here you can exempt individual data types (e.g. names or emails) from anonymization — either entirely or only for specific values you define. Everything else is still masked.",
+    "patternLabel": "Only exempt specific values (optional)",
+    "exampleLabel": "Example:",
+    "patternHint": "The pattern is a regular expression — the value must fully match it, case-insensitive. Leave empty to exempt the whole category.",
     "invalidPattern": "This pattern is not a valid regular expression.",
     "patternTooLong": "The pattern must not exceed {{max}} characters.",
     "unsafePattern": "This pattern was rejected because it could cause excessive processing time.",
@@ -18,47 +18,69 @@
     "categories": {
       "person_name": {
         "label": "Person names",
-        "description": "First and last names of natural persons"
+        "description": "First and last names of natural persons",
+        "placeholder": "Erika Mustermann",
+        "example": "exempts exactly this name. Use the | key to list several names."
       },
       "organization": {
         "label": "Organizations",
-        "description": "Names of companies, institutions, and public bodies"
+        "description": "Names of companies, institutions, and public bodies",
+        "placeholder": "Stadt Musterstadt",
+        "example": "exempts exactly this organization. Use the | key to list several organizations."
       },
       "location": {
         "label": "Locations & addresses",
-        "description": "Cities, countries, streets, and addresses"
+        "description": "Cities, countries, streets, and addresses",
+        "placeholder": "Musterstadt",
+        "example": "exempts exactly this location. Use the | key to list several locations."
       },
       "email_address": {
         "label": "Email addresses",
-        "description": "Personal and organizational email addresses"
+        "description": "Personal and organizational email addresses",
+        "placeholder": ".*@muster-stadt\\.de",
+        "example": "exempts all email addresses ending in @muster-stadt.de. Use the | key to list several addresses."
       },
       "phone_number": {
         "label": "Phone numbers",
-        "description": "Landline and mobile numbers"
+        "description": "Landline and mobile numbers",
+        "placeholder": "0681 .*",
+        "example": "exempts all phone numbers with the area code 0681. Use the | key to list several numbers."
       },
       "url_or_ip": {
         "label": "URLs & IP addresses",
-        "description": "Web addresses and IP addresses"
+        "description": "Web addresses and IP addresses",
+        "placeholder": ".*muster-stadt\\.de.*",
+        "example": "exempts all addresses containing muster-stadt.de. Use the | key to list several addresses."
       },
       "date_time": {
         "label": "Dates & times",
-        "description": "Specific dates and times, e.g. dates of birth"
+        "description": "Specific dates and times, e.g. dates of birth",
+        "placeholder": "\\d{4}",
+        "example": "exempts all four-digit numbers, e.g. years. Use the | key to list several values."
       },
       "financial_account": {
         "label": "Financial accounts",
-        "description": "Credit card numbers, IBANs, and bank account numbers"
+        "description": "Credit card numbers, IBANs, and bank account numbers",
+        "placeholder": "DE12 .*",
+        "example": "exempts all IBANs starting with DE12. Use the | key to list several values."
       },
       "government_id": {
         "label": "Government IDs",
-        "description": "Social security, passport, driver's license, and medical license numbers"
+        "description": "Social security, passport, driver's license, and medical license numbers",
+        "placeholder": ".*muster.*",
+        "example": "exempts all values containing “muster”. Use the | key to list several values."
       },
       "nationality_religion_politics": {
         "label": "Nationality, religion & politics",
-        "description": "References to nationality, religious, or political affiliation"
+        "description": "References to nationality, religious, or political affiliation",
+        "placeholder": ".*muster.*",
+        "example": "exempts all values containing “muster”. Use the | key to list several values."
       },
       "other": {
         "label": "Other / unrecognized",
-        "description": "Personal data detected by the engine that does not fit a known category"
+        "description": "Personal data detected by the engine that does not fit a known category",
+        "placeholder": ".*muster.*",
+        "example": "exempts all values containing “muster”. Use the | key to list several values."
       }
     }
   }


### PR DESCRIPTION
## Was & warum

Die Anonymisierungs-Einstellungen (Admin → Anonymisierung) waren sprachlich kryptisch und nutzten für jede Kategorie denselben E-Mail-Platzhalter. Dieser PR macht verständlich, wie Admins einzelne Daten-Arten von der Anonymisierung ausnehmen.

## Änderungen

- Beschreibung, Feld-Label und Hinweistext klarer formuliert (Ayunis Core als Akteur, „maskiert" statt „entfernt", kein „KI")
- Kategorie-spezifische Platzhalter statt eines globalen (z. B. E-Mail → `.*@muster-stadt\.de`, Telefon → `0681 .*`, Datum → `\d{4}`)
- Pro Kategorie ein verständliches Beispiel unter dem Feld, das das Muster in Klartext erklärt
- Hinweis auf Mehrfach-Eingabe über die Tastatureingabe `|` (pro Bereich passend)
- Monospace-Schrift aus dem Eingabefeld entfernt

## Tickets

- AYC-275 — Wording-Anpassung bei Anonymisierungs-Feature
- PRD-8 — Product Update Anonymisation Pipeline

## Tests / Checks

- ✅ ESLint (inkl. `--max-warnings=0`), Prettier, TypeScript Typecheck
- ✅ i18n DE/EN Key-Parität (59/59), JSON valide
- ✅ Manuell auf der Anonymisierungs-Seite geprüft

## Follow-up (Vorschlag)

„Mehrere Werte als einfache Liste eingeben" (Backend baut den Regex), statt `|` manuell tippen zu müssen — die Zielgruppe im öffentlichen Sektor kennt das `|`-Zeichen auf der Tastatur oft nicht. Sinnvoll als eigenes Ticket.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy and presentation-only changes in admin anonymization settings; no API, validation, or masking logic changes.
> 
> **Overview**
> Improves **anonymization exception** guidance in admin settings by rewriting EN/DE copy and showing **category-specific** placeholders and plain-language examples on each PII row.
> 
> **`PiiCategoryRow`** now loads `placeholder` and `example` from `piiWhitelist.categories.{category}` instead of a single shared `patternPlaceholder`. When validation passes, the footer shows an **Example:** line (sample pattern in normal foreground text) plus the updated regex hint; the pattern input drops **`font-mono`**.
> 
> Locale files add **`exampleLabel`**, refresh the page **description**, **patternLabel**, and **patternHint**, and define **placeholder** / **example** for every category (including how to list multiple values with **|**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e96f98cc68b1fcc35f5c31aa9a0b272580a6ff8f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
