### PR TITLE
fix(iam): remove sensitive data from logs (AYC-371)

### DIFF
--- a/ayunis-core-backend/src/common/middleware/sentry-context.middleware.spec.ts
+++ b/ayunis-core-backend/src/common/middleware/sentry-context.middleware.spec.ts
@@ -1,0 +1,77 @@
+import type { Request, Response } from 'express';
+import * as Sentry from '@sentry/nestjs';
+import { SentryContextMiddleware } from './sentry-context.middleware';
+
+jest.mock('@sentry/nestjs', () => {
+  const setTag = jest.fn();
+  const setExtra = jest.fn();
+  return {
+    getCurrentScope: jest.fn(() => ({ setTag, setExtra })),
+  };
+});
+
+describe('SentryContextMiddleware', () => {
+  let middleware: SentryContextMiddleware;
+  let setExtra: jest.Mock;
+  let next: jest.Mock;
+
+  const getExtra = (name: string): unknown =>
+    setExtra.mock.calls.find((call) => call[0] === name)?.[1];
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    middleware = new SentryContextMiddleware();
+    const scope = Sentry.getCurrentScope();
+    setExtra = scope.setExtra as unknown as jest.Mock;
+    next = jest.fn();
+  });
+
+  it('redacts sensitive keys in the request body', () => {
+    const req = {
+      path: '/auth/login',
+      method: 'POST',
+      body: { email: 'user@example.com', password: 'super-secret' },
+      params: {},
+      query: {},
+    } as unknown as Request;
+
+    middleware.use(req, {} as Response, next);
+
+    expect(getExtra('requestBody')).toEqual({
+      email: 'user@example.com',
+      password: '[REDACTED]',
+    });
+    expect(next).toHaveBeenCalled();
+  });
+
+  it('redacts invite tokens passed as route params', () => {
+    const req = {
+      path: '/invites/token/abc',
+      method: 'GET',
+      body: {},
+      params: { token: 'eyJhbGciOiJIUzI1NiJ9.invite-jwt.signature' },
+      query: {},
+    } as unknown as Request;
+
+    middleware.use(req, {} as Response, next);
+
+    expect(getExtra('requestParams')).toEqual({ token: '[REDACTED]' });
+  });
+
+  it('redacts tokens passed as query parameters', () => {
+    const req = {
+      path: '/reset-password',
+      method: 'GET',
+      body: {},
+      params: {},
+      query: { token: 'reset-token-value', page: '1' },
+    } as unknown as Request;
+
+    middleware.use(req, {} as Response, next);
+
+    expect(getExtra('requestQuery')).toEqual({
+      token: '[REDACTED]',
+      page: '1',
+    });
+  });
+});

--- a/ayunis-core-backend/src/common/middleware/sentry-context.middleware.ts
+++ b/ayunis-core-backend/src/common/middleware/sentry-context.middleware.ts
@@ -2,7 +2,16 @@ import { Injectable, NestMiddleware } from '@nestjs/common';
 import { Request, Response, NextFunction } from 'express';
 import * as Sentry from '@sentry/nestjs';
 
