### PR TITLE
feat(models): assign anonymous mode per team model override (AYC-2)

### DIFF
--- a/ayunis-core-backend/src/domain/models/application/use-cases/update-team-permitted-model/update-team-permitted-model.command.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/update-team-permitted-model/update-team-permitted-model.command.ts
@@ -1,0 +1,10 @@
+import type { UUID } from 'crypto';
+
+export class UpdateTeamPermittedModelCommand {
+  constructor(
+    public readonly permittedModelId: UUID,
+    public readonly orgId: UUID,
+    public readonly teamId: UUID,
+    public readonly anonymousOnly: boolean,
+  ) {}
+}

--- a/ayunis-core-backend/src/domain/models/application/use-cases/update-team-permitted-model/update-team-permitted-model.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/update-team-permitted-model/update-team-permitted-model.use-case.spec.ts
@@ -1,0 +1,194 @@
+import type { TestingModule } from '@nestjs/testing';
+import { Test } from '@nestjs/testing';
+import { UpdateTeamPermittedModelUseCase } from './update-team-permitted-model.use-case';
+import { UpdateTeamPermittedModelCommand } from './update-team-permitted-model.command';
+import { PermittedModelsRepository } from '../../ports/permitted-models.repository';
+import { GetTeamUseCase } from 'src/iam/teams/application/use-cases/get-team/get-team.use-case';
+import { Team } from 'src/iam/teams/domain/team.entity';
+import { TeamNotFoundError } from 'src/iam/teams/application/teams.errors';
+import { ContextService } from 'src/common/context/services/context.service';
+import { UserRole } from 'src/iam/users/domain/value-objects/role.object';
+import { SystemRole } from 'src/iam/users/domain/value-objects/system-role.enum';
+import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
+import {
+  PermittedModelNotFoundError,
+  PermittedModelNotInTeamError,
+  TeamNotFoundInOrgError,
+} from '../../models.errors';
+import { PermittedLanguageModel } from 'src/domain/models/domain/permitted-model.entity';
+import { LanguageModel } from 'src/domain/models/domain/models/language.model';
+import { ModelProvider } from 'src/domain/models/domain/value-objects/model-provider.enum';
+import { PermittedModelScope } from 'src/domain/models/domain/value-objects/permitted-model-scope.enum';
+import { randomUUID } from 'crypto';
+import { TeamPermittedModelValidator } from '../../services/team-permitted-model-validator.service';
+
+describe('UpdateTeamPermittedModelUseCase', () => {
+  let useCase: UpdateTeamPermittedModelUseCase;
+  let permittedModelsRepository: jest.Mocked<PermittedModelsRepository>;
+  let getTeamUseCase: jest.Mocked<GetTeamUseCase>;
+  let contextService: jest.Mocked<ContextService>;
+
+  const orgId = randomUUID();
+  const teamId = randomUUID();
+  const permittedModelId = randomUUID();
+
+  const languageModel = new LanguageModel({
+    id: randomUUID(),
+    name: 'claude-3-5-sonnet',
+    provider: ModelProvider.ANTHROPIC,
+    displayName: 'Claude 3.5 Sonnet',
+    canStream: true,
+    canUseTools: true,
+    isReasoning: false,
+    canVision: true,
+    isArchived: false,
+  });
+
+  beforeEach(async () => {
+    permittedModelsRepository = {
+      findOne: jest.fn(),
+      update: jest.fn(),
+    } as unknown as jest.Mocked<PermittedModelsRepository>;
+
+    getTeamUseCase = {
+      execute: jest
+        .fn()
+        .mockResolvedValue(
+          new Team({ name: 'test-team', orgId, modelOverrideEnabled: false }),
+        ),
+    } as unknown as jest.Mocked<GetTeamUseCase>;
+
+    contextService = {
+      get: jest.fn(),
+    } as unknown as jest.Mocked<ContextService>;
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        UpdateTeamPermittedModelUseCase,
+        TeamPermittedModelValidator,
+        {
+          provide: PermittedModelsRepository,
+          useValue: permittedModelsRepository,
+        },
+        { provide: GetTeamUseCase, useValue: getTeamUseCase },
+        { provide: ContextService, useValue: contextService },
+      ],
+    }).compile();
+
+    useCase = module.get(UpdateTeamPermittedModelUseCase);
+  });
+
+  function setAdminContext(): void {
+    contextService.get.mockImplementation((key) => {
+      if (key === 'orgId') return orgId;
+      if (key === 'role') return UserRole.ADMIN;
+      if (key === 'systemRole') return SystemRole.CUSTOMER;
+      return undefined;
+    });
+  }
+
+  function makeTeamModel(anonymousOnly: boolean): PermittedLanguageModel {
+    return new PermittedLanguageModel({
+      id: permittedModelId,
+      model: languageModel,
+      orgId,
+      scope: PermittedModelScope.TEAM,
+      scopeId: teamId,
+      anonymousOnly,
+    });
+  }
+
+  it('should update anonymousOnly on a team permitted model', async () => {
+    setAdminContext();
+    permittedModelsRepository.findOne.mockResolvedValue(makeTeamModel(false));
+    permittedModelsRepository.update.mockImplementation((model) =>
+      Promise.resolve(model),
+    );
+
+    const command = new UpdateTeamPermittedModelCommand(
+      permittedModelId,
+      orgId,
+      teamId,
+      true,
+    );
+    const result = await useCase.execute(command);
+
+    expect(result.anonymousOnly).toBe(true);
+    expect(result.scope).toBe(PermittedModelScope.TEAM);
+    expect(result.scopeId).toBe(teamId);
+    const updateArg = permittedModelsRepository.update.mock.calls[0][0];
+    expect(updateArg.id).toBe(permittedModelId);
+    expect(updateArg.anonymousOnly).toBe(true);
+  });
+
+  it('should throw UnauthorizedAccessError for non-admin users', async () => {
+    contextService.get.mockImplementation((key) => {
+      if (key === 'orgId') return orgId;
+      if (key === 'role') return UserRole.USER;
+      if (key === 'systemRole') return SystemRole.CUSTOMER;
+      return undefined;
+    });
+
+    const command = new UpdateTeamPermittedModelCommand(
+      permittedModelId,
+      orgId,
+      teamId,
+      true,
+    );
+    await expect(useCase.execute(command)).rejects.toThrow(
+      UnauthorizedAccessError,
+    );
+  });
+
+  it('should throw TeamNotFoundInOrgError when team does not exist in org', async () => {
+    setAdminContext();
+    getTeamUseCase.execute.mockRejectedValue(new TeamNotFoundError(teamId));
+
+    const command = new UpdateTeamPermittedModelCommand(
+      permittedModelId,
+      orgId,
+      teamId,
+      true,
+    );
+    await expect(useCase.execute(command)).rejects.toThrow(
+      TeamNotFoundInOrgError,
+    );
+  });
+
+  it('should throw PermittedModelNotFoundError when model not found', async () => {
+    setAdminContext();
+    permittedModelsRepository.findOne.mockResolvedValue(null);
+
+    const command = new UpdateTeamPermittedModelCommand(
+      permittedModelId,
+      orgId,
+      teamId,
+      true,
+    );
+    await expect(useCase.execute(command)).rejects.toThrow(
+      PermittedModelNotFoundError,
+    );
+  });
+
+  it('should throw PermittedModelNotInTeamError when model belongs to different team', async () => {
+    setAdminContext();
+    const otherTeamModel = new PermittedLanguageModel({
+      id: permittedModelId,
+      model: languageModel,
+      orgId,
+      scope: PermittedModelScope.TEAM,
+      scopeId: randomUUID(),
+    });
+    permittedModelsRepository.findOne.mockResolvedValue(otherTeamModel);
+
+    const command = new UpdateTeamPermittedModelCommand(
+      permittedModelId,
+      orgId,
+      teamId,
+      true,
+    );
+    await expect(useCase.execute(command)).rejects.toThrow(
+      PermittedModelNotInTeamError,
+    );
+  });
+});

