### PR TITLE
wip(speech): add speech synthesis endpoint (AYC-129)

### DIFF
--- a/ayunis-core-backend/.env.example
+++ b/ayunis-core-backend/.env.example
@@ -113,6 +113,11 @@ MISTRAL_API_KEY=
 ## Model used for audio transcription; must support the transcription API,
 ## e.g. voxtral-mini-latest (default) or voxtral-mini-2602
 MISTRAL_TRANSCRIPTION_MODEL=
+## Model used for text-to-speech (default: voxtral-mini-tts-latest)
+MISTRAL_TTS_MODEL=
+## Voice for text-to-speech (default: en_paul_neutral); Mistral requires a
+## voice on every request — presets via GET /v1/audio/voices
+MISTRAL_TTS_VOICE=
 ## OpenAI API
 OPENAI_API_KEY=
 ## Anthropic API

--- a/ayunis-core-backend/src/app/app.module.ts
+++ b/ayunis-core-backend/src/app/app.module.ts
@@ -21,6 +21,7 @@ import { McpModule } from '../domain/mcp/mcp.module';
 import { MarketplaceModule } from '../domain/marketplace/marketplace.module';
 import { UsageModule } from '../domain/usage/usage.module';
 import { TranscriptionsModule } from '../domain/transcriptions/transcriptions.module';
+import { SpeechModule } from '../domain/speech/speech.module';
 import { ChatSettingsModule } from '../domain/chat-settings/chat-settings.module';
 import { AnonymizationSettingsModule } from '../domain/anonymization-settings/anonymization-settings.module';
 import { RetentionPoliciesModule } from '../domain/retention-policies/retention-policies.module';
@@ -128,6 +129,7 @@ import { IntegrationsModule } from '../integrations/integrations.module';
     MarketplaceModule,
     UsageModule,
     TranscriptionsModule,
+    SpeechModule,
     ChatSettingsModule,
     AnonymizationSettingsModule,
     RetentionPoliciesModule,

