### PR TITLE
feat(subscriptions): super-admin change subscription type via cancel/delete + recreate (AYC-354)

### DIFF
--- a/ayunis-core-backend/src/iam/subscriptions/application/ports/subscription.repository.ts
+++ b/ayunis-core-backend/src/iam/subscriptions/application/ports/subscription.repository.ts
@@ -1,11 +1,18 @@
 import type { UUID } from 'crypto';
 import type { Subscription } from '../../domain/subscription.entity';
 import type { SubscriptionBillingInfo } from '../../domain/subscription-billing-info.entity';
+import type { OldSubscriptionDisposition } from '../../domain/value-objects/old-subscription-disposition.enum';
 
 export interface UpdateSubscriptionStartDateParams {
   subscriptionId: UUID;
   startsAt: Date;
   renewalCycleAnchor?: Date;
+}
+
+export interface ReplaceSubscriptionParams {
+  oldSubscriptionId: UUID;
+  disposition: OldSubscriptionDisposition;
+  newSubscription: Subscription;
 }
 
 export abstract class SubscriptionRepository {
@@ -22,4 +29,10 @@ export abstract class SubscriptionRepository {
     billingInfo: SubscriptionBillingInfo,
   ): Promise<SubscriptionBillingInfo>;
   abstract delete(id: UUID): Promise<void>;
+  /**
+   * Atomically end the current subscription (cancel or delete, per the
+   * disposition) and create the new one in a single transaction, so the org is
+   * never left without a subscription or with two active subscriptions.
+   */
+  abstract replace(params: ReplaceSubscriptionParams): Promise<Subscription>;
 }

--- a/ayunis-core-backend/src/iam/subscriptions/application/services/subscription-factory.service.ts
+++ b/ayunis-core-backend/src/iam/subscriptions/application/services/subscription-factory.service.ts
@@ -1,0 +1,180 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import type { UUID } from 'crypto';
+import { Subscription } from 'src/iam/subscriptions/domain/subscription.entity';
+import { SeatBasedSubscription } from 'src/iam/subscriptions/domain/seat-based-subscription.entity';
+import { UsageBasedSubscription } from 'src/iam/subscriptions/domain/usage-based-subscription.entity';
+import { SubscriptionBillingInfo } from 'src/iam/subscriptions/domain/subscription-billing-info.entity';
+import { SubscriptionType } from 'src/iam/subscriptions/domain/value-objects/subscription-type.enum';
+import { RenewalCycle } from 'src/iam/subscriptions/domain/value-objects/renewal-cycle.enum';
+import {
+  InvalidSubscriptionDataError,
+  TooManyUsedSeatsError,
+} from '../subscription.errors';
+import type { User } from 'src/iam/users/domain/user.entity';
+import { GetInvitesByOrgQuery } from 'src/iam/invites/application/use-cases/get-invites-by-org/get-invites-by-org.query';
+import { FindUsersByOrgIdQuery } from 'src/iam/users/application/use-cases/find-users-by-org-id/find-users-by-org-id.query';
+import { GetInvitesByOrgUseCase } from 'src/iam/invites/application/use-cases/get-invites-by-org/get-invites-by-org.use-case';
+import { FindUsersByOrgIdUseCase } from 'src/iam/users/application/use-cases/find-users-by-org-id/find-users-by-org-id.use-case';
+
+/**
+ * The data required to construct a brand-new subscription. Shared by the
+ * create and change (cancel/delete + recreate) flows — both their commands
+ * satisfy this shape structurally.
+ */
+export interface BuildSubscriptionParams {
+  orgId: UUID;
+  requestingUserId: UUID;
+  type: SubscriptionType;
+  noOfSeats?: number;
+  monthlyCredits?: number;
+  companyName: string;
+  subText?: string;
+  street: string;
+  houseNumber: string;
+  postalCode: string;
+  city: string;
+  country: string;
+  vatNumber?: string;
+  startsAt?: Date;
+}
+
+/**
+ * Builds and validates new {@link Subscription} domain objects from raw command
+ * data. Extracted from CreateSubscriptionUseCase so the change-subscription flow
+ * can construct the replacement subscription with identical validation rules
+ * (seat count vs used seats, price configuration, positive monthly credits).
+ *
+ * It does NOT enforce the "at most one non-cancelled subscription" invariant —
+ * that belongs to the caller, since create and change differ on it.
+ */
+@Injectable()
+export class SubscriptionFactory {
+  private readonly logger = new Logger(SubscriptionFactory.name);
+
+  constructor(
+    private readonly configService: ConfigService,
+    private readonly getInvitesByOrgUseCase: GetInvitesByOrgUseCase,
+    private readonly findUsersByOrgIdUseCase: FindUsersByOrgIdUseCase,
+  ) {}
+
+  async build(params: BuildSubscriptionParams): Promise<Subscription> {
+    return params.type === SubscriptionType.USAGE_BASED
+      ? this.buildUsageBased(params)
+      : this.buildSeatBased(params);
+  }
+
+  private buildUsageBased(
+    params: BuildSubscriptionParams,
+  ): UsageBasedSubscription {
+    if (!params.monthlyCredits || params.monthlyCredits <= 0) {
+      throw new InvalidSubscriptionDataError(
+        'Monthly credits must be greater than 0 for usage-based subscriptions',
+      );
+    }
+
+    this.logger.log('Building usage-based subscription', {
+      orgId: params.orgId,
+      monthlyCredits: params.monthlyCredits,
+    });
+
+    return new UsageBasedSubscription({
+      orgId: params.orgId,
+      monthlyCredits: params.monthlyCredits,
+      startsAt: params.startsAt,
+      billingInfo: this.buildBillingInfo(params),
+    });
+  }
+
+  private async buildSeatBased(
+    params: BuildSubscriptionParams,
+  ): Promise<SeatBasedSubscription> {
+    const noOfSeats = params.noOfSeats ?? 1;
+
+    this.logger.log('Building seat-based subscription', {
+      orgId: params.orgId,
+      noOfSeats,
+    });
+
+    if (noOfSeats <= 0) {
+      throw new InvalidSubscriptionDataError(
+        'Number of seats must be greater than 0',
+      );
+    }
+
+    await this.validateSeatCount(
+      params.orgId,
+      params.requestingUserId,
+      noOfSeats,
+    );
+
+    const pricePerSeat = this.configService.get<number>(
+      'subscriptions.pricePerSeatYearly',
+    );
+    if (!pricePerSeat) {
+      throw new InvalidSubscriptionDataError('Price per seat not configured');
+    }
+
+    const startsAt = params.startsAt ?? new Date();
+    return new SeatBasedSubscription({
+      orgId: params.orgId,
+      noOfSeats,
+      renewalCycle: RenewalCycle.YEARLY,
+      pricePerSeat,
+      renewalCycleAnchor: startsAt,
+      startsAt,
+      billingInfo: this.buildBillingInfo(params),
+    });
+  }
+
+  private async validateSeatCount(
+    orgId: UUID,
+    requestingUserId: User['id'],
+    noOfSeats: number,
+  ): Promise<void> {
+    const [invitesResult, usersResult] = await Promise.all([
+      this.getInvitesByOrgUseCase.execute(
+        new GetInvitesByOrgQuery({
+          orgId,
+          requestingUserId,
+          onlyOpen: true,
+        }),
+      ),
+      this.findUsersByOrgIdUseCase.execute(
+        new FindUsersByOrgIdQuery({
+          orgId,
+          pagination: { limit: 1000, offset: 0 },
+        }),
+      ),
+    ]);
+    const openInvitesCount = invitesResult.total ?? invitesResult.data.length;
+    if (
+      openInvitesCount + (usersResult.total ?? usersResult.data.length) >
+      noOfSeats
+    ) {
+      this.logger.warn('Too many used seats', {
+        orgId,
+        openInvites: openInvitesCount,
+      });
+      throw new TooManyUsedSeatsError({
+        orgId,
+        openInvites: openInvitesCount,
+      });
+    }
+  }
+
+  private buildBillingInfo(
+    params: BuildSubscriptionParams,
+  ): SubscriptionBillingInfo {
+    return new SubscriptionBillingInfo({
+      companyName: params.companyName,
+      subText: params.subText,
+      street: params.street,
+      houseNumber: params.houseNumber,
+      postalCode: params.postalCode,
+      city: params.city,
+      country: params.country,
+      vatNumber: params.vatNumber,
+    });
+  }
+}

--- a/ayunis-core-backend/src/iam/subscriptions/application/use-cases/change-subscription/change-subscription.command.ts
+++ b/ayunis-core-backend/src/iam/subscriptions/application/use-cases/change-subscription/change-subscription.command.ts
@@ -1,0 +1,62 @@
+import type { UUID } from 'crypto';
+import { SubscriptionType } from '../../../domain/value-objects/subscription-type.enum';
+import type { OldSubscriptionDisposition } from '../../../domain/value-objects/old-subscription-disposition.enum';
+
+/**
+ * Replace an organization's current subscription with a new one. The current
+ * subscription is ended according to {@link disposition} (cancelled or deleted)
+ * and a brand-new subscription is created with the supplied data — this is the
+ * only correct way to change subscription type, since the type is a TypeORM STI
+ * discriminator and cannot be mutated in place.
+ */
+export class ChangeSubscriptionCommand {
+  public readonly orgId: UUID;
+  public readonly requestingUserId: UUID;
+  public readonly disposition: OldSubscriptionDisposition;
+  public readonly type: SubscriptionType;
+  public readonly noOfSeats?: number;
+  public readonly monthlyCredits?: number;
+  public readonly companyName: string;
+  public readonly subText?: string;
+  public readonly street: string;
+  public readonly houseNumber: string;
+  public readonly postalCode: string;
+  public readonly city: string;
+  public readonly country: string;
+  public readonly vatNumber?: string;
+  public readonly startsAt?: Date;
+
+  constructor(params: {
+    orgId: UUID;
+    requestingUserId: UUID;
+    disposition: OldSubscriptionDisposition;
+    type?: SubscriptionType;
+    noOfSeats?: number;
+    monthlyCredits?: number;
+    companyName: string;
+    subText?: string;
+    street: string;
+    houseNumber: string;
+    postalCode: string;
+    city: string;
+    country: string;
+    vatNumber?: string;
+    startsAt?: Date;
+  }) {
+    this.orgId = params.orgId;
+    this.requestingUserId = params.requestingUserId;
+    this.disposition = params.disposition;
+    this.type = params.type ?? SubscriptionType.SEAT_BASED;
+    this.noOfSeats = params.noOfSeats;
+    this.monthlyCredits = params.monthlyCredits;
+    this.companyName = params.companyName;
+    this.subText = params.subText;
+    this.street = params.street;
+    this.houseNumber = params.houseNumber;
+    this.postalCode = params.postalCode;
+    this.city = params.city;
+    this.country = params.country;
+    this.vatNumber = params.vatNumber;
+    this.startsAt = params.startsAt;
+  }
+}

