### PR TITLE
wip(academy): regenerate API client for quiz endpoints (AYC-245)

### DIFF
--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
@@ -4232,12 +4232,79 @@ export interface AcademyChapterResponseDto {
   position: number;
   /** Whether a quiz is activated for this chapter (shown at chapter end) */
   quizEnabled: boolean;
+  /** Percentage of correct answers required to pass this chapter quiz */
+  passThreshold: number;
   /** The modules of the chapter, ordered by position */
   courseModules: CourseModuleResponseDto[];
   /** The date the chapter was created */
   createdAt: string;
   /** The date the chapter was last updated */
   updatedAt: string;
+}
+
+export interface QuizAnswerOptionForTakingResponseDto {
+  /** The answer option text */
+  text: string;
+}
+
+export interface QuizQuestionForTakingResponseDto {
+  /** The unique identifier of the question */
+  id: string;
+  /** The question prompt */
+  text: string;
+  /** The answer options, without indicating the correct one */
+  options: QuizAnswerOptionForTakingResponseDto[];
+}
+
+export interface SubmitQuizAnswerDto {
+  /** The id of the answered question */
+  questionId: string;
+  /** The 0-based index of the selected answer option */
+  selectedOptionIndex: number;
+}
+
+export interface SubmitQuizRequestDto {
+  /** One answer per drawn question */
+  answers: SubmitQuizAnswerDto[];
+}
+
+export interface QuizResultResponseDto {
+  /** Whether the attempt met the chapter pass threshold */
+  passed: boolean;
+  /** Number of questions answered correctly */
+  correctCount: number;
+  /** Number of questions in the attempt */
+  totalCount: number;
+  /** Number of correct answers required to pass */
+  requiredCount: number;
+  /** Score as a percentage of correct answers */
+  score: number;
+  /** Whether passing this chapter completed the whole academy for the user */
+  academyCompleted: boolean;
+}
+
+export interface ChapterProgressResponseDto {
+  /** The chapter this progress refers to */
+  chapterId: string;
+  /** Whether the learner has passed this chapter quiz */
+  passed: boolean;
+  /** Score of the most recent attempt, as a percentage */
+  lastScore: number;
+  /**
+   * When the chapter was most recently passed, if ever
+   * @nullable
+   */
+  lastPassedAt: string | null;
+}
+
+export interface AcademyProgressResponseDto {
+  /** Per-chapter progress for the current user */
+  chapters: ChapterProgressResponseDto[];
+  /**
+   * When the user last completed the whole academy, or null if never
+   * @nullable
+   */
+  academyCompletedAt: string | null;
 }
 
 export interface QuizAnswerOptionResponseDto {
@@ -4275,6 +4342,8 @@ export interface SuperAdminAcademyChapterResponseDto {
   position: number;
   /** Whether a quiz is activated for this chapter (shown at chapter end) */
   quizEnabled: boolean;
+  /** Percentage of correct answers required to pass this chapter quiz */
+  passThreshold: number;
   /** The modules of the chapter, ordered by position */
   courseModules: CourseModuleResponseDto[];
   /** The date the chapter was created */
@@ -4316,6 +4385,12 @@ export interface UpdateChapterRequestDto {
   description: string;
   /** Whether a quiz is activated for this chapter */
   quizEnabled?: boolean;
+  /**
+   * Percentage of correct answers required to pass this chapter quiz
+   * @minimum 1
+   * @maximum 100
+   */
+  passThreshold?: number;
 }
 
 export interface CreateCourseModuleRequestDto {

--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.ts
@@ -26,6 +26,7 @@ import type {
 
 import type {
   AcademyChapterResponseDto,
+  AcademyProgressResponseDto,
   AcceptInviteDto,
   AcceptInviteResponseDto,
   ActiveSubscriptionResponseDto,
@@ -125,7 +126,9 @@ import type {
   PromoteToSuperAdminDto,
   ProviderUsageChartResponseDto,
   ProviderUsageResponseDto,
+  QuizQuestionForTakingResponseDto,
   QuizQuestionResponseDto,
+  QuizResultResponseDto,
   RegisterDto,
   ReorderChaptersRequestDto,
   ReorderCourseModulesRequestDto,
@@ -151,6 +154,7 @@ import type {
   SkillSourcesControllerAddFileSourceBody,
   SkillTemplateResponseDto,
   StorageControllerUploadFileBody,
+  SubmitQuizRequestDto,
   SubscriptionResponseDto,
   SubscriptionResponseDtoNullable,
   SuccessResponseDto,
@@ -17587,6 +17591,261 @@ export function useAcademyChaptersControllerGetChapters<TData = Awaited<ReturnTy
  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
 
   const queryOptions = getAcademyChaptersControllerGetChaptersQueryOptions(options)
+
+  const query = useQuery(queryOptions, queryClient) as  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+
+  query.queryKey = queryOptions.queryKey ;
+
+  return query;
+}
+
+
+
+
+
+/**
+ * Draw up to 10 random questions from the chapter pool (the whole pool if smaller). Correct answers are never included.
+ * @summary Get a chapter quiz
+ */
+export const academyQuizControllerGetChapterQuiz = (
+    chapterId: string,
+ signal?: AbortSignal
+) => {
+      
+      
+      return customAxiosInstance<QuizQuestionForTakingResponseDto[]>(
+      {url: `/academy/chapters/${chapterId}/quiz`, method: 'GET', signal
+    },
+      );
+    }
+  
+
+
+
+export const getAcademyQuizControllerGetChapterQuizQueryKey = (chapterId?: string,) => {
+    return [
+    `/academy/chapters/${chapterId}/quiz`
+    ] as const;
+    }
+
+    
+export const getAcademyQuizControllerGetChapterQuizQueryOptions = <TData = Awaited<ReturnType<typeof academyQuizControllerGetChapterQuiz>>, TError = void>(chapterId: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof academyQuizControllerGetChapterQuiz>>, TError, TData>>, }
+) => {
+
+const {query: queryOptions} = options ?? {};
+
+  const queryKey =  queryOptions?.queryKey ?? getAcademyQuizControllerGetChapterQuizQueryKey(chapterId);
+
+  
+
+    const queryFn: QueryFunction<Awaited<ReturnType<typeof academyQuizControllerGetChapterQuiz>>> = ({ signal }) => academyQuizControllerGetChapterQuiz(chapterId, signal);
+
+      
+
+      
+
+   return  { queryKey, queryFn, enabled: !!(chapterId), ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof academyQuizControllerGetChapterQuiz>>, TError, TData> & { queryKey: DataTag<QueryKey, TData, TError> }
+}
+
+export type AcademyQuizControllerGetChapterQuizQueryResult = NonNullable<Awaited<ReturnType<typeof academyQuizControllerGetChapterQuiz>>>
+export type AcademyQuizControllerGetChapterQuizQueryError = void
+
+
+export function useAcademyQuizControllerGetChapterQuiz<TData = Awaited<ReturnType<typeof academyQuizControllerGetChapterQuiz>>, TError = void>(
+ chapterId: string, options: { query:Partial<UseQueryOptions<Awaited<ReturnType<typeof academyQuizControllerGetChapterQuiz>>, TError, TData>> & Pick<
+        DefinedInitialDataOptions<
+          Awaited<ReturnType<typeof academyQuizControllerGetChapterQuiz>>,
+          TError,
+          Awaited<ReturnType<typeof academyQuizControllerGetChapterQuiz>>
+        > , 'initialData'
+      >, }
+ , queryClient?: QueryClient
+  ):  DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useAcademyQuizControllerGetChapterQuiz<TData = Awaited<ReturnType<typeof academyQuizControllerGetChapterQuiz>>, TError = void>(
+ chapterId: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof academyQuizControllerGetChapterQuiz>>, TError, TData>> & Pick<
+        UndefinedInitialDataOptions<
+          Awaited<ReturnType<typeof academyQuizControllerGetChapterQuiz>>,
+          TError,
+          Awaited<ReturnType<typeof academyQuizControllerGetChapterQuiz>>
+        > , 'initialData'
+      >, }
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useAcademyQuizControllerGetChapterQuiz<TData = Awaited<ReturnType<typeof academyQuizControllerGetChapterQuiz>>, TError = void>(
+ chapterId: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof academyQuizControllerGetChapterQuiz>>, TError, TData>>, }
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+/**
+ * @summary Get a chapter quiz
+ */
+
+export function useAcademyQuizControllerGetChapterQuiz<TData = Awaited<ReturnType<typeof academyQuizControllerGetChapterQuiz>>, TError = void>(
+ chapterId: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof academyQuizControllerGetChapterQuiz>>, TError, TData>>, }
+ , queryClient?: QueryClient 
+ ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
+
+  const queryOptions = getAcademyQuizControllerGetChapterQuizQueryOptions(chapterId,options)
+
+  const query = useQuery(queryOptions, queryClient) as  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+
+  query.queryKey = queryOptions.queryKey ;
+
+  return query;
+}
+
+
+
+
+
+/**
+ * Grade a quiz submission against the chapter pass threshold, record progress and, when the whole academy is passed, stamp completion. Unlimited retries.
+ * @summary Submit a chapter quiz
+ */
+export const academyQuizControllerSubmitChapterQuiz = (
+    chapterId: string,
+    submitQuizRequestDto: SubmitQuizRequestDto,
+ signal?: AbortSignal
+) => {
+      
+      
+      return customAxiosInstance<QuizResultResponseDto>(
+      {url: `/academy/chapters/${chapterId}/quiz/submit`, method: 'POST',
+      headers: {'Content-Type': 'application/json', },
+      data: submitQuizRequestDto, signal
+    },
+      );
+    }
+  
+
+
+export const getAcademyQuizControllerSubmitChapterQuizMutationOptions = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof academyQuizControllerSubmitChapterQuiz>>, TError,{chapterId: string;data: SubmitQuizRequestDto}, TContext>, }
+): UseMutationOptions<Awaited<ReturnType<typeof academyQuizControllerSubmitChapterQuiz>>, TError,{chapterId: string;data: SubmitQuizRequestDto}, TContext> => {
+
+const mutationKey = ['academyQuizControllerSubmitChapterQuiz'];
+const {mutation: mutationOptions} = options ?
+      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
+      options
+      : {...options, mutation: {...options.mutation, mutationKey}}
+      : {mutation: { mutationKey, }};
+
+      
+
+
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof academyQuizControllerSubmitChapterQuiz>>, {chapterId: string;data: SubmitQuizRequestDto}> = (props) => {
+          const {chapterId,data} = props ?? {};
+
+          return  academyQuizControllerSubmitChapterQuiz(chapterId,data,)
+        }
+
+        
+
+
+  return  { mutationFn, ...mutationOptions }}
+
+    export type AcademyQuizControllerSubmitChapterQuizMutationResult = NonNullable<Awaited<ReturnType<typeof academyQuizControllerSubmitChapterQuiz>>>
+    export type AcademyQuizControllerSubmitChapterQuizMutationBody = SubmitQuizRequestDto
+    export type AcademyQuizControllerSubmitChapterQuizMutationError = void
+
+    /**
+ * @summary Submit a chapter quiz
+ */
+export const useAcademyQuizControllerSubmitChapterQuiz = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof academyQuizControllerSubmitChapterQuiz>>, TError,{chapterId: string;data: SubmitQuizRequestDto}, TContext>, }
+ , queryClient?: QueryClient): UseMutationResult<
+        Awaited<ReturnType<typeof academyQuizControllerSubmitChapterQuiz>>,
+        TError,
+        {chapterId: string;data: SubmitQuizRequestDto},
+        TContext
+      > => {
+
+      const mutationOptions = getAcademyQuizControllerSubmitChapterQuizMutationOptions(options);
+
+      return useMutation(mutationOptions, queryClient);
+    }
+    
+/**
+ * Get the current user per-chapter pass state and the whole-academy completion date.
+ * @summary Get academy progress
+ */
+export const academyQuizControllerGetProgress = (
+    
+ signal?: AbortSignal
+) => {
+      
+      
+      return customAxiosInstance<AcademyProgressResponseDto>(
+      {url: `/academy/progress`, method: 'GET', signal
+    },
+      );
+    }
+  
+
+
+
+export const getAcademyQuizControllerGetProgressQueryKey = () => {
+    return [
+    `/academy/progress`
+    ] as const;
+    }
+
+    
+export const getAcademyQuizControllerGetProgressQueryOptions = <TData = Awaited<ReturnType<typeof academyQuizControllerGetProgress>>, TError = void>( options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof academyQuizControllerGetProgress>>, TError, TData>>, }
+) => {
+
+const {query: queryOptions} = options ?? {};
+
+  const queryKey =  queryOptions?.queryKey ?? getAcademyQuizControllerGetProgressQueryKey();
+
+  
+
+    const queryFn: QueryFunction<Awaited<ReturnType<typeof academyQuizControllerGetProgress>>> = ({ signal }) => academyQuizControllerGetProgress(signal);
+
+      
+
+      
+
+   return  { queryKey, queryFn, ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof academyQuizControllerGetProgress>>, TError, TData> & { queryKey: DataTag<QueryKey, TData, TError> }
+}
+
+export type AcademyQuizControllerGetProgressQueryResult = NonNullable<Awaited<ReturnType<typeof academyQuizControllerGetProgress>>>
+export type AcademyQuizControllerGetProgressQueryError = void
+
+
+export function useAcademyQuizControllerGetProgress<TData = Awaited<ReturnType<typeof academyQuizControllerGetProgress>>, TError = void>(
+  options: { query:Partial<UseQueryOptions<Awaited<ReturnType<typeof academyQuizControllerGetProgress>>, TError, TData>> & Pick<
+        DefinedInitialDataOptions<
+          Awaited<ReturnType<typeof academyQuizControllerGetProgress>>,
+          TError,
+          Awaited<ReturnType<typeof academyQuizControllerGetProgress>>
+        > , 'initialData'
+      >, }
+ , queryClient?: QueryClient
+  ):  DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useAcademyQuizControllerGetProgress<TData = Awaited<ReturnType<typeof academyQuizControllerGetProgress>>, TError = void>(
+  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof academyQuizControllerGetProgress>>, TError, TData>> & Pick<
+        UndefinedInitialDataOptions<
+          Awaited<ReturnType<typeof academyQuizControllerGetProgress>>,
+          TError,
+          Awaited<ReturnType<typeof academyQuizControllerGetProgress>>
+        > , 'initialData'
+      >, }
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useAcademyQuizControllerGetProgress<TData = Awaited<ReturnType<typeof academyQuizControllerGetProgress>>, TError = void>(
+  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof academyQuizControllerGetProgress>>, TError, TData>>, }
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+/**
+ * @summary Get academy progress
+ */
+
+export function useAcademyQuizControllerGetProgress<TData = Awaited<ReturnType<typeof academyQuizControllerGetProgress>>, TError = void>(
+  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof academyQuizControllerGetProgress>>, TError, TData>>, }
+ , queryClient?: QueryClient 
+ ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
+
+  const queryOptions = getAcademyQuizControllerGetProgressQueryOptions(options)
 
   const query = useQuery(queryOptions, queryClient) as  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
 

--- a/ayunis-core-frontend/src/shared/api/openapi-schema.json
+++ b/ayunis-core-frontend/src/shared/api/openapi-schema.json
@@ -8497,6 +8497,122 @@
         "tags": ["Academy"]
       }
     },
