### PR TITLE
fix(mcp): sanitize mcp tool names for llm provider compatibility (AYC-412)

### DIFF
--- a/ayunis-core-backend/src/domain/runs/application/services/mcp-tool-assembler.service.ts
+++ b/ayunis-core-backend/src/domain/runs/application/services/mcp-tool-assembler.service.ts
@@ -1,0 +1,178 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { UUID } from 'crypto';
+import { Thread } from 'src/domain/threads/domain/thread.entity';
+import { Tool } from 'src/domain/tools/domain/tool.entity';
+import { DiscoverMcpCapabilitiesUseCase } from 'src/domain/mcp/application/use-cases/discover-mcp-capabilities/discover-mcp-capabilities.use-case';
+import { DiscoverMcpCapabilitiesQuery } from 'src/domain/mcp/application/use-cases/discover-mcp-capabilities/discover-mcp-capabilities.query';
+import { GetMcpIntegrationsByIdsUseCase } from 'src/domain/mcp/application/use-cases/get-mcp-integrations-by-ids/get-mcp-integrations-by-ids.use-case';
+import { GetMcpIntegrationsByIdsQuery } from 'src/domain/mcp/application/use-cases/get-mcp-integrations-by-ids/get-mcp-integrations-by-ids.query';
+import { McpIntegrationTool } from 'src/domain/tools/domain/tools/mcp-integration-tool.entity';
+import { McpIntegrationResource } from 'src/domain/tools/domain/tools/mcp-integration-resource.entity';
+import { MarketplaceMcpIntegration } from 'src/domain/mcp/domain/integrations/marketplace-mcp-integration.entity';
+
+type McpCapability = Awaited<
+  ReturnType<DiscoverMcpCapabilitiesUseCase['execute']>
+>;
+type McpIntegrationMeta = { name: string; logoUrl: string | null };
+
+/**
+ * Assembles MCP tools and resources for a thread's integrations. Lives
+ * outside ToolAssemblyService to keep that file under the 500-line cap and
+ * to keep MCP-specific logic in one place.
+ */
+@Injectable()
+export class McpToolAssemblerService {
+  private readonly logger = new Logger(McpToolAssemblerService.name);
+
+  constructor(
+    private readonly discoverMcpCapabilitiesUseCase: DiscoverMcpCapabilitiesUseCase,
+    private readonly getMcpIntegrationsByIdsUseCase: GetMcpIntegrationsByIdsUseCase,
+  ) {}
+
+  /**
+   * Discovers and assembles the thread's MCP tools, dropping any whose name
+   * is in `reservedNames` (built-ins) or already used by another MCP tool —
+   * providers reject requests with duplicate tool names, and execution
+   * lookup by name would silently resolve to the wrong tool.
+   */
+  async assemble(
+    thread: Thread,
+    reservedNames: ReadonlySet<string>,
+  ): Promise<Tool[]> {
+    const mcpTools = await this.assembleMcpTools(thread);
+    const { unique, duplicates } = McpToolAssemblerService.filterDuplicateNames(
+      mcpTools,
+      reservedNames,
+    );
+    for (const duplicate of duplicates) {
+      this.logger.warn(
+        `Duplicate MCP tool name '${duplicate.name}', skipping later occurrence`,
+      );
+    }
+    return unique;
+  }
+
+  /**
+   * Keeps the first occurrence of each name; the rest are returned so the
+   * caller can log what was dropped. `reservedNames` marks names already
+   * taken by other tools (built-ins) — entries carrying one count as
+   * duplicates.
+   */
+  private static filterDuplicateNames<T extends { name: string }>(
+    tools: T[],
+    reservedNames: ReadonlySet<string>,
+  ): { unique: T[]; duplicates: T[] } {
+    const seen = new Set<string>(reservedNames);
+    const unique: T[] = [];
+    const duplicates: T[] = [];
+    for (const tool of tools) {
+      if (seen.has(tool.name)) {
+        duplicates.push(tool);
+      } else {
+        seen.add(tool.name);
+        unique.push(tool);
+      }
+    }
+    return { unique, duplicates };
+  }
+
+  private async assembleMcpTools(thread: Thread): Promise<Tool[]> {
+    const mcpIntegrationIds = new Set<UUID>();
+    thread.mcpIntegrationIds.forEach((id) => mcpIntegrationIds.add(id));
+
+    if (mcpIntegrationIds.size === 0) return [];
+
+    const integrationIdList = [...mcpIntegrationIds];
+
+    const integrations = await this.getMcpIntegrationsByIdsUseCase.execute(
+      new GetMcpIntegrationsByIdsQuery(integrationIdList),
+    );
+    const integrationMetaMap = this.buildMcpIntegrationMetaMap(integrations);
+
+    const mcpResults = await Promise.allSettled(
+      integrationIdList.map((integrationId) =>
+        this.discoverMcpCapabilitiesUseCase.execute(
+          new DiscoverMcpCapabilitiesQuery(integrationId),
+        ),
+      ),
+    );
+
+    const mcpCapabilities = this.collectMcpCapabilities(
+      mcpResults,
+      integrationIdList,
+      integrationMetaMap,
+    );
+
+    return this.mapMcpCapabilitiesToTools(mcpCapabilities, integrationMetaMap);
+  }
+
+  private buildMcpIntegrationMetaMap(
+    integrations: Awaited<
+      ReturnType<GetMcpIntegrationsByIdsUseCase['execute']>
+    >,
+  ): Map<UUID, McpIntegrationMeta> {
+    const integrationMetaMap = new Map<UUID, McpIntegrationMeta>();
+    for (const integration of integrations) {
+      integrationMetaMap.set(integration.id, {
+        name: integration.name,
+        logoUrl:
+          integration instanceof MarketplaceMcpIntegration
+            ? integration.logoUrl
+            : null,
+      });
+    }
+    return integrationMetaMap;
+  }
+
+  private collectMcpCapabilities(
+    mcpResults: PromiseSettledResult<McpCapability>[],
+    integrationIdList: UUID[],
+    integrationMetaMap: Map<UUID, McpIntegrationMeta>,
+  ): McpCapability[] {
+    return mcpResults
+      .map((result, index) => {
+        if (result.status === 'fulfilled') {
+          return result.value;
+        }
+        const failedId = integrationIdList[index];
+        const meta = integrationMetaMap.get(failedId);
+        this.logger.warn(
+          `MCP integration '${meta?.name ?? failedId}' unavailable, skipping`,
+          {
+            integrationId: failedId,
+            error:
+              result.reason instanceof Error
+                ? result.reason.message
+                : 'Unknown error',
+          },
+        );
+        return null;
+      })
+      .filter((cap): cap is McpCapability => cap !== null);
+  }
+
+  private mapMcpCapabilitiesToTools(
+    mcpCapabilities: McpCapability[],
+    integrationMetaMap: Map<UUID, McpIntegrationMeta>,
+  ): Tool[] {
+    return [
+      ...mcpCapabilities.flatMap((capability) =>
+        capability.tools.map((tool) => {
+          const meta = integrationMetaMap.get(tool.integrationId);
+          return new McpIntegrationTool(
+            tool,
+            capability.returnsPii,
+            meta?.name ?? 'Unknown',
+            meta?.logoUrl ?? null,
+          );
+        }),
+      ),
+      ...mcpCapabilities.flatMap((capability) =>
+        capability.resources.map(
+          (resource) =>
+            new McpIntegrationResource(resource, capability.returnsPii),
+        ),
+      ),
+    ];
+  }
+}

