### PR TITLE
wip(auth): branch login into mfa pending state, add mfa login controller (AYC-62)

### DIFF
--- a/ayunis-core-backend/src/common/errors/base.error.ts
+++ b/ayunis-core-backend/src/common/errors/base.error.ts
@@ -3,14 +3,14 @@ import {
   ConflictException,
   ForbiddenException,
   GatewayTimeoutException,
+  HttpException,
+  HttpStatus,
   InternalServerErrorException,
   NotFoundException,
   NotImplementedException,
   ServiceUnavailableException,
   UnauthorizedException,
 } from '@nestjs/common';
-
-export type ErrorCode = string;
 
 export interface ErrorMetadata {
   [key: string]: unknown;
@@ -23,7 +23,7 @@ export abstract class ApplicationError extends Error {
   /**
    * Error code - used for identifying the error type
    */
-  readonly code: ErrorCode;
+  readonly code: string;
 
   /**
    * HTTP status code that should be returned to the client
@@ -37,7 +37,7 @@ export abstract class ApplicationError extends Error {
 
   constructor(
     message: string,
-    code: ErrorCode,
+    code: string,
     statusCode: number = 500,
     metadata?: ErrorMetadata,
   ) {
@@ -48,9 +48,7 @@ export abstract class ApplicationError extends Error {
     this.metadata = metadata;
 
     // Maintain proper stack trace for where the error was thrown (V8 engines)
-    if (Error.captureStackTrace) {
-      Error.captureStackTrace(this, this.constructor);
-    }
+    Error.captureStackTrace(this, this.constructor);
   }
 
   /**
@@ -63,25 +61,25 @@ export abstract class ApplicationError extends Error {
       ...(this.metadata && { metadata: this.metadata }),
     };
 
-    switch (this.statusCode) {
-      case 401:
-        return new UnauthorizedException(body);
-      case 403:
-        return new ForbiddenException(body);
-      case 404:
-        return new NotFoundException(body);
-      case 409:
-        return new ConflictException(body);
-      case 500:
-        return new InternalServerErrorException(body);
-      case 501:
-        return new NotImplementedException(body);
-      case 503:
-        return new ServiceUnavailableException(body);
-      case 504:
-        return new GatewayTimeoutException(body);
-      default:
-        return new BadRequestException(body);
-    }
+    const factory = EXCEPTION_FACTORIES[this.statusCode];
+    return factory ? factory(body) : new BadRequestException(body);
   }
 }
+
+// The value type includes undefined because not every status code has a
+// dedicated factory — lookups for unmapped codes fall back to 400.
+const EXCEPTION_FACTORIES: Record<
+  number,
+  ((body: object) => HttpException) | undefined
+> = {
+  401: (body) => new UnauthorizedException(body),
+  403: (body) => new ForbiddenException(body),
+  404: (body) => new NotFoundException(body),
+  409: (body) => new ConflictException(body),
+  // Nest ships no TooManyRequestsException; use the generic base.
+  429: (body) => new HttpException(body, HttpStatus.TOO_MANY_REQUESTS),
+  500: (body) => new InternalServerErrorException(body),
+  501: (body) => new NotImplementedException(body),
+  503: (body) => new ServiceUnavailableException(body),
+  504: (body) => new GatewayTimeoutException(body),
+};

--- a/ayunis-core-backend/src/db/migrations/1783154787547-CreateMfaTables.ts
+++ b/ayunis-core-backend/src/db/migrations/1783154787547-CreateMfaTables.ts
@@ -1,30 +1,59 @@
-import { MigrationInterface, QueryRunner } from "typeorm";
+import type { MigrationInterface, QueryRunner } from 'typeorm';
 
 export class CreateMfaTables1783154787547 implements MigrationInterface {
-    name = 'CreateMfaTables1783154787547'
+  name = 'CreateMfaTables1783154787547';
 
-    public async up(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.query(`CREATE TABLE "user_totps" ("id" character varying NOT NULL, "createdAt" TIMESTAMP NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP NOT NULL DEFAULT now(), "userId" character varying NOT NULL, "encryptedSecret" text NOT NULL, "confirmedAt" TIMESTAMP WITH TIME ZONE, "failedAttempts" integer NOT NULL DEFAULT '0', "lockedUntil" TIMESTAMP WITH TIME ZONE, "lastUsedCounter" integer, CONSTRAINT "UQ_7bd8b674fdd1d213dd37315d3ed" UNIQUE ("userId"), CONSTRAINT "REL_7bd8b674fdd1d213dd37315d3e" UNIQUE ("userId"), CONSTRAINT "PK_7eb7f99a78fba7ed2094702a6e5" PRIMARY KEY ("id"))`);
-        await queryRunner.query(`CREATE INDEX "IDX_7bd8b674fdd1d213dd37315d3e" ON "user_totps" ("userId") `);
-        await queryRunner.query(`CREATE TABLE "org_mfa_requirements" ("id" character varying NOT NULL, "createdAt" TIMESTAMP NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP NOT NULL DEFAULT now(), "orgId" character varying NOT NULL, "required" boolean NOT NULL DEFAULT false, CONSTRAINT "UQ_b4e23d13eca54acfac69e1d1cc4" UNIQUE ("orgId"), CONSTRAINT "PK_bd7616cac9385812208559f6892" PRIMARY KEY ("id"))`);
-        await queryRunner.query(`CREATE INDEX "IDX_b4e23d13eca54acfac69e1d1cc" ON "org_mfa_requirements" ("orgId") `);
-        await queryRunner.query(`CREATE TABLE "mfa_recovery_codes" ("id" character varying NOT NULL, "createdAt" TIMESTAMP NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP NOT NULL DEFAULT now(), "userId" character varying NOT NULL, "codeHash" character varying NOT NULL, "usedAt" TIMESTAMP WITH TIME ZONE, CONSTRAINT "PK_0076416b1b84361afc3371ba121" PRIMARY KEY ("id"))`);
-        await queryRunner.query(`CREATE INDEX "IDX_1aeec4efb39bc7c382cbce9994" ON "mfa_recovery_codes" ("userId") `);
-        await queryRunner.query(`ALTER TABLE "user_totps" ADD CONSTRAINT "FK_7bd8b674fdd1d213dd37315d3ed" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE NO ACTION`);
-        await queryRunner.query(`ALTER TABLE "org_mfa_requirements" ADD CONSTRAINT "FK_b4e23d13eca54acfac69e1d1cc4" FOREIGN KEY ("orgId") REFERENCES "orgs"("id") ON DELETE CASCADE ON UPDATE NO ACTION`);
-        await queryRunner.query(`ALTER TABLE "mfa_recovery_codes" ADD CONSTRAINT "FK_1aeec4efb39bc7c382cbce99948" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE NO ACTION`);
-    }
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE "user_totps" ("id" character varying NOT NULL, "createdAt" TIMESTAMP NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP NOT NULL DEFAULT now(), "userId" character varying NOT NULL, "encryptedSecret" text NOT NULL, "confirmedAt" TIMESTAMP WITH TIME ZONE, "failedAttempts" integer NOT NULL DEFAULT '0', "lockedUntil" TIMESTAMP WITH TIME ZONE, "lastUsedCounter" integer, CONSTRAINT "UQ_7bd8b674fdd1d213dd37315d3ed" UNIQUE ("userId"), CONSTRAINT "REL_7bd8b674fdd1d213dd37315d3e" UNIQUE ("userId"), CONSTRAINT "PK_7eb7f99a78fba7ed2094702a6e5" PRIMARY KEY ("id"))`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_7bd8b674fdd1d213dd37315d3e" ON "user_totps" ("userId") `,
+    );
+    await queryRunner.query(
+      `CREATE TABLE "org_mfa_requirements" ("id" character varying NOT NULL, "createdAt" TIMESTAMP NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP NOT NULL DEFAULT now(), "orgId" character varying NOT NULL, "required" boolean NOT NULL DEFAULT false, CONSTRAINT "UQ_b4e23d13eca54acfac69e1d1cc4" UNIQUE ("orgId"), CONSTRAINT "PK_bd7616cac9385812208559f6892" PRIMARY KEY ("id"))`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_b4e23d13eca54acfac69e1d1cc" ON "org_mfa_requirements" ("orgId") `,
+    );
+    await queryRunner.query(
+      `CREATE TABLE "mfa_recovery_codes" ("id" character varying NOT NULL, "createdAt" TIMESTAMP NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP NOT NULL DEFAULT now(), "userId" character varying NOT NULL, "codeHash" character varying NOT NULL, "usedAt" TIMESTAMP WITH TIME ZONE, CONSTRAINT "PK_0076416b1b84361afc3371ba121" PRIMARY KEY ("id"))`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_1aeec4efb39bc7c382cbce9994" ON "mfa_recovery_codes" ("userId") `,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "user_totps" ADD CONSTRAINT "FK_7bd8b674fdd1d213dd37315d3ed" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "org_mfa_requirements" ADD CONSTRAINT "FK_b4e23d13eca54acfac69e1d1cc4" FOREIGN KEY ("orgId") REFERENCES "orgs"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "mfa_recovery_codes" ADD CONSTRAINT "FK_1aeec4efb39bc7c382cbce99948" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+  }
 
-    public async down(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.query(`ALTER TABLE "mfa_recovery_codes" DROP CONSTRAINT "FK_1aeec4efb39bc7c382cbce99948"`);
-        await queryRunner.query(`ALTER TABLE "org_mfa_requirements" DROP CONSTRAINT "FK_b4e23d13eca54acfac69e1d1cc4"`);
-        await queryRunner.query(`ALTER TABLE "user_totps" DROP CONSTRAINT "FK_7bd8b674fdd1d213dd37315d3ed"`);
-        await queryRunner.query(`DROP INDEX "public"."IDX_1aeec4efb39bc7c382cbce9994"`);
-        await queryRunner.query(`DROP TABLE "mfa_recovery_codes"`);
-        await queryRunner.query(`DROP INDEX "public"."IDX_b4e23d13eca54acfac69e1d1cc"`);
-        await queryRunner.query(`DROP TABLE "org_mfa_requirements"`);
-        await queryRunner.query(`DROP INDEX "public"."IDX_7bd8b674fdd1d213dd37315d3e"`);
-        await queryRunner.query(`DROP TABLE "user_totps"`);
-    }
-
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "mfa_recovery_codes" DROP CONSTRAINT "FK_1aeec4efb39bc7c382cbce99948"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "org_mfa_requirements" DROP CONSTRAINT "FK_b4e23d13eca54acfac69e1d1cc4"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "user_totps" DROP CONSTRAINT "FK_7bd8b674fdd1d213dd37315d3ed"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_1aeec4efb39bc7c382cbce9994"`,
+    );
+    await queryRunner.query(`DROP TABLE "mfa_recovery_codes"`);
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_b4e23d13eca54acfac69e1d1cc"`,
+    );
+    await queryRunner.query(`DROP TABLE "org_mfa_requirements"`);
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_7bd8b674fdd1d213dd37315d3e"`,
+    );
+    await queryRunner.query(`DROP TABLE "user_totps"`);
+  }
 }

--- a/ayunis-core-backend/src/iam/authentication/authentication.module.ts
+++ b/ayunis-core-backend/src/iam/authentication/authentication.module.ts
@@ -30,8 +30,10 @@ import { HashingModule } from '../hashing/hashing.module';
 import { SubscriptionsModule } from '../subscriptions/subscriptions.module';
 import { TrialsModule } from '../trials/trials.module';
 import { ApiKeysModule } from '../api-keys/api-keys.module';
+import { MfaModule } from '../mfa/mfa.module';
 import { ClsModule } from 'nestjs-cls';
 import { UserContextInterceptor } from './application/interceptors/user-context.interceptor';
+import { MfaLoginController } from './presenters/http/mfa-login.controller';
 
 export interface AuthenticationConfig {
   provider?: AuthProvider;
@@ -48,6 +50,7 @@ const AUTHENTICATION_IMPORTS = [
   SubscriptionsModule,
   TrialsModule,
   ApiKeysModule,
+  MfaModule,
   JwtConfigModule,
   ClsModule.forFeature(),
 ];
@@ -117,7 +120,7 @@ export class AuthenticationModule {
         createAuthenticationRepositoryProvider(options),
         ...AUTHENTICATION_PROVIDERS,
       ],
-      controllers: [AuthenticationController],
+      controllers: [AuthenticationController, MfaLoginController],
       exports: AUTHENTICATION_EXPORTS,
     };
   }

--- a/ayunis-core-backend/src/iam/authentication/presenters/http/authentication.controller.spec.ts
+++ b/ayunis-core-backend/src/iam/authentication/presenters/http/authentication.controller.spec.ts
@@ -17,6 +17,8 @@ import { HttpStatus } from '@nestjs/common';
 import type { UUID } from 'crypto';
 import { RATE_LIMIT_KEY } from '../../../authorization/application/decorators/rate-limit.decorator';
 import type { RateLimitOptions } from '../../../authorization/application/decorators/rate-limit.decorator';
+import { CheckMfaLoginRequirementUseCase } from 'src/iam/mfa/application/use-cases/check-mfa-login-requirement/check-mfa-login-requirement.use-case';
+import { MfaPendingJwtService } from 'src/iam/mfa/application/services/mfa-pending-jwt.service';
 
 describe('AuthenticationController', () => {
   let controller: AuthenticationController;
@@ -24,6 +26,8 @@ describe('AuthenticationController', () => {
   let mockRefreshTokenUseCase: Partial<RefreshTokenUseCase>;
   let mockRegisterUserUseCase: Partial<RegisterUserUseCase>;
   let mockGetCurrentUserUseCase: Partial<GetCurrentUserUseCase>;
+  let mockCheckMfaLoginRequirementUseCase: { execute: jest.Mock };
+  let mockMfaPendingJwtService: { generate: jest.Mock };
   let mockConfigService: Partial<ConfigService>;
   let mockJwtService: Partial<JwtService>;
 
@@ -40,6 +44,12 @@ describe('AuthenticationController', () => {
     mockGetCurrentUserUseCase = {
       execute: jest.fn(),
     };
+    mockCheckMfaLoginRequirementUseCase = {
+      execute: jest.fn(),
+    };
+    mockMfaPendingJwtService = {
+      generate: jest.fn(),
+    };
     mockConfigService = {
       get: jest.fn(),
     };
@@ -54,6 +64,14 @@ describe('AuthenticationController', () => {
         { provide: RefreshTokenUseCase, useValue: mockRefreshTokenUseCase },
         { provide: RegisterUserUseCase, useValue: mockRegisterUserUseCase },
         { provide: GetCurrentUserUseCase, useValue: mockGetCurrentUserUseCase },
+        {
+          provide: CheckMfaLoginRequirementUseCase,
+          useValue: mockCheckMfaLoginRequirementUseCase,
+        },
+        {
+          provide: MfaPendingJwtService,
+          useValue: mockMfaPendingJwtService,
+        },
         { provide: ConfigService, useValue: mockConfigService },
         { provide: JwtService, useValue: mockJwtService },
         {
@@ -93,6 +111,96 @@ describe('AuthenticationController', () => {
       expect(options).toBeDefined();
       expect(options?.limit).toBe(10);
       expect(options?.windowMs).toBe(15 * 60 * 1000);
+    });
+  });
+
+  describe('login', () => {
+    const activeUser = new ActiveUser({
+      id: 'user-id' as UUID,
+      email: 'test@example.com',
+      emailVerified: true,
+      role: UserRole.USER,
+      systemRole: SystemRole.CUSTOMER,
+      orgId: 'org-id' as UUID,
+      name: 'name',
+    });
+    let mockRequest: Partial<Request>;
+    let mockResponse: Partial<Response>;
+
+    beforeEach(() => {
+      mockRequest = { user: activeUser, cookies: {} } as Partial<Request>;
+      mockResponse = {
+        json: jest.fn().mockReturnThis(),
+        cookie: jest.fn().mockReturnThis(),
+        clearCookie: jest.fn().mockReturnThis(),
+      };
+      jest
+        .spyOn(mockConfigService, 'get')
+        .mockImplementation(
+          (key: string, defaultValue?: unknown) => defaultValue ?? 'value',
+        );
+    });
+
+    it('issues session cookies when no MFA is required', async () => {
+      mockCheckMfaLoginRequirementUseCase.execute.mockResolvedValue('none');
+      const tokens = new AuthTokens('access', 'refresh');
+      jest.spyOn(mockLoginUseCase, 'execute').mockResolvedValue(tokens);
+
+      await controller.login(mockRequest as Request, mockResponse as Response);
+
+      expect(mockResponse.cookie).toHaveBeenCalledWith(
+        'access_token',
+        'access',
+        expect.any(Object),
+      );
+      expect(mockResponse.cookie).toHaveBeenCalledWith(
+        'refresh_token',
+        'refresh',
+        expect.any(Object),
+      );
+      expect(mockResponse.json).toHaveBeenCalledWith({
+        success: true,
+        mfaRequired: false,
+        enrollmentRequired: false,
+      });
+    });
+
+    it('sets only the MFA pending cookie when the user must verify', async () => {
+      mockCheckMfaLoginRequirementUseCase.execute.mockResolvedValue('verify');
+      mockMfaPendingJwtService.generate.mockReturnValue('pending-token');
+
+      await controller.login(mockRequest as Request, mockResponse as Response);
+
+      expect(mockLoginUseCase.execute).not.toHaveBeenCalled();
+      expect(mockResponse.cookie).toHaveBeenCalledTimes(1);
+      expect(mockResponse.cookie).toHaveBeenCalledWith(
+        'mfa_pending_token',
+        'pending-token',
+        expect.any(Object),
+      );
+      expect(mockResponse.json).toHaveBeenCalledWith({
+        success: true,
+        mfaRequired: true,
+        enrollmentRequired: false,
+      });
+    });
+
+    it('signals forced enrollment when the org requires MFA', async () => {
+      mockCheckMfaLoginRequirementUseCase.execute.mockResolvedValue('enroll');
+      mockMfaPendingJwtService.generate.mockReturnValue('pending-token');
+
+      await controller.login(mockRequest as Request, mockResponse as Response);
+
+      expect(mockLoginUseCase.execute).not.toHaveBeenCalled();
+      expect(mockMfaPendingJwtService.generate).toHaveBeenCalledWith({
+        userId: activeUser.id,
+        enrollmentRequired: true,
+      });
+      expect(mockResponse.json).toHaveBeenCalledWith({
+        success: true,
+        mfaRequired: true,
+        enrollmentRequired: true,
+      });
     });
   });
 

--- a/ayunis-core-backend/src/iam/authentication/presenters/http/authentication.controller.ts
+++ b/ayunis-core-backend/src/iam/authentication/presenters/http/authentication.controller.ts
@@ -27,12 +27,20 @@ import { LoginDto } from './dtos/login.dto';
 import {
   SuccessResponseDto,
   ErrorResponseDto,
+  LoginResponseDto,
   MeResponseDto,
 } from './dtos/auth-response.dto';
 import { Request, Response } from 'express';
 import { ConfigService } from '@nestjs/config';
 import { ActiveUser } from '../../domain/active-user.entity';
-import { setCookies, clearCookies } from 'src/common/util/cookie.util';
+import {
+  setCookies,
+  clearCookies,
+  setMfaPendingCookie,
+} from 'src/common/util/cookie.util';
+import { CheckMfaLoginRequirementUseCase } from 'src/iam/mfa/application/use-cases/check-mfa-login-requirement/check-mfa-login-requirement.use-case';
+import { CheckMfaLoginRequirementQuery } from 'src/iam/mfa/application/use-cases/check-mfa-login-requirement/check-mfa-login-requirement.query';
+import { MfaPendingJwtService } from 'src/iam/mfa/application/services/mfa-pending-jwt.service';
 
 // Import use cases
 import { LoginUseCase } from '../../application/use-cases/login/login.use-case';
@@ -55,6 +63,8 @@ export class AuthenticationController {
     private readonly refreshTokenUseCase: RefreshTokenUseCase,
     private readonly registerUserUseCase: RegisterUserUseCase,
     private readonly getCurrentUserUseCase: GetCurrentUserUseCase,
+    private readonly checkMfaLoginRequirementUseCase: CheckMfaLoginRequirementUseCase,
+    private readonly mfaPendingJwtService: MfaPendingJwtService,
     private readonly configService: ConfigService,
     private readonly meResponseDtoMapper: MeResponseDtoMapper,
   ) {}
@@ -75,8 +85,10 @@ export class AuthenticationController {
   })
   @ApiResponse({
     status: HttpStatus.OK,
-    description: 'Login successful. Authentication cookies are set.',
-    type: SuccessResponseDto,
+    description:
+      'Credentials accepted. Session cookies are set unless mfaRequired is ' +
+      'true, in which case a short-lived MFA pending cookie is set instead.',
+    type: LoginResponseDto,
   })
   @ApiUnauthorizedResponse({
     description: 'Invalid credentials',
@@ -89,10 +101,43 @@ export class AuthenticationController {
   async login(@Req() req: Request, @Res() res: Response) {
     this.logger.log('login');
     const user = req.user as ActiveUser;
-    const tokens = await this.loginUseCase.execute(new LoginCommand(user));
 
+    const mfaRequirement = await this.checkMfaLoginRequirementUseCase.execute(
+      new CheckMfaLoginRequirementQuery(user.id, user.orgId),
+    );
+
+    if (mfaRequirement !== 'none') {
+      return this.respondMfaPending(res, user, mfaRequirement === 'enroll');
+    }
+
+    const tokens = await this.loginUseCase.execute(new LoginCommand(user));
     setCookies(res, tokens, this.configService, true);
-    return res.json({ success: true });
+    return res.json({
+      success: true,
+      mfaRequired: false,
+      enrollmentRequired: false,
+    } satisfies LoginResponseDto);
+  }
+
+  /**
+   * Withholds session cookies and issues the short-lived MFA pending cookie
+   * instead; the login completes via the /auth/mfa endpoints.
+   */
+  private respondMfaPending(
+    res: Response,
+    user: ActiveUser,
+    enrollmentRequired: boolean,
+  ) {
+    const pendingToken = this.mfaPendingJwtService.generate({
+      userId: user.id,
+      enrollmentRequired,
+    });
+    setMfaPendingCookie(res, pendingToken, this.configService);
+    return res.json({
+      success: true,
+      mfaRequired: true,
+      enrollmentRequired,
+    } satisfies LoginResponseDto);
   }
 
   @Public()

--- a/ayunis-core-backend/src/iam/authentication/presenters/http/dtos/auth-response.dto.ts
+++ b/ayunis-core-backend/src/iam/authentication/presenters/http/dtos/auth-response.dto.ts
@@ -10,6 +10,46 @@ export class SuccessResponseDto {
   success: boolean;
 }
 
+export class LoginResponseDto {
+  @ApiProperty({
+    description: 'Whether the credentials were accepted',
+    example: true,
+  })
+  success: boolean;
+
+  @ApiProperty({
+    description:
+      'True when a second factor is required before a session is issued. ' +
+      'Complete the login via /auth/mfa/verify (or /auth/mfa/setup when ' +
+      'enrollmentRequired is true).',
+    example: false,
+  })
+  mfaRequired: boolean;
+
+  @ApiProperty({
+    description:
+      'True when the org requires two-factor auth and the user must enroll ' +
+      'before receiving a session.',
+    example: false,
+  })
+  enrollmentRequired: boolean;
+}
+
+export class MfaLoginConfirmResponseDto {
+  @ApiProperty({
+    description: 'Operation success status',
+    example: true,
+  })
+  success: boolean;
+
+  @ApiProperty({
+    description:
+      'Single-use recovery codes issued on enrollment. Shown exactly once.',
+    type: [String],
+  })
+  recoveryCodes: string[];
+}
+
 export class MeResponseDto {
   @ApiProperty({
     description: 'User email address',

--- a/ayunis-core-backend/src/iam/authentication/presenters/http/mfa-login.controller.ts
+++ b/ayunis-core-backend/src/iam/authentication/presenters/http/mfa-login.controller.ts
@@ -1,0 +1,175 @@
+import {
+  Body,
+  Controller,
+  HttpCode,
+  HttpStatus,
+  Logger,
+  Post,
+  Req,
+  Res,
+} from '@nestjs/common';
+import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { Request, Response } from 'express';
+import { ConfigService } from '@nestjs/config';
+import type { UUID } from 'crypto';
+import { Public } from 'src/common/guards/public.guard';
+import { RateLimit } from 'src/iam/authorization/application/decorators/rate-limit.decorator';
+import { setCookies, clearMfaPendingCookie } from 'src/common/util/cookie.util';
+import { ActiveUser } from '../../domain/active-user.entity';
+import { LoginUseCase } from '../../application/use-cases/login/login.use-case';
+import { LoginCommand } from '../../application/use-cases/login/login.command';
+import { FindUserByIdUseCase } from 'src/iam/users/application/use-cases/find-user-by-id/find-user-by-id.use-case';
+import { FindUserByIdQuery } from 'src/iam/users/application/use-cases/find-user-by-id/find-user-by-id.query';
+import type { MfaPendingJwtPayload } from 'src/iam/mfa/application/services/mfa-pending-jwt.service';
+import { MfaPendingJwtService } from 'src/iam/mfa/application/services/mfa-pending-jwt.service';
+import { VerifyMfaCodeUseCase } from 'src/iam/mfa/application/use-cases/verify-mfa-code/verify-mfa-code.use-case';
+import { VerifyMfaCodeCommand } from 'src/iam/mfa/application/use-cases/verify-mfa-code/verify-mfa-code.command';
+import { SetupTotpUseCase } from 'src/iam/mfa/application/use-cases/setup-totp/setup-totp.use-case';
+import { SetupTotpCommand } from 'src/iam/mfa/application/use-cases/setup-totp/setup-totp.command';
+import { ConfirmTotpUseCase } from 'src/iam/mfa/application/use-cases/confirm-totp/confirm-totp.use-case';
+import { ConfirmTotpCommand } from 'src/iam/mfa/application/use-cases/confirm-totp/confirm-totp.command';
+import {
+  InvalidMfaPendingTokenError,
+  MfaEnrollmentNotAllowedError,
+} from 'src/iam/mfa/application/mfa.errors';
+import { MfaCodeRequestDto } from 'src/iam/mfa/presenters/http/dtos/mfa-code-request.dto';
+import { MfaSetupResponseDto } from 'src/iam/mfa/presenters/http/dtos/mfa-setup-response.dto';
+import {
+  SuccessResponseDto,
+  MfaLoginConfirmResponseDto,
+} from './dtos/auth-response.dto';
+
+/**
+ * Completes a login that entered the MFA pending state. All routes are
+ * public in the guard sense but require a valid MFA pending cookie, which
+ * only a successful password login can set.
+ */
+@ApiTags('Authentication')
+@Controller('auth/mfa')
+export class MfaLoginController {
+  private readonly logger = new Logger(MfaLoginController.name);
+
+  constructor(
+    private readonly mfaPendingJwtService: MfaPendingJwtService,
+    private readonly verifyMfaCodeUseCase: VerifyMfaCodeUseCase,
+    private readonly setupTotpUseCase: SetupTotpUseCase,
+    private readonly confirmTotpUseCase: ConfirmTotpUseCase,
+    private readonly findUserByIdUseCase: FindUserByIdUseCase,
+    private readonly loginUseCase: LoginUseCase,
+    private readonly configService: ConfigService,
+  ) {}
+
+  @Public()
+  @RateLimit({ limit: 10, windowMs: 15 * 60 * 1000 })
+  @Post('verify')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Complete login with a TOTP or recovery code',
+    description:
+      'Requires the MFA pending cookie set by a successful password login.',
+  })
+  @ApiResponse({ status: HttpStatus.OK, type: SuccessResponseDto })
+  async verify(
+    @Req() req: Request,
+    @Res() res: Response,
+    @Body() dto: MfaCodeRequestDto,
+  ) {
+    const payload = this.readPendingToken(req);
+    this.logger.log('verify', { userId: payload.sub });
+
+    await this.verifyMfaCodeUseCase.execute(
+      new VerifyMfaCodeCommand(payload.sub, dto.code),
+    );
+    await this.completeLogin(res, payload.sub);
+    return res.json({ success: true });
+  }
+
+  @Public()
+  @RateLimit({ limit: 5, windowMs: 15 * 60 * 1000 })
+  @Post('setup')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Start forced TOTP enrollment during login',
+    description:
+      'Only available when the pending token has enrollmentRequired (the ' +
+      'org mandates MFA and the user is not enrolled).',
+  })
+  @ApiResponse({ status: HttpStatus.OK, type: MfaSetupResponseDto })
+  async setup(@Req() req: Request): Promise<MfaSetupResponseDto> {
+    const payload = this.readPendingToken(req);
+    if (!payload.enrollmentRequired) {
+      throw new MfaEnrollmentNotAllowedError();
+    }
+    this.logger.log('setup', { userId: payload.sub });
+
+    const user = await this.findUserByIdUseCase.execute(
+      new FindUserByIdQuery(payload.sub),
+    );
+    return this.setupTotpUseCase.execute(
+      new SetupTotpCommand(user.id, user.email),
+    );
+  }
+
+  @Public()
+  @RateLimit({ limit: 10, windowMs: 15 * 60 * 1000 })
+  @Post('setup/confirm')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Confirm forced enrollment and complete the login',
+    description:
+      'Activates two-factor auth, returns the recovery codes and issues ' +
+      'the session cookies.',
+  })
+  @ApiResponse({ status: HttpStatus.OK, type: MfaLoginConfirmResponseDto })
+  async confirmSetup(
+    @Req() req: Request,
+    @Res() res: Response,
+    @Body() dto: MfaCodeRequestDto,
+  ) {
+    const payload = this.readPendingToken(req);
+    if (!payload.enrollmentRequired) {
+      throw new MfaEnrollmentNotAllowedError();
+    }
+    this.logger.log('confirmSetup', { userId: payload.sub });
+
+    const recoveryCodes = await this.confirmTotpUseCase.execute(
+      new ConfirmTotpCommand(payload.sub, dto.code),
+    );
+    await this.completeLogin(res, payload.sub);
+    return res.json({ success: true, recoveryCodes });
+  }
+
+  private readPendingToken(req: Request): MfaPendingJwtPayload {
+    const cookieName = this.configService.get<string>(
+      'auth.cookie.mfaPendingTokenName',
+      'mfa_pending_token',
+    );
+    const token = req.cookies[cookieName] as string | undefined;
+    if (!token) {
+      throw new InvalidMfaPendingTokenError();
+    }
+    return this.mfaPendingJwtService.verify(token);
+  }
+
+  private async completeLogin(res: Response, userId: UUID): Promise<void> {
+    const user = await this.findUserByIdUseCase.execute(
+      new FindUserByIdQuery(userId),
+    );
+    const tokens = await this.loginUseCase.execute(
+      new LoginCommand(
+        new ActiveUser({
+          id: user.id,
+          email: user.email,
+          emailVerified: user.emailVerified,
+          role: user.role,
+          systemRole: user.systemRole,
+          orgId: user.orgId,
+          name: user.name,
+        }),
+      ),
+    );
+
+    clearMfaPendingCookie(res, this.configService);
+    setCookies(res, tokens, this.configService, true);
+  }
+}

