### PR TITLE
wip(models): extract use case logger base class (AYC-000)

### DIFF
--- a/ayunis-core-backend/src/common/use-case/base-use-case.spec.ts
+++ b/ayunis-core-backend/src/common/use-case/base-use-case.spec.ts
@@ -1,0 +1,11 @@
+import { BaseUseCase } from './base-use-case';
+
+class ExampleUseCase extends BaseUseCase {}
+
+describe('BaseUseCase', () => {
+  it('uses the subclass name as the logger context', () => {
+    const useCase = new ExampleUseCase();
+
+    expect((useCase as any).logger.context).toBe(ExampleUseCase.name);
+  });
+});

--- a/ayunis-core-backend/src/common/use-case/base-use-case.ts
+++ b/ayunis-core-backend/src/common/use-case/base-use-case.ts
@@ -1,0 +1,5 @@
+import { Logger } from '@nestjs/common';
+
+export abstract class BaseUseCase {
+  protected readonly logger = new Logger(this.constructor.name);
+}

--- a/ayunis-core-backend/src/domain/models/application/use-cases/clear-defaults-by-catalog-model-id/clear-defaults-by-catalog-model-id.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/clear-defaults-by-catalog-model-id/clear-defaults-by-catalog-model-id.use-case.ts
@@ -1,18 +1,17 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { BaseUseCase } from 'src/common/use-case/base-use-case';
 import { ClearDefaultsByCatalogModelIdCommand } from './clear-defaults-by-catalog-model-id.command';
 import { PermittedModelsRepository } from '../../ports/permitted-models.repository';
 import { UserDefaultModelsRepository } from '../../ports/user-default-models.repository';
 
 @Injectable()
