### PR TITLE
feat(openai-compat): support /v1/models list and retrieve endpoints (AYC-392)

### DIFF
--- a/ayunis-core-backend/src/domain/openai-compat/SUMMARY.md
+++ b/ayunis-core-backend/src/domain/openai-compat/SUMMARY.md
@@ -1,7 +1,7 @@
 OpenAI-compatible Chat Completions
-Stateless POST /api/openai-compat/v1/chat/completions surface compatible with the OpenAI SDK (clients configure `base_url=…/api/openai-compat/v1`)
+Stateless POST /api/openai-compat/v1/chat/completions and GET /api/openai-compat/v1/models surface compatible with the OpenAI SDK (clients configure `base_url=…/api/openai-compat/v1`)
 
-This module exposes an OpenAI-compatible chat-completions endpoint so external clients can target ayunis with the standard OpenAI SDK. The surface is stateless — no thread persistence, `threadId` is synthesised per request — and authenticated via API key.
+This module exposes an OpenAI-compatible chat-completions endpoint plus model list/retrieve endpoints so external clients can target ayunis with the standard OpenAI SDK (many clients verify connections and populate model pickers via `GET /v1/models`). The surface is stateless — no thread persistence, `threadId` is synthesised per request — and authenticated via API key.
 
 The module consumes `ModelsModule` for `GetPermittedLanguageModelsUseCase`, `GetInferenceUseCase`, and `StreamInferenceUseCase`, `RunsModule` for `InferenceUsageGuard` (preflight quota check + post-hoc usage accounting), `AuthorizationModule` for `SubscriptionGuard` (bound at the controller so it runs AFTER `AuthGuard('api-key')` populates `request.user`), and `TrialsModule` for `IncrementTrialMessagesUseCase` (trial message counting that mirrors `RunsController.send-message`). It does not own its own persistence. Cross-module imports of inference port shapes (`StreamInferenceInput`, `InferenceResponse`, chunk types) are an intentional trade-off baselined in `.dependency-cruiser-known-violations.json` for the openai-compat → models edge.
 
@@ -9,8 +9,12 @@ The module consumes `ModelsModule` for `GetPermittedLanguageModelsUseCase`, `Get
 
 - **ChatCompletionsController** (`presenters/http/chat-completions.controller.ts`): POST `/api/openai-compat/v1/chat/completions` (controller path `openai-compat/v1/chat` + global `api` prefix; SDK clients set `base_url=…/api/openai-compat/v1`) supporting both non-streaming JSON and Server-Sent Events streaming. Authenticated via `@UseGuards(AuthGuard('api-key'), SubscriptionGuard)` (overrides the global `JwtAuthGuard` for this route) with `@RequireSubscription({ type: SubscriptionType.USAGE_BASED })` so only orgs with a usage-based subscription — or remaining trial messages — may call the endpoint. When the gate is satisfied via the trial fallback, the controller fires `IncrementTrialMessagesUseCase` once per completion (fire-and-forget, failures logged but never blocking). Rate-limited at 60 requests/minute per client IP via the global `RateLimitGuard` (production only; the guard short-circuits in non-prod). All orchestration is delegated to the use case; the controller only handles DTO ↔ command conversion, trial accounting, and SSE framing.
 
+- **ModelsController** (`presenters/http/models.controller.ts`): GET `/api/openai-compat/v1/models` (list) and GET `/api/openai-compat/v1/models/:model` (retrieve). Same guard/filter stack as `ChatCompletionsController` (api-key auth, `SubscriptionGuard` + `@RequireSubscription(USAGE_BASED)`, `OpenAIExceptionFilter`, 60 req/min rate limit). Returns the caller's org-permitted language models in the OpenAI list/model shape; `id` is the internal `Model.name` so listed ids are directly usable as the `"model"` field on chat completions. No trial accounting — that is chat-only.
+
 ## Use Cases
 
+- **ListOpenAIModelsUseCase** (`application/use-cases/list-openai-models`): Fetches the org's permitted language models via `GetPermittedLanguageModelsUseCase`, dedupes by `Model.name` (first occurrence wins, mirroring the chat use case's `find()`-based model resolution), and maps to the OpenAI list envelope.
+- **GetOpenAIModelUseCase** (`application/use-cases/get-openai-model`): Composes `ListOpenAIModelsUseCase` and returns the entry matching the requested name, throwing `OpenAIModelNotFoundError` (404) otherwise.
 - **ExecuteOpenAIChatCompletionUseCase** (`application/use-cases/execute-openai-chat-completion`): Sole orchestrator on this surface. Resolves the requested model against the caller's org permits, runs `InferenceUsageGuard.preflight`, dispatches to `GetInferenceUseCase` (non-streaming) or `StreamInferenceUseCase` (streaming), and accounts usage via `InferenceUsageGuard.collectUsage`. Streaming usage is recorded via RxJS `finalize()` so totals are summed across chunks and flushed on complete, error, or client unsubscribe (AYC-92 streaming usage-drift fix).
 
 ## Mappers
@@ -19,6 +23,7 @@ The module consumes `ModelsModule` for `GetPermittedLanguageModelsUseCase`, `Get
 - **OpenAIResponseMapper** (`application/mappers/openai-response.mapper.ts`): Converts an `InferenceResponse` into the OpenAI `chat.completion` shape.
 - **OpenAIStreamMapper** (`application/mappers/openai-stream.mapper.ts`): Converts a domain stream chunk into an OpenAI `chat.completion.chunk`, dropping empty/thinking-only/usage-only chunks (returns `null`, filtered upstream).
 - **OpenAIErrorMapper** (`application/mappers/openai-error.mapper.ts`): Converts domain errors to OpenAI-style error response bodies.
