### PR TITLE
feat(admin-settings): group sidebar links into labeled sections (AYC-000)

### DIFF
--- a/ayunis-core-frontend/src/pages/admin-settings/admin-settings-layout/ui/AdminSettingsSidebar.tsx
+++ b/ayunis-core-frontend/src/pages/admin-settings/admin-settings-layout/ui/AdminSettingsSidebar.tsx
@@ -14,7 +14,7 @@ import {
 import { useTranslation } from 'react-i18next';
 import {
   SettingsSidebarWidget,
-  type SidebarMenuItem,
+  type SidebarMenuGroup,
 } from '@/widgets/settings-sidebar/ui/SettingsSidebarWidget';
 import { useIsLetterheadsEnabled } from '@/features/feature-toggles';
 
@@ -22,72 +22,92 @@ export function AdminSettingsSidebar() {
   const { t } = useTranslation('admin-settings-layout');
   const isLetterheadsEnabled = useIsLetterheadsEnabled();
 
-  const menuItems: SidebarMenuItem[] = [
+  const groups: SidebarMenuGroup[] = [
     {
-      to: '/admin-settings/users',
-      icon: <User />,
-      label: t('layout.users'),
+      labelKey: 'groups.membersAccess',
+      items: [
+        {
+          to: '/admin-settings/users',
+          icon: <User />,
+          label: t('layout.users'),
+        },
+        {
+          to: '/admin-settings/teams',
+          icon: <Users />,
+          label: t('layout.teams'),
+        },
+        {
+          to: '/admin-settings/api-keys',
+          icon: <Key />,
+          label: t('layout.apiKeys'),
+        },
+      ],
     },
     {
-      to: '/admin-settings/teams',
-      icon: <Users />,
-      label: t('layout.teams'),
+      labelKey: 'groups.aiAssistant',
+      items: [
+        {
+          to: '/admin-settings/models',
+          icon: <Brain />,
+          label: t('layout.models'),
+        },
+        {
+          to: '/admin-settings/integrations',
+          icon: <Plug />,
+          label: t('layout.integrations'),
+        },
+        {
+          to: '/admin-settings/instructions',
+          icon: <MessageSquareText />,
+          label: t('layout.instructions'),
+        },
+        ...(isLetterheadsEnabled
+          ? [
+              {
+                to: '/admin-settings/letterheads' as const,
+                icon: <FileText />,
+                label: t('layout.letterheads'),
+              },
+            ]
+          : []),
+      ],
     },
     {
-      to: '/admin-settings/models',
-      icon: <Brain />,
-      label: t('layout.models'),
+      labelKey: 'groups.privacyCompliance',
+      items: [
+        {
+          to: '/admin-settings/security',
+          icon: <Shield />,
+          label: t('layout.security'),
+        },
+        {
+          to: '/admin-settings/anonymization',
+          icon: <ShieldCheck />,
+          label: t('layout.anonymization'),
+        },
+        {
+          to: '/admin-settings/retention',
+          icon: <Trash2 />,
+          label: t('layout.retention'),
+        },
+      ],
     },
     {
-      to: '/admin-settings/integrations',
-      icon: <Plug />,
-      label: t('layout.integrations'),
+      labelKey: 'groups.analytics',
+      items: [
+        {
+          to: '/admin-settings/usage',
+          icon: <BarChart3 />,
+          label: t('layout.usage'),
+        },
+      ],
     },
-    {
-      to: '/admin-settings/security',
-      icon: <Shield />,
-      label: t('layout.security'),
-    },
-    {
-      to: '/admin-settings/anonymization',
-      icon: <ShieldCheck />,
-      label: t('layout.anonymization'),
-    },
-    {
-      to: '/admin-settings/retention',
-      icon: <Trash2 />,
-      label: t('layout.retention'),
-    },
-    {
-      to: '/admin-settings/instructions',
-      icon: <MessageSquareText />,
-      label: t('layout.instructions'),
-    },
-    {
-      to: '/admin-settings/api-keys',
-      icon: <Key />,
-      label: t('layout.apiKeys'),
-    },
-    {
-      to: '/admin-settings/usage',
-      icon: <BarChart3 />,
-      label: t('layout.usage'),
-    },
-    ...(isLetterheadsEnabled
-      ? [
-          {
-            to: '/admin-settings/letterheads' as const,
-            icon: <FileText />,
-            label: t('layout.letterheads'),
-          },
-        ]
-      : []),
   ];
 
   return (
     <SettingsSidebarWidget
       translationNamespace="admin-settings-layout"
-      menuItems={menuItems}
+      groups={groups}
     />
   );
 }

--- a/ayunis-core-frontend/src/shared/locales/de/admin-settings-layout.json
+++ b/ayunis-core-frontend/src/shared/locales/de/admin-settings-layout.json
@@ -15,5 +15,11 @@
     "instructions": "Chat",
     "letterheads": "Briefpapier",
     "apiKeys": "API-Schlüssel"
+  },
+  "groups": {
+    "membersAccess": "Mitglieder & Zugriff",
+    "aiAssistant": "KI-Assistent",
+    "privacyCompliance": "Datenschutz & Compliance",
+    "analytics": "Auswertung"
   }
 }

