### PR TITLE
feat(academy): let super admins set the quiz pass threshold (AYC-245)

### DIFF
--- a/ayunis-core-backend/src/domain/academy/SUMMARY.md
+++ b/ayunis-core-backend/src/domain/academy/SUMMARY.md
@@ -1,39 +1,41 @@
 # Academy
 
 Platform-global learning content for the **Ayunis Core Academy** add-on
-(`AddonType.AYUNIS_CORE_ACADEMY`): chapters containing video courseModules and
-per-chapter quizzes, authored centrally by super admins. Learners in orgs with
-the add-on active read the content, take quizzes, and accumulate per-chapter
-and whole-academy completion.
+(`AddonType.AYUNIS_CORE_ACADEMY`): chapters containing video courseModules and an
+optional per-chapter quiz, authored centrally by super admins. Learners in an
+org with the add-on active read the content, take chapter quizzes, and build up
+progress toward whole-academy completion.
 
 ## Model
 
 - `AcademyChapter` — `{ id, title, description, position, quizEnabled,
-  passThreshold, courseModules[] }`. `passThreshold` is the percent of asked
-  questions that must be answered correctly (default 80).
+  passThreshold, courseModules[], quizQuestions[] }`. `quizEnabled` shows the
+  quiz at chapter end; `passThreshold` is the percent of correct answers needed
+  to pass (default 80).
 - `AcademyCourseModule` — `{ id, chapterId, title, description?, loomUrl, position }`,
   cascade-deleted with its chapter. `loomUrl` is a validated Loom share/embed
   link (`https://loom.com/(share|embed)/...`).
-- `AcademyQuizQuestion` — `{ id, chapterId, text, position, options[] }`, the
-  chapter's question pool; each option carries `text` + `isCorrect`,
-  cascade-deleted with its chapter.
-- `AcademyChapterProgress` — one row per `(user, chapter)`, upserted on every
-  attempt. `passedAt` is the most recent passing attempt and is never cleared
-  by a later failing attempt; `lastScore`/`lastAttemptAt` track the latest try.
-- `AcademyCompletion` — one row per user; `completedAt` is stamped/refreshed
-  when every currently quiz-enabled chapter is passed and is never revoked by
-  later content changes.
+- `AcademyQuizQuestion` — `{ id, chapterId, text, options[], position }`,
+  cascade-deleted with its chapter. `options` is jsonb `{ text, isCorrect }[]`
+  with 2–6 options, exactly one correct (`quiz-question-validation.ts`).
 
-## Quiz mechanics
+## Quiz-taking & progress
 
-- A quiz attempt draws `DRAWN_QUESTION_COUNT` (10) random questions from the
-  chapter pool (the whole pool if smaller). Correct answers never leave the
-  server.
-- Submit validates the answer set (exact expected count, no duplicates, all
-  ids from the chapter pool — the drawn set itself is not persisted), grades
-  against the chapter's `passThreshold` (`requiredCorrect` rounds up, e.g.
-  80% of 7 → 6), upserts chapter progress, and on a pass recomputes the
-  whole-academy completion snapshot.
+Learner-facing, add-on gated (`@RequireAddon`), correct answers never sent to
+the client:
+
+- `GetChapterQuizUseCase` draws up to `DRAWN_QUESTION_COUNT` (10) random
+  questions — the whole pool when smaller (`quiz.constants.ts`).
+- `SubmitChapterQuizUseCase` grades against `requiredCorrect(total, threshold)`
+  (ceil), enforces the drawn answer count (the drawn set itself is not
+  persisted), upserts `AcademyChapterProgress` (one row per user+chapter:
+  `passedAt` refreshed on each pass, `lastScore`), and — when every
+  `quizEnabled` chapter has a passing row — stamps the single per-user
+  `AcademyCompletion.completedAt` snapshot. That snapshot is the anchor
+  for the future access gate: it is only ever written on full completion, never
+  cleared by content changes, so adding a chapter never revokes a completion.
+- `GetAcademyProgressUseCase` returns per-chapter pass state + the completion
+  date. Unlimited retries; each retry re-draws.
 
 ## Ordering
 
@@ -57,7 +59,7 @@ Authenticated users in an org with the academy add-on active
 (`@RequireAddon(AYUNIS_CORE_ACADEMY)`), two controllers under `academy`:
 
 - `AcademyChaptersController` (`academy/chapters`) — list chapters with nested
-  ordered courseModules.
+  ordered courseModules (no quiz questions).
 - `AcademyQuizController` (`academy`) — draw a quiz
   (`GET chapters/:chapterId/quiz`), submit answers
   (`POST chapters/:chapterId/quiz/submit`), and read progress
@@ -65,24 +67,23 @@ Authenticated users in an org with the academy add-on active
 
 ## Management
 