+- **OpenAIModelMapper** (`application/mappers/openai-model.mapper.ts`): Converts a `LanguageModel` into the OpenAI model object (`id` = `Model.name`, `owned_by` = provider, `created` = unix seconds from `createdAt`) and wraps lists in the OpenAI list envelope.
 
 ## Filters
 

--- a/ayunis-core-backend/src/domain/openai-compat/application/mappers/openai-model.mapper.spec.ts
+++ b/ayunis-core-backend/src/domain/openai-compat/application/mappers/openai-model.mapper.spec.ts
@@ -1,0 +1,56 @@
+import { OpenAIModelMapper } from './openai-model.mapper';
+import { LanguageModel } from 'src/domain/models/domain/models/language.model';
+import { ModelProvider } from 'src/domain/models/domain/value-objects/model-provider.enum';
+
+describe('OpenAIModelMapper', () => {
+  const mapper = new OpenAIModelMapper();
+
+  const buildModel = (
+    overrides?: Partial<ConstructorParameters<typeof LanguageModel>[0]>,
+  ): LanguageModel =>
+    new LanguageModel({
+      name: 'gpt-4o',
+      provider: ModelProvider.OPENAI,
+      displayName: 'GPT-4o',
+      canStream: true,
+      canUseTools: true,
+      isReasoning: false,
+      canVision: false,
+      isArchived: false,
+      ...overrides,
+    });
+
+  describe('toModelObject', () => {
+    it('maps name, provider, and createdAt to the OpenAI model shape', () => {
+      const createdAt = new Date('2025-06-01T12:00:00.500Z');
+      const result = mapper.toModelObject(buildModel({ createdAt }));
+
+      expect(result).toEqual({
+        id: 'gpt-4o',
+        object: 'model',
+        created: Math.floor(createdAt.getTime() / 1000),
+        owned_by: ModelProvider.OPENAI,
+      });
+    });
+  });
+
+  describe('toListResponse', () => {
+    it('wraps mapped models in an OpenAI list envelope', () => {
+      const result = mapper.toListResponse([
+        buildModel(),
+        buildModel({
+          name: 'claude-sonnet',
+          provider: ModelProvider.ANTHROPIC,
+        }),
+      ]);
+
+      expect(result.object).toBe('list');
+      expect(result.data.map((m) => m.id)).toEqual(['gpt-4o', 'claude-sonnet']);
+      expect(result.data.every((m) => m.object === 'model')).toBe(true);
+    });
+
+    it('returns an empty data array for no models', () => {
+      expect(mapper.toListResponse([])).toEqual({ object: 'list', data: [] });
+    });
+  });
+});

--- a/ayunis-core-backend/src/domain/openai-compat/application/mappers/openai-model.mapper.ts
+++ b/ayunis-core-backend/src/domain/openai-compat/application/mappers/openai-model.mapper.ts
@@ -1,0 +1,28 @@
+import { Injectable } from '@nestjs/common';
+import type { LanguageModel } from 'src/domain/models/domain/models/language.model';
+import type {
+  OpenAIModelListResponse,
+  OpenAIModelObject,
+} from '../types/openai-model.types';
+
+@Injectable()
+export class OpenAIModelMapper {
+  toModelObject(model: LanguageModel): OpenAIModelObject {
+    return {
+      // `id` must be the internal model name — chat/completions resolves the
+      // request's "model" field against `Model.name`, so whatever this list
+      // returns has to be directly usable there.
+      id: model.name,
+      object: 'model',
+      created: Math.floor(model.createdAt.getTime() / 1000),
+      owned_by: model.provider,
+    };
+  }
+
+  toListResponse(models: LanguageModel[]): OpenAIModelListResponse {
+    return {
+      object: 'list',
+      data: models.map((model) => this.toModelObject(model)),
+    };
+  }
+}

