### PR TITLE
feat(mfa): add account settings 2fa card and admin org toggle with user reset (AYC-62)

### DIFF
--- a/ayunis-core-frontend/src/pages/admin-settings/security-settings/api/useOrgMfaRequirement.ts
+++ b/ayunis-core-frontend/src/pages/admin-settings/security-settings/api/useOrgMfaRequirement.ts
@@ -1,0 +1,44 @@
+import {
+  useMfaControllerGetOrgRequirement,
+  useMfaControllerUpdateOrgRequirement,
+  getMfaControllerGetOrgRequirementQueryKey,
+} from '@/shared/api/generated/ayunisCoreAPI';
+import { useQueryClient } from '@tanstack/react-query';
+import { showSuccess, showError } from '@/shared/lib/toast';
+import { useTranslation } from 'react-i18next';
+
+export function useOrgMfaRequirement() {
+  const { t } = useTranslation('admin-settings-security');
+  const queryClient = useQueryClient();
+  const queryKey = getMfaControllerGetOrgRequirementQueryKey();
+
+  const { data, isLoading, isError, refetch } =
+    useMfaControllerGetOrgRequirement();
+
+  const updateMutation = useMfaControllerUpdateOrgRequirement({
+    mutation: {
+      onSuccess: () => {
+        showSuccess(t('mfaRequirement.saved'));
+      },
+      onError: () => {
+        showError(t('mfaRequirement.error'));
+      },
+      onSettled: async () => {
+        await queryClient.invalidateQueries({ queryKey });
+      },
+    },
+  });
+
+  function setRequired(required: boolean) {
+    updateMutation.mutate({ data: { required } });
+  }
+
+  return {
+    required: data?.required ?? false,
+    isLoading,
+    isError,
+    refetch,
+    isUpdating: updateMutation.isPending,
+    setRequired,
+  };
+}

