### PR TITLE
fix(ci): restore staging deploys broken by corepack removal in node:26-alpine (AYC-000)

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -26,8 +26,14 @@ jobs:
             cd /home/ayunis/apps/ayunis-core
             git fetch origin main
             git reset --hard origin/main
-            # Build with cache while old containers still serve traffic
-            docker compose build
+            # Build with cache while old containers still serve traffic. If the
+            # build fails, abort BEFORE touching running containers — otherwise a
+            # broken build would tear down the app and restart the stale image
+            # while the deploy still reports success (see AYC: corepack outage).
+            if ! docker compose build; then
+              echo "::error::docker compose build failed — keeping current containers, not deploying"
+              exit 1
+            fi
             # Quick swap — downtime is only the restart
             docker compose down
             docker compose up -d

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,10 @@
 # ---- Stage 1: Build — install workspace, build FE + BE, create prod bundle ----
 FROM node:26-alpine AS build
 
-# pnpm via corepack (version pinned by root package.json "packageManager")
-RUN corepack enable
+# pnpm via corepack (version pinned by root package.json "packageManager").
+# node:26-alpine no longer bundles corepack, so install it explicitly before
+# enabling. `corepack enable` still honors the root "packageManager" pin.
+RUN npm install -g corepack@latest && corepack enable
 # Native build deps for bcrypt (node-pre-gyp builds from source on musl/alpine)
 RUN apk add --no-cache python3 make g++ gcc
 


### PR DESCRIPTION
node:26-alpine no longer bundles corepack, so the Dockerfile's `RUN corepack enable` failed (exit 127) and the backend image stopped building. The staging deploy then silently restarted the stale image and still reported success, so nothing merged after 2026-06-23 — including the provider-openai streaming fix (#885) — actually shipped.

- Dockerfile: install corepack@latest via npm before enabling it (honors the root packageManager pin)
- deploy-staging.yml: abort before `docker compose down` when the build fails, so a broken build fails the deploy instead of restarting the stale image under a green checkmark

Verified locally: full build stage passes and the built deploy bundle contains the #885 break.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CI/Docker build plumbing; no application runtime or auth/data logic is modified.
> 
> **Overview**
> **Restores image builds** after `node:26-alpine` stopped shipping corepack by running `npm install -g corepack@latest` before `corepack enable`, so pnpm still follows the root `packageManager` pin.
> 
> **Hardens staging deploys** so a failed `docker compose build` exits with an error and leaves running containers untouched, instead of continuing with `down`/`up` and reporting success on a stale image.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c1e3be062d440dcda60a79b9a788a92d59812dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->