### PR TITLE
feat(academy): add learner quiz-taking flow (AYC-245)

### DIFF
--- a/ayunis-core-frontend/src/app/routeTree.gen.ts
+++ b/ayunis-core-frontend/src/app/routeTree.gen.ts
@@ -60,6 +60,7 @@ import { Route as AuthenticatedAdminSettingsLetterheadsIndexRouteImport } from '
 import { Route as AuthenticatedSuperAdminSettingsOrgsIdRouteImport } from './routes/_authenticated/super-admin-settings.orgs.$id'
 import { Route as AuthenticatedAdminSettingsTeamsIdRouteImport } from './routes/_authenticated/admin-settings.teams.$id'
 import { Route as AuthenticatedAdminSettingsLetterheadsIdRouteImport } from './routes/_authenticated/admin-settings.letterheads.$id'
+import { Route as AuthenticatedAcademyChapterIdQuizRouteImport } from './routes/_authenticated/academy.$chapterId_.quiz'
 
 const AuthenticatedRoute = AuthenticatedRouteImport.update({
   id: '/_authenticated',
@@ -353,6 +354,12 @@ const AuthenticatedAdminSettingsLetterheadsIdRoute =
     path: '/admin-settings/letterheads/$id',
     getParentRoute: () => AuthenticatedRoute,
   } as any)
