### PR TITLE
wip(academy): add quiz-taking and progress use cases (AYC-245)

### DIFF
--- a/ayunis-core-backend/src/domain/academy/academy.module.ts
+++ b/ayunis-core-backend/src/domain/academy/academy.module.ts
@@ -29,6 +29,9 @@ import { ReorderCourseModulesUseCase } from './application/use-cases/reorder-cou
 import { CreateQuizQuestionUseCase } from './application/use-cases/create-quiz-question/create-quiz-question.use-case';
 import { UpdateQuizQuestionUseCase } from './application/use-cases/update-quiz-question/update-quiz-question.use-case';
 import { DeleteQuizQuestionUseCase } from './application/use-cases/delete-quiz-question/delete-quiz-question.use-case';
+import { GetChapterQuizUseCase } from './application/use-cases/get-chapter-quiz/get-chapter-quiz.use-case';
+import { SubmitChapterQuizUseCase } from './application/use-cases/submit-chapter-quiz/submit-chapter-quiz.use-case';
+import { GetAcademyProgressUseCase } from './application/use-cases/get-academy-progress/get-academy-progress.use-case';
 import { SuperAdminAcademyChaptersController } from './presenters/http/super-admin-academy-chapters.controller';
 import { SuperAdminAcademyCourseModulesController } from './presenters/http/super-admin-academy-course-modules.controller';
 import { SuperAdminAcademyQuizQuestionsController } from './presenters/http/super-admin-academy-quiz-questions.controller';
@@ -92,7 +95,14 @@ import { AcademyResponseDtoMapper } from './presenters/http/mappers/academy-resp
     CreateQuizQuestionUseCase,
     UpdateQuizQuestionUseCase,
     DeleteQuizQuestionUseCase,
+    GetChapterQuizUseCase,
+    SubmitChapterQuizUseCase,
+    GetAcademyProgressUseCase,
   ],
-  exports: [GetAcademyContentUseCase],
+  exports: [
+    GetAcademyContentUseCase,
+    GetAcademyProgressUseCase,
+    SubmitChapterQuizUseCase,
+  ],
 })
 export class AcademyModule {}

--- a/ayunis-core-backend/src/domain/academy/application/academy.errors.ts
+++ b/ayunis-core-backend/src/domain/academy/application/academy.errors.ts
@@ -7,6 +7,8 @@ export enum AcademyErrorCode {
   QUIZ_QUESTION_NOT_FOUND = 'QUIZ_QUESTION_NOT_FOUND',
   INVALID_REORDER = 'INVALID_REORDER',
   INVALID_QUIZ_QUESTION = 'INVALID_QUIZ_QUESTION',
+  QUIZ_NOT_AVAILABLE = 'QUIZ_NOT_AVAILABLE',
+  INVALID_QUIZ_SUBMISSION = 'INVALID_QUIZ_SUBMISSION',
   UNEXPECTED_ACADEMY_ERROR = 'UNEXPECTED_ACADEMY_ERROR',
 }
 
