### PR TITLE
feat(platform-config): add persistent app-wide alert banner for super admins (AYC-342)

### DIFF
--- a/ayunis-core-backend/src/iam/platform-config/SUMMARY.md
+++ b/ayunis-core-backend/src/iam/platform-config/SUMMARY.md
@@ -1,0 +1,15 @@
+Platform Configuration
+Stores instance-wide configuration as key/value pairs, managed by super admins.
+
+Holds global, deployment-level settings that are not scoped to any organization or user — the credits-per-euro conversion rate, per-tier fair-use limits, the image-generation fair-use limit, and the persistent app-wide alert banner. Values are read by other modules at runtime and edited by super admins through dedicated HTTP endpoints.
+
+This module is a generic platform-wide settings store. The core entity is `PlatformConfig` (a `{ key, value }` pair); valid keys are enumerated in `PlatformConfigKey` (`CREDITS_PER_EURO`, the `FAIR_USE_*` tier limit/window keys, and `APP_ALERT_ENABLED` / `APP_ALERT_MESSAGE`). All values are persisted as strings in a single `platform_config` table (PK on `key`), so adding a new setting is just a new enum key and use case — no migration required. Persistence is abstracted by `PlatformConfigRepositoryPort` (`get`, `set`, and `setMany` — an atomic multi-key upsert used when several keys must change together) with a PostgreSQL implementation (`PlatformConfigRepository`, mapping `PlatformConfigRecord`).
+
+Key use cases: `GetCreditsPerEuroUseCase` / `SetCreditsPerEuroUseCase` (the global credits-per-euro rate used for credit calculations; get throws `PlatformConfigNotFoundError` when unset), `GetFairUseLimitsUseCase` / `SetFairUseLimitUseCase` / `SetImageFairUseLimitUseCase` (per-tier message limits plus a single image-generation bucket; the getter falls back to baked-in defaults so it always returns a value), and `GetAppAlertUseCase` / `SetAppAlertUseCase` (the app-wide alert banner — get returns `{ enabled, message }`, defaulting to disabled/empty when unset; set writes both keys atomically via `setMany` and rejects enabling the banner without a non-empty message). Validation failures raise `PlatformConfigInvalidValueError`.
+
+HTTP entry points:
+
+- `SuperAdminPlatformConfigController` (`super-admin/platform-config`, `SUPER_ADMIN` only) — `GET`/`PUT credits-per-euro`, `GET`/`PUT fair-use-limits`, `PUT image-fair-use-limit`, and `PUT app-alert`.
+- `AppAlertController` (`app-alert`, any authenticated user) — `GET` the current alert banner so the frontend can render it on every page. This is intentionally not super-admin-gated; only writing the banner is restricted.
+
+Providers exported for cross-module use: `GetCreditsPerEuroUseCase`, `GetFairUseLimitsUseCase`, and `GetAppAlertUseCase`. The credits-per-euro rate is consumed by credit/usage calculation, the fair-use limits by the **quotas** module's runtime enforcement, and the app alert by the frontend banner widget.

--- a/ayunis-core-backend/src/iam/platform-config/application/use-cases/get-app-alert/get-app-alert.query.ts
+++ b/ayunis-core-backend/src/iam/platform-config/application/use-cases/get-app-alert/get-app-alert.query.ts
@@ -1,0 +1,1 @@
+export class GetAppAlertQuery {}

--- a/ayunis-core-backend/src/iam/platform-config/application/use-cases/get-app-alert/get-app-alert.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/platform-config/application/use-cases/get-app-alert/get-app-alert.use-case.spec.ts
@@ -1,0 +1,63 @@
+import { GetAppAlertUseCase } from './get-app-alert.use-case';
+import type { PlatformConfigRepositoryPort } from '../../ports/platform-config.repository';
+import { PlatformConfig } from '../../../domain/platform-config.entity';
+import { PlatformConfigKey } from '../../../domain/platform-config-keys.enum';
+
+describe('GetAppAlertUseCase', () => {
+  let useCase: GetAppAlertUseCase;
+  let repository: jest.Mocked<PlatformConfigRepositoryPort>;
+
+  beforeEach(() => {
+    repository = {
+      get: jest.fn(),
+      set: jest.fn(),
+      setMany: jest.fn(),
+    };
+
+    useCase = new GetAppAlertUseCase(repository);
+  });
+
+  it('should return the enabled flag and message from the repository', async () => {
+    repository.get.mockImplementation((key) => {
+      if (key === PlatformConfigKey.APP_ALERT_ENABLED) {
+        return Promise.resolve(new PlatformConfig({ key, value: 'true' }));
+      }
+      return Promise.resolve(
+        new PlatformConfig({
+          key,
+          value: 'Scheduled maintenance tonight at 22:00.',
+        }),
+      );
+    });
+
+    const result = await useCase.execute();
+
+    expect(result).toEqual({
+      enabled: true,
+      message: 'Scheduled maintenance tonight at 22:00.',
+    });
+  });
+
+  it('should default to disabled with an empty message when nothing is configured', async () => {
+    repository.get.mockResolvedValue(null);
+
+    const result = await useCase.execute();
+
+    expect(result).toEqual({ enabled: false, message: '' });
+  });
+
+  it('should treat any stored value other than "true" as disabled', async () => {
+    repository.get.mockImplementation((key) => {
+      if (key === PlatformConfigKey.APP_ALERT_ENABLED) {
+        return Promise.resolve(new PlatformConfig({ key, value: 'false' }));
+      }
+      return Promise.resolve(
+        new PlatformConfig({ key, value: 'Old announcement' }),
+      );
+    });
+
+    const result = await useCase.execute();
+
+    expect(result).toEqual({ enabled: false, message: 'Old announcement' });
+  });
+});

--- a/ayunis-core-backend/src/iam/platform-config/application/use-cases/get-app-alert/get-app-alert.use-case.ts
+++ b/ayunis-core-backend/src/iam/platform-config/application/use-cases/get-app-alert/get-app-alert.use-case.ts
@@ -1,0 +1,23 @@
+import { Injectable } from '@nestjs/common';
+import { PlatformConfigRepositoryPort } from '../../ports/platform-config.repository';
+import { PlatformConfigKey } from '../../../domain/platform-config-keys.enum';
+import { AppAlert } from '../../../domain/app-alert';
+
+@Injectable()
+export class GetAppAlertUseCase {
+  constructor(
+    private readonly configRepository: PlatformConfigRepositoryPort,
+  ) {}
+
+  async execute(): Promise<AppAlert> {
+    const [enabledConfig, messageConfig] = await Promise.all([
+      this.configRepository.get(PlatformConfigKey.APP_ALERT_ENABLED),
+      this.configRepository.get(PlatformConfigKey.APP_ALERT_MESSAGE),
+    ]);
+
+    return {
+      enabled: enabledConfig?.value === 'true',
+      message: messageConfig?.value ?? '',
+    };
+  }
+}

--- a/ayunis-core-backend/src/iam/platform-config/application/use-cases/set-app-alert/set-app-alert.command.ts
+++ b/ayunis-core-backend/src/iam/platform-config/application/use-cases/set-app-alert/set-app-alert.command.ts
@@ -1,0 +1,9 @@
+export class SetAppAlertCommand {
+  readonly enabled: boolean;
+  readonly message: string;
+
+  constructor(params: { enabled: boolean; message: string }) {
+    this.enabled = params.enabled;
+    this.message = params.message;
+  }
+}