--- a/ayunis-core-backend/src/config/models.config.ts
+++ b/ayunis-core-backend/src/config/models.config.ts
@@ -8,6 +8,10 @@ const mistralConfig = () => ({
   // voxtral-small only supports audio chat, not /v1/audio/transcriptions.
   transcriptionModel:
     process.env.MISTRAL_TRANSCRIPTION_MODEL ?? 'voxtral-mini-latest',
+  ttsModel: process.env.MISTRAL_TTS_MODEL ?? 'voxtral-mini-tts-latest',
+  // Mistral requires a voice on every speech request; presets are listed
+  // at GET /v1/audio/voices (English and French only as of 2026-07)
+  ttsVoice: process.env.MISTRAL_TTS_VOICE ?? 'en_paul_neutral',
 });
 
 export const modelsConfig = registerAs('models', () => ({

--- a/ayunis-core-backend/src/domain/speech/SUMMARY.md
+++ b/ayunis-core-backend/src/domain/speech/SUMMARY.md
@@ -1,0 +1,42 @@
+# Speech Module
+
+Text-to-speech synthesis. Converts text into spoken audio via Mistral's
+Voxtral TTS models, used by the frontend's "read out loud" button on
+assistant messages.
+
+## Structure
+
+```text
+speech/
+├── application/
+│   ├── ports/text-to-speech.port.ts      # TextToSpeechPort (abstract)
+│   ├── speech.errors.ts                  # SpeechError + subclasses
+│   └── use-cases/synthesize-speech/      # SynthesizeSpeechUseCase + command
+├── infrastructure/
+│   └── mistral-text-to-speech.service.ts # Mistral audio.speech adapter
+├── presenters/http/
+│   ├── speech.controller.ts              # POST /speech → audio/mpeg
+│   └── dtos/synthesize-speech.dto.ts
+└── speech.module.ts
+```
+
+## Behavior
+
+- `POST /speech` with `{ input: string }` returns the synthesized speech as
+  a binary `audio/mpeg` (mp3) response (`StreamableFile`).
+- Input is capped at 5,000 characters (`MAX_TTS_INPUT_CHARS`); empty and
+  whitespace-only input is rejected with 400.
+- Auth comes from the global guard chain; the route is rate-limited
+  (10/min per client, enforced in production only).
+- Model and voice are configured via `MISTRAL_TTS_MODEL` (default
+  `voxtral-mini-tts-latest`) and `MISTRAL_TTS_VOICE` (default
+  `en_paul_neutral`; Mistral requires a voice on every request) in
+  `src/config/models.config.ts`.
+- The Mistral adapter retries transient (5xx) errors with backoff and maps
+  failures to `SpeechServiceUnavailableError` / `SpeechSynthesisFailedError`.
+
+## Dependencies
+
+- `ContextModule` for the authenticated user check in the use case.
+- `@mistralai/mistralai` v2 (`client.audio.speech.complete`, base64 →
+  Buffer).

--- a/ayunis-core-backend/src/domain/speech/application/ports/text-to-speech.port.ts
+++ b/ayunis-core-backend/src/domain/speech/application/ports/text-to-speech.port.ts
@@ -1,0 +1,3 @@
+export abstract class TextToSpeechPort {
+  abstract synthesize(input: string): Promise<Buffer>;
+}

--- a/ayunis-core-backend/src/domain/speech/application/speech.errors.ts
+++ b/ayunis-core-backend/src/domain/speech/application/speech.errors.ts
@@ -1,0 +1,52 @@
+import type { ErrorMetadata } from '../../../common/errors/base.error';
+import { ApplicationError } from '../../../common/errors/base.error';
+
+/**
+ * Error codes specific to the Speech domain
+ */
+export enum SpeechErrorCode {
+  SPEECH_SYNTHESIS_FAILED = 'SPEECH_SYNTHESIS_FAILED',
+  INVALID_SPEECH_INPUT = 'INVALID_SPEECH_INPUT',
+  SPEECH_SERVICE_UNAVAILABLE = 'SPEECH_SERVICE_UNAVAILABLE',
+}
+
+/**
+ * Base speech error that all speech-specific errors should extend
+ */
+export abstract class SpeechError extends ApplicationError {
+  constructor(
+    message: string,
+    code: SpeechErrorCode,
+    statusCode: number = 400,
+    metadata?: ErrorMetadata,
+  ) {
+    super(message, code, statusCode, metadata);
+  }
+}
+
+export class SpeechSynthesisFailedError extends SpeechError {
+  constructor(
+    message: string = 'Speech synthesis failed',
+    metadata?: ErrorMetadata,
+  ) {
+    super(message, SpeechErrorCode.SPEECH_SYNTHESIS_FAILED, 500, metadata);
+  }
+}
+
+export class InvalidSpeechInputError extends SpeechError {
+  constructor(
+    message: string = 'Invalid speech input',
+    metadata?: ErrorMetadata,
+  ) {
+    super(message, SpeechErrorCode.INVALID_SPEECH_INPUT, 400, metadata);
+  }
+}
+
+export class SpeechServiceUnavailableError extends SpeechError {
+  constructor(
+    message: string = 'Speech service unavailable',
+    metadata?: ErrorMetadata,
+  ) {
+    super(message, SpeechErrorCode.SPEECH_SERVICE_UNAVAILABLE, 503, metadata);
+  }
+}

--- a/ayunis-core-backend/src/domain/speech/application/use-cases/synthesize-speech/synthesize-speech.command.ts
+++ b/ayunis-core-backend/src/domain/speech/application/use-cases/synthesize-speech/synthesize-speech.command.ts
@@ -1,0 +1,7 @@
+export class SynthesizeSpeechCommand {
+  public readonly input: string;
+
+  constructor(params: { input: string }) {
+    this.input = params.input;
+  }
+}

--- a/ayunis-core-backend/src/domain/speech/application/use-cases/synthesize-speech/synthesize-speech.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/speech/application/use-cases/synthesize-speech/synthesize-speech.use-case.spec.ts
@@ -1,0 +1,65 @@
+import { Test } from '@nestjs/testing';
+import type { TestingModule } from '@nestjs/testing';
+import { SynthesizeSpeechUseCase } from './synthesize-speech.use-case';
+import { SynthesizeSpeechCommand } from './synthesize-speech.command';
+import { TextToSpeechPort } from '../../ports/text-to-speech.port';
+import { InvalidSpeechInputError } from '../../speech.errors';
+import { ContextService } from 'src/common/context/services/context.service';
+import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
+
+describe('SynthesizeSpeechUseCase', () => {
+  let useCase: SynthesizeSpeechUseCase;
+  let synthesize: jest.Mock;
+  let getContext: jest.Mock;
+
+  const speechAudio = Buffer.from('fake mp3 audio bytes');
+
+  beforeEach(async () => {
+    synthesize = jest.fn().mockResolvedValue(speechAudio);
+    getContext = jest.fn().mockReturnValue('a2c5e9d1-user-id');
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        SynthesizeSpeechUseCase,
+        { provide: TextToSpeechPort, useValue: { synthesize } },
+        { provide: ContextService, useValue: { get: getContext } },
+      ],
+    }).compile();
+
+    useCase = module.get(SynthesizeSpeechUseCase);
+  });
+
+  it('should return the synthesized audio for valid input', async () => {
+    const result = await useCase.execute(
+      new SynthesizeSpeechCommand({ input: 'Ihr Antrag wurde genehmigt.' }),
+    );
+
+    expect(result).toEqual(speechAudio);
+    expect(synthesize).toHaveBeenCalledWith('Ihr Antrag wurde genehmigt.');
+  });
+
+  it('should reject when no user is in the request context', async () => {
+    getContext.mockReturnValue(undefined);
+
+    await expect(
+      useCase.execute(new SynthesizeSpeechCommand({ input: 'Guten Tag.' })),
+    ).rejects.toThrow(UnauthorizedAccessError);
+    expect(synthesize).not.toHaveBeenCalled();
+  });
+
+  it('should reject empty or whitespace-only input', async () => {
+    await expect(
+      useCase.execute(new SynthesizeSpeechCommand({ input: '   \n ' })),
+    ).rejects.toThrow(InvalidSpeechInputError);
+    expect(synthesize).not.toHaveBeenCalled();
+  });
+
+  it('should reject input longer than 5000 characters', async () => {
+    const longInput = 'a'.repeat(5001);
+
+    await expect(
+      useCase.execute(new SynthesizeSpeechCommand({ input: longInput })),
+    ).rejects.toThrow(InvalidSpeechInputError);
+    expect(synthesize).not.toHaveBeenCalled();
+  });
+});

