### PR TITLE
fix(app-alert): round top corners and frost banner background (AYC-362)

### DIFF
--- a/ayunis-core-frontend/src/widgets/app-alert-banner/ui/AppAlertBanner.tsx
+++ b/ayunis-core-frontend/src/widgets/app-alert-banner/ui/AppAlertBanner.tsx
@@ -1,6 +1,5 @@
 import { TriangleAlert } from 'lucide-react';
 import { useAppAlertControllerGetAppAlert } from '@/shared/api';
-import { Alert, AlertDescription } from '@/shared/ui/shadcn/alert';
 
 /**
  * Persistent app-wide alert banner shown at the top of every authenticated
@@ -15,14 +14,12 @@ export default function AppAlertBanner() {
   }
 
   return (
-    <Alert
-      variant="warning"
-      className="shrink-0 items-center rounded-none border-x-0 border-t-0 px-4 py-2 [&>svg]:translate-y-0"
+    <div
+      role="alert"
+      className="relative grid w-full shrink-0 grid-cols-[calc(var(--spacing)*4)_1fr] items-center gap-x-3 rounded-none border border-x-0 border-t-0 bg-warning/10 px-4 py-2 text-sm text-warning backdrop-blur-md md:rounded-t-xl"
     >
-      <TriangleAlert className="h-4 w-4" />
-      <AlertDescription className="text-warning font-medium">
-        {data.message}
-      </AlertDescription>
-    </Alert>
+      <TriangleAlert className="size-4" />
+      <p className="font-medium">{data.message}</p>
+    </div>
   );
 }


### PR DESCRIPTION
Follow-up to the merged alignment fix (#908), addressing review
comments on the app alert banner:

- The banner sits inside the inset SidebarInset, which has rounded-xl
  corners on md+. The banner's square top corners poked out past the
  container's rounded corners (the top-left/right overlay). Match the
  radius with md:rounded-t-xl so the banner follows the inset on
  desktop and stays square on mobile.
- Swap the opaque bg-card for a translucent warning tint plus
  backdrop-blur (bg-warning/10 backdrop-blur-md) so the banner has the
  intended frosted-glass look.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only change in a single banner component; no API, auth, or data handling.
> 
> **Overview**
> **App alert banner** styling is updated so it visually matches the inset layout and reads as a frosted warning strip instead of the shared `Alert` card.
> 
> The shadcn **`Alert`** / **`AlertDescription`** wrapper is replaced with a plain **`div`** (`role="alert"`) and a grid for the icon and message. **Desktop** gets **`md:rounded-t-xl`** so the banner’s top corners align with **`SidebarInset`**; mobile stays square on top. Background shifts to **`bg-warning/10`** with **`backdrop-blur-md`** for a translucent frosted look (replacing the opaque card-style treatment).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 06d905a9f408c316483ac15f1eefdfb3ecc5a3b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