--- a/ayunis-core-backend/src/iam/platform-config/application/use-cases/set-app-alert/set-app-alert.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/platform-config/application/use-cases/set-app-alert/set-app-alert.use-case.spec.ts
@@ -1,0 +1,74 @@
+import { SetAppAlertUseCase } from './set-app-alert.use-case';
+import { SetAppAlertCommand } from './set-app-alert.command';
+import type { PlatformConfigRepositoryPort } from '../../ports/platform-config.repository';
+import { PlatformConfigInvalidValueError } from '../../platform-config.errors';
+import { PlatformConfigKey } from '../../../domain/platform-config-keys.enum';
+import { APP_ALERT_MESSAGE_MAX_LENGTH } from '../../../domain/app-alert';
+
+describe('SetAppAlertUseCase', () => {
+  let useCase: SetAppAlertUseCase;
+  let repository: jest.Mocked<PlatformConfigRepositoryPort>;
+
+  beforeEach(() => {
+    repository = {
+      get: jest.fn(),
+      set: jest.fn(),
+      setMany: jest.fn(),
+    };
+
+    useCase = new SetAppAlertUseCase(repository);
+  });
+
+  it('should persist the enabled flag and message as a single batch', async () => {
+    await useCase.execute(
+      new SetAppAlertCommand({
+        enabled: true,
+        message: 'The system is currently experiencing degraded performance.',
+      }),
+    );
+
+    expect(repository.setMany).toHaveBeenCalledWith(
+      new Map([
+        [PlatformConfigKey.APP_ALERT_ENABLED, 'true'],
+        [
+          PlatformConfigKey.APP_ALERT_MESSAGE,
+          'The system is currently experiencing degraded performance.',
+        ],
+      ]),
+    );
+  });
+
+  it('should allow disabling the alert with an empty message', async () => {
+    await useCase.execute(
+      new SetAppAlertCommand({ enabled: false, message: '' }),
+    );
+
+    expect(repository.setMany).toHaveBeenCalledWith(
+      new Map([
+        [PlatformConfigKey.APP_ALERT_ENABLED, 'false'],
+        [PlatformConfigKey.APP_ALERT_MESSAGE, ''],
+      ]),
+    );
+  });
+
+  it('should reject enabling the alert without a message', async () => {
+    await expect(
+      useCase.execute(
+        new SetAppAlertCommand({ enabled: true, message: '   ' }),
+      ),
+    ).rejects.toThrow(PlatformConfigInvalidValueError);
+    expect(repository.setMany).not.toHaveBeenCalled();
+  });
+
+  it('should reject a message longer than the maximum length', async () => {
+    await expect(
+      useCase.execute(
+        new SetAppAlertCommand({
+          enabled: true,
+          message: 'a'.repeat(APP_ALERT_MESSAGE_MAX_LENGTH + 1),
+        }),
+      ),
+    ).rejects.toThrow(PlatformConfigInvalidValueError);
+    expect(repository.setMany).not.toHaveBeenCalled();
+  });
+});

--- a/ayunis-core-backend/src/iam/platform-config/application/use-cases/set-app-alert/set-app-alert.use-case.ts
+++ b/ayunis-core-backend/src/iam/platform-config/application/use-cases/set-app-alert/set-app-alert.use-case.ts
@@ -1,0 +1,41 @@
+import { Injectable } from '@nestjs/common';
+import { PlatformConfigRepositoryPort } from '../../ports/platform-config.repository';
+import { PlatformConfigKey } from '../../../domain/platform-config-keys.enum';
+import { PlatformConfigInvalidValueError } from '../../platform-config.errors';
+import { APP_ALERT_MESSAGE_MAX_LENGTH } from '../../../domain/app-alert';
+import { SetAppAlertCommand } from './set-app-alert.command';
+
+@Injectable()
+export class SetAppAlertUseCase {
+  constructor(
+    private readonly configRepository: PlatformConfigRepositoryPort,
+  ) {}
+
+  async execute(command: SetAppAlertCommand): Promise<void> {
+    if (command.message.length > APP_ALERT_MESSAGE_MAX_LENGTH) {
+      throw new PlatformConfigInvalidValueError(
+        PlatformConfigKey.APP_ALERT_MESSAGE,
+        `must be at most ${APP_ALERT_MESSAGE_MAX_LENGTH} characters`,
+      );
+    }
+
+    // The banner is meaningless without text, so a request to enable it must
+    // carry a non-empty message. Disabling it may clear the message.
+    if (command.enabled && command.message.trim().length === 0) {
+      throw new PlatformConfigInvalidValueError(
+        PlatformConfigKey.APP_ALERT_MESSAGE,
+        'message is required when the alert is enabled',
+      );
+    }
+
+    await this.configRepository.setMany(
+      new Map<PlatformConfigKey, string>([
+        [
+          PlatformConfigKey.APP_ALERT_ENABLED,
+          command.enabled ? 'true' : 'false',
+        ],
+        [PlatformConfigKey.APP_ALERT_MESSAGE, command.message],
+      ]),
+    );
+  }
+}

--- a/ayunis-core-backend/src/iam/platform-config/domain/app-alert.ts
+++ b/ayunis-core-backend/src/iam/platform-config/domain/app-alert.ts
@@ -1,0 +1,12 @@
+/**
+ * The persistent app-wide alert banner configuration controlled by super
+ * admins. When `enabled` is true the `message` is shown as a warning banner at
+ * the top of every authenticated page.
+ */
+export interface AppAlert {
+  enabled: boolean;
+  message: string;
+}
+
+/** Maximum length of the alert banner message. */
+export const APP_ALERT_MESSAGE_MAX_LENGTH = 1000;

--- a/ayunis-core-backend/src/iam/platform-config/domain/platform-config-keys.enum.ts
+++ b/ayunis-core-backend/src/iam/platform-config/domain/platform-config-keys.enum.ts
@@ -16,4 +16,8 @@ export enum PlatformConfigKey {
   FAIR_USE_HIGH_WINDOW_MS = 'FAIR_USE_HIGH_WINDOW_MS',
   FAIR_USE_IMAGES_LIMIT = 'FAIR_USE_IMAGES_LIMIT',
   FAIR_USE_IMAGES_WINDOW_MS = 'FAIR_USE_IMAGES_WINDOW_MS',
+  // Persistent app-wide alert banner controlled by super admins. ENABLED is
+  // stored as the string 'true' | 'false'; MESSAGE holds the banner text.
+  APP_ALERT_ENABLED = 'APP_ALERT_ENABLED',
+  APP_ALERT_MESSAGE = 'APP_ALERT_MESSAGE',
 }

--- a/ayunis-core-backend/src/iam/platform-config/platform-config.module.ts
+++ b/ayunis-core-backend/src/iam/platform-config/platform-config.module.ts
@@ -8,11 +8,14 @@ import { SetCreditsPerEuroUseCase } from './application/use-cases/set-credits-pe
 import { GetFairUseLimitsUseCase } from './application/use-cases/get-fair-use-limits/get-fair-use-limits.use-case';
 import { SetFairUseLimitUseCase } from './application/use-cases/set-fair-use-limit/set-fair-use-limit.use-case';
 import { SetImageFairUseLimitUseCase } from './application/use-cases/set-image-fair-use-limit/set-image-fair-use-limit.use-case';
+import { GetAppAlertUseCase } from './application/use-cases/get-app-alert/get-app-alert.use-case';
+import { SetAppAlertUseCase } from './application/use-cases/set-app-alert/set-app-alert.use-case';
 import { SuperAdminPlatformConfigController } from './presenters/http/super-admin-platform-config.controller';
