### PR TITLE
fix(authorization): stop logging no-trial denials as errors in SubscriptionGuard (AYC-153)

### DIFF
--- a/ayunis-core-backend/src/iam/authorization/application/authorization.errors.ts
+++ b/ayunis-core-backend/src/iam/authorization/application/authorization.errors.ts
@@ -1,9 +1,11 @@
 import type { ErrorMetadata } from 'src/common/errors/base.error';
 import { ApplicationError } from 'src/common/errors/base.error';
+import { SubscriptionType } from 'src/iam/subscriptions/domain/value-objects/subscription-type.enum';
 
 export enum AuthorizationErrorCode {
   EMAIL_NOT_VERIFIED = 'EMAIL_NOT_VERIFIED',
   RATE_LIMIT_EXCEEDED = 'RATE_LIMIT_EXCEEDED',
+  SUBSCRIPTION_REQUIRED = 'SUBSCRIPTION_REQUIRED',
 }
 
 export abstract class AuthorizationError extends ApplicationError {
@@ -34,6 +36,19 @@ export class RateLimitExceededError extends AuthorizationError {
       reason || 'Rate limit exceeded',
       AuthorizationErrorCode.RATE_LIMIT_EXCEEDED,
       429,
+      metadata,
+    );
+  }
+}
+
+export class SubscriptionRequiredError extends AuthorizationError {
+  constructor(requiredType?: SubscriptionType, metadata?: ErrorMetadata) {
+    super(
+      requiredType === SubscriptionType.USAGE_BASED
+        ? 'This feature requires a usage-based subscription.'
+        : 'This feature requires an active subscription.',
+      AuthorizationErrorCode.SUBSCRIPTION_REQUIRED,
+      403,
       metadata,
     );
   }

--- a/ayunis-core-backend/src/iam/authorization/application/guards/subscription.guard.spec.ts
+++ b/ayunis-core-backend/src/iam/authorization/application/guards/subscription.guard.spec.ts
@@ -1,4 +1,5 @@
 import type { ExecutionContext } from '@nestjs/common';
+import { Logger } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
 import type { UUID } from 'crypto';
 import { randomUUID } from 'crypto';
@@ -180,7 +181,12 @@ describe('SubscriptionGuard', () => {
       expect(request.subscriptionContext).toBeUndefined();
     });
 
-    it('denies when GetTrial throws TrialNotFoundError', async () => {
+    it('denies gracefully at warn (not error) when the org has no trial', async () => {
+      const errorSpy = jest
+        .spyOn(Logger.prototype, 'error')
+        .mockImplementation();
+      const warnSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation();
+
       hasActiveSubscriptionUseCase.execute.mockResolvedValue({
         hasActiveSubscription: false,
         subscriptionType: null,
@@ -195,6 +201,40 @@ describe('SubscriptionGuard', () => {
       const result = await makeGuard(reflector).canActivate(context);
 
       expect(result).toBe(false);
+      // A "no trial" denial is a normal authz decision: warn, never error.
+      expect(warnSpy).toHaveBeenCalledWith(
+        'Access denied: no trial found',
+        expect.objectContaining({ orgId }),
+      );
+      expect(errorSpy).not.toHaveBeenCalled();
+
+      errorSpy.mockRestore();
+      warnSpy.mockRestore();
+    });
+
+    it('logs at error and denies when the trial lookup fails unexpectedly', async () => {
+      const errorSpy = jest
+        .spyOn(Logger.prototype, 'error')
+        .mockImplementation();
+
+      hasActiveSubscriptionUseCase.execute.mockResolvedValue({
+        hasActiveSubscription: false,
+        subscriptionType: null,
+      });
+      getTrialUseCase.execute.mockRejectedValue(new Error('db unavailable'));
+
+      const { context, reflector } = createContext({
+        options: {},
+        user: { id: userId, orgId },
+      });
+
+      const result = await makeGuard(reflector).canActivate(context);
+
+      // Only TrialNotFoundError is graceful; a real fault still surfaces at error.
+      expect(result).toBe(false);
+      expect(errorSpy).toHaveBeenCalled();
+
+      errorSpy.mockRestore();
     });
 
     it('grants access on the unfiltered form when any active subscription exists', async () => {

--- a/ayunis-core-backend/src/iam/authorization/application/guards/subscription.guard.spec.ts
+++ b/ayunis-core-backend/src/iam/authorization/application/guards/subscription.guard.spec.ts
@@ -14,6 +14,7 @@ import { REQUIRE_SUBSCRIPTION_KEY } from '../decorators/subscription.decorator';
 import { IS_PUBLIC_KEY } from 'src/common/guards/public.guard';
 import { TrialNotFoundError } from 'src/iam/trials/application/trial.errors';
 import { Trial } from 'src/iam/trials/domain/trial.entity';
+import { SubscriptionRequiredError } from '../authorization.errors';
 
 interface ContextOverrides {
   options?: unknown;
@@ -161,7 +162,7 @@ describe('SubscriptionGuard', () => {
       });
     });
 
-    it('denies when subscription does not match the filter AND trial is exhausted', async () => {
+    it('throws a usage-based SubscriptionRequiredError when the filter is unmet AND trial is exhausted', async () => {
       hasActiveSubscriptionUseCase.execute.mockResolvedValue({
         hasActiveSubscription: false,
         subscriptionType: null,
@@ -175,13 +176,39 @@ describe('SubscriptionGuard', () => {
         user: { id: userId, orgId },
       });
 
-      const result = await makeGuard(reflector).canActivate(context);
-
-      expect(result).toBe(false);
+      await expect(
+        makeGuard(reflector).canActivate(context),
+      ).rejects.toMatchObject({
+        code: 'SUBSCRIPTION_REQUIRED',
+        statusCode: 403,
+        message: expect.stringContaining('usage-based'),
+      });
       expect(request.subscriptionContext).toBeUndefined();
     });
 
-    it('denies gracefully at warn (not error) when the org has no trial', async () => {
+    it('throws an active-subscription SubscriptionRequiredError for an untyped gate', async () => {
+      hasActiveSubscriptionUseCase.execute.mockResolvedValue({
+        hasActiveSubscription: false,
+        subscriptionType: null,
+      });
+      getTrialUseCase.execute.mockResolvedValue(
+        new Trial({ orgId, messagesSent: 10, maxMessages: 10 }),
+      );
+
+      const { context, reflector } = createContext({
+        options: {},
+        user: { id: userId, orgId },
+      });
+
+      await expect(
+        makeGuard(reflector).canActivate(context),
+      ).rejects.toMatchObject({
+        code: 'SUBSCRIPTION_REQUIRED',
+        message: 'This feature requires an active subscription.',
+      });
+    });
+
+    it('denies at warn (not error) with SubscriptionRequiredError when the org has no trial', async () => {
       const errorSpy = jest
         .spyOn(Logger.prototype, 'error')
         .mockImplementation();
@@ -198,9 +225,9 @@ describe('SubscriptionGuard', () => {
         user: { id: userId, orgId },
       });
 
-      const result = await makeGuard(reflector).canActivate(context);
-
-      expect(result).toBe(false);
+      await expect(
+        makeGuard(reflector).canActivate(context),
+      ).rejects.toBeInstanceOf(SubscriptionRequiredError);
       // A "no trial" denial is a normal authz decision: warn, never error.
       expect(warnSpy).toHaveBeenCalledWith(
         'Access denied: no trial found',
@@ -295,7 +322,7 @@ describe('SubscriptionGuard', () => {
       expect(request.subscriptionContext?.hasRemainingTrialMessages).toBe(true);
     });
 
-    it('denies when seat-only and trial-exhausted under a usage-based filter', async () => {
+    it('denies (throws SubscriptionRequiredError) when seat-only and trial-exhausted under a usage-based filter', async () => {
       hasActiveSubscriptionUseCase.execute.mockResolvedValue({
         hasActiveSubscription: false,
         subscriptionType: null,
@@ -309,9 +336,9 @@ describe('SubscriptionGuard', () => {
         user: { apiKeyId, orgId },
       });
 
-      const result = await makeGuard(reflector).canActivate(context);
-
-      expect(result).toBe(false);
+      await expect(
+        makeGuard(reflector).canActivate(context),
+      ).rejects.toBeInstanceOf(SubscriptionRequiredError);
     });
   });
 });

--- a/ayunis-core-backend/src/iam/authorization/application/guards/subscription.guard.ts
+++ b/ayunis-core-backend/src/iam/authorization/application/guards/subscription.guard.ts
@@ -14,6 +14,8 @@ import { HasActiveSubscriptionQuery } from 'src/iam/subscriptions/application/us
 import { GetTrialUseCase } from 'src/iam/trials/application/use-cases/get-trial/get-trial.use-case';
 import { GetTrialQuery } from 'src/iam/trials/application/use-cases/get-trial/get-trial.query';
 import { TrialNotFoundError } from 'src/iam/trials/application/trial.errors';
+import { ApplicationError } from 'src/common/errors/base.error';
+import { SubscriptionRequiredError } from '../authorization.errors';
 import { IS_PUBLIC_KEY } from 'src/common/guards/public.guard';
 import {
   REQUIRE_SUBSCRIPTION_KEY,
@@ -116,8 +118,20 @@ export class SubscriptionGuard implements CanActivate {
         return true;
       }
 
-      return await this.evaluateTrialAccess(principal, request);
+      const grantedByTrial = await this.evaluateTrialAccess(principal, request);
+      if (grantedByTrial) {
+        return true;
+      }
+
+      throw new SubscriptionRequiredError(options.type);
     } catch (error) {
+      // Denials (SubscriptionRequiredError) and other domain errors are normal
+      // outcomes: let them surface so ApplicationErrorFilter renders a coded
+      // 403. Only truly unexpected failures fall through to the error log.
+      if (error instanceof ApplicationError) {
+        throw error;
+      }
+
       this.logger.error('Error checking subscription/trial', {
         error: error instanceof Error ? error.message : 'Unknown error',
         orgId: principal.orgId,

--- a/ayunis-core-backend/src/iam/authorization/application/guards/subscription.guard.ts
+++ b/ayunis-core-backend/src/iam/authorization/application/guards/subscription.guard.ts
@@ -13,6 +13,7 @@ import { HasActiveSubscriptionUseCase } from 'src/iam/subscriptions/application/
 import { HasActiveSubscriptionQuery } from 'src/iam/subscriptions/application/use-cases/has-active-subscription/has-active-subscription.query';
 import { GetTrialUseCase } from 'src/iam/trials/application/use-cases/get-trial/get-trial.use-case';
 import { GetTrialQuery } from 'src/iam/trials/application/use-cases/get-trial/get-trial.query';
+import { TrialNotFoundError } from 'src/iam/trials/application/trial.errors';
 import { IS_PUBLIC_KEY } from 'src/common/guards/public.guard';
 import {
   REQUIRE_SUBSCRIPTION_KEY,
@@ -34,6 +35,8 @@ interface GuardPrincipal {
   userId?: UUID;
   apiKeyId?: UUID;
 }
+
+type Trial = Awaited<ReturnType<GetTrialUseCase['execute']>>;
 
 @Injectable()
 export class SubscriptionGuard implements CanActivate {
@@ -85,6 +88,14 @@ export class SubscriptionGuard implements CanActivate {
       requiredType: options.type,
     });
 
+    return this.evaluateSubscriptionAccess(principal, options, request);
+  }
+
+  private async evaluateSubscriptionAccess(
+    principal: GuardPrincipal,
+    options: RequireSubscriptionOptions,
+    request: RequestWithSubscriptionContext,
+  ): Promise<boolean> {
     try {
       const { hasActiveSubscription } =
         await this.hasActiveSubscriptionUseCase.execute(
@@ -105,49 +116,7 @@ export class SubscriptionGuard implements CanActivate {
         return true;
       }
 
-      this.logger.debug('No matching subscription, checking trial capacity', {
-        orgId: principal.orgId,
-      });
-
-      const trial = await this.getTrialUseCase.execute(
-        new GetTrialQuery(principal.orgId),
-      );
-
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- defensive guard for runtime safety
-      if (!trial) {
-        this.logger.warn('Access denied: no trial found', {
-          orgId: principal.orgId,
-        });
-
-        return false;
-      }
-
-      const hasRemainingMessages = trial.messagesSent < trial.maxMessages;
-      const remainingMessages = trial.maxMessages - trial.messagesSent;
-
-      if (hasRemainingMessages) {
-        this.logger.debug('Access granted: trial has remaining messages', {
-          orgId: principal.orgId,
-          messagesSent: trial.messagesSent,
-          maxMessages: trial.maxMessages,
-          remainingMessages,
-        });
-
-        request.subscriptionContext = {
-          hasActiveSubscription: false,
-          hasRemainingTrialMessages: true,
-        };
-
-        return true;
-      }
-
-      this.logger.warn('Access denied: trial exhausted', {
-        orgId: principal.orgId,
-        messagesSent: trial.messagesSent,
-        maxMessages: trial.maxMessages,
-      });
-
-      return false;
+      return await this.evaluateTrialAccess(principal, request);
     } catch (error) {
       this.logger.error('Error checking subscription/trial', {
         error: error instanceof Error ? error.message : 'Unknown error',
@@ -155,6 +124,61 @@ export class SubscriptionGuard implements CanActivate {
       });
 
       return false;
+    }
+  }
+
+  private async evaluateTrialAccess(
+    principal: GuardPrincipal,
+    request: RequestWithSubscriptionContext,
+  ): Promise<boolean> {
+    this.logger.debug('No matching subscription, checking trial capacity', {
+      orgId: principal.orgId,
+    });
+
+    const trial = await this.getTrialOrNull(principal.orgId);
+
+    if (!trial) {
+      this.logger.warn('Access denied: no trial found', {
+        orgId: principal.orgId,
+      });
+
+      return false;
+    }
+
+    if (trial.messagesSent < trial.maxMessages) {
+      this.logger.debug('Access granted: trial has remaining messages', {
+        orgId: principal.orgId,
+        messagesSent: trial.messagesSent,
+        maxMessages: trial.maxMessages,
+        remainingMessages: trial.maxMessages - trial.messagesSent,
+      });
+
+      request.subscriptionContext = {
+        hasActiveSubscription: false,
+        hasRemainingTrialMessages: true,
+      };
+
+      return true;
+    }
+
+    this.logger.warn('Access denied: trial exhausted', {
+      orgId: principal.orgId,
+      messagesSent: trial.messagesSent,
+      maxMessages: trial.maxMessages,
+    });
+
+    return false;
+  }
+
+  private async getTrialOrNull(orgId: UUID): Promise<Trial | null> {
+    try {
+      return await this.getTrialUseCase.execute(new GetTrialQuery(orgId));
+    } catch (error) {
+      if (error instanceof TrialNotFoundError) {
+        return null;
+      }
+
+      throw error;
     }
   }
 

--- a/ayunis-core-backend/src/iam/authorization/application/guards/usage-based-subscription.guard.spec.ts
+++ b/ayunis-core-backend/src/iam/authorization/application/guards/usage-based-subscription.guard.spec.ts
@@ -5,6 +5,7 @@ import type { IsUsageBasedSubscriptionUseCase } from 'src/iam/subscriptions/appl
 import { IS_PUBLIC_KEY } from 'src/common/guards/public.guard';
 import { REQUIRE_USAGE_BASED_SUBSCRIPTION_KEY } from '../decorators/usage-based-subscription.decorator';
 import { UsageBasedSubscriptionGuard } from './usage-based-subscription.guard';
+import { SubscriptionRequiredError } from '../authorization.errors';
 
 describe('UsageBasedSubscriptionGuard', () => {
   const orgId = '11111111-1111-1111-1111-111111111111' as UUID;
@@ -44,11 +45,18 @@ describe('UsageBasedSubscriptionGuard', () => {
     await expect(guard.canActivate(contextFor({ orgId }))).resolves.toBe(true);
   });
 
-  it('denies when required and the org is not usage-based', async () => {
+  it('throws a usage-based SubscriptionRequiredError when required and the org is not usage-based', async () => {
     reflectorValues[REQUIRE_USAGE_BASED_SUBSCRIPTION_KEY] = true;
     isUsageBased.execute.mockResolvedValue(false);
 
-    await expect(guard.canActivate(contextFor({ orgId }))).resolves.toBe(false);
+    const promise = guard.canActivate(contextFor({ orgId }));
+
+    await expect(promise).rejects.toBeInstanceOf(SubscriptionRequiredError);
+    await expect(promise).rejects.toMatchObject({
+      code: 'SUBSCRIPTION_REQUIRED',
+      statusCode: 403,
+      message: expect.stringContaining('usage-based'),
+    });
   });
 
   it('denies when required but there is no principal', async () => {

--- a/ayunis-core-backend/src/iam/authorization/application/guards/usage-based-subscription.guard.ts
+++ b/ayunis-core-backend/src/iam/authorization/application/guards/usage-based-subscription.guard.ts
@@ -8,12 +8,15 @@ import { Reflector } from '@nestjs/core';
 import { Request } from 'express';
 import type { UUID } from 'crypto';
 
+import { ApplicationError } from 'src/common/errors/base.error';
 import { IS_PUBLIC_KEY } from 'src/common/guards/public.guard';
 import { ActiveUser } from 'src/iam/authentication/domain/active-user.entity';
 import type { ApiKeyPrincipal } from 'src/iam/authentication/application/strategies/api-key.strategy';
 import { IsUsageBasedSubscriptionQuery } from 'src/iam/subscriptions/application/use-cases/is-usage-based-subscription/is-usage-based-subscription.query';
 import { IsUsageBasedSubscriptionUseCase } from 'src/iam/subscriptions/application/use-cases/is-usage-based-subscription/is-usage-based-subscription.use-case';
+import { SubscriptionType } from 'src/iam/subscriptions/domain/value-objects/subscription-type.enum';
 
+import { SubscriptionRequiredError } from '../authorization.errors';
 import { REQUIRE_USAGE_BASED_SUBSCRIPTION_KEY } from '../decorators/usage-based-subscription.decorator';
 
 type RequestPrincipal = ActiveUser | ApiKeyPrincipal;
@@ -90,10 +93,15 @@ export class UsageBasedSubscriptionGuard implements CanActivate {
         this.logger.warn(
           `Access denied: org ${orgId} has no active usage-based subscription`,
         );
+        throw new SubscriptionRequiredError(SubscriptionType.USAGE_BASED);
       }
 
       return isUsageBased;
     } catch (error) {
+      if (error instanceof ApplicationError) {
+        throw error;
+      }
+
       this.logger.error(
         `Failed to check usage-based subscription for org ${orgId}`,
         error instanceof Error ? error.stack : undefined,

--- a/ayunis-core-frontend/src/pages/admin-settings/api-keys-settings/api/useCreateApiKey.ts
+++ b/ayunis-core-frontend/src/pages/admin-settings/api-keys-settings/api/useCreateApiKey.ts
@@ -33,6 +33,8 @@ export function useCreateApiKey(
             setValidationErrors(form, errors, t, 'apiKeys.validation');
           } else if (code === 'API_KEY_EXPIRATION_IN_PAST') {
             showError(t('apiKeys.createApiKey.expirationInPast'));
+          } else if (code === 'SUBSCRIPTION_REQUIRED') {
+            showError(t('apiKeys.createApiKey.subscriptionRequired'));
           } else {
             showError(t('apiKeys.createApiKey.error'));
           }

--- a/ayunis-core-frontend/src/shared/locales/de/admin-settings-api-keys.json
+++ b/ayunis-core-frontend/src/shared/locales/de/admin-settings-api-keys.json
@@ -42,7 +42,8 @@
     "createApiKey": {
       "success": "API-Schlüssel erstellt",
       "error": "API-Schlüssel konnte nicht erstellt werden",
-      "expirationInPast": "Das Ablaufdatum muss in der Zukunft liegen"
+      "expirationInPast": "Das Ablaufdatum muss in der Zukunft liegen",
+      "subscriptionRequired": "API-Schlüssel erfordern ein nutzungsbasiertes Abonnement. Wenden Sie sich an Ihre Administration, um das Abonnement zu erweitern."
     },
     "revokeApiKey": {
       "title": "API-Schlüssel widerrufen",

--- a/ayunis-core-frontend/src/shared/locales/en/admin-settings-api-keys.json
+++ b/ayunis-core-frontend/src/shared/locales/en/admin-settings-api-keys.json
@@ -42,7 +42,8 @@
     "createApiKey": {
       "success": "API key created",
       "error": "Failed to create API key",
-      "expirationInPast": "Expiration date must be in the future"
+      "expirationInPast": "Expiration date must be in the future",
+      "subscriptionRequired": "API keys require a usage-based subscription. Contact your administrator to upgrade."
     },
     "revokeApiKey": {
       "title": "Revoke API key",


### PR DESCRIPTION
When a non-eligible org (e.g. seat-based) hit a @RequireSubscription-gated
route, the guard fell through to GetTrialUseCase, which throws
TrialNotFoundError for an org with no trial. That landed in the guard's
catch-all and logged every normal "no trial" denial at error level with a
stack trace, so a routine authorization decision looked like a system fault
and the intended graceful branch was dead code.

Add getTrialOrNull(), which translates TrialNotFoundError to a null result so
the guard denies gracefully at warn; any other error still surfaces at error.
GetTrialUseCase is left unchanged - the super-admin trials controller relies
on its throw-on-not-found contract.

Also extract the subscription/trial decision into evaluateSubscriptionAccess
and evaluateTrialAccess so canActivate stays within the function-length gate.

Part A of AYC-153; the user-facing 'subscription required' message (Part B)
follows separately.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how subscription denials surface to clients (structured 403 vs silent false) across guarded routes; behavior is intentional but affects API consumers beyond the API-keys UI.
> 
> **Overview**
> Subscription-gated routes now return a structured **`SUBSCRIPTION_REQUIRED`** 403 (via **`SubscriptionRequiredError`**) when the org lacks a matching subscription and trial cannot grant access, instead of a generic guard denial. Messages distinguish **usage-based** vs **any active** subscription requirements.
> 
> **`SubscriptionGuard`** maps **`TrialNotFoundError`** to a null trial through **`getTrialOrNull()`**, so missing-trial denials stay at **warn** (not **error**); unexpected trial lookup failures still log at error and fail closed. **`UsageBasedSubscriptionGuard`** throws the same error when the org is not usage-based.
> 
> The admin **create API key** flow handles **`SUBSCRIPTION_REQUIRED`** with new EN/DE copy explaining that API keys need a usage-based subscription.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1dde2909d71b57460cea6169a155f2c400d1561. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->