@@ -68,6 +70,23 @@ export class InvalidReorderError extends AcademyError {
 export class InvalidQuizQuestionError extends AcademyError {
   constructor(reason: string, metadata?: ErrorMetadata) {
     super(reason, AcademyErrorCode.INVALID_QUIZ_QUESTION, 400, metadata);
+  }
+}
+
+export class QuizNotAvailableError extends AcademyError {
+  constructor(chapterId: string, metadata?: ErrorMetadata) {
+    super(
+      `No quiz is available for chapter ${chapterId}`,
+      AcademyErrorCode.QUIZ_NOT_AVAILABLE,
+      400,
+      metadata,
+    );
+  }
+}
+
+export class InvalidQuizSubmissionError extends AcademyError {
+  constructor(reason: string, metadata?: ErrorMetadata) {
+    super(reason, AcademyErrorCode.INVALID_QUIZ_SUBMISSION, 400, metadata);
   }
 }
 

--- a/ayunis-core-backend/src/domain/academy/application/ports/academy-chapter.repository.ts
+++ b/ayunis-core-backend/src/domain/academy/application/ports/academy-chapter.repository.ts
@@ -6,6 +6,7 @@ export abstract class AcademyChapterRepository {
   abstract findAllWithQuizContent(): Promise<AcademyChapter[]>;
   abstract findOne(id: UUID): Promise<AcademyChapter | null>;
   abstract findAllIds(): Promise<UUID[]>;
+  abstract findQuizEnabledIds(): Promise<UUID[]>;
   abstract findMaxPosition(): Promise<number | null>;
   abstract create(chapter: AcademyChapter): Promise<AcademyChapter>;
   abstract update(chapter: AcademyChapter): Promise<AcademyChapter>;

--- a/ayunis-core-backend/src/domain/academy/application/quiz.constants.spec.ts
+++ b/ayunis-core-backend/src/domain/academy/application/quiz.constants.spec.ts
@@ -1,0 +1,15 @@
+import { requiredCorrect } from './quiz.constants';
+
+describe('requiredCorrect', () => {
+  it.each([
+    [10, 80, 8],
+    [7, 80, 6],
+    [5, 80, 4],
+    [10, 100, 10],
+    [10, 50, 5],
+    [3, 80, 3],
+    [1, 80, 1],
+  ])('requires %i*%i%% -> %i correct', (total, thresholdPct, expected) => {
+    expect(requiredCorrect(total, thresholdPct)).toBe(expected);
+  });
+});

--- a/ayunis-core-backend/src/domain/academy/application/use-cases/get-academy-progress/get-academy-progress.query.ts
+++ b/ayunis-core-backend/src/domain/academy/application/use-cases/get-academy-progress/get-academy-progress.query.ts
@@ -1,0 +1,9 @@
+import type { UUID } from 'crypto';
+
+export class GetAcademyProgressQuery {
+  public readonly userId: UUID;
+
+  constructor(params: { userId: UUID }) {
+    this.userId = params.userId;
+  }
+}

--- a/ayunis-core-backend/src/domain/academy/application/use-cases/get-academy-progress/get-academy-progress.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/academy/application/use-cases/get-academy-progress/get-academy-progress.use-case.spec.ts
@@ -1,0 +1,81 @@
+import type { TestingModule } from '@nestjs/testing';
+import { Test } from '@nestjs/testing';
+import { Logger } from '@nestjs/common';
+import { randomUUID } from 'crypto';
+import { GetAcademyProgressUseCase } from './get-academy-progress.use-case';
+import { GetAcademyProgressQuery } from './get-academy-progress.query';
+import { AcademyChapterProgressRepository } from '../../ports/academy-chapter-progress.repository';
+import { AcademyCompletionRepository } from '../../ports/academy-completion.repository';
+import { AcademyChapterProgress } from '../../../domain/academy-chapter-progress.entity';
+import { AcademyCompletion } from '../../../domain/academy-completion.entity';
+
+describe('GetAcademyProgressUseCase', () => {
+  let useCase: GetAcademyProgressUseCase;
+  let progressRepository: jest.Mocked<AcademyChapterProgressRepository>;
+  let completionRepository: jest.Mocked<AcademyCompletionRepository>;
+
+  const userId = randomUUID();
+  const chapterId = randomUUID();
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        GetAcademyProgressUseCase,
+        {
+          provide: AcademyChapterProgressRepository,
+          useValue: { findAllByUser: jest.fn() },
+        },
+        {
+          provide: AcademyCompletionRepository,
+          useValue: { findByUser: jest.fn() },
+        },
+      ],
+    }).compile();
+
+    useCase = module.get(GetAcademyProgressUseCase);
+    progressRepository = module.get(AcademyChapterProgressRepository);
+    completionRepository = module.get(AcademyCompletionRepository);
+    jest.spyOn(Logger.prototype, 'log').mockImplementation();
+    jest.spyOn(Logger.prototype, 'error').mockImplementation();
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  it('maps progress rows and the completion snapshot', async () => {
+    const passedAt = new Date('2026-02-01T00:00:00Z');
+    const completedAt = new Date('2026-02-02T00:00:00Z');
+    progressRepository.findAllByUser.mockResolvedValue([
+      new AcademyChapterProgress({
+        userId,
+        chapterId,
+        passedAt,
+        lastScore: 90,
+        lastAttemptAt: passedAt,
+      }),
+    ]);
+    completionRepository.findByUser.mockResolvedValue(
+      new AcademyCompletion({ userId, completedAt }),
+    );
+
+    const result = await useCase.execute(
+      new GetAcademyProgressQuery({ userId }),
+    );
+
+    expect(result.academyCompletedAt).toEqual(completedAt);
+    expect(result.chapters).toEqual([
+      { chapterId, passed: true, lastScore: 90, lastPassedAt: passedAt },
+    ]);
+  });
+
+  it('returns a null completion date when the academy is not completed', async () => {
+    progressRepository.findAllByUser.mockResolvedValue([]);
+    completionRepository.findByUser.mockResolvedValue(null);
+
+    const result = await useCase.execute(
+      new GetAcademyProgressQuery({ userId }),
+    );
+
+    expect(result.academyCompletedAt).toBeNull();
+    expect(result.chapters).toEqual([]);
+  });
+});

--- a/ayunis-core-backend/src/domain/academy/application/use-cases/get-academy-progress/get-academy-progress.use-case.ts
+++ b/ayunis-core-backend/src/domain/academy/application/use-cases/get-academy-progress/get-academy-progress.use-case.ts
@@ -1,0 +1,56 @@
+import { Injectable, Logger } from '@nestjs/common';
+import type { UUID } from 'crypto';
+import { ApplicationError } from 'src/common/errors/base.error';
+import { AcademyChapterProgressRepository } from '../../ports/academy-chapter-progress.repository';
+import { AcademyCompletionRepository } from '../../ports/academy-completion.repository';
+import { UnexpectedAcademyError } from '../../academy.errors';
+import { GetAcademyProgressQuery } from './get-academy-progress.query';
+
+export interface ChapterProgressView {
+  readonly chapterId: UUID;
+  readonly passed: boolean;
+  readonly lastScore: number;
+  readonly lastPassedAt: Date | null;
+}
+
+export interface AcademyProgressView {
+  readonly chapters: ChapterProgressView[];
+  readonly academyCompletedAt: Date | null;
+}
+
+@Injectable()
+export class GetAcademyProgressUseCase {
+  private readonly logger = new Logger(GetAcademyProgressUseCase.name);
+
+  constructor(
+    private readonly progressRepository: AcademyChapterProgressRepository,
+    private readonly completionRepository: AcademyCompletionRepository,
+  ) {}
+
+  async execute(query: GetAcademyProgressQuery): Promise<AcademyProgressView> {
+    this.logger.log('Getting academy progress', { userId: query.userId });
+    try {
+      const progress = await this.progressRepository.findAllByUser(
+        query.userId,
+      );
+      const completion = await this.completionRepository.findByUser(
+        query.userId,
+      );
+      return {
+        chapters: progress.map((p) => ({
+          chapterId: p.chapterId,
+          passed: p.passed,
+          lastScore: p.lastScore,
+          lastPassedAt: p.passedAt,
+        })),
+        academyCompletedAt: completion?.completedAt ?? null,
+      };
+    } catch (error) {
+      if (error instanceof ApplicationError) throw error;
+      this.logger.error('Error getting academy progress', {
+        error: error as Error,
+      });
+      throw new UnexpectedAcademyError(error);
+    }
+  }
+}