+const AuthenticatedAcademyChapterIdQuizRoute =
+  AuthenticatedAcademyChapterIdQuizRouteImport.update({
+    id: '/academy/$chapterId_/quiz',
+    path: '/academy/$chapterId/quiz',
+    getParentRoute: () => AuthenticatedRoute,
+  } as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
@@ -392,6 +399,7 @@ export interface FileRoutesByFullPath {
   '/settings/': typeof AuthenticatedSettingsIndexRoute
   '/skills/': typeof AuthenticatedSkillsIndexRoute
   '/super-admin-settings/': typeof AuthenticatedSuperAdminSettingsIndexRoute
+  '/academy/$chapterId/quiz': typeof AuthenticatedAcademyChapterIdQuizRoute
   '/admin-settings/letterheads/$id': typeof AuthenticatedAdminSettingsLetterheadsIdRoute
   '/admin-settings/teams/$id': typeof AuthenticatedAdminSettingsTeamsIdRoute
   '/super-admin-settings/orgs/$id': typeof AuthenticatedSuperAdminSettingsOrgsIdRoute
@@ -444,6 +452,7 @@ export interface FileRoutesByTo {
   '/settings': typeof AuthenticatedSettingsIndexRoute
   '/skills': typeof AuthenticatedSkillsIndexRoute
   '/super-admin-settings': typeof AuthenticatedSuperAdminSettingsIndexRoute
+  '/academy/$chapterId/quiz': typeof AuthenticatedAcademyChapterIdQuizRoute
   '/admin-settings/letterheads/$id': typeof AuthenticatedAdminSettingsLetterheadsIdRoute
   '/admin-settings/teams/$id': typeof AuthenticatedAdminSettingsTeamsIdRoute
   '/super-admin-settings/orgs/$id': typeof AuthenticatedSuperAdminSettingsOrgsIdRoute
@@ -498,6 +507,7 @@ export interface FileRoutesById {
   '/_authenticated/settings/': typeof AuthenticatedSettingsIndexRoute
   '/_authenticated/skills/': typeof AuthenticatedSkillsIndexRoute
   '/_authenticated/super-admin-settings/': typeof AuthenticatedSuperAdminSettingsIndexRoute
+  '/_authenticated/academy/$chapterId_/quiz': typeof AuthenticatedAcademyChapterIdQuizRoute
   '/_authenticated/admin-settings/letterheads/$id': typeof AuthenticatedAdminSettingsLetterheadsIdRoute
   '/_authenticated/admin-settings/teams/$id': typeof AuthenticatedAdminSettingsTeamsIdRoute
   '/_authenticated/super-admin-settings/orgs/$id': typeof AuthenticatedSuperAdminSettingsOrgsIdRoute
@@ -552,6 +562,7 @@ export interface FileRouteTypes {
     | '/settings/'
     | '/skills/'
     | '/super-admin-settings/'
+    | '/academy/$chapterId/quiz'
     | '/admin-settings/letterheads/$id'
     | '/admin-settings/teams/$id'
     | '/super-admin-settings/orgs/$id'
@@ -604,6 +615,7 @@ export interface FileRouteTypes {
     | '/settings'
     | '/skills'
     | '/super-admin-settings'
+    | '/academy/$chapterId/quiz'
     | '/admin-settings/letterheads/$id'
     | '/admin-settings/teams/$id'
     | '/super-admin-settings/orgs/$id'
@@ -657,6 +669,7 @@ export interface FileRouteTypes {
     | '/_authenticated/settings/'
     | '/_authenticated/skills/'
     | '/_authenticated/super-admin-settings/'
+    | '/_authenticated/academy/$chapterId_/quiz'
     | '/_authenticated/admin-settings/letterheads/$id'
     | '/_authenticated/admin-settings/teams/$id'
     | '/_authenticated/super-admin-settings/orgs/$id'
@@ -1045,6 +1058,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedAdminSettingsLetterheadsIdRouteImport
       parentRoute: typeof AuthenticatedRoute
     }
+    '/_authenticated/academy/$chapterId_/quiz': {
+      id: '/_authenticated/academy/$chapterId_/quiz'
+      path: '/academy/$chapterId/quiz'
+      fullPath: '/academy/$chapterId/quiz'
+      preLoaderRoute: typeof AuthenticatedAcademyChapterIdQuizRouteImport
+      parentRoute: typeof AuthenticatedRoute
+    }
   }
 }
 
@@ -1076,6 +1096,7 @@ interface AuthenticatedRouteChildren {
   AuthenticatedSettingsIndexRoute: typeof AuthenticatedSettingsIndexRoute
   AuthenticatedSkillsIndexRoute: typeof AuthenticatedSkillsIndexRoute
   AuthenticatedSuperAdminSettingsIndexRoute: typeof AuthenticatedSuperAdminSettingsIndexRoute
+  AuthenticatedAcademyChapterIdQuizRoute: typeof AuthenticatedAcademyChapterIdQuizRoute
   AuthenticatedAdminSettingsLetterheadsIdRoute: typeof AuthenticatedAdminSettingsLetterheadsIdRoute
   AuthenticatedAdminSettingsTeamsIdRoute: typeof AuthenticatedAdminSettingsTeamsIdRoute
   AuthenticatedSuperAdminSettingsOrgsIdRoute: typeof AuthenticatedSuperAdminSettingsOrgsIdRoute
@@ -1127,6 +1148,8 @@ const AuthenticatedRouteChildren: AuthenticatedRouteChildren = {
   AuthenticatedSkillsIndexRoute: AuthenticatedSkillsIndexRoute,
   AuthenticatedSuperAdminSettingsIndexRoute:
     AuthenticatedSuperAdminSettingsIndexRoute,
+  AuthenticatedAcademyChapterIdQuizRoute:
+    AuthenticatedAcademyChapterIdQuizRoute,
   AuthenticatedAdminSettingsLetterheadsIdRoute:
     AuthenticatedAdminSettingsLetterheadsIdRoute,
   AuthenticatedAdminSettingsTeamsIdRoute:

--- a/ayunis-core-frontend/src/app/routes/_authenticated/academy.$chapterId_.quiz.tsx
+++ b/ayunis-core-frontend/src/app/routes/_authenticated/academy.$chapterId_.quiz.tsx
@@ -1,0 +1,43 @@
+import { createFileRoute, redirect } from '@tanstack/react-router';
+import { ChapterQuizPage } from '@/pages/academy';
+import { isAcademyAddonActive } from '@/features/academy';
+import {
+  addonsControllerList,
+  getAddonsControllerListQueryKey,
+  academyChaptersControllerGetChapters,
+  getAcademyChaptersControllerGetChaptersQueryKey,
+} from '@/shared/api/generated/ayunisCoreAPI';
+
+export const Route = createFileRoute(
+  '/_authenticated/academy/$chapterId_/quiz',
+)({
+  component: RouteComponent,
+  loader: async ({ context: { queryClient }, params: { chapterId } }) => {
+    const addons = await queryClient.fetchQuery({
+      queryKey: getAddonsControllerListQueryKey(),
+      queryFn: () => addonsControllerList(),
+    });
+    if (!isAcademyAddonActive(addons)) {
+      throw redirect({ to: '/chat' });
+    }
+    const chapters = await queryClient.fetchQuery({
+      queryKey: getAcademyChaptersControllerGetChaptersQueryKey(),
+      queryFn: () => academyChaptersControllerGetChapters(),
+    });
+    const chapter = chapters.find((c) => c.id === chapterId);
+    // No quiz here → send the learner back to the chapter.
+    if (!chapter?.quizEnabled) {
+      throw redirect({
+        to: '/academy/$chapterId',
+        params: { chapterId },
+        search: {},
+      });
+    }
+    return { chapter };
+  },
+});
+
+function RouteComponent() {
+  const { chapter } = Route.useLoaderData();
+  return <ChapterQuizPage chapter={chapter} />;
+}

--- a/ayunis-core-frontend/src/pages/academy/api/useAcademyProgress.ts
+++ b/ayunis-core-frontend/src/pages/academy/api/useAcademyProgress.ts
@@ -1,0 +1,11 @@
+import { useAcademyQuizControllerGetProgress } from '@/shared/api';
+
+// Per-chapter pass state plus the whole-academy completion date for the
+// current user. Drives the passed badges and the completion banner.
+export function useAcademyProgress() {
+  const { data, isLoading } = useAcademyQuizControllerGetProgress();
+  return {
+    progress: data,
+    isLoading,
+  };
+}

--- a/ayunis-core-frontend/src/pages/academy/api/useChapterQuiz.ts
+++ b/ayunis-core-frontend/src/pages/academy/api/useChapterQuiz.ts
@@ -1,0 +1,22 @@
+import { useAcademyQuizControllerGetChapterQuiz } from '@/shared/api';
+
+// Fetches a fresh random draw of quiz questions for a chapter. `staleTime: 0`
+// so that retrying re-draws a new set of questions.
+export function useChapterQuiz(chapterId: string) {
+  const { data, isLoading, isError, refetch, isRefetching } =
+    useAcademyQuizControllerGetChapterQuiz(chapterId, {
+      query: {
+        staleTime: 0,
+        gcTime: 0,
+        refetchOnWindowFocus: false,
+      },
+    });
+
+  return {
+    questions: data ?? [],
+    isLoading,
+    isError,
+    isRefetching,
+    refetch,
+  };
+}

--- a/ayunis-core-frontend/src/pages/academy/api/useSubmitChapterQuiz.ts
+++ b/ayunis-core-frontend/src/pages/academy/api/useSubmitChapterQuiz.ts
@@ -1,0 +1,58 @@
+import { useQueryClient } from '@tanstack/react-query';
+import { useRouter } from '@tanstack/react-router';
+import { useTranslation } from 'react-i18next';
+import { showError } from '@/shared/lib/toast';
+import {
+  useAcademyQuizControllerSubmitChapterQuiz,
+  getAcademyQuizControllerGetProgressQueryKey,
+  getAcademyChaptersControllerGetChaptersQueryKey,
+  type SubmitQuizRequestDto,
+} from '@/shared/api';
+import extractErrorData from '@/shared/api/extract-error-data';
+
+export function useSubmitChapterQuiz() {
+  const { t } = useTranslation('academy');
+  const queryClient = useQueryClient();
+  const router = useRouter();
+
+  const mutation = useAcademyQuizControllerSubmitChapterQuiz({
+    mutation: {
+      onSuccess: async () => {
+        await queryClient.invalidateQueries({
+          queryKey: getAcademyQuizControllerGetProgressQueryKey(),
+        });
+        await queryClient.invalidateQueries({
+          queryKey: getAcademyChaptersControllerGetChaptersQueryKey(),
+        });
+      },
+      onError: (error: unknown) => {
+        try {
+          const { code } = extractErrorData(error);
+          if (code === 'QUIZ_NOT_AVAILABLE') {
+            showError(t('quiz.errors.notAvailable'));
+          } else if (code === 'INVALID_QUIZ_SUBMISSION') {
+            showError(t('quiz.errors.invalidSubmission'));
+          } else {
+            showError(t('quiz.errors.submitFailed'));
+          }
+        } catch {
+          showError(t('quiz.errors.submitFailed'));
+        }
+      },
+      onSettled: async () => {
+        await router.invalidate();
+      },
+    },
+  });
+
+  function submitQuiz(chapterId: string, data: SubmitQuizRequestDto) {
+    mutation.mutate({ chapterId, data });
+  }
+
+  return {
+    submitQuiz,
+    isSubmitting: mutation.isPending,
+    result: mutation.data,
+    reset: mutation.reset,
+  };
+}

--- a/ayunis-core-frontend/src/pages/academy/index.ts
+++ b/ayunis-core-frontend/src/pages/academy/index.ts
@@ -1,2 +1,3 @@
 export { default as AcademyPage } from './ui/AcademyPage';
 export { default as ChapterDetailPage } from './ui/ChapterDetailPage';
+export { default as ChapterQuizPage } from './ui/ChapterQuizPage';

--- a/ayunis-core-frontend/src/pages/academy/ui/AcademyPage.tsx
+++ b/ayunis-core-frontend/src/pages/academy/ui/AcademyPage.tsx
@@ -9,9 +9,12 @@ import {
   ItemDescription,
   ItemTitle,
 } from '@/shared/ui/shadcn/item';
+import { Badge } from '@/shared/ui/shadcn/badge';
+import { CheckCircle2, Trophy } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { Link } from '@tanstack/react-router';
 import type { AcademyChapterResponseDto } from '@/shared/api/generated/ayunisCoreAPI.schemas';
+import { useAcademyProgress } from '../api/useAcademyProgress';
 
 interface AcademyPageProps {
   chapters: AcademyChapterResponseDto[];
@@ -19,6 +22,11 @@ interface AcademyPageProps {
 
 export default function AcademyPage({ chapters }: Readonly<AcademyPageProps>) {
   const { t } = useTranslation('academy');
+  const { progress } = useAcademyProgress();
+
+  const passedChapterIds = new Set(
+    (progress?.chapters ?? []).filter((c) => c.passed).map((c) => c.chapterId),
+  );
 
   const sortedChapters = [...chapters].sort((a, b) => a.position - b.position);
 
@@ -45,6 +53,17 @@ export default function AcademyPage({ chapters }: Readonly<AcademyPageProps>) {
         contentHeader={header}
         contentArea={
           <div className="space-y-3">
+            {progress?.academyCompletedAt && (
+              <div className="flex items-start gap-2 rounded-lg border bg-muted p-3">
+                <Trophy className="h-5 w-5 shrink-0 text-amber-500" />
+                <div>
+                  <p className="font-medium">{t('progress.completed.title')}</p>
+                  <p className="text-sm text-muted-foreground">
+                    {t('progress.completed.description')}
+                  </p>
+                </div>
+              </div>
+            )}
             {sortedChapters.map((chapter) => (
               <Item key={chapter.id} variant="outline">
                 <Link
@@ -53,7 +72,15 @@ export default function AcademyPage({ chapters }: Readonly<AcademyPageProps>) {
                   className="flex-1"
                 >
                   <ItemContent>
-                    <ItemTitle>{chapter.title}</ItemTitle>
+                    <ItemTitle className="flex items-center gap-2">
+                      {chapter.title}
+                      {passedChapterIds.has(chapter.id) && (
+                        <Badge variant="secondary" className="gap-1">
+                          <CheckCircle2 className="h-3 w-3 text-green-600" />
+                          {t('progress.passed')}
+                        </Badge>
+                      )}
+                    </ItemTitle>
                     <ItemDescription>{chapter.description}</ItemDescription>
                   </ItemContent>
                 </Link>

--- a/ayunis-core-frontend/src/pages/academy/ui/ChapterDetailPage.tsx
+++ b/ayunis-core-frontend/src/pages/academy/ui/ChapterDetailPage.tsx
@@ -40,6 +40,17 @@ export default function ChapterDetailPage({
     });
   };
 
+  const finishChapter = () => {
+    if (chapter.quizEnabled) {
+      void navigate({
+        to: '/academy/$chapterId/quiz',
+        params: { chapterId: chapter.id },
+      });
+      return;
+    }
+    void navigate({ to: '/academy' });
+  };
+
   const header = (
     <ContentAreaHeader
       breadcrumbs={[
@@ -70,10 +81,19 @@ export default function ChapterDetailPage({
               </CardHeader>
               <CardContent>
                 {modules.length === 0 ? (
-                  <EmptyState
-                    title={t('detail.noModules.title')}
-                    description={t('detail.noModules.description')}
-                  />
+                  <div className="space-y-3">
+                    <EmptyState
+                      title={t('detail.noModules.title')}
+                      description={t('detail.noModules.description')}
+                    />
+                    {/* Without modules the quiz has no other entry point, and
+                        an unreachable quiz blocks whole-academy completion. */}
+                    {chapter.quizEnabled && (
+                      <Button onClick={finishChapter}>
+                        {t('detail.startQuiz')}
+                      </Button>
+                    )}
+                  </div>
                 ) : (
                   <Button onClick={() => goToModule(0)}>
                     {t('detail.letsGo')}
@@ -126,8 +146,8 @@ export default function ChapterDetailPage({
             {t('detail.previous')}
           </Button>
           {isLast ? (
-            <Button onClick={() => void navigate({ to: '/academy' })}>
-              {t('detail.finish')}
+            <Button onClick={finishChapter}>
+              {chapter.quizEnabled ? t('detail.startQuiz') : t('detail.finish')}
               <Check className="h-4 w-4" />
             </Button>
           ) : (

--- a/ayunis-core-frontend/src/pages/academy/ui/ChapterQuizPage.tsx
+++ b/ayunis-core-frontend/src/pages/academy/ui/ChapterQuizPage.tsx
@@ -1,0 +1,134 @@
+import { useNavigate } from '@tanstack/react-router';
+import { useTranslation } from 'react-i18next';
+import AppLayout from '@/layouts/app-layout';
+import ContentAreaLayout from '@/layouts/content-area-layout/ui/ContentAreaLayout';
+import ContentAreaHeader from '@/widgets/content-area-header/ui/ContentAreaHeader';
+import { EmptyState } from '@/widgets/empty-state';
+import { Button } from '@/shared/ui/shadcn/button';
+import type { AcademyChapterResponseDto } from '@/shared/api/generated/ayunisCoreAPI.schemas';
+import { useChapterQuiz } from '../api/useChapterQuiz';
+import { useSubmitChapterQuiz } from '../api/useSubmitChapterQuiz';
+import QuizForm from './QuizForm';
+import QuizResultCard from './QuizResultCard';
+
+interface ChapterQuizPageProps {
+  chapter: AcademyChapterResponseDto;
+}
+
+export default function ChapterQuizPage({
+  chapter,
+}: Readonly<ChapterQuizPageProps>) {
+  const { t } = useTranslation('academy');
+  const navigate = useNavigate();
+  const { questions, isLoading, isError, isRefetching, refetch } =
+    useChapterQuiz(chapter.id);
+  const { submitQuiz, isSubmitting, result, reset } = useSubmitChapterQuiz();
+
+  const goToAcademy = () => void navigate({ to: '/academy' });
+  const handleRetry = () => {
+    reset();
+    void refetch();
+  };
+
+  const header = (
+    <ContentAreaHeader
+      breadcrumbs={[
+        { label: t('page.title'), href: '/academy' },
+        { label: chapter.title, href: `/academy/${chapter.id}` },
+        { label: t('quiz.title') },
+      ]}
+    />
+  );
+
+  return (
+    <AppLayout>
+      <ContentAreaLayout
+        contentHeader={header}
+        contentArea={
+          <div className="pb-8">
+            {renderQuizBody({
+              // A retry re-draw must not show the previous questions/answers,
+              // so a refetch unmounts the form just like the initial load.
+              isLoading: isLoading || isRefetching,
+              isError,
+              questions,
+              result,
+              isSubmitting,
+              onSubmit: (data) => submitQuiz(chapter.id, data),
+              onRetry: handleRetry,
+              onBackToAcademy: goToAcademy,
+              labels: {
+                loadError: t('quiz.errors.loadFailed'),
+                loadErrorDescription: t('quiz.errors.loadFailedDescription'),
+                empty: t('quiz.errors.notAvailable'),
+                emptyDescription: t('quiz.errors.notAvailableDescription'),
+                retry: t('quiz.retry'),
+              },
+            })}
+          </div>
+        }
+      />
+    </AppLayout>
+  );
+}
+
+interface QuizBodyArgs {
+  isLoading: boolean;
+  isError: boolean;
+  questions: React.ComponentProps<typeof QuizForm>['questions'];
+  result: React.ComponentProps<typeof QuizResultCard>['result'] | undefined;
+  isSubmitting: boolean;
+  onSubmit: React.ComponentProps<typeof QuizForm>['onSubmit'];
+  onRetry: () => void;
+  onBackToAcademy: () => void;
+  labels: {
+    loadError: string;
+    loadErrorDescription: string;
+    empty: string;
+    emptyDescription: string;
+    retry: string;
+  };
+}
+
+function renderQuizBody(args: Readonly<QuizBodyArgs>) {
+  if (args.result) {
+    return (
+      <QuizResultCard
+        result={args.result}
+        onRetry={args.onRetry}
+        onBackToAcademy={args.onBackToAcademy}
+      />
+    );
+  }
+  if (args.isLoading) {
+    return <p className="text-muted-foreground">…</p>;
+  }
+  if (args.isError) {
+    return (
+      <div className="space-y-3">
+        <EmptyState
+          title={args.labels.loadError}
+          description={args.labels.loadErrorDescription}
+        />
+        <Button variant="outline" onClick={args.onRetry}>
+          {args.labels.retry}
+        </Button>
+      </div>
+    );
+  }
+  if (args.questions.length === 0) {
+    return (
+      <EmptyState
+        title={args.labels.empty}
+        description={args.labels.emptyDescription}
+      />
+    );
+  }
+  return (
+    <QuizForm
+      questions={args.questions}
+      isSubmitting={args.isSubmitting}
+      onSubmit={args.onSubmit}
+    />
+  );
+}

--- a/ayunis-core-frontend/src/pages/academy/ui/QuizForm.tsx
+++ b/ayunis-core-frontend/src/pages/academy/ui/QuizForm.tsx
@@ -1,0 +1,62 @@
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Button } from '@/shared/ui/shadcn/button';
+import type {
+  QuizQuestionForTakingResponseDto,
+  SubmitQuizRequestDto,
+} from '@/shared/api/generated/ayunisCoreAPI.schemas';
+import QuizQuestionCard from './QuizQuestionCard';
+
+interface QuizFormProps {
+  questions: QuizQuestionForTakingResponseDto[];
+  isSubmitting: boolean;
+  onSubmit: (data: SubmitQuizRequestDto) => void;
+}
+
+export default function QuizForm({
+  questions,
+  isSubmitting,
+  onSubmit,
+}: Readonly<QuizFormProps>) {
+  const { t } = useTranslation('academy');
+  const [answers, setAnswers] = useState<Record<string, number>>({});
+
+  const allAnswered = questions.every((q) => Object.hasOwn(answers, q.id));
+
+  const handleSubmit = () => {
+    onSubmit({
+      answers: questions.map((q) => ({
+        questionId: q.id,
+        selectedOptionIndex: answers[q.id],
+      })),
+    });
+  };
+
+  return (
+    <div className="mx-auto max-w-[800px] space-y-4">
+      {questions.map((question, index) => (
+        <QuizQuestionCard
+          key={question.id}
+          question={question}
+          index={index}
+          total={questions.length}
+          selectedIndex={answers[question.id]}
+          disabled={isSubmitting}
+          onSelect={(optionIndex) =>
+            setAnswers((prev) => ({ ...prev, [question.id]: optionIndex }))
+          }
+        />
+      ))}
+      <div className="flex items-center justify-end gap-3">
+        {!allAnswered && (
+          <span className="text-sm text-muted-foreground">
+            {t('quiz.answerAll')}
+          </span>
+        )}
+        <Button disabled={!allAnswered || isSubmitting} onClick={handleSubmit}>
+          {t('quiz.submit')}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/ayunis-core-frontend/src/pages/academy/ui/QuizQuestionCard.tsx
+++ b/ayunis-core-frontend/src/pages/academy/ui/QuizQuestionCard.tsx
@@ -1,0 +1,52 @@
+import { useTranslation } from 'react-i18next';
+import type { QuizQuestionForTakingResponseDto } from '@/shared/api/generated/ayunisCoreAPI.schemas';
+
+interface QuizQuestionCardProps {
+  question: QuizQuestionForTakingResponseDto;
+  index: number;
+  total: number;
+  selectedIndex?: number;
+  disabled?: boolean;
+  onSelect: (optionIndex: number) => void;
+}
+
+export default function QuizQuestionCard({
+  question,
+  index,
+  total,
+  selectedIndex,
+  disabled,
+  onSelect,
+}: Readonly<QuizQuestionCardProps>) {
+  const { t } = useTranslation('academy');
+
+  return (
+    <div className="space-y-3 rounded-lg border p-4">
+      <div>
+        <p className="text-xs font-medium text-muted-foreground">
+          {t('quiz.questionCounter', { current: index + 1, total })}
+        </p>
+        <h3 className="mt-1 font-medium whitespace-pre-line">
+          {question.text}
+        </h3>
+      </div>
+      <ul className="space-y-2">
+        {question.options.map((option, optionIndex) => (
+          <li key={optionIndex}>
+            <label className="flex cursor-pointer items-center gap-2 rounded-md border p-2 hover:bg-muted">
+              <input
+                type="radio"
+                name={`question-${question.id}`}
+                className="h-4 w-4 shrink-0"
+                checked={selectedIndex === optionIndex}
+                disabled={disabled}
+                onChange={() => onSelect(optionIndex)}
+              />
+              <span className="text-sm">{option.text}</span>
+            </label>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/ayunis-core-frontend/src/pages/academy/ui/QuizResultCard.tsx
+++ b/ayunis-core-frontend/src/pages/academy/ui/QuizResultCard.tsx
@@ -1,0 +1,78 @@
+import { useTranslation } from 'react-i18next';
+import { CheckCircle2, RotateCcw, Trophy, XCircle } from 'lucide-react';
+import { Button } from '@/shared/ui/shadcn/button';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/shared/ui/shadcn/card';
+import type { QuizResultResponseDto } from '@/shared/api/generated/ayunisCoreAPI.schemas';
+
+interface QuizResultCardProps {
+  result: QuizResultResponseDto;
+  onRetry: () => void;
+  onBackToAcademy: () => void;
+}
+
+export default function QuizResultCard({
+  result,
+  onRetry,
+  onBackToAcademy,
+}: Readonly<QuizResultCardProps>) {
+  const { t } = useTranslation('academy');
+
+  return (
+    <Card className="mx-auto max-w-[600px]">
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          {result.passed ? (
+            <CheckCircle2 className="h-5 w-5 text-green-600" />
+          ) : (
+            <XCircle className="h-5 w-5 text-destructive" />
+          )}
+          {result.passed ? t('quiz.passed.title') : t('quiz.failed.title')}
+        </CardTitle>
+        <CardDescription>
+          {t('quiz.result.score', {
+            correct: result.correctCount,
+            total: result.totalCount,
+            score: result.score,
+          })}
+          {' — '}
+          {t('quiz.result.required', { required: result.requiredCount })}
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {result.academyCompleted && (
+          <div className="flex items-start gap-2 rounded-lg border bg-muted p-3">
+            <Trophy className="h-5 w-5 shrink-0 text-amber-500" />
+            <div>
+              <p className="font-medium">{t('quiz.completed.title')}</p>
+              <p className="text-sm text-muted-foreground">
+                {t('quiz.completed.description')}
+              </p>
+            </div>
+          </div>
+        )}
+        <div className="flex flex-wrap gap-3">
+          {result.passed ? (
+            <Button onClick={onBackToAcademy}>{t('quiz.backToAcademy')}</Button>
+          ) : (
+            <Button onClick={onRetry}>
+              <RotateCcw className="h-4 w-4" />
+              {t('quiz.retry')}
+            </Button>
+          )}
+          {result.passed && (
+            <Button variant="outline" onClick={onRetry}>
+              <RotateCcw className="h-4 w-4" />
+              {t('quiz.retry')}
+            </Button>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/ayunis-core-frontend/src/shared/locales/de/academy.json
+++ b/ayunis-core-frontend/src/shared/locales/de/academy.json
@@ -11,10 +11,48 @@
     "previous": "Zurück",
     "next": "Weiter",
     "finish": "Abschließen",
+    "startQuiz": "Quiz starten",
     "modulesTitle": "Module",
     "noModules": {
       "title": "Noch keine Module",
       "description": "Dieses Kapitel enthält noch keine Module."
+    }
+  },
+  "quiz": {
+    "title": "Quiz",
+    "questionCounter": "Frage {{current}} von {{total}}",
+    "submit": "Antworten absenden",
+    "answerAll": "Beantworte alle Fragen, um abzusenden",
+    "retry": "Erneut versuchen",
+    "backToAcademy": "Zurück zur Academy",
+    "passed": {
+      "title": "Kapitel bestanden!"
+    },
+    "failed": {
+      "title": "Noch nicht ganz"
+    },
+    "result": {
+      "score": "Du hast {{correct}} von {{total}} richtig ({{score}} %)",
+      "required": "Du brauchst {{required}} richtige Antworten zum Bestehen."
+    },
+    "completed": {
+      "title": "Academy abgeschlossen!",
+      "description": "Du hast jedes Kapitel bestanden. Glückwunsch!"
+    },
+    "errors": {
+      "loadFailed": "Das Quiz konnte nicht geladen werden.",
+      "loadFailedDescription": "Bitte versuche es erneut.",
+      "notAvailable": "Dieses Quiz ist nicht verfügbar.",
+      "notAvailableDescription": "Dieses Kapitel hat derzeit kein Quiz.",
+      "invalidSubmission": "Deine Eingabe war ungültig. Bitte versuche es erneut.",
+      "submitFailed": "Deine Antworten konnten nicht gesendet werden. Bitte versuche es erneut."
+    }
+  },
+  "progress": {
+    "passed": "Bestanden",
+    "completed": {
+      "title": "Academy abgeschlossen!",
+      "description": "Du hast jedes Kapitel bestanden."
     }
   }
 }

--- a/ayunis-core-frontend/src/shared/locales/en/academy.json
+++ b/ayunis-core-frontend/src/shared/locales/en/academy.json
@@ -11,10 +11,48 @@
     "previous": "Previous",
     "next": "Next",
     "finish": "Finish",
+    "startQuiz": "Start quiz",
     "modulesTitle": "Modules",
     "noModules": {
       "title": "No modules yet",
       "description": "This chapter doesn't have any modules yet."
+    }
+  },
+  "quiz": {
+    "title": "Quiz",
+    "questionCounter": "Question {{current}} of {{total}}",
+    "submit": "Submit answers",
+    "answerAll": "Answer all questions to submit",
+    "retry": "Try again",
+    "backToAcademy": "Back to academy",
+    "passed": {
+      "title": "Chapter passed!"
+    },
+    "failed": {
+      "title": "Not quite yet"
+    },
+    "result": {
+      "score": "You scored {{correct}} of {{total}} ({{score}}%)",
+      "required": "You need {{required}} correct to pass."
+    },
+    "completed": {
+      "title": "Academy complete!",
+      "description": "You've passed every chapter. Congratulations!"
+    },
+    "errors": {
+      "loadFailed": "Couldn't load the quiz.",
+      "loadFailedDescription": "Please try again.",
+      "notAvailable": "This quiz isn't available.",
+      "notAvailableDescription": "This chapter has no quiz to take right now.",
+      "invalidSubmission": "Your submission was invalid. Please try again.",
+      "submitFailed": "Couldn't submit your answers. Please try again."
+    }
+  },
+  "progress": {
+    "passed": "Passed",
+    "completed": {
+      "title": "Academy complete!",
+      "description": "You've passed every chapter."
     }
   }
 }


### PR DESCRIPTION
At a quiz-enabled chapter's end the Finish button opens a quiz of up to 10 randomly drawn questions. Learners pick one answer per question, submit, and see a pass/fail result with score and the required count, retry unlimited times (each retry re-draws), and get a celebration when passing the whole academy. The chapter list shows Passed badges and an academy-completed banner from the progress endpoint. Adds the quiz route, ChapterQuizPage/QuizForm/QuizQuestionCard/QuizResultCard, the query/mutation hooks and en/de copy.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New mutation-driven learner flow depends on quiz API correctness and cache invalidation; mis-handled redirects or submission errors could block academy completion, but scope is limited to the academy feature with existing route guards.
> 
> **Overview**
> Adds a **learner quiz flow** for quiz-enabled chapters: a new authenticated route at `/academy/$chapterId/quiz` (addon + `quizEnabled` guards) renders **ChapterQuizPage**, which loads a random question set, collects answers, submits to the quiz API, and shows pass/fail with score, retry (each retry refetches with `staleTime: 0`), and whole-academy completion messaging.
> 
> **Chapter navigation** now sends learners to the quiz instead of straight back to the academy list when `quizEnabled`—on the last module, on finish, and on module-less chapters via **Start quiz**. The academy index pulls **progress** to show **Passed** badges per chapter and a completion banner when `academyCompletedAt` is set.
> 
> Supporting pieces: `useAcademyProgress`, `useChapterQuiz`, `useSubmitChapterQuiz` (invalidates progress/chapters, maps API error codes to toasts), UI building blocks (`QuizForm`, `QuizQuestionCard`, `QuizResultCard`), and en/de academy copy for quiz and progress strings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d64486491d660e6dfe45d1c19e96d6264107b6a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->