### PR TITLE
feat(admin): add admin user CSV export AYC-333

### DIFF
--- a/ayunis-core-backend/src/iam/users/application/ports/admin-users-export.repository.ts
+++ b/ayunis-core-backend/src/iam/users/application/ports/admin-users-export.repository.ts
@@ -1,0 +1,16 @@
+import type { UUID } from 'crypto';
+
+export interface AdminUserExportRow {
+  id: UUID;
+  name: string;
+  email: string;
+  role: string;
+  orgName: string;
+  teams: string | null;
+  subscriptionType: string;
+  subscriptionStartsAt: Date | string;
+}
+
+export abstract class AdminUsersExportRepository {
+  abstract findSubscribedOrgAdmins(): Promise<AdminUserExportRow[]>;
+}

--- a/ayunis-core-backend/src/iam/users/application/use-cases/export-admin-users/export-admin-users.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/export-admin-users/export-admin-users.use-case.spec.ts
@@ -1,0 +1,44 @@
+import { ExportAdminUsersUseCase } from './export-admin-users.use-case';
+import { UserRole } from 'src/iam/users/domain/value-objects/role.object';
+import type { UUID } from 'crypto';
+import type { AdminUsersExportRepository } from '../../ports/admin-users-export.repository';
+
+describe('ExportAdminUsersUseCase', () => {
+  it('should export subscribed organization admins as CSV', async () => {
+    const repository: jest.Mocked<AdminUsersExportRepository> = {
+      findSubscribedOrgAdmins: jest.fn().mockResolvedValue([
+        {
+          id: 'user-1' as UUID,
+          name: 'Ada Lovelace',
+          email: 'ada@example.com',
+          role: UserRole.ADMIN,
+          orgName: 'Ayunis',
+          teams: 'Engineering, Product',
+          subscriptionType: 'SEAT_BASED',
+          subscriptionStartsAt: new Date('2026-07-01T10:30:00.000Z'),
+        },
+        {
+          id: 'user-2' as UUID,
+          name: 'Grace',
+          email: 'grace@example.com',
+          role: UserRole.ADMIN,
+          orgName: 'Future Org',
+          teams: '',
+          subscriptionType: 'USAGE_BASED',
+          subscriptionStartsAt: '2026-09-15T00:00:00.000Z',
+        },
+      ]),
+    };
+
+    const csv = await new ExportAdminUsersUseCase(repository).execute();
+
+    expect(repository.findSubscribedOrgAdmins).toHaveBeenCalledTimes(1);
+    expect(csv).toBe(
+      [
+        '"Eindeutige ID","Vorname","Nachname","E-Mail","Rolle","Organisation","Teams","Abonnement","Abonnement Startdatum"',
+        '"user-1","Ada","Lovelace","ada@example.com","admin","Ayunis","Engineering, Product","SEAT_BASED","2026-07-01"',
+        '"user-2","Grace","","grace@example.com","admin","Future Org","","USAGE_BASED","2026-09-15"',
+      ].join('\n'),
+    );
+  });
+});