--- a/ayunis-core-backend/src/domain/speech/application/use-cases/synthesize-speech/synthesize-speech.use-case.ts
+++ b/ayunis-core-backend/src/domain/speech/application/use-cases/synthesize-speech/synthesize-speech.use-case.ts
@@ -1,0 +1,64 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { TextToSpeechPort } from '../../ports/text-to-speech.port';
+import { SynthesizeSpeechCommand } from './synthesize-speech.command';
+import { ContextService } from 'src/common/context/services/context.service';
+import {
+  InvalidSpeechInputError,
+  SpeechSynthesisFailedError,
+} from '../../speech.errors';
+import { ApplicationError } from 'src/common/errors/base.error';
+import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
+
+// Bounds TTS cost and latency; the frontend truncates to the same limit
+export const MAX_TTS_INPUT_CHARS = 5000;
+
+@Injectable()
+export class SynthesizeSpeechUseCase {
+  private readonly logger = new Logger(SynthesizeSpeechUseCase.name);
+
+  constructor(
+    private readonly textToSpeechPort: TextToSpeechPort,
+    private readonly contextService: ContextService,
+  ) {}
+
+  async execute(command: SynthesizeSpeechCommand): Promise<Buffer> {
+    this.logger.log('execute', { inputLength: command.input.length });
+
+    try {
+      const userId = this.contextService.get('userId');
+      if (!userId) {
+        throw new UnauthorizedAccessError();
+      }
+
+      if (!command.input || command.input.trim().length === 0) {
+        throw new InvalidSpeechInputError('Empty speech input');
+      }
+
+      if (command.input.length > MAX_TTS_INPUT_CHARS) {
+        throw new InvalidSpeechInputError(
+          `Speech input exceeds maximum length of ${MAX_TTS_INPUT_CHARS} characters`,
+        );
+      }
+
+      const audio = await this.textToSpeechPort.synthesize(command.input);
+
+      this.logger.log('Speech synthesis completed', {
+        audioBytes: audio.length,
+      });
+
+      return audio;
+    } catch (error) {
+      if (error instanceof ApplicationError) {
+        throw error;
+      }
+      this.logger.error('Failed to synthesize speech', {
+        error: error instanceof Error ? error.message : 'Unknown error',
+      });
+      throw new SpeechSynthesisFailedError(
+        error instanceof Error
+          ? error.message
+          : 'Unknown error during speech synthesis',
+      );
+    }
+  }
+}