-Super-admin only (`@SystemRoles(SUPER_ADMIN)`), three controllers under
-`super-admin/academy`:
+Super-admin only (`@SystemRoles(SUPER_ADMIN)`) under `super-admin/academy`:
 
 - `SuperAdminAcademyChaptersController` (`super-admin/academy/chapters`) —
-  list (chapters with nested ordered courseModules), create, update (incl.
-  `quizEnabled`/`passThreshold`), delete, reorder (`PUT chapters/order`,
-  declared before the `:id` routes).
+  list (chapters with nested ordered courseModules **and quiz questions incl.
+  correct answers**), create, update (title/description/`quizEnabled`/
+  `passThreshold`), delete, reorder (`PUT chapters/order`, before `:id`).
 - `SuperAdminAcademyCourseModulesController` (`super-admin/academy`) — create
   (`POST chapters/:chapterId/course-modules`), reorder
   (`PUT chapters/:chapterId/course-modules/order`), update/delete (`course-modules/:id`).
 - `SuperAdminAcademyQuizQuestionsController` (`super-admin/academy`) — create
-  (`POST chapters/:chapterId/quiz-questions`), update/delete
-  (`quiz-questions/:id`).
+  (`POST chapters/:chapterId/quiz-questions`), update/delete (`quiz-questions/:id`).
 
 ## Layout
 
-Standard hexagonal: `domain/` (chapter, courseModule, quiz question, progress
-and completion entities), `application/` (repository ports, use-cases, quiz
-constants, errors, reorder validation), `infrastructure/` (Postgres records +
-mapper + repositories), `presenters/http/` (learner + super-admin controllers,
-DTOs, response mapper).
+Standard hexagonal: `domain/` (chapter, courseModule, quizQuestion, chapter
+progress + completion entities), `application/` (repository ports, use-cases,
+errors, reorder + quiz-question validation, `quiz.constants.ts`),
+`infrastructure/` (Postgres records + mapper + repositories), `presenters/http/`
+(super-admin + learner controllers, DTOs, response mapper). The learner DTOs
+deliberately omit `isCorrect`; grading is server-side.

--- a/ayunis-core-frontend/src/pages/super-admin-settings/academy/api/useSetChapterQuizEnabled.ts
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/academy/api/useSetChapterQuizEnabled.ts
@@ -1,3 +1,4 @@
+import { useRef } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { useRouter } from '@tanstack/react-router';
 import { useTranslation } from 'react-i18next';
@@ -30,11 +31,23 @@ export function useSetChapterQuizEnabled() {
     },
   });
 
