### PR TITLE
ci(dependabot): copy locaboo dependabot workflow and config (AYC-000)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,33 @@
+# Broad default ownership would request reviews on unrelated changes.
+# Add top-level paths here explicitly when ownership should be enforced.
+
+# Repository automation and release management.
+/.github/ @devbydaniel
+/Dockerfile @devbydaniel
+/docker-compose.yml @devbydaniel
+
+# AI assistant configuration and instructions.
+/.cursor/ @devbydaniel
+/.codex/ @devbydaniel
+/.claude/ @devbydaniel
+
+# Ayunis Core applications.
+/ayunis-core-backend/ @devbydaniel
+/ayunis-core-frontend/ @devbydaniel
+/ayunis-core-anonymize/ @devbydaniel
+/ayunis-core-code-execution/ @devbydaniel
+
+# Workspace packages.
+/packages/ @devbydaniel
+
+# Dependabot-managed files - no auto-review.
+/package.json
+/package-lock.json
+/pnpm-lock.yaml
+/ayunis-core-backend/package.json
+/ayunis-core-frontend/package.json
+/ayunis-core-anonymize/pyproject.toml
+/ayunis-core-anonymize/uv.lock
+/ayunis-core-code-execution/requirements.txt
+/ayunis-core-code-execution/pyproject.toml
+/.github/dependabot.yml

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,14 @@ updates:
       prefix: "chore(deps)"
     labels:
       - "dependencies"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 5
+    groups:
+      root-dependencies:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   # Backend (NestJS)
   - package-ecosystem: "npm"
@@ -23,21 +30,36 @@ updates:
     labels:
       - "dependencies"
       - "backend"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 8
     groups:
       nest:
         patterns:
           - "@nestjs/*"
+        update-types:
+          - "minor"
+          - "patch"
       typescript:
         patterns:
           - "typescript"
           - "ts-*"
           - "@types/*"
+        update-types:
+          - "minor"
+          - "patch"
       testing:
         patterns:
           - "jest"
           - "@jest/*"
           - "supertest"
+        update-types:
+          - "minor"
+          - "patch"
+      other:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   # Frontend (React/Vite)
   - package-ecosystem: "npm"
@@ -50,23 +72,41 @@ updates:
     labels:
       - "dependencies"
       - "frontend"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 8
     groups:
       react:
         patterns:
           - "react"
           - "react-dom"
           - "@types/react*"
+        update-types:
+          - "minor"
+          - "patch"
       tanstack:
         patterns:
           - "@tanstack/*"
+        update-types:
+          - "minor"
+          - "patch"
       radix:
         patterns:
           - "@radix-ui/*"
+        update-types:
+          - "minor"
+          - "patch"
       vite:
         patterns:
           - "vite"
           - "@vitejs/*"
+        update-types:
+          - "minor"
+          - "patch"
+      other:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   # Anonymize service (Python/uv)
   - package-ecosystem: "uv"
@@ -105,6 +145,13 @@ updates:
     labels:
       - "dependencies"
       - "docker"
+    groups:
+      docker-images:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "docker"
     directory: "/ayunis-core-anonymize"
@@ -139,3 +186,10 @@ updates:
     labels:
       - "dependencies"
       - "ci"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/workflows/dependabot-remove-codeowners.yml
+++ b/.github/workflows/dependabot-remove-codeowners.yml
@@ -1,0 +1,42 @@
+name: Remove CODEOWNERS from Dependabot PRs
+
+on:
+  pull_request_target:
+    types: [opened, ready_for_review, reopened]
+
+jobs:
+  remove-codeowner-reviews:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Remove CODEOWNERS review requests
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const { owner, repo, number } = context.issue;
+
+            const { data } = await github.rest.pulls.listRequestedReviewers({
+              owner,
+              repo,
+              pull_number: number,
+            });
+
+            const reviewers = data.users.map(u => u.login);
+            const teamReviewers = data.teams.map(t => t.slug);
+
+            if (reviewers.length === 0 && teamReviewers.length === 0) {
+              core.info('No review requests to remove.');
+              return;
+            }
+
+            await github.rest.pulls.removeRequestedReviewers({
+              owner,
+              repo,
+              pull_number: number,
+              reviewers,
+              team_reviewers: teamReviewers,
+            });
+
+            core.info(`Removed reviewers: ${reviewers.concat(teamReviewers).join(', ')}`);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CI and repo governance only; the workflow uses pull_request_target with PR write scope but is gated to dependabot[bot] and only removes review requests.
> 
> **Overview**
> Introduces **path-scoped CODEOWNERS** so `@devbydaniel` is requested on app, infra, and automation paths, while **lockfiles, package manifests, and `dependabot.yml` are listed without owners** so dependency bumps do not auto-request human review.
> 
> **Dependabot** is tightened: lower **open PR caps** (e.g. root 5, backend/frontend 8), **grouped minor/patch** updates for npm (including new `other` groups), Docker, and GitHub Actions, leaving major bumps separate.
> 
> A new **`pull_request_target` workflow** runs for Dependabot PRs and **removes all pending CODEOWNERS review requests** via the GitHub API, so bot PRs stay mergeable without owner gates even when touched paths would normally require review.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 279fe2516ecd2a7ffcf053732e49ea65bad086cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->