### PR TITLE
wip(inference): add tool normalizer with name codec and schema utilities (AYC-412)

### DIFF
--- a/packages/inference/src/index.ts
+++ b/packages/inference/src/index.ts
@@ -11,6 +11,19 @@ export type {
   ToolUseContent,
 } from './message';
 export type { JsonSchema, ToolSchema } from './tool-schema';
+export {
+  CombinatorFlattener,
+  SchemaWalker,
+  ToolNameCodec,
+  convertDraft04ExclusiveBoundsNode,
+  isRecord,
+} from './tool-normalizer';
+export type {
+  JsonObject,
+  JsonValue,
+  MutableSchema,
+  VisitNode,
+} from './tool-normalizer';
 export type {
   FinishReason,
   ModelProvider,

--- a/packages/inference/src/tool-normalizer/combinator-flattener.spec.ts
+++ b/packages/inference/src/tool-normalizer/combinator-flattener.spec.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest';
+
+import type { MutableSchema } from './walk-schema';
+import { CombinatorFlattener } from './combinator-flattener';
+
+function flatten(schema: MutableSchema): MutableSchema {
+  new CombinatorFlattener(schema).flatten();
+  return schema;
+}
+
+describe('CombinatorFlattener', () => {
+  it('merges oneOf branch properties into the root and drops their required', () => {
+    expect(
+      flatten({
+        type: 'object',
+        oneOf: [
+          { properties: { a: { type: 'string' } }, required: ['a'] },
+          { properties: { b: { type: 'number' } }, required: ['b'] },
+        ],
+      }),
+    ).toEqual({
+      type: 'object',
+      properties: { a: { type: 'string' }, b: { type: 'number' } },
+    });
+  });
+
+  it('keeps required from allOf branches', () => {
+    expect(
+      flatten({
+        type: 'object',
+        allOf: [
+          { properties: { a: { type: 'string' } }, required: ['a'] },
+          { properties: { b: { type: 'number' } }, required: ['b'] },
+        ],
+      }),
+    ).toEqual({
+      type: 'object',
+      properties: { a: { type: 'string' }, b: { type: 'number' } },
+      required: ['a', 'b'],
+    });
+  });
+
+  it('collects properties from combinators nested inside a branch', () => {
+    expect(
+      flatten({
+        type: 'object',
+        oneOf: [{ allOf: [{ properties: { a: { type: 'string' } } }] }],
+      }),
+    ).toEqual({
+      type: 'object',
+      properties: { a: { type: 'string' } },
+    });
+  });
+
+  it('hoists branch $defs under their original key', () => {
+    expect(
+      flatten({
+        type: 'object',
+        allOf: [
+          {
+            $defs: { Addr: { type: 'object' } },
+            properties: { home: { $ref: '#/$defs/Addr' } },
+            required: ['home'],
+          },
+        ],
+      }),
+    ).toEqual({
+      type: 'object',
+      properties: { home: { $ref: '#/$defs/Addr' } },
+      required: ['home'],
+      $defs: { Addr: { type: 'object' } },
+    });
+  });
+
+  it('keeps root defs when a branch defines the same name (first wins)', () => {
+    expect(
+      flatten({
+        type: 'object',
+        $defs: { Addr: { type: 'object' } },
+        properties: { home: { $ref: '#/$defs/Addr' } },
+        allOf: [
+          {
+            $defs: { Addr: { type: 'string' }, Extra: { type: 'number' } },
+            properties: { other: { $ref: '#/$defs/Extra' } },
+          },
+        ],
+      }),
+    ).toEqual({
+      type: 'object',
+      properties: {
+        home: { $ref: '#/$defs/Addr' },
+        other: { $ref: '#/$defs/Extra' },
+      },
+      $defs: { Addr: { type: 'object' }, Extra: { type: 'number' } },
+    });
+  });
+
+  it('leaves schemas without top-level combinators untouched', () => {
+    expect(flatten({ type: 'object' })).toEqual({ type: 'object' });
+  });
+});

--- a/packages/inference/src/tool-normalizer/combinator-flattener.ts
+++ b/packages/inference/src/tool-normalizer/combinator-flattener.ts
@@ -1,0 +1,97 @@
+import type { JsonObject, JsonValue } from './json-value';
+import type { MutableSchema } from './walk-schema';
+import { DEFS_KEYS, isRecord } from './walk-schema';
+
+const COMBINATOR_KEYS = ['oneOf', 'anyOf', 'allOf'] as const;
+
+type DefsKey = (typeof DEFS_KEYS)[number];
+
+// Merges top-level `oneOf`/`anyOf`/`allOf` branches into the root, for
+// providers that reject combinators there (Anthropic, OpenAI strict mode).
+// Only `allOf` keeps `required` (its branches all apply); `oneOf`/`anyOf`
+// requirements are alternatives and are dropped.
+export class CombinatorFlattener {
+  private readonly properties: JsonObject;
+  private readonly required: Set<string>;
+  private readonly defs: Record<DefsKey, JsonObject>;
+
+  constructor(private readonly root: MutableSchema) {
+    this.properties = isRecord(root.properties) ? { ...root.properties } : {};
+    this.required = new Set(asStringArray(root.required));
+    // Seeded from the root so branch defs merge first-wins against it —
+    // a branch must never rewire what the root's `$ref`s resolve to.
+    this.defs = {
+      $defs: { ...asObject(root.$defs) },
+      definitions: { ...asObject(root.definitions) },
+    };
+  }
+
+  flatten(): void {
+    let flattened = false;
+    for (const combinator of COMBINATOR_KEYS) {
+      const branches = this.root[combinator];
+      if (!Array.isArray(branches)) continue;
+      delete this.root[combinator];
+      flattened = true;
+      for (const branch of branches.filter(isRecord)) {
+        this.collect(branch, combinator === 'allOf');
+      }
+    }
+    if (flattened) this.writeBack();
+  }
+
+  // Descends through combinators nested inside a branch so params and their
+  // definitions are never silently dropped; `required` only propagates
+  // through further `allOf` nesting.
+  private collect(branch: JsonObject, mergeRequired: boolean): void {
+    mergeFirstWins(this.properties, branch.properties);
+    for (const key of DEFS_KEYS) {
+      mergeFirstWins(this.defs[key], branch[key]);
+    }
+    if (mergeRequired) {
+      asStringArray(branch.required).forEach((name) => this.required.add(name));
+    }
+    for (const combinator of COMBINATOR_KEYS) {
+      const nested = branch[combinator];
+      if (!Array.isArray(nested)) continue;
+      for (const child of nested.filter(isRecord)) {
+        this.collect(child, mergeRequired && combinator === 'allOf');
+      }
+    }
+  }
+
+  private writeBack(): void {
+    this.root.properties = this.properties;
+    if (this.required.size > 0) {
+      this.root.required = [...this.required];
+    }
+    // Keep each defs collection under its original key so `$ref` paths
+    // (`#/$defs/…` vs `#/definitions/…`) still resolve.
+    for (const key of DEFS_KEYS) {
+      if (Object.keys(this.defs[key]).length > 0) {
+        this.root[key] = this.defs[key];
+      }
+    }
+  }
+}
+
+// Copies `source`'s entries into `target`, keeping any existing key.
+function mergeFirstWins(
+  target: JsonObject,
+  source: JsonValue | undefined,
+): void {
+  if (!isRecord(source)) return;
+  for (const [name, value] of Object.entries(source)) {
+    target[name] ??= value;
+  }
+}
+
+function asObject(value: JsonValue | undefined): JsonObject {
+  return isRecord(value) ? value : {};
+}
+
+function asStringArray(value: JsonValue | undefined): string[] {
+  return Array.isArray(value)
+    ? value.filter((v): v is string => typeof v === 'string')
+    : [];
+}

--- a/packages/inference/src/tool-normalizer/draft04-compat.spec.ts
+++ b/packages/inference/src/tool-normalizer/draft04-compat.spec.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+
+import { convertDraft04ExclusiveBoundsNode } from './draft04-compat';
+
+describe('convertDraft04ExclusiveBoundsNode', () => {
+  it('leaves modern numeric bounds untouched', () => {
+    const node = { type: 'number', exclusiveMinimum: 0, maximum: 10 };
+    convertDraft04ExclusiveBoundsNode(node);
+    expect(node).toEqual({ type: 'number', exclusiveMinimum: 0, maximum: 10 });
+  });
+
+  it('converts a boolean exclusiveMinimum to its numeric form', () => {
+    const node = { type: 'number', minimum: 0, exclusiveMinimum: true };
+    convertDraft04ExclusiveBoundsNode(node);
+    expect(node).toEqual({ type: 'number', exclusiveMinimum: 0 });
+  });
+
+  it('converts a boolean exclusiveMaximum to its numeric form', () => {
+    const node = { type: 'number', maximum: 10, exclusiveMaximum: true };
+    convertDraft04ExclusiveBoundsNode(node);
+    expect(node).toEqual({ type: 'number', exclusiveMaximum: 10 });
+  });
+
+  it('drops boolean exclusive bounds without a numeric counterpart', () => {
+    const node = {
+      type: 'number',
+      exclusiveMinimum: false,
+      exclusiveMaximum: true,
+    };
+    convertDraft04ExclusiveBoundsNode(node);
+    expect(node).toEqual({ type: 'number' });
+  });
+});

--- a/packages/inference/src/tool-normalizer/draft04-compat.ts
+++ b/packages/inference/src/tool-normalizer/draft04-compat.ts
@@ -1,0 +1,33 @@
+import type { JsonObject } from './json-value';
+
+// Exclusive-bound keyword → the inclusive bound it qualifies in draft-04.
+const BOUND_FOR = {
+  exclusiveMinimum: 'minimum',
+  exclusiveMaximum: 'maximum',
+} as const;
+
+/**
+ * Draft-04 JSON Schema expressed exclusive bounds as booleans qualifying
+ * `minimum` / `maximum`; draft 2020-12 expects the numeric bound itself.
+ * MCP servers still emit the draft-04 form, which LLM provider APIs reject.
+ * Converts both bounds on a single schema node, in place.
+ */
+export function convertDraft04ExclusiveBoundsNode(node: JsonObject): void {
+  convertBound(node, 'exclusiveMinimum');
+  convertBound(node, 'exclusiveMaximum');
+}
+
+function convertBound(
+  schema: JsonObject,
+  exclusiveKey: keyof typeof BOUND_FOR,
+): void {
+  const boundKey = BOUND_FOR[exclusiveKey];
+  const exclusive = schema[exclusiveKey];
+  if (typeof exclusive !== 'boolean') return;
+  if (exclusive && typeof schema[boundKey] === 'number') {
+    schema[exclusiveKey] = schema[boundKey];
+    delete schema[boundKey];
+  } else {
+    delete schema[exclusiveKey];
+  }
+}

--- a/packages/inference/src/tool-normalizer/index.ts
+++ b/packages/inference/src/tool-normalizer/index.ts
@@ -1,0 +1,6 @@
+export { convertDraft04ExclusiveBoundsNode } from './draft04-compat';
+export { SchemaWalker, isRecord } from './walk-schema';
+export { ToolNameCodec } from './tool-name-codec';
+export { CombinatorFlattener } from './combinator-flattener';
+export type { MutableSchema, VisitNode } from './walk-schema';
+export type { JsonObject, JsonValue } from './json-value';

--- a/packages/inference/src/tool-normalizer/json-value.ts
+++ b/packages/inference/src/tool-normalizer/json-value.ts
@@ -1,0 +1,6 @@
+export type JsonValue =
+  string | number | boolean | null | JsonValue[] | JsonObject;
+
+export interface JsonObject {
+  [key: string]: JsonValue;
+}

--- a/packages/inference/src/tool-normalizer/tool-name-codec.spec.ts
+++ b/packages/inference/src/tool-normalizer/tool-name-codec.spec.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it } from 'vitest';
+
+import { ToolNameCodec } from './tool-name-codec';
+
+const tool = (name: string) => ({ name, description: 'd', parameters: {} });
+
+describe('ToolNameCodec', () => {
+  it('passes provider-safe names through verbatim', () => {
+    const codec = new ToolNameCodec([tool('search_documents')]);
+    expect(codec.encode('search_documents')).toBe('search_documents');
+    expect(codec.decode('search_documents')).toBe('search_documents');
+  });
+
+  it('sanitizes unsafe characters and round-trips back to the original', () => {
+    const codec = new ToolNameCodec([tool('notion.search')]);
+    expect(codec.encode('notion.search')).toBe('notion_search');
+    expect(codec.decode('notion_search')).toBe('notion.search');
+  });
+
+  it('suffixes a stable hash when a sanitized name collides with a verbatim one', () => {
+    const codec = new ToolNameCodec([
+      tool('code_execution'),
+      tool('code.execution'),
+    ]);
+    expect(codec.encode('code_execution')).toBe('code_execution');
+    const wire = codec.encode('code.execution');
+    expect(wire).toMatch(/^code_execution_[a-z0-9]{6}$/);
+    expect(codec.decode(wire)).toBe('code.execution');
+  });
+
+  it('suffixes both when two transformed names share a sanitized base', () => {
+    const codec = new ToolNameCodec([tool('a.b'), tool('a:b')]);
+    const first = codec.encode('a.b');
+    const second = codec.encode('a:b');
+    expect(first).not.toBe(second);
+    expect(first).toMatch(/^a_b_[a-z0-9]{6}$/);
+    expect(second).toMatch(/^a_b_[a-z0-9]{6}$/);
+    expect(codec.decode(first)).toBe('a.b');
+    expect(codec.decode(second)).toBe('a:b');
+  });
+
+  it('is deterministic regardless of tool order', () => {
+    const toolsA = [
+      tool('code_execution'),
+      tool('code.execution'),
+      tool('a.b'),
+    ];
+    const toolsB = [...toolsA].reverse();
+    const a = new ToolNameCodec(toolsA);
+    const b = new ToolNameCodec(toolsB);
+    for (const t of toolsA) {
+      expect(a.encode(t.name)).toBe(b.encode(t.name));
+    }
+  });
+
+  it('keeps wire names within 64 characters, suffix included', () => {
+    const long = 'x'.repeat(80) + '.' + 'y'.repeat(10);
+    const codec = new ToolNameCodec([tool(long)]);
+    const wire = codec.encode(long);
+    expect(wire.length).toBeLessThanOrEqual(64);
+    expect(codec.decode(wire)).toBe(long);
+  });
+
+  it('falls back to a hashed placeholder for names without safe characters', () => {
+    const codec = new ToolNameCodec([tool('äöü')]);
+    const wire = codec.encode('äöü');
+    expect(wire).toMatch(/^[a-zA-Z0-9_-]{1,64}$/);
+    expect(codec.decode(wire)).toBe('äöü');
+  });
+
+  it('extends the suffix when a generated wire name is already taken', () => {
+    // Learn the suffix 'code.execution' gets, then declare a safe tool with
+    // exactly that literal name — the transformed tool must move aside.
+    const probe = new ToolNameCodec([
+      tool('code_execution'),
+      tool('code.execution'),
+    ]);
+    const occupied = probe.encode('code.execution');
+
+    const codec = new ToolNameCodec([
+      tool('code_execution'),
+      tool('code.execution'),
+      tool(occupied),
+    ]);
+    expect(codec.encode(occupied)).toBe(occupied);
+    const moved = codec.encode('code.execution');
+    expect(moved).not.toBe(occupied);
+    expect(moved).not.toBe('code_execution');
+    expect(codec.decode(moved)).toBe('code.execution');
+  });
+
+  it('guarantees unique wire names for adversarial tool sets', () => {
+    const originals = [
+      'code_execution',
+      'code.execution',
+      'code:execution',
+      'code execution',
+      'a.b',
+      'a:b',
+      'a_b',
+    ];
+    const codec = new ToolNameCodec(originals.map(tool));
+    const wires = originals.map((name) => codec.encode(name));
+    expect(new Set(wires).size).toBe(originals.length);
+    for (let i = 0; i < originals.length; i++) {
+      expect(codec.decode(wires[i])).toBe(originals[i]);
+    }
+  });
+
+  it('keeps a departed tool off a declared wire name (no conflation)', () => {
+    // 'foo.bar' was detached; 'foo_bar' is a live tool. The departed tool's
+    // history must not be attributed to the live one.
+    const codec = new ToolNameCodec([tool('foo_bar')]);
+    const wire = codec.encode('foo.bar');
+    expect(wire).not.toBe('foo_bar');
+    expect(wire).toMatch(/^foo_bar_[a-z0-9]{6}$/);
+  });
+
+  it('passes a safe name matching a declared wire name through unchanged', () => {
+    // Safe unknown names are never remapped, even when they coincide with
+    // a declared tool's wire form.
+    const codec = new ToolNameCodec([tool('notion.search')]);
+    expect(codec.encode('notion_search')).toBe('notion_search');
+  });
+
+  it('passes safe unknown names through both directions', () => {
+    const codec = new ToolNameCodec([tool('known')]);
+    expect(codec.encode('not_in_map')).toBe('not_in_map');
+    expect(codec.decode('not_in_map')).toBe('not_in_map');
+  });
+
+  it('sanitizes unknown unsafe names on the way out (departed tools in history)', () => {
+    const codec = new ToolNameCodec([tool('known')]);
+    // A tool detached mid-conversation is absent from the map, but its
+    // historical calls must still reach the wire under a safe name.
+    expect(codec.encode('departed.tool')).toBe('departed_tool');
+  });
+
+  it('decodes a departed tool wire name back to its canonical form', () => {
+    const codec = new ToolNameCodec([tool('known')]);
+    const wire = codec.encode('departed.tool');
+    expect(codec.decode(wire)).toBe('departed.tool');
+  });
+
+  it('gives distinct wire names to two departed tools sharing a base', () => {
+    const codec = new ToolNameCodec([tool('known')]);
+    const first = codec.encode('a.b');
+    const second = codec.encode('a:b');
+    expect(first).not.toBe(second);
+    expect(codec.decode(first)).toBe('a.b');
+    expect(codec.decode(second)).toBe('a:b');
+  });
+
+  it('collapses duplicate declared names into a single mapping', () => {
+    const codec = new ToolNameCodec([
+      tool('notion.search'),
+      tool('notion.search'),
+    ]);
+    const wire = codec.encode('notion.search');
+    expect(wire).toBe('notion_search');
+    expect(codec.decode(wire)).toBe('notion.search');
+  });
+
+  it('gives a departed tool the same wire name it had while declared', () => {
+    // 'foo.bar' collided with 'foo_bar' last turn and got a suffix; after it
+    // detaches, its history must still encode to that same suffixed name.
+    const declared = new ToolNameCodec([tool('foo_bar'), tool('foo.bar')]);
+    const liveWire = declared.encode('foo.bar');
+
+    const afterDetach = new ToolNameCodec([tool('foo_bar')]);
+    expect(afterDetach.encode('foo.bar')).toBe(liveWire);
+  });
+
+  it('keeps probing when a departed tool suffixed name is also taken', () => {
+    // Learn the suffix 'foo.bar' would get, then declare tools occupying both
+    // the base and that suffixed name — the departed tool must land elsewhere.
+    const probe = new ToolNameCodec([tool('foo_bar'), tool('foo.bar')]);
+    const occupied = probe.encode('foo.bar');
+
+    const codec = new ToolNameCodec([tool('foo_bar'), tool(occupied)]);
+    const wire = codec.encode('foo.bar');
+    expect(wire).not.toBe('foo_bar');
+    expect(wire).not.toBe(occupied);
+    expect(wire).toMatch(/^foo_bar_[a-z0-9]{6}$/);
+  });
+});

