### PR TITLE
fix(inference): normalize tool schemas and wire names for openai (AYC-412)

### DIFF
--- a/packages/provider-openai/src/convert-chunk.spec.ts
+++ b/packages/provider-openai/src/convert-chunk.spec.ts
@@ -1,10 +1,16 @@
 import type { ChatCompletionChunk } from 'openai/resources/chat/completions';
 import { describe, expect, it } from 'vitest';
 
-import { convertChunk } from './convert-chunk';
+import { ToolNameCodec } from '@ayunis/inference';
+
+import { convertChunk as convert } from './convert-chunk';
 
 const chunk = (value: unknown): ChatCompletionChunk =>
   value as ChatCompletionChunk;
+
+// Passthrough map — name translation is covered by its own tests below.
+const convertChunk = (c: ChatCompletionChunk) =>
+  convert(c, new ToolNameCodec([]));
 
 describe('convertChunk', () => {
   it('converts a text content delta', () => {
@@ -94,5 +100,36 @@ describe('convertChunk', () => {
     expect(
       convertChunk(chunk({ choices: [{ index: 0, delta: {} }] })),
     ).toBeNull();
+  });
+});
+
+describe('convertChunk wire-name decoding', () => {
+  it('maps a wire tool name back to the original and records the wire name', () => {
+    const codec = new ToolNameCodec([
+      { name: 'notion.search', description: 'd', parameters: {} },
+    ]);
+    const result = convert(
+      chunk({
+        choices: [
+          {
+            delta: {
+              tool_calls: [
+                { index: 0, id: 'call_1', function: { name: 'notion_search' } },
+              ],
+            },
+          },
+        ],
+      }),
+      codec,
+    );
+    expect(result?.toolCallDeltas).toEqual([
+      {
+        index: 0,
+        id: 'call_1',
+        name: 'notion.search',
+        argumentsDelta: null,
+        providerMetadata: { wireName: 'notion_search' },
+      },
+    ]);
   });
 });

--- a/packages/provider-openai/src/convert-chunk.ts
+++ b/packages/provider-openai/src/convert-chunk.ts
@@ -1,6 +1,10 @@
 import type { ChatCompletionChunk } from 'openai/resources/chat/completions';
 
-import type { FinishReason, ProviderChunk } from '@ayunis/inference';
+import type {
+  FinishReason,
+  ProviderChunk,
+  ToolNameCodec,
+} from '@ayunis/inference';
 
 /**
  * Converts one OpenAI Chat Completions stream chunk to a provider-agnostic
@@ -9,6 +13,7 @@ import type { FinishReason, ProviderChunk } from '@ayunis/inference';
  */
 export const convertChunk = (
   chunk: ChatCompletionChunk,
+  codec: ToolNameCodec,
 ): ProviderChunk | null => {
   const result: ProviderChunk = {};
   let carriesSomething = false;
@@ -21,12 +26,20 @@ export const convertChunk = (
       carriesSomething = true;
     }
     if (choice.delta.tool_calls && choice.delta.tool_calls.length > 0) {
-      result.toolCallDeltas = choice.delta.tool_calls.map((call) => ({
-        index: call.index,
-        id: call.id ?? null,
-        name: call.function?.name ?? null,
-        argumentsDelta: call.function?.arguments ?? null,
-      }));
+      result.toolCallDeltas = choice.delta.tool_calls.map((call) => {
+        const wireName = call.function?.name ?? null;
+        const name = wireName === null ? null : codec.decode(wireName);
+        return {
+          index: call.index,
+          id: call.id ?? null,
+          name,
+          argumentsDelta: call.function?.arguments ?? null,
+          // Record what the model actually saw when names were translated.
+          ...(name !== null && name !== wireName
+            ? { providerMetadata: { wireName } }
+            : {}),
+        };
+      });
       carriesSomething = true;
     }
     if (choice.finish_reason) {

--- a/packages/provider-openai/src/convert-request.spec.ts
+++ b/packages/provider-openai/src/convert-request.spec.ts
@@ -1,11 +1,21 @@
 import type { Message } from '@ayunis/inference';
+import { ToolNameCodec } from '@ayunis/inference';
 import { describe, expect, it } from 'vitest';
 
 import {
-  convertMessages,
-  convertTool,
-  convertToolChoice,
+  convertMessages as convertMessagesFn,
+  convertTool as convertToolFn,
+  convertToolChoice as convertToolChoiceFn,
 } from './convert-request';
+
+// Passthrough map — name translation is covered by its own tests below.
+const passthrough = new ToolNameCodec([]);
+const convertMessages = (instructions: string, messages: Message[]) =>
+  convertMessagesFn(instructions, messages, passthrough);
+const convertTool = (tool: Parameters<typeof convertToolFn>[0]) =>
+  convertToolFn(tool, passthrough);
+const convertToolChoice = (choice: Parameters<typeof convertToolChoiceFn>[0]) =>
+  convertToolChoiceFn(choice, passthrough);
 
 describe('convertTool', () => {
   it('maps the schema to a strict OpenAI function tool', () => {
@@ -279,5 +289,49 @@ describe('convertMessages', () => {
     expect(convertMessages('', messages)).toEqual([
       { role: 'assistant', content: 'Answer' },
     ]);
+  });
+});
+
+describe('wire-name encoding', () => {
+  const codec = new ToolNameCodec([
+    { name: 'notion.search', description: 'd', parameters: {} },
+  ]);
+
+  it('declares tools under their wire names', () => {
+    expect(
+      convertToolFn(
+        {
+          name: 'notion.search',
+          description: 'd',
+          parameters: { type: 'object' },
+        },
+        codec,
+      ).function.name,
+    ).toBe('notion_search');
+  });
+
+  it('translates tool_call names in assistant history', () => {
+    const messages: Message[] = [
+      {
+        role: 'assistant',
+        content: [
+          { type: 'tool_use', id: 'call_1', name: 'notion.search', input: {} },
+        ],
+      },
+    ];
+    const converted = convertMessagesFn('', messages, codec);
+    expect(converted[0]).toMatchObject({
+      role: 'assistant',
+      tool_calls: [
+        { id: 'call_1', function: { name: 'notion_search', arguments: '{}' } },
+      ],
+    });
+  });
+
+  it('translates a specific tool choice', () => {
+    expect(convertToolChoiceFn({ tool: 'notion.search' }, codec)).toEqual({
+      type: 'function',
+      function: { name: 'notion_search' },
+    });
   });
 });

--- a/packages/provider-openai/src/convert-request.ts
+++ b/packages/provider-openai/src/convert-request.ts
@@ -13,14 +13,18 @@ import type {
   MessageContent,
   ToolChoice,
   ToolSchema,
+  ToolNameCodec,
 } from '@ayunis/inference';
 
 import { normalizeSchemaForOpenAI } from './normalize-schema';
 
-export const convertTool = (tool: ToolSchema): ChatCompletionTool => ({
+export const convertTool = (
+  tool: ToolSchema,
+  codec: ToolNameCodec,
+): ChatCompletionTool => ({
   type: 'function',
   function: {
-    name: tool.name,
+    name: codec.encode(tool.name),
     description: tool.description,
     // OpenAI requires strict-mode-compatible schemas (unsupported `format`
     // values stripped, all properties required, additionalProperties false);
@@ -35,6 +39,7 @@ export const convertTool = (tool: ToolSchema): ChatCompletionTool => ({
 /* eslint-disable sonarjs/function-return-type */
 export const convertToolChoice = (
   toolChoice: ToolChoice,
+  codec: ToolNameCodec,
 ): ChatCompletionToolChoiceOption => {
   if (toolChoice === 'auto') {
     return 'auto';
@@ -42,7 +47,10 @@ export const convertToolChoice = (
   if (toolChoice === 'required') {
     return 'required';
   }
-  return { type: 'function', function: { name: toolChoice.tool } };
+  return {
+    type: 'function',
+    function: { name: codec.encode(toolChoice.tool) },
+  };
 };
 /* eslint-enable sonarjs/function-return-type */
 
@@ -56,6 +64,7 @@ export const convertToolChoice = (
 export const convertMessages = (
   instructions: string,
   messages: readonly Message[],
+  codec: ToolNameCodec,
 ): ChatCompletionMessageParam[] => {
   const converted: ChatCompletionMessageParam[] = [];
   if (instructions) {
@@ -63,7 +72,7 @@ export const convertMessages = (
   }
   for (const message of messages) {
     if (message.role === 'assistant') {
-      const assistant = convertAssistant(message.content);
+      const assistant = convertAssistant(message.content, codec);
       // Skip assistant turns with neither text nor tool calls (e.g. a
       // thinking-only turn, since thinking is dropped) — Chat Completions
       // rejects an assistant message with null content and no tool_calls.
@@ -113,6 +122,7 @@ const convertUser = (
 
 const convertAssistant = (
   content: readonly MessageContent[],
+  codec: ToolNameCodec,
 ): ChatCompletionAssistantMessageParam => {
   const toolCalls = content
     .filter((c): c is Extract<MessageContent, { type: 'tool_use' }> => {
@@ -121,7 +131,10 @@ const convertAssistant = (
     .map((c): ChatCompletionMessageToolCall => ({
       id: c.id,
       type: 'function',
-      function: { name: c.name, arguments: JSON.stringify(c.input) },
+      function: {
+        name: codec.encode(c.name),
+        arguments: JSON.stringify(c.input),
+      },
     }));
   const text = joinText(content);
   const message: ChatCompletionAssistantMessageParam = {

--- a/packages/provider-openai/src/normalize-schema.spec.ts
+++ b/packages/provider-openai/src/normalize-schema.spec.ts
@@ -3,10 +3,6 @@ import { describe, expect, it } from 'vitest';
 import { normalizeSchemaForOpenAI } from './normalize-schema';
 
 describe('normalizeSchemaForOpenAI', () => {
-  it('returns undefined for undefined input', () => {
-    expect(normalizeSchemaForOpenAI(undefined)).toBeUndefined();
-  });
-
   it('adds additionalProperties:false and required for objects', () => {
     expect(
       normalizeSchemaForOpenAI({
@@ -64,5 +60,68 @@ describe('normalizeSchemaForOpenAI', () => {
         items: { type: 'string', format: 'uri' },
       }),
     ).toEqual({ type: 'array', items: { type: 'string' } });
+  });
+
+  it('collapses tuple-form items into a single anyOf schema', () => {
+    expect(
+      normalizeSchemaForOpenAI({
+        type: 'array',
+        items: [{ type: 'string', format: 'uri' }, { type: 'number' }],
+      }),
+    ).toEqual({
+      type: 'array',
+      items: { anyOf: [{ type: 'string' }, { type: 'number' }] },
+    });
+  });
+
+  it('flattens top-level combinators, which strict mode rejects', () => {
+    expect(
+      normalizeSchemaForOpenAI({
+        type: 'object',
+        oneOf: [
+          { properties: { a: { type: 'string' } }, required: ['a'] },
+          { properties: { b: { type: 'number' } }, required: ['b'] },
+        ],
+      }),
+    ).toEqual({
+      type: 'object',
+      additionalProperties: false,
+      properties: { a: { type: 'string' }, b: { type: 'number' } },
+      required: ['a', 'b'],
+    });
+  });
+
+  it('converts draft-04 boolean exclusive bounds to their numeric form', () => {
+    expect(
+      normalizeSchemaForOpenAI({
+        type: 'object',
+        properties: {
+          page: { type: 'integer', minimum: 0, exclusiveMinimum: true },
+          size: { type: 'integer', maximum: 10, exclusiveMaximum: true },
+        },
+      }),
+    ).toEqual({
+      type: 'object',
+      additionalProperties: false,
+      required: ['page', 'size'],
+      properties: {
+        page: { type: 'integer', exclusiveMinimum: 0 },
+        size: { type: 'integer', exclusiveMaximum: 10 },
+      },
+    });
+  });
+
+  it('drops boolean exclusive bounds without a numeric counterpart', () => {
+    expect(
+      normalizeSchemaForOpenAI({
+        type: 'object',
+        properties: { n: { type: 'number', exclusiveMinimum: false } },
+      }),
+    ).toEqual({
+      type: 'object',
+      additionalProperties: false,
+      required: ['n'],
+      properties: { n: { type: 'number' } },
+    });
   });
 });

--- a/packages/provider-openai/src/normalize-schema.ts
+++ b/packages/provider-openai/src/normalize-schema.ts
@@ -1,12 +1,12 @@
-import type { JsonSchema } from '@ayunis/inference';
+import type { JsonSchema, MutableSchema } from '@ayunis/inference';
+import {
+  CombinatorFlattener,
+  SchemaWalker,
+  convertDraft04ExclusiveBoundsNode,
+} from '@ayunis/inference';
 
-/**
- * OpenAI only supports a subset of JSON Schema `format` values; MCP servers
- * often emit unsupported ones (e.g. `uri`, `uri-reference`) that make the API
- * reject the request with a 400. Anything outside this set is stripped.
- *
- * @see https://platform.openai.com/docs/guides/structured-outputs#supported-schemas
- */
+// Hand-maintained — the SDK doesn't type them.
+// https://platform.openai.com/docs/guides/structured-outputs#supported-schemas
 const OPENAI_SUPPORTED_FORMATS = new Set([
   'date-time',
   'time',
@@ -19,71 +19,43 @@ const OPENAI_SUPPORTED_FORMATS = new Set([
   'uuid',
 ]);
 
-/**
- * Normalizes a tool's JSON schema for OpenAI Chat Completions tools used with
- * `strict: true`. Strict mode requires `additionalProperties: false` on every
- * object and every property listed in `required`; unsupported `format` values
- * are also stripped. Recurses into properties and array items.
- */
-export function normalizeSchemaForOpenAI(
-  schema: Record<string, unknown> | undefined,
-): JsonSchema | undefined {
-  if (!schema) return undefined;
-
-  const normalized = { ...schema };
-
+const walker = new SchemaWalker((node) => {
   if (
-    typeof normalized.format === 'string' &&
-    !OPENAI_SUPPORTED_FORMATS.has(normalized.format)
+    typeof node.format === 'string' &&
+    !OPENAI_SUPPORTED_FORMATS.has(node.format)
   ) {
-    delete normalized.format;
+    delete node.format;
   }
+  convertDraft04ExclusiveBoundsNode(node);
+  normalizeObjectType(node);
+  return node;
+});
 
-  normalizeObjectType(normalized);
-  normalizeProperties(normalized);
-  normalizeArrayItems(normalized);
-
-  return normalized;
-}
-
-/**
- * Strict mode treats any schema declaring `properties` as an object, even when
- * an explicit `type: 'object'` is omitted (common in MCP-style schemas).
- */
-function isObjectSchema(schema: Record<string, unknown>): boolean {
+// Strict mode treats any schema declaring `properties` as an object, even when
+// an explicit `type: 'object'` is omitted (common in MCP-style schemas).
+function isObjectSchema(schema: MutableSchema): boolean {
   return schema.type === 'object' || 'properties' in schema;
 }
 
-function normalizeObjectType(schema: Record<string, unknown>): void {
-  if (!isObjectSchema(schema)) return;
+function normalizeObjectType(schema: MutableSchema): void {
+  if (!isObjectSchema(schema)) {
+    return;
+  }
   // Strict mode requires additionalProperties:false on every object — force it
   // even when the source schema set it to `true`, which OpenAI rejects.
   schema.additionalProperties = false;
-  if (!('properties' in schema)) {
+  if (schema.properties && typeof schema.properties === 'object') {
+    schema.required = Object.keys(schema.properties);
+  } else {
     schema.properties = {};
     schema.required = [];
   }
 }
 
-function normalizeProperties(schema: Record<string, unknown>): void {
-  if (!schema.properties || typeof schema.properties !== 'object') return;
+export function normalizeSchemaForOpenAI(schema: JsonSchema): JsonSchema {
+  const root = walker.walk(schema);
+  new CombinatorFlattener(root).flatten();
+  normalizeObjectType(root);
 
-  const props = schema.properties as Record<string, Record<string, unknown>>;
-  schema.properties = Object.fromEntries(
-    Object.entries(props).map(([key, value]) => [
-      key,
-      normalizeSchemaForOpenAI(value),
-    ]),
-  );
-
-  // Strict mode requires every property to be listed in `required`. The
-  // presence of `properties` is what marks this node as an object.
-  schema.required = Object.keys(props);
-}
-
-function normalizeArrayItems(schema: Record<string, unknown>): void {
-  if (!schema.items || typeof schema.items !== 'object') return;
-  schema.items = normalizeSchemaForOpenAI(
-    schema.items as Record<string, unknown>,
-  );
+  return root;
 }

--- a/packages/provider-openai/src/openai-provider.ts
+++ b/packages/provider-openai/src/openai-provider.ts
@@ -6,6 +6,7 @@ import type {
   ProviderChunk,
   ProviderRequest,
 } from '@ayunis/inference';
+import { ToolNameCodec } from '@ayunis/inference';
 
 import { convertChunk } from './convert-chunk';
 import {
@@ -82,7 +83,8 @@ async function* streamChat(
   model: string,
   request: ProviderRequest,
 ): AsyncIterable<ProviderChunk> {
-  const params = buildParams(model, request);
+  const codec = new ToolNameCodec(request.tools);
+  const params = buildParams(model, request, codec);
   const stream = await client.chat.completions.create(
     params,
     request.signal ? { signal: request.signal } : undefined,
@@ -101,7 +103,7 @@ async function* streamChat(
     // convertChunk maps unrecognized finish reasons to `null`, so keying off
     // the mapped value would miss a genuine finish and never break.
     if (chunk.choices.at(0)?.finish_reason) sawFinishReason = true;
-    const converted = convertChunk(chunk);
+    const converted = convertChunk(chunk, codec);
     if (!converted) continue;
     yield converted;
     if (sawFinishReason && converted.usage) break;
@@ -111,14 +113,17 @@ async function* streamChat(
 const buildParams = (
   model: string,
   request: ProviderRequest,
+  codec: ToolNameCodec,
 ): ChatCompletionCreateParamsStreaming => {
   const hasTools = request.tools.length > 0;
   return {
     model,
-    messages: convertMessages(request.instructions, request.messages),
-    ...(hasTools ? { tools: request.tools.map(convertTool) } : {}),
+    messages: convertMessages(request.instructions, request.messages, codec),
+    ...(hasTools
+      ? { tools: request.tools.map((tool) => convertTool(tool, codec)) }
+      : {}),
     ...(hasTools && request.toolChoice !== undefined
-      ? { tool_choice: convertToolChoice(request.toolChoice) }
+      ? { tool_choice: convertToolChoice(request.toolChoice, codec) }
       : {}),
     stream: true,
     stream_options: { include_usage: true },


### PR DESCRIPTION
Fixes the AYC-412 400s for OpenAI models. Strict-mode function tools require every property listed in `required`, reject unknown keywords, root combinators, draft-04 exclusive bounds, and names over 64 chars.

- `normalize-schema.ts`: applies strict-mode rules via the shared `SchemaWalker`/`CombinatorFlattener` from #993 (walk → flatten → re-normalize root object type).
- Wires the `ToolNameCodec` through tool declarations, history, `tool_choice`, and inbound chunks.

Live-verified against the OpenAI API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect every OpenAI tool call path (schemas, history replay, and streaming decode); incorrect normalization or name mapping could break tool execution or cause API rejections.
> 
> **Overview**
> Fixes OpenAI **strict function-tool** 400s by tightening schema normalization and keeping **canonical vs wire** tool names consistent end-to-end.
> 
> **Schema normalization** in `normalizeSchemaForOpenAI` now uses shared **`SchemaWalker`**, **`CombinatorFlattener`**, and draft-04 exclusive-bound conversion (plus tuple `items` → `anyOf`, top-level combinator flattening). The function no longer accepts `undefined` schemas.
> 
> **Tool naming** flows through a per-request **`ToolNameCodec`**: outbound tool declarations, assistant history `tool_calls`, `tool_choice`, and inbound stream chunks **encode/decode** names (e.g. `notion.search` ↔ `notion_search`). When the wire name differs, chunk deltas include **`providerMetadata.wireName`**.
> 
> The OpenAI provider builds one codec from `request.tools` and passes it through **`buildParams`** and **`convertChunk`**. Tests split passthrough vs wire-name cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7dfed20560c40522c1290c770579b5b6487046dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->