### PR TITLE
fix(invites): stop logging full invite JWTs (AYC-387)

### DIFF
--- a/ayunis-core-backend/src/iam/invites/application/use-cases/get-invite-by-token/get-invite-by-token.use-case.ts
+++ b/ayunis-core-backend/src/iam/invites/application/use-cases/get-invite-by-token/get-invite-by-token.use-case.ts
@@ -37,7 +37,7 @@ export class GetInviteByTokenUseCase {
   ) {}
 
   async execute(query: GetInviteByTokenQuery): Promise<InviteWithOrgDetails> {
-    this.logger.log('execute', { token: query.token });
+    this.logger.log('execute', { hasToken: !!query.token });
 
     // Verify and decode the JWT token
     let payload: InviteJwtPayload;

--- a/ayunis-core-backend/src/iam/invites/presenters/http/invites.controller.ts
+++ b/ayunis-core-backend/src/iam/invites/presenters/http/invites.controller.ts
@@ -68,6 +68,7 @@ import { CreateInviteResponseDto } from './dtos/create-invite-response.dto';
 import { DeleteAllPendingInvitesResponseDto } from './dtos/delete-all-pending-invites-response.dto';
 import { DeleteAllPendingInvitesUseCase } from '../../application/use-cases/delete-all-pending-invites/delete-all-pending-invites.use-case';
 import { DeleteAllPendingInvitesCommand } from '../../application/use-cases/delete-all-pending-invites/delete-all-pending-invites.command';
+import type { Invite } from '../../domain/invite.entity';
 
 @ApiTags('invites')
 @Controller('invites')
@@ -124,43 +125,8 @@ export class InvitesController {
         userId,
       }),
     );
-    // Build invitation link
-    const frontendBaseUrl = this.configService.get<string>(
-      'app.frontend.baseUrl',
-    );
-    const inviteAcceptEndpoint = this.configService.get<string>(
-      'app.frontend.inviteAcceptEndpoint',
-    );
-    const inviteAcceptUrl = `${frontendBaseUrl}${inviteAcceptEndpoint}?token=${token}`;
 
-    // Send invitation email if email configuration is available
-    const hasEmailConfig = this.configService.get<boolean>('emails.hasConfig');
-    if (hasEmailConfig) {
-      this.logger.debug('Sending invitation email', {
-        inviteId: invite.id,
-        email: invite.email,
-      });
-
-      await this.sendInvitationEmailUseCase.execute(
-        new SendInvitationEmailCommand(invite, inviteAcceptUrl),
-      );
-
-      this.logger.debug('Invitation email sent successfully', {
-        inviteId: invite.id,
-        email: invite.email,
-      });
-      return { url: null };
-    } else {
-      // Return the invitation URL to the frontend
-      this.logger.debug(
-        'Email configuration not available, skipping email send',
-        {
-          inviteId: invite.id,
-          email: invite.email,
-        },
-      );
-      return { url: inviteAcceptUrl };
-    }
+    return this.deliverInvite(invite, token);
   }
 
   @Post('bulk')
@@ -279,7 +245,7 @@ export class InvitesController {
   async getInviteByToken(
     @Param('token') token: string,
   ): Promise<InviteDetailResponseDto> {
-    this.logger.log('getInviteByToken', { token });
+    this.logger.log('getInviteByToken', { hasToken: !!token });
 
     const inviteWithOrg = await this.getInviteByTokenUseCase.execute(
       new GetInviteByTokenQuery(token),
@@ -361,6 +327,13 @@ export class InvitesController {
       new ResendExpiredInviteCommand(inviteId),
     );
 
+    return this.deliverInvite(invite, token);
+  }
+
+  private async deliverInvite(
+    invite: Invite,
+    token: string,
+  ): Promise<CreateInviteResponseDto> {
     // Build invitation link
     const frontendBaseUrl = this.configService.get<string>(
       'app.frontend.baseUrl',
@@ -372,28 +345,31 @@ export class InvitesController {
 
     // Send invitation email if email configuration is available
     const hasEmailConfig = this.configService.get<boolean>('emails.hasConfig');
-    if (hasEmailConfig) {
-      this.logger.debug('Sending invitation email for resent invite', {
-        inviteId: invite.id,
-        email: invite.email,
-      });
-
-      await this.sendInvitationEmailUseCase.execute(
-        new SendInvitationEmailCommand(invite, inviteAcceptUrl),
+    if (!hasEmailConfig) {
+      this.logger.debug(
+        'Email configuration not available, skipping email send',
+        {
+          inviteId: invite.id,
+          email: invite.email,
+        },
       );
-
-      this.logger.debug('Invitation email sent successfully', {
-        inviteId: invite.id,
-        email: invite.email,
-      });
-      return { url: null };
-    } else {
-      this.logger.debug('Email configuration not available, returning URL', {
-        inviteId: invite.id,
-        email: invite.email,
-      });
       return { url: inviteAcceptUrl };
     }
+
+    this.logger.debug('Sending invitation email', {
+      inviteId: invite.id,
+      email: invite.email,
+    });
+
+    await this.sendInvitationEmailUseCase.execute(
+      new SendInvitationEmailCommand(invite, inviteAcceptUrl),
+    );
+
+    this.logger.debug('Invitation email sent successfully', {
+      inviteId: invite.id,
+      email: invite.email,
+    });
+    return { url: null };
   }
 
   @Delete('all')


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Invite JWTs were being written to logs in full, creating a secrets-in-logs risk. Anyone with log access could extract a valid invite token and accept an invite. This occurred in two places:

- `InvitesController.getInviteByToken` — logged `{ token }` (the raw JWT from the URL path).
- `GetInviteByTokenUseCase.execute` — logged `{ token: query.token }` (the same raw JWT).

## Change

- Both log statements now record `{ hasToken: !!token }` instead of the raw JWT. This keeps the diagnostic signal (a request arrived with/without a token) without leaking the secret, and matches the existing `acceptInvite` logging pattern already used in the same controller and the `AcceptInviteUseCase`.
- Extracted the duplicated invite-delivery logic (build accept URL + send email or return URL) from `create` and `resendExpiredInvite` into a private `deliverInvite` helper. This was required because the pre-commit/CI complexity gate runs on the whole changed file and those two pre-existing methods exceeded the 50-line limit; the extraction brings them back under the limit and removes duplication.

## Verification

- `eslint` passes on both changed files (only the pre-existing, ungated `max-params` warning on the DI constructor remains).
- The gated complexity config (`eslint.complexity.config.mjs`) passes on the controller.
- All pre-commit checks pass (ESLint, Prettier, TypeScript typecheck, complexity, dependency, duplication, file-size).

## Notes

The remaining `logger.error('Invalid invite token', ...)` calls in the invites module only log `error.message` / the JWT library error object, not the token string, so they were left unchanged.

Refs: AYC-387
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [AYC-387](https://linear.app/ayunis/issue/AYC-387/stop-logging-invite-jwts-in-full)

<div><a href="https://cursor.com/agents/bc-96502d9d-aa30-40b3-bc86-3db51f52fb67"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-96502d9d-aa30-40b3-bc86-3db51f52fb67"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

