### PR TITLE
fix(inference): normalize tool schemas to gemini subset and wire names (AYC-412)

### DIFF
--- a/packages/provider-gemini/src/convert-chunk.spec.ts
+++ b/packages/provider-gemini/src/convert-chunk.spec.ts
@@ -2,10 +2,16 @@ import type { GenerateContentResponse } from '@google/genai';
 import { FinishReason } from '@google/genai';
 import { describe, expect, it } from 'vitest';
 
-import { convertChunk } from './convert-chunk';
+import { ToolNameCodec } from '@ayunis/inference';
+
+import { convertChunk as convert } from './convert-chunk';
 
 const chunk = (data: unknown): GenerateContentResponse =>
   data as GenerateContentResponse;
+
+// Passthrough map — name translation is covered by its own tests below.
+const convertChunk = (c: GenerateContentResponse) =>
+  convert(c, new ToolNameCodec([]));
 
 describe('convertChunk', () => {
   it('converts a text part to a text delta', () => {
@@ -114,5 +120,42 @@ describe('convertChunk', () => {
     expect(
       convertChunk(chunk({ candidates: [{ content: { parts: [] } }] })),
     ).toBeNull();
+  });
+});
+
+describe('convertChunk wire-name decoding', () => {
+  it('maps a wire tool name back to the original and records the wire name', () => {
+    const codec = new ToolNameCodec([
+      { name: 'notion.search', description: 'd', parameters: {} },
+    ]);
+    const result = convert(
+      chunk({
+        candidates: [
+          {
+            content: {
+              parts: [
+                {
+                  functionCall: {
+                    id: 'fc_1',
+                    name: 'notion_search',
+                    args: { q: 'x' },
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      }),
+      codec,
+    );
+    expect(result?.toolCallDeltas).toEqual([
+      {
+        index: 0,
+        id: 'fc_1',
+        name: 'notion.search',
+        argumentsDelta: '{"q":"x"}',
+        providerMetadata: { wireName: 'notion_search' },
+      },
+    ]);
   });
 });

--- a/packages/provider-gemini/src/convert-chunk.ts
+++ b/packages/provider-gemini/src/convert-chunk.ts
@@ -6,6 +6,7 @@ import type {
   ProviderChunk,
   ProviderMetadata,
   ToolCallDelta,
+  ToolNameCodec,
 } from '@ayunis/inference';
 
 interface CollectedParts {
@@ -23,9 +24,10 @@ interface CollectedParts {
  */
 export const convertChunk = (
   chunk: GenerateContentResponse,
+  codec: ToolNameCodec,
 ): ProviderChunk | null => {
   const candidate = chunk.candidates?.[0];
-  const collected = collectParts(candidate?.content?.parts ?? []);
+  const collected = collectParts(candidate?.content?.parts ?? [], codec);
 
   const result: ProviderChunk = {
     ...textFacet(collected),
@@ -37,7 +39,10 @@ export const convertChunk = (
   return Object.keys(result).length > 0 ? result : null;
 };
 
-const collectParts = (parts: readonly Part[]): CollectedParts => {
+const collectParts = (
+  parts: readonly Part[],
+  codec: ToolNameCodec,
+): CollectedParts => {
   let text = '';
   let textSignature: string | undefined;
   const toolCallDeltas: ToolCallDelta[] = [];
@@ -47,7 +52,7 @@ const collectParts = (parts: readonly Part[]): CollectedParts => {
       textSignature ??= part.thoughtSignature;
     }
     if (part.functionCall) {
-      toolCallDeltas.push(toToolCallDelta(part, index));
+      toolCallDeltas.push(toToolCallDelta(part, index, codec));
     }
   });
   return { text, textSignature, toolCallDeltas };
@@ -84,16 +89,26 @@ const usageFacet = (
       }
     : {};
 
-const toToolCallDelta = (part: Part, index: number): ToolCallDelta => {
+const toToolCallDelta = (
+  part: Part,
+  index: number,
+  codec: ToolNameCodec,
+): ToolCallDelta => {
   const fc = part.functionCall ?? {};
+  const wireName = fc.name ?? null;
+  const name = wireName === null ? null : codec.decode(wireName);
   const delta: ToolCallDelta = {
     index,
-    id: fc.id ?? fc.name ?? null,
-    name: fc.name ?? null,
+    id: fc.id ?? wireName ?? null,
+    name,
     argumentsDelta: stringifyArgs(fc.args),
   };
-  const metadata = toProviderMetadata(part.thoughtSignature);
-  if (metadata) {
+  // Merge the thought signature with the wire name the model actually saw.
+  const metadata = {
+    ...toProviderMetadata(part.thoughtSignature),
+    ...(name !== null && name !== wireName ? { wireName } : {}),
+  };
+  if (Object.keys(metadata).length > 0) {
     delta.providerMetadata = metadata;
   }
   return delta;

--- a/packages/provider-gemini/src/convert-request.spec.ts
+++ b/packages/provider-gemini/src/convert-request.spec.ts
@@ -1,13 +1,25 @@
 import type { Message, ToolSchema } from '@ayunis/inference';
+import { ToolNameCodec } from '@ayunis/inference';
 import { FunctionCallingConfigMode } from '@google/genai';
 import { describe, expect, it } from 'vitest';
 
 import {
-  buildConfig,
-  convertMessages,
-  convertTool,
-  convertToolChoice,
+  buildConfig as buildConfigFn,
+  convertMessages as convertMessagesFn,
+  convertTool as convertToolFn,
+  convertToolChoice as convertToolChoiceFn,
 } from './convert-request';
+
+// Passthrough map — name translation is covered by its own tests below.
+const passthrough = new ToolNameCodec([]);
+const convertMessages = (messages: Message[]) =>
+  convertMessagesFn(messages, passthrough);
+const convertTool = (tool: ToolSchema) => convertToolFn(tool, passthrough);
+const convertToolChoice = (choice: Parameters<typeof convertToolChoiceFn>[0]) =>
+  convertToolChoiceFn(choice, passthrough);
+const buildConfig = (
+  input: Omit<Parameters<typeof buildConfigFn>[0], 'codec'>,
+) => buildConfigFn({ ...input, codec: passthrough });
 
 describe('convertTool', () => {
   it('maps a tool schema to a Gemini function declaration', () => {
@@ -221,5 +233,60 @@ describe('convertMessages', () => {
       { role: 'assistant', content: [{ type: 'thinking', thinking: 'hmm' }] },
     ];
     expect(convertMessages(messages)).toEqual([]);
+  });
+});
+
+describe('wire-name encoding', () => {
+  const codec = new ToolNameCodec([
+    { name: 'notion.search', description: 'd', parameters: {} },
+  ]);
+
+  it('declares tools under their wire names', () => {
+    expect(
+      convertToolFn(
+        { name: 'notion.search', description: 'd', parameters: {} },
+        codec,
+      ).name,
+    ).toBe('notion_search');
+  });
+
+  it('translates functionCall and functionResponse names in history', () => {
+    const messages: Message[] = [
+      {
+        role: 'assistant',
+        content: [
+          { type: 'tool_use', id: 'fc_1', name: 'notion.search', input: {} },
+        ],
+      },
+      {
+        role: 'tool_result',
+        content: [
+          {
+            type: 'tool_result',
+            toolCallId: 'fc_1',
+            toolName: 'notion.search',
+            result: 'ok',
+          },
+        ],
+      },
+    ];
+    const [assistant, toolResult] = convertMessagesFn(messages, codec);
+    expect(assistant.parts?.[0]).toEqual({
+      functionCall: { id: 'fc_1', name: 'notion_search', args: {} },
+    });
+    expect(toolResult.parts?.[0]).toEqual({
+      functionResponse: {
+        id: 'fc_1',
+        name: 'notion_search',
+        response: { result: 'ok' },
+      },
+    });
+  });
+
+  it('translates allowedFunctionNames for a specific tool choice', () => {
+    expect(convertToolChoiceFn({ tool: 'notion.search' }, codec)).toEqual({
+      mode: FunctionCallingConfigMode.ANY,
+      allowedFunctionNames: ['notion_search'],
+    });
   });
 });

--- a/packages/provider-gemini/src/convert-request.ts
+++ b/packages/provider-gemini/src/convert-request.ts
@@ -13,16 +13,23 @@ import type {
   ProviderMetadata,
   ToolChoice,
   ToolSchema,
+  ToolNameCodec,
 } from '@ayunis/inference';
 
-export const convertTool = (tool: ToolSchema): FunctionDeclaration => ({
-  name: tool.name,
+import { normalizeSchemaForGemini } from './normalize-schema';
+
+export const convertTool = (
+  tool: ToolSchema,
+  codec: ToolNameCodec,
+): FunctionDeclaration => ({
+  name: codec.encode(tool.name),
   description: tool.description,
-  parameters: tool.parameters,
+  parameters: normalizeSchemaForGemini(tool.parameters),
 });
 
 export const convertToolChoice = (
   toolChoice: ToolChoice,
+  codec: ToolNameCodec,
 ): FunctionCallingConfig => {
   if (toolChoice === 'auto') {
     return { mode: FunctionCallingConfigMode.AUTO };
@@ -32,7 +39,7 @@ export const convertToolChoice = (
   }
   return {
     mode: FunctionCallingConfigMode.ANY,
-    allowedFunctionNames: [toolChoice.tool],
+    allowedFunctionNames: [codec.encode(toolChoice.tool)],
   };
 };
 
@@ -46,19 +53,24 @@ export const buildConfig = (input: {
   instructions: string;
   tools: readonly ToolSchema[];
   toolChoice?: ToolChoice;
+  codec: ToolNameCodec;
 }): GenerateContentConfig => {
-  const { instructions, tools, toolChoice } = input;
+  const { instructions, tools, toolChoice, codec } = input;
   const hasTools = tools.length > 0;
   return {
     systemInstruction: instructions
       ? { role: 'user', parts: [{ text: instructions }] }
       : undefined,
     tools: hasTools
-      ? [{ functionDeclarations: tools.map(convertTool) }]
+      ? [
+          {
+            functionDeclarations: tools.map((tool) => convertTool(tool, codec)),
+          },
+        ]
       : undefined,
     toolConfig:
       hasTools && toolChoice !== undefined
-        ? { functionCallingConfig: convertToolChoice(toolChoice) }
+        ? { functionCallingConfig: convertToolChoice(toolChoice, codec) }
         : undefined,
   };
 };
@@ -70,10 +82,13 @@ export const buildConfig = (input: {
  * `functionResponse` part. Messages that produce no parts are dropped — Gemini
  * rejects empty content.
  */
-export const convertMessages = (messages: readonly Message[]): Content[] => {
+export const convertMessages = (
+  messages: readonly Message[],
+  codec: ToolNameCodec,
+): Content[] => {
   const contents: Content[] = [];
   for (const message of messages) {
-    const content = convertMessage(message);
+    const content = convertMessage(message, codec);
     if (content && (content.parts?.length ?? 0) > 0) {
       contents.push(content);
     }
@@ -81,12 +96,18 @@ export const convertMessages = (messages: readonly Message[]): Content[] => {
   return contents;
 };
 
-const convertMessage = (message: Message): Content | null => {
+const convertMessage = (
+  message: Message,
+  codec: ToolNameCodec,
+): Content | null => {
   switch (message.role) {
     case 'assistant':
-      return { role: 'model', parts: convertAssistant(message.content) };
+      return { role: 'model', parts: convertAssistant(message.content, codec) };
     case 'tool_result':
-      return { role: 'user', parts: convertToolResults(message.content) };
+      return {
+        role: 'user',
+        parts: convertToolResults(message.content, codec),
+      };
     case 'system':
       return { role: 'user', parts: convertSystem(message.content) };
     case 'user':
@@ -108,7 +129,10 @@ const convertUser = (content: readonly MessageContent[]): Part[] => {
   return parts;
 };
 
-const convertAssistant = (content: readonly MessageContent[]): Part[] => {
+const convertAssistant = (
+  content: readonly MessageContent[],
+  codec: ToolNameCodec,
+): Part[] => {
   const parts: Part[] = [];
   for (const c of content) {
     if (c.type === 'text') {
@@ -116,7 +140,13 @@ const convertAssistant = (content: readonly MessageContent[]): Part[] => {
     } else if (c.type === 'tool_use') {
       parts.push(
         withSignature(
-          { functionCall: { id: c.id, name: c.name, args: c.input } },
+          {
+            functionCall: {
+              id: c.id,
+              name: codec.encode(c.name),
+              args: c.input,
+            },
+          },
           c.providerMetadata,
         ),
       );
@@ -125,7 +155,10 @@ const convertAssistant = (content: readonly MessageContent[]): Part[] => {
   return parts;
 };
 
-const convertToolResults = (content: readonly MessageContent[]): Part[] =>
+const convertToolResults = (
+  content: readonly MessageContent[],
+  codec: ToolNameCodec,
+): Part[] =>
   content
     .filter((c): c is Extract<MessageContent, { type: 'tool_result' }> => {
       return c.type === 'tool_result';
@@ -133,7 +166,7 @@ const convertToolResults = (content: readonly MessageContent[]): Part[] =>
     .map((c) => ({
       functionResponse: {
         id: c.toolCallId,
-        name: c.toolName,
+        name: codec.encode(c.toolName),
         response: { result: c.result },
       },
     }));

--- a/packages/provider-gemini/src/dereference-refs.ts
+++ b/packages/provider-gemini/src/dereference-refs.ts
@@ -1,0 +1,96 @@
+import type { JsonObject, JsonValue } from '@ayunis/inference';
+import { isRecord } from '@ayunis/inference';
+
+const DEFS_KEYS = new Set(['$defs', 'definitions']);
+
+// Acyclic ref DAGs can expand exponentially when inlined (each def
+// referencing the previous one twice doubles the output per level — the
+// "billion laughs" shape). Schemas come from third-party MCP servers, so
+// expansion is budgeted; past the cap refs degrade to permissive schemas.
+const MAX_REF_EXPANSIONS = 1000;
+
+interface ResolveState {
+  readonly root: JsonObject;
+  expansions: number;
+}
+
+// Inlines local `$ref` pointers (`#/…`) — Gemini's schema subset has no
+// reference support, so refs must expand before pruning or the referenced
+// parameters vanish. Cycles are cut to an empty (permissive) schema; the
+// tool validates its real inputs.
+export function dereferenceLocalRefs(root: JsonObject): JsonObject {
+  const state: ResolveState = { root, expansions: 0 };
+  const resolved = resolveValue(root, state, new Set());
+  return isRecord(resolved) ? resolved : root;
+}
+
+function resolveValue(
+  value: JsonValue,
+  state: ResolveState,
+  stack: ReadonlySet<string>,
+): JsonValue {
+  let resolved: JsonValue = value;
+  if (Array.isArray(value)) {
+    resolved = value.map((entry) => resolveValue(entry, state, stack));
+  } else if (isRecord(value)) {
+    resolved = resolveNode(value, state, stack);
+  }
+  return resolved;
+}
+
+function resolveNode(
+  node: JsonObject,
+  state: ResolveState,
+  stack: ReadonlySet<string>,
+): JsonValue {
+  const { $ref, ...rest } = node;
+  const siblings: JsonObject = {};
+  for (const [key, value] of Object.entries(rest)) {
+    // Defs are only read through refs and pruned later — no need to descend.
+    siblings[key] = DEFS_KEYS.has(key)
+      ? value
+      : resolveValue(value, state, stack);
+  }
+  return inlineRef($ref, siblings, state, stack);
+}
+
+function inlineRef(
+  $ref: JsonValue | undefined,
+  siblings: JsonObject,
+  state: ResolveState,
+  stack: ReadonlySet<string>,
+): JsonValue {
+  let result: JsonValue = siblings;
+  if (
+    typeof $ref === 'string' &&
+    !stack.has($ref) &&
+    state.expansions < MAX_REF_EXPANSIONS
+  ) {
+    const target = lookupPointer(state.root, $ref);
+    if (target !== undefined) {
+      state.expansions += 1;
+      const inlined = resolveValue(target, state, new Set([...stack, $ref]));
+      // Sibling keys next to `$ref` override the referenced schema.
+      result = isRecord(inlined) ? { ...inlined, ...siblings } : inlined;
+    }
+  }
+  return result;
+}
+
+function lookupPointer(root: JsonObject, ref: string): JsonValue | undefined {
+  if (!ref.startsWith('#/')) {
+    return undefined;
+  }
+  let current: JsonValue | undefined = root;
+  for (const segment of ref.slice(2).split('/')) {
+    const key = segment.replaceAll('~1', '/').replaceAll('~0', '~');
+    if (Array.isArray(current)) {
+      current = current[Number(key)];
+    } else if (isRecord(current)) {
+      current = current[key];
+    } else {
+      return undefined;
+    }
+  }
+  return current;
+}

--- a/packages/provider-gemini/src/gemini-provider.ts
+++ b/packages/provider-gemini/src/gemini-provider.ts
@@ -6,6 +6,7 @@ import type {
   ProviderChunk,
   ProviderRequest,
 } from '@ayunis/inference';
+import { ToolNameCodec } from '@ayunis/inference';
 
 import { convertChunk } from './convert-chunk';
 import { buildConfig, convertMessages } from './convert-request';
@@ -46,9 +47,10 @@ async function* streamChat(
   maxRetries: number,
   request: ProviderRequest,
 ): AsyncIterable<ProviderChunk> {
-  const stream = await openStream(client, model, maxRetries, request);
+  const codec = new ToolNameCodec(request.tools);
+  const stream = await openStream(client, model, maxRetries, request, codec);
   for await (const chunk of stream) {
-    const converted = convertChunk(chunk);
+    const converted = convertChunk(chunk, codec);
     if (converted) {
       yield converted;
     }
@@ -65,17 +67,19 @@ const openStream = (
   model: string,
   maxRetries: number,
   request: ProviderRequest,
+  codec: ToolNameCodec,
 ): Promise<AsyncGenerator<GenerateContentResponse>> =>
   withRetry(
     () =>
       client.models.generateContentStream({
         model,
-        contents: convertMessages(request.messages),
+        contents: convertMessages(request.messages, codec),
         config: {
           ...buildConfig({
             instructions: request.instructions,
             tools: request.tools,
             toolChoice: request.toolChoice,
+            codec,
           }),
           ...(request.signal ? { abortSignal: request.signal } : {}),
         },

--- a/packages/provider-gemini/src/normalize-schema.spec.ts
+++ b/packages/provider-gemini/src/normalize-schema.spec.ts
@@ -1,0 +1,355 @@
+import { describe, expect, it } from 'vitest';
+
+import { normalizeSchemaForGemini } from './normalize-schema';
+
+describe('normalizeSchemaForGemini', () => {
+  it('leaves a plain object schema untouched', () => {
+    const schema = {
+      type: 'object',
+      properties: { q: { type: 'string', description: 'Query' } },
+      required: ['q'],
+    };
+    expect(normalizeSchemaForGemini(schema)).toEqual(schema);
+  });
+
+  it('drops keywords outside the Gemini schema subset', () => {
+    expect(
+      normalizeSchemaForGemini({
+        $schema: 'http://json-schema.org/draft-07/schema#',
+        type: 'object',
+        additionalProperties: false,
+        properties: { q: { type: 'string' } },
+      }),
+    ).toEqual({
+      type: 'object',
+      properties: { q: { type: 'string' } },
+    });
+  });
+
+  it('folds draft-04 boolean exclusive bounds into inclusive bounds', () => {
+    expect(
+      normalizeSchemaForGemini({
+        type: 'object',
+        properties: {
+          page: { type: 'integer', minimum: 0, exclusiveMinimum: true },
+        },
+      }),
+    ).toEqual({
+      type: 'object',
+      properties: { page: { type: 'integer', minimum: 0 } },
+    });
+  });
+
+  it('folds numeric 2020-12 exclusive bounds into inclusive bounds', () => {
+    expect(
+      normalizeSchemaForGemini({
+        type: 'object',
+        properties: {
+          page: { type: 'integer', exclusiveMinimum: 0, exclusiveMaximum: 10 },
+        },
+      }),
+    ).toEqual({
+      type: 'object',
+      properties: { page: { type: 'integer', minimum: 0, maximum: 10 } },
+    });
+  });
+
+  it('strips formats Gemini does not support but keeps supported ones', () => {
+    expect(
+      normalizeSchemaForGemini({
+        type: 'object',
+        properties: {
+          url: { type: 'string', format: 'uri' },
+          at: { type: 'string', format: 'date-time' },
+        },
+      }),
+    ).toEqual({
+      type: 'object',
+      properties: {
+        url: { type: 'string' },
+        at: { type: 'string', format: 'date-time' },
+      },
+    });
+  });
+
+  it('converts nullable type arrays to a single type with nullable', () => {
+    expect(
+      normalizeSchemaForGemini({
+        type: 'object',
+        properties: { note: { type: ['string', 'null'] } },
+      }),
+    ).toEqual({
+      type: 'object',
+      properties: { note: { type: 'string', nullable: true } },
+    });
+  });
+
+  it('renames oneOf to the supported anyOf', () => {
+    expect(
+      normalizeSchemaForGemini({
+        type: 'object',
+        properties: {
+          filter: { oneOf: [{ type: 'string' }, { type: 'integer' }] },
+        },
+      }),
+    ).toEqual({
+      type: 'object',
+      properties: {
+        filter: { anyOf: [{ type: 'string' }, { type: 'integer' }] },
+      },
+    });
+  });
+
+  it('collapses tuple-form items and normalizes each entry', () => {
+    expect(
+      normalizeSchemaForGemini({
+        type: 'array',
+        items: [
+          { type: 'number', minimum: 0, exclusiveMinimum: true },
+          { type: 'string', format: 'uri' },
+        ],
+      }),
+    ).toEqual({
+      type: 'array',
+      items: {
+        anyOf: [{ type: 'number', minimum: 0 }, { type: 'string' }],
+      },
+    });
+  });
+
+  it('adds type object to nodes declaring properties without a type', () => {
+    expect(
+      normalizeSchemaForGemini({
+        type: 'object',
+        properties: {
+          choice: {
+            anyOf: [
+              { properties: { a: { type: 'string' } } },
+              { properties: { b: { type: 'number' } } },
+            ],
+          },
+        },
+      }),
+    ).toEqual({
+      type: 'object',
+      properties: {
+        choice: {
+          anyOf: [
+            { type: 'object', properties: { a: { type: 'string' } } },
+            { type: 'object', properties: { b: { type: 'number' } } },
+          ],
+        },
+      },
+    });
+  });
+
+  it('recurses into array items', () => {
+    expect(
+      normalizeSchemaForGemini({
+        type: 'array',
+        items: { type: 'integer', minimum: 1, exclusiveMinimum: true },
+      }),
+    ).toEqual({
+      type: 'array',
+      items: { type: 'integer', minimum: 1 },
+    });
+  });
+
+  it('merges allOf branches into the node, unioning required', () => {
+    expect(
+      normalizeSchemaForGemini({
+        type: 'object',
+        allOf: [
+          { properties: { a: { type: 'string' } }, required: ['a'] },
+          { properties: { b: { type: 'number' } }, required: ['b'] },
+        ],
+      }),
+    ).toEqual({
+      type: 'object',
+      properties: { a: { type: 'string' }, b: { type: 'number' } },
+      required: ['a', 'b'],
+    });
+  });
+
+  it('merges allOf nested inside branches and on property nodes', () => {
+    expect(
+      normalizeSchemaForGemini({
+        type: 'object',
+        properties: {
+          item: {
+            allOf: [
+              { properties: { a: { type: 'string' } } },
+              { allOf: [{ properties: { b: { type: 'number' } } }] },
+            ],
+          },
+        },
+      }),
+    ).toEqual({
+      type: 'object',
+      properties: {
+        item: {
+          type: 'object',
+          properties: { a: { type: 'string' }, b: { type: 'number' } },
+        },
+      },
+    });
+  });
+
+  it('inlines local $refs and drops the defs collections', () => {
+    expect(
+      normalizeSchemaForGemini({
+        type: 'object',
+        $defs: {
+          Addr: {
+            type: 'object',
+            properties: { street: { type: 'string' } },
+            description: 'An address',
+          },
+        },
+        properties: {
+          home: { $ref: '#/$defs/Addr', description: 'Home address' },
+        },
+      }),
+    ).toEqual({
+      type: 'object',
+      properties: {
+        home: {
+          type: 'object',
+          properties: { street: { type: 'string' } },
+          // Sibling keys next to $ref override the referenced schema.
+          description: 'Home address',
+        },
+      },
+    });
+  });
+
+  it('inlines refs through the draft-04 definitions key', () => {
+    expect(
+      normalizeSchemaForGemini({
+        type: 'object',
+        definitions: { Id: { type: 'string' } },
+        properties: { id: { $ref: '#/definitions/Id' } },
+      }),
+    ).toEqual({
+      type: 'object',
+      properties: { id: { type: 'string' } },
+    });
+  });
+
+  it('cuts recursive $refs instead of expanding forever', () => {
+    expect(
+      normalizeSchemaForGemini({
+        type: 'object',
+        $defs: {
+          Node: {
+            type: 'object',
+            properties: { child: { $ref: '#/$defs/Node' } },
+          },
+        },
+        properties: { tree: { $ref: '#/$defs/Node' } },
+      }),
+    ).toEqual({
+      type: 'object',
+      properties: {
+        tree: { type: 'object', properties: { child: {} } },
+      },
+    });
+  });
+
+  it('expands multi-type arrays into anyOf branches', () => {
+    expect(
+      normalizeSchemaForGemini({
+        type: 'object',
+        properties: { id: { type: ['string', 'integer', 'null'] } },
+      }),
+    ).toEqual({
+      type: 'object',
+      properties: {
+        id: {
+          nullable: true,
+          anyOf: [{ type: 'string' }, { type: 'integer' }],
+        },
+      },
+    });
+  });
+
+  it('concatenates oneOf into an existing anyOf instead of dropping it', () => {
+    expect(
+      normalizeSchemaForGemini({
+        type: 'object',
+        properties: {
+          v: {
+            anyOf: [{ type: 'string' }],
+            oneOf: [{ type: 'object', properties: { a: { type: 'string' } } }],
+          },
+        },
+      }),
+    ).toEqual({
+      type: 'object',
+      properties: {
+        v: {
+          anyOf: [
+            { type: 'string' },
+            { type: 'object', properties: { a: { type: 'string' } } },
+          ],
+        },
+      },
+    });
+  });
+
+  it('keeps oneOf branches when a type union already produced anyOf', () => {
+    expect(
+      normalizeSchemaForGemini({
+        type: 'object',
+        properties: {
+          v: {
+            type: ['string', 'integer'],
+            oneOf: [{ type: 'object', properties: { a: { type: 'boolean' } } }],
+          },
+        },
+      }),
+    ).toEqual({
+      type: 'object',
+      properties: {
+        v: {
+          anyOf: [
+            { type: 'string' },
+            { type: 'integer' },
+            { type: 'object', properties: { a: { type: 'boolean' } } },
+          ],
+        },
+      },
+    });
+  });
+
+  it('caps runaway expansion of acyclic ref chains (billion laughs)', () => {
+    // Each def references the previous one twice — uncapped inlining would
+    // expand to 2^18 leaf nodes from a few hundred bytes of schema.
+    const defs: Record<string, unknown> = { d0: { type: 'string' } };
+    for (let i = 1; i <= 18; i += 1) {
+      defs[`d${i}`] = {
+        type: 'object',
+        properties: {
+          a: { $ref: `#/$defs/d${i - 1}` },
+          b: { $ref: `#/$defs/d${i - 1}` },
+        },
+      };
+    }
+    const out = normalizeSchemaForGemini({
+      type: 'object',
+      $defs: defs,
+      properties: { root: { $ref: '#/$defs/d18' } },
+    });
+    expect(JSON.stringify(out).length).toBeLessThan(100_000);
+  });
+
+  it('does not mutate the input schema', () => {
+    const schema = {
+      type: 'object',
+      properties: { n: { type: ['number', 'null'], exclusiveMinimum: 0 } },
+    };
+    const copy = structuredClone(schema);
+    normalizeSchemaForGemini(schema);
+    expect(schema).toEqual(copy);
+  });
+});

--- a/packages/provider-gemini/src/normalize-schema.ts
+++ b/packages/provider-gemini/src/normalize-schema.ts
@@ -1,0 +1,176 @@
+import type { Schema } from '@google/genai';
+
+import type {
+  JsonObject,
+  JsonSchema,
+  JsonValue,
+  MutableSchema,
+} from '@ayunis/inference';
+import { SchemaWalker, isRecord } from '@ayunis/inference';
+
+import { dereferenceLocalRefs } from './dereference-refs';
+
+const GEMINI_SCHEMA_KEY_LIST = [
+  'anyOf',
+  'default',
+  'description',
+  'enum',
+  'example',
+  'format',
+  'items',
+  'maximum',
+  'maxItems',
+  'maxLength',
+  'maxProperties',
+  'minimum',
+  'minItems',
+  'minLength',
+  'minProperties',
+  'nullable',
+  'pattern',
+  'properties',
+  'propertyOrdering',
+  'required',
+  'title',
+  'type',
+] as const satisfies readonly (keyof Schema)[];
+
+const GEMINI_SCHEMA_KEYS: ReadonlySet<string> = new Set(GEMINI_SCHEMA_KEY_LIST);
+const GEMINI_SUPPORTED_FORMATS = new Set([
+  'date-time',
+  'enum',
+  'int32',
+  'int64',
+  'float',
+  'double',
+]);
+
+const walker = new SchemaWalker((node) => {
+  mergeAllOf(node);
+  foldExclusiveBound(node, 'exclusiveMinimum', 'minimum');
+  foldExclusiveBound(node, 'exclusiveMaximum', 'maximum');
+  normalizeTypeUnion(node);
+  normalizeFormat(node);
+  // Gemini rejects `properties` on nodes without an explicit OBJECT type
+  // (common in MCP combinator branches).
+  if ('properties' in node && !('type' in node)) {
+    node.type = 'object';
+  }
+  // Gemini cannot conjoin two unions (no allOf) — concatenate instead:
+  // looser, but every branch stays visible to the model.
+  if (Array.isArray(node.oneOf)) {
+    node.anyOf = [
+      ...(Array.isArray(node.anyOf) ? node.anyOf : []),
+      ...node.oneOf,
+    ];
+  }
+
+  return pickGeminiKeys(node);
+});
+
+// Gemini has no exclusive-bound keywords — fold both the draft-04 boolean and
+// 2020-12 numeric forms into the inclusive bound (looser is fine; the tool
+// validates its real inputs).
+function foldExclusiveBound(
+  schema: MutableSchema,
+  exclusiveKey: 'exclusiveMinimum' | 'exclusiveMaximum',
+  boundKey: 'minimum' | 'maximum',
+): void {
+  const exclusive = schema[exclusiveKey];
+  if (typeof exclusive === 'number' && !(boundKey in schema)) {
+    schema[boundKey] = exclusive;
+  }
+  delete schema[exclusiveKey];
+}
+
+// Gemini has no allOf — merge every branch (and any allOf nested within a
+// branch) into the node itself. The node's own values win, `required` is
+// the union of all branches (they all apply).
+function mergeAllOf(node: MutableSchema): void {
+  for (const branch of collectAllOfBranches(node.allOf)) {
+    mergeBranch(node, branch);
+  }
+  delete node.allOf;
+}
+
+function collectAllOfBranches(allOf: JsonValue | undefined): JsonObject[] {
+  if (!Array.isArray(allOf)) return [];
+  return allOf
+    .filter(isRecord)
+    .flatMap((branch) => [branch, ...collectAllOfBranches(branch.allOf)]);
+}
+
+const SEPARATELY_MERGED_KEYS = new Set(['allOf', 'properties', 'required']);
+
+function mergeBranch(node: MutableSchema, branch: JsonObject): void {
+  mergeProperties(node, branch.properties);
+  mergeRequired(node, branch.required);
+  for (const [key, value] of Object.entries(branch)) {
+    if (!SEPARATELY_MERGED_KEYS.has(key)) {
+      node[key] ??= value;
+    }
+  }
+}
+
+function mergeProperties(node: MutableSchema, props: JsonValue): void {
+  if (!isRecord(props)) return;
+  // Copied before merging — branch objects belong to the caller's input.
+  const merged = isRecord(node.properties) ? { ...node.properties } : {};
+  for (const [name, prop] of Object.entries(props)) {
+    merged[name] ??= prop;
+  }
+  node.properties = merged;
+}
+
+function mergeRequired(node: MutableSchema, required: JsonValue): void {
+  const names = [...asStringArray(node.required), ...asStringArray(required)];
+  if (names.length > 0) {
+    node.required = [...new Set(names)];
+  }
+}
+
+function asStringArray(value: JsonValue | undefined): string[] {
+  return Array.isArray(value)
+    ? value.filter((v): v is string => typeof v === 'string')
+    : [];
+}
+
+function normalizeTypeUnion(schema: MutableSchema): void {
+  if (!Array.isArray(schema.type)) return;
+  const types = schema.type.filter((t): t is string => typeof t === 'string');
+  const nonNull = types.filter((t) => t !== 'null');
+  if (nonNull.length !== types.length) {
+    schema.nullable = true;
+  }
+  // Gemini's `type` is single-valued; a real union becomes anyOf branches.
+  if (nonNull.length > 1 && !('anyOf' in schema)) {
+    delete schema.type;
+    schema.anyOf = nonNull.map((type) => ({ type }));
+    return;
+  }
+  schema.type = nonNull[0] ?? 'string';
+}
+
+function normalizeFormat(schema: MutableSchema): void {
+  if (
+    typeof schema.format === 'string' &&
+    !GEMINI_SUPPORTED_FORMATS.has(schema.format)
+  ) {
+    delete schema.format;
+  }
+}
+
+function pickGeminiKeys(node: MutableSchema): MutableSchema {
+  const picked: MutableSchema = {};
+  for (const [key, value] of Object.entries(node)) {
+    if (GEMINI_SCHEMA_KEYS.has(key)) {
+      picked[key] = value;
+    }
+  }
+  return picked;
+}
+
+export function normalizeSchemaForGemini(schema: JsonSchema): JsonSchema {
+  // Wire data is JSON, so its values are JsonValue by construction.
+  return walker.walk(dereferenceLocalRefs(schema as MutableSchema));
+}


### PR DESCRIPTION
Fixes the AYC-412 400s for Gemini models. Gemini accepts only an OpenAPI-style schema subset and rejects unknown fields outright.

- `normalize-schema.ts`: whitelists the supported `Schema` keys (typed `satisfies readonly (keyof Schema)[]` against the SDK), folds exclusive bounds, infers missing `type`, rewrites `oneOf` → `anyOf`, and hoists `$defs`.
- Wires the `ToolNameCodec` through declarations, history (including `functionResponse.name`), `tool_choice`, and inbound chunks (merged with `thoughtSignature` metadata).

Live-verified against the Gemini API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect all Gemini tool declarations and multi-turn tool history; schema rewriting is intentionally looser than full JSON Schema but avoids API failures on third-party MCP tools.
> 
> **Overview**
> Fixes Gemini **400** rejections on tool-heavy requests (AYC-412) by shaping MCP-style JSON Schemas into Gemini’s supported subset and keeping tool names consistent on the wire.
> 
> **Schema normalization** runs on every tool declaration via new `normalizeSchemaForGemini`: local `$ref` / `$defs` are inlined first (with cycle cuts and a ref-expansion budget for hostile schemas), then a walker strips unsupported keywords, folds exclusive bounds, merges `allOf`, rewrites `oneOf` into `anyOf`, normalizes nullable/type unions and tuple `items`, and whitelists only Gemini `Schema` keys.
> 
> **Tool naming** uses a per-request `ToolNameCodec` from `request.tools`: outbound paths encode names on declarations, chat history (`functionCall` / `functionResponse`), and `allowedFunctionNames`; streaming chunks decode wire names back to canonical names and attach `wireName` in metadata when they differ.
> 
> The Gemini provider constructs one codec per stream and threads it through `convertMessages`, `buildConfig`, and `convertChunk`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9f2b80814f952a650c2674e7895c83193d3f955. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->