### PR TITLE
feat(academy): add per-chapter quiz question pool (AYC-244)

### DIFF
--- a/ayunis-core-backend/src/db/migrations/1782913003187-AddAcademyQuizQuestions.ts
+++ b/ayunis-core-backend/src/db/migrations/1782913003187-AddAcademyQuizQuestions.ts
@@ -1,0 +1,33 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddAcademyQuizQuestions1782913003187 implements MigrationInterface {
+  name = 'AddAcademyQuizQuestions1782913003187';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE "academy_quiz_questions" ("id" character varying NOT NULL, "createdAt" TIMESTAMP NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP NOT NULL DEFAULT now(), "chapterId" character varying NOT NULL, "text" text NOT NULL, "options" jsonb NOT NULL, "position" integer NOT NULL, CONSTRAINT "PK_2351acb2a20e16b6d87f986d25c" PRIMARY KEY ("id"))`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_37ef5879e7742e11cd9bfbcb5f" ON "academy_quiz_questions" ("chapterId") `,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "academy_chapters" ADD "quizEnabled" boolean NOT NULL DEFAULT false`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "academy_quiz_questions" ADD CONSTRAINT "FK_37ef5879e7742e11cd9bfbcb5fc" FOREIGN KEY ("chapterId") REFERENCES "academy_chapters"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "academy_quiz_questions" DROP CONSTRAINT "FK_37ef5879e7742e11cd9bfbcb5fc"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "academy_chapters" DROP COLUMN "quizEnabled"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_37ef5879e7742e11cd9bfbcb5f"`,
+    );
+    await queryRunner.query(`DROP TABLE "academy_quiz_questions"`);
+  }
+}

--- a/ayunis-core-backend/src/domain/academy/academy.module.ts
+++ b/ayunis-core-backend/src/domain/academy/academy.module.ts
@@ -2,12 +2,16 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { AcademyChapterRecord } from './infrastructure/persistence/local/schema/academy-chapter.record';
 import { AcademyCourseModuleRecord } from './infrastructure/persistence/local/schema/academy-course-module.record';
+import { AcademyQuizQuestionRecord } from './infrastructure/persistence/local/schema/academy-quiz-question.record';
 import { AcademyMapper } from './infrastructure/persistence/local/mappers/academy.mapper';
 import { LocalAcademyChapterRepository } from './infrastructure/persistence/local/local-academy-chapter.repository';
 import { LocalAcademyCourseModuleRepository } from './infrastructure/persistence/local/local-academy-course-module.repository';
+import { LocalAcademyQuizQuestionRepository } from './infrastructure/persistence/local/local-academy-quiz-question.repository';
 import { AcademyChapterRepository } from './application/ports/academy-chapter.repository';
 import { AcademyCourseModuleRepository } from './application/ports/academy-course-module.repository';
+import { AcademyQuizQuestionRepository } from './application/ports/academy-quiz-question.repository';
 import { GetAcademyContentUseCase } from './application/use-cases/get-academy-content/get-academy-content.use-case';
+import { GetAcademyManagementContentUseCase } from './application/use-cases/get-academy-management-content/get-academy-management-content.use-case';
 import { CreateChapterUseCase } from './application/use-cases/create-chapter/create-chapter.use-case';
 import { UpdateChapterUseCase } from './application/use-cases/update-chapter/update-chapter.use-case';
 import { DeleteChapterUseCase } from './application/use-cases/delete-chapter/delete-chapter.use-case';
@@ -16,25 +20,35 @@ import { CreateCourseModuleUseCase } from './application/use-cases/create-course
 import { UpdateCourseModuleUseCase } from './application/use-cases/update-course-module/update-course-module.use-case';
 import { DeleteCourseModuleUseCase } from './application/use-cases/delete-course-module/delete-course-module.use-case';
 import { ReorderCourseModulesUseCase } from './application/use-cases/reorder-course-modules/reorder-course-modules.use-case';
+import { CreateQuizQuestionUseCase } from './application/use-cases/create-quiz-question/create-quiz-question.use-case';
+import { UpdateQuizQuestionUseCase } from './application/use-cases/update-quiz-question/update-quiz-question.use-case';
+import { DeleteQuizQuestionUseCase } from './application/use-cases/delete-quiz-question/delete-quiz-question.use-case';
 import { SuperAdminAcademyChaptersController } from './presenters/http/super-admin-academy-chapters.controller';
 import { SuperAdminAcademyCourseModulesController } from './presenters/http/super-admin-academy-course-modules.controller';
+import { SuperAdminAcademyQuizQuestionsController } from './presenters/http/super-admin-academy-quiz-questions.controller';
 import { AcademyChaptersController } from './presenters/http/academy-chapters.controller';
 import { AcademyResponseDtoMapper } from './presenters/http/mappers/academy-response-dto.mapper';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([AcademyChapterRecord, AcademyCourseModuleRecord]),
+    TypeOrmModule.forFeature([
+      AcademyChapterRecord,
+      AcademyCourseModuleRecord,
+      AcademyQuizQuestionRecord,
+    ]),
   ],
   controllers: [
     AcademyChaptersController,
     SuperAdminAcademyChaptersController,
     SuperAdminAcademyCourseModulesController,
+    SuperAdminAcademyQuizQuestionsController,
   ],
   providers: [
     AcademyResponseDtoMapper,
     AcademyMapper,
     LocalAcademyChapterRepository,
     LocalAcademyCourseModuleRepository,
+    LocalAcademyQuizQuestionRepository,
     {
       provide: AcademyChapterRepository,
       useExisting: LocalAcademyChapterRepository,
@@ -43,7 +57,12 @@ import { AcademyResponseDtoMapper } from './presenters/http/mappers/academy-resp
       provide: AcademyCourseModuleRepository,
       useExisting: LocalAcademyCourseModuleRepository,
     },
+    {
+      provide: AcademyQuizQuestionRepository,
+      useExisting: LocalAcademyQuizQuestionRepository,
+    },
     GetAcademyContentUseCase,
+    GetAcademyManagementContentUseCase,
     CreateChapterUseCase,
     UpdateChapterUseCase,
     DeleteChapterUseCase,
@@ -52,6 +71,9 @@ import { AcademyResponseDtoMapper } from './presenters/http/mappers/academy-resp
     UpdateCourseModuleUseCase,
     DeleteCourseModuleUseCase,
     ReorderCourseModulesUseCase,
+    CreateQuizQuestionUseCase,
+    UpdateQuizQuestionUseCase,
+    DeleteQuizQuestionUseCase,
   ],
   exports: [GetAcademyContentUseCase],
 })

--- a/ayunis-core-backend/src/domain/academy/application/academy.errors.ts
+++ b/ayunis-core-backend/src/domain/academy/application/academy.errors.ts
@@ -4,7 +4,9 @@ import { ApplicationError } from '../../../common/errors/base.error';
 export enum AcademyErrorCode {
   CHAPTER_NOT_FOUND = 'CHAPTER_NOT_FOUND',
   COURSE_MODULE_NOT_FOUND = 'COURSE_MODULE_NOT_FOUND',
+  QUIZ_QUESTION_NOT_FOUND = 'QUIZ_QUESTION_NOT_FOUND',
   INVALID_REORDER = 'INVALID_REORDER',
+  INVALID_QUIZ_QUESTION = 'INVALID_QUIZ_QUESTION',
   UNEXPECTED_ACADEMY_ERROR = 'UNEXPECTED_ACADEMY_ERROR',
 }
 
@@ -41,6 +43,17 @@ export class CourseModuleNotFoundError extends AcademyError {
   }
 }
 
+export class QuizQuestionNotFoundError extends AcademyError {
+  constructor(quizQuestionId: string, metadata?: ErrorMetadata) {
+    super(
+      `Academy quiz question with ID ${quizQuestionId} not found`,
+      AcademyErrorCode.QUIZ_QUESTION_NOT_FOUND,
+      404,
+      metadata,
+    );
+  }
+}
+
 export class InvalidReorderError extends AcademyError {
   constructor(metadata?: ErrorMetadata) {
     super(
@@ -49,6 +62,12 @@ export class InvalidReorderError extends AcademyError {
       400,
       metadata,
     );
+  }
+}
+
+export class InvalidQuizQuestionError extends AcademyError {
+  constructor(reason: string, metadata?: ErrorMetadata) {
+    super(reason, AcademyErrorCode.INVALID_QUIZ_QUESTION, 400, metadata);
   }
 }
 

--- a/ayunis-core-backend/src/domain/academy/application/ports/academy-chapter.repository.ts
+++ b/ayunis-core-backend/src/domain/academy/application/ports/academy-chapter.repository.ts
@@ -3,6 +3,7 @@ import type { AcademyChapter } from '../../domain/academy-chapter.entity';
 
 export abstract class AcademyChapterRepository {
   abstract findAllWithCourseModules(): Promise<AcademyChapter[]>;
+  abstract findAllWithQuizContent(): Promise<AcademyChapter[]>;
   abstract findOne(id: UUID): Promise<AcademyChapter | null>;
   abstract findAllIds(): Promise<UUID[]>;
   abstract findMaxPosition(): Promise<number | null>;

--- a/ayunis-core-backend/src/domain/academy/application/ports/academy-quiz-question.repository.ts
+++ b/ayunis-core-backend/src/domain/academy/application/ports/academy-quiz-question.repository.ts
@@ -1,0 +1,14 @@
+import type { UUID } from 'crypto';
+import type { AcademyQuizQuestion } from '../../domain/academy-quiz-question.entity';
+
+export abstract class AcademyQuizQuestionRepository {
+  abstract findOne(id: UUID): Promise<AcademyQuizQuestion | null>;
+  abstract findMaxPosition(chapterId: UUID): Promise<number | null>;
+  abstract create(
+    quizQuestion: AcademyQuizQuestion,
+  ): Promise<AcademyQuizQuestion>;
+  abstract update(
+    quizQuestion: AcademyQuizQuestion,
+  ): Promise<AcademyQuizQuestion>;
+  abstract delete(id: UUID): Promise<void>;
+}

--- a/ayunis-core-backend/src/domain/academy/application/quiz-question-validation.ts
+++ b/ayunis-core-backend/src/domain/academy/application/quiz-question-validation.ts
@@ -1,0 +1,28 @@
+import type { QuizAnswerOption } from '../domain/academy-quiz-question.entity';
+import { InvalidQuizQuestionError } from './academy.errors';
+
+export const MIN_QUIZ_OPTIONS = 2;
+export const MAX_QUIZ_OPTIONS = 6;
+
+/**
+ * Enforces the quiz question invariants that class-validator cannot express:
+ * between MIN and MAX options, non-empty option texts, and exactly one option
+ * marked as correct (single-correct multiple choice). Throws
+ * InvalidQuizQuestionError otherwise.
+ */
+export function assertValidQuizOptions(options: QuizAnswerOption[]): void {
+  if (options.length < MIN_QUIZ_OPTIONS || options.length > MAX_QUIZ_OPTIONS) {
+    throw new InvalidQuizQuestionError(
+      `A quiz question must have between ${MIN_QUIZ_OPTIONS} and ${MAX_QUIZ_OPTIONS} options`,
+    );
+  }
+  if (options.some((option) => option.text.trim().length === 0)) {
+    throw new InvalidQuizQuestionError('Quiz option texts must not be empty');
+  }
+  const correctCount = options.filter((option) => option.isCorrect).length;
+  if (correctCount !== 1) {
+    throw new InvalidQuizQuestionError(
+      'A quiz question must have exactly one correct option',
+    );
+  }
+}

--- a/ayunis-core-backend/src/domain/academy/application/use-cases/create-quiz-question/create-quiz-question.command.ts
+++ b/ayunis-core-backend/src/domain/academy/application/use-cases/create-quiz-question/create-quiz-question.command.ts
@@ -1,0 +1,18 @@
+import type { UUID } from 'crypto';
+import type { QuizAnswerOption } from '../../../domain/academy-quiz-question.entity';
+
+export class CreateQuizQuestionCommand {
+  public readonly chapterId: UUID;
+  public readonly text: string;
+  public readonly options: QuizAnswerOption[];
+
+  constructor(params: {
+    chapterId: UUID;
+    text: string;
+    options: QuizAnswerOption[];
+  }) {
+    this.chapterId = params.chapterId;
+    this.text = params.text;
+    this.options = params.options;
+  }
+}

--- a/ayunis-core-backend/src/domain/academy/application/use-cases/create-quiz-question/create-quiz-question.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/academy/application/use-cases/create-quiz-question/create-quiz-question.use-case.spec.ts
@@ -1,0 +1,145 @@
+import type { TestingModule } from '@nestjs/testing';
+import { Test } from '@nestjs/testing';
+import { Logger } from '@nestjs/common';
+import { randomUUID } from 'crypto';
+import { CreateQuizQuestionUseCase } from './create-quiz-question.use-case';
+import { CreateQuizQuestionCommand } from './create-quiz-question.command';
+import { AcademyChapterRepository } from '../../ports/academy-chapter.repository';
+import { AcademyQuizQuestionRepository } from '../../ports/academy-quiz-question.repository';
+import { AcademyChapter } from '../../../domain/academy-chapter.entity';
+import { AcademyQuizQuestion } from '../../../domain/academy-quiz-question.entity';
+import {
+  ChapterNotFoundError,
+  InvalidQuizQuestionError,
+} from '../../academy.errors';
+
+const validOptions = [
+  { text: 'A large language model', isCorrect: true },
+  { text: 'A database', isCorrect: false },
+];
+
+describe('CreateQuizQuestionUseCase', () => {
+  let useCase: CreateQuizQuestionUseCase;
+  let chapterRepository: jest.Mocked<AcademyChapterRepository>;
+  let quizQuestionRepository: jest.Mocked<AcademyQuizQuestionRepository>;
+
+  const chapter = new AcademyChapter({
+    title: 'Getting Started',
+    description: 'Basics of Ayunis Core',
+    position: 0,
+  });
+
+  beforeAll(async () => {
+    const mockChapterRepository = { findOne: jest.fn() };
+    const mockQuizQuestionRepository = {
+      findMaxPosition: jest.fn(),
+      create: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        CreateQuizQuestionUseCase,
+        { provide: AcademyChapterRepository, useValue: mockChapterRepository },
+        {
+          provide: AcademyQuizQuestionRepository,
+          useValue: mockQuizQuestionRepository,
+        },
+      ],
+    }).compile();
+
+    useCase = module.get<CreateQuizQuestionUseCase>(CreateQuizQuestionUseCase);
+    chapterRepository = module.get(AcademyChapterRepository);
+    quizQuestionRepository = module.get(AcademyQuizQuestionRepository);
+
+    jest.spyOn(Logger.prototype, 'log').mockImplementation();
+    jest.spyOn(Logger.prototype, 'error').mockImplementation();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should create a question appended after the last position', async () => {
+    chapterRepository.findOne.mockResolvedValue(chapter);
+    quizQuestionRepository.findMaxPosition.mockResolvedValue(3);
+    quizQuestionRepository.create.mockImplementation(
+      async (question: AcademyQuizQuestion) => question,
+    );
+
+    const result = await useCase.execute(
+      new CreateQuizQuestionCommand({
+        chapterId: chapter.id,
+        text: 'What is an LLM?',
+        options: validOptions,
+      }),
+    );
+
+    expect(result.position).toBe(4);
+    expect(result.chapterId).toBe(chapter.id);
+    expect(quizQuestionRepository.create).toHaveBeenCalledWith(
+      expect.any(AcademyQuizQuestion),
+    );
+  });
+
+  it('should create the first question of a chapter at position 0', async () => {
+    chapterRepository.findOne.mockResolvedValue(chapter);
+    quizQuestionRepository.findMaxPosition.mockResolvedValue(null);
+    quizQuestionRepository.create.mockImplementation(
+      async (question: AcademyQuizQuestion) => question,
+    );
+
+    const result = await useCase.execute(
+      new CreateQuizQuestionCommand({
+        chapterId: chapter.id,
+        text: 'What is an LLM?',
+        options: validOptions,
+      }),
+    );
+
+    expect(result.position).toBe(0);
+  });
+
+  it('should reject creation for a non-existent chapter', async () => {
+    chapterRepository.findOne.mockResolvedValue(null);
+
+    await expect(
+      useCase.execute(
+        new CreateQuizQuestionCommand({
+          chapterId: randomUUID(),
+          text: 'Orphan question',
+          options: validOptions,
+        }),
+      ),
+    ).rejects.toThrow(ChapterNotFoundError);
+    expect(quizQuestionRepository.create).not.toHaveBeenCalled();
+  });
+
+  it('should reject a question without exactly one correct option', async () => {
+    await expect(
+      useCase.execute(
+        new CreateQuizQuestionCommand({
+          chapterId: chapter.id,
+          text: 'No correct answer',
+          options: [
+            { text: 'Option A', isCorrect: false },
+            { text: 'Option B', isCorrect: false },
+          ],
+        }),
+      ),
+    ).rejects.toThrow(InvalidQuizQuestionError);
+    expect(quizQuestionRepository.create).not.toHaveBeenCalled();
+  });
+
+  it('should reject a question with fewer than two options', async () => {
+    await expect(
+      useCase.execute(
+        new CreateQuizQuestionCommand({
+          chapterId: chapter.id,
+          text: 'Only one option',
+          options: [{ text: 'Option A', isCorrect: true }],
+        }),
+      ),
+    ).rejects.toThrow(InvalidQuizQuestionError);
+    expect(quizQuestionRepository.create).not.toHaveBeenCalled();
+  });
+});

