### PR TITLE
fix(users): check orgId when updating user roles (AYC-378)

### DIFF
--- a/ayunis-core-backend/src/iam/users/application/use-cases/delete-user/delete-user.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/delete-user/delete-user.use-case.spec.ts
@@ -19,6 +19,7 @@ import { DeleteInviteByEmailUseCase } from 'src/iam/invites/application/use-case
 import { ContextService } from 'src/common/context/services/context.service';
 import { User } from 'src/iam/users/domain/user.entity';
 import { UserRole } from 'src/iam/users/domain/value-objects/role.object';
+import { UserUnauthorizedError } from '../../users.errors';
 
 describe('DeleteUserUseCase', () => {
   let useCase: DeleteUserUseCase;
@@ -128,6 +129,32 @@ describe('DeleteUserUseCase', () => {
         email: mockUser.email,
       }),
     );
+  });
+
+  it('should reject deleting a user from a different organization', async () => {
+    const command = new DeleteUserCommand({
+      userId: '223e4567-e89b-12d3-a456-426614174001',
+      orgId: '123e4567-e89b-12d3-a456-426614174000',
+    });
+
+    const mockUser = new User({
+      id: command.userId,
+      email: 'user@example.com',
+      emailVerified: true,
+      passwordHash: 'hash',
+      role: UserRole.USER,
+      orgId: '999e4567-e89b-12d3-a456-426614174999',
+      name: 'Test User',
+      hasAcceptedMarketing: false,
+    });
+
+    jest.spyOn(mockUsersRepository, 'findOneById').mockResolvedValue(mockUser);
+
+    await expect(useCase.execute(command)).rejects.toThrow(
+      UserUnauthorizedError,
+    );
+    expect(mockUsersRepository.delete).not.toHaveBeenCalled();
+    expect(mockEventEmitter.emitAsync).not.toHaveBeenCalled();
   });
 
   it('should handle repository errors', async () => {

--- a/ayunis-core-backend/src/iam/users/application/use-cases/delete-user/delete-user.use-case.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/delete-user/delete-user.use-case.ts
@@ -41,10 +41,15 @@ export class DeleteUserUseCase {
       throw new UserNotFoundError(command.userId);
     }
 
-    // Super admins can delete any user, regular admins can only delete users from their org
+    // Super admins can delete any user, regular admins can only delete users
+    // from their own org. The passed command.orgId must match both the
+    // requester's org (from context) and the target user's org to prevent
+    // cross-org deletion.
     const isSuperAdmin = systemRole === SystemRole.SUPER_ADMIN;
     const isOrgAdmin =
-      orgRole === UserRole.ADMIN && requestUserOrgId === userToDelete.orgId;
+      orgRole === UserRole.ADMIN &&
+      requestUserOrgId === command.orgId &&
+      command.orgId === userToDelete.orgId;
     if (!isSuperAdmin && !isOrgAdmin) {
       throw new UserUnauthorizedError(
         'You are not allowed to delete this user',

--- a/ayunis-core-backend/src/iam/users/application/use-cases/update-user-role/update-user-role.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/update-user-role/update-user-role.use-case.spec.ts
@@ -8,12 +8,15 @@ import { User } from '../../../domain/user.entity';
 import { UserRole } from '../../../domain/value-objects/role.object';
 import type { UUID } from 'crypto';
 import { EventEmitter2 } from '@nestjs/event-emitter';
-import { UserUnexpectedError } from '../../users.errors';
+import { UserUnauthorizedError, UserUnexpectedError } from '../../users.errors';
+import { ContextService } from 'src/common/context/services/context.service';
 
 describe('UpdateUserRoleUseCase', () => {
   let useCase: UpdateUserRoleUseCase;
   let mockUsersRepository: Partial<UsersRepository>;
   let mockEventEmitter: { emitAsync: jest.Mock };
+  let requesterOrgId: UUID | undefined;
+  let mockContextService: Partial<ContextService>;
 
   beforeAll(async () => {
     mockUsersRepository = {
@@ -23,9 +26,15 @@ describe('UpdateUserRoleUseCase', () => {
     mockEventEmitter = {
       emitAsync: jest.fn().mockResolvedValue([]),
     };
+    mockContextService = {
+      get: jest.fn((key?: string) =>
+        key === 'orgId' ? requesterOrgId : undefined,
+      ) as ContextService['get'],
+    };
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         UpdateUserRoleUseCase,
+        { provide: ContextService, useValue: mockContextService },
         { provide: UsersRepository, useValue: mockUsersRepository },
         { provide: EventEmitter2, useValue: mockEventEmitter },
       ],
@@ -35,6 +44,7 @@ describe('UpdateUserRoleUseCase', () => {
   });
   beforeEach(() => {
     jest.clearAllMocks();
+    requesterOrgId = 'org-id' as UUID;
   });
 
   it('should be defined', () => {
@@ -98,6 +108,48 @@ describe('UpdateUserRoleUseCase', () => {
         user: mockUser,
       }),
     );
+  });
+
+  it('should reject updating a user from a different organization', async () => {
+    requesterOrgId = 'requester-org-id' as UUID;
+    const command = new UpdateUserRoleCommand(
+      'user-id' as UUID,
+      UserRole.ADMIN,
+    );
+    const mockUser = new User({
+      id: 'user-id' as UUID,
+      email: 'test@example.com',
+      emailVerified: false,
+      passwordHash: 'hash',
+      role: UserRole.USER,
+      orgId: 'other-org-id' as UUID,
+      name: 'Test User',
+      hasAcceptedMarketing: false,
+    });
+
+    jest.spyOn(mockUsersRepository, 'findOneById').mockResolvedValue(mockUser);
+
+    await expect(useCase.execute(command)).rejects.toThrow(
+      UserUnauthorizedError,
+    );
+    expect(mockUsersRepository.findOneById).toHaveBeenCalledWith('user-id');
+    expect(mockUsersRepository.update).not.toHaveBeenCalled();
+    expect(mockEventEmitter.emitAsync).not.toHaveBeenCalled();
+  });
+
+  it('should reject when the requester is not authenticated', async () => {
+    requesterOrgId = undefined;
+    const command = new UpdateUserRoleCommand(
+      'user-id' as UUID,
+      UserRole.ADMIN,
+    );
+
+    await expect(useCase.execute(command)).rejects.toThrow(
+      UserUnauthorizedError,
+    );
+    expect(mockUsersRepository.findOneById).not.toHaveBeenCalled();
+    expect(mockUsersRepository.update).not.toHaveBeenCalled();
+    expect(mockEventEmitter.emitAsync).not.toHaveBeenCalled();
   });
 
   it('should handle repository errors when finding user', async () => {

--- a/ayunis-core-backend/src/iam/users/application/use-cases/update-user-role/update-user-role.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/update-user-role/update-user-role.use-case.spec.ts
@@ -29,7 +29,7 @@ describe('UpdateUserRoleUseCase', () => {
     mockContextService = {
       get: jest.fn((key?: string) =>
         key === 'orgId' ? requesterOrgId : undefined,
-      ) as ContextService['get'],
+      ) as unknown as ContextService['get'],
     };
     const module: TestingModule = await Test.createTestingModule({
       providers: [

--- a/ayunis-core-backend/src/iam/users/application/use-cases/update-user-role/update-user-role.use-case.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/update-user-role/update-user-role.use-case.ts
@@ -3,8 +3,13 @@ import { EventEmitter2 } from '@nestjs/event-emitter';
 import { UsersRepository } from '../../ports/users.repository';
 import { UpdateUserRoleCommand } from './update-user-role.command';
 import { User } from '../../../domain/user.entity';
-import { UserNotFoundError, UserUnexpectedError } from '../../users.errors';
+import {
+  UserNotFoundError,
+  UserUnauthorizedError,
+  UserUnexpectedError,
+} from '../../users.errors';
 import { ApplicationError } from 'src/common/errors/base.error';
+import { ContextService } from 'src/common/context/services/context.service';
 import { UserUpdatedEvent } from '../../events/user-updated.event';
 
 @Injectable()
@@ -12,6 +17,7 @@ export class UpdateUserRoleUseCase {
   private readonly logger = new Logger(UpdateUserRoleUseCase.name);
 
   constructor(
+    private readonly contextService: ContextService,
     private readonly usersRepository: UsersRepository,
     private readonly eventEmitter: EventEmitter2,
   ) {}
@@ -22,11 +28,24 @@ export class UpdateUserRoleUseCase {
       newRole: command.newRole,
     });
 
+    const requesterOrgId = this.contextService.get('orgId');
+    if (!requesterOrgId) {
+      throw new UserUnauthorizedError('User not authenticated');
+    }
+
     try {
       // Find the user
       const user = await this.usersRepository.findOneById(command.userId);
       if (!user) {
         throw new UserNotFoundError(command.userId);
+      }
+
+      // Prevent cross-org role changes: the target user must belong to the
+      // requesting admin's organization.
+      if (user.orgId !== requesterOrgId) {
+        throw new UserUnauthorizedError(
+          'You are not allowed to update this user',
+        );
       }
 
       // Update the role


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Cross-org vulnerability in the IAM users module (AYC-378):

- **`update-user-role.use-case.ts`** never checked the `orgId`. An org admin could pass a foreign user's UUID and change that user's role **across tenants**.
- **`delete-user.use-case.ts`** accepted a `command.orgId` but never read it — the authorization check relied solely on the context org, leaving the passed org unvalidated.

## Changes

- **`update-user-role`**: read the requester's `orgId` from `ContextService` (the same pattern already used by `admin-update-user`) and reject the update with `UserUnauthorizedError` when the target user belongs to a different organization. Also rejects unauthenticated requests. No controller change was required, so the endpoint's DTO/signature is unchanged.
- **`delete-user`**: the org-admin authorization check now compares the passed `command.orgId` against **both** the requester's context org and the target user's org, so the passed scope is authoritative and cross-org deletion stays blocked for org admins. Super-admin bypass is unchanged.

## Tests

- New unit test: `update-user-role` rejects updating a user from a different organization.
- New unit test: `update-user-role` rejects an unauthenticated requester.
- New unit test: `delete-user` rejects cross-org deletion.
- All existing tests for both use cases still pass (12 tests green).

## Validation

- `pnpm jest` for both use cases: 12 passed.
- Pre-commit hooks passed on both commits: ESLint, Prettier, TypeScript typecheck, complexity gate, dependency check, duplication check, file-size check.

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [AYC-378](https://linear.app/ayunis/issue/AYC-378/check-orgid-when-updating-user-roles)

<div><a href="https://cursor.com/agents/bc-d7e1131d-367a-451b-8faf-155b2815cd06"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d7e1131d-367a-451b-8faf-155b2815cd06"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