--- a/ayunis-core-frontend/src/pages/admin-settings/security-settings/ui/MfaRequirementCard.tsx
+++ b/ayunis-core-frontend/src/pages/admin-settings/security-settings/ui/MfaRequirementCard.tsx
@@ -1,0 +1,44 @@
+import { useTranslation } from 'react-i18next';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/shared/ui/shadcn/card';
+import { Switch } from '@/shared/ui/shadcn/switch';
+import { Label } from '@/shared/ui/shadcn/label';
+import { useOrgMfaRequirement } from '../api/useOrgMfaRequirement';
+
+export function MfaRequirementCard() {
+  const { t } = useTranslation('admin-settings-security');
+  const { required, isLoading, isUpdating, setRequired } =
+    useOrgMfaRequirement();
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{t('mfaRequirement.title')}</CardTitle>
+        <CardDescription>{t('mfaRequirement.description')}</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className="flex items-center justify-between gap-4">
+          <div className="space-y-1">
+            <Label htmlFor="mfa-required-switch">
+              {t('mfaRequirement.toggleLabel')}
+            </Label>
+            <p className="text-sm text-muted-foreground">
+              {t('mfaRequirement.toggleHint')}
+            </p>
+          </div>
+          <Switch
+            id="mfa-required-switch"
+            checked={required}
+            disabled={isLoading || isUpdating}
+            onCheckedChange={setRequired}
+          />
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/ayunis-core-frontend/src/pages/admin-settings/security-settings/ui/SecuritySettingsPage.tsx
+++ b/ayunis-core-frontend/src/pages/admin-settings/security-settings/ui/SecuritySettingsPage.tsx
@@ -21,6 +21,7 @@ import {
 import extractErrorData from '@/shared/api/extract-error-data';
 import { showSuccess, showError } from '@/shared/lib/toast';
 import { isValidCidrOrIp } from '../lib/validate-cidr';
+import { MfaRequirementCard } from './MfaRequirementCard';
 import { RemoveRestrictionsDialog } from './RemoveRestrictionsDialog';
 import { AlertCircle, Info, Loader2 } from 'lucide-react';
 import { Alert, AlertDescription } from '@/shared/ui/shadcn/alert';
@@ -245,6 +246,10 @@ export function SecuritySettingsPage() {
           </div>
         </CardContent>
       </Card>
+
+      <div className="mt-4">
+        <MfaRequirementCard />
+      </div>
 
       <RemoveRestrictionsDialog
         open={removeDialogOpen}

--- a/ayunis-core-frontend/src/pages/admin-settings/users-settings/api/useResetUserMfa.ts
+++ b/ayunis-core-frontend/src/pages/admin-settings/users-settings/api/useResetUserMfa.ts
@@ -1,0 +1,42 @@
+import { useMfaControllerResetUser } from '@/shared/api/generated/ayunisCoreAPI';
+import { showError, showSuccess } from '@/shared/lib/toast';
+import { useTranslation } from 'react-i18next';
+import extractErrorData from '@/shared/api/extract-error-data';
+
+interface UseResetUserMfaOptions {
+  onSuccessCallback?: () => void;
+}
+
+export function useResetUserMfa(options?: UseResetUserMfaOptions) {
+  const { t } = useTranslation('admin-settings-users');
+
+  const mutation = useMfaControllerResetUser({
+    mutation: {
+      onSuccess: () => {
+        showSuccess(t('resetMfa.success'));
+        options?.onSuccessCallback?.();
+      },
+      onError: (error) => {
+        try {
+          const { code } = extractErrorData(error);
+          if (code === 'MFA_SELF_RESET_NOT_ALLOWED') {
+            showError(t('resetMfa.errorSelf'));
+          } else {
+            showError(t('resetMfa.error'));
+          }
+        } catch {
+          showError(t('resetMfa.error'));
+        }
+      },
+    },
+  });
+
+  function resetUserMfa(userId: string) {
+    mutation.mutate({ userId });
+  }
+
+  return {
+    resetUserMfa,
+    isLoading: mutation.isPending,
+  };
+}

--- a/ayunis-core-frontend/src/pages/admin-settings/users-settings/ui/UsersSection.tsx
+++ b/ayunis-core-frontend/src/pages/admin-settings/users-settings/ui/UsersSection.tsx
@@ -27,10 +27,14 @@ import {
   Mail,
   Coins,
   Ban,
+  ShieldOff,
 } from 'lucide-react';
+import TooltipIf from '@/widgets/tooltip-if/ui/TooltipIf';
 import { useUserRoleUpdate } from '../api/useUserRoleUpdate';
 import { useUserDelete } from '../api/useUserDelete';
 import { useTriggerPasswordReset } from '../api/useTriggerPasswordReset';
+import { useResetUserMfa } from '../api/useResetUserMfa';
+import { useMe } from '@/widgets/app-sidebar/api/useMe';
 import EditUserDialog from './EditUserDialog';
 import { useState, type ReactNode } from 'react';
 import type { User } from '../model/openapi';
@@ -63,6 +67,7 @@ export default function UsersSection({
   const [editingUser, setEditingUser] = useState<User | null>(null);
   const [creditLimitUser, setCreditLimitUser] = useState<User | null>(null);
   const hasCreditBudget = useHasCreditBudget();
+  const { user: currentUser } = useMe();
   const { userLimits, setUserLimit, removeUserLimit, isSaving } =
     useUserCreditLimits(() => setCreditLimitUser(null));
 
@@ -87,6 +92,9 @@ export default function UsersSection({
     useTriggerPasswordReset({
       onSuccessCallback: () => setLoadingUserId(null),
     });
+  const { resetUserMfa, isLoading: isResettingMfa } = useResetUserMfa({
+    onSuccessCallback: () => setLoadingUserId(null),
+  });
   const { confirm } = useConfirmation();
 
   const handleRoleToggle = (user: User) => {
@@ -143,10 +151,26 @@ export default function UsersSection({
     });
   };
 
+  const handleResetMfa = (user: UserResponseDto) => {
+    confirm({
+      title: t('resetMfa.confirmTitle'),
+      description: t('resetMfa.confirmDescription', {
+        name: user.name,
+      }),
+      confirmText: t('resetMfa.confirmText'),
+      cancelText: t('confirmations.cancelText'),
+      variant: 'destructive',
+      onConfirm: () => {
+        setLoadingUserId(user.id);
+        resetUserMfa(user.id);
+      },
+    });
+  };
+
   const isUserLoading = (userId: string) => {
     return (
       loadingUserId === userId &&
-      (isUpdatingRole || isDeletingUser || isTriggeringReset)
+      (isUpdatingRole || isDeletingUser || isTriggeringReset || isResettingMfa)
     );
   };
 
@@ -225,6 +249,21 @@ export default function UsersSection({
                         <Mail />
                         {t('users.sendPasswordReset')}
                       </DropdownMenuItem>
+                      <TooltipIf
+                        condition={user.email === currentUser?.email}
+                        tooltip={t('resetMfa.selfTooltip')}
+                      >
+                        <DropdownMenuItem
+                          onClick={() => handleResetMfa(user)}
+                          disabled={
+                            isUserLoading(user.id) ||
+                            user.email === currentUser?.email
+                          }
+                        >
+                          <ShieldOff />
+                          {t('resetMfa.menuItem')}
+                        </DropdownMenuItem>
+                      </TooltipIf>
                       {hasCreditBudget && (
                         <DropdownMenuItem
                           onClick={() => setCreditLimitUser(user)}

--- a/ayunis-core-frontend/src/pages/settings/account-settings/api/useMfa.ts
+++ b/ayunis-core-frontend/src/pages/settings/account-settings/api/useMfa.ts
@@ -1,0 +1,111 @@
+import { useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { useTranslation } from 'react-i18next';
+import {
+  useMfaControllerGetStatus,
+  useMfaControllerSetup,
+  useMfaControllerConfirm,
+  useMfaControllerDisable,
+  getMfaControllerGetStatusQueryKey,
+} from '@/shared/api/generated/ayunisCoreAPI';
+import type { MfaSetupResponseDto } from '@/shared/api/generated/ayunisCoreAPI.schemas';
+import extractErrorData from '@/shared/api/extract-error-data';
+import { showError, showSuccess } from '@/shared/lib/toast';
+
+/**
+ * Self-service two-factor management in account settings: status, the
+ * enable flow (setup → confirm → one-time recovery codes) and the
+ * code-guarded disable flow.
+ */
+export function useMfa() {
+  const { t } = useTranslation('settings');
+  const queryClient = useQueryClient();
+  const statusQuery = useMfaControllerGetStatus();
+  const setupMutation = useMfaControllerSetup();
+  const confirmMutation = useMfaControllerConfirm();
+  const disableMutation = useMfaControllerDisable();
+  const [setup, setSetup] = useState<MfaSetupResponseDto | null>(null);
+  const [recoveryCodes, setRecoveryCodes] = useState<string[] | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const invalidateStatus = () =>
+    queryClient.invalidateQueries({
+      queryKey: getMfaControllerGetStatusQueryKey(),
+    });
+
+  const mapCodeError = (error: unknown) => {
+    try {
+      const { code } = extractErrorData(error);
+      if (code === 'INVALID_MFA_CODE') {
+        setErrorMessage(t('account.mfa.error.invalidCode'));
+      } else if (code === 'MFA_LOCKED') {
+        setErrorMessage(t('account.mfa.error.locked'));
+      } else if (code === 'MFA_REQUIRED_BY_ORG') {
+        showError(t('account.mfa.error.requiredByOrg'));
+      } else {
+        showError(t('account.mfa.error.unexpected'));
+      }
+    } catch {
+      showError(t('account.mfa.error.unexpected'));
+    }
+  };
+
+  const startSetup = () => {
+    setErrorMessage(null);
+    setupMutation.mutate(undefined, {
+      onSuccess: (data) => setSetup(data),
+      onError: mapCodeError,
+    });
+  };
+
+  const confirm = (code: string) => {
+    setErrorMessage(null);
+    confirmMutation.mutate(
+      { data: { code } },
+      {
+        onSuccess: (data) => {
+          setRecoveryCodes(data.recoveryCodes);
+          void invalidateStatus();
+        },
+        onError: mapCodeError,
+      },
+    );
+  };
+
+  const disable = (code: string, onDone: () => void) => {
+    setErrorMessage(null);
+    disableMutation.mutate(
+      { data: { code } },
+      {
+        onSuccess: () => {
+          showSuccess(t('account.mfa.disabledSuccessfully'));
+          void invalidateStatus();
+          onDone();
+        },
+        onError: mapCodeError,
+      },
+    );
+  };
+
+  const resetEnrollmentState = () => {
+    setSetup(null);
+    setRecoveryCodes(null);
+    setErrorMessage(null);
+  };
+
+  return {
+    status: statusQuery.data,
+    isLoadingStatus: statusQuery.isLoading,
+    isStatusError: statusQuery.isError,
+    startSetup,
+    isSettingUp: setupMutation.isPending,
+    setup,
+    confirm,
+    isConfirming: confirmMutation.isPending,
+    recoveryCodes,
+    disable,
+    isDisabling: disableMutation.isPending,
+    errorMessage,
+    resetEnrollmentState,
+  };
+}

--- a/ayunis-core-frontend/src/pages/settings/account-settings/ui/AccountSettingsPage.tsx
+++ b/ayunis-core-frontend/src/pages/settings/account-settings/ui/AccountSettingsPage.tsx
@@ -10,6 +10,7 @@ import { Button } from '@/shared/ui/shadcn/button';
 import { useTranslation } from 'react-i18next';
 import { HelpLink } from '@/shared/ui/help-link/HelpLink';
 import PasswordSettingsPage from './PasswordSettingsPage';
+import { TwoFactorCard } from './TwoFactorCard';
 
 export default function AccountSettingsPage({
   user,
@@ -26,6 +27,7 @@ export default function AccountSettingsPage({
       <div className="space-y-4">
         <ProfileInformationCard user={user} />
         <PasswordSettingsPage />
+        <TwoFactorCard />
         {/* Account Actions */}
         <Card>
           <CardHeader>

--- a/ayunis-core-frontend/src/pages/settings/account-settings/ui/TwoFactorCard.tsx
+++ b/ayunis-core-frontend/src/pages/settings/account-settings/ui/TwoFactorCard.tsx
@@ -1,0 +1,199 @@
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from '@/shared/ui/shadcn/card';
+import { Badge } from '@/shared/ui/shadcn/badge';
+import { Button } from '@/shared/ui/shadcn/button';
+import { Skeleton } from '@/shared/ui/shadcn/skeleton';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from '@/shared/ui/shadcn/dialog';
+import { Input } from '@/shared/ui/shadcn/input';
+import {
+  MfaEnrollmentPanel,
+  RecoveryCodesPanel,
+} from '@/widgets/mfa-enrollment';
+import { useMfa } from '../api/useMfa';
+
+export function TwoFactorCard() {
+  const { t } = useTranslation('settings');
+  const mfa = useMfa();
+  const [enableOpen, setEnableOpen] = useState(false);
+  const [disableOpen, setDisableOpen] = useState(false);
+
+  const enabled = mfa.status?.enabled ?? false;
+
+  const openEnable = () => {
+    mfa.resetEnrollmentState();
+    mfa.startSetup();
+    setEnableOpen(true);
+  };
+
+  const closeEnable = () => {
+    setEnableOpen(false);
+    mfa.resetEnrollmentState();
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          {t('account.mfa.title')}
+          {enabled && (
+            <Badge variant="secondary">{t('account.mfa.enabledBadge')}</Badge>
+          )}
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {mfa.isLoadingStatus && (
+          <div className="flex items-center justify-between gap-4">
+            <Skeleton className="h-5 w-2/3" />
+            <Skeleton className="h-9 w-24" />
+          </div>
+        )}
+        {mfa.isStatusError && (
+          <p className="text-sm text-destructive">
+            {t('account.mfa.error.statusFailed')}
+          </p>
+        )}
+        {!mfa.isLoadingStatus && !mfa.isStatusError && (
+          <div className="flex items-center justify-between gap-4">
+            <div className="text-sm text-muted-foreground">
+              {enabled
+                ? t('account.mfa.enabledDescription', {
+                    count: mfa.status?.recoveryCodesRemaining ?? 0,
+                  })
+                : t('account.mfa.disabledDescription')}
+            </div>
+            {enabled ? (
+              <Button variant="outline" onClick={() => setDisableOpen(true)}>
+                {t('account.mfa.disableButton')}
+              </Button>
+            ) : (
+              <Button onClick={openEnable}>
+                {t('account.mfa.enableButton')}
+              </Button>
+            )}
+          </div>
+        )}
+      </CardContent>
+
+      <Dialog
+        open={enableOpen}
+        onOpenChange={(open) => {
+          // Block dismissal on the recovery-codes step — they are shown once.
+          if (!open && mfa.recoveryCodes) return;
+          if (!open) closeEnable();
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{t('account.mfa.enableDialogTitle')}</DialogTitle>
+            <DialogDescription>
+              {mfa.recoveryCodes
+                ? t('account.mfa.recoveryCodesDescription')
+                : t('account.mfa.enableDialogDescription')}
+            </DialogDescription>
+          </DialogHeader>
+          {mfa.recoveryCodes ? (
+            <RecoveryCodesPanel
+              codes={mfa.recoveryCodes}
+              continueLabel={t('account.mfa.done')}
+              onContinue={closeEnable}
+            />
+          ) : (
+            mfa.setup && (
+              <MfaEnrollmentPanel
+                qrCodeDataUri={mfa.setup.qrCodeDataUri}
+                secret={mfa.setup.secret}
+                onConfirm={mfa.confirm}
+                isConfirming={mfa.isConfirming}
+                errorMessage={mfa.errorMessage}
+              />
+            )
+          )}
+        </DialogContent>
+      </Dialog>
+
+      <DisableDialog
+        open={disableOpen}
+        onOpenChange={setDisableOpen}
+        onDisable={(code) => mfa.disable(code, () => setDisableOpen(false))}
+        isDisabling={mfa.isDisabling}
+        errorMessage={mfa.errorMessage}
+      />
+    </Card>
+  );
+}
+
+function DisableDialog({
+  open,
+  onOpenChange,
+  onDisable,
+  isDisabling,
+  errorMessage,
+}: Readonly<{
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onDisable: (code: string) => void;
+  isDisabling: boolean;
+  errorMessage: string | null;
+}>) {
+  const { t } = useTranslation('settings');
+  const [code, setCode] = useState('');
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) setCode('');
+        onOpenChange(next);
+      }}
+    >
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{t('account.mfa.disableDialogTitle')}</DialogTitle>
+          <DialogDescription>
+            {t('account.mfa.disableDialogDescription')}
+          </DialogDescription>
+        </DialogHeader>
+        <form
+          className="space-y-4"
+          onSubmit={(e) => {
+            e.preventDefault();
+            if (code.trim().length >= 6 && !isDisabling) onDisable(code);
+          }}
+        >
+          <Input
+            autoFocus
+            value={code}
+            onChange={(e) => setCode(e.target.value)}
+            placeholder={t('account.mfa.codePlaceholder')}
+            className="font-mono"
+          />
+          {errorMessage && (
+            <p className="text-sm text-destructive">{errorMessage}</p>
+          )}
+          <Button
+            type="submit"
+            variant="destructive"
+            className="w-full"
+            disabled={code.trim().length < 6 || isDisabling}
+          >
+            {isDisabling
+              ? t('account.mfa.disabling')
+              : t('account.mfa.disableConfirm')}
+          </Button>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/ayunis-core-frontend/src/shared/locales/de/admin-settings-security.json
+++ b/ayunis-core-frontend/src/shared/locales/de/admin-settings-security.json
@@ -22,5 +22,13 @@
     "noRestrictions": "Derzeit sind keine IP-Einschränkungen konfiguriert. Alle IP-Adressen sind erlaubt.",
     "loadError": "Fehler beim Laden der IP-Zulassungslisten-Einstellungen.",
     "retry": "Erneut versuchen"
+  },
+  "mfaRequirement": {
+    "title": "Zwei-Faktor-Authentifizierung",
+    "description": "Verpflichten Sie alle Nutzer Ihrer Organisation, ihr Konto mit einer Authenticator-App zu schützen.",
+    "toggleLabel": "Zwei-Faktor-Authentifizierung verpflichtend",
+    "toggleHint": "Gilt ab der nächsten Anmeldung. Nutzer ohne Zwei-Faktor-Authentifizierung werden aufgefordert, sie einzurichten, bevor sie fortfahren können.",
+    "saved": "Zwei-Faktor-Anforderung aktualisiert.",
+    "error": "Die Zwei-Faktor-Anforderung konnte nicht aktualisiert werden. Bitte versuchen Sie es erneut."
   }
 }

--- a/ayunis-core-frontend/src/shared/locales/de/admin-settings-users.json
+++ b/ayunis-core-frontend/src/shared/locales/de/admin-settings-users.json
@@ -186,5 +186,15 @@
     "tooManyRows": "Zu viele Zeilen. Maximum ist 500.",
     "emailAlreadyInvited": "E-Mail hat bereits eine ausstehende Einladung",
     "emailAlreadyUser": "E-Mail ist bereits ein Benutzer in dieser Organisation"
+  },
+  "resetMfa": {
+    "menuItem": "Zwei-Faktor-Authentifizierung zurücksetzen",
+    "selfTooltip": "Sie können Ihre eigene Zwei-Faktor-Authentifizierung nicht zurücksetzen – verwalten Sie sie in Ihren Kontoeinstellungen.",
+    "errorSelf": "Sie können Ihre eigene Zwei-Faktor-Authentifizierung nicht zurücksetzen.",
+    "confirmTitle": "Zwei-Faktor-Authentifizierung zurücksetzen?",
+    "confirmDescription": "{{name}} kann sich danach nur mit dem Passwort anmelden und muss die Zwei-Faktor-Authentifizierung neu einrichten. Verwenden Sie dies, wenn ein Nutzer den Zugriff auf Authenticator-App und Wiederherstellungscodes verloren hat.",
+    "confirmText": "Zurücksetzen",
+    "success": "Zwei-Faktor-Authentifizierung wurde zurückgesetzt.",
+    "error": "Zwei-Faktor-Authentifizierung konnte nicht zurückgesetzt werden."
   }
 }

--- a/ayunis-core-frontend/src/shared/locales/de/settings.json
+++ b/ayunis-core-frontend/src/shared/locales/de/settings.json
@@ -55,6 +55,31 @@
       "invalidPassword": "Passwort muss mindestens 8 Zeichen lang sein und einen Großbuchstaben, einen Kleinbuchstaben und eine Zahl enthalten.",
       "incorrectCurrentPassword": "Aktuelles Passwort ist falsch",
       "currentPasswordRequired": "Aktuelles Passwort ist erforderlich"
+    },
+    "mfa": {
+      "title": "Zwei-Faktor-Authentifizierung",
+      "enabledBadge": "Aktiviert",
+      "enabledDescription": "Ihr Konto ist mit einer Authenticator-App geschützt. {{count}} Wiederherstellungscodes übrig.",
+      "disabledDescription": "Schützen Sie Ihr Konto mit einem zweiten Anmeldeschritt über eine Authenticator-App.",
+      "enableButton": "Aktivieren",
+      "disableButton": "Deaktivieren",
+      "enableDialogTitle": "Zwei-Faktor-Authentifizierung einrichten",
+      "enableDialogDescription": "Scannen Sie den QR-Code und bestätigen Sie mit einem Code aus Ihrer Authenticator-App.",
+      "recoveryCodesDescription": "Speichern Sie Ihre Wiederherstellungscodes, bevor Sie diesen Dialog schließen.",
+      "done": "Fertig",
+      "disableDialogTitle": "Zwei-Faktor-Authentifizierung deaktivieren",
+      "disableDialogDescription": "Geben Sie zur Bestätigung einen Code aus Ihrer Authenticator-App (oder einen Wiederherstellungscode) ein.",
+      "codePlaceholder": "123456 oder XXXXX-XXXXX",
+      "disableConfirm": "Zwei-Faktor-Authentifizierung deaktivieren",
+      "disabling": "Wird deaktiviert…",
+      "disabledSuccessfully": "Zwei-Faktor-Authentifizierung deaktiviert.",
+      "error": {
+        "invalidCode": "Dieser Code ist ungültig. Bitte versuchen Sie es erneut.",
+        "locked": "Zu viele Fehlversuche. Bitte warten Sie 15 Minuten.",
+        "requiredByOrg": "Ihre Organisation verlangt Zwei-Faktor-Authentifizierung — sie kann nicht deaktiviert werden.",
+        "unexpected": "Etwas ist schiefgelaufen. Bitte versuchen Sie es erneut.",
+        "statusFailed": "Zwei-Faktor-Status konnte nicht geladen werden. Bitte laden Sie die Seite neu."
+      }
     }
   },
   "general": {

--- a/ayunis-core-frontend/src/shared/locales/en/admin-settings-security.json
+++ b/ayunis-core-frontend/src/shared/locales/en/admin-settings-security.json
@@ -22,5 +22,13 @@
     "noRestrictions": "No IP restrictions are currently configured. All IP addresses are allowed.",
     "loadError": "Failed to load IP allow list settings.",
     "retry": "Retry"
+  },
+  "mfaRequirement": {
+    "title": "Two-factor authentication",
+    "description": "Require every user in your organization to protect their account with an authenticator app.",
+    "toggleLabel": "Require two-factor authentication",
+    "toggleHint": "Applies at each user's next login. Users without two-factor authentication will be asked to set it up before they can continue.",
+    "saved": "Two-factor requirement updated.",
+    "error": "Could not update the two-factor requirement. Please try again."
   }
 }

--- a/ayunis-core-frontend/src/shared/locales/en/admin-settings-users.json
+++ b/ayunis-core-frontend/src/shared/locales/en/admin-settings-users.json
@@ -185,5 +185,15 @@
     "tooManyRows": "Too many rows. Maximum is 500.",
     "emailAlreadyInvited": "Email already has a pending invite",
     "emailAlreadyUser": "Email is already a user in this organization"
+  },
+  "resetMfa": {
+    "menuItem": "Reset two-factor authentication",
+    "selfTooltip": "You cannot reset your own two-factor authentication — manage it in your account settings.",
+    "errorSelf": "You cannot reset your own two-factor authentication.",
+    "confirmTitle": "Reset two-factor authentication?",
+    "confirmDescription": "{{name}} will be able to sign in with just their password and must set up two-factor authentication again. Use this when a user has lost access to their authenticator app and recovery codes.",
+    "confirmText": "Reset",
+    "success": "Two-factor authentication has been reset.",
+    "error": "Could not reset two-factor authentication."
   }
 }

--- a/ayunis-core-frontend/src/shared/locales/en/settings.json
+++ b/ayunis-core-frontend/src/shared/locales/en/settings.json
@@ -55,6 +55,31 @@
       "invalidPassword": "Password must be at least 8 characters and include an uppercase letter, a lowercase letter, and a number.",
       "incorrectCurrentPassword": "Current password is incorrect",
       "currentPasswordRequired": "Current password is required"
+    },
+    "mfa": {
+      "title": "Two-factor authentication",
+      "enabledBadge": "Enabled",
+      "enabledDescription": "Your account is protected with an authenticator app. {{count}} recovery codes remaining.",
+      "disabledDescription": "Add a second login step with an authenticator app to protect your account.",
+      "enableButton": "Enable",
+      "disableButton": "Disable",
+      "enableDialogTitle": "Set up two-factor authentication",
+      "enableDialogDescription": "Scan the QR code and confirm with a code from your authenticator app.",
+      "recoveryCodesDescription": "Save your recovery codes before closing this dialog.",
+      "done": "Done",
+      "disableDialogTitle": "Disable two-factor authentication",
+      "disableDialogDescription": "Enter a code from your authenticator app (or a recovery code) to confirm.",
+      "codePlaceholder": "123456 or XXXXX-XXXXX",
+      "disableConfirm": "Disable two-factor authentication",
+      "disabling": "Disabling…",
+      "disabledSuccessfully": "Two-factor authentication disabled.",
+      "error": {
+        "invalidCode": "That code is not valid. Please try again.",
+        "locked": "Too many failed attempts. Please wait 15 minutes.",
+        "requiredByOrg": "Your organization requires two-factor authentication — it cannot be disabled.",
+        "unexpected": "Something went wrong. Please try again.",
+        "statusFailed": "Could not load the two-factor status. Please reload the page."
+      }
     }
   },
   "general": {


### PR DESCRIPTION
Completes TOTP two-factor authentication (AYC-62): users enroll via
account settings (QR + recovery codes), login becomes two-step for
enrolled users, org admins can require 2FA (forced enrollment at next
login) and reset a locked-out user's 2FA from user management.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authentication enrollment, org policy, and admin MFA reset; mistakes could lock users out or weaken 2FA, though self-reset is blocked and disable respects org requirement errors.
> 
> **Overview**
> Adds **self-service two-factor authentication** on account settings via a new **TwoFactorCard**: status, QR enrollment through shared `MfaEnrollmentPanel` / `RecoveryCodesPanel`, one-time recovery codes (dialog cannot close until acknowledged), and code-guarded disable with API error handling including org-required MFA.
> 
> **Admin security settings** gain an **MfaRequirementCard** switch that reads and updates org-wide “require 2FA at next login” through generated MFA org-requirement APIs, with toast feedback and query invalidation.
> 
> **User management** adds a **Reset two-factor authentication** action (confirm dialog, loading state) wired to `useMfaControllerResetUser`; the current user cannot reset their own MFA (UI disabled + `MFA_SELF_RESET_NOT_ALLOWED` messaging).
> 
> English and German locale strings cover MFA account, org requirement, and reset flows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0af9efa0b31dba8c1e65d249416dbe7cb78c36c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->