### PR TITLE
wip(academy): add learner quiz-taking and progress endpoints (AYC-245)

### DIFF
--- a/ayunis-core-backend/src/domain/academy/SUMMARY.md
+++ b/ayunis-core-backend/src/domain/academy/SUMMARY.md
@@ -1,16 +1,39 @@
 # Academy
 
 Platform-global learning content for the **Ayunis Core Academy** add-on
-(`AddonType.AYUNIS_CORE_ACADEMY`): chapters containing video courseModules, authored
-centrally by super admins. There is no org or user-facing surface yet — read
-access gated by the org's add-on activation is a follow-up.
+(`AddonType.AYUNIS_CORE_ACADEMY`): chapters containing video courseModules and
+per-chapter quizzes, authored centrally by super admins. Learners in orgs with
+the add-on active read the content, take quizzes, and accumulate per-chapter
+and whole-academy completion.
 
 ## Model
 
-- `AcademyChapter` — `{ id, title, description, position, courseModules[] }`.
+- `AcademyChapter` — `{ id, title, description, position, quizEnabled,
+  passThreshold, courseModules[] }`. `passThreshold` is the percent of asked
+  questions that must be answered correctly (default 80).
 - `AcademyCourseModule` — `{ id, chapterId, title, description?, loomUrl, position }`,
   cascade-deleted with its chapter. `loomUrl` is a validated Loom share/embed
   link (`https://loom.com/(share|embed)/...`).
+- `AcademyQuizQuestion` — `{ id, chapterId, text, position, options[] }`, the
+  chapter's question pool; each option carries `text` + `isCorrect`,
+  cascade-deleted with its chapter.
+- `AcademyChapterProgress` — one row per `(user, chapter)`, upserted on every
+  attempt. `passedAt` is the most recent passing attempt and is never cleared
+  by a later failing attempt; `lastScore`/`lastAttemptAt` track the latest try.
+- `AcademyCompletion` — one row per user; `completedAt` is stamped/refreshed
+  when every currently quiz-enabled chapter is passed and is never revoked by
+  later content changes.
+
+## Quiz mechanics
+
+- A quiz attempt draws `DRAWN_QUESTION_COUNT` (10) random questions from the
+  chapter pool (the whole pool if smaller). Correct answers never leave the
+  server.
+- Submit validates the answer set (exact expected count, no duplicates, all
+  ids from the chapter pool — the drawn set itself is not persisted), grades
+  against the chapter's `passThreshold` (`requiredCorrect` rounds up, e.g.
+  80% of 7 → 6), upserts chapter progress, and on a pass recomputes the
+  whole-academy completion snapshot.
 
 ## Ordering
 
@@ -26,21 +49,40 @@ and are freely sortable:
 - Concurrent reorders are last-write-wins (acceptable for a super-admin-only
   surface).
 
+Quiz questions also carry an append-only `position` (no reorder surface).
+
+## Learner surface
+
+Authenticated users in an org with the academy add-on active
+(`@RequireAddon(AYUNIS_CORE_ACADEMY)`), two controllers under `academy`:
+
+- `AcademyChaptersController` (`academy/chapters`) — list chapters with nested
+  ordered courseModules.
+- `AcademyQuizController` (`academy`) — draw a quiz
+  (`GET chapters/:chapterId/quiz`), submit answers
+  (`POST chapters/:chapterId/quiz/submit`), and read progress
+  (`GET progress`: per-chapter pass state + `academyCompletedAt`).
+
 ## Management
 
-Super-admin only (`@SystemRoles(SUPER_ADMIN)`), two controllers under
+Super-admin only (`@SystemRoles(SUPER_ADMIN)`), three controllers under
 `super-admin/academy`:
 
 - `SuperAdminAcademyChaptersController` (`super-admin/academy/chapters`) —
-  list (chapters with nested ordered courseModules), create, update, delete,
-  reorder (`PUT chapters/order`, declared before the `:id` routes).
+  list (chapters with nested ordered courseModules), create, update (incl.
+  `quizEnabled`/`passThreshold`), delete, reorder (`PUT chapters/order`,
+  declared before the `:id` routes).
 - `SuperAdminAcademyCourseModulesController` (`super-admin/academy`) — create
   (`POST chapters/:chapterId/course-modules`), reorder
   (`PUT chapters/:chapterId/course-modules/order`), update/delete (`course-modules/:id`).
+- `SuperAdminAcademyQuizQuestionsController` (`super-admin/academy`) — create
+  (`POST chapters/:chapterId/quiz-questions`), update/delete
+  (`quiz-questions/:id`).
 
 ## Layout
 
