### PR TITLE
test(credit-limits): extract shared spec fixtures and mock factory (AYC-167)

### DIFF
--- a/.claude/skills/backend-test-fixtures/SKILL.md
+++ b/.claude/skills/backend-test-fixtures/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: backend-test-fixtures
+description: Shared test fixtures for backend specs — port mock factories, domain builders, and shared IDs in a per-module testing/ folder. Use when a module's *.use-case.spec.ts files repeat the same mock-repository literal, inline entity construction, or hardcoded UUIDs across files.
+---
+
+# Backend Test Fixtures
+
+Most repetition in backend unit specs is **setup**, not assertions: the same
+port mock object, the same `new Entity({...})` literals, and the same hardcoded
+UUIDs copy-pasted into every `*.spec.ts`. Extract that setup into a per-module
+fixtures file so a port-signature change is a one-line edit instead of a
+nine-file sweep.
+
+**Extract setup. Keep assertions explicit.** Per-test `expect(...).toEqual(...)`
+bodies document the contract — never hide them behind helpers.
+
+## When to use
+
+- A module has ≥3 specs that each re-declare the same `jest.Mocked<XRepository>` literal.
+- Specs build the same domain entity inline (`new UserCreditLimit({...})`) repeatedly.
+- The same UUID literals (`'1111…'`, `'2222…'`) appear across multiple specs.
+
+**When NOT to use:** a single spec, or a one-off mock used in one place. Don't
+build infrastructure for one caller.
+
+## The hard constraint: keep `jest` out of the production build
+
+A fixtures file uses the `jest` global, so it must never reach the production
+`tsc` build. `tsconfig.build.json` only excludes `**/*spec.ts`, so the file
+**cannot** be named `*.fixtures.ts` at an arbitrary path.
+
+Put it in a `testing/` folder, which is excluded from both the build and
+coverage:
+
+- `tsconfig.build.json` → `exclude` includes `"**/testing/**"`
+- `package.json` jest `collectCoverageFrom` → includes `"!**/testing/**"`
+
+Both exclusions already exist (added with the credit-limits fixtures). Place new
+fixtures under `<module>/application/testing/` and they are covered. Import them
+**only** from `*.spec.ts` files.
+
+## The pattern (canonical example)
+
+See `src/iam/credit-limits/application/testing/credit-limit.fixtures.ts` and any
+of `src/iam/credit-limits/application/use-cases/*/*.use-case.spec.ts`.
+
+A fixtures file exports three things:
+
+```ts
+// 1. Shared identifiers — one source of truth for test IDs.
+export const TEST_ORG_ID = '11111111-1111-1111-1111-111111111111' as UUID;
+export const TEST_USER_ID = '22222222-2222-2222-2222-222222222222' as UUID;
+export const TEST_TEAM_ID = '33333333-3333-3333-3333-333333333333' as UUID;
+
+// 2. Domain builders — sensible defaults, override only what the test asserts.
+//    One builder per entity subclass, so there is no union to juggle.
+export function aUserCreditLimit(
+  overrides: { orgId?: UUID; userId?: UUID; monthlyCredits?: number } = {},
+): UserCreditLimit {
+  const { orgId = TEST_ORG_ID, userId = TEST_USER_ID, monthlyCredits = 5000 } = overrides;
+  return new UserCreditLimit({ orgId, userId, monthlyCredits });
+}
+
+// 3. A port mock factory — defaults model the "empty" state. No `as` cast needed:
+//    the object literal already satisfies jest.Mocked<T>.
+export function createMockCreditLimitRepository(): jest.Mocked<CreditLimitRepository> {
+  return {
+    save: jest.fn().mockImplementation((limit) => Promise.resolve(limit)),
+    findUserLimits: jest.fn().mockResolvedValue([]),
+    findByUserId: jest.fn().mockResolvedValue(null),
+    // …every port method, with a sensible default…
+  };
+}
+```
+
+In a spec, setup collapses to:
+
+```ts
+const orgId = TEST_ORG_ID;
+const repository = createMockCreditLimitRepository();
+const existing = aUserCreditLimit({ monthlyCredits: 1000 });
+repository.findByUserId.mockResolvedValue(existing);   // override per test
+```
+
+## Rules
+
+- **Defaults model the empty/happy path.** Mock finders resolve to `null`/`[]`,
+  `save` echoes its argument, deletes resolve. Tests override per case.
+- **`import type` for type-only imports** (the port is only used in
+  `jest.Mocked<T>`), and **no `as jest.Mocked<T>` cast** on the literal — both
+  trip ESLint otherwise.
+- **One builder per entity subclass** (`aUserCreditLimit` / `aTeamCreditLimit`)
+  rather than a single builder that branches on scope.
+- Keep the dominant spec style (`Test.createTestingModule`) — fixtures replace
+  the *mock setup*, not the testing harness.
+
+## Validate
+
+```bash
+pnpm jest src/<module>                                  # specs still green
+npx tsc -p tsconfig.build.json --noEmit                 # testing/ NOT compiled
+npx eslint --max-warnings=0 <changed files>             # mirrors pre-commit
+```