--- a/ayunis-core-backend/src/domain/openai-compat/application/openai-compat.errors.ts
+++ b/ayunis-core-backend/src/domain/openai-compat/application/openai-compat.errors.ts
@@ -4,6 +4,7 @@ import type { ErrorMetadata } from 'src/common/errors/base.error';
 export enum OpenAICompatErrorCode {
   INVALID_REQUEST = 'OPENAI_COMPAT_INVALID_REQUEST',
   MODEL_NOT_FOUND = 'OPENAI_COMPAT_MODEL_NOT_FOUND',
+  UNEXPECTED = 'OPENAI_COMPAT_UNEXPECTED',
 }
 
 export class OpenAIInvalidRequestError extends ApplicationError {
@@ -20,5 +21,13 @@ export class OpenAIModelNotFoundError extends ApplicationError {
       404,
       { modelName },
     );
+  }
+}
+
+export class OpenAIUnexpectedError extends ApplicationError {
+  constructor(error: unknown) {
+    super('Unexpected error occurred', OpenAICompatErrorCode.UNEXPECTED, 500, {
+      error,
+    });
   }
 }

--- a/ayunis-core-backend/src/domain/openai-compat/application/types/openai-model.types.ts
+++ b/ayunis-core-backend/src/domain/openai-compat/application/types/openai-model.types.ts
@@ -1,0 +1,11 @@
+export interface OpenAIModelObject {
+  id: string;
+  object: 'model';
+  created: number;
+  owned_by: string;
+}
+
+export interface OpenAIModelListResponse {
+  object: 'list';
+  data: OpenAIModelObject[];
+}

--- a/ayunis-core-backend/src/domain/openai-compat/application/use-cases/get-openai-model/get-openai-model.query.ts
+++ b/ayunis-core-backend/src/domain/openai-compat/application/use-cases/get-openai-model/get-openai-model.query.ts
@@ -1,0 +1,8 @@
+import type { UUID } from 'crypto';
+
+export class GetOpenAIModelQuery {
+  constructor(
+    public readonly orgId: UUID,
+    public readonly modelName: string,
+  ) {}
+}

--- a/ayunis-core-backend/src/domain/openai-compat/application/use-cases/get-openai-model/get-openai-model.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/openai-compat/application/use-cases/get-openai-model/get-openai-model.use-case.spec.ts
@@ -1,0 +1,44 @@
+import { randomUUID } from 'crypto';
+import { GetOpenAIModelUseCase } from './get-openai-model.use-case';
+import { GetOpenAIModelQuery } from './get-openai-model.query';
+import type { ListOpenAIModelsUseCase } from '../list-openai-models/list-openai-models.use-case';
+import { OpenAIModelNotFoundError } from '../../openai-compat.errors';
+import type { OpenAIModelObject } from '../../types/openai-model.types';
+
+describe('GetOpenAIModelUseCase', () => {
+  let useCase: GetOpenAIModelUseCase;
+  let listOpenAIModelsUseCase: jest.Mocked<ListOpenAIModelsUseCase>;
+
+  const orgId = randomUUID();
+
+  const modelObject: OpenAIModelObject = {
+    id: 'gpt-4o',
+    object: 'model',
+    created: 1_748_736_000,
+    owned_by: 'openai',
+  };
+
+  beforeEach(() => {
+    listOpenAIModelsUseCase = {
+      execute: jest
+        .fn()
+        .mockResolvedValue({ object: 'list', data: [modelObject] }),
+    } as unknown as jest.Mocked<ListOpenAIModelsUseCase>;
+
+    useCase = new GetOpenAIModelUseCase(listOpenAIModelsUseCase);
+  });
+
+  it('returns the model object matching the requested name', async () => {
+    const result = await useCase.execute(
+      new GetOpenAIModelQuery(orgId, 'gpt-4o'),
+    );
+
+    expect(result).toEqual(modelObject);
+  });
+
+  it('throws OpenAIModelNotFoundError for an unknown model name', async () => {
+    await expect(
+      useCase.execute(new GetOpenAIModelQuery(orgId, 'does-not-exist')),
+    ).rejects.toThrow(OpenAIModelNotFoundError);
+  });
+});

