### PR TITLE
fix(provider-openai): stop draining stream after finish + usage (AYC-000)

### DIFF
--- a/packages/provider-openai/src/openai-provider.spec.ts
+++ b/packages/provider-openai/src/openai-provider.spec.ts
@@ -1,6 +1,45 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { ProviderChunk, ProviderRequest } from '@ayunis/inference';
 
 import { azure, openai } from './openai-provider';
+
+const { createMock } = vi.hoisted(() => ({ createMock: vi.fn() }));
+
+vi.mock('openai', () => {
+  class FakeOpenAI {
+    chat = { completions: { create: createMock } };
+  }
+  return { default: FakeOpenAI, OpenAI: FakeOpenAI, AzureOpenAI: FakeOpenAI };
+});
+
+/**
+ * Builds a fake OpenAI stream that records how many chunks the consumer
+ * pulled, so a test can assert the loop stopped early instead of draining.
+ */
+function fakeStream(chunks: unknown[], onPull: () => void) {
+  let i = 0;
+  return {
+    [Symbol.asyncIterator]() {
+      return {
+        next() {
+          onPull();
+          if (i >= chunks.length) {
+            return Promise.resolve({ done: true, value: undefined });
+          }
+          return Promise.resolve({ done: false, value: chunks[i++] });
+        },
+        return() {
+          return Promise.resolve({ done: true, value: undefined });
+        },
+      };
+    },
+  };
+}
+
+function makeRequest(): ProviderRequest {
+  return { instructions: '', messages: [], tools: [] };
+}
 
 describe('openai', () => {
   it('names the provider openai:<model> and exposes a stream function', () => {
@@ -29,5 +68,100 @@ describe('azure', () => {
     });
     expect(provider.name).toBe('azure:gpt-4o-deployment');
     expect(typeof provider.stream).toBe('function');
+  });
+});
+
+describe('streamChat', () => {
+  it('stops reading after finish_reason + usage and never consumes the trailing terminator', async () => {
+    const content = {
+      choices: [{ index: 0, delta: { content: 'hi' }, finish_reason: null }],
+    };
+    const finish = {
+      choices: [{ index: 0, delta: {}, finish_reason: 'stop' }],
+    };
+    const usage = {
+      choices: [],
+      usage: { prompt_tokens: 10, completion_tokens: 5 },
+    };
+    // A trailing chunk that, if consumed, would leak into the output. It must
+    // never be read — the loop should exit after the usage chunk above.
+    const leak = {
+      choices: [{ index: 0, delta: { content: 'LEAK' }, finish_reason: null }],
+    };
+
+    let pulls = 0;
+    createMock.mockReturnValue(
+      fakeStream([content, finish, usage, leak], () => {
+        pulls++;
+      }),
+    );
+
+    const provider = openai({ apiKey: 'sk-test', model: 'gpt-5' });
+    const out: ProviderChunk[] = [];
+    for await (const chunk of provider.stream(makeRequest())) {
+      out.push(chunk);
+    }
+
+    expect(out).toEqual([
+      { textDelta: 'hi' },
+      { finishReason: 'stop' },
+      { usage: { inputTokens: 10, outputTokens: 5 } },
+    ]);
+    expect(out.some((c) => c.textDelta === 'LEAK')).toBe(false);
+    // content + finish + usage = 3 pulls; the trailing terminator is never read.
+    expect(pulls).toBe(3);
+  });
+
+  it('exits early even when the finish reason maps to null (unrecognized reason)', async () => {
+    const content = {
+      choices: [{ index: 0, delta: { content: 'hi' }, finish_reason: null }],
+    };
+    // convertChunk maps an unrecognized finish_reason to finishReason: null.
+    // The early exit must still fire — it keys off the raw chunk, not the map.
+    const finish = {
+      choices: [{ index: 0, delta: {}, finish_reason: 'some_future_reason' }],
+    };
+    const usage = {
+      choices: [],
+      usage: { prompt_tokens: 1, completion_tokens: 1 },
+    };
+    const leak = {
+      choices: [{ index: 0, delta: { content: 'LEAK' }, finish_reason: null }],
+    };
+
+    let pulls = 0;
+    createMock.mockReturnValue(
+      fakeStream([content, finish, usage, leak], () => {
+        pulls++;
+      }),
+    );
+
+    const provider = openai({ apiKey: 'sk-test', model: 'gpt-5' });
+    const out: ProviderChunk[] = [];
+    for await (const chunk of provider.stream(makeRequest())) {
+      out.push(chunk);
+    }
+
+    expect(out.some((c) => c.textDelta === 'LEAK')).toBe(false);
+    expect(pulls).toBe(3);
+  });
+
+  it('drains the full stream when usage never arrives', async () => {
+    const content = {
+      choices: [{ index: 0, delta: { content: 'hi' }, finish_reason: null }],
+    };
+    const finish = {
+      choices: [{ index: 0, delta: {}, finish_reason: 'stop' }],
+    };
+
+    createMock.mockReturnValue(fakeStream([content, finish], () => {}));
+
+    const provider = openai({ apiKey: 'sk-test', model: 'gpt-5' });
+    const out: ProviderChunk[] = [];
+    for await (const chunk of provider.stream(makeRequest())) {
+      out.push(chunk);
+    }
+
+    expect(out).toEqual([{ textDelta: 'hi' }, { finishReason: 'stop' }]);
   });
 });

