### PR TITLE
chore(tooling): use pnpm in worktree setup hooks (AYC-000)

### DIFF
--- a/.config/wt.toml
+++ b/.config/wt.toml
@@ -13,11 +13,8 @@ done
 '''
 
 [post-start]
-install-node = '''
-(cd ayunis-core-backend && npm ci) &
-pid1=$!
-(cd ayunis-core-frontend && npm ci) &
-pid2=$!
-wait $pid1 && wait $pid2
-'''
+# Single root install: this is a pnpm workspace (workspace:* deps), so `npm ci`
+# fails with EUNSUPPORTEDPROTOCOL. One `pnpm install` links every workspace
+# (backend, frontend, and packages/*) and honors onlyBuiltDependencies.
+install-node = "pnpm install --frozen-lockfile"
 # install-python = "cd ayunis-core-anonymize && uv sync"  # uncomment if you work on anonymize


### PR DESCRIPTION
The wt worktree post-start hook ran `npm ci`, which fails on this pnpm
workspace (workspace:* deps -> EUNSUPPORTEDPROTOCOL). Replace the two
per-package npm installs with a single root `pnpm install --frozen-lockfile`,
which links every workspace (backend, frontend, packages/*) and honors the
onlyBuiltDependencies allowlist.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev-only worktree bootstrap config; no runtime app, auth, or data-path changes.
> 
> **Overview**
> Updates the **wt** worktree `[post-start]` hook so new worktrees install Node dependencies correctly for this **pnpm** monorepo.
> 
> **Before:** `install-node` ran parallel `npm ci` in `ayunis-core-backend` and `ayunis-core-frontend`, which breaks on `workspace:*` deps (`EUNSUPPORTEDPROTOCOL`).
> 
> **After:** One root `pnpm install --frozen-lockfile` installs and links backend, frontend, and `packages/*`, with a short comment explaining why. The `pre-start` env copy behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0eb7f90fae2cf67d3c0b416c506c850876d17d59. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->