--- a/ayunis-core-backend/src/domain/openai-compat/application/use-cases/get-openai-model/get-openai-model.use-case.ts
+++ b/ayunis-core-backend/src/domain/openai-compat/application/use-cases/get-openai-model/get-openai-model.use-case.ts
@@ -1,0 +1,43 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ApplicationError } from 'src/common/errors/base.error';
+import {
+  OpenAIModelNotFoundError,
+  OpenAIUnexpectedError,
+} from '../../openai-compat.errors';
+import type { OpenAIModelObject } from '../../types/openai-model.types';
+import { ListOpenAIModelsUseCase } from '../list-openai-models/list-openai-models.use-case';
+import { ListOpenAIModelsQuery } from '../list-openai-models/list-openai-models.query';
+import { GetOpenAIModelQuery } from './get-openai-model.query';
+
+@Injectable()
+export class GetOpenAIModelUseCase {
+  private readonly logger = new Logger(GetOpenAIModelUseCase.name);
+
+  constructor(
+    private readonly listOpenAIModelsUseCase: ListOpenAIModelsUseCase,
+  ) {}
+
+  async execute(query: GetOpenAIModelQuery): Promise<OpenAIModelObject> {
+    this.logger.log('Getting OpenAI-compatible model', {
+      orgId: query.orgId,
+      modelName: query.modelName,
+    });
+
+    try {
+      const list = await this.listOpenAIModelsUseCase.execute(
+        new ListOpenAIModelsQuery(query.orgId),
+      );
+      const match = list.data.find((model) => model.id === query.modelName);
+      if (!match) {
+        throw new OpenAIModelNotFoundError(query.modelName);
+      }
+      return match;
+    } catch (error) {
+      if (error instanceof ApplicationError) throw error;
+      this.logger.error('Error getting OpenAI-compatible model', {
+        error: error as Error,
+      });
+      throw new OpenAIUnexpectedError(error);
+    }
+  }
+}

--- a/ayunis-core-backend/src/domain/openai-compat/application/use-cases/list-openai-models/list-openai-models.query.ts
+++ b/ayunis-core-backend/src/domain/openai-compat/application/use-cases/list-openai-models/list-openai-models.query.ts
@@ -1,0 +1,5 @@
+import type { UUID } from 'crypto';
+
+export class ListOpenAIModelsQuery {
+  constructor(public readonly orgId: UUID) {}
+}

--- a/ayunis-core-backend/src/domain/openai-compat/application/use-cases/list-openai-models/list-openai-models.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/openai-compat/application/use-cases/list-openai-models/list-openai-models.use-case.spec.ts
@@ -1,0 +1,110 @@
+import { randomUUID } from 'crypto';
+import { ListOpenAIModelsUseCase } from './list-openai-models.use-case';
+import { ListOpenAIModelsQuery } from './list-openai-models.query';
+import type { GetPermittedLanguageModelsUseCase } from 'src/domain/models/application/use-cases/get-permitted-language-models/get-permitted-language-models.use-case';
+import { LanguageModel } from 'src/domain/models/domain/models/language.model';
+import { PermittedLanguageModel } from 'src/domain/models/domain/permitted-model.entity';
+import { ModelProvider } from 'src/domain/models/domain/value-objects/model-provider.enum';
+import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
+import { OpenAIUnexpectedError } from '../../openai-compat.errors';
+import { OpenAIModelMapper } from '../../mappers/openai-model.mapper';
+
+describe('ListOpenAIModelsUseCase', () => {
+  let useCase: ListOpenAIModelsUseCase;
+  let getPermittedLanguageModelsUseCase: jest.Mocked<GetPermittedLanguageModelsUseCase>;
+
+  const orgId = randomUUID();
+
+  const buildModel = (
+    overrides?: Partial<ConstructorParameters<typeof LanguageModel>[0]>,
+  ): LanguageModel =>
+    new LanguageModel({
+      name: 'gpt-4o',
+      provider: ModelProvider.OPENAI,
+      displayName: 'GPT-4o',
+      canStream: true,
+      canUseTools: true,
+      isReasoning: false,
+      canVision: false,
+      isArchived: false,
+      ...overrides,
+    });
+
+  const permit = (model: LanguageModel): PermittedLanguageModel =>
+    new PermittedLanguageModel({ model, orgId });
+
+  beforeEach(() => {
+    getPermittedLanguageModelsUseCase = {
+      execute: jest.fn().mockResolvedValue([]),
+    } as unknown as jest.Mocked<GetPermittedLanguageModelsUseCase>;
+
+    useCase = new ListOpenAIModelsUseCase(
+      getPermittedLanguageModelsUseCase,
+      new OpenAIModelMapper(),
+    );
+  });
+
+  it('returns permitted models mapped to the OpenAI list shape', async () => {
+    const createdAt = new Date('2025-06-01T00:00:00Z');
+    getPermittedLanguageModelsUseCase.execute.mockResolvedValue([
+      permit(buildModel({ createdAt })),
+      permit(
+        buildModel({
+          name: 'claude-sonnet',
+          provider: ModelProvider.ANTHROPIC,
+        }),
+      ),
+    ]);
+
+    const result = await useCase.execute(new ListOpenAIModelsQuery(orgId));
+
+    expect(result.object).toBe('list');
+    expect(result.data).toHaveLength(2);
+    expect(result.data[0]).toEqual({
+      id: 'gpt-4o',
+      object: 'model',
+      created: Math.floor(createdAt.getTime() / 1000),
+      owned_by: ModelProvider.OPENAI,
+    });
+    expect(result.data[1].id).toBe('claude-sonnet');
+    expect(result.data[1].owned_by).toBe(ModelProvider.ANTHROPIC);
+  });
+
+  it('returns an empty list when no models are permitted', async () => {
+    const result = await useCase.execute(new ListOpenAIModelsQuery(orgId));
+
+    expect(result).toEqual({ object: 'list', data: [] });
+  });
+
+  it('dedupes models sharing a name, keeping the first occurrence', async () => {
+    getPermittedLanguageModelsUseCase.execute.mockResolvedValue([
+      permit(buildModel({ name: 'shared', provider: ModelProvider.OPENAI })),
+      permit(buildModel({ name: 'shared', provider: ModelProvider.AZURE })),
+    ]);
+
+    const result = await useCase.execute(new ListOpenAIModelsQuery(orgId));
+
+    expect(result.data).toHaveLength(1);
+    expect(result.data[0].owned_by).toBe(ModelProvider.OPENAI);
+  });
+
+  it('rethrows ApplicationError subclasses unchanged', async () => {
+    getPermittedLanguageModelsUseCase.execute.mockRejectedValue(
+      new UnauthorizedAccessError(),
+    );
+
+    await expect(
+      useCase.execute(new ListOpenAIModelsQuery(orgId)),
+    ).rejects.toThrow(UnauthorizedAccessError);
+  });
+
+  it('wraps unexpected errors in OpenAIUnexpectedError', async () => {
+    getPermittedLanguageModelsUseCase.execute.mockRejectedValue(
+      new Error('db down'),
+    );
+
+    await expect(
+      useCase.execute(new ListOpenAIModelsQuery(orgId)),
+    ).rejects.toThrow(OpenAIUnexpectedError);
+  });
+});