--- a/ayunis-core-backend/src/domain/models/application/use-cases/update-team-permitted-model/update-team-permitted-model.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/update-team-permitted-model/update-team-permitted-model.use-case.ts
@@ -1,0 +1,70 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { PermittedModelsRepository } from '../../ports/permitted-models.repository';
+import { UpdateTeamPermittedModelCommand } from './update-team-permitted-model.command';
+import { PermittedLanguageModel } from 'src/domain/models/domain/permitted-model.entity';
+import { ApplicationError } from 'src/common/errors/base.error';
+import {
+  NotALanguageModelError,
+  UnexpectedModelError,
+} from '../../models.errors';
+import { TeamPermittedModelValidator } from '../../services/team-permitted-model-validator.service';
+import { LanguageModel } from 'src/domain/models/domain/models/language.model';
+
+@Injectable()
+export class UpdateTeamPermittedModelUseCase {
+  private readonly logger = new Logger(UpdateTeamPermittedModelUseCase.name);
+
+  constructor(
+    private readonly permittedModelsRepository: PermittedModelsRepository,
+    private readonly validator: TeamPermittedModelValidator,
+  ) {}
+
+  async execute(
+    command: UpdateTeamPermittedModelCommand,
+  ): Promise<PermittedLanguageModel> {
+    this.logger.log('execute', {
+      permittedModelId: command.permittedModelId,
+      orgId: command.orgId,
+      teamId: command.teamId,
+      anonymousOnly: command.anonymousOnly,
+    });
+
+    try {
+      this.validator.validateAdminAccess(command.orgId);
+      await this.validator.validateTeamInOrg(command.teamId, command.orgId);
+      const existing = await this.validator.validateModelBelongsToTeam(
+        command.permittedModelId,
+        command.teamId,
+        command.orgId,
+      );
+
+      if (!(existing.model instanceof LanguageModel)) {
+        throw new NotALanguageModelError(existing.model.id);
+      }
+
+      const updated = new PermittedLanguageModel({
+        id: existing.id,
+        model: existing.model,
+        orgId: existing.orgId,
+        scope: existing.scope,
+        scopeId: existing.scopeId,
+        isDefault: existing.isDefault,
+        anonymousOnly: command.anonymousOnly,
+        createdAt: existing.createdAt,
+        updatedAt: new Date(),
+      });
+
+      return (await this.permittedModelsRepository.update(
+        updated,
+      )) as PermittedLanguageModel;
+    } catch (error) {
+      if (error instanceof ApplicationError) {
+        throw error;
+      }
+      this.logger.error('Error updating team permitted model', error);
+      throw new UnexpectedModelError(
+        error instanceof Error ? error : new Error('Unknown error'),
+      );
+    }
+  }
+}