--- a/ayunis-core-backend/src/domain/speech/infrastructure/mistral-text-to-speech.service.spec.ts
+++ b/ayunis-core-backend/src/domain/speech/infrastructure/mistral-text-to-speech.service.spec.ts
@@ -1,0 +1,141 @@
+import { Test } from '@nestjs/testing';
+import type { TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { SDKError } from '@mistralai/mistralai/models/errors';
+import { MistralTextToSpeechService } from './mistral-text-to-speech.service';
+import {
+  SpeechServiceUnavailableError,
+  SpeechSynthesisFailedError,
+} from '../application/speech.errors';
+
+// Mock the Mistral SDK
+jest.mock('@mistralai/mistralai', () => ({
+  Mistral: jest.fn().mockImplementation(() => ({
+    audio: {
+      speech: {
+        complete: jest.fn(),
+      },
+    },
+  })),
+}));
+
+// Mock retryWithBackoff to execute fn directly (no retries in tests)
+jest.mock('src/common/util/retryWithBackoff', () => ({
+  __esModule: true,
+  default: ({ fn }: { fn: () => Promise<unknown> }) => fn(),
+}));
+
+function createSdkError(statusCode: number): SDKError {
+  const response = {
+    status: statusCode,
+    headers: new Headers({ 'content-type': 'application/json' }),
+  } as unknown as Response;
+  return new SDKError(`API error: ${statusCode}`, {
+    response,
+    request: {} as Request,
+    body: '{}',
+  });
+}
+
+describe('MistralTextToSpeechService', () => {
+  let mockClient: {
+    audio: { speech: { complete: jest.Mock } };
+  };
+
+  const speechAudio = Buffer.from('fake mp3 audio bytes');
+
+  async function createService(config: Record<string, string | undefined>) {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        MistralTextToSpeechService,
+        {
+          provide: ConfigService,
+          useValue: {
+            // Mirror ConfigService.get(key, default) fallback behavior
+            get: jest.fn(
+              (key: string, defaultValue?: string) =>
+                config[key] ?? defaultValue,
+            ),
+          },
+        },
+      ],
+    }).compile();
+
+    const service = module.get(MistralTextToSpeechService);
+    mockClient = (service as unknown as { client: typeof mockClient }).client;
+    mockClient.audio.speech.complete.mockResolvedValue({
+      audioData: speechAudio.toString('base64'),
+    });
+    return service;
+  }
+
+  it('should request the configured TTS model and voice with mp3 output', async () => {
+    const service = await createService({
+      'models.mistral.apiKey': 'test-api-key',
+      'models.mistral.ttsModel': 'voxtral-mini-tts-2603',
+      'models.mistral.ttsVoice': 'aurora',
+    });
+
+    await service.synthesize('Ihr Antrag wurde genehmigt.');
+
+    expect(mockClient.audio.speech.complete).toHaveBeenCalledWith({
+      model: 'voxtral-mini-tts-2603',
+      voiceId: 'aurora',
+      input: 'Ihr Antrag wurde genehmigt.',
+      responseFormat: 'mp3',
+      stream: false,
+    });
+  });
+
+  it('should fall back to the default voice when none is configured', async () => {
+    // Mistral rejects speech requests without a voice, so the service must
+    // always send one
+    const service = await createService({
+      'models.mistral.apiKey': 'test-api-key',
+      'models.mistral.ttsModel': 'voxtral-mini-tts-latest',
+    });
+
+    await service.synthesize('Guten Tag.');
+
+    const request = mockClient.audio.speech.complete.mock.calls[0][0] as Record<
+      string,
+      unknown
+    >;
+    expect(request.voiceId).toBe('en_paul_neutral');
+  });
+
+  it('should decode the base64 audio payload into a Buffer', async () => {
+    const service = await createService({
+      'models.mistral.apiKey': 'test-api-key',
+      'models.mistral.ttsModel': 'voxtral-mini-tts-latest',
+    });
+
+    const result = await service.synthesize('Guten Tag.');
+
+    expect(result).toEqual(speechAudio);
+  });
+
+  it('should map 5xx SDK errors to SpeechServiceUnavailableError', async () => {
+    const service = await createService({
+      'models.mistral.apiKey': 'test-api-key',
+      'models.mistral.ttsModel': 'voxtral-mini-tts-latest',
+    });
+    mockClient.audio.speech.complete.mockRejectedValue(createSdkError(503));
+
+    await expect(service.synthesize('Guten Tag.')).rejects.toThrow(
+      SpeechServiceUnavailableError,
+    );
+  });
+
+  it('should wrap non-transient errors in SpeechSynthesisFailedError', async () => {
+    const service = await createService({
+      'models.mistral.apiKey': 'test-api-key',
+      'models.mistral.ttsModel': 'voxtral-mini-tts-latest',
+    });
+    mockClient.audio.speech.complete.mockRejectedValue(createSdkError(422));
+
+    await expect(service.synthesize('Guten Tag.')).rejects.toThrow(
+      SpeechSynthesisFailedError,
+    );
+  });
+});

