### PR TITLE
feat(webhooks): add orgId to user.deleted payload (AYC-317)

### DIFF
--- a/ayunis-core-backend/src/integrations/webhooks/domain/webhook-events/user-deleted.webhook-event.ts
+++ b/ayunis-core-backend/src/integrations/webhooks/domain/webhook-events/user-deleted.webhook-event.ts
@@ -4,13 +4,13 @@ import { WebhookEvent } from '../webhook-event.entity';
 
 export class UserDeletedWebhookEvent extends WebhookEvent {
   readonly eventType: WebhookEventType = WebhookEventType.USER_DELETED;
-  readonly data: { id: UUID; email: string };
+  readonly data: { id: UUID; email: string; orgId: UUID };
   readonly timestamp: Date;
 
-  constructor(params: { id: UUID; email: string }) {
+  constructor(params: { id: UUID; email: string; orgId: UUID }) {
     super();
     this.eventType = WebhookEventType.USER_DELETED;
-    this.data = { id: params.id, email: params.email };
+    this.data = { id: params.id, email: params.email, orgId: params.orgId };
     this.timestamp = new Date();
   }
 }

--- a/ayunis-core-backend/src/integrations/webhooks/listeners/webhook-dispatch.listener.spec.ts
+++ b/ayunis-core-backend/src/integrations/webhooks/listeners/webhook-dispatch.listener.spec.ts
@@ -121,7 +121,7 @@ describe('WebhookDispatchListener', () => {
   });
 
   describe('handleUserDeleted', () => {
-    it('should dispatch UserDeletedWebhookEvent with id and email', async () => {
+    it('should dispatch UserDeletedWebhookEvent with id, email and orgId', async () => {
       await listener.handleUserDeleted(
         new UserDeletedEvent(USER_ID, ORG_ID, 'test@example.com'),
       );
@@ -132,6 +132,7 @@ describe('WebhookDispatchListener', () => {
       expect(command.event.data).toEqual({
         id: USER_ID,
         email: 'test@example.com',
+        orgId: ORG_ID,
       });
     });
   });

--- a/ayunis-core-backend/src/integrations/webhooks/listeners/webhook-dispatch.listener.ts
+++ b/ayunis-core-backend/src/integrations/webhooks/listeners/webhook-dispatch.listener.ts
@@ -67,7 +67,11 @@ export class WebhookDispatchListener {
   @OnEvent(UserDeletedEvent.EVENT_NAME)
   async handleUserDeleted(event: UserDeletedEvent): Promise<void> {
     await this.dispatch(
-      new UserDeletedWebhookEvent({ id: event.userId, email: event.email }),
+      new UserDeletedWebhookEvent({
+        id: event.userId,
+        email: event.email,
+        orgId: event.orgId,
+      }),
     );
   }
 


### PR DESCRIPTION
Connect matches StartDeliver users by email, which is not globally
unique, so every lookup must be scoped to the customer. user.deleted
was the last user event whose payload lacked orgId, forcing a global
email lookup that could soft-delete a same-email user under the wrong
customer.

- Add orgId to UserDeletedWebhookEvent data (now { id, email, orgId })
- Pass event.orgId through the dispatch listener
- Update listener spec assertion

Refs: AYC-314

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01M56LVnc6wirG8FJaHNRjQx

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive webhook field only; no auth or deletion logic changes. Webhook consumers must accept the new property but existing handlers that ignore extra fields remain safe.
> 
> **Overview**
> The **`user.deleted`** webhook payload now includes **`orgId`** alongside `id` and `email`, so downstream consumers (e.g. Connect) can scope user lookups by customer instead of relying on email alone.
> 
> **`UserDeletedWebhookEvent`** and **`WebhookDispatchListener.handleUserDeleted`** forward `event.orgId` from the domain event; the listener spec asserts the expanded payload.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 930187bef9bbe5930c067830a24ac3b898c8d9ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->