--- a/ayunis-core-backend/src/domain/models/models.module.ts
+++ b/ayunis-core-backend/src/domain/models/models.module.ts
@@ -91,6 +91,7 @@ import { TeamsModule } from 'src/iam/teams/teams.module';
 import { GetEffectiveLanguageModelsUseCase } from './application/use-cases/get-effective-language-models/get-effective-language-models.use-case';
 import { CreateTeamPermittedModelUseCase } from './application/use-cases/create-team-permitted-model/create-team-permitted-model.use-case';
 import { DeleteTeamPermittedModelUseCase } from './application/use-cases/delete-team-permitted-model/delete-team-permitted-model.use-case';
+import { UpdateTeamPermittedModelUseCase } from './application/use-cases/update-team-permitted-model/update-team-permitted-model.use-case';
 import { GetTeamPermittedModelsUseCase } from './application/use-cases/get-team-permitted-models/get-team-permitted-models.use-case';
 import { SetTeamDefaultModelUseCase } from './application/use-cases/set-team-default-model/set-team-default-model.use-case';
 import { TeamPermittedModelsController } from './presenters/http/team-permitted-models.controller';
@@ -286,6 +287,7 @@ import { MessagesModule } from '../messages/messages.module';
     GetTeamPermittedModelsUseCase,
     CreateTeamPermittedModelUseCase,
     DeleteTeamPermittedModelUseCase,
+    UpdateTeamPermittedModelUseCase,
     SetTeamDefaultModelUseCase,
     CreatePermittedModelUseCase,
     DeletePermittedModelUseCase,

