### PR TITLE
fix(chat-ui): clarify upload action wording (AYC-318)

### DIFF
--- a/ayunis-core-frontend/src/shared/locales/de/common.json
+++ b/ayunis-core-frontend/src/shared/locales/de/common.json
@@ -51,7 +51,7 @@
     "documentTooLargeForChat": "Dieses Dokument ist zu groß für die Verarbeitung im Chat. Bitte laden Sie es stattdessen in eine Wissenssammlung hoch.",
     "fileSourceDeleteError": "Fehler beim Löschen der Datei",
     "sourceNotFound": "Datei nicht gefunden. Sie wurde möglicherweise gelöscht.",
-    "uploadFile": "Datei hochladen",
+    "uploadFile": "Datei oder Bild hochladen",
     "imageLimitExceeded": "Maximal {{max}} Bilder erlaubt. Einige Bilder wurden nicht hinzugefügt.",
     "addKnowledgeBase": "Wissenssammlung hinzufügen",
     "knowledgeBasesLoadError": "Fehler beim Laden der Wissenssammlungen",

--- a/ayunis-core-frontend/src/shared/locales/en/common.json
+++ b/ayunis-core-frontend/src/shared/locales/en/common.json
@@ -51,7 +51,7 @@
     "documentTooLargeForChat": "This document is too large to process in a chat. Please add it to a knowledge base instead.",
     "fileSourceDeleteError": "Error deleting file",
     "sourceNotFound": "File not found. It may have been deleted.",
-    "uploadFile": "Upload File",
+    "uploadFile": "Upload File or Image",
     "imageLimitExceeded": "Maximum {{max}} images allowed. Some images were not added.",
     "addKnowledgeBase": "Add Knowledge Base",
     "knowledgeBasesLoadError": "Error loading knowledge bases",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Clarifies the wording of the upload action in the chat composer's "+" menu. The previous label `Datei hochladen` ("Upload File") did not convey that images can also be uploaded.

### Changes
- DE: `Datei hochladen` → `Datei oder Bild hochladen`
- EN: `Upload File` → `Upload File or Image`

The label is the `chatInput.uploadFile` i18n key rendered in `PlusButton.tsx`.

Resolves AYC-318.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [AYC-318](https://linear.app/ayunis/issue/AYC-318/wording-fur-upload-aktion-prazisieren)

<div><a href="https://cursor.com/agents/bc-b3eef270-511d-4080-a78c-33371c143196"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b3eef270-511d-4080-a78c-33371c143196"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