+    "/academy/chapters/{chapterId}/quiz": {
+      "get": {
+        "description": "Draw up to 10 random questions from the chapter pool (the whole pool if smaller). Correct answers are never included.",
+        "operationId": "AcademyQuizController_getChapterQuiz",
+        "parameters": [
+          {
+            "name": "chapterId",
+            "required": true,
+            "in": "path",
+            "description": "Chapter ID",
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/QuizQuestionForTakingResponseDto"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "User not authenticated or academy add-on not active"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "summary": "Get a chapter quiz",
+        "tags": ["Academy"]
+      }
+    },
+    "/academy/chapters/{chapterId}/quiz/submit": {
+      "post": {
+        "description": "Grade a quiz submission against the chapter pass threshold, record progress and, when the whole academy is passed, stamp completion. Unlimited retries.",
+        "operationId": "AcademyQuizController_submitChapterQuiz",
+        "parameters": [
+          {
+            "name": "chapterId",
+            "required": true,
+            "in": "path",
+            "description": "Chapter ID",
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SubmitQuizRequestDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QuizResultResponseDto"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "User not authenticated or academy add-on not active"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "summary": "Submit a chapter quiz",
+        "tags": ["Academy"]
+      }
+    },
+    "/academy/progress": {
+      "get": {
+        "description": "Get the current user per-chapter pass state and the whole-academy completion date.",
+        "operationId": "AcademyQuizController_getProgress",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AcademyProgressResponseDto"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "User not authenticated or academy add-on not active"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "summary": "Get academy progress",
+        "tags": ["Academy"]
+      }
+    },
     "/super-admin/academy/chapters": {
       "get": {
         "description": "Retrieve all chapters with nested modules, ordered by position. Only accessible to super admins.",
@@ -15991,6 +16107,11 @@
             "description": "Whether a quiz is activated for this chapter (shown at chapter end)",
             "example": false
           },
+          "passThreshold": {
+            "type": "integer",
+            "description": "Percentage of correct answers required to pass this chapter quiz",
+            "example": 80
+          },
           "courseModules": {
             "description": "The modules of the chapter, ordered by position",
             "type": "array",
@@ -16015,10 +16136,160 @@
           "description",
           "position",
           "quizEnabled",
+          "passThreshold",
           "courseModules",
           "createdAt",
           "updatedAt"
         ]
+      },
+      "QuizAnswerOptionForTakingResponseDto": {
+        "type": "object",
+        "properties": {
+          "text": {
+            "type": "string",
+            "description": "The answer option text",
+            "example": "A large language model"
+          }
+        },
+        "required": ["text"]
+      },
+      "QuizQuestionForTakingResponseDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "The unique identifier of the question"
+          },
+          "text": {
+            "type": "string",
+            "description": "The question prompt",
+            "example": "What is an LLM?"
+          },
+          "options": {
+            "description": "The answer options, without indicating the correct one",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/QuizAnswerOptionForTakingResponseDto"
+            }
+          }
+        },
+        "required": ["id", "text", "options"]
+      },
+      "SubmitQuizAnswerDto": {
+        "type": "object",
+        "properties": {
+          "questionId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "The id of the answered question"
+          },
+          "selectedOptionIndex": {
+            "type": "integer",
+            "description": "The 0-based index of the selected answer option",
+            "example": 0
+          }
+        },
+        "required": ["questionId", "selectedOptionIndex"]
+      },
+      "SubmitQuizRequestDto": {
+        "type": "object",
+        "properties": {
+          "answers": {
+            "description": "One answer per drawn question",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SubmitQuizAnswerDto"
+            }
+          }
+        },
+        "required": ["answers"]
+      },
+      "QuizResultResponseDto": {
+        "type": "object",
+        "properties": {
+          "passed": {
+            "type": "boolean",
+            "description": "Whether the attempt met the chapter pass threshold"
+          },
+          "correctCount": {
+            "type": "integer",
+            "description": "Number of questions answered correctly",
+            "example": 8
+          },
+          "totalCount": {
+            "type": "integer",
+            "description": "Number of questions in the attempt",
+            "example": 10
+          },
+          "requiredCount": {
+            "type": "integer",
+            "description": "Number of correct answers required to pass",
+            "example": 8
+          },
+          "score": {
+            "type": "integer",
+            "description": "Score as a percentage of correct answers",
+            "example": 80
+          },
+          "academyCompleted": {
+            "type": "boolean",
+            "description": "Whether passing this chapter completed the whole academy for the user"
+          }
+        },
+        "required": [
+          "passed",
+          "correctCount",
+          "totalCount",
+          "requiredCount",
+          "score",
+          "academyCompleted"
+        ]
+      },
+      "ChapterProgressResponseDto": {
+        "type": "object",
+        "properties": {
+          "chapterId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "The chapter this progress refers to"
+          },
+          "passed": {
+            "type": "boolean",
+            "description": "Whether the learner has passed this chapter quiz"
+          },
+          "lastScore": {
+            "type": "integer",
+            "description": "Score of the most recent attempt, as a percentage",
+            "example": 80
+          },
+          "lastPassedAt": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true,
+            "description": "When the chapter was most recently passed, if ever"
+          }
+        },
+        "required": ["chapterId", "passed", "lastScore", "lastPassedAt"]
+      },
+      "AcademyProgressResponseDto": {
+        "type": "object",
+        "properties": {
+          "chapters": {
+            "description": "Per-chapter progress for the current user",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ChapterProgressResponseDto"
+            }
+          },
+          "academyCompletedAt": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true,
+            "description": "When the user last completed the whole academy, or null if never"
+          }
+        },
+        "required": ["chapters", "academyCompletedAt"]
       },
       "QuizAnswerOptionResponseDto": {
         "type": "object",
@@ -16115,6 +16386,11 @@
             "description": "Whether a quiz is activated for this chapter (shown at chapter end)",
             "example": false
           },
