### PR TITLE
feat(onboarding): explain locked steps with a prerequisite tooltip (AYC-000)

### DIFF
--- a/ayunis-core-frontend/src/pages/onboarding/ui/OnboardingCategoryCard.tsx
+++ b/ayunis-core-frontend/src/pages/onboarding/ui/OnboardingCategoryCard.tsx
@@ -81,22 +81,36 @@ export default function OnboardingCategoryCard({
               </div>
             )}
             <div className="divide-y divide-border/50">
-              {category.steps.map((step, index) => (
-                <OnboardingStepItem
-                  key={step.id}
-                  step={step}
-                  completed={completedSteps.has(step.id)}
-                  locked={
-                    !completedSteps.has(step.id) &&
-                    !!step.dependsOn &&
-                    !completedSteps.has(step.dependsOn)
-                  }
-                  defaultExpanded={
-                    defaultExpanded && index === firstIncompleteStepIndex
-                  }
-                  onComplete={onCompleteStep}
-                />
-              ))}
+              {category.steps.map((step, index) => {
+                const prerequisite = step.dependsOn
+                  ? category.steps.find((s) => s.id === step.dependsOn)
+                  : undefined;
+                return (
+                  <OnboardingStepItem
+                    key={step.id}
+                    step={step}
+                    completed={completedSteps.has(step.id)}
+                    locked={
+                      !completedSteps.has(step.id) &&
+                      !!step.dependsOn &&
+                      !completedSteps.has(step.dependsOn)
+                    }
+                    lockedTooltip={
+                      prerequisite
+                        ? t('lockedTooltip', {
+                            step: t(
+                              `steps.${prerequisite.translationKey}.title`,
+                            ),
+                          })
+                        : undefined
+                    }
+                    defaultExpanded={
+                      defaultExpanded && index === firstIncompleteStepIndex
+                    }
+                    onComplete={onCompleteStep}
+                  />
+                );
+              })}
             </div>
           </AccordionContent>
         </AccordionItem>

--- a/ayunis-core-frontend/src/pages/onboarding/ui/OnboardingStepItem.tsx
+++ b/ayunis-core-frontend/src/pages/onboarding/ui/OnboardingStepItem.tsx
@@ -9,6 +9,7 @@ import {
 } from '@/shared/ui/shadcn/accordion';
 import { Button } from '@/shared/ui/shadcn/button';
 import { Checkbox } from '@/shared/ui/shadcn/checkbox';
