### PR TITLE
fix(inference): convert draft-04 exclusive bounds in mistral tool schemas (AYC-412)

### DIFF
--- a/packages/provider-mistral/src/convert-request.spec.ts
+++ b/packages/provider-mistral/src/convert-request.spec.ts
@@ -23,6 +23,23 @@ describe('convertTool', () => {
       },
     });
   });
+
+  it('converts draft-04 exclusive bounds Mistral would reject', () => {
+    const tool: ToolSchema = {
+      name: 'paginate',
+      description: 'Paginate',
+      parameters: {
+        type: 'object',
+        properties: {
+          page: { type: 'integer', minimum: 0, exclusiveMinimum: true },
+        },
+      },
+    };
+    expect(convertTool(tool).function.parameters).toEqual({
+      type: 'object',
+      properties: { page: { type: 'integer', exclusiveMinimum: 0 } },
+    });
+  });
 });
 
 describe('convertToolChoice', () => {

--- a/packages/provider-mistral/src/convert-request.ts
+++ b/packages/provider-mistral/src/convert-request.ts
@@ -14,12 +14,14 @@ import type {
   ToolSchema,
 } from '@ayunis/inference';
 
+import { normalizeSchemaForMistral } from './normalize-schema';
+
 export const convertTool = (tool: ToolSchema): Tool => ({
   type: 'function',
   function: {
     name: tool.name,
     description: tool.description,
-    parameters: tool.parameters,
+    parameters: normalizeSchemaForMistral(tool.parameters),
   },
 });
 

--- a/packages/provider-mistral/src/normalize-schema.ts
+++ b/packages/provider-mistral/src/normalize-schema.ts
@@ -1,0 +1,14 @@
+import type { JsonSchema, MutableSchema } from '@ayunis/inference';
+import {
+  SchemaWalker,
+  convertDraft04ExclusiveBoundsNode,
+} from '@ayunis/inference';
+
+const walker = new SchemaWalker((node: MutableSchema) => {
+  convertDraft04ExclusiveBoundsNode(node);
+  return node;
+});
+
+export function normalizeSchemaForMistral(schema: JsonSchema): JsonSchema {
+  return walker.walk(schema);
+}


### PR DESCRIPTION
- Mistral rejects the draft-04 boolean exclusiveMinimum/exclusiveMaximum
  form MCP servers emit ("True is not of type 'number'", 400)
- same conversion as the anthropic and openai providers

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to tool schema shaping on outbound requests; reuses existing shared normalizer logic already used by other providers.
> 
> **Overview**
> Mistral tool calls were failing with **400** when MCP tool schemas used **draft-04** `exclusiveMinimum` / `exclusiveMaximum` as booleans (e.g. `minimum: 0, exclusiveMinimum: true`), which Mistral’s validator rejects.
> 
> **`convertTool`** now runs tool `parameters` through **`normalizeSchemaForMistral`**, a new helper that walks the JSON Schema with shared **`SchemaWalker`** / **`convertDraft04ExclusiveBoundsNode`** from `@ayunis/inference`—the same approach as the Anthropic and OpenAI providers. Boolean exclusive bounds are rewritten to numeric `exclusiveMinimum` / `exclusiveMaximum` before the request is sent.
> 
> A unit test in **`convert-request.spec.ts`** asserts the paginate-style schema is converted as Mistral expects.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7dcada542a5fd3864afc2528eee4fb88c8f2df8a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->