-Standard hexagonal: `domain/` (chapter + courseModule entities), `application/`
-(repository ports, use-cases, errors, reorder validation), `infrastructure/`
-(Postgres records + mapper + repositories), `presenters/http/` (super-admin
-controllers + DTOs + response mapper).
+Standard hexagonal: `domain/` (chapter, courseModule, quiz question, progress
+and completion entities), `application/` (repository ports, use-cases, quiz
+constants, errors, reorder validation), `infrastructure/` (Postgres records +
+mapper + repositories), `presenters/http/` (learner + super-admin controllers,
+DTOs, response mapper).

--- a/ayunis-core-backend/src/domain/academy/academy.module.ts
+++ b/ayunis-core-backend/src/domain/academy/academy.module.ts
@@ -36,6 +36,7 @@ import { SuperAdminAcademyChaptersController } from './presenters/http/super-adm
 import { SuperAdminAcademyCourseModulesController } from './presenters/http/super-admin-academy-course-modules.controller';
 import { SuperAdminAcademyQuizQuestionsController } from './presenters/http/super-admin-academy-quiz-questions.controller';
 import { AcademyChaptersController } from './presenters/http/academy-chapters.controller';
+import { AcademyQuizController } from './presenters/http/academy-quiz.controller';
 import { AcademyResponseDtoMapper } from './presenters/http/mappers/academy-response-dto.mapper';
 
 @Module({
@@ -50,6 +51,7 @@ import { AcademyResponseDtoMapper } from './presenters/http/mappers/academy-resp
   ],
   controllers: [
     AcademyChaptersController,
+    AcademyQuizController,
     SuperAdminAcademyChaptersController,
     SuperAdminAcademyCourseModulesController,
     SuperAdminAcademyQuizQuestionsController,

--- a/ayunis-core-backend/src/domain/academy/presenters/http/academy-quiz.controller.ts
+++ b/ayunis-core-backend/src/domain/academy/presenters/http/academy-quiz.controller.ts
@@ -1,0 +1,121 @@
+import {
+  Body,
+  Controller,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Logger,
+  Param,
+  ParseUUIDPipe,
+  Post,
+} from '@nestjs/common';
+import type { UUID } from 'crypto';
+import {
+  ApiInternalServerErrorResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiParam,
+  ApiTags,
+  ApiUnauthorizedResponse,
+} from '@nestjs/swagger';
+import { RequireAddon } from 'src/iam/authorization/application/decorators/addon.decorator';
+import { AddonType } from 'src/iam/addons/domain/value-objects/addon-type.enum';
+import {
+  CurrentUser,
+  UserProperty,
+} from 'src/iam/authentication/application/decorators/current-user.decorator';
+import { GetChapterQuizUseCase } from '../../application/use-cases/get-chapter-quiz/get-chapter-quiz.use-case';
+import { GetChapterQuizQuery } from '../../application/use-cases/get-chapter-quiz/get-chapter-quiz.query';
+import { SubmitChapterQuizUseCase } from '../../application/use-cases/submit-chapter-quiz/submit-chapter-quiz.use-case';
+import { SubmitChapterQuizCommand } from '../../application/use-cases/submit-chapter-quiz/submit-chapter-quiz.command';
+import { GetAcademyProgressUseCase } from '../../application/use-cases/get-academy-progress/get-academy-progress.use-case';
+import { GetAcademyProgressQuery } from '../../application/use-cases/get-academy-progress/get-academy-progress.query';
+import { QuizQuestionForTakingResponseDto } from './dto/quiz-question-for-taking-response.dto';
+import { SubmitQuizRequestDto } from './dto/submit-quiz-request.dto';
+import { QuizResultResponseDto } from './dto/quiz-result-response.dto';
+import { AcademyProgressResponseDto } from './dto/academy-progress-response.dto';
+import { AcademyResponseDtoMapper } from './mappers/academy-response-dto.mapper';
+
+@ApiTags('Academy')
+@Controller('academy')
+@RequireAddon(AddonType.AYUNIS_CORE_ACADEMY)
+export class AcademyQuizController {
+  private readonly logger = new Logger(AcademyQuizController.name);
+
+  constructor(
+    private readonly getChapterQuizUseCase: GetChapterQuizUseCase,
+    private readonly submitChapterQuizUseCase: SubmitChapterQuizUseCase,
+    private readonly getAcademyProgressUseCase: GetAcademyProgressUseCase,
+    private readonly responseMapper: AcademyResponseDtoMapper,
+  ) {}
+
+  @Get('chapters/:chapterId/quiz')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Get a chapter quiz',
+    description:
+      'Draw up to 10 random questions from the chapter pool (the whole pool if smaller). Correct answers are never included.',
+  })
+  @ApiParam({ name: 'chapterId', description: 'Chapter ID', format: 'uuid' })
+  @ApiOkResponse({ type: [QuizQuestionForTakingResponseDto] })
+  @ApiUnauthorizedResponse({
+    description: 'User not authenticated or academy add-on not active',
+  })
+  @ApiInternalServerErrorResponse({ description: 'Internal server error' })
+  async getChapterQuiz(
+    @Param('chapterId', ParseUUIDPipe) chapterId: UUID,
+  ): Promise<QuizQuestionForTakingResponseDto[]> {
+    this.logger.log(`Getting quiz for chapter ${chapterId}`);
+    const questions = await this.getChapterQuizUseCase.execute(
+      new GetChapterQuizQuery({ chapterId }),
+    );
+    return this.responseMapper.quizForTakingToDtoArray(questions);
+  }
+
+  @Post('chapters/:chapterId/quiz/submit')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Submit a chapter quiz',
+    description:
+      'Grade a quiz submission against the chapter pass threshold, record progress and, when the whole academy is passed, stamp completion. Unlimited retries.',
+  })
+  @ApiParam({ name: 'chapterId', description: 'Chapter ID', format: 'uuid' })
+  @ApiOkResponse({ type: QuizResultResponseDto })
+  @ApiUnauthorizedResponse({
+    description: 'User not authenticated or academy add-on not active',
+  })
+  @ApiInternalServerErrorResponse({ description: 'Internal server error' })
+  async submitChapterQuiz(
+    @Param('chapterId', ParseUUIDPipe) chapterId: UUID,
+    @Body() dto: SubmitQuizRequestDto,
+    @CurrentUser(UserProperty.ID) userId: UUID,
+  ): Promise<QuizResultResponseDto> {
+    this.logger.log(`Submitting quiz for chapter ${chapterId}`);
+    const result = await this.submitChapterQuizUseCase.execute(
+      new SubmitChapterQuizCommand({ userId, chapterId, answers: dto.answers }),
+    );
+    return this.responseMapper.quizResultToDto(result);
+  }
+
+  @Get('progress')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Get academy progress',
+    description:
+      'Get the current user per-chapter pass state and the whole-academy completion date.',
+  })
+  @ApiOkResponse({ type: AcademyProgressResponseDto })
+  @ApiUnauthorizedResponse({
+    description: 'User not authenticated or academy add-on not active',
+  })
+  @ApiInternalServerErrorResponse({ description: 'Internal server error' })
+  async getProgress(
+    @CurrentUser(UserProperty.ID) userId: UUID,
+  ): Promise<AcademyProgressResponseDto> {
+    this.logger.log('Getting academy progress');
+    const progress = await this.getAcademyProgressUseCase.execute(
+      new GetAcademyProgressQuery({ userId }),
+    );
+    return this.responseMapper.progressToDto(progress);
+  }
+}

