### PR TITLE
ci(complexity): unify local hook with CI ESLint complexity check (AYC-316)

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -34,6 +34,14 @@ BE_TS_STAGED=$(printf "%s" "$STAGED_FILES" | grep -E '^ayunis-core-backend/(src|
 PKG_TS_STAGED=$(printf "%s" "$STAGED_FILES" | grep -E '^packages/[^/]+/(src|examples)/.*\.ts$' || true)
 PKG_DIRS=$(printf "%s\n" "$PKG_TS_STAGED" | sed -E 's#^(packages/[^/]+)/.*#\1#' | sort -u)
 
+# Complexity gate scope: ALL staged backend + workspace-package .ts files. This
+# is intentionally broader than the lint scopes above (which target src/apps/
+# libs/test and src/examples) so it matches the CI "Complexity Check" workflow
+# (.github/workflows/complexity-check.yml) exactly — including root config files
+# like orval.config.ts / tsup.config.ts that CI complexity-checks but the lint
+# jobs skip. The eslint.complexity.config.mjs `ignores` handle exclusions.
+COMPLEXITY_TS_STAGED=$(printf "%s" "$STAGED_FILES" | grep -E '^(ayunis-core-backend|packages)/.*\.ts$' || true)
+
 # All staged TS/TSX files (for file size check)
 ALL_TS_STAGED=$(printf "%s" "$STAGED_FILES" | grep -E '\.(ts|tsx)$' || true)
 
@@ -59,6 +67,7 @@ FE_PRETTIER_STATUS_FILE="$STATUS_DIR/fe_prettier.status"
 FE_TSC_STATUS_FILE="$STATUS_DIR/fe_tsc.status"
 FE_ESLINT_STATUS_FILE="$STATUS_DIR/fe_eslint.status"
 BE_ESLINT_STATUS_FILE="$STATUS_DIR/be_eslint.status"
+COMPLEXITY_STATUS_FILE="$STATUS_DIR/complexity.status"
 BE_PRETTIER_STATUS_FILE="$STATUS_DIR/be_prettier.status"
 BE_TSC_STATUS_FILE="$STATUS_DIR/be_tsc.status"
 DEPCRUISE_STATUS_FILE="$STATUS_DIR/depcruise.status"
@@ -139,16 +148,41 @@ run_be_eslint() {
   set +e
   (
     cd ayunis-core-backend >/dev/null 2>&1
-    # --max-warnings=0 turns the warn-level complexity rules (complexity,
-    # max-lines-per-function) into a blocking gate on changed files, replacing
-    # the old lizard check. max-params is suppressed here: NestJS DI constructors
-    # legitimately need >5 params, so it stays a non-blocking warn (see
-    # eslint.config.mjs).
+    # --max-warnings=0 turns the remaining warn-level rules into a blocking gate
+    # on changed files. The complexity rules (complexity, max-lines-per-function)
+    # and max-params are suppressed here because complexity is enforced by the
+    # dedicated `run_complexity` job below, which runs the exact same
+    # eslint.complexity.config.mjs check as CI (single source of truth, no
+    # divergence). max-params stays a non-blocking warn anyway: NestJS DI
+    # constructors legitimately need >5 params.
     printf "%s" "$BE_TS_STAGED" \
       | sed 's#^ayunis-core-backend/##' \
       | tr '\n' '\0' \
-      | xargs -0 pnpm exec eslint --format stylish --max-warnings=0 --rule '{"max-params":"off"}' $ESLINT_FIX_ARGS
+      | xargs -0 pnpm exec eslint --format stylish --max-warnings=0 --rule '{"max-params":"off","complexity":"off","max-lines-per-function":"off"}' $ESLINT_FIX_ARGS
   )
+  STATUS=$?
+  set -e
+  printf "%s" "$STATUS" > "$STATUS_FILE"
+}
+
+# Complexity gate (backend + workspace packages). Runs the SAME ESLint config
+# and invocation as the CI "Complexity Check" workflow
+# (.github/workflows/complexity-check.yml) so a commit that passes locally
+# cannot fail CI on complexity alone. ESLint is invoked from the repo root via
+# the backend-installed binary with repo-relative paths, so the config's `**/`
+# globbed `ignores`/`files` resolve identically for backend and package files.
+run_complexity() {
+  STATUS_FILE="$1"
+  print_section "Complexity • ESLint (staged backend + packages TS)"
+  printf "%s\n" "$COMPLEXITY_TS_STAGED" | sed 's#^# - #'
+  set +e
+  printf "%s" "$COMPLEXITY_TS_STAGED" \
+    | sed '/^$/d' \
+    | tr '\n' '\0' \
+    | xargs -0 ayunis-core-backend/node_modules/.bin/eslint \
+        --no-config-lookup \
+        --config ayunis-core-backend/eslint.complexity.config.mjs \
+        --no-warn-ignored
   STATUS=$?
   set -e
   printf "%s" "$STATUS" > "$STATUS_FILE"
@@ -205,10 +239,12 @@ run_pkg_checks() {
   st=0
   (
     cd "$pkg_dir" >/dev/null 2>&1
-    # --max-warnings=0 makes the warn-level complexity rules a blocking gate on
-    # changed files (replaces lizard); max-params stays a non-blocking warn.
+    # --max-warnings=0 makes the remaining warn-level rules a blocking gate on
+    # changed files. Complexity (complexity / max-lines-per-function) is owned by
+    # the dedicated `run_complexity` job (same eslint.complexity.config.mjs check
+    # as CI), so it is suppressed here; max-params stays a non-blocking warn.
     printf "%s" "$pkg_rel" | tr '\n' '\0' \
-      | xargs -0 pnpm exec eslint --format stylish --max-warnings=0 --rule '{"max-params":"off"}' $ESLINT_FIX_ARGS
+      | xargs -0 pnpm exec eslint --format stylish --max-warnings=0 --rule '{"max-params":"off","complexity":"off","max-lines-per-function":"off"}' $ESLINT_FIX_ARGS
   ) || st=1
   (
     cd "$pkg_dir" >/dev/null 2>&1
@@ -320,9 +356,14 @@ if [ -n "$BE_TS_STAGED" ]; then
   run_be_tsc "$BE_TSC_STATUS_FILE" &
 fi
 
+# Complexity gate (backend + workspace packages) — same check as CI.
+if [ -n "$COMPLEXITY_TS_STAGED" ]; then
+  run_complexity "$COMPLEXITY_STATUS_FILE" &
+fi
+
 # Architecture + duplication checks (backend TS only — jscpd doesn't handle JSX
-# well). Complexity is enforced by the backend ESLint run above (complexity /
-# max-lines-per-function as a --max-warnings=0 gate).
+# well). Complexity is enforced by the dedicated run_complexity job above (the
+# same eslint.complexity.config.mjs check as CI).
 if [ -n "$BE_TS_STAGED" ]; then
   run_depcruise "$DEPCRUISE_STATUS_FILE" &
   run_be_duplication "$BE_DUPLICATION_STATUS_FILE" &
@@ -356,6 +397,7 @@ FE_STATUS=$(cat "$FE_PRETTIER_STATUS_FILE" 2>/dev/null || printf "0")
 FE_TSC_STATUS=$(cat "$FE_TSC_STATUS_FILE" 2>/dev/null || printf "0")
 FE_ESLINT_STATUS=$(cat "$FE_ESLINT_STATUS_FILE" 2>/dev/null || printf "0")
 ESLINT_STATUS=$(cat "$BE_ESLINT_STATUS_FILE" 2>/dev/null || printf "0")
+COMPLEXITY_STATUS=$(cat "$COMPLEXITY_STATUS_FILE" 2>/dev/null || printf "0")
 PRETTIER_STATUS=$(cat "$BE_PRETTIER_STATUS_FILE" 2>/dev/null || printf "0")
 BE_TSC_STATUS=$(cat "$BE_TSC_STATUS_FILE" 2>/dev/null || printf "0")
 DEPCRUISE_STATUS=$(cat "$DEPCRUISE_STATUS_FILE" 2>/dev/null || printf "0")
@@ -422,8 +464,18 @@ if [ -n "$BE_TS_STAGED" ]; then
   fi
 fi
 
-# Architecture + duplication results (backend only). Complexity is reported as
-# part of the "Backend ESLint" result above.
+# Complexity result (backend + packages — same ESLint check as CI).
+if [ -n "$COMPLEXITY_TS_STAGED" ]; then
+  if [ "$COMPLEXITY_STATUS" -ne 0 ]; then
+    printf "%b\n" "${RED}❌ Complexity check failed (complexity / max-lines-per-function)${NC}"
+    FAILED=1
+  else
+    printf "%b\n" "${GREEN}✅ Complexity check passed${NC}"
+  fi
+fi
+
+# Architecture + duplication results (backend only). Complexity is reported in
+# its own "Complexity check" result above (the dedicated CI-equivalent gate).
 if [ -n "$BE_TS_STAGED" ]; then
   if [ "$DEPCRUISE_STATUS" -ne 0 ]; then
     printf "%b\n" "${RED}❌ Dependency check failed (architecture violations)${NC}"
@@ -446,7 +498,7 @@ if [ -n "$PKG_TS_STAGED" ]; then
     pkg_name=$(basename "$pkg_dir")
     pkg_status=$(cat "$pkg_status_file" 2>/dev/null || printf "0")
     if [ "$pkg_status" -ne 0 ]; then
-      printf "%b\n" "${RED}❌ Package ${pkg_name} checks failed (eslint/prettier/tsc/complexity/circular/duplication)${NC}"
+      printf "%b\n" "${RED}❌ Package ${pkg_name} checks failed (eslint/prettier/tsc/circular/duplication)${NC}"
       FAILED=1
     else
       printf "%b\n" "${GREEN}✅ Package ${pkg_name} checks passed${NC}"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Makes the local pre-commit hook run the **exact same ESLint complexity check as CI**, closing a remaining divergence so a commit that passes locally cannot fail CI on complexity alone.

### Context

The bulk of this work (retiring **lizard** in favor of ESLint) already shipped in #849: lizard was removed from the pre-commit hook and `complexity-check.yml`, `scripts/check-complexity.sh` and the `pip install lizard` were deleted, and ESLint complexity gates were added with matching thresholds. No lizard remnants remain (only explanatory "old lizard" comments).

What was still divergent:

- **CI** (`.github/workflows/complexity-check.yml`) runs the dedicated `ayunis-core-backend/eslint.complexity.config.mjs` over **all** changed `ayunis-core-backend/**/*.ts` + `packages/**/*.ts` files.
- **Local hook** folded complexity into the full-lint `--max-warnings=0` run, scoped only to `src|apps|libs|test` (backend) and `src|examples` (packages).

So a `.ts` file outside those dirs (e.g. `orval.config.ts`, `tsup.config.ts`, `vitest.config.ts`) was complexity-checked by CI but **skipped locally** → "passes local, fails CI". Verified: a 64-line function in such a file is flagged by CI's config but missed by the old hook scope.

## Changes (`.husky/pre-commit`)

- **Add a dedicated `run_complexity` job** that runs the identical CI invocation — `eslint --no-config-lookup --config ayunis-core-backend/eslint.complexity.config.mjs --no-warn-ignored` from the repo root (via the backend-installed binary, so the config's `**/`-globbed `ignores`/`files` resolve for both backend and package files) — over **all** staged `ayunis-core-backend/**/*.ts` + `packages/**/*.ts` files.
- **Stop blocking on complexity in the full-lint runs** (`run_be_eslint`, `run_pkg_checks`): `complexity` and `max-lines-per-function` are now suppressed there (alongside the existing `max-params` suppression) and owned solely by the dedicated job — mirroring CI's two-layer model (full lint = warns/non-blocking; dedicated complexity = errors/blocking).
- Adds a dedicated **"Complexity check"** result line to the summary and updates the now-stale comments.

Single source of truth: local and CI run the same config, same file scope, same thresholds (`complexity ≤ 10`, `max-lines-per-function ≤ 50` with `skipBlankLines`/`skipComments`) and the same `ignores` (entities, records, migrations, generated, CQRS carriers, tests, etc.).

## Testing

- `sh -n .husky/pre-commit` — syntax OK.
- Staged a 64-line function in a backend root-level `.ts` (outside the old lint scope): the full hook now runs the **Complexity** job and reports `❌ Complexity check failed`, exit 1. The old hook would have skipped it entirely.
- Confirmed backend `src` files and `packages/**` files are covered by the dedicated invocation, and excluded files (`*.command.ts`, `*.spec.ts`, etc.) remain ignored.
- Hook passes cleanly for the actual change in this PR.

## Done-when checklist

- [x] Local pre-commit hook and CI run the **same** ESLint complexity check with identical thresholds.
- [x] A change that passes the local hook does not fail CI on complexity alone (file-scope gap closed).
- [x] Lizard fully removed (already done in #849; confirmed no remaining install/workflow/hook/exclusion workaround — only descriptive comments remain).
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [AYC-316](https://linear.app/ayunis/issue/AYC-316/unify-complexity-checks-replace-the-local-lizard-hook-with-the-ci)

<div><a href="https://cursor.com/agents/bc-5c0a9cb7-109a-4f3d-b2af-75ff9308acf2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5c0a9cb7-109a-4f3d-b2af-75ff9308acf2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