--- a/ayunis-core-backend/src/domain/academy/application/use-cases/create-quiz-question/create-quiz-question.use-case.ts
+++ b/ayunis-core-backend/src/domain/academy/application/use-cases/create-quiz-question/create-quiz-question.use-case.ts
@@ -1,0 +1,52 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ApplicationError } from 'src/common/errors/base.error';
+import { AcademyChapterRepository } from '../../ports/academy-chapter.repository';
+import { AcademyQuizQuestionRepository } from '../../ports/academy-quiz-question.repository';
+import { AcademyQuizQuestion } from '../../../domain/academy-quiz-question.entity';
+import {
+  ChapterNotFoundError,
+  UnexpectedAcademyError,
+} from '../../academy.errors';
+import { assertValidQuizOptions } from '../../quiz-question-validation';
+import { CreateQuizQuestionCommand } from './create-quiz-question.command';
+
+@Injectable()
+export class CreateQuizQuestionUseCase {
+  private readonly logger = new Logger(CreateQuizQuestionUseCase.name);
+
+  constructor(
+    private readonly chapterRepository: AcademyChapterRepository,
+    private readonly quizQuestionRepository: AcademyQuizQuestionRepository,
+  ) {}
+
+  async execute(
+    command: CreateQuizQuestionCommand,
+  ): Promise<AcademyQuizQuestion> {
+    this.logger.log('Creating academy quiz question', {
+      chapterId: command.chapterId,
+    });
+    try {
+      assertValidQuizOptions(command.options);
+      const chapter = await this.chapterRepository.findOne(command.chapterId);
+      if (!chapter) {
+        throw new ChapterNotFoundError(command.chapterId);
+      }
+      const maxPosition = await this.quizQuestionRepository.findMaxPosition(
+        command.chapterId,
+      );
+      const quizQuestion = new AcademyQuizQuestion({
+        chapterId: command.chapterId,
+        text: command.text,
+        options: command.options,
+        position: (maxPosition ?? -1) + 1,
+      });
+      return await this.quizQuestionRepository.create(quizQuestion);
+    } catch (error) {
+      if (error instanceof ApplicationError) throw error;
+      this.logger.error('Error creating academy quiz question', {
+        error: error as Error,
+      });
+      throw new UnexpectedAcademyError(error);
+    }
+  }
+}

--- a/ayunis-core-backend/src/domain/academy/application/use-cases/delete-quiz-question/delete-quiz-question.command.ts
+++ b/ayunis-core-backend/src/domain/academy/application/use-cases/delete-quiz-question/delete-quiz-question.command.ts
@@ -1,0 +1,9 @@
+import type { UUID } from 'crypto';
+
+export class DeleteQuizQuestionCommand {
+  public readonly quizQuestionId: UUID;
+
+  constructor(params: { quizQuestionId: UUID }) {
+    this.quizQuestionId = params.quizQuestionId;
+  }
+}

--- a/ayunis-core-backend/src/domain/academy/application/use-cases/delete-quiz-question/delete-quiz-question.use-case.ts
+++ b/ayunis-core-backend/src/domain/academy/application/use-cases/delete-quiz-question/delete-quiz-question.use-case.ts
@@ -1,0 +1,29 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ApplicationError } from 'src/common/errors/base.error';
+import { AcademyQuizQuestionRepository } from '../../ports/academy-quiz-question.repository';
+import { UnexpectedAcademyError } from '../../academy.errors';
+import { DeleteQuizQuestionCommand } from './delete-quiz-question.command';
+
+@Injectable()
+export class DeleteQuizQuestionUseCase {
+  private readonly logger = new Logger(DeleteQuizQuestionUseCase.name);
+
+  constructor(
+    private readonly quizQuestionRepository: AcademyQuizQuestionRepository,
+  ) {}
+
+  async execute(command: DeleteQuizQuestionCommand): Promise<void> {
+    this.logger.log('Deleting academy quiz question', {
+      quizQuestionId: command.quizQuestionId,
+    });
+    try {
+      await this.quizQuestionRepository.delete(command.quizQuestionId);
+    } catch (error) {
+      if (error instanceof ApplicationError) throw error;
+      this.logger.error('Error deleting academy quiz question', {
+        error: error as Error,
+      });
+      throw new UnexpectedAcademyError(error);
+    }
+  }
+}

--- a/ayunis-core-backend/src/domain/academy/application/use-cases/get-academy-management-content/get-academy-management-content.query.ts
+++ b/ayunis-core-backend/src/domain/academy/application/use-cases/get-academy-management-content/get-academy-management-content.query.ts
@@ -1,0 +1,1 @@
+export class GetAcademyManagementContentQuery {}

--- a/ayunis-core-backend/src/domain/academy/application/use-cases/get-academy-management-content/get-academy-management-content.use-case.ts
+++ b/ayunis-core-backend/src/domain/academy/application/use-cases/get-academy-management-content/get-academy-management-content.use-case.ts
@@ -1,0 +1,35 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ApplicationError } from 'src/common/errors/base.error';
+import { AcademyChapterRepository } from '../../ports/academy-chapter.repository';
+import { AcademyChapter } from '../../../domain/academy-chapter.entity';
+import { UnexpectedAcademyError } from '../../academy.errors';
+import { GetAcademyManagementContentQuery } from './get-academy-management-content.query';
+
+/**
+ * Super-admin-only read: returns chapters with their modules AND quiz
+ * questions (including correct answers). The learner-facing
+ * GetAcademyContentUseCase never loads quiz questions, so correct answers
+ * cannot leak to learners.
+ */
+@Injectable()
+export class GetAcademyManagementContentUseCase {
+  private readonly logger = new Logger(GetAcademyManagementContentUseCase.name);
+
+  constructor(private readonly chapterRepository: AcademyChapterRepository) {}
+
+  async execute(
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    _query: GetAcademyManagementContentQuery,
+  ): Promise<AcademyChapter[]> {
+    this.logger.log('Getting academy management content');
+    try {
+      return await this.chapterRepository.findAllWithQuizContent();
+    } catch (error) {
+      if (error instanceof ApplicationError) throw error;
+      this.logger.error('Error getting academy management content', {
+        error: error as Error,
+      });
+      throw new UnexpectedAcademyError(error);
+    }
+  }
+}

--- a/ayunis-core-backend/src/domain/academy/application/use-cases/update-chapter/update-chapter.command.ts
+++ b/ayunis-core-backend/src/domain/academy/application/use-cases/update-chapter/update-chapter.command.ts
@@ -4,10 +4,17 @@ export class UpdateChapterCommand {
   public readonly chapterId: UUID;
   public readonly title: string;
   public readonly description: string;
+  public readonly quizEnabled?: boolean;
 
-  constructor(params: { chapterId: UUID; title: string; description: string }) {
+  constructor(params: {
+    chapterId: UUID;
+    title: string;
+    description: string;
+    quizEnabled?: boolean;
+  }) {
     this.chapterId = params.chapterId;
     this.title = params.title;
     this.description = params.description;
+    this.quizEnabled = params.quizEnabled;
   }
 }

--- a/ayunis-core-backend/src/domain/academy/application/use-cases/update-chapter/update-chapter.use-case.ts
+++ b/ayunis-core-backend/src/domain/academy/application/use-cases/update-chapter/update-chapter.use-case.ts
@@ -28,7 +28,9 @@ export class UpdateChapterUseCase {
         title: command.title,
         description: command.description,
         position: existing.position,
+        quizEnabled: command.quizEnabled ?? existing.quizEnabled,
         courseModules: existing.courseModules,
+        quizQuestions: existing.quizQuestions,
         createdAt: existing.createdAt,
         updatedAt: new Date(),
       });
@@ -38,7 +40,9 @@ export class UpdateChapterUseCase {
         title: persisted.title,
         description: persisted.description,
         position: persisted.position,
+        quizEnabled: persisted.quizEnabled,
         courseModules: existing.courseModules,
+        quizQuestions: existing.quizQuestions,
         createdAt: persisted.createdAt,
         updatedAt: persisted.updatedAt,
       });

--- a/ayunis-core-backend/src/domain/academy/application/use-cases/update-quiz-question/update-quiz-question.command.ts
+++ b/ayunis-core-backend/src/domain/academy/application/use-cases/update-quiz-question/update-quiz-question.command.ts
@@ -1,0 +1,18 @@
+import type { UUID } from 'crypto';
+import type { QuizAnswerOption } from '../../../domain/academy-quiz-question.entity';
+
+export class UpdateQuizQuestionCommand {
+  public readonly quizQuestionId: UUID;
+  public readonly text: string;
+  public readonly options: QuizAnswerOption[];
+
+  constructor(params: {
+    quizQuestionId: UUID;
+    text: string;
+    options: QuizAnswerOption[];
+  }) {
+    this.quizQuestionId = params.quizQuestionId;
+    this.text = params.text;
+    this.options = params.options;
+  }
+}

--- a/ayunis-core-backend/src/domain/academy/application/use-cases/update-quiz-question/update-quiz-question.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/academy/application/use-cases/update-quiz-question/update-quiz-question.use-case.spec.ts
@@ -1,0 +1,106 @@
+import type { TestingModule } from '@nestjs/testing';
+import { Test } from '@nestjs/testing';
+import { Logger } from '@nestjs/common';
+import { randomUUID } from 'crypto';
+import { UpdateQuizQuestionUseCase } from './update-quiz-question.use-case';
+import { UpdateQuizQuestionCommand } from './update-quiz-question.command';
+import { AcademyQuizQuestionRepository } from '../../ports/academy-quiz-question.repository';
+import { AcademyQuizQuestion } from '../../../domain/academy-quiz-question.entity';
+import {
+  InvalidQuizQuestionError,
+  QuizQuestionNotFoundError,
+} from '../../academy.errors';
+
+const validOptions = [
+  { text: 'A large language model', isCorrect: true },
+  { text: 'A database', isCorrect: false },
+];
+
+describe('UpdateQuizQuestionUseCase', () => {
+  let useCase: UpdateQuizQuestionUseCase;
+  let quizQuestionRepository: jest.Mocked<AcademyQuizQuestionRepository>;
+
+  const existing = new AcademyQuizQuestion({
+    chapterId: randomUUID(),
+    text: 'Original question',
+    options: validOptions,
+    position: 2,
+  });
+
+  beforeAll(async () => {
+    const mockQuizQuestionRepository = {
+      findOne: jest.fn(),
+      update: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        UpdateQuizQuestionUseCase,
+        {
+          provide: AcademyQuizQuestionRepository,
+          useValue: mockQuizQuestionRepository,
+        },
+      ],
+    }).compile();
+
+    useCase = module.get<UpdateQuizQuestionUseCase>(UpdateQuizQuestionUseCase);
+    quizQuestionRepository = module.get(AcademyQuizQuestionRepository);
+
+    jest.spyOn(Logger.prototype, 'log').mockImplementation();
+    jest.spyOn(Logger.prototype, 'error').mockImplementation();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should update the prompt and options while preserving position', async () => {
+    quizQuestionRepository.findOne.mockResolvedValue(existing);
+    quizQuestionRepository.update.mockImplementation(
+      async (question: AcademyQuizQuestion) => question,
+    );
+
+    const result = await useCase.execute(
+      new UpdateQuizQuestionCommand({
+        quizQuestionId: existing.id,
+        text: 'Updated question',
+        options: validOptions,
+      }),
+    );
+
+    expect(result.text).toBe('Updated question');
+    expect(result.position).toBe(2);
+    expect(result.chapterId).toBe(existing.chapterId);
+  });
+
+  it('should reject update for a non-existent question', async () => {
+    quizQuestionRepository.findOne.mockResolvedValue(null);
+
+    await expect(
+      useCase.execute(
+        new UpdateQuizQuestionCommand({
+          quizQuestionId: randomUUID(),
+          text: 'Ghost question',
+          options: validOptions,
+        }),
+      ),
+    ).rejects.toThrow(QuizQuestionNotFoundError);
+    expect(quizQuestionRepository.update).not.toHaveBeenCalled();
+  });
+
+  it('should reject an update with multiple correct options', async () => {
+    await expect(
+      useCase.execute(
+        new UpdateQuizQuestionCommand({
+          quizQuestionId: existing.id,
+          text: 'Two correct answers',
+          options: [
+            { text: 'Option A', isCorrect: true },
+            { text: 'Option B', isCorrect: true },
+          ],
+        }),
+      ),
+    ).rejects.toThrow(InvalidQuizQuestionError);
+    expect(quizQuestionRepository.update).not.toHaveBeenCalled();
+  });
+});