--- a/ayunis-core-backend/src/domain/academy/presenters/http/dto/academy-progress-response.dto.ts
+++ b/ayunis-core-backend/src/domain/academy/presenters/http/dto/academy-progress-response.dto.ts
@@ -1,0 +1,49 @@
+import { ApiProperty } from '@nestjs/swagger';
+import type { UUID } from 'crypto';
+
+export class ChapterProgressResponseDto {
+  @ApiProperty({
+    type: 'string',
+    format: 'uuid',
+    description: 'The chapter this progress refers to',
+  })
+  chapterId: UUID;
+
+  @ApiProperty({
+    type: 'boolean',
+    description: 'Whether the learner has passed this chapter quiz',
+  })
+  passed: boolean;
+
+  @ApiProperty({
+    type: 'integer',
+    description: 'Score of the most recent attempt, as a percentage',
+    example: 80,
+  })
+  lastScore: number;
+
+  @ApiProperty({
+    type: 'string',
+    format: 'date-time',
+    nullable: true,
+    description: 'When the chapter was most recently passed, if ever',
+  })
+  lastPassedAt: Date | null;
+}
+
+export class AcademyProgressResponseDto {
+  @ApiProperty({
+    type: [ChapterProgressResponseDto],
+    description: 'Per-chapter progress for the current user',
+  })
+  chapters: ChapterProgressResponseDto[];
+
+  @ApiProperty({
+    type: 'string',
+    format: 'date-time',
+    nullable: true,
+    description:
+      'When the user last completed the whole academy, or null if never',
+  })
+  academyCompletedAt: Date | null;
+}

