### PR TITLE
fix(frontend): send credentials with web manifest fetch to fix 401 (AYC-000)

### DIFF
--- a/ayunis-core-frontend/index.html
+++ b/ayunis-core-frontend/index.html
@@ -18,7 +18,11 @@
       sizes="180x180"
       href="/favicon/apple-touch-icon.png"
     />
-    <link rel="manifest" href="/favicon/site.webmanifest" />
+    <link
+      rel="manifest"
+      href="/favicon/site.webmanifest"
+      crossorigin="use-credentials"
+    />
     <title>Ayunis Core</title>
   </head>
   <body>

--- a/ayunis-core-frontend/public/favicon/site.webmanifest
+++ b/ayunis-core-frontend/public/favicon/site.webmanifest
@@ -1,6 +1,6 @@
 {
-  "name": "MyWebSite",
-  "short_name": "MySite",
+  "name": "Ayunis Core",
+  "short_name": "Ayunis",
   "icons": [
     {
       "src": "/web-app-manifest-192x192.png",


### PR DESCRIPTION
Add crossorigin="use-credentials" to the manifest link tag so Chrome includes credentials when fetching site.webmanifest. Behind nginx Basic Auth (stage) the manifest request was sent without the auth header, producing a 401 "Manifest fetch failed" on every page.

Also replace the placeholder PWA name/short_name (MyWebSite/MySite) with Ayunis Core/Ayunis.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small HTML/manifest metadata changes with no application logic or security model changes beyond correct credential behavior for an existing auth-protected manifest URL.
> 
> **Overview**
> Fixes **manifest fetch failures (401)** on environments protected by nginx Basic Auth (e.g. stage) by adding `crossorigin="use-credentials"` on the manifest `<link>` in `index.html`, so the browser includes credentials when requesting `site.webmanifest`.
> 
> Updates PWA metadata in `site.webmanifest`: **name** and **short_name** change from placeholder `MyWebSite` / `MySite` to **Ayunis Core** / **Ayunis**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4cae045617a2157839145f8d44dd89e10d77b8ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->