### PR TITLE
refactor(models): split oversized execute() methods into helpers (AYC-000)

### DIFF
--- a/ayunis-core-backend/src/domain/models/application/use-cases/delete-permitted-model/delete-permitted-model.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/delete-permitted-model/delete-permitted-model.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { BaseUseCase } from 'src/common/use-case/base-use-case';
 import { DeletePermittedModelCommand } from './delete-permitted-model.command';
 import { PermittedModelsRepository } from '../../ports/permitted-models.repository';
 import {
@@ -31,9 +32,8 @@ import { UserRole } from 'src/iam/users/domain/value-objects/role.object';
 import { SystemRole } from 'src/iam/users/domain/value-objects/system-role.enum';
 
 @Injectable()
-export class DeletePermittedModelUseCase {
-  private readonly logger = new Logger(DeletePermittedModelUseCase.name);
-
+export class DeletePermittedModelUseCase extends BaseUseCase {
+  // eslint-disable-next-line max-params -- deletion flow orchestrates multiple collaborators
   constructor(
     private readonly permittedModelsRepository: PermittedModelsRepository,
     private readonly deleteUserDefaultModelByModelIdUseCase: DeleteUserDefaultModelsByModelIdUseCase,
@@ -42,7 +42,9 @@ export class DeletePermittedModelUseCase {
     private readonly findAllThreadsByOrgWithSourcesUseCase: FindAllThreadsByOrgWithSourcesUseCase,
     private readonly deleteSourcesUseCase: DeleteSourcesUseCase,
     private readonly contextService: ContextService,
-  ) {}
+  ) {
+    super();
+  }
 
   @Transactional()
   async execute(command: DeletePermittedModelCommand): Promise<void> {
@@ -51,53 +53,10 @@ export class DeletePermittedModelUseCase {
       orgId: command.orgId,
     });
     try {
-      const orgId = this.contextService.get('orgId');
-      const orgRole = this.contextService.get('role');
-      const systemRole = this.contextService.get('systemRole');
-      const isOrgAdmin = orgRole === UserRole.ADMIN && orgId === command.orgId;
-      const isSuperAdmin = systemRole === SystemRole.SUPER_ADMIN;
-      if (!isOrgAdmin && !isSuperAdmin) {
-        throw new UnauthorizedAccessError();
-      }
-      const model = await this.permittedModelsRepository.findOne({
-        id: command.permittedModelId,
-      });
-      if (!model) {
-        this.logger.error('Model not found', {
-          modelId: command.permittedModelId,
-          orgId: command.orgId,
-        });
-        throw new PermittedModelDeletionFailedError('Model not found', {
-          modelId: command.permittedModelId,
-        });
-      }
+      this.ensureAuthorized(command.orgId);
+      const model = await this.findDeletableModel(command);
 
-      // Verify the model belongs to the specified org
-      if (model.orgId !== command.orgId) {
-        throw new UnauthorizedAccessError();
-      }
-
-      if (model instanceof PermittedLanguageModel) {
-        return this.deletePermittedLanguageModel(command.orgId, model);
-      } else if (model instanceof PermittedEmbeddingModel) {
-        return this.deletePermittedEmbeddingModel(command.orgId, model);
-      } else if (model instanceof PermittedImageGenerationModel) {
-        return this.deletePermittedImageGenerationModel(command.orgId, model);
-      } else {
-        this.logger.error(
-          'Model is not a language, embedding, or image-generation model',
-          {
-            modelId: command.permittedModelId,
-            orgId: command.orgId,
-          },
-        );
-        throw new PermittedModelDeletionFailedError(
-          'Model is not a language, embedding, or image-generation model',
-          {
-            modelId: command.permittedModelId,
-          },
-        );
-      }
+      return await this.deleteModelByType(command.orgId, model);
     } catch (error) {
       if (error instanceof ApplicationError) {
         throw error;
@@ -107,6 +66,82 @@ export class DeletePermittedModelUseCase {
         error instanceof Error ? error : new Error('Unknown error'),
       );
     }
+  }
+
+  private ensureAuthorized(orgId: UUID): void {
+    const currentOrgId = this.contextService.get('orgId');
+    const orgRole = this.contextService.get('role');
+    const systemRole = this.contextService.get('systemRole');
+    const isOrgAdmin = orgRole === UserRole.ADMIN && currentOrgId === orgId;
+    const isSuperAdmin = systemRole === SystemRole.SUPER_ADMIN;
+
+    if (!isOrgAdmin && !isSuperAdmin) {
+      throw new UnauthorizedAccessError();
+    }
+  }
+
+  private async findDeletableModel(
+    command: DeletePermittedModelCommand,
+  ): Promise<
+    | PermittedLanguageModel
+    | PermittedEmbeddingModel
+    | PermittedImageGenerationModel
+  > {
+    const model = await this.permittedModelsRepository.findOne({
+      id: command.permittedModelId,
+    });
+    if (!model) {
+      this.logger.error('Model not found', {
+        modelId: command.permittedModelId,
+        orgId: command.orgId,
+      });
+      throw new PermittedModelDeletionFailedError('Model not found', {
+        modelId: command.permittedModelId,
+      });
+    }
+
+    if (model.orgId !== command.orgId) {
+      throw new UnauthorizedAccessError();
+    }
+
+    if (
+      model instanceof PermittedLanguageModel ||
+      model instanceof PermittedEmbeddingModel ||
+      model instanceof PermittedImageGenerationModel
+    ) {
+      return model;
+    }
+
+    this.logger.error(
+      'Model is not a language, embedding, or image-generation model',
+      {
+        modelId: command.permittedModelId,
+        orgId: command.orgId,
+      },
+    );
+    throw new PermittedModelDeletionFailedError(
+      'Model is not a language, embedding, or image-generation model',
+      {
+        modelId: command.permittedModelId,
+      },
+    );
+  }
+
+  private async deleteModelByType(
+    orgId: UUID,
+    model:
+      | PermittedLanguageModel
+      | PermittedEmbeddingModel
+      | PermittedImageGenerationModel,
+  ): Promise<void> {
+    if (model instanceof PermittedLanguageModel) {
+      return await this.deletePermittedLanguageModel(orgId, model);
+    }
+    if (model instanceof PermittedEmbeddingModel) {
+      return await this.deletePermittedEmbeddingModel(orgId, model);
+    }
+
+    return await this.deletePermittedImageGenerationModel(orgId, model);
   }
 
   private async deletePermittedLanguageModel(

--- a/ayunis-core-backend/src/domain/models/application/use-cases/get-default-model/get-default-model.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/get-default-model/get-default-model.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { BaseUseCase } from 'src/common/use-case/base-use-case';
 import type { UUID } from 'crypto';
 import { GetDefaultModelQuery } from './get-default-model.query';
 import { PermittedLanguageModel } from 'src/domain/models/domain/permitted-model.entity';
@@ -9,14 +10,14 @@ import { GetEffectiveLanguageModelsQuery } from '../get-effective-language-model
 import { DefaultModelNotFoundError, ModelError } from '../../models.errors';
 
 @Injectable()
-export class GetDefaultModelUseCase {
-  private readonly logger = new Logger(GetDefaultModelUseCase.name);
-
+export class GetDefaultModelUseCase extends BaseUseCase {
   constructor(
     private readonly permittedModelsRepository: PermittedModelsRepository,
     private readonly userDefaultModelsRepository: UserDefaultModelsRepository,
     private readonly getEffectiveLanguageModelsUseCase: GetEffectiveLanguageModelsUseCase,
-  ) {}
+  ) {
+    super();
+  }
 
   async execute(query: GetDefaultModelQuery): Promise<PermittedLanguageModel> {
     this.logger.log('execute', { query });
@@ -33,65 +34,13 @@ export class GetDefaultModelUseCase {
         effectiveModelIds.has(model.model.id) &&
         !query.blacklistedModelIds?.includes(model.model.id);
 
-      // Step 1: User default
-      if (query.userId) {
-        const userDefault = await this.userDefaultModelsRepository.findByUserId(
-          query.userId,
-        );
-
-        if (userDefault && isInEffectiveSet(userDefault)) {
-          this.logger.debug('Using user default model', {
-            userId: query.userId,
-            modelId: userDefault.id,
-          });
-          return userDefault;
-        }
-      }
-
-      // Step 2: Team defaults (from override teams)
-      if (query.userId && overrideTeamIds.length > 0) {
-        const teamDefault = await this.resolveTeamDefault(
-          overrideTeamIds,
-          query.orgId,
-          effectiveModelIds,
-          query.blacklistedModelIds,
-        );
-        if (teamDefault) {
-          this.logger.debug('Using team default model', {
-            modelId: teamDefault.id,
-          });
-          return teamDefault;
-        }
-      }
-
-      // Step 3: Org default
-      const orgDefault =
-        await this.permittedModelsRepository.findOrgDefaultLanguage(
-          query.orgId,
-        );
-      if (orgDefault && isInEffectiveSet(orgDefault)) {
-        this.logger.debug('Using org default model', {
-          orgId: query.orgId,
-          modelId: orgDefault.id,
-        });
-        return orgDefault;
-      }
-
-      // Step 4: First available from effective set, alphabetically
-      const sorted = [...effectiveModels].sort((a, b) =>
-        a.model.name.localeCompare(b.model.name),
+      return await this.resolveDefaultModel(
+        query,
+        overrideTeamIds,
+        effectiveModels,
+        effectiveModelIds,
+        isInEffectiveSet,
       );
-
-      for (const model of sorted) {
-        if (!query.blacklistedModelIds?.includes(model.model.id)) {
-          this.logger.debug('Using first available model alphabetically', {
-            modelId: model.id,
-          });
-          return model;
-        }
-      }
-
-      throw new DefaultModelNotFoundError(query.orgId);
     } catch (error) {
       if (error instanceof ModelError) {
         throw error;
@@ -103,6 +52,119 @@ export class GetDefaultModelUseCase {
       });
       throw error;
     }
+  }
+
+  private async resolveDefaultModel(
+    query: GetDefaultModelQuery,
+    overrideTeamIds: UUID[],
+    effectiveModels: PermittedLanguageModel[],
+    effectiveModelIds: Set<UUID>,
+    isInEffectiveSet: (model: PermittedLanguageModel) => boolean,
+  ): Promise<PermittedLanguageModel> {
+    const userDefault = await this.findUserDefault(query, isInEffectiveSet);
+    if (userDefault) {
+      return userDefault;
+    }
+
+    const teamDefault = await this.findTeamDefault(
+      query,
+      overrideTeamIds,
+      effectiveModelIds,
+    );
+    if (teamDefault) {
+      return teamDefault;
+    }
+
+    const orgDefault = await this.findOrgDefault(query.orgId, isInEffectiveSet);
+    if (orgDefault) {
+      return orgDefault;
+    }
+
+    return this.findFirstAvailableModel(query, effectiveModels);
+  }
+
+  private async findUserDefault(
+    query: GetDefaultModelQuery,
+    isInEffectiveSet: (model: PermittedLanguageModel) => boolean,
+  ): Promise<PermittedLanguageModel | null> {
+    if (!query.userId) {
+      return null;
+    }
+
+    const userDefault = await this.userDefaultModelsRepository.findByUserId(
+      query.userId,
+    );
+    if (!userDefault || !isInEffectiveSet(userDefault)) {
+      return null;
+    }
+
+    this.logger.debug('Using user default model', {
+      userId: query.userId,
+      modelId: userDefault.id,
+    });
+    return userDefault;
+  }
+
+  private async findTeamDefault(
+    query: GetDefaultModelQuery,
+    overrideTeamIds: UUID[],
+    effectiveModelIds: Set<UUID>,
+  ): Promise<PermittedLanguageModel | null> {
+    if (!query.userId || overrideTeamIds.length === 0) {
+      return null;
+    }
+
+    const teamDefault = await this.resolveTeamDefault(
+      overrideTeamIds,
+      query.orgId,
+      effectiveModelIds,
+      query.blacklistedModelIds,
+    );
+    if (!teamDefault) {
+      return null;
+    }
+
+    this.logger.debug('Using team default model', {
+      modelId: teamDefault.id,
+    });
+    return teamDefault;
+  }
+
+  private async findOrgDefault(
+    orgId: UUID,
+    isInEffectiveSet: (model: PermittedLanguageModel) => boolean,
+  ): Promise<PermittedLanguageModel | null> {
+    const orgDefault =
+      await this.permittedModelsRepository.findOrgDefaultLanguage(orgId);
+    if (!orgDefault || !isInEffectiveSet(orgDefault)) {
+      return null;
+    }
+
+    this.logger.debug('Using org default model', {
+      orgId,
+      modelId: orgDefault.id,
+    });
+    return orgDefault;
+  }
+
+  private findFirstAvailableModel(
+    query: GetDefaultModelQuery,
+    effectiveModels: PermittedLanguageModel[],
+  ): PermittedLanguageModel {
+    const model = [...effectiveModels]
+      .sort((a, b) => a.model.name.localeCompare(b.model.name))
+      .find(
+        (candidate) => !query.blacklistedModelIds?.includes(candidate.model.id),
+      );
+
+    if (!model) {
+      throw new DefaultModelNotFoundError(query.orgId);
+    }
+
+    this.logger.debug('Using first available model alphabetically', {
+      modelId: model.id,
+    });
+    return model;
   }
 
   private async resolveTeamDefault(

--- a/ayunis-core-backend/src/domain/models/application/use-cases/set-org-default-language-model/set-org-default-language-model.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/set-org-default-language-model/set-org-default-language-model.use-case.ts
@@ -1,4 +1,6 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import type { UUID } from 'crypto';
+import { BaseUseCase } from 'src/common/use-case/base-use-case';
 import { SetOrgDefaultLanguageModelCommand } from './set-org-default-language-model.command';
 import { PermittedLanguageModel } from '../../../domain/permitted-model.entity';
 import { PermittedModelsRepository } from '../../ports/permitted-models.repository';
@@ -8,13 +10,13 @@ import { SystemRole } from 'src/iam/users/domain/value-objects/system-role.enum'
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
 
 @Injectable()
-export class SetOrgDefaultLanguageModelUseCase {
-  private readonly logger = new Logger(SetOrgDefaultLanguageModelUseCase.name);
-
+export class SetOrgDefaultLanguageModelUseCase extends BaseUseCase {
   constructor(
     private readonly permittedModelsRepository: PermittedModelsRepository,
     private readonly contextService: ContextService,
-  ) {}
+  ) {
+    super();
+  }
 
   async execute(
     command: SetOrgDefaultLanguageModelCommand,
@@ -25,61 +27,13 @@ export class SetOrgDefaultLanguageModelUseCase {
     });
 
     try {
-      // Check if the user is authorized to set the organization default model
-      const orgId = this.contextService.get('orgId');
-      const systemRole = this.contextService.get('systemRole');
-      const isFromOrg = orgId === command.orgId;
-      const isSuperAdmin = systemRole === SystemRole.SUPER_ADMIN;
-      if (!isFromOrg && !isSuperAdmin) {
-        throw new UnauthorizedAccessError();
-      }
+      this.ensureAuthorized(command.orgId);
+      const permittedModel = await this.findPermittedLanguageModel(command);
+      const action = await this.getDefaultAction(command.orgId);
 
-      // Only language models may participate in org-default flows.
-      const permittedModel =
-        await this.permittedModelsRepository.findOneLanguage({
-          id: command.permittedModelId,
-          orgId: command.orgId,
-        });
-
-      if (!permittedModel) {
-        this.logger.error('Permitted model not found', {
-          permittedModelId: command.permittedModelId,
-          orgId: command.orgId,
-        });
-        throw new PermittedModelNotFoundError(command.permittedModelId);
-      }
-
-      // Check if there's already a default model
-      const existingDefault =
-        await this.permittedModelsRepository.findOrgDefaultLanguage(
-          command.orgId,
-        );
-
-      const action = existingDefault ? 'updating' : 'setting';
-      this.logger.debug(
-        `Permitted model found, ${action} organization default`,
-        {
-          permittedModelId: command.permittedModelId,
-          orgId: command.orgId,
-          modelName: permittedModel.model.name,
-          modelProvider: permittedModel.model.provider,
-          existingDefaultId: existingDefault?.id,
-        },
-      );
-
-      // Set the model as the organization's default (handles both create and update)
-      const orgDefaultModel = await this.permittedModelsRepository.setAsDefault(
-        {
-          id: command.permittedModelId,
-          orgId: command.orgId,
-        },
-      );
-
-      this.logger.debug(`Organization default model ${action} successfully`, {
-        orgId: command.orgId,
-        modelId: orgDefaultModel.id,
-        action,
-      });
+      this.logBeforeSet(command, permittedModel, action);
+      const orgDefaultModel = await this.setOrgDefault(command);
+      this.logAfterSet(command.orgId, orgDefaultModel.id, action);
 
       return orgDefaultModel;
     } catch (error) {
@@ -93,5 +47,79 @@ export class SetOrgDefaultLanguageModelUseCase {
       });
       throw error;
     }
+  }
+
+  private ensureAuthorized(orgId: string): void {
+    const currentOrgId = this.contextService.get('orgId');
+    const systemRole = this.contextService.get('systemRole');
+    const isFromOrg = currentOrgId === orgId;
+    const isSuperAdmin = systemRole === SystemRole.SUPER_ADMIN;
+
+    if (!isFromOrg && !isSuperAdmin) {
+      throw new UnauthorizedAccessError();
+    }
+  }
+
+  private async findPermittedLanguageModel(
+    command: SetOrgDefaultLanguageModelCommand,
+  ): Promise<PermittedLanguageModel> {
+    const permittedModel = await this.permittedModelsRepository.findOneLanguage(
+      {
+        id: command.permittedModelId,
+        orgId: command.orgId,
+      },
+    );
+    if (permittedModel) {
+      return permittedModel;
+    }
+
+    this.logger.error('Permitted model not found', {
+      permittedModelId: command.permittedModelId,
+      orgId: command.orgId,
+    });
+    throw new PermittedModelNotFoundError(command.permittedModelId);
+  }
+
+  private async getDefaultAction(
+    orgId: UUID,
+  ): Promise<'setting' | 'updating'> {
+    const existingDefault =
+      await this.permittedModelsRepository.findOrgDefaultLanguage(orgId);
+
+    return existingDefault ? 'updating' : 'setting';
+  }
+
+  private logBeforeSet(
+    command: SetOrgDefaultLanguageModelCommand,
+    permittedModel: PermittedLanguageModel,
+    action: 'setting' | 'updating',
+  ): void {
+    this.logger.debug(`Permitted model found, ${action} organization default`, {
+      permittedModelId: command.permittedModelId,
+      orgId: command.orgId,
+      modelName: permittedModel.model.name,
+      modelProvider: permittedModel.model.provider,
+    });
+  }
+
+  private async setOrgDefault(
+    command: SetOrgDefaultLanguageModelCommand,
+  ): Promise<PermittedLanguageModel> {
+    return await this.permittedModelsRepository.setAsDefault({
+      id: command.permittedModelId,
+      orgId: command.orgId,
+    });
+  }
+
+  private logAfterSet(
+    orgId: string,
+    modelId: string,
+    action: 'setting' | 'updating',
+  ): void {
+    this.logger.debug(`Organization default model ${action} successfully`, {
+      orgId,
+      modelId,
+      action,
+    });
   }
 }

--- a/ayunis-core-backend/src/domain/models/application/use-cases/set-user-default-language-model/set-user-default-language-model.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/set-user-default-language-model/set-user-default-language-model.use-case.ts
@@ -1,4 +1,6 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import type { UUID } from 'crypto';
+import { BaseUseCase } from 'src/common/use-case/base-use-case';
 import { SetUserDefaultLanguageModelCommand } from './set-user-default-language-model.command';
 import { PermittedLanguageModel } from '../../../domain/permitted-model.entity';
 import { PermittedModelsRepository } from '../../ports/permitted-models.repository';
@@ -8,14 +10,14 @@ import { ContextService } from 'src/common/context/services/context.service';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
 
 @Injectable()
-export class SetUserDefaultLanguageModelUseCase {
-  private readonly logger = new Logger(SetUserDefaultLanguageModelUseCase.name);
-
+export class SetUserDefaultLanguageModelUseCase extends BaseUseCase {
   constructor(
     private readonly permittedModelsRepository: PermittedModelsRepository,
     private readonly userDefaultModelsRepository: UserDefaultModelsRepository,
     private readonly contextService: ContextService,
-  ) {}
+  ) {
+    super();
+  }
 
   async execute(
     command: SetUserDefaultLanguageModelCommand,
@@ -27,47 +29,16 @@ export class SetUserDefaultLanguageModelUseCase {
     });
 
     try {
-      // First, verify that the permitted model exists and belongs to the organization
-      const userId = this.contextService.get('userId');
-      if (userId !== command.userId) {
-        throw new UnauthorizedAccessError();
-      }
-      const permittedModel =
-        await this.permittedModelsRepository.findOneLanguage({
-          id: command.permittedModelId,
-        });
+      this.ensureAuthorized(command.userId);
+      const permittedModel = await this.findPermittedLanguageModel(command);
+      const action = await this.getDefaultAction(command.userId);
 
-      if (!permittedModel) {
-        this.logger.error('Permitted model not found', {
-          permittedModelId: command.permittedModelId,
-          orgId: command.orgId,
-        });
-        throw new PermittedModelNotFoundError(command.permittedModelId);
-      }
-
-      // Check if there's already a user default model
-      const existingUserDefault =
-        await this.userDefaultModelsRepository.findByUserId(command.userId);
-
-      const action = existingUserDefault ? 'updating' : 'setting';
-      this.logger.debug(`Permitted model found, ${action} user default`, {
-        modelName: permittedModel.model.name,
-        modelProvider: permittedModel.model.provider,
-        existingDefaultId: existingUserDefault?.id,
-      });
-
-      // Set the model as the user's default (handles both create and update)
-      const userDefaultModel =
-        await this.userDefaultModelsRepository.setAsDefault(
-          permittedModel,
-          command.userId,
-        );
-
-      this.logger.debug(`User default model ${action} successfully`, {
-        userId: command.userId,
-        modelId: userDefaultModel.id,
-        action,
-      });
+      this.logBeforeSet(permittedModel, action);
+      const userDefaultModel = await this.setUserDefault(
+        command,
+        permittedModel,
+      );
+      this.logAfterSet(command.userId, userDefaultModel.id, action);
 
       return userDefaultModel;
     } catch (error) {
@@ -82,5 +53,71 @@ export class SetUserDefaultLanguageModelUseCase {
       });
       throw error;
     }
+  }
+
+  private ensureAuthorized(userId: string): void {
+    if (this.contextService.get('userId') !== userId) {
+      throw new UnauthorizedAccessError();
+    }
+  }
+
+  private async findPermittedLanguageModel(
+    command: SetUserDefaultLanguageModelCommand,
+  ): Promise<PermittedLanguageModel> {
+    const permittedModel = await this.permittedModelsRepository.findOneLanguage(
+      {
+        id: command.permittedModelId,
+      },
+    );
+    if (permittedModel) {
+      return permittedModel;
+    }
+
+    this.logger.error('Permitted model not found', {
+      permittedModelId: command.permittedModelId,
+      orgId: command.orgId,
+    });
+    throw new PermittedModelNotFoundError(command.permittedModelId);
+  }
+
+  private async getDefaultAction(
+    userId: UUID,
+  ): Promise<'setting' | 'updating'> {
+    const existingUserDefault =
+      await this.userDefaultModelsRepository.findByUserId(userId);
+
+    return existingUserDefault ? 'updating' : 'setting';
+  }
+
+  private logBeforeSet(
+    permittedModel: PermittedLanguageModel,
+    action: 'setting' | 'updating',
+  ): void {
+    this.logger.debug(`Permitted model found, ${action} user default`, {
+      modelName: permittedModel.model.name,
+      modelProvider: permittedModel.model.provider,
+    });
+  }
+
+  private async setUserDefault(
+    command: SetUserDefaultLanguageModelCommand,
+    permittedModel: PermittedLanguageModel,
+  ): Promise<PermittedLanguageModel> {
+    return await this.userDefaultModelsRepository.setAsDefault(
+      permittedModel,
+      command.userId,
+    );
+  }
+
+  private logAfterSet(
+    userId: string,
+    modelId: string,
+    action: 'setting' | 'updating',
+  ): void {
+    this.logger.debug(`User default model ${action} successfully`, {
+      userId,
+      modelId,
+      action,
+    });
   }
 }

--- a/ayunis-core-backend/src/domain/models/application/use-cases/update-permitted-model/update-permitted-model.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/update-permitted-model/update-permitted-model.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { BaseUseCase } from 'src/common/use-case/base-use-case';
 import { UpdatePermittedModelCommand } from './update-permitted-model.command';
 import { PermittedModelsRepository } from '../../ports/permitted-models.repository';
 import {
@@ -19,14 +20,14 @@ import { ImageGenerationModel } from 'src/domain/models/domain/models/image-gene
 import { ModelPolicyService } from '../../services/model-policy.service';
 
 @Injectable()
-export class UpdatePermittedModelUseCase {
-  private readonly logger = new Logger(UpdatePermittedModelUseCase.name);
-
+export class UpdatePermittedModelUseCase extends BaseUseCase {
   constructor(
     private readonly permittedModelsRepository: PermittedModelsRepository,
     private readonly contextService: ContextService,
     private readonly modelPolicy: ModelPolicyService,
-  ) {}
+  ) {
+    super();
+  }
 
   async execute(command: UpdatePermittedModelCommand): Promise<PermittedModel> {
     this.logger.log('execute', {
@@ -36,74 +37,10 @@ export class UpdatePermittedModelUseCase {
     });
 
     try {
-      const orgId = this.contextService.get('orgId');
-      const orgRole = this.contextService.get('role');
-      const systemRole = this.contextService.get('systemRole');
-      const isOrgAdmin = orgRole === UserRole.ADMIN && orgId === command.orgId;
-      const isSuperAdmin = systemRole === SystemRole.SUPER_ADMIN;
-
-      if (!isOrgAdmin && !isSuperAdmin) {
-        throw new UnauthorizedAccessError();
-      }
-
-      const existingModel = await this.permittedModelsRepository.findOne({
-        id: command.permittedModelId,
-      });
-
-      if (!existingModel) {
-        throw new PermittedModelNotFoundError(command.permittedModelId);
-      }
-
-      // Verify the model belongs to the specified org
-      if (existingModel.orgId !== command.orgId) {
-        throw new UnauthorizedAccessError();
-      }
-
+      this.ensureAuthorized(command.orgId);
+      const existingModel = await this.findExistingModel(command);
       this.modelPolicy.assertSupported(existingModel.model);
-
-      // Create updated model with new anonymousOnly value, preserving the correct type
-      let updatedModel: PermittedModel;
-      if (existingModel.model instanceof LanguageModel) {
-        updatedModel = new PermittedLanguageModel({
-          id: existingModel.id,
-          model: existingModel.model,
-          orgId: existingModel.orgId,
-          scope: existingModel.scope,
-          scopeId: existingModel.scopeId,
-          isDefault: existingModel.isDefault,
-          anonymousOnly: command.anonymousOnly,
-          createdAt: existingModel.createdAt,
-          updatedAt: new Date(),
-        });
-      } else if (existingModel.model instanceof EmbeddingModel) {
-        updatedModel = new PermittedEmbeddingModel({
-          id: existingModel.id,
-          model: existingModel.model,
-          orgId: existingModel.orgId,
-          scope: existingModel.scope,
-          scopeId: existingModel.scopeId,
-          isDefault: existingModel.isDefault,
-          anonymousOnly: command.anonymousOnly,
-          createdAt: existingModel.createdAt,
-          updatedAt: new Date(),
-        });
-      } else if (existingModel.model instanceof ImageGenerationModel) {
-        updatedModel = new PermittedImageGenerationModel({
-          id: existingModel.id,
-          model: existingModel.model,
-          orgId: existingModel.orgId,
-          scope: existingModel.scope,
-          scopeId: existingModel.scopeId,
-          isDefault: existingModel.isDefault,
-          anonymousOnly: command.anonymousOnly,
-          createdAt: existingModel.createdAt,
-          updatedAt: new Date(),
-        });
-      } else {
-        throw new Error(
-          `Unknown model type: ${existingModel.model.constructor.name}`,
-        );
-      }
+      const updatedModel = this.buildUpdatedModel(existingModel, command);
 
       return await this.permittedModelsRepository.update(updatedModel);
     } catch (error) {
@@ -113,5 +50,66 @@ export class UpdatePermittedModelUseCase {
       this.logger.error('Error updating permitted model', error);
       throw error;
     }
+  }
+
+  private ensureAuthorized(orgId: string): void {
+    const currentOrgId = this.contextService.get('orgId');
+    const orgRole = this.contextService.get('role');
+    const systemRole = this.contextService.get('systemRole');
+    const isOrgAdmin = orgRole === UserRole.ADMIN && currentOrgId === orgId;
+    const isSuperAdmin = systemRole === SystemRole.SUPER_ADMIN;
+
+    if (!isOrgAdmin && !isSuperAdmin) {
+      throw new UnauthorizedAccessError();
+    }
+  }
+
+  private async findExistingModel(
+    command: UpdatePermittedModelCommand,
+  ): Promise<PermittedModel> {
+    const existingModel = await this.permittedModelsRepository.findOne({
+      id: command.permittedModelId,
+    });
+    if (!existingModel) {
+      throw new PermittedModelNotFoundError(command.permittedModelId);
+    }
+    if (existingModel.orgId !== command.orgId) {
+      throw new UnauthorizedAccessError();
+    }
+
+    return existingModel;
+  }
+
+  private buildUpdatedModel(
+    existingModel: PermittedModel,
+    command: UpdatePermittedModelCommand,
+  ): PermittedModel {
+    const baseProps = {
+      id: existingModel.id,
+      orgId: existingModel.orgId,
+      scope: existingModel.scope,
+      scopeId: existingModel.scopeId,
+      isDefault: existingModel.isDefault,
+      anonymousOnly: command.anonymousOnly,
+      createdAt: existingModel.createdAt,
+      updatedAt: new Date(),
+    };
+
+    if (existingModel.model instanceof LanguageModel) {
+      return new PermittedLanguageModel({ ...baseProps, model: existingModel.model });
+    }
+    if (existingModel.model instanceof EmbeddingModel) {
+      return new PermittedEmbeddingModel({ ...baseProps, model: existingModel.model });
+    }
+    if (existingModel.model instanceof ImageGenerationModel) {
+      return new PermittedImageGenerationModel({
+        ...baseProps,
+        model: existingModel.model,
+      });
+    }
+
+    throw new Error(
+      `Unknown model type: ${existingModel.model.constructor.name}`,
+    );
   }
 }


### PR DESCRIPTION
Extract the authorization checks, lookups, and logging out of the oversized execute() methods in five model use cases (get-default-model, set-org/set-user-default-language-model, update/delete-permitted-model) into private helpers, bringing each under the complexity and function-length gates. Also adopts BaseUseCase for these five and corrects two type widenings surfaced by the extraction (UUID params, narrowed model in buildUpdatedModel). No behavior change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Structural refactor with preserved auth and business flows; only minor debug log field differences (e.g. dropped `existingDefaultId` on org/user default set).
> 
> **Overview**
> Refactors five model application use cases so **`execute()`** is a thin orchestration layer and complexity/length lint gates pass, with **no intended behavior change**.
> 
> Each use case now **extends `BaseUseCase`** (shared `logger`) instead of declaring its own `Logger`. Authorization, model lookup/validation, default-resolution steps, and debug logging move into **private helpers**—for example `ensureAuthorized`, `findDeletableModel` / `deleteModelByType`, `resolveDefaultModel` with `findUserDefault` / `findTeamDefault` / `findOrgDefault` / `findFirstAvailableModel`, and set-default flows split into find, action label, set, and log helpers. **`UpdatePermittedModelUseCase`** consolidates entity rebuild into `buildUpdatedModel` with shared `baseProps`.
> 
> Small typing cleanups from the extraction: **`UUID`** on some org/user id parameters and **narrower union returns** where models are validated by `instanceof`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd8231e1b74623ee66f84cb461db110870fcf804. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->