### PR TITLE
fix(inference): convert draft-04 bounds and wire names for mistral (AYC-412)

### DIFF
--- a/packages/provider-mistral/src/convert-chunk.spec.ts
+++ b/packages/provider-mistral/src/convert-chunk.spec.ts
@@ -1,9 +1,14 @@
 import type { CompletionEvent } from '@mistralai/mistralai/models/components';
 import { describe, expect, it } from 'vitest';
 
-import { convertChunk } from './convert-chunk';
+import { ToolNameCodec } from '@ayunis/inference';
+
+import { convertChunk as convert } from './convert-chunk';
 
 const event = (data: unknown): CompletionEvent => ({ data }) as CompletionEvent;
+
+// Passthrough map — name translation is covered by its own tests below.
+const convertChunk = (e: CompletionEvent) => convert(e, new ToolNameCodec([]));
 
 describe('convertChunk', () => {
   it('converts a text content delta', () => {
@@ -110,5 +115,40 @@ describe('convertChunk', () => {
     expect(
       convertChunk(event({ choices: [{ index: 0, delta: {} }] })),
     ).toBeNull();
+  });
+});
+
+describe('convertChunk wire-name decoding', () => {
+  it('maps a wire tool name back to the original and records the wire name', () => {
+    const codec = new ToolNameCodec([
+      { name: 'notion.search', description: 'd', parameters: {} },
+    ]);
+    const result = convert(
+      event({
+        choices: [
+          {
+            delta: {
+              toolCalls: [
+                {
+                  index: 0,
+                  id: 'call_1',
+                  function: { name: 'notion_search', arguments: '{}' },
+                },
+              ],
+            },
+          },
+        ],
+      }),
+      codec,
+    );
+    expect(result?.toolCallDeltas).toEqual([
+      {
+        index: 0,
+        id: 'call_1',
+        name: 'notion.search',
+        argumentsDelta: '{}',
+        providerMetadata: { wireName: 'notion_search' },
+      },
+    ]);
   });
 });

--- a/packages/provider-mistral/src/convert-chunk.ts
+++ b/packages/provider-mistral/src/convert-chunk.ts
@@ -8,13 +8,17 @@ import type {
   FinishReason,
   ProviderChunk,
   ToolCallDelta,
+  ToolNameCodec,
 } from '@ayunis/inference';
 
 /**
  * Converts one Mistral chat stream event to a provider-agnostic chunk. Returns
  * null for events that carry nothing usable. Usage arrives on the final event.
  */
-export const convertChunk = (event: CompletionEvent): ProviderChunk | null => {
+export const convertChunk = (
+  event: CompletionEvent,
+  codec: ToolNameCodec,
+): ProviderChunk | null => {
   const result: ProviderChunk = {};
   let carriesSomething = false;
 
@@ -25,7 +29,7 @@ export const convertChunk = (event: CompletionEvent): ProviderChunk | null => {
       result.textDelta = textDelta;
       carriesSomething = true;
     }
-    const toolCallDeltas = extractToolCallDeltas(choice.delta.toolCalls);
+    const toolCallDeltas = extractToolCallDeltas(choice.delta.toolCalls, codec);
     if (toolCallDeltas.length > 0) {
       result.toolCallDeltas = toolCallDeltas;
       carriesSomething = true;
@@ -66,21 +70,28 @@ const extractTextDelta = (
 
 const extractToolCallDeltas = (
   toolCalls: ToolCall[] | null | undefined,
+  codec: ToolNameCodec,
 ): ToolCallDelta[] => {
   if (!toolCalls) {
     return [];
   }
   return toolCalls
     .filter((tc) => tc.index !== undefined)
-    .map((tc) => ({
-      index: tc.index!,
-      id: tc.id ?? null,
-      name: tc.function.name,
-      argumentsDelta:
-        typeof tc.function.arguments === 'string'
-          ? tc.function.arguments
-          : JSON.stringify(tc.function.arguments),
-    }));
+    .map((tc) => {
+      const wireName = tc.function.name;
+      const name = codec.decode(wireName);
+      return {
+        index: tc.index!,
+        id: tc.id ?? null,
+        name,
+        argumentsDelta:
+          typeof tc.function.arguments === 'string'
+            ? tc.function.arguments
+            : JSON.stringify(tc.function.arguments),
+        // Record what the model actually saw when names were translated.
+        ...(name !== wireName ? { providerMetadata: { wireName } } : {}),
+      };
+    });
 };
 
 const mapFinishReason = (reason: string): FinishReason => {

--- a/packages/provider-mistral/src/convert-request.spec.ts
+++ b/packages/provider-mistral/src/convert-request.spec.ts
@@ -1,11 +1,20 @@
 import type { Message, ToolSchema } from '@ayunis/inference';
+import { ToolNameCodec } from '@ayunis/inference';
 import { describe, expect, it } from 'vitest';
 
 import {
-  convertMessages,
-  convertTool,
-  convertToolChoice,
+  convertMessages as convertMessagesFn,
+  convertTool as convertToolFn,
+  convertToolChoice as convertToolChoiceFn,
 } from './convert-request';
+
+// Passthrough map — name translation is covered by its own tests below.
+const passthrough = new ToolNameCodec([]);
+const convertMessages = (instructions: string, messages: Message[]) =>
+  convertMessagesFn(instructions, messages, passthrough);
+const convertTool = (tool: ToolSchema) => convertToolFn(tool, passthrough);
+const convertToolChoice = (choice: Parameters<typeof convertToolChoiceFn>[0]) =>
+  convertToolChoiceFn(choice, passthrough);
 
 describe('convertTool', () => {
   it('wraps a tool schema as a Mistral function tool', () => {
@@ -21,6 +30,23 @@ describe('convertTool', () => {
         description: 'Search the web',
         parameters: { type: 'object', properties: {} },
       },
+    });
+  });
+
+  it('converts draft-04 exclusive bounds Mistral would reject', () => {
+    const tool: ToolSchema = {
+      name: 'paginate',
+      description: 'Paginate',
+      parameters: {
+        type: 'object',
+        properties: {
+          page: { type: 'integer', minimum: 0, exclusiveMinimum: true },
+        },
+      },
+    };
+    expect(convertTool(tool).function.parameters).toEqual({
+      type: 'object',
+      properties: { page: { type: 'integer', exclusiveMinimum: 0 } },
     });
   });
 });
@@ -152,5 +178,43 @@ describe('convertMessages', () => {
     expect(convertMessages('', messages)).toEqual([
       { role: 'system', content: 'Context' },
     ]);
+  });
+});
+
+describe('wire-name encoding', () => {
+  const codec = new ToolNameCodec([
+    { name: 'notion.search', description: 'd', parameters: {} },
+  ]);
+
+  it('declares tools under their wire names', () => {
+    expect(
+      convertToolFn(
+        { name: 'notion.search', description: 'd', parameters: {} },
+        codec,
+      ).function.name,
+    ).toBe('notion_search');
+  });
+
+  it('translates tool_call names in assistant history', () => {
+    const messages: Message[] = [
+      {
+        role: 'assistant',
+        content: [
+          { type: 'tool_use', id: 'call_1', name: 'notion.search', input: {} },
+        ],
+      },
+    ];
+    const [assistant] = convertMessagesFn('', messages, codec);
+    expect(assistant).toMatchObject({
+      role: 'assistant',
+      toolCalls: [{ id: 'call_1', function: { name: 'notion_search' } }],
+    });
+  });
+
+  it('translates a specific tool choice', () => {
+    expect(convertToolChoiceFn({ tool: 'notion.search' }, codec)).toEqual({
+      type: 'function',
+      function: { name: 'notion_search' },
+    });
   });
 });

--- a/packages/provider-mistral/src/convert-request.ts
+++ b/packages/provider-mistral/src/convert-request.ts
@@ -12,14 +12,17 @@ import type {
   MessageContent,
   ToolChoice,
   ToolSchema,
+  ToolNameCodec,
 } from '@ayunis/inference';
 
-export const convertTool = (tool: ToolSchema): Tool => ({
+import { normalizeSchemaForMistral } from './normalize-schema';
+
+export const convertTool = (tool: ToolSchema, codec: ToolNameCodec): Tool => ({
   type: 'function',
   function: {
-    name: tool.name,
+    name: codec.encode(tool.name),
     description: tool.description,
-    parameters: tool.parameters,
+    parameters: normalizeSchemaForMistral(tool.parameters),
   },
 });
 
@@ -28,6 +31,7 @@ export const convertTool = (tool: ToolSchema): Tool => ({
 /* eslint-disable sonarjs/function-return-type */
 export const convertToolChoice = (
   toolChoice: ToolChoice,
+  codec: ToolNameCodec,
 ): MistralToolChoice | ToolChoiceEnum => {
   if (toolChoice === 'auto') {
     return 'auto';
@@ -35,7 +39,10 @@ export const convertToolChoice = (
   if (toolChoice === 'required') {
     return 'required';
   }
-  return { type: 'function', function: { name: toolChoice.tool } };
+  return {
+    type: 'function',
+    function: { name: codec.encode(toolChoice.tool) },
+  };
 };
 /* eslint-enable sonarjs/function-return-type */
 
@@ -49,6 +56,7 @@ export const convertToolChoice = (
 export const convertMessages = (
   instructions: string,
   messages: readonly Message[],
+  codec: ToolNameCodec,
 ): Messages[] => {
   const converted: Messages[] = [];
   if (instructions) {
@@ -56,7 +64,7 @@ export const convertMessages = (
   }
   for (const message of messages) {
     if (message.role === 'assistant') {
-      const assistant = convertAssistant(message.content);
+      const assistant = convertAssistant(message.content, codec);
       // Skip assistant turns with neither text nor tool calls (e.g. a
       // thinking-only turn, since thinking is dropped) — an assistant message
       // with no content and no tool calls carries nothing.
@@ -106,6 +114,7 @@ const convertUser = (
 
 const convertAssistant = (
   content: readonly MessageContent[],
+  codec: ToolNameCodec,
 ): Messages & { role: 'assistant' } => {
   const toolCalls = content
     .filter((c): c is Extract<MessageContent, { type: 'tool_use' }> => {
@@ -114,7 +123,10 @@ const convertAssistant = (
     .map((c): ToolCall => ({
       id: c.id,
       type: 'function',
-      function: { name: c.name, arguments: JSON.stringify(c.input) },
+      function: {
+        name: codec.encode(c.name),
+        arguments: JSON.stringify(c.input),
+      },
     }));
   const text = joinText(content);
   const message: Messages & { role: 'assistant' } = {

--- a/packages/provider-mistral/src/mistral-provider.ts
+++ b/packages/provider-mistral/src/mistral-provider.ts
@@ -7,6 +7,7 @@ import type {
   ProviderChunk,
   ProviderRequest,
 } from '@ayunis/inference';
+import { ToolNameCodec } from '@ayunis/inference';
 
 import { convertChunk } from './convert-chunk';
 import {
@@ -70,13 +71,14 @@ async function* streamChat(
   model: string,
   request: ProviderRequest,
 ): AsyncIterable<ProviderChunk> {
-  const params = buildParams(model, request);
+  const codec = new ToolNameCodec(request.tools);
+  const params = buildParams(model, request, codec);
   const stream = await client.chat.stream(
     params,
     request.signal ? { signal: request.signal } : undefined,
   );
   for await (const event of stream) {
-    const converted = convertChunk(event);
+    const converted = convertChunk(event, codec);
     if (converted) {
       yield converted;
     }
@@ -86,14 +88,17 @@ async function* streamChat(
 const buildParams = (
   model: string,
   request: ProviderRequest,
+  codec: ToolNameCodec,
 ): ChatCompletionStreamRequest => {
   const hasTools = request.tools.length > 0;
   return {
     model,
-    messages: convertMessages(request.instructions, request.messages),
-    ...(hasTools ? { tools: request.tools.map(convertTool) } : {}),
+    messages: convertMessages(request.instructions, request.messages, codec),
+    ...(hasTools
+      ? { tools: request.tools.map((tool) => convertTool(tool, codec)) }
+      : {}),
     ...(hasTools && request.toolChoice !== undefined
-      ? { toolChoice: convertToolChoice(request.toolChoice) }
+      ? { toolChoice: convertToolChoice(request.toolChoice, codec) }
       : {}),
     stream: true,
   };

--- a/packages/provider-mistral/src/normalize-schema.ts
+++ b/packages/provider-mistral/src/normalize-schema.ts
@@ -1,0 +1,14 @@
+import type { JsonSchema, MutableSchema } from '@ayunis/inference';
+import {
+  SchemaWalker,
+  convertDraft04ExclusiveBoundsNode,
+} from '@ayunis/inference';
+
+const walker = new SchemaWalker((node: MutableSchema) => {
+  convertDraft04ExclusiveBoundsNode(node);
+  return node;
+});
+
+export function normalizeSchemaForMistral(schema: JsonSchema): JsonSchema {
+  return walker.walk(schema);
+}


### PR DESCRIPTION
Fixes the AYC-412 tool-schema rejections for Mistral models: converts draft-04 boolean `exclusiveMinimum`/`exclusiveMaximum` to numeric form (shared helper from #993) and wires the `ToolNameCodec` through declarations, history, `tool_choice`, and inbound chunks. Mistral is otherwise tolerant, so no further schema normalization is needed.

Live-verified against the Mistral API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect all Mistral tool-calling paths (schemas, history replay, and streaming deltas); mistakes could break tool invocation or API validation, but scope is limited to the Mistral adapter with targeted tests.
> 
> **Overview**
> Fixes Mistral tool-schema rejections (AYC-412) by **normalizing tool parameter JSON Schema** before send—boolean draft-04 `exclusiveMinimum`/`exclusiveMaximum` are rewritten to numeric `exclusiveMinimum`/`exclusiveMaximum` via a new `normalizeSchemaForMistral` helper built on the shared inference `SchemaWalker`.
> 
> **Tool naming** is now symmetric end-to-end: a per-request `ToolNameCodec` is created from `request.tools` in `mistral-provider`, passed into request conversion and chunk conversion. Outbound paths **encode** canonical names (tool declarations, assistant history tool calls, named `tool_choice`); inbound streaming tool-call deltas **decode** wire names back to canonical names and attach `providerMetadata.wireName` when the model saw a translated name.
> 
> Tests cover schema normalization, wire-name encode/decode, and existing converters use a passthrough codec where name translation is tested separately.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 442276561d30986ed0058678b47fbb12a8c73a2c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->