### PR TITLE
wip(inference): normalize mcp tool schemas for anthropic (AYC-412)

### DIFF
--- a/packages/inference/src/index.ts
+++ b/packages/inference/src/index.ts
@@ -11,6 +11,18 @@ export type {
   ToolUseContent,
 } from './message';
 export type { JsonSchema, ToolSchema } from './tool-schema';
+export {
+  CombinatorFlattener,
+  SchemaWalker,
+  convertDraft04ExclusiveBoundsNode,
+  isRecord,
+} from './tool-normalizer';
+export type {
+  JsonObject,
+  JsonValue,
+  MutableSchema,
+  VisitNode,
+} from './tool-normalizer';
 export type {
   FinishReason,
   ModelProvider,

--- a/packages/inference/src/tool-normalizer/combinator-flattener.spec.ts
+++ b/packages/inference/src/tool-normalizer/combinator-flattener.spec.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+
+import type { MutableSchema } from './walk-schema';
+import { CombinatorFlattener } from './combinator-flattener';
+
+function flatten(schema: MutableSchema): MutableSchema {
+  new CombinatorFlattener(schema).flatten();
+  return schema;
+}
+
+describe('CombinatorFlattener', () => {
+  it('merges oneOf branch properties into the root and drops their required', () => {
+    expect(
+      flatten({
+        type: 'object',
+        oneOf: [
+          { properties: { a: { type: 'string' } }, required: ['a'] },
+          { properties: { b: { type: 'number' } }, required: ['b'] },
+        ],
+      }),
+    ).toEqual({
+      type: 'object',
+      properties: { a: { type: 'string' }, b: { type: 'number' } },
+    });
+  });
+
+  it('keeps required from allOf branches', () => {
+    expect(
+      flatten({
+        type: 'object',
+        allOf: [
+          { properties: { a: { type: 'string' } }, required: ['a'] },
+          { properties: { b: { type: 'number' } }, required: ['b'] },
+        ],
+      }),
+    ).toEqual({
+      type: 'object',
+      properties: { a: { type: 'string' }, b: { type: 'number' } },
+      required: ['a', 'b'],
+    });
+  });
+
+  it('collects properties from combinators nested inside a branch', () => {
+    expect(
+      flatten({
+        type: 'object',
+        oneOf: [{ allOf: [{ properties: { a: { type: 'string' } } }] }],
+      }),
+    ).toEqual({
+      type: 'object',
+      properties: { a: { type: 'string' } },
+    });
+  });
+
+  it('hoists branch $defs under their original key', () => {
+    expect(
+      flatten({
+        type: 'object',
+        allOf: [
+          {
+            $defs: { Addr: { type: 'object' } },
+            properties: { home: { $ref: '#/$defs/Addr' } },
+            required: ['home'],
+          },
+        ],
+      }),
+    ).toEqual({
+      type: 'object',
+      properties: { home: { $ref: '#/$defs/Addr' } },
+      required: ['home'],
+      $defs: { Addr: { type: 'object' } },
+    });
+  });
+
+  it('leaves schemas without top-level combinators untouched', () => {
+    expect(flatten({ type: 'object' })).toEqual({ type: 'object' });
+  });
+});

--- a/packages/inference/src/tool-normalizer/combinator-flattener.ts
+++ b/packages/inference/src/tool-normalizer/combinator-flattener.ts
@@ -1,0 +1,94 @@
+import type { JsonObject, JsonValue } from './json-value';
+import type { MutableSchema } from './walk-schema';
+import { DEFS_KEYS, isRecord } from './walk-schema';
+
+const COMBINATOR_KEYS = ['oneOf', 'anyOf', 'allOf'] as const;
+
+type DefsKey = (typeof DEFS_KEYS)[number];
+
+// Merges top-level `oneOf`/`anyOf`/`allOf` branches into the root, for
+// providers that reject combinators there (Anthropic, OpenAI strict mode).
+// Only `allOf` keeps `required` (its branches all apply); `oneOf`/`anyOf`
+// requirements are alternatives and are dropped.
+export class CombinatorFlattener {
+  private readonly properties: JsonObject;
+  private readonly required: Set<string>;
+  private readonly defs: Record<DefsKey, JsonObject> = {
+    $defs: {},
+    definitions: {},
+  };
+
+  constructor(private readonly root: MutableSchema) {
+    this.properties = isRecord(root.properties) ? { ...root.properties } : {};
+    this.required = new Set(asStringArray(root.required));
+  }
+
+  flatten(): void {
+    let flattened = false;
+    for (const combinator of COMBINATOR_KEYS) {
+      const branches = this.root[combinator];
+      if (!Array.isArray(branches)) continue;
+      delete this.root[combinator];
+      flattened = true;
+      for (const branch of branches.filter(isRecord)) {
+        this.collect(branch, combinator === 'allOf');
+      }
+    }
+    if (flattened) this.writeBack();
+  }
+
+  // Descends through combinators nested inside a branch so params and their
+  // definitions are never silently dropped; `required` only propagates
+  // through further `allOf` nesting.
+  private collect(branch: JsonObject, mergeRequired: boolean): void {
+    mergeFirstWins(this.properties, branch.properties);
+    for (const key of DEFS_KEYS) {
+      mergeFirstWins(this.defs[key], branch[key]);
+    }
+    if (mergeRequired) {
+      asStringArray(branch.required).forEach((name) => this.required.add(name));
+    }
+    for (const combinator of COMBINATOR_KEYS) {
+      const nested = branch[combinator];
+      if (!Array.isArray(nested)) continue;
+      for (const child of nested.filter(isRecord)) {
+        this.collect(child, mergeRequired && combinator === 'allOf');
+      }
+    }
+  }
+
+  private writeBack(): void {
+    this.root.properties = this.properties;
+    if (this.required.size > 0) {
+      this.root.required = [...this.required];
+    }
+    // Keep each defs collection under its original key so `$ref` paths
+    // (`#/$defs/…` vs `#/definitions/…`) still resolve.
+    for (const key of DEFS_KEYS) {
+      if (Object.keys(this.defs[key]).length > 0) {
+        this.root[key] = { ...asObject(this.root[key]), ...this.defs[key] };
+      }
+    }
+  }
+}
+
+// Copies `source`'s entries into `target`, keeping any existing key.
+function mergeFirstWins(
+  target: JsonObject,
+  source: JsonValue | undefined,
+): void {
+  if (!isRecord(source)) return;
+  for (const [name, value] of Object.entries(source)) {
+    target[name] ??= value;
+  }
+}
+
+function asObject(value: JsonValue | undefined): JsonObject {
+  return isRecord(value) ? value : {};
+}
+
+function asStringArray(value: JsonValue | undefined): string[] {
+  return Array.isArray(value)
+    ? value.filter((v): v is string => typeof v === 'string')
+    : [];
+}

--- a/packages/inference/src/tool-normalizer/draft04-compat.spec.ts
+++ b/packages/inference/src/tool-normalizer/draft04-compat.spec.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+
+import { convertDraft04ExclusiveBoundsNode } from './draft04-compat';
+
+describe('convertDraft04ExclusiveBoundsNode', () => {
+  it('leaves modern numeric bounds untouched', () => {
+    const node = { type: 'number', exclusiveMinimum: 0, maximum: 10 };
+    convertDraft04ExclusiveBoundsNode(node);
+    expect(node).toEqual({ type: 'number', exclusiveMinimum: 0, maximum: 10 });
+  });
+
+  it('converts a boolean exclusiveMinimum to its numeric form', () => {
+    const node = { type: 'number', minimum: 0, exclusiveMinimum: true };
+    convertDraft04ExclusiveBoundsNode(node);
+    expect(node).toEqual({ type: 'number', exclusiveMinimum: 0 });
+  });
+
+  it('converts a boolean exclusiveMaximum to its numeric form', () => {
+    const node = { type: 'number', maximum: 10, exclusiveMaximum: true };
+    convertDraft04ExclusiveBoundsNode(node);
+    expect(node).toEqual({ type: 'number', exclusiveMaximum: 10 });
+  });
+
+  it('drops boolean exclusive bounds without a numeric counterpart', () => {
+    const node = {
+      type: 'number',
+      exclusiveMinimum: false,
+      exclusiveMaximum: true,
+    };
+    convertDraft04ExclusiveBoundsNode(node);
+    expect(node).toEqual({ type: 'number' });
+  });
+});

--- a/packages/inference/src/tool-normalizer/draft04-compat.ts
+++ b/packages/inference/src/tool-normalizer/draft04-compat.ts
@@ -1,0 +1,33 @@
+import type { JsonObject } from './json-value';
+
+// Exclusive-bound keyword → the inclusive bound it qualifies in draft-04.
+const BOUND_FOR = {
+  exclusiveMinimum: 'minimum',
+  exclusiveMaximum: 'maximum',
+} as const;
+
+/**
+ * Draft-04 JSON Schema expressed exclusive bounds as booleans qualifying
+ * `minimum` / `maximum`; draft 2020-12 expects the numeric bound itself.
+ * MCP servers still emit the draft-04 form, which LLM provider APIs reject.
+ * Converts both bounds on a single schema node, in place.
+ */
+export function convertDraft04ExclusiveBoundsNode(node: JsonObject): void {
+  convertBound(node, 'exclusiveMinimum');
+  convertBound(node, 'exclusiveMaximum');
+}
+
+function convertBound(
+  schema: JsonObject,
+  exclusiveKey: keyof typeof BOUND_FOR,
+): void {
+  const boundKey = BOUND_FOR[exclusiveKey];
+  const exclusive = schema[exclusiveKey];
+  if (typeof exclusive !== 'boolean') return;
+  if (exclusive && typeof schema[boundKey] === 'number') {
+    schema[exclusiveKey] = schema[boundKey];
+    delete schema[boundKey];
+  } else {
+    delete schema[exclusiveKey];
+  }
+}

--- a/packages/inference/src/tool-normalizer/index.ts
+++ b/packages/inference/src/tool-normalizer/index.ts
@@ -1,0 +1,5 @@
+export { convertDraft04ExclusiveBoundsNode } from './draft04-compat';
+export { SchemaWalker, isRecord } from './walk-schema';
+export { CombinatorFlattener } from './combinator-flattener';
+export type { MutableSchema, VisitNode } from './walk-schema';
+export type { JsonObject, JsonValue } from './json-value';

--- a/packages/inference/src/tool-normalizer/json-value.ts
+++ b/packages/inference/src/tool-normalizer/json-value.ts
@@ -1,0 +1,6 @@
+export type JsonValue =
+  string | number | boolean | null | JsonValue[] | JsonObject;
+
+export interface JsonObject {
+  [key: string]: JsonValue;
+}

--- a/packages/inference/src/tool-normalizer/walk-schema.spec.ts
+++ b/packages/inference/src/tool-normalizer/walk-schema.spec.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest';
+
+import type { MutableSchema } from './walk-schema';
+import { SchemaWalker } from './walk-schema';
+
+const identityWalker = new SchemaWalker((node: MutableSchema) => node);
+const markingWalker = new SchemaWalker((node: MutableSchema) => {
+  node.visited = true;
+  return node;
+});
+
+describe('SchemaWalker', () => {
+  it('returns an equal schema for an identity rule', () => {
+    const schema = {
+      type: 'object',
+      properties: { q: { type: 'string' } },
+      required: ['q'],
+    };
+    expect(identityWalker.walk(schema)).toEqual(schema);
+  });
+
+  it('visits nested schemas in properties, $defs, items and combinators', () => {
+    expect(
+      markingWalker.walk({
+        properties: { a: { type: 'string' } },
+        $defs: { b: { type: 'number' } },
+        items: { type: 'integer' },
+        anyOf: [{ type: 'boolean' }],
+      }),
+    ).toEqual({
+      visited: true,
+      properties: { a: { type: 'string', visited: true } },
+      $defs: { b: { type: 'number', visited: true } },
+      items: { type: 'integer', visited: true },
+      anyOf: [{ type: 'boolean', visited: true }],
+    });
+  });
+
+  it('does not descend into data-value keys like default and enum', () => {
+    expect(
+      markingWalker.walk({
+        properties: {
+          a: { type: 'object', default: { nested: true }, enum: ['x'] },
+        },
+      }),
+    ).toEqual({
+      visited: true,
+      properties: {
+        a: {
+          type: 'object',
+          visited: true,
+          default: { nested: true },
+          enum: ['x'],
+        },
+      },
+    });
+  });
+
+  it('collapses tuple-form items into a single anyOf schema', () => {
+    expect(
+      identityWalker.walk({
+        type: 'array',
+        items: [{ type: 'number' }, { type: 'string' }],
+        additionalItems: false,
+      }),
+    ).toEqual({
+      type: 'array',
+      items: { anyOf: [{ type: 'number' }, { type: 'string' }] },
+    });
+  });
+
+  it('walks tuple entries recursively', () => {
+    expect(
+      markingWalker.walk({
+        type: 'array',
+        items: [{ type: 'array', items: [{ type: 'number' }] }],
+      }),
+    ).toEqual({
+      type: 'array',
+      visited: true,
+      items: {
+        anyOf: [
+          {
+            type: 'array',
+            visited: true,
+            items: { anyOf: [{ type: 'number', visited: true }] },
+          },
+        ],
+      },
+    });
+  });
+
+  it('does not mutate the input schema', () => {
+    const schema = {
+      type: 'array',
+      items: [{ type: 'number' }],
+      properties: { a: { type: 'string' } },
+    };
+    const copy = structuredClone(schema);
+    markingWalker.walk(schema);
+    expect(schema).toEqual(copy);
+  });
+});

--- a/packages/inference/src/tool-normalizer/walk-schema.ts
+++ b/packages/inference/src/tool-normalizer/walk-schema.ts
@@ -1,0 +1,72 @@
+import type { JsonObject, JsonValue } from './json-value';
+import type { JsonSchema } from '../tool-schema';
+
+export type MutableSchema = JsonObject;
+export type VisitNode = (node: MutableSchema) => MutableSchema; // Receives a fresh shallow copy of a schema node — mutate and return it.
+
+// Keys holding reusable sub-schema definitions `$ref` may point at. The walk
+// must descend into every key the flattener hoists, so both derive from this.
+export const DEFS_KEYS = ['$defs', 'definitions'] as const;
+const SCHEMA_MAP_KEYS = new Set(['properties', ...DEFS_KEYS]);
+const OPAQUE_VALUE_KEYS = new Set(['default', 'example', 'const', 'enum']);
+
+// Recursively applies a provider's per-node rule to a JSON schema without
+// mutating the input. Collapses draft-04/-07 tuple-form `items` on the way,
+// since no provider accepts an array there.
+export class SchemaWalker {
+  constructor(private readonly visitNode: VisitNode) {}
+
+  walk(schema: JsonSchema): JsonObject {
+    // Wire data is JSON, so its values are JsonValue by construction.
+    return this.walkNode(schema as MutableSchema);
+  }
+
+  private walkNode(input: Readonly<MutableSchema>): MutableSchema {
+    const node = this.visitNode({ ...input });
+    // `additionalItems` only qualifies tuple validation, which collapses below.
+    if (Array.isArray(node.items)) delete node.additionalItems;
+    for (const [key, value] of Object.entries(node)) {
+      node[key] = this.walkValue(key, value);
+    }
+    return node;
+  }
+
+  private walkValue(key: string, value: JsonValue): JsonValue {
+    if (OPAQUE_VALUE_KEYS.has(key)) {
+      return value;
+    }
+
+    let walked: JsonValue = value;
+    if (SCHEMA_MAP_KEYS.has(key) && isRecord(value)) {
+      walked = mapValues(value, (child) =>
+        isRecord(child) ? this.walkNode(child) : child,
+      );
+    } else if (key === 'items' && Array.isArray(value)) {
+      walked = { anyOf: this.walkEntries(value) };
+    } else if (Array.isArray(value)) {
+      walked = this.walkEntries(value);
+    } else if (isRecord(value)) {
+      walked = this.walkNode(value);
+    }
+    return walked;
+  }
+
+  private walkEntries(entries: JsonValue[]): JsonValue[] {
+    return entries.map((entry) =>
+      isRecord(entry) ? this.walkNode(entry) : entry,
+    );
+  }
+}
+
+function mapValues(
+  obj: JsonObject,
+  fn: (value: JsonValue) => JsonValue,
+): JsonObject {
+  return Object.fromEntries(
+    Object.entries(obj).map(([key, value]) => [key, fn(value)]),
+  );
+}
+
+export function isRecord(value: unknown): value is JsonObject {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/packages/provider-anthropic/src/convert-request.spec.ts
+++ b/packages/provider-anthropic/src/convert-request.spec.ts
@@ -21,6 +21,20 @@ describe('convertTool', () => {
       input_schema: { type: 'object', properties: {} },
     });
   });