--- a/ayunis-core-backend/package.json
+++ b/ayunis-core-backend/package.json
@@ -191,7 +191,8 @@
       "!**/*.module.ts",
       "!**/*.record.ts",
       "!**/index.ts",
-      "!**/cli/**"
+      "!**/cli/**",
+      "!**/testing/**"
     ],
     "coverageDirectory": "../coverage",
     "testEnvironment": "node",

--- a/ayunis-core-backend/src/iam/credit-limits/application/listeners/subscription-cancelled.listener.spec.ts
+++ b/ayunis-core-backend/src/iam/credit-limits/application/listeners/subscription-cancelled.listener.spec.ts
@@ -1,11 +1,11 @@
-import type { UUID } from 'crypto';
 import { SubscriptionType } from 'src/iam/subscriptions/domain/value-objects/subscription-type.enum';
 import type { SubscriptionCancelledEvent } from 'src/iam/subscriptions/application/events/subscription-cancelled.event';
 import type { RemoveOrgCreditLimitsUseCase } from '../use-cases/remove-org-credit-limits/remove-org-credit-limits.use-case';
+import { TEST_ORG_ID } from '../testing/credit-limit.fixtures';
 import { SubscriptionCancelledListener } from './subscription-cancelled.listener';
 
 describe('SubscriptionCancelledListener', () => {
-  const orgId = '11111111-1111-1111-1111-111111111111' as UUID;
+  const orgId = TEST_ORG_ID;
   let removeOrgCreditLimits: { execute: jest.Mock };
   let listener: SubscriptionCancelledListener;
 

--- a/ayunis-core-backend/src/iam/credit-limits/application/testing/credit-limit.fixtures.ts
+++ b/ayunis-core-backend/src/iam/credit-limits/application/testing/credit-limit.fixtures.ts
@@ -1,0 +1,49 @@
+import type { UUID } from 'crypto';
+import { UserCreditLimit } from '../../domain/user-credit-limit.entity';
+import { TeamCreditLimit } from '../../domain/team-credit-limit.entity';
+import type { CreditLimitRepository } from '../ports/credit-limit.repository';
+
+// Shared identifiers — one source of truth for credit-limits test IDs.
+export const TEST_ORG_ID = '11111111-1111-1111-1111-111111111111' as UUID;
+export const TEST_USER_ID = '22222222-2222-2222-2222-222222222222' as UUID;
+export const TEST_TEAM_ID = '33333333-3333-3333-3333-333333333333' as UUID;
+
+// Domain builders — sensible defaults, override only what a test asserts.
+// One builder per entity subclass, so no discriminated union to juggle.
+export function aUserCreditLimit(
+  overrides: { orgId?: UUID; userId?: UUID; monthlyCredits?: number } = {},
+): UserCreditLimit {
+  const {
+    orgId = TEST_ORG_ID,
+    userId = TEST_USER_ID,
+    monthlyCredits = 5000,
+  } = overrides;
+  return new UserCreditLimit({ orgId, userId, monthlyCredits });
+}
+
+export function aTeamCreditLimit(
+  overrides: { orgId?: UUID; teamId?: UUID; monthlyCredits?: number } = {},
+): TeamCreditLimit {
+  const {
+    orgId = TEST_ORG_ID,
+    teamId = TEST_TEAM_ID,
+    monthlyCredits = 20000,
+  } = overrides;
+  return new TeamCreditLimit({ orgId, teamId, monthlyCredits });
+}
+
+// Port mock factory — defaults model the "empty" state: finders resolve to
+// null/[], save echoes its argument, deletes resolve. Tests override per case.
+export function createMockCreditLimitRepository(): jest.Mocked<CreditLimitRepository> {
+  return {
+    save: jest.fn().mockImplementation((limit) => Promise.resolve(limit)),
+    findUserLimits: jest.fn().mockResolvedValue([]),
+    findTeamLimits: jest.fn().mockResolvedValue([]),
+    findByUserId: jest.fn().mockResolvedValue(null),
+    findByTeamId: jest.fn().mockResolvedValue(null),
+    findByTeamIds: jest.fn().mockResolvedValue([]),
+    deleteByUserId: jest.fn().mockResolvedValue(undefined),
+    deleteByTeamId: jest.fn().mockResolvedValue(undefined),
+    deleteByOrg: jest.fn().mockResolvedValue(undefined),
+  };
+}

--- a/ayunis-core-backend/src/iam/credit-limits/application/use-cases/get-team-credit-limits-overview/get-team-credit-limits-overview.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/credit-limits/application/use-cases/get-team-credit-limits-overview/get-team-credit-limits-overview.use-case.spec.ts
@@ -1,12 +1,16 @@
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
-import type { UUID } from 'crypto';
 import { ContextService } from 'src/common/context/services/context.service';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
 import { ListTeamsUseCase } from 'src/iam/teams/application/use-cases/list-teams/list-teams.use-case';
 import { GetMonthlyCreditUsageForTeamUseCase } from 'src/domain/usage/application/use-cases/get-monthly-credit-usage-for-team/get-monthly-credit-usage-for-team.use-case';
 import { CreditLimitRepository } from '../../ports/credit-limit.repository';
-import { TeamCreditLimit } from '../../../domain/team-credit-limit.entity';
+import {
+  aTeamCreditLimit,
+  createMockCreditLimitRepository,
+  TEST_ORG_ID,
+  TEST_TEAM_ID,
+} from '../../testing/credit-limit.fixtures';
 import { GetTeamCreditLimitsOverviewUseCase } from './get-team-credit-limits-overview.use-case';
 
 describe('GetTeamCreditLimitsOverviewUseCase', () => {
@@ -16,27 +20,14 @@ describe('GetTeamCreditLimitsOverviewUseCase', () => {
   let listTeams: { execute: jest.Mock };
   let getUsage: { execute: jest.Mock };
 
-  const orgId = '11111111-1111-1111-1111-111111111111' as UUID;
-  const teamId = '33333333-3333-3333-3333-333333333333' as UUID;
+  const orgId = TEST_ORG_ID;
+  const teamId = TEST_TEAM_ID;
 
-  const teamLimit = new TeamCreditLimit({
-    orgId,
-    teamId,
-    monthlyCredits: 20000,
-  });
+  const teamLimit = aTeamCreditLimit();
 
   beforeEach(async () => {
-    repository = {
-      save: jest.fn(),
-      findUserLimits: jest.fn(),
-      findTeamLimits: jest.fn().mockResolvedValue([teamLimit]),
-      findByUserId: jest.fn(),
-      findByTeamId: jest.fn(),
-      findByTeamIds: jest.fn(),
-      deleteByUserId: jest.fn(),
-      deleteByTeamId: jest.fn(),
-      deleteByOrg: jest.fn(),
-    };
+    repository = createMockCreditLimitRepository();
+    repository.findTeamLimits.mockResolvedValue([teamLimit]);
     context = { get: jest.fn().mockReturnValue(orgId) };
     listTeams = {
       execute: jest

--- a/ayunis-core-backend/src/iam/credit-limits/application/use-cases/get-user-credit-limits-overview/get-user-credit-limits-overview.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/credit-limits/application/use-cases/get-user-credit-limits-overview/get-user-credit-limits-overview.use-case.spec.ts
@@ -6,7 +6,12 @@ import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.e
 import { FindUsersByIdsUseCase } from 'src/iam/users/application/use-cases/find-users-by-ids/find-users-by-ids.use-case';
 import { GetMonthlyCreditUsageForUsersUseCase } from 'src/domain/usage/application/use-cases/get-monthly-credit-usage-for-users/get-monthly-credit-usage-for-users.use-case';
 import { CreditLimitRepository } from '../../ports/credit-limit.repository';
-import { UserCreditLimit } from '../../../domain/user-credit-limit.entity';
+import {
+  aUserCreditLimit,
+  createMockCreditLimitRepository,
+  TEST_ORG_ID,
+  TEST_USER_ID,
+} from '../../testing/credit-limit.fixtures';
 import { GetUserCreditLimitsOverviewUseCase } from './get-user-credit-limits-overview.use-case';
 
 describe('GetUserCreditLimitsOverviewUseCase', () => {
@@ -16,27 +21,14 @@ describe('GetUserCreditLimitsOverviewUseCase', () => {
   let findUsersByIds: { execute: jest.Mock };
   let getUsage: { execute: jest.Mock };
 
-  const orgId = '11111111-1111-1111-1111-111111111111' as UUID;
-  const userId = '22222222-2222-2222-2222-222222222222' as UUID;
+  const orgId = TEST_ORG_ID;
+  const userId = TEST_USER_ID;
 
-  const userLimit = new UserCreditLimit({
-    orgId,
-    userId,
-    monthlyCredits: 5000,
-  });
+  const userLimit = aUserCreditLimit();
 
   beforeEach(async () => {
-    repository = {
-      save: jest.fn(),
-      findUserLimits: jest.fn().mockResolvedValue([userLimit]),
-      findTeamLimits: jest.fn(),
-      findByUserId: jest.fn(),
-      findByTeamId: jest.fn(),
-      findByTeamIds: jest.fn(),
-      deleteByUserId: jest.fn(),
-      deleteByTeamId: jest.fn(),
-      deleteByOrg: jest.fn(),
-    };
+    repository = createMockCreditLimitRepository();
+    repository.findUserLimits.mockResolvedValue([userLimit]);
     context = { get: jest.fn().mockReturnValue(orgId) };
     findUsersByIds = {
       execute: jest

--- a/ayunis-core-backend/src/iam/credit-limits/application/use-cases/remove-org-credit-limits/remove-org-credit-limits.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/credit-limits/application/use-cases/remove-org-credit-limits/remove-org-credit-limits.use-case.spec.ts
@@ -1,7 +1,10 @@
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
-import type { UUID } from 'crypto';
 import { CreditLimitRepository } from '../../ports/credit-limit.repository';
+import {
+  createMockCreditLimitRepository,
+  TEST_ORG_ID,
+} from '../../testing/credit-limit.fixtures';
 import { RemoveOrgCreditLimitsUseCase } from './remove-org-credit-limits.use-case';
 import { RemoveOrgCreditLimitsCommand } from './remove-org-credit-limits.command';
 
@@ -9,20 +12,10 @@ describe('RemoveOrgCreditLimitsUseCase', () => {
   let useCase: RemoveOrgCreditLimitsUseCase;
   let repository: jest.Mocked<CreditLimitRepository>;
 
-  const orgId = '11111111-1111-1111-1111-111111111111' as UUID;
+  const orgId = TEST_ORG_ID;
 
   beforeEach(async () => {
-    repository = {
-      save: jest.fn(),
-      findUserLimits: jest.fn(),
-      findTeamLimits: jest.fn(),
-      findByUserId: jest.fn(),
-      findByTeamId: jest.fn(),
-      findByTeamIds: jest.fn(),
-      deleteByUserId: jest.fn(),
-      deleteByTeamId: jest.fn(),
-      deleteByOrg: jest.fn().mockResolvedValue(undefined),
-    };
+    repository = createMockCreditLimitRepository();
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [

--- a/ayunis-core-backend/src/iam/credit-limits/application/use-cases/remove-team-credit-limit/remove-team-credit-limit.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/credit-limits/application/use-cases/remove-team-credit-limit/remove-team-credit-limit.use-case.spec.ts
@@ -1,8 +1,12 @@
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
-import type { UUID } from 'crypto';
 import { ContextService } from 'src/common/context/services/context.service';
 import { CreditLimitRepository } from '../../ports/credit-limit.repository';
+import {
+  createMockCreditLimitRepository,
+  TEST_ORG_ID,
+  TEST_TEAM_ID,
+} from '../../testing/credit-limit.fixtures';
 import { RemoveTeamCreditLimitUseCase } from './remove-team-credit-limit.use-case';
 import { RemoveTeamCreditLimitCommand } from './remove-team-credit-limit.command';
 
@@ -10,21 +14,11 @@ describe('RemoveTeamCreditLimitUseCase', () => {
   let useCase: RemoveTeamCreditLimitUseCase;
   let repository: jest.Mocked<CreditLimitRepository>;
 
-  const orgId = '11111111-1111-1111-1111-111111111111' as UUID;
-  const teamId = '33333333-3333-3333-3333-333333333333' as UUID;
+  const orgId = TEST_ORG_ID;
+  const teamId = TEST_TEAM_ID;
 
   beforeEach(async () => {
-    repository = {
-      save: jest.fn(),
-      findUserLimits: jest.fn(),
-      findTeamLimits: jest.fn(),
-      findByUserId: jest.fn(),
-      findByTeamId: jest.fn(),
-      findByTeamIds: jest.fn(),
-      deleteByUserId: jest.fn().mockResolvedValue(undefined),
-      deleteByTeamId: jest.fn().mockResolvedValue(undefined),
-      deleteByOrg: jest.fn().mockResolvedValue(undefined),
-    };
+    repository = createMockCreditLimitRepository();
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [

--- a/ayunis-core-backend/src/iam/credit-limits/application/use-cases/remove-user-credit-limit/remove-user-credit-limit.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/credit-limits/application/use-cases/remove-user-credit-limit/remove-user-credit-limit.use-case.spec.ts
@@ -1,8 +1,12 @@
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
-import type { UUID } from 'crypto';
 import { ContextService } from 'src/common/context/services/context.service';
 import { CreditLimitRepository } from '../../ports/credit-limit.repository';
+import {
+  createMockCreditLimitRepository,
+  TEST_ORG_ID,
+  TEST_USER_ID,
+} from '../../testing/credit-limit.fixtures';
 import { RemoveUserCreditLimitUseCase } from './remove-user-credit-limit.use-case';
 import { RemoveUserCreditLimitCommand } from './remove-user-credit-limit.command';
 
@@ -10,21 +14,11 @@ describe('RemoveUserCreditLimitUseCase', () => {
   let useCase: RemoveUserCreditLimitUseCase;
   let repository: jest.Mocked<CreditLimitRepository>;
 
-  const orgId = '11111111-1111-1111-1111-111111111111' as UUID;
-  const userId = '22222222-2222-2222-2222-222222222222' as UUID;
+  const orgId = TEST_ORG_ID;
+  const userId = TEST_USER_ID;
 
   beforeEach(async () => {
-    repository = {
-      save: jest.fn(),
-      findUserLimits: jest.fn(),
-      findTeamLimits: jest.fn(),
-      findByUserId: jest.fn(),
-      findByTeamId: jest.fn(),
-      findByTeamIds: jest.fn(),
-      deleteByUserId: jest.fn().mockResolvedValue(undefined),
-      deleteByTeamId: jest.fn().mockResolvedValue(undefined),
-      deleteByOrg: jest.fn().mockResolvedValue(undefined),
-    };
+    repository = createMockCreditLimitRepository();
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [

--- a/ayunis-core-backend/src/iam/credit-limits/application/use-cases/resolve-credit-limits-for-user/resolve-credit-limits-for-user.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/credit-limits/application/use-cases/resolve-credit-limits-for-user/resolve-credit-limits-for-user.use-case.spec.ts
@@ -4,8 +4,14 @@ import type { UUID } from 'crypto';
 import { FindTeamsByUserIdUseCase } from 'src/iam/teams/application/use-cases/find-teams-by-user-id/find-teams-by-user-id.use-case';
 import { Team } from 'src/iam/teams/domain/team.entity';
 import { CreditLimitRepository } from '../../ports/credit-limit.repository';
-import { UserCreditLimit } from '../../../domain/user-credit-limit.entity';
-import { TeamCreditLimit } from '../../../domain/team-credit-limit.entity';
+import {
+  aTeamCreditLimit,
+  aUserCreditLimit,
+  createMockCreditLimitRepository,
+  TEST_ORG_ID,
+  TEST_TEAM_ID,
+  TEST_USER_ID,
+} from '../../testing/credit-limit.fixtures';
 import { ResolveCreditLimitsForUserUseCase } from './resolve-credit-limits-for-user.use-case';
 import { ResolveCreditLimitsForUserQuery } from './resolve-credit-limits-for-user.query';
 
@@ -14,26 +20,16 @@ describe('ResolveCreditLimitsForUserUseCase', () => {
   let repository: jest.Mocked<CreditLimitRepository>;
   let findTeams: { execute: jest.Mock };
 
-  const orgId = '11111111-1111-1111-1111-111111111111' as UUID;
-  const userId = '22222222-2222-2222-2222-222222222222' as UUID;
-  const teamAId = '33333333-3333-3333-3333-333333333333' as UUID;
+  const orgId = TEST_ORG_ID;
+  const userId = TEST_USER_ID;
+  const teamAId = TEST_TEAM_ID;
   const teamBId = '44444444-4444-4444-4444-444444444444' as UUID;
 
   const team = (id: UUID): Team =>
     new Team({ id, name: `team-${id}`, orgId, modelOverrideEnabled: false });
 
   beforeEach(async () => {
-    repository = {
-      save: jest.fn(),
-      findUserLimits: jest.fn(),
-      findTeamLimits: jest.fn(),
-      findByUserId: jest.fn().mockResolvedValue(null),
-      findByTeamId: jest.fn(),
-      findByTeamIds: jest.fn().mockResolvedValue([]),
-      deleteByUserId: jest.fn(),
-      deleteByTeamId: jest.fn(),
-      deleteByOrg: jest.fn(),
-    };
+    repository = createMockCreditLimitRepository();
     findTeams = { execute: jest.fn().mockResolvedValue([]) };
 
     const module: TestingModule = await Test.createTestingModule({
@@ -56,21 +52,11 @@ describe('ResolveCreditLimitsForUserUseCase', () => {
   });
 
   it('returns the personal limit and only the limited teams the user belongs to', async () => {
-    repository.findByUserId.mockResolvedValue(
-      new UserCreditLimit({
-        orgId,
-        userId,
-        monthlyCredits: 5000,
-      }),
-    );
+    repository.findByUserId.mockResolvedValue(aUserCreditLimit());
     findTeams.execute.mockResolvedValue([team(teamAId), team(teamBId)]);
     // Only team A has a configured limit.
     repository.findByTeamIds.mockResolvedValue([
-      new TeamCreditLimit({
-        orgId,
-        teamId: teamAId,
-        monthlyCredits: 20000,
-      }),
+      aTeamCreditLimit({ teamId: teamAId }),
     ]);
 
     const result = await useCase.execute(

--- a/ayunis-core-backend/src/iam/credit-limits/application/use-cases/set-team-credit-limit/set-team-credit-limit.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/credit-limits/application/use-cases/set-team-credit-limit/set-team-credit-limit.use-case.spec.ts
@@ -1,6 +1,5 @@
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
-import type { UUID } from 'crypto';
 import { ContextService } from 'src/common/context/services/context.service';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
 import { GetTeamUseCase } from 'src/iam/teams/application/use-cases/get-team/get-team.use-case';
@@ -8,6 +7,12 @@ import { TeamNotFoundError } from 'src/iam/teams/application/teams.errors';
 import { CreditLimitRepository } from '../../ports/credit-limit.repository';
 import { TeamCreditLimit } from '../../../domain/team-credit-limit.entity';
 import { InvalidCreditLimitError } from '../../credit-limits.errors';
+import {
+  aTeamCreditLimit,
+  createMockCreditLimitRepository,
+  TEST_ORG_ID,
+  TEST_TEAM_ID,
+} from '../../testing/credit-limit.fixtures';
 import { SetTeamCreditLimitUseCase } from './set-team-credit-limit.use-case';
 import { SetTeamCreditLimitCommand } from './set-team-credit-limit.command';
 
@@ -17,21 +22,11 @@ describe('SetTeamCreditLimitUseCase', () => {
   let context: { get: jest.Mock };
   let getTeam: { execute: jest.Mock };
 
-  const orgId = '11111111-1111-1111-1111-111111111111' as UUID;
-  const teamId = '33333333-3333-3333-3333-333333333333' as UUID;
+  const orgId = TEST_ORG_ID;
+  const teamId = TEST_TEAM_ID;
 
   beforeEach(async () => {
-    repository = {
-      save: jest.fn().mockImplementation((limit) => Promise.resolve(limit)),
-      findUserLimits: jest.fn(),
-      findTeamLimits: jest.fn(),
-      findByUserId: jest.fn(),
-      findByTeamId: jest.fn().mockResolvedValue(null),
-      findByTeamIds: jest.fn(),
-      deleteByUserId: jest.fn(),
-      deleteByTeamId: jest.fn(),
-      deleteByOrg: jest.fn(),
-    };
+    repository = createMockCreditLimitRepository();
     context = { get: jest.fn().mockReturnValue(orgId) };
     // Default: target team belongs to the caller's org (GetTeam resolves).
     getTeam = { execute: jest.fn().mockResolvedValue({ id: teamId }) };
@@ -60,11 +55,7 @@ describe('SetTeamCreditLimitUseCase', () => {
   });
 
   it('updates an existing team limit in place, preserving its identity', async () => {
-    const existing = new TeamCreditLimit({
-      orgId,
-      teamId,
-      monthlyCredits: 5000,
-    });
+    const existing = aTeamCreditLimit({ monthlyCredits: 5000 });
     repository.findByTeamId.mockResolvedValue(existing);
 
     const result = await useCase.execute(

--- a/ayunis-core-backend/src/iam/credit-limits/application/use-cases/set-user-credit-limit/set-user-credit-limit.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/credit-limits/application/use-cases/set-user-credit-limit/set-user-credit-limit.use-case.spec.ts
@@ -1,6 +1,5 @@
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
-import type { UUID } from 'crypto';
 import { ContextService } from 'src/common/context/services/context.service';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
 import { FindUsersByIdsUseCase } from 'src/iam/users/application/use-cases/find-users-by-ids/find-users-by-ids.use-case';
@@ -10,6 +9,12 @@ import {
   CreditLimitTargetNotFoundError,
   InvalidCreditLimitError,
 } from '../../credit-limits.errors';
+import {
+  aUserCreditLimit,
+  createMockCreditLimitRepository,
+  TEST_ORG_ID,
+  TEST_USER_ID,
+} from '../../testing/credit-limit.fixtures';
 import { SetUserCreditLimitUseCase } from './set-user-credit-limit.use-case';
 import { SetUserCreditLimitCommand } from './set-user-credit-limit.command';
 
@@ -19,21 +24,11 @@ describe('SetUserCreditLimitUseCase', () => {
   let context: { get: jest.Mock };
   let findUsersByIds: { execute: jest.Mock };
 
-  const orgId = '11111111-1111-1111-1111-111111111111' as UUID;
-  const userId = '22222222-2222-2222-2222-222222222222' as UUID;
+  const orgId = TEST_ORG_ID;
+  const userId = TEST_USER_ID;
 
   beforeEach(async () => {
-    repository = {
-      save: jest.fn().mockImplementation((limit) => Promise.resolve(limit)),
-      findUserLimits: jest.fn(),
-      findTeamLimits: jest.fn(),
-      findByUserId: jest.fn().mockResolvedValue(null),
-      findByTeamId: jest.fn(),
-      findByTeamIds: jest.fn(),
-      deleteByUserId: jest.fn(),
-      deleteByTeamId: jest.fn(),
-      deleteByOrg: jest.fn(),
-    };
+    repository = createMockCreditLimitRepository();
     context = { get: jest.fn().mockReturnValue(orgId) };
     // Default: target is a member of the caller's org.
     findUsersByIds = {
@@ -64,11 +59,7 @@ describe('SetUserCreditLimitUseCase', () => {
   });
 
   it('updates an existing limit in place, preserving its identity', async () => {
-    const existing = new UserCreditLimit({
-      orgId,
-      userId,
-      monthlyCredits: 1000,
-    });
+    const existing = aUserCreditLimit({ monthlyCredits: 1000 });
     repository.findByUserId.mockResolvedValue(existing);
 
     const result = await useCase.execute(

--- a/ayunis-core-backend/src/iam/credit-limits/application/utils/select-credit-limits.spec.ts
+++ b/ayunis-core-backend/src/iam/credit-limits/application/utils/select-credit-limits.spec.ts
@@ -1,20 +1,18 @@
-import type { UUID } from 'crypto';
-import { UserCreditLimit } from '../../domain/user-credit-limit.entity';
-import { TeamCreditLimit } from '../../domain/team-credit-limit.entity';
+import {
+  aTeamCreditLimit,
+  aUserCreditLimit,
+  TEST_TEAM_ID,
+  TEST_USER_ID,
+} from '../testing/credit-limit.fixtures';
 import { selectUserCreditLimits } from './select-user-credit-limits';
 import { selectTeamCreditLimits } from './select-team-credit-limits';
 
 describe('credit limit selectors', () => {
-  const orgId = '11111111-1111-1111-1111-111111111111' as UUID;
-  const userId = '22222222-2222-2222-2222-222222222222' as UUID;
-  const teamId = '33333333-3333-3333-3333-333333333333' as UUID;
+  const userId = TEST_USER_ID;
+  const teamId = TEST_TEAM_ID;
 
   it('flattens user limits into their read shape', () => {
-    const userLimit = new UserCreditLimit({
-      orgId,
-      userId,
-      monthlyCredits: 5000,
-    });
+    const userLimit = aUserCreditLimit();
 
     expect(selectUserCreditLimits([userLimit])).toEqual([
       { userId, monthlyCredits: 5000 },
@@ -22,11 +20,7 @@ describe('credit limit selectors', () => {
   });
 
   it('flattens team limits into their read shape', () => {
-    const teamLimit = new TeamCreditLimit({
-      orgId,
-      teamId,
-      monthlyCredits: 20000,
-    });
+    const teamLimit = aTeamCreditLimit();
 
     expect(selectTeamCreditLimits([teamLimit])).toEqual([
       { teamId, monthlyCredits: 20000 },

--- a/ayunis-core-backend/tsconfig.build.json
+++ b/ayunis-core-backend/tsconfig.build.json
@@ -1,4 +1,4 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": ["node_modules", "test", "dist", "**/*spec.ts"]
+  "exclude": ["node_modules", "test", "dist", "**/*spec.ts", "**/testing/**"]
 }


### PR DESCRIPTION
Extract repeated unit-test setup for the credit-limits module into a
single reusable fixtures file, and document the pattern as a skill.

- Add application/testing/credit-limit.fixtures.ts exporting shared test
  IDs, aUserCreditLimit/aTeamCreditLimit builders, and a
  createMockCreditLimitRepository() port mock factory.
- Refactor the 6 use-case specs + the selector spec to use them; the
  7-method repository literal, inline entity construction, and hardcoded
  UUIDs no longer repeat across files (specs net -66 lines).
- Exclude **/testing/** from the production build (tsconfig.build.json)
  and from coverage (jest collectCoverageFrom) so jest-dependent helpers
  never reach tsc.
- Add the backend-test-fixtures skill describing the pattern and its
  build/coverage constraints for future modules.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only refactor and documentation; no runtime or production code paths change.
> 
> **Overview**
> Introduces a **per-module test fixtures** pattern for credit-limits: shared org/user/team IDs, `aUserCreditLimit` / `aTeamCreditLimit` builders, and `createMockCreditLimitRepository()` replace repeated inline mocks and entity literals across use-case, listener, and selector specs.
> 
> **Build/coverage guardrails:** `**/testing/**` is excluded from `tsconfig.build.json` and Jest `collectCoverageFrom` so jest-dependent helpers never ship in production.
> 
> Documents the approach in the new **backend-test-fixtures** skill for reuse in other backend modules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd5adfe1acad2bc53805d15940afbac98b53131e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->