--- a/ayunis-core-backend/src/domain/academy/application/use-cases/update-quiz-question/update-quiz-question.use-case.ts
+++ b/ayunis-core-backend/src/domain/academy/application/use-cases/update-quiz-question/update-quiz-question.use-case.ts
@@ -1,0 +1,52 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ApplicationError } from 'src/common/errors/base.error';
+import { AcademyQuizQuestionRepository } from '../../ports/academy-quiz-question.repository';
+import { AcademyQuizQuestion } from '../../../domain/academy-quiz-question.entity';
+import {
+  QuizQuestionNotFoundError,
+  UnexpectedAcademyError,
+} from '../../academy.errors';
+import { assertValidQuizOptions } from '../../quiz-question-validation';
+import { UpdateQuizQuestionCommand } from './update-quiz-question.command';
+
+@Injectable()
+export class UpdateQuizQuestionUseCase {
+  private readonly logger = new Logger(UpdateQuizQuestionUseCase.name);
+
+  constructor(
+    private readonly quizQuestionRepository: AcademyQuizQuestionRepository,
+  ) {}
+
+  async execute(
+    command: UpdateQuizQuestionCommand,
+  ): Promise<AcademyQuizQuestion> {
+    this.logger.log('Updating academy quiz question', {
+      quizQuestionId: command.quizQuestionId,
+    });
+    try {
+      assertValidQuizOptions(command.options);
+      const existing = await this.quizQuestionRepository.findOne(
+        command.quizQuestionId,
+      );
+      if (!existing) {
+        throw new QuizQuestionNotFoundError(command.quizQuestionId);
+      }
+      const updated = new AcademyQuizQuestion({
+        id: existing.id,
+        chapterId: existing.chapterId,
+        text: command.text,
+        options: command.options,
+        position: existing.position,
+        createdAt: existing.createdAt,
+        updatedAt: new Date(),
+      });
+      return await this.quizQuestionRepository.update(updated);
+    } catch (error) {
+      if (error instanceof ApplicationError) throw error;
+      this.logger.error('Error updating academy quiz question', {
+        error: error as Error,
+      });
+      throw new UnexpectedAcademyError(error);
+    }
+  }
+}

--- a/ayunis-core-backend/src/domain/academy/domain/academy-chapter.entity.ts
+++ b/ayunis-core-backend/src/domain/academy/domain/academy-chapter.entity.ts
@@ -1,13 +1,16 @@
 import type { UUID } from 'crypto';
 import { randomUUID } from 'crypto';
 import type { AcademyCourseModule } from './academy-course-module.entity';