--- a/ayunis-core-backend/src/domain/speech/infrastructure/mistral-text-to-speech.service.ts
+++ b/ayunis-core-backend/src/domain/speech/infrastructure/mistral-text-to-speech.service.ts
@@ -1,0 +1,97 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { Mistral } from '@mistralai/mistralai';
+import { SDKError } from '@mistralai/mistralai/models/errors';
+import { TextToSpeechPort } from '../application/ports/text-to-speech.port';
+import {
+  SpeechServiceUnavailableError,
+  SpeechSynthesisFailedError,
+} from '../application/speech.errors';
+import retryWithBackoff from 'src/common/util/retryWithBackoff';
+
+@Injectable()
+export class MistralTextToSpeechService extends TextToSpeechPort {
+  private readonly logger = new Logger(MistralTextToSpeechService.name);
+  private readonly client: Mistral;
+  private readonly model: string;
+  private readonly voiceId: string;
+
+  constructor(private readonly configService: ConfigService) {
+    super();
+    this.client = new Mistral({
+      apiKey: this.configService.get('models.mistral.apiKey'),
+      // TTS on long input is slower than transcription
+      timeoutMs: 60_000,
+    });
+    this.model = this.configService.get<string>(
+      'models.mistral.ttsModel',
+      'voxtral-mini-tts-latest',
+    );
+    // Mistral rejects speech requests without a voice — always send one
+    this.voiceId = this.configService.get<string>(
+      'models.mistral.ttsVoice',
+      'en_paul_neutral',
+    );
+  }
+
+  async synthesize(input: string): Promise<Buffer> {
+    this.logger.log('Starting speech synthesis', {
+      model: this.model,
+      inputLength: input.length,
+    });
+
+    try {
+      const response = await retryWithBackoff({
+        fn: () =>
+          this.client.audio.speech.complete({
+            model: this.model,
+            voiceId: this.voiceId,
+            input,
+            responseFormat: 'mp3',
+            stream: false,
+          }),
+        maxRetries: 3,
+        delay: 2000,
+        retryIfError: (error: Error) => this.shouldRetry(error),
+      });
+
+      const audio = Buffer.from(response.audioData, 'base64');
+
+      this.logger.log('Speech synthesis completed', {
+        audioBytes: audio.length,
+      });
+
+      return audio;
+    } catch (error) {
+      this.logger.error('Speech synthesis failed', {
+        error: error instanceof Error ? error.message : 'Unknown error',
+      });
+
+      if (error instanceof SDKError && error.statusCode >= 500) {
+        throw new SpeechServiceUnavailableError(
+          'Mistral speech service is currently unavailable',
+        );
+      }
+
+      throw new SpeechSynthesisFailedError(
+        `Mistral speech synthesis failed: ${
+          error instanceof Error ? error.message : 'Unknown error'
+        }`,
+      );
+    }
+  }
+
+  private shouldRetry(error: Error): boolean {
+    const isTransient = error instanceof SDKError && error.statusCode >= 500;
+    if (isTransient) {
+      this.logger.warn(
+        'Retrying Mistral speech synthesis after transient error',
+        {
+          statusCode: error.statusCode,
+          message: error.message,
+        },
+      );
+    }
+    return isTransient;
+  }
+}