--- a/ayunis-core-frontend/src/shared/locales/en/admin-settings-layout.json
+++ b/ayunis-core-frontend/src/shared/locales/en/admin-settings-layout.json
@@ -15,5 +15,11 @@
     "instructions": "Chat",
     "letterheads": "Letterheads",
     "apiKeys": "API Keys"
+  },
+  "groups": {
+    "membersAccess": "Members & Access",
+    "aiAssistant": "AI Assistant",
+    "privacyCompliance": "Privacy & Compliance",
+    "analytics": "Analytics"
   }
 }

--- a/ayunis-core-frontend/src/widgets/settings-sidebar/ui/SettingsSidebarWidget.tsx
+++ b/ayunis-core-frontend/src/widgets/settings-sidebar/ui/SettingsSidebarWidget.tsx
@@ -20,17 +20,51 @@ export interface SidebarMenuItem {
   label: string;
 }
 
+export interface SidebarMenuGroup {
+  /** Translation key for the group label, resolved within `translationNamespace`. */
+  labelKey: string;
+  items: SidebarMenuItem[];
+}
+
 interface SettingsSidebarWidgetProps {
   translationNamespace: string;
-  menuItems: SidebarMenuItem[];
+  /** Flat list rendered under a single "Settings" group. */
+  menuItems?: SidebarMenuItem[];
+  /** Grouped items, each rendered under its own label. Takes precedence over `menuItems`. */
+  groups?: SidebarMenuGroup[];
+}
+
+function SidebarItems({
+  items,
+  pathname,
+}: Readonly<{ items: SidebarMenuItem[]; pathname: string }>) {
+  return (
+    <SidebarMenu>
+      {items.map((item) => (
+        <SidebarMenuItem key={item.to}>
+          <SidebarMenuButton asChild isActive={pathname.startsWith(item.to)}>
+            <Link to={item.to}>
+              {item.icon}
+              <span>{item.label}</span>
+            </Link>
+          </SidebarMenuButton>
+        </SidebarMenuItem>
+      ))}
+    </SidebarMenu>
+  );
 }
 
 export function SettingsSidebarWidget({
   translationNamespace,
   menuItems,
+  groups,
 }: Readonly<SettingsSidebarWidgetProps>) {
   const { t } = useTranslation(translationNamespace);
   const location = useLocation();
+
+  const resolvedGroups: SidebarMenuGroup[] = groups ?? [
+    { labelKey: 'layout.settings', items: menuItems ?? [] },
+  ];
 
   return (
     <Sidebar collapsible="icon" variant="inset">
@@ -55,24 +89,12 @@ export function SettingsSidebarWidget({
       </SidebarHeader>
 
       <SidebarContent>
-        <SidebarGroup>
-          <SidebarGroupLabel>{t('layout.settings')}</SidebarGroupLabel>
-          <SidebarMenu>
-            {menuItems.map((item) => (
-              <SidebarMenuItem key={item.to}>
-                <SidebarMenuButton
-                  asChild
-                  isActive={location.pathname.startsWith(item.to)}
-                >
-                  <Link to={item.to}>
-                    {item.icon}
-                    <span>{item.label}</span>
-                  </Link>
-                </SidebarMenuButton>
-              </SidebarMenuItem>
-            ))}
-          </SidebarMenu>
-        </SidebarGroup>
+        {resolvedGroups.map((group) => (
+          <SidebarGroup key={group.labelKey}>
+            <SidebarGroupLabel>{t(group.labelKey)}</SidebarGroupLabel>
+            <SidebarItems items={group.items} pathname={location.pathname} />
+          </SidebarGroup>
+        ))}
       </SidebarContent>
       <SidebarFooter />
     </Sidebar>


### PR DESCRIPTION
- Extend SettingsSidebarWidget with an optional grouped 'groups' prop
  (one SidebarGroup/label per group); flat 'menuItems' still supported
- Reorganize admin settings nav into Members & Access, AI Assistant,
  Privacy & Compliance, and Analytics
- Add group label translations (en/de)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Navigation-only UI and i18n changes; routes and backward-compatible `menuItems` usage for other settings layouts are unchanged.
> 
> **Overview**
> **Settings sidebar** now supports optional **grouped navigation**: each group gets its own `SidebarGroupLabel`, while the existing flat `menuItems` API still works (it is rendered as one default “Settings” group). Menu link rendering is extracted into a small `SidebarItems` helper.
> 
> **Admin settings** switches from a single flat list to four labeled sections—Members & Access, AI Assistant, Privacy & Compliance, and Analytics—with the same routes and icons as before (letterheads still gated by the feature toggle). **English and German** locale files add the new `groups.*` label keys.
> 
> User and super-admin settings sidebars are unchanged; they continue to pass `menuItems` only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4fc22c5e48b91767d8c7caa9bf924996c0560051. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->