### PR TITLE
perf(models): enable anthropic prompt caching for direct api and bedrock (AYC-000)

### DIFF
--- a/ayunis-core-backend/src/domain/runs/application/services/system-prompt-builder.service.spec.ts
+++ b/ayunis-core-backend/src/domain/runs/application/services/system-prompt-builder.service.spec.ts
@@ -15,6 +15,32 @@ describe('SystemPromptBuilderService', () => {
     service = new SystemPromptBuilderService();
   });
 
+  describe('context preamble', () => {
+    it('includes the date without time of day, keeping the prompt cache prefix stable', () => {
+      const prompt = service.build({
+        tools: [],
+        currentTime: new Date('2026-01-15T10:23:45.678Z'),
+      });
+
+      expect(prompt).toContain('Current date: 2026-01-15');
+      expect(prompt).not.toContain('10:23');
+      expect(prompt).not.toContain('Current time:');
+    });
+
+    it('produces byte-identical prompts for different times on the same day', () => {
+      const morning = service.build({
+        tools: [],
+        currentTime: new Date('2026-01-15T08:00:00.000Z'),
+      });
+      const evening = service.build({
+        tools: [],
+        currentTime: new Date('2026-01-15T19:59:59.999Z'),
+      });
+
+      expect(morning).toBe(evening);
+    });
+  });
+
   describe('anonymization section', () => {
     it('includes the anonymized_data section when isAnonymous is true', () => {
       const prompt = service.build({

--- a/ayunis-core-backend/src/domain/runs/application/services/system-prompt-builder.service.ts
+++ b/ayunis-core-backend/src/domain/runs/application/services/system-prompt-builder.service.ts
@@ -61,6 +61,9 @@ export class SystemPromptBuilderService {
     return sections.filter(Boolean).join('\n\n').trim();
   }
 
+  // Date only, no time of day: the preamble sits at the top of the system
+  // prompt, and prompt caching is a byte-exact prefix match — a timestamp
+  // here would invalidate the provider cache on every request.
   private buildPreamble(currentTime: Date): string {
     return `You are an AI assistant powered by Ayunis Core, an open-source AI gateway platform designed for public administrations.
 
@@ -69,7 +72,7 @@ Ayunis Core is an AI platform that enables intelligent conversations, customizab
 </application_details>
 
 <context>
-Current time: ${currentTime.toISOString()}
+Current date: ${currentTime.toISOString().slice(0, 10)}
 </context>`;
   }
 

--- a/packages/provider-anthropic/src/anthropic-provider.spec.ts
+++ b/packages/provider-anthropic/src/anthropic-provider.spec.ts
@@ -1,0 +1,95 @@
+import type Anthropic from '@anthropic-ai/sdk';
+import type { MessageCreateParamsStreaming } from '@anthropic-ai/sdk/resources/messages';
+import { describe, expect, it } from 'vitest';
+
+import type { AnthropicCompatibleClient } from './anthropic-provider';
+import { createMessagesProvider } from './anthropic-provider';
+
+/** Captures the params of each messages.create call and streams nothing. */
+const captureClient = (
+  captured: MessageCreateParamsStreaming[],
+): AnthropicCompatibleClient => ({
+  messages: {
+    create: ((params: MessageCreateParamsStreaming) => {
+      captured.push(params);
+      return Promise.resolve(
+        (async function* () {})() as unknown as Anthropic.Messages.MessageStreamEvent,
+      );
+    }) as unknown as Anthropic['messages']['create'],
+  },
+});
+
+const drain = async (stream: AsyncIterable<unknown>): Promise<unknown[]> => {
+  const chunks: unknown[] = [];
+  for await (const chunk of stream) {
+    chunks.push(chunk);
+  }
+  return chunks;
+};
+
+describe('createMessagesProvider prompt caching', () => {
+  it('sends the system prompt as a cached text block', async () => {
+    const captured: MessageCreateParamsStreaming[] = [];
+    const provider = createMessagesProvider(
+      captureClient(captured),
+      'test:model-x',
+      'model-x',
+      1024,
+    );
+
+    await drain(
+      provider.stream({
+        instructions: 'You are helpful.',
+        messages: [
+          { role: 'user', content: [{ type: 'text', text: 'Hello' }] },
+        ],
+        tools: [],
+      }),
+    );
+
+    expect(captured[0].system).toEqual([
+      {
+        type: 'text',
+        text: 'You are helpful.',
+        cache_control: { type: 'ephemeral' },
+      },
+    ]);
+  });
+
+  it('marks the last content block of the conversation as a cache breakpoint', async () => {
+    const captured: MessageCreateParamsStreaming[] = [];
+    const provider = createMessagesProvider(
+      captureClient(captured),
+      'test:model-x',
+      'model-x',
+      1024,
+    );
+
+    await drain(
+      provider.stream({
+        instructions: '',
+        messages: [
+          { role: 'user', content: [{ type: 'text', text: 'First' }] },
+          { role: 'assistant', content: [{ type: 'text', text: 'Reply' }] },
+          { role: 'user', content: [{ type: 'text', text: 'Second' }] },
+        ],
+        tools: [],
+      }),
+    );
+
+    expect(captured[0].messages).toEqual([
+      { role: 'user', content: [{ type: 'text', text: 'First' }] },
+      { role: 'assistant', content: [{ type: 'text', text: 'Reply' }] },
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'text',
+            text: 'Second',
+            cache_control: { type: 'ephemeral' },
+          },
+        ],
+      },
+    ]);
+  });
+});

--- a/packages/provider-anthropic/src/anthropic-provider.ts
+++ b/packages/provider-anthropic/src/anthropic-provider.ts
@@ -10,8 +10,10 @@ import type {
 import { convertChunk } from './convert-chunk';
 import {
   convertMessages,
+  convertSystem,
   convertTool,
   convertToolChoice,
+  markCacheBreakpoint,
 } from './convert-request';
 
 // Kept well below model maximums on purpose: Bedrock reserves
@@ -98,8 +100,11 @@ const buildParams = (
   request: ProviderRequest,
 ): MessageCreateParamsStreaming => ({
   model,
-  system: request.instructions,
-  messages: convertMessages(request.messages),
+  // Two prompt-cache breakpoints: the system block (which also covers the
+  // tool definitions rendered before it) and the conversation tail, so each
+  // turn and agent-loop iteration reuses the previous request's cache.
+  system: convertSystem(request.instructions),
+  messages: markCacheBreakpoint(convertMessages(request.messages)),
   tools: request.tools.map(convertTool),
   // Anthropic rejects tool_choice when no tools are supplied, so only send it
   // alongside a non-empty tools array.

--- a/packages/provider-anthropic/src/convert-request.spec.ts
+++ b/packages/provider-anthropic/src/convert-request.spec.ts
@@ -3,8 +3,10 @@ import { describe, expect, it } from 'vitest';
 
 import {
   convertMessages,
+  convertSystem,
   convertTool,
   convertToolChoice,
+  markCacheBreakpoint,
 } from './convert-request';
 
 describe('convertTool', () => {
@@ -216,5 +218,90 @@ describe('convertMessages', () => {
 
   it('returns an empty array for an empty history', () => {
     expect(convertMessages([])).toEqual([]);
+  });
+});
+
+describe('convertSystem', () => {
+  it('wraps non-empty instructions in a cached text block', () => {
+    expect(convertSystem('You are helpful.')).toEqual([
+      {
+        type: 'text',
+        text: 'You are helpful.',
+        cache_control: { type: 'ephemeral' },
+      },
+    ]);
+  });
+
+  it('returns empty instructions unchanged — nothing to cache', () => {
+    expect(convertSystem('')).toBe('');
+  });
+});
+
+describe('markCacheBreakpoint', () => {
+  it('marks the last content block of the last message', () => {
+    const marked = markCacheBreakpoint([
+      { role: 'user', content: [{ type: 'text', text: 'first' }] },
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'a' },
+          { type: 'text', text: 'b' },
+        ],
+      },
+    ]);
+    expect(marked).toEqual([
+      { role: 'user', content: [{ type: 'text', text: 'first' }] },
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'a' },
+          { type: 'text', text: 'b', cache_control: { type: 'ephemeral' } },
+        ],
+      },
+    ]);
+  });
+
+  it('skips thinking blocks — they cannot carry cache_control', () => {
+    const marked = markCacheBreakpoint([
+      {
+        role: 'assistant',
+        content: [
+          { type: 'text', text: 'answer' },
+          { type: 'thinking', thinking: 'hmm', signature: 'sig' },
+        ],
+      },
+    ]);
+    expect(marked).toEqual([
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'text',
+            text: 'answer',
+            cache_control: { type: 'ephemeral' },
+          },
+          { type: 'thinking', thinking: 'hmm', signature: 'sig' },
+        ],
+      },
+    ]);
+  });
+
+  it('leaves messages unmarked when no block can carry cache_control', () => {
+    const marked = markCacheBreakpoint([
+      {
+        role: 'assistant',
+        content: [{ type: 'thinking', thinking: 'hmm', signature: 'sig' }],
+      },
+    ]);
+    expect(marked).toEqual([
+      {
+        role: 'assistant',
+        content: [{ type: 'thinking', thinking: 'hmm', signature: 'sig' }],
+      },
+    ]);
+  });
+
+  it('returns an empty message list unchanged', () => {
+    expect(markCacheBreakpoint([])).toEqual([]);
   });
 });