--- a/packages/inference/src/tool-normalizer/tool-name-codec.ts
+++ b/packages/inference/src/tool-normalizer/tool-name-codec.ts
@@ -1,0 +1,159 @@
+import type { ToolSchema } from '../tool-schema';
+
+// The strictest provider rules: Anthropic/OpenAI charset, OpenAI's 64-char cap.
+const WIRE_NAME_RE = /^[A-Za-z0-9_-]{1,64}$/;
+const MAX_WIRE_NAME_LENGTH = 64;
+const HASH_LENGTH = 6;
+const HASH_SUFFIX_LENGTH = 1 + HASH_LENGTH;
+
+// Bidirectional per-request codec between canonical tool names and the
+// provider-safe names presented on the wire. Deterministic and
+// order-independent: safe names always keep their exact name, transformed
+// names are resolved in sorted order with collision probing, so the same
+// tool set always yields the same unique mapping (stored conversations
+// replay consistently).
+export class ToolNameCodec {
+  private readonly wireByCanonical = new Map<string, string>();
+  private readonly canonicalByWire = new Map<string, string>();
+
+  constructor(tools: readonly ToolSchema[]) {
+    const names = unique(tools.map((tool) => tool.name));
+    const unsafeNames = names.filter((name) => !isWireSafe(name));
+    const unsafeBaseCounts = countBy(unsafeNames, toWireSafeName);
+
+    // Safe names are never renamed — they claim their exact name first, so
+    // stored conversations that carry them keep matching across requests.
+    for (const name of names.filter(isWireSafe)) {
+      this.claim(name, name);
+    }
+
+    for (const name of unsafeNames.toSorted(compareCodeUnit)) {
+      this.claim(name, this.resolveDeclaredName(name, unsafeBaseCounts));
+    }
+  }
+
+  encode(canonical: string): string {
+    return (
+      this.wireByCanonical.get(canonical) ??
+      this.resolveHistoricalName(canonical)
+    );
+  }
+
+  decode(wire: string): string {
+    return this.canonicalByWire.get(wire) ?? wire;
+  }
+
+  private resolveDeclaredName(
+    canonical: string,
+    unsafeBaseCounts: ReadonlyMap<string, number>,
+  ): string {
+    const base = toWireSafeName(canonical);
+    const needsSuffix =
+      (unsafeBaseCounts.get(base) ?? 0) > 1 || this.canonicalByWire.has(base);
+    const preferred = needsSuffix ? addHashSuffix(base, canonical, 0) : base;
+
+    return this.firstFreeName(preferred, base, canonical);
+  }
+
+  // A name absent from the map belongs to a tool detached mid-conversation.
+  // Safe names pass through untouched; unsafe names are sanitized — but
+  // never onto a declared tool's wire name, which would misattribute the
+  // call. The result is claimed so decode can reverse it and later departed
+  // names cannot land on the same wire name.
+  private resolveHistoricalName(canonical: string): string {
+    if (isWireSafe(canonical)) {
+      return canonical;
+    }
+
+    const base = toWireSafeName(canonical);
+    const preferred = this.canonicalByWire.has(base)
+      ? addHashSuffix(base, canonical, 0)
+      : base;
+
+    const wire = this.firstFreeName(preferred, base, canonical);
+    this.claim(canonical, wire);
+    return wire;
+  }
+
+  private firstFreeName(
+    preferred: string,
+    base: string,
+    canonical: string,
+  ): string {
+    let candidate = preferred;
+    let attempt = 0;
+
+    while (this.canonicalByWire.has(candidate)) {
+      attempt += 1;
+      candidate = addHashSuffix(base, canonical, attempt);
+    }
+
+    return candidate;
+  }
+
+  private claim(canonical: string, wire: string): void {
+    this.wireByCanonical.set(canonical, wire);
+    this.canonicalByWire.set(wire, canonical);
+  }
+}
+
+function isWireSafe(name: string): boolean {
+  return WIRE_NAME_RE.test(name);
+}
+
+function toWireSafeName(name: string): string {
+  const safe = name
+    .replace(/[^A-Za-z0-9_-]/g, '_')
+    .slice(0, MAX_WIRE_NAME_LENGTH);
+  return /[A-Za-z0-9]/.test(safe) ? safe : `tool_${hash(name)}`;
+}
+
+// Hash of the canonical name disambiguates (canonicals are unique per
+// request); `attempt` extends the input when a hash itself is contested.
+function addHashSuffix(
+  base: string,
+  canonical: string,
+  attempt: number,
+): string {
+  const seed = attempt === 0 ? canonical : `${canonical}#${attempt}`;
+  const suffix = `_${hash(seed)}`;
+
+  return `${base.slice(0, MAX_WIRE_NAME_LENGTH - HASH_SUFFIX_LENGTH)}${suffix}`;
+}
+
+// Code-unit comparison, not locale-dependent localeCompare — determinism
+// must hold across platforms.
+function compareCodeUnit(a: string, b: string): number {
+  // eslint-disable-next-line sonarjs/no-nested-conditional
+  return a < b ? -1 : a > b ? 1 : 0;
+}
+
+function unique<T>(items: readonly T[]): T[] {
+  return [...new Set(items)];
+}
+
+function countBy<T>(
+  items: readonly T[],
+  keyOf: (item: T) => string,
+): Map<string, number> {
+  const counts = new Map<string, number>();
+
+  for (const item of items) {
+    const key = keyOf(item);
+    counts.set(key, (counts.get(key) ?? 0) + 1);
+  }
+
+  return counts;
+}
+
+// FNV-1a 32-bit, base36 — stable across runs and platforms.
+function hash(input: string): string {
+  let value = 0x811c9dc5;
+
+  for (let index = 0; index < input.length; index += 1) {
+    value ^= input.charCodeAt(index);
+    value = Math.imul(value, 0x01000193) >>> 0;
+  }
+
+  return value.toString(36).padStart(HASH_LENGTH, '0').slice(0, HASH_LENGTH);
+}

