### PR TITLE
wip(academy): add quiz progress and completion persistence (AYC-245)

### DIFF
--- a/ayunis-core-backend/src/db/migrations/1782919084340-AddAcademyQuizProgress.ts
+++ b/ayunis-core-backend/src/db/migrations/1782919084340-AddAcademyQuizProgress.ts
@@ -1,0 +1,49 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddAcademyQuizProgress1782919084340 implements MigrationInterface {
+  name = 'AddAcademyQuizProgress1782919084340';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE "academy_completion" ("id" character varying NOT NULL, "createdAt" TIMESTAMP NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP NOT NULL DEFAULT now(), "userId" character varying NOT NULL, "completedAt" TIMESTAMP NOT NULL, CONSTRAINT "UQ_academy_completion_userId" UNIQUE ("userId"), CONSTRAINT "PK_722753921b9d93a836836f3104d" PRIMARY KEY ("id"))`,
+    );
+    await queryRunner.query(
+      `CREATE TABLE "academy_chapter_progress" ("id" character varying NOT NULL, "createdAt" TIMESTAMP NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP NOT NULL DEFAULT now(), "userId" character varying NOT NULL, "chapterId" character varying NOT NULL, "passedAt" TIMESTAMP, "lastScore" integer NOT NULL, "lastAttemptAt" TIMESTAMP NOT NULL, CONSTRAINT "UQ_academy_chapter_progress_userId_chapterId" UNIQUE ("userId", "chapterId"), CONSTRAINT "PK_67c1ea3857755fa775a436bbacb" PRIMARY KEY ("id"))`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_961aad6754409b40a0941b0ea5" ON "academy_chapter_progress" ("userId") `,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "academy_chapters" ADD "passThreshold" integer NOT NULL DEFAULT '80'`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "academy_completion" ADD CONSTRAINT "FK_67f81c137898b80d17c7f10b9e9" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "academy_chapter_progress" ADD CONSTRAINT "FK_961aad6754409b40a0941b0ea52" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "academy_chapter_progress" ADD CONSTRAINT "FK_fd6b8e64f93dc35830e8c29b66d" FOREIGN KEY ("chapterId") REFERENCES "academy_chapters"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "academy_chapter_progress" DROP CONSTRAINT "FK_fd6b8e64f93dc35830e8c29b66d"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "academy_chapter_progress" DROP CONSTRAINT "FK_961aad6754409b40a0941b0ea52"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "academy_completion" DROP CONSTRAINT "FK_67f81c137898b80d17c7f10b9e9"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "academy_chapters" DROP COLUMN "passThreshold"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_961aad6754409b40a0941b0ea5"`,
+    );
+    await queryRunner.query(`DROP TABLE "academy_chapter_progress"`);
+    await queryRunner.query(`DROP TABLE "academy_completion"`);
+  }
+}

--- a/ayunis-core-backend/src/domain/academy/academy.module.ts
+++ b/ayunis-core-backend/src/domain/academy/academy.module.ts
@@ -1,13 +1,19 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { AcademyChapterRecord } from './infrastructure/persistence/local/schema/academy-chapter.record';
+import { AcademyChapterProgressRecord } from './infrastructure/persistence/local/schema/academy-chapter-progress.record';
+import { AcademyCompletionRecord } from './infrastructure/persistence/local/schema/academy-completion.record';
 import { AcademyCourseModuleRecord } from './infrastructure/persistence/local/schema/academy-course-module.record';
 import { AcademyQuizQuestionRecord } from './infrastructure/persistence/local/schema/academy-quiz-question.record';
 import { AcademyMapper } from './infrastructure/persistence/local/mappers/academy.mapper';
 import { LocalAcademyChapterRepository } from './infrastructure/persistence/local/local-academy-chapter.repository';
