### PR TITLE
feat(speech): read-out-loud button on assistant messages (AYC-129)

### DIFF
--- a/ayunis-core-frontend/src/pages/chat/api/useReadOutLoud.ts
+++ b/ayunis-core-frontend/src/pages/chat/api/useReadOutLoud.ts
@@ -1,0 +1,101 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { speechControllerSynthesize } from '@/shared/api';
+import extractErrorData from '@/shared/api/extract-error-data';
+import { showError } from '@/shared/lib/toast';
+
+export type ReadOutLoudStatus = 'idle' | 'loading' | 'playing';
+
+// Matches the backend's MAX_TTS_INPUT_CHARS cap
+export const MAX_TTS_INPUT_CHARS = 5000;
+
+export function useReadOutLoud() {
+  const { t } = useTranslation('chat');
+  const [status, setStatus] = useState<ReadOutLoudStatus>('idle');
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+  const objectUrlRef = useRef<string | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
+
+  const reset = useCallback(() => {
+    if (audioRef.current) {
+      audioRef.current.pause();
+      audioRef.current = null;
+    }
+    if (objectUrlRef.current) {
+      URL.revokeObjectURL(objectUrlRef.current);
+      objectUrlRef.current = null;
+    }
+    setStatus('idle');
+  }, []);
+
+  // Stop playback and release the object URL when the message unmounts
+  useEffect(() => {
+    return () => {
+      abortRef.current?.abort();
+      if (audioRef.current) {
+        audioRef.current.pause();
+      }
+      if (objectUrlRef.current) {
+        URL.revokeObjectURL(objectUrlRef.current);
+      }
+    };
+  }, []);
+
+  const handleError = useCallback(
+    (error: unknown) => {
+      try {
+        const { code } = extractErrorData(error);
+        if (code === 'SPEECH_SERVICE_UNAVAILABLE') {
+          showError(t('chat.errorReadOutLoudUnavailable'));
+        } else {
+          showError(t('chat.errorReadOutLoud'));
+        }
+      } catch {
+        // Non-Axios error (audio playback failure, etc.)
+        showError(t('chat.errorReadOutLoud'));
+      }
+    },
+    [t],
+  );
+
+  const start = useCallback(
+    async (text: string) => {
+      setStatus('loading');
+      const controller = new AbortController();
+      abortRef.current = controller;
+
+      try {
+        const blob = await speechControllerSynthesize(
+          { input: text.slice(0, MAX_TTS_INPUT_CHARS) },
+          controller.signal,
+        );
+        if (controller.signal.aborted) return;
+
+        const url = URL.createObjectURL(blob);
+        objectUrlRef.current = url;
+        const audio = new Audio(url);
+        audioRef.current = audio;
+        audio.onended = reset;
+        audio.onerror = () => {
+          reset();
+          showError(t('chat.errorReadOutLoud'));
+        };
+
+        await audio.play();
+        setStatus('playing');
+      } catch (error) {
+        if (controller.signal.aborted) return;
+        reset();
+        handleError(error);
+      }
+    },
+    [handleError, reset, t],
+  );
+
+  const stop = useCallback(() => {
+    abortRef.current?.abort();
+    reset();
+  }, [reset]);
+
+  return { status, start, stop };
+}

--- a/ayunis-core-frontend/src/pages/chat/ui/AssistantRunBlock.tsx
+++ b/ayunis-core-frontend/src/pages/chat/ui/AssistantRunBlock.tsx
@@ -7,6 +7,7 @@ import brandIconDark from '@/shared/assets/brand/brand-icon-round-dark.svg';
 import { AgentRunTimeline } from '@/pages/chat/ui/agent-run-timeline';
 import type { AgentRunUnit } from '@/pages/chat/ui/agent-run-timeline';
 import CopyAssistantTextButton from './CopyAssistantTextButton';
