### PR TITLE
fix(models): generated images use prompt-fit aspect ratio + add download (AYC-293)

### DIFF
--- a/ayunis-core-backend/src/domain/models/infrastructure/image-generation/azure.image-generation.spec.ts
+++ b/ayunis-core-backend/src/domain/models/infrastructure/image-generation/azure.image-generation.spec.ts
@@ -154,7 +154,7 @@ describe('AzureImageGenerationHandler', () => {
       ).rejects.toThrow("Unsupported image quality 'ultra'");
     });
 
-    it('should default to 1024x1024 and auto when not provided', async () => {
+    it('should default to auto size and auto quality when not provided', async () => {
       const fakeB64 = Buffer.from('fake-image-data').toString('base64');
       mockImagesGenerate.mockResolvedValue({
         data: [{ b64_json: fakeB64 }],
@@ -165,9 +165,43 @@ describe('AzureImageGenerationHandler', () => {
 
       expect(mockImagesGenerate).toHaveBeenCalledWith(
         expect.objectContaining({
-          size: '1024x1024',
+          size: 'auto',
           quality: 'auto',
         }),
+      );
+    });
+
+    it.each([
+      ['square', '1024x1024'],
+      ['landscape', '1536x1024'],
+      ['portrait', '1024x1536'],
+      ['auto', 'auto'],
+    ])(
+      'should map semantic size %s to provider size %s',
+      async (semantic, expected) => {
+        const fakeB64 = Buffer.from('fake-image-data').toString('base64');
+        mockImagesGenerate.mockResolvedValue({
+          data: [{ b64_json: fakeB64 }],
+        });
+
+        await handler.generate(createInput({ size: semantic }));
+
+        expect(mockImagesGenerate).toHaveBeenCalledWith(
+          expect.objectContaining({ size: expected }),
+        );
+      },
+    );
+
+    it('should still accept raw provider dimensions', async () => {
+      const fakeB64 = Buffer.from('fake-image-data').toString('base64');
+      mockImagesGenerate.mockResolvedValue({
+        data: [{ b64_json: fakeB64 }],
+      });
+
+      await handler.generate(createInput({ size: '1536x1024' }));
+
+      expect(mockImagesGenerate).toHaveBeenCalledWith(
+        expect.objectContaining({ size: '1536x1024' }),
       );
     });
 

--- a/ayunis-core-backend/src/domain/models/infrastructure/image-generation/azure.image-generation.ts
+++ b/ayunis-core-backend/src/domain/models/infrastructure/image-generation/azure.image-generation.ts
@@ -1,6 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { APIError, AzureOpenAI } from 'openai';
+import type { ImagesResponse } from 'openai/resources/images';
 import {
   ImageGenerationHandler,
   ImageGenerationInput,
@@ -11,11 +12,27 @@ import { ImageGenerationFailedError } from '../../application/models.errors';
 const VALID_SIZES = ['1024x1024', '1024x1536', '1536x1024', 'auto'] as const;
 type ImageSize = (typeof VALID_SIZES)[number];
 
+// Semantic aspect-ratio aliases the LLM tool can request, mapped to the
+// dimensions the provider understands. Keeps the model-facing vocabulary
+// stable even if provider-specific dimensions change.
+const SIZE_ALIASES: Record<string, ImageSize> = {
+  auto: 'auto',
+  square: '1024x1024',
+  landscape: '1536x1024',
+  portrait: '1024x1536',
+};
+
 const VALID_QUALITIES = ['low', 'medium', 'high', 'auto'] as const;
 type ImageQuality = (typeof VALID_QUALITIES)[number];
 
-function isValidSize(value: string): value is ImageSize {
-  return (VALID_SIZES as readonly string[]).includes(value);
+function resolveSize(value: string): ImageSize | undefined {
+  if (value in SIZE_ALIASES) {
+    return SIZE_ALIASES[value];
+  }
+  if ((VALID_SIZES as readonly string[]).includes(value)) {
+    return value as ImageSize;
+  }
+  return undefined;
 }
 
 function isValidQuality(value: string): value is ImageQuality {
@@ -44,10 +61,12 @@ export class AzureImageGenerationHandler extends ImageGenerationHandler {
     size: ImageSize;
     quality: ImageQuality;
   } {
-    const size = input.size ?? '1024x1024';
-    if (!isValidSize(size)) {
+    const size = resolveSize(input.size ?? 'auto');
+    if (!size) {
       throw new ImageGenerationFailedError(
-        `Unsupported image size '${size}'. Supported sizes: ${VALID_SIZES.join(', ')}`,
+        `Unsupported image size '${input.size}'. Supported sizes: ${Object.keys(
+          SIZE_ALIASES,
+        ).join(', ')}, ${VALID_SIZES.join(', ')}`,
       );
     }
 
@@ -79,71 +98,81 @@ export class AzureImageGenerationHandler extends ImageGenerationHandler {
         quality,
         n: 1,
       });
-
-      const imageData = response.data?.[0];
-      if (!imageData?.b64_json) {
-        throw new ImageGenerationFailedError(
-          'No image data returned from Azure OpenAI',
-        );
-      }
-
-      const imageBuffer = Buffer.from(imageData.b64_json, 'base64');
-
-      const usage = response.usage
-        ? {
-            inputTokens: response.usage.input_tokens,
-            outputTokens: response.usage.output_tokens,
-            totalTokens: response.usage.total_tokens,
-          }
-        : undefined;
-
-      this.logger.log('Image generated successfully', {
-        model: input.model.name,
-        sizeBytes: imageBuffer.length,
-        inputTokens: usage?.inputTokens,
-        outputTokens: usage?.outputTokens,
-        totalTokens: usage?.totalTokens,
-      });
-
-      return new ImageGenerationResult(
-        imageBuffer,
-        'image/png',
-        imageData.revised_prompt,
-        usage,
-      );
+      return this.buildResult(response, input.model.name);
     } catch (error) {
-      if (error instanceof ImageGenerationFailedError) {
-        throw error;
-      }
+      this.handleGenerationError(error, input.model.name);
+    }
+  }
 
-      if (error instanceof APIError) {
-        const errorCode = String(error.code ?? '');
-        this.logger.error('Azure OpenAI API error during image generation', {
-          status: String(error.status ?? ''),
-          code: errorCode,
-          message: error.message,
-          model: input.model.name,
-        });
-
-        if (errorCode === 'content_policy_violation') {
-          throw new ImageGenerationFailedError(
-            'The image could not be generated because the prompt was flagged by the content policy. Please revise your prompt and try again.',
-          );
-        }
-
-        throw new ImageGenerationFailedError(
-          'The image could not be generated due to a service error. Please try again later.',
-        );
-      }
-
-      this.logger.error('Unexpected error during image generation', {
-        error: error instanceof Error ? error.message : 'Unknown error',
-        model: input.model.name,
-      });
-
+  private buildResult(
+    response: ImagesResponse,
+    modelName: string,
+  ): ImageGenerationResult {
+    const imageData = response.data?.[0];
+    if (!imageData?.b64_json) {
       throw new ImageGenerationFailedError(
-        'An unexpected error occurred while generating the image. Please try again later.',
+        'No image data returned from Azure OpenAI',
       );
     }
+
+    const imageBuffer = Buffer.from(imageData.b64_json, 'base64');
+
+    const usage = response.usage
+      ? {
+          inputTokens: response.usage.input_tokens,
+          outputTokens: response.usage.output_tokens,
+          totalTokens: response.usage.total_tokens,
+        }
+      : undefined;
+
+    this.logger.log('Image generated successfully', {
+      model: modelName,
+      sizeBytes: imageBuffer.length,
+      inputTokens: usage?.inputTokens,
+      outputTokens: usage?.outputTokens,
+      totalTokens: usage?.totalTokens,
+    });
+
+    return new ImageGenerationResult(
+      imageBuffer,
+      'image/png',
+      imageData.revised_prompt,
+      usage,
+    );
+  }
+
+  private handleGenerationError(error: unknown, modelName: string): never {
+    if (error instanceof ImageGenerationFailedError) {
+      throw error;
+    }
+
+    if (error instanceof APIError) {
+      const errorCode = String(error.code ?? '');
+      this.logger.error('Azure OpenAI API error during image generation', {
+        status: String(error.status ?? ''),
+        code: errorCode,
+        message: error.message,
+        model: modelName,
+      });
+
+      if (errorCode === 'content_policy_violation') {
+        throw new ImageGenerationFailedError(
+          'The image could not be generated because the prompt was flagged by the content policy. Please revise your prompt and try again.',
+        );
+      }
+
+      throw new ImageGenerationFailedError(
+        'The image could not be generated due to a service error. Please try again later.',
+      );
+    }
+
+    this.logger.error('Unexpected error during image generation', {
+      error: error instanceof Error ? error.message : 'Unknown error',
+      model: modelName,
+    });
+
+    throw new ImageGenerationFailedError(
+      'An unexpected error occurred while generating the image. Please try again later.',
+    );
   }
 }

--- a/ayunis-core-backend/src/domain/tools/application/handlers/generate-image-tool.handler.spec.ts
+++ b/ayunis-core-backend/src/domain/tools/application/handlers/generate-image-tool.handler.spec.ts
@@ -129,6 +129,42 @@ describe('GenerateImageToolHandler', () => {
     expect(command.prompt).toBe('A cat wearing a hat');
   });
 
+  it('should pass the requested size to GenerateImageUseCase', async () => {
+    setupHappyPath();
+
+    await handler.execute({
+      tool: new GenerateImageTool(),
+      input: { prompt: 'A wide flow diagram', size: 'landscape' },
+      context: { orgId: mockOrgId, threadId: mockThreadId },
+    });
+
+    const command = mockGenerateImage.execute.mock.calls[0][0];
+    expect(command.size).toBe('landscape');
+  });
+
+  it('should leave size undefined when not provided', async () => {
+    setupHappyPath();
+
+    await handler.execute({
+      tool: new GenerateImageTool(),
+      input: { prompt: 'A cat wearing a hat' },
+      context: { orgId: mockOrgId, threadId: mockThreadId },
+    });
+
+    const command = mockGenerateImage.execute.mock.calls[0][0];
+    expect(command.size).toBeUndefined();
+  });
+
+  it('should reject an invalid size value', async () => {
+    await expect(
+      handler.execute({
+        tool: new GenerateImageTool(),
+        input: { prompt: 'A cat', size: 'panoramic' },
+        context: { orgId: mockOrgId, threadId: mockThreadId },
+      }),
+    ).rejects.toThrow(ToolExecutionFailedError);
+  });
+
   it('should pass correct params to SaveGeneratedImageUseCase', async () => {
     setupHappyPath();
 

--- a/ayunis-core-backend/src/domain/tools/application/handlers/generate-image-tool.handler.ts
+++ b/ayunis-core-backend/src/domain/tools/application/handlers/generate-image-tool.handler.ts
@@ -75,6 +75,7 @@ export class GenerateImageToolHandler extends ToolExecutionHandler {
       new GenerateImageCommand({
         model: permittedModel.model,
         prompt: validatedInput.prompt,
+        size: validatedInput.size,
       }),
     );
 

--- a/ayunis-core-backend/src/domain/tools/domain/tools/generate-image-tool.entity.ts
+++ b/ayunis-core-backend/src/domain/tools/domain/tools/generate-image-tool.entity.ts
@@ -12,6 +12,12 @@ const generateImageToolParameters = {
       description: 'A detailed text description of the image to generate',
       maxLength: 4000,
     },
+    size: {
+      type: 'string' as const,
+      enum: ['auto', 'square', 'landscape', 'portrait'] as const,
+      description:
+        "The aspect ratio of the generated image. Choose the ratio that best fits the content so it is not cropped: 'landscape' for wide content such as flow charts, diagrams, banners or scenery; 'portrait' for tall content such as posters or full-body figures; 'square' for icons, avatars or balanced compositions. Use 'auto' (the default) to let the model pick the best ratio for the prompt.",
+    },
   },
   required: ['prompt'],
   additionalProperties: false,

--- a/ayunis-core-frontend/src/pages/chat/ui/chat-widgets/GenerateImageWidget.tsx
+++ b/ayunis-core-frontend/src/pages/chat/ui/chat-widgets/GenerateImageWidget.tsx
@@ -1,10 +1,29 @@
 import { useState } from 'react';
-import { Image as ImageIcon, Loader2 } from 'lucide-react';
+import { Download, Image as ImageIcon, Loader2 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { Dialog, DialogContent, DialogTitle } from '@/shared/ui/shadcn/dialog';
+import { Button } from '@/shared/ui/shadcn/button';
 import { useResolveGeneratedImage } from '../../api/useResolveGeneratedImage';
 import type { ToolUseMessageContent } from '../../model/openapi';
 import ImageGenerationLoader from './ImageGenerationLoader';
+
+async function downloadImage(url: string, fileName: string): Promise<void> {
+  try {
+    const response = await fetch(url);
+    const blob = await response.blob();
+    const objectUrl = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = objectUrl;
+    link.download = fileName;
+    document.body.appendChild(link);
+    link.click();
+    link.remove();
+    URL.revokeObjectURL(objectUrl);
+  } catch {
+    // Cross-origin fetch can be blocked; fall back to opening the full image.
+    window.open(url, '_blank', 'noopener,noreferrer');
+  }
+}
 
 interface GenerateImageWidgetProps {
   readonly content: ToolUseMessageContent;
@@ -102,6 +121,18 @@ export default function GenerateImageWidget({
             alt={altText}
             className="w-full h-full max-h-[90vh] object-contain rounded-lg"
           />
+          <Button
+            type="button"
+            variant="secondary"
+            size="sm"
+            className="absolute left-3 top-3 gap-2 shadow-md"
+            onClick={() =>
+              void downloadImage(url, 'ayunis-generated-image.png')
+            }
+          >
+            <Download className="size-4" />
+            {t('chat.tools.generate_image.download')}
+          </Button>
         </DialogContent>
       </Dialog>
     </>

--- a/ayunis-core-frontend/src/shared/locales/de/chat.json
+++ b/ayunis-core-frontend/src/shared/locales/de/chat.json
@@ -167,7 +167,8 @@
         "loading": "Bild wird geladen…",
         "error": "Generiertes Bild konnte nicht geladen werden",
         "altFallback": "Generiertes Bild",
-        "openPreview": "Bildvorschau öffnen"
+        "openPreview": "Bildvorschau öffnen",
+        "download": "Bild herunterladen"
       }
     },
     "charts": {

--- a/ayunis-core-frontend/src/shared/locales/en/chat.json
+++ b/ayunis-core-frontend/src/shared/locales/en/chat.json
@@ -167,7 +167,8 @@
         "loading": "Loading image…",
         "error": "Could not load generated image",
         "altFallback": "Generated image",
-        "openPreview": "Open image preview"
+        "openPreview": "Open image preview",
+        "download": "Download image"
       }
     },
     "charts": {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Reported in Ayunis (AYC-293): Ayunis-generated graphics are **always returned as a 1024×1024 square regardless of the prompt**, so wide content (e.g. a horizontal LoRaWAN flow diagram) gets its sides cut off. There was also no way to download the full image.

## Root cause

The `generate_image` tool only accepted a `prompt` — no size was ever passed down. As a result `GenerateImageCommand.size` was always `undefined`, and the Azure handler defaulted to `1024x1024`. Every image was forced into a square, cropping wide/tall content.

## Changes

**Backend — aspect ratio**
- Added an optional `size` param to the `generate_image` tool with semantic values `auto | square | landscape | portrait`, plus guidance so the model picks the ratio that fits the content (landscape for diagrams/banners, portrait for posters, etc.).
- Threaded the requested size through the tool handler → `GenerateImageCommand` → use case → handler.
- The Azure handler now maps semantic sizes to provider dimensions (`square→1024x1024`, `landscape→1536x1024`, `portrait→1024x1536`) and **defaults to `auto`**, letting the provider choose the best ratio when none is requested. Raw provider dimensions are still accepted.
- Refactored `generate()` into smaller helpers (`buildResult`, `handleGenerationError`) to stay within the complexity gate.

**Frontend — usability**
- Added a **Download** button to the generated-image preview dialog so the full image can be saved (falls back to opening in a new tab if a cross-origin blob fetch is blocked).
- Added `download` translation keys (en/de).

## Tests
- Updated Azure handler specs: default is now `auto`, plus new cases covering semantic→dimension mapping and raw dimensions.
- Added tool-handler specs verifying `size` is passed through, defaults to undefined, and that invalid values are rejected.
- All affected backend unit tests pass; frontend and backend typecheck/lint clean (verified via pre-commit hooks).

## Notes
This relies on `gpt-image-1`'s `auto` size support (already in the handler's valid-size list). With `auto`, the aspect ratio now follows the prompt instead of being fixed to a square.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [AYC-293](https://linear.app/ayunis/issue/AYC-293/ayunis-generated-graphics-are-always-cropped)

<div><a href="https://cursor.com/agents/bc-0fe1af29-c88e-4365-8b52-3e97ef12e3af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0fe1af29-c88e-4365-8b52-3e97ef12e3af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