--- a/ayunis-core-backend/src/domain/academy/presenters/http/dto/quiz-question-for-taking-response.dto.ts
+++ b/ayunis-core-backend/src/domain/academy/presenters/http/dto/quiz-question-for-taking-response.dto.ts
@@ -1,0 +1,37 @@
+import { ApiProperty } from '@nestjs/swagger';
+import type { UUID } from 'crypto';
+
+/**
+ * A quiz answer option as shown to a learner taking the quiz. It deliberately
+ * omits `isCorrect` — correct answers are never sent to the client.
+ */
+export class QuizAnswerOptionForTakingResponseDto {
+  @ApiProperty({
+    type: 'string',
+    description: 'The answer option text',
+    example: 'A large language model',
+  })
+  text: string;
+}
+
+export class QuizQuestionForTakingResponseDto {
+  @ApiProperty({
+    type: 'string',
+    format: 'uuid',
+    description: 'The unique identifier of the question',
+  })
+  id: UUID;
+
+  @ApiProperty({
+    type: 'string',
+    description: 'The question prompt',
+    example: 'What is an LLM?',
+  })
+  text: string;
+
+  @ApiProperty({
+    type: [QuizAnswerOptionForTakingResponseDto],
+    description: 'The answer options, without indicating the correct one',
+  })
+  options: QuizAnswerOptionForTakingResponseDto[];
+}

--- a/ayunis-core-backend/src/domain/academy/presenters/http/dto/quiz-result-response.dto.ts
+++ b/ayunis-core-backend/src/domain/academy/presenters/http/dto/quiz-result-response.dto.ts
@@ -1,0 +1,44 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class QuizResultResponseDto {
+  @ApiProperty({
+    type: 'boolean',
+    description: 'Whether the attempt met the chapter pass threshold',
+  })
+  passed: boolean;
+
+  @ApiProperty({
+    type: 'integer',
+    description: 'Number of questions answered correctly',
+    example: 8,
+  })
+  correctCount: number;
+
+  @ApiProperty({
+    type: 'integer',
+    description: 'Number of questions in the attempt',
+    example: 10,
+  })
+  totalCount: number;
+
+  @ApiProperty({
+    type: 'integer',
+    description: 'Number of correct answers required to pass',
+    example: 8,
+  })
+  requiredCount: number;
+
+  @ApiProperty({
+    type: 'integer',
+    description: 'Score as a percentage of correct answers',
+    example: 80,
+  })
+  score: number;
+
+  @ApiProperty({
+    type: 'boolean',
+    description:
+      'Whether passing this chapter completed the whole academy for the user',
+  })
+  academyCompleted: boolean;
+}

--- a/ayunis-core-backend/src/domain/academy/presenters/http/dto/submit-quiz-request.dto.ts
+++ b/ayunis-core-backend/src/domain/academy/presenters/http/dto/submit-quiz-request.dto.ts
@@ -1,0 +1,42 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import type { UUID } from 'crypto';
+import {
+  ArrayMinSize,
+  IsArray,
+  IsInt,
+  IsUUID,
+  Min,
+  ValidateNested,
+} from 'class-validator';
+
+export class SubmitQuizAnswerDto {
+  @ApiProperty({
+    type: 'string',
+    format: 'uuid',
+    description: 'The id of the answered question',
+  })
+  @IsUUID()
+  questionId: UUID;
+
+  @ApiProperty({
+    type: 'integer',
+    description: 'The 0-based index of the selected answer option',
+    example: 0,
+  })
+  @IsInt()
+  @Min(0)
+  selectedOptionIndex: number;
+}
+
+export class SubmitQuizRequestDto {
+  @ApiProperty({
+    type: [SubmitQuizAnswerDto],
+    description: 'One answer per drawn question',
+  })
+  @IsArray()
+  @ArrayMinSize(1)
+  @ValidateNested({ each: true })
+  @Type(() => SubmitQuizAnswerDto)
+  answers: SubmitQuizAnswerDto[];
+}

--- a/ayunis-core-backend/src/domain/academy/presenters/http/mappers/academy-response-dto.mapper.ts
+++ b/ayunis-core-backend/src/domain/academy/presenters/http/mappers/academy-response-dto.mapper.ts
@@ -2,6 +2,8 @@ import { Injectable } from '@nestjs/common';
 import type { AcademyChapter } from '../../../domain/academy-chapter.entity';
 import type { AcademyCourseModule } from '../../../domain/academy-course-module.entity';
 import type { AcademyQuizQuestion } from '../../../domain/academy-quiz-question.entity';