--- a/ayunis-core-backend/src/domain/academy/application/use-cases/get-chapter-quiz/get-chapter-quiz.query.ts
+++ b/ayunis-core-backend/src/domain/academy/application/use-cases/get-chapter-quiz/get-chapter-quiz.query.ts
@@ -1,0 +1,9 @@
+import type { UUID } from 'crypto';
+
+export class GetChapterQuizQuery {
+  public readonly chapterId: UUID;
+
+  constructor(params: { chapterId: UUID }) {
+    this.chapterId = params.chapterId;
+  }
+}

--- a/ayunis-core-backend/src/domain/academy/application/use-cases/get-chapter-quiz/get-chapter-quiz.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/academy/application/use-cases/get-chapter-quiz/get-chapter-quiz.use-case.spec.ts
@@ -1,0 +1,122 @@
+import type { TestingModule } from '@nestjs/testing';
+import { Test } from '@nestjs/testing';
+import { Logger } from '@nestjs/common';
+import { randomUUID } from 'crypto';
+import type { UUID } from 'crypto';
+import { GetChapterQuizUseCase } from './get-chapter-quiz.use-case';
+import { GetChapterQuizQuery } from './get-chapter-quiz.query';
+import { AcademyChapterRepository } from '../../ports/academy-chapter.repository';
+import { AcademyQuizQuestionRepository } from '../../ports/academy-quiz-question.repository';
+import { AcademyChapter } from '../../../domain/academy-chapter.entity';
+import { AcademyQuizQuestion } from '../../../domain/academy-quiz-question.entity';
+import {
+  ChapterNotFoundError,
+  QuizNotAvailableError,
+} from '../../academy.errors';
+
+function makePool(chapterId: UUID, count: number): AcademyQuizQuestion[] {
+  return Array.from(
+    { length: count },
+    (_, i) =>
+      new AcademyQuizQuestion({
+        chapterId,
+        text: `Question ${i}`,
+        position: i,
+        options: [
+          { text: 'Correct', isCorrect: true },
+          { text: 'Wrong', isCorrect: false },
+        ],
+      }),
+  );
+}
+
+describe('GetChapterQuizUseCase', () => {
+  let useCase: GetChapterQuizUseCase;
+  let chapterRepository: jest.Mocked<AcademyChapterRepository>;
+  let quizQuestionRepository: jest.Mocked<AcademyQuizQuestionRepository>;
+
+  const chapter = new AcademyChapter({
+    title: 'Getting Started',
+    description: 'Basics',
+    position: 0,
+    quizEnabled: true,
+  });
+
+  beforeAll(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        GetChapterQuizUseCase,
+        { provide: AcademyChapterRepository, useValue: { findOne: jest.fn() } },
+        {
+          provide: AcademyQuizQuestionRepository,
+          useValue: { findAllByChapter: jest.fn() },
+        },
+      ],
+    }).compile();
+
+    useCase = module.get(GetChapterQuizUseCase);
+    chapterRepository = module.get(AcademyChapterRepository);
+    quizQuestionRepository = module.get(AcademyQuizQuestionRepository);
+    jest.spyOn(Logger.prototype, 'log').mockImplementation();
+    jest.spyOn(Logger.prototype, 'error').mockImplementation();
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  it('draws exactly 10 distinct questions from a larger pool', async () => {
+    const pool = makePool(chapter.id, 15);
+    chapterRepository.findOne.mockResolvedValue(chapter);
+    quizQuestionRepository.findAllByChapter.mockResolvedValue(pool);
+
+    const result = await useCase.execute(
+      new GetChapterQuizQuery({ chapterId: chapter.id }),
+    );
+
+    expect(result).toHaveLength(10);
+    const ids = new Set(result.map((q) => q.id));
+    expect(ids.size).toBe(10);
+    const poolIds = new Set(pool.map((q) => q.id));
+    expect(result.every((q) => poolIds.has(q.id))).toBe(true);
+  });
+
+  it('draws the whole pool when it holds fewer than 10 questions', async () => {
+    const pool = makePool(chapter.id, 7);
+    chapterRepository.findOne.mockResolvedValue(chapter);
+    quizQuestionRepository.findAllByChapter.mockResolvedValue(pool);
+
+    const result = await useCase.execute(
+      new GetChapterQuizQuery({ chapterId: chapter.id }),
+    );
+
+    expect(result).toHaveLength(7);
+  });
+
+  it('throws when the chapter does not exist', async () => {
+    chapterRepository.findOne.mockResolvedValue(null);
+    await expect(
+      useCase.execute(new GetChapterQuizQuery({ chapterId: randomUUID() })),
+    ).rejects.toThrow(ChapterNotFoundError);
+  });
+
+  it('throws when the quiz is not enabled', async () => {
+    chapterRepository.findOne.mockResolvedValue(
+      new AcademyChapter({
+        title: 'No quiz',
+        description: '',
+        position: 1,
+        quizEnabled: false,
+      }),
+    );
+    await expect(
+      useCase.execute(new GetChapterQuizQuery({ chapterId: chapter.id })),
+    ).rejects.toThrow(QuizNotAvailableError);
+  });
+
+  it('throws when the pool is empty', async () => {
+    chapterRepository.findOne.mockResolvedValue(chapter);
+    quizQuestionRepository.findAllByChapter.mockResolvedValue([]);
+    await expect(
+      useCase.execute(new GetChapterQuizQuery({ chapterId: chapter.id })),
+    ).rejects.toThrow(QuizNotAvailableError);
+  });
+});

