### PR TITLE
wip(auth): reject typed tokens in session paths, add mfa pending plumbing (AYC-62)

### DIFF
--- a/ayunis-core-backend/.env.example
+++ b/ayunis-core-backend/.env.example
@@ -89,6 +89,13 @@ JWT_INVITE_EXPIRES_IN=
 JWT_EMAIL_CONFIRMATION_EXPIRES_IN=
 # Optional
 JWT_PASSWORD_RESET_EXPIRES_IN=
+# Optional. Lifetime of the MFA pending token issued between password
+# verification and 2FA code entry (default 5m)
+JWT_MFA_PENDING_EXPIRES_IN=
+
+# Key for encrypting TOTP secrets at rest (AES-256-GCM). REQUIRED once MFA
+# is used. Generate a secure value with: openssl rand -hex 32
+MFA_ENCRYPTION_KEY=
 
 # Database
 POSTGRES_HOST=

--- a/ayunis-core-backend/src/common/util/cookie.util.ts
+++ b/ayunis-core-backend/src/common/util/cookie.util.ts
@@ -91,6 +91,44 @@ export function clearCookies(
 
   response.clearCookie(accessTokenName, baseOptions);
   response.clearCookie(refreshTokenName, baseOptions);
+  clearMfaPendingCookie(response, configService);
+}
+
+export function setMfaPendingCookie(
+  response: Response,
+  token: string,
+  configService: ConfigService,
+): void {
+  const baseOptions = buildCookieOptions(configService);
+
+  response.cookie(getMfaPendingTokenName(configService), token, {
+    ...baseOptions,
+    maxAge: getMfaPendingTokenMaxAge(configService),
+  });
+}
+
+export function clearMfaPendingCookie(
+  response: Response,
+  configService: ConfigService,
+): void {
+  const baseOptions = buildCookieOptions(configService);
+
+  response.clearCookie(getMfaPendingTokenName(configService), baseOptions);
+}
+
+function getMfaPendingTokenName(configService: ConfigService): string {
+  return configService.get<string>(
+    'auth.cookie.mfaPendingTokenName',
+    'mfa_pending_token',
+  );
+}
+
+function getMfaPendingTokenMaxAge(configService: ConfigService): number {
+  const expiresIn = configService.get<string>(
+    'auth.jwt.mfaPendingExpiresIn',
+    '5m',
+  );
+  return getMillisecondsFromJwtExpiry(expiresIn);
 }
 
 function getAccessTokenMaxAge(configService: ConfigService): number {

--- a/ayunis-core-backend/src/config/authentication.config.ts
+++ b/ayunis-core-backend/src/config/authentication.config.ts
@@ -47,6 +47,7 @@ function jwtConfig(secret: string) {
     passwordResetExpiresIn: process.env.JWT_PASSWORD_RESET_EXPIRES_IN || '2h',
     initialPasswordExpiresIn:
       process.env.JWT_INITIAL_PASSWORD_EXPIRES_IN || '7d',
+    mfaPendingExpiresIn: process.env.JWT_MFA_PENDING_EXPIRES_IN || '5m',
   };
 }
 
@@ -59,6 +60,7 @@ function cookieConfig(secret: string) {
     sameSite: process.env.COOKIE_SAME_SITE || 'lax',
     accessTokenName: 'access_token',
     refreshTokenName: 'refresh_token',
+    mfaPendingTokenName: 'mfa_pending_token',
   };
 }
 

--- a/ayunis-core-backend/src/iam/authentication/application/strategies/jwt.strategy.ts
+++ b/ayunis-core-backend/src/iam/authentication/application/strategies/jwt.strategy.ts
@@ -17,6 +17,7 @@ interface JwtPayload {
   systemRole: SystemRole;
   orgId: UUID;
   name: string;
+  type?: string;
 }
 
 @Injectable()
@@ -47,7 +48,14 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
     });
   }
 
-  validate(payload: JwtPayload): ActiveUser {
+  validate(payload: JwtPayload): ActiveUser | null {
+    // Special-purpose tokens (e.g. MFA pending) share the same secret and
+    // carry a `type` claim; they must never authenticate as a session.
+    if (payload.type !== undefined) {
+      this.logger.warn('Rejected typed token presented as access token');
+      return null;
+    }
+
     return new ActiveUser({
       id: payload.sub,
       email: payload.email,

--- a/ayunis-core-backend/src/iam/authentication/application/use-cases/refresh-token/refresh-token.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/authentication/application/use-cases/refresh-token/refresh-token.use-case.spec.ts
@@ -90,4 +90,16 @@ describe('RefreshTokenUseCase', () => {
 
     await expect(useCase.execute(command)).rejects.toThrow(InvalidTokenError);
   });
+
+  it('should reject typed special-purpose tokens with a valid sub (laundering)', async () => {
+    const command = new RefreshTokenCommand('mfa-pending-token');
+
+    jest
+      .spyOn(mockJwtService, 'verify')
+      .mockReturnValue({ sub: 'user-id-123', type: 'mfa_pending' });
+
+    await expect(useCase.execute(command)).rejects.toThrow(InvalidTokenError);
+    expect(mockFindUserByIdUseCase.execute).not.toHaveBeenCalled();
+    expect(mockAuthRepository.generateTokens).not.toHaveBeenCalled();
+  });
 });

--- a/ayunis-core-backend/src/iam/authentication/application/use-cases/refresh-token/refresh-token.use-case.ts
+++ b/ayunis-core-backend/src/iam/authentication/application/use-cases/refresh-token/refresh-token.use-case.ts
@@ -23,11 +23,17 @@ export class RefreshTokenUseCase {
   async execute(command: RefreshTokenCommand): Promise<AuthTokens> {
     this.logger.log('refreshToken');
     try {
-      const payload = this.jwtService.verify<{ sub: string }>(
+      const payload = this.jwtService.verify<{ sub: string; type?: string }>(
         command.refreshToken,
       );
 
       if (!payload.sub) {
+        throw new InvalidTokenError('Invalid token payload');
+      }
+
+      // Special-purpose tokens (e.g. MFA pending) share the same secret and
+      // carry a `type` claim; they must never be exchangeable for a session.
+      if (payload.type !== undefined) {
         throw new InvalidTokenError('Invalid token payload');
       }
 


### PR DESCRIPTION
- refresh flow and JwtStrategy reject any JWT carrying a type claim, so
  special-purpose tokens sharing the JWT secret can never be exchanged
  for a session
- add mfaPendingExpiresIn (5m) and mfa_pending_token cookie name to auth
  config, plus set/clear helpers; logout clears the pending cookie
- document JWT_MFA_PENDING_EXPIRES_IN and MFA_ENCRYPTION_KEY in .env.example

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes authentication and refresh validation; behavior is restrictive (rejects typed tokens) but touches security-critical paths.
> 
> **Overview**
> Hardens auth so **special-purpose JWTs** (e.g. MFA pending) that share `JWT_SECRET` cannot be used as a full session: **`JwtStrategy`** rejects any access token with a `type` claim, and **`RefreshTokenUseCase`** refuses to mint new tokens from refresh tokens that carry `type` (with a spec covering “laundering” via a valid `sub`).
> 
> Adds **MFA pending infrastructure** ahead of full 2FA: `mfaPendingExpiresIn` / `mfa_pending_token` in auth config, **`setMfaPendingCookie`** / **`clearMfaPendingCookie`**, and **`clearCookies`** now clears the pending cookie on logout. **`.env.example`** documents `JWT_MFA_PENDING_EXPIRES_IN` and `MFA_ENCRYPTION_KEY`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c562e55d928acdcfee0b5603b7358790b69ef0e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->