### PR TITLE
feat(authorization): return coded SUBSCRIPTION_REQUIRED 403 with user-facing message (AYC-153)

### DIFF
--- a/ayunis-core-frontend/src/pages/admin-settings/api-keys-settings/api/useCreateApiKey.ts
+++ b/ayunis-core-frontend/src/pages/admin-settings/api-keys-settings/api/useCreateApiKey.ts
@@ -33,6 +33,8 @@ export function useCreateApiKey(
             setValidationErrors(form, errors, t, 'apiKeys.validation');
           } else if (code === 'API_KEY_EXPIRATION_IN_PAST') {
             showError(t('apiKeys.createApiKey.expirationInPast'));
+          } else if (code === 'SUBSCRIPTION_REQUIRED') {
+            showError(t('apiKeys.createApiKey.subscriptionRequired'));
           } else {
             showError(t('apiKeys.createApiKey.error'));
           }

--- a/ayunis-core-frontend/src/shared/locales/de/admin-settings-api-keys.json
+++ b/ayunis-core-frontend/src/shared/locales/de/admin-settings-api-keys.json
@@ -42,7 +42,8 @@
     "createApiKey": {
       "success": "API-Schlüssel erstellt",
       "error": "API-Schlüssel konnte nicht erstellt werden",
-      "expirationInPast": "Das Ablaufdatum muss in der Zukunft liegen"
+      "expirationInPast": "Das Ablaufdatum muss in der Zukunft liegen",
+      "subscriptionRequired": "API-Schlüssel erfordern ein nutzungsbasiertes Abonnement. Wenden Sie sich an Ihre Administration, um das Abonnement zu erweitern."
     },
     "revokeApiKey": {
       "title": "API-Schlüssel widerrufen",

--- a/ayunis-core-frontend/src/shared/locales/en/admin-settings-api-keys.json
+++ b/ayunis-core-frontend/src/shared/locales/en/admin-settings-api-keys.json
@@ -42,7 +42,8 @@
     "createApiKey": {
       "success": "API key created",
       "error": "Failed to create API key",
-      "expirationInPast": "Expiration date must be in the future"
+      "expirationInPast": "Expiration date must be in the future",
+      "subscriptionRequired": "API keys require a usage-based subscription. Contact your administrator to upgrade."
     },
     "revokeApiKey": {
       "title": "Revoke API key",


### PR DESCRIPTION
SubscriptionGuard now throws SubscriptionRequiredError on denial instead of
returning false, so ApplicationErrorFilter renders a 403 with a stable
SUBSCRIPTION_REQUIRED code and a type-aware message (usage-based gate vs any
active subscription). The catch-all re-throws ApplicationErrors so denials and
domain errors surface to the filter instead of being swallowed as generic
'Forbidden resource'. The graceful no-trial path from Part A is preserved.

The frontend surfaces a specific, translated (en + de) toast on API-key
creation denial by branching on the SUBSCRIPTION_REQUIRED code.

Applies to all @RequireSubscription routes (api-keys, openai-compat, runs);
the runs chat frontend is unaffected as it matches on the 403 status, not the
body.

Part B of AYC-153; Part A (graceful no-trial logging) landed separately.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized error handling and copy only; no auth, billing, or API contract changes beyond displaying an existing error code.
> 
> **Overview**
> When creating an API key fails with the backend **`SUBSCRIPTION_REQUIRED`** error code (403 from subscription-gated routes), the create mutation shows a **specific error toast** instead of the generic “failed to create” message.
> 
> **`useCreateApiKey`** branches on that code alongside existing handling for validation and expiration errors. New **`apiKeys.createApiKey.subscriptionRequired`** strings were added in **English** and **German**, explaining that API keys need a usage-based subscription and to contact an administrator to upgrade.
> 
> This is the frontend half of surfacing structured subscription denials; other subscription-protected routes are unchanged in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b737442d475a695c25d13b6a908c85b0821c219c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->