### PR TITLE
feat(webhooks): add email to user.deleted payload (AYC-314)

### DIFF
--- a/ayunis-core-backend/src/iam/users/application/events/user-deleted.event.ts
+++ b/ayunis-core-backend/src/iam/users/application/events/user-deleted.event.ts
@@ -6,5 +6,6 @@ export class UserDeletedEvent {
   constructor(
     public readonly userId: UUID,
     public readonly orgId: UUID,
+    public readonly email: string,
   ) {}
 }

--- a/ayunis-core-backend/src/iam/users/application/use-cases/delete-user/delete-user.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/delete-user/delete-user.use-case.spec.ts
@@ -125,6 +125,7 @@ describe('DeleteUserUseCase', () => {
       expect.objectContaining({
         userId: command.userId,
         orgId: mockUser.orgId,
+        email: mockUser.email,
       }),
     );
   });

--- a/ayunis-core-backend/src/iam/users/application/use-cases/delete-user/delete-user.use-case.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/delete-user/delete-user.use-case.ts
@@ -11,6 +11,7 @@ import { ContextService } from 'src/common/context/services/context.service';
 import { Transactional } from '@nestjs-cls/transactional';
 import { InviteNotFoundError } from 'src/iam/invites/application/invites.errors';
 import { UserDeletedEvent } from '../../events/user-deleted.event';
+import type { User } from 'src/iam/users/domain/user.entity';
 
 @Injectable()
 export class DeleteUserUseCase {
@@ -64,15 +65,19 @@ export class DeleteUserUseCase {
         }
         throw error;
       });
+    this.emitUserDeleted(userToDelete);
+  }
+
+  private emitUserDeleted(user: User): void {
     this.eventEmitter
       .emitAsync(
         UserDeletedEvent.EVENT_NAME,
-        new UserDeletedEvent(command.userId, userToDelete.orgId),
+        new UserDeletedEvent(user.id, user.orgId, user.email),
       )
       .catch((err: unknown) => {
         this.logger.error('Failed to emit UserDeletedEvent', {
           error: err instanceof Error ? err.message : 'Unknown error',
-          userId: command.userId,
+          userId: user.id,
         });
       });
   }

--- a/ayunis-core-backend/src/integrations/webhooks/domain/webhook-events/user-deleted.webhook-event.ts
+++ b/ayunis-core-backend/src/integrations/webhooks/domain/webhook-events/user-deleted.webhook-event.ts
@@ -4,13 +4,13 @@ import { WebhookEvent } from '../webhook-event.entity';
 
 export class UserDeletedWebhookEvent extends WebhookEvent {
   readonly eventType: WebhookEventType = WebhookEventType.USER_DELETED;
-  readonly data: UUID;
+  readonly data: { id: UUID; email: string };
   readonly timestamp: Date;
 
-  constructor(userId: UUID) {
+  constructor(params: { id: UUID; email: string }) {
     super();
     this.eventType = WebhookEventType.USER_DELETED;
-    this.data = userId;
+    this.data = { id: params.id, email: params.email };
     this.timestamp = new Date();
   }
 }

--- a/ayunis-core-backend/src/integrations/webhooks/listeners/webhook-dispatch.listener.spec.ts
+++ b/ayunis-core-backend/src/integrations/webhooks/listeners/webhook-dispatch.listener.spec.ts
@@ -121,12 +121,18 @@ describe('WebhookDispatchListener', () => {
   });
 
   describe('handleUserDeleted', () => {
-    it('should dispatch UserDeletedWebhookEvent', async () => {
-      await listener.handleUserDeleted(new UserDeletedEvent(USER_ID, ORG_ID));
+    it('should dispatch UserDeletedWebhookEvent with id and email', async () => {
+      await listener.handleUserDeleted(
+        new UserDeletedEvent(USER_ID, ORG_ID, 'test@example.com'),
+      );
 
       expect(sendWebhookUseCase.execute).toHaveBeenCalledTimes(1);
       const command = sendWebhookUseCase.execute.mock.calls[0][0];
       expect(command.event.eventType).toBe(WebhookEventType.USER_DELETED);
+      expect(command.event.data).toEqual({
+        id: USER_ID,
+        email: 'test@example.com',
+      });
     });
   });
 
@@ -439,7 +445,9 @@ describe('WebhookDispatchListener', () => {
       );
 
       await expect(
-        listener.handleUserDeleted(new UserDeletedEvent(USER_ID, ORG_ID)),
+        listener.handleUserDeleted(
+          new UserDeletedEvent(USER_ID, ORG_ID, 'test@example.com'),
+        ),
       ).resolves.toBeUndefined();
     });
   });

--- a/ayunis-core-backend/src/integrations/webhooks/listeners/webhook-dispatch.listener.ts
+++ b/ayunis-core-backend/src/integrations/webhooks/listeners/webhook-dispatch.listener.ts
@@ -66,7 +66,9 @@ export class WebhookDispatchListener {
 
   @OnEvent(UserDeletedEvent.EVENT_NAME)
   async handleUserDeleted(event: UserDeletedEvent): Promise<void> {
-    await this.dispatch(new UserDeletedWebhookEvent(event.userId));
+    await this.dispatch(
+      new UserDeletedWebhookEvent({ id: event.userId, email: event.email }),
+    );
   }
 
   @OnEvent(OrgCreatedEvent.EVENT_NAME)


### PR DESCRIPTION
Connect now matches StartDeliver users by email, but user.deleted
was the only webhook still emitting a bare userId UUID. Thread the
deleted user's email (already loaded in DeleteUserUseCase) through
the domain event and listener so the payload data becomes
{ id, email }, matching the shape Connect expects.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> This is a breaking webhook contract change for any receiver that still expects `data` to be a UUID only; it also adds email (PII) to the deleted-user webhook payload.
> 
> **Overview**
> **`user.deleted`** now carries the deleted user’s **email** from delete flow through domain events into outbound webhooks, so consumers can match users by email (e.g. Connect / StartDeliver) instead of relying on a bare user id alone.
> 
> `UserDeletedEvent` gains an `email` field; `DeleteUserUseCase` emits it via a small **`emitUserDeleted(user)`** helper using the user already loaded for deletion. **`UserDeletedWebhookEvent`** payload **`data`** changes from a single UUID to **`{ id, email }`**, and **`WebhookDispatchListener`** maps the domain event into that shape. Specs assert the new event and webhook payload fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0fd7ba846c1ec18ef006295aee857315ee4ee89d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->