### PR TITLE
fix(subscriptions): coerce seat/credit inputs to numbers in change flow (AYC-354)

### DIFF
--- a/ayunis-core-frontend/src/pages/super-admin-settings/org/api/useSuperAdminSubscriptionChange.ts
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/org/api/useSuperAdminSubscriptionChange.ts
@@ -85,9 +85,14 @@ export default function useSuperAdminSubscriptionChange({
         country: data.country,
         vatNumber: data.vatNumber,
         type: data.type,
-        noOfSeats: data.type === 'SEAT_BASED' ? data.noOfSeats : undefined,
+        // form.getValues() returns raw RHF state; the number inputs hold
+        // strings, so coerce them (the create flow gets these already coerced
+        // from handleSubmit's zod-resolved data, but the change flow reads raw
+        // values because the disposition is picked in a second dialog).
+        noOfSeats:
+          data.type === 'SEAT_BASED' ? Number(data.noOfSeats) : undefined,
         monthlyCredits:
-          data.type === 'USAGE_BASED' ? data.monthlyCredits : undefined,
+          data.type === 'USAGE_BASED' ? Number(data.monthlyCredits) : undefined,
         startsAt: data.startsAt,
         oldSubscriptionDisposition: disposition,
       },


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single-file payload fix for a known type mismatch; no auth or broader billing logic changes.
> 
> **Overview**
> Fixes super-admin **subscription change** requests sending **string** `noOfSeats` / `monthlyCredits` to the API when those fields come from raw react-hook-form state.
> 
> `confirmChange` builds the payload with `form.getValues()` after the old-subscription disposition is chosen in a second step, so it skips the zod resolver path used on create (`handleSubmit`). Number inputs still store strings in RHF; the change payload now applies **`Number(...)`** for seat-based and usage-based types so the API gets numeric values, matching what the create flow already sends after zod coercion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c87233df6dc3c6fbffc66df26e244ecfe0105237. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->