--- a/packages/provider-anthropic/src/convert-request.ts
+++ b/packages/provider-anthropic/src/convert-request.ts
@@ -12,6 +12,59 @@ type AnthropicToolChoice =
   | Anthropic.Messages.ToolChoiceAny
   | Anthropic.Messages.ToolChoiceTool;
 
+const EPHEMERAL_CACHE = { type: 'ephemeral' } as const;
+
+/**
+ * Converts instructions to the Anthropic system param, marking them as a
+ * prompt-cache breakpoint. Because Anthropic renders tools → system →
+ * messages, this one breakpoint caches the tool definitions and the system
+ * prompt together. Empty instructions pass through — a marker on an empty
+ * block would be a pointless cache entry.
+ */
+export const convertSystem = (
+  instructions: string,
+): string | Anthropic.TextBlockParam[] =>
+  instructions
+    ? [{ type: 'text', text: instructions, cache_control: EPHEMERAL_CACHE }]
+    : instructions;
+
+/** Block types that accept cache_control (thinking blocks do not). */
+const CACHEABLE_BLOCK_TYPES = new Set([
+  'text',
+  'image',
+  'tool_use',
+  'tool_result',
+  'document',
+]);
+
+/**
+ * Marks the last cacheable content block of the last message as a
+ * prompt-cache breakpoint, so each request reuses the cache entry the
+ * previous turn (or agent-loop iteration) wrote. The marker moves with the
+ * conversation tail; earlier entries stay valid as read points.
+ */
+export const markCacheBreakpoint = (
+  messages: Anthropic.MessageParam[],
+): Anthropic.MessageParam[] => {
+  const lastMessage = messages.at(-1);
+  if (!lastMessage) {
+    return messages;
+  }
+  const blocks = asBlocks(lastMessage.content);
+  const lastCacheable = blocks.findLast((block) =>
+    CACHEABLE_BLOCK_TYPES.has(block.type),
+  );
+  if (!lastCacheable) {
+    return messages;
+  }
+  const markedContent = blocks.map((block) =>
+    block === lastCacheable
+      ? { ...block, cache_control: EPHEMERAL_CACHE }
+      : block,
+  );
+  return [...messages.slice(0, -1), { ...lastMessage, content: markedContent }];
+};
+
 export const convertTool = (tool: ToolSchema): Anthropic.Tool => ({
   name: tool.name,
   description: tool.description,


### PR DESCRIPTION
- Mark the system prompt as a cache_control breakpoint; because Anthropic
  renders tools -> system -> messages, it caches tool definitions and
  system prompt together
- Mark the last cacheable content block of the conversation as a moving
  breakpoint so every turn and agent-loop iteration reuses the previous
  request's cache entry
- On Bedrock, cache reads are also exempt from the TPM quota burndown,
  reducing ThrottlingException-driven latency

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes wire format for all Anthropic/Bedrock inference calls and slightly reduces temporal context in the system preamble (date vs time); behavior is covered by tests but affects production latency/cost paths.
> 
> **Overview**
> Enables **Anthropic ephemeral prompt caching** on the shared Messages provider (direct API and Bedrock) so multi-turn chats and agent loops reuse prior request prefixes instead of re-billing the full prompt every time.
> 
> The provider now sends the system instructions as a `cache_control: ephemeral` text block and marks the **last cacheable block** on the final message (skipping thinking-only tails). Unit tests lock in both behaviors end-to-end.
> 
> Separately, the system prompt preamble switches from a full ISO **timestamp** to **date-only** (`YYYY-MM-DD`) so the top of the system string stays byte-stable within a day—matching Anthropic’s exact-prefix cache rules and avoiding per-request cache invalidation from the clock.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75fb99aa5e85340d0bc9da73d001cdd0006107f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->