### PR TITLE
fix(inference): normalize tool schemas and wire names for anthropic (AYC-412)

### DIFF
--- a/packages/provider-anthropic/src/anthropic-provider.ts
+++ b/packages/provider-anthropic/src/anthropic-provider.ts
@@ -6,6 +6,7 @@ import type {
   ProviderChunk,
   ProviderRequest,
 } from '@ayunis/inference';
+import { ToolNameCodec } from '@ayunis/inference';
 
 import { convertChunk } from './convert-chunk';
 import {
@@ -81,13 +82,14 @@ async function* streamMessages(
   maxTokens: number,
   request: ProviderRequest,
 ): AsyncIterable<ProviderChunk> {
-  const params = buildParams(model, maxTokens, request);
+  const codec = new ToolNameCodec(request.tools);
+  const params = buildParams(model, maxTokens, request, codec);
   const stream = await client.messages.create(
     params,
     request.signal ? { signal: request.signal } : undefined,
   );
   for await (const event of stream) {
-    const chunk = convertChunk(event);
+    const chunk = convertChunk(event, codec);
     if (chunk) {
       yield chunk;
     }
@@ -98,18 +100,19 @@ const buildParams = (
   model: string,
   maxTokens: number,
   request: ProviderRequest,
+  codec: ToolNameCodec,
 ): MessageCreateParamsStreaming => ({
   model,
   // Two prompt-cache breakpoints: the system block (which also covers the
   // tool definitions rendered before it) and the conversation tail, so each
   // turn and agent-loop iteration reuses the previous request's cache.
   system: convertSystem(request.instructions),
-  messages: markCacheBreakpoint(convertMessages(request.messages)),
-  tools: request.tools.map(convertTool),
+  messages: markCacheBreakpoint(convertMessages(request.messages, codec)),
+  tools: request.tools.map((tool) => convertTool(tool, codec)),
   // Anthropic rejects tool_choice when no tools are supplied, so only send it
   // alongside a non-empty tools array.
   ...(request.tools.length > 0 && request.toolChoice !== undefined
-    ? { tool_choice: convertToolChoice(request.toolChoice) }
+    ? { tool_choice: convertToolChoice(request.toolChoice, codec) }
     : {}),
   max_tokens: maxTokens,
   stream: true,

--- a/packages/provider-anthropic/src/convert-chunk.spec.ts
+++ b/packages/provider-anthropic/src/convert-chunk.spec.ts
@@ -1,10 +1,16 @@
 import type Anthropic from '@anthropic-ai/sdk';
 import { describe, expect, it } from 'vitest';
 
-import { convertChunk } from './convert-chunk';
+import { ToolNameCodec } from '@ayunis/inference';
+
+import { convertChunk as convert } from './convert-chunk';
 
 const event = (value: unknown): Anthropic.Messages.MessageStreamEvent =>
   value as Anthropic.Messages.MessageStreamEvent;
+
+// Passthrough map — name translation is covered by its own tests below.
+const convertChunk = (e: Anthropic.Messages.MessageStreamEvent) =>
+  convert(e, new ToolNameCodec([]));
 
 describe('convertChunk', () => {
   it('converts message_start to input usage', () => {
@@ -133,5 +139,36 @@ describe('convertChunk', () => {
     expect(
       convertChunk(event({ type: 'content_block_stop', index: 0 })),
     ).toBeNull();
+  });
+});
+
+describe('convertChunk wire-name decoding', () => {
+  it('maps a wire tool name back to the original and records the wire name', () => {
+    const codec = new ToolNameCodec([
+      { name: 'notion.search', description: 'd', parameters: {} },
+    ]);
+    expect(
+      convert(
+        event({
+          type: 'content_block_start',
+          index: 0,
+          content_block: {
+            type: 'tool_use',
+            id: 'toolu_1',
+            name: 'notion_search',
+          },
+        }),
+        codec,
+      ),
+    ).toEqual({
+      toolCallDeltas: [
+        {
+          index: 0,
+          id: 'toolu_1',
+          name: 'notion.search',
+          providerMetadata: { wireName: 'notion_search' },
+        },
+      ],
+    });
   });
 });

--- a/packages/provider-anthropic/src/convert-chunk.ts
+++ b/packages/provider-anthropic/src/convert-chunk.ts
@@ -1,6 +1,10 @@
 import type Anthropic from '@anthropic-ai/sdk';
 
-import type { FinishReason, ProviderChunk } from '@ayunis/inference';
+import type {
+  FinishReason,
+  ProviderChunk,
+  ToolNameCodec,
+} from '@ayunis/inference';
 
 /**
  * Converts one Anthropic stream event to a provider-agnostic chunk.
@@ -8,12 +12,13 @@ import type { FinishReason, ProviderChunk } from '@ayunis/inference';
  */
 export const convertChunk = (
   event: Anthropic.Messages.MessageStreamEvent,
+  codec: ToolNameCodec,
 ): ProviderChunk | null => {
   switch (event.type) {
     case 'content_block_delta':
       return convertContentBlockDelta(event);
     case 'content_block_start':
-      return convertContentBlockStart(event);
+      return convertContentBlockStart(event, codec);
     case 'message_start': {
       // input_tokens excludes tokens covered by the prompt cache; the cache
       // fields carry the rest of the prompt so hosts can account for it.
@@ -64,16 +69,21 @@ const convertContentBlockDelta = (
 
 const convertContentBlockStart = (
   event: Anthropic.Messages.ContentBlockStartEvent,
+  codec: ToolNameCodec,
 ): ProviderChunk | null => {
   if (event.content_block.type !== 'tool_use') {
     return null;
   }
+  const wireName = event.content_block.name;
+  const name = codec.decode(wireName);
   return {
     toolCallDeltas: [
       {
         index: event.index,
         id: event.content_block.id,
-        name: event.content_block.name,
+        name,
+        // Record what the model actually saw when names were translated.
+        ...(name !== wireName ? { providerMetadata: { wireName } } : {}),
       },
     ],
   };

--- a/packages/provider-anthropic/src/convert-request.spec.ts
+++ b/packages/provider-anthropic/src/convert-request.spec.ts
@@ -1,13 +1,23 @@
 import type { Message } from '@ayunis/inference';
+import { ToolNameCodec } from '@ayunis/inference';
 import { describe, expect, it } from 'vitest';
 
 import {
-  convertMessages,
+  convertMessages as convertMessagesFn,
   convertSystem,
-  convertTool,
-  convertToolChoice,
+  convertTool as convertToolFn,
+  convertToolChoice as convertToolChoiceFn,
   markCacheBreakpoint,
 } from './convert-request';
+
+// Passthrough map — name translation is covered by its own tests below.
+const passthrough = new ToolNameCodec([]);
+const convertMessages = (messages: Message[]) =>
+  convertMessagesFn(messages, passthrough);
+const convertTool = (tool: Parameters<typeof convertToolFn>[0]) =>
+  convertToolFn(tool, passthrough);
+const convertToolChoice = (choice: Parameters<typeof convertToolChoiceFn>[0]) =>
+  convertToolChoiceFn(choice, passthrough);
 
 describe('convertTool', () => {
   it('maps the schema to Anthropic input_schema', () => {
@@ -21,6 +31,20 @@ describe('convertTool', () => {
       name: 'search',
       description: 'Searches',
       input_schema: { type: 'object', properties: {} },
+    });
+  });
+
+  it('normalizes MCP-style schemas that Anthropic would reject', () => {
+    expect(
+      convertTool({
+        name: 'search',
+        description: 'Searches',
+        parameters: { properties: { q: { type: 'string' } } },
+      }),
+    ).toEqual({
+      name: 'search',
+      description: 'Searches',
+      input_schema: { type: 'object', properties: { q: { type: 'string' } } },
     });
   });
 });
@@ -303,5 +327,46 @@ describe('markCacheBreakpoint', () => {
 
   it('returns an empty message list unchanged', () => {
     expect(markCacheBreakpoint([])).toEqual([]);
+  });
+});
+
+describe('wire-name encoding', () => {
+  const codec = new ToolNameCodec([
+    { name: 'notion.search', description: 'd', parameters: {} },
+  ]);
+
+  it('declares tools under their wire names', () => {
+    expect(
+      convertToolFn(
+        {
+          name: 'notion.search',
+          description: 'd',
+          parameters: { type: 'object' },
+        },
+        codec,
+      ).name,
+    ).toBe('notion_search');
+  });
+
+  it('translates tool_use names in assistant history', () => {
+    const messages: Message[] = [
+      {
+        role: 'assistant',
+        content: [
+          { type: 'tool_use', id: 'toolu_1', name: 'notion.search', input: {} },
+        ],
+      },
+    ];
+    const [assistant] = convertMessagesFn(messages, codec);
+    expect(assistant.content).toEqual([
+      { type: 'tool_use', id: 'toolu_1', name: 'notion_search', input: {} },
+    ]);
+  });
+
+  it('translates a specific tool choice', () => {
+    expect(convertToolChoiceFn({ tool: 'notion.search' }, codec)).toEqual({
+      type: 'tool',
+      name: 'notion_search',
+    });
   });
 });

--- a/packages/provider-anthropic/src/convert-request.ts
+++ b/packages/provider-anthropic/src/convert-request.ts
@@ -5,7 +5,10 @@ import type {
   MessageContent,
   ToolChoice,
   ToolSchema,
+  ToolNameCodec,
 } from '@ayunis/inference';
+
+import { normalizeSchemaForAnthropic } from './normalize-schema';
 
 type AnthropicToolChoice =
   | Anthropic.Messages.ToolChoiceAuto
@@ -65,14 +68,18 @@ export const markCacheBreakpoint = (
   return [...messages.slice(0, -1), { ...lastMessage, content: markedContent }];
 };
 
-export const convertTool = (tool: ToolSchema): Anthropic.Tool => ({
-  name: tool.name,
+export const convertTool = (
+  tool: ToolSchema,
+  codec: ToolNameCodec,
+): Anthropic.Tool => ({
+  name: codec.encode(tool.name),
   description: tool.description,
-  input_schema: tool.parameters as Anthropic.Messages.Tool.InputSchema,
+  input_schema: normalizeSchemaForAnthropic(tool.parameters),
 });
 
 export const convertToolChoice = (
   toolChoice: ToolChoice,
+  codec: ToolNameCodec,
 ): AnthropicToolChoice => {
   if (toolChoice === 'auto') {
     return { type: 'auto' };
@@ -80,7 +87,7 @@ export const convertToolChoice = (
   if (toolChoice === 'required') {
     return { type: 'any' };
   }
-  return { type: 'tool', name: toolChoice.tool };
+  return { type: 'tool', name: codec.encode(toolChoice.tool) };
 };
 
 /**
@@ -90,10 +97,11 @@ export const convertToolChoice = (
  */
 export const convertMessages = (
   messages: readonly Message[],
+  codec: ToolNameCodec,
 ): Anthropic.MessageParam[] => {
   const converted: Anthropic.MessageParam[] = [];
   for (const message of messages) {
-    const next = convertMessage(message);
+    const next = convertMessage(message, codec);
     // A message can convert to nothing (e.g. an assistant turn whose only
     // content was unsigned thinking) — Anthropic rejects empty content.
     if (asBlocks(next.content).length === 0) {
@@ -122,12 +130,15 @@ const asBlocks = (
 ): Anthropic.ContentBlockParam[] =>
   typeof content === 'string' ? [{ type: 'text', text: content }] : content;
 
-const convertMessage = (message: Message): Anthropic.MessageParam => {
+const convertMessage = (
+  message: Message,
+  codec: ToolNameCodec,
+): Anthropic.MessageParam => {
   if (message.role === 'assistant') {
     return {
       role: 'assistant',
       content: message.content
-        .map(convertAssistantContent)
+        .map((content) => convertAssistantContent(content, codec))
         .filter((block): block is NonNullable<typeof block> => block !== null),
     };
   }
@@ -136,6 +147,7 @@ const convertMessage = (message: Message): Anthropic.MessageParam => {
 
 const convertAssistantContent = (
   content: MessageContent,
+  codec: ToolNameCodec,
 ): Anthropic.ContentBlockParam | null => {
   switch (content.type) {
     case 'thinking':
@@ -154,7 +166,7 @@ const convertAssistantContent = (
       return {
         type: 'tool_use',
         id: content.id,
-        name: content.name,
+        name: codec.encode(content.name),
         input: content.input,
       };
     case 'tool_result':

--- a/packages/provider-anthropic/src/normalize-schema.spec.ts
+++ b/packages/provider-anthropic/src/normalize-schema.spec.ts
@@ -1,0 +1,217 @@
+import { describe, expect, it } from 'vitest';
+
+import { normalizeSchemaForAnthropic } from './normalize-schema';
+
+describe('normalizeSchemaForAnthropic', () => {
+  it('leaves a valid object schema untouched', () => {
+    const schema = {
+      type: 'object',
+      properties: { q: { type: 'string' } },
+      required: ['q'],
+    };
+    expect(normalizeSchemaForAnthropic(schema)).toEqual(schema);
+  });
+
+  it('adds top-level type object when missing but properties are present', () => {
+    expect(
+      normalizeSchemaForAnthropic({ properties: { q: { type: 'string' } } }),
+    ).toEqual({ type: 'object', properties: { q: { type: 'string' } } });
+  });
+
+  it('turns an empty schema into an empty object schema', () => {
+    expect(normalizeSchemaForAnthropic({})).toEqual({
+      type: 'object',
+      properties: {},
+    });
+  });
+
+  it('converts draft-04 boolean exclusiveMinimum to its 2020-12 numeric form', () => {
+    expect(
+      normalizeSchemaForAnthropic({
+        type: 'object',
+        properties: {
+          n: { type: 'number', minimum: 0, exclusiveMinimum: true },
+        },
+      }),
+    ).toEqual({
+      type: 'object',
+      properties: { n: { type: 'number', exclusiveMinimum: 0 } },
+    });
+  });
+
+  it('converts draft-04 boolean exclusiveMaximum to its 2020-12 numeric form', () => {
+    expect(
+      normalizeSchemaForAnthropic({
+        type: 'object',
+        properties: {
+          n: { type: 'number', maximum: 10, exclusiveMaximum: true },
+        },
+      }),
+    ).toEqual({
+      type: 'object',
+      properties: { n: { type: 'number', exclusiveMaximum: 10 } },
+    });
+  });
+
+  it('drops boolean exclusive bounds that have no numeric counterpart', () => {
+    expect(
+      normalizeSchemaForAnthropic({
+        type: 'object',
+        properties: {
+          n: {
+            type: 'number',
+            exclusiveMinimum: false,
+            exclusiveMaximum: true,
+          },
+        },
+      }),
+    ).toEqual({
+      type: 'object',
+      properties: { n: { type: 'number' } },
+    });
+  });
+
+  it('flattens a top-level oneOf into merged properties', () => {
+    expect(
+      normalizeSchemaForAnthropic({
+        type: 'object',
+        oneOf: [
+          { properties: { a: { type: 'string' } }, required: ['a'] },
+          { properties: { b: { type: 'number' } }, required: ['b'] },
+        ],
+      }),
+    ).toEqual({
+      type: 'object',
+      properties: { a: { type: 'string' }, b: { type: 'number' } },
+    });
+  });
+
+  it('flattens a top-level allOf and keeps its required fields', () => {
+    expect(
+      normalizeSchemaForAnthropic({
+        type: 'object',
+        allOf: [
+          { properties: { a: { type: 'string' } }, required: ['a'] },
+          { properties: { b: { type: 'number' } }, required: ['b'] },
+        ],
+      }),
+    ).toEqual({
+      type: 'object',
+      properties: { a: { type: 'string' }, b: { type: 'number' } },
+      required: ['a', 'b'],
+    });
+  });
+
+  it('keeps nested oneOf below the top level', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        filter: { oneOf: [{ type: 'string' }, { type: 'number' }] },
+      },
+    };
+    expect(normalizeSchemaForAnthropic(schema)).toEqual(schema);
+  });
+
+  it('normalizes draft-04 bounds inside array items and $defs', () => {
+    expect(
+      normalizeSchemaForAnthropic({
+        type: 'object',
+        properties: {
+          list: {
+            type: 'array',
+            items: { type: 'integer', minimum: 1, exclusiveMinimum: true },
+          },
+        },
+        $defs: {
+          amount: { type: 'number', maximum: 5, exclusiveMaximum: true },
+        },
+      }),
+    ).toEqual({
+      type: 'object',
+      properties: {
+        list: {
+          type: 'array',
+          items: { type: 'integer', exclusiveMinimum: 1 },
+        },
+      },
+      $defs: { amount: { type: 'number', exclusiveMaximum: 5 } },
+    });
+  });
+
+  it('collapses tuple-form items arrays into a single anyOf schema', () => {
+    expect(
+      normalizeSchemaForAnthropic({
+        type: 'object',
+        properties: {
+          point: {
+            type: 'array',
+            items: [{ type: 'number' }, { type: 'string' }],
+          },
+        },
+      }),
+    ).toEqual({
+      type: 'object',
+      properties: {
+        point: {
+          type: 'array',
+          items: { anyOf: [{ type: 'number' }, { type: 'string' }] },
+        },
+      },
+    });
+  });
+
+  it('collects properties from combinators nested inside a branch', () => {
+    expect(
+      normalizeSchemaForAnthropic({
+        type: 'object',
+        oneOf: [{ allOf: [{ properties: { a: { type: 'string' } } }] }],
+      }),
+    ).toEqual({
+      type: 'object',
+      properties: { a: { type: 'string' } },
+    });
+  });
+
+  it('hoists branch $defs to the root so $ref pointers still resolve', () => {
+    expect(
+      normalizeSchemaForAnthropic({
+        type: 'object',
+        allOf: [
+          {
+            $defs: {
+              Addr: {
+                type: 'object',
+                properties: { city: { type: 'string' } },
+              },
+            },
+            properties: { home: { $ref: '#/$defs/Addr' } },
+            required: ['home'],
+          },
+        ],
+      }),
+    ).toEqual({
+      type: 'object',
+      properties: { home: { $ref: '#/$defs/Addr' } },
+      required: ['home'],
+      $defs: {
+        Addr: { type: 'object', properties: { city: { type: 'string' } } },
+      },
+    });
+  });
+
+  it('coerces a non-object root to an empty object schema', () => {
+    expect(normalizeSchemaForAnthropic({ type: 'string' })).toEqual({
+      type: 'object',
+      properties: {},
+    });
+  });
+
+  it('does not mutate the input schema', () => {
+    const schema = {
+      properties: { n: { type: 'number', minimum: 0, exclusiveMinimum: true } },
+    };
+    const copy = structuredClone(schema);
+    normalizeSchemaForAnthropic(schema);
+    expect(schema).toEqual(copy);
+  });
+});

--- a/packages/provider-anthropic/src/normalize-schema.ts
+++ b/packages/provider-anthropic/src/normalize-schema.ts
@@ -1,0 +1,26 @@
+import type Anthropic from '@anthropic-ai/sdk';
+import type { JsonObject, JsonSchema } from '@ayunis/inference';
+import {
+  CombinatorFlattener,
+  SchemaWalker,
+  convertDraft04ExclusiveBoundsNode,
+} from '@ayunis/inference';
+
+export type AnthropicInputSchema = JsonObject &
+  Anthropic.Messages.Tool.InputSchema;
+
+const walker = new SchemaWalker((node) => {
+  convertDraft04ExclusiveBoundsNode(node);
+  return node;
+});
+
+export function normalizeSchemaForAnthropic(
+  schema: JsonSchema,
+): AnthropicInputSchema {
+  const root = walker.walk(schema);
+  new CombinatorFlattener(root).flatten();
+
+  root.type = 'object';
+  root.properties ??= {};
+  return root as AnthropicInputSchema;
+}


### PR DESCRIPTION
Fixes the AYC-412 400s for Claude models. Anthropic rejects tool names outside `^[a-zA-Z0-9_-]{1,128}$` and schemas missing a top-level `type`, with boolean draft-04 exclusive bounds, or with root combinators.

- `normalize-schema.ts`: walks each tool schema (shared `SchemaWalker` from #993), coerces the root to `type: object`, converts draft-04 bounds, flattens root `oneOf`/`anyOf`/`allOf`.
- Wires the `ToolNameCodec` through all four crossings: tool declarations, assistant `tool_use` history, `tool_choice`, and inbound stream chunks (decoded back to canonical names, `providerMetadata.wireName` when translated).

All failure modes were reproduced against the live Anthropic API before the fix and re-verified after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the Anthropic request/response boundary for every tool call (name mapping and schema rewriting); incorrect normalization could alter model-visible tool definitions or break replay, though behavior is covered by extensive unit tests.
> 
> **Overview**
> Fixes Anthropic **400** failures when MCP-style tools use invalid wire names or JSON schemas the API rejects.
> 
> **Tool name translation:** A per-request `ToolNameCodec` now runs through the streaming path—tool declarations, assistant `tool_use` history, `tool_choice`, and inbound stream chunks. Canonical names like `notion.search` are encoded to Anthropic-safe wire names on the way out; stream `tool_use` blocks are decoded back to canonical names, with `providerMetadata.wireName` when a translation happened.
> 
> **Schema normalization:** New `normalizeSchemaForAnthropic` walks each tool’s parameters (shared `SchemaWalker` / `CombinatorFlattener` from inference), coerces the root to `type: object`, converts draft-04 boolean exclusive bounds, flattens root combinators, and handles tuple `items`—replacing the previous raw schema cast on `input_schema`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1ae655a08a39951d01b5f233cbcc394f88e936f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->