--- a/ayunis-core-backend/src/iam/mfa/application/mfa.errors.ts
+++ b/ayunis-core-backend/src/iam/mfa/application/mfa.errors.ts
@@ -111,7 +111,10 @@ export class UnexpectedMfaError extends ApplicationError {
       'An unexpected error occurred',
       MfaErrorCode.UNEXPECTED_MFA_ERROR,
       500,
-      { error: error instanceof Error ? error.message : String(error), ...metadata },
+      {
+        error: error instanceof Error ? error.message : String(error),
+        ...metadata,
+      },
     );
   }
 }

--- a/ayunis-core-backend/src/iam/mfa/application/services/mfa-pending-jwt.service.spec.ts
+++ b/ayunis-core-backend/src/iam/mfa/application/services/mfa-pending-jwt.service.spec.ts
@@ -1,0 +1,71 @@
+import type { TestingModule } from '@nestjs/testing';
+import { Test } from '@nestjs/testing';
+import { JwtModule, JwtService } from '@nestjs/jwt';
+import { ConfigService } from '@nestjs/config';
+import type { UUID } from 'crypto';
+import { MfaPendingJwtService } from './mfa-pending-jwt.service';
+import { InvalidMfaPendingTokenError } from '../mfa.errors';
+
+describe('MfaPendingJwtService', () => {
+  const userId = 'user-id-123' as UUID;
+  let service: MfaPendingJwtService;
+  let jwtService: JwtService;
+
+  beforeAll(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [JwtModule.register({ secret: 'test-secret' })],
+      providers: [
+        MfaPendingJwtService,
+        {
+          provide: ConfigService,
+          useValue: {
+            get: jest.fn((key: string, defaultValue?: unknown) => defaultValue),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get(MfaPendingJwtService);
+    jwtService = module.get(JwtService);
+  });
+
+  it('round-trips a pending token with its payload', () => {
+    const token = service.generate({ userId, enrollmentRequired: true });
+    const payload = service.verify(token);
+
+    expect(payload.sub).toBe(userId);
+    expect(payload.type).toBe('mfa_pending');
+    expect(payload.enrollmentRequired).toBe(true);
+  });
+
+  it('rejects a session-style token without a type claim', () => {
+    const sessionLikeToken = jwtService.sign({ sub: userId });
+
+    expect(() => service.verify(sessionLikeToken)).toThrow(
+      InvalidMfaPendingTokenError,
+    );
+  });
+
+  it('rejects a token with a different type claim', () => {
+    const otherTypedToken = jwtService.sign({ sub: userId, type: 'other' });
+
+    expect(() => service.verify(otherTypedToken)).toThrow(
+      InvalidMfaPendingTokenError,
+    );
+  });
+
+  it('rejects an expired pending token', () => {
+    const expired = jwtService.sign(
+      { sub: userId, type: 'mfa_pending', enrollmentRequired: false },
+      { expiresIn: '-1s' },
+    );
+
+    expect(() => service.verify(expired)).toThrow(InvalidMfaPendingTokenError);
+  });
+
+  it('rejects garbage tokens', () => {
+    expect(() => service.verify('not-a-jwt')).toThrow(
+      InvalidMfaPendingTokenError,
+    );
+  });
+});

--- a/ayunis-core-backend/src/iam/mfa/application/services/mfa-pending-jwt.service.ts
+++ b/ayunis-core-backend/src/iam/mfa/application/services/mfa-pending-jwt.service.ts
@@ -1,0 +1,69 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+import { ConfigService } from '@nestjs/config';
+import type { UUID } from 'crypto';
+import type { StringValue } from 'ms';
+import { InvalidMfaPendingTokenError } from '../mfa.errors';
+
+export const MFA_PENDING_TOKEN_TYPE = 'mfa_pending';
+
+export interface MfaPendingJwtPayload {
+  sub: UUID;
+  /**
+   * Discriminates this token from every other JWT signed with the shared
+   * secret. Session token paths reject any payload carrying a `type` claim,
+   * and this service rejects any token without exactly this type.
+   */
+  type: typeof MFA_PENDING_TOKEN_TYPE;
+  /** True when the org requires MFA and the user still has to enroll. */
+  enrollmentRequired: boolean;
+}
+
+@Injectable()
+export class MfaPendingJwtService {
+  private readonly logger = new Logger(MfaPendingJwtService.name);
+
+  constructor(
+    private readonly jwtService: JwtService,
+    private readonly configService: ConfigService,
+  ) {}
+
+  generate(params: { userId: UUID; enrollmentRequired: boolean }): string {
+    this.logger.log('generateMfaPendingToken', { userId: params.userId });
+
+    const expiresIn = this.configService.get<StringValue>(
+      'auth.jwt.mfaPendingExpiresIn',
+      '5m',
+    );
+    const payload: MfaPendingJwtPayload = {
+      sub: params.userId,
+      type: MFA_PENDING_TOKEN_TYPE,
+      enrollmentRequired: params.enrollmentRequired,
+    };
+
+    return this.jwtService.sign(payload, { expiresIn });
+  }
+
+  verify(token: string): MfaPendingJwtPayload {
+    try {
+      const payload =
+        this.jwtService.verify<Partial<MfaPendingJwtPayload>>(token);
+
+      if (payload.type !== MFA_PENDING_TOKEN_TYPE || !payload.sub) {
+        throw new InvalidMfaPendingTokenError();
+      }
+
+      return {
+        sub: payload.sub,
+        type: MFA_PENDING_TOKEN_TYPE,
+        enrollmentRequired: payload.enrollmentRequired === true,
+      };
+    } catch (error: unknown) {
+      if (error instanceof InvalidMfaPendingTokenError) {
+        throw error;
+      }
+      this.logger.warn('MFA pending token verification failed', { error });
+      throw new InvalidMfaPendingTokenError();
+    }
+  }
+}

--- a/ayunis-core-backend/src/iam/mfa/application/use-cases/verify-mfa-code/verify-mfa-code.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/mfa/application/use-cases/verify-mfa-code/verify-mfa-code.use-case.spec.ts
@@ -22,7 +22,10 @@ describe('VerifyMfaCodeUseCase', () => {
   let userTotps: jest.Mocked<
     Pick<
       UserTotpsRepository,
-      'findByUserId' | 'markVerified' | 'registerFailedAttempt' | 'resetFailures'
+      | 'findByUserId'
+      | 'markVerified'
+      | 'registerFailedAttempt'
+      | 'resetFailures'
     >
   >;
   let recoveryCodes: jest.Mocked<
@@ -170,7 +173,10 @@ describe('VerifyMfaCodeUseCase', () => {
     await expect(
       useCase.execute(new VerifyMfaCodeCommand(userId, 'abcde-12345')),
     ).resolves.toBeUndefined();
-    expect(recoveryCodes.consume).toHaveBeenCalledWith(code.id, expect.any(Date));
+    expect(recoveryCodes.consume).toHaveBeenCalledWith(
+      code.id,
+      expect.any(Date),
+    );
     expect(userTotps.resetFailures).toHaveBeenCalledWith(userId);
   });
 

--- a/ayunis-core-backend/src/iam/mfa/application/use-cases/verify-mfa-code/verify-mfa-code.use-case.ts
+++ b/ayunis-core-backend/src/iam/mfa/application/use-cases/verify-mfa-code/verify-mfa-code.use-case.ts
@@ -102,7 +102,10 @@ export class VerifyMfaCodeUseCase {
       const matches = await this.compareHashUseCase.execute(
         new CompareHashCommand(normalized, candidate.codeHash),
       );
-      if (matches && (await this.recoveryCodesRepository.consume(candidate.id, now))) {
+      if (
+        matches &&
+        (await this.recoveryCodesRepository.consume(candidate.id, now))
+      ) {
         await this.userTotpsRepository.resetFailures(userId);
         return true;
       }

--- a/ayunis-core-backend/src/iam/mfa/mfa.module.ts
+++ b/ayunis-core-backend/src/iam/mfa/mfa.module.ts
@@ -2,6 +2,8 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { HashingModule } from '../hashing/hashing.module';
 import { UsersModule } from '../users/users.module';
+import { JwtConfigModule } from '../authentication/jwt.module';
+import { MfaPendingJwtService } from './application/services/mfa-pending-jwt.service';
 import { UserTotpRecord } from './infrastructure/repositories/local/schema/user-totp.record';
 import { MfaRecoveryCodeRecord } from './infrastructure/repositories/local/schema/mfa-recovery-code.record';
 import { OrgMfaRequirementRecord } from './infrastructure/repositories/local/schema/org-mfa-requirement.record';
@@ -35,6 +37,7 @@ import { MfaController } from './presenters/http/mfa.controller';
     ]),
     HashingModule,
     UsersModule,
+    JwtConfigModule,
   ],
   controllers: [MfaController],
   providers: [
@@ -67,12 +70,14 @@ import { MfaController } from './presenters/http/mfa.controller';
     UpsertOrgMfaRequirementUseCase,
     ResetUserMfaUseCase,
     CheckMfaLoginRequirementUseCase,
+    MfaPendingJwtService,
   ],
   exports: [
     SetupTotpUseCase,
     ConfirmTotpUseCase,
     VerifyMfaCodeUseCase,
     CheckMfaLoginRequirementUseCase,
+    MfaPendingJwtService,
   ],
 })
 export class MfaModule {}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Changes the core login path and introduces cookie/JWT state between password and session issuance; mistakes could bypass MFA or leak partial auth.
> 
> **Overview**
> Password login now checks org/user MFA requirements **before** issuing session cookies. When verification or forced enrollment is needed, it returns **`LoginResponseDto`** (`mfaRequired`, `enrollmentRequired`) and sets a short-lived **`mfa_pending_token`** cookie instead of access/refresh tokens.
> 
> **`MfaLoginController`** (`/auth/mfa/*`) completes that flow: **`verify`** (TOTP/recovery then full session), **`setup`** / **`setup/confirm`** for org-mandated enrollment (recovery codes on confirm). Access is gated by **`MfaPendingJwtService`** (typed `mfa_pending` JWT, configurable TTL).
> 
> **`ApplicationError.toHttpException`** is refactored to a status-code factory map, including **429** via generic **`HttpException`**. **`MfaModule`** exports **`MfaPendingJwtService`** and **`CheckMfaLoginRequirementUseCase`**; auth module imports **`MfaModule`** and registers the new controller. Controller specs cover the three login branches; **`MfaPendingJwtService`** has dedicated unit tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2b9f9dab240683938cab69a5a3fbf0039be8b25. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->