### PR TITLE
feat(academy): make module video full width (AYC-327)

### DIFF
--- a/ayunis-core-frontend/src/layouts/content-area-layout/ui/ContentAreaLayout.tsx
+++ b/ayunis-core-frontend/src/layouts/content-area-layout/ui/ContentAreaLayout.tsx
@@ -6,6 +6,11 @@ interface ContentAreaLayoutProps {
   contentArea: React.ReactNode;
   className?: string;
   resetKey?: unknown;
+  /**
+   * When true, the content area is not constrained to the default max width,
+   * allowing children to span the full width of the scroll region.
+   */
+  fullWidth?: boolean;
 }
 
 export const ContentAreaLayout: React.FC<ContentAreaLayoutProps> = ({
@@ -13,22 +18,25 @@ export const ContentAreaLayout: React.FC<ContentAreaLayoutProps> = ({
   contentArea,
   className = '',
   resetKey,
+  fullWidth = false,
 }) => {
   const { scrollRef, headerScrolled, onScroll } =
     useContentScrollHeader(resetKey);
 
   return (
     <div className={`flex min-h-0 flex-col absolute inset-0 pb-4 ${className}`}>
-      <div className="content-scroll-region relative flex min-h-0 flex-1 flex-col pr-2">
+      <div className="content-scroll-region relative flex min-h-0 flex-1 flex-col">
         <div
           ref={scrollRef}
-          className="min-h-0 flex-1 overflow-x-hidden overflow-y-auto w-full"
+          className="content-scroll-viewport min-h-0 flex-1 overflow-x-hidden overflow-y-auto w-full"
           onScroll={onScroll}
         >
           {contentHeader && (
             <div className="content-scroll-header-offset" aria-hidden />
           )}
-          <div className="mx-auto w-full max-w-[800px] px-2 pb-3">
+          <div
+            className={`mx-auto w-full px-2 pb-3 ${fullWidth ? '' : 'max-w-[800px]'}`}
+          >
             {contentArea}
           </div>
         </div>

--- a/ayunis-core-frontend/src/pages/academy/ui/ChapterDetailPage.tsx
+++ b/ayunis-core-frontend/src/pages/academy/ui/ChapterDetailPage.tsx
@@ -93,9 +93,21 @@ export default function ChapterDetailPage({
   const isLast = currentIndex === modules.length - 1;
 
   const moduleView = (
-    <div className="flex flex-col gap-4 lg:flex-row">
-      {/* Main column: video + navigation */}
-      <div className="flex-1 space-y-4">
+    <div className="space-y-4">
+      {/* Full-width video */}
+      <div className="aspect-video overflow-hidden rounded-lg border bg-muted">
+        <iframe
+          key={currentModule.id}
+          src={toLoomEmbedUrl(currentModule.loomUrl)}
+          title={currentModule.title}
+          className="h-full w-full"
+          allowFullScreen
+          allow="autoplay; fullscreen; picture-in-picture"
+        />
+      </div>
+
+      {/* Constrained text region: title, description, navigation, module list */}
+      <div className="mx-auto max-w-[800px] space-y-4">
         <div>
           <h2 className="text-lg font-semibold">{currentModule.title}</h2>
           {currentModule.description && (
@@ -104,16 +116,7 @@ export default function ChapterDetailPage({
             </p>
           )}
         </div>
-        <div className="aspect-video w-full overflow-hidden rounded-lg border bg-muted">
-          <iframe
-            key={currentModule.id}
-            src={toLoomEmbedUrl(currentModule.loomUrl)}
-            title={currentModule.title}
-            className="h-full w-full"
-            allowFullScreen
-            allow="autoplay; fullscreen; picture-in-picture"
-          />
-        </div>
+
         <div className="flex items-center justify-between">
           <Button
             variant="outline"
@@ -134,36 +137,40 @@ export default function ChapterDetailPage({
             </Button>
           )}
         </div>
-      </div>
 
-      {/* Side column: module title list */}
-      <nav className="lg:w-56 lg:flex-shrink-0">
-        <p className="mb-2 px-2 text-sm font-medium text-muted-foreground">
-          {t('detail.modulesTitle')}
-        </p>
-        <ul className="space-y-1">
-          {modules.map((module, index) => (
-            <li key={module.id}>
-              <Button
-                variant={index === currentIndex ? 'secondary' : 'ghost'}
-                onClick={() => goToModule(index)}
-                className="w-full justify-start gap-2 text-left"
-              >
-                <span className="text-muted-foreground tabular-nums">
-                  {index + 1}
-                </span>
-                <span className="truncate">{module.title}</span>
-              </Button>
-            </li>
-          ))}
-        </ul>
-      </nav>
+        {/* Module title list */}
+        <nav>
+          <p className="mb-2 px-2 text-sm font-medium text-muted-foreground">
+            {t('detail.modulesTitle')}
+          </p>
+          <ul className="space-y-1">
+            {modules.map((module, index) => (
+              <li key={module.id}>
+                <Button
+                  variant={index === currentIndex ? 'secondary' : 'ghost'}
+                  onClick={() => goToModule(index)}
+                  className="w-full justify-start gap-2 text-left"
+                >
+                  <span className="text-muted-foreground tabular-nums">
+                    {index + 1}
+                  </span>
+                  <span className="truncate">{module.title}</span>
+                </Button>
+              </li>
+            ))}
+          </ul>
+        </nav>
+      </div>
     </div>
   );
 
   return (
     <AppLayout>
-      <ContentAreaLayout contentHeader={header} contentArea={moduleView} />
+      <ContentAreaLayout
+        contentHeader={header}
+        contentArea={moduleView}
+        fullWidth
+      />
     </AppLayout>
   );
 }

--- a/ayunis-core-frontend/src/styles/scroll-region.css
+++ b/ayunis-core-frontend/src/styles/scroll-region.css
@@ -9,6 +9,15 @@
     --content-scroll-header-gap: 1rem;
   }
 
+  /*
+   * Reserve scrollbar space on both sides so content stays horizontally
+   * symmetric whether or not a scrollbar is present. Without this, the
+   * scrollbar only eats space on the right, shifting full-width content left.
+   */
+  .content-scroll-viewport {
+    scrollbar-gutter: stable both-edges;
+  }
+
   .content-scroll-header {
     @apply absolute inset-x-0 top-0 z-10 overflow-hidden rounded-t-xl border-b border-transparent px-3 py-2;
     @apply bg-background/80 backdrop-blur-md transition-[border-color] duration-200 ease-out;


### PR DESCRIPTION
* Add a fullWidth prop to ContentAreaLayout that drops the max-width
  cap so content can span the full scroll region.
* Restructure the academy module view: video renders full width at the
  top, with title, description, navigation, and the module list in a
  constrained (max-w-800) column below.
* Fix horizontal asymmetry in ContentAreaLayout structurally: remove the
  right-only pr-2 gutter and reserve scrollbar space on both sides via
  scrollbar-gutter stable both-edges, so full-width content stays
  centered whether or not a scrollbar is present.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only layout and CSS changes; `fullWidth` is opt-in and only used on the academy module view, with a minor global scroll styling tweak on all content pages.
> 
> **Overview**
> Adds an optional **`fullWidth`** flag on **`ContentAreaLayout`** so the inner content wrapper can skip the default **`max-w-[800px]`** cap while keeping the same scroll/header behavior. Academy chapter module view uses it and is restructured: the Loom video sits **full width at the top**, with title, description, prev/next controls, and the module list in a **centered max-width column** below (replacing the previous side-by-side layout with a sidebar nav).
> 
> Scroll chrome is adjusted for full-width content: the scroll region drops the right-only **`pr-2`** gutter, the scroll container gets a **`content-scroll-viewport`** hook, and **`scrollbar-gutter: stable both-edges`** keeps horizontal alignment centered when a vertical scrollbar appears.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 550883c3d634785bb0bc1c2988ff9f66c1cf6cde. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->