+import TooltipIf from '@/widgets/tooltip-if/ui/TooltipIf';
 import { cn } from '@/shared/lib/shadcn/utils';
 import { getHelpCenterUrl } from '@/shared/lib/help-center';
 import {
@@ -28,6 +29,7 @@ interface OnboardingStepItemProps {
   step: OnboardingStep;
   completed: boolean;
   locked: boolean;
+  lockedTooltip?: string;
   defaultExpanded?: boolean;
   onComplete: (stepId: string) => void;
 }
@@ -36,6 +38,7 @@ export default function OnboardingStepItem({
   step,
   completed,
   locked,
+  lockedTooltip,
   defaultExpanded = false,
   onComplete,
 }: Readonly<OnboardingStepItemProps>) {
@@ -170,72 +173,77 @@ export default function OnboardingStepItem({
   };
 
   return (
-    <Accordion
-      type="single"
-      collapsible
-      defaultValue={defaultExpanded && !locked ? step.id : undefined}
+    <TooltipIf
+      condition={locked && !!lockedTooltip}
+      tooltip={lockedTooltip ?? ''}
     >
-      <AccordionItem
-        value={step.id}
-        disabled={locked}
-        className={cn('border-b-0', (completed || locked) && 'opacity-60')}
+      <Accordion
+        type="single"
+        collapsible
+        defaultValue={defaultExpanded && !locked ? step.id : undefined}
       >
-        <div className="flex items-center gap-3 py-2.5 [&>h3]:flex-1 [&>h3]:min-w-0">
-          {locked ? (
-            <div className="flex items-center justify-center size-5 shrink-0">
-              <Lock className="size-3.5 text-muted-foreground" />
-            </div>
-          ) : (
-            <Checkbox
-              checked={completed}
-              onCheckedChange={() => onComplete(step.id)}
-              aria-label={completed ? 'Completed' : 'Mark as complete'}
-            />
-          )}
-
-          <AccordionTrigger
-            className={cn(
-              'py-0 items-center hover:no-underline [&>svg]:size-3.5',
-              locked && 'disabled:opacity-100 [&>svg]:hidden',
+        <AccordionItem
+          value={step.id}
+          disabled={locked}
+          className={cn('border-b-0', (completed || locked) && 'opacity-60')}
+        >
+          <div className="flex items-center gap-3 py-2.5 [&>h3]:flex-1 [&>h3]:min-w-0">
+            {locked ? (
+              <div className="flex items-center justify-center size-5 shrink-0">
+                <Lock className="size-3.5 text-muted-foreground" />
+              </div>
+            ) : (
+              <Checkbox
+                checked={completed}
+                onCheckedChange={() => onComplete(step.id)}
+                aria-label={completed ? 'Completed' : 'Mark as complete'}
+              />
             )}
-          >
-            <span
+
+            <AccordionTrigger
               className={cn(
-                'text-sm font-medium',
-                completed && 'line-through text-muted-foreground',
-                locked && 'text-muted-foreground',
+                'py-0 items-center hover:no-underline [&>svg]:size-3.5',
+                locked && 'disabled:opacity-100 [&>svg]:hidden',
               )}
             >
-              {t(`steps.${step.translationKey}.title`)}
-            </span>
-          </AccordionTrigger>
-        </div>
+              <span
+                className={cn(
+                  'text-sm font-medium',
+                  completed && 'line-through text-muted-foreground',
+                  locked && 'text-muted-foreground',
+                )}
+              >
+                {t(`steps.${step.translationKey}.title`)}
+              </span>
+            </AccordionTrigger>
+          </div>
 
-        <AccordionContent className="ml-7 space-y-2 pb-2.5 pt-0">
-          <p className="text-sm text-muted-foreground leading-relaxed">
-            {t(`steps.${step.translationKey}.description`)}
-          </p>
-          {(step.action ?? step.secondaryAction) && (
-            <div className="flex items-center gap-2">
-              {step.action && (
-                <Button size="sm" onClick={handleAction} disabled={completed}>
-                  {t(`steps.${step.translationKey}.action`)}
-                  <ArrowRight className="size-3" />
-                </Button>
-              )}
-              {step.secondaryAction && (
-                <Button
-                  size="sm"
-                  variant="ghost"
-                  onClick={handleSecondaryAction}
-                >
-                  {t(`steps.${step.translationKey}.secondaryAction`)}
-                </Button>
-              )}
-            </div>
-          )}
-        </AccordionContent>
-      </AccordionItem>
-    </Accordion>
+          <AccordionContent className="ml-7 space-y-2 pb-2.5 pt-0">
+            <p className="text-sm text-muted-foreground leading-relaxed">
+              {t(`steps.${step.translationKey}.description`)}
+            </p>
+            {(step.action ?? step.secondaryAction) && (
+              <div className="flex items-center gap-2">
+                {step.action && (
+                  <Button size="sm" onClick={handleAction} disabled={completed}>
+                    {t(`steps.${step.translationKey}.action`)}
+                    <ArrowRight className="size-3" />
+                  </Button>
+                )}
+                {step.secondaryAction && (
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    onClick={handleSecondaryAction}
+                  >
+                    {t(`steps.${step.translationKey}.secondaryAction`)}
+                  </Button>
+                )}
+              </div>
+            )}
+          </AccordionContent>
+        </AccordionItem>
+      </Accordion>
+    </TooltipIf>
   );
 }

--- a/ayunis-core-frontend/src/shared/locales/de/getting-started.json
+++ b/ayunis-core-frontend/src/shared/locales/de/getting-started.json
@@ -10,6 +10,7 @@
   "progress": {
     "completed": "{{count}} von {{total}} erledigt"
   },
+  "lockedTooltip": "Schließen Sie zuerst „{{step}}“ ab, um diesen Schritt freizuschalten.",
   "saveError": "Dein Fortschritt konnte nicht gespeichert werden. Bitte versuche es erneut.",
   "spotlightDismiss": "Alles klar",
   "returnButton": "Zurück zu Erste Schritte",

--- a/ayunis-core-frontend/src/shared/locales/en/getting-started.json
+++ b/ayunis-core-frontend/src/shared/locales/en/getting-started.json
@@ -10,6 +10,7 @@
   "progress": {
     "completed": "{{count}} of {{total}} completed"
   },
+  "lockedTooltip": "Complete “{{step}}” first to unlock this step.",
   "saveError": "Could not save your progress. Please try again.",
   "spotlightDismiss": "Got it",
   "returnButton": "Back to Getting Started",


### PR DESCRIPTION
- Wrap locked step rows in TooltipIf naming the step that must be
  completed first

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Onboarding UI and copy only; no changes to step completion logic or APIs.
> 
> **Overview**
> Locked onboarding steps now show a **hover tooltip** that names the prerequisite step users must complete first, instead of only displaying a lock icon.
> 
> `OnboardingCategoryCard` resolves `step.dependsOn` within the category and builds the message from a new `lockedTooltip` i18n key (EN/DE), interpolating the prerequisite step title. `OnboardingStepItem` accepts optional `lockedTooltip` and wraps the step row in `TooltipIf` when the step is locked and copy is available.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf523da5d126a38c885c3587fb87f0d5fb8a8eab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->