+import type { QuizAttemptResult } from '../../../application/use-cases/submit-chapter-quiz/submit-chapter-quiz.use-case';
+import type { AcademyProgressView } from '../../../application/use-cases/get-academy-progress/get-academy-progress.use-case';
 import { AcademyChapterResponseDto } from '../dto/academy-chapter-response.dto';
 import { CourseModuleResponseDto } from '../dto/course-module-response.dto';
 import { SuperAdminAcademyChapterResponseDto } from '../dto/super-admin-academy-chapter-response.dto';
@@ -9,6 +11,15 @@ import {
   QuizAnswerOptionResponseDto,
   QuizQuestionResponseDto,
 } from '../dto/quiz-question-response.dto';
+import {
+  QuizAnswerOptionForTakingResponseDto,
+  QuizQuestionForTakingResponseDto,
+} from '../dto/quiz-question-for-taking-response.dto';
+import { QuizResultResponseDto } from '../dto/quiz-result-response.dto';
+import {
+  AcademyProgressResponseDto,
+  ChapterProgressResponseDto,
+} from '../dto/academy-progress-response.dto';
 
 @Injectable()
 export class AcademyResponseDtoMapper {
@@ -70,6 +81,48 @@ export class AcademyResponseDtoMapper {
     dto.position = entity.position;
     dto.createdAt = entity.createdAt;
     dto.updatedAt = entity.updatedAt;
+    return dto;
+  }
+
+  // Strips `isCorrect` — the learner-facing quiz never exposes correct answers.
+  quizForTakingToDtoArray(
+    entities: AcademyQuizQuestion[],
+  ): QuizQuestionForTakingResponseDto[] {
+    return entities.map((entity) => {
+      const dto = new QuizQuestionForTakingResponseDto();
+      dto.id = entity.id;
+      dto.text = entity.text;
+      dto.options = entity.options.map((option) => {
+        const optionDto = new QuizAnswerOptionForTakingResponseDto();
+        optionDto.text = option.text;
+        return optionDto;
+      });
+      return dto;
+    });
+  }
+
+  quizResultToDto(result: QuizAttemptResult): QuizResultResponseDto {
+    const dto = new QuizResultResponseDto();
+    dto.passed = result.passed;
+    dto.correctCount = result.correctCount;
+    dto.totalCount = result.totalCount;
+    dto.requiredCount = result.requiredCount;
+    dto.score = result.score;
+    dto.academyCompleted = result.academyCompleted;
+    return dto;
+  }
+
+  progressToDto(view: AcademyProgressView): AcademyProgressResponseDto {
+    const dto = new AcademyProgressResponseDto();
+    dto.chapters = view.chapters.map((chapter) => {
+      const chapterDto = new ChapterProgressResponseDto();
+      chapterDto.chapterId = chapter.chapterId;
+      chapterDto.passed = chapter.passed;
+      chapterDto.lastScore = chapter.lastScore;
+      chapterDto.lastPassedAt = chapter.lastPassedAt;
+      return chapterDto;
+    });
+    dto.academyCompletedAt = view.academyCompletedAt;
     return dto;
   }
 


### PR DESCRIPTION
Add AcademyQuizController (add-on gated) exposing GET chapters/:id/quiz (drawn questions without correct answers), POST chapters/:id/quiz/submit (grades, records progress, returns pass result) and GET progress (per-chapter pass state plus whole-academy completion date). Add the request/response DTOs and mapper methods, with the learner quiz DTO deliberately omitting isCorrect.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New authenticated endpoints persist quiz progress and completion; grading stays server-side and learner responses omit answer keys, but submit validation depends on existing use-case rules.
> 
> **Overview**
> Exposes the **learner-facing Academy quiz API** for orgs with the academy add-on: draw a chapter quiz, submit answers for grading/progress, and read overall progress.
> 
> A new **`AcademyQuizController`** (same `@RequireAddon(AYUNIS_CORE_ACADEMY)` pattern as chapter listing) wires three routes to existing use cases: **`GET academy/chapters/:chapterId/quiz`** returns a random draw of questions with options only (no `isCorrect`), **`POST academy/chapters/:chapterId/quiz/submit`** accepts per-question option indices for the authenticated user and returns pass/score plus whether the whole academy was completed, and **`GET academy/progress`** returns per-chapter pass state and `academyCompletedAt`.
> 
> Adds Swagger DTOs for those payloads, extends **`AcademyResponseDtoMapper`** with learner-safe mapping (`quizForTakingToDtoArray` strips correct flags), registers the controller in **`academy.module.ts`**, and updates **`SUMMARY.md`** to document the learner surface and quiz/progress model.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit edbb17f9d5493d71448cbc38186ad247955b1a4f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->