-const SENSITIVE_KEYS = ['password', 'token', 'secret', 'apikey', 'api_key'];
+const SENSITIVE_KEYS = [
+  'password',
+  'token',
+  'secret',
+  'apikey',
+  'api_key',
+  'jwt',
+  'authorization',
+  'cookie',
+];
 
 /**
  * Enriches the current Sentry scope with request context so that any
@@ -18,18 +27,18 @@ export class SentryContextMiddleware implements NestMiddleware {
     Sentry.getCurrentScope().setTag('path', req.path);
     Sentry.getCurrentScope().setTag('method', req.method);
 
-    Sentry.getCurrentScope().setExtra('requestBody', sanitizeBody(req.body));
-    Sentry.getCurrentScope().setExtra('requestParams', req.params);
-    Sentry.getCurrentScope().setExtra('requestQuery', req.query);
+    Sentry.getCurrentScope().setExtra('requestBody', sanitize(req.body));
+    Sentry.getCurrentScope().setExtra('requestParams', sanitize(req.params));
+    Sentry.getCurrentScope().setExtra('requestQuery', sanitize(req.query));
 
     next();
   }
 }
 
-function sanitizeBody(body: unknown): unknown {
-  if (!body || typeof body !== 'object') return body;
+function sanitize(value: unknown): unknown {
+  if (!value || typeof value !== 'object') return value;
 
-  const sanitized = { ...body } as Record<string, unknown>;
+  const sanitized = { ...value } as Record<string, unknown>;
 
   for (const key of Object.keys(sanitized)) {
     if (SENSITIVE_KEYS.some((sk) => key.toLowerCase().includes(sk))) {

--- a/ayunis-core-backend/src/iam/authentication/presenters/http/authentication.controller.ts
+++ b/ayunis-core-backend/src/iam/authentication/presenters/http/authentication.controller.ts
@@ -163,7 +163,7 @@ export class AuthenticationController {
     type: ErrorResponseDto,
   })
   async refresh(@Req() req: Request, @Res() res: Response) {
-    this.logger.log('refresh', { req });
+    this.logger.log('refresh');
     const refreshTokenName = this.configService.get<string>(
       'auth.cookie.refreshTokenName',
     );
@@ -232,16 +232,9 @@ export class AuthenticationController {
     const refreshToken = cookies[refreshTokenName];
 
     // First, try to get user info from access token
-    if (accessToken) {
-      try {
-        const user = await this.getCurrentUserUseCase.execute(
-          new GetCurrentUserCommand(accessToken),
-        );
-        return res.json(this.meResponseDtoMapper.toDto(user));
-      } catch (error) {
-        this.logger.debug('Access token verification failed', error);
-        // Continue to refresh token logic
-      }
+    const currentUser = await this.tryGetUserFromAccessToken(accessToken);
+    if (currentUser) {
+      return res.json(this.meResponseDtoMapper.toDto(currentUser));
     }
 
     // If access token is invalid/missing, try refresh token
@@ -252,6 +245,29 @@ export class AuthenticationController {
       });
     }
 
+    return this.refreshAndRespondWithUser(res, refreshToken);
+  }
+
+  private async tryGetUserFromAccessToken(
+    accessToken: string | undefined,
+  ): Promise<ActiveUser | null> {
+    if (!accessToken) {
+      return null;
+    }
+    try {
+      return await this.getCurrentUserUseCase.execute(
+        new GetCurrentUserCommand(accessToken),
+      );
+    } catch (error) {
+      this.logger.debug('Access token verification failed', error);
+      return null;
+    }
+  }
+
+  private async refreshAndRespondWithUser(
+    res: Response,
+    refreshToken: string,
+  ): Promise<Response> {
     try {
       // Try to refresh tokens - this will validate the refresh token
       const tokens = await this.refreshTokenUseCase.execute(

--- a/ayunis-core-backend/src/iam/invites/application/use-cases/get-invite-by-token/get-invite-by-token.use-case.ts
+++ b/ayunis-core-backend/src/iam/invites/application/use-cases/get-invite-by-token/get-invite-by-token.use-case.ts
@@ -37,7 +37,7 @@ export class GetInviteByTokenUseCase {
   ) {}
 
   async execute(query: GetInviteByTokenQuery): Promise<InviteWithOrgDetails> {
-    this.logger.log('execute', { token: query.token });
+    this.logger.log('execute', { hasToken: !!query.token });
 
     // Verify and decode the JWT token
     let payload: InviteJwtPayload;

--- a/ayunis-core-backend/src/iam/invites/presenters/http/invites.controller.ts
+++ b/ayunis-core-backend/src/iam/invites/presenters/http/invites.controller.ts
@@ -20,6 +20,7 @@ import {
   ApiQuery,
 } from '@nestjs/swagger';
 import { UUID } from 'crypto';
+import { Invite } from '../../domain/invite.entity';
 import {
   CurrentUser,
   UserProperty,
@@ -124,7 +125,19 @@ export class InvitesController {
         userId,
       }),
     );
-    // Build invitation link
+
+    return this.deliverInvite(invite, token);
+  }
+
+  /**
+   * Sends the invitation email when email is configured, otherwise returns the
+   * invitation URL so the caller can share it manually. The URL contains the
+   * raw invite JWT, so it is never logged.
+   */
+  private async deliverInvite(
+    invite: Invite,
+    token: string,
+  ): Promise<CreateInviteResponseDto> {
     const frontendBaseUrl = this.configService.get<string>(
       'app.frontend.baseUrl',
     );
@@ -133,34 +146,27 @@ export class InvitesController {
     );
     const inviteAcceptUrl = `${frontendBaseUrl}${inviteAcceptEndpoint}?token=${token}`;
 
-    // Send invitation email if email configuration is available
     const hasEmailConfig = this.configService.get<boolean>('emails.hasConfig');
-    if (hasEmailConfig) {
-      this.logger.debug('Sending invitation email', {
+    if (!hasEmailConfig) {
+      this.logger.debug('Email configuration not available, returning URL', {
         inviteId: invite.id,
         email: invite.email,
       });
-
-      await this.sendInvitationEmailUseCase.execute(
-        new SendInvitationEmailCommand(invite, inviteAcceptUrl),
-      );
-
-      this.logger.debug('Invitation email sent successfully', {
-        inviteId: invite.id,
-        email: invite.email,
-      });
-      return { url: null };
-    } else {
-      // Return the invitation URL to the frontend
-      this.logger.debug(
-        'Email configuration not available, skipping email send',
-        {
-          inviteId: invite.id,
-          email: invite.email,
-        },
-      );
       return { url: inviteAcceptUrl };
     }
+
+    this.logger.debug('Sending invitation email', {
+      inviteId: invite.id,
+      email: invite.email,
+    });
+    await this.sendInvitationEmailUseCase.execute(
+      new SendInvitationEmailCommand(invite, inviteAcceptUrl),
+    );
+    this.logger.debug('Invitation email sent successfully', {
+      inviteId: invite.id,
+      email: invite.email,
+    });
+    return { url: null };
   }
 
   @Post('bulk')
@@ -279,7 +285,7 @@ export class InvitesController {
   async getInviteByToken(
     @Param('token') token: string,
   ): Promise<InviteDetailResponseDto> {
-    this.logger.log('getInviteByToken', { token });
+    this.logger.log('getInviteByToken', { hasToken: !!token });
 
     const inviteWithOrg = await this.getInviteByTokenUseCase.execute(
       new GetInviteByTokenQuery(token),
@@ -361,39 +367,7 @@ export class InvitesController {
       new ResendExpiredInviteCommand(inviteId),
     );
 
-    // Build invitation link
-    const frontendBaseUrl = this.configService.get<string>(
-      'app.frontend.baseUrl',
-    );
-    const inviteAcceptEndpoint = this.configService.get<string>(
-      'app.frontend.inviteAcceptEndpoint',
-    );
-    const inviteAcceptUrl = `${frontendBaseUrl}${inviteAcceptEndpoint}?token=${token}`;
-
-    // Send invitation email if email configuration is available
-    const hasEmailConfig = this.configService.get<boolean>('emails.hasConfig');
-    if (hasEmailConfig) {
-      this.logger.debug('Sending invitation email for resent invite', {
-        inviteId: invite.id,
-        email: invite.email,
-      });
-
-      await this.sendInvitationEmailUseCase.execute(
-        new SendInvitationEmailCommand(invite, inviteAcceptUrl),
-      );
-
-      this.logger.debug('Invitation email sent successfully', {
-        inviteId: invite.id,
-        email: invite.email,
-      });
-      return { url: null };
-    } else {
-      this.logger.debug('Email configuration not available, returning URL', {
-        inviteId: invite.id,
-        email: invite.email,
-      });
-      return { url: inviteAcceptUrl };
-    }
+    return this.deliverInvite(invite, token);
   }
 
   @Delete('all')


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

A data-privacy review (AYC-371) flagged three places where sensitive data leaked into logs / Sentry:

1. **Full invite JWTs** were logged in plaintext.
2. The `POST /auth/refresh` endpoint logged the entire `req` object, including auth cookies (access/refresh tokens).
3. The Sentry request-context middleware sanitized only the request **body** — `requestParams` and `requestQuery` were captured unfiltered, so tokens passed via URL params (e.g. invite links) or query strings (e.g. password-reset tokens) reached Sentry.

## Changes

- **`authentication.controller.ts`** — `refresh()` now logs only `'refresh'` instead of `{ req }`, so auth cookies are no longer written to logs.
- **`invites.controller.ts`** — `getInviteByToken()` logs `{ hasToken: !!token }` instead of the raw invite JWT (matching the existing `acceptInvite` pattern).
- **`get-invite-by-token.use-case.ts`** — same treatment for the use-case log line.
- **`sentry-context.middleware.ts`** — the sanitizer now runs over `body`, `params`, and `query`, and the sensitive-key list was extended with `jwt`, `authorization`, and `cookie`.

### Supporting refactor

Editing `authentication.controller.ts` and `invites.controller.ts` triggers the repo's complexity gate on the whole file. To keep the touched files within the `max-lines-per-function` limit, three pre-existing over-length methods were split via behavior-preserving extractions:

- `me()` → `tryGetUserFromAccessToken()` + `refreshAndRespondWithUser()`
- `create()` / `resendExpiredInvite()` → shared `deliverInvite()` helper (also removes duplicated email-send logic)

## Testing

- Added `sentry-context.middleware.spec.ts` covering redaction of sensitive keys in body, route params, and query params.
- `npx jest` on the affected suites — 50 tests pass.
- ESLint (incl. complexity gate), Prettier, and TypeScript checks pass on changed files; all pre-commit hooks passed.

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [AYC-371](https://linear.app/ayunis/issue/AYC-371/remove-sensitive-data-from-logs)

<div><a href="https://cursor.com/agents/bc-78e9794d-7745-4e80-95a4-24514ee93d86"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-78e9794d-7745-4e80-95a4-24514ee93d86"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