+import { AppAlertController } from './presenters/http/app-alert.controller';
 
 @Module({
   imports: [TypeOrmModule.forFeature([PlatformConfigRecord])],
-  controllers: [SuperAdminPlatformConfigController],
+  controllers: [SuperAdminPlatformConfigController, AppAlertController],
   providers: [
     {
       provide: PlatformConfigRepositoryPort,
@@ -23,7 +26,13 @@ import { SuperAdminPlatformConfigController } from './presenters/http/super-admi
     GetFairUseLimitsUseCase,
     SetFairUseLimitUseCase,
     SetImageFairUseLimitUseCase,
+    GetAppAlertUseCase,
+    SetAppAlertUseCase,
   ],
-  exports: [GetCreditsPerEuroUseCase, GetFairUseLimitsUseCase],
+  exports: [
+    GetCreditsPerEuroUseCase,
+    GetFairUseLimitsUseCase,
+    GetAppAlertUseCase,
+  ],
 })
 export class PlatformConfigModule {}

--- a/ayunis-core-backend/src/iam/platform-config/presenters/http/app-alert.controller.ts
+++ b/ayunis-core-backend/src/iam/platform-config/presenters/http/app-alert.controller.ts
@@ -1,0 +1,43 @@
+import { Controller, Get, Logger, HttpCode, HttpStatus } from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiUnauthorizedResponse,
+  ApiInternalServerErrorResponse,
+} from '@nestjs/swagger';
+import { GetAppAlertUseCase } from '../../application/use-cases/get-app-alert/get-app-alert.use-case';
+import { AppAlertResponseDto } from './dto/app-alert-response.dto';
+
+/**
+ * Read-only endpoint for the app-wide alert banner, accessible to every
+ * authenticated user (no super-admin requirement) so the banner can render on
+ * all pages. Writing the configuration is restricted to super admins via
+ * {@link SuperAdminPlatformConfigController}.
+ */
+@ApiTags('App Alert')
+@Controller('app-alert')
+export class AppAlertController {
+  private readonly logger = new Logger(AppAlertController.name);
+
+  constructor(private readonly getAppAlertUseCase: GetAppAlertUseCase) {}
+
+  @Get()
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Get the current app-wide alert banner',
+    description:
+      'Retrieve the persistent alert banner configuration shown to all users. Returns `enabled: false` with an empty message when no banner has been configured.',
+  })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'Successfully retrieved the app alert configuration',
+    type: AppAlertResponseDto,
+  })
+  @ApiUnauthorizedResponse({ description: 'User not authenticated' })
+  @ApiInternalServerErrorResponse({ description: 'Internal server error' })
+  async getAppAlert(): Promise<AppAlertResponseDto> {
+    this.logger.log('Getting app alert configuration');
+    return this.getAppAlertUseCase.execute();
+  }
+}

--- a/ayunis-core-backend/src/iam/platform-config/presenters/http/dto/app-alert-response.dto.ts
+++ b/ayunis-core-backend/src/iam/platform-config/presenters/http/dto/app-alert-response.dto.ts
@@ -1,0 +1,15 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class AppAlertResponseDto {
+  @ApiProperty({
+    description: 'Whether the app-wide alert banner is currently shown',
+    example: true,
+  })
+  enabled: boolean;
+
+  @ApiProperty({
+    description: 'The alert banner text shown to all users',
+    example: 'The system is currently experiencing degraded performance.',
+  })
+  message: string;
+}

--- a/ayunis-core-backend/src/iam/platform-config/presenters/http/dto/set-app-alert-request.dto.ts
+++ b/ayunis-core-backend/src/iam/platform-config/presenters/http/dto/set-app-alert-request.dto.ts
@@ -1,0 +1,22 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsBoolean, IsString, MaxLength } from 'class-validator';
+import { APP_ALERT_MESSAGE_MAX_LENGTH } from '../../../domain/app-alert';
+
+export class SetAppAlertRequestDto {
+  @ApiProperty({
+    description: 'Whether to show the app-wide alert banner',
+    example: true,
+  })
+  @IsBoolean()
+  enabled: boolean;
+
+  @ApiProperty({
+    description:
+      'The alert banner text. Required (non-empty) when enabled is true.',
+    example: 'The system is currently experiencing degraded performance.',
+    maxLength: APP_ALERT_MESSAGE_MAX_LENGTH,
+  })
+  @IsString()
+  @MaxLength(APP_ALERT_MESSAGE_MAX_LENGTH)
+  message: string;
+}

--- a/ayunis-core-backend/src/iam/platform-config/presenters/http/super-admin-platform-config.controller.ts
+++ b/ayunis-core-backend/src/iam/platform-config/presenters/http/super-admin-platform-config.controller.ts
@@ -24,11 +24,14 @@ import { SetFairUseLimitUseCase } from '../../application/use-cases/set-fair-use
 import { SetFairUseLimitCommand } from '../../application/use-cases/set-fair-use-limit/set-fair-use-limit.command';
 import { SetImageFairUseLimitUseCase } from '../../application/use-cases/set-image-fair-use-limit/set-image-fair-use-limit.use-case';
 import { SetImageFairUseLimitCommand } from '../../application/use-cases/set-image-fair-use-limit/set-image-fair-use-limit.command';
+import { SetAppAlertUseCase } from '../../application/use-cases/set-app-alert/set-app-alert.use-case';
+import { SetAppAlertCommand } from '../../application/use-cases/set-app-alert/set-app-alert.command';
 import { CreditsPerEuroResponseDto } from './dto/credits-per-euro-response.dto';
 import { SetCreditsPerEuroRequestDto } from './dto/set-credits-per-euro-request.dto';
 import { FairUseLimitsResponseDto } from './dto/fair-use-limits-response.dto';
 import { SetFairUseLimitRequestDto } from './dto/set-fair-use-limit-request.dto';
 import { SetImageFairUseLimitRequestDto } from './dto/set-image-fair-use-limit-request.dto';
+import { SetAppAlertRequestDto } from './dto/set-app-alert-request.dto';
 
 @ApiTags('Super Admin Platform Config')
 @Controller('super-admin/platform-config')
@@ -42,6 +45,7 @@ export class SuperAdminPlatformConfigController {
     private readonly getFairUseLimitsUseCase: GetFairUseLimitsUseCase,
     private readonly setFairUseLimitUseCase: SetFairUseLimitUseCase,
     private readonly setImageFairUseLimitUseCase: SetImageFairUseLimitUseCase,
+    private readonly setAppAlertUseCase: SetAppAlertUseCase,
   ) {}
 
   @Get('credits-per-euro')
@@ -195,5 +199,37 @@ export class SuperAdminPlatformConfigController {
     });
     await this.setImageFairUseLimitUseCase.execute(command);
     this.logger.log('Successfully updated image fair-use limit');
+  }
+
+  @Put('app-alert')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({
+    summary: 'Set the app-wide alert banner',
+    description:
+      'Enable or disable the persistent alert banner shown to all users and set its message. When enabling, a non-empty message is required. Super admin only.',
+  })
+  @ApiResponse({
+    status: HttpStatus.NO_CONTENT,
+    description: 'Successfully updated the app alert banner',
+  })
+  @ApiResponse({
+    status: HttpStatus.BAD_REQUEST,
+    description:
+      'Invalid value provided (message required when enabled, or message too long)',
+  })
+  @ApiUnauthorizedResponse({
+    description: 'User not authenticated or not authorized as super admin',
+  })
+  @ApiInternalServerErrorResponse({
+    description: 'Internal server error',
+  })
+  async setAppAlert(@Body() dto: SetAppAlertRequestDto): Promise<void> {
+    this.logger.log(`Setting app alert: enabled=${dto.enabled}`);
+    const command = new SetAppAlertCommand({
+      enabled: dto.enabled,
+      message: dto.message,
+    });
+    await this.setAppAlertUseCase.execute(command);
+    this.logger.log('Successfully updated app alert banner');
   }
 }

--- a/ayunis-core-frontend/src/app/routeTree.gen.ts
+++ b/ayunis-core-frontend/src/app/routeTree.gen.ts
@@ -52,6 +52,7 @@ import { Route as AuthenticatedSuperAdminSettingsSkillsIndexRouteImport } from '
 import { Route as AuthenticatedSuperAdminSettingsPlatformConfigIndexRouteImport } from './routes/_authenticated/super-admin-settings.platform-config.index'
 import { Route as AuthenticatedSuperAdminSettingsOrgsIndexRouteImport } from './routes/_authenticated/super-admin-settings.orgs.index'
 import { Route as AuthenticatedSuperAdminSettingsModelsCatalogIndexRouteImport } from './routes/_authenticated/super-admin-settings.models-catalog.index'