--- a/ayunis-core-backend/src/domain/runs/application/services/tool-assembly.service.spec.ts
+++ b/ayunis-core-backend/src/domain/runs/application/services/tool-assembly.service.spec.ts
@@ -21,14 +21,14 @@ describe('ToolAssemblyService — image generation tool assembly', () => {
 
   /**
    * Build a ToolAssemblyService with mocked dependencies.
-   * Constructor order (14 params):
-   *  0 configService, 1 assembleToolsUseCase, 2 discoverMcpCapabilitiesUseCase,
+   * Constructor order (13 params):
+   *  0 configService, 1 assembleToolsUseCase, 2 mcpToolAssembler,
    *  3 systemPromptBuilderService, 4 findActiveSkillsUseCase,
    *  5 getUserSystemPromptUseCase, 6 getOrgSystemPromptUseCase,
-   *  7 getMcpIntegrationsByIdsUseCase, 8 findActiveAlwaysOnTemplatesUseCase,
-   *  9 features, 10 contextService,
-   *  11 getPermittedImageGenerationModelUseCase, 12 artifactToolAssembler,
-   *  13 getOrgChatSettingsUseCase
+   *  7 findActiveAlwaysOnTemplatesUseCase,
+   *  8 features, 9 contextService,
+   *  10 getPermittedImageGenerationModelUseCase, 11 artifactToolAssembler,
+   *  12 getOrgChatSettingsUseCase
    */
   async function buildService(overrides: {
     contextServiceGet?: jest.Mock;
@@ -36,6 +36,8 @@ describe('ToolAssemblyService — image generation tool assembly', () => {
     assembleToolExecute?: jest.Mock;
     internetSearchIsAvailable?: boolean;
     orgChatSettingsExecute?: jest.Mock;
+    discoverMcpExecute?: jest.Mock;
+    mcpIntegrationsExecute?: jest.Mock;
   }) {
     const mod = await import('./tool-assembly.service');
 
@@ -53,13 +55,16 @@ describe('ToolAssemblyService — image generation tool assembly', () => {
             Promise.resolve(createMockTool(cmd.type)),
           ),
     };
-    const discoverMcpCapabilitiesUseCase = { execute: jest.fn() };
+    const discoverMcpCapabilitiesUseCase = {
+      execute: overrides.discoverMcpExecute ?? jest.fn(),
+    };
     const systemPromptBuilderService = null;
     const findActiveSkillsUseCase = null;
     const getUserSystemPromptUseCase = null;
     const getOrgSystemPromptUseCase = null;
     const getMcpIntegrationsByIdsUseCase = {
-      execute: jest.fn().mockResolvedValue([]),
+      execute:
+        overrides.mcpIntegrationsExecute ?? jest.fn().mockResolvedValue([]),
     };
     const findActiveAlwaysOnTemplatesUseCase = null;
     const features = { skillsEnabled: false };
@@ -78,15 +83,20 @@ describe('ToolAssemblyService — image generation tool assembly', () => {
         jest.fn().mockResolvedValue({ internetSearchEnabled: true }),
     };
 
+    const mcpMod = await import('./mcp-tool-assembler.service');
+    const mcpToolAssembler = new (mcpMod.McpToolAssemblerService as any)(
+      discoverMcpCapabilitiesUseCase,
+      getMcpIntegrationsByIdsUseCase,
+    );
+
     const service = new (mod.ToolAssemblyService as any)(
       configService,
       assembleToolsUseCase,
-      discoverMcpCapabilitiesUseCase,
+      mcpToolAssembler,
       systemPromptBuilderService,
       findActiveSkillsUseCase,
       getUserSystemPromptUseCase,
       getOrgSystemPromptUseCase,
-      getMcpIntegrationsByIdsUseCase,
       findActiveAlwaysOnTemplatesUseCase,
       features,
       contextService,
@@ -103,6 +113,82 @@ describe('ToolAssemblyService — image generation tool assembly', () => {
       getOrgChatSettingsUseCase,
     };
   }
+
+  it('drops MCP tools whose sanitized name collides with a built-in tool', async () => {
+    const integrationId = randomUUID();
+    const { service } = await buildService({
+      contextServiceGet: jest.fn().mockReturnValue(mockOrgId),
+      imageModelExecute: jest.fn().mockResolvedValue({}),
+      // 'code.execution' sanitizes to 'code_execution' — the built-in's name
+      discoverMcpExecute: jest.fn().mockResolvedValue({
+        tools: [
+          {
+            name: 'code.execution',
+            description: 'third-party tool',
+            inputSchema: { type: 'object', properties: {} },
+            integrationId,
+          },
+        ],
+        resources: [],
+        prompts: [],
+        returnsPii: false,
+      }),
+      mcpIntegrationsExecute: jest
+        .fn()
+        .mockResolvedValue([{ id: integrationId, name: 'Nasty Integration' }]),
+    });
+
+    const thread = new Thread({
+      userId: randomUUID(),
+      messages: [],
+      mcpIntegrationIds: [integrationId],
+      sourceAssignments: [],
+    });
+    const tools = await service.assembleTools(thread, [], new Map());
+
+    const collisions = tools.filter(
+      (t: { name: string }) => t.name === 'code_execution',
+    );
+    expect(collisions).toHaveLength(1);
+    expect(collisions[0].type).toBe(ToolType.CODE_EXECUTION);
+  });
+
+  it('keeps only the first MCP tool when two share a sanitized name', async () => {
+    const integrationId = randomUUID();
+    const duplicateTool = (description: string) => ({
+      name: 'notion.search',
+      description,
+      inputSchema: { type: 'object', properties: {} },
+      integrationId,
+    });
+    const { service } = await buildService({
+      contextServiceGet: jest.fn().mockReturnValue(mockOrgId),
+      imageModelExecute: jest.fn().mockResolvedValue({}),
+      discoverMcpExecute: jest.fn().mockResolvedValue({
+        tools: [duplicateTool('first'), duplicateTool('second')],
+        resources: [],
+        prompts: [],
+        returnsPii: false,
+      }),
+      mcpIntegrationsExecute: jest
+        .fn()
+        .mockResolvedValue([{ id: integrationId, name: 'Integration' }]),
+    });
+
+    const thread = new Thread({
+      userId: randomUUID(),
+      messages: [],
+      mcpIntegrationIds: [integrationId],
+      sourceAssignments: [],
+    });
+    const tools = await service.assembleTools(thread, [], new Map());
+
+    const matches = tools.filter(
+      (t: { name: string }) => t.name === 'notion_search',
+    );
+    expect(matches).toHaveLength(1);
+    expect(matches[0].description).toBe('first');
+  });
 
   it('should include generate_image tool when org has a permitted image model', async () => {
     const { service } = await buildService({

--- a/ayunis-core-backend/src/domain/runs/application/services/tool-assembly.service.ts
+++ b/ayunis-core-backend/src/domain/runs/application/services/tool-assembly.service.ts
@@ -1,15 +1,10 @@
 import { Inject, Injectable, Logger } from '@nestjs/common';
 import { ConfigService, ConfigType } from '@nestjs/config';
-import { UUID } from 'crypto';
 import { Thread } from 'src/domain/threads/domain/thread.entity';
 import { Tool } from 'src/domain/tools/domain/tool.entity';
 import { ToolType } from 'src/domain/tools/domain/value-objects/tool-type.enum';
 import { AssembleToolUseCase } from 'src/domain/tools/application/use-cases/assemble-tool/assemble-tool.use-case';
 import { AssembleToolCommand } from 'src/domain/tools/application/use-cases/assemble-tool/assemble-tool.command';
-import { DiscoverMcpCapabilitiesUseCase } from 'src/domain/mcp/application/use-cases/discover-mcp-capabilities/discover-mcp-capabilities.use-case';
-import { DiscoverMcpCapabilitiesQuery } from 'src/domain/mcp/application/use-cases/discover-mcp-capabilities/discover-mcp-capabilities.query';
-import { McpIntegrationTool } from 'src/domain/tools/domain/tools/mcp-integration-tool.entity';
-import { McpIntegrationResource } from 'src/domain/tools/domain/tools/mcp-integration-resource.entity';
 import { SourceType } from 'src/domain/sources/domain/source-type.enum';
 import { TextSource } from 'src/domain/sources/domain/sources/text-source.entity';
 import { SystemPromptBuilderService } from './system-prompt-builder.service';
@@ -19,9 +14,6 @@ import { Skill } from 'src/domain/skills/domain/skill.entity';
 import { GetUserSystemPromptUseCase } from 'src/domain/chat-settings/application/use-cases/get-user-system-prompt/get-user-system-prompt.use-case';
 import { GetOrgSystemPromptUseCase } from 'src/domain/chat-settings/application/use-cases/get-org-system-prompt/get-org-system-prompt.use-case';
 import { GetOrgChatSettingsUseCase } from 'src/domain/chat-settings/application/use-cases/get-org-chat-settings/get-org-chat-settings.use-case';
-import { GetMcpIntegrationsByIdsUseCase } from 'src/domain/mcp/application/use-cases/get-mcp-integrations-by-ids/get-mcp-integrations-by-ids.use-case';
-import { GetMcpIntegrationsByIdsQuery } from 'src/domain/mcp/application/use-cases/get-mcp-integrations-by-ids/get-mcp-integrations-by-ids.query';
-import { MarketplaceMcpIntegration } from 'src/domain/mcp/domain/integrations/marketplace-mcp-integration.entity';
 import { FindActiveAlwaysOnTemplatesUseCase } from 'src/domain/skill-templates/application/use-cases/find-active-always-on-templates/find-active-always-on-templates.use-case';
 import { FindActiveAlwaysOnTemplatesQuery } from 'src/domain/skill-templates/application/use-cases/find-active-always-on-templates/find-active-always-on-templates.query';
 import { featuresConfig } from 'src/config/features.config';
@@ -38,11 +30,7 @@ import { assembleImageGenerationTools } from './image-generation-tool-assembly.h
 import { ContextService } from 'src/common/context/services/context.service';
 import { GetPermittedImageGenerationModelUseCase } from 'src/domain/models/application/use-cases/get-permitted-image-generation-model/get-permitted-image-generation-model.use-case';
 import { ArtifactToolAssemblerService } from './artifact-tool-assembler.service';
-
-type McpCapability = Awaited<
-  ReturnType<DiscoverMcpCapabilitiesUseCase['execute']>
->;
-type McpIntegrationMeta = { name: string; logoUrl: string | null };
+import { McpToolAssemblerService } from './mcp-tool-assembler.service';
 
 @Injectable()
 export class ToolAssemblyService {
@@ -51,12 +39,11 @@ export class ToolAssemblyService {
   constructor(
     private readonly configService: ConfigService,
     private readonly assembleToolsUseCase: AssembleToolUseCase,
-    private readonly discoverMcpCapabilitiesUseCase: DiscoverMcpCapabilitiesUseCase,
+    private readonly mcpToolAssembler: McpToolAssemblerService,
     private readonly systemPromptBuilderService: SystemPromptBuilderService,
     private readonly findActiveSkillsUseCase: FindActiveSkillsUseCase,
     private readonly getUserSystemPromptUseCase: GetUserSystemPromptUseCase,
     private readonly getOrgSystemPromptUseCase: GetOrgSystemPromptUseCase,
-    private readonly getMcpIntegrationsByIdsUseCase: GetMcpIntegrationsByIdsUseCase,
     private readonly findActiveAlwaysOnTemplatesUseCase: FindActiveAlwaysOnTemplatesUseCase,
     @Inject(featuresConfig.KEY)
     private readonly features: ConfigType<typeof featuresConfig>,
@@ -210,9 +197,6 @@ export class ToolAssemblyService {
   ): Promise<Tool[]> {
     const tools: Tool[] = [];
 
-    // Discover and add MCP tools/resources from thread integrations
-    tools.push(...(await this.assembleMcpTools(thread)));
-
     // Code execution tool is always available
     tools.push(await this.assembleCodeExecutionTool(thread));
 
@@ -255,6 +239,13 @@ export class ToolAssemblyService {
     tools.push(...(await this.assembleSourceTools(thread)));
     tools.push(...(await this.assembleKnowledgeTools(thread)));
     tools.push(...(await this.assembleActivateSkillTool(slugMap)));
+
+    // MCP tools/resources go last: their (sanitized) names are third-party
+    // and must not shadow a built-in tool of the same name.
+    const reservedNames = new Set(tools.map((tool) => tool.name));
+    tools.push(
+      ...(await this.mcpToolAssembler.assemble(thread, reservedNames)),
+    );
 
     return tools;
   }
@@ -376,106 +367,6 @@ export class ToolAssemblyService {
           type: ToolType.ACTIVATE_SKILL,
           context: slugMap,
         }),
-      ),
-    ];
-  }
-
-  private async assembleMcpTools(thread: Thread): Promise<Tool[]> {
-    const mcpIntegrationIds = new Set<UUID>();
-    thread.mcpIntegrationIds.forEach((id) => mcpIntegrationIds.add(id));
-
-    if (mcpIntegrationIds.size === 0) return [];
-
-    const integrationIdList = [...mcpIntegrationIds];
-
-    const integrations = await this.getMcpIntegrationsByIdsUseCase.execute(
-      new GetMcpIntegrationsByIdsQuery(integrationIdList),
-    );
-    const integrationMetaMap = this.buildMcpIntegrationMetaMap(integrations);
-
-    const mcpResults = await Promise.allSettled(
-      integrationIdList.map((integrationId) =>
-        this.discoverMcpCapabilitiesUseCase.execute(
-          new DiscoverMcpCapabilitiesQuery(integrationId),
-        ),
-      ),
-    );
-
-    const mcpCapabilities = this.collectMcpCapabilities(
-      mcpResults,
-      integrationIdList,
-      integrationMetaMap,
-    );
-
-    return this.mapMcpCapabilitiesToTools(mcpCapabilities, integrationMetaMap);
-  }
-
-  private buildMcpIntegrationMetaMap(
-    integrations: Awaited<
-      ReturnType<GetMcpIntegrationsByIdsUseCase['execute']>
-    >,
-  ): Map<UUID, McpIntegrationMeta> {
-    const integrationMetaMap = new Map<UUID, McpIntegrationMeta>();
-    for (const integration of integrations) {
-      integrationMetaMap.set(integration.id, {
-        name: integration.name,
-        logoUrl:
-          integration instanceof MarketplaceMcpIntegration
-            ? integration.logoUrl
-            : null,
-      });
-    }
-    return integrationMetaMap;
-  }
-
-  private collectMcpCapabilities(
-    mcpResults: PromiseSettledResult<McpCapability>[],
-    integrationIdList: UUID[],
-    integrationMetaMap: Map<UUID, McpIntegrationMeta>,
-  ): McpCapability[] {
-    return mcpResults
-      .map((result, index) => {
-        if (result.status === 'fulfilled') {
-          return result.value;
-        }
-        const failedId = integrationIdList[index];
-        const meta = integrationMetaMap.get(failedId);
-        this.logger.warn(
-          `MCP integration '${meta?.name ?? failedId}' unavailable, skipping`,
-          {
-            integrationId: failedId,
-            error:
-              result.reason instanceof Error
-                ? result.reason.message
-                : 'Unknown error',
-          },
-        );
-        return null;
-      })
-      .filter((cap): cap is McpCapability => cap !== null);
-  }
-
-  private mapMcpCapabilitiesToTools(
-    mcpCapabilities: McpCapability[],
-    integrationMetaMap: Map<UUID, McpIntegrationMeta>,
-  ): Tool[] {
-    return [
-      ...mcpCapabilities.flatMap((capability) =>
-        capability.tools.map((tool) => {
-          const meta = integrationMetaMap.get(tool.integrationId);
-          return new McpIntegrationTool(
-            tool,
-            capability.returnsPii,
-            meta?.name ?? 'Unknown',
-            meta?.logoUrl ?? null,
-          );
-        }),
-      ),
-      ...mcpCapabilities.flatMap((capability) =>
-        capability.resources.map(
-          (resource) =>
-            new McpIntegrationResource(resource, capability.returnsPii),
-        ),
       ),
     ];
   }

--- a/ayunis-core-backend/src/domain/runs/runs.module.ts
+++ b/ayunis-core-backend/src/domain/runs/runs.module.ts
@@ -9,6 +9,7 @@ import { ExecuteRunAndSetTitleUseCase } from './application/use-cases/execute-ru
 import { SystemPromptBuilderService } from './application/services/system-prompt-builder.service';
 import { ToolAssemblyService } from './application/services/tool-assembly.service';
 import { ArtifactToolAssemblerService } from './application/services/artifact-tool-assembler.service';
+import { McpToolAssemblerService } from './application/services/mcp-tool-assembler.service';
 import { ToolResultCollectorService } from './application/services/tool-result-collector.service';
 import { MessageCleanupService } from './application/services/message-cleanup.service';
 import { StreamingInferenceService } from './application/services/streaming-inference.service';
@@ -61,6 +62,7 @@ import { LetterheadsModule } from 'src/domain/letterheads/letterheads.module';
     SystemPromptBuilderService,
     ToolAssemblyService,
     ArtifactToolAssemblerService,
+    McpToolAssemblerService,
     ToolResultCollectorService,
     MessageCleanupService,
     StreamingInferenceService,

--- a/ayunis-core-backend/src/domain/tools/application/handlers/mcp-integration-tool.handler.ts
+++ b/ayunis-core-backend/src/domain/tools/application/handlers/mcp-integration-tool.handler.ts
@@ -23,14 +23,13 @@ export class McpIntegrationToolHandler implements ToolExecutionHandler {
     const { tool, input } = params;
     this.logger.log('execute', tool, input);
     try {
-      const validatedInput = tool.validateParams(input) as Record<
-        string,
-        unknown
-      >;
+      const validatedInput = tool.validateParams(input);
       const result = await this.executeMcpToolUseCase.execute(
         new ExecuteMcpToolCommand(
           tool.integrationId,
-          tool.name,
+          // The MCP server knows the tool by its original name, not the
+          // provider-sanitized `tool.name`.
+          tool.mcpToolName,
           validatedInput,
         ),
       );

--- a/ayunis-core-backend/src/domain/tools/domain/tools/mcp-integration-resource.entity.spec.ts
+++ b/ayunis-core-backend/src/domain/tools/domain/tools/mcp-integration-resource.entity.spec.ts
@@ -1,0 +1,20 @@
+import { randomUUID } from 'crypto';
+import { McpResource } from 'src/domain/mcp/domain/mcp-resource.entity';
+import { McpIntegrationResource } from './mcp-integration-resource.entity';
+
+describe('McpIntegrationResource', () => {
+  it('sanitizes the human-readable resource name into a valid tool name', () => {
+    const resource = new McpResource({
+      uri: 'file:///docs/readme.md',
+      name: 'Project README',
+      description: 'The project readme',
+      mimeType: 'text/markdown',
+      integrationId: randomUUID(),
+    });
+
+    const tool = new McpIntegrationResource(resource, false);
+
+    expect(tool.name).toBe('Project_README');
+    expect(tool.description).toContain('Project README');
+  });
+});

--- a/ayunis-core-backend/src/domain/tools/domain/tools/mcp-integration-resource.entity.ts
+++ b/ayunis-core-backend/src/domain/tools/domain/tools/mcp-integration-resource.entity.ts
@@ -4,6 +4,7 @@ import { ToolType } from '../value-objects/tool-type.enum';
 import type { FromSchema, JSONSchema } from 'json-schema-to-ts';
 import type { UUID } from 'crypto';
 import type { McpResource } from 'src/domain/mcp/domain/mcp-resource.entity';
+import { sanitizeMcpToolName } from './mcp-tool-name.util';
 
 const mcpResourceToolParameters = {
   type: 'object' as const,
@@ -16,7 +17,10 @@ const mcpResourceToolParameters = {
 type McpResourceToolParameters = FromSchema<typeof mcpResourceToolParameters>;
 
 function getDescription(mcpResource: McpResource): string {
-  return `Retrieve this resource from the MCP integration: ${mcpResource.name}.\nDescription: ${mcpResource.description ?? ''}\nURI: ${mcpResource.uri}\nArguments: ${mcpResource.arguments?.map((arg) => `${arg.name}: ${arg.description}`).join(', ')}`;
+  const argumentList = mcpResource.arguments
+    ?.map((arg) => `${arg.name}: ${arg.description}`)
+    .join(', ');
+  return `Retrieve this resource from the MCP integration: ${mcpResource.name}.\nDescription: ${mcpResource.description ?? ''}\nURI: ${mcpResource.uri}\nArguments: ${argumentList}`;
 }
 
 /**
@@ -30,7 +34,7 @@ export class McpIntegrationResource extends Tool {
 
   constructor(mcpResource: McpResource, returnsPii: boolean) {
     super({
-      name: mcpResource.name,
+      name: sanitizeMcpToolName(mcpResource.name),
       description: getDescription(mcpResource),
       parameters: mcpResourceToolParameters,
       type: ToolType.MCP_RESOURCE,

--- a/ayunis-core-backend/src/domain/tools/domain/tools/mcp-integration-tool.entity.spec.ts
+++ b/ayunis-core-backend/src/domain/tools/domain/tools/mcp-integration-tool.entity.spec.ts
@@ -1,0 +1,68 @@
+import { randomUUID } from 'crypto';
+import { McpTool } from 'src/domain/mcp/domain/mcp-tool.entity';
+import { McpIntegrationTool } from './mcp-integration-tool.entity';
+
+describe('McpIntegrationTool', () => {
+  function createTool(name: string): McpIntegrationTool {
+    const mcpTool = new McpTool(
+      name,
+      'A tool',
+      { type: 'object', properties: {} },
+      randomUUID(),
+    );
+    return new McpIntegrationTool(mcpTool, false, 'Integration', null);
+  }
+
+  it('sanitizes the model-facing name to the provider-accepted pattern', () => {
+    const tool = createTool('Project README.fetch');
+    expect(tool.name).toBe('Project_README_fetch');
+  });
+
+  it('preserves the original MCP tool name for server calls', () => {
+    const tool = createTool('Project README.fetch');
+    expect(tool.mcpToolName).toBe('Project README.fetch');
+  });
+
+  it('keeps valid names identical on both sides', () => {
+    const tool = createTool('search_documents');
+    expect(tool.name).toBe('search_documents');
+    expect(tool.mcpToolName).toBe('search_documents');
+  });
+
+  describe('validateParams', () => {
+    it('still rejects params that violate a compilable schema', () => {
+      const mcpTool = new McpTool(
+        'search',
+        'A tool',
+        {
+          type: 'object',
+          properties: { query: { type: 'string' } },
+          required: ['query'],
+        },
+        randomUUID(),
+      );
+      const tool = new McpIntegrationTool(mcpTool, false, 'Integration', null);
+      expect(() => tool.validateParams({})).toThrow();
+    });
+
+    it('passes params through when the server schema does not compile (draft-04 keywords)', () => {
+      const mcpTool = new McpTool(
+        'search',
+        'A tool',
+        {
+          type: 'object',
+          properties: {
+            query: { type: 'string' },
+            page: { type: 'integer', minimum: 0, exclusiveMinimum: true },
+          },
+          required: ['query'],
+        },
+        randomUUID(),
+      );
+      const tool = new McpIntegrationTool(mcpTool, false, 'Integration', null);
+      expect(tool.validateParams({ query: 'Alpha' })).toEqual({
+        query: 'Alpha',
+      });
+    });
+  });
+});

--- a/ayunis-core-backend/src/domain/tools/domain/tools/mcp-integration-tool.entity.ts
+++ b/ayunis-core-backend/src/domain/tools/domain/tools/mcp-integration-tool.entity.ts
@@ -1,9 +1,9 @@
 import { createAjv } from 'src/common/validators/ajv.factory';
 import { Tool } from '../tool.entity';
 import { ToolType } from '../value-objects/tool-type.enum';
-import type { FromSchema } from 'json-schema-to-ts';
 import type { UUID } from 'crypto';
 import type { McpTool } from 'src/domain/mcp/domain/mcp-tool.entity';
+import { sanitizeMcpToolName } from './mcp-tool-name.util';
 
 /**
  * Ephemeral tool entity representing an MCP tool.
@@ -12,6 +12,8 @@ import type { McpTool } from 'src/domain/mcp/domain/mcp-tool.entity';
  */
 export class McpIntegrationTool extends Tool {
   public readonly integrationId: UUID;
+  /** Original MCP server tool name — `name` is sanitized for LLM providers. */
+  public readonly mcpToolName: string;
   public readonly integrationName: string;
   public readonly integrationLogoUrl: string | null;
   private readonly _returnsPii: boolean;
@@ -23,22 +25,31 @@ export class McpIntegrationTool extends Tool {
     integrationLogoUrl: string | null,
   ) {
     super({
-      name: mcpTool.name,
+      name: sanitizeMcpToolName(mcpTool.name),
       description: mcpTool.description ?? '',
       parameters: mcpTool.inputSchema,
       type: ToolType.MCP_TOOL,
     });
     this.integrationId = mcpTool.integrationId;
+    this.mcpToolName = mcpTool.name;
     this.integrationName = integrationName;
     this.integrationLogoUrl = integrationLogoUrl;
     this._returnsPii = returnsPii;
   }
 
-  validateParams(
-    params: Record<string, unknown>,
-  ): FromSchema<typeof this.parameters> {
+  // Third-party MCP schemas are runtime data, so no compile-time param type
+  // can be derived from them — Record is the honest return type.
+  validateParams(params: Record<string, unknown>): Record<string, unknown> {
     const ajv = createAjv();
-    const validate = ajv.compile(this.parameters);
+    let validate: ReturnType<typeof ajv.compile>;
+    try {
+      validate = ajv.compile(this.parameters);
+    } catch {
+      // Third-party MCP schemas may use dialects ajv rejects (e.g. draft-04
+      // boolean exclusiveMinimum). The server validates its own inputs, so
+      // skip local validation rather than blocking execution.
+      return params;
+    }
     const valid = validate(params);
     if (!valid) {
       throw new Error(JSON.stringify(validate.errors));

--- a/ayunis-core-backend/src/domain/tools/domain/tools/mcp-tool-name.util.spec.ts
+++ b/ayunis-core-backend/src/domain/tools/domain/tools/mcp-tool-name.util.spec.ts
@@ -1,0 +1,26 @@
+import { sanitizeMcpToolName } from './mcp-tool-name.util';
+
+describe('sanitizeMcpToolName', () => {
+  it('keeps already-valid names unchanged', () => {
+    expect(sanitizeMcpToolName('search_documents')).toBe('search_documents');
+    expect(sanitizeMcpToolName('API-post-page')).toBe('API-post-page');
+  });
+
+  it('replaces spaces with underscores', () => {
+    expect(sanitizeMcpToolName('Project README')).toBe('Project_README');
+  });
+
+  it('replaces dots, colons and slashes with underscores', () => {
+    expect(sanitizeMcpToolName('notion.search')).toBe('notion_search');
+    expect(sanitizeMcpToolName('fs:read/file')).toBe('fs_read_file');
+  });
+
+  it('truncates names longer than 64 characters', () => {
+    expect(sanitizeMcpToolName('a'.repeat(80))).toBe('a'.repeat(64));
+  });
+
+  it('falls back to a placeholder for names without valid characters', () => {
+    expect(sanitizeMcpToolName('äöü')).toBe('mcp_tool');
+    expect(sanitizeMcpToolName('')).toBe('mcp_tool');
+  });
+});

--- a/ayunis-core-backend/src/domain/tools/domain/tools/mcp-tool-name.util.ts
+++ b/ayunis-core-backend/src/domain/tools/domain/tools/mcp-tool-name.util.ts
@@ -1,0 +1,16 @@
+/**
+ * LLM providers restrict tool names (Anthropic: `^[a-zA-Z0-9_-]{1,128}$`,
+ * OpenAI: 64 chars max of the same charset) and reject the whole request
+ * with a 400 otherwise. MCP tool and resource names are not bound by these
+ * rules, so they are sanitized before being exposed to the model.
+ */
+
+const MAX_TOOL_NAME_LENGTH = 64;
+const FALLBACK_TOOL_NAME = 'mcp_tool';
+
+export function sanitizeMcpToolName(name: string): string {
+  const sanitized = name
+    .replace(/[^a-zA-Z0-9_-]/g, '_')
+    .slice(0, MAX_TOOL_NAME_LENGTH);
+  return /[a-zA-Z0-9]/.test(sanitized) ? sanitized : FALLBACK_TOOL_NAME;
+}


### PR DESCRIPTION
- LLM providers (Anthropic, OpenAI) reject tool names outside
  ^[a-zA-Z0-9_-]+$ with a 400; MCP tool and resource names are
  unrestricted (resource names are human-readable titles with spaces)
- sanitize the model-facing name in McpIntegrationTool and
  McpIntegrationResource, keep the original name on the entity so the
  MCP server is still called with the name it knows
- drop duplicate MCP tool names at assembly (providers reject
  duplicates; execution lookup by name was ambiguous anyway)

Completes the MCP-with-Claude 400 fix started in the previous branch.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the tool list exposed to models and MCP execution naming path; incorrect sanitization or deduplication could hide tools or call the wrong MCP tool, but scope is limited to MCP assembly with targeted tests.
> 
> **Overview**
> Fixes **400 errors** when runs include MCP tools whose names violate Anthropic/OpenAI rules (spaces, dots, etc.) by **sanitizing** model-facing tool names via `sanitizeMcpToolName` on `McpIntegrationTool` and `McpIntegrationResource`, while keeping the **original name** on `mcpToolName` so execution still calls the MCP server correctly.
> 
> **Tool assembly** moves MCP discovery into new `McpToolAssemblerService`, appends MCP tools **after** built-ins, and **drops** MCP entries whose sanitized name collides with a built-in or an earlier MCP tool (first wins, warnings logged). `McpIntegrationTool.validateParams` **skips local AJV** when third-party schemas fail to compile instead of blocking execution.
> 
> Tests cover sanitization, handler/entity behavior, and collision deduplication in `tool-assembly.service.spec.ts`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7dbccfcbc6bbf4d63f2b121e696a9d6256db2fe4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->