--- a/ayunis-core-backend/src/domain/academy/application/use-cases/get-chapter-quiz/get-chapter-quiz.use-case.ts
+++ b/ayunis-core-backend/src/domain/academy/application/use-cases/get-chapter-quiz/get-chapter-quiz.use-case.ts
@@ -1,0 +1,65 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ApplicationError } from 'src/common/errors/base.error';
+import { AcademyChapterRepository } from '../../ports/academy-chapter.repository';
+import { AcademyQuizQuestionRepository } from '../../ports/academy-quiz-question.repository';
+import { AcademyQuizQuestion } from '../../../domain/academy-quiz-question.entity';
+import {
+  ChapterNotFoundError,
+  QuizNotAvailableError,
+  UnexpectedAcademyError,
+} from '../../academy.errors';
+import { DRAWN_QUESTION_COUNT } from '../../quiz.constants';
+import { GetChapterQuizQuery } from './get-chapter-quiz.query';
+
+@Injectable()
+export class GetChapterQuizUseCase {
+  private readonly logger = new Logger(GetChapterQuizUseCase.name);
+
+  constructor(
+    private readonly chapterRepository: AcademyChapterRepository,
+    private readonly quizQuestionRepository: AcademyQuizQuestionRepository,
+  ) {}
+
+  async execute(query: GetChapterQuizQuery): Promise<AcademyQuizQuestion[]> {
+    this.logger.log('Getting chapter quiz', { chapterId: query.chapterId });
+    try {
+      const chapter = await this.chapterRepository.findOne(query.chapterId);
+      if (!chapter) {
+        throw new ChapterNotFoundError(query.chapterId);
+      }
+      if (!chapter.quizEnabled) {
+        throw new QuizNotAvailableError(query.chapterId);
+      }
+      const pool = await this.quizQuestionRepository.findAllByChapter(
+        query.chapterId,
+      );
+      if (pool.length === 0) {
+        throw new QuizNotAvailableError(query.chapterId);
+      }
+      return this.drawRandom(pool, DRAWN_QUESTION_COUNT);
+    } catch (error) {
+      if (error instanceof ApplicationError) throw error;
+      this.logger.error('Error getting chapter quiz', {
+        error: error as Error,
+      });
+      throw new UnexpectedAcademyError(error);
+    }
+  }
+
+  // Fisher–Yates shuffle over a copy, returning the first `count` items (or the
+  // whole pool when it holds fewer than `count`).
+  private drawRandom(
+    pool: AcademyQuizQuestion[],
+    count: number,
+  ): AcademyQuizQuestion[] {
+    const shuffled = [...pool];
+    for (let i = shuffled.length - 1; i > 0; i--) {
+      // Non-security shuffle: which quiz questions a learner is asked is not a
+      // secret and correct answers are never sent to the client.
+      // eslint-disable-next-line sonarjs/pseudo-random -- non-cryptographic quiz question selection
+      const j = Math.floor(Math.random() * (i + 1));
+      [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
+    }
+    return shuffled.slice(0, Math.min(count, shuffled.length));
+  }
+}

--- a/ayunis-core-backend/src/domain/academy/application/use-cases/submit-chapter-quiz/submit-chapter-quiz.command.ts
+++ b/ayunis-core-backend/src/domain/academy/application/use-cases/submit-chapter-quiz/submit-chapter-quiz.command.ts
@@ -1,0 +1,22 @@
+import type { UUID } from 'crypto';
+
+export interface QuizAnswerSubmission {
+  readonly questionId: UUID;
+  readonly selectedOptionIndex: number;
+}
+
+export class SubmitChapterQuizCommand {
+  public readonly userId: UUID;
+  public readonly chapterId: UUID;
+  public readonly answers: QuizAnswerSubmission[];
+
+  constructor(params: {
+    userId: UUID;
+    chapterId: UUID;
+    answers: QuizAnswerSubmission[];
+  }) {
+    this.userId = params.userId;
+    this.chapterId = params.chapterId;
+    this.answers = params.answers;
+  }
+}

--- a/ayunis-core-backend/src/domain/academy/application/use-cases/submit-chapter-quiz/submit-chapter-quiz.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/academy/application/use-cases/submit-chapter-quiz/submit-chapter-quiz.use-case.spec.ts
@@ -1,0 +1,297 @@
+import type { TestingModule } from '@nestjs/testing';
+import { Test } from '@nestjs/testing';
+import { Logger } from '@nestjs/common';
+import { randomUUID } from 'crypto';
+import type { UUID } from 'crypto';
+import { SubmitChapterQuizUseCase } from './submit-chapter-quiz.use-case';
+import type { QuizAnswerSubmission } from './submit-chapter-quiz.command';
+import { SubmitChapterQuizCommand } from './submit-chapter-quiz.command';
+import { AcademyChapterRepository } from '../../ports/academy-chapter.repository';
+import { AcademyChapterProgressRepository } from '../../ports/academy-chapter-progress.repository';
+import { AcademyCompletionRepository } from '../../ports/academy-completion.repository';
+import { AcademyQuizQuestionRepository } from '../../ports/academy-quiz-question.repository';
+import { AcademyChapter } from '../../../domain/academy-chapter.entity';
+import { AcademyChapterProgress } from '../../../domain/academy-chapter-progress.entity';
+import { AcademyQuizQuestion } from '../../../domain/academy-quiz-question.entity';
+import {
+  InvalidQuizSubmissionError,
+  QuizNotAvailableError,
+} from '../../academy.errors';
+
+function makePool(chapterId: UUID, count: number): AcademyQuizQuestion[] {
+  return Array.from(
+    { length: count },
+    (_, i) =>
+      new AcademyQuizQuestion({
+        chapterId,
+        text: `Question ${i}`,
+        position: i,
+        // index 0 is correct, index 1 is wrong
+        options: [
+          { text: 'Correct', isCorrect: true },
+          { text: 'Wrong', isCorrect: false },
+        ],
+      }),
+  );
+}
+
+// Answer the first `correct` questions correctly (index 0) and the rest wrong.
+function answersFor(
+  pool: AcademyQuizQuestion[],
+  correct: number,
+): QuizAnswerSubmission[] {
+  return pool.map((q, i) => ({
+    questionId: q.id,
+    selectedOptionIndex: i < correct ? 0 : 1,
+  }));
+}
+
+describe('SubmitChapterQuizUseCase', () => {
+  let useCase: SubmitChapterQuizUseCase;
+  let chapterRepository: jest.Mocked<AcademyChapterRepository>;
+  let quizQuestionRepository: jest.Mocked<AcademyQuizQuestionRepository>;
+  let progressRepository: jest.Mocked<AcademyChapterProgressRepository>;
+  let completionRepository: jest.Mocked<AcademyCompletionRepository>;
+
+  const userId = randomUUID();
+  const chapter = new AcademyChapter({
+    title: 'Getting Started',
+    description: 'Basics',
+    position: 0,
+    quizEnabled: true,
+  });
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        SubmitChapterQuizUseCase,
+        {
+          provide: AcademyChapterRepository,
+          useValue: { findOne: jest.fn(), findQuizEnabledIds: jest.fn() },
+        },
+        {
+          provide: AcademyQuizQuestionRepository,
+          useValue: { findAllByChapter: jest.fn() },
+        },
+        {
+          provide: AcademyChapterProgressRepository,
+          useValue: {
+            findByUserAndChapter: jest.fn(),
+            findAllByUser: jest.fn(),
+            upsert: jest.fn(),
+          },
+        },
+        {
+          provide: AcademyCompletionRepository,
+          useValue: { findByUser: jest.fn(), upsert: jest.fn() },
+        },
+      ],
+    }).compile();
+
+    useCase = module.get(SubmitChapterQuizUseCase);
+    chapterRepository = module.get(AcademyChapterRepository);
+    quizQuestionRepository = module.get(AcademyQuizQuestionRepository);
+    progressRepository = module.get(AcademyChapterProgressRepository);
+    completionRepository = module.get(AcademyCompletionRepository);
+
+    chapterRepository.findOne.mockResolvedValue(chapter);
+    chapterRepository.findQuizEnabledIds.mockResolvedValue([chapter.id]);
+    progressRepository.findByUserAndChapter.mockResolvedValue(null);
+    progressRepository.upsert.mockImplementation(async (p) => p);
+    completionRepository.findByUser.mockResolvedValue(null);
+    completionRepository.upsert.mockImplementation(async (c) => c);
+    jest.spyOn(Logger.prototype, 'log').mockImplementation();
+    jest.spyOn(Logger.prototype, 'error').mockImplementation();
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  function submit(answers: QuizAnswerSubmission[]) {
+    return useCase.execute(
+      new SubmitChapterQuizCommand({ userId, chapterId: chapter.id, answers }),
+    );
+  }
+
+  it('passes at 8 of 10 correct (80% threshold)', async () => {
+    const pool = makePool(chapter.id, 10);
+    quizQuestionRepository.findAllByChapter.mockResolvedValue(pool);
+    progressRepository.findAllByUser.mockResolvedValue([
+      new AcademyChapterProgress({
+        userId,
+        chapterId: chapter.id,
+        passedAt: new Date(),
+        lastScore: 80,
+        lastAttemptAt: new Date(),
+      }),
+    ]);
+
+    const result = await submit(answersFor(pool, 8));
+
+    expect(result.passed).toBe(true);
+    expect(result.correctCount).toBe(8);
+    expect(result.totalCount).toBe(10);
+    expect(result.requiredCount).toBe(8);
+    expect(result.score).toBe(80);
+    expect(result.academyCompleted).toBe(true);
+  });
+
+  it('fails at 7 of 10 correct', async () => {
+    const pool = makePool(chapter.id, 10);
+    quizQuestionRepository.findAllByChapter.mockResolvedValue(pool);
+
+    const result = await submit(answersFor(pool, 7));
+
+    expect(result.passed).toBe(false);
+    expect(result.requiredCount).toBe(8);
+    expect(result.academyCompleted).toBe(false);
+    expect(completionRepository.upsert).not.toHaveBeenCalled();
+  });
+
+  it('scales the required count for a pool smaller than 10 (6 of 7 passes)', async () => {
+    const pool = makePool(chapter.id, 7);
+    quizQuestionRepository.findAllByChapter.mockResolvedValue(pool);
+    progressRepository.findAllByUser.mockResolvedValue([
+      new AcademyChapterProgress({
+        userId,
+        chapterId: chapter.id,
+        passedAt: new Date(),
+        lastScore: 86,
+        lastAttemptAt: new Date(),
+      }),
+    ]);
+
+    const result = await submit(answersFor(pool, 6));
+
+    expect(result.requiredCount).toBe(6);
+    expect(result.passed).toBe(true);
+  });
+
+  it('fails a small pool below its scaled threshold (5 of 7)', async () => {
+    const pool = makePool(chapter.id, 7);
+    quizQuestionRepository.findAllByChapter.mockResolvedValue(pool);
+
+    const result = await submit(answersFor(pool, 5));
+
+    expect(result.requiredCount).toBe(6);
+    expect(result.passed).toBe(false);
+  });
+
+  it('stamps passedAt on the progress row when passing', async () => {
+    const pool = makePool(chapter.id, 10);
+    quizQuestionRepository.findAllByChapter.mockResolvedValue(pool);
+    progressRepository.findAllByUser.mockResolvedValue([]);
+
+    await submit(answersFor(pool, 10));
+
+    const saved = progressRepository.upsert.mock.calls[0][0];
+    expect(saved.passedAt).not.toBeNull();
+    expect(saved.lastScore).toBe(100);
+  });
+
+  it('keeps a previous pass when a later attempt fails', async () => {
+    const previousPass = new Date('2026-01-01T00:00:00Z');
+    progressRepository.findByUserAndChapter.mockResolvedValue(
+      new AcademyChapterProgress({
+        userId,
+        chapterId: chapter.id,
+        passedAt: previousPass,
+        lastScore: 90,
+        lastAttemptAt: previousPass,
+      }),
+    );
+    const pool = makePool(chapter.id, 10);
+    quizQuestionRepository.findAllByChapter.mockResolvedValue(pool);
+
+    await submit(answersFor(pool, 3));
+
+    const saved = progressRepository.upsert.mock.calls[0][0];
+    expect(saved.passedAt).toEqual(previousPass);
+    expect(saved.lastScore).toBe(30);
+  });
+
+  it('does not stamp academy completion while another quiz chapter is unpassed', async () => {
+    const otherChapterId = randomUUID();
+    chapterRepository.findQuizEnabledIds.mockResolvedValue([
+      chapter.id,
+      otherChapterId,
+    ]);
+    const pool = makePool(chapter.id, 10);
+    quizQuestionRepository.findAllByChapter.mockResolvedValue(pool);
+    progressRepository.findAllByUser.mockResolvedValue([
+      new AcademyChapterProgress({
+        userId,
+        chapterId: chapter.id,
+        passedAt: new Date(),
+        lastScore: 100,
+        lastAttemptAt: new Date(),
+      }),
+    ]);
+
+    const result = await submit(answersFor(pool, 10));
+
+    expect(result.passed).toBe(true);
+    expect(result.academyCompleted).toBe(false);
+    expect(completionRepository.upsert).not.toHaveBeenCalled();
+  });
+
+  it('stamps academy completion once every quiz chapter is passed', async () => {
+    const otherChapterId = randomUUID();
+    chapterRepository.findQuizEnabledIds.mockResolvedValue([
+      chapter.id,
+      otherChapterId,
+    ]);
+    const pool = makePool(chapter.id, 10);
+    quizQuestionRepository.findAllByChapter.mockResolvedValue(pool);
+    progressRepository.findAllByUser.mockResolvedValue([
+      new AcademyChapterProgress({
+        userId,
+        chapterId: chapter.id,
+        passedAt: new Date(),
+        lastScore: 100,
+        lastAttemptAt: new Date(),
+      }),
+      new AcademyChapterProgress({
+        userId,
+        chapterId: otherChapterId,
+        passedAt: new Date(),
+        lastScore: 100,
+        lastAttemptAt: new Date(),
+      }),
+    ]);
+
+    const result = await submit(answersFor(pool, 10));
+
+    expect(result.academyCompleted).toBe(true);
+    expect(completionRepository.upsert).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects a submission with fewer answers than drawn', async () => {
+    const pool = makePool(chapter.id, 10);
+    quizQuestionRepository.findAllByChapter.mockResolvedValue(pool);
+
+    await expect(submit(answersFor(pool, 10).slice(0, 3))).rejects.toThrow(
+      InvalidQuizSubmissionError,
+    );
+    expect(progressRepository.upsert).not.toHaveBeenCalled();
+  });
+
+  it('rejects an answer referencing a question outside the chapter pool', async () => {
+    const pool = makePool(chapter.id, 10);
+    quizQuestionRepository.findAllByChapter.mockResolvedValue(pool);
+    const answers = answersFor(pool, 10);
+    answers[0] = { questionId: randomUUID(), selectedOptionIndex: 0 };
+
+    await expect(submit(answers)).rejects.toThrow(InvalidQuizSubmissionError);
+    expect(progressRepository.upsert).not.toHaveBeenCalled();
+  });
+
+  it('rejects a submission when the chapter has no questions', async () => {
+    quizQuestionRepository.findAllByChapter.mockResolvedValue([]);
+
+    await expect(submit([])).rejects.toThrow(QuizNotAvailableError);
+    await expect(submit([])).rejects.toThrow(
+      `No quiz is available for chapter ${chapter.id}`,
+    );
+    expect(progressRepository.upsert).not.toHaveBeenCalled();
+  });
+});

