### PR TITLE
fix(onboarding): keep first-step spotlight clear of frosted header and alert banner (AYC-417)

### DIFF
--- a/ayunis-core-frontend/src/widgets/app-alert-banner/ui/AppAlertBanner.tsx
+++ b/ayunis-core-frontend/src/widgets/app-alert-banner/ui/AppAlertBanner.tsx
@@ -16,6 +16,7 @@ export default function AppAlertBanner() {
   return (
     <div
       role="alert"
+      data-app-alert-banner
       className="relative grid w-full shrink-0 grid-cols-[calc(var(--spacing)*4)_1fr] items-center gap-x-3 rounded-none border border-x-0 border-t-0 bg-warning/10 px-4 py-2 text-sm text-warning backdrop-blur-md md:rounded-t-xl"
     >
       <TriangleAlert className="size-4" />

--- a/ayunis-core-frontend/src/widgets/onboarding/ui/TourRenderer.tsx
+++ b/ayunis-core-frontend/src/widgets/onboarding/ui/TourRenderer.tsx
@@ -20,6 +20,13 @@ import {
 const SPOTLIGHT_BORDER_COLOR = 'var(--brand)';
 const SPOTLIGHT_STROKE_WIDTH = 4;
 const SPOTLIGHT_PADDING = 0;
+const FROSTED_HEADER_SCROLL_OFFSET = 72;
+
+function measureScrollOffset(): number {
+  const banner = document.querySelector('[data-app-alert-banner]');
+  const bannerHeight = banner?.getBoundingClientRect().height ?? 0;
+  return FROSTED_HEADER_SCROLL_OFFSET + bannerHeight;
+}
 
 function readSpotlightRadius(target: string): number {
   const el = document.querySelector(`[data-tour="${target}"]`);
@@ -67,6 +74,7 @@ export default function TourRenderer({
   onEnd,
 }: Readonly<{ request: TourRequest; onEnd: () => void }>) {
   const [spotlightRadius, setSpotlightRadius] = useState(SPOTLIGHT_PADDING);
+  const [scrollOffset, setScrollOffset] = useState(measureScrollOffset);
   const isTargetReady = useStableTarget(request.target);
 
   // Dismiss the tour when the user clicks the highlighted target. react-joyride
@@ -122,6 +130,7 @@ export default function TourRenderer({
       targetWaitTimeout: 3000,
       zIndex: 10000,
       closeButtonAction: 'skip',
+      scrollOffset,
     },
     styles: {
       spotlight: {
@@ -134,6 +143,7 @@ export default function TourRenderer({
     onEvent: (data: EventData) => {
       if (data.type === EVENTS.STEP_BEFORE) {
         setSpotlightRadius(readSpotlightRadius(request.target));
+        setScrollOffset(measureScrollOffset());
       }
       if (
         data.type === EVENTS.TOUR_END ||


### PR DESCRIPTION
## Problem

The first onboarding tour step ("Modelle konfigurieren") highlights the tall language-models card on `/admin-settings/models`. react-joyride scrolled the target with its default `scrollOffset` (20px), so the card's top landed **under** the absolutely-positioned frosted content header (`.content-scroll-header`, `z-10`). Since joyride's overlay uses `z-index: 10000`, the spotlight cutout was drawn **over** the header.

With the app alert banner enabled, the content is pushed down further, so a slight overlap remained even with a fixed offset.

Only the first step was affected — the other steps target small controls that don't get scrolled under the header.

## Fix

Set joyride `scrollOffset` to the frosted header height (72px) **plus the measured app-alert-banner height**, so the highlighted target always clears both the header and the banner regardless of banner text length.

- `TourRenderer.tsx` — `scrollOffset` = 72 + measured banner height
- `AppAlertBanner.tsx` — added `data-app-alert-banner` as a stable measurement selector

## Testing

- With and without the app alert banner active → first-step spotlight now sits fully below the frosted header
- Other tour steps unchanged

Closes AYC-417

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI-only onboarding scroll/spotlight tweak with no auth, data, or API changes.
> 
> **Overview**
> Fixes onboarding tour scroll positioning so tall first-step targets (e.g. the models card) are not scrolled under the frosted content header or the app alert banner.
> 
> **`AppAlertBanner`** now exposes `data-app-alert-banner` so height can be measured in the DOM.
> 
> **`TourRenderer`** computes react-joyride `scrollOffset` as a fixed **72px** frosted-header allowance plus the live banner height from `measureScrollOffset()`, passes it into joyride options, and **re-measures on each `STEP_BEFORE`** so banner on/off or text changes stay correct.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e369565e77c73a4a0baf79577e941f5b3b96528d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->