### PR TITLE
fix(chat-input): keep attachments in a scrollable area (AYC-339)

### DIFF
--- a/ayunis-core-frontend/src/widgets/chat-input/ui/ChatInput.tsx
+++ b/ayunis-core-frontend/src/widgets/chat-input/ui/ChatInput.tsx
@@ -25,6 +25,7 @@ import { useFileDrop } from '../hooks/useFileDrop';
 import { PendingImageThumbnail } from './PendingImageThumbnail';
 import { cn } from '@/shared/lib/shadcn/utils';
 import { SourcesList } from './SourcesList';
+import { ScrollFadeContainer } from './ScrollFadeContainer';
 import { showError } from '@/shared/lib/toast';
 import { MicrophoneButton } from './MicrophoneButton';
 import type {
@@ -303,7 +304,7 @@ const ChatInput = forwardRef<ChatInputRef, ChatInputProps>(
               />
 
               {pendingImages.length > 0 && (
-                <div className="flex flex-wrap gap-2 items-center">
+                <ScrollFadeContainer>
                   {pendingImages.map((image: PendingImage) => (
                     <PendingImageThumbnail
                       key={image.id}
@@ -311,7 +312,7 @@ const ChatInput = forwardRef<ChatInputRef, ChatInputProps>(
                       onRemove={removeImage}
                     />
                   ))}
-                </div>
+                </ScrollFadeContainer>
               )}
 
               <TextareaAutosize

--- a/ayunis-core-frontend/src/widgets/chat-input/ui/ScrollFadeContainer.tsx
+++ b/ayunis-core-frontend/src/widgets/chat-input/ui/ScrollFadeContainer.tsx
@@ -1,0 +1,60 @@
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react';
+import { cn } from '@/shared/lib/shadcn/utils';
+
+const FADE_MASK = 'linear-gradient(to top, transparent 0, black 1.25rem)';
+
+interface ScrollFadeContainerProps {
+  children: ReactNode;
+  className?: string;
+}
+
+export function ScrollFadeContainer({
+  children,
+  className,
+}: Readonly<ScrollFadeContainerProps>) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const contentRef = useRef<HTMLDivElement>(null);
+  const [showFade, setShowFade] = useState(false);
+
+  const updateFade = useCallback(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const hasOverflow = el.scrollHeight > el.clientHeight + 1;
+    const atBottom = el.scrollTop + el.clientHeight >= el.scrollHeight - 1;
+    setShowFade(hasOverflow && !atBottom);
+  }, []);
+
+  useEffect(() => {
+    const content = contentRef.current;
+    if (!content) return;
+    const observer = new ResizeObserver(updateFade);
+    observer.observe(content);
+    return () => observer.disconnect();
+  }, [updateFade]);
+
+  return (
+    <div
+      ref={scrollRef}
+      onScroll={updateFade}
+      className="max-h-[4.5rem] overflow-y-auto"
+      style={
+        showFade
+          ? { maskImage: FADE_MASK, WebkitMaskImage: FADE_MASK }
+          : undefined
+      }
+    >
+      <div
+        ref={contentRef}
+        className={cn('flex flex-wrap items-center gap-2', className)}
+      >
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/ayunis-core-frontend/src/widgets/chat-input/ui/SourcesList.tsx
+++ b/ayunis-core-frontend/src/widgets/chat-input/ui/SourcesList.tsx
@@ -16,6 +16,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from '@/shared/ui/shadcn/tooltip';
+import { ScrollFadeContainer } from './ScrollFadeContainer';
 
 // Icons
 import {
@@ -97,7 +98,7 @@ export function SourcesList({
   }
 
   return (
-    <div className="flex flex-wrap gap-2 items-center">
+    <ScrollFadeContainer>
       {knowledgeBases.map((kb) => (
         <Badge key={`kb-${kb.id}`} variant="secondary">
           <Brain className="h-3 w-3" />
@@ -179,6 +180,6 @@ export function SourcesList({
 
         return badge;
       })}
-    </div>
+    </ScrollFadeContainer>
   );
 }


### PR DESCRIPTION
## Problem

Attaching many documents at once made the attachment list grow without bound and push the chat input off-screen — in Chrome the view jumped to the top and couldn't be scrolled back. Reported by Stadt Nürtingen.

## Fix

The attached-sources list and the pending-images row now render inside a small `ScrollFadeContainer`:

- height caps at ~2 rows, then scrolls — it grows with the content, so 1–2 files don't reserve empty space
- a soft bottom fade that appears only while there's more to scroll and disappears once you're at the bottom

## Why a native scroll container and not the shadcn `ScrollArea`?

`ScrollArea` is built for **externally-fixed heights** (`h-full`, `h-[500px]`, as used elsewhere in the repo) — its Radix viewport wraps content in a `display:table` element with a `height:100%` viewport, so it ignores a **content-driven `max-height`**. This strip needs the opposite: shrink with few chips, cap with many. Forcing `ScrollArea` here would mean either reserving empty height (fixed height) or hacking Radix internals via descendant selectors. A native `overflow-y-auto` container is the idiomatic fit; only the fade (no library equivalent) stays custom.

## Test

New chat → attach many documents → the list stays at 2 rows and scrolls, the chat input stays visible. A fade hints at more below and clears at the bottom.
