### PR TITLE
ci(hooks): run related jest tests in pre-commit (AYC-175)

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -70,6 +70,7 @@ BE_ESLINT_STATUS_FILE="$STATUS_DIR/be_eslint.status"
 COMPLEXITY_STATUS_FILE="$STATUS_DIR/complexity.status"
 BE_PRETTIER_STATUS_FILE="$STATUS_DIR/be_prettier.status"
 BE_TSC_STATUS_FILE="$STATUS_DIR/be_tsc.status"
+BE_JEST_STATUS_FILE="$STATUS_DIR/be_jest.status"
 DEPCRUISE_STATUS_FILE="$STATUS_DIR/depcruise.status"
 FE_DEPCRUISE_STATUS_FILE="$STATUS_DIR/fe_depcruise.status"
 BE_DUPLICATION_STATUS_FILE="$STATUS_DIR/be_duplication.status"
@@ -226,6 +227,29 @@ run_be_tsc() {
   printf "%s" "$STATUS" > "$STATUS_FILE"
 }
 
+run_be_jest() {
+  STATUS_FILE="$1"
+  print_section "Backend • Jest (tests related to staged TS)"
+  printf "%s\n" "$BE_TS_STAGED" \
+    | sed 's#^ayunis-core-backend/##' \
+    | sed 's#^# - #'
+  set +e
+  (
+    cd ayunis-core-backend >/dev/null 2>&1
+    # --findRelatedTests runs only the *.spec.ts that import the staged files
+    # (plus any staged spec files themselves), so this stays fast and scoped to
+    # the change. --passWithNoTests keeps commits that touch no covered code
+    # green; --bail stops at the first failing suite.
+    printf "%s" "$BE_TS_STAGED" \
+      | sed 's#^ayunis-core-backend/##' \
+      | tr '\n' '\0' \
+      | xargs -0 pnpm exec jest --bail --passWithNoTests --findRelatedTests
+  )
+  STATUS=$?
+  set -e
+  printf "%s" "$STATUS" > "$STATUS_FILE"
+}
+
 # Generic checks for one workspace package under packages/* (eslint, prettier,
 # typecheck, complexity, circular deps, duplication). Runs as a single parallel
 # job per touched package, so new packages need no edits to this hook.
@@ -354,6 +378,7 @@ if [ -n "$BE_TS_STAGED" ]; then
   run_be_eslint "$BE_ESLINT_STATUS_FILE" &
   run_be_prettier "$BE_PRETTIER_STATUS_FILE" &
   run_be_tsc "$BE_TSC_STATUS_FILE" &
+  run_be_jest "$BE_JEST_STATUS_FILE" &
 fi
 
 # Complexity gate (backend + workspace packages) — same check as CI.
@@ -400,6 +425,7 @@ ESLINT_STATUS=$(cat "$BE_ESLINT_STATUS_FILE" 2>/dev/null || printf "0")
 COMPLEXITY_STATUS=$(cat "$COMPLEXITY_STATUS_FILE" 2>/dev/null || printf "0")
 PRETTIER_STATUS=$(cat "$BE_PRETTIER_STATUS_FILE" 2>/dev/null || printf "0")
 BE_TSC_STATUS=$(cat "$BE_TSC_STATUS_FILE" 2>/dev/null || printf "0")
+BE_JEST_STATUS=$(cat "$BE_JEST_STATUS_FILE" 2>/dev/null || printf "0")
 DEPCRUISE_STATUS=$(cat "$DEPCRUISE_STATUS_FILE" 2>/dev/null || printf "0")
 FE_DEPCRUISE_STATUS=$(cat "$FE_DEPCRUISE_STATUS_FILE" 2>/dev/null || printf "0")
 BE_DUPLICATION_STATUS=$(cat "$BE_DUPLICATION_STATUS_FILE" 2>/dev/null || printf "0")
@@ -461,6 +487,12 @@ if [ -n "$BE_TS_STAGED" ]; then
     FAILED=1
   else
     printf "%b\n" "${GREEN}✅ Backend TypeScript typecheck passed${NC}"
+  fi
+  if [ "$BE_JEST_STATUS" -ne 0 ]; then
+    printf "%b\n" "${RED}❌ Backend Jest (related tests) failed${NC}"
+    FAILED=1
+  else
+    printf "%b\n" "${GREEN}✅ Backend Jest (related tests) passed${NC}"
   fi
 fi
 


### PR DESCRIPTION
The backend Jest suite was broken (stale jest-mock@29.7.0 in
ayunis-core-backend/node_modules shadowing the hoisted 30.4.1), yet
commits passed because the pre-commit hook never ran tests — only
pnpm test and CI exercised jest.

Add a Backend Jest job to .husky/pre-commit that runs
`jest --findRelatedTests` on staged backend .ts files, scoped to the
change so it stays fast (--bail, --passWithNoTests). Tests now gate
commits alongside lint/typecheck/complexity.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Developer workflow only: commits with staged backend TS may take longer and can fail on test regressions; no runtime or production behavior changes.
> 
> **Overview**
> **Backend commits that stage `.ts` under `ayunis-core-backend` now run Jest before the commit completes**, closing a gap where lint/typecheck passed locally while the suite could still be broken until CI or manual `pnpm test`.
> 
> The hook adds a parallel **`run_be_jest`** job wired like existing backend gates: status file, launch when `BE_TS_STAGED` is non-empty, and pass/fail lines in the final summary. Inside `ayunis-core-backend`, staged paths are passed to **`jest --findRelatedTests`** with **`--bail`** and **`--passWithNoTests`** so only specs tied to the change run, failures block quickly, and changes with no related tests do not fail the hook.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d1d2fa3c234eff3a694c696033e67a8d1a1b8c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->