+import type { AcademyQuizQuestion } from './academy-quiz-question.entity';
 
 export class AcademyChapter {
   public readonly id: UUID;
   public readonly title: string;
   public readonly description: string;
   public readonly position: number;
+  public readonly quizEnabled: boolean;
   public readonly courseModules: AcademyCourseModule[];
+  public readonly quizQuestions: AcademyQuizQuestion[];
   public readonly createdAt: Date;
   public readonly updatedAt: Date;
 
@@ -16,7 +19,9 @@ export class AcademyChapter {
     title: string;
     description: string;
     position: number;
+    quizEnabled?: boolean;
     courseModules?: AcademyCourseModule[];
+    quizQuestions?: AcademyQuizQuestion[];
     createdAt?: Date;
     updatedAt?: Date;
   }) {
@@ -24,7 +29,9 @@ export class AcademyChapter {
     this.title = params.title;
     this.description = params.description;
     this.position = params.position;
+    this.quizEnabled = params.quizEnabled ?? false;
     this.courseModules = params.courseModules ?? [];
+    this.quizQuestions = params.quizQuestions ?? [];
     this.createdAt = params.createdAt ?? new Date();
     this.updatedAt = params.updatedAt ?? new Date();
   }

--- a/ayunis-core-backend/src/domain/academy/domain/academy-quiz-question.entity.ts
+++ b/ayunis-core-backend/src/domain/academy/domain/academy-quiz-question.entity.ts
@@ -1,0 +1,35 @@
+import type { UUID } from 'crypto';
+import { randomUUID } from 'crypto';
+
+export interface QuizAnswerOption {
+  readonly text: string;
+  readonly isCorrect: boolean;
+}
+
+export class AcademyQuizQuestion {
+  public readonly id: UUID;
+  public readonly chapterId: UUID;
+  public readonly text: string;
+  public readonly options: QuizAnswerOption[];
+  public readonly position: number;
+  public readonly createdAt: Date;
+  public readonly updatedAt: Date;
+
+  constructor(params: {
+    id?: UUID;
+    chapterId: UUID;
+    text: string;
+    options: QuizAnswerOption[];
+    position: number;
+    createdAt?: Date;
+    updatedAt?: Date;
+  }) {
+    this.id = params.id ?? randomUUID();
+    this.chapterId = params.chapterId;
+    this.text = params.text;
+    this.options = params.options;
+    this.position = params.position;
+    this.createdAt = params.createdAt ?? new Date();
+    this.updatedAt = params.updatedAt ?? new Date();
+  }
+}

--- a/ayunis-core-backend/src/domain/academy/infrastructure/persistence/local/local-academy-chapter.repository.ts
+++ b/ayunis-core-backend/src/domain/academy/infrastructure/persistence/local/local-academy-chapter.repository.ts
@@ -33,6 +33,20 @@ export class LocalAcademyChapterRepository implements AcademyChapterRepository {
     return records.map((record) => this.mapper.chapterToDomain(record));
   }
 
+  async findAllWithQuizContent(): Promise<AcademyChapter[]> {
+    this.logger.log('findAllWithQuizContent');
+    const records = await this.repository.find({
+      relations: { courseModules: true, quizQuestions: true },
+      order: {
+        position: 'ASC',
+        createdAt: 'ASC',
+        courseModules: { position: 'ASC', createdAt: 'ASC' },
+        quizQuestions: { position: 'ASC', createdAt: 'ASC' },
+      },
+    });
+    return records.map((record) => this.mapper.chapterToDomain(record));
+  }
+
   async findOne(id: UUID): Promise<AcademyChapter | null> {
     this.logger.log('findOne', { id });
     const record = await this.repository.findOne({

--- a/ayunis-core-backend/src/domain/academy/infrastructure/persistence/local/local-academy-quiz-question.repository.ts
+++ b/ayunis-core-backend/src/domain/academy/infrastructure/persistence/local/local-academy-quiz-question.repository.ts
@@ -1,0 +1,59 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import type { UUID } from 'crypto';
+
+import { AcademyQuizQuestionRepository } from '../../../application/ports/academy-quiz-question.repository';
+import { AcademyQuizQuestion } from '../../../domain/academy-quiz-question.entity';
+import { AcademyQuizQuestionRecord } from './schema/academy-quiz-question.record';
+import { AcademyMapper } from './mappers/academy.mapper';
+import { QuizQuestionNotFoundError } from '../../../application/academy.errors';
+
+@Injectable()
+export class LocalAcademyQuizQuestionRepository implements AcademyQuizQuestionRepository {
+  private readonly logger = new Logger(LocalAcademyQuizQuestionRepository.name);
+
+  constructor(
+    @InjectRepository(AcademyQuizQuestionRecord)
+    private readonly repository: Repository<AcademyQuizQuestionRecord>,
+    private readonly mapper: AcademyMapper,
+  ) {}
+
+  async findOne(id: UUID): Promise<AcademyQuizQuestion | null> {
+    this.logger.log('findOne', { id });
+    const record = await this.repository.findOne({ where: { id } });
+    if (!record) return null;
+    return this.mapper.quizQuestionToDomain(record);
+  }
+
+  async findMaxPosition(chapterId: UUID): Promise<number | null> {
+    this.logger.log('findMaxPosition', { chapterId });
+    return this.repository.maximum('position', { chapterId });
+  }
+
+  async create(
+    quizQuestion: AcademyQuizQuestion,
+  ): Promise<AcademyQuizQuestion> {
+    this.logger.log('create', { chapterId: quizQuestion.chapterId });
+    const record = this.mapper.quizQuestionToRecord(quizQuestion);
+    const saved = await this.repository.save(record);
+    return this.mapper.quizQuestionToDomain(saved);
+  }
+
+  async update(
+    quizQuestion: AcademyQuizQuestion,
+  ): Promise<AcademyQuizQuestion> {
+    this.logger.log('update', { id: quizQuestion.id });
+    const record = this.mapper.quizQuestionToRecord(quizQuestion);
+    const saved = await this.repository.save(record);
+    return this.mapper.quizQuestionToDomain(saved);
+  }
+
+  async delete(id: UUID): Promise<void> {
+    this.logger.log('delete', { id });
+    const result = await this.repository.delete({ id });
+    if (result.affected === 0) {
+      throw new QuizQuestionNotFoundError(id);
+    }
+  }
+}

--- a/ayunis-core-backend/src/domain/academy/infrastructure/persistence/local/mappers/academy.mapper.ts
+++ b/ayunis-core-backend/src/domain/academy/infrastructure/persistence/local/mappers/academy.mapper.ts
@@ -1,8 +1,10 @@
 import { Injectable } from '@nestjs/common';
 import { AcademyChapter } from '../../../../domain/academy-chapter.entity';
 import { AcademyCourseModule } from '../../../../domain/academy-course-module.entity';
+import { AcademyQuizQuestion } from '../../../../domain/academy-quiz-question.entity';
 import { AcademyChapterRecord } from '../schema/academy-chapter.record';
 import { AcademyCourseModuleRecord } from '../schema/academy-course-module.record';
+import { AcademyQuizQuestionRecord } from '../schema/academy-quiz-question.record';
 
 @Injectable()
 export class AcademyMapper {
@@ -12,8 +14,12 @@ export class AcademyMapper {
       title: record.title,
       description: record.description,
       position: record.position,
+      quizEnabled: record.quizEnabled,
       courseModules: record.courseModules?.map((courseModule) =>
         this.courseModuleToDomain(courseModule),
+      ),
+      quizQuestions: record.quizQuestions?.map((quizQuestion) =>
+        this.quizQuestionToDomain(quizQuestion),
       ),
       createdAt: record.createdAt,
       updatedAt: record.updatedAt,
@@ -26,6 +32,7 @@ export class AcademyMapper {
     record.title = domain.title;
     record.description = domain.description;
     record.position = domain.position;
+    record.quizEnabled = domain.quizEnabled;
     return record;
   }
 
@@ -49,6 +56,28 @@ export class AcademyMapper {
     record.title = domain.title;
     record.description = domain.description;
     record.loomUrl = domain.loomUrl;
+    record.position = domain.position;
+    return record;
+  }
+
+  quizQuestionToDomain(record: AcademyQuizQuestionRecord): AcademyQuizQuestion {
+    return new AcademyQuizQuestion({
+      id: record.id,
+      chapterId: record.chapterId,
+      text: record.text,
+      options: record.options,
+      position: record.position,
+      createdAt: record.createdAt,
+      updatedAt: record.updatedAt,
+    });
+  }
+
+  quizQuestionToRecord(domain: AcademyQuizQuestion): AcademyQuizQuestionRecord {
+    const record = new AcademyQuizQuestionRecord();
+    record.id = domain.id;
+    record.chapterId = domain.chapterId;
+    record.text = domain.text;
+    record.options = domain.options;
     record.position = domain.position;
     return record;
   }

--- a/ayunis-core-backend/src/domain/academy/infrastructure/persistence/local/schema/academy-chapter.record.ts
+++ b/ayunis-core-backend/src/domain/academy/infrastructure/persistence/local/schema/academy-chapter.record.ts
@@ -1,6 +1,7 @@
 import { Column, Entity, OneToMany } from 'typeorm';
 import { BaseRecord } from '../../../../../../common/db/base-record';
 import { AcademyCourseModuleRecord } from './academy-course-module.record';
+import { AcademyQuizQuestionRecord } from './academy-quiz-question.record';
 
 @Entity({ name: 'academy_chapters' })
 export class AcademyChapterRecord extends BaseRecord {
@@ -13,10 +14,20 @@ export class AcademyChapterRecord extends BaseRecord {
   @Column({ nullable: false, type: 'int' })
   position: number;
 
+  @Column({ nullable: false, type: 'boolean', default: false })
+  quizEnabled: boolean;
+
   // Only populated when the relation is explicitly loaded
   @OneToMany(
     () => AcademyCourseModuleRecord,
     (courseModule) => courseModule.chapter,
   )
   courseModules?: AcademyCourseModuleRecord[];
+
+  // Only populated when the relation is explicitly loaded
+  @OneToMany(
+    () => AcademyQuizQuestionRecord,
+    (quizQuestion) => quizQuestion.chapter,
+  )
+  quizQuestions?: AcademyQuizQuestionRecord[];
 }

--- a/ayunis-core-backend/src/domain/academy/infrastructure/persistence/local/schema/academy-quiz-question.record.ts
+++ b/ayunis-core-backend/src/domain/academy/infrastructure/persistence/local/schema/academy-quiz-question.record.ts
@@ -1,0 +1,26 @@
+import { UUID } from 'crypto';
+import { Column, Entity, Index, ManyToOne } from 'typeorm';
+import { BaseRecord } from '../../../../../../common/db/base-record';
+import { AcademyChapterRecord } from './academy-chapter.record';
+import type { QuizAnswerOption } from '../../../../domain/academy-quiz-question.entity';
+
+@Entity({ name: 'academy_quiz_questions' })
+export class AcademyQuizQuestionRecord extends BaseRecord {
+  @Column()
+  @Index()
+  chapterId: UUID;
+
+  @ManyToOne(() => AcademyChapterRecord, (chapter) => chapter.quizQuestions, {
+    onDelete: 'CASCADE',
+  })
+  chapter: AcademyChapterRecord;
+
+  @Column({ nullable: false, type: 'text' })
+  text: string;
+
+  @Column({ nullable: false, type: 'jsonb' })
+  options: QuizAnswerOption[];
+
+  @Column({ nullable: false, type: 'int' })
+  position: number;
+}

--- a/ayunis-core-backend/src/domain/academy/presenters/http/dto/academy-chapter-response.dto.ts
+++ b/ayunis-core-backend/src/domain/academy/presenters/http/dto/academy-chapter-response.dto.ts
@@ -32,6 +32,14 @@ export class AcademyChapterResponseDto {
   position: number;
 
   @ApiProperty({
+    type: 'boolean',
+    description:
+      'Whether a quiz is activated for this chapter (shown at chapter end)',
+    example: false,
+  })
+  quizEnabled: boolean;
+
+  @ApiProperty({
     type: [CourseModuleResponseDto],
     description: 'The modules of the chapter, ordered by position',
   })

--- a/ayunis-core-backend/src/domain/academy/presenters/http/dto/create-quiz-question-request.dto.ts
+++ b/ayunis-core-backend/src/domain/academy/presenters/http/dto/create-quiz-question-request.dto.ts
@@ -1,0 +1,57 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import {
+  ArrayMaxSize,
+  ArrayMinSize,
+  IsArray,
+  IsBoolean,
+  IsNotEmpty,
+  IsString,
+  MaxLength,
+  ValidateNested,
+} from 'class-validator';
+
+export class QuizAnswerOptionRequestDto {
+  @ApiProperty({
+    description: 'The answer option text',
+    example: 'A large language model',
+    maxLength: 500,
+  })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(500)
+  text: string;
+
+  @ApiProperty({
+    description: 'Whether this option is the correct answer',
+    example: true,
+  })
+  @IsBoolean()
+  isCorrect: boolean;
+}
+
+export class CreateQuizQuestionRequestDto {
+  @ApiProperty({
+    description: 'The question prompt',
+    example: 'What is an LLM?',
+    maxLength: 2000,
+  })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(2000)
+  text: string;
+
+  @ApiProperty({
+    description:
+      'The answer options. Between 2 and 6 options with exactly one marked correct.',
+    type: [QuizAnswerOptionRequestDto],
+    minItems: 2,
+    maxItems: 6,
+  })
+  @IsArray()
+  @ArrayMinSize(2)
+  @ArrayMaxSize(6)
+  @ValidateNested({ each: true })
+  @Type(() => QuizAnswerOptionRequestDto)
+  options: QuizAnswerOptionRequestDto[];
+}

--- a/ayunis-core-backend/src/domain/academy/presenters/http/dto/quiz-question-response.dto.ts
+++ b/ayunis-core-backend/src/domain/academy/presenters/http/dto/quiz-question-response.dto.ts
@@ -1,0 +1,68 @@
+import { ApiProperty } from '@nestjs/swagger';
+import type { UUID } from 'crypto';
+
+export class QuizAnswerOptionResponseDto {
+  @ApiProperty({
+    type: 'string',
+    description: 'The answer option text',
+    example: 'A large language model',
+  })
+  text: string;
+
+  @ApiProperty({
+    type: 'boolean',
+    description: 'Whether this option is the correct answer',
+    example: true,
+  })
+  isCorrect: boolean;
+}
+
+export class QuizQuestionResponseDto {
+  @ApiProperty({
+    type: 'string',
+    format: 'uuid',
+    description: 'The unique identifier of the quiz question',
+  })
+  id: UUID;
+
+  @ApiProperty({
+    type: 'string',
+    format: 'uuid',
+    description: 'The id of the chapter the question belongs to',
+  })
+  chapterId: UUID;
+
+  @ApiProperty({
+    type: 'string',
+    description: 'The question prompt',
+    example: 'What is an LLM?',
+  })
+  text: string;
+
+  @ApiProperty({
+    type: [QuizAnswerOptionResponseDto],
+    description: 'The answer options with the correct one flagged',
+  })
+  options: QuizAnswerOptionResponseDto[];
+
+  @ApiProperty({
+    type: 'integer',
+    description: 'The position of the question within its chapter (0-based)',
+    example: 0,
+  })
+  position: number;
+
+  @ApiProperty({
+    type: 'string',
+    format: 'date-time',
+    description: 'The date the question was created',
+  })
+  createdAt: Date;
+
+  @ApiProperty({
+    type: 'string',
+    format: 'date-time',
+    description: 'The date the question was last updated',
+  })
+  updatedAt: Date;
+}

--- a/ayunis-core-backend/src/domain/academy/presenters/http/dto/super-admin-academy-chapter-response.dto.ts
+++ b/ayunis-core-backend/src/domain/academy/presenters/http/dto/super-admin-academy-chapter-response.dto.ts
@@ -1,0 +1,16 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { AcademyChapterResponseDto } from './academy-chapter-response.dto';
+import { QuizQuestionResponseDto } from './quiz-question-response.dto';
+
+/**
+ * Super-admin variant of the chapter response that additionally exposes the
+ * quiz question pool (including correct answers). This DTO must NEVER be
+ * returned from a learner-facing endpoint.
+ */
+export class SuperAdminAcademyChapterResponseDto extends AcademyChapterResponseDto {
+  @ApiProperty({
+    type: [QuizQuestionResponseDto],
+    description: 'The quiz question pool of the chapter, ordered by position',
+  })
+  quizQuestions: QuizQuestionResponseDto[];
+}

--- a/ayunis-core-backend/src/domain/academy/presenters/http/dto/update-chapter-request.dto.ts
+++ b/ayunis-core-backend/src/domain/academy/presenters/http/dto/update-chapter-request.dto.ts
@@ -1,4 +1,15 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsBoolean, IsOptional } from 'class-validator';
 import { CreateChapterRequestDto } from './create-chapter-request.dto';
 
-// Full-replace update: same fields and validation as create.
-export class UpdateChapterRequestDto extends CreateChapterRequestDto {}
+// Full-replace update: same fields and validation as create, plus the
+// optional per-chapter quiz activation toggle.
+export class UpdateChapterRequestDto extends CreateChapterRequestDto {
+  @ApiPropertyOptional({
+    description: 'Whether a quiz is activated for this chapter',
+    example: false,
+  })
+  @IsOptional()
+  @IsBoolean()
+  quizEnabled?: boolean;
+}

--- a/ayunis-core-backend/src/domain/academy/presenters/http/dto/update-quiz-question-request.dto.ts
+++ b/ayunis-core-backend/src/domain/academy/presenters/http/dto/update-quiz-question-request.dto.ts
@@ -1,0 +1,4 @@
+import { CreateQuizQuestionRequestDto } from './create-quiz-question-request.dto';
+
+// Full-replace update: same fields and validation as create.
+export class UpdateQuizQuestionRequestDto extends CreateQuizQuestionRequestDto {}

--- a/ayunis-core-backend/src/domain/academy/presenters/http/mappers/academy-response-dto.mapper.ts
+++ b/ayunis-core-backend/src/domain/academy/presenters/http/mappers/academy-response-dto.mapper.ts
@@ -1,27 +1,75 @@
 import { Injectable } from '@nestjs/common';
 import type { AcademyChapter } from '../../../domain/academy-chapter.entity';
 import type { AcademyCourseModule } from '../../../domain/academy-course-module.entity';
+import type { AcademyQuizQuestion } from '../../../domain/academy-quiz-question.entity';
 import { AcademyChapterResponseDto } from '../dto/academy-chapter-response.dto';
 import { CourseModuleResponseDto } from '../dto/course-module-response.dto';
+import { SuperAdminAcademyChapterResponseDto } from '../dto/super-admin-academy-chapter-response.dto';
+import {
+  QuizAnswerOptionResponseDto,
+  QuizQuestionResponseDto,
+} from '../dto/quiz-question-response.dto';
 
 @Injectable()
 export class AcademyResponseDtoMapper {
   chapterToDto(entity: AcademyChapter): AcademyChapterResponseDto {
     const dto = new AcademyChapterResponseDto();
-    dto.id = entity.id;
-    dto.title = entity.title;
-    dto.description = entity.description;
-    dto.position = entity.position;
-    dto.courseModules = entity.courseModules.map((courseModule) =>
-      this.courseModuleToDto(courseModule),
-    );
-    dto.createdAt = entity.createdAt;
-    dto.updatedAt = entity.updatedAt;
+    this.assignChapterBaseFields(dto, entity);
     return dto;
   }
 
   chapterToDtoArray(entities: AcademyChapter[]): AcademyChapterResponseDto[] {
     return entities.map((entity) => this.chapterToDto(entity));
+  }
+
+  chapterToSuperAdminDto(
+    entity: AcademyChapter,
+  ): SuperAdminAcademyChapterResponseDto {
+    const dto = new SuperAdminAcademyChapterResponseDto();
+    this.assignChapterBaseFields(dto, entity);
+    dto.quizQuestions = entity.quizQuestions.map((quizQuestion) =>
+      this.quizQuestionToDto(quizQuestion),
+    );
+    return dto;
+  }
+
+  chapterToSuperAdminDtoArray(
+    entities: AcademyChapter[],
+  ): SuperAdminAcademyChapterResponseDto[] {
+    return entities.map((entity) => this.chapterToSuperAdminDto(entity));
+  }
+
+  private assignChapterBaseFields(
+    dto: AcademyChapterResponseDto,
+    entity: AcademyChapter,
+  ): void {
+    dto.id = entity.id;
+    dto.title = entity.title;
+    dto.description = entity.description;
+    dto.position = entity.position;
+    dto.quizEnabled = entity.quizEnabled;
+    dto.courseModules = entity.courseModules.map((courseModule) =>
+      this.courseModuleToDto(courseModule),
+    );
+    dto.createdAt = entity.createdAt;
+    dto.updatedAt = entity.updatedAt;
+  }
+
+  quizQuestionToDto(entity: AcademyQuizQuestion): QuizQuestionResponseDto {
+    const dto = new QuizQuestionResponseDto();
+    dto.id = entity.id;
+    dto.chapterId = entity.chapterId;
+    dto.text = entity.text;
+    dto.options = entity.options.map((option) => {
+      const optionDto = new QuizAnswerOptionResponseDto();
+      optionDto.text = option.text;
+      optionDto.isCorrect = option.isCorrect;
+      return optionDto;
+    });
+    dto.position = entity.position;
+    dto.createdAt = entity.createdAt;
+    dto.updatedAt = entity.updatedAt;
+    return dto;
   }
 
   courseModuleToDto(entity: AcademyCourseModule): CourseModuleResponseDto {

--- a/ayunis-core-backend/src/domain/academy/presenters/http/super-admin-academy-chapters.controller.ts
+++ b/ayunis-core-backend/src/domain/academy/presenters/http/super-admin-academy-chapters.controller.ts
@@ -25,8 +25,8 @@ import {
 import type { UUID } from 'crypto';
 import { SystemRoles } from 'src/iam/authorization/application/decorators/system-roles.decorator';
 import { SystemRole } from 'src/iam/users/domain/value-objects/system-role.enum';
-import { GetAcademyContentUseCase } from '../../application/use-cases/get-academy-content/get-academy-content.use-case';
-import { GetAcademyContentQuery } from '../../application/use-cases/get-academy-content/get-academy-content.query';
+import { GetAcademyManagementContentUseCase } from '../../application/use-cases/get-academy-management-content/get-academy-management-content.use-case';
+import { GetAcademyManagementContentQuery } from '../../application/use-cases/get-academy-management-content/get-academy-management-content.query';
 import { CreateChapterUseCase } from '../../application/use-cases/create-chapter/create-chapter.use-case';
 import { CreateChapterCommand } from '../../application/use-cases/create-chapter/create-chapter.command';
 import { UpdateChapterUseCase } from '../../application/use-cases/update-chapter/update-chapter.use-case';
@@ -39,6 +39,7 @@ import { CreateChapterRequestDto } from './dto/create-chapter-request.dto';
 import { UpdateChapterRequestDto } from './dto/update-chapter-request.dto';
 import { ReorderChaptersRequestDto } from './dto/reorder-chapters-request.dto';
 import { AcademyChapterResponseDto } from './dto/academy-chapter-response.dto';
+import { SuperAdminAcademyChapterResponseDto } from './dto/super-admin-academy-chapter-response.dto';
 import { AcademyResponseDtoMapper } from './mappers/academy-response-dto.mapper';
 
 @ApiTags('Super Admin Academy')
@@ -50,7 +51,7 @@ export class SuperAdminAcademyChaptersController {
   );
 
   constructor(
-    private readonly getAcademyContentUseCase: GetAcademyContentUseCase,
+    private readonly getAcademyManagementContentUseCase: GetAcademyManagementContentUseCase,
     private readonly createChapterUseCase: CreateChapterUseCase,
     private readonly updateChapterUseCase: UpdateChapterUseCase,
     private readonly deleteChapterUseCase: DeleteChapterUseCase,
@@ -67,18 +68,18 @@ export class SuperAdminAcademyChaptersController {
   })
   @ApiOkResponse({
     description: 'Successfully retrieved academy chapters',
-    type: [AcademyChapterResponseDto],
+    type: [SuperAdminAcademyChapterResponseDto],
   })
   @ApiUnauthorizedResponse({
     description: 'User not authenticated or not authorized as super admin',
   })
   @ApiInternalServerErrorResponse({ description: 'Internal server error' })
-  async getChapters(): Promise<AcademyChapterResponseDto[]> {
+  async getChapters(): Promise<SuperAdminAcademyChapterResponseDto[]> {
     this.logger.log('Getting academy chapters');
-    const chapters = await this.getAcademyContentUseCase.execute(
-      new GetAcademyContentQuery(),
+    const chapters = await this.getAcademyManagementContentUseCase.execute(
+      new GetAcademyManagementContentQuery(),
     );
-    return this.responseMapper.chapterToDtoArray(chapters);
+    return this.responseMapper.chapterToSuperAdminDtoArray(chapters);
   }
 
   @Post()
@@ -171,6 +172,7 @@ export class SuperAdminAcademyChaptersController {
         chapterId: id,
         title: dto.title,
         description: dto.description,
+        quizEnabled: dto.quizEnabled,
       }),
     );
     return this.responseMapper.chapterToDto(chapter);

--- a/ayunis-core-backend/src/domain/academy/presenters/http/super-admin-academy-quiz-questions.controller.ts
+++ b/ayunis-core-backend/src/domain/academy/presenters/http/super-admin-academy-quiz-questions.controller.ts
@@ -1,0 +1,166 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  HttpCode,
+  HttpStatus,
+  Logger,
+  Param,
+  ParseUUIDPipe,
+  Post,
+  Put,
+} from '@nestjs/common';
+import type { UUID } from 'crypto';
+import {
+  ApiBody,
+  ApiCreatedResponse,
+  ApiInternalServerErrorResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiParam,
+  ApiResponse,
+  ApiTags,
+  ApiUnauthorizedResponse,
+} from '@nestjs/swagger';
+import { SystemRoles } from 'src/iam/authorization/application/decorators/system-roles.decorator';
+import { SystemRole } from 'src/iam/users/domain/value-objects/system-role.enum';
+import { CreateQuizQuestionUseCase } from '../../application/use-cases/create-quiz-question/create-quiz-question.use-case';
+import { CreateQuizQuestionCommand } from '../../application/use-cases/create-quiz-question/create-quiz-question.command';
+import { UpdateQuizQuestionUseCase } from '../../application/use-cases/update-quiz-question/update-quiz-question.use-case';
+import { UpdateQuizQuestionCommand } from '../../application/use-cases/update-quiz-question/update-quiz-question.command';
+import { DeleteQuizQuestionUseCase } from '../../application/use-cases/delete-quiz-question/delete-quiz-question.use-case';
+import { DeleteQuizQuestionCommand } from '../../application/use-cases/delete-quiz-question/delete-quiz-question.command';
+import { CreateQuizQuestionRequestDto } from './dto/create-quiz-question-request.dto';
+import { UpdateQuizQuestionRequestDto } from './dto/update-quiz-question-request.dto';
+import { QuizQuestionResponseDto } from './dto/quiz-question-response.dto';
+import { AcademyResponseDtoMapper } from './mappers/academy-response-dto.mapper';
+
+@ApiTags('Super Admin Academy')
+@Controller('super-admin/academy')
+@SystemRoles(SystemRole.SUPER_ADMIN)
+export class SuperAdminAcademyQuizQuestionsController {
+  private readonly logger = new Logger(
+    SuperAdminAcademyQuizQuestionsController.name,
+  );
+
+  constructor(
+    private readonly createQuizQuestionUseCase: CreateQuizQuestionUseCase,
+    private readonly updateQuizQuestionUseCase: UpdateQuizQuestionUseCase,
+    private readonly deleteQuizQuestionUseCase: DeleteQuizQuestionUseCase,
+    private readonly responseMapper: AcademyResponseDtoMapper,
+  ) {}
+
+  @Post('chapters/:chapterId/quiz-questions')
+  @HttpCode(HttpStatus.CREATED)
+  @ApiOperation({
+    summary: 'Create a new academy quiz question',
+    description:
+      'Add a question to a chapter quiz pool, appended after the last position. Only accessible to super admins.',
+  })
+  @ApiParam({ name: 'chapterId', description: 'Chapter ID', format: 'uuid' })
+  @ApiBody({ type: CreateQuizQuestionRequestDto })
+  @ApiCreatedResponse({
+    description: 'Successfully created quiz question',
+    type: QuizQuestionResponseDto,
+  })
+  @ApiResponse({
+    status: HttpStatus.NOT_FOUND,
+    description: 'Chapter not found',
+  })
+  @ApiResponse({
+    status: HttpStatus.BAD_REQUEST,
+    description: 'Invalid question (bad option count or no single correct)',
+  })
+  @ApiUnauthorizedResponse({
+    description: 'User not authenticated or not authorized as super admin',
+  })
+  @ApiInternalServerErrorResponse({ description: 'Internal server error' })
+  async createQuizQuestion(
+    @Param('chapterId', ParseUUIDPipe) chapterId: UUID,
+    @Body() dto: CreateQuizQuestionRequestDto,
+  ): Promise<QuizQuestionResponseDto> {
+    this.logger.log(`Creating academy quiz question in chapter ${chapterId}`);
+    const quizQuestion = await this.createQuizQuestionUseCase.execute(
+      new CreateQuizQuestionCommand({
+        chapterId,
+        text: dto.text,
+        options: dto.options.map((option) => ({
+          text: option.text,
+          isCorrect: option.isCorrect,
+        })),
+      }),
+    );
+    return this.responseMapper.quizQuestionToDto(quizQuestion);
+  }
+
+  @Put('quiz-questions/:id')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Update an academy quiz question',
+    description:
+      'Replace the prompt and answer options of a quiz question. Only accessible to super admins.',
+  })
+  @ApiParam({ name: 'id', description: 'Quiz question ID', format: 'uuid' })
+  @ApiBody({ type: UpdateQuizQuestionRequestDto })
+  @ApiOkResponse({
+    description: 'Successfully updated quiz question',
+    type: QuizQuestionResponseDto,
+  })
+  @ApiResponse({
+    status: HttpStatus.NOT_FOUND,
+    description: 'Quiz question not found',
+  })
+  @ApiResponse({
+    status: HttpStatus.BAD_REQUEST,
+    description: 'Invalid question (bad option count or no single correct)',
+  })
+  @ApiUnauthorizedResponse({
+    description: 'User not authenticated or not authorized as super admin',
+  })
+  @ApiInternalServerErrorResponse({ description: 'Internal server error' })
+  async updateQuizQuestion(
+    @Param('id', ParseUUIDPipe) id: UUID,
+    @Body() dto: UpdateQuizQuestionRequestDto,
+  ): Promise<QuizQuestionResponseDto> {
+    this.logger.log(`Updating academy quiz question ${id}`);
+    const quizQuestion = await this.updateQuizQuestionUseCase.execute(
+      new UpdateQuizQuestionCommand({
+        quizQuestionId: id,
+        text: dto.text,
+        options: dto.options.map((option) => ({
+          text: option.text,
+          isCorrect: option.isCorrect,
+        })),
+      }),
+    );
+    return this.responseMapper.quizQuestionToDto(quizQuestion);
+  }
+
+  @Delete('quiz-questions/:id')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({
+    summary: 'Delete an academy quiz question',
+    description: 'Delete a quiz question. Only accessible to super admins.',
+  })
+  @ApiParam({ name: 'id', description: 'Quiz question ID', format: 'uuid' })
+  @ApiResponse({
+    status: HttpStatus.NO_CONTENT,
+    description: 'Successfully deleted quiz question',
+  })
+  @ApiResponse({
+    status: HttpStatus.NOT_FOUND,
+    description: 'Quiz question not found',
+  })
+  @ApiUnauthorizedResponse({
+    description: 'User not authenticated or not authorized as super admin',
+  })
+  @ApiInternalServerErrorResponse({ description: 'Internal server error' })
+  async deleteQuizQuestion(
+    @Param('id', ParseUUIDPipe) id: UUID,
+  ): Promise<void> {
+    this.logger.log(`Deleting academy quiz question ${id}`);
+    await this.deleteQuizQuestionUseCase.execute(
+      new DeleteQuizQuestionCommand({ quizQuestionId: id }),
+    );
+  }
+}

--- a/ayunis-core-frontend/src/pages/super-admin-settings/academy/api/useCreateQuestion.ts
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/academy/api/useCreateQuestion.ts
@@ -1,0 +1,66 @@
+import { useQueryClient } from '@tanstack/react-query';
+import type { UseFormReturn } from 'react-hook-form';
+import { useRouter } from '@tanstack/react-router';
+import { useTranslation } from 'react-i18next';
+import { showSuccess, showError } from '@/shared/lib/toast';
+import {
+  useSuperAdminAcademyQuizQuestionsControllerCreateQuizQuestion,
+  getSuperAdminAcademyChaptersControllerGetChaptersQueryKey,
+  type CreateQuizQuestionRequestDto,
+} from '@/shared/api';
+import extractErrorData from '@/shared/api/extract-error-data';
+import { setValidationErrors } from '@/shared/lib/set-validation-errors';
+import type { QuestionFormValues } from '../model/questionFormSchema';
+
+export function useCreateQuestion(
+  form: UseFormReturn<QuestionFormValues>,
+  onSuccess?: () => void,
+) {
+  const { t } = useTranslation('super-admin-settings-academy');
+  const queryClient = useQueryClient();
+  const router = useRouter();
+  const mutation =
+    useSuperAdminAcademyQuizQuestionsControllerCreateQuizQuestion({
+      mutation: {
+        onSuccess: async () => {
+          await queryClient.invalidateQueries({
+            queryKey:
+              getSuperAdminAcademyChaptersControllerGetChaptersQueryKey(),
+          });
+          showSuccess(t('toast.questionCreateSuccess'));
+          onSuccess?.();
+        },
+        onError: (error: unknown) => {
+          try {
+            const { code, errors } = extractErrorData(error);
+            if (code === 'VALIDATION_ERROR' && errors) {
+              setValidationErrors(form, errors, t, 'validation');
+            } else if (code === 'CHAPTER_NOT_FOUND') {
+              showError(t('toast.chapterNotFound'));
+            } else if (code === 'INVALID_QUIZ_QUESTION') {
+              showError(t('toast.questionInvalid'));
+            } else {
+              showError(t('toast.questionCreateError'));
+            }
+          } catch {
+            showError(t('toast.questionCreateError'));
+          }
+        },
+        onSettled: async () => {
+          await router.invalidate();
+        },
+      },
+    });
+
+  function createQuestion(
+    chapterId: string,
+    data: CreateQuizQuestionRequestDto,
+  ) {
+    mutation.mutate({ chapterId, data });
+  }
+
+  return {
+    createQuestion,
+    isCreating: mutation.isPending,
+  };
+}

--- a/ayunis-core-frontend/src/pages/super-admin-settings/academy/api/useDeleteQuestion.ts
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/academy/api/useDeleteQuestion.ts
@@ -1,0 +1,51 @@
+import { useQueryClient } from '@tanstack/react-query';
+import { useRouter } from '@tanstack/react-router';
+import { useTranslation } from 'react-i18next';
+import { showSuccess, showError } from '@/shared/lib/toast';
+import {
+  useSuperAdminAcademyQuizQuestionsControllerDeleteQuizQuestion,
+  getSuperAdminAcademyChaptersControllerGetChaptersQueryKey,
+} from '@/shared/api';
+import extractErrorData from '@/shared/api/extract-error-data';
+
+export function useDeleteQuestion() {
+  const { t } = useTranslation('super-admin-settings-academy');
+  const queryClient = useQueryClient();
+  const router = useRouter();
+  const mutation =
+    useSuperAdminAcademyQuizQuestionsControllerDeleteQuizQuestion({
+      mutation: {
+        onSuccess: async () => {
+          await queryClient.invalidateQueries({
+            queryKey:
+              getSuperAdminAcademyChaptersControllerGetChaptersQueryKey(),
+          });
+          showSuccess(t('toast.questionDeleteSuccess'));
+        },
+        onError: (error: unknown) => {
+          try {
+            const { code } = extractErrorData(error);
+            if (code === 'QUIZ_QUESTION_NOT_FOUND') {
+              showError(t('toast.questionNotFound'));
+            } else {
+              showError(t('toast.questionDeleteError'));
+            }
+          } catch {
+            showError(t('toast.questionDeleteError'));
+          }
+        },
+        onSettled: async () => {
+          await router.invalidate();
+        },
+      },
+    });
+
+  function deleteQuestion(id: string) {
+    mutation.mutate({ id });
+  }
+
+  return {
+    deleteQuestion,
+    isDeleting: mutation.isPending,
+  };
+}

--- a/ayunis-core-frontend/src/pages/super-admin-settings/academy/api/useSetChapterQuizEnabled.ts
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/academy/api/useSetChapterQuizEnabled.ts
@@ -1,0 +1,51 @@
+import { useQueryClient } from '@tanstack/react-query';
+import { useRouter } from '@tanstack/react-router';
+import { useTranslation } from 'react-i18next';
+import { showError } from '@/shared/lib/toast';
+import {
+  useSuperAdminAcademyChaptersControllerUpdateChapter,
+  getSuperAdminAcademyChaptersControllerGetChaptersQueryKey,
+  type SuperAdminAcademyChapterResponseDto,
+} from '@/shared/api';
+
+// Toggles the per-chapter quiz activation. Update is a full replace, so the
+// current title/description are sent alongside the new quizEnabled flag.
+export function useSetChapterQuizEnabled() {
+  const { t } = useTranslation('super-admin-settings-academy');
+  const queryClient = useQueryClient();
+  const router = useRouter();
+  const mutation = useSuperAdminAcademyChaptersControllerUpdateChapter({
+    mutation: {
+      onSuccess: async () => {
+        await queryClient.invalidateQueries({
+          queryKey: getSuperAdminAcademyChaptersControllerGetChaptersQueryKey(),
+        });
+      },
+      onError: () => {
+        showError(t('toast.quizToggleError'));
+      },
+      onSettled: async () => {
+        await router.invalidate();
+      },
+    },
+  });
+
+  function setQuizEnabled(
+    chapter: SuperAdminAcademyChapterResponseDto,
+    quizEnabled: boolean,
+  ) {
+    mutation.mutate({
+      id: chapter.id,
+      data: {
+        title: chapter.title,
+        description: chapter.description,
+        quizEnabled,
+      },
+    });
+  }
+
+  return {
+    setQuizEnabled,
+    isSettingQuiz: mutation.isPending,
+  };
+}

--- a/ayunis-core-frontend/src/pages/super-admin-settings/academy/api/useUpdateQuestion.ts
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/academy/api/useUpdateQuestion.ts
@@ -1,0 +1,63 @@
+import { useQueryClient } from '@tanstack/react-query';
+import type { UseFormReturn } from 'react-hook-form';
+import { useRouter } from '@tanstack/react-router';
+import { useTranslation } from 'react-i18next';
+import { showSuccess, showError } from '@/shared/lib/toast';
+import {
+  useSuperAdminAcademyQuizQuestionsControllerUpdateQuizQuestion,
+  getSuperAdminAcademyChaptersControllerGetChaptersQueryKey,
+  type UpdateQuizQuestionRequestDto,
+} from '@/shared/api';
+import extractErrorData from '@/shared/api/extract-error-data';
+import { setValidationErrors } from '@/shared/lib/set-validation-errors';
+import type { QuestionFormValues } from '../model/questionFormSchema';
+
+export function useUpdateQuestion(
+  form: UseFormReturn<QuestionFormValues>,
+  onSuccess?: () => void,
+) {
+  const { t } = useTranslation('super-admin-settings-academy');
+  const queryClient = useQueryClient();
+  const router = useRouter();
+  const mutation =
+    useSuperAdminAcademyQuizQuestionsControllerUpdateQuizQuestion({
+      mutation: {
+        onSuccess: async () => {
+          await queryClient.invalidateQueries({
+            queryKey:
+              getSuperAdminAcademyChaptersControllerGetChaptersQueryKey(),
+          });
+          showSuccess(t('toast.questionUpdateSuccess'));
+          onSuccess?.();
+        },
+        onError: (error: unknown) => {
+          try {
+            const { code, errors } = extractErrorData(error);
+            if (code === 'VALIDATION_ERROR' && errors) {
+              setValidationErrors(form, errors, t, 'validation');
+            } else if (code === 'QUIZ_QUESTION_NOT_FOUND') {
+              showError(t('toast.questionNotFound'));
+            } else if (code === 'INVALID_QUIZ_QUESTION') {
+              showError(t('toast.questionInvalid'));
+            } else {
+              showError(t('toast.questionUpdateError'));
+            }
+          } catch {
+            showError(t('toast.questionUpdateError'));
+          }
+        },
+        onSettled: async () => {
+          await router.invalidate();
+        },
+      },
+    });
+
+  function updateQuestion(id: string, data: UpdateQuizQuestionRequestDto) {
+    mutation.mutate({ id, data });
+  }
+
+  return {
+    updateQuestion,
+    isUpdating: mutation.isPending,
+  };
+}

--- a/ayunis-core-frontend/src/pages/super-admin-settings/academy/model/questionFormSchema.ts
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/academy/model/questionFormSchema.ts
@@ -1,0 +1,36 @@
+import * as z from 'zod';
+
+// Mirrors the backend DTO validation (CreateQuizQuestionRequestDto) plus the
+// single-correct rule enforced in the use case (exactly one correct option).
+export const MIN_OPTIONS = 2;
+export const MAX_OPTIONS = 6;
+
+export function createQuestionFormSchema(t: (key: string) => string) {
+  return z
+    .object({
+      text: z
+        .string()
+        .min(1, t('questionForm.textRequired'))
+        .max(2000, t('questionForm.textTooLong')),
+      options: z
+        .array(
+          z.object({
+            text: z
+              .string()
+              .min(1, t('questionForm.optionRequired'))
+              .max(500, t('questionForm.optionTooLong')),
+          }),
+        )
+        .min(MIN_OPTIONS, t('questionForm.tooFewOptions'))
+        .max(MAX_OPTIONS, t('questionForm.tooManyOptions')),
+      correctOptionIndex: z.number().int().min(0),
+    })
+    .refine((data) => data.correctOptionIndex < data.options.length, {
+      message: t('questionForm.correctRequired'),
+      path: ['correctOptionIndex'],
+    });
+}
+
+export type QuestionFormValues = z.infer<
+  ReturnType<typeof createQuestionFormSchema>
+>;

--- a/ayunis-core-frontend/src/pages/super-admin-settings/academy/ui/ChapterCard.tsx
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/academy/ui/ChapterCard.tsx
@@ -17,8 +17,8 @@ import {
 import { CSS } from '@dnd-kit/utilities';
 import { useTranslation } from 'react-i18next';
 import type {
-  AcademyChapterResponseDto,
   CourseModuleResponseDto,
+  SuperAdminAcademyChapterResponseDto,
 } from '@/shared/api';
 import {
   Card,
@@ -30,11 +30,12 @@ import {
 import { Button } from '@/shared/ui/shadcn/button';
 import { GripVertical, Pencil, Plus, Trash2 } from 'lucide-react';
 import { ModuleItem } from './ModuleItem';
+import { QuizSection } from './QuizSection';
 import { useReorderModules } from '../api/useReorderModules';
 import { moveById } from '../lib/sortOrder';
 
 interface ChapterCardProps {
-  chapter: AcademyChapterResponseDto;
+  chapter: SuperAdminAcademyChapterResponseDto;
   onEdit: () => void;
   onDelete: () => void;
   onAddModule: () => void;
@@ -175,6 +176,7 @@ export function ChapterCard({
             <Plus className="h-4 w-4" />
             {t('page.addModule')}
           </Button>
+          <QuizSection chapter={chapter} />
         </CardContent>
       </Card>
     </div>

--- a/ayunis-core-frontend/src/pages/super-admin-settings/academy/ui/Page.tsx
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/academy/ui/Page.tsx
@@ -15,8 +15,8 @@ import {
 } from '@dnd-kit/sortable';
 import { useTranslation } from 'react-i18next';
 import type {
-  AcademyChapterResponseDto,
   CourseModuleResponseDto,
+  SuperAdminAcademyChapterResponseDto,
 } from '@/shared/api';
 import SuperAdminSettingsLayout from '../../super-admin-settings-layout';
 import { Button } from '@/shared/ui/shadcn/button';
@@ -30,7 +30,7 @@ import { useReorderChapters } from '../api/useReorderChapters';
 import { moveById } from '../lib/sortOrder';
 
 interface AcademyPageProps {
-  chapters: AcademyChapterResponseDto[];
+  chapters: SuperAdminAcademyChapterResponseDto[];
 }
 
 interface ModuleDialogState {
@@ -42,7 +42,7 @@ export default function AcademyPage({ chapters }: Readonly<AcademyPageProps>) {
   const { t } = useTranslation('super-admin-settings-academy');
   const [chapterDialogOpen, setChapterDialogOpen] = useState(false);
   const [editChapter, setEditChapter] =
-    useState<AcademyChapterResponseDto | null>(null);
+    useState<SuperAdminAcademyChapterResponseDto | null>(null);
   const [moduleDialog, setModuleDialog] = useState<ModuleDialogState | null>(
     null,
   );
@@ -78,7 +78,7 @@ export default function AcademyPage({ chapters }: Readonly<AcademyPageProps>) {
     reorderChapters(next.map((chapter) => chapter.id));
   }
 
-  function handleDeleteChapter(chapter: AcademyChapterResponseDto) {
+  function handleDeleteChapter(chapter: SuperAdminAcademyChapterResponseDto) {
     confirm({
       title: t('deleteChapter.title'),
       description: t('deleteChapter.description', { title: chapter.title }),

--- a/ayunis-core-frontend/src/pages/super-admin-settings/academy/ui/QuestionFormDialog.tsx
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/academy/ui/QuestionFormDialog.tsx
@@ -1,0 +1,243 @@
+import { useEffect } from 'react';
+import { useFieldArray, useForm, useWatch } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useTranslation } from 'react-i18next';
+import { Plus, Trash2 } from 'lucide-react';
+import type { QuizQuestionResponseDto } from '@/shared/api';
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/shared/ui/shadcn/dialog';
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/shared/ui/shadcn/form';
+import { Input } from '@/shared/ui/shadcn/input';
+import { Textarea } from '@/shared/ui/shadcn/textarea';
+import { Button } from '@/shared/ui/shadcn/button';
+import {
+  createQuestionFormSchema,
+  MAX_OPTIONS,
+  MIN_OPTIONS,
+  type QuestionFormValues,
+} from '../model/questionFormSchema';
+import { useCreateQuestion } from '../api/useCreateQuestion';
+import { useUpdateQuestion } from '../api/useUpdateQuestion';
+
+interface QuestionFormDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  chapterId: string;
+  question: QuizQuestionResponseDto | null;
+}
+
+const EMPTY_OPTIONS = [{ text: '' }, { text: '' }];
+
+function toFormValues(
+  question: QuizQuestionResponseDto | null,
+): QuestionFormValues {
+  if (!question) {
+    return { text: '', options: EMPTY_OPTIONS, correctOptionIndex: 0 };
+  }
+  const correctIndex = question.options.findIndex((o) => o.isCorrect);
+  return {
+    text: question.text,
+    options: question.options.map((o) => ({ text: o.text })),
+    correctOptionIndex: correctIndex < 0 ? 0 : correctIndex,
+  };
+}
+
+export function QuestionFormDialog({
+  open,
+  onOpenChange,
+  chapterId,
+  question,
+}: Readonly<QuestionFormDialogProps>) {
+  const { t } = useTranslation('super-admin-settings-academy');
+  const isEdit = question !== null;
+
+  const form = useForm<QuestionFormValues>({
+    resolver: zodResolver(createQuestionFormSchema(t)),
+    defaultValues: toFormValues(null),
+  });
+  const { fields, append, remove } = useFieldArray({
+    control: form.control,
+    name: 'options',
+  });
+  const correctOptionIndex = useWatch({
+    control: form.control,
+    name: 'correctOptionIndex',
+  });
+
+  useEffect(() => {
+    if (open) {
+      form.reset(toFormValues(question));
+    }
+  }, [open, question, form]);
+
+  function close() {
+    onOpenChange(false);
+    form.reset(toFormValues(null));
+  }
+
+  const { createQuestion, isCreating } = useCreateQuestion(form, close);
+  const { updateQuestion, isUpdating } = useUpdateQuestion(form, close);
+  const isSubmitting = isCreating || isUpdating;
+
+  function removeOption(index: number) {
+    remove(index);
+    if (index === correctOptionIndex) {
+      form.setValue('correctOptionIndex', 0);
+    } else if (index < correctOptionIndex) {
+      form.setValue('correctOptionIndex', correctOptionIndex - 1);
+    }
+  }
+
+  function onSubmit(data: QuestionFormValues) {
+    const payload = {
+      text: data.text,
+      options: data.options.map((option, index) => ({
+        text: option.text,
+        isCorrect: index === data.correctOptionIndex,
+      })),
+    };
+    if (isEdit) {
+      updateQuestion(question.id, payload);
+    } else {
+      createQuestion(chapterId, payload);
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[560px]">
+        <DialogHeader>
+          <DialogTitle>
+            {isEdit
+              ? t('questionForm.editTitle')
+              : t('questionForm.createTitle')}
+          </DialogTitle>
+        </DialogHeader>
+        <Form {...form}>
+          <form
+            onSubmit={(e) => void form.handleSubmit(onSubmit)(e)}
+            className="space-y-4"
+          >
+            <FormField
+              control={form.control}
+              name="text"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>{t('questionForm.text')}</FormLabel>
+                  <FormControl>
+                    <Textarea
+                      {...field}
+                      placeholder={t('questionForm.textPlaceholder')}
+                      disabled={isSubmitting}
+                      rows={2}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <div className="space-y-2">
+              <FormLabel>{t('questionForm.options')}</FormLabel>
+              <p className="text-xs text-muted-foreground">
+                {t('questionForm.optionsHint')}
+              </p>
+              {fields.map((fieldItem, index) => (
+                <FormField
+                  key={fieldItem.id}
+                  control={form.control}
+                  name={`options.${index}.text`}
+                  render={({ field }) => (
+                    <FormItem>
+                      <div className="flex items-center gap-2">
+                        <input
+                          type="radio"
+                          name="correctOption"
+                          className="h-4 w-4 shrink-0"
+                          aria-label={t('questionForm.markCorrect')}
+                          checked={correctOptionIndex === index}
+                          disabled={isSubmitting}
+                          onChange={() =>
+                            form.setValue('correctOptionIndex', index, {
+                              shouldValidate: true,
+                            })
+                          }
+                        />
+                        <FormControl>
+                          <Input
+                            {...field}
+                            placeholder={t('questionForm.optionPlaceholder', {
+                              number: index + 1,
+                            })}
+                            disabled={isSubmitting}
+                          />
+                        </FormControl>
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="icon"
+                          className="shrink-0 text-destructive hover:text-destructive"
+                          aria-label={t('questionForm.removeOption')}
+                          disabled={
+                            isSubmitting || fields.length <= MIN_OPTIONS
+                          }
+                          onClick={() => removeOption(index)}
+                        >
+                          <Trash2 className="h-4 w-4" />
+                        </Button>
+                      </div>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              ))}
+              {form.formState.errors.correctOptionIndex && (
+                <p className="text-sm text-destructive">
+                  {form.formState.errors.correctOptionIndex.message}
+                </p>
+              )}
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                disabled={isSubmitting || fields.length >= MAX_OPTIONS}
+                onClick={() => append({ text: '' })}
+              >
+                <Plus className="h-4 w-4" />
+                {t('questionForm.addOption')}
+              </Button>
+            </div>
+
+            <DialogFooter>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={close}
+                disabled={isSubmitting}
+              >
+                {t('questionForm.cancel')}
+              </Button>
+              <Button type="submit" disabled={isSubmitting}>
+                {isSubmitting
+                  ? t('questionForm.saving')
+                  : t('questionForm.save')}
+              </Button>
+            </DialogFooter>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/ayunis-core-frontend/src/pages/super-admin-settings/academy/ui/QuizSection.tsx
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/academy/ui/QuizSection.tsx
@@ -1,0 +1,121 @@
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Pencil, Plus, Trash2 } from 'lucide-react';
+import type {
+  QuizQuestionResponseDto,
+  SuperAdminAcademyChapterResponseDto,
+} from '@/shared/api';
+import {
+  Item,
+  ItemActions,
+  ItemContent,
+  ItemTitle,
+} from '@/shared/ui/shadcn/item';
+import { Button } from '@/shared/ui/shadcn/button';
+import { Switch } from '@/shared/ui/shadcn/switch';
+import { Label } from '@/shared/ui/shadcn/label';
+import { useConfirmation } from '@/widgets/confirmation-modal';
+import { QuestionFormDialog } from './QuestionFormDialog';
+import { useDeleteQuestion } from '../api/useDeleteQuestion';
+import { useSetChapterQuizEnabled } from '../api/useSetChapterQuizEnabled';
+
+interface QuizSectionProps {
+  chapter: SuperAdminAcademyChapterResponseDto;
+}
+
+export function QuizSection({ chapter }: Readonly<QuizSectionProps>) {
+  const { t } = useTranslation('super-admin-settings-academy');
+  const [dialogQuestion, setDialogQuestion] =
+    useState<QuizQuestionResponseDto | null>(null);
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const { setQuizEnabled, isSettingQuiz } = useSetChapterQuizEnabled();
+  const { deleteQuestion, isDeleting } = useDeleteQuestion();
+  const { confirm } = useConfirmation();
+
+  function openCreate() {
+    setDialogQuestion(null);
+    setDialogOpen(true);
+  }
+
+  function openEdit(question: QuizQuestionResponseDto) {
+    setDialogQuestion(question);
+    setDialogOpen(true);
+  }
+
+  function handleDelete(question: QuizQuestionResponseDto) {
+    confirm({
+      title: t('deleteQuestion.title'),
+      description: t('deleteQuestion.description'),
+      confirmText: t('deleteQuestion.confirm'),
+      cancelText: t('deleteQuestion.cancel'),
+      variant: 'destructive',
+      onConfirm: () => deleteQuestion(question.id),
+    });
+  }
+
+  const switchId = `quiz-enabled-${chapter.id}`;
+
+  return (
+    <div className="space-y-2 border-t pt-3">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <Switch
+            id={switchId}
+            checked={chapter.quizEnabled}
+            disabled={isSettingQuiz}
+            onCheckedChange={(checked) => setQuizEnabled(chapter, checked)}
+          />
+          <Label htmlFor={switchId}>{t('quiz.enableLabel')}</Label>
+        </div>
+        <Button variant="outline" size="sm" onClick={openCreate}>
+          <Plus className="h-4 w-4" />
+          {t('quiz.addQuestion')}
+        </Button>
+      </div>
+
+      {chapter.quizQuestions.length === 0 ? (
+        <p className="py-1 text-sm text-muted-foreground">
+          {t('quiz.noQuestions')}
+        </p>
+      ) : (
+        <div className="flex flex-col gap-2">
+          {chapter.quizQuestions.map((question) => (
+            <Item key={question.id} variant="outline" size="sm">
+              <ItemContent>
+                <ItemTitle>{question.text}</ItemTitle>
+              </ItemContent>
+              <ItemActions>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  onClick={() => openEdit(question)}
+                >
+                  <Pencil className="h-4 w-4" />
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="text-destructive hover:text-destructive"
+                  onClick={() => handleDelete(question)}
+                  disabled={isDeleting}
+                >
+                  <Trash2 className="h-4 w-4" />
+                </Button>
+              </ItemActions>
+            </Item>
+          ))}
+        </div>
+      )}
+
+      <QuestionFormDialog
+        open={dialogOpen}
+        onOpenChange={(open) => {
+          setDialogOpen(open);
+          if (!open) setDialogQuestion(null);
+        }}
+        chapterId={chapter.id}
+        question={dialogQuestion}
+      />
+    </div>
+  );
+}

--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
@@ -4230,12 +4230,59 @@ export interface AcademyChapterResponseDto {
   description: string;
   /** The position of the chapter (0-based) */
   position: number;
+  /** Whether a quiz is activated for this chapter (shown at chapter end) */
+  quizEnabled: boolean;
   /** The modules of the chapter, ordered by position */
   courseModules: CourseModuleResponseDto[];
   /** The date the chapter was created */
   createdAt: string;
   /** The date the chapter was last updated */
   updatedAt: string;
+}
+
+export interface QuizAnswerOptionResponseDto {
+  /** The answer option text */
+  text: string;
+  /** Whether this option is the correct answer */
+  isCorrect: boolean;
+}
+
+export interface QuizQuestionResponseDto {
+  /** The unique identifier of the quiz question */
+  id: string;
+  /** The id of the chapter the question belongs to */
+  chapterId: string;
+  /** The question prompt */
+  text: string;
+  /** The answer options with the correct one flagged */
+  options: QuizAnswerOptionResponseDto[];
+  /** The position of the question within its chapter (0-based) */
+  position: number;
+  /** The date the question was created */
+  createdAt: string;
+  /** The date the question was last updated */
+  updatedAt: string;
+}
+
+export interface SuperAdminAcademyChapterResponseDto {
+  /** The unique identifier of the chapter */
+  id: string;
+  /** The title of the chapter */
+  title: string;
+  /** A description of what the chapter covers */
+  description: string;
+  /** The position of the chapter (0-based) */
+  position: number;
+  /** Whether a quiz is activated for this chapter (shown at chapter end) */
+  quizEnabled: boolean;
+  /** The modules of the chapter, ordered by position */
+  courseModules: CourseModuleResponseDto[];
+  /** The date the chapter was created */
+  createdAt: string;
+  /** The date the chapter was last updated */
+  updatedAt: string;
+  /** The quiz question pool of the chapter, ordered by position */
+  quizQuestions: QuizQuestionResponseDto[];
 }
 
 export interface CreateChapterRequestDto {
@@ -4267,6 +4314,8 @@ export interface UpdateChapterRequestDto {
    * @maxLength 2000
    */
   description: string;
+  /** Whether a quiz is activated for this chapter */
+  quizEnabled?: boolean;
 }
 
 export interface CreateCourseModuleRequestDto {
@@ -4308,6 +4357,44 @@ export interface UpdateCourseModuleRequestDto {
    * @maxLength 500
    */
   loomUrl: string;
+}
+
+export interface QuizAnswerOptionRequestDto {
+  /**
+   * The answer option text
+   * @maxLength 500
+   */
+  text: string;
+  /** Whether this option is the correct answer */
+  isCorrect: boolean;
+}
+
+export interface CreateQuizQuestionRequestDto {
+  /**
+   * The question prompt
+   * @maxLength 2000
+   */
+  text: string;
+  /**
+   * The answer options. Between 2 and 6 options with exactly one marked correct.
+   * @minItems 2
+   * @maxItems 6
+   */
+  options: QuizAnswerOptionRequestDto[];
+}
+
+export interface UpdateQuizQuestionRequestDto {
+  /**
+   * The question prompt
+   * @maxLength 2000
+   */
+  text: string;
+  /**
+   * The answer options. Between 2 and 6 options with exactly one marked correct.
+   * @minItems 2
+   * @maxItems 6
+   */
+  options: QuizAnswerOptionRequestDto[];
 }
 
 export interface ChatCompletionRequestDto { [key: string]: unknown }

--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.ts
@@ -62,6 +62,7 @@ import type {
   CreateOrgRequestDto,
   CreatePermittedModelDto,
   CreatePredefinedIntegrationDto,
+  CreateQuizQuestionRequestDto,
   CreateSkillDto,
   CreateSkillShareDto,
   CreateSkillTemplateDto,
@@ -124,6 +125,7 @@ import type {
   PromoteToSuperAdminDto,
   ProviderUsageChartResponseDto,
   ProviderUsageResponseDto,
+  QuizQuestionResponseDto,
   RegisterDto,
   ReorderChaptersRequestDto,
   ReorderCourseModulesRequestDto,
@@ -152,6 +154,7 @@ import type {
   SubscriptionResponseDto,
   SubscriptionResponseDtoNullable,
   SuccessResponseDto,
+  SuperAdminAcademyChapterResponseDto,
   SuperAdminCatalogModelsControllerGetAllCatalogModels200Item,
   SuperAdminCatalogModelsControllerGetCatalogModelById200,
   SuperAdminOrgListResponseDto,
@@ -196,6 +199,7 @@ import type {
   UpdatePasswordDto,
   UpdatePermittedModelDto,
   UpdatePiiWhitelistRequestDto,
+  UpdateQuizQuestionRequestDto,
   UpdateRetentionPolicyRequestDto,
   UpdateSeatsDto,
   UpdateSkillDto,
@@ -17605,7 +17609,7 @@ export const superAdminAcademyChaptersControllerGetChapters = (
 ) => {
       
       
-      return customAxiosInstance<AcademyChapterResponseDto[]>(
+      return customAxiosInstance<SuperAdminAcademyChapterResponseDto[]>(
       {url: `/super-admin/academy/chapters`, method: 'GET', signal
     },
       );
@@ -18207,6 +18211,202 @@ export const useSuperAdminAcademyCourseModulesControllerDeleteCourseModule = <TE
       > => {
 
       const mutationOptions = getSuperAdminAcademyCourseModulesControllerDeleteCourseModuleMutationOptions(options);
+
+      return useMutation(mutationOptions, queryClient);
+    }
+    
+/**
+ * Add a question to a chapter quiz pool, appended after the last position. Only accessible to super admins.
+ * @summary Create a new academy quiz question
+ */
+export const superAdminAcademyQuizQuestionsControllerCreateQuizQuestion = (
+    chapterId: string,
+    createQuizQuestionRequestDto: CreateQuizQuestionRequestDto,
+ signal?: AbortSignal
+) => {
+      
+      
+      return customAxiosInstance<QuizQuestionResponseDto>(
+      {url: `/super-admin/academy/chapters/${chapterId}/quiz-questions`, method: 'POST',
+      headers: {'Content-Type': 'application/json', },
+      data: createQuizQuestionRequestDto, signal
+    },
+      );
+    }
+  
+
+
+export const getSuperAdminAcademyQuizQuestionsControllerCreateQuizQuestionMutationOptions = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof superAdminAcademyQuizQuestionsControllerCreateQuizQuestion>>, TError,{chapterId: string;data: CreateQuizQuestionRequestDto}, TContext>, }
+): UseMutationOptions<Awaited<ReturnType<typeof superAdminAcademyQuizQuestionsControllerCreateQuizQuestion>>, TError,{chapterId: string;data: CreateQuizQuestionRequestDto}, TContext> => {
+
+const mutationKey = ['superAdminAcademyQuizQuestionsControllerCreateQuizQuestion'];
+const {mutation: mutationOptions} = options ?
+      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
+      options
+      : {...options, mutation: {...options.mutation, mutationKey}}
+      : {mutation: { mutationKey, }};
+
+      
+
+
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof superAdminAcademyQuizQuestionsControllerCreateQuizQuestion>>, {chapterId: string;data: CreateQuizQuestionRequestDto}> = (props) => {
+          const {chapterId,data} = props ?? {};
+
+          return  superAdminAcademyQuizQuestionsControllerCreateQuizQuestion(chapterId,data,)
+        }
+
+        
+
+
+  return  { mutationFn, ...mutationOptions }}
+
+    export type SuperAdminAcademyQuizQuestionsControllerCreateQuizQuestionMutationResult = NonNullable<Awaited<ReturnType<typeof superAdminAcademyQuizQuestionsControllerCreateQuizQuestion>>>
+    export type SuperAdminAcademyQuizQuestionsControllerCreateQuizQuestionMutationBody = CreateQuizQuestionRequestDto
+    export type SuperAdminAcademyQuizQuestionsControllerCreateQuizQuestionMutationError = void
+
+    /**
+ * @summary Create a new academy quiz question
+ */
+export const useSuperAdminAcademyQuizQuestionsControllerCreateQuizQuestion = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof superAdminAcademyQuizQuestionsControllerCreateQuizQuestion>>, TError,{chapterId: string;data: CreateQuizQuestionRequestDto}, TContext>, }
+ , queryClient?: QueryClient): UseMutationResult<
+        Awaited<ReturnType<typeof superAdminAcademyQuizQuestionsControllerCreateQuizQuestion>>,
+        TError,
+        {chapterId: string;data: CreateQuizQuestionRequestDto},
+        TContext
+      > => {
+
+      const mutationOptions = getSuperAdminAcademyQuizQuestionsControllerCreateQuizQuestionMutationOptions(options);
+
+      return useMutation(mutationOptions, queryClient);
+    }
+    
+/**
+ * Replace the prompt and answer options of a quiz question. Only accessible to super admins.
+ * @summary Update an academy quiz question
+ */
+export const superAdminAcademyQuizQuestionsControllerUpdateQuizQuestion = (
+    id: string,
+    updateQuizQuestionRequestDto: UpdateQuizQuestionRequestDto,
+ ) => {
+      
+      
+      return customAxiosInstance<QuizQuestionResponseDto>(
+      {url: `/super-admin/academy/quiz-questions/${id}`, method: 'PUT',
+      headers: {'Content-Type': 'application/json', },
+      data: updateQuizQuestionRequestDto
+    },
+      );
+    }
+  
+
+
+export const getSuperAdminAcademyQuizQuestionsControllerUpdateQuizQuestionMutationOptions = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof superAdminAcademyQuizQuestionsControllerUpdateQuizQuestion>>, TError,{id: string;data: UpdateQuizQuestionRequestDto}, TContext>, }
+): UseMutationOptions<Awaited<ReturnType<typeof superAdminAcademyQuizQuestionsControllerUpdateQuizQuestion>>, TError,{id: string;data: UpdateQuizQuestionRequestDto}, TContext> => {
+
+const mutationKey = ['superAdminAcademyQuizQuestionsControllerUpdateQuizQuestion'];
+const {mutation: mutationOptions} = options ?
+      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
+      options
+      : {...options, mutation: {...options.mutation, mutationKey}}
+      : {mutation: { mutationKey, }};
+
+      
+
+
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof superAdminAcademyQuizQuestionsControllerUpdateQuizQuestion>>, {id: string;data: UpdateQuizQuestionRequestDto}> = (props) => {
+          const {id,data} = props ?? {};
+
+          return  superAdminAcademyQuizQuestionsControllerUpdateQuizQuestion(id,data,)
+        }
+
+        
+
+
+  return  { mutationFn, ...mutationOptions }}
+
+    export type SuperAdminAcademyQuizQuestionsControllerUpdateQuizQuestionMutationResult = NonNullable<Awaited<ReturnType<typeof superAdminAcademyQuizQuestionsControllerUpdateQuizQuestion>>>
+    export type SuperAdminAcademyQuizQuestionsControllerUpdateQuizQuestionMutationBody = UpdateQuizQuestionRequestDto
+    export type SuperAdminAcademyQuizQuestionsControllerUpdateQuizQuestionMutationError = void
+
+    /**
+ * @summary Update an academy quiz question
+ */
+export const useSuperAdminAcademyQuizQuestionsControllerUpdateQuizQuestion = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof superAdminAcademyQuizQuestionsControllerUpdateQuizQuestion>>, TError,{id: string;data: UpdateQuizQuestionRequestDto}, TContext>, }
+ , queryClient?: QueryClient): UseMutationResult<
+        Awaited<ReturnType<typeof superAdminAcademyQuizQuestionsControllerUpdateQuizQuestion>>,
+        TError,
+        {id: string;data: UpdateQuizQuestionRequestDto},
+        TContext
+      > => {
+
+      const mutationOptions = getSuperAdminAcademyQuizQuestionsControllerUpdateQuizQuestionMutationOptions(options);
+
+      return useMutation(mutationOptions, queryClient);
+    }
+    
+/**
+ * Delete a quiz question. Only accessible to super admins.
+ * @summary Delete an academy quiz question
+ */
+export const superAdminAcademyQuizQuestionsControllerDeleteQuizQuestion = (
+    id: string,
+ ) => {
+      
+      
+      return customAxiosInstance<void>(
+      {url: `/super-admin/academy/quiz-questions/${id}`, method: 'DELETE'
+    },
+      );
+    }
+  
+
+
+export const getSuperAdminAcademyQuizQuestionsControllerDeleteQuizQuestionMutationOptions = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof superAdminAcademyQuizQuestionsControllerDeleteQuizQuestion>>, TError,{id: string}, TContext>, }
+): UseMutationOptions<Awaited<ReturnType<typeof superAdminAcademyQuizQuestionsControllerDeleteQuizQuestion>>, TError,{id: string}, TContext> => {
+
+const mutationKey = ['superAdminAcademyQuizQuestionsControllerDeleteQuizQuestion'];
+const {mutation: mutationOptions} = options ?
+      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
+      options
+      : {...options, mutation: {...options.mutation, mutationKey}}
+      : {mutation: { mutationKey, }};
+
+      
+
+
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof superAdminAcademyQuizQuestionsControllerDeleteQuizQuestion>>, {id: string}> = (props) => {
+          const {id} = props ?? {};
+
+          return  superAdminAcademyQuizQuestionsControllerDeleteQuizQuestion(id,)
+        }
+
+        
+
+
+  return  { mutationFn, ...mutationOptions }}
+
+    export type SuperAdminAcademyQuizQuestionsControllerDeleteQuizQuestionMutationResult = NonNullable<Awaited<ReturnType<typeof superAdminAcademyQuizQuestionsControllerDeleteQuizQuestion>>>
+    
+    export type SuperAdminAcademyQuizQuestionsControllerDeleteQuizQuestionMutationError = void
+
+    /**
+ * @summary Delete an academy quiz question
+ */
+export const useSuperAdminAcademyQuizQuestionsControllerDeleteQuizQuestion = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof superAdminAcademyQuizQuestionsControllerDeleteQuizQuestion>>, TError,{id: string}, TContext>, }
+ , queryClient?: QueryClient): UseMutationResult<
+        Awaited<ReturnType<typeof superAdminAcademyQuizQuestionsControllerDeleteQuizQuestion>>,
+        TError,
+        {id: string},
+        TContext
+      > => {
+
+      const mutationOptions = getSuperAdminAcademyQuizQuestionsControllerDeleteQuizQuestionMutationOptions(options);
 
       return useMutation(mutationOptions, queryClient);
     }

--- a/ayunis-core-frontend/src/shared/api/openapi-schema.json
+++ b/ayunis-core-frontend/src/shared/api/openapi-schema.json
@@ -8510,7 +8510,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/AcademyChapterResponseDto"
+                    "$ref": "#/components/schemas/SuperAdminAcademyChapterResponseDto"
                   }
                 }
               }
@@ -8856,6 +8856,146 @@
           }
         },
         "summary": "Delete an academy module",
+        "tags": ["Super Admin Academy"]
+      }
+    },
+    "/super-admin/academy/chapters/{chapterId}/quiz-questions": {
+      "post": {
+        "description": "Add a question to a chapter quiz pool, appended after the last position. Only accessible to super admins.",
+        "operationId": "SuperAdminAcademyQuizQuestionsController_createQuizQuestion",
+        "parameters": [
+          {
+            "name": "chapterId",
+            "required": true,
+            "in": "path",
+            "description": "Chapter ID",
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateQuizQuestionRequestDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Successfully created quiz question",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QuizQuestionResponseDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid question (bad option count or no single correct)"
+          },
+          "401": {
+            "description": "User not authenticated or not authorized as super admin"
+          },
+          "404": {
+            "description": "Chapter not found"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "summary": "Create a new academy quiz question",
+        "tags": ["Super Admin Academy"]
+      }
+    },
+    "/super-admin/academy/quiz-questions/{id}": {
+      "put": {
+        "description": "Replace the prompt and answer options of a quiz question. Only accessible to super admins.",
+        "operationId": "SuperAdminAcademyQuizQuestionsController_updateQuizQuestion",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "description": "Quiz question ID",
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateQuizQuestionRequestDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successfully updated quiz question",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QuizQuestionResponseDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid question (bad option count or no single correct)"
+          },
+          "401": {
+            "description": "User not authenticated or not authorized as super admin"
+          },
+          "404": {
+            "description": "Quiz question not found"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "summary": "Update an academy quiz question",
+        "tags": ["Super Admin Academy"]
+      },
+      "delete": {
+        "description": "Delete a quiz question. Only accessible to super admins.",
+        "operationId": "SuperAdminAcademyQuizQuestionsController_deleteQuizQuestion",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "description": "Quiz question ID",
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successfully deleted quiz question"
+          },
+          "401": {
+            "description": "User not authenticated or not authorized as super admin"
+          },
+          "404": {
+            "description": "Quiz question not found"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "summary": "Delete an academy quiz question",
         "tags": ["Super Admin Academy"]
       }
     },
@@ -15846,6 +15986,11 @@
             "description": "The position of the chapter (0-based)",
             "example": 0
           },
+          "quizEnabled": {
+            "type": "boolean",
+            "description": "Whether a quiz is activated for this chapter (shown at chapter end)",
+            "example": false
+          },
           "courseModules": {
             "description": "The modules of the chapter, ordered by position",
             "type": "array",
@@ -15869,9 +16014,142 @@
           "title",
           "description",
           "position",
+          "quizEnabled",
           "courseModules",
           "createdAt",
           "updatedAt"
+        ]
+      },
+      "QuizAnswerOptionResponseDto": {
+        "type": "object",
+        "properties": {
+          "text": {
+            "type": "string",
+            "description": "The answer option text",
+            "example": "A large language model"
+          },
+          "isCorrect": {
+            "type": "boolean",
+            "description": "Whether this option is the correct answer",
+            "example": true
+          }
+        },
+        "required": ["text", "isCorrect"]
+      },
+      "QuizQuestionResponseDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "The unique identifier of the quiz question"
+          },
+          "chapterId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "The id of the chapter the question belongs to"
+          },
+          "text": {
+            "type": "string",
+            "description": "The question prompt",
+            "example": "What is an LLM?"
+          },
+          "options": {
+            "description": "The answer options with the correct one flagged",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/QuizAnswerOptionResponseDto"
+            }
+          },
+          "position": {
+            "type": "integer",
+            "description": "The position of the question within its chapter (0-based)",
+            "example": 0
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "The date the question was created"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "The date the question was last updated"
+          }
+        },
+        "required": [
+          "id",
+          "chapterId",
+          "text",
+          "options",
+          "position",
+          "createdAt",
+          "updatedAt"
+        ]
+      },
+      "SuperAdminAcademyChapterResponseDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "The unique identifier of the chapter"
+          },
+          "title": {
+            "type": "string",
+            "description": "The title of the chapter",
+            "example": "Getting Started"
+          },
+          "description": {
+            "type": "string",
+            "description": "A description of what the chapter covers",
+            "example": "Learn the basics of working with Ayunis Core."
+          },
+          "position": {
+            "type": "integer",
+            "description": "The position of the chapter (0-based)",
+            "example": 0
+          },
+          "quizEnabled": {
+            "type": "boolean",
+            "description": "Whether a quiz is activated for this chapter (shown at chapter end)",
+            "example": false
+          },
+          "courseModules": {
+            "description": "The modules of the chapter, ordered by position",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CourseModuleResponseDto"
+            }
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "The date the chapter was created"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "The date the chapter was last updated"
+          },
+          "quizQuestions": {
+            "description": "The quiz question pool of the chapter, ordered by position",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/QuizQuestionResponseDto"
+            }
+          }
+        },
+        "required": [
+          "id",
+          "title",
+          "description",
+          "position",
+          "quizEnabled",
+          "courseModules",
+          "createdAt",
+          "updatedAt",
+          "quizQuestions"
         ]
       },
       "CreateChapterRequestDto": {
@@ -15920,6 +16198,11 @@
             "description": "A description of what the chapter covers",
             "example": "Learn the basics of working with Ayunis Core.",
             "maxLength": 2000
+          },
+          "quizEnabled": {
+            "type": "boolean",
+            "description": "Whether a quiz is activated for this chapter",
+            "example": false
           }
         },
         "required": ["title", "description"]