--- a/ayunis-core-backend/src/domain/models/presenters/http/team-permitted-models.controller.ts
+++ b/ayunis-core-backend/src/domain/models/presenters/http/team-permitted-models.controller.ts
@@ -4,6 +4,7 @@ import {
   Post,
   Delete,
   Put,
+  Patch,
   Body,
   Param,
   ParseUUIDPipe,
@@ -31,9 +32,12 @@ import { CreateTeamPermittedModelUseCase } from '../../application/use-cases/cre
 import { CreateTeamPermittedModelCommand } from '../../application/use-cases/create-team-permitted-model/create-team-permitted-model.command';
 import { DeleteTeamPermittedModelUseCase } from '../../application/use-cases/delete-team-permitted-model/delete-team-permitted-model.use-case';
 import { DeleteTeamPermittedModelCommand } from '../../application/use-cases/delete-team-permitted-model/delete-team-permitted-model.command';
+import { UpdateTeamPermittedModelUseCase } from '../../application/use-cases/update-team-permitted-model/update-team-permitted-model.use-case';
+import { UpdateTeamPermittedModelCommand } from '../../application/use-cases/update-team-permitted-model/update-team-permitted-model.command';
 import { SetTeamDefaultModelUseCase } from '../../application/use-cases/set-team-default-model/set-team-default-model.use-case';
 import { SetTeamDefaultModelCommand } from '../../application/use-cases/set-team-default-model/set-team-default-model.command';
 import { CreateTeamPermittedModelDto } from './dto/create-team-permitted-model.dto';
+import { UpdatePermittedModelDto } from './dto/update-permitted-model.dto';
 import { SetTeamDefaultModelDto } from './dto/set-team-default-model.dto';
 import { PermittedLanguageModelResponseDto } from './dto/permitted-language-model-response.dto';
 import { PermittedLanguageModel } from '../../domain/permitted-model.entity';
@@ -44,6 +48,7 @@ import { ModelResponseDtoMapper } from './mappers/model-response-dto.mapper';
 @Roles(UserRole.ADMIN)
 @ApiExtraModels(
   CreateTeamPermittedModelDto,
+  UpdatePermittedModelDto,
   SetTeamDefaultModelDto,
   PermittedLanguageModelResponseDto,
 )
@@ -54,6 +59,7 @@ export class TeamPermittedModelsController {
     private readonly getTeamPermittedModelsUseCase: GetTeamPermittedModelsUseCase,
     private readonly createTeamPermittedModelUseCase: CreateTeamPermittedModelUseCase,
     private readonly deleteTeamPermittedModelUseCase: DeleteTeamPermittedModelUseCase,
+    private readonly updateTeamPermittedModelUseCase: UpdateTeamPermittedModelUseCase,
     private readonly setTeamDefaultModelUseCase: SetTeamDefaultModelUseCase,
     private readonly modelResponseDtoMapper: ModelResponseDtoMapper,
   ) {}
@@ -126,6 +132,40 @@ export class TeamPermittedModelsController {
       );
     }
     return this.modelResponseDtoMapper.toLanguageModelDto(created);
+  }
+
+  @Patch(':id')
+  @ApiOperation({
+    summary: "Update a team's permitted model",
+    description:
+      'Updates a team-scoped permitted model, e.g. toggling whether it ' +
+      'enforces anonymous mode for members of the team.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Successfully updated team permitted model',
+    schema: { $ref: getSchemaPath(PermittedLanguageModelResponseDto) },
+  })
+  @ApiResponse({ status: 404, description: 'Permitted model not found' })
+  async updateTeamPermittedModel(
+    @Param('teamId', ParseUUIDPipe) teamId: UUID,
+    @Param('id', ParseUUIDPipe) id: UUID,
+    @Body() dto: UpdatePermittedModelDto,
+    @CurrentUser(UserProperty.ORG_ID) orgId: UUID,
+  ): Promise<PermittedLanguageModelResponseDto> {
+    this.logger.log('updateTeamPermittedModel', {
+      teamId,
+      permittedModelId: id,
+      anonymousOnly: dto.anonymousOnly,
+    });
+    const command = new UpdateTeamPermittedModelCommand(
+      id,
+      orgId,
+      teamId,
+      dto.anonymousOnly,
+    );
+    const updated = await this.updateTeamPermittedModelUseCase.execute(command);
+    return this.modelResponseDtoMapper.toLanguageModelDto(updated);
   }
 
   @Delete(':id')

