### PR TITLE
fix(invites): raise invite creation rate limit for org onboarding (AYC-409)

### DIFF
--- a/ayunis-core-backend/src/iam/authorization/application/guards/rate-limit.guard.spec.ts
+++ b/ayunis-core-backend/src/iam/authorization/application/guards/rate-limit.guard.spec.ts
@@ -1,0 +1,89 @@
+import { Logger } from '@nestjs/common';
+import type { ExecutionContext } from '@nestjs/common';
+import type { Reflector } from '@nestjs/core';
+import type { ConfigService } from '@nestjs/config';
+import { RateLimitGuard } from './rate-limit.guard';
+import { RateLimitExceededError } from '../authorization.errors';
+import type { RateLimitOptions } from '../decorators/rate-limit.decorator';
+
+describe('RateLimitGuard', () => {
+  let guard: RateLimitGuard;
+  let reflector: jest.Mocked<Reflector>;
+  let configService: jest.Mocked<ConfigService>;
+
+  const clientIp = '203.0.113.7';
+
+  function createContext(handlerName = 'create'): ExecutionContext {
+    const request = { headers: { 'x-forwarded-for': clientIp } };
+    return {
+      switchToHttp: () => ({ getRequest: () => request }),
+      getHandler: () => ({ name: handlerName }),
+      getClass: () => ({ name: 'InvitesController' }),
+    } as unknown as ExecutionContext;
+  }
+
+  beforeEach(() => {
+    reflector = {
+      getAllAndOverride: jest.fn(),
+    } as unknown as jest.Mocked<Reflector>;
+    configService = {
+      get: jest.fn(),
+    } as unknown as jest.Mocked<ConfigService>;
+
+    guard = new RateLimitGuard(reflector, configService);
+
+    jest.spyOn(Logger.prototype, 'debug').mockImplementation();
+    jest.spyOn(Logger.prototype, 'warn').mockImplementation();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('skips rate limiting outside production', () => {
+    configService.get.mockReturnValue(false); // app.isProduction
+    reflector.getAllAndOverride.mockReturnValue({
+      limit: 1,
+      windowMs: 60_000,
+    } satisfies RateLimitOptions);
+
+    expect(guard.canActivate(createContext())).toBe(true);
+    // Well beyond the limit but still allowed because it is not production.
+    expect(guard.canActivate(createContext())).toBe(true);
+  });
+
+  it('allows exactly "limit" requests then blocks the next within the window', () => {
+    configService.get.mockReturnValue(true); // app.isProduction
+    const options: RateLimitOptions = { limit: 3, windowMs: 15 * 60 * 1000 };
+    reflector.getAllAndOverride.mockReturnValue(options);
+
+    for (let i = 0; i < options.limit; i++) {
+      expect(guard.canActivate(createContext())).toBe(true);
+    }
+
+    expect(() => guard.canActivate(createContext())).toThrow(
+      RateLimitExceededError,
+    );
+  });
+
+  it('resets the counter once the window has elapsed', () => {
+    configService.get.mockReturnValue(true); // app.isProduction
+    const options: RateLimitOptions = { limit: 2, windowMs: 1000 };
+    reflector.getAllAndOverride.mockReturnValue(options);
+
+    const nowSpy = jest.spyOn(Date, 'now');
+    nowSpy.mockReturnValue(0);
+
+    expect(guard.canActivate(createContext())).toBe(true);
+    expect(guard.canActivate(createContext())).toBe(true);
+    expect(() => guard.canActivate(createContext())).toThrow(
+      RateLimitExceededError,
+    );
+
+    // Advance past the window: the counter should reset.
+    nowSpy.mockReturnValue(2000);
+    expect(guard.canActivate(createContext())).toBe(true);
+
+    nowSpy.mockRestore();
+  });
+});

--- a/ayunis-core-backend/src/iam/invites/presenters/http/invites.controller.rate-limit.spec.ts
+++ b/ayunis-core-backend/src/iam/invites/presenters/http/invites.controller.rate-limit.spec.ts
@@ -1,0 +1,22 @@
+import { Reflector } from '@nestjs/core';
+import { InvitesController } from './invites.controller';
+import {
+  RATE_LIMIT_KEY,
+  type RateLimitOptions,
+} from 'src/iam/authorization/application/decorators/rate-limit.decorator';
+
+describe('InvitesController rate limits', () => {
+  const reflector = new Reflector();
+
+  it('allows admins to create enough invites to onboard an organization (AYC-409)', () => {
+    const options = reflector.get<RateLimitOptions>(
+      RATE_LIMIT_KEY,
+      InvitesController.prototype.create,
+    );
+
+    expect(options).toBeDefined();
+    // Regression guard: onboarding a whole org must not fail after ~10 invites.
+    expect(options.limit).toBeGreaterThanOrEqual(100);
+    expect(options.windowMs).toBe(15 * 60 * 1000);
+  });
+});

--- a/ayunis-core-backend/src/iam/invites/presenters/http/invites.controller.ts
+++ b/ayunis-core-backend/src/iam/invites/presenters/http/invites.controller.ts
@@ -90,7 +90,11 @@ export class InvitesController {
   ) {}
 
   @Post()
-  @RateLimit({ limit: 10, windowMs: 15 * 60 * 1000 }) // 10 invites per 15 minutes
+  // Admins onboarding a whole organization can legitimately create many
+  // invitations back-to-back. The previous limit of 10 per 15 minutes blocked
+  // that flow (AYC-409). Keep an upper bound to deter abuse while allowing
+  // realistic bulk onboarding.
+  @RateLimit({ limit: 100, windowMs: 15 * 60 * 1000 }) // 100 invites per 15 minutes
   @ApiOperation({
     summary: 'Create a new invite',
     description:

--- a/ayunis-core-frontend/src/pages/admin-settings/users-settings/api/useInviteCreate.ts
+++ b/ayunis-core-frontend/src/pages/admin-settings/users-settings/api/useInviteCreate.ts
@@ -35,6 +35,9 @@ export function useInviteCreate(
             case 'USER_EMAIL_PROVIDER_BLACKLISTED':
               showError(t('inviteCreate.emailProviderBlacklisted'));
               break;
+            case 'RATE_LIMIT_EXCEEDED':
+              showError(t('inviteCreate.rateLimitExceeded'));
+              break;
             default:
               showError(t('inviteCreate.error'));
           }

--- a/ayunis-core-frontend/src/shared/locales/de/admin-settings-users.json
+++ b/ayunis-core-frontend/src/shared/locales/de/admin-settings-users.json
@@ -90,7 +90,8 @@
     "error": "Fehler beim Erstellen der Einladung. Bitte versuchen Sie es erneut.",
     "emailNotAvailable": "Einladung nicht möglich.",
     "userAlreadyExists": "Diese E-Mail-Adresse ist bereits als Benutzer in Ihrer Organisation registriert.",
-    "emailProviderBlacklisted": "Private E-Mail-Adressen (z. B. Gmail, GMX, Web.de, t-online) sind aus Sicherheitsgründen nicht erlaubt. Bitte verwenden Sie eine geschäftliche E-Mail-Adresse."
+    "emailProviderBlacklisted": "Private E-Mail-Adressen (z. B. Gmail, GMX, Web.de, t-online) sind aus Sicherheitsgründen nicht erlaubt. Bitte verwenden Sie eine geschäftliche E-Mail-Adresse.",
+    "rateLimitExceeded": "Sie haben in kurzer Zeit viele Einladungen erstellt. Bitte warten Sie einige Minuten, bevor Sie weitere erstellen."
   },
   "inviteResend": {
     "success": "Einladung erfolgreich erneut gesendet!",

--- a/ayunis-core-frontend/src/shared/locales/en/admin-settings-users.json
+++ b/ayunis-core-frontend/src/shared/locales/en/admin-settings-users.json
@@ -89,7 +89,8 @@
     "error": "Failed to create invite. Please try again.",
     "emailNotAvailable": "Invite not possible.",
     "userAlreadyExists": "This email address is already registered as a user in your organization.",
-    "emailProviderBlacklisted": "Private email addresses (e.g. Gmail, GMX, Web.de, t-online) are not allowed for security reasons. Please use a work email address."
+    "emailProviderBlacklisted": "Private email addresses (e.g. Gmail, GMX, Web.de, t-online) are not allowed for security reasons. Please use a work email address.",
+    "rateLimitExceeded": "You've created a lot of invitations in a short time. Please wait a few minutes before creating more."
   },
   "inviteResend": {
     "success": "Invite resent successfully!",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Customer **Stadt Nidda** reported that while setting up user accounts, invitation creation failed after ~9 invites with the generic error *"Fehler beim Erstellen der Einladung. Bitte versuchen Sie es erneut."* (AYC-409). A page refresh appeared to help, but the failure kept recurring during bulk onboarding.

## Root cause

The `POST /invites` endpoint was rate limited to **10 requests per 15 minutes** per IP (`@RateLimit({ limit: 10, windowMs: 15 * 60 * 1000 })`). The rate-limit guard allows `limit` requests and rejects the next one, so the 11th single invite in a 15-minute window threw `RateLimitExceededError` (HTTP 429). An admin onboarding a whole organization one invite at a time hits this almost immediately.

The frontend only mapped specific invite error codes (`USER_ALREADY_EXISTS`, `EMAIL_NOT_AVAILABLE`, `USER_EMAIL_PROVIDER_BLACKLISTED`); `RATE_LIMIT_EXCEEDED` fell through to the generic *"please try again"* toast — which is exactly the confusing message the customer saw, giving no hint that they were being throttled.

## Changes

- **Backend** — Raise the single-invite creation limit from `10` to `100` per 15 minutes. This comfortably covers realistic org onboarding while still capping runaway abuse. (Bulk and resend endpoints are unchanged.)
- **Frontend** — Map `RATE_LIMIT_EXCEEDED` to a clear, actionable message (EN + DE) telling the user to wait a few minutes, instead of the generic error.
- **Tests**
  - New `rate-limit.guard.spec.ts` covering the previously-untested guard: skips outside production, allows exactly `limit` requests then blocks, and resets after the window elapses.
  - New `invites.controller.rate-limit.spec.ts` regression test pinning the invite-create limit to `>= 100` so this doesn't silently regress.

## Verification

- `jest` on the affected suites: **16 passed**.
- ESLint clean on changed files.
- Full pre-commit suite (backend + frontend lint, prettier, typecheck, complexity, dependency, duplication) passed.

## Notes

The "refresh fixed it" observation in the report is likely imprecise timing (the 15-minute window naturally elapsing) — a client refresh does not reset the server-side, IP-keyed in-memory counter. The `10`-per-window threshold is the only hard limit in the invite flow near the reported count, and the German error text in the screenshot matches the generic fall-through toast exactly, both confirming the diagnosis.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [AYC-409](https://linear.app/ayunis/issue/AYC-409/invitation-creation-fails-after-nine-generated-invites)

<div><a href="https://cursor.com/agents/bc-37d02cc0-184e-4ded-ba6e-221b9556ed35"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-37d02cc0-184e-4ded-ba6e-221b9556ed35"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

