### PR TITLE
fix(usage): bill prompt-cache tokens as input tokens (AYC-000)

### DIFF
--- a/ayunis-core-backend/src/domain/models/application/ports/stream-inference.handler.ts
+++ b/ayunis-core-backend/src/domain/models/application/ports/stream-inference.handler.ts
@@ -65,6 +65,10 @@ export class StreamInferenceResponseChunk {
   public readonly usage?: {
     inputTokens?: number;
     outputTokens?: number;
+    /** Prompt tokens served from the provider's prompt cache. */
+    cacheReadInputTokens?: number;
+    /** Prompt tokens written to the provider's prompt cache. */
+    cacheWriteInputTokens?: number;
   };
 
   constructor(params: {
@@ -78,6 +82,8 @@ export class StreamInferenceResponseChunk {
     usage?: {
       inputTokens?: number;
       outputTokens?: number;
+      cacheReadInputTokens?: number;
+      cacheWriteInputTokens?: number;
     };
   }) {
     this.thinkingDelta = params.thinkingDelta;

--- a/ayunis-core-backend/src/domain/models/infrastructure/runtime/response-accumulator.spec.ts
+++ b/ayunis-core-backend/src/domain/models/infrastructure/runtime/response-accumulator.spec.ts
@@ -102,6 +102,29 @@ describe('accumulateResponse', () => {
     });
   });
 
+  it('bills cached prompt tokens as input tokens in response meta', async () => {
+    // Anthropic's input_tokens excludes prompt-cache reads/writes; billing
+    // counts the full prompt as input (Option A).
+    const response = await accumulateResponse(
+      stream([
+        { textDelta: 'x' },
+        {
+          usage: {
+            inputTokens: 3,
+            cacheWriteInputTokens: 90,
+            cacheReadInputTokens: 900,
+            outputTokens: 7,
+          },
+        },
+      ]),
+    );
+    expect(response.meta).toEqual({
+      inputTokens: 993,
+      outputTokens: 7,
+      totalTokens: 1000,
+    });
+  });
+
   it('takes last-wins usage when providers emit cumulative usage per chunk', async () => {
     const response = await accumulateResponse(
       stream([

--- a/ayunis-core-backend/src/domain/models/infrastructure/runtime/response-accumulator.ts
+++ b/ayunis-core-backend/src/domain/models/infrastructure/runtime/response-accumulator.ts
@@ -150,14 +150,18 @@ class StreamResponseAccumulator {
 
   private buildMeta(): ResponseMeta {
     const { outputTokens } = this;
+    const cacheReadInputTokens = this.cacheReadInputTokens ?? 0;
+    const cacheWriteInputTokens = this.cacheWriteInputTokens ?? 0;
     // Cached prompt tokens are billed as ordinary input: the provider's
     // inputTokens excludes tokens covered by the prompt cache (Anthropic,
-    // Bedrock), so the full prompt is the sum of all three fields.
+    // Bedrock), so the full prompt is the sum of all three fields. Cache
+    // activity can be reported without an uncached remainder, so treat a
+    // missing inputTokens as zero whenever any input field is present.
     const inputTokens =
-      this.inputTokens !== undefined
-        ? this.inputTokens +
-          (this.cacheReadInputTokens ?? 0) +
-          (this.cacheWriteInputTokens ?? 0)
+      this.inputTokens !== undefined ||
+      cacheReadInputTokens ||
+      cacheWriteInputTokens
+        ? (this.inputTokens ?? 0) + cacheReadInputTokens + cacheWriteInputTokens
         : undefined;
     const totalTokens =
       inputTokens !== undefined && outputTokens !== undefined

--- a/ayunis-core-backend/src/domain/models/infrastructure/runtime/response-accumulator.ts
+++ b/ayunis-core-backend/src/domain/models/infrastructure/runtime/response-accumulator.ts
@@ -19,9 +19,7 @@ interface ToolCallAccumulator {
 }
 
 type ResponseContent =
-  | TextMessageContent
-  | ToolUseMessageContent
-  | ThinkingMessageContent;
+  TextMessageContent | ToolUseMessageContent | ThinkingMessageContent;
 
 interface ResponseMeta {
   inputTokens?: number;
@@ -50,6 +48,8 @@ class StreamResponseAccumulator {
   private readonly toolCalls = new Map<number, ToolCallAccumulator>();
   private inputTokens?: number;
   private outputTokens?: number;
+  private cacheReadInputTokens?: number;
+  private cacheWriteInputTokens?: number;
   private finishReason: FinishReason = null;
 
   async consume(
@@ -103,6 +103,10 @@ class StreamResponseAccumulator {
     if (usage.inputTokens !== undefined) this.inputTokens = usage.inputTokens;
     if (usage.outputTokens !== undefined)
       this.outputTokens = usage.outputTokens;
+    if (usage.cacheReadInputTokens !== undefined)
+      this.cacheReadInputTokens = usage.cacheReadInputTokens;
+    if (usage.cacheWriteInputTokens !== undefined)
+      this.cacheWriteInputTokens = usage.cacheWriteInputTokens;
   }
 
   private build(): InferenceResponse {
@@ -145,7 +149,16 @@ class StreamResponseAccumulator {
   }
 
   private buildMeta(): ResponseMeta {
-    const { inputTokens, outputTokens } = this;
+    const { outputTokens } = this;
+    // Cached prompt tokens are billed as ordinary input: the provider's
+    // inputTokens excludes tokens covered by the prompt cache (Anthropic,
+    // Bedrock), so the full prompt is the sum of all three fields.
+    const inputTokens =
+      this.inputTokens !== undefined
+        ? this.inputTokens +
+          (this.cacheReadInputTokens ?? 0) +
+          (this.cacheWriteInputTokens ?? 0)
+        : undefined;
     const totalTokens =
       inputTokens !== undefined && outputTokens !== undefined
         ? inputTokens + outputTokens

--- a/ayunis-core-backend/src/domain/runs/application/helpers/buffered-stream.helper.ts
+++ b/ayunis-core-backend/src/domain/runs/application/helpers/buffered-stream.helper.ts
@@ -1,0 +1,59 @@
+import type { Observable } from 'rxjs';
+
+/**
+ * Bridges an RxJS Observable to an AsyncIterable while recording every
+ * emitted value in the caller-owned `buffer` (the caller reads it afterwards,
+ * e.g. for usage extraction). Invokes `onComplete` only when the source
+ * completed successfully and the consumer drained every buffered value.
+ */
+export function observableToBufferedAsyncIterable<T>(
+  source$: Observable<T>,
+  buffer: T[],
+  onComplete: () => void,
+): AsyncIterable<T> {
+  return {
+    [Symbol.asyncIterator]() {
+      let completed = false;
+      let error: Error | null = null;
+      let consumedIndex = 0;
+
+      const subscription = source$.subscribe({
+        next: (value) => {
+          buffer.push(value);
+        },
+        error: (err) => {
+          error = err as Error;
+          completed = true;
+        },
+        complete: () => {
+          completed = true;
+        },
+      });
+
+      return {
+        async next() {
+          while (consumedIndex >= buffer.length && !completed) {
+            await new Promise((resolve) => setTimeout(resolve, 10));
+          }
+
+          if (error) {
+            subscription.unsubscribe();
+            throw error;
+          }
+
+          if (consumedIndex < buffer.length) {
+            const value = buffer[consumedIndex++];
+            return { value, done: false } as IteratorResult<T, void>;
+          } else {
+            subscription.unsubscribe();
+            onComplete();
+            return {
+              done: true,
+              value: undefined,
+            } as IteratorReturnResult<void>;
+          }
+        },
+      };
+    },
+  } as AsyncIterable<T>;
+}

--- a/ayunis-core-backend/src/domain/runs/application/services/streaming-inference.service.spec.ts
+++ b/ayunis-core-backend/src/domain/runs/application/services/streaming-inference.service.spec.ts
@@ -15,6 +15,8 @@ describe('StreamingInferenceService.extractUsageFromChunks', () => {
   const chunkWithUsage = (usage: {
     inputTokens?: number;
     outputTokens?: number;
+    cacheReadInputTokens?: number;
+    cacheWriteInputTokens?: number;
   }): StreamInferenceResponseChunk =>
     new StreamInferenceResponseChunk({
       thinkingDelta: null,
@@ -52,5 +54,32 @@ describe('StreamingInferenceService.extractUsageFromChunks', () => {
       chunkWithUsage({ inputTokens: 100, outputTokens: 30 }),
     ]);
     expect(usage).toEqual({ inputTokens: 100, outputTokens: 30 });
+  });
+
+  it('bills cached prompt tokens as input tokens', () => {
+    // Anthropic's input_tokens excludes tokens served by or written to the
+    // prompt cache. Option A billing: customers pay for the full prompt as
+    // if uncached, so cache read/write tokens count as input.
+    const usage = service.extractUsageFromChunks([
+      chunkWithUsage({
+        inputTokens: 3,
+        cacheWriteInputTokens: 9677,
+        cacheReadInputTokens: 0,
+      }),
+      chunkWithUsage({ outputTokens: 42 }),
+    ]);
+    expect(usage).toEqual({ inputTokens: 9680, outputTokens: 42 });
+  });
+
+  it('bills cache reads and writes together with uncached input', () => {
+    const usage = service.extractUsageFromChunks([
+      chunkWithUsage({
+        inputTokens: 10,
+        cacheWriteInputTokens: 200,
+        cacheReadInputTokens: 3000,
+        outputTokens: 5,
+      }),
+    ]);
+    expect(usage).toEqual({ inputTokens: 3210, outputTokens: 5 });
   });
 });

--- a/ayunis-core-backend/src/domain/runs/application/services/streaming-inference.service.ts
+++ b/ayunis-core-backend/src/domain/runs/application/services/streaming-inference.service.ts
@@ -23,11 +23,10 @@ import { safeJsonParse } from 'src/common/util/unicode-sanitizer';
 import { ContextService } from 'src/common/context/services/context.service';
 import { InferenceCompletedEvent } from '../events/inference-completed.event';
 import { extractInferenceErrorInfo } from '../helpers/extract-inference-error-info.helper';
+import { observableToBufferedAsyncIterable } from '../helpers/buffered-stream.helper';
 
 type AssistantContentBlock =
-  | TextMessageContent
-  | ToolUseMessageContent
-  | ThinkingMessageContent;
+  TextMessageContent | ToolUseMessageContent | ThinkingMessageContent;
 
 interface AccumulatedToolCall {
   id: string | null;
@@ -44,6 +43,15 @@ interface AccumulatedState {
   thinkingSignature: string | null;
   toolCalls: Map<number, AccumulatedToolCall>;
 }
+
+const initialAccumulatedState = (): AccumulatedState => ({
+  text: '',
+  thinking: '',
+  textProviderMetadata: null,
+  thinkingId: null,
+  thinkingSignature: null,
+  toolCalls: new Map(),
+});
 
 /**
  * Executes streaming inference, accumulates response chunks, yields partial
@@ -69,87 +77,39 @@ export class StreamingInferenceService {
     threadId: UUID;
     orgId: UUID;
   }): AsyncGenerator<AssistantMessage, void, unknown> {
-    const { model, messages, tools, instructions, threadId, orgId } = params;
+    const { model, tools, threadId, orgId } = params;
 
-    const streamInput = new StreamInferenceInput({
-      model,
-      messages,
-      systemPrompt: instructions ?? '',
-      tools,
-      toolChoice: ModelToolChoice.AUTO,
-      orgId,
-    });
-
-    const stream$ = this.streamInferenceUseCase.execute(streamInput);
-
-    const assistantMessage = new AssistantMessage({
-      threadId,
-      content: [],
-    });
-
-    const state: AccumulatedState = {
-      text: '',
-      thinking: '',
-      textProviderMetadata: null,
-      thinkingId: null,
-      thinkingSignature: null,
-      toolCalls: new Map(),
-    };
-
+    const stream$ = this.startStream(params);
+    const assistantMessage = new AssistantMessage({ threadId, content: [] });
+    const state = initialAccumulatedState();
     let streamCompletedSuccessfully = false;
     const allChunks: StreamInferenceResponseChunk[] = [];
     const startTime = Date.now();
 
-    const asyncIterable = this.buildAsyncIterable(stream$, allChunks, () => {
-      streamCompletedSuccessfully = true;
-    });
+    const asyncIterable = observableToBufferedAsyncIterable(
+      stream$,
+      allChunks,
+      () => {
+        streamCompletedSuccessfully = true;
+      },
+    );
 
     let inferenceError: unknown;
     try {
-      for await (const message of this.processStreamingChunks(
+      yield* this.processStreamingChunks(
         asyncIterable,
         assistantMessage,
         state,
         tools,
-      )) {
-        yield message;
-      }
+      );
     } catch (error) {
       inferenceError = error;
       throw error;
     } finally {
-      const userId = this.contextService.get('userId');
-      const contextOrgId = this.contextService.get('orgId');
-      this.eventEmitter
-        .emitAsync(
-          InferenceCompletedEvent.EVENT_NAME,
-          new InferenceCompletedEvent(
-            userId ?? ('unknown' as UUID),
-            contextOrgId ?? orgId,
-            model.name,
-            model.provider,
-            true,
-            Date.now() - startTime,
-            inferenceError
-              ? extractInferenceErrorInfo(inferenceError)
-              : undefined,
-          ),
-        )
-        .catch((err: unknown) => {
-          this.logger.error('Failed to emit InferenceCompletedEvent', {
-            error: err instanceof Error ? err.message : 'Unknown error',
-          });
-        });
+      this.emitInferenceCompleted(model, orgId, startTime, inferenceError);
       // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- mutated in callback, TS can't track
       if (streamCompletedSuccessfully && allChunks.length > 0) {
-        const usage = this.extractUsageFromChunks(allChunks);
-        if (usage) {
-          this.inferenceUsageGuard.collectUsage(
-            model,
-            usage,
-            assistantMessage.id,
-          );
-        }
+        this.collectStreamUsage(model, allChunks, assistantMessage.id);
       }
 
       await this.saveAccumulatedMessage(
@@ -162,59 +122,64 @@ export class StreamingInferenceService {
     }
   }
 
-  private buildAsyncIterable(
-    stream$: ReturnType<StreamInferenceUseCase['execute']>,
-    allChunks: StreamInferenceResponseChunk[],
-    onComplete: () => void,
-  ): AsyncIterable<StreamInferenceResponseChunk> {
-    return {
-      [Symbol.asyncIterator]() {
-        let completed = false;
-        let error: Error | null = null;
-        let consumedIndex = 0;
+  private startStream(params: {
+    model: LanguageModel;
+    messages: Message[];
+    tools: Tool[];
+    instructions?: string;
+    orgId: UUID;
+  }): ReturnType<StreamInferenceUseCase['execute']> {
+    return this.streamInferenceUseCase.execute(
+      new StreamInferenceInput({
+        model: params.model,
+        messages: params.messages,
+        systemPrompt: params.instructions ?? '',
+        tools: params.tools,
+        toolChoice: ModelToolChoice.AUTO,
+        orgId: params.orgId,
+      }),
+    );
+  }
 
-        const subscription = stream$.subscribe({
-          next: (chunk) => {
-            allChunks.push(chunk);
-          },
-          error: (err) => {
-            error = err as Error;
-            completed = true;
-          },
-          complete: () => {
-            completed = true;
-          },
+  private collectStreamUsage(
+    model: LanguageModel,
+    chunks: StreamInferenceResponseChunk[],
+    messageId: UUID,
+  ): void {
+    const usage = this.extractUsageFromChunks(chunks);
+    if (usage) {
+      this.inferenceUsageGuard.collectUsage(model, usage, messageId);
+    }
+  }
+
+  private emitInferenceCompleted(
+    model: LanguageModel,
+    orgId: UUID,
+    startTime: number,
+    inferenceError: unknown,
+  ): void {
+    const userId = this.contextService.get('userId');
+    const contextOrgId = this.contextService.get('orgId');
+    this.eventEmitter
+      .emitAsync(
+        InferenceCompletedEvent.EVENT_NAME,
+        new InferenceCompletedEvent(
+          userId ?? ('unknown' as UUID),
+          contextOrgId ?? orgId,
+          model.name,
+          model.provider,
+          true,
+          Date.now() - startTime,
+          inferenceError
+            ? extractInferenceErrorInfo(inferenceError)
+            : undefined,
+        ),
+      )
+      .catch((err: unknown) => {
+        this.logger.error('Failed to emit InferenceCompletedEvent', {
+          error: err instanceof Error ? err.message : 'Unknown error',
         });
-
-        return {
-          async next() {
-            while (consumedIndex >= allChunks.length && !completed) {
-              await new Promise((resolve) => setTimeout(resolve, 10));
-            }
-
-            if (error) {
-              subscription.unsubscribe();
-              throw error;
-            }
-
-            if (consumedIndex < allChunks.length) {
-              const chunk = allChunks[consumedIndex++];
-              return { value: chunk, done: false } as IteratorResult<
-                StreamInferenceResponseChunk,
-                void
-              >;
-            } else {
-              subscription.unsubscribe();
-              onComplete();
-              return {
-                done: true,
-                value: undefined,
-              } as IteratorReturnResult<void>;
-            }
-          },
-        };
-      },
-    } as AsyncIterable<StreamInferenceResponseChunk>;
+      });
   }
 
   private async *processStreamingChunks(
@@ -222,7 +187,7 @@ export class StreamingInferenceService {
     assistantMessage: AssistantMessage,
     state: AccumulatedState,
     tools: Tool[],
-  ): AsyncGenerator<AssistantMessage, void, void> {
+  ): AsyncGenerator<AssistantMessage, void, unknown> {
     for await (const chunk of asyncIterable) {
       const shouldUpdate = this.accumulateChunk(chunk, state);
 
@@ -451,25 +416,53 @@ export class StreamingInferenceService {
   extractUsageFromChunks(
     chunks: StreamInferenceResponseChunk[],
   ): { inputTokens: number; outputTokens: number } | undefined {
-    // Providers report cumulative usage on every chunk (Gemini repeats
-    // promptTokenCount on each chunk; candidatesTokenCount only appears on the
-    // final one). Summing across chunks would over-count, so take last-wins per
-    // field, matching the non-streaming accumulator (response-accumulator.ts).
-    let inputTokens: number | undefined;
-    let outputTokens: number | undefined;
+    const usage = this.lastWinsUsage(chunks);
+    if (usage.inputTokens === undefined && usage.outputTokens === undefined) {
+      return undefined;
+    }
+    const cacheRead = usage.cacheReadInputTokens ?? 0;
+    const cacheWrite = usage.cacheWriteInputTokens ?? 0;
+    if (cacheRead || cacheWrite) {
+      this.logger.debug('Prompt cache activity', {
+        uncachedInputTokens: usage.inputTokens ?? 0,
+        cacheReadInputTokens: cacheRead,
+        cacheWriteInputTokens: cacheWrite,
+      });
+    }
+    // Cached prompt tokens are billed as ordinary input: the provider's
+    // inputTokens excludes tokens covered by the prompt cache, so without
+    // this the billed input collapses to the uncached remainder (~3 tokens).
+    return {
+      inputTokens: (usage.inputTokens ?? 0) + cacheRead + cacheWrite,
+      outputTokens: usage.outputTokens ?? 0,
+    };
+  }
 
+  /**
+   * Providers report cumulative usage on every chunk (Gemini repeats
+   * promptTokenCount on each chunk; candidatesTokenCount only appears on the
+   * final one). Summing across chunks would over-count, so take last-wins per
+   * field, matching the non-streaming accumulator (response-accumulator.ts).
+   */
+  private lastWinsUsage(
+    chunks: StreamInferenceResponseChunk[],
+  ): NonNullable<StreamInferenceResponseChunk['usage']> {
+    const result: NonNullable<StreamInferenceResponseChunk['usage']> = {};
     for (const chunk of chunks) {
       if (!chunk.usage) continue;
       if (chunk.usage.inputTokens !== undefined) {
-        inputTokens = chunk.usage.inputTokens;
+        result.inputTokens = chunk.usage.inputTokens;
       }
       if (chunk.usage.outputTokens !== undefined) {
-        outputTokens = chunk.usage.outputTokens;
+        result.outputTokens = chunk.usage.outputTokens;
+      }
+      if (chunk.usage.cacheReadInputTokens !== undefined) {
+        result.cacheReadInputTokens = chunk.usage.cacheReadInputTokens;
+      }
+      if (chunk.usage.cacheWriteInputTokens !== undefined) {
+        result.cacheWriteInputTokens = chunk.usage.cacheWriteInputTokens;
       }
     }
-
-    return inputTokens === undefined && outputTokens === undefined
-      ? undefined
-      : { inputTokens: inputTokens ?? 0, outputTokens: outputTokens ?? 0 };
+    return result;
   }
 }

--- a/ayunis-core-backend/src/domain/runs/application/services/streaming-inference.service.ts
+++ b/ayunis-core-backend/src/domain/runs/application/services/streaming-inference.service.ts
@@ -417,14 +417,20 @@ export class StreamingInferenceService {
     chunks: StreamInferenceResponseChunk[],
   ): { inputTokens: number; outputTokens: number } | undefined {
     const usage = this.lastWinsUsage(chunks);
-    if (usage.inputTokens === undefined && usage.outputTokens === undefined) {
-      return undefined;
-    }
+    const uncachedInputTokens = usage.inputTokens ?? 0;
     const cacheRead = usage.cacheReadInputTokens ?? 0;
     const cacheWrite = usage.cacheWriteInputTokens ?? 0;
-    if (cacheRead || cacheWrite) {
+    const hasCache = cacheRead > 0 || cacheWrite > 0;
+    if (
+      usage.inputTokens === undefined &&
+      usage.outputTokens === undefined &&
+      !hasCache
+    ) {
+      return undefined;
+    }
+    if (hasCache) {
       this.logger.debug('Prompt cache activity', {
-        uncachedInputTokens: usage.inputTokens ?? 0,
+        uncachedInputTokens,
         cacheReadInputTokens: cacheRead,
         cacheWriteInputTokens: cacheWrite,
       });
@@ -433,7 +439,7 @@ export class StreamingInferenceService {
     // inputTokens excludes tokens covered by the prompt cache, so without
     // this the billed input collapses to the uncached remainder (~3 tokens).
     return {
-      inputTokens: (usage.inputTokens ?? 0) + cacheRead + cacheWrite,
+      inputTokens: uncachedInputTokens + cacheRead + cacheWrite,
       outputTokens: usage.outputTokens ?? 0,
     };
   }

--- a/packages/inference/src/provider.ts
+++ b/packages/inference/src/provider.ts
@@ -6,8 +6,17 @@ export type ToolChoice = 'auto' | 'required' | { tool: string };
 export type FinishReason = 'stop' | 'length' | 'tool_calls' | null;
 
 export interface Usage {
+  /**
+   * Input tokens processed at the full rate. For providers with prompt
+   * caching (Anthropic, Bedrock) this EXCLUDES tokens covered by the cache —
+   * see the cache fields below for the remainder of the prompt.
+   */
   inputTokens?: number;
   outputTokens?: number;
+  /** Prompt tokens served from the provider's prompt cache. */
+  cacheReadInputTokens?: number;
+  /** Prompt tokens written to the provider's prompt cache. */
+  cacheWriteInputTokens?: number;
 }
 
 export interface ToolCallDelta {

--- a/packages/provider-anthropic/src/convert-chunk.spec.ts
+++ b/packages/provider-anthropic/src/convert-chunk.spec.ts
@@ -18,6 +18,29 @@ describe('convertChunk', () => {
     ).toEqual({ usage: { inputTokens: 123 } });
   });
 
+  it('passes prompt-cache token counts through message_start usage', () => {
+    expect(
+      convertChunk(
+        event({
+          type: 'message_start',
+          message: {
+            usage: {
+              input_tokens: 3,
+              cache_creation_input_tokens: 9677,
+              cache_read_input_tokens: 0,
+            },
+          },
+        }),
+      ),
+    ).toEqual({
+      usage: {
+        inputTokens: 3,
+        cacheWriteInputTokens: 9677,
+        cacheReadInputTokens: 0,
+      },
+    });
+  });
+
   it('converts text deltas', () => {
     expect(
       convertChunk(

--- a/packages/provider-anthropic/src/convert-chunk.ts
+++ b/packages/provider-anthropic/src/convert-chunk.ts
@@ -14,10 +14,22 @@ export const convertChunk = (
       return convertContentBlockDelta(event);
     case 'content_block_start':
       return convertContentBlockStart(event);
-    case 'message_start':
+    case 'message_start': {
+      // input_tokens excludes tokens covered by the prompt cache; the cache
+      // fields carry the rest of the prompt so hosts can account for it.
+      const usage = event.message.usage;
       return {
-        usage: { inputTokens: event.message.usage.input_tokens },
+        usage: {
+          inputTokens: usage.input_tokens,
+          ...(typeof usage.cache_read_input_tokens === 'number'
+            ? { cacheReadInputTokens: usage.cache_read_input_tokens }
+            : {}),
+          ...(typeof usage.cache_creation_input_tokens === 'number'
+            ? { cacheWriteInputTokens: usage.cache_creation_input_tokens }
+            : {}),
+        },
       };
+    }
     case 'message_delta':
       return {
         finishReason: mapStopReason(event.delta.stop_reason),


### PR DESCRIPTION
- Anthropic/Bedrock report input_tokens excluding tokens covered by the
  prompt cache, so with caching enabled billed input collapsed to the
  uncached remainder (~3 tokens per request)
- Pass cache_read/cache_creation token counts through the provider Usage
  type and sum them into billed inputTokens in both the streaming and
  non-streaming paths (Option A: customers pay as if uncached)
- Log prompt-cache activity at debug level so cache hits are visible in
  backend logs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how input tokens are computed for billing and usage guards; incorrect math would affect customer charges, though behavior is covered by new unit tests.
> 
> **Overview**
> Fixes **under-billing** when Anthropic/Bedrock prompt caching is on: provider `input_tokens` omits cache read/write, so billed input had collapsed to a tiny uncached remainder.
> 
> **Provider layer:** `Usage` and stream chunks gain `cacheReadInputTokens` / `cacheWriteInputTokens`; Anthropic `message_start` maps `cache_read_input_tokens` and `cache_creation_input_tokens` through.
> 
> **Billing (Option A — full prompt as input):** Streaming (`extractUsageFromChunks` + `InferenceUsageGuard`) and non-streaming (`response-accumulator` meta) now set billed `inputTokens` to uncached input plus cache read plus cache write, with last-wins per field unchanged. Debug logs record cache activity on the streaming path.
> 
> **Refactor:** Observable→async-iterable buffering moves to shared `observableToBufferedAsyncIterable`; `StreamingInferenceService` is split into smaller helpers without changing stream behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c27838408b36e338e52f1ef1866de5c810dc82b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->