--- a/ayunis-core-backend/src/iam/users/application/use-cases/export-admin-users/export-admin-users.use-case.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/export-admin-users/export-admin-users.use-case.ts
@@ -1,0 +1,78 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { convertCSVToString } from 'src/common/util/csv';
+import {
+  AdminUserExportRow,
+  AdminUsersExportRepository,
+} from '../../ports/admin-users-export.repository';
+
+@Injectable()
+export class ExportAdminUsersUseCase {
+  private readonly logger = new Logger(ExportAdminUsersUseCase.name);
+
+  constructor(
+    private readonly adminUsersExportRepository: AdminUsersExportRepository,
+  ) {}
+
+  async execute(): Promise<string> {
+    this.logger.log('Exporting admin users for subscribed organizations');
+
+    const rows =
+      await this.adminUsersExportRepository.findSubscribedOrgAdmins();
+
+    return convertCSVToString({
+      headers: [
+        'Eindeutige ID',
+        'Vorname',
+        'Nachname',
+        'E-Mail',
+        'Rolle',
+        'Organisation',
+        'Teams',
+        'Abonnement',
+        'Abonnement Startdatum',
+      ],
+      rows: rows.map((row) => this.toCsvRow(row)),
+    });
+  }
+
+  private toCsvRow(row: AdminUserExportRow): string[] {
+    const { firstName, lastName } = this.splitName(row.name);
+
+    return [
+      row.id,
+      firstName,
+      lastName,
+      row.email,
+      row.role,
+      row.orgName,
+      row.teams ?? '',
+      row.subscriptionType,
+      this.formatDate(row.subscriptionStartsAt),
+    ];
+  }
+
+  private splitName(name: string): { firstName: string; lastName: string } {
+    const parts = name.trim().split(/\s+/).filter(Boolean);
+
+    if (parts.length === 0) {
+      return { firstName: '', lastName: '' };
+    }
+
+    if (parts.length === 1) {
+      return { firstName: parts[0], lastName: '' };
+    }
+
+    return {
+      firstName: parts.slice(0, -1).join(' '),
+      lastName: parts[parts.length - 1],
+    };
+  }
+
+  private formatDate(date: Date | string): string {
+    if (date instanceof Date) {
+      return date.toISOString().slice(0, 10);
+    }
+
+    return new Date(date).toISOString().slice(0, 10);
+  }
+}

--- a/ayunis-core-backend/src/iam/users/infrastructure/repositories/local/local-admin-users-export.repository.ts
+++ b/ayunis-core-backend/src/iam/users/infrastructure/repositories/local/local-admin-users-export.repository.ts
@@ -1,0 +1,54 @@
+import { Injectable } from '@nestjs/common';
+import { DataSource } from 'typeorm';
+import {
+  AdminUserExportRow,
+  AdminUsersExportRepository,
+} from 'src/iam/users/application/ports/admin-users-export.repository';
+import { OrgRecord } from 'src/iam/orgs/infrastructure/repositories/local/schema/org.record';
+import { SubscriptionRecord } from 'src/iam/subscriptions/infrastructure/persistence/local/schema/subscription.record';
+import { TeamMemberRecord } from 'src/iam/teams/infrastructure/repositories/local/schema/team-member.record';
+import { TeamRecord } from 'src/iam/teams/infrastructure/repositories/local/schema/team.record';
+import { UserRole } from 'src/iam/users/domain/value-objects/role.object';
+import { UserRecord } from './schema/user.record';
+
+@Injectable()
+export class LocalAdminUsersExportRepository implements AdminUsersExportRepository {
+  constructor(private readonly dataSource: DataSource) {}
+
+  findSubscribedOrgAdmins(): Promise<AdminUserExportRow[]> {
+    return this.dataSource
+      .createQueryBuilder()
+      .select('user.id', 'id')
+      .addSelect('user.name', 'name')
+      .addSelect('user.email', 'email')
+      .addSelect('user.role', 'role')
+      .addSelect('org.name', 'orgName')
+      .addSelect('subscription.type', 'subscriptionType')
+      .addSelect('subscription.startsAt', 'subscriptionStartsAt')
+      .addSelect(
+        "COALESCE(STRING_AGG(DISTINCT team.name, ', ' ORDER BY team.name), '')",
+        'teams',
+      )
+      .from(UserRecord, 'user')
+      .innerJoin(OrgRecord, 'org', 'org.id = user.orgId')
+      .innerJoin(
+        SubscriptionRecord,
+        'subscription',
+        'subscription.orgId = user.orgId AND subscription.cancelledAt IS NULL',
+      )
+      .leftJoin(TeamMemberRecord, 'teamMember', 'teamMember.userId = user.id')
+      .leftJoin(TeamRecord, 'team', 'team.id = teamMember.teamId')
+      .where('user.role = :role', { role: UserRole.ADMIN })
+      .groupBy('user.id')
+      .addGroupBy('user.name')
+      .addGroupBy('user.email')
+      .addGroupBy('user.role')
+      .addGroupBy('org.name')
+      .addGroupBy('subscription.type')
+      .addGroupBy('subscription.startsAt')
+      .orderBy('org.name', 'ASC')
+      .addOrderBy('user.name', 'ASC')
+      .addOrderBy('user.email', 'ASC')
+      .getRawMany<AdminUserExportRow>();
+  }
+}

