### PR TITLE
fix(layout): prevent new-chat backdrop from clipping below viewport (AYC-000)

### DIFF
--- a/ayunis-core-frontend/src/layouts/app-layout/ui/AppLayout.tsx
+++ b/ayunis-core-frontend/src/layouts/app-layout/ui/AppLayout.tsx
@@ -19,7 +19,7 @@ export default function AppLayout({
     <SidebarProvider pathname={location.pathname}>
       {sidebar ?? <AppSidebar />}
       <SidebarInset className="md:peer-data-[variant=inset]:[box-shadow:var(--shadow-sidebar-inset)]">
-        <div className="flex h-screen flex-col">
+        <div className="flex flex-1 flex-col min-h-0">
           <AppAlertBanner />
           <div className="flex flex-1 flex-col min-h-0 p-4 pt-0 relative md:rounded-xl md:overflow-hidden">
             {children}


### PR DESCRIPTION
The AppLayout wrapper added for the app-alert banner used h-screen
(100vh) without flex-1. Because SidebarInset carries an 8px inset
margin (m-2), a rigid 100vh child overflowed the viewport by the
margin, pushing the new-chat backdrop's rounded bottom edge and
gradient peak below #app's overflow:hidden — so it rendered hard-cut.

The pre-banner layout carried flex-1 on this element, which set
flex-basis:0 and made h-screen a no-op for sizing. Restoring flex-1
+ min-h-0 lets the wrapper fill the inset content box (viewport minus
margins) instead of seeding 100vh, so the backdrop ends cleanly inside
the rounded inset with the intended 8px bottom gap.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single Tailwind class change on the app shell layout with no logic or API impact.
> 
> **Overview**
> Fixes **new-chat backdrop** clipping at the bottom of the inset panel by changing how `AppLayout` sizes its main content wrapper.
> 
> The inner wrapper around `AppAlertBanner` and page content switches from **`h-screen`** to **`flex flex-1 flex-col min-h-0`**, so height comes from the flex parent (`SidebarInset`) instead of a fixed **100vh**. With inset **`m-2`**, a full-viewport child was taller than the rounded inset and got cut off by **`overflow:hidden`** on the content area; flex sizing keeps the backdrop and gradient inside the inset with the intended bottom gap.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b6a565fb111f4b0b43168a03ebee46dfe17ef40. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->