--- a/ayunis-core-backend/src/domain/academy/application/use-cases/submit-chapter-quiz/submit-chapter-quiz.use-case.ts
+++ b/ayunis-core-backend/src/domain/academy/application/use-cases/submit-chapter-quiz/submit-chapter-quiz.use-case.ts
@@ -1,0 +1,189 @@
+import { Injectable, Logger } from '@nestjs/common';
+import type { UUID } from 'crypto';
+import { ApplicationError } from 'src/common/errors/base.error';
+import { AcademyChapterRepository } from '../../ports/academy-chapter.repository';
+import { AcademyChapterProgressRepository } from '../../ports/academy-chapter-progress.repository';
+import { AcademyCompletionRepository } from '../../ports/academy-completion.repository';
+import { AcademyQuizQuestionRepository } from '../../ports/academy-quiz-question.repository';
+import { AcademyChapter } from '../../../domain/academy-chapter.entity';
+import { AcademyChapterProgress } from '../../../domain/academy-chapter-progress.entity';
+import { AcademyCompletion } from '../../../domain/academy-completion.entity';
+import { AcademyQuizQuestion } from '../../../domain/academy-quiz-question.entity';
+import {
+  ChapterNotFoundError,
+  InvalidQuizSubmissionError,
+  QuizNotAvailableError,
+  UnexpectedAcademyError,
+} from '../../academy.errors';
+import { DRAWN_QUESTION_COUNT, requiredCorrect } from '../../quiz.constants';
+import {
+  QuizAnswerSubmission,
+  SubmitChapterQuizCommand,
+} from './submit-chapter-quiz.command';
+
+export interface QuizAttemptResult {
+  readonly passed: boolean;
+  readonly correctCount: number;
+  readonly totalCount: number;
+  readonly requiredCount: number;
+  readonly score: number;
+  readonly academyCompleted: boolean;
+}
+
+@Injectable()
+export class SubmitChapterQuizUseCase {
+  private readonly logger = new Logger(SubmitChapterQuizUseCase.name);
+
+  constructor(
+    private readonly chapterRepository: AcademyChapterRepository,
+    private readonly quizQuestionRepository: AcademyQuizQuestionRepository,
+    private readonly progressRepository: AcademyChapterProgressRepository,
+    private readonly completionRepository: AcademyCompletionRepository,
+  ) {}
+
+  async execute(command: SubmitChapterQuizCommand): Promise<QuizAttemptResult> {
+    this.logger.log('Submitting chapter quiz', {
+      userId: command.userId,
+      chapterId: command.chapterId,
+    });
+    try {
+      const chapter = await this.loadQuizChapter(command.chapterId);
+      const pool = await this.quizQuestionRepository.findAllByChapter(
+        command.chapterId,
+      );
+      if (pool.length === 0) {
+        throw new QuizNotAvailableError(command.chapterId);
+      }
+      const grade = this.grade(pool, command.answers, chapter.passThreshold);
+      await this.persistProgress(command, grade);
+      const academyCompleted = grade.passed
+        ? await this.recomputeCompletion(command.userId)
+        : false;
+      return { ...grade, academyCompleted };
+    } catch (error) {
+      if (error instanceof ApplicationError) throw error;
+      this.logger.error('Error submitting chapter quiz', {
+        error: error as Error,
+      });
+      throw new UnexpectedAcademyError(error);
+    }
+  }
+
+  private async loadQuizChapter(chapterId: UUID): Promise<AcademyChapter> {
+    const chapter = await this.chapterRepository.findOne(chapterId);
+    if (!chapter) {
+      throw new ChapterNotFoundError(chapterId);
+    }
+    if (!chapter.quizEnabled) {
+      throw new QuizNotAvailableError(chapterId);
+    }
+    return chapter;
+  }
+
+  private grade(
+    pool: AcademyQuizQuestion[],
+    answers: QuizAnswerSubmission[],
+    thresholdPct: number,
+  ): Omit<QuizAttemptResult, 'academyCompleted'> {
+    const expectedCount = Math.min(DRAWN_QUESTION_COUNT, pool.length);
+    this.assertAnswerShape(answers, expectedCount);
+    const byId = new Map(pool.map((question) => [question.id, question]));
+    let correctCount = 0;
+    for (const answer of answers) {
+      if (this.isAnswerCorrect(byId, answer)) correctCount++;
+    }
+    const totalCount = answers.length;
+    const requiredCount = requiredCorrect(totalCount, thresholdPct);
+    return {
+      correctCount,
+      totalCount,
+      requiredCount,
+      passed: correctCount >= requiredCount,
+      score: Math.round((correctCount / totalCount) * 100),
+    };
+  }
+
+  private assertAnswerShape(
+    answers: QuizAnswerSubmission[],
+    expectedCount: number,
+  ): void {
+    if (answers.length !== expectedCount) {
+      throw new InvalidQuizSubmissionError(
+        `Expected exactly ${expectedCount} answers, received ${answers.length}`,
+      );
+    }
+    const uniqueIds = new Set(answers.map((answer) => answer.questionId));
+    if (uniqueIds.size !== answers.length) {
+      throw new InvalidQuizSubmissionError('Duplicate questions in submission');
+    }
+  }
+
+  private isAnswerCorrect(
+    byId: Map<UUID, AcademyQuizQuestion>,
+    answer: QuizAnswerSubmission,
+  ): boolean {
+    const question = byId.get(answer.questionId);
+    if (!question) {
+      throw new InvalidQuizSubmissionError(
+        `Question ${answer.questionId} is not part of this chapter quiz`,
+      );
+    }
+    const { selectedOptionIndex } = answer;
+    if (
+      selectedOptionIndex < 0 ||
+      selectedOptionIndex >= question.options.length
+    ) {
+      throw new InvalidQuizSubmissionError(
+        `Invalid option index for question ${answer.questionId}`,
+      );
+    }
+    return question.options[selectedOptionIndex].isCorrect;
+  }
+
+  private async persistProgress(
+    command: SubmitChapterQuizCommand,
+    grade: Omit<QuizAttemptResult, 'academyCompleted'>,
+  ): Promise<void> {
+    const now = new Date();
+    const existing = await this.progressRepository.findByUserAndChapter(
+      command.userId,
+      command.chapterId,
+    );
+    await this.progressRepository.upsert(
+      new AcademyChapterProgress({
+        id: existing?.id,
+        userId: command.userId,
+        chapterId: command.chapterId,
+        // Keep a previous pass on a later failure — passing is not undone.
+        passedAt: grade.passed ? now : (existing?.passedAt ?? null),
+        lastScore: grade.score,
+        lastAttemptAt: now,
+        createdAt: existing?.createdAt,
+      }),
+    );
+  }
+
+  // Stamp/refresh the single whole-academy completion snapshot when every
+  // currently quiz-enabled chapter has a passing progress row.
+  private async recomputeCompletion(userId: UUID): Promise<boolean> {
+    const quizEnabledIds = await this.chapterRepository.findQuizEnabledIds();
+    const progress = await this.progressRepository.findAllByUser(userId);
+    const passedIds = new Set(
+      progress.filter((p) => p.passed).map((p) => p.chapterId),
+    );
+    const completed =
+      quizEnabledIds.length > 0 &&
+      quizEnabledIds.every((id) => passedIds.has(id));
+    if (!completed) return false;
+    const existing = await this.completionRepository.findByUser(userId);
+    await this.completionRepository.upsert(
+      new AcademyCompletion({
+        id: existing?.id,
+        userId,
+        completedAt: new Date(),
+        createdAt: existing?.createdAt,
+      }),
+    );
+    return true;
+  }
+}