--- a/ayunis-core-backend/src/iam/subscriptions/application/use-cases/change-subscription/change-subscription.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/subscriptions/application/use-cases/change-subscription/change-subscription.use-case.spec.ts
@@ -1,0 +1,291 @@
+import type { TestingModule } from '@nestjs/testing';
+import { Test } from '@nestjs/testing';
+import { Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { randomUUID } from 'crypto';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { Paginated } from 'src/common/pagination/paginated.entity';
+import { ChangeSubscriptionUseCase } from './change-subscription.use-case';
+import { ChangeSubscriptionCommand } from './change-subscription.command';
+import { SubscriptionRepository } from '../../ports/subscription.repository';
+import { SubscriptionFactory } from '../../services/subscription-factory.service';
+import { GetInvitesByOrgUseCase } from 'src/iam/invites/application/use-cases/get-invites-by-org/get-invites-by-org.use-case';
+import { FindUsersByOrgIdUseCase } from 'src/iam/users/application/use-cases/find-users-by-org-id/find-users-by-org-id.use-case';
+import { ContextService } from 'src/common/context/services/context.service';
+import { SeatBasedSubscription } from 'src/iam/subscriptions/domain/seat-based-subscription.entity';
+import { UsageBasedSubscription } from 'src/iam/subscriptions/domain/usage-based-subscription.entity';
+import { SubscriptionType } from 'src/iam/subscriptions/domain/value-objects/subscription-type.enum';
+import { OldSubscriptionDisposition } from 'src/iam/subscriptions/domain/value-objects/old-subscription-disposition.enum';
+import { RenewalCycle } from 'src/iam/subscriptions/domain/value-objects/renewal-cycle.enum';
+import { SubscriptionBillingInfo } from 'src/iam/subscriptions/domain/subscription-billing-info.entity';
+import { SystemRole } from 'src/iam/users/domain/value-objects/system-role.enum';
+import { UserRole } from 'src/iam/users/domain/value-objects/role.object';
+import {
+  SubscriptionNotFoundError,
+  TooManyUsedSeatsError,
+} from '../../subscription.errors';
+import type { Subscription } from 'src/iam/subscriptions/domain/subscription.entity';
+import { SubscriptionCreatedEvent } from '../../events/subscription-created.event';
+import { SubscriptionCancelledEvent } from '../../events/subscription-cancelled.event';
+import type { ReplaceSubscriptionParams } from '../../ports/subscription.repository';
+
+describe('ChangeSubscriptionUseCase', () => {
+  let useCase: ChangeSubscriptionUseCase;
+  let subscriptionRepository: jest.Mocked<SubscriptionRepository>;
+  let getInvitesByOrgUseCase: jest.Mocked<GetInvitesByOrgUseCase>;
+  let findUsersByOrgIdUseCase: jest.Mocked<FindUsersByOrgIdUseCase>;
+  let configService: jest.Mocked<ConfigService>;
+  let contextService: jest.Mocked<ContextService>;
+  let eventEmitter: jest.Mocked<Pick<EventEmitter2, 'emitAsync'>>;
+
+  const orgId = randomUUID();
+  const requestingUserId = randomUUID();
+
+  const baseBillingParams = {
+    companyName: 'Gemeinde Musterstadt',
+    street: 'Hauptstraße',
+    houseNumber: '1',
+    postalCode: '12345',
+    city: 'Musterstadt',
+    country: 'DE',
+  };
+
+  function billingInfo(): SubscriptionBillingInfo {
+    return new SubscriptionBillingInfo(baseBillingParams);
+  }
+
+  function existingSeatBased(): SeatBasedSubscription {
+    return new SeatBasedSubscription({
+      orgId,
+      noOfSeats: 5,
+      pricePerSeat: 99.99,
+      renewalCycle: RenewalCycle.YEARLY,
+      renewalCycleAnchor: new Date('2026-01-01T00:00:00.000Z'),
+      startsAt: new Date('2026-01-01T00:00:00.000Z'),
+      billingInfo: billingInfo(),
+    });
+  }
+
+  beforeAll(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ChangeSubscriptionUseCase,
+        SubscriptionFactory,
+        {
+          provide: SubscriptionRepository,
+          useValue: {
+            findLatestByOrgId: jest.fn(),
+            replace: jest.fn((params: ReplaceSubscriptionParams) =>
+              Promise.resolve(params.newSubscription),
+            ),
+          },
+        },
+        { provide: GetInvitesByOrgUseCase, useValue: { execute: jest.fn() } },
+        { provide: FindUsersByOrgIdUseCase, useValue: { execute: jest.fn() } },
+        {
+          provide: EventEmitter2,
+          useValue: { emitAsync: jest.fn().mockResolvedValue([]) },
+        },
+        { provide: ConfigService, useValue: { get: jest.fn() } },
+        { provide: ContextService, useValue: { get: jest.fn() } },
+      ],
+    }).compile();
+
+    useCase = module.get(ChangeSubscriptionUseCase);
+    subscriptionRepository = module.get(SubscriptionRepository);
+    getInvitesByOrgUseCase = module.get(GetInvitesByOrgUseCase);
+    findUsersByOrgIdUseCase = module.get(FindUsersByOrgIdUseCase);
+    configService = module.get(ConfigService);
+    contextService = module.get(ContextService);
+    eventEmitter = module.get(EventEmitter2);
+
+    jest.spyOn(Logger.prototype, 'log').mockImplementation();
+    jest.spyOn(Logger.prototype, 'debug').mockImplementation();
+    jest.spyOn(Logger.prototype, 'warn').mockImplementation();
+    jest.spyOn(Logger.prototype, 'error').mockImplementation();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  function setupSuperAdminContext(): void {
+    contextService.get.mockImplementation(((key: string) => {
+      if (key === 'systemRole') return SystemRole.SUPER_ADMIN;
+      if (key === 'role') return UserRole.USER;
+      if (key === 'orgId') return randomUUID();
+      return undefined;
+    }) as never);
+  }
+
+  function mockCurrentSubscription(subscription: Subscription): void {
+    subscriptionRepository.findLatestByOrgId.mockResolvedValue(subscription);
+  }
+
+  function mockInvitesAndUsers(openInvites: number, userCount: number): void {
+    getInvitesByOrgUseCase.execute.mockResolvedValue(
+      new Paginated({ data: [], limit: 1000, offset: 0, total: openInvites }),
+    );
+    findUsersByOrgIdUseCase.execute.mockResolvedValue(
+      new Paginated({ data: [], limit: 1000, offset: 0, total: userCount }),
+    );
+  }
+
+  function seatToUsageCommand(
+    disposition: OldSubscriptionDisposition,
+  ): ChangeSubscriptionCommand {
+    return new ChangeSubscriptionCommand({
+      orgId,
+      requestingUserId,
+      disposition,
+      type: SubscriptionType.USAGE_BASED,
+      monthlyCredits: 1000,
+      ...baseBillingParams,
+    });
+  }
+
+  describe('seat-based → usage-based', () => {
+    it('replaces with a usage-based subscription and emits created + cancelled on CANCEL', async () => {
+      setupSuperAdminContext();
+      mockCurrentSubscription(existingSeatBased());
+
+      const result = await useCase.execute(
+        seatToUsageCommand(OldSubscriptionDisposition.CANCEL),
+      );
+
+      expect(result).toBeInstanceOf(UsageBasedSubscription);
+      expect((result as UsageBasedSubscription).monthlyCredits).toBe(1000);
+
+      const replaceArg = subscriptionRepository.replace.mock.calls[0][0];
+      expect(replaceArg.disposition).toBe(OldSubscriptionDisposition.CANCEL);
+      expect(replaceArg.newSubscription).toBeInstanceOf(UsageBasedSubscription);
+
+      const emittedEvents = eventEmitter.emitAsync.mock.calls.map((c) => c[0]);
+      expect(emittedEvents).toContain(SubscriptionCancelledEvent.EVENT_NAME);
+      expect(emittedEvents).toContain(SubscriptionCreatedEvent.EVENT_NAME);
+
+      // The cancelled event must carry a cancelledAt matching the now-persisted
+      // soft-cancellation, not the null it had before replace().
+      const cancelledEvent = eventEmitter.emitAsync.mock.calls.find(
+        (c) => c[0] === SubscriptionCancelledEvent.EVENT_NAME,
+      )?.[1] as SubscriptionCancelledEvent;
+      expect(cancelledEvent.payload.cancelledAt).toBeInstanceOf(Date);
+    });
+
+    it('does NOT emit cancelled on DELETE, only created', async () => {
+      setupSuperAdminContext();
+      mockCurrentSubscription(existingSeatBased());
+
+      await useCase.execute(
+        seatToUsageCommand(OldSubscriptionDisposition.DELETE),
+      );
+
+      const replaceArg = subscriptionRepository.replace.mock.calls[0][0];
+      expect(replaceArg.disposition).toBe(OldSubscriptionDisposition.DELETE);
+
+      const emittedEvents = eventEmitter.emitAsync.mock.calls.map((c) => c[0]);
+      expect(emittedEvents).not.toContain(
+        SubscriptionCancelledEvent.EVENT_NAME,
+      );
+      expect(emittedEvents).toContain(SubscriptionCreatedEvent.EVENT_NAME);
+    });
+
+    it('passes the current subscription id as the one to replace', async () => {
+      setupSuperAdminContext();
+      const current = existingSeatBased();
+      mockCurrentSubscription(current);
+
+      await useCase.execute(
+        seatToUsageCommand(OldSubscriptionDisposition.CANCEL),
+      );
+
+      expect(
+        subscriptionRepository.replace.mock.calls[0][0].oldSubscriptionId,
+      ).toBe(current.id);
+    });
+  });
+
+  describe('usage-based → seat-based', () => {
+    function existingUsageBased(): UsageBasedSubscription {
+      return new UsageBasedSubscription({
+        orgId,
+        monthlyCredits: 500,
+        startsAt: new Date('2026-01-01T00:00:00.000Z'),
+        billingInfo: billingInfo(),
+      });
+    }
+
+    it('replaces with a seat-based subscription using configured price', async () => {
+      setupSuperAdminContext();
+      mockCurrentSubscription(existingUsageBased());
+      mockInvitesAndUsers(0, 2);
+      configService.get.mockReturnValue(99.99);
+
+      const command = new ChangeSubscriptionCommand({
+        orgId,
+        requestingUserId,
+        disposition: OldSubscriptionDisposition.CANCEL,
+        type: SubscriptionType.SEAT_BASED,
+        noOfSeats: 10,
+        ...baseBillingParams,
+      });
+
+      const result = await useCase.execute(command);
+
+      expect(result).toBeInstanceOf(SeatBasedSubscription);
+      expect((result as SeatBasedSubscription).noOfSeats).toBe(10);
+      expect((result as SeatBasedSubscription).pricePerSeat).toBe(99.99);
+    });
+  });
+
+  describe('validation happens before mutating the old subscription', () => {
+    it('throws TooManyUsedSeatsError and never calls replace', async () => {
+      setupSuperAdminContext();
+      mockCurrentSubscription(existingSeatBased());
+      mockInvitesAndUsers(3, 4); // 7 used > 5 seats
+      configService.get.mockReturnValue(99.99);
+
+      const command = new ChangeSubscriptionCommand({
+        orgId,
+        requestingUserId,
+        disposition: OldSubscriptionDisposition.DELETE,
+        type: SubscriptionType.SEAT_BASED,
+        noOfSeats: 5,
+        ...baseBillingParams,
+      });
+
+      await expect(useCase.execute(command)).rejects.toThrow(
+        TooManyUsedSeatsError,
+      );
+      expect(subscriptionRepository.replace).not.toHaveBeenCalled();
+      expect(eventEmitter.emitAsync).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('replaceable subscription selection', () => {
+    it('throws SubscriptionNotFoundError when no subscription exists', async () => {
+      setupSuperAdminContext();
+      subscriptionRepository.findLatestByOrgId.mockResolvedValue(null);
+
+      await expect(
+        useCase.execute(seatToUsageCommand(OldSubscriptionDisposition.CANCEL)),
+      ).rejects.toThrow(SubscriptionNotFoundError);
+      expect(subscriptionRepository.replace).not.toHaveBeenCalled();
+    });
+
+    it('replaces the latest subscription even when it is already cancelled', async () => {
+      setupSuperAdminContext();
+      const cancelled = existingSeatBased();
+      cancelled.cancelledAt = new Date();
+      mockCurrentSubscription(cancelled);
+
+      await useCase.execute(
+        seatToUsageCommand(OldSubscriptionDisposition.CANCEL),
+      );
+
+      expect(
+        subscriptionRepository.replace.mock.calls[0][0].oldSubscriptionId,
+      ).toBe(cancelled.id);
+    });
+  });
+});

--- a/ayunis-core-backend/src/iam/subscriptions/application/use-cases/change-subscription/change-subscription.use-case.ts
+++ b/ayunis-core-backend/src/iam/subscriptions/application/use-cases/change-subscription/change-subscription.use-case.ts
@@ -1,0 +1,131 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { ChangeSubscriptionCommand } from './change-subscription.command';
+import { SubscriptionRepository } from '../../ports/subscription.repository';
+import { Subscription } from 'src/iam/subscriptions/domain/subscription.entity';
+import { OldSubscriptionDisposition } from 'src/iam/subscriptions/domain/value-objects/old-subscription-disposition.enum';
+import {
+  SubscriptionNotFoundError,
+  UnexpectedSubscriptionError,
+} from '../../subscription.errors';
+import { ApplicationError } from 'src/common/errors/base.error';
+import { SubscriptionCreatedEvent } from '../../events/subscription-created.event';
+import { SubscriptionCancelledEvent } from '../../events/subscription-cancelled.event';
+import { toSubscriptionEventData } from '../../mappers/to-subscription-event-data.mapper';
+import { ContextService } from 'src/common/context/services/context.service';
+import { validateSubscriptionAccess } from '../../util/validate-subscription-access';
+import { SubscriptionFactory } from '../../services/subscription-factory.service';
+
+@Injectable()
+export class ChangeSubscriptionUseCase {
+  private readonly logger = new Logger(ChangeSubscriptionUseCase.name);
+
+  constructor(
+    private readonly subscriptionRepository: SubscriptionRepository,
+    private readonly subscriptionFactory: SubscriptionFactory,
+    private readonly eventEmitter: EventEmitter2,
+    private readonly contextService: ContextService,
+  ) {}
+
+  async execute(command: ChangeSubscriptionCommand): Promise<Subscription> {
+    this.logger.log('Changing subscription', {
+      orgId: command.orgId,
+      type: command.type,
+      disposition: command.disposition,
+    });
+
+    try {
+      validateSubscriptionAccess(
+        this.contextService,
+        command.requestingUserId,
+        command.orgId,
+      );
+
+      const current = await this.findReplaceableSubscription(command.orgId);
+
+      // Build and validate the new subscription BEFORE touching the old one,
+      // so a validation failure (e.g. too few seats) leaves the org untouched.
+      const newSubscription = await this.subscriptionFactory.build(command);
+
+      const createdSubscription = await this.subscriptionRepository.replace({
+        oldSubscriptionId: current.id,
+        disposition: command.disposition,
+        newSubscription,
+      });
+
+      // Reflect the soft-cancellation on the in-memory entity so the emitted
+      // SubscriptionCancelledEvent carries a cancelledAt matching the persisted
+      // row (mirrors CancelSubscriptionUseCase). Preserve an existing timestamp
+      // when the subscription was already cancelled.
+      if (
+        command.disposition === OldSubscriptionDisposition.CANCEL &&
+        !current.cancelledAt
+      ) {
+        current.cancelledAt = new Date();
+      }
+
+      this.emitEvents(command, current, createdSubscription);
+
+      return createdSubscription;
+    } catch (error) {
+      if (error instanceof ApplicationError) {
+        throw error;
+      }
+      this.logger.error('Subscription change failed', {
+        error: error instanceof Error ? error.message : 'Unknown error',
+        orgId: command.orgId,
+        requestingUserId: command.requestingUserId,
+      });
+      throw new UnexpectedSubscriptionError(
+        'Unexpected error during subscription change',
+        { error: error as Error },
+      );
+    }
+  }
+
+  private async findReplaceableSubscription(
+    orgId: Subscription['orgId'],
+  ): Promise<Subscription> {
+    // Target the org's latest subscription — the exact one the super-admin UI
+    // displays (and offers "Change" on). It may be active, cancelled, or
+    // scheduled for the future; any of those can be replaced.
+    const subscription =
+      await this.subscriptionRepository.findLatestByOrgId(orgId);
+    if (!subscription) {
+      this.logger.warn('No subscription to change', { orgId });
+      throw new SubscriptionNotFoundError(orgId);
+    }
+    return subscription;
+  }
+
+  private emitEvents(
+    command: ChangeSubscriptionCommand,
+    oldSubscription: Subscription,
+    newSubscription: Subscription,
+  ): void {
+    if (command.disposition === OldSubscriptionDisposition.CANCEL) {
+      this.safeEmit(
+        SubscriptionCancelledEvent.EVENT_NAME,
+        new SubscriptionCancelledEvent(
+          command.orgId,
+          toSubscriptionEventData(oldSubscription),
+        ),
+      );
+    }
+    this.safeEmit(
+      SubscriptionCreatedEvent.EVENT_NAME,
+      new SubscriptionCreatedEvent(
+        command.orgId,
+        toSubscriptionEventData(newSubscription),
+      ),
+    );
+  }
+
+  private safeEmit(eventName: string, event: object): void {
+    this.eventEmitter.emitAsync(eventName, event).catch((err: unknown) => {
+      this.logger.error(`Failed to emit ${eventName}`, {
+        error: err instanceof Error ? err.message : 'Unknown error',
+      });
+    });
+  }
+}

--- a/ayunis-core-backend/src/iam/subscriptions/application/use-cases/create-subscription/create-subscription.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/subscriptions/application/use-cases/create-subscription/create-subscription.use-case.spec.ts
@@ -10,6 +10,7 @@ import { GetInvitesByOrgUseCase } from 'src/iam/invites/application/use-cases/ge
 import { FindUsersByOrgIdUseCase } from 'src/iam/users/application/use-cases/find-users-by-org-id/find-users-by-org-id.use-case';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { ContextService } from 'src/common/context/services/context.service';
+import { SubscriptionFactory } from '../../services/subscription-factory.service';
 import { SeatBasedSubscription } from 'src/iam/subscriptions/domain/seat-based-subscription.entity';
 import { UsageBasedSubscription } from 'src/iam/subscriptions/domain/usage-based-subscription.entity';
 import { SubscriptionType } from 'src/iam/subscriptions/domain/value-objects/subscription-type.enum';
@@ -49,6 +50,7 @@ describe('CreateSubscriptionUseCase', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         CreateSubscriptionUseCase,
+        SubscriptionFactory,
         {
           provide: SubscriptionRepository,
           useValue: {

--- a/ayunis-core-backend/src/iam/subscriptions/application/use-cases/create-subscription/create-subscription.use-case.ts
+++ b/ayunis-core-backend/src/iam/subscriptions/application/use-cases/create-subscription/create-subscription.use-case.ts
@@ -3,29 +3,17 @@ import { EventEmitter2 } from '@nestjs/event-emitter';
 import { CreateSubscriptionCommand } from './create-subscription.command';
 import { SubscriptionRepository } from '../../ports/subscription.repository';
 import { Subscription } from 'src/iam/subscriptions/domain/subscription.entity';
-import { SeatBasedSubscription } from 'src/iam/subscriptions/domain/seat-based-subscription.entity';
-import { UsageBasedSubscription } from 'src/iam/subscriptions/domain/usage-based-subscription.entity';
-import { SubscriptionType } from 'src/iam/subscriptions/domain/value-objects/subscription-type.enum';
-import { ConfigService } from '@nestjs/config';
-import { RenewalCycle } from 'src/iam/subscriptions/domain/value-objects/renewal-cycle.enum';
 import {
   SubscriptionAlreadyExistsError,
-  InvalidSubscriptionDataError,
   UnexpectedSubscriptionError,
-  TooManyUsedSeatsError,
 } from '../../subscription.errors';
-import { SubscriptionBillingInfo } from 'src/iam/subscriptions/domain/subscription-billing-info.entity';
 
 import { ApplicationError } from 'src/common/errors/base.error';
-import type { User } from 'src/iam/users/domain/user.entity';
-import { GetInvitesByOrgQuery } from 'src/iam/invites/application/use-cases/get-invites-by-org/get-invites-by-org.query';
-import { FindUsersByOrgIdQuery } from 'src/iam/users/application/use-cases/find-users-by-org-id/find-users-by-org-id.query';
-import { GetInvitesByOrgUseCase } from 'src/iam/invites/application/use-cases/get-invites-by-org/get-invites-by-org.use-case';
-import { FindUsersByOrgIdUseCase } from 'src/iam/users/application/use-cases/find-users-by-org-id/find-users-by-org-id.use-case';
 import { SubscriptionCreatedEvent } from '../../events/subscription-created.event';
 import { toSubscriptionEventData } from '../../mappers/to-subscription-event-data.mapper';
 import { ContextService } from 'src/common/context/services/context.service';
 import { validateSubscriptionAccess } from '../../util/validate-subscription-access';
+import { SubscriptionFactory } from '../../services/subscription-factory.service';
 
 @Injectable()
 export class CreateSubscriptionUseCase {
@@ -33,9 +21,7 @@ export class CreateSubscriptionUseCase {
 
   constructor(
     private readonly subscriptionRepository: SubscriptionRepository,
-    private readonly configService: ConfigService,
-    private readonly getInvitesByOrgUseCase: GetInvitesByOrgUseCase,
-    private readonly findUsersByOrgIdUseCase: FindUsersByOrgIdUseCase,
+    private readonly subscriptionFactory: SubscriptionFactory,
     private readonly eventEmitter: EventEmitter2,
     private readonly contextService: ContextService,
   ) {}
@@ -50,10 +36,7 @@ export class CreateSubscriptionUseCase {
 
       await this.ensureNoExistingSubscription(command.orgId);
 
-      const subscription =
-        command.type === SubscriptionType.USAGE_BASED
-          ? this.createUsageBasedSubscription(command)
-          : await this.createSeatBasedSubscription(command);
+      const subscription = await this.subscriptionFactory.build(command);
 
       const createdSubscription =
         await this.subscriptionRepository.create(subscription);
@@ -107,119 +90,5 @@ export class CreateSubscriptionUseCase {
       });
       throw new SubscriptionAlreadyExistsError(orgId);
     }
-  }
-
-  private createUsageBasedSubscription(
-    command: CreateSubscriptionCommand,
-  ): UsageBasedSubscription {
-    if (!command.monthlyCredits || command.monthlyCredits <= 0) {
-      throw new InvalidSubscriptionDataError(
-        'Monthly credits must be greater than 0 for usage-based subscriptions',
-      );
-    }
-
-    this.logger.log('Creating usage-based subscription', {
-      orgId: command.orgId,
-      monthlyCredits: command.monthlyCredits,
-    });
-
-    return new UsageBasedSubscription({
-      orgId: command.orgId,
-      monthlyCredits: command.monthlyCredits,
-      startsAt: command.startsAt,
-      billingInfo: this.buildBillingInfo(command),
-    });
-  }
-
-  private async createSeatBasedSubscription(
-    command: CreateSubscriptionCommand,
-  ): Promise<SeatBasedSubscription> {
-    const noOfSeats = command.noOfSeats ?? 1;
-
-    this.logger.log('Creating seat-based subscription', {
-      orgId: command.orgId,
-      noOfSeats,
-    });
-
-    if (noOfSeats <= 0) {
-      throw new InvalidSubscriptionDataError(
-        'Number of seats must be greater than 0',
-      );
-    }
-
-    await this.validateSeatCount(
-      command.orgId,
-      command.requestingUserId,
-      noOfSeats,
-    );
-
-    const pricePerSeat = this.configService.get<number>(
-      'subscriptions.pricePerSeatYearly',
-    );
-    if (!pricePerSeat) {
-      throw new InvalidSubscriptionDataError('Price per seat not configured');
-    }
-
-    const startsAt = command.startsAt ?? new Date();
-    return new SeatBasedSubscription({
-      orgId: command.orgId,
-      noOfSeats,
-      renewalCycle: RenewalCycle.YEARLY,
-      pricePerSeat,
-      renewalCycleAnchor: startsAt,
-      startsAt,
-      billingInfo: this.buildBillingInfo(command),
-    });
-  }
-
-  private async validateSeatCount(
-    orgId: Subscription['orgId'],
-    requestingUserId: User['id'],
-    noOfSeats: number,
-  ): Promise<void> {
-    const [invitesResult, usersResult] = await Promise.all([
-      this.getInvitesByOrgUseCase.execute(
-        new GetInvitesByOrgQuery({
-          orgId,
-          requestingUserId,
-          onlyOpen: true,
-        }),
-      ),
-      this.findUsersByOrgIdUseCase.execute(
-        new FindUsersByOrgIdQuery({
-          orgId,
-          pagination: { limit: 1000, offset: 0 },
-        }),
-      ),
-    ]);
-    const openInvitesCount = invitesResult.total ?? invitesResult.data.length;
-    if (
-      openInvitesCount + (usersResult.total ?? usersResult.data.length) >
-      noOfSeats
-    ) {
-      this.logger.warn('Too many used seats', {
-        orgId,
-        openInvites: openInvitesCount,
-      });
-      throw new TooManyUsedSeatsError({
-        orgId,
-        openInvites: openInvitesCount,
-      });
-    }
-  }
-
-  private buildBillingInfo(
-    command: CreateSubscriptionCommand,
-  ): SubscriptionBillingInfo {
-    return new SubscriptionBillingInfo({
-      companyName: command.companyName,
-      subText: command.subText,
-      street: command.street,
-      houseNumber: command.houseNumber,
-      postalCode: command.postalCode,
-      city: command.city,
-      country: command.country,
-      vatNumber: command.vatNumber,
-    });
   }
 }

--- a/ayunis-core-backend/src/iam/subscriptions/domain/value-objects/old-subscription-disposition.enum.ts
+++ b/ayunis-core-backend/src/iam/subscriptions/domain/value-objects/old-subscription-disposition.enum.ts
@@ -1,0 +1,13 @@
+/**
+ * How the current subscription is handled when a super admin changes an
+ * organization's subscription (the type/data cannot be mutated in place — the
+ * current subscription is ended and a new one is created).
+ *
+ * - CANCEL: soft-cancel the current subscription (sets cancelledAt), keeping it
+ *   in history for billing/audit purposes.
+ * - DELETE: hard-delete the current subscription row, leaving no record of it.
+ */
+export enum OldSubscriptionDisposition {
+  CANCEL = 'CANCEL',
+  DELETE = 'DELETE',
+}

--- a/ayunis-core-backend/src/iam/subscriptions/infrastructure/persistence/local/local-subscriptions.repository.ts
+++ b/ayunis-core-backend/src/iam/subscriptions/infrastructure/persistence/local/local-subscriptions.repository.ts
@@ -1,9 +1,13 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { DataSource, Repository } from 'typeorm';
+import { DataSource, EntityManager, IsNull, Repository } from 'typeorm';
 import { UUID } from 'crypto';
-import { SubscriptionRepository } from 'src/iam/subscriptions/application/ports/subscription.repository';
+import {
+  ReplaceSubscriptionParams,
+  SubscriptionRepository,
+} from 'src/iam/subscriptions/application/ports/subscription.repository';
 import { Subscription } from 'src/iam/subscriptions/domain/subscription.entity';
+import { OldSubscriptionDisposition } from 'src/iam/subscriptions/domain/value-objects/old-subscription-disposition.enum';
 import {
   SeatBasedSubscriptionRecord,
   SubscriptionRecord,
@@ -81,14 +85,9 @@ export class LocalSubscriptionsRepository extends SubscriptionRepository {
 
       // Save subscription and billing info in a transaction to guarantee
       // the subscription row exists before the billing info FK references it.
-      await this.dataSource.transaction(async (manager) => {
-        const billingInfo = record.billingInfo;
-        record.billingInfo =
-          undefined as unknown as SubscriptionBillingInfoRecord;
-        await manager.save(SubscriptionRecord, record);
-        await manager.save(SubscriptionBillingInfoRecord, billingInfo);
-        record.billingInfo = billingInfo;
-      });
+      await this.dataSource.transaction((manager) =>
+        this.insertSubscriptionWithBilling(manager, record),
+      );
 
       this.logger.log(`Created subscription with id ${subscription.id}`);
       return this.subscriptionMapper.toDomain(record);
@@ -99,6 +98,55 @@ export class LocalSubscriptionsRepository extends SubscriptionRepository {
       );
       throw error;
     }
+  }
+
+  async replace(params: ReplaceSubscriptionParams): Promise<Subscription> {
+    const { oldSubscriptionId, disposition, newSubscription } = params;
+    try {
+      const record = this.subscriptionMapper.toRecord(newSubscription);
+
+      // End the old subscription and insert the new one atomically so the org
+      // is never left without a subscription (or with two active ones).
+      await this.dataSource.transaction(async (manager) => {
+        if (disposition === OldSubscriptionDisposition.DELETE) {
+          await manager.delete(SubscriptionRecord, oldSubscriptionId);
+        } else {
+          // Only stamp cancelledAt when not already cancelled, so replacing an
+          // already-cancelled subscription preserves its original cancellation
+          // timestamp (kept for billing/audit history).
+          await manager.update(
+            SubscriptionRecord,
+            { id: oldSubscriptionId, cancelledAt: IsNull() },
+            { cancelledAt: new Date() },
+          );
+        }
+        await this.insertSubscriptionWithBilling(manager, record);
+      });
+
+      this.logger.log(
+        `Replaced subscription ${oldSubscriptionId} (${disposition}) with ${newSubscription.id}`,
+      );
+      return this.subscriptionMapper.toDomain(record);
+    } catch (error) {
+      this.logger.error(
+        `Failed to replace subscription ${oldSubscriptionId}`,
+        error,
+      );
+      throw error;
+    }
+  }
+
+  // Persists a subscription record and its billing info, ensuring the
+  // subscription row exists before the billing-info FK references it.
+  private async insertSubscriptionWithBilling(
+    manager: EntityManager,
+    record: SubscriptionRecord,
+  ): Promise<void> {
+    const billingInfo = record.billingInfo;
+    record.billingInfo = undefined as unknown as SubscriptionBillingInfoRecord;
+    await manager.save(SubscriptionRecord, record);
+    await manager.save(SubscriptionBillingInfoRecord, billingInfo);
+    record.billingInfo = billingInfo;
   }
 
   async update(subscription: Subscription): Promise<Subscription> {

--- a/ayunis-core-backend/src/iam/subscriptions/presenters/http/dto/change-subscription-request.dto.ts
+++ b/ayunis-core-backend/src/iam/subscriptions/presenters/http/dto/change-subscription-request.dto.ts
@@ -1,0 +1,15 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsEnum } from 'class-validator';
+import { CreateSubscriptionRequestDto } from './create-subscription-request.dto';
+import { OldSubscriptionDisposition } from '../../../domain/value-objects/old-subscription-disposition.enum';
+
+export class ChangeSubscriptionRequestDto extends CreateSubscriptionRequestDto {
+  @ApiProperty({
+    description:
+      'How to handle the current subscription. CANCEL soft-cancels it (kept in history); DELETE removes it entirely. A new subscription is created with the provided data either way.',
+    enum: OldSubscriptionDisposition,
+    example: OldSubscriptionDisposition.CANCEL,
+  })
+  @IsEnum(OldSubscriptionDisposition)
+  oldSubscriptionDisposition: OldSubscriptionDisposition;
+}

--- a/ayunis-core-backend/src/iam/subscriptions/presenters/http/super-admin-subscription.mappers.ts
+++ b/ayunis-core-backend/src/iam/subscriptions/presenters/http/super-admin-subscription.mappers.ts
@@ -1,0 +1,59 @@
+import type { UUID } from 'crypto';
+import { CreateSubscriptionCommand } from '../../application/use-cases/create-subscription/create-subscription.command';
+import { ChangeSubscriptionCommand } from '../../application/use-cases/change-subscription/change-subscription.command';
+import type { CreateSubscriptionRequestDto } from './dto/create-subscription-request.dto';
+import type { ChangeSubscriptionRequestDto } from './dto/change-subscription-request.dto';
+import type { BillingInfoFieldsDto } from './dto/billing-info-fields.dto';
+
+function parseStartsAt(value?: string): Date | undefined {
+  return value ? new Date(value) : undefined;
+}
+
+export function toBillingInfoParams(dto: BillingInfoFieldsDto) {
+  return {
+    companyName: dto.companyName,
+    street: dto.street,
+    houseNumber: dto.houseNumber,
+    postalCode: dto.postalCode,
+    city: dto.city,
+    country: dto.country,
+    vatNumber: dto.vatNumber,
+  };
+}
+
+function toBillingFields(dto: CreateSubscriptionRequestDto) {
+  return { ...toBillingInfoParams(dto), subText: dto.subText };
+}
+
+export function toCreateCommand(
+  orgId: UUID,
+  userId: UUID,
+  dto: CreateSubscriptionRequestDto,
+): CreateSubscriptionCommand {
+  return new CreateSubscriptionCommand({
+    orgId,
+    requestingUserId: userId,
+    ...toBillingFields(dto),
+    type: dto.type,
+    noOfSeats: dto.noOfSeats,
+    monthlyCredits: dto.monthlyCredits,
+    startsAt: parseStartsAt(dto.startsAt),
+  });
+}
+
+export function toChangeCommand(
+  orgId: UUID,
+  userId: UUID,
+  dto: ChangeSubscriptionRequestDto,
+): ChangeSubscriptionCommand {
+  return new ChangeSubscriptionCommand({
+    orgId,
+    requestingUserId: userId,
+    ...toBillingFields(dto),
+    disposition: dto.oldSubscriptionDisposition,
+    type: dto.type,
+    noOfSeats: dto.noOfSeats,
+    monthlyCredits: dto.monthlyCredits,
+    startsAt: parseStartsAt(dto.startsAt),
+  });
+}

--- a/ayunis-core-backend/src/iam/subscriptions/presenters/http/super-admin-subscriptions.controller.ts
+++ b/ayunis-core-backend/src/iam/subscriptions/presenters/http/super-admin-subscriptions.controller.ts
@@ -16,7 +16,6 @@ import {
   ApiResponse,
   ApiExtraModels,
   getSchemaPath,
-  ApiParam,
   ApiUnauthorizedResponse,
   ApiInternalServerErrorResponse,
 } from '@nestjs/swagger';
@@ -28,7 +27,7 @@ import {
 import { GetLatestSubscriptionUseCase } from '../../application/use-cases/get-latest-subscription/get-latest-subscription.use-case';
 import { GetLatestSubscriptionQuery } from '../../application/use-cases/get-latest-subscription/get-latest-subscription.query';
 import { CreateSubscriptionUseCase } from '../../application/use-cases/create-subscription/create-subscription.use-case';
-import { CreateSubscriptionCommand } from '../../application/use-cases/create-subscription/create-subscription.command';
+import { ChangeSubscriptionUseCase } from '../../application/use-cases/change-subscription/change-subscription.use-case';
 import { CancelSubscriptionUseCase } from '../../application/use-cases/cancel-subscription/cancel-subscription.use-case';
 import { CancelSubscriptionCommand } from '../../application/use-cases/cancel-subscription/cancel-subscription.command';
 import { UncancelSubscriptionUseCase } from '../../application/use-cases/uncancel-subscription/uncancel-subscription.use-case';
@@ -38,8 +37,15 @@ import {
   SubscriptionResponseDtoNullable,
 } from './dto/subscription-response.dto';
 import { CreateSubscriptionRequestDto } from './dto/create-subscription-request.dto';
+import { ChangeSubscriptionRequestDto } from './dto/change-subscription-request.dto';
 import { ActiveSubscriptionResponseDto } from './dto/active-subscription-response.dto';
 import { SubscriptionResponseMapper } from './mappers/subscription-response.mapper';
+import { OrgIdParam } from './super-admin-subscriptions.decorators';
+import {
+  toCreateCommand,
+  toChangeCommand,
+  toBillingInfoParams,
+} from './super-admin-subscription.mappers';
 
 import { UpdateSeatsCommand } from '../../application/use-cases/update-seats/update-seats.command';
 import { UpdateSeatsDto } from './dto/update-seats.dto';
@@ -57,6 +63,10 @@ import { SystemRole } from 'src/iam/users/domain/value-objects/system-role.enum'
 import { SubscriptionNotFoundError } from '../../application/subscription.errors';
 import { UpdateStartDateDto } from './dto/update-start-date.dto';
 
+const UNAUTHORIZED_DESCRIPTION =
+  'User not authenticated or not authorized as super admin';
+const INTERNAL_ERROR_DESCRIPTION = 'Internal server error';
+
 @ApiTags('Super Admin Subscriptions')
 @Controller('super-admin/subscriptions')
 @SystemRoles(SystemRole.SUPER_ADMIN)
@@ -64,6 +74,7 @@ import { UpdateStartDateDto } from './dto/update-start-date.dto';
   SubscriptionResponseDto,
   SubscriptionResponseDtoNullable,
   CreateSubscriptionRequestDto,
+  ChangeSubscriptionRequestDto,
   ActiveSubscriptionResponseDto,
   UpdateBillingInfoDto,
   UpdateStartDateDto,
@@ -75,6 +86,7 @@ export class SuperAdminSubscriptionsController {
   constructor(
     private readonly getLatestSubscriptionUseCase: GetLatestSubscriptionUseCase,
     private readonly createSubscriptionUseCase: CreateSubscriptionUseCase,
+    private readonly changeSubscriptionUseCase: ChangeSubscriptionUseCase,
     private readonly cancelSubscriptionUseCase: CancelSubscriptionUseCase,
     private readonly uncancelSubscriptionUseCase: UncancelSubscriptionUseCase,
     private readonly subscriptionResponseMapper: SubscriptionResponseMapper,
@@ -91,12 +103,7 @@ export class SuperAdminSubscriptionsController {
     description:
       'Retrieve subscription details for the specified organization. This endpoint is only accessible to super admins.',
   })
-  @ApiParam({
-    name: 'orgId',
-    description: 'Organization ID to get subscription for',
-    format: 'uuid',
-    example: '123e4567-e89b-12d3-a456-426614174000',
-  })
+  @OrgIdParam('Organization ID to get subscription for')
   @ApiResponse({
     status: HttpStatus.OK,
     description: 'Successfully retrieved subscription details',
@@ -104,12 +111,8 @@ export class SuperAdminSubscriptionsController {
       $ref: getSchemaPath(SubscriptionResponseDtoNullable),
     },
   })
-  @ApiUnauthorizedResponse({
-    description: 'User not authenticated or not authorized as super admin',
-  })
-  @ApiInternalServerErrorResponse({
-    description: 'Internal server error',
-  })
+  @ApiUnauthorizedResponse({ description: UNAUTHORIZED_DESCRIPTION })
+  @ApiInternalServerErrorResponse({ description: INTERNAL_ERROR_DESCRIPTION })
   async getSubscription(
     @Param('orgId') orgId: UUID,
     @CurrentUser(UserProperty.ID) userId: UUID,
@@ -146,12 +149,7 @@ export class SuperAdminSubscriptionsController {
     description:
       'Create a new subscription for the specified organization. This endpoint is only accessible to super admins.',
   })
-  @ApiParam({
-    name: 'orgId',
-    description: 'Organization ID to create subscription for',
-    format: 'uuid',
-    example: '123e4567-e89b-12d3-a456-426614174000',
-  })
+  @OrgIdParam('Organization ID to create subscription for')
   @ApiResponse({
     status: HttpStatus.CREATED,
     description: 'Successfully created subscription',
@@ -167,12 +165,8 @@ export class SuperAdminSubscriptionsController {
     status: HttpStatus.CONFLICT,
     description: 'Subscription already exists for this organization',
   })
-  @ApiUnauthorizedResponse({
-    description: 'User not authenticated or not authorized as super admin',
-  })
-  @ApiInternalServerErrorResponse({
-    description: 'Internal server error',
-  })
+  @ApiUnauthorizedResponse({ description: UNAUTHORIZED_DESCRIPTION })
+  @ApiInternalServerErrorResponse({ description: INTERNAL_ERROR_DESCRIPTION })
   async createSubscription(
     @Param('orgId') orgId: UUID,
     @CurrentUser(UserProperty.ID) userId: UUID,
@@ -181,28 +175,46 @@ export class SuperAdminSubscriptionsController {
     this.logger.log(
       `Creating subscription for org ${orgId} by super admin ${userId}`,
     );
-
-    const command = new CreateSubscriptionCommand({
-      orgId,
-      requestingUserId: userId,
-      type: createSubscriptionDto.type,
-      noOfSeats: createSubscriptionDto.noOfSeats,
-      monthlyCredits: createSubscriptionDto.monthlyCredits,
-      companyName: createSubscriptionDto.companyName,
-      subText: createSubscriptionDto.subText,
-      street: createSubscriptionDto.street,
-      houseNumber: createSubscriptionDto.houseNumber,
-      postalCode: createSubscriptionDto.postalCode,
-      city: createSubscriptionDto.city,
-      country: createSubscriptionDto.country,
-      vatNumber: createSubscriptionDto.vatNumber,
-      startsAt: createSubscriptionDto.startsAt
-        ? new Date(createSubscriptionDto.startsAt)
-        : undefined,
-    });
-
-    await this.createSubscriptionUseCase.execute(command);
+    await this.createSubscriptionUseCase.execute(
+      toCreateCommand(orgId, userId, createSubscriptionDto),
+    );
     this.logger.log(`Successfully created subscription for org ${orgId}`);
+  }
+
+  @Post(':orgId/change')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Change an organization subscription (cancel/delete + recreate)',
+    description:
+      'Ends the current subscription (cancelled or deleted, per oldSubscriptionDisposition) and creates a new one with the provided data. This is the only way to change subscription type. Only accessible to super admins.',
+  })
+  @OrgIdParam('Organization ID to change the subscription for')
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'Successfully changed subscription',
+  })
+  @ApiResponse({
+    status: HttpStatus.BAD_REQUEST,
+    description: 'Invalid subscription data provided',
+  })
+  @ApiResponse({
+    status: HttpStatus.NOT_FOUND,
+    description: 'No active subscription found for the organization',
+  })
+  @ApiUnauthorizedResponse({ description: UNAUTHORIZED_DESCRIPTION })
+  @ApiInternalServerErrorResponse({ description: INTERNAL_ERROR_DESCRIPTION })
+  async changeSubscription(
+    @Param('orgId') orgId: UUID,
+    @CurrentUser(UserProperty.ID) userId: UUID,
+    @Body() changeSubscriptionDto: ChangeSubscriptionRequestDto,
+  ): Promise<void> {
+    this.logger.log(
+      `Changing subscription for org ${orgId} by super admin ${userId}`,
+    );
+    await this.changeSubscriptionUseCase.execute(
+      toChangeCommand(orgId, userId, changeSubscriptionDto),
+    );
+    this.logger.log(`Successfully changed subscription for org ${orgId}`);
   }
 
   @Put(':orgId/seats')
@@ -212,12 +224,7 @@ export class SuperAdminSubscriptionsController {
     description:
       'Update the number of seats for the specified organization. This endpoint is only accessible to super admins.',
   })
-  @ApiParam({
-    name: 'orgId',
-    description: 'Organization ID to update seats for',
-    format: 'uuid',
-    example: '123e4567-e89b-12d3-a456-426614174000',
-  })
+  @OrgIdParam('Organization ID to update seats for')
   @ApiResponse({
     status: HttpStatus.NO_CONTENT,
     description: 'Successfully updated seats',
@@ -230,12 +237,8 @@ export class SuperAdminSubscriptionsController {
     status: HttpStatus.NOT_FOUND,
     description: 'No subscription found for the organization',
   })
-  @ApiUnauthorizedResponse({
-    description: 'User not authenticated or not authorized as super admin',
-  })
-  @ApiInternalServerErrorResponse({
-    description: 'Internal server error',
-  })
+  @ApiUnauthorizedResponse({ description: UNAUTHORIZED_DESCRIPTION })
+  @ApiInternalServerErrorResponse({ description: INTERNAL_ERROR_DESCRIPTION })
   async updateSeats(
     @Param('orgId') orgId: UUID,
     @CurrentUser(UserProperty.ID) userId: UUID,
@@ -256,12 +259,7 @@ export class SuperAdminSubscriptionsController {
   @ApiOperation({
     summary: 'Update monthly credits for an organization (super admin)',
   })
-  @ApiParam({
-    name: 'orgId',
-    description: 'Organization ID to update monthly credits for',
-    format: 'uuid',
-    example: '123e4567-e89b-12d3-a456-426614174000',
-  })
+  @OrgIdParam('Organization ID to update monthly credits for')
   @ApiResponse({
     status: HttpStatus.NO_CONTENT,
     description: 'Successfully updated monthly credits',
@@ -275,9 +273,7 @@ export class SuperAdminSubscriptionsController {
     status: HttpStatus.NOT_FOUND,
     description: 'No subscription found for the organization',
   })
-  @ApiUnauthorizedResponse({
-    description: 'User not authenticated or not authorized as super admin',
-  })
+  @ApiUnauthorizedResponse({ description: UNAUTHORIZED_DESCRIPTION })
   async updateMonthlyCredits(
     @Param('orgId') orgId: UUID,
     @CurrentUser(UserProperty.ID) userId: UUID,
@@ -302,12 +298,7 @@ export class SuperAdminSubscriptionsController {
     description:
       'Update the billing information for the specified organization. This endpoint is only accessible to super admins.',
   })
-  @ApiParam({
-    name: 'orgId',
-    description: 'Organization ID to update billing info for',
-    format: 'uuid',
-    example: '123e4567-e89b-12d3-a456-426614174000',
-  })
+  @OrgIdParam('Organization ID to update billing info for')
   @ApiResponse({
     status: HttpStatus.NO_CONTENT,
     description: 'Successfully updated billing information',
@@ -320,12 +311,8 @@ export class SuperAdminSubscriptionsController {
     status: HttpStatus.NOT_FOUND,
     description: 'No subscription found for the organization',
   })
-  @ApiUnauthorizedResponse({
-    description: 'User not authenticated or not authorized as super admin',
-  })
-  @ApiInternalServerErrorResponse({
-    description: 'Internal server error',
-  })
+  @ApiUnauthorizedResponse({ description: UNAUTHORIZED_DESCRIPTION })
+  @ApiInternalServerErrorResponse({ description: INTERNAL_ERROR_DESCRIPTION })
   async updateBillingInfo(
     @Param('orgId') orgId: UUID,
     @CurrentUser(UserProperty.ID) userId: UUID,
@@ -337,15 +324,7 @@ export class SuperAdminSubscriptionsController {
     const command = new UpdateBillingInfoCommand({
       orgId,
       requestingUserId: userId,
-      billingInfo: {
-        companyName: updateBillingInfoDto.companyName,
-        street: updateBillingInfoDto.street,
-        houseNumber: updateBillingInfoDto.houseNumber,
-        postalCode: updateBillingInfoDto.postalCode,
-        city: updateBillingInfoDto.city,
-        country: updateBillingInfoDto.country,
-        vatNumber: updateBillingInfoDto.vatNumber,
-      },
+      billingInfo: toBillingInfoParams(updateBillingInfoDto),
     });
     await this.updateBillingInfoUseCase.execute(command);
     this.logger.log(`Successfully updated billing info for org ${orgId}`);
@@ -358,12 +337,7 @@ export class SuperAdminSubscriptionsController {
     description:
       'Update the start date for the latest subscription of the specified organization. This endpoint is only accessible to super admins.',
   })
-  @ApiParam({
-    name: 'orgId',
-    description: 'Organization ID to update the subscription start date for',
-    format: 'uuid',
-    example: '123e4567-e89b-12d3-a456-426614174000',
-  })
+  @OrgIdParam('Organization ID to update the subscription start date for')
   @ApiResponse({
     status: HttpStatus.NO_CONTENT,
     description: 'Successfully updated subscription start date',
@@ -376,12 +350,8 @@ export class SuperAdminSubscriptionsController {
     status: HttpStatus.NOT_FOUND,
     description: 'No subscription found for the organization',
   })
-  @ApiUnauthorizedResponse({
-    description: 'User not authenticated or not authorized as super admin',
-  })
-  @ApiInternalServerErrorResponse({
-    description: 'Internal server error',
-  })
+  @ApiUnauthorizedResponse({ description: UNAUTHORIZED_DESCRIPTION })
+  @ApiInternalServerErrorResponse({ description: INTERNAL_ERROR_DESCRIPTION })
   async updateStartDate(
     @Param('orgId') orgId: UUID,
     @CurrentUser(UserProperty.ID) userId: UUID,
@@ -410,12 +380,7 @@ export class SuperAdminSubscriptionsController {
     description:
       'Cancel the subscription for the specified organization. This endpoint is only accessible to super admins.',
   })
-  @ApiParam({
-    name: 'orgId',
-    description: 'Organization ID to cancel subscription for',
-    format: 'uuid',
-    example: '123e4567-e89b-12d3-a456-426614174000',
-  })
+  @OrgIdParam('Organization ID to cancel subscription for')
   @ApiResponse({
     status: HttpStatus.NO_CONTENT,
     description: 'Successfully cancelled subscription',
@@ -428,12 +393,8 @@ export class SuperAdminSubscriptionsController {
     status: HttpStatus.CONFLICT,
     description: 'Subscription is already cancelled',
   })
-  @ApiUnauthorizedResponse({
-    description: 'User not authenticated or not authorized as super admin',
-  })
-  @ApiInternalServerErrorResponse({
-    description: 'Internal server error',
-  })
+  @ApiUnauthorizedResponse({ description: UNAUTHORIZED_DESCRIPTION })
+  @ApiInternalServerErrorResponse({ description: INTERNAL_ERROR_DESCRIPTION })
   async cancelSubscription(
     @Param('orgId') orgId: UUID,
     @CurrentUser(UserProperty.ID) userId: UUID,
@@ -457,12 +418,7 @@ export class SuperAdminSubscriptionsController {
     description:
       'Uncancel the subscription for the specified organization. This endpoint is only accessible to super admins.',
   })
-  @ApiParam({
-    name: 'orgId',
-    description: 'Organization ID to uncancel subscription for',
-    format: 'uuid',
-    example: '123e4567-e89b-12d3-a456-426614174000',
-  })
+  @OrgIdParam('Organization ID to uncancel subscription for')
   @ApiResponse({
     status: HttpStatus.NO_CONTENT,
     description: 'Successfully uncancelled subscription',
@@ -475,12 +431,8 @@ export class SuperAdminSubscriptionsController {
     status: HttpStatus.CONFLICT,
     description: 'Subscription is not cancelled',
   })
-  @ApiUnauthorizedResponse({
-    description: 'User not authenticated or not authorized as super admin',
-  })
-  @ApiInternalServerErrorResponse({
-    description: 'Internal server error',
-  })
+  @ApiUnauthorizedResponse({ description: UNAUTHORIZED_DESCRIPTION })
+  @ApiInternalServerErrorResponse({ description: INTERNAL_ERROR_DESCRIPTION })
   async uncancelSubscription(
     @Param('orgId') orgId: UUID,
     @CurrentUser(UserProperty.ID) userId: UUID,

--- a/ayunis-core-backend/src/iam/subscriptions/presenters/http/super-admin-subscriptions.decorators.ts
+++ b/ayunis-core-backend/src/iam/subscriptions/presenters/http/super-admin-subscriptions.decorators.ts
@@ -1,0 +1,18 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiParam } from '@nestjs/swagger';
+
+/**
+ * The `orgId` path parameter documentation shared by every super-admin
+ * subscriptions endpoint. The description varies per endpoint and is passed in
+ * so the generated OpenAPI schema stays identical to the inline form.
+ */
+export function OrgIdParam(description: string): MethodDecorator {
+  return applyDecorators(
+    ApiParam({
+      name: 'orgId',
+      description,
+      format: 'uuid',
+      example: '123e4567-e89b-12d3-a456-426614174000',
+    }),
+  );
+}

--- a/ayunis-core-backend/src/iam/subscriptions/subscriptions.module.ts
+++ b/ayunis-core-backend/src/iam/subscriptions/subscriptions.module.ts
@@ -28,6 +28,8 @@ import { GetMonthlyCreditLimitUseCase } from './application/use-cases/get-monthl
 import { IsUsageBasedSubscriptionUseCase } from './application/use-cases/is-usage-based-subscription/is-usage-based-subscription.use-case';
 import { UpdateStartDateUseCase } from './application/use-cases/update-start-date/update-start-date.use-case';
 import { UpdateMonthlyCreditsUseCase } from './application/use-cases/update-monthly-credits/update-monthly-credits.use-case';
+import { ChangeSubscriptionUseCase } from './application/use-cases/change-subscription/change-subscription.use-case';
+import { SubscriptionFactory } from './application/services/subscription-factory.service';
 
 @Module({
   imports: [
@@ -49,10 +51,12 @@ import { UpdateMonthlyCreditsUseCase } from './application/use-cases/update-mont
     SubscriptionMapper,
     SubscriptionResponseMapper,
     SubscriptionBillingInfoMapper,
+    SubscriptionFactory,
     HasActiveSubscriptionUseCase,
     GetActiveSubscriptionUseCase,
     GetLatestSubscriptionUseCase,
     CreateSubscriptionUseCase,
+    ChangeSubscriptionUseCase,
     CancelSubscriptionUseCase,
     UncancelSubscriptionUseCase,
     UpdateSeatsUseCase,

--- a/ayunis-core-frontend/src/pages/super-admin-settings/org/api/subscriptionForm.ts
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/org/api/subscriptionForm.ts
@@ -1,0 +1,69 @@
+import { z } from 'zod';
+import type { CreateSubscriptionFormData } from '@/widgets/billing';
+
+const subscriptionTypes = ['SEAT_BASED', 'USAGE_BASED'] as const;
+
+/**
+ * Shared zod schema for the super-admin subscription forms (create and change).
+ * Field-required messages come from the `super-admin-settings-org` namespace.
+ */
+export function buildSubscriptionFormSchema(t: (key: string) => string) {
+  return z
+    .object({
+      companyName: z
+        .string()
+        .min(1, t('subscription.createErrorCompanyNameRequired')),
+      subText: z.string().optional(),
+      street: z.string().min(1, t('subscription.createErrorStreetRequired')),
+      houseNumber: z
+        .string()
+        .min(1, t('subscription.createErrorHouseNumberRequired')),
+      postalCode: z
+        .string()
+        .min(1, t('subscription.createErrorPostalCodeRequired')),
+      city: z.string().min(1, t('subscription.createErrorCityRequired')),
+      country: z.string().min(1, t('subscription.createErrorCountryRequired')),
+      vatNumber: z.string().optional(),
+      type: z.enum(subscriptionTypes),
+      noOfSeats: z.coerce.number().optional(),
+      monthlyCredits: z.coerce.number().optional(),
+      startsAt: z.string().optional(),
+    })
+    .superRefine((data, ctx) => {
+      if (
+        data.type === 'SEAT_BASED' &&
+        (!data.noOfSeats || data.noOfSeats < 1)
+      ) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: t('subscription.createErrorNoOfSeatsRequired'),
+          path: ['noOfSeats'],
+        });
+      }
+      if (
+        data.type === 'USAGE_BASED' &&
+        (!data.monthlyCredits || data.monthlyCredits < 1)
+      ) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: t('subscription.createErrorMonthlyCreditsRequired'),
+          path: ['monthlyCredits'],
+        });
+      }
+    });
+}
+
+export const subscriptionFormDefaultValues: CreateSubscriptionFormData = {
+  companyName: '',
+  subText: '',
+  street: '',
+  houseNumber: '',
+  postalCode: '',
+  city: '',
+  country: '',
+  vatNumber: '',
+  type: 'SEAT_BASED',
+  noOfSeats: 5,
+  monthlyCredits: 1000,
+  startsAt: undefined,
+};

--- a/ayunis-core-frontend/src/pages/super-admin-settings/org/api/useSuperAdminSubscriptionChange.ts
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/org/api/useSuperAdminSubscriptionChange.ts
@@ -1,6 +1,7 @@
+import type { ChangeSubscriptionRequestDtoOldSubscriptionDisposition } from '@/shared/api';
 import {
   getSuperAdminSubscriptionsControllerGetSubscriptionQueryKey,
-  useSuperAdminSubscriptionsControllerCreateSubscription,
+  useSuperAdminSubscriptionsControllerChangeSubscription,
 } from '@/shared/api';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
@@ -15,13 +16,15 @@ import {
   subscriptionFormDefaultValues,
 } from './subscriptionForm';
 
-interface UseSuperAdminSubscriptionCreateProps {
+interface UseSuperAdminSubscriptionChangeProps {
   orgId: string;
+  onSuccess?: () => void;
 }
 
-export default function useSuperAdminSubscriptionCreate({
+export default function useSuperAdminSubscriptionChange({
   orgId,
-}: UseSuperAdminSubscriptionCreateProps) {
+  onSuccess,
+}: UseSuperAdminSubscriptionChangeProps) {
   const { t } = useTranslation('super-admin-settings-org');
   const queryClient = useQueryClient();
   const router = useRouter();
@@ -30,29 +33,28 @@ export default function useSuperAdminSubscriptionCreate({
     defaultValues: subscriptionFormDefaultValues,
   });
 
-  const { mutate: createSubscription } =
-    useSuperAdminSubscriptionsControllerCreateSubscription({
+  const { mutate: changeSubscription, isPending } =
+    useSuperAdminSubscriptionsControllerChangeSubscription({
       mutation: {
         onSuccess: () => {
-          form.reset();
-          showSuccess(t('subscription.createSuccess'));
+          showSuccess(t('subscription.changeSuccess'));
+          onSuccess?.();
         },
         onError: (error) => {
           try {
             const { code } = extractErrorData(error);
             switch (code) {
-              case 'SUBSCRIPTION_ALREADY_EXISTS':
-                showError(t('subscription.createErrorAlreadyExists'));
+              case 'SUBSCRIPTION_NOT_FOUND':
+                showError(t('subscription.changeErrorSubscriptionNotFound'));
                 break;
               case 'TOO_MANY_USED_SEATS':
-                showError(t('subscription.createErrorTooManyUsedSeats'));
+                showError(t('subscription.changeErrorTooManyUsedSeats'));
                 break;
               default:
-                showError(t('subscription.createErrorUnexpected'));
+                showError(t('subscription.changeErrorUnexpected'));
             }
           } catch {
-            // Non-AxiosError (network failure, request cancellation, etc.)
-            showError(t('subscription.createErrorUnexpected'));
+            showError(t('subscription.changeErrorUnexpected'));
           }
         },
         onSettled: () => {
@@ -67,8 +69,11 @@ export default function useSuperAdminSubscriptionCreate({
       },
     });
 
-  const handleSubmit = form.handleSubmit((data) => {
-    createSubscription({
+  const confirmChange = (
+    disposition: ChangeSubscriptionRequestDtoOldSubscriptionDisposition,
+  ) => {
+    const data = form.getValues();
+    changeSubscription({
       orgId,
       data: {
         companyName: data.companyName,
@@ -84,9 +89,10 @@ export default function useSuperAdminSubscriptionCreate({
         monthlyCredits:
           data.type === 'USAGE_BASED' ? data.monthlyCredits : undefined,
         startsAt: data.startsAt,
+        oldSubscriptionDisposition: disposition,
       },
     });
-  });
+  };
 
-  return { form, handleSubmit };
+  return { form, confirmChange, isPending };
 }

--- a/ayunis-core-frontend/src/pages/super-admin-settings/org/ui/ChangeSubscriptionDialog.tsx
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/org/ui/ChangeSubscriptionDialog.tsx
@@ -1,0 +1,136 @@
+import { useState } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/shared/ui/shadcn/dialog';
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/shared/ui/shadcn/alert-dialog';
+import { Form } from '@/shared/ui/shadcn/form';
+import { Button } from '@/shared/ui/shadcn/button';
+import { ScrollArea } from '@/shared/ui/shadcn/scroll-area';
+import { SubscriptionFormFields } from '@/widgets/billing';
+import { ChangeSubscriptionRequestDtoOldSubscriptionDisposition } from '@/shared/api';
+import { useTranslation } from 'react-i18next';
+import useSuperAdminSubscriptionChange from '../api/useSuperAdminSubscriptionChange';
+
+interface ChangeSubscriptionDialogProps {
+  trigger: React.ReactNode;
+  orgId: string;
+}
+
+export default function ChangeSubscriptionDialog({
+  trigger,
+  orgId,
+}: Readonly<ChangeSubscriptionDialogProps>) {
+  const { t } = useTranslation('super-admin-settings-org');
+  const [open, setOpen] = useState(false);
+  const [warningOpen, setWarningOpen] = useState(false);
+
+  const { form, confirmChange, isPending } = useSuperAdminSubscriptionChange({
+    orgId,
+    onSuccess: () => {
+      setWarningOpen(false);
+      setOpen(false);
+      form.reset();
+    },
+  });
+
+  // Validate the form first; only open the destructive warning when it passes.
+  const handleContinue = form.handleSubmit(() => setWarningOpen(true));
+
+  return (
+    <>
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogTrigger asChild>{trigger}</DialogTrigger>
+        <DialogContent className="sm:max-w-[500px]">
+          <DialogHeader>
+            <DialogTitle>{t('changeSubscriptionDialog.title')}</DialogTitle>
+            <DialogDescription>
+              {t('changeSubscriptionDialog.description')}
+            </DialogDescription>
+          </DialogHeader>
+          <ScrollArea className="h-[500px]">
+            <Form {...form}>
+              <form
+                onSubmit={(e) => {
+                  void handleContinue(e);
+                }}
+                className="space-y-6"
+              >
+                <SubscriptionFormFields form={form} t={t} />
+                <DialogFooter>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    onClick={() => setOpen(false)}
+                    disabled={isPending}
+                  >
+                    {t('changeSubscriptionDialog.back')}
+                  </Button>
+                  <Button type="submit" disabled={isPending}>
+                    {t('changeSubscriptionDialog.continue')}
+                  </Button>
+                </DialogFooter>
+              </form>
+            </Form>
+          </ScrollArea>
+        </DialogContent>
+      </Dialog>
+
+      <AlertDialog open={warningOpen} onOpenChange={setWarningOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              {t('changeSubscriptionDialog.warningTitle')}
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              {t('changeSubscriptionDialog.warningDescription')}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter className="flex-col gap-2 sm:flex-col sm:space-x-0">
+            <Button
+              variant="destructive"
+              onClick={() =>
+                confirmChange(
+                  ChangeSubscriptionRequestDtoOldSubscriptionDisposition.CANCEL,
+                )
+              }
+              disabled={isPending}
+            >
+              {t('changeSubscriptionDialog.confirmCancel')}
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={() =>
+                confirmChange(
+                  ChangeSubscriptionRequestDtoOldSubscriptionDisposition.DELETE,
+                )
+              }
+              disabled={isPending}
+            >
+              {t('changeSubscriptionDialog.confirmDelete')}
+            </Button>
+            <Button
+              variant="outline"
+              onClick={() => setWarningOpen(false)}
+              disabled={isPending}
+            >
+              {t('changeSubscriptionDialog.back')}
+            </Button>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}

--- a/ayunis-core-frontend/src/pages/super-admin-settings/org/ui/Page.tsx
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/org/ui/Page.tsx
@@ -8,6 +8,7 @@ import type {
 } from '@/shared/api';
 import { SubscriptionResponseDtoType } from '@/shared/api';
 import { Badge } from '@/shared/ui/shadcn/badge';
+import { Button } from '@/shared/ui/shadcn/button';
 import { Alert, AlertDescription } from '@/shared/ui/shadcn/alert';
 import { ClockIcon } from 'lucide-react';
 import UsersTable from './UsersTable';
@@ -16,6 +17,7 @@ import LicenseSeatsSection from './LicenseSeatsSection';
 import CreditBudgetSection from './CreditBudgetSection';
 import BillingInfoSection from './BillingInfoSection';
 import SubscriptionCancellationSection from './SubscriptionCancellationSection';
+import ChangeSubscriptionDialog from './ChangeSubscriptionDialog';
 import NoSubscriptionSection from './NoSubscriptionSection';
 import ModelsSection from './ModelsSection';
 import CrawlDomainsSection from './CrawlDomainsSection';
@@ -130,6 +132,16 @@ export default function SuperAdminSettingsOrgPage({
         <TabsContent value="subscriptions" className="mt-4">
           {subscription ? (
             <div className="space-y-4">
+              <div className="flex justify-end">
+                <ChangeSubscriptionDialog
+                  orgId={org.id}
+                  trigger={
+                    <Button variant="outline">
+                      {t('changeSubscriptionDialog.changeButton')}
+                    </Button>
+                  }
+                />
+              </div>
               {new Date(subscription.startsAt) > new Date() && (
                 <Alert>
                   <ClockIcon className="h-4 w-4" />

--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
@@ -636,6 +636,65 @@ export interface CreateSubscriptionRequestDto {
   startsAt?: string;
 }
 
+/**
+ * Subscription type. Defaults to SEAT_BASED if not specified.
+ */
+export type ChangeSubscriptionRequestDtoType = typeof ChangeSubscriptionRequestDtoType[keyof typeof ChangeSubscriptionRequestDtoType];
+
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const ChangeSubscriptionRequestDtoType = {
+  SEAT_BASED: 'SEAT_BASED',
+  USAGE_BASED: 'USAGE_BASED',
+} as const;
+
+/**
+ * How to handle the current subscription. CANCEL soft-cancels it (kept in history); DELETE removes it entirely. A new subscription is created with the provided data either way.
+ */
+export type ChangeSubscriptionRequestDtoOldSubscriptionDisposition = typeof ChangeSubscriptionRequestDtoOldSubscriptionDisposition[keyof typeof ChangeSubscriptionRequestDtoOldSubscriptionDisposition];
+
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const ChangeSubscriptionRequestDtoOldSubscriptionDisposition = {
+  CANCEL: 'CANCEL',
+  DELETE: 'DELETE',
+} as const;
+
+export interface ChangeSubscriptionRequestDto {
+  /** Company name for the subscription */
+  companyName: string;
+  /** Street for the subscription */
+  street: string;
+  /** House number for the subscription */
+  houseNumber: string;
+  /** Postal code for the subscription */
+  postalCode: string;
+  /** City for the subscription */
+  city: string;
+  /** Country for the subscription */
+  country: string;
+  /** VAT number for the subscription */
+  vatNumber?: string;
+  /** Subscription type. Defaults to SEAT_BASED if not specified. */
+  type?: ChangeSubscriptionRequestDtoType;
+  /**
+   * Number of seats for the subscription (seat-based only)
+   * @minimum 1
+   */
+  noOfSeats?: number;
+  /**
+   * Monthly credit budget (usage-based only)
+   * @minimum 1
+   */
+  monthlyCredits?: number;
+  /** Sub text for the subscription */
+  subText?: string;
+  /** Start date for the subscription (ISO 8601). If omitted, the subscription starts immediately. */
+  startsAt?: string;
+  /** How to handle the current subscription. CANCEL soft-cancels it (kept in history); DELETE removes it entirely. A new subscription is created with the provided data either way. */
+  oldSubscriptionDisposition: ChangeSubscriptionRequestDtoOldSubscriptionDisposition;
+}
+
 export interface UpdateBillingInfoDto {
   /** Company name for the subscription */
   companyName: string;

--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.ts
@@ -38,6 +38,7 @@ import type {
   ArtifactResponseDto,
   ArtifactVersionResponseDto,
   ArtifactsControllerExportParams,
+  ChangeSubscriptionRequestDto,
   ChatCompletionRequestDto,
   ConfirmEmailDto,
   CrawlDomainGrantResponseDto,
@@ -3197,6 +3198,73 @@ export const useSuperAdminSubscriptionsControllerCancelSubscription = <TError = 
       > => {
 
       const mutationOptions = getSuperAdminSubscriptionsControllerCancelSubscriptionMutationOptions(options);
+
+      return useMutation(mutationOptions, queryClient);
+    }
+    
+/**
+ * Ends the current subscription (cancelled or deleted, per oldSubscriptionDisposition) and creates a new one with the provided data. This is the only way to change subscription type. Only accessible to super admins.
+ * @summary Change an organization subscription (cancel/delete + recreate)
+ */
+export const superAdminSubscriptionsControllerChangeSubscription = (
+    orgId: string,
+    changeSubscriptionRequestDto: ChangeSubscriptionRequestDto,
+ signal?: AbortSignal
+) => {
+      
+      
+      return customAxiosInstance<void>(
+      {url: `/super-admin/subscriptions/${orgId}/change`, method: 'POST',
+      headers: {'Content-Type': 'application/json', },
+      data: changeSubscriptionRequestDto, signal
+    },
+      );
+    }
+  
+
+
+export const getSuperAdminSubscriptionsControllerChangeSubscriptionMutationOptions = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof superAdminSubscriptionsControllerChangeSubscription>>, TError,{orgId: string;data: ChangeSubscriptionRequestDto}, TContext>, }
+): UseMutationOptions<Awaited<ReturnType<typeof superAdminSubscriptionsControllerChangeSubscription>>, TError,{orgId: string;data: ChangeSubscriptionRequestDto}, TContext> => {
+
+const mutationKey = ['superAdminSubscriptionsControllerChangeSubscription'];
+const {mutation: mutationOptions} = options ?
+      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
+      options
+      : {...options, mutation: {...options.mutation, mutationKey}}
+      : {mutation: { mutationKey, }};
+
+      
+
+
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof superAdminSubscriptionsControllerChangeSubscription>>, {orgId: string;data: ChangeSubscriptionRequestDto}> = (props) => {
+          const {orgId,data} = props ?? {};
+
+          return  superAdminSubscriptionsControllerChangeSubscription(orgId,data,)
+        }
+
+        
+
+
+  return  { mutationFn, ...mutationOptions }}
+
+    export type SuperAdminSubscriptionsControllerChangeSubscriptionMutationResult = NonNullable<Awaited<ReturnType<typeof superAdminSubscriptionsControllerChangeSubscription>>>
+    export type SuperAdminSubscriptionsControllerChangeSubscriptionMutationBody = ChangeSubscriptionRequestDto
+    export type SuperAdminSubscriptionsControllerChangeSubscriptionMutationError = void
+
+    /**
+ * @summary Change an organization subscription (cancel/delete + recreate)
+ */
+export const useSuperAdminSubscriptionsControllerChangeSubscription = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof superAdminSubscriptionsControllerChangeSubscription>>, TError,{orgId: string;data: ChangeSubscriptionRequestDto}, TContext>, }
+ , queryClient?: QueryClient): UseMutationResult<
+        Awaited<ReturnType<typeof superAdminSubscriptionsControllerChangeSubscription>>,
+        TError,
+        {orgId: string;data: ChangeSubscriptionRequestDto},
+        TContext
+      > => {
+
+      const mutationOptions = getSuperAdminSubscriptionsControllerChangeSubscriptionMutationOptions(options);
 
       return useMutation(mutationOptions, queryClient);
     }

--- a/ayunis-core-frontend/src/shared/api/openapi-schema.json
+++ b/ayunis-core-frontend/src/shared/api/openapi-schema.json
@@ -1494,6 +1494,54 @@
         "tags": ["Super Admin Subscriptions"]
       }
     },
+    "/super-admin/subscriptions/{orgId}/change": {
+      "post": {
+        "description": "Ends the current subscription (cancelled or deleted, per oldSubscriptionDisposition) and creates a new one with the provided data. This is the only way to change subscription type. Only accessible to super admins.",
+        "operationId": "SuperAdminSubscriptionsController_changeSubscription",
+        "parameters": [
+          {
+            "name": "orgId",
+            "required": true,
+            "in": "path",
+            "description": "Organization ID to change the subscription for",
+            "schema": {
+              "format": "uuid",
+              "example": "123e4567-e89b-12d3-a456-426614174000",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ChangeSubscriptionRequestDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successfully changed subscription"
+          },
+          "400": {
+            "description": "Invalid subscription data provided"
+          },
+          "401": {
+            "description": "User not authenticated or not authorized as super admin"
+          },
+          "404": {
+            "description": "No active subscription found for the organization"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "summary": "Change an organization subscription (cancel/delete + recreate)",
+        "tags": ["Super Admin Subscriptions"]
+      }
+    },
     "/super-admin/subscriptions/{orgId}/seats": {
       "put": {
         "description": "Update the number of seats for the specified organization. This endpoint is only accessible to super admins.",
@@ -10099,6 +10147,91 @@
           "postalCode",
           "city",
           "country"
+        ]
+      },
+      "ChangeSubscriptionRequestDto": {
+        "type": "object",
+        "properties": {
+          "companyName": {
+            "type": "string",
+            "description": "Company name for the subscription",
+            "example": "Acme Inc."
+          },
+          "street": {
+            "type": "string",
+            "description": "Street for the subscription",
+            "example": "123 Main St"
+          },
+          "houseNumber": {
+            "type": "string",
+            "description": "House number for the subscription",
+            "example": "123"
+          },
+          "postalCode": {
+            "type": "string",
+            "description": "Postal code for the subscription",
+            "example": "12345"
+          },
+          "city": {
+            "type": "string",
+            "description": "City for the subscription",
+            "example": "New York"
+          },
+          "country": {
+            "type": "string",
+            "description": "Country for the subscription",
+            "example": "United States"
+          },
+          "vatNumber": {
+            "type": "string",
+            "description": "VAT number for the subscription",
+            "example": "1234567890"
+          },
+          "type": {
+            "type": "string",
+            "description": "Subscription type. Defaults to SEAT_BASED if not specified.",
+            "enum": ["SEAT_BASED", "USAGE_BASED"],
+            "example": "SEAT_BASED",
+            "default": "SEAT_BASED"
+          },
+          "noOfSeats": {
+            "type": "number",
+            "description": "Number of seats for the subscription (seat-based only)",
+            "example": 10,
+            "minimum": 1,
+            "default": 1
+          },
+          "monthlyCredits": {
+            "type": "number",
+            "description": "Monthly credit budget (usage-based only)",
+            "example": 1000,
+            "minimum": 1
+          },
+          "subText": {
+            "type": "string",
+            "description": "Sub text for the subscription",
+            "example": "Sub text"
+          },
+          "startsAt": {
+            "type": "string",
+            "description": "Start date for the subscription (ISO 8601). If omitted, the subscription starts immediately.",
+            "example": "2026-07-01T00:00:00.000Z"
+          },
+          "oldSubscriptionDisposition": {
+            "type": "string",
+            "description": "How to handle the current subscription. CANCEL soft-cancels it (kept in history); DELETE removes it entirely. A new subscription is created with the provided data either way.",
+            "enum": ["CANCEL", "DELETE"],
+            "example": "CANCEL"
+          }
+        },
+        "required": [
+          "companyName",
+          "street",
+          "houseNumber",
+          "postalCode",
+          "city",
+          "country",
+          "oldSubscriptionDisposition"
         ]
       },
       "UpdateBillingInfoDto": {

--- a/ayunis-core-frontend/src/shared/locales/de/super-admin-settings-org.json
+++ b/ayunis-core-frontend/src/shared/locales/de/super-admin-settings-org.json
@@ -76,7 +76,11 @@
         "invalid": "Startdatum ist ungültig"
       },
       "invalid": "Ungültige Eingabe"
-    }
+    },
+    "changeSuccess": "Abonnement erfolgreich geändert",
+    "changeErrorSubscriptionNotFound": "Kein aktives Abonnement zum Ändern vorhanden",
+    "changeErrorTooManyUsedSeats": "Zu viele Nutzer sind bereits in dieser Organisation. Wählen Sie mehr Plätze für das neue Abonnement.",
+    "changeErrorUnexpected": "Ein unerwarteter Fehler ist aufgetreten"
   },
   "licenseSeats": {
     "title": "Lizenzplätze",
@@ -147,6 +151,18 @@
     "startsAtLabel": "Startdatum",
     "startsAtPlaceholder": "Startet sofort",
     "startsAtDescription": "Leer lassen, damit das Abonnement sofort startet, oder ein zukünftiges Datum wählen."
+  },
+  "changeSubscriptionDialog": {
+    "title": "Abonnement ändern",
+    "description": "Ändern Sie den Abonnement-Typ oder die Daten. Dabei wird das aktuelle Abonnement beendet und ein neues erstellt — der Typ kann nicht direkt geändert werden.",
+    "changeButton": "Abonnement ändern",
+    "continue": "Weiter",
+    "changing": "Wird geändert...",
+    "warningTitle": "Dieses Abonnement ändern?",
+    "warningDescription": "Dabei wird das aktuelle Abonnement beendet und ein neues mit den eingegebenen Daten erstellt. Wählen Sie, wie mit dem aktuellen Abonnement verfahren werden soll. Diese Aktion kann nicht rückgängig gemacht werden.",
+    "confirmCancel": "Aktuelles kündigen & neues erstellen",
+    "confirmDelete": "Aktuelles löschen & neues erstellen",
+    "back": "Zurück"
   },
   "trialDialog": {
     "title": "Trial erstellen",

--- a/ayunis-core-frontend/src/shared/locales/en/super-admin-settings-org.json
+++ b/ayunis-core-frontend/src/shared/locales/en/super-admin-settings-org.json
@@ -76,7 +76,11 @@
         "invalid": "Start date is invalid"
       },
       "invalid": "Invalid input"
-    }
+    },
+    "changeSuccess": "Subscription changed successfully",
+    "changeErrorSubscriptionNotFound": "No active subscription to change",
+    "changeErrorTooManyUsedSeats": "Too many users are already in this organization. Choose more seats for the new subscription.",
+    "changeErrorUnexpected": "An unexpected error occurred"
   },
   "licenseSeats": {
     "title": "License Seats",
@@ -147,6 +151,18 @@
     "startsAtLabel": "Start Date",
     "startsAtPlaceholder": "Starts immediately",
     "startsAtDescription": "Leave empty for the subscription to start immediately, or pick a future date."
+  },
+  "changeSubscriptionDialog": {
+    "title": "Change Subscription",
+    "description": "Change the subscription type or its data. This ends the current subscription and creates a new one — the type cannot be changed in place.",
+    "changeButton": "Change Subscription",
+    "continue": "Continue",
+    "changing": "Changing...",
+    "warningTitle": "Change this subscription?",
+    "warningDescription": "This ends the current subscription and creates a new one with the data you entered. Choose how to handle the current subscription. This cannot be undone.",
+    "confirmCancel": "Cancel current & create new",
+    "confirmDelete": "Delete current & create new",
+    "back": "Back"
   },
   "trialDialog": {
     "title": "Create Trial",

--- a/ayunis-core-frontend/src/widgets/billing/index.ts
+++ b/ayunis-core-frontend/src/widgets/billing/index.ts
@@ -1,6 +1,7 @@
 export { default as BillingInfoSection } from './ui/BillingInfoSection';
 export { default as BillingInfoUpdateDialog } from './ui/BillingInfoUpdateDialog';
 export { default as CreateSubscriptionDialog } from './ui/CreateSubscriptionDialog';
+export { SubscriptionFormFields } from './ui/CreateSubscriptionDialog';
 export type { CreateSubscriptionFormData } from './ui/CreateSubscriptionDialog';
 export { default as LicenseSeatsSection } from './ui/LicenseSeatsSection';
 export { default as LicenseSeatsUpdateDialog } from './ui/LicenseSeatsUpdateDialog';

--- a/ayunis-core-frontend/src/widgets/billing/ui/CreateSubscriptionDialog.tsx
+++ b/ayunis-core-frontend/src/widgets/billing/ui/CreateSubscriptionDialog.tsx
@@ -78,7 +78,6 @@ export default function CreateSubscriptionDialog({
   };
 
   const defaultLabel = t('subscriptionDialog.createSubscription');
-  const subscriptionType = form.watch('type');
 
   return (
     <Dialog>
@@ -98,85 +97,7 @@ export default function CreateSubscriptionDialog({
               }}
               className="space-y-6"
             >
-              <BillingInfoFields form={form} t={t} />
-              <FormField
-                control={form.control}
-                name="type"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>{t('subscriptionDialog.typeLabel')}</FormLabel>
-                    <Select onValueChange={field.onChange} value={field.value}>
-                      <FormControl>
-                        <SelectTrigger className="w-full">
-                          <SelectValue
-                            placeholder={t(
-                              'subscriptionDialog.typePlaceholder',
-                            )}
-                          />
-                        </SelectTrigger>
-                      </FormControl>
-                      <SelectContent>
-                        <SelectItem value="SEAT_BASED">
-                          {t('subscriptionDialog.typeSeatBased')}
-                        </SelectItem>
-                        <SelectItem value="USAGE_BASED">
-                          {t('subscriptionDialog.typeUsageBased')}
-                        </SelectItem>
-                      </SelectContent>
-                    </Select>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-              {subscriptionType === 'SEAT_BASED' && (
-                <FormField
-                  control={form.control}
-                  name="noOfSeats"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>{t('billingInfo.noOfSeatsLabel')}</FormLabel>
-                      <FormControl>
-                        <Input
-                          placeholder={t('billingInfo.noOfSeatsPlaceholder')}
-                          type="number"
-                          {...field}
-                        />
-                      </FormControl>
-                      <FormMessage />
-                      <FormDescription>
-                        {t('subscriptionDialog.noOfSeatsDescription')}
-                      </FormDescription>
-                    </FormItem>
-                  )}
-                />
-              )}
-              {subscriptionType === 'USAGE_BASED' && (
-                <FormField
-                  control={form.control}
-                  name="monthlyCredits"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>
-                        {t('subscriptionDialog.monthlyCreditsLabel')}
-                      </FormLabel>
-                      <FormControl>
-                        <Input
-                          placeholder={t(
-                            'subscriptionDialog.monthlyCreditsPlaceholder',
-                          )}
-                          type="number"
-                          {...field}
-                        />
-                      </FormControl>
-                      <FormMessage />
-                      <FormDescription>
-                        {t('subscriptionDialog.monthlyCreditsDescription')}
-                      </FormDescription>
-                    </FormItem>
-                  )}
-                />
-              )}
-              <StartDateField form={form} t={t} />
+              <SubscriptionFormFields form={form} t={t} />
               {priceSection}
               <DialogFooter>
                 <DialogClose asChild>
@@ -200,6 +121,98 @@ export default function CreateSubscriptionDialog({
         </ScrollArea>
       </DialogContent>
     </Dialog>
+  );
+}
+
+export function SubscriptionFormFields({
+  form,
+  t,
+}: Readonly<{
+  form: UseFormReturn<CreateSubscriptionFormData>;
+  t: (key: string) => string;
+}>) {
+  const subscriptionType = form.watch('type');
+
+  return (
+    <>
+      <BillingInfoFields form={form} t={t} />
+      <FormField
+        control={form.control}
+        name="type"
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel>{t('subscriptionDialog.typeLabel')}</FormLabel>
+            <Select onValueChange={field.onChange} value={field.value}>
+              <FormControl>
+                <SelectTrigger className="w-full">
+                  <SelectValue
+                    placeholder={t('subscriptionDialog.typePlaceholder')}
+                  />
+                </SelectTrigger>
+              </FormControl>
+              <SelectContent>
+                <SelectItem value="SEAT_BASED">
+                  {t('subscriptionDialog.typeSeatBased')}
+                </SelectItem>
+                <SelectItem value="USAGE_BASED">
+                  {t('subscriptionDialog.typeUsageBased')}
+                </SelectItem>
+              </SelectContent>
+            </Select>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+      {subscriptionType === 'SEAT_BASED' && (
+        <FormField
+          control={form.control}
+          name="noOfSeats"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>{t('billingInfo.noOfSeatsLabel')}</FormLabel>
+              <FormControl>
+                <Input
+                  placeholder={t('billingInfo.noOfSeatsPlaceholder')}
+                  type="number"
+                  {...field}
+                />
+              </FormControl>
+              <FormMessage />
+              <FormDescription>
+                {t('subscriptionDialog.noOfSeatsDescription')}
+              </FormDescription>
+            </FormItem>
+          )}
+        />
+      )}
+      {subscriptionType === 'USAGE_BASED' && (
+        <FormField
+          control={form.control}
+          name="monthlyCredits"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>
+                {t('subscriptionDialog.monthlyCreditsLabel')}
+              </FormLabel>
+              <FormControl>
+                <Input
+                  placeholder={t(
+                    'subscriptionDialog.monthlyCreditsPlaceholder',
+                  )}
+                  type="number"
+                  {...field}
+                />
+              </FormControl>
+              <FormMessage />
+              <FormDescription>
+                {t('subscriptionDialog.monthlyCreditsDescription')}
+              </FormDescription>
+            </FormItem>
+          )}
+        />
+      )}
+      <StartDateField form={form} t={t} />
+    </>
   );
 }
 


### PR DESCRIPTION
Add a super-admin flow to switch an organization between seat-based and usage-based subscriptions. The type is a TypeORM single-table-inheritance discriminator and cannot be mutated in place, so the current subscription is ended and a new one is created with full freshly-entered data (including billing info).

Backend:
- Extract SubscriptionFactory from CreateSubscriptionUseCase (shared build + validation).
- Add transactional SubscriptionRepository.replace() that cancels or hard-deletes the current subscription and inserts the new one atomically.
- Add ChangeSubscriptionUseCase + POST /super-admin/subscriptions/:orgId/change with oldSubscriptionDisposition (CANCEL keeps history, DELETE removes it). New data is validated before the old subscription is touched.
- Extract API-doc decorators and command mappers to keep the controller under the size limit.

Frontend:
- ChangeSubscriptionDialog: reuses the extracted SubscriptionFormFields and adds a destructive warning where the admin picks cancel-or-delete.
- Share the subscription form schema/defaults between the create and change hooks.
- Regenerate API client; add EN/DE i18n.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XAc91VzyP6NdgLtBTwx5LX

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core subscription lifecycle and billing data (including hard DELETE), though guarded by super-admin access, pre-validation, and a single DB transaction.
> 
> **Overview**
> Adds a **super-admin “change subscription”** path because subscription type is a TypeORM STI discriminator and cannot be updated in place. The org’s latest subscription is ended (**CANCEL** or **DELETE**) and a new one is created with fresh billing and type-specific fields.
> 
> **Backend:** Shared **`SubscriptionFactory`** holds create/change validation (seats vs users/invites, credits, billing). **`CreateSubscriptionUseCase`** delegates building to the factory. New **`ChangeSubscriptionUseCase`** validates the replacement *before* mutating the old row, then calls transactional **`SubscriptionRepository.replace()`** (soft-cancel or hard-delete + insert). Exposes **`POST /super-admin/subscriptions/:orgId/change`** with `oldSubscriptionDisposition`; emits **`SubscriptionCreatedEvent`** and **`SubscriptionCancelledEvent`** only on CANCEL. Controller helpers (`OrgIdParam`, command mappers) reduce duplication.
> 
> **Frontend:** **`ChangeSubscriptionDialog`** on the org subscriptions tab reuses extracted **`SubscriptionFormFields`** and a two-step flow (form → destructive confirm for cancel vs delete). Create/change hooks share **`subscriptionForm`** schema/defaults; API client and EN/DE strings updated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6756f0a86b81620e7087612488bee283953f3a6b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->