### PR TITLE
fix(inference): normalize tool schemas to gemini schema subset (AYC-412)

### DIFF
--- a/packages/provider-gemini/src/convert-request.ts
+++ b/packages/provider-gemini/src/convert-request.ts
@@ -15,10 +15,12 @@ import type {
   ToolSchema,
 } from '@ayunis/inference';
 
+import { normalizeSchemaForGemini } from './normalize-schema';
+
 export const convertTool = (tool: ToolSchema): FunctionDeclaration => ({
   name: tool.name,
   description: tool.description,
-  parameters: tool.parameters,
+  parameters: normalizeSchemaForGemini(tool.parameters),
 });
 
 export const convertToolChoice = (

--- a/packages/provider-gemini/src/normalize-schema.spec.ts
+++ b/packages/provider-gemini/src/normalize-schema.spec.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from 'vitest';
+
+import { normalizeSchemaForGemini } from './normalize-schema';
+
+describe('normalizeSchemaForGemini', () => {
+  it('leaves a plain object schema untouched', () => {
+    const schema = {
+      type: 'object',
+      properties: { q: { type: 'string', description: 'Query' } },
+      required: ['q'],
+    };
+    expect(normalizeSchemaForGemini(schema)).toEqual(schema);
+  });
+
+  it('drops keywords outside the Gemini schema subset', () => {
+    expect(
+      normalizeSchemaForGemini({
+        $schema: 'http://json-schema.org/draft-07/schema#',
+        type: 'object',
+        additionalProperties: false,
+        properties: { q: { type: 'string' } },
+      }),
+    ).toEqual({
+      type: 'object',
+      properties: { q: { type: 'string' } },
+    });
+  });
+
+  it('folds draft-04 boolean exclusive bounds into inclusive bounds', () => {
+    expect(
+      normalizeSchemaForGemini({
+        type: 'object',
+        properties: {
+          page: { type: 'integer', minimum: 0, exclusiveMinimum: true },
+        },
+      }),
+    ).toEqual({
+      type: 'object',
+      properties: { page: { type: 'integer', minimum: 0 } },
+    });
+  });
+
+  it('folds numeric 2020-12 exclusive bounds into inclusive bounds', () => {
+    expect(
+      normalizeSchemaForGemini({
+        type: 'object',
+        properties: {
+          page: { type: 'integer', exclusiveMinimum: 0, exclusiveMaximum: 10 },
+        },
+      }),
+    ).toEqual({
+      type: 'object',
+      properties: { page: { type: 'integer', minimum: 0, maximum: 10 } },
+    });
+  });
+
+  it('strips formats Gemini does not support but keeps supported ones', () => {
+    expect(
+      normalizeSchemaForGemini({
+        type: 'object',
+        properties: {
+          url: { type: 'string', format: 'uri' },
+          at: { type: 'string', format: 'date-time' },
+        },
+      }),
+    ).toEqual({
+      type: 'object',
+      properties: {
+        url: { type: 'string' },
+        at: { type: 'string', format: 'date-time' },
+      },
+    });
+  });
+
+  it('converts nullable type arrays to a single type with nullable', () => {
+    expect(
+      normalizeSchemaForGemini({
+        type: 'object',
+        properties: { note: { type: ['string', 'null'] } },
+      }),
+    ).toEqual({
+      type: 'object',
+      properties: { note: { type: 'string', nullable: true } },
+    });
+  });
+
+  it('renames oneOf to the supported anyOf', () => {
+    expect(
+      normalizeSchemaForGemini({
+        type: 'object',
+        properties: {
+          filter: { oneOf: [{ type: 'string' }, { type: 'integer' }] },
+        },
+      }),
+    ).toEqual({
+      type: 'object',
+      properties: {
+        filter: { anyOf: [{ type: 'string' }, { type: 'integer' }] },
+      },
+    });
+  });
+
+  it('collapses tuple-form items and normalizes each entry', () => {
+    expect(
+      normalizeSchemaForGemini({
+        type: 'array',
+        items: [
+          { type: 'number', minimum: 0, exclusiveMinimum: true },
+          { type: 'string', format: 'uri' },
+        ],
+      }),
+    ).toEqual({
+      type: 'array',
+      items: {
+        anyOf: [{ type: 'number', minimum: 0 }, { type: 'string' }],
+      },
+    });
+  });
+
+  it('adds type object to nodes declaring properties without a type', () => {
+    expect(
+      normalizeSchemaForGemini({
+        type: 'object',
+        properties: {
+          choice: {
+            anyOf: [
+              { properties: { a: { type: 'string' } } },
+              { properties: { b: { type: 'number' } } },
+            ],
+          },
+        },
+      }),
+    ).toEqual({
+      type: 'object',
+      properties: {
+        choice: {
+          anyOf: [
+            { type: 'object', properties: { a: { type: 'string' } } },
+            { type: 'object', properties: { b: { type: 'number' } } },
+          ],
+        },
+      },
+    });
+  });
+
+  it('recurses into array items', () => {
+    expect(
+      normalizeSchemaForGemini({
+        type: 'array',
+        items: { type: 'integer', minimum: 1, exclusiveMinimum: true },
+      }),
+    ).toEqual({
+      type: 'array',
+      items: { type: 'integer', minimum: 1 },
+    });
+  });
+
+  it('does not mutate the input schema', () => {
+    const schema = {
+      type: 'object',
+      properties: { n: { type: ['number', 'null'], exclusiveMinimum: 0 } },
+    };
+    const copy = structuredClone(schema);
+    normalizeSchemaForGemini(schema);
+    expect(schema).toEqual(copy);
+  });
+});

--- a/packages/provider-gemini/src/normalize-schema.ts
+++ b/packages/provider-gemini/src/normalize-schema.ts
@@ -1,0 +1,104 @@
+import type { Schema } from '@google/genai';
+
+import type { JsonSchema, MutableSchema } from '@ayunis/inference';
+import { SchemaWalker } from '@ayunis/inference';
+
+const GEMINI_SCHEMA_KEY_LIST = [
+  'anyOf',
+  'default',
+  'description',
+  'enum',
+  'example',
+  'format',
+  'items',
+  'maximum',
+  'maxItems',
+  'maxLength',
+  'maxProperties',
+  'minimum',
+  'minItems',
+  'minLength',
+  'minProperties',
+  'nullable',
+  'pattern',
+  'properties',
+  'propertyOrdering',
+  'required',
+  'title',
+  'type',
+] as const satisfies readonly (keyof Schema)[];
+
+const GEMINI_SCHEMA_KEYS: ReadonlySet<string> = new Set(GEMINI_SCHEMA_KEY_LIST);
+const GEMINI_SUPPORTED_FORMATS = new Set([
+  'date-time',
+  'enum',
+  'int32',
+  'int64',
+  'float',
+  'double',
+]);
+
+const walker = new SchemaWalker((node) => {
+  foldExclusiveBound(node, 'exclusiveMinimum', 'minimum');
+  foldExclusiveBound(node, 'exclusiveMaximum', 'maximum');
+  normalizeTypeArray(node);
+  normalizeFormat(node);
+  // Gemini rejects `properties` on nodes without an explicit OBJECT type
+  // (common in MCP combinator branches).
+  if ('properties' in node && !('type' in node)) {
+    node.type = 'object';
+  }
+  if (Array.isArray(node.oneOf) && !('anyOf' in node)) {
+    node.anyOf = node.oneOf;
+  }
+
+  return pickGeminiKeys(node);
+});
+
+// Gemini has no exclusive-bound keywords — fold both the draft-04 boolean and
+// 2020-12 numeric forms into the inclusive bound (looser is fine; the tool
+// validates its real inputs).
+function foldExclusiveBound(
+  schema: MutableSchema,
+  exclusiveKey: 'exclusiveMinimum' | 'exclusiveMaximum',
+  boundKey: 'minimum' | 'maximum',
+): void {
+  const exclusive = schema[exclusiveKey];
+  if (typeof exclusive === 'number' && !(boundKey in schema)) {
+    schema[boundKey] = exclusive;
+  }
+  delete schema[exclusiveKey];
+}
+
+function normalizeTypeArray(schema: MutableSchema): void {
+  if (!Array.isArray(schema.type)) return;
+  const types = schema.type.filter((t): t is string => typeof t === 'string');
+  const nonNull = types.filter((t) => t !== 'null');
+  if (nonNull.length !== types.length) {
+    schema.nullable = true;
+  }
+  schema.type = nonNull[0] ?? 'string';
+}
+
+function normalizeFormat(schema: MutableSchema): void {
+  if (
+    typeof schema.format === 'string' &&
+    !GEMINI_SUPPORTED_FORMATS.has(schema.format)
+  ) {
+    delete schema.format;
+  }
+}
+
+function pickGeminiKeys(node: MutableSchema): MutableSchema {
+  const picked: MutableSchema = {};
+  for (const [key, value] of Object.entries(node)) {
+    if (GEMINI_SCHEMA_KEYS.has(key)) {
+      picked[key] = value;
+    }
+  }
+  return picked;
+}
+
+export function normalizeSchemaForGemini(schema: JsonSchema): JsonSchema {
+  return walker.walk(schema);
+}


### PR DESCRIPTION
- Gemini function declarations accept only an OpenAPI-style subset of
  JSON Schema and 400 on unknown fields ("Unknown name ... Cannot find
  field") that MCP servers emit ($schema, additionalProperties,
  exclusive bounds, oneOf, unsupported formats)
- drop unsupported keywords, fold exclusive bounds into inclusive ones,
  map oneOf to the supported anyOf, convert nullable type arrays

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how tool schemas are interpreted for Gemini (bounds loosened, combinators remapped); wrong normalization could still break tool calling but avoids hard API failures on MCP schemas.
> 
> **Overview**
> Tool parameters sent in Gemini function declarations are now passed through **`normalizeSchemaForGemini`** instead of being forwarded raw, so MCP and full JSON Schema tool definitions no longer trigger Gemini **400** responses on unknown keywords.
> 
> The normalizer walks each schema node and **strips** fields outside Gemini’s allowed set (e.g. `$schema`, `additionalProperties`), **maps** `oneOf` → `anyOf`, **converts** `type: ['string','null']` to `nullable`, **folds** exclusive min/max into inclusive bounds, **drops** unsupported `format` values, **injects** `type: 'object'` where `properties` appear without a type, and relies on the shared **`SchemaWalker`** for tuple `items` collapse and non-mutating traversal. **`convertTool`** is the only integration point; tests cover the normalization rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 674d939d98d9808104564efd9b19880aab6e299b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->