--- a/ayunis-core-backend/src/domain/academy/infrastructure/persistence/local/local-academy-chapter.repository.ts
+++ b/ayunis-core-backend/src/domain/academy/infrastructure/persistence/local/local-academy-chapter.repository.ts
@@ -64,6 +64,15 @@ export class LocalAcademyChapterRepository implements AcademyChapterRepository {
     return records.map((record) => record.id);
   }
 
+  async findQuizEnabledIds(): Promise<UUID[]> {
+    this.logger.log('findQuizEnabledIds');
+    const records = await this.repository.find({
+      where: { quizEnabled: true },
+      select: { id: true },
+    });
+    return records.map((record) => record.id);
+  }
+
   async findMaxPosition(): Promise<number | null> {
     this.logger.log('findMaxPosition');
     return this.repository.maximum('position');


### PR DESCRIPTION
Add GetChapterQuiz (draws up to 10 random questions, whole pool when smaller), SubmitChapterQuiz (grades against the per-chapter threshold, enforces the drawn answer count, upserts per-chapter progress and stamps the whole-academy completion snapshot when every quiz-enabled chapter is passed) and GetAcademyProgress use cases. Add QUIZ_NOT_AVAILABLE and INVALID_QUIZ_SUBMISSION errors, findQuizEnabledIds on the chapter repository, and unit specs covering grading boundaries, small pools, progress upsert and completion stamping.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Submit flow writes user progress and academy completion with non-trivial grading rules; behavior is well covered by unit tests but there are no HTTP endpoints in this diff yet.
> 
> **Overview**
> Adds **learner-facing academy quiz flow** in the application layer: fetch a chapter quiz, submit answers, and read per-user progress.
> 
> **GetChapterQuiz** returns up to 10 randomly shuffled questions from the chapter pool (or the full pool when smaller), and rejects missing chapters, disabled quizzes, or empty pools via new **`QUIZ_NOT_AVAILABLE`** errors.
> 
> **SubmitChapterQuiz** grades submissions against the chapter **`passThreshold`** (using **`requiredCorrect`** for scaled pass counts), validates answer shape (exact drawn count, no duplicates, in-pool option indices), upserts **chapter progress** (a pass is **not** revoked on later failures), and when every **quiz-enabled** chapter is passed, upserts the **whole-academy completion** snapshot. Invalid payloads use **`INVALID_QUIZ_SUBMISSION`**.
> 
> **GetAcademyProgress** exposes per-chapter pass/score timestamps plus **`academyCompletedAt`**.
> 
> Wiring: three use cases registered in **`AcademyModule`** with **`GetAcademyProgressUseCase`** and **`SubmitChapterQuizUseCase`** exported; **`findQuizEnabledIds`** added on the chapter repository port and local TypeORM implementation. Unit specs cover grading boundaries, completion stamping, and quiz draw behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5dee5c896eb19ea5a2e339673cc10835482bd5a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->