--- a/ayunis-core-backend/src/iam/users/presenters/http/super-admin-user-exports.controller.ts
+++ b/ayunis-core-backend/src/iam/users/presenters/http/super-admin-user-exports.controller.ts
@@ -1,0 +1,65 @@
+import {
+  Controller,
+  Get,
+  Header,
+  HttpCode,
+  HttpStatus,
+  Logger,
+} from '@nestjs/common';
+import {
+  ApiInternalServerErrorResponse,
+  ApiOperation,
+  ApiResponse,
+  ApiTags,
+  ApiUnauthorizedResponse,
+} from '@nestjs/swagger';
+import { SystemRoles } from 'src/iam/authorization/application/decorators/system-roles.decorator';
+import { SystemRole } from 'src/iam/users/domain/value-objects/system-role.enum';
+import { ExportAdminUsersUseCase } from '../../application/use-cases/export-admin-users/export-admin-users.use-case';
+
+@ApiTags('Super Admin Users')
+@Controller('super-admin/users/export')
+@SystemRoles(SystemRole.SUPER_ADMIN)
+export class SuperAdminUserExportsController {
+  private readonly logger = new Logger(SuperAdminUserExportsController.name);
+
+  constructor(
+    private readonly exportAdminUsersUseCase: ExportAdminUsersUseCase,
+  ) {}
+
+  @Get('admins.csv')
+  @HttpCode(HttpStatus.OK)
+  @Header('Content-Type', 'text/csv; charset=utf-8')
+  @Header(
+    'Content-Disposition',
+    'attachment; filename="admin-users-export.csv"',
+  )
+  @ApiOperation({
+    summary: 'Export admin users as CSV',
+    description:
+      'Export all admin users from organizations with a non-cancelled subscription, including subscriptions that start in the future. This endpoint is only accessible to super admins.',
+  })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'CSV export generated successfully',
+    content: {
+      'text/csv': {
+        schema: {
+          type: 'string',
+          format: 'binary',
+        },
+      },
+    },
+  })
+  @ApiUnauthorizedResponse({
+    description: 'User not authenticated or not authorized as super admin',
+  })
+  @ApiInternalServerErrorResponse({
+    description: 'Internal server error occurred while exporting admin users',
+  })
+  async exportAdminUsers(): Promise<string> {
+    this.logger.log('exportAdminUsers');
+
+    return this.exportAdminUsersUseCase.execute();
+  }
+}

--- a/ayunis-core-backend/src/iam/users/users.module.ts
+++ b/ayunis-core-backend/src/iam/users/users.module.ts
@@ -1,6 +1,8 @@
 import { Module } from '@nestjs/common';
 import { UsersRepository } from './application/ports/users.repository';
+import { AdminUsersExportRepository } from './application/ports/admin-users-export.repository';
 import { LocalUsersRepository } from './infrastructure/repositories/local/local-users.repository';
+import { LocalAdminUsersExportRepository } from './infrastructure/repositories/local/local-admin-users-export.repository';
 import { ConfigService, ConfigModule } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { UserRecord } from './infrastructure/repositories/local/schema/user.record';
@@ -51,10 +53,12 @@ import { OrgsModule } from '../orgs/orgs.module';
 import { SendSetInitialPasswordEmailUseCase } from './application/use-cases/send-set-initial-password-email/send-set-initial-password-email.use-case';
 import { TriggerSetInitialPasswordUseCase } from './application/use-cases/trigger-set-initial-password/trigger-set-initial-password.use-case';
 import { SuperAdminUsersController } from './presenters/http/super-admin-users.controller';
+import { SuperAdminUserExportsController } from './presenters/http/super-admin-user-exports.controller';
 import { SuperAdminManagementController } from './presenters/http/super-admin-management.controller';
 import { FindSuperAdminsUseCase } from './application/use-cases/find-super-admins/find-super-admins.use-case';
 import { PromoteToSuperAdminUseCase } from './application/use-cases/promote-to-super-admin/promote-to-super-admin.use-case';
 import { DemoteFromSuperAdminUseCase } from './application/use-cases/demote-from-super-admin/demote-from-super-admin.use-case';