+          "passThreshold": {
+            "type": "integer",
+            "description": "Percentage of correct answers required to pass this chapter quiz",
+            "example": 80
+          },
           "courseModules": {
             "description": "The modules of the chapter, ordered by position",
             "type": "array",
@@ -16146,6 +16422,7 @@
           "description",
           "position",
           "quizEnabled",
+          "passThreshold",
           "courseModules",
           "createdAt",
           "updatedAt",
@@ -16203,6 +16480,13 @@
             "type": "boolean",
             "description": "Whether a quiz is activated for this chapter",
             "example": false
+          },
+          "passThreshold": {
+            "type": "number",
+            "description": "Percentage of correct answers required to pass this chapter quiz",
+            "example": 80,
+            "minimum": 1,
+            "maximum": 100
           }
         },
         "required": ["title", "description"]


### PR DESCRIPTION
Regenerate the frontend OpenAPI client so the learner quiz-taking and progress endpoints, the new quiz DTOs and the chapter passThreshold field are available to the UI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Auto-generated API bindings only; no runtime or auth logic changes in the frontend.
> 
> **Overview**
> Regenerates the frontend OpenAPI client from an updated backend spec so Academy quiz-taking and progress APIs are typed and callable from the UI.
> 
> **New learner-facing API surface:** `GET /academy/chapters/{chapterId}/quiz` (random questions without correct answers), `POST .../quiz/submit` (grading and progress), and `GET /academy/progress` (per-chapter pass state and academy completion). Orval adds matching axios helpers plus React Query hooks such as `useAcademyQuizControllerGetChapterQuiz`, `useAcademyQuizControllerSubmitChapterQuiz`, and `useAcademyQuizControllerGetProgress`.
> 
> **Schema updates:** Chapter DTOs gain required **`passThreshold`**; admin **`UpdateChapterRequestDto`** can set optional **`passThreshold`** (1–100). New DTOs cover quiz taking (`QuizQuestionForTakingResponseDto`, submit payload/result) and progress (`AcademyProgressResponseDto`, `ChapterProgressResponseDto`).
> 
> Changes are confined to **`openapi-schema.json`** and generated **`ayunisCoreAPI.ts`** / **`ayunisCoreAPI.schemas.ts`**—no feature UI in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5c3f9b0fb8841d3440916dea552d995cfa662ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->