### PR TITLE
chore(skills): refresh deployed agent skills from agentfiles store (AYC-000)

### DIFF
--- a/.claude/skills/ayunis-core-backend/SKILL.md
+++ b/.claude/skills/ayunis-core-backend/SKILL.md
@@ -30,6 +30,24 @@ Cross-module communication uses **exported use cases**, not ports/adapters. When
 
 Before modifying any module, read its `SUMMARY.md`. See [ARCHITECTURE.md](../../ARCHITECTURE.md) for the complete module index.
 
+## ConfigService access — match the `registerAs` namespace
+
+Backend config is loaded via `registerAs('<namespace>', () => ({...}))` factories. **The lookup key must be prefixed with the namespace**, or `ConfigService.get(...)` returns `undefined` and the call site silently uses a missing value (e.g. `apiKey: undefined` → 401 at runtime, not at boot).
+
+For model providers, the namespace is `models`:
+
+```typescript
+// CORRECT ✓
+this.configService.get<string>('models.mistral.apiKey')
+this.configService.get<string>('models.openai.apiKey')
+this.configService.get<string>('models.anthropic.apiKey')
+
+// WRONG ✗ — un-namespaced; returns undefined
+this.configService.get<string>('mistral.apiKey')
+```
+
+Before adding a new provider handler, **grep an existing one** for the exact key path rather than transcribing from the `.env` variable name — the env-var → config-key mapping lives in the `registerAs` factory and the namespace is easy to drop on the floor.
+
 ## User Context
 
 User identity comes from `ContextService`, not method parameters:

--- a/.claude/skills/ayunis-core-frontend-dev/SKILL.md
+++ b/.claude/skills/ayunis-core-frontend-dev/SKILL.md
@@ -18,8 +18,8 @@ Before modifying any layer, read its `SUMMARY.md` in `src/[layer]/SUMMARY.md`. T
 ## Validation Sequence
 
 ```bash
-npm run build                  # Must succeed
-npm run lint                   # Must pass
+pnpm run build                 # Must succeed
+pnpm run lint                  # Must pass
 ```
 
 ## Architecture (Feature-Sliced Design)
@@ -55,7 +55,7 @@ Keep `ui/` components focused on component logic. Extract pure functions that do
 After backend API changes, regenerate the client:
 
 ```bash
-npm run openapi:update  # Regenerates src/shared/api/generated/
+pnpm run openapi:update  # Regenerates src/shared/api/generated/
 ```
 
 **Never edit generated code manually** — it will be overwritten.
@@ -68,8 +68,8 @@ For hooks that back a form (create/update dialogs), load the **frontend-form-pat
 
 ## Completion Checklist
 
-- [ ] `npm run build` succeeds
-- [ ] `npm run lint` passes
+- [ ] `pnpm run build` succeeds
+- [ ] `pnpm run lint` passes
 - [ ] Page renders without console errors
 - [ ] No `any` types introduced
 - [ ] Import rules respected (no upward imports)

--- a/.claude/skills/backend-debugging/SKILL.md
+++ b/.claude/skills/backend-debugging/SKILL.md
@@ -73,7 +73,7 @@ A mapper's `instanceof` or `switch` doesn't cover all cases. Check what the data
 ```bash
 # Quick database query through the dev stack:
 cd ayunis-core-backend
-npx ts-node -r tsconfig-paths/register -e "
+pnpm exec ts-node -r tsconfig-paths/register -e "
 import './src/config/env';
 import { DataSource } from 'typeorm';
 // ... query the relevant table
@@ -90,5 +90,5 @@ import { DataSource } from 'typeorm';
 
 ```bash
 cd ayunis-core-backend
-npm run lint && npx tsc --noEmit && npm run test
+pnpm run lint && pnpm exec tsc --noEmit && pnpm run test
 ```

--- a/.claude/skills/dev-environment/SKILL.md
+++ b/.claude/skills/dev-environment/SKILL.md
@@ -73,3 +73,59 @@ If `./dev up` fails, check logs:
 ./dev logs backend
 ./dev logs infra
 ```