--- a/ayunis-core-backend/src/domain/openai-compat/application/use-cases/list-openai-models/list-openai-models.use-case.ts
+++ b/ayunis-core-backend/src/domain/openai-compat/application/use-cases/list-openai-models/list-openai-models.use-case.ts
@@ -1,0 +1,49 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ApplicationError } from 'src/common/errors/base.error';
+import { GetPermittedLanguageModelsUseCase } from 'src/domain/models/application/use-cases/get-permitted-language-models/get-permitted-language-models.use-case';
+import { GetPermittedLanguageModelsQuery } from 'src/domain/models/application/use-cases/get-permitted-language-models/get-permitted-language-models.query';
+import type { LanguageModel } from 'src/domain/models/domain/models/language.model';
+import { OpenAIUnexpectedError } from '../../openai-compat.errors';
+import { OpenAIModelMapper } from '../../mappers/openai-model.mapper';
+import type { OpenAIModelListResponse } from '../../types/openai-model.types';
+import { ListOpenAIModelsQuery } from './list-openai-models.query';
+
+@Injectable()
+export class ListOpenAIModelsUseCase {
+  private readonly logger = new Logger(ListOpenAIModelsUseCase.name);
+
+  constructor(
+    private readonly getPermittedLanguageModelsUseCase: GetPermittedLanguageModelsUseCase,
+    private readonly modelMapper: OpenAIModelMapper,
+  ) {}
+
+  async execute(
+    query: ListOpenAIModelsQuery,
+  ): Promise<OpenAIModelListResponse> {
+    this.logger.log('Listing OpenAI-compatible models', { orgId: query.orgId });
+
+    try {
+      const permitted = await this.getPermittedLanguageModelsUseCase.execute(
+        new GetPermittedLanguageModelsQuery(query.orgId),
+      );
+
+      // Dedupe by name, first occurrence wins — chat/completions resolves the
+      // "model" field with `find()` over the same list, so this keeps the
+      // advertised ids exactly the set of names a completion request accepts.
+      const byName = new Map<string, LanguageModel>();
+      for (const { model } of permitted) {
+        if (!byName.has(model.name)) {
+          byName.set(model.name, model);
+        }
+      }
+
+      return this.modelMapper.toListResponse([...byName.values()]);
+    } catch (error) {
+      if (error instanceof ApplicationError) throw error;
+      this.logger.error('Error listing OpenAI-compatible models', {
+        error: error as Error,
+      });
+      throw new OpenAIUnexpectedError(error);
+    }
+  }
+}

--- a/ayunis-core-backend/src/domain/openai-compat/openai-compat.module.ts
+++ b/ayunis-core-backend/src/domain/openai-compat/openai-compat.module.ts
@@ -4,7 +4,11 @@ import { ModelsModule } from '../models/models.module';
 import { RunsModule } from '../runs/runs.module';
 import { AuthorizationModule } from 'src/iam/authorization/authorization.module';
 import { ChatCompletionsController } from './presenters/http/chat-completions.controller';