--- a/packages/provider-openai/src/openai-provider.ts
+++ b/packages/provider-openai/src/openai-provider.ts
@@ -87,11 +87,24 @@ async function* streamChat(
     params,
     request.signal ? { signal: request.signal } : undefined,
   );
+  // With stream_options.include_usage the wire order is:
+  //   content… → finish_reason chunk → usage chunk → [DONE] → connection close.
+  // Once we have both the finish reason and the usage, the caller has
+  // everything it needs. Stop here instead of draining to [DONE]: reading
+  // through the connection teardown is what some egress proxies cut or
+  // idle-time-out, which the OpenAI SDK surfaces as a spurious
+  // APIConnectionError *after* an otherwise complete response. Breaking early
+  // closes the stream from our side and avoids that tail entirely.
+  let sawFinishReason = false;
   for await (const chunk of stream) {
+    // Track the finish from the *raw* chunk, not the mapped ProviderChunk:
+    // convertChunk maps unrecognized finish reasons to `null`, so keying off
+    // the mapped value would miss a genuine finish and never break.
+    if (chunk.choices.at(0)?.finish_reason) sawFinishReason = true;
     const converted = convertChunk(chunk);
-    if (converted) {
-      yield converted;
-    }
+    if (!converted) continue;
+    yield converted;
+    if (sawFinishReason && converted.usage) break;
   }
 }
 


### PR DESCRIPTION
The Chat Completions stream loop drained to [DONE], reading through the
connection teardown. Some prod egress proxies cut or idle-time-out that
tail, which the OpenAI SDK surfaces as a spurious APIConnectionError
*after* a complete response — producing an error modal despite fully
streamed text. Affected OpenAI + Azure (shared package), not Bedrock.

Restore the pre-refactor early break: once both finish_reason and usage
have arrived, stop iterating and close the stream from our side. Mirrors
the old BaseOpenAIChatStreamInferenceHandler behavior removed in AYC-283.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core inference streaming for OpenAI and Azure; behavior change is intentional but could affect edge cases where usage arrives before finish or never arrives (latter still drains).
> 
> **Overview**
> Fixes spurious **APIConnectionError** modals after successful OpenAI/Azure chat streams by **breaking out of the stream loop** once both **finish_reason** and **usage** have been yielded, instead of reading through `[DONE]` and connection teardown (which some egress proxies truncate).
> 
> **`streamChat`** now tracks finish from the **raw** SSE chunk (not mapped `ProviderChunk`, so unrecognized finish reasons still trigger early exit), skips empty conversions with `continue`, and **`break`s** when `sawFinishReason && converted.usage`. When usage never arrives, behavior is unchanged—the loop still drains to the end.
> 
> Adds **Vitest** coverage with a mocked `openai` client: asserts no trailing chunk is consumed, early exit with unrecognized finish reasons, and full drain without usage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6ddf9b5f826cc24c935297a74a6dfa43bdddba5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->