+
+  it('normalizes MCP-style schemas that Anthropic would reject', () => {
+    expect(
+      convertTool({
+        name: 'search',
+        description: 'Searches',
+        parameters: { properties: { q: { type: 'string' } } },
+      }),
+    ).toEqual({
+      name: 'search',
+      description: 'Searches',
+      input_schema: { type: 'object', properties: { q: { type: 'string' } } },
+    });
+  });
 });
 
 describe('convertToolChoice', () => {

--- a/packages/provider-anthropic/src/convert-request.ts
+++ b/packages/provider-anthropic/src/convert-request.ts
@@ -7,6 +7,8 @@ import type {
   ToolSchema,
 } from '@ayunis/inference';
 
+import { normalizeSchemaForAnthropic } from './normalize-schema';
+
 type AnthropicToolChoice =
   | Anthropic.Messages.ToolChoiceAuto
   | Anthropic.Messages.ToolChoiceAny
@@ -15,7 +17,7 @@ type AnthropicToolChoice =
 export const convertTool = (tool: ToolSchema): Anthropic.Tool => ({
   name: tool.name,
   description: tool.description,
-  input_schema: tool.parameters as Anthropic.Messages.Tool.InputSchema,
+  input_schema: normalizeSchemaForAnthropic(tool.parameters),
 });
 
 export const convertToolChoice = (

--- a/packages/provider-anthropic/src/normalize-schema.spec.ts
+++ b/packages/provider-anthropic/src/normalize-schema.spec.ts
@@ -1,0 +1,217 @@
+import { describe, expect, it } from 'vitest';
+
+import { normalizeSchemaForAnthropic } from './normalize-schema';
+
+describe('normalizeSchemaForAnthropic', () => {
+  it('leaves a valid object schema untouched', () => {
+    const schema = {
+      type: 'object',
+      properties: { q: { type: 'string' } },
+      required: ['q'],
+    };
+    expect(normalizeSchemaForAnthropic(schema)).toEqual(schema);
+  });
+
+  it('adds top-level type object when missing but properties are present', () => {
+    expect(
+      normalizeSchemaForAnthropic({ properties: { q: { type: 'string' } } }),
+    ).toEqual({ type: 'object', properties: { q: { type: 'string' } } });
+  });
+
+  it('turns an empty schema into an empty object schema', () => {
+    expect(normalizeSchemaForAnthropic({})).toEqual({
+      type: 'object',
+      properties: {},
+    });
+  });
+
+  it('converts draft-04 boolean exclusiveMinimum to its 2020-12 numeric form', () => {
+    expect(
+      normalizeSchemaForAnthropic({
+        type: 'object',
+        properties: {
+          n: { type: 'number', minimum: 0, exclusiveMinimum: true },
+        },
+      }),
+    ).toEqual({
+      type: 'object',
+      properties: { n: { type: 'number', exclusiveMinimum: 0 } },
+    });
+  });
+
+  it('converts draft-04 boolean exclusiveMaximum to its 2020-12 numeric form', () => {
+    expect(
+      normalizeSchemaForAnthropic({
+        type: 'object',
+        properties: {
+          n: { type: 'number', maximum: 10, exclusiveMaximum: true },
+        },
+      }),
+    ).toEqual({
+      type: 'object',
+      properties: { n: { type: 'number', exclusiveMaximum: 10 } },
+    });
+  });
+
+  it('drops boolean exclusive bounds that have no numeric counterpart', () => {
+    expect(
+      normalizeSchemaForAnthropic({
+        type: 'object',
+        properties: {
+          n: {
+            type: 'number',
+            exclusiveMinimum: false,
+            exclusiveMaximum: true,
+          },
+        },
+      }),
+    ).toEqual({
+      type: 'object',
+      properties: { n: { type: 'number' } },
+    });
+  });
+
+  it('flattens a top-level oneOf into merged properties', () => {
+    expect(
+      normalizeSchemaForAnthropic({
+        type: 'object',
+        oneOf: [
+          { properties: { a: { type: 'string' } }, required: ['a'] },
+          { properties: { b: { type: 'number' } }, required: ['b'] },
+        ],
+      }),
+    ).toEqual({
+      type: 'object',
+      properties: { a: { type: 'string' }, b: { type: 'number' } },
+    });
+  });
+
+  it('flattens a top-level allOf and keeps its required fields', () => {
+    expect(
+      normalizeSchemaForAnthropic({
+        type: 'object',
+        allOf: [
+          { properties: { a: { type: 'string' } }, required: ['a'] },
+          { properties: { b: { type: 'number' } }, required: ['b'] },
+        ],
+      }),
+    ).toEqual({
+      type: 'object',
+      properties: { a: { type: 'string' }, b: { type: 'number' } },
+      required: ['a', 'b'],
+    });
+  });
+
+  it('keeps nested oneOf below the top level', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        filter: { oneOf: [{ type: 'string' }, { type: 'number' }] },
+      },
+    };
+    expect(normalizeSchemaForAnthropic(schema)).toEqual(schema);
+  });
+
+  it('normalizes draft-04 bounds inside array items and $defs', () => {
+    expect(
+      normalizeSchemaForAnthropic({
+        type: 'object',
+        properties: {
+          list: {
+            type: 'array',
+            items: { type: 'integer', minimum: 1, exclusiveMinimum: true },
+          },
+        },
+        $defs: {
+          amount: { type: 'number', maximum: 5, exclusiveMaximum: true },
+        },
+      }),
+    ).toEqual({
+      type: 'object',
+      properties: {
+        list: {
+          type: 'array',
+          items: { type: 'integer', exclusiveMinimum: 1 },
+        },
+      },
+      $defs: { amount: { type: 'number', exclusiveMaximum: 5 } },
+    });
+  });
+
+  it('collapses tuple-form items arrays into a single anyOf schema', () => {
+    expect(
+      normalizeSchemaForAnthropic({
+        type: 'object',
+        properties: {
+          point: {
+            type: 'array',
+            items: [{ type: 'number' }, { type: 'string' }],
+          },
+        },
+      }),
+    ).toEqual({
+      type: 'object',
+      properties: {
+        point: {
+          type: 'array',
+          items: { anyOf: [{ type: 'number' }, { type: 'string' }] },
+        },
+      },
+    });
+  });
+
+  it('collects properties from combinators nested inside a branch', () => {
+    expect(
+      normalizeSchemaForAnthropic({
+        type: 'object',
+        oneOf: [{ allOf: [{ properties: { a: { type: 'string' } } }] }],
+      }),
+    ).toEqual({
+      type: 'object',
+      properties: { a: { type: 'string' } },
+    });
+  });
+
+  it('hoists branch $defs to the root so $ref pointers still resolve', () => {
+    expect(
+      normalizeSchemaForAnthropic({
+        type: 'object',
+        allOf: [
+          {
+            $defs: {
+              Addr: {
+                type: 'object',
+                properties: { city: { type: 'string' } },
+              },
+            },
+            properties: { home: { $ref: '#/$defs/Addr' } },
+            required: ['home'],
+          },
+        ],
+      }),
+    ).toEqual({
+      type: 'object',
+      properties: { home: { $ref: '#/$defs/Addr' } },
+      required: ['home'],
+      $defs: {
+        Addr: { type: 'object', properties: { city: { type: 'string' } } },
+      },
+    });
+  });
+
+  it('coerces a non-object root to an empty object schema', () => {
+    expect(normalizeSchemaForAnthropic({ type: 'string' })).toEqual({
+      type: 'object',
+      properties: {},
+    });
+  });
+
+  it('does not mutate the input schema', () => {
+    const schema = {
+      properties: { n: { type: 'number', minimum: 0, exclusiveMinimum: true } },
+    };
+    const copy = structuredClone(schema);
+    normalizeSchemaForAnthropic(schema);
+    expect(schema).toEqual(copy);
+  });
+});