--- a/packages/inference/src/tool-normalizer/walk-schema.spec.ts
+++ b/packages/inference/src/tool-normalizer/walk-schema.spec.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest';
+
+import type { MutableSchema } from './walk-schema';
+import { SchemaWalker } from './walk-schema';
+
+const identityWalker = new SchemaWalker((node: MutableSchema) => node);
+const markingWalker = new SchemaWalker((node: MutableSchema) => {
+  node.visited = true;
+  return node;
+});
+
+describe('SchemaWalker', () => {
+  it('returns an equal schema for an identity rule', () => {
+    const schema = {
+      type: 'object',
+      properties: { q: { type: 'string' } },
+      required: ['q'],
+    };
+    expect(identityWalker.walk(schema)).toEqual(schema);
+  });
+
+  it('visits nested schemas in properties, $defs, items and combinators', () => {
+    expect(
+      markingWalker.walk({
+        properties: { a: { type: 'string' } },
+        $defs: { b: { type: 'number' } },
+        items: { type: 'integer' },
+        anyOf: [{ type: 'boolean' }],
+      }),
+    ).toEqual({
+      visited: true,
+      properties: { a: { type: 'string', visited: true } },
+      $defs: { b: { type: 'number', visited: true } },
+      items: { type: 'integer', visited: true },
+      anyOf: [{ type: 'boolean', visited: true }],
+    });
+  });
+
+  it('does not descend into data-value keys like default and enum', () => {
+    expect(
+      markingWalker.walk({
+        properties: {
+          a: { type: 'object', default: { nested: true }, enum: ['x'] },
+        },
+      }),
+    ).toEqual({
+      visited: true,
+      properties: {
+        a: {
+          type: 'object',
+          visited: true,
+          default: { nested: true },
+          enum: ['x'],
+        },
+      },
+    });
+  });
+
+  it('collapses tuple-form items into a single anyOf schema', () => {
+    expect(
+      identityWalker.walk({
+        type: 'array',
+        items: [{ type: 'number' }, { type: 'string' }],
+        additionalItems: false,
+      }),
+    ).toEqual({
+      type: 'array',
+      items: { anyOf: [{ type: 'number' }, { type: 'string' }] },
+    });
+  });
+
+  it('walks tuple entries recursively', () => {
+    expect(
+      markingWalker.walk({
+        type: 'array',
+        items: [{ type: 'array', items: [{ type: 'number' }] }],
+      }),
+    ).toEqual({
+      type: 'array',
+      visited: true,
+      items: {
+        anyOf: [
+          {
+            type: 'array',
+            visited: true,
+            items: { anyOf: [{ type: 'number', visited: true }] },
+          },
+        ],
+      },
+    });
+  });
+
+  it('does not mutate the input schema', () => {
+    const schema = {
+      type: 'array',
+      items: [{ type: 'number' }],
+      properties: { a: { type: 'string' } },
+    };
+    const copy = structuredClone(schema);
+    markingWalker.walk(schema);
+    expect(schema).toEqual(copy);
+  });
+});

