### PR TITLE
chore(models): include provider error message in inference failure logs (AYC-412)

### DIFF
--- a/ayunis-core-backend/src/domain/models/application/use-cases/get-inference/get-inference.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/get-inference/get-inference.use-case.ts
@@ -66,6 +66,7 @@ export class GetInferenceUseCase {
       toolCount: command.tools.length,
       toolChoice: command.toolChoice,
       errorName: error instanceof Error ? error.name : 'Unknown',
+      errorMessage: error instanceof Error ? error.message : String(error),
       status,
     });
     throw new InferenceFailedError('Provider inference failed', { status });

--- a/ayunis-core-backend/src/domain/models/application/use-cases/stream-inference/stream-inference.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/stream-inference/stream-inference.use-case.ts
@@ -47,6 +47,7 @@ export class StreamInferenceUseCase {
       toolCount: input.tools.length,
       toolChoice: input.toolChoice,
       errorName: error instanceof Error ? error.name : 'Unknown',
+      errorMessage: error instanceof Error ? error.message : String(error),
       status,
     });
     return new InferenceFailedError('Provider inference failed', { status });


### PR DESCRIPTION
- inference failures logged only errorName and status, hiding the
  provider's actual message ('Ein unerwarteter Fehler' with no cause in
  the logs); log error.message alongside

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Logging-only change with no change to error types, HTTP responses, or inference flow.
> 
> **Overview**
> **Provider inference failure logs** now include an `errorMessage` field alongside the existing `errorName` and upstream `status`.
> 
> The change applies to both **non-streaming** (`GetInferenceUseCase`) and **streaming** (`StreamInferenceUseCase`) error handlers. Messages come from `error.message` when the thrown value is an `Error`, otherwise `String(error)`.
> 
> API behavior is unchanged: failures still surface as `InferenceFailedError` with the same status extraction; only structured logging gains the provider’s text for debugging (e.g. opaque upstream messages that were previously invisible in logs).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91dcbad3362672b24750d9b393dfe0d5a14a6d87. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->