+import { ModelsController } from './presenters/http/models.controller';
 import { ExecuteOpenAIChatCompletionUseCase } from './application/use-cases/execute-openai-chat-completion/execute-openai-chat-completion.use-case';
+import { ListOpenAIModelsUseCase } from './application/use-cases/list-openai-models/list-openai-models.use-case';
+import { GetOpenAIModelUseCase } from './application/use-cases/get-openai-model/get-openai-model.use-case';
+import { OpenAIModelMapper } from './application/mappers/openai-model.mapper';
 import { OpenAIRequestMapper } from './application/mappers/openai-request.mapper';
 import { OpenAIResponseMapper } from './application/mappers/openai-response.mapper';
 import { OpenAIStreamMapper } from './application/mappers/openai-stream.mapper';
@@ -29,9 +33,12 @@ import { ApplicationErrorFilter } from 'src/common/filters/application-error.fil
     // resolves it from Passport at request time and needs no import here.
     // `@Public()` is read by JwtAuthGuard via Reflector — also no import needed.
   ],
-  controllers: [ChatCompletionsController],
+  controllers: [ChatCompletionsController, ModelsController],
   providers: [
     ExecuteOpenAIChatCompletionUseCase,
+    ListOpenAIModelsUseCase,
+    GetOpenAIModelUseCase,
+    OpenAIModelMapper,
     OpenAIRequestMapper,
     OpenAIResponseMapper,
     OpenAIStreamMapper,

--- a/ayunis-core-backend/src/domain/openai-compat/presenters/http/models.controller.ts
+++ b/ayunis-core-backend/src/domain/openai-compat/presenters/http/models.controller.ts
@@ -1,0 +1,68 @@
+import { Controller, Get, Param, UseFilters, UseGuards } from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+import type { UUID } from 'crypto';
+import { ContextService } from 'src/common/context/services/context.service';
+import { RateLimit } from 'src/iam/authorization/application/decorators/rate-limit.decorator';
+import { RequireSubscription } from 'src/iam/authorization/application/decorators/subscription.decorator';
+import { SubscriptionGuard } from 'src/iam/authorization/application/guards/subscription.guard';
+import { SubscriptionType } from 'src/iam/subscriptions/domain/value-objects/subscription-type.enum';
+import { Public } from 'src/common/guards/public.guard';
+import { ListOpenAIModelsUseCase } from '../../application/use-cases/list-openai-models/list-openai-models.use-case';
+import { ListOpenAIModelsQuery } from '../../application/use-cases/list-openai-models/list-openai-models.query';
+import { GetOpenAIModelUseCase } from '../../application/use-cases/get-openai-model/get-openai-model.use-case';
+import { GetOpenAIModelQuery } from '../../application/use-cases/get-openai-model/get-openai-model.query';
+import type {
+  OpenAIModelListResponse,
+  OpenAIModelObject,
+} from '../../application/types/openai-model.types';
+import { OpenAIExceptionFilter } from './filters/openai-exception.filter';
+
+/**
+ * OpenAI-compatible model endpoints. Many OpenAI SDK clients verify a
+ * connection and populate their model pickers via `GET /v1/models`, so
+ * these routes exist purely for client compatibility.
+ *
+ * The guard/filter stack mirrors `ChatCompletionsController` — see the
+ * comment there for why `SubscriptionGuard` is bound controller-scoped
+ * (it must run AFTER api-key auth populates `request.user`) and why
+ * `OpenAIExceptionFilter` is registered via `@UseFilters` in addition to
+ * the module-level APP_FILTER.
+ */
+@Controller('openai-compat/v1/models')
+@Public() // bypass the global JwtAuthGuard; AuthGuard('api-key') takes over
+@UseGuards(AuthGuard('api-key'), SubscriptionGuard)
+@RequireSubscription({ type: SubscriptionType.USAGE_BASED })
+@UseFilters(OpenAIExceptionFilter)
+@RateLimit({ limit: 60, windowMs: 60_000 })
+export class ModelsController {
+  constructor(
+    private readonly listOpenAIModelsUseCase: ListOpenAIModelsUseCase,
+    private readonly getOpenAIModelUseCase: GetOpenAIModelUseCase,
+    private readonly contextService: ContextService,
+  ) {}
+
+  @Get()
+  async list(): Promise<OpenAIModelListResponse> {
+    return this.listOpenAIModelsUseCase.execute(
+      new ListOpenAIModelsQuery(this.resolveOrgId()),
+    );
+  }
+
+  @Get(':model')
+  async retrieve(@Param('model') model: string): Promise<OpenAIModelObject> {
+    return this.getOpenAIModelUseCase.execute(
+      new GetOpenAIModelQuery(this.resolveOrgId(), model),
+    );
+  }
+
+  private resolveOrgId(): UUID {
+    // ApiKeyStrategy populates the context. Throwing here means the guard
+    // somehow let an unauthenticated request through; surfaces as a 500
+    // 'server_error' to the client.
+    const orgId = this.contextService.get('orgId');
+    if (!orgId) {
+      throw new Error('orgId missing from context after auth');
+    }
+    return orgId;
+  }
+}

--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.ts
@@ -17756,6 +17756,180 @@ const {mutation: mutationOptions} = options ?
       return useMutation(mutationOptions, queryClient);
     }
     