+import { Route as AuthenticatedSuperAdminSettingsAppAlertsIndexRouteImport } from './routes/_authenticated/super-admin-settings.app-alerts.index'
 import { Route as AuthenticatedSuperAdminSettingsAcademyIndexRouteImport } from './routes/_authenticated/super-admin-settings.academy.index'
 import { Route as AuthenticatedAdminSettingsTeamsIndexRouteImport } from './routes/_authenticated/admin-settings.teams.index'
 import { Route as AuthenticatedAdminSettingsLetterheadsIndexRouteImport } from './routes/_authenticated/admin-settings.letterheads.index'
@@ -303,6 +304,12 @@ const AuthenticatedSuperAdminSettingsModelsCatalogIndexRoute =
     path: '/super-admin-settings/models-catalog/',
     getParentRoute: () => AuthenticatedRoute,
   } as any)
+const AuthenticatedSuperAdminSettingsAppAlertsIndexRoute =
+  AuthenticatedSuperAdminSettingsAppAlertsIndexRouteImport.update({
+    id: '/super-admin-settings/app-alerts/',
+    path: '/super-admin-settings/app-alerts/',
+    getParentRoute: () => AuthenticatedRoute,
+  } as any)
 const AuthenticatedSuperAdminSettingsAcademyIndexRoute =
   AuthenticatedSuperAdminSettingsAcademyIndexRouteImport.update({
     id: '/super-admin-settings/academy/',
@@ -383,6 +390,7 @@ export interface FileRoutesByFullPath {
   '/admin-settings/letterheads/': typeof AuthenticatedAdminSettingsLetterheadsIndexRoute
   '/admin-settings/teams/': typeof AuthenticatedAdminSettingsTeamsIndexRoute
   '/super-admin-settings/academy/': typeof AuthenticatedSuperAdminSettingsAcademyIndexRoute
+  '/super-admin-settings/app-alerts/': typeof AuthenticatedSuperAdminSettingsAppAlertsIndexRoute
   '/super-admin-settings/models-catalog/': typeof AuthenticatedSuperAdminSettingsModelsCatalogIndexRoute
   '/super-admin-settings/orgs/': typeof AuthenticatedSuperAdminSettingsOrgsIndexRoute
   '/super-admin-settings/platform-config/': typeof AuthenticatedSuperAdminSettingsPlatformConfigIndexRoute
@@ -433,6 +441,7 @@ export interface FileRoutesByTo {
   '/admin-settings/letterheads': typeof AuthenticatedAdminSettingsLetterheadsIndexRoute
   '/admin-settings/teams': typeof AuthenticatedAdminSettingsTeamsIndexRoute
   '/super-admin-settings/academy': typeof AuthenticatedSuperAdminSettingsAcademyIndexRoute
+  '/super-admin-settings/app-alerts': typeof AuthenticatedSuperAdminSettingsAppAlertsIndexRoute
   '/super-admin-settings/models-catalog': typeof AuthenticatedSuperAdminSettingsModelsCatalogIndexRoute
   '/super-admin-settings/orgs': typeof AuthenticatedSuperAdminSettingsOrgsIndexRoute
   '/super-admin-settings/platform-config': typeof AuthenticatedSuperAdminSettingsPlatformConfigIndexRoute
@@ -485,6 +494,7 @@ export interface FileRoutesById {
   '/_authenticated/admin-settings/letterheads/': typeof AuthenticatedAdminSettingsLetterheadsIndexRoute
   '/_authenticated/admin-settings/teams/': typeof AuthenticatedAdminSettingsTeamsIndexRoute
   '/_authenticated/super-admin-settings/academy/': typeof AuthenticatedSuperAdminSettingsAcademyIndexRoute
+  '/_authenticated/super-admin-settings/app-alerts/': typeof AuthenticatedSuperAdminSettingsAppAlertsIndexRoute
   '/_authenticated/super-admin-settings/models-catalog/': typeof AuthenticatedSuperAdminSettingsModelsCatalogIndexRoute
   '/_authenticated/super-admin-settings/orgs/': typeof AuthenticatedSuperAdminSettingsOrgsIndexRoute
   '/_authenticated/super-admin-settings/platform-config/': typeof AuthenticatedSuperAdminSettingsPlatformConfigIndexRoute
@@ -537,6 +547,7 @@ export interface FileRouteTypes {
     | '/admin-settings/letterheads/'
     | '/admin-settings/teams/'
     | '/super-admin-settings/academy/'
+    | '/super-admin-settings/app-alerts/'
     | '/super-admin-settings/models-catalog/'
     | '/super-admin-settings/orgs/'
     | '/super-admin-settings/platform-config/'
@@ -587,6 +598,7 @@ export interface FileRouteTypes {
     | '/admin-settings/letterheads'
     | '/admin-settings/teams'
     | '/super-admin-settings/academy'
+    | '/super-admin-settings/app-alerts'
     | '/super-admin-settings/models-catalog'
     | '/super-admin-settings/orgs'
     | '/super-admin-settings/platform-config'
@@ -638,6 +650,7 @@ export interface FileRouteTypes {
     | '/_authenticated/admin-settings/letterheads/'
     | '/_authenticated/admin-settings/teams/'
     | '/_authenticated/super-admin-settings/academy/'
+    | '/_authenticated/super-admin-settings/app-alerts/'
     | '/_authenticated/super-admin-settings/models-catalog/'
     | '/_authenticated/super-admin-settings/orgs/'
     | '/_authenticated/super-admin-settings/platform-config/'
@@ -963,6 +976,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedSuperAdminSettingsModelsCatalogIndexRouteImport
       parentRoute: typeof AuthenticatedRoute
     }
+    '/_authenticated/super-admin-settings/app-alerts/': {
+      id: '/_authenticated/super-admin-settings/app-alerts/'
+      path: '/super-admin-settings/app-alerts'
+      fullPath: '/super-admin-settings/app-alerts/'
+      preLoaderRoute: typeof AuthenticatedSuperAdminSettingsAppAlertsIndexRouteImport
+      parentRoute: typeof AuthenticatedRoute
+    }
     '/_authenticated/super-admin-settings/academy/': {
       id: '/_authenticated/super-admin-settings/academy/'
       path: '/super-admin-settings/academy'
@@ -1041,6 +1061,7 @@ interface AuthenticatedRouteChildren {
   AuthenticatedAdminSettingsLetterheadsIndexRoute: typeof AuthenticatedAdminSettingsLetterheadsIndexRoute
   AuthenticatedAdminSettingsTeamsIndexRoute: typeof AuthenticatedAdminSettingsTeamsIndexRoute
   AuthenticatedSuperAdminSettingsAcademyIndexRoute: typeof AuthenticatedSuperAdminSettingsAcademyIndexRoute
+  AuthenticatedSuperAdminSettingsAppAlertsIndexRoute: typeof AuthenticatedSuperAdminSettingsAppAlertsIndexRoute
   AuthenticatedSuperAdminSettingsModelsCatalogIndexRoute: typeof AuthenticatedSuperAdminSettingsModelsCatalogIndexRoute
   AuthenticatedSuperAdminSettingsOrgsIndexRoute: typeof AuthenticatedSuperAdminSettingsOrgsIndexRoute
   AuthenticatedSuperAdminSettingsPlatformConfigIndexRoute: typeof AuthenticatedSuperAdminSettingsPlatformConfigIndexRoute
@@ -1096,6 +1117,8 @@ const AuthenticatedRouteChildren: AuthenticatedRouteChildren = {
     AuthenticatedAdminSettingsTeamsIndexRoute,
   AuthenticatedSuperAdminSettingsAcademyIndexRoute:
     AuthenticatedSuperAdminSettingsAcademyIndexRoute,
+  AuthenticatedSuperAdminSettingsAppAlertsIndexRoute:
+    AuthenticatedSuperAdminSettingsAppAlertsIndexRoute,
   AuthenticatedSuperAdminSettingsModelsCatalogIndexRoute:
     AuthenticatedSuperAdminSettingsModelsCatalogIndexRoute,
   AuthenticatedSuperAdminSettingsOrgsIndexRoute:

--- a/ayunis-core-frontend/src/app/routes/_authenticated/super-admin-settings.app-alerts.index.tsx
+++ b/ayunis-core-frontend/src/app/routes/_authenticated/super-admin-settings.app-alerts.index.tsx
@@ -1,0 +1,18 @@
+import { createFileRoute, redirect } from '@tanstack/react-router';
+import AppAlertsPage from '@/pages/super-admin-settings/app-alerts';
+import { MeResponseDtoSystemRole } from '@/shared/api/generated/ayunisCoreAPI.schemas';
+
+export const Route = createFileRoute(
+  '/_authenticated/super-admin-settings/app-alerts/',
+)({
+  component: RouteComponent,
+  beforeLoad: ({ context: { user } }) => {
+    if (user.systemRole !== MeResponseDtoSystemRole.super_admin) {
+      throw redirect({ to: '/' });
+    }
+  },
+});
+
+function RouteComponent() {
+  return <AppAlertsPage />;
+}

--- a/ayunis-core-frontend/src/i18n.ts
+++ b/ayunis-core-frontend/src/i18n.ts
@@ -54,6 +54,8 @@ import enArtifacts from './shared/locales/en/artifacts.json';
 import deArtifacts from './shared/locales/de/artifacts.json';
 import enSuperAdminSettingsPlatformConfig from './shared/locales/en/super-admin-settings-platform-config.json';
 import deSuperAdminSettingsPlatformConfig from './shared/locales/de/super-admin-settings-platform-config.json';
+import enSuperAdminSettingsAppAlerts from './shared/locales/en/super-admin-settings-app-alerts.json';
+import deSuperAdminSettingsAppAlerts from './shared/locales/de/super-admin-settings-app-alerts.json';
 import enAdminSettingsSecurity from './shared/locales/en/admin-settings-security.json';
 import deAdminSettingsSecurity from './shared/locales/de/admin-settings-security.json';
 import enAdminSettingsAnonymization from './shared/locales/en/admin-settings-anonymization.json';
@@ -97,6 +99,7 @@ const resources = {
     academy: enAcademy,
     artifacts: enArtifacts,
     'super-admin-settings-platform-config': enSuperAdminSettingsPlatformConfig,
+    'super-admin-settings-app-alerts': enSuperAdminSettingsAppAlerts,
     'admin-settings-security': enAdminSettingsSecurity,
     'admin-settings-anonymization': enAdminSettingsAnonymization,
     'admin-settings-retention': enAdminSettingsRetention,
@@ -132,6 +135,7 @@ const resources = {
     academy: deAcademy,
     artifacts: deArtifacts,
     'super-admin-settings-platform-config': deSuperAdminSettingsPlatformConfig,
+    'super-admin-settings-app-alerts': deSuperAdminSettingsAppAlerts,
     'admin-settings-security': deAdminSettingsSecurity,
     'admin-settings-anonymization': deAdminSettingsAnonymization,
     'admin-settings-retention': deAdminSettingsRetention,

--- a/ayunis-core-frontend/src/layouts/app-layout/ui/AppLayout.tsx
+++ b/ayunis-core-frontend/src/layouts/app-layout/ui/AppLayout.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { useRouterState } from '@tanstack/react-router';
 import { SidebarProvider, SidebarInset } from '@/shared/ui/shadcn/sidebar';
 import AppSidebar from '@/widgets/app-sidebar';
+import AppAlertBanner from '@/widgets/app-alert-banner';
 
 interface AppLayoutProps {
   children: React.ReactNode;
@@ -18,8 +19,11 @@ export default function AppLayout({
     <SidebarProvider pathname={location.pathname}>
       {sidebar ?? <AppSidebar />}
       <SidebarInset className="md:peer-data-[variant=inset]:[box-shadow:var(--shadow-sidebar-inset)]">
-        <div className="flex flex-1 flex-col h-screen min-h-0 p-4 pt-0 relative md:rounded-xl md:overflow-hidden">
-          {children}
+        <div className="flex h-screen flex-col">
+          <AppAlertBanner />
+          <div className="flex flex-1 flex-col min-h-0 p-4 pt-0 relative md:rounded-xl md:overflow-hidden">
+            {children}
+          </div>
         </div>
       </SidebarInset>
     </SidebarProvider>

--- a/ayunis-core-frontend/src/pages/super-admin-settings/app-alerts/api/useAppAlert.ts
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/app-alerts/api/useAppAlert.ts
@@ -1,0 +1,11 @@
+import { useAppAlertControllerGetAppAlert } from '@/shared/api';
+
+export default function useAppAlert() {
+  const { data, isLoading, isError } = useAppAlertControllerGetAppAlert();
+
+  return {
+    appAlert: data,
+    isLoading,
+    isError,
+  };
+}

--- a/ayunis-core-frontend/src/pages/super-admin-settings/app-alerts/api/useSetAppAlert.ts
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/app-alerts/api/useSetAppAlert.ts
@@ -1,0 +1,50 @@
+import type { UseFormReturn } from 'react-hook-form';
+import { useQueryClient } from '@tanstack/react-query';
+import { useTranslation } from 'react-i18next';
+import { showError, showSuccess } from '@/shared/lib/toast';
+import extractErrorData from '@/shared/api/extract-error-data';
+import { setValidationErrors } from '@/shared/lib/set-validation-errors';
+import {
+  useSuperAdminPlatformConfigControllerSetAppAlert,
+  getAppAlertControllerGetAppAlertQueryKey,
+} from '@/shared/api';
+import type { AppAlertFormFields } from '../model/types';
+
+export default function useSetAppAlert(
+  form: UseFormReturn<AppAlertFormFields>,
+  onSuccessCallback?: () => void,
+) {
+  const { t } = useTranslation('super-admin-settings-app-alerts');
+  const queryClient = useQueryClient();
+
+  const { mutate, isPending } =
+    useSuperAdminPlatformConfigControllerSetAppAlert({
+      mutation: {
+        onSuccess: () => {
+          void queryClient.invalidateQueries({
+            queryKey: getAppAlertControllerGetAppAlertQueryKey(),
+          });
+          showSuccess(t('toast.updateSuccess'));
+          onSuccessCallback?.();
+        },
+        onError: (error: unknown) => {
+          try {
+            const { code, errors } = extractErrorData(error);
+            if (code === 'VALIDATION_ERROR' && errors) {
+              setValidationErrors(form, errors, t, 'validation');
+            } else {
+              showError(t('toast.updateError'));
+            }
+          } catch {
+            showError(t('toast.updateError'));
+          }
+        },
+      },
+    });
+
+  function setAppAlert(data: AppAlertFormFields) {
+    mutate({ data: { enabled: data.enabled, message: data.message } });
+  }
+
+  return { setAppAlert, isPending };
+}

--- a/ayunis-core-frontend/src/pages/super-admin-settings/app-alerts/index.ts
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/app-alerts/index.ts
@@ -1,0 +1,1 @@
+export { default } from './ui/AppAlertsPage';

--- a/ayunis-core-frontend/src/pages/super-admin-settings/app-alerts/model/createAppAlertSchema.ts
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/app-alerts/model/createAppAlertSchema.ts
@@ -1,0 +1,22 @@
+import { z } from 'zod';
+import type { TFunction } from 'i18next';
+
+const APP_ALERT_MESSAGE_MAX_LENGTH = 1000;
+
+/**
+ * Validation for the app-wide alert banner form. A message is only required
+ * when the banner is enabled — disabling it may leave the message empty.
+ */
+export function createAppAlertSchema(t: TFunction) {
+  return z
+    .object({
+      enabled: z.boolean(),
+      message: z
+        .string()
+        .max(APP_ALERT_MESSAGE_MAX_LENGTH, t('validation.message.maxLength')),
+    })
+    .refine((data) => !data.enabled || data.message.trim().length > 0, {
+      path: ['message'],
+      message: t('validation.message.required'),
+    });
+}

--- a/ayunis-core-frontend/src/pages/super-admin-settings/app-alerts/model/types.ts
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/app-alerts/model/types.ts
@@ -1,0 +1,4 @@
+export interface AppAlertFormFields {
+  enabled: boolean;
+  message: string;
+}

--- a/ayunis-core-frontend/src/pages/super-admin-settings/app-alerts/ui/AppAlertSection.tsx
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/app-alerts/ui/AppAlertSection.tsx
@@ -1,0 +1,121 @@
+import { useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { AlertCircle, Loader2 } from 'lucide-react';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/shared/ui/shadcn/card';
+import { Button } from '@/shared/ui/shadcn/button';
+import { Switch } from '@/shared/ui/shadcn/switch';
+import { Textarea } from '@/shared/ui/shadcn/textarea';
+import { Alert, AlertDescription } from '@/shared/ui/shadcn/alert';
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/shared/ui/shadcn/form';
+import useAppAlert from '../api/useAppAlert';
+import useSetAppAlert from '../api/useSetAppAlert';
+import { createAppAlertSchema } from '../model/createAppAlertSchema';
+import type { AppAlertFormFields } from '../model/types';
+
+export default function AppAlertSection() {
+  const { t } = useTranslation('super-admin-settings-app-alerts');
+  const { appAlert, isLoading, isError } = useAppAlert();
+
+  const form = useForm<AppAlertFormFields>({
+    resolver: zodResolver(createAppAlertSchema(t)),
+    defaultValues: { enabled: false, message: '' },
+  });
+  const { setAppAlert, isPending } = useSetAppAlert(form);
+
+  useEffect(() => {
+    if (appAlert) {
+      form.reset({ enabled: appAlert.enabled, message: appAlert.message });
+    }
+  }, [appAlert, form]);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{t('appAlert.title')}</CardTitle>
+        <CardDescription>{t('appAlert.description')}</CardDescription>
+      </CardHeader>
+      <CardContent>
+        {isError && (
+          <Alert variant="destructive" className="mb-4">
+            <AlertCircle className="h-4 w-4" />
+            <AlertDescription>{t('appAlert.loadError')}</AlertDescription>
+          </Alert>
+        )}
+        {isLoading && (
+          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+            <Loader2 className="h-4 w-4 animate-spin" />
+          </div>
+        )}
+        {!isLoading && !isError && (
+          <Form {...form}>
+            <form
+              onSubmit={(e) => void form.handleSubmit(setAppAlert)(e)}
+              className="space-y-6"
+            >
+              <FormField
+                control={form.control}
+                name="enabled"
+                render={({ field }) => (
+                  <FormItem className="flex items-center justify-between gap-4">
+                    <div className="space-y-0.5">
+                      <FormLabel>{t('appAlert.showAlertLabel')}</FormLabel>
+                      <FormDescription>
+                        {t('appAlert.showAlertDescription')}
+                      </FormDescription>
+                    </div>
+                    <FormControl>
+                      <Switch
+                        checked={field.value}
+                        onCheckedChange={field.onChange}
+                        disabled={isPending}
+                      />
+                    </FormControl>
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="message"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>{t('appAlert.messageLabel')}</FormLabel>
+                    <FormControl>
+                      <Textarea
+                        {...field}
+                        placeholder={t('appAlert.messagePlaceholder')}
+                        maxLength={1000}
+                        className="min-h-[100px]"
+                        disabled={isPending}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <Button type="submit" disabled={isPending}>
+                {isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                {t('appAlert.save')}
+              </Button>
+            </form>
+          </Form>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/ayunis-core-frontend/src/pages/super-admin-settings/app-alerts/ui/AppAlertsPage.tsx
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/app-alerts/ui/AppAlertsPage.tsx
@@ -1,0 +1,15 @@
+import { useTranslation } from 'react-i18next';
+import SuperAdminSettingsLayout from '../../super-admin-settings-layout';
+import AppAlertSection from './AppAlertSection';
+
+export default function AppAlertsPage() {
+  const { t } = useTranslation('super-admin-settings-app-alerts');
+
+  return (
+    <SuperAdminSettingsLayout pageTitle={t('title')}>
+      <div className="space-y-6">
+        <AppAlertSection />
+      </div>
+    </SuperAdminSettingsLayout>
+  );
+}

--- a/ayunis-core-frontend/src/pages/super-admin-settings/super-admin-settings-layout/ui/SuperAdminSettingsSidebar.tsx
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/super-admin-settings-layout/ui/SuperAdminSettingsSidebar.tsx
@@ -6,6 +6,7 @@ import {
   Settings2,
   GraduationCap,
   Users,
+  Megaphone,
 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import {
@@ -51,6 +52,11 @@ export function SuperAdminSettingsSidebar() {
       to: '/super-admin-settings/platform-config',
       icon: <Settings2 />,
       label: t('layout.platformConfig'),
+    },
+    {
+      to: '/super-admin-settings/app-alerts',
+      icon: <Megaphone />,
+      label: t('layout.appAlerts'),
     },
   ];
 

--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
@@ -3718,6 +3718,23 @@ export interface SetImageFairUseLimitRequestDto {
   windowMs: number;
 }
 
+export interface SetAppAlertRequestDto {
+  /** Whether to show the app-wide alert banner */
+  enabled: boolean;
+  /**
+   * The alert banner text. Required (non-empty) when enabled is true.
+   * @maxLength 1000
+   */
+  message: string;
+}
+
+export interface AppAlertResponseDto {
+  /** Whether the app-wide alert banner is currently shown */
+  enabled: boolean;
+  /** The alert banner text shown to all users */
+  message: string;
+}
+
 /**
  * Type of the message content
  */

--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.ts
@@ -35,6 +35,7 @@ import type {
   AddonStatusResponseDto,
   AdminUpdateUserDto,
   ApiKeyResponseDto,
+  AppAlertResponseDto,
   ArtifactResponseDto,
   ArtifactVersionResponseDto,
   ArtifactsControllerExportParams,
@@ -130,6 +131,7 @@ import type {
   RevertArtifactDto,
   RunsControllerSendMessage200,
   RunsControllerSendMessageBody,
+  SetAppAlertRequestDto,
   SetCreditsPerEuroRequestDto,
   SetFairUseLimitRequestDto,
   SetImageFairUseLimitRequestDto,
@@ -15620,6 +15622,165 @@ export const useSuperAdminPlatformConfigControllerSetImageFairUseLimit = <TError
       return useMutation(mutationOptions, queryClient);
     }
     
+/**
+ * Enable or disable the persistent alert banner shown to all users and set its message. When enabling, a non-empty message is required. Super admin only.
+ * @summary Set the app-wide alert banner
+ */
+export const superAdminPlatformConfigControllerSetAppAlert = (
+    setAppAlertRequestDto: SetAppAlertRequestDto,
+ ) => {
+      
+      
+      return customAxiosInstance<void>(
+      {url: `/super-admin/platform-config/app-alert`, method: 'PUT',
+      headers: {'Content-Type': 'application/json', },
+      data: setAppAlertRequestDto
+    },
+      );
+    }
+  
+
+
+export const getSuperAdminPlatformConfigControllerSetAppAlertMutationOptions = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof superAdminPlatformConfigControllerSetAppAlert>>, TError,{data: SetAppAlertRequestDto}, TContext>, }
+): UseMutationOptions<Awaited<ReturnType<typeof superAdminPlatformConfigControllerSetAppAlert>>, TError,{data: SetAppAlertRequestDto}, TContext> => {
+
+const mutationKey = ['superAdminPlatformConfigControllerSetAppAlert'];
+const {mutation: mutationOptions} = options ?
+      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
+      options
+      : {...options, mutation: {...options.mutation, mutationKey}}
+      : {mutation: { mutationKey, }};
+
+      
+
+
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof superAdminPlatformConfigControllerSetAppAlert>>, {data: SetAppAlertRequestDto}> = (props) => {
+          const {data} = props ?? {};
+
+          return  superAdminPlatformConfigControllerSetAppAlert(data,)
+        }
+
+        
+
+
+  return  { mutationFn, ...mutationOptions }}
+
+    export type SuperAdminPlatformConfigControllerSetAppAlertMutationResult = NonNullable<Awaited<ReturnType<typeof superAdminPlatformConfigControllerSetAppAlert>>>
+    export type SuperAdminPlatformConfigControllerSetAppAlertMutationBody = SetAppAlertRequestDto
+    export type SuperAdminPlatformConfigControllerSetAppAlertMutationError = void
+
+    /**
+ * @summary Set the app-wide alert banner
+ */
+export const useSuperAdminPlatformConfigControllerSetAppAlert = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof superAdminPlatformConfigControllerSetAppAlert>>, TError,{data: SetAppAlertRequestDto}, TContext>, }
+ , queryClient?: QueryClient): UseMutationResult<
+        Awaited<ReturnType<typeof superAdminPlatformConfigControllerSetAppAlert>>,
+        TError,
+        {data: SetAppAlertRequestDto},
+        TContext
+      > => {
+
+      const mutationOptions = getSuperAdminPlatformConfigControllerSetAppAlertMutationOptions(options);
+
+      return useMutation(mutationOptions, queryClient);
+    }
+    
+/**
+ * Retrieve the persistent alert banner configuration shown to all users. Returns `enabled: false` with an empty message when no banner has been configured.
+ * @summary Get the current app-wide alert banner
+ */
+export const appAlertControllerGetAppAlert = (
+    
+ signal?: AbortSignal
+) => {
+      
+      
+      return customAxiosInstance<AppAlertResponseDto>(
+      {url: `/app-alert`, method: 'GET', signal
+    },
+      );
+    }
+  
+
+
+
+export const getAppAlertControllerGetAppAlertQueryKey = () => {
+    return [
+    `/app-alert`
+    ] as const;
+    }
+
+    
+export const getAppAlertControllerGetAppAlertQueryOptions = <TData = Awaited<ReturnType<typeof appAlertControllerGetAppAlert>>, TError = void>( options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof appAlertControllerGetAppAlert>>, TError, TData>>, }
+) => {
+
+const {query: queryOptions} = options ?? {};
+
+  const queryKey =  queryOptions?.queryKey ?? getAppAlertControllerGetAppAlertQueryKey();
+
+  
+
+    const queryFn: QueryFunction<Awaited<ReturnType<typeof appAlertControllerGetAppAlert>>> = ({ signal }) => appAlertControllerGetAppAlert(signal);
+
+      
+
+      
+
+   return  { queryKey, queryFn, ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof appAlertControllerGetAppAlert>>, TError, TData> & { queryKey: DataTag<QueryKey, TData, TError> }
+}
+
+export type AppAlertControllerGetAppAlertQueryResult = NonNullable<Awaited<ReturnType<typeof appAlertControllerGetAppAlert>>>
+export type AppAlertControllerGetAppAlertQueryError = void
+
+
+export function useAppAlertControllerGetAppAlert<TData = Awaited<ReturnType<typeof appAlertControllerGetAppAlert>>, TError = void>(
+  options: { query:Partial<UseQueryOptions<Awaited<ReturnType<typeof appAlertControllerGetAppAlert>>, TError, TData>> & Pick<
+        DefinedInitialDataOptions<
+          Awaited<ReturnType<typeof appAlertControllerGetAppAlert>>,
+          TError,
+          Awaited<ReturnType<typeof appAlertControllerGetAppAlert>>
+        > , 'initialData'
+      >, }
+ , queryClient?: QueryClient
+  ):  DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useAppAlertControllerGetAppAlert<TData = Awaited<ReturnType<typeof appAlertControllerGetAppAlert>>, TError = void>(
+  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof appAlertControllerGetAppAlert>>, TError, TData>> & Pick<
+        UndefinedInitialDataOptions<
+          Awaited<ReturnType<typeof appAlertControllerGetAppAlert>>,
+          TError,
+          Awaited<ReturnType<typeof appAlertControllerGetAppAlert>>
+        > , 'initialData'
+      >, }
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useAppAlertControllerGetAppAlert<TData = Awaited<ReturnType<typeof appAlertControllerGetAppAlert>>, TError = void>(
+  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof appAlertControllerGetAppAlert>>, TError, TData>>, }
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+/**
+ * @summary Get the current app-wide alert banner
+ */
+
+export function useAppAlertControllerGetAppAlert<TData = Awaited<ReturnType<typeof appAlertControllerGetAppAlert>>, TError = void>(
+  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof appAlertControllerGetAppAlert>>, TError, TData>>, }
+ , queryClient?: QueryClient 
+ ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
+
+  const queryOptions = getAppAlertControllerGetAppAlertQueryOptions(options)
+
+  const query = useQuery(queryOptions, queryClient) as  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+
+  query.queryKey = queryOptions.queryKey ;
+
+  return query;
+}
+
+
+
+
+
 /**
  * Sends a user message (with optional image attachments) and returns a server-sent events stream with the AI response. Images are processed transactionally with the message.
  * @summary Send a message with optional images and receive streaming response

--- a/ayunis-core-frontend/src/shared/api/openapi-schema.json
+++ b/ayunis-core-frontend/src/shared/api/openapi-schema.json
@@ -7611,6 +7611,66 @@
         "tags": ["Super Admin Platform Config"]
       }
     },
+    "/super-admin/platform-config/app-alert": {
+      "put": {
+        "description": "Enable or disable the persistent alert banner shown to all users and set its message. When enabling, a non-empty message is required. Super admin only.",
+        "operationId": "SuperAdminPlatformConfigController_setAppAlert",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetAppAlertRequestDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "description": "Successfully updated the app alert banner"
+          },
+          "400": {
+            "description": "Invalid value provided (message required when enabled, or message too long)"
+          },
+          "401": {
+            "description": "User not authenticated or not authorized as super admin"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "summary": "Set the app-wide alert banner",
+        "tags": ["Super Admin Platform Config"]
+      }
+    },
+    "/app-alert": {
+      "get": {
+        "description": "Retrieve the persistent alert banner configuration shown to all users. Returns `enabled: false` with an empty message when no banner has been configured.",
+        "operationId": "AppAlertController_getAppAlert",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved the app alert configuration",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AppAlertResponseDto"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "User not authenticated"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "summary": "Get the current app-wide alert banner",
+        "tags": ["App Alert"]
+      }
+    },
     "/runs/send-message": {
       "post": {
         "description": "Sends a user message (with optional image attachments) and returns a server-sent events stream with the AI response. Images are processed transactionally with the message.",
@@ -14608,6 +14668,39 @@
           }
         },
         "required": ["limit", "windowMs"]
+      },
+      "SetAppAlertRequestDto": {
+        "type": "object",
+        "properties": {
+          "enabled": {
+            "type": "boolean",
+            "description": "Whether to show the app-wide alert banner",
+            "example": true
+          },
+          "message": {
+            "type": "string",
+            "description": "The alert banner text. Required (non-empty) when enabled is true.",
+            "example": "The system is currently experiencing degraded performance.",
+            "maxLength": 1000
+          }
+        },
+        "required": ["enabled", "message"]
+      },
+      "AppAlertResponseDto": {
+        "type": "object",
+        "properties": {
+          "enabled": {
+            "type": "boolean",
+            "description": "Whether the app-wide alert banner is currently shown",
+            "example": true
+          },
+          "message": {
+            "type": "string",
+            "description": "The alert banner text shown to all users",
+            "example": "The system is currently experiencing degraded performance."
+          }
+        },
+        "required": ["enabled", "message"]
       },
       "MessageContentResponseDto": {
         "type": "object",

--- a/ayunis-core-frontend/src/shared/locales/de/super-admin-settings-app-alerts.json
+++ b/ayunis-core-frontend/src/shared/locales/de/super-admin-settings-app-alerts.json
@@ -1,0 +1,26 @@
+{
+  "title": "App-Hinweise",
+  "appAlert": {
+    "title": "Hinweisbanner",
+    "description": "Zeigt allen Benutzern ein dauerhaftes Warnbanner am oberen Rand jeder Seite an.",
+    "showAlertLabel": "Hinweis anzeigen",
+    "showAlertDescription": "Wenn aktiviert, wird die untenstehende Nachricht allen Benutzern auf jeder Seite angezeigt.",
+    "messageLabel": "Hinweistext",
+    "messagePlaceholder": "z. B. Wir untersuchen derzeit eine Störung des Dienstes.",
+    "save": "Speichern",
+    "loadError": "Die Konfiguration des Hinweisbanners konnte nicht geladen werden."
+  },
+  "toast": {
+    "updateSuccess": "Hinweisbanner aktualisiert.",
+    "updateError": "Das Hinweisbanner konnte nicht aktualisiert werden."
+  },
+  "validation": {
+    "message": {
+      "isNotEmpty": "Wenn der Hinweis aktiviert ist, muss ein Text angegeben werden.",
+      "required": "Wenn der Hinweis aktiviert ist, muss ein Text angegeben werden.",
+      "maxLength": "Der Text darf höchstens 1000 Zeichen lang sein.",
+      "invalid": "Ungültiger Text."
+    },
+    "invalid": "Ungültige Eingabe."
+  }
+}

--- a/ayunis-core-frontend/src/shared/locales/de/super-admin-settings-layout.json
+++ b/ayunis-core-frontend/src/shared/locales/de/super-admin-settings-layout.json
@@ -10,6 +10,7 @@
     "skills": "Skill-Vorlagen",
     "academy": "Academy",
     "superAdmins": "Super-Admins",
-    "platformConfig": "Plattform-Konfiguration"
+    "platformConfig": "Plattform-Konfiguration",
+    "appAlerts": "App-Hinweise"
   }
 }

--- a/ayunis-core-frontend/src/shared/locales/en/super-admin-settings-app-alerts.json
+++ b/ayunis-core-frontend/src/shared/locales/en/super-admin-settings-app-alerts.json
@@ -1,0 +1,26 @@
+{
+  "title": "App Alerts",
+  "appAlert": {
+    "title": "Alert Banner",
+    "description": "Show a persistent warning banner at the top of every page for all users.",
+    "showAlertLabel": "Show alert",
+    "showAlertDescription": "When enabled, the message below is shown to all users on every page.",
+    "messageLabel": "Alert message",
+    "messagePlaceholder": "e.g. We are currently investigating a service disruption.",
+    "save": "Save",
+    "loadError": "Failed to load the alert banner configuration."
+  },
+  "toast": {
+    "updateSuccess": "Alert banner updated.",
+    "updateError": "Failed to update the alert banner."
+  },
+  "validation": {
+    "message": {
+      "isNotEmpty": "A message is required when the alert is enabled.",
+      "required": "A message is required when the alert is enabled.",
+      "maxLength": "The message must be 1000 characters or fewer.",
+      "invalid": "Invalid message."
+    },
+    "invalid": "Invalid input."
+  }
+}

--- a/ayunis-core-frontend/src/shared/locales/en/super-admin-settings-layout.json
+++ b/ayunis-core-frontend/src/shared/locales/en/super-admin-settings-layout.json
@@ -10,6 +10,7 @@
     "skills": "Skill Templates",
     "academy": "Academy",
     "superAdmins": "Super Admins",
-    "platformConfig": "Platform Config"
+    "platformConfig": "Platform Config",
+    "appAlerts": "App Alerts"
   }
 }

--- a/ayunis-core-frontend/src/widgets/app-alert-banner/index.ts
+++ b/ayunis-core-frontend/src/widgets/app-alert-banner/index.ts
@@ -1,0 +1,1 @@
+export { default } from './ui/AppAlertBanner';

--- a/ayunis-core-frontend/src/widgets/app-alert-banner/ui/AppAlertBanner.tsx
+++ b/ayunis-core-frontend/src/widgets/app-alert-banner/ui/AppAlertBanner.tsx
@@ -1,0 +1,28 @@
+import { TriangleAlert } from 'lucide-react';
+import { useAppAlertControllerGetAppAlert } from '@/shared/api';
+import { Alert, AlertDescription } from '@/shared/ui/shadcn/alert';
+
+/**
+ * Persistent app-wide alert banner shown at the top of every authenticated
+ * page when a super admin has enabled it. Renders nothing when disabled or
+ * when no message has been configured.
+ */
+export default function AppAlertBanner() {
+  const { data } = useAppAlertControllerGetAppAlert();
+
+  if (!data?.enabled || data.message.trim().length === 0) {
+    return null;
+  }
+
+  return (
+    <Alert
+      variant="warning"
+      className="shrink-0 items-center rounded-none border-x-0 border-t-0 px-4 py-2"
+    >
+      <TriangleAlert className="h-4 w-4" />
+      <AlertDescription className="text-warning font-medium">
+        {data.message}
+      </AlertDescription>
+    </Alert>
+  );
+}


### PR DESCRIPTION
## AYC-342 — Persistent custom alert banner for super admins

Lets super admins show an always-present warning banner with custom text across the whole app (e.g. to announce an outage like the one in the linked incident).

### What's included
- **New super-admin page "App Alerts"** (under the Super Admin sidebar) with a **Show alert** toggle and a message field. When the toggle is on, a message is required.
- **Global warning banner** rendered at the very top of the app layout on every authenticated page.
- **Backend** (extends the existing `platform-config` key/value store — no migration needed):
  - `APP_ALERT_ENABLED` / `APP_ALERT_MESSAGE` keys + `GetAppAlert` / `SetAppAlert` use cases (message required when enabled, max 1000 chars).
  - `PUT /super-admin/platform-config/app-alert` — super-admin only (configure).
  - `GET /app-alert` — any authenticated user (so the banner loads everywhere).
- Regenerated frontend API client; en/de translations.

### Validation
- Backend: 7 new unit tests pass; tsc + ESLint clean; all pre-commit checks pass.
- Frontend: `pnpm run build` succeeds; lint 0 errors; new route registered.
- **Runtime (curl against local backend):** default → `{enabled:false,message:""}`; PUT enable → `204`; GET reflects the message; enabling with a blank message → `400` with the expected validation error.

> Note: the global banner was not browser-smoke-tested (the `bb` headless tool isn't installed on the dev machine); it was verified via build/type-check and mirrors the existing `Alert` (`warning` variant) usage.

Closes AYC-342

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Feature is additive with super-admin-only writes and standard validation; banner text is shown to all users but is admin-controlled operational messaging, not auth or billing logic.
> 
> **Overview**
> Adds a **super-admin–controlled app-wide alert banner** stored in platform config (`APP_ALERT_ENABLED` / `APP_ALERT_MESSAGE`), with no DB migration.
> 
> **Backend:** New `GetAppAlert` / `SetAppAlert` use cases (defaults when unset; atomic `setMany`; non-empty message required when enabled; 1000-char cap). **Super admins** update via `PUT /super-admin/platform-config/app-alert`; **any authenticated user** reads via `GET /app-alert`. `GetAppAlertUseCase` is exported from the module.
> 
> **Frontend:** New **App Alerts** super-admin settings page (toggle + message form), sidebar entry, en/de i18n, and regenerated API client. **`AppAlertBanner`** in `AppLayout` fetches `GET /app-alert` and shows a warning strip when enabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2923bdce71791be3d29ba0bcc0dd2bf8fcb972f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->