--- a/packages/inference/src/tool-normalizer/walk-schema.ts
+++ b/packages/inference/src/tool-normalizer/walk-schema.ts
@@ -1,0 +1,73 @@
+import type { JsonObject, JsonValue } from './json-value';
+import type { JsonSchema } from '../tool-schema';
+
+export type MutableSchema = JsonObject;
+export type VisitNode = (node: MutableSchema) => MutableSchema; // Receives a fresh shallow copy of a schema node — mutate and return it.
+
+// Keys holding reusable sub-schema definitions `$ref` may point at. The walk
+// must descend into every key the flattener hoists, so both derive from this.
+export const DEFS_KEYS = ['$defs', 'definitions'] as const;
+const SCHEMA_MAP_KEYS = new Set(['properties', ...DEFS_KEYS]);
+const OPAQUE_VALUE_KEYS = new Set(['default', 'example', 'const', 'enum']);
+
+// Recursively applies a provider's per-node rule to a JSON schema without
+// mutating the input. Collapses draft-04/-07 tuple-form `items` on the way,
+// since no provider accepts an array there.
+export class SchemaWalker {
+  constructor(private readonly visitNode: VisitNode) {}
+
+  walk(schema: JsonSchema): JsonObject {
+    // Wire data is JSON, so its values are JsonValue by construction.
+    return this.walkNode(schema as MutableSchema);
+  }
+
+  private walkNode(input: Readonly<MutableSchema>): MutableSchema {
+    const node = this.visitNode({ ...input });
+    // `additionalItems` only qualifies tuple validation, which collapses below.
+    if (Array.isArray(node.items)) delete node.additionalItems;
+    for (const [key, value] of Object.entries(node)) {
+      node[key] = this.walkValue(key, value);
+    }
+    return node;
+  }
+
+  private walkValue(key: string, value: JsonValue): JsonValue {
+    if (OPAQUE_VALUE_KEYS.has(key)) {
+      return value;
+    }
+
+    let walked: JsonValue = value;
+    if (SCHEMA_MAP_KEYS.has(key) && isRecord(value)) {
+      walked = mapValues(value, (child) =>
+        isRecord(child) ? this.walkNode(child) : child,
+      );
+    } else if (key === 'items' && Array.isArray(value)) {
+      walked = { anyOf: this.walkEntries(value) };
+    } else if (Array.isArray(value)) {
+      walked = this.walkEntries(value);
+    } else if (isRecord(value)) {
+      walked = this.walkNode(value);
+    }
+
+    return walked;
+  }
+
+  private walkEntries(entries: JsonValue[]): JsonValue[] {
+    return entries.map((entry) =>
+      isRecord(entry) ? this.walkNode(entry) : entry,
+    );
+  }
+}
+
+function mapValues(
+  obj: JsonObject,
+  fn: (value: JsonValue) => JsonValue,
+): JsonObject {
+  return Object.fromEntries(
+    Object.entries(obj).map(([key, value]) => [key, fn(value)]),
+  );
+}
+
+export function isRecord(value: unknown): value is JsonObject {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}


