### PR TITLE
fix(invites): clarify private email restriction in invite error (AYC-366)

### DIFF
--- a/ayunis-core-backend/src/iam/invites/application/use-cases/create-invite/create-invite.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/invites/application/use-cases/create-invite/create-invite.use-case.spec.ts
@@ -21,6 +21,7 @@ import {
   InvalidSeatsError,
   UnexpectedInviteError,
 } from '../../invites.errors';
+import { UserEmailProviderBlacklistedError } from 'src/iam/users/application/users.errors';
 
 describe('CreateInviteUseCase', () => {
   let useCase: CreateInviteUseCase;
@@ -379,6 +380,30 @@ describe('CreateInviteUseCase', () => {
       await expect(useCase.execute(command)).rejects.toThrow(
         EmailNotAvailableError,
       );
+      expect(invitesRepository.create).not.toHaveBeenCalled();
+    });
+
+    it('should reject invites for private email providers on the blacklist', async () => {
+      // Arrange
+      const command = new CreateInviteCommand({
+        email: 'azv-eutingen@t-online.de',
+        orgId: mockOrgId,
+        role: UserRole.USER,
+        userId: mockUserId,
+      });
+
+      configService.get.mockReturnValueOnce([
+        'gmail',
+        'gmx',
+        'web',
+        't-online',
+      ]); // auth.emailProviderBlacklist
+
+      // Act & Assert
+      await expect(useCase.execute(command)).rejects.toThrow(
+        UserEmailProviderBlacklistedError,
+      );
+      expect(findUserByEmailUseCase.execute).not.toHaveBeenCalled();
       expect(invitesRepository.create).not.toHaveBeenCalled();
     });
 

--- a/ayunis-core-frontend/src/shared/locales/de/admin-settings-users.json
+++ b/ayunis-core-frontend/src/shared/locales/de/admin-settings-users.json
@@ -90,7 +90,7 @@
     "error": "Fehler beim Erstellen der Einladung. Bitte versuchen Sie es erneut.",
     "emailNotAvailable": "Einladung nicht möglich.",
     "userAlreadyExists": "Diese E-Mail-Adresse ist bereits als Benutzer in Ihrer Organisation registriert.",
-    "emailProviderBlacklisted": "E-Mail-Adresse von diesem Provider ist nicht erlaubt. Bitte verwenden Sie Ihr Firmen E-Mail-Adresse."
+    "emailProviderBlacklisted": "Private E-Mail-Adressen (z. B. Gmail, GMX, Web.de, t-online) sind aus Sicherheitsgründen nicht erlaubt. Bitte verwenden Sie eine geschäftliche E-Mail-Adresse."
   },
   "inviteResend": {
     "success": "Einladung erfolgreich erneut gesendet!",

--- a/ayunis-core-frontend/src/shared/locales/en/admin-settings-users.json
+++ b/ayunis-core-frontend/src/shared/locales/en/admin-settings-users.json
@@ -89,7 +89,7 @@
     "error": "Failed to create invite. Please try again.",
     "emailNotAvailable": "Invite not possible.",
     "userAlreadyExists": "This email address is already registered as a user in your organization.",
-    "emailProviderBlacklisted": "Email address from this provider is not allowed. Please use your company email address."
+    "emailProviderBlacklisted": "Private email addresses (e.g. Gmail, GMX, Web.de, t-online) are not allowed for security reasons. Please use a work email address."
   },
   "inviteResend": {
     "success": "Invite resent successfully!",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Inviting a user with a private email provider (e.g. `t-online.de`, GMX, Gmail, Web.de) is intentionally blocked for security reasons — only verified work email addresses are allowed. The backend already rejects these with a specific `USER_EMAIL_PROVIDER_BLACKLISTED` error, and the frontend already maps that code to a dedicated toast. However, the displayed message was grammatically incorrect (`"... Bitte verwenden Sie Ihr Firmen E-Mail-Adresse."`) and did not explain **why** the address was rejected, so admins could still be confused.

Source: [Zendesk #31289](https://locaboo.zendesk.com/tickets/31289) / Linear AYC-366

## Changes

- Reworded the DE and EN `inviteCreate.emailProviderBlacklisted` messages to clearly state that private email addresses are not allowed for security reasons and that a work email address must be used, with examples (Gmail, GMX, Web.de, t-online).
- Added a `CreateInviteUseCase` test that locks the rejection behavior for a blacklisted private provider (`azv-eutingen@t-online.de` → `UserEmailProviderBlacklistedError`, no invite created).

## Notes

The end-to-end handling (backend error code → frontend specific toast) already existed since Dec 2025; this PR focuses on making the message clear and correct, and hardening it with a test.

## Validation

- `pnpm exec jest --testPathPatterns=create-invite` — 12 passed
- `pnpm exec eslint` on the changed backend spec — clean
- Locale JSON files parse successfully
- Pre-commit hooks (Prettier, ESLint, tsc, complexity, dep-cruiser, file-size) all passed

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [AYC-366](https://linear.app/ayunis/issue/AYC-366/clarify-private-email-restriction-in-invite-error)

<div><a href="https://cursor.com/agents/bc-db8cdce3-1259-4c3c-bcae-58416b671422"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-db8cdce3-1259-4c3c-bcae-58416b671422"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