--- a/ayunis-core-backend/src/domain/speech/presenters/http/dtos/synthesize-speech.dto.ts
+++ b/ayunis-core-backend/src/domain/speech/presenters/http/dtos/synthesize-speech.dto.ts
@@ -1,0 +1,14 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsString, MaxLength } from 'class-validator';
+
+export class SynthesizeSpeechDto {
+  @ApiProperty({
+    description: 'The text to synthesize into speech',
+    example: 'Ihr Antrag wurde genehmigt.',
+    maxLength: 5000,
+  })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(5000)
+  input: string;
+}

--- a/ayunis-core-backend/src/domain/speech/presenters/http/speech.controller.ts
+++ b/ayunis-core-backend/src/domain/speech/presenters/http/speech.controller.ts
@@ -1,0 +1,75 @@
+import {
+  Body,
+  Controller,
+  HttpCode,
+  Logger,
+  Post,
+  Res,
+  StreamableFile,
+} from '@nestjs/common';
+import type { Response } from 'express';
+import {
+  ApiBearerAuth,
+  ApiOperation,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { SynthesizeSpeechUseCase } from '../../application/use-cases/synthesize-speech/synthesize-speech.use-case';
+import { SynthesizeSpeechCommand } from '../../application/use-cases/synthesize-speech/synthesize-speech.command';
+import { SynthesizeSpeechDto } from './dtos/synthesize-speech.dto';
+import { RateLimit } from 'src/iam/authorization/application/decorators/rate-limit.decorator';
+
+@ApiTags('speech')
+@ApiBearerAuth()
+@Controller('speech')
+export class SpeechController {
+  private readonly logger = new Logger(SpeechController.name);
+
+  constructor(
+    private readonly synthesizeSpeechUseCase: SynthesizeSpeechUseCase,
+  ) {}
+
+  @Post()
+  @HttpCode(200)
+  @RateLimit({ limit: 10, windowMs: 60_000 })
+  @ApiOperation({
+    summary: 'Synthesize speech from text',
+    description:
+      'Convert text to spoken audio using the configured text-to-speech model. ' +
+      'Returns the generated audio as an MP3 stream.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'The synthesized speech audio',
+    content: {
+      'audio/mpeg': {
+        schema: { type: 'string', format: 'binary' },
+      },
+    },
+  })
+  @ApiResponse({
+    status: 400,
+    description: 'Invalid or too long input text',
+  })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 500, description: 'Speech synthesis failed' })
+  async synthesize(
+    @Body() dto: SynthesizeSpeechDto,
+    @Res({ passthrough: true }) res: Response,
+  ): Promise<StreamableFile> {
+    this.logger.log('Speech synthesis request received', {
+      inputLength: dto.input.length,
+    });
+
+    const audio = await this.synthesizeSpeechUseCase.execute(
+      new SynthesizeSpeechCommand({ input: dto.input }),
+    );
+
+    res.set({
+      'Content-Type': 'audio/mpeg',
+      'Content-Disposition': 'inline; filename="speech.mp3"',
+    });
+
+    return new StreamableFile(audio);
+  }
+}

