### PR TITLE
chore(deps): upgrade @mistralai/mistralai to v2 (AYC-129)

### DIFF
--- a/ayunis-core-backend/package.json
+++ b/ayunis-core-backend/package.json
@@ -56,7 +56,7 @@
     "@ayunis/provider-mistral": "workspace:*",
     "@ayunis/provider-ollama": "workspace:*",
     "@ayunis/provider-openai": "workspace:*",
-    "@mistralai/mistralai": "^1.14.0",
+    "@mistralai/mistralai": "^2.4.1",
     "@modelcontextprotocol/sdk": "^1.20.2",
     "@nestjs-cls/transactional": "^3.1.0",
     "@nestjs-cls/transactional-adapter-typeorm": "^1.3.0",
@@ -199,7 +199,8 @@
       "<rootDir>/../jest.setup.js"
     ],
     "moduleNameMapper": {
-      "^src/(.*)$": "<rootDir>/$1"
+      "^src/(.*)$": "<rootDir>/$1",
+      "^@mistralai/mistralai/models/errors$": "<rootDir>/../test/shims/mistral-models-errors.ts"
     },
     "coverageThreshold": {
       "global": {

--- a/ayunis-core-backend/package.json
+++ b/ayunis-core-backend/package.json
@@ -56,7 +56,7 @@
     "@ayunis/provider-mistral": "workspace:*",
     "@ayunis/provider-ollama": "workspace:*",
     "@ayunis/provider-openai": "workspace:*",
-    "@mistralai/mistralai": "^1.14.0",
+    "@mistralai/mistralai": "^2.4.1",
     "@modelcontextprotocol/sdk": "^1.20.2",
     "@nestjs-cls/transactional": "^3.1.0",
     "@nestjs-cls/transactional-adapter-typeorm": "^1.3.0",
@@ -203,7 +203,8 @@
       "<rootDir>/../jest.setup.js"
     ],
     "moduleNameMapper": {
-      "^src/(.*)$": "<rootDir>/$1"
+      "^src/(.*)$": "<rootDir>/$1",
+      "^@mistralai/mistralai/models/errors$": "<rootDir>/../test/shims/mistral-models-errors.ts"
     },
     "coverageThreshold": {
       "global": {

--- a/ayunis-core-backend/test/shims/mistral-models-errors.ts
+++ b/ayunis-core-backend/test/shims/mistral-models-errors.ts
@@ -1,0 +1,78 @@
+/**
+ * Test-only shim for '@mistralai/mistralai/models/errors'.
+ *
+ * The v2 SDK is ESM-only; Jest's CommonJS runtime cannot parse its build and
+ * ts-jest only transforms .ts files. jest's moduleNameMapper points the
+ * subpath here so specs and services under test share the same classes
+ * (instanceof stays consistent). Mirrors esm/models/errors/mistralerror.js
+ * and esm/models/errors/httpclienterrors.js — keep the constructor
+ * signatures and fields in sync when upgrading the SDK.
+ */
+export class MistralError extends Error {
+  readonly statusCode: number;
+  readonly body: string;
+  readonly headers: Headers;
+  readonly contentType: string;
+  readonly rawResponse: Response;
+
+  constructor(
+    message: string,
+    httpMeta: { response: Response; request: Request; body: string },
+  ) {
+    super(message);
+    this.statusCode = httpMeta.response.status;
+    this.body = httpMeta.body;
+    this.headers = httpMeta.response.headers;
+    this.contentType = httpMeta.response.headers.get('content-type') || '';
+    this.rawResponse = httpMeta.response;
+    this.name = 'MistralError';
+  }
+}
+
+export class SDKError extends MistralError {
+  constructor(
+    message: string,
+    httpMeta: { response: Response; request: Request; body: string },
+  ) {
+    super(message, httpMeta);
+    this.name = 'SDKError';
+  }
+}
+
+export class HTTPClientError extends Error {
+  override readonly cause: unknown;
+
+  constructor(message: string, opts?: { cause?: unknown }) {
+    let msg = message;
+    if (opts?.cause) {
+      const cause =
+        opts.cause instanceof Error ? opts.cause : JSON.stringify(opts.cause);
+      msg += `: ${cause}`;
+    }
+    super(msg, opts);
+    this.name = 'HTTPClientError';
+    if (typeof this.cause === 'undefined') {
+      this.cause = opts?.cause;
+    }
+  }
+}
+
+export class UnexpectedClientError extends HTTPClientError {
+  override readonly name: string = 'UnexpectedClientError';
+}
+
+export class InvalidRequestError extends HTTPClientError {
+  override readonly name: string = 'InvalidRequestError';
+}
+
+export class RequestAbortedError extends HTTPClientError {
+  override readonly name: string = 'RequestAbortedError';
+}
+
+export class RequestTimeoutError extends HTTPClientError {
+  override readonly name: string = 'RequestTimeoutError';
+}
+
+export class ConnectionError extends HTTPClientError {
+  override readonly name: string = 'ConnectionError';
+}

--- a/ayunis-core-backend/test/shims/mistral-models-errors.ts
+++ b/ayunis-core-backend/test/shims/mistral-models-errors.ts
@@ -1,0 +1,39 @@
+/**
+ * Test-only shim for '@mistralai/mistralai/models/errors'.
+ *
+ * The v2 SDK is ESM-only; Jest's CommonJS runtime cannot parse its build and
+ * ts-jest only transforms .ts files. jest's moduleNameMapper points the
+ * subpath here so specs and services under test share the same classes
+ * (instanceof stays consistent). Mirrors esm/models/errors/mistralerror.js —
+ * keep the constructor signature and fields in sync when upgrading the SDK.
+ */
+export class MistralError extends Error {
+  readonly statusCode: number;
+  readonly body: string;
+  readonly headers: Headers;
+  readonly contentType: string;
+  readonly rawResponse: Response;
+
+  constructor(
+    message: string,
+    httpMeta: { response: Response; request: Request; body: string },
+  ) {
+    super(message);
+    this.statusCode = httpMeta.response.status;
+    this.body = httpMeta.body;
+    this.headers = httpMeta.response.headers;
+    this.contentType = httpMeta.response.headers.get('content-type') || '';
+    this.rawResponse = httpMeta.response;
+    this.name = 'MistralError';
+  }
+}
+
+export class SDKError extends MistralError {
+  constructor(
+    message: string,
+    httpMeta: { response: Response; request: Request; body: string },
+  ) {
+    super(message, httpMeta);
+    this.name = 'SDKError';
+  }
+}

--- a/ayunis-core-backend/tsconfig.json
+++ b/ayunis-core-backend/tsconfig.json
@@ -27,7 +27,11 @@
     "forceConsistentCasingInFileNames": true,
     "paths": {
       "src/*": ["./src/*"],
-      "@modelcontextprotocol/sdk/client/*": ["./node_modules/@modelcontextprotocol/sdk/dist/cjs/client/*"]
+      "@modelcontextprotocol/sdk/client/*": ["./node_modules/@modelcontextprotocol/sdk/dist/cjs/client/*"],
+      // @mistralai/mistralai v2 is ESM-only with an exports map that node10
+      // moduleResolution cannot read; map subpaths to the esm build (runtime
+      // uses Node 26 require(esm)).
+      "@mistralai/mistralai/*": ["./node_modules/@mistralai/mistralai/esm/*"]
     }
   }
 }

--- a/ayunis-core-backend/tsconfig.json
+++ b/ayunis-core-backend/tsconfig.json
@@ -31,7 +31,11 @@
     "types": ["node", "jest", "multer"],
     "paths": {
       "src/*": ["./src/*"],
-      "@modelcontextprotocol/sdk/client/*": ["./node_modules/@modelcontextprotocol/sdk/dist/cjs/client/*"]
+      "@modelcontextprotocol/sdk/client/*": ["./node_modules/@modelcontextprotocol/sdk/dist/cjs/client/*"],
+      // @mistralai/mistralai v2 is ESM-only with an exports map that node10
+      // moduleResolution cannot read; map subpaths to the esm build (runtime
+      // uses Node 26 require(esm)).
+      "@mistralai/mistralai/*": ["./node_modules/@mistralai/mistralai/esm/*"]
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,8 +48,8 @@ importers:
         specifier: workspace:*
         version: link:../packages/provider-openai
       '@mistralai/mistralai':
-        specifier: ^1.14.0
-        version: 1.15.1
+        specifier: ^2.4.1
+        version: 2.4.1(@opentelemetry/api@1.9.1)
       '@modelcontextprotocol/sdk':
         specifier: ^1.20.2
         version: 1.29.0(zod@4.4.3)
@@ -458,7 +458,7 @@ importers:
         version: 1.167.0(@tanstack/react-router@1.170.8(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@tanstack/router-core@1.171.6)(csstype@3.2.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@tanstack/router-plugin':
         specifier: ^1.166.13
-        version: 1.168.11(@tanstack/react-router@1.170.8(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite@6.4.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.106.0(lightningcss@1.32.0))
+        version: 1.168.11(@tanstack/react-router@1.170.8(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite@6.4.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.106.0(lightningcss@1.32.0)(postcss@8.5.15))
       '@tiptap/extension-link':
         specifier: ^3.20.0
         version: 3.23.6(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))(@tiptap/pm@3.23.6)
@@ -2435,6 +2435,14 @@ packages:
 
   '@mistralai/mistralai@1.15.1':
     resolution: {integrity: sha512-fb995eiz3r0KsBGtRjFV+/iLbX+UpfalxpF+YitT3R6ukrPD4PN+FGwwmYcRFhNAzVzDUtTVxQYnjQWEnwV5nw==}
+
+  '@mistralai/mistralai@2.4.1':
+    resolution: {integrity: sha512-vNpR2GR76aW7fK8Dcu1NRx3fdSPO1QruRDo4GbfXfkro2mvp194xIAvJ2BP4ZykzyWtJoDmBe+Qsk9D443aqlg==}
+    peerDependencies:
+      '@opentelemetry/api': ^1.9.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
 
   '@modelcontextprotocol/sdk@1.29.0':
     resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
@@ -13780,6 +13788,18 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
+  '@mistralai/mistralai@2.4.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/semantic-conventions': 1.41.1
+      ws: 8.21.0
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.2(zod@3.25.76)
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
     dependencies:
       '@hono/node-server': 1.19.14(hono@4.12.23)
@@ -16303,7 +16323,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@tanstack/router-plugin@1.168.11(@tanstack/react-router@1.170.8(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite@6.4.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.106.0(lightningcss@1.32.0))':
+  '@tanstack/router-plugin@1.168.11(@tanstack/react-router@1.170.8(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite@6.4.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.106.0(lightningcss@1.32.0)(postcss@8.5.15))':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/plugin-syntax-jsx': 7.29.7(@babel/core@7.29.7)
@@ -16321,7 +16341,7 @@ snapshots:
     optionalDependencies:
       '@tanstack/react-router': 1.170.8(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       vite: 6.4.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
-      webpack: 5.106.0(lightningcss@1.32.0)
+      webpack: 5.106.0(lightningcss@1.32.0)(postcss@8.5.15)
     transitivePeerDependencies:
       - supports-color
 
@@ -24182,15 +24202,16 @@ snapshots:
       '@swc/core': 1.15.40
       postcss: 8.5.15
 
-  terser-webpack-plugin@5.6.1(lightningcss@1.32.0)(webpack@5.106.0(lightningcss@1.32.0)):
+  terser-webpack-plugin@5.6.1(lightningcss@1.32.0)(postcss@8.5.15)(webpack@5.106.0(lightningcss@1.32.0)(postcss@8.5.15)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       terser: 5.48.0
-      webpack: 5.106.0(lightningcss@1.32.0)
+      webpack: 5.106.0(lightningcss@1.32.0)(postcss@8.5.15)
     optionalDependencies:
       lightningcss: 1.32.0
+      postcss: 8.5.15
     optional: true
 
   terser@5.48.0:
@@ -24977,7 +24998,7 @@ snapshots:
       - postcss
       - uglify-js
 
-  webpack@5.106.0(lightningcss@1.32.0):
+  webpack@5.106.0(lightningcss@1.32.0)(postcss@8.5.15):
     dependencies:
       '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.9
@@ -25001,7 +25022,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.3
-      terser-webpack-plugin: 5.6.1(lightningcss@1.32.0)(webpack@5.106.0(lightningcss@1.32.0))
+      terser-webpack-plugin: 5.6.1(lightningcss@1.32.0)(postcss@8.5.15)(webpack@5.106.0(lightningcss@1.32.0)(postcss@8.5.15))
       watchpack: 2.5.1
       webpack-sources: 3.5.0
     transitivePeerDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,8 +48,8 @@ importers:
         specifier: workspace:*
         version: link:../packages/provider-openai
       '@mistralai/mistralai':
-        specifier: ^1.14.0
-        version: 1.15.1
+        specifier: ^2.4.1
+        version: 2.5.0(@opentelemetry/api@1.9.1)
       '@modelcontextprotocol/sdk':
         specifier: ^1.20.2
         version: 1.29.0(zod@4.4.3)
@@ -2518,6 +2518,14 @@ packages:
 
   '@mistralai/mistralai@1.15.1':
     resolution: {integrity: sha512-fb995eiz3r0KsBGtRjFV+/iLbX+UpfalxpF+YitT3R6ukrPD4PN+FGwwmYcRFhNAzVzDUtTVxQYnjQWEnwV5nw==}
+
+  '@mistralai/mistralai@2.5.0':
+    resolution: {integrity: sha512-S/r6tkiUHblaDJGsb84WS0ePTF2YHVta2EoTi1NJqHNt5mfRRS2uE4v7hCYV134+an+fk6WgG3+aFfinJbQBjQ==}
+    peerDependencies:
+      '@opentelemetry/api': ^1.9.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
 
   '@modelcontextprotocol/sdk@1.29.0':
     resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
@@ -13932,6 +13940,18 @@ snapshots:
       ws: 8.21.0
       zod: 3.25.76
       zod-to-json-schema: 3.25.2(zod@3.25.76)
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@mistralai/mistralai@2.5.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/semantic-conventions': 1.41.1
+      ws: 8.21.0
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.2(zod@3.25.76)
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate


### PR DESCRIPTION
- v2 adds the audio.speech TTS API needed for read-out-loud (AYC-129)
- v2 is ESM-only: map SDK subpaths in tsconfig paths (node10 resolution
  cannot read its exports map); runtime uses Node 26 require(esm)
- add test-only shim for models/errors via jest moduleNameMapper so
  CJS jest suites keep constructing real-shaped SDK errors
- packages/provider-mistral intentionally stays on SDK v1 (own follow-up)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches a major SDK major version and ESM resolution paths for Mistral calls (embeddings, retries, future TTS); mis-resolution or shim drift could break error handling or tests without affecting unrelated code much.
> 
> **Overview**
> **Upgrades** `core-backend`’s direct dependency on `@mistralai/mistralai` from **v1.14** to **v2.4+** (lock resolves to 2.5.0), mainly to unlock **v2 APIs such as `audio.speech` TTS** for read-out-loud work.
> 
> Because **v2 is ESM-only**, the PR adds a **`tsconfig` `paths` map** from `@mistralai/mistralai/*` to the package’s **`esm/*` build** so TypeScript and tooling can resolve subpaths where the exports map is awkward; runtime is expected to load ESM via **Node’s `require(esm)`** on supported Node versions.
> 
> **Jest** gets a **`moduleNameMapper`** entry that redirects `@mistralai/mistralai/models/errors` to a **test-only shim** (`test/shims/mistral-models-errors.ts`) so CJS Jest can still use SDK-shaped error classes and keep **`instanceof` checks** consistent in specs (e.g. transient-error and embeddings handler tests). The shim is documented to stay in sync with the SDK when upgrading.
> 
> The lockfile reflects the new SDK version and its optional OpenTelemetry peer. **`@ayunis/provider-mistral` is not upgraded here** and remains on SDK v1 per the PR notes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a40e22fb4e2e85c364d66bed32f5da3eaa58634. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->