+
+### Migration fails with `42P07 duplicate-table` — stale Postgres volume
+
+Slots reuse their Postgres data volume across branches. If a previous branch
+on this slot already ran a migration that creates the same table as the
+current branch's pending migration, `./dev up` fails with:
+
+```text
+error: relation "<table>" already exists (PostgreSQL 42P07)
+```
+
+The volume is stale — it has the table but no record of the migration that
+created it. Resolving it means wiping the slot's Postgres volume so `./dev up`
+replays migrations from scratch.
+
+**Do not run this yourself.** Wiping a volume requires a destructive Docker
+flag (`docker compose down -v`), which is on the Forbidden Actions list in
+`CLAUDE.md` — volumes hold database data that cannot be restored. Instead,
+surface the situation to the user and let them decide. Tell them the slot's
+Postgres volume is stale and that recovering it requires:
+
+```bash
+# Run by the user — destroys the slot's Postgres data
+docker compose -p ayunis-dev-<SLOT> down -v
+./dev up --slot <SLOT>
+```
+
+Slots are per-developer scratch state (not shared), so this is normally safe —
+but it is the user's call, not the agent's.
+
+### `./dev up` silently skips frontend — cross-worktree slot squat
+
+When two worktrees both think they own the same slot (e.g. both ran
+`./dev up --slot 2` at different times), the frontend port can end up held by
+a `vite`/`node` process from worktree A while you `./dev up` in worktree B.
+`./dev up` sees the port is bound, assumes the frontend is already running,
+and **silently skips frontend startup**. The backend comes up fresh against
+your branch's code, but the frontend serves worktree A's old code — confusing
+because `./dev status` looks healthy.
+
+Diagnose:
+
+```bash
+# Which process is on this slot's frontend port? (3021 = slot 2, 3031 = slot 3, ...)
+lsof -nP -iTCP:3021 -sTCP:LISTEN
+
+# Inspect that process's cwd — if it points to a different worktree, that's the squatter
+lsof -p <PID> | grep cwd
+```
+
+Fix: the squatter process must be stopped before `./dev up --slot <SLOT>` will
+start the frontend. **Do not kill it yourself** — killing processes is on the
+Forbidden Actions list in `CLAUDE.md` (a process that looks like a stray `vite`
+may be tied to infrastructure you don't understand). Report the offending PID
+and its worktree cwd to the user and let them stop it. If you want to keep both
+worktrees running, give them different slots instead.

--- a/.claude/skills/feature-toggles/SKILL.md
+++ b/.claude/skills/feature-toggles/SKILL.md
@@ -21,11 +21,11 @@ description: Add, modify, or remove feature toggles. Use when gating new feature
 2. Add property to `FeatureTogglesResponseDto` with `@ApiProperty`.
 3. Return it in `AppController.featureToggles()`.
 4. Apply `@RequireFeature(FeatureFlag.Xxx)` to the controller(s). Controller-level = gates all routes. The decorator composes `UseGuards` internally — do not add `@UseGuards(FeatureGuard)` separately.
-5. Run guard tests: `npm run test -- --testPathPattern=feature.guard`
+5. Run guard tests: `pnpm run test -- --testPathPattern=feature.guard`
 
 ### Frontend
 
-1. Regenerate API client: `VITE_API_BASE_URL=http://localhost:<backend-port>/api npm run openapi:update` from `ayunis-core-frontend/`.
+1. Regenerate API client: `VITE_API_BASE_URL=http://localhost:<backend-port>/api pnpm run openapi:update` from `ayunis-core-frontend/`.
 1. Add convenience hook in `useIsFeatureEnabled.ts` (follow `useIsSkillsEnabled` pattern).
 1. Gate sidebar item in `AppSidebar.tsx` — add to the conditional spread pattern.
 1. Gate route loaders — `throw redirect({ to: '/chat' })` when disabled (see `skills.index.tsx`).

--- a/.claude/skills/fix-schema-drift/SKILL.md
+++ b/.claude/skills/fix-schema-drift/SKILL.md
@@ -13,14 +13,14 @@ The dev stack must be running (`./dev status`). Start with `./dev up` if needed.
 
 ```bash
 cd ayunis-core-frontend
-npm run openapi:update
+pnpm run openapi:update
 ```
 
 Then stage and commit the changed files with `gt modify` or `gt create`.
 
 ## Notes
 
-- Never hand-edit generated files — always regenerate via `npm run openapi:update`
-- `npm run openapi:update` runs `openapi:fetch` → `openapi:format` → `openapi:generate`. The format step (`prettier --write`) is required: `fetch-openapi-schema.js` writes via `JSON.stringify(_, null, 2)`, which puts every short array on multiple lines, but the canonical on-disk format is prettier's compact-when-fits style. Without the format step, schema regens produce ~2000 lines of whitespace-only churn.
-- If you ever need to format the schema by itself: `npm run openapi:format`
+- Never hand-edit generated files — always regenerate via `pnpm run openapi:update`
+- `pnpm run openapi:update` runs `openapi:fetch` → `openapi:format` → `openapi:generate`. The format step (`prettier --write`) is required: `fetch-openapi-schema.js` writes via `JSON.stringify(_, null, 2)`, which puts every short array on multiple lines, but the canonical on-disk format is prettier's compact-when-fits style. Without the format step, schema regens produce ~2000 lines of whitespace-only churn.
+- If you ever need to format the schema by itself: `pnpm run openapi:format`
 - Formatting-only changes are normal — still commit them to keep CI green

--- a/.claude/skills/fix-sentry-issues/SKILL.md
+++ b/.claude/skills/fix-sentry-issues/SKILL.md
@@ -68,10 +68,10 @@ Before reporting done:
 
 ```bash
 # Backend
-cd ayunis-core-backend && npm run lint && npx tsc --noEmit && npm run test
+cd ayunis-core-backend && pnpm run lint && pnpm exec tsc --noEmit && pnpm run test
 
 # Frontend
-cd ayunis-core-frontend && npm run lint && npx tsc --noEmit
+cd ayunis-core-frontend && pnpm run lint && pnpm exec tsc --noEmit
 ```
 
 If you can reproduce the bug locally (e.g. via curl for backend or the browser for frontend), confirm it no longer fires.

--- a/.claude/skills/git-workflow/SKILL.md
+++ b/.claude/skills/git-workflow/SKILL.md
@@ -119,12 +119,98 @@ gt modify
 
 **Always push the full stack** — never push a single branch. Pushing only one branch after a restack or amend leaves descendant branches' remote refs stale (old SHAs), which causes duplicate-commit merge conflicts the next time someone restacks a child branch.
 
+#### Before force-pushing: check for remote-only commits
+
+`--force` will overwrite remote commits that aren't in your local branch — most commonly commits authored by Cursor agents, CI bots, or teammates after you last pulled. Always reconcile first:
+
 ```bash
-# Always use --stack to push all branches in the stack
+# 1. Fetch latest remote state for all stack branches
+git fetch origin
+
+# 2. For EVERY branch in the stack — including ones you didn't touch this session
+gt log short                                  # show the stack
+git log --oneline HEAD..origin/<branch>       # commits on remote that aren't local
+```
+
+**Check every branch `gt log short` shows, not just the ones you edited.** Cursor Agent autofixes, CI commits, and teammate pushes routinely land on the lower (scaffold/base) branches of a stack you've been working in. `gt submit --stack --force --no-interactive` will silently overwrite those without prompting; the "remote updated" warning is informational, not a halt under `--no-interactive`. Skipping the sync check on "untouched" branches has overwritten work multiple times.
+
+If `git log --oneline HEAD..origin/<branch>` shows any commits, **stop and reconcile** before pushing — typically by `git pull --rebase` or `gt restack` to fold those commits in. Never use `--force` to discard them silently.
+
+#### During the push: read Graphite's warnings
+
+Graphite prints `WARNING: Branch X has been updated remotely. Force submitting local version to remote...` when `--force` is about to overwrite remote commits. **Treat this warning as a halt condition** — abort the submit (Ctrl-C while it's iterating, or skip with `--no-interactive` only after you've verified there are no remote-only commits), pull the missing commits, then retry.
+
+```bash
+# Submit the full stack — but only after the pre-flight check above
 gt submit --stack --force --no-interactive
 ```
 
-Use `--force` to ensure remote refs are updated even if Graphite thinks they're current. Add `--publish` to take PRs out of draft.
+Use `--force` to update stale remote refs after a restack or amend. Add `--publish` to take PRs out of draft.
+
+### Verifying stack state after restack / submit
+
+Graphite operations can no-op silently (`gt restack` on a stack that's already up to date, or after a checkout to the wrong branch). Don't claim "done" until you've checked:
+
+```bash
+gt log short                       # current stack and which branch is checked out
+git branch --show-current          # confirm you're not on main
+git status                         # confirm working tree is clean
+```
+
+If `gt restack` produced no visible output, that often means the stack was already restacked or you're not on a stacked branch. Re-check `gt log short` before reporting success.
+
+### Restack before submit
+
+`gt modify` automatically restacks descendants **only when those descendants are checked out in the same worktree**. If `gt submit --stack` aborts with `WARNING: You must restack before submitting this stack. ERROR: Aborting non-interactive submit.`, run `gt restack` first, then re-run the submit:
+
+```bash
+gt restack
+gt submit --stack --force --no-interactive
+```
+
+### Worktree + stack collisions
+
+When a descendant branch is checked out in another worktree, both `gt modify` and `gt restack` skip it with a message like:
+
+```text
+Did not restack branch <name> because it is checked out in worktree <path>.
+```
+
+`gt submit --stack` will then abort with the "must restack" error and looping won't fix it — the descendant *cannot* be restacked from here. Two valid recoveries:
+
+1. **`cd` into the blocking worktree** and restack + submit from there:
+
+   ```bash
+   gt submit --cwd <blocking-worktree-path> --no-stack --force --no-interactive
+   # or, equivalently, after cd-ing in:
+   cd <blocking-worktree-path>
+   gt restack && gt submit --stack --force --no-interactive
+   ```
+
+2. **Single-branch submit here, follow-up in the other worktree.** Submit only the amended branch from the current worktree, then leave the user a clear instruction to restack the descendant from its own worktree:
+
+   ```bash
+   gt submit --force --no-interactive   # pushes only the current branch
+   ```
+
+   Tell the user: *"<descendant-branch> is restacked locally but not pushed — run `gt restack && gt submit --stack --force` from its worktree at `<path>`."*
+
+This is the only situation where `gt submit` without `--stack` is acceptable. Outside this case, the "always push the full stack" rule stands.
+
+### Force-submit safety
+
+If `gt submit --stack --force` prints `WARNING: Branch <name> has been updated remotely. Force submitting local version to remote...`, **do not silently proceed**. The remote has commits that the local branch is about to overwrite. Stop and reconcile:
+
+```bash
+git fetch
+git log HEAD..origin/<branch>          # show what would be overwritten
+```
+
+Surface the divergence to the user (paste the log) and confirm before re-running the force submit. If the SHAs are actually equivalent (only metadata drift), say so and proceed; otherwise rebase locally first.
+
+### Pre-submit hygiene
+
+Before `gt modify` or `gt submit`, run `git status --short` and review the working tree. If files you didn't touch in this session are modified (formatter passes, removed `eslint-disable` comments, watcher artifacts, etc.), surface them to the user explicitly before staging — do not silently bundle them into the commit. Either `git restore` the unrelated files or get explicit confirmation that they belong in the commit.
 
 ### Rules
 
@@ -133,6 +219,8 @@ Use `--force` to ensure remote refs are updated even if Graphite thinks they're 
 - Never use `--no-verify` — let the hooks run
 - Never use raw `git commit` — always go through `gt`
 - Never use raw `git push` — always go through `gt submit`
+- Before `--force`-submitting, `git fetch origin` and check for remote-only commits per branch
+- After `gt restack` / `gt submit`, verify the stack state (`gt log short`) before reporting success
 
 ## Pre-commit Hooks
 

--- a/.claude/skills/linear-implement/SKILL.md
+++ b/.claude/skills/linear-implement/SKILL.md
@@ -35,9 +35,18 @@ Parse out:
 
 If anything material is unclear or the premise looks off, stop and ask Daniel before starting. Don't invent scope.
 
-### 3. Mark In Progress
+### 3. Mark started
+
+Move the ticket to the team's "started" state. **The state name is not the same
+across teams** — see the per-team state-names table in the `manage-linear` skill
+and use the team's actual started-state name. For AYC tickets this is
+`"In Development"`, not `"In Progress"`:
 
 ```bash
+# AYC ticket
+linear issue update <ID> --state "In Development"
+
+# Other teams (default until proven otherwise)
 linear issue update <ID> --state "In Progress"
 ```
 
@@ -95,7 +104,12 @@ If validation passes, no blockers remain, and Daniel is satisfied with the summa
 linear issue update <ID> --state "Done"
 ```
 
-If a blocker follow-up was created, leave the ticket In Progress and call that out instead.
+(`Done` is the standard closed-state name and currently shared across the AYC
+team — check `manage-linear`'s per-team state-names table if working in a team
+that diverges.)
+
+If a blocker follow-up was created, leave the ticket in the started state and
+call that out instead.
 
 ## Rules
 

--- a/.claude/skills/manage-linear/SKILL.md
+++ b/.claude/skills/manage-linear/SKILL.md
@@ -20,13 +20,38 @@ Run `linear --help` or `linear <command> --help` for full option details — don
 - **List issues:** `linear issue list --team <KEY> --sort priority [--limit N]`
 - **List all states:** add `--all-states` (default: unstarted only)
 - **Filter by state:** `--state started`, `--state backlog`, etc.
-- **All assignees:** `--all-assignees` (default: your issues only)
+- **Other people's issues (was `--all-assignees` on `issue list`):** the flag was removed from `issue list` and moved to a separate `issue query` subcommand:
+
+  ```bash
+  linear issue query --team <KEY> --all-assignees --all-states --sort manual
+  ```
+
+  Running `linear issue list --all-assignees` now errors out with: `--all-assignees has been removed from 'issue mine'. Use 'linear issue query --all-assignees' for assignee filtering`.
 - **Create issue:** `linear issue create --team <KEY> --title "..." [--description "..." | --description-file path] [--assignee self] [--priority 1-4] [--label "..."] [--project "..."] [--state "..."]`
 - **View issue:** `linear issue view <ID> [--json]`
 - **Update issue:** `linear issue update <ID> [--state "..." | --title "..." | --assignee "..." | --priority N | --label "..." | ...]`
 - **Delete issue:** `linear issue delete <ID>`
 - **Comments:** `linear issue comment add <ID>`, `linear issue comment list <ID>`
 - **Relations:** `linear issue relation add <ID> <type> <relatedID>`
+
+### Gotchas
+
+- **`--project` on `issue create` rejects UUIDs.** Pass the project name or slug:
+
+  ```bash
+  linear issue create --team AYC --project "Workspaces" --title "..."   # works
+  linear issue create --team AYC --project fb01ed91-... --title "..."   # → "Project not found"
+  ```
+
+  UUIDs *do* work on `project view` / `project update`, just not on `issue create`. Look up the slug via `linear project list --json` when uncertain.
+- **`linear issue view` does not list sub-issues.** To enumerate children of a parent, use the raw GraphQL fallback:
+
+  ```bash
+  linear api 'query($id: String!){ issue(id:$id){ children{ nodes{ identifier title state{ name } } } } }' \
+    --variable id=<PARENT_ID>
+  ```
+
+- **Newly created issues may not be queryable immediately.** If `linear issue view <ID>` right after `issue create` fails with "Could not find referenced Issue", wait a second and retry — trust the URL printed by `create`.
 
 ### Teams
 
@@ -67,6 +92,26 @@ For anything the CLI doesn't cover: `linear api '<query>' [--variable key=value]
 | MGM  | Management  |
 | SAL  | Sales       |
 
+### Per-team state names
+
+State names are NOT uniform across teams. **Do not hardcode `"In Progress"` or
+`"Done"`** — look up the team's actual state before updating. Confirmed
+divergences:
+
+| Team | Started state    | Closed state |
+|------|------------------|--------------|
+| AYC  | `In Development` | `Done`       |
+
+(Other teams default to the standard `In Progress` / `Done` until a divergence is
+observed and added here.)
+
+To enumerate any team's states yourself:
+
+```bash
+linear api 'query($key: String!){ team(id: $key){ states { nodes { name type } } } }' \
+  --variable key=<TEAM_KEY>
+```
+
 ## Guidelines
 
 - **Always use `--no-interactive`** on `issue create` when running non-interactively (avoids prompts).
@@ -74,3 +119,4 @@ For anything the CLI doesn't cover: `linear api '<query>' [--variable key=value]
 - **Issue IDs** look like `AYC-4` (team key + number).
 - **Ask before creating/updating/deleting** — treat writes with care.
 - **Subtasks** should always be created with `--state Backlog`, not `Triage` — the parent has already been triaged.
+- **Create sub-issues upfront when a ticket enumerates iterations.** If the parent ticket spells out "iter 1 / iter 2 / iter 3" or numbered phases, propose creating one sub-issue per iteration during planning, *before* implementation starts. Update each sub-issue's state as work progresses (`In Progress` → `Done`) rather than reconstructing the mapping after the fact.

--- a/.claude/skills/nestjs-hexagonal-backend/SKILL.md
+++ b/.claude/skills/nestjs-hexagonal-backend/SKILL.md
@@ -19,9 +19,11 @@ Every change follows red-green TDD. Do NOT write production code without a faili
 
 ```bash
 # During each cycle:
-npm run test -- --testPathPattern=<module>   # Run focused tests (red → green)
-npm run lint && npx tsc --noEmit && npm run test  # Full validation (refactor step)
+pnpm run test -- --testPathPatterns=<module>  # Run focused tests (red → green)
+pnpm exec eslint <touched-files> && pnpm exec tsc --noEmit && pnpm run test  # Full validation (refactor step)
 ```
+
+> The Jest flag is `--testPathPatterns` (plural). The singular `--testPathPattern` was removed and now errors out: `Option testPathPattern was replaced by --testPathPatterns`.
 
 ### What Makes a Meaningful Test
 
@@ -57,9 +59,17 @@ it("should work", async () => {
 ## Validation Sequence
 
 ```bash
-npm run lint                    # Must pass
-npx tsc --noEmit               # 0 type errors
-npm run test                   # All tests pass
+pnpm exec eslint <touched-files>     # Lint without rewriting unrelated files
+pnpm exec tsc --noEmit               # 0 type errors
+pnpm run test                        # All tests pass
+```
+
+> ⚠ **`pnpm run lint` is wired with `--fix`** in `ayunis-core-backend/package.json` — running it as a verification step will auto-rewrite unrelated files (migrations, fixtures, entities) and leave them in the working tree. Prefer `pnpm exec eslint <paths>` for verification. If you do run `pnpm run lint`, immediately check `git status --short` and `git restore` any files outside your change set.
+
+For an architecture cross-check before declaring done (catches the no-cross-module-port-imports / no-domain-imports-presenters rules that the pre-commit hook enforces), also run dep-cruiser:
+
+```bash
+pnpm exec depcruise src        # or whatever the project's depcheck script is
 ```
 
 ## Backend-Specific TypeScript Rules
@@ -70,9 +80,11 @@ npm run test                   # All tests pass
 
 ## Module Structure (Hexagonal)
 
+Every domain module ships a `SUMMARY.md`. Read it first when editing an existing module, and **create one when you scaffold a new module** — don't submit a PR for a new module without it. The repo convention is uniform: ~96% of existing modules have one, and Bugbot will flag any new module that lands without it.
+
 ```text
 [module]/
-├── SUMMARY.md           # ← Read this first
+├── SUMMARY.md           # ← Read this first; required for every module
 ├── domain/              # Pure entities, no decorators
 ├── application/
 │   ├── use-cases/       # Business operations
@@ -118,12 +130,15 @@ For schema changes, use the `typeorm-migrations` skill. Never write migrations b
 
 ## Completion Checklist
 
-- [ ] `npm run lint` passes
-- [ ] `npx tsc --noEmit` shows 0 errors
-- [ ] `npm run test` all pass
+- [ ] `pnpm exec eslint <touched-files>` passes (avoid `pnpm run lint` — it's wired with `--fix`)
+- [ ] `pnpm exec tsc --noEmit` shows 0 errors
+- [ ] `pnpm run test` all pass
+- [ ] `pnpm exec depcruise src` reports no new violations (catches cross-module port/presenter imports the pre-commit hook will reject)
+- [ ] `git status --short` shows only files you intended to change
 - [ ] No `any` types introduced
 - [ ] DTOs have validation decorators
 - [ ] New entities have proper mappers
+- [ ] New module has a `SUMMARY.md` at its root (the repo convention; missing files are flagged by Bugbot)
 
 ## Anti-Patterns
 

--- a/.claude/skills/new-page/SKILL.md
+++ b/.claude/skills/new-page/SKILL.md
@@ -283,7 +283,7 @@ A page **cannot** import from:
 3. **Regenerate route tree**:
 
    ```bash
-   npx tsr generate
+   pnpm exec tsr generate
    ```
 
    This updates `src/app/routeTree.gen.ts` automatically.
@@ -291,9 +291,9 @@ A page **cannot** import from:
 4. **Validate**:
 
    ```bash
-   npm run lint
-   npx tsc --noEmit
-   npm run build
+   pnpm run lint
+   pnpm exec tsc --noEmit
+   pnpm run build
    ```
 
 5. **Visual check**: Navigate to the new route in the browser and verify it renders.

--- a/.claude/skills/rebase/SKILL.md
+++ b/.claude/skills/rebase/SKILL.md
@@ -96,9 +96,9 @@ If more conflicts arise on the next commit, repeat from step 1.
 Don't manually resolve. Accept either side and regenerate:
 
 ```bash
-git checkout --theirs package-lock.json
-npm install
-git add package-lock.json
+git checkout --theirs pnpm-lock.yaml   # or package-lock.json for npm repos
+pnpm install                           # use the repo's package manager: pnpm for ayunis-core, npm otherwise
+git add pnpm-lock.yaml
 ```
 
 ### Auto-generated files (migrations, GraphQL schema)

--- a/.claude/skills/seed-database/SKILL.md
+++ b/.claude/skills/seed-database/SKILL.md
@@ -13,8 +13,8 @@ Run from `ayunis-core-backend/`:
 
 | Command | Description |
 |---|---|
-| `npm run seed:minimal:ts` | Upsert fixture data (idempotent — skips existing rows) |
-| `npm run seed:clean:ts` | Truncate all tables first, then seed |
+| `pnpm run seed:minimal:ts` | Upsert fixture data (idempotent — skips existing rows) |
+| `pnpm run seed:clean:ts` | Truncate all tables first, then seed |
 
 The `:ts` variants run from source; the non-`:ts` variants run from `dist/` (requires a build).
 

--- a/.claude/skills/typeorm-migrations/SKILL.md
+++ b/.claude/skills/typeorm-migrations/SKILL.md
@@ -71,7 +71,7 @@ export class AgentRecord extends BaseRecord {
 The dev stack must be running (`./dev status`).
 
 ```bash
-npm run migration:generate:dev -- src/db/migrations/DescriptiveMigrationName
+pnpm run migration:generate:dev -- src/db/migrations/DescriptiveMigrationName
 ```
 
 ### 3. Review the Generated Migration
@@ -85,13 +85,13 @@ If the migration contains unexpected drift, the local DB may be out of sync. Rec
 ### 4. Run the Migration
 
 ```bash
-npm run migration:run:dev
+pnpm run migration:run:dev
 ```
 
 ### 5. Verify Zero Drift
 
 ```bash
-npm run migration:generate:dev -- src/db/migrations/VerifyNoDrift
+pnpm run migration:generate:dev -- src/db/migrations/VerifyNoDrift
 ```
 
 This **must** print `No changes in database schema were found`. If it generates a file, entities and migrations are still out of sync — investigate before committing.
@@ -99,8 +99,8 @@ This **must** print `No changes in database schema were found`. If it generates 
 ### 6. Validate
 
 ```bash
-npx tsc --noEmit
-npm run test
+pnpm exec tsc --noEmit
+pnpm run test
 ```
 
 ## Naming Convention

--- a/.claude/skills/worktree/SKILL.md
+++ b/.claude/skills/worktree/SKILL.md
@@ -24,14 +24,50 @@ git worktree add "$WORKTREE_DIR" -b "feat/${TASK_ID,,}/work" HEAD
 # OR existing branch:
 git worktree add "$WORKTREE_DIR" "$BRANCH"
 
+# Track the new branch in Graphite — REQUIRED before any `gt create`.
+# `git worktree add -b` produces a branch Graphite doesn't know about, so the
+# first `gt create` fails with "Cannot perform this operation on untracked
+# branch". Track it as a child of main:
+cd "$WORKTREE_DIR" && gt track --parent main
+
 # Symlink secret .env files (gitignored, not in the new worktree)
 ln -sf "$REPO_ROOT/ayunis-core-backend/.env" "$WORKTREE_DIR/ayunis-core-backend/.env"
 ln -sf "$REPO_ROOT/ayunis-core-frontend/.env" "$WORKTREE_DIR/ayunis-core-frontend/.env"
 
-# Install dependencies
-cd "$WORKTREE_DIR/ayunis-core-backend" && npm install
-cd "$WORKTREE_DIR/ayunis-core-frontend" && npm install
+# Install dependencies — ayunis-core is a pnpm workspace
+# (pnpm-workspace.yaml + pnpm-lock.yaml at repo root, packageManager pinned to pnpm).
+# Never `npm install` inside a sub-project — that creates a stray package-lock.json
+# and resolves the wrong tree.
+cd "$WORKTREE_DIR" && pnpm install
 ```
+
+## Empty Base Branch Gotcha
+
+The worktree branch `feat/<task>/work` is the **base** — Graphite stacks are
+built on top of it (see the `git-workflow` skill). Following git-workflow,
+the first commit goes on a `gt create` child branch, leaving the worktree
+base intentionally empty.
+
+That's fine until you push. `gt submit --stack` refuses to submit an empty
+base branch:
+
+```text
+WARNING: This branch does not introduce any changes: ▸ feat/<task>/work
+Nothing to submit!
+```
+
+Fix: re-parent the child directly onto `main` so the empty base drops out
+of the stack:
+
+```bash
+gt track --parent main --force   # run on the CHILD branch, not the base
+gt submit --stack --force --no-interactive
+```
+
+Alternative (single-PR tasks): skip the `gt create` and commit on the
+worktree base branch directly with `gt modify --commit` so the base
+isn't empty in the first place. Prefer this when the task is a single
+self-contained change, not a stack.
 
 ## Scenario C — Use an existing worktree
 

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ AGENTS.md
 .agentfiles.lock
 .claude/worktrees/
 .claude/**/*.local.*
+.claude/scheduled_tasks.lock


### PR DESCRIPTION
Sync the checked-in .claude/skills copies to the agentfiles store source:

- npm -> pnpm across all validation/command snippets (pnpm workspace)
- git-workflow: Graphite force-submit safety, remote-only-commit pre-flight, restack-before-submit, worktree+stack collision recovery, pre-submit hygiene
- manage-linear/linear-implement: Linear CLI drift (issue query, project slug not UUID, per-team states; AYC started state is In Development)
- nestjs-hexagonal-backend/ayunis-core-backend: --testPathPatterns, eslint via pnpm exec, depcruise check, SUMMARY.md required, ConfigService namespace gotcha
- dev-environment: hand destructive docker -v / kill steps to the user per Forbidden Actions instead of running them
- .gitignore: ignore .claude/scheduled_tasks.lock

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and ignore-file only; no application runtime or CI behavior changes. Wrong agent guidance could still cause mistaken commands locally, but merge risk to production code is negligible.
> 
> **Overview**
> Syncs checked-in **`.claude/skills`** with the agentfiles store so agents follow current repo tooling and safer workflows.
> 
> **Command snippets** across skills move from **`npm`** to **`pnpm`** (root workspace install, lint/build/test, migrations, seeds, OpenAPI regen). Backend guidance adds **`pnpm exec eslint`** / **`tsc`** instead of **`pnpm run lint`** where lint is **`--fix`**, Jest **`--testPathPatterns`**, and **`depcruise`** in the completion checklist. **`ayunis-core-backend`** documents the **`ConfigService`** **`registerAs`** namespace prefix (e.g. **`models.*.apiKey`**) to avoid silent undefined config.
> 
> **`git-workflow`** and **`worktree`** expand Graphite safety: pre-flight for remote-only commits before **`--force`** submit, restack-before-submit, worktree/stack collision recovery, pre-submit hygiene, **`gt track --parent main`** after new worktrees, and handling empty worktree base branches on submit.
> 
> **Linear skills** reflect CLI drift (**`issue query --all-assignees`**, project slug on create, GraphQL for sub-issues) and **per-team workflow states** (AYC started = **`In Development`**).
> 
> **`dev-environment`** adds troubleshooting for stale Postgres volumes (**`42P07`**) and cross-worktree frontend port squatting, with destructive **`docker compose down -v`** / process kills delegated to the user per forbidden actions.
> 
> **`.gitignore`** adds **`.claude/scheduled_tasks.lock`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30427c6e52ad91574d9934194aa05a04d0aed04c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->