--- a/ayunis-core-backend/src/domain/speech/speech.module.ts
+++ b/ayunis-core-backend/src/domain/speech/speech.module.ts
@@ -1,0 +1,20 @@
+import { Module } from '@nestjs/common';
+import { SpeechController } from './presenters/http/speech.controller';
+import { SynthesizeSpeechUseCase } from './application/use-cases/synthesize-speech/synthesize-speech.use-case';
+import { TextToSpeechPort } from './application/ports/text-to-speech.port';
+import { MistralTextToSpeechService } from './infrastructure/mistral-text-to-speech.service';
+import { ContextModule } from 'src/common/context/context.module';
+
+@Module({
+  imports: [ContextModule],
+  controllers: [SpeechController],
+  providers: [
+    SynthesizeSpeechUseCase,
+    {
+      provide: TextToSpeechPort,
+      useClass: MistralTextToSpeechService,
+    },
+  ],
+  exports: [TextToSpeechPort, SynthesizeSpeechUseCase],
+})
+export class SpeechModule {}


### PR DESCRIPTION
- new speech module mirroring transcriptions (hexagonal): port, errors,
  synthesize-speech use case (5000-char cap), Mistral TTS adapter
- POST /speech returns audio/mpeg via StreamableFile; rate-limited 10/min
- model/voice configurable via MISTRAL_TTS_MODEL / MISTRAL_TTS_VOICE;
  Mistral requires a voice on every request, default en_paul_neutral
  (no German presets exist as of 2026-07)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New authenticated API that forwards user text to Mistral (cost/abuse surface) mitigated by auth, rate limits, and input caps; no changes to core auth or data persistence.
> 
> **Overview**
> Adds **text-to-speech** for assistant “read out loud”: a new `SpeechModule` (hexagonal layout aligned with transcriptions) exposes **`POST /speech`** with `{ input }`, returning **MP3** (`audio/mpeg`) as a `StreamableFile`.
> 
> **`SynthesizeSpeechUseCase`** requires an authenticated user, rejects empty/whitespace input, and caps text at **5,000** characters. **`MistralTextToSpeechService`** calls `audio.speech.complete` (mp3, base64 → `Buffer`), retries **5xx** with backoff, and maps errors to domain speech errors. The route is **rate-limited** (10/min) and uses global auth guards.
> 
> Configuration is extended with **`MISTRAL_TTS_MODEL`** / **`MISTRAL_TTS_VOICE`** (defaults `voxtral-mini-tts-latest` and `en_paul_neutral`) in `models.config.ts` and `.env.example`; **`SpeechModule`** is registered in `AppModule`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 732c258b7e1387f60a81da8b8fb8c15b63c43061. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->