### PR TITLE
fix(app-alert): vertically align icon with text in alert banner (AYC-362)

### DIFF
--- a/ayunis-core-frontend/src/widgets/app-alert-banner/ui/AppAlertBanner.tsx
+++ b/ayunis-core-frontend/src/widgets/app-alert-banner/ui/AppAlertBanner.tsx
@@ -17,7 +17,7 @@ export default function AppAlertBanner() {
   return (
     <Alert
       variant="warning"
-      className="shrink-0 items-center rounded-none border-x-0 border-t-0 px-4 py-2"
+      className="shrink-0 items-center rounded-none border-x-0 border-t-0 px-4 py-2 [&>svg]:translate-y-0"
     >
       <TriangleAlert className="h-4 w-4" />
       <AlertDescription className="text-warning font-medium">


### PR DESCRIPTION
## What

Fixes the icon/text misalignment in the app-wide alert banner (AYC-362). The warning triangle icon sat slightly below the text's vertical center.

## Why

The shared shadcn `Alert` component applies `[&>svg]:translate-y-0.5` to nudge the icon down for its default top-aligned, multi-line layout. The app alert banner overrides that to a single-line, vertically-centered layout (`items-center`), where the extra 0.5 nudge pushed the icon below the text center.

## How

Override the icon translate to `0` on the banner's `<Alert>` (`[&>svg]:translate-y-0`), keeping `items-center`. `cn()` uses `tailwind-merge`, so this cleanly supersedes the shared `translate-y-0.5` without touching the shared component (whose nudge is still correct for other alerts).

Single-line change in `AppAlertBanner.tsx`. Lint, typecheck, and pre-commit checks pass.

Closes AYC-362

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single Tailwind class override on a presentational banner; no logic or API changes.
> 
> **Overview**
> Fixes misaligned warning icon in the app-wide alert banner by overriding the shared **Alert** component’s default `[&>svg]:translate-y-0.5` (meant for top-aligned multi-line alerts).
> 
> **AppAlertBanner** adds `[&>svg]:translate-y-0` on its **Alert** `className` so the icon stays vertically centered with the single-line message.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62f0837176aefc1530cbd231cf1bfb67d2fa8569. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->