@@ -15985,6 +16268,65 @@
           }
         },
         "required": ["title", "loomUrl"]
+      },
+      "QuizAnswerOptionRequestDto": {
+        "type": "object",
+        "properties": {
+          "text": {
+            "type": "string",
+            "description": "The answer option text",
+            "example": "A large language model",
+            "maxLength": 500
+          },
+          "isCorrect": {
+            "type": "boolean",
+            "description": "Whether this option is the correct answer",
+            "example": true
+          }
+        },
+        "required": ["text", "isCorrect"]
+      },
+      "CreateQuizQuestionRequestDto": {
+        "type": "object",
+        "properties": {
+          "text": {
+            "type": "string",
+            "description": "The question prompt",
+            "example": "What is an LLM?",
+            "maxLength": 2000
+          },
+          "options": {
+            "description": "The answer options. Between 2 and 6 options with exactly one marked correct.",
+            "minItems": 2,
+            "maxItems": 6,
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/QuizAnswerOptionRequestDto"
+            }
+          }
+        },
+        "required": ["text", "options"]
+      },
+      "UpdateQuizQuestionRequestDto": {
+        "type": "object",
+        "properties": {
+          "text": {
+            "type": "string",
+            "description": "The question prompt",
+            "example": "What is an LLM?",
+            "maxLength": 2000
+          },
+          "options": {
+            "description": "The answer options. Between 2 and 6 options with exactly one marked correct.",
+            "minItems": 2,
+            "maxItems": 6,
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/QuizAnswerOptionRequestDto"
+            }
+          }
+        },
+        "required": ["text", "options"]
       },
       "ChatCompletionRequestDto": {
         "type": "object",

--- a/ayunis-core-frontend/src/shared/locales/de/super-admin-settings-academy.json
+++ b/ayunis-core-frontend/src/shared/locales/de/super-admin-settings-academy.json
@@ -43,6 +43,39 @@
     "saving": "Wird gespeichert...",
     "cancel": "Abbrechen"
   },
