### PR TITLE
wip(speech): regenerate api client for speech endpoint (AYC-129)

### DIFF
--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
@@ -4163,6 +4163,14 @@ export interface UpsertOrgChatSettingsDto {
   internetSearchEnabled: boolean;
 }
 
+export interface SynthesizeSpeechDto {
+  /**
+   * The text to synthesize into speech
+   * @maxLength 5000
+   */
+  input: string;
+}
+
 export interface RetentionPolicyResponseDto {
   /**
    * Configured retention window in days, or null when retention is disabled (data kept forever).

--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.ts
@@ -167,6 +167,7 @@ import type {
   SuperAdminUsageDataControllerGetUserUsageParams,
   SuperAdminUserResponseDto,
   SuperAdminUsersControllerGetUsersByOrgIdParams,
+  SynthesizeSpeechDto,
   TeamCreditLimitItemDto,
   TeamCreditLimitResponseDto,
   TeamMemberResponseDto,
@@ -17271,6 +17272,73 @@ export const useOrgChatSettingsControllerUpsertOrgChatSettings = <TError = void,
       > => {
 
       const mutationOptions = getOrgChatSettingsControllerUpsertOrgChatSettingsMutationOptions(options);
+
+      return useMutation(mutationOptions, queryClient);
+    }
+    
+/**
+ * Convert text to spoken audio using the configured text-to-speech model. Returns the generated audio as an MP3 stream.
+ * @summary Synthesize speech from text
+ */
+export const speechControllerSynthesize = (
+    synthesizeSpeechDto: SynthesizeSpeechDto,
+ signal?: AbortSignal
+) => {
+      
+      
+      return customAxiosInstance<Blob>(
+      {url: `/speech`, method: 'POST',
+      headers: {'Content-Type': 'application/json', },
+      data: synthesizeSpeechDto,
+        responseType: 'blob', signal
+    },
+      );
+    }
+  
+
+
+export const getSpeechControllerSynthesizeMutationOptions = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof speechControllerSynthesize>>, TError,{data: SynthesizeSpeechDto}, TContext>, }
+): UseMutationOptions<Awaited<ReturnType<typeof speechControllerSynthesize>>, TError,{data: SynthesizeSpeechDto}, TContext> => {
+
+const mutationKey = ['speechControllerSynthesize'];
+const {mutation: mutationOptions} = options ?
+      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
+      options
+      : {...options, mutation: {...options.mutation, mutationKey}}
+      : {mutation: { mutationKey, }};
+
+      
+
+
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof speechControllerSynthesize>>, {data: SynthesizeSpeechDto}> = (props) => {
+          const {data} = props ?? {};
+
+          return  speechControllerSynthesize(data,)
+        }
+
+        
+
+
+  return  { mutationFn, ...mutationOptions }}
+
+    export type SpeechControllerSynthesizeMutationResult = NonNullable<Awaited<ReturnType<typeof speechControllerSynthesize>>>
+    export type SpeechControllerSynthesizeMutationBody = SynthesizeSpeechDto
+    export type SpeechControllerSynthesizeMutationError = void
+
+    /**
+ * @summary Synthesize speech from text
+ */
+export const useSpeechControllerSynthesize = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof speechControllerSynthesize>>, TError,{data: SynthesizeSpeechDto}, TContext>, }
+ , queryClient?: QueryClient): UseMutationResult<
+        Awaited<ReturnType<typeof speechControllerSynthesize>>,
+        TError,
+        {data: SynthesizeSpeechDto},
+        TContext
+      > => {
+
+      const mutationOptions = getSpeechControllerSynthesizeMutationOptions(options);
 
       return useMutation(mutationOptions, queryClient);
     }

--- a/ayunis-core-frontend/src/shared/api/openapi-schema.json
+++ b/ayunis-core-frontend/src/shared/api/openapi-schema.json
@@ -8367,6 +8367,52 @@
         "tags": ["Chat Settings"]
       }
     },
+    "/speech": {
+      "post": {
+        "description": "Convert text to spoken audio using the configured text-to-speech model. Returns the generated audio as an MP3 stream.",
+        "operationId": "SpeechController_synthesize",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SynthesizeSpeechDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The synthesized speech audio",
+            "content": {
+              "audio/mpeg": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid or too long input text"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "500": {
+            "description": "Speech synthesis failed"
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "Synthesize speech from text",
+        "tags": ["speech"]
+      }
+    },
     "/retention-policies/org": {
       "get": {
         "operationId": "RetentionPoliciesController_get",
@@ -15613,6 +15659,18 @@
           }
         },
         "required": ["internetSearchEnabled"]
+      },
+      "SynthesizeSpeechDto": {
+        "type": "object",
+        "properties": {
+          "input": {
+            "type": "string",
+            "description": "The text to synthesize into speech",
+            "example": "Ihr Antrag wurde genehmigt.",
+            "maxLength": 5000
+          }
+        },
+        "required": ["input"]
       },
       "RetentionPolicyResponseDto": {
         "type": "object",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Generated-only changes with no runtime behavior until feature code uses the new hook; low blast radius.
> 
> **Overview**
> Regenerates the Orval API client so the frontend can call the new **text-to-speech** API added on the backend.
> 
> The OpenAPI spec and generated code now include **`SynthesizeSpeechDto`** (`input`, max 5000 characters) and **`POST /speech`**, which returns synthesized audio as an **MP3 blob** (`responseType: 'blob'`). Exports **`speechControllerSynthesize`** and the **`useSpeechControllerSynthesize`** React Query mutation hook, mirroring the existing transcription client pattern.
> 
> No application UI or feature logic in this diff—only **`openapi-schema.json`** and generated **`ayunisCoreAPI.ts`** / **`ayunisCoreAPI.schemas.ts`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3f8ff10bab1d6d84c653c44b1bb4386feaaed7b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->