+import { LocalAcademyChapterProgressRepository } from './infrastructure/persistence/local/local-academy-chapter-progress.repository';
+import { LocalAcademyCompletionRepository } from './infrastructure/persistence/local/local-academy-completion.repository';
 import { LocalAcademyCourseModuleRepository } from './infrastructure/persistence/local/local-academy-course-module.repository';
 import { LocalAcademyQuizQuestionRepository } from './infrastructure/persistence/local/local-academy-quiz-question.repository';
 import { AcademyChapterRepository } from './application/ports/academy-chapter.repository';
+import { AcademyChapterProgressRepository } from './application/ports/academy-chapter-progress.repository';
+import { AcademyCompletionRepository } from './application/ports/academy-completion.repository';
 import { AcademyCourseModuleRepository } from './application/ports/academy-course-module.repository';
 import { AcademyQuizQuestionRepository } from './application/ports/academy-quiz-question.repository';
 import { GetAcademyContentUseCase } from './application/use-cases/get-academy-content/get-academy-content.use-case';
@@ -35,6 +41,8 @@ import { AcademyResponseDtoMapper } from './presenters/http/mappers/academy-resp
       AcademyChapterRecord,
       AcademyCourseModuleRecord,
       AcademyQuizQuestionRecord,
+      AcademyChapterProgressRecord,
+      AcademyCompletionRecord,
     ]),
   ],
   controllers: [
@@ -49,6 +57,8 @@ import { AcademyResponseDtoMapper } from './presenters/http/mappers/academy-resp
     LocalAcademyChapterRepository,
     LocalAcademyCourseModuleRepository,
     LocalAcademyQuizQuestionRepository,
+    LocalAcademyChapterProgressRepository,
+    LocalAcademyCompletionRepository,
     {
       provide: AcademyChapterRepository,
       useExisting: LocalAcademyChapterRepository,
@@ -60,6 +70,14 @@ import { AcademyResponseDtoMapper } from './presenters/http/mappers/academy-resp
     {
       provide: AcademyQuizQuestionRepository,
       useExisting: LocalAcademyQuizQuestionRepository,
+    },
+    {
+      provide: AcademyChapterProgressRepository,
+      useExisting: LocalAcademyChapterProgressRepository,
+    },
+    {
+      provide: AcademyCompletionRepository,
+      useExisting: LocalAcademyCompletionRepository,
     },
     GetAcademyContentUseCase,
     GetAcademyManagementContentUseCase,

--- a/ayunis-core-backend/src/domain/academy/application/ports/academy-chapter-progress.repository.ts
+++ b/ayunis-core-backend/src/domain/academy/application/ports/academy-chapter-progress.repository.ts
@@ -1,0 +1,13 @@
+import type { UUID } from 'crypto';
+import type { AcademyChapterProgress } from '../../domain/academy-chapter-progress.entity';
+
+export abstract class AcademyChapterProgressRepository {
+  abstract findByUserAndChapter(
+    userId: UUID,
+    chapterId: UUID,
+  ): Promise<AcademyChapterProgress | null>;
+  abstract findAllByUser(userId: UUID): Promise<AcademyChapterProgress[]>;
+  abstract upsert(
+    progress: AcademyChapterProgress,
+  ): Promise<AcademyChapterProgress>;
+}

--- a/ayunis-core-backend/src/domain/academy/application/ports/academy-completion.repository.ts
+++ b/ayunis-core-backend/src/domain/academy/application/ports/academy-completion.repository.ts
@@ -1,0 +1,7 @@
+import type { UUID } from 'crypto';
+import type { AcademyCompletion } from '../../domain/academy-completion.entity';
+
+export abstract class AcademyCompletionRepository {
+  abstract findByUser(userId: UUID): Promise<AcademyCompletion | null>;
+  abstract upsert(completion: AcademyCompletion): Promise<AcademyCompletion>;
+}

--- a/ayunis-core-backend/src/domain/academy/application/ports/academy-quiz-question.repository.ts
+++ b/ayunis-core-backend/src/domain/academy/application/ports/academy-quiz-question.repository.ts
@@ -3,6 +3,7 @@ import type { AcademyQuizQuestion } from '../../domain/academy-quiz-question.ent
 
 export abstract class AcademyQuizQuestionRepository {
   abstract findOne(id: UUID): Promise<AcademyQuizQuestion | null>;
+  abstract findAllByChapter(chapterId: UUID): Promise<AcademyQuizQuestion[]>;
   abstract findMaxPosition(chapterId: UUID): Promise<number | null>;
   abstract create(
     quizQuestion: AcademyQuizQuestion,

--- a/ayunis-core-backend/src/domain/academy/domain/academy-chapter-progress.entity.ts
+++ b/ayunis-core-backend/src/domain/academy/domain/academy-chapter-progress.entity.ts
@@ -1,0 +1,43 @@
+import type { UUID } from 'crypto';
+import { randomUUID } from 'crypto';
+
+/**
+ * A learner's quiz progress for a single chapter. One row per (user, chapter),
+ * upserted on every attempt. `passedAt` is the timestamp of the most recent
+ * passing attempt (refreshed on re-pass); it is the durable working tracker the
+ * whole-academy completion is derived from — it never drives access on its own.
+ */
+export class AcademyChapterProgress {
+  public readonly id: UUID;
+  public readonly userId: UUID;
+  public readonly chapterId: UUID;
+  public readonly passedAt: Date | null;
+  public readonly lastScore: number;
+  public readonly lastAttemptAt: Date;
+  public readonly createdAt: Date;
+  public readonly updatedAt: Date;
+
+  constructor(params: {
+    id?: UUID;
+    userId: UUID;
+    chapterId: UUID;
+    passedAt?: Date | null;
+    lastScore: number;
+    lastAttemptAt: Date;
+    createdAt?: Date;
+    updatedAt?: Date;
+  }) {
+    this.id = params.id ?? randomUUID();
+    this.userId = params.userId;
+    this.chapterId = params.chapterId;
+    this.passedAt = params.passedAt ?? null;
+    this.lastScore = params.lastScore;
+    this.lastAttemptAt = params.lastAttemptAt;
+    this.createdAt = params.createdAt ?? new Date();
+    this.updatedAt = params.updatedAt ?? new Date();
+  }
+
+  get passed(): boolean {
+    return this.passedAt !== null;
+  }
+}

--- a/ayunis-core-backend/src/domain/academy/domain/academy-completion.entity.ts
+++ b/ayunis-core-backend/src/domain/academy/domain/academy-completion.entity.ts
@@ -1,0 +1,31 @@
+import type { UUID } from 'crypto';
+import { randomUUID } from 'crypto';
+
+/**
+ * A learner's whole-academy completion snapshot. One row per user, stamped when
+ * every currently quiz-enabled chapter has been passed. `completedAt` is only
+ * ever (re)written on full completion — it is never cleared or recomputed by
+ * content changes, so adding a chapter never revokes an existing completion.
+ * This single date is what a future access gate reads.
+ */
+export class AcademyCompletion {
+  public readonly id: UUID;
+  public readonly userId: UUID;
+  public readonly completedAt: Date;
+  public readonly createdAt: Date;
+  public readonly updatedAt: Date;
+
+  constructor(params: {
+    id?: UUID;
+    userId: UUID;
+    completedAt: Date;
+    createdAt?: Date;
+    updatedAt?: Date;
+  }) {
+    this.id = params.id ?? randomUUID();
+    this.userId = params.userId;
+    this.completedAt = params.completedAt;
+    this.createdAt = params.createdAt ?? new Date();
+    this.updatedAt = params.updatedAt ?? new Date();
+  }
+}

--- a/ayunis-core-backend/src/domain/academy/infrastructure/persistence/local/local-academy-chapter-progress.repository.ts
+++ b/ayunis-core-backend/src/domain/academy/infrastructure/persistence/local/local-academy-chapter-progress.repository.ts
@@ -1,0 +1,52 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import type { UUID } from 'crypto';
+
+import { AcademyChapterProgressRepository } from '../../../application/ports/academy-chapter-progress.repository';
+import { AcademyChapterProgress } from '../../../domain/academy-chapter-progress.entity';
+import { AcademyChapterProgressRecord } from './schema/academy-chapter-progress.record';
+import { AcademyMapper } from './mappers/academy.mapper';
+
+@Injectable()
+export class LocalAcademyChapterProgressRepository implements AcademyChapterProgressRepository {
+  private readonly logger = new Logger(
+    LocalAcademyChapterProgressRepository.name,
+  );
+
+  constructor(
+    @InjectRepository(AcademyChapterProgressRecord)
+    private readonly repository: Repository<AcademyChapterProgressRecord>,
+    private readonly mapper: AcademyMapper,
+  ) {}
+
+  async findByUserAndChapter(
+    userId: UUID,
+    chapterId: UUID,
+  ): Promise<AcademyChapterProgress | null> {
+    this.logger.log('findByUserAndChapter', { userId, chapterId });
+    const record = await this.repository.findOne({
+      where: { userId, chapterId },
+    });
+    if (!record) return null;
+    return this.mapper.chapterProgressToDomain(record);
+  }
+
+  async findAllByUser(userId: UUID): Promise<AcademyChapterProgress[]> {
+    this.logger.log('findAllByUser', { userId });
+    const records = await this.repository.find({ where: { userId } });
+    return records.map((record) => this.mapper.chapterProgressToDomain(record));
+  }
+
+  async upsert(
+    progress: AcademyChapterProgress,
+  ): Promise<AcademyChapterProgress> {
+    this.logger.log('upsert', {
+      userId: progress.userId,
+      chapterId: progress.chapterId,
+    });
+    const record = this.mapper.chapterProgressToRecord(progress);
+    const saved = await this.repository.save(record);
+    return this.mapper.chapterProgressToDomain(saved);
+  }
+}

--- a/ayunis-core-backend/src/domain/academy/infrastructure/persistence/local/local-academy-completion.repository.ts
+++ b/ayunis-core-backend/src/domain/academy/infrastructure/persistence/local/local-academy-completion.repository.ts
@@ -1,0 +1,34 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import type { UUID } from 'crypto';
+
+import { AcademyCompletionRepository } from '../../../application/ports/academy-completion.repository';
+import { AcademyCompletion } from '../../../domain/academy-completion.entity';
+import { AcademyCompletionRecord } from './schema/academy-completion.record';
+import { AcademyMapper } from './mappers/academy.mapper';
+
+@Injectable()
+export class LocalAcademyCompletionRepository implements AcademyCompletionRepository {
+  private readonly logger = new Logger(LocalAcademyCompletionRepository.name);
+
+  constructor(
+    @InjectRepository(AcademyCompletionRecord)
+    private readonly repository: Repository<AcademyCompletionRecord>,
+    private readonly mapper: AcademyMapper,
+  ) {}
+
+  async findByUser(userId: UUID): Promise<AcademyCompletion | null> {
+    this.logger.log('findByUser', { userId });
+    const record = await this.repository.findOne({ where: { userId } });
+    if (!record) return null;
+    return this.mapper.completionToDomain(record);
+  }
+
+  async upsert(completion: AcademyCompletion): Promise<AcademyCompletion> {
+    this.logger.log('upsert', { userId: completion.userId });
+    const record = this.mapper.completionToRecord(completion);
+    const saved = await this.repository.save(record);
+    return this.mapper.completionToDomain(saved);
+  }
+}

--- a/ayunis-core-backend/src/domain/academy/infrastructure/persistence/local/local-academy-quiz-question.repository.ts
+++ b/ayunis-core-backend/src/domain/academy/infrastructure/persistence/local/local-academy-quiz-question.repository.ts
@@ -26,6 +26,15 @@ export class LocalAcademyQuizQuestionRepository implements AcademyQuizQuestionRe
     return this.mapper.quizQuestionToDomain(record);
   }
 
+  async findAllByChapter(chapterId: UUID): Promise<AcademyQuizQuestion[]> {
+    this.logger.log('findAllByChapter', { chapterId });
+    const records = await this.repository.find({
+      where: { chapterId },
+      order: { position: 'ASC', createdAt: 'ASC' },
+    });
+    return records.map((record) => this.mapper.quizQuestionToDomain(record));
+  }
+
   async findMaxPosition(chapterId: UUID): Promise<number | null> {
     this.logger.log('findMaxPosition', { chapterId });
     return this.repository.maximum('position', { chapterId });

--- a/ayunis-core-backend/src/domain/academy/infrastructure/persistence/local/mappers/academy.mapper.ts
+++ b/ayunis-core-backend/src/domain/academy/infrastructure/persistence/local/mappers/academy.mapper.ts
@@ -1,8 +1,12 @@
 import { Injectable } from '@nestjs/common';
 import { AcademyChapter } from '../../../../domain/academy-chapter.entity';
+import { AcademyChapterProgress } from '../../../../domain/academy-chapter-progress.entity';
+import { AcademyCompletion } from '../../../../domain/academy-completion.entity';
 import { AcademyCourseModule } from '../../../../domain/academy-course-module.entity';
 import { AcademyQuizQuestion } from '../../../../domain/academy-quiz-question.entity';
 import { AcademyChapterRecord } from '../schema/academy-chapter.record';
+import { AcademyChapterProgressRecord } from '../schema/academy-chapter-progress.record';
+import { AcademyCompletionRecord } from '../schema/academy-completion.record';
 import { AcademyCourseModuleRecord } from '../schema/academy-course-module.record';
 import { AcademyQuizQuestionRecord } from '../schema/academy-quiz-question.record';
 
@@ -81,6 +85,52 @@ export class AcademyMapper {
     record.text = domain.text;
     record.options = domain.options;
     record.position = domain.position;
+    return record;
+  }
+
+  chapterProgressToDomain(
+    record: AcademyChapterProgressRecord,
+  ): AcademyChapterProgress {
+    return new AcademyChapterProgress({
+      id: record.id,
+      userId: record.userId,
+      chapterId: record.chapterId,
+      passedAt: record.passedAt,
+      lastScore: record.lastScore,
+      lastAttemptAt: record.lastAttemptAt,
+      createdAt: record.createdAt,
+      updatedAt: record.updatedAt,
+    });
+  }
+
+  chapterProgressToRecord(
+    domain: AcademyChapterProgress,
+  ): AcademyChapterProgressRecord {
+    const record = new AcademyChapterProgressRecord();
+    record.id = domain.id;
+    record.userId = domain.userId;
+    record.chapterId = domain.chapterId;
+    record.passedAt = domain.passedAt;
+    record.lastScore = domain.lastScore;
+    record.lastAttemptAt = domain.lastAttemptAt;
+    return record;
+  }
+
+  completionToDomain(record: AcademyCompletionRecord): AcademyCompletion {
+    return new AcademyCompletion({
+      id: record.id,
+      userId: record.userId,
+      completedAt: record.completedAt,
+      createdAt: record.createdAt,
+      updatedAt: record.updatedAt,
+    });
+  }
+
+  completionToRecord(domain: AcademyCompletion): AcademyCompletionRecord {
+    const record = new AcademyCompletionRecord();
+    record.id = domain.id;
+    record.userId = domain.userId;
+    record.completedAt = domain.completedAt;
     return record;
   }
 }

--- a/ayunis-core-backend/src/domain/academy/infrastructure/persistence/local/schema/academy-chapter-progress.record.ts
+++ b/ayunis-core-backend/src/domain/academy/infrastructure/persistence/local/schema/academy-chapter-progress.record.ts
@@ -1,0 +1,34 @@
+import { UUID } from 'crypto';
+import { Column, Entity, Index, ManyToOne, Unique } from 'typeorm';
+import { BaseRecord } from '../../../../../../common/db/base-record';
+import { UserRecord } from '../../../../../../iam/users/infrastructure/repositories/local/schema/user.record';
+import { AcademyChapterRecord } from './academy-chapter.record';
+
+@Entity({ name: 'academy_chapter_progress' })
+@Unique('UQ_academy_chapter_progress_userId_chapterId', ['userId', 'chapterId'])
+export class AcademyChapterProgressRecord extends BaseRecord {
+  @Column()
+  @Index()
+  userId: UUID;
+
+  @ManyToOne(() => UserRecord, { nullable: false, onDelete: 'CASCADE' })
+  user: UserRecord;
+
+  @Column()
+  chapterId: UUID;
+
+  @ManyToOne(() => AcademyChapterRecord, {
+    nullable: false,
+    onDelete: 'CASCADE',
+  })
+  chapter: AcademyChapterRecord;
+
+  @Column({ nullable: true, type: 'timestamp' })
+  passedAt: Date | null;
+
+  @Column({ nullable: false, type: 'int' })
+  lastScore: number;
+
+  @Column({ nullable: false, type: 'timestamp' })
+  lastAttemptAt: Date;
+}

--- a/ayunis-core-backend/src/domain/academy/infrastructure/persistence/local/schema/academy-completion.record.ts
+++ b/ayunis-core-backend/src/domain/academy/infrastructure/persistence/local/schema/academy-completion.record.ts
@@ -1,0 +1,17 @@
+import { UUID } from 'crypto';
+import { Column, Entity, ManyToOne, Unique } from 'typeorm';
+import { BaseRecord } from '../../../../../../common/db/base-record';
+import { UserRecord } from '../../../../../../iam/users/infrastructure/repositories/local/schema/user.record';
+
+@Entity({ name: 'academy_completion' })
+@Unique('UQ_academy_completion_userId', ['userId'])
+export class AcademyCompletionRecord extends BaseRecord {
+  @Column()
+  userId: UUID;
+
+  @ManyToOne(() => UserRecord, { nullable: false, onDelete: 'CASCADE' })
+  user: UserRecord;
+
+  @Column({ nullable: false, type: 'timestamp' })
+  completedAt: Date;
+}


### PR DESCRIPTION
Add AcademyChapterProgress (per user+chapter working tracker) and AcademyCompletion (single whole-academy snapshot) domain entities, records, ports and local repositories. Add findAllByChapter to the quiz-question repository for drawing and grading. Wire records/repos into AcademyModule and add the migration (new tables plus FKs, unique constraints, userId index).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Schema migration adds user-linked tables with CASCADE deletes; behavior is additive with no new API endpoints in this PR, but completion data may later gate access.
> 
> **Overview**
> Adds **persistence for academy quiz progress and whole-academy completion**, ahead of submit/grade flows and a future access gate.
> 
> A migration creates **`academy_chapter_progress`** (one row per user+chapter: `lastScore`, `lastAttemptAt`, optional `passedAt`) and **`academy_completion`** (one row per user with `completedAt`), with FKs to users/chapters, unique constraints, and a userId index on chapter progress. It also adds **`passThreshold`** on **`academy_chapters`** (default 80).
> 
> New domain types **`AcademyChapterProgress`** and **`AcademyCompletion`**, TypeORM records, **`AcademyMapper`** mappings, repository ports, and local implementations are wired into **`AcademyModule`**. **`AcademyQuizQuestionRepository`** gains **`findAllByChapter`** (ordered by position) for upcoming quiz draw/grade logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10e26533b11df2aea9e9863321b282c313771803. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->