### PR TITLE
docs(skills): require hooks for API calls and generated client use (AYC-000)

### DIFF
--- a/.claude/skills/frontend-hook-reference/SKILL.md
+++ b/.claude/skills/frontend-hook-reference/SKILL.md
@@ -269,6 +269,41 @@ return {
 };
 ```
 
+### 6. API calls live in a hook, never inline in a page
+
+Any component that calls the API does so through a hook in the page's `api/` directory — including side-effecting actions like file/CSV/PDF exports and downloads. Pages stay declarative: they consume the hook's return (`{ data, isLoading, ... }` or `{ exportEntities, isExporting }`) and render. Don't inline `fetch`/blob-download/`URL.createObjectURL` logic into a page component.
+
+```typescript
+// WRONG ✗ — export logic inlined in the page component
+export default function UsersPage() {
+  const exportAdmins = async () => {
+    const blob = await someControllerExport();
+    const url = URL.createObjectURL(blob);
+    // ...DOM download dance inside the page...
+  };
+  return <Button onClick={() => void exportAdmins()}>Export</Button>;
+}
+
+// CORRECT ✓ — logic in a hook, page just consumes it
+export default function UsersPage() {
+  const { exportAdmins, isExporting } = useUserExport();
+  return <Button onClick={() => void exportAdmins()} disabled={isExporting}>Export</Button>;
+}
+```
+
+### 7. Always use the generated client from `@/shared/api`
+
+Never hand-write a request path with `axiosInstance.get`/`post`. Import the Orval-generated function (e.g. `entityControllerExport`) from `@/shared/api`. The generated client is the single source of truth for URLs, typing, and the request/response contract — hand-written paths drift silently when the backend changes.
+
+```typescript
+// WRONG ✗ — bypasses Orval, hand-written path + untyped response
+const blob = await axiosInstance.get('/admin/users/export', { responseType: 'blob' });
+
+// CORRECT ✓ — generated, typed function
+import { entityControllerExport } from '@/shared/api';
+const blob = await entityControllerExport();
+```
+
 ## Checklist
 
 When creating or modifying a hook, verify:
@@ -279,3 +314,5 @@ When creating or modifying a hook, verify:
 - [ ] `onSuccess` invalidates relevant query keys
 - [ ] `void` used for fire-and-forget `invalidateQueries`/`router.invalidate()`
 - [ ] User-facing strings go through `useTranslation`, not hardcoded
+- [ ] No API/blob-download logic inlined in a page — it lives in a hook in `api/`
+- [ ] Uses the generated client from `@/shared/api`, not a hand-written `axiosInstance` path


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only change to a Claude skill file; no runtime or application code is modified.
> 
> **Overview**
> Extends the **frontend-hook-reference** skill with two new rules and matching checklist items.
> 
> **Rule 6** requires all API usage (including exports/downloads with blob/`URL.createObjectURL` flows) to live in page `api/` hooks; pages only consume hook return values like `{ exportEntities, isExporting }` instead of inlining fetch/download logic.
> 
> **Rule 7** forbids hand-written `axiosInstance` paths and mandates Orval-generated functions from `@/shared/api` as the single source of truth for URLs and typing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a05a618df8faaa5bd0920e01cb98c27cd02fe43b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->