### PR TITLE
feat(onboarding): allow dismissing getting-started from sidebar with confirmation (AYC-000)

### DIFF
--- a/ayunis-core-frontend/src/pages/onboarding/ui/OnboardingContent.tsx
+++ b/ayunis-core-frontend/src/pages/onboarding/ui/OnboardingContent.tsx
@@ -8,6 +8,7 @@ import { Skeleton } from '@/shared/ui/shadcn/skeleton';
 import { useMe } from '@/widgets/app-sidebar/api/useMe';
 import { MeResponseDtoRole } from '@/shared/api/generated/ayunisCoreAPI.schemas';
 import { Alert, AlertDescription } from '@/shared/ui/shadcn/alert';
+import { useConfirmation } from '@/widgets/confirmation-modal';
 import { useOnboarding, useOnboardingProgress } from '@/widgets/onboarding';
 import { useUpdateOnboarding } from '../api/useUpdateOnboarding';
 import brandIconDark from '@/shared/assets/brand/brand-icon-round-dark.svg';
@@ -26,7 +27,9 @@ function getMilestoneMessage(
 
 export default function OnboardingContent() {
   const { t } = useTranslation('getting-started');
+  const { t: tCommon } = useTranslation('common');
   const navigate = useNavigate();
+  const { confirm } = useConfirmation();
   const { user } = useMe();
   const isAdmin = user?.role === MeResponseDtoRole.admin;
   const {
@@ -61,12 +64,21 @@ export default function OnboardingContent() {
   );
 
   const handleToggleHidden = () => {
-    const nextHidden = !hidden;
-    updateOnboarding({ completedStepIds, hidden: nextHidden });
-
-    if (nextHidden) {
-      void navigate({ to: '/chat' });
+    if (hidden) {
+      updateOnboarding({ completedStepIds, hidden: false });
+      return;
     }
+
+    confirm({
+      title: tCommon('sidebar.hideGettingStartedConfirm.title'),
+      description: tCommon('sidebar.hideGettingStartedConfirm.description'),
+      confirmText: tCommon('sidebar.hideGettingStartedConfirm.confirmText'),
+      cancelText: tCommon('sidebar.hideGettingStartedConfirm.cancelText'),
+      onConfirm: () => {
+        updateOnboarding({ completedStepIds, hidden: true });
+        void navigate({ to: '/chat' });
+      },
+    });
   };
 
   const isAllComplete = overallProgress >= 100;

--- a/ayunis-core-frontend/src/shared/locales/de/common.json
+++ b/ayunis-core-frontend/src/shared/locales/de/common.json
@@ -9,6 +9,13 @@
     "marketplace": "Marketplace",
     "academy": "Academy",
     "gettingStarted": "Erste Schritte",
+    "hideGettingStarted": "Erste Schritte ausblenden",
+    "hideGettingStartedConfirm": {
+      "title": "Erste Schritte ausblenden?",
+      "description": "Sie können diese Seite jederzeit unter Konto-Einstellungen → Erste Schritte aufrufen.",
+      "confirmText": "Ausblenden",
+      "cancelText": "Abbrechen"
+    },
     "accountSettings": "Konto-Einstellungen",
     "adminSettings": "Admin-Einstellungen",
     "superAdminSettings": "Super Admin-Einstellungen",

--- a/ayunis-core-frontend/src/shared/locales/de/getting-started.json
+++ b/ayunis-core-frontend/src/shared/locales/de/getting-started.json
@@ -4,7 +4,7 @@
     "description": "Entdecken Sie, was Ayunis Core für Sie tun kann.",
     "checkboxHint": "Haken Sie erledigte Schritte selbst ab, um Ihren Fortschritt zu verfolgen.",
     "hide": "Erste Schritte ausblenden",
-    "hideHint": "Sie finden diese Seite jederzeit unter Einstellungen → Erste Schritte.",
+    "hideHint": "Sie finden diese Seite jederzeit unter Konto-Einstellungen → Erste Schritte.",
     "show": "In der Sidebar wieder einblenden"
   },
   "progress": {

--- a/ayunis-core-frontend/src/shared/locales/en/common.json
+++ b/ayunis-core-frontend/src/shared/locales/en/common.json
@@ -9,6 +9,13 @@
     "marketplace": "Marketplace",
     "academy": "Academy",
     "gettingStarted": "Getting Started",
+    "hideGettingStarted": "Hide getting started",
+    "hideGettingStartedConfirm": {
+      "title": "Hide getting started?",
+      "description": "You can always access this page under Account Settings → Getting Started.",
+      "confirmText": "Hide",
+      "cancelText": "Cancel"
+    },
     "accountSettings": "Account Settings",
     "adminSettings": "Admin Settings",
     "superAdminSettings": "Super Admin Settings",

--- a/ayunis-core-frontend/src/shared/locales/en/getting-started.json
+++ b/ayunis-core-frontend/src/shared/locales/en/getting-started.json
@@ -4,7 +4,7 @@
     "description": "Discover what Ayunis Core can do for you.",
     "checkboxHint": "Check off completed steps to track your progress.",
     "hide": "Hide getting started",
-    "hideHint": "You can find this page anytime under Settings → Getting Started.",
+    "hideHint": "You can find this page anytime under Account Settings → Getting Started.",
     "show": "Show again in sidebar"
   },
   "progress": {

--- a/ayunis-core-frontend/src/widgets/app-sidebar/api/useHideOnboarding.ts
+++ b/ayunis-core-frontend/src/widgets/app-sidebar/api/useHideOnboarding.ts
@@ -1,0 +1,35 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useTranslation } from 'react-i18next';
+import {
+  onboardingControllerUpdateOnboarding,
+  getOnboardingControllerGetOnboardingQueryKey,
+} from '@/shared/api/generated/ayunisCoreAPI';
+import { showError } from '@/shared/lib/toast';
+
+export function useHideOnboarding() {
+  const { t } = useTranslation('getting-started');
+  const queryClient = useQueryClient();
+
+  const mutation = useMutation({
+    mutationFn: async (completedStepIds: string[]) => {
+      return await onboardingControllerUpdateOnboarding({
+        completedStepIds,
+        hidden: true,
+      });
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
+        queryKey: getOnboardingControllerGetOnboardingQueryKey(),
+      });
+    },
+    onError: () => {
+      showError(t('saveError'));
+    },
+  });
+
+  return {
+    hideOnboarding: (completedStepIds: string[]) =>
+      mutation.mutate(completedStepIds),
+    isLoading: mutation.isPending,
+  };
+}

--- a/ayunis-core-frontend/src/widgets/app-sidebar/ui/OnboardingCard.tsx
+++ b/ayunis-core-frontend/src/widgets/app-sidebar/ui/OnboardingCard.tsx
@@ -1,8 +1,10 @@
-import { ChevronRight } from 'lucide-react';
+import { ChevronRight, X } from 'lucide-react';
 import { Link } from '@tanstack/react-router';
 import { useTranslation } from 'react-i18next';
 import { Progress } from '@/shared/ui/shadcn/progress';
+import { useConfirmation } from '@/widgets/confirmation-modal';
 import { useMe } from '../api/useMe';
+import { useHideOnboarding } from '../api/useHideOnboarding';
 import { MeResponseDtoRole } from '@/shared/api/generated/ayunisCoreAPI.schemas';
 import { useOnboarding, useOnboardingProgress } from '@/widgets/onboarding';
 
@@ -12,16 +14,40 @@ export function OnboardingCard() {
   const isAdmin = user?.role === MeResponseDtoRole.admin;
   const { completedStepIds, hidden, isLoading } = useOnboarding();
   const { progressPercent } = useOnboardingProgress(isAdmin, completedStepIds);
+  const { hideOnboarding } = useHideOnboarding();
+  const { confirm } = useConfirmation();
 
   if (isLoading || hidden || progressPercent >= 100) {
     return null;
   }
 
+  const handleHideClick = (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    confirm({
+      title: t('sidebar.hideGettingStartedConfirm.title'),
+      description: t('sidebar.hideGettingStartedConfirm.description'),
+      confirmText: t('sidebar.hideGettingStartedConfirm.confirmText'),
+      cancelText: t('sidebar.hideGettingStartedConfirm.cancelText'),
+      onConfirm: () => {
+        hideOnboarding(completedStepIds);
+      },
+    });
+  };
+
   return (
     <Link
       to="/getting-started"
-      className="flex items-center gap-3 rounded-lg border bg-card p-3 hover:bg-accent/50 transition-colors"
+      className="group relative flex items-center gap-3 rounded-lg border bg-card p-3 hover:bg-accent/50 transition-colors"
     >
+      <button
+        type="button"
+        aria-label={t('sidebar.hideGettingStarted')}
+        onClick={handleHideClick}
+        className="absolute top-0 right-0 translate-x-1/2 -translate-y-1/2 flex size-5 items-center justify-center rounded-full border bg-background shadow-sm text-muted-foreground hover:text-foreground opacity-0 group-hover:opacity-100 focus-visible:opacity-100 transition-opacity"
+      >
+        <X className="size-3" />
+      </button>
       <div className="flex-1 min-w-0">
         <div className="flex items-center justify-between">
           <span className="text-sm font-semibold">


### PR DESCRIPTION
- Add hover-revealed X badge on the sidebar onboarding card that opens
  a confirmation modal before hiding
- Route the getting-started page hide button through the same modal
- Point hint wording to Konto-Einstellungen -> Erste Schritte

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only onboarding preference changes reusing existing confirmation and update APIs; no auth or data-model changes.
> 
> **Overview**
> Users can **hide Getting Started from the sidebar** without opening the full page: the sidebar card gets a hover/focus **X** control that opens the shared **confirmation modal** before persisting `hidden: true` via a new `useHideOnboarding` mutation.
> 
> The **Getting Started page** hide action now uses the **same confirmation flow** (show again still toggles immediately). Copy adds shared `sidebar.hideGettingStartedConfirm` strings (EN/DE) and updates the hide hint to **Account Settings → Getting Started**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b273ab1c7d551708847eba24d5e54170178d39a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->