--- a/ayunis-core-frontend/src/pages/admin-settings/team-detail/api/useUpdateTeamPermittedModel.ts
+++ b/ayunis-core-frontend/src/pages/admin-settings/team-detail/api/useUpdateTeamPermittedModel.ts
@@ -1,0 +1,64 @@
+import { useQueryClient } from '@tanstack/react-query';
+import { useTranslation } from 'react-i18next';
+import {
+  useTeamPermittedModelsControllerUpdateTeamPermittedModel,
+  getTeamPermittedModelsControllerListTeamPermittedModelsQueryKey,
+} from '@/shared/api/generated/ayunisCoreAPI';
+import type { PermittedLanguageModelResponseDto } from '@/shared/api/generated/ayunisCoreAPI.schemas';
+import { showError } from '@/shared/lib/toast';
+
+interface UpdateTeamPermittedModelParams {
+  permittedModelId: string;
+  anonymousOnly: boolean;
+}
+
+export function useUpdateTeamPermittedModel(teamId: string) {
+  const { t } = useTranslation('admin-settings-teams');
+  const queryClient = useQueryClient();
+  const listQueryKey =
+    getTeamPermittedModelsControllerListTeamPermittedModelsQueryKey(teamId);
+
+  const mutation = useTeamPermittedModelsControllerUpdateTeamPermittedModel({
+    mutation: {
+      onMutate: async ({ id, data }) => {
+        await queryClient.cancelQueries({ queryKey: listQueryKey });
+        const previous =
+          queryClient.getQueryData<PermittedLanguageModelResponseDto[]>(
+            listQueryKey,
+          );
+        queryClient.setQueryData<PermittedLanguageModelResponseDto[]>(
+          listQueryKey,
+          (models) =>
+            models?.map((model) =>
+              model.id === id
+                ? { ...model, anonymousOnly: data.anonymousOnly }
+                : model,
+            ),
+        );
+        return { previous };
+      },
+      onError: (_error, _vars, context) => {
+        if (context?.previous) {
+          queryClient.setQueryData(listQueryKey, context.previous);
+        }
+        showError(t('teamDetail.models.updateError'));
+      },
+      onSettled: () => {
+        void queryClient.invalidateQueries({ queryKey: listQueryKey });
+      },
+    },
+  });
+
+  function updateTeamPermittedModel(params: UpdateTeamPermittedModelParams) {
+    mutation.mutate({
+      teamId,
+      id: params.permittedModelId,
+      data: { anonymousOnly: params.anonymousOnly },
+    });
+  }
+
+  return {
+    updateTeamPermittedModel,
+    isUpdating: mutation.isPending,
+  };
+}

--- a/ayunis-core-frontend/src/pages/admin-settings/team-detail/ui/TeamModelsTab.tsx
+++ b/ayunis-core-frontend/src/pages/admin-settings/team-detail/ui/TeamModelsTab.tsx
@@ -22,6 +22,7 @@ import { getTeamsControllerGetTeamQueryKey } from '@/shared/api/generated/ayunis
 import { useTeamPermittedModels } from '../api/useTeamPermittedModels';
 import { useCreateTeamPermittedModel } from '../api/useCreateTeamPermittedModel';
 import { useDeleteTeamPermittedModel } from '../api/useDeleteTeamPermittedModel';
+import { useUpdateTeamPermittedModel } from '../api/useUpdateTeamPermittedModel';
 import { useToggleModelOverride } from '../api/useToggleModelOverride';
 import { TeamDefaultModelCard } from './TeamDefaultModelCard';
 