+  "quiz": {
+    "enableLabel": "Quiz aktiviert",
+    "addQuestion": "Frage hinzufügen",
+    "noQuestions": "Noch keine Quizfragen."
+  },
+  "questionForm": {
+    "createTitle": "Frage erstellen",
+    "editTitle": "Frage bearbeiten",
+    "text": "Frage",
+    "textPlaceholder": "z. B. Was ist ein LLM?",
+    "textRequired": "Frage ist erforderlich",
+    "textTooLong": "Frage darf höchstens 2.000 Zeichen lang sein",
+    "options": "Antwortoptionen",
+    "optionsHint": "Fügen Sie 2–6 Optionen hinzu und wählen Sie die einzige richtige Antwort.",
+    "optionPlaceholder": "Option {{number}}",
+    "optionRequired": "Optionstext ist erforderlich",
+    "optionTooLong": "Option darf höchstens 500 Zeichen lang sein",
+    "tooFewOptions": "Mindestens 2 Optionen sind erforderlich",
+    "tooManyOptions": "Höchstens 6 Optionen sind erlaubt",
+    "correctRequired": "Wählen Sie die richtige Antwort",
+    "markCorrect": "Als richtige Antwort markieren",
+    "addOption": "Option hinzufügen",
+    "removeOption": "Option entfernen",
+    "save": "Speichern",
+    "saving": "Wird gespeichert...",
+    "cancel": "Abbrechen"
+  },
+  "deleteQuestion": {
+    "title": "Frage löschen",
+    "description": "Möchten Sie diese Quizfrage wirklich löschen? Diese Aktion kann nicht rückgängig gemacht werden.",
+    "confirm": "Löschen",
+    "cancel": "Abbrechen"
+  },
   "deleteChapter": {
     "title": "Kapitel löschen",
     "description": "Möchten Sie \"{{title}}\" und alle zugehörigen Module wirklich löschen? Diese Aktion kann nicht rückgängig gemacht werden.",
@@ -70,6 +103,15 @@
     "moduleDeleteSuccess": "Modul erfolgreich gelöscht",
     "moduleDeleteError": "Modul konnte nicht gelöscht werden",
     "moduleNotFound": "Modul nicht gefunden",
+    "questionCreateSuccess": "Frage erfolgreich erstellt",
+    "questionCreateError": "Frage konnte nicht erstellt werden",
+    "questionUpdateSuccess": "Frage erfolgreich aktualisiert",
+    "questionUpdateError": "Frage konnte nicht aktualisiert werden",
+    "questionDeleteSuccess": "Frage erfolgreich gelöscht",
+    "questionDeleteError": "Frage konnte nicht gelöscht werden",
+    "questionNotFound": "Frage nicht gefunden",
+    "questionInvalid": "Ungültige Frage: 2–6 Optionen mit genau einer richtigen Antwort erforderlich",
+    "quizToggleError": "Quiz-Einstellung konnte nicht aktualisiert werden",
     "reorderError": "Die neue Reihenfolge konnte nicht gespeichert werden"
   },
   "validation": {

--- a/ayunis-core-frontend/src/shared/locales/en/super-admin-settings-academy.json
+++ b/ayunis-core-frontend/src/shared/locales/en/super-admin-settings-academy.json
@@ -43,6 +43,39 @@
     "saving": "Saving...",
     "cancel": "Cancel"
   },
