### PR TITLE
fix(artifacts): pin letterhead PDF page size to A4 (AYC-411)

### DIFF
--- a/ayunis-core-backend/src/domain/artifacts/infrastructure/export/html-document-export.service.spec.ts
+++ b/ayunis-core-backend/src/domain/artifacts/infrastructure/export/html-document-export.service.spec.ts
@@ -242,7 +242,16 @@ describe('HtmlDocumentExportService', () => {
         expect(htmlArg).toContain('55mm');
         expect(htmlArg).toContain('15mm');
         expect(htmlArg).toContain(
-          '@page {\n    margin: 20mm 15mm 20mm 15mm;\n  }',
+          '@page {\n    size: A4;\n    margin: 20mm 15mm 20mm 15mm;\n  }',
+        );
+      });
+
+      it('should declare an explicit A4 page size so preferCSSPageSize keeps A4', async () => {
+        await service.exportToPdf('<p>Hello</p>', letterheadConfig);
+
+        const htmlArg = mockPage.setContent.mock.calls[0][0] as string;
+        expect(htmlArg).toContain(
+          '@page :first {\n    size: A4;\n    margin: 55mm 15mm 20mm 15mm;\n  }',
         );
       });
 

--- a/ayunis-core-backend/src/domain/artifacts/infrastructure/export/html-document-export.service.ts
+++ b/ayunis-core-backend/src/domain/artifacts/infrastructure/export/html-document-export.service.ts
@@ -202,6 +202,12 @@ export class HtmlDocumentExportService
     const { continuationPageMargins: cont, firstPageMargins: first } =
       letterhead;
 
+    // `preferCSSPageSize: true` makes Puppeteer ignore the `format: 'A4'`
+    // option, so the page size must be declared here. Without an explicit
+    // `size`, Chromium falls back to its locale-dependent default (US Letter
+    // in production), which is 18mm shorter than A4. That mismatch causes the
+    // A4 letterhead background to be scaled to fit, distorting the design and
+    // throwing off the configured margins.
     return `
   body {
     margin: 0;
@@ -211,9 +217,11 @@ export class HtmlDocumentExportService
     margin-top: 0;
   }
   @page {
+    size: A4;
     margin: ${cont.top}mm ${cont.right}mm ${cont.bottom}mm ${cont.left}mm;
   }
   @page :first {
+    size: A4;
     margin: ${first.top}mm ${first.right}mm ${first.bottom}mm ${first.left}mm;
   }`;
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Letterhead PDF exports in production ignore the configured bottom margin and render the letterhead design misaligned (AYC-411).

## Root cause

When a letterhead is applied, `HtmlDocumentExportService` renders the content PDF with:

```ts
{ format: 'A4', preferCSSPageSize: true, margin: 0 }
```

Per the Puppeteer docs, `preferCSSPageSize: true` makes the `format` (and `width`/`height`) option **ignored** — the page size comes entirely from the CSS `@page` rules. The injected `@page` rules only declared `margin`, never a `size`. With no CSS page size, Chromium falls back to its **locale-dependent default paper size**, which in the production container is **US Letter** (216×279mm) rather than **A4** (210×297mm).

The content PDF was therefore rendered at Letter size — ~18mm shorter than A4. The `PdfLetterheadCompositor` sizes each output page to the content page and scales the A4 letterhead background to fit, so the A4 design got squished to Letter dimensions, distorting the layout and shifting the configured margins (most visibly the bottom margin). This is environment-dependent, which is why it reproduced in production but not necessarily locally.

## Fix

Declare `size: A4` in both injected `@page` rules (`@page` and `@page :first`) so the content PDF is deterministically A4 regardless of the host's default paper size, keeping it aligned with the A4 letterhead background.

## Verification

- Confirmed via the Puppeteer docs that `format` is ignored under `preferCSSPageSize: true`.
- Rendered sample HTML through real headless Chrome: with `size: A4` the resulting page is A4 (≈595×842pt); without it the dimensions depend on the environment default.
- Updated and ran the unit tests (`html-document-export`, `pdf-letterhead-compositor`) — all pass; lint, typecheck, and complexity pre-commit checks pass.

## Notes

The comment thread on the issue noted the "design ignored" wording was unclear — this fix addresses both the visible bottom-margin problem and the underlying page-size/scaling mismatch that distorts the design.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [AYC-411](https://linear.app/ayunis/issue/AYC-411/letterhead-content-ignores-margins-and-design)

<div><a href="https://cursor.com/agents/bc-ebafae9f-bfa0-489b-81be-28be5b3f8403"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ebafae9f-bfa0-489b-81be-28be5b3f8403"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

