### PR TITLE
docs(frontend-skill): forbid hand-editing shared shadcn UI (AYC-000)

### DIFF
--- a/.claude/skills/ayunis-core-frontend-dev/SKILL.md
+++ b/.claude/skills/ayunis-core-frontend-dev/SKILL.md
@@ -36,6 +36,14 @@ src/
 
 Layers only depend on layers to their right. Never import upward.
 
+## Shared shadcn UI — Never Modify
+
+**Never edit the shared shadcn components in `src/shared/ui/shadcn/` yourself.** These are managed via the shadcn registry (`components.json`) and are shared design-system primitives. Editing them by hand causes drift from the registry and breaks every consumer.
+
+- To add or update a shadcn component, use the shadcn CLI (`pnpm dlx shadcn@latest add <component>`) — do not hand-write or hand-patch files under `src/shared/ui/shadcn/`.
+- If a component's behavior or styling needs to change for a feature, **wrap or compose it** in your own component (in the relevant `ui/` directory or `src/shared/ui/` outside `shadcn/`) rather than modifying the primitive.
+- If you believe a shared shadcn primitive genuinely must change, **stop and ask the user** — do not make the change on your own.
+
 ### Page module internals
 
 Each page module can have these subdirectories:
@@ -73,3 +81,4 @@ For hooks that back a form (create/update dialogs), load the **frontend-form-pat
 - [ ] Page renders without console errors
 - [ ] No `any` types introduced
 - [ ] Import rules respected (no upward imports)
+- [ ] No hand-edits to `src/shared/ui/shadcn/`


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only change to an agent skill file; no application code, build, or runtime behavior is modified.
> 
> **Overview**
> Extends the **ayunis-core-frontend-dev** skill with a **Shared shadcn UI — Never Modify** section so automated frontend work follows the same rule already enforced elsewhere (e.g. Bugbot): **`src/shared/ui/shadcn/`** is registry-managed via `components.json` and must not be patched by hand.
> 
> The new guidance tells contributors to add/update primitives with **`pnpm dlx shadcn@latest add <component>`**, to **wrap or compose** shadcn components in feature-local or non-`shadcn` shared UI when behavior or styling must differ, and to **ask the user** before changing a shared primitive. The **Completion Checklist** gains an item: **No hand-edits to `src/shared/ui/shadcn/`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1323508f307d51553e7e087f0363f081da7778d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->