+export const modelsControllerList = (
+    
+ signal?: AbortSignal
+) => {
+      
+      
+      return customAxiosInstance<void>(
+      {url: `/openai-compat/v1/models`, method: 'GET', signal
+    },
+      );
+    }
+  
+
+
+
+export const getModelsControllerListQueryKey = () => {
+    return [
+    `/openai-compat/v1/models`
+    ] as const;
+    }
+
+    
+export const getModelsControllerListQueryOptions = <TData = Awaited<ReturnType<typeof modelsControllerList>>, TError = unknown>( options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof modelsControllerList>>, TError, TData>>, }
+) => {
+
+const {query: queryOptions} = options ?? {};
+
+  const queryKey =  queryOptions?.queryKey ?? getModelsControllerListQueryKey();
+
+  
+
+    const queryFn: QueryFunction<Awaited<ReturnType<typeof modelsControllerList>>> = ({ signal }) => modelsControllerList(signal);
+
+      
+
+      
+
+   return  { queryKey, queryFn, ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof modelsControllerList>>, TError, TData> & { queryKey: DataTag<QueryKey, TData, TError> }
+}
+
+export type ModelsControllerListQueryResult = NonNullable<Awaited<ReturnType<typeof modelsControllerList>>>
+export type ModelsControllerListQueryError = unknown
+
+
+export function useModelsControllerList<TData = Awaited<ReturnType<typeof modelsControllerList>>, TError = unknown>(
+  options: { query:Partial<UseQueryOptions<Awaited<ReturnType<typeof modelsControllerList>>, TError, TData>> & Pick<
+        DefinedInitialDataOptions<
+          Awaited<ReturnType<typeof modelsControllerList>>,
+          TError,
+          Awaited<ReturnType<typeof modelsControllerList>>
+        > , 'initialData'
+      >, }
+ , queryClient?: QueryClient
+  ):  DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useModelsControllerList<TData = Awaited<ReturnType<typeof modelsControllerList>>, TError = unknown>(
+  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof modelsControllerList>>, TError, TData>> & Pick<
+        UndefinedInitialDataOptions<
+          Awaited<ReturnType<typeof modelsControllerList>>,
+          TError,
+          Awaited<ReturnType<typeof modelsControllerList>>
+        > , 'initialData'
+      >, }
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useModelsControllerList<TData = Awaited<ReturnType<typeof modelsControllerList>>, TError = unknown>(
+  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof modelsControllerList>>, TError, TData>>, }
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+
+export function useModelsControllerList<TData = Awaited<ReturnType<typeof modelsControllerList>>, TError = unknown>(
+  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof modelsControllerList>>, TError, TData>>, }
+ , queryClient?: QueryClient 
+ ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
+
+  const queryOptions = getModelsControllerListQueryOptions(options)
+
+  const query = useQuery(queryOptions, queryClient) as  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+
+  query.queryKey = queryOptions.queryKey ;
+
+  return query;
+}
+
+
+
+
+
+export const modelsControllerRetrieve = (
+    model: string,
+ signal?: AbortSignal
+) => {
+      
+      
+      return customAxiosInstance<void>(
+      {url: `/openai-compat/v1/models/${model}`, method: 'GET', signal
+    },
+      );
+    }
+  
+
+
+
+export const getModelsControllerRetrieveQueryKey = (model?: string,) => {
+    return [
+    `/openai-compat/v1/models/${model}`
+    ] as const;
+    }
+
+    
+export const getModelsControllerRetrieveQueryOptions = <TData = Awaited<ReturnType<typeof modelsControllerRetrieve>>, TError = unknown>(model: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof modelsControllerRetrieve>>, TError, TData>>, }
+) => {
+
+const {query: queryOptions} = options ?? {};
+
+  const queryKey =  queryOptions?.queryKey ?? getModelsControllerRetrieveQueryKey(model);
+
+  
+
+    const queryFn: QueryFunction<Awaited<ReturnType<typeof modelsControllerRetrieve>>> = ({ signal }) => modelsControllerRetrieve(model, signal);
+
+      
+
+      
+
+   return  { queryKey, queryFn, enabled: !!(model), ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof modelsControllerRetrieve>>, TError, TData> & { queryKey: DataTag<QueryKey, TData, TError> }
+}
+
+export type ModelsControllerRetrieveQueryResult = NonNullable<Awaited<ReturnType<typeof modelsControllerRetrieve>>>
+export type ModelsControllerRetrieveQueryError = unknown
+
+
+export function useModelsControllerRetrieve<TData = Awaited<ReturnType<typeof modelsControllerRetrieve>>, TError = unknown>(
+ model: string, options: { query:Partial<UseQueryOptions<Awaited<ReturnType<typeof modelsControllerRetrieve>>, TError, TData>> & Pick<
+        DefinedInitialDataOptions<
+          Awaited<ReturnType<typeof modelsControllerRetrieve>>,
+          TError,
+          Awaited<ReturnType<typeof modelsControllerRetrieve>>
+        > , 'initialData'
+      >, }
+ , queryClient?: QueryClient
+  ):  DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useModelsControllerRetrieve<TData = Awaited<ReturnType<typeof modelsControllerRetrieve>>, TError = unknown>(
+ model: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof modelsControllerRetrieve>>, TError, TData>> & Pick<
+        UndefinedInitialDataOptions<
+          Awaited<ReturnType<typeof modelsControllerRetrieve>>,
+          TError,
+          Awaited<ReturnType<typeof modelsControllerRetrieve>>
+        > , 'initialData'
+      >, }
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useModelsControllerRetrieve<TData = Awaited<ReturnType<typeof modelsControllerRetrieve>>, TError = unknown>(
+ model: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof modelsControllerRetrieve>>, TError, TData>>, }
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+
+export function useModelsControllerRetrieve<TData = Awaited<ReturnType<typeof modelsControllerRetrieve>>, TError = unknown>(
+ model: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof modelsControllerRetrieve>>, TError, TData>>, }
+ , queryClient?: QueryClient 
+ ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
+
+  const queryOptions = getModelsControllerRetrieveQueryOptions(model,options)
+
+  const query = useQuery(queryOptions, queryClient) as  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+
+  query.queryKey = queryOptions.queryKey ;
+
+  return query;
+}
+
+
+
+
+
 /**
  * @summary List all add-ons with their active state for an organization
  */