### PR DESCRIPTION
## What

Adds a shared `tool-normalizer` toolkit to `packages/inference`, used by all provider packages in the PRs stacked above:

- **`ToolNameCodec`** — a per-request, bidirectional map between canonical tool names (`notion.search`) and provider-safe wire names (`notion_search`). Canonical names live everywhere in the app (DB, execution, UI); the wire name exists only inside a provider request.
- **`SchemaWalker`** — recursive JSON-schema traversal shared by the provider normalizers (handles `$defs`, tuple items, opaque value keys).
- **`CombinatorFlattener`** — merges top-level `oneOf`/`anyOf`/`allOf` (Anthropic and OpenAI strict mode both reject root combinators).
- **draft-04 compat** — converts boolean `exclusiveMinimum`/`exclusiveMaximum` to numeric draft-07+ form.
- **`JsonValue`/`JsonObject`** — strict recursive JSON types; no `any`.

## Why in the provider packages

Each LLM API rejects a different schema dialect and tool-name pattern (Anthropic: `^[a-zA-Z0-9_-]{1,128}$`; OpenAI strict: 64 chars; Gemini: OpenAPI subset). That is wire-format knowledge, exactly what the provider packages exist to encapsulate. Handling it there means no domain module ever needs to know about provider naming rules, and adding a provider never touches the backend.