+import { ExportAdminUsersUseCase } from './application/use-cases/export-admin-users/export-admin-users.use-case';
 
 @Module({
   imports: [
@@ -86,6 +90,7 @@ import { DemoteFromSuperAdminUseCase } from './application/use-cases/demote-from
     UserPasswordResetController,
     AdminUserController,
     SuperAdminUsersController,
+    SuperAdminUserExportsController,
     SuperAdminManagementController,
   ],
   providers: [
@@ -96,6 +101,10 @@ import { DemoteFromSuperAdminUseCase } from './application/use-cases/demote-from
         return new LocalUsersRepository(userRepository);
       },
       inject: [getRepositoryToken(UserRecord)],
+    },
+    {
+      provide: AdminUsersExportRepository,
+      useClass: LocalAdminUsersExportRepository,
     },
     // Use cases
     FindUserByIdUseCase,
@@ -128,6 +137,7 @@ import { DemoteFromSuperAdminUseCase } from './application/use-cases/demote-from
     FindSuperAdminsUseCase,
     PromoteToSuperAdminUseCase,
     DemoteFromSuperAdminUseCase,
+    ExportAdminUsersUseCase,
     // Services
     EmailConfirmationJwtService,
     // Mappers

--- a/ayunis-core-frontend/src/app/routeTree.gen.ts
+++ b/ayunis-core-frontend/src/app/routeTree.gen.ts
@@ -46,6 +46,7 @@ import { Route as AuthenticatedAcademyChapterIdRouteImport } from './routes/_aut
 import { Route as onboardingPasswordResetRouteImport } from './routes/(onboarding)/password.reset'
 import { Route as onboardingPasswordForgotRouteImport } from './routes/(onboarding)/password.forgot'
 import { Route as onboardingAccountActivateRouteImport } from './routes/(onboarding)/account.activate'
+import { Route as AuthenticatedSuperAdminSettingsUsersIndexRouteImport } from './routes/_authenticated/super-admin-settings.users.index'
 import { Route as AuthenticatedSuperAdminSettingsSuperAdminsIndexRouteImport } from './routes/_authenticated/super-admin-settings.super-admins.index'
 import { Route as AuthenticatedSuperAdminSettingsSkillsIndexRouteImport } from './routes/_authenticated/super-admin-settings.skills.index'
 import { Route as AuthenticatedSuperAdminSettingsPlatformConfigIndexRouteImport } from './routes/_authenticated/super-admin-settings.platform-config.index'
@@ -266,6 +267,12 @@ const onboardingAccountActivateRoute =
     path: '/account/activate',
     getParentRoute: () => rootRouteImport,
   } as any)