+  "quiz": {
+    "enableLabel": "Quiz enabled",
+    "addQuestion": "Add Question",
+    "noQuestions": "No quiz questions yet."
+  },
+  "questionForm": {
+    "createTitle": "Create Question",
+    "editTitle": "Edit Question",
+    "text": "Question",
+    "textPlaceholder": "e.g., What is an LLM?",
+    "textRequired": "Question is required",
+    "textTooLong": "Question must be 2,000 characters or fewer",
+    "options": "Answer options",
+    "optionsHint": "Add 2–6 options and select the single correct answer.",
+    "optionPlaceholder": "Option {{number}}",
+    "optionRequired": "Option text is required",
+    "optionTooLong": "Option must be 500 characters or fewer",
+    "tooFewOptions": "At least 2 options are required",
+    "tooManyOptions": "At most 6 options are allowed",
+    "correctRequired": "Select the correct answer",
+    "markCorrect": "Mark as correct answer",
+    "addOption": "Add option",
+    "removeOption": "Remove option",
+    "save": "Save",
+    "saving": "Saving...",
+    "cancel": "Cancel"
+  },
+  "deleteQuestion": {
+    "title": "Delete Question",
+    "description": "Are you sure you want to delete this quiz question? This action cannot be undone.",
+    "confirm": "Delete",
+    "cancel": "Cancel"
+  },
   "deleteChapter": {
     "title": "Delete Chapter",
     "description": "Are you sure you want to delete \"{{title}}\" and all of its modules? This action cannot be undone.",
@@ -70,6 +103,15 @@
     "moduleDeleteSuccess": "Module deleted successfully",
     "moduleDeleteError": "Failed to delete module",
     "moduleNotFound": "Module not found",
+    "questionCreateSuccess": "Question created successfully",
+    "questionCreateError": "Failed to create question",
+    "questionUpdateSuccess": "Question updated successfully",
+    "questionUpdateError": "Failed to update question",
+    "questionDeleteSuccess": "Question deleted successfully",
+    "questionDeleteError": "Failed to delete question",
+    "questionNotFound": "Question not found",
+    "questionInvalid": "Invalid question: add 2–6 options with exactly one correct answer",
+    "quizToggleError": "Failed to update the quiz setting",
     "reorderError": "Failed to save the new order"
   },
   "validation": {


### PR DESCRIPTION
Foundation for the academy quiz engine (Iteration 2). Super admins can
maintain a pool of single-correct multiple-choice questions per chapter and
toggle a per-chapter quiz on/off. Learner quiz-taking, thresholds and
certificates follow in AYC-245+.

- New academy_quiz_questions table (jsonb options) + quizEnabled flag on
  academy_chapters, with migration
- Super-admin CRUD for quiz questions (2-6 options, exactly one correct,
  validated in the use case)
- Dedicated super-admin read path so correct answers never load or serialize
  on the learner endpoint; learner chapter DTO only gains a quizEnabled flag
- Inline quiz management in the super-admin ChapterCard (toggle, question
  list, add/edit/delete dialog with dynamic options + single-correct radio)
- Regenerated API client, en/de translations

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017Er3fMQTin8wrFDW62dCjH

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New DB migration and super-admin-only APIs; correct-answer exposure depends on keeping learner reads on the existing use case and DTOs—worth verifying in review.
> 
> **Overview**
> Adds the **quiz content foundation** for academy chapters: super admins can define a per-chapter pool of single-correct multiple-choice questions and turn quizzes on or off per chapter. Learner quiz-taking is out of scope here.
> 
> **Backend:** New `academy_quiz_questions` storage (jsonb options) and `quizEnabled` on chapters via migration. Super-admin CRUD for questions with use-case validation (2–6 options, exactly one correct). Chapter updates accept optional `quizEnabled`. Super-admin chapter list switches to `GetAcademyManagementContentUseCase` and `SuperAdminAcademyChapterResponseDto` (includes questions and `isCorrect`); the learner `GetAcademyContentUseCase` path is unchanged and only exposes **`quizEnabled`** on chapters—no question payloads.
> 
> **Frontend:** Super-admin academy UI gains a **QuizSection** on each chapter (toggle, list, add/edit/delete dialog with dynamic options). API client and en/de strings regenerated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43dda7258de42d81ba4ff9a50371fe081afe6309. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->