--- a/packages/provider-anthropic/src/normalize-schema.ts
+++ b/packages/provider-anthropic/src/normalize-schema.ts
@@ -1,0 +1,26 @@
+import type Anthropic from '@anthropic-ai/sdk';
+import type { JsonObject, JsonSchema } from '@ayunis/inference';
+import {
+  CombinatorFlattener,
+  SchemaWalker,
+  convertDraft04ExclusiveBoundsNode,
+} from '@ayunis/inference';
+
+export type AnthropicInputSchema = JsonObject &
+  Anthropic.Messages.Tool.InputSchema;
+
+const walker = new SchemaWalker((node) => {
+  convertDraft04ExclusiveBoundsNode(node);
+  return node;
+});
+
+export function normalizeSchemaForAnthropic(
+  schema: JsonSchema,
+): AnthropicInputSchema {
+  const root = walker.walk(schema);
+  new CombinatorFlattener(root).flatten();
+
+  root.type = 'object';
+  root.properties ??= {};
+  return root as AnthropicInputSchema;
+}


### PR DESCRIPTION
- MCP servers emit schemas Anthropic rejects with 400: missing top-level
  type object, draft-04 boolean exclusiveMinimum/Maximum, and
  oneOf/allOf/anyOf at the top level of input_schema
- add normalize-schema.ts (mirrors the OpenAI provider's normalization)
  and apply it in convertTool; also fixes Claude via Bedrock, which
  shares convertTool

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Top-level combinator flattening and required-field handling change schema semantics for some MCP tools, though impact is limited to Anthropic/Bedrock tool registration and is heavily tested.
> 
> **Overview**
> Adds shared JSON Schema **tool normalization** in `@ayunis/inference` and runs it when building Anthropic `input_schema`, so MCP tool definitions that previously triggered **400** responses are accepted.
> 
> The new **`tool-normalizer`** module provides **`SchemaWalker`** (immutable recursive walk, tuple `items` → `anyOf`, skips opaque keys like `enum`/`default`), **`CombinatorFlattener`** (merges top-level `oneOf`/`anyOf`/`allOf` into root `properties`, keeps `required` only for `allOf`, hoists branch `$defs`), and **`convertDraft04ExclusiveBoundsNode`** (boolean `exclusiveMinimum`/`exclusiveMaximum` → numeric 2020-12 form). These utilities are **re-exported** from the inference package.
> 
> **`normalizeSchemaForAnthropic`** applies the walker + flattener, then forces **`type: 'object'`** and ensures **`properties`** (including empty object for invalid/empty roots). **`convertTool`** now passes parameters through this normalizer instead of casting them directly.
> 
> Coverage includes unit specs for each normalizer piece, Anthropic normalization cases, and an integration test on **`convertTool`** for schemas missing top-level `type: 'object'`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1513a30513d54dee559c08abb1421e56a624373f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->