-export class ClearDefaultsByCatalogModelIdUseCase {
-  private readonly logger = new Logger(
-    ClearDefaultsByCatalogModelIdUseCase.name,
-  );
-
+export class ClearDefaultsByCatalogModelIdUseCase extends BaseUseCase {
   constructor(
     private readonly permittedModelsRepository: PermittedModelsRepository,
     private readonly userDefaultModelsRepository: UserDefaultModelsRepository,
-  ) {}
+  ) {
+    super();
+  }
 
   async execute(command: ClearDefaultsByCatalogModelIdCommand): Promise<void> {
     this.logger.log('Clearing defaults for archived catalog model', {

--- a/ayunis-core-backend/src/domain/models/application/use-cases/create-embedding-model/create-embedding-model.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/create-embedding-model/create-embedding-model.use-case.ts
@@ -7,13 +7,14 @@ import {
   UnexpectedModelError,
 } from '../../models.errors';
 import { ApplicationError } from 'src/common/errors/base.error';
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { BaseUseCase } from 'src/common/use-case/base-use-case';
 
 @Injectable()
-export class CreateEmbeddingModelUseCase {
-  private readonly logger = new Logger(CreateEmbeddingModelUseCase.name);
-
-  constructor(private readonly modelsRepository: ModelsRepository) {}
+export class CreateEmbeddingModelUseCase extends BaseUseCase {
+  constructor(private readonly modelsRepository: ModelsRepository) {
+    super();
+  }
 
   async execute(command: CreateEmbeddingModelCommand): Promise<EmbeddingModel> {
     this.logger.log('Creating embedding model', {

--- a/ayunis-core-backend/src/domain/models/application/use-cases/create-image-generation-model/create-image-generation-model.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/create-image-generation-model/create-image-generation-model.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { BaseUseCase } from 'src/common/use-case/base-use-case';
 import { ApplicationError } from 'src/common/errors/base.error';
 import { ImageGenerationModel } from 'src/domain/models/domain/models/image-generation.model';
 import { ModelsRepository } from '../../ports/models.repository';
@@ -10,13 +11,13 @@ import { ModelPolicyService } from '../../services/model-policy.service';
 import { CreateImageGenerationModelCommand } from './create-image-generation-model.command';
 
 @Injectable()
-export class CreateImageGenerationModelUseCase {
-  private readonly logger = new Logger(CreateImageGenerationModelUseCase.name);
-
+export class CreateImageGenerationModelUseCase extends BaseUseCase {
   constructor(
     private readonly modelsRepository: ModelsRepository,
     private readonly modelPolicy: ModelPolicyService,
-  ) {}
+  ) {
+    super();
+  }
 
   async execute(
     command: CreateImageGenerationModelCommand,

--- a/ayunis-core-backend/src/domain/models/application/use-cases/create-permitted-model/create-permitted-model.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/create-permitted-model/create-permitted-model.use-case.ts
@@ -2,7 +2,8 @@ import { PermittedModel } from 'src/domain/models/domain/permitted-model.entity'
 import { PermittedModelsRepository } from '../../ports/permitted-models.repository';
 import { ModelsRepository } from '../../ports/models.repository';
 import { CreatePermittedModelCommand } from './create-permitted-model.command';
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { BaseUseCase } from 'src/common/use-case/base-use-case';
 import { ApplicationError } from 'src/common/errors/base.error';
 import { ContextService } from 'src/common/context/services/context.service';
 import { UserRole } from 'src/iam/users/domain/value-objects/role.object';
@@ -12,14 +13,15 @@ import { ModelNotFoundError, UnexpectedModelError } from '../../models.errors';
 import { ModelPolicyService } from '../../services/model-policy.service';
 
 @Injectable()
-export class CreatePermittedModelUseCase {
-  private readonly logger = new Logger(CreatePermittedModelUseCase.name);
+export class CreatePermittedModelUseCase extends BaseUseCase {
   constructor(
     private readonly permittedModelsRepository: PermittedModelsRepository,
     private readonly modelsRepository: ModelsRepository,
     private readonly contextService: ContextService,
     private readonly modelPolicy: ModelPolicyService,
-  ) {}
+  ) {
+    super();
+  }
 
   async execute(command: CreatePermittedModelCommand): Promise<PermittedModel> {
     this.logger.log('execute', {

--- a/ayunis-core-backend/src/domain/models/application/use-cases/create-team-permitted-model/create-team-permitted-model.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/create-team-permitted-model/create-team-permitted-model.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { BaseUseCase } from 'src/common/use-case/base-use-case';
 import { PermittedModelsRepository } from '../../ports/permitted-models.repository';
 import { ModelsRepository } from '../../ports/models.repository';
 import { CreateTeamPermittedModelCommand } from './create-team-permitted-model.command';
@@ -15,14 +16,14 @@ import { TeamPermittedModelValidator } from '../../services/team-permitted-model
 import { LanguageModel } from 'src/domain/models/domain/models/language.model';
 
 @Injectable()
-export class CreateTeamPermittedModelUseCase {
-  private readonly logger = new Logger(CreateTeamPermittedModelUseCase.name);
-
+export class CreateTeamPermittedModelUseCase extends BaseUseCase {
   constructor(
     private readonly permittedModelsRepository: PermittedModelsRepository,
     private readonly modelsRepository: ModelsRepository,
     private readonly validator: TeamPermittedModelValidator,
-  ) {}
+  ) {
+    super();
+  }
 
   async execute(
     command: CreateTeamPermittedModelCommand,

--- a/ayunis-core-backend/src/domain/models/application/use-cases/delete-model/delete-model.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/delete-model/delete-model.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { BaseUseCase } from 'src/common/use-case/base-use-case';
 import { ModelsRepository } from '../../ports/models.repository';
 import { DeleteModelCommand } from './delete-model.command';
 import {
@@ -12,15 +13,15 @@ import { DeletePermittedModelCommand } from '../delete-permitted-model/delete-pe
 import { FindAllOrgIdsUseCase } from 'src/iam/orgs/application/use-cases/find-all-org-ids/find-all-org-ids.use-case';
 
 @Injectable()
-export class DeleteModelUseCase {
-  private readonly logger = new Logger(DeleteModelUseCase.name);
-
+export class DeleteModelUseCase extends BaseUseCase {
   constructor(
     private readonly modelsRepository: ModelsRepository,
     private readonly findAllOrgIdsUseCase: FindAllOrgIdsUseCase,
     private readonly getPermittedModelsUseCase: GetPermittedModelsUseCase,
     private readonly deletePermittedModelUseCase: DeletePermittedModelUseCase,
-  ) {}
+  ) {
+    super();
+  }
 
   async execute(command: DeleteModelCommand): Promise<void> {
     this.logger.log('execute', {

--- a/ayunis-core-backend/src/domain/models/application/use-cases/delete-permitted-model/delete-permitted-model.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/delete-permitted-model/delete-permitted-model.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { BaseUseCase } from 'src/common/use-case/base-use-case';
 import { DeletePermittedModelCommand } from './delete-permitted-model.command';
 import { PermittedModelsRepository } from '../../ports/permitted-models.repository';
 import {
@@ -31,9 +32,8 @@ import { UserRole } from 'src/iam/users/domain/value-objects/role.object';
 import { SystemRole } from 'src/iam/users/domain/value-objects/system-role.enum';
 
 @Injectable()
-export class DeletePermittedModelUseCase {
-  private readonly logger = new Logger(DeletePermittedModelUseCase.name);
-
+export class DeletePermittedModelUseCase extends BaseUseCase {
+  // eslint-disable-next-line max-params -- deletion flow orchestrates multiple collaborators
   constructor(
     private readonly permittedModelsRepository: PermittedModelsRepository,
     private readonly deleteUserDefaultModelByModelIdUseCase: DeleteUserDefaultModelsByModelIdUseCase,
@@ -42,7 +42,9 @@ export class DeletePermittedModelUseCase {
     private readonly findAllThreadsByOrgWithSourcesUseCase: FindAllThreadsByOrgWithSourcesUseCase,
     private readonly deleteSourcesUseCase: DeleteSourcesUseCase,
     private readonly contextService: ContextService,
-  ) {}
+  ) {
+    super();
+  }
 
   @Transactional()
   async execute(command: DeletePermittedModelCommand): Promise<void> {
@@ -51,53 +53,10 @@ export class DeletePermittedModelUseCase {
       orgId: command.orgId,
     });
     try {
-      const orgId = this.contextService.get('orgId');
-      const orgRole = this.contextService.get('role');
-      const systemRole = this.contextService.get('systemRole');
-      const isOrgAdmin = orgRole === UserRole.ADMIN && orgId === command.orgId;
-      const isSuperAdmin = systemRole === SystemRole.SUPER_ADMIN;
-      if (!isOrgAdmin && !isSuperAdmin) {
-        throw new UnauthorizedAccessError();
-      }
-      const model = await this.permittedModelsRepository.findOne({
-        id: command.permittedModelId,
-      });
-      if (!model) {
-        this.logger.error('Model not found', {
-          modelId: command.permittedModelId,
-          orgId: command.orgId,
-        });
-        throw new PermittedModelDeletionFailedError('Model not found', {
-          modelId: command.permittedModelId,
-        });
-      }
+      this.ensureAuthorized(command.orgId);
+      const model = await this.findDeletableModel(command);
 
-      // Verify the model belongs to the specified org
-      if (model.orgId !== command.orgId) {
-        throw new UnauthorizedAccessError();
-      }
-
-      if (model instanceof PermittedLanguageModel) {
-        return this.deletePermittedLanguageModel(command.orgId, model);
-      } else if (model instanceof PermittedEmbeddingModel) {
-        return this.deletePermittedEmbeddingModel(command.orgId, model);
-      } else if (model instanceof PermittedImageGenerationModel) {
-        return this.deletePermittedImageGenerationModel(command.orgId, model);
-      } else {
-        this.logger.error(
-          'Model is not a language, embedding, or image-generation model',
-          {
-            modelId: command.permittedModelId,
-            orgId: command.orgId,
-          },
-        );
-        throw new PermittedModelDeletionFailedError(
-          'Model is not a language, embedding, or image-generation model',
-          {
-            modelId: command.permittedModelId,
-          },
-        );
-      }
+      return await this.deleteModelByType(command.orgId, model);
     } catch (error) {
       if (error instanceof ApplicationError) {
         throw error;
@@ -107,6 +66,82 @@ export class DeletePermittedModelUseCase {
         error instanceof Error ? error : new Error('Unknown error'),
       );
     }
+  }
+
+  private ensureAuthorized(orgId: UUID): void {
+    const currentOrgId = this.contextService.get('orgId');
+    const orgRole = this.contextService.get('role');
+    const systemRole = this.contextService.get('systemRole');
+    const isOrgAdmin = orgRole === UserRole.ADMIN && currentOrgId === orgId;
+    const isSuperAdmin = systemRole === SystemRole.SUPER_ADMIN;
+
+    if (!isOrgAdmin && !isSuperAdmin) {
+      throw new UnauthorizedAccessError();
+    }
+  }
+
+  private async findDeletableModel(
+    command: DeletePermittedModelCommand,
+  ): Promise<
+    | PermittedLanguageModel
+    | PermittedEmbeddingModel
+    | PermittedImageGenerationModel
+  > {
+    const model = await this.permittedModelsRepository.findOne({
+      id: command.permittedModelId,
+    });
+    if (!model) {
+      this.logger.error('Model not found', {
+        modelId: command.permittedModelId,
+        orgId: command.orgId,
+      });
+      throw new PermittedModelDeletionFailedError('Model not found', {
+        modelId: command.permittedModelId,
+      });
+    }
+
+    if (model.orgId !== command.orgId) {
+      throw new UnauthorizedAccessError();
+    }
+
+    if (
+      model instanceof PermittedLanguageModel ||
+      model instanceof PermittedEmbeddingModel ||
+      model instanceof PermittedImageGenerationModel
+    ) {
+      return model;
+    }
+
+    this.logger.error(
+      'Model is not a language, embedding, or image-generation model',
+      {
+        modelId: command.permittedModelId,
+        orgId: command.orgId,
+      },
+    );
+    throw new PermittedModelDeletionFailedError(
+      'Model is not a language, embedding, or image-generation model',
+      {
+        modelId: command.permittedModelId,
+      },
+    );
+  }
+
+  private async deleteModelByType(
+    orgId: UUID,
+    model:
+      | PermittedLanguageModel
+      | PermittedEmbeddingModel
+      | PermittedImageGenerationModel,
+  ): Promise<void> {
+    if (model instanceof PermittedLanguageModel) {
+      return await this.deletePermittedLanguageModel(orgId, model);
+    }
+    if (model instanceof PermittedEmbeddingModel) {
+      return await this.deletePermittedEmbeddingModel(orgId, model);
+    }
+
+    return await this.deletePermittedImageGenerationModel(orgId, model);
   }
 
   private async deletePermittedLanguageModel(

--- a/ayunis-core-backend/src/domain/models/application/use-cases/delete-team-permitted-model/delete-team-permitted-model.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/delete-team-permitted-model/delete-team-permitted-model.use-case.ts
@@ -1,18 +1,19 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { PermittedModelsRepository } from '../../ports/permitted-models.repository';
 import { DeleteTeamPermittedModelCommand } from './delete-team-permitted-model.command';
 import { ApplicationError } from 'src/common/errors/base.error';
 import { UnexpectedModelError } from '../../models.errors';
 import { TeamPermittedModelValidator } from '../../services/team-permitted-model-validator.service';
+import { BaseUseCase } from 'src/common/use-case/base-use-case';
 
 @Injectable()
-export class DeleteTeamPermittedModelUseCase {
-  private readonly logger = new Logger(DeleteTeamPermittedModelUseCase.name);
-
+export class DeleteTeamPermittedModelUseCase extends BaseUseCase {
   constructor(
     private readonly permittedModelsRepository: PermittedModelsRepository,
     private readonly validator: TeamPermittedModelValidator,
-  ) {}
+  ) {
+    super();
+  }
 
   async execute(command: DeleteTeamPermittedModelCommand): Promise<void> {
     this.logger.log('execute', {

--- a/ayunis-core-backend/src/domain/models/application/use-cases/delete-user-default-model/delete-user-default-model.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/delete-user-default-model/delete-user-default-model.use-case.ts
@@ -1,15 +1,16 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { BaseUseCase } from 'src/common/use-case/base-use-case';
 import { DeleteUserDefaultModelCommand } from './delete-user-default-model.command';
 import { UserDefaultModelsRepository } from '../../ports/user-default-models.repository';
 import { ModelError } from '../../models.errors';
 
 @Injectable()
-export class DeleteUserDefaultModelUseCase {
-  private readonly logger = new Logger(DeleteUserDefaultModelUseCase.name);
-
+export class DeleteUserDefaultModelUseCase extends BaseUseCase {
   constructor(
     private readonly userDefaultModelsRepository: UserDefaultModelsRepository,
-  ) {}
+  ) {
+    super();
+  }
 
   async execute(command: DeleteUserDefaultModelCommand): Promise<void> {
     this.logger.log('execute', {

--- a/ayunis-core-backend/src/domain/models/application/use-cases/delete-user-default-models-by-model-id/delete-user-default-models-by-model-id.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/delete-user-default-models-by-model-id/delete-user-default-models-by-model-id.use-case.ts
@@ -1,16 +1,15 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { BaseUseCase } from 'src/common/use-case/base-use-case';
 import { UserDefaultModelsRepository } from '../../ports/user-default-models.repository';
 import { DeleteUserDefaultModelsByModelIdCommand } from './delete-user-default-models-by-model-id.command';
 
 @Injectable()
-export class DeleteUserDefaultModelsByModelIdUseCase {
-  private readonly logger = new Logger(
-    DeleteUserDefaultModelsByModelIdUseCase.name,
-  );
-
+export class DeleteUserDefaultModelsByModelIdUseCase extends BaseUseCase {
   constructor(
     private readonly userDefaultModelsRepository: UserDefaultModelsRepository,
-  ) {}
+  ) {
+    super();
+  }
 
   async execute(
     command: DeleteUserDefaultModelsByModelIdCommand,

--- a/ayunis-core-backend/src/domain/models/application/use-cases/generate-image/generate-image.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/generate-image/generate-image.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { BaseUseCase } from 'src/common/use-case/base-use-case';
 import { ApplicationError } from 'src/common/errors/base.error';
 import { ImageGenerationHandlerRegistry } from '../../registry/image-generation-handler.registry';
 import {
@@ -9,12 +10,12 @@ import { ImageGenerationFailedError } from '../../models.errors';
 import { GenerateImageCommand } from './generate-image.command';
 
 @Injectable()
-export class GenerateImageUseCase {
-  private readonly logger = new Logger(GenerateImageUseCase.name);
-
+export class GenerateImageUseCase extends BaseUseCase {
   constructor(
     private readonly imageGenerationHandlerRegistry: ImageGenerationHandlerRegistry,
-  ) {}
+  ) {
+    super();
+  }
 
   async execute(command: GenerateImageCommand): Promise<ImageGenerationResult> {
     this.logger.log('execute', {

--- a/ayunis-core-backend/src/domain/models/application/use-cases/get-all-models/get-all-models.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/get-all-models/get-all-models.use-case.ts
@@ -1,12 +1,13 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { BaseUseCase } from 'src/common/use-case/base-use-case';
 import { ModelsRepository } from '../../ports/models.repository';
 import { Model } from 'src/domain/models/domain/model.entity';
 
 @Injectable()
-export class GetAllModelsUseCase {
-  private readonly logger = new Logger(GetAllModelsUseCase.name);
-
-  constructor(private readonly modelsRepository: ModelsRepository) {}
+export class GetAllModelsUseCase extends BaseUseCase {
+  constructor(private readonly modelsRepository: ModelsRepository) {
+    super();
+  }
 
   async execute(): Promise<Model[]> {
     this.logger.log('execute');

--- a/ayunis-core-backend/src/domain/models/application/use-cases/get-configured-models-by-type/get-configured-models-by-type.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/get-configured-models-by-type/get-configured-models-by-type.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { BaseUseCase } from 'src/common/use-case/base-use-case';
 import { ConfigService } from '@nestjs/config';
 import { ContextService } from 'src/common/context/services/context.service';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
@@ -11,15 +12,15 @@ import { ModelProviderInfoRegistry } from '../../registry/model-provider-info.re
 import { GetConfiguredModelsByTypeQuery } from './get-configured-models-by-type.query';
 
 @Injectable()
-export class GetConfiguredModelsByTypeUseCase {
-  private readonly logger = new Logger(GetConfiguredModelsByTypeUseCase.name);
-
+export class GetConfiguredModelsByTypeUseCase extends BaseUseCase {
   constructor(
     private readonly modelsRepository: ModelsRepository,
     private readonly contextService: ContextService,
     private readonly configService: ConfigService,
     private readonly modelProviderInfoRegistry: ModelProviderInfoRegistry,
-  ) {}
+  ) {
+    super();
+  }
 
   async execute(query: GetConfiguredModelsByTypeQuery): Promise<Model[]> {
     const orgRole = this.contextService.get('role');

--- a/ayunis-core-backend/src/domain/models/application/use-cases/get-default-model/get-default-model.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/get-default-model/get-default-model.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { BaseUseCase } from 'src/common/use-case/base-use-case';
 import type { UUID } from 'crypto';
 import { GetDefaultModelQuery } from './get-default-model.query';
 import { PermittedLanguageModel } from 'src/domain/models/domain/permitted-model.entity';
@@ -9,14 +10,14 @@ import { GetEffectiveLanguageModelsQuery } from '../get-effective-language-model
 import { DefaultModelNotFoundError, ModelError } from '../../models.errors';
 
 @Injectable()
-export class GetDefaultModelUseCase {
-  private readonly logger = new Logger(GetDefaultModelUseCase.name);
-
+export class GetDefaultModelUseCase extends BaseUseCase {
   constructor(
     private readonly permittedModelsRepository: PermittedModelsRepository,
     private readonly userDefaultModelsRepository: UserDefaultModelsRepository,
     private readonly getEffectiveLanguageModelsUseCase: GetEffectiveLanguageModelsUseCase,
-  ) {}
+  ) {
+    super();
+  }
 
   async execute(query: GetDefaultModelQuery): Promise<PermittedLanguageModel> {
     this.logger.log('execute', { query });
@@ -33,65 +34,13 @@ export class GetDefaultModelUseCase {
         effectiveModelIds.has(model.model.id) &&
         !query.blacklistedModelIds?.includes(model.model.id);
 
-      // Step 1: User default
-      if (query.userId) {
-        const userDefault = await this.userDefaultModelsRepository.findByUserId(
-          query.userId,
-        );
-
-        if (userDefault && isInEffectiveSet(userDefault)) {
-          this.logger.debug('Using user default model', {
-            userId: query.userId,
-            modelId: userDefault.id,
-          });
-          return userDefault;
-        }
-      }
-
-      // Step 2: Team defaults (from override teams)
-      if (query.userId && overrideTeamIds.length > 0) {
-        const teamDefault = await this.resolveTeamDefault(
-          overrideTeamIds,
-          query.orgId,
-          effectiveModelIds,
-          query.blacklistedModelIds,
-        );
-        if (teamDefault) {
-          this.logger.debug('Using team default model', {
-            modelId: teamDefault.id,
-          });
-          return teamDefault;
-        }
-      }
-
-      // Step 3: Org default
-      const orgDefault =
-        await this.permittedModelsRepository.findOrgDefaultLanguage(
-          query.orgId,
-        );
-      if (orgDefault && isInEffectiveSet(orgDefault)) {
-        this.logger.debug('Using org default model', {
-          orgId: query.orgId,
-          modelId: orgDefault.id,
-        });
-        return orgDefault;
-      }
-
-      // Step 4: First available from effective set, alphabetically
-      const sorted = [...effectiveModels].sort((a, b) =>
-        a.model.name.localeCompare(b.model.name),
+      return await this.resolveDefaultModel(
+        query,
+        overrideTeamIds,
+        effectiveModels,
+        effectiveModelIds,
+        isInEffectiveSet,
       );
-
-      for (const model of sorted) {
-        if (!query.blacklistedModelIds?.includes(model.model.id)) {
-          this.logger.debug('Using first available model alphabetically', {
-            modelId: model.id,
-          });
-          return model;
-        }
-      }
-
-      throw new DefaultModelNotFoundError(query.orgId);
     } catch (error) {
       if (error instanceof ModelError) {
         throw error;
@@ -103,6 +52,119 @@ export class GetDefaultModelUseCase {
       });
       throw error;
     }
+  }
+
+  private async resolveDefaultModel(
+    query: GetDefaultModelQuery,
+    overrideTeamIds: UUID[],
+    effectiveModels: PermittedLanguageModel[],
+    effectiveModelIds: Set<UUID>,
+    isInEffectiveSet: (model: PermittedLanguageModel) => boolean,
+  ): Promise<PermittedLanguageModel> {
+    const userDefault = await this.findUserDefault(query, isInEffectiveSet);
+    if (userDefault) {
+      return userDefault;
+    }
+
+    const teamDefault = await this.findTeamDefault(
+      query,
+      overrideTeamIds,
+      effectiveModelIds,
+    );
+    if (teamDefault) {
+      return teamDefault;
+    }
+
+    const orgDefault = await this.findOrgDefault(query.orgId, isInEffectiveSet);
+    if (orgDefault) {
+      return orgDefault;
+    }
+
+    return this.findFirstAvailableModel(query, effectiveModels);
+  }
+
+  private async findUserDefault(
+    query: GetDefaultModelQuery,
+    isInEffectiveSet: (model: PermittedLanguageModel) => boolean,
+  ): Promise<PermittedLanguageModel | null> {
+    if (!query.userId) {
+      return null;
+    }
+
+    const userDefault = await this.userDefaultModelsRepository.findByUserId(
+      query.userId,
+    );
+    if (!userDefault || !isInEffectiveSet(userDefault)) {
+      return null;
+    }
+
+    this.logger.debug('Using user default model', {
+      userId: query.userId,
+      modelId: userDefault.id,
+    });
+    return userDefault;
+  }
+
+  private async findTeamDefault(
+    query: GetDefaultModelQuery,
+    overrideTeamIds: UUID[],
+    effectiveModelIds: Set<UUID>,
+  ): Promise<PermittedLanguageModel | null> {
+    if (!query.userId || overrideTeamIds.length === 0) {
+      return null;
+    }
+
+    const teamDefault = await this.resolveTeamDefault(
+      overrideTeamIds,
+      query.orgId,
+      effectiveModelIds,
+      query.blacklistedModelIds,
+    );
+    if (!teamDefault) {
+      return null;
+    }
+
+    this.logger.debug('Using team default model', {
+      modelId: teamDefault.id,
+    });
+    return teamDefault;
+  }
+
+  private async findOrgDefault(
+    orgId: UUID,
+    isInEffectiveSet: (model: PermittedLanguageModel) => boolean,
+  ): Promise<PermittedLanguageModel | null> {
+    const orgDefault =
+      await this.permittedModelsRepository.findOrgDefaultLanguage(orgId);
+    if (!orgDefault || !isInEffectiveSet(orgDefault)) {
+      return null;
+    }
+
+    this.logger.debug('Using org default model', {
+      orgId,
+      modelId: orgDefault.id,
+    });
+    return orgDefault;
+  }
+
+  private findFirstAvailableModel(
+    query: GetDefaultModelQuery,
+    effectiveModels: PermittedLanguageModel[],
+  ): PermittedLanguageModel {
+    const model = [...effectiveModels]
+      .sort((a, b) => a.model.name.localeCompare(b.model.name))
+      .find(
+        (candidate) => !query.blacklistedModelIds?.includes(candidate.model.id),
+      );
+
+    if (!model) {
+      throw new DefaultModelNotFoundError(query.orgId);
+    }
+
+    this.logger.debug('Using first available model alphabetically', {
+      modelId: model.id,
+    });
+    return model;
   }
 
   private async resolveTeamDefault(

--- a/ayunis-core-backend/src/domain/models/application/use-cases/get-effective-language-models/get-effective-language-models.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/get-effective-language-models/get-effective-language-models.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { BaseUseCase } from 'src/common/use-case/base-use-case';
 import type { UUID } from 'crypto';
 import { ApplicationError } from 'src/common/errors/base.error';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
@@ -13,14 +14,14 @@ import { SystemRole } from 'src/iam/users/domain/value-objects/system-role.enum'
 import type { EffectiveLanguageModelsResult } from './effective-language-models-result';
 
 @Injectable()
-export class GetEffectiveLanguageModelsUseCase {
-  private readonly logger = new Logger(GetEffectiveLanguageModelsUseCase.name);
-
+export class GetEffectiveLanguageModelsUseCase extends BaseUseCase {
   constructor(
     private readonly permittedModelsRepository: PermittedModelsRepository,
     private readonly findTeamsByUserIdUseCase: FindTeamsByUserIdUseCase,
     private readonly contextService: ContextService,
-  ) {}
+  ) {
+    super();
+  }
 
   async execute(
     query: GetEffectiveLanguageModelsQuery,

--- a/ayunis-core-backend/src/domain/models/application/use-cases/get-inference/get-inference.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/get-inference/get-inference.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger, UnauthorizedException } from '@nestjs/common';
+import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { BaseUseCase } from 'src/common/use-case/base-use-case';
 import { GetInferenceCommand } from './get-inference.command';
 import { InferenceHandlerRegistry } from '../../registry/inference-handler.registry';
 import {
@@ -11,13 +12,13 @@ import { ContextService } from 'src/common/context/services/context.service';
 import { extractUpstreamStatus } from '../../helpers/extract-upstream-status.helper';
 
 @Injectable()
-export class GetInferenceUseCase {
-  private readonly logger = new Logger(GetInferenceUseCase.name);
-
+export class GetInferenceUseCase extends BaseUseCase {
   constructor(
     private readonly inferenceHandlerRegistry: InferenceHandlerRegistry,
     private readonly contextService: ContextService,
-  ) {}
+  ) {
+    super();
+  }
 
   async execute(command: GetInferenceCommand): Promise<InferenceResponse> {
     this.logger.log('triggerInference', {

--- a/ayunis-core-backend/src/domain/models/application/use-cases/get-model-by-id/get-model-by-id.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/get-model-by-id/get-model-by-id.use-case.ts
@@ -1,14 +1,15 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { BaseUseCase } from 'src/common/use-case/base-use-case';
 import { Model } from 'src/domain/models/domain/model.entity';
 import { ModelsRepository } from '../../ports/models.repository';
 import { GetModelByIdQuery } from './get-model-by-id.query';
 import { ModelNotFoundByIdError } from '../../models.errors';
 
 @Injectable()
-export class GetModelByIdUseCase {
-  private readonly logger = new Logger(GetModelByIdUseCase.name);
-
-  constructor(private readonly modelsRepository: ModelsRepository) {}
+export class GetModelByIdUseCase extends BaseUseCase {
+  constructor(private readonly modelsRepository: ModelsRepository) {
+    super();
+  }
 
   async execute(query: GetModelByIdQuery): Promise<Model> {
     this.logger.log('execute', { id: query.id });

--- a/ayunis-core-backend/src/domain/models/application/use-cases/get-model/get-model.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/get-model/get-model.use-case.ts
@@ -1,14 +1,15 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { BaseUseCase } from 'src/common/use-case/base-use-case';
 import { Model } from 'src/domain/models/domain/model.entity';
 import { ModelsRepository } from '../../ports/models.repository';
 import { GetModelQuery } from './get-model.query';
 import { ModelNotFoundByNameAndProviderError } from '../../models.errors';
 
 @Injectable()
-export class GetModelUseCase {
-  private readonly logger = new Logger(GetModelUseCase.name);
-
-  constructor(private readonly modelsRepository: ModelsRepository) {}
+export class GetModelUseCase extends BaseUseCase {
+  constructor(private readonly modelsRepository: ModelsRepository) {
+    super();
+  }
 
   async execute(query: GetModelQuery): Promise<Model> {
     this.logger.log('execute', query);

--- a/ayunis-core-backend/src/domain/models/application/use-cases/get-org-default-model/get-org-default-model.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/get-org-default-model/get-org-default-model.use-case.ts
@@ -1,16 +1,17 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { BaseUseCase } from 'src/common/use-case/base-use-case';
 import { GetOrgDefaultModelQuery } from './get-org-default-model.query';
 import { PermittedLanguageModel } from '../../../domain/permitted-model.entity';
 import { PermittedModelsRepository } from '../../ports/permitted-models.repository';
 import { ModelError } from '../../models.errors';
 
 @Injectable()
-export class GetOrgDefaultModelUseCase {
-  private readonly logger = new Logger(GetOrgDefaultModelUseCase.name);
-
+export class GetOrgDefaultModelUseCase extends BaseUseCase {
   constructor(
     private readonly permittedModelsRepository: PermittedModelsRepository,
-  ) {}
+  ) {
+    super();
+  }
 
   async execute(
     query: GetOrgDefaultModelQuery,
@@ -39,7 +40,7 @@ export class GetOrgDefaultModelUseCase {
         });
       }
 
-      return orgDefaultModel || null;
+      return orgDefaultModel ?? null;
     } catch (error) {
       if (error instanceof ModelError) {
         throw error;

--- a/ayunis-core-backend/src/domain/models/application/use-cases/get-permitted-embedding-model/get-permitted-embedding-model.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/get-permitted-embedding-model/get-permitted-embedding-model.use-case.ts
@@ -6,19 +6,20 @@ import {
   UnexpectedModelError,
 } from '../../models.errors';
 import { ApplicationError } from 'src/common/errors/base.error';
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { BaseUseCase } from 'src/common/use-case/base-use-case';
 import { ContextService } from 'src/common/context/services/context.service';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
 import { SystemRole } from 'src/iam/users/domain/value-objects/system-role.enum';
 
 @Injectable()
-export class GetPermittedEmbeddingModelUseCase {
-  private readonly logger = new Logger(GetPermittedEmbeddingModelUseCase.name);
-
+export class GetPermittedEmbeddingModelUseCase extends BaseUseCase {
   constructor(
     private readonly permittedModelsRepository: PermittedModelsRepository,
     private readonly contextService: ContextService,
-  ) {}
+  ) {
+    super();
+  }
 
   async execute(
     query: GetPermittedEmbeddingModelQuery,

--- a/ayunis-core-backend/src/domain/models/application/use-cases/get-permitted-image-generation-model/get-permitted-image-generation-model.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/get-permitted-image-generation-model/get-permitted-image-generation-model.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { BaseUseCase } from 'src/common/use-case/base-use-case';
 import { ApplicationError } from 'src/common/errors/base.error';
 import { ContextService } from 'src/common/context/services/context.service';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
@@ -13,16 +14,14 @@ import { ModelPolicyService } from '../../services/model-policy.service';
 import { GetPermittedImageGenerationModelQuery } from './get-permitted-image-generation-model.query';
 
 @Injectable()
-export class GetPermittedImageGenerationModelUseCase {
-  private readonly logger = new Logger(
-    GetPermittedImageGenerationModelUseCase.name,
-  );
-
+export class GetPermittedImageGenerationModelUseCase extends BaseUseCase {
   constructor(
     private readonly permittedModelsRepository: PermittedModelsRepository,
     private readonly contextService: ContextService,
     private readonly modelPolicy: ModelPolicyService,
-  ) {}
+  ) {
+    super();
+  }
 
   async execute(
     query: GetPermittedImageGenerationModelQuery,

--- a/ayunis-core-backend/src/domain/models/application/use-cases/get-permitted-language-model/get-permitted-language-model.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/get-permitted-language-model/get-permitted-language-model.use-case.ts
@@ -6,18 +6,20 @@ import {
   ModelNotFoundByIdError,
   UnexpectedModelError,
 } from '../../models.errors';
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { BaseUseCase } from 'src/common/use-case/base-use-case';
 import { ContextService } from 'src/common/context/services/context.service';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
 import { SystemRole } from 'src/iam/users/domain/value-objects/system-role.enum';
 
 @Injectable()
-export class GetPermittedLanguageModelUseCase {
-  private readonly logger = new Logger(GetPermittedLanguageModelUseCase.name);
+export class GetPermittedLanguageModelUseCase extends BaseUseCase {
   constructor(
     private readonly permittedModelsRepository: PermittedModelsRepository,
     private readonly contextService: ContextService,
-  ) {}
+  ) {
+    super();
+  }
 
   async execute(
     query: GetPermittedLanguageModelQuery,

--- a/ayunis-core-backend/src/domain/models/application/use-cases/get-permitted-language-models/get-permitted-language-models.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/get-permitted-language-models/get-permitted-language-models.use-case.ts
@@ -1,7 +1,8 @@
 import { PermittedLanguageModel } from 'src/domain/models/domain/permitted-model.entity';
 import { PermittedModelsRepository } from '../../ports/permitted-models.repository';
 import { GetPermittedLanguageModelsQuery } from './get-permitted-language-models.query';
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { BaseUseCase } from 'src/common/use-case/base-use-case';
 import { UnexpectedModelError } from '../../models.errors';
 import { ApplicationError } from 'src/common/errors/base.error';
 import { ContextService } from 'src/common/context/services/context.service';
@@ -9,13 +10,13 @@ import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.e
 import { SystemRole } from 'src/iam/users/domain/value-objects/system-role.enum';
 
 @Injectable()
-export class GetPermittedLanguageModelsUseCase {
-  private readonly logger = new Logger(GetPermittedLanguageModelsUseCase.name);
-
+export class GetPermittedLanguageModelsUseCase extends BaseUseCase {
   constructor(
     private readonly permittedModelsRepository: PermittedModelsRepository,
     private readonly contextService: ContextService,
-  ) {}
+  ) {
+    super();
+  }
 
   async execute(
     query: GetPermittedLanguageModelsQuery,

--- a/ayunis-core-backend/src/domain/models/application/use-cases/get-permitted-model/get-permitted-model.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/get-permitted-model/get-permitted-model.use-case.ts
@@ -5,18 +5,20 @@ import {
   UnexpectedModelError,
 } from '../../models.errors';
 import { GetPermittedModelQuery } from './get-permitted-model.query';
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { BaseUseCase } from 'src/common/use-case/base-use-case';
 import { ContextService } from 'src/common/context/services/context.service';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
 import { SystemRole } from 'src/iam/users/domain/value-objects/system-role.enum';
 
 @Injectable()
-export class GetPermittedModelUseCase {
-  private readonly logger = new Logger(GetPermittedModelUseCase.name);
+export class GetPermittedModelUseCase extends BaseUseCase {
   constructor(
     private readonly permittedModelsRepository: PermittedModelsRepository,
     private readonly contextService: ContextService,
-  ) {}
+  ) {
+    super();
+  }
 
   async execute(query: GetPermittedModelQuery): Promise<PermittedModel> {
     try {

--- a/ayunis-core-backend/src/domain/models/application/use-cases/get-permitted-models/get-permitted-models.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/get-permitted-models/get-permitted-models.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { BaseUseCase } from 'src/common/use-case/base-use-case';
 import { GetPermittedModelsQuery } from './get-permitted-models.query';
 import { PermittedModelsRepository } from '../../ports/permitted-models.repository';
 import { PermittedModel } from 'src/domain/models/domain/permitted-model.entity';
@@ -7,13 +8,13 @@ import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.e
 import { SystemRole } from 'src/iam/users/domain/value-objects/system-role.enum';
 
 @Injectable()
-export class GetPermittedModelsUseCase {
-  private readonly logger = new Logger(GetPermittedModelsUseCase.name);
-
+export class GetPermittedModelsUseCase extends BaseUseCase {
   constructor(
     private readonly permittedModelsRepository: PermittedModelsRepository,
     private readonly contextService: ContextService,
-  ) {}
+  ) {
+    super();
+  }
 
   async execute(query: GetPermittedModelsQuery): Promise<PermittedModel[]> {
     this.logger.debug('Getting permitted models', {

--- a/ayunis-core-backend/src/domain/models/application/use-cases/get-team-permitted-models/get-team-permitted-models.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/get-team-permitted-models/get-team-permitted-models.use-case.ts
@@ -1,19 +1,20 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { PermittedModelsRepository } from '../../ports/permitted-models.repository';
 import { GetTeamPermittedModelsQuery } from './get-team-permitted-models.query';
 import { PermittedLanguageModel } from 'src/domain/models/domain/permitted-model.entity';
 import { ApplicationError } from 'src/common/errors/base.error';
 import { UnexpectedModelError } from '../../models.errors';
 import { TeamPermittedModelValidator } from '../../services/team-permitted-model-validator.service';
+import { BaseUseCase } from 'src/common/use-case/base-use-case';
 
 @Injectable()
-export class GetTeamPermittedModelsUseCase {
-  private readonly logger = new Logger(GetTeamPermittedModelsUseCase.name);
-
+export class GetTeamPermittedModelsUseCase extends BaseUseCase {
   constructor(
     private readonly permittedModelsRepository: PermittedModelsRepository,
     private readonly validator: TeamPermittedModelValidator,
-  ) {}
+  ) {
+    super();
+  }
 
   async execute(
     query: GetTeamPermittedModelsQuery,

--- a/ayunis-core-backend/src/domain/models/application/use-cases/get-user-default-model/get-user-default-model.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/get-user-default-model/get-user-default-model.use-case.ts
@@ -1,16 +1,17 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { BaseUseCase } from 'src/common/use-case/base-use-case';
 import { GetUserDefaultModelQuery } from './get-user-default-model.query';
 import { PermittedLanguageModel } from '../../../domain/permitted-model.entity';
 import { UserDefaultModelsRepository } from '../../ports/user-default-models.repository';
 import { ModelError } from '../../models.errors';
 
 @Injectable()
-export class GetUserDefaultModelUseCase {
-  private readonly logger = new Logger(GetUserDefaultModelUseCase.name);
-
+export class GetUserDefaultModelUseCase extends BaseUseCase {
   constructor(
     private readonly userDefaultModelsRepository: UserDefaultModelsRepository,
-  ) {}
+  ) {
+    super();
+  }
 
   async execute(
     query: GetUserDefaultModelQuery,

--- a/ayunis-core-backend/src/domain/models/application/use-cases/set-org-default-language-model/set-org-default-language-model.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/set-org-default-language-model/set-org-default-language-model.use-case.ts
@@ -1,4 +1,6 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import type { UUID } from 'crypto';
+import { BaseUseCase } from 'src/common/use-case/base-use-case';
 import { SetOrgDefaultLanguageModelCommand } from './set-org-default-language-model.command';
 import { PermittedLanguageModel } from '../../../domain/permitted-model.entity';
 import { PermittedModelsRepository } from '../../ports/permitted-models.repository';
@@ -8,13 +10,13 @@ import { SystemRole } from 'src/iam/users/domain/value-objects/system-role.enum'
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
 
 @Injectable()
-export class SetOrgDefaultLanguageModelUseCase {
-  private readonly logger = new Logger(SetOrgDefaultLanguageModelUseCase.name);
-
+export class SetOrgDefaultLanguageModelUseCase extends BaseUseCase {
   constructor(
     private readonly permittedModelsRepository: PermittedModelsRepository,
     private readonly contextService: ContextService,
-  ) {}
+  ) {
+    super();
+  }
 
   async execute(
     command: SetOrgDefaultLanguageModelCommand,
@@ -25,61 +27,13 @@ export class SetOrgDefaultLanguageModelUseCase {
     });
 
     try {
-      // Check if the user is authorized to set the organization default model
-      const orgId = this.contextService.get('orgId');
-      const systemRole = this.contextService.get('systemRole');
-      const isFromOrg = orgId === command.orgId;
-      const isSuperAdmin = systemRole === SystemRole.SUPER_ADMIN;
-      if (!isFromOrg && !isSuperAdmin) {
-        throw new UnauthorizedAccessError();
-      }
+      this.ensureAuthorized(command.orgId);
+      const permittedModel = await this.findPermittedLanguageModel(command);
+      const action = await this.getDefaultAction(command.orgId);
 
-      // Only language models may participate in org-default flows.
-      const permittedModel =
-        await this.permittedModelsRepository.findOneLanguage({
-          id: command.permittedModelId,
-          orgId: command.orgId,
-        });
-
-      if (!permittedModel) {
-        this.logger.error('Permitted model not found', {
-          permittedModelId: command.permittedModelId,
-          orgId: command.orgId,
-        });
-        throw new PermittedModelNotFoundError(command.permittedModelId);
-      }
-
-      // Check if there's already a default model
-      const existingDefault =
-        await this.permittedModelsRepository.findOrgDefaultLanguage(
-          command.orgId,
-        );
-
-      const action = existingDefault ? 'updating' : 'setting';
-      this.logger.debug(
-        `Permitted model found, ${action} organization default`,
-        {
-          permittedModelId: command.permittedModelId,
-          orgId: command.orgId,
-          modelName: permittedModel.model.name,
-          modelProvider: permittedModel.model.provider,
-          existingDefaultId: existingDefault?.id,
-        },
-      );
-
-      // Set the model as the organization's default (handles both create and update)
-      const orgDefaultModel = await this.permittedModelsRepository.setAsDefault(
-        {
-          id: command.permittedModelId,
-          orgId: command.orgId,
-        },
-      );
-
-      this.logger.debug(`Organization default model ${action} successfully`, {
-        orgId: command.orgId,
-        modelId: orgDefaultModel.id,
-        action,
-      });
+      this.logBeforeSet(command, permittedModel, action);
+      const orgDefaultModel = await this.setOrgDefault(command);
+      this.logAfterSet(command.orgId, orgDefaultModel.id, action);
 
       return orgDefaultModel;
     } catch (error) {
@@ -93,5 +47,79 @@ export class SetOrgDefaultLanguageModelUseCase {
       });
       throw error;
     }
+  }
+
+  private ensureAuthorized(orgId: string): void {
+    const currentOrgId = this.contextService.get('orgId');
+    const systemRole = this.contextService.get('systemRole');
+    const isFromOrg = currentOrgId === orgId;
+    const isSuperAdmin = systemRole === SystemRole.SUPER_ADMIN;
+
+    if (!isFromOrg && !isSuperAdmin) {
+      throw new UnauthorizedAccessError();
+    }
+  }
+
+  private async findPermittedLanguageModel(
+    command: SetOrgDefaultLanguageModelCommand,
+  ): Promise<PermittedLanguageModel> {
+    const permittedModel = await this.permittedModelsRepository.findOneLanguage(
+      {
+        id: command.permittedModelId,
+        orgId: command.orgId,
+      },
+    );
+    if (permittedModel) {
+      return permittedModel;
+    }
+
+    this.logger.error('Permitted model not found', {
+      permittedModelId: command.permittedModelId,
+      orgId: command.orgId,
+    });
+    throw new PermittedModelNotFoundError(command.permittedModelId);
+  }
+
+  private async getDefaultAction(
+    orgId: UUID,
+  ): Promise<'setting' | 'updating'> {
+    const existingDefault =
+      await this.permittedModelsRepository.findOrgDefaultLanguage(orgId);
+
+    return existingDefault ? 'updating' : 'setting';
+  }
+
+  private logBeforeSet(
+    command: SetOrgDefaultLanguageModelCommand,
+    permittedModel: PermittedLanguageModel,
+    action: 'setting' | 'updating',
+  ): void {
+    this.logger.debug(`Permitted model found, ${action} organization default`, {
+      permittedModelId: command.permittedModelId,
+      orgId: command.orgId,
+      modelName: permittedModel.model.name,
+      modelProvider: permittedModel.model.provider,
+    });
+  }
+
+  private async setOrgDefault(
+    command: SetOrgDefaultLanguageModelCommand,
+  ): Promise<PermittedLanguageModel> {
+    return await this.permittedModelsRepository.setAsDefault({
+      id: command.permittedModelId,
+      orgId: command.orgId,
+    });
+  }
+
+  private logAfterSet(
+    orgId: string,
+    modelId: string,
+    action: 'setting' | 'updating',
+  ): void {
+    this.logger.debug(`Organization default model ${action} successfully`, {
+      orgId,
+      modelId,
+      action,
+    });
   }
 }

--- a/ayunis-core-backend/src/domain/models/application/use-cases/set-team-default-model/set-team-default-model.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/set-team-default-model/set-team-default-model.use-case.ts
@@ -1,19 +1,20 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { PermittedModelsRepository } from '../../ports/permitted-models.repository';
 import { SetTeamDefaultModelCommand } from './set-team-default-model.command';
 import { PermittedLanguageModel } from 'src/domain/models/domain/permitted-model.entity';
 import { ApplicationError } from 'src/common/errors/base.error';
 import { UnexpectedModelError } from '../../models.errors';
 import { TeamPermittedModelValidator } from '../../services/team-permitted-model-validator.service';
+import { BaseUseCase } from 'src/common/use-case/base-use-case';
 
 @Injectable()
-export class SetTeamDefaultModelUseCase {
-  private readonly logger = new Logger(SetTeamDefaultModelUseCase.name);
-
+export class SetTeamDefaultModelUseCase extends BaseUseCase {
   constructor(
     private readonly permittedModelsRepository: PermittedModelsRepository,
     private readonly validator: TeamPermittedModelValidator,
-  ) {}
+  ) {
+    super();
+  }
 
   async execute(
     command: SetTeamDefaultModelCommand,

--- a/ayunis-core-backend/src/domain/models/application/use-cases/set-user-default-language-model/set-user-default-language-model.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/set-user-default-language-model/set-user-default-language-model.use-case.ts
@@ -1,4 +1,6 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import type { UUID } from 'crypto';
+import { BaseUseCase } from 'src/common/use-case/base-use-case';
 import { SetUserDefaultLanguageModelCommand } from './set-user-default-language-model.command';
 import { PermittedLanguageModel } from '../../../domain/permitted-model.entity';
 import { PermittedModelsRepository } from '../../ports/permitted-models.repository';
@@ -8,14 +10,14 @@ import { ContextService } from 'src/common/context/services/context.service';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
 
 @Injectable()
-export class SetUserDefaultLanguageModelUseCase {
-  private readonly logger = new Logger(SetUserDefaultLanguageModelUseCase.name);
-
+export class SetUserDefaultLanguageModelUseCase extends BaseUseCase {
   constructor(
     private readonly permittedModelsRepository: PermittedModelsRepository,
     private readonly userDefaultModelsRepository: UserDefaultModelsRepository,
     private readonly contextService: ContextService,
-  ) {}
+  ) {
+    super();
+  }
 
   async execute(
     command: SetUserDefaultLanguageModelCommand,
@@ -27,47 +29,16 @@ export class SetUserDefaultLanguageModelUseCase {
     });
 
     try {
-      // First, verify that the permitted model exists and belongs to the organization
-      const userId = this.contextService.get('userId');
-      if (userId !== command.userId) {
-        throw new UnauthorizedAccessError();
-      }
-      const permittedModel =
-        await this.permittedModelsRepository.findOneLanguage({
-          id: command.permittedModelId,
-        });
+      this.ensureAuthorized(command.userId);
+      const permittedModel = await this.findPermittedLanguageModel(command);
+      const action = await this.getDefaultAction(command.userId);
 
-      if (!permittedModel) {
-        this.logger.error('Permitted model not found', {
-          permittedModelId: command.permittedModelId,
-          orgId: command.orgId,
-        });
-        throw new PermittedModelNotFoundError(command.permittedModelId);
-      }
-
-      // Check if there's already a user default model
-      const existingUserDefault =
-        await this.userDefaultModelsRepository.findByUserId(command.userId);
-
-      const action = existingUserDefault ? 'updating' : 'setting';
-      this.logger.debug(`Permitted model found, ${action} user default`, {
-        modelName: permittedModel.model.name,
-        modelProvider: permittedModel.model.provider,
-        existingDefaultId: existingUserDefault?.id,
-      });
-
-      // Set the model as the user's default (handles both create and update)
-      const userDefaultModel =
-        await this.userDefaultModelsRepository.setAsDefault(
-          permittedModel,
-          command.userId,
-        );
-
-      this.logger.debug(`User default model ${action} successfully`, {
-        userId: command.userId,
-        modelId: userDefaultModel.id,
-        action,
-      });
+      this.logBeforeSet(permittedModel, action);
+      const userDefaultModel = await this.setUserDefault(
+        command,
+        permittedModel,
+      );
+      this.logAfterSet(command.userId, userDefaultModel.id, action);
 
       return userDefaultModel;
     } catch (error) {
@@ -82,5 +53,71 @@ export class SetUserDefaultLanguageModelUseCase {
       });
       throw error;
     }
+  }
+
+  private ensureAuthorized(userId: string): void {
+    if (this.contextService.get('userId') !== userId) {
+      throw new UnauthorizedAccessError();
+    }
+  }
+
+  private async findPermittedLanguageModel(
+    command: SetUserDefaultLanguageModelCommand,
+  ): Promise<PermittedLanguageModel> {
+    const permittedModel = await this.permittedModelsRepository.findOneLanguage(
+      {
+        id: command.permittedModelId,
+      },
+    );
+    if (permittedModel) {
+      return permittedModel;
+    }
+
+    this.logger.error('Permitted model not found', {
+      permittedModelId: command.permittedModelId,
+      orgId: command.orgId,
+    });
+    throw new PermittedModelNotFoundError(command.permittedModelId);
+  }
+
+  private async getDefaultAction(
+    userId: UUID,
+  ): Promise<'setting' | 'updating'> {
+    const existingUserDefault =
+      await this.userDefaultModelsRepository.findByUserId(userId);
+
+    return existingUserDefault ? 'updating' : 'setting';
+  }
+
+  private logBeforeSet(
+    permittedModel: PermittedLanguageModel,
+    action: 'setting' | 'updating',
+  ): void {
+    this.logger.debug(`Permitted model found, ${action} user default`, {
+      modelName: permittedModel.model.name,
+      modelProvider: permittedModel.model.provider,
+    });
+  }
+
+  private async setUserDefault(
+    command: SetUserDefaultLanguageModelCommand,
+    permittedModel: PermittedLanguageModel,
+  ): Promise<PermittedLanguageModel> {
+    return await this.userDefaultModelsRepository.setAsDefault(
+      permittedModel,
+      command.userId,
+    );
+  }
+
+  private logAfterSet(
+    userId: string,
+    modelId: string,
+    action: 'setting' | 'updating',
+  ): void {
+    this.logger.debug(`User default model ${action} successfully`, {
+      userId,
+      modelId,
+      action,
+    });
   }
 }

--- a/ayunis-core-backend/src/domain/models/application/use-cases/stream-inference/stream-inference.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/stream-inference/stream-inference.use-case.ts
@@ -1,5 +1,6 @@
 import { Observable, catchError, throwError } from 'rxjs';
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { BaseUseCase } from 'src/common/use-case/base-use-case';
 import { StreamInferenceHandlerRegistry } from '../../registry/stream-inference-handler.registry';
 import {
   StreamInferenceHandler,
@@ -12,11 +13,12 @@ import { ApplicationError } from 'src/common/errors/base.error';
 import { extractUpstreamStatus } from '../../helpers/extract-upstream-status.helper';
 
 @Injectable()
-export class StreamInferenceUseCase {
-  private readonly logger = new Logger(StreamInferenceUseCase.name);
+export class StreamInferenceUseCase extends BaseUseCase {
   constructor(
     private readonly streamInferenceRegistry: StreamInferenceHandlerRegistry,
-  ) {}
+  ) {
+    super();
+  }
 
   execute(
     input: StreamInferenceInput,

--- a/ayunis-core-backend/src/domain/models/application/use-cases/update-embedding-model/update-embedding-model.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/update-embedding-model/update-embedding-model.use-case.ts
@@ -6,18 +6,19 @@ import {
   UnexpectedModelError,
 } from '../../models.errors';
 import { ApplicationError } from 'src/common/errors/base.error';
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { BaseUseCase } from 'src/common/use-case/base-use-case';
 import { ClearDefaultsByCatalogModelIdUseCase } from '../clear-defaults-by-catalog-model-id/clear-defaults-by-catalog-model-id.use-case';
 import { ClearDefaultsByCatalogModelIdCommand } from '../clear-defaults-by-catalog-model-id/clear-defaults-by-catalog-model-id.command';
 
 @Injectable()
-export class UpdateEmbeddingModelUseCase {
-  private readonly logger = new Logger(UpdateEmbeddingModelUseCase.name);
-
+export class UpdateEmbeddingModelUseCase extends BaseUseCase {
   constructor(
     private readonly modelsRepository: ModelsRepository,
     private readonly clearDefaultsUseCase: ClearDefaultsByCatalogModelIdUseCase,
-  ) {}
+  ) {
+    super();
+  }
 
   async execute(command: UpdateEmbeddingModelCommand): Promise<EmbeddingModel> {
     try {

--- a/ayunis-core-backend/src/domain/models/application/use-cases/update-image-generation-model/update-image-generation-model.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/update-image-generation-model/update-image-generation-model.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { BaseUseCase } from 'src/common/use-case/base-use-case';
 import { ApplicationError } from 'src/common/errors/base.error';
 import { ImageGenerationModel } from 'src/domain/models/domain/models/image-generation.model';
 import {
@@ -10,13 +11,13 @@ import { ModelPolicyService } from '../../services/model-policy.service';
 import { UpdateImageGenerationModelCommand } from './update-image-generation-model.command';
 
 @Injectable()
-export class UpdateImageGenerationModelUseCase {
-  private readonly logger = new Logger(UpdateImageGenerationModelUseCase.name);
-
+export class UpdateImageGenerationModelUseCase extends BaseUseCase {
   constructor(
     private readonly modelsRepository: ModelsRepository,
     private readonly modelPolicy: ModelPolicyService,
-  ) {}
+  ) {
+    super();
+  }
 
   async execute(
     command: UpdateImageGenerationModelCommand,

--- a/ayunis-core-backend/src/domain/models/application/use-cases/update-language-model/update-language-model.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/update-language-model/update-language-model.use-case.ts
@@ -6,18 +6,19 @@ import {
   UnexpectedModelError,
 } from '../../models.errors';
 import { ApplicationError } from 'src/common/errors/base.error';
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { BaseUseCase } from 'src/common/use-case/base-use-case';
 import { ClearDefaultsByCatalogModelIdUseCase } from '../clear-defaults-by-catalog-model-id/clear-defaults-by-catalog-model-id.use-case';
 import { ClearDefaultsByCatalogModelIdCommand } from '../clear-defaults-by-catalog-model-id/clear-defaults-by-catalog-model-id.command';
 
 @Injectable()
-export class UpdateLanguageModelUseCase {
-  private readonly logger = new Logger(UpdateLanguageModelUseCase.name);
-
+export class UpdateLanguageModelUseCase extends BaseUseCase {
   constructor(
     private readonly modelsRepository: ModelsRepository,
     private readonly clearDefaultsUseCase: ClearDefaultsByCatalogModelIdUseCase,
-  ) {}
+  ) {
+    super();
+  }
 
   async execute(command: UpdateLanguageModelCommand): Promise<LanguageModel> {
     try {

--- a/ayunis-core-backend/src/domain/models/application/use-cases/update-permitted-model/update-permitted-model.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/update-permitted-model/update-permitted-model.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { BaseUseCase } from 'src/common/use-case/base-use-case';
 import { UpdatePermittedModelCommand } from './update-permitted-model.command';
 import { PermittedModelsRepository } from '../../ports/permitted-models.repository';
 import {
@@ -19,14 +20,14 @@ import { ImageGenerationModel } from 'src/domain/models/domain/models/image-gene
 import { ModelPolicyService } from '../../services/model-policy.service';
 
 @Injectable()
-export class UpdatePermittedModelUseCase {
-  private readonly logger = new Logger(UpdatePermittedModelUseCase.name);
-
+export class UpdatePermittedModelUseCase extends BaseUseCase {
   constructor(
     private readonly permittedModelsRepository: PermittedModelsRepository,
     private readonly contextService: ContextService,
     private readonly modelPolicy: ModelPolicyService,
-  ) {}
+  ) {
+    super();
+  }
 
   async execute(command: UpdatePermittedModelCommand): Promise<PermittedModel> {
     this.logger.log('execute', {
@@ -36,74 +37,10 @@ export class UpdatePermittedModelUseCase {
     });
 
     try {
-      const orgId = this.contextService.get('orgId');
-      const orgRole = this.contextService.get('role');
-      const systemRole = this.contextService.get('systemRole');
-      const isOrgAdmin = orgRole === UserRole.ADMIN && orgId === command.orgId;
-      const isSuperAdmin = systemRole === SystemRole.SUPER_ADMIN;
-
-      if (!isOrgAdmin && !isSuperAdmin) {
-        throw new UnauthorizedAccessError();
-      }
-
-      const existingModel = await this.permittedModelsRepository.findOne({
-        id: command.permittedModelId,
-      });
-
-      if (!existingModel) {
-        throw new PermittedModelNotFoundError(command.permittedModelId);
-      }
-
-      // Verify the model belongs to the specified org
-      if (existingModel.orgId !== command.orgId) {
-        throw new UnauthorizedAccessError();
-      }
-
+      this.ensureAuthorized(command.orgId);
+      const existingModel = await this.findExistingModel(command);
       this.modelPolicy.assertSupported(existingModel.model);
-
-      // Create updated model with new anonymousOnly value, preserving the correct type
-      let updatedModel: PermittedModel;
-      if (existingModel.model instanceof LanguageModel) {
-        updatedModel = new PermittedLanguageModel({
-          id: existingModel.id,
-          model: existingModel.model,
-          orgId: existingModel.orgId,
-          scope: existingModel.scope,
-          scopeId: existingModel.scopeId,
-          isDefault: existingModel.isDefault,
-          anonymousOnly: command.anonymousOnly,
-          createdAt: existingModel.createdAt,
-          updatedAt: new Date(),
-        });
-      } else if (existingModel.model instanceof EmbeddingModel) {
-        updatedModel = new PermittedEmbeddingModel({
-          id: existingModel.id,
-          model: existingModel.model,
-          orgId: existingModel.orgId,
-          scope: existingModel.scope,
-          scopeId: existingModel.scopeId,
-          isDefault: existingModel.isDefault,
-          anonymousOnly: command.anonymousOnly,
-          createdAt: existingModel.createdAt,
-          updatedAt: new Date(),
-        });
-      } else if (existingModel.model instanceof ImageGenerationModel) {
-        updatedModel = new PermittedImageGenerationModel({
-          id: existingModel.id,
-          model: existingModel.model,
-          orgId: existingModel.orgId,
-          scope: existingModel.scope,
-          scopeId: existingModel.scopeId,
-          isDefault: existingModel.isDefault,
-          anonymousOnly: command.anonymousOnly,
-          createdAt: existingModel.createdAt,
-          updatedAt: new Date(),
-        });
-      } else {
-        throw new Error(
-          `Unknown model type: ${existingModel.model.constructor.name}`,
-        );
-      }
+      const updatedModel = this.buildUpdatedModel(existingModel, command);
 
       return await this.permittedModelsRepository.update(updatedModel);
     } catch (error) {
@@ -113,5 +50,66 @@ export class UpdatePermittedModelUseCase {
       this.logger.error('Error updating permitted model', error);
       throw error;
     }
+  }
+
+  private ensureAuthorized(orgId: string): void {
+    const currentOrgId = this.contextService.get('orgId');
+    const orgRole = this.contextService.get('role');
+    const systemRole = this.contextService.get('systemRole');
+    const isOrgAdmin = orgRole === UserRole.ADMIN && currentOrgId === orgId;
+    const isSuperAdmin = systemRole === SystemRole.SUPER_ADMIN;
+
+    if (!isOrgAdmin && !isSuperAdmin) {
+      throw new UnauthorizedAccessError();
+    }
+  }
+
+  private async findExistingModel(
+    command: UpdatePermittedModelCommand,
+  ): Promise<PermittedModel> {
+    const existingModel = await this.permittedModelsRepository.findOne({
+      id: command.permittedModelId,
+    });
+    if (!existingModel) {
+      throw new PermittedModelNotFoundError(command.permittedModelId);
+    }
+    if (existingModel.orgId !== command.orgId) {
+      throw new UnauthorizedAccessError();
+    }
+
+    return existingModel;
+  }
+
+  private buildUpdatedModel(
+    existingModel: PermittedModel,
+    command: UpdatePermittedModelCommand,
+  ): PermittedModel {
+    const baseProps = {
+      id: existingModel.id,
+      orgId: existingModel.orgId,
+      scope: existingModel.scope,
+      scopeId: existingModel.scopeId,
+      isDefault: existingModel.isDefault,
+      anonymousOnly: command.anonymousOnly,
+      createdAt: existingModel.createdAt,
+      updatedAt: new Date(),
+    };
+
+    if (existingModel.model instanceof LanguageModel) {
+      return new PermittedLanguageModel({ ...baseProps, model: existingModel.model });
+    }
+    if (existingModel.model instanceof EmbeddingModel) {
+      return new PermittedEmbeddingModel({ ...baseProps, model: existingModel.model });
+    }
+    if (existingModel.model instanceof ImageGenerationModel) {
+      return new PermittedImageGenerationModel({
+        ...baseProps,
+        model: existingModel.model,
+      });
+    }
+
+    throw new Error(
+      `Unknown model type: ${existingModel.model.constructor.name}`,
+    );
   }
 }

--- a/ayunis-core-backend/src/domain/models/application/use-cases/update-team-permitted-model/update-team-permitted-model.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/update-team-permitted-model/update-team-permitted-model.use-case.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { PermittedModelsRepository } from '../../ports/permitted-models.repository';
 import { UpdateTeamPermittedModelCommand } from './update-team-permitted-model.command';
 import { PermittedLanguageModel } from 'src/domain/models/domain/permitted-model.entity';
@@ -9,15 +9,16 @@ import {
 } from '../../models.errors';
 import { TeamPermittedModelValidator } from '../../services/team-permitted-model-validator.service';
 import { LanguageModel } from 'src/domain/models/domain/models/language.model';
+import { BaseUseCase } from 'src/common/use-case/base-use-case';
 
 @Injectable()
-export class UpdateTeamPermittedModelUseCase {
-  private readonly logger = new Logger(UpdateTeamPermittedModelUseCase.name);
-
+export class UpdateTeamPermittedModelUseCase extends BaseUseCase {
   constructor(
     private readonly permittedModelsRepository: PermittedModelsRepository,
     private readonly validator: TeamPermittedModelValidator,
-  ) {}
+  ) {
+    super();
+  }
 
   async execute(
     command: UpdateTeamPermittedModelCommand,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Wide refactor across model permission, default selection, deletion, and inference use cases; behavior should be unchanged but regressions in auth checks or default resolution would affect core product behavior.
> 
> **Overview**
> Introduces a shared **`BaseUseCase`** that provides a Nest **`Logger`** keyed to the subclass name (with a unit test), and migrates the **models** application use cases to extend it instead of declaring loggers inline.
> 
> Most classes only change inheritance and **`super()`** in constructors; behavior and log messages stay the same. A few flows are **restructured into private helpers** without intended logic changes: permitted-model deletion (auth, lookup, type dispatch), default-model resolution (user → team → org → fallback), org/user default assignment, and permitted-model updates (auth, lookup, typed entity rebuild).
> 
> **`GetOrgDefaultModelUseCase`** now returns **`orgDefaultModel ?? null`** instead of **`|| null`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c980add7fd1e69ca1aa978927e202d545e7aed3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->