+const AuthenticatedSuperAdminSettingsUsersIndexRoute =
+  AuthenticatedSuperAdminSettingsUsersIndexRouteImport.update({
+    id: '/super-admin-settings/users/',
+    path: '/super-admin-settings/users/',
+    getParentRoute: () => AuthenticatedRoute,
+  } as any)
 const AuthenticatedSuperAdminSettingsSuperAdminsIndexRoute =
   AuthenticatedSuperAdminSettingsSuperAdminsIndexRouteImport.update({
     id: '/super-admin-settings/super-admins/',
@@ -381,6 +388,7 @@ export interface FileRoutesByFullPath {
   '/super-admin-settings/platform-config/': typeof AuthenticatedSuperAdminSettingsPlatformConfigIndexRoute
   '/super-admin-settings/skills/': typeof AuthenticatedSuperAdminSettingsSkillsIndexRoute
   '/super-admin-settings/super-admins/': typeof AuthenticatedSuperAdminSettingsSuperAdminsIndexRoute
+  '/super-admin-settings/users/': typeof AuthenticatedSuperAdminSettingsUsersIndexRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
@@ -430,6 +438,7 @@ export interface FileRoutesByTo {
   '/super-admin-settings/platform-config': typeof AuthenticatedSuperAdminSettingsPlatformConfigIndexRoute
   '/super-admin-settings/skills': typeof AuthenticatedSuperAdminSettingsSkillsIndexRoute
   '/super-admin-settings/super-admins': typeof AuthenticatedSuperAdminSettingsSuperAdminsIndexRoute
+  '/super-admin-settings/users': typeof AuthenticatedSuperAdminSettingsUsersIndexRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -481,6 +490,7 @@ export interface FileRoutesById {
   '/_authenticated/super-admin-settings/platform-config/': typeof AuthenticatedSuperAdminSettingsPlatformConfigIndexRoute
   '/_authenticated/super-admin-settings/skills/': typeof AuthenticatedSuperAdminSettingsSkillsIndexRoute
   '/_authenticated/super-admin-settings/super-admins/': typeof AuthenticatedSuperAdminSettingsSuperAdminsIndexRoute
+  '/_authenticated/super-admin-settings/users/': typeof AuthenticatedSuperAdminSettingsUsersIndexRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -532,6 +542,7 @@ export interface FileRouteTypes {
     | '/super-admin-settings/platform-config/'
     | '/super-admin-settings/skills/'
     | '/super-admin-settings/super-admins/'
+    | '/super-admin-settings/users/'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
@@ -581,6 +592,7 @@ export interface FileRouteTypes {
     | '/super-admin-settings/platform-config'
     | '/super-admin-settings/skills'
     | '/super-admin-settings/super-admins'
+    | '/super-admin-settings/users'
   id:
     | '__root__'
     | '/'
@@ -631,6 +643,7 @@ export interface FileRouteTypes {
     | '/_authenticated/super-admin-settings/platform-config/'
     | '/_authenticated/super-admin-settings/skills/'
     | '/_authenticated/super-admin-settings/super-admins/'
+    | '/_authenticated/super-admin-settings/users/'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -908,6 +921,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof onboardingAccountActivateRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/_authenticated/super-admin-settings/users/': {
+      id: '/_authenticated/super-admin-settings/users/'
+      path: '/super-admin-settings/users'
+      fullPath: '/super-admin-settings/users/'
+      preLoaderRoute: typeof AuthenticatedSuperAdminSettingsUsersIndexRouteImport
+      parentRoute: typeof AuthenticatedRoute
+    }
     '/_authenticated/super-admin-settings/super-admins/': {
       id: '/_authenticated/super-admin-settings/super-admins/'
       path: '/super-admin-settings/super-admins'
@@ -1026,6 +1046,7 @@ interface AuthenticatedRouteChildren {
   AuthenticatedSuperAdminSettingsPlatformConfigIndexRoute: typeof AuthenticatedSuperAdminSettingsPlatformConfigIndexRoute
   AuthenticatedSuperAdminSettingsSkillsIndexRoute: typeof AuthenticatedSuperAdminSettingsSkillsIndexRoute
   AuthenticatedSuperAdminSettingsSuperAdminsIndexRoute: typeof AuthenticatedSuperAdminSettingsSuperAdminsIndexRoute
+  AuthenticatedSuperAdminSettingsUsersIndexRoute: typeof AuthenticatedSuperAdminSettingsUsersIndexRoute
 }
 
 const AuthenticatedRouteChildren: AuthenticatedRouteChildren = {
@@ -1085,6 +1106,8 @@ const AuthenticatedRouteChildren: AuthenticatedRouteChildren = {
     AuthenticatedSuperAdminSettingsSkillsIndexRoute,
   AuthenticatedSuperAdminSettingsSuperAdminsIndexRoute:
     AuthenticatedSuperAdminSettingsSuperAdminsIndexRoute,
+  AuthenticatedSuperAdminSettingsUsersIndexRoute:
+    AuthenticatedSuperAdminSettingsUsersIndexRoute,
 }
 
 const AuthenticatedRouteWithChildren = AuthenticatedRoute._addFileChildren(

--- a/ayunis-core-frontend/src/app/routes/_authenticated/super-admin-settings.users.index.tsx
+++ b/ayunis-core-frontend/src/app/routes/_authenticated/super-admin-settings.users.index.tsx
@@ -1,0 +1,8 @@
+import { createFileRoute } from '@tanstack/react-router';
+import SuperAdminUsersPage from '@/pages/super-admin-settings/users';
+
+export const Route = createFileRoute(
+  '/_authenticated/super-admin-settings/users/',
+)({
+  component: SuperAdminUsersPage,
+});

--- a/ayunis-core-frontend/src/i18n.ts
+++ b/ayunis-core-frontend/src/i18n.ts
@@ -44,6 +44,8 @@ import enSuperAdminSettingsSkills from './shared/locales/en/super-admin-settings
 import deSuperAdminSettingsSkills from './shared/locales/de/super-admin-settings-skills.json';
 import enSuperAdminSettingsSuperAdmins from './shared/locales/en/super-admin-settings-super-admins.json';
 import deSuperAdminSettingsSuperAdmins from './shared/locales/de/super-admin-settings-super-admins.json';
+import enSuperAdminSettingsUsers from './shared/locales/en/super-admin-settings-users.json';
+import deSuperAdminSettingsUsers from './shared/locales/de/super-admin-settings-users.json';
 import enSuperAdminSettingsAcademy from './shared/locales/en/super-admin-settings-academy.json';
 import deSuperAdminSettingsAcademy from './shared/locales/de/super-admin-settings-academy.json';
 import enAcademy from './shared/locales/en/academy.json';
@@ -90,6 +92,7 @@ const resources = {
     'knowledge-bases': enKnowledgeBases,
     'super-admin-settings-skills': enSuperAdminSettingsSkills,
     'super-admin-settings-super-admins': enSuperAdminSettingsSuperAdmins,
+    'super-admin-settings-users': enSuperAdminSettingsUsers,
     'super-admin-settings-academy': enSuperAdminSettingsAcademy,
     academy: enAcademy,
     artifacts: enArtifacts,
@@ -124,6 +127,7 @@ const resources = {
     'knowledge-bases': deKnowledgeBases,
     'super-admin-settings-skills': deSuperAdminSettingsSkills,
     'super-admin-settings-super-admins': deSuperAdminSettingsSuperAdmins,
+    'super-admin-settings-users': deSuperAdminSettingsUsers,
     'super-admin-settings-academy': deSuperAdminSettingsAcademy,
     academy: deAcademy,
     artifacts: deArtifacts,

--- a/ayunis-core-frontend/src/pages/super-admin-settings/super-admin-settings-layout/ui/SuperAdminSettingsSidebar.tsx
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/super-admin-settings-layout/ui/SuperAdminSettingsSidebar.tsx
@@ -5,6 +5,7 @@ import {
   ShieldCheck,
   Settings2,
   GraduationCap,
+  Users,
 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import {
@@ -20,6 +21,11 @@ export function SuperAdminSettingsSidebar() {
       to: '/super-admin-settings/orgs',
       icon: <Building2 />,
       label: t('layout.orgs'),
+    },
+    {
+      to: '/super-admin-settings/users',
+      icon: <Users />,
+      label: t('layout.users'),
     },
     {
       to: '/super-admin-settings/models-catalog',

--- a/ayunis-core-frontend/src/pages/super-admin-settings/users/index.ts
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/users/index.ts
@@ -1,0 +1,1 @@
+export { default } from './ui/Page';

--- a/ayunis-core-frontend/src/pages/super-admin-settings/users/ui/Page.tsx
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/users/ui/Page.tsx
@@ -1,0 +1,52 @@
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Download } from 'lucide-react';
+import { toast } from 'sonner';
+import SuperAdminSettingsLayout from '../../super-admin-settings-layout';
+import { axiosInstance } from '@/shared/api';
+import { Button } from '@/shared/ui/shadcn/button';
+
+export default function SuperAdminUsersPage() {
+  const { t } = useTranslation('super-admin-settings-users');
+  const { t: tLayout } = useTranslation('super-admin-settings-layout');
+  const [isExporting, setIsExporting] = useState(false);
+
+  const exportAdmins = async () => {
+    setIsExporting(true);
+
+    try {
+      const response = await axiosInstance.get<Blob>(
+        '/super-admin/users/export/admins.csv',
+        {
+          responseType: 'blob',
+        },
+      );
+      const url = URL.createObjectURL(response.data);
+      const link = document.createElement('a');
+      link.href = url;
+      link.download = 'admin-users-export.csv';
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+      URL.revokeObjectURL(url);
+    } catch (error) {
+      console.error('Failed to export admin users', error);
+      toast.error(t('export.error'));
+    } finally {
+      setIsExporting(false);
+    }
+  };
+
+  return (
+    <SuperAdminSettingsLayout pageTitle={tLayout('layout.users')}>
+      <div className="flex flex-col gap-4">
+        <div className="rounded-lg border bg-card p-6 shadow-sm">
+          <Button onClick={() => void exportAdmins()} disabled={isExporting}>
+            <Download />
+            {isExporting ? t('export.loading') : t('export.button')}
+          </Button>
+        </div>
+      </div>
+    </SuperAdminSettingsLayout>
+  );
+}

--- a/ayunis-core-frontend/src/shared/locales/de/super-admin-settings-layout.json
+++ b/ayunis-core-frontend/src/shared/locales/de/super-admin-settings-layout.json
@@ -5,6 +5,7 @@
     "returnToMainApp": "Zur Anwendung zurückkehren",
     "settings": "Einstellungen",
     "orgs": "Organisationen",
+    "users": "Benutzer",
     "modelsCatalog": "Model-Katalog",
     "skills": "Skill-Vorlagen",
     "academy": "Academy",

--- a/ayunis-core-frontend/src/shared/locales/de/super-admin-settings-users.json
+++ b/ayunis-core-frontend/src/shared/locales/de/super-admin-settings-users.json
@@ -1,0 +1,7 @@
+{
+  "export": {
+    "button": "Admin-CSV exportieren",
+    "loading": "Exportiert...",
+    "error": "Admin-Export fehlgeschlagen"
+  }
+}

--- a/ayunis-core-frontend/src/shared/locales/en/super-admin-settings-layout.json
+++ b/ayunis-core-frontend/src/shared/locales/en/super-admin-settings-layout.json
@@ -5,6 +5,7 @@
     "returnToMainApp": "Return to main app",
     "settings": "Settings",
     "orgs": "Organizations",
+    "users": "Users",
     "modelsCatalog": "Models Catalog",
     "skills": "Skill Templates",
     "academy": "Academy",

--- a/ayunis-core-frontend/src/shared/locales/en/super-admin-settings-users.json
+++ b/ayunis-core-frontend/src/shared/locales/en/super-admin-settings-users.json
@@ -1,0 +1,7 @@
+{
+  "export": {
+    "button": "Export admins CSV",
+    "loading": "Exporting...",
+    "error": "Admin export failed"
+  }
+}


### PR DESCRIPTION
## Summary
- add a super-admin Users settings page with a CSV export button
- add a super-admin CSV endpoint for admin users from organizations with non-cancelled subscriptions, including future starts
- include admin export repository/use case coverage for CSV formatting

## Validation
- pnpm --dir ayunis-core-frontend run build
- pnpm --dir ayunis-core-backend run build
- pnpm --dir ayunis-core-backend exec jest iam/users/application/use-cases/export-admin-users/export-admin-users.use-case.spec.ts --runInBand
- focused frontend/backend eslint on touched files
- pre-commit checks passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The endpoint exposes admin PII (emails, org, subscription) but is restricted to `SUPER_ADMIN`; main risk is bulk data export scope and query correctness if subscription joins duplicate rows.
> 
> **Overview**
> Adds a **super-admin-only** flow to download a CSV of **organization admins** whose org has a **non-cancelled subscription** (including future start dates).
> 
> On the backend, a new `GET super-admin/users/export/admins.csv` endpoint loads rows via a TypeORM query (users, org, subscription, aggregated teams), maps them through `ExportAdminUsersUseCase` into German column headers with split first/last name and ISO dates, and returns an attachment. Wiring includes `AdminUsersExportRepository`, `LocalAdminUsersExportRepository`, module registration, and a unit test for CSV formatting.
> 
> On the frontend, super-admin settings gains a **Users** sidebar entry and page at `/super-admin-settings/users` with an export button that fetches the blob and triggers `admin-users-export.csv` download, plus EN/DE strings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1bad618a1e50819523013b3b7b79240ac05b6a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->