@@ -56,6 +57,7 @@ export function TeamModelsTab({
     useCreateTeamPermittedModel(teamId);
   const { deleteTeamPermittedModel, isDeleting } =
     useDeleteTeamPermittedModel(teamId);
+  const { updateTeamPermittedModel } = useUpdateTeamPermittedModel(teamId);
 
   const permittedModelIds = new Set(teamPermittedModels.map((m) => m.modelId));
   const permittedModelByModelId = new Map(
@@ -84,7 +86,9 @@ export function TeamModelsTab({
     deletePermittedModel: (permittedModelId: string) => {
       deleteTeamPermittedModel(permittedModelId);
     },
-    updatePermittedModel: undefined,
+    updatePermittedModel: (params) => {
+      updateTeamPermittedModel(params);
+    },
     isEnabling: isCreating,
     isDisabling: isDeleting,
   };

--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.ts
@@ -5179,6 +5179,73 @@ export const useTeamPermittedModelsControllerCreateTeamPermittedModel = <TError 
     }
     
 /**
+ * Updates a team-scoped permitted model, e.g. toggling whether it enforces anonymous mode for members of the team.
+ * @summary Update a team's permitted model
+ */
+export const teamPermittedModelsControllerUpdateTeamPermittedModel = (
+    teamId: string,
+    id: string,
+    updatePermittedModelDto: UpdatePermittedModelDto,
+ ) => {
+      
+      
+      return customAxiosInstance<PermittedLanguageModelResponseDto>(
+      {url: `/teams/${teamId}/permitted-models/${id}`, method: 'PATCH',
+      headers: {'Content-Type': 'application/json', },
+      data: updatePermittedModelDto
+    },
+      );
+    }
+  
+
+
+export const getTeamPermittedModelsControllerUpdateTeamPermittedModelMutationOptions = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof teamPermittedModelsControllerUpdateTeamPermittedModel>>, TError,{teamId: string;id: string;data: UpdatePermittedModelDto}, TContext>, }
+): UseMutationOptions<Awaited<ReturnType<typeof teamPermittedModelsControllerUpdateTeamPermittedModel>>, TError,{teamId: string;id: string;data: UpdatePermittedModelDto}, TContext> => {
+
+const mutationKey = ['teamPermittedModelsControllerUpdateTeamPermittedModel'];
+const {mutation: mutationOptions} = options ?
+      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
+      options
+      : {...options, mutation: {...options.mutation, mutationKey}}
+      : {mutation: { mutationKey, }};
+
+      
+
+
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof teamPermittedModelsControllerUpdateTeamPermittedModel>>, {teamId: string;id: string;data: UpdatePermittedModelDto}> = (props) => {
+          const {teamId,id,data} = props ?? {};
+
+          return  teamPermittedModelsControllerUpdateTeamPermittedModel(teamId,id,data,)
+        }
+
+        
+
+
+  return  { mutationFn, ...mutationOptions }}
+
+    export type TeamPermittedModelsControllerUpdateTeamPermittedModelMutationResult = NonNullable<Awaited<ReturnType<typeof teamPermittedModelsControllerUpdateTeamPermittedModel>>>
+    export type TeamPermittedModelsControllerUpdateTeamPermittedModelMutationBody = UpdatePermittedModelDto
+    export type TeamPermittedModelsControllerUpdateTeamPermittedModelMutationError = void
+
+    /**
+ * @summary Update a team's permitted model
+ */
+export const useTeamPermittedModelsControllerUpdateTeamPermittedModel = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof teamPermittedModelsControllerUpdateTeamPermittedModel>>, TError,{teamId: string;id: string;data: UpdatePermittedModelDto}, TContext>, }
+ , queryClient?: QueryClient): UseMutationResult<
+        Awaited<ReturnType<typeof teamPermittedModelsControllerUpdateTeamPermittedModel>>,
+        TError,
+        {teamId: string;id: string;data: UpdatePermittedModelDto},
+        TContext
+      > => {
+
+      const mutationOptions = getTeamPermittedModelsControllerUpdateTeamPermittedModelMutationOptions(options);
+
+      return useMutation(mutationOptions, queryClient);
+    }
+    
+/**
  * @summary Remove a permitted model from a team
  */
 export const teamPermittedModelsControllerDeleteTeamPermittedModel = (

--- a/ayunis-core-frontend/src/shared/api/openapi-schema.json
+++ b/ayunis-core-frontend/src/shared/api/openapi-schema.json
@@ -2328,6 +2328,55 @@
       }
     },
     "/teams/{teamId}/permitted-models/{id}": {
+      "patch": {
+        "description": "Updates a team-scoped permitted model, e.g. toggling whether it enforces anonymous mode for members of the team.",
+        "operationId": "TeamPermittedModelsController_updateTeamPermittedModel",
+        "parameters": [
+          {
+            "name": "teamId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdatePermittedModelDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successfully updated team permitted model",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PermittedLanguageModelResponseDto"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Permitted model not found"
+          }
+        },
+        "summary": "Update a team's permitted model",
+        "tags": ["team-permitted-models"]
+      },
       "delete": {
         "operationId": "TeamPermittedModelsController_deleteTeamPermittedModel",
         "parameters": [

--- a/ayunis-core-frontend/src/shared/locales/de/admin-settings-teams.json
+++ b/ayunis-core-frontend/src/shared/locales/de/admin-settings-teams.json
@@ -106,7 +106,8 @@
       "disableSuccess": "Modell für Team deaktiviert",
       "disableError": "Modell konnte nicht für Team deaktiviert werden",
       "disableModelNotFound": "Modell nicht gefunden",
-      "disableModelInvalid": "Dieses Modell kann nicht für das Team deaktiviert werden"
+      "disableModelInvalid": "Dieses Modell kann nicht für das Team deaktiviert werden",
+      "updateError": "Modelleinstellung konnte nicht aktualisiert werden"
     },
     "removeMember": {
       "confirmTitle": "Mitglied entfernen",

--- a/ayunis-core-frontend/src/shared/locales/en/admin-settings-teams.json
+++ b/ayunis-core-frontend/src/shared/locales/en/admin-settings-teams.json
@@ -106,7 +106,8 @@
       "disableSuccess": "Model disabled for team",
       "disableError": "Failed to disable model for team",
       "disableModelNotFound": "Model not found",
-      "disableModelInvalid": "This model cannot be disabled for the team"
+      "disableModelInvalid": "This model cannot be disabled for the team",
+      "updateError": "Failed to update model setting"
     },
     "removeMember": {
       "confirmTitle": "Remove Member",


### PR DESCRIPTION
## What & why

Closes [AYC-2](https://linear.app/ayunis/issue/AYC-2/anonymen-modus-individuell-in-teams-zuweisen).

Admins could already enforce **anonymous mode** on org-level models (admin settings → models), but the option was missing for **team model overrides** (admin settings → teams → &lt;team&gt; → models). This PR brings the team model tab to parity.

- **If a team model override has the toggle on, anonymous mode is enforced for anyone from that team who selects the model** — same behavior as the org-wide setting.

## How

The `anonymousOnly` flag already exists end-to-end on the `PermittedModel` entity (org **and** team scope) and is already honored at chat time (`create-thread` / `execute-run` read `model.anonymousOnly`). The only gap was that nothing could *set* it to `true` on a team-scoped row. This PR fills that gap:

**Backend**
- New `UpdateTeamPermittedModelUseCase` (+ command) mirroring the org `UpdatePermittedModelUseCase`, reusing `TeamPermittedModelValidator` for admin-access / team-in-org / model-belongs-to-team checks.
- New `PATCH /teams/:teamId/permitted-models/:id` endpoint on `TeamPermittedModelsController`, reusing the existing `UpdatePermittedModelDto` (`{ anonymousOnly }`) and `PermittedLanguageModelResponseDto`.
- Registered the use case in `ModelsModule`.

**Frontend**
- New `useUpdateTeamPermittedModel` hook (optimistic update of the team model list) wired into `TeamModelsTab` as `actions.updatePermittedModel`. The shared `ModelTypeCard` widget already renders the anonymous-mode toggle whenever `updatePermittedModel` is provided, so the toggle now appears for teams exactly as it does for the org.
- Added `updateError` i18n keys (EN + DE).
- Regenerated the API client for the new endpoint (schema + generated client only).

**Enforcement** is unchanged/reused: a team-scoped model resolved via the effective-models path carries its own `anonymousOnly`, which `create-thread` uses to force `isAnonymous`.

## Testing

- `UpdateTeamPermittedModelUseCase` unit spec (success + auth/validation error paths) — 5 tests, passing. Full team + permitted-model use-case suites: 18 passing.
- Backend typecheck, backend/frontend ESLint + Prettier, complexity, dependency, duplication and file-size checks all pass (pre-commit).
- API client regenerated against a live backend and diffed — purely additive.
- Browser E2E of the toggle was not run: the local `anonymize` dev container was in a restart loop this session, so the full stack could not be brought up cleanly. The toggle logic is covered by unit tests + type-safety, and the enforcement path it feeds is pre-existing and unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[AYC-2]: https://michael-loy.atlassian.net/browse/AYC-2?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