### PR TITLE
fix(models): default bedrock region to eu-central-1, lower default max_tokens to 16384 (AYC-000)

### DIFF
--- a/ayunis-core-backend/.env.example
+++ b/ayunis-core-backend/.env.example
@@ -115,6 +115,7 @@ OPENAI_API_KEY=
 ## Anthropic API
 ANTHROPIC_API_KEY=
 ## AWS Bedrock (Anthropic models via AWS)
+# Defaults to eu-central-1 when unset (after AWS_REGION / AWS_DEFAULT_REGION)
 AWS_BEDROCK_REGION=
 AWS_BEDROCK_ACCESS_KEY_ID=
 AWS_BEDROCK_SECRET_ACCESS_KEY=

--- a/packages/provider-anthropic/src/anthropic-provider.ts
+++ b/packages/provider-anthropic/src/anthropic-provider.ts
@@ -14,7 +14,11 @@ import {
   convertToolChoice,
 } from './convert-request';
 
-export const DEFAULT_MAX_TOKENS = 64_000;
+// Kept well below model maximums on purpose: Bedrock reserves
+// input_tokens + max_tokens against the account's TPM quota when admitting a
+// request, so an oversized budget triggers throttling long before real usage
+// warrants it. Hosts needing longer outputs can pass `maxTokens` explicitly.
+export const DEFAULT_MAX_TOKENS = 16_384;
 
 /**
  * Any client that speaks the Anthropic Messages streaming API — the Anthropic

--- a/packages/provider-anthropic/src/bedrock-provider.spec.ts
+++ b/packages/provider-anthropic/src/bedrock-provider.spec.ts
@@ -39,7 +39,7 @@ describe('resolveAwsRegion', () => {
     ).toBe('ap-south-1');
   });
 
-  it('uses us-east-1 when nothing is set', () => {
-    expect(resolveAwsRegion(undefined, {})).toBe('us-east-1');
+  it('uses eu-central-1 when nothing is set', () => {
+    expect(resolveAwsRegion(undefined, {})).toBe('eu-central-1');
   });
 });

--- a/packages/provider-anthropic/src/bedrock-provider.ts
+++ b/packages/provider-anthropic/src/bedrock-provider.ts
@@ -7,12 +7,12 @@ import {
   DEFAULT_MAX_TOKENS,
 } from './anthropic-provider';
 
-const DEFAULT_AWS_REGION = 'us-east-1';
+const DEFAULT_AWS_REGION = 'eu-central-1';
 
 export interface BedrockProviderOptions {
   /** Bedrock model id, e.g. 'anthropic.claude-sonnet-4-20250514-v1:0'. */
   model: string;
-  /** AWS region. Default: 'us-east-1'. */
+  /** AWS region. Default: 'eu-central-1'. */
   awsRegion?: string;
   /** Static AWS access key. Omit both keys to use the AWS credential chain. */
   awsAccessKey?: string;
@@ -42,7 +42,7 @@ export const bedrock = (options: BedrockProviderOptions): ModelProvider => {
 /**
  * Resolves the AWS region: an explicit option wins, then the standard AWS
  * region env vars, then the default — so a deployment configured purely via
- * the environment isn't silently pinned to us-east-1.
+ * the environment isn't silently pinned to eu-central-1.
  */
 export const resolveAwsRegion = (
   region: string | undefined,


### PR DESCRIPTION
- Bedrock reserves input_tokens + max_tokens against the account TPM
  quota when admitting a request; the previous 64k default caused early
  ThrottlingException + silent SDK retries, perceived as slow models
- Region fallback us-east-1 -> eu-central-1 for EU deployments
- Both remain overridable via provider options and env

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default inference behavior (region routing and max output reservation) for all Bedrock and Anthropic provider users who relied on implicit defaults, which can affect latency, throttling, and where requests land in AWS.
> 
> **Overview**
> Tightens **AWS Bedrock** defaults for EU-style deployments and reduces how aggressively requests reserve TPM quota.
> 
> **Region:** When no explicit `awsRegion` or `AWS_REGION` / `AWS_DEFAULT_REGION` is set, Bedrock now defaults to **`eu-central-1`** instead of **`us-east-1`**. Docs in `.env.example` note that resolution order is unchanged (env still wins over the default).
> 
> **Output budget:** Shared **`DEFAULT_MAX_TOKENS`** drops from **64k to 16,384** for both the direct Anthropic and Bedrock providers (same constant). The comment explains Bedrock counts `input_tokens + max_tokens` against TPM at admission, so a huge default could cause throttling and SDK retries that feel like slow models. Callers can still pass **`maxTokens`** in provider options.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 772ab0f31e6e286ed5da7af8ec19f13bffe82be1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->