+  // A threshold blur and a switch toggle can fire in the same gesture as two
+  // concurrent updates with no ordering guarantee. Serialize them so the
+  // later user action always wins; errors surface via onError above.
+  const queueRef = useRef<Promise<unknown>>(Promise.resolve());
+  function enqueueUpdate(
+    variables: Parameters<typeof mutation.mutateAsync>[0],
+  ) {
+    queueRef.current = queueRef.current
+      .then(() => mutation.mutateAsync(variables))
+      .catch(() => undefined);
+  }
+
   function setQuizEnabled(
     chapter: SuperAdminAcademyChapterResponseDto,
     quizEnabled: boolean,
   ) {
-    mutation.mutate({
+    enqueueUpdate({
       id: chapter.id,
       data: {
         title: chapter.title,
@@ -44,8 +57,25 @@ export function useSetChapterQuizEnabled() {
     });
   }
 
+  function setPassThreshold(
+    chapter: SuperAdminAcademyChapterResponseDto,
+    passThreshold: number,
+  ) {
+    enqueueUpdate({
+      id: chapter.id,
+      data: {
+        title: chapter.title,
+        description: chapter.description,
+        // quizEnabled is deliberately omitted (backend keeps the current
+        // value), so a threshold update can never replay a stale toggle.
+        passThreshold,
+      },
+    });
+  }
+
   return {
     setQuizEnabled,
+    setPassThreshold,
     isSettingQuiz: mutation.isPending,
   };
 }

--- a/ayunis-core-frontend/src/pages/super-admin-settings/academy/ui/QuizSection.tsx
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/academy/ui/QuizSection.tsx
@@ -14,6 +14,7 @@ import {
 import { Button } from '@/shared/ui/shadcn/button';
 import { Switch } from '@/shared/ui/shadcn/switch';
 import { Label } from '@/shared/ui/shadcn/label';
+import { Input } from '@/shared/ui/shadcn/input';
 import { useConfirmation } from '@/widgets/confirmation-modal';
 import { QuestionFormDialog } from './QuestionFormDialog';
 import { useDeleteQuestion } from '../api/useDeleteQuestion';
@@ -28,9 +29,23 @@ export function QuizSection({ chapter }: Readonly<QuizSectionProps>) {
   const [dialogQuestion, setDialogQuestion] =
     useState<QuizQuestionResponseDto | null>(null);
   const [dialogOpen, setDialogOpen] = useState(false);
-  const { setQuizEnabled, isSettingQuiz } = useSetChapterQuizEnabled();
+  const { setQuizEnabled, setPassThreshold, isSettingQuiz } =
+    useSetChapterQuizEnabled();
   const { deleteQuestion, isDeleting } = useDeleteQuestion();
   const { confirm } = useConfirmation();
+  const [threshold, setThreshold] = useState(chapter.passThreshold);
+
+  function commitThreshold() {
+    // A cleared field yields NaN — revert to the saved value instead of
+    // sending an invalid payload.
+    if (Number.isNaN(threshold)) {
+      setThreshold(chapter.passThreshold);
+      return;
+    }
+    const clamped = Math.min(100, Math.max(1, Math.round(threshold)));
+    if (clamped !== threshold) setThreshold(clamped);
+    if (clamped !== chapter.passThreshold) setPassThreshold(chapter, clamped);
+  }
 
   function openCreate() {
     setDialogQuestion(null);
@@ -72,6 +87,28 @@ export function QuizSection({ chapter }: Readonly<QuizSectionProps>) {
           {t('quiz.addQuestion')}
         </Button>
       </div>
+
+      {chapter.quizEnabled && (
+        <div className="flex items-center gap-2">
+          <Label htmlFor={`quiz-threshold-${chapter.id}`}>
+            {t('quiz.thresholdLabel')}
+          </Label>
+          <Input
+            id={`quiz-threshold-${chapter.id}`}
+            type="number"
+            min={1}
+            max={100}
+            className="w-20"
+            value={threshold}
+            disabled={isSettingQuiz}
+            onChange={(e) => setThreshold(e.target.valueAsNumber)}
+            onBlur={commitThreshold}
+          />
+          <span className="text-sm text-muted-foreground">
+            {t('quiz.thresholdSuffix')}
+          </span>
+        </div>
+      )}
 
       {chapter.quizQuestions.length === 0 ? (
         <p className="py-1 text-sm text-muted-foreground">

--- a/ayunis-core-frontend/src/shared/locales/de/super-admin-settings-academy.json
+++ b/ayunis-core-frontend/src/shared/locales/de/super-admin-settings-academy.json
@@ -46,7 +46,9 @@
   "quiz": {
     "enableLabel": "Quiz aktiviert",
     "addQuestion": "Frage hinzufügen",
-    "noQuestions": "Noch keine Quizfragen."
+    "noQuestions": "Noch keine Quizfragen.",
+    "thresholdLabel": "Bestehensschwelle",
+    "thresholdSuffix": "% richtig zum Bestehen"
   },
   "questionForm": {
     "createTitle": "Frage erstellen",

--- a/ayunis-core-frontend/src/shared/locales/en/super-admin-settings-academy.json
+++ b/ayunis-core-frontend/src/shared/locales/en/super-admin-settings-academy.json
@@ -46,7 +46,9 @@
   "quiz": {
     "enableLabel": "Quiz enabled",
     "addQuestion": "Add Question",
-    "noQuestions": "No quiz questions yet."
+    "noQuestions": "No quiz questions yet.",
+    "thresholdLabel": "Pass threshold",
+    "thresholdSuffix": "% correct to pass"
   },
   "questionForm": {
     "createTitle": "Create Question",


### PR DESCRIPTION
Add a per-chapter pass-threshold input to the super-admin quiz section (persisted via the chapter update, 1-100%, default 80). Update the academy module SUMMARY to document quiz-taking, per-chapter progress and the whole-academy completion snapshot.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Super-admin-only UI and docs on top of existing chapter update and grading; main risk is concurrent-update ordering, which the new queue addresses.
> 
> **Overview**
> Super admins can now set each chapter’s **quiz pass threshold** (1–100%, saved on blur) from the academy quiz section when the quiz is enabled. Values are clamped and invalid empty input reverts to the saved threshold; updates go through the existing chapter update API with **`passThreshold` only** ( **`quizEnabled` omitted** ) so threshold saves don’t replay a stale toggle.
> 
> **`useSetChapterQuizEnabled`** now exposes **`setPassThreshold`** and **serializes** chapter updates in a queue so a threshold blur and quiz toggle in the same gesture don’t race.
> 
> The academy **`SUMMARY.md`** is refreshed to document **`passThreshold`**, quiz-taking/progress/completion behavior, and super-admin chapter updates. EN/DE copy adds threshold label strings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44a12cd5550adabac38176c00a0905806872124b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->