--- a/ayunis-core-frontend/src/shared/api/openapi-schema.json
+++ b/ayunis-core-frontend/src/shared/api/openapi-schema.json
@@ -8668,6 +8668,39 @@
         "tags": ["ChatCompletions"]
       }
     },
+    "/openai-compat/v1/models": {
+      "get": {
+        "operationId": "ModelsController_list",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "tags": ["Models"]
+      }
+    },
+    "/openai-compat/v1/models/{model}": {
+      "get": {
+        "operationId": "ModelsController_retrieve",
+        "parameters": [
+          {
+            "name": "model",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "tags": ["Models"]
+      }
+    },
     "/super-admin/addons/{orgId}": {
       "get": {
         "operationId": "SuperAdminAddonsController_list",


### PR DESCRIPTION
- Add GET /v1/models and GET /v1/models/{model} so OpenAI-compatible
  clients can verify connections and populate model pickers
- Model ids are internal Model.name values, deduped first-wins to
  mirror chat completions model resolution
- Same guard stack as chat completions (api-key auth, usage-based
  subscription, OpenAI error envelope, 60 req/min rate limit)
- Regenerate OpenAPI schema and frontend client

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only endpoints reusing existing auth/subscription and permitted-model logic; main risk is advertised model ids diverging from chat resolution if dedupe rules drift.
> 
> **Overview**
> **Adds OpenAI-compatible `GET /v1/models` and `GET /v1/models/{model}`** so SDK clients can health-check and fill model pickers, alongside the existing chat completions surface.
> 
> A new **`ModelsController`** mirrors chat’s api-key auth, usage-based **`SubscriptionGuard`**, **`OpenAIExceptionFilter`**, and 60 req/min rate limit (no trial message accounting). **`ListOpenAIModelsUseCase`** loads org-permitted language models, **dedupes by internal `Model.name` (first wins)** to stay aligned with chat completion model resolution, and **`OpenAIModelMapper`** exposes **`id` = `Model.name`** in the standard OpenAI list/model JSON shape. **`GetOpenAIModelUseCase`** reuses the list and returns **404 `OpenAIModelNotFoundError`** when the name isn’t permitted; unexpected failures map to new **`OpenAIUnexpectedError`**. Module wiring, **`SUMMARY.md`**, unit tests, and **regenerated OpenAPI + frontend API client** complete the change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0b749300b496865030b5e61fa4ab6312f58ab3d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->