## Codec guarantees (all tested)

- **Deterministic and order-independent**: the same tool set always produces the same mapping — safe names are never renamed; transformed names resolve in sorted code-unit order with collision probing (FNV-1a hash suffixes).
- **Uniqueness enforced**, not just probable: probing extends the hash seed until a free wire name is found, even for adversarial tool sets.
- **Departed tools never conflate**: a tool detached mid-conversation encodes its history under the same wire name it had while declared — never onto a live tool's wire name.
- Inbound tool calls are decoded back to canonical names; when a name was translated, the original wire name is recorded in `providerMetadata.wireName` for auditability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Incorrect name or schema normalization could misroute tool calls or send schemas providers reject; behavior is complex but isolated in new, heavily tested library code with no direct production wiring in this diff.
> 
> **Overview**
> Introduces a new **`tool-normalizer`** module in `packages/inference` and re-exports it from the package entry so provider adapters can normalize MCP tool names and JSON Schemas before LLM APIs.
> 
> **`ToolNameCodec`** maps canonical tool names (e.g. `notion.search`) to provider-safe wire names (`notion_search`), with deterministic collision handling, a 64-character cap, and stable encoding for tools removed mid-conversation so history does not conflate with live tools.
> 
> **`SchemaWalker`** walks schemas immutably (properties, `$defs`, combinators), skips opaque value keys, and collapses tuple `items` arrays into `anyOf`. **`CombinatorFlattener`** merges top-level `oneOf`/`anyOf`/`allOf` into the root object for APIs that reject root combinators. **`convertDraft04ExclusiveBoundsNode`** rewrites draft-04 boolean `exclusiveMinimum`/`exclusiveMaximum` to numeric draft-07+ form.
> 
> Vitest coverage is included for each component.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88ea2b19a7a8c9c4b87f76ad8c1730e491ea2842. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->