+import ReadAssistantTextButton from './ReadAssistantTextButton';
 
 interface AssistantRunBlockProps {
   unit: AgentRunUnit;
@@ -52,7 +53,12 @@ export default function AssistantRunBlock({
             onOpenArtifact={onOpenArtifact}
           />
         </div>
-        {hasFinalText && <CopyAssistantTextButton contentRef={contentRef} />}
+        {hasFinalText && (
+          <div className="flex items-center gap-1">
+            <CopyAssistantTextButton contentRef={contentRef} />
+            <ReadAssistantTextButton contentRef={contentRef} />
+          </div>
+        )}
       </div>
     </div>
   );

--- a/ayunis-core-frontend/src/pages/chat/ui/ReadAssistantTextButton.tsx
+++ b/ayunis-core-frontend/src/pages/chat/ui/ReadAssistantTextButton.tsx
@@ -1,0 +1,70 @@
+import { Loader2, Square, Volume2 } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { Button } from '@/shared/ui/shadcn/button';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/shared/ui/shadcn/tooltip';
+import { useReadOutLoud } from '../api/useReadOutLoud';
+
+interface ReadAssistantTextButtonProps {
+  readonly contentRef: React.RefObject<HTMLDivElement | null>;
+}
+
+function extractSpeakableText(container: HTMLElement): string {
+  const parts: string[] = [];
+  container.querySelectorAll('[data-copyable="true"]').forEach((element) => {
+    // Read block-level children individually so code blocks can be
+    // skipped — listening to raw code read aloud is useless
+    Array.from(element.children).forEach((child) => {
+      if (child.tagName === 'PRE') return;
+      const text = (child as HTMLElement).innerText.trim();
+      if (text) parts.push(text);
+    });
+  });
+  return parts.join('\n\n').trim();
+}
+
+export default function ReadAssistantTextButton({
+  contentRef,
+}: ReadAssistantTextButtonProps) {
+  const { t } = useTranslation('chat');
+  const { status, start, stop } = useReadOutLoud();
+
+  const handleClick = () => {
+    if (status !== 'idle') {
+      stop();
+      return;
+    }
+    const el = contentRef.current;
+    if (!el) return;
+    const text = extractSpeakableText(el);
+    if (!text) return;
+    void start(text);
+  };
+
+  const label =
+    status === 'idle' ? t('chat.readOutLoud') : t('chat.stopReading');
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-7 w-7 mt-1"
+          onClick={handleClick}
+          aria-label={label}
+        >
+          {status === 'loading' && (
+            <Loader2 className="h-3.5 w-3.5 animate-spin" />
+          )}
+          {status === 'playing' && <Square className="h-3.5 w-3.5" />}
+          {status === 'idle' && <Volume2 className="h-3.5 w-3.5" />}
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent>{label}</TooltipContent>
+    </Tooltip>
+  );
+}

--- a/ayunis-core-frontend/src/shared/locales/de/chat.json
+++ b/ayunis-core-frontend/src/shared/locales/de/chat.json
@@ -37,6 +37,10 @@
     "errorRemoveAgent": "Agent konnte nicht entfernt werden",
     "skillInstructions": "Fähigkeits-Anweisungen",
     "copyToClipboard": "In die Zwischenablage kopieren",
+    "readOutLoud": "Vorlesen",
+    "stopReading": "Vorlesen stoppen",
+    "errorReadOutLoud": "Audio konnte nicht erzeugt werden. Bitte erneut versuchen.",
+    "errorReadOutLoudUnavailable": "Der Sprachdienst ist derzeit nicht verfügbar. Bitte später erneut versuchen.",
     "timeline": {
       "working": "Arbeite…",
       "thoughtProcess": "Gedankengang",

--- a/ayunis-core-frontend/src/shared/locales/en/chat.json
+++ b/ayunis-core-frontend/src/shared/locales/en/chat.json
@@ -37,6 +37,10 @@
     "errorRemoveAgent": "Agent could not be removed",
     "skillInstructions": "Skill instructions",
     "copyToClipboard": "Copy to clipboard",
+    "readOutLoud": "Read out loud",
+    "stopReading": "Stop reading",
+    "errorReadOutLoud": "Could not generate audio. Please try again.",
+    "errorReadOutLoudUnavailable": "The speech service is currently unavailable. Please try again later.",
     "timeline": {
       "working": "Working…",
       "thoughtProcess": "Thought process",


### PR DESCRIPTION
- speaker button next to copy on assistant messages; fetch-then-play
  with idle/loading/playing states, click again stops
- useReadOutLoud hook: blob via generated client, HTMLAudioElement
  playback, abort on stop/unmount, object URL cleanup
- reads rendered markdown text, skips code blocks; 5000-char cap
  matching the backend limit
- en/de i18n keys

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Chat UI-only change reusing the existing speech API; main exposure is sending assistant message text to TTS when the user clicks play.
> 
> **Overview**
> Adds **read out loud** on assistant messages with final text: a speaker control sits next to **copy**, using the same message content ref.
> 
> **`useReadOutLoud`** calls **`speechControllerSynthesize`**, plays the returned MP3 via **`HTMLAudioElement`**, and manages **idle / loading / playing** states. A second click or **stop** aborts the request and pauses playback; unmount cleans up object URLs and in-flight requests. Input is capped at **5000** characters to match the backend. Errors distinguish **`SPEECH_SERVICE_UNAVAILABLE`** from generic failures.
> 
> **`ReadAssistantTextButton`** pulls speakable text from **`[data-copyable="true"]`** blocks (same pattern as copy) but **skips `<pre>`** code blocks. **en/de** strings cover labels